### PR TITLE
fix: Wave 0 — Production bug fixes (BUG-39, 40, 41)

### DIFF
--- a/runtime/agent-session.rkt
+++ b/runtime/agent-session.rkt
@@ -43,9 +43,7 @@
          "../runtime/session-store.rkt"
          "../runtime/session-index.rkt"
          "../runtime/compactor.rkt"
-         (only-in "../extensions/api.rkt"
-                  extension-name
-                  list-extensions)
+         (only-in "../extensions/api.rkt" extension-name list-extensions)
          (only-in "../runtime/context-builder.rkt"
                   (build-session-context context-builder:build-session-context))
          "../util/ids.rkt"
@@ -127,8 +125,7 @@
 (define (buffer-or-append! sess entry)
   (if (agent-session-persisted? sess)
       (append-entry! (session-log-path (agent-session-session-dir sess)) entry)
-      (set-agent-session-pending-entries!
-       sess (cons entry (agent-session-pending-entries sess)))))
+      (set-agent-session-pending-entries! sess (cons entry (agent-session-pending-entries sess)))))
 
 (define (session-index-path dir)
   (build-path dir "session.index"))
@@ -188,14 +185,15 @@
 
   ;; #668: Emit resources.discover event — extensions can discover skill/prompt/theme paths
   (let ([ext-reg (hash-ref config 'extension-registry #f)])
-    (emit-session-event!
-     (agent-session-event-bus sess)
-     sid
-     "resources.discover"
-     (hasheq 'session-id sid
-             'extensions (if ext-reg
-                             (map extension-name (list-extensions ext-reg))
-                             '()))))
+    (emit-session-event! (agent-session-event-bus sess)
+                         sid
+                         "resources.discover"
+                         (hasheq 'session-id
+                                 sid
+                                 'extensions
+                                 (if ext-reg
+                                     (map extension-name (list-extensions ext-reg))
+                                     '()))))
 
   sess)
 
@@ -261,9 +259,7 @@
 
   ;; Dispatch 'session-start hook with reason 'resume
   (define resume-start-payload (hasheq 'session-id session-id 'config config 'reason 'resume))
-  (maybe-dispatch-hooks (hash-ref config 'extension-registry #f)
-                        'session-start
-                        resume-start-payload)
+  (maybe-dispatch-hooks (hash-ref config 'extension-registry #f) 'session-start resume-start-payload)
 
   ;; Subscribe to fork/compact events from TUI/CLI
   (wire-session-event-handlers! sess)
@@ -277,14 +273,16 @@
 (define (fork-session sess [parent-entry-id #f])
   ;; Guard — refuse fork on closed session
   (unless (session-active? sess)
-    (raise (exn:fail (format "fork-session: session ~a is closed"
-                             (agent-session-session-id sess))
+    (raise (exn:fail (format "fork-session: session ~a is closed" (agent-session-session-id sess))
                      (current-continuation-marks))))
   ;; #669: Dispatch 'session-before-fork hook — extensions can block fork
   (let* ([ext-reg (agent-session-extension-registry sess)]
-         [fork-payload (hasheq 'session-id (agent-session-session-id sess)
-                               'parent-entry-id parent-entry-id
-                               'reason "user-fork")])
+         [fork-payload (hasheq 'session-id
+                               (agent-session-session-id sess)
+                               'parent-entry-id
+                               parent-entry-id
+                               'reason
+                               "user-fork")])
     (maybe-dispatch-hooks ext-reg 'session-before-fork fork-payload)
     ;; For now: proceed with fork (block support would short-circuit here)
     (fork-session-internal sess parent-entry-id)))
@@ -368,11 +366,10 @@
 
   ;; Dispatch 'session-start hook with reason 'fork
   (when (agent-session-extension-registry sess)
-    (maybe-dispatch-hooks (agent-session-extension-registry sess)
-                          'session-start
-                          (hasheq 'session-id new-id
-                                  'reason 'fork
-                                  'parent-session-id (agent-session-session-id sess))))
+    (maybe-dispatch-hooks
+     (agent-session-extension-registry sess)
+     'session-start
+     (hasheq 'session-id new-id 'reason 'fork 'parent-session-id (agent-session-session-id sess))))
 
   new-sess)
 
@@ -394,8 +391,7 @@
   ;; Ensure index exists (build if first time)
   (unless (agent-session-index sess)
     (when (file-exists? log-path)
-      (set-agent-session-index!
-       sess (build-index! log-path idx-path))))
+      (set-agent-session-index! sess (build-index! log-path idx-path))))
   (define idx (agent-session-index sess))
 
   ;; Convert string to message struct if needed
@@ -405,8 +401,7 @@
           ;; Determine parent from active leaf in index (#521: use stored IDs)
           (define parent-id
             (if idx
-                (let ([leaf (active-leaf idx)])
-                  (and leaf (message-id leaf)))
+                (let ([leaf (active-leaf idx)]) (and leaf (message-id leaf)))
                 ;; No index yet — determine from log
                 (let ([existing (if (file-exists? log-path)
                                     (load-session-log log-path)
@@ -435,7 +430,16 @@
     (if idx
         (context-builder:build-session-context idx)
         ;; Fallback: no index — use linear history (backward compat)
-        (load-session-log log-path)))
+        (let ([existing (if (file-exists? log-path)
+                            (load-session-log log-path)
+                            '())])
+          ;; BUG-39: Include buffered user message in context.
+          ;; On first prompt, the user message was buffered by buffer-or-append!
+          ;; but not yet persisted. Without this, context is empty → 0 tokens →
+          ;; should-compact? returns #f → compaction/hooks never fire on turn 1.
+          (if (null? existing)
+              (list user-msg)
+              (append existing (list user-msg))))))
 
   ;; Extract settings from path entries (#522)
   (define settings (extract-path-settings context-messages))
@@ -459,15 +463,12 @@
 ;;   model-change and thinking-level-change entries.
 ;;   Returns a hash with 'model and 'thinking-level keys.
 (define (extract-path-settings messages)
-  (for/fold ([settings (hasheq)])
-            ([msg (in-list messages)])
+  (for/fold ([settings (hasheq)]) ([msg (in-list messages)])
     (define kind (message-kind msg))
     (cond
-      [(and (eq? kind 'model-change)
-            (hash? (message-meta msg)))
+      [(and (eq? kind 'model-change) (hash? (message-meta msg)))
        (hash-set settings 'model (hash-ref (message-meta msg) 'model #f))]
-      [(and (eq? kind 'thinking-level-change)
-            (hash? (message-meta msg)))
+      [(and (eq? kind 'thinking-level-change) (hash? (message-meta msg)))
        (hash-set settings 'thinking-level (hash-ref (message-meta msg) 'level #f))]
       [else settings])))
 
@@ -494,24 +495,34 @@
      (cond
        [(and last-compact (< (- now-ms last-compact) 2000))
         context-with-system] ; too soon after last compaction
-       [(agent-session-compacting? sess)
-        context-with-system] ; recursive compaction guard
+       [(agent-session-compacting? sess) context-with-system] ; recursive compaction guard
        [else
         (set-agent-session-compacting?! sess #t)
-        (emit-session-event! bus sid "compaction.start"
+        (emit-session-event! bus
+                             sid
+                             "compaction.start"
                              (hasheq 'tokenCount token-count 'budgetThreshold token-budget-threshold))
         (dynamic-wind
          (lambda () (void))
          (lambda ()
-           (maybe-compact-context-internal sess context-with-system token-count token-budget-threshold bus sid))
+           (maybe-compact-context-internal sess
+                                           context-with-system
+                                           token-count
+                                           token-budget-threshold
+                                           bus
+                                           sid))
          (lambda ()
            (set-agent-session-compacting?! sess #f)
            (set-agent-session-last-compaction-time! sess (current-inexact-milliseconds))
-           (emit-session-event! bus sid "compaction.end"
-                                (hasheq 'tokenCount token-count))))])]))
+           (emit-session-event! bus sid "compaction.end" (hasheq 'tokenCount token-count))))])]))
 
 ;; Internal compaction logic (extracted from maybe-compact-context for dynamic-wind)
-(define (maybe-compact-context-internal sess context-with-system token-count token-budget-threshold bus sid)
+(define (maybe-compact-context-internal sess
+                                        context-with-system
+                                        token-count
+                                        token-budget-threshold
+                                        bus
+                                        sid)
   ;; Dispatch 'session-before-compact hook
   (define compact-payload
     (hasheq 'session-id
@@ -529,15 +540,20 @@
   (cond
     [(and compact-hook-res (eq? (hook-result-action compact-hook-res) 'block)) context-with-system]
     [else
-     (emit-session-event! bus sid "compaction.warning"
+     (emit-session-event! bus
+                          sid
+                          "compaction.warning"
                           (hasheq 'tokenCount token-count 'budgetThreshold token-budget-threshold))
      (define compact-result (compact-history context-with-system))
-     (emit-session-event! bus sid "compaction.completed"
+     (emit-session-event! bus
+                          sid
+                          "compaction.completed"
                           (hasheq 'removedCount
                                   (compaction-result-removed-count compact-result)
                                   'keptCount
                                   (length (compaction-result-kept-messages compact-result))
-                                  'tokenCount token-count))
+                                  'tokenCount
+                                  token-count))
      (compaction-result->message-list compact-result)]))
 
 ;; dispatch-iteration — model-select hook + iteration loop dispatch.
@@ -594,8 +610,7 @@
 (define (run-prompt! sess user-message #:max-iterations [max-iter-override #f])
   ;; B4: Guard — refuse operations on closed sessions
   (unless (session-active? sess)
-    (raise (exn:fail (format "run-prompt!: session ~a is closed"
-                             (agent-session-session-id sess))
+    (raise (exn:fail (format "run-prompt!: session ~a is closed" (agent-session-session-id sess))
                      (current-continuation-marks))))
   (define bus (agent-session-event-bus sess))
   (define sid (agent-session-session-id sess))
@@ -607,8 +622,7 @@
   ;; #666: Dispatch 'input hook — intercept/transform user input before processing
   (define ext-reg (agent-session-extension-registry sess))
   (define-values (_processed-input input-hook-res)
-    (maybe-dispatch-hooks ext-reg 'input
-                          (hasheq 'session-id sid 'message user-message)))
+    (maybe-dispatch-hooks ext-reg 'input (hasheq 'session-id sid 'message user-message)))
   (cond
     [(and input-hook-res (eq? (hook-result-action input-hook-res) 'block))
      ;; Input blocked by extension
@@ -669,8 +683,7 @@
   (define log-path (session-log-path (agent-session-session-dir sess)))
   (if (file-exists? log-path)
       ;; #773: Filter out session-info (version header) entries
-      (filter (lambda (m) (not (eq? (message-kind m) 'session-info)))
-              (load-session-log log-path))
+      (filter (lambda (m) (not (eq? (message-kind m) 'session-info))) (load-session-log log-path))
       '()))
 
 (define (session-active? sess)
@@ -679,6 +692,10 @@
 (define (close-session! sess)
   ;; B5: Idempotency guard — only close once
   (when (session-active? sess)
+    ;; BUG-40: Flush buffered entries before deactivating.
+    ;; Without this, entries buffered via buffer-or-append! are lost
+    ;; and resume-agent-session fails with "directory not found".
+    (ensure-persisted! sess)
     (emit-session-event! (agent-session-event-bus sess)
                          (agent-session-session-id sess)
                          "session.closed"
@@ -688,7 +705,9 @@
     (define shutdown-payload
       (hasheq 'session-id (agent-session-session-id sess) 'duration session-duration))
     (define-values (_shutdown-payload _shutdown-res)
-      (maybe-dispatch-hooks (agent-session-extension-registry sess) 'session-shutdown shutdown-payload))
+      (maybe-dispatch-hooks (agent-session-extension-registry sess)
+                            'session-shutdown
+                            shutdown-payload))
     (set-agent-session-active?! sess #f)))
 
 ;; ============================================================
@@ -733,8 +752,7 @@
          (define log-path (session-log-path (agent-session-session-dir sess)))
          (when (file-exists? log-path)
            (define history (load-session-log log-path))
-           (when (and (not (null? history))
-                      (not (agent-session-compacting? sess)))
+           (when (and (not (null? history)) (not (agent-session-compacting? sess)))
              (set-agent-session-compacting?! sess #t)
              (define compact-result (compact-history history))
              (set-agent-session-compacting?! sess #f)

--- a/runtime/compactor.rkt
+++ b/runtime/compactor.rkt
@@ -257,8 +257,7 @@
 ;; Check if a message contains tool-call parts.
 (define (has-tool-calls? msg)
   (define content (message-content msg))
-  (and (list? content)
-       (ormap tool-call-part? content)))
+  (and (list? content) (ormap tool-call-part? content)))
 
 ;; Check if a message is a tool-result.
 (define (tool-result-message? msg)
@@ -307,7 +306,6 @@
 ;;         iterative compaction.
 ;; v0.9.1 (#636): Hook blocking now actually prevents compaction.
 (define (compact-history messages
-                         #:strategy [strategy (default-strategy)]
                          #:summarize-fn [summarize-fn default-summarize]
                          #:provider [provider #f]
                          #:model-name [model-name #f]
@@ -319,8 +317,7 @@
   ;; #769: Hook can provide custom summary via amend action.
   (define hook-res
     (and hook-dispatcher
-         (hook-dispatcher 'session-before-compact
-                          (hasheq 'message-count (length messages) 'strategy strategy))))
+         (hook-dispatcher 'session-before-compact (hasheq 'message-count (length messages)))))
   (cond
     [(and (hook-result? hook-res) (eq? (hook-result-action hook-res) 'block))
      ;; Hook blocked compaction — return identity result immediately
@@ -363,7 +360,8 @@
                   (llm-summarize adjusted-old
                                  provider
                                  model-name
-                                 #:previous-summary (or prev-summary (find-previous-summary adjusted-recent))
+                                 #:previous-summary
+                                 (or prev-summary (find-previous-summary adjusted-recent))
                                  #:file-tracker cumulative-ft)
                   (summarize-fn adjusted-old))))
         ;; Append turn prefix to summary if split-turn detected
@@ -383,14 +381,17 @@
               (message-id (car adjusted-recent))
               #f))
         (define summary-msg
-          (make-message
-           (format "compaction-~a" (current-inexact-milliseconds))
-           #f ; no parent — compaction summaries are root-level context
-           'system
-           'compaction-summary
-           (list (make-text-part summary-text))
-           (current-seconds)
-           (hash-set (hash-set (hash-set file-tracker-meta 'type "compaction") 'removedCount (length adjusted-old)) 'firstKeptEntryId first-kept-id)))
+          (make-message (format "compaction-~a" (current-inexact-milliseconds))
+                        #f ; no parent — compaction summaries are root-level context
+                        'system
+                        'compaction-summary
+                        (list (make-text-part summary-text))
+                        (current-seconds)
+                        (hash-set (hash-set (hash-set file-tracker-meta 'type "compaction")
+                                            'removedCount
+                                            (length adjusted-old))
+                                  'firstKeptEntryId
+                                  first-kept-id)))
         (compaction-result summary-msg (length adjusted-old) adjusted-recent)])]))
 
 ;; ============================================================
@@ -415,7 +416,6 @@
 ;; the filesystem. Equivalent to `compact-history` but named to make
 ;; the advisory contract crystal clear.
 (define (compact-history-advisory messages
-                                  #:strategy [strategy (default-strategy)]
                                   #:summarize-fn [summarize-fn default-summarize]
                                   #:provider [provider #f]
                                   #:model-name [model-name #f]
@@ -423,7 +423,6 @@
                                   #:hook-dispatcher [hook-dispatcher #f]
                                   #:token-config [token-config (default-token-compaction-config)])
   (compact-history messages
-                   #:strategy strategy
                    #:summarize-fn summarize-fn
                    #:provider provider
                    #:model-name model-name
@@ -444,7 +443,6 @@
 ;; instead of replaying the full history.
 (define (compact-and-persist! messages
                               session-log-path
-                              #:strategy [strategy (default-strategy)]
                               #:summarize-fn [summarize-fn default-summarize]
                               #:provider [provider #f]
                               #:model-name [model-name #f]
@@ -453,7 +451,6 @@
                               #:token-config [token-config (default-token-compaction-config)])
   (define result
     (compact-history messages
-                     #:strategy strategy
                      #:summarize-fn summarize-fn
                      #:provider provider
                      #:model-name model-name

--- a/runtime/ctx-compact.rkt
+++ b/runtime/ctx-compact.rkt
@@ -19,28 +19,27 @@
          "../runtime/compaction-hooks.rkt"
          "../util/protocol-types.rkt")
 
-(provide
- ;; Compact request struct
- (struct-out ctx-compact-request)
- ctx-compact?
+;; Compact request struct
+(provide (struct-out ctx-compact-request)
+         ctx-compact?
 
- ;; Main API
- ctx-compact
- ctx-compact-async
+         ;; Main API
+         ctx-compact
+         ctx-compact-async
 
- ;; Rate limiting
- rate-limit-allowed?
- reset-rate-limit!
- current-compact-rate-limit
- current-compact-rate-window
+         ;; Rate limiting
+         rate-limit-allowed?
+         reset-rate-limit!
+         current-compact-rate-limit
+         current-compact-rate-window
 
- ;; Callbacks
- compact-callback-result
- compact-callback-result?
- compact-callback-result-success?
- compact-callback-result-summary
- compact-callback-result-error
- compact-callback-result-removed-count)
+         ;; Callbacks
+         compact-callback-result
+         compact-callback-result?
+         compact-callback-result-success?
+         compact-callback-result-summary
+         compact-callback-result-error
+         compact-callback-result-removed-count)
 
 ;; ============================================================
 ;; Parameters
@@ -58,11 +57,11 @@
 
 ;; A compaction request from an extension
 (struct ctx-compact-request
-  (instructions       ; string or #f — custom summarization instructions
-   on-complete        ; (or/c procedure? #f) — called with compact-callback-result on success
-   on-error           ; (or/c procedure? #f) — called with compact-callback-result on failure
-   requested-at       ; exact-positive-integer — timestamp
-   )
+        (instructions ; string or #f — custom summarization instructions
+         on-complete ; (or/c procedure? #f) — called with compact-callback-result on success
+         on-error ; (or/c procedure? #f) — called with compact-callback-result on failure
+         requested-at ; exact-positive-integer — timestamp
+         )
   #:transparent)
 
 ;; Shorter alias
@@ -70,11 +69,11 @@
 
 ;; Result passed to callbacks
 (struct compact-callback-result
-  (success?        ; boolean
-   summary         ; string or #f
-   error           ; string or #f
-   removed-count   ; integer
-   )
+        (success? ; boolean
+         summary ; string or #f
+         error ; string or #f
+         removed-count ; integer
+         )
   #:transparent)
 
 ;; ============================================================
@@ -88,18 +87,14 @@
   (define now (current-seconds))
   (define window (current-compact-rate-window))
   (define limit (current-compact-rate-limit))
-  (define recent
-    (filter (lambda (ts) (> (+ ts window) now))
-            (unbox rate-limit-timestamps)))
+  (define recent (filter (lambda (ts) (> (+ ts window) now)) (unbox rate-limit-timestamps)))
   (< (length recent) limit))
 
 ;; Record a compaction request for rate limiting.
 (define (record-rate-limit!)
   (define now (current-seconds))
   (define window (current-compact-rate-window))
-  (define recent
-    (filter (lambda (ts) (> (+ ts window) now))
-            (unbox rate-limit-timestamps)))
+  (define recent (filter (lambda (ts) (> (+ ts window) now)) (unbox rate-limit-timestamps)))
   (set-box! rate-limit-timestamps (cons now recent)))
 
 ;; Reset the rate limit counter (for testing or admin override).
@@ -113,59 +108,78 @@
 ;; Trigger compaction synchronously with custom instructions.
 ;; Returns compact-callback-result.
 (define (ctx-compact messages
-                      strategy
-                      #:instructions [instructions #f]
-                      #:bus [bus #f]
-                      #:session-id [session-id #f]
-                      #:on-complete [on-complete #f]
-                      #:on-error [on-error #f]
-                      #:provider [provider #f]
-                      #:hook-dispatcher [hook-dispatcher #f])
+                     strategy
+                     #:instructions [instructions #f]
+                     #:bus [bus #f]
+                     #:session-id [session-id #f]
+                     #:on-complete [on-complete #f]
+                     #:on-error [on-error #f]
+                     #:provider [provider #f]
+                     #:hook-dispatcher [hook-dispatcher #f])
   ;; Check rate limit
   (if (not (rate-limit-allowed?))
-      (let ([result (compact-callback-result #f #f
-                       (format "rate limited: max ~a compactions per ~a seconds"
-                               (current-compact-rate-limit)
-                               (current-compact-rate-window))
-                       0)])
-        (when on-error (on-error result))
+      (let ([result (compact-callback-result #f
+                                             #f
+                                             (format "rate limited: max ~a compactions per ~a seconds"
+                                                     (current-compact-rate-limit)
+                                                     (current-compact-rate-window))
+                                             0)])
+        (when on-error
+          (on-error result))
         result)
       (begin
         (record-rate-limit!)
-        (perform-compact messages strategy instructions bus session-id
-                         on-complete on-error provider hook-dispatcher))))
+        (perform-compact messages
+                         strategy
+                         instructions
+                         bus
+                         session-id
+                         on-complete
+                         on-error
+                         provider
+                         hook-dispatcher))))
 
-  ;; Internal compaction logic (after rate limit check)
-(define (perform-compact messages strategy instructions bus session-id
-                          on-complete on-error provider hook-dispatcher)
+;; Internal compaction logic (after rate limit check)
+(define (perform-compact messages
+                         strategy
+                         instructions
+                         bus
+                         session-id
+                         on-complete
+                         on-error
+                         provider
+                         hook-dispatcher)
   ;; Publish compaction start event
   (when bus
-    (publish-compaction-start! bus 'extension
-                                (length messages)
-                                0  ;; tokens-before (estimated)
-                                session-id
-                                "extension-triggered"))
+    (publish-compaction-start! bus
+                               'extension
+                               (length messages)
+                               0 ;; tokens-before (estimated)
+                               session-id
+                               "extension-triggered"))
 
   ;; Attempt compaction
-  (with-handlers ([exn:fail?
-                   (lambda (e)
-                     (define result (compact-callback-result #f #f
-                                      (exn-message e) 0))
-                     (when bus
-                       (publish-compaction-end! bus 'extension 0 0 0
-                                                 session-id "extension-triggered"
-                                                 #:summary-generated? #f))
-                     (when on-error (on-error result))
-                     result)])
+  (with-handlers ([exn:fail? (lambda (e)
+                               (define result (compact-callback-result #f #f (exn-message e) 0))
+                               (when bus
+                                 (publish-compaction-end! bus
+                                                          'extension
+                                                          0
+                                                          0
+                                                          0
+                                                          session-id
+                                                          "extension-triggered"
+                                                          #:summary-generated? #f))
+                               (when on-error
+                                 (on-error result))
+                               result)])
     ;; Build enriched payload for the hook
     (define enriched-payload
-      (build-enriched-compact-payload messages strategy
-                                       #:session-id session-id))
+      (build-enriched-compact-payload messages strategy #:session-id session-id))
 
     ;; Dispatch enriched before-compact hook
     (define-values (hook-res enriched)
-      (dispatch-enriched-before-compact hook-dispatcher messages strategy
-                                         #:session-id session-id))
+      (dispatch-enriched-before-compact hook-dispatcher messages strategy #:session-id session-id))
 
     ;; Check if hook provides custom summary
     (define custom-summary (maybe-use-custom-summary hook-res))
@@ -175,59 +189,61 @@
       (if custom-summary
           ;; Use extension-provided summary directly
           (compaction-result
-           (make-message (format "summary-~a" (current-milliseconds))
-                         #f 'system 'text
-                         (list (make-text-part custom-summary))
-                         (current-seconds)
-                         (hasheq 'type 'compaction-summary
-                                 'source 'extension
-                                 'instructions instructions))
+           (make-message
+            (format "summary-~a" (current-milliseconds))
+            #f
+            'system
+            'text
+            (list (make-text-part custom-summary))
+            (current-seconds)
+            (hasheq 'type 'compaction-summary 'source 'extension 'instructions instructions))
            (max 0 (- (length messages) (compaction-strategy-keep-recent-count strategy)))
            (take (reverse messages)
-                 (min (compaction-strategy-keep-recent-count strategy)
-                      (length messages))))
+                 (min (compaction-strategy-keep-recent-count strategy) (length messages))))
           ;; Use standard compaction
-          (compact-history messages #:strategy strategy)))
+          (compact-history messages)))
 
     ;; Publish compaction end event
     (when bus
-      (publish-compaction-end! bus 'extension
-                                (compaction-result-removed-count result)
-                                0  ;; tokens-before
-                                0  ;; tokens-after
-                                session-id "extension-triggered"
-                                #:summary-generated? #t))
+      (publish-compaction-end! bus
+                               'extension
+                               (compaction-result-removed-count result)
+                               0 ;; tokens-before
+                               0 ;; tokens-after
+                               session-id
+                               "extension-triggered"
+                               #:summary-generated? #t))
 
     ;; Build callback result
     (define cb-result
-      (compact-callback-result #t
-                                (or custom-summary
-                                    (format "compacted ~a messages"
-                                            (compaction-result-removed-count result)))
-                                #f
-                                (compaction-result-removed-count result)))
+      (compact-callback-result
+       #t
+       (or custom-summary (format "compacted ~a messages" (compaction-result-removed-count result)))
+       #f
+       (compaction-result-removed-count result)))
 
-    (when on-complete (on-complete cb-result))
+    (when on-complete
+      (on-complete cb-result))
     cb-result))
 
 ;; Trigger compaction asynchronously (returns immediately).
 ;; Callbacks are invoked on completion/error.
 (define (ctx-compact-async messages
-                            strategy
-                            #:instructions [instructions #f]
-                            #:bus [bus #f]
-                            #:session-id [session-id #f]
-                            #:on-complete [on-complete #f]
-                            #:on-error [on-error #f]
-                            #:provider [provider #f]
-                            #:hook-dispatcher [hook-dispatcher #f])
-  (thread
-   (lambda ()
-     (ctx-compact messages strategy
-                   #:instructions instructions
-                   #:bus bus
-                   #:session-id session-id
-                   #:on-complete on-complete
-                   #:on-error on-error
-                   #:provider provider
-                   #:hook-dispatcher hook-dispatcher))))
+                           strategy
+                           #:instructions [instructions #f]
+                           #:bus [bus #f]
+                           #:session-id [session-id #f]
+                           #:on-complete [on-complete #f]
+                           #:on-error [on-error #f]
+                           #:provider [provider #f]
+                           #:hook-dispatcher [hook-dispatcher #f])
+  (thread (lambda ()
+            (ctx-compact messages
+                         strategy
+                         #:instructions instructions
+                         #:bus bus
+                         #:session-id session-id
+                         #:on-complete on-complete
+                         #:on-error on-error
+                         #:provider provider
+                         #:hook-dispatcher hook-dispatcher))))

--- a/tests/test-agent-session.rkt
+++ b/tests/test-agent-session.rkt
@@ -20,38 +20,69 @@
          racket/file
          racket/string
          (only-in "../util/protocol-types.rkt"
-                  message message? message-id message-role message-content message-parent-id
-                  message-kind make-message make-text-part make-tool-result-part
-                  text-part? text-part-text
-                  tool-call-part? tool-call-part-id tool-call-part-name
-                  tool-result-part? tool-result-part-content tool-result-part-is-error?
-                  make-loop-result loop-result? loop-result-termination-reason
-                  loop-result-messages loop-result-metadata
-                  event event-event event-payload event-ev
+                  message
+                  message?
+                  message-id
+                  message-role
+                  message-content
+                  message-parent-id
+                  message-kind
+                  make-message
+                  make-text-part
+                  make-tool-result-part
+                  text-part?
+                  text-part-text
+                  tool-call-part?
+                  tool-call-part-id
+                  tool-call-part-name
+                  tool-result-part?
+                  tool-result-part-content
+                  tool-result-part-is-error?
+                  make-loop-result
+                  loop-result?
+                  loop-result-termination-reason
+                  loop-result-messages
+                  loop-result-metadata
+                  event
+                  event-event
+                  event-payload
+                  event-ev
                   make-event
                   content-part->jsexpr)
          "../agent/event-bus.rkt"
          "../llm/model.rkt"
          "../llm/provider.rkt"
-         (only-in "../tools/tool.rkt"
-                  make-tool make-tool-registry register-tool!
-                  make-success-result)
+         (only-in "../tools/tool.rkt" make-tool make-tool-registry register-tool! make-success-result)
          (only-in "../extensions/api.rkt"
-                  extension-registry? make-extension-registry register-extension! extension)
+                  extension-registry?
+                  make-extension-registry
+                  register-extension!
+                  extension)
          (only-in "../extensions/hooks.rkt" hook-pass hook-amend hook-block)
          "../runtime/agent-session.rkt"
          (only-in "../runtime/session-store.rkt" append-entry! load-session-log)
          (only-in "../runtime/compactor.rkt"
-                  compaction-strategy compaction-result->message-list compact-history
-                  build-tiered-context tiered-context tiered-context? tiered-context-tier-a
-                  tiered-context-tier-b tiered-context-tier-c tiered-context->message-list)
-         (only-in "../runtime/token-compaction.rkt"
-                  token-compaction-config)
+                  compaction-strategy
+                  compaction-result->message-list
+                  compact-history
+                  build-tiered-context
+                  tiered-context
+                  tiered-context?
+                  tiered-context-tier-a
+                  tiered-context-tier-b
+                  tiered-context-tier-c
+                  tiered-context->message-list)
+         (only-in "../runtime/token-compaction.rkt" token-compaction-config)
          (only-in "helpers/mock-provider.rkt"
-                  make-multi-mock-provider make-test-config
-                  make-simple-mock-provider make-tool-call-mock-provider)
+                  make-multi-mock-provider
+                  make-test-config
+                  make-simple-mock-provider
+                  make-tool-call-mock-provider)
          (only-in "../util/cancellation.rkt"
-                  make-cancellation-token cancellation-token? cancellation-token-cancelled? cancel-token!))
+                  make-cancellation-token
+                  cancellation-token?
+                  cancellation-token-cancelled?
+                  cancel-token!))
 
 ;; ============================================================
 ;; Helpers
@@ -62,10 +93,7 @@
 
 (define (make-event-collector bus)
   (define collected (box '()))
-  (subscribe! bus
-              (λ (evt)
-                (set-box! collected
-                          (append (unbox collected) (list evt)))))
+  (subscribe! bus (λ (evt) (set-box! collected (append (unbox collected) (list evt)))))
   collected)
 
 (define (event-names collected-box)
@@ -84,8 +112,9 @@
        (define cleaned (string-trim args))
        (if (or (string=? cleaned "") (string=? cleaned "{}"))
            (hash)
-           (for/hash ([m (in-list (regexp-match* #rx"\"([^\"]+)\"\\s*:\\s*\"([^\"]*)\"" cleaned
-                                              #:match-select values))])
+           (for/hash ([m (in-list (regexp-match* #rx"\"([^\"]+)\"\\s*:\\s*\"([^\"]*)\""
+                                                 cleaned
+                                                 #:match-select values))])
              (values (string->symbol (cadr m)) (caddr m)))))]
     [else (hash)]))
 
@@ -93,966 +122,877 @@
 ;; Test suite
 ;; ============================================================
 
-(define-test-suite test-agent-session-suite
-
-  ;; ── 1. Create session ──
-
-  (test-case "make-agent-session creates session with valid ID and empty history"
-    (define dir (make-temp-dir))
-    (define bus (make-event-bus))
-    (define evts (make-event-collector bus))
-    (define prov (make-mock-provider
-                  (make-model-response
-                   (list (hash 'type "text" 'text "hi"))
-                   (hash) "mock" 'stop)))
-    (define sess (make-agent-session (make-test-config dir bus prov)))
-
-    (check-pred agent-session? sess)
-    (check-true (string? (session-id sess)))
-    (check-true (> (string-length (session-id sess)) 0))
-    (check-equal? (session-history sess) '())
-    (check-pred session-active? sess)
-
-    ;; session.started event emitted
-    (check-not-false (member "session.started" (event-names evts)))
-
-    (delete-directory/files dir #:must-exist? #f))
-
-  ;; ── 2. Run prompt — text only ──
-
-  (test-case "run-prompt! with text response persists user + assistant messages"
-    (define dir (make-temp-dir))
-    (define bus (make-event-bus))
-    (define prov (make-mock-provider
-                  (make-model-response
-                   (list (hash 'type "text" 'text "Hello, world!"))
-                   (hash 'prompt_tokens 5 'completion_tokens 3 'total_tokens 8)
-                   "mock-model"
-                   'stop)))
-    (define sess (make-agent-session (make-test-config dir bus prov)))
-
-    (define-values (updated-sess result)
-      (run-prompt! sess "Say hello"))
-
-    ;; Check result
-    (check-equal? (loop-result-termination-reason result) 'completed)
-
-    ;; Check history: user + assistant
-    (define hist (session-history updated-sess))
-    (check-equal? (length hist) 2)
-    (check-equal? (message-role (first hist)) 'user)
-    (check-equal? (message-role (second hist)) 'assistant)
-
-    ;; Check content
-    (check-equal? (text-of (first hist)) "Say hello")
-    (check-equal? (text-of (second hist)) "Hello, world!")
-
-    (delete-directory/files dir #:must-exist? #f))
-
-  ;; ── 3. History accumulation across multiple prompts ──
-
-  (test-case "run-prompt! accumulates history across multiple calls"
-    (define dir (make-temp-dir))
-    (define bus (make-event-bus))
-    (define prov (make-multi-mock-provider
-                  (list (make-model-response
-                         (list (hash 'type "text" 'text "First response"))
-                         (hash) "mock" 'stop)
-                        (make-model-response
-                         (list (hash 'type "text" 'text "Second response"))
-                         (hash) "mock" 'stop))))
-    (define sess (make-agent-session (make-test-config dir bus prov)))
-
-    (define-values (s1 r1) (run-prompt! sess "First prompt"))
-    (define-values (s2 r2) (run-prompt! s1 "Second prompt"))
-
-    (define hist (session-history s2))
-    (check-equal? (length hist) 4)
-    (check-equal? (text-of (list-ref hist 0)) "First prompt")
-    (check-equal? (text-of (list-ref hist 1)) "First response")
-    (check-equal? (text-of (list-ref hist 2)) "Second prompt")
-    (check-equal? (text-of (list-ref hist 3)) "Second response")
-
-    (delete-directory/files dir #:must-exist? #f))
-
-  ;; ── 4. Resume session ──
-
-  (test-case "resume-agent-session loads history and continues"
-    (define dir (make-temp-dir))
-    (define bus (make-event-bus))
-    (define evts (make-event-collector bus))
-    (define prov (make-multi-mock-provider
-                  (list (make-model-response
-                         (list (hash 'type "text" 'text "First"))
-                         (hash) "mock" 'stop)
-                        (make-model-response
-                         (list (hash 'type "text" 'text "After resume"))
-                         (hash) "mock" 'stop))))
-
-    ;; Create and run first prompt
-    (define sess1 (make-agent-session (make-test-config dir bus prov)))
-    (define-values (s1 _r1) (run-prompt! sess1 "Hello"))
-    (define sid (session-id s1))
-
-    ;; Clear event collector for resume check
-    (set-box! evts '())
-
-    ;; Resume session
-    (define sess2 (resume-agent-session sid (make-test-config dir bus prov)))
-    (check-equal? (session-id sess2) sid)
-
-    ;; History preserved
-    (define hist (session-history sess2))
-    (check-equal? (length hist) 2)
-    (check-equal? (message-role (first hist)) 'user)
-    (check-equal? (message-role (second hist)) 'assistant)
-
-    ;; session.resumed event
-    (check-not-false (member "session.resumed" (event-names evts)))
-
-    ;; Continue with another prompt
-    (define-values (s2 r2) (run-prompt! sess2 "Continue"))
-    (check-equal? (loop-result-termination-reason r2) 'completed)
-
-    (define hist2 (session-history s2))
-    (check-equal? (length hist2) 4)
-    (check-equal? (text-of (list-ref hist2 2)) "Continue")
-    (check-equal? (text-of (list-ref hist2 3)) "After resume")
-
-    (delete-directory/files dir #:must-exist? #f))
-
-  ;; ── 5. Fork session — full history ──
-
-  (test-case "fork-session copies full history to new session"
-    (define dir (make-temp-dir))
-    (define bus (make-event-bus))
-    (define evts (make-event-collector bus))
-    (define prov (make-mock-provider
-                  (make-model-response
-                   (list (hash 'type "text" 'text "Response"))
-                   (hash) "mock" 'stop)))
-
-    (define sess1 (make-agent-session (make-test-config dir bus prov)))
-    (define-values (s1 _) (run-prompt! sess1 "Prompt 1"))
-
-    (define forked (fork-session s1))
-
-    ;; New ID
-    (check-not-equal? (session-id forked) (session-id s1))
-
-    ;; Same history content
-    (define orig-hist (session-history s1))
-    (define fork-hist (session-history forked))
-    (check-equal? (length fork-hist) (length orig-hist))
-    (check-equal? (text-of (first fork-hist)) "Prompt 1")
-    (check-equal? (text-of (second fork-hist)) "Response")
-
-    ;; session.forked event
-    (check-not-false (member "session.forked" (event-names evts)))
-
-    (delete-directory/files dir #:must-exist? #f))
-
-  ;; ── 6. Fork session — at specific entry ──
-
-  (test-case "fork-session at specific entry copies partial history"
-    (define dir (make-temp-dir))
-    (define bus (make-event-bus))
-    (define prov (make-multi-mock-provider
-                  (list (make-model-response
-                         (list (hash 'type "text" 'text "First"))
-                         (hash) "mock" 'stop)
-                        (make-model-response
-                         (list (hash 'type "text" 'text "Second"))
-                         (hash) "mock" 'stop))))
-
-    (define sess (make-agent-session (make-test-config dir bus prov)))
-    (define-values (s1 _r1) (run-prompt! sess "Prompt 1"))
-    (define-values (s2 _r2) (run-prompt! s1 "Prompt 2"))
-
-    (define hist (session-history s2))
-    (check-equal? (length hist) 4)
-
-    ;; Fork at second entry (first assistant message)
-    (define second-entry-id (message-id (second hist)))
-    (define forked (fork-session s2 second-entry-id))
-
-    (define fork-hist (session-history forked))
-    (check-equal? (length fork-hist) 2)
-    (check-equal? (text-of (first fork-hist)) "Prompt 1")
-    (check-equal? (text-of (second fork-hist)) "First")
-
-    (delete-directory/files dir #:must-exist? #f))
-
-  ;; ── 7. Tool-call execution loop ──
-
-  (test-case "run-prompt! executes tool calls and feeds results back"
-    (define dir (make-temp-dir))
-    (define bus (make-event-bus))
-    (define reg (make-tool-registry))
-
-    ;; Register echo tool
-    (register-tool! reg
-      (make-tool "echo"
-                 "Echoes the input message"
-                 (hasheq 'type "object"
-                         'properties (hasheq 'message (hasheq 'type "string"))
-                         'required '(message))
-                 (lambda (args ctx)
-                   (define a (parse-tool-args args))
-                   (make-success-result
-                    (list (hasheq 'type "text"
-                                  'text (string-append "Echo: "
-                                                       (hash-ref a 'message ""))))))))
-
-    ;; Mock: first returns tool-call, then text
-    (define prov (make-multi-mock-provider
-                  (list
-                   ;; First turn: call echo tool
-                   (make-model-response
-                    (list (hash 'type "tool-call" 'id "tc-1" 'name "echo"
-                                'arguments (hash 'message "hello world")))
-                    (hash) "mock" 'tool-calls)
-                   ;; Second turn: text response
-                   (make-model-response
-                    (list (hash 'type "text" 'text "I echoed hello world"))
-                    (hash) "mock" 'stop))))
-
-    (define sess (make-agent-session (make-test-config dir bus prov reg)))
-    (define-values (s result) (run-prompt! sess "Echo hello world"))
-
-    ;; Should complete
-    (check-equal? (loop-result-termination-reason result) 'completed)
-
-    ;; History: user, assistant(tool-call), tool-result, assistant(text)
-    (define hist (session-history s))
-    (check-equal? (length hist) 4)
-    (check-equal? (message-role (list-ref hist 0)) 'user)
-    (check-equal? (message-role (list-ref hist 1)) 'assistant)
-    (check-equal? (message-role (list-ref hist 2)) 'tool)
-    (check-equal? (message-role (list-ref hist 3)) 'assistant)
-
-    ;; Check tool-call in assistant message
-    (define assistant-1 (list-ref hist 1))
-    (define tc-parts (filter tool-call-part? (message-content assistant-1)))
-    (check-equal? (length tc-parts) 1)
-    (check-equal? (tool-call-part-name (first tc-parts)) "echo")
-    (check-equal? (tool-call-part-id (first tc-parts)) "tc-1")
-
-    ;; Check tool-result content
-    (define tool-result-msg (list-ref hist 2))
-    (define tr-parts (filter tool-result-part? (message-content tool-result-msg)))
-    (check-equal? (length tr-parts) 1)
-    (check-false (tool-result-part-is-error? (first tr-parts)))
-    ;; Tool result content should contain echo output
-    (define tr-content (tool-result-part-content (first tr-parts)))
-    (check-not-false (member "Echo: hello world"
-                             (map (lambda (c) (hash-ref c 'text #f))
-                                  (filter hash? tr-content))))
-
-    ;; Final assistant text
-    (check-equal? (text-of (list-ref hist 3)) "I echoed hello world")
-
-    (delete-directory/files dir #:must-exist? #f))
-
-  ;; ── 8. Max-iteration guard ──
-
-  (test-case "run-prompt! stops after max-iterations"
-    (define dir (make-temp-dir))
-    (define bus (make-event-bus))
-    (define evts (make-event-collector bus))
-    (define reg (make-tool-registry))
-
-    ;; Register loop tool
-    (register-tool! reg
-      (make-tool "loop"
-                 "Loops forever"
-                 (hasheq 'type "object"
-                         'properties (hasheq 'n (hasheq 'type "integer"))
-                         'required '())
-                 (lambda (args ctx)
-                   (make-success-result
-                    (list (hasheq 'type "text" 'text "loop result"))))))
-
-    ;; Mock always returns tool-calls
-    (define prov (make-multi-mock-provider
-                  (list (make-model-response
-                         (list (hash 'type "tool-call" 'id "tc-loop" 'name "loop"
-                                     'arguments (hash)))
-                         (hash) "mock" 'tool-calls))))
-
-    (define sess (make-agent-session
-                  (hash 'provider prov
-                        'tool-registry reg
-                        'event-bus bus
-                        'session-dir dir
-                        'max-iterations 2)))
-
-    (define-values (s result) (run-prompt! sess "keep looping"))
-
-    ;; Should stop with max-iterations-exceeded
-    (check-equal? (loop-result-termination-reason result) 'max-iterations-exceeded)
-
-    ;; Log: user, assistant(tool), tool-result, assistant(tool)
-    (define hist (session-history s))
-    (check-equal? (length hist) 4)
-    (check-equal? (message-role (first hist)) 'user)
-    (check-equal? (message-role (second hist)) 'assistant)
-    (check-equal? (message-role (third hist)) 'tool)
-    (check-equal? (message-role (fourth hist)) 'assistant)
-
-    ;; runtime.error event emitted
-    (check-not-false (member "runtime.error" (event-names evts)))
-
-    (delete-directory/files dir #:must-exist? #f))
-
-  ;; ── BUG-34: Provider exception handling ──
-
-  (test-case "run-prompt! catches provider exception and emits runtime.error event"
-    (define dir (make-temp-dir))
-    (define bus (make-event-bus))
-    (define evts (make-event-collector bus))
-
-    ;; Create a provider that raises exn:fail
-    (define prov
-      (make-provider
-       (lambda () "failing-mock")
-       (lambda () (hash 'streaming #t 'token-counting #t))
-       ;; send: raise exception
-       (lambda (req)
-         (error "provider-error" "Simulated provider failure"))
-       ;; stream: raise exception
-       (lambda (req)
-         (error "provider-error" "Simulated provider failure"))))
-
-    (define sess (make-agent-session (make-test-config dir bus prov)))
-
-    ;; Should NOT crash - should return error result
-    (define-values (s result)
-      (run-prompt! sess "This should not crash"))
-
-    ;; Verify error result returned
-    (check-equal? (loop-result-termination-reason result) 'error
-                  "should return 'error termination reason")
-
-    ;; Verify metadata contains error info
-    (define meta (loop-result-metadata result))
-    (check-not-false (hash-has-key? meta 'error)
-                     "metadata should contain error key")
-    (check-equal? (hash-ref meta 'errorType) 'provider-error
-                  "metadata should have errorType 'provider-error")
-
-    ;; Verify runtime.error event was emitted
-    (check-not-false (member "runtime.error" (event-names evts))
-                     "runtime.error event should be emitted")
-
-    ;; Verify session is still usable (history has user message)
-    (define hist (session-history s))
-    (check-equal? (length hist) 1 "user message should be persisted")
-    (check-equal? (message-role (first hist)) 'user)
-
-    (delete-directory/files dir #:must-exist? #f))
-
-  ;; ── 9. Session active/close ──
-
-  (test-case "session-active? and close-session!"
-    (define dir (make-temp-dir))
-    (define bus (make-event-bus))
-    (define evts (make-event-collector bus))
-    (define prov (make-mock-provider
-                  (make-model-response
-                   (list (hash 'type "text" 'text "hi"))
-                   (hash) "mock" 'stop)))
-
-    (define sess (make-agent-session (make-test-config dir bus prov)))
-    (check-pred session-active? sess)
-
-    (close-session! sess)
-    (check-false (session-active? sess))
-
-    ;; session.closed event
-    (check-not-false (member "session.closed" (event-names evts)))
-
-    (delete-directory/files dir #:must-exist? #f))
-
-  ;; ── 10. Events in correct order ──
-
-  (test-case "events emitted in correct order for text turn"
-    (define dir (make-temp-dir))
-    (define bus (make-event-bus))
-    (define evts (make-event-collector bus))
-    (define prov (make-mock-provider
-                  (make-model-response
-                   (list (hash 'type "text" 'text "Response"))
-                   (hash) "mock" 'stop)))
-
-    (define sess (make-agent-session (make-test-config dir bus prov)))
-    (define-values (s _) (run-prompt! sess "Test"))
-
-    (define names (event-names evts))
-    ;; session.started should be first
-    (check-equal? (first names) "session.started")
-    ;; session.updated should be last
-    (check-equal? (last names) "session.updated")
-    ;; Core loop events in between
-    (check-not-false (member "turn.started" names))
-    (check-not-false (member "turn.completed" names))
-    (check-not-false (member "context.built" names))
-    (check-not-false (member "assistant.message.completed" names))
-
-    (delete-directory/files dir #:must-exist? #f))
-
-  ;; ── 11. run-prompt! accepts message struct ──
-
-  (test-case "run-prompt! accepts message struct as input"
-    (define dir (make-temp-dir))
-    (define bus (make-event-bus))
-    (define prov (make-mock-provider
-                  (make-model-response
-                   (list (hash 'type "text" 'text "Got it"))
-                   (hash) "mock" 'stop)))
-
-    (define sess (make-agent-session (make-test-config dir bus prov)))
-    (define user-msg (make-message "custom-id" #f 'user 'message
-                                   (list (make-text-part "Custom message"))
-                                   (current-seconds) (hasheq)))
-    (define-values (s result) (run-prompt! sess user-msg))
-
-    (check-equal? (loop-result-termination-reason result) 'completed)
-    (define hist (session-history s))
-    (check-equal? (length hist) 2)
-    (check-equal? (message-id (first hist)) "custom-id")
-
-    (delete-directory/files dir #:must-exist? #f))
-
-  ;; ── 12. Tool-call events include tool.call.started ──
-
-  (test-case "tool-call scenario emits tool.call.started events"
-    (define dir (make-temp-dir))
-    (define bus (make-event-bus))
-    (define evts (make-event-collector bus))
-    (define reg (make-tool-registry))
-
-    (register-tool! reg
-      (make-tool "echo"
-                 "Echoes input"
-                 (hasheq 'type "object"
-                         'properties (hasheq 'msg (hasheq 'type "string"))
-                         'required '())
-                 (lambda (args ctx)
-                   (make-success-result
-                    (list (hasheq 'type "text" 'text "echoed"))))))
-
-    (define prov (make-multi-mock-provider
-                  (list
-                   (make-model-response
-                    (list (hash 'type "tool-call" 'id "tc-1" 'name "echo"
-                                'arguments (hash 'msg "hi")))
-                    (hash) "mock" 'tool-calls)
-                   (make-model-response
-                    (list (hash 'type "text" 'text "Done"))
-                    (hash) "mock" 'stop))))
-
-    (define sess (make-agent-session (make-test-config dir bus prov reg)))
-    (define-values (s result) (run-prompt! sess "Echo hi"))
-
-    (define names (event-names evts))
-    ;; Should have tool.call.started from first turn
-    (check-not-false (member "tool.call.started" names))
-    ;; Should have two turn.started events (two iterations)
-    (define turn-started-count (length (filter (λ (n) (equal? n "turn.started")) names)))
-    (check-equal? turn-started-count 2 "two turns for tool-call loop")
-
-    (delete-directory/files dir #:must-exist? #f))
-
-  ;; ── 13. system-instructions field defaults to '() ──
-
-  (test-case "agent-session has system-instructions field, defaults to '()"
-    (define dir (make-temp-dir))
-    (define bus (make-event-bus))
-    (define prov (make-mock-provider
-                  (make-model-response
-                   (list (hash 'type "text" 'text "hi"))
-                   (hash) "mock" 'stop)))
-    (define sess (make-agent-session (make-test-config dir bus prov)))
-    (check-equal? (agent-session-system-instructions sess) '()
-                  "system-instructions defaults to empty list")
-    (delete-directory/files dir #:must-exist? #f))
-
-  ;; ── 14. system-instructions stored when provided ──
-
-  (test-case "make-agent-session stores system-instructions from config"
-    (define dir (make-temp-dir))
-    (define bus (make-event-bus))
-    (define prov (make-mock-provider
-                  (make-model-response
-                   (list (hash 'type "text" 'text "hi"))
-                   (hash) "mock" 'stop)))
-    (define instrs '("You are a helpful assistant." "Always be concise."))
-    (define sess (make-agent-session
-                  (hash-set (make-test-config dir bus prov)
-                            'system-instructions instrs)))
-    (check-equal? (agent-session-system-instructions sess) instrs
-                  "system-instructions stored from config")
-    (delete-directory/files dir #:must-exist? #f))
-
-  ;; ── 15. run-prompt! injects system message but doesn't persist it ──
-
-  (test-case "run-prompt! with system-instructions prepends system message to context"
-    (define dir (make-temp-dir))
-    (define bus (make-event-bus))
-    (define evts (make-event-collector bus))
-    ;; Track what context the provider actually receives
-    (define captured-context (box #f))
-    (define prov
-      (make-provider
-       (lambda () "context-capture")
-       (lambda () (hash 'streaming #t 'token-counting #t))
-       ;; send: unused by run-agent-turn but required by provider interface
-       (lambda (req)
-         (make-model-response
-          (list (hash 'type "text" 'text "Response"))
-          (hash) "mock" 'stop))
-       ;; stream: capture the messages sent to the model
-       (lambda (req)
-         (set-box! captured-context (model-request-messages req))
-         (list (stream-chunk "Response" #f #f #t)))))
-    (define instrs '("You are a coding expert."))
-    (define sess (make-agent-session
-                  (hash-set (make-test-config dir bus prov)
-                            'system-instructions instrs)))
-    (define-values (s result) (run-prompt! sess "Write code"))
-
-    ;; Check that the context sent to the provider has a system message first
-    (define ctx (unbox captured-context))
-    (check-not-false ctx "provider should have received context")
-    ;; The first message in context should be a raw hash with role "system"
-    (define first-msg (first ctx))
-    (check-equal? (hash-ref first-msg 'role) "system"
-                  "first context message should be system role")
-    ;; The content should contain the instruction text
-    (define first-content (hash-ref first-msg 'content))
-    (check-true (string-contains? first-content "You are a coding expert.")
-                "system message should contain the instruction text")
-
-    ;; The system message should NOT be in the persisted session log
-    (define hist (session-history s))
-    (check-equal? (length hist) 2 "history should only have user + assistant")
-    (check-equal? (message-role (first hist)) 'user)
-    (check-equal? (message-role (second hist)) 'assistant)
-
-    (delete-directory/files dir #:must-exist? #f))
-
-  ;; ── 16. fork-session copies system-instructions ──
-
-  (test-case "fork-session copies system-instructions from parent"
-    (define dir (make-temp-dir))
-    (define bus (make-event-bus))
-    (define prov (make-mock-provider
-                  (make-model-response
-                   (list (hash 'type "text" 'text "hi"))
-                   (hash) "mock" 'stop)))
-    (define instrs '("Be helpful." "Be safe."))
-    (define sess (make-agent-session
-                  (hash-set (make-test-config dir bus prov)
-                            'system-instructions instrs)))
-    (define forked (fork-session sess))
-    (check-equal? (agent-session-system-instructions forked) instrs
-                  "forked session should inherit system-instructions")
-    (delete-directory/files dir #:must-exist? #f))
-
-  ;; ── 17. Session log is reloadable from disk ──
-
-  (test-case "session log persists to disk and survives object recreation"
-    (define dir (make-temp-dir))
-    (define bus (make-event-bus))
-    (define prov (make-multi-mock-provider
-                  (list (make-model-response
-                         (list (hash 'type "text" 'text "First"))
-                         (hash) "mock" 'stop)
-                        (make-model-response
-                         (list (hash 'type "text" 'text "Second"))
-                         (hash) "mock" 'stop))))
-
-    ;; Create and run
-    (define sess1 (make-agent-session (make-test-config dir bus prov)))
-    (define-values (s1 _) (run-prompt! sess1 "Hello"))
-    (define sid (session-id s1))
-
-    ;; Resume in a new object
-    (define bus2 (make-event-bus))
-    (define sess2 (resume-agent-session sid (make-test-config dir bus2 prov)))
-    (define hist (session-history sess2))
-    (check-equal? (length hist) 2)
-
-    ;; Can continue
-    (define-values (s2 r2) (run-prompt! sess2 "More"))
-    (check-equal? (loop-result-termination-reason r2) 'completed)
-    (check-equal? (length (session-history s2)) 4)
-
-    (delete-directory/files dir #:must-exist? #f))
-
-  ;; ── 18. turn-start hook dispatched (F2: renamed from before-turn) ──
-
-  (test-case "run-prompt! dispatches 'turn-start hook when extension-registry present"
-    (define dir (make-temp-dir))
-    (define bus (make-event-bus))
-    (define hook-called? (box #f))
-    (define prov (make-mock-provider
-                  (make-model-response
-                   (list (hash 'type "text" 'text "hi"))
-                   (hash) "mock" 'stop)))
-    (define ext-reg (make-extension-registry))
-    (register-extension! ext-reg
-      (extension "test-ext" "1.0" "0.1"
-                 (hasheq 'turn-start
-                         (lambda (ctx)
-                           (set-box! hook-called? #t)
-                           (hook-pass ctx)))))
-    (define sess (make-agent-session
-                  (hash-set (make-test-config dir bus prov)
-                            'extension-registry ext-reg)))
-    (define-values (s result) (run-prompt! sess "hello"))
-    (check-true (unbox hook-called?) "turn-start hook should have been called")
-    (delete-directory/files dir #:must-exist? #f))
-
-  ;; ── 19. turn-end hook dispatched (F2: renamed from after-turn) ──
-
-  (test-case "run-prompt! dispatches 'turn-end hook on completed turn"
-    (define dir (make-temp-dir))
-    (define bus (make-event-bus))
-    (define turn-end-called? (box #f))
-    (define prov (make-mock-provider
-                  (make-model-response
-                   (list (hash 'type "text" 'text "done"))
-                   (hash) "mock" 'stop)))
-    (define ext-reg (make-extension-registry))
-    (register-extension! ext-reg
-      (extension "test-ext" "1.0" "0.1"
-                 (hasheq 'turn-end
-                         (lambda (result)
-                           (set-box! turn-end-called? #t)
-                           (hook-pass result)))))
-    (define sess (make-agent-session
-                  (hash-set (make-test-config dir bus prov)
-                            'extension-registry ext-reg)))
-    (define-values (s result) (run-prompt! sess "hello"))
-    (check-true (unbox turn-end-called?) "turn-end hook should have been called")
-    (delete-directory/files dir #:must-exist? #f))
-
-  ;; ── 20. hooks skipped when extension-registry is #f ──
-
-  (test-case "run-prompt! skips hooks when extension-registry is #f"
-    (define dir (make-temp-dir))
-    (define bus (make-event-bus))
-    (define prov (make-mock-provider
-                  (make-model-response
-                   (list (hash 'type "text" 'text "ok"))
-                   (hash) "mock" 'stop)))
-    ;; No extension-registry — default is #f
-    (define sess (make-agent-session (make-test-config dir bus prov)))
-    ;; Should complete without error even though no registry exists
-    (define-values (s result) (run-prompt! sess "hello"))
-    (check-pred loop-result? result)
-    (check-equal? (loop-result-termination-reason result) 'completed)
-    (delete-directory/files dir #:must-exist? #f))
-
-  ;; ── F1: tool-result hook amending with non-message values are filtered ──
-
-  (test-case "tool-result hook amending with non-message values are filtered"
-    (define dir (make-temp-dir))
-    (define bus (make-event-bus))
-    (define reg (make-tool-registry))
-    (register-tool! reg
-      (make-tool "echo"
-                 "Echoes input"
-                 (hasheq 'type "object"
-                         'properties (hasheq 'msg (hasheq 'type "string"))
-                         'required '())
-                 (lambda (args ctx)
-                   (make-success-result
-                    (list (hasheq 'type "text" 'text "echoed"))))))
-    (define prov (make-multi-mock-provider
-                  (list
-                   (make-model-response
-                    (list (hash 'type "tool-call" 'id "tc-1" 'name "echo"
-                                'arguments (hash 'msg "hi")))
-                    (hash) "mock" 'tool-calls)
-                   (make-model-response
-                    (list (hash 'type "text" 'text "Done"))
-                    (hash) "mock" 'stop))))
-    (define ext-reg (make-extension-registry))
-    (register-extension! ext-reg
-      (extension "dirty-ext" "1.0" "0.1"
-                 (hasheq 'tool-result
-                         (lambda (msgs)
-                           ;; Amend with a mix of valid messages and junk
-                           (hook-amend (append msgs (list "junk-string" 42)))))))
-    (define sess (make-agent-session
-                  (hash-set (make-test-config dir bus prov reg)
-                            'extension-registry ext-reg)))
-    (define-values (s result) (run-prompt! sess "Echo hi"))
-    (check-equal? (loop-result-termination-reason result) 'completed)
-    ;; History: user, assistant(tool-call), tool-result, assistant(text)
-    ;; The junk values should be filtered out — still 4 entries
-    (define hist (session-history s))
-    (check-equal? (length hist) 4)
-    (check-equal? (message-role (list-ref hist 0)) 'user)
-    (check-equal? (message-role (list-ref hist 1)) 'assistant)
-    (check-equal? (message-role (list-ref hist 2)) 'tool)
-    (check-equal? (message-role (list-ref hist 3)) 'assistant)
-    (delete-directory/files dir #:must-exist? #f))
-
-  ;; ── F6: turn-start 'block skips the turn ──
-
-  (test-case "turn-start hook 'block skips the turn"
-    (define dir (make-temp-dir))
-    (define bus (make-event-bus))
-    (define evts (make-event-collector bus))
-    (define prov (make-mock-provider
-                  (make-model-response
-                   (list (hash 'type "text" 'text "should not appear"))
-                   (hash) "mock" 'stop)))
-    (define ext-reg (make-extension-registry))
-    (register-extension! ext-reg
-      (extension "block-ext" "1.0" "0.1"
-                 (hasheq 'turn-start
-                         (lambda (ctx)
-                           (hook-block "blocked for testing")))))
-    (define sess (make-agent-session
-                  (hash-set (make-test-config dir bus prov)
-                            'extension-registry ext-reg)))
-    (define-values (s result) (run-prompt! sess "hello"))
-    (check-equal? (loop-result-termination-reason result) 'completed)
-    (check-equal? (hash-ref (loop-result-metadata result) 'reason) "extension-block")
-    ;; History should only have user message (no model call)
-    (define hist (session-history s))
-    (check-equal? (length hist) 1)
-    (check-equal? (message-role (first hist)) 'user)
-    ;; turn.blocked event emitted
-    (check-not-false (member "turn.blocked" (event-names evts)))
-    (delete-directory/files dir #:must-exist? #f))
-
-  ;; ── F2: hook points use BLUEPRINT §7 names ──
-
-  (test-case "hooks fire on 'turn-start and 'tool-call (BLUEPRINT names)"
-    (define dir (make-temp-dir))
-    (define bus (make-event-bus))
-    (define turn-start-called? (box #f))
-    (define tool-call-called? (box #f))
-    (define reg (make-tool-registry))
-    (register-tool! reg
-      (make-tool "echo"
-                 "Echoes input"
-                 (hasheq 'type "object"
-                         'properties (hasheq 'msg (hasheq 'type "string"))
-                         'required '())
-                 (lambda (args ctx)
-                   (make-success-result
-                    (list (hasheq 'type "text" 'text "echoed"))))))
-    (define prov (make-multi-mock-provider
-                  (list
-                   (make-model-response
-                    (list (hash 'type "tool-call" 'id "tc-1" 'name "echo"
-                                'arguments (hash 'msg "hi")))
-                    (hash) "mock" 'tool-calls)
-                   (make-model-response
-                    (list (hash 'type "text" 'text "Done"))
-                    (hash) "mock" 'stop))))
-    (define ext-reg (make-extension-registry))
-    (register-extension! ext-reg
-      (extension "blueprint-names-ext" "1.0" "0.1"
-                 (hasheq 'turn-start
-                         (lambda (ctx)
-                           (set-box! turn-start-called? #t)
-                           (hook-pass ctx))
-                         'tool-call
-                         (lambda (tcs)
-                           (set-box! tool-call-called? #t)
-                           (hook-pass tcs)))))
-    (define sess (make-agent-session
-                  (hash-set (make-test-config dir bus prov reg)
-                            'extension-registry ext-reg)))
-    (define-values (s result) (run-prompt! sess "Echo hi"))
-    (check-true (unbox turn-start-called?) "'turn-start hook should have been called")
-    (check-true (unbox tool-call-called?) "'tool-call hook should have been called")
-    (delete-directory/files dir #:must-exist? #f))
-
-  ;; ── GAP-5 FIXED: hook exception during dispatch is isolated ──
-
-  (test-case "hook exception during dispatch is isolated and session continues"
-    (define dir (make-temp-dir))
-    (define bus (make-event-bus))
-    (define prov (make-mock-provider
-                  (make-model-response
-                   (list (hash 'type "text" 'text "hi"))
-                   (hash) "mock" 'stop)))
-    (define ext-reg (make-extension-registry))
-    (register-extension! ext-reg
-      (extension "crashing-ext" "1.0" "0.1"
-                 (hasheq 'turn-start
-                         (lambda (ctx)
-                           (error "crashing-hook" "intentional test error")))))
-    (define sess (make-agent-session
-                  (hash-set (make-test-config dir bus prov)
-                            'extension-registry ext-reg)))
-    ;; The crashing handler should be isolated — session should NOT raise
-    (check-not-exn (lambda () (run-prompt! sess "hello"))
-                   "exception in hook should be isolated, not propagate")
-    (delete-directory/files dir #:must-exist? #f))
-
-  ;; ── WP-35: Cooperative Cancellation Tests ──
-
-  (test-case "run-prompt! with pre-cancelled token returns 'cancelled"
-    (define dir (make-temp-dir))
-    (define bus (make-event-bus))
-    (define evts (make-event-collector bus))
-    (define tok (make-cancellation-token))
-    (cancel-token! tok)  ; pre-cancel
-    (define prov (make-mock-provider
-                  (make-model-response
-                   (list (hash 'type "text" 'text "should not appear"))
-                   (hash) "mock" 'stop)))
-    (define sess (make-agent-session
-                  (hash-set (make-test-config dir bus prov)
-                            'cancellation-token tok)))
-    (define-values (s result) (run-prompt! sess "hello"))
-    (check-equal? (loop-result-termination-reason result) 'cancelled
-                  "should return 'cancelled when token is pre-cancelled")
-    ;; No model response in history — only the user message was appended
-    (define hist (session-history s))
-    (check-equal? (length hist) 1 "only user message in history")
-    (check-equal? (message-role (first hist)) 'user)
-    (delete-directory/files dir #:must-exist? #f))
-
-  (test-case "run-prompt! with pre-cancelled token emits turn.cancelled event"
-    (define dir (make-temp-dir))
-    (define bus (make-event-bus))
-    (define evts (make-event-collector bus))
-    (define tok (make-cancellation-token))
-    (cancel-token! tok)
-    (define prov (make-mock-provider
-                  (make-model-response
-                   (list (hash 'type "text" 'text "should not appear"))
-                   (hash) "mock" 'stop)))
-    (define sess (make-agent-session
-                  (hash-set (make-test-config dir bus prov)
-                            'cancellation-token tok)))
-    (define-values (s result) (run-prompt! sess "hello"))
-    (define names (event-names evts))
-    (check-not-false (member "turn.cancelled" names)
-                     "turn.cancelled event should be emitted")
-    (delete-directory/files dir #:must-exist? #f))
-
-  (test-case "run-prompt! token cancelled mid-loop stops after current iteration"
-    (define dir (make-temp-dir))
-    (define bus (make-event-bus))
-    (define evts (make-event-collector bus))
-    (define reg (make-tool-registry))
-    (define tok (make-cancellation-token
-                 #:callback (λ (_)
-                   (void))))
-
-    ;; Register a tool
-    (register-tool! reg
-      (make-tool "echo"
-                 "Echoes input"
-                 (hasheq 'type "object"
-                         'properties (hasheq 'msg (hasheq 'type "string"))
-                         'required '())
-                 (lambda (args ctx)
-                   (make-success-result
-                    (list (hasheq 'type "text" 'text "echoed"))))))
-
-    ;; Provider: first turn = tool call, second turn = would-be text (never reached)
-    ;; Cancel the token AFTER the first turn completes (in the tool-call hook)
-    (define turn-count (box 0))
-    (define prov
-      (make-provider
-       (lambda () "cancel-mid-loop")
-       (lambda () (hash 'streaming #t 'token-counting #t))
-       (lambda (req)
-         (make-model-response '() (hash) "mock" 'stop))
-       (lambda (req)
-         (define i (unbox turn-count))
-         (set-box! turn-count (add1 i))
-         (cond
-           [(= i 0)
-            ;; First turn: return a tool call
-            (list (stream-chunk "calling tool" #f #f #f)
-                  (stream-chunk #f (hasheq 'id "tc-1" 'name "echo" 'arguments "{}") #f #f)
-                  (stream-chunk #f #f (hasheq) #t))]
-           [else
-            ;; Second turn: text response
-            (list (stream-chunk "final text" #f #f #f)
-                  (stream-chunk #f #f (hasheq) #t))]))))
-
-    ;; Use tool-call hook to cancel the token between iterations
-    (define ext-reg (make-extension-registry))
-    (register-extension! ext-reg
-      (extension "cancel-ext" "1.0" "0.1"
-                 (hasheq 'tool-call
-                         (lambda (tcs)
-                           ;; Cancel after first tool call is dispatched
-                           (cancel-token! tok)
-                           (hook-pass tcs)))))
-
-    (define sess (make-agent-session
-                  (hash 'provider prov
-                        'tool-registry reg
-                        'event-bus bus
-                        'session-dir dir
-                        'extension-registry ext-reg
-                        'cancellation-token tok
-                        'max-iterations 5)))
-
-    (define-values (s result) (run-prompt! sess "trigger tool call"))
-
-    ;; Should have been cancelled after the first iteration completed
-    (check-equal? (loop-result-termination-reason result) 'cancelled
-                  "should terminate with 'cancelled when token cancelled mid-loop")
-    ;; turn.cancelled event emitted
-    (check-not-false (member "turn.cancelled" (event-names evts))
-                     "turn.cancelled event should be emitted")
-    ;; History should have user + assistant(tool-call) + tool-result from first iteration
-    (define hist (session-history s))
-    (check-true (>= (length hist) 3)
-                "should have at least user + assistant + tool-result from first iteration")
-    (delete-directory/files dir #:must-exist? #f))
-
-  (test-case "run-prompt! with no cancellation token runs normally (backward compat)"
-    (define dir (make-temp-dir))
-    (define bus (make-event-bus))
-    (define prov (make-mock-provider
-                  (make-model-response
-                   (list (hash 'type "text" 'text "normal response"))
-                   (hash) "mock" 'stop)))
-    ;; No cancellation-token in config
-    (define sess (make-agent-session (make-test-config dir bus prov)))
-    (define-values (s result) (run-prompt! sess "hello"))
-    (check-equal? (loop-result-termination-reason result) 'completed
-                  "should complete normally without cancellation token")
-    (define hist (session-history s))
-    (check-equal? (length hist) 2 "user + assistant")
-    (delete-directory/files dir #:must-exist? #f))
-
-  (test-case "run-prompt! with uncancelled token runs normally"
-    (define dir (make-temp-dir))
-    (define bus (make-event-bus))
-    (define tok (make-cancellation-token))  ; not cancelled
-    (define prov (make-mock-provider
-                  (make-model-response
-                   (list (hash 'type "text" 'text "normal response"))
-                   (hash) "mock" 'stop)))
-    (define sess (make-agent-session
-                  (hash-set (make-test-config dir bus prov)
-                            'cancellation-token tok)))
-    (define-values (s result) (run-prompt! sess "hello"))
-    (check-equal? (loop-result-termination-reason result) 'completed
-                  "should complete normally with uncancelled token")
-    (define hist (session-history s))
-    (check-equal? (length hist) 2 "user + assistant")
-    (delete-directory/files dir #:must-exist? #f))
-  )
+(define-test-suite
+ test-agent-session-suite
+ ;; ── 1. Create session ──
+ (test-case "make-agent-session creates session with valid ID and empty history"
+   (define dir (make-temp-dir))
+   (define bus (make-event-bus))
+   (define evts (make-event-collector bus))
+   (define prov
+     (make-mock-provider
+      (make-model-response (list (hash 'type "text" 'text "hi")) (hash) "mock" 'stop)))
+   (define sess (make-agent-session (make-test-config dir bus prov)))
+
+   (check-pred agent-session? sess)
+   (check-true (string? (session-id sess)))
+   (check-true (> (string-length (session-id sess)) 0))
+   (check-equal? (session-history sess) '())
+   (check-pred session-active? sess)
+
+   ;; session.started event emitted
+   (check-not-false (member "session.started" (event-names evts)))
+
+   (delete-directory/files dir #:must-exist? #f))
+ ;; ── 2. Run prompt — text only ──
+ (test-case "run-prompt! with text response persists user + assistant messages"
+   (define dir (make-temp-dir))
+   (define bus (make-event-bus))
+   (define prov
+     (make-mock-provider (make-model-response
+                          (list (hash 'type "text" 'text "Hello, world!"))
+                          (hash 'prompt_tokens 5 'completion_tokens 3 'total_tokens 8)
+                          "mock-model"
+                          'stop)))
+   (define sess (make-agent-session (make-test-config dir bus prov)))
+
+   (define-values (updated-sess result) (run-prompt! sess "Say hello"))
+
+   ;; Check result
+   (check-equal? (loop-result-termination-reason result) 'completed)
+
+   ;; Check history: user + assistant
+   (define hist (session-history updated-sess))
+   (check-equal? (length hist) 2)
+   (check-equal? (message-role (first hist)) 'user)
+   (check-equal? (message-role (second hist)) 'assistant)
+
+   ;; Check content
+   (check-equal? (text-of (first hist)) "Say hello")
+   (check-equal? (text-of (second hist)) "Hello, world!")
+
+   (delete-directory/files dir #:must-exist? #f))
+ ;; ── 3. History accumulation across multiple prompts ──
+ (test-case "run-prompt! accumulates history across multiple calls"
+   (define dir (make-temp-dir))
+   (define bus (make-event-bus))
+   (define prov
+     (make-multi-mock-provider
+      (list
+       (make-model-response (list (hash 'type "text" 'text "First response")) (hash) "mock" 'stop)
+       (make-model-response (list (hash 'type "text" 'text "Second response")) (hash) "mock" 'stop))))
+   (define sess (make-agent-session (make-test-config dir bus prov)))
+
+   (define-values (s1 r1) (run-prompt! sess "First prompt"))
+   (define-values (s2 r2) (run-prompt! s1 "Second prompt"))
+
+   (define hist (session-history s2))
+   (check-equal? (length hist) 4)
+   (check-equal? (text-of (list-ref hist 0)) "First prompt")
+   (check-equal? (text-of (list-ref hist 1)) "First response")
+   (check-equal? (text-of (list-ref hist 2)) "Second prompt")
+   (check-equal? (text-of (list-ref hist 3)) "Second response")
+
+   (delete-directory/files dir #:must-exist? #f))
+ ;; ── 4. Resume session ──
+ (test-case "resume-agent-session loads history and continues"
+   (define dir (make-temp-dir))
+   (define bus (make-event-bus))
+   (define evts (make-event-collector bus))
+   (define prov
+     (make-multi-mock-provider
+      (list
+       (make-model-response (list (hash 'type "text" 'text "First")) (hash) "mock" 'stop)
+       (make-model-response (list (hash 'type "text" 'text "After resume")) (hash) "mock" 'stop))))
+
+   ;; Create and run first prompt
+   (define sess1 (make-agent-session (make-test-config dir bus prov)))
+   (define-values (s1 _r1) (run-prompt! sess1 "Hello"))
+   (define sid (session-id s1))
+
+   ;; Clear event collector for resume check
+   (set-box! evts '())
+
+   ;; Resume session
+   (define sess2 (resume-agent-session sid (make-test-config dir bus prov)))
+   (check-equal? (session-id sess2) sid)
+
+   ;; History preserved
+   (define hist (session-history sess2))
+   (check-equal? (length hist) 2)
+   (check-equal? (message-role (first hist)) 'user)
+   (check-equal? (message-role (second hist)) 'assistant)
+
+   ;; session.resumed event
+   (check-not-false (member "session.resumed" (event-names evts)))
+
+   ;; Continue with another prompt
+   (define-values (s2 r2) (run-prompt! sess2 "Continue"))
+   (check-equal? (loop-result-termination-reason r2) 'completed)
+
+   (define hist2 (session-history s2))
+   (check-equal? (length hist2) 4)
+   (check-equal? (text-of (list-ref hist2 2)) "Continue")
+   (check-equal? (text-of (list-ref hist2 3)) "After resume")
+
+   (delete-directory/files dir #:must-exist? #f))
+ ;; ── 5. Fork session — full history ──
+ (test-case "fork-session copies full history to new session"
+   (define dir (make-temp-dir))
+   (define bus (make-event-bus))
+   (define evts (make-event-collector bus))
+   (define prov
+     (make-mock-provider
+      (make-model-response (list (hash 'type "text" 'text "Response")) (hash) "mock" 'stop)))
+
+   (define sess1 (make-agent-session (make-test-config dir bus prov)))
+   (define-values (s1 _) (run-prompt! sess1 "Prompt 1"))
+
+   (define forked (fork-session s1))
+
+   ;; New ID
+   (check-not-equal? (session-id forked) (session-id s1))
+
+   ;; Same history content
+   (define orig-hist (session-history s1))
+   (define fork-hist (session-history forked))
+   (check-equal? (length fork-hist) (length orig-hist))
+   (check-equal? (text-of (first fork-hist)) "Prompt 1")
+   (check-equal? (text-of (second fork-hist)) "Response")
+
+   ;; session.forked event
+   (check-not-false (member "session.forked" (event-names evts)))
+
+   (delete-directory/files dir #:must-exist? #f))
+ ;; ── 6. Fork session — at specific entry ──
+ (test-case "fork-session at specific entry copies partial history"
+   (define dir (make-temp-dir))
+   (define bus (make-event-bus))
+   (define prov
+     (make-multi-mock-provider
+      (list (make-model-response (list (hash 'type "text" 'text "First")) (hash) "mock" 'stop)
+            (make-model-response (list (hash 'type "text" 'text "Second")) (hash) "mock" 'stop))))
+
+   (define sess (make-agent-session (make-test-config dir bus prov)))
+   (define-values (s1 _r1) (run-prompt! sess "Prompt 1"))
+   (define-values (s2 _r2) (run-prompt! s1 "Prompt 2"))
+
+   (define hist (session-history s2))
+   (check-equal? (length hist) 4)
+
+   ;; Fork at second entry (first assistant message)
+   (define second-entry-id (message-id (second hist)))
+   (define forked (fork-session s2 second-entry-id))
+
+   (define fork-hist (session-history forked))
+   (check-equal? (length fork-hist) 2)
+   (check-equal? (text-of (first fork-hist)) "Prompt 1")
+   (check-equal? (text-of (second fork-hist)) "First")
+
+   (delete-directory/files dir #:must-exist? #f))
+ ;; ── 7. Tool-call execution loop ──
+ (test-case "run-prompt! executes tool calls and feeds results back"
+   (define dir (make-temp-dir))
+   (define bus (make-event-bus))
+   (define reg (make-tool-registry))
+
+   ;; Register echo tool
+   (register-tool!
+    reg
+    (make-tool
+     "echo"
+     "Echoes the input message"
+     (hasheq 'type
+             "object"
+             'properties
+             (hasheq 'message (hasheq 'type "string"))
+             'required
+             '(message))
+     (lambda (args ctx)
+       (define a (parse-tool-args args))
+       (make-success-result
+        (list (hasheq 'type "text" 'text (string-append "Echo: " (hash-ref a 'message ""))))))))
+
+   ;; Mock: first returns tool-call, then text
+   (define prov
+     (make-multi-mock-provider
+      (list
+       ;; First turn: call echo tool
+       (make-model-response
+        (list
+         (hash 'type "tool-call" 'id "tc-1" 'name "echo" 'arguments (hash 'message "hello world")))
+        (hash)
+        "mock"
+        'tool-calls)
+       ;; Second turn: text response
+       (make-model-response (list (hash 'type "text" 'text "I echoed hello world"))
+                            (hash)
+                            "mock"
+                            'stop))))
+
+   (define sess (make-agent-session (make-test-config dir bus prov reg)))
+   (define-values (s result) (run-prompt! sess "Echo hello world"))
+
+   ;; Should complete
+   (check-equal? (loop-result-termination-reason result) 'completed)
+
+   ;; History: user, assistant(tool-call), tool-result, assistant(text)
+   (define hist (session-history s))
+   (check-equal? (length hist) 4)
+   (check-equal? (message-role (list-ref hist 0)) 'user)
+   (check-equal? (message-role (list-ref hist 1)) 'assistant)
+   (check-equal? (message-role (list-ref hist 2)) 'tool)
+   (check-equal? (message-role (list-ref hist 3)) 'assistant)
+
+   ;; Check tool-call in assistant message
+   (define assistant-1 (list-ref hist 1))
+   (define tc-parts (filter tool-call-part? (message-content assistant-1)))
+   (check-equal? (length tc-parts) 1)
+   (check-equal? (tool-call-part-name (first tc-parts)) "echo")
+   (check-equal? (tool-call-part-id (first tc-parts)) "tc-1")
+
+   ;; Check tool-result content
+   (define tool-result-msg (list-ref hist 2))
+   (define tr-parts (filter tool-result-part? (message-content tool-result-msg)))
+   (check-equal? (length tr-parts) 1)
+   (check-false (tool-result-part-is-error? (first tr-parts)))
+   ;; Tool result content should contain echo output
+   (define tr-content (tool-result-part-content (first tr-parts)))
+   (check-not-false (member "Echo: hello world"
+                            (map (lambda (c) (hash-ref c 'text #f)) (filter hash? tr-content))))
+
+   ;; Final assistant text
+   (check-equal? (text-of (list-ref hist 3)) "I echoed hello world")
+
+   (delete-directory/files dir #:must-exist? #f))
+ ;; ── 8. Max-iteration guard ──
+ (test-case "run-prompt! stops after max-iterations"
+   (define dir (make-temp-dir))
+   (define bus (make-event-bus))
+   (define evts (make-event-collector bus))
+   (define reg (make-tool-registry))
+
+   ;; Register loop tool
+   (register-tool!
+    reg
+    (make-tool "loop"
+               "Loops forever"
+               (hasheq 'type "object" 'properties (hasheq 'n (hasheq 'type "integer")) 'required '())
+               (lambda (args ctx)
+                 (make-success-result (list (hasheq 'type "text" 'text "loop result"))))))
+
+   ;; Mock always returns tool-calls
+   (define prov
+     (make-multi-mock-provider
+      (list (make-model-response
+             (list (hash 'type "tool-call" 'id "tc-loop" 'name "loop" 'arguments (hash)))
+             (hash)
+             "mock"
+             'tool-calls))))
+
+   (define sess
+     (make-agent-session
+      (hash 'provider prov 'tool-registry reg 'event-bus bus 'session-dir dir 'max-iterations 2)))
+
+   (define-values (s result) (run-prompt! sess "keep looping"))
+
+   ;; Should stop with max-iterations-exceeded
+   (check-equal? (loop-result-termination-reason result) 'max-iterations-exceeded)
+
+   ;; Log: user, assistant(tool), tool-result, assistant(tool)
+   (define hist (session-history s))
+   (check-equal? (length hist) 4)
+   (check-equal? (message-role (first hist)) 'user)
+   (check-equal? (message-role (second hist)) 'assistant)
+   (check-equal? (message-role (third hist)) 'tool)
+   (check-equal? (message-role (fourth hist)) 'assistant)
+
+   ;; runtime.error event emitted
+   (check-not-false (member "runtime.error" (event-names evts)))
+
+   (delete-directory/files dir #:must-exist? #f))
+ ;; ── BUG-34: Provider exception handling ──
+ (test-case "run-prompt! catches provider exception and emits runtime.error event"
+   (define dir (make-temp-dir))
+   (define bus (make-event-bus))
+   (define evts (make-event-collector bus))
+
+   ;; Create a provider that raises exn:fail
+   (define prov
+     (make-provider (lambda () "failing-mock")
+                    (lambda () (hash 'streaming #t 'token-counting #t))
+                    ;; send: raise exception
+                    (lambda (req) (error "provider-error" "Simulated provider failure"))
+                    ;; stream: raise exception
+                    (lambda (req) (error "provider-error" "Simulated provider failure"))))
+
+   (define sess (make-agent-session (make-test-config dir bus prov)))
+
+   ;; Should NOT crash - should return error result
+   (define-values (s result) (run-prompt! sess "This should not crash"))
+
+   ;; Verify error result returned
+   (check-equal? (loop-result-termination-reason result)
+                 'error
+                 "should return 'error termination reason")
+
+   ;; Verify metadata contains error info
+   (define meta (loop-result-metadata result))
+   (check-not-false (hash-has-key? meta 'error) "metadata should contain error key")
+   (check-equal? (hash-ref meta 'errorType)
+                 'provider-error
+                 "metadata should have errorType 'provider-error")
+
+   ;; Verify runtime.error event was emitted
+   (check-not-false (member "runtime.error" (event-names evts))
+                    "runtime.error event should be emitted")
+
+   ;; Verify session is still usable (history has user message)
+   (define hist (session-history s))
+   (check-equal? (length hist) 1 "user message should be persisted")
+   (check-equal? (message-role (first hist)) 'user)
+
+   (delete-directory/files dir #:must-exist? #f))
+ ;; ── 9. Session active/close ──
+ (test-case "session-active? and close-session!"
+   (define dir (make-temp-dir))
+   (define bus (make-event-bus))
+   (define evts (make-event-collector bus))
+   (define prov
+     (make-mock-provider
+      (make-model-response (list (hash 'type "text" 'text "hi")) (hash) "mock" 'stop)))
+
+   (define sess (make-agent-session (make-test-config dir bus prov)))
+   (check-pred session-active? sess)
+
+   (close-session! sess)
+   (check-false (session-active? sess))
+
+   ;; session.closed event
+   (check-not-false (member "session.closed" (event-names evts)))
+
+   (delete-directory/files dir #:must-exist? #f))
+ ;; ── 10. Events in correct order ──
+ (test-case "events emitted in correct order for text turn"
+   (define dir (make-temp-dir))
+   (define bus (make-event-bus))
+   (define evts (make-event-collector bus))
+   (define prov
+     (make-mock-provider
+      (make-model-response (list (hash 'type "text" 'text "Response")) (hash) "mock" 'stop)))
+
+   (define sess (make-agent-session (make-test-config dir bus prov)))
+   (define-values (s _) (run-prompt! sess "Test"))
+
+   (define names (event-names evts))
+   ;; session.started should be first
+   (check-equal? (first names) "session.started")
+   ;; session.updated should be last
+   (check-equal? (last names) "session.updated")
+   ;; Core loop events in between
+   (check-not-false (member "turn.started" names))
+   (check-not-false (member "turn.completed" names))
+   (check-not-false (member "context.built" names))
+   (check-not-false (member "assistant.message.completed" names))
+
+   (delete-directory/files dir #:must-exist? #f))
+ ;; ── 11. run-prompt! accepts message struct ──
+ (test-case "run-prompt! accepts message struct as input"
+   (define dir (make-temp-dir))
+   (define bus (make-event-bus))
+   (define prov
+     (make-mock-provider
+      (make-model-response (list (hash 'type "text" 'text "Got it")) (hash) "mock" 'stop)))
+
+   (define sess (make-agent-session (make-test-config dir bus prov)))
+   (define user-msg
+     (make-message "custom-id"
+                   #f
+                   'user
+                   'message
+                   (list (make-text-part "Custom message"))
+                   (current-seconds)
+                   (hasheq)))
+   (define-values (s result) (run-prompt! sess user-msg))
+
+   (check-equal? (loop-result-termination-reason result) 'completed)
+   (define hist (session-history s))
+   (check-equal? (length hist) 2)
+   (check-equal? (message-id (first hist)) "custom-id")
+
+   (delete-directory/files dir #:must-exist? #f))
+ ;; ── 12. Tool-call events include tool.call.started ──
+ (test-case "tool-call scenario emits tool.call.started events"
+   (define dir (make-temp-dir))
+   (define bus (make-event-bus))
+   (define evts (make-event-collector bus))
+   (define reg (make-tool-registry))
+
+   (register-tool!
+    reg
+    (make-tool "echo"
+               "Echoes input"
+               (hasheq 'type "object" 'properties (hasheq 'msg (hasheq 'type "string")) 'required '())
+               (lambda (args ctx) (make-success-result (list (hasheq 'type "text" 'text "echoed"))))))
+
+   (define prov
+     (make-multi-mock-provider
+      (list (make-model-response
+             (list (hash 'type "tool-call" 'id "tc-1" 'name "echo" 'arguments (hash 'msg "hi")))
+             (hash)
+             "mock"
+             'tool-calls)
+            (make-model-response (list (hash 'type "text" 'text "Done")) (hash) "mock" 'stop))))
+
+   (define sess (make-agent-session (make-test-config dir bus prov reg)))
+   (define-values (s result) (run-prompt! sess "Echo hi"))
+
+   (define names (event-names evts))
+   ;; Should have tool.call.started from first turn
+   (check-not-false (member "tool.call.started" names))
+   ;; Should have two turn.started events (two iterations)
+   (define turn-started-count (length (filter (λ (n) (equal? n "turn.started")) names)))
+   (check-equal? turn-started-count 2 "two turns for tool-call loop")
+
+   (delete-directory/files dir #:must-exist? #f))
+ ;; ── 13. system-instructions field defaults to '() ──
+ (test-case "agent-session has system-instructions field, defaults to '()"
+   (define dir (make-temp-dir))
+   (define bus (make-event-bus))
+   (define prov
+     (make-mock-provider
+      (make-model-response (list (hash 'type "text" 'text "hi")) (hash) "mock" 'stop)))
+   (define sess (make-agent-session (make-test-config dir bus prov)))
+   (check-equal? (agent-session-system-instructions sess)
+                 '()
+                 "system-instructions defaults to empty list")
+   (delete-directory/files dir #:must-exist? #f))
+ ;; ── 14. system-instructions stored when provided ──
+ (test-case "make-agent-session stores system-instructions from config"
+   (define dir (make-temp-dir))
+   (define bus (make-event-bus))
+   (define prov
+     (make-mock-provider
+      (make-model-response (list (hash 'type "text" 'text "hi")) (hash) "mock" 'stop)))
+   (define instrs '("You are a helpful assistant." "Always be concise."))
+   (define sess
+     (make-agent-session (hash-set (make-test-config dir bus prov) 'system-instructions instrs)))
+   (check-equal? (agent-session-system-instructions sess)
+                 instrs
+                 "system-instructions stored from config")
+   (delete-directory/files dir #:must-exist? #f))
+ ;; ── 15. run-prompt! injects system message but doesn't persist it ──
+ (test-case "run-prompt! with system-instructions prepends system message to context"
+   (define dir (make-temp-dir))
+   (define bus (make-event-bus))
+   (define evts (make-event-collector bus))
+   ;; Track what context the provider actually receives
+   (define captured-context (box #f))
+   (define prov
+     (make-provider
+      (lambda () "context-capture")
+      (lambda () (hash 'streaming #t 'token-counting #t))
+      ;; send: unused by run-agent-turn but required by provider interface
+      (lambda (req)
+        (make-model-response (list (hash 'type "text" 'text "Response")) (hash) "mock" 'stop))
+      ;; stream: capture the messages sent to the model
+      (lambda (req)
+        (set-box! captured-context (model-request-messages req))
+        (list (stream-chunk "Response" #f #f #t)))))
+   (define instrs '("You are a coding expert."))
+   (define sess
+     (make-agent-session (hash-set (make-test-config dir bus prov) 'system-instructions instrs)))
+   (define-values (s result) (run-prompt! sess "Write code"))
+
+   ;; Check that the context sent to the provider has a system message first
+   (define ctx (unbox captured-context))
+   (check-not-false ctx "provider should have received context")
+   ;; The first message in context should be a raw hash with role "system"
+   (define first-msg (first ctx))
+   (check-equal? (hash-ref first-msg 'role) "system" "first context message should be system role")
+   ;; The content should contain the instruction text
+   (define first-content (hash-ref first-msg 'content))
+   (check-true (string-contains? first-content "You are a coding expert.")
+               "system message should contain the instruction text")
+
+   ;; The system message should NOT be in the persisted session log
+   (define hist (session-history s))
+   (check-equal? (length hist) 2 "history should only have user + assistant")
+   (check-equal? (message-role (first hist)) 'user)
+   (check-equal? (message-role (second hist)) 'assistant)
+
+   (delete-directory/files dir #:must-exist? #f))
+ ;; ── 16. fork-session copies system-instructions ──
+ (test-case "fork-session copies system-instructions from parent"
+   (define dir (make-temp-dir))
+   (define bus (make-event-bus))
+   (define prov
+     (make-mock-provider
+      (make-model-response (list (hash 'type "text" 'text "hi")) (hash) "mock" 'stop)))
+   (define instrs '("Be helpful." "Be safe."))
+   (define sess
+     (make-agent-session (hash-set (make-test-config dir bus prov) 'system-instructions instrs)))
+   (define forked (fork-session sess))
+   (check-equal? (agent-session-system-instructions forked)
+                 instrs
+                 "forked session should inherit system-instructions")
+   (delete-directory/files dir #:must-exist? #f))
+ ;; ── 17. Session log is reloadable from disk ──
+ (test-case "session log persists to disk and survives object recreation"
+   (define dir (make-temp-dir))
+   (define bus (make-event-bus))
+   (define prov
+     (make-multi-mock-provider
+      (list (make-model-response (list (hash 'type "text" 'text "First")) (hash) "mock" 'stop)
+            (make-model-response (list (hash 'type "text" 'text "Second")) (hash) "mock" 'stop))))
+
+   ;; Create and run
+   (define sess1 (make-agent-session (make-test-config dir bus prov)))
+   (define-values (s1 _) (run-prompt! sess1 "Hello"))
+   (define sid (session-id s1))
+
+   ;; Resume in a new object
+   (define bus2 (make-event-bus))
+   (define sess2 (resume-agent-session sid (make-test-config dir bus2 prov)))
+   (define hist (session-history sess2))
+   (check-equal? (length hist) 2)
+
+   ;; Can continue
+   (define-values (s2 r2) (run-prompt! sess2 "More"))
+   (check-equal? (loop-result-termination-reason r2) 'completed)
+   (check-equal? (length (session-history s2)) 4)
+
+   (delete-directory/files dir #:must-exist? #f))
+ ;; ── 18. turn-start hook dispatched (F2: renamed from before-turn) ──
+ (test-case "run-prompt! dispatches 'turn-start hook when extension-registry present"
+   (define dir (make-temp-dir))
+   (define bus (make-event-bus))
+   (define hook-called? (box #f))
+   (define prov
+     (make-mock-provider
+      (make-model-response (list (hash 'type "text" 'text "hi")) (hash) "mock" 'stop)))
+   (define ext-reg (make-extension-registry))
+   (register-extension! ext-reg
+                        (extension "test-ext"
+                                   "1.0"
+                                   "0.1"
+                                   (hasheq 'turn-start
+                                           (lambda (ctx)
+                                             (set-box! hook-called? #t)
+                                             (hook-pass ctx)))))
+   (define sess
+     (make-agent-session (hash-set (make-test-config dir bus prov) 'extension-registry ext-reg)))
+   (define-values (s result) (run-prompt! sess "hello"))
+   (check-true (unbox hook-called?) "turn-start hook should have been called")
+   (delete-directory/files dir #:must-exist? #f))
+ ;; ── 19. turn-end hook dispatched (F2: renamed from after-turn) ──
+ (test-case "run-prompt! dispatches 'turn-end hook on completed turn"
+   (define dir (make-temp-dir))
+   (define bus (make-event-bus))
+   (define turn-end-called? (box #f))
+   (define prov
+     (make-mock-provider
+      (make-model-response (list (hash 'type "text" 'text "done")) (hash) "mock" 'stop)))
+   (define ext-reg (make-extension-registry))
+   (register-extension! ext-reg
+                        (extension "test-ext"
+                                   "1.0"
+                                   "0.1"
+                                   (hasheq 'turn-end
+                                           (lambda (result)
+                                             (set-box! turn-end-called? #t)
+                                             (hook-pass result)))))
+   (define sess
+     (make-agent-session (hash-set (make-test-config dir bus prov) 'extension-registry ext-reg)))
+   (define-values (s result) (run-prompt! sess "hello"))
+   (check-true (unbox turn-end-called?) "turn-end hook should have been called")
+   (delete-directory/files dir #:must-exist? #f))
+ ;; ── 20. hooks skipped when extension-registry is #f ──
+ (test-case "run-prompt! skips hooks when extension-registry is #f"
+   (define dir (make-temp-dir))
+   (define bus (make-event-bus))
+   (define prov
+     (make-mock-provider
+      (make-model-response (list (hash 'type "text" 'text "ok")) (hash) "mock" 'stop)))
+   ;; No extension-registry — default is #f
+   (define sess (make-agent-session (make-test-config dir bus prov)))
+   ;; Should complete without error even though no registry exists
+   (define-values (s result) (run-prompt! sess "hello"))
+   (check-pred loop-result? result)
+   (check-equal? (loop-result-termination-reason result) 'completed)
+   (delete-directory/files dir #:must-exist? #f))
+ ;; ── F1: tool-result hook amending with non-message values are filtered ──
+ (test-case "tool-result hook amending with non-message values are filtered"
+   (define dir (make-temp-dir))
+   (define bus (make-event-bus))
+   (define reg (make-tool-registry))
+   (register-tool!
+    reg
+    (make-tool "echo"
+               "Echoes input"
+               (hasheq 'type "object" 'properties (hasheq 'msg (hasheq 'type "string")) 'required '())
+               (lambda (args ctx) (make-success-result (list (hasheq 'type "text" 'text "echoed"))))))
+   (define prov
+     (make-multi-mock-provider
+      (list (make-model-response
+             (list (hash 'type "tool-call" 'id "tc-1" 'name "echo" 'arguments (hash 'msg "hi")))
+             (hash)
+             "mock"
+             'tool-calls)
+            (make-model-response (list (hash 'type "text" 'text "Done")) (hash) "mock" 'stop))))
+   (define ext-reg (make-extension-registry))
+   (register-extension! ext-reg
+                        (extension "dirty-ext"
+                                   "1.0"
+                                   "0.1"
+                                   (hasheq 'tool-result
+                                           (lambda (msgs)
+                                             ;; Amend with a mix of valid messages and junk
+                                             (hook-amend (append msgs (list "junk-string" 42)))))))
+   (define sess
+     (make-agent-session (hash-set (make-test-config dir bus prov reg) 'extension-registry ext-reg)))
+   (define-values (s result) (run-prompt! sess "Echo hi"))
+   (check-equal? (loop-result-termination-reason result) 'completed)
+   ;; History: user, assistant(tool-call), tool-result, assistant(text)
+   ;; The junk values should be filtered out — still 4 entries
+   (define hist (session-history s))
+   (check-equal? (length hist) 4)
+   (check-equal? (message-role (list-ref hist 0)) 'user)
+   (check-equal? (message-role (list-ref hist 1)) 'assistant)
+   (check-equal? (message-role (list-ref hist 2)) 'tool)
+   (check-equal? (message-role (list-ref hist 3)) 'assistant)
+   (delete-directory/files dir #:must-exist? #f))
+ ;; ── F6: turn-start 'block skips the turn ──
+ (test-case "turn-start hook 'block skips the turn"
+   (define dir (make-temp-dir))
+   (define bus (make-event-bus))
+   (define evts (make-event-collector bus))
+   (define prov
+     (make-mock-provider
+      (make-model-response (list (hash 'type "text" 'text "should not appear")) (hash) "mock" 'stop)))
+   (define ext-reg (make-extension-registry))
+   (register-extension! ext-reg
+                        (extension "block-ext"
+                                   "1.0"
+                                   "0.1"
+                                   (hasheq 'turn-start
+                                           (lambda (ctx) (hook-block "blocked for testing")))))
+   (define sess
+     (make-agent-session (hash-set (make-test-config dir bus prov) 'extension-registry ext-reg)))
+   (define-values (s result) (run-prompt! sess "hello"))
+   (check-equal? (loop-result-termination-reason result) 'completed)
+   (check-equal? (hash-ref (loop-result-metadata result) 'reason) "extension-block")
+   ;; History should only have user message (no model call)
+   (define hist (session-history s))
+   (check-equal? (length hist) 1)
+   (check-equal? (message-role (first hist)) 'user)
+   ;; turn.blocked event emitted
+   (check-not-false (member "turn.blocked" (event-names evts)))
+   (delete-directory/files dir #:must-exist? #f))
+ ;; ── F2: hook points use BLUEPRINT §7 names ──
+ (test-case "hooks fire on 'turn-start and 'tool-call (BLUEPRINT names)"
+   (define dir (make-temp-dir))
+   (define bus (make-event-bus))
+   (define turn-start-called? (box #f))
+   (define tool-call-called? (box #f))
+   (define reg (make-tool-registry))
+   (register-tool!
+    reg
+    (make-tool "echo"
+               "Echoes input"
+               (hasheq 'type "object" 'properties (hasheq 'msg (hasheq 'type "string")) 'required '())
+               (lambda (args ctx) (make-success-result (list (hasheq 'type "text" 'text "echoed"))))))
+   (define prov
+     (make-multi-mock-provider
+      (list (make-model-response
+             (list (hash 'type "tool-call" 'id "tc-1" 'name "echo" 'arguments (hash 'msg "hi")))
+             (hash)
+             "mock"
+             'tool-calls)
+            (make-model-response (list (hash 'type "text" 'text "Done")) (hash) "mock" 'stop))))
+   (define ext-reg (make-extension-registry))
+   (register-extension! ext-reg
+                        (extension "blueprint-names-ext"
+                                   "1.0"
+                                   "0.1"
+                                   (hasheq 'turn-start
+                                           (lambda (ctx)
+                                             (set-box! turn-start-called? #t)
+                                             (hook-pass ctx))
+                                           'tool-call
+                                           (lambda (tcs)
+                                             (set-box! tool-call-called? #t)
+                                             (hook-pass tcs)))))
+   (define sess
+     (make-agent-session (hash-set (make-test-config dir bus prov reg) 'extension-registry ext-reg)))
+   (define-values (s result) (run-prompt! sess "Echo hi"))
+   (check-true (unbox turn-start-called?) "'turn-start hook should have been called")
+   (check-true (unbox tool-call-called?) "'tool-call hook should have been called")
+   (delete-directory/files dir #:must-exist? #f))
+ ;; ── GAP-5 FIXED: hook exception during dispatch is isolated ──
+ (test-case "hook exception during dispatch is isolated and session continues"
+   (define dir (make-temp-dir))
+   (define bus (make-event-bus))
+   (define prov
+     (make-mock-provider
+      (make-model-response (list (hash 'type "text" 'text "hi")) (hash) "mock" 'stop)))
+   (define ext-reg (make-extension-registry))
+   (register-extension!
+    ext-reg
+    (extension "crashing-ext"
+               "1.0"
+               "0.1"
+               (hasheq 'turn-start (lambda (ctx) (error "crashing-hook" "intentional test error")))))
+   (define sess
+     (make-agent-session (hash-set (make-test-config dir bus prov) 'extension-registry ext-reg)))
+   ;; The crashing handler should be isolated — session should NOT raise
+   (check-not-exn (lambda () (run-prompt! sess "hello"))
+                  "exception in hook should be isolated, not propagate")
+   (delete-directory/files dir #:must-exist? #f))
+ ;; ── WP-35: Cooperative Cancellation Tests ──
+ (test-case "run-prompt! with pre-cancelled token returns 'cancelled"
+   (define dir (make-temp-dir))
+   (define bus (make-event-bus))
+   (define evts (make-event-collector bus))
+   (define tok (make-cancellation-token))
+   (cancel-token! tok) ; pre-cancel
+   (define prov
+     (make-mock-provider
+      (make-model-response (list (hash 'type "text" 'text "should not appear")) (hash) "mock" 'stop)))
+   (define sess
+     (make-agent-session (hash-set (make-test-config dir bus prov) 'cancellation-token tok)))
+   (define-values (s result) (run-prompt! sess "hello"))
+   (check-equal? (loop-result-termination-reason result)
+                 'cancelled
+                 "should return 'cancelled when token is pre-cancelled")
+   ;; No model response in history — only the user message was appended
+   (define hist (session-history s))
+   (check-equal? (length hist) 1 "only user message in history")
+   (check-equal? (message-role (first hist)) 'user)
+   (delete-directory/files dir #:must-exist? #f))
+ (test-case "run-prompt! with pre-cancelled token emits turn.cancelled event"
+   (define dir (make-temp-dir))
+   (define bus (make-event-bus))
+   (define evts (make-event-collector bus))
+   (define tok (make-cancellation-token))
+   (cancel-token! tok)
+   (define prov
+     (make-mock-provider
+      (make-model-response (list (hash 'type "text" 'text "should not appear")) (hash) "mock" 'stop)))
+   (define sess
+     (make-agent-session (hash-set (make-test-config dir bus prov) 'cancellation-token tok)))
+   (define-values (s result) (run-prompt! sess "hello"))
+   (define names (event-names evts))
+   (check-not-false (member "turn.cancelled" names) "turn.cancelled event should be emitted")
+   (delete-directory/files dir #:must-exist? #f))
+ (test-case "run-prompt! token cancelled mid-loop stops after current iteration"
+   (define dir (make-temp-dir))
+   (define bus (make-event-bus))
+   (define evts (make-event-collector bus))
+   (define reg (make-tool-registry))
+   (define tok (make-cancellation-token #:callback (λ (_) (void))))
+
+   ;; Register a tool
+   (register-tool!
+    reg
+    (make-tool "echo"
+               "Echoes input"
+               (hasheq 'type "object" 'properties (hasheq 'msg (hasheq 'type "string")) 'required '())
+               (lambda (args ctx) (make-success-result (list (hasheq 'type "text" 'text "echoed"))))))
+
+   ;; Provider: first turn = tool call, second turn = would-be text (never reached)
+   ;; Cancel the token AFTER the first turn completes (in the tool-call hook)
+   (define turn-count (box 0))
+   (define prov
+     (make-provider
+      (lambda () "cancel-mid-loop")
+      (lambda () (hash 'streaming #t 'token-counting #t))
+      (lambda (req) (make-model-response '() (hash) "mock" 'stop))
+      (lambda (req)
+        (define i (unbox turn-count))
+        (set-box! turn-count (add1 i))
+        (cond
+          [(= i 0)
+           ;; First turn: return a tool call
+           (list (stream-chunk "calling tool" #f #f #f)
+                 (stream-chunk #f (hasheq 'id "tc-1" 'name "echo" 'arguments "{}") #f #f)
+                 (stream-chunk #f #f (hasheq) #t))]
+          ;; Second turn: text response
+          [else (list (stream-chunk "final text" #f #f #f) (stream-chunk #f #f (hasheq) #t))]))))
+
+   ;; Use tool-call hook to cancel the token between iterations
+   (define ext-reg (make-extension-registry))
+   (register-extension! ext-reg
+                        (extension "cancel-ext"
+                                   "1.0"
+                                   "0.1"
+                                   (hasheq 'tool-call
+                                           (lambda (tcs)
+                                             ;; Cancel after first tool call is dispatched
+                                             (cancel-token! tok)
+                                             (hook-pass tcs)))))
+
+   (define sess
+     (make-agent-session (hash 'provider
+                               prov
+                               'tool-registry
+                               reg
+                               'event-bus
+                               bus
+                               'session-dir
+                               dir
+                               'extension-registry
+                               ext-reg
+                               'cancellation-token
+                               tok
+                               'max-iterations
+                               5)))
+
+   (define-values (s result) (run-prompt! sess "trigger tool call"))
+
+   ;; Should have been cancelled after the first iteration completed
+   (check-equal? (loop-result-termination-reason result)
+                 'cancelled
+                 "should terminate with 'cancelled when token cancelled mid-loop")
+   ;; turn.cancelled event emitted
+   (check-not-false (member "turn.cancelled" (event-names evts))
+                    "turn.cancelled event should be emitted")
+   ;; History should have user + assistant(tool-call) + tool-result from first iteration
+   (define hist (session-history s))
+   (check-true (>= (length hist) 3)
+               "should have at least user + assistant + tool-result from first iteration")
+   (delete-directory/files dir #:must-exist? #f))
+ (test-case "run-prompt! with no cancellation token runs normally (backward compat)"
+   (define dir (make-temp-dir))
+   (define bus (make-event-bus))
+   (define prov
+     (make-mock-provider
+      (make-model-response (list (hash 'type "text" 'text "normal response")) (hash) "mock" 'stop)))
+   ;; No cancellation-token in config
+   (define sess (make-agent-session (make-test-config dir bus prov)))
+   (define-values (s result) (run-prompt! sess "hello"))
+   (check-equal? (loop-result-termination-reason result)
+                 'completed
+                 "should complete normally without cancellation token")
+   (define hist (session-history s))
+   (check-equal? (length hist) 2 "user + assistant")
+   (delete-directory/files dir #:must-exist? #f))
+ (test-case "run-prompt! with uncancelled token runs normally"
+   (define dir (make-temp-dir))
+   (define bus (make-event-bus))
+   (define tok (make-cancellation-token)) ; not cancelled
+   (define prov
+     (make-mock-provider
+      (make-model-response (list (hash 'type "text" 'text "normal response")) (hash) "mock" 'stop)))
+   (define sess
+     (make-agent-session (hash-set (make-test-config dir bus prov) 'cancellation-token tok)))
+   (define-values (s result) (run-prompt! sess "hello"))
+   (check-equal? (loop-result-termination-reason result)
+                 'completed
+                 "should complete normally with uncancelled token")
+   (define hist (session-history s))
+   (check-equal? (length hist) 2 "user + assistant")
+   (delete-directory/files dir #:must-exist? #f)))
 
 ;; ============================================================
 ;; extension-registry and model-name wiring
@@ -1063,35 +1003,34 @@
         [bus (make-event-bus)]
         [reg (make-tool-registry)]
         [prov (make-mock-provider
-               (make-model-response
-                (list (hash 'type "text" 'text "hi"))
-                (hash) "mock" 'stop))])
-    (define sess (make-agent-session
-                  (hasheq 'provider prov
-                          'tool-registry reg
-                          'event-bus bus
-                          'session-dir (path->string tmpdir))))
+               (make-model-response (list (hash 'type "text" 'text "hi")) (hash) "mock" 'stop))])
+    (define sess
+      (make-agent-session
+       (hasheq 'provider prov 'tool-registry reg 'event-bus bus 'session-dir (path->string tmpdir))))
     (check-false (agent-session-extension-registry sess)
                  "agent-session: extension-registry defaults to #f")
-    (check-false (agent-session-model-name sess)
-                 "agent-session: model-name defaults to #f")))
+    (check-false (agent-session-model-name sess) "agent-session: model-name defaults to #f")))
 
 (test-case "extension-registry is stored when provided"
   (let ([tmpdir (make-temporary-file "q-session-~a" 'directory)]
         [bus (make-event-bus)]
         [reg (make-tool-registry)]
         [prov (make-mock-provider
-               (make-model-response
-                (list (hash 'type "text" 'text "hi"))
-                (hash) "mock" 'stop))]
+               (make-model-response (list (hash 'type "text" 'text "hi")) (hash) "mock" 'stop))]
         [ext-reg (make-extension-registry)])
-    (define sess (make-agent-session
-                  (hasheq 'provider prov
-                          'tool-registry reg
-                          'event-bus bus
-                          'session-dir (path->string tmpdir)
-                          'extension-registry ext-reg)))
-    (check-pred extension-registry? (agent-session-extension-registry sess)
+    (define sess
+      (make-agent-session (hasheq 'provider
+                                  prov
+                                  'tool-registry
+                                  reg
+                                  'event-bus
+                                  bus
+                                  'session-dir
+                                  (path->string tmpdir)
+                                  'extension-registry
+                                  ext-reg)))
+    (check-pred extension-registry?
+                (agent-session-extension-registry sess)
                 "agent-session: extension-registry stored when provided")))
 
 (test-case "model-name is stored when provided"
@@ -1099,16 +1038,20 @@
         [bus (make-event-bus)]
         [reg (make-tool-registry)]
         [prov (make-mock-provider
-               (make-model-response
-                (list (hash 'type "text" 'text "hi"))
-                (hash) "mock" 'stop))])
-    (define sess (make-agent-session
-                  (hasheq 'provider prov
-                          'tool-registry reg
-                          'event-bus bus
-                          'session-dir (path->string tmpdir)
-                          'model-name "gpt-4o")))
-    (check-equal? (agent-session-model-name sess) "gpt-4o"
+               (make-model-response (list (hash 'type "text" 'text "hi")) (hash) "mock" 'stop))])
+    (define sess
+      (make-agent-session (hasheq 'provider
+                                  prov
+                                  'tool-registry
+                                  reg
+                                  'event-bus
+                                  bus
+                                  'session-dir
+                                  (path->string tmpdir)
+                                  'model-name
+                                  "gpt-4o")))
+    (check-equal? (agent-session-model-name sess)
+                  "gpt-4o"
                   "agent-session: model-name stored when provided")))
 
 (test-case "Both extension-registry and model-name together"
@@ -1116,17 +1059,21 @@
         [bus (make-event-bus)]
         [reg (make-tool-registry)]
         [prov (make-mock-provider
-               (make-model-response
-                (list (hash 'type "text" 'text "hi"))
-                (hash) "mock" 'stop))]
+               (make-model-response (list (hash 'type "text" 'text "hi")) (hash) "mock" 'stop))]
         [ext-reg (make-extension-registry)])
-    (define sess (make-agent-session
-                  (hasheq 'provider prov
-                          'tool-registry reg
-                          'event-bus bus
-                          'session-dir (path->string tmpdir)
-                          'extension-registry ext-reg
-                          'model-name "claude-3")))
+    (define sess
+      (make-agent-session (hasheq 'provider
+                                  prov
+                                  'tool-registry
+                                  reg
+                                  'event-bus
+                                  bus
+                                  'session-dir
+                                  (path->string tmpdir)
+                                  'extension-registry
+                                  ext-reg
+                                  'model-name
+                                  "claude-3")))
     (check-true (extension-registry? (agent-session-extension-registry sess)))
     (check-equal? (agent-session-model-name sess) "claude-3")))
 
@@ -1135,31 +1082,41 @@
         [bus (make-event-bus)]
         [reg (make-tool-registry)]
         [prov (make-mock-provider
-               (make-model-response
-                (list (hash 'type "text" 'text "hi"))
-                (hash) "mock" 'stop))]
+               (make-model-response (list (hash 'type "text" 'text "hi")) (hash) "mock" 'stop))]
         [ext-reg (make-extension-registry)])
     ;; Create a session first
-    (define sess (make-agent-session
-                  (hasheq 'provider prov
-                          'tool-registry reg
-                          'event-bus bus
-                          'session-dir (path->string tmpdir)
-                          'extension-registry ext-reg
-                          'model-name "test-model")))
+    (define sess
+      (make-agent-session (hasheq 'provider
+                                  prov
+                                  'tool-registry
+                                  reg
+                                  'event-bus
+                                  bus
+                                  'session-dir
+                                  (path->string tmpdir)
+                                  'extension-registry
+                                  ext-reg
+                                  'model-name
+                                  "test-model")))
     ;; #771: ensure session directory exists for resume test
     (make-directory* (build-path tmpdir (session-id sess)))
     (with-output-to-file (build-path tmpdir (session-id sess) "session.jsonl") (lambda () (void)))
     (define sid (session-id sess))
     ;; Resume it
-    (define resumed (resume-agent-session
-                     sid
-                     (hasheq 'provider prov
-                             'tool-registry reg
-                             'event-bus bus
-                             'session-dir (path->string tmpdir)
-                             'extension-registry ext-reg
-                             'model-name "test-model")))
+    (define resumed
+      (resume-agent-session sid
+                            (hasheq 'provider
+                                    prov
+                                    'tool-registry
+                                    reg
+                                    'event-bus
+                                    bus
+                                    'session-dir
+                                    (path->string tmpdir)
+                                    'extension-registry
+                                    ext-reg
+                                    'model-name
+                                    "test-model")))
     (check-true (extension-registry? (agent-session-extension-registry resumed)))
     (check-equal? (agent-session-model-name resumed) "test-model")))
 
@@ -1168,29 +1125,38 @@
         [bus (make-event-bus)]
         [reg (make-tool-registry)]
         [prov (make-mock-provider
-               (make-model-response
-                (list (hash 'type "text" 'text "hi"))
-                (hash) "mock" 'stop))]
+               (make-model-response (list (hash 'type "text" 'text "hi")) (hash) "mock" 'stop))]
         [instrs '("System instruction A")])
-    (define sess (make-agent-session
-                  (hasheq 'provider prov
-                          'tool-registry reg
-                          'event-bus bus
-                          'session-dir (path->string tmpdir)
-                          'system-instructions instrs)))
+    (define sess
+      (make-agent-session (hasheq 'provider
+                                  prov
+                                  'tool-registry
+                                  reg
+                                  'event-bus
+                                  bus
+                                  'session-dir
+                                  (path->string tmpdir)
+                                  'system-instructions
+                                  instrs)))
     ;; #771: ensure directory exists for resume test
     (make-directory* (build-path (string->path (path->string tmpdir)) (session-id sess)))
     (with-output-to-file (build-path tmpdir (session-id sess) "session.jsonl") (lambda () (void)))
     (define sid (session-id sess))
     ;; Resume it
-    (define resumed (resume-agent-session
-                     sid
-                     (hasheq 'provider prov
-                             'tool-registry reg
-                             'event-bus bus
-                             'session-dir (path->string tmpdir)
-                             'system-instructions instrs)))
-    (check-equal? (agent-session-system-instructions resumed) instrs
+    (define resumed
+      (resume-agent-session sid
+                            (hasheq 'provider
+                                    prov
+                                    'tool-registry
+                                    reg
+                                    'event-bus
+                                    bus
+                                    'session-dir
+                                    (path->string tmpdir)
+                                    'system-instructions
+                                    instrs)))
+    (check-equal? (agent-session-system-instructions resumed)
+                  instrs
                   "resume-agent-session preserves system-instructions")))
 
 (test-case "fork-session copies extension-registry and model-name"
@@ -1198,17 +1164,21 @@
         [bus (make-event-bus)]
         [reg (make-tool-registry)]
         [prov (make-mock-provider
-               (make-model-response
-                (list (hash 'type "text" 'text "hi"))
-                (hash) "mock" 'stop))]
+               (make-model-response (list (hash 'type "text" 'text "hi")) (hash) "mock" 'stop))]
         [ext-reg (make-extension-registry)])
-    (define sess (make-agent-session
-                  (hasheq 'provider prov
-                          'tool-registry reg
-                          'event-bus bus
-                          'session-dir (path->string tmpdir)
-                          'extension-registry ext-reg
-                          'model-name "fork-model")))
+    (define sess
+      (make-agent-session (hasheq 'provider
+                                  prov
+                                  'tool-registry
+                                  reg
+                                  'event-bus
+                                  bus
+                                  'session-dir
+                                  (path->string tmpdir)
+                                  'extension-registry
+                                  ext-reg
+                                  'model-name
+                                  "fork-model")))
     (define forked (fork-session sess))
     (check-true (extension-registry? (agent-session-extension-registry forked)))
     (check-equal? (agent-session-model-name forked) "fork-model")))
@@ -1219,203 +1189,227 @@
 
 ;; compactor.rkt exports already imported above
 
-(define-test-suite test-tiered-context-suite
+(define-test-suite
+ test-tiered-context-suite
+ ;; ── Helper to create messages with specific properties ──
+ (test-case "build-tiered-context splits messages into three tiers"
+   (define msgs
+     (list
+      ;; Older messages (will be Tier A - compacted)
+      (make-message "id-1" #f 'user 'message (list (make-text-part "Old user 1")) 1000 (hasheq))
+      (make-message "id-2"
+                    "id-1"
+                    'assistant
+                    'message
+                    (list (make-text-part "Old assistant 1"))
+                    1001
+                    (hasheq))
+      ;; Recent messages (Tier B - full)
+      (make-message "id-3" #f 'user 'message (list (make-text-part "Recent user")) 2000 (hasheq))
+      (make-message "id-4"
+                    "id-3"
+                    'assistant
+                    'message
+                    (list (make-text-part "Recent assistant"))
+                    2001
+                    (hasheq))
+      ;; Current turn (Tier C)
+      (make-message "id-5" #f 'user 'message (list (make-text-part "Current user")) 3000 (hasheq))))
 
-  ;; ── Helper to create messages with specific properties ──
-  (test-case "build-tiered-context splits messages into three tiers"
-    (define msgs
-      (list
-       ;; Older messages (will be Tier A - compacted)
-       (make-message "id-1" #f 'user 'message (list (make-text-part "Old user 1")) 1000 (hasheq))
-       (make-message "id-2" "id-1" 'assistant 'message (list (make-text-part "Old assistant 1")) 1001 (hasheq))
-       ;; Recent messages (Tier B - full)
-       (make-message "id-3" #f 'user 'message (list (make-text-part "Recent user")) 2000 (hasheq))
-       (make-message "id-4" "id-3" 'assistant 'message (list (make-text-part "Recent assistant")) 2001 (hasheq))
-       ;; Current turn (Tier C)
-       (make-message "id-5" #f 'user 'message (list (make-text-part "Current user")) 3000 (hasheq))))
+   ;; Compact the older portion to simulate Tier A
+   (define-values (old-msgs recent-msgs) (values (take msgs 2) (drop msgs 2)))
+   (define compact-result (compact-history msgs #:token-config (token-compaction-config 10 0 10)))
+   (define compacted-context (compaction-result->message-list compact-result))
 
-    ;; Compact the older portion to simulate Tier A
-    (define-values (old-msgs recent-msgs) (values (take msgs 2) (drop msgs 2)))
-    (define compact-result (compact-history msgs #:strategy (compaction-strategy 10 2)
-                                           #:token-config (token-compaction-config 10 0 10)))
-    (define compacted-context (compaction-result->message-list compact-result))
+   ;; Now build tiered context
+   (define tiered (build-tiered-context compacted-context #:tier-b-count 2 #:tier-c-count 1))
 
-    ;; Now build tiered context
-    (define tiered (build-tiered-context compacted-context #:tier-b-count 2 #:tier-c-count 1))
+   ;; Tier A should have the summary message
+   (check-equal? (length (tiered-context-tier-a tiered)) 1 "Tier A should have 1 summary message")
+   (check-equal? (message-kind (first (tiered-context-tier-a tiered)))
+                 'compaction-summary
+                 "Tier A should contain compaction-summary message")
 
-    ;; Tier A should have the summary message
-    (check-equal? (length (tiered-context-tier-a tiered)) 1
-                  "Tier A should have 1 summary message")
-    (check-equal? (message-kind (first (tiered-context-tier-a tiered))) 'compaction-summary
-                  "Tier A should contain compaction-summary message")
+   ;; Tier B should have recent messages
+   ;; With token compaction: summary + 3 kept = 4 msgs. Tier C=1, Tier B=2, Tier A=1
+   (check-equal? (length (tiered-context-tier-b tiered))
+                 2
+                 "Tier B should have 2 messages (remaining after Tier C)")
 
-    ;; Tier B should have recent messages
-    ;; With token compaction: summary + 3 kept = 4 msgs. Tier C=1, Tier B=2, Tier A=1
-    (check-equal? (length (tiered-context-tier-b tiered)) 2
-                  "Tier B should have 2 messages (remaining after Tier C)")
+   ;; Tier C should have the most recent message
+   (check-equal? (length (tiered-context-tier-c tiered)) 1 "Tier C should have 1 message")
+   (check-equal? (message-content (first (tiered-context-tier-c tiered)))
+                 (message-content (last msgs))
+                 "Tier C should contain the most recent message"))
+ (test-case "build-tiered-context with no compaction returns empty Tier A"
+   (define msgs
+     (list (make-message "id-1" #f 'user 'message (list (make-text-part "User 1")) 1000 (hasheq))
+           (make-message "id-2"
+                         "id-1"
+                         'assistant
+                         'message
+                         (list (make-text-part "Assistant 1"))
+                         1001
+                         (hasheq))
+           (make-message "id-3" #f 'user 'message (list (make-text-part "User 2")) 1002 (hasheq))))
 
-    ;; Tier C should have the most recent message
-    (check-equal? (length (tiered-context-tier-c tiered)) 1
-                  "Tier C should have 1 message")
-    (check-equal? (message-content (first (tiered-context-tier-c tiered)))
-                  (message-content (last msgs))
-                  "Tier C should contain the most recent message"))
+   ;; Build tiered context without prior compaction
+   (define tiered (build-tiered-context msgs #:tier-b-count 2 #:tier-c-count 1))
 
-  (test-case "build-tiered-context with no compaction returns empty Tier A"
-    (define msgs
-      (list
-       (make-message "id-1" #f 'user 'message (list (make-text-part "User 1")) 1000 (hasheq))
-       (make-message "id-2" "id-1" 'assistant 'message (list (make-text-part "Assistant 1")) 1001 (hasheq))
-       (make-message "id-3" #f 'user 'message (list (make-text-part "User 2")) 1002 (hasheq))))
+   ;; Tier A should be empty (no compaction summaries)
+   (check-equal? (length (tiered-context-tier-a tiered))
+                 0
+                 "Tier A should be empty when no compaction summaries exist")
 
-    ;; Build tiered context without prior compaction
-    (define tiered (build-tiered-context msgs #:tier-b-count 2 #:tier-c-count 1))
+   ;; Tier B should have the older messages
+   (check-equal? (length (tiered-context-tier-b tiered)) 2 "Tier B should have 2 messages")
 
-    ;; Tier A should be empty (no compaction summaries)
-    (check-equal? (length (tiered-context-tier-a tiered)) 0
-                  "Tier A should be empty when no compaction summaries exist")
+   ;; Tier C should have the most recent
+   (check-equal? (length (tiered-context-tier-c tiered)) 1 "Tier C should have 1 message"))
+ (test-case "tiered-context->message-list flattens in correct order"
+   (define tier-a
+     (list (make-message "sum-1"
+                         #f
+                         'system
+                         'compaction-summary
+                         (list (make-text-part "Summary"))
+                         1000
+                         (hasheq))))
+   (define tier-b
+     (list (make-message "id-1" #f 'user 'message (list (make-text-part "Tier B")) 2000 (hasheq))))
+   (define tier-c
+     (list (make-message "id-2" #f 'user 'message (list (make-text-part "Tier C")) 3000 (hasheq))))
 
-    ;; Tier B should have the older messages
-    (check-equal? (length (tiered-context-tier-b tiered)) 2
-                  "Tier B should have 2 messages")
+   (define tiered (tiered-context tier-a tier-b tier-c))
+   (define flat (tiered-context->message-list tiered))
 
-    ;; Tier C should have the most recent
-    (check-equal? (length (tiered-context-tier-c tiered)) 1
-                  "Tier C should have 1 message"))
+   ;; Order should be: Tier A (summary), Tier B (recent), Tier C (current)
+   (check-equal? (length flat) 3)
+   (check-equal? (message-kind (first flat)) 'compaction-summary)
+   (check-equal? (text-part-text (first (message-content (second flat)))) "Tier B")
+   (check-equal? (text-part-text (first (message-content (third flat)))) "Tier C"))
+ (test-case "build-tiered-context respects custom tier boundaries"
+   (define msgs
+     (for/list ([i (in-range 10)])
+       (make-message (format "id-~a" i)
+                     #f
+                     'user
+                     'message
+                     (list (make-text-part (format "Message ~a" i)))
+                     i
+                     (hasheq))))
 
-  (test-case "tiered-context->message-list flattens in correct order"
-    (define tier-a
-      (list (make-message "sum-1" #f 'system 'compaction-summary
-                          (list (make-text-part "Summary")) 1000 (hasheq))))
-    (define tier-b
-      (list (make-message "id-1" #f 'user 'message (list (make-text-part "Tier B")) 2000 (hasheq))))
-    (define tier-c
-      (list (make-message "id-2" #f 'user 'message (list (make-text-part "Tier C")) 3000 (hasheq))))
+   ;; tier-b-count=3, tier-c-count=2
+   (define tiered (build-tiered-context msgs #:tier-b-count 3 #:tier-c-count 2))
 
-    (define tiered (tiered-context tier-a tier-b tier-c))
-    (define flat (tiered-context->message-list tiered))
+   ;; Total: 10 messages, Tier C takes last 2, Tier B takes 3 before that
+   ;; Tier A is empty (no compaction), Tier B has 5, Tier C has 2? No...
+   ;; Actually: Tier B = recent but not current = 3, Tier C = current = 2
+   ;; Remaining = 10 - 3 - 2 = 5 would be Tier A if compacted, but we have no summaries
+   (check-equal? (length (tiered-context-tier-a tiered)) 0)
+   (check-equal? (length (tiered-context-tier-b tiered)) 3 "Tier B should have exactly 3 messages")
+   (check-equal? (length (tiered-context-tier-c tiered)) 2 "Tier C should have exactly 2 messages"))
+ (test-case "build-tiered-context with empty input"
+   (define tiered (build-tiered-context '() #:tier-b-count 5 #:tier-c-count 1))
+   (check-equal? (length (tiered-context-tier-a tiered)) 0)
+   (check-equal? (length (tiered-context-tier-b tiered)) 0)
+   (check-equal? (length (tiered-context-tier-c tiered)) 0))
+ (test-case "build-tiered-context handles messages smaller than tier-c-count"
+   (define msgs
+     (list (make-message "id-1" #f 'user 'message (list (make-text-part "Only")) 1000 (hasheq))))
 
-    ;; Order should be: Tier A (summary), Tier B (recent), Tier C (current)
-    (check-equal? (length flat) 3)
-    (check-equal? (message-kind (first flat)) 'compaction-summary)
-    (check-equal? (text-part-text (first (message-content (second flat)))) "Tier B")
-    (check-equal? (text-part-text (first (message-content (third flat)))) "Tier C"))
+   (define tiered (build-tiered-context msgs #:tier-b-count 5 #:tier-c-count 3))
 
-  (test-case "build-tiered-context respects custom tier boundaries"
-    (define msgs
-      (for/list ([i (in-range 10)])
-        (make-message (format "id-~a" i) #f 'user 'message
-                      (list (make-text-part (format "Message ~a" i)))
-                      i (hasheq))))
-
-    ;; tier-b-count=3, tier-c-count=2
-    (define tiered (build-tiered-context msgs #:tier-b-count 3 #:tier-c-count 2))
-
-    ;; Total: 10 messages, Tier C takes last 2, Tier B takes 3 before that
-    ;; Tier A is empty (no compaction), Tier B has 5, Tier C has 2? No...
-    ;; Actually: Tier B = recent but not current = 3, Tier C = current = 2
-    ;; Remaining = 10 - 3 - 2 = 5 would be Tier A if compacted, but we have no summaries
-    (check-equal? (length (tiered-context-tier-a tiered)) 0)
-    (check-equal? (length (tiered-context-tier-b tiered)) 3
-                  "Tier B should have exactly 3 messages")
-    (check-equal? (length (tiered-context-tier-c tiered)) 2
-                  "Tier C should have exactly 2 messages"))
-
-  (test-case "build-tiered-context with empty input"
-    (define tiered (build-tiered-context '() #:tier-b-count 5 #:tier-c-count 1))
-    (check-equal? (length (tiered-context-tier-a tiered)) 0)
-    (check-equal? (length (tiered-context-tier-b tiered)) 0)
-    (check-equal? (length (tiered-context-tier-c tiered)) 0))
-
-  (test-case "build-tiered-context handles messages smaller than tier-c-count"
-    (define msgs
-      (list (make-message "id-1" #f 'user 'message (list (make-text-part "Only")) 1000 (hasheq))))
-
-    (define tiered (build-tiered-context msgs #:tier-b-count 5 #:tier-c-count 3))
-
-    ;; With only 1 message and tier-c-count=3, all go to Tier C
-    (check-equal? (length (tiered-context-tier-a tiered)) 0)
-    (check-equal? (length (tiered-context-tier-b tiered)) 0)
-    (check-equal? (length (tiered-context-tier-c tiered)) 1)))
+   ;; With only 1 message and tier-c-count=3, all go to Tier C
+   (check-equal? (length (tiered-context-tier-a tiered)) 0)
+   (check-equal? (length (tiered-context-tier-b tiered)) 0)
+   (check-equal? (length (tiered-context-tier-c tiered)) 1)))
 
 ;; ============================================================
 ;; Fork/compact event wiring tests
 ;; ============================================================
 
 (define test-event-wiring-suite
-  (test-suite
-   "event wiring for fork/compact"
+  (test-suite "event wiring for fork/compact"
 
-   (test-case "fork.requested event triggers fork-session"
-     (define bus (make-event-bus))
-     (define tmpdir (make-temp-dir))
-     (define prov (make-mock-provider
-                   (make-model-response
-                    (list (hash 'type "text" 'text "hi"))
-                    (hash) "mock" 'stop)))
-     (define cfg (hasheq 'provider prov
-                         'tool-registry (make-tool-registry)
-                         'event-bus bus
-                         'session-dir tmpdir))
-     (define sess (make-agent-session cfg))
-     ;; Add a user message to the session via run-prompt!
-     (run-prompt! sess "test message")
-     ;; Collect events from fork
-     (define fork-events (box '()))
-     (subscribe! bus (lambda (evt)
-                       (set-box! fork-events (cons evt (unbox fork-events))))
-       #:filter (lambda (e)
-                  (member (event-ev e)
-                          '("session.fork.completed" "session.fork.failed"))))
-     ;; Publish fork.requested with the first user message ID
-     (define history (session-history sess))
-     (define first-msg-id (and (pair? history) (message-id (car history))))
-     (publish! bus (make-event "fork.requested"
-                               1001
-                               (session-id sess) #f
-                               (hasheq 'entry-id (or first-msg-id "unknown"))))
-     ;; Allow thread to process (publish! is synchronous but yield for safety)
-     (sync/timeout 0.5 never-evt)
-     ;; Verify fork completed event was emitted
-     (check-not-equal? (length (unbox fork-events)) 0
-                       "fork.requested should trigger session.fork.completed or session.forked")
-     (close-session! sess)
-     (delete-directory/files tmpdir))
+    (test-case "fork.requested event triggers fork-session"
+      (define bus (make-event-bus))
+      (define tmpdir (make-temp-dir))
+      (define prov
+        (make-mock-provider
+         (make-model-response (list (hash 'type "text" 'text "hi")) (hash) "mock" 'stop)))
+      (define cfg
+        (hasheq 'provider
+                prov
+                'tool-registry
+                (make-tool-registry)
+                'event-bus
+                bus
+                'session-dir
+                tmpdir))
+      (define sess (make-agent-session cfg))
+      ;; Add a user message to the session via run-prompt!
+      (run-prompt! sess "test message")
+      ;; Collect events from fork
+      (define fork-events (box '()))
+      (subscribe! bus
+                  (lambda (evt) (set-box! fork-events (cons evt (unbox fork-events))))
+                  #:filter (lambda (e)
+                             (member (event-ev e) '("session.fork.completed" "session.fork.failed"))))
+      ;; Publish fork.requested with the first user message ID
+      (define history (session-history sess))
+      (define first-msg-id (and (pair? history) (message-id (car history))))
+      (publish! bus
+                (make-event "fork.requested"
+                            1001
+                            (session-id sess)
+                            #f
+                            (hasheq 'entry-id (or first-msg-id "unknown"))))
+      ;; Allow thread to process (publish! is synchronous but yield for safety)
+      (sync/timeout 0.5 never-evt)
+      ;; Verify fork completed event was emitted
+      (check-not-equal? (length (unbox fork-events))
+                        0
+                        "fork.requested should trigger session.fork.completed or session.forked")
+      (close-session! sess)
+      (delete-directory/files tmpdir))
 
-   (test-case "compact.requested event triggers compaction"
-     (define bus (make-event-bus))
-     (define tmpdir (make-temp-dir))
-     (define prov (make-mock-provider
-                   (make-model-response
-                    (list (hash 'type "text" 'text "hi"))
-                    (hash) "mock" 'stop)))
-     (define cfg (hasheq 'provider prov
-                         'tool-registry (make-tool-registry)
-                         'event-bus bus
-                         'session-dir tmpdir))
-     (define sess (make-agent-session cfg))
-     ;; Add messages via run-prompt!
-     (for ([i (in-range 3)])
-       (run-prompt! sess (format "message ~a" i)))
-     ;; Collect events from compact
-     (define compact-events (box '()))
-     (subscribe! bus (lambda (evt)
-                       (set-box! compact-events (cons evt (unbox compact-events))))
-       #:filter (lambda (e)
-                  (member (event-ev e)
-                          '("session.compact.completed" "session.compact.failed"))))
-     ;; Publish compact.requested
-     (publish! bus (make-event "compact.requested"
-                               1001
-                               (session-id sess) #f
-                               (hasheq)))
-     ;; Allow thread to process (publish! is synchronous but yield for safety)
-     (sync/timeout 0.5 never-evt)
-     ;; Verify compact completed event was emitted
-     (check-not-equal? (length (unbox compact-events)) 0
-                       "compact.requested should trigger session.compact.completed")
-     (close-session! sess)
-     (delete-directory/files tmpdir))))
+    (test-case "compact.requested event triggers compaction"
+      (define bus (make-event-bus))
+      (define tmpdir (make-temp-dir))
+      (define prov
+        (make-mock-provider
+         (make-model-response (list (hash 'type "text" 'text "hi")) (hash) "mock" 'stop)))
+      (define cfg
+        (hasheq 'provider
+                prov
+                'tool-registry
+                (make-tool-registry)
+                'event-bus
+                bus
+                'session-dir
+                tmpdir))
+      (define sess (make-agent-session cfg))
+      ;; Add messages via run-prompt!
+      (for ([i (in-range 3)])
+        (run-prompt! sess (format "message ~a" i)))
+      ;; Collect events from compact
+      (define compact-events (box '()))
+      (subscribe! bus
+                  (lambda (evt) (set-box! compact-events (cons evt (unbox compact-events))))
+                  #:filter (lambda (e)
+                             (member (event-ev e)
+                                     '("session.compact.completed" "session.compact.failed"))))
+      ;; Publish compact.requested
+      (publish! bus (make-event "compact.requested" 1001 (session-id sess) #f (hasheq)))
+      ;; Allow thread to process (publish! is synchronous but yield for safety)
+      (sync/timeout 0.5 never-evt)
+      ;; Verify compact completed event was emitted
+      (check-not-equal? (length (unbox compact-events))
+                        0
+                        "compact.requested should trigger session.compact.completed")
+      (close-session! sess)
+      (delete-directory/files tmpdir))))
 
 ;; ============================================================
 ;; Run

--- a/tests/test-compactor.rkt
+++ b/tests/test-compactor.rkt
@@ -126,9 +126,7 @@
 
   (test-case "compact-history reduces message count"
     (define msgs (make-n-messages 30))
-    (define strategy (compaction-strategy 20 5))
     (define result (compact-history msgs
-                                     #:strategy strategy
                                      #:summarize-fn test-summarize
                                      #:token-config tiny-tc))
     ;; With tiny-tc (keep-recent=5 tokens), only ~1 message fits in keep-recent
@@ -140,9 +138,7 @@
 
   (test-case "compact-history summary message is a system message"
     (define msgs (make-n-messages 10))
-    (define strategy (compaction-strategy 8 2))
     (define result (compact-history msgs
-                                     #:strategy strategy
                                      #:summarize-fn test-summarize
                                      #:token-config tiny-tc))
     (define summary (compaction-result-summary-message result))
@@ -151,9 +147,7 @@
 
   (test-case "compact-history summary contains information from summarized messages"
     (define msgs (make-n-messages 10))
-    (define strategy (compaction-strategy 8 2))
     (define result (compact-history msgs
-                                     #:strategy strategy
                                      #:summarize-fn test-summarize
                                      #:token-config tiny-tc))
     (define summary (compaction-result-summary-message result))
@@ -166,9 +160,7 @@
 
   (test-case "compact-history preserves recent messages verbatim"
     (define msgs (make-n-messages 10))
-    (define strategy (compaction-strategy 8 2))
     (define result (compact-history msgs
-                                     #:strategy strategy
                                      #:summarize-fn test-summarize
                                      #:token-config tiny-tc))
     (define kept (compaction-result-kept-messages result))
@@ -180,9 +172,7 @@
   (test-case "compact-history does not modify original messages"
     (define msgs (make-n-messages 10))
     (define msgs-before (map msg-id msgs))
-    (define strategy (compaction-strategy 8 2))
     (compact-history msgs
-                     #:strategy strategy
                      #:summarize-fn test-summarize
                      #:token-config tiny-tc)
     ;; Original list unchanged
@@ -193,9 +183,7 @@
   (test-case "compact-history with too few messages returns identity"
     ;; If total messages <= keep-recent-count, nothing to compact
     (define msgs (make-n-messages 5))
-    (define strategy (compaction-strategy 50 20))
     (define result (compact-history msgs
-                                     #:strategy strategy
                                      #:summarize-fn test-summarize))
     ;; No compaction happens — all messages are "recent"
     (check-equal? (compaction-result-removed-count result) 0)
@@ -205,7 +193,6 @@
 
   (test-case "compact-history with empty messages returns empty result"
     (define result (compact-history '()
-                                     #:strategy (compaction-strategy 50 20)
                                      #:summarize-fn test-summarize))
     (check-equal? (compaction-result-removed-count result) 0)
     (check-equal? (compaction-result-kept-messages result) '())
@@ -213,9 +200,7 @@
 
   (test-case "compact-history produces valid shorter message list"
     (define msgs (make-n-messages 50))
-    (define strategy (compaction-strategy 30 10))
     (define result (compact-history msgs
-                                     #:strategy strategy
                                      #:summarize-fn test-summarize
                                      #:token-config tiny-tc))
     (define compacted-list (compaction-result->message-list result))
@@ -232,11 +217,9 @@
 
   (test-case "custom summarize function is used"
     (define msgs (make-n-messages 10))
-    (define strategy (compaction-strategy 8 2))
     (define (custom-summarize ms)
       (format "CUSTOM: ~a messages summarized" (length ms)))
     (define result (compact-history msgs
-                                     #:strategy strategy
                                      #:summarize-fn custom-summarize
                                      #:token-config tiny-tc))
     (define summary (compaction-result-summary-message result))
@@ -249,9 +232,7 @@
 
   (test-case "compaction-result->message-list returns summary + kept"
     (define msgs (make-n-messages 15))
-    (define strategy (compaction-strategy 10 5))
     (define result (compact-history msgs
-                                     #:strategy strategy
                                      #:summarize-fn test-summarize
                                      #:token-config tiny-tc))
     (define merged (compaction-result->message-list result))
@@ -262,9 +243,7 @@
 
   (test-case "compaction-result->message-list with no compaction returns kept only"
     (define msgs (make-n-messages 5))
-    (define strategy (compaction-strategy 50 20))
     (define result (compact-history msgs
-                                     #:strategy strategy
                                      #:summarize-fn test-summarize))
     (define merged (compaction-result->message-list result))
     (check-equal? (length merged) 5)
@@ -283,9 +262,7 @@
                                               (format "Original ~a" i))))
     ;; Run compaction
     (define msgs (load-session-log path))
-    (define strategy (compaction-strategy 6 4))
     (define result (compact-history msgs
-                                     #:strategy strategy
                                      #:summarize-fn test-summarize
                                      #:token-config tiny-tc))
     ;; Write compaction entry
@@ -308,9 +285,7 @@
     (append-entries! path original-msgs)
     ;; Compact
     (define msgs (load-session-log path))
-    (define strategy (compaction-strategy 6 4))
     (define result (compact-history msgs
-                                     #:strategy strategy
                                      #:summarize-fn test-summarize
                                      #:token-config tiny-tc))
     (write-compaction-entry! path result)
@@ -327,9 +302,7 @@
     (define path (session-path dir))
     (append-entries! path (make-n-messages 10))
     (define msgs (load-session-log path))
-    (define strategy (compaction-strategy 6 4))
     (define result (compact-history msgs
-                                     #:strategy strategy
                                      #:summarize-fn test-summarize
                                      #:token-config tiny-tc))
     (write-compaction-entry! path result)
@@ -344,9 +317,7 @@
     (define path (session-path dir))
     (append-entries! path (make-n-messages 3))
     (define msgs (load-session-log path))
-    (define strategy (compaction-strategy 50 20))
     (define result (compact-history msgs
-                                     #:strategy strategy
                                      #:summarize-fn test-summarize))
     (write-compaction-entry! path result)
     ;; No compaction happened — log should still have 3 entries
@@ -388,9 +359,7 @@
     (define loaded (load-session-log path))
     (check-equal? (length loaded) 30)
     ;; Compact and persist
-    (define strategy (compaction-strategy 20 5))
     (define result (compact-and-persist! loaded path
-                                          #:strategy strategy
                                           #:summarize-fn test-summarize
                                           #:token-config tiny-tc))
     ;; Log should now have 30 originals + 1 compaction summary = 31
@@ -413,9 +382,7 @@
     (for ([m (in-list msgs)])
       (append-entry! path m))
     (define loaded (load-session-log path))
-    (define strategy (compaction-strategy 20 5))
     (define result (compact-and-persist! loaded path
-                                          #:strategy strategy
                                           #:summarize-fn test-summarize
                                           #:token-config tiny-tc))
     (check-pred compaction-result? result)
@@ -432,9 +399,7 @@
     (for ([m (in-list msgs)])
       (append-entry! path m))
     (define loaded (load-session-log path))
-    (define strategy (compaction-strategy 50 20))
     (define result (compact-and-persist! loaded path
-                                          #:strategy strategy
                                           #:summarize-fn test-summarize))
     ;; removed-count is 0, no summary entry written
     (check-equal? (compaction-result-removed-count result) 0)
@@ -450,13 +415,10 @@
 
   (test-case "compact-history-advisory is advisory-only (alias for compact-history)"
     (define msgs (make-n-messages 30))
-    (define strategy (compaction-strategy 20 5))
     (define r1 (compact-history msgs
-                                #:strategy strategy
                                 #:summarize-fn test-summarize
                                 #:token-config tiny-tc))
     (define r2 (compact-history-advisory msgs
-                                          #:strategy strategy
                                           #:summarize-fn test-summarize
                                           #:token-config tiny-tc))
     ;; Both return the same removed-count and kept-count
@@ -482,9 +444,7 @@
     (check-equal? (length entries-before) 10)
     ;; Run advisory compaction
     (define loaded (load-session-log path))
-    (define strategy (compaction-strategy 6 4))
     (compact-history loaded
-                     #:strategy strategy
                      #:summarize-fn test-summarize
                      #:token-config tiny-tc)
     ;; Verify log is unchanged

--- a/tests/test-replay.rkt
+++ b/tests/test-replay.rkt
@@ -23,6 +23,7 @@
          "../runtime/agent-session.rkt"
          "../runtime/session-index.rkt"
          "../runtime/compactor.rkt"
+         (only-in "../runtime/token-compaction.rkt" token-compaction-config)
          "../agent/event-bus.rkt"
          "../llm/model.rkt"
          "../llm/provider.rkt"
@@ -64,7 +65,10 @@
   (build-path dir "session.jsonl"))
 
 (define (make-test-message id parent-id role kind [text "hello"] [timestamp #f])
-  (make-message id parent-id role kind
+  (make-message id
+                parent-id
+                role
+                kind
                 (list (make-text-part text))
                 (or timestamp (current-seconds))
                 (hasheq)))
@@ -94,8 +98,7 @@
 ;; Extract all entry IDs in order from a session log file
 (define (extract-entry-ids path)
   (if (file-exists? path)
-      (let ([entries (load-session-log path)])
-        (map message-id entries))
+      (let ([entries (load-session-log path)]) (map message-id entries))
       '()))
 
 ;; Count total entries in session log
@@ -114,11 +117,8 @@
    (lambda () "mock")
    (lambda () (hash 'streaming #t 'token-counting #t))
    (lambda (req)
-     (make-model-response
-      (list (hash 'type "text" 'text response-text))
-      (hash) "mock" 'stop))
-   (lambda (req)
-     (list (stream-chunk response-text #f #f #t)))))
+     (make-model-response (list (hash 'type "text" 'text response-text)) (hash) "mock" 'stop))
+   (lambda (req) (list (stream-chunk response-text #f #f #t)))))
 
 ;; ============================================================
 ;; Session Tree Generator (deterministic)
@@ -143,9 +143,13 @@
         (define role (random-choice rng '(user assistant tool system)))
         (define kind (random-choice rng '(message tool-result compaction-summary)))
         (set! counter (add1 counter))
-        (define msg (make-test-message id parent-id role kind
-                                       (format "Message ~a at depth ~a" id depth)
-                                       (+ 1000000 counter)))
+        (define msg
+          (make-test-message id
+                             parent-id
+                             role
+                             kind
+                             (format "Message ~a at depth ~a" id depth)
+                             (+ 1000000 counter)))
         (set! messages (cons msg messages))
         ;; Recursively generate children for this node
         (gen-branch id (add1 depth)))))
@@ -168,9 +172,8 @@
   (for ([i (in-range length)])
     (define id (format "chain-~a" i))
     (define role (if (even? i) 'user 'assistant))
-    (define msg (make-test-message id parent-id role 'message
-                                   (format "Chain message ~a" i)
-                                   (+ 1000000 i)))
+    (define msg
+      (make-test-message id parent-id role 'message (format "Chain message ~a" i) (+ 1000000 i)))
     (set! messages (cons msg messages))
     (set! parent-id id))
   (reverse messages))
@@ -201,9 +204,13 @@
       (define id (next-id))
       (set! counter (add1 counter))
       (define role (random-choice rng '(user assistant)))
-      (define msg (make-test-message id fork-parent role 'message
-                                     (format "Fork ~a branch ~a" f i)
-                                     (+ 1000000 counter)))
+      (define msg
+        (make-test-message id
+                           fork-parent
+                           role
+                           'message
+                           (format "Fork ~a branch ~a" f i)
+                           (+ 1000000 counter)))
       (set! new-children (cons id new-children))
       (set! messages (cons msg messages)))
     ;; Add new children as potential future fork points
@@ -216,635 +223,608 @@
 ;; ============================================================
 
 (define-test-suite test-property-replay-reconstructs-tree
+                   (test-case "PROPERTY: replay preserves empty session tree"
+                     (define rng (make-seeded-rng SEED-1))
+                     (define dir (make-temp-dir))
+                     (define path (session-path dir))
 
-  (test-case "PROPERTY: replay preserves empty session tree"
-    (define rng (make-seeded-rng SEED-1))
-    (define dir (make-temp-dir))
-    (define path (session-path dir))
+                     ;; Empty session
+                     (define original-tree (build-visible-tree '()))
+                     (define replayed (replay-session path))
+                     (define replayed-tree (build-visible-tree replayed))
 
-    ;; Empty session
-    (define original-tree (build-visible-tree '()))
-    (define replayed (replay-session path))
-    (define replayed-tree (build-visible-tree replayed))
+                     (check-true (trees-equivalent? original-tree replayed-tree)
+                                 "Empty session tree should be preserved after replay")
+                     (delete-directory/files dir #:must-exist? #f))
+                   (test-case "PROPERTY: replay preserves linear chain tree structure"
+                     (define rng (make-seeded-rng SEED-1))
+                     (define dir (make-temp-dir))
+                     (define path (session-path dir))
 
-    (check-true (trees-equivalent? original-tree replayed-tree)
-                "Empty session tree should be preserved after replay")
-    (delete-directory/files dir #:must-exist? #f))
+                     ;; Generate deterministic linear chain
+                     (define messages (generate-linear-chain rng 10))
+                     (append-entries! path messages)
 
-  (test-case "PROPERTY: replay preserves linear chain tree structure"
-    (define rng (make-seeded-rng SEED-1))
-    (define dir (make-temp-dir))
-    (define path (session-path dir))
+                     ;; Build original tree
+                     (define original-tree (build-visible-tree messages))
 
-    ;; Generate deterministic linear chain
-    (define messages (generate-linear-chain rng 10))
-    (append-entries! path messages)
+                     ;; Replay and rebuild tree
+                     (define replayed (replay-session path))
+                     (define replayed-tree (build-visible-tree replayed))
 
-    ;; Build original tree
-    (define original-tree (build-visible-tree messages))
+                     (check-true (trees-equivalent? original-tree replayed-tree)
+                                 "Linear chain tree should be preserved after replay")
+                     (check-equal? (length replayed) (length messages))
+                     (delete-directory/files dir #:must-exist? #f))
+                   (test-case "PROPERTY: replay preserves forked session tree structure"
+                     (define rng (make-seeded-rng SEED-2))
+                     (define dir (make-temp-dir))
+                     (define path (session-path dir))
 
-    ;; Replay and rebuild tree
-    (define replayed (replay-session path))
-    (define replayed-tree (build-visible-tree replayed))
+                     ;; Generate deterministic forked session
+                     (define messages (generate-forked-session rng 5 3))
+                     (append-entries! path messages)
 
-    (check-true (trees-equivalent? original-tree replayed-tree)
-                "Linear chain tree should be preserved after replay")
-    (check-equal? (length replayed) (length messages))
-    (delete-directory/files dir #:must-exist? #f))
+                     ;; Build original tree
+                     (define original-tree (build-visible-tree messages))
 
-  (test-case "PROPERTY: replay preserves forked session tree structure"
-    (define rng (make-seeded-rng SEED-2))
-    (define dir (make-temp-dir))
-    (define path (session-path dir))
+                     ;; Replay and rebuild tree
+                     (define replayed (replay-session path))
+                     (define replayed-tree (build-visible-tree replayed))
 
-    ;; Generate deterministic forked session
-    (define messages (generate-forked-session rng 5 3))
-    (append-entries! path messages)
+                     (check-true (trees-equivalent? original-tree replayed-tree)
+                                 "Forked session tree should be preserved after replay")
+                     (check-equal? (length replayed) (length messages))
+                     (delete-directory/files dir #:must-exist? #f))
+                   (test-case "PROPERTY: replay preserves complex random tree structure"
+                     (define rng (make-seeded-rng SEED-3))
+                     (define dir (make-temp-dir))
+                     (define path (session-path dir))
 
-    ;; Build original tree
-    (define original-tree (build-visible-tree messages))
+                     ;; Generate deterministic complex tree
+                     (define messages (generate-session-tree rng 5 3))
+                     (append-entries! path messages)
 
-    ;; Replay and rebuild tree
-    (define replayed (replay-session path))
-    (define replayed-tree (build-visible-tree replayed))
+                     ;; Build original tree
+                     (define original-tree (build-visible-tree messages))
 
-    (check-true (trees-equivalent? original-tree replayed-tree)
-                "Forked session tree should be preserved after replay")
-    (check-equal? (length replayed) (length messages))
-    (delete-directory/files dir #:must-exist? #f))
+                     ;; Replay and rebuild tree
+                     (define replayed (replay-session path))
+                     (define replayed-tree (build-visible-tree replayed))
 
-  (test-case "PROPERTY: replay preserves complex random tree structure"
-    (define rng (make-seeded-rng SEED-3))
-    (define dir (make-temp-dir))
-    (define path (session-path dir))
+                     (check-true (trees-equivalent? original-tree replayed-tree)
+                                 "Complex session tree should be preserved after replay")
+                     (check-equal? (length replayed) (length messages))
+                     (delete-directory/files dir #:must-exist? #f))
+                   (test-case "PROPERTY: multiple replays produce identical results"
+                     (define rng (make-seeded-rng SEED-4))
+                     (define dir (make-temp-dir))
+                     (define path (session-path dir))
 
-    ;; Generate deterministic complex tree
-    (define messages (generate-session-tree rng 5 3))
-    (append-entries! path messages)
+                     ;; Generate and write session
+                     (define messages (generate-session-tree rng 4 2))
+                     (append-entries! path messages)
 
-    ;; Build original tree
-    (define original-tree (build-visible-tree messages))
+                     ;; Multiple replays should produce identical results
+                     (define replay1 (replay-session path))
+                     (define replay2 (replay-session path))
+                     (define replay3 (load-session-log path))
 
-    ;; Replay and rebuild tree
-    (define replayed (replay-session path))
-    (define replayed-tree (build-visible-tree replayed))
+                     (check-equal? (map message-id replay1) (map message-id replay2))
+                     (check-equal? (map message-id replay2) (map message-id replay3))
+                     (delete-directory/files dir #:must-exist? #f))
+                   (test-case "PROPERTY: replay preserves parent-child relationships"
+                     (define rng (make-seeded-rng SEED-1))
+                     (define dir (make-temp-dir))
+                     (define path (session-path dir))
 
-    (check-true (trees-equivalent? original-tree replayed-tree)
-                "Complex session tree should be preserved after replay")
-    (check-equal? (length replayed) (length messages))
-    (delete-directory/files dir #:must-exist? #f))
+                     ;; Generate session with known parent relationships
+                     (define messages (generate-forked-session rng 3 2))
+                     (append-entries! path messages)
 
-  (test-case "PROPERTY: multiple replays produce identical results"
-    (define rng (make-seeded-rng SEED-4))
-    (define dir (make-temp-dir))
-    (define path (session-path dir))
+                     (define replayed (replay-session path))
 
-    ;; Generate and write session
-    (define messages (generate-session-tree rng 4 2))
-    (append-entries! path messages)
-
-    ;; Multiple replays should produce identical results
-    (define replay1 (replay-session path))
-    (define replay2 (replay-session path))
-    (define replay3 (load-session-log path))
-
-    (check-equal? (map message-id replay1) (map message-id replay2))
-    (check-equal? (map message-id replay2) (map message-id replay3))
-    (delete-directory/files dir #:must-exist? #f))
-
-  (test-case "PROPERTY: replay preserves parent-child relationships"
-    (define rng (make-seeded-rng SEED-1))
-    (define dir (make-temp-dir))
-    (define path (session-path dir))
-
-    ;; Generate session with known parent relationships
-    (define messages (generate-forked-session rng 3 2))
-    (append-entries! path messages)
-
-    (define replayed (replay-session path))
-
-    ;; Check each message preserves its parent
-    (for ([orig (in-list messages)]
-          [repl (in-list replayed)])
-      (check-equal? (message-id repl) (message-id orig))
-      (check-equal? (message-parent-id repl) (message-parent-id orig)))
-    (delete-directory/files dir #:must-exist? #f))
-  )
+                     ;; Check each message preserves its parent
+                     (for ([orig (in-list messages)]
+                           [repl (in-list replayed)])
+                       (check-equal? (message-id repl) (message-id orig))
+                       (check-equal? (message-parent-id repl) (message-parent-id orig)))
+                     (delete-directory/files dir #:must-exist? #f)))
 
 ;; ============================================================
 ;; Property 2: append-only invariant (never rewrites prior entries)
 ;; ============================================================
 
-(define-test-suite test-property-append-only-invariant
+(define-test-suite
+ test-property-append-only-invariant
+ (test-case "PROPERTY: append-entry! only adds entries, never modifies existing"
+   (define dir (make-temp-dir))
+   (define path (session-path dir))
 
-  (test-case "PROPERTY: append-entry! only adds entries, never modifies existing"
-    (define dir (make-temp-dir))
-    (define path (session-path dir))
+   ;; Initial entries with deterministic IDs
+   (define msgs-1
+     (list (make-test-message "append-test-0" #f 'user 'message "First" 1000)
+           (make-test-message "append-test-1" "append-test-0" 'assistant 'message "Second" 1001)
+           (make-test-message "append-test-2" "append-test-1" 'user 'message "Third" 1002)))
+   (append-entries! path msgs-1)
 
-    ;; Initial entries with deterministic IDs
-    (define msgs-1 (list
-      (make-test-message "append-test-0" #f 'user 'message "First" 1000)
-      (make-test-message "append-test-1" "append-test-0" 'assistant 'message "Second" 1001)
-      (make-test-message "append-test-2" "append-test-1" 'user 'message "Third" 1002)))
-    (append-entries! path msgs-1)
+   ;; Capture state after first write
+   (define content-1 (get-file-content path))
+   (define ids-1 (extract-entry-ids path))
 
-    ;; Capture state after first write
-    (define content-1 (get-file-content path))
-    (define ids-1 (extract-entry-ids path))
+   ;; Append more entries
+   (define msgs-2
+     (list (make-test-message "append-test-3" "append-test-2" 'assistant 'message "Fourth" 1003)
+           (make-test-message "append-test-4" "append-test-3" 'user 'message "Fifth" 1004)))
 
-    ;; Append more entries
-    (define msgs-2 (list
-      (make-test-message "append-test-3" "append-test-2" 'assistant 'message "Fourth" 1003)
-      (make-test-message "append-test-4" "append-test-3" 'user 'message "Fifth" 1004)))
+   (for ([m (in-list msgs-2)])
+     (append-entry! path m))
 
-    (for ([m (in-list msgs-2)])
-      (append-entry! path m))
+   ;; Verify original entries unchanged
+   (define ids-2 (extract-entry-ids path))
+   (check-equal? (take ids-2 (length ids-1)) ids-1 "Original entry IDs should be unchanged")
+   (check-true (string-prefix? (get-file-content path) content-1)
+               "File should start with original content")
+   (delete-directory/files dir #:must-exist? #f))
+ (test-case "PROPERTY: append-entries! is atomic and append-only"
+   (define rng (make-seeded-rng SEED-2))
+   (define dir (make-temp-dir))
+   (define path (session-path dir))
 
-    ;; Verify original entries unchanged
-    (define ids-2 (extract-entry-ids path))
-    (check-equal? (take ids-2 (length ids-1)) ids-1
-                  "Original entry IDs should be unchanged")
-    (check-true (string-prefix? (get-file-content path) content-1)
-                "File should start with original content")
-    (delete-directory/files dir #:must-exist? #f))
+   ;; First batch
+   (define msgs-1 (generate-session-tree rng 3 2))
+   (append-entries! path msgs-1)
+   (define count-1 (count-entries path))
 
-  (test-case "PROPERTY: append-entries! is atomic and append-only"
-    (define rng (make-seeded-rng SEED-2))
-    (define dir (make-temp-dir))
-    (define path (session-path dir))
+   ;; Second batch
+   (define msgs-2 (generate-session-tree rng 2 2))
+   (append-entries! path msgs-2)
+   (define count-2 (count-entries path))
 
-    ;; First batch
-    (define msgs-1 (generate-session-tree rng 3 2))
-    (append-entries! path msgs-1)
-    (define count-1 (count-entries path))
+   ;; Total should be sum (append-only)
+   (check-equal? count-2 (+ count-1 (length msgs-2)) "Total entries should equal sum of batches")
+   (delete-directory/files dir #:must-exist? #f))
+ (test-case "PROPERTY: file size monotonically increases with appends"
+   (define dir (make-temp-dir))
+   (define path (session-path dir))
 
-    ;; Second batch
-    (define msgs-2 (generate-session-tree rng 2 2))
-    (append-entries! path msgs-2)
-    (define count-2 (count-entries path))
+   (define sizes '())
 
-    ;; Total should be sum (append-only)
-    (check-equal? count-2 (+ count-1 (length msgs-2))
-                  "Total entries should equal sum of batches")
-    (delete-directory/files dir #:must-exist? #f))
+   ;; Record size after each append
+   (for ([i (in-range 5)])
+     (define msgs
+       (list (make-test-message (format "size-test-~a" i)
+                                (if (= i 0)
+                                    #f
+                                    (format "size-test-~a" (sub1 i)))
+                                'user
+                                'message)))
+     (append-entries! path msgs)
+     (set! sizes (cons (file-size path) sizes)))
 
-  (test-case "PROPERTY: file size monotonically increases with appends"
-    (define dir (make-temp-dir))
-    (define path (session-path dir))
+   ;; Verify monotonic increase
+   (define sizes-ascending (reverse sizes))
+   (for ([a (in-list sizes-ascending)]
+         [b (in-list (cdr sizes-ascending))])
+     (check-true (> b a) (format "File size should increase: ~a -> ~a" a b)))
+   (delete-directory/files dir #:must-exist? #f))
+ (test-case "PROPERTY: entry IDs remain unique after multiple appends"
+   (define dir (make-temp-dir))
+   (define path (session-path dir))
 
-    (define sizes '())
+   ;; Append multiple batches with manually unique IDs
+   (for ([batch (in-range 3)])
+     (define msgs
+       (for/list ([i (in-range 5)])
+         (make-test-message (format "unique-id-~a-~a" batch i)
+                            (if (and (= batch 0) (= i 0))
+                                #f
+                                (format "unique-id-~a-~a"
+                                        (if (= i 0)
+                                            (sub1 batch)
+                                            batch)
+                                        (if (= i 0)
+                                            4
+                                            (sub1 i))))
+                            'user
+                            'message
+                            (format "Batch ~a message ~a" batch i)
+                            (+ 1000000 (* batch 100) i))))
+     (append-entries! path msgs))
 
-    ;; Record size after each append
-    (for ([i (in-range 5)])
-      (define msgs (list (make-test-message (format "size-test-~a" i)
-                                            (if (= i 0) #f (format "size-test-~a" (sub1 i)))
-                                            'user 'message)))
-      (append-entries! path msgs)
-      (set! sizes (cons (file-size path) sizes)))
+   ;; Check all IDs are unique
+   (define all-ids (extract-entry-ids path))
+   (check-equal? (length all-ids) 15)
+   (check-equal? (length all-ids) (length (remove-duplicates all-ids)))
+   (delete-directory/files dir #:must-exist? #f))
+ (test-case "PROPERTY: corruption cannot happen via normal append operations"
+   (define dir (make-temp-dir))
+   (define path (session-path dir))
 
-    ;; Verify monotonic increase
-    (define sizes-ascending (reverse sizes))
-    (for ([a (in-list sizes-ascending)]
-          [b (in-list (cdr sizes-ascending))])
-      (check-true (> b a)
-                  (format "File size should increase: ~a -> ~a" a b)))
-    (delete-directory/files dir #:must-exist? #f))
+   ;; Append many entries
+   (for ([i (in-range 50)])
+     (define msg
+       (make-test-message (format "corrupt-test-~a" i)
+                          (if (= i 0)
+                              #f
+                              (format "corrupt-test-~a" (sub1 i)))
+                          'user
+                          'message))
+     (append-entry! path msg))
 
-  (test-case "PROPERTY: entry IDs remain unique after multiple appends"
-    (define dir (make-temp-dir))
-    (define path (session-path dir))
-
-    ;; Append multiple batches with manually unique IDs
-    (for ([batch (in-range 3)])
-      (define msgs
-        (for/list ([i (in-range 5)])
-          (make-test-message
-            (format "unique-id-~a-~a" batch i)
-            (if (and (= batch 0) (= i 0))
-                #f
-                (format "unique-id-~a-~a" (if (= i 0) (sub1 batch) batch) (if (= i 0) 4 (sub1 i))))
-            'user 'message
-            (format "Batch ~a message ~a" batch i)
-            (+ 1000000 (* batch 100) i))))
-      (append-entries! path msgs))
-
-    ;; Check all IDs are unique
-    (define all-ids (extract-entry-ids path))
-    (check-equal? (length all-ids) 15)
-    (check-equal? (length all-ids) (length (remove-duplicates all-ids)))
-    (delete-directory/files dir #:must-exist? #f))
-
-  (test-case "PROPERTY: corruption cannot happen via normal append operations"
-    (define dir (make-temp-dir))
-    (define path (session-path dir))
-
-    ;; Append many entries
-    (for ([i (in-range 50)])
-      (define msg (make-test-message (format "corrupt-test-~a" i)
-                                     (if (= i 0) #f (format "corrupt-test-~a" (sub1 i)))
-                                     'user 'message))
-      (append-entry! path msg))
-
-    ;; Verify integrity
-    (define report (verify-session-integrity path))
-    (check-equal? (hash-ref report 'invalid-entries) '())
-    (check-false (hash-ref report 'truncated-at-end?))
-    (check-true (hash-ref report 'entry-order-valid?))
-    (delete-directory/files dir #:must-exist? #f))
-  )
+   ;; Verify integrity
+   (define report (verify-session-integrity path))
+   (check-equal? (hash-ref report 'invalid-entries) '())
+   (check-false (hash-ref report 'truncated-at-end?))
+   (check-true (hash-ref report 'entry-order-valid?))
+   (delete-directory/files dir #:must-exist? #f)))
 
 ;; ============================================================
 ;; Property 3: fork produces valid branch
 ;; ============================================================
 
-(define-test-suite test-property-fork-produces-valid-branch
+(define-test-suite
+ test-property-fork-produces-valid-branch
+ (test-case "PROPERTY: fork at specific point creates valid partial branch"
+   (define dir (make-temp-dir))
+   (define bus (make-event-bus))
+   (define prov (make-mock-provider-for-replay "fork test"))
 
-  (test-case "PROPERTY: fork at specific point creates valid partial branch"
-    (define dir (make-temp-dir))
-    (define bus (make-event-bus))
-    (define prov (make-mock-provider-for-replay "fork test"))
+   ;; Create original session
+   (define config
+     (hash 'provider prov 'tool-registry (make-tool-registry) 'event-bus bus 'session-dir dir))
+   (define orig-session (make-agent-session config))
 
-    ;; Create original session
-    (define config (hash 'provider prov
-                        'tool-registry (make-tool-registry)
-                        'event-bus bus
-                        'session-dir dir))
-    (define orig-session (make-agent-session config))
+   ;; Add some messages with deterministic IDs
+   (define messages
+     (list (make-test-message "fork-test-0" #f 'system 'message "Root" 1000)
+           (make-test-message "fork-test-1" "fork-test-0" 'user 'message "First" 1001)
+           (make-test-message "fork-test-2" "fork-test-1" 'assistant 'message "Second" 1002)
+           (make-test-message "fork-test-3" "fork-test-2" 'user 'message "Third" 1003)
+           (make-test-message "fork-test-4" "fork-test-3" 'assistant 'message "Fourth" 1004)))
+   (define log-path (build-path (agent-session-session-dir orig-session) "session.jsonl"))
+   (append-entries! log-path messages)
 
-    ;; Add some messages with deterministic IDs
-    (define messages (list
-      (make-test-message "fork-test-0" #f 'system 'message "Root" 1000)
-      (make-test-message "fork-test-1" "fork-test-0" 'user 'message "First" 1001)
-      (make-test-message "fork-test-2" "fork-test-1" 'assistant 'message "Second" 1002)
-      (make-test-message "fork-test-3" "fork-test-2" 'user 'message "Third" 1003)
-      (make-test-message "fork-test-4" "fork-test-3" 'assistant 'message "Fourth" 1004)))
-    (define log-path (build-path (agent-session-session-dir orig-session) "session.jsonl"))
-    (append-entries! log-path messages)
+   ;; Fork at middle point (index 3 = 4th message)
+   (define fork-point-id "fork-test-3")
+   (define forked-session (fork-session orig-session fork-point-id))
 
-    ;; Fork at middle point (index 3 = 4th message)
-    (define fork-point-id "fork-test-3")
-    (define forked-session (fork-session orig-session fork-point-id))
+   ;; Verify fork has correct subset (4 messages: 0,1,2,3)
+   (define forked-history (session-history forked-session))
+   (check-equal? (length forked-history) 4)
 
-    ;; Verify fork has correct subset (4 messages: 0,1,2,3)
-    (define forked-history (session-history forked-session))
-    (check-equal? (length forked-history) 4)
+   ;; Verify IDs match original up to fork point
+   (for ([i (in-range 4)])
+     (check-equal? (message-id (list-ref forked-history i)) (message-id (list-ref messages i))))
 
-    ;; Verify IDs match original up to fork point
-    (for ([i (in-range 4)])
-      (check-equal? (message-id (list-ref forked-history i))
-                    (message-id (list-ref messages i))))
+   ;; Verify fork has new session ID
+   (check-not-equal? (session-id forked-session) (session-id orig-session))
+   (delete-directory/files dir #:must-exist? #f))
+ (test-case "PROPERTY: fork preserves tree structure of partial history"
+   (define dir (make-temp-dir))
+   (define bus (make-event-bus))
+   (define prov (make-mock-provider-for-replay "fork tree"))
 
-    ;; Verify fork has new session ID
-    (check-not-equal? (session-id forked-session) (session-id orig-session))
-    (delete-directory/files dir #:must-exist? #f))
+   (define config
+     (hash 'provider prov 'tool-registry (make-tool-registry) 'event-bus bus 'session-dir dir))
+   (define orig-session (make-agent-session config))
 
-  (test-case "PROPERTY: fork preserves tree structure of partial history"
-    (define dir (make-temp-dir))
-    (define bus (make-event-bus))
-    (define prov (make-mock-provider-for-replay "fork tree"))
+   ;; Create deterministic forked session structure
+   ;; Root -> A, B; A -> C, D
+   (define messages
+     (list (make-test-message "fork-tree-root" #f 'system 'message "Root" 1000)
+           (make-test-message "fork-tree-a" "fork-tree-root" 'user 'message "A" 1001)
+           (make-test-message "fork-tree-b" "fork-tree-root" 'assistant 'message "B" 1002)
+           (make-test-message "fork-tree-c" "fork-tree-a" 'user 'message "C" 1003)
+           (make-test-message "fork-tree-d" "fork-tree-a" 'assistant 'message "D" 1004)))
+   (define log-path (build-path (agent-session-session-dir orig-session) "session.jsonl"))
+   (append-entries! log-path messages)
 
-    (define config (hash 'provider prov
-                        'tool-registry (make-tool-registry)
-                        'event-bus bus
-                        'session-dir dir))
-    (define orig-session (make-agent-session config))
+   ;; Build original tree
+   (define original-tree (build-visible-tree messages))
 
-    ;; Create deterministic forked session structure
-    ;; Root -> A, B; A -> C, D
-    (define messages (list
-      (make-test-message "fork-tree-root" #f 'system 'message "Root" 1000)
-      (make-test-message "fork-tree-a" "fork-tree-root" 'user 'message "A" 1001)
-      (make-test-message "fork-tree-b" "fork-tree-root" 'assistant 'message "B" 1002)
-      (make-test-message "fork-tree-c" "fork-tree-a" 'user 'message "C" 1003)
-      (make-test-message "fork-tree-d" "fork-tree-a" 'assistant 'message "D" 1004)))
-    (define log-path (build-path (agent-session-session-dir orig-session) "session.jsonl"))
-    (append-entries! log-path messages)
+   ;; Fork at "fork-tree-a" (index 1) - should preserve root and A
+   (define forked (fork-session orig-session "fork-tree-a"))
+   (define forked-history (session-history forked))
+   (define forked-tree (build-visible-tree forked-history))
 
-    ;; Build original tree
-    (define original-tree (build-visible-tree messages))
+   ;; Forked tree should have root->A relationship preserved
+   (check-not-false (member "fork-tree-a" (hash-ref forked-tree "fork-tree-root" '())))
 
-    ;; Fork at "fork-tree-a" (index 1) - should preserve root and A
-    (define forked (fork-session orig-session "fork-tree-a"))
-    (define forked-history (session-history forked))
-    (define forked-tree (build-visible-tree forked-history))
+   ;; All nodes in fork should have same children as original (if within fork)
+   (check-equal? (hash-ref forked-tree "fork-tree-root" '()) (list "fork-tree-a"))
+   (delete-directory/files dir #:must-exist? #f))
+ (test-case "PROPERTY: fork at non-existent point copies all entries"
+   (define rng (make-seeded-rng SEED-3))
+   (define dir (make-temp-dir))
+   (define bus (make-event-bus))
+   (define prov (make-mock-provider-for-replay "fork all"))
 
-    ;; Forked tree should have root->A relationship preserved
-    (check-not-false (member "fork-tree-a" (hash-ref forked-tree "fork-tree-root" '())))
+   (define config
+     (hash 'provider prov 'tool-registry (make-tool-registry) 'event-bus bus 'session-dir dir))
+   (define orig-session (make-agent-session config))
 
-    ;; All nodes in fork should have same children as original (if within fork)
-    (check-equal? (hash-ref forked-tree "fork-tree-root" '())
-                  (list "fork-tree-a"))
-    (delete-directory/files dir #:must-exist? #f))
+   (define messages (generate-linear-chain rng 5))
+   (define log-path (build-path (agent-session-session-dir orig-session) "session.jsonl"))
+   (append-entries! log-path messages)
 
-  (test-case "PROPERTY: fork at non-existent point copies all entries"
-    (define rng (make-seeded-rng SEED-3))
-    (define dir (make-temp-dir))
-    (define bus (make-event-bus))
-    (define prov (make-mock-provider-for-replay "fork all"))
+   ;; Fork at non-existent ID
+   (define forked (fork-session orig-session "non-existent-id"))
+   (define forked-history (session-history forked))
 
-    (define config (hash 'provider prov
-                        'tool-registry (make-tool-registry)
-                        'event-bus bus
-                        'session-dir dir))
-    (define orig-session (make-agent-session config))
+   ;; Should have all messages
+   (check-equal? (length forked-history) (length messages))
+   (delete-directory/files dir #:must-exist? #f))
+ (test-case "PROPERTY: fork without point copies full history"
+   (define rng (make-seeded-rng SEED-4))
+   (define dir (make-temp-dir))
+   (define bus (make-event-bus))
+   (define prov (make-mock-provider-for-replay "fork full"))
 
-    (define messages (generate-linear-chain rng 5))
-    (define log-path (build-path (agent-session-session-dir orig-session) "session.jsonl"))
-    (append-entries! log-path messages)
+   (define config
+     (hash 'provider prov 'tool-registry (make-tool-registry) 'event-bus bus 'session-dir dir))
+   (define orig-session (make-agent-session config))
 
-    ;; Fork at non-existent ID
-    (define forked (fork-session orig-session "non-existent-id"))
-    (define forked-history (session-history forked))
+   (define messages (generate-session-tree rng 3 2))
+   (define log-path (build-path (agent-session-session-dir orig-session) "session.jsonl"))
+   (append-entries! log-path messages)
 
-    ;; Should have all messages
-    (check-equal? (length forked-history) (length messages))
-    (delete-directory/files dir #:must-exist? #f))
+   ;; Fork without specifying point
+   (define forked (fork-session orig-session))
+   (define forked-history (session-history forked))
 
-  (test-case "PROPERTY: fork without point copies full history"
-    (define rng (make-seeded-rng SEED-4))
-    (define dir (make-temp-dir))
-    (define bus (make-event-bus))
-    (define prov (make-mock-provider-for-replay "fork full"))
+   ;; Should have all messages
+   (check-equal? (length forked-history) (length messages))
+   (check-equal? (map message-id forked-history) (map message-id messages))
+   (delete-directory/files dir #:must-exist? #f))
+ (test-case "PROPERTY: forked session can continue independently"
+   (define dir (make-temp-dir))
+   (define bus (make-event-bus))
+   (define prov (make-mock-provider-for-replay "fork continue"))
 
-    (define config (hash 'provider prov
-                        'tool-registry (make-tool-registry)
-                        'event-bus bus
-                        'session-dir dir))
-    (define orig-session (make-agent-session config))
+   (define config
+     (hash 'provider prov 'tool-registry (make-tool-registry) 'event-bus bus 'session-dir dir))
+   (define orig-session (make-agent-session config))
 
-    (define messages (generate-session-tree rng 3 2))
-    (define log-path (build-path (agent-session-session-dir orig-session) "session.jsonl"))
-    (append-entries! log-path messages)
+   ;; Initial messages with deterministic IDs
+   (define messages
+     (list (make-test-message "fork-ind-0" #f 'system 'message "Root" 1000)
+           (make-test-message "fork-ind-1" "fork-ind-0" 'user 'message "First" 1001)
+           (make-test-message "fork-ind-2" "fork-ind-1" 'assistant 'message "Second" 1002)))
+   (define log-path (build-path (agent-session-session-dir orig-session) "session.jsonl"))
+   (append-entries! log-path messages)
 
-    ;; Fork without specifying point
-    (define forked (fork-session orig-session))
-    (define forked-history (session-history forked))
+   ;; Fork
+   (define forked (fork-session orig-session))
 
-    ;; Should have all messages
-    (check-equal? (length forked-history) (length messages))
-    (check-equal? (map message-id forked-history) (map message-id messages))
-    (delete-directory/files dir #:must-exist? #f))
+   ;; Add different messages to each
+   (define orig-new (make-test-message "orig-new" "fork-ind-2" 'user 'message "Orig new" 1003))
+   (define fork-new (make-test-message "fork-new" "fork-ind-2" 'assistant 'message "Fork new" 1003))
 
-  (test-case "PROPERTY: forked session can continue independently"
-    (define dir (make-temp-dir))
-    (define bus (make-event-bus))
-    (define prov (make-mock-provider-for-replay "fork continue"))
+   (append-entry! log-path orig-new)
+   (append-entry! (build-path (agent-session-session-dir forked) "session.jsonl") fork-new)
 
-    (define config (hash 'provider prov
-                        'tool-registry (make-tool-registry)
-                        'event-bus bus
-                        'session-dir dir))
-    (define orig-session (make-agent-session config))
+   ;; Verify independence
+   (define orig-history (session-history orig-session))
+   (define forked-history (session-history forked))
 
-    ;; Initial messages with deterministic IDs
-    (define messages (list
-      (make-test-message "fork-ind-0" #f 'system 'message "Root" 1000)
-      (make-test-message "fork-ind-1" "fork-ind-0" 'user 'message "First" 1001)
-      (make-test-message "fork-ind-2" "fork-ind-1" 'assistant 'message "Second" 1002)))
-    (define log-path (build-path (agent-session-session-dir orig-session) "session.jsonl"))
-    (append-entries! log-path messages)
+   (check-not-false (member "orig-new" (map message-id orig-history)))
+   (check-false (member "fork-new" (map message-id orig-history)))
+   (check-not-false (member "fork-new" (map message-id forked-history)))
+   (check-false (member "orig-new" (map message-id forked-history)))
+   (delete-directory/files dir #:must-exist? #f))
+ (test-case "PROPERTY: fork preserves deterministic replay property"
+   (define rng (make-seeded-rng SEED-2))
+   (define dir (make-temp-dir))
+   (define bus (make-event-bus))
+   (define prov (make-mock-provider-for-replay "fork replay"))
 
-    ;; Fork
-    (define forked (fork-session orig-session))
+   (define config
+     (hash 'provider prov 'tool-registry (make-tool-registry) 'event-bus bus 'session-dir dir))
+   (define orig-session (make-agent-session config))
 
-    ;; Add different messages to each
-    (define orig-new (make-test-message "orig-new" "fork-ind-2" 'user 'message "Orig new" 1003))
-    (define fork-new (make-test-message "fork-new" "fork-ind-2" 'assistant 'message "Fork new" 1003))
+   (define messages (generate-forked-session rng 3 2))
+   (define log-path (build-path (agent-session-session-dir orig-session) "session.jsonl"))
+   (append-entries! log-path messages)
 
-    (append-entry! log-path orig-new)
-    (append-entry! (build-path (agent-session-session-dir forked) "session.jsonl") fork-new)
+   ;; Fork and replay both
+   (define forked (fork-session orig-session (message-id (list-ref messages 4))))
 
-    ;; Verify independence
-    (define orig-history (session-history orig-session))
-    (define forked-history (session-history forked))
+   (define orig-replay (replay-session log-path))
+   (define fork-replay
+     (replay-session (build-path (agent-session-session-dir forked) "session.jsonl")))
 
-    (check-not-false (member "orig-new" (map message-id orig-history)))
-    (check-false (member "fork-new" (map message-id orig-history)))
-    (check-not-false (member "fork-new" (map message-id forked-history)))
-    (check-false (member "orig-new" (map message-id forked-history)))
-    (delete-directory/files dir #:must-exist? #f))
-
-  (test-case "PROPERTY: fork preserves deterministic replay property"
-    (define rng (make-seeded-rng SEED-2))
-    (define dir (make-temp-dir))
-    (define bus (make-event-bus))
-    (define prov (make-mock-provider-for-replay "fork replay"))
-
-    (define config (hash 'provider prov
-                        'tool-registry (make-tool-registry)
-                        'event-bus bus
-                        'session-dir dir))
-    (define orig-session (make-agent-session config))
-
-    (define messages (generate-forked-session rng 3 2))
-    (define log-path (build-path (agent-session-session-dir orig-session) "session.jsonl"))
-    (append-entries! log-path messages)
-
-    ;; Fork and replay both
-    (define forked (fork-session orig-session (message-id (list-ref messages 4))))
-
-    (define orig-replay (replay-session log-path))
-    (define fork-replay (replay-session (build-path (agent-session-session-dir forked) "session.jsonl")))
-
-    ;; Both should be valid replays
-    (check-true (> (length orig-replay) (length fork-replay)))
-    (check-equal? (take (map message-id orig-replay) (length fork-replay))
-                  (map message-id fork-replay))
-    (delete-directory/files dir #:must-exist? #f))
-  )
+   ;; Both should be valid replays
+   (check-true (> (length orig-replay) (length fork-replay)))
+   (check-equal? (take (map message-id orig-replay) (length fork-replay))
+                 (map message-id fork-replay))
+   (delete-directory/files dir #:must-exist? #f)))
 
 ;; ============================================================
 ;; Property 4: compaction preserves queryable history
 ;; ============================================================
 
-(define-test-suite test-property-compaction-preserves-queryable-history
+(define-test-suite
+ test-property-compaction-preserves-queryable-history
+ (test-case "PROPERTY: compaction preserves all entry IDs in log"
+   (define rng (make-seeded-rng SEED-1))
+   (define dir (make-temp-dir))
+   (define path (session-path dir))
 
-  (test-case "PROPERTY: compaction preserves all entry IDs in log"
-    (define rng (make-seeded-rng SEED-1))
-    (define dir (make-temp-dir))
-    (define path (session-path dir))
+   ;; Create session with many messages
+   (define messages (generate-session-tree rng 4 3))
+   (append-entries! path messages)
 
-    ;; Create session with many messages
-    (define messages (generate-session-tree rng 4 3))
-    (append-entries! path messages)
+   ;; Get IDs before compaction
+   (define ids-before (extract-entry-ids path))
 
-    ;; Get IDs before compaction
-    (define ids-before (extract-entry-ids path))
+   ;; Compact history
+   (define loaded (load-session-log path))
+   (define low-tc (token-compaction-config 10 5 20))
+   (compact-and-persist! loaded path #:token-config low-tc)
 
-    ;; Compact history
-    (define loaded (load-session-log path))
-    (define strategy (compaction-strategy 10 5))
-    (compact-and-persist! loaded path #:strategy strategy)
+   ;; Get IDs after compaction
+   (define ids-after (extract-entry-ids path))
 
-    ;; Get IDs after compaction
-    (define ids-after (extract-entry-ids path))
+   ;; All original IDs should still be present
+   (for ([id (in-list ids-before)])
+     (check-not-false (member id ids-after) (format "Original ID ~a should still be in log" id)))
+   (delete-directory/files dir #:must-exist? #f))
+ (test-case "PROPERTY: compaction adds summary but doesn't remove entries"
+   (define rng (make-seeded-rng SEED-2))
+   (define dir (make-temp-dir))
+   (define path (session-path dir))
 
-    ;; All original IDs should still be present
-    (for ([id (in-list ids-before)])
-      (check-not-false (member id ids-after)
-                       (format "Original ID ~a should still be in log" id)))
-    (delete-directory/files dir #:must-exist? #f))
+   ;; Create session
+   (define messages (make-n-messages 30))
+   (for ([m (in-list messages)])
+     (append-entry! path m))
 
-  (test-case "PROPERTY: compaction adds summary but doesn't remove entries"
-    (define rng (make-seeded-rng SEED-2))
-    (define dir (make-temp-dir))
-    (define path (session-path dir))
+   (define count-before (count-entries path))
 
-    ;; Create session
-    (define messages (make-n-messages 30))
-    (for ([m (in-list messages)])
-      (append-entry! path m))
+   ;; Compact
+   (define loaded (load-session-log path))
+   (define low-tc (token-compaction-config 10 5 20))
+   (compact-and-persist! loaded path #:token-config low-tc)
 
-    (define count-before (count-entries path))
+   (define count-after (count-entries path))
 
-    ;; Compact
-    (define loaded (load-session-log path))
-    (define strategy (compaction-strategy 20 5))
-    (compact-and-persist! loaded path #:strategy strategy)
+   ;; Should have original count + 1 summary
+   (check-equal? count-after (add1 count-before))
+   (delete-directory/files dir #:must-exist? #f))
+ (test-case "PROPERTY: query operations work after compaction"
+   (define rng (make-seeded-rng SEED-3))
+   (define dir (make-temp-dir))
+   (define path (session-path dir))
 
-    (define count-after (count-entries path))
+   ;; Create and index session
+   (define messages (generate-forked-session rng 4 2))
+   (append-entries! path messages)
 
-    ;; Should have original count + 1 summary
-    (check-equal? count-after (add1 count-before))
-    (delete-directory/files dir #:must-exist? #f))
+   (define idx-path (build-path (path-only path) "session.index"))
+   (define idx-before (build-index! path idx-path))
 
-  (test-case "PROPERTY: query operations work after compaction"
-    (define rng (make-seeded-rng SEED-3))
-    (define dir (make-temp-dir))
-    (define path (session-path dir))
+   ;; Compact
+   (define loaded (load-session-log path))
+   (define low-tc (token-compaction-config 10 5 20))
+   (compact-and-persist! loaded path #:token-config low-tc)
 
-    ;; Create and index session
-    (define messages (generate-forked-session rng 4 2))
-    (append-entries! path messages)
+   ;; Rebuild index after compaction
+   (define idx-after (build-index! path idx-path))
 
-    (define idx-path (build-path (path-only path) "session.index"))
-    (define idx-before (build-index! path idx-path))
+   ;; Index should still be valid — after compaction has original entries + summary
+   (check-true (> (hash-count (session-index-by-id idx-after))
+                  (hash-count (session-index-by-id idx-before))))
 
-    ;; Compact
-    (define loaded (load-session-log path))
-    (define strategy (compaction-strategy 8 4))
-    (compact-and-persist! loaded path #:strategy strategy)
+   ;; Lookup operations should work
+   (for ([msg (in-list messages)])
+     (define found (lookup-entry idx-after (message-id msg)))
+     (check-not-false found)
+     (check-equal? (message-id found) (message-id msg)))
+   (delete-directory/files dir #:must-exist? #f))
+ (test-case "PROPERTY: tree structure preserved after compaction"
+   (define rng (make-seeded-rng SEED-4))
+   (define dir (make-temp-dir))
+   (define path (session-path dir))
 
-    ;; Rebuild index after compaction
-    (define idx-after (build-index! path idx-path))
+   ;; Create forked session
+   (define messages (generate-forked-session rng 5 3))
+   (append-entries! path messages)
 
-    ;; Index should still be valid
-    (check-true (> (hash-count (session-index-by-id idx-after))
-                   (hash-count (session-index-by-id idx-before))))
+   ;; Build tree before
+   (define tree-before (build-visible-tree (load-session-log path)))
 
-    ;; Lookup operations should work
-    (for ([msg (in-list messages)])
-      (define found (lookup-entry idx-after (message-id msg)))
-      (check-not-false found)
-      (check-equal? (message-id found) (message-id msg)))
-    (delete-directory/files dir #:must-exist? #f))
+   ;; Compact
+   (define loaded (load-session-log path))
+   (define low-tc (token-compaction-config 10 5 20))
+   (compact-and-persist! loaded path #:token-config low-tc)
 
-  (test-case "PROPERTY: tree structure preserved after compaction"
-    (define rng (make-seeded-rng SEED-4))
-    (define dir (make-temp-dir))
-    (define path (session-path dir))
+   ;; Build tree after
+   (define tree-after (build-visible-tree (load-session-log path)))
 
-    ;; Create forked session
-    (define messages (generate-forked-session rng 5 3))
-    (append-entries! path messages)
+   ;; Original relationships should still exist
+   (for ([(id children) (in-hash tree-before)])
+     (check-equal? (hash-ref tree-after id '()) children))
+   (delete-directory/files dir #:must-exist? #f))
+ (test-case "PROPERTY: replay after compaction includes all original entries"
+   (define rng (make-seeded-rng SEED-1))
+   (define dir (make-temp-dir))
+   (define path (session-path dir))
 
-    ;; Build tree before
-    (define tree-before (build-visible-tree (load-session-log path)))
+   ;; Create session
+   (define messages (generate-session-tree rng 4 2))
+   (append-entries! path messages)
 
-    ;; Compact
-    (define loaded (load-session-log path))
-    (define strategy (compaction-strategy 10 5))
-    (compact-and-persist! loaded path #:strategy strategy)
+   ;; Original replay
+   (define replay-before (replay-session path))
 
-    ;; Build tree after
-    (define tree-after (build-visible-tree (load-session-log path)))
+   ;; Compact
+   (define loaded (load-session-log path))
+   (define low-tc (token-compaction-config 10 5 20))
+   (compact-and-persist! loaded path #:token-config low-tc)
 
-    ;; Original relationships should still exist
-    (for ([(id children) (in-hash tree-before)])
-      (check-equal? (hash-ref tree-after id '()) children))
-    (delete-directory/files dir #:must-exist? #f))
+   ;; Replay after compaction
+   (define replay-after (replay-session path))
 
-  (test-case "PROPERTY: replay after compaction includes all original entries"
-    (define rng (make-seeded-rng SEED-1))
-    (define dir (make-temp-dir))
-    (define path (session-path dir))
+   ;; Original entries should be subset of replay-after
+   (define ids-before (map message-id replay-before))
+   (define ids-after (map message-id replay-after))
 
-    ;; Create session
-    (define messages (generate-session-tree rng 4 2))
-    (append-entries! path messages)
+   (for ([id (in-list ids-before)])
+     (check-not-false (member id ids-after)))
+   (delete-directory/files dir #:must-exist? #f))
+ (test-case "PROPERTY: compaction summary is queryable"
+   (define rng (make-seeded-rng SEED-2))
+   (define dir (make-temp-dir))
+   (define path (session-path dir))
 
-    ;; Original replay
-    (define replay-before (replay-session path))
+   ;; Create session
+   (define messages (make-n-messages 25))
+   (for ([m (in-list messages)])
+     (append-entry! path m))
 
-    ;; Compact
-    (define loaded (load-session-log path))
-    (define strategy (compaction-strategy 8 4))
-    (compact-and-persist! loaded path #:strategy strategy)
+   ;; Compact
+   (define loaded (load-session-log path))
+   (define low-tc (token-compaction-config 10 5 20))
+   (define result (compact-and-persist! loaded path #:token-config low-tc))
 
-    ;; Replay after compaction
-    (define replay-after (replay-session path))
+   ;; Load and find summary
+   (define all-entries (load-session-log path))
+   (define summary-entries
+     (filter (lambda (m) (eq? (message-kind m) 'compaction-summary)) all-entries))
 
-    ;; Original entries should be subset of replay-after
-    (define ids-before (map message-id replay-before))
-    (define ids-after (map message-id replay-after))
+   (check-equal? (length summary-entries) 1)
+   (check-equal? (message-role (first summary-entries)) 'system)
 
-    (for ([id (in-list ids-before)])
-      (check-not-false (member id ids-after)))
-    (delete-directory/files dir #:must-exist? #f))
+   ;; Summary should have metadata
+   (define meta (message-meta (first summary-entries)))
+   (check-equal? (hash-ref meta 'type) "compaction")
+   (check-true (positive? (hash-ref meta 'removedCount))
+               (format "expected positive removedCount, got ~a" (hash-ref meta 'removedCount)))
+   (delete-directory/files dir #:must-exist? #f))
+ (test-case "PROPERTY: no compaction when under threshold"
+   (define rng (make-seeded-rng SEED-3))
+   (define dir (make-temp-dir))
+   (define path (session-path dir))
 
-  (test-case "PROPERTY: compaction summary is queryable"
-    (define rng (make-seeded-rng SEED-2))
-    (define dir (make-temp-dir))
-    (define path (session-path dir))
+   ;; Small session
+   (define messages (make-n-messages 5))
+   (for ([m (in-list messages)])
+     (append-entry! path m))
 
-    ;; Create session
-    (define messages (make-n-messages 25))
-    (for ([m (in-list messages)])
-      (append-entry! path m))
+   (define count-before (count-entries path))
 
-    ;; Compact
-    (define loaded (load-session-log path))
-    (define strategy (compaction-strategy 15 5))
-    (define result (compact-and-persist! loaded path #:strategy strategy))
+   ;; Compact with high threshold
+   (define loaded (load-session-log path))
+   (define high-tc (token-compaction-config 50 20 1000000))
+   (define result (compact-and-persist! loaded path #:token-config high-tc))
 
-    ;; Load and find summary
-    (define all-entries (load-session-log path))
-    (define summary-entries
-      (filter (lambda (m) (eq? (message-kind m) 'compaction-summary)) all-entries))
+   (define count-after (count-entries path))
 
-    (check-equal? (length summary-entries) 1)
-    (check-equal? (message-role (first summary-entries)) 'system)
-
-    ;; Summary should have metadata
-    (define meta (message-meta (first summary-entries)))
-    (check-equal? (hash-ref meta 'type) "compaction")
-    (check-equal? (hash-ref meta 'removedCount) 15)
-    (delete-directory/files dir #:must-exist? #f))
-
-  (test-case "PROPERTY: no compaction when under threshold"
-    (define rng (make-seeded-rng SEED-3))
-    (define dir (make-temp-dir))
-    (define path (session-path dir))
-
-    ;; Small session
-    (define messages (make-n-messages 5))
-    (for ([m (in-list messages)])
-      (append-entry! path m))
-
-    (define count-before (count-entries path))
-
-    ;; Compact with high threshold
-    (define loaded (load-session-log path))
-    (define strategy (compaction-strategy 50 20))
-    (define result (compact-and-persist! loaded path #:strategy strategy))
-
-    (define count-after (count-entries path))
-
-    ;; Should be no change (no summary added)
-    (check-equal? count-after count-before)
-    (check-false (compaction-result-summary-message result))
-    (delete-directory/files dir #:must-exist? #f))
-  )
+   ;; Should be no change (no summary added)
+   (check-equal? count-after count-before)
+   (check-false (compaction-result-summary-message result))
+   (delete-directory/files dir #:must-exist? #f)))
 
 ;; ============================================================
 ;; Helper for make-n-messages (used by compactor tests)
@@ -852,7 +832,10 @@
 
 (define (make-n-messages n)
   (for/list ([i (in-range n)])
-    (make-test-message (format "msg~a" i) #f 'user 'message
+    (make-test-message (format "msg~a" i)
+                       #f
+                       'user
+                       'message
                        (format "Message ~a content" i)
                        (+ 1000000 i))))
 
@@ -861,10 +844,10 @@
 ;; ============================================================
 
 (define-test-suite test-replay-properties
-  test-property-replay-reconstructs-tree
-  test-property-append-only-invariant
-  test-property-fork-produces-valid-branch
-  test-property-compaction-preserves-queryable-history)
+                   test-property-replay-reconstructs-tree
+                   test-property-append-only-invariant
+                   test-property-fork-produces-valid-branch
+                   test-property-compaction-preserves-queryable-history)
 
 ;; Run all tests
 (run-tests test-replay-properties)


### PR DESCRIPTION
## Wave 0: Production Bug Fixes

Addresses milestone #53 — v0.10.1 Comprehensive Bug Audit & Remediation.

### Changes

**BUG-40** (#918): `close-session!` → `ensure-persisted!`
- Add `(ensure-persisted! sess)` before `(set-agent-session-active?! sess #f)`
- Prevents data loss when closing sessions without running a prompt
- Fixes `resume-agent-session` "directory not found" errors

**BUG-39** (#919): `build-session-context` → include buffered message
- On first prompt (idx=#f), append buffered user message to context
- Ensures compaction hooks and `should-compact?` evaluate with correct token count

**BUG-41** (#920): Remove dead `#:strategy` parameter
- Remove from `compact-history`, `compact-history-advisory`, `compact-and-persist!`
- Update all callers to use `#:token-config` with low token budgets
- Clean up unused `strategy` defs in test files

### Verification
- `raco test q/tests/test-compactor.rkt` — 35/35 ✅
- `raco test q/tests/test-replay.rkt` — 24/24 ✅
- `raco test q/tests/test-agent-session.rkt` — 45/45 ✅
- `raco test q/tests/test-hooks-complete.rkt` — 29/29 ✅ (was failing with ERROR)
- All compaction tests pass (token-compaction, edge-cases, hooks, guard, ctx-compact)
