### PR TITLE
[v0.9.4] Split-turn Detection and Handling (#692)

### DIFF
--- a/runtime/split-turn.rkt
+++ b/runtime/split-turn.rkt
@@ -1,0 +1,149 @@
+#lang racket/base
+
+;; runtime/split-turn.rkt — Split-turn detection and handling (#690-#692)
+;;
+;; When a compaction window split falls in the middle of a multi-message
+;; turn (user → assistant → tool_calls → tool_results → next user), we
+;; must detect the split and produce a turn-prefix summary so the
+;; assistant retains context about the truncated turn.
+;;
+;; Turn model:
+;;   A "turn" starts with a user message and includes all subsequent
+;;   assistant, tool-call, and tool-result messages until the next user
+;;   message (or end of history).
+;;
+;;   Turn boundary = user-role message (or system-instruction).
+;;
+;; #690: detect-split-turn — check if split index falls mid-turn
+;; #691: generate-turn-prefix — summarize the partial turn
+;; #692: parent feature combining both
+
+(require racket/contract
+         racket/list
+         racket/string
+         "../util/protocol-types.rkt")
+
+(provide
+ ;; #690: Split-turn detection
+ split-turn-result?
+ find-split-turn
+ split-turn-result-split-index
+ split-turn-result-turn-start-index
+ split-turn-result-turn-messages
+ split-turn-result-is-split?
+ ;; #691: Turn-prefix generation
+ generate-turn-prefix
+ ;; Turn boundary helpers
+ find-turn-start
+ messages-at-turn-boundary
+ turn-start-index)
+
+;; ============================================================
+;; #690: Split-turn detection
+;; ============================================================
+
+;; Result of split-turn analysis.
+;; split-index     : where the compaction cut was made
+;; turn-start-index: index of the start of the turn containing the cut
+;; turn-messages   : messages in the partial turn (from turn-start to split-index)
+;; is-split?       : #t if the cut falls mid-turn (turn-start != split-index)
+(struct split-turn-result (split-index
+                           turn-start-index
+                           turn-messages
+                           is-split?)
+  #:transparent)
+
+;; Check if a message is a turn-start (user role or system-instruction kind).
+(define (turn-start? msg)
+  (or (eq? (message-role msg) 'user)
+      (eq? (message-kind msg) 'system-instruction)))
+
+;; Find the index of the start of the turn containing the given index.
+;; Walks backward from index to find the nearest turn-start message.
+(define (turn-start-index messages idx)
+  (let loop ([i idx])
+    (cond
+      [(< i 0) 0]
+      [(turn-start? (list-ref messages i)) i]
+      [else (loop (sub1 i))])))
+
+;; Find the full turn start index (exported alias for clarity).
+(define (find-turn-start messages idx)
+  (turn-start-index messages idx))
+
+;; Analyze whether a split at split-index falls mid-turn.
+;; A split at index N means messages[0..N) are old (to summarize)
+;; and messages[N..] are recent (to keep). The split is clean if
+;; messages[N] starts a new turn (user or system-instruction).
+;; Returns a split-turn-result.
+(define (find-split-turn messages split-index)
+  (cond
+    ;; Edge cases: no messages or split at end
+    [(or (null? messages) (>= split-index (length messages)))
+     (split-turn-result split-index split-index '() #f)]
+    ;; Split at index 0 = everything is recent, no split
+    [(= split-index 0)
+     (split-turn-result 0 0 '() #f)]
+    [else
+     ;; Check if the first "recent" message starts a new turn
+     (define first-recent (list-ref messages split-index))
+     (define at-turn-boundary? (turn-start? first-recent))
+     (cond
+       [at-turn-boundary?
+        ;; Clean split — no turn is truncated
+        (split-turn-result split-index split-index '() #f)]
+       [else
+        ;; Mid-turn split — find where this partial turn starts
+        (define ts-idx (turn-start-index messages split-index))
+        (define turn-msgs (take (drop messages ts-idx) (- split-index ts-idx)))
+        (split-turn-result split-index ts-idx turn-msgs #t)])]))
+
+;; Adjust a split index to align with the nearest turn boundary.
+;; If the split falls mid-turn, moves backward to the turn start.
+;; Returns the adjusted index.
+(define (messages-at-turn-boundary messages split-index)
+  (define result (find-split-turn messages split-index))
+  (if (split-turn-result-is-split? result)
+      (split-turn-result-turn-start-index result)
+      split-index))
+
+;; ============================================================
+;; #691: Turn-prefix generation
+;; ============================================================
+
+;; Generate a text summary prefix for a partial turn.
+;; This captures the essence of what was happening in the truncated turn
+;; so the assistant has context even though the full turn is summarized.
+;;
+;; The prefix includes:
+;;   - Role annotations for each message
+;;   - Text content (truncated per message if very long)
+;;   - A structural summary header
+(define (generate-turn-prefix turn-messages)
+  (cond
+    [(null? turn-messages) ""]
+    [else
+     (define parts
+       (for/list ([msg (in-list turn-messages)])
+         (define role (message-role msg))
+         (define text (extract-message-text msg))
+         (define truncated (if (> (string-length text) 500)
+                               (string-append (substring text 0 500) "...")
+                               text))
+         (format "[~a] ~a" role truncated)))
+     (string-append
+      "--- TURN PREFIX (partial turn before compaction) ---\n"
+      (string-join parts "\n")
+      "\n--- END TURN PREFIX ---")]))
+
+;; Extract text from a single message
+(define (extract-message-text msg)
+  (define content (message-content msg))
+  (cond
+    [(string? content) content]
+    [(list? content)
+     (string-append*
+      (for/list ([part (in-list content)]
+                 #:when (text-part? part))
+        (text-part-text part)))]
+    [else ""]))

--- a/tests/test-split-turn.rkt
+++ b/tests/test-split-turn.rkt
@@ -1,0 +1,207 @@
+#lang racket
+
+;; tests/test-split-turn.rkt — tests for Split-turn Detection (#690-#692)
+;;
+;; Covers:
+;;   - #690: detect split-turn during compaction window calculation
+;;   - #691: generate turn-prefix summary
+;;   - #692: parent feature integration
+
+(require rackunit
+         "../util/protocol-types.rkt"
+         "../runtime/split-turn.rkt")
+
+;; ============================================================
+;; Helpers
+;; ============================================================
+
+(define msg-counter 0)
+(define (next-id!)
+  (set! msg-counter (add1 msg-counter))
+  (format "msg-~a" msg-counter))
+
+(define (make-user-msg text)
+  (make-message (next-id!) #f 'user 'text
+                (list (make-text-part text))
+                (current-seconds) (hasheq)))
+
+(define (make-assistant-msg text)
+  (make-message (next-id!) #f 'assistant 'text
+                (list (make-text-part text))
+                (current-seconds) (hasheq)))
+
+(define (make-tool-result-msg text)
+  (make-message (next-id!) #f 'tool 'tool-result
+                (list (make-text-part text))
+                (current-seconds) (hasheq)))
+
+(define (make-system-msg text)
+  (make-message (next-id!) #f 'system 'system-instruction
+                (list (make-text-part text))
+                (current-seconds) (hasheq)))
+
+;; A typical multi-message turn: user → assistant → tool_result → assistant
+(define (make-full-turn user-text assistant-text tool-text final-text)
+  (list (make-user-msg user-text)
+        (make-assistant-msg assistant-text)
+        (make-tool-result-msg tool-text)
+        (make-assistant-msg final-text)))
+
+;; ============================================================
+;; #690: Split-turn detection
+;; ============================================================
+
+(test-case "find-split-turn: empty messages returns no split"
+  (define result (find-split-turn '() 0))
+  (check-false (split-turn-result-is-split? result)))
+
+(test-case "find-split-turn: split at index 0 is not a split"
+  (define msgs (list (make-user-msg "hello")))
+  (define result (find-split-turn msgs 0))
+  (check-false (split-turn-result-is-split? result))
+  (check-equal? (split-turn-result-split-index result) 0))
+
+(test-case "find-split-turn: split at user boundary is not a split"
+  ;; Two complete turns, split between them
+  (define msgs (append (make-full-turn "q1" "a1" "t1" "f1")
+                       (make-full-turn "q2" "a2" "t2" "f2")))
+  ;; Split at index 4 (start of second turn = user message)
+  (define result (find-split-turn msgs 4))
+  (check-false (split-turn-result-is-split? result)))
+
+(test-case "find-split-turn: split mid-turn detects split"
+  ;; One full turn + start of second turn, split in middle of second turn
+  (define msgs (append (make-full-turn "q1" "a1" "t1" "f1")
+                       (list (make-user-msg "q2")
+                             (make-assistant-msg "a2")
+                             (make-tool-result-msg "t2"))))
+  ;; Split at index 6 (after tool result but before turn completes)
+  ;; The turn starts at index 4 (user "q2"), split at 6 is mid-turn
+  (define result (find-split-turn msgs 6))
+  (check-true (split-turn-result-is-split? result))
+  (check-equal? (split-turn-result-turn-start-index result) 4)
+  (check-equal? (length (split-turn-result-turn-messages result)) 2))
+
+(test-case "find-split-turn: split after assistant in turn"
+  (define msgs (list (make-user-msg "q1")
+                     (make-assistant-msg "a1")
+                     (make-assistant-msg "continuing")))
+  ;; Split at index 2 (after second assistant msg, mid-turn)
+  (define result (find-split-turn msgs 2))
+  (check-true (split-turn-result-is-split? result))
+  (check-equal? (split-turn-result-turn-start-index result) 0))
+
+(test-case "find-split-turn: turn-messages contains the partial turn"
+  (define msgs (list (make-user-msg "q1")
+                     (make-assistant-msg "a1")
+                     (make-tool-result-msg "t1")
+                     (make-assistant-msg "f1")
+                     (make-user-msg "q2")
+                     (make-assistant-msg "a2")))
+  ;; Split at index 5 (mid second turn, after assistant)
+  (define result (find-split-turn msgs 5))
+  (check-true (split-turn-result-is-split? result))
+  (check-equal? (split-turn-result-turn-start-index result) 4)
+  ;; Turn messages = index 4 only (user "q2") — split is at 5, so messages[4..5) = just user
+  (check-equal? (length (split-turn-result-turn-messages result)) 1))
+
+(test-case "turn-start-index: finds user message"
+  (define msgs (list (make-user-msg "q1")
+                     (make-assistant-msg "a1")))
+  (check-equal? (turn-start-index msgs 1) 0))
+
+(test-case "turn-start-index: user at index 0"
+  (define msgs (list (make-user-msg "q1")))
+  (check-equal? (turn-start-index msgs 0) 0))
+
+(test-case "messages-at-turn-boundary: adjusts mid-turn to turn start"
+  (define msgs (list (make-user-msg "q1")
+                     (make-assistant-msg "a1")
+                     (make-tool-result-msg "t1")))
+  (define adjusted (messages-at-turn-boundary msgs 2))
+  (check-equal? adjusted 0))
+
+(test-case "messages-at-turn-boundary: keeps turn-boundary split"
+  (define msgs (append (make-full-turn "q1" "a1" "t1" "f1")
+                       (make-full-turn "q2" "a2" "t2" "f2")))
+  (define adjusted (messages-at-turn-boundary msgs 4))
+  (check-equal? adjusted 4))
+
+(test-case "find-turn-start: finds nearest user message backward"
+  (define msgs (list (make-user-msg "q1")
+                     (make-assistant-msg "a1")
+                     (make-tool-result-msg "t1")
+                     (make-user-msg "q2")
+                     (make-assistant-msg "a2")))
+  (check-equal? (find-turn-start msgs 4) 3)
+  (check-equal? (find-turn-start msgs 2) 0))
+
+;; ============================================================
+;; #691: Turn-prefix generation
+;; ============================================================
+
+(test-case "generate-turn-prefix: empty messages returns empty string"
+  (check-equal? (generate-turn-prefix '()) ""))
+
+(test-case "generate-turn-prefix: includes role annotations"
+  (define msgs (list (make-user-msg "what is 2+2?")
+                     (make-assistant-msg "let me calculate")))
+  (define prefix (generate-turn-prefix msgs))
+  (check-true (string-contains? prefix "[user]"))
+  (check-true (string-contains? prefix "[assistant]"))
+  (check-true (string-contains? prefix "TURN PREFIX")))
+
+(test-case "generate-turn-prefix: includes message text"
+  (define msgs (list (make-user-msg "what is 2+2?")))
+  (define prefix (generate-turn-prefix msgs))
+  (check-true (string-contains? prefix "what is 2+2?")))
+
+(test-case "generate-turn-prefix: truncates very long messages"
+  (define long-text (make-string 1000 #\x))
+  (define msgs (list (make-user-msg long-text)))
+  (define prefix (generate-turn-prefix msgs))
+  ;; Should be truncated to ~500 chars + "..."
+  (check-true (< (string-length prefix) 700))
+  (check-true (string-contains? prefix "...")))
+
+(test-case "generate-turn-prefix: handles tool-result messages"
+  (define msgs (list (make-user-msg "run bash")
+                     (make-assistant-msg "executing")
+                     (make-tool-result-msg "output: 42")))
+  (define prefix (generate-turn-prefix msgs))
+  (check-true (string-contains? prefix "[tool]"))
+  (check-true (string-contains? prefix "output: 42")))
+
+;; ============================================================
+;; #692: Integration — split-turn with token compaction
+;; ============================================================
+
+(test-case "integration: token-based split with turn detection"
+  ;; Create messages where a token-based split would fall mid-turn
+  (define msgs (append
+                (make-full-turn "question one" "answer one" "tool one" "final one")
+                (list (make-user-msg "question two")
+                      (make-assistant-msg "answer two"))))
+  ;; Simulate split at index 5 (mid second turn)
+  (define split-idx 5)
+  (define result (find-split-turn msgs split-idx))
+  (check-true (split-turn-result-is-split? result))
+  ;; Generate prefix for the partial turn
+  (define prefix (generate-turn-prefix (split-turn-result-turn-messages result)))
+  (check-true (string-contains? prefix "question two"))
+  (check-true (> (string-length prefix) 0)))
+
+(test-case "integration: no prefix needed for clean turn-boundary split"
+  (define msgs (append (make-full-turn "q1" "a1" "t1" "f1")
+                       (make-full-turn "q2" "a2" "t2" "f2")))
+  (define result (find-split-turn msgs 4))
+  (check-false (split-turn-result-is-split? result))
+  (define prefix (generate-turn-prefix (split-turn-result-turn-messages result)))
+  (check-equal? prefix ""))
+
+(test-case "integration: system-instruction counts as turn-start"
+  (define msgs (list (make-system-msg "you are helpful")
+                     (make-user-msg "hello")
+                     (make-assistant-msg "hi")))
+  ;; turn-start at index 0 (system) and index 1 (user)
+  (check-equal? (turn-start-index msgs 2) 1))


### PR DESCRIPTION
## Split-turn Detection and Handling

Implements Wave 1 of v0.9.4 milestone (Compaction Intelligence).

### Changes
- **#690**: Detect split-turn during compaction — `find-split-turn`, `turn-start-index`, `messages-at-turn-boundary`
- **#691**: Turn-prefix summary generation — `generate-turn-prefix` with role annotations and message truncation
- **#692**: Parent feature with integration tests

New module `runtime/split-turn.rkt`:
- `split-turn-result` struct tracking split index, turn start, partial messages, is-split flag
- Turn boundary detection based on user/system-instruction roles
- Turn-prefix summary for truncated turns in compaction output

19 new tests, all pass.

Closes #690
Closes #691
Closes #692