### PR TITLE
🔥 hotfix: tool serialization + CLI paste duplication

### DIFF
--- a/agent/loop.rkt
+++ b/agent/loop.rkt
@@ -168,8 +168,8 @@
          #:state st)
 
   ;; 4. Build model-request and call provider-stream
-  ;; tools is already a (listof hash?) in OpenAI format,
-  ;; passed in by the caller (iteration.rkt).
+  ;; tools is a (listof hash?) in OpenAI normalized format,
+  ;; passed in by the caller (iteration.rkt) via list-tools-jsexpr.
   (define req (make-model-request raw-messages tools (hasheq)))
 
   ;; R2-7: model-request-pre hook -- dispatch before sending to provider

--- a/runtime/iteration.rkt
+++ b/runtime/iteration.rkt
@@ -27,7 +27,7 @@
          (only-in "../tools/tool.rkt"
                   make-exec-context
                   tool-result-content tool-result-is-error?
-                  list-tools)
+                  list-tools-jsexpr)
          "../tools/scheduler.rkt"
          "../extensions/hooks.rkt"
          "../runtime/session-store.rkt"
@@ -229,7 +229,7 @@
                                    (hasheq 'session-id session-id 'turn-id turn-id)))
 
        ;; Get tools from registry for the LLM request
-       (define tools (and reg (list-tools reg)))
+       (define tools (and reg (list-tools-jsexpr reg)))
 
        (define result
          (run-agent-turn ctx-final prov bus

--- a/tests/test-tool-registry.rkt
+++ b/tests/test-tool-registry.rkt
@@ -342,6 +342,35 @@
      (check-false (tool-result-is-error? echo-result))
      (check-equal? (hash-ref (list-ref (tool-result-content echo-result) 0) 'text)
                    "hello"))
-   ))
+
+   ;; ============================================================
+   ;; 6. Tool serialization (tool->jsexpr / list-tools-jsexpr)
+   ;; ============================================================
+
+   (test-case "tool->jsexpr produces OpenAI normalized format"
+     (define schema
+       (hasheq 'type "object"
+               'properties (hasheq 'path (hasheq 'type "string"))
+               'required '("path")))
+     (define ser-tool (make-tool "read_file" "Read a file" schema void))
+     (define jx (tool->jsexpr ser-tool))
+     (check-equal? (hash-ref jx 'type) "function")
+     (define fn (hash-ref jx 'function))
+     (check-equal? (hash-ref fn 'name) "read_file")
+     (check-equal? (hash-ref fn 'description) "Read a file")
+     (check-equal? (hash-ref fn 'parameters) schema))
+
+   (test-case "list-tools-jsexpr returns serialized tool list"
+     (define reg (make-tool-registry))
+     (register-tool! reg t)
+     (define jtools (list-tools-jsexpr reg))
+     (check-equal? (length jtools) 1)
+     (define jx (car jtools))
+     (check-equal? (hash-ref jx 'type) "function")
+     (check-equal? (hash-ref (hash-ref jx 'function) 'name) "read_file"))
+
+   (test-case "list-tools-jsexpr returns empty list for empty registry"
+     (define reg (make-tool-registry))
+     (check-equal? (list-tools-jsexpr reg) '()))))
 
 (run-tests tool-reg-tests)

--- a/tools/tool.rkt
+++ b/tools/tool.rkt
@@ -29,6 +29,7 @@
  tool-description
  tool-schema
  tool-execute
+ tool->jsexpr
 
  ;; ── Tool result (re-exported from agent/types.rkt) ──
  tool-result?
@@ -64,6 +65,7 @@
  unregister-tool!
  lookup-tool
  list-tools
+ list-tools-jsexpr
  tool-names)
 
 ;; ============================================================
@@ -164,6 +166,20 @@
 
 (define (lookup-tool reg name)
   (hash-ref (tool-registry-tools-box reg) name #f))
+
+;; tool->jsexpr : tool? -> hash?
+;; Serialize a tool struct to the OpenAI normalized format.
+;; Output: {"type":"function","function":{"name":"...","description":"...","parameters":{...}}}
+(define (tool->jsexpr t)
+  (hasheq 'type "function"
+          'function (hasheq 'name (tool-name t)
+                            'description (tool-description t)
+                            'parameters (tool-schema t))))
+
+;; list-tools-jsexpr : tool-registry? -> (listof hash?)
+;; Return all registered tools serialized to the OpenAI normalized JSON format.
+(define (list-tools-jsexpr reg)
+  (map tool->jsexpr (hash-values (tool-registry-tools-box reg))))
 
 (define (list-tools reg)
   (hash-values (tool-registry-tools-box reg)))


### PR DESCRIPTION
## Summary

Two critical fixes:

### 1. Tool structs crash on every message (v0.1.0 regression)

`list-tools` returned raw `tool` structs which were passed directly into the LLM request body, causing `jsexpr->bytes` to crash on **every message** to any provider (OpenAI, Gemini, Anthropic). Bug existed since v0.1.0.

### 2. CLI input duplication on paste

Readline 8.2 enables bracketed paste mode by default. The Racket `rl_getc_function` wrapper mishandles the ANSI escape sequences, causing the first few characters of pasted text to be prepended to the full input.

## Changes

### Fix 1: Tool serialization (`fe2342e`)
- **`tools/tool.rkt`**: Added `tool->jsexpr` (struct → OpenAI hash) and `list-tools-jsexpr`
- **`runtime/iteration.rkt`**: Use `list-tools-jsexpr` instead of `list-tools`
- **`agent/loop.rkt`**: Corrected comment
- **`tests/test-tool-registry.rkt`**: +3 test cases

### Fix 2: Bracketed paste (`26d6bbe`)
- **`interfaces/cli.rkt`**: Call `rl_variable_bind("enable-bracketed-paste", "off")` at readline init

## Testing

- 3,070 tests passing, 0 failures
- 6/6 lints green
- Pre-commit hook passed on both commits

## Files Changed

| File | Change |
|------|--------|
| `tools/tool.rkt` | +16 (tool->jsexpr, list-tools-jsexpr, exports) |
| `runtime/iteration.rkt` | 2 lines changed |
| `agent/loop.rkt` | Comment fix |
| `tests/test-tool-registry.rkt` | +31 (3 test cases) |
| `interfaces/cli.rkt` | +12 (disable bracketed paste) |