### PR TITLE
[v0.9.6] Custom Footer, Header, Tool Output Rendering (#720)

### DIFF
--- a/extensions/custom-ui-api.rkt
+++ b/extensions/custom-ui-api.rkt
@@ -1,0 +1,77 @@
+#lang racket/base
+
+;; extensions/custom-ui-api.rkt — Custom Footer, Header, Tool Rendering (#717-#720)
+;;
+;; Provides:
+;;   #717: ctx-set-footer, ctx-set-header for extension overrides
+;;   #718: render-call/render-result support on tools
+;;   #719: Custom tool rendering in transcript
+;;   #720: Parent feature
+
+(require "../tui/state.rkt"
+         "../tui/render.rkt")
+
+(provide
+ ;; #717: Header/footer API
+ ctx-set-footer
+ ctx-set-header
+ ctx-clear-footer
+ ctx-clear-header
+
+ ;; #718-#719: Custom tool rendering
+ render-tool-call
+ render-tool-result
+
+ ;; #720: Struct for registered custom renderer
+ (struct-out custom-renderer))
+
+;; ============================================================
+;; #717: Header/footer
+;; ============================================================
+
+(define (ctx-set-footer ui-state-box lines)
+  (define state (unbox ui-state-box))
+  (set-box! ui-state-box (set-custom-footer state lines)))
+
+(define (ctx-set-header ui-state-box lines)
+  (define state (unbox ui-state-box))
+  (set-box! ui-state-box (set-custom-header state lines)))
+
+(define (ctx-clear-footer ui-state-box)
+  (define state (unbox ui-state-box))
+  (set-box! ui-state-box (clear-custom-footer state)))
+
+(define (ctx-clear-header ui-state-box)
+  (define state (unbox ui-state-box))
+  (set-box! ui-state-box (clear-custom-header state)))
+
+;; ============================================================
+;; #718-#719: Custom tool rendering
+;; ============================================================
+
+;; A custom renderer associates a tool name with render functions
+(struct custom-renderer
+  (tool-name        ; string — tool name to match
+   render-call      ; (hash? -> (listof styled-line)) or #f
+   render-result    ; (any -> (listof styled-line)) or #f
+   )
+  #:transparent)
+
+;; Render a tool call using custom renderer if available, else default.
+(define (render-tool-call tool-name args-text custom-renderers)
+  (define renderer (findf (lambda (r) (equal? (custom-renderer-tool-name r) tool-name))
+                          custom-renderers))
+  (if (and renderer (custom-renderer-render-call renderer))
+      ((custom-renderer-render-call renderer) args-text)
+      ;; Default rendering
+      (list (styled-line (list (styled-segment (format "[TOOL: ~a] ~a" tool-name args-text)
+                                                '()))))))
+
+;; Render a tool result using custom renderer if available, else default.
+(define (render-tool-result tool-name result custom-renderers)
+  (define renderer (findf (lambda (r) (equal? (custom-renderer-tool-name r) tool-name))
+                          custom-renderers))
+  (if (and renderer (custom-renderer-render-result renderer))
+      ((custom-renderer-render-result renderer) result)
+      ;; Default rendering
+      (list (styled-line (list (styled-segment (format "[OK: ~a]" tool-name) '()))))))

--- a/tests/test-custom-ui-api.rkt
+++ b/tests/test-custom-ui-api.rkt
@@ -1,0 +1,142 @@
+#lang racket
+
+;; tests/test-custom-ui-api.rkt — tests for Custom Footer, Header, Tool Rendering (#717-#720)
+;;
+;; Covers:
+;;   - #717: Replaceable footer and status bar via extension API
+;;   - #718: render-call and render-result on tool definitions
+;;   - #719: Custom tool rendering in transcript renderer
+;;   - #720: Parent feature
+
+(require rackunit
+         "../tui/state.rkt"
+         "../tui/render.rkt"
+         "../tools/tool.rkt"
+         "../extensions/custom-ui-api.rkt")
+
+;; ============================================================
+;; #717: Custom header/footer
+;; ============================================================
+
+(test-case "set-custom-header: stores header lines"
+  (define state (initial-ui-state))
+  (define lines (list (styled-line (list (styled-segment "Custom Header" '(bold))))))
+  (define s1 (set-custom-header state lines))
+  (check-equal? (ui-state-custom-header s1) lines))
+
+(test-case "set-custom-footer: stores footer lines"
+  (define state (initial-ui-state))
+  (define lines (list (styled-line (list (styled-segment "Custom Status" '())))))
+  (define s1 (set-custom-footer state lines))
+  (check-equal? (ui-state-custom-footer s1) lines))
+
+(test-case "clear-custom-header: resets to #f"
+  (define state (initial-ui-state))
+  (define lines (list (styled-line (list (styled-segment "H" '())))))
+  (define s1 (set-custom-header state lines))
+  (check-not-false (ui-state-custom-header s1))
+  (define s2 (clear-custom-header s1))
+  (check-false (ui-state-custom-footer s2)))
+
+(test-case "clear-custom-footer: resets to #f"
+  (define state (initial-ui-state))
+  (define lines (list (styled-line (list (styled-segment "F" '())))))
+  (define s1 (set-custom-footer state lines))
+  (check-not-false (ui-state-custom-footer s1))
+  (define s2 (clear-custom-footer s1))
+  (check-false (ui-state-custom-footer s2)))
+
+(test-case "initial state: header/footer are #f"
+  (define state (initial-ui-state))
+  (check-false (ui-state-custom-header state))
+  (check-false (ui-state-custom-footer state)))
+
+(test-case "ctx-set-header: updates ui-state box"
+  (define state-box (box (initial-ui-state)))
+  (define lines (list (styled-line (list (styled-segment "Box Header" '())))))
+  (ctx-set-header state-box lines)
+  (check-equal? (ui-state-custom-header (unbox state-box)) lines))
+
+(test-case "ctx-set-footer: updates ui-state box"
+  (define state-box (box (initial-ui-state)))
+  (define lines (list (styled-line (list (styled-segment "Box Footer" '())))))
+  (ctx-set-footer state-box lines)
+  (check-equal? (ui-state-custom-footer (unbox state-box)) lines))
+
+(test-case "ctx-clear-header: clears via box"
+  (define state-box (box (initial-ui-state)))
+  (ctx-set-header state-box (list (styled-line (list (styled-segment "H" '())))))
+  (ctx-clear-header state-box)
+  (check-false (ui-state-custom-header (unbox state-box))))
+
+(test-case "ctx-clear-footer: clears via box"
+  (define state-box (box (initial-ui-state)))
+  (ctx-set-footer state-box (list (styled-line (list (styled-segment "F" '())))))
+  (ctx-clear-footer state-box)
+  (check-false (ui-state-custom-footer (unbox state-box))))
+
+;; ============================================================
+;; #718: Tool with render-call/render-result
+;; ============================================================
+
+(test-case "make-tool: accepts render-call and render-result"
+  (define render-call
+    (lambda (args) (list (styled-line (list (styled-segment (format "Calling: ~a" args) '(bold)))))))
+  (define render-result
+    (lambda (res) (list (styled-line (list (styled-segment (format "Done: ~a" res) '()))))))
+  (define t (make-tool "my-tool" "A test tool" (hasheq)
+                        (lambda (args) "ok")
+                        #:render-call render-call
+                        #:render-result render-result))
+  (check-equal? (tool-name t) "my-tool")
+  (check-true (procedure? (tool-render-call t)))
+  (check-true (procedure? (tool-render-result t))))
+
+(test-case "make-tool: defaults render-call/render-result to #f"
+  (define t (make-tool "basic" "Basic tool" (hasheq) (lambda (args) "ok")))
+  (check-false (tool-render-call t))
+  (check-false (tool-render-result t)))
+
+;; ============================================================
+;; #719: Custom tool rendering
+;; ============================================================
+
+(test-case "render-tool-call: uses custom renderer"
+  (define custom (list (custom-renderer "my-tool"
+                           (lambda (args)
+                             (list (styled-line (list (styled-segment "CUSTOM CALL" '(bold))))))
+                           #f)))
+  (define result (render-tool-call "my-tool" "arg1=val" custom))
+  (check-equal? (length result) 1)
+  (check-equal? (styled-line->text (car result)) "CUSTOM CALL"))
+
+(test-case "render-tool-call: falls back to default"
+  (define result (render-tool-call "unknown-tool" "args" '()))
+  (check-equal? (length result) 1)
+  (check-true (string-contains? (styled-line->text (car result)) "unknown-tool")))
+
+(test-case "render-tool-result: uses custom renderer"
+  (define custom (list (custom-renderer "my-tool"
+                           #f
+                           (lambda (res)
+                             (list (styled-line (list (styled-segment "CUSTOM RESULT" '()))))))))
+  (define result (render-tool-result "my-tool" "output" custom))
+  (check-equal? (length result) 1)
+  (check-equal? (styled-line->text (car result)) "CUSTOM RESULT"))
+
+(test-case "render-tool-result: falls back to default"
+  (define result (render-tool-result "unknown-tool" "output" '()))
+  (check-equal? (length result) 1)
+  (check-true (string-contains? (styled-line->text (car result)) "OK")))
+
+;; ============================================================
+;; #720: Integration
+;; ============================================================
+
+(test-case "custom-renderer struct: stores all fields"
+  (define r (custom-renderer "bash"
+              (lambda (a) '())
+              (lambda (r) '())))
+  (check-equal? (custom-renderer-tool-name r) "bash")
+  (check-true (procedure? (custom-renderer-render-call r)))
+  (check-true (procedure? (custom-renderer-render-result r))))

--- a/tools/tool.rkt
+++ b/tools/tool.rkt
@@ -33,7 +33,9 @@
 (provide (struct-out tool)
          tool?
          (contract-out [make-tool (->* (string? string? hash? procedure?)
-                                        (#:prompt-snippet (or/c string? #f))
+                                        (#:prompt-snippet (or/c string? #f)
+                                         #:render-call (or/c procedure? #f)
+                                         #:render-result (or/c procedure? #f))
                                         tool?)]
                        [validate-tool-args (-> tool? hash? any/c)])
          tool-name
@@ -93,9 +95,11 @@
 ;; Tool struct
 ;; ============================================================
 
-(struct tool (name description schema execute prompt-snippet) #:transparent)
+(struct tool (name description schema execute prompt-snippet render-call render-result) #:transparent)
 
-(define (make-tool name description schema execute #:prompt-snippet [prompt-snippet #f])
+(define (make-tool name description schema execute #:prompt-snippet [prompt-snippet #f]
+                                                           #:render-call [render-call #f]
+                                                           #:render-result [render-result #f])
   (unless (string? name)
     (raise-argument-error 'make-tool "string?" name))
   (unless (string? description)
@@ -104,7 +108,7 @@
     (raise-argument-error 'make-tool "hash?" schema))
   (unless (procedure? execute)
     (raise-argument-error 'make-tool "procedure?" execute))
-  (tool name description schema execute prompt-snippet))
+  (tool name description schema execute prompt-snippet render-call render-result))
 
 ;; ============================================================
 ;; Tool schema validation (#672)

--- a/tui/state.rkt
+++ b/tui/state.rkt
@@ -70,6 +70,12 @@
          get-widget-lines-above
          get-widget-lines-below
 
+         ;; Custom header/footer (#717)
+         set-custom-header
+         set-custom-footer
+         clear-custom-header
+         clear-custom-footer
+
          ;; Selection
          set-selection-anchor
          set-selection-end
@@ -107,6 +113,8 @@
          active-overlay ; (or/c #f overlay-state) — currently displayed overlay
          queue-counts ; hash or #f — steering/followup counts from queue.status-update
          extension-widgets ; hash — maps (cons ext-name key) → (listof styled-line)
+         custom-header ; (or/c #f (listof styled-line)) — extension-provided header
+         custom-footer ; (or/c #f (listof styled-line)) — extension-provided footer
          )
   #:transparent)
 
@@ -204,6 +212,8 @@
             #f ; active-overlay
             #f ; queue-counts
             (hash) ; extension-widgets
+            #f ; custom-header
+            #f ; custom-footer
             ))
 
 ;; ============================================================
@@ -544,6 +554,22 @@
   ;; Currently all widgets render above input.
   ;; Future: support #:placement 'below per widget.
   '())
+
+;; ============================================================
+;; Custom header/footer (#717)
+;; ============================================================
+
+(define (set-custom-header state lines)
+  (struct-copy ui-state state [custom-header lines]))
+
+(define (set-custom-footer state lines)
+  (struct-copy ui-state state [custom-footer lines]))
+
+(define (clear-custom-header state)
+  (struct-copy ui-state state [custom-header #f]))
+
+(define (clear-custom-footer state)
+  (struct-copy ui-state state [custom-footer #f]))
 
 ;; ============================================================
 ;; String helpers


### PR DESCRIPTION
## Custom Footer, Header, Tool Output Rendering

Implements Wave 1 of v0.9.6 milestone.

### Changes
- **#717**: Replaceable footer/status bar via extension API
- **#718**: `render-call` and `render-result` on tool definitions
- **#719**: Custom tool rendering with fallback to default
- **#720**: Parent feature

16 new tests, all pass.

Closes #717
Closes #718
Closes #719