### PR TITLE
feat(tui): 0-based layout row indexing (Wave 5, #377-#379)

### DIFF
--- a/tests/test-tui-renderer.rkt
+++ b/tests/test-tui-renderer.rkt
@@ -318,7 +318,7 @@
       (define state (initial-ui-state #:session-id "test-session" #:model-name "gpt-4"))
       (define input-st (initial-input-state))
       (define layout (compute-layout 80 24))
-      (define status-row-num (- (tui-layout-status-row layout) 1))
+      (define status-row-num (tui-layout-status-row layout))
       (run-render-frame! ubuf state input-st layout)
       (define status-str (mock-ubuf-row-string ubuf status-row-num))
       (check-true (string-contains? status-str "q") "status bar contains 'q' indicator")
@@ -329,7 +329,7 @@
       (define state (initial-ui-state #:session-id "s1"))
       (define input-st (initial-input-state))
       (define layout (compute-layout 80 24))
-      (define status-row-num (- (tui-layout-status-row layout) 1))
+      (define status-row-num (tui-layout-status-row layout))
       (run-render-frame! ubuf state input-st layout)
       (define inverse-count
         (mock-ubuf-row-style-count ubuf status-row-num (lambda (c) (= (mock-cell-bg c) 7))))
@@ -340,7 +340,7 @@
       (define state (struct-copy ui-state (initial-ui-state #:session-id "s1") [busy? #t]))
       (define input-st (initial-input-state))
       (define layout (compute-layout 80 24))
-      (define status-row-num (- (tui-layout-status-row layout) 1))
+      (define status-row-num (tui-layout-status-row layout))
       (run-render-frame! ubuf state input-st layout)
       (define status-str (mock-ubuf-row-string ubuf status-row-num))
       ;; Status bar should have busy marker (⏳) or session info
@@ -355,7 +355,7 @@
       (define state (initial-ui-state))
       (define input-st (input-insert-char (input-insert-char (initial-input-state) #\h) #\i))
       (define layout (compute-layout 80 24))
-      (define input-row-num (- (tui-layout-input-row layout) 1))
+      (define input-row-num (tui-layout-input-row layout))
       (run-render-frame! ubuf state input-st layout)
       (define input-str (mock-ubuf-row-string ubuf input-row-num))
       (check-true (string-contains? input-str "q>") "input line shows q> prompt")
@@ -366,7 +366,7 @@
       (define state (initial-ui-state))
       (define input-st (input-insert-char (initial-input-state) #\x))
       (define layout (compute-layout 80 24))
-      (define input-row-num (- (tui-layout-input-row layout) 1))
+      (define input-row-num (tui-layout-input-row layout))
       (run-render-frame! ubuf state input-st layout)
       (define bold-count (mock-ubuf-row-style-count ubuf input-row-num mock-cell-bold))
       (check-true (> bold-count 0) "input line should have bold style"))
@@ -376,7 +376,7 @@
       (define state (initial-ui-state))
       (define input-st (initial-input-state))
       (define layout (compute-layout 80 24))
-      (define input-row-num (- (tui-layout-input-row layout) 1))
+      (define input-row-num (tui-layout-input-row layout))
       (run-render-frame! ubuf state input-st layout)
       (define input-str (mock-ubuf-row-string ubuf input-row-num))
       (check-true (string-contains? input-str "q>") "empty input still shows prompt"))
@@ -389,7 +389,7 @@
       (define layout (compute-layout 80 24))
       (define-values (cursor-col cursor-row) (run-render-frame! ubuf state input-st layout))
       ;; cursor-row should be input row
-      (check-equal? cursor-row (- (tui-layout-input-row layout) 1))
+      (check-equal? cursor-row (tui-layout-input-row layout))
       ;; cursor-col should account for "q> " (4 chars) + 2 chars typed
       (check-true (>= cursor-col 4) "cursor column should be >= prompt width"))
 
@@ -419,7 +419,7 @@
       (define layout (compute-layout 80 10))
       (run-render-frame! ubuf state input-st layout)
       ;; Empty transcript cells have bg=0 (ANSI black)
-      (define trans-start (sub1 (tui-layout-transcript-start-row layout)))
+      (define trans-start (tui-layout-transcript-start-row layout))
       (define cell (mock-ubuf-cell ubuf 0 trans-start))
       (check-equal? (mock-cell-bg cell) 0 "empty cells use bg=0"))
 
@@ -429,7 +429,7 @@
       (define input-st (initial-input-state))
       (define layout (compute-layout 80 10))
       (run-render-frame! ubuf state input-st layout)
-      (define header-y (sub1 (tui-layout-header-row layout)))
+      (define header-y (tui-layout-header-row layout))
       (define cell (mock-ubuf-cell ubuf 1 header-y))
       (check-equal? (mock-cell-bg cell) 7 "header uses inverse bg=7"))
 

--- a/tests/tui/layout.rkt
+++ b/tests/tui/layout.rkt
@@ -7,81 +7,80 @@
          "../../../q/tui/layout.rkt")
 
 (define layout-tests
-  (test-suite
-   "TUI Layout"
+  (test-suite "TUI Layout"
 
-   ;; --------------------------------------------------------
-   ;; compute-layout: 80x24 standard terminal
-   ;; --------------------------------------------------------
-   (test-case "standard 80x24 terminal layout"
-     (let ([L (compute-layout 80 24)])
-       (check-equal? (tui-layout-cols L) 80)
-       (check-equal? (tui-layout-rows L) 24)
-       (check-equal? (tui-layout-header-row L) 1)
-       (check-equal? (tui-layout-transcript-start-row L) 2)
-       (check-equal? (tui-layout-transcript-height L) 21)   ;; 24 - 3
-       (check-equal? (tui-layout-status-row L) 23)           ;; 2 + 21
-       (check-equal? (tui-layout-input-row L) 24)))          ;; 3 + 21
+    ;; --------------------------------------------------------
+    ;; compute-layout: 80x24 standard terminal
+    ;; --------------------------------------------------------
+    (test-case "standard 80x24 terminal layout"
+      (let ([L (compute-layout 80 24)])
+        (check-equal? (tui-layout-cols L) 80)
+        (check-equal? (tui-layout-rows L) 24)
+        (check-equal? (tui-layout-header-row L) 0)
+        (check-equal? (tui-layout-transcript-start-row L) 1)
+        (check-equal? (tui-layout-transcript-height L) 21) ;; 24 - 3
+        (check-equal? (tui-layout-status-row L) 22) ;; 1 + 21
+        (check-equal? (tui-layout-input-row L) 23))) ;; 2 + 21
 
-   ;; --------------------------------------------------------
-   ;; compute-layout: minimum size clamped to 4 rows
-   ;; --------------------------------------------------------
-   (test-case "minimum size 80x3 clamped to 4 rows"
-     (let ([L (compute-layout 80 3)])
-       (check-equal? (tui-layout-rows L) 4)
-       (check-equal? (tui-layout-transcript-height L) 1)
-       (check-equal? (tui-layout-header-row L) 1)
-       (check-equal? (tui-layout-status-row L) 3)
-       (check-equal? (tui-layout-input-row L) 4)))
+    ;; --------------------------------------------------------
+    ;; compute-layout: minimum size clamped to 4 rows
+    ;; --------------------------------------------------------
+    (test-case "minimum size 80x3 clamped to 4 rows"
+      (let ([L (compute-layout 80 3)])
+        (check-equal? (tui-layout-rows L) 4)
+        (check-equal? (tui-layout-transcript-height L) 1)
+        (check-equal? (tui-layout-header-row L) 0)
+        (check-equal? (tui-layout-status-row L) 2)
+        (check-equal? (tui-layout-input-row L) 3)))
 
-   ;; --------------------------------------------------------
-   ;; compute-layout: tall terminal 120x50
-   ;; --------------------------------------------------------
-   (test-case "tall 120x50 terminal layout"
-     (let ([L (compute-layout 120 50)])
-       (check-equal? (tui-layout-cols L) 120)
-       (check-equal? (tui-layout-rows L) 50)
-       (check-equal? (tui-layout-transcript-height L) 47)   ;; 50 - 3
-       (check-equal? (tui-layout-status-row L) 49)
-       (check-equal? (tui-layout-input-row L) 50)))
+    ;; --------------------------------------------------------
+    ;; compute-layout: tall terminal 120x50
+    ;; --------------------------------------------------------
+    (test-case "tall 120x50 terminal layout"
+      (let ([L (compute-layout 120 50)])
+        (check-equal? (tui-layout-cols L) 120)
+        (check-equal? (tui-layout-rows L) 50)
+        (check-equal? (tui-layout-transcript-height L) 47) ;; 50 - 3
+        (check-equal? (tui-layout-status-row L) 48)
+        (check-equal? (tui-layout-input-row L) 49)))
 
-   ;; --------------------------------------------------------
-   ;; Transcript height = rows - 3 for rows >= 4
-   ;; --------------------------------------------------------
-   (test-case "transcript height equals rows minus 3 for rows 4..29"
-     (for ([r (in-range 4 30)])
-       (define L (compute-layout 80 r))
-       (check-equal? (tui-layout-transcript-height L) (- r 3)
-                     (format "transcript height for rows=~a" r))))
+    ;; --------------------------------------------------------
+    ;; Transcript height = rows - 3 for rows >= 4
+    ;; --------------------------------------------------------
+    (test-case "transcript height equals rows minus 3 for rows 4..29"
+      (for ([r (in-range 4 30)])
+        (define L (compute-layout 80 r))
+        (check-equal? (tui-layout-transcript-height L)
+                      (- r 3)
+                      (format "transcript height for rows=~a" r))))
 
-   ;; --------------------------------------------------------
-   ;; Row positions are consistent
-   ;; --------------------------------------------------------
-   (test-case "row positions are internally consistent for rows 4..19"
-     (for ([r (in-range 4 20)])
-       (define L (compute-layout 80 r))
-       (check-equal? (tui-layout-header-row L) 1)
-       (check-equal? (tui-layout-transcript-start-row L) 2)
-       (check-equal? (+ (tui-layout-transcript-start-row L)
-                        (tui-layout-transcript-height L))
-                     (tui-layout-status-row L)
-                     (format "rows=~a: transcript-start + height = status-row" r))
-       (check-equal? (+ (tui-layout-status-row L) 1)
-                     (tui-layout-input-row L)
-                     (format "rows=~a: status-row + 1 = input-row" r))))
+    ;; --------------------------------------------------------
+    ;; Row positions are consistent
+    ;; --------------------------------------------------------
+    (test-case "row positions are internally consistent for rows 4..19"
+      (for ([r (in-range 4 20)])
+        (define L (compute-layout 80 r))
+        (check-equal? (tui-layout-header-row L) 0)
+        (check-equal? (tui-layout-transcript-start-row L) 1)
+        (check-equal? (+ (tui-layout-transcript-start-row L) (tui-layout-transcript-height L))
+                      (tui-layout-status-row L)
+                      (format "rows=~a: transcript-start + height = status-row" r))
+        (check-equal? (+ (tui-layout-status-row L) 1)
+                      (tui-layout-input-row L)
+                      (format "rows=~a: status-row + 1 = input-row" r))))
 
-   ;; --------------------------------------------------------
-   ;; tui-layout predicate
-   ;; --------------------------------------------------------
-   (test-case "tui-layout? predicate returns #t"
-     (check-true (tui-layout? (compute-layout 80 24))))
+    ;; --------------------------------------------------------
+    ;; tui-layout predicate
+    ;; --------------------------------------------------------
+    (test-case "tui-layout? predicate returns #t"
+      (check-true (tui-layout? (compute-layout 80 24))))
 
-   ;; --------------------------------------------------------
-   ;; Narrow width doesn't crash
-   ;; --------------------------------------------------------
-   (test-case "narrow width 10x24 does not crash"
-     (let ([L (compute-layout 10 24)])
-       (check-equal? (tui-layout-cols L) 10)
-       (check-equal? (tui-layout-rows L) 24)))))
+    ;; --------------------------------------------------------
+    ;; Narrow width doesn't crash
+    ;; --------------------------------------------------------
+    (test-case "narrow width 10x24 does not crash"
+      (let ([L (compute-layout 10 24)])
+        (check-equal? (tui-layout-cols L) 10)
+        (check-equal? (tui-layout-rows L) 24)))))
 
 (run-tests layout-tests)

--- a/tui/layout.rkt
+++ b/tui/layout.rkt
@@ -5,37 +5,37 @@
 ;; Pure functions that compute which panels go where on screen.
 ;; No terminal I/O.
 
-(provide
- ;; Layout computation
- compute-layout
+;; Layout computation
+(provide compute-layout
 
- ;; Layout struct
- (struct-out tui-layout))
+         ;; Layout struct
+         (struct-out tui-layout))
 
 ;; Screen layout: where each panel starts and how tall it is
 (struct tui-layout
-  (cols rows                ; screen dimensions
-   header-row               ; row number for header (1-based)
-   transcript-start-row     ; row number for transcript start (1-based)
-   transcript-height        ; number of rows available for transcript
-   status-row               ; row number for status bar (1-based)
-   input-row                ; row number for input line (1-based)
-   )
+        (cols rows ; screen dimensions
+              header-row ; row number for header (0-based)
+              transcript-start-row ; row number for transcript start (0-based)
+              transcript-height ; number of rows available for transcript
+              status-row ; row number for status bar (0-based)
+              input-row ; row number for input line (0-based)
+              )
   #:transparent)
 
 ;; Compute layout given screen dimensions
-;; Layout:
-;;   Row 1:        Header (1 line) — "q | session | model"
-;;   Row 2..H-2:   Transcript (H-3 lines)
-;;   Row H-1:      Status bar (1 line)
-;;   Row H:        Input line (1 line)
+;; Layout (0-based row numbers):
+;;   Row 0:        Header (1 line) — "q | session | model"
+;;   Row 1..H-3:   Transcript (H-3 lines)
+;;   Row H-2:      Status bar (1 line)
+;;   Row H-1:      Input line (1 line)
 (define (compute-layout cols rows)
-  (define min-height 4)  ; Need at least header + 1 transcript + status + input
+  (define min-height 4) ; Need at least header + 1 transcript + status + input
   (define actual-rows (max min-height rows))
   (define transcript-h (max 1 (- actual-rows 3)))
-  (tui-layout cols actual-rows
-              1                    ; header-row
-              2                    ; transcript-start-row
-              transcript-h         ; transcript-height
-              (+ 2 transcript-h)   ; status-row
-              (+ 3 transcript-h))) ; input-row
+  (tui-layout cols
+              actual-rows
+              0 ; header-row
+              1 ; transcript-start-row
+              transcript-h ; transcript-height
+              (+ 1 transcript-h) ; status-row
+              (+ 2 transcript-h))) ; input-row

--- a/tui/renderer.rkt
+++ b/tui/renderer.rkt
@@ -176,12 +176,11 @@
   (define ubuf-clear! (current-ubuf-clear))
   (define ubuf-putstring! (current-ubuf-putstring))
 
-  ;; ubuf is 0-indexed, layout rows are 1-indexed.
-  ;; Convert all row numbers to 0-indexed for ubuf calls.
-  (define header-y (- header-row 1))
-  (define trans-y (- transcript-start-row 1))
-  (define status-y (- status-row 1))
-  (define input-y (- input-row 1))
+  ;; Layout rows are 0-based, matching ubuf's 0-based indexing.
+  (define header-y header-row)
+  (define trans-y transcript-start-row)
+  (define status-y status-row)
+  (define input-y input-row)
 
   ;; 1. Clear the buffer
   (ubuf-clear! ubuf)

--- a/tui/tui-keybindings.rkt
+++ b/tui/tui-keybindings.rkt
@@ -113,10 +113,10 @@
          (define-values (all-lines _state*) (render-transcript state trans-height cols))
          ;; Map screen rows to line indices (screen row → rendered line index)
          ;; Mouse y is 0-based: row 0 = header, row 1 = first transcript line.
-         ;; trans-y is 1-based: value 2 means transcript starts at screen row 1 (0-based).
-         ;; So: line-index = screen-row - (trans-y - 1)
-         (define start-idx (max 0 (- start-row (sub1 trans-y))))
-         (define end-idx (min (sub1 (length all-lines)) (- end-row (sub1 trans-y))))
+         ;; trans-y is now 0-based: value 1 means transcript starts at screen row 1.
+         ;; So: line-index = screen-row - trans-y
+         (define start-idx (max 0 (- start-row trans-y)))
+         (define end-idx (min (sub1 (length all-lines)) (- end-row trans-y)))
          (if (> start-idx end-idx)
              ""
              (string-join


### PR DESCRIPTION
## Wave 5: 0-Based Layout Row Consistency

Implements #377 (parent), #378 (W5.1: 0-based layout), #379 (W5.2: mouse coords).

### Changes

**W5.1 (#378) — Convert compute-layout to 0-based:**
- `layout.rkt`: header-row=0, transcript-start-row=1, status/input adjusted
- `renderer.rkt`: removed all `(- x-row 1)` conversions, uses layout rows directly
- Layout rows now match ubuf's 0-based indexing — no more conversion layer

**W5.2 (#379) — Mouse coordinate consistency:**
- Verified `decode-mouse-x10` already produces 0-based coordinates
- Removed `(sub1 trans-y)` in selection-text mapping
- Selection coordinates now consistently 0-based end-to-end

### Impact
- Eliminates a class of off-by-one bugs in coordinate handling
- No visual regressions — output is identical

### Tests
- All 3437 tests pass
- Format lint clean