### PR TITLE
FEAT-64: Leaf pointer navigation in session tree

### DIFF
--- a/runtime/session-index.rkt
+++ b/runtime/session-index.rkt
@@ -28,6 +28,7 @@
          "../runtime/session-store.rkt")
 
 (provide session-index?
+         session-index
          session-index-by-id
          session-index-entry-order
          session-index-bookmarks
@@ -54,6 +55,17 @@
          bookmark?
          bookmark-id
          bookmark-entry-id
+         ;; FEAT-64: navigation
+         navigate-result
+         navigate-result?
+         navigate-result-entry
+         navigate-result-branch
+         navigate-result-children
+         navigate-result-leaf?
+         navigate-to-entry!
+         navigate-to-leaf!
+         navigate-next-leaf!
+         navigate-prev-leaf!
          bookmark-label
          bookmark-timestamp
          make-bookmark
@@ -235,6 +247,62 @@
       #f))
 
 ;; ============================================================
+;; FEAT-64: Leaf pointer navigation
+;; ============================================================
+
+;; navigate-result : entry branch children leaf?
+(struct navigate-result (entry branch children leaf?) #:transparent)
+
+(define (navigate-to-entry! idx entry-id)
+  (define entry (lookup-entry idx entry-id))
+  (if (not entry)
+      #f
+      (let* ([branch (or (get-branch idx entry-id) '())]
+             [children (hash-ref (session-index-children idx) entry-id '())]
+             [is-leaf (null? children)])
+        (set-box! (session-index-active-leaf-id idx) entry-id)
+        (navigate-result entry branch children is-leaf))))
+
+(define (navigate-to-leaf! idx entry-id)
+  (define result (navigate-to-entry! idx entry-id))
+  (if (and result (navigate-result-leaf? result)) result #f))
+
+(define (navigate-next-leaf! idx)
+  (define leaves (leaf-nodes idx))
+  (if (null? leaves)
+      #f
+      (let* ([current-id (unbox (session-index-active-leaf-id idx))]
+             [leaf-ids (map message-id leaves)]
+             [current-pos (if current-id
+                              (or (for/first ([id (in-list leaf-ids)]
+                                              [i (in-naturals)]
+                                              #:when (equal? id current-id))
+                                    i)
+                                  -1)
+                              -1)]
+             [next-pos (modulo (add1 current-pos) (length leaves))]
+             [next-entry (list-ref leaves next-pos)])
+        (navigate-to-entry! idx (message-id next-entry)))))
+
+(define (navigate-prev-leaf! idx)
+  (define leaves (leaf-nodes idx))
+  (if (null? leaves)
+      #f
+      (let* ([current-id (unbox (session-index-active-leaf-id idx))]
+             [leaf-ids (map message-id leaves)]
+             [n (length leaves)]
+             [current-pos (if current-id
+                              (or (for/first ([id (in-list leaf-ids)]
+                                              [i (in-naturals)]
+                                              #:when (equal? id current-id))
+                                    i)
+                                  0)
+                              0)]
+             [prev-pos (modulo (sub1 current-pos) n)]
+             [prev-entry (list-ref leaves prev-pos)])
+        (navigate-to-entry! idx (message-id prev-entry)))))
+
+;; ============================================================
 ;; Tree operations (#496)
 ;; ============================================================
 
@@ -304,21 +372,23 @@
 
 ;; Build a set of all ancestors of a given entry (inclusive)
 (define (ancestor-set idx id)
-  (let loop ([current id] [acc (set)])
+  (let loop ([current id]
+             [acc (set)])
     (cond
       [(not current) acc]
       [(set-member? acc current) acc]
       [else
        (define msg (hash-ref (session-index-by-id idx) current #f))
-       (loop (and msg (message-parent-id msg))
-             (set-add acc current))])))
+       (loop (and msg (message-parent-id msg)) (set-add acc current))])))
 
 ;; Collect entries along the path from old-leaf-id towards ancestor-id.
 ;; Stops at ancestor-id or when token budget is exhausted.
 ;; Returns (listof message) in chronological order (oldest first).
 ;; session-index? string? string? integer? -> (listof message)
 (define (collect-branch-entries idx old-leaf-id ancestor-id token-budget)
-  (let loop ([current old-leaf-id] [acc '()] [tokens-used 0])
+  (let loop ([current old-leaf-id]
+             [acc '()]
+             [tokens-used 0])
     (cond
       [(not current) acc]
       [(equal? current ancestor-id) acc]
@@ -329,17 +399,15 @@
          [(not msg) acc]
          [else
           (define cost (estimate-entry-tokens msg))
-          (loop (message-parent-id msg)
-                (cons msg acc)
-                (+ tokens-used cost))])])))
+          (loop (message-parent-id msg) (cons msg acc) (+ tokens-used cost))])])))
 
 ;; Rough token estimate for a message (~4 chars per token)
 (define (estimate-entry-tokens msg)
   (define content (message-content msg))
   (for/sum ([part (in-list content)])
-    (cond
-      [(text-part? part) (quotient (string-length (text-part-text part)) 4)]
-      [else 10]))) ; rough estimate for non-text parts
+           (cond
+             [(text-part? part) (quotient (string-length (text-part-text part)) 4)]
+             [else 10]))) ; rough estimate for non-text parts
 
 (require racket/set)
 

--- a/tests/test-session-navigation.rkt
+++ b/tests/test-session-navigation.rkt
@@ -1,0 +1,112 @@
+#lang racket
+
+;; tests/test-session-navigation.rkt — FEAT-64: leaf pointer navigation
+
+(require rackunit
+         "../runtime/session-index.rkt"
+         "../util/protocol-types.rkt")
+
+;; Helper: create a session-index from a list of messages (in order)
+(define (build-test-index messages)
+  (define by-id (make-hash))
+  (define children (make-hash))
+  (for ([msg (in-list messages)])
+    (hash-set! by-id (message-id msg) msg)
+    (define pid (message-parent-id msg))
+    (when pid
+      (hash-set! children pid (cons (message-id msg) (hash-ref children pid '())))))
+  (session-index by-id children (list->vector messages) (make-hash) (box #f) (make-semaphore 1)))
+
+(define (make-msg id parent content)
+  (message id parent 'user 'user content 1000 (hasheq)))
+
+;; Tree:
+;; root -> a -> b (leaf)
+;; root -> c (leaf)
+;; root -> d -> e -> f (leaf)
+(define (make-test-index)
+  (build-test-index (list (make-msg "root" #f "root")
+                          (make-msg "a" "root" "a")
+                          (make-msg "b" "a" "b")
+                          (make-msg "c" "root" "c")
+                          (make-msg "d" "root" "d")
+                          (make-msg "e" "d" "e")
+                          (make-msg "f" "e" "f"))))
+
+;; ============================================================
+;; navigate-to-entry!
+;; ============================================================
+
+(test-case "navigate-to-entry! returns entry and context"
+  (define idx (make-test-index))
+  (define result (navigate-to-entry! idx "b"))
+  (check-not-false result)
+  (check-equal? (message-id (navigate-result-entry result)) "b")
+  ;; Branch: root -> a -> b
+  (check-equal? (length (navigate-result-branch result)) 3)
+  (check-true (navigate-result-leaf? result)))
+
+(test-case "navigate-to-entry! returns #f for unknown entry"
+  (define idx (make-test-index))
+  (check-false (navigate-to-entry! idx "nonexistent")))
+
+(test-case "navigate-to-entry! for non-leaf shows children"
+  (define idx (make-test-index))
+  (define result (navigate-to-entry! idx "a"))
+  (check-not-false result)
+  (check-false (navigate-result-leaf? result))
+  (check-equal? (length (navigate-result-children result)) 1))
+
+(test-case "navigate-to-entry! sets active leaf pointer"
+  (define idx (make-test-index))
+  (navigate-to-entry! idx "c")
+  (define active (active-leaf idx))
+  (check-not-false active)
+  (check-equal? (message-id active) "c"))
+
+;; ============================================================
+;; navigate-to-leaf!
+;; ============================================================
+
+(test-case "navigate-to-leaf! succeeds for leaf node"
+  (define idx (make-test-index))
+  (define result (navigate-to-leaf! idx "f"))
+  (check-not-false result)
+  (check-equal? (message-id (navigate-result-entry result)) "f"))
+
+(test-case "navigate-to-leaf! returns #f for non-leaf node"
+  (define idx (make-test-index))
+  (check-false (navigate-to-leaf! idx "a")))
+
+;; ============================================================
+;; navigate-next-leaf! / navigate-prev-leaf!
+;; ============================================================
+
+(test-case "navigate-next-leaf! cycles through leaves"
+  (define idx (make-test-index))
+  (navigate-to-entry! idx "b")
+  (define r1 (navigate-next-leaf! idx))
+  (check-not-false r1)
+  (check-equal? (message-id (navigate-result-entry r1)) "c")
+  (define r2 (navigate-next-leaf! idx))
+  (check-not-false r2)
+  (check-equal? (message-id (navigate-result-entry r2)) "f")
+  ;; Wraps around
+  (define r3 (navigate-next-leaf! idx))
+  (check-not-false r3)
+  (check-equal? (message-id (navigate-result-entry r3)) "b"))
+
+(test-case "navigate-next-leaf! returns #f for empty index"
+  (define idx (build-test-index '()))
+  (check-false (navigate-next-leaf! idx)))
+
+(test-case "navigate-prev-leaf! cycles backwards"
+  (define idx (make-test-index))
+  (navigate-to-entry! idx "c")
+  (define r1 (navigate-prev-leaf! idx))
+  (check-not-false r1)
+  (check-equal? (message-id (navigate-result-entry r1)) "b"))
+
+(test-case "navigate-prev-leaf! returns #f for empty index"
+  (define idx (build-test-index '()))
+  (check-false (navigate-prev-leaf! idx)))


### PR DESCRIPTION
## FEAT-64: Leaf pointer navigation

Add navigate-to-entry!, navigate-to-leaf!, navigate-next-leaf!, navigate-prev-leaf!
for cyclic leaf navigation.

11 test cases. Closes #954