### PR TITLE
fix(#487,#488): Wave 1 — bright-color ANSI support + style-only diff detection

### DIFF
--- a/tests/test-tui-renderer.rkt
+++ b/tests/test-tui-renderer.rkt
@@ -151,6 +151,26 @@
       (check-not-false (member '#:fg kws) "fg present")
       (check-equal? (list-ref vals (index-of kws '#:fg)) 1 "red fg=1"))
 
+    (test-case "style->ubuf-kws converts bright-black to fg=8"
+      (define-values (kws vals) (style->ubuf-kws '(bright-black)))
+      (check-not-false (member '#:fg kws) "fg keyword present")
+      (check-equal? (list-ref vals (index-of kws '#:fg)) 8 "bright-black fg=8"))
+
+    (test-case "style->ubuf-kws converts bright-green to fg=10"
+      (define-values (kws vals) (style->ubuf-kws '(bright-green)))
+      (check-not-false (member '#:fg kws) "fg keyword present")
+      (check-equal? (list-ref vals (index-of kws '#:fg)) 10 "bright-green fg=10"))
+
+    (test-case "style->ubuf-kws converts bright-white to fg=15"
+      (define-values (kws vals) (style->ubuf-kws '(bright-white)))
+      (check-not-false (member '#:fg kws) "fg keyword present")
+      (check-equal? (list-ref vals (index-of kws '#:fg)) 15 "bright-white fg=15"))
+
+    (test-case "style->ubuf-kws bright-blue overrides dim"
+      (define-values (kws vals) (style->ubuf-kws '(dim bright-blue)))
+      (check-not-false (member '#:fg kws) "fg keyword present")
+      (check-equal? (list-ref vals (index-of kws '#:fg)) 12 "bright-blue fg=12 (overrides dim 8)"))
+
     (test-case "style->ubuf-kws handles empty style list"
       (define-values (kws vals) (style->ubuf-kws '()))
       (check-equal? kws '() "empty styles → no keywords")

--- a/tests/tui/frame-diff.rkt
+++ b/tests/tui/frame-diff.rkt
@@ -76,3 +76,27 @@
                     (diff-cmd 'write 4 "e")
                     (diff-cmd 'write 5 "f"))
               "grow by multiple lines yields all writes")
+
+;; ──────────────────────────────
+;; ANSI content in frames (#488)
+;; ──────────────────────────────
+
+;; Style-only changes: same text, different ANSI codes → detected as changed
+(define ansi-frame-a '("\x1b[1;31merror\x1b[0m" "plain" "\x1b[36minfo\x1b[0m"))
+(define ansi-frame-b '("\x1b[1;32merror\x1b[0m" "plain" "\x1b[36minfo\x1b[0m"))
+
+(check-equal? (diff-frames ansi-frame-a ansi-frame-b)
+              (list (diff-cmd 'write 0 "\x1b[1;32merror\x1b[0m"))
+              "style-only change detected (red→green)")
+
+;; ANSI frames identical → no diff
+(check-equal? (diff-frames ansi-frame-a ansi-frame-a)
+              '()
+              "identical ANSI frames yield no diff")
+
+;; Bright-color ANSI content
+(define ansi-bright '("\x1b[90mmuted\x1b[0m"))
+(define ansi-plain '("muted"))
+(check-equal? (diff-frames ansi-bright ansi-plain)
+              (list (diff-cmd 'write 0 "muted"))
+              "bright-color ANSI vs plain text detected")

--- a/tests/tui/render.rkt
+++ b/tests/tui/render.rkt
@@ -668,6 +668,20 @@
       (check-equal? (styles->sgr '()) ""))
 
     (test-case "styles->sgr: bold cyan"
-      (check-equal? (styles->sgr '(bold cyan)) "\x1b[1;36m"))))
+      (check-equal? (styles->sgr '(bold cyan)) "\x1b[1;36m"))
+
+    ;; Bright color support (SGR 90-97)
+    (test-case "styles->sgr: bright-black"
+      (check-equal? (styles->sgr '(bright-black)) "\x1b[90m"))
+
+    (test-case "styles->sgr: bright-green"
+      (check-equal? (styles->sgr '(bright-green)) "\x1b[92m"))
+
+    (test-case "styles->sgr: bold bright-white"
+      (check-equal? (styles->sgr '(bold bright-white)) "\x1b[1;97m"))
+
+    (test-case "styled-line->ansi: bright color segment"
+      (define sl (styled-line (list (styled-segment "muted text" '(bright-black)))))
+      (check-equal? (styled-line->ansi sl) "\x1b[90mmuted text\x1b[0m"))))
 
 (run-tests cjk-wrapping-tests)

--- a/tui/render.rkt
+++ b/tui/render.rkt
@@ -132,6 +132,9 @@
         [(dim) 2]
         [(black) 30] [(red) 31] [(green) 32] [(yellow) 33]
         [(blue) 34] [(magenta) 35] [(cyan) 36] [(white) 37]
+        [(bright-black) 90] [(bright-red) 91] [(bright-green) 92]
+        [(bright-yellow) 93] [(bright-blue) 94] [(bright-magenta) 95]
+        [(bright-cyan) 96] [(bright-white) 97]
         [else #f])))
   (define valid (filter values codes))
   (if (null? valid)

--- a/tui/renderer.rkt
+++ b/tui/renderer.rkt
@@ -133,6 +133,15 @@
       [(magenta) (set! fg-color 5)]
       [(cyan) (set! fg-color 6)]
       [(white) (set! fg-color 7)]
+      ;; Bright colors use 8-bit: 8=bright-black, 9=bright-red, etc.
+      [(bright-black) (set! fg-color 8)]
+      [(bright-red) (set! fg-color 9)]
+      [(bright-green) (set! fg-color 10)]
+      [(bright-yellow) (set! fg-color 11)]
+      [(bright-blue) (set! fg-color 12)]
+      [(bright-magenta) (set! fg-color 13)]
+      [(bright-cyan) (set! fg-color 14)]
+      [(bright-white) (set! fg-color 15)]
       [else (void)]))
   ;; Collect kw/val pairs — only include non-defaults
   (define pairs '())


### PR DESCRIPTION
## Wave 1: Incremental Diff Correctness

Fix the rendering pipeline to preserve ANSI styling on partial updates.

### Changes
- **#487**: Frame vector already stores ANSI strings (verified) — no change needed
- **#488**: Added bright-color (SGR 90-97) support to `styles->sgr` and `style->ubuf-kws`
  - Theme tokens like `bright-black`, `bright-green` now produce correct ANSI codes
  - Previously silently dropped by the `else #f` / `else (void)` fallbacks

### Testing
- All 565 TUI tests pass
- New tests: bright-color SGR, bright-color ubuf keywords, ANSI frame-diff detection
- Format lint green

Fixes: #487, #488
Refs: #486