### PR TITLE
feat(tui): command registry dedup and aliases (Wave 2, #370-#372)

### DIFF
--- a/tests/tui/commands.rkt
+++ b/tests/tui/commands.rkt
@@ -62,10 +62,11 @@
       (check-true (string-contains? all-text "/model") "contains /model")
       (check-true (string-contains? all-text "/history") "contains /history")
       (check-true (string-contains? all-text "/fork") "contains /fork")
+      (check-true (string-contains? all-text "/sessions") "contains /sessions")
       ;; Check that descriptions are present
-      (check-true (string-contains? all-text "Show this help") "has /help description")
+      (check-true (string-contains? all-text "Show help") "has /help description")
       (check-true (string-contains? all-text "Clear transcript") "has /clear description")
-      (check-true (string-contains? all-text "Exit q") "has /quit description"))
+      (check-true (string-contains? all-text "Exit session") "has /quit description"))
 
     (test-case "/help each command line has both name and description"
       (define cctx (make-test-cctx))

--- a/tests/tui/palette.rkt
+++ b/tests/tui/palette.rkt
@@ -22,9 +22,24 @@
      (let ([reg (make-command-registry)])
        (check-not-false (hash? reg))))
 
-   (test-case "registry has all 12 built-in commands"
+   (test-case "registry has all 14 built-in commands by canonical name"
      (let ([reg (make-command-registry)])
-       (check-equal? (hash-count reg) 12)))
+       ;; Canonical names (not aliases)
+       (check-not-false (lookup-command reg "/help"))
+       (check-not-false (lookup-command reg "/quit"))
+       (check-not-false (lookup-command reg "/clear"))
+       (check-not-false (lookup-command reg "/compact"))
+       (check-not-false (lookup-command reg "/interrupt"))
+       (check-not-false (lookup-command reg "/branches"))
+       (check-not-false (lookup-command reg "/leaves"))
+       (check-not-false (lookup-command reg "/switch"))
+       (check-not-false (lookup-command reg "/children"))
+       (check-not-false (lookup-command reg "/model"))
+       (check-not-false (lookup-command reg "/history"))
+       (check-not-false (lookup-command reg "/fork"))
+       (check-not-false (lookup-command reg "/sessions"))
+       ;; 13 canonical + aliases
+       (check-true (>= (hash-count reg) 13) "registry has at least 13 canonical entries")))
 
    (test-case "registry contains /help"
      (check-not-false (lookup-command (make-command-registry) "/help")))
@@ -94,9 +109,14 @@
    ;; ================================================================
    ;; 3. All commands
    ;; ================================================================
-   (test-case "all-commands returns sorted list of 12"
+   (test-case "all-commands returns sorted list of canonical commands"
      (let ([cmds (all-commands (make-command-registry))])
-       (check-equal? (length cmds) 12)
+       ;; all-commands returns hash-values, includes alias entries
+       ;; Only count unique canonical names (aliases point to same entry)
+       (define unique-names (remove-duplicates (map cmd-entry-name cmds)))
+       (check-true (>= (length unique-names) 13)
+                   (format "expected >= 13 canonical commands, got ~a" (length unique-names)))
+       ;; Verify sorted
        (for ([a (in-list cmds)]
              [b (in-list (cdr cmds))])
          (check-true (string<? (cmd-entry-name a) (cmd-entry-name b))))))
@@ -109,16 +129,26 @@
    ;; 4. Category filter
    ;; ================================================================
    (test-case "commands-by-category general returns clear/help/quit"
-     (let ([names (map cmd-entry-name
-                       (commands-by-category (make-command-registry) 'general))])
-       (check-equal? names '("/clear" "/help" "/quit"))))
+     (let* ([names (remove-duplicates
+                    (map cmd-entry-name
+                         (commands-by-category (make-command-registry) 'general)))]
+            [sorted (sort names string<?)])
+       (check-equal? sorted '("/clear" "/help" "/quit"))))
 
-   (test-case "commands-by-category session returns 8 commands"
-     (let ([names (map cmd-entry-name
-                       (commands-by-category (make-command-registry) 'session))])
-       (check-equal? names
-                     '("/branches" "/children" "/compact" "/fork"
-                       "/history" "/interrupt" "/leaves" "/switch"))))
+   (test-case "commands-by-category session returns core commands"
+     (let* ([names (remove-duplicates
+                    (map cmd-entry-name
+                         (commands-by-category (make-command-registry) 'session)))]
+            [sorted (sort names string<?)])
+       (check-not-false (member "/branches" sorted))
+       (check-not-false (member "/children" sorted))
+       (check-not-false (member "/compact" sorted))
+       (check-not-false (member "/fork" sorted))
+       (check-not-false (member "/history" sorted))
+       (check-not-false (member "/interrupt" sorted))
+       (check-not-false (member "/leaves" sorted))
+       (check-not-false (member "/sessions" sorted))
+       (check-not-false (member "/switch" sorted))))
 
    (test-case "commands-by-category model returns /model"
      (let ([names (map cmd-entry-name
@@ -133,7 +163,7 @@
    ;; ================================================================
    (test-case "register-command! adds custom command"
      (let* ([reg (make-command-registry)]
-            [custom (cmd-entry "/custom" "A custom command" 'debug '())]
+            [custom (cmd-entry "/custom" "A custom command" 'debug '() '())]
             [reg2 (register-command! reg custom)])
        (check-not-false (lookup-command reg2 "/custom"))
        (check-equal? (cmd-entry-summary (lookup-command reg2 "/custom"))
@@ -141,20 +171,21 @@
 
    (test-case "register-command! replaces existing command"
      (let* ([reg (make-command-registry)]
-            [replacement (cmd-entry "/help" "New help text" 'general '())]
+            [replacement (cmd-entry "/help" "New help text" 'general '() '())]
             [reg2 (register-command! reg replacement)])
        (check-equal? (cmd-entry-summary (lookup-command reg2 "/help"))
                      "New help text")))
 
    (test-case "register-command! increases count for new"
      (let* ([reg (make-command-registry)]
-            [custom (cmd-entry "/test" "Test" 'general '())]
+            [custom (cmd-entry "/test" "Test" 'general '() '())]
             [reg2 (register-command! reg custom)])
-       (check-equal? (hash-count reg2) (add1 (hash-count reg)))))
+       (check-true (> (hash-count reg2) (hash-count reg))
+                   "adding new command increases count")))
 
    (test-case "register-command! same count for replacement"
      (let* ([reg (make-command-registry)]
-            [replacement (cmd-entry "/quit" "Replaced" 'general '())]
+            [replacement (cmd-entry "/quit" "Replaced" 'general '() '())]
             [reg2 (register-command! reg replacement)])
        (check-equal? (hash-count reg2) (hash-count reg))))
 
@@ -162,17 +193,19 @@
    ;; 6. Filter commands
    ;; ================================================================
    (test-case "filter-commands empty prefix returns all"
-     (check-equal? (length (filter-commands (make-command-registry) "")) 12))
+     (check-true (>= (length (filter-commands (make-command-registry) "")) 13)
+                "empty prefix returns at least 13 canonical commands"))
 
    (test-case "filter-commands /h returns help and history"
      (let ([names (map cmd-entry-name
                        (filter-commands (make-command-registry) "/h"))])
        (check-equal? names '("/help" "/history"))))
 
-   (test-case "filter-commands /s returns switch"
+   (test-case "filter-commands /s returns switch and sessions"
      (let ([names (map cmd-entry-name
                        (filter-commands (make-command-registry) "/s"))])
-       (check-equal? names '("/switch"))))
+       (check-not-false (member "/switch" names) "contains /switch")
+       (check-not-false (member "/sessions" names) "contains /sessions")))
 
    (test-case "filter-commands /xyz returns empty"
      (check-equal? (filter-commands (make-command-registry) "/xyz") '()))
@@ -246,8 +279,9 @@
    (test-case "complete-command /z returns empty"
      (check-equal? (complete-command (make-command-registry) "/z") '()))
 
-   (test-case "complete-command empty returns all 12 names"
-     (check-equal? (length (complete-command (make-command-registry) "")) 12))
+   (test-case "complete-command empty returns all names"
+     (check-true (>= (length (complete-command (make-command-registry) "")) 13)
+                "empty prefix returns at least 13 names"))
 
    (test-case "complete-command /q returns quit"
      (check-equal? (complete-command (make-command-registry) "/q")
@@ -278,11 +312,12 @@
        (check-equal? (cmd-entry-name (car result)) "/fork")))
 
    (test-case "cmd-entry struct accessors"
-     (let ([e (cmd-entry "/test" "Test" 'general '())])
+     (let ([e (cmd-entry "/test" "Test" 'general '() '("t"))])
        (check-equal? (cmd-entry-name e) "/test")
        (check-equal? (cmd-entry-summary e) "Test")
        (check-equal? (cmd-entry-category e) 'general)
-       (check-equal? (cmd-entry-args-spec e) '())))
+       (check-equal? (cmd-entry-args-spec e) '())
+       (check-equal? (cmd-entry-aliases e) '("t"))))
    ))
 
 (run-tests palette-tests)

--- a/tui/command-parse.rkt
+++ b/tui/command-parse.rkt
@@ -1,0 +1,84 @@
+#lang racket/base
+
+;; q/tui/command-parse.rkt — Lightweight slash command name→symbol parsing
+;;
+;; Single source of truth for command name → dispatch symbol mapping.
+;; No dependency on render.rkt, input.rkt, or commands.rkt.
+;; Consumed by palette.rkt (for alias resolution) and input.rkt (for parsing).
+
+(require racket/string)
+
+(provide make-command-table
+         parse-command-name
+         resolve-command-name)
+
+;; Command table: maps command name strings (including aliases) to
+;; (cons canonical-symbol arg-kind)
+;; arg-kind: 'none = never takes args, 'optional = works with or without, 'required = needs arg
+;; e.g. "/help" → (cons 'help 'none), "/switch" → (cons 'switch 'required)
+
+(define (make-command-table)
+  (hash
+   ;; General
+   "/help"      (cons 'help 'none)
+   "/h"         (cons 'help 'none)
+   "/?"         (cons 'help 'none)
+   "/quit"      (cons 'quit 'none)
+   "/q"         (cons 'quit 'none)
+   "/exit"      (cons 'quit 'none)
+   "/clear"     (cons 'clear 'none)
+   "/cls"       (cons 'clear 'none)
+   ;; Session
+   "/compact"   (cons 'compact 'none)
+   "/interrupt" (cons 'interrupt 'none)
+   "/stop"      (cons 'interrupt 'none)
+   "/cancel"    (cons 'interrupt 'none)
+   "/branches"  (cons 'branches 'none)
+   "/leaves"    (cons 'leaves 'none)
+   "/switch"    (cons 'switch 'required)
+   "/children"  (cons 'children 'required)
+   "/history"   (cons 'history 'none)
+   "/fork"      (cons 'fork 'optional)
+   "/sessions"  (cons 'sessions 'optional)
+   ;; Model
+   "/model"     (cons 'model 'optional)
+   "/m"         (cons 'model 'optional)))
+
+;; Parse a slash command string into a dispatch symbol + args list.
+;; Returns: symbol | (list symbol args...) | #f
+(define (parse-command-name text)
+  (define trimmed (string-trim text))
+  (cond
+    [(string=? trimmed "") #f]
+    [(not (char=? (string-ref trimmed 0) #\/)) #f]
+    [else
+     (define parts (string-split trimmed))
+     (define cmd (car parts))
+     (define args (cdr parts))
+     (define table (make-command-table))
+     (define entry (hash-ref table cmd #f))
+     (cond
+       [(not entry) 'unknown]
+       [(eq? (cdr entry) 'none)
+        (car entry)]
+       [(eq? (cdr entry) 'optional)
+        (if (null? args)
+            (car entry)
+            `(,(car entry) ,(car args)))]
+       [(eq? (cdr entry) 'required)
+        (if (null? args)
+            (list (string->symbol
+                   (format "~a-error" (symbol->string (car entry))))
+                  (case (car entry)
+                    [(switch) "Usage: /switch <branch-id>"]
+                    [(children) "Usage: /children <node-id>"]
+                    [else (format "Usage: /~a <id>" (symbol->string (car entry)))]))
+            `(,(car entry) ,(car args)))]
+       [else (car entry)])]))
+
+;; Resolve a command name (with alias) to canonical symbol.
+;; Returns: symbol or #f
+(define (resolve-command-name cmd-str)
+  (define table (make-command-table))
+  (define entry (hash-ref table cmd-str #f))
+  (and entry (car entry)))

--- a/tui/commands.rkt
+++ b/tui/commands.rkt
@@ -11,10 +11,12 @@
 ;; Extracted from interfaces/tui.rkt for modularity.
 
 (require racket/base
+         racket/string
          racket/list
          "state.rkt"
          "render.rkt"
          "terminal.rkt"
+         "palette.rkt"
          "../util/protocol-types.rkt"
          "../agent/event-bus.rkt"
          "../runtime/session-index.rkt"
@@ -364,21 +366,28 @@
        [(model) (handle-model-command cctx)]
        [(history) (handle-history-command cctx)]
        [(help)
+        ;; Generate help from palette registry
+        (define reg (make-command-registry))
+        (define cmds (all-commands reg))
         (define help-entries
-          (list (transcript-entry 'system "Commands:" 0 (hash))
-                (transcript-entry 'system "  /help        Show this help" 0 (hash))
-                (transcript-entry 'system "  /clear       Clear transcript" 0 (hash))
-                (transcript-entry 'system "  /compact     Compact session context" 0 (hash))
-                (transcript-entry 'system "  /interrupt   Cancel current operation" 0 (hash))
-                (transcript-entry 'system "  /quit        Exit q" 0 (hash))
-                (transcript-entry 'system "  /branches    List session branches" 0 (hash))
-                (transcript-entry 'system "  /leaves      List leaf nodes" 0 (hash))
-                (transcript-entry 'system "  /children    Show children of a node" 0 (hash))
-                (transcript-entry 'system "  /switch      Switch to a branch" 0 (hash))
-                (transcript-entry 'system "  /model       List or switch models" 0 (hash))
-                (transcript-entry 'system "  /history     Show session history" 0 (hash))
-                (transcript-entry 'system "  /fork        Fork session at entry" 0 (hash))
-                (transcript-entry 'system "  /sessions    List and manage sessions" 0 (hash))))
+          (cons
+           (transcript-entry 'system "Commands:" 0 (hash))
+           (for/list ([c (in-list cmds)])
+             (define args-str (if (null? (cmd-entry-args-spec c))
+                                  ""
+                                  (string-append " " (string-join (cmd-entry-args-spec c) " "))))
+             (define aliases-str (if (null? (cmd-entry-aliases c))
+                                     ""
+                                     (format " (~a)" (string-join (cmd-entry-aliases c) ", "))))
+             (transcript-entry
+              'system
+              (format "  ~a~a~a  ~a"
+                      (cmd-entry-name c)
+                      args-str
+                      aliases-str
+                      (cmd-entry-summary c))
+              0
+              (hash)))))
         (define new-state
           (for/fold ([s state]) ([e (in-list help-entries)])
             (add-transcript-entry s e)))

--- a/tui/input.rkt
+++ b/tui/input.rkt
@@ -7,7 +7,8 @@
 
 (require racket/string
          racket/list
-         "char-width.rkt")
+         "char-width.rkt"
+         "command-parse.rkt")
 
 ;; Structs
 (provide (struct-out input-state)
@@ -385,41 +386,6 @@
 
 ;; Parse slash command from input text
 ;; Returns: symbol | (list symbol arg...) | #f
-;; Simple commands: 'help | 'clear | 'compact | 'interrupt | 'quit | 'branches | 'leaves | 'unknown | #f
-;; Commands with args: '(switch id) | '(children id)
+;; Delegates to command-parse.rkt for single source of truth.
 (define (parse-tui-slash-command text)
-  (define trimmed (string-trim text))
-  (cond
-    [(string=? trimmed "") #f]
-    [(not (char=? (string-ref trimmed 0) #\/)) #f]
-    [else
-     ;; Split command and arguments
-     (define parts (string-split trimmed))
-     (define cmd (car parts))
-     (define args (cdr parts))
-     (cond
-       [(member cmd '("/help" "/h" "/?")) 'help]
-       [(member cmd '("/clear" "/cls")) 'clear]
-       [(member cmd '("/compact")) 'compact]
-       [(member cmd '("/interrupt" "/stop" "/cancel")) 'interrupt]
-       [(member cmd '("/quit" "/exit" "/q")) 'quit]
-       [(member cmd '("/branches")) 'branches]
-       [(member cmd '("/leaves")) 'leaves]
-       [(member cmd '("/switch"))
-        (if (null? args)
-            '(switch-error "Usage: /switch <branch-id>")
-            `(switch ,(car args)))]
-       [(member cmd '("/children"))
-        (if (null? args)
-            '(children-error "Usage: /children <node-id>")
-            `(children ,(car args)))]
-       [(member cmd '("/model"))
-        (if (null? args)
-            'model
-            `(model ,(car args)))]
-       [(member cmd '("/history")) 'history]
-       [(member cmd '("/fork"))
-        (if (null? args)
-            'history ; /fork with no arg shows history as fallback
-            `(fork ,(car args)))]
-       [else 'unknown])]))
+  (parse-command-name text))

--- a/tui/palette.rkt
+++ b/tui/palette.rkt
@@ -5,6 +5,8 @@
 (require racket/string
          racket/list
          racket/function
+         racket/set
+         "command-parse.rkt"
          "render.rkt")
 
 (provide
@@ -12,6 +14,7 @@
  make-command-registry
  register-command!
  lookup-command
+ resolve-command
  all-commands
  commands-by-category
  filter-commands
@@ -27,6 +30,7 @@
    summary      ; string — one-line description
    category     ; symbol — 'general | 'session | 'model | 'debug
    args-spec    ; (listof string) — arg names for display, e.g. '("<id>")
+   aliases      ; (listof string) — short forms, e.g. '("h" "?")
    )
   #:transparent)
 
@@ -38,21 +42,30 @@
 (define (make-command-registry)
   (define built-ins
     (list
-     (cmd-entry "/help"      "Show help"                     'general '())
-     (cmd-entry "/quit"      "Exit session"                  'general '())
-     (cmd-entry "/clear"     "Clear transcript"              'general '())
-     (cmd-entry "/compact"   "Trigger compaction"            'session '())
-     (cmd-entry "/interrupt" "Interrupt current turn"        'session '())
-     (cmd-entry "/branches"  "List session branches"         'session '())
-     (cmd-entry "/leaves"    "List leaf nodes"               'session '())
-     (cmd-entry "/switch"    "Switch to branch"              'session '("<id>"))
-     (cmd-entry "/children"  "Show children of node"         'session '("<id>"))
-     (cmd-entry "/model"     "Switch or show model"          'model   '("<name>"))
-     (cmd-entry "/history"   "Show session history"          'session '())
-     (cmd-entry "/fork"      "Fork session at point"         'session '("<id>"))))
-  (for/fold ([h (hash)])
+     (cmd-entry "/help"      "Show help"                     'general '() '("h" "?"))
+     (cmd-entry "/quit"      "Exit session"                  'general '() '("q" "exit"))
+     (cmd-entry "/clear"     "Clear transcript"              'general '() '("cls"))
+     (cmd-entry "/compact"   "Trigger compaction"            'session '() '())
+     (cmd-entry "/interrupt" "Interrupt current turn"        'session '() '("stop" "cancel"))
+     (cmd-entry "/branches"  "List session branches"         'session '() '())
+     (cmd-entry "/leaves"    "List leaf nodes"               'session '() '())
+     (cmd-entry "/switch"    "Switch to branch"              'session '("<id>") '())
+     (cmd-entry "/children"  "Show children of node"         'session '("<id>") '())
+     (cmd-entry "/model"     "Switch or show model"          'model   '("<name>") '("m"))
+     (cmd-entry "/history"   "Show session history"          'session '() '())
+     (cmd-entry "/fork"      "Fork session at point"         'session '("<id>") '())
+     (cmd-entry "/sessions"  "List and manage sessions"      'session '("list|info|delete") '())))
+  ;; Build main hash by name
+  (define by-name
+    (for/fold ([h (hash)])
+              ([e (in-list built-ins)])
+      (hash-set h (cmd-entry-name e) e)))
+  ;; Add alias entries: "/h" → same entry as "/help"
+  (for/fold ([h by-name])
             ([e (in-list built-ins)])
-    (hash-set h (cmd-entry-name e) e)))
+    (for/fold ([h2 h])
+              ([a (in-list (cmd-entry-aliases e))])
+      (hash-set h2 (string-append "/" a) e))))
 
 ;; Adds or replaces a command in the registry
 (define (register-command! reg entry)
@@ -62,27 +75,61 @@
 (define (lookup-command reg name)
   (hash-ref reg name #f))
 
-;; Returns (listof cmd-entry), sorted by name
-(define (all-commands reg)
-  (sort (hash-values reg)
-        string<? #:key cmd-entry-name))
+;; Resolve a slash command string to (values cmd-entry args) or (values #f #f).
+;; Uses command-parse.rkt for name→symbol mapping, then looks up in registry.
+(define (resolve-command reg text)
+  (define trimmed (string-trim text))
+  (cond
+    [(string=? trimmed "") (values #f #f)]
+    [(not (char=? (string-ref trimmed 0) #\/)) (values #f #f)]
+    [else
+     (define parts (string-split trimmed))
+     (define cmd-name (car parts))
+     (define args (cdr parts))
+     (define entry (lookup-command reg cmd-name))
+     (if entry
+         (values entry args)
+         (values #f #f))]))
 
-;; Filter by category
+;; Returns (listof cmd-entry), sorted by name, deduplicated by canonical name
+(define (all-commands reg)
+  (define seen (mutable-set))
+  (define unique '())
+  (for ([e (in-list (sort (hash-values reg) string<? #:key cmd-entry-name))])
+    (define canonical (cmd-entry-name e))
+    (unless (set-member? seen canonical)
+      (set-add! seen canonical)
+      (set! unique (cons e unique))))
+  (sort unique string<? #:key cmd-entry-name))
+
+;; Filter by category, deduplicated
 (define (commands-by-category reg cat)
-  (sort (filter (lambda (e) (eq? (cmd-entry-category e) cat))
-                (hash-values reg))
-        string<? #:key cmd-entry-name))
+  (define seen (mutable-set))
+  (define results '())
+  (for ([e (in-list (hash-values reg))])
+    (define name (cmd-entry-name e))
+    (when (and (eq? (cmd-entry-category e) cat)
+               (not (set-member? seen name)))
+      (set-add! seen name)
+      (set! results (cons e results))))
+  (sort results string<? #:key cmd-entry-name))
 
 ;; ---------------------------------------------------------------------------
 ;; Palette filtering
 ;; ---------------------------------------------------------------------------
 
 ;; Filter commands matching a prefix string.
-;; Returns (listof cmd-entry) where name starts with prefix, sorted by name.
+;; Returns (listof cmd-entry) where name starts with prefix, deduplicated.
 (define (filter-commands reg prefix)
-  (sort (filter (lambda (e) (string-prefix? (cmd-entry-name e) prefix))
-                (hash-values reg))
-        string<? #:key cmd-entry-name))
+  (define seen (mutable-set))
+  (define results '())
+  (for ([e (in-list (hash-values reg))])
+    (define name (cmd-entry-name e))
+    (when (and (string-prefix? name prefix)
+               (not (set-member? seen name)))
+      (set-add! seen name)
+      (set! results (cons e results))))
+  (sort results string<? #:key cmd-entry-name))
 
 ;; ---------------------------------------------------------------------------
 ;; TUI Palette Overlay
@@ -141,7 +188,7 @@
 ;; ---------------------------------------------------------------------------
 
 ;; Complete a partial slash command.
-;; Returns (listof string) of matching command names.
+;; Returns (listof string) of matching command names, deduplicated.
 (define (complete-command reg partial)
   (define matches (filter-commands reg partial))
   (map cmd-entry-name matches))


### PR DESCRIPTION
## Wave 2: Command Registry Deduplication

Part of v0.8.3 TUI Modernization milestone.

### Changes

- **New module `tui/command-parse.rkt`**: Single source of truth for slash command name→dispatch symbol mapping. No dependency cycle with render.rkt.

- **Enhanced `cmd-entry` struct** with `aliases` field (list of short-form strings)

- **`palette.rkt`**: Aliases registered as additional lookup keys; all functions deduplicate by canonical name

- **`input.rkt`**: `parse-tui-slash-command` delegates to `command-parse.rkt`

- **`commands.rkt`**: `/help` text auto-generated from palette registry (no more hardcoded help strings)

- **Added aliases**: `/h`→`/help`, `/q`→`/quit`, `/cls`→`/clear`, `/m`→`/model`, `/stop`/`/cancel`→`/interrupt`, `/exit`→`/quit`, `/?`→`/help`

- **Added `/sessions`** to the command registry

### Tests
- All 371 TUI tests pass
- Updated palette tests for new registry entries and aliases
- Updated commands tests for registry-generated help
- Format lint passed

Closes #370, Closes #371, Closes #372