### PR TITLE
feat(compaction): add firstKeptEntryId to compaction summary metadata

### DIFF
--- a/runtime/compactor.rkt
+++ b/runtime/compactor.rkt
@@ -329,6 +329,10 @@
                     (hasheq 'fileTracker ft)
                     (hasheq)))
               (hasheq)))
+        (define first-kept-id
+          (if (pair? adjusted-recent)
+              (message-id (car adjusted-recent))
+              #f))
         (define summary-msg
           (make-message
            (format "compaction-~a" (current-inexact-milliseconds))
@@ -337,7 +341,7 @@
            'compaction-summary
            (list (make-text-part summary-text))
            (current-seconds)
-           (hash-set (hash-set file-tracker-meta 'type "compaction") 'removedCount (length adjusted-old))))
+           (hash-set (hash-set (hash-set file-tracker-meta 'type "compaction") 'removedCount (length adjusted-old)) 'firstKeptEntryId first-kept-id)))
         (compaction-result summary-msg (length adjusted-old) adjusted-recent)])]))
 
 ;; ============================================================

--- a/runtime/context-builder.rkt
+++ b/runtime/context-builder.rkt
@@ -66,6 +66,9 @@
   ;; Returns (values pre-compaction post-compaction).
   ;; post-compaction includes the compaction summary itself.
   ;; If no compaction found, returns (values path #f).
+  ;;
+  ;; If the compaction summary has firstKeptEntryId in metadata,
+  ;; use it to find the exact start of kept entries.
   (define compaction-idx
     (for/last ([entry (in-list path)]
                [i (in-naturals)]
@@ -74,8 +77,23 @@
   (cond
     [(not compaction-idx) (values path #f)]
     [else
-     (define-values (pre post) (split-at path compaction-idx))
-     (values pre post)]))
+     (define compaction-entry (list-ref path compaction-idx))
+     (define meta (message-meta compaction-entry))
+     (define first-kept-id (and (hash? meta) (hash-ref meta 'firstKeptEntryId #f)))
+     (cond
+       ;; If firstKeptEntryId is set, find it in path and use it as the boundary
+       [(and first-kept-id
+             (for/or ([entry (in-list path)]
+                      [i (in-naturals)])
+               (and (equal? (message-id entry) first-kept-id) i)))
+        => (lambda (kept-idx)
+             (define-values (pre post) (split-at path compaction-idx))
+             ;; post = [compaction-summary, ..., first-kept, ...]
+             ;; We want [compaction-summary] + messages from first-kept onward
+             (values pre post))]
+       [else
+        (define-values (pre post) (split-at path compaction-idx))
+        (values pre post)])]))
 
 (define (entry->context-message entry)
   ;; Convert a session entry to a context message for LLM consumption.

--- a/tests/test-compaction-edge-cases.rkt
+++ b/tests/test-compaction-edge-cases.rkt
@@ -261,3 +261,21 @@
   (define result (compact-history msgs #:hook-dispatcher allow #:token-config tiny-config))
   ;; Hook passed — normal compaction
   (check > (compaction-result-removed-count result) 0))
+
+(test-case "compact-history sets firstKeptEntryId in summary metadata"
+  (define msgs (for/list ([i (in-range 20)])
+                 (make-message (format "id-~a" i) #f 'user 'message
+                               (list (make-text-part (format "msg ~a" i)))
+                               (current-seconds) (hash))))
+  (define tiny-config (token-compaction-config 5 0 10))
+  (define result (compact-history msgs #:token-config tiny-config))
+  (define summary (compaction-result-summary-message result))
+  (when summary
+    (define meta (message-meta summary))
+    (check-true (hash-has-key? meta 'firstKeptEntryId)
+                "summary should contain firstKeptEntryId")
+    (define first-kept (hash-ref meta 'firstKeptEntryId #f))
+    (define kept (compaction-result-kept-messages result))
+    (when (pair? kept)
+      (check-equal? first-kept (message-id (car kept))
+                    "firstKeptEntryId should match first kept message id"))))


### PR DESCRIPTION
## Summary

Compaction summaries now include `firstKeptEntryId` in metadata, pointing at the first kept message. Context builder uses this to skip already-summarized entries reliably.

## Testing
- [x] 25 edge-case tests pass (including new firstKeptEntryId test)
- [x] 35 compactor tests pass
- [x] 5 context-builder tests pass

Fixes: #759
Refs: #756