### PR TITLE
🔥 hotfix(cli): disable readline bracketed paste to prevent input duplication

### DIFF
--- a/interfaces/cli.rkt
+++ b/interfaces/cli.rkt
@@ -21,7 +21,8 @@
          racket/match
          racket/string
          racket/format
-         racket/list)
+         racket/list
+         (only-in ffi/unsafe ffi-lib get-ffi-obj _fun _string _int))
 
 ;; readline support: try to load, fall back to plain read-line
 ;; Prefer GNU libreadline over libedit for proper UTF-8 support.
@@ -32,6 +33,16 @@
 (define readline-available?
   (with-handlers ([exn:fail? (lambda (_) #f)])
     (void (dynamic-require 'readline/rktrl #f))
+    ;; Disable bracketed paste mode — readline 8.2 enables it by default,
+    ;; but the Racket rl_getc_function wrapper can mishandle the ANSI
+    ;; escape sequences, causing pasted text to be duplicated in the
+    ;; returned line (first few characters get prepended).
+    (with-handlers ([exn:fail? void])
+      (define librl (ffi-lib "libreadline" '("8.2" "8.1" "8" #f)))
+      (define rl-variable-bind
+        (get-ffi-obj "rl_variable_bind" librl
+                     (_fun _string _string -> _int)))
+      (rl-variable-bind "enable-bracketed-paste" "off"))
     #t))
 
 (define (read-line-with-history prompt in [out (current-output-port)])


### PR DESCRIPTION
## Summary

When pasting text into the q CLI, the first few characters get duplicated at the start of the input line. For example, pasting `"Wie ging das Spiel..."` becomes `"Wie ging das Wie ging das Spiel..."`.

## Root Cause

Readline 8.2 enables bracketed paste mode by default (sends `\e[?2004h` to terminal). The terminal responds with `\e[200~...text...\e[201~` on paste. The Racket `rl_getc_function` wrapper can mishandle these ANSI escape sequences during rapid character-by-character reads, causing partial text to be prepended to the full line.

## Fix

Call `rl_variable_bind("enable-bracketed-paste", "off")` when readline is first loaded in CLI mode. This tells readline not to request bracketed paste from the terminal, avoiding the problematic escape sequence handling.

## Testing

- 3,070 tests passing, 0 failures
- 6/6 lints green
- Pre-commit hook passed

## Files Changed

| File | Change |
|------|--------|
| `interfaces/cli.rkt` | +12 (ffi-lib import + bracketed-paste disable) |