### PR TITLE
refactor(llm): extract HTTP helpers, model-setting helper, unify content helpers

### DIFF
--- a/llm/anthropic.rkt
+++ b/llm/anthropic.rkt
@@ -18,10 +18,11 @@
          net/http-client
          "model.rkt"
          "provider.rkt"
-         "stream.rkt")
+         "stream.rkt"
+         "http-helpers.rkt")
 
-(provide ;; Provider constructor
- make-anthropic-provider
+;; Provider constructor
+(provide make-anthropic-provider
          ;; Request/response helpers (exported for testing)
          anthropic-build-request-body
          anthropic-parse-response
@@ -78,22 +79,22 @@
         ;; Assistant with list content (tool calls)
         [(and (equal? role "assistant") (list? content))
          (hasheq 'role
-               "assistant"
-               'content
-               (for/list ([block (in-list content)])
-                 (define btype (hash-ref block 'type "text"))
-                 (cond
-                   [(equal? btype "text") (hasheq 'type "text" 'text (hash-ref block 'text ""))]
-                   [(equal? btype "tool-call")
-                    (hasheq 'type
-                          "tool_use"
-                          'id
-                          (hash-ref block 'id "")
-                          'name
-                          (hash-ref block 'name "")
-                          'input
-                          (hash-ref block 'arguments (hasheq)))]
-                   [else block])))]
+                 "assistant"
+                 'content
+                 (for/list ([block (in-list content)])
+                   (define btype (hash-ref block 'type "text"))
+                   (cond
+                     [(equal? btype "text") (hasheq 'type "text" 'text (hash-ref block 'text ""))]
+                     [(equal? btype "tool-call")
+                      (hasheq 'type
+                              "tool_use"
+                              'id
+                              (hash-ref block 'id "")
+                              'name
+                              (hash-ref block 'name "")
+                              'input
+                              (hash-ref block 'arguments (hasheq)))]
+                     [else block])))]
         ;; Simple string content: wrap in text block
         [(string? content) (hasheq 'role role 'content (list (hasheq 'type "text" 'text content)))]
         ;; Fallback: pass through
@@ -151,11 +152,11 @@
   ;; Translate usage: input_tokens → prompt_tokens, output_tokens → completion_tokens
   (define usage
     (hasheq 'prompt_tokens
-          (hash-ref usage-raw 'input_tokens 0)
-          'completion_tokens
-          (hash-ref usage-raw 'output_tokens 0)
-          'total_tokens
-          (+ (hash-ref usage-raw 'input_tokens 0) (hash-ref usage-raw 'output_tokens 0))))
+            (hash-ref usage-raw 'input_tokens 0)
+            'completion_tokens
+            (hash-ref usage-raw 'output_tokens 0)
+            'total_tokens
+            (+ (hash-ref usage-raw 'input_tokens 0) (hash-ref usage-raw 'output_tokens 0))))
 
   ;; Translate content blocks
   (define content
@@ -165,13 +166,13 @@
         [(equal? type "text") (hasheq 'type "text" 'text (hash-ref block 'text ""))]
         [(equal? type "tool_use")
          (hasheq 'type
-               "tool-call"
-               'id
-               (hash-ref block 'id "")
-               'name
-               (hash-ref block 'name "")
-               'arguments
-               (hash-ref block 'input (hasheq)))]
+                 "tool-call"
+                 'id
+                 (hash-ref block 'id "")
+                 'name
+                 (hash-ref block 'name "")
+                 'arguments
+                 (hash-ref block 'input (hasheq)))]
         [else block])))
 
   (make-model-response content usage model-name stop-reason))
@@ -236,17 +237,18 @@
        [(equal? delta-type "input_json_delta")
         ;; Partial JSON for tool input — emit as tool-call delta
         (define partial-json (hash-ref delta 'partial_json ""))
-        (set! results
-              (cons (stream-chunk #f
-                                  (hasheq 'index
-                                        (unbox tool-index-box)
-                                        'id
-                                        (unbox tool-id-box)
-                                        'function
-                                        (hasheq 'name (unbox tool-name-box) 'arguments partial-json))
-                                  #f
-                                  #f)
-                    results))]
+        (set!
+         results
+         (cons (stream-chunk #f
+                             (hasheq 'index
+                                     (unbox tool-index-box)
+                                     'id
+                                     (unbox tool-id-box)
+                                     'function
+                                     (hasheq 'name (unbox tool-name-box) 'arguments partial-json))
+                             #f
+                             #f)
+               results))]
        [else (void)])]
 
     ;; Tool use block starts
@@ -284,27 +286,17 @@
 ;; ============================================================
 
 (define (anthropic-check-http-status! status-line response-body)
-  (define status-str
-    (if (bytes? status-line)
-        (bytes->string/utf-8 status-line)
-        status-line))
-  (define status-code
-    (let ([parts (regexp-match #rx"^HTTP/[^ ]+ ([0-9]+)" status-str)])
-      (if parts
-          (string->number (cadr parts))
-          0)))
-  (when (>= status-code 400)
+  (define status-code (extract-status-code status-line))
+  (when (http-error? status-code)
     (define error-body
       (if (bytes? response-body)
           (bytes->string/utf-8 response-body)
           response-body))
     (cond
       [(= status-code 401)
-       (raise (exn:fail (format "Anthropic API authentication failed (401): ~a" error-body)
-                        (current-continuation-marks)))]
+       (raise-http-error! (format "Anthropic API authentication failed (401): ~a" error-body))]
       [(= status-code 403)
-       (raise (exn:fail (format "Anthropic API forbidden (403): ~a" error-body)
-                        (current-continuation-marks)))]
+       (raise-http-error! (format "Anthropic API forbidden (403): ~a" error-body))]
       [(= status-code 429)
        (define retry-hint
          (with-handlers ([exn:fail? (lambda (_) "")])
@@ -313,14 +305,10 @@
            (if retry-ms
                (format " Retry after ~a seconds." (quotient retry-ms 1000))
                " Please wait and try again.")))
-       (raise (exn:fail (format "Anthropic API rate limited (429):~a\n~a" retry-hint error-body)
-                        (current-continuation-marks)))]
+       (raise-http-error! (format "Anthropic API rate limited (429):~a\n~a" retry-hint error-body))]
       [(>= status-code 500)
-       (raise (exn:fail (format "Anthropic API server error (~a): ~a" status-code error-body)
-                        (current-continuation-marks)))]
-      [else
-       (raise (exn:fail (format "Anthropic API error (~a): ~a" status-code error-body)
-                        (current-continuation-marks)))])))
+       (raise-http-error! (format "Anthropic API server error (~a): ~a" status-code error-body))]
+      [else (raise-http-error! (format "Anthropic API error (~a): ~a" status-code error-body))])))
 
 ;; ============================================================
 ;; HTTP request execution (non-streaming)
@@ -335,14 +323,13 @@
           "Content-Type: application/json"))
   (define body-bytes (jsexpr->bytes body))
   ;; Wrap entire request in overall timeout (SEC-11)
-  (call-with-request-timeout
-   (lambda ()
-     (define-values (status-line response-headers response-port)
-       (http-sendrecv uri 'POST #:headers headers #:data body-bytes))
-     (define response-body (read-response-body response-port))
-     ;; Check HTTP status
-     (anthropic-check-http-status! status-line response-body)
-     (bytes->jsexpr response-body))))
+  (call-with-request-timeout (lambda ()
+                               (define-values (status-line response-headers response-port)
+                                 (http-sendrecv uri 'POST #:headers headers #:data body-bytes))
+                               (define response-body (read-response-body response-port))
+                               ;; Check HTTP status
+                               (anthropic-check-http-status! status-line response-body)
+                               (bytes->jsexpr response-body))))
 
 ;; ============================================================
 ;; Provider constructor
@@ -355,23 +342,13 @@
   (define default-model (hash-ref config 'model ANTHROPIC-DEFAULT-MODEL))
 
   (define (send req)
-    (define merged-req
-      (if (hash-has-key? (model-request-settings req) 'model)
-          req
-          (make-model-request (model-request-messages req)
-                              (model-request-tools req)
-                              (hash-set (model-request-settings req) 'model default-model))))
+    (define merged-req (ensure-model-setting req default-model))
     (define body (anthropic-build-request-body merged-req))
     (define raw (anthropic-do-http-request base-url api-key "/v1/messages" body))
     (anthropic-parse-response raw))
 
   (define (stream req)
-    (define merged-req
-      (if (hash-has-key? (model-request-settings req) 'model)
-          req
-          (make-model-request (model-request-messages req)
-                              (model-request-tools req)
-                              (hash-set (model-request-settings req) 'model default-model))))
+    (define merged-req (ensure-model-setting req default-model))
     (define body (anthropic-build-request-body merged-req #:stream? #t))
     (define url-str (string-append (string-trim base-url "/") "/v1/messages"))
     (define uri (string->url url-str))
@@ -382,11 +359,10 @@
     (define body-bytes (jsexpr->bytes body))
     ;; Wrap initial HTTP request in overall timeout (SEC-11)
     (define result-vec
-      (call-with-request-timeout
-       (lambda ()
-         (define-values (sl rh rp)
-           (http-sendrecv uri 'POST #:headers headers #:data body-bytes))
-         (vector sl rh rp))))
+      (call-with-request-timeout (lambda ()
+                                   (define-values (sl rh rp)
+                                     (http-sendrecv uri 'POST #:headers headers #:data body-bytes))
+                                   (vector sl rh rp))))
     (define status-line (vector-ref result-vec 0))
     (define response-headers (vector-ref result-vec 1))
     (define response-port (vector-ref result-vec 2))

--- a/llm/gemini.rkt
+++ b/llm/gemini.rkt
@@ -20,10 +20,11 @@
          net/http-client
          "model.rkt"
          "provider.rkt"
-         "stream.rkt")
+         "stream.rkt"
+         "http-helpers.rkt")
 
-(provide ;; Provider constructor
- make-gemini-provider
+;; Provider constructor
+(provide make-gemini-provider
          ;; Request/response helpers (exported for testing)
          gemini-build-request-body
          gemini-parse-response
@@ -112,7 +113,7 @@
                  (if (string? content) content "")))
            (define tool-name (hash-ref call-id->name tool-call-id ""))
            (list (hasheq 'functionResponse
-                       (hasheq 'name tool-name 'response (hasheq 'content tool-result-content))))]
+                         (hasheq 'name tool-name 'response (hasheq 'content tool-result-content))))]
           ;; Assistant with list content (tool calls + text)
           [(and (equal? role "assistant") (list? content))
            (for/list ([block (in-list content)])
@@ -154,8 +155,8 @@
         (hash-set with-system
                   'tools
                   (list (hasheq 'functionDeclarations
-                              (for/list ([tool (in-list (model-request-tools req))])
-                                (gemini-translate-tool tool)))))
+                                (for/list ([tool (in-list (model-request-tools req))])
+                                  (gemini-translate-tool tool)))))
         with-system))
 
   with-tools)
@@ -207,11 +208,11 @@
   (define total-tokens (hash-ref usage-raw 'totalTokenCount (+ prompt-tokens candidates-tokens)))
   (define usage
     (hasheq 'prompt_tokens
-          prompt-tokens
-          'completion_tokens
-          candidates-tokens
-          'total_tokens
-          total-tokens))
+            prompt-tokens
+            'completion_tokens
+            candidates-tokens
+            'total_tokens
+            total-tokens))
 
   ;; Translate content parts
   (define content
@@ -222,13 +223,13 @@
          (let* ([fc (hash-ref part 'functionCall)]
                 [tool-id (gemini-gen-tool-id)])
            (hasheq 'type
-                 "tool-call"
-                 'id
-                 tool-id
-                 'name
-                 (hash-ref fc 'name "")
-                 'arguments
-                 (hash-ref fc 'args (hasheq))))]
+                   "tool-call"
+                   'id
+                   tool-id
+                   'name
+                   (hash-ref fc 'name "")
+                   'arguments
+                   (hash-ref fc 'args (hasheq))))]
         [else part])))
 
   ;; Check for safety/recitation filtering — add warning when content is empty
@@ -310,12 +311,13 @@
       [(hash-has-key? part 'functionCall)
        (let* ([fc (hash-ref part 'functionCall)]
               [tc-delta
-               (hasheq 'index
-                     0
-                     'id
-                     (gemini-gen-tool-id)
-                     'function
-                     (hasheq 'name (hash-ref fc 'name "") 'arguments (hash-ref fc 'args (hasheq))))])
+               (hasheq
+                'index
+                0
+                'id
+                (gemini-gen-tool-id)
+                'function
+                (hasheq 'name (hash-ref fc 'name "") 'arguments (hash-ref fc 'args (hasheq))))])
          (set! results (cons (stream-chunk #f tc-delta #f #f) results)))]
       [else (void)]))
 
@@ -324,18 +326,19 @@
     [(and finish-reason (not (eq? finish-reason 'null)) (not (null? finish-reason)))
      (let* ([usage (if usage-raw
                        (hasheq 'prompt_tokens
-                             (hash-ref usage-raw 'promptTokenCount 0)
-                             'completion_tokens
-                             (hash-ref usage-raw 'candidatesTokenCount 0)
-                             'total_tokens
-                             (hash-ref usage-raw 'totalTokenCount 0))
+                               (hash-ref usage-raw 'promptTokenCount 0)
+                               'completion_tokens
+                               (hash-ref usage-raw 'candidatesTokenCount 0)
+                               'total_tokens
+                               (hash-ref usage-raw 'totalTokenCount 0))
                        (hasheq))])
        (set! results (cons (stream-chunk #f #f usage #t) results)))]
     [(and usage-raw (not finish-reason))
      ;; Usage-only event without finish — emit usage chunk
      (let* ([prompt-tokens (hash-ref usage-raw 'promptTokenCount 0)])
        (when (> prompt-tokens 0)
-         (set! results (cons (stream-chunk #f #f (hasheq 'prompt_tokens prompt-tokens) #f) results))))])
+         (set! results
+               (cons (stream-chunk #f #f (hasheq 'prompt_tokens prompt-tokens) #f) results))))])
 
   (reverse results))
 
@@ -344,40 +347,23 @@
 ;; ============================================================
 
 (define (gemini-check-http-status! status-line response-body)
-  (define status-str
-    (if (bytes? status-line)
-        (bytes->string/utf-8 status-line)
-        status-line))
-  (define status-code
-    (let ([parts (regexp-match #rx"^HTTP/[^ ]+ ([0-9]+)" status-str)])
-      (if parts
-          (string->number (cadr parts))
-          0)))
-  (when (>= status-code 400)
+  (define status-code (extract-status-code status-line))
+  (when (http-error? status-code)
     (define error-body
       (if (bytes? response-body)
           (bytes->string/utf-8 response-body)
           response-body))
     (cond
-      [(= status-code 400)
-       (raise (exn:fail (format "Gemini API bad request (400): ~a" error-body)
-                        (current-continuation-marks)))]
+      [(= status-code 400) (raise-http-error! (format "Gemini API bad request (400): ~a" error-body))]
       [(= status-code 401)
-       (raise (exn:fail (format "Gemini API authentication failed (401): ~a" error-body)
-                        (current-continuation-marks)))]
-      [(= status-code 403)
-       (raise (exn:fail (format "Gemini API forbidden (403): ~a" error-body)
-                        (current-continuation-marks)))]
+       (raise-http-error! (format "Gemini API authentication failed (401): ~a" error-body))]
+      [(= status-code 403) (raise-http-error! (format "Gemini API forbidden (403): ~a" error-body))]
       [(= status-code 429)
-       (raise (exn:fail (format "Gemini API rate limited (429). Please wait and try again.\n~a"
-                                error-body)
-                        (current-continuation-marks)))]
+       (raise-http-error! (format "Gemini API rate limited (429). Please wait and try again.\n~a"
+                                  error-body))]
       [(>= status-code 500)
-       (raise (exn:fail (format "Gemini API server error (~a): ~a" status-code error-body)
-                        (current-continuation-marks)))]
-      [else
-       (raise (exn:fail (format "Gemini API error (~a): ~a" status-code error-body)
-                        (current-continuation-marks)))])))
+       (raise-http-error! (format "Gemini API server error (~a): ~a" status-code error-body))]
+      [else (raise-http-error! (format "Gemini API error (~a): ~a" status-code error-body))])))
 
 ;; ============================================================
 ;; HTTP request execution (non-streaming)
@@ -390,14 +376,13 @@
   (define headers (list "Content-Type: application/json" (format "x-goog-api-key: ~a" api-key)))
   (define body-bytes (jsexpr->bytes body))
   ;; Wrap entire request in overall timeout (SEC-11)
-  (call-with-request-timeout
-   (lambda ()
-     (define-values (status-line response-headers response-port)
-       (http-sendrecv uri 'POST #:headers headers #:data body-bytes))
-     (define response-body (read-response-body response-port))
-     ;; Check HTTP status
-     (gemini-check-http-status! status-line response-body)
-     (bytes->jsexpr response-body))))
+  (call-with-request-timeout (lambda ()
+                               (define-values (status-line response-headers response-port)
+                                 (http-sendrecv uri 'POST #:headers headers #:data body-bytes))
+                               (define response-body (read-response-body response-port))
+                               ;; Check HTTP status
+                               (gemini-check-http-status! status-line response-body)
+                               (bytes->jsexpr response-body))))
 
 ;; ============================================================
 ;; Provider constructor
@@ -410,12 +395,7 @@
   (define default-model (hash-ref config 'model GEMINI-DEFAULT-MODEL))
 
   (define (send req)
-    (define merged-req
-      (if (hash-has-key? (model-request-settings req) 'model)
-          req
-          (make-model-request (model-request-messages req)
-                              (model-request-tools req)
-                              (hash-set (model-request-settings req) 'model default-model))))
+    (define merged-req (ensure-model-setting req default-model))
     (define body (gemini-build-request-body merged-req))
     (define model-name (hash-ref (model-request-settings merged-req) 'model default-model))
     ;; Bind per-request counter (Issue #200)
@@ -424,12 +404,7 @@
       (gemini-parse-response raw)))
 
   (define (stream req)
-    (define merged-req
-      (if (hash-has-key? (model-request-settings req) 'model)
-          req
-          (make-model-request (model-request-messages req)
-                              (model-request-tools req)
-                              (hash-set (model-request-settings req) 'model default-model))))
+    (define merged-req (ensure-model-setting req default-model))
     (define body (gemini-build-request-body merged-req #:stream? #t))
     (define model-name (hash-ref (model-request-settings merged-req) 'model default-model))
     (define url-str
@@ -443,11 +418,10 @@
     (define body-bytes (jsexpr->bytes body))
     ;; Wrap initial HTTP request in overall timeout (SEC-11)
     (define result-vec
-      (call-with-request-timeout
-       (lambda ()
-         (define-values (sl rh rp)
-           (http-sendrecv uri 'POST #:headers headers #:data body-bytes))
-         (vector sl rh rp))))
+      (call-with-request-timeout (lambda ()
+                                   (define-values (sl rh rp)
+                                     (http-sendrecv uri 'POST #:headers headers #:data body-bytes))
+                                   (vector sl rh rp))))
     (define status-line (vector-ref result-vec 0))
     (define response-headers (vector-ref result-vec 1))
     (define response-port (vector-ref result-vec 2))

--- a/llm/http-helpers.rkt
+++ b/llm/http-helpers.rkt
@@ -1,0 +1,44 @@
+#lang racket/base
+
+;; llm/http-helpers.rkt — Shared HTTP error handling utilities
+;;
+;; Common helpers for parsing HTTP status lines and raising errors.
+;; Used by anthropic.rkt, gemini.rkt, and openai-compatible.rkt.
+
+(require racket/contract)
+
+(provide extract-status-code
+         http-error?
+         raise-http-error!)
+
+;; ============================================================
+;; Contracts
+;; ============================================================
+
+(define status-line/c (or/c bytes? string?))
+
+(define response-body/c (or/c bytes? string?))
+
+;; ============================================================
+;; Helpers
+;; ============================================================
+
+;; Parse "HTTP/N.N NNN ..." → integer status code.
+;; Returns 0 if the pattern cannot be matched.
+(define (extract-status-code status-line)
+  (define status-str
+    (if (bytes? status-line)
+        (bytes->string/utf-8 status-line)
+        status-line))
+  (define m (regexp-match #rx"^HTTP/[^ ]+ ([0-9]+)" status-str))
+  (if m
+      (string->number (cadr m))
+      0))
+
+;; Returns #t when status-code indicates a client or server error (>= 400).
+(define (http-error? status-code)
+  (>= status-code 400))
+
+;; Raise exn:fail with a formatted HTTP error message.
+(define (raise-http-error! message)
+  (raise (exn:fail message (current-continuation-marks))))

--- a/llm/openai-compatible.rkt
+++ b/llm/openai-compatible.rkt
@@ -18,10 +18,11 @@
          net/http-client
          "model.rkt"
          "provider.rkt"
-         "stream.rkt")
+         "stream.rkt"
+         "http-helpers.rkt")
 
-(provide ;; Provider constructor
- make-openai-compatible-provider
+;; Provider constructor
+(provide make-openai-compatible-provider
          ;; Request/response helpers (exported for testing)
          openai-build-request-body
          openai-parse-response
@@ -100,13 +101,13 @@
                        (with-handlers ([exn:fail? (lambda (e) args-str)])
                          (string->jsexpr args-str)))
                      (hasheq 'type
-                           "tool-call"
-                           'id
-                           (hash-ref tc 'id)
-                           'name
-                           (hash-ref fn 'name)
-                           'arguments
-                           args))
+                             "tool-call"
+                             'id
+                             (hash-ref tc 'id)
+                             'name
+                             (hash-ref fn 'name)
+                             'arguments
+                             args))
                    '()))]))
 
   (make-model-response content usage model-name finish-reason))
@@ -126,26 +127,25 @@
   (define headers (list (format "Authorization: Bearer ~a" api-key) "Content-Type: application/json"))
   (define body-bytes (jsexpr->bytes body))
   ;; Wrap entire request in overall timeout (SEC-11)
-  (call-with-request-timeout
-   (lambda ()
-     (define-values (status-line response-headers response-port)
-       (if port
-           (http-sendrecv host
-                          path-str
-                          #:port port
-                          #:ssl? ssl?
-                          #:method "POST"
-                          #:headers headers
-                          #:data body-bytes)
-           (http-sendrecv host
-                          path-str
-                          #:ssl? ssl?
-                          #:method "POST"
-                          #:headers headers
-                          #:data body-bytes)))
-     (define response-body (read-response-body/timeout response-port))
-     (check-http-status! status-line response-body)
-     (bytes->jsexpr response-body))))
+  (call-with-request-timeout (lambda ()
+                               (define-values (status-line response-headers response-port)
+                                 (if port
+                                     (http-sendrecv host
+                                                    path-str
+                                                    #:port port
+                                                    #:ssl? ssl?
+                                                    #:method "POST"
+                                                    #:headers headers
+                                                    #:data body-bytes)
+                                     (http-sendrecv host
+                                                    path-str
+                                                    #:ssl? ssl?
+                                                    #:method "POST"
+                                                    #:headers headers
+                                                    #:data body-bytes)))
+                               (define response-body (read-response-body/timeout response-port))
+                               (check-http-status! status-line response-body)
+                               (bytes->jsexpr response-body))))
 
 ;; ============================================================
 ;; HTTP status check helper
@@ -184,21 +184,15 @@
         response-body
         (string->bytes/utf-8 response-body)))
   ;; Extract numeric status code from "HTTP/1.1 200 OK" or similar
-  (define status-code
-    (let ([m (regexp-match #rx"HTTP/[0-9.]+ ([0-9]+)" status-str)])
-      (if m
-          (string->number (cadr m))
-          0)))
+  (define status-code (extract-status-code status-line))
   (cond
     ;; Redirects — http-sendrecv does not follow them automatically
     [(and (>= status-code 300) (< status-code 400))
-     (raise
-      (exn:fail
-       (format
-        "API request redirected (~a: ~a). The server returned a redirect — check your base-url in config.json."
-        status-code
-        status-str)
-       (current-continuation-marks)))]
+     (raise-http-error!
+      (format
+       "API request redirected (~a: ~a). The server returned a redirect — check your base-url in config.json."
+       status-code
+       status-str))]
     ;; Client/server errors
     [(= status-code 429)
      (define error-text-429
@@ -206,16 +200,15 @@
                                     (format "<binary body ~a bytes>" (bytes-length response-bytes)))])
          (define jsexpr (bytes->jsexpr response-bytes))
          (or (extract-error-message jsexpr) (format "~a" jsexpr))))
-     (raise (exn:fail (format "API rate limited (429). Please wait and try again.\n~a" error-text-429)
-                      (current-continuation-marks)))]
-    [(>= status-code 400)
+     (raise-http-error! (format "API rate limited (429). Please wait and try again.\n~a"
+                                error-text-429))]
+    [(http-error? status-code)
      (define error-text
        (with-handlers ([exn:fail? (λ (_)
                                     (format "<binary body ~a bytes>" (bytes-length response-bytes)))])
          (define jsexpr (bytes->jsexpr response-bytes))
          (or (extract-error-message jsexpr) (format "~a" jsexpr))))
-     (raise (exn:fail (format "API request failed (~a): ~a" status-code error-text)
-                      (current-continuation-marks)))]))
+     (raise-http-error! (format "API request failed (~a): ~a" status-code error-text))]))
 
 ;; ============================================================
 ;; Provider constructor
@@ -259,24 +252,23 @@
     ;; call-with-request-timeout returns a single value,
     ;; so we capture the 3 http-sendrecv values in a vector.
     (define result-vec
-      (call-with-request-timeout
-       (lambda ()
-         (define-values (sl rh rp)
-           (if req-port
-               (http-sendrecv host
-                              path-str
-                              #:port req-port
-                              #:ssl? ssl?
-                              #:method "POST"
-                              #:headers headers
-                              #:data body-bytes)
-               (http-sendrecv host
-                              path-str
-                              #:ssl? ssl?
-                              #:method "POST"
-                              #:headers headers
-                              #:data body-bytes)))
-         (vector sl rh rp))))
+      (call-with-request-timeout (lambda ()
+                                   (define-values (sl rh rp)
+                                     (if req-port
+                                         (http-sendrecv host
+                                                        path-str
+                                                        #:port req-port
+                                                        #:ssl? ssl?
+                                                        #:method "POST"
+                                                        #:headers headers
+                                                        #:data body-bytes)
+                                         (http-sendrecv host
+                                                        path-str
+                                                        #:ssl? ssl?
+                                                        #:method "POST"
+                                                        #:headers headers
+                                                        #:data body-bytes)))
+                                   (vector sl rh rp))))
     (define status-line (vector-ref result-vec 0))
     (define response-headers (vector-ref result-vec 1))
     (define response-port (vector-ref result-vec 2))

--- a/llm/provider.rkt
+++ b/llm/provider.rkt
@@ -19,6 +19,7 @@
 
 (provide provider?
          validate-api-key!
+         ensure-model-setting
          (contract-out [provider-name (-> provider? string?)]
                        [provider-send (-> provider? model-request? any/c)]
                        [provider-stream (-> provider? model-request? any/c)]
@@ -27,6 +28,18 @@
                        [make-provider (-> procedure? procedure? procedure? procedure? provider?)]
                        [make-mock-provider
                         (->* (any/c) (#:name string? #:stream-chunks (or/c #f list?)) provider?)]))
+
+;; ============================================================
+;; Model-setting helper (ARCH-08)
+;; ============================================================
+
+;; Ensure the model-request has a 'model setting; if missing, set it to default-model.
+(define (ensure-model-setting req default-model)
+  (if (hash-has-key? (model-request-settings req) 'model)
+      req
+      (make-model-request (model-request-messages req)
+                          (model-request-tools req)
+                          (hash-set (model-request-settings req) 'model default-model))))
 
 ;; ============================================================
 ;; API key validation helper

--- a/util/content-helpers.rkt
+++ b/util/content-helpers.rkt
@@ -3,21 +3,23 @@
 ;; util/content-helpers.rkt — shared content-part → string helpers
 ;;
 ;; Extracted from agent/loop.rkt and cli/render.rkt to eliminate
-;; near-duplication (QUAL-03).  Both functions handle content-part
-;; lists, plain strings, and hashes.
+;; near-duplication (QUAL-03).  Unified via optional handle-hash?
+;; parameter (QUAL-13).
 
 (require racket/format
          racket/string)
 
-(provide ;; Content extraction helpers
- result-content->string
+;; Content extraction helpers
+(provide result-content->string
          tool-result-content->string)
 
-;; Convert tool-result content to a string for the API.
+;; Convert result content to a string for the API.
 ;; Content may be a list of content-part hashes, plain strings, or nested data.
-(define (result-content->string content)
+;; When #:handle-hash? is #t, top-level hashes are unwrapped (used by tool-result variant).
+(define (result-content->string content #:handle-hash? [handle-hash? #f])
   (cond
     [(string? content) content]
+    [(and handle-hash? (hash? content)) (hash-ref content 'text (format "~a" content))]
     [(list? content)
      (string-join (for/list ([part (in-list content)])
                     (cond
@@ -31,14 +33,4 @@
 ;; Same as result-content->string but also handles top-level hashes
 ;; (e.g. a single content hash with a 'text key).
 (define (tool-result-content->string content)
-  (cond
-    [(string? content) content]
-    [(list? content)
-     (string-join (for/list ([part (in-list content)])
-                    (cond
-                      [(string? part) part]
-                      [(hash? part) (hash-ref part 'text (format "~a" part))]
-                      [else (format "~a" part)]))
-                  "\n")]
-    [(hash? content) (hash-ref content 'text (format "~a" content))]
-    [else (format "~a" content)]))
+  (result-content->string content #:handle-hash? #t))


### PR DESCRIPTION
## Issues: #295 #296 #297 #298

### QUAL-10 (#296): Extract shared HTTP error handling
- New `llm/http-helpers.rkt` with `extract-status-code`, `http-error?`, `raise-http-error!`
- All 3 providers use shared helpers, keep provider-specific messages

### ARCH-08 (#297): Extract `ensure-model-setting` helper
- New helper in `llm/provider.rkt` replaces 4 boilerplate blocks
- Each was 5 lines → 1 line call

### QUAL-13 (#298): Unify content-helper functions
- `result-content->string` accepts `#:handle-hash?` parameter
- `tool-result-content->string` delegates with `#:handle-hash? #t`

### Verification
- [x] test-anthropic: all pass
- [x] test-gemini: all pass
- [x] test-openai-compatible: all pass
- [x] test-provider: all pass
- [x] lint-format passes

Closes #295 Closes #296 Closes #297 Closes #298