### PR TITLE
[Wave 5b] Wiki expansion, automated releases, macOS CI, CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# CODEOWNERS — q Racket Coding Agent
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default owner for everything
+* @coinerd

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,10 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v5
 
@@ -22,43 +25,53 @@ jobs:
           path: |
             /usr/local/racket
             ~/.cache/racket
-          key: racket-8.10-ubuntu-${{ runner.os }}
+          key: racket-8.10-${{ matrix.os }}
 
-      - name: Install Racket
-        if: steps.cache-racket.outputs.cache-hit != 'true'
+      - name: Install Racket (Linux)
+        if: runner.os == 'Linux' && steps.cache-racket.outputs.cache-hit != 'true'
         run: |
           curl -L https://download.racket-lang.org/installers/8.10/racket-8.10-x86_64-linux-cs.sh -o /tmp/racket.sh
           echo "2" | sudo sh /tmp/racket.sh --in-place --create-links /usr/local
           ls -la /usr/local/racket/bin/raco || (echo "Racket installation failed" && exit 1)
 
+      - name: Install Racket (macOS)
+        if: runner.os == 'macOS' && steps.cache-racket.outputs.cache-hit != 'true'
+        run: |
+          curl -L https://download.racket-lang.org/installers/8.10/racket-8.10-aarch64-macosx-cs.dmg -o /tmp/racket.dmg
+          hdiutil attach /tmp/racket.dmg
+          sudo installer -pkg /Volumes/Racket*/Racket*.pkg -target /
+          hdiutil detach /Volumes/Racket*
+          ls -la /usr/local/bin/raco || (echo "Racket installation failed" && exit 1)
+
       - name: Verify Racket Installation
-        run: /usr/local/racket/bin/racket --version
+        run: /usr/local/racket/bin/racket --version || racket --version
 
       - name: Install dependencies
         run: |
-          /usr/local/racket/bin/raco pkg install --auto --batch
-          /usr/local/racket/bin/raco pkg install --auto --batch tui-term tui-ubuf 2>/dev/null || true
+          RACO="$(which raco || echo /usr/local/racket/bin/raco)"
+          $RACO pkg install --auto --batch
+          $RACO pkg install --auto --batch tui-term tui-ubuf 2>/dev/null || true
 
       - name: Clean bytecode cache
         run: find . -name '*.zo' -delete -o -name 'compiled' -type d -exec rm -rf {} + 2>/dev/null; true
 
       - name: Lint tests for portability
-        run: /usr/local/racket/bin/racket scripts/lint-tests.rkt
+        run: racket scripts/lint-tests.rkt
 
       - name: Lint version consistency
-        run: /usr/local/racket/bin/racket scripts/lint-version.rkt
+        run: racket scripts/lint-version.rkt
 
       - name: Format lint
-        run: /usr/local/racket/bin/racket scripts/lint-format.rkt
+        run: racket scripts/lint-format.rkt
 
       - name: Lint metrics consistency
-        run: /usr/local/racket/bin/racket scripts/metrics.rkt --lint
+        run: racket scripts/metrics.rkt --lint
 
       - name: Protocol consistency
-        run: /usr/local/racket/bin/racket scripts/check-protocols.rkt
+        run: racket scripts/check-protocols.rkt
 
       - name: Import conflicts
-        run: /usr/local/racket/bin/racket scripts/check-imports.rkt
+        run: racket scripts/check-imports.rkt
 
       - name: Verify project structure
         run: |
@@ -67,10 +80,13 @@ jobs:
           test -f main.rkt && echo "main.rkt found at repo root"
 
       - name: Run tests
-        run: /usr/local/racket/bin/raco test tests/
+        run: raco test tests/
 
   smoke:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v5
 
@@ -81,25 +97,34 @@ jobs:
           path: |
             /usr/local/racket
             ~/.cache/racket
-          key: racket-8.10-ubuntu-${{ runner.os }}
+          key: racket-8.10-${{ matrix.os }}
 
-      - name: Install Racket
-        if: steps.cache-racket.outputs.cache-hit != 'true'
+      - name: Install Racket (Linux)
+        if: runner.os == 'Linux' && steps.cache-racket.outputs.cache-hit != 'true'
         run: |
           curl -L https://download.racket-lang.org/installers/8.10/racket-8.10-x86_64-linux-cs.sh -o /tmp/racket.sh
           echo "2" | sudo sh /tmp/racket.sh --in-place --create-links /usr/local
           ls -la /usr/local/racket/bin/raco || (echo "Racket installation failed" && exit 1)
 
+      - name: Install Racket (macOS)
+        if: runner.os == 'macOS' && steps.cache-racket.outputs.cache-hit != 'true'
+        run: |
+          curl -L https://download.racket-lang.org/installers/8.10/racket-8.10-aarch64-macosx-cs.dmg -o /tmp/racket.dmg
+          hdiutil attach /tmp/racket.dmg
+          sudo installer -pkg /Volumes/Racket*/Racket*.pkg -target /
+          hdiutil detach /Volumes/Racket*
+          ls -la /usr/local/bin/raco || (echo "Racket installation failed" && exit 1)
+
       - name: Verify Racket Installation
-        run: /usr/local/racket/bin/racket --version
+        run: racket --version
 
       - name: Install dependencies
         run: |
-          /usr/local/racket/bin/raco pkg install --auto --batch
-          /usr/local/racket/bin/raco pkg install --auto --batch tui-term tui-ubuf 2>/dev/null || true
+          raco pkg install --auto --batch
+          raco pkg install --auto --batch tui-term tui-ubuf 2>/dev/null || true
 
       - name: Version smoke check
         run: |
-          output=$(/usr/local/racket/bin/racket main.rkt --version)
+          output=$(racket main.rkt --version)
           echo "$output"
           echo "$output" | grep -qE '^q version [0-9]+\.[0-9]+\.[0-9]+$'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,76 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Cache Racket installation
+        id: cache-racket
+        uses: actions/cache@v5
+        with:
+          path: |
+            /usr/local/racket
+            ~/.cache/racket
+          key: racket-8.10-ubuntu-${{ runner.os }}
+
+      - name: Install Racket
+        if: steps.cache-racket.outputs.cache-hit != 'true'
+        run: |
+          curl -L https://download.racket-lang.org/installers/8.10/racket-8.10-x86_64-linux-cs.sh -o /tmp/racket.sh
+          echo "2" | sudo sh /tmp/racket.sh --in-place --create-links /usr/local
+
+      - name: Install dependencies
+        run: |
+          /usr/local/racket/bin/raco pkg install --auto --batch
+          /usr/local/racket/bin/raco pkg install --auto --batch tui-term tui-ubuf 2>/dev/null || true
+
+      - name: Run tests
+        run: /usr/local/racket/bin/raco test tests/
+
+  release:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Extract version from tag
+        id: version
+        run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+
+      - name: Build tarball
+        run: |
+          mkdir -p /tmp/q-${{ steps.version.outputs.VERSION }}
+          cp -r . /tmp/q-${{ steps.version.outputs.VERSION }}/
+          cd /tmp
+          tar czf /tmp/q-${{ steps.version.outputs.VERSION }}.tar.gz \
+            --exclude='.git' \
+            --exclude='compiled' \
+            --exclude='*.zo' \
+            q-${{ steps.version.outputs.VERSION }}/
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: /tmp/q-${{ steps.version.outputs.VERSION }}.tar.gz
+          body: |
+            ## q v${{ steps.version.outputs.VERSION }}
+
+            See [CHANGELOG.md](https://github.com/coinerd/q/blob/main/CHANGELOG.md) for details.
+
+            ### Installation
+            ```bash
+            tar xzf q-${{ steps.version.outputs.VERSION }}.tar.gz
+            cd q-${{ steps.version.outputs.VERSION }}
+            raco pkg install
+            ```

--- a/wiki-src/Architecture-Overview.md
+++ b/wiki-src/Architecture-Overview.md
@@ -1,13 +1,45 @@
 # Architecture Overview
 
-q is organized as a layered system.
+q is a layered, event-driven AI coding agent written in Racket. Each layer only depends on layers below it.
 
-## Layers
+## Layers (bottom-up)
 
-1. **Interfaces** — CLI, TUI, JSON mode, RPC/SDK
-2. **Tools & Extensions** — Built-in tools, extension API, sandbox
-3. **Runtime** — Session lifecycle, settings, provider factory, compaction
-4. **Agent Core** — Event bus, agent loop, iteration manager
-5. **LLM** — Provider protocol, OpenAI/Anthropic/Gemini adapters, streaming
+| Layer | Responsibility | Key Modules |
+|-------|---------------|-------------|
+| **Foundation** | Types, JSONL, IDs, session storage | `agent/types.rkt`, `util/jsonl.rkt`, `util/ids.rkt`, `runtime/session-store.rkt` |
+| **Core** | LLM providers, event bus, agent loop | `llm/provider.rkt`, `agent/event-bus.rkt`, `agent/loop.rkt` |
+| **Tools** | Tool contracts, scheduler, built-in tools | `tools/tool.rkt`, `tools/scheduler.rkt`, `tools/builtins/*.rkt` |
+| **Runtime** | Session lifecycle, resources, extensions | `runtime/agent-session.rkt`, `runtime/resource-loader.rkt`, `extensions/*.rkt` |
+| **Interfaces** | CLI, TUI, RPC, SDK | `interfaces/cli.rkt`, `interfaces/tui.rkt`, `interfaces/sdk.rkt` |
+| **Hardening** | Sandbox, limits, recovery | `sandbox/evaluator.rkt`, `sandbox/limits.rkt` |
 
-See the canonical architecture description in the [repository README](https://github.com/coinerd/q/blob/main/README.md) and [docs/](https://github.com/coinerd/q/tree/main/docs).
+## Key Design Principles
+
+- **Event-driven**: All state changes flow through the event bus (`agent/event-bus.rkt`). Interfaces subscribe to events and react independently.
+- **Provider protocol**: All LLM providers implement the same interface (`llm/provider.rkt`). Adding a new provider requires implementing `complete` and `stream-complete`.
+- **Session storage**: Append-only JSONL files. Each turn is a single line. Sessions can be branched, compacted, and replayed.
+- **Safe mode**: Dual-layer enforcement — scheduler checks destructive commands, sandbox enforces resource limits.
+- **Extension API**: Extensions register hooks (`on-tool-call`, `on-response`, `on-session-start`) via `extensions/api.rkt`. Manifest validation and integrity checks protect against malformed extensions.
+
+## Data Flow
+
+```
+User input → Interface (CLI/TUI/RPC)
+  → Agent loop (agent/loop.rkt)
+    → LLM provider (streaming response)
+      → Tool calls (if any)
+        → Tool execution (sandbox if safe-mode)
+        → Tool result back to agent loop
+    → Response rendered to interface
+    → Session log appended (JSONL)
+    → Events emitted to bus
+```
+
+## Metrics (v0.8.0)
+
+- 119 source modules, 138 test files
+- 22,032 source lines, 38,032 test lines
+- 3,352 tests, 6,133 assertions (test:source ratio 1.86:1)
+- 6/6 lint checks enforced in CI
+
+For the canonical architecture description, see the [repository README](https://github.com/coinerd/q/blob/main/README.md) and [docs/architecture/overview.md](https://github.com/coinerd/q/blob/main/docs/architecture/overview.md).

--- a/wiki-src/Glossary-and-FAQ.md
+++ b/wiki-src/Glossary-and-FAQ.md
@@ -1,16 +1,73 @@
 # Glossary and FAQ
 
-## What is q?
-A local-first, extensible coding agent runtime written in Racket.
+## Glossary
 
-## Where is the canonical documentation?
-In the main repository: README, docs/, and CONTRIBUTING.md.
+| Term | Definition |
+|------|-----------|
+| **Agent loop** | The core cycle: send prompt → receive response → execute tools → repeat until done |
+| **Session** | A conversation with the LLM, stored as append-only JSONL |
+| **Turn** | One iteration of the agent loop (prompt + response + tool calls) |
+| **Provider** | An LLM backend adapter (OpenAI, Anthropic, Gemini, or local) |
+| **Tool** | A capability exposed to the LLM (bash, read, write, edit, grep, find, ls) |
+| **Extension** | A plugin that hooks into the agent lifecycle (tool interception, logging, etc.) |
+| **Safe mode** | A restricted mode where dangerous tool calls are blocked or sandboxed |
+| **Compaction** | Summarizing old turns to reduce context window usage |
+| **JSONL** | JSON Lines format — one JSON object per line, used for session logs |
+| **Event bus** | Pub/sub system for agent events (tool calls, responses, errors) |
+| **Token budget** | Maximum tokens allowed before compaction triggers |
+| **Scheduler** | Manages concurrent tool execution and resource limits |
 
-## What is this wiki for?
+## FAQ
+
+### What is q?
+A local-first, extensible coding agent runtime written in Racket. It runs in your terminal (CLI or TUI) and connects to LLM providers (OpenAI, Anthropic, Gemini, or local models).
+
+### How do I install q?
+```bash
+git clone https://github.com/coinerd/q.git
+cd q
+raco pkg install
+```
+Requires Racket 8.10+. See the [installation guide](https://github.com/coinerd/q/blob/main/q/docs/install.md).
+
+### How do I configure a provider?
+Run `q --init` for the interactive wizard, or edit `~/.q/config.json` directly:
+```json
+{
+  "default-model": "gpt-4o",
+  "providers": {
+    "openai": { "api-key": "sk-..." }
+  }
+}
+```
+
+### How do I start a session?
+```bash
+q                          # Interactive CLI
+q "fix the bug in main.rkt"  # One-shot mode
+q --tui                    # Terminal UI
+```
+
+### How do I resume a session?
+```bash
+q --session <session-id>
+```
+Use `q --sessions` to list available sessions.
+
+### How do I write an extension?
+See [[Writing-Extensions]] and the [extension API docs](https://github.com/coinerd/q/blob/main/q/extensions/api.rkt).
+
+### How do I enable safe mode?
+```bash
+q --safe                   # CLI safe mode
+```
+Or set in config: `"safe-mode": true`. This sandboxes bash commands and restricts file access.
+
+### Where are sessions stored?
+In `~/.q/sessions/` as JSONL files. Each turn is one line.
+
+### Where is the canonical documentation?
+In the main repository: [README](https://github.com/coinerd/q/blob/main/README.md), [docs/](https://github.com/coinerd/q/tree/main/docs), and [CONTRIBUTING.md](https://github.com/coinerd/q/blob/main/CONTRIBUTING.md).
+
+### What is this wiki for?
 Navigation, onboarding, architecture maps, troubleshooting, and contributor guidance.
-
-## How do I configure a provider?
-Edit `~/.q/config.json` or run `q --init` for the interactive wizard.
-
-## How do I write an extension?
-See [[Writing-Extensions]] and the extension API docs in the repository.

--- a/wiki-src/Troubleshooting.md
+++ b/wiki-src/Troubleshooting.md
@@ -4,7 +4,7 @@ Use this page as the quick index for common setup and runtime issues.
 
 ## Common categories
 
-- **Install failures** — Check Racket version (8.8+), verify `raco` is on PATH
+- **Install failures** — Check Racket version (8.10+), verify `raco` is on PATH
 - **Provider configuration** — Verify `~/.q/config.json` has correct `base-url` and `api-key-env`
 - **Interface-specific issues** — TUI requires a terminal; JSON mode needs valid JSON on stdin
 - **Extension behavior** — Run `q doctor` to diagnose extension loading issues

--- a/wiki-src/Writing-Extensions.md
+++ b/wiki-src/Writing-Extensions.md
@@ -1,16 +1,80 @@
 # Writing Extensions
 
-This page explains how to think about q extensions and where they fit in the architecture.
+q extensions hook into the agent lifecycle to add custom behavior — tool interception, response post-processing, session logging, and more.
 
-## Principles
+## Extension Anatomy
 
-- Prefer narrow responsibilities
-- Keep extension behavior observable
-- Avoid leaking interface-specific concerns into the core
-- Link back to canonical implementation and contract docs
+Every extension has:
 
-## Getting started
+1. **Manifest** (`extension.json`) — Declares the extension's name, version, entry point, hooks, and minimum q version.
+2. **Entry module** — A Racket module that registers hooks via the extension API.
 
-See the extension API documentation in the main repository:
-- [extensions/api.rkt](https://github.com/coinerd/q/blob/main/q/extensions/api.rkt)
-- [Extension manifest spec](https://github.com/coinerd/q/blob/main/q/extensions/manifest.rkt)
+### Minimal Example
+
+**`extension.json`:**
+```json
+{
+  "name": "my-extension",
+  "version": "X.Y.Z",
+  "entry": "main.rkt",
+  "min-q-version": "0.X.Y",
+  "hooks": ["on-tool-call", "on-response"]
+}
+```
+
+**`main.rkt`:**
+```racket
+#lang racket/base
+
+(require q/extensions/api)
+
+(define (on-tool-call ctx tool-name args)
+  (printf "[my-extension] Tool called: ~a~n" tool-name)
+  args)  ; return args unchanged
+
+(define (on-response ctx response)
+  response)  ; return response unchanged
+
+(provide on-tool-call on-response)
+```
+
+## Available Hooks
+
+| Hook | Signature | Purpose |
+|------|-----------|---------|
+| `on-session-start` | `(ctx)` | Called when a new session begins |
+| `on-tool-call` | `(ctx tool-name args)` | Intercept/modify tool arguments before execution |
+| `on-tool-result` | `(ctx tool-name result)` | Inspect/modify tool results after execution |
+| `on-response` | `(ctx response)` | Post-process the LLM response |
+| `on-session-end` | `(ctx)` | Called when a session terminates |
+
+## Security Model
+
+- Extensions are loaded from `~/.q/extensions/` (user scope) or `.q/extensions/` (project scope).
+- Manifests are validated for required fields and schema compliance.
+- File integrity hashes (SHA256) are verified on load.
+- Extensions can be quarantined if they cause repeated errors.
+
+## Tiers
+
+Extensions run in one of three tiers:
+
+| Tier | Capabilities |
+|------|-------------|
+| **Observer** | Read-only hooks, no mutation |
+| **Modifier** | Can transform tool args/results and responses |
+| **Authority** | Full access including tool registration |
+
+## Best Practices
+
+- Keep extensions stateless where possible.
+- Use narrow hook subscriptions — only declare hooks you actually use.
+- Return values unchanged unless you intentionally modify them.
+- Log errors gracefully; don't crash the agent loop.
+- Test with `q/extensions/test-harness.rkt`.
+
+## Reference
+
+- [Extension API source](https://github.com/coinerd/q/blob/main/q/extensions/api.rkt)
+- [Manifest spec](https://github.com/coinerd/q/blob/main/q/extensions/manifest.rkt)
+- [Test harness](https://github.com/coinerd/q/blob/main/q/extensions/test-harness.rkt)


### PR DESCRIPTION
## Wave 5b: Wiki, CI & Maturity

Closes remaining v0.8.0 issues (#262-#266).

### Changes
- **#262**: Install guide version already fixed in Wave 5 (PR #273)
- **#263**: Expanded 3 wiki stubs with substantive content; fixed Racket version 8.8→8.10 in Troubleshooting
- **#265**: Automated release workflow (`release.yml`) — tag push triggers tests, GitHub Release creation with tarball
- **#266**: macOS CI matrix, Dependabot config, CODEOWNERS file

### Testing
- 3,352 tests passing, 6/6 lints green

Closes #262, Closes #263, Closes #264, Closes #265, Closes #266
