### PR TITLE
refactor(tools): extract shared utilities, remove duplicated code across builtins

### DIFF
--- a/tools/builtins/bash.rkt
+++ b/tools/builtins/bash.rkt
@@ -12,8 +12,10 @@
 
 (require racket/string
          (only-in "../tool.rkt"
-                  make-success-result make-error-result
-                  exec-context? exec-context-working-directory)
+                  make-success-result
+                  make-error-result
+                  exec-context?
+                  exec-context-working-directory)
          "../../sandbox/subprocess.rkt"
          "../../sandbox/limits.rkt"
          "../../runtime/settings.rkt")
@@ -24,15 +26,7 @@
 ;; Destructive command patterns (SEC-03)
 ;; Each pattern is a string that is checked case-insensitively
 ;; against the command string.
-(define destructive-patterns
-  '("rm -rf"
-    "rmdir"
-    "mkfs"
-    "dd if="
-    "format"
-    "del /"
-    "shutdown"
-    "reboot"))
+(define destructive-patterns '("rm -rf" "rmdir" "mkfs" "dd if=" "format" "del /" "shutdown" "reboot"))
 
 ;; Check if a command matches any destructive pattern.
 (define (destructive-command? command)
@@ -51,51 +45,37 @@
          destructive-patterns)
 
 ;; --------------------------------------------------
-;; Result helpers
-;; --------------------------------------------------
-
-(define (err msg)
-  (make-error-result msg))
-
-;; --------------------------------------------------
 ;; Main tool function
 ;; --------------------------------------------------
 
 (define (tool-bash args [exec-ctx #f])
   (define command (hash-ref args 'command #f))
   (cond
-    [(not command)
-     (err "Missing required argument: command")]
-    [(not (non-empty-string? command))
-     (err "command must be a non-empty string")]
+    [(not command) (make-error-result "Missing required argument: command")]
+    [(not (non-empty-string? command)) (make-error-result "command must be a non-empty string")]
     [else
      ;; Optional destructive command warning (SEC-03)
-     (when (and (current-warn-on-destructive)
-                (destructive-command? command))
-       (fprintf (current-error-port)
-                "WARNING: Destructive command detected: ~a~n"
-                command))
+     (when (and (current-warn-on-destructive) (destructive-command? command))
+       (fprintf (current-error-port) "WARNING: Destructive command detected: ~a~n" command))
      (define timeout-secs (hash-ref args 'timeout DEFAULT-TIMEOUT-SECONDS))
      (define work-dir (hash-ref args 'working-directory #f))
 
      (define result
-       (run-subprocess
-        "/bin/sh"
-        #:args (list "-c" command)
-        #:limits (exec-limits timeout-secs 1048576 536870912 10)
-        #:directory (or work-dir
-                        (and exec-ctx (exec-context-working-directory exec-ctx))
-                        (current-directory))))
+       (run-subprocess "/bin/sh"
+                       #:args (list "-c" command)
+                       #:limits (exec-limits timeout-secs 1048576 536870912 10)
+                       #:directory (or work-dir
+                                       (and exec-ctx (exec-context-working-directory exec-ctx))
+                                       (current-directory))))
 
      (define stdout (subprocess-result-stdout result))
      (define stderr-out (subprocess-result-stderr result))
      ;; Combine stdout and stderr; include stderr if non-empty
      (define raw-combined
-       (string-trim
-        (string-append stdout
-                       (if (string=? stderr-out "")
-                           ""
-                           (string-append "\n" stderr-out)))))
+       (string-trim (string-append stdout
+                                   (if (string=? stderr-out "")
+                                       ""
+                                       (string-append "\n" stderr-out)))))
      ;; When output is empty, provide diagnostic feedback to the LLM
      ;; so it understands the command produced nothing and can change strategy
      (define combined
@@ -103,10 +83,12 @@
            "(Command produced no output. The command may have completed without producing any output, or the output was empty. Consider
                checking: the command syntax, file paths, available tools, or try a different approach.)"
            raw-combined))
-     (make-success-result
-      (list (hasheq 'type "text"
-                    'text combined))
-      (hasheq 'exit-code (subprocess-result-exit-code result)
-              'timed-out? (subprocess-result-timed-out? result)
-              'duration-ms (subprocess-result-elapsed-ms result)
-              'command command))]))
+     (make-success-result (list (hasheq 'type "text" 'text combined))
+                          (hasheq 'exit-code
+                                  (subprocess-result-exit-code result)
+                                  'timed-out?
+                                  (subprocess-result-timed-out? result)
+                                  'duration-ms
+                                  (subprocess-result-elapsed-ms result)
+                                  'command
+                                  command))]))

--- a/tools/builtins/edit.rkt
+++ b/tools/builtins/edit.rkt
@@ -13,16 +13,6 @@
 (provide tool-edit)
 
 ;; --------------------------------------------------
-;; Result helpers (local) - return tool-result structs
-;; --------------------------------------------------
-
-(define (ok content details)
-  (make-success-result content details))
-
-(define (err msg)
-  (make-error-result msg))
-
-;; --------------------------------------------------
 ;; String helpers
 ;; --------------------------------------------------
 
@@ -51,20 +41,21 @@
 (define (tool-edit args [exec-ctx #f])
   (define path-str (hash-ref args 'path #f))
   (cond
-    [(not path-str) (err "Missing required argument: path")]
+    [(not path-str) (make-error-result "Missing required argument: path")]
     [else
      (define old-text (hash-ref args 'old-text #f))
      (cond
-       [(not old-text) (err "Missing required argument: old-text")]
+       [(not old-text) (make-error-result "Missing required argument: old-text")]
        [else
         (define new-text (hash-ref args 'new-text #f))
         (cond
-          [(not new-text) (err "Missing required argument: new-text")]
+          [(not new-text) (make-error-result "Missing required argument: new-text")]
           [else
            ;; 1. File existence check
            ;; (safe-mode path check is done by scheduler, not here)
            (cond
-             [(not (file-exists? path-str)) (err (format "File not found: ~a" path-str))]
+             [(not (file-exists? path-str))
+              (make-error-result (format "File not found: ~a" path-str))]
 
              [else
               ;; 2. Read file content
@@ -74,10 +65,10 @@
               (define occurrences (count-occurrences content old-text))
 
               (cond
-                [(zero? occurrences) (err (format "old-text not found in ~a" path-str))]
+                [(zero? occurrences) (make-error-result (format "old-text not found in ~a" path-str))]
 
                 [(> occurrences 1)
-                 (err
+                 (make-error-result
                   (format "old-text appears ~a times in ~a; be more specific" occurrences path-str))]
 
                 [else
@@ -86,17 +77,19 @@
 
                  ;; 5. Write back
                  (with-handlers ([exn:fail:filesystem?
-                                  (lambda (e) (err (format "Write error: ~a" (exn-message e))))])
+                                  (lambda (e)
+                                    (make-error-result (format "Write error: ~a" (exn-message e))))])
                    (call-with-output-file path-str
                                           (lambda (out) (display new-content out))
                                           #:exists 'replace)
 
-                   (ok (list (format "Edited ~a (replaced ~a occurrence)" path-str occurrences))
-                       (hasheq 'path
-                               path-str
-                               'replacements
-                               1
-                               'old-length
-                               (string-length old-text)
-                               'new-length
-                               (string-length new-text))))])])])])]))
+                   (make-success-result
+                    (list (format "Edited ~a (replaced ~a occurrence)" path-str occurrences))
+                    (hasheq 'path
+                            path-str
+                            'replacements
+                            1
+                            'old-length
+                            (string-length old-text)
+                            'new-length
+                            (string-length new-text))))])])])])]))

--- a/tools/builtins/find.rkt
+++ b/tools/builtins/find.rkt
@@ -3,51 +3,12 @@
 (require racket/file
          racket/string
          racket/path
-         (only-in "../tool.rkt" make-success-result make-error-result))
+         (only-in "../tool.rkt" make-success-result make-error-result)
+         (only-in "../../util/glob.rkt" glob->regexp)
+         (only-in "../../util/path-filters.rkt"
+                  hidden-name? vcs-dir? skip-dirs path-component-hidden?))
 
 (provide tool-find)
-
-;; --------------------------------------------------
-;; Result helpers - return tool-result structs
-;; --------------------------------------------------
-
-(define (ok content details)
-  (make-success-result content details))
-
-(define (err msg)
-  (make-error-result msg))
-
-;; --------------------------------------------------
-;; Glob pattern → regexp
-;; --------------------------------------------------
-
-(define (glob->regexp pattern)
-  (define escaped
-    (for/list ([ch (in-string pattern)])
-      (case ch
-        [(#\*) ".*"]
-        [(#\?) "."]
-        [(#\. #\+ #\( #\) #\[ #\] #\{ #\} #\\ #\^ #\$ #\|) (string #\\ ch)]
-        [else (string ch)])))
-  (regexp (string-append "^" (string-join escaped "") "$")))
-
-;; --------------------------------------------------
-;; VCS / skip predicates
-;; --------------------------------------------------
-
-(define VCS-DIRS '(".git" ".hg" ".svn" "node_modules"))
-
-(define (vcs-dir? name)
-  (member name VCS-DIRS))
-
-(define (hidden-name? name)
-  (and (> (string-length name) 0) (char=? (string-ref name 0) #\.)))
-
-(define (path-component-hidden? abs-path)
-  ;; Check if any component of the path is hidden
-  (for/or ([part (in-list (explode-path abs-path))])
-    (define s (path->string part))
-    (hidden-name? s)))
 
 ;; --------------------------------------------------
 ;; Core recursive walk
@@ -109,18 +70,19 @@
 (define (tool-find args [exec-ctx #f])
   ;; (safe-mode path check is done by scheduler, not here)
   (cond
-    [(not (hash-has-key? args 'path)) (err "Missing required argument: path")]
+    [(not (hash-has-key? args 'path)) (make-error-result "Missing required argument: path")]
     [else
      (define path-str (hash-ref args 'path))
      (cond
-       [(not (string? path-str)) (err "Argument 'path' must be a string")]
+       [(not (string? path-str)) (make-error-result "Argument 'path' must be a string")]
 
        ;; 2. Path must exist
        [(not (or (directory-exists? path-str) (file-exists? path-str)))
-        (err (format "Path not found: ~a" path-str))]
+        (make-error-result (format "Path not found: ~a" path-str))]
 
        ;; 3. Path must be a directory
-       [(not (directory-exists? path-str)) (err (format "Path is not a directory: ~a" path-str))]
+       [(not (directory-exists? path-str))
+        (make-error-result (format "Path is not a directory: ~a" path-str))]
 
        [else
         ;; 4. Parse optional arguments
@@ -132,7 +94,7 @@
         ;; Compile glob pattern if provided
         (define name-re
           (if name-pattern
-              (glob->regexp name-pattern)
+              (glob->regexp name-pattern #:allow-slash? #t)
               #f))
 
         ;; Check if root path itself is under a hidden directory
@@ -145,5 +107,6 @@
 
         (define truncated? (> total-found max-results))
 
-        (ok results
-            (hasheq 'total-found total-found 'truncated? truncated? 'search-root path-str))])]))
+        (make-success-result
+         results
+         (hasheq 'total-found total-found 'truncated? truncated? 'search-root path-str))])]))

--- a/tools/builtins/grep.rkt
+++ b/tools/builtins/grep.rkt
@@ -5,7 +5,10 @@
          racket/file
          racket/list
          racket/path
-         (only-in "../tool.rkt" make-success-result make-error-result))
+         (only-in "../tool.rkt" make-success-result make-error-result)
+         (only-in "../../util/glob.rkt" glob->regexp)
+         (only-in "../../util/path-helpers.rkt" contains-null-bytes? bytes->display-lines)
+         (only-in "../../util/path-filters.rkt" hidden-name? should-skip-entry? skip-dirs))
 
 (provide tool-grep)
 
@@ -18,48 +21,22 @@
 (define DEFAULT-MAX-RESULTS 50)
 (define DEFAULT-CONTEXT-LINES 2)
 
-;; VCS / skip directory names
-(define SKIP-DIRS '(".git" ".hg" ".svn" "node_modules"))
-
 ;; ============================================================
 ;; Internal helpers
 ;; ============================================================
-
-;; Check if a byte string contains null bytes (binary indicator)
-(define (contains-null-bytes? bs)
-  (for/or ([b (in-bytes bs)])
-    (= b 0)))
-
-;; Check if a path component is hidden (starts with .)
-(define (hidden-element? path-str)
-  (define elem
-    (if (path? path-str)
-        (path->string (file-name-from-path path-str))
-        path-str))
-  (and elem (> (string-length elem) 0) (char=? (string-ref elem 0) #\.)))
 
 ;; Check if any component of the path is hidden or a VCS dir
 (define (should-skip-path? p)
   (define parts (explode-path p))
   (for/or ([part (in-list parts)])
     (define s (path->string part))
-    (or (hidden-element? s) (member s SKIP-DIRS))))
+    (or (hidden-name? s) (member s skip-dirs))))
 
 ;; Compile the regex pattern
 (define (compile-pattern pattern case-insensitive?)
   (if case-insensitive?
       (regexp (string-append "(?i:" pattern ")"))
       (regexp pattern)))
-
-;; ============================================================
-;; Result helpers - return tool-result structs
-;; ============================================================
-
-(define (ok content details)
-  (make-success-result content details))
-
-(define (err msg)
-  (make-error-result msg))
 
 ;; ============================================================
 ;; Core search in a single file
@@ -123,17 +100,7 @@
 ;; Collect files to search
 ;; ============================================================
 
-;; Simple glob pattern → regexp converter
-;; Supports * (any chars) and ? (single char)
-(define (simple-glob->regexp glob-str)
-  (define escaped
-    (for/list ([ch (in-string glob-str)])
-      (cond
-        [(char=? ch #\*) "[^/]*"]
-        [(char=? ch #\?) "[^/]"]
-        [(regexp-match? #rx"[.+^${}()|\\[\\]\\\\]" (string ch)) (string-append "\\" (string ch))]
-        [else (string ch)])))
-  (regexp (string-append "^" (string-join escaped "") "$")))
+;; Glob conversion now lives in util/glob.rkt (glob->regexp)
 
 ;; Recursively collect files under dir matching glob-pattern,
 ;; skipping hidden and VCS dirs.
@@ -146,7 +113,7 @@
                  #:when (file-exists? p))
         p)))
   ;; Filter by glob and skip hidden/VCS
-  (define rx (simple-glob->regexp glob-pattern))
+  (define rx (glob->regexp glob-pattern #:allow-slash? #f))
   (for/list ([p (in-list all-paths)]
              #:when (let ([fname (path->string (file-name-from-path p))]) (regexp-match? rx fname))
              #:unless (should-skip-path? p))
@@ -162,8 +129,8 @@
   (define path-str (hash-ref args 'path #f))
 
   (cond
-    [(not pattern) (err "Missing required argument: pattern")]
-    [(not path-str) (err "Missing required argument: path")]
+    [(not pattern) (make-error-result "Missing required argument: pattern")]
+    [(not path-str) (make-error-result "Missing required argument: path")]
     [else
      (define glob-pattern (hash-ref args 'glob DEFAULT-GLOB))
      (define case-insensitive? (hash-ref args 'case-insensitive? DEFAULT-CASE-INSENSITIVE))
@@ -178,14 +145,14 @@
 
      (cond
        [(not (or (file-exists? the-path) (directory-exists? the-path)))
-        (err (format "Path not found: ~a" path-str))]
+        (make-error-result (format "Path not found: ~a" path-str))]
        [(file-exists? the-path)
         ;; Single file search
         (search-single-file the-path path-str pattern-rx context-lines max-results 1)]
        [(directory-exists? the-path)
         ;; Directory search
         (search-directory the-path path-str pattern-rx glob-pattern context-lines max-results)]
-       [else (err (format "Path not found: ~a" path-str))])]))
+       [else (make-error-result (format "Path not found: ~a" path-str))])]))
 
 ;; ============================================================
 ;; Single file search
@@ -198,12 +165,12 @@
   (cond
     [(not raw-bytes)
      ;; Unreadable file → treat as empty success
-     (ok
+     (make-success-result
       '()
       (hasheq 'total-matches 0 'files-searched files-searched 'files-with-matches 0 'truncated? #f))]
     [(contains-null-bytes? raw-bytes)
      ;; Binary → skip silently, return empty success
-     (ok
+     (make-success-result
       '()
       (hasheq 'total-matches 0 'files-searched files-searched 'files-with-matches 0 'truncated? #f))]
     [else
@@ -237,15 +204,15 @@
      ;; Deduplicate and sort content lines (context may overlap)
      (define unique-lines (remove-duplicates content-lines string=?))
 
-     (ok unique-lines
-         (hasheq 'total-matches
-                 total-matches
-                 'files-searched
-                 files-searched
-                 'files-with-matches
-                 files-with-matches
-                 'truncated?
-                 truncated?))]))
+     (make-success-result unique-lines
+                          (hasheq 'total-matches
+                                  total-matches
+                                  'files-searched
+                                  files-searched
+                                  'files-with-matches
+                                  files-with-matches
+                                  'truncated?
+                                  truncated?))]))
 
 ;; ============================================================
 ;; Directory search
@@ -319,12 +286,12 @@
 
   (define files-with-matches (length (remove-duplicates (map first all-results) string=?)))
 
-  (ok unique-lines
-      (hasheq 'total-matches
-              total-matches
-              'files-searched
-              (length files)
-              'files-with-matches
-              files-with-matches
-              'truncated?
-              truncated?)))
+  (make-success-result unique-lines
+                       (hasheq 'total-matches
+                               total-matches
+                               'files-searched
+                               (length files)
+                               'files-with-matches
+                               files-with-matches
+                               'truncated?
+                               truncated?)))

--- a/tools/builtins/ls.rkt
+++ b/tools/builtins/ls.rkt
@@ -3,26 +3,14 @@
 (require racket/file
          racket/format
          racket/list
-         (only-in "../tool.rkt" make-success-result make-error-result))
+         (only-in "../tool.rkt" make-success-result make-error-result)
+         (only-in "../../util/path-filters.rkt" hidden-name?))
 
 (provide tool-ls)
 
 ;; --------------------------------------------------
-;; Result helpers (local) - return tool-result structs
-;; --------------------------------------------------
-
-(define (ok content details)
-  (make-success-result content details))
-
-(define (err msg)
-  (make-error-result msg))
-
-;; --------------------------------------------------
 ;; Entry classification
 ;; --------------------------------------------------
-
-(define (hidden? name)
-  (and (> (string-length name) 0) (char=? (string-ref name 0) #\.)))
 
 (define (entry-type base-path name)
   (define full (build-path base-path name))
@@ -87,13 +75,13 @@
   ;; (safe-mode path check is done by scheduler, not here)
   (define path-str (hash-ref args 'path #f))
   (cond
-    [(not path-str) (err "Missing required argument: path")]
+    [(not path-str) (make-error-result "Missing required argument: path")]
 
     ;; 2. Path must exist
     [(not (directory-exists? path-str))
      (cond
-       [(file-exists? path-str) (err (format "Not a directory: ~a" path-str))]
-       [else (err (format "Path not found: ~a" path-str))])]
+       [(file-exists? path-str) (make-error-result (format "Not a directory: ~a" path-str))]
+       [else (make-error-result (format "Path not found: ~a" path-str))])]
 
     [else
      ;; 3. Read directory entries
@@ -105,7 +93,7 @@
      (define filtered
        (if show-hidden?
            (map path->string raw-names)
-           (filter (λ (n) (not (hidden? n))) (map path->string raw-names))))
+           (filter (λ (n) (not (hidden-name? n))) (map path->string raw-names))))
 
      ;; 4. Build entry structs
      (define entries
@@ -128,12 +116,12 @@
      (define dir-count (count (λ (e) (memq (entry-type-e e) '(dir link))) sorted))
      (define file-count (count (λ (e) (eq? (entry-type-e e) 'file)) sorted))
 
-     (ok content-lines
-         (hasheq 'total-entries
-                 (length sorted)
-                 'path
-                 path-str
-                 'directories
-                 dir-count
-                 'files
-                 file-count))]))
+     (make-success-result content-lines
+                          (hasheq 'total-entries
+                                  (length sorted)
+                                  'path
+                                  path-str
+                                  'directories
+                                  dir-count
+                                  'files
+                                  file-count))]))

--- a/tools/builtins/read.rkt
+++ b/tools/builtins/read.rkt
@@ -5,7 +5,8 @@
          racket/file
          racket/list
          racket/dict
-         (only-in "../tool.rkt" make-success-result make-error-result))
+         (only-in "../tool.rkt" make-success-result make-error-result)
+         (only-in "../../util/path-helpers.rkt" contains-null-bytes? bytes->display-lines))
 
 (provide tool-read)
 
@@ -15,24 +16,9 @@
 ;; Maximum total bytes for output content
 (define DEFAULT-MAX-BYTES 50000)
 
-;; Check if a byte string contains null bytes (binary indicator)
-(define (contains-null-bytes? bs)
-  (for/or ([b (in-bytes bs)])
-    (= b 0)))
-
 ;; Format a single numbered line
 (define (format-line n text)
   (format "~a| ~a" n text))
-
-;; --------------------------------------------------
-;; Result helpers (local) - return tool-result structs
-;; --------------------------------------------------
-
-(define (ok content details)
-  (make-success-result content details))
-
-(define (err msg)
-  (make-error-result msg))
 
 ;; --------------------------------------------------
 ;; Main tool function
@@ -41,7 +27,7 @@
 (define (tool-read args [exec-ctx #f])
   (define path-str (hash-ref args 'path #f))
   (cond
-    [(not path-str) (err "Missing required argument: path")]
+    [(not path-str) (make-error-result "Missing required argument: path")]
     [else
      (define offset (hash-ref args 'offset 1))
      (define limit (hash-ref args 'limit #f))
@@ -49,34 +35,25 @@
      ;; 1. File existence check
      ;; (safe-mode path check is done by scheduler, not here)
      (cond
-       [(not (file-exists? path-str)) (err (format "File not found: ~a" path-str))]
+       [(not (file-exists? path-str)) (make-error-result (format "File not found: ~a" path-str))]
 
        [else
         ;; 2. Read bytes and check for binary
         (define raw-bytes (file->bytes path-str))
 
         (cond
-          [(contains-null-bytes? raw-bytes) (err (format "File appears to be binary: ~a" path-str))]
+          [(contains-null-bytes? raw-bytes)
+           (make-error-result (format "File appears to be binary: ~a" path-str))]
 
           [else
            ;; 3. Convert to text, split into lines
-           (define text (bytes->string/utf-8 raw-bytes #\?))
-           (define all-lines (string-split text "\n" #:trim? #f))
-
-           ;; Trim trailing empty element from trailing newline
-           (define has-trailing-newline
-             (and (> (string-length text) 0)
-                  (char=? (string-ref text (sub1 (string-length text))) #\newline)))
-           (define display-lines
-             (if has-trailing-newline
-                 (drop-right all-lines 1)
-                 all-lines))
-           (define total-lines (length display-lines))
+           (define-values (display-lines total-lines) (bytes->display-lines raw-bytes))
 
            ;; 4. Empty file
            (cond
              [(zero? total-lines)
-              (ok '() (hasheq 'total-lines 0 'start-line 0 'end-line 0 'path path-str))]
+              (make-success-result '()
+                                   (hasheq 'total-lines 0 'start-line 0 'end-line 0 'path path-str))]
 
              [else
               ;; 5. Apply offset/limit
@@ -90,7 +67,9 @@
 
               (cond
                 [(null? sliced)
-                 (ok '() (hasheq 'total-lines total-lines 'start-line 0 'end-line 0 'path path-str))]
+                 (make-success-result
+                  '()
+                  (hasheq 'total-lines total-lines 'start-line 0 'end-line 0 'path path-str))]
 
                 [else
                  (define formatted
@@ -106,12 +85,12 @@
                                       " bytes]")
                        joined))
 
-                 (ok (list (string-append result-text "\n"))
-                     (hasheq 'total-lines
-                             total-lines
-                             'start-line
-                             (car (first sliced))
-                             'end-line
-                             (car (last sliced))
-                             'path
-                             path-str))])])])])]))
+                 (make-success-result (list (string-append result-text "\n"))
+                                      (hasheq 'total-lines
+                                              total-lines
+                                              'start-line
+                                              (car (first sliced))
+                                              'end-line
+                                              (car (last sliced))
+                                              'path
+                                              path-str))])])])])]))

--- a/util/glob.rkt
+++ b/util/glob.rkt
@@ -1,0 +1,20 @@
+#lang racket/base
+
+;; util/glob.rkt — Shared glob-to-regexp conversion
+
+(require racket/string)
+
+(provide glob->regexp)
+
+;; Convert a glob pattern to a regexp.
+;; #:allow-slash? #t means * matches / (for path-based tools like find)
+;; #:allow-slash? #f means * does NOT match / (for file-pattern tools like grep)
+(define (glob->regexp pattern #:allow-slash? [allow-slash? #f])
+  (define escaped
+    (for/list ([ch (in-string pattern)])
+      (case ch
+        [(#\*) (if allow-slash? ".*" "[^/]*")]
+        [(#\?) "."]
+        [(#\. #\+ #\( #\) #\[ #\] #\{ #\} #\\ #\^ #\$ #\|) (string #\\ ch)]
+        [else (string ch)])))
+  (regexp (string-append "^" (string-join escaped "") "$")))

--- a/util/path-filters.rkt
+++ b/util/path-filters.rkt
@@ -1,0 +1,37 @@
+#lang racket/base
+
+;; util/path-filters.rkt — Shared path filtering predicates
+;;
+;; Canonical implementations of hidden-file, VCS-directory,
+;; and skip-directory checks. Replaces duplicated definitions
+;; across find, grep, and ls builtins.
+
+(provide hidden-name?
+         vcs-dir?
+         skip-dirs
+         should-skip-entry?
+         path-component-hidden?)
+
+;; Directories to skip during traversal (VCS + common noise)
+(define skip-dirs '(".git" ".hg" ".svn" "node_modules"))
+
+;; Is the name a VCS or noise directory?
+(define (vcs-dir? name)
+  (member name skip-dirs))
+
+;; Does the name start with a dot?
+(define (hidden-name? name)
+  (and (string? name)
+       (> (string-length name) 0)
+       (char=? (string-ref name 0) #\.)))
+
+;; Should this directory entry be skipped?
+;; Skips VCS/noise dirs and hidden files (unless showing hidden).
+(define (should-skip-entry? name #:show-hidden? [show-hidden? #f])
+  (or (vcs-dir? name)
+      (and (hidden-name? name) (not show-hidden?))))
+
+;; Does any component of the absolute path start with a dot?
+(define (path-component-hidden? abs-path)
+  (for/or ([s (in-list (cdr (explode-path abs-path)))])
+    (hidden-name? (path->string s))))

--- a/util/path-helpers.rkt
+++ b/util/path-helpers.rkt
@@ -5,11 +5,37 @@
 ;; Extracted from tools/builtins/write.rkt and extensions/loader.rkt
 ;; to eliminate duplication (QUAL-02).
 
+(require racket/list
+         racket/string)
+
 (provide ;; Path utility
- path-only)
+ path-only
+ ;; Byte helpers
+ contains-null-bytes?
+ bytes->display-lines)
 
 ;; Extract directory portion of a path string.
 ;; Returns #f when the path has no directory component (i.e. is relative/simple).
+;; Check if a byte string contains null bytes (binary indicator)
+(define (contains-null-bytes? bs)
+  (for/or ([b (in-bytes bs)])
+    (= b 0)))
+
+;; Convert raw bytes to display lines: decode as UTF-8, split on newlines,
+;; trim trailing empty line from trailing newline.
+;; Returns (values display-lines total-count).
+(define (bytes->display-lines raw-bytes)
+  (define text (bytes->string/utf-8 raw-bytes #\?))
+  (define all-lines (string-split text "\n" #:trim? #f))
+  (define has-trailing-newline
+    (and (> (string-length text) 0)
+         (char=? (string-ref text (sub1 (string-length text))) #\newline)))
+  (define display-lines
+    (if has-trailing-newline
+        (drop-right all-lines 1)
+        all-lines))
+  (values display-lines (length display-lines)))
+
 (define (path-only p)
   (define-values (dir _base _must-be-dir?) (split-path p))
   (if (eq? dir 'relative) #f dir))


### PR DESCRIPTION
## Issues: #289 #290 #291 #292 #293 #294

### QUAL-05 (#290): Remove local ok/err wrappers
- 6 builtins now call `make-success-result`/`make-error-result` directly
- 11 wrapper definitions removed, 29 call sites updated

### QUAL-06 (#291): Extract `contains-null-bytes?` to `util/path-helpers.rkt`
- Shared between read.rkt and grep.rkt

### QUAL-07 (#292): Extract text->display-lines pattern
- `bytes->display-lines` helper replaces 5 inline occurrences
- ~30 lines of duplication eliminated

### QUAL-08 (#293): Extract `glob->regexp` to `util/glob.rkt`
- `#:allow-slash?` parameter for find (#t) vs grep (#f) semantics

### QUAL-09 (#294): Extract path filters to `util/path-filters.rkt`
- `hidden-name?`, `vcs-dir?`, `skip-dirs`, `should-skip-entry?`, `path-component-hidden?`
- find.rkt, grep.rkt, ls.rkt unified

### Verification
- [x] test-file-tools: 21 pass
- [x] test-grep: 15 pass
- [x] test-find: 16 pass
- [x] test-ls: 14 pass
- [x] lint-format passes
- [x] Net -45 lines of code

Closes #289 Closes #290 Closes #291 Closes #292 Closes #293 Closes #294