### PR TITLE
[v0.9.4] Token-based Compaction Window Split (#689)

### DIFF
--- a/runtime/token-compaction.rkt
+++ b/runtime/token-compaction.rkt
@@ -1,0 +1,131 @@
+#lang racket/base
+
+;; runtime/token-compaction.rkt — Token-based compaction window split (#686-#689)
+;;
+;; Provides token-aware compaction window calculation that replaces
+;; fixed-count window splitting with token-budget-based splitting.
+;;
+;; #686: Backward token walk for compaction boundary
+;; #687: Configurable keep-recent-tokens and reserve-tokens
+;; #688: Token estimation fallback for messages without usage data
+;; #689: Token-based compaction window split (parent)
+;;
+;; Instead of "keep last N messages", the token-based approach walks
+;; messages backward accumulating estimated tokens until the budget is
+;; met. Messages beyond the budget are candidates for summarization.
+
+(require racket/contract
+         racket/list
+         "../util/protocol-types.rkt"
+         "../llm/token-budget.rkt"
+         "context-builder.rkt")
+
+(provide
+ (struct-out token-compaction-config)
+ ;; Token-based window split
+ build-token-summary-window
+ ;; Backward token walk
+ backward-token-walk
+ ;; Token estimation for message lists
+ estimate-messages-tokens
+ ;; Configuration helpers
+ default-token-compaction-config
+ make-token-compaction-config)
+
+;; ============================================================
+;; #687: Token compaction configuration
+;; ============================================================
+
+;; Token-based compaction configuration.
+;; keep-recent-tokens : how many tokens of recent messages to keep verbatim
+;; reserve-tokens     : tokens reserved for system prompt + response headroom
+;; max-context-tokens : total context window size (default: 100k)
+(struct token-compaction-config (keep-recent-tokens
+                                 reserve-tokens
+                                 max-context-tokens)
+  #:transparent)
+
+;; Default: keep 30k tokens of recent messages, reserve 10k for system/response
+(define (default-token-compaction-config)
+  (token-compaction-config 30000 10000 DEFAULT-TOKEN-BUDGET-THRESHOLD))
+
+;; Constructor with defaults
+(define (make-token-compaction-config #:keep-recent-tokens [keep-recent 30000]
+                                      #:reserve-tokens [reserve 10000]
+                                      #:max-context-tokens [max-ctx DEFAULT-TOKEN-BUDGET-THRESHOLD])
+  (token-compaction-config keep-recent reserve max-ctx))
+
+;; ============================================================
+;; #688: Token estimation for message lists
+;; ============================================================
+
+;; Estimate total tokens for a list of messages.
+;; Uses estimate-message-tokens from context-builder which handles
+;; text-part extraction and heuristic token estimation.
+(define (estimate-messages-tokens messages)
+  (for/sum ([m (in-list messages)])
+    (estimate-message-tokens m)))
+
+;; ============================================================
+;; #686: Backward token walk for compaction boundary
+;; ============================================================
+
+;; Walk messages from newest to oldest, accumulating tokens.
+;; Returns (values kept-messages overflow-messages) where:
+;;   kept-messages    : messages that fit within the keep-recent budget (in original order)
+;;   overflow-messages : messages beyond the budget (in original order, to be summarized)
+;;
+;; The walk stops accumulating when adding another message would exceed
+;; keep-recent-tokens. Messages beyond that point are overflow candidates.
+(define (backward-token-walk messages keep-recent-tokens)
+  (define n (length messages))
+  ;; Walk from end (index n-1) toward beginning
+  (let loop ([i (sub1 n)]
+             [used-tokens 0])
+    (cond
+      [(< i 0)
+       ;; All messages fit within budget
+       (values messages '())]
+      [else
+       (define msg (list-ref messages i))
+       (define msg-tokens (estimate-message-tokens msg))
+       (define new-total (+ used-tokens msg-tokens))
+       (cond
+         ;; Still within budget — include this message and continue walking
+         [(<= new-total keep-recent-tokens)
+          (loop (sub1 i) new-total)]
+         ;; Budget exceeded — messages[0..i] are overflow, messages[i+1..n-1] are kept
+         [else
+          (define overflow (take messages (add1 i)))
+          (define kept (drop messages (add1 i)))
+          (values kept overflow)])])))
+
+;; ============================================================
+;; #689: Token-based compaction window split
+;; ============================================================
+
+;; Split messages into old (to summarize) and recent (to keep) based
+;; on token budgets rather than fixed message counts.
+;;
+;; Strategy:
+;;   1. Calculate effective budget: max-context - reserve-tokens
+;;   2. Walk backward from newest messages, keeping up to keep-recent-tokens
+;;   3. Older messages become the summarization window
+;;
+;; Returns (values old-messages recent-messages)
+(define (build-token-summary-window messages config)
+  (define keep-recent (token-compaction-config-keep-recent-tokens config))
+  (define reserve (token-compaction-config-reserve-tokens config))
+  (define max-ctx (token-compaction-config-max-context-tokens config))
+
+  (define effective-budget (- max-ctx reserve))
+
+  ;; If total messages fit within effective budget, nothing to summarize
+  (define total-tokens (estimate-messages-tokens messages))
+  (cond
+    [(<= total-tokens effective-budget)
+     (values '() messages)]
+    [else
+     ;; Use backward token walk to find the split point
+     (define-values (kept overflow) (backward-token-walk messages keep-recent))
+     (values overflow kept)]))

--- a/tests/test-token-compaction.rkt
+++ b/tests/test-token-compaction.rkt
@@ -1,0 +1,212 @@
+#lang racket
+
+;; tests/test-token-compaction.rkt — tests for Token-based Compaction (#686-#689)
+;;
+;; Covers:
+;;   - #687: Configurable keep-recent-tokens and reserve-tokens
+;;   - #688: Token estimation fallback for messages without usage data
+;;   - #686: Backward token walk for compaction boundary
+;;   - #689: Token-based compaction window split
+
+(require rackunit
+         "../util/protocol-types.rkt"
+         "../runtime/token-compaction.rkt"
+         "../llm/token-budget.rkt")
+
+;; ============================================================
+;; Helpers
+;; ============================================================
+
+;; Create a simple text message
+(define (make-test-msg role text)
+  (make-message (format "msg-~a" (current-milliseconds))
+                #f role 'text
+                (list (make-text-part text))
+                (current-seconds)
+                (hasheq)))
+
+;; Create a message with known approximate token count
+;; estimate-text-tokens uses chars/4 ratio for plain text
+(define (make-msg-with-tokens role approx-tokens)
+  (define chars (* approx-tokens 4))
+  (make-test-msg role (make-string chars #\a)))
+
+;; ============================================================
+;; #687: Token compaction configuration
+;; ============================================================
+
+(test-case "default-token-compaction-config has sensible defaults"
+  (define cfg (default-token-compaction-config))
+  (check-true (token-compaction-config? cfg))
+  (check-equal? (token-compaction-config-keep-recent-tokens cfg) 30000)
+  (check-equal? (token-compaction-config-reserve-tokens cfg) 10000)
+  (check-equal? (token-compaction-config-max-context-tokens cfg) DEFAULT-TOKEN-BUDGET-THRESHOLD))
+
+(test-case "make-token-compaction-config accepts keyword overrides"
+  (define cfg (make-token-compaction-config #:keep-recent-tokens 5000
+                                            #:reserve-tokens 2000
+                                            #:max-context-tokens 50000))
+  (check-equal? (token-compaction-config-keep-recent-tokens cfg) 5000)
+  (check-equal? (token-compaction-config-reserve-tokens cfg) 2000)
+  (check-equal? (token-compaction-config-max-context-tokens cfg) 50000))
+
+(test-case "token-compaction-config is transparent"
+  (define cfg (token-compaction-config 1000 500 10000))
+  (check-equal? (token-compaction-config-keep-recent-tokens cfg) 1000)
+  (check-equal? (token-compaction-config-reserve-tokens cfg) 500)
+  (check-equal? (token-compaction-config-max-context-tokens cfg) 10000))
+
+;; ============================================================
+;; #688: Token estimation for messages
+;; ============================================================
+
+(test-case "estimate-messages-tokens returns 0 for empty list"
+  (check-equal? (estimate-messages-tokens '()) 0))
+
+(test-case "estimate-messages-tokens sums across messages"
+  (define msgs (list (make-msg-with-tokens 'user 100)
+                     (make-msg-with-tokens 'assistant 200)))
+  (define total (estimate-messages-tokens msgs))
+  (check-true (> total 0))
+  ;; Should be approximately 300 tokens (with chars/4 heuristic)
+  (check-true (<= total 400))
+  (check-true (>= total 250)))
+
+(test-case "estimate-messages-tokens handles messages without content parts"
+  ;; A message with empty content should contribute 0 tokens
+  (define msg (make-message "m1" #f 'user 'text '() (current-seconds) (hasheq)))
+  (check-equal? (estimate-messages-tokens (list msg)) 0))
+
+(test-case "estimate-messages-tokens handles mixed content"
+  (define msgs (list (make-test-msg 'user "short")
+                     (make-msg-with-tokens 'assistant 50)))
+  (define total (estimate-messages-tokens msgs))
+  (check-true (> total 0)))
+
+;; ============================================================
+;; #686: Backward token walk
+;; ============================================================
+
+(test-case "backward-token-walk: all messages fit within budget"
+  (define msgs (list (make-test-msg 'user "hello")
+                     (make-test-msg 'assistant "hi there")))
+  (define-values (kept overflow) (backward-token-walk msgs 10000))
+  (check-equal? kept msgs)
+  (check-equal? overflow '()))
+
+(test-case "backward-token-walk: empty messages"
+  (define-values (kept overflow) (backward-token-walk '() 1000))
+  (check-equal? kept '())
+  (check-equal? overflow '()))
+
+(test-case "backward-token-walk: single message exceeds budget"
+  (define msgs (list (make-msg-with-tokens 'user 100)))
+  (define-values (kept overflow) (backward-token-walk msgs 5))
+  (check-equal? kept '())
+  (check-equal? (length overflow) 1))
+
+(test-case "backward-token-walk: splits at budget boundary"
+  ;; 5 messages of ~100 tokens each, budget of 200 tokens
+  ;; Should keep ~2 most recent messages, overflow ~3 older ones
+  (define msgs (for/list ([i (in-range 5)])
+                 (make-msg-with-tokens 'user 100)))
+  (define-values (kept overflow) (backward-token-walk msgs 200))
+  ;; Kept should be the most recent messages
+  (check-true (>= (length kept) 1))
+  (check-true (<= (length kept) 2))
+  ;; Overflow should be the older messages
+  (check-true (>= (length overflow) 3))
+  ;; Total should equal original count
+  (check-equal? (+ (length kept) (length overflow)) 5))
+
+(test-case "backward-token-walk: preserves message order"
+  (define msgs (list (make-test-msg 'user "first")
+                     (make-test-msg 'assistant "second")
+                     (make-test-msg 'user "third")))
+  (define-values (kept overflow) (backward-token-walk msgs 100))
+  ;; Both kept and overflow should maintain original order
+  (check-equal? (+ (length kept) (length overflow)) 3)
+  ;; If split, first message should be in overflow
+  (when (> (length overflow) 0)
+    (check-equal? (text-part-text (car (message-content (car overflow)))) "first")))
+
+;; ============================================================
+;; #689: Token-based compaction window split
+;; ============================================================
+
+(test-case "build-token-summary-window: nothing to summarize when under budget"
+  (define cfg (make-token-compaction-config #:keep-recent-tokens 50000
+                                            #:reserve-tokens 1000
+                                            #:max-context-tokens 100000))
+  (define msgs (list (make-test-msg 'user "hello")
+                     (make-test-msg 'assistant "world")))
+  (define-values (old recent) (build-token-summary-window msgs cfg))
+  (check-equal? old '())
+  (check-equal? recent msgs))
+
+(test-case "build-token-summary-window: splits when over budget"
+  (define cfg (make-token-compaction-config #:keep-recent-tokens 100
+                                            #:reserve-tokens 50
+                                            #:max-context-tokens 500))
+  ;; Create messages totaling well over 450 tokens (500 - 50 reserve)
+  (define msgs (for/list ([i (in-range 10)])
+                 (make-msg-with-tokens 'user 100)))
+  (define-values (old recent) (build-token-summary-window msgs cfg))
+  ;; Should have something to summarize
+  (check-true (> (length old) 0))
+  ;; Recent should be non-empty
+  (check-true (> (length recent) 0))
+  ;; Total should equal original count
+  (check-equal? (+ (length old) (length recent)) 10))
+
+(test-case "build-token-summary-window: empty messages returns empty"
+  (define cfg (default-token-compaction-config))
+  (define-values (old recent) (build-token-summary-window '() cfg))
+  (check-equal? old '())
+  (check-equal? recent '()))
+
+(test-case "build-token-summary-window: reserve tokens reduce effective budget"
+  (define cfg (make-token-compaction-config #:keep-recent-tokens 50
+                                            #:reserve-tokens 450
+                                            #:max-context-tokens 500))
+  ;; With only 50 effective budget (500 - 450), even small messages
+  ;; should trigger overflow quickly
+  (define msgs (for/list ([i (in-range 5)])
+                 (make-msg-with-tokens 'user 100)))
+  (define-values (old recent) (build-token-summary-window msgs cfg))
+  ;; Most should be overflow
+  (check-true (>= (length old) 3)))
+
+(test-case "build-token-summary-window: kept messages are the most recent"
+  (define cfg (make-token-compaction-config #:keep-recent-tokens 100
+                                            #:reserve-tokens 0
+                                            #:max-context-tokens 500))
+  ;; 5 messages of 100 tokens each = 500 tokens total
+  ;; keep-recent-tokens = 100, so only ~1 recent message kept
+  (define msgs (for/list ([i (in-range 5)])
+                 (make-message (format "msg-~a" i) #f 'user 'text
+                               (list (make-text-part (format "message-~a" i)))
+                               (current-seconds) (hasheq))))
+  (define-values (old recent) (build-token-summary-window msgs cfg))
+  ;; The most recent message should be in 'recent'
+  (when (and (> (length recent) 0) (> (length old) 0))
+    (define last-recent (car (take-right recent 1)))
+    (check-equal? (message-id last-recent) "msg-4")))
+
+(test-case "build-token-summary-window: integrates with estimate-messages-tokens"
+  ;; Verify that the split is consistent with token estimates
+  ;; Use a small max-context to force overflow
+  (define cfg (make-token-compaction-config #:keep-recent-tokens 200
+                                            #:reserve-tokens 0
+                                            #:max-context-tokens 400))
+  ;; 8 messages of 100 tokens each = 800 tokens total
+  ;; max-context = 400, so effective budget = 400
+  ;; keep-recent = 200, so ~2 recent messages kept
+  (define msgs (for/list ([i (in-range 8)])
+                 (make-msg-with-tokens 'user 100)))
+  (define-values (old recent) (build-token-summary-window msgs cfg))
+  (check-true (> (length old) 0))
+  (check-true (> (length recent) 0))
+  ;; Recent messages should use roughly <= keep-recent-tokens (with estimation slack)
+  (define recent-tokens (estimate-messages-tokens recent))
+  (check-true (<= recent-tokens 250)))


### PR DESCRIPTION
## Token-based Compaction Window Split

Implements Wave 0 of v0.9.4 milestone (Compaction Intelligence).

### Changes
- **#687**: Configurable `keep-recent-tokens` and `reserve-tokens` via `token-compaction-config` struct
- **#688**: Token estimation fallback for messages without usage data using `estimate-messages-tokens`
- **#686**: Backward token walk for compaction boundary — walks newest→oldest accumulating tokens
- **#689**: Token-based compaction window split — replaces fixed-count splitting with budget-aware splitting

New module `runtime/token-compaction.rkt` provides:
- `token-compaction-config` struct with sensible defaults (30k keep, 10k reserve, 100k max)
- `backward-token-walk` — token-budget-aware boundary detection
- `build-token-summary-window` — drop-in replacement for count-based `build-summary-window`
- `estimate-messages-tokens` — convenient token estimation for message lists

18 new tests, all pass.

Closes #686
Closes #687
Closes #688