### PR TITLE
feat(compaction): stale usage guard after compaction

### DIFF
--- a/runtime/agent-session.rkt
+++ b/runtime/agent-session.rkt
@@ -58,6 +58,8 @@
          agent-session-system-instructions
          agent-session-compacting?
          set-agent-session-compacting?!
+         agent-session-last-compaction-time
+         set-agent-session-last-compaction-time!
          make-agent-session
          resume-agent-session
          fork-session
@@ -86,7 +88,8 @@
          config ; hash (runtime settings)
          [active? #:mutable] ; boolean
          [start-time #:mutable] ; integer (seconds since epoch)
-         [compacting? #:mutable]) ; boolean — guard against recursive compaction
+         [compacting? #:mutable] ; boolean — guard against recursive compaction
+         [last-compaction-time #:mutable]) ; integer or #f — timestamp of last compaction
   #:transparent)
 
 ;; ============================================================
@@ -134,7 +137,8 @@
                    config
                    #t ; active
                    session-created-at
-                   #f)) ; compacting?
+                   #f ; compacting?
+                   #f)) ; last-compaction-time
 
   ;; Emit session.started
   (emit-session-event! (agent-session-event-bus sess) sid "session.started" (hasheq 'sessionId sid))
@@ -207,7 +211,8 @@
                    config
                    #t
                    (now-seconds)
-                   #f)) ; compacting?
+                   #f ; compacting?
+                   #f)) ; last-compaction-time
 
   ;; Emit session.resumed
   (emit-session-event! (agent-session-event-bus sess)
@@ -301,7 +306,8 @@
                    (agent-session-config sess)
                    #t
                    (now-seconds)
-                   #f)) ; compacting?
+                   #f ; compacting?
+                   #f)) ; last-compaction-time
 
   ;; Emit session.forked on original session's bus
   (emit-session-event! (agent-session-event-bus sess)
@@ -436,21 +442,27 @@
   (cond
     [(not (should-compact? token-count token-budget-threshold)) context-with-system]
     [else
-     ;; Guard against recursive compaction
-     (if (agent-session-compacting? sess)
-         context-with-system
-         (begin
-           (set-agent-session-compacting?! sess #t)
-           (emit-session-event! bus sid "compaction.start"
-                                (hasheq 'tokenCount token-count 'budgetThreshold token-budget-threshold))
-           (dynamic-wind
-            (lambda () (void))
-            (lambda ()
-              (maybe-compact-context-internal sess context-with-system token-count token-budget-threshold bus sid))
-            (lambda ()
-              (set-agent-session-compacting?! sess #f)
-              (emit-session-event! bus sid "compaction.end"
-                                    (hasheq 'tokenCount token-count))))))]))
+     ;; #770: Stale usage guard — skip if compaction just completed
+     (define last-compact (agent-session-last-compaction-time sess))
+     (define now-ms (current-inexact-milliseconds))
+     (cond
+       [(and last-compact (< (- now-ms last-compact) 2000))
+        context-with-system] ; too soon after last compaction
+       [(agent-session-compacting? sess)
+        context-with-system] ; recursive compaction guard
+       [else
+        (set-agent-session-compacting?! sess #t)
+        (emit-session-event! bus sid "compaction.start"
+                             (hasheq 'tokenCount token-count 'budgetThreshold token-budget-threshold))
+        (dynamic-wind
+         (lambda () (void))
+         (lambda ()
+           (maybe-compact-context-internal sess context-with-system token-count token-budget-threshold bus sid))
+         (lambda ()
+           (set-agent-session-compacting?! sess #f)
+           (set-agent-session-last-compaction-time! sess (current-inexact-milliseconds))
+           (emit-session-event! bus sid "compaction.end"
+                                (hasheq 'tokenCount token-count))))])]))
 
 ;; Internal compaction logic (extracted from maybe-compact-context for dynamic-wind)
 (define (maybe-compact-context-internal sess context-with-system token-count token-budget-threshold bus sid)

--- a/tests/test-stale-usage-guard.rkt
+++ b/tests/test-stale-usage-guard.rkt
@@ -1,0 +1,59 @@
+#lang racket
+
+;;; tests/test-stale-usage-guard.rkt — tests for stale usage guard (#770)
+;;;
+;;; Verifies that compaction is not re-triggered with stale usage data
+;;; immediately after a compaction cycle.
+
+(require rackunit
+         rackunit/text-ui
+         "../util/protocol-types.rkt"
+         "../agent/event-bus.rkt"
+         "../runtime/agent-session.rkt")
+
+(define (make-temp-dir)
+  (make-temporary-file "q-stale-test-~a" 'directory))
+
+(define (make-test-session)
+  (make-agent-session
+   (hasheq 'session-dir (make-temp-dir)
+           'event-bus (make-event-bus)
+           'provider #f
+           'tool-registry #f
+           'model-name "test"
+           'system-instructions '())))
+
+(test-case "last-compaction-time starts as #f"
+  (define sess (make-test-session))
+  (check-false (agent-session-last-compaction-time sess)))
+
+(test-case "last-compaction-time updated after compaction"
+  (define sess (make-test-session))
+  (set-agent-session-last-compaction-time! sess (current-inexact-milliseconds))
+  (check-not-false (agent-session-last-compaction-time sess)))
+
+(test-case "stale usage guard prevents immediate re-compaction"
+  (define sess (make-test-session))
+  ;; Simulate recent compaction
+  (set-agent-session-last-compaction-time! sess (current-inexact-milliseconds))
+  ;; Create context that would normally trigger compaction (threshold 0 = always)
+  (define context
+    (list (make-message "m1" #f 'user 'message
+                        (list (make-text-part "hello world")) (current-seconds) (hasheq))))
+  ;; maybe-compact-context should return context unchanged (stale guard)
+  (define result (maybe-compact-context sess context 0))
+  (check-equal? result context))
+
+(test-case "fresh usage after cooldown triggers normally"
+  (define sess (make-test-session))
+  ;; Simulate compaction that happened 3 seconds ago
+  (set-agent-session-last-compaction-time! sess (- (current-inexact-milliseconds) 3000))
+  ;; Create context with enough messages to trigger
+  (define context
+    (list (make-message "m1" #f 'user 'message
+                        (list (make-text-part "hello")) (current-seconds) (hasheq))))
+  ;; Should not be blocked by stale guard (3s > 2s cooldown)
+  ;; The actual compaction depends on token count vs threshold, but stale guard is passed
+  (define result (maybe-compact-context sess context 0))
+  ;; Result should be valid (may or may not compact, but shouldn't be stale-blocked)
+  (check-true (list? result)))


### PR DESCRIPTION
## Summary

Add `last-compaction-time` timestamp to session. Skip auto-compaction if last compaction completed within 2 seconds to prevent stale usage data from triggering re-compaction.

## Testing
- [x] 4 new stale usage guard tests
- [x] All pre-commit hooks pass

Fixes: #770
Refs: #766