### PR TITLE
test: TUI out-of-order & duplicate event tests (#808)

### DIFF
--- a/tests/test-streaming-transitions.rkt
+++ b/tests/test-streaming-transitions.rkt
@@ -275,7 +275,122 @@
     (define states (simulate-and-record s0 events))
     (define final (state-at states 4))
     (check-false (ui-state-streaming-text final) "streaming cleared on cancel")
-    (check-false (ui-state-busy? final) "not busy after cancel"))))
+    (check-false (ui-state-busy? final) "not busy after cancel"))
+
+   ;; ============================================================
+   ;; Wave 5: Out-of-order & duplicate event tests
+   ;; ============================================================
+
+   ;; T1: tool.call.completed without prior tool.call.started
+   ;; Risk: Phantom [OK: ?] entry with no matching [TOOL] start
+   (test-case
+    "out-of-order: tool.call.completed without prior tool.call.started"
+    (define s0 (initial-ui-state))
+    (define events
+      (list (make-test-event "turn.started" (hasheq))
+            (make-test-event "assistant.message.completed"
+                             (hasheq 'messageId "m1" 'content "Done"))
+            (make-test-event "tool.call.completed"
+                             (hasheq 'name "bash" 'result "ok"))
+            (make-test-event "turn.completed"
+                             (hasheq 'termination 'completed 'turnId "t1"))))
+    (define states (simulate-and-record s0 events))
+    (define final (state-at states 4))
+    ;; The state machine should still create a tool-end entry
+    ;; even without a matching tool-start
+    (check-equal? (transcript-types final) '(assistant tool-end)
+                  "tool-end appears without matching tool-start")
+    (check-false (ui-state-busy? final) "not busy"))
+
+   ;; T2: Duplicate assistant.message.completed
+   ;; Risk: Duplicate transcript entries
+   (test-case
+    "duplicate: two assistant.message.completed events"
+    (define s0 (initial-ui-state))
+    (define events
+      (list (make-test-event "turn.started" (hasheq))
+            (make-test-event "model.stream.delta" (hasheq 'delta "Hello"))
+            (make-test-event "assistant.message.completed"
+                             (hasheq 'messageId "m1" 'content "Hello"))
+            ;; Duplicate!
+            (make-test-event "assistant.message.completed"
+                             (hasheq 'messageId "m1" 'content "Hello"))
+            (make-test-event "turn.completed"
+                             (hasheq 'termination 'completed 'turnId "t1"))))
+    (define states (simulate-and-record s0 events))
+    (define final (state-at states 5))
+    ;; Two assistant entries will appear — this documents current behavior
+    (check-equal? (length (filter (lambda (t) (eq? t 'assistant))
+                                   (transcript-types final)))
+                  2
+                  "duplicate assistant.message.completed creates 2 entries")
+    (check-false (ui-state-streaming-text final) "streaming cleared"))
+
+   ;; T3: Duplicate tool.call.started for same tool
+   ;; Risk: Orphaned [TOOL] with no [OK]
+   (test-case
+    "duplicate: two tool.call.started for same tool"
+    (define s0 (initial-ui-state))
+    (define events
+      (list (make-test-event "turn.started" (hasheq))
+            (make-test-event "assistant.message.completed"
+                             (hasheq 'messageId "m1" 'content "Working"))
+            (make-test-event "tool.call.started"
+                             (hasheq 'id "tc-1" 'name "read" 'arguments "/a"))
+            ;; Duplicate tool start!
+            (make-test-event "tool.call.started"
+                             (hasheq 'id "tc-1" 'name "read" 'arguments "/a"))
+            (make-test-event "tool.call.completed"
+                             (hasheq 'name "read" 'result "data"))))
+    (define states (simulate-and-record s0 events))
+    (define final (state-at states 5))
+    ;; Two tool-start entries, one tool-end
+    (check-equal? (transcript-types final) '(assistant tool-start tool-start tool-end)
+                  "duplicate tool-start creates 2 start entries, 1 end")
+    ;; State machine clears pending-tool-name on completion
+    (check-false (ui-state-pending-tool-name final) "pending cleared"))
+
+   ;; T4: model.stream.delta after assistant.message.completed
+   ;; Risk: Permanent busy state, orphan streaming text
+   (test-case
+    "out-of-order: model.stream.delta after assistant.message.completed"
+    (define s0 (initial-ui-state))
+    (define events
+      (list (make-test-event "turn.started" (hasheq))
+            (make-test-event "model.stream.delta" (hasheq 'delta "Hello"))
+            (make-test-event "assistant.message.completed"
+                             (hasheq 'messageId "m1" 'content "Hello"))
+            ;; Late delta!
+            (make-test-event "model.stream.delta" (hasheq 'delta " extra"))
+            (make-test-event "turn.completed"
+                             (hasheq 'termination 'completed 'turnId "t1"))))
+    (define states (simulate-and-record s0 events))
+    (define final (state-at states 5))
+    ;; The late delta should not leave streaming text hanging
+    ;; (state machine sets streaming-text on delta, but completed cleared it
+    ;; and the late delta sets it again — this documents current behavior)
+    (check-not-false (ui-state-streaming-text final)
+                     "late delta re-activates streaming text (documents current behavior)")
+    (check-false (ui-state-busy? final) "busy cleared by turn.completed"))
+
+   ;; T5: compaction.started without compaction.completed
+   ;; Risk: Stuck "Compacting..." status
+   (test-case
+    "out-of-order: compaction.started without compaction.completed"
+    (define s0 (initial-ui-state))
+    (define events
+      (list (make-test-event "turn.started" (hasheq))
+            (make-test-event "model.stream.delta" (hasheq 'delta "Hi"))
+            (make-test-event "assistant.message.completed"
+                             (hasheq 'messageId "m1" 'content "Hi"))
+            (make-test-event "compaction.started" (hasheq))
+            (make-test-event "turn.completed"
+                             (hasheq 'termination 'completed 'turnId "t1"))))
+    (define states (simulate-and-record s0 events))
+    (define final (state-at states 5))
+    ;; Status message should still say "Compacting..." since completed never fired
+    (check-equal? (ui-state-status-message final) "Compacting..."
+                  "status stuck on Compacting... (documents current behavior)"))))
 
 (module+ main
   (run-tests streaming-transition-tests))


### PR DESCRIPTION
## Wave 5 — TUI Out-of-Order & Duplicate Event Tests

Addresses #808.

### 5 new tests in test-streaming-transitions.rkt
- T1: tool.call.completed without prior tool.call.started
- T2: duplicate assistant.message.completed events
- T3: duplicate tool.call.started for same tool
- T4: model.stream.delta after assistant.message.completed
- T5: compaction.started without compaction.completed

All tests pass, documenting current state machine behavior for edge cases.
