### PR TITLE
fix: Wave 3 - Render performance optimization (BUG-35,36)

### DIFF
--- a/tests/tui/render.rkt
+++ b/tests/tui/render.rkt
@@ -752,3 +752,73 @@
       (check-equal? (length lines) 1))))
 
 (run-tests bug26-tests)
+
+;; ============================================================
+;; BUG-35: Render cache eviction
+;; ============================================================
+
+(define bug35-tests
+  (test-suite "BUG-35: Render cache eviction"
+
+    (test-case "cache evicts old entries beyond limit"
+      (define s0 (initial-ui-state))
+      ;; Add 150 entries to the cache
+      (define s1
+        (for/fold ([s s0])
+                  ([i (in-range 150)])
+          (rendered-cache-set s i (list (styled-line (list (styled-segment (format "entry ~a" i) (hash))))))))
+      ;; Cache should be bounded (not 150 entries)
+      (define cache-size (hash-count (ui-state-rendered-cache s1)))
+      (check-true (< cache-size 150) "cache should be bounded")
+      ;; Most recent entries should still be there
+      (check-not-false (rendered-cache-ref s1 149) "recent entry 149 present")
+      (check-not-false (rendered-cache-ref s1 100) "entry 100 present"))
+
+    (test-case "cache preserves entries below limit"
+      (define s0 (initial-ui-state))
+      (define s1
+        (for/fold ([s s0])
+                  ([i (in-range 50)])
+          (rendered-cache-set s i (list (styled-line (list (styled-segment (format "entry ~a" i) (hash))))))))
+      (define cache-size (hash-count (ui-state-rendered-cache s1)))
+      (check-equal? cache-size 50 "cache keeps 50 entries under limit"))))
+
+(run-tests bug35-tests)
+
+;; ============================================================
+;; BUG-36: O(n^2) render performance — use cons+reverse
+;; ============================================================
+
+(define bug36-tests
+  (test-suite "BUG-36: Render performance"
+
+    (test-case "render-transcript produces correct output with many entries"
+      (define state0 (initial-ui-state))
+      ;; Create state with 50 entries
+      (define entries
+        (for/list ([i (in-range 50)])
+          (make-entry 'assistant (format "Line ~a" i) (* i 1000) (hash))))
+      (define s1 (struct-copy ui-state state0 [transcript entries]))
+      (define-values (lines _st) (render-transcript s1 200 80))
+      ;; Should render all 50 entries
+      (check-true (> (length lines) 0) "renders output")
+      ;; Output should be in order (first entry first)
+      (define all-text (string-join (map styled-line->text lines) " "))
+      (check-not-false (string-contains? all-text "Line 0") "first entry present")
+      (check-not-false (string-contains? all-text "Line 49") "last entry present"))
+
+    (test-case "render-transcript with mixed cached and uncached entries"
+      ;; Pre-populate cache for some entries
+      (define state0 (initial-ui-state))
+      (define entries
+        (for/list ([i (in-range 10)])
+          (make-entry 'assistant (format "Entry ~a" i) (* i 1000) (hash))))
+      (define s1 (struct-copy ui-state state0 [transcript entries]))
+      ;; First render populates cache
+      (define-values (lines1 s1r) (render-transcript s1 200 80))
+      ;; Second render should use cache and produce same output
+      (define-values (lines2 s2r) (render-transcript s1r 200 80))
+      (check-equal? (length lines1) (length lines2) "cached render same length")
+      (check-equal? (map styled-line->text lines1) (map styled-line->text lines2) "cached render same content"))))
+
+(run-tests bug36-tests)

--- a/tui/render.rkt
+++ b/tui/render.rkt
@@ -434,31 +434,32 @@
         state
         (rendered-cache-set-width (rendered-cache-clear state) width)))
   ;; Format entries using cache where possible
+  ;; BUG-36 fix: cons lines in reverse order, then reverse at the end
   (define-values (formatted-lines state1)
-    (for/fold ([lines '()]
-               [st state0])
-              ([e (in-list entries)])
-      (define eid (transcript-entry-id e))
-      (define cached (and eid (rendered-cache-ref st eid)))
-      ;; Defense-in-depth: verify cached entry matches current entry text.
-      ;; If there's an ID collision (e.g. scrollback + runtime entries sharing IDs),
-      ;; the fingerprint won't match and we re-render instead of showing stale content.
-      (define cache-valid?
-        (and cached
-             (let ([entry-text (transcript-entry-text e)])
-               (and (string? entry-text)
-                    (> (string-length entry-text) 0)
-                    (> (length cached) 0)
-                    (let* ([first-line (styled-line->text (car cached))]
-                           [prefix-len (min 20 (string-length entry-text))]
-                           [prefix (substring entry-text 0 prefix-len)])
-                      (string-contains? first-line prefix))))))
-      (if cache-valid?
-          (values (append lines cached) st)
-          (let ([fmt (format-entry e width)])
-            (if eid
-                (values (append lines fmt) (rendered-cache-set st eid fmt))
-                (values (append lines fmt) st))))))
+    (let loop ([entries entries] [rev-lines '()] [st state0])
+      (if (null? entries)
+          (values (reverse rev-lines) st)
+          (let* ([e (car entries)]
+                 [eid (transcript-entry-id e)]
+                 [cached (and eid (rendered-cache-ref st eid))]
+                 [entry-text (transcript-entry-text e)]
+                 [cache-valid?
+                  (and cached
+                       (string? entry-text)
+                       (> (string-length entry-text) 0)
+                       (> (length cached) 0)
+                       (let* ([first-line (styled-line->text (car cached))]
+                              [prefix-len (min 20 (string-length entry-text))]
+                              [prefix (substring entry-text 0 prefix-len)])
+                         (string-contains? first-line prefix)))])
+            (if cache-valid?
+                (loop (cdr entries)
+                      (foldl (lambda (l acc) (cons l acc)) rev-lines cached)
+                      st)
+                (let ([fmt (format-entry e width)])
+                  (loop (cdr entries)
+                        (foldl (lambda (l acc) (cons l acc)) rev-lines fmt)
+                        (if eid (rendered-cache-set st eid fmt) st))))))))
   ;; If streaming, append the partial streaming text (not cached)
   (define streaming (ui-state-streaming-text state))
   (define all-lines

--- a/tui/state.rkt
+++ b/tui/state.rkt
@@ -6,6 +6,7 @@
 ;; The ui-state struct captures everything the TUI needs to render.
 
 (require racket/string
+         racket/list
          json
          "../util/protocol-types.rkt")
 
@@ -172,10 +173,22 @@
   (hash-ref (ui-state-rendered-cache state) entry-id #f))
 
 ;; Store cached rendered lines for an entry id, returning new state
+;; Maximum number of entries in the render cache
+(define RENDER-CACHE-MAX-SIZE 100)
+
 (define (rendered-cache-set state entry-id lines)
-  (struct-copy ui-state
-               state
-               [rendered-cache (hash-set (ui-state-rendered-cache state) entry-id lines)]))
+  (define old-cache (ui-state-rendered-cache state))
+  (define new-cache (hash-set old-cache entry-id lines))
+  ;; BUG-35 fix: evict oldest entries when cache exceeds limit
+  (define pruned-cache
+    (if (<= (hash-count new-cache) RENDER-CACHE-MAX-SIZE)
+        new-cache
+        ;; Remove oldest entries (lowest keys)
+        (let ([sorted-keys (sort (hash-keys new-cache) <)])
+          (for/fold ([c new-cache])
+                    ([k (in-list (take sorted-keys (- (hash-count new-cache) RENDER-CACHE-MAX-SIZE)))])
+            (hash-remove c k)))))
+  (struct-copy ui-state state [rendered-cache pruned-cache]))
 
 ;; Clear the entire render cache and reset width
 (define (rendered-cache-clear state)


### PR DESCRIPTION
Fixes #906

- BUG-35: Render cache now evicts entries beyond 100 limit
- BUG-36: Replace O(n^2) append with O(n) cons+reverse in render loop

4 new regression tests.

Closes #907. Closes #908.