### PR TITLE
feat: Unify Context Assembly Pipeline (Wave 6 — #646/#647/#648)

### DIFF
--- a/runtime/compactor.rkt
+++ b/runtime/compactor.rkt
@@ -49,11 +49,12 @@
          make-llm-summarize-fn
          extract-file-tracker
          format-messages-for-summary
-         ;; Tiered Context Assembly (WP-37)
+         ;; Tiered Context Assembly (WP-37) — DEPRECATED (#648)
+         ;; Use build-session-context/tokens from context-builder.rkt instead.
          (struct-out tiered-context)
          build-tiered-context
          tiered-context->message-list
-         ;; R2-6: Context Assembly Hooks
+         ;; R2-6: Context Assembly Hooks — DEPRECATED (#648)
          build-tiered-context-with-hooks
          (struct-out context-assembly-payload)
          payload->tiered-context
@@ -365,7 +366,9 @@
 
 ;; ============================================================
 ;; Tiered Context Assembly (WP-37)
-;; ============================================================
+;; DEPRECATED (#648): Use build-session-context/tokens from context-builder.rkt
+;; instead. build-tiered-context remains for backward compatibility but will
+;; be removed in a future version.
 
 ;; Tiered context holds messages split into three tiers:
 ;; - Tier A: Compacted summaries of older messages

--- a/runtime/context-builder.rkt
+++ b/runtime/context-builder.rkt
@@ -9,10 +9,16 @@
 ;; Issue #498: Context assembly pipeline (tree walk).
 
 (require racket/list
+         racket/string
+         racket/set
          "../util/protocol-types.rkt"
-         "../runtime/session-index.rkt")
+         "../runtime/session-index.rkt"
+         "../llm/token-budget.rkt")
 
 (provide build-session-context
+         build-session-context/tokens
+         truncate-messages-to-budget
+         estimate-message-tokens
          entry->context-message)
 
 ;; ============================================================
@@ -96,6 +102,86 @@
 (define (transform-summary-to-user entry)
   ;; Transform a summary entry into a user-role message for context.
   (struct-copy message entry [role 'user]))
+
+;; ============================================================
+;; Token-aware context assembly (#646, #647)
+;; ============================================================
+
+;; Estimate token count for a single message struct.
+;; Extracts text from all text-parts in the message content.
+(define (estimate-message-tokens msg)
+  (define text-parts
+    (for/list ([part (in-list (message-content msg))]
+               #:when (text-part? part))
+      (text-part-text part)))
+  (estimate-text-tokens (string-join text-parts " ")))
+
+;; Build session context with token budget enforcement.
+;; If the assembled messages exceed max-tokens, truncates older messages
+;; while preserving system instructions and compaction summaries.
+;; Returns (values messages total-tokens)
+(define (build-session-context/tokens idx #:max-tokens max-tokens)
+  (define messages (build-session-context idx))
+  (cond
+    [(null? messages) (values '() 0)]
+    [else
+     (define total (for/sum ([m (in-list messages)]) (estimate-message-tokens m)))
+     (cond
+       [(<= total max-tokens) (values messages total)]
+       [else
+        (define truncated (truncate-messages-to-budget messages max-tokens))
+        (define new-total (for/sum ([m (in-list truncated)]) (estimate-message-tokens m)))
+        (values truncated new-total)])]))
+
+;; Truncate a message list to fit within a token budget.
+;; Strategy:
+;;   1. Always keep system-instruction and compaction-summary messages
+;;   2. Remove oldest non-system messages until within budget
+;;   3. Return truncated list
+(define (truncate-messages-to-budget messages max-tokens)
+  (cond
+    [(null? messages) '()]
+    [(<= (for/sum ([m (in-list messages)]) (estimate-message-tokens m))
+         max-tokens)
+     messages]
+    [else
+     ;; Separate protected (system/compaction) from removable messages
+     (define-values (protected removable)
+       (partition (lambda (m)
+                    (memq (message-kind m) '(system-instruction compaction-summary)))
+                  messages))
+     ;; Protected messages always included; drop oldest removable until budget met
+     (define protected-tokens
+       (for/sum ([m (in-list protected)]) (estimate-message-tokens m)))
+     (define remaining-budget (- max-tokens protected-tokens))
+     (cond
+       [(<= remaining-budget 0) protected]
+       [else
+        ;; Keep most recent removable messages that fit
+        (define kept-removable
+          (fit-messages-from-recent removable remaining-budget))
+        ;; Reassemble in original order: protected + kept-removable
+        ;; (preserving order from original messages list)
+        (define kept-ids (for/set ([m (in-list kept-removable)]) (message-id m)))
+        (for/list ([m (in-list messages)]
+                   #:when (or (memq (message-kind m) '(system-instruction compaction-summary))
+                              (set-member? kept-ids (message-id m))))
+          m)])]))
+
+;; Fit as many messages as possible from the recent end within a token budget.
+;; Returns messages in their original order.
+(define (fit-messages-from-recent messages budget)
+  (let loop ([remaining (reverse messages)]
+             [acc '()]
+             [used 0])
+    (cond
+      [(null? remaining) (reverse acc)]
+      [else
+       (define m (car remaining))
+       (define tokens (estimate-message-tokens m))
+       (cond
+         [(> (+ used tokens) budget) (reverse acc)]
+         [else (loop (cdr remaining) (cons m acc) (+ used tokens))])])))
 
 ;; ============================================================
 ;; Utility

--- a/tests/test-context-builder.rkt
+++ b/tests/test-context-builder.rkt
@@ -119,3 +119,95 @@
    ))
 
 (run-tests context-builder-tests)
+
+;; ============================================================
+;; Token-aware context assembly tests (#646, #647)
+;; ============================================================
+
+(define token-aware-tests
+  (test-suite
+   "Token-aware context assembly"
+
+   (test-case "estimate-message-tokens: empty message"
+     (define msg (make-message "m1" #f 'user 'message (list) 1000 (hash)))
+     (check-equal? (estimate-message-tokens msg) 0))
+
+   (test-case "estimate-message-tokens: text message"
+     (define msg (make-message "m1" #f 'user 'message
+                               (list (make-text-part "Hello world")) 1000 (hash)))
+     (check-true (>= (estimate-message-tokens msg) 1)))
+
+   (test-case "estimate-message-tokens: long message"
+     (define long-text (make-string 1000 #\a))
+     (define msg (make-message "m1" #f 'user 'message
+                               (list (make-text-part long-text)) 1000 (hash)))
+     (define tokens (estimate-message-tokens msg))
+     (check-true (> tokens 0)))
+
+   (test-case "truncate-messages-to-budget: messages within budget are unchanged"
+     (define msgs
+       (for/list ([i (in-range 3)])
+         (make-message (format "m~a" i) #f 'user 'message
+                       (list (make-text-part "short")) 1000 (hash))))
+     (define result (truncate-messages-to-budget msgs 10000))
+     (check-equal? (length result) 3))
+
+   (test-case "truncate-messages-to-budget: truncates oldest when over budget"
+     (define msgs
+       (for/list ([i (in-range 10)])
+         (make-message (format "m~a" i) #f 'user 'message
+                       (list (make-text-part (make-string 100 #\x))) 1000 (hash))))
+     ;; Each message ~25 tokens. 10 messages = ~250 tokens. Budget 100 → ~4 fit.
+     (define result (truncate-messages-to-budget msgs 100))
+     (check-true (< (length result) 10))
+     (check-true (>= (length result) 1))
+     ;; Should keep the most recent messages (highest index)
+     (check-equal? (message-id (last result)) "m9"))
+
+   (test-case "truncate-messages-to-budget: preserves system instructions"
+     (define sys-msg
+       (make-message "sys" #f 'system 'system-instruction
+                     (list (make-text-part "You are helpful.")) 1000 (hash)))
+     (define user-msgs
+       (for/list ([i (in-range 10)])
+         (make-message (format "m~a" i) #f 'user 'message
+                       (list (make-text-part (make-string 100 #\x))) 1000 (hash))))
+     (define msgs (cons sys-msg user-msgs))
+     ;; Tiny budget — system instruction should survive
+     (define result (truncate-messages-to-budget msgs 10))
+     (define sys-remaining (filter (lambda (m) (eq? (message-kind m) 'system-instruction)) result))
+     (check-equal? (length sys-remaining) 1)
+     (check-equal? (message-id (car sys-remaining)) "sys"))
+
+   (test-case "truncate-messages-to-budget: preserves compaction summaries"
+     (define summary-msg
+       (make-message "summary1" #f 'system 'compaction-summary
+                     (list (make-text-part "Summary of old messages")) 1000 (hash)))
+     (define user-msgs
+       (for/list ([i (in-range 10)])
+         (make-message (format "m~a" i) #f 'user 'message
+                       (list (make-text-part (make-string 100 #\x))) 1000 (hash))))
+     (define msgs (cons summary-msg user-msgs))
+     (define result (truncate-messages-to-budget msgs 10))
+     (define summaries (filter (lambda (m) (eq? (message-kind m) 'compaction-summary)) result))
+     (check-equal? (length summaries) 1))
+
+   (test-case "truncate-messages-to-budget: empty list returns empty"
+     (check-equal? (truncate-messages-to-budget '() 100) '()))
+
+   (test-case "build-session-context/tokens: returns values"
+     (define dir (make-temp-dir))
+     (define sp (session-path dir))
+     (define ip (build-path dir "index.jsonl"))
+     (define entries
+       (list (make-timestamped-message "root" #f 'user 'message 1000)
+             (make-timestamped-message "c1" "root" 'assistant 'message 1001)))
+     (append-entries! sp entries)
+     (define idx (build-index! sp ip))
+     (define-values (msgs tokens) (build-session-context/tokens idx #:max-tokens 10000))
+     (check-true (>= (length msgs) 1))
+     (check-true (>= tokens 0))
+     (delete-directory/files dir #:must-exist? #f))
+   ))
+
+(run-tests token-aware-tests)


### PR DESCRIPTION
## Wave 6: Unify Context Assembly Pipeline

Fixes #646, #647, #648

### Changes

**#646: Token-aware truncation in build-session-context**
- New `build-session-context/tokens` takes `#:max-tokens` budget
- Returns `(values messages total-tokens)` — caller gets exact token count
- Falls back to full context when within budget

**#647: Token-aware message truncation**
- New `truncate-messages-to-budget` preserves system-instruction and compaction-summary
- Removes oldest removable messages until within budget
- `fit-messages-from-recent` keeps most recent messages that fit

**#648: Deprecate orphaned build-tiered-context**
- Marked as DEPRECATED in compactor.rkt with migration note
- `build-session-context/tokens` is the recommended replacement
- Existing API preserved for backward compatibility

### New Exports
- `build-session-context/tokens`
- `truncate-messages-to-budget`
- `estimate-message-tokens`

### Tests
- 9 new tests in `test-context-builder.rkt`
- All 14 context-builder tests pass
- All 35 compactor tests pass

### Verification
```
raco test q/tests/test-context-builder.rkt    # 14 passed
raco test q/tests/test-compaction-edge-cases.rkt # 24 passed
racket q/scripts/lint-format.rkt              # PASSED
```