### PR TITLE
feat(tui): Markdown expansion, theme system, ANSI-aware wrapping (Wave 4)

### DIFF
--- a/tests/test-markdown.rkt
+++ b/tests/test-markdown.rkt
@@ -262,6 +262,72 @@
      (check-equal? result
                    (list (md-token 'bold "bold")
                          (md-token 'text " ")
-                         (md-token 'link (cons "url" "link")))))))
+                         (md-token 'link (cons "url" "link")))))
+
+   ;; ============================================================
+   ;; New token types (#405)
+   ;; ============================================================
+
+   (test-case "horizontal rule: ---"
+     (define result (parse-line "---"))
+     (check-equal? result (list (md-token 'hr #t))))
+
+   (test-case "horizontal rule: ***"
+     (define result (parse-line "***"))
+     (check-equal? result (list (md-token 'hr #t))))
+
+   (test-case "horizontal rule: ___"
+     (define result (parse-line "___"))
+     (check-equal? result (list (md-token 'hr #t))))
+
+   (test-case "horizontal rule with spaces"
+     (define result (parse-line "- - -"))
+     (check-equal? result (list (md-token 'hr #t))))
+
+   (test-case "unordered list: dash"
+     (define result (parse-line "- item one"))
+     (check-equal? (md-token-type (car result)) 'unordered-list)
+     (check-equal? (car (md-token-content (car result))) 0))
+
+   (test-case "unordered list: asterisk"
+     (define result (parse-line "* item two"))
+     (check-equal? (md-token-type (car result)) 'unordered-list))
+
+   (test-case "unordered list: plus"
+     (define result (parse-line "+ item three"))
+     (check-equal? (md-token-type (car result)) 'unordered-list))
+
+   (test-case "unordered list: indented"
+     (define result (parse-line "  - nested item"))
+     (check-equal? (md-token-type (car result)) 'unordered-list)
+     (check-equal? (car (md-token-content (car result))) 1))
+
+   (test-case "ordered list"
+     (define result (parse-line "1. first item"))
+     (check-equal? (md-token-type (car result)) 'ordered-list)
+     (check-equal? (car (md-token-content (car result))) 0)
+     (check-equal? (cadr (md-token-content (car result))) 1))
+
+   (test-case "ordered list: indented"
+     (define result (parse-line "  3. nested"))
+     (check-equal? (md-token-type (car result)) 'ordered-list)
+     (check-equal? (car (md-token-content (car result))) 1)
+     (check-equal? (cadr (md-token-content (car result))) 3))
+
+   (test-case "blockquote"
+     (define result (parse-line "> quoted text"))
+     (check-equal? (md-token-type (car result)) 'blockquote)
+     (check-equal? (car (md-token-content (car result))) 1))
+
+   (test-case "strikethrough"
+     (define result (parse-inline-markdown "~~deleted~~"))
+     (check-equal? result (list (md-token 'strikethrough "deleted"))))
+
+   (test-case "strikethrough in text"
+     (define result (parse-inline-markdown "keep ~~remove~~ keep"))
+     (check-equal? (length result) 3)
+     (check-equal? (md-token-type (cadr result)) 'strikethrough)
+     (check-equal? (md-token-content (cadr result)) "remove"))
+   ))
 
 (run-tests markdown-suite 'verbose)

--- a/tests/tui/ansi-wrap.rkt
+++ b/tests/tui/ansi-wrap.rkt
@@ -1,0 +1,70 @@
+#lang racket
+
+;; tests/tui/ansi-wrap.rkt — Tests for ANSI-aware word wrapping
+
+(require rackunit
+         rackunit/text-ui
+         "../../../q/tui/ansi-wrap.rkt")
+
+(define ESC (integer->char 27))
+
+(define ansi-wrap-tests
+  (test-suite
+   "ANSI-aware word wrapping"
+
+   (test-case "plain text wrapping"
+     (define result (wrap-ansi-line "hello world" 6))
+     (check-equal? (length result) 2)
+     (check-equal? (ansi-visible-width (car result)) 6)   ; "hello "
+     (check-equal? (ansi-visible-width (cadr result)) 5))  ; "world"
+
+   (test-case "no wrap needed"
+     (define result (wrap-ansi-line "short" 80))
+     (check-equal? result '("short")))
+
+   (test-case "ansi-visible-width ignores escape sequences"
+     (define s (format "~a[1;36mhello~a[0m" ESC ESC))
+     (check-equal? (ansi-visible-width s) 5))
+
+   (test-case "wrap preserves ANSI codes"
+     (define s (format "~a[31mhello world~a[0m" ESC ESC))
+     (define result (wrap-ansi-line s 6))
+     (check-equal? (length result) 2)
+     (check-true (string-contains? (car result) "[31m"))
+     (check-equal? (ansi-visible-width (car result)) 6)
+     (check-equal? (ansi-visible-width (cadr result)) 5))
+
+   (test-case "wrap with multiple ANSI segments"
+     (define s (format "~a[1m~a[31mhello ~a[32mworld test~a[0m" ESC ESC ESC ESC))
+     (define result (wrap-ansi-line s 8))
+     (check >= (length result) 2))
+
+   (test-case "find-ansi-break-pos skips escape sequences"
+     (define s (format "~a[1mhello~a[0m world" ESC ESC))
+     (define pos (find-ansi-break-pos s 5))
+     (check-true (<= (ansi-visible-width (substring s 0 pos)) 5)))
+
+   (test-case "wrap-ansi-text splits on newlines"
+     (define s "first line\nsecond line")
+     (define result (wrap-ansi-text s 80))
+     (check-equal? (length result) 2))
+
+   (test-case "wrap-ansi-text wraps long lines after newline split"
+     (define s "a very long line that needs to be wrapped\nshort")
+     (define result (wrap-ansi-text s 10))
+     (check >= (length result) 3))
+
+   (test-case "zero-width returns input"
+     (check-equal? (wrap-ansi-text "hello" 0) '("hello")))
+
+   (test-case "long word breaks at width"
+     (define result (wrap-ansi-line "abcdefghij" 5))
+     (check-equal? (length result) 2)
+     (check-equal? (ansi-visible-width (car result)) 5))
+
+   (test-case "break at word boundary preserves space position"
+     (define result (wrap-ansi-line "aaa bbb ccc" 4))
+     (check >= (length result) 2))
+   ))
+
+(run-tests ansi-wrap-tests)

--- a/tests/tui/theme.rkt
+++ b/tests/tui/theme.rkt
@@ -1,0 +1,61 @@
+#lang racket
+
+;; tests/tui/theme.rkt — Tests for TUI theme system
+
+(require rackunit
+         rackunit/text-ui
+         "../../../q/tui/theme.rkt")
+
+(define theme-tests
+  (test-suite
+   "TUI Theme"
+
+   (test-case "default-dark-theme has correct fields"
+     (check-equal? (tui-theme-text default-dark-theme) 'white)
+     (check-equal? (tui-theme-accent default-dark-theme) 'cyan)
+     (check-equal? (tui-theme-error default-dark-theme) 'red)
+     (check-equal? (tui-theme-success default-dark-theme) 'green)
+     (check-equal? (tui-theme-warning default-dark-theme) 'yellow)
+     (check-equal? (tui-theme-md-heading default-dark-theme) 'cyan)
+     (check-equal? (tui-theme-input-prompt default-dark-theme) 'cyan))
+
+   (test-case "default-light-theme has dark text"
+     (check-equal? (tui-theme-text default-light-theme) 'black)
+     (check-equal? (tui-theme-accent default-light-theme) 'blue))
+
+   (test-case "theme-ref resolves field names"
+     (parameterize ([current-tui-theme default-dark-theme])
+       (check-equal? (theme-ref 'text) 'white)
+       (check-equal? (theme-ref 'accent) 'cyan)
+       (check-equal? (theme-ref 'md-heading) 'cyan)
+       (check-equal? (theme-ref 'nonexistent) #f)))
+
+   (test-case "theme-color->sgr: named colors"
+     (check-equal? (theme-color->sgr 'red) "31")
+     (check-equal? (theme-color->sgr 'cyan) "36")
+     (check-equal? (theme-color->sgr 'bright-white) "97")
+     (check-equal? (theme-color->sgr 'bright-black) "90")
+     (check-equal? (theme-color->sgr #f) #f))
+
+   (test-case "theme-color->sgr-bg: named colors"
+     (check-equal? (theme-color->sgr-bg 'blue) "44")
+     (check-equal? (theme-color->sgr-bg 'cyan) "46")
+     (check-equal? (theme-color->sgr-bg 'bright-black) "100"))
+
+   (test-case "theme-color->sgr: 256-color string passthrough"
+     (check-equal? (theme-color->sgr "38;5;202") "38;5;202"))
+
+   (test-case "theme-color->sgr-bg: string converts fg to bg"
+     (check-equal? (theme-color->sgr-bg "38;5;202") "48;5;202"))
+
+   (test-case "current-tui-theme parameter"
+     (parameterize ([current-tui-theme default-light-theme])
+       (check-equal? (tui-theme-text (current-tui-theme)) 'black))
+     (check-equal? (tui-theme-text (current-tui-theme)) 'white))
+
+   (test-case "tui-theme? predicate"
+     (check-true (tui-theme? default-dark-theme))
+     (check-false (tui-theme? 'cyan)))
+   ))
+
+(run-tests theme-tests)

--- a/tui/ansi-wrap.rkt
+++ b/tui/ansi-wrap.rkt
@@ -1,0 +1,137 @@
+#lang racket/base
+
+;; q/tui/ansi-wrap.rkt — ANSI-aware word wrapping
+;;
+;; Wraps text that may contain ANSI/SGR escape sequences.
+;; Escape sequences have zero visual width and should not be broken.
+
+(require racket/string
+         "char-width.rkt")
+
+(provide wrap-ansi-line
+         wrap-ansi-text
+         ansi-visible-width
+         find-ansi-break-pos)
+
+;; ============================================================
+;; ANSI-aware visible width
+;; ============================================================
+
+;; ansi-visible-width : String → Natural
+;; Returns the visual column width, skipping ANSI escape sequences.
+(define (ansi-visible-width s)
+  (let loop ([i 0] [col 0])
+    (cond
+      [(>= i (string-length s)) col]
+      [else
+       (define c (string-ref s i))
+       (cond
+         ;; Start of escape sequence — skip to the end
+         [(eq? c (integer->char 27))
+          (define end (skip-ansi-sequence s i))
+          (loop end col)]
+         [else
+          (loop (add1 i) (+ col (char-width c)))])])))
+
+;; Skip a complete ANSI escape sequence starting at position i.
+;; Returns the index after the sequence.
+;; Handles CSI sequences (ESC [ ... final-byte).
+(define (skip-ansi-sequence s i)
+  (cond
+    [(>= (add1 i) (string-length s)) (string-length s)]
+    [(eq? (string-ref s (add1 i)) #\[)
+     ;; CSI sequence: ESC [ <params> <final-byte>
+     (let loop ([j (+ i 2)])
+       (cond
+         [(>= j (string-length s)) (string-length s)]
+         [else
+          (define c (string-ref s j))
+          (if (ansi-final-byte? c)
+              (add1 j)
+              (loop (add1 j)))]))]
+    ;; Non-CSI escape (ESC X): skip 2 bytes
+    [else (+ i 2)]))
+
+;; Check if a byte is a CSI final byte (0x40–0x7E)
+(define (ansi-final-byte? c)
+  (define cp (char->integer c))
+  (and (>= cp #x40) (<= cp #x7E)))
+
+;; ============================================================
+;; ANSI-aware wrapping
+;; ============================================================
+
+;; wrap-ansi-line : String Natural → (Listof String)
+;; Wraps a single line that may contain ANSI escape sequences.
+;; Preserves escape sequences intact — never breaks inside one.
+(define (wrap-ansi-line line max-width)
+  (if (<= (ansi-visible-width line) max-width)
+      (list line)
+      (let loop ([remaining line]
+                 [acc '()])
+        (define vw (ansi-visible-width remaining))
+        (cond
+          [(<= vw max-width) (reverse (cons remaining acc))]
+          [else
+           (define break-pos (find-ansi-break-pos remaining max-width))
+           (cond
+             [(<= break-pos 0)
+              ;; Cannot break — emit the whole thing as one line
+              (reverse (cons remaining acc))]
+             [else
+              (loop (substring remaining break-pos)
+                    (cons (substring remaining 0 break-pos) acc))])]))))
+
+;; find-ansi-break-pos : String Natural → Natural
+;; Finds a break position in a string that may contain ANSI sequences.
+;; Returns a character index (not column index) to break at.
+;; Prefers breaking at whitespace. Skips escape sequences as zero-width.
+(define (find-ansi-break-pos text max-width)
+  (let loop ([i 0]
+             [col 0]
+             [last-space-idx #f]
+             [last-space-col 0])
+    (cond
+      [(>= i (string-length text)) (string-length text)]
+      ;; Exceeded visible width
+      [(>= col max-width)
+       (cond
+         [last-space-idx last-space-idx]
+         ;; No space found — break at current position
+         [else i])]
+      [else
+       (define c (string-ref text i))
+       (cond
+         ;; Escape sequence — skip entirely
+         [(eq? c (integer->char 27))
+          (define end (skip-ansi-sequence text i))
+          (loop end col last-space-idx last-space-col)]
+         ;; Whitespace — record potential break point
+         [(char-whitespace? c)
+          (loop (add1 i) (+ col (char-width c)) (add1 i) (+ col (char-width c)))]
+         ;; Regular character
+         [else
+          (define w (char-width c))
+          (define new-col (+ col w))
+          (cond
+            [(> new-col max-width)
+             (cond
+               [last-space-idx last-space-idx]
+               ;; No space found — break at current position
+               [else i])]
+            [else
+             (loop (add1 i) new-col last-space-idx last-space-col)])])])))
+
+;; ============================================================
+;; Convenience: wrap ANSI text with newline splitting
+;; ============================================================
+
+;; wrap-ansi-text : String Natural → (Listof String)
+;; Splits on newlines first, then wraps each line.
+(define (wrap-ansi-text text max-width)
+  (if (<= max-width 0)
+      (list text)
+      (let ([lines (string-split text "\n")])
+        (apply append
+               (for/list ([line (in-list lines)])
+                 (wrap-ansi-line line max-width))))))

--- a/tui/theme.rkt
+++ b/tui/theme.rkt
@@ -1,0 +1,211 @@
+#lang racket/base
+
+;; q/tui/theme.rkt — Semantic theme system for TUI colors
+;;
+;; Replaces hardcoded ANSI colors with named semantic slots.
+;; Default dark theme matches the original hardcoded colors.
+
+(require racket/contract)
+
+(provide tui-theme
+         tui-theme?
+         tui-theme-text
+         tui-theme-accent
+         tui-theme-muted
+         tui-theme-error
+         tui-theme-success
+         tui-theme-warning
+         tui-theme-tool-title
+         tui-theme-md-heading
+         tui-theme-md-code
+         tui-theme-md-code-block-bg
+         tui-theme-md-bold
+         tui-theme-md-italic
+         tui-theme-md-link
+         tui-theme-md-blockquote
+         tui-theme-md-list-bullet
+         tui-theme-md-hr
+         tui-theme-status-bg
+         tui-theme-selection-bg
+         tui-theme-input-prompt
+         tui-theme-border
+         default-dark-theme
+         default-light-theme
+         current-tui-theme
+         theme-ref
+         theme-color->sgr
+         theme-color->sgr-bg)
+
+;; ============================================================
+;; Theme struct — all fields are ANSI color names or #f for default
+;; ============================================================
+
+;; Each field is either:
+;;   - An ANSI color symbol: 'black 'red 'green 'yellow 'blue 'magenta 'cyan 'white
+;;   - A bright variant: 'bright-black 'bright-red ... 'bright-white
+;;   - An SGR parameter string like "38;5;202" (256-color) or "38;2;255;128;0" (truecolor)
+;;   - #f meaning "default terminal color"
+
+(struct tui-theme
+        (text accent
+              muted
+              error
+              success
+              warning
+              tool-title
+              md-heading
+              md-code
+              md-code-block-bg
+              md-bold
+              md-italic
+              md-link
+              md-blockquote
+              md-list-bullet
+              md-hr
+              status-bg
+              selection-bg
+              input-prompt
+              border)
+  #:transparent)
+
+;; Default dark theme — matches original hardcoded colors
+(define default-dark-theme
+  ;; Basic semantic colors
+  (tui-theme 'white ; text
+             'cyan ; accent
+             'bright-black ; muted
+             'red ; error
+             'green ; success
+             'yellow ; warning
+             ;; Tool/UI
+             'cyan ; tool-title
+             ;; Markdown
+             'cyan ; md-heading
+             'bright-green ; md-code
+             'bright-black ; md-code-block-bg
+             'bright-white ; md-bold
+             'bright-black ; md-italic
+             'cyan ; md-link
+             'bright-black ; md-blockquote
+             'cyan ; md-list-bullet
+             'bright-black ; md-hr
+             ;; UI elements
+             'blue ; status-bg
+             'cyan ; selection-bg
+             'cyan ; input-prompt
+             'bright-black ; border
+             ))
+
+;; Default light theme
+(define default-light-theme
+  (tui-theme 'black ; text
+             'blue ; accent
+             'bright-black ; muted
+             'red ; error
+             'green ; success
+             'yellow ; warning
+             'blue ; tool-title
+             'blue ; md-heading
+             'green ; md-code
+             'bright-white ; md-code-block-bg
+             'black ; md-bold
+             'bright-black ; md-italic
+             'blue ; md-link
+             'bright-black ; md-blockquote
+             'blue ; md-list-bullet
+             'bright-black ; md-hr
+             'blue ; status-bg
+             'cyan ; selection-bg
+             'blue ; input-prompt
+             'bright-black ; border
+             ))
+
+;; Current theme parameter
+(define current-tui-theme (make-parameter default-dark-theme))
+
+;; Resolve a theme field to an SGR parameter string.
+;; Returns #f if the color is #f (use default).
+(define (theme-ref field-name)
+  (define theme (current-tui-theme))
+  (case field-name
+    [(text) (tui-theme-text theme)]
+    [(accent) (tui-theme-accent theme)]
+    [(muted) (tui-theme-muted theme)]
+    [(error) (tui-theme-error theme)]
+    [(success) (tui-theme-success theme)]
+    [(warning) (tui-theme-warning theme)]
+    [(tool-title) (tui-theme-tool-title theme)]
+    [(md-heading) (tui-theme-md-heading theme)]
+    [(md-code) (tui-theme-md-code theme)]
+    [(md-code-bg) (tui-theme-md-code-block-bg theme)]
+    [(md-bold) (tui-theme-md-bold theme)]
+    [(md-italic) (tui-theme-md-italic theme)]
+    [(md-link) (tui-theme-md-link theme)]
+    [(md-blockquote) (tui-theme-md-blockquote theme)]
+    [(md-bullet) (tui-theme-md-list-bullet theme)]
+    [(md-hr) (tui-theme-md-hr theme)]
+    [(status-bg) (tui-theme-status-bg theme)]
+    [(selection-bg) (tui-theme-selection-bg theme)]
+    [(input-prompt) (tui-theme-input-prompt theme)]
+    [(border) (tui-theme-border theme)]
+    [else #f]))
+
+;; Convert a theme color value to an SGR foreground parameter string.
+(define (theme-color->sgr color)
+  (cond
+    [(not color) #f]
+    [(string? color) color] ;; Already an SGR parameter string
+    [(symbol? color)
+     (case color
+       [(black) "30"]
+       [(red) "31"]
+       [(green) "32"]
+       [(yellow) "33"]
+       [(blue) "34"]
+       [(magenta) "35"]
+       [(cyan) "36"]
+       [(white) "37"]
+       [(bright-black) "90"]
+       [(bright-red) "91"]
+       [(bright-green) "92"]
+       [(bright-yellow) "93"]
+       [(bright-blue) "94"]
+       [(bright-magenta) "95"]
+       [(bright-cyan) "96"]
+       [(bright-white) "97"]
+       [else #f])]
+    [else #f]))
+
+;; Convert a theme color value to an SGR background parameter string.
+(define (theme-color->sgr-bg color)
+  (cond
+    [(not color) #f]
+    [(string? color)
+     ;; Replace leading "3" with "4" for background
+     (if (string-prefix? color "3")
+         (string-append "4" (substring color 1))
+         color)]
+    [(symbol? color)
+     (case color
+       [(black) "40"]
+       [(red) "41"]
+       [(green) "42"]
+       [(yellow) "43"]
+       [(blue) "44"]
+       [(magenta) "45"]
+       [(cyan) "46"]
+       [(white) "47"]
+       [(bright-black) "100"]
+       [(bright-red) "101"]
+       [(bright-green) "102"]
+       [(bright-yellow) "103"]
+       [(bright-blue) "104"]
+       [(bright-magenta) "105"]
+       [(bright-cyan) "106"]
+       [(bright-white) "107"]
+       [else #f])]
+    [else #f]))
+
+(define (string-prefix? s prefix)
+  (and (>= (string-length s) (string-length prefix))
+       (string=? (substring s 0 (string-length prefix)) prefix)))

--- a/util/markdown.rkt
+++ b/util/markdown.rkt
@@ -19,6 +19,7 @@
          md-token-type
          md-token-content
          parse-markdown
+         parse-line
          parse-inline-markdown)
 
 ;; ============================================================
@@ -27,6 +28,7 @@
 
 (struct md-token (type content) #:transparent)
 ;; type : 'text | 'bold | 'italic | 'code | 'code-block | 'header | 'link | 'newline
+;;        | 'unordered-list | 'ordered-list | 'blockquote | 'hr | 'strikethrough
 ;; content : any
 ;;   'text       → string (literal text)
 ;;   'bold       → string (bold text content)
@@ -36,6 +38,11 @@
 ;;   'header     → (cons level-number header-text-string)
 ;;   'link       → (cons url-string link-text-string)
 ;;   'newline    → string "\n" (line separator)
+;;   'unordered-list → (cons indent-level list-text-string)
+;;   'ordered-list   → (cons indent-level (cons number list-text-string))
+;;   'blockquote    → string (quoted text, without > prefix)
+;;   'hr            → #t
+;;   'strikethrough → string (struck-through text)
 
 ;; ============================================================
 ;; Block-level parsing
@@ -53,8 +60,7 @@
 
 ;; For code blocks we cannot use (?s) flag (not supported in Racket #px).
 ;; Instead we use a manual approach: scan for triple-backtick boundaries.
-(define code-block-rx
-  (regexp "```([a-zA-Z0-9_-]*)[\n]"))
+(define code-block-rx (regexp "```([a-zA-Z0-9_-]*)[\n]"))
 
 (define (parse-code-blocks text)
   ;; Manual approach: split on triple-backtick boundaries.
@@ -76,11 +82,15 @@
        ;; Find the language tag (rest of the opening line)
        (define after-open (+ open-pos 3)) ; skip ```
        (define newline-pos (find-char text after-open #\newline))
-       (define lang (if (and newline-pos (> newline-pos after-open))
-                        (string-trim (substring text after-open newline-pos))
-                        ""))
+       (define lang
+         (if (and newline-pos (> newline-pos after-open))
+             (string-trim (substring text after-open newline-pos))
+             ""))
        ;; Find closing ```
-       (define code-start (if newline-pos (add1 newline-pos) after-open))
+       (define code-start
+         (if newline-pos
+             (add1 newline-pos)
+             after-open))
        (define close-pos (find-triple-backtick text code-start))
        (cond
          [(not close-pos)
@@ -91,20 +101,20 @@
           (define code (substring text code-start close-pos))
           ;; Consume trailing newline after ``` if present
           (define after-close (+ close-pos 3)) ; skip closing ```
-          (define trailing-nl? (and (< after-close len)
-                                    (char=? (string-ref text after-close) #\newline)))
+          (define trailing-nl?
+            (and (< after-close len) (char=? (string-ref text after-close) #\newline)))
           (set! result
                 (append result
-                        (list (md-token 'code-block
-                                        (cons (if (string=? lang "") #f lang) code))
+                        (list (md-token 'code-block (cons (if (string=? lang "") #f lang) code))
                               ;; Newline separator after code block
                               (md-token 'newline "\n"))))
-          (set! pos (if trailing-nl? (add1 after-close) after-close))
+          (set! pos
+                (if trailing-nl?
+                    (add1 after-close)
+                    after-close))
           (loop)])]))
   ;; Filter out empty text tokens
-  (filter (lambda (t)
-            (not (and (eq? (md-token-type t) 'text)
-                      (string=? (md-token-content t) ""))))
+  (filter (lambda (t) (not (and (eq? (md-token-type t) 'text) (string=? (md-token-content t) ""))))
           result))
 
 ;; Find the start of a triple-backtick sequence (```) at or after pos
@@ -129,25 +139,54 @@
         (define parsed-lines (map parse-line lines))
         (if (= (length parsed-lines) 1)
             (car parsed-lines)
-            (append*
-             (for/list ([line-tokens (in-list parsed-lines)]
-                        [i (in-naturals)])
-               (if (< i (sub1 (length parsed-lines)))
-                   (append line-tokens (list (md-token 'newline "\n")))
-                   line-tokens)))))))
+            (append* (for/list ([line-tokens (in-list parsed-lines)]
+                                [i (in-naturals)])
+                       (if (< i (sub1 (length parsed-lines)))
+                           (append line-tokens (list (md-token 'newline "\n")))
+                           line-tokens)))))))
 
-;; Parse a single line: check for header, then inline parse.
+;; Parse a single line: check for header, blockquote, list, hr, then inline parse.
 (define (parse-line line)
-  (define header-match (regexp-match-positions #px"^(#{1,6})[ \t]+(.+)$" line))
   (cond
-    [header-match
-     (define hashes (substring line (car (cadr header-match))
-                               (cdr (cadr header-match))))
-     (define header-text (substring line (car (caddr header-match))
-                                     (cdr (caddr header-match))))
-     (list (md-token 'header (cons (string-length hashes) header-text)))]
-    [else
-     (parse-inline-markdown line)]))
+    ;; Horizontal rule: 3+ hyphens/asterisks/underscores with optional spaces
+    [(or (regexp-match? #px"^[ \t]*-[- \t]*-[- \t]*-[ \t]*$" line)
+          (regexp-match? #px"^[ \t]*[*][*]+[* \t]*$" line)
+          (regexp-match? #px"^[ \t]*___+[_ \t]*$" line))
+     (list (md-token 'hr #t))]
+    ;; Header: # heading
+    [(regexp-match-positions #px"^(#{1,6})[ \t]+(.+)$" line)
+     =>
+     (lambda (m)
+       (define hashes (substring line (car (cadr m)) (cdr (cadr m))))
+       (define header-text (substring line (car (caddr m)) (cdr (caddr m))))
+       (list (md-token 'header (cons (string-length hashes) header-text))))]
+    ;; Blockquote: > text
+    [(regexp-match-positions #px"^[ \t]*(>+)[ \t]?(.*)$" line)
+     =>
+     (lambda (m)
+       (define depth (string-length (substring line (car (cadr m)) (cdr (cadr m)))))
+       (define quoted-text (substring line (car (caddr m)) (cdr (caddr m))))
+       ;; Parse inline within the quoted text
+       (define inner (parse-inline-markdown quoted-text))
+       (list (md-token 'blockquote (cons depth inner))))]
+    ;; Unordered list: [-*+] text
+    [(regexp-match-positions #px"^([ \t]*)([-*+])[ \t]+(.+)$" line)
+     =>
+     (lambda (m)
+       (define indent (quotient (string-length (substring line (car (cadr m)) (cdr (cadr m)))) 2))
+       (define list-text (substring line (car (cadddr m)) (cdr (cadddr m))))
+       (define inner (parse-inline-markdown list-text))
+       (cons (md-token 'unordered-list (cons indent inner)) inner))]
+    ;; Ordered list: N. text
+    [(regexp-match-positions #px"^([ \t]*)([0-9]+)[.][ \t]+(.+)$" line)
+     =>
+     (lambda (m)
+       (define indent (quotient (string-length (substring line (car (cadr m)) (cdr (cadr m)))) 2))
+       (define num (string->number (substring line (car (caddr m)) (cdr (caddr m)))))
+       (define list-text (substring line (car (cadddr m)) (cdr (cadddr m))))
+       (define inner (parse-inline-markdown list-text))
+       (cons (md-token 'ordered-list (cons indent (cons num inner))) inner))]
+    [else (parse-inline-markdown line)]))
 
 ;; ============================================================
 ;; Inline parsing
@@ -165,7 +204,8 @@
     [else
      ;; Collect all matches with their positions, then process left-to-right
      ;; by repeatedly scanning from the current position.
-     (let loop ([pos 0] [acc '()])
+     (let loop ([pos 0]
+                [acc '()])
        (cond
          [(>= pos len) (reverse acc)]
          [else
@@ -185,8 +225,7 @@
                    (cons (md-token 'text (substring text pos start)) acc)
                    acc))
              ;; Emit the matched token
-             (define new-acc2
-               (cons (md-token type content) new-acc))
+             (define new-acc2 (cons (md-token type content) new-acc))
              (loop end new-acc2)])]))]))
 
 ;; Find the first inline markdown construct starting at or after `pos`.
@@ -195,17 +234,17 @@
 (define (find-first-inline text pos)
   (define len (string-length text))
   (define candidates
-    (filter
-     values
-     (list
-      ;; Inline code: `code`
-      (find-inline-code text pos len)
-      ;; Bold: **text**
-      (find-bold text pos len)
-      ;; Italic: *text*
-      (find-italic text pos len)
-      ;; Links: [text](url)
-      (find-link text pos len))))
+    (filter values
+            ;; Inline code: `code`
+            (list (find-inline-code text pos len)
+                  ;; Bold: **text**
+                  (find-bold text pos len)
+                  ;; Italic: *text*
+                  (find-italic text pos len)
+                  ;; Strikethrough: ~~text~~
+                  (find-strikethrough text pos len)
+                  ;; Links: [text](url)
+                  (find-link text pos len))))
   (if (null? candidates)
       #f
       ;; Return the one with the smallest start position
@@ -251,8 +290,7 @@
           ;; Opening * found at i. Find closing * after i+1
           (define close-pos (find-closing-asterisk text (+ i 2) len))
           (if close-pos
-              (list 'italic i (add1 close-pos)
-                    (substring text (add1 i) close-pos))
+              (list 'italic i (add1 close-pos) (substring text (add1 i) close-pos))
               (loop (add1 i)))]
          [else (loop (add1 i))])]
       [else (loop (add1 i))])))
@@ -270,6 +308,24 @@
            (loop (+ i 2)))] ; skip ** and keep looking
       [else (loop (add1 i))])))
 
+;; Find strikethrough: ~~text~~ starting at or after pos
+(define (find-strikethrough text pos len)
+  (let loop ([i pos])
+    (cond
+      [(> (+ i 3) len) #f]
+      [(and (char=? (string-ref text i) #\~) (char=? (string-ref text (+ i 1)) #\~))
+       ;; Found ~~, look for closing ~~
+       (define close-pos
+         (let search ([j (+ i 2)])
+           (cond
+             [(> (+ j 1) len) #f]
+             [(and (char=? (string-ref text j) #\~) (char=? (string-ref text (+ j 1)) #\~)) j]
+             [else (search (+ j 1))])))
+       (if (and close-pos (> close-pos (+ i 2)))
+           (list 'strikethrough i (+ close-pos 2) (substring text (+ i 2) close-pos))
+           (loop (+ i 2)))]
+      [else (loop (add1 i))])))
+
 ;; Find link: [text](url) starting at or after pos, char-by-char
 (define (find-link text pos len)
   (let loop ([i pos])
@@ -280,8 +336,7 @@
        (define close-bracket (find-char text (add1 i) #\]))
        (cond
          [(not close-bracket) (loop (add1 i))]
-         [(and (< (add1 close-bracket) len)
-               (char=? (string-ref text (add1 close-bracket)) #\())
+         [(and (< (add1 close-bracket) len) (char=? (string-ref text (add1 close-bracket)) #\())
           ;; Found ](, look for closing )
           (define close-paren (find-char text (+ close-bracket 2) #\)))
           (cond


### PR DESCRIPTION
## Wave 4 — Issues #405, #406, #407

### #405: Expand markdown token coverage
- Horizontal rules (`---`, `***`, `___` with spaces)
- Unordered lists (`-`, `*`, `+`) with indent levels
- Ordered lists (`N.`) with indent levels  
- Blockquotes (`>`) with depth tracking
- Strikethrough (`~~text~~`)
- 13 new markdown tests (38 → 51 total)

### #407: Semantic theme system
- New `tui/theme.rkt` with `tui-theme` struct (20 semantic slots)
- `default-dark-theme` matches original hardcoded colors
- `default-light-theme` for bright terminals
- `current-tui-theme` parameter for runtime switching
- `theme-color->sgr` / `theme-color->sgr-bg` for ANSI output
- 9 theme tests

### #406: ANSI-aware word wrapping
- New `tui/ansi-wrap.rkt` with `wrap-ansi-line`, `wrap-ansi-text`
- Skips ANSI/SGR escape sequences (zero visual width)
- Breaks at word boundaries, never inside escape sequences
- 11 wrapping tests

**Total: 33 new tests, 649 lines added across 6 files.**