### PR TITLE
feat(quality): JSON keymap, markdown fixes, test coverage, manifest hash, minor cleanup

### DIFF
--- a/extensions/loader.rkt
+++ b/extensions/loader.rkt
@@ -222,7 +222,9 @@
    #:description (hash-ref h 'description "")
    #:author (hash-ref h 'author "unknown")))
 
-;; SEC-05: Compute SHA256 hash of all files listed in the manifest
+;; SEC-05: Compute SHA256 hash of all files listed in the manifest.
+;; Warns and includes a special marker for missing files (instead of
+;; silently skipping them, which would weaken the integrity guarantee).
 (define (compute-extension-directory-hash ext-dir manifest-hash)
   (define files (hash-ref manifest-hash 'files '()))
   (if (null? files)
@@ -233,9 +235,17 @@
           (lambda (out)
             (for ([f (in-list sorted)])
               (define full-path (build-path ext-dir f))
-              (when (file-exists? full-path)
-                (call-with-input-file full-path
-                  (lambda (in) (display (port->string in) out)))))))))))
+              (cond
+                [(file-exists? full-path)
+                 (call-with-input-file full-path
+                   (lambda (in) (display (port->string in) out)))]
+                [else
+                 (log-warning
+                  "extension manifest: declared file missing: ~a (in ~a)"
+                  f ext-dir)
+                 ;; Include a special marker so the hash changes when files
+                 ;; are missing — prevents a "missing files = no change" exploit
+                 (display (format "[MISSING:~a]" f) out)]))))))))
 
 ;; Classify an exception into a category symbol.
 (define (classify-exception e)

--- a/tests/tui/bracketed-paste.rkt
+++ b/tests/tui/bracketed-paste.rkt
@@ -1,0 +1,76 @@
+#lang racket
+
+;; tests/tui/bracketed-paste.rkt — Tests for bracketed paste support (#435)
+;;
+;; Tests bracketed paste begin/end detection, buffer accumulation,
+;; and paste-event construction.
+
+(require rackunit
+         rackunit/text-ui
+         "../../tui/terminal-input.rkt")
+
+(define paste-tests
+  (test-suite
+   "bracketed-paste"
+
+   ;; Reset state before each test
+   (test-case "bracketed-paste-begin-pattern?"
+     (check-true (bracketed-paste-begin-pattern? "200" #\~))
+     (check-false (bracketed-paste-begin-pattern? "201" #\~))
+     (check-false (bracketed-paste-begin-pattern? "200" #\A)))
+
+   (test-case "bracketed-paste-end-pattern?"
+     (check-true (bracketed-paste-end-pattern? "201" #\~))
+     (check-false (bracketed-paste-end-pattern? "200" #\~))
+     (check-false (bracketed-paste-end-pattern? "201" #\A)))
+
+   (test-case "paste-buffer lifecycle"
+     (paste-buffer-reset!)
+     (check-equal? (paste-buffer-get) "")
+     (check-false (in-paste?))
+
+     ;; Start paste
+     (set-in-paste! #t)
+     (check-true (in-paste?))
+
+     ;; Accumulate
+     (paste-buffer-add! "hello ")
+     (check-equal? (paste-buffer-get) "hello ")
+
+     (paste-buffer-add! "world")
+     (check-equal? (paste-buffer-get) "hello world")
+
+     ;; End paste
+     (set-in-paste! #f)
+     (check-false (in-paste?))
+
+     ;; Reset
+     (paste-buffer-reset!)
+     (check-equal? (paste-buffer-get) ""))
+
+   (test-case "paste-buffer-max-size cap"
+     (paste-buffer-reset!)
+     ;; Add exactly max size (1MB)
+     (define big-str (make-string 1048576 #\x))
+     (paste-buffer-add! big-str)
+     (check-equal? (string-length (paste-buffer-get)) 1048576)
+     ;; Adding one more char should be silently dropped (exceeds 1MB)
+     (paste-buffer-add! "y")
+     (check-equal? (string-length (paste-buffer-get)) 1048576)
+     (paste-buffer-reset!))
+
+   (test-case "make-paste-event and paste-event?"
+     (define evt (make-paste-event "hello world"))
+     (check-true (paste-event? evt))
+     (check-false (paste-event? "not an event"))
+     (check-false (paste-event? (vector 'other)))
+     (check-equal? (vector-ref evt 1) "hello world"))
+
+   (test-case "paste-buffer-add! empty string is noop"
+     (paste-buffer-reset!)
+     (paste-buffer-add! "")
+     (check-equal? (paste-buffer-get) "")
+     (paste-buffer-reset!))
+   ))
+
+(run-tests paste-tests)

--- a/tests/tui/utf8-accumulator.rkt
+++ b/tests/tui/utf8-accumulator.rkt
@@ -1,0 +1,73 @@
+#lang racket
+
+;; tests/tui/utf8-accumulator.rkt — Tests for UTF-8 accumulator (#435)
+;;
+;; Tests utf8-accumulate-char, utf8-lead-byte-count,
+;; utf8-continuation-byte?, utf8-high-byte?, and reassemble-utf8-chars.
+
+(require rackunit
+         rackunit/text-ui
+         "../../tui/terminal-input.rkt")
+
+(define utf8-tests
+  (test-suite
+   "utf8-accumulator"
+
+   (test-case "utf8-lead-byte-count"
+     (check-equal? (utf8-lead-byte-count 65) 1)   ; ASCII 'A'
+     (check-equal? (utf8-lead-byte-count 127) 1)   ; DEL
+     (check-equal? (utf8-lead-byte-count 128) 1)   ; continuation
+     (check-equal? (utf8-lead-byte-count 192) 2)   ; 2-byte lead
+     (check-equal? (utf8-lead-byte-count 224) 3)   ; 3-byte lead
+     (check-equal? (utf8-lead-byte-count 240) 4)   ; 4-byte lead
+     (check-equal? (utf8-lead-byte-count 248) 1))  ; invalid
+
+   (test-case "utf8-continuation-byte?"
+     (check-false (utf8-continuation-byte? 65))
+     (check-false (utf8-continuation-byte? 127))
+     (check-true (utf8-continuation-byte? 128))
+     (check-true (utf8-continuation-byte? 191))
+     (check-false (utf8-continuation-byte? 192)))
+
+   (test-case "utf8-high-byte?"
+     (check-false (utf8-high-byte? #\A))
+     (check-false (utf8-high-byte? #\z))
+     (check-true (utf8-high-byte? (integer->char 200))))
+
+   (test-case "utf8-accumulate-char ASCII"
+     (utf8-accumulator-reset!)
+     (check-equal? (utf8-accumulator-length) 0)
+     (define result (utf8-accumulate-char #\A))
+     (check-equal? result #\A)
+     (check-equal? (utf8-accumulator-length) 0))
+
+   (test-case "utf8-accumulate-char 2-byte UTF-8"
+     (utf8-accumulator-reset!)
+     ;; 'ü' = U+00FC = 0xC3 0xBC
+     (define r1 (utf8-accumulate-char (integer->char #xC3)))
+     (check-false r1) ; incomplete
+     (check-equal? (utf8-accumulator-length) 1)
+     (define r2 (utf8-accumulate-char (integer->char #xBC)))
+     (check-equal? r2 #\ü)
+     (check-equal? (utf8-accumulator-length) 0))
+
+   (test-case "utf8-accumulate-char 3-byte UTF-8 (CJK)"
+     (utf8-accumulator-reset!)
+     ;; '日' = U+65E5 = 0xE6 0x97 0xA5
+     (define r1 (utf8-accumulate-char (integer->char #xE6)))
+     (check-false r1)
+     (define r2 (utf8-accumulate-char (integer->char #x97)))
+     (check-false r2)
+     (check-equal? (utf8-accumulator-length) 2)
+     (define r3 (utf8-accumulate-char (integer->char #xA5)))
+     (check-equal? r3 #\日)
+     (check-equal? (utf8-accumulator-length) 0))
+
+   (test-case "reassemble-utf8-chars"
+     (check-equal? (reassemble-utf8-chars (list #\A)) #\A)
+     (check-equal? (reassemble-utf8-chars
+                    (list (integer->char #xC3) (integer->char #xBC)))
+                   #\ü))
+   ))
+
+(run-tests utf8-tests)

--- a/tui/char-width.rkt
+++ b/tui/char-width.rkt
@@ -8,8 +8,7 @@
 ;;
 ;; Reference: Unicode East Asian Width property (UAX #11)
 
-(require racket/contract
-         racket/string)
+(require racket/string)
 
 (provide char-width
          string-visible-width

--- a/tui/input.rkt
+++ b/tui/input.rkt
@@ -147,7 +147,7 @@
       (let* ([prev-start (prev-grapheme-start buf cur)]
              [new-buf (string-append (substring buf 0 prev-start) (substring buf cur))])
         (push-undo st (struct-copy input-state st [buffer new-buf] [cursor prev-start])))))
-;; Visible input width helper — prompt takes 4 columns ("q> ")
+;; Visible input width helper — prompt takes 3 columns (">> ")
 (define INPUT-PROMPT-WIDTH 3)
 
 ;; Compute the visible window of the buffer given a terminal width.

--- a/tui/keymap.rkt
+++ b/tui/keymap.rkt
@@ -9,6 +9,8 @@
          racket/port
          racket/file
          racket/match
+         racket/function
+         json
          "../util/config-paths.rkt")
 
 (provide key-spec
@@ -220,32 +222,53 @@
       [else (string->symbol rest)]))
   (key-spec key-name ctrl shift alt))
 
-;; Minimal config reader (sexp-based, no JSON dependency needed)
-;; Keybindings file format: (("key" . "action") ...)
-;; where "key" uses C-/M-/S- prefixes, e.g. "C-a", "M-x", "C-S-right"
+;; JSON keybindings loader.
+;; Keybindings file format: [{ "key": "C-a", "action": "select-all" }, ...]
+;; Key format: C- = ctrl, M- = alt, S- = shift, then key name.
+;; Uses the `json` library for proper JSON parsing — key order in objects
+;; is not significant.
 
 (define (load-keybindings-file path)
-  (with-handlers ([exn:fail? (lambda (e) #f)])
+  (with-handlers ([exn:fail?
+                   (lambda (e)
+                     (log-warning
+                      (format "keymap: failed to load ~a: ~a"
+                              path (exn-message e)))
+                     #f)])
     (if (file-exists? path)
         (let ([content (file->string path)])
-          (parse-keybindings-content content))
+          (parse-keybindings-content content path))
         #f)))
 
-(define (parse-keybindings-content content)
-  ;; Match key/action pairs from JSON config
-  (define kb-rx
-    (regexp
-     (string-append
-      "\"key\"[ \t]*:[ \t]*\"([^\"]+)\"][ \t]*,"
-      "[ \t]*\"action\"[ \t]*:[ \t]*\"([^\"]+)\"")))
-  (let ([entries (regexp-match* kb-rx content)])
-    (if (null? entries)
+(define (parse-keybindings-content content [source-path "<keybindings>"])
+  (with-handlers ([exn:fail?
+                   (lambda (e)
+                     (log-warning
+                      (format "keymap: invalid JSON in ~a: ~a"
+                              source-path (exn-message e)))
+                     #f)])
+    (define data (string->jsexpr content))
+    (unless (list? data)
+      (raise (exn:fail (format "keymap: expected JSON array in ~a" source-path)
+                       (current-continuation-marks))))
+    (define bindings
+      (for/list ([entry (in-list data)]
+                 #:when (and (hash? entry)
+                             (hash-has-key? entry 'key)
+                             (hash-has-key? entry 'action)))
+        (define key-str (hash-ref entry 'key #f))
+        (define action-str (hash-ref entry 'action #f))
+        (if (and (string? key-str) (string? action-str))
+            (cons (parse-key-string key-str)
+                  (string->symbol action-str))
+            (begin
+              (log-warning
+               (format "keymap: skipping invalid entry in ~a: ~v"
+                       source-path entry))
+              #f))))
+    (define valid-bindings (filter identity bindings))
+    (if (null? valid-bindings)
         #f
-        (for/list ([e (in-list entries)])
-          (define m (regexp-match kb-rx e))
-          (if m
-              (cons (parse-key-string (cadr m))
-                    (string->symbol (caddr m)))
-              #f)))))
+        valid-bindings)))
 
 

--- a/tui/state.rkt
+++ b/tui/state.rkt
@@ -185,7 +185,7 @@
 ;; Returns a new ui-state (immutable update).
 ;; This is the core event→state reduction.
 (define (apply-event-to-state state evt)
-  ;; evt is an event struct from agent/types.rkt
+  ;; evt is an event struct from util/protocol-types.rkt
   ;; (event version ev time session-id turn-id payload)
   (define ev (event-ev evt))
   (define payload (event-payload evt))

--- a/tui/terminal.rkt
+++ b/tui/terminal.rkt
@@ -468,6 +468,8 @@
 ;; clipboard-copy is replaced by copy-text! from clipboard.rkt
 
 ;; Backward-compatible wrapper: clipboard-copy calls copy-text!
+;; DEPRECATED: Use copy-text! directly. This wrapper will be removed
+;; in a future version.
 (define (clipboard-copy text)
   (copy-text! text))
 

--- a/util/markdown.rkt
+++ b/util/markdown.rkt
@@ -23,8 +23,17 @@
          parse-inline-markdown)
 
 ;; ============================================================
-;; Core struct — flat token model (no nesting in first version)
+;; Core struct — token model with selective nesting
 ;; ============================================================
+;;
+;; Block-level tokens (blockquote, unordered-list, ordered-list) contain
+;; nested token lists from inline parsing. Their content field is:
+;;   blockquote     → (cons depth (listof md-token))
+;;   unordered-list → (cons indent (listof md-token))
+;;   ordered-list   → (cons indent (cons number (listof md-token)))
+;;
+;; All other tokens carry flat content (strings, pairs, #t).
+;; Consumers should handle nested token lists for these three types.
 
 (struct md-token (type content) #:transparent)
 ;; type : 'text | 'bold | 'italic | 'code | 'code-block | 'header | 'link | 'newline
@@ -38,9 +47,9 @@
 ;;   'header     → (cons level-number header-text-string)
 ;;   'link       → (cons url-string link-text-string)
 ;;   'newline    → string "\n" (line separator)
-;;   'unordered-list → (cons indent-level list-text-string)
-;;   'ordered-list   → (cons indent-level (cons number list-text-string))
-;;   'blockquote    → string (quoted text, without > prefix)
+;;   'unordered-list → (cons indent-level (listof md-token))
+;;   'ordered-list   → (cons indent-level (cons number (listof md-token)))
+;;   'blockquote    → (cons depth (listof md-token))
 ;;   'hr            → #t
 ;;   'strikethrough → string (struck-through text)
 
@@ -64,9 +73,9 @@
 
 (define (parse-code-blocks text)
   ;; Manual approach: split on triple-backtick boundaries.
-  ;; Find opening ``` and closing ``` pairs.
+  ;; Uses cons + reverse for O(n) accumulation.
   (define len (string-length text))
-  (define result '())
+  (define result-acc '())
   (define pos 0)
   (let loop ()
     (define open-pos (find-triple-backtick text pos))
@@ -74,11 +83,15 @@
       [(not open-pos)
        ;; No more code blocks — emit remaining text
        (when (< pos len)
-         (set! result (append result (parse-regular-text (substring text pos len)))))]
+         (set! result-acc
+               (foldl cons result-acc
+                      (parse-regular-text (substring text pos len)))))]
       [else
        ;; Emit text before the code block
        (when (> open-pos pos)
-         (set! result (append result (parse-regular-text (substring text pos open-pos)))))
+         (set! result-acc
+               (foldl cons result-acc
+                      (parse-regular-text (substring text pos open-pos)))))
        ;; Find the language tag (rest of the opening line)
        (define after-open (+ open-pos 3)) ; skip ```
        (define newline-pos (find-char text after-open #\newline))
@@ -95,7 +108,9 @@
        (cond
          [(not close-pos)
           ;; Unclosed code block — emit opening fence as text
-          (set! result (append result (list (md-token 'text (substring text open-pos len)))))
+          (set! result-acc
+                (cons (md-token 'text (substring text open-pos len))
+                      result-acc))
           (set! pos len)]
          [else
           (define code (substring text code-start close-pos))
@@ -103,19 +118,20 @@
           (define after-close (+ close-pos 3)) ; skip closing ```
           (define trailing-nl?
             (and (< after-close len) (char=? (string-ref text after-close) #\newline)))
-          (set! result
-                (append result
-                        (list (md-token 'code-block (cons (if (string=? lang "") #f lang) code))
-                              ;; Newline separator after code block
-                              (md-token 'newline "\n"))))
+          (set! result-acc
+                (cons (md-token 'newline "\n")
+                      (cons (md-token 'code-block
+                                      (cons (if (string=? lang "") #f lang) code))
+                            result-acc)))
           (set! pos
                 (if trailing-nl?
                     (add1 after-close)
                     after-close))
           (loop)])]))
   ;; Filter out empty text tokens
-  (filter (lambda (t) (not (and (eq? (md-token-type t) 'text) (string=? (md-token-content t) ""))))
-          result))
+  (filter (lambda (t) (not (and (eq? (md-token-type t) 'text)
+                                 (string=? (md-token-content t) ""))))
+          (reverse result-acc)))
 
 ;; Find the start of a triple-backtick sequence (```) at or after pos
 (define (find-triple-backtick text pos)
@@ -150,7 +166,7 @@
   (cond
     ;; Horizontal rule: 3+ hyphens/asterisks/underscores with optional spaces
     [(or (regexp-match? #px"^[ \t]*-[- \t]*-[- \t]*-[ \t]*$" line)
-          (regexp-match? #px"^[ \t]*[*][*]+[* \t]*$" line)
+          (regexp-match? #px"^[ \t]*[*][*][*][* \t]*$" line)
           (regexp-match? #px"^[ \t]*___+[_ \t]*$" line))
      (list (md-token 'hr #t))]
     ;; Header: # heading


### PR DESCRIPTION
## Wave 4 — Quality & Cleanup (P2)

### Changes
- **#433**: Replace regex-based JSON keymap parser with proper `json` library
- **#434**: Fix markdown HR regex (3+ asterisks), document nesting model, O(n²)→O(n) code block parsing
- **#435**: Add 6 bracketed paste tests, 7 UTF-8 accumulator tests
- **#436**: Warn on missing manifest files, include marker in integrity hash
- **#437**: Fix stale comments, deprecation warning on clipboard-copy, remove dead require

### Testing
- [x] 15 keymap tests pass
- [x] 51 markdown tests pass
- [x] 6 bracketed paste tests pass
- [x] 7 UTF-8 accumulator tests pass
- [x] Format lint passes

Fixes: #433, #434, #435, #436, #437