### PR TITLE
test: TUI state transition tests + event simulator (#800)

### DIFF
--- a/tests/test-streaming-transitions.rkt
+++ b/tests/test-streaming-transitions.rkt
@@ -1,0 +1,205 @@
+#lang racket
+
+;; tests/test-streaming-transitions.rkt — Wave 2: Comprehensive TUI state transition tests
+;;
+;; Tests for all streaming -> tool state transitions in the TUI state machine.
+;; Uses the event-simulator infrastructure for clean event sequence testing.
+
+(require rackunit
+         rackunit/text-ui
+         "tui/event-simulator.rkt"
+         "../tui/state.rkt"
+         "../util/protocol-types.rkt")
+
+(define streaming-transition-tests
+  (test-suite
+   "TUI Streaming State Transitions"
+
+   ;; Test 1: Streaming text committed when assistant.message.completed fires
+   ;; before tool.call.started
+   (test-case
+    "streaming text committed when assistant.message.completed fires before tool.call.started"
+    (define s0 (initial-ui-state))
+    (define events
+      (list (make-test-event "turn.started" (hasheq))
+            (make-test-event "model.stream.delta" (hasheq 'delta "Answer: "))
+            (make-test-event "model.stream.delta" (hasheq 'delta "42"))
+            (make-test-event "assistant.message.completed"
+                             (hasheq 'messageId "m1" 'content "Answer: 42"))
+            (make-test-event "tool.call.started"
+                             (hasheq 'id "tc-1" 'name "read"
+                                     'arguments (hasheq 'path "/tmp/test.txt")))))
+    (define states (simulate-and-record s0 events))
+    (define final (state-at states 5))
+    (check-equal? (transcript-types final) '(assistant tool-start)
+                  "assistant + tool-start in transcript")
+    (check-false (ui-state-streaming-text final)
+                 "streaming-text cleared after assistant.message.completed")
+    (check-equal? (transcript-entry-text (car (ui-state-transcript final)))
+                  "Answer: 42"
+                  "committed text matches streamed content"))
+
+   ;; Test 2: Full text committed before tool calls in complete cycle
+   (test-case
+    "full text committed before tool calls in complete cycle"
+    (define s0 (initial-ui-state))
+    (define events
+      (list (make-test-event "turn.started" (hasheq))
+            (make-test-event "model.stream.delta" (hasheq 'delta "Hello "))
+            (make-test-event "model.stream.delta" (hasheq 'delta "world"))
+            (make-test-event "assistant.message.completed"
+                             (hasheq 'messageId "m1" 'content "Hello world"))
+            (make-test-event "tool.call.started"
+                             (hasheq 'id "tc-1" 'name "read"
+                                     'arguments (hasheq 'path "/tmp/x")))
+            (make-test-event "tool.call.completed"
+                             (hasheq 'name "read" 'result "content"))
+            (make-test-event "turn.completed"
+                             (hasheq 'termination 'tool-calls-pending 'turnId "turn-1"))))
+    (define states (simulate-and-record s0 events))
+    (define final (state-at states 7))
+    (check-equal? (transcript-types final) '(assistant tool-start tool-end)
+                  "full transcript: assistant, tool-start, tool-end")
+    (check-false (ui-state-streaming-text final)
+                 "streaming-text clear at end of tool-call turn")
+    (check-false (ui-state-busy? final) "not busy after turn.completed"))
+
+   ;; Test 3: Streaming text does NOT accumulate across turns
+   (test-case
+    "streaming text does NOT accumulate across turns"
+    (define s0 (initial-ui-state))
+    (define events
+      (list (make-test-event "turn.started" (hasheq))
+            (make-test-event "model.stream.delta" (hasheq 'delta "Turn1"))
+            (make-test-event "assistant.message.completed"
+                             (hasheq 'messageId "m1" 'content "Turn1"))
+            (make-test-event "turn.completed"
+                             (hasheq 'termination 'completed 'turnId "turn-1"))
+            (make-test-event "turn.started" (hasheq) #:turn-id "turn-2")
+            (make-test-event "model.stream.delta" (hasheq 'delta "Turn2")
+                             #:turn-id "turn-2")))
+    (define states (simulate-and-record s0 events))
+    (define final (state-at states 6))
+    (check-equal? (ui-state-streaming-text final) "Turn2"
+                  "no cross-turn accumulation")
+    (check-equal? (transcript-length final) 1
+                  "only one assistant entry from turn 1"))
+
+   ;; Test 4: Full tool-use loop: answer + tool + follow-up answer
+   (test-case
+    "full tool-use loop: answer + tool + follow-up answer"
+    (define s0 (initial-ui-state))
+    (define events
+      (list (make-test-event "turn.started" (hasheq))
+            (make-test-event "model.stream.delta" (hasheq 'delta "CL answer"))
+            (make-test-event "assistant.message.completed"
+                             (hasheq 'messageId "m1" 'content "CL answer"))
+            (make-test-event "tool.call.started"
+                             (hasheq 'id "tc-1" 'name "read"
+                                     'arguments (hasheq 'path "/tmp/x")))
+            (make-test-event "tool.call.completed"
+                             (hasheq 'name "read" 'result "file data"))
+            (make-test-event "turn.completed"
+                             (hasheq 'termination 'tool-calls-pending 'turnId "turn-1"))
+            (make-test-event "turn.started" (hasheq) #:turn-id "turn-2")
+            (make-test-event "model.stream.delta" (hasheq 'delta "Follow-up")
+                             #:turn-id "turn-2")
+            (make-test-event "assistant.message.completed"
+                             (hasheq 'messageId "m2" 'content "Follow-up")
+                             #:turn-id "turn-2")
+            (make-test-event "turn.completed"
+                             (hasheq 'termination 'completed 'turnId "turn-2"))))
+    (define states (simulate-and-record s0 events))
+    (define final (state-at states 11))
+    (check-equal? (transcript-types final)
+                  '(assistant tool-start tool-end assistant)
+                  "full loop: both assistant entries preserved with tool entries")
+    (check-false (ui-state-streaming-text final)
+                 "streaming-text clear after full loop")
+    (check-false (ui-state-busy? final) "not busy after loop completes"))
+
+   ;; Test 5: Tool calls without prior streaming (edge case)
+   (test-case
+    "tool calls without prior streaming"
+    (define s0 (initial-ui-state))
+    (define events
+      (list (make-test-event "turn.started" (hasheq))
+            (make-test-event "assistant.message.completed"
+                             (hasheq 'messageId "m1" 'content ""))
+            (make-test-event "tool.call.started"
+                             (hasheq 'id "tc-1" 'name "bash"
+                                     'arguments (hasheq 'command "ls")))
+            (make-test-event "tool.call.completed"
+                             (hasheq 'name "bash" 'result "file1\nfile2"))))
+    (define states (simulate-and-record s0 events))
+    (define final (state-at states 4))
+    (check-equal? (transcript-types final) '(assistant tool-start tool-end)
+                  "assistant (empty) + tool entries")
+    (check-false (ui-state-streaming-text final) "no streaming text"))
+
+   ;; Test 6: Cancellation mid-stream clears streaming text
+   (test-case
+    "cancellation mid-stream clears streaming text"
+    (define s0 (initial-ui-state))
+    (define events
+      (list (make-test-event "turn.started" (hasheq))
+            (make-test-event "model.stream.delta" (hasheq 'delta "Partial answer..."))
+            (make-test-event "turn.cancelled" (hasheq))))
+    (define states (simulate-and-record s0 events))
+    (define final (state-at states 3))
+    (check-false (ui-state-streaming-text final)
+                 "streaming-text cleared on cancel")
+    (check-false (ui-state-busy? final) "not busy after cancel")
+    (check-equal? (transcript-length final) 0
+                  "no transcript entries for cancelled turn"))
+
+   ;; Test 7: Multiple tool calls preserve all entries
+   (test-case
+    "multiple tool calls preserve all entries"
+    (define s0 (initial-ui-state))
+    (define events
+      (list (make-test-event "turn.started" (hasheq))
+            (make-test-event "model.stream.delta" (hasheq 'delta "Reading files..."))
+            (make-test-event "assistant.message.completed"
+                             (hasheq 'messageId "m1" 'content "Reading files..."))
+            (make-test-event "tool.call.started"
+                             (hasheq 'id "tc-1" 'name "read"
+                                     'arguments (hasheq 'path "/tmp/a")))
+            (make-test-event "tool.call.started"
+                             (hasheq 'id "tc-2" 'name "bash"
+                                     'arguments (hasheq 'command "ls")))
+            (make-test-event "tool.call.completed"
+                             (hasheq 'name "read" 'result "content-a"))
+            (make-test-event "tool.call.completed"
+                             (hasheq 'name "bash" 'result "file1"))))
+    (define states (simulate-and-record s0 events))
+    (define final (state-at states 7))
+    (check-equal? (transcript-length final) 5
+                  "5 entries: 1 assistant + 2 tool-starts + 2 tool-ends")
+    (check-equal? (transcript-types final)
+                  '(assistant tool-start tool-start tool-end tool-end)
+                  "all entry types correct"))
+
+   ;; Test 8: Failed tool calls are recorded as tool-fail
+   (test-case
+    "failed tool calls are recorded as tool-fail"
+    (define s0 (initial-ui-state))
+    (define events
+      (list (make-test-event "turn.started" (hasheq))
+            (make-test-event "assistant.message.completed"
+                             (hasheq 'messageId "m1" 'content "Let me read that"))
+            (make-test-event "tool.call.started"
+                             (hasheq 'id "tc-1" 'name "read"
+                                     'arguments (hasheq 'path "/nonexistent")))
+            (make-test-event "tool.call.failed"
+                             (hasheq 'name "read" 'error "File not found"))))
+    (define states (simulate-and-record s0 events))
+    (define final (state-at states 4))
+    (check-equal? (transcript-types final) '(assistant tool-start tool-fail)
+                  "last entry is tool-fail, not tool-end")
+    (define fail-text (last (transcript-texts final)))
+    (check-not-false (regexp-match #rx"\\[FAIL:" fail-text)
+                     (format "fail entry has FAIL prefix, got: ~a" fail-text)))))
+
+(module+ main
+  (run-tests streaming-transition-tests))

--- a/tests/test-tui-renderer.rkt
+++ b/tests/test-tui-renderer.rkt
@@ -11,7 +11,9 @@
          "../tui/layout.rkt"
          "../tui/state.rkt"
          "../tui/input.rkt"
-         "../tui/char-width.rkt")
+         "../tui/char-width.rkt"
+         "../util/protocol-types.rkt"
+         "tui/event-simulator.rkt")
 
 ;; ============================================================
 ;; Mock ubuf implementation for testing
@@ -527,9 +529,86 @@
       ;; Should not raise — render wraps/truncates
       (check-not-exn (lambda () (run-render-frame! ubuf state input-st layout))))))
 
-;; ============================================================
-;; Run tests
-;; ============================================================
+   ;; ============================================================
+   ;; Render-level transition tests (Wave 2, sub-issue #803)
+   ;; ============================================================
+
+   (test-case
+    "render shows assistant text + tool messages after full cycle"
+    (define ubuf (make-mock-ubuf 80 24))
+    ;; Build state with: assistant text, tool-start, tool-end
+    (define s0 (initial-ui-state))
+    (define events
+      (list (make-test-event "turn.started" (hasheq))
+            (make-test-event "model.stream.delta" (hasheq 'delta "CL answer"))
+            (make-test-event "assistant.message.completed"
+                             (hasheq 'messageId "m1" 'content "CL answer"))
+            (make-test-event "tool.call.started"
+                             (hasheq 'id "tc-1" 'name "read"
+                                     'arguments "/tmp/x"))
+            (make-test-event "tool.call.completed"
+                             (hasheq 'name "read" 'result "file data"))))
+    (define state (simulate-events s0 events))
+    (define input-st (initial-input-state))
+    (define layout (compute-layout 80 24))
+    ;; Should not raise
+    (check-not-exn (lambda () (run-render-frame! ubuf state input-st layout)))
+    ;; Verify transcript has all 3 entries
+    (check-equal? (transcript-types state) '(assistant tool-start tool-end)))
+
+   (test-case
+    "render shows streaming text below committed entries"
+    (define ubuf (make-mock-ubuf 80 24))
+    ;; Build state with: tool-start in transcript + streaming text active
+    (define s0 (initial-ui-state))
+    (define events
+      (list (make-test-event "turn.started" (hasheq))
+            (make-test-event "assistant.message.completed"
+                             (hasheq 'messageId "m1" 'content "Previous answer"))
+            (make-test-event "tool.call.started"
+                             (hasheq 'id "tc-1" 'name "bash"
+                                     'arguments "ls"))))
+    ;; Add streaming text to simulate mid-stream state
+    (define state (struct-copy ui-state (simulate-events s0 events)
+                                [streaming-text "New answer streaming"]))
+    (define input-st (initial-input-state))
+    (define layout (compute-layout 80 24))
+    ;; Should not raise — streaming text renders below committed entries
+    (check-not-exn (lambda () (run-render-frame! ubuf state input-st layout)))
+    ;; Verify state has streaming text
+    (check-equal? (ui-state-streaming-text state) "New answer streaming"))
+
+   (test-case
+    "render does not lose content with many tool messages"
+    (define ubuf (make-mock-ubuf 40 5))
+    ;; Build state with many tool entries + 1 assistant entry
+    (define s0 (initial-ui-state))
+    (define base-events
+      (list (make-test-event "turn.started" (hasheq))
+            (make-test-event "assistant.message.completed"
+                             (hasheq 'messageId "m1" 'content "Answer"))))
+    ;; Add 10 tool entries
+    (define tool-events
+      (for*/list ([i (in-range 5)])
+        (list (make-test-event "tool.call.started"
+                               (hasheq 'id (format "tc-~a" i)
+                                       'name "read"
+                                       'arguments (format "/tmp/f~a" i)))
+              (make-test-event "tool.call.completed"
+                               (hasheq 'name "read"
+                                       'result (format "data-~a" i))))))
+    (define state (simulate-events s0 (append base-events (apply append tool-events))))
+    (define input-st (initial-input-state))
+    (define layout (compute-layout 40 5))
+    ;; Should not raise even with small transcript area
+    (check-not-exn (lambda () (run-render-frame! ubuf state input-st layout)))
+    ;; Verify transcript has all entries
+    (check-equal? (transcript-length state) 11 ; 1 assistant + 5 tool-start + 5 tool-end
+                  "all entries preserved in transcript"))
+
+   ;; ============================================================
+   ;; Run tests
+   ;; ============================================================
 
 (module+ main
   (run-tests renderer-tests))

--- a/tests/tui/event-simulator.rkt
+++ b/tests/tui/event-simulator.rkt
@@ -1,0 +1,62 @@
+#lang racket/base
+
+;; tests/tui/event-simulator.rkt — Infrastructure for TUI state transition testing
+;;
+;; Provides helpers to simulate sequences of events on a ui-state and
+;; inspect intermediate states. Used by test-streaming-transitions.rkt
+;; and other TUI state transition test files.
+
+(require racket/match
+         "../../tui/state.rkt"
+         "../../util/protocol-types.rkt")
+
+(provide make-test-event
+         simulate-events
+         simulate-and-record
+         state-at
+         transcript-types
+         transcript-texts
+         transcript-length)
+
+;; make-test-event : string? hash? [#:time nat] [#:session-id string?] [#:turn-id string?] -> event?
+(define (make-test-event ev-type
+                         payload
+                         #:time [time 1000]
+                         #:session-id [session-id "test-session"]
+                         #:turn-id [turn-id "turn-1"])
+  (event 1 ev-type time session-id turn-id payload))
+
+;; simulate-events : ui-state? (listof event?) -> ui-state?
+;; Applies events sequentially, returning the final state.
+(define (simulate-events state events)
+  (for/fold ([st state])
+            ([evt (in-list events)])
+    (apply-event-to-state st evt)))
+
+;; simulate-and-record : ui-state? (listof event?) -> (listof ui-state?)
+;; Applies events sequentially, recording all intermediate states.
+;; Returns list: [initial, after-evt1, after-evt2, ...]
+(define (simulate-and-record state events)
+  (define states (list state))
+  (for ([evt (in-list events)])
+    (define next (apply-event-to-state (car states) evt))
+    (set! states (cons next states)))
+  (reverse states))
+
+;; state-at : (listof ui-state?) integer -> ui-state?
+;; Convenience accessor for intermediate states from simulate-and-record.
+;; Index 0 = initial state, 1 = after first event, etc.
+(define (state-at states idx)
+  (list-ref states idx))
+
+;; transcript-types : ui-state? -> (listof symbol?)
+(define (transcript-types state)
+  (map transcript-entry-kind (ui-state-transcript state)))
+
+;; transcript-texts : ui-state? -> (listof string?)
+(define (transcript-texts state)
+  (map transcript-entry-text (ui-state-transcript state)))
+
+;; transcript-length : ui-state? -> nat
+(define (transcript-length state)
+  (length (ui-state-transcript state)))


### PR DESCRIPTION
## Wave 2 — TUI State Transition Tests

Addresses #800, #801, #802, #803.

### New files
- `tests/tui/event-simulator.rkt`: Event simulation infrastructure
- `tests/test-streaming-transitions.rkt`: 8 critical state transition tests

### Modified files
- `tests/test-tui-renderer.rkt`: 3 render-level transition tests added

### Testing
- All 8 state transition tests pass
- All 51 renderer tests pass (48 existing + 3 new)
- All 56 TUI state tests pass (no regressions)
- All 50 loop tests pass (no regressions)
