### PR TITLE
feat(#496-#500): Wave 3 — Session Tree Foundation

### DIFF
--- a/runtime/context-builder.rkt
+++ b/runtime/context-builder.rkt
@@ -1,0 +1,117 @@
+#lang racket/base
+
+;; q/runtime/context-builder.rkt — Context assembly from session tree
+;;
+;; Walks the session tree from active leaf to root, handling
+;; compaction summaries, branch summaries, and settings entries.
+;; Returns a provider-ready message list for LLM consumption.
+;;
+;; Issue #498: Context assembly pipeline (tree walk).
+
+(require racket/list
+         "../util/protocol-types.rkt"
+         "../runtime/session-index.rkt")
+
+(provide build-session-context
+         entry->context-message)
+
+;; ============================================================
+;; Context assembly pipeline (#498)
+;; ============================================================
+
+(define (build-session-context idx)
+  ;; Build a provider-ready message list from the session index.
+  ;; Algorithm:
+  ;;   1. Get active leaf from index
+  ;;   2. Walk leaf→root collecting path entries
+  ;;   3. Find latest compaction-summary on path
+  ;;   4. If compaction found → include summary + messages after compaction point
+  ;;   5. If no compaction → include all path messages
+  ;;   6. Filter out settings/label/bookmark entries
+  ;;   7. Transform summaries to user-role messages
+  ;;   8. Return provider-ready message list (reversed to root→leaf order)
+  ;;
+  ;; Returns (listof message?) suitable for LLM provider consumption.
+  (define leaf (active-leaf idx))
+  (cond
+    [(not leaf) '()]
+    [else
+     (define path (get-branch idx (message-id leaf)))
+     (cond
+       [(not path) '()]
+       [else
+        ;; path is root→leaf order from get-branch
+        (assemble-context path)])]))
+
+(define (assemble-context path)
+  ;; Process a root→leaf path into context messages.
+  ;; Handles compaction summaries and entry type filtering.
+  (define-values (pre-compaction post-compaction)
+    (split-at-compaction path))
+  (define relevant-entries
+    (if post-compaction
+        ;; Include compaction summary + everything after it
+        post-compaction
+        ;; No compaction — use full path
+        path))
+  ;; Filter and transform entries
+  (filter-map entry->context-message relevant-entries))
+
+(define (split-at-compaction path)
+  ;; Split path at the last compaction summary.
+  ;; Returns (values pre-compaction post-compaction).
+  ;; post-compaction includes the compaction summary itself.
+  ;; If no compaction found, returns (values path #f).
+  (define compaction-idx
+    (for/last ([entry (in-list path)]
+               [i (in-naturals)]
+               #:when (compaction-summary-entry? entry))
+      i))
+  (cond
+    [(not compaction-idx) (values path #f)]
+    [else
+     (define-values (pre post) (split-at path compaction-idx))
+     (values pre post)]))
+
+(define (entry->context-message entry)
+  ;; Convert a session entry to a context message for LLM consumption.
+  ;; Returns a message or #f if the entry should be excluded.
+  (define kind (message-kind entry))
+  (cond
+    ;; Standard messages pass through
+    [(memq kind '(message))
+     entry]
+    ;; Compaction summaries become user-role messages
+    [(eq? kind 'compaction-summary)
+     (transform-summary-to-user entry)]
+    ;; Branch summaries become user-role messages
+    [(eq? kind 'branch-summary)
+     (transform-summary-to-user entry)]
+    ;; Filter out metadata entries
+    [(memq kind '(session-info model-change thinking-level-change))
+     #f]
+    ;; Tool results pass through
+    [(eq? kind 'tool-result)
+     entry]
+    ;; System instructions pass through
+    [(eq? kind 'system-instruction)
+     entry]
+    ;; Custom messages pass through
+    [(eq? kind 'custom-message)
+     entry]
+    ;; Unknown kinds pass through (backward compatibility)
+    [else entry]))
+
+(define (transform-summary-to-user entry)
+  ;; Transform a summary entry into a user-role message for context.
+  (struct-copy message entry
+               [role 'user]))
+
+;; ============================================================
+;; Utility
+;; ============================================================
+
+(define (filter-map f lst)
+  (for/list ([x (in-list lst)]
+             #:when (f x))
+    (f x)))

--- a/runtime/session-index.rkt
+++ b/runtime/session-index.rkt
@@ -41,6 +41,12 @@
          active-leaf
          switch-leaf!
          mark-active-leaf!
+         ;; Tree operations (#496)
+         get-branch
+         branch!
+         reset-leaf!
+         append-to-leaf!
+         leaf-depth
          ;; Bookmark API
          bookmark?
          bookmark-id
@@ -223,6 +229,77 @@
       (begin
         (set-box! (session-index-active-leaf-id idx) entry-id)
         entry-id)
+      #f))
+
+;; ============================================================
+;; Tree operations (#496)
+;; ============================================================
+
+(define (get-branch idx entry-id)
+  ;; Walk entry→root, returning the path as a list of messages.
+  ;; The root is first, the given entry is last.
+  ;; Returns #f if entry-id is not found.
+  (define (walk-up id acc)
+    (define entry (lookup-entry idx id))
+    (cond
+      [(not entry) #f]
+      [else
+       (define new-acc (cons entry acc))
+       (define pid (message-parent-id entry))
+       (if pid
+           (walk-up pid new-acc)
+           new-acc)]))
+  (walk-up entry-id '()))
+
+(define (branch! idx entry-id)
+  ;; Move active leaf to the given entry-id.
+  ;; Returns the entry on success, #f if not found.
+  (define entry (lookup-entry idx entry-id))
+  (cond
+    [(not entry) #f]
+    [else
+     (set-box! (session-index-active-leaf-id idx) entry-id)
+     entry]))
+
+(define (reset-leaf! idx)
+  ;; Set active leaf to #f (use latest entry as default).
+  (set-box! (session-index-active-leaf-id idx) #f)
+  (void))
+
+(define (append-to-leaf! idx entry)
+  ;; Create child of active leaf, advance leaf pointer.
+  ;; Adds entry to the index and updates parent-child map.
+  ;; Returns the entry on success.
+  (define parent (active-leaf idx))
+  (define parent-id (if parent (message-id parent) #f))
+  ;; Update entry's parent-id to match
+  (define fixed-entry
+    (if (and parent-id (not (message-parent-id entry)))
+        (struct-copy message entry [parent-id parent-id])
+        entry))
+  ;; Add to by-id
+  (hash-set! (session-index-by-id idx) (message-id fixed-entry) fixed-entry)
+  ;; Add to children of parent
+  (when parent-id
+    (hash-update! (session-index-children idx)
+                  parent-id
+                  (lambda (lst) (append lst (list fixed-entry)))))
+  ;; Initialize own children list
+  (hash-set! (session-index-children idx) (message-id fixed-entry) '())
+  ;; Append to entry-order vector — use vector->list, append, list->vector
+  ;; through the by-id and children hashes (which ARE mutable)
+  ;; Note: entry-order is immutable, so we create a new vector.
+  ;; For session-index, callers should rebuild the index after bulk operations.
+  ;; For single appends, the entry-order vector is best-effort (in-memory only).
+  (set-box! (session-index-active-leaf-id idx) (message-id fixed-entry))
+  fixed-entry)
+
+(define (leaf-depth idx entry-id)
+  ;; Depth from root to given entry (root = 0).
+  ;; Returns #f if entry-id is not found.
+  (define path (get-branch idx entry-id))
+  (if path
+      (sub1 (length path))
       #f))
 
 ;; ============================================================

--- a/runtime/session-store.rkt
+++ b/runtime/session-store.rkt
@@ -35,7 +35,14 @@
   [verify-session-integrity (path-string? . -> . hash?)]
   [repair-session-log!      (path-string? . -> . hash?)]
   [has-pending-marker?      (path-string? . -> . boolean?)]
-  [pending-marker-path      (path-string? . -> . path?)]))
+  [pending-marker-path      (path-string? . -> . path?)])
+ ;; Session versioning (#499)
+ CURRENT-SESSION-VERSION
+ write-session-version-header!
+ ensure-session-version-header!
+ migrate-session-log!
+ ;; Session forking (#500)
+ fork-session!)
 
 ;; ── Write-ahead marker ──
 
@@ -309,3 +316,134 @@
                 (or bak-path "N/A")))
 
      (hasheq 'entries-kept (length valid-entries) 'entries-removed removed)]))
+
+;; ============================================================
+;; Session versioning (#499)
+;; ============================================================
+
+;; Current session log format version.
+;; Version 1: original format (no version header).
+;; Version 2: version header as first entry (kind=session-info, meta.version=2).
+(define CURRENT-SESSION-VERSION 2)
+
+;; ============================================================
+;; Session forking (#500)
+;; ============================================================
+
+(define (fork-session! source-path source-entry-id dest-path)
+  ;; Extract root→entry path from source session to a new JSONL file.
+  ;; The new session starts with a version header and all entries from
+  ;; the extracted path. Original session is unchanged.
+  ;; Returns the number of entries copied.
+  ;;
+  ;; source-path: path to source session JSONL
+  ;; source-entry-id: id of the entry to fork at (inclusive)
+  ;; dest-path: path for the new forked session JSONL
+  (define entries (load-session-log source-path))
+  ;; Build by-id map
+  (define by-id (make-hash))
+  (for ([e (in-list entries)])
+    (hash-set! by-id (message-id e) e))
+  ;; Walk from entry to root
+  (define (walk-up id acc)
+    (define e (hash-ref by-id id #f))
+    (cond
+      [(not e) acc]
+      [else
+       (define new-acc (cons e acc))
+       (define pid (message-parent-id e))
+       (if pid
+           (walk-up pid new-acc)
+           new-acc)]))
+  (define path-entries (walk-up source-entry-id '()))
+  ;; Write version header + path entries to dest
+  (ensure-parent-dirs* dest-path)
+  (define header-msg
+    (make-message (format "session-version-header")
+                  #f
+                  'system
+                  'session-info
+                  '()
+                  (current-seconds)
+                  (hasheq 'version CURRENT-SESSION-VERSION
+                          'parentSession (path->string source-path))))
+  (define all-entries (cons header-msg path-entries))
+  ;; Write dest file
+  (jsonl-append-entries! dest-path (map message->jsexpr all-entries))
+  ;; Return count (excluding header)
+  (length path-entries))
+
+(define (write-session-version-header! log-path)
+  ;; Write a version header entry as the first line of a new session log.
+  ;; Only writes if the file doesn't exist or is empty.
+  (ensure-parent-dirs* log-path)
+  (cond
+    [(and (file-exists? log-path)
+          (> (file-size log-path) 0))
+     (void)] ;; Already has content — don't prepend
+    [else
+     (define header-msg
+       (make-message (format "session-version-header")
+                     #f
+                     'system
+                     'session-info
+                     '()
+                     (current-seconds)
+                     (hasheq 'version CURRENT-SESSION-VERSION)))
+     ;; Write directly (don't use append-entry! to avoid marker overhead)
+     (call-with-output-file log-path
+                            (lambda (out)
+                              (write-json (message->jsexpr header-msg) out)
+                              (newline out))
+                            #:mode 'text
+                            #:exists 'truncate)]))
+
+(define (ensure-session-version-header! log-path)
+  ;; Check if session log has a version header; add one if not.
+  ;; Returns the detected version number.
+  (cond
+    [(not (file-exists? log-path))
+     (write-session-version-header! log-path)
+     CURRENT-SESSION-VERSION]
+    [(= (file-size log-path) 0)
+     (write-session-version-header! log-path)
+     CURRENT-SESSION-VERSION]
+    [else
+     ;; Check first line for version header
+     (define entries (load-session-log log-path))
+     (cond
+       [(null? entries)
+        (write-session-version-header! log-path)
+        CURRENT-SESSION-VERSION]
+       [(session-info-entry? (car entries))
+        (hash-ref (message-meta (car entries)) 'version 1)]
+       [else
+        ;; Old format (v1) — no version header. Run migration.
+        (migrate-session-log! log-path 1 CURRENT-SESSION-VERSION)
+        CURRENT-SESSION-VERSION])]))
+
+(define (migrate-session-log! log-path from-version to-version)
+  ;; Migrate session log from one version to another.
+  ;; Currently only supports 1->2 (add version header).
+  (when (< from-version to-version)
+    (define entries (load-session-log log-path))
+    (define header-msg
+      (make-message (format "session-version-header")
+                    #f
+                    'system
+                    'session-info
+                    '()
+                    (current-seconds)
+                    (hasheq 'version to-version)))
+    ;; Rewrite with header prepended
+    (define all-entries (cons header-msg entries))
+    ;; Backup original
+    (define bak-path (format "~a.v~a.bak" log-path from-version))
+    (when (file-exists? bak-path)
+      (delete-file bak-path))
+    (rename-file-or-directory log-path bak-path #t)
+    ;; Write new version
+    (jsonl-append-entries! log-path (map message->jsexpr all-entries))
+    (fprintf (current-error-port)
+             "Session migrated v~a -> v~a: ~a entries. Backup: ~a\n"
+             from-version to-version (length entries) bak-path)))

--- a/tests/test-context-builder.rkt
+++ b/tests/test-context-builder.rkt
@@ -1,0 +1,121 @@
+#lang racket
+
+;; tests/test-context-builder.rkt — Tests for runtime/context-builder.rkt (#498)
+
+(require rackunit
+         rackunit/text-ui
+         racket/file
+         racket/list
+         "../util/protocol-types.rkt"
+         "../runtime/session-store.rkt"
+         "../runtime/session-index.rkt"
+         "../runtime/context-builder.rkt")
+
+;; Helpers
+(define (make-temp-dir)
+  (make-temporary-file "q-ctx-test-~a" 'directory))
+
+(define (session-path dir)
+  (build-path dir "session.jsonl"))
+
+(define (index-path dir)
+  (build-path dir "session.index"))
+
+(define (make-timestamped-message id parent-id role kind ts)
+  (make-message id parent-id role kind
+                (list (make-text-part (format "~a-entry" id)))
+                ts (hasheq)))
+
+(define context-builder-tests
+  (test-suite
+   "context-builder"
+
+   ;; Build index from a simple linear session and extract context
+   (test-case "build-session-context: linear path"
+     (define dir (make-temp-dir))
+     (define sp (session-path dir))
+     (define ip (index-path dir))
+     (define entries
+       (list (make-timestamped-message "root" #f 'user 'message 1000)
+             (make-timestamped-message "c1" "root" 'assistant 'message 1001)
+             (make-timestamped-message "c2" "c1" 'user 'message 1002)))
+     (append-entries! sp entries)
+     (define idx (build-index! sp ip))
+     (define ctx (build-session-context idx))
+     ;; All 3 entries should be in context (message entries pass through)
+     (check-equal? (length ctx) 3)
+     (check-equal? (message-id (first ctx)) "root")
+     (check-equal? (message-id (last ctx)) "c2")
+     (delete-directory/files dir #:must-exist? #f))
+
+   ;; Compaction summary truncates earlier messages
+   (test-case "build-session-context: compaction truncates early entries"
+     (define dir (make-temp-dir))
+     (define sp (session-path dir))
+     (define ip (index-path dir))
+     (define entries
+       (list (make-timestamped-message "root" #f 'user 'message 1000)
+             (make-timestamped-message "c1" "root" 'assistant 'message 1001)
+             (make-message "compact1" #f 'system 'compaction-summary
+                           (list (make-text-part "summary"))
+                           1002 (hasheq))
+             (make-timestamped-message "c2" "compact1" 'user 'message 1003)))
+     (append-entries! sp entries)
+     (define idx (build-index! sp ip))
+     (define ctx (build-session-context idx))
+     ;; Compaction summary + c2 (root and c1 are before compaction)
+     (check-equal? (length ctx) 2)
+     ;; Compaction summary becomes user-role
+     (check-equal? (message-role (first ctx)) 'user)
+     (check-equal? (message-id (last ctx)) "c2")
+     (delete-directory/files dir #:must-exist? #f))
+
+   ;; Session-info entries are filtered out
+   (test-case "build-session-context: filters session-info entries"
+     (define dir (make-temp-dir))
+     (define sp (session-path dir))
+     (define ip (index-path dir))
+     (define entries
+       (list (make-message "info1" #f 'system 'session-info '() 1000
+                           (hasheq 'version 2))
+             (make-timestamped-message "root" "info1" 'user 'message 1001)))
+     (append-entries! sp entries)
+     (define idx (build-index! sp ip))
+     (define ctx (build-session-context idx))
+     (check-equal? (length ctx) 1)
+     (check-equal? (message-id (first ctx)) "root")
+     (delete-directory/files dir #:must-exist? #f))
+
+   ;; Empty session returns empty context
+   (test-case "build-session-context: empty session"
+     (define dir (make-temp-dir))
+     (define sp (session-path dir))
+     (define ip (index-path dir))
+     ;; Don't write any entries
+     (define idx (build-index! sp ip))
+     (define ctx (build-session-context idx))
+     (check-equal? ctx '())
+     (delete-directory/files dir #:must-exist? #f))
+
+   ;; Branched session with branch! switch
+   (test-case "build-session-context: branched path"
+     (define dir (make-temp-dir))
+     (define sp (session-path dir))
+     (define ip (index-path dir))
+     (define entries
+       (list (make-timestamped-message "root" #f 'user 'message 1000)
+             (make-timestamped-message "c1" "root" 'assistant 'message 1001)
+             (make-timestamped-message "c2" "root" 'assistant 'message 1002)
+             (make-timestamped-message "c1a" "c1" 'user 'message 1003)))
+     (append-entries! sp entries)
+     (define idx (build-index! sp ip))
+     ;; Switch to c1a branch (root -> c1 -> c1a)
+     (branch! idx "c1a")
+     (define ctx (build-session-context idx))
+     (check-equal? (length ctx) 3)
+     (check-equal? (message-id (first ctx)) "root")
+     (check-equal? (message-id (last ctx)) "c1a")
+     (delete-directory/files dir #:must-exist? #f))
+   ))
+
+(run-tests context-builder-tests)

--- a/tests/test-session-store.rkt
+++ b/tests/test-session-store.rkt
@@ -5,8 +5,10 @@
 (require rackunit
          rackunit/text-ui
          racket/file
+         racket/list
          "../util/protocol-types.rkt"
-         "../runtime/session-store.rkt")
+         "../runtime/session-store.rkt"
+         "../runtime/session-index.rkt")
 
 ;; ── Helpers ──
 
@@ -587,6 +589,187 @@
                            (make-timestamped-message "id2" "id1" 'assistant 'message 1000)))
     (define report (verify-session-integrity path))
     (check-true (hash-ref report 'entry-order-valid?))
+    (delete-directory/files dir #:must-exist? #f))
+
+  ;; ============================================================
+  ;; Tree operations (#496)
+  ;; ============================================================
+
+  (test-case "get-branch: walks entry to root"
+    (define dir (make-temp-dir))
+    (define path (session-path dir))
+    (define idx-path (build-path dir "session.index"))
+    (define entries
+      (list (make-timestamped-message "root" #f 'user 'message 1000)
+            (make-timestamped-message "child1" "root" 'assistant 'message 1001)
+            (make-timestamped-message "child2" "child1" 'user 'message 1002)))
+    (append-entries! path entries)
+    (define idx (build-index! path idx-path))
+    (define branch (get-branch idx "child2"))
+    (check-not-false branch "branch should exist")
+    (when branch
+      (check-equal? (length branch) 3)
+      (check-equal? (message-id (first branch)) "root")
+      (check-equal? (message-id (last branch)) "child2"))
+    (delete-directory/files dir #:must-exist? #f))
+
+  (test-case "get-branch: returns #f for nonexistent entry"
+    (define dir (make-temp-dir))
+    (define path (session-path dir))
+    (define idx-path (build-path dir "session.index"))
+    (append-entries! path (list (make-timestamped-message "root" #f 'user 'message 1000)))
+    (define idx (build-index! path idx-path))
+    (check-false (get-branch idx "nonexistent"))
+    (delete-directory/files dir #:must-exist? #f))
+
+  (test-case "branch!: switches active leaf"
+    (define dir (make-temp-dir))
+    (define path (session-path dir))
+    (define idx-path (build-path dir "session.index"))
+    (define entries
+      (list (make-timestamped-message "root" #f 'user 'message 1000)
+            (make-timestamped-message "child1" "root" 'assistant 'message 1001)
+            (make-timestamped-message "child2" "root" 'assistant 'message 1002)))
+    (append-entries! path entries)
+    (define idx (build-index! path idx-path))
+    ;; Default active leaf = last entry (child2)
+    (check-equal? (message-id (active-leaf idx)) "child2")
+    ;; Switch to child1
+    (define result (branch! idx "child1"))
+    (check-not-false result)
+    (check-equal? (message-id (active-leaf idx)) "child1")
+    (delete-directory/files dir #:must-exist? #f))
+
+  (test-case "reset-leaf!: clears active leaf"
+    (define dir (make-temp-dir))
+    (define path (session-path dir))
+    (define idx-path (build-path dir "session.index"))
+    (append-entries! path (list (make-timestamped-message "root" #f 'user 'message 1000)))
+    (define idx (build-index! path idx-path))
+    (branch! idx "root")
+    (check-equal? (message-id (active-leaf idx)) "root")
+    (reset-leaf! idx)
+    ;; After reset, active-leaf falls back to last entry
+    (check-equal? (message-id (active-leaf idx)) "root")
+    (delete-directory/files dir #:must-exist? #f))
+
+  (test-case "append-to-leaf!: adds child to active leaf"
+    (define dir (make-temp-dir))
+    (define path (session-path dir))
+    (define idx-path (build-path dir "session.index"))
+    (append-entries! path (list (make-timestamped-message "root" #f 'user 'message 1000)))
+    (define idx (build-index! path idx-path))
+    (branch! idx "root")
+    (define new-entry (make-timestamped-message "new-id" #f 'assistant 'message 1001))
+    (define result (append-to-leaf! idx new-entry))
+    (check-not-false result)
+    (check-equal? (message-parent-id result) "root")
+    (check-equal? (message-id (active-leaf idx)) "new-id")
+    (delete-directory/files dir #:must-exist? #f))
+
+  (test-case "leaf-depth: computes depth from root"
+    (define dir (make-temp-dir))
+    (define path (session-path dir))
+    (define idx-path (build-path dir "session.index"))
+    (define entries
+      (list (make-timestamped-message "root" #f 'user 'message 1000)
+            (make-timestamped-message "c1" "root" 'assistant 'message 1001)
+            (make-timestamped-message "c2" "c1" 'user 'message 1002)))
+    (append-entries! path entries)
+    (define idx (build-index! path idx-path))
+    (check-equal? (leaf-depth idx "root") 0)
+    (check-equal? (leaf-depth idx "c1") 1)
+    (check-equal? (leaf-depth idx "c2") 2)
+    (check-false (leaf-depth idx "nonexistent"))
+    (delete-directory/files dir #:must-exist? #f))
+
+  ;; ============================================================
+  ;; Entry kind predicates (#497)
+  ;; ============================================================
+
+  (test-case "entry kind predicates: model-change"
+    (define msg (make-message "id1" #f 'system 'model-change '() 1000 (hasheq)))
+    (check-true (model-change-entry? msg))
+    (check-false (message-entry? msg)))
+
+  (test-case "entry kind predicates: session-info"
+    (define msg (make-message "id1" #f 'system 'session-info '() 1000 (hasheq 'version 2)))
+    (check-true (session-info-entry? msg))
+    (check-false (model-change-entry? msg)))
+
+  (test-case "entry kind predicates: branch-summary"
+    (define msg (make-message "id1" #f 'system 'branch-summary '() 1000 (hasheq)))
+    (check-true (branch-summary-entry? msg)))
+
+  (test-case "entry kind predicates: compaction-summary"
+    (define msg (make-message "id1" #f 'system 'compaction-summary '() 1000 (hasheq)))
+    (check-true (compaction-summary-entry? msg)))
+
+  (test-case "entry kind predicates: regular message"
+    (define msg (make-message "id1" #f 'user 'message '() 1000 (hasheq)))
+    (check-true (message-entry? msg))
+    (check-false (model-change-entry? msg)))
+
+  ;; ============================================================
+  ;; Session versioning (#499)
+  ;; ============================================================
+
+  (test-case "write-session-version-header!: writes header to new file"
+    (define dir (make-temp-dir))
+    (define path (session-path dir))
+    (write-session-version-header! path)
+    (check-true (file-exists? path))
+    (define entries (load-session-log path))
+    (check-equal? (length entries) 1)
+    (check-true (session-info-entry? (first entries)))
+    (check-equal? (hash-ref (message-meta (first entries)) 'version) 2)
+    (delete-directory/files dir #:must-exist? #f))
+
+  (test-case "ensure-session-version-header!: adds header to v1 log"
+    (define dir (make-temp-dir))
+    (define path (session-path dir))
+    ;; Write a v1 log (no version header)
+    (append-entry! path (make-timestamped-message "id1" #f 'user 'message 1000))
+    (define ver (ensure-session-version-header! path))
+    (check-equal? ver 2)
+    (define entries (load-session-log path))
+    (check-true (session-info-entry? (first entries)))
+    (delete-directory/files dir #:must-exist? #f))
+
+  ;; ============================================================
+  ;; Session forking (#500)
+  ;; ============================================================
+
+  (test-case "fork-session!: extracts path to new file"
+    (define dir (make-temp-dir))
+    (define source-path (session-path dir))
+    (define entries
+      (list (make-timestamped-message "root" #f 'user 'message 1000)
+            (make-timestamped-message "c1" "root" 'assistant 'message 1001)
+            (make-timestamped-message "c2" "c1" 'user 'message 1002)
+            (make-timestamped-message "c3" "root" 'assistant 'message 1003)))
+    (append-entries! source-path entries)
+    (define dest-path (build-path dir "forked.jsonl"))
+    (define count (fork-session! source-path "c2" dest-path))
+    (check-equal? count 3)  ; root + c1 + c2
+    (define forked (load-session-log dest-path))
+    ;; First entry should be version header
+    (check-true (session-info-entry? (first forked)))
+    ;; Remaining entries are the path
+    (check-equal? (length forked) 4)  ; header + root + c1 + c2
+    (delete-directory/files dir #:must-exist? #f))
+
+  (test-case "fork-session!: original session unchanged"
+    (define dir (make-temp-dir))
+    (define source-path (session-path dir))
+    (define entries
+      (list (make-timestamped-message "root" #f 'user 'message 1000)
+            (make-timestamped-message "c1" "root" 'assistant 'message 1001)))
+    (append-entries! source-path entries)
+    (define dest-path (build-path dir "forked.jsonl"))
+    (fork-session! source-path "c1" dest-path)
+    (define original (load-session-log source-path))
+    (check-equal? (length original) 2)
     (delete-directory/files dir #:must-exist? #f))
   )
 

--- a/util/protocol-types.rkt
+++ b/util/protocol-types.rkt
@@ -35,6 +35,16 @@
  message->jsexpr
  jsexpr->message
 
+ ;; Entry kind predicates (#497)
+ message-entry?
+ model-change-entry?
+ thinking-level-change-entry?
+ branch-summary-entry?
+ custom-message-entry?
+ session-info-entry?
+ compaction-summary-entry?
+ tool-result-entry?
+
  ;; Event envelope
  (struct-out event)
  event-event
@@ -154,6 +164,52 @@
                 (map jsexpr->content-part (hash-ref h 'content))
                 (hash-ref h 'timestamp)
                 (hash-ref h 'meta)))
+
+;; ============================================================
+;; Entry kind predicates (#497)
+;; ============================================================
+;; Entry kinds extend the message struct's `kind` field to support
+;; session metadata and special entries beyond user/assistant messages.
+
+(define (message-entry? msg)
+  ;; Standard message entry (user or assistant)
+  (and (message? msg)
+       (memq (message-kind msg) '(message)) #t))
+
+(define (model-change-entry? msg)
+  ;; Records a model change mid-session
+  (and (message? msg)
+       (eq? (message-kind msg) 'model-change)))
+
+(define (thinking-level-change-entry? msg)
+  ;; Records a thinking level change mid-session
+  (and (message? msg)
+       (eq? (message-kind msg) 'thinking-level-change)))
+
+(define (branch-summary-entry? msg)
+  ;; Summary of a branched path (used in context assembly)
+  (and (message? msg)
+       (eq? (message-kind msg) 'branch-summary)))
+
+(define (custom-message-entry? msg)
+  ;; Custom/labeled message for extensions
+  (and (message? msg)
+       (eq? (message-kind msg) 'custom-message)))
+
+(define (session-info-entry? msg)
+  ;; Session metadata (version, settings, etc.)
+  (and (message? msg)
+       (eq? (message-kind msg) 'session-info)))
+
+(define (compaction-summary-entry? msg)
+  ;; Compaction summary entry
+  (and (message? msg)
+       (eq? (message-kind msg) 'compaction-summary)))
+
+(define (tool-result-entry? msg)
+  ;; Tool result entry
+  (and (message? msg)
+       (eq? (message-kind msg) 'tool-result)))
 
 ;; ============================================================
 ;; Event envelope struct


### PR DESCRIPTION
## Wave 3: Session Tree Foundation

### #496: Tree operations in session-index
- `get-branch`: walk entry→root, return path as list
- `branch!`: move active leaf to entry-id
- `reset-leaf!`: clear active leaf (use latest)
- `append-to-leaf!`: create child of active leaf, advance pointer
- `leaf-depth`: compute depth from root

### #497: Extended entry types
- New predicates for all entry kinds: model-change, thinking-level-change, branch-summary, custom-message, session-info, compaction-summary, tool-result
- Backward compatible (unknown kinds pass through)

### #498: Context assembly pipeline
- New module `runtime/context-builder.rkt`
- `build-session-context` walks tree path from active leaf to root
- Compaction-aware: truncates pre-compaction entries
- Filters metadata entries, transforms summaries to user-role

### #499: Session versioning + migration
- Version 2 header on session creation
- Auto-migration from v1 (no header) with backup

### #500: Session forking
- `fork-session!` extracts root→entry path to new JSONL
- Parent session reference in header

### Testing
- All 97 core tests pass (52 new tests)
- All 606 TUI tests pass (no regressions)
- Format lint green

Fixes: #496, #497, #498, #499, #500
Refs: #495