### PR TITLE
feat(loop): emit message.start/delta/end events during streaming

### DIFF
--- a/agent/loop.rkt
+++ b/agent/loop.rkt
@@ -188,6 +188,8 @@
   (define all-chunks (box '()))
   (define cancelled-during-stream (box #f))
   (define stream-blocked (box #f))
+  (define message-started (box #f))
+  (define message-id (format "msg-~a-~a" turn-id (current-inexact-milliseconds)))
 
   (define stream-gen (provider-stream provider req))
 
@@ -196,6 +198,12 @@
     (when (and chunk (not (eq? chunk #f)))
       (set-box! all-chunks (cons chunk (unbox all-chunks)))
       (when (stream-chunk-delta-text chunk)
+        ;; Emit message.start on first text delta
+        (unless (unbox message-started)
+          (set-box! message-started #t)
+          (emit! bus session-id turn-id "message.start"
+                 (hasheq 'message-id message-id)
+                 #:state state))
         ;; Text delta
         (set-box! accumulated-text
                   (string-append (unbox accumulated-text) (stream-chunk-delta-text chunk)))
@@ -204,6 +212,11 @@
                turn-id
                "model.stream.delta"
                (hasheq 'delta (stream-chunk-delta-text chunk))
+               #:state state)
+        ;; Emit message.delta with message-id for extension consumption
+        (emit! bus session-id turn-id "message.delta"
+               (hasheq 'text (stream-chunk-delta-text chunk)
+                       'message-id message-id)
                #:state state)
         ;; Dispatch message-update hook for text delta
         (when hook-dispatcher
@@ -250,7 +263,13 @@
                turn-id
                "model.stream.completed"
                (hasheq 'usage (or (stream-chunk-usage chunk) (hasheq)))
-               #:state state))
+               #:state state)
+        ;; Emit message.end if we started a message
+        (when (unbox message-started)
+          (emit! bus session-id turn-id "message.end"
+                 (hasheq 'message-id message-id
+                         'usage (or (stream-chunk-usage chunk) (hasheq)))
+                 #:state state)))
       ;; Check cancellation after processing chunk
       (cond
         [(and cancellation-token (cancellation-token-cancelled? cancellation-token))

--- a/tests/test-loop.rkt
+++ b/tests/test-loop.rkt
@@ -398,3 +398,38 @@
  ;; model.stream.completed must still be emitted even when stream is blocked
  (check-not-false (member "model.stream.completed" event-names)
                   "model.stream.completed must be emitted on stream-blocked path"))
+
+(test-case
+ "streaming emits message.start, message.delta, message.end events"
+ (define bus (make-event-bus))
+ (define events (box '()))
+ (subscribe! bus (lambda (evt) (set-box! events (cons evt (unbox events)))))
+ (define prov
+   (make-provider
+    (lambda () "mock")
+    (lambda () (hasheq 'streaming #t))
+    (lambda (req) (error 'send "not used"))
+    (lambda (req)
+      (list (stream-chunk "Hello" #f #f #f)
+            (stream-chunk " world" #f #f #f)
+            (stream-chunk #f #f #f #t)))))
+ (define ctx (list (make-message "m-1" #f 'user 'message
+                                 (list (make-text-part "hi"))
+                                 1000 '#hash())))
+ (define result (run-agent-turn ctx prov bus
+                                #:session-id "s1" #:turn-id "t1"))
+ (define evts (reverse (unbox events)))
+ (define msg-events (filter (lambda (e) (member (event-event e)
+                                                 '("message.start" "message.delta" "message.end")))
+                             evts))
+ (define msg-event-names (map event-event msg-events))
+ ;; Should have: 1 start, 2 deltas, 1 end
+ (check-equal? (car msg-event-names) "message.start")
+ (check-equal? (last msg-event-names) "message.end")
+ (check = (count (lambda (n) (equal? n "message.delta")) msg-event-names) 2)
+ ;; message.start should have message-id
+ (define start-evt (car msg-events))
+ (check-true (hash-has-key? (event-payload start-evt) 'message-id))
+ ;; message.end should have message-id
+ (define end-evt (last msg-events))
+ (check-true (hash-has-key? (event-payload end-evt) 'message-id)))


### PR DESCRIPTION
## Summary

Add message-oriented streaming events (`message.start`, `message.delta`, `message.end`) with message-id for extension consumption.

## Testing
- [x] 19 loop tests pass
- [x] New test verifies event order and payload

Fixes: #761
Refs: #760