### PR TITLE
fix: Agent Loop Event Pairing (Wave 0 — #632/#633/#634)

### DIFF
--- a/agent/loop.rkt
+++ b/agent/loop.rkt
@@ -261,7 +261,11 @@
                 "turn.cancelled"
                 (hasheq 'reason "cancellation-token")
                 #:state state)]
-        [(unbox stream-blocked) (void)] ;; message-update hook blocked -- stop streaming
+        [(unbox stream-blocked)
+         ;; message-update hook blocked -- emit model.stream.completed then stop streaming
+         (emit! bus session-id turn-id "model.stream.completed"
+                (hasheq 'usage (hasheq))
+                #:state state)]
         [else (stream-loop)])))
 
   (hasheq 'text
@@ -520,8 +524,10 @@
 
   (cond
     [(and (hook-result? pre-hook-result) (eq? (hook-result-action pre-hook-result) 'block))
-     ;; Hook blocked the request -- return early
+     ;; Hook blocked the request -- emit turn.completed then return early
      (emit! bus session-id turn-id "model.request.blocked" (hasheq 'reason "hook"))
+     (emit! bus session-id turn-id "turn.completed"
+            (hasheq 'termination 'hook-blocked 'turnId turn-id 'reason "model-request-pre-blocked"))
      (loop-result raw-messages 'hook-blocked (hasheq 'hook 'model-request-pre))]
     [else
      (emit! bus
@@ -552,6 +558,8 @@
      (cond
        [(and (hook-result? msg-start-result) (eq? (hook-result-action msg-start-result) 'block))
         (emit! bus session-id turn-id "message.blocked" (hasheq 'hook 'message-start))
+        (emit! bus session-id turn-id "turn.completed"
+               (hasheq 'termination 'hook-blocked 'turnId turn-id 'reason "message-start-blocked"))
         (loop-result raw-messages 'hook-blocked (hasheq 'hook 'message-start))]
        [else
         ;; 5-7. Stream from provider

--- a/tests/test-loop.rkt
+++ b/tests/test-loop.rkt
@@ -301,3 +301,100 @@
  (check-not-false (member 'message-update hooks))
  (check-not-false (member 'model-response-post hooks))
  (check-not-false (member 'message-end hooks)))
+
+;; ============================================================
+;; 6. BUG #633: turn.started/turn.completed pairing on hook-blocked paths
+;; ============================================================
+
+(test-case
+ "BUG #633: model-request-pre hook block emits turn.completed"
+ (define bus (make-event-bus))
+ (define events '())
+ (subscribe! bus (lambda (evt) (set! events (cons evt events))))
+ (define (blocking-pre-hook hook-point payload)
+   (if (eq? hook-point 'model-request-pre)
+       (hook-block "test-block")
+       #f))
+ (define prov
+   (make-provider
+    (lambda () "mock")
+    (lambda () (hasheq 'streaming #t))
+    (lambda (req) (error 'send "not used"))
+    (lambda (req) (list (stream-chunk #f #f #f #t)))))
+ (define ctx (list (make-message "m-1" #f 'user 'message
+                                 (list (make-text-part "hi"))
+                                 1000 '#hash())))
+ (define result (run-agent-turn ctx prov bus
+                                #:session-id "s1" #:turn-id "t1"
+                                #:hook-dispatcher blocking-pre-hook))
+ ;; Must be hook-blocked
+ (check-equal? (loop-result-termination-reason result) 'hook-blocked)
+ ;; Both turn.started AND turn.completed must be in events
+ (define event-names (map event-event (reverse events)))
+ (check-not-false (member "turn.started" event-names)
+                  "turn.started must be emitted")
+ (check-not-false (member "turn.completed" event-names)
+                  "turn.completed must be emitted after hook-blocked early return"))
+
+(test-case
+ "BUG #633: message-start hook block emits turn.completed"
+ (define bus (make-event-bus))
+ (define events '())
+ (subscribe! bus (lambda (evt) (set! events (cons evt events))))
+ (define (blocking-msg-start-hook hook-point payload)
+   (if (eq? hook-point 'message-start)
+       (hook-block "test-block")
+       #f))
+ (define prov
+   (make-provider
+    (lambda () "mock")
+    (lambda () (hasheq 'streaming #t))
+    (lambda (req) (error 'send "not used"))
+    (lambda (req) (list (stream-chunk #f #f #f #t)))))
+ (define ctx (list (make-message "m-1" #f 'user 'message
+                                 (list (make-text-part "hi"))
+                                 1000 '#hash())))
+ (define result (run-agent-turn ctx prov bus
+                                #:session-id "s1" #:turn-id "t1"
+                                #:hook-dispatcher blocking-msg-start-hook))
+ ;; Must be hook-blocked
+ (check-equal? (loop-result-termination-reason result) 'hook-blocked)
+ ;; Both turn.started AND turn.completed must be in events
+ (define event-names (map event-event (reverse events)))
+ (check-not-false (member "turn.started" event-names)
+                  "turn.started must be emitted")
+ (check-not-false (member "turn.completed" event-names)
+                  "turn.completed must be emitted after message-start hook block"))
+
+;; ============================================================
+;; 7. BUG #634: stream-blocked emits model.stream.completed
+;; ============================================================
+
+(test-case
+ "BUG #634: stream-blocked by message-update hook emits model.stream.completed"
+ (define bus (make-event-bus))
+ (define events '())
+ (subscribe! bus (lambda (evt) (set! events (cons evt events))))
+ (define (blocking-update-hook hook-point payload)
+   (if (eq? hook-point 'message-update)
+       (hook-block "test-stream-block")
+       #f))
+ (define prov
+   (make-provider
+    (lambda () "mock")
+    (lambda () (hasheq 'streaming #t))
+    (lambda (req) (error 'send "not used"))
+    (lambda (req)
+      ;; Emit one text delta, then done
+      (list (stream-chunk "hello" #f #f #f)
+            (stream-chunk #f #f #f #t)))))
+ (define ctx (list (make-message "m-1" #f 'user 'message
+                                 (list (make-text-part "hi"))
+                                 1000 '#hash())))
+ (define result (run-agent-turn ctx prov bus
+                                #:session-id "s1" #:turn-id "t1"
+                                #:hook-dispatcher blocking-update-hook))
+ (define event-names (map event-event (reverse events)))
+ ;; model.stream.completed must still be emitted even when stream is blocked
+ (check-not-false (member "model.stream.completed" event-names)
+                  "model.stream.completed must be emitted on stream-blocked path"))


### PR DESCRIPTION
## Wave 0: Agent Loop Event Pairing

Fixes #632 (parent), #633, #634

### Bugs Fixed

**#633 (P0): turn.started/turn.completed pairing gap**
- `turn.started` was emitted at the start of every turn, but `turn.completed` was skipped on two hook-blocked early-return paths:
  - `model-request-pre` hook block (loop.rkt)
  - `message-start` hook block (loop.rkt)
- Event consumers (TUI, extensions) could leak state or hang waiting for the paired event
- **Fix:** Emit `turn.completed` with `termination: hook-blocked` before both early returns

**#634 (P2): stream-blocked skips model.stream.completed**
- When `message-update` hook blocked streaming, the stream loop stopped without emitting `model.stream.completed`
- TUI could remain in an inconsistent streaming state
- **Fix:** Emit `model.stream.completed` with empty usage before stopping the stream loop

### Tests Added
- 3 new test cases verifying event pairing on all three blocked paths
- All 18 loop tests pass

### Verification
```
raco test q/tests/test-loop.rkt  # 18 tests passed
racket q/scripts/lint-format.rkt  # PASSED
```