### PR TITLE
Fix TUI crash: handle #f previous-frame in diff-frames (#390)

### DIFF
--- a/tests/tui/frame-diff.rkt
+++ b/tests/tui/frame-diff.rkt
@@ -34,3 +34,11 @@
 
 ;; frame->string-lines is identity
 (check-equal? (frame->string-lines frame-3) frame-3 "frame->string-lines returns the frame unchanged")
+
+;; #f prev (first render) → full redraw (Issue #390)
+(check-equal? (diff-frames #f frame-3)
+              (list (diff-cmd 'full 0 #f))
+              "#f prev yields full redraw (first render)")
+(check-equal? (diff-frames #f empty-frame)
+              (list (diff-cmd 'full 0 #f))
+              "#f prev with empty current yields full redraw")

--- a/tui/frame-diff.rkt
+++ b/tui/frame-diff.rkt
@@ -23,6 +23,8 @@
 ;; Returns: (listof diff-cmd)
 (define (diff-frames prev curr)
   (cond
+    ;; No previous frame (first render or resize) — full redraw
+    [(not prev) (list (diff-cmd 'full 0 #f))]
     [(null? prev) (list (diff-cmd 'full 0 #f))]
     [(not (= (length prev) (length curr))) (list (diff-cmd 'full 0 #f))]
     [else


### PR DESCRIPTION
## Summary

Fixes #390

The `previous-frame-box` is initialized to `#f`, but `diff-frames` only handled `(null? prev)` — not `#f`. On first render, `diff-frames` received `#f` and crashed with `length: contract violation`.

## Changes

- `q/tui/frame-diff.rkt`: Add `(not prev)` guard before `(null? prev)` check
- `q/tests/tui/frame-diff.rkt`: Add tests for `#f` previous frame

## Verification

- All TUI tests pass (130+ tests)
- Format lint passes
- `racket main.rkt --tui` no longer crashes on launch