### PR TITLE
fix(ci): use shell installer for macOS instead of DMG

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,11 +37,9 @@ jobs:
       - name: Install Racket (macOS)
         if: runner.os == 'macOS' && steps.cache-racket.outputs.cache-hit != 'true'
         run: |
-          curl -L https://download.racket-lang.org/installers/8.10/racket-8.10-aarch64-macosx-cs.dmg -o /tmp/racket.dmg
-          hdiutil attach /tmp/racket.dmg
-          sudo installer -pkg /Volumes/Racket*/Racket*.pkg -target /
-          hdiutil detach /Volumes/Racket*
-          ls -la /usr/local/bin/raco || (echo "Racket installation failed" && exit 1)
+          curl -L https://download.racket-lang.org/installers/8.10/racket-8.10-aarch64-macosx-cs.sh -o /tmp/racket.sh
+          echo "2" | sudo sh /tmp/racket.sh --in-place --create-links /usr/local
+          ls -la /usr/local/racket/bin/raco || (echo "Racket installation failed" && exit 1)
 
       - name: Verify Racket Installation
         run: /usr/local/racket/bin/racket --version || racket --version
@@ -109,11 +107,9 @@ jobs:
       - name: Install Racket (macOS)
         if: runner.os == 'macOS' && steps.cache-racket.outputs.cache-hit != 'true'
         run: |
-          curl -L https://download.racket-lang.org/installers/8.10/racket-8.10-aarch64-macosx-cs.dmg -o /tmp/racket.dmg
-          hdiutil attach /tmp/racket.dmg
-          sudo installer -pkg /Volumes/Racket*/Racket*.pkg -target /
-          hdiutil detach /Volumes/Racket*
-          ls -la /usr/local/bin/raco || (echo "Racket installation failed" && exit 1)
+          curl -L https://download.racket-lang.org/installers/8.10/racket-8.10-aarch64-macosx-cs.sh -o /tmp/racket.sh
+          echo "2" | sudo sh /tmp/racket.sh --in-place --create-links /usr/local
+          ls -la /usr/local/racket/bin/raco || (echo "Racket installation failed" && exit 1)
 
       - name: Verify Racket Installation
         run: racket --version


### PR DESCRIPTION
Fixes the macOS CI failure where `installer -pkg /Volumes/Racket*/Racket*.pkg` failed with "the package path specified was invalid".

The Racket 8.10 DMG mounts as `/Volumes/Racket v8.10` with a space in the path, and the `.pkg` glob didn't match the actual package name inside.

**Fix**: Use the `.sh` shell installer on macOS too (aarch64 build), identical to the Linux approach. This avoids DMG mounting entirely.