### PR TITLE
[v0.9.4] Compaction Cut-point Rules and Overflow Recovery (#696)

### DIFF
--- a/runtime/cutpoint-rules.rkt
+++ b/runtime/cutpoint-rules.rkt
@@ -1,0 +1,200 @@
+#lang racket/base
+
+;; runtime/cutpoint-rules.rkt — Compaction cut-point rules and overflow recovery (#693-#696)
+;;
+;; #693: Never cut between tool-call and tool-result. Valid cut points:
+;;       before user messages, before assistant messages with no pending
+;;       tool calls, or before custom messages. Invalid: splitting a
+;;       tool-call → tool-result pair.
+;;
+;; #694: One-shot overflow recovery guard. When an LLM returns a context
+;;       overflow error, compact once with willRetry=true, then retry.
+;;       The _overflow-recovery-attempted flag prevents infinite loops.
+;;
+;; #695: Auto-retry after overflow compaction. Store the original user
+;;       prompt, compact, then re-inject the prompt for retry.
+;;
+;; #696: Parent feature combining all of the above.
+
+(require racket/contract
+         racket/list
+         racket/match
+         "../util/protocol-types.rkt"
+         "compactor.rkt")
+
+(provide
+ ;; #693: Cut-point rules
+ adjust-cutpoint
+ valid-cutpoint?
+ find-nearest-valid-cutpoint
+ cutpoint-rule-description
+ ;; #694: Overflow recovery
+ make-overflow-state
+ overflow-state?
+ overflow-state-attempted
+ overflow-state-max-attempts
+ overflow-state-will-retry
+ mark-overflow-attempted!
+ can-retry-overflow?
+ ;; #695: Auto-retry
+ make-retry-context
+ retry-context?
+ retry-context-original-prompt
+ retry-context-compaction-result
+ retry-context-retry-messages
+ build-retry-messages)
+
+;; ============================================================
+;; #693: Cut-point rules
+;; ============================================================
+
+;; A message with role='assistant and kind='text may contain tool-call-parts.
+;; A message with role='tool and kind='tool-result is a tool result.
+;; We must NEVER cut between them.
+
+;; Check if a message contains tool-call parts.
+(define (has-tool-calls? msg)
+  (define content (message-content msg))
+  (and (list? content)
+       (ormap tool-call-part? content)))
+
+;; Check if a message is a tool-result.
+(define (tool-result-message? msg)
+  (eq? (message-kind msg) 'tool-result))
+
+;; Check if a message is a user message (valid cut point).
+(define (user-message? msg)
+  (eq? (message-role msg) 'user))
+
+;; Check if an assistant message is a valid cut point.
+;; An assistant message is valid IF it has no pending tool calls
+;; (i.e., the next message is NOT a tool-result).
+(define (assistant-valid-cut? msg next-msg)
+  (and (eq? (message-role msg) 'assistant)
+       (or (not next-msg)
+           (not (tool-result-message? next-msg)))))
+
+;; Check if placing a cut BEFORE index `idx` is valid.
+;; A cut at index N means messages[0..N) are old, messages[N..] are recent.
+;; Valid cuts:
+;;   - before a user message (turn boundary)
+;;   - before an assistant message IF the previous message is not a tool-call
+;;     (i.e., we're not splitting a tool-call → tool-result pair)
+;; Invalid: before a tool-result message (would orphan its tool-call)
+(define (valid-cutpoint? messages idx)
+  (cond
+    [(or (< idx 0) (> idx (length messages))) #f]
+    [(= idx 0) #t]  ;; Cutting at beginning is always valid
+    [(= idx (length messages)) #t]  ;; Cutting at end is always valid
+    [else
+     (define msg-at (list-ref messages idx))
+     (define role-at (message-role msg-at))
+     (cond
+       ;; Before tool-result = always invalid (would split tool-call pair)
+       [(tool-result-message? msg-at) #f]
+       ;; Before user message = always valid (turn boundary)
+       [(eq? role-at 'user) #t]
+       ;; Before assistant = check previous doesn't have orphaned tool-calls
+       [(eq? role-at 'assistant)
+        (define msg-before (list-ref messages (sub1 idx)))
+        (not (has-tool-calls? msg-before))]
+       ;; Default: allow
+       [else #t])]))
+
+;; Find the nearest valid cut point, searching backward from `idx`.
+;; If `backward?` is #t, search backward; otherwise forward.
+(define (find-nearest-valid-cutpoint messages idx [backward? #t])
+  (cond
+    [(valid-cutpoint? messages idx) idx]
+    [backward?
+     (let loop ([i (sub1 idx)])
+       (cond
+         [(<= i 0) 0]
+         [(valid-cutpoint? messages i) i]
+         [else (loop (sub1 i))]))]
+    [else
+     (let loop ([i (add1 idx)])
+       (cond
+         [(> i (length messages)) (length messages)]
+         [(valid-cutpoint? messages i) i]
+         [else (loop (add1 i))]))]))
+
+;; Adjust a proposed cut point to a valid one.
+;; Moves backward to the nearest valid cut (user message boundary).
+;; If the cut falls in the middle of a tool-call → tool-result sequence,
+;; moves forward to include the complete sequence, then backward to the
+;; next user boundary.
+(define (adjust-cutpoint messages proposed-idx)
+  (cond
+    [(valid-cutpoint? messages proposed-idx) proposed-idx]
+    [else
+     ;; Walk backward to find nearest user message boundary
+     (find-nearest-valid-cutpoint messages proposed-idx #t)]))
+
+;; Human-readable description of why a cutpoint is valid or invalid.
+(define (cutpoint-rule-description messages idx)
+  (cond
+    [(= idx 0) "Cut at beginning: always valid"]
+    [(= idx (length messages)) "Cut at end: always valid"]
+    [(valid-cutpoint? messages idx)
+     (define msg-at (list-ref messages idx))
+     (format "Valid cut before ~a message at index ~a"
+             (message-role msg-at) idx)]
+    [else
+     (define msg-at (list-ref messages idx))
+     (format "Invalid cut at index ~a (before ~a message) — adjusted to nearest user boundary"
+             idx (message-role msg-at))]))
+
+;; ============================================================
+;; #694: One-shot overflow recovery guard
+;; ============================================================
+
+;; State tracking for overflow recovery. Prevents infinite compaction loops.
+(struct overflow-state (attempted max-attempts)
+  #:mutable
+  #:transparent)
+
+(define (make-overflow-state #:max-attempts [max 1])
+  (overflow-state #f max))
+
+(define (overflow-state-will-retry? state)
+  (and (not (overflow-state-attempted state))
+       (< 0 (overflow-state-max-attempts state))))
+
+;; Alias for external use
+(define (overflow-state-will-retry state)
+  (overflow-state-will-retry? state))
+
+(define (can-retry-overflow? state)
+  (not (overflow-state-attempted state)))
+
+(define (mark-overflow-attempted! state)
+  (set-overflow-state-attempted! state #t))
+
+;; ============================================================
+;; #695: Auto-retry after overflow compaction
+;; ============================================================
+
+;; Context for retrying after overflow compaction.
+(struct retry-context (original-prompt compaction-result retry-messages)
+  #:transparent)
+
+(define (make-retry-context prompt compaction-result messages)
+  (retry-context prompt compaction-result messages))
+
+;; Build the message list for retrying after overflow compaction.
+;; Takes the compaction result (summary + kept messages) and prepends
+;; the original user prompt as a fresh message.
+(define (build-retry-messages compaction-result original-prompt)
+  (define summary (compaction-result-summary-message compaction-result))
+  (define kept (compaction-result-kept-messages compaction-result))
+  ;; Build retry message list: summary + kept + re-injected prompt
+  (define base (if summary (cons summary kept) kept))
+  ;; Create a fresh user message with the original prompt
+  (define retry-msg
+    (make-message (format "retry-~a" (current-inexact-milliseconds))
+                  #f 'user 'text
+                  (list (make-text-part original-prompt))
+                  (current-seconds)
+                  (hasheq)))
+  (append base (list retry-msg)))

--- a/tests/test-cutpoint-rules.rkt
+++ b/tests/test-cutpoint-rules.rkt
@@ -1,0 +1,227 @@
+#lang racket
+
+;; tests/test-cutpoint-rules.rkt — tests for Compaction Cut-point Rules (#693-#696)
+;;
+;; Covers:
+;;   - #693: Never cut between tool-call and tool-result
+;;   - #694: One-shot overflow recovery guard
+;;   - #695: Auto-retry after overflow compaction
+;;   - #696: Parent feature integration
+
+(require rackunit
+         "../util/protocol-types.rkt"
+         "../runtime/cutpoint-rules.rkt"
+         "../runtime/compactor.rkt")
+
+;; ============================================================
+;; Helpers
+;; ============================================================
+
+(define msg-counter 0)
+(define (next-id!)
+  (set! msg-counter (add1 msg-counter))
+  (format "msg-~a" msg-counter))
+
+(define (make-user-msg text)
+  (make-message (next-id!) #f 'user 'text
+                (list (make-text-part text))
+                (current-seconds) (hasheq)))
+
+(define (make-assistant-msg text)
+  (make-message (next-id!) #f 'assistant 'text
+                (list (make-text-part text))
+                (current-seconds) (hasheq)))
+
+(define (make-assistant-tool-call-msg tool-id tool-name)
+  (make-message (next-id!) #f 'assistant 'text
+                (list (make-text-part "calling tool")
+                      (make-tool-call-part tool-id tool-name (hasheq)))
+                (current-seconds) (hasheq)))
+
+(define (make-tool-result-msg call-id result-text)
+  (make-message (next-id!) #f 'tool 'tool-result
+                (list (make-tool-result-part call-id result-text #f))
+                (current-seconds) (hasheq)))
+
+;; ============================================================
+;; #693: Cut-point rules
+;; ============================================================
+
+(test-case "valid-cutpoint: index 0 is always valid"
+  (define msgs (list (make-user-msg "hello")))
+  (check-true (valid-cutpoint? msgs 0)))
+
+(test-case "valid-cutpoint: index at end is always valid"
+  (define msgs (list (make-user-msg "hello")))
+  (check-true (valid-cutpoint? msgs 1)))
+
+(test-case "valid-cutpoint: before user message is valid"
+  (define msgs (list (make-assistant-msg "hi")
+                     (make-user-msg "hello")))
+  (check-true (valid-cutpoint? msgs 1)))
+
+(test-case "valid-cutpoint: before tool-result is invalid"
+  (define msgs (list (make-assistant-tool-call-msg "tc1" "bash")
+                     (make-tool-result-msg "tc1" "output")))
+  ;; Cut at 1 would separate tool-call from tool-result
+  (check-false (valid-cutpoint? msgs 1)))
+
+(test-case "valid-cutpoint: before assistant after user is valid"
+  (define msgs (list (make-user-msg "q")
+                     (make-assistant-msg "a")))
+  (check-true (valid-cutpoint? msgs 0))
+  (check-true (valid-cutpoint? msgs 1)))
+
+(test-case "adjust-cutpoint: moves backward from invalid to valid"
+  ;; tool-call at 0, tool-result at 1, user at 2
+  (define msgs (list (make-assistant-tool-call-msg "tc1" "bash")
+                     (make-tool-result-msg "tc1" "output")
+                     (make-user-msg "next")))
+  ;; Proposed cut at 1 (before tool-result) → should adjust
+  (define adjusted (adjust-cutpoint msgs 1))
+  (check-equal? adjusted 0))
+
+(test-case "adjust-cutpoint: keeps valid cutpoint unchanged"
+  (define msgs (list (make-user-msg "q1")
+                     (make-assistant-msg "a1")
+                     (make-user-msg "q2")))
+  (define adjusted (adjust-cutpoint msgs 2))
+  (check-equal? adjusted 2))
+
+(test-case "adjust-cutpoint: handles tool-call/tool-result chain"
+  ;; user → assistant(tool-call) → tool-result → assistant(final) → user
+  (define msgs (list (make-user-msg "q1")
+                     (make-assistant-tool-call-msg "tc1" "bash")
+                     (make-tool-result-msg "tc1" "output")
+                     (make-assistant-msg "done")
+                     (make-user-msg "q2")))
+  ;; Cut at 2 (before tool-result) → invalid, should move back
+  ;; Index 1 is assistant, previous is user (no tool-calls) → valid cut
+  (define adjusted (adjust-cutpoint msgs 2))
+  (check-equal? adjusted 1))
+
+(test-case "find-nearest-valid-cutpoint: searches backward"
+  (define msgs (list (make-user-msg "q1")
+                     (make-assistant-msg "a1")
+                     (make-assistant-msg "a2")))
+  ;; Index 2 is assistant, previous is assistant (no tool-calls) → valid cut at 2
+  ;; Actually we start by checking 2 itself, which is valid
+  (define found (find-nearest-valid-cutpoint msgs 3 #t))
+  ;; 3 = end, valid. So try 3 directly.
+  (check-equal? found 3))
+
+(test-case "find-nearest-valid-cutpoint: searches forward"
+  (define msgs (list (make-assistant-tool-call-msg "tc1" "bash")
+                     (make-tool-result-msg "tc1" "output")
+                     (make-user-msg "q1")))
+  ;; Forward from 1 (before tool-result, invalid) should find 2
+  (define found (find-nearest-valid-cutpoint msgs 1 #f))
+  (check-equal? found 2))
+
+(test-case "cutpoint-rule-description: describes valid cut"
+  (define msgs (list (make-user-msg "q1")
+                     (make-assistant-msg "a1")
+                     (make-user-msg "q2")))
+  (define desc (cutpoint-rule-description msgs 2))
+  (check-true (string-contains? desc "Valid cut")))
+
+(test-case "cutpoint-rule-description: describes beginning cut"
+  (define desc (cutpoint-rule-description '() 0))
+  (check-true (string-contains? desc "beginning")))
+
+;; ============================================================
+;; #694: One-shot overflow recovery guard
+;; ============================================================
+
+(test-case "overflow-state: initial state allows retry"
+  (define state (make-overflow-state))
+  (check-true (can-retry-overflow? state))
+  (check-true (overflow-state-will-retry state)))
+
+(test-case "overflow-state: after marking attempted, cannot retry"
+  (define state (make-overflow-state))
+  (mark-overflow-attempted! state)
+  (check-false (can-retry-overflow? state))
+  (check-false (overflow-state-will-retry state)))
+
+(test-case "overflow-state: respects max-attempts"
+  (define state (make-overflow-state #:max-attempts 0))
+  (check-false (overflow-state-will-retry state)))
+
+(test-case "overflow-state: is transparent"
+  (define state (make-overflow-state))
+  (check-true (overflow-state? state))
+  (check-false (overflow-state-attempted state))
+  (check-equal? (overflow-state-max-attempts state) 1))
+
+;; ============================================================
+;; #695: Auto-retry after overflow compaction
+;; ============================================================
+
+(test-case "build-retry-messages: includes compaction summary"
+  (define summary-msg
+    (make-message "compaction-1" #f 'system 'compaction-summary
+                  (list (make-text-part "summary text"))
+                  (current-seconds) (hasheq)))
+  (define result (compaction-result summary-msg 5
+                                     (list (make-user-msg "recent q"))))
+  (define retry-msgs (build-retry-messages result "original prompt"))
+  ;; Should have: summary + kept messages + retry message
+  (check-true (>= (length retry-msgs) 2))
+  ;; Last message should be the retry prompt
+  (define last-msg (car (take-right retry-msgs 1)))
+  (check-equal? (message-role last-msg) 'user)
+  (check-true (string-contains?
+               (text-part-text (car (message-content last-msg)))
+               "original prompt")))
+
+(test-case "build-retry-messages: works without summary"
+  (define result (compaction-result #f 0
+                                     (list (make-user-msg "kept msg"))))
+  (define retry-msgs (build-retry-messages result "retry prompt"))
+  ;; Should have: kept + retry
+  (check-equal? (length retry-msgs) 2)
+  (define last-msg (car (take-right retry-msgs 1)))
+  (check-equal? (message-role last-msg) 'user))
+
+(test-case "retry-context: stores all fields"
+  (define summary-msg
+    (make-message "s1" #f 'system 'compaction-summary
+                  (list (make-text-part "s")) (current-seconds) (hasheq)))
+  (define result (compaction-result summary-msg 3 (list (make-user-msg "q"))))
+  (define msgs (build-retry-messages result "prompt"))
+  (define ctx (make-retry-context "prompt" result msgs))
+  (check-true (retry-context? ctx))
+  (check-equal? (retry-context-original-prompt ctx) "prompt")
+  (check-equal? (retry-context-compaction-result ctx) result)
+  (check-equal? (retry-context-retry-messages ctx) msgs))
+
+;; ============================================================
+;; #696: Integration
+;; ============================================================
+
+(test-case "integration: cutpoint adjustment with overflow recovery"
+  ;; Simulate: messages that would overflow, cut-point needs adjustment
+  (define msgs (list (make-user-msg "q1")
+                     (make-assistant-tool-call-msg "tc1" "bash")
+                     (make-tool-result-msg "tc1" "long output...")
+                     (make-assistant-msg "final answer")
+                     (make-user-msg "q2")
+                     (make-assistant-msg "a2")))
+  ;; Proposed cut at 2 (before tool-result) → adjust
+  (define adjusted (adjust-cutpoint msgs 2))
+  ;; Index 1 is assistant, previous is user → valid cut
+  (check-equal? adjusted 1)
+  ;; Overflow recovery state
+  (define state (make-overflow-state))
+  (check-true (can-retry-overflow? state))
+  ;; After compaction, build retry
+  (define summary-msg
+    (make-message "s1" #f 'system 'compaction-summary
+                  (list (make-text-part "summarized history"))
+                  (current-seconds) (hasheq)))
+  (define result (compaction-result summary-msg 2 (drop msgs 4)))
+  (define retry-msgs (build-retry-messages result "q2"))
+  (check-true (> (length retry-msgs) 0))
+  (mark-overflow-attempted! state)
+  (check-false (can-retry-overflow? state)))


### PR DESCRIPTION
## Compaction Cut-point Rules and Overflow Recovery

Implements Wave 2 of v0.9.4 milestone (Compaction Intelligence).

### Changes
- **#693**: Cut-point rules — never cut between tool-call and tool-result
  - `valid-cutpoint?` enforces tool-call pair integrity
  - `adjust-cutpoint` finds nearest valid boundary
  - Forward/backward search with `find-nearest-valid-cutpoint`
- **#694**: One-shot overflow recovery guard
  - `overflow-state` prevents infinite compaction loops
  - `can-retry-overflow?` / `mark-overflow-attempted!` API
- **#695**: Auto-retry after overflow compaction
  - `build-retry-messages` creates context with re-injected prompt
  - `retry-context` struct for complete retry state

New module `runtime/cutpoint-rules.rkt` with 20 tests.

Closes #693
Closes #694
Closes #695