### PR TITLE
test: TUI field interaction tests (#809)

### DIFF
--- a/tests/test-streaming-transitions.rkt
+++ b/tests/test-streaming-transitions.rkt
@@ -390,7 +390,97 @@
     (define final (state-at states 5))
     ;; Status message should still say "Compacting..." since completed never fired
     (check-equal? (ui-state-status-message final) "Compacting..."
-                  "status stuck on Compacting... (documents current behavior)"))))
+                  "status stuck on Compacting... (documents current behavior)"))
+
+   ;; ============================================================
+   ;; Wave 6: Field interaction tests (T6, T7, T9, T10)
+   ;; ============================================================
+
+   ;; T6: Nested turn.started × 2 then turn.completed × 1
+   ;; Risk: Premature idle display
+   (test-case
+    "nested turn.started ×2 then turn.completed ×1: still busy"
+    (define s0 (initial-ui-state))
+    (define events
+      (list (make-test-event "turn.started" (hasheq))
+            ;; Second turn.started before any turn.completed
+            (make-test-event "turn.started" (hasheq))
+            (make-test-event "model.stream.delta" (hasheq 'delta "Hello"))
+            ;; Only one turn.completed
+            (make-test-event "turn.completed"
+                             (hasheq 'termination 'completed 'turnId "t1"))))
+    (define states (simulate-and-record s0 events))
+    (define final (state-at states 4))
+    ;; After one turn.completed, busy is #f (documents current behavior)
+    (check-false (ui-state-busy? final)
+                 "busy cleared by single turn.completed (documents behavior)"))
+
+   ;; T7: compaction.started during active streaming
+   ;; Risk: Status overrides busy indicator
+   (test-case
+    "compaction.started during active streaming: status overrides"
+    (define s0 (initial-ui-state))
+    (define events
+      (list (make-test-event "turn.started" (hasheq))
+            (make-test-event "model.stream.delta" (hasheq 'delta "Streaming..."))
+            ;; Compaction starts mid-stream
+            (make-test-event "compaction.started" (hasheq))
+            (make-test-event "model.stream.delta" (hasheq 'delta " more"))
+            (make-test-event "compaction.completed" (hasheq))
+            (make-test-event "assistant.message.completed"
+                             (hasheq 'messageId "m1" 'content "Streaming... more"))
+            (make-test-event "turn.completed"
+                             (hasheq 'termination 'completed 'turnId "t1"))))
+    (define states (simulate-and-record s0 events))
+    (define final (state-at states 7))
+    (check-false (ui-state-status-message final) "status cleared after compaction.completed")
+    (check-false (ui-state-busy? final) "busy cleared after turn.completed")
+    (check-false (ui-state-streaming-text final) "streaming cleared after turn.completed"))
+
+   ;; T9: session.started during active session
+   ;; Risk: Session-id overwrite without separator
+   (test-case
+    "session.started during active session: session-id overwrite"
+    (define s0 (initial-ui-state #:session-id "old-session"))
+    (define events
+      (list (make-test-event "turn.started" (hasheq))
+            (make-test-event "model.stream.delta" (hasheq 'delta "Hello"))
+            ;; New session starts while old is active
+            (make-test-event "session.started"
+                             (hasheq 'sessionId "new-session"))
+            (make-test-event "assistant.message.completed"
+                             (hasheq 'messageId "m1" 'content "Hello"))
+            (make-test-event "turn.completed"
+                             (hasheq 'termination 'completed 'turnId "t1"))))
+    (define states (simulate-and-record s0 events))
+    (define final (state-at states 5))
+    ;; Session-id should be updated to new value
+    (check-equal? (ui-state-session-id final) "new-session"
+                  "session-id updated to new-session")
+    ;; A system entry for session start should appear
+    (check-true (member 'system (transcript-types final))
+                "system entry for new session present"))
+
+   ;; T10: queue.status-update event
+   ;; Risk: queue-counts field never tested
+   (test-case
+    "queue.status-update sets queue-counts field"
+    (define s0 (initial-ui-state))
+    (define events
+      (list (make-test-event "turn.started" (hasheq))
+            (make-test-event "model.stream.delta" (hasheq 'delta "Hi"))
+            (make-test-event "assistant.message.completed"
+                             (hasheq 'messageId "m1" 'content "Hi"))
+            (make-test-event "queue.status-update"
+                             (hasheq 'steering 2 'followup 1))
+            (make-test-event "turn.completed"
+                             (hasheq 'termination 'completed 'turnId "t1"))))
+    (define states (simulate-and-record s0 events))
+    (define final (state-at states 5))
+    (define qc (ui-state-queue-counts final))
+    (check-not-false qc "queue-counts is set")
+    (check-equal? (hash-ref qc 'steering) 2 "steering count = 2")
+    (check-equal? (hash-ref qc 'followup) 1 "followup count = 1"))))
 
 (module+ main
   (run-tests streaming-transition-tests))

--- a/tests/test-tui-overlay-state.rkt
+++ b/tests/test-tui-overlay-state.rkt
@@ -1,0 +1,67 @@
+#lang racket
+
+;; tests/test-tui-overlay-state.rkt — Wave 6: T11 overlay + event interaction
+;;
+;; Verifies that overlay state interacts correctly with incoming events.
+;; When an overlay is active and events arrive, the transcript should still
+;; mutate underneath and the overlay should persist.
+
+(require rackunit
+         rackunit/text-ui
+         "tui/event-simulator.rkt"
+         "../tui/state.rkt"
+         "../util/protocol-types.rkt")
+
+(define overlay-state-tests
+  (test-suite
+   "TUI Overlay + Event Interaction"
+
+   ;; T11: Events arriving while overlay is active
+   ;; Risk: Overlay persists, transcript mutates underneath
+   (test-case
+    "events during active overlay: transcript mutates underneath"
+    (define s0 (initial-ui-state))
+    ;; Start a turn to have some context
+    (define s1
+      (simulate-events s0
+        (list (make-test-event "turn.started" (hasheq))
+              (make-test-event "model.stream.delta" (hasheq 'delta "Hello"))
+              (make-test-event "assistant.message.completed"
+                               (hasheq 'messageId "m1" 'content "Hello"))
+              (make-test-event "turn.completed"
+                               (hasheq 'termination 'completed 'turnId "t1")))))
+    ;; Show overlay (e.g., command palette)
+    (define s2 (show-overlay s1 'command-palette
+                             '(("Option 1" normal) ("Option 2" normal))
+                             "se"))
+    (check-true (overlay-active? s2) "overlay is active")
+
+    ;; Now events arrive while overlay is up
+    (define s3
+      (simulate-events s2
+        (list (make-test-event "turn.started" (hasheq))
+              (make-test-event "model.stream.delta" (hasheq 'delta "Background"))
+              (make-test-event "assistant.message.completed"
+                               (hasheq 'messageId "m2" 'content "Background"))
+              (make-test-event "turn.completed"
+                               (hasheq 'termination 'completed 'turnId "t2")))))
+
+    ;; Overlay should still be active
+    (check-true (overlay-active? s3)
+                "overlay persists through background events")
+    ;; Transcript should have grown
+    (check-true (> (transcript-length s3) (transcript-length s2))
+                "transcript grew during overlay"))
+
+   ;; Overlay dismiss clears overlay
+   (test-case
+    "dismiss-overlay clears active overlay"
+    (define s0 (initial-ui-state))
+    (define s1 (show-overlay s0 'command-palette '(("A" normal)) ""))
+    (check-true (overlay-active? s1) "overlay active")
+    (define s2 (dismiss-overlay s1))
+    (check-false (overlay-active? s2) "overlay dismissed")
+    (check-false (ui-state-active-overlay s2) "active-overlay is #f"))))
+
+(module+ main
+  (run-tests overlay-state-tests))

--- a/tests/test-tui-selection-state.rkt
+++ b/tests/test-tui-selection-state.rkt
@@ -1,0 +1,67 @@
+#lang racket
+
+;; tests/test-tui-selection-state.rkt — Wave 6: T8 selection + transcript mutation
+;;
+;; Verifies that mouse selection state interacts correctly with transcript mutations
+;; caused by incoming events.
+
+(require rackunit
+         rackunit/text-ui
+         "tui/event-simulator.rkt"
+         "../tui/state.rkt"
+         "../util/protocol-types.rkt")
+
+(define selection-state-tests
+  (test-suite
+   "TUI Selection + Transcript Mutation"
+
+   ;; T8: Selection + transcript mutation via event
+   ;; When a new event adds to the transcript while selection is active,
+   ;; the selection coordinates become stale (wrong row offset).
+   (test-case
+    "selection becomes stale when transcript mutates"
+    (define s0 (initial-ui-state))
+    ;; Build up some transcript
+    (define s1
+      (simulate-events s0
+        (list (make-test-event "turn.started" (hasheq))
+              (make-test-event "model.stream.delta" (hasheq 'delta "Line 1"))
+              (make-test-event "assistant.message.completed"
+                               (hasheq 'messageId "m1" 'content "Line 1"))
+              (make-test-event "turn.completed"
+                               (hasheq 'termination 'completed 'turnId "t1")))))
+    ;; Now set a selection
+    (define s2 (set-selection-anchor s1 0 0))
+    (define s3 (set-selection-end s2 5 0))
+    (check-true (has-selection? s3) "selection is active")
+
+    ;; Now a new turn adds transcript entries — selection coords are now stale
+    (define s4
+      (simulate-events s3
+        (list (make-test-event "turn.started" (hasheq))
+              (make-test-event "model.stream.delta" (hasheq 'delta "Line 2"))
+              (make-test-event "assistant.message.completed"
+                               (hasheq 'messageId "m2" 'content "Line 2"))
+              (make-test-event "turn.completed"
+                               (hasheq 'termination 'completed 'turnId "t2")))))
+    ;; Selection is still technically active (coords unchanged)
+    (check-true (has-selection? s4)
+                "selection still active after transcript growth (documents behavior)")
+    ;; But the transcript is longer now
+    (check-equal? (transcript-length s4) 3
+                  "3 entries after 2 turns + session-start? or 2 entries from turns"))
+
+   ;; Selection cleared when scroll changes
+   (test-case
+    "clear-selection resets anchor and end"
+    (define s0 (initial-ui-state))
+    (define s1 (set-selection-anchor s0 0 0))
+    (define s2 (set-selection-end s1 10 5))
+    (check-true (has-selection? s2) "selection active before clear")
+    (define s3 (clear-selection s2))
+    (check-false (has-selection? s3) "selection cleared")
+    (check-false (ui-state-sel-anchor s3) "anchor is #f")
+    (check-false (ui-state-sel-end s3) "end is #f"))))
+
+(module+ main
+  (run-tests selection-state-tests))


### PR DESCRIPTION
## Wave 6 — TUI Field Interaction Tests

Addresses #809, #810, #811, #812.

### Modified: test-streaming-transitions.rkt (4 tests)
- T6: Nested turn.started ×2 then turn.completed ×1
- T7: compaction.started during active streaming
- T9: session.started during active session
- T10: queue.status-update event

### New: test-tui-selection-state.rkt (2 tests)
- T8: Selection + transcript mutation interaction

### New: test-tui-overlay-state.rkt (2 tests)
- T11: Overlay + event interaction
