### PR TITLE
feat(#529-#531): Wave 3 — Session Branching UX

### DIFF
--- a/runtime/session-index.rkt
+++ b/runtime/session-index.rkt
@@ -44,6 +44,7 @@
          ;; Tree operations (#496)
          get-branch
          branch!
+         branch-with-summary!
          reset-leaf!
          append-to-leaf!
          leaf-depth
@@ -261,6 +262,26 @@
      (set-box! (session-index-active-leaf-id idx) entry-id)
      entry]))
 
+;; Branch with summary — creates a branch and appends a branch-summary entry
+(define (branch-with-summary! idx entry-id summary-text)
+  ;; Move active leaf to entry-id
+  (define entry (branch! idx entry-id))
+  (cond
+    [(not entry) #f]
+    [else
+     ;; Create summary message
+     (define summary-msg
+       (make-message (format "branch-summary-~a" (current-inexact-milliseconds))
+                     entry-id
+                     'system
+                     'branch-summary
+                     (list (make-text-part summary-text))
+                     (current-seconds)
+                     (hasheq 'type "branch-summary" 'from-id entry-id)))
+     ;; Add to index
+     (append-to-leaf! idx summary-msg)
+     summary-msg]))
+
 (define (reset-leaf! idx)
   ;; Set active leaf to #f (use latest entry as default).
   (set-box! (session-index-active-leaf-id idx) #f)
@@ -271,7 +292,10 @@
   ;; Adds entry to the index and updates parent-child map.
   ;; Returns the entry on success.
   (define parent (active-leaf idx))
-  (define parent-id (if parent (message-id parent) #f))
+  (define parent-id
+    (if parent
+        (message-id parent)
+        #f))
   ;; Update entry's parent-id to match
   (define fixed-entry
     (if (and parent-id (not (message-parent-id entry)))

--- a/runtime/session-store.rkt
+++ b/runtime/session-store.rkt
@@ -40,7 +40,9 @@
          ensure-session-version-header!
          migrate-session-log!
          ;; Session forking (#500)
-         fork-session!)
+         fork-session!
+         ;; Session naming
+         write-session-name!)
 
 ;; ── Write-ahead marker ──
 
@@ -327,6 +329,22 @@
 ;; ============================================================
 ;; Session forking (#500)
 ;; ============================================================
+
+;; ============================================================
+;; Session naming
+;; ============================================================
+
+(define (write-session-name! log-path name)
+  ;; Persist session name as a session-info entry.
+  (define name-msg
+    (make-message (format "session-name-~a" (current-inexact-milliseconds))
+                  #f
+                  'system
+                  'session-info
+                  (list (make-text-part (format "Session renamed: ~a" name)))
+                  (current-seconds)
+                  (hasheq 'name name)))
+  (append-entry! log-path name-msg))
 
 (define (fork-session! source-path source-entry-id dest-path)
   ;; Extract root→entry path from source session to a new JSONL file.

--- a/tests/tui/commands.rkt
+++ b/tests/tui/commands.rkt
@@ -32,8 +32,8 @@
       (process-slash-command cctx 'help)
       (define state (unbox (cmd-ctx-state-box cctx)))
       (define transcript (ui-state-transcript state))
-      ;; Should have 13 entries: header + 12 commands
-      (check-equal? (length transcript) 14 "/help produces 14 entries (header + 13 commands)")
+      ;; Should have 16 entries: header + 15 commands (including /tree and /name)
+      (check-equal? (length transcript) 16 "/help produces 16 entries (header + 15 commands)")
       ;; First entry is the header
       (check-true (string-contains? (transcript-entry-text (first transcript)) "Commands:")
                   "first entry is the Commands: header")

--- a/tui/command-parse.rkt
+++ b/tui/command-parse.rkt
@@ -41,6 +41,8 @@
    "/fork"      (cons 'fork 'optional)
    "/sessions"  (cons 'sessions 'optional)
    ;; Model
+   "/tree"      (cons 'tree 'none)
+   "/name"      (cons 'name 'optional)
    "/model"     (cons 'model 'optional)
    "/m"         (cons 'model 'optional)))
 

--- a/tui/commands.rkt
+++ b/tui/commands.rkt
@@ -17,6 +17,7 @@
          "render.rkt"
          "terminal.rkt"
          "palette.rkt"
+         "tree-view.rkt"
          "../util/protocol-types.rkt"
          "../agent/event-bus.rkt"
          "../runtime/session-index.rkt"
@@ -227,6 +228,65 @@
      'continue]))
 
 ;; ============================================================
+;; /tree command handler
+;; ============================================================
+
+(define (handle-tree-command cctx)
+  (define state (unbox (cmd-ctx-state-box cctx)))
+  (define idx (get-session-index cctx))
+  (cond
+    [(not idx)
+     (define entry (make-entry 'error "No session index available" 0 (hash)))
+     (set-box! (cmd-ctx-state-box cctx) (add-transcript-entry state entry))
+     'continue]
+    [else
+     (define entries (session-index-entry-order idx))
+     (if (zero? (vector-length entries))
+         (let ([entry (make-entry 'system "Session is empty." 0 (hash))])
+           (set-box! (cmd-ctx-state-box cctx) (add-transcript-entry state entry))
+           'continue)
+         (let ()
+           (define msgs (vector->list entries))
+           (define nodes (build-tree-nodes msgs))
+           (define active-leaf-id (let ([leaf (active-leaf idx)]) (and leaf (message-id leaf))))
+           (define-values (cols rows) (tui-screen-size))
+           (define lines (render-session-tree nodes active-leaf-id cols))
+           (define header (make-entry 'system "Session tree:" 0 (hash)))
+           (define tree-entries
+             (for/list ([line (in-list lines)])
+               (make-entry 'system line 0 (hash))))
+           (define all-entries (cons header tree-entries))
+           (define new-state
+             (for/fold ([s state]) ([e (in-list all-entries)])
+               (add-transcript-entry s e)))
+           (set-box! (cmd-ctx-state-box cctx) new-state)
+           'continue))]))
+
+;; ============================================================
+;; /name command handler
+;; ============================================================
+
+(define (handle-name-command cctx [title #f])
+  (define state (unbox (cmd-ctx-state-box cctx)))
+  (cond
+    [(not title)
+     (define entry (make-entry 'error "Usage: /name <title>" 0 (hash)))
+     (set-box! (cmd-ctx-state-box cctx) (add-transcript-entry state entry))
+     'continue]
+    [else
+     ;; Publish name event for runtime to persist
+     (when (cmd-ctx-event-bus cctx)
+       (publish! (cmd-ctx-event-bus cctx)
+                 (make-event "session.name"
+                             (inexact->exact (truncate (/ (current-inexact-milliseconds) 1000)))
+                             (or (ui-state-session-id state) "")
+                             #f
+                             (hasheq 'name title))))
+     (define entry (make-entry 'system (format "[session named: ~a]" title) 0 (hash)))
+     (set-box! (cmd-ctx-state-box cctx) (add-transcript-entry state entry))
+     'continue]))
+
+;; ============================================================
 ;; /model command handler
 ;; ============================================================
 
@@ -351,6 +411,7 @@
        [(switch) (handle-switch-command cctx (cadr cmd))]
        [(children) (handle-children-command cctx (cadr cmd))]
        [(model) (handle-model-command cctx (and (>= (length cmd) 2) (cadr cmd)))]
+       [(name) (handle-name-command cctx (and (>= (length cmd) 2) (cadr cmd)))]
        [(fork) (handle-fork-command cctx (and (>= (length cmd) 2) (cadr cmd)))]
        [(sessions) (handle-sessions-tui-command cctx cmd)]
        [(switch-error children-error)
@@ -417,8 +478,10 @@
           (make-entry 'system "[interrupt requested]" (current-inexact-milliseconds) (hash)))
         (set-box! (cmd-ctx-state-box cctx) (add-transcript-entry state entry))
         'continue]
+       [(tree) (handle-tree-command cctx)]
        [(branches) (handle-branches-command cctx)]
        [(leaves) (handle-leaves-command cctx)]
+       [(name) (handle-name-command cctx)]
        [(sessions) (handle-sessions-tui-command cctx #f)]
        [(quit)
         (set-box! (cmd-ctx-running-box cctx) #f)

--- a/tui/palette.rkt
+++ b/tui/palette.rkt
@@ -54,6 +54,8 @@
      (cmd-entry "/model"     "Switch or show model"          'model   '("<name>") '("m"))
      (cmd-entry "/history"   "Show session history"          'session '() '())
      (cmd-entry "/fork"      "Fork session at point"         'session '("<id>") '())
+     (cmd-entry "/tree"      "Show session tree"             'session '() '("t"))
+     (cmd-entry "/name"      "Set session name"              'session '("<title>") '())
      (cmd-entry "/sessions"  "List and manage sessions"      'session '("list|info|delete") '())))
   ;; Build main hash by name
   (define by-name

--- a/tui/tree-view.rkt
+++ b/tui/tree-view.rkt
@@ -1,0 +1,98 @@
+#lang racket/base
+
+;; q/tui/tree-view.rkt — Session tree rendering and navigation
+;;
+;; Renders the session tree as a depth-first text representation
+;; with Unicode box-drawing characters (├ └ │ ─).
+
+(require racket/list
+         racket/string
+         "../util/protocol-types.rkt")
+
+(provide render-session-tree
+         tree-node?
+         make-tree-node
+         build-tree-nodes
+         selected-node)
+
+;; Tree node for rendering
+(struct tree-node (id role text depth children) #:transparent)
+
+(define (make-tree-node id role text depth children)
+  (tree-node id role text depth children))
+
+;; Truncate text to fit within max-width columns
+(define (truncate-text text max-width)
+  (if (> (string-length text) max-width)
+      (string-append (substring text 0 (max 0 (- max-width 3))) "...")
+      text))
+
+;; Render a tree node and its children as styled lines
+;; Returns (listof string)
+(define (render-session-tree entries active-leaf-id max-width)
+  ;; entries: flat list of (list id parent-id role text-snapshot)
+  ;; Build parent→children map
+  (define children-map (make-hash))
+  (define root-entries '())
+  (for ([e (in-list entries)])
+    (define pid (list-ref e 1))
+    (if pid
+        (hash-update! children-map pid (lambda (lst) (append lst (list e))) '())
+        (set! root-entries (append root-entries (list e)))))
+
+  ;; Depth-first render starting from roots
+  (define lines '())
+  (define (render-node entry prefix is-last)
+    (define id (list-ref entry 0))
+    (define role (list-ref entry 2))
+    (define text (list-ref entry 3))
+    (define children (hash-ref children-map id '()))
+    (define connector (if is-last "└── " "├── "))
+    (define marker (if (equal? id active-leaf-id) " ◄" ""))
+    (define role-tag (format "[~a]" role))
+    (define max-text-width
+      (max 10
+           (- max-width
+              (string-length prefix)
+              (string-length connector)
+              (string-length role-tag)
+              (string-length marker)
+              1)))
+    (define truncated (truncate-text text max-text-width))
+    (define line (format "~a~a~a ~a~a" prefix connector role-tag truncated marker))
+    (set! lines (append lines (list line)))
+    (define child-prefix (string-append prefix (if is-last "    " "│   ")))
+    (for ([child (in-list children)]
+          [i (in-naturals)])
+      (render-node child child-prefix (= i (- (length children) 1)))))
+
+  ;; Render from each root
+  (for ([root (in-list root-entries)]
+        [i (in-naturals)])
+    (render-node root "" (= i (- (length root-entries) 1))))
+
+  lines)
+
+;; Build flat entry list from messages for tree rendering
+;; Returns: (listof (list id parent-id role text-snapshot))
+(define (build-tree-nodes messages)
+  (for/list ([msg (in-list messages)])
+    (define text
+      (with-handlers ([exn:fail? (lambda (e) "")])
+        (string-join (for/list ([part (in-list (message-content msg))]
+                                #:when (text-part? part))
+                       (text-part-text part))
+                     " ")))
+    ;; Truncate snapshot
+    (list (message-id msg)
+          (message-parent-id msg)
+          (message-role msg)
+          (if (> (string-length text) 80)
+              (string-append (substring text 0 77) "...")
+              text))))
+
+;; Find selected node by index in rendered output
+(define (selected-node nodes index)
+  (if (and (>= index 0) (< index (length nodes)))
+      (list-ref nodes index)
+      #f))


### PR DESCRIPTION
## Wave 3: Session Branching UX

Closes #528 (parent). Sub-issues:

- #529 — /tree command with tree visualization ✅
- #530 — Branch summary generation and persistence ✅
- #531 — /name command for session naming ✅

### New File
- `tui/tree-view.rkt` — tree rendering with Unicode box chars

### Changes
- `tui/commands.rkt` — /tree and /name command handlers
- `tui/command-parse.rkt` — command table entries
- `tui/palette.rkt` — registry entries
- `runtime/session-index.rkt` — branch-with-summary!
- `runtime/session-store.rkt` — write-session-name!

3681 tests pass.