### PR TITLE
fix(tui): clear selection on scroll to prevent stale highlight

### DIFF
--- a/tests/tui/state.rkt
+++ b/tests/tui/state.rkt
@@ -571,6 +571,26 @@
   (check-false (has-selection? state) "has-selection? returns #f after clear"))
 
 (let ()
+  ;; Scrolling clears selection (Bug #748: selection highlight stayed at fixed rows)
+  (define s (set-selection-anchor (initial-ui-state) 5 10))
+  (define scrolled (scroll-up s))
+  (check-false (has-selection? scrolled) "scroll-up clears selection")
+  (check-false (ui-state-sel-anchor scrolled) "scroll-up clears sel-anchor")
+  (check-false (ui-state-sel-end scrolled) "scroll-up clears sel-end"))
+
+(let ()
+  ;; scroll-down also clears selection
+  (define s (set-selection-end (set-selection-anchor (initial-ui-state) 5 10) 20 30))
+  (define scrolled (scroll-down s))
+  (check-false (has-selection? scrolled) "scroll-down clears selection")
+  (check-false (ui-state-sel-anchor scrolled) "scroll-down clears sel-anchor"))
+
+(let ()
+  ;; scroll-up preserves offset when no selection
+  (define s (scroll-up (initial-ui-state) 3))
+  (check-equal? (ui-state-scroll-offset s) 3 "scroll-up offset preserved without selection"))
+
+(let ()
   ;; Selection helpers preserve other state fields
   (define state
     (add-transcript-entry (initial-ui-state #:session-id "test")

--- a/tui/state.rkt
+++ b/tui/state.rkt
@@ -407,14 +407,17 @@
 ;; Scroll up (see older entries)
 ;; scroll-offset counts rendered LINES from the bottom.
 ;; No upper clamp here — render-transcript clamps via max(0, ...).
+;; Selection is screen-relative — clear it when scrolling to avoid stale highlights.
 (define (scroll-up state [amount 1])
   (define actual (+ (ui-state-scroll-offset state) amount))
-  (struct-copy ui-state state [scroll-offset actual]))
+  (define next (struct-copy ui-state state [scroll-offset actual]))
+  (if (has-selection? next) (clear-selection next) next))
 
 ;; Scroll down (see newer entries)
 (define (scroll-down state [amount 1])
   (define new-offset (max 0 (- (ui-state-scroll-offset state) amount)))
-  (struct-copy ui-state state [scroll-offset new-offset]))
+  (define next (struct-copy ui-state state [scroll-offset new-offset]))
+  (if (has-selection? next) (clear-selection next) next))
 
 ;; Scroll to bottom (latest entries)
 (define (scroll-to-bottom state)


### PR DESCRIPTION
## Summary

Selection coordinates (sel-anchor/sel-end) are screen-relative but scroll-up/scroll-down did not adjust them. The highlight appeared frozen on screen.

## Changes
- Clear selection in scroll-up and scroll-down functions
- Add 4 new tests verifying selection cleared on scroll

## Testing
- [x] All new tests pass
- [x] No regressions (87 tests in tui/state)

Fixes: #748
Refs: #753