### PR TITLE
fix: Test Lint Cleanup (Wave 2 — #637/#638/#639)

### DIFF
--- a/tests/test-bash.rkt
+++ b/tests/test-bash.rkt
@@ -100,7 +100,7 @@
      (check-false (destructive-command? "grep 'rm -rf' file.txt")))
 
    (test-case "ls -la is NOT destructive"
-     (check-false (destructive-command? "ls -la /home/user")))
+     (check-false (destructive-command? "ls -la /tmp")))
 
    (test-case "echo hello | grep h is NOT destructive"
      (check-false (destructive-command? "echo hello | grep h")))

--- a/tests/test-iteration.rkt
+++ b/tests/test-iteration.rkt
@@ -177,12 +177,12 @@
 (test-case "ensure-hash-args with empty JSON object string returns empty hash"
   (define result (ensure-hash-args "{}"))
   (check-pred hash? result)
-  (check-equal? (hash-keys result) '()))
+  (check-equal? (sort (hash-keys result) symbol<?) '()))
 
 (test-case "ensure-hash-args with empty string returns empty hash"
   (define result (ensure-hash-args ""))
   (check-pred hash? result)
-  (check-equal? (hash-keys result) '()))
+  (check-equal? (sort (hash-keys result) symbol<?) '()))
 
 ;; Run tests
 (module+ main

--- a/tests/test-replay.rkt
+++ b/tests/test-replay.rkt
@@ -85,8 +85,8 @@
 
 ;; Check if two trees are equivalent
 (define (trees-equivalent? tree1 tree2)
-  (define keys1 (hash-keys tree1))
-  (define keys2 (hash-keys tree2))
+  (define keys1 (sort (hash-keys tree1) string<?))
+  (define keys2 (sort (hash-keys tree2) string<?))
   (and (= (length keys1) (length keys2))
        (for/and ([k (in-list keys1)])
          (equal? (hash-ref tree1 k '()) (hash-ref tree2 k '())))))

--- a/tests/test-types.rkt
+++ b/tests/test-types.rkt
@@ -325,7 +325,7 @@
 
 (test-case "empty payload event"
   (define evt-empty (make-event "session.started" 0 "s" #f '#hash()))
-  (check-equal? (hash-keys (event-payload (roundtrip-event evt-empty))) '()))
+  (check-equal? (sort (hash-keys (event-payload (roundtrip-event evt-empty))) symbol<?) '()))
 
 (test-case "bookmark message kind"
   (define msg-bm (make-message "bm-1" "msg-1" 'user 'bookmark


### PR DESCRIPTION
## Wave 2: Test Lint Cleanup

Fixes #637 (parent), #638, #639

### Fixes
- **#638**: Replace hardcoded `/home/user` path with `/tmp` in test-bash.rkt:103
- **#639**: Wrap 5 `hash-keys` calls with `sort` to eliminate nondeterministic ordering warnings

### Verification
```
racket q/scripts/lint-tests.rkt   # 0 infos, PASSED
racket q/scripts/lint-format.rkt  # PASSED
raco test q/tests/test-bash.rkt q/tests/test-iteration.rkt q/tests/test-replay.rkt q/tests/test-types.rkt  # all pass
```