### PR TITLE
fix: Compactor Hook Enforcement (Wave 1 — #635/#636)

### DIFF
--- a/runtime/compactor.rkt
+++ b/runtime/compactor.rkt
@@ -232,6 +232,7 @@
 ;; v0.8.9: Added #:provider, #:model-name for LLM-powered summarization,
 ;;         #:hook-dispatcher for extension hooks, #:previous-summary for
 ;;         iterative compaction.
+;; v0.9.1 (#636): Hook blocking now actually prevents compaction.
 (define (compact-history messages
                          #:strategy [strategy (default-strategy)]
                          #:summarize-fn [summarize-fn default-summarize]
@@ -240,46 +241,49 @@
                          #:previous-summary [prev-summary #f]
                          #:hook-dispatcher [hook-dispatcher #f])
   ;; Dispatch 'session-before-compact hook if dispatcher provided
-  (when hook-dispatcher
-    (define hook-res
-      (hook-dispatcher 'session-before-compact
-                       (hasheq 'message-count (length messages) 'strategy strategy)))
-    (when (and (hook-result? hook-res) (eq? (hook-result-action hook-res) 'block))
-      ;; Hook blocked compaction — return identity result
-      (compaction-result #f 0 messages)))
-  (define-values (old recent) (build-summary-window messages strategy))
+  ;; Returns identity result if hook blocks, otherwise proceeds with compaction.
   (cond
-    ;; Nothing to summarize — return identity result
-    [(null? old) (compaction-result #f 0 recent)]
+    [(and hook-dispatcher
+          (let ([hook-res (hook-dispatcher 'session-before-compact
+                                          (hasheq 'message-count (length messages) 'strategy strategy))])
+            (and (hook-result? hook-res) (eq? (hook-result-action hook-res) 'block))))
+     ;; Hook blocked compaction — return identity result immediately
+     (compaction-result #f 0 messages)]
     [else
-     ;; Choose summarization: LLM if provider given, else use summarize-fn
-     (define summary-text
-       (if (and provider model-name)
-           (let ([file-tracker (extract-file-tracker old)])
-             (llm-summarize old
-                            provider
-                            model-name
-                            #:previous-summary (or prev-summary (find-previous-summary recent))
-                            #:file-tracker file-tracker))
-           (summarize-fn old)))
-     ;; Build file tracker metadata for the summary message
-     (define file-tracker-meta
-       (if (and provider model-name)
-           (let ([ft (extract-file-tracker old)])
-             (if (> (hash-count ft) 0)
-                 (hasheq 'fileTracker ft)
-                 (hasheq)))
-           (hasheq)))
-     (define summary-msg
-       (make-message
-        (format "compaction-~a" (current-inexact-milliseconds))
-        #f ; no parent — compaction summaries are root-level context
-        'system
-        'compaction-summary
-        (list (make-text-part summary-text))
-        (current-seconds)
-        (hash-set (hash-set file-tracker-meta 'type "compaction") 'removedCount (length old))))
-     (compaction-result summary-msg (length old) recent)]))
+     ;; Proceed with compaction
+     (define-values (old recent) (build-summary-window messages strategy))
+     (cond
+       ;; Nothing to summarize — return identity result
+       [(null? old) (compaction-result #f 0 recent)]
+       [else
+        ;; Choose summarization: LLM if provider given, else use summarize-fn
+        (define summary-text
+          (if (and provider model-name)
+              (let ([file-tracker (extract-file-tracker old)])
+                (llm-summarize old
+                               provider
+                               model-name
+                               #:previous-summary (or prev-summary (find-previous-summary recent))
+                               #:file-tracker file-tracker))
+              (summarize-fn old)))
+        ;; Build file tracker metadata for the summary message
+        (define file-tracker-meta
+          (if (and provider model-name)
+              (let ([ft (extract-file-tracker old)])
+                (if (> (hash-count ft) 0)
+                    (hasheq 'fileTracker ft)
+                    (hasheq)))
+              (hasheq)))
+        (define summary-msg
+          (make-message
+           (format "compaction-~a" (current-inexact-milliseconds))
+           #f ; no parent — compaction summaries are root-level context
+           'system
+           'compaction-summary
+           (list (make-text-part summary-text))
+           (current-seconds)
+           (hash-set (hash-set file-tracker-meta 'type "compaction") 'removedCount (length old))))
+        (compaction-result summary-msg (length old) recent)])]))
 
 ;; ============================================================
 ;; compaction-result->message-list

--- a/tests/test-compaction-edge-cases.rkt
+++ b/tests/test-compaction-edge-cases.rkt
@@ -235,18 +235,19 @@
   ;; Empty messages → identity result regardless of hook
   (check-equal? (compaction-result-removed-count result) 0))
 
-(test-case "edge-compact: hook blocking does not prevent compaction (known gap)"
-  ;; NOTE: The hook-dispatcher 'session-before-compact' is called but its
-  ;; result is ignored. The `when` form's return value is not used to
-  ;; short-circuit the function. This is a known gap — the hook is
-  ;; advisory-only and cannot block compaction.
+(test-case "edge-compact: hook blocking prevents compaction (#636)"
+  ;; FIX #636: The hook-dispatcher 'session-before-compact' now properly
+  ;; blocks compaction. The `cond` form returns the identity result when
+  ;; the hook returns 'block.
   (define msgs (for/list ([i (in-range 30)])
                  (make-test-msg 'assistant (format "msg-~a" i))))
   (define blocker (lambda (hook payload)
                     (hook-result 'block (hasheq))))
   (define result (compact-history msgs #:hook-dispatcher blocker))
-  ;; Hook cannot actually block — compaction proceeds normally
-  (check > (compaction-result-removed-count result) 0))
+  ;; Hook blocks — no messages compacted, identity result returned
+  (check-equal? (compaction-result-removed-count result) 0)
+  (check-equal? (length (compaction-result-kept-messages result)) 30)
+  (check-false (compaction-result-summary-message result)))
 
 (test-case "edge-compact: hook allows compaction"
   (define msgs (for/list ([i (in-range 30)])


### PR DESCRIPTION
## Wave 1: Compactor Hook Enforcement

Fixes #635 (parent), #636

### Bug Fixed

**#636 (P1): compact-history hook blocking is advisory-only**
- The `session-before-compact` hook was called but its result was discarded
- The `when` form computed the identity result but never returned it
- Extensions could not actually block compaction despite returning `blockwhencondblock`, the function immediately returns `(compaction-result #f 0 messages)` — an identity result with no compaction applied.

### Test Changes
- Updated the previously-failing test that documented this as a known gap
- All 24 compaction edge-case tests pass

### Verification
```
raco test q/tests/test-compaction-edge-cases.rkt  # 24 tests passed
raco test q/tests/test-compaction.rkt             # 35 tests passed
racket q/scripts/lint-format.rkt                  # PASSED
```