### PR TITLE
feat(tui): Kitty keyboard protocol & configurable keybindings (#410, #411)

### DIFF
--- a/tests/test-tui-terminal.rkt
+++ b/tests/test-tui-terminal.rkt
@@ -225,12 +225,65 @@
      (check-false (parse-da1-response "not-a-response")))
    ))
 
+
+;; ============================================================
+;; Kitty keyboard protocol (Issue #410)
+;; ============================================================
+
+(define kitty-protocol-tests
+  (test-suite
+   "Kitty keyboard protocol"
+
+   (test-case "kitty-codepoint->key maps special keys"
+     (check-equal? (kitty-codepoint->key 57344) 'escape)
+     (check-equal? (kitty-codepoint->key 57345) 'enter)
+     (check-equal? (kitty-codepoint->key 57350) 'left)
+     (check-equal? (kitty-codepoint->key 57352) 'up)
+     (check-equal? (kitty-codepoint->key 57356) 'home)
+     (check-equal? (kitty-codepoint->key 57357) 'end))
+
+   (test-case "kitty-codepoint->key maps F-keys"
+     (check-equal? (kitty-codepoint->key 57376) 'f1)
+     (check-equal? (kitty-codepoint->key 57387) 'f12))
+
+   (test-case "kitty-codepoint->key maps printable ASCII"
+     (check-equal? (kitty-codepoint->key 65) #\A)
+     (check-equal? (kitty-codepoint->key 97) #\a)
+     (check-equal? (kitty-codepoint->key 32) #\space))
+
+   (test-case "parse-kitty-csi-u returns key with modifiers"
+     (define result (parse-kitty-csi-u 65 5))
+     (check-equal? (car result) #\A)
+     (check-not-false (member 'ctrl (cadr result)))
+     (check-not-false (member 'shift (cadr result))))
+
+   (test-case "parse-modify-other-keys returns key with modifiers"
+     (define result (parse-modify-other-keys 5 65))
+     (check-equal? (car result) #\A)
+     (check-not-false (member 'ctrl (cadr result)))
+     (check-not-false (member 'shift (cadr result))))
+
+   (test-case "modify-other-keys-enable/disable produce output"
+     (check-not-exn
+      (lambda ()
+        (with-output-to-string modify-other-keys-enable!)
+        (with-output-to-string modify-other-keys-disable!))))
+
+   (test-case "kitty-mode-enable/disable safe when unsupported"
+     (detect-kitty-support!)
+     (check-not-exn
+      (lambda ()
+        (with-output-to-string kitty-mode-enable!)
+        (with-output-to-string kitty-mode-disable!))))
+   ))
+
 (define all-tests
   (test-suite
    "All TUI Terminal Tests"
    terminal-tests
    keycode-mapping-tests
-   buffered-sync-tests))
+   buffered-sync-tests
+   kitty-protocol-tests))
 
 (run-tests all-tests)
 

--- a/tests/tui/keymap.rkt
+++ b/tests/tui/keymap.rkt
@@ -1,0 +1,104 @@
+#lang racket
+
+;; tests/tui/keymap.rkt — Tests for configurable keybindings (Issue #411)
+
+(require rackunit
+         rackunit/text-ui
+         "../../../q/tui/keymap.rkt")
+
+(define keymap-tests
+  (test-suite
+   "Configurable keybindings"
+
+   (test-case "key-spec creation and access"
+     (define ks (key-spec #\a #t #f #f))
+     (check-equal? (key-spec-name ks) #\a)
+     (check-true (key-spec-ctrl ks))
+     (check-false (key-spec-shift ks))
+     (check-false (key-spec-alt ks)))
+
+   (test-case "keycode->key-spec"
+     (define ks (keycode->key-spec 'up #:ctrl #t))
+     (check-equal? (key-spec-name ks) 'up)
+     (check-true (key-spec-ctrl ks)))
+
+   (test-case "key-spec equality"
+     (define a (key-spec #\a #t #f #f))
+     (define b (key-spec #\a #t #f #f))
+     (define c (key-spec #\a #f #t #f))
+     (check-true (key-spec=? a b))
+     (check-false (key-spec=? a c)))
+
+   (test-case "keymap-add! and lookup"
+     (define km (make-keymap))
+     (keymap-add! km (key-spec 'up #f #f #f) 'scroll-up)
+     (check-equal? (keymap-lookup km (key-spec 'up #f #f #f)) 'scroll-up)
+     (check-false (keymap-lookup km (key-spec 'down #f #f #f))))
+
+   (test-case "keymap-add! overwrites existing"
+     (define km (make-keymap))
+     (keymap-add! km (key-spec #\a #t #f #f) 'select-all)
+     (keymap-add! km (key-spec #\a #t #f #f) 'new-action)
+     (check-equal? (keymap-lookup km (key-spec #\a #t #f #f)) 'new-action))
+
+   (test-case "keymap-remove!"
+     (define km (make-keymap))
+     (keymap-add! km (key-spec #\x #t #f #f) 'cut)
+     (keymap-remove! km (key-spec #\x #t #f #f))
+     (check-false (keymap-lookup km (key-spec #\x #t #f #f))))
+
+   (test-case "keymap-list returns entries"
+     (define km (make-keymap))
+     (keymap-add! km (key-spec 'up #f #f #f) 'scroll-up)
+     (keymap-add! km (key-spec 'down #f #f #f) 'scroll-down)
+     (check-equal? (length (keymap-list km)) 2))
+
+   (test-case "keymap-find-conflicts returns empty for clean keymap"
+     (define km (make-keymap))
+     (keymap-add! km (key-spec 'up #f #f #f) 'scroll-up)
+     (keymap-add! km (key-spec 'down #f #f #f) 'scroll-down)
+     (check-equal? (keymap-find-conflicts km) '()))
+
+   (test-case "keymap-merge combines keymaps"
+     (define base (make-keymap))
+     (keymap-add! base (key-spec 'up #f #f #f) 'scroll-up)
+     (define override (make-keymap))
+     (keymap-add! override (key-spec #\j #f #f #f) 'scroll-down)
+     (keymap-merge base override)
+     (check-equal? (keymap-lookup base (key-spec #\j #f #f #f)) 'scroll-down)
+     ;; base keeps its own binding
+     (check-equal? (keymap-lookup base (key-spec 'up #f #f #f)) 'scroll-up))
+
+   (test-case "default-keymap has standard bindings"
+     (define km (default-keymap))
+     (check-equal? (keymap-lookup km (key-spec 'up #f #f #f)) 'scroll-up)
+     (check-equal? (keymap-lookup km (key-spec 'return #f #f #f)) 'submit)
+     (check-equal? (keymap-lookup km (key-spec #\c #t #f #f)) 'copy))
+
+   (test-case "parse-key-string handles C-a"
+     (define ks (parse-key-string "C-a"))
+     (check-equal? (key-spec-name ks) #\a)
+     (check-true (key-spec-ctrl ks))
+     (check-false (key-spec-alt ks)))
+
+   (test-case "parse-key-string handles C-M-x"
+     (define ks (parse-key-string "C-M-x"))
+     (check-equal? (key-spec-name ks) #\x)
+     (check-true (key-spec-ctrl ks))
+     (check-true (key-spec-alt ks)))
+
+   (test-case "parse-key-string handles up"
+     (define ks (parse-key-string "up"))
+     (check-equal? (key-spec-name ks) 'up))
+
+   (test-case "parse-key-string handles S-right"
+     (define ks (parse-key-string "S-right"))
+     (check-equal? (key-spec-name ks) 'right)
+     (check-true (key-spec-shift ks)))
+
+   (test-case "key-spec->keycode produces readable name"
+     (define ks (key-spec #\a #t #f #f))
+     (check-equal? (key-spec->keycode ks) '|C-a|))
+   ))
+
+(run-tests keymap-tests)

--- a/tui/keymap.rkt
+++ b/tui/keymap.rkt
@@ -1,0 +1,251 @@
+#lang racket/base
+
+;; q/tui/keymap.rkt — Configurable keybindings system (Issue #411)
+;;
+;; Provides a data-driven keymap that replaces hardcoded key handling.
+;; Users can override keybindings via ~/.q/keybindings.json.
+
+(require racket/string
+         racket/port
+         racket/file
+         racket/match
+         "../util/config-paths.rkt")
+
+(provide key-spec
+         key-spec?
+         key-spec-name
+         key-spec-ctrl
+         key-spec-shift
+         key-spec-alt
+         keycode->key-spec
+         key-spec->keycode
+         key-spec=?
+         parse-key-string
+
+         make-keymap
+         keymap-add!
+         keymap-remove!
+         keymap-lookup
+         keymap-list
+         keymap-find-conflicts
+         keymap-merge
+
+         default-keymap
+         load-user-keymap)
+
+;; ============================================================
+;; Key specification
+;; ============================================================
+
+;; A key-spec identifies a key combination.
+;; name: char? or symbol? (e.g. #\a, 'up, 'return)
+;; ctrl, shift, alt: booleans for modifier keys
+(struct key-spec (name ctrl shift alt) #:transparent)
+
+;; Convert a terminal keycode to a key-spec.
+;; keycode: char?, symbol?, or 'ctrl-c etc.
+(define (keycode->key-spec keycode
+                            #:ctrl [ctrl #f]
+                            #:shift [shift #f]
+                            #:alt [alt #f])
+  (key-spec keycode ctrl shift alt))
+
+;; Convert key-spec back to a terminal-style keycode symbol.
+(define (key-spec->keycode ks)
+  (define base (key-spec-name ks))
+  (define mods
+    (string-append
+     (if (key-spec-ctrl ks) "C-" "")
+     (if (key-spec-alt ks) "M-" "")
+     (if (key-spec-shift ks) "S-" "")))
+  (string->symbol
+   (string-append mods
+                  (cond
+                    [(char? base) (string base)]
+                    [(symbol? base) (symbol->string base)]
+                    [else "?"]))))
+
+;; Check equality of two key-specs
+(define (key-spec=? a b)
+  (and (equal? (key-spec-name a) (key-spec-name b))
+       (eq? (key-spec-ctrl a) (key-spec-ctrl b))
+       (eq? (key-spec-shift a) (key-spec-shift b))
+       (eq? (key-spec-alt a) (key-spec-alt b))))
+
+;; ============================================================
+;; Keymap data structure
+;; ============================================================
+
+;; A keymap maps key-specs to action symbols.
+;; Stored as a mutable list of (cons key-spec action).
+(struct keymap (entries) #:mutable)
+
+(define (make-keymap)
+  (keymap '()))
+
+(define (keymap-add! km ks action)
+  ;; Remove existing binding for this key-spec
+  (set-keymap-entries!
+   km
+   (cons (cons ks action)
+         (filter (lambda (e) (not (key-spec=? (car e) ks)))
+                 (keymap-entries km)))))
+
+(define (keymap-remove! km ks)
+  (set-keymap-entries!
+   km
+   (filter (lambda (e) (not (key-spec=? (car e) ks)))
+           (keymap-entries km))))
+
+(define (keymap-lookup km ks)
+  (define entry
+    (for/first ([e (in-list (keymap-entries km))]
+                #:when (key-spec=? (car e) ks))
+      e))
+  (and entry (cdr entry)))
+
+(define (keymap-list km)
+  (keymap-entries km))
+
+;; Find conflicting bindings (same key-spec, different actions)
+(define (keymap-find-conflicts km)
+  (define entries (keymap-entries km))
+  (for/list ([e (in-list entries)]
+             [i (in-naturals)]
+             #:when (for/or ([e2 (in-list entries)]
+                             [j (in-naturals)]
+                             #:when (and (< i j)
+                                         (key-spec=? (car e) (car e2))
+                                         (not (eq? (cdr e) (cdr e2)))))
+                      #t))
+    (car e)))
+
+;; Merge a source keymap into a target (target wins on conflict)
+(define (keymap-merge target source)
+  (for ([e (in-list (keymap-entries source))])
+    (when (not (keymap-lookup target (car e)))
+      (keymap-add! target (car e) (cdr e)))))
+
+;; ============================================================
+;; Default keymap
+;; ============================================================
+
+(define (default-keymap)
+  (define km (make-keymap))
+  ;; Navigation
+  (keymap-add! km (key-spec 'up #f #f #f) 'scroll-up)
+  (keymap-add! km (key-spec 'down #f #f #f) 'scroll-down)
+  (keymap-add! km (key-spec 'page-up #f #f #f) 'page-up)
+  (keymap-add! km (key-spec 'page-down #f #f #f) 'page-down)
+  (keymap-add! km (key-spec 'home #f #f #f) 'scroll-top)
+  (keymap-add! km (key-spec 'end #f #f #f) 'scroll-bottom)
+  ;; Ctrl+up/down for scrolling
+  (keymap-add! km (key-spec 'up #t #f #f) 'scroll-up)
+  (keymap-add! km (key-spec 'down #t #f #f) 'scroll-down)
+  ;; Input
+  (keymap-add! km (key-spec 'return #f #f #f) 'submit)
+  (keymap-add! km (key-spec 'backspace #f #f #f) 'backspace)
+  (keymap-add! km (key-spec 'delete #f #f #f) 'delete)
+  (keymap-add! km (key-spec 'escape #f #f #f) 'cancel)
+  ;; Word navigation
+  (keymap-add! km (key-spec 'left #t #f #f) 'word-left)
+  (keymap-add! km (key-spec 'right #t #f #f) 'word-right)
+  ;; Line navigation
+  (keymap-add! km (key-spec 'left #f #t #f) 'home)
+  (keymap-add! km (key-spec 'right #f #t #f) 'end)
+  ;; Ctrl-C for copy
+  (keymap-add! km (key-spec #\c #t #f #f) 'copy)
+  ;; Ctrl-X for cut
+  (keymap-add! km (key-spec #\x #t #f #f) 'cut)
+  ;; Ctrl-V for paste
+  (keymap-add! km (key-spec #\v #t #f #f) 'paste)
+  ;; Ctrl-A for select-all
+  (keymap-add! km (key-spec #\a #t #f #f) 'select-all)
+  ;; Ctrl-U for clear input
+  (keymap-add! km (key-spec #\u #t #f #f) 'clear-input)
+  ;; Ctrl-L for clear screen
+  (keymap-add! km (key-spec #\l #t #f #f) 'clear-screen)
+  km)
+
+;; ============================================================
+;; User keymap loading from JSON
+;; ============================================================
+
+;; Load user keymap overrides from ~/.q/keybindings.json
+;; Format: [{ "key": "C-a", "action": "select-all" }, ...]
+;; Key format: C- = ctrl, M- = alt, S- = shift, then key name
+;; Returns #f if file doesn't exist, otherwise a keymap
+(define (load-user-keymap)
+  (with-handlers ([exn:fail? (lambda (e) #f)])
+    (define config-dir (global-config-dir))
+    (define kb-path (build-path config-dir "keybindings.json"))
+    (if (file-exists? kb-path)
+        (let ([bindings (load-keybindings-file kb-path)])
+          (if (list? bindings)
+              (let ([km (make-keymap)])
+                (for ([b (in-list bindings)])
+                  (when (and b (pair? b))
+                    (keymap-add! km (car b) (cdr b))))
+                km)
+              #f))
+        #f)))
+
+
+
+;; Parse a key string like "C-M-a", "C-up", "S-right"
+(define (parse-key-string s)
+  (define ctrl #f)
+  (define alt #f)
+  (define shift #f)
+  (define rest s)
+  ;; Parse modifier prefixes
+  (cond
+    [(string-prefix? rest "C-M-")
+     (begin (set! ctrl #t) (set! alt #t) (set! rest (substring rest 4)))]
+    [(string-prefix? rest "M-C-")
+     (begin (set! ctrl #t) (set! alt #t) (set! rest (substring rest 4)))]
+    [(string-prefix? rest "C-S-")
+     (begin (set! ctrl #t) (set! shift #t) (set! rest (substring rest 4)))]
+    [(string-prefix? rest "C-")
+     (begin (set! ctrl #t) (set! rest (substring rest 2)))]
+    [(string-prefix? rest "M-")
+     (begin (set! alt #t) (set! rest (substring rest 2)))]
+    [(string-prefix? rest "S-")
+     (begin (set! shift #t) (set! rest (substring rest 2)))]
+    [else (void)])
+  ;; Parse the key name
+  (define key-name
+    (cond
+      [(= (string-length rest) 1) (string-ref rest 0)]
+      [else (string->symbol rest)]))
+  (key-spec key-name ctrl shift alt))
+
+;; Minimal config reader (sexp-based, no JSON dependency needed)
+;; Keybindings file format: (("key" . "action") ...)
+;; where "key" uses C-/M-/S- prefixes, e.g. "C-a", "M-x", "C-S-right"
+
+(define (load-keybindings-file path)
+  (with-handlers ([exn:fail? (lambda (e) #f)])
+    (if (file-exists? path)
+        (let ([content (file->string path)])
+          (parse-keybindings-content content))
+        #f)))
+
+(define (parse-keybindings-content content)
+  ;; Match key/action pairs from JSON config
+  (define kb-rx
+    (regexp
+     (string-append
+      "\"key\"[ \t]*:[ \t]*\"([^\"]+)\"][ \t]*,"
+      "[ \t]*\"action\"[ \t]*:[ \t]*\"([^\"]+)\"")))
+  (let ([entries (regexp-match* kb-rx content)])
+    (if (null? entries)
+        #f
+        (for/list ([e (in-list entries)])
+          (define m (regexp-match kb-rx e))
+          (if m
+              (cons (parse-key-string (cadr m))
+                    (string->symbol (caddr m)))
+              #f)))))
+
+

--- a/tui/terminal-input.rkt
+++ b/tui/terminal-input.rkt
@@ -18,6 +18,17 @@
          input-buffer-reset!
          input-buffer-length
 
+         ;; Kitty keyboard protocol (Issue #410)
+         kitty-mode-supported?
+         kitty-mode-enable!
+         kitty-mode-disable!
+         modify-other-keys-enable!
+         modify-other-keys-disable!
+         parse-kitty-csi-u
+         parse-modify-other-keys
+         kitty-codepoint->key
+         detect-kitty-support!
+
          ;; Bracketed paste support
          bracketed-paste-start-seq
          bracketed-paste-end-seq
@@ -236,6 +247,117 @@
        [(and (byte? b4) (= b4 70)) (make-tkeymsg-raw 'end)]
        [else (make-tkeymsg-raw 'escape)])]
     [else (make-tkeymsg-raw 'escape)]))
+
+;; ============================================================
+;; Kitty keyboard protocol (Issue #410)
+;; ============================================================
+
+;; Kitty keyboard protocol provides unambiguous key encoding.
+;; Enable: ESC[=1u  Disable: ESC[=0u
+;; Sequences: ESC[<codepoint>;<modifiers>u
+;; Modifier bitmask: 1=shift, 2=alt, 4=ctrl, 8=super
+
+(define kitty-supported #f)
+
+(define (kitty-mode-supported?)
+  kitty-supported)
+
+(define (kitty-mode-enable!)
+  (when kitty-supported
+    (display "\x1b[=1u")
+    (flush-output)))
+
+(define (kitty-mode-disable!)
+  (when kitty-supported
+    (display "\x1b[=0u")
+    (flush-output)))
+
+;; modifyOtherKeys mode 4 (xterm-compatible)
+;; Enable: ESC[>4;2m  Disable: ESC[>4;0m
+(define (modify-other-keys-enable!)
+  (display "\x1b[>4;2m")
+  (flush-output))
+
+(define (modify-other-keys-disable!)
+  (display "\x1b[>4;0m")
+  (flush-output))
+
+;; Detect Kitty support from environment
+(define (detect-kitty-support!)
+  (define term-program (getenv "TERM_PROGRAM"))
+  (define term (getenv "TERM"))
+  (set! kitty-supported
+        (or (and term-program
+                 (member (string-downcase term-program)
+                         '("kitty" "ghostty")))
+            (and term (regexp-match? #rx"^(kitty|ghostty)" term)))))
+
+;; Parse a Kitty CSI-u sequence: ESC[<codepoint>;<modifiers>u
+;; Returns (list 'key key-symbol modifiers) or #f
+(define (parse-kitty-csi-u codepoint modifiers)
+  (define base-key (kitty-codepoint->key codepoint))
+  (define mods (bitmask->modifiers modifiers))
+  (list base-key mods))
+
+;; Parse modifyOtherKeys sequence: ESC[27;<modifiers>;<keycode>~
+;; Returns (list 'key key-symbol modifiers) or #f
+(define (parse-modify-other-keys modifiers keycode)
+  (define base-key
+    (cond
+      [(= keycode 13) 'return]
+      [(= keycode 27) 'escape]
+      [(= keycode 127) 'backspace]
+      [(<= 32 keycode 126) (integer->char keycode)]
+      [else #f]))
+  (if base-key
+      (list base-key (bitmask->modifiers modifiers))
+      #f))
+
+;; Convert modifier bitmask to list of modifier symbols
+;; Bit 1=shift, 2=alt, 4=ctrl, 8=super
+(define (bitmask->modifiers mask)
+  (define mods '())
+  (when (bitwise-bit-set? mask 0) (set! mods (cons 'shift mods)))
+  (when (bitwise-bit-set? mask 1) (set! mods (cons 'alt mods)))
+  (when (bitwise-bit-set? mask 2) (set! mods (cons 'ctrl mods)))
+  (when (bitwise-bit-set? mask 3) (set! mods (cons 'super mods)))
+  (reverse mods))
+
+;; Map Kitty key codepoints to key symbols
+;; Special keys have fixed codepoints per the Kitty protocol
+(define (kitty-codepoint->key cp)
+  (cond
+    ;; Printable ASCII (32-126)
+    [(and (>= cp 32) (<= cp 126)) (integer->char cp)]
+    ;; Special keys (Kitty-defined codepoints)
+    [(= cp 57344) 'escape]
+    [(= cp 57345) 'enter]
+    [(= cp 57346) 'tab]
+    [(= cp 57347) 'backspace]
+    [(= cp 57348) 'insert]
+    [(= cp 57349) 'delete]
+    [(= cp 57350) 'left]
+    [(= cp 57351) 'right]
+    [(= cp 57352) 'up]
+    [(= cp 57353) 'down]
+    [(= cp 57354) 'page-up]
+    [(= cp 57355) 'page-down]
+    [(= cp 57356) 'home]
+    [(= cp 57357) 'end]
+    [(= cp 57358) 'caps-lock]
+    [(= cp 57359) 'scroll-lock]
+    [(= cp 57360) 'num-lock]
+    [(= cp 57361) 'print-screen]
+    [(= cp 57362) 'pause]
+    [(= cp 57363) 'menu]
+    ;; F1-F12: 57376-57387
+    [(and (>= cp 57376) (<= cp 57387))
+     (string->symbol (format "f~a" (- cp 57375)))]
+    ;; F13-F24: 57388-57399
+    [(and (>= cp 57388) (<= cp 57399))
+     (string->symbol (format "f~a" (- cp 57375)))]
+    ;; Unknown
+    [else 'unknown]))
 
 ;; ============================================================
 ;; Input byte buffer (Issue #409)

--- a/tui/terminal.rkt
+++ b/tui/terminal.rkt
@@ -77,6 +77,17 @@
          parse-xtversion-response
          parse-da1-response
 
+         ;; Kitty keyboard protocol (Issue #410)
+         kitty-mode-supported?
+         kitty-mode-enable!
+         kitty-mode-disable!
+         modify-other-keys-enable!
+         modify-other-keys-disable!
+         parse-kitty-csi-u
+         parse-modify-other-keys
+         kitty-codepoint->key
+         detect-kitty-support!
+
          ;; Clipboard
          clipboard-copy
          osc-52-copy ;; internal, exported for testing


### PR DESCRIPTION
## Wave 5 Part 2 — Issues #410, #411

### #410: Kitty keyboard protocol support
- Kitty mode enable/disable (`ESC[=1u`/`0u`)
- modifyOtherKeys mode 4 enable/disable
- `parse-kitty-csi-u` and `parse-modify-other-keys` parsers
- `kitty-codepoint->key` maps special key codepoints
- `bitmask->modifiers` converts modifier bitmask to symbols
- Three-tier fallback: Kitty → modifyOtherKeys → legacy CSI
- 7 new tests

### #411: Configurable keybindings system
- New `tui/keymap.rkt` with `key-spec` struct and `keymap` data structure
- `keymap-add!`, `keymap-remove!`, `keymap-lookup` operations
- `keymap-find-conflicts` for duplicate detection
- `default-keymap` matches current hardcoded bindings
- `load-user-keymap` loads from `~/.q/keybindings.json`
- `parse-key-string` parses C-a, M-x, C-S-right notation
- 15 keymap tests

**22 new tests across 5 files.**