### PR TITLE
feat(compaction): replace fixed-count with token-based compaction

### DIFF
--- a/runtime/compactor.rkt
+++ b/runtime/compactor.rkt
@@ -31,7 +31,11 @@
                   hook-result
                   hook-result?
                   hook-result-action
-                  hook-result-payload))
+                  hook-result-payload)
+         (only-in "token-compaction.rkt"
+                  build-token-summary-window
+                  default-token-compaction-config
+                  token-compaction-config))
 
 (provide (struct-out compaction-strategy)
          (struct-out compaction-result)
@@ -220,6 +224,47 @@
      (values old-to-summarize recent)]))
 
 ;; ============================================================
+;; Inline cutpoint adjustment (avoids circular dep with cutpoint-rules.rkt)
+;; ============================================================
+
+;; Check if a message contains tool-call parts.
+(define (has-tool-calls? msg)
+  (define content (message-content msg))
+  (and (list? content)
+       (ormap tool-call-part? content)))
+
+;; Check if a message is a tool-result.
+(define (tool-result-message? msg)
+  (eq? (message-kind msg) 'tool-result))
+
+;; Check if placing a cut BEFORE index `idx` is valid.
+;; A cut at N means messages[0..N) are old, messages[N..] are recent.
+(define (valid-cutpoint? messages idx)
+  (cond
+    [(or (< idx 0) (> idx (length messages))) #f]
+    [(or (= idx 0) (= idx (length messages))) #t]
+    [else
+     (define msg-at (list-ref messages idx))
+     (cond
+       [(tool-result-message? msg-at) #f]
+       [(eq? (message-role msg-at) 'user) #t]
+       [(eq? (message-role msg-at) 'assistant)
+        (define msg-before (list-ref messages (sub1 idx)))
+        (not (has-tool-calls? msg-before))]
+       [else #t])]))
+
+;; Adjust a proposed cut point backward to nearest valid position.
+(define (adjust-cutpoint messages proposed-idx)
+  (cond
+    [(valid-cutpoint? messages proposed-idx) proposed-idx]
+    [else
+     (let loop ([i (sub1 proposed-idx)])
+       (cond
+         [(<= i 0) 0]
+         [(valid-cutpoint? messages i) i]
+         [else (loop (sub1 i))]))]))
+
+;; ============================================================
 ;; compact-history
 ;; ============================================================
 
@@ -240,7 +285,8 @@
                          #:provider [provider #f]
                          #:model-name [model-name #f]
                          #:previous-summary [prev-summary #f]
-                         #:hook-dispatcher [hook-dispatcher #f])
+                         #:hook-dispatcher [hook-dispatcher #f]
+                         #:token-config [token-config (default-token-compaction-config)])
   ;; Dispatch 'session-before-compact hook if dispatcher provided
   ;; Returns identity result if hook blocks, otherwise proceeds with compaction.
   (cond
@@ -251,26 +297,34 @@
      ;; Hook blocked compaction — return identity result immediately
      (compaction-result #f 0 messages)]
     [else
-     ;; Proceed with compaction
-     (define-values (old recent) (build-summary-window messages strategy))
+     ;; Use token-based window split instead of fixed-count
+     (define-values (old recent) (build-token-summary-window messages token-config))
+     ;; Adjust cutpoint to a valid boundary (e.g., don't split mid-tool-call)
+     (define-values (adjusted-old adjusted-recent)
+       (if (and (pair? old) (pair? recent))
+           (let ([cut-idx (adjust-cutpoint messages (length old))])
+             (if (and cut-idx (> cut-idx 0) (< cut-idx (length messages)))
+                 (values (take messages cut-idx) (drop messages cut-idx))
+                 (values old recent)))
+           (values old recent)))
      (cond
        ;; Nothing to summarize — return identity result
-       [(null? old) (compaction-result #f 0 recent)]
+       [(null? adjusted-old) (compaction-result #f 0 adjusted-recent)]
        [else
         ;; Choose summarization: LLM if provider given, else use summarize-fn
         (define summary-text
           (if (and provider model-name)
-              (let ([file-tracker (extract-file-tracker old)])
-                (llm-summarize old
+              (let ([file-tracker (extract-file-tracker adjusted-old)])
+                (llm-summarize adjusted-old
                                provider
                                model-name
-                               #:previous-summary (or prev-summary (find-previous-summary recent))
+                               #:previous-summary (or prev-summary (find-previous-summary adjusted-recent))
                                #:file-tracker file-tracker))
-              (summarize-fn old)))
+              (summarize-fn adjusted-old)))
         ;; Build file tracker metadata for the summary message
         (define file-tracker-meta
           (if (and provider model-name)
-              (let ([ft (extract-file-tracker old)])
+              (let ([ft (extract-file-tracker adjusted-old)])
                 (if (> (hash-count ft) 0)
                     (hasheq 'fileTracker ft)
                     (hasheq)))
@@ -283,8 +337,8 @@
            'compaction-summary
            (list (make-text-part summary-text))
            (current-seconds)
-           (hash-set (hash-set file-tracker-meta 'type "compaction") 'removedCount (length old))))
-        (compaction-result summary-msg (length old) recent)])]))
+           (hash-set (hash-set file-tracker-meta 'type "compaction") 'removedCount (length adjusted-old))))
+        (compaction-result summary-msg (length adjusted-old) adjusted-recent)])]))
 
 ;; ============================================================
 ;; compaction-result->message-list
@@ -313,14 +367,16 @@
                                   #:provider [provider #f]
                                   #:model-name [model-name #f]
                                   #:previous-summary [prev-summary #f]
-                                  #:hook-dispatcher [hook-dispatcher #f])
+                                  #:hook-dispatcher [hook-dispatcher #f]
+                                  #:token-config [token-config (default-token-compaction-config)])
   (compact-history messages
                    #:strategy strategy
                    #:summarize-fn summarize-fn
                    #:provider provider
                    #:model-name model-name
                    #:previous-summary prev-summary
-                   #:hook-dispatcher hook-dispatcher))
+                   #:hook-dispatcher hook-dispatcher
+                   #:token-config token-config))
 
 ;; ============================================================
 ;; compact-and-persist!
@@ -340,7 +396,8 @@
                               #:provider [provider #f]
                               #:model-name [model-name #f]
                               #:previous-summary [prev-summary #f]
-                              #:hook-dispatcher [hook-dispatcher #f])
+                              #:hook-dispatcher [hook-dispatcher #f]
+                              #:token-config [token-config (default-token-compaction-config)])
   (define result
     (compact-history messages
                      #:strategy strategy
@@ -348,7 +405,8 @@
                      #:provider provider
                      #:model-name model-name
                      #:previous-summary prev-summary
-                     #:hook-dispatcher hook-dispatcher))
+                     #:hook-dispatcher hook-dispatcher
+                     #:token-config token-config))
   (write-compaction-entry! session-log-path result)
   result)
 

--- a/tests/test-compaction-edge-cases.rkt
+++ b/tests/test-compaction-edge-cases.rkt
@@ -18,6 +18,7 @@
          "../runtime/context-builder.rkt"
          "../runtime/session-index.rkt"
          "../runtime/session-store.rkt"
+         "../runtime/token-compaction.rkt"
          "../util/protocol-types.rkt"
          (only-in "../util/hook-types.rkt" hook-result hook-result-action))
 
@@ -193,11 +194,13 @@
 (test-case "edge-compact: keep-recent-count + 1 messages (one compacted)"
   (define msgs (for/list ([i (in-range 21)])
                  (make-test-msg 'assistant (format "msg-~a" i))))
-  (define result (compact-history msgs))
-  ;; 21 > 20 (keep-recent), so 1 old message should be summarized
+  ;; Use a tiny token config so 21 messages exceed the budget
+  (define tiny-config (token-compaction-config 5 0 10))
+  (define result (compact-history msgs #:token-config tiny-config))
+  ;; With tiny config, some messages should be compacted
   (check > (compaction-result-removed-count result) 0)
   (check-true (message? (compaction-result-summary-message result))
-              "should have a summary when messages exceed keep-recent"))
+              "should have a summary when messages exceed token budget"))
 
 (test-case "edge-compact: tiered-context with only compaction summaries"
   ;; Only compaction summaries, no regular messages
@@ -252,8 +255,9 @@
 (test-case "edge-compact: hook allows compaction"
   (define msgs (for/list ([i (in-range 30)])
                  (make-test-msg 'assistant (format "msg-~a" i))))
+  (define tiny-config (token-compaction-config 5 0 10))
   (define allow (lambda (hook payload)
                   (hook-result 'pass (hasheq))))
-  (define result (compact-history msgs #:hook-dispatcher allow))
+  (define result (compact-history msgs #:hook-dispatcher allow #:token-config tiny-config))
   ;; Hook passed — normal compaction
   (check > (compaction-result-removed-count result) 0))

--- a/tests/test-compactor.rkt
+++ b/tests/test-compactor.rkt
@@ -18,6 +18,7 @@
          "../util/protocol-types.rkt"
          "../runtime/compactor.rkt"
          "../runtime/session-store.rkt"
+         "../runtime/token-compaction.rkt"
          ;; R2-6: Import hooks for context-assembly testing
          "../util/hook-types.rkt")
 
@@ -46,6 +47,11 @@
 
 (define (msg-id msg)
   (message-id msg))
+
+;; Tiny token config for tests that need compaction to trigger.
+;; keep-recent=5 tokens, reserve=0, max-context=10 tokens.
+;; This forces compaction on even small test messages.
+(define tiny-tc (token-compaction-config 5 0 10))
 
 ;; Build a list of N simple messages for testing
 (define (make-n-messages n)
@@ -123,19 +129,22 @@
     (define strategy (compaction-strategy 20 5))
     (define result (compact-history msgs
                                      #:strategy strategy
-                                     #:summarize-fn test-summarize))
-    ;; Should have: 1 summary + 5 recent = 6
-    (check-equal? (length (compaction-result-kept-messages result)) 5)
+                                     #:summarize-fn test-summarize
+                                     #:token-config tiny-tc))
+    ;; With tiny-tc (keep-recent=5 tokens), only ~1 message fits in keep-recent
+    ;; budget (4 tokens per msg), so 29 msgs are summarized, 1 kept
+    (check-equal? (length (compaction-result-kept-messages result)) 1)
     (check-true (< (+ 1 (length (compaction-result-kept-messages result))) ; summary + kept
                     (length msgs)))
-    (check-equal? (compaction-result-removed-count result) 20))
+    (check-equal? (compaction-result-removed-count result) 29))
 
   (test-case "compact-history summary message is a system message"
     (define msgs (make-n-messages 10))
     (define strategy (compaction-strategy 8 2))
     (define result (compact-history msgs
                                      #:strategy strategy
-                                     #:summarize-fn test-summarize))
+                                     #:summarize-fn test-summarize
+                                     #:token-config tiny-tc))
     (define summary (compaction-result-summary-message result))
     (check-equal? (message-role summary) 'system)
     (check-equal? (message-kind summary) 'compaction-summary))
@@ -145,14 +154,14 @@
     (define strategy (compaction-strategy 8 2))
     (define result (compact-history msgs
                                      #:strategy strategy
-                                     #:summarize-fn test-summarize))
+                                     #:summarize-fn test-summarize
+                                     #:token-config tiny-tc))
     (define summary (compaction-result-summary-message result))
     (define summary-text (msg-text summary))
-    ;; The summary should contain text from the first 8 messages
+    ;; With tiny-tc, first 9 messages are summarized (kept = last 1)
     (check-true (string-contains? summary-text "Message 0"))
-    (check-true (string-contains? summary-text "Message 7"))
-    ;; The summary should NOT contain text from the kept messages
-    (check-false (string-contains? summary-text "Message 8"))
+    (check-true (string-contains? summary-text "Message 8"))
+    ;; The summary should NOT contain text from the kept message
     (check-false (string-contains? summary-text "Message 9")))
 
   (test-case "compact-history preserves recent messages verbatim"
@@ -160,13 +169,13 @@
     (define strategy (compaction-strategy 8 2))
     (define result (compact-history msgs
                                      #:strategy strategy
-                                     #:summarize-fn test-summarize))
+                                     #:summarize-fn test-summarize
+                                     #:token-config tiny-tc))
     (define kept (compaction-result-kept-messages result))
-    (check-equal? (length kept) 2)
-    (check-equal? (msg-id (first kept)) "msg8")
-    (check-equal? (msg-id (second kept)) "msg9")
-    (check-equal? (msg-text (first kept)) "Message 8 content")
-    (check-equal? (msg-text (second kept)) "Message 9 content"))
+    ;; With tiny-tc, only the last message fits in keep-recent budget
+    (check-equal? (length kept) 1)
+    (check-equal? (msg-id (first kept)) "msg9")
+    (check-equal? (msg-text (first kept)) "Message 9 content"))
 
   (test-case "compact-history does not modify original messages"
     (define msgs (make-n-messages 10))
@@ -174,7 +183,8 @@
     (define strategy (compaction-strategy 8 2))
     (compact-history msgs
                      #:strategy strategy
-                     #:summarize-fn test-summarize)
+                     #:summarize-fn test-summarize
+                     #:token-config tiny-tc)
     ;; Original list unchanged
     (define msgs-after (map msg-id msgs))
     (check-equal? msgs-before msgs-after)
@@ -206,15 +216,15 @@
     (define strategy (compaction-strategy 30 10))
     (define result (compact-history msgs
                                      #:strategy strategy
-                                     #:summarize-fn test-summarize))
+                                     #:summarize-fn test-summarize
+                                     #:token-config tiny-tc))
     (define compacted-list (compaction-result->message-list result))
-    ;; 1 summary + 10 recent = 11 total
-    (check-equal? (length compacted-list) 11)
+    ;; With tiny-tc, only 1 message kept: 1 summary + 1 kept = 2 total
+    (check-equal? (length compacted-list) 2)
     ;; First element should be the summary
     (check-equal? (message-kind (first compacted-list)) 'compaction-summary)
-    ;; Remaining should be the kept messages
-    (check-equal? (msg-id (second compacted-list)) "msg40")
-    (check-equal? (msg-id (last compacted-list)) "msg49"))
+    ;; Remaining should be the kept message
+    (check-equal? (msg-id (second compacted-list)) "msg49"))
 
   ;; ══════════════════════════════════════════════════════════════
   ;; Custom summarize function
@@ -227,9 +237,11 @@
       (format "CUSTOM: ~a messages summarized" (length ms)))
     (define result (compact-history msgs
                                      #:strategy strategy
-                                     #:summarize-fn custom-summarize))
+                                     #:summarize-fn custom-summarize
+                                     #:token-config tiny-tc))
     (define summary (compaction-result-summary-message result))
-    (check-true (string-contains? (msg-text summary) "CUSTOM: 8 messages")))
+    ;; With tiny-tc, 9 messages are summarized (not 8 as with old strategy)
+    (check-true (string-contains? (msg-text summary) "CUSTOM: 9 messages")))
 
   ;; ══════════════════════════════════════════════════════════════
   ;; compaction-result->message-list
@@ -240,9 +252,10 @@
     (define strategy (compaction-strategy 10 5))
     (define result (compact-history msgs
                                      #:strategy strategy
-                                     #:summarize-fn test-summarize))
+                                     #:summarize-fn test-summarize
+                                     #:token-config tiny-tc))
     (define merged (compaction-result->message-list result))
-    (check-equal? (length merged) 6)  ; 1 summary + 5 kept
+    (check-equal? (length merged) 2)  ; 1 summary + 1 kept
     (check-equal? (message-kind (first merged)) 'compaction-summary)
     (for ([m (in-list (drop merged 1))])
       (check-equal? (message-kind m) 'message)))
@@ -273,7 +286,8 @@
     (define strategy (compaction-strategy 6 4))
     (define result (compact-history msgs
                                      #:strategy strategy
-                                     #:summarize-fn test-summarize))
+                                     #:summarize-fn test-summarize
+                                     #:token-config tiny-tc))
     ;; Write compaction entry
     (write-compaction-entry! path result)
     ;; The session log should now have original 10 + compaction entry = 11
@@ -297,7 +311,8 @@
     (define strategy (compaction-strategy 6 4))
     (define result (compact-history msgs
                                      #:strategy strategy
-                                     #:summarize-fn test-summarize))
+                                     #:summarize-fn test-summarize
+                                     #:token-config tiny-tc))
     (write-compaction-entry! path result)
     ;; Reload — original entries must all still be there
     (define all-entries (load-session-log path))
@@ -315,11 +330,12 @@
     (define strategy (compaction-strategy 6 4))
     (define result (compact-history msgs
                                      #:strategy strategy
-                                     #:summarize-fn test-summarize))
+                                     #:summarize-fn test-summarize
+                                     #:token-config tiny-tc))
     (write-compaction-entry! path result)
     (define all-entries (load-session-log path))
     (define compaction-entry (last all-entries))
-    (check-equal? (hash-ref (message-meta compaction-entry) 'removedCount) 6)
+    (check-equal? (hash-ref (message-meta compaction-entry) 'removedCount) 9)
     (check-equal? (hash-ref (message-meta compaction-entry) 'type) "compaction")
     (delete-directory/files dir #:must-exist? #f))
 
@@ -375,7 +391,8 @@
     (define strategy (compaction-strategy 20 5))
     (define result (compact-and-persist! loaded path
                                           #:strategy strategy
-                                          #:summarize-fn test-summarize))
+                                          #:summarize-fn test-summarize
+                                          #:token-config tiny-tc))
     ;; Log should now have 30 originals + 1 compaction summary = 31
     (define all-entries (load-session-log path))
     (check-equal? (length all-entries) 31)
@@ -399,10 +416,11 @@
     (define strategy (compaction-strategy 20 5))
     (define result (compact-and-persist! loaded path
                                           #:strategy strategy
-                                          #:summarize-fn test-summarize))
+                                          #:summarize-fn test-summarize
+                                          #:token-config tiny-tc))
     (check-pred compaction-result? result)
-    (check-equal? (compaction-result-removed-count result) 20)
-    (check-equal? (length (compaction-result-kept-messages result)) 5)
+    (check-equal? (compaction-result-removed-count result) 29)
+    (check-equal? (length (compaction-result-kept-messages result)) 1)
     (check-true (message? (compaction-result-summary-message result)))
     (delete-directory/files dir #:must-exist? #f))
 
@@ -435,10 +453,12 @@
     (define strategy (compaction-strategy 20 5))
     (define r1 (compact-history msgs
                                 #:strategy strategy
-                                #:summarize-fn test-summarize))
+                                #:summarize-fn test-summarize
+                                #:token-config tiny-tc))
     (define r2 (compact-history-advisory msgs
                                           #:strategy strategy
-                                          #:summarize-fn test-summarize))
+                                          #:summarize-fn test-summarize
+                                          #:token-config tiny-tc))
     ;; Both return the same removed-count and kept-count
     (check-equal? (compaction-result-removed-count r1)
                   (compaction-result-removed-count r2))
@@ -465,7 +485,8 @@
     (define strategy (compaction-strategy 6 4))
     (compact-history loaded
                      #:strategy strategy
-                     #:summarize-fn test-summarize)
+                     #:summarize-fn test-summarize
+                     #:token-config tiny-tc)
     ;; Verify log is unchanged
     (define entries-after (load-session-log path))
     (check-equal? (length entries-after) 10)


### PR DESCRIPTION
## Summary

Replace `build-summary-window` (fixed message-count) with `build-token-summary-window` (token-budget-based).

## Changes
- Token-based compaction: walks messages backward, keeps recent within token budget
- Inline cutpoint adjustment: avoids splitting mid-tool-call pairs
- Default config: 30k keep-recent, 10k reserve, 100k max-context
- Threads `#:token-config` through `compact-history-advisory` and `compact-and-persist!`
- All tests updated to use tiny-tc for deterministic behavior

## Testing
- [x] 35 compactor tests pass
- [x] 93 total compaction tests pass
- [x] No regressions

Fixes: #758
Refs: #756