### PR TITLE
fix(BUG-56): Disable mouse tracking on terminal close

### DIFF
--- a/tests/test-tui-terminal.rkt
+++ b/tests/test-tui-terminal.rkt
@@ -26,264 +26,286 @@
 ;; ============================================================
 
 (define terminal-tests
-  (test-suite
-   "TUI Terminal Adapter (tui-term)"
+  (test-suite "TUI Terminal Adapter (tui-term)"
 
-   ;; ============================================================
-   ;; 1. Terminal lifecycle (open/close)
-   ;; ============================================================
+    ;; ============================================================
+    ;; 1. Terminal lifecycle (open/close)
+    ;; ============================================================
 
-   (test-case "tui-term-open is a procedure accepting #:tty keyword"
-     (check-pred procedure? tui-term-open)
-     ;; Check arity: should accept at least 0 args, with keyword support
-     (check-true (procedure-arity-includes? tui-term-open 0)))
+    (test-case "tui-term-open is a procedure accepting #:tty keyword"
+      (check-pred procedure? tui-term-open)
+      ;; Check arity: should accept at least 0 args, with keyword support
+      (check-true (procedure-arity-includes? tui-term-open 0)))
 
-   (test-case "tui-term-close is a procedure"
-     (check-pred procedure? tui-term-close)
-     (check-true (procedure-arity-includes? tui-term-close 1)))
+    (test-case "tui-term-close is a procedure"
+      (check-pred procedure? tui-term-close)
+      (check-true (procedure-arity-includes? tui-term-close 1)))
 
-   (test-case "with-tui-terminal is a macro (syntax transformer)"
-     ;; The macro should expand correctly
-     (check-true (procedure? tui-screen-size)))
+    (test-case "with-tui-terminal is a macro (syntax transformer)"
+      ;; The macro should expand correctly
+      (check-true (procedure? tui-screen-size)))
 
-   ;; ============================================================
-   ;; 2. Screen size query
-   ;; ============================================================
+    ;; ============================================================
+    ;; 2. Screen size query
+    ;; ============================================================
 
-   (test-case "tui-screen-size is a procedure returning two values"
-     (check-pred procedure? tui-screen-size)
-     ;; In headless environment, may return default values
-     (define-values (cols rows) (tui-screen-size))
-     (check-true (or (integer? cols) (not cols)))
-     (check-true (or (integer? rows) (not rows))))
+    (test-case "tui-screen-size is a procedure returning two values"
+      (check-pred procedure? tui-screen-size)
+      ;; In headless environment, may return default values
+      (define-values (cols rows) (tui-screen-size))
+      (check-true (or (integer? cols) (not cols)))
+      (check-true (or (integer? rows) (not rows))))
 
-   (test-case "tui-screen-size-changed? returns boolean"
-     (check-pred procedure? tui-screen-size-changed?)
-     (define result (tui-screen-size-changed?))
-     (check-true (boolean? result)))
+    (test-case "tui-screen-size-changed? returns boolean"
+      (check-pred procedure? tui-screen-size-changed?)
+      (define result (tui-screen-size-changed?))
+      (check-true (boolean? result)))
 
-   (test-case "tui-screen-size-cache-reset! is a procedure"
-     (check-pred procedure? tui-screen-size-cache-reset!)
-     ;; Should run without error
-     (check-not-exn (lambda () (tui-screen-size-cache-reset!))))
+    (test-case "tui-screen-size-cache-reset! is a procedure"
+      (check-pred procedure? tui-screen-size-cache-reset!)
+      ;; Should run without error
+      (check-not-exn (lambda () (tui-screen-size-cache-reset!))))
 
-   ;; ============================================================
-   ;; 3. Key message to keycode conversion
-   ;; ============================================================
+    ;; ============================================================
+    ;; 3. Key message to keycode conversion
+    ;; ============================================================
 
-   (test-case "tui-keycode extracts char from mock key message"
-     ;; Test that tui-keycode works with the expected interface
-     ;; We test the pure key mapping logic separately
-     (check-true (procedure? tui-keycode)))
+    (test-case "tui-keycode extracts char from mock key message"
+      ;; Test that tui-keycode works with the expected interface
+      ;; We test the pure key mapping logic separately
+      (check-true (procedure? tui-keycode)))
 
-   (test-case "Key helpers work correctly"
-     (check-pred tui-key-char? #\a)
-     (check-pred tui-key-char? #\return)
-     (check-false (tui-key-char? 'left))
-     (check-false (tui-key-char? 'backspace))
+    (test-case "Key helpers work correctly"
+      (check-pred tui-key-char? #\a)
+      (check-pred tui-key-char? #\return)
+      (check-false (tui-key-char? 'left))
+      (check-false (tui-key-char? 'backspace))
 
-     (check-equal? (tui-key-char #\a) #\a)
-     (check-equal? (tui-key-char #\Z) #\Z)
+      (check-equal? (tui-key-char #\a) #\a)
+      (check-equal? (tui-key-char #\Z) #\Z)
 
-     (check-equal? (tui-key-symbol 'left) 'left)
-     (check-equal? (tui-key-symbol 'up) 'up))
+      (check-equal? (tui-key-symbol 'left) 'left)
+      (check-equal? (tui-key-symbol 'up) 'up))
 
-   (test-case "tui-read-key is a procedure with #:timeout keyword"
-     (check-true (procedure? tui-read-key)))
+    (test-case "tui-read-key is a procedure with #:timeout keyword"
+      (check-true (procedure? tui-read-key)))
 
-   (test-case "tui-byte-ready? returns boolean"
-     (check-pred procedure? tui-byte-ready?)
-     (define result (tui-byte-ready?))
-     (check-true (boolean? result)))
+    (test-case "tui-byte-ready? returns boolean"
+      (check-pred procedure? tui-byte-ready?)
+      (define result (tui-byte-ready?))
+      (check-true (boolean? result)))
 
-   ;; ============================================================
-   ;; 4. Drawing primitives exist and are procedures
-   ;; ============================================================
+    ;; ============================================================
+    ;; 4. Drawing primitives exist and are procedures
+    ;; ============================================================
 
-   (test-case "Drawing primitives are procedures"
-     (check-pred procedure? tui-clear-screen)
-     (check-pred procedure? tui-cursor)
-     (check-pred procedure? tui-display)
-     (check-pred procedure? tui-newline)
-     (check-pred procedure? tui-clear-line-right)
-     (check-true (procedure? tui-flush)))
+    (test-case "Drawing primitives are procedures"
+      (check-pred procedure? tui-clear-screen)
+      (check-pred procedure? tui-cursor)
+      (check-pred procedure? tui-display)
+      (check-pred procedure? tui-newline)
+      (check-pred procedure? tui-clear-line-right)
+      (check-true (procedure? tui-flush)))
 
-   ;; ============================================================
-   ;; 5. Cursor visibility functions exist
-   ;; ============================================================
+    ;; ============================================================
+    ;; 5. Cursor visibility functions exist
+    ;; ============================================================
 
-   (test-case "Cursor visibility functions are procedures"
-     (check-pred procedure? tui-cursor-hide)
-     (check-true (procedure? tui-cursor-show)))
+    (test-case "Cursor visibility functions are procedures"
+      (check-pred procedure? tui-cursor-hide)
+      (check-true (procedure? tui-cursor-show)))
 
-   ;; ============================================================
-   ;; 6. Style functions exist
-   ;; ============================================================
+    ;; ============================================================
+    ;; 6. Style functions exist
+    ;; ============================================================
 
-   (test-case "Style functions are procedures"
-     (check-pred procedure? tui-normal)
-     (check-pred procedure? tui-bold)
-     (check-pred procedure? tui-inverse)
-     (check-pred procedure? tui-underline)
-     (check-pred procedure? tui-dim)
-     (check-true (procedure? tui-fg)))
+    (test-case "Style functions are procedures"
+      (check-pred procedure? tui-normal)
+      (check-pred procedure? tui-bold)
+      (check-pred procedure? tui-inverse)
+      (check-pred procedure? tui-underline)
+      (check-pred procedure? tui-dim)
+      (check-true (procedure? tui-fg)))
 
-   ;; ============================================================
-   ;; 7. Mouse tracking functions exist
-   ;; ============================================================
+    ;; ============================================================
+    ;; 7. Mouse tracking functions exist
+    ;; ============================================================
 
-   (test-case "Mouse tracking functions are procedures"
-     (check-pred procedure? enable-mouse-tracking)
-     (check-true (procedure? disable-mouse-tracking)))
-   ))
+    (test-case "Mouse tracking functions are procedures"
+      (check-pred procedure? enable-mouse-tracking)
+      (check-true (procedure? disable-mouse-tracking)))))
 
 ;; ============================================================
 ;; Keycode mapping tests (pure function tests)
 ;; ============================================================
 
 (define keycode-mapping-tests
-  (test-suite
-   "TUI Keycode Mappings"
+  (test-suite "TUI Keycode Mappings"
 
-   ;; These tests verify that the internal key mapping logic
-   ;; correctly translates tui-term keys to our symbols.
-   ;; The actual tui-keycode function works with tkeymsg structures,
-   ;; so we verify the contract is correct.
+    ;; These tests verify that the internal key mapping logic
+    ;; correctly translates tui-term keys to our symbols.
+    ;; The actual tui-keycode function works with tkeymsg structures,
+    ;; so we verify the contract is correct.
 
-   (test-case "tui-keycode returns #f for non-key messages"
-     ;; When passed a non-tkeymsg, should return #f
-     (check-equal? (tui-keycode "not-a-message") #f)
-     (check-equal? (tui-keycode 42) #f)
-     (check-equal? (tui-keycode #f) #f))
+    (test-case "tui-keycode returns #f for non-key messages"
+      ;; When passed a non-tkeymsg, should return #f
+      (check-equal? (tui-keycode "not-a-message") #f)
+      (check-equal? (tui-keycode 42) #f)
+      (check-equal? (tui-keycode #f) #f))
 
-   ;; Note: Full keycode conversion tests would require
-   ;; creating actual tkeymsg structures, which depends on
-   ;; tui/term/messages. The adapter handles this translation
-   ;; internally.
-   ))
+    ;; Note: Full keycode conversion tests would require
+    ;; creating actual tkeymsg structures, which depends on
+    ;; tui/term/messages. The adapter handles this translation
+    ;; internally.
+    ))
 
 ;; ============================================================
 ;; Run all tests
 ;; ============================================================
-
 
 ;; ============================================================
 ;; Buffered stdin & sync detection (Issues #409, #412)
 ;; ============================================================
 
 (define buffered-sync-tests
-  (test-suite
-   "Buffered stdin & sync detection"
+  (test-suite "Buffered stdin & sync detection"
 
-   (test-case "buffered-read-byte: returns #f on empty port timeout"
-     (define in (open-input-string ""))
-     (define result (buffered-read-byte in 0.001))
-     (check-equal? result #f))
+    (test-case "buffered-read-byte: returns #f on empty port timeout"
+      (define in (open-input-string ""))
+      (define result (buffered-read-byte in 0.001))
+      (check-equal? result #f))
 
-   (test-case "buffered-read-byte: reads byte from string port"
-     (define in (open-input-string "A"))
-     (define result (buffered-read-byte in 0.1))
-     (check-equal? result 65))
+    (test-case "buffered-read-byte: reads byte from string port"
+      (define in (open-input-string "A"))
+      (define result (buffered-read-byte in 0.1))
+      (check-equal? result 65))
 
-   (test-case "buffered-read-byte: reads multiple bytes sequentially"
-     (define in (open-input-string "ABC"))
-     (input-buffer-reset!)
-     (check-equal? (buffered-read-byte in 0.1) 65)
-     (check-equal? (buffered-read-byte in 0.1) 66)
-     (check-equal? (buffered-read-byte in 0.1) 67)
-     (check-equal? (buffered-read-byte in 0.001) #f))
+    (test-case "buffered-read-byte: reads multiple bytes sequentially"
+      (define in (open-input-string "ABC"))
+      (input-buffer-reset!)
+      (check-equal? (buffered-read-byte in 0.1) 65)
+      (check-equal? (buffered-read-byte in 0.1) 66)
+      (check-equal? (buffered-read-byte in 0.1) 67)
+      (check-equal? (buffered-read-byte in 0.001) #f))
 
-   (test-case "input-buffer-reset! clears buffer state"
-     (define in (open-input-string "X"))
-     (buffered-read-byte in 0.1)
-     (input-buffer-reset!)
-     (check-equal? (input-buffer-length) 0))
+    (test-case "input-buffer-reset! clears buffer state"
+      (define in (open-input-string "X"))
+      (buffered-read-byte in 0.1)
+      (input-buffer-reset!)
+      (check-equal? (input-buffer-length) 0))
 
-   (test-case "detect-sync-mode-support! runs without error"
-     (detect-sync-mode-support!)
-     (check-true (or (terminal-sync-available?)
-                     (not (terminal-sync-available?)))))
+    (test-case "detect-sync-mode-support! runs without error"
+      (detect-sync-mode-support!)
+      (check-true (or (terminal-sync-available?) (not (terminal-sync-available?)))))
 
-   (test-case "terminal-sync-begin/end are safe to call"
-     (detect-sync-mode-support!)
-     (terminal-sync-begin!)
-     (terminal-sync-end!)
-     (check-not-exn (lambda ()
-                      (terminal-sync-begin!)
-                      (terminal-sync-end!))))
+    (test-case "terminal-sync-begin/end are safe to call"
+      (detect-sync-mode-support!)
+      (terminal-sync-begin!)
+      (terminal-sync-end!)
+      (check-not-exn (lambda ()
+                       (terminal-sync-begin!)
+                       (terminal-sync-end!))))
 
-   (test-case "parse-xtversion-response matches valid response"
-     (check-not-false
-      (parse-xtversion-response
-       (format "~a[>0;10" (integer->char 27))))
-     (check-false (parse-xtversion-response "not-a-response")))
+    (test-case "parse-xtversion-response matches valid response"
+      (check-not-false (parse-xtversion-response (format "~a[>0;10" (integer->char 27))))
+      (check-false (parse-xtversion-response "not-a-response")))
 
-   (test-case "parse-da1-response matches valid DA1 response"
-     (check-not-false
-      (parse-da1-response
-       (format "~a[?64;1;2;6;22c" (integer->char 27))))
-     (check-false (parse-da1-response "not-a-response")))
-   ))
-
+    (test-case "parse-da1-response matches valid DA1 response"
+      (check-not-false (parse-da1-response (format "~a[?64;1;2;6;22c" (integer->char 27))))
+      (check-false (parse-da1-response "not-a-response")))))
 
 ;; ============================================================
 ;; Kitty keyboard protocol (Issue #410)
 ;; ============================================================
 
 (define kitty-protocol-tests
-  (test-suite
-   "Kitty keyboard protocol"
+  (test-suite "Kitty keyboard protocol"
 
-   (test-case "kitty-codepoint->key maps special keys"
-     (check-equal? (kitty-codepoint->key 57344) 'escape)
-     (check-equal? (kitty-codepoint->key 57345) 'enter)
-     (check-equal? (kitty-codepoint->key 57350) 'left)
-     (check-equal? (kitty-codepoint->key 57352) 'up)
-     (check-equal? (kitty-codepoint->key 57356) 'home)
-     (check-equal? (kitty-codepoint->key 57357) 'end))
+    (test-case "kitty-codepoint->key maps special keys"
+      (check-equal? (kitty-codepoint->key 57344) 'escape)
+      (check-equal? (kitty-codepoint->key 57345) 'enter)
+      (check-equal? (kitty-codepoint->key 57350) 'left)
+      (check-equal? (kitty-codepoint->key 57352) 'up)
+      (check-equal? (kitty-codepoint->key 57356) 'home)
+      (check-equal? (kitty-codepoint->key 57357) 'end))
 
-   (test-case "kitty-codepoint->key maps F-keys"
-     (check-equal? (kitty-codepoint->key 57376) 'f1)
-     (check-equal? (kitty-codepoint->key 57387) 'f12))
+    (test-case "kitty-codepoint->key maps F-keys"
+      (check-equal? (kitty-codepoint->key 57376) 'f1)
+      (check-equal? (kitty-codepoint->key 57387) 'f12))
 
-   (test-case "kitty-codepoint->key maps printable ASCII"
-     (check-equal? (kitty-codepoint->key 65) #\A)
-     (check-equal? (kitty-codepoint->key 97) #\a)
-     (check-equal? (kitty-codepoint->key 32) #\space))
+    (test-case "kitty-codepoint->key maps printable ASCII"
+      (check-equal? (kitty-codepoint->key 65) #\A)
+      (check-equal? (kitty-codepoint->key 97) #\a)
+      (check-equal? (kitty-codepoint->key 32) #\space))
 
-   (test-case "parse-kitty-csi-u returns key with modifiers"
-     (define result (parse-kitty-csi-u 65 5))
-     (check-equal? (car result) #\A)
-     (check-not-false (member 'ctrl (cadr result)))
-     (check-not-false (member 'shift (cadr result))))
+    (test-case "parse-kitty-csi-u returns key with modifiers"
+      (define result (parse-kitty-csi-u 65 5))
+      (check-equal? (car result) #\A)
+      (check-not-false (member 'ctrl (cadr result)))
+      (check-not-false (member 'shift (cadr result))))
 
-   (test-case "parse-modify-other-keys returns key with modifiers"
-     (define result (parse-modify-other-keys 5 65))
-     (check-equal? (car result) #\A)
-     (check-not-false (member 'ctrl (cadr result)))
-     (check-not-false (member 'shift (cadr result))))
+    (test-case "parse-modify-other-keys returns key with modifiers"
+      (define result (parse-modify-other-keys 5 65))
+      (check-equal? (car result) #\A)
+      (check-not-false (member 'ctrl (cadr result)))
+      (check-not-false (member 'shift (cadr result))))
 
-   (test-case "modify-other-keys-enable/disable produce output"
-     (check-not-exn
-      (lambda ()
-        (with-output-to-string modify-other-keys-enable!)
-        (with-output-to-string modify-other-keys-disable!))))
+    (test-case "modify-other-keys-enable/disable produce output"
+      (check-not-exn (lambda ()
+                       (with-output-to-string modify-other-keys-enable!)
+                       (with-output-to-string modify-other-keys-disable!))))
 
-   (test-case "kitty-mode-enable/disable safe when unsupported"
-     (detect-kitty-support!)
-     (check-not-exn
-      (lambda ()
-        (with-output-to-string kitty-mode-enable!)
-        (with-output-to-string kitty-mode-disable!))))
-   ))
+    (test-case "kitty-mode-enable/disable safe when unsupported"
+      (detect-kitty-support!)
+      (check-not-exn (lambda ()
+                       (with-output-to-string kitty-mode-enable!)
+                       (with-output-to-string kitty-mode-disable!))))))
+
+;; ============================================================
+;; BUG-56: Mouse tracking must be disabled on terminal close
+;; ============================================================
+
+(define bug56-tests
+  (test-suite "BUG-56: Mouse tracking cleanup on close"
+
+    (test-case "disable-mouse-tracking emits correct escape sequences"
+      (define output (with-output-to-string disable-mouse-tracking))
+      ;; Should contain ESC[?1002l and ESC[?1000l
+      (check-not-false (string-contains? output "\x1b[?1002l")
+                       "disables button-event tracking (mode 1002)")
+      (check-not-false (string-contains? output "\x1b[?1000l") "disables basic tracking (mode 1000)"))
+
+    (test-case "tui-term-close output includes mouse disable sequences"
+      ;; Verify that tui-term-close calls disable-mouse-tracking
+      ;; We test by checking that disable-mouse-tracking output appears
+      ;; when close runs. Since tui-term-close needs a real term object
+      ;; which we can't create in headless mode, we verify the function
+      ;; is called by checking the output of disable-mouse-tracking itself.
+      ;; The real integration test is that the function is in the body.
+      (check-pred procedure? disable-mouse-tracking)
+      (check-pred procedure? tui-term-close)
+      ;; Verify disable-mouse-tracking is safe to call multiple times
+      (check-not-exn (lambda ()
+                       (with-output-to-string (lambda ()
+                                                (disable-mouse-tracking)
+                                                (disable-mouse-tracking))))))
+
+    (test-case "enable then disable produces symmetric sequences"
+      (define enable-output (with-output-to-string enable-mouse-tracking))
+      (define disable-output (with-output-to-string disable-mouse-tracking))
+      ;; Enable sets modes, disable resets them
+      (check-not-false (string-contains? enable-output "\x1b[?1000h"))
+      (check-not-false (string-contains? enable-output "\x1b[?1002h"))
+      (check-not-false (string-contains? disable-output "\x1b[?1000l"))
+      (check-not-false (string-contains? disable-output "\x1b[?1002l")))))
 
 (define all-tests
-  (test-suite
-   "All TUI Terminal Tests"
-   terminal-tests
-   keycode-mapping-tests
-   buffered-sync-tests
-   kitty-protocol-tests))
+  (test-suite "All TUI Terminal Tests"
+    terminal-tests
+    keycode-mapping-tests
+    buffered-sync-tests
+    kitty-protocol-tests
+    bug56-tests))
 
 (run-tests all-tests)
 
@@ -296,16 +318,15 @@
   (define output (with-output-to-bytes (lambda () (osc-52-copy "hello"))))
   (define str (bytes->string/latin-1 output))
   (check-true (string-prefix? str (string-append (string (integer->char 27)) "]52;c;aGVsbG8="))
-                "osc-52: base64 encoded")
-  (check-true (string-suffix? str (string (integer->char 27) #\\))
-                "osc-52: ends with ST"))
+              "osc-52: base64 encoded")
+  (check-true (string-suffix? str (string (integer->char 27) #\\)) "osc-52: ends with ST"))
 
 (let ()
   ;; osc-52-copy handles empty string (clears clipboard with empty base64)
   (define output (with-output-to-bytes (lambda () (osc-52-copy ""))))
   (define str (bytes->string/latin-1 output))
   (check-true (string-prefix? str (string-append (string (integer->char 27)) "]52;c;"))
-                "osc-52: empty string still emits OSC 52 (clears clipboard)"))
+              "osc-52: empty string still emits OSC 52 (clears clipboard)"))
 
 (let ()
   ;; osc-52-copy handles spaces and special chars
@@ -321,10 +342,7 @@
   ;; detect-clipboard-tool returns #f or a valid tool list
   (define tool (detect-clipboard-tool))
   (check-true (or (not tool)
-                  (and (list? tool)
-                       (= (length tool) 2)
-                       (path? (car tool))
-                       (symbol? (cadr tool))))
+                  (and (list? tool) (= (length tool) 2) (path? (car tool)) (symbol? (cadr tool))))
               "detect-clipboard-tool returns #f or (list path symbol)"))
 
 (let ()
@@ -341,21 +359,17 @@
     ;; should always also emit OSC 52. Test by calling osc-52-copy directly.
     (osc-52-copy "test fallback"))
   (define str (bytes->string/latin-1 (get-output-bytes output)))
-  (check-true (string-contains? str "]52;c;")
-              "clipboard fallback: OSC 52 emitted"))
+  (check-true (string-contains? str "]52;c;") "clipboard fallback: OSC 52 emitted"))
 
 (let ()
   ;; clipboard-copy-via-tool args are correct for each tool type
   ;; We test the args logic by checking the function exists and handles errors
-  (check-true (procedure? clipboard-copy-via-tool)
-              "clipboard-copy-via-tool is a procedure"))
+  (check-true (procedure? clipboard-copy-via-tool) "clipboard-copy-via-tool is a procedure"))
 
 (let ()
   ;; clipboard-copy is exported and callable
-  (check-pred procedure? clipboard-copy
-              "clipboard-copy is a procedure")
-  (check-true (procedure? detect-clipboard-tool)
-              "detect-clipboard-tool is a procedure"))
+  (check-pred procedure? clipboard-copy "clipboard-copy is a procedure")
+  (check-true (procedure? detect-clipboard-tool) "detect-clipboard-tool is a procedure"))
 
 ;; ============================================================
 ;; FD leak fix: stub-current-term-size port cleanup
@@ -368,14 +382,12 @@
   (for ([i (in-range 50)])
     (tui-screen-size-cache-reset!)
     (define-values (cols rows) (tui-screen-size))
-    (check-true (and (exact-positive-integer? cols)
-                     (exact-positive-integer? rows))
+    (check-true (and (exact-positive-integer? cols) (exact-positive-integer? rows))
                 (format "iteration ~a: got valid size ~ax~a" i cols rows))))
 
 (test-case "stub-current-term-size: returns 80x24 when stty fails"
   ;; In environments where stty size fails, should still return 80x24
   (tui-screen-size-cache-reset!)
   (define-values (cols rows) (tui-screen-size))
-  (check-true (and (exact-positive-integer? cols)
-                   (exact-positive-integer? rows))
+  (check-true (and (exact-positive-integer? cols) (exact-positive-integer? rows))
               (format "size is positive: ~ax~a" cols rows)))

--- a/tui/terminal.rkt
+++ b/tui/terminal.rkt
@@ -160,8 +160,13 @@
   term)
 
 ;; Close terminal and restore state.
-;; Shows cursor, restores normal screen, closes tty.
+;; Disables mouse tracking, shows cursor, restores normal screen, closes tty.
+;; BUG-56 fix: disable-mouse-tracking is now in tui-term-close for
+;; defense-in-depth — ensures mouse tracking is always disabled regardless
+;; of exit path (normal exit, error handler, or unexpected crash).
 (define (tui-term-close term)
+  (with-handlers ([exn:fail? (lambda (e) (void))])
+    (disable-mouse-tracking))
   (disable-bracketed-paste)
   (term-show-cursor term)
   (term-normal-screen term)
@@ -392,8 +397,7 @@
                [(eof-object? n) #f]
                [(and (integer? n) (> n 0))
                 (define resp (bytes->string/latin-1 (subbytes buf 0 n)))
-                (or (parse-xtversion-response resp)
-                    (parse-da1-response resp))]
+                (or (parse-xtversion-response resp) (parse-da1-response resp))]
                [else #f])))])))
 
 ;; Check if port is a real terminal.
@@ -407,10 +411,9 @@
   ;; Try interactive query first
   (define query-result (query-terminal-version))
   (cond
-    [query-result
-     ;; Terminal responded to query — it likely supports sync mode
-     ;; (most modern terminals that respond to DA also support DEC 2026)
-     (set! sync-mode-supported #t)]
+    ;; Terminal responded to query — it likely supports sync mode
+    ;; (most modern terminals that respond to DA also support DEC 2026)
+    [query-result (set! sync-mode-supported #t)]
     [else
      ;; Fall back to env var heuristics
      (define term-program (getenv "TERM_PROGRAM"))
@@ -418,8 +421,7 @@
      (set! sync-mode-supported
            (or (and term-program
                     (member (string-downcase term-program)
-                            '("wezterm" "kitty" "hyper" "alacritty" "ghostty"
-                              "rio" "contour")))
+                            '("wezterm" "kitty" "hyper" "alacritty" "ghostty" "rio" "contour")))
                (and term (regexp-match? #rx"^(foot|kitty|wezterm|ghostty)" term))))]))
 
 ;; Begin synchronized output bracket.

--- a/tui/tui-init.rkt
+++ b/tui/tui-init.rkt
@@ -84,7 +84,8 @@
                             base-state
                             (let ([max-id (for/fold ([m -1]) ([e (in-list loaded)])
                                             (max m (or (transcript-entry-id e) -1)))])
-                              (struct-copy ui-state base-state
+                              (struct-copy ui-state
+                                           base-state
                                            [transcript loaded]
                                            [next-entry-id (add1 max-id)]))))
                       base-state)]
@@ -117,8 +118,9 @@
                                           [transcript (ui-state-transcript state)])
                                      (when (not (null? transcript))
                                        (save-scrollback transcript scrollback-path)))))
-                               ;; Cleanup terminal
+                               ;; Cleanup terminal (BUG-56: mouse disable in close)
                                (with-handlers ([exn:fail? (lambda (_) (void))])
+                                 (disable-mouse-tracking)
                                  (tui-term-close (unbox (tui-ctx-term-box ctx))))
                                (raise e))])
     (tui-main-loop ctx))
@@ -143,6 +145,7 @@
   (with-handlers ([exn:break? (lambda (e) (void))]
                   [exn:fail? (lambda (e)
                                (with-handlers ([exn:fail? (lambda (_) (void))])
+                                 (disable-mouse-tracking)
                                  (tui-term-close (unbox (tui-ctx-term-box ctx))))
                                (raise e))])
     (tui-main-loop ctx))


### PR DESCRIPTION
Addresses #941.

fix(BUG-56): disable mouse tracking in tui-term-close and error handlers

Defense-in-depth fix for terminal state corruption on crash.

- Add disable-mouse-tracking to tui-term-close (terminal.rkt)
  so mouse tracking is always disabled regardless of exit path.
- Add explicit disable-mouse-tracking in exn:fail? handlers
  in both run-tui-with-runtime and run-tui (tui-init.rkt).
- Add BUG-56 test suite verifying mouse disable sequences.

Closes #941