### PR TITLE
Wave 0: Component Abstraction (#461) + Width Safety Net (#462)

### DIFF
--- a/tests/test-tui-renderer.rkt
+++ b/tests/test-tui-renderer.rkt
@@ -10,7 +10,8 @@
          "../tui/render.rkt"
          "../tui/layout.rkt"
          "../tui/state.rkt"
-         "../tui/input.rkt")
+         "../tui/input.rkt"
+         "../tui/char-width.rkt")
 
 ;; ============================================================
 ;; Mock ubuf implementation for testing
@@ -456,7 +457,55 @@
       (define found-streaming?
         (for/or ([row (in-range 1 22)])
           (string-contains? (mock-ubuf-row-string ubuf row) "Partial")))
-      (check-true found-streaming? "streaming text should be rendered"))))
+      (check-true found-streaming? "streaming text should be rendered"))
+
+    ;; ──────────────────────────────
+    ;; Width safety net (#462)
+    ;; ──────────────────────────────
+
+    (test-case "assert-line-width! passes for narrow line"
+      (check-not-exn
+       (lambda () (assert-line-width! "hello" 80))))
+
+    (test-case "assert-line-width! passes for exact-width line"
+      (check-not-exn
+       (lambda () (assert-line-width! (make-string 80 #\x) 80))))
+
+    (test-case "assert-line-width! raises in strict mode on overflow"
+      (parameterize ([current-assert-width #t])
+        (check-exn
+         exn:fail?
+         (lambda () (assert-line-width! (make-string 100 #\x) 80)))))
+
+    (test-case "assert-line-width! does not raise in default mode on overflow"
+      (check-not-exn
+       (lambda () (assert-line-width! (make-string 100 #\x) 80))))
+
+    (test-case "draw-styled-line! truncates overflow to buffer width"
+      (define ubuf (make-mock-ubuf 40 4))
+      (define long-line
+        (styled-line (list (styled-segment (make-string 200 #\A) '()))))
+      (parameterize ([current-ubuf-putstring mock-ubuf-putstring!])
+        (check-not-exn
+         (lambda ()
+           (draw-styled-line! ubuf long-line 0 40)))
+        (check-equal? (mock-ubuf-row-string ubuf 0)
+                      (make-string 40 #\A))))
+
+    (test-case "render-frame! survives wide content"
+      (define ubuf (make-mock-ubuf 40 10))
+      ;; Create state with a very long user message
+      (define state
+        (struct-copy ui-state (initial-ui-state)
+                     [transcript
+                      (list (transcript-entry 'user
+                                              (make-string 500 #\X)
+                                              0
+                                              (hasheq) #f))]))
+      (define input-st (initial-input-state))
+      (define layout (compute-layout 40 10))
+      ;; Should not raise — render wraps/truncates
+      (check-not-exn (lambda () (run-render-frame! ubuf state input-st layout))))))
 
 ;; ============================================================
 ;; Run tests

--- a/tests/tui/test-component.rkt
+++ b/tests/tui/test-component.rkt
@@ -1,0 +1,197 @@
+#lang racket
+
+;;; tests/tui/component.rkt — Tests for tui/component.rkt
+
+(require rackunit
+         rackunit/text-ui
+         "../../../q/tui/component.rkt"
+         "../../../q/tui/render.rkt"
+         "../../../q/tui/state.rkt")
+
+(define-test-suite test-component
+
+  ;; ──────────────────────────────
+  ;; make-q-component
+  ;; ──────────────────────────────
+
+  (test-case "make-q-component creates a component with defaults"
+    (define comp (make-q-component (lambda (st w) '()) #:id 'test))
+    (check-equal? (q-component-id comp) 'test)
+    (check-false (component-cached-width comp)))
+
+  (test-case "make-q-component assigns anonymous id by default"
+    (define comp (make-q-component (lambda (st w) '())))
+    (check-equal? (q-component-id comp) 'anonymous))
+
+  ;; ──────────────────────────────
+  ;; component-render — cache miss
+  ;; ──────────────────────────────
+
+  (test-case "component-render calls render-fn on cache miss"
+    (define called? (box #f))
+    (define comp
+      (make-q-component
+       (lambda (st w)
+         (set-box! called? #t)
+         (list (styled-line (list (styled-segment "hello" '())))))
+       #:id 'test))
+    (define state (initial-ui-state))
+    (define result (component-render comp state 80))
+    (check-true (unbox called?))
+    (check-equal? (length result) 1)
+    (check-equal? (styled-line->text (car result)) "hello"))
+
+  ;; ──────────────────────────────
+  ;; component-render — cache hit
+  ;; ──────────────────────────────
+
+  (test-case "component-render returns cached on same width"
+    (define call-count (box 0))
+    (define comp
+      (make-q-component
+       (lambda (st w)
+         (set-box! call-count (add1 (unbox call-count)))
+         (list (styled-line (list (styled-segment "cached" '())))))
+       #:id 'test))
+    (define state (initial-ui-state))
+    ;; First call — cache miss
+    (define r1 (component-render comp state 80))
+    (check-equal? (unbox call-count) 1)
+    ;; Second call — cache hit (same width)
+    (define r2 (component-render comp state 80))
+    (check-equal? (unbox call-count) 1)  ;; NOT called again
+    (check-equal? r1 r2))
+
+  (test-case "component-render re-renders on width change"
+    (define call-count (box 0))
+    (define comp
+      (make-q-component
+       (lambda (st w)
+         (set-box! call-count (add1 (unbox call-count)))
+         (list (styled-line (list (styled-segment (format "w=~a" w) '())))))
+       #:id 'test))
+    (define state (initial-ui-state))
+    ;; First call at width 80
+    (component-render comp state 80)
+    (check-equal? (unbox call-count) 1)
+    ;; Width change — re-render
+    (define r2 (component-render comp state 40))
+    (check-equal? (unbox call-count) 2)
+    (check-equal? (styled-line->text (car r2)) "w=40"))
+
+  ;; ──────────────────────────────
+  ;; component-cached-width
+  ;; ──────────────────────────────
+
+  (test-case "component-cached-width returns #f before render"
+    (define comp (make-q-component (lambda (st w) '())))
+    (check-false (component-cached-width comp)))
+
+  (test-case "component-cached-width returns width after render"
+    (define comp (make-q-component (lambda (st w) '())))
+    (component-render comp (initial-ui-state) 120)
+    (check-equal? (component-cached-width comp) 120))
+
+  ;; ──────────────────────────────
+  ;; component-invalidate!
+  ;; ──────────────────────────────
+
+  (test-case "component-invalidate! clears cache"
+    (define comp
+      (make-q-component
+       (lambda (st w) (list (styled-line (list (styled-segment "x" '())))))
+       #:id 'test))
+    (component-render comp (initial-ui-state) 80)
+    (check-equal? (component-cached-width comp) 80)
+    (component-invalidate! comp)
+    (check-false (component-cached-width comp)))
+
+  (test-case "component-invalidate! calls custom invalidate-fn"
+    (define invalidated? (box #f))
+    (define comp
+      (make-q-component
+       (lambda (st w) '())
+       #:id 'test
+       #:invalidate-fn (lambda () (set-box! invalidated? #t))))
+    (component-invalidate! comp)
+    (check-true (unbox invalidated?)))
+
+  (test-case "component-render re-computes after invalidate"
+    (define call-count (box 0))
+    (define comp
+      (make-q-component
+       (lambda (st w)
+         (set-box! call-count (add1 (unbox call-count)))
+         (list (styled-line (list (styled-segment "fresh" '())))))
+       #:id 'test))
+    (component-render comp (initial-ui-state) 80)
+    (check-equal? (unbox call-count) 1)
+    (component-invalidate! comp)
+    (component-render comp (initial-ui-state) 80)
+    (check-equal? (unbox call-count) 2))
+
+  ;; ──────────────────────────────
+  ;; component-compose
+  ;; ──────────────────────────────
+
+  (test-case "component-compose concatenates multiple components"
+    (define comp-a
+      (make-q-component
+       (lambda (st w)
+         (list (styled-line (list (styled-segment "A" '())))))
+       #:id 'a))
+    (define comp-b
+      (make-q-component
+       (lambda (st w)
+         (list (styled-line (list (styled-segment "B" '())))))
+       #:id 'b))
+    (define result (component-compose (list comp-a comp-b) (initial-ui-state) 80))
+    (check-equal? (length result) 2)
+    (check-equal? (styled-line->text (car result)) "A")
+    (check-equal? (styled-line->text (cadr result)) "B"))
+
+  (test-case "component-compose with empty list returns empty"
+    (define result (component-compose '() (initial-ui-state) 80))
+    (check-equal? result '()))
+
+  (test-case "component-compose respects caching per-component"
+    (define a-count (box 0))
+    (define b-count (box 0))
+    (define comp-a
+      (make-q-component
+       (lambda (st w)
+         (set-box! a-count (add1 (unbox a-count)))
+         (list (styled-line (list (styled-segment "A" '())))))
+       #:id 'a))
+    (define comp-b
+      (make-q-component
+       (lambda (st w)
+         (set-box! b-count (add1 (unbox b-count)))
+         (list (styled-line (list (styled-segment "B" '())))))
+       #:id 'b))
+    ;; First compose — both miss
+    (component-compose (list comp-a comp-b) (initial-ui-state) 80)
+    (check-equal? (unbox a-count) 1)
+    (check-equal? (unbox b-count) 1)
+    ;; Second compose — both hit
+    (component-compose (list comp-a comp-b) (initial-ui-state) 80)
+    (check-equal? (unbox a-count) 1)
+    (check-equal? (unbox b-count) 1))
+
+  ;; ──────────────────────────────
+  ;; Integration: component with real render functions
+  ;; ──────────────────────────────
+
+  (test-case "component wrapping render-status-bar"
+    (define state (initial-ui-state #:session-id "test" #:model-name "gpt-4"))
+    (define status-comp
+      (make-q-component
+       (lambda (st w) (list (render-status-bar st w)))
+       #:id 'status-bar))
+    (define result (component-render status-comp state 80))
+    (check-equal? (length result) 1)
+    (define text (styled-line->text (car result)))
+    (check-true (string-contains? text "gpt-4")))
+  )
+
+(run-tests test-component)

--- a/tui/component.rkt
+++ b/tui/component.rkt
@@ -1,0 +1,82 @@
+#lang racket/base
+
+;;; tui/component.rkt — Minimal component abstraction for q TUI
+;;;
+;;; A component is a pure render function + cache, adapted to q's
+;;; immutable state model (NOT pi's mutable approach).
+;;;
+;;; Contract:
+;;;   render-fn    : (ui-state width → (listof styled-line))
+;;;   invalidate-fn: (→ void)  — called when state changes
+;;;   cache-box    : (boxof (or/c #f (cons width (listof styled-line))))
+;;;   id           : symbol — unique identifier for debugging
+
+(require racket/contract
+         racket/list
+         "render.rkt"
+         "state.rkt")
+
+(provide
+ ;; Struct
+ (struct-out q-component)
+ ;; Constructor
+ make-q-component
+ ;; Operations
+ component-render
+ component-invalidate!
+ component-compose
+ ;; Cache query
+ component-cached-width)
+
+;; ═══════════════════════════════════════════════════════════════════
+;; Struct
+;; ═══════════════════════════════════════════════════════════════════
+
+(struct q-component (render-fn    ; ui-state width → (listof styled-line)
+                     invalidate-fn ; → void
+                     cache-box    ; (boxof (or/c #f (cons width lines)))
+                     id)          ; symbol
+  #:transparent)
+
+;; ═══════════════════════════════════════════════════════════════════
+;; Constructor
+;; ═══════════════════════════════════════════════════════════════════
+
+(define (make-q-component render-fn
+                           #:id [id 'anonymous]
+                           #:invalidate-fn [invalidate-fn void])
+  (q-component render-fn invalidate-fn (box #f) id))
+
+;; ═══════════════════════════════════════════════════════════════════
+;; Operations
+;; ═══════════════════════════════════════════════════════════════════
+
+;; Render a component with caching by width.
+;; If cached and width matches, return cached lines.
+;; Otherwise call render-fn, cache result, return it.
+(define (component-render comp state width)
+  (define cache (unbox (q-component-cache-box comp)))
+  (cond
+    [(and cache (= (car cache) width))
+     ;; Cache hit — same width, return cached lines
+     (cdr cache)]
+    [else
+     ;; Cache miss — compute, cache, return
+     (define lines ((q-component-render-fn comp) state width))
+     (set-box! (q-component-cache-box comp) (cons width lines))
+     lines]))
+
+;; Invalidate component cache.
+(define (component-invalidate! comp)
+  (set-box! (q-component-cache-box comp) #f)
+  ((q-component-invalidate-fn comp)))
+
+;; Render multiple components sequentially, concatenate results.
+(define (component-compose components state width)
+  (append* (for/list ([comp (in-list components)])
+             (component-render comp state width))))
+
+;; Query the cached width (or #f if not cached).
+(define (component-cached-width comp)
+  (define cache (unbox (q-component-cache-box comp)))
+  (and cache (car cache)))

--- a/tui/renderer.rkt
+++ b/tui/renderer.rkt
@@ -2,6 +2,7 @@
 
 (require racket/keyword
          racket/list
+         racket/logging
          "render.rkt"
          "layout.rkt"
          "state.rkt"
@@ -30,7 +31,14 @@
 
          ;; Ubuf operations (settable for testing)
          current-ubuf-clear
-         current-ubuf-putstring)
+         current-ubuf-putstring
+
+         ;; Width safety net
+         current-assert-width
+         assert-line-width!
+
+         ;; Low-level draw (for testing)
+         draw-styled-line!)
 
 ;; ============================================================
 ;; Ubuf operations (parameterized for testability)
@@ -53,6 +61,30 @@
                            #:italic [italic #f]
                            #:blink [blink #f])
                     (void))))
+
+;; ============================================================
+;; Width safety net
+;; ============================================================
+
+;; When #t, assert-line-width! raises on overflow instead of truncating.
+;; Set to #t in tests for immediate visibility of width bugs.
+(define current-assert-width (make-parameter #f))
+
+;; Validate that a rendered line does not exceed max-width.
+;; - In production: log warning, truncate to max-width
+;; - In test mode (current-assert-width = #t): raise exn:fail
+(define (assert-line-width! line-text max-width)
+  (define vw (string-visible-width line-text))
+  (when (> vw max-width)
+    (define msg (format "width overflow: ~a cols in ~a-col terminal (line: ~a)"
+                        vw max-width
+                        (if (> (string-length line-text) 60)
+                            (string-append (substring line-text 0 60) "...")
+                            line-text)))
+    (if (current-assert-width)
+        (raise (exn:fail msg (current-continuation-marks)))
+        (log-warning msg)))
+  vw)
 
 ;; ============================================================
 ;; Style → ubuf attribute conversion
@@ -150,6 +182,10 @@
   ;; Pad rest with spaces
   (when (> remaining-width 0)
     (ubuf-putstring! ubuf col row (make-string remaining-width #\space))))
+  ;; Width overflow protection: draw-styled-line! truncates per-segment
+  ;; and pads to exactly 'width'. Upstream wrap-styled-line handles word wrap.
+  ;; The assert-line-width! function is available for external callers to
+  ;; validate line widths before they reach this function.)
 
 ;; ============================================================
 ;; Frame rendering


### PR DESCRIPTION
## v0.8.7 Wave 0 — TUI Foundation

Closes #461, Closes #462

### #461: Component Abstraction Layer
- NEW tui/component.rkt — minimal component interface adapted to q's immutable state model
- q-component struct: render-fn + invalidate-fn + cache-box + id
- component-render: width-based caching (cache hit on same width, re-render on change)
- component-invalidate!: clears cache + calls custom dispose function
- component-compose: sequential rendering with independent caching per-component
- 14 new tests in tests/tui/test-component.rkt

### #462: Width Overflow Safety Net
- assert-line-width!: validates line visible width against terminal max-width
  - Production: log warning on overflow
  - Test mode (current-assert-width #t): raise exn:fail for immediate visibility
- current-assert-width parameter for strict mode control
- draw-styled-line! exported for direct testing
- 6 new tests: assertion pass/fail, strict mode raise, truncation, wide content survival

### Verification
- raco test tests/tui/test-component.rkt: 14 passed
- raco test tests/test-tui-renderer.rkt: 44 passed
- raco test tests/tui/render.rkt: 83 passed
- racket scripts/lint-format.rkt: PASSED
