### PR TITLE
feat(tools): add per-file mutation queue for parallel tool execution

### DIFF
--- a/tests/test-file-mutation-queue.rkt
+++ b/tests/test-file-mutation-queue.rkt
@@ -1,0 +1,116 @@
+#lang racket
+
+;;; tests/test-file-mutation-queue.rkt — tests for per-file serialization.
+;;;
+;;; Verifies:
+;;;   - Two concurrent edits on same file are serialized (no race)
+;;;   - Different files run in parallel
+;;;   - Self-cleaning: semaphore removed after completion
+;;;   - #f path runs without serialization
+
+(require rackunit
+         racket/file
+         "../tools/file-mutation-queue.rkt")
+
+;; ============================================================
+;; Helpers
+;; ============================================================
+
+(define (make-temp-file)
+  (define tmp (make-temporary-file "/tmp/mq-test-~a"))
+  (with-output-to-file tmp (lambda () (display "0")) #:exists 'replace)
+  tmp)
+
+(define (increment-file path-str)
+  (with-file-mutation-queue
+   path-str
+   (lambda ()
+     ;; read-modify-write
+     (define val
+       (with-input-from-file (string->path path-str)
+         (lambda () (string->number (port->string)))))
+     (sleep 0.01) ;; simulate latency to make races more likely
+     (with-output-to-file (string->path path-str)
+       (lambda () (display (add1 val)))
+       #:exists 'replace))))
+
+;; ============================================================
+;; Tests
+;; ============================================================
+
+(test-case "two concurrent edits on same file: no data loss"
+  (define tmp (make-temp-file))
+  (define path-str (path->string tmp))
+  ;; Run 10 parallel increments — without the queue, some would be lost
+  (define threads
+    (for/list ([_ (in-range 10)])
+      (thread (lambda () (increment-file path-str)))))
+  (for-each thread-wait threads)
+  (define final
+    (with-input-from-file tmp (lambda () (string->number (port->string)))))
+  (check-equal? final 10 "all 10 increments should be preserved")
+  (delete-file tmp))
+
+(test-case "different files run in parallel"
+  (define tmp1 (make-temp-file))
+  (define tmp2 (make-temp-file))
+  (define path1 (path->string tmp1))
+  (define path2 (path->string tmp2))
+  (define started (current-inexact-milliseconds))
+  (define t1 (thread (lambda () (increment-file path1))))
+  (define t2 (thread (lambda () (increment-file path2))))
+  (thread-wait t1)
+  (thread-wait t2)
+  (define elapsed (- (current-inexact-milliseconds) started))
+  ;; If truly parallel, should be ~10ms, not ~20ms
+  (check-true (< elapsed 50)
+              (format "two different files should run in parallel, took ~ams" elapsed))
+  (delete-file tmp1)
+  (delete-file tmp2))
+
+(test-case "self-cleaning: stats drop to zero after completion"
+  (define tmp (make-temp-file))
+  (define path-str (path->string tmp))
+  (with-file-mutation-queue path-str (lambda () 'done))
+  (check-equal? (mutation-queue-stats) 0 "no active locks after completion")
+  (delete-file tmp))
+
+(test-case "#f path runs without serialization"
+  (define result (with-file-mutation-queue #f (lambda () 42)))
+  (check-equal? result 42 "#f path runs thunk directly"))
+
+(test-case "queue stats reflect active operations"
+  (define tmp (make-temp-file))
+  (define path-str (path->string tmp))
+  (define ch (make-channel))
+  (thread
+   (lambda ()
+     (with-file-mutation-queue
+      path-str
+      (lambda ()
+        (channel-put ch 'started)
+        (sleep 0.05)
+        'done))))
+  (channel-get ch) ;; wait for start
+  (check-true (positive? (mutation-queue-stats))
+              "should have 1 active lock during operation")
+  (sleep 0.1) ;; wait for completion
+  (check-equal? (mutation-queue-stats) 0 "active lock cleaned up after completion")
+  (delete-file tmp))
+
+(test-case "symlink resolves to same lock"
+  (define tmp (make-temp-file))
+  (define path-str (path->string tmp))
+  (define link-path "/tmp/mq-test-link")
+  (with-handlers ([exn:fail? (lambda (_) (void))])
+    (when (file-exists? link-path) (delete-file link-path))
+    (make-file-or-directory-link tmp link-path)
+    (define t1 (thread (lambda () (increment-file path-str))))
+    (define t2 (thread (lambda () (increment-file link-path))))
+    (thread-wait t1)
+    (thread-wait t2)
+    (define final
+      (with-input-from-file tmp (lambda () (string->number (port->string)))))
+    (check-equal? final 2 "symlink and real path should share the same lock")
+    (when (file-exists? link-path) (delete-file link-path)))
+  (when (file-exists? tmp) (delete-file tmp)))

--- a/tools/file-mutation-queue.rkt
+++ b/tools/file-mutation-queue.rkt
@@ -1,0 +1,97 @@
+#lang racket/base
+
+;;; tools/file-mutation-queue.rkt — per-file semaphore for serializing mutations.
+;;;
+;;; Prevents concurrent read-modify-write races when parallel tool calls
+;;; target the same file path.
+;;;
+;;; Exports:
+;;;   - with-file-mutation-queue — wrap a thunk with per-path serialization
+;;;   - mutation-queue-stats     — (for testing) return active count
+
+(require racket/path)
+
+(provide with-file-mutation-queue
+         mutation-queue-stats)
+
+;; ============================================================
+;; Internal state
+;; ============================================================
+
+;; Global hash: resolved-path-string → (box count)
+;; The box tracks pending operations; when it drops to 0, entry is removed.
+(define path-locks (make-hash))
+(define path-locks-mutex (make-semaphore 1))
+
+;; Per-path semaphores: resolved-path-string → semaphore
+(define path-semaphores (make-hash))
+(define path-sema-mutex (make-semaphore 1))
+
+;; ============================================================
+;; Resolve a path to its canonical form for deduplication
+;; ============================================================
+
+(define (canonicalize-path path-str)
+  (with-handlers ([exn:fail? (lambda (_) path-str)])
+    ;; resolve-path handles symlinks; needs an actual path
+    (if (file-exists? path-str)
+        (path->string (resolve-path (string->path path-str)))
+        ;; For non-existent files, normalize the string
+        (path->string (simplify-path (string->path path-str))))))
+
+;; ============================================================
+;; Get or create a semaphore for a path
+;; ============================================================
+
+(define (get-path-semaphore canonical-path)
+  (call-with-semaphore path-sema-mutex
+    (lambda ()
+      (hash-ref! path-semaphores canonical-path (lambda () (make-semaphore 1))))))
+
+;; ============================================================
+;; Acquire/release tracking
+;; ============================================================
+
+(define (track-acquire canonical-path)
+  (call-with-semaphore path-locks-mutex
+    (lambda ()
+      (define existing (hash-ref path-locks canonical-path #f))
+      (if existing
+          (set-box! existing (add1 (unbox existing)))
+          (hash-set! path-locks canonical-path (box 1))))))
+
+(define (track-release canonical-path)
+  (call-with-semaphore path-locks-mutex
+    (lambda ()
+      (define existing (hash-ref path-locks canonical-path #f))
+      (when existing
+        (set-box! existing (sub1 (unbox existing)))
+        (when (zero? (unbox existing))
+          (hash-remove! path-locks canonical-path)
+          (hash-remove! path-semaphores canonical-path))))))
+
+;; ============================================================
+;; Public API
+;; ============================================================
+
+;; Wrap a thunk so that concurrent calls for the same file path are serialized.
+;; path-str is the raw file path (may contain ~, symlinks, etc.)
+;; If path-str is #f, runs the thunk without serialization.
+(define (with-file-mutation-queue path-str thunk)
+  (if (not path-str)
+      (thunk)
+      (let* ([canonical (canonicalize-path path-str)]
+             [sema (get-path-semaphore canonical)])
+        (track-acquire canonical)
+        (dynamic-wind
+          (lambda () (semaphore-wait sema))
+          thunk
+          (lambda ()
+            (semaphore-post sema)
+            (track-release canonical))))))
+
+;; Return the number of active (pending) path locks (for testing)
+(define (mutation-queue-stats)
+  (call-with-semaphore path-locks-mutex
+    (lambda ()
+      (hash-count path-locks))))

--- a/tools/scheduler.rkt
+++ b/tools/scheduler.rkt
@@ -27,7 +27,9 @@
          (only-in "../util/hook-types.rkt"
                   hook-result? hook-result-action hook-result-payload)
          (only-in "../util/safe-mode-predicates.rkt"
-                  safe-mode? allowed-tool? allowed-path? safe-mode-project-root))
+                  safe-mode? allowed-tool? allowed-path? safe-mode-project-root)
+         (only-in "file-mutation-queue.rkt"
+                  with-file-mutation-queue))
 
 (provide
  ;; ── Result struct ──
@@ -199,7 +201,8 @@
                  tc))
            tc))
 
-     ;; Execute the tool
+     ;; Execute the tool (with file mutation queue for write tools)
+     (define file-mutating-tools '("write" "edit"))
      (define exec-result
        (with-handlers ([exn:fail?
                         (lambda (e)
@@ -207,7 +210,14 @@
                            (format "tool '~a' raised: ~a"
                                    tc-name
                                    (exn-message e))))])
-         ((tool-execute t) (tool-call-arguments tc-to-execute) exec-ctx)))
+         (define args (tool-call-arguments tc-to-execute))
+         (define path-arg (and (member tc-name file-mutating-tools)
+                               (hash? args)
+                               (hash-ref args 'path #f)))
+         (with-file-mutation-queue
+          path-arg
+          (lambda ()
+            ((tool-execute t) args exec-ctx)))))
 
      ;; Dispatch 'tool-result-post hook
      (define post-payload


### PR DESCRIPTION
## Summary

Prevents concurrent read-modify-write races when parallel tool calls target the same file.

## Changes
- New `tools/file-mutation-queue.rkt`: per-path semaphore with symlink dedup and self-cleaning
- Wired into `scheduler.rkt` for `edit` and `write` tools
- 6 new tests (concurrent safety, parallel different-files, self-cleaning, #f path, stats, symlinks)

## Testing
- [x] 6 mutation queue tests pass
- [x] 42 scheduler tests pass (no regressions)

Fixes: #757
Refs: #756