### PR TITLE
feat(session): format versioning and migration infrastructure

### DIFF
--- a/runtime/agent-session.rkt
+++ b/runtime/agent-session.rkt
@@ -114,9 +114,11 @@
   (unless (agent-session-persisted? sess)
     (make-directory* (agent-session-session-dir sess))
     (set-agent-session-persisted?! sess #t)
+    ;; #773: Write version header to new session log
+    (define log-path (session-log-path (agent-session-session-dir sess)))
+    (write-session-version-header! log-path)
     ;; Flush any buffered entries
     (when (not (null? (agent-session-pending-entries sess)))
-      (define log-path (session-log-path (agent-session-session-dir sess)))
       (for ([entry (in-list (reverse (agent-session-pending-entries sess)))])
         (append-entry! log-path entry))
       (set-agent-session-pending-entries! sess '()))))
@@ -210,7 +212,11 @@
   (unless (directory-exists? dir)
     (error 'resume-agent-session "session directory not found: ~a" dir))
 
+  ;; #773: Ensure session version header is up to date
   (define log-path (session-log-path dir))
+  (when (file-exists? log-path)
+    (ensure-session-version-header! log-path))
+
   (define idx-path (session-index-path dir))
 
   ;; Rebuild index from log (if log exists)
@@ -652,7 +658,9 @@
 (define (session-history sess)
   (define log-path (session-log-path (agent-session-session-dir sess)))
   (if (file-exists? log-path)
-      (load-session-log log-path)
+      ;; #773: Filter out session-info (version header) entries
+      (filter (lambda (m) (not (eq? (message-kind m) 'session-info)))
+              (load-session-log log-path))
       '()))
 
 (define (session-active? sess)

--- a/runtime/session-migration.rkt
+++ b/runtime/session-migration.rkt
@@ -1,0 +1,106 @@
+#lang racket/base
+
+;;; runtime/session-migration.rkt — session format versioning and migration
+;;;
+;;; Provides:
+;;;   current-session-version — the current format version number
+;;;   read-session-version    — read version from session log
+;;;   migrate-session-log!    — migrate a session log to current version
+;;;   ensure-session-version! — ensure version header exists and is current
+;;;
+;;; Migration chain: v1 → v2
+;;;   v1: No version header (original format)
+;;;   v2: Version header as first line (session-info message)
+;;;
+;;; This module wraps the versioning infrastructure from session-store.rkt
+;;; and provides a clean migration API.
+;;;
+;;; #773
+
+(require racket/file
+         json
+         "../util/jsonl.rkt"
+         "../util/protocol-types.rkt")
+
+(provide current-session-version
+         read-session-version
+         migrate-session-log!
+         ensure-session-version!)
+
+;; Current format version (synced with session-store.rkt)
+(define current-session-version 2)
+
+;; Read the session version from a log file.
+;; Returns 1 if no version header (v1 format) or the version from the header.
+;; path-string? -> exact-nonnegative-integer?
+(define (read-session-version path)
+  (if (not (file-exists? path))
+      current-session-version
+      (let ([first-entry (read-first-log-entry path)])
+        (cond
+          [(not first-entry) current-session-version]
+          [(session-info-entry? first-entry)
+           (hash-ref (message-meta first-entry) 'version 1)]
+          [else 1]))))
+
+;; Check if a message is a session-info entry (version header)
+(define (session-info-entry? msg)
+  (and (message? msg)
+       (eq? (message-kind msg) 'session-info)))
+
+;; Read only the first entry from a JSONL log
+(define (read-first-log-entry path)
+  (with-handlers ([exn:fail? (lambda (_) #f)])
+    (call-with-input-file path
+      (lambda (in)
+        (define line (read-line in))
+        (if (eof-object? line)
+            #f
+            (jsexpr->message (string->jsexpr line))))
+      #:mode 'text)))
+
+;; Migrate a session log from one version to another.
+;; Currently supports: v1 → v2 (add version header)
+;; path-string? -> void?
+(define (migrate-session-log! path)
+  (unless (file-exists? path)
+    (error 'migrate-session-log! "file not found: ~a" path))
+  (define version (read-session-version path))
+  (when (< version current-session-version)
+    ;; v1 → v2: prepend version header
+    (when (= version 1)
+      (migrate-v1->v2! path))))
+
+;; Migration v1 → v2: prepend session-info version header
+(define (migrate-v1->v2! path)
+  (define entries (load-session-log path))
+  (define header-msg
+    (make-message (format "session-version-header-~a" (current-inexact-milliseconds))
+                  #f
+                  'system
+                  'session-info
+                  '()
+                  (current-seconds)
+                  (hasheq 'version current-session-version)))
+  ;; Backup original
+  (define bak-path (format "~a.v1.bak" path))
+  (when (file-exists? bak-path)
+    (delete-file bak-path))
+  (rename-file-or-directory path bak-path #t)
+  ;; Write new version
+  (jsonl-append-entries! path (map message->jsexpr (cons header-msg entries)))
+  (fprintf (current-error-port)
+           "Session migrated v1 -> v~a: ~a entries. Backup: ~a\n"
+           current-session-version (length entries) bak-path))
+
+;; Load session log entries (re-export helper)
+(require (only-in "../runtime/session-store.rkt" load-session-log))
+
+;; Ensure session has a version header (write if missing)
+(define (ensure-session-version! path)
+  (unless (and (file-exists? path) (> (file-size path) 0))
+    (write-session-version-header! path)))
+
+;; Re-export writer from session-store
+(require (only-in "../runtime/session-store.rkt"
+                  write-session-version-header!))

--- a/tests/test-session-migration.rkt
+++ b/tests/test-session-migration.rkt
@@ -1,0 +1,124 @@
+#lang racket
+
+;;; tests/test-session-migration.rkt — tests for session format versioning (#773)
+
+(require rackunit
+         rackunit/text-ui
+         racket/file
+         json
+         "../util/jsonl.rkt"
+         "../util/protocol-types.rkt"
+         "../runtime/session-migration.rkt")
+
+(define (make-temp-file)
+  (make-temporary-file "q-migration-test-~a.jsonl"))
+
+(define (write-v1-file! path)
+  ;; Write a v1 format file (no version header, just messages)
+  (call-with-output-file path
+    (lambda (out)
+      (write-json (message->jsexpr
+                   (make-message "m1" #f 'user 'message
+                                 (list (make-text-part "hello")) (current-seconds) (hasheq))) out)
+      (newline out)
+      (write-json (message->jsexpr
+                   (make-message "m2" #f 'assistant 'message
+                                 (list (make-text-part "hi")) (current-seconds) (hasheq))) out)
+      (newline out))
+    #:exists 'truncate))
+
+(define (write-v2-file! path)
+  ;; Write a v2 format file (with session-info version header)
+  (call-with-output-file path
+    (lambda (out)
+      (write-json (message->jsexpr
+                   (make-message "session-version-header-test" #f 'system 'session-info
+                                 '() (current-seconds) (hasheq 'version 2))) out)
+      (newline out)
+      (write-json (message->jsexpr
+                   (make-message "m1" #f 'user 'message
+                                 (list (make-text-part "hello")) (current-seconds) (hasheq))) out)
+      (newline out))
+    #:exists 'truncate))
+
+(test-case "current-session-version is 2"
+  (check-equal? current-session-version 2))
+
+(test-case "read-session-version returns 1 for v1 file (no header)"
+  (define path (make-temp-file))
+  (dynamic-wind
+   (lambda () (void))
+   (lambda ()
+     (write-v1-file! path)
+     (check-equal? (read-session-version path) 1))
+   (lambda () (delete-file path))))
+
+(test-case "read-session-version returns 2 for v2 file (with header)"
+  (define path (make-temp-file))
+  (dynamic-wind
+   (lambda () (void))
+   (lambda ()
+     (write-v2-file! path)
+     (check-equal? (read-session-version path) 2))
+   (lambda () (delete-file path))))
+
+(test-case "migrate-v1-to-v2 adds version header"
+  (define path (make-temp-file))
+  (dynamic-wind
+   (lambda () (void))
+   (lambda ()
+     (write-v1-file! path)
+     ;; Migrate
+     (migrate-session-log! path)
+     ;; Check version is now 2
+     (check-equal? (read-session-version path) 2)
+     ;; Check all entries are preserved (header + 2 originals)
+     (define entries (jsonl-read-all-valid path))
+     (check-equal? (length entries) 3)
+     ;; First entry should be the version header
+     (define header (jsexpr->message (car entries)))
+     (check-equal? (message-kind header) 'session-info)
+     (check-equal? (hash-ref (message-meta header) 'version) 2)
+     ;; Original entries preserved
+     (define msg1 (jsexpr->message (cadr entries)))
+     (check-equal? (message-id msg1) "m1")
+     (define msg2 (jsexpr->message (caddr entries)))
+     (check-equal? (message-id msg2) "m2"))
+   (lambda () (when (file-exists? path) (delete-file path)))))
+
+(test-case "migration is idempotent — v2 file unchanged"
+  (define path (make-temp-file))
+  (dynamic-wind
+   (lambda () (void))
+   (lambda ()
+     (write-v2-file! path)
+     (define before-count (length (jsonl-read-all-valid path)))
+     (migrate-session-log! path)
+     (define after-count (length (jsonl-read-all-valid path)))
+     (check-equal? after-count before-count)
+     (check-equal? (read-session-version path) 2))
+   (lambda () (delete-file path))))
+
+(test-case "migration creates backup of v1 file"
+  (define path (make-temp-file))
+  (dynamic-wind
+   (lambda () (void))
+   (lambda ()
+     (write-v1-file! path)
+     (migrate-session-log! path)
+     (define bak-path (format "~a.v1.bak" path))
+     (check-true (file-exists? bak-path))
+     (delete-file bak-path))
+   (lambda () (when (file-exists? path) (delete-file path)))))
+
+(test-case "ensure-session-version! creates header for new file"
+  (define path (make-temporary-file "q-version-test-~a.jsonl"))
+  (dynamic-wind
+   (lambda () (void))
+   (lambda ()
+     (delete-file path)
+     (ensure-session-version! path)
+     (check-true (file-exists? path))
+     (check-equal? (read-session-version path) 2))
+   (lambda ()
+     (when (file-exists? path) (delete-file path)))))


### PR DESCRIPTION
## Summary

Add `runtime/session-migration.rkt` with version detection (v1/v2) and migration chain.
Version header prepended on session creation, automatic migration on resume.
`session-history` now filters out session-info metadata entries.

## Testing
- [x] 7 migration tests (version detection, migration, idempotency, backup)
- [x] 45 agent-session tests pass
- [x] 47 session-store tests pass

Fixes: #773
Refs: #772