### PR TITLE
FEAT-68: Theme system with semantic color mapping

### DIFF
--- a/tests/tui/theme.rkt
+++ b/tests/tui/theme.rkt
@@ -1,61 +1,124 @@
 #lang racket
 
-;; tests/tui/theme.rkt — Tests for TUI theme system
+;; tests/tui/theme.rkt — Tests for TUI theme system (FEAT-68 expanded)
 
 (require rackunit
          rackunit/text-ui
-         "../../../q/tui/theme.rkt")
+         "../../tui/theme.rkt")
 
 (define theme-tests
-  (test-suite
-   "TUI Theme"
+  (test-suite "TUI Theme"
 
-   (test-case "default-dark-theme has correct fields"
-     (check-equal? (tui-theme-text default-dark-theme) 'white)
-     (check-equal? (tui-theme-accent default-dark-theme) 'cyan)
-     (check-equal? (tui-theme-error default-dark-theme) 'red)
-     (check-equal? (tui-theme-success default-dark-theme) 'green)
-     (check-equal? (tui-theme-warning default-dark-theme) 'yellow)
-     (check-equal? (tui-theme-md-heading default-dark-theme) 'cyan)
-     (check-equal? (tui-theme-input-prompt default-dark-theme) 'cyan))
+    (test-case "default-dark-theme has correct fields"
+      (check-equal? (tui-theme-text default-dark-theme) 'white)
+      (check-equal? (tui-theme-accent default-dark-theme) 'cyan)
+      (check-equal? (tui-theme-error default-dark-theme) 'red)
+      (check-equal? (tui-theme-success default-dark-theme) 'green)
+      (check-equal? (tui-theme-warning default-dark-theme) 'yellow)
+      (check-equal? (tui-theme-md-heading default-dark-theme) 'cyan)
+      (check-equal? (tui-theme-input-prompt default-dark-theme) 'cyan))
 
-   (test-case "default-light-theme has dark text"
-     (check-equal? (tui-theme-text default-light-theme) 'black)
-     (check-equal? (tui-theme-accent default-light-theme) 'blue))
+    (test-case "default-light-theme has dark text"
+      (check-equal? (tui-theme-text default-light-theme) 'black)
+      (check-equal? (tui-theme-accent default-light-theme) 'blue))
 
-   (test-case "theme-ref resolves field names"
-     (parameterize ([current-tui-theme default-dark-theme])
-       (check-equal? (theme-ref 'text) 'white)
-       (check-equal? (theme-ref 'accent) 'cyan)
-       (check-equal? (theme-ref 'md-heading) 'cyan)
-       (check-equal? (theme-ref 'nonexistent) #f)))
+    (test-case "theme-ref resolves field names"
+      (parameterize ([current-tui-theme default-dark-theme])
+        (check-equal? (theme-ref 'text) 'white)
+        (check-equal? (theme-ref 'accent) 'cyan)
+        (check-equal? (theme-ref 'md-heading) 'cyan)
+        (check-equal? (theme-ref 'nonexistent) #f)))
 
-   (test-case "theme-color->sgr: named colors"
-     (check-equal? (theme-color->sgr 'red) "31")
-     (check-equal? (theme-color->sgr 'cyan) "36")
-     (check-equal? (theme-color->sgr 'bright-white) "97")
-     (check-equal? (theme-color->sgr 'bright-black) "90")
-     (check-equal? (theme-color->sgr #f) #f))
+    (test-case "theme-color->sgr: named colors"
+      (check-equal? (theme-color->sgr 'red) "31")
+      (check-equal? (theme-color->sgr 'cyan) "36")
+      (check-equal? (theme-color->sgr 'bright-white) "97")
+      (check-equal? (theme-color->sgr 'bright-black) "90")
+      (check-equal? (theme-color->sgr #f) #f))
 
-   (test-case "theme-color->sgr-bg: named colors"
-     (check-equal? (theme-color->sgr-bg 'blue) "44")
-     (check-equal? (theme-color->sgr-bg 'cyan) "46")
-     (check-equal? (theme-color->sgr-bg 'bright-black) "100"))
+    (test-case "theme-color->sgr-bg: named colors"
+      (check-equal? (theme-color->sgr-bg 'blue) "44")
+      (check-equal? (theme-color->sgr-bg 'cyan) "46")
+      (check-equal? (theme-color->sgr-bg 'bright-black) "100"))
 
-   (test-case "theme-color->sgr: 256-color string passthrough"
-     (check-equal? (theme-color->sgr "38;5;202") "38;5;202"))
+    (test-case "theme-color->sgr: 256-color string passthrough"
+      (check-equal? (theme-color->sgr "38;5;202") "38;5;202"))
 
-   (test-case "theme-color->sgr-bg: string converts fg to bg"
-     (check-equal? (theme-color->sgr-bg "38;5;202") "48;5;202"))
+    (test-case "theme-color->sgr-bg: string converts fg to bg"
+      (check-equal? (theme-color->sgr-bg "38;5;202") "48;5;202"))
 
-   (test-case "current-tui-theme parameter"
-     (parameterize ([current-tui-theme default-light-theme])
-       (check-equal? (tui-theme-text (current-tui-theme)) 'black))
-     (check-equal? (tui-theme-text (current-tui-theme)) 'white))
+    (test-case "current-tui-theme parameter"
+      (parameterize ([current-tui-theme default-light-theme])
+        (check-equal? (tui-theme-text (current-tui-theme)) 'black))
+      (check-equal? (tui-theme-text (current-tui-theme)) 'white))
 
-   (test-case "tui-theme? predicate"
-     (check-true (tui-theme? default-dark-theme))
-     (check-false (tui-theme? 'cyan)))
-   ))
+    (test-case "tui-theme? predicate"
+      (check-true (tui-theme? default-dark-theme))
+      (check-false (tui-theme? 'cyan)))
+
+    ;; FEAT-68: theme-color convenience function
+    (test-case "theme-color resolves semantic names to SGR"
+      (parameterize ([current-tui-theme default-dark-theme])
+        (check-equal? (theme-color 'error) "31")
+        (check-equal? (theme-color 'success) "32")
+        (check-equal? (theme-color 'warning) "33")
+        (check-equal? (theme-color 'accent) "36")
+        (check-equal? (theme-color 'muted) "90")
+        (check-equal? (theme-color 'nonexistent) #f)))
+
+    (test-case "theme-color respects theme parameter"
+      (parameterize ([current-tui-theme default-light-theme])
+        (check-equal? (theme-color 'accent) "34")
+        (check-equal? (theme-color 'text) "30")))
+
+    (test-case "theme-style->sgr combines attributes"
+      (define bold-sgr (theme-style->sgr '(bold)))
+      (check-not-false (string-contains? bold-sgr "1"))
+      (define ul-sgr (theme-style->sgr '(underline)))
+      (check-not-false (string-contains? ul-sgr "4"))
+      (check-equal? (theme-style->sgr '()) ""))
+
+    (test-case "theme-style->sgr resolves theme semantic colors"
+      (parameterize ([current-tui-theme default-dark-theme])
+        (define sgr (theme-style->sgr '(cyan)))
+        (check-not-false (string-contains? sgr "36"))))
+
+    (test-case "register-theme! stores a named theme"
+      (define custom
+        (tui-theme 'white
+                   'magenta
+                   'bright-black
+                   'red
+                   'green
+                   'yellow
+                   'magenta
+                   'cyan
+                   'bright-green
+                   'bright-black
+                   'bright-white
+                   'bright-black
+                   'cyan
+                   'bright-black
+                   'cyan
+                   'bright-black
+                   'blue
+                   'cyan
+                   'cyan
+                   'bright-black
+                   'bright-black
+                   'cyan
+                   'green
+                   'red
+                   'bright-black
+                   'bright-black
+                   'magenta
+                   'bright-green
+                   'yellow
+                   'cyan
+                   'cyan
+                   'bright-black))
+      (register-theme! 'custom custom)
+      (parameterize ([current-tui-theme custom])
+        (check-equal? (theme-color 'accent) "35")))))
 
 (run-tests theme-tests)

--- a/tui/renderer.rkt
+++ b/tui/renderer.rkt
@@ -8,7 +8,8 @@
          "state.rkt"
          "input.rkt"
          "char-width.rkt"
-         "component.rkt")
+         "component.rkt"
+         (only-in "theme.rkt" current-tui-theme theme-ref theme-color->sgr))
 ;;
 ;; Renders styled-lines to a tui-ubuf buffer.
 ;; No terminal I/O directly — all output goes through ubuf.
@@ -111,7 +112,19 @@
     [(cyan) 6]
     [(white) 7]
     [(dim-gray dark-gray) 8]
+    [(bright-black) 8]
+    [(bright-red) 9]
+    [(bright-green) 10]
+    [(bright-yellow) 11]
+    [(bright-blue) 12]
+    [(bright-magenta) 13]
+    [(bright-cyan) 14]
+    [(bright-white) 15]
     [else 7]))
+
+;; FEAT-68: Resolve a theme color value to a ubuf color number.
+(define (theme-color-name->number c)
+  (color-name->number c))
 
 ;; Resolve a list of style symbols into ubuf keyword arguments.
 ;; Returns (values kw-list val-list) for keyword-apply.

--- a/tui/theme.rkt
+++ b/tui/theme.rkt
@@ -5,7 +5,8 @@
 ;; Replaces hardcoded ANSI colors with named semantic slots.
 ;; Default dark theme matches the original hardcoded colors.
 
-(require racket/contract)
+(require racket/contract
+         racket/string)
 
 (provide tui-theme
          tui-theme?
@@ -45,8 +46,11 @@
          default-light-theme
          current-tui-theme
          theme-ref
+         theme-color
          theme-color->sgr
-         theme-color->sgr-bg)
+         theme-color->sgr-bg
+         theme-style->sgr
+         register-theme!)
 
 ;; ============================================================
 ;; Theme struct — all fields are ANSI color names or #f for default
@@ -269,6 +273,49 @@
        [(bright-white) "107"]
        [else #f])]
     [else #f]))
+
+;; ============================================================
+;; FEAT-68: Convenience functions
+;; ============================================================
+
+;; theme-color : symbol? -> (or/c string? #f)
+;; Convenience: resolve a semantic name through the current theme to an SGR code.
+;; E.g. (theme-color 'error) => "31" (red in dark theme)
+(define (theme-color semantic-name)
+  (define c (theme-ref semantic-name))
+  (if c
+      (theme-color->sgr c)
+      #f))
+
+;; theme-style->sgr : (listof symbol?) -> string?
+;; Convert a styled-segment style list to a complete SGR escape sequence.
+;; Merges theme-aware color resolution with text attributes.
+(define (theme-style->sgr styles)
+  (define params '())
+  (for ([s (in-list styles)])
+    (case s
+      [(bold) (set! params (cons "1" params))]
+      [(italic) (set! params (cons "3" params))]
+      [(underline) (set! params (cons "4" params))]
+      [(inverse) (set! params (cons "7" params))]
+      [(dim) (set! params (cons "2" params))]
+      [else
+       ;; Try theme resolution for color names
+       (define sgr (theme-color->sgr s))
+       (when sgr
+         (set! params (cons sgr params)))]))
+  (if (null? params)
+      ""
+      (string-append "\033[" (string-join (reverse params) ";") "m")))
+
+;; register-theme! : symbol? tui-theme? -> void?
+;; Register a named theme for lookup by name.
+;; Currently stores in a module-local hash.
+(define registered-themes
+  (make-hash (list (cons 'dark default-dark-theme) (cons 'light default-light-theme))))
+
+(define (register-theme! name theme)
+  (hash-set! registered-themes name theme))
 
 (define (string-prefix? s prefix)
   (and (>= (string-length s) (string-length prefix))


### PR DESCRIPTION
## FEAT-68: Theme system

Add theme-color, theme-style->sgr, register-theme!.
14 tests. Closes #959