### PR TITLE
fix: Wave 2 - Event naming and missing handler fixes (BUG-32,33,34)

### DIFF
--- a/tests/tui/state.rkt
+++ b/tests/tui/state.rkt
@@ -586,7 +586,41 @@
                    [streaming-text "leftover stream"]))
       (define evt (make-test-event "turn.completed" (hash)))
       (define s1 (apply-event-to-state s0 evt))
-      (check-false (ui-state-streaming-text s1) "turn.completed clears streaming-text"))))
+      (check-false (ui-state-streaming-text s1) "turn.completed clears streaming-text"))
+
+    ;; ============================================================
+    ;; W2: BUG-32,33,34 — Event naming and missing handler fixes
+    ;; ============================================================
+
+    (test-case "BUG-32: compaction.start sets status message"
+      (define s0 (initial-ui-state))
+      (define evt (make-test-event "compaction.start" (hash)))
+      (define s1 (apply-event-to-state s0 evt))
+      (check-equal? (ui-state-status-message s1) "Compacting..."))
+
+    (test-case "BUG-32: compaction.end clears status message"
+      (define s0 (struct-copy ui-state (initial-ui-state) [status-message "Compacting..."]))
+      (define evt (make-test-event "compaction.end" (hash)))
+      (define s1 (apply-event-to-state s0 evt))
+      (check-false (ui-state-status-message s1)))
+
+    (test-case "BUG-33: auto-retry.start adds system entry"
+      (define s0 (initial-ui-state))
+      (define evt (make-test-event "auto-retry.start" (hash 'attempt 2 'maxAttempts 3)))
+      (define s1 (apply-event-to-state s0 evt))
+      (define entries (ui-state-transcript s1))
+      (check > (length entries) 0 "auto-retry.start adds an entry")
+      (define last-entry (last entries))
+      (check-equal? (transcript-entry-kind last-entry) 'system)
+      (check-not-false (string-contains? (transcript-entry-text last-entry) "retry")))
+
+    (test-case "BUG-34: model.stream.completed clears streaming-text"
+      (define s0 (struct-copy ui-state (initial-ui-state)
+                   [busy? #t]
+                   [streaming-text "partial..."]))
+      (define evt (make-test-event "model.stream.completed" (hash)))
+      (define s1 (apply-event-to-state s0 evt))
+      (check-false (ui-state-streaming-text s1) "model.stream.completed clears streaming-text"))))
 
 (run-tests state-tests)
 

--- a/tui/state.rkt
+++ b/tui/state.rkt
@@ -363,8 +363,12 @@
       (make-entry 'system (format "[session forked: ~a]" new-sid) (event-time evt) (hash)))]
 
     [("compaction.started") (struct-copy ui-state state [status-message "Compacting..."])]
+    ;; BUG-32 fix: runtime emits compaction.start (not compaction.started)
+    [("compaction.start") (struct-copy ui-state state [status-message "Compacting..."])]
 
     [("compaction.completed") (struct-copy ui-state state [status-message #f])]
+    ;; BUG-32 fix: runtime emits compaction.end (not compaction.completed)
+    [("compaction.end") (struct-copy ui-state state [status-message #f])]
 
     ;; Model request initiated — mark busy if not already
     [("model.request.started") (struct-copy ui-state state [busy? #t])]
@@ -385,6 +389,20 @@
 
     [("queue.status-update")
      (struct-copy ui-state state [queue-counts payload])]
+
+    ;; BUG-33 fix: auto-retry event from runtime/iteration.rkt
+    [("auto-retry.start")
+     (define attempt (hash-ref payload 'attempt "?"))
+     (define max-attempts (hash-ref payload 'maxAttempts "?"))
+     (append-entry
+      state
+      (make-entry 'system
+                  (format "[retry: attempt ~a/~a]" attempt max-attempts)
+                  (event-time evt) (hash)))]
+
+    ;; BUG-34 fix: model.stream.completed clears streaming text
+    [("model.stream.completed")
+     (struct-copy ui-state state [streaming-text #f])]
 
     [else state])) ;; Ignore unknown events
 


### PR DESCRIPTION
Fixes #902

- BUG-32: Add compaction.start/end handlers matching runtime event names
- BUG-33: Add auto-retry.start handler showing retry status
- BUG-34: Add model.stream.completed handler to clear streaming text

4 new regression tests.

Closes #903. Closes #904. Closes #905.