### PR TITLE
Wave 1: TUI Critical Fixes & Failure Injection (#605-#608)

### DIFF
--- a/tests/test-failure-injection.rkt
+++ b/tests/test-failure-injection.rkt
@@ -1,0 +1,330 @@
+#lang racket
+
+;; tests/test-failure-injection.rkt — Failure injection tests
+;;
+;; Tests that the system handles failures gracefully:
+;; - Provider stream errors (network, auth, malformed)
+;; - Error classification in dispatch-iteration
+;; - Tool execution errors
+;; - IO/disk errors during session persistence
+;; - Extension hook failures
+;;
+;; Issue #607: Failure injection test harness
+
+(require rackunit
+         rackunit/text-ui
+         json
+         "../llm/model.rkt"
+         "../llm/provider.rkt"
+         (only-in "../tools/tool.rkt"
+                  make-tool-registry register-tool! make-tool
+                  make-exec-context
+                  make-success-result make-error-result
+                  tool-result? tool-result-is-error?)
+         "../tools/scheduler.rkt"
+         "../agent/event-bus.rkt"
+         (only-in "../util/protocol-types.rkt"
+                  make-event event? event-event event-payload
+                  loop-result? loop-result-termination-reason
+                  loop-result-messages)
+         "../extensions/api.rkt"
+         "../util/jsonl.rkt"
+         (prefix-in sdk: "../interfaces/sdk.rkt")
+         "helpers/mock-provider.rkt")
+
+(require (only-in "../main.rkt"
+                  register-default-tools!
+                  make-event-bus))
+
+;; ============================================================
+;; Failure injection helpers
+;; ============================================================
+
+(define (make-temp-dir)
+  (make-temporary-file "q-fail-~a" 'directory))
+
+(define (cleanup-dir dir)
+  (when (directory-exists? dir)
+    (delete-directory/files dir)))
+
+;; Provider that raises on nth call
+(define (make-failing-provider #:on-call [n 1]
+                               #:error [err (exn:fail "injected provider failure"
+                                                      (current-continuation-marks))])
+  (define call-count (box 0))
+  (make-provider
+   (lambda () "failing-mock")
+   (lambda () (hash 'streaming #t 'token-counting #t))
+   (lambda (req)
+     (set-box! call-count (add1 (unbox call-count)))
+     (if (= (unbox call-count) n)
+         (raise err)
+         (make-model-response
+          (list (hash 'type "text" 'text "ok"))
+          (hasheq 'prompt-tokens 5 'completion-tokens 2 'total-tokens 7)
+          "fail-mock" 'stop)))
+   (lambda (req)
+     (set-box! call-count (add1 (unbox call-count)))
+     (if (= (unbox call-count) n)
+         (raise err)
+         (list (stream-chunk "ok" #f
+                             (hasheq 'prompt-tokens 5 'completion-tokens 2 'total-tokens 7)
+                             #t))))))
+
+;; Provider that returns malformed response (wrong shape)
+(define (make-malformed-provider)
+  (make-provider
+   (lambda () "malformed-mock")
+   (lambda () (hash 'streaming #t 'token-counting #t))
+   ;; send returns a hash instead of model-response
+   (lambda (req) (hasheq 'wrong "shape"))
+   ;; stream returns empty list
+   (lambda (req) '())))
+
+;; Provider that fails mid-stream (first chunk ok, second raises)
+(define (make-midstream-failure-provider)
+  (define sent-first? (box #f))
+  (make-provider
+   (lambda () "midstream-fail")
+   (lambda () (hash 'streaming #t 'token-counting #t))
+   (lambda (req)
+     (raise (exn:fail "midstream failure" (current-continuation-marks))))
+   (lambda (req)
+     (if (unbox sent-first?)
+         (raise (exn:fail "midstream failure" (current-continuation-marks)))
+         (begin
+           (set-box! sent-first? #t)
+           (list (stream-chunk "partial " #f #f #f)
+                 (stream-chunk #f #f #f #t)))))))
+
+;; ============================================================
+;; Test: Provider errors don't crash session
+;; ============================================================
+
+(test-case "fail-inject: provider error on first call"
+  (define dir (make-temp-dir))
+  (define bus (make-event-bus))
+  (define events (box '()))
+  (subscribe! bus (lambda (e)
+                    (set-box! events (cons (event-event e) (unbox events)))))
+  (define prov (make-failing-provider #:on-call 1))
+  (define rt (sdk:make-runtime #:provider prov
+                               #:session-dir dir
+                               #:tool-registry (make-tool-registry)
+                               #:event-bus bus))
+  (define rt2 (sdk:open-session rt))
+  (define-values (rt3 result) (sdk:run-prompt! rt2 "trigger error"))
+  ;; Session should survive
+  (check-true (sdk:runtime? rt3)
+              "runtime should survive provider error")
+  ;; Should have started a turn
+  (check-not-false (member "turn.started" (reverse (unbox events)))
+                   "should emit turn.started before error")
+  (cleanup-dir dir))
+
+(test-case "fail-inject: provider error on second call (mid-session)"
+  (define dir (make-temp-dir))
+  (define prov (make-failing-provider #:on-call 2))
+  (define rt (sdk:make-runtime #:provider prov
+                               #:session-dir dir
+                               #:tool-registry (make-tool-registry)))
+  (define rt2 (sdk:open-session rt))
+  ;; First call succeeds
+  (define-values (rt3 result1) (sdk:run-prompt! rt2 "first prompt"))
+  (check-pred loop-result? result1)
+  (check-equal? (loop-result-termination-reason result1) 'completed)
+  ;; Second call fails — should not crash
+  (define-values (rt4 result2) (sdk:run-prompt! rt3 "second prompt"))
+  (check-true (sdk:runtime? rt4)
+              "runtime should survive mid-session provider error")
+  ;; First turn's data should still be in session
+  (define info (sdk:session-info rt4))
+  (check >= (hash-ref info 'history-length) 2
+         "first turn data should persist after error")
+  (cleanup-dir dir))
+
+(test-case "fail-inject: malformed provider response"
+  (define dir (make-temp-dir))
+  (define prov (make-malformed-provider))
+  (define rt (sdk:make-runtime #:provider prov
+                               #:session-dir dir
+                               #:tool-registry (make-tool-registry)))
+  (define rt2 (sdk:open-session rt))
+  (define-values (rt3 result) (sdk:run-prompt! rt2 "trigger malformed"))
+  ;; Should not crash — malformed response handled gracefully
+  (check-true (sdk:runtime? rt3)
+              "runtime should survive malformed provider response")
+  (cleanup-dir dir))
+
+(test-case "fail-inject: mid-stream failure captures partial output"
+  (define dir (make-temp-dir))
+  (define prov (make-midstream-failure-provider))
+  (define rt (sdk:make-runtime #:provider prov
+                               #:session-dir dir
+                               #:tool-registry (make-tool-registry)))
+  (define rt2 (sdk:open-session rt))
+  (define-values (rt3 result) (sdk:run-prompt! rt2 "trigger midstream"))
+  ;; Should survive and may have partial output
+  (check-true (sdk:runtime? rt3)
+              "runtime should survive mid-stream failure")
+  (cleanup-dir dir))
+
+;; ============================================================
+;; Test: Tool execution errors
+;; ============================================================
+
+(test-case "fail-inject: tool raises exception during execution"
+  (define dir (make-temp-dir))
+  (define reg (make-tool-registry))
+  (register-tool! reg
+    (make-tool "crash-tool" "Crashes on execution"
+               (hasheq 'type "object"
+                       'properties (hasheq))
+               (lambda (args ctx)
+                 (raise (exn:fail "tool crash!"
+                                  (current-continuation-marks))))))
+  (define prov (make-tool-call-mock-provider "crash-tool" (hasheq) "recovered"))
+  (define rt (sdk:make-runtime #:provider prov
+                               #:session-dir dir
+                               #:tool-registry reg
+                               #:max-iterations 5))
+  (define rt2 (sdk:open-session rt))
+  (define-values (rt3 result) (sdk:run-prompt! rt2 "use crash tool"))
+  ;; Should survive tool crash
+  (check-true (sdk:runtime? rt3)
+              "runtime should survive tool execution exception")
+  (cleanup-dir dir))
+
+(test-case "fail-inject: tool returns error result"
+  (define dir (make-temp-dir))
+  (define reg (make-tool-registry))
+  (register-tool! reg
+    (make-tool "error-tool" "Returns error"
+               (hasheq 'type "object"
+                       'properties (hasheq))
+               (lambda (args ctx)
+                 (make-error-result "deliberate error"))))
+  (define prov (make-tool-call-mock-provider "error-tool" (hasheq) "handled error"))
+  (define rt (sdk:make-runtime #:provider prov
+                               #:session-dir dir
+                               #:tool-registry reg
+                               #:max-iterations 5))
+  (define rt2 (sdk:open-session rt))
+  (define-values (rt3 result) (sdk:run-prompt! rt2 "use error tool"))
+  (check-true (sdk:runtime? rt3))
+  (check-pred loop-result? result)
+  ;; Should complete: error result is a normal flow, not an exception
+  (check-equal? (loop-result-termination-reason result) 'completed
+                "tool error result should allow completion")
+  (cleanup-dir dir))
+
+;; ============================================================
+;; Test: Missing tool
+;; ============================================================
+
+(test-case "fail-inject: tool-call for unregistered tool"
+  (define dir (make-temp-dir))
+  (define reg (make-tool-registry))
+  ;; No tools registered — provider asks for a non-existent tool
+  (define prov (make-tool-call-mock-provider "nonexistent" (hasheq) "handled"))
+  (define rt (sdk:make-runtime #:provider prov
+                               #:session-dir dir
+                               #:tool-registry reg
+                               #:max-iterations 5))
+  (define rt2 (sdk:open-session rt))
+  (define-values (rt3 result) (sdk:run-prompt! rt2 "call missing tool"))
+  (check-true (sdk:runtime? rt3)
+              "runtime should survive missing tool")
+  (cleanup-dir dir))
+
+;; ============================================================
+;; Test: Session persistence under stress
+;; ============================================================
+
+(test-case "fail-inject: multiple prompts with intermittent failures"
+  (define dir (make-temp-dir))
+  (define call-idx (box 0))
+  (define flaky-prov
+    (make-provider
+     (lambda () "flaky")
+     (lambda () (hash 'streaming #t 'token-counting #t))
+     (lambda (req)
+       (set-box! call-idx (add1 (unbox call-idx)))
+       (if (odd? (unbox call-idx))
+           (make-model-response
+            (list (hash 'type "text" 'text "ok"))
+            (hasheq 'prompt-tokens 5 'completion-tokens 2 'total-tokens 7)
+            "flaky" 'stop)
+           (raise (exn:fail "intermittent failure"
+                            (current-continuation-marks)))))
+     (lambda (req)
+       (set-box! call-idx (add1 (unbox call-idx)))
+       (if (odd? (unbox call-idx))
+           (list (stream-chunk "ok" #f
+                               (hasheq 'prompt-tokens 5 'completion-tokens 2 'total-tokens 7)
+                               #t))
+           (raise (exn:fail "intermittent failure"
+                            (current-continuation-marks)))))))
+  (define rt (sdk:make-runtime #:provider flaky-prov
+                               #:session-dir dir
+                               #:tool-registry (make-tool-registry)))
+  (define rt2 (sdk:open-session rt))
+  ;; Run 4 prompts — even ones fail, odd ones succeed
+  (define-values (rt3 _1) (sdk:run-prompt! rt2 "p1"))
+  (define-values (rt4 _2) (sdk:run-prompt! rt3 "p2"))
+  (define-values (rt5 _3) (sdk:run-prompt! rt4 "p3"))
+  (define-values (rt6 _4) (sdk:run-prompt! rt5 "p4"))
+  ;; Final runtime should be valid
+  (check-true (sdk:runtime? rt6)
+              "runtime should survive intermittent failures")
+  ;; Session should have some persisted data
+  (define info (sdk:session-info rt6))
+  (check >= (hash-ref info 'history-length) 2
+         "some successful turns should be persisted")
+  (cleanup-dir dir))
+
+;; ============================================================
+;; Test: Event coherence under failures
+;; ============================================================
+
+(test-case "fail-inject: turn.started/turn.completed pairing under error"
+  (define dir (make-temp-dir))
+  (define bus (make-event-bus))
+  (define events (box '()))
+  (subscribe! bus (lambda (e)
+                    (set-box! events (cons (event-event e) (unbox events)))))
+  (define prov (make-failing-provider #:on-call 1))
+  (define rt (sdk:make-runtime #:provider prov
+                               #:session-dir dir
+                               #:tool-registry (make-tool-registry)
+                               #:event-bus bus))
+  (define rt2 (sdk:open-session rt))
+  (define-values (rt3 _) (sdk:run-prompt! rt2 "trigger error"))
+  (define evts (reverse (unbox events)))
+  ;; turn.started should be emitted
+  (check-not-false (member "turn.started" evts)
+                   "turn.started should be emitted before error")
+  ;; NOTE: Current behavior does NOT always pair turn.started with
+  ;; turn.completed on provider errors. This test documents the gap.
+  ;; A future fix should ensure pairing (turn.failed or turn.completed).
+  (define start-count (length (filter (lambda (e) (equal? e "turn.started")) evts)))
+  (check-equal? start-count 1 "exactly one turn.started should be emitted")
+  (cleanup-dir dir))
+
+(test-case "fail-inject: session.started emitted even when turn fails"
+  (define dir (make-temp-dir))
+  (define bus (make-event-bus))
+  (define events (box '()))
+  (subscribe! bus (lambda (e)
+                    (set-box! events (cons (event-event e) (unbox events)))))
+  (define prov (make-failing-provider #:on-call 1))
+  (define rt (sdk:make-runtime #:provider prov
+                               #:session-dir dir
+                               #:tool-registry (make-tool-registry)
+                               #:event-bus bus))
+  (define rt2 (sdk:open-session rt))
+  (sdk:run-prompt! rt2 "trigger error")
+  (define evts (reverse (unbox events)))
+  (check-not-false (member "session.started" evts)
+                   "session.started should be emitted even before a failing turn")
+  (cleanup-dir dir))

--- a/tests/tui/render.rkt
+++ b/tests/tui/render.rkt
@@ -682,6 +682,34 @@
 
     (test-case "styled-line->ansi: bright color segment"
       (define sl (styled-line (list (styled-segment "muted text" '(bright-black)))))
-      (check-equal? (styled-line->ansi sl) "\x1b[90mmuted text\x1b[0m"))))
+      (check-equal? (styled-line->ansi sl) "\x1b[90mmuted text\x1b[0m"))
+
+    ;; SGR leak regression: styled→plain segment must not leak styles
+    (test-case "styled-line->ansi: styled to plain segment resets SGR"
+      (define sl (styled-line (list (styled-segment "> " '(bold cyan))
+                                     (styled-segment "hello" '()))))
+      (define ansi (styled-line->ansi sl))
+      ;; First segment gets SGR codes (no leading reset since it's first)
+      (check-true (string-contains? ansi "\x1b[1;36m> "))
+      ;; Plain segment after styled gets a reset before it
+      (check-true (string-contains? ansi "\x1b[0mhello"))
+      (check-true (string-suffix? ansi "\x1b[0m"))
+      ;; The "hello" text must NOT have the cyan/bold style active
+      (check-false (string-contains? ansi "\x1b[1;36mhello")
+                   "plain segment must not inherit previous style"))
+
+    (test-case "styled-line->ansi: three segments with mixed styles"
+      (define sl (styled-line (list (styled-segment "[" '(bold))
+                                     (styled-segment "ok" '(green))
+                                     (styled-segment "]" '()))))
+      (define ansi (styled-line->ansi sl))
+      ;; First segment: no leading reset
+      (check-true (string-contains? ansi "\x1b[1m["))
+      ;; Second segment: reset + new style
+      (check-true (string-contains? ansi "\x1b[0m\x1b[32mok"))
+      ;; Third segment (plain after styled): reset
+      (check-true (string-contains? ansi "\x1b[0m]"))
+      ;; Final reset
+      (check-true (string-suffix? ansi "\x1b[0m")))))
 
 (run-tests cjk-wrapping-tests)

--- a/tests/tui/test-command-integration.rkt
+++ b/tests/tui/test-command-integration.rkt
@@ -1,0 +1,189 @@
+#lang racket
+
+;; tests/tui/test-command-integration.rkt — TUI command integration tests
+;;
+;; Tests that TUI slash commands correctly interact with session state,
+;; transcript, rendering, and the command parsing pipeline.
+;;
+;; Issue #608: TUI command integration tests
+
+(require rackunit
+         rackunit/text-ui
+         "../../../q/tui/commands.rkt"
+         "../../../q/tui/command-parse.rkt"
+         "../../../q/tui/state.rkt"
+         "../../../q/tui/render.rkt"
+         "../../../q/util/protocol-types.rkt")
+
+;; Helper to make a simple cmd-ctx with a fresh state
+(define (make-test-cctx)
+  (cmd-ctx (box (initial-ui-state))
+           (box #t) ;; running
+           #f ;; event-bus
+           #f ;; session-dir
+           (box #f) ;; needs-redraw
+           #f)) ;; model-registry-box
+
+;; Helper: get transcript text entries from cctx state
+(define (get-transcript-texts cctx)
+  (define state (unbox (cmd-ctx-state-box cctx)))
+  (map transcript-entry-text (ui-state-transcript state)))
+
+;; Helper: check if any transcript entry contains a string
+(define (transcript-contains? cctx substr)
+  (ormap (lambda (t) (string-contains? t substr))
+         (get-transcript-texts cctx)))
+
+;; ============================================================
+;; Command parsing
+;; ============================================================
+
+(test-case "cmd-parse: parse-command-name extracts command from slash prefix"
+  (check-equal? (parse-command-name "/help") 'help)
+  (check-equal? (parse-command-name "/clear") 'clear)
+  (check-equal? (parse-command-name "/quit") 'quit)
+  (check-equal? (parse-command-name "/unknown-xyz") 'unknown))
+
+(test-case "cmd-parse: parse-command-name handles edge cases"
+  ;; Single "/" returns 'unknown (has slash but no command)
+  (check-equal? (parse-command-name "/") 'unknown)
+  (check-equal? (parse-command-name "") #f)
+  (check-equal? (parse-command-name "no-slash") #f))
+
+(test-case "cmd-parse: resolve-command-name maps aliases"
+  ;; "/q" should resolve to 'quit
+  (check-equal? (resolve-command-name "/q") 'quit)
+  ;; "/h" should resolve to 'help
+  (check-equal? (resolve-command-name "/h") 'help))
+
+;; ============================================================
+;; /help integration
+;; ============================================================
+
+(test-case "cmd-integ: /help triggers needs-redraw"
+  (define cctx (make-test-cctx))
+  (process-slash-command cctx 'help)
+  (check-true (unbox (cmd-ctx-needs-redraw-box cctx))
+              "/help should set needs-redraw"))
+
+(test-case "cmd-integ: /help transcript entries are 'system kind"
+  (define cctx (make-test-cctx))
+  (process-slash-command cctx 'help)
+  (define state (unbox (cmd-ctx-state-box cctx)))
+  (define transcript (ui-state-transcript state))
+  (for ([entry (in-list transcript)])
+    (check-equal? (transcript-entry-kind entry) 'system
+                  (format "entry '~a...' should be 'system kind"
+                          (substring (transcript-entry-text entry)
+                                     0 (min 30 (string-length
+                                                (transcript-entry-text entry))))))))
+
+;; ============================================================
+;; /clear integration
+;; ============================================================
+
+(test-case "cmd-integ: /clear removes all transcript entries"
+  (define cctx (make-test-cctx))
+  ;; Add some transcript entries first
+  (define state-box (cmd-ctx-state-box cctx))
+  (set-box! state-box
+            (struct-copy ui-state (unbox state-box)
+                         [transcript (list (transcript-entry 'user "test msg" 0 (hash) #f)
+                                           (transcript-entry 'assistant "response" 0 (hash) #f))]))
+  (process-slash-command cctx 'clear)
+  (define state (unbox state-box))
+  (check-equal? (length (ui-state-transcript state)) 0
+                "/clear should empty transcript"))
+
+(test-case "cmd-integ: /clear triggers needs-redraw"
+  (define cctx (make-test-cctx))
+  (process-slash-command cctx 'clear)
+  (check-true (unbox (cmd-ctx-needs-redraw-box cctx))
+              "/clear should set needs-redraw"))
+
+(test-case "cmd-integ: /clear returns 'continue (doesn't quit)"
+  (define cctx (make-test-cctx))
+  (define result (process-slash-command cctx 'clear))
+  (check-equal? result 'continue
+                "/clear should return 'continue"))
+
+;; ============================================================
+;; /quit integration
+;; ============================================================
+
+(test-case "cmd-integ: /quit sets running to #f"
+  (define cctx (make-test-cctx))
+  (check-true (unbox (cmd-ctx-running-box cctx)))
+  (process-slash-command cctx 'quit)
+  (check-false (unbox (cmd-ctx-running-box cctx))
+               "/quit should set running to #f"))
+
+(test-case "cmd-integ: /quit returns 'quit"
+  (define cctx (make-test-cctx))
+  (define result (process-slash-command cctx 'quit))
+  (check-equal? result 'quit))
+
+;; ============================================================
+;; Unknown commands
+;; ============================================================
+
+(test-case "cmd-integ: unknown command shows error in transcript"
+  (define cctx (make-test-cctx))
+  (process-slash-command cctx 'unknown)
+  (check-true (transcript-contains? cctx "Unknown command")
+              "unknown command should show error message"))
+
+(test-case "cmd-integ: unknown command still returns 'continue"
+  (define cctx (make-test-cctx))
+  (define result (process-slash-command cctx 'nonexistent))
+  (check-equal? result 'continue
+                "unknown command should return 'continue"))
+
+;; ============================================================
+;; Command table completeness
+;; ============================================================
+
+(test-case "cmd-integ: all expected commands are in command table"
+  (define ct (make-command-table))
+  ;; Core commands (note: table keys include the "/" prefix)
+  (check-not-false (hash-ref ct "/help" #f) "help in command table")
+  (check-not-false (hash-ref ct "/clear" #f) "clear in command table")
+  (check-not-false (hash-ref ct "/quit" #f) "quit in command table"))
+
+;; ============================================================
+;; State isolation between commands
+;; ============================================================
+
+(test-case "cmd-integ: commands don't interfere with each other"
+  (define cctx (make-test-cctx))
+  ;; Run /help
+  (process-slash-command cctx 'help)
+  (define state-after-help (unbox (cmd-ctx-state-box cctx)))
+  (define help-entry-count (length (ui-state-transcript state-after-help)))
+  ;; Run /clear
+  (process-slash-command cctx 'clear)
+  (define state-after-clear (unbox (cmd-ctx-state-box cctx)))
+  (check-equal? (length (ui-state-transcript state-after-clear)) 0
+                "/clear should clear /help entries")
+  ;; Run /help again — should add entries again
+  (process-slash-command cctx 'help)
+  (define state-final (unbox (cmd-ctx-state-box cctx)))
+  (check-equal? (length (ui-state-transcript state-final)) help-entry-count
+                "/help after /clear should re-add entries"))
+
+;; ============================================================
+;; Transcript entry rendering
+;; ============================================================
+
+(test-case "cmd-integ: transcript entries can be formatted by render pipeline"
+  (define cctx (make-test-cctx))
+  (process-slash-command cctx 'help)
+  (define state (unbox (cmd-ctx-state-box cctx)))
+  (define transcript (ui-state-transcript state))
+  ;; Each transcript entry should be renderable by format-entry
+  (for ([entry (in-list transcript)])
+    (define lines (format-entry entry 80))
+    (check-true (list? lines)
+                "format-entry should return a list of styled-lines")
+    (check > (length lines) 0
+           "format-entry should return at least one line")))

--- a/tui/render.rkt
+++ b/tui/render.rkt
@@ -106,17 +106,30 @@
 ;; Convert a styled-line to an ANSI-encoded string.
 ;; Each segment gets its SGR codes; a final reset is appended.
 (define (styled-line->ansi sl)
+  ;; Emit reset before each segment so styles don't leak between them.
+  ;; This means every segment starts with \x1b[0m (except the very first
+  ;; one if it has no previous styled segment to reset from). We use a
+  ;; simple rule: reset before every segment after the first styled one.
+  (define seen-styled? (box #f))
   (define parts
     (for/list ([seg (in-list (styled-line-segments sl))])
       (define text (styled-segment-text seg))
       (define styles (styled-segment-style seg))
-      (if (null? styles)
-          text
-          (string-append (styles->sgr styles) text))))
+      (cond
+        [(null? styles)
+         ;; Plain segment: reset if a previous segment had styles
+         (if (unbox seen-styled?)
+             (string-append "\x1b[0m" text)
+             text)]
+        [else
+         ;; Styled segment: reset before (if not first) + SGR + text
+         (define reset-prefix
+           (if (unbox seen-styled?) "\x1b[0m" ""))
+         (set-box! seen-styled? #t)
+         (string-append reset-prefix (styles->sgr styles) text)])))
   (define content (apply string-append parts))
   ;; Append SGR reset if any segment had styles
-  (if (for/or ([seg (in-list (styled-line-segments sl))])
-        (pair? (styled-segment-style seg)))
+  (if (unbox seen-styled?)
       (string-append content "\x1b[0m")
       content))
 

--- a/tui/renderer.rkt
+++ b/tui/renderer.rkt
@@ -239,7 +239,9 @@
 
   ;; Build frame-lines for diffing
   (define frame-vec (make-vector rows ""))
-  (vector-set! frame-vec header-y header-text)
+  ;; Header: store ANSI-encoded (inverse video) for correct incremental diff
+  (vector-set! frame-vec header-y
+                (string-append "\x1b[0m\x1b[30;47m" header-text "\x1b[0m"))
 
   ;; 3. Draw transcript entries (with render cache)
   (define-values (trans-lines-raw ui-state*) (render-transcript ui-state transcript-height cols))

--- a/tui/tui-render-loop.rkt
+++ b/tui/tui-render-loop.rkt
@@ -196,7 +196,8 @@
          [(write)
           (tui-cursor 1 (+ (diff-cmd-row cmd) 1)) ; ANSI is 1-based
           (display "\x1b[2K" (current-output-port)) ; clear line
-          (display (diff-cmd-content cmd) (current-output-port))]
+          (display (fix-sgr-bg-black (diff-cmd-content cmd))
+                   (current-output-port))]
          [(clear-from)
           ;; Clear from given row to end of screen
           (tui-cursor 1 (+ (diff-cmd-row cmd) 1))


### PR DESCRIPTION
## Wave 1 — TUI Critical Fixes & Failure Injection (v0.9.0)

### Bug Fixes (#605)

**styled-line->ansi SGR leak** — When a styled segment was followed by a plain segment, the style leaked into the plain text. Now emits `\x1b[0m` reset before plain segments after any styled segment.

**Incremental render bg-black fix** — `fix-sgr-bg-black` was only applied on full redraws, not incremental updates. Now applied consistently.

**Header ANSI in frame-vec** — Header was stored as plain text in frame vector, causing incorrect incremental diffs. Now includes inverse-video SGR codes.

### New Tests

**test-failure-injection.rkt** (10 tests) — #607
- Provider errors (first call, mid-session, malformed, mid-stream)
- Tool execution errors (exception, error result)
- Missing tool handling
- Intermittent failures across multiple prompts
- Event coherence under failures

**test-command-integration.rkt** (15 tests) — #608
- Command parsing (parse-command-name, resolve aliases, edge cases)
- /help, /clear, /quit integration
- Unknown command handling
- State isolation between commands
- Transcript rendering pipeline

**render.rkt SGR leak tests** (2 tests)
- styled→plain segment resets SGR
- Three segments with mixed styles

### Note
#606 (selection display-width) was already fixed in v0.8.9 (commit f067016, PR#545). Closing as already-done.

### Metrics
- Test count: 3714 → 3741 (+27)
- All lints pass

Closes #605, #606, #607, #608