### PR TITLE
FEAT-58: Rich extension-ctx with session-store, tool-registry, ui-channel

### DIFF
--- a/extensions/context.rkt
+++ b/extensions/context.rkt
@@ -17,54 +17,71 @@
 
 (require racket/contract)
 
-(provide
- ;; Struct and predicate
- extension-ctx
- extension-ctx?
- ;; Constructor
- make-extension-ctx
- ;; Accessors
- ctx-session-id
- ctx-session-dir
- ctx-event-bus
- ctx-extension-registry
- ctx-model
- ctx-signal
- ctx-cwd)
+;; Struct and predicate
+(provide extension-ctx
+         extension-ctx?
+         ;; Constructor
+         make-extension-ctx
+         ;; Accessors (original)
+         ctx-session-id
+         ctx-session-dir
+         ctx-event-bus
+         ctx-extension-registry
+         ctx-model
+         ctx-signal
+         ctx-cwd
+         ;; Accessors (FEAT-58: rich extension context)
+         ctx-session-store
+         ctx-tool-registry
+         ctx-command-registry
+         ctx-ui-channel)
 
 ;; ============================================================
 ;; extension-ctx struct
 ;; ============================================================
 
 (struct extension-ctx
-  (session-id          ; string?
-   session-dir         ; (or/c path-string? #f)
-   event-bus           ; event-bus?
-   extension-registry  ; extension-registry?
-   model-name          ; (or/c string? #f)
-   cancellation-token  ; (or/c cancellation-token? #f)
-   working-directory)  ; (or/c path-string? #f)
+        (session-id ; string?
+         session-dir ; (or/c path-string? #f)
+         event-bus ; event-bus?
+         extension-registry ; extension-registry?
+         model-name ; (or/c string? #f)
+         cancellation-token ; (or/c cancellation-token? #f)
+         working-directory ; (or/c path-string? #f)
+         ;; FEAT-58: rich extension context fields
+         session-store ; (or/c any/c #f) — read-only session access
+         tool-registry ; (or/c any/c #f) — dynamic tool registration
+         command-registry ; (or/c any/c #f) — slash command registration
+         ui-channel) ; (or/c channel? #f) — user interaction requests
   #:transparent)
 
 ;; ============================================================
 ;; Constructor — keyword args with optional fields defaulting to #f
 ;; ============================================================
 
-(define (make-extension-ctx
-         #:session-id session-id
-         #:session-dir session-dir
-         #:event-bus event-bus
-         #:extension-registry extension-registry
-         #:model-name [model-name #f]
-         #:cancellation-token [cancellation-token #f]
-         #:working-directory [working-directory #f])
+(define (make-extension-ctx #:session-id session-id
+                            #:session-dir session-dir
+                            #:event-bus event-bus
+                            #:extension-registry extension-registry
+                            #:model-name [model-name #f]
+                            #:cancellation-token [cancellation-token #f]
+                            #:working-directory [working-directory #f]
+                            ;; FEAT-58: optional rich context fields
+                            #:session-store [session-store #f]
+                            #:tool-registry [tool-registry #f]
+                            #:command-registry [command-registry #f]
+                            #:ui-channel [ui-channel #f])
   (extension-ctx session-id
                  session-dir
                  event-bus
                  extension-registry
                  model-name
                  cancellation-token
-                 working-directory))
+                 working-directory
+                 session-store
+                 tool-registry
+                 command-registry
+                 ui-channel))
 
 ;; ============================================================
 ;; Accessor aliases — short, ergonomic names
@@ -77,3 +94,8 @@
 (define ctx-model extension-ctx-model-name)
 (define ctx-signal extension-ctx-cancellation-token)
 (define ctx-cwd extension-ctx-working-directory)
+;; FEAT-58: rich context accessor aliases
+(define ctx-session-store extension-ctx-session-store)
+(define ctx-tool-registry extension-ctx-tool-registry)
+(define ctx-command-registry extension-ctx-command-registry)
+(define ctx-ui-channel extension-ctx-ui-channel)

--- a/tests/test-extension-context.rkt
+++ b/tests/test-extension-context.rkt
@@ -298,6 +298,169 @@
     (check-eq? (hook-result-action result) 'block)
     (check-equal? (hook-result-payload result) "handler crasher failed for critical hook tool-call")))
 
+;; ============================================================
+;; 1b. extension-ctx new fields (FEAT-58)
+;; ============================================================
+
+(test-case "make-extension-ctx accepts new optional fields (session-store, tool-registry, command-registry, ui-channel)"
+  (define bus (make-event-bus))
+  (define reg (make-extension-registry))
+  (define store (box 'session-store-mock))
+  (define tools (box 'tool-registry-mock))
+  (define cmds (box 'command-registry-mock))
+  (define ui-ch (make-channel))
+  (define ctx
+    (make-extension-ctx #:session-id "sess-058"
+                        #:session-dir "/tmp/sess-058"
+                        #:event-bus bus
+                        #:extension-registry reg
+                        #:session-store store
+                        #:tool-registry tools
+                        #:command-registry cmds
+                        #:ui-channel ui-ch))
+  (check-eq? (ctx-session-store ctx) store)
+  (check-eq? (ctx-tool-registry ctx) tools)
+  (check-eq? (ctx-command-registry ctx) cmds)
+  (check-eq? (ctx-ui-channel ctx) ui-ch))
+
+(test-case "make-extension-ctx new fields default to #f for backward compat"
+  (define ctx
+    (make-extension-ctx #:session-id "s"
+                        #:session-dir "/tmp"
+                        #:event-bus (make-event-bus)
+                        #:extension-registry (make-extension-registry)))
+  (check-false (ctx-session-store ctx))
+  (check-false (ctx-tool-registry ctx))
+  (check-false (ctx-command-registry ctx))
+  (check-false (ctx-ui-channel ctx)))
+
+(test-case "make-extension-ctx with mixed old and new fields"
+  (define bus (make-event-bus))
+  (define reg (make-extension-registry))
+  (define store (box 'store))
+  (define ctx
+    (make-extension-ctx #:session-id "s"
+                        #:session-dir "/tmp"
+                        #:event-bus bus
+                        #:extension-registry reg
+                        #:model-name "gpt-4o"
+                        #:session-store store))
+  (check-equal? (ctx-session-id ctx) "s")
+  (check-equal? (ctx-model ctx) "gpt-4o")
+  (check-eq? (ctx-session-store ctx) store)
+  ;; Others default to #f
+  (check-false (ctx-tool-registry ctx))
+  (check-false (ctx-command-registry ctx))
+  (check-false (ctx-ui-channel ctx)))
+
+(test-case "extension-ctx with new fields is still transparent"
+  (define bus (make-event-bus))
+  (define reg (make-extension-registry))
+  (define ui-ch (make-channel))
+  (define ctx1
+    (make-extension-ctx #:session-id "s"
+                        #:session-dir "/tmp"
+                        #:event-bus bus
+                        #:extension-registry reg
+                        #:ui-channel ui-ch))
+  (define ctx2
+    (make-extension-ctx #:session-id "s"
+                        #:session-dir "/tmp"
+                        #:event-bus bus
+                        #:extension-registry reg
+                        #:ui-channel ui-ch))
+  (check-equal? ctx1 ctx2))
+
+(test-case "ctx-session-store returns session store or #f"
+  (define store (box 'store))
+  (define ctx-with
+    (make-extension-ctx #:session-id "s"
+                        #:session-dir "/tmp"
+                        #:event-bus (make-event-bus)
+                        #:extension-registry (make-extension-registry)
+                        #:session-store store))
+  (check-eq? (ctx-session-store ctx-with) store)
+  (define ctx-without
+    (make-extension-ctx #:session-id "s"
+                        #:session-dir "/tmp"
+                        #:event-bus (make-event-bus)
+                        #:extension-registry (make-extension-registry)))
+  (check-false (ctx-session-store ctx-without)))
+
+(test-case "ctx-tool-registry returns tool registry or #f"
+  (define tools (box 'tools))
+  (define ctx-with
+    (make-extension-ctx #:session-id "s"
+                        #:session-dir "/tmp"
+                        #:event-bus (make-event-bus)
+                        #:extension-registry (make-extension-registry)
+                        #:tool-registry tools))
+  (check-eq? (ctx-tool-registry ctx-with) tools)
+  (define ctx-without
+    (make-extension-ctx #:session-id "s"
+                        #:session-dir "/tmp"
+                        #:event-bus (make-event-bus)
+                        #:extension-registry (make-extension-registry)))
+  (check-false (ctx-tool-registry ctx-without)))
+
+(test-case "ctx-command-registry returns command registry or #f"
+  (define cmds (box 'cmds))
+  (define ctx-with
+    (make-extension-ctx #:session-id "s"
+                        #:session-dir "/tmp"
+                        #:event-bus (make-event-bus)
+                        #:extension-registry (make-extension-registry)
+                        #:command-registry cmds))
+  (check-eq? (ctx-command-registry ctx-with) cmds)
+  (define ctx-without
+    (make-extension-ctx #:session-id "s"
+                        #:session-dir "/tmp"
+                        #:event-bus (make-event-bus)
+                        #:extension-registry (make-extension-registry)))
+  (check-false (ctx-command-registry ctx-without)))
+
+(test-case "ctx-ui-channel returns channel or #f"
+  (define ui-ch (make-channel))
+  (define ctx-with
+    (make-extension-ctx #:session-id "s"
+                        #:session-dir "/tmp"
+                        #:event-bus (make-event-bus)
+                        #:extension-registry (make-extension-registry)
+                        #:ui-channel ui-ch))
+  (check-eq? (ctx-ui-channel ctx-with) ui-ch)
+  (define ctx-without
+    (make-extension-ctx #:session-id "s"
+                        #:session-dir "/tmp"
+                        #:event-bus (make-event-bus)
+                        #:extension-registry (make-extension-registry)))
+  (check-false (ctx-ui-channel ctx-without)))
+
+(test-case "dispatch-hooks with #:ctx: handler can access new ctx fields"
+  (define reg (make-extension-registry))
+  (define store (box 'my-store))
+  (define ctx
+    (make-extension-ctx #:session-id "sess-new-fields"
+                        #:session-dir "/tmp"
+                        #:event-bus (make-event-bus)
+                        #:extension-registry reg
+                        #:session-store store))
+  (define received-store (box #f))
+  (register-extension! reg
+                       (extension "store-reader"
+                                  "1"
+                                  "1"
+                                  (hasheq 'tool-call
+                                          (λ (c p)
+                                            (set-box! received-store (ctx-session-store c))
+                                            (hook-pass p)))))
+  (parameterize ([current-hook-timeout-ms #f])
+    (dispatch-hooks 'tool-call "payload" reg #:ctx ctx)
+    (check-eq? (unbox received-store) store)))
+
+;; ============================================================
+;; 3. backward compat — old tests continue below
+;; ============================================================
+
 (test-case "dispatch-hooks with #:ctx: cancelled token accessible via ctx-signal"
   (define reg (make-extension-registry))
   (define tok (make-cancellation-token))


### PR DESCRIPTION
## FEAT-58: Rich extension-ctx with session-store, tool-registry, ui-channel

### Changes
Add 4 new optional keyword fields to the `extension-ctx` struct:

| Field | Purpose | Default |
|-------|---------|---------|
| `session-store` | Read-only session access for extensions | `#f` |
| `tool-registry` | Dynamic tool registration | `#f` |
| `command-registry` | Slash command registration | `#f` |
| `ui-channel` | Channel for user interaction (confirm/select/input) | `#f` |

### Files Changed
- `q/extensions/context.rkt` — 4 new struct fields + constructor keyword args + accessor aliases
- `q/tests/test-extension-context.rkt` — 10 new test cases

### Backward Compatibility
All new fields default to `#f`. Existing call sites use keyword args, so no changes needed.

### TDD
Tests written first (new field accessors, defaults, transparency, dispatch-hooks integration).

Closes #947
