### PR TITLE
feat(tui): Rendered-line caching (Wave 4, #374-#376)

### DIFF
--- a/tests/interfaces/tui.rkt
+++ b/tests/interfaces/tui.rkt
@@ -11,13 +11,25 @@
          "../../../q/tui/state.rkt"
          "../../../q/tui/terminal.rkt"
          (only-in "../../../q/tui/render.rkt"
-                  styled-line styled-line?
-                  styled-segment styled-segment?
-                  styled-line-segments styled-segment-text styled-segment-style
-                  apply-selection-highlight highlight-line-range style-invert
-                  render-transcript render-status-bar render-input-line
-                  render-branch-list render-leaf-nodes render-children-list
-                  format-entry md-format-assistant wrap-styled-line)
+                  styled-line
+                  styled-line?
+                  styled-segment
+                  styled-segment?
+                  styled-line-segments
+                  styled-segment-text
+                  styled-segment-style
+                  apply-selection-highlight
+                  highlight-line-range
+                  style-invert
+                  render-transcript
+                  render-status-bar
+                  render-input-line
+                  render-branch-list
+                  render-leaf-nodes
+                  render-children-list
+                  format-entry
+                  md-format-assistant
+                  wrap-styled-line)
          "../../../q/tui/layout.rkt"
          "../../../q/util/protocol-types.rkt"
          "../../../q/agent/event-bus.rkt"
@@ -26,17 +38,13 @@
 (test-case "make-tui-ctx returns a valid tui-ctx with default values"
   (let ([ctx (make-tui-ctx)])
     (check-true (tui-ctx? ctx) "make-tui-ctx returns a tui-ctx")
-    (check-true (ui-state? (unbox (tui-ctx-ui-state-box ctx)))
-                "initial ui-state is a ui-state")
+    (check-true (ui-state? (unbox (tui-ctx-ui-state-box ctx))) "initial ui-state is a ui-state")
     (check-true (input-state? (unbox (tui-ctx-input-state-box ctx)))
                 "initial input-state is an input-state")
-    (check-false (tui-ctx-event-bus ctx)
-                 "event-bus defaults to #f")
-    (check-true (unbox (tui-ctx-running-box ctx))
-                "running defaults to #t")
+    (check-false (tui-ctx-event-bus ctx) "event-bus defaults to #f")
+    (check-true (unbox (tui-ctx-running-box ctx)) "running defaults to #t")
     ;; BUG-33: needs-redraw defaults to #t (first frame must draw)
-    (check-true (unbox (tui-ctx-needs-redraw-box ctx))
-                "needs-redraw defaults to #t")))
+    (check-true (unbox (tui-ctx-needs-redraw-box ctx)) "needs-redraw defaults to #t")))
 
 (test-case "make-tui-ctx stores event-bus and session-runner kwargs"
   (let ([bus (make-event-bus)]
@@ -48,26 +56,21 @@
 (test-case "BUG-33: needs-redraw flag is set by key events"
   (let ([ctx (make-tui-ctx)])
     ;; Initial state: needs-redraw is #t
-    (check-true (unbox (tui-ctx-needs-redraw-box ctx))
-                "BUG-33: initial needs-redraw is #t")
+    (check-true (unbox (tui-ctx-needs-redraw-box ctx)) "BUG-33: initial needs-redraw is #t")
     ;; Simulate: mark as drawn
     (set-box! (tui-ctx-needs-redraw-box ctx) #f)
-    (check-false (unbox (tui-ctx-needs-redraw-box ctx))
-                 "BUG-33: can clear needs-redraw")
+    (check-false (unbox (tui-ctx-needs-redraw-box ctx)) "BUG-33: can clear needs-redraw")
     ;; Simulate: key press marks dirty
     (handle-key ctx #\h)
-    (check-true (unbox (tui-ctx-needs-redraw-box ctx))
-                "BUG-33: key press sets needs-redraw")
+    (check-true (unbox (tui-ctx-needs-redraw-box ctx)) "BUG-33: key press sets needs-redraw")
     ;; Simulate: escape key still marks dirty (cursor may need reposition)
     (set-box! (tui-ctx-needs-redraw-box ctx) #f)
     (handle-key ctx #\u001b)
-    (check-true (unbox (tui-ctx-needs-redraw-box ctx))
-                "BUG-33: escape key sets needs-redraw")
+    (check-true (unbox (tui-ctx-needs-redraw-box ctx)) "BUG-33: escape key sets needs-redraw")
     ;; Simulate: arrow keys mark dirty
     (set-box! (tui-ctx-needs-redraw-box ctx) #f)
     (handle-key ctx 'left)
-    (check-true (unbox (tui-ctx-needs-redraw-box ctx))
-                "BUG-33: arrow key sets needs-redraw")))
+    (check-true (unbox (tui-ctx-needs-redraw-box ctx)) "BUG-33: arrow key sets needs-redraw")))
 
 ;; ============================================================
 ;; handle-key — character input
@@ -93,20 +96,20 @@
   (let ([ctx (make-tui-ctx)])
     (handle-key ctx #\a)
     (handle-key ctx #\b)
-  (define result (handle-key ctx #\backspace))
-  (check-equal? result 'continue "backspace returns 'continue")
-  (check-equal? (input-state-buffer (unbox (tui-ctx-input-state-box ctx)))
-                "a"
-                "backspace removes last char")))
+    (define result (handle-key ctx #\backspace))
+    (check-equal? result 'continue "backspace returns 'continue")
+    (check-equal? (input-state-buffer (unbox (tui-ctx-input-state-box ctx)))
+                  "a"
+                  "backspace removes last char")))
 
 (test-case "handle-key: rubout (delete) removes character"
   (let ([ctx (make-tui-ctx)])
     (handle-key ctx #\x)
-  (define result (handle-key ctx #\rubout))
-  (check-equal? result 'continue "rubout returns 'continue")
-  (check-equal? (input-state-buffer (unbox (tui-ctx-input-state-box ctx)))
-                ""
-                "rubout removes char")))
+    (define result (handle-key ctx #\rubout))
+    (check-equal? result 'continue "rubout returns 'continue")
+    (check-equal? (input-state-buffer (unbox (tui-ctx-input-state-box ctx)))
+                  ""
+                  "rubout removes char")))
 
 (test-case "handle-key: return on empty buffer returns 'continue"
   (let ([ctx (make-tui-ctx)])
@@ -136,8 +139,7 @@
     (define result (handle-key ctx #\newline))
     (check-equal? result 'continue "newline inserts, does not submit")
     (define inp (unbox (tui-ctx-input-state-box ctx)))
-    (check-true (string-contains? (input-state-buffer inp) "\n")
-                "newline char in buffer")))
+    (check-true (string-contains? (input-state-buffer inp) "\n") "newline char in buffer")))
 
 (test-case "handle-key: slash /help command is parsed"
   (let ([ctx (make-tui-ctx)])
@@ -173,33 +175,29 @@
   (let ([ctx (make-tui-ctx)])
     (handle-key ctx #\a)
     (handle-key ctx #\b)
-  (define result (handle-key ctx 'left))
-  (check-equal? result 'continue "left returns 'continue")
-  (check-equal? (input-state-cursor (unbox (tui-ctx-input-state-box ctx)))
-                1
-                "cursor moved left")))
+    (define result (handle-key ctx 'left))
+    (check-equal? result 'continue "left returns 'continue")
+    (check-equal? (input-state-cursor (unbox (tui-ctx-input-state-box ctx))) 1 "cursor moved left")))
 
 (test-case "handle-key: right arrow moves cursor right"
   (let ([ctx (make-tui-ctx)])
     (handle-key ctx #\a)
     (handle-key ctx 'left)
-  (define result (handle-key ctx 'right))
-  (check-equal? result 'continue "right returns 'continue")
-  (check-equal? (input-state-cursor (unbox (tui-ctx-input-state-box ctx)))
-                1
-                "cursor moved right")))
+    (define result (handle-key ctx 'right))
+    (check-equal? result 'continue "right returns 'continue")
+    (check-equal? (input-state-cursor (unbox (tui-ctx-input-state-box ctx))) 1 "cursor moved right")))
 
 (test-case "handle-key: up arrow restores history entry"
   (let ([ctx (make-tui-ctx)])
     ;; Push some history by submitting
     (handle-key ctx #\a)
-  (handle-key ctx #\return)
-  ;; Now press up
-  (define result (handle-key ctx 'up))
-  (check-equal? result 'continue "up returns 'continue")
-  (check-equal? (input-state-buffer (unbox (tui-ctx-input-state-box ctx)))
-                "a"
-                "up restores history entry")))
+    (handle-key ctx #\return)
+    ;; Now press up
+    (define result (handle-key ctx 'up))
+    (check-equal? result 'continue "up returns 'continue")
+    (check-equal? (input-state-buffer (unbox (tui-ctx-input-state-box ctx)))
+                  "a"
+                  "up restores history entry")))
 
 (test-case "handle-key: down arrow after up returns 'continue"
   (let ([ctx (make-tui-ctx)])
@@ -254,7 +252,7 @@
     ;; Add entries to transcript
     (define state (unbox (tui-ctx-ui-state-box ctx)))
     (for ([i (in-range 10)])
-      (define entry (transcript-entry 'system (format "line ~a" i) 0 (hash)))
+      (define entry (make-entry 'system (format "line ~a" i) 0 (hash)))
       (set! state (add-transcript-entry state entry)))
     (set-box! (tui-ctx-ui-state-box ctx) state)
     (define result (handle-key ctx 'page-up))
@@ -268,7 +266,7 @@
   (let ([ctx (make-tui-ctx)])
     (define state (unbox (tui-ctx-ui-state-box ctx)))
     (for ([i (in-range 10)])
-      (define entry (transcript-entry 'system (format "line ~a" i) 0 (hash)))
+      (define entry (make-entry 'system (format "line ~a" i) 0 (hash)))
       (set! state (add-transcript-entry state entry)))
     (set! state (scroll-up state 20))
     (set-box! (tui-ctx-ui-state-box ctx) state)
@@ -311,7 +309,7 @@
     ;; Add some transcript entries first
     (define state (unbox (tui-ctx-ui-state-box ctx)))
     (set-box! (tui-ctx-ui-state-box ctx)
-              (add-transcript-entry state (transcript-entry 'user "hello" 0 (hash))))
+              (add-transcript-entry state (make-entry 'user "hello" 0 (hash))))
     (check-true (positive? (length (ui-state-transcript (unbox (tui-ctx-ui-state-box ctx)))))
                 "transcript has entries before clear")
     (define result (process-slash-command ctx 'clear))
@@ -345,7 +343,8 @@
     (define result (process-slash-command ctx 'interrupt))
     (check-equal? result 'continue "interrupt returns 'continue")
     (check-true (event? received) "interrupt publishes event")
-    (check-equal? (event-ev received) "interrupt.requested"
+    (check-equal? (event-ev received)
+                  "interrupt.requested"
                   "interrupt publishes correct event type")))
 
 (test-case "process-slash-command: /interrupt without bus returns 'continue"
@@ -396,11 +395,11 @@
          (define evt (sync/timeout 0 ch-inner))
          (when evt
            (define state (unbox (tui-ctx-ui-state-box ctx)))
-           (set-box! (tui-ctx-ui-state-box ctx)
-                     (apply-event-to-state state evt))
+           (set-box! (tui-ctx-ui-state-box ctx) (apply-event-to-state state evt))
            (loop)))))
     ;; Check the event was applied
-    (check-equal? (ui-state-session-id (unbox (tui-ctx-ui-state-box ctx))) "s1"
+    (check-equal? (ui-state-session-id (unbox (tui-ctx-ui-state-box ctx)))
+                  "s1"
                   "drain-events: session.started applied via channel")))
 
 (test-case "tui-ctx has event-ch async-channel"
@@ -436,10 +435,10 @@
     (handle-key ctx #\a)
     (handle-key ctx #\return)
     (define result (handle-key ctx 'kp-up))
-  (check-equal? result 'continue "kp-up returns 'continue")
-  (check-equal? (input-state-buffer (unbox (tui-ctx-input-state-box ctx)))
-                "a"
-                "kp-up loads history")))
+    (check-equal? result 'continue "kp-up returns 'continue")
+    (check-equal? (input-state-buffer (unbox (tui-ctx-input-state-box ctx)))
+                  "a"
+                  "kp-up loads history")))
 
 (test-case "BUG-31: kp-down returns 'continue"
   (let ([ctx (make-tui-ctx)])
@@ -488,7 +487,7 @@
   (let ([ctx (make-tui-ctx)])
     (define state (unbox (tui-ctx-ui-state-box ctx)))
     (for ([i (in-range 10)])
-      (define entry (transcript-entry 'system (format "line ~a" i) 0 (hash)))
+      (define entry (make-entry 'system (format "line ~a" i) 0 (hash)))
       (set! state (add-transcript-entry state entry)))
     (set-box! (tui-ctx-ui-state-box ctx) state)
     (define result (handle-key ctx 'pgup))
@@ -499,7 +498,7 @@
   (let ([ctx (make-tui-ctx)])
     (define state (unbox (tui-ctx-ui-state-box ctx)))
     (for ([i (in-range 10)])
-      (define entry (transcript-entry 'system (format "line ~a" i) 0 (hash)))
+      (define entry (make-entry 'system (format "line ~a" i) 0 (hash)))
       (set! state (add-transcript-entry state entry)))
     (set! state (scroll-up state 20))
     (set-box! (tui-ctx-ui-state-box ctx) state)
@@ -512,7 +511,7 @@
   (let ([ctx (make-tui-ctx)])
     (define state (unbox (tui-ctx-ui-state-box ctx)))
     (for ([i (in-range 10)])
-      (define entry (transcript-entry 'system (format "line ~a" i) 0 (hash)))
+      (define entry (make-entry 'system (format "line ~a" i) 0 (hash)))
       (set! state (add-transcript-entry state entry)))
     (set-box! (tui-ctx-ui-state-box ctx) state)
     (define result (handle-key ctx 'kp-pgup))
@@ -524,7 +523,7 @@
   (let ([ctx (make-tui-ctx)])
     (define state (unbox (tui-ctx-ui-state-box ctx)))
     (for ([i (in-range 10)])
-      (define entry (transcript-entry 'system (format "line ~a" i) 0 (hash)))
+      (define entry (make-entry 'system (format "line ~a" i) 0 (hash)))
       (set! state (add-transcript-entry state entry)))
     (set! state (scroll-up state 20))
     (set-box! (tui-ctx-ui-state-box ctx) state)
@@ -543,7 +542,6 @@
                   ""
                   "kp-enter clears buffer after submit")))
 
-
 ;; --------------------------------------------------------
 ;; fix-sgr-bg-black — SGR post-processor
 ;; --------------------------------------------------------
@@ -552,32 +550,31 @@
 (test-case "fix-sgr: standalone \\e[40m → \\e[49m"
   (let ()
     ;; T1: standalone \e[40m → \e[49m
-    (check-equal? (fix-sgr-bg-black "\x1b[40m") "\x1b[49m"
-                  "fix-sgr: standalone bg=black → default")))
+    (check-equal? (fix-sgr-bg-black "\x1b[40m") "\x1b[49m" "fix-sgr: standalone bg=black → default")))
 
 (test-case "fix-sgr: compound fg+bg black → fg+default"
   (let ()
     ;; T2: compound \e[37;40m → \e[37;49m (fg+bg)
-    (check-equal? (fix-sgr-bg-black "\x1b[37;40m") "\x1b[37;49m"
+    (check-equal? (fix-sgr-bg-black "\x1b[37;40m")
+                  "\x1b[37;49m"
                   "fix-sgr: compound fg+bg black → fg+default")))
 
 (test-case "fix-sgr: compound fg+bg+bold → fg+default+bold"
   (let ()
     ;; T3: compound \e[37;40;1m → \e[37;49;1m (fg+bg+bold)
-    (check-equal? (fix-sgr-bg-black "\x1b[37;40;1m") "\x1b[37;49;1m"
+    (check-equal? (fix-sgr-bg-black "\x1b[37;40;1m")
+                  "\x1b[37;49;1m"
                   "fix-sgr: compound fg+bg+bold → fg+default+bold")))
 
 (test-case "fix-sgr: non-black bg preserved"
   (let ()
     ;; T4: non-black bg preserved
-    (check-equal? (fix-sgr-bg-black "\x1b[47m") "\x1b[47m"
-                  "fix-sgr: non-black bg unchanged")))
+    (check-equal? (fix-sgr-bg-black "\x1b[47m") "\x1b[47m" "fix-sgr: non-black bg unchanged")))
 
 (test-case "fix-sgr: plain text passthrough unchanged"
   (let ()
     ;; T5: plain text passthrough
-    (check-equal? (fix-sgr-bg-black "hello world") "hello world"
-                  "fix-sgr: plain text unchanged")))
+    (check-equal? (fix-sgr-bg-black "hello world") "hello world" "fix-sgr: plain text unchanged")))
 
 (test-case "fix-sgr: mixed sequences handled"
   (let ()
@@ -589,8 +586,7 @@
 (test-case "fix-sgr: empty SGR unchanged"
   (let ()
     ;; T7: empty SGR \e[m
-    (check-equal? (fix-sgr-bg-black "\x1b[m") "\x1b[m"
-                  "fix-sgr: empty SGR unchanged")))
+    (check-equal? (fix-sgr-bg-black "\x1b[m") "\x1b[m" "fix-sgr: empty SGR unchanged")))
 
 (test-case "fix-sgr: multiple SGR all fixed"
   (let ()
@@ -602,32 +598,37 @@
 (test-case "fix-sgr: bg=0 as first param → default"
   (let ()
     ;; T9: bg=0 first param \e[40;1m
-    (check-equal? (fix-sgr-bg-black "\x1b[40;1m") "\x1b[49;1m"
+    (check-equal? (fix-sgr-bg-black "\x1b[40;1m")
+                  "\x1b[49;1m"
                   "fix-sgr: bg=0 as first param → default")))
 
 (test-case "fix-sgr: 256-color fg index 40 not changed"
   (let ()
     ;; T10: 256-color fg with index 40 — should NOT be changed
     ;; \e[38;5;40m is fg=256-color-40, not bg=black
-    (check-equal? (fix-sgr-bg-black "\x1b[38;5;40m") "\x1b[38;5;40m"
+    (check-equal? (fix-sgr-bg-black "\x1b[38;5;40m")
+                  "\x1b[38;5;40m"
                   "fix-sgr: 256-color fg index 40 not changed")))
 
 (test-case "fix-sgr: 256-color bg index 40 not changed"
   (let ()
     ;; T11: 256-color bg with index 40 — should NOT be changed
-    (check-equal? (fix-sgr-bg-black "\x1b[48;5;40m") "\x1b[48;5;40m"
+    (check-equal? (fix-sgr-bg-black "\x1b[48;5;40m")
+                  "\x1b[48;5;40m"
                   "fix-sgr: 256-color bg index 40 not changed")))
 
 (test-case "fix-sgr: truecolor fg R=40 not changed"
   (let ()
     ;; T12: truecolor fg with R=40 — should NOT be changed
-    (check-equal? (fix-sgr-bg-black "\x1b[38;2;40;0;0m") "\x1b[38;2;40;0;0m"
+    (check-equal? (fix-sgr-bg-black "\x1b[38;2;40;0;0m")
+                  "\x1b[38;2;40;0;0m"
                   "fix-sgr: truecolor fg R=40 not changed")))
 
 (test-case "fix-sgr: truecolor bg R=40 not changed"
   (let ()
     ;; T13: truecolor bg with R=40 — should NOT be changed
-    (check-equal? (fix-sgr-bg-black "\x1b[48;2;40;0;0m") "\x1b[48;2;40;0;0m"
+    (check-equal? (fix-sgr-bg-black "\x1b[48;2;40;0;0m")
+                  "\x1b[48;2;40;0;0m"
                   "fix-sgr: truecolor bg R=40 not changed")))
 
 ;; --------------------------------------------------------
@@ -640,7 +641,7 @@
     (define ctx (make-tui-ctx))
     (define state (unbox (tui-ctx-ui-state-box ctx)))
     (for ([i (in-range 10)])
-      (define entry (transcript-entry 'system (format "line ~a" i) 0 (hash)))
+      (define entry (make-entry 'system (format "line ~a" i) 0 (hash)))
       (set! state (add-transcript-entry state entry)))
     (set-box! (tui-ctx-ui-state-box ctx) state)
     (handle-mouse ctx '(scroll-up 0 5))
@@ -654,7 +655,7 @@
     (define ctx (make-tui-ctx))
     (define state (unbox (tui-ctx-ui-state-box ctx)))
     (for ([i (in-range 10)])
-      (define entry (transcript-entry 'system (format "line ~a" i) 0 (hash)))
+      (define entry (make-entry 'system (format "line ~a" i) 0 (hash)))
       (set! state (add-transcript-entry state entry)))
     (set! state (scroll-up state 10))
     (set-box! (tui-ctx-ui-state-box ctx) state)
@@ -669,7 +670,7 @@
     (define ctx (make-tui-ctx))
     (define state (unbox (tui-ctx-ui-state-box ctx)))
     (for ([i (in-range 10)])
-      (define entry (transcript-entry 'system (format "line ~a" i) 0 (hash)))
+      (define entry (make-entry 'system (format "line ~a" i) 0 (hash)))
       (set! state (add-transcript-entry state entry)))
     (set! state (scroll-up state 2))
     (set-box! (tui-ctx-ui-state-box ctx) state)
@@ -684,7 +685,7 @@
     (define ctx (make-tui-ctx))
     (define state (unbox (tui-ctx-ui-state-box ctx)))
     (for ([i (in-range 10)])
-      (define entry (transcript-entry 'system (format "line ~a" i) 0 (hash)))
+      (define entry (make-entry 'system (format "line ~a" i) 0 (hash)))
       (set! state (add-transcript-entry state entry)))
     (set! state (scroll-up state 5))
     (set-box! (tui-ctx-ui-state-box ctx) state)
@@ -705,22 +706,22 @@
   (let ()
     ;; Right click does NOT set selection (only left button)
     (define ctx (make-tui-ctx))
-    (handle-mouse ctx '(click 2 10 5))  ;; button=2 (right)
+    (handle-mouse ctx '(click 2 10 5)) ;; button=2 (right)
     (define state (unbox (tui-ctx-ui-state-box ctx)))
     (check-false (ui-state-sel-anchor state) "right click does not set selection")))
 (test-case "middle click does not set selection"
   (let ()
     ;; Middle click does NOT set selection (only left button)
     (define ctx (make-tui-ctx))
-    (handle-mouse ctx '(click 1 10 5))  ;; button=1 (middle)
+    (handle-mouse ctx '(click 1 10 5)) ;; button=1 (middle)
     (define state (unbox (tui-ctx-ui-state-box ctx)))
     (check-false (ui-state-sel-anchor state) "middle click does not set selection")))
 (test-case "drag updates sel-end"
   (let ()
     ;; Drag updates selection end
     (define ctx (make-tui-ctx))
-    (handle-mouse ctx '(click 0 10 5))   ;; start
-    (handle-mouse ctx '(drag 15 8))     ;; drag to new position
+    (handle-mouse ctx '(click 0 10 5)) ;; start
+    (handle-mouse ctx '(drag 15 8)) ;; drag to new position
     (define state (unbox (tui-ctx-ui-state-box ctx)))
     (check-equal? (ui-state-sel-end state) '(15 . 8) "drag updates sel-end")))
 (test-case "drag without anchor does nothing"
@@ -734,8 +735,8 @@
   (let ()
     ;; Release preserves selection (for visual feedback + clipboard)
     (define ctx (make-tui-ctx))
-    (handle-mouse ctx '(click 0 10 5))   ;; start
-    (handle-mouse ctx '(release 15 8))   ;; release
+    (handle-mouse ctx '(click 0 10 5)) ;; start
+    (handle-mouse ctx '(release 15 8)) ;; release
     (define state (unbox (tui-ctx-ui-state-box ctx)))
     (check-not-false (ui-state-sel-anchor state) "release preserves sel-anchor")
     (check-not-false (ui-state-sel-end state) "release preserves sel-end")))
@@ -749,8 +750,8 @@
 (test-case "styled-line->text concatenates segments"
   (let ()
     ;; styled-line->text extracts plain text
-    (define line (styled-line (list (styled-segment "hello" '(bold cyan))
-                                    (styled-segment " world" '(dim)))))
+    (define line
+      (styled-line (list (styled-segment "hello" '(bold cyan)) (styled-segment " world" '(dim)))))
     (check-equal? (styled-line->text line) "hello world" "styled-line->text concatenates segments")))
 (test-case "empty styled-line gives empty string"
   (let ()
@@ -763,10 +764,8 @@
     (define ctx (make-tui-ctx))
     (define state (unbox (tui-ctx-ui-state-box ctx)))
     ;; Add a user message entry
-    (define state2 (add-transcript-entry state
-                 (transcript-entry 'user "hello world" 0 (hash))))
-    (define state3 (add-transcript-entry state2
-                 (transcript-entry 'assistant "test response" 0 (hash))))
+    (define state2 (add-transcript-entry state (make-entry 'user "hello world" 0 (hash))))
+    (define state3 (add-transcript-entry state2 (make-entry 'assistant "test response" 0 (hash))))
     (set-box! (tui-ctx-ui-state-box ctx) state3)
     ;; Set selection anchor at (0, 0) — but transcript starts below header
     (define state-sel (set-selection-anchor state3 0 2))
@@ -779,8 +778,7 @@
     ;; selection-text returns "" for out-of-bounds coordinates
     (define ctx (make-tui-ctx))
     (define state (unbox (tui-ctx-ui-state-box ctx)))
-    (define state2 (add-transcript-entry state
-                 (transcript-entry 'system "log entry" 0 (hash))))
+    (define state2 (add-transcript-entry state (make-entry 'system "log entry" 0 (hash))))
     (set-box! (tui-ctx-ui-state-box ctx) state2)
     ;; Selection entirely out of transcript bounds
     (define state-sel (set-selection-anchor state2 0 100))
@@ -810,21 +808,15 @@
 (test-case "decode-mouse-x10: middle drag"
   (let ()
     ;; Right click: cb=34 (button=2, no motion)
-    (check-equal? (decode-mouse-x10 34 38 43)
-                  '(mouse click 2 5 10)
-                  "decode-mouse-x10: right click")))
+    (check-equal? (decode-mouse-x10 34 38 43) '(mouse click 2 5 10) "decode-mouse-x10: right click")))
 (test-case "decode-mouse-x10: release (P0 — was silently dropped)"
   (let ()
     ;; Drag (left held + motion): cb = 32+32 = 64
-    (check-equal? (decode-mouse-x10 64 38 43)
-                  '(mouse drag 5 10)
-                  "decode-mouse-x10: left drag")))
+    (check-equal? (decode-mouse-x10 64 38 43) '(mouse drag 5 10) "decode-mouse-x10: left drag")))
 (test-case "decode-mouse-x10: release at (0,0)"
   (let ()
     ;; Drag (middle held + motion): cb = 33+32 = 65
-    (check-equal? (decode-mouse-x10 65 38 43)
-                  '(mouse drag 5 10)
-                  "decode-mouse-x10: middle drag")))
+    (check-equal? (decode-mouse-x10 65 38 43) '(mouse drag 5 10) "decode-mouse-x10: middle drag")))
 (test-case "decode-mouse-x10: scroll up"
   (let ()
     ;; Release: cb=35 (button=3, NO motion bit) — this was the P0 bug
@@ -841,9 +833,7 @@
 (test-case "decode-mouse-x10: cb=67 is release (button=3 regardless of motion)"
   (let ()
     ;; Scroll up: cb = 96 (64 + 0 + 32)
-    (check-equal? (decode-mouse-x10 96 33 33)
-                  '(mouse scroll-up 0 0)
-                  "decode-mouse-x10: scroll up")))
+    (check-equal? (decode-mouse-x10 96 33 33) '(mouse scroll-up 0 0) "decode-mouse-x10: scroll up")))
 (test-case "decode-mouse-x10: scroll down cb=97"
   (let ()
     ;; Scroll down: cb = 97 (64 + 1 + 32)
@@ -865,10 +855,8 @@
     (define ctx (make-tui-ctx))
     (define state (unbox (tui-ctx-ui-state-box ctx)))
     ;; Add two entries so we have multiple lines
-    (define state2 (add-transcript-entry state
-                     (transcript-entry 'user "first line" 0 (hash))))
-    (define state3 (add-transcript-entry state2
-                     (transcript-entry 'assistant "second line" 0 (hash))))
+    (define state2 (add-transcript-entry state (make-entry 'user "first line" 0 (hash))))
+    (define state3 (add-transcript-entry state2 (make-entry 'assistant "second line" 0 (hash))))
     (set-box! (tui-ctx-ui-state-box ctx) state3)
     ;; Select first transcript line (screen row 1 = first line after header)
     (define state-sel (set-selection-anchor state3 0 1))
@@ -882,10 +870,8 @@
     ;; selection-text row mapping — second transcript line
     (define ctx (make-tui-ctx))
     (define state (unbox (tui-ctx-ui-state-box ctx)))
-    (define state2 (add-transcript-entry state
-                     (transcript-entry 'user "alpha" 0 (hash))))
-    (define state3 (add-transcript-entry state2
-                     (transcript-entry 'assistant "beta" 0 (hash))))
+    (define state2 (add-transcript-entry state (make-entry 'user "alpha" 0 (hash))))
+    (define state3 (add-transcript-entry state2 (make-entry 'assistant "beta" 0 (hash))))
     (set-box! (tui-ctx-ui-state-box ctx) state3)
     ;; Select second transcript line (screen row 2)
     (define state-sel (set-selection-anchor state3 0 2))
@@ -899,25 +885,22 @@
     (define ctx (make-tui-ctx))
     ;; Add transcript content
     (define state (unbox (tui-ctx-ui-state-box ctx)))
-    (define state2 (add-transcript-entry state
-                     (transcript-entry 'assistant "Hello world this is a test" 0 (hash))))
+    (define state2
+      (add-transcript-entry state (make-entry 'assistant "Hello world this is a test" 0 (hash))))
     (set-box! (tui-ctx-ui-state-box ctx) state2)
 
     ;; Simulate click (left button, col 0, row 1)
     (handle-mouse ctx '(click 0 0 1))
     (define after-click (unbox (tui-ctx-ui-state-box ctx)))
-    (check-not-false (ui-state-sel-anchor after-click)
-                     "selection lifecycle: anchor set after click")
-    (check-not-false (ui-state-sel-end after-click)
-                     "selection lifecycle: end set after click")
+    (check-not-false (ui-state-sel-anchor after-click) "selection lifecycle: anchor set after click")
+    (check-not-false (ui-state-sel-end after-click) "selection lifecycle: end set after click")
 
     ;; Simulate drag (col 10, row 1)
     (handle-mouse ctx '(drag 10 1))
     (define after-drag (unbox (tui-ctx-ui-state-box ctx)))
     (check-not-false (ui-state-sel-anchor after-drag)
                      "selection lifecycle: anchor persists during drag")
-    (check-not-false (ui-state-sel-end after-drag)
-                     "selection lifecycle: end updated during drag")
+    (check-not-false (ui-state-sel-end after-drag) "selection lifecycle: end updated during drag")
 
     ;; Simulate release (col 10, row 1)
     (handle-mouse ctx '(release 10 1))
@@ -931,10 +914,8 @@
     ;; Test 2: Next click resets selection
     (define ctx (make-tui-ctx))
     (define state (unbox (tui-ctx-ui-state-box ctx)))
-    (define state2 (add-transcript-entry state
-                     (transcript-entry 'assistant "First line" 0 (hash))))
-    (define state3 (add-transcript-entry state2
-                     (transcript-entry 'assistant "Second line" 0 (hash))))
+    (define state2 (add-transcript-entry state (make-entry 'assistant "First line" 0 (hash))))
+    (define state3 (add-transcript-entry state2 (make-entry 'assistant "Second line" 0 (hash))))
     (set-box! (tui-ctx-ui-state-box ctx) state3)
 
     ;; Select first line
@@ -957,8 +938,7 @@
     ;; Test 3: Zero-length selection has no text
     (define ctx (make-tui-ctx))
     (define state (unbox (tui-ctx-ui-state-box ctx)))
-    (define state2 (add-transcript-entry state
-                     (transcript-entry 'assistant "Hello" 0 (hash))))
+    (define state2 (add-transcript-entry state (make-entry 'assistant "Hello" 0 (hash))))
     (set-box! (tui-ctx-ui-state-box ctx) state2)
     ;; Click and release at same point (no drag)
     (handle-mouse ctx '(click 0 3 1))
@@ -973,20 +953,19 @@
   (let ()
     ;; Release does NOT move sel-end to release position
     (define ctx (make-tui-ctx))
-    (handle-mouse ctx '(click 0 2 1))    ;; left-click at (2,1)
-    (handle-mouse ctx '(drag 10 1))       ;; drag to (10,1)
-    (handle-mouse ctx '(release 20 1))    ;; release at (20,1) — should NOT move end
+    (handle-mouse ctx '(click 0 2 1)) ;; left-click at (2,1)
+    (handle-mouse ctx '(drag 10 1)) ;; drag to (10,1)
+    (handle-mouse ctx '(release 20 1)) ;; release at (20,1) — should NOT move end
     (define state (unbox (tui-ctx-ui-state-box ctx)))
     (define sel-end (ui-state-sel-end state))
-    (check-equal? sel-end '(10 . 1)
-                  "release does not move sel-end: stays at last drag position")))
+    (check-equal? sel-end '(10 . 1) "release does not move sel-end: stays at last drag position")))
 (test-case "right-click does not change sel-anchor"
   (let ()
     ;; Right-click does not corrupt existing selection
     (define ctx (make-tui-ctx))
     (define state (unbox (tui-ctx-ui-state-box ctx)))
-    (define state2 (add-transcript-entry state
-                     (transcript-entry 'assistant "Hello world test string" 0 (hash))))
+    (define state2
+      (add-transcript-entry state (make-entry 'assistant "Hello world test string" 0 (hash))))
     (set-box! (tui-ctx-ui-state-box ctx) state2)
     ;; Left-click and drag to select "Hello"
     (handle-mouse ctx '(click 0 0 1))
@@ -998,17 +977,19 @@
     (handle-mouse ctx '(release 15 3))
     (define after-right-click (unbox (tui-ctx-ui-state-box ctx)))
     ;; Selection endpoints should be UNCHANGED by right-click
-    (check-equal? (ui-state-sel-anchor after-right-click) '(0 . 1)
+    (check-equal? (ui-state-sel-anchor after-right-click)
+                  '(0 . 1)
                   "right-click does not change sel-anchor")
-    (check-equal? (ui-state-sel-end after-right-click) drag-end
+    (check-equal? (ui-state-sel-end after-right-click)
+                  drag-end
                   "right-click does not change sel-end")))
 (test-case "Resize polling tests (BUG: TUI not resized on terminal resize)"
   (let ()
     ;; Release copies correct text (from drag selection, not release position)
     (define ctx (make-tui-ctx))
     (define state (unbox (tui-ctx-ui-state-box ctx)))
-    (define state2 (add-transcript-entry state
-                     (transcript-entry 'assistant "Alpha Beta Gamma Delta" 0 (hash))))
+    (define state2
+      (add-transcript-entry state (make-entry 'assistant "Alpha Beta Gamma Delta" 0 (hash))))
     (set-box! (tui-ctx-ui-state-box ctx) state2)
     ;; Select first 5 chars ("Alpha") — drag to col 4 (0..4 = 5 chars)
     (handle-mouse ctx '(click 0 0 1))
@@ -1017,8 +998,7 @@
     (handle-mouse ctx '(release 20 1))
     (define state-after (unbox (tui-ctx-ui-state-box ctx)))
     (define text (selection-text ctx state-after))
-    (check-true (and (string? text)
-                     (string=? text "Alpha"))
+    (check-true (and (string? text) (string=? text "Alpha"))
                 (format "release copies drag selection text, got: ~s" text))))
 (test-case "Resize polling tests (BUG: TUI not resized on terminal resize)"
   (let ()
@@ -1035,16 +1015,14 @@
     (define ctx (make-tui-ctx))
     (set-box! (tui-ctx-needs-redraw-box ctx) #f)
     (mark-dirty! ctx)
-    (check-true (unbox (tui-ctx-needs-redraw-box ctx))
-                "resize poll: mark-dirty! sets redraw flag")))
+    (check-true (unbox (tui-ctx-needs-redraw-box ctx)) "resize poll: mark-dirty! sets redraw flag")))
 (test-case "no-feedback-loop: first call returns #t"
   (let ()
     ;; Test: tui-screen-size-cache-reset! clears cached size
     ;; After reset, tui-screen-size should re-query (not crash)
     (tui-screen-size-cache-reset!)
     (define-values (cols rows) (tui-screen-size))
-    (check-true (and (integer? cols) (> cols 0))
-                "resize poll: cols is positive integer after reset")
+    (check-true (and (integer? cols) (> cols 0)) "resize poll: cols is positive integer after reset")
     (check-true (and (integer? rows) (> rows 0))
                 "resize poll: rows is positive integer after reset")))
 (test-case "no-feedback-loop: first call returns #t"
@@ -1086,7 +1064,8 @@
     (define ctx (make-tui-ctx))
     ;; Add transcript entries so selection has text to select
     (define state0 (unbox (tui-ctx-ui-state-box ctx)))
-    (define state1 (add-transcript-entry state0 (transcript-entry 'assistant "Alpha Beta Gamma Delta" 0 (hash))))
+    (define state1
+      (add-transcript-entry state0 (make-entry 'assistant "Alpha Beta Gamma Delta" 0 (hash))))
     (set-box! (tui-ctx-ui-state-box ctx) state1)
     ;; Set up a selection via mouse click+drag at row 1 (transcript line 0)
     (handle-mouse ctx '(click 0 0 1))
@@ -1095,8 +1074,9 @@
     (define state-with-sel (unbox (tui-ctx-ui-state-box ctx)))
     (check-not-false (has-selection? state-with-sel) "ctrl-c: selection exists after drag")
     ;; Ctrl-C should copy — test by checking handle-key returns 'continue
-    (define result (parameterize ([current-clipboard-mode 'osc52])
-                     (handle-key ctx 'ctrl-c)))
+    (define result
+      (parameterize ([current-clipboard-mode 'osc52])
+        (handle-key ctx 'ctrl-c)))
     (check-equal? result 'continue "ctrl-c: handle-key returns 'continue")))
 (test-case "ctrl-c no selection: returns 'continue"
   (let ()
@@ -1104,15 +1084,13 @@
     (define ctx (make-tui-ctx))
     (define state (unbox (tui-ctx-ui-state-box ctx)))
     ;; No selection set — should not crash
-    (define result (parameterize ([current-clipboard-mode 'osc52])
-                     (handle-key ctx 'ctrl-c)))
+    (define result
+      (parameterize ([current-clipboard-mode 'osc52])
+        (handle-key ctx 'ctrl-c)))
     (check-equal? result 'continue "ctrl-c no selection: returns 'continue")))
 (test-case "current-clipboard-mode is a parameter"
   (let ()
     ;; copy-text! is accessible from interfaces/tui
-    (check-true (procedure? copy-text!)
-                "copy-text! is exported from interfaces/tui")
-    (check-true (procedure? copy-selection!)
-                "copy-selection! is exported from interfaces/tui")
-    (check-true (parameter? current-clipboard-mode)
-                "current-clipboard-mode is a parameter")))
+    (check-true (procedure? copy-text!) "copy-text! is exported from interfaces/tui")
+    (check-true (procedure? copy-selection!) "copy-selection! is exported from interfaces/tui")
+    (check-true (parameter? current-clipboard-mode) "current-clipboard-mode is a parameter")))

--- a/tests/test-scrollback.rkt
+++ b/tests/test-scrollback.rkt
@@ -9,7 +9,7 @@
 ;; ============================================================
 
 (test-case "transcript-entry->jsexpr serializes fields"
-  (define entry (transcript-entry 'assistant "hello" 12345 (hash 'model "gpt")))
+  (define entry (make-entry 'assistant "hello" 12345 (hash 'model "gpt")))
   (define j (transcript-entry->jsexpr entry))
   (check-equal? (hash-ref j 'kind) "assistant")
   (check-equal? (hash-ref j 'text) "hello")
@@ -24,7 +24,7 @@
   (check-equal? (transcript-entry-timestamp entry) 99))
 
 (test-case "transcript-entry round-trip preserves data"
-  (define original (transcript-entry 'system "test" 42 (hash 'key "val")))
+  (define original (make-entry 'system "test" 42 (hash 'key "val")))
   (define restored (jsexpr->transcript-entry (transcript-entry->jsexpr original)))
   (check-equal? (transcript-entry-text restored) "test")
   (check-eq? (transcript-entry-kind restored) 'system)
@@ -36,9 +36,7 @@
 
 (test-case "save-scrollback and load-scrollback round-trip"
   (define tmp (make-temporary-file "q-test-scrollback-~a.jsonl"))
-  (define entries
-    (list (transcript-entry 'assistant "hello" 1 (hash))
-          (transcript-entry 'user "world" 2 (hash))))
+  (define entries (list (make-entry 'assistant "hello" 1 (hash)) (make-entry 'user "world" 2 (hash))))
   (save-scrollback entries tmp)
   (define loaded (load-scrollback tmp))
   (check-equal? (length loaded) 2)
@@ -55,7 +53,7 @@
   (define tmp (make-temporary-file "q-test-scrollback-~a.jsonl"))
   (define entries
     (for/list ([i (in-range 600)])
-      (transcript-entry 'system (format "entry-~a" i) i (hash))))
+      (make-entry 'system (format "entry-~a" i) i (hash))))
   (save-scrollback entries tmp)
   (define loaded (load-scrollback tmp))
   ;; Should be trimmed to 500 (scrollback-max-entries)

--- a/tests/test-tui-enter.rkt
+++ b/tests/test-tui-enter.rkt
@@ -125,14 +125,14 @@
     ;; --------------------------------------------------
     (test-case "welcome transcript entries have system kind"
       (define welcome-entries
-        (list (transcript-entry 'system
-                                "Welcome to q! Type a message to get started."
-                                (current-inexact-milliseconds)
-                                (hash))
-              (transcript-entry 'system
-                                "Commands: /help for reference, /quit to exit."
-                                (current-inexact-milliseconds)
-                                (hash))))
+        (list (make-entry 'system
+                          "Welcome to q! Type a message to get started."
+                          (current-inexact-milliseconds)
+                          (hash))
+              (make-entry 'system
+                          "Commands: /help for reference, /quit to exit."
+                          (current-inexact-milliseconds)
+                          (hash))))
       (for ([entry (in-list welcome-entries)])
         (check-equal? (transcript-entry-kind entry) 'system)
         (check-pred string? (transcript-entry-text entry))
@@ -141,9 +141,8 @@
 
     (test-case "welcome entries prepended before user entries"
       (define welcome-entries
-        (list (transcript-entry 'system "Welcome" 0 (hash))
-              (transcript-entry 'system "Commands" 0 (hash))))
-      (define user-entries (list (transcript-entry 'user "hello" 0 (hash))))
+        (list (make-entry 'system "Welcome" 0 (hash)) (make-entry 'system "Commands" 0 (hash))))
+      (define user-entries (list (make-entry 'user "hello" 0 (hash))))
       (define combined (append welcome-entries user-entries))
       (check-equal? (length combined) 3)
       (check-equal? (transcript-entry-kind (car combined)) 'system)
@@ -151,14 +150,14 @@
 
     (test-case "welcome entries contain expected text"
       (define welcome-entries
-        (list (transcript-entry 'system
-                                "Welcome to q! Type a message to get started."
-                                (current-inexact-milliseconds)
-                                (hash))
-              (transcript-entry 'system
-                                "Commands: /help for reference, /quit to exit."
-                                (current-inexact-milliseconds)
-                                (hash))))
+        (list (make-entry 'system
+                          "Welcome to q! Type a message to get started."
+                          (current-inexact-milliseconds)
+                          (hash))
+              (make-entry 'system
+                          "Commands: /help for reference, /quit to exit."
+                          (current-inexact-milliseconds)
+                          (hash))))
       (check-equal? (transcript-entry-text (first welcome-entries))
                     "Welcome to q! Type a message to get started.")
       (check-equal? (transcript-entry-text (second welcome-entries))

--- a/tests/test-tui-keybindings.rkt
+++ b/tests/test-tui-keybindings.rkt
@@ -79,7 +79,7 @@
       (define ctx (make-tui-ctx))
       ;; Add a transcript entry
       (define state (unbox (tui-ctx-ui-state-box ctx)))
-      (define entry (transcript-entry 'user "hello" (current-inexact-milliseconds) (hash)))
+      (define entry (make-entry 'user "hello" (current-inexact-milliseconds) (hash)))
       (set-box! (tui-ctx-ui-state-box ctx) (add-transcript-entry state entry))
       (check-equal? (length (ui-state-transcript (unbox (tui-ctx-ui-state-box ctx)))) 1)
       (process-slash-command ctx 'clear)

--- a/tests/test-tui-renderer.rkt
+++ b/tests/test-tui-renderer.rkt
@@ -61,22 +61,24 @@
 ;; Put a string to the mock ubuf
 ;; Matches real tui-ubuf signature exactly:
 ;;   (ubuf x y str #:fg [7] #:bg [0] #:bold [#f] #:underline [#f] #:italic [#f] #:blink [#f])
-(define (mock-ubuf-putstring! ubuf col row str
-                               #:fg [fg 7]
-                               #:bg [bg 0]
-                               #:bold [bold #f]
-                               #:underline [underline #f]
-                               #:italic [italic #f]
-                               #:blink [blink #f])
+(define (mock-ubuf-putstring! ubuf
+                              col
+                              row
+                              str
+                              #:fg [fg 7]
+                              #:bg [bg 0]
+                              #:bold [bold #f]
+                              #:underline [underline #f]
+                              #:italic [italic #f]
+                              #:blink [blink #f])
   (for ([i (in-range (string-length str))])
     (mock-ubuf-set-cell! ubuf (+ col i) row (string-ref str i) bold underline fg bg)))
 
 ;; Read a row as string (ignoring styles)
 (define (mock-ubuf-row-string ubuf row)
   (define cols (mock-ubuf-cols ubuf))
-  (list->string
-   (for/list ([col (in-range 0 cols)])
-     (mock-cell-char (mock-ubuf-cell ubuf col row)))))
+  (list->string (for/list ([col (in-range 0 cols)])
+                  (mock-cell-char (mock-ubuf-cell ubuf col row)))))
 
 ;; Check if a row has a specific style attribute
 (define (mock-ubuf-row-has-style? ubuf row style-pred)
@@ -87,8 +89,7 @@
 ;; Count cells with a specific style in a row
 (define (mock-ubuf-row-style-count ubuf row style-accessor)
   (define cols (mock-ubuf-cols ubuf))
-  (for/sum ([col (in-range 0 cols)])
-    (if (style-accessor (mock-ubuf-cell ubuf col row)) 1 0)))
+  (for/sum ([col (in-range 0 cols)]) (if (style-accessor (mock-ubuf-cell ubuf col row)) 1 0)))
 
 ;; ============================================================
 ;; Test helpers
@@ -98,402 +99,364 @@
 (define (run-render-frame! ubuf state input-st layout)
   (parameterize ([current-ubuf-clear mock-ubuf-clear!]
                  [current-ubuf-putstring mock-ubuf-putstring!])
-    (render-frame! ubuf state input-st layout)))
+    (define-values (cc cr _st) (render-frame! ubuf state input-st layout))
+    (values cc cr)))
 
 ;; ============================================================
 ;; Test suite
 ;; ============================================================
 
 (define renderer-tests
-  (test-suite
-   "TUI Renderer"
+  (test-suite "TUI Renderer"
 
-   ;; --------------------------------------------------------
-   ;; style->ubuf-kws
-   ;; --------------------------------------------------------
-   (test-case "style->ubuf-kws converts bold"
-     (define-values (kws vals) (style->ubuf-kws '(bold)))
-     (check-not-false (member '#:bold kws) "bold keyword present")
-     (check-equal? (list-ref vals (index-of kws '#:bold)) #t "bold value is #t"))
+    ;; --------------------------------------------------------
+    ;; style->ubuf-kws
+    ;; --------------------------------------------------------
+    (test-case "style->ubuf-kws converts bold"
+      (define-values (kws vals) (style->ubuf-kws '(bold)))
+      (check-not-false (member '#:bold kws) "bold keyword present")
+      (check-equal? (list-ref vals (index-of kws '#:bold)) #t "bold value is #t"))
 
-   (test-case "style->ubuf-kws converts inverse to fg/bg swap"
-     (define-values (kws vals) (style->ubuf-kws '(inverse)))
-     (check-not-false (member '#:fg kws) "fg keyword present")
-     (check-not-false (member '#:bg kws) "bg keyword present")
-     (check-equal? (list-ref vals (index-of kws '#:fg)) 0 "inverse fg=0")
-     (check-equal? (list-ref vals (index-of kws '#:bg)) 7 "inverse bg=7"))
+    (test-case "style->ubuf-kws converts inverse to fg/bg swap"
+      (define-values (kws vals) (style->ubuf-kws '(inverse)))
+      (check-not-false (member '#:fg kws) "fg keyword present")
+      (check-not-false (member '#:bg kws) "bg keyword present")
+      (check-equal? (list-ref vals (index-of kws '#:fg)) 0 "inverse fg=0")
+      (check-equal? (list-ref vals (index-of kws '#:bg)) 7 "inverse bg=7"))
 
-   (test-case "style->ubuf-kws converts underline"
-     (define-values (kws vals) (style->ubuf-kws '(underline)))
-     (check-not-false (member '#:underline kws) "underline keyword present")
-     (check-equal? (list-ref vals (index-of kws '#:underline)) #t "underline value is #t"))
+    (test-case "style->ubuf-kws converts underline"
+      (define-values (kws vals) (style->ubuf-kws '(underline)))
+      (check-not-false (member '#:underline kws) "underline keyword present")
+      (check-equal? (list-ref vals (index-of kws '#:underline)) #t "underline value is #t"))
 
-   (test-case "style->ubuf-kws converts dim to fg=8"
-     (define-values (kws vals) (style->ubuf-kws '(dim)))
-     (check-not-false (member '#:fg kws) "fg keyword present")
-     (check-equal? (list-ref vals (index-of kws '#:fg)) 8 "dim fg=8"))
+    (test-case "style->ubuf-kws converts dim to fg=8"
+      (define-values (kws vals) (style->ubuf-kws '(dim)))
+      (check-not-false (member '#:fg kws) "fg keyword present")
+      (check-equal? (list-ref vals (index-of kws '#:fg)) 8 "dim fg=8"))
 
-   (test-case "style->ubuf-kws converts red to fg=1"
-     (define-values (kws vals) (style->ubuf-kws '(red)))
-     (check-not-false (member '#:fg kws) "fg keyword present")
-     (check-equal? (list-ref vals (index-of kws '#:fg)) 1 "red fg=1"))
+    (test-case "style->ubuf-kws converts red to fg=1"
+      (define-values (kws vals) (style->ubuf-kws '(red)))
+      (check-not-false (member '#:fg kws) "fg keyword present")
+      (check-equal? (list-ref vals (index-of kws '#:fg)) 1 "red fg=1"))
 
-   (test-case "style->ubuf-kws converts green to fg=2"
-     (define-values (kws vals) (style->ubuf-kws '(green)))
-     (check-not-false (member '#:fg kws) "fg keyword present")
-     (check-equal? (list-ref vals (index-of kws '#:fg)) 2 "green fg=2"))
+    (test-case "style->ubuf-kws converts green to fg=2"
+      (define-values (kws vals) (style->ubuf-kws '(green)))
+      (check-not-false (member '#:fg kws) "fg keyword present")
+      (check-equal? (list-ref vals (index-of kws '#:fg)) 2 "green fg=2"))
 
-   (test-case "style->ubuf-kws converts multiple styles"
-     (define-values (kws vals) (style->ubuf-kws '(bold red)))
-     (check-not-false (member '#:bold kws) "bold present")
-     (check-not-false (member '#:fg kws) "fg present")
-     (check-equal? (list-ref vals (index-of kws '#:fg)) 1 "red fg=1"))
+    (test-case "style->ubuf-kws converts multiple styles"
+      (define-values (kws vals) (style->ubuf-kws '(bold red)))
+      (check-not-false (member '#:bold kws) "bold present")
+      (check-not-false (member '#:fg kws) "fg present")
+      (check-equal? (list-ref vals (index-of kws '#:fg)) 1 "red fg=1"))
 
-   (test-case "style->ubuf-kws handles empty style list"
-     (define-values (kws vals) (style->ubuf-kws '()))
-     (check-equal? kws '() "empty styles → no keywords")
-     (check-equal? vals '() "empty styles → no values"))
+    (test-case "style->ubuf-kws handles empty style list"
+      (define-values (kws vals) (style->ubuf-kws '()))
+      (check-equal? kws '() "empty styles → no keywords")
+      (check-equal? vals '() "empty styles → no values"))
 
-   (test-case "style->ubuf-kws ignores unknown styles"
-     (define-values (kws vals) (style->ubuf-kws '(bold unknown-style)))
-     (check-not-false (member '#:bold kws) "bold present")
-     ;; Only bold should appear (unknown-style ignored)
-     (check-equal? (length kws) 1 "only 1 keyword for unknown style"))
+    (test-case "style->ubuf-kws ignores unknown styles"
+      (define-values (kws vals) (style->ubuf-kws '(bold unknown-style)))
+      (check-not-false (member '#:bold kws) "bold present")
+      ;; Only bold should appear (unknown-style ignored)
+      (check-equal? (length kws) 1 "only 1 keyword for unknown style"))
 
-   (test-case "style->ubuf-kws bold+underline returns sorted keywords"
-     (define-values (kws vals) (style->ubuf-kws '(bold underline)))
-     ;; keyword-apply requires sorted keywords
-     (check-equal? kws '(#:bold #:underline) "keywords must be sorted"))
+    (test-case "style->ubuf-kws bold+underline returns sorted keywords"
+      (define-values (kws vals) (style->ubuf-kws '(bold underline)))
+      ;; keyword-apply requires sorted keywords
+      (check-equal? kws '(#:bold #:underline) "keywords must be sorted"))
 
-   (test-case "style->ubuf-kws inverse returns sorted keywords"
-     (define-values (kws vals) (style->ubuf-kws '(inverse)))
-     (check-equal? kws '(#:bg #:fg) "inverse keywords must be sorted: bg before fg"))
+    (test-case "style->ubuf-kws inverse returns sorted keywords"
+      (define-values (kws vals) (style->ubuf-kws '(inverse)))
+      (check-equal? kws '(#:bg #:fg) "inverse keywords must be sorted: bg before fg"))
 
-   (test-case "style->ubuf-kws cyan+underline returns sorted keywords"
-     (define-values (kws vals) (style->ubuf-kws '(cyan underline)))
-     (check-equal? kws '(#:fg #:underline) "cyan+underline keywords must be sorted"))
+    (test-case "style->ubuf-kws cyan+underline returns sorted keywords"
+      (define-values (kws vals) (style->ubuf-kws '(cyan underline)))
+      (check-equal? kws '(#:fg #:underline) "cyan+underline keywords must be sorted"))
 
-   (test-case "style->ubuf-kws bold+italic returns sorted keywords"
-     (define-values (kws vals) (style->ubuf-kws '(bold italic)))
-     (check-equal? kws '(#:bold #:italic) "bold+italic keywords must be sorted"))
+    (test-case "style->ubuf-kws bold+italic returns sorted keywords"
+      (define-values (kws vals) (style->ubuf-kws '(bold italic)))
+      (check-equal? kws '(#:bold #:italic) "bold+italic keywords must be sorted"))
 
-   (test-case "style->ubuf-kws all styles returns sorted keywords"
-     (define-values (kws vals) (style->ubuf-kws '(inverse bold underline)))
-     (check-equal? kws '(#:bg #:bold #:fg #:underline) "all styles keywords must be sorted"))
+    (test-case "style->ubuf-kws all styles returns sorted keywords"
+      (define-values (kws vals) (style->ubuf-kws '(inverse bold underline)))
+      (check-equal? kws '(#:bg #:bold #:fg #:underline) "all styles keywords must be sorted"))
 
-   (test-case "style->ubuf-kws blue converts to fg=4"
-     (define-values (kws vals) (style->ubuf-kws '(blue)))
-     (check-equal? kws '(#:fg))
-     (check-equal? vals '(4)))
+    (test-case "style->ubuf-kws blue converts to fg=4"
+      (define-values (kws vals) (style->ubuf-kws '(blue)))
+      (check-equal? kws '(#:fg))
+      (check-equal? vals '(4)))
 
-   (test-case "style->ubuf-kws yellow converts to fg=3"
-     (define-values (kws vals) (style->ubuf-kws '(yellow)))
-     (check-equal? kws '(#:fg))
-     (check-equal? vals '(3)))
+    (test-case "style->ubuf-kws yellow converts to fg=3"
+      (define-values (kws vals) (style->ubuf-kws '(yellow)))
+      (check-equal? kws '(#:fg))
+      (check-equal? vals '(3)))
 
-   (test-case "style->ubuf-kws bold+yellow returns sorted keywords"
-     (define-values (kws vals) (style->ubuf-kws '(bold yellow)))
-     (check-equal? kws '(#:bold #:fg) "bold+yellow sorted")
-     (check-equal? vals '(#t 3)))
+    (test-case "style->ubuf-kws bold+yellow returns sorted keywords"
+      (define-values (kws vals) (style->ubuf-kws '(bold yellow)))
+      (check-equal? kws '(#:bold #:fg) "bold+yellow sorted")
+      (check-equal? vals '(#t 3)))
 
-   ;; --------------------------------------------------------
-   ;; Header rendering
-   ;; --------------------------------------------------------
-   (test-case "render-frame! draws header row"
-     (define ubuf (make-mock-ubuf 80 24))
-     (define state (initial-ui-state))
-     (define input-st (initial-input-state))
-     (define layout (compute-layout 80 24))
-     (run-render-frame! ubuf state input-st layout)
-     ;; Check header row (row 1)
-     (define header-str (mock-ubuf-row-string ubuf 0))
-     (check-true (string-prefix? header-str " q ")
-                 "header should start with ' q '")
-     ;; Header should be full width
-     (check-equal? (string-length header-str) 80
-                   "header should be full width"))
+    ;; --------------------------------------------------------
+    ;; Header rendering
+    ;; --------------------------------------------------------
+    (test-case "render-frame! draws header row"
+      (define ubuf (make-mock-ubuf 80 24))
+      (define state (initial-ui-state))
+      (define input-st (initial-input-state))
+      (define layout (compute-layout 80 24))
+      (run-render-frame! ubuf state input-st layout)
+      ;; Check header row (row 1)
+      (define header-str (mock-ubuf-row-string ubuf 0))
+      (check-true (string-prefix? header-str " q ") "header should start with ' q '")
+      ;; Header should be full width
+      (check-equal? (string-length header-str) 80 "header should be full width"))
 
-   (test-case "header row has inverse style applied (fg=0, bg=7)"
-     (define ubuf (make-mock-ubuf 40 10))
-     (define state (initial-ui-state))
-     (define input-st (initial-input-state))
-     (define layout (compute-layout 40 10))
-     (run-render-frame! ubuf state input-st layout)
-     ;; Header should have inverse style: bg=7
-     (define inverse-count
-       (mock-ubuf-row-style-count ubuf 0 (lambda (c) (= (mock-cell-bg c) 7))))
-     (check-true (> inverse-count 0) "header should have bg=7 (inverse)"))
+    (test-case "header row has inverse style applied (fg=0, bg=7)"
+      (define ubuf (make-mock-ubuf 40 10))
+      (define state (initial-ui-state))
+      (define input-st (initial-input-state))
+      (define layout (compute-layout 40 10))
+      (run-render-frame! ubuf state input-st layout)
+      ;; Header should have inverse style: bg=7
+      (define inverse-count (mock-ubuf-row-style-count ubuf 0 (lambda (c) (= (mock-cell-bg c) 7))))
+      (check-true (> inverse-count 0) "header should have bg=7 (inverse)"))
 
-   (test-case "render-frame! clears buffer before drawing"
-     (define ubuf (make-mock-ubuf 40 10))
-     ;; Pre-populate with some data
-     (for ([row (in-range 0 10)])
-       (for ([col (in-range 0 40)])
-         (mock-ubuf-set-cell! ubuf col row #\X #f #f 7 0)))
-     (define state (initial-ui-state))
-     (define input-st (initial-input-state))
-     (define layout (compute-layout 40 10))
-     (run-render-frame! ubuf state input-st layout)
-     ;; Header row should be drawn with new content
-     (define header-str (mock-ubuf-row-string ubuf 0))
-     (check-true (string-prefix? header-str " q ")
-                 "header should be redrawn"))
+    (test-case "render-frame! clears buffer before drawing"
+      (define ubuf (make-mock-ubuf 40 10))
+      ;; Pre-populate with some data
+      (for ([row (in-range 0 10)])
+        (for ([col (in-range 0 40)])
+          (mock-ubuf-set-cell! ubuf col row #\X #f #f 7 0)))
+      (define state (initial-ui-state))
+      (define input-st (initial-input-state))
+      (define layout (compute-layout 40 10))
+      (run-render-frame! ubuf state input-st layout)
+      ;; Header row should be drawn with new content
+      (define header-str (mock-ubuf-row-string ubuf 0))
+      (check-true (string-prefix? header-str " q ") "header should be redrawn"))
 
-   ;; --------------------------------------------------------
-   ;; Transcript line rendering with styles
-   ;; --------------------------------------------------------
-   (test-case "render-frame! draws transcript entries"
-     (define ubuf (make-mock-ubuf 80 24))
-     (define state
-       (add-transcript-entry
-        (initial-ui-state)
-        (transcript-entry 'user "Hello" 0 (hash))))
-     (define input-st (initial-input-state))
-     (define layout (compute-layout 80 24))
-     (run-render-frame! ubuf state input-st layout)
-     ;; Check transcript area (row 2 onwards)
-     ;; The user entry should appear with "> " prefix
-     (define found-user?
-       (for/or ([row (in-range 1 23)])
-         (string-contains? (mock-ubuf-row-string ubuf row) "> ")))
-     (check-true found-user? "user entry should have prompt prefix"))
+    ;; --------------------------------------------------------
+    ;; Transcript line rendering with styles
+    ;; --------------------------------------------------------
+    (test-case "render-frame! draws transcript entries"
+      (define ubuf (make-mock-ubuf 80 24))
+      (define state (add-transcript-entry (initial-ui-state) (make-entry 'user "Hello" 0 (hash))))
+      (define input-st (initial-input-state))
+      (define layout (compute-layout 80 24))
+      (run-render-frame! ubuf state input-st layout)
+      ;; Check transcript area (row 2 onwards)
+      ;; The user entry should appear with "> " prefix
+      (define found-user?
+        (for/or ([row (in-range 1 23)])
+          (string-contains? (mock-ubuf-row-string ubuf row) "> ")))
+      (check-true found-user? "user entry should have prompt prefix"))
 
-   (test-case "render-frame! renders assistant messages"
-     (define ubuf (make-mock-ubuf 80 24))
-     (define state
-       (add-transcript-entry
-        (initial-ui-state)
-        (transcript-entry 'assistant "Assistant response" 0 (hash))))
-     (define input-st (initial-input-state))
-     (define layout (compute-layout 80 24))
-     (run-render-frame! ubuf state input-st layout)
-     ;; Assistant message should be visible
-     (define found-assistant?
-       (for/or ([row (in-range 1 23)])
-         (string-contains? (mock-ubuf-row-string ubuf row) "Assistant")))
-     (check-true found-assistant? "assistant message should be rendered"))
+    (test-case "render-frame! renders assistant messages"
+      (define ubuf (make-mock-ubuf 80 24))
+      (define state
+        (add-transcript-entry (initial-ui-state)
+                              (make-entry 'assistant "Assistant response" 0 (hash))))
+      (define input-st (initial-input-state))
+      (define layout (compute-layout 80 24))
+      (run-render-frame! ubuf state input-st layout)
+      ;; Assistant message should be visible
+      (define found-assistant?
+        (for/or ([row (in-range 1 23)])
+          (string-contains? (mock-ubuf-row-string ubuf row) "Assistant")))
+      (check-true found-assistant? "assistant message should be rendered"))
 
-   (test-case "render-frame! renders error messages with bold red style"
-     (define ubuf (make-mock-ubuf 80 24))
-     (define state
-       (add-transcript-entry
-        (initial-ui-state)
-        (transcript-entry 'error "Error occurred" 0 (hash))))
-     (define input-st (initial-input-state))
-     (define layout (compute-layout 80 24))
-     (run-render-frame! ubuf state input-st layout)
-     ;; Error message should be visible
-     (define found-error?
-       (for/or ([row (in-range 1 23)])
-         (string-contains? (mock-ubuf-row-string ubuf row) "Error")))
-     (check-true found-error? "error message should be rendered"))
+    (test-case "render-frame! renders error messages with bold red style"
+      (define ubuf (make-mock-ubuf 80 24))
+      (define state
+        (add-transcript-entry (initial-ui-state) (make-entry 'error "Error occurred" 0 (hash))))
+      (define input-st (initial-input-state))
+      (define layout (compute-layout 80 24))
+      (run-render-frame! ubuf state input-st layout)
+      ;; Error message should be visible
+      (define found-error?
+        (for/or ([row (in-range 1 23)])
+          (string-contains? (mock-ubuf-row-string ubuf row) "Error")))
+      (check-true found-error? "error message should be rendered"))
 
-   (test-case "render-frame! truncates long transcript lines"
-     (define ubuf (make-mock-ubuf 40 10))
-     (define long-text (make-string 100 #\A))
-     (define state
-       (add-transcript-entry
-        (initial-ui-state)
-        (transcript-entry 'assistant long-text 0 (hash))))
-     (define input-st (initial-input-state))
-     (define layout (compute-layout 40 10))
-     (run-render-frame! ubuf state input-st layout)
-     ;; The line should be truncated/padded to 40 columns
-     (define row2-str (mock-ubuf-row-string ubuf 1))
-     (check-equal? (string-length row2-str) 40
-                   "transcript line should be exactly 40 columns"))
+    (test-case "render-frame! truncates long transcript lines"
+      (define ubuf (make-mock-ubuf 40 10))
+      (define long-text (make-string 100 #\A))
+      (define state
+        (add-transcript-entry (initial-ui-state) (make-entry 'assistant long-text 0 (hash))))
+      (define input-st (initial-input-state))
+      (define layout (compute-layout 40 10))
+      (run-render-frame! ubuf state input-st layout)
+      ;; The line should be truncated/padded to 40 columns
+      (define row2-str (mock-ubuf-row-string ubuf 1))
+      (check-equal? (string-length row2-str) 40 "transcript line should be exactly 40 columns"))
 
-   (test-case "render-frame! shows multiple transcript entries"
-     (define ubuf (make-mock-ubuf 80 24))
-     (define state
-       (for/fold ([s (initial-ui-state)])
-                 ([msg '("First" "Second" "Third")])
-         (add-transcript-entry s (transcript-entry 'assistant msg 0 (hash)))))
-     (define input-st (initial-input-state))
-     (define layout (compute-layout 80 24))
-     (run-render-frame! ubuf state input-st layout)
-     ;; Should show the last entries that fit
-     (define found-entries
-       (for/sum ([row (in-range 1 23)])
-         (define str (mock-ubuf-row-string ubuf row))
-         (if (or (string-contains? str "First")
-                 (string-contains? str "Second")
-                 (string-contains? str "Third"))
-             1
-             0)))
-     (check-true (>= found-entries 1) "should show at least one entry"))
+    (test-case "render-frame! shows multiple transcript entries"
+      (define ubuf (make-mock-ubuf 80 24))
+      (define state
+        (for/fold ([s (initial-ui-state)]) ([msg '("First" "Second" "Third")])
+          (add-transcript-entry s (make-entry 'assistant msg 0 (hash)))))
+      (define input-st (initial-input-state))
+      (define layout (compute-layout 80 24))
+      (run-render-frame! ubuf state input-st layout)
+      ;; Should show the last entries that fit
+      (define found-entries
+        (for/sum ([row (in-range 1 23)])
+                 (define str (mock-ubuf-row-string ubuf row))
+                 (if (or (string-contains? str "First")
+                         (string-contains? str "Second")
+                         (string-contains? str "Third"))
+                     1
+                     0)))
+      (check-true (>= found-entries 1) "should show at least one entry"))
 
-   ;; --------------------------------------------------------
-   ;; Status bar rendering
-   ;; --------------------------------------------------------
-   (test-case "render-frame! draws status bar"
-     (define ubuf (make-mock-ubuf 80 24))
-     (define state (initial-ui-state #:session-id "test-session" #:model-name "gpt-4"))
-     (define input-st (initial-input-state))
-     (define layout (compute-layout 80 24))
-     (define status-row-num (- (tui-layout-status-row layout) 1))
-     (run-render-frame! ubuf state input-st layout)
-     (define status-str (mock-ubuf-row-string ubuf status-row-num))
-     (check-true (string-contains? status-str "q")
-                 "status bar contains 'q' indicator")
-     (check-true (string-contains? status-str "test-session")
-                 "status bar shows session id"))
+    ;; --------------------------------------------------------
+    ;; Status bar rendering
+    ;; --------------------------------------------------------
+    (test-case "render-frame! draws status bar"
+      (define ubuf (make-mock-ubuf 80 24))
+      (define state (initial-ui-state #:session-id "test-session" #:model-name "gpt-4"))
+      (define input-st (initial-input-state))
+      (define layout (compute-layout 80 24))
+      (define status-row-num (- (tui-layout-status-row layout) 1))
+      (run-render-frame! ubuf state input-st layout)
+      (define status-str (mock-ubuf-row-string ubuf status-row-num))
+      (check-true (string-contains? status-str "q") "status bar contains 'q' indicator")
+      (check-true (string-contains? status-str "test-session") "status bar shows session id"))
 
-   (test-case "status bar has inverse style (bg=7)"
-     (define ubuf (make-mock-ubuf 80 24))
-     (define state (initial-ui-state #:session-id "s1"))
-     (define input-st (initial-input-state))
-     (define layout (compute-layout 80 24))
-     (define status-row-num (- (tui-layout-status-row layout) 1))
-     (run-render-frame! ubuf state input-st layout)
-     (define inverse-count
-       (mock-ubuf-row-style-count ubuf status-row-num (lambda (c) (= (mock-cell-bg c) 7))))
-     (check-true (> inverse-count 0) "status bar should have bg=7 (inverse)"))
+    (test-case "status bar has inverse style (bg=7)"
+      (define ubuf (make-mock-ubuf 80 24))
+      (define state (initial-ui-state #:session-id "s1"))
+      (define input-st (initial-input-state))
+      (define layout (compute-layout 80 24))
+      (define status-row-num (- (tui-layout-status-row layout) 1))
+      (run-render-frame! ubuf state input-st layout)
+      (define inverse-count
+        (mock-ubuf-row-style-count ubuf status-row-num (lambda (c) (= (mock-cell-bg c) 7))))
+      (check-true (> inverse-count 0) "status bar should have bg=7 (inverse)"))
 
-   (test-case "status bar shows busy indicator when busy"
-     (define ubuf (make-mock-ubuf 80 24))
-     (define state
-       (struct-copy ui-state (initial-ui-state #:session-id "s1")
-                    [busy? #t]))
-     (define input-st (initial-input-state))
-     (define layout (compute-layout 80 24))
-     (define status-row-num (- (tui-layout-status-row layout) 1))
-     (run-render-frame! ubuf state input-st layout)
-     (define status-str (mock-ubuf-row-string ubuf status-row-num))
-     ;; Status bar should have busy marker (⏳) or session info
-     (check-true (or (string-contains? status-str "⏳")
-                     (string-contains? status-str "s1"))
-                 "status bar should show content"))
+    (test-case "status bar shows busy indicator when busy"
+      (define ubuf (make-mock-ubuf 80 24))
+      (define state (struct-copy ui-state (initial-ui-state #:session-id "s1") [busy? #t]))
+      (define input-st (initial-input-state))
+      (define layout (compute-layout 80 24))
+      (define status-row-num (- (tui-layout-status-row layout) 1))
+      (run-render-frame! ubuf state input-st layout)
+      (define status-str (mock-ubuf-row-string ubuf status-row-num))
+      ;; Status bar should have busy marker (⏳) or session info
+      (check-true (or (string-contains? status-str "⏳") (string-contains? status-str "s1"))
+                  "status bar should show content"))
 
-   ;; --------------------------------------------------------
-   ;; Input line rendering
-   ;; --------------------------------------------------------
-   (test-case "render-frame! draws input line with prompt"
-     (define ubuf (make-mock-ubuf 80 24))
-     (define state (initial-ui-state))
-     (define input-st
-       (input-insert-char (input-insert-char (initial-input-state) #\h) #\i))
-     (define layout (compute-layout 80 24))
-     (define input-row-num (- (tui-layout-input-row layout) 1))
-     (run-render-frame! ubuf state input-st layout)
-     (define input-str (mock-ubuf-row-string ubuf input-row-num))
-     (check-true (string-contains? input-str "q>")
-                 "input line shows q> prompt")
-     (check-true (string-contains? input-str "hi")
-                 "input line shows typed text"))
+    ;; --------------------------------------------------------
+    ;; Input line rendering
+    ;; --------------------------------------------------------
+    (test-case "render-frame! draws input line with prompt"
+      (define ubuf (make-mock-ubuf 80 24))
+      (define state (initial-ui-state))
+      (define input-st (input-insert-char (input-insert-char (initial-input-state) #\h) #\i))
+      (define layout (compute-layout 80 24))
+      (define input-row-num (- (tui-layout-input-row layout) 1))
+      (run-render-frame! ubuf state input-st layout)
+      (define input-str (mock-ubuf-row-string ubuf input-row-num))
+      (check-true (string-contains? input-str "q>") "input line shows q> prompt")
+      (check-true (string-contains? input-str "hi") "input line shows typed text"))
 
-   (test-case "input line has bold style"
-     (define ubuf (make-mock-ubuf 80 24))
-     (define state (initial-ui-state))
-     (define input-st (input-insert-char (initial-input-state) #\x))
-     (define layout (compute-layout 80 24))
-     (define input-row-num (- (tui-layout-input-row layout) 1))
-     (run-render-frame! ubuf state input-st layout)
-     (define bold-count (mock-ubuf-row-style-count ubuf input-row-num mock-cell-bold))
-     (check-true (> bold-count 0) "input line should have bold style"))
+    (test-case "input line has bold style"
+      (define ubuf (make-mock-ubuf 80 24))
+      (define state (initial-ui-state))
+      (define input-st (input-insert-char (initial-input-state) #\x))
+      (define layout (compute-layout 80 24))
+      (define input-row-num (- (tui-layout-input-row layout) 1))
+      (run-render-frame! ubuf state input-st layout)
+      (define bold-count (mock-ubuf-row-style-count ubuf input-row-num mock-cell-bold))
+      (check-true (> bold-count 0) "input line should have bold style"))
 
-   (test-case "input line handles empty buffer"
-     (define ubuf (make-mock-ubuf 80 24))
-     (define state (initial-ui-state))
-     (define input-st (initial-input-state))
-     (define layout (compute-layout 80 24))
-     (define input-row-num (- (tui-layout-input-row layout) 1))
-     (run-render-frame! ubuf state input-st layout)
-     (define input-str (mock-ubuf-row-string ubuf input-row-num))
-     (check-true (string-contains? input-str "q>")
-                 "empty input still shows prompt"))
+    (test-case "input line handles empty buffer"
+      (define ubuf (make-mock-ubuf 80 24))
+      (define state (initial-ui-state))
+      (define input-st (initial-input-state))
+      (define layout (compute-layout 80 24))
+      (define input-row-num (- (tui-layout-input-row layout) 1))
+      (run-render-frame! ubuf state input-st layout)
+      (define input-str (mock-ubuf-row-string ubuf input-row-num))
+      (check-true (string-contains? input-str "q>") "empty input still shows prompt"))
 
-   (test-case "render-frame! returns cursor position"
-     (define ubuf (make-mock-ubuf 80 24))
-     (define state (initial-ui-state))
-     (define input-st
-       (input-insert-char
-        (input-insert-char (initial-input-state) #\a)
-        #\b))
-     ;; cursor should be at position 2 (after "ab")
-     (define layout (compute-layout 80 24))
-     (define-values (cursor-col cursor-row)
-       (run-render-frame! ubuf state input-st layout))
-     ;; cursor-row should be input row
-     (check-equal? cursor-row (- (tui-layout-input-row layout) 1))
-     ;; cursor-col should account for "q> " (4 chars) + 2 chars typed
-     (check-true (>= cursor-col 4) "cursor column should be >= prompt width"))
+    (test-case "render-frame! returns cursor position"
+      (define ubuf (make-mock-ubuf 80 24))
+      (define state (initial-ui-state))
+      (define input-st (input-insert-char (input-insert-char (initial-input-state) #\a) #\b))
+      ;; cursor should be at position 2 (after "ab")
+      (define layout (compute-layout 80 24))
+      (define-values (cursor-col cursor-row) (run-render-frame! ubuf state input-st layout))
+      ;; cursor-row should be input row
+      (check-equal? cursor-row (- (tui-layout-input-row layout) 1))
+      ;; cursor-col should account for "q> " (4 chars) + 2 chars typed
+      (check-true (>= cursor-col 4) "cursor column should be >= prompt width"))
 
-   ;; --------------------------------------------------------
-   ;; Layout edge cases
-   ;; --------------------------------------------------------
-   (test-case "render-frame! handles minimum screen size"
-     (define ubuf (make-mock-ubuf 20 4))
-     (define state (initial-ui-state))
-     (define input-st (initial-input-state))
-     (define layout (compute-layout 20 4))
-     ;; Should not error on minimum size
-     (check-not-exn
-      (lambda ()
-        (run-render-frame! ubuf state input-st layout))))
+    ;; --------------------------------------------------------
+    ;; Layout edge cases
+    ;; --------------------------------------------------------
+    (test-case "render-frame! handles minimum screen size"
+      (define ubuf (make-mock-ubuf 20 4))
+      (define state (initial-ui-state))
+      (define input-st (initial-input-state))
+      (define layout (compute-layout 20 4))
+      ;; Should not error on minimum size
+      (check-not-exn (lambda () (run-render-frame! ubuf state input-st layout))))
 
-   (test-case "render-frame! handles wide screen"
-     (define ubuf (make-mock-ubuf 200 50))
-     (define state (initial-ui-state))
-     (define input-st (initial-input-state))
-     (define layout (compute-layout 200 50))
-     ;; Should not error on large size
-     (check-not-exn
-      (lambda ()
-        (run-render-frame! ubuf state input-st layout))))
+    (test-case "render-frame! handles wide screen"
+      (define ubuf (make-mock-ubuf 200 50))
+      (define state (initial-ui-state))
+      (define input-st (initial-input-state))
+      (define layout (compute-layout 200 50))
+      ;; Should not error on large size
+      (check-not-exn (lambda () (run-render-frame! ubuf state input-st layout))))
 
-   (test-case "render-frame! uses bg=0 for transcript area"
-     (define ubuf (make-mock-ubuf 80 10))
-     (define state (initial-ui-state))
-     (define input-st (initial-input-state))
-     (define layout (compute-layout 80 10))
-     (run-render-frame! ubuf state input-st layout)
-     ;; Empty transcript cells have bg=0 (ANSI black)
-     (define trans-start (sub1 (tui-layout-transcript-start-row layout)))
-     (define cell (mock-ubuf-cell ubuf 0 trans-start))
-     (check-equal? (mock-cell-bg cell) 0 "empty cells use bg=0"))
+    (test-case "render-frame! uses bg=0 for transcript area"
+      (define ubuf (make-mock-ubuf 80 10))
+      (define state (initial-ui-state))
+      (define input-st (initial-input-state))
+      (define layout (compute-layout 80 10))
+      (run-render-frame! ubuf state input-st layout)
+      ;; Empty transcript cells have bg=0 (ANSI black)
+      (define trans-start (sub1 (tui-layout-transcript-start-row layout)))
+      (define cell (mock-ubuf-cell ubuf 0 trans-start))
+      (check-equal? (mock-cell-bg cell) 0 "empty cells use bg=0"))
 
-   (test-case "render-frame! inverse header keeps explicit bg=7"
-     (define ubuf (make-mock-ubuf 80 10))
-     (define state (initial-ui-state))
-     (define input-st (initial-input-state))
-     (define layout (compute-layout 80 10))
-     (run-render-frame! ubuf state input-st layout)
-     (define header-y (sub1 (tui-layout-header-row layout)))
-     (define cell (mock-ubuf-cell ubuf 1 header-y))
-     (check-equal? (mock-cell-bg cell) 7 "header uses inverse bg=7"))
+    (test-case "render-frame! inverse header keeps explicit bg=7"
+      (define ubuf (make-mock-ubuf 80 10))
+      (define state (initial-ui-state))
+      (define input-st (initial-input-state))
+      (define layout (compute-layout 80 10))
+      (run-render-frame! ubuf state input-st layout)
+      (define header-y (sub1 (tui-layout-header-row layout)))
+      (define cell (mock-ubuf-cell ubuf 1 header-y))
+      (check-equal? (mock-cell-bg cell) 7 "header uses inverse bg=7"))
 
-   (test-case "render-frame! handles many transcript entries"
-     (define ubuf (make-mock-ubuf 80 24))
-     (define state
-       (for/fold ([s (initial-ui-state)])
-                 ([i (in-range 100)])
-         (add-transcript-entry s (transcript-entry 'system (format "Line ~a" i) 0 (hash)))))
-     (define input-st (initial-input-state))
-     (define layout (compute-layout 80 24))
-     ;; Should only show the visible portion without error
-     (check-not-exn
-      (lambda ()
-        (run-render-frame! ubuf state input-st layout))))
+    (test-case "render-frame! handles many transcript entries"
+      (define ubuf (make-mock-ubuf 80 24))
+      (define state
+        (for/fold ([s (initial-ui-state)]) ([i (in-range 100)])
+          (add-transcript-entry s (make-entry 'system (format "Line ~a" i) 0 (hash)))))
+      (define input-st (initial-input-state))
+      (define layout (compute-layout 80 24))
+      ;; Should only show the visible portion without error
+      (check-not-exn (lambda () (run-render-frame! ubuf state input-st layout))))
 
-   ;; --------------------------------------------------------
-   ;; Integration: render with streaming text
-   ;; --------------------------------------------------------
-   (test-case "render-frame! shows streaming text"
-     (define ubuf (make-mock-ubuf 80 24))
-     (define state
-       (struct-copy ui-state (initial-ui-state)
-                   [streaming-text "Partial response..."]))
-     (define input-st (initial-input-state))
-     (define layout (compute-layout 80 24))
-     (run-render-frame! ubuf state input-st layout)
-     ;; Streaming text should appear in transcript area (rows 2–22)
-     (define found-streaming?
-       (for/or ([row (in-range 1 22)])
-         (string-contains? (mock-ubuf-row-string ubuf row) "Partial")))
-     (check-true found-streaming? "streaming text should be rendered"))
-
-   ))
+    ;; --------------------------------------------------------
+    ;; Integration: render with streaming text
+    ;; --------------------------------------------------------
+    (test-case "render-frame! shows streaming text"
+      (define ubuf (make-mock-ubuf 80 24))
+      (define state (struct-copy ui-state (initial-ui-state) [streaming-text "Partial response..."]))
+      (define input-st (initial-input-state))
+      (define layout (compute-layout 80 24))
+      (run-render-frame! ubuf state input-st layout)
+      ;; Streaming text should appear in transcript area (rows 2–22)
+      (define found-streaming?
+        (for/or ([row (in-range 1 22)])
+          (string-contains? (mock-ubuf-row-string ubuf row) "Partial")))
+      (check-true found-streaming? "streaming text should be rendered"))))
 
 ;; ============================================================
 ;; Run tests

--- a/tests/tui/commands.rkt
+++ b/tests/tui/commands.rkt
@@ -95,7 +95,7 @@
       ;; Add an entry first
       (set-box! (cmd-ctx-state-box cctx)
                 (add-transcript-entry (unbox (cmd-ctx-state-box cctx))
-                                      (transcript-entry 'user "hello" 0 (hash))))
+                                      (make-entry 'user "hello" 0 (hash))))
       (check-equal? (length (ui-state-transcript (unbox (cmd-ctx-state-box cctx)))) 1)
       (process-slash-command cctx 'clear)
       (check-equal? (length (ui-state-transcript (unbox (cmd-ctx-state-box cctx))))

--- a/tests/tui/render.rkt
+++ b/tests/tui/render.rkt
@@ -93,13 +93,13 @@
     ;; format-entry
     ;; --------------------------------------------------------
     (test-case "format-entry assistant message"
-      (let ([entry (transcript-entry 'assistant "Hello!" 1000 (hash))])
+      (let ([entry (make-entry 'assistant "Hello!" 1000 (hash))])
         (define lines (format-entry entry 80))
         (check-equal? (length lines) 1 "one line")
         (check-equal? (styled-segment-text (first (styled-line-segments (first lines)))) "Hello!")))
 
     (test-case "format-entry user message has prompt prefix"
-      (let ([entry (transcript-entry 'user "Hello!" 1000 (hash))])
+      (let ([entry (make-entry 'user "Hello!" 1000 (hash))])
         (define lines (format-entry entry 80))
         (define segs (styled-line-segments (first lines)))
         ;; Two segments: cyan prompt + bold text
@@ -110,7 +110,7 @@
         (check-equal? (styled-segment-style (second segs)) '(bold))))
 
     (test-case "format-entry error message has [ERR] prefix and bold red style"
-      (let ([entry (transcript-entry 'error "Oops" 1000 (hash))])
+      (let ([entry (make-entry 'error "Oops" 1000 (hash))])
         (define lines (format-entry entry 80))
         (define seg (first (styled-line-segments (first lines))))
         (check-true (string-contains? (styled-segment-text seg) "[ERR]"))
@@ -152,7 +152,7 @@
     ;; Markdown rendering via format-entry (assistant)
     ;; --------------------------------------------------------
     (test-case "format-entry assistant bold text"
-      (let ([entry (transcript-entry 'assistant "hello **world** end" 1000 (hash))])
+      (let ([entry (make-entry 'assistant "hello **world** end" 1000 (hash))])
         (define lines (format-entry entry 80))
         (check-equal? (length lines) 1 "one line")
         (define segs (styled-line-segments (first lines)))
@@ -164,7 +164,7 @@
         (check-equal? (styled-segment-text (third segs)) " end")))
 
     (test-case "format-entry assistant italic text"
-      (let ([entry (transcript-entry 'assistant "say *hi* now" 1000 (hash))])
+      (let ([entry (make-entry 'assistant "say *hi* now" 1000 (hash))])
         (define lines (format-entry entry 80))
         (define segs (styled-line-segments (first lines)))
         (check-equal? (length segs) 3)
@@ -172,7 +172,7 @@
         (check-equal? (styled-segment-text (second segs)) "hi")))
 
     (test-case "format-entry assistant inline code"
-      (let ([entry (transcript-entry 'assistant "use `foo` here" 1000 (hash))])
+      (let ([entry (make-entry 'assistant "use `foo` here" 1000 (hash))])
         (define lines (format-entry entry 80))
         (define segs (styled-line-segments (first lines)))
         (check-equal? (length segs) 3)
@@ -180,7 +180,7 @@
         (check-equal? (styled-segment-text (second segs)) "foo")))
 
     (test-case "format-entry assistant header"
-      (let ([entry (transcript-entry 'assistant "### Title" 1000 (hash))])
+      (let ([entry (make-entry 'assistant "### Title" 1000 (hash))])
         (define lines (format-entry entry 80))
         (check-equal? (length lines) 1 "one line")
         (define segs (styled-line-segments (first lines)))
@@ -188,14 +188,14 @@
         (check-equal? (styled-segment-style (first segs)) '(bold yellow))))
 
     (test-case "format-entry assistant multi-line with newline"
-      (let ([entry (transcript-entry 'assistant "line1\nline2" 1000 (hash))])
+      (let ([entry (make-entry 'assistant "line1\nline2" 1000 (hash))])
         (define lines (format-entry entry 80))
         (check-equal? (length lines) 2 "two lines")
         (check-equal? (styled-segment-text (first (styled-line-segments (first lines)))) "line1")
         (check-equal? (styled-segment-text (first (styled-line-segments (second lines)))) "line2")))
 
     (test-case "format-entry assistant code block produces green lines"
-      (let ([entry (transcript-entry 'assistant "```\ncode line\n```" 1000 (hash))])
+      (let ([entry (make-entry 'assistant "```\ncode line\n```" 1000 (hash))])
         (define lines (format-entry entry 80))
         ;; code-block line + trailing newline line
         (check-true (>= (length lines) 1) "at least one code line")
@@ -204,7 +204,7 @@
         (check-true (string-contains? (styled-segment-text (first code-segs)) "code line"))))
 
     (test-case "format-entry assistant link uses blue underline"
-      (let ([entry (transcript-entry 'assistant "click [here](http://example.com) ok" 1000 (hash))])
+      (let ([entry (make-entry 'assistant "click [here](http://example.com) ok" 1000 (hash))])
         (define lines (format-entry entry 80))
         (define segs (styled-line-segments (first lines)))
         ;; text "click " + link "here" + text " ok"
@@ -216,7 +216,7 @@
         (check-not-false (member 'underline (styled-segment-style link-seg)) "link has underline")))
 
     (test-case "format-entry tool-start shows [TOOL] text prefix and cyan color"
-      (let ([entry (transcript-entry 'tool-start "[TOOL: read]" 1000 (hash))])
+      (let ([entry (make-entry 'tool-start "[TOOL: read]" 1000 (hash))])
         (define lines (format-entry entry 80))
         (define seg (first (styled-line-segments (first lines))))
         (check-true (string-contains? (styled-segment-text seg) "[TOOL")
@@ -224,7 +224,7 @@
         (check-equal? (styled-segment-style seg) '(cyan))))
 
     (test-case "format-entry tool-end shows [OK] text prefix and green color"
-      (let ([entry (transcript-entry 'tool-end "[OK: read]" 1000 (hash))])
+      (let ([entry (make-entry 'tool-end "[OK: read]" 1000 (hash))])
         (define lines (format-entry entry 80))
         (define seg (first (styled-line-segments (first lines))))
         (check-true (string-contains? (styled-segment-text seg) "[OK")
@@ -232,7 +232,7 @@
         (check-equal? (styled-segment-style seg) '(green))))
 
     (test-case "format-entry tool-fail shows [FAIL] text prefix and red color"
-      (let ([entry (transcript-entry 'tool-fail "[FAIL: read]" 1000 (hash))])
+      (let ([entry (make-entry 'tool-fail "[FAIL: read]" 1000 (hash))])
         (define lines (format-entry entry 80))
         (define seg (first (styled-line-segments (first lines))))
         (check-true (string-contains? (styled-segment-text seg) "[FAIL")
@@ -240,7 +240,7 @@
         (check-equal? (styled-segment-style seg) '(red))))
 
     (test-case "format-entry system shows [SYS] prefix"
-      (let ([entry (transcript-entry 'system "Session started" 1000 (hash))])
+      (let ([entry (make-entry 'system "Session started" 1000 (hash))])
         (define lines (format-entry entry 80))
         (define seg (first (styled-line-segments (first lines))))
         (check-true (string-contains? (styled-segment-text seg) "[SYS]"))
@@ -250,68 +250,73 @@
     ;; Line-based viewport slicing (render-transcript)
     ;; --------------------------------------------------------
     (test-case "render-transcript: content fits in height returns all lines"
-      (let* ([entries (list (transcript-entry 'system "line1" 0 (hash))
-                            (transcript-entry 'system "line2" 0 (hash)))]
+      (let* ([entries (list (make-entry 'system "line1" 0 (hash))
+                            (make-entry 'system "line2" 0 (hash)))]
              [state (struct-copy ui-state (initial-ui-state) [transcript entries])])
-        (define lines (render-transcript state 10 200))
+        (define-values (lines _st) (render-transcript state 10 200))
         (check-equal? (length lines) 2 "render-transcript: returns all when fits")))
 
     (test-case "render-transcript: more lines than height shows last N"
-      (let* ([entries (list (transcript-entry 'system "line1" 0 (hash))
-                            (transcript-entry 'system "line2" 0 (hash))
-                            (transcript-entry 'system "line3" 0 (hash)))]
+      (let* ([entries (list (make-entry 'system "line1" 0 (hash))
+                            (make-entry 'system "line2" 0 (hash))
+                            (make-entry 'system "line3" 0 (hash)))]
              [state (struct-copy ui-state (initial-ui-state) [transcript entries])])
-        (define lines (render-transcript state 2 200))
+        (define-values (lines _st) (render-transcript state 2 200))
         (check-equal? (length lines) 2 "render-transcript: shows last 2 of 3 lines")
         ;; First visible should be "[SYS] line2", second "[SYS] line3"
-        (check-equal? (styled-segment-text (first (styled-line-segments (first lines)))) "[SYS] line2")
-        (check-equal? (styled-segment-text (first (styled-line-segments (second lines)))) "[SYS] line3")))
+        (check-equal? (styled-segment-text (first (styled-line-segments (first lines))))
+                      "[SYS] line2")
+        (check-equal? (styled-segment-text (first (styled-line-segments (second lines))))
+                      "[SYS] line3")))
 
     (test-case "render-transcript: scroll-offset=1 shows lines offset 1 from bottom"
-      (let* ([entries (list (transcript-entry 'system "line1" 0 (hash))
-                            (transcript-entry 'system "line2" 0 (hash))
-                            (transcript-entry 'system "line3" 0 (hash))
-                            (transcript-entry 'system "line4" 0 (hash)))]
+      (let* ([entries (list (make-entry 'system "line1" 0 (hash))
+                            (make-entry 'system "line2" 0 (hash))
+                            (make-entry 'system "line3" 0 (hash))
+                            (make-entry 'system "line4" 0 (hash)))]
              [state (struct-copy ui-state (initial-ui-state) [transcript entries] [scroll-offset 1])])
-        (define lines (render-transcript state 2 200))
+        (define-values (lines _st) (render-transcript state 2 200))
         (check-equal? (length lines) 2 "render-transcript: scroll=1 shows 2 lines")
         ;; Should show [SYS] line2 and [SYS] line3 (offset 1 from bottom)
-        (check-equal? (styled-segment-text (first (styled-line-segments (first lines)))) "[SYS] line2")
-        (check-equal? (styled-segment-text (first (styled-line-segments (second lines)))) "[SYS] line3")))
+        (check-equal? (styled-segment-text (first (styled-line-segments (first lines))))
+                      "[SYS] line2")
+        (check-equal? (styled-segment-text (first (styled-line-segments (second lines))))
+                      "[SYS] line3")))
 
     (test-case "render-transcript: scroll-offset=2 shows older lines"
-      (let* ([entries (list (transcript-entry 'system "line1" 0 (hash))
-                            (transcript-entry 'system "line2" 0 (hash))
-                            (transcript-entry 'system "line3" 0 (hash))
-                            (transcript-entry 'system "line4" 0 (hash))
-                            (transcript-entry 'system "line5" 0 (hash)))]
+      (let* ([entries (list (make-entry 'system "line1" 0 (hash))
+                            (make-entry 'system "line2" 0 (hash))
+                            (make-entry 'system "line3" 0 (hash))
+                            (make-entry 'system "line4" 0 (hash))
+                            (make-entry 'system "line5" 0 (hash)))]
              [state (struct-copy ui-state (initial-ui-state) [transcript entries] [scroll-offset 2])])
-        (define lines (render-transcript state 3 200))
+        (define-values (lines _st) (render-transcript state 3 200))
         (check-equal? (length lines) 3 "render-transcript: scroll=2 shows 3 lines")
         ;; Should show [SYS] line1, [SYS] line2, [SYS] line3 (last 5 - 3 - 2 = start at 0)
-        (check-equal? (styled-segment-text (first (styled-line-segments (first lines)))) "[SYS] line1")))
+        (check-equal? (styled-segment-text (first (styled-line-segments (first lines))))
+                      "[SYS] line1")))
 
     (test-case "render-transcript: scroll-offset larger than content clamps to top"
-      (let* ([entries (list (transcript-entry 'system "line1" 0 (hash))
-                            (transcript-entry 'system "line2" 0 (hash)))]
+      (let* ([entries (list (make-entry 'system "line1" 0 (hash))
+                            (make-entry 'system "line2" 0 (hash)))]
              [state
               (struct-copy ui-state (initial-ui-state) [transcript entries] [scroll-offset 100])])
-        (define lines (render-transcript state 10 200))
+        (define-values (lines _st) (render-transcript state 10 200))
         ;; Both lines fit, scroll doesn't matter
         (check-equal? (length lines) 2 "render-transcript: small content always shows all")))
 
     (test-case "render-transcript: empty transcript returns empty"
       (let ([state (initial-ui-state)])
-        (define lines (render-transcript state 10 200))
+        (define-values (lines _st) (render-transcript state 10 200))
         (check-equal? (length lines) 0 "render-transcript: empty returns empty")))
 
     (test-case "render-transcript: streaming text shown at bottom when scroll=0"
-      (let* ([entries (list (transcript-entry 'system "line1" 0 (hash)))]
+      (let* ([entries (list (make-entry 'system "line1" 0 (hash)))]
              [state (struct-copy ui-state
                                  (initial-ui-state)
                                  [transcript entries]
                                  [streaming-text "streaming..."])])
-        (define lines (render-transcript state 10 200))
+        (define-values (lines _st) (render-transcript state 10 200))
         (check-equal? (length lines) 2 "streaming text appended")
         ;; Last line should be the streaming text (dim)
         (define last-seg (first (styled-line-segments (last lines))))
@@ -551,8 +556,7 @@
       (let ([state (initial-ui-state #:session-id "test-sess" #:model-name "gpt-4")])
         (define line (render-status-bar state 80))
         (define text (styled-segment-text (first (styled-line-segments line))))
-        (check-false (string-contains? text "[thinking...]")
-                     "no [thinking...] when not busy")))
+        (check-false (string-contains? text "[thinking...]") "no [thinking...] when not busy")))
 
     (test-case "render-status-bar does NOT show [thinking...] when streaming text present"
       (let ([state (struct-copy ui-state
@@ -610,8 +614,7 @@
       (for ([line result])
         (for ([seg (styled-line-segments line)])
           (check-not-false (member 'bold (styled-segment-style seg))
-                           (format "segment '~a' should be bold"
-                                   (styled-segment-text seg))))))
+                           (format "segment '~a' should be bold" (styled-segment-text seg))))))
 
     (test-case "wrap-text: long ASCII string still works correctly"
       ;; Regression test: ensure ASCII wrapping still works after refactor

--- a/tests/tui/state.rkt
+++ b/tests/tui/state.rkt
@@ -191,7 +191,7 @@
 
     (test-case "add-transcript-entry: appends entry and resets scroll"
       (let* ([s (struct-copy ui-state (initial-ui-state) [scroll-offset 5])]
-             [entry (transcript-entry 'user "hello" 1000 (hash))]
+             [entry (make-entry 'user "hello" 1000 (hash))]
              [s2 (add-transcript-entry s entry)])
         (check-equal? (length (ui-state-transcript s2)) 1)
         (check-equal? (transcript-entry-kind (first (ui-state-transcript s2))) 'user)
@@ -203,14 +203,14 @@
 
     (test-case "visible-entries: returns all entries (line slicing is renderer's job)"
       (let* ([entries (for/list ([i (in-range 10)])
-                        (transcript-entry 'assistant (format "msg ~a" i) i (hash)))]
+                        (make-entry 'assistant (format "msg ~a" i) i (hash)))]
              [s (struct-copy ui-state (initial-ui-state) [transcript entries])]
              [vis (visible-entries s 5)])
         (check-equal? (length vis) 10 "visible-entries: returns all entries regardless of height")))
 
     (test-case "visible-entries: ignores scroll offset (line slicing is renderer's job)"
       (let* ([entries (for/list ([i (in-range 10)])
-                        (transcript-entry 'assistant (format "msg ~a" i) i (hash)))]
+                        (make-entry 'assistant (format "msg ~a" i) i (hash)))]
              [s (struct-copy ui-state (initial-ui-state) [transcript entries] [scroll-offset 3])]
              [vis (visible-entries s 5)])
         (check-equal? (length vis) 10 "visible-entries: returns all entries regardless of scroll")))
@@ -221,7 +221,7 @@
 
     (test-case "scroll-up: increments offset"
       (let* ([entries (for/list ([i (in-range 10)])
-                        (transcript-entry 'assistant (format "msg ~a" i) i (hash)))]
+                        (make-entry 'assistant (format "msg ~a" i) i (hash)))]
              [s (struct-copy ui-state (initial-ui-state) [transcript entries])]
              [s2 (scroll-up s)]
              [s3 (scroll-up s2 5)])
@@ -245,13 +245,13 @@
 
     (test-case "scroll-to-top: sets large offset for renderer clamping"
       (let* ([entries (for/list ([i (in-range 10)])
-                        (transcript-entry 'assistant (format "msg ~a" i) i (hash)))]
+                        (make-entry 'assistant (format "msg ~a" i) i (hash)))]
              [s (struct-copy ui-state (initial-ui-state) [transcript entries])]
              [s-top (scroll-to-top s)])
         (check-true (> (ui-state-scroll-offset s-top) 100)
-                   "scroll-to-top sets large offset for multi-line entries")
+                    "scroll-to-top sets large offset for multi-line entries")
         (check-true (> (ui-state-scroll-offset s-top) (length entries))
-                   "scroll-to-top offset exceeds entry count")))
+                    "scroll-to-top offset exceeds entry count")))
 
     ;; ============================================================
     ;; ui-busy?, ui-session-label, ui-model-label, ui-status-text
@@ -383,8 +383,8 @@
     (test-case "save-scrollback writes JSONL file"
       (let* ([tmpdir (make-temporary-file "scrollback-test-~a" 'directory)]
              [path (build-path tmpdir "scrollback.jsonl")]
-             [entries (list (transcript-entry 'assistant "Hello" 1000 (hash 'foo "bar"))
-                            (transcript-entry 'tool-start "[tool: bash]" 1001 (hash 'name "bash")))])
+             [entries (list (make-entry 'assistant "Hello" 1000 (hash 'foo "bar"))
+                            (make-entry 'tool-start "[tool: bash]" 1001 (hash 'name "bash")))])
         (save-scrollback entries path)
         (check-true (file-exists? path) "save-scrollback creates file")
         (define content (file->string path))
@@ -421,16 +421,16 @@
     (test-case "roundtrip: save then load preserves events"
       (let* ([tmpdir (make-temporary-file "scrollback-test-~a" 'directory)]
              [path (build-path tmpdir "scrollback.jsonl")]
-             [entries (list (transcript-entry 'assistant "Hello world" 1000 (hash))
-                            (transcript-entry 'tool-start "[TOOL: bash]" 1001 (hash 'name "bash"))
-                            (transcript-entry 'tool-end "[OK: bash]" 1002 (hash 'name "bash"))
-                            (transcript-entry 'tool-fail
-                                              "[FAIL: read] not found"
-                                              1003
-                                              (hash 'name "read" 'error "not found"))
-                            (transcript-entry 'system "Session started" 1004 (hash))
-                            (transcript-entry 'error "Error: boom" 1005 (hash))
-                            (transcript-entry 'user "What is 2+2?" 1006 (hash)))])
+             [entries (list (make-entry 'assistant "Hello world" 1000 (hash))
+                            (make-entry 'tool-start "[TOOL: bash]" 1001 (hash 'name "bash"))
+                            (make-entry 'tool-end "[OK: bash]" 1002 (hash 'name "bash"))
+                            (make-entry 'tool-fail
+                                        "[FAIL: read] not found"
+                                        1003
+                                        (hash 'name "read" 'error "not found"))
+                            (make-entry 'system "Session started" 1004 (hash))
+                            (make-entry 'error "Error: boom" 1005 (hash))
+                            (make-entry 'user "What is 2+2?" 1006 (hash)))])
         (save-scrollback entries path)
         (define loaded (load-scrollback path))
         (check-equal? (length loaded) 7 "roundtrip: same entry count")
@@ -573,7 +573,7 @@
   ;; Selection helpers preserve other state fields
   (define state
     (add-transcript-entry (initial-ui-state #:session-id "test")
-                          (transcript-entry 'assistant "hello" 0 (hash))))
+                          (make-entry 'assistant "hello" 0 (hash))))
   (define state+sel (set-selection-anchor state 5 10))
   (check-equal? (ui-state-session-id state+sel) "test" "set-selection-anchor preserves session-id")
   (check-equal? (ui-state-scroll-offset state+sel) 0 "set-selection-anchor preserves scroll-offset"))

--- a/tui/commands.rkt
+++ b/tui/commands.rkt
@@ -100,7 +100,7 @@
   (define lines (render-branch-list branches-with-active cols))
   (define new-state
     (for/fold ([s state]) ([line (in-list lines)])
-      (add-transcript-entry s (transcript-entry 'system (styled-line->text line) 0 (hash)))))
+      (add-transcript-entry s (make-entry 'system (styled-line->text line) 0 (hash)))))
   (set-box! (cmd-ctx-state-box cctx) (set-visible-branches new-state branches-with-active))
   'continue)
 
@@ -118,7 +118,7 @@
   (define lines (render-leaf-nodes branches-with-active cols))
   (define new-state
     (for/fold ([s state]) ([line (in-list lines)])
-      (add-transcript-entry s (transcript-entry 'system (styled-line->text line) 0 (hash)))))
+      (add-transcript-entry s (make-entry 'system (styled-line->text line) 0 (hash)))))
   (set-box! (cmd-ctx-state-box cctx) new-state)
   'continue)
 
@@ -128,11 +128,11 @@
   (define idx (get-session-index cctx))
   (define entry
     (if (and idx (lookup-entry idx branch-id))
-        (transcript-entry 'system
-                          (format "[switched to branch: ~a]" branch-id)
-                          0
-                          (hasheq 'branch-id branch-id))
-        (transcript-entry 'error (format "Branch not found: ~a" branch-id) 0 (hasheq))))
+        (make-entry 'system
+                    (format "[switched to branch: ~a]" branch-id)
+                    0
+                    (hasheq 'branch-id branch-id))
+        (make-entry 'error (format "Branch not found: ~a" branch-id) 0 (hasheq))))
   (define new-state (add-transcript-entry state entry))
   (when (and idx (lookup-entry idx branch-id))
     (set-box! (cmd-ctx-state-box cctx) (set-current-branch new-state branch-id)))
@@ -164,7 +164,7 @@
   ;; Add lines to transcript
   (define final-state
     (for/fold ([s new-state]) ([line (in-list lines)])
-      (add-transcript-entry s (transcript-entry 'system (styled-line->text line) 0 (hash)))))
+      (add-transcript-entry s (make-entry 'system (styled-line->text line) 0 (hash)))))
   (set-box! (cmd-ctx-state-box cctx) final-state)
   'continue)
 
@@ -177,20 +177,20 @@
   (define idx (get-session-index cctx))
   (cond
     [(not idx)
-     (define entry (transcript-entry 'error "No session index available" 0 (hash)))
+     (define entry (make-entry 'error "No session index available" 0 (hash)))
      (set-box! (cmd-ctx-state-box cctx) (add-transcript-entry state entry))
      'continue]
     [else
      (define entries (session-index-entry-order idx))
      (if (null? entries)
-         (let ([entry (transcript-entry 'system "Session is empty." 0 (hash))])
+         (let ([entry (make-entry 'system "Session is empty." 0 (hash))])
            (set-box! (cmd-ctx-state-box cctx) (add-transcript-entry state entry))
            'continue)
          (let ()
-           (define header (transcript-entry 'system "Session history:" 0 (hash)))
+           (define header (make-entry 'system "Session history:" 0 (hash)))
            (define entries-out
              (for/list ([msg (in-vector entries)])
-               (transcript-entry 'system (format "  [~a]" (message-role msg)) 0 (hash))))
+               (make-entry 'system (format "  [~a]" (message-role msg)) 0 (hash))))
            (define all-entries (cons header entries-out))
            (define new-state
              (for/fold ([s state]) ([e (in-list all-entries)])
@@ -206,15 +206,15 @@
   (define state (unbox (cmd-ctx-state-box cctx)))
   (cond
     [(not entry-id)
-     (define entry (transcript-entry 'error "Usage: /fork <entry-id>" 0 (hash)))
+     (define entry (make-entry 'error "Usage: /fork <entry-id>" 0 (hash)))
      (set-box! (cmd-ctx-state-box cctx) (add-transcript-entry state entry))
      'continue]
     [else
      (define entry
-       (transcript-entry 'system
-                         (format "[fork requested at: ~a]" entry-id)
-                         0
-                         (hasheq 'fork-entry-id entry-id)))
+       (make-entry 'system
+                   (format "[fork requested at: ~a]" entry-id)
+                   0
+                   (hasheq 'fork-entry-id entry-id)))
      ;; Publish fork event for runtime to handle
      (when (cmd-ctx-event-bus cctx)
        (publish! (cmd-ctx-event-bus cctx)
@@ -238,22 +238,21 @@
   (cond
     ;; No registry available
     [(not reg)
-     (define entry (transcript-entry 'error "[no model registry available]" 0 (hash)))
+     (define entry (make-entry 'error "[no model registry available]" 0 (hash)))
      (set-box! (cmd-ctx-state-box cctx) (add-transcript-entry state entry))
      'continue]
     ;; No argument — list available models
     [(not arg)
      (define models (available-models reg))
      (define default (default-model reg))
-     (define header (transcript-entry 'system "Available models:" 0 (hash)))
+     (define header (make-entry 'system "Available models:" 0 (hash)))
      (define model-entries
        (for/list ([m (in-list models)])
          (define marker (if (equal? (model-entry-name m) default) " *" "  "))
-         (transcript-entry
-          'system
-          (format "~a ~a (~a)" marker (model-entry-name m) (model-entry-provider-name m))
-          0
-          (hash))))
+         (make-entry 'system
+                     (format "~a ~a (~a)" marker (model-entry-name m) (model-entry-provider-name m))
+                     0
+                     (hash))))
      (define all-entries (cons header model-entries))
      (define new-state
        (for/fold ([s state]) ([e (in-list all-entries)])
@@ -266,10 +265,10 @@
      (cond
        [(not resolution)
         (define entry
-          (transcript-entry 'error
-                            (format "Model not found: ~a. Use /model to list available models." arg)
-                            0
-                            (hash)))
+          (make-entry 'error
+                      (format "Model not found: ~a. Use /model to list available models." arg)
+                      0
+                      (hash)))
         (set-box! (cmd-ctx-state-box cctx) (add-transcript-entry state entry))
         'continue]
        [else
@@ -281,19 +280,19 @@
                                 (or (ui-state-session-id state) "")
                                 #f
                                 (hasheq 'model
-                                      (model-resolution-model-name resolution)
-                                      'provider
-                                      (model-resolution-provider-name resolution)))))
+                                        (model-resolution-model-name resolution)
+                                        'provider
+                                        (model-resolution-provider-name resolution)))))
         (define entry
-          (transcript-entry 'system
-                            (format "[switched to model: ~a (provider: ~a)]"
-                                    (model-resolution-model-name resolution)
-                                    (model-resolution-provider-name resolution))
-                            0
-                            (hasheq 'model
-                                  (model-resolution-model-name resolution)
-                                  'provider
-                                  (model-resolution-provider-name resolution))))
+          (make-entry 'system
+                      (format "[switched to model: ~a (provider: ~a)]"
+                              (model-resolution-model-name resolution)
+                              (model-resolution-provider-name resolution))
+                      0
+                      (hasheq 'model
+                              (model-resolution-model-name resolution)
+                              'provider
+                              (model-resolution-provider-name resolution))))
         (set-box! (cmd-ctx-state-box cctx) (add-transcript-entry state entry))
         'continue])]))
 
@@ -311,25 +310,24 @@
        (define sess-list (sessions-list session-dir #:limit 10))
        (define strings (sessions-list->strings sess-list))
        (if (null? sess-list)
-           (list (transcript-entry 'system "No sessions found." 0 (hash)))
+           (list (make-entry 'system "No sessions found." 0 (hash)))
            (for/list ([s (in-list strings)])
-             (transcript-entry 'system s 0 (hash))))]
+             (make-entry 'system s 0 (hash))))]
       ;; /sessions info <id>
       [(and (list? cmd) (>= (length cmd) 3) (eq? (cadr cmd) 'info))
        (define sid (caddr cmd))
        (define info (sessions-info session-dir sid))
-       (list (transcript-entry 'system (sessions-info->string info) 0 (hash)))]
+       (list (make-entry 'system (sessions-info->string info) 0 (hash)))]
       ;; /sessions delete <id>
       [(and (list? cmd) (>= (length cmd) 3) (eq? (cadr cmd) 'delete))
        (define sid (caddr cmd))
        (define result (sessions-delete session-dir sid))
        (list (case result
-               [(ok) (transcript-entry 'system (format "Session ~a deleted." sid) 0 (hash))]
-               [(not-found) (transcript-entry 'error (format "Session not found: ~a" sid) 0 (hash))]
-               [(cancelled) (transcript-entry 'system "Cancelled." 0 (hash))]))]
+               [(ok) (make-entry 'system (format "Session ~a deleted." sid) 0 (hash))]
+               [(not-found) (make-entry 'error (format "Session not found: ~a" sid) 0 (hash))]
+               [(cancelled) (make-entry 'system "Cancelled." 0 (hash))]))]
       ;; Fallback
-      [else
-       (list (transcript-entry 'system "Usage: /sessions [list|info <id>|delete <id>]" 0 (hash)))]))
+      [else (list (make-entry 'system "Usage: /sessions [list|info <id>|delete <id>]" 0 (hash)))]))
   (define new-state
     (for/fold ([s state]) ([e (in-list entries)])
       (add-transcript-entry s e)))
@@ -356,7 +354,7 @@
        [(fork) (handle-fork-command cctx (and (>= (length cmd) 2) (cadr cmd)))]
        [(sessions) (handle-sessions-tui-command cctx cmd)]
        [(switch-error children-error)
-        (define entry (transcript-entry 'error (cadr cmd) 0 (hash)))
+        (define entry (make-entry 'error (cadr cmd) 0 (hash)))
         (set-box! (cmd-ctx-state-box cctx) (add-transcript-entry state entry))
         'continue]
        [else 'continue])]
@@ -371,21 +369,19 @@
         (define cmds (all-commands reg))
         (define help-entries
           (cons
-           (transcript-entry 'system "Commands:" 0 (hash))
+           (make-entry 'system "Commands:" 0 (hash))
            (for/list ([c (in-list cmds)])
-             (define args-str (if (null? (cmd-entry-args-spec c))
-                                  ""
-                                  (string-append " " (string-join (cmd-entry-args-spec c) " "))))
-             (define aliases-str (if (null? (cmd-entry-aliases c))
-                                     ""
-                                     (format " (~a)" (string-join (cmd-entry-aliases c) ", "))))
-             (transcript-entry
+             (define args-str
+               (if (null? (cmd-entry-args-spec c))
+                   ""
+                   (string-append " " (string-join (cmd-entry-args-spec c) " "))))
+             (define aliases-str
+               (if (null? (cmd-entry-aliases c))
+                   ""
+                   (format " (~a)" (string-join (cmd-entry-aliases c) ", "))))
+             (make-entry
               'system
-              (format "  ~a~a~a  ~a"
-                      (cmd-entry-name c)
-                      args-str
-                      aliases-str
-                      (cmd-entry-summary c))
+              (format "  ~a~a~a  ~a" (cmd-entry-name c) args-str aliases-str (cmd-entry-summary c))
               0
               (hash)))))
         (define new-state
@@ -398,7 +394,7 @@
         'continue]
        [(compact)
         ;; Compact: add status message and notify runtime
-        (define entry (transcript-entry 'system "[compact requested]" 0 (hash)))
+        (define entry (make-entry 'system "[compact requested]" 0 (hash)))
         (set-box! (cmd-ctx-state-box cctx) (add-transcript-entry state entry))
         (when (cmd-ctx-event-bus cctx)
           (publish! (cmd-ctx-event-bus cctx)
@@ -418,7 +414,7 @@
                                 #f
                                 (hash))))
         (define entry
-          (transcript-entry 'system "[interrupt requested]" (current-inexact-milliseconds) (hash)))
+          (make-entry 'system "[interrupt requested]" (current-inexact-milliseconds) (hash)))
         (set-box! (cmd-ctx-state-box cctx) (add-transcript-entry state entry))
         'continue]
        [(branches) (handle-branches-command cctx)]
@@ -428,7 +424,7 @@
         (set-box! (cmd-ctx-running-box cctx) #f)
         'quit]
        [(unknown)
-        (define entry (transcript-entry 'error "Unknown command. Type /help for commands." 0 (hash)))
+        (define entry (make-entry 'error "Unknown command. Type /help for commands." 0 (hash)))
         (set-box! (cmd-ctx-state-box cctx) (add-transcript-entry state entry))
         'continue]
        [else 'continue])]))

--- a/tui/render.rkt
+++ b/tui/render.rkt
@@ -192,8 +192,7 @@
         (if (<= (string-visible-width remaining) max-width)
             (reverse (cons remaining acc))
             (let ([break-pos (find-break-pos remaining max-width)])
-              (loop (substring remaining break-pos)
-                    (cons (substring remaining 0 break-pos) acc)))))))
+              (loop (substring remaining break-pos) (cons (substring remaining 0 break-pos) acc)))))))
 
 ;; Find a good break position using visible column width (prefer space).
 ;; Returns a character index (not a column index) into `text`.
@@ -205,21 +204,17 @@
              [last-space-idx #f])
     (cond
       [(>= i (string-length text)) (string-length text)]
-      [(>= col max-width)
-       ;; Exceeded width — break at last space or current position
-       (or last-space-idx i)]
+      ;; Exceeded width — break at last space or current position
+      [(>= col max-width) (or last-space-idx i)]
       [else
        (define c (string-ref text i))
        (define w (char-width c))
        (define new-col (+ col w))
        (cond
          ;; Char would exceed max-width on its own
-         [(> new-col max-width)
-          (or last-space-idx i)]
-         [(char-whitespace? c)
-          (loop (add1 i) new-col (add1 i))]
-         [else
-          (loop (add1 i) new-col last-space-idx)])])))
+         [(> new-col max-width) (or last-space-idx i)]
+         [(char-whitespace? c) (loop (add1 i) new-col (add1 i))]
+         [else (loop (add1 i) new-col last-space-idx)])])))
 
 ;; Invert a style (add 'inverse if not present, remove if present)
 (define (style-invert style)
@@ -308,9 +303,25 @@
 (define (render-transcript state transcript-height [width 200])
   (define entries (ui-state-transcript state))
   (define scroll-offset (ui-state-scroll-offset state))
-  ;; Format all entries into lines
-  (define formatted-lines (apply append (map (lambda (e) (format-entry e width)) entries)))
-  ;; If streaming, append the partial streaming text
+  ;; Check width validity — flush cache if terminal resized
+  (define state0
+    (if (rendered-cache-width-valid? state width)
+        state
+        (rendered-cache-set-width (rendered-cache-clear! state) width)))
+  ;; Format entries using cache where possible
+  (define-values (formatted-lines state1)
+    (for/fold ([lines '()]
+               [st state0])
+              ([e (in-list entries)])
+      (define eid (transcript-entry-id e))
+      (define cached (and eid (rendered-cache-ref st eid)))
+      (if cached
+          (values (append lines cached) st)
+          (let ([fmt (format-entry e width)])
+            (if eid
+                (values (append lines fmt) (rendered-cache-set st eid fmt))
+                (values (append lines fmt) st))))))
+  ;; If streaming, append the partial streaming text (not cached)
   (define streaming (ui-state-streaming-text state))
   (define all-lines
     (if (and streaming (not (string=? streaming "")))
@@ -319,12 +330,13 @@
                   (styled-line (list (styled-segment line '(dim))))))
         formatted-lines))
   (define total (length all-lines))
-  (if (<= total transcript-height)
-      all-lines
-      (let* ([start (max 0 (- total transcript-height scroll-offset))]
-             [end (max transcript-height (- total scroll-offset))]
-             [available (drop all-lines start)])
-        (take available (min transcript-height (length available))))))
+  (define sliced-lines
+    (if (<= total transcript-height)
+        all-lines
+        (let* ([start (max 0 (- total transcript-height scroll-offset))]
+               [available (drop all-lines start)])
+          (take available (min transcript-height (length available))))))
+  (values sliced-lines state1))
 
 ;; Render the status bar (bottom area above input)
 ;; Returns styled-line

--- a/tui/renderer.rkt
+++ b/tui/renderer.rkt
@@ -21,34 +21,37 @@
 ;;   dim     = fg=8 (dark gray)
 ;;   reset   = fg=7, bg=0, bold=#f (default values)
 
-(provide
- ;; Main rendering function
- render-frame!
+;; Main rendering function
+(provide render-frame!
 
- ;; Style mapping (for testing)
- style->ubuf-kws
+         ;; Style mapping (for testing)
+         style->ubuf-kws
 
- ;; Ubuf operations (settable for testing)
- current-ubuf-clear
- current-ubuf-putstring)
+         ;; Ubuf operations (settable for testing)
+         current-ubuf-clear
+         current-ubuf-putstring)
 
 ;; ============================================================
 ;; Ubuf operations (parameterized for testability)
 ;; ============================================================
 
 ;; Parameter for ubuf-clear! function
-(define current-ubuf-clear
-  (make-parameter (lambda (ubuf) (void))))
+(define current-ubuf-clear (make-parameter (lambda (ubuf) (void))))
 
 ;; Parameter for ubuf-putstring! function
 ;; Signature matches tui-ubuf: (ubuf x y str #:fg #:bg #:bold #:underline ...)
 (define current-ubuf-putstring
-  (make-parameter
-   (lambda (ubuf x y str
-            #:fg [fg 7] #:bg [bg 0]
-            #:bold [bold #f] #:underline [underline #f]
-            #:italic [italic #f] #:blink [blink #f])
-     (void))))
+  (make-parameter (lambda (ubuf
+                           x
+                           y
+                           str
+                           #:fg [fg 7]
+                           #:bg [bg 0]
+                           #:bold [bold #f]
+                           #:underline [underline #f]
+                           #:italic [italic #f]
+                           #:blink [blink #f])
+                    (void))))
 
 ;; ============================================================
 ;; Style → ubuf attribute conversion
@@ -57,16 +60,16 @@
 ;; Color name → ANSI color number
 (define (color-name->number c)
   (case c
-    [(black)  0]
-    [(red)    1]
-    [(green)  2]
+    [(black) 0]
+    [(red) 1]
+    [(green) 2]
     [(yellow) 3]
-    [(blue)   4]
-    [(magenta)5]
-    [(cyan)   6]
-    [(white)  7]
+    [(blue) 4]
+    [(magenta) 5]
+    [(cyan) 6]
+    [(white) 7]
     [(dim-gray dark-gray) 8]
-    [else     7]))
+    [else 7]))
 
 ;; Resolve a list of style symbols into ubuf keyword arguments.
 ;; Returns (values kw-list val-list) for keyword-apply.
@@ -75,26 +78,28 @@
 ;; Style symbols from render.rkt:
 ;;   'bold 'inverse 'underline 'dim 'red 'green 'yellow 'cyan
 (define (style->ubuf-kws styles)
-  (define fg-color   #f)
-  (define bg-color   #f)
-  (define bold?      #f)
+  (define fg-color #f)
+  (define bg-color #f)
+  (define bold? #f)
   (define underline? #f)
-  (define italic?    #f)
-  (define inverse?   #f)
+  (define italic? #f)
+  (define inverse? #f)
   (for ([s (in-list styles)])
     (case s
-      [(bold)      (set! bold? #t)]
-      [(italic)    (set! italic? #t)]
-      [(inverse)   (set! inverse? #t)]
+      [(bold) (set! bold? #t)]
+      [(italic) (set! italic? #t)]
+      [(inverse) (set! inverse? #t)]
       [(underline) (set! underline? #t)]
-      [(dim)       (when (not fg-color) (set! fg-color 8))]
-      [(red)       (set! fg-color 1)]
-      [(green)     (set! fg-color 2)]
-      [(yellow)    (set! fg-color 3)]
-      [(blue)      (set! fg-color 4)]
-      [(magenta)   (set! fg-color 5)]
-      [(cyan)      (set! fg-color 6)]
-      [(white)     (set! fg-color 7)]
+      [(dim)
+       (when (not fg-color)
+         (set! fg-color 8))]
+      [(red) (set! fg-color 1)]
+      [(green) (set! fg-color 2)]
+      [(yellow) (set! fg-color 3)]
+      [(blue) (set! fg-color 4)]
+      [(magenta) (set! fg-color 5)]
+      [(cyan) (set! fg-color 6)]
+      [(white) (set! fg-color 7)]
       [else (void)]))
   ;; Collect kw/val pairs — only include non-defaults
   (define pairs '())
@@ -176,7 +181,7 @@
   (define header-y (- header-row 1))
   (define trans-y (- transcript-start-row 1))
   (define status-y (- status-row 1))
-  (define input-y  (- input-row 1))
+  (define input-y (- input-row 1))
 
   ;; 1. Clear the buffer
   (ubuf-clear! ubuf)
@@ -185,8 +190,8 @@
   (define header-text (format " q ~a" (make-string (max 0 (- cols 3)) #\space)))
   (ubuf-putstring! ubuf 0 header-y header-text #:fg 0 #:bg 7)
 
-  ;; 3. Draw transcript entries
-  (define trans-lines-raw (render-transcript ui-state transcript-height cols))
+  ;; 3. Draw transcript entries (with render cache)
+  (define-values (trans-lines-raw ui-state*) (render-transcript ui-state transcript-height cols))
   ;; Apply selection highlight if selection is active
   (define sel-anchor (ui-state-sel-anchor ui-state))
   (define sel-end (ui-state-sel-end ui-state))
@@ -216,4 +221,4 @@
   ;; 6. Return cursor position (0-indexed for ANSI escape)
   (define-values (_visible-text _scroll-offset cursor-display-col)
     (input-visible-window input-st cols))
-  (values cursor-display-col input-y))
+  (values cursor-display-col input-y ui-state*))

--- a/tui/scrollback.rkt
+++ b/tui/scrollback.rkt
@@ -6,52 +6,59 @@
          "../util/jsonl.rkt"
          json)
 
-(provide
- ;; Conversion
- transcript-entry->jsexpr
- jsexpr->transcript-entry
+;; Conversion
+(provide transcript-entry->jsexpr
+         jsexpr->transcript-entry
 
- ;; Persistence
- save-scrollback
- load-scrollback)
+         ;; Persistence
+         save-scrollback
+         load-scrollback)
 
 ;; Maximum number of scrollback entries to keep on disk.
 (define scrollback-max-entries 500)
 
 ;; Serialize a transcript-entry to a JSON-compatible hash.
 (define (transcript-entry->jsexpr entry)
-  (hasheq 'kind  (symbol->string (transcript-entry-kind entry))
-        'text  (transcript-entry-text entry)
-        'timestamp (transcript-entry-timestamp entry)
-        'meta (hash->jsexpr-deep (transcript-entry-meta entry))))
+  (hasheq 'kind
+          (symbol->string (transcript-entry-kind entry))
+          'text
+          (transcript-entry-text entry)
+          'timestamp
+          (transcript-entry-timestamp entry)
+          'meta
+          (hash->jsexpr-deep (transcript-entry-meta entry))))
 
 ;; Deserialize a jsexpr hash back to a transcript-entry.
 (define (jsexpr->transcript-entry h)
-  (transcript-entry
-   (string->symbol (hash-ref h 'kind "system"))
-   (hash-ref h 'text "")
-   (hash-ref h 'timestamp 0)
-   (jsexpr->hash-deep (hash-ref h 'meta (hash)))))
+  (transcript-entry (string->symbol (hash-ref h 'kind "system"))
+                    (hash-ref h 'text "")
+                    (hash-ref h 'timestamp 0)
+                    (jsexpr->hash-deep (hash-ref h 'meta (hash)))
+                    #f))
 
 ;; Save transcript-entries to a JSONL file.
 ;; Atomically rewrites with only the last scrollback-max-entries entries
 ;; to prevent unbounded file growth.
 ;; Accepts both string? and path? for the path argument.
 (define (save-scrollback entries path)
-  (define path-str (if (path? path) (path->string path) path))
-  (define trimmed (if (> (length entries) scrollback-max-entries)
-                      (take-right entries scrollback-max-entries)
-                      entries))
+  (define path-str
+    (if (path? path)
+        (path->string path)
+        path))
+  (define trimmed
+    (if (> (length entries) scrollback-max-entries)
+        (take-right entries scrollback-max-entries)
+        entries))
   (define jsexprs (map transcript-entry->jsexpr trimmed))
   ;; Atomic rewrite: write to temp then rename
   (define tmp-path (string-append path-str ".tmp"))
   (call-with-output-file tmp-path
-    (lambda (out)
-      (for ([entry (in-list jsexprs)])
-        (write-json entry out)
-        (newline out)))
-    #:mode 'text
-    #:exists 'replace)
+                         (lambda (out)
+                           (for ([entry (in-list jsexprs)])
+                             (write-json entry out)
+                             (newline out)))
+                         #:mode 'text
+                         #:exists 'replace)
   (rename-file-or-directory tmp-path path-str #t))
 
 ;; Load transcript-entries from a JSONL file.
@@ -63,7 +70,10 @@
 ;; Deep hash → nested jsexpr conversion (handles nested hashes)
 (define (hash->jsexpr-deep h)
   (for/hash ([(k v) (in-hash h)])
-    (values k (if (hash? v) (hash->jsexpr-deep v) v))))
+    (values k
+            (if (hash? v)
+                (hash->jsexpr-deep v)
+                v))))
 
 ;; Deep jsexpr → nested hash conversion
 (define (jsexpr->hash-deep h)

--- a/tui/state.rkt
+++ b/tui/state.rkt
@@ -17,6 +17,19 @@
          ;; Constructors
          initial-ui-state
 
+         ;; Entry helpers
+         make-entry
+         assign-entry-id
+         next-entry-id
+
+         ;; Render cache helpers
+         rendered-cache-ref
+         rendered-cache-set
+         rendered-cache-clear!
+         rendered-cache-invalidate-entry
+         rendered-cache-width-valid?
+         rendered-cache-set-width
+
          ;; Branch management
          set-current-branch
          set-visible-branches
@@ -48,12 +61,14 @@
          set-selection-end
          clear-selection
          has-selection?)
+
 ;; A single line in the transcript display
 (struct transcript-entry
         (kind ; symbol: 'assistant | 'tool-start | 'tool-end | 'tool-fail | 'system | 'error | 'user
          text ; string — the display text
          timestamp ; number — epoch seconds (or 0)
          meta ; hash — extra data (tool name, error message, etc.)
+         id ; integer or #f — unique entry id for render cache
          )
   #:transparent)
 
@@ -72,6 +87,9 @@
          visible-branches ; (listof branch-info) — cached branch list for display
          sel-anchor ; (cons col row) or #f — mouse selection start
          sel-end ; (cons col row) or #f — mouse selection end
+         rendered-cache ; hash — maps entry-id → (listof styled-line)
+         rendered-cache-width ; integer or #f — width used for cache
+         next-entry-id ; integer — monotonic counter
          )
   #:transparent)
 
@@ -85,7 +103,60 @@
          )
   #:transparent)
 
+;; ============================================================
+;; Entry construction helpers
+;; ============================================================
+
+;; Create a transcript-entry with id=#f (not yet assigned)
+(define (make-entry kind text timestamp meta)
+  (transcript-entry kind text timestamp meta #f))
+
+;; Assign a unique id to an entry, returning (values new-entry new-state)
+(define (assign-entry-id entry state)
+  (define id (ui-state-next-entry-id state))
+  (values (struct-copy transcript-entry entry [id id])
+          (struct-copy ui-state state [next-entry-id (add1 id)])))
+
+;; Get the current next-entry-id (without incrementing)
+(define (next-entry-id state)
+  (ui-state-next-entry-id state))
+
+;; ============================================================
+;; Render cache helpers
+;; ============================================================
+
+;; Look up cached rendered lines for an entry id
+(define (rendered-cache-ref state entry-id)
+  (hash-ref (ui-state-rendered-cache state) entry-id #f))
+
+;; Store cached rendered lines for an entry id, returning new state
+(define (rendered-cache-set state entry-id lines)
+  (struct-copy ui-state
+               state
+               [rendered-cache (hash-set (ui-state-rendered-cache state) entry-id lines)]))
+
+;; Clear the entire render cache and reset width
+(define (rendered-cache-clear! state)
+  (struct-copy ui-state state [rendered-cache (hash)] [rendered-cache-width #f]))
+
+;; Remove a single entry from the render cache
+(define (rendered-cache-invalidate-entry state entry-id)
+  (struct-copy ui-state
+               state
+               [rendered-cache (hash-remove (ui-state-rendered-cache state) entry-id)]))
+
+;; Check if the cache width matches the given width
+(define (rendered-cache-width-valid? state width)
+  (equal? (ui-state-rendered-cache-width state) width))
+
+;; Set the cache width (typically after clearing cache on resize)
+(define (rendered-cache-set-width state width)
+  (struct-copy ui-state state [rendered-cache-width width]))
+
+;; ============================================================
 ;; Constructor with defaults
+;; ============================================================
+
 (define (initial-ui-state #:session-id [session-id #f]
                           #:model-name [model-name #f]
                           #:mode [mode 'chat])
@@ -101,7 +172,14 @@
             #f ; current-branch
             '() ; visible-branches
             #f ; sel-anchor
-            #f)) ; sel-end
+            #f ; sel-end
+            (hash) ; rendered-cache
+            #f ; rendered-cache-width
+            0)) ; next-entry-id
+
+;; ============================================================
+;; Event reduction
+;; ============================================================
 
 ;; Apply a runtime event to the UI state.
 ;; Returns a new ui-state (immutable update).
@@ -111,6 +189,12 @@
   ;; (event version ev time session-id turn-id payload)
   (define ev (event-ev evt))
   (define payload (event-payload evt))
+
+  ;; Helper: create entry, assign id, append to transcript, return new state
+  (define (append-entry st entry)
+    (define-values (id-entry st1) (assign-entry-id entry st))
+    (struct-copy ui-state st1 [transcript (append (ui-state-transcript st1) (list id-entry))]))
+
   (case ev
     [("assistant.message.completed")
      ;; Add assistant text to transcript, mark not busy
@@ -120,10 +204,7 @@
      (define content (or streamed (hash-ref payload 'content "")))
      (define ts (event-time evt))
      (struct-copy ui-state
-                  state
-                  [transcript
-                   (append (ui-state-transcript state)
-                           (list (transcript-entry 'assistant content ts (hash))))]
+                  (append-entry state (make-entry 'assistant content ts (hash)))
                   [busy? #f]
                   [pending-tool-name #f]
                   [streaming-text #f])]
@@ -143,10 +224,7 @@
      (define ts (event-time evt))
      (define meta (hasheq 'name name 'arguments (or args-raw "")))
      (struct-copy ui-state
-                  state
-                  [transcript
-                   (append (ui-state-transcript state)
-                           (list (transcript-entry 'tool-start text ts meta)))]
+                  (append-entry state (make-entry 'tool-start text ts meta))
                   [busy? #t]
                   [pending-tool-name name])]
 
@@ -165,10 +243,7 @@
      (define ts (event-time evt))
      (define meta (hasheq 'name name 'result (or result-raw "")))
      (struct-copy ui-state
-                  state
-                  [transcript
-                   (append (ui-state-transcript state)
-                           (list (transcript-entry 'tool-end text ts meta)))]
+                  (append-entry state (make-entry 'tool-end text ts meta))
                   [pending-tool-name #f])]
 
     [("tool.call.failed")
@@ -176,55 +251,38 @@
      (define name (hash-ref payload 'name "?"))
      (define err (hash-ref payload 'error "unknown"))
      (define ts (event-time evt))
-     (struct-copy ui-state
-                  state
-                  [transcript
-                   (append (ui-state-transcript state)
-                           (list (transcript-entry 'tool-fail
-                                                   (format "[FAIL: ~a] ~a" name err)
-                                                   ts
-                                                   (hasheq 'name name 'error err))))]
-                  [pending-tool-name #f])]
+     (struct-copy
+      ui-state
+      (append-entry
+       state
+       (make-entry 'tool-fail (format "[FAIL: ~a] ~a" name err) ts (hasheq 'name name 'error err)))
+      [pending-tool-name #f])]
 
     [("runtime.error")
      (define err (hash-ref payload 'error "unknown error"))
      (define ts (event-time evt))
      (struct-copy ui-state
-                  state
-                  [transcript
-                   (append (ui-state-transcript state)
-                           (list (transcript-entry 'error (format "Error: ~a" err) ts (hash))))]
+                  (append-entry state (make-entry 'error (format "Error: ~a" err) ts (hash)))
                   [busy? #f])]
 
     [("session.started")
      (define sid (hash-ref payload 'sessionId ""))
-     (struct-copy ui-state
-                  state
-                  [session-id sid]
-                  [transcript
-                   (append (ui-state-transcript state)
-                           (list (transcript-entry 'system
-                                                   (format "Session started: ~a" sid)
-                                                   (event-time evt)
-                                                   (hash))))])]
+     (define s1 (struct-copy ui-state state [session-id sid]))
+     (append-entry s1
+                   (make-entry 'system (format "Session started: ~a" sid) (event-time evt) (hash)))]
 
     [("session.resumed")
      (define sid (hash-ref payload 'sessionId ""))
-     (struct-copy ui-state
-                  state
-                  [session-id sid]
-                  [transcript
-                   (append (ui-state-transcript state)
-                           (list (transcript-entry 'system
-                                                   (format "Session resumed: ~a" sid)
-                                                   (event-time evt)
-                                                   (hash))))])]
+     (define s1 (struct-copy ui-state state [session-id sid]))
+     (append-entry s1
+                   (make-entry 'system (format "Session resumed: ~a" sid) (event-time evt) (hash)))]
 
     [("model.stream.delta")
      ;; Accumulate streaming text from the model
      (define delta (hash-ref payload 'delta ""))
      (define current-streaming (ui-state-streaming-text state))
      (define new-streaming (string-append (or current-streaming "") delta))
+     ;; Invalidate cache for the streaming entry (if re-rendering)
      (struct-copy ui-state state [streaming-text new-streaming] [busy? #t])]
 
     ;; Agent starts processing — mark busy
@@ -239,25 +297,15 @@
 
     [("compaction.warning")
      (define tc (hash-ref payload 'tokenCount "?"))
-     (struct-copy ui-state
-                  state
-                  [transcript
-                   (append (ui-state-transcript state)
-                           (list (transcript-entry 'system
-                                                   (format "[compaction warning: ~a tokens]" tc)
-                                                   (event-time evt)
-                                                   (hash))))])]
+     (append-entry
+      state
+      (make-entry 'system (format "[compaction warning: ~a tokens]" tc) (event-time evt) (hash)))]
 
     [("session.forked")
      (define new-sid (hash-ref payload 'newSessionId ""))
-     (struct-copy ui-state
-                  state
-                  [transcript
-                   (append (ui-state-transcript state)
-                           (list (transcript-entry 'system
-                                                   (format "[session forked: ~a]" new-sid)
-                                                   (event-time evt)
-                                                   (hash))))])]
+     (append-entry
+      state
+      (make-entry 'system (format "[session forked: ~a]" new-sid) (event-time evt) (hash)))]
 
     [("compaction.started") (struct-copy ui-state state [status-message "Compacting..."])]
 
@@ -273,22 +321,29 @@
      (define name (hash-ref payload 'name "?"))
      (define reason (hash-ref payload 'reason "blocked by extension"))
      (struct-copy ui-state
-                  state
-                  [transcript
-                   (append (ui-state-transcript state)
-                           (list (transcript-entry 'system
-                                                   (format "[tool blocked: ~a — ~a]" name reason)
-                                                   (event-time evt)
-                                                   (hasheq 'name name))))]
+                  (append-entry state
+                                (make-entry 'system
+                                            (format "[tool blocked: ~a — ~a]" name reason)
+                                            (event-time evt)
+                                            (hasheq 'name name)))
                   [pending-tool-name #f])]
 
     [else state])) ;; Ignore unknown events
 
+;; ============================================================
+;; Transcript helpers
+;; ============================================================
+
 ;; Add a user message to transcript (called when user submits input)
+;; Assigns an entry id if the entry doesn't already have one.
 (define (add-transcript-entry state entry)
+  (define-values (id-entry state1)
+    (if (transcript-entry-id entry)
+        (values entry state)
+        (assign-entry-id entry state)))
   (struct-copy ui-state
-               state
-               [transcript (append (ui-state-transcript state) (list entry))]
+               state1
+               [transcript (append (ui-state-transcript state1) (list id-entry))]
                [scroll-offset 0])) ;; Reset scroll to bottom
 
 ;; Get visible entries — returns all transcript entries.
@@ -319,6 +374,10 @@
 (define (scroll-to-top state)
   (struct-copy ui-state state [scroll-offset 999999]))
 
+;; ============================================================
+;; Selection
+;; ============================================================
+
 ;; Set mouse selection anchor (start of drag)
 (define (set-selection-anchor state col row)
   (struct-copy ui-state state [sel-anchor (cons col row)] [sel-end (cons col row)]))
@@ -335,7 +394,10 @@
 (define (has-selection? state)
   (and (ui-state-sel-anchor state) (ui-state-sel-end state)))
 
+;; ============================================================
 ;; Queries
+;; ============================================================
+
 (define (ui-busy? state)
   (ui-state-busy? state))
 

--- a/tui/tui-init.rkt
+++ b/tui/tui-init.rkt
@@ -81,17 +81,16 @@
                             base-state
                             (struct-copy ui-state base-state [transcript loaded])))
                       base-state)]
-           [welcome-entries
-            (if (and first-run? (null? (ui-state-transcript state)))
-                (list (transcript-entry 'system
-                                        "Welcome to q! Type a message to get started."
-                                        (current-inexact-milliseconds)
-                                        (hash))
-                      (transcript-entry 'system
-                                        "Commands: /help for reference, /quit to exit."
-                                        (current-inexact-milliseconds)
-                                        (hash)))
-                '())])
+           [welcome-entries (if (and first-run? (null? (ui-state-transcript state)))
+                                (list (make-entry 'system
+                                                  "Welcome to q! Type a message to get started."
+                                                  (current-inexact-milliseconds)
+                                                  (hash))
+                                      (make-entry 'system
+                                                  "Commands: /help for reference, /quit to exit."
+                                                  (current-inexact-milliseconds)
+                                                  (hash)))
+                                '())])
       (if (not (null? welcome-entries))
           (struct-copy ui-state
                        state

--- a/tui/tui-keybindings.rkt
+++ b/tui/tui-keybindings.rkt
@@ -110,7 +110,7 @@
          (define layout (compute-layout cols rows))
          (define trans-y (tui-layout-transcript-start-row layout))
          (define trans-height (tui-layout-transcript-height layout))
-         (define all-lines (render-transcript state trans-height cols))
+         (define-values (all-lines _state*) (render-transcript state trans-height cols))
          ;; Map screen rows to line indices (screen row → rendered line index)
          ;; Mouse y is 0-based: row 0 = header, row 1 = first transcript line.
          ;; trans-y is 1-based: value 2 means transcript starts at screen row 1 (0-based).
@@ -184,7 +184,7 @@
            (list 'command (or cmd 'unknown))]
           [else
            ;; Add user message to transcript
-           (define user-entry (transcript-entry 'user text (current-inexact-milliseconds) (hash)))
+           (define user-entry (make-entry 'user text (current-inexact-milliseconds) (hash)))
            (set-box! (tui-ctx-ui-state-box ctx) (add-transcript-entry state user-entry))
            (list 'submit text)])]
        [(#\newline)
@@ -215,7 +215,7 @@
            (list 'command (or cmd 'unknown))]
           [else
            ;; Add user message to transcript
-           (define user-entry (transcript-entry 'user text (current-inexact-milliseconds) (hash)))
+           (define user-entry (make-entry 'user text (current-inexact-milliseconds) (hash)))
            (set-box! (tui-ctx-ui-state-box ctx) (add-transcript-entry state user-entry))
            (list 'submit text)])]
        [(left kp-left)

--- a/tui/tui-render-loop.rkt
+++ b/tui/tui-render-loop.rkt
@@ -161,7 +161,10 @@
   (define layout (compute-layout cols rows))
 
   ;; Render to ubuf (returns cursor position)
-  (define-values (cursor-col cursor-row) (renderer:render-frame! ubuf state inp layout))
+  (define-values (cursor-col cursor-row state*) (renderer:render-frame! ubuf state inp layout))
+
+  ;; Write back state with updated render cache
+  (set-box! (tui-ctx-ui-state-box ctx) state*)
 
   ;; Display ubuf to terminal
   (tui-cursor-hide)


### PR DESCRIPTION
## Wave 4: Rendered-Line Caching

Implements #374 (parent), #375 (W4.1: entry IDs + cache to state), #376 (W4.2: wire cache into render-transcript).

### Changes

**W4.1 (#375) — Entry IDs + Cache in State:**
- `transcript-entry` struct gains `id` field (monotonic integer, #f for pre-existing)
- `ui-state` gains `rendered-cache` (hash: id→styled-lines), `rendered-cache-width`, `next-entry-id`
- New `make-entry` helper: 4-arg constructor with id=#f
- New `assign-entry-id`: assigns monotonic ID and advances counter
- New cache helpers: `rendered-cache-ref/set/clear!/invalidate-entry/width-valid?/set-width`
- All existing `transcript-entry` constructor calls migrated to `make-entry`

**W4.2 (#376) — Wire Cache into render-transcript:**
- `render-transcript` returns `(values lines new-state)` using cache
- Cache hits skip `format-entry`; misses populate cache
- Cache flushed on width change (terminal resize)
- `renderer.rkt render-frame!` returns 3 values: cursor-col, cursor-row, updated-state
- `tui-render-loop` writes cached state back to ui-state box
- `tui-keybindings` uses `define-values` for new return contract

### Tests
- All 3437 tests pass
- Format lint clean
- New cache fields tested via existing state tests

### Performance Impact
Entries that have already been formatted are cached. Only new/modified entries (streaming deltas) trigger `format-entry`. Width changes flush the entire cache.