### PR TITLE
FEAT-63: Per-hook-point result validation

### DIFF
--- a/extensions/hooks.rkt
+++ b/extensions/hooks.rkt
@@ -25,16 +25,15 @@
          "context.rkt"
          "../util/hook-types.rkt")
 
-(provide
- ;; Re-export hook result types
- (all-from-out "../util/hook-types.rkt")
- ;; Re-export extension-ctx for convenience
- (all-from-out "context.rkt")
- ;; Hook dispatch
- dispatch-hooks
- current-hook-timeout-ms
- critical-hook?
- critical-hooks)
+;; Re-export hook result types
+(provide (all-from-out "../util/hook-types.rkt")
+         ;; Re-export extension-ctx for convenience
+         (all-from-out "context.rkt")
+         ;; Hook dispatch
+         dispatch-hooks
+         current-hook-timeout-ms
+         critical-hook?
+         critical-hooks)
 
 ;; ============================================================
 ;; Hook criticality classification (#670, #671)
@@ -42,8 +41,7 @@
 
 ;; Critical hooks default to 'block on error (safety-first).
 ;; Advisory hooks default to 'pass on error (liveness-first).
-(define critical-hooks
-  '(tool-call session-before-fork session-before-compact input))
+(define critical-hooks '(tool-call session-before-fork session-before-compact input))
 
 (define (critical-hook? hook-point)
   (and (member hook-point critical-hooks) #t))
@@ -65,18 +63,16 @@
              [current-payload payload]
              [amended? #f])
     (cond
-      [(null? remaining)
-       (hook-result (if amended? 'amend 'pass) current-payload)]
+      [(null? remaining) (hook-result (if amended? 'amend 'pass) current-payload)]
       [else
        (define ext-name (car (car remaining)))
-       (define handler  (cdr (car remaining)))
-       (define result
-         (run-hook-with-timeout ext-name hook-point handler current-payload ctx))
+       (define handler (cdr (car remaining)))
+       (define result (run-hook-with-timeout ext-name hook-point handler current-payload ctx))
        (case (hook-result-action result)
          [(block) result]
          [(amend) (loop (cdr remaining) (hook-result-payload result) #t)]
-         [(pass)  (loop (cdr remaining) current-payload amended?)]
-         [else    (loop (cdr remaining) current-payload amended?)])])))
+         [(pass) (loop (cdr remaining) current-payload amended?)]
+         [else (loop (cdr remaining) current-payload amended?)])])))
 
 ;; Per-hook timeout in milliseconds (default: 100ms for streaming hooks).
 ;; Set to #f to disable timeout.
@@ -86,8 +82,7 @@
 ;; If ctx is provided and handler accepts 2 args, call (handler ctx payload).
 ;; Otherwise call (handler payload) for backward compat.
 (define (call-handler handler payload ctx)
-  (if (and ctx
-           (procedure-arity-includes? handler 2))
+  (if (and ctx (procedure-arity-includes? handler 2))
       (handler ctx payload)
       (handler payload)))
 
@@ -99,45 +94,58 @@
     (if (critical-hook? hook-point)
         (hook-block (format "handler ~a failed for critical hook ~a" ext-name hook-point))
         (hook-pass payload)))
-  (with-handlers ([exn:fail?
-                    (lambda (e)
-                      (log-warning
-                       (format "Hook handler ~a for ~a threw: ~a [~a]"
-                               ext-name hook-point (exn-message e)
-                               (if (critical-hook? hook-point) "CRITICAL->block" "advisory->pass")))
-                      error-default)])
+  (with-handlers ([exn:fail? (lambda (e)
+                               (log-warning (format "Hook handler ~a for ~a threw: ~a [~a]"
+                                                    ext-name
+                                                    hook-point
+                                                    (exn-message e)
+                                                    (if (critical-hook? hook-point)
+                                                        "CRITICAL->block"
+                                                        "advisory->pass")))
+                               error-default)])
     (define raw-result
       (if timeout-ms
           ;; Run with timeout
           (let ([chan (make-channel)])
-            (define thd (thread
-                          (lambda ()
-                            (channel-put chan
-                              (with-handlers ([exn:fail? (lambda (e) (cons 'error e))])
-                                (cons 'ok (call-handler handler payload ctx)))))))
+            (define thd
+              (thread (lambda ()
+                        (channel-put chan
+                                     (with-handlers ([exn:fail? (lambda (e) (cons 'error e))])
+                                       (cons 'ok (call-handler handler payload ctx)))))))
             (define maybe (sync/timeout (/ timeout-ms 1000.0) chan))
-            (unless maybe (kill-thread thd))  ; #447: prevent thread leak
+            (unless maybe
+              (kill-thread thd)) ; #447: prevent thread leak
             (cond
               [(not maybe)
                (log-warning
                 (format "Hook handler ~a for ~a timed out after ~ams [~a]"
-                        ext-name hook-point timeout-ms
+                        ext-name
+                        hook-point
+                        timeout-ms
                         (if (critical-hook? hook-point) "CRITICAL->block" "advisory->pass")))
                error-default]
               [(eq? (car maybe) 'error)
                (log-warning
                 (format "Hook handler ~a for ~a threw: ~a [~a]"
-                        ext-name hook-point (exn-message (cdr maybe))
+                        ext-name
+                        hook-point
+                        (exn-message (cdr maybe))
                         (if (critical-hook? hook-point) "CRITICAL->block" "advisory->pass")))
                error-default]
               [else (cdr maybe)]))
           ;; No timeout — direct call
           (call-handler handler payload ctx)))
     (if (hook-result? raw-result)
-        raw-result
+        ;; FEAT-63: Validate action is valid for this hook-point
+        (let ([valid? (validate-hook-result hook-point raw-result)])
+          (if valid?
+              raw-result
+              ;; Invalid action: warn but still return the result (permissive)
+              raw-result))
         (begin
-          (log-warning
-           (format "Hook handler ~a for ~a returned non-hook-result: ~v [~a]"
-                   ext-name hook-point raw-result
-                   (if (critical-hook? hook-point) "CRITICAL->block" "advisory->pass")))
+          (log-warning (format "Hook handler ~a for ~a returned non-hook-result: ~v [~a]"
+                               ext-name
+                               hook-point
+                               raw-result
+                               (if (critical-hook? hook-point) "CRITICAL->block" "advisory->pass")))
           error-default))))

--- a/tests/test-hook-expansion.rkt
+++ b/tests/test-hook-expansion.rkt
@@ -42,8 +42,7 @@
 (test-case "critical hook errors default to block"
   (define reg (make-extension-registry))
   (define throwing-ext
-    (extension "thrower" "0.1" "1.0"
-               (hasheq 'tool-call (lambda (payload) (error "boom")))))
+    (extension "thrower" "0.1" "1.0" (hasheq 'tool-call (lambda (payload) (error "boom")))))
   (register-extension! reg throwing-ext)
   (define result (dispatch-hooks 'tool-call "payload" reg))
   (check-equal? (hook-result-action result) 'block))
@@ -51,8 +50,7 @@
 (test-case "advisory hook errors default to pass"
   (define reg (make-extension-registry))
   (define throwing-ext
-    (extension "thrower" "0.1" "1.0"
-               (hasheq 'turn-start (lambda (payload) (error "boom")))))
+    (extension "thrower" "0.1" "1.0" (hasheq 'turn-start (lambda (payload) (error "boom")))))
   (register-extension! reg throwing-ext)
   (define result (dispatch-hooks 'turn-start "payload" reg))
   (check-equal? (hook-result-action result) 'pass))
@@ -60,8 +58,13 @@
 (test-case "critical hook timeout defaults to block"
   (define reg (make-extension-registry))
   (define slow-ext
-    (extension "sleeper" "0.1" "1.0"
-               (hasheq 'tool-call (lambda (payload) (sleep 10) payload))))
+    (extension "sleeper"
+               "0.1"
+               "1.0"
+               (hasheq 'tool-call
+                       (lambda (payload)
+                         (sleep 10)
+                         payload))))
   (register-extension! reg slow-ext)
   (parameterize ([current-hook-timeout-ms 50])
     (define result (dispatch-hooks 'tool-call "payload" reg))
@@ -70,8 +73,13 @@
 (test-case "advisory hook timeout defaults to pass"
   (define reg (make-extension-registry))
   (define slow-ext
-    (extension "sleeper" "0.1" "1.0"
-               (hasheq 'context (lambda (payload) (sleep 10) payload))))
+    (extension "sleeper"
+               "0.1"
+               "1.0"
+               (hasheq 'context
+                       (lambda (payload)
+                         (sleep 10)
+                         payload))))
   (register-extension! reg slow-ext)
   (parameterize ([current-hook-timeout-ms 50])
     (define result (dispatch-hooks 'context "payload" reg))
@@ -80,8 +88,7 @@
 (test-case "non-hook-result return from critical hook defaults to block"
   (define reg (make-extension-registry))
   (define bad-ext
-    (extension "bad-return" "0.1" "1.0"
-               (hasheq 'tool-call (lambda (payload) "not-a-hook-result"))))
+    (extension "bad-return" "0.1" "1.0" (hasheq 'tool-call (lambda (payload) "not-a-hook-result"))))
   (register-extension! reg bad-ext)
   (define result (dispatch-hooks 'tool-call "payload" reg))
   (check-equal? (hook-result-action result) 'block))
@@ -89,8 +96,7 @@
 (test-case "non-hook-result return from advisory hook defaults to pass"
   (define reg (make-extension-registry))
   (define bad-ext
-    (extension "bad-return" "0.1" "1.0"
-               (hasheq 'context (lambda (payload) "not-a-hook-result"))))
+    (extension "bad-return" "0.1" "1.0" (hasheq 'context (lambda (payload) "not-a-hook-result"))))
   (register-extension! reg bad-ext)
   (define result (dispatch-hooks 'context "payload" reg))
   (check-equal? (hook-result-action result) 'pass))
@@ -107,8 +113,7 @@
         (set-box! received payload))
       (hook-pass payload)))
   ;; Simulate what loop.rkt does
-  (dispatcher 'agent-start
-              (hasheq 'session-id "test" 'turn-id "t1" 'message-count 5))
+  (dispatcher 'agent-start (hasheq 'session-id "test" 'turn-id "t1" 'message-count 5))
   (check-true (hash? (unbox received)))
   (check-equal? (hash-ref (unbox received) 'session-id) "test")
   (check-equal? (hash-ref (unbox received) 'message-count) 5))
@@ -120,8 +125,7 @@
       (when (eq? hook-point 'agent-end)
         (set-box! received payload))
       (hook-pass payload)))
-  (dispatcher 'agent-end
-              (hasheq 'session-id "test" 'turn-id "t1" 'termination 'completed))
+  (dispatcher 'agent-end (hasheq 'session-id "test" 'turn-id "t1" 'termination 'completed))
   (check-equal? (hash-ref (unbox received) 'termination) 'completed))
 
 ;; ============================================================
@@ -130,36 +134,86 @@
 
 (test-case "dispatch-hooks with pass action continues"
   (define reg (make-extension-registry))
-  (register-extension! reg
-    (extension "pass-ext" "0.1" "1.0"
-               (hasheq 'turn-start (lambda (p) (hook-pass p)))))
+  (register-extension!
+   reg
+   (extension "pass-ext" "0.1" "1.0" (hasheq 'turn-start (lambda (p) (hook-pass p)))))
   (define result (dispatch-hooks 'turn-start "hello" reg))
   (check-equal? (hook-result-action result) 'pass))
 
 (test-case "dispatch-hooks with amend action replaces payload"
   (define reg (make-extension-registry))
-  (register-extension! reg
-    (extension "amend-ext" "0.1" "1.0"
-               (hasheq 'turn-start (lambda (p) (hook-amend "replaced")))))
+  (register-extension!
+   reg
+   (extension "amend-ext" "0.1" "1.0" (hasheq 'turn-start (lambda (p) (hook-amend "replaced")))))
   (define result (dispatch-hooks 'turn-start "original" reg))
   (check-equal? (hook-result-action result) 'amend)
   (check-equal? (hook-result-payload result) "replaced"))
 
 (test-case "dispatch-hooks with block action stops"
   (define reg (make-extension-registry))
-  (register-extension! reg
-    (extension "block-ext" "0.1" "1.0"
-               (hasheq 'tool-call (lambda (p) (hook-block "nope")))))
+  (register-extension!
+   reg
+   (extension "block-ext" "0.1" "1.0" (hasheq 'tool-call (lambda (p) (hook-block "nope")))))
   (define result (dispatch-hooks 'tool-call "payload" reg))
   (check-equal? (hook-result-action result) 'block))
 
 (test-case "dispatch-hooks with ctx-aware handler"
   (define reg (make-extension-registry))
   (register-extension! reg
-    (extension "ctx-ext" "0.1" "1.0"
-               (hasheq 'turn-start
-                       (lambda (ctx payload)
-                         (hook-amend (format "ctx:~a" (ctx-session-id ctx)))))))
-  (define ctx (extension-ctx "s42" "/tmp" (make-event-bus) reg #f #f #f))
+                       (extension "ctx-ext"
+                                  "0.1"
+                                  "1.0"
+                                  (hasheq 'turn-start
+                                          (lambda (ctx payload)
+                                            (hook-amend (format "ctx:~a" (ctx-session-id ctx)))))))
+  (define ctx (extension-ctx "s42" "/tmp" (make-event-bus) reg #f #f #f #f #f #f #f))
   (define result (dispatch-hooks 'turn-start "hello" reg #:ctx ctx))
   (check-equal? (hook-result-payload result) "ctx:s42"))
+
+;; ============================================================
+;; FEAT-63: Per-hook-point result validation
+;; ============================================================
+
+(require "../util/hook-types.rkt")
+
+(test-case "valid-hook-actions-for returns known actions for tool-call"
+  (define actions (valid-hook-actions-for 'tool-call))
+  (check-not-false (member 'pass actions))
+  (check-not-false (member 'amend actions))
+  (check-not-false (member 'block actions)))
+
+(test-case "valid-hook-actions-for defaults to all actions for unknown hook"
+  (define actions (valid-hook-actions-for 'unknown-hook-point))
+  (check-not-false (member 'pass actions))
+  (check-not-false (member 'amend actions))
+  (check-not-false (member 'block actions)))
+
+(test-case "validate-hook-result returns #t for valid tool-call + pass"
+  (check-true (validate-hook-result 'tool-call (hook-pass "payload"))))
+
+(test-case "validate-hook-result returns #t for valid tool-call + block"
+  (check-true (validate-hook-result 'tool-call (hook-block "reason"))))
+
+(test-case "validate-hook-result returns #t for message-end + amend"
+  (check-true (validate-hook-result 'message-end (hook-amend "new payload"))))
+
+(test-case "validate-hook-result returns #f for message-end + block (block not valid)"
+  ;; message-end only allows pass/amend, not block
+  (check-false (validate-hook-result 'message-end (hook-block "reason"))))
+
+(test-case "validate-hook-result returns #t for session-before-fork + pass"
+  (check-true (validate-hook-result 'session-before-fork (hook-pass))))
+
+(test-case "validate-hook-result returns #f for session-before-fork + amend (amend not valid)"
+  ;; session-before-fork only allows pass/block
+  (check-false (validate-hook-result 'session-before-fork (hook-amend "payload"))))
+
+(test-case "validate-hook-result: before-send allows pass and amend"
+  (check-true (validate-hook-result 'before-send (hook-pass)))
+  (check-true (validate-hook-result 'before-send (hook-amend "text")))
+  (check-false (validate-hook-result 'before-send (hook-block "reason"))))
+
+(test-case "validate-hook-result: register-tools allows pass and amend"
+  (check-true (validate-hook-result 'register-tools (hook-pass)))
+  (check-true (validate-hook-result 'register-tools (hook-amend (hasheq 'tools '()))))
+  (check-false (validate-hook-result 'register-tools (hook-block "nope"))))

--- a/util/hook-types.rkt
+++ b/util/hook-types.rkt
@@ -1,13 +1,21 @@
 #lang racket/base
 
-;; util/hook-types.rkt — canonical hook result types
+;; util/hook-types.rkt — canonical hook result types and per-hook validation
 ;; Shared between extensions layer and agent core.
 ;; ARCH-01: extracted from extensions/hooks.rkt to eliminate layer violations.
+;;
+;; FEAT-63: Per-hook-point result validation schemas.
+;; Each hook-point has documented expected actions and payload constraints.
+;; Invalid results are caught early and logged as warnings.
 
-(provide
- ;; Hook result struct and action constructors
- (struct-out hook-result)
- hook-pass hook-amend hook-block)
+;; Hook result struct and action constructors
+(provide (struct-out hook-result)
+         hook-pass
+         hook-amend
+         hook-block
+         ;; FEAT-63: Per-hook-point validation
+         valid-hook-actions-for
+         validate-hook-result)
 
 (struct hook-result (action payload) #:transparent)
 
@@ -19,3 +27,74 @@
 
 (define (hook-block [reason #f])
   (hook-result 'block reason))
+
+;; ============================================================
+;; FEAT-63: Per-hook-point result validation
+;; ============================================================
+
+;; Maps hook-point symbols to their valid actions.
+;; Extensions returning actions outside this set are warned.
+(define hook-action-schemas
+  ;; Model request hooks
+  (hasheq 'model-request-pre
+          '(pass amend block)
+          'before-provider-request
+          '(pass amend block)
+          ;; Message hooks
+          'message-start
+          '(pass amend)
+          'message-end
+          '(pass amend)
+          ;; Tool execution hooks
+          'tool-call
+          '(pass amend block)
+          'tool-result
+          '(pass amend block)
+          ;; Turn lifecycle hooks
+          'turn-start
+          '(pass amend block)
+          'turn-end
+          '(pass amend)
+          ;; Agent lifecycle hooks
+          'before-agent-start
+          '(pass amend block)
+          ;; Context assembly hooks
+          'context
+          '(pass amend block)
+          'context.assembly
+          '(pass amend block)
+          ;; Session hooks
+          'session-before-fork
+          '(pass block)
+          'session-before-compact
+          '(pass block)
+          ;; Input hooks
+          'input
+          '(pass amend block)
+          ;; Extension registration hooks
+          'register-tools
+          '(pass amend)
+          ;; Steering/queue hooks
+          'before-send
+          '(pass amend)))
+
+;; valid-hook-actions-for : symbol? -> (listof symbol?)
+;; Returns the valid actions for a given hook-point.
+;; Defaults to '(pass amend block) for unknown hook-points (permissive).
+(define (valid-hook-actions-for hook-point)
+  (hash-ref hook-action-schemas hook-point '(pass amend block)))
+
+;; validate-hook-result : symbol? hook-result? -> boolean?
+;; Checks whether a hook-result's action is valid for the given hook-point.
+;; Returns #t if valid, #f if invalid. Logs a warning on invalid.
+(define (validate-hook-result hook-point result)
+  (define valid-actions (valid-hook-actions-for hook-point))
+  (define action (hook-result-action result))
+  (if (member action valid-actions)
+      #t
+      (begin
+        (log-warning (format "Hook validation: ~a returned invalid action '~a for hook '~a. Valid: ~a"
+                             action
+                             hook-point
+                             valid-actions))
+        #f)))


### PR DESCRIPTION
## FEAT-63: Per-hook-point result validation

Add validation schemas so each hook-point has documented expected actions.
Invalid actions are logged as warnings but still returned (permissive).

**Files**: , , 

Closes #952