### PR TITLE
test: edge cases + event ordering regression guard (#807)

### DIFF
--- a/tests/test-event-ordering.rkt
+++ b/tests/test-event-ordering.rkt
@@ -1,0 +1,178 @@
+#lang racket
+
+;; tests/test-event-ordering.rkt — Wave 4: Regression guard
+;;
+;; CI-level invariant: for any agent turn with streaming text,
+;; assistant.message.completed MUST appear before any tool.call.started
+;; in the event sequence. This test would FAIL without the B1 fix.
+
+(require rackunit
+         rackunit/text-ui
+         "../agent/loop.rkt"
+         "../agent/event-bus.rkt"
+         "../llm/provider.rkt"
+         "../llm/model.rkt"
+         "../agent/types.rkt"
+         "../util/protocol-types.rkt")
+
+(define event-ordering-tests
+  (test-suite
+   "Event Ordering Invariant Regression Guard"
+
+   ;; Invariant test: assistant.message.completed before tool.call.started
+   ;; This would fail if the B1 fix (Wave 1) were reverted.
+   (test-case
+    "regression: assistant.message.completed before tool.call.started (invariant)"
+    ;; Test with multiple turn scenarios
+    (define scenarios
+      (list
+       ;; Scenario 1: Text then tool call
+       (cons "text+tool"
+             (lambda ()
+               (list (stream-chunk "Answer" #f #f #f)
+                     (stream-chunk #f
+                                   (hasheq 'id "tc-1" 'index 0
+                                           'function (hasheq 'name "read"
+                                                             'arguments "{\"path\":\"x\"}"))
+                                   #f #f)
+                     (stream-chunk #f #f #f #t))))
+       ;; Scenario 2: Long text then multiple tool calls
+       (cons "long-text+2-tools"
+             (lambda ()
+               (list (stream-chunk "Let me " #f #f #f)
+                     (stream-chunk "check " #f #f #f)
+                     (stream-chunk "that." #f #f #f)
+                     (stream-chunk #f
+                                   (hasheq 'id "tc-1" 'index 0
+                                           'function (hasheq 'name "read"
+                                                             'arguments "{\"path\":\"a\"}"))
+                                   #f #f)
+                     (stream-chunk #f
+                                   (hasheq 'id "tc-2" 'index 1
+                                           'function (hasheq 'name "bash"
+                                                             'arguments "{\"command\":\"ls\"}"))
+                                   #f #f)
+                     (stream-chunk #f #f #f #t))))
+       ;; Scenario 3: No text, only tool call
+       (cons "tool-only"
+             (lambda ()
+               (list (stream-chunk #f
+                                   (hasheq 'id "tc-1" 'index 0
+                                           'function (hasheq 'name "bash"
+                                                             'arguments "{\"command\":\"ls\"}"))
+                                   #f #f)
+                     (stream-chunk #f #f #f #t))))))
+
+    (define tools
+      (list (hasheq 'type "function"
+                    'function (hasheq 'name "read" 'parameters (hasheq)))
+            (hasheq 'type "function"
+                    'function (hasheq 'name "bash" 'parameters (hasheq)))))
+
+    (for ([scenario scenarios])
+      (define name (car scenario))
+      (define make-chunks (cdr scenario))
+      (define bus (make-event-bus))
+      (define captured (box '()))
+
+      (subscribe! bus (lambda (evt)
+                        (set-box! captured
+                                  (append (unbox captured)
+                                          (list (event-ev evt))))))
+
+      (define prov
+        (make-provider
+         (lambda () "mock")
+         (lambda () (hasheq 'streaming #t))
+         (lambda (req) (error 'send "not used"))
+         (lambda (req) (make-chunks))))
+
+      (define ctx (list (make-message "m-1" #f 'user 'message
+                                      (list (make-text-part "go"))
+                                      1000 '#hash())))
+
+      (run-agent-turn ctx prov bus
+                      #:session-id "s1" #:turn-id "t1"
+                      #:tools tools)
+
+      (define events (unbox captured))
+      (define amc-idx (index-of events "assistant.message.completed"))
+      (define tcs-idx (index-of events "tool.call.started"))
+
+      (check-not-false amc-idx
+                       (format "~a: assistant.message.completed found" name))
+      (check-not-false tcs-idx
+                       (format "~a: tool.call.started found" name))
+      (check-true (< amc-idx tcs-idx)
+                  (format "~a: assistant.message.completed (~a) before tool.call.started (~a)"
+                          name amc-idx tcs-idx))))
+
+   ;; Additional invariant: turn.started is always first event
+   (test-case
+    "regression: turn.started is always the first event"
+    (define bus (make-event-bus))
+    (define captured (box '()))
+    (subscribe! bus (lambda (evt)
+                      (set-box! captured
+                                (append (unbox captured)
+                                        (list (event-ev evt))))))
+
+    (define prov
+      (make-provider
+       (lambda () "mock")
+       (lambda () (hasheq 'streaming #t))
+       (lambda (req) (error 'send "not used"))
+       (lambda (req)
+         (list (stream-chunk "Hi" #f #f #f)
+               (stream-chunk #f #f #f #t)))))
+
+    (define ctx (list (make-message "m-1" #f 'user 'message
+                                    (list (make-text-part "hello"))
+                                    1000 '#hash())))
+
+    (run-agent-turn ctx prov bus #:session-id "s1" #:turn-id "t1")
+
+    (define events (unbox captured))
+    (check-equal? (car events) "turn.started"
+                  "turn.started must be the first event in the sequence"))
+
+   ;; Invariant: turn.completed is always last event
+   (test-case
+    "regression: turn.completed is always the last event"
+    (define bus (make-event-bus))
+    (define captured (box '()))
+    (subscribe! bus (lambda (evt)
+                      (set-box! captured
+                                (append (unbox captured)
+                                        (list (event-ev evt))))))
+
+    (define prov
+      (make-provider
+       (lambda () "mock")
+       (lambda () (hasheq 'streaming #t))
+       (lambda (req) (error 'send "not used"))
+       (lambda (req)
+         (list (stream-chunk "Go" #f #f #f)
+               (stream-chunk #f
+                             (hasheq 'id "tc-1" 'index 0
+                                     'function (hasheq 'name "read"
+                                                       'arguments "{\"path\":\"x\"}"))
+                             #f #f)
+               (stream-chunk #f #f #f #t)))))
+
+    (define ctx (list (make-message "m-1" #f 'user 'message
+                                    (list (make-text-part "go"))
+                                    1000 '#hash())))
+
+    (run-agent-turn ctx prov bus
+                    #:session-id "s1" #:turn-id "t1"
+                    #:tools (list (hasheq 'type "function"
+                                          'function (hasheq 'name "read"
+                                                            'parameters (hasheq)))))
+
+    (define events (unbox captured))
+    (check-equal? (last events) "turn.completed"
+                  "turn.completed must be the last event in the sequence"))))
+
+(module+ main
+  (run-tests event-ordering-tests))

--- a/tests/test-streaming-transitions.rkt
+++ b/tests/test-streaming-transitions.rkt
@@ -199,7 +199,83 @@
                   "last entry is tool-fail, not tool-end")
     (define fail-text (last (transcript-texts final)))
     (check-not-false (regexp-match #rx"\\[FAIL:" fail-text)
-                     (format "fail entry has FAIL prefix, got: ~a" fail-text)))))
+                     (format "fail entry has FAIL prefix, got: ~a" fail-text)))
+
+   ;; ============================================================
+   ;; Wave 4 edge case tests
+   ;; ============================================================
+
+   ;; Edge 1: Empty streaming text — no content deltas at all
+   (test-case
+    "empty streaming: no deltas, only completion"
+    (define s0 (initial-ui-state))
+    (define events
+      (list (make-test-event "turn.started" (hasheq))
+            (make-test-event "assistant.message.completed"
+                             (hasheq 'messageId "m1" 'content ""))
+            (make-test-event "turn.completed"
+                             (hasheq 'termination 'completed 'turnId "turn-1"))))
+    (define states (simulate-and-record s0 events))
+    (define final (state-at states 3))
+    (check-false (ui-state-streaming-text final) "no streaming text")
+    (check-false (ui-state-busy? final) "not busy")
+    (check-equal? (transcript-length final) 1 "one transcript entry for empty message"))
+
+   ;; Edge 2: Concurrent tool calls — both started before either completes
+   (test-case
+    "concurrent tool calls: both started before either completes"
+    (define s0 (initial-ui-state))
+    (define events
+      (list (make-test-event "turn.started" (hasheq))
+            (make-test-event "assistant.message.completed"
+                             (hasheq 'messageId "m1" 'content "Working..."))
+            (make-test-event "tool.call.started"
+                             (hasheq 'id "tc-1" 'name "read" 'arguments "/tmp/a"))
+            (make-test-event "tool.call.started"
+                             (hasheq 'id "tc-2" 'name "read" 'arguments "/tmp/b"))
+            (make-test-event "tool.call.completed"
+                             (hasheq 'name "read" 'result "data-b"))
+            (make-test-event "tool.call.completed"
+                             (hasheq 'name "read" 'result "data-a"))))
+    (define states (simulate-and-record s0 events))
+    (define final (state-at states 6))
+    (check-equal? (transcript-length final) 5
+                  "5 entries: 1 assistant + 2 tool-starts + 2 tool-ends")
+    (check-false (ui-state-busy? final) "not busy"))
+
+   ;; Edge 3: Rapid events — delta+completed+tool-start in quick succession
+   (test-case
+    "rapid events: delta then completed then tool-start"
+    (define s0 (initial-ui-state))
+    (define events
+      (list (make-test-event "turn.started" (hasheq))
+            (make-test-event "model.stream.delta" (hasheq 'delta "X"))
+            (make-test-event "assistant.message.completed"
+                             (hasheq 'messageId "m1" 'content "X"))
+            (make-test-event "tool.call.started"
+                             (hasheq 'id "tc-1" 'name "bash" 'arguments "echo hi"))
+            (make-test-event "tool.call.completed"
+                             (hasheq 'name "bash" 'result "hi"))))
+    (define states (simulate-and-record s0 events))
+    (define final (state-at states 5))
+    (check-equal? (transcript-types final) '(assistant tool-start tool-end)
+                  "rapid succession produces correct transcript")
+    (check-false (ui-state-streaming-text final) "streaming cleared"))
+
+   ;; Edge 4: Cancelled turn clears all state
+   (test-case
+    "cancelled turn clears streaming text and busy state"
+    (define s0 (initial-ui-state))
+    (define events
+      (list (make-test-event "turn.started" (hasheq))
+            (make-test-event "model.stream.delta" (hasheq 'delta "Partial..."))
+            (make-test-event "tool.call.started"
+                             (hasheq 'id "tc-1" 'name "read" 'arguments "/tmp/x"))
+            (make-test-event "turn.cancelled" (hasheq))))
+    (define states (simulate-and-record s0 events))
+    (define final (state-at states 4))
+    (check-false (ui-state-streaming-text final) "streaming cleared on cancel")
+    (check-false (ui-state-busy? final) "not busy after cancel"))))
 
 (module+ main
   (run-tests streaming-transition-tests))


### PR DESCRIPTION
## Wave 4 — Edge Cases + Event Ordering Regression Guard

Addresses #807. Final wave of the TUI streaming bug plan.

### Modified
- `tests/test-streaming-transitions.rkt`: 4 edge case tests added

### New
- `tests/test-event-ordering.rkt`: 3 regression invariant tests

### Edge case tests
1. Empty streaming (no deltas, only completion)
2. Concurrent tool calls (both started before either completes)
3. Rapid events (delta+completed+tool-start in quick succession)
4. Cancelled turn clears all state

### Regression invariant tests
5. assistant.message.completed before tool.call.started (3 scenarios)
6. turn.started is always first event
7. turn.completed is always last event
