### PR TITLE
feat(runtime): auto-retry with exponential backoff on provider errors

### DIFF
--- a/runtime/auto-retry.rkt
+++ b/runtime/auto-retry.rkt
@@ -1,0 +1,78 @@
+#lang racket/base
+
+;;; runtime/auto-retry.rkt — Auto-retry with exponential backoff
+;;;
+;;; Provides retry logic for transient provider errors (429, 5xx, timeouts).
+;;; Wraps a thunk with configurable retry attempts and exponential backoff.
+
+(require racket/match
+         racket/string
+         "../util/protocol-types.rkt")
+
+(provide
+ ;; Predicates
+ retryable-error?
+ ;; Retry execution
+ with-auto-retry
+ ;; Configuration
+ default-max-retries
+ default-base-delay-ms
+ default-max-delay-ms
+ ;; Struct for retry stats
+ (struct-out retry-stats))
+
+;; ============================================================
+;; Configuration
+;; ============================================================
+
+(define default-max-retries 2)
+(define default-base-delay-ms 1000)
+(define default-max-delay-ms 30000)
+
+;; ============================================================
+;; Structs
+;; ============================================================
+
+(struct retry-stats (attempts final-delay-ms succeeded?) #:transparent)
+
+;; ============================================================
+;; Predicates
+;; ============================================================
+
+;; Check if an error is retryable (transient / rate-limit / server error).
+(define (retryable-error? exn)
+  (define msg (exn-message exn))
+  (define retryable-patterns
+    '("429" "rate" "overloaded" "quota" "too many"
+      "500" "502" "503" "504" "server error"
+      "timeout" "timed out" "connection" "network"
+      "retry" "backoff"))
+  (for/or ([pattern (in-list retryable-patterns)])
+    (string-contains? (string-downcase msg) pattern)))
+
+;; ============================================================
+;; Retry logic
+;; ============================================================
+
+;; Execute a thunk with automatic retry on retryable errors.
+;; Returns the thunk result on success, or re-raises on non-retryable
+;; error or after max-retries exhausted.
+(define (with-auto-retry thunk
+                          #:max-retries [max-retries default-max-retries]
+                          #:base-delay-ms [base-delay-ms default-base-delay-ms]
+                          #:max-delay-ms [max-delay-ms default-max-delay-ms]
+                          #:on-retry [on-retry #f])
+  (let loop ([attempt 0] [delay-ms 0])
+    (with-handlers
+        ([exn:fail?
+          (lambda (exn)
+            (cond
+              [(and (retryable-error? exn) (< attempt max-retries))
+               (define next-delay (min (* base-delay-ms (expt 2 attempt)) max-delay-ms))
+               ;; Call retry callback if provided
+               (when on-retry
+                 (on-retry (add1 attempt) max-retries next-delay (exn-message exn)))
+               (sleep (/ next-delay 1000.0))
+               (loop (add1 attempt) next-delay)]
+              [else (raise exn)]))])
+      (thunk))))

--- a/runtime/iteration.rkt
+++ b/runtime/iteration.rkt
@@ -71,7 +71,9 @@
                   cancellation-token? cancellation-token-cancelled?)
          ;; R2-6: Import hook-result accessors
          (only-in "../util/hook-types.rkt"
-                  hook-result-action hook-result-payload hook-result?))
+                  hook-result-action hook-result-payload hook-result?)
+         (only-in "../runtime/auto-retry.rkt"
+                  with-auto-retry retryable-error?))
 
 (provide run-iteration-loop
          emit-session-event!
@@ -211,11 +213,24 @@
           (merge-tool-lists base-tools ext-tools)
           base-tools)))
 
-  (run-agent-turn ctx-final prov bus
-                  #:session-id session-id
-                  #:turn-id turn-id
-                  #:tools tools
-                  #:cancellation-token token))
+  (with-auto-retry
+   (lambda ()
+     (run-agent-turn ctx-final prov bus
+                     #:session-id session-id
+                     #:turn-id turn-id
+                     #:tools tools
+                     #:cancellation-token token))
+   #:max-retries 2
+   #:base-delay-ms 1000
+   #:on-retry (lambda (attempt max-retries delay-ms error-msg)
+                (publish! bus
+                          (make-event "auto-retry.start"
+                                                (current-inexact-milliseconds)
+                                                session-id turn-id
+                                                (hasheq 'attempt attempt
+                                                        'max-retries max-retries
+                                                        'delay-ms delay-ms
+                                                        'error error-msg))))))
 
 ;; Handle tool-calls-pending: extract calls, run through scheduler, emit events,
 ;; and return (values tool-result-messages updated-ctx) for the next loop iteration.

--- a/tests/test-auto-retry.rkt
+++ b/tests/test-auto-retry.rkt
@@ -1,0 +1,130 @@
+#lang racket
+
+;;; tests/test-auto-retry.rkt — tests for runtime/auto-retry.rkt
+
+(require rackunit
+         rackunit/text-ui
+         "../runtime/auto-retry.rkt")
+
+;; ============================================================
+;; retryable-error? predicate tests
+;; ============================================================
+
+(test-case "retryable-error?: rate limit errors"
+  (check-true (retryable-error? (exn:fail "HTTP 429 rate limit" (current-continuation-marks))))
+  (check-true (retryable-error? (exn:fail "rate limit exceeded" (current-continuation-marks))))
+  (check-true (retryable-error? (exn:fail "Too many requests" (current-continuation-marks)))))
+
+(test-case "retryable-error?: server errors"
+  (check-true (retryable-error? (exn:fail "HTTP 500 server error" (current-continuation-marks))))
+  (check-true (retryable-error? (exn:fail "HTTP 502 bad gateway" (current-continuation-marks))))
+  (check-true (retryable-error? (exn:fail "HTTP 503 service unavailable" (current-continuation-marks))))
+  (check-true (retryable-error? (exn:fail "HTTP 504 gateway timeout" (current-continuation-marks)))))
+
+(test-case "retryable-error?: timeout errors"
+  (check-true (retryable-error? (exn:fail "connection timed out" (current-continuation-marks))))
+  (check-true (retryable-error? (exn:fail "timeout waiting for response" (current-continuation-marks))))
+  (check-true (retryable-error? (exn:fail "network connection reset" (current-continuation-marks)))))
+
+(test-case "retryable-error?: non-retryable errors"
+  (check-false (retryable-error? (exn:fail "invalid API key" (current-continuation-marks))))
+  (check-false (retryable-error? (exn:fail "model not found" (current-continuation-marks))))
+  (check-false (retryable-error? (exn:fail "bad request: missing field" (current-continuation-marks)))))
+
+(test-case "retryable-error?: case insensitive"
+  (check-true (retryable-error? (exn:fail "RATE LIMIT EXCEEDED" (current-continuation-marks))))
+  (check-true (retryable-error? (exn:fail "Overloaded Service" (current-continuation-marks)))))
+
+;; ============================================================
+;; with-auto-retry execution tests
+;; ============================================================
+
+(test-case "with-auto-retry: succeeds on first try"
+  (define result (with-auto-retry (lambda () 42)))
+  (check-equal? result 42))
+
+(test-case "with-auto-retry: retries on retryable error then succeeds"
+  (define attempt (box 0))
+  (define retries (box '()))
+  (define result
+    (with-auto-retry
+     (lambda ()
+       (set-box! attempt (add1 (unbox attempt)))
+       (if (= (unbox attempt) 1)
+           (raise (exn:fail "HTTP 503 service unavailable" (current-continuation-marks)))
+           "success"))
+     #:max-retries 2
+     #:base-delay-ms 10
+     #:on-retry (lambda (attempt max-retries delay-ms error-msg)
+                  (set-box! retries (cons (list attempt delay-ms error-msg) (unbox retries))))))
+  (check-equal? result "success")
+  (check-equal? (unbox attempt) 2)
+  ;; One retry callback fired
+  (check-equal? (length (unbox retries)) 1)
+  (check-equal? (first (first (unbox retries))) 1)
+  (check-true (string-contains? (third (first (unbox retries))) "503")))
+
+(test-case "with-auto-retry: exhausts retries and re-raises"
+  (define attempt (box 0))
+  (check-exn
+   exn:fail?
+   (lambda ()
+     (with-auto-retry
+      (lambda ()
+        (set-box! attempt (add1 (unbox attempt)))
+        (raise (exn:fail "HTTP 503 service unavailable" (current-continuation-marks))))
+      #:max-retries 2
+      #:base-delay-ms 10)))
+  ;; Should have tried 3 times: initial + 2 retries
+  (check-equal? (unbox attempt) 3))
+
+(test-case "with-auto-retry: non-retryable error raised immediately"
+  (define attempt (box 0))
+  (check-exn
+   exn:fail?
+   (lambda ()
+     (with-auto-retry
+      (lambda ()
+        (set-box! attempt (add1 (unbox attempt)))
+        (raise (exn:fail "invalid API key" (current-continuation-marks))))
+      #:max-retries 3
+      #:base-delay-ms 10)))
+  ;; Should only try once — non-retryable
+  (check-equal? (unbox attempt) 1))
+
+(test-case "with-auto-retry: exponential backoff increases delay"
+  (define delays (box '()))
+  (check-exn
+   exn:fail?
+   (lambda ()
+     (with-auto-retry
+      (lambda ()
+        (raise (exn:fail "HTTP 503" (current-continuation-marks))))
+      #:max-retries 3
+      #:base-delay-ms 10
+      #:on-retry (lambda (attempt max-retries delay-ms error-msg)
+                   (set-box! delays (cons delay-ms (unbox delays)))))))
+  ;; Delays should be: 10, 20, 40 (exponential with base 10ms)
+  (define sorted-delays (reverse (unbox delays)))
+  (check-equal? (length sorted-delays) 3)
+  (check-equal? (first sorted-delays) 10)
+  (check-equal? (second sorted-delays) 20)
+  (check-equal? (third sorted-delays) 40))
+
+(test-case "with-auto-retry: delay capped at max-delay-ms"
+  (define delays (box '()))
+  (check-exn
+   exn:fail?
+   (lambda ()
+     (with-auto-retry
+      (lambda ()
+        (raise (exn:fail "HTTP 503" (current-continuation-marks))))
+      #:max-retries 5
+      #:base-delay-ms 100
+      #:max-delay-ms 200
+      #:on-retry (lambda (attempt max-retries delay-ms error-msg)
+                   (set-box! delays (cons delay-ms (unbox delays)))))))
+  (define sorted-delays (reverse (unbox delays)))
+  ;; Delays should be capped at 200: 100, 200, 200, 200, 200
+  (for ([d (in-list sorted-delays)])
+    (check-true (<= d 200) (format "delay ~a should be <= 200" d))))


### PR DESCRIPTION
## Summary

Add `runtime/auto-retry.rkt` with retryable error detection and exponential backoff. Wired around `run-provider-turn` in iteration.rkt.

## Testing
- [x] 11 auto-retry tests (predicate, retry, backoff, cap)
- [x] 5 iteration tests pass
- [x] All pre-commit hooks pass

Fixes: #762
Refs: #760