### PR TITLE
feat(tui): CJK/wide-char width awareness (Wave 1, #366-#369)

### DIFF
--- a/tests/tui/char-width.rkt
+++ b/tests/tui/char-width.rkt
@@ -1,0 +1,121 @@
+#lang racket
+
+;; tests/tui/char-width.rkt — Tests for Unicode-aware terminal column width
+
+(require rackunit
+         rackunit/text-ui
+         "../../../q/tui/char-width.rkt")
+
+(define char-width-tests
+  (test-suite
+   "TUI char-width"
+
+   ;; ============================================================
+   ;; char-width — single character width
+   ;; ============================================================
+
+   (test-case "ASCII letters are width 1"
+     (check-equal? (char-width #\a) 1)
+     (check-equal? (char-width #\Z) 1)
+     (check-equal? (char-width #\0) 1)
+     (check-equal? (char-width #\ ) 1))
+
+   (test-case "CJK ideographs are width 2"
+     ;; CJK Unified Ideographs (U+4E00–U+9FFF)
+     (check-equal? (char-width #\你) 2)
+     (check-equal? (char-width #\好) 2)
+     (check-equal? (char-width #\世) 2)
+     (check-equal? (char-width #\界) 2)
+     (check-equal? (char-width #\中) 2)
+     (check-equal? (char-width #\文) 2))
+
+   (test-case "CJK Extension B are width 2"
+     ;; U+20000 is outside BMP — Racket represents as surrogate pair or
+     ;; directly depending on build. Test a known one if available.
+     ;; Skip if the character can't be constructed.
+     (let ([c (integer->char #x20000)])
+       (when c
+         (check-equal? (char-width c) 2))))
+
+   (test-case "Hiragana and Katakana are width 2"
+     (check-equal? (char-width #\あ) 2)   ; Hiragana
+     (check-equal? (char-width #\ア) 2))  ; Katakana
+
+   (test-case "Hangul syllables are width 2"
+     (check-equal? (char-width #\한) 2)
+     (check-equal? (char-width #\국) 2))
+
+   (test-case "Fullwidth variants are width 2"
+     ;; Fullwidth Latin (U+FF01–U+FF5E)
+     (check-equal? (char-width #\！) 2)  ; U+FF01
+     (check-equal? (char-width #\｝) 2)) ; U+FF5D
+
+   (test-case "Emoji are width 2"
+     ;; Basic emoji — these are in BMP supplementary planes or basic ranges
+     ;; Racket may represent some as chars directly
+     (check-equal? (char-width (integer->char #x2600)) 2)  ; ☀
+     (check-equal? (char-width (integer->char #x2605)) 2)  ; ★
+     (check-equal? (char-width (integer->char #x263A)) 2)) ; ☺
+
+   (test-case "Control characters are width 0"
+     (check-equal? (char-width #\nul) 0)
+     (check-equal? (char-width #\tab) 0)
+     (check-equal? (char-width #\return) 0)
+     (check-equal? (char-width #\newline) 0))
+
+   (test-case "Combining marks are width 0"
+     ;; Combining Diacritical Marks (U+0300–U+036F)
+     (check-equal? (char-width (integer->char #x0300)) 0)  ; Combining grave
+     (check-equal? (char-width (integer->char #x0301)) 0)  ; Combining acute
+     (check-equal? (char-width (integer->char #x0302)) 0)  ; Combining circumflex
+     (check-equal? (char-width (integer->char #x0308)) 0)) ; Combining diaeresis
+
+   (test-case "Variation selectors are width 0"
+     ;; Variation Selectors (U+FE00–U+FE0F)
+     (check-equal? (char-width (integer->char #xFE00)) 0)
+     (check-equal? (char-width (integer->char #xFE0F)) 0))
+
+   (test-case "Box drawing chars are width 1"
+     (check-equal? (char-width #\─) 1)  ; U+2500
+     (check-equal? (char-width #\│) 1)  ; U+2502
+     (check-equal? (char-width #\┌) 1)  ; U+250C
+     (check-equal? (char-width #\┘) 1)) ; U+2518
+
+   ;; ============================================================
+   ;; string-visible-width
+   ;; ============================================================
+
+   (test-case "ASCII string: hello → 5"
+     (check-equal? (string-visible-width "hello") 5))
+
+   (test-case "CJK string: 你好 → 4"
+     (check-equal? (string-visible-width "你好") 4))
+
+   (test-case "Mixed ASCII+CJK: hi你好 → 6"
+     (check-equal? (string-visible-width "hi你好") 6))
+
+   (test-case "Mixed with fullwidth: A！B → 4"
+     (check-equal? (string-visible-width "A！B") 4))
+
+   (test-case "Emoji string: ★★ → 4"
+     (check-equal? (string-visible-width (list->string (list (integer->char #x2605) (integer->char #x2605)))) 4))
+
+   (test-case "Empty string → 0"
+     (check-equal? (string-visible-width "") 0))
+
+   (test-case "String with combining mark: e + combining acute → 1"
+     ;; é as e (U+0065) + combining acute (U+0301)
+     (check-equal? (string-visible-width "e\u0301") 1))
+
+   (test-case "CJK with combining mark: 你 + combining acute → 2"
+     (check-equal? (string-visible-width "你\u0301") 2))
+
+   (test-case "Control characters contribute 0"
+     (check-equal? (string-visible-width "a\tb") 2)
+     (check-equal? (string-visible-width "a\nb") 2))
+
+   (test-case "long mixed string"
+     ;; "hello你好world世界" = 5 + 4 + 5 + 4 = 18
+     (check-equal? (string-visible-width "hello你好world世界") 18))))
+
+(run-tests char-width-tests)

--- a/tests/tui/input.rkt
+++ b/tests/tui/input.rkt
@@ -4,7 +4,8 @@
 
 (require rackunit
          rackunit/text-ui
-         "../../../q/tui/input.rkt")
+         "../../../q/tui/input.rkt"
+         "../../../q/tui/char-width.rkt")
 
 (define input-tests
   (test-suite
@@ -494,6 +495,52 @@
             [st2 (input-insert-newline st1)])
        (check-false (input-state-history-idx st2)
                     "insert-newline clears history browsing")))
+
+   ;; ============================================================
+   ;; CJK/wide-char visible window tests (Wave 1: #369)
+   ;; ============================================================
+
+   (test-case "input-visible-window: CJK text fits in window"
+     (define st (input-state "你好" 2 '() #f #f 0))
+     (define-values (vis offset cursor-col) (input-visible-window st 80))
+     (check-equal? vis "你好")
+     (check-equal? offset 0)
+     ;; cursor at char 2, visible width from 0 to 2 = 4 cols
+     (check-equal? cursor-col (+ INPUT-PROMPT-WIDTH 4)))
+
+   (test-case "input-visible-window: CJK text scrolls"
+     ;; 10 CJK chars = 20 visible cols, terminal 12 cols
+     (define buf "一二三四五六七八九十")
+     (define st (input-state buf 10 '() #f #f 0))
+     (define-values (vis offset cursor-col) (input-visible-window st 12))
+     (check-true (> offset 0) "offset should be positive to show cursor")
+     (check-true (< (string-visible-width vis) 20) "visible text < full width")
+     (check-true (and (>= cursor-col INPUT-PROMPT-WIDTH)
+                      (< cursor-col 12))
+                (format "cursor-col ~a should be in prompt..cols" cursor-col)))
+
+   (test-case "input-visible-window: mixed ASCII+CJK"
+     ;; hello你好 = 5+4 = 9 visible cols
+     (define st (input-state "hello你好" 7 '() #f #f 0))
+     (define-values (vis offset cursor-col) (input-visible-window st 20))
+     (check-equal? vis "hello你好")
+     (check-equal? offset 0)
+     ;; cursor at char 7, visible width from 0 to 7 = 5+4 = 9 cols
+     (check-equal? cursor-col (+ INPUT-PROMPT-WIDTH 9)))
+
+   (test-case "input-visible-window: cursor before wide char"
+     ;; cursor at 0, buffer starts with CJK
+     (define st (input-state "你好世界" 0 '() #f #f 0))
+     (define-values (vis offset cursor-col) (input-visible-window st 80))
+     (check-equal? offset 0)
+     (check-equal? cursor-col INPUT-PROMPT-WIDTH))
+
+   (test-case "input-visible-window: long CJK scrolls when cursor at end"
+     (define buf "一二三四五六七八九十")
+     (define st (input-state buf 10 '() #f #f 0))
+     (define-values (vis offset cursor-col) (input-visible-window st 10))
+     (check-true (> offset 0) "should scroll right")
+     (check-true (< cursor-col 10) "cursor should be within terminal width"))
    ))
 
 (run-tests input-tests)

--- a/tests/tui/render.rkt
+++ b/tests/tui/render.rkt
@@ -6,7 +6,8 @@
          rackunit/text-ui
          "../../../q/tui/render.rkt"
          "../../../q/tui/state.rkt"
-         "../../../q/tui/input.rkt")
+         "../../../q/tui/input.rkt"
+         "../../../q/tui/char-width.rkt")
 
 (define render-tests
   (test-suite "TUI Render"
@@ -564,3 +565,66 @@
                      "no [thinking...] when streaming text is present")))))
 
 (run-tests thinking-tests)
+
+;; CJK/wide-char wrapping tests (Wave 1: #368)
+(define cjk-wrapping-tests
+  (test-suite "CJK/wide-char wrapping"
+
+    (test-case "wrap-text: CJK string wraps at visual column boundary"
+      ;; 你好世界 = 4+4 = 8 visible cols, 4 chars
+      ;; Wrap at width 5 → first line: 你好 (4 cols), second: 世界 (4 cols)
+      (define result (wrap-text "你好世界" 5))
+      (check-equal? (length result) 2 "CJK wraps into 2 lines")
+      (check-equal? (string-visible-width (first result)) 4 "first line is 4 cols")
+      (check-equal? (string-visible-width (second result)) 4 "second line is 4 cols"))
+
+    (test-case "wrap-text: mixed ASCII+CJK wraps correctly"
+      ;; hello你好 = 5+4 = 9 visible cols
+      ;; Wrap at width 9 → fits in one line
+      (define result1 (wrap-text "hello你好" 9))
+      (check-equal? (length result1) 1 "9 cols: fits in one line")
+      ;; Wrap at width 7 → hello (5) + 你 (2) = 7 cols on first line
+      ;; But 你 is char index 5, 好 is char index 6
+      (define result2 (wrap-text "hello你好" 7))
+      (check > (length result2) 1 "7 cols: wraps to multiple lines")
+      (check-equal? (string-visible-width (first result2)) 7 "first line is 7 cols"))
+
+    (test-case "wrap-text: combining marks don't consume column budget"
+      ;; e + combining acute (2 chars, 1 visible col)
+      (define result (wrap-text "e\u0301e\u0301e\u0301" 3))
+      (check-equal? (length result) 1 "combining marks fit in 3 cols"))
+
+    (test-case "wrap-single-line: long CJK string wraps correctly"
+      ;; 10 CJK chars = 20 visible cols, wrap at 10 → 2 lines of 10 cols each
+      (define cjk-str "一二三四五六七八九十")
+      (define result (wrap-single-line cjk-str 10))
+      (check-equal? (length result) 2)
+      (check-equal? (string-visible-width (first result)) 10)
+      (check-equal? (string-visible-width (second result)) 10))
+
+    (test-case "wrap-styled-line: CJK with styles preserves segment styles"
+      (define sl (styled-line (list (styled-segment "你好世界" '(bold)))))
+      (define result (wrap-styled-line sl 5))
+      (check-equal? (length result) 2 "CJK styled line wraps to 2 lines")
+      ;; All segments should have 'bold style
+      (for ([line result])
+        (for ([seg (styled-line-segments line)])
+          (check-not-false (member 'bold (styled-segment-style seg))
+                           (format "segment '~a' should be bold"
+                                   (styled-segment-text seg))))))
+
+    (test-case "wrap-text: long ASCII string still works correctly"
+      ;; Regression test: ensure ASCII wrapping still works after refactor
+      (define result (wrap-text (make-string 100 #\a) 40))
+      (check-equal? (length result) 3 "100 a's at width 40 = 3 lines")
+      (check-equal? (apply string-append result) (make-string 100 #\a)))
+
+    (test-case "wrap-text: whitespace break with mixed content"
+      ;; "hello 你好" = 5+1+4 = 10 visible cols
+      ;; Wrap at 8 → "hello " (6 cols) + "你好" (4 cols)
+      (define result (wrap-text "hello 你好" 8))
+      (check-equal? (length result) 2)
+      (check-equal? (first result) "hello ")
+      (check-equal? (second result) "你好"))))
+
+(run-tests cjk-wrapping-tests)

--- a/tui/char-width.rkt
+++ b/tui/char-width.rkt
@@ -1,0 +1,125 @@
+#lang racket/base
+
+;; q/tui/char-width.rkt — Unicode-aware terminal column width
+;;
+;; Provides functions for computing the visual column width of characters
+;; and strings in a terminal. CJK characters consume 2 columns, combining
+;; marks and control characters consume 0, and everything else is 1.
+;;
+;; Reference: Unicode East Asian Width property (UAX #11)
+
+(require racket/contract)
+
+(provide char-width
+         string-visible-width
+         visible-width)
+
+;; char-width : Char → {0, 1, 2}
+;; Returns the terminal column width of a single character.
+(define (char-width c)
+  (define cp (char->integer c))
+  (cond
+    ;; Control characters (C0/C1): width 0
+    [(< cp #x20) 0]
+    [(= cp #x7F) 0]
+    [(and (>= cp #x80) (<= cp #x9F)) 0]
+
+    ;; Combining Diacritical Marks (U+0300–U+036F): width 0
+    [(and (>= cp #x0300) (<= cp #x036F)) 0]
+
+    ;; Combining Diacritical Marks Extended (U+1AB0–U+1AFF): width 0
+    [(and (>= cp #x1AB0) (<= cp #x1AFF)) 0]
+
+    ;; Combining Diacritical Marks Supplement (U+1DC0–U+1DFF): width 0
+    [(and (>= cp #x1DC0) (<= cp #x1DFF)) 0]
+
+    ;; Combining Diacritical Marks for Symbols (U+20D0–U+20FF): width 0
+    [(and (>= cp #x20D0) (<= cp #x20FF)) 0]
+
+    ;; Combining Half Marks (U+FE20–U+FE2F): width 0
+    [(and (>= cp #xFE20) (<= cp #xFE2F)) 0]
+
+    ;; Variation Selectors (U+FE00–U+FE0F): width 0
+    [(and (>= cp #xFE00) (<= cp #xFE0F)) 0]
+
+    ;; Variation Selectors Supplement (U+E0100–U+E01EF): width 0
+    [(and (>= cp #xE0100) (<= cp #xE01EF)) 0]
+
+    ;; Zero Width Joiner (U+200D), Zero Width Non-Joiner (U+200C),
+    ;; Zero Width Space (U+200B), Word Joiner (U+2060): width 0
+    [(= cp #x200B) 0]
+    [(= cp #x200C) 0]
+    [(= cp #x200D) 0]
+    [(= cp #x2060) 0]
+
+    ;; Left-to-Right / Right-to-Left marks: width 0
+    [(= cp #x200E) 0]
+    [(= cp #x200F) 0]
+    [(and (>= cp #x202A) (<= cp #x202E)) 0]
+    [(and (>= cp #x2066) (<= cp #x2069)) 0]
+
+    ;; Hangul Jamo (U+1100–U+11FF): width 2
+    [(and (>= cp #x1100) (<= cp #x11FF)) 2]
+
+    ;; CJK Radicals Supplement (U+2E80–U+2EFF): width 2
+    [(and (>= cp #x2E80) (<= cp #x2EFF)) 2]
+
+    ;; Kangxi Radicals (U+2F00–U+2FDF): width 2
+    [(and (>= cp #x2F00) (<= cp #x2FDF)) 2]
+
+    ;; CJK Symbols and Punctuation (U+3000–U+303F):
+    ;;   U+3000 (ideographic space) is width 2, most others width 2
+    [(and (>= cp #x3000) (<= cp #x303F)) 2]
+
+    ;; Hiragana (U+3040–U+309F): width 2
+    [(and (>= cp #x3040) (<= cp #x309F)) 2]
+
+    ;; Katakana (U+30A0–U+30FF): width 2
+    [(and (>= cp #x30A0) (<= cp #x30FF)) 2]
+
+    ;; Bopomofo (U+3100–U+312F): width 2
+    [(and (>= cp #x3100) (<= cp #x312F)) 2]
+
+    ;; Hangul Compatibility Jamo (U+3130–U+318F): width 2
+    [(and (>= cp #x3130) (<= cp #x318F)) 2]
+
+    ;; CJK Unified Ideographs (U+4E00–U+9FFF): width 2
+    [(and (>= cp #x4E00) (<= cp #x9FFF)) 2]
+
+    ;; Hangul Syllables (U+AC00–U+D7AF): width 2
+    [(and (>= cp #xAC00) (<= cp #xD7AF)) 2]
+
+    ;; CJK Compatibility Ideographs (U+F900–U+FAFF): width 2
+    [(and (>= cp #xF900) (<= cp #xFAFF)) 2]
+
+    ;; Halfwidth and Fullwidth Forms (U+FF00–U+FFEF):
+    ;; Fullwidth variants are width 2, halfwidth are width 1
+    [(and (>= cp #xFF01) (<= cp #xFF60)) 2]  ; Fullwidth
+    [(and (>= cp #xFFE0) (<= cp #xFFE6)) 2]  ; Fullwidth signs
+
+    ;; Miscellaneous Symbols (U+2600–U+26FF): width 2 (emoji-like)
+    [(and (>= cp #x2600) (<= cp #x26FF)) 2]
+
+    ;; Dingbats (U+2700–U+27BF): width 2
+    [(and (>= cp #x2700) (<= cp #x27BF)) 2]
+
+    ;; CJK Unified Ideographs Extension A (U+3400–U+4DBF): width 2
+    [(and (>= cp #x3400) (<= cp #x4DBF)) 2]
+
+    ;; CJK Unified Ideographs Extension B–I (U+20000–U+323AF): width 2
+    [(and (>= cp #x20000) (<= cp #x323AF)) 2]
+
+    ;; CJK Compatibility Ideographs Supplement (U+2F800–U+2FA1F): width 2
+    [(and (>= cp #x2F800) (<= cp #x2FA1F)) 2]
+
+    ;; Default: width 1 (ASCII, Latin, Cyrillic, etc.)
+    [else 1]))
+
+;; string-visible-width : String → Natural
+;; Returns the total visual column width of a string.
+(define (string-visible-width s)
+  (for/sum ([c (in-string s)])
+    (char-width c)))
+
+;; Alias for convenience
+(define visible-width string-visible-width)

--- a/tui/input.rkt
+++ b/tui/input.rkt
@@ -6,7 +6,8 @@
 ;; The input-state struct is immutable.
 
 (require racket/string
-         racket/list)
+         racket/list
+         "char-width.rkt")
 
 ;; Structs
 (provide (struct-out input-state)
@@ -89,23 +90,79 @@
 
 ;; Compute the visible window of the buffer given a terminal width.
 ;; Returns (values visible-text scroll-offset cursor-display-col)
-;; scroll-offset is the index of the first visible character.
+;; scroll-offset is the character index of the first visible character.
+;; Uses visible column width (CJK-aware) instead of string-length.
 (define (input-visible-window st cols)
   (define buf (input-state-buffer st))
   (define cur (input-state-cursor st))
   (define offset (input-state-scroll-offset st))
   (define max-visible (max 1 (- cols INPUT-PROMPT-WIDTH)))
+  ;; Compute visible width from offset to cursor
+  (define cursor-offset-width
+    (if (or (>= offset (string-length buf))
+            (< cur offset))
+        0
+        (string-visible-width (substring buf offset cur))))
+  ;; Compute total visible width from offset to end
+  (define buf-remaining-width
+    (if (>= offset (string-length buf))
+        0
+        (string-visible-width (substring buf offset))))
   ;; Adjust offset so cursor is visible
   (define new-offset
     (cond
-      [(< cur offset) cur]
-      [(>= cur (+ offset max-visible)) (+ (- cur max-visible) 1)]
+      ;; Cursor is before current offset
+      [(< cur offset)
+       ;; Walk backward from offset to find a new offset
+       ;; that places cursor at or near the left edge
+       (find-offset-for-cursor buf cur max-visible)]
+      ;; Cursor's visible width from offset exceeds max-visible
+      [(> cursor-offset-width max-visible)
+       (find-offset-for-cursor buf cur max-visible)]
       [else offset]))
   (define clamped-offset (max 0 (min new-offset (string-length buf))))
-  (define end-pos (min (string-length buf) (+ clamped-offset max-visible)))
+  ;; Find end position: advance from clamped-offset until visible width > max-visible
+  (define end-pos (find-end-pos buf clamped-offset max-visible))
   (define visible-text (substring buf clamped-offset end-pos))
-  (define cursor-display-col (+ INPUT-PROMPT-WIDTH (- cur clamped-offset)))
+  (define cursor-display-col
+    (+ INPUT-PROMPT-WIDTH
+       (if (>= clamped-offset cur)
+           0
+           (string-visible-width (substring buf clamped-offset cur)))))
   (values visible-text clamped-offset cursor-display-col))
+
+;; Find a character offset into `buf` such that the visible width from
+;; that offset to `cursor` fits within `max-visible` columns.
+;; The cursor is placed as far right as possible (one column from the edge).
+(define (find-offset-for-cursor buf cursor max-visible)
+  ;; Target: visible width from offset to cursor <= max-visible - 1
+  (define target-width (max 1 (- max-visible 1)))
+  (let loop ([i (min cursor (string-length buf))]
+             [col 0])
+    (cond
+      [(<= i 0) 0]
+      [else
+       (define c (string-ref buf (sub1 i)))
+       (define w (char-width c))
+       (define new-col (+ col w))
+       (if (> new-col target-width)
+           i
+           (loop (sub1 i) new-col))])))
+
+;; Find end position: advance from start-offset until visible width
+;; would exceed max-visible columns.
+(define (find-end-pos buf start-offset max-visible)
+  (let loop ([i start-offset]
+             [col 0])
+    (cond
+      [(>= i (string-length buf)) (string-length buf)]
+      [else
+       (define c (string-ref buf i))
+       (define w (char-width c))
+       (define new-col (+ col w))
+       (if (> new-col max-visible)
+           i
+           (loop (add1 i) new-col))])))
 
 ;; Insert a literal newline at cursor position (for multi-line input)
 (define (input-insert-newline st)

--- a/tui/render.rkt
+++ b/tui/render.rkt
@@ -5,6 +5,7 @@
          racket/function
          "state.rkt"
          "input.rkt"
+         "char-width.rkt"
          "../util/markdown.rkt")
 
 ;; Types
@@ -30,7 +31,9 @@
 
          ;; Helpers
          styled-line->text
-         wrap-styled-line)
+         wrap-styled-line
+         wrap-text
+         wrap-single-line)
 
 ;; A styled segment (part of a line)
 (struct styled-segment
@@ -90,7 +93,7 @@
 ;; Preserves segment styles by tracking character-to-segment mapping.
 (define (wrap-styled-line sl width)
   (define text (styled-line->text sl))
-  (if (<= (string-length text) width)
+  (if (<= (string-visible-width text) width)
       (list sl)
       (let* ([segs (styled-line-segments sl)]
              ;; Build char-style table: for each character, which style?
@@ -171,7 +174,8 @@
   ;; Flush remaining inline segments
   (flush-current lines current-segs))
 
-;; Wrap text to a given width, returning list of strings
+;; Wrap text to a given width, returning list of strings.
+;; Uses visible column width (CJK-aware) instead of string-length.
 (define (wrap-text text max-width)
   (if (<= max-width 0)
       (list text)
@@ -181,23 +185,41 @@
                  (wrap-single-line line max-width))))))
 
 (define (wrap-single-line line max-width)
-  (if (<= (string-length line) max-width)
+  (if (<= (string-visible-width line) max-width)
       (list line)
       (let loop ([remaining line]
                  [acc '()])
-        (if (<= (string-length remaining) max-width)
+        (if (<= (string-visible-width remaining) max-width)
             (reverse (cons remaining acc))
             (let ([break-pos (find-break-pos remaining max-width)])
-              (loop (substring remaining break-pos) (cons (substring remaining 0 break-pos) acc)))))))
+              (loop (substring remaining break-pos)
+                    (cons (substring remaining 0 break-pos) acc)))))))
 
-;; Find a good break position (prefer space)
+;; Find a good break position using visible column width (prefer space).
+;; Returns a character index (not a column index) into `text`.
 (define (find-break-pos text max-width)
-  (define search-start (sub1 max-width))
-  (let loop ([i search-start])
+  ;; Walk through the string by character, accumulating visible width.
+  ;; Find the last whitespace before visible width exceeds max-width.
+  (let loop ([i 0]
+             [col 0]
+             [last-space-idx #f])
     (cond
-      [(<= i 0) max-width]
-      [(char-whitespace? (string-ref text i)) (+ i 1)]
-      [else (loop (sub1 i))])))
+      [(>= i (string-length text)) (string-length text)]
+      [(>= col max-width)
+       ;; Exceeded width — break at last space or current position
+       (or last-space-idx i)]
+      [else
+       (define c (string-ref text i))
+       (define w (char-width c))
+       (define new-col (+ col w))
+       (cond
+         ;; Char would exceed max-width on its own
+         [(> new-col max-width)
+          (or last-space-idx i)]
+         [(char-whitespace? c)
+          (loop (add1 i) new-col (add1 i))]
+         [else
+          (loop (add1 i) new-col last-space-idx)])])))
 
 ;; Invert a style (add 'inverse if not present, remove if present)
 (define (style-invert style)


### PR DESCRIPTION
## Wave 1: CJK/Wide-Char Width Awareness

Part of v0.8.3 TUI Modernization milestone.

### Changes

- **New module `tui/char-width.rkt`** (#367): Unicode-aware terminal column width functions (`char-width`, `string-visible-width`) following UAX #11. Covers CJK ideographs, Hiragana, Katakana, Hangul, fullwidth variants, emoji, combining marks (width 0), control characters (width 0).

- **Refactor text wrapping** (#368): `wrap-text`, `wrap-single-line`, and `find-break-pos` in `tui/render.rkt` now use visible column width instead of `string-length`. CJK text wraps at correct visual boundaries.

- **Refactor input scrolling** (#369): `input-visible-window` in `tui/input.rkt` now computes cursor position and scroll offset using visible column width. Wide-char cursor positioning works correctly.

### Tests
- 21 new char-width tests
- 8 new CJK wrapping tests in render tests
- 5 new CJK visible window tests in input tests
- All 371 TUI tests pass
- Format lint passed

Closes #367, Closes #368, Closes #369