### PR TITLE
FEAT-59: Channel-based UI interaction for extensions

### DIFF
--- a/extensions/ui-channel.rkt
+++ b/extensions/ui-channel.rkt
@@ -1,0 +1,150 @@
+#lang racket/base
+
+;; extensions/ui-channel.rkt — Channel-based UI interaction for extensions
+;;
+;; FEAT-59: Provides blocking UI primitives that extensions call to interact
+;; with the user through the TUI via a channel-based request/response protocol.
+;;
+;; The ui-channel is a Racket channel? that carries UI request structs.
+;; The TUI (or test harness) reads from this channel and sends responses
+;; back via the response channel embedded in each request.
+
+(require racket/contract)
+
+;; UI request structs
+(provide (struct-out ui-request)
+         (struct-out ui-confirm-request)
+         (struct-out ui-select-request)
+         (struct-out ui-input-request)
+         (struct-out ui-response)
+
+         ;; High-level API for extensions
+         ui-confirm!
+         ui-select!
+         ui-input!
+
+         ;; Channel creation
+         make-ui-channel
+         ui-channel?
+
+         ;; Response waiting
+         wait-for-ui-response)
+
+;; ============================================================
+;; UI channel type
+;; ============================================================
+
+;; A ui-channel is just a Racket channel that carries ui-request? values.
+(define (ui-channel? v)
+  (channel? v))
+(define (make-ui-channel)
+  (make-channel))
+
+;; ============================================================
+;; UI request/response structs
+;; ============================================================
+
+;; Base request
+(struct ui-request
+        (type ; symbol — 'confirm, 'select, 'input
+         response-ch ; channel? — where to send the response
+         prompt ; string?
+         )
+  #:transparent)
+
+;; Confirm request: yes/no
+(struct ui-confirm-request
+        ui-request
+        (default ; boolean?
+         )
+  #:transparent)
+
+;; Select request: pick from list
+(struct ui-select-request
+        ui-request
+        (options ; (listof (cons/c string? string?)) — (id . label)
+         multi? ; boolean? — allow multi-select
+         )
+  #:transparent)
+
+;; Input request: free text
+(struct ui-input-request
+        ui-request
+        (default ; (or/c string? #f)
+         placeholder ; (or/c string? #f)
+         )
+  #:transparent)
+
+;; Response from UI
+(struct ui-response
+        (value ; any/c — the user's response
+         cancelled? ; boolean? — did the user cancel?
+         )
+  #:transparent)
+
+;; ============================================================
+;; High-level API
+;; ============================================================
+
+;; ui-confirm! : ui-channel? string? #:default boolean? #:timeout number? -> (or/c boolean? 'timed-out)
+(define (ui-confirm! ch prompt #:default [default #f] #:timeout [timeout 30])
+  (define resp-ch (make-channel))
+  (define req (ui-confirm-request 'confirm resp-ch prompt default))
+  (channel-put ch req)
+  (wait-for-ui-response resp-ch
+                        timeout
+                        (lambda () default) ; timeout → default
+                        (lambda (resp)
+                          (if (ui-response-cancelled? resp)
+                              #f
+                              (ui-response-value resp)))))
+
+;; ui-select! : ui-channel? (listof (cons/c string? string?))
+;;              #:prompt string? #:multi? boolean? #:timeout number?
+;;              -> (or/c (listof string?) 'timed-out #f)
+(define (ui-select! ch
+                    options
+                    #:prompt [prompt "Select:"]
+                    #:multi? [multi? #f]
+                    #:timeout [timeout 60])
+  (if (null? options)
+      #f
+      (let ([resp-ch (make-channel)])
+        (define req (ui-select-request 'select resp-ch prompt options multi?))
+        (channel-put ch req)
+        (wait-for-ui-response resp-ch
+                              timeout
+                              (lambda () 'timed-out)
+                              (lambda (resp)
+                                (if (ui-response-cancelled? resp)
+                                    #f
+                                    (ui-response-value resp)))))))
+
+;; ui-input! : ui-channel? string? #:default (or/c string? #f) #:timeout number?
+;;             -> (or/c string? 'timed-out #f)
+(define (ui-input! ch
+                   prompt
+                   #:default [default #f]
+                   #:placeholder [placeholder ""]
+                   #:timeout [timeout 120])
+  (define resp-ch (make-channel))
+  (define req (ui-input-request 'input resp-ch prompt default placeholder))
+  (channel-put ch req)
+  (wait-for-ui-response resp-ch
+                        timeout
+                        (lambda () 'timed-out)
+                        (lambda (resp)
+                          (if (ui-response-cancelled? resp)
+                              #f
+                              (ui-response-value resp)))))
+
+;; ============================================================
+;; Response waiting
+;; ============================================================
+
+;; wait-for-ui-response : channel? number? (-> any) (ui-response? -> any) -> any
+(define (wait-for-ui-response resp-ch timeout on-timeout on-response)
+  (define result (sync/timeout timeout resp-ch))
+  (if (not result)
+      (on-timeout)
+      (on-response result)))

--- a/tests/test-ui-channel.rkt
+++ b/tests/test-ui-channel.rkt
@@ -1,0 +1,140 @@
+#lang racket
+
+;; tests/test-ui-channel.rkt — FEAT-59: channel-based UI interaction
+
+(require rackunit
+         "../extensions/ui-channel.rkt")
+
+;; ============================================================
+;; Helper: run a UI call in a thread, return request + result channel
+;; ============================================================
+
+(define (run-ui-in-thread thunk)
+  (define result-ch (make-channel))
+  (define ui-ch (make-ui-channel))
+  (thread (lambda ()
+            (define r (thunk ui-ch))
+            (channel-put result-ch (list 'done r))))
+  (define req (channel-get ui-ch))
+  (values req result-ch))
+
+;; ============================================================
+;; Struct shape tests
+;; ============================================================
+
+(test-case "ui-confirm-request has correct type, prompt, default"
+  (define-values (req result-ch)
+    (run-ui-in-thread (lambda (ch) (ui-confirm! ch "Continue?" #:default #t #:timeout 5))))
+  (check-equal? (ui-request-type req) 'confirm)
+  (check-equal? (ui-request-prompt req) "Continue?")
+  (check-equal? (ui-confirm-request-default req) #t)
+  (channel-put (ui-request-response-ch req) (ui-response #t #f))
+  (channel-get result-ch))
+
+(test-case "ui-select-request has options and multi?"
+  (define-values (req result-ch)
+    (run-ui-in-thread (lambda (ch)
+                        (ui-select! ch
+                                    '(("a" . "Option A") ("b" . "Option B"))
+                                    #:prompt "Pick one"
+                                    #:multi? #t
+                                    #:timeout 5))))
+  (check-equal? (ui-request-type req) 'select)
+  (check-equal? (ui-select-request-multi? req) #t)
+  (check-equal? (length (ui-select-request-options req)) 2)
+  (channel-put (ui-request-response-ch req) (ui-response '("a") #f))
+  (channel-get result-ch))
+
+(test-case "ui-input-request has placeholder and default"
+  (define-values (req result-ch)
+    (run-ui-in-thread
+     (lambda (ch) (ui-input! ch "Name?" #:default "anon" #:placeholder "type here" #:timeout 5))))
+  (check-equal? (ui-request-type req) 'input)
+  (check-equal? (ui-input-request-placeholder req) "type here")
+  (check-equal? (ui-input-request-default req) "anon")
+  (channel-put (ui-request-response-ch req) (ui-response "anon" #f))
+  (channel-get result-ch))
+
+;; ============================================================
+;; Confirm response handling
+;; ============================================================
+
+(test-case "ui-confirm! returns user value on confirm"
+  (define-values (req result-ch)
+    (run-ui-in-thread (lambda (ch) (ui-confirm! ch "OK?" #:default #f #:timeout 5))))
+  (channel-put (ui-request-response-ch req) (ui-response #t #f))
+  (define result-msg (channel-get result-ch))
+  (check-equal? (cadr result-msg) #t))
+
+(test-case "ui-confirm! returns #f on cancelled"
+  (define-values (req result-ch)
+    (run-ui-in-thread (lambda (ch) (ui-confirm! ch "Sure?" #:timeout 5))))
+  (channel-put (ui-request-response-ch req) (ui-response #t #t))
+  (define result-msg (channel-get result-ch))
+  (check-equal? (cadr result-msg) #f))
+
+;; ============================================================
+;; Select response handling
+;; ============================================================
+
+(test-case "ui-select! returns selected id"
+  (define-values (req result-ch)
+    (run-ui-in-thread (lambda (ch) (ui-select! ch '(("x" . "X") ("y" . "Y")) #:timeout 5))))
+  (channel-put (ui-request-response-ch req) (ui-response '("x") #f))
+  (define result-msg (channel-get result-ch))
+  (check-equal? (cadr result-msg) '("x")))
+
+(test-case "ui-select! returns #f on empty options"
+  (check-equal? (ui-select! (make-ui-channel) '() #:timeout 1) #f))
+
+(test-case "ui-select! returns #f on cancelled"
+  (define-values (req result-ch)
+    (run-ui-in-thread (lambda (ch) (ui-select! ch '(("a" . "A")) #:timeout 5))))
+  (channel-put (ui-request-response-ch req) (ui-response #f #t))
+  (define result-msg (channel-get result-ch))
+  (check-false (cadr result-msg)))
+
+;; ============================================================
+;; Input response handling
+;; ============================================================
+
+(test-case "ui-input! returns user text"
+  (define-values (req result-ch) (run-ui-in-thread (lambda (ch) (ui-input! ch "Enter:" #:timeout 5))))
+  (channel-put (ui-request-response-ch req) (ui-response "hello" #f))
+  (define result-msg (channel-get result-ch))
+  (check-equal? (cadr result-msg) "hello"))
+
+(test-case "ui-input! returns #f on cancelled"
+  (define-values (req result-ch) (run-ui-in-thread (lambda (ch) (ui-input! ch "Name?" #:timeout 5))))
+  (channel-put (ui-request-response-ch req) (ui-response "" #t))
+  (define result-msg (channel-get result-ch))
+  (check-false (cadr result-msg)))
+
+;; ============================================================
+;; Timeout handling
+;; ============================================================
+
+(test-case "ui-confirm! returns default on timeout"
+  (define ch (make-ui-channel))
+  (thread (lambda () (channel-get ch))) ; drain request, don't respond
+  (define result (ui-confirm! ch "Wait?" #:default #t #:timeout 0.1))
+  (check-equal? result #t))
+
+(test-case "ui-select! returns timed-out on timeout"
+  (define ch (make-ui-channel))
+  (thread (lambda () (channel-get ch))) ; drain request
+  (define result (ui-select! ch '(("a" . "A")) #:timeout 0.1))
+  (check-equal? result 'timed-out))
+
+(test-case "ui-input! returns timed-out on timeout"
+  (define ch (make-ui-channel))
+  (thread (lambda () (channel-get ch))) ; drain request
+  (define result (ui-input! ch "Quick!" #:timeout 0.1))
+  (check-equal? result 'timed-out))
+
+;; ============================================================
+;; Channel type
+;; ============================================================
+
+(test-case "make-ui-channel creates a ui-channel"
+  (check-true (ui-channel? (make-ui-channel))))


### PR DESCRIPTION
## FEAT-59: Channel-based UI interaction

Add blocking UI primitives (ui-confirm!, ui-select!, ui-input!) with channel-based request/response protocol.

14 test cases covering struct shapes, responses, cancellation, timeouts.

Closes #948