### PR TITLE
fix(BUG-57): Fix mouse selection offset in large terminals

### DIFF
--- a/tests/tui/render.rkt
+++ b/tests/tui/render.rkt
@@ -841,3 +841,87 @@
       (check-true (> (length lines) 0) "non-empty entry renders lines"))))
 
 (run-tests bug37-tests)
+
+;; ============================================================
+;; BUG-57: Selection offset must account for transcript padding
+;; ============================================================
+
+
+;; ============================================================
+;; BUG-57: Selection offset must account for transcript padding
+;; ============================================================
+
+(define bug57-tests
+  (test-suite "BUG-57: Selection padding offset"
+
+    (test-case "apply-selection-highlight with pad-count=0 (baseline)"
+      ;; 5 lines, selection on line 2, trans-start=1, pad-count=0
+      (define lines
+        (for/list ([i (in-range 5)])
+          (styled-line (list (styled-segment (format "Line ~a" i) '())))))
+      ;; Select line at screen row 2 (trans-start=1, so line idx=1)
+      (define anchor (cons 0 2))
+      (define end (cons 5 2))
+      (define result (apply-selection-highlight lines anchor end 1 0))
+      ;; Line at index 1 should be highlighted
+      (define highlighted-line (list-ref result 1))
+      (check-not-false
+       (for/or ([seg (styled-line-segments highlighted-line)])
+         (member 'inverse (styled-segment-style seg)))
+       "line at index 1 should be highlighted when pad-count=0"))
+
+    (test-case "apply-selection-highlight with pad-count=12 (user scenario)"
+      ;; Simulate user's case: 25 content lines in 37-row transcript area
+      ;; Content lines drawn starting at row (trans-y + pad-count) = 1 + 12 = 13
+      ;; User clicks screen row 13 -> line index 0
+      (define lines
+        (for/list ([i (in-range 5)])
+          (styled-line (list (styled-segment (format "Line ~a" i) '())))))
+      (define anchor (cons 0 13))
+      (define end (cons 5 13))
+      ;; With pad-count=12, screen row 13 maps to line index 0
+      (define result (apply-selection-highlight lines anchor end 1 12))
+      (define highlighted-line (list-ref result 0))
+      (check-not-false
+       (for/or ([seg (styled-line-segments highlighted-line)])
+         (member 'inverse (styled-segment-style seg)))
+       "line at index 0 should be highlighted with pad-count=12"))
+
+    (test-case "apply-selection-highlight with pad-count=5"
+      ;; 3 lines in 8-row area -> pad-count=5
+      ;; Content starts at screen row (trans-y + 5) = 6
+      ;; Click screen row 7 -> line index 1
+      (define lines
+        (for/list ([i (in-range 3)])
+          (styled-line (list (styled-segment (format "Line ~a" i) '())))))
+      (define anchor (cons 0 7))
+      (define end (cons 5 7))
+      (define result (apply-selection-highlight lines anchor end 1 5))
+      (define highlighted-line (list-ref result 1))
+      (check-not-false
+       (for/or ([seg (styled-line-segments highlighted-line)])
+         (member 'inverse (styled-segment-style seg)))
+       "line at index 1 should be highlighted with pad-count=5"))
+
+    (test-case "click in padding area (above content) highlights nothing"
+      (define lines
+        (for/list ([i (in-range 3)])
+          (styled-line (list (styled-segment (format "Line ~a" i) '())))))
+      ;; Click screen row 2 which is in padding area (trans-y=1, pad-count=5)
+      (define anchor (cons 0 2))
+      (define end (cons 5 2))
+      ;; Should NOT crash, selection in padding is gracefully handled
+      (define result (apply-selection-highlight lines anchor end 1 5))
+      (check-equal? (length result) 3 "returns all lines unmodified"))
+
+    (test-case "no selection returns lines unchanged regardless of pad-count"
+      (define lines
+        (for/list ([i (in-range 3)])
+          (styled-line (list (styled-segment (format "Line ~a" i) '())))))
+      (define result (apply-selection-highlight lines #f #f 1 5))
+      (check-equal? (map styled-line->text result)
+                    (map styled-line->text lines)
+                    "no selection passes through unchanged"))
+    ))
+
+(run-tests bug57-tests)

--- a/tui/render.rkt
+++ b/tui/render.rkt
@@ -76,16 +76,20 @@
   (case kind
     [(assistant)
      (if (string=? (string-trim text) "")
-         '()  ;; empty/whitespace → no lines
+         '() ;; empty/whitespace → no lines
          (md-format-assistant text width))]
     [(tool-start) (list (styled-line (list (styled-segment text (theme->style 'tool-title)))))]
     [(tool-end) (list (styled-line (list (styled-segment text (theme->style 'success)))))]
     [(tool-fail) (list (styled-line (list (styled-segment text (theme->style 'error)))))]
-    [(system) (list (styled-line (list (styled-segment (string-append "[SYS] " text) (theme->style 'muted)))))]
-    [(error) (list (styled-line (list (styled-segment (string-append "[ERR] " text) (theme->style 'error '(bold))))))]
+    [(system)
+     (list (styled-line (list (styled-segment (string-append "[SYS] " text) (theme->style 'muted)))))]
+    [(error)
+     (list (styled-line (list (styled-segment (string-append "[ERR] " text)
+                                              (theme->style 'error '(bold))))))]
     [(user)
      ;; Split into themed prompt + bold text
-     (list (styled-line (list (styled-segment "> " (theme->style 'input-prompt '(bold))) (styled-segment text '(bold)))))]
+     (list (styled-line (list (styled-segment "> " (theme->style 'input-prompt '(bold)))
+                              (styled-segment text '(bold)))))]
     [else (list (plain-line text))]))
 
 ;; Convert a single md-token to a styled-segment
@@ -127,8 +131,7 @@
              text)]
         [else
          ;; Styled segment: reset before (if not first) + SGR + text
-         (define reset-prefix
-           (if (unbox seen-styled?) "\x1b[0m" ""))
+         (define reset-prefix (if (unbox seen-styled?) "\x1b[0m" ""))
          (set-box! seen-styled? #t)
          (string-append reset-prefix (styles->sgr styles) text)])))
   (define content (apply string-append parts))
@@ -148,11 +151,22 @@
         [(underline) 4]
         [(inverse) 7]
         [(dim) 2]
-        [(black) 30] [(red) 31] [(green) 32] [(yellow) 33]
-        [(blue) 34] [(magenta) 35] [(cyan) 36] [(white) 37]
-        [(bright-black) 90] [(bright-red) 91] [(bright-green) 92]
-        [(bright-yellow) 93] [(bright-blue) 94] [(bright-magenta) 95]
-        [(bright-cyan) 96] [(bright-white) 97]
+        [(black) 30]
+        [(red) 31]
+        [(green) 32]
+        [(yellow) 33]
+        [(blue) 34]
+        [(magenta) 35]
+        [(cyan) 36]
+        [(white) 37]
+        [(bright-black) 90]
+        [(bright-red) 91]
+        [(bright-green) 92]
+        [(bright-yellow) 93]
+        [(bright-blue) 94]
+        [(bright-magenta) 95]
+        [(bright-cyan) 96]
+        [(bright-white) 97]
         [else #f])))
   (define valid (filter values codes))
   (if (null? valid)
@@ -235,16 +249,16 @@
          (define header-text (cdr (md-token-content tok)))
          ;; Heading uses md-heading theme color
          (values (append prev-lines
-                         (list (styled-line (list (styled-segment header-text (theme->style 'md-heading '(bold)))))))
+                         (list (styled-line (list (styled-segment header-text
+                                                                  (theme->style 'md-heading
+                                                                                '(bold)))))))
                  '())]
         [(hr)
          (define prev-lines (flush-current lines current-segs))
          ;; Horizontal rule — dim line
          (values (append prev-lines
-                         (list (styled-line
-                                (list (styled-segment
-                                       (make-string (max width 20) #\u2500)
-                                       (theme->style 'muted))))))
+                         (list (styled-line (list (styled-segment (make-string (max width 20) #\u2500)
+                                                                  (theme->style 'muted))))))
                  '())]
         [(blockquote)
          (define prev-lines (flush-current lines current-segs))
@@ -257,24 +271,19 @@
            (for/list ([t (in-list inner-tokens)])
              (md-token->segment t)))
          (define bq-line
-           (styled-line
-            (cons (styled-segment (string-append prefix " ") (theme->style 'muted))
-                  inner-segs)))
+           (styled-line (cons (styled-segment (string-append prefix " ") (theme->style 'muted))
+                              inner-segs)))
          (values (append prev-lines (list bq-line)) '())]
         [(unordered-list)
          (define prev-lines (flush-current lines current-segs))
          (define ul-content (md-token-content tok))
          (define indent (car ul-content))
          (define inner-tokens (cdr ul-content))
-         (define bullet-prefix
-           (string-append (make-string (* indent 2) #\space) "\u2022 "))
+         (define bullet-prefix (string-append (make-string (* indent 2) #\space) "\u2022 "))
          (define inner-segs
            (for/list ([t (in-list inner-tokens)])
              (md-token->segment t)))
-         (define ul-line
-           (styled-line
-            (cons (styled-segment bullet-prefix '())
-                  inner-segs)))
+         (define ul-line (styled-line (cons (styled-segment bullet-prefix '()) inner-segs)))
          (values (append prev-lines (list ul-line)) '())]
         [(ordered-list)
          (define prev-lines (flush-current lines current-segs))
@@ -282,16 +291,11 @@
          (define indent (car ol-content))
          (define num (cadr ol-content))
          (define inner-tokens (cddr ol-content))
-         (define ol-prefix
-           (string-append (make-string (* indent 2) #\space)
-                          (format "~a. " num)))
+         (define ol-prefix (string-append (make-string (* indent 2) #\space) (format "~a. " num)))
          (define inner-segs
            (for/list ([t (in-list inner-tokens)])
              (md-token->segment t)))
-         (define ol-line
-           (styled-line
-            (cons (styled-segment ol-prefix '())
-                  inner-segs)))
+         (define ol-line (styled-line (cons (styled-segment ol-prefix '()) inner-segs)))
          (values (append prev-lines (list ol-line)) '())]
         [else
          ;; Inline token — accumulate segments
@@ -352,17 +356,19 @@
 ;; sel-anchor and sel-end are (cons col row) in screen coordinates,
 ;; where row is 0-based (row 0 = header, row 1 = first transcript line).
 ;; trans-start is the 0-based row where transcript starts (typically 1).
+;; pad-count is the number of blank rows at top of transcript area
+;; (BUG-57 fix: content is pushed down by pad-count rows when sparse).
 ;; Returns new list of styled-lines with 'inverse on selected ranges.
-(define (apply-selection-highlight lines sel-anchor sel-end trans-start)
+(define (apply-selection-highlight lines sel-anchor sel-end trans-start [pad-count 0])
   (if (not (and sel-anchor sel-end))
       lines ;; no selection — pass through
       (let ()
         ;; Normalize: ensure anchor <= end
         (define-values (start-col start-row end-col end-row)
           (normalize-selection-range sel-anchor sel-end))
-        ;; Convert screen rows to line indices
-        (define sel-start-idx (max 0 (- start-row trans-start)))
-        (define sel-end-idx (- end-row trans-start))
+        ;; Convert screen rows to line indices (BUG-57: subtract pad-count)
+        (define sel-start-idx (max 0 (- start-row trans-start pad-count)))
+        (define sel-end-idx (- end-row trans-start pad-count))
         (for/list ([line (in-list lines)]
                    [i (in-naturals)])
           (cond
@@ -439,30 +445,31 @@
   ;; Format entries using cache where possible
   ;; BUG-36 fix: cons lines in reverse order, then reverse at the end
   (define-values (formatted-lines state1)
-    (let loop ([entries entries] [rev-lines '()] [st state0])
+    (let loop ([entries entries]
+               [rev-lines '()]
+               [st state0])
       (if (null? entries)
           (values (reverse rev-lines) st)
           (let* ([e (car entries)]
                  [eid (transcript-entry-id e)]
                  [cached (and eid (rendered-cache-ref st eid))]
                  [entry-text (transcript-entry-text e)]
-                 [cache-valid?
-                  (and cached
-                       (string? entry-text)
-                       (> (string-length entry-text) 0)
-                       (> (length cached) 0)
-                       (let* ([first-line (styled-line->text (car cached))]
-                              [prefix-len (min 20 (string-length entry-text))]
-                              [prefix (substring entry-text 0 prefix-len)])
-                         (string-contains? first-line prefix)))])
+                 [cache-valid? (and cached
+                                    (string? entry-text)
+                                    (> (string-length entry-text) 0)
+                                    (> (length cached) 0)
+                                    (let* ([first-line (styled-line->text (car cached))]
+                                           [prefix-len (min 20 (string-length entry-text))]
+                                           [prefix (substring entry-text 0 prefix-len)])
+                                      (string-contains? first-line prefix)))])
             (if cache-valid?
-                (loop (cdr entries)
-                      (foldl (lambda (l acc) (cons l acc)) rev-lines cached)
-                      st)
+                (loop (cdr entries) (foldl (lambda (l acc) (cons l acc)) rev-lines cached) st)
                 (let ([fmt (format-entry e width)])
                   (loop (cdr entries)
                         (foldl (lambda (l acc) (cons l acc)) rev-lines fmt)
-                        (if eid (rendered-cache-set st eid fmt) st))))))))
+                        (if eid
+                            (rendered-cache-set st eid fmt)
+                            st))))))))
   ;; If streaming, append the partial streaming text (not cached)
   (define streaming (ui-state-streaming-text state))
   (define all-lines
@@ -505,7 +512,8 @@
 (define (render-input-line input-st width)
   (define-values (visible-text scroll-offset cursor-col) (input-visible-window input-st width))
   (define prompt-str "q> ")
-  (define pad-len (max 0 (- width (string-visible-width prompt-str) (string-visible-width visible-text))))
+  (define pad-len
+    (max 0 (- width (string-visible-width prompt-str) (string-visible-width visible-text))))
   (styled-line (list (styled-segment prompt-str (theme->style 'input-prompt '(bold)))
                      (styled-segment (string-append visible-text (make-string pad-len #\space))
                                      '(bold)))))

--- a/tui/renderer.rkt
+++ b/tui/renderer.rkt
@@ -83,11 +83,13 @@
 (define (assert-line-width! line-text max-width)
   (define vw (string-visible-width line-text))
   (when (> vw max-width)
-    (define msg (format "width overflow: ~a cols in ~a-col terminal (line: ~a)"
-                        vw max-width
-                        (if (> (string-length line-text) 60)
-                            (string-append (substring line-text 0 60) "...")
-                            line-text)))
+    (define msg
+      (format "width overflow: ~a cols in ~a-col terminal (line: ~a)"
+              vw
+              max-width
+              (if (> (string-length line-text) 60)
+                  (string-append (substring line-text 0 60) "...")
+                  line-text)))
     (if (current-assert-width)
         (raise (exn:fail msg (current-continuation-marks)))
         (log-warning msg)))
@@ -198,10 +200,10 @@
   ;; Pad rest with spaces
   (when (> remaining-width 0)
     (ubuf-putstring! ubuf col row (make-string remaining-width #\space))))
-  ;; Width overflow protection: draw-styled-line! truncates per-segment
-  ;; and pads to exactly 'width'. Upstream wrap-styled-line handles word wrap.
-  ;; The assert-line-width! function is available for external callers to
-  ;; validate line widths before they reach this function.)
+;; Width overflow protection: draw-styled-line! truncates per-segment
+;; and pads to exactly 'width'. Upstream wrap-styled-line handles word wrap.
+;; The assert-line-width! function is available for external callers to
+;; validate line widths before they reach this function.)
 
 ;; ============================================================
 ;; Frame rendering
@@ -247,28 +249,28 @@
   ;; Build frame-lines for diffing
   (define frame-vec (make-vector rows ""))
   ;; Header: store ANSI-encoded (inverse video) for correct incremental diff
-  (vector-set! frame-vec header-y
-                (string-append "\x1b[0m\x1b[30;47m" header-text "\x1b[0m"))
+  (vector-set! frame-vec header-y (string-append "\x1b[0m\x1b[30;47m" header-text "\x1b[0m"))
 
   ;; 3. Draw transcript entries (with render cache)
   (define-values (trans-lines-raw ui-state*) (render-transcript ui-state transcript-height cols))
-  ;; Apply selection highlight if selection is active
+  ;; Determine visible lines and padding BEFORE selection (BUG-57)
+  (define visible-lines-raw
+    (if (> (length trans-lines-raw) transcript-height)
+        (take-right trans-lines-raw transcript-height)
+        trans-lines-raw))
+  (define pad-count (- transcript-height (length visible-lines-raw)))
+  ;; Apply selection highlight with pad-count for correct coordinate mapping
   (define sel-anchor (ui-state-sel-anchor ui-state))
   (define sel-end (ui-state-sel-end ui-state))
   (define trans-lines
     (if (and sel-anchor sel-end)
-        (apply-selection-highlight trans-lines-raw sel-anchor sel-end trans-y)
-        trans-lines-raw))
-  (define visible-lines
-    (if (> (length trans-lines) transcript-height)
-        (take-right trans-lines transcript-height)
-        trans-lines))
-  (define pad-count (- transcript-height (length visible-lines)))
+        (apply-selection-highlight visible-lines-raw sel-anchor sel-end trans-y pad-count)
+        visible-lines-raw))
   (for ([i (in-range pad-count)])
     (define blank (make-string cols #\space))
     (ubuf-putstring! ubuf 0 (+ trans-y i) blank)
     (vector-set! frame-vec (+ trans-y i) blank))
-  (for ([line (in-list visible-lines)]
+  (for ([line (in-list trans-lines)]
         [i (in-naturals)])
     (define line-ansi (styled-line->ansi line))
     (assert-line-width! (styled-line->text line) cols)
@@ -304,9 +306,10 @@
   (define overlay (ui-state-active-overlay ui-state))
   (when overlay
     (define ov-content (overlay-state-content overlay))
-    (define ov-lines (if (> (length ov-content) transcript-height)
-                         (take-right ov-content transcript-height)
-                         ov-content))
+    (define ov-lines
+      (if (> (length ov-content) transcript-height)
+          (take-right ov-content transcript-height)
+          ov-content))
     ;; Clear overlay background
     (for ([i (in-range transcript-height)])
       (ubuf-putstring! ubuf 0 (+ trans-y i) (make-string cols #\space) #:bg 8))
@@ -338,17 +341,14 @@
 ;; Input line is NOT wrapped as a component because it changes every keystroke
 ;; and receives separate input-state not available through ui-state.
 (define (make-render-components)
-  (render-components
-   ;; Transcript component
-   (make-q-component
-    (lambda (st w)
-      (define-values (lines _st) (render-transcript st 1000 w))
-      lines)
-    #:id 'transcript)
-   ;; Status bar component
-   (make-q-component
-    (lambda (st w) (list (render-status-bar st w)))
-    #:id 'status-bar)))
+  ;; Transcript component
+  (render-components (make-q-component (lambda (st w)
+                                         (define-values (lines _st) (render-transcript st 1000 w))
+                                         lines)
+                                       #:id 'transcript)
+                     ;; Status bar component
+                     (make-q-component (lambda (st w) (list (render-status-bar st w)))
+                                       #:id 'status-bar)))
 
 ;; Render transcript zone through component. Returns (values lines ui-state).
 (define (render-components-transcript comps state height width)

--- a/tui/tui-keybindings.rkt
+++ b/tui/tui-keybindings.rkt
@@ -17,6 +17,7 @@
 ;;              clipboard-backend-available?, styled-line->text
 
 (require racket/string
+         racket/list
          racket/async-channel
          "../tui/terminal.rkt"
          "../tui/state.rkt"
@@ -127,31 +128,35 @@
          (define trans-y (tui-layout-transcript-start-row layout))
          (define trans-height (tui-layout-transcript-height layout))
          (define-values (all-lines _state*) (render-transcript state trans-height cols))
-         ;; Map screen rows to line indices (screen row → rendered line index)
+         ;; BUG-57: Compute pad-count for correct coordinate mapping
+         (define visible-lines
+           (if (> (length all-lines) trans-height)
+               (take-right all-lines trans-height)
+               all-lines))
+         (define pad-count (- trans-height (length visible-lines)))
+         ;; Map screen rows to line indices (account for padding)
          ;; Mouse y is 0-based: row 0 = header, row 1 = first transcript line.
-         ;; trans-y is now 0-based: value 1 means transcript starts at screen row 1.
-         ;; So: line-index = screen-row - trans-y
-         (define start-idx (max 0 (- start-row trans-y)))
-         (define end-idx (min (sub1 (length all-lines)) (- end-row trans-y)))
+         ;; Content starts at (trans-y + pad-count). So:
+         ;;   line-index = screen-row - trans-y - pad-count
+         (define start-idx (max 0 (- start-row trans-y pad-count)))
+         (define end-idx (min (sub1 (length visible-lines)) (- end-row trans-y pad-count)))
          (if (> start-idx end-idx)
              ""
              (string-join
               (for/list ([i (in-range start-idx (add1 end-idx))])
-                (define line (list-ref all-lines i))
+                (define line (list-ref visible-lines i))
                 (define text (styled-line->text line))
                 (cond
                   [(= i start-idx end-idx)
                    ;; Single line: extract column range (display-col→string-offset)
                    (substring text
-                              (min (display-col->string-offset text start-col)
-                                   (string-length text))
+                              (min (display-col->string-offset text start-col) (string-length text))
                               (min (display-col->string-offset text (add1 end-col))
                                    (string-length text)))]
                   ;; First line: from start-col to end
                   [(= i start-idx)
                    (substring text
-                              (min (display-col->string-offset text start-col)
-                                   (string-length text)))]
+                              (min (display-col->string-offset text start-col) (string-length text)))]
                   ;; Last line: from 0 to end-col
                   [(= i end-idx)
                    (substring text
@@ -208,8 +213,7 @@
 ;; for keymap lookup. Handles modifier-prefixed symbols like 'ctrl-z.
 (define (keycode->key-spec-from-msg keycode)
   (cond
-    [(char? keycode)
-     (key-spec keycode #f #f #f)]
+    [(char? keycode) (key-spec keycode #f #f #f)]
     [(symbol? keycode)
      (define s (symbol->string keycode))
      (cond
@@ -231,26 +235,36 @@
   (case action
     [(submit) #f] ;; Complex — fall through to hardcoded for proper submit flow
     [(backspace)
-     (set-box! (tui-ctx-input-state-box ctx) (input-backspace inp)) 'handled]
+     (set-box! (tui-ctx-input-state-box ctx) (input-backspace inp))
+     'handled]
     [(delete)
-     (set-box! (tui-ctx-input-state-box ctx) (input-delete inp)) 'handled]
+     (set-box! (tui-ctx-input-state-box ctx) (input-delete inp))
+     'handled]
     [(home)
-     (set-box! (tui-ctx-input-state-box ctx) (input-home inp)) 'handled]
+     (set-box! (tui-ctx-input-state-box ctx) (input-home inp))
+     'handled]
     [(end)
-     (set-box! (tui-ctx-input-state-box ctx) (input-end inp)) 'handled]
+     (set-box! (tui-ctx-input-state-box ctx) (input-end inp))
+     'handled]
     [(history-up)
-     (set-box! (tui-ctx-input-state-box ctx) (input-history-up inp)) 'handled]
+     (set-box! (tui-ctx-input-state-box ctx) (input-history-up inp))
+     'handled]
     [(history-down)
-     (set-box! (tui-ctx-input-state-box ctx) (input-history-down inp)) 'handled]
+     (set-box! (tui-ctx-input-state-box ctx) (input-history-down inp))
+     'handled]
     [(word-left)
-     (set-box! (tui-ctx-input-state-box ctx) (input-cursor-word-left inp)) 'handled]
+     (set-box! (tui-ctx-input-state-box ctx) (input-cursor-word-left inp))
+     'handled]
     [(word-right)
-     (set-box! (tui-ctx-input-state-box ctx) (input-cursor-word-right inp)) 'handled]
+     (set-box! (tui-ctx-input-state-box ctx) (input-cursor-word-right inp))
+     'handled]
     [(clear-input)
-     (set-box! (tui-ctx-input-state-box ctx) (input-kill-to-beginning inp)) 'handled]
+     (set-box! (tui-ctx-input-state-box ctx) (input-kill-to-beginning inp))
+     'handled]
     [(clear-screen)
-     (mark-dirty! ctx) 'handled]
-    [(copy) #f]  ;; Complex — let hardcoded handle
+     (mark-dirty! ctx)
+     'handled]
+    [(copy) #f] ;; Complex — let hardcoded handle
     [(cut) #f]
     [(paste)
      (define text (clipboard-paste))
@@ -259,9 +273,11 @@
      'handled]
     [(select-all) #f] ;; Complex — let hardcoded handle
     [(scroll-up)
-     (set-box! (tui-ctx-ui-state-box ctx) (scroll-up state 1)) 'handled]
+     (set-box! (tui-ctx-ui-state-box ctx) (scroll-up state 1))
+     'handled]
     [(scroll-down)
-     (set-box! (tui-ctx-ui-state-box ctx) (scroll-down state 1)) 'handled]
+     (set-box! (tui-ctx-ui-state-box ctx) (scroll-down state 1))
+     'handled]
     [(page-up)
      (define-values (_cols rows) (tui-screen-size))
      (define layout (compute-layout _cols rows))
@@ -275,9 +291,11 @@
                (scroll-down state (max 1 (tui-layout-transcript-height layout))))
      'handled]
     [(scroll-top)
-     (set-box! (tui-ctx-ui-state-box ctx) (scroll-to-top state)) 'handled]
+     (set-box! (tui-ctx-ui-state-box ctx) (scroll-to-top state))
+     'handled]
     [(scroll-bottom)
-     (set-box! (tui-ctx-ui-state-box ctx) (scroll-to-bottom state)) 'handled]
+     (set-box! (tui-ctx-ui-state-box ctx) (scroll-to-bottom state))
+     'handled]
     [else #f]))
 
 (define (reload-keymap!)
@@ -296,8 +314,7 @@
   (define ks (keycode->key-spec-from-msg keycode))
   (define action (and ks (keymap-lookup km ks)))
   (cond
-    [(and action (eq? (dispatch-keymap-action ctx inp state action) 'handled))
-     'continue]
+    [(and action (eq? (dispatch-keymap-action ctx inp state action) 'handled)) 'continue]
     ;; Fallback to hardcoded behavior
     [(char? keycode)
      (case keycode


### PR DESCRIPTION
Addresses #942.

fix(BUG-57): account for transcript padding in mouse selection

Mouse selection appeared pad-count rows below the click position
because the coordinate mapping did not account for top-padding
added when transcript content is shorter than the transcript area.

- apply-selection-highlight now accepts pad-count parameter
- renderer.rkt computes pad-count before selection highlight
- selection-text in tui-keybindings.rkt computes pad-count for
  correct text extraction
- 5 new TDD tests covering pad-count=0, 5, 12 scenarios

Closes #942