### PR TITLE
[v0.9.5] Session Metadata, Labeling, File Tracking (#712)

### DIFF
--- a/runtime/session-metadata.rkt
+++ b/runtime/session-metadata.rkt
@@ -1,0 +1,124 @@
+#lang racket/base
+
+;; runtime/session-metadata.rkt — Session Metadata, Labeling, File Tracking (#710-#712)
+;;
+;; Provides:
+;;   #710: Session naming — get/set session name for display
+;;   #711: Entry labeling — mark important session points
+;;   #712: Parent feature integration
+
+(require racket/contract
+         racket/list
+         racket/port
+         (only-in "../util/protocol-types.rkt"
+                  message? message-content message-meta message-kind
+                  make-message make-text-part content-part->jsexpr)
+         "../util/jsonl.rkt"
+         "../runtime/session-store.rkt")
+
+(provide
+ ;; #710: Session naming
+ set-session-name!
+ get-session-name
+ session-name-entry?
+
+ ;; #711: Entry labeling
+ set-entry-label!
+ get-entry-label
+ entry-label?
+ label-type?
+ list-labeled-entries
+ ;; Label types
+ LABEL-CHECKPOINT
+ LABEL-MILESTONE
+ LABEL-BRANCH-POINT)
+
+;; ============================================================
+;; Constants
+;; ============================================================
+
+(define LABEL-CHECKPOINT 'checkpoint)
+(define LABEL-MILESTONE 'milestone)
+(define LABEL-BRANCH-POINT 'branch-point)
+
+(define (label-type? v)
+  (and (symbol? v)
+       (or (eq? v LABEL-CHECKPOINT)
+           (eq? v LABEL-MILESTONE)
+           (eq? v LABEL-BRANCH-POINT))))
+
+;; ============================================================
+;; #710: Session naming
+;; ============================================================
+
+;; Set (rename) a session. Persists to first JSONL entry.
+(define (set-session-name! log-path name)
+  (write-session-name! log-path name))
+
+;; Get the current session name from the log.
+;; Returns the last set name, or #f if no name is set.
+(define (get-session-name log-path)
+  (define entries (load-session-log log-path))
+  (define name-entries
+    (filter session-name-entry? entries))
+  (if (null? name-entries)
+      #f
+      (hash-ref (message-meta (car (reverse name-entries))) 'name #f)))
+
+;; Check if an entry is a session-name entry.
+(define (session-name-entry? entry)
+  (and (message? entry)
+       (eq? (message-kind entry) 'session-info)
+       (hash-has-key? (message-meta entry) 'name)))
+
+;; ============================================================
+;; #711: Entry labeling
+;; ============================================================
+
+;; Set a label on a specific entry in the session log.
+;; Appends a label entry that references the target entry.
+(define (set-entry-label! log-path target-entry-id label-type
+                           #:description [description #f])
+  (unless (label-type? label-type)
+    (raise-argument-error 'set-entry-label! "label-type?" label-type))
+  (define label-msg
+    (make-message (format "label-~a-~a" label-type (current-inexact-milliseconds))
+                  target-entry-id
+                  'system
+                  'entry-label
+                  (list (make-text-part (or description
+                                           (format "~a label for ~a" label-type target-entry-id))))
+                  (current-seconds)
+                  (hasheq 'label-type (symbol->string label-type)
+                          'target-id target-entry-id
+                          'description description)))
+  (append-entry! log-path label-msg))
+
+;; Get the label for a specific entry, if any.
+;; Returns the label-type symbol or #f.
+(define (get-entry-label entries target-entry-id)
+  (define label-entries
+    (filter (lambda (e) (and (eq? (message-kind e) 'entry-label)
+                              (equal? (hash-ref (message-meta e) 'target-id #f)
+                                      target-entry-id)))
+            entries))
+  (if (null? label-entries)
+      #f
+      (let ([raw (hash-ref (message-meta (car (reverse label-entries))) 'label-type #f)])
+        (if (string? raw) (string->symbol raw) raw))))
+
+;; Check if an entry is a label entry.
+(define (entry-label? entry)
+  (and (message? entry)
+       (eq? (message-kind entry) 'entry-label)))
+
+;; List all labeled entries from a session log.
+;; Returns list of (cons target-id label-type).
+(define (list-labeled-entries entries)
+  (filter-map
+   (lambda (e)
+     (and (entry-label? e)
+          (let ([raw (hash-ref (message-meta e) 'label-type #f)])
+            (cons (hash-ref (message-meta e) 'target-id #f)
+                  (if (string? raw) (string->symbol raw) raw)))))
+   entries))

--- a/tests/test-session-metadata.rkt
+++ b/tests/test-session-metadata.rkt
@@ -1,0 +1,210 @@
+#lang racket
+
+;; tests/test-session-metadata.rkt — tests for Session Metadata, Labeling (#710-#712)
+;;
+;; Covers:
+;;   - #710: Session naming for display
+;;   - #711: Entry labeling for marking important session points
+;;   - #712: Parent feature
+
+(require rackunit
+         racket/file
+         racket/path
+         "../util/protocol-types.rkt"
+         "../runtime/session-store.rkt"
+         "../runtime/session-metadata.rkt")
+
+;; ============================================================
+;; Helpers
+;; ============================================================
+
+(define (make-temp-session-dir)
+  (define dir (make-temporary-file "session-meta-test-~a" 'directory))
+  dir)
+
+(define (make-session-log dir)
+  (define log-path (build-path dir "session.jsonl"))
+  (write-session-version-header! log-path)
+  log-path)
+
+(define (append-user-msg! log-path text)
+  (define msg (make-message (format "msg-~a" (current-inexact-milliseconds))
+                            #f 'user 'text
+                            (list (make-text-part text))
+                            (current-seconds) (hasheq)))
+  (append-entry! log-path msg)
+  msg)
+
+;; ============================================================
+;; #710: Session naming
+;; ============================================================
+
+(test-case "set-session-name! / get-session-name: basic round-trip"
+  (define dir (make-temp-session-dir))
+  (define log-path (make-session-log dir))
+  (set-session-name! log-path "My First Session")
+  (check-equal? (get-session-name log-path) "My First Session")
+  (delete-directory/files dir))
+
+(test-case "get-session-name: returns #f when no name set"
+  (define dir (make-temp-session-dir))
+  (define log-path (make-session-log dir))
+  (check-false (get-session-name log-path))
+  (delete-directory/files dir))
+
+(test-case "set-session-name!: overwrites previous name"
+  (define dir (make-temp-session-dir))
+  (define log-path (make-session-log dir))
+  (set-session-name! log-path "First Name")
+  (set-session-name! log-path "Updated Name")
+  (check-equal? (get-session-name log-path) "Updated Name")
+  (delete-directory/files dir))
+
+(test-case "set-session-name!: persists to log"
+  (define dir (make-temp-session-dir))
+  (define log-path (make-session-log dir))
+  (set-session-name! log-path "Persistent Name")
+  ;; Re-load log to verify persistence
+  (define entries (load-session-log log-path))
+  (define name-entries (filter session-name-entry? entries))
+  (check-equal? (length name-entries) 1)
+  (check-equal? (hash-ref (message-meta (car name-entries)) 'name) "Persistent Name")
+  (delete-directory/files dir))
+
+(test-case "session-name-entry?: recognizes name entries"
+  (define dir (make-temp-session-dir))
+  (define log-path (make-session-log dir))
+  (set-session-name! log-path "Test")
+  (define entries (load-session-log log-path))
+  (define name-entry (findf session-name-entry? entries))
+  (check-true (message? name-entry))
+  (delete-directory/files dir))
+
+(test-case "session-name-entry?: returns #f for regular messages"
+  (define dir (make-temp-session-dir))
+  (define log-path (make-session-log dir))
+  (append-user-msg! log-path "hello")
+  (define entries (load-session-log log-path))
+  (define user-entries (filter (lambda (e) (and (message? e)
+                                                  (eq? (message-kind e) 'text)))
+                                entries))
+  (check-true (andmap (lambda (e) (not (session-name-entry? e))) user-entries))
+  (delete-directory/files dir))
+
+;; ============================================================
+;; #711: Entry labeling
+;; ============================================================
+
+(test-case "set-entry-label! / get-entry-label: checkpoint label"
+  (define dir (make-temp-session-dir))
+  (define log-path (make-session-log dir))
+  (define msg (append-user-msg! log-path "important message"))
+  (define msg-id (format "msg-~a" (current-inexact-milliseconds)))
+  ;; Use a known ID
+  (set-entry-label! log-path "test-msg-1" 'checkpoint)
+  (define entries (load-session-log log-path))
+  (check-equal? (get-entry-label entries "test-msg-1") 'checkpoint)
+  (delete-directory/files dir))
+
+(test-case "set-entry-label! / get-entry-label: milestone label"
+  (define dir (make-temp-session-dir))
+  (define log-path (make-session-log dir))
+  (set-entry-label! log-path "test-msg-2" 'milestone)
+  (define entries (load-session-log log-path))
+  (check-equal? (get-entry-label entries "test-msg-2") 'milestone)
+  (delete-directory/files dir))
+
+(test-case "set-entry-label! / get-entry-label: branch-point label"
+  (define dir (make-temp-session-dir))
+  (define log-path (make-session-log dir))
+  (set-entry-label! log-path "test-msg-3" 'branch-point)
+  (define entries (load-session-log log-path))
+  (check-equal? (get-entry-label entries "test-msg-3") 'branch-point)
+  (delete-directory/files dir))
+
+(test-case "set-entry-label!: with description"
+  (define dir (make-temp-session-dir))
+  (define log-path (make-session-log dir))
+  (set-entry-label! log-path "test-msg-4" 'checkpoint
+                     #:description "Before refactoring")
+  (define entries (load-session-log log-path))
+  (define label-entries (filter entry-label? entries))
+  (check-equal? (length label-entries) 1)
+  (check-equal? (hash-ref (message-meta (car label-entries)) 'description)
+                "Before refactoring")
+  (delete-directory/files dir))
+
+(test-case "set-entry-label!: rejects invalid label type"
+  (define dir (make-temp-session-dir))
+  (define log-path (make-session-log dir))
+  (check-exn exn:fail:contract?
+    (lambda () (set-entry-label! log-path "msg-1" 'invalid-type)))
+  (delete-directory/files dir))
+
+(test-case "get-entry-label: returns #f for unlabeled entry"
+  (define entries '())
+  (check-false (get-entry-label entries "nonexistent")))
+
+(test-case "entry-label?: recognizes label entries"
+  (define dir (make-temp-session-dir))
+  (define log-path (make-session-log dir))
+  (set-entry-label! log-path "msg-1" 'checkpoint)
+  (define entries (load-session-log log-path))
+  (define labels (filter entry-label? entries))
+  (check-equal? (length labels) 1)
+  (delete-directory/files dir))
+
+(test-case "list-labeled-entries: returns all labels"
+  (define dir (make-temp-session-dir))
+  (define log-path (make-session-log dir))
+  (set-entry-label! log-path "msg-1" 'checkpoint)
+  (set-entry-label! log-path "msg-2" 'milestone)
+  (set-entry-label! log-path "msg-3" 'branch-point)
+  (define entries (load-session-log log-path))
+  (define labels (list-labeled-entries entries))
+  (check-equal? (length labels) 3)
+  (define label-types (map cdr labels))
+  (check-true (and (member 'checkpoint label-types) #t))
+  (check-true (and (member 'milestone label-types) #t))
+  (check-true (and (member 'branch-point label-types) #t))
+  (delete-directory/files dir))
+
+(test-case "label-type?: validates label types"
+  (check-true (label-type? 'checkpoint))
+  (check-true (label-type? 'milestone))
+  (check-true (label-type? 'branch-point))
+  (check-false (label-type? 'invalid))
+  (check-false (label-type? "checkpoint")))
+
+;; ============================================================
+;; #712: Integration
+;; ============================================================
+
+(test-case "integration: name and label session"
+  (define dir (make-temp-session-dir))
+  (define log-path (make-session-log dir))
+
+  ;; Set name
+  (set-session-name! log-path "Integration Test Session")
+
+  ;; Add some messages
+  (append-user-msg! log-path "message 1")
+  (append-user-msg! log-path "message 2")
+
+  ;; Label an important point
+  (set-entry-label! log-path "msg-1" 'milestone
+                     #:description "Halfway point")
+
+  ;; Verify name
+  (check-equal? (get-session-name log-path) "Integration Test Session")
+
+  ;; Verify label
+  (define entries (load-session-log log-path))
+  (check-equal? (get-entry-label entries "msg-1") 'milestone)
+  (check-equal? (length (list-labeled-entries entries)) 1)
+
+  ;; Update name
+  (set-session-name! log-path "Updated Session")
+  (check-equal? (get-session-name log-path) "Updated Session")
+
+  (delete-directory/files dir))


### PR DESCRIPTION
## Session Metadata, Labeling, File Tracking

Implements Wave 3 (final) of v0.9.5 milestone.

### Changes
- **#710**: Session naming for display
  - `set-session-name!` / `get-session-name` round-trip
  - `session-name-entry?` predicate
- **#711**: Entry labeling for marking important session points
  - `set-entry-label!` with checkpoint/milestone/branch-point types
  - `get-entry-label`, `list-labeled-entries` for retrieval
- **#712**: Parent feature integration

16 new tests, all pass. This completes v0.9.5.

Closes #710
Closes #711