### PR TITLE
fix: Wave 4 - UX polish (BUG-37,38)

### DIFF
--- a/tests/tui/render.rkt
+++ b/tests/tui/render.rkt
@@ -822,3 +822,22 @@
       (check-equal? (map styled-line->text lines1) (map styled-line->text lines2) "cached render same content"))))
 
 (run-tests bug36-tests)
+
+;; ============================================================
+;; BUG-37: Skip empty assistant entries in render
+;; ============================================================
+
+(define bug37-tests
+  (test-suite "BUG-37: Empty assistant entries"
+
+    (test-case "format-entry skips whitespace-only assistant text"
+      (define entry (make-entry 'assistant "   " 1000 (hash)))
+      (define lines (format-entry entry 80))
+      (check-equal? (length lines) 0 "whitespace-only entry renders 0 lines"))
+
+    (test-case "format-entry renders non-empty assistant text"
+      (define entry (make-entry 'assistant "Hello world" 1000 (hash)))
+      (define lines (format-entry entry 80))
+      (check-true (> (length lines) 0) "non-empty entry renders lines"))))
+
+(run-tests bug37-tests)

--- a/tests/tui/state.rkt
+++ b/tests/tui/state.rkt
@@ -620,7 +620,31 @@
                    [streaming-text "partial..."]))
       (define evt (make-test-event "model.stream.completed" (hash)))
       (define s1 (apply-event-to-state s0 evt))
-      (check-false (ui-state-streaming-text s1) "model.stream.completed clears streaming-text"))))
+      (check-false (ui-state-streaming-text s1) "model.stream.completed clears streaming-text"))
+
+    ;; ============================================================
+    ;; W4: BUG-37,38 — UX polish
+    ;; ============================================================
+
+    (test-case "BUG-38: tool.call.started guards against pending overwrite"
+      ;; If a tool is already pending, don't overwrite its name
+      (define s0 (struct-copy ui-state (initial-ui-state)
+                   [busy? #t]
+                   [pending-tool-name "read"]))
+      (define evt (make-test-event "tool.call.started"
+                   (hash 'name "bash" 'arguments "{\"cmd\":\"ls\"}")))
+      (define s1 (apply-event-to-state s0 evt))
+      ;; pending-tool-name should stay as the original "read"
+      (check-equal? (ui-state-pending-tool-name s1) "read" "pending-tool-name not overwritten")
+      ;; But the tool-start entry should still be added
+      (check-true (> (length (ui-state-transcript s1)) 0) "tool-start entry added"))
+
+    (test-case "BUG-38: tool.call.started sets name when no tool pending"
+      (define s0 (initial-ui-state))
+      (define evt (make-test-event "tool.call.started"
+                   (hash 'name "bash" 'arguments "{\"cmd\":\"ls\"}")))
+      (define s1 (apply-event-to-state s0 evt))
+      (check-equal? (ui-state-pending-tool-name s1) "bash" "pending-tool-name set"))))
 
 (run-tests state-tests)
 

--- a/tui/render.rkt
+++ b/tui/render.rkt
@@ -72,9 +72,12 @@
   (define kind (transcript-entry-kind entry))
   ;; BUG-26 fix: guard #f text — replace with empty string
   (define text (or (transcript-entry-text entry) ""))
+  ;; BUG-37 fix: skip whitespace-only assistant entries
   (case kind
-    ;; Parse markdown and render as styled-lines
-    [(assistant) (md-format-assistant text width)]
+    [(assistant)
+     (if (string=? (string-trim text) "")
+         '()  ;; empty/whitespace → no lines
+         (md-format-assistant text width))]
     [(tool-start) (list (styled-line (list (styled-segment text (theme->style 'tool-title)))))]
     [(tool-end) (list (styled-line (list (styled-segment text (theme->style 'success)))))]
     [(tool-fail) (list (styled-line (list (styled-segment text (theme->style 'error)))))]

--- a/tui/state.rkt
+++ b/tui/state.rkt
@@ -272,22 +272,19 @@
 
     [("tool.call.started")
      ;; Show tool started with arguments, mark busy
-     (define name (hash-ref payload 'name "?"))
-     (define args-raw (hash-ref payload 'arguments #f))
-     (define arg-summary
-       (if args-raw
-           (extract-arg-summary args-raw)
-           ""))
-     (define text
-       (if (string=? arg-summary "")
-           (format "[TOOL: ~a]" name)
-           (format "[TOOL: ~a] ~a" name arg-summary)))
-     (define ts (event-time evt))
-     (define meta (hasheq 'name name 'arguments (or args-raw "")))
-     (struct-copy ui-state
-                  (append-entry state (make-entry 'tool-start text ts meta))
-                  [busy? #t]
-                  [pending-tool-name name])]
+     (let* ([name (hash-ref payload 'name "?")]
+            [args-raw (hash-ref payload 'arguments #f)]
+            [arg-summary (if args-raw (extract-arg-summary args-raw) "")]
+            [text (if (string=? arg-summary "")
+                      (format "[TOOL: ~a]" name)
+                      (format "[TOOL: ~a] ~a" name arg-summary))]
+            [ts (event-time evt)]
+            [meta (hasheq 'name name 'arguments (or args-raw ""))]
+            [new-state (append-entry state (make-entry 'tool-start text ts meta))])
+       ;; BUG-38 fix: don't overwrite pending-tool-name if one is already set
+       (if (ui-state-pending-tool-name state)
+           (struct-copy ui-state new-state (busy? #t))
+           (struct-copy ui-state new-state (busy? #t) (pending-tool-name name))))]
 
     [("tool.call.completed")
      ;; Show tool completed with result summary


### PR DESCRIPTION
Fixes #909

- BUG-37: Skip whitespace-only assistant entries in render
- BUG-38: Guard tool.call.started against pending-tool-name overwrite

4 new regression tests.

Closes #910. Closes #911.