### PR TITLE
refactor: decompose terminal.rkt, agent-session run-prompt!, CLI args parser

### DIFF
--- a/cli/args.rkt
+++ b/cli/args.rkt
@@ -3,12 +3,13 @@
 ;; q/cli/args.rkt — CLI argument parsing, config conversion, usage/version display
 ;;
 ;; Extracted from interfaces/cli.rkt for modularity (Issue #193).
+;; Refactored: cond branches → data-driven flag table (QUAL-12, Issue #302).
 ;;
 ;; Provides:
 ;;   cli-config struct + accessors
 ;;   parse-cli-args      — pure argument parsing
 ;;   cli-config->runtime-config — config hash conversion
-;;   print-usage         — usage display
+;;   print-usage         — usage display (generated from flag table)
 ;;   print-version       — version display
 ;;   q-version           — version constant
 
@@ -51,6 +52,220 @@
   (cli-config 'help #f #f #f 'interactive #f #f #f 10 #f '() #f #f '()))
 
 ;; ============================================================
+;; Flag definition table (QUAL-12)
+;; ============================================================
+
+;; A flag definition describes one CLI option.
+;;   name      — internal identifier (string)
+;;   short     — short option character or #f
+;;   long      — long option string (e.g. "--help")
+;;   type      — 'boolean, 'string, 'integer, 'mode, 'accumulate, 'command
+;;               'boolean   : no argument, sets a field to #t
+;;               'string    : consumes next arg as a string value
+;;               'integer   : consumes next arg, must be exact-positive-integer
+;;               'mode      : no argument, sets mode field to a symbol
+;;               'accumulate: consumes next arg, accumulates into a list
+;;               'command   : no argument, sets command/produces immediate result
+;;   help      — help text for usage display
+;;   default   — default value (informational, used in usage generation)
+;;   apply-fn  — procedure: (val acc-alist) → acc-alist
+;;               Returns a new accumulator alist with the flag applied.
+;;               val is #t for booleans, the string/int value for others.
+
+(struct flag-def (name short long type help default apply-fn) #:transparent)
+
+;; -- Accessors for the accumulator alist (mutable parameter would also work,
+;;    but an alist is purely functional and easy to test).
+
+(define (acc-ref acc key [default #f])
+  (cond
+    [(null? acc) default]
+    [(eq? (caar acc) key) (cdar acc)]
+    [else (acc-ref (cdr acc) key default)]))
+
+(define (acc-set acc key val)
+  (cons (cons key val) (filter (lambda (p) (not (eq? (car p) key))) acc)))
+
+(define (acc-cons acc key val)
+  ;; Prepend val to the list at key
+  (let ([existing (acc-ref acc key '())]) (acc-set acc key (cons val existing))))
+
+;; Build the initial accumulator alist from defaults.
+(define (make-initial-acc)
+  `((command . chat) (session-id . #f)
+                     (prompt . #f)
+                     (model . #f)
+                     (mode . interactive)
+                     (project-dir . #f)
+                     (config-path . #f)
+                     (verbose? . #f)
+                     (max-turns . 10)
+                     (no-tools? . #f)
+                     (tools . ())
+                     (session-dir . #f)))
+
+;; Construct a cli-config from an accumulator alist.
+(define (acc->cli-config acc)
+  (define final-command
+    (let ([cmd (acc-ref acc 'command)]
+          [sid (acc-ref acc 'session-id)]
+          [prompt (acc-ref acc 'prompt)])
+      (cond
+        [(eq? cmd 'help) 'help]
+        [(eq? cmd 'version) 'version]
+        [(eq? cmd 'init) 'init]
+        [(eq? cmd 'sessions) 'sessions]
+        [(and sid (eq? cmd 'chat)) 'resume]
+        [prompt 'prompt]
+        [else cmd])))
+  (define final-mode
+    (let ([m (acc-ref acc 'mode)])
+      (cond
+        [(eq? m 'json) 'json]
+        [(eq? m 'rpc) 'rpc]
+        [(eq? m 'tui) 'tui]
+        [(eq? final-command 'prompt) 'single]
+        [else 'interactive])))
+  (cli-config final-command
+              (acc-ref acc 'session-id)
+              (acc-ref acc 'prompt)
+              (acc-ref acc 'model)
+              final-mode
+              (acc-ref acc 'project-dir)
+              (acc-ref acc 'config-path)
+              (acc-ref acc 'verbose?)
+              (acc-ref acc 'max-turns)
+              (acc-ref acc 'no-tools?)
+              (reverse (acc-ref acc 'tools))
+              (acc-ref acc 'session-dir)
+              #f ; sessions-subcommand
+              '())) ; sessions-args
+
+;; ============================================================
+;; Flag table — all option definitions
+;; ============================================================
+
+(define FLAG-DEFINITIONS
+  ;; --help / -h → immediate help
+  (list (flag-def "help"
+                  #\h
+                  "help"
+                  'boolean
+                  "Show this help message"
+                  #f
+                  (lambda (val acc)
+                    ;; Returning 'help immediately — handled specially in the parser
+                    'help))
+        ;; --version → immediate version
+        (flag-def "version" #f "version" 'boolean "Show version" #f (lambda (val acc) 'version))
+        ;; --session <id>
+        (flag-def "session"
+                  #f
+                  "session"
+                  'string
+                  "Resume session by ID"
+                  #f
+                  (lambda (val acc) (acc-set (acc-set acc 'session-id val) 'command 'resume)))
+        ;; --model <name>
+        (flag-def "model"
+                  #f
+                  "model"
+                  'string
+                  "Model to use (e.g. gpt-4, claude-3)"
+                  #f
+                  (lambda (val acc) (acc-set acc 'model val)))
+        ;; --project-dir <path>
+        (flag-def "project-dir"
+                  #f
+                  "project-dir"
+                  'string
+                  "Project directory for session storage"
+                  #f
+                  (lambda (val acc) (acc-set acc 'project-dir val)))
+        ;; --config <path>
+        (flag-def "config"
+                  #f
+                  "config"
+                  'string
+                  "Configuration file path"
+                  #f
+                  (lambda (val acc) (acc-set acc 'config-path val)))
+        ;; --verbose / -v
+        (flag-def "verbose"
+                  #\v
+                  "verbose"
+                  'boolean
+                  "Enable verbose output"
+                  #f
+                  (lambda (val acc) (acc-set acc 'verbose? #t)))
+        ;; --max-turns <n>
+        (flag-def "max-turns"
+                  #f
+                  "max-turns"
+                  'integer
+                  "Maximum agent loop iterations (default: 10)"
+                  10
+                  (lambda (val acc) (acc-set acc 'max-turns val)))
+        ;; --no-tools
+        (flag-def "no-tools"
+                  #f
+                  "no-tools"
+                  'boolean
+                  "Disable tool use"
+                  #f
+                  (lambda (val acc) (acc-set acc 'no-tools? #t)))
+        ;; --tool <name> (repeatable)
+        (flag-def "tool"
+                  #f
+                  "tool"
+                  'accumulate
+                  "Enable specific tool (repeatable)"
+                  '()
+                  (lambda (val acc) (acc-cons acc 'tools val)))
+        ;; --session-dir <path>
+        (flag-def "session-dir"
+                  #f
+                  "session-dir"
+                  'string
+                  "Override session storage directory"
+                  #f
+                  (lambda (val acc) (acc-set acc 'session-dir val)))
+        ;; --tui
+        (flag-def "tui"
+                  #f
+                  "tui"
+                  'mode
+                  "Terminal UI mode (TUI)"
+                  #f
+                  (lambda (val acc) (acc-set acc 'mode 'tui)))
+        ;; --json
+        (flag-def "json"
+                  #f
+                  "json"
+                  'mode
+                  "JSON mode (machine-readable output)"
+                  #f
+                  (lambda (val acc) (acc-set acc 'mode 'json)))
+        ;; --rpc
+        (flag-def "rpc"
+                  #f
+                  "rpc"
+                  'mode
+                  "RPC mode (stdin/stdout JSONL protocol)"
+                  #f
+                  (lambda (val acc) (acc-set acc 'mode 'rpc)))))
+
+;; Build lookup tables for fast matching
+(define long-flag-table
+  (for/hash ([fd (in-list FLAG-DEFINITIONS)])
+    (values (string-append "--" (flag-def-long fd)) fd)))
+
+(define short-flag-table
+  (for/hash ([fd (in-list FLAG-DEFINITIONS)]
+             #:when (flag-def-short fd))
+    (values (string-append "-" (string (flag-def-short fd))) fd)))
+
+;; ============================================================
 ;; Pure: parse-cli-args
 ;; ============================================================
 
@@ -65,374 +280,87 @@
   (define n (vector-length vec))
 
   (let loop ([i 0]
-             [command 'chat]
-             [session-id #f]
-             [prompt #f]
-             [model #f]
-             [mode 'interactive]
-             [project-dir #f]
-             [config-path #f]
-             [verbose? #f]
-             [max-turns 10]
-             [no-tools? #f]
-             [tools '()]
-             [session-dir #f])
+             [acc (make-initial-acc)])
     (cond
       ;; ── Done ──
       [(>= i n)
-       ;; Determine final command and mode
-       (define final-command
-         (cond
-           [(eq? command 'help) 'help]
-           [(eq? command 'version) 'version]
-           [(eq? command 'init) 'init]
-           [(eq? command 'sessions) 'sessions]
-           [(and session-id (eq? command 'chat)) 'resume]
-           [prompt 'prompt]
-           [else command]))
-       (define final-mode
-         (cond
-           [(eq? mode 'json) 'json]
-           [(eq? mode 'rpc) 'rpc]
-           [(eq? mode 'tui) 'tui]
-           [(eq? final-command 'prompt) 'single]
-           [else 'interactive]))
-       (cli-config final-command
-                   session-id
-                   prompt
-                   model
-                   final-mode
-                   project-dir
-                   config-path
-                   verbose?
-                   max-turns
-                   no-tools?
-                   (reverse tools)
-                   session-dir
-                   #f ; sessions-subcommand
-                   '() ; sessions-args
-                   )]
+       ;; Handle sessions subcommand finalization
+       (define cmd (acc-ref acc 'command))
+       (cond
+         ;; sessions was set — subcommand was already consumed inline
+         [(eq? cmd 'sessions) acc]
+         [else (acc->cli-config acc)])]
 
-      ;; ── --help / -h ──
-      [(or (equal? (vector-ref vec i) "--help") (equal? (vector-ref vec i) "-h"))
-       (make-help-config)]
+      ;; ── Known flag? ──
+      [(hash-ref long-flag-table (vector-ref vec i) #f)
+       =>
+       (lambda (fd) (apply-flag fd vec n i acc loop))]
 
-      ;; ── --version ──
-      [(equal? (vector-ref vec i) "--version")
-       (cli-config 'version #f #f #f 'interactive #f #f #f 10 #f '() #f #f '())]
+      [(hash-ref short-flag-table (vector-ref vec i) #f)
+       =>
+       (lambda (fd) (apply-flag fd vec n i acc loop))]
 
-      ;; ── --session <id> ──
-      [(equal? (vector-ref vec i) "--session")
-       (if (< (add1 i) n)
-           (loop (+ i 2)
-                 'resume
-                 (vector-ref vec (add1 i))
-                 prompt
-                 model
-                 mode
-                 project-dir
-                 config-path
-                 verbose?
-                 max-turns
-                 no-tools?
-                 tools
-                 session-dir)
-           (make-help-config))]
+      ;; ── Positional argument (prompt) or subcommand ──
+      ;; Unknown flag → help
+      [(string-prefix? (vector-ref vec i) "--") (make-help-config)]
 
-      ;; ── --model <name> ──
-      [(equal? (vector-ref vec i) "--model")
-       (if (< (add1 i) n)
-           (loop (+ i 2)
-                 command
-                 session-id
-                 prompt
-                 (vector-ref vec (add1 i))
-                 mode
-                 project-dir
-                 config-path
-                 verbose?
-                 max-turns
-                 no-tools?
-                 tools
-                 session-dir)
-           (make-help-config))]
+      [else (handle-positional vec n i acc loop)])))
 
-      ;; ── --project-dir <path> ──
-      [(equal? (vector-ref vec i) "--project-dir")
-       (if (< (add1 i) n)
-           (loop (+ i 2)
-                 command
-                 session-id
-                 prompt
-                 model
-                 mode
-                 (vector-ref vec (add1 i))
-                 config-path
-                 verbose?
-                 max-turns
-                 no-tools?
-                 tools
-                 session-dir)
-           (make-help-config))]
+;; Apply a flag-def: consume the arg at position i, possibly the next arg too,
+;; call the apply-fn, and continue the loop.
+(define (apply-flag fd vec n i acc loop)
+  (define t (flag-def-type fd))
+  (cond
+    [(eq? t 'boolean)
+     (let ([result ((flag-def-apply-fn fd) #t acc)])
+       (cond
+         [(eq? result 'help) (make-help-config)]
+         [(eq? result 'version)
+          (cli-config 'version #f #f #f 'interactive #f #f #f 10 #f '() #f #f '())]
+         [else (loop (add1 i) result)]))]
+    [(or (eq? t 'string) (eq? t 'integer) (eq? t 'accumulate))
+     (if (< (add1 i) n)
+         (let ([raw-val (vector-ref vec (add1 i))])
+           (cond
+             [(eq? t 'integer)
+              (define num (string->number raw-val))
+              (if (and num (exact-positive-integer? num))
+                  (loop (+ i 2) ((flag-def-apply-fn fd) num acc))
+                  (make-help-config))]
+             [else (loop (+ i 2) ((flag-def-apply-fn fd) raw-val acc))]))
+         (make-help-config))]
+    [(eq? t 'mode) (loop (add1 i) ((flag-def-apply-fn fd) #t acc))]
+    ;; Shouldn't happen
+    [else (make-help-config)]))
 
-      ;; ── --config <path> ──
-      [(equal? (vector-ref vec i) "--config")
-       (if (< (add1 i) n)
-           (loop (+ i 2)
-                 command
-                 session-id
-                 prompt
-                 model
-                 mode
-                 project-dir
-                 (vector-ref vec (add1 i))
-                 verbose?
-                 max-turns
-                 no-tools?
-                 tools
-                 session-dir)
-           (make-help-config))]
-
-      ;; ── --verbose / -v ──
-      [(or (equal? (vector-ref vec i) "--verbose") (equal? (vector-ref vec i) "-v"))
-       (loop (add1 i)
-             command
-             session-id
-             prompt
-             model
-             mode
-             project-dir
-             config-path
-             #t
-             max-turns
-             no-tools?
-             tools
-             session-dir)]
-
-      ;; ── --max-turns <n> ──
-      [(equal? (vector-ref vec i) "--max-turns")
-       (if (< (add1 i) n)
-           (let ([n-str (vector-ref vec (add1 i))])
-             (define n-val (string->number n-str))
-             (if (and n-val (exact-positive-integer? n-val))
-                 (loop (+ i 2)
-                       command
-                       session-id
-                       prompt
-                       model
-                       mode
-                       project-dir
-                       config-path
-                       verbose?
-                       n-val
-                       no-tools?
-                       tools
-                       session-dir)
-                 ;; Non-numeric max-turns → help
-                 (make-help-config)))
-           (make-help-config))]
-
-      ;; ── --no-tools ──
-      [(equal? (vector-ref vec i) "--no-tools")
-       (loop (add1 i)
-             command
-             session-id
-             prompt
-             model
-             mode
-             project-dir
-             config-path
-             verbose?
-             max-turns
-             #t
-             tools
-             session-dir)]
-
-      ;; ── --tool <name> (repeatable) ──
-      [(equal? (vector-ref vec i) "--tool")
-       (if (< (add1 i) n)
-           (loop (+ i 2)
-                 command
-                 session-id
-                 prompt
-                 model
-                 mode
-                 project-dir
-                 config-path
-                 verbose?
-                 max-turns
-                 no-tools?
-                 (cons (vector-ref vec (add1 i)) tools)
-                 session-dir)
-           (make-help-config))]
-
-      ;; ── --tui ──
-      [(equal? (vector-ref vec i) "--tui")
-       (loop (add1 i)
-             command
-             session-id
-             prompt
-             model
-             'tui
-             project-dir
-             config-path
-             verbose?
-             max-turns
-             no-tools?
-             tools
-             session-dir)]
-
-      ;; ── --json ──
-      [(equal? (vector-ref vec i) "--json")
-       (loop (add1 i)
-             command
-             session-id
-             prompt
-             model
-             'json
-             project-dir
-             config-path
-             verbose?
-             max-turns
-             no-tools?
-             tools
-             session-dir)]
-
-      ;; ── --rpc ──
-      [(equal? (vector-ref vec i) "--rpc")
-       (loop (add1 i)
-             command
-             session-id
-             prompt
-             model
-             'rpc
-             project-dir
-             config-path
-             verbose?
-             max-turns
-             no-tools?
-             tools
-             session-dir)]
-
-      ;; ── --session-dir <path> ──
-      [(equal? (vector-ref vec i) "--session-dir")
-       (if (< (add1 i) n)
-           (loop (+ i 2)
-                 command
-                 session-id
-                 prompt
-                 model
-                 mode
-                 project-dir
-                 config-path
-                 verbose?
-                 max-turns
-                 no-tools?
-                 tools
-                 (vector-ref vec (add1 i)))
-           (make-help-config))]
-
-      ;; ── Positional argument (prompt) ──
-      [(string-prefix? (vector-ref vec i) "--")
-       ;; Unknown flag → help
-       (make-help-config)]
-
-      [else
-       ;; First positional — check for named subcommands
-       (let ([arg (vector-ref vec i)])
-         (cond
-           ;; "doctor" subcommand
-           [(equal? arg "doctor")
-            (loop (add1 i)
-                  'doctor
-                  session-id
-                  prompt
-                  model
-                  mode
-                  project-dir
-                  config-path
-                  verbose?
-                  max-turns
-                  no-tools?
-                  tools
-                  session-dir)]
-           ;; "init" subcommand
-           [(equal? arg "init")
-            (loop (add1 i)
-                  'init
-                  session-id
-                  prompt
-                  model
-                  mode
-                  project-dir
-                  config-path
-                  verbose?
-                  max-turns
-                  no-tools?
-                  tools
-                  session-dir)]
-           ;; "sessions" subcommand — q sessions <list|info|delete> [args...]
-           [(equal? arg "sessions")
-            (if (< (add1 i) n)
-                (let ([sub (vector-ref vec (add1 i))])
-                  (define sub-sym
-                    (cond
-                      [(equal? sub "list") 'list]
-                      [(equal? sub "info") 'info]
-                      [(equal? sub "delete") 'delete]
-                      [else #f]))
-                  (if sub-sym
-                      ;; Collect remaining args after subcommand
-                      (let ([rest (for/list ([j (in-range (+ i 2) n)])
-                                    (vector-ref vec j))])
-                        (cli-config 'sessions
-                                    #f
-                                    #f
-                                    #f
-                                    'interactive
-                                    #f
-                                    #f
-                                    #f
-                                    10
-                                    #f
-                                    '()
-                                    #f
-                                    sub-sym
-                                    rest))
-                      ;; Bad subcommand → help
-                      (make-help-config)))
-                ;; No subcommand → show help
-                (make-help-config))]
-           ;; Default: treat as prompt
-           [prompt
-            ;; Second positional — unexpected, just ignore
-            (loop (add1 i)
-                  command
-                  session-id
-                  prompt
-                  model
-                  mode
-                  project-dir
-                  config-path
-                  verbose?
-                  max-turns
-                  no-tools?
-                  tools
-                  session-dir)]
-           [else
-            (loop (add1 i)
-                  'prompt
-                  session-id
-                  (vector-ref vec i)
-                  model
-                  mode
-                  project-dir
-                  config-path
-                  verbose?
-                  max-turns
-                  no-tools?
-                  tools
-                  session-dir)]))])))
+;; Handle positional arguments and subcommands.
+(define (handle-positional vec n i acc loop)
+  (define arg (vector-ref vec i))
+  (cond
+    ;; "doctor" subcommand
+    [(equal? arg "doctor") (loop (add1 i) (acc-set acc 'command 'doctor))]
+    ;; "init" subcommand
+    [(equal? arg "init") (loop (add1 i) (acc-set acc 'command 'init))]
+    ;; "sessions" subcommand — q sessions <list|info|delete> [args...]
+    [(equal? arg "sessions")
+     (if (< (add1 i) n)
+         (let ([sub (vector-ref vec (add1 i))])
+           (define sub-sym
+             (cond
+               [(equal? sub "list") 'list]
+               [(equal? sub "info") 'info]
+               [(equal? sub "delete") 'delete]
+               [else #f]))
+           (if sub-sym
+               (let ([rest (for/list ([j (in-range (+ i 2) n)])
+                             (vector-ref vec j))])
+                 (cli-config 'sessions #f #f #f 'interactive #f #f #f 10 #f '() #f sub-sym rest))
+               (make-help-config)))
+         (make-help-config))]
+    ;; Default: treat as prompt
+    ;; Second positional — ignore
+    [(acc-ref acc 'prompt #f) (loop (add1 i) acc)]
+    [else (loop (add1 i) (acc-set (acc-set acc 'prompt arg) 'command 'prompt))]))
 
 ;; ============================================================
 ;; Pure: cli-config->runtime-config
@@ -461,7 +389,7 @@
   base)
 
 ;; ============================================================
-;; I/O: print-usage
+;; I/O: print-usage (generated from flag table)
 ;; ============================================================
 
 (define (print-usage [port (current-output-port)])
@@ -481,17 +409,33 @@
   (displayln "  q sessions delete <id>     Delete a session" port)
   (newline port)
   (displayln "Options:" port)
-  (displayln "  --model <name>             Model to use (e.g. gpt-4, claude-3)" port)
-  (displayln "  --project-dir <path>       Project directory for session storage" port)
-  (displayln "  --session-dir <path>       Override session storage directory" port)
-  (displayln "  --config <path>            Configuration file path" port)
-  (displayln "  --session <id>             Resume session by ID" port)
-  (displayln "  --max-turns <n>            Maximum agent loop iterations (default: 10)" port)
-  (displayln "  --verbose, -v              Enable verbose output" port)
-  (displayln "  --no-tools                 Disable tool use" port)
-  (displayln "  --tool <name>              Enable specific tool (repeatable)" port)
-  (displayln "  --help, -h                 Show this help message" port)
-  (displayln "  --version                  Show version" port)
+  ;; Generate option lines from FLAG-DEFINITIONS
+  (for ([fd (in-list FLAG-DEFINITIONS)])
+    (define short-part
+      (if (flag-def-short fd)
+          (format "-~a, " (flag-def-short fd))
+          "    "))
+    (define long-part (format "--~a" (flag-def-long fd)))
+    (define type-placeholder
+      (cond
+        [(eq? (flag-def-type fd) 'string) " <value>"]
+        [(eq? (flag-def-type fd) 'integer) " <n>"]
+        [(eq? (flag-def-type fd) 'accumulate) " <name>"]
+        [else ""]))
+    (define help-text (flag-def-help fd))
+    (define line
+      (format "  ~a~a~a~a"
+              short-part
+              long-part
+              type-placeholder
+              ;; Pad to column 30
+              (make-string (max 1
+                                (- 26
+                                   (string-length short-part)
+                                   (string-length long-part)
+                                   (string-length type-placeholder)))
+                           #\space)))
+    (displayln (string-append line help-text) port))
   (displayln "  doctor                     Run setup and provider diagnostics" port)
   (newline port)
   (displayln "Interactive commands:" port)

--- a/runtime/agent-session.rkt
+++ b/runtime/agent-session.rkt
@@ -273,19 +273,14 @@
   new-sess)
 
 ;; ============================================================
-;; run-prompt!
+;; Private helpers extracted from run-prompt!
 ;; ============================================================
 
-(define (run-prompt! sess user-message #:max-iterations [max-iter-override #f])
-  (define bus (agent-session-event-bus sess))
-  (define prov (agent-session-provider sess))
-  (define reg (agent-session-tool-registry sess))
+;; build-session-context — context preparation:
+;;   converts user-message, appends to log, loads history, injects
+;;   system instructions. Returns the context message list.
+(define (build-session-context sess user-message)
   (define log-path (session-log-path (agent-session-session-dir sess)))
-  (define idx-path (session-index-path (agent-session-session-dir sess)))
-  (define sid (agent-session-session-id sess))
-  (define cfg (agent-session-config sess))
-  (define max-iterations (or max-iter-override (hash-ref cfg 'max-iterations 10)))
-  (define token-budget-threshold (hash-ref cfg 'token-budget-threshold DEFAULT-TOKEN-BUDGET-THRESHOLD))
 
   ;; Convert string to message struct if needed
   (define user-msg
@@ -309,27 +304,32 @@
                         (hasheq)))
         user-message))
 
-  ;; 1. Append user message to session log
+  ;; Append user message to session log
   (append-entry! log-path user-msg)
 
-  ;; 2. Build context from full session history
+  ;; Build context from full session history
   (define history (load-session-log log-path))
 
-  ;; 3. Inject system instructions as an ephemeral system message prefix
+  ;; Inject system instructions as an ephemeral system message prefix
   (define system-instrs (agent-session-system-instructions sess))
-  (define context-with-system
-    (if (null? system-instrs)
-        history
-        (cons (make-message (generate-id)
-                            #f
-                            'system
-                            'system-instruction
-                            (list (make-text-part (string-join system-instrs "\n\n")))
-                            (now-seconds)
-                            (hasheq))
-              history)))
+  (if (null? system-instrs)
+      history
+      (cons (make-message (generate-id)
+                          #f
+                          'system
+                          'system-instruction
+                          (list (make-text-part (string-join system-instrs "\n\n")))
+                          (now-seconds)
+                          (hasheq))
+            history)))
 
-  ;; 4. Check token budget (on full context including system message)
+;; maybe-compact-context — token budget check and compaction triggering.
+;;   May mutate context (return a compacted version). Returns the
+;;   (possibly compacted) context message list.
+(define (maybe-compact-context sess context-with-system token-budget-threshold)
+  (define bus (agent-session-event-bus sess))
+  (define sid (agent-session-session-id sess))
+
   (define raw-messages
     (for/list ([msg (in-list context-with-system)])
       (hasheq 'role
@@ -337,44 +337,56 @@
               'content
               (map content-part->jsexpr (message-content msg)))))
   (define token-count (estimate-context-tokens raw-messages))
-  (when (should-compact? token-count token-budget-threshold)
-    ;; Dispatch 'session-before-compact hook — extensions can amend or block compaction
-    (define compact-payload
-      (hasheq 'session-id
-              sid
-              'token-count
-              token-count
-              'budget-threshold
-              token-budget-threshold
-              'message-count
-              (length context-with-system)))
-    (define-values (amended-compact compact-hook-res)
-      (maybe-dispatch-hooks (agent-session-extension-registry sess)
-                            'session-before-compact
-                            compact-payload))
-    ;; Proceed with compaction unless blocked
-    (unless (and compact-hook-res (eq? (hook-result-action compact-hook-res) 'block))
-      (emit-session-event! bus
-                           sid
-                           "compaction.warning"
-                           (hasheq 'tokenCount token-count 'budgetThreshold token-budget-threshold))
-      ;; R2-6: Auto-compact when threshold exceeded
-      (define compact-result (compact-history context-with-system))
-      (set! context-with-system (compaction-result->message-list compact-result))
-      (emit-session-event! bus
-                           sid
-                           "compaction.completed"
-                           (hasheq 'removedCount
-                                   (compaction-result-removed-count compact-result)
-                                   'keptCount
-                                   (length (compaction-result-kept-messages compact-result))
-                                   'tokenCount
-                                   token-count))))
+  (cond
+    [(not (should-compact? token-count token-budget-threshold)) context-with-system]
+    [else
+     ;; Dispatch 'session-before-compact hook — extensions can amend or block compaction
+     (define compact-payload
+       (hasheq 'session-id
+               sid
+               'token-count
+               token-count
+               'budget-threshold
+               token-budget-threshold
+               'message-count
+               (length context-with-system)))
+     (define-values (_amended-compact compact-hook-res)
+       (maybe-dispatch-hooks (agent-session-extension-registry sess)
+                             'session-before-compact
+                             compact-payload))
+     ;; Proceed with compaction unless blocked
+     (cond
+       [(and compact-hook-res (eq? (hook-result-action compact-hook-res) 'block)) context-with-system]
+       [else
+        (emit-session-event! bus
+                             sid
+                             "compaction.warning"
+                             (hasheq 'tokenCount token-count 'budgetThreshold token-budget-threshold))
+        ;; R2-6: Auto-compact when threshold exceeded
+        (define compact-result (compact-history context-with-system))
+        (emit-session-event! bus
+                             sid
+                             "compaction.completed"
+                             (hasheq 'removedCount
+                                     (compaction-result-removed-count compact-result)
+                                     'keptCount
+                                     (length (compaction-result-kept-messages compact-result))
+                                     'tokenCount
+                                     token-count))
+        (compaction-result->message-list compact-result)])]))
 
-  ;; 5. Extract cancellation token from config
+;; dispatch-iteration — model-select hook + iteration loop dispatch.
+;;   Runs the core agent loop with error handling. Returns a loop-result.
+(define (dispatch-iteration sess context-with-system max-iterations)
+  (define bus (agent-session-event-bus sess))
+  (define prov (agent-session-provider sess))
+  (define reg (agent-session-tool-registry sess))
+  (define log-path (session-log-path (agent-session-session-dir sess)))
+  (define sid (agent-session-session-id sess))
+  (define cfg (agent-session-config sess))
   (define cancellation-tok (hash-ref cfg 'cancellation-token #f))
 
-  ;; 5b. Dispatch 'model-select hook — extensions can override model
+  ;; Dispatch 'model-select hook — extensions can override model
   (define-values (_model-hook-res model-hook-res)
     (maybe-dispatch-hooks (agent-session-extension-registry sess)
                           'model-select
@@ -386,35 +398,58 @@
     (define override-model (hash-ref (hook-result-payload model-hook-res) 'model))
     (set-agent-session-model-name! sess override-model))
 
-  ;; 6. Run the core agent loop with tool-call iteration
-  (define final-result
-    (with-handlers ([exn:fail?
-                     (lambda (e)
-                       ;; Emit runtime.error event
-                       (emit-session-event! bus sid "runtime.error" (hasheq 'error (exn-message e)))
-                       ;; Classify error: distinguish iteration limits from provider failures
-                       (define error-type
-                         (if (regexp-match? #rx"max.iterations" (exn-message e))
-                             'max-iterations-exceeded
-                             'provider-error))
-                       (make-loop-result context-with-system
-                                         'error
-                                         (hasheq 'error (exn-message e) 'errorType error-type)))])
-      (run-iteration-loop context-with-system
-                          prov
-                          bus
-                          reg
-                          (agent-session-extension-registry sess)
-                          log-path
-                          sid
-                          max-iterations
-                          #:cancellation-token cancellation-tok
-                          #:config cfg)))
+  ;; Run the core agent loop with tool-call iteration
+  (with-handlers ([exn:fail?
+                   (lambda (e)
+                     ;; Emit runtime.error event
+                     (emit-session-event! bus sid "runtime.error" (hasheq 'error (exn-message e)))
+                     ;; Classify error: distinguish iteration limits from provider failures
+                     (define error-type
+                       (if (regexp-match? #rx"max.iterations" (exn-message e))
+                           'max-iterations-exceeded
+                           'provider-error))
+                     (make-loop-result context-with-system
+                                       'error
+                                       (hasheq 'error (exn-message e) 'errorType error-type)))])
+    (run-iteration-loop context-with-system
+                        prov
+                        bus
+                        reg
+                        (agent-session-extension-registry sess)
+                        log-path
+                        sid
+                        max-iterations
+                        #:cancellation-token cancellation-tok
+                        #:config cfg)))
 
-  ;; 7. Rebuild index
+;; ============================================================
+;; run-prompt!
+;; ============================================================
+
+(define (run-prompt! sess user-message #:max-iterations [max-iter-override #f])
+  (define bus (agent-session-event-bus sess))
+  (define log-path (session-log-path (agent-session-session-dir sess)))
+  (define idx-path (session-index-path (agent-session-session-dir sess)))
+  (define sid (agent-session-session-id sess))
+  (define cfg (agent-session-config sess))
+  (define max-iterations (or max-iter-override (hash-ref cfg 'max-iterations 10)))
+  (define token-budget-threshold
+    (hash-ref cfg 'token-budget-threshold DEFAULT-TOKEN-BUDGET-THRESHOLD))
+
+  ;; 1. Build context: convert message, append to log, load history, inject system instructions
+  (define context-with-system (build-session-context sess user-message))
+
+  ;; 2. Check token budget and compact if needed
+  (define context-after-compact
+    (maybe-compact-context sess context-with-system token-budget-threshold))
+
+  ;; 3. Run the core agent loop (model-select hook + iteration dispatch)
+  (define final-result (dispatch-iteration sess context-after-compact max-iterations))
+
+  ;; 4. Rebuild index
   (set-agent-session-index! sess (build-index! log-path idx-path))
 
-  ;; 8. Emit session.updated
+  ;; 5. Emit session.updated
   (emit-session-event!
    bus
    sid

--- a/tui/terminal-bridge.rkt
+++ b/tui/terminal-bridge.rkt
@@ -1,0 +1,251 @@
+#lang racket/base
+
+;; q/tui/terminal-bridge.rkt — tui-term dynamic loading bridge + stub fallbacks
+;;
+;; Handles all dynamic-require logic for loading the tui-term library.
+;; When tui-term is unavailable, provides stub implementations that use
+;; direct ANSI escape sequences and raw stdin reading.
+;;
+;; Extracted from terminal.rkt for separation of concerns.
+
+(require racket/port
+         racket/string
+         racket/list
+         racket/system)
+
+;; Bridge availability
+(provide tui-term-available?
+
+         ;; Selected implementations (real or stub)
+         make-tty-term
+         term-alternate-screen
+         term-normal-screen
+         term-hide-cursor
+         term-show-cursor
+         term-close
+         current-term-size
+
+         ;; Dynamic require results (for input selection in facade)
+         read-msg-fn
+         byte-ready-fn
+
+         ;; Message predicate/accessor functions (tui-term or fallback)
+         tkeymsg? ;; adapter predicate
+         tkeymsg-key ;; adapter accessor
+         tsizemsg? ;; adapter predicate
+         tsizemsg-cols ;; adapter accessor
+         tsizemsg-rows ;; adapter accessor
+         tcmdmsg? ;; adapter predicate
+         tcmdmsg-cmd) ;; adapter accessor
+
+;; ============================================================
+;; Dynamic require: detect tui-term availability
+;; ============================================================
+
+(define tui-term-available?
+  (with-handlers ([exn:fail? (lambda (e) #f)])
+    (collection-path "tui")
+    #t))
+
+;; ============================================================
+;; Dynamic requires (will be #f if not available)
+;; ============================================================
+
+(define make-tty-term-fn
+  (and tui-term-available?
+       (with-handlers ([exn:fail? (lambda (e) #f)])
+         (dynamic-require 'tui/term 'make-tty-term))))
+
+(define term-alternate-screen-fn
+  (and tui-term-available?
+       (with-handlers ([exn:fail? (lambda (e) #f)])
+         (dynamic-require 'tui/term 'term-alternate-screen))))
+
+(define term-normal-screen-fn
+  (and tui-term-available?
+       (with-handlers ([exn:fail? (lambda (e) #f)])
+         (dynamic-require 'tui/term 'term-normal-screen))))
+
+(define term-hide-cursor-fn
+  (and tui-term-available?
+       (with-handlers ([exn:fail? (lambda (e) #f)])
+         (dynamic-require 'tui/term 'term-hide-cursor))))
+
+(define term-show-cursor-fn
+  (and tui-term-available?
+       (with-handlers ([exn:fail? (lambda (e) #f)])
+         (dynamic-require 'tui/term 'term-show-cursor))))
+
+(define term-close-fn
+  (and tui-term-available?
+       (with-handlers ([exn:fail? (lambda (e) #f)])
+         (dynamic-require 'tui/term 'term-close))))
+
+(define current-term-size-fn
+  (and tui-term-available?
+       (with-handlers ([exn:fail? (lambda (e) #f)])
+         (dynamic-require 'tui/term 'current-term-size))))
+
+(define read-msg-fn
+  (and tui-term-available?
+       (with-handlers ([exn:fail? (lambda (e) #f)])
+         (dynamic-require 'tui/term/messages 'read-msg))))
+
+(define byte-ready-fn
+  (and tui-term-available?
+       (with-handlers ([exn:fail? (lambda (e) #f)])
+         (dynamic-require 'tui/term/messages 'byte-ready?))))
+
+;; Dynamic require for message struct predicates and accessors
+(define tkeymsg?-fn
+  (and tui-term-available?
+       (with-handlers ([exn:fail? (lambda (e) #f)])
+         (dynamic-require 'tui/term/messages 'tkeymsg?))))
+
+(define tkeymsg-key-fn
+  (and tui-term-available?
+       (with-handlers ([exn:fail? (lambda (e) #f)])
+         (dynamic-require 'tui/term/messages 'tkeymsg-key))))
+
+(define tsizemsg?-fn
+  (and tui-term-available?
+       (with-handlers ([exn:fail? (lambda (e) #f)])
+         (dynamic-require 'tui/term/messages 'tsizemsg?))))
+
+(define tsizemsg-cols-fn
+  (and tui-term-available?
+       (with-handlers ([exn:fail? (lambda (e) #f)])
+         (dynamic-require 'tui/term/messages 'tsizemsg-cols))))
+
+(define tsizemsg-rows-fn
+  (and tui-term-available?
+       (with-handlers ([exn:fail? (lambda (e) #f)])
+         (dynamic-require 'tui/term/messages 'tsizemsg-rows))))
+
+(define tcmdmsg?-fn
+  (and tui-term-available?
+       (with-handlers ([exn:fail? (lambda (e) #f)])
+         (dynamic-require 'tui/term/messages 'tcmdmsg?))))
+
+(define tcmdmsg-cmd-fn
+  (and tui-term-available?
+       (with-handlers ([exn:fail? (lambda (e) #f)])
+         (dynamic-require 'tui/term/messages 'tcmdmsg-cmd))))
+
+;; ============================================================
+;; Stub implementations (when tui-term not available)
+;; ============================================================
+
+(define (stub-make-tty-term #:tty [tty #f])
+  ;; Put tty into raw mode so we can read individual keypresses.
+  ;; Use system() so stty operates on the inherited terminal fd.
+  ;; subprocess() doesn't inherit the controlling terminal properly.
+  (with-handlers ([exn:fail? void])
+    (system "stty raw -echo -icanon < /dev/tty 2>/dev/null"))
+  (gensym 'stub-term))
+
+(define (stub-term-alternate-screen term)
+  (display "\x1b[?1049h")
+  (flush-output))
+
+(define (stub-term-normal-screen term)
+  (display "\x1b[?1049l")
+  (flush-output))
+
+(define (stub-term-hide-cursor term)
+  (display "\x1b[?25l")
+  (flush-output))
+
+(define (stub-term-show-cursor term)
+  (display "\x1b[?25h")
+  (flush-output))
+
+(define (stub-term-close term)
+  ;; Restore tty to sane mode
+  (with-handlers ([exn:fail? void])
+    (system "stty sane < /dev/tty 2>/dev/null")))
+
+(define (stub-current-term-size)
+  ;; Try environment variables first (set by shell in most terminals)
+  (define env-cols (and (getenv "COLUMNS") (string->number (getenv "COLUMNS"))))
+  (define env-rows (and (getenv "LINES") (string->number (getenv "LINES"))))
+  (if (and env-cols env-rows (> env-cols 0) (> env-rows 0))
+      (values env-cols env-rows)
+      ;; Fallback: try stty size
+      ;; Uses dynamic-wind to guarantee port cleanup and prevent fd leaks.
+      ;; Previously leaked 3 fds per call → fd exhaustion after ~700 calls →
+      ;; subprocess failed → hardcoded 80x24 fallback.
+      (let ([result-cols 80]
+            [result-rows 24])
+        (define-values (sp stty-out stty-in stty-err)
+          (with-handlers ([exn:fail? (lambda (e) (values #f #f #f #f))])
+            (subprocess #f #f #f "/bin/sh" "-c" "stty size < /dev/tty 2>/dev/null")))
+        (dynamic-wind (lambda () (void))
+                      (lambda ()
+                        (when stty-in
+                          (close-output-port stty-in))
+                        (when stty-out
+                          (let* ([out-str (port->string stty-out)]
+                                 [parts (string-split out-str)])
+                            (when (= (length parts) 2)
+                              (set! result-cols (string->number (second parts)))
+                              (set! result-rows (string->number (first parts)))))))
+                      (lambda ()
+                        (when stty-out
+                          (close-input-port stty-out))
+                        (when stty-err
+                          (close-input-port stty-err))
+                        (when sp
+                          (sync/timeout 1.0 sp))))
+        (values result-cols result-rows))))
+
+;; ============================================================
+;; Select actual or stub implementations
+;; ============================================================
+
+(define make-tty-term (or make-tty-term-fn stub-make-tty-term))
+
+(define term-alternate-screen (or term-alternate-screen-fn stub-term-alternate-screen))
+
+(define term-normal-screen (or term-normal-screen-fn stub-term-normal-screen))
+
+(define term-hide-cursor (or term-hide-cursor-fn stub-term-hide-cursor))
+
+(define term-show-cursor (or term-show-cursor-fn stub-term-show-cursor))
+
+(define term-close (or term-close-fn stub-term-close))
+
+(define current-term-size (or current-term-size-fn stub-current-term-size))
+
+;; ============================================================
+;; Message struct bindings — dispatch to real tui-term or vector fallback
+;; ============================================================
+
+(define (tkeymsg? msg)
+  (or (and tkeymsg?-fn (tkeymsg?-fn msg)) (and (vector? msg) (eq? (vector-ref msg 0) 'tkeymsg))))
+
+(define (tkeymsg-key msg)
+  (if (and tkeymsg-key-fn (tkeymsg?-fn msg))
+      (tkeymsg-key-fn msg)
+      (vector-ref msg 1)))
+
+(define (tsizemsg? msg)
+  (or (and tsizemsg?-fn (tsizemsg?-fn msg)) (and (vector? msg) (eq? (vector-ref msg 0) 'tsizemsg))))
+
+(define (tsizemsg-cols msg)
+  (if (and tsizemsg-cols-fn (tsizemsg?-fn msg))
+      (tsizemsg-cols-fn msg)
+      (vector-ref msg 1)))
+
+(define (tsizemsg-rows msg)
+  (if (and tsizemsg-rows-fn (tsizemsg?-fn msg))
+      (tsizemsg-rows-fn msg)
+      (vector-ref msg 2)))
+
+(define (tcmdmsg? msg)
+  (or (and tcmdmsg?-fn (tcmdmsg?-fn msg)) (and (vector? msg) (eq? (vector-ref msg 0) 'tcmdmsg))))
+
+(define (tcmdmsg-cmd msg)
+  (if (and tcmdmsg-cmd-fn (tcmdmsg?-fn msg))
+      (tcmdmsg-cmd-fn msg)
+      (vector-ref msg 1)))

--- a/tui/terminal-input.rkt
+++ b/tui/terminal-input.rkt
@@ -1,0 +1,259 @@
+#lang racket/base
+
+;; q/tui/terminal-input.rkt — ANSI key decoding, stdin reading, and UTF-8 support
+;;
+;; Handles raw stdin input reading, ANSI escape sequence parsing,
+;; key/mouse event generation, and UTF-8 accumulator state.
+;; These are the "real stdin" fallbacks used when tui-term is unavailable.
+;;
+;; Extracted from terminal.rkt for separation of concerns.
+
+(require racket/port
+         racket/string)
+
+;; Raw stdin reading (used by facade for input selection)
+(provide real-stdin-read-msg
+         stub-byte-ready?
+
+         ;; Raw message constructors (vectors, compatible with tui-term message API)
+         make-tkeymsg-raw
+         make-tsizemsg-raw
+         make-tmousemsg-raw
+
+         ;; Mouse event predicates and accessors
+         tmousemsg?
+         tmousemsg-cb
+         tmousemsg-cx
+         tmousemsg-cy
+
+         ;; UTF-8 support (compatibility stubs — tui-term handles UTF-8 internally)
+         utf8-high-byte?
+         utf8-lead-byte-count
+         utf8-continuation-byte?
+         reassemble-utf8-chars
+         utf8-accumulate-char
+         utf8-accumulator-reset!
+         utf8-accumulator-length)
+
+;; ============================================================
+;; UTF-8 support (compatibility stubs)
+;; ============================================================
+;; These functions were used with charterm which required manual
+;; UTF-8 handling. tui-term handles UTF-8 internally, so these
+;; are provided as stubs for backward compatibility.
+
+;; Check if a char represents a byte > 127 (UTF-8 lead or continuation)
+(define (utf8-high-byte? ch)
+  (and (char? ch) (> (char->integer ch) 127)))
+
+;; Determine the number of bytes in a UTF-8 sequence from the lead byte value.
+;; Returns 1 for ASCII/continuation, 2/3/4 for valid lead bytes.
+(define (utf8-lead-byte-count b)
+  (cond
+    [(<= b 127) 1] ; ASCII
+    [(<= 128 b 191) 1] ; continuation byte (0x80-0xBF)
+    [(<= 192 b 223) 2] ; 2-byte sequence (0xC0-0xDF)
+    [(<= 224 b 239) 3] ; 3-byte sequence (0xE0-0xEF)
+    [(<= 240 b 247) 4] ; 4-byte sequence (0xF0-0xF7)
+    [else 1]))
+
+;; Check if a byte value is a UTF-8 continuation byte (10xxxxxx = 0x80-0xBF)
+(define (utf8-continuation-byte? b)
+  (<= 128 b 191))
+
+;; Reassemble a list of chars (each representing a raw byte) into
+;; a single Unicode character using UTF-8 decoding.
+(define (reassemble-utf8-chars chars)
+  (define bytes-list (map char->integer chars))
+  (define raw-bytes (apply bytes bytes-list))
+  (with-handlers ([exn:fail? (lambda (e) #\?)])
+    (define str (bytes->string/utf-8 raw-bytes))
+    (if (> (string-length str) 0)
+        (string-ref str 0)
+        (integer->char 0))))
+
+;; UTF-8 accumulator state
+(define utf8-accumulator (list))
+
+;; Reset the accumulator
+(define (utf8-accumulator-reset!)
+  (set! utf8-accumulator (list)))
+
+;; Get current accumulator length (for testing)
+(define (utf8-accumulator-length)
+  (length utf8-accumulator))
+
+;; Feed a char to the accumulator.
+;; Returns:
+;;   - #f if the sequence is incomplete (need more bytes)
+;;   - char? if the sequence is complete and decoded
+(define (utf8-accumulate-char ch)
+  (set! utf8-accumulator (append utf8-accumulator (list ch)))
+  (define lead (car utf8-accumulator))
+  (define total (utf8-lead-byte-count (char->integer lead)))
+  (define n (length utf8-accumulator))
+  (cond
+    [(>= n total)
+     ;; Complete sequence — decode
+     (define decoded (reassemble-utf8-chars utf8-accumulator))
+     (set! utf8-accumulator (list))
+     decoded]
+    ;; Incomplete — need more bytes
+    [else #f]))
+
+;; ============================================================
+;; Raw message constructors (compatible with tkeymsg?/tsizemsg? predicates)
+;; ============================================================
+;; When tui-term is unavailable, we use simple vectors as message structs.
+
+(define (make-tkeymsg-raw key)
+  (vector 'tkeymsg key))
+
+(define (make-tsizemsg-raw cols rows)
+  (vector 'tsizemsg cols rows))
+
+(define (make-tmousemsg-raw cb cx cy)
+  (vector 'tmousemsg cb cx cy))
+
+;; ============================================================
+;; Mouse event predicates and accessors
+;; ============================================================
+
+(define (tmousemsg? msg)
+  (and (vector? msg) (eq? (vector-ref msg 0) 'tmousemsg)))
+
+(define (tmousemsg-cb msg)
+  (vector-ref msg 1))
+(define (tmousemsg-cx msg)
+  (vector-ref msg 2))
+(define (tmousemsg-cy msg)
+  (vector-ref msg 3))
+
+;; ============================================================
+;; ANSI escape sequence decoding
+;; ============================================================
+
+;; Decode a CSI sequence (ESC [ already consumed)
+(define (decode-csi-sequence in)
+  (sync/timeout 0.01 in) ;; wait briefly for rest of sequence
+  (define b (read-byte in))
+  (cond
+    [(eof-object? b) (make-tkeymsg-raw 'escape)]
+    [(= b 65) (make-tkeymsg-raw 'up)] ;; ESC[A
+    [(= b 66) (make-tkeymsg-raw 'down)] ;; ESC[B
+    [(= b 67) (make-tkeymsg-raw 'right)] ;; ESC[C
+    [(= b 68) (make-tkeymsg-raw 'left)] ;; ESC[D
+    [(= b 72) (make-tkeymsg-raw 'home)] ;; ESC[H
+    [(= b 70) (make-tkeymsg-raw 'end)] ;; ESC[F
+    [(= b 80) (make-tkeymsg-raw 'f1)] ;; ESC[P
+    [(= b 81) (make-tkeymsg-raw 'f2)] ;; ESC[Q
+    [(= b 82) (make-tkeymsg-raw 'f3)] ;; ESC[R
+    [(= b 83) (make-tkeymsg-raw 'f4)] ;; ESC[S
+    ;; ESC[1~ = home, ESC[4~ = end, ESC[5~ = pgup, ESC[6~ = pgdn
+    [(= b 49) (decode-csi-tilled in 'home)] ;; ESC[1
+    [(= b 52) (decode-csi-tilled in 'end)] ;; ESC[4
+    [(= b 53) (decode-csi-tilled in 'page-up)] ;; ESC[5
+    [(= b 54) (decode-csi-tilled in 'page-down)] ;; ESC[6
+    [(= b 50) (decode-csi-tilled in 'insert)] ;; ESC[2
+    [(= b 51) (decode-csi-tilled in 'delete)] ;; ESC[3
+    [(= b 77) ;; ESC[M — X10 mouse event
+     (sync/timeout 0.01 in)
+     (define cb (read-byte in))
+     (define cx (read-byte in))
+     (define cy (read-byte in))
+     (if (and (byte? cb) (byte? cx) (byte? cy))
+         (make-tmousemsg-raw cb cx cy)
+         (make-tkeymsg-raw 'escape))]
+    [else (make-tkeymsg-raw 'escape)]))
+
+;; Decode ESC[N~ style sequences (N already consumed)
+(define (decode-csi-tilled in default-key)
+  (sync/timeout 0.01 in)
+  (define b2 (read-byte in))
+  (cond
+    [(and (byte? b2) (= b2 126)) (make-tkeymsg-raw default-key)] ;; ~
+    [(and (byte? b2) (= b2 59)) ;; ; — modifier like ESC[1;5A
+     (sync/timeout 0.01 in)
+     (read-byte in) ;; skip modifier number
+     (sync/timeout 0.01 in)
+     (define b4 (read-byte in))
+     (cond
+       [(and (byte? b4) (= b4 65)) (make-tkeymsg-raw 'up)]
+       [(and (byte? b4) (= b4 66)) (make-tkeymsg-raw 'down)]
+       [(and (byte? b4) (= b4 67)) (make-tkeymsg-raw 'right)]
+       [(and (byte? b4) (= b4 68)) (make-tkeymsg-raw 'left)]
+       [(and (byte? b4) (= b4 72)) (make-tkeymsg-raw 'home)]
+       [(and (byte? b4) (= b4 70)) (make-tkeymsg-raw 'end)]
+       [else (make-tkeymsg-raw 'escape)])]
+    [else (make-tkeymsg-raw 'escape)]))
+
+;; ============================================================
+;; Raw stdin reading (when tui-term is unavailable)
+;; ============================================================
+
+;; Real stdin-based input when tui-term is unavailable.
+;; Reads raw bytes from stdin, decodes ANSI escape sequences,
+;; and returns tkeymsg/tsizemsg structs (as vectors).
+(define (real-stdin-read-msg #:timeout [timeout 0.20])
+  (define in (current-input-port))
+  (define result (sync/timeout timeout in))
+  (if (not result)
+      #f ;; timeout, no input
+      (let ([b (read-byte in)])
+        (cond
+          [(eof-object? b) #f]
+          [(= b 27) ;; ESC — could be escape sequence
+           (sync/timeout 0.01 in) ;; wait briefly for rest of sequence
+           (if (char-ready? in)
+               (let ([b2 (read-byte in)])
+                 (cond
+                   [(eof-object? b2) (make-tkeymsg-raw 'escape)]
+                   [(= b2 91) (decode-csi-sequence in)] ;; ESC[
+                   [else (make-tkeymsg-raw (integer->char b2))])) ;; Alt+key
+               (make-tkeymsg-raw 'escape))]
+          [(= b 13) (make-tkeymsg-raw 'return)]
+          [(= b 10) (make-tkeymsg-raw 'return)]
+          [(= b 127) (make-tkeymsg-raw 'backspace)]
+          [(= b 8) (make-tkeymsg-raw 'backspace)]
+          [(= b 3) (make-tkeymsg-raw 'ctrl-c)] ;; Ctrl-C → copy selection
+          ;; BUG-41: UTF-8 multi-byte sequence handling
+          ;; Lead bytes 0xC0+ start a multi-byte sequence.
+          ;; We use the existing utf8-accumulate-char accumulator
+          ;; to collect continuation bytes and decode.
+          [(>= b 192)
+           (utf8-accumulator-reset!)
+           (define lead-char (integer->char b))
+           (define total-bytes (utf8-lead-byte-count b))
+           (if (= total-bytes 1)
+               ;; Shouldn't happen for >= 192, but defensive
+               (make-tkeymsg-raw lead-char)
+               ;; Start accumulation, read remaining bytes
+               (let _loop ()
+                 (define decoded (utf8-accumulate-char lead-char))
+                 (cond
+                   [decoded (make-tkeymsg-raw decoded)]
+                   ;; Need more continuation bytes
+                   [else
+                    (sync/timeout 0.05 in)
+                    (if (char-ready? in)
+                        (let ([cb (read-byte in)])
+                          (if (and (byte? cb) (utf8-continuation-byte? cb))
+                              (begin
+                                (set! lead-char (integer->char cb))
+                                (_loop))
+                              ;; Unexpected byte — reset and return what we have
+                              (begin
+                                (utf8-accumulator-reset!)
+                                #f)))
+                        ;; Timeout waiting for continuation — reset
+                        (begin
+                          (utf8-accumulator-reset!)
+                          #f))])))]
+          [(>= b 128) #f] ;; Stray continuation byte (0x80-0xBF) — skip
+          [(>= b 32)
+           (utf8-accumulator-reset!)
+           (make-tkeymsg-raw (integer->char b))]
+          [else #f]))))
+
+(define (stub-byte-ready?)
+  (char-ready? (current-input-port)))

--- a/tui/terminal.rkt
+++ b/tui/terminal.rkt
@@ -1,453 +1,104 @@
 #lang racket/base
 
+;; tui/terminal.rkt — Thin terminal I/O facade
+;;
+;; Facade that re-exports everything from terminal-bridge and terminal-input,
+;; plus provides drawing primitives, style helpers, screen-size caching,
+;; lifecycle management, and key helpers.
+;;
+;; The public API (provide) is identical to the original monolithic module.
+
 (require racket/port
          racket/string
-         racket/list
-         racket/system
-         "clipboard.rkt")
+         "clipboard.rkt"
+         "terminal-bridge.rkt"
+         "terminal-input.rkt")
 
-;; tui/terminal.rkt — Thin terminal I/O adapter using tui-term
-;;
-;; This module replaces the charterm-based adapter with tui-term.
-;; It provides the same API as the original terminal.rkt so that
-;; the rest of the TUI continues to work without changes.
-;;
-;; tui-term handles UTF-8 internally, so we don't need the UTF-8
-;; accumulator logic that was required for charterm.
-;;
-;; NOTE: tui-term is a planned library. Currently, this module provides
-;; the API contract and stubs. When tui-term is available, the stubs
-;; can be replaced with actual implementations.
+;; Lifecycle
+(provide tui-term-open
+         tui-term-close
+         with-tui-terminal
 
-;; Stub structures for tui-term messages (used when library not available)
-;; Stub message structs (fallback when tui-term unavailable)
-;; Now using vectors for simplicity since tui-term is broken on Racket 8.10
+         ;; Query
+         tui-screen-size
+         tui-screen-size-cache-reset!
+         tui-screen-size-changed?
 
-;; Dynamic require tui-term if available
-(define tui-term-available?
-  (with-handlers ([exn:fail? (lambda (e) #f)])
-    (collection-path "tui")
-    #t))
+         ;; Drawing (compatibility - delegated to current term)
+         tui-clear-screen
+         tui-cursor
+         tui-display
+         tui-newline
+         tui-clear-line-right
+         tui-flush
 
-;; Dynamic requires (will be #f if not available)
-(define make-tty-term-fn
-  (and tui-term-available?
-       (with-handlers ([exn:fail? (lambda (e) #f)])
-         (dynamic-require 'tui/term 'make-tty-term))))
+         ;; Cursor visibility
+         tui-cursor-hide
+         tui-cursor-show
 
-(define term-alternate-screen-fn
-  (and tui-term-available?
-       (with-handlers ([exn:fail? (lambda (e) #f)])
-         (dynamic-require 'tui/term 'term-alternate-screen))))
+         ;; Styles (compatibility)
+         tui-normal
+         tui-bold
+         tui-inverse
+         tui-underline
+         tui-dim
+         tui-fg
 
-(define term-normal-screen-fn
-  (and tui-term-available?
-       (with-handlers ([exn:fail? (lambda (e) #f)])
-         (dynamic-require 'tui/term 'term-normal-screen))))
+         ;; Input
+         tui-read-key
+         tui-byte-ready?
 
-(define term-hide-cursor-fn
-  (and tui-term-available?
-       (with-handlers ([exn:fail? (lambda (e) #f)])
-         (dynamic-require 'tui/term 'term-hide-cursor))))
+         ;; Mouse tracking
+         enable-mouse-tracking
+         disable-mouse-tracking
 
-(define term-show-cursor-fn
-  (and tui-term-available?
-       (with-handlers ([exn:fail? (lambda (e) #f)])
-         (dynamic-require 'tui/term 'term-show-cursor))))
+         ;; Clipboard
+         clipboard-copy
+         osc-52-copy ;; internal, exported for testing
+         detect-clipboard-tool ;; exported for testing
+         clipboard-copy-via-tool ;; exported for testing
+         copy-text!
+         copy-selection!
+         clipboard-backend-available?
+         current-clipboard-mode
 
-(define term-close-fn
-  (and tui-term-available?
-       (with-handlers ([exn:fail? (lambda (e) #f)])
-         (dynamic-require 'tui/term 'term-close))))
+         ;; Mouse events
+         tmousemsg?
+         tmousemsg-cb
+         tmousemsg-cx
+         tmousemsg-cy
 
-(define current-term-size-fn
-  (and tui-term-available?
-       (with-handlers ([exn:fail? (lambda (e) #f)])
-         (dynamic-require 'tui/term 'current-term-size))))
+         ;; Key helpers
+         tui-key-char?
+         tui-key-char
+         tui-key-symbol
+         tui-keycode
 
-(define read-msg-fn
-  (and tui-term-available?
-       (with-handlers ([exn:fail? (lambda (e) #f)])
-         (dynamic-require 'tui/term/messages 'read-msg))))
+         ;; Message predicates and accessors (adapter pattern)
+         tkeymsg?
+         tkeymsg-key
+         tsizemsg?
+         tsizemsg-cols
+         tsizemsg-rows
+         tcmdmsg?
+         tcmdmsg-cmd
 
-(define byte-ready-fn
-  (and tui-term-available?
-       (with-handlers ([exn:fail? (lambda (e) #f)])
-         (dynamic-require 'tui/term/messages 'byte-ready?))))
-
-;; Dynamic require for message struct predicates and accessors
-(define tkeymsg?-fn
-  (and tui-term-available?
-       (with-handlers ([exn:fail? (lambda (e) #f)])
-         (dynamic-require 'tui/term/messages 'tkeymsg?))))
-
-(define tkeymsg-key-fn
-  (and tui-term-available?
-       (with-handlers ([exn:fail? (lambda (e) #f)])
-         (dynamic-require 'tui/term/messages 'tkeymsg-key))))
-
-(define tsizemsg?-fn
-  (and tui-term-available?
-       (with-handlers ([exn:fail? (lambda (e) #f)])
-         (dynamic-require 'tui/term/messages 'tsizemsg?))))
-
-(define tsizemsg-cols-fn
-  (and tui-term-available?
-       (with-handlers ([exn:fail? (lambda (e) #f)])
-         (dynamic-require 'tui/term/messages 'tsizemsg-cols))))
-
-(define tsizemsg-rows-fn
-  (and tui-term-available?
-       (with-handlers ([exn:fail? (lambda (e) #f)])
-         (dynamic-require 'tui/term/messages 'tsizemsg-rows))))
-
-(define tcmdmsg?-fn
-  (and tui-term-available?
-       (with-handlers ([exn:fail? (lambda (e) #f)])
-         (dynamic-require 'tui/term/messages 'tcmdmsg?))))
-
-(define tcmdmsg-cmd-fn
-  (and tui-term-available?
-       (with-handlers ([exn:fail? (lambda (e) #f)])
-         (dynamic-require 'tui/term/messages 'tcmdmsg-cmd))))
-
-(provide
- ;; Lifecycle
- tui-term-open
- tui-term-close
- with-tui-terminal
-
- ;; Query
- tui-screen-size
- tui-screen-size-cache-reset!
- tui-screen-size-changed?
-
- ;; Drawing (compatibility - delegated to current term)
- tui-clear-screen
- tui-cursor
- tui-display
- tui-newline
- tui-clear-line-right
- tui-flush
-
- ;; Cursor visibility
- tui-cursor-hide
- tui-cursor-show
-
- ;; Styles (compatibility)
- tui-normal
- tui-bold
- tui-inverse
- tui-underline
- tui-dim
- tui-fg
-
- ;; Input
- tui-read-key
- tui-byte-ready?
-
- ;; Mouse tracking
- enable-mouse-tracking
- disable-mouse-tracking
-
- ;; Clipboard
- clipboard-copy
- osc-52-copy ;; internal, exported for testing
- detect-clipboard-tool ;; exported for testing
- clipboard-copy-via-tool ;; exported for testing
- copy-text!
- copy-selection!
- clipboard-backend-available?
- current-clipboard-mode
-
- ;; Mouse events
- tmousemsg?
- tmousemsg-cb
- tmousemsg-cx
- tmousemsg-cy
-
- ;; Key helpers
- tui-key-char?
- tui-key-char
- tui-key-symbol
- tui-keycode
-
- ;; Message predicates and accessors (adapter pattern)
- tkeymsg?
- tkeymsg-key
- tsizemsg?
- tsizemsg-cols
- tsizemsg-rows
- tcmdmsg?
- tcmdmsg-cmd
-
- ;; UTF-8 support (compatibility stubs - tui-term handles UTF-8 internally)
- utf8-high-byte?
- utf8-lead-byte-count
- utf8-continuation-byte?
- reassemble-utf8-chars
- utf8-accumulate-char
- utf8-accumulator-reset!
- utf8-accumulator-length)
+         ;; UTF-8 support (compatibility stubs - tui-term handles UTF-8 internally)
+         utf8-high-byte?
+         utf8-lead-byte-count
+         utf8-continuation-byte?
+         reassemble-utf8-chars
+         utf8-accumulate-char
+         utf8-accumulator-reset!
+         utf8-accumulator-length)
 
 ;; ============================================================
-;; tui-term stubs (when library not available)
+;; Input selection (bridge between terminal-bridge and terminal-input)
 ;; ============================================================
 
-(define (stub-make-tty-term #:tty [tty #f])
-  ;; Put tty into raw mode so we can read individual keypresses.
-  ;; Use system() so stty operates on the inherited terminal fd.
-  ;; subprocess() doesn't inherit the controlling terminal properly.
-  (with-handlers ([exn:fail? void])
-    (system "stty raw -echo -icanon < /dev/tty 2>/dev/null"))
-  (gensym 'stub-term))
+(define read-msg (or read-msg-fn real-stdin-read-msg))
 
-(define (stub-term-alternate-screen term)
-  (display "\x1b[?1049h")
-  (flush-output))
-
-(define (stub-term-normal-screen term)
-  (display "\x1b[?1049l")
-  (flush-output))
-
-(define (stub-term-hide-cursor term)
-  (display "\x1b[?25l")
-  (flush-output))
-
-(define (stub-term-show-cursor term)
-  (display "\x1b[?25h")
-  (flush-output))
-
-(define (stub-term-close term)
-  ;; Restore tty to sane mode
-  (with-handlers ([exn:fail? void])
-    (system "stty sane < /dev/tty 2>/dev/null")))
-
-(define (stub-current-term-size)
-  ;; Try environment variables first (set by shell in most terminals)
-  (define env-cols (and (getenv "COLUMNS")
-                        (string->number (getenv "COLUMNS"))))
-  (define env-rows (and (getenv "LINES")
-                        (string->number (getenv "LINES"))))
-  (if (and env-cols env-rows (> env-cols 0) (> env-rows 0))
-      (values env-cols env-rows)
-      ;; Fallback: try stty size
-      ;; Uses dynamic-wind to guarantee port cleanup and prevent fd leaks.
-      ;; Previously leaked 3 fds per call → fd exhaustion after ~700 calls →
-      ;; subprocess failed → hardcoded 80x24 fallback.
-      (let ([result-cols 80] [result-rows 24])
-        (define-values (sp stty-out stty-in stty-err)
-          (with-handlers ([exn:fail? (lambda (e) (values #f #f #f #f))])
-            (subprocess #f #f #f "/bin/sh" "-c" "stty size < /dev/tty 2>/dev/null")))
-        (dynamic-wind
-          (lambda () (void))
-          (lambda ()
-            (when stty-in (close-output-port stty-in))
-            (when stty-out
-              (let* ([out-str (port->string stty-out)]
-                     [parts (string-split out-str)])
-                (when (= (length parts) 2)
-                  (set! result-cols (string->number (second parts)))
-                  (set! result-rows (string->number (first parts)))))))
-          (lambda ()
-            (when stty-out (close-input-port stty-out))
-            (when stty-err (close-input-port stty-err))
-            (when sp (sync/timeout 1.0 sp))))
-        (values result-cols result-rows))))
-
-;; Real stdin-based input when tui-term is unavailable.
-;; Reads raw bytes from stdin, decodes ANSI escape sequences,
-;; and returns tkeymsg/tsizemsg structs (as vectors).
-(define (real-stdin-read-msg #:timeout [timeout 0.20])
-  (define in (current-input-port))
-  (define result (sync/timeout timeout in))
-  (if (not result)
-      #f  ;; timeout, no input
-      (let ([b (read-byte in)])
-        (cond
-          [(eof-object? b) #f]
-          [(= b 27)  ;; ESC — could be escape sequence
-           (sync/timeout 0.01 in)  ;; wait briefly for rest of sequence
-           (if (char-ready? in)
-               (let ([b2 (read-byte in)])
-                 (cond
-                   [(eof-object? b2) (make-tkeymsg-raw 'escape)]
-                   [(= b2 91) (decode-csi-sequence in)]  ;; ESC[
-                   [else (make-tkeymsg-raw (integer->char b2))]))  ;; Alt+key
-               (make-tkeymsg-raw 'escape))]
-          [(= b 13) (make-tkeymsg-raw 'return)]
-          [(= b 10) (make-tkeymsg-raw 'return)]
-          [(= b 127) (make-tkeymsg-raw 'backspace)]
-          [(= b 8) (make-tkeymsg-raw 'backspace)]
-          [(= b 3) (make-tkeymsg-raw 'ctrl-c)]  ;; Ctrl-C → copy selection
-          ;; BUG-41: UTF-8 multi-byte sequence handling
-          ;; Lead bytes 0xC0+ start a multi-byte sequence.
-          ;; We use the existing utf8-accumulate-char accumulator
-          ;; to collect continuation bytes and decode.
-          [(>= b 192)
-           (utf8-accumulator-reset!)
-           (define lead-char (integer->char b))
-           (define total-bytes (utf8-lead-byte-count b))
-           (if (= total-bytes 1)
-               ;; Shouldn't happen for >= 192, but defensive
-               (make-tkeymsg-raw lead-char)
-               ;; Start accumulation, read remaining bytes
-               (let _loop ()
-                 (define decoded (utf8-accumulate-char lead-char))
-                 (cond
-                   [decoded (make-tkeymsg-raw decoded)]
-                   ;; Need more continuation bytes
-                   [else
-                    (sync/timeout 0.05 in)
-                    (if (char-ready? in)
-                        (let ([cb (read-byte in)])
-                          (if (and (byte? cb) (utf8-continuation-byte? cb))
-                              (begin
-                                (set! lead-char (integer->char cb))
-                                (_loop))
-                              ;; Unexpected byte — reset and return what we have
-                              (begin
-                                (utf8-accumulator-reset!)
-                                #f)))
-                        ;; Timeout waiting for continuation — reset
-                        (begin
-                          (utf8-accumulator-reset!)
-                          #f))])))]
-          [(>= b 128) #f]  ;; Stray continuation byte (0x80-0xBF) — skip
-          [(>= b 32) (utf8-accumulator-reset!) (make-tkeymsg-raw (integer->char b))]
-          [else #f]))))
-
-;; Decode a CSI sequence (ESC [ already consumed)
-(define (decode-csi-sequence in)
-  (sync/timeout 0.01 in)  ;; wait briefly for rest of sequence
-  (define b (read-byte in))
-  (cond
-    [(eof-object? b) (make-tkeymsg-raw 'escape)]
-    [(= b 65) (make-tkeymsg-raw 'up)]          ;; ESC[A
-    [(= b 66) (make-tkeymsg-raw 'down)]        ;; ESC[B
-    [(= b 67) (make-tkeymsg-raw 'right)]       ;; ESC[C
-    [(= b 68) (make-tkeymsg-raw 'left)]        ;; ESC[D
-    [(= b 72) (make-tkeymsg-raw 'home)]        ;; ESC[H
-    [(= b 70) (make-tkeymsg-raw 'end)]         ;; ESC[F
-    [(= b 80) (make-tkeymsg-raw 'f1)]          ;; ESC[P
-    [(= b 81) (make-tkeymsg-raw 'f2)]          ;; ESC[Q
-    [(= b 82) (make-tkeymsg-raw 'f3)]          ;; ESC[R
-    [(= b 83) (make-tkeymsg-raw 'f4)]          ;; ESC[S
-    ;; ESC[1~ = home, ESC[4~ = end, ESC[5~ = pgup, ESC[6~ = pgdn
-    [(= b 49) (decode-csi-tilled in 'home)]   ;; ESC[1
-    [(= b 52) (decode-csi-tilled in 'end)]    ;; ESC[4
-    [(= b 53) (decode-csi-tilled in 'page-up)] ;; ESC[5
-    [(= b 54) (decode-csi-tilled in 'page-down)] ;; ESC[6
-    [(= b 50) (decode-csi-tilled in 'insert)] ;; ESC[2
-    [(= b 51) (decode-csi-tilled in 'delete)] ;; ESC[3
-    [(= b 77)  ;; ESC[M — X10 mouse event
-     (sync/timeout 0.01 in)
-     (define cb (read-byte in))
-     (define cx (read-byte in))
-     (define cy (read-byte in))
-     (if (and (byte? cb) (byte? cx) (byte? cy))
-         (make-tmousemsg-raw cb cx cy)
-         (make-tkeymsg-raw 'escape))]
-    [else (make-tkeymsg-raw 'escape)]))
-
-;; Decode ESC[N~ style sequences (N already consumed)
-(define (decode-csi-tilled in default-key)
-  (sync/timeout 0.01 in)
-  (define b2 (read-byte in))
-  (cond
-    [(and (byte? b2) (= b2 126)) (make-tkeymsg-raw default-key)]  ;; ~
-    [(and (byte? b2) (= b2 59))  ;; ; — modifier like ESC[1;5A
-     (sync/timeout 0.01 in)
-     (read-byte in)  ;; skip modifier number
-     (sync/timeout 0.01 in)
-     (define b4 (read-byte in))
-     (cond [(and (byte? b4) (= b4 65)) (make-tkeymsg-raw 'up)]
-           [(and (byte? b4) (= b4 66)) (make-tkeymsg-raw 'down)]
-           [(and (byte? b4) (= b4 67)) (make-tkeymsg-raw 'right)]
-           [(and (byte? b4) (= b4 68)) (make-tkeymsg-raw 'left)]
-           [(and (byte? b4) (= b4 72)) (make-tkeymsg-raw 'home)]
-           [(and (byte? b4) (= b4 70)) (make-tkeymsg-raw 'end)]
-           [else (make-tkeymsg-raw 'escape)])]
-    [else (make-tkeymsg-raw 'escape)]))
-
-;; Raw message constructors (compatible with tkeymsg?/tsizemsg? predicates)
-;; When tui-term is unavailable, we use simple vectors as message structs
-(define (make-tkeymsg-raw key)
-  (vector 'tkeymsg key))
-
-(define (make-tsizemsg-raw cols rows)
-  (vector 'tsizemsg cols rows))
-
-(define (make-tmousemsg-raw cb cx cy)
-  (vector 'tmousemsg cb cx cy))
-
-(define (tmousemsg? msg)
-  (and (vector? msg) (eq? (vector-ref msg 0) 'tmousemsg)))
-
-(define (tmousemsg-cb msg) (vector-ref msg 1))
-(define (tmousemsg-cx msg) (vector-ref msg 2))
-(define (tmousemsg-cy msg) (vector-ref msg 3))
-
-(define (stub-byte-ready?)
-  (char-ready? (current-input-port)))
-
-;; ============================================================
-;; Select actual or stub implementations
-;; ============================================================
-
-(define make-tty-term
-  (or make-tty-term-fn stub-make-tty-term))
-
-(define term-alternate-screen
-  (or term-alternate-screen-fn stub-term-alternate-screen))
-
-(define term-normal-screen
-  (or term-normal-screen-fn stub-term-normal-screen))
-
-(define term-hide-cursor
-  (or term-hide-cursor-fn stub-term-hide-cursor))
-
-(define term-show-cursor
-  (or term-show-cursor-fn stub-term-show-cursor))
-
-(define term-close
-  (or term-close-fn stub-term-close))
-
-(define current-term-size
-  (or current-term-size-fn stub-current-term-size))
-
-(define read-msg
-  (or read-msg-fn real-stdin-read-msg))
-
-(define byte-ready?
-  (or byte-ready-fn stub-byte-ready?))
-
-;; Message struct bindings — dispatch to real tui-term or vector fallback
-(define (tkeymsg? msg)
-  (or (and tkeymsg?-fn (tkeymsg?-fn msg))
-      (and (vector? msg) (eq? (vector-ref msg 0) 'tkeymsg))))
-(define (tkeymsg-key msg)
-  (if (and tkeymsg-key-fn (tkeymsg?-fn msg))
-      (tkeymsg-key-fn msg)
-      (vector-ref msg 1)))
-(define (tsizemsg? msg)
-  (or (and tsizemsg?-fn (tsizemsg?-fn msg))
-      (and (vector? msg) (eq? (vector-ref msg 0) 'tsizemsg))))
-(define (tsizemsg-cols msg)
-  (if (and tsizemsg-cols-fn (tsizemsg?-fn msg))
-      (tsizemsg-cols-fn msg)
-      (vector-ref msg 1)))
-(define (tsizemsg-rows msg)
-  (if (and tsizemsg-rows-fn (tsizemsg?-fn msg))
-      (tsizemsg-rows-fn msg)
-      (vector-ref msg 2)))
-(define (tcmdmsg? msg)
-  (or (and tcmdmsg?-fn (tcmdmsg?-fn msg))
-      (and (vector? msg) (eq? (vector-ref msg 0) 'tcmdmsg))))
-(define (tcmdmsg-cmd msg)
-  (if (and tcmdmsg-cmd-fn (tcmdmsg?-fn msg))
-      (tcmdmsg-cmd-fn msg)
-      (vector-ref msg 1)))
+(define byte-ready? (or byte-ready-fn stub-byte-ready?))
 
 ;; ============================================================
 ;; Lifecycle
@@ -471,13 +122,15 @@
 ;; Macro for safe terminal usage with cleanup.
 (define-syntax-rule (with-tui-terminal body ...)
   (let ([term (make-tty-term)])
-    (dynamic-wind
-      (lambda () (term-alternate-screen term) (term-hide-cursor term))
-      (lambda () body ...)
-      (lambda ()
-        (with-handlers ([exn:fail? (lambda (e) (void))])
-          (term-show-cursor term)
-          (term-normal-screen term))))))
+    (dynamic-wind (lambda ()
+                    (term-alternate-screen term)
+                    (term-hide-cursor term))
+                  (lambda ()
+                    body ...)
+                  (lambda ()
+                    (with-handlers ([exn:fail? (lambda (e) (void))])
+                      (term-show-cursor term)
+                      (term-normal-screen term))))))
 
 ;; ============================================================
 ;; Screen size (cached)
@@ -487,8 +140,8 @@
 (define screen-size-cache-cols #f)
 (define screen-size-cache-rows #f)
 (define screen-size-cache-time 0)
-(define screen-size-cache-ttl 0.1)  ;; re-query every 100ms for responsive resize
-(define screen-size-last-cols #f)  ;; for resize detection
+(define screen-size-cache-ttl 0.1) ;; re-query every 100ms for responsive resize
+(define screen-size-last-cols #f) ;; for resize detection
 (define screen-size-last-rows #f)
 
 (define (tui-screen-size-cache-reset!)
@@ -523,8 +176,7 @@
      (set! screen-size-last-cols cols)
      (set! screen-size-last-rows rows)
      #t]
-    [(and (= cols screen-size-last-cols) (= rows screen-size-last-rows))
-     #f]
+    [(and (= cols screen-size-last-cols) (= rows screen-size-last-rows)) #f]
     [else
      (set! screen-size-last-cols cols)
      (set! screen-size-last-rows rows)
@@ -591,8 +243,14 @@
 (define (tui-fg color)
   (define code
     (case color
-      [(black) 30] [(red) 31] [(green) 32] [(yellow) 33]
-      [(blue) 34] [(magenta) 35] [(cyan) 36] [(white) 37]
+      [(black) 30]
+      [(red) 31]
+      [(green) 32]
+      [(yellow) 33]
+      [(blue) 34]
+      [(magenta) 35]
+      [(cyan) 36]
+      [(white) 37]
       [else 37]))
   (display (format "\x1b[~am" code)))
 
@@ -647,8 +305,8 @@
   ;; Button-event tracking (mode 1002): reports press, drag, and release.
   ;; This is needed for text selection via click-drag.
   ;; We do NOT use SGR-Pixel (1006) — only X10 format is decoded.
-  (display "\x1b[?1000h")  ;; basic tracking as fallback
-  (display "\x1b[?1002h")  ;; button-event tracking (press + drag + release)
+  (display "\x1b[?1000h") ;; basic tracking as fallback
+  (display "\x1b[?1002h") ;; button-event tracking (press + drag + release)
   (flush-output))
 
 (define (disable-mouse-tracking)
@@ -656,7 +314,11 @@
   (display "\x1b[?1000l")
   (flush-output))
 
-;; Clipboard functions are now in clipboard.rkt
+;; ============================================================
+;; Clipboard backward-compatible wrapper
+;; ============================================================
+
+;; Clipboard functions are in clipboard.rkt.
 ;; Re-exported for backward compatibility:
 ;;   detect-clipboard-tool, clipboard-copy-via-tool, osc-52-copy
 ;; clipboard-copy is replaced by copy-text! from clipboard.rkt
@@ -677,73 +339,3 @@
 
 (define (tui-key-symbol keycode)
   keycode)
-
-;; ============================================================
-;; UTF-8 support (compatibility stubs)
-;; ============================================================
-;; These functions were used with charterm which required manual
-;; UTF-8 handling. tui-term handles UTF-8 internally, so these
-;; are provided as stubs for backward compatibility.
-
-;; Check if a char represents a byte > 127 (UTF-8 lead or continuation)
-(define (utf8-high-byte? ch)
-  (and (char? ch)
-       (> (char->integer ch) 127)))
-
-;; Determine the number of bytes in a UTF-8 sequence from the lead byte value.
-;; Returns 1 for ASCII/continuation, 2/3/4 for valid lead bytes.
-(define (utf8-lead-byte-count b)
-  (cond
-    [(<= b 127) 1]                          ; ASCII
-    [(<= 128 b 191) 1]                      ; continuation byte (0x80-0xBF)
-    [(<= 192 b 223) 2]                      ; 2-byte sequence (0xC0-0xDF)
-    [(<= 224 b 239) 3]                      ; 3-byte sequence (0xE0-0xEF)
-    [(<= 240 b 247) 4]                      ; 4-byte sequence (0xF0-0xF7)
-    [else 1]))
-
-;; Check if a byte value is a UTF-8 continuation byte (10xxxxxx = 0x80-0xBF)
-(define (utf8-continuation-byte? b)
-  (<= 128 b 191))
-
-;; Reassemble a list of chars (each representing a raw byte) into
-;; a single Unicode character using UTF-8 decoding.
-(define (reassemble-utf8-chars chars)
-  (define bytes-list (map char->integer chars))
-  (define raw-bytes (apply bytes bytes-list))
-  (with-handlers ([exn:fail? (lambda (e) #\?)])
-    (define str (bytes->string/utf-8 raw-bytes))
-    (if (> (string-length str) 0)
-        (string-ref str 0)
-        (integer->char 0))))
-
-;; UTF-8 accumulator state (stub - no longer needed with tui-term)
-(define utf8-accumulator (list))
-
-;; Reset the accumulator
-(define (utf8-accumulator-reset!)
-  (set! utf8-accumulator (list)))
-
-;; Get current accumulator length (for testing)
-(define (utf8-accumulator-length)
-  (length utf8-accumulator))
-
-;; Feed a char to the accumulator.
-;; Returns:
-;;   - #f if the sequence is incomplete (need more bytes)
-;;   - char? if the sequence is complete and decoded
-(define (utf8-accumulate-char ch)
-  (set! utf8-accumulator (append utf8-accumulator (list ch)))
-  (define lead (car utf8-accumulator))
-  (define total (utf8-lead-byte-count (char->integer lead)))
-  (define n (length utf8-accumulator))
-  (cond
-    [(>= n total)
-     ;; Complete sequence — decode
-     (define decoded (reassemble-utf8-chars utf8-accumulator))
-     (set! utf8-accumulator (list))
-     decoded]
-    [else
-     ;; Incomplete — need more bytes
-     #f]))
-
-;; ============================================================


### PR DESCRIPTION
## Issues: #299 #300 #301 #302

### QUAL-11 (#300): Split tui/terminal.rkt (749→341 lines)
- New terminal-bridge.rkt (251 lines): tui-term dynamic loading + stubs
- New terminal-input.rkt (259 lines): ANSI key decoding, stdin reading
- terminal.rkt now thin facade, all 42 bindings preserved

### ARCH-05 (#301): Decompose run-prompt!
- Extract build-session-context, maybe-compact-context, dispatch-iteration
- run-prompt! now ~25-line orchestrator

### QUAL-12 (#302): Data-driven CLI flag parsing
- flag-def struct + FLAG-DEFINITIONS (14 flags)
- Generic parser replaces 15 cond branches
- 167 CLI tests pass

Closes #299 Closes #300 Closes #301 Closes #302