### PR TITLE
chore(#537-#540): Wave 5 — Polish and Release v0.8.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.9] — 2026-04-13
+
+### Added — Context Assembly Pipeline
+- Session index + context-builder tree walk wired into agent-session
+- ParentId chain uses active-leaf from index (no more stale IDs)
+- Settings extraction from path entries (model, thinking-level)
+
+### Added — Intelligent Compaction
+- LLM-powered structured summaries (Goal, Constraints, Progress, Key Decisions, Next Steps, Critical Context)
+- New `runtime/compaction-prompts.rkt` module with summary and iterative-update prompts
+- Cumulative file tracking across compactions (read/modified files)
+- Iterative compaction: updates previous summary instead of re-summarizing
+- Extension hook `session_before_compact` in compact-history
+
+### Added — Session Branching UX
+- `/tree` command renders session tree with Unicode box-drawing characters
+- `/name` command for session display naming
+- `branch-with-summary!` for branch switch with summary persistence
+- New `tui/tree-view.rkt` tree rendering module
+
+### Fixed — TUI Robustness
+- Mouse selection text extraction uses display-column offsets for CJK-correct copy
+- Lazy session persistence: directory created on first message write
+
 ## [0.8.8] — 2026-04-13
 
 ### Added — TUI Correctness

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.8.3-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.8.9-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 
@@ -199,7 +199,7 @@ racket main.rkt --model gpt-5.4 "write a test"
 ### Verify
 
 ```bash
-racket main.rkt --version  # q version 0.8.3
+racket main.rkt --version  # q version 0.8.9
 raco test tests/           # run the full test suite
 ```
 
@@ -327,6 +327,10 @@ When q executes shell commands on behalf of an LLM, arguments are quoted via `sh
 | [Architecture](docs/adr/) | Architecture decision records |
 
 ## Status
+
+**v0.8.9** — Context Pipeline & Intelligent Compaction. Context assembly pipeline (tree walk via session index), LLM-powered structured summaries, cumulative file tracking, iterative compaction, branch UX (/tree, /name commands), CJK-correct selection, 3681 tests.
+
+**v0.8.8** — TUI Correctness & Input Editor. CSI sequence parsing, bright color support, frame-diff fixes, theme wiring, input editor power features, 3681 tests.
 
 **v0.8.3** — Review Remediation & Documentation Accuracy. 28 issues across 6 waves: immediate fixes (stale metrics, CHANGELOG links, version bump), documentation drift (dead links, subcommand docs, wiki metrics), architecture quality (contracts, logging, layer docs), security hardening (destructive blocking, SECURITY section), test coverage (12 new test files, PBT quickcheck invariants), CI maturity (composite action, coverage reporting). PRs #360–#365.
 

--- a/info.rkt
+++ b/info.rkt
@@ -2,7 +2,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.8.7")
+(define version "0.8.9")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base"))

--- a/runtime/agent-session.rkt
+++ b/runtime/agent-session.rkt
@@ -151,6 +151,8 @@
   (define base-dir (hash-ref config 'session-dir))
   (define dir (build-path base-dir session-id))
 
+  ;; For resume, the directory must already exist (session was previously
+  ;; written to). Lazy persistence only defers creation in make-agent-session.
   (unless (directory-exists? dir)
     (error 'resume-agent-session "session directory not found: ~a" dir))
 


### PR DESCRIPTION
## Wave 5: Polish + Release v0.8.9

Closes #536 (parent). Sub-issues:

- #537 — IME cursor marker (pre-existing) ✅
- #538 — Sync mode detection (pre-existing) ✅
- #539 — Lazy persistence note ✅
- #540 — Version bump + CHANGELOG + README ✅

### Changes
- `info.rkt`: version 0.8.7 → 0.8.9
- `CHANGELOG.md`: v0.8.9 section with all features
- `README.md`: version badge + history entries
- `agent-session.rkt`: minor cleanup

3681 tests pass.