### PR TITLE
feat(compaction): hook-provided custom summaries

### DIFF
--- a/runtime/compactor.rkt
+++ b/runtime/compactor.rkt
@@ -316,11 +316,13 @@
                          #:token-config [token-config (default-token-compaction-config)])
   ;; Dispatch 'session-before-compact hook if dispatcher provided
   ;; Returns identity result if hook blocks, otherwise proceeds with compaction.
+  ;; #769: Hook can provide custom summary via amend action.
+  (define hook-res
+    (and hook-dispatcher
+         (hook-dispatcher 'session-before-compact
+                          (hasheq 'message-count (length messages) 'strategy strategy))))
   (cond
-    [(and hook-dispatcher
-          (let ([hook-res (hook-dispatcher 'session-before-compact
-                                          (hasheq 'message-count (length messages) 'strategy strategy))])
-            (and (hook-result? hook-res) (eq? (hook-result-action hook-res) 'block))))
+    [(and (hook-result? hook-res) (eq? (hook-result-action hook-res) 'block))
      ;; Hook blocked compaction — return identity result immediately
      (compaction-result #f 0 messages)]
     [else
@@ -348,15 +350,22 @@
         (define current-ft (extract-file-tracker adjusted-old))
         (define previous-ft (find-previous-file-tracker adjusted-recent))
         (define cumulative-ft (merge-file-trackers current-ft previous-ft))
-        ;; Build summarization with cumulative file tracker
+        ;; #769: Check for hook-provided custom summary
+        (define custom-summary
+          (and (hook-result? hook-res)
+               (eq? (hook-result-action hook-res) 'amend)
+               (let ([payload (hook-result-payload hook-res)])
+                 (and (hash? payload) (hash-ref payload 'summary #f)))))
+        ;; Build summarization — use custom summary if provided, else standard path
         (define base-summary-text
-          (if (and provider model-name)
-              (llm-summarize adjusted-old
-                             provider
-                             model-name
-                             #:previous-summary (or prev-summary (find-previous-summary adjusted-recent))
-                             #:file-tracker cumulative-ft)
-              (summarize-fn adjusted-old)))
+          (or custom-summary
+              (if (and provider model-name)
+                  (llm-summarize adjusted-old
+                                 provider
+                                 model-name
+                                 #:previous-summary (or prev-summary (find-previous-summary adjusted-recent))
+                                 #:file-tracker cumulative-ft)
+                  (summarize-fn adjusted-old))))
         ;; Append turn prefix to summary if split-turn detected
         (define summary-text
           (if (string=? turn-prefix "")

--- a/tests/test-hook-custom-summaries.rkt
+++ b/tests/test-hook-custom-summaries.rkt
@@ -1,0 +1,94 @@
+#lang racket
+
+;;; tests/test-hook-custom-summaries.rkt — tests for hook-provided custom summaries (#769)
+;;;
+;;; Verifies that session-before-compact hook can provide custom summary
+;;; to skip the LLM call.
+
+(require rackunit
+         rackunit/text-ui
+         "../util/protocol-types.rkt"
+         "../runtime/compactor.rkt"
+         "../runtime/token-compaction.rkt"
+         "../util/hook-types.rkt")
+
+;; Helper: create a simple message
+(define (msg id role text)
+  (make-message id #f role 'message (list (make-text-part text)) (current-seconds) (hasheq)))
+
+;; Tiny token config
+(define tiny-tc (token-compaction-config 3 0 5))
+
+(test-case "hook returning custom summary skips summarize-fn"
+  (define call-count (box 0))
+  (define counting-summarizer
+    (lambda (messages)
+      (set-box! call-count (add1 (unbox call-count)))
+      "LLM summary"))
+  (define custom-hook
+    (lambda (hook-point payload)
+      (hook-result 'amend (hasheq 'summary "Custom hook summary"))))
+  (define msgs
+    (list (msg "m1" 'user "Message one text")
+          (msg "m2" 'assistant "Response two text")
+          (msg "m3" 'user "Message three text")
+          (msg "m4" 'assistant "Response four text")
+          (msg "m5" 'user "Message five text")))
+  (define result
+    (compact-history msgs
+                     #:summarize-fn counting-summarizer
+                     #:hook-dispatcher custom-hook
+                     #:token-config tiny-tc))
+  ;; Custom summary should be used
+  (define summary (compaction-result-summary-message result))
+  (define summary-text
+    (and summary
+         (string-join (for/list ([part (in-list (message-content summary))]
+                                 #:when (text-part? part))
+                        (text-part-text part)) "")))
+  ;; The summarize-fn should NOT have been called
+  (check-equal? (unbox call-count) 0)
+  ;; Summary text should contain the custom text
+  (check-not-false (and summary-text (string-contains? summary-text "Custom hook summary"))))
+
+(test-case "hook returning pass still uses summarize-fn"
+  (define call-count (box 0))
+  (define counting-summarizer
+    (lambda (messages)
+      (set-box! call-count (add1 (unbox call-count)))
+      "Default summary"))
+  (define pass-hook
+    (lambda (hook-point payload)
+      (hook-result 'pass (hasheq))))
+  (define msgs
+    (list (msg "m1" 'user "Message one text")
+          (msg "m2" 'assistant "Response two text")
+          (msg "m3" 'user "Message three text")
+          (msg "m4" 'assistant "Response four text")
+          (msg "m5" 'user "Message five text")))
+  (define result
+    (compact-history msgs
+                     #:summarize-fn counting-summarizer
+                     #:hook-dispatcher pass-hook
+                     #:token-config tiny-tc))
+  ;; summarize-fn SHOULD have been called
+  (check-equal? (unbox call-count) 1))
+
+(test-case "hook returning block prevents compaction"
+  (define block-hook
+    (lambda (hook-point payload)
+      (hook-result 'block (hasheq))))
+  (define msgs
+    (list (msg "m1" 'user "Message one text")
+          (msg "m2" 'assistant "Response two text")
+          (msg "m3" 'user "Message three text")
+          (msg "m4" 'assistant "Response four text")
+          (msg "m5" 'user "Message five text")))
+  (define result
+    (compact-history msgs
+                     #:hook-dispatcher block-hook
+                     #:token-config tiny-tc))
+  ;; No summary should be produced
+  (check-false (compaction-result-summary-message result))
+  ;; All messages kept
+  (check-equal? (length (compaction-result-kept-messages result)) 5))


### PR DESCRIPTION
## Summary

Allow `session-before-compact` hook to provide custom summary via amend action. Skips LLM call when custom summary provided.

## Testing
- [x] 3 new hook custom summary tests
- [x] All pre-commit hooks pass

Fixes: #769
Refs: #766