### PR TITLE
fix: doctor checks — packages, TUI libs, credential detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,8 +238,8 @@ q/
 |--------|-------|
 | Test files | 94 |
 | Source modules | 83 |
-| Source lines | 16813 |
-| Test lines | 27707 |
+| Source lines | 16855 |
+| Test lines | 27706 |
 | Test assertions | 4750 |
 | `raco test` results | 2,877 tests passing |
 

--- a/README.md
+++ b/README.md
@@ -238,8 +238,8 @@ q/
 |--------|-------|
 | Test files | 94 |
 | Source modules | 83 |
-| Source lines | 16671 |
-| Test lines | 27706 |
+| Source lines | 16813 |
+| Test lines | 27707 |
 | Test assertions | 4750 |
 | `raco test` results | 2,877 tests passing |
 

--- a/interfaces/doctor.rkt
+++ b/interfaces/doctor.rkt
@@ -255,23 +255,37 @@
 
 (define (check-tui-packages)
   ;; q uses tui-term and tui-ubuf as optional TUI backends.
-  ;; Both are optional — TUI degrades gracefully without them.
-  (define tui-term?
+  ;; They may be installed but fail to compile on some Racket versions.
+  ;; Use dynamic-require for pkg/lib to avoid hard dependency.
+  (define table
     (with-handlers ([exn:fail? (λ (_) #f)])
-      (dynamic-require 'tui-term #f)
-      #t))
-  (define tui-ubuf?
+      ((dynamic-require 'pkg/lib 'installed-pkg-table))))
+  (define (pkg-installed? name)
+    (and table (hash-has-key? table name)))
+  (define (mod-loadable? mod-path)
     (with-handlers ([exn:fail? (λ (_) #f)])
-      (dynamic-require 'tui-ubuf #f)
+      (dynamic-require mod-path #f)
       #t))
+  (define tui-term-installed? (pkg-installed? "tui-term"))
+  (define tui-ubuf-installed? (pkg-installed? "tui-ubuf"))
+  (define tui-term-loadable? (mod-loadable? 'tui-term))
+  (define tui-ubuf-loadable? (mod-loadable? 'tui-ubuf))
   (cond
-    [(and tui-term? tui-ubuf?)
+    [(and tui-term-loadable? tui-ubuf-loadable?)
      (check-result "TUI" 'ok "tui-term + tui-ubuf available")]
-    [(or tui-term? tui-ubuf?)
+    [(and tui-term-installed? tui-ubuf-installed?
+          (not tui-term-loadable?) (not tui-ubuf-loadable?))
      (check-result "TUI" 'warning
-                   (format "~a available, ~amissing — TUI may be degraded (raco pkg install tui-term tui-ubuf)"
-                           (if tui-term? "tui-term" "")
-                           (if tui-term? "tui-ubuf " "tui-term ")))]
+                   "tui-term + tui-ubuf installed but broken (may need newer Racket)")]
+    [(or tui-term-loadable? tui-ubuf-loadable?)
+     (check-result "TUI" 'warning
+                   (format "~a loadable, ~anot — TUI may be degraded"
+                           (if tui-term-loadable? "tui-term" "")
+                           (if tui-ubuf-loadable? "tui-ubuf " "tui-term ")))]
+    [(or tui-term-installed? tui-ubuf-installed?)
+     (check-result "TUI" 'warning
+                   (format "~a installed but broken (may need newer Racket)"
+                           (if tui-term-installed? "tui-term" "tui-ubuf")))]
     [else
      (check-result "TUI" 'warning "tui-term/tui-ubuf not installed — TUI mode will not work (raco pkg install tui-term tui-ubuf)")]))
 

--- a/interfaces/doctor.rkt
+++ b/interfaces/doctor.rkt
@@ -111,13 +111,9 @@
 ;; ============================================================
 
 (define (check-packages)
-  (with-handlers ([exn:fail?
-                   (λ (e)
-                     (check-result "Packages" 'error
-                                   (format "failed to load q: ~a"
-                                           (exn-message e))))])
-    (dynamic-require ''q/main #f)
-    (check-result "Packages" 'ok "q modules load successfully")))
+  ;; doctor is itself part of q and is already loaded.
+  ;; If we reach this point, the core module system works.
+  (check-result "Packages" 'ok "q modules loaded (doctor is running)"))
 
 ;; ============================================================
 ;; Check: config directory (~/.q/)
@@ -186,6 +182,13 @@
   (define cred-file-exists? (file-exists? cred-file))
   ;; Check config file for provider keys
   (define prov-names (provider-names settings))
+  ;; Helper: is a provider local (no API key needed)?
+  (define (local-provider? name)
+    (define cfg (provider-config settings name))
+    (define base-url (and (hash? cfg) (hash-ref cfg 'base-url #f)))
+    (and base-url
+         (string? base-url)
+         (regexp-match? #rx"^https?://(127\\.0\\.0\\.1|localhost|0\\.0\\.0\\.0)(:|/)" base-url)))
   (define configured-providers
     (for/list ([name (in-list prov-names)])
       (define prov-cfg (provider-config settings name))
@@ -193,24 +196,36 @@
       (and cred (credential-provider-name cred))))
   (define providers-with-keys
     (filter (lambda (x) x) configured-providers))
+  ;; Separate local vs remote providers
+  (define local-provs (filter local-provider? prov-names))
+  (define remote-provs (filter (lambda (n) (not (local-provider? n))) prov-names))
+  ;; Providers that have keys (normalize to strings)
+  (define key-names (map (lambda (x) (if (symbol? x) (symbol->string x) x)) providers-with-keys))
+  ;; Local provider names for display
+  (define local-names (map (lambda (x) (if (symbol? x) (symbol->string x) x)) local-provs))
 
   (cond
     [(not (null? env-keys-found))
      (check-result "Credentials" 'ok
-                   (format "env: ~a" (string-join (map (lambda (x) (if (symbol? x) (symbol->string x) x)) env-keys-found) ", ")))]
-    [(not (null? providers-with-keys))
+                   (format "env: ~a" (string-join env-keys-found ", ")))]
+    [(not (null? key-names))
      (check-result "Credentials" 'ok
-                   (format "configured: ~a" (string-join (map (lambda (x) (if (symbol? x) (symbol->string x) x)) providers-with-keys) ", ")))]
+                   (format "configured: ~a" (string-join key-names ", ")))]
     [(and cred-file-exists?)
      (check-result "Credentials" 'warning
                    "credentials file exists but no keys resolved")]
     [(null? prov-names)
      (check-result "Credentials" 'warning
                    "no providers configured — set ANTHROPIC_API_KEY or OPENAI_API_KEY, or edit ~/.q/config.json")]
+    ;; All providers are local — no keys needed
+    [(null? remote-provs)
+     (check-result "Credentials" 'ok
+                   (format "local-only: ~a (no API keys needed)" (string-join local-names ", ")))]
     [else
      (check-result "Credentials" 'error
-                   (format "providers configured (~a) but no API keys found"
-                           (string-join (map ~a prov-names) ", ")))]))
+                   (format "remote providers (~a) need API keys; local: ~a"
+                           (string-join (map (lambda (x) (if (symbol? x) (symbol->string x) x)) remote-provs) ", ")
+                           (string-join local-names ", ")))]))
 
 ;; ============================================================
 ;; Check: session directory (~/.q/sessions/)
@@ -239,13 +254,26 @@
 ;; ============================================================
 
 (define (check-tui-packages)
-  (define available?
+  ;; q uses tui-term and tui-ubuf as optional TUI backends.
+  ;; Both are optional — TUI degrades gracefully without them.
+  (define tui-term?
     (with-handlers ([exn:fail? (λ (_) #f)])
-      (dynamic-require 'char-term #f)
+      (dynamic-require 'tui-term #f)
       #t))
-  (if available?
-      (check-result "TUI (char-term)" 'ok "available")
-      (check-result "TUI (char-term)" 'warning "not installed — TUI mode will not work (raco pkg install char-term)")))
+  (define tui-ubuf?
+    (with-handlers ([exn:fail? (λ (_) #f)])
+      (dynamic-require 'tui-ubuf #f)
+      #t))
+  (cond
+    [(and tui-term? tui-ubuf?)
+     (check-result "TUI" 'ok "tui-term + tui-ubuf available")]
+    [(or tui-term? tui-ubuf?)
+     (check-result "TUI" 'warning
+                   (format "~a available, ~amissing — TUI may be degraded (raco pkg install tui-term tui-ubuf)"
+                           (if tui-term? "tui-term" "")
+                           (if tui-term? "tui-ubuf " "tui-term ")))]
+    [else
+     (check-result "TUI" 'warning "tui-term/tui-ubuf not installed — TUI mode will not work (raco pkg install tui-term tui-ubuf)")]))
 
 ;; ============================================================
 ;; run-doctor — main entry point

--- a/runtime/settings.rkt
+++ b/runtime/settings.rkt
@@ -175,7 +175,7 @@
 ;; List configured provider names.
 (define (provider-names settings)
   (define providers-hash (setting-ref settings 'providers (hash)))
-  (map (lambda (k) (if (symbol? k) (symbol->string k) k)) (hash-keys providers-hash)))
+  (hash-keys providers-hash))
 
 ;; ============================================================
 ;; Parallel execution setting

--- a/tests/test-settings.rkt
+++ b/tests/test-settings.rkt
@@ -166,9 +166,8 @@
 (test-case "provider-names: lists configured providers"
   (define settings (q-settings sample-global-config (hash) sample-global-config))
   (define names (provider-names settings))
-  ;; provider-names normalizes JSON symbol keys to strings
-  (check-true (and (member "openai" names) #t))
-  (check-true (and (member "anthropic" names) #t))
+  (check-true (and (member 'openai names) #t))
+  (check-true (and (member 'anthropic names) #t))
   (check-equal? (length names) 2))
 
 (test-case "provider-names: returns empty list when no providers"


### PR DESCRIPTION
## Bug Fixes

Fixes four `q doctor` check issues:

### 1. Package check: false error
**Before:** `✗ Packages: failed to load q: instantiate: unknown module`
**Cause:** `dynamic-require q/main` used collection path that never resolves
**Fix:** If doctor is running, q modules are loaded by definition

### 2. TUI check: wrong package names
**Before:** `⚠ TUI (char-term): not installed`
**Cause:** Checked for `char-term` instead of `tui-term`/`tui-ubuf`
**Fix:** Checks both `tui-term` and `tui-ubuf`

### 3. Credentials check: missed configured keys
**Before:** `✗ providers configured (local, zai) but no API keys found`
**Cause:** `provider-names` string normalization broke `provider-config` symbol-key lookup; local providers (127.0.0.1) falsely flagged as needing keys
**Fix:** Reverted `provider-names` to raw hash keys; added `local-provider?` detection for localhost URLs

### 4. TUI check: installed-but-broken detection
**Before:** Reported packages as not installed even though they were
**Cause:** `dynamic-require` fails at collection resolver, indistinguishable from not-installed
**Fix:** Uses `pkg/lib` via dynamic-require to check installation separately from loadability. Reports: installed+loadable, installed+broken, not-installed

## Verification
- `racket main.rkt doctor` now shows correct results for all checks
- 2877 tests, 0 failures

## Commits
- `10155e8` fix: doctor checks — packages, TUI libs, credential detection
- `8f64bde` fix: doctor TUI check — detect installed-but-broken packages