### PR TITLE
Wave 6: CI Maturity & Project Hygiene (#354)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,4 @@
 # Files excluded from release tarballs (git archive)
 .github/            export-ignore
 benchmarks/         export-ignore
-CONTRIBUTING.md     export-ignore
 dist/               export-ignore

--- a/.github/actions/setup-racket/action.yml
+++ b/.github/actions/setup-racket/action.yml
@@ -1,0 +1,57 @@
+name: 'Setup Racket'
+description: 'Install Racket 8.10 with caching and dependencies'
+inputs:
+  racket-version:
+    description: 'Racket version to install'
+    required: false
+    default: '8.10'
+runs:
+  using: 'composite'
+  steps:
+    - name: Cache Racket installation
+      id: cache-racket
+      uses: actions/cache@v5
+      with:
+        path: |
+          ~/racket-install
+        key: racket-${{ inputs.racket-version }}-${{ runner.os }}
+
+    - name: Install Racket (Linux)
+      if: runner.os == 'Linux' && steps.cache-racket.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        curl -L https://download.racket-lang.org/installers/${{ inputs.racket-version }}/racket-${{ inputs.racket-version }}-x86_64-linux-cs.sh -o /tmp/racket.sh
+        sh /tmp/racket.sh --in-place --dest $HOME/racket-install
+        ls -la $HOME/racket-install/bin/raco || (echo "Racket installation failed" && exit 1)
+
+    - name: Install Racket (macOS)
+      if: runner.os == 'macOS' && steps.cache-racket.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        curl -L https://download.racket-lang.org/installers/${{ inputs.racket-version }}/racket-${{ inputs.racket-version }}-aarch64-macosx-cs.dmg -o /tmp/racket.dmg
+        hdiutil attach -nobrowse /tmp/racket.dmg
+        MOUNT=$(ls -d /Volumes/Racket* | head -1)
+        echo "Mounted at: $MOUNT"
+        RACKET_DIR="$MOUNT/Racket v${{ inputs.racket-version }}"
+        if [ ! -d "$RACKET_DIR/bin" ]; then
+          echo "ERROR: $RACKET_DIR/bin not found"
+          ls -la "$MOUNT"
+          exit 1
+        fi
+        echo "Installing from: $RACKET_DIR"
+        cp -R "$RACKET_DIR" $HOME/racket-install
+        hdiutil detach "$MOUNT"
+
+    - name: Add Racket to PATH
+      shell: bash
+      run: echo "$HOME/racket-install/bin" >> $GITHUB_PATH
+
+    - name: Verify Racket Installation
+      shell: bash
+      run: racket --version
+
+    - name: Install dependencies
+      shell: bash
+      run: |
+        raco pkg install --auto --batch
+        raco pkg install --auto --batch tui-term tui-ubuf 2>/dev/null || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,48 +18,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Cache Racket installation
-        id: cache-racket
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/racket-install
-          key: racket-8.10-${{ matrix.os }}
-
-      - name: Install Racket (Linux)
-        if: runner.os == 'Linux' && steps.cache-racket.outputs.cache-hit != 'true'
-        run: |
-          curl -L https://download.racket-lang.org/installers/8.10/racket-8.10-x86_64-linux-cs.sh -o /tmp/racket.sh
-          sh /tmp/racket.sh --in-place --dest $HOME/racket-install
-          ls -la $HOME/racket-install/bin/raco || (echo "Racket installation failed" && exit 1)
-
-      - name: Install Racket (macOS)
-        if: runner.os == 'macOS' && steps.cache-racket.outputs.cache-hit != 'true'
-        run: |
-          curl -L https://download.racket-lang.org/installers/8.10/racket-8.10-aarch64-macosx-cs.dmg -o /tmp/racket.dmg
-          hdiutil attach -nobrowse /tmp/racket.dmg
-          MOUNT=$(ls -d /Volumes/Racket* | head -1)
-          echo "Mounted at: $MOUNT"
-          RACKET_DIR="$MOUNT/Racket v8.10"
-          if [ ! -d "$RACKET_DIR/bin" ]; then
-            echo "ERROR: $RACKET_DIR/bin not found"
-            ls -la "$MOUNT"
-            exit 1
-          fi
-          echo "Installing from: $RACKET_DIR"
-          cp -R "$RACKET_DIR" $HOME/racket-install
-          hdiutil detach "$MOUNT"
-
-      - name: Add Racket to PATH
-        run: echo "$HOME/racket-install/bin" >> $GITHUB_PATH
-
-      - name: Verify Racket Installation
-        run: racket --version
-
-      - name: Install dependencies
-        run: |
-          raco pkg install --auto --batch
-          raco pkg install --auto --batch tui-term tui-ubuf 2>/dev/null || true
+      - name: Setup Racket
+        uses: ./.github/actions/setup-racket
 
       - name: Clean bytecode cache
         run: find . -name '*.zo' -delete -o -name 'compiled' -type d -exec rm -rf {} + 2>/dev/null; true
@@ -91,6 +51,12 @@ jobs:
       - name: Run tests
         run: raco test tests/
 
+      - name: Coverage report
+        if: runner.os == 'Linux'
+        run: |
+          raco pkg install --auto --batch cover-coveralls 2>/dev/null || true
+          raco cover tests/ 2>/dev/null || echo "Coverage step completed (optional)"
+
   smoke:
     strategy:
       matrix:
@@ -99,48 +65,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Cache Racket installation
-        id: cache-racket
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/racket-install
-          key: racket-8.10-${{ matrix.os }}
-
-      - name: Install Racket (Linux)
-        if: runner.os == 'Linux' && steps.cache-racket.outputs.cache-hit != 'true'
-        run: |
-          curl -L https://download.racket-lang.org/installers/8.10/racket-8.10-x86_64-linux-cs.sh -o /tmp/racket.sh
-          sh /tmp/racket.sh --in-place --dest $HOME/racket-install
-          ls -la $HOME/racket-install/bin/raco || (echo "Racket installation failed" && exit 1)
-
-      - name: Install Racket (macOS)
-        if: runner.os == 'macOS' && steps.cache-racket.outputs.cache-hit != 'true'
-        run: |
-          curl -L https://download.racket-lang.org/installers/8.10/racket-8.10-aarch64-macosx-cs.dmg -o /tmp/racket.dmg
-          hdiutil attach -nobrowse /tmp/racket.dmg
-          MOUNT=$(ls -d /Volumes/Racket* | head -1)
-          echo "Mounted at: $MOUNT"
-          RACKET_DIR="$MOUNT/Racket v8.10"
-          if [ ! -d "$RACKET_DIR/bin" ]; then
-            echo "ERROR: $RACKET_DIR/bin not found"
-            ls -la "$MOUNT"
-            exit 1
-          fi
-          echo "Installing from: $RACKET_DIR"
-          cp -R "$RACKET_DIR" $HOME/racket-install
-          hdiutil detach "$MOUNT"
-
-      - name: Add Racket to PATH
-        run: echo "$HOME/racket-install/bin" >> $GITHUB_PATH
-
-      - name: Verify Racket Installation
-        run: racket --version
-
-      - name: Install dependencies
-        run: |
-          raco pkg install --auto --batch
-          raco pkg install --auto --batch tui-term tui-ubuf 2>/dev/null || true
+      - name: Setup Racket
+        uses: ./.github/actions/setup-racket
 
       - name: Version smoke check
         run: |


### PR DESCRIPTION
## Wave 6: CI & Maturity

Addresses 2 sub-issues under epic #354.

### Changes
- **MAT-01** (#355): Verified dist/ is gitignored, removed local stale tarballs
- **MAT-02** (#355): Extracted CI composite action `.github/actions/setup-racket/` — DRYs ~60 lines of duplicated install steps
- **MAT-04** (#356): releasing.md already fixed in Wave 2
- **MAT-05** (#356): Added optional coverage step to CI
- **MAT-07** (#356): Removed CONTRIBUTING.md from .gitattributes export-ignore

### Verification
- ✅ All lints pass
- ✅ CI workflow syntax valid

Fixes #355, Fixes #356
Refs #354