### PR TITLE
fix: emit assistant.message.completed before tool calls + clear streaming-text (#799)

### DIFF
--- a/agent/loop.rkt
+++ b/agent/loop.rkt
@@ -463,7 +463,15 @@
          'completed
          (hasheq 'turnId turn-id 'usage (or effective-usage (hasheq)) 'model "streamed"))]
        [else
-        ;; Tool calls detected -- emit tool.call.started for each
+        ;; Tool calls detected -- commit assistant text FIRST, then emit tool.call.started
+        ;; Bug B1 fix: emit assistant.message.completed before tool.call.started
+        ;; so the TUI commits streaming text to permanent transcript.
+        (emit! bus
+               session-id
+               turn-id
+               "assistant.message.completed"
+               (hasheq 'messageId assistant-msg-id 'content (text-part-text final-text-part))
+               #:state state)
         (for ([tc (in-list tool-call-parts)])
           (emit! bus
                  session-id

--- a/tests/test-streaming-tool-bug.rkt
+++ b/tests/test-streaming-tool-bug.rkt
@@ -49,7 +49,7 @@
    ;; ------------------------------------------------------------------
 
    (test-case
-    "BUG: streaming text NOT committed when tool.call.started follows (no assistant.message.completed)"
+    "FIXED: streaming text cleared on turn.completed when tool.call.started follows (no assistant.message.completed)"
     ;; This test FAILS before the fix, demonstrating the bug.
     ;; After Wave 1 fix (adding assistant.message.completed to loop.rkt),
     ;; the agent loop will emit the event and this scenario won't occur.
@@ -101,11 +101,10 @@
                                                              'turnId "turn-1"))))
     (check-false (ui-state-busy? s6) "turn.completed → not busy")
 
-    ;; BUG ASSERTION: streaming-text is STILL not cleared on turn.completed
-    ;; (Bug B2 — turn.completed doesn't clear streaming-text)
-    ;; The answer "The answer is 42." is lost from display on next turn
-    (check-equal? (ui-state-streaming-text s6) "The answer is 42."
-                   "BUG B2 PRESENT: streaming-text persists after turn.completed"))
+    ;; After B2 fix: turn.completed NOW clears streaming-text
+    ;; (defense-in-depth so stale text doesn't contaminate next turn)
+    (check-false (ui-state-streaming-text s6)
+                 "B2 FIXED: streaming-text cleared on turn.completed"))
 
    ;; ------------------------------------------------------------------
    ;; CORRECT BEHAVIOR: When assistant.message.completed IS emitted,
@@ -173,7 +172,7 @@
                   "no cross-turn accumulation after proper completion"))
 
    (test-case
-    "BUG: streaming text accumulates across turns when assistant.message.completed missing"
+    "FIXED: streaming text does not accumulate across turns when assistant.message.completed missing"
     ;; This is the actual worst case: no assistant.message.completed AND no
     ;; streaming-text cleanup on turn.completed
     (define s0 (initial-ui-state))
@@ -189,18 +188,18 @@
                                                           (hasheq 'termination 'tool-calls-pending
                                                                  'turnId "turn-1"))))
 
-    ;; BUG: streaming-text still has "Leftover "
-    (check-equal? (ui-state-streaming-text s4) "Leftover "
-                  "BUG B2: streaming-text persists across turn boundary")
+    ;; B2 FIX: turn.completed NOW clears streaming-text
+    (check-false (ui-state-streaming-text s4)
+                 "B2 FIXED: streaming-text cleared on turn.completed even without assistant.message.completed")
 
-    ;; Turn 2: stream new text
+    ;; Turn 2: stream new text — no contamination
     (define s5 (apply-event-to-state s4 (make-test-event "turn.started" (hasheq) #:turn-id "turn-2")))
     (define s6 (apply-event-to-state s5 (make-test-event "model.stream.delta" (hasheq 'delta "New text")
                                                           #:turn-id "turn-2")))
 
-    ;; BUG: streaming-text is "Leftover New text" — contaminated!
-    (check-equal? (ui-state-streaming-text s6) "Leftover New text"
-                  "BUG CONFIRMED: cross-turn contamination from uncleared streaming-text"))))
+    ;; FIXED: streaming-text is just "New text" — no contamination
+    (check-equal? (ui-state-streaming-text s6) "New text"
+                  "B2 FIXED: no cross-turn contamination"))))
 
 (module+ main
   (run-tests streaming-tool-bug-tests))

--- a/tui/state.rkt
+++ b/tui/state.rkt
@@ -336,8 +336,10 @@
     ;; Agent starts processing — mark busy
     [("turn.started") (struct-copy ui-state state [busy? #t])]
 
-    ;; Agent done processing — mark not busy
-    [("turn.completed") (struct-copy ui-state state [busy? #f])]
+    ;; Agent done processing — mark not busy, clear streaming-text
+    ;; Bug B2 fix: clear streaming-text on turn.completed as defense-in-depth
+    ;; so stale streaming text doesn't contaminate next turn.
+    [("turn.completed") (struct-copy ui-state state [busy? #f] [streaming-text #f])]
 
     [("turn.cancelled")
      ;; Agent turn was cancelled — clear busy state


### PR DESCRIPTION
## Wave 1 — Fix Core Event Emission Bugs (B1 + B2)

Fixes #799.

### Changes

**Bug B1** (`q/agent/loop.rkt`):
- In the tool-call branch of `process-stream-response`, `assistant.message.completed` was never emitted
- The TUI only commits streaming-text to permanent transcript upon receiving this event
- Fix: emit `assistant.message.completed` BEFORE `tool.call.started` events

**Bug B2** (`q/tui/state.rkt`):
- `turn.completed` handler set `busy?=#f` but did not clear `streaming-text`
- Stale text accumulated across turn boundaries
- Fix: add `[streaming-text #f]` to `turn.completed` handler

### Testing
- `raco test q/tests/test-streaming-tool-bug.rkt` — 4/4 pass
- `raco test q/tests/test-loop.rkt` — all pass
- `raco test q/tests/tui/state.rkt` — 56/56 pass
- No new regressions (1 pre-existing failure in test-integration unrelated)

### Related
- Issue: #799
- Milestone: v0.9.8 (MS#50)
