### PR TITLE
test: multi-turn tool-use workflow tests (#882)

### DIFF
--- a/tests/test-tui-tool-cycle.rkt
+++ b/tests/test-tui-tool-cycle.rkt
@@ -1,0 +1,111 @@
+#lang racket
+
+;; tests/test-tui-tool-cycle.rkt — Single tool call cycle workflow tests
+;; (Wave 3, W3.1 #883).
+;;
+;; Tests that a single tool call start→complete/failed/blocked cycle
+;; correctly creates transcript entries and updates busy state.
+
+(require rackunit
+         rackunit/text-ui
+         "tui/workflow-harness.rkt"
+         "tui/mock-tui-session.rkt"
+         "../tui/state.rkt")
+
+(define tool-cycle-tests
+  (test-suite
+   "Single Tool Call Cycle Tests"
+
+   ;; TC1: Complete tool cycle (start→complete) creates two entries
+   (test-case "TC1: start→complete creates tool-start and tool-end entries"
+     (define ms (make-mock-session))
+     (define ms1
+       (mock-apply-events
+        ms
+        (list
+         (cons "turn.started" (hash))
+         (cons "tool.call.started"
+               (hash 'name "read" 'arguments "{\"path\":\"main.rkt\"}"))
+         (cons "tool.call.completed"
+               (hash 'name "read" 'result "(define x 1)"))
+         (cons "turn.completed" (hash)))))
+     (define texts (mock-entry-texts ms1))
+     ;; Should have 2 entries: tool-start + tool-end
+     (check-equal? (length texts) 2)
+     ;; Tool start includes arg summary
+     (check-not-false
+      (find-entry-by-text (mock-session-state ms1) "[TOOL: read]")
+      "should find tool-start entry")
+     ;; Tool end includes result
+     (check-not-false
+      (find-entry-by-text (mock-session-state ms1) "[OK: read]")
+      "should find tool-end entry")
+     ;; Not busy after turn completed
+     (check-false (mock-busy? ms1)))
+
+   ;; TC2: Failed tool cycle creates tool-start and tool-fail entries
+   (test-case "TC2: start→failed creates tool-start and tool-fail entries"
+     (define ms (make-mock-session))
+     (define ms1
+       (mock-apply-events
+        ms
+        (list
+         (cons "turn.started" (hash))
+         (cons "tool.call.started"
+               (hash 'name "bash" 'arguments "{\"command\":\"rm -rf /\"}"))
+         (cons "tool.call.failed"
+               (hash 'name "bash" 'error "permission denied"))
+         (cons "turn.completed" (hash)))))
+     (define texts (mock-entry-texts ms1))
+     (check-equal? (length texts) 2)
+     (check-not-false
+      (find-entry-by-text (mock-session-state ms1) "[TOOL: bash]")
+      "should find tool-start entry")
+     (check-not-false
+      (find-entry-by-text (mock-session-state ms1) "[FAIL: bash]")
+      "should find tool-fail entry"))
+
+   ;; TC3: Blocked tool creates system entry with reason
+   (test-case "TC3: blocked tool creates system entry"
+     (define ms (make-mock-session))
+     (define ms1
+       (mock-apply-events
+        ms
+        (list
+         (cons "turn.started" (hash))
+         (cons "tool.call.started"
+               (hash 'name "bash" 'arguments "{\"command\":\"ls\"}"))
+         (cons "tool.call.blocked"
+               (hash 'name "bash" 'reason "sandbox policy"))
+         (cons "turn.completed" (hash)))))
+     (define texts (mock-entry-texts ms1))
+     ;; tool-start + blocked system entry = 2 entries
+     (check-equal? (length texts) 2)
+     (check-not-false
+      (find-entry-by-text (mock-session-state ms1) "[tool blocked: bash")
+      "should find blocked tool entry"))
+
+   ;; TC4: Tool cycle renders correctly in terminal output
+   (test-case "TC4: tool cycle renders in terminal output"
+     (define state0 (initial-ui-state))
+     (define events
+       (event-sequence
+        "turn.started" (hash)
+        "tool.call.started" (hash 'name "read" 'arguments "{\"path\":\"test.rkt\"}")
+        "tool.call.completed" (hash 'name "read" 'result "ok")
+        "assistant.message.completed" (hash 'content "Done reading.")
+        "turn.completed" (hash)))
+     (define state1 (apply-events state0 events))
+     (define-values (lines _st) (render-state-strings state1 80 24))
+     ;; All 3 entries should appear in rendered output
+     (check-not-false
+      (for/or ([l (in-list lines)]) (string-contains? l "[TOOL: read]"))
+      "tool start should render")
+     (check-not-false
+      (for/or ([l (in-list lines)]) (string-contains? l "[OK: read]"))
+      "tool end should render")
+     (check-not-false
+      (for/or ([l (in-list lines)]) (string-contains? l "Done reading."))
+      "assistant message should render"))))
+
+(run-tests tool-cycle-tests)

--- a/tests/test-tui-tool-failure-streaming.rkt
+++ b/tests/test-tui-tool-failure-streaming.rkt
@@ -1,0 +1,94 @@
+#lang racket
+
+;; tests/test-tui-tool-failure-streaming.rkt — Tool failure, streaming
+;; interleaving, and edge case tests (Wave 3, W3.3 #885).
+;;
+;; Tests runtime errors during tool calls, streaming text interleaving
+;; with tool calls, and cancelled tool operations.
+
+(require rackunit
+         rackunit/text-ui
+         "tui/workflow-harness.rkt"
+         "tui/mock-tui-session.rkt"
+         "../tui/state.rkt")
+
+(define tool-failure-streaming-tests
+  (test-suite
+   "Tool Failure & Streaming Tests"
+
+   ;; TF1: runtime.error creates error entry and clears busy
+   (test-case "TF1: runtime.error creates error entry and clears busy"
+     (define ms (make-mock-session))
+     (define ms1
+       (mock-apply-events
+        ms
+        (list
+         (cons "turn.started" (hash))
+         (cons "tool.call.started"
+               (hash 'name "bash" 'arguments "{\"command\":\"bad-cmd\"}"))
+         (cons "runtime.error"
+               (hash 'error "connection lost"))
+         (cons "turn.completed" (hash)))))
+     (define texts (mock-entry-texts ms1))
+     ;; tool-start + error = 2 entries
+     (check-equal? (length texts) 2)
+     (check-not-false
+      (find-entry-by-text (mock-session-state ms1) "Error: connection lost")
+      "should find error entry")
+     (check-false (mock-busy? ms1)))
+
+   ;; TF2: Streaming text interleaved with tool call
+   (test-case "TF2: streaming text + tool call produces correct entries"
+     ;; Note: assistant.message.completed prefers streaming text over payload
+     ;; content. To test a clean assistant entry, we skip streaming before it.
+     (define state0 (initial-ui-state))
+     (define events
+       (event-sequence
+        "turn.started" (hash)
+        "tool.call.started" (hash 'name "read" 'arguments "{\"path\":\"x.rkt\"}")
+        "tool.call.completed" (hash 'name "read" 'result "contents")
+        ;; No streaming before this assistant event, so content comes from payload
+        "assistant.message.completed" (hash 'content "Here is the file.")
+        "turn.completed" (hash)))
+     (define state1 (apply-events state0 events))
+     ;; tool-start + tool-end + assistant = 3 entries
+     (check-equal? (entry-count state1) 3)
+     (check-false (ui-state-streaming-text state1))
+     (check-not-false (find-entry-by-text state1 "[TOOL: read]"))
+     (check-not-false (find-entry-by-text state1 "Here is the file.")))
+
+   ;; TF3: Cancelled turn with active tool call cleans up state
+   (test-case "TF3: cancelled turn cleans up busy and streaming"
+     (define state0 (initial-ui-state))
+     (define events
+       (event-sequence
+        "turn.started" (hash)
+        "model.stream.delta" (hash 'delta "Thinking...")
+        "tool.call.started" (hash 'name "bash" 'arguments "{\"command\":\"sleep 10\"}")
+        "turn.cancelled" (hash)))
+     (define state1 (apply-events state0 events))
+     ;; Cancel clears busy, streaming, pending-tool-name
+     (check-false (ui-state-busy? state1))
+     (check-false (ui-state-streaming-text state1))
+     (check-false (ui-state-pending-tool-name state1))
+     ;; Tool-start entry still exists (was already appended)
+     (check-equal? (entry-count state1) 1)
+     (check-not-false (find-entry-by-text state1 "[TOOL: bash]")))
+
+   ;; TF4: Multiple streaming deltas accumulate correctly
+   (test-case "TF4: multiple streaming deltas accumulate"
+     (define state0 (initial-ui-state))
+     (define events
+       (event-sequence
+        "turn.started" (hash)
+        "model.stream.delta" (hash 'delta "Hello")
+        "model.stream.delta" (hash 'delta " ")
+        "model.stream.delta" (hash 'delta "world")))
+     (define state1 (apply-events state0 events))
+     ;; Streaming text should accumulate: "Hello world"
+     (check-equal? (ui-state-streaming-text state1) "Hello world")
+     (check-true (ui-state-busy? state1))
+     ;; No transcript entries from streaming alone
+     (check-equal? (entry-count state1) 0))))
+
+(run-tests tool-failure-streaming-tests)

--- a/tests/test-tui-tool-sequences.rkt
+++ b/tests/test-tui-tool-sequences.rkt
@@ -1,0 +1,127 @@
+#lang racket
+
+;; tests/test-tui-tool-sequences.rkt — Sequential and concurrent tool call
+;; tests (Wave 3, W3.2 #884).
+;;
+;; Tests that multiple tool calls in sequence and overlapping patterns
+;; produce correct transcript entries and maintain state consistency.
+
+(require rackunit
+         rackunit/text-ui
+         "tui/workflow-harness.rkt"
+         "tui/mock-tui-session.rkt"
+         "../tui/state.rkt")
+
+(define tool-sequence-tests
+  (test-suite
+   "Sequential & Concurrent Tool Tests"
+
+   ;; SQ1: Sequential tool calls (read→edit→bash) all recorded
+   (test-case "SQ1: sequential tools read→edit→bash all recorded"
+     (define ms (make-mock-session))
+     (define ms1
+       (mock-apply-events
+        ms
+        (list
+         (cons "turn.started" (hash))
+         (cons "tool.call.started"
+               (hash 'name "read" 'arguments "{\"path\":\"a.rkt\"}"))
+         (cons "tool.call.completed"
+               (hash 'name "read" 'result "(define a 1)"))
+         (cons "tool.call.started"
+               (hash 'name "edit" 'arguments "{\"path\":\"a.rkt\",\"old\":\"1\",\"new\":\"2\"}"))
+         (cons "tool.call.completed"
+               (hash 'name "edit" 'result "ok"))
+         (cons "tool.call.started"
+               (hash 'name "bash" 'arguments "{\"command\":\"raco test\"}"))
+         (cons "tool.call.completed"
+               (hash 'name "bash" 'result "3 tests passed"))
+         (cons "assistant.message.completed"
+               (hash 'content "All done."))
+         (cons "turn.completed" (hash)))))
+     (define texts (mock-entry-texts ms1))
+     ;; 3 tool-starts + 3 tool-ends + 1 assistant = 7 entries
+     (check-equal? (length texts) 7)
+     ;; Verify each tool pair
+     (check-not-false
+      (find-entry-by-text (mock-session-state ms1) "[TOOL: read]")
+      "should find read tool-start")
+     (check-not-false
+      (find-entry-by-text (mock-session-state ms1) "[TOOL: edit]")
+      "should find edit tool-start")
+     (check-not-false
+      (find-entry-by-text (mock-session-state ms1) "[TOOL: bash]")
+      "should find bash tool-start")
+     ;; All renders correctly
+     (define rendered (mock-render ms1 80 24))
+     (check-true (>= (length rendered) 1))
+     (check-false (mock-busy? ms1)))
+
+   ;; SQ2: Multiple tool calls in single turn maintain ordering
+   (test-case "SQ2: tools in single turn maintain ordering"
+     (define state0 (initial-ui-state))
+     (define events
+       (event-sequence
+        "turn.started" (hash)
+        "tool.call.started" (hash 'name "tool-a" 'arguments "{\"x\":1}")
+        "tool.call.completed" (hash 'name "tool-a" 'result "a-result")
+        "tool.call.started" (hash 'name "tool-b" 'arguments "{\"y\":2}")
+        "tool.call.completed" (hash 'name "tool-b" 'result "b-result")
+        "turn.completed" (hash)))
+     (define state1 (apply-events state0 events))
+     (define texts (state->texts state1))
+     ;; Order: tool-a start, tool-a end, tool-b start, tool-b end
+     (check-equal? (length texts) 4)
+     (define a-start-idx
+       (for/first ([i (in-naturals)] [t (in-list texts)]
+                   #:when (string-contains? t "[TOOL: tool-a]")) i))
+     (define a-end-idx
+       (for/first ([i (in-naturals)] [t (in-list texts)]
+                   #:when (string-contains? t "[OK: tool-a]")) i))
+     (define b-start-idx
+       (for/first ([i (in-naturals)] [t (in-list texts)]
+                   #:when (string-contains? t "[TOOL: tool-b]")) i))
+     (check-true (< a-start-idx a-end-idx b-start-idx)
+                 "tool-a start < tool-a end < tool-b start"))
+
+   ;; SQ3: Two full turns with different tools each turn
+   (test-case "SQ3: two turns with different tools each turn"
+     (define ms (make-mock-session))
+     (define ms1
+       (mock-apply-events
+        ms
+        (list
+         ;; Turn 1: read file
+         (cons "turn.started" (hash))
+         (cons "tool.call.started"
+               (hash 'name "read" 'arguments "{\"path\":\"f.rkt\"}"))
+         (cons "tool.call.completed"
+               (hash 'name "read" 'result "content"))
+         (cons "assistant.message.completed"
+               (hash 'content "File read."))
+         (cons "turn.completed" (hash))
+         ;; Turn 2: edit file
+         (cons "turn.started" (hash))
+         (cons "tool.call.started"
+               (hash 'name "edit" 'arguments "{\"path\":\"f.rkt\"}"))
+         (cons "tool.call.completed"
+               (hash 'name "edit" 'result "ok"))
+         (cons "assistant.message.completed"
+               (hash 'content "File edited."))
+         (cons "turn.completed" (hash)))))
+     (define texts (mock-entry-texts ms1))
+     ;; Turn 1: tool-start + tool-end + assistant = 3
+     ;; Turn 2: tool-start + tool-end + assistant = 3
+     (check-equal? (length texts) 6)
+     ;; Both tools present
+     (check-not-false
+      (find-entry-by-text (mock-session-state ms1) "[TOOL: read]"))
+     (check-not-false
+      (find-entry-by-text (mock-session-state ms1) "[TOOL: edit]"))
+     ;; Both assistants present
+     (check-not-false
+      (find-entry-by-text (mock-session-state ms1) "File read."))
+     (check-not-false
+      (find-entry-by-text (mock-session-state ms1) "File edited.")))))
+
+(run-tests tool-sequence-tests)


### PR DESCRIPTION
Wave 3 of v0.9.9 — Multi-turn tool-use workflow tests.

- W3.1 (#883): 4 single tool call cycle tests (start→complete/failed/blocked)
- W3.2 (#884): 3 sequential and multi-turn tool ordering tests
- W3.3 (#885): 4 tool failure, streaming, and cancellation tests

All 11 tests pass.

Closes #882, Closes #883, Closes #884, Closes #885