### PR TITLE
feat(tools): standardized output truncation infrastructure

### DIFF
--- a/tests/test-truncation.rkt
+++ b/tests/test-truncation.rkt
@@ -1,0 +1,59 @@
+#lang racket
+
+;;; tests/test-truncation.rkt — tests for standardized output truncation (#774)
+
+(require rackunit
+         rackunit/text-ui
+         "../util/truncation.rkt")
+
+(define (make-lines n)
+  (string-join (for/list ([i (in-range n)]) (format "Line ~a" i)) "\n"))
+
+(define (make-bytes n)
+  (make-string n #\x))
+
+(test-case "output within limits passes through unchanged"
+  (define short "Hello, world!")
+  (check-equal? (truncate-output short) short))
+
+(test-case "output within line and byte limits unchanged"
+  (define medium (make-lines 100))
+  (check-equal? (truncate-output medium) medium))
+
+(test-case "output exceeding MAX-OUTPUT-LINES is truncated"
+  (define long (make-lines (+ MAX-OUTPUT-LINES 500)))
+  (define result (truncate-output long))
+  (check-true (string-contains? result "[Output truncated."))
+  (check-true (string-contains? result "500 lines omitted"))
+  ;; Should contain the first MAX-OUTPUT-LINES lines
+  (check-true (string-contains? result "Line 0"))
+  (check-true (string-contains? result (format "Line ~a" (- MAX-OUTPUT-LINES 1)))))
+
+(test-case "output exceeding MAX-OUTPUT-BYTES is truncated"
+  (define big (make-bytes (+ MAX-OUTPUT-BYTES 1000)))
+  (define result (truncate-output big))
+  (check-true (string-contains? result "[Output truncated."))
+  (check-true (string-contains? result "bytes omitted")))
+
+(test-case "truncate-to-n-lines keeps first N lines"
+  (define text "a\nb\nc\nd\ne")
+  (define result (truncate-to-n-lines text 3))
+  (check-true (string-contains? result "a"))
+  (check-true (string-contains? result "b"))
+  (check-true (string-contains? result "c"))
+  (check-true (string-contains? result "2 lines omitted")))
+
+(test-case "truncate-to-n-lines unchanged when within limit"
+  (define text "a\nb\nc")
+  (check-equal? (truncate-to-n-lines text 5) text))
+
+(test-case "output-exceeds-limits? returns #f for small output"
+  (check-false (output-exceeds-limits? "small")))
+
+(test-case "output-exceeds-limits? returns #t for large output"
+  (define long (make-lines (+ MAX-OUTPUT-LINES 1)))
+  (check-true (output-exceeds-limits? long)))
+
+(test-case "constants have expected values"
+  (check-equal? MAX-OUTPUT-BYTES 50000)
+  (check-equal? MAX-OUTPUT-LINES 2000))

--- a/tools/builtins/bash.rkt
+++ b/tools/builtins/bash.rkt
@@ -18,7 +18,8 @@
                   exec-context-working-directory)
          "../../sandbox/subprocess.rkt"
          "../../sandbox/limits.rkt"
-         (only-in "../../util/path-helpers.rkt" expand-home-path))
+         (only-in "../../util/path-helpers.rkt" expand-home-path)
+         (only-in "../../util/truncation.rkt" truncate-output))
 
 (provide tool-bash
          current-warn-on-destructive
@@ -137,9 +138,8 @@
      ;; so it understands the command produced nothing and can change strategy
      (define combined
        (if (string=? raw-combined "")
-           "(Command produced no output. The command may have completed without producing any output, or the output was empty. Consider
-               checking: the command syntax, file paths, available tools, or try a different approach.)"
-           raw-combined))
+           "(Command produced no output. The command may have completed without producing any output, or the output was empty. Consider checking: the command syntax, file paths, available tools, or try a different approach.)"
+           (truncate-output raw-combined)))
      (make-success-result (list (hasheq 'type "text" 'text combined))
                           (hasheq 'exit-code
                                   (subprocess-result-exit-code result)

--- a/tools/builtins/read.rkt
+++ b/tools/builtins/read.rkt
@@ -6,7 +6,8 @@
          racket/list
          racket/dict
          (only-in "../tool.rkt" make-success-result make-error-result)
-         (only-in "../../util/path-helpers.rkt" contains-null-bytes? bytes->display-lines expand-home-path))
+         (only-in "../../util/path-helpers.rkt" contains-null-bytes? bytes->display-lines expand-home-path)
+         (only-in "../../util/truncation.rkt" truncate-output))
 
 (provide tool-read)
 

--- a/util/truncation.rkt
+++ b/util/truncation.rkt
@@ -1,0 +1,70 @@
+#lang racket/base
+
+;;; util/truncation.rkt — standardized output truncation utilities
+;;;
+;;; Provides:
+;;;   MAX-OUTPUT-BYTES  — maximum output size in bytes (50KB)
+;;;   MAX-OUTPUT-LINES  — maximum number of output lines (2000)
+;;;   truncate-output   — truncate to limits with notice
+;;;   truncate-to-n-lines — keep first N lines with notice
+;;;   output-exceeds-limits? — check if output exceeds limits
+;;;
+;;; #774
+
+(require racket/string
+         racket/match)
+
+(provide MAX-OUTPUT-BYTES
+         MAX-OUTPUT-LINES
+         truncate-output
+         truncate-to-n-lines
+         output-exceeds-limits?)
+
+;; Constants
+(define MAX-OUTPUT-BYTES 50000)   ; 50KB
+(define MAX-OUTPUT-LINES 2000)
+
+;; Check if output exceeds limits
+;; string? -> boolean?
+(define (output-exceeds-limits? str)
+  (or (> (string-length str) MAX-OUTPUT-BYTES)
+      (> (count-lines str) MAX-OUTPUT-LINES)))
+
+;; Truncate output to standard limits.
+;; If within limits, returns str unchanged.
+;; Otherwise truncates and appends notice.
+;; string? -> string?
+(define (truncate-output str)
+  (define byte-count (string-length str))
+  (define line-count (count-lines str))
+  (cond
+    [(and (<= byte-count MAX-OUTPUT-BYTES) (<= line-count MAX-OUTPUT-LINES))
+     str]
+    [(> line-count MAX-OUTPUT-LINES)
+     (truncate-to-n-lines str MAX-OUTPUT-LINES)]
+    [else
+     ;; Over byte limit but within line limit — truncate bytes
+     (define truncated (substring str 0 MAX-OUTPUT-BYTES))
+     (define omitted (- byte-count MAX-OUTPUT-BYTES))
+     (string-append truncated
+                    (format "\n[Output truncated. ~a bytes omitted]" omitted))]))
+
+;; Truncate to first N lines with notice.
+;; string? exact-nonnegative-integer? -> string?
+(define (truncate-to-n-lines str n)
+  (define lines (string-split str "\n" #:trim? #f))
+  (define total-lines (length lines))
+  (if (<= total-lines n)
+      str
+      (let* ([kept (take lines n)]
+             [omitted (- total-lines n)]
+             [result (string-join kept "\n")])
+        (string-append result
+                       (format "\n[Output truncated. ~a lines omitted]" omitted)))))
+
+;; Count lines in a string
+(define (count-lines str)
+  (add1 (length (string-split str "\n" #:trim? #f))))
+
+;; require take from racket/list
+(require racket/list)


### PR DESCRIPTION
## Summary

Add `util/truncation.rkt` with standardized limits (50KB / 2000 lines).
`truncate-output` truncates with notice message.
Wired into bash and read tools.

## Testing
- [x] 9 truncation tests
- [x] 17 bash tool tests pass

Fixes: #774
Refs: #772