### PR TITLE
fix: Wave 0 - Critical crash and data loss fixes (BUG-26,27,28)

### DIFF
--- a/runtime/session-switch.rkt
+++ b/runtime/session-switch.rkt
@@ -145,7 +145,7 @@
               'reason reason
               'previous-session-id prev-id
               'session-dir session-dir))
-    (publish! bus (make-event "session.start"
+    (publish! bus (make-event "session.started"
                               (current-seconds)
                               session-id
                               #f

--- a/tests/test-session-switch.rkt
+++ b/tests/test-session-switch.rkt
@@ -97,7 +97,7 @@
   (define evts (unbox captured))
   (check-equal? (length evts) 1)
   (define evt (car evts))
-  (check-equal? (event-ev evt) "session.start")
+  (check-equal? (event-ev evt) "session.started")
   (check-equal? (hash-ref (event-payload evt) 'session-id) "session-1")
   (check-equal? (hash-ref (event-payload evt) 'reason) 'new))
 
@@ -155,7 +155,7 @@
 
   ;; Should have session.start event only (no teardown for new)
   (define evts (unbox captured))
-  (define start-evts (filter (lambda (e) (string=? (event-ev e) "session.start")) evts))
+  (define start-evts (filter (lambda (e) (string=? (event-ev e) "session.started")) evts))
   (define shutdown-evts (filter (lambda (e) (string=? (event-ev e) "session.shutdown")) evts))
   (check-equal? (length start-evts) 1)
   (check-equal? (length shutdown-evts) 0))
@@ -182,7 +182,7 @@
 
   ;; Should have both shutdown and start events
   (define evts (unbox captured))
-  (define start-evts (filter (lambda (e) (string=? (event-ev e) "session.start")) evts))
+  (define start-evts (filter (lambda (e) (string=? (event-ev e) "session.started")) evts))
   (define shutdown-evts (filter (lambda (e) (string=? (event-ev e) "session.shutdown")) evts))
   (check-equal? (length shutdown-evts) 1)
   (check-equal? (length start-evts) 1)

--- a/tests/tui/render.rkt
+++ b/tests/tui/render.rkt
@@ -713,3 +713,42 @@
       (check-true (string-suffix? ansi "\x1b[0m")))))
 
 (run-tests cjk-wrapping-tests)
+
+;; ============================================================
+;; BUG-26: #f text in render pipeline must not crash
+;; ============================================================
+
+(define bug26-tests
+  (test-suite "BUG-26: #f text guard in render pipeline"
+
+    (test-case "render-transcript with #f text entry does not crash"
+      (define state0 (initial-ui-state))
+      (define entry-with-#f (transcript-entry 'assistant #f 1000 (hash) #f))
+      (define state1 (struct-copy ui-state state0 [transcript (list entry-with-#f)]))
+      ;; Must not crash — previously threw string=? contract violation
+      (define-values (lines _st) (render-transcript state1 24 80))
+      ;; Empty text → 0 rendered lines (no crash)
+      (check-equal? (length lines) 0 "#f text renders zero lines (no crash)"))
+
+    (test-case "format-entry with #f text for assistant returns empty list"
+      (define entry (transcript-entry 'assistant #f 1000 (hash) #f))
+      ;; Must not crash — returns 0 lines since empty text has no markdown tokens
+      (define lines (format-entry entry 80))
+      (check-equal? (length lines) 0))
+
+    (test-case "format-entry with empty string text for assistant works"
+      (define entry (make-entry 'assistant "" 1000 (hash)))
+      (define lines (format-entry entry 80))
+      (check-equal? (length lines) 0))
+
+    (test-case "format-entry with #f text for tool-start does not crash"
+      (define entry (transcript-entry 'tool-start #f 1000 (hash) #f))
+      (define lines (format-entry entry 80))
+      (check-equal? (length lines) 1))
+
+    (test-case "format-entry with #f text for system does not crash"
+      (define entry (transcript-entry 'system #f 1000 (hash) #f))
+      (define lines (format-entry entry 80))
+      (check-equal? (length lines) 1))))
+
+(run-tests bug26-tests)

--- a/tests/tui/state.rkt
+++ b/tests/tui/state.rkt
@@ -808,3 +808,42 @@
                    "render should show new content, not stale cached content")
   (check-false (string-contains? rendered-text "Old content")
                "render should NOT show stale old content"))
+
+;; ============================================================
+;; W0.2: BUG-27 — scrollback save on crash (tui-init.rkt)
+;; Tests for the state-level guarantee; tui-init is tested via integration
+;; ============================================================
+
+(test-case "W0.2: save-scrollback succeeds with valid entries"
+  (define tmpdir (make-temporary-file "scrollback-save-~a" 'directory))
+  (define path (build-path tmpdir "scrollback.jsonl"))
+  (define entries
+    (list (make-entry 'assistant "test" 1000 (hash))
+          (make-entry 'system "info" 1001 (hash))))
+  ;; save-scrollback should succeed
+  (save-scrollback entries path)
+  (check-true (file-exists? path))
+  (define loaded (load-scrollback path))
+  (check-equal? (length loaded) 2)
+  (delete-directory/files tmpdir))
+
+;; ============================================================
+;; W0.3: BUG-28 — session.start vs session.started naming
+;; ============================================================
+
+(test-case "W0.3: session.started event updates session-id"
+  (define s0 (initial-ui-state))
+  (define evt (make-test-event "session.started" (hash 'sessionId "new-sess-1")))
+  (define s1 (apply-event-to-state s0 evt))
+  (check-equal? (ui-state-session-id s1) "new-sess-1")
+  (check-equal? (length (ui-state-transcript s1)) 1)
+  (check-not-false
+   (string-contains? (transcript-entry-text (first (ui-state-transcript s1)))
+                      "new-sess-1")))
+
+(test-case "W0.3: session.started with reason in payload"
+  (define s0 (initial-ui-state))
+  (define evt (make-test-event "session.started"
+                               (hash 'sessionId "sess-2" 'reason 'resume)))
+  (define s1 (apply-event-to-state s0 evt))
+  (check-equal? (ui-state-session-id s1) "sess-2"))

--- a/tui/render.rkt
+++ b/tui/render.rkt
@@ -70,7 +70,8 @@
 (define (format-entry entry [width 200])
   ;; Returns (listof styled-line) — usually 1 line, but could be multi-line
   (define kind (transcript-entry-kind entry))
-  (define text (transcript-entry-text entry))
+  ;; BUG-26 fix: guard #f text — replace with empty string
+  (define text (or (transcript-entry-text entry) ""))
   (case kind
     ;; Parse markdown and render as styled-lines
     [(assistant) (md-format-assistant text width)]

--- a/tui/tui-init.rkt
+++ b/tui/tui-init.rkt
@@ -109,7 +109,15 @@
   (tui-ctx-init-terminal! ctx)
   (with-handlers ([exn:break? (lambda (e) (void))]
                   [exn:fail? (lambda (e)
-                               ;; Try cleanup before re-raising
+                               ;; BUG-27 fix: Save scrollback BEFORE re-raising
+                               ;; so that crash doesn't lose the transcript.
+                               (with-handlers ([exn:fail? (lambda (_) (void))])
+                                 (when scrollback-path
+                                   (let* ([state (unbox (tui-ctx-ui-state-box ctx))]
+                                          [transcript (ui-state-transcript state)])
+                                     (when (not (null? transcript))
+                                       (save-scrollback transcript scrollback-path)))))
+                               ;; Cleanup terminal
                                (with-handlers ([exn:fail? (lambda (_) (void))])
                                  (tui-term-close (unbox (tui-ctx-term-box ctx))))
                                (raise e))])


### PR DESCRIPTION
Fixes #894

- BUG-26: Guard #f text in render pipeline
- BUG-27: Save scrollback in crash handler
- BUG-28: Fix session.start naming mismatch

Closes #895. Closes #896. Closes #897.