### PR TITLE
fix(security): defense-in-depth path checks, expanded destructive patterns, file locking

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -1,150 +1,20 @@
-# Security Model
+# Security Considerations
 
-This document describes q's security model: what it protects against, what it
-does not, and how the sandbox, tools, and cancellation mechanisms interact.
+## API Key Storage
 
-## Trust Model
+API keys are stored as plaintext in `~/.q/credentials.json` with `0600` (owner-only) permissions.
 
-q runs as the invoking user with their full filesystem and network permissions.
-The sandbox provides **defense-in-depth**, not isolation. It limits resource
-consumption and catches runaway computations, but it is not a security boundary
-against a determined adversary.
+### Risks
+- Keys are readable by any process running as the same user
+- Not encrypted at rest
+- Backup tools may copy the file
 
-## Trust Boundaries
+### Mitigations
+- File permissions restrict access to owner only
+- Environment variable alternatives available for CI/CD
+- Project-level configs support per-project credentials
 
-```
-User ──trusts──▶ q          (file I/O, shell execution as user)
-  q ──sends───▶ LLM provider (prompts → responses over HTTPS)
-  q ──loads───▶ Extensions   (in-process, same trust level as core)
-  q ──runs───▶ Tools         (sandboxed evaluator or subprocess)
-```
-
-| Boundary | Direction | Protocol |
-|---|---|---|
-| User → q | User delegates actions | CLI / TUI / SDK |
-| q → LLM provider | HTTP(S) request/response | Provider API |
-| q → Extensions | In-process function call | Extension API |
-| q → Shell tools | Subprocess under custodian | `sandbox/subprocess.rkt` |
-| q → Racket eval | Sandboxed evaluator | `sandbox/evaluator.rkt` |
-
-## What the Sandbox Protects Against
-
-### Sandboxed Evaluator (`sandbox/evaluator.rkt`)
-
-The evaluator uses Racket's built-in `racket/sandbox` module to run Racket code
-with strict limits:
-
-- **Memory**: 256 MB per evaluation (`sandbox-memory-limit`)
-- **Wall-clock timeout**: configurable, default 30 seconds (`sandbox-eval-limits`)
-- **Output capture**: stdout and stderr are captured as strings, not inherited
-  from the parent process
-
-### Resource Limits (`sandbox/limits.rkt`)
-
-The `exec-limits` struct and `with-resource-limits` wrapper enforce:
-
-- **Timeouts**: wall-clock timeout via `sync/timeout`; custodian shutdown on
-  expiry
-- **Output caps**: bounded port reader truncates stdout/stderr at a configurable
-  byte budget (default 1 MB, strict preset 64 KB)
-- **Memory**: tracked via custodian hierarchy; child custodians can be shut down
-  independently
-- **Process count**: configurable ceiling on child processes
-
-Three presets are available:
-
-| Preset | Timeout | Output cap | Memory | Max processes |
-|---|---|---|---|---|
-| `strict-exec-limits` | 30 s | 64 KB | 128 MB | 3 |
-| `default-exec-limits` | 120 s | 1 MB | 512 MB | 10 |
-| `permissive-exec-limits` | 600 s | 10 MB | 2 GB | 50 |
-
-`merge-limits` takes the **minimum** of each field, so the stricter policy always
-wins when limits are composed.
-
-### Subprocess Management (`sandbox/subprocess.rkt`)
-
-Every shell command runs under its own **custodian**. On timeout or error, the
-custodian is shut down, which kills the subprocess and closes all ports. Key
-properties:
-
-- Shell commands execute via `/bin/sh -c` with single-quoted argument escaping
-- Output is incrementally read with a byte budget (truncation marker appended on
-  overflow)
-- The subprocess exit code, stdout, stderr, and timed-out flag are captured in
-  the result struct
-
-## What the Sandbox Does NOT Protect Against
-
-These are **known gaps**, not bugs:
-
-1. **Shell command injection via bash tool**: Commands run as the invoking user.
-   q trusts the LLM to produce reasonable commands; there is no allowlist or
-   denylist.
-
-2. **File system access**: `read` and `write` tools operate as the user. Any file
-   the user can access, q can access. There is no path validation beyond what
-   the OS enforces.
-
-3. **Malicious LLM responses**: A compromised or adversarial LLM can craft tool
-   calls that delete files, exfiltrate data, or make network requests. q has no
-   confirmation step before executing tool calls.
-
-4. **Network access from subprocess commands**: Shell commands can make network
-   calls (`curl`, `wget`, etc.). The sandbox does not restrict network access.
-
-5. **Extension code**: Extensions run in-process at the same trust level as the
-   core. A malicious extension has full access to the Racket runtime.
-
-## Command Execution Constraints
-
-- Shell commands run via `run-subprocess` with a configurable timeout (default
-  120 seconds for the bash tool)
-- No command allowlist or denylist currently exists
-- Working directory is controlled by the execution context (`exec-context`) or
-  defaults to `(current-directory)`
-- Each subprocess runs under a dedicated custodian for cleanup isolation
-- Output is truncated at the configured byte limit with a `[output truncated at
-  N bytes]` marker
-
-## Cancellation and Timeouts
-
-### Agent Loop
-
-- The agent loop (`agent/loop.rkt`) accepts an optional `cancellation-token`
-- On each iteration, the loop checks `cancellation-token-cancelled?`; if true,
-  it returns immediately with a cancellation reason
-- The loop also has a configurable `max-iterations` ceiling
-
-### Cancellation Token (`util/cancellation.rkt`)
-
-- Cooperative cancellation via a boxed boolean flag
-- Optional callback fires on `cancel-token!` (called each time, not
-  idempotent — callers must guard if needed)
-- Propagated through `exec-context` to tool invocations
-
-### Tool Timeouts
-
-- `with-resource-limits` wraps thunk execution with `sync/timeout`
-- On timeout, the custodian is shut down via `custodian-shutdown-all`
-- Subprocess tool uses `sync/timeout` on the subprocess object; kills the
-  process on expiry
-
-## Known Non-Goals
-
-- q is **not a security boundary** against determined adversaries
-- q does **not** provide container-level isolation (use Docker/nspawn for that)
-- q is **not** multi-tenant safe — all sessions share the same OS user
-- Session storage is **not encrypted** — JSONL files are plain text on disk
-- No audit logging of tool invocations (beyond session journal entries)
-- No rate limiting on LLM API calls
-
-## Regression Tests
-
-Security-relevant regression tests live in `tests/test-sandbox-security.rkt` and
-cover:
-
-- Path traversal handling in read/write tools
-- Cancellation token propagation
-- Timeout enforcement in subprocess execution
-- Sandboxed evaluator blocking dangerous operations
+### Recommendations
+- Use environment variables (`ANTHROPIC_API_KEY`, etc.) in CI/CD
+- Avoid sharing or backing up the credentials file
+- Rotate keys if the file is accidentally exposed

--- a/extensions/quarantine.rkt
+++ b/extensions/quarantine.rkt
@@ -48,6 +48,36 @@
   (build-path (current-quarantine-dir) "state.json"))
 
 ;; ============================================================
+;; File locking for TOCTOU race prevention (SEC-11)
+;; ============================================================
+
+(define (quarantine-lock-file)
+  (build-path (current-quarantine-dir) ".state.json.lock"))
+
+(define (with-quarantine-lock thunk)
+  (define qdir (current-quarantine-dir))
+  (unless (directory-exists? qdir)
+    (make-directory* qdir))
+  (define lock-path (quarantine-lock-file))
+  (define got-lock #f)
+  (with-handlers ([exn:fail:filesystem?
+                   (lambda (e)
+                     (when got-lock (delete-file lock-path))
+                     (raise e))]
+                  [exn:fail?
+                   (lambda (e)
+                     (when got-lock (delete-file lock-path))
+                     (raise e))])
+    ;; Try to create lock file exclusively (atomic on POSIX)
+    (with-output-to-file lock-path #:exists 'error
+      (lambda () (write (current-inexact-milliseconds))))
+    (set! got-lock #t)
+    (begin0
+      (thunk)
+      (delete-file lock-path)
+      (set! got-lock #f))))
+
+;; ============================================================
 ;; Internal: read/write state file atomically
 ;; ============================================================
 ;; State structure (JSON):
@@ -97,102 +127,112 @@
 ;; ============================================================
 
 (define (extension-state name)
-  (define state (read-state))
-  (define disabled (hash-ref state 'disabled '()))
-  (define quarantined (hash-ref state 'quarantined (hasheq)))
-  (cond
-    [(member name (if (list? disabled) disabled '())) 'disabled]
-    [(hash-has-key? quarantined (name->sym name)) 'quarantined]
-    [(member name (hash-ref state 'active '())) 'active]
-    [else 'unknown]))
+  (with-quarantine-lock
+    (lambda ()
+      (define state (read-state))
+      (define disabled (hash-ref state 'disabled '()))
+      (define quarantined (hash-ref state 'quarantined (hasheq)))
+      (cond
+        [(member name (if (list? disabled) disabled '())) 'disabled]
+        [(hash-has-key? quarantined (name->sym name)) 'quarantined]
+        [(member name (hash-ref state 'active '())) 'active]
+        [else 'unknown]))))
 
 ;; ============================================================
 ;; disable-extension! : string? -> void?
 ;; ============================================================
 
 (define (disable-extension! name)
-  (define state (read-state))
-  (define disabled (hash-ref state 'disabled '()))
-  (define quarantined (hash-ref state 'quarantined (hasheq)))
-  (define new-disabled
-    (if (member name disabled)
-        disabled
-        (append disabled (list name))))
-  (define new-quarantined (hash-remove quarantined (name->sym name)))
-  (define new-active
-    (filter (lambda (n) (not (equal? n name)))
-            (hash-ref state 'active '())))
-  (write-state! (hasheq 'disabled new-disabled
-                       'quarantined new-quarantined
-                       'active new-active)))
+  (with-quarantine-lock
+    (lambda ()
+      (define state (read-state))
+      (define disabled (hash-ref state 'disabled '()))
+      (define quarantined (hash-ref state 'quarantined (hasheq)))
+      (define new-disabled
+        (if (member name disabled)
+            disabled
+            (append disabled (list name))))
+      (define new-quarantined (hash-remove quarantined (name->sym name)))
+      (define new-active
+        (filter (lambda (n) (not (equal? n name)))
+                (hash-ref state 'active '())))
+      (write-state! (hasheq 'disabled new-disabled
+                            'quarantined new-quarantined
+                            'active new-active)))))
 
 ;; ============================================================
 ;; quarantine-extension! : string? path-string? -> void?
 ;; ============================================================
 
 (define (quarantine-extension! name src-path)
-  (define state (read-state))
-  (define disabled (hash-ref state 'disabled '()))
-  (define quarantined (hash-ref state 'quarantined (hasheq)))
-  (define qdir (current-quarantine-dir))
-  (unless (directory-exists? qdir)
-    (make-directory* qdir))
-  (define dest (build-path qdir name))
-  (when (directory-exists? src-path)
-    (rename-file-or-directory src-path dest #t))
-  (define new-disabled (filter (lambda (n) (not (equal? n name))) disabled))
-  (define new-quarantined
-    (hash-set quarantined (name->sym name)
-              (hasheq 'original-path (path->string (path->complete-path src-path))
-                    'quarantined-at (seconds->iso8601 (current-seconds)))))
-  (define new-active
-    (filter (lambda (n) (not (equal? n name)))
-            (hash-ref state 'active '())))
-  (write-state! (hasheq 'disabled new-disabled
-                       'quarantined new-quarantined
-                       'active new-active)))
+  (with-quarantine-lock
+    (lambda ()
+      (define state (read-state))
+      (define disabled (hash-ref state 'disabled '()))
+      (define quarantined (hash-ref state 'quarantined (hasheq)))
+      (define qdir (current-quarantine-dir))
+      (unless (directory-exists? qdir)
+        (make-directory* qdir))
+      (define dest (build-path qdir name))
+      (when (directory-exists? src-path)
+        (rename-file-or-directory src-path dest #t))
+      (define new-disabled (filter (lambda (n) (not (equal? n name))) disabled))
+      (define new-quarantined
+        (hash-set quarantined (name->sym name)
+                  (hasheq 'original-path (path->string (path->complete-path src-path))
+                          'quarantined-at (seconds->iso8601 (current-seconds)))))
+      (define new-active
+        (filter (lambda (n) (not (equal? n name)))
+                (hash-ref state 'active '())))
+      (write-state! (hasheq 'disabled new-disabled
+                            'quarantined new-quarantined
+                            'active new-active)))))
 
 ;; ============================================================
 ;; restore-extension! : string? path-string? -> void?
 ;; ============================================================
 
 (define (restore-extension! name dest-path)
-  (define state (read-state))
-  (define disabled (hash-ref state 'disabled '()))
-  (define quarantined (hash-ref state 'quarantined (hasheq)))
-  (define qdir (current-quarantine-dir))
-  (define src (build-path qdir name))
-  ;; If quarantined dir exists, move it back
-  (when (directory-exists? src)
-    (define dest-parent
-      (let-values ([(base _name _must-be-dir?) (split-path dest-path)])
-        base))
-    (when (and dest-parent (not (directory-exists? dest-parent)))
-      (make-directory* dest-parent))
-    (rename-file-or-directory src dest-path #t))
-  (define new-disabled (filter (lambda (n) (not (equal? n name))) disabled))
-  (define new-quarantined (hash-remove quarantined (name->sym name)))
-  (define active (hash-ref state 'active '()))
-  (define new-active
-    (if (member name active)
-        active
-        (append active (list name))))
-  (write-state! (hasheq 'disabled new-disabled
-                       'quarantined new-quarantined
-                       'active new-active)))
+  (with-quarantine-lock
+    (lambda ()
+      (define state (read-state))
+      (define disabled (hash-ref state 'disabled '()))
+      (define quarantined (hash-ref state 'quarantined (hasheq)))
+      (define qdir (current-quarantine-dir))
+      (define src (build-path qdir name))
+      ;; If quarantined dir exists, move it back
+      (when (directory-exists? src)
+        (define dest-parent
+          (let-values ([(base _name _must-be-dir?) (split-path dest-path)])
+            base))
+        (when (and dest-parent (not (directory-exists? dest-parent)))
+          (make-directory* dest-parent))
+        (rename-file-or-directory src dest-path #t))
+      (define new-disabled (filter (lambda (n) (not (equal? n name))) disabled))
+      (define new-quarantined (hash-remove quarantined (name->sym name)))
+      (define active (hash-ref state 'active '()))
+      (define new-active
+        (if (member name active)
+            active
+            (append active (list name))))
+      (write-state! (hasheq 'disabled new-disabled
+                            'quarantined new-quarantined
+                            'active new-active)))))
 
 ;; ============================================================
 ;; list-quarantined : -> (listof hash?)
 ;; ============================================================
 
 (define (list-quarantined)
-  (define state (read-state))
-  (define quarantined (hash-ref state 'quarantined (hasheq)))
-  (for/list ([(sym-key meta) (in-hash quarantined)])
-    (make-hash (list (cons 'name (sym->name sym-key))
-                     (cons 'state "quarantined")
-                     (cons 'original-path (hash-ref meta 'original-path ""))
-                     (cons 'quarantined-at (hash-ref meta 'quarantined-at ""))))))
+  (with-quarantine-lock
+    (lambda ()
+      (define state (read-state))
+      (define quarantined (hash-ref state 'quarantined (hasheq)))
+      (for/list ([(sym-key meta) (in-hash quarantined)])
+        (make-hash (list (cons 'name (sym->name sym-key))
+                         (cons 'state "quarantined")
+                         (cons 'original-path (hash-ref meta 'original-path ""))
+                         (cons 'quarantined-at (hash-ref meta 'quarantined-at ""))))))))
 
 ;; ============================================================
 ;; format-extension-status : string? -> string?
@@ -204,13 +244,15 @@
     ['active   (format "~a: active" name)]
     ['disabled (format "~a: disabled" name)]
     ['quarantined
-     (define state (read-state))
-     (define quarantined (hash-ref state 'quarantined (hasheq)))
-     (define meta (hash-ref quarantined (name->sym name) (hash)))
-     (format "~a: quarantined (from ~a at ~a)"
-             name
-             (hash-ref meta 'original-path "?")
-             (hash-ref meta 'quarantined-at "?"))]
+     (with-quarantine-lock
+       (lambda ()
+         (define state (read-state))
+         (define quarantined (hash-ref state 'quarantined (hasheq)))
+         (define meta (hash-ref quarantined (name->sym name) (hash)))
+         (format "~a: quarantined (from ~a at ~a)"
+                 name
+                 (hash-ref meta 'original-path "?")
+                 (hash-ref meta 'quarantined-at "?"))))]
     ['unknown  (format "~a: unknown" name)]))
 
 ;; ============================================================

--- a/runtime/auth-store.rkt
+++ b/runtime/auth-store.rkt
@@ -220,6 +220,10 @@
                (values (if (symbol? k) (symbol->string k) k) v)))))]))
 
 ;; Save a credential to the dedicated credential file.
+;; SECURITY NOTE: API keys are stored as plaintext on disk.
+;; The credential file has #o600 (owner-only) permissions, but keys
+;; are not encrypted at rest. On shared systems, consider using
+;; environment variables or a dedicated secrets manager instead.
 (define (save-credential-file! provider-name api-key [path (credential-file-path)])
   (with-handlers ([exn:fail? (λ (e) (void))])
     (define dir (path-only path))
@@ -256,6 +260,10 @@
 ;; Read existing JSON config, update the provider's api-key, write back.
 ;; If the file doesn't exist, create a new config structure.
 ;; Handles errors gracefully — does not propagate exceptions.
+;; SECURITY NOTE: API keys are stored as plaintext on disk.
+;; The credential file has #o600 (owner-only) permissions, but keys
+;; are not encrypted at rest. On shared systems, consider using
+;; environment variables or a dedicated secrets manager instead.
 (define (write-credential-to-config! config-path provider-name api-key)
   (with-handlers ([exn:fail? (lambda (e) (void))])
     (internal-write-credential-to-config! config-path provider-name api-key)))

--- a/tools/builtins/bash.rkt
+++ b/tools/builtins/bash.rkt
@@ -26,7 +26,20 @@
 ;; Destructive command patterns (SEC-03)
 ;; Each pattern is a string that is checked case-insensitively
 ;; against the command string.
-(define destructive-patterns '("rm -rf" "rmdir" "mkfs" "dd if=" "format" "del /" "shutdown" "reboot"))
+(define destructive-patterns
+  '("rm -rf" "rmdir" "mkfs" "dd if=" "format" "del /" "shutdown" "reboot"
+    "chmod -R 777 /"       ;; recursive permission destruction
+    "curl " "| sh"         ;; pipe-to-shell patterns
+    "wget " "| bash"       ;; pipe-to-shell patterns
+    "> /etc/passwd"        ;; critical system file override
+    "> /etc/shadow"        ;; critical system file override
+    "dd of=/dev/"          ;; disk destruction
+    "git push --force"     ;; force push
+    ":(){:|:&};:"          ;; fork bomb
+    "chmod 000 /"          ;; recursive permission lockout
+    "> /dev/sd"            ;; device file write
+    "mv / "                ;; root directory move
+    ))
 
 ;; Check if a command matches any destructive pattern.
 (define (destructive-command? command)

--- a/tools/builtins/edit.rkt
+++ b/tools/builtins/edit.rkt
@@ -8,7 +8,9 @@
 ;;   Returns:  tool-result with success or error details
 
 (require racket/file
-         (only-in "../tool.rkt" make-success-result make-error-result))
+         (only-in "../tool.rkt" make-success-result make-error-result)
+         (only-in "../../util/safe-mode-predicates.rkt"
+                  safe-mode? allowed-path? safe-mode-project-root))
 
 (provide tool-edit)
 
@@ -51,9 +53,12 @@
         (cond
           [(not new-text) (make-error-result "Missing required argument: new-text")]
           [else
-           ;; 1. File existence check
-           ;; (safe-mode path check is done by scheduler, not here)
+           ;; Defense-in-depth: verify path even if scheduler already checked (SEC-09)
            (cond
+             [(and (safe-mode?) (not (allowed-path? path-str)))
+              (make-error-result
+               (format "edit: path '~a' outside project root (~a)"
+                       path-str (safe-mode-project-root)))]
              [(not (file-exists? path-str))
               (make-error-result (format "File not found: ~a" path-str))]
 

--- a/tools/builtins/write.rkt
+++ b/tools/builtins/write.rkt
@@ -3,7 +3,9 @@
 (require racket/file
          (only-in "../tool.rkt" make-success-result make-error-result)
          (only-in "../../util/path-helpers.rkt" path-only)
-         (only-in "../../util/errors.rkt" raise-tool-error tool-error?))
+         (only-in "../../util/errors.rkt" raise-tool-error tool-error?)
+         (only-in "../../util/safe-mode-predicates.rkt"
+                  safe-mode? allowed-path? safe-mode-project-root))
 
 (provide tool-write
          current-max-write-bytes)
@@ -12,11 +14,15 @@
 (define current-max-write-bytes (make-parameter 1048576))
 
 ;; Main tool function
-;; (safe-mode path check is done by scheduler, not here)
 (define (tool-write args [exec-ctx #f])
   (define path-str (hash-ref args 'path #f))
   (cond
     [(not path-str) (make-error-result "Missing required argument: path")]
+    [(and (safe-mode?) (not (allowed-path? path-str)))
+     ;; Defense-in-depth: verify path even if scheduler already checked (SEC-09)
+     (make-error-result
+      (format "write: path '~a' outside project root (~a)"
+              path-str (safe-mode-project-root)))]
     [else
      (define content-str (hash-ref args 'content ""))
      (with-handlers ([exn:fail:filesystem?


### PR DESCRIPTION
## Issues: #306 #307 #308 #309 #310

### SEC-09 (#307): Defense-in-depth path checks
- write.rkt and edit.rkt now check safe-mode allowed-path even without scheduler

### SEC-10 (#308): Expanded destructive patterns
- 9 new patterns for pipe-to-shell, disk destruction, system file override

### SEC-11 (#309): File locking for quarantine
- Atomic file creation lock prevents TOCTOU races

### SEC-12 (#310): Plaintext API key risk docs
- SECURITY NOTE docstrings + docs/security.md

Closes #306 Closes #307 Closes #308 Closes #309 Closes #310