### PR TITLE
Wave 2: Documentation Drift Remediation (#335)

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,16 @@ raco test tests/           # run the full test suite
 | `--tool <name>` | Enable specific tool(s) only (repeatable) |
 | `--project-dir <path>` | Override project directory |
 
+**Subcommands:**
+
+| Command | Purpose |
+|---------|----------|
+| `q init` | Guided setup wizard (config, provider, API key) |
+| `q doctor` | Run setup and provider diagnostics |
+| `q sessions list` | List sessions |
+| `q sessions info <id>` | Show session details |
+| `q sessions delete <id>` | Delete a session |
+
 ## Module Structure
 
 ```
@@ -250,7 +260,8 @@ q/
 ├── tests/          Full test suite (120 files)
 ├── tools/          Tool registry, scheduler, 9 built-in tools
 ├── tui/            Terminal UI: rendering, input, state, clipboard
-└── util/           JSONL, ANSI, markdown, IDs, cancellation, paths
+├── util/           JSONL, ANSI, markdown, IDs, cancellation, paths
+└── wiring/         Run modes: interactive, JSON-RPC, mode dispatch
 ```
 
 ## Test Suite
@@ -279,6 +290,8 @@ raco test tests/tui/
 
 [MIT](LICENSE)
 
+> **Contributors:** `CONTRIBUTING.md` is excluded from release tarballs. Clone the repo for the full contributor guidelines.
+
 ## Documentation
 
 | Doc | Description |
@@ -286,7 +299,7 @@ raco test tests/tui/
 | [Install Guide](docs/install.md) | Full setup instructions |
 | [Tutorials](docs/tutorials/) | Team setup and builder cookbook |
 | [Demos](docs/demos/) | Example session transcripts |
-| [Architecture](docs/architecture/) | System design deep dives |
+| [Architecture](docs/adr/) | Architecture decision records |
 
 ## Status
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,10 +28,13 @@ q/docs/
 ├── why-q.md           ← motivation and packaging roadmap
 ├── adr/               ← architecture decision records
 │   ├── README.md
-│   ├── 0001-event-first-architecture.md
-│   ├── 0002-provider-dispatch-pattern.md
-│   ├── 0003-safe-mode-design.md
-│   └── 0004-session-journal-append-only.md
+│   ├── 0001-small-trusted-core.md
+│   ├── 0002-append-only-jsonl-session-log.md
+│   ├── 0003-event-bus-architecture.md
+│   ├── 0004-provider-abstraction.md
+│   ├── 0005-interface-separation.md
+│   ├── 0006-extension-hook-model.md
+│   └── 0007-sandboxing-boundary.md
 ├── demos/             ← demo scripts and walkthroughs
 └── tutorials/         ← builder and team setup guides
     ├── builder-tutorials.md

--- a/docs/demos/README.md
+++ b/docs/demos/README.md
@@ -29,7 +29,7 @@ raco q --model gpt-5.4
 raco q --json
 
 # Resume a session
-raco q --resume <session-id>
+raco q --session <session-id>
 ```
 
 See the [main README](../../README.md) for installation and configuration.

--- a/docs/install.md
+++ b/docs/install.md
@@ -38,7 +38,8 @@ cd q
 raco pkg install --auto
 
 # 3. Verify
-raco q --version   # or: racket main.rkt --version
+raco q --version              # installed package
+# From source tree instead: racket main.rkt --version
 ```
 
 ## First-Run Verification
@@ -46,8 +47,8 @@ raco q --version   # or: racket main.rkt --version
 After installing, confirm everything works:
 
 ```bash
-raco q --version            # should print: q version 0.8.1
-raco q doctor               # checks Racket version, dependencies, config
+raco q --version            # installed package; or: racket main.rkt --version
+raco q doctor               # installed package; or: racket main.rkt doctor
 ```
 
 ## Shell Setup
@@ -77,6 +78,9 @@ After setup you can run:
 q --tui          # launch the terminal UI
 q "hello"        # single-shot prompt
 ```
+
+> **From source tree** (without `raco pkg install`): prefix all commands with `racket main.rkt`.
+> For example: `racket main.rkt --tui`, `racket main.rkt "hello"`.
 
 ## Upgrading
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -16,7 +16,7 @@ q follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html) (**MAJOR.MI
 
 Before starting a release, verify every item below:
 
-- [ ] All tests pass: `raco test .` from the `q/` root
+- [ ] All tests pass: `raco test tests/` from the `q/` root
 - [ ] Version bumped in `info.rkt` **and** `util/version.rkt` (both must match)
 - [ ] `CHANGELOG.md` updated with the new version entry
 - [ ] `README.md` metrics (test count, module count) updated

--- a/docs/tutorials/README.md
+++ b/docs/tutorials/README.md
@@ -18,4 +18,4 @@ Hands-on guides for extending and adopting q.
 
 - [Installation Guide](../install.md) — Full setup instructions
 - [Demos](../demos/) — Example session transcripts
-- [Architecture](../../docs/architecture/overview.md) — How q works internally
+- [Architecture](../adr/) — Architecture decision records

--- a/wiki-src/Architecture-Overview.md
+++ b/wiki-src/Architecture-Overview.md
@@ -37,9 +37,11 @@ User input → Interface (CLI/TUI/RPC)
 
 ## Metrics (v0.8.1)
 
-- 119 source modules, 138 test files
-- 22,032 source lines, 38,032 test lines
-- 3,352 tests, 6,133 assertions (test:source ratio 1.86:1)
+> _See `racket scripts/metrics.rkt` for current numbers._
+
+- 124 source modules, 140 test files
+- 22,171 source lines, 38,076 test lines
+- 3,275 tests, 6,133 assertions (test:source ratio 1.72:1)
 - 6/6 lint checks enforced in CI
 
-For the canonical architecture description, see the [repository README](https://github.com/coinerd/q/blob/main/README.md) and [docs/architecture/overview.md](https://github.com/coinerd/q/blob/main/docs/architecture/overview.md).
+For the canonical architecture description, see the [repository README](https://github.com/coinerd/q/blob/main/README.md) and [docs/adr/README.md](https://github.com/coinerd/q/blob/main/q/docs/adr/README.md).

--- a/wiki-src/Glossary-and-FAQ.md
+++ b/wiki-src/Glossary-and-FAQ.md
@@ -31,7 +31,7 @@ raco pkg install
 Requires Racket 8.10+. See the [installation guide](https://github.com/coinerd/q/blob/main/q/docs/install.md).
 
 ### How do I configure a provider?
-Run `q --init` for the interactive wizard, or edit `~/.q/config.json` directly:
+Run `q init` for the guided setup wizard, or edit `~/.q/config.json` directly:
 ```json
 {
   "default-model": "gpt-4o",


### PR DESCRIPTION
## Wave 2: Documentation Drift Remediation

Addresses 4 sub-issues under epic #335.

### Changes
- **DOC-03** (#336): Added wiring/ to README module structure table
- **DOC-05** (#336): Fixed dead links to docs/architecture/ → docs/adr/ in README, tutorials, wiki
- **DOC-06** (#336): Updated ADR listing in docs/README.md to match actual 7 ADR files
- **DOC-07** (#337): Fixed --resume → --session in docs/demos/README.md
- **DOC-09** (#337): Added subcommands table (init, doctor, sessions) to README CLI section
- **DOC-10** (#337): Clarified raco q vs racket main.rkt in docs/install.md
- **DOC-11** (#338): Updated stale metrics in wiki Architecture-Overview (119→124, 138→140, etc.)
- **MAT-04** (#339): Fixed raco test . → raco test tests/ in docs/releasing.md
- **MAT-07** (#339): Added CONTRIBUTING.md tarball note in README

### Verification
- ✅ 3,275 tests passing
- ✅ All lints pass (version, format, metrics)

Fixes #336, Fixes #337, Fixes #338, Fixes #339
Refs #335