### PR TITLE
fix(#482,#483,#484,#485): Wave 0 — frame-diff bug, theme wiring, width safety

### DIFF
--- a/tests/tui/render.rkt
+++ b/tests/tui/render.rkt
@@ -105,7 +105,7 @@
         ;; Two segments: cyan prompt + bold text
         (check-equal? (length segs) 2)
         (check-equal? (styled-segment-text (first segs)) "> ")
-        (check-equal? (styled-segment-style (first segs)) '(bold cyan))
+        (check-equal? (styled-segment-style (first segs)) '(bold cyan) "user prompt uses theme")
         (check-equal? (styled-segment-text (second segs)) "Hello!")
         (check-equal? (styled-segment-style (second segs)) '(bold))))
 
@@ -114,7 +114,9 @@
         (define lines (format-entry entry 80))
         (define seg (first (styled-line-segments (first lines))))
         (check-true (string-contains? (styled-segment-text seg) "[ERR]"))
-        (check-equal? (styled-segment-style seg) '(bold red) "error entry has bold red style")))
+        ;; Error uses theme->style 'error '(bold) which resolves to '(bold red)
+        (check-not-false (member 'red (styled-segment-style seg)) "error has red")
+        (check-not-false (member 'bold (styled-segment-style seg)) "error has bold")))
 
     ;; --------------------------------------------------------
     ;; render-status-bar and render-input-line
@@ -176,7 +178,9 @@
         (define lines (format-entry entry 80))
         (define segs (styled-line-segments (first lines)))
         (check-equal? (length segs) 3)
-        (check-equal? (styled-segment-style (second segs)) '(cyan))
+        ;; Inline code uses theme 'md-code → 'bright-green in default dark theme
+        (check-not-false (member 'bright-green (styled-segment-style (second segs)))
+                         "inline code uses theme md-code color")
         (check-equal? (styled-segment-text (second segs)) "foo")))
 
     (test-case "format-entry assistant header"
@@ -185,7 +189,9 @@
         (check-equal? (length lines) 1 "one line")
         (define segs (styled-line-segments (first lines)))
         (check-equal? (styled-segment-text (first segs)) "Title")
-        (check-equal? (styled-segment-style (first segs)) '(bold yellow))))
+        ;; Header uses theme 'md-heading → 'cyan in default dark theme
+        (check-not-false (member 'bold (styled-segment-style (first segs))) "header is bold")
+        (check-not-false (member 'cyan (styled-segment-style (first segs))) "header uses theme md-heading")))
 
     (test-case "format-entry assistant multi-line with newline"
       (let ([entry (make-entry 'assistant "line1\nline2" 1000 (hash))])
@@ -200,7 +206,9 @@
         ;; code-block line + trailing newline line
         (check-true (>= (length lines) 1) "at least one code line")
         (define code-segs (styled-line-segments (first lines)))
-        (check-equal? (styled-segment-style (first code-segs)) '(green))
+        ;; Code block uses theme 'md-code → 'bright-green in default dark theme
+        (check-not-false (member 'bright-green (styled-segment-style (first code-segs)))
+                         "code block uses theme md-code color")
         (check-true (string-contains? (styled-segment-text (first code-segs)) "code line"))))
 
     (test-case "format-entry assistant link uses blue underline"
@@ -212,8 +220,9 @@
         ;; Second segment is the link
         (define link-seg (second segs))
         (check-equal? (styled-segment-text link-seg) "here")
-        (check-not-false (member 'blue (styled-segment-style link-seg)) "link has blue")
-        (check-not-false (member 'underline (styled-segment-style link-seg)) "link has underline")))
+        ;; Link uses theme 'md-link → 'cyan in default dark theme
+        (check-not-false (member 'underline (styled-segment-style link-seg)) "link has underline")
+        (check-not-false (member 'cyan (styled-segment-style link-seg)) "link uses theme md-link color")))
 
     (test-case "format-entry tool-start shows [TOOL] text prefix and cyan color"
       (let ([entry (make-entry 'tool-start "[TOOL: read]" 1000 (hash))])
@@ -221,7 +230,8 @@
         (define seg (first (styled-line-segments (first lines))))
         (check-true (string-contains? (styled-segment-text seg) "[TOOL")
                     "tool-start text has [TOOL] prefix")
-        (check-equal? (styled-segment-style seg) '(cyan))))
+        ;; tool-start uses theme 'tool-title → 'cyan in default dark theme
+        (check-equal? (styled-segment-style seg) '(cyan) "tool-start uses theme")))
 
     (test-case "format-entry tool-end shows [OK] text prefix and green color"
       (let ([entry (make-entry 'tool-end "[OK: read]" 1000 (hash))])
@@ -229,7 +239,8 @@
         (define seg (first (styled-line-segments (first lines))))
         (check-true (string-contains? (styled-segment-text seg) "[OK")
                     "tool-end text has [OK] prefix")
-        (check-equal? (styled-segment-style seg) '(green))))
+        ;; tool-end uses theme 'success → 'green in default dark theme
+        (check-equal? (styled-segment-style seg) '(green) "tool-end uses theme")))
 
     (test-case "format-entry tool-fail shows [FAIL] text prefix and red color"
       (let ([entry (make-entry 'tool-fail "[FAIL: read]" 1000 (hash))])
@@ -237,14 +248,16 @@
         (define seg (first (styled-line-segments (first lines))))
         (check-true (string-contains? (styled-segment-text seg) "[FAIL")
                     "tool-fail text has [FAIL] prefix")
-        (check-equal? (styled-segment-style seg) '(red))))
+        ;; tool-fail uses theme 'error → 'red in default dark theme
+        (check-equal? (styled-segment-style seg) '(red) "tool-fail uses theme")))
 
     (test-case "format-entry system shows [SYS] prefix"
       (let ([entry (make-entry 'system "Session started" 1000 (hash))])
         (define lines (format-entry entry 80))
         (define seg (first (styled-line-segments (first lines))))
         (check-true (string-contains? (styled-segment-text seg) "[SYS]"))
-        (check-equal? (styled-segment-style seg) '(dim))))
+        ;; System uses theme 'muted → 'bright-black in default dark theme
+        (check-equal? (styled-segment-style seg) '(bright-black) "system uses theme muted")))
 
     ;; --------------------------------------------------------
     ;; Line-based viewport slicing (render-transcript)
@@ -321,7 +334,8 @@
         ;; Last line should be the streaming text (dim)
         (define last-seg (first (styled-line-segments (last lines))))
         (check-equal? (styled-segment-text last-seg) "streaming...")
-        (check-equal? (styled-segment-style last-seg) '(dim))))))
+        ;; Streaming text uses theme 'muted → 'bright-black in default dark theme
+        (check-equal? (styled-segment-style last-seg) '(bright-black) "streaming uses theme muted")))))
 
 (run-tests render-tests)
 
@@ -514,8 +528,8 @@
         ;; None of the code lines should be wrapped
         ;; (they may exceed terminal width but that's handled by draw-styled-line!)
         (check-not-false
-         (member 'green (apply append (map styled-segment-style (styled-line-segments line))))
-         (format "code line '~a' should be green" line-text))))
+         (member 'bright-green (apply append (map styled-segment-style (styled-line-segments line))))
+         (format "code line '~a' should be bright-green (theme md-code)" line-text))))
 
     (test-case "md-format-assistant does NOT wrap headers"
       (define header-text (string-append "# " (make-string 200 #\h)))

--- a/tui/frame-diff.rkt
+++ b/tui/frame-diff.rkt
@@ -60,10 +60,10 @@
        ;; Current is shorter — diff common prefix, clear surplus
        [else
         (define common-diffs
-          (for/list ([p (in-list curr)]
+          (for/list ([p (in-list prev)]
                      [c (in-list curr)]
                      [i (in-naturals)]
-                     #:when (not (string=? (list-ref prev i) c)))
+                     #:when (not (string=? p c)))
             (diff-cmd 'write i c)))
         ;; Clear rows from curr-len to prev-len-1
         (define cleared

--- a/tui/render.rkt
+++ b/tui/render.rkt
@@ -6,6 +6,7 @@
          "state.rkt"
          "input.rkt"
          "char-width.rkt"
+         "theme.rkt"
          "../util/markdown.rkt")
 
 ;; Types
@@ -55,6 +56,16 @@
 (define (plain-line text)
   (styled-line (list (styled-segment text '()))))
 
+;; Resolve a theme field to a style list for styled-segment.
+;; Returns a list of symbols suitable for the style field.
+;; For example: (theme->style 'accent) => '(cyan)
+;;              (theme->style 'accent '(bold)) => '(bold cyan)
+(define (theme->style field [modifiers '()])
+  (define color (theme-ref field))
+  (if color
+      (append modifiers (list color))
+      modifiers))
+
 ;; Format a transcript entry into styled lines
 (define (format-entry entry [width 200])
   ;; Returns (listof styled-line) — usually 1 line, but could be multi-line
@@ -63,14 +74,14 @@
   (case kind
     ;; Parse markdown and render as styled-lines
     [(assistant) (md-format-assistant text width)]
-    [(tool-start) (list (styled-line (list (styled-segment text '(cyan)))))]
-    [(tool-end) (list (styled-line (list (styled-segment text '(green)))))]
-    [(tool-fail) (list (styled-line (list (styled-segment text '(red)))))]
-    [(system) (list (styled-line (list (styled-segment (string-append "[SYS] " text) '(dim)))))]
-    [(error) (list (styled-line (list (styled-segment (string-append "[ERR] " text) '(bold red)))))]
+    [(tool-start) (list (styled-line (list (styled-segment text (theme->style 'tool-title)))))]
+    [(tool-end) (list (styled-line (list (styled-segment text (theme->style 'success)))))]
+    [(tool-fail) (list (styled-line (list (styled-segment text (theme->style 'error)))))]
+    [(system) (list (styled-line (list (styled-segment (string-append "[SYS] " text) (theme->style 'muted)))))]
+    [(error) (list (styled-line (list (styled-segment (string-append "[ERR] " text) (theme->style 'error '(bold))))))]
     [(user)
-     ;; Split into cyan prompt + bold text, like pi's user message styling
-     (list (styled-line (list (styled-segment "> " '(bold cyan)) (styled-segment text '(bold)))))]
+     ;; Split into themed prompt + bold text
+     (list (styled-line (list (styled-segment "> " (theme->style 'input-prompt '(bold))) (styled-segment text '(bold)))))]
     [else (list (plain-line text))]))
 
 ;; Convert a single md-token to a styled-segment
@@ -83,8 +94,8 @@
     [(text) (styled-segment content '())]
     [(bold) (styled-segment content '(bold))]
     [(italic) (styled-segment content '(italic))]
-    [(code) (styled-segment content '(cyan))]
-    [(link) (styled-segment (cdr content) '(blue underline))]
+    [(code) (styled-segment content (theme->style 'md-code))]
+    [(link) (styled-segment (cdr content) (theme->style 'md-link '(underline)))]
     [else (styled-segment (format "~a" content) '())]))
 
 ;; Extract plain text from a styled-line (local helper)
@@ -196,14 +207,14 @@
          (define code (cdr (md-token-content tok)))
          (define code-lines
            (for/list ([line (string-split code "\n" #:trim? #f)])
-             (styled-line (list (styled-segment (string-append "  " line) '(green))))))
+             (styled-line (list (styled-segment (string-append "  " line) (theme->style 'md-code))))))
          (values (append prev-lines code-lines) '())]
         [(header)
          (define prev-lines (flush-current lines current-segs))
          (define header-text (cdr (md-token-content tok)))
-         ;; Gold/yellow like pi's mdHeading
+         ;; Heading uses md-heading theme color
          (values (append prev-lines
-                         (list (styled-line (list (styled-segment header-text '(bold yellow))))))
+                         (list (styled-line (list (styled-segment header-text (theme->style 'md-heading '(bold)))))))
                  '())]
         [else
          ;; Inline token — accumulate segments
@@ -367,7 +378,7 @@
     (if (and streaming (not (string=? streaming "")))
         (append formatted-lines
                 (for/list ([line (in-list (wrap-text streaming width))])
-                  (styled-line (list (styled-segment line '(dim))))))
+                  (styled-line (list (styled-segment line (theme->style 'muted))))))
         formatted-lines))
   (define total (length all-lines))
   (define sliced-lines
@@ -398,13 +409,13 @@
   (styled-line (list (styled-segment padded '(inverse)))))
 
 ;; Render the input line
-;; Returns styled-line with cyan prompt + bold text
+;; Returns styled-line with themed prompt + bold text
 ;; Returns styled-line
 (define (render-input-line input-st width)
   (define-values (visible-text scroll-offset cursor-col) (input-visible-window input-st width))
   (define prompt-str "q> ")
   (define pad-len (max 0 (- width (string-visible-width prompt-str) (string-visible-width visible-text))))
-  (styled-line (list (styled-segment prompt-str '(bold cyan))
+  (styled-line (list (styled-segment prompt-str (theme->style 'input-prompt '(bold)))
                      (styled-segment (string-append visible-text (make-string pad-len #\space))
                                      '(bold)))))
 
@@ -424,8 +435,8 @@
       (define line-text (format "~a~a. ~a (~a)~a" prefix i id role-str leaf-indicator))
       (define style
         (if (branch-info-active? b)
-            '(bold green)
-            '(dim)))
+            (theme->style 'success '(bold))
+            (theme->style 'muted)))
       (styled-line (list (styled-segment line-text style)))))
   (cons header branch-lines))
 
@@ -445,8 +456,8 @@
       (define line-text (format "~a~a. ~a (~a)" prefix i id role-str))
       (define style
         (if (branch-info-active? b)
-            '(bold green)
-            '(dim)))
+            (theme->style 'success '(bold))
+            (theme->style 'muted)))
       (styled-line (list (styled-segment line-text style)))))
   (cons header leaf-lines))
 
@@ -457,7 +468,7 @@
     (styled-line (list (styled-segment (format "  Children of ~a (~a):" parent-id (length children))
                                        '(bold underline)))))
   (if (null? children)
-      (list header (styled-line (list (styled-segment "    (no children)" '(dim)))))
+      (list header (styled-line (list (styled-segment "    (no children)" (theme->style 'muted)))))
       (cons header
             (for/list ([b (in-list children)]
                        [i (in-naturals 1)])
@@ -465,4 +476,4 @@
               (define role-str (symbol->string (branch-info-role b)))
               (define leaf-indicator (if (branch-info-leaf? b) " [leaf]" ""))
               (define line-text (format "    ~a. ~a (~a)~a" i id role-str leaf-indicator))
-              (styled-line (list (styled-segment line-text '(dim))))))))
+              (styled-line (list (styled-segment line-text (theme->style 'muted))))))))

--- a/tui/renderer.rkt
+++ b/tui/renderer.rkt
@@ -252,16 +252,20 @@
     (vector-set! frame-vec (+ trans-y i) blank))
   (for ([line (in-list visible-lines)]
         [i (in-naturals)])
+    (define line-ansi (styled-line->ansi line))
+    (assert-line-width! (styled-line->text line) cols)
     (draw-styled-line! ubuf line (+ trans-y pad-count i) cols)
-    (vector-set! frame-vec (+ trans-y pad-count i) (styled-line->ansi line)))
+    (vector-set! frame-vec (+ trans-y pad-count i) line-ansi))
 
   ;; 4. Draw status bar (inverse = fg=0, bg=7)
   (define status-line (render-status-bar ui-state cols))
+  (assert-line-width! (styled-line->text status-line) cols)
   (draw-styled-line! ubuf status-line status-y cols)
   (vector-set! frame-vec status-y (styled-line->ansi status-line))
 
   ;; 5. Draw input line
   (define input-line (render-input-line input-st cols))
+  (assert-line-width! (styled-line->text input-line) cols)
   (draw-styled-line! ubuf input-line input-y cols)
   (vector-set! frame-vec input-y (styled-line->ansi input-line))
 


### PR DESCRIPTION
## Wave 0: v0.8.7 Review Fixes

Close all findings from the post-v0.8.7 review before building new features.

### Changes
- **#482**: Fix `frame-diff.rkt` — shorter-frame branch iterated `curr` instead of `prev`
- **#483**: Wire theme tokens into `render.rkt` — replace all 15+ hardcoded color symbols with `theme->style` lookups
- **#484**: Wire `assert-line-width!` into production render pipeline (transcript, status, input lines)
- **#485**: Tests updated for theme-resolved color values

### Testing
- All 614 TUI tests pass
- Format lint green
- Zero hardcoded color symbols remain in render.rkt

Fixes: #482, #483, #484
Refs: #481