### PR TITLE
Wave 1: IME Cursor (#464) + Render Debounce (#465) + Incremental Diff (#466)

### DIFF
--- a/tests/tui/frame-diff.rkt
+++ b/tests/tui/frame-diff.rkt
@@ -27,10 +27,15 @@
               (list (diff-cmd 'write 0 "a") (diff-cmd 'write 1 "b") (diff-cmd 'write 2 "c"))
               "all lines changed yields write cmds for all rows")
 
-;; Different length → full redraw
+;; Different length (curr longer) — incremental append
 (check-equal? (diff-frames frame-3 frame-4)
-              (list (diff-cmd 'full 0 #f))
-              "different-length frames yield full redraw")
+              (list (diff-cmd 'write 3 "line3"))
+              "longer frame yields append write cmd")
+
+;; Different length (curr shorter) — incremental clear
+(check-equal? (diff-frames frame-4 frame-3)
+              (list (diff-cmd 'clear-from 3 #f))
+              "shorter frame yields clear-from cmd")
 
 ;; frame->string-lines is identity
 (check-equal? (frame->string-lines frame-3) frame-3 "frame->string-lines returns the frame unchanged")
@@ -42,3 +47,32 @@
 (check-equal? (diff-frames #f empty-frame)
               (list (diff-cmd 'full 0 #f))
               "#f prev with empty current yields full redraw")
+
+;; ──────────────────────────────
+;; Incremental resize tests (#466)
+;; ──────────────────────────────
+
+;; Append + change in common region
+(define frame-3-mod-append '("line0" "CHANGED" "line2" "extra"))
+(check-equal? (diff-frames frame-3 frame-3-mod-append)
+              (list (diff-cmd 'write 1 "CHANGED")
+                    (diff-cmd 'write 3 "extra"))
+              "changed + appended yields write for both")
+
+;; Shrink with change in common region
+(define frame-4-mod-shrink '("line0" "DIFF" "line2"))
+(check-equal? (diff-frames frame-4 frame-4-mod-shrink)
+              (list (diff-cmd 'write 1 "DIFF")
+                    (diff-cmd 'clear-from 3 #f))
+              "changed + shrunk yields write + clear-from")
+
+;; Grow by multiple lines
+(define frame-6 '("a" "b" "c" "d" "e" "f"))
+(check-equal? (diff-frames frame-3 frame-6)
+              (list (diff-cmd 'write 0 "a")
+                    (diff-cmd 'write 1 "b")
+                    (diff-cmd 'write 2 "c")
+                    (diff-cmd 'write 3 "d")
+                    (diff-cmd 'write 4 "e")
+                    (diff-cmd 'write 5 "f"))
+              "grow by multiple lines yields all writes")

--- a/tests/tui/test-cursor-marker.rkt
+++ b/tests/tui/test-cursor-marker.rkt
@@ -1,0 +1,48 @@
+#lang racket
+
+;; tests/tui/test-cursor-marker.rkt — Tests for IME cursor marker (#464)
+
+(require rackunit
+         rackunit/text-ui
+         "../../../q/tui/terminal.rkt")
+
+(define-test-suite test-cursor-marker
+
+  (test-case "CURSOR-MARKER is a non-empty string"
+    (check-pred string? CURSOR-MARKER)
+    (check-true (> (string-length CURSOR-MARKER) 0)))
+
+  (test-case "CURSOR-MARKER uses APC protocol"
+    ;; Should start with ESC _ (APC introducer)
+    (check-equal? (substring CURSOR-MARKER 0 2) "\x1b_")
+    ;; Should end with BEL (0x07)
+    (define last-char (string-ref CURSOR-MARKER (sub1 (string-length CURSOR-MARKER))))
+    (check-equal? (char->integer last-char) 7))
+
+  (test-case "strip-cursor-marker returns clean string when no marker"
+    (define-values (clean pos) (strip-cursor-marker "hello world"))
+    (check-equal? clean "hello world")
+    (check-false pos))
+
+  (test-case "strip-cursor-marker removes marker from string"
+    (define-values (clean pos) (strip-cursor-marker (string-append "hello" CURSOR-MARKER)))
+    (check-equal? clean "hello")
+    (check-equal? pos (cons 0 5)))
+
+  (test-case "strip-cursor-marker handles marker in middle"
+    (define-values (clean pos) (strip-cursor-marker (string-append "abc" CURSOR-MARKER "def")))
+    (check-equal? clean "abcdef")
+    (check-equal? pos (cons 0 3)))
+
+  (test-case "strip-cursor-marker handles marker in multi-line string"
+    (define-values (clean pos)
+      (strip-cursor-marker (string-append "line0\nline1" CURSOR-MARKER)))
+    (check-equal? clean "line0\nline1")
+    (check-equal? pos (cons 1 5)))
+
+  (test-case "strip-cursor-marker handles only marker"
+    (define-values (clean pos) (strip-cursor-marker CURSOR-MARKER))
+    (check-equal? clean "")
+    (check-equal? pos (cons 0 0))))
+
+(run-tests test-cursor-marker)

--- a/tui/frame-diff.rkt
+++ b/tui/frame-diff.rkt
@@ -1,5 +1,7 @@
 #lang racket/base
 
+(require racket/list)
+
 (provide (struct-out diff-cmd)
          diff-frames
          frame->string-lines)
@@ -21,17 +23,49 @@
 ;; prev: (listof string) — previous frame lines (may be empty for first frame)
 ;; curr: (listof string) — current frame lines
 ;; Returns: (listof diff-cmd)
+;;
+;; Handles frames of different lengths incrementally:
+;;   - Changed lines → 'write
+;;   - New lines (curr longer) → 'write for appended lines
+;;   - Removed lines (prev longer) → 'clear-from for surplus rows
 (define (diff-frames prev curr)
   (cond
     ;; No previous frame (first render or resize) — full redraw
     [(not prev) (list (diff-cmd 'full 0 #f))]
     [(null? prev) (list (diff-cmd 'full 0 #f))]
-    [(not (= (length prev) (length curr))) (list (diff-cmd 'full 0 #f))]
     [else
-     (define diffs
-       (for/list ([p (in-list prev)]
-                  [c (in-list curr)]
-                  [i (in-naturals)]
-                  #:when (not (string=? p c)))
-         (diff-cmd 'write i c)))
-     diffs]))
+     (define prev-len (length prev))
+     (define curr-len (length curr))
+     (cond
+       ;; Same length — standard row-by-row diff
+       [(= prev-len curr-len)
+        (for/list ([p (in-list prev)]
+                   [c (in-list curr)]
+                   [i (in-naturals)]
+                   #:when (not (string=? p c)))
+          (diff-cmd 'write i c))]
+       ;; Current is longer — diff common prefix, append new lines
+       [(> curr-len prev-len)
+        (define common-diffs
+          (for/list ([p (in-list prev)]
+                     [c (in-list curr)]
+                     [i (in-naturals)]
+                     #:when (not (string=? p c)))
+            (diff-cmd 'write i c)))
+        (define appended
+          (for/list ([c (in-list (drop curr prev-len))]
+                     [i (in-naturals prev-len)])
+            (diff-cmd 'write i c)))
+        (append common-diffs appended)]
+       ;; Current is shorter — diff common prefix, clear surplus
+       [else
+        (define common-diffs
+          (for/list ([p (in-list curr)]
+                     [c (in-list curr)]
+                     [i (in-naturals)]
+                     #:when (not (string=? (list-ref prev i) c)))
+            (diff-cmd 'write i c)))
+        ;; Clear rows from curr-len to prev-len-1
+        (define cleared
+          (list (diff-cmd 'clear-from curr-len #f)))
+        (append common-diffs cleared)])]))

--- a/tui/terminal.rkt
+++ b/tui/terminal.rkt
@@ -23,6 +23,7 @@
 
 (require racket/port
          racket/string
+         racket/list
          "clipboard.rkt"
          "terminal-bridge.rkt"
          "terminal-input.rkt")
@@ -97,6 +98,10 @@
          copy-selection!
          clipboard-backend-available?
          current-clipboard-mode
+
+         ;; IME cursor support
+         CURSOR-MARKER
+         strip-cursor-marker
 
          ;; Mouse events
          tmousemsg?
@@ -485,3 +490,34 @@
 
 (define (tui-key-symbol keycode)
   keycode)
+
+;; ============================================================
+;; IME Cursor Marker (APC protocol)
+;; ============================================================
+
+;; Zero-width APC marker for IME cursor positioning.
+;; Uses \x1b_q:c\x07 which is silently ignored by terminals
+;; that don't understand it, and used by CJK-aware terminals
+;; for correct IME composition placement.
+;; Replaces the iTerm2-specific \x1b]1337;CursorMarker\x1b\\.
+(define CURSOR-MARKER "\x1b_q:c\x07")
+
+;; Strip CURSOR_MARKER from rendered output and return the
+;; clean string. The marker is zero-width, so stripping it
+;; doesn't affect layout.
+;; Returns (values clean-string (or/c #f (cons row col)))
+;; where row/col indicate where the marker was found (0-indexed).
+(define (strip-cursor-marker str)
+  (define m (regexp-match-positions (regexp-quote CURSOR-MARKER) str))
+  (if m
+      (let ([idx (caar m)])
+        (values (string-replace str CURSOR-MARKER "")
+                ;; Compute row/col from position before the marker
+                (let* ([before (substring str 0 idx)]
+                       [lines (if (string=? before "")
+                                  '("")
+                                  (string-split before "\n"))]
+                       [row (sub1 (length lines))]
+                       [col (string-length (last lines))])
+                  (cons row col))))
+      (values str #f)))

--- a/tui/tui-render-loop.rkt
+++ b/tui/tui-render-loop.rkt
@@ -58,6 +58,14 @@
     (collection-path "tui")
     #t))
 
+;; Minimum render interval in milliseconds.
+;; Coalesces rapid state changes (e.g., streaming) into single frames.
+;; 16ms ≈ 60fps, prevents flicker during fast streaming output.
+(define MIN-RENDER-INTERVAL-MS 16)
+
+;; Track last render timestamp for debouncing.
+(define last-render-ms (box 0.0))
+
 (define make-ubuf-fn
   (and tui-ubuf-available?
        (with-handlers ([exn:fail? (lambda (e) #f)])
@@ -188,6 +196,10 @@
           (tui-cursor 1 (+ (diff-cmd-row cmd) 1)) ; ANSI is 1-based
           (display "\x1b[2K" (current-output-port)) ; clear line
           (display (diff-cmd-content cmd) (current-output-port))]
+         [(clear-from)
+          ;; Clear from given row to end of screen
+          (tui-cursor 1 (+ (diff-cmd-row cmd) 1))
+          (display "\x1b[J" (current-output-port))]
          [else (void)]))
      (tui-flush)])
 
@@ -196,11 +208,12 @@
 
   ;; Position cursor at input location (renderer returns 0-indexed, ANSI is 1-indexed)
   (tui-cursor (+ cursor-col 1) (+ cursor-row 1))
-  ;; Emit IME cursor marker for CJK input support (Kitty/Ghostty/WezTerm)
-  (when (terminal-sync-available?)
-    (display "\x1b]1337;CursorMarker\x1b\\" (current-output-port)))
+  ;; Emit IME cursor marker for CJK input support
+  ;; Uses APC protocol — silently ignored by terminals that don't understand it
+  (display CURSOR-MARKER (current-output-port))
   (tui-cursor-show)
   (tui-flush)
+  (set-box! last-render-ms (current-inexact-milliseconds))
   (set-box! (tui-ctx-needs-redraw-box ctx) #f))
 
 ;; Deprecated: Old draw-frame is now an alias for render-frame!
@@ -253,9 +266,20 @@
       (tui-ctx-resize-ubuf! ctx)
       (mark-dirty! ctx))
 
-    ;; Draw the frame only when state changed
+    ;; Draw the frame only when state changed (with debouncing)
     (when (unbox (tui-ctx-needs-redraw-box ctx))
-      (render-frame! ctx))
+      (define now (current-inexact-milliseconds))
+      (define elapsed (- now (unbox last-render-ms)))
+      (cond
+        [(< elapsed MIN-RENDER-INTERVAL-MS)
+         ;; Too soon — sleep the remainder, then render
+         (sleep (/ (- MIN-RENDER-INTERVAL-MS elapsed) 1000.0))
+         ;; Re-check in case resize happened during sleep
+         (when (unbox (tui-ctx-needs-redraw-box ctx))
+           (render-frame! ctx))]
+        [else
+         ;; Enough time elapsed — render immediately
+         (render-frame! ctx)]))
 
     (when (unbox (tui-ctx-running-box ctx))
       ;; Get next message from terminal (adapter pattern)


### PR DESCRIPTION
## v0.8.7 Wave 1 — Core UX Fixes

Closes #464, Closes #465, Closes #466

### #464: APC CURSOR_MARKER for IME Support
- Replace iTerm2-specific ESC]1337;CursorMarker with APC protocol ESC_q:c BEL
- Zero-width marker silently ignored by terminals that don't understand it
- CJK-aware terminals use it for correct IME composition placement
- CURSOR-MARKER constant + strip-cursor-marker function for position extraction
- 7 new tests in tests/tui/test-cursor-marker.rkt

### #465: Render Debouncing (16ms Frame Cap)
- MIN-RENDER-INTERVAL-MS = 16 prevents flicker during streaming output
- Main loop sleeps remainder when elapsed < 16ms, then re-checks
- Tracks last-render-ms timestamp, updated on each render
- Resize bypasses debounce (immediate redraw)

### #466: Incremental Frame-Diff for Resize
- diff-frames now handles length mismatches incrementally (no more full redraw)
- Longer curr: diff common prefix + append write cmds
- Shorter curr: diff common prefix + clear-from cmd (ESC[J)
- render-frame! handles new clear-from diff type
- 3 new incremental diff tests

### Verification
- tests/tui/test-cursor-marker.rkt: 7 passed
- tests/tui/frame-diff.rkt: 12 passed
- tests/test-tui-render-loop.rkt: 18 passed
- tests/test-tui-renderer.rkt: 44 passed
- tests/test-terminal-input.rkt: 56 passed
- tests/test-arch-boundaries.rkt: 2 passed
- racket scripts/lint-format.rkt: PASSED
