### PR TITLE
FEAT-69: Markdown rendering in TUI transcript

### DIFF
--- a/tests/tui/test-markdown.rkt
+++ b/tests/tui/test-markdown.rkt
@@ -1,0 +1,134 @@
+#lang racket
+
+;; tests/tui/test-markdown.rkt — FEAT-69: Markdown rendering in TUI transcript
+
+(require rackunit
+         rackunit/text-ui
+         "../../tui/markdown.rkt"
+         "../../tui/render.rkt"
+         "../../util/markdown.rkt")
+
+(define markdown-tests
+  (test-suite "TUI Markdown Rendering"
+
+    ;; ============================================================
+    ;; Headers
+    ;; ============================================================
+    (test-case "### headers render bold with theme style"
+      (define lines (markdown->styled-lines "## Hello World" 80))
+      (check > (length lines) 0)
+      (define segs (styled-line-segments (car lines)))
+      (check > (length segs) 0)
+      (check-equal? (styled-segment-text (car segs)) "Hello World")
+      (check-not-false (member 'bold (styled-segment-style (car segs)))))
+
+    (test-case "# h1 header renders"
+      (define lines (markdown->styled-lines "# Title" 80))
+      (check > (length lines) 0)
+      (check-not-false (string-contains? (styled-line-plain-text (car lines)) "Title")))
+
+    ;; ============================================================
+    ;; Bold and italic
+    ;; ============================================================
+    (test-case "**bold** renders with bold style"
+      (define lines (markdown->styled-lines "This is **important** text" 80))
+      (check > (length lines) 0)
+      (define all-segs (append-map styled-line-segments lines))
+      (define bold-segs (filter (lambda (s) (member 'bold (styled-segment-style s))) all-segs))
+      (check > (length bold-segs) 0)
+      (check-equal? (styled-segment-text (car bold-segs)) "important"))
+
+    (test-case "*italic* renders with italic style"
+      (define lines (markdown->styled-lines "This is *emphasized* text" 80))
+      (check > (length lines) 0)
+      (define all-segs (append-map styled-line-segments lines))
+      (define italic-segs (filter (lambda (s) (member 'italic (styled-segment-style s))) all-segs))
+      (check > (length italic-segs) 0)
+      (check-equal? (styled-segment-text (car italic-segs)) "emphasized"))
+
+    ;; ============================================================
+    ;; Inline code
+    ;; ============================================================
+    (test-case "`code` renders with code style"
+      (define lines (markdown->styled-lines "Use `raco test` to run" 80))
+      (check > (length lines) 0)
+      (define all-segs (append-map styled-line-segments lines))
+      (define code-segs
+        (filter (lambda (s) (member 'bright-green (styled-segment-style s))) all-segs))
+      (check > (length code-segs) 0)
+      (check-equal? (styled-segment-text (car code-segs)) "raco test"))
+
+    ;; ============================================================
+    ;; Code blocks
+    ;; ============================================================
+    (test-case "code blocks render inset"
+      (define lines (markdown->styled-lines "```racket\n(define x 42)\n```" 80))
+      (check > (length lines) 0)
+      ;; Each code line should have indentation prefix
+      (define line-text (styled-line-plain-text (car lines)))
+      (check-not-false (string-contains? line-text "(define x 42)")))
+
+    ;; ============================================================
+    ;; Lists
+    ;; ============================================================
+    (test-case "- unordered list renders with bullet"
+      (define lines (markdown->styled-lines "- First item\n- Second item" 80))
+      (check >= (length lines) 2)
+      (check-not-false (string-contains? (styled-line-plain-text (car lines)) "First item"))
+      (check-not-false (string-contains? (styled-line-plain-text (cadr lines)) "Second item")))
+
+    (test-case "ordered list renders with number"
+      (define lines (markdown->styled-lines "1. First\n2. Second" 80))
+      (check >= (length lines) 2)
+      (check-not-false (string-contains? (styled-line-plain-text (car lines)) "1. First")))
+
+    ;; ============================================================
+    ;; Links
+    ;; ============================================================
+    (test-case "[link](url) renders with underline"
+      (define lines (markdown->styled-lines "Click [here](https://racket-lang.org) for info" 80))
+      (check > (length lines) 0)
+      (define all-segs (append-map styled-line-segments lines))
+      (define link-segs (filter (lambda (s) (member 'underline (styled-segment-style s))) all-segs))
+      (check > (length link-segs) 0)
+      (check-equal? (styled-segment-text (car link-segs)) "here"))
+
+    ;; ============================================================
+    ;; Horizontal rules
+    ;; ============================================================
+    (test-case "--- renders as horizontal rule"
+      (define lines (markdown->styled-lines "above\n---\nbelow" 80))
+      (check >= (length lines) 3)
+      (check-not-false (string-contains? (styled-line-plain-text (car lines)) "above"))
+      (check-not-false (string-contains? (styled-line-plain-text (last lines)) "below")))
+
+    ;; ============================================================
+    ;; Token-based API
+    ;; ============================================================
+    (test-case "markdown-tokens->styled-lines works with pre-parsed tokens"
+      (define tokens (parse-markdown "**bold** and `code`"))
+      (define lines (markdown-tokens->styled-lines tokens 80))
+      (check > (length lines) 0)
+      (define all-segs (append-map styled-line-segments lines))
+      (define bold-segs (filter (lambda (s) (member 'bold (styled-segment-style s))) all-segs))
+      (check > (length bold-segs) 0))
+
+    ;; ============================================================
+    ;; Edge cases
+    ;; ============================================================
+    (test-case "empty input returns empty lines"
+      (define lines (markdown->styled-lines "" 80))
+      (check-equal? (length lines) 0))
+
+    (test-case "plain text renders as-is"
+      (define lines (markdown->styled-lines "Hello world" 80))
+      (check > (length lines) 0)
+      (check-equal? (styled-line-plain-text (car lines)) "Hello world"))
+
+    (test-case "mixed bold, italic, code in one line"
+      (define lines (markdown->styled-lines "**bold** *italic* `code`" 80))
+      (check > (length lines) 0)
+      (define all-segs (append-map styled-line-segments lines))
+      (check >= (length all-segs) 3))))
+
+(run-tests markdown-tests)

--- a/tui/markdown.rkt
+++ b/tui/markdown.rkt
@@ -1,0 +1,122 @@
+#lang racket/base
+
+;; q/tui/markdown.rkt — TUI markdown rendering facade
+;;
+;; Provides a unified API for rendering markdown to styled-lines in the TUI.
+;; Wraps the parse-markdown tokenizer (from util/markdown.rkt) and the
+;; md-format-assistant renderer (from render.rkt) into a single entry point.
+;;
+;; FEAT-69: Dedicated module for markdown → styled-line conversion.
+
+(require racket/list
+         racket/string
+         (only-in "../util/markdown.rkt" parse-markdown md-token md-token-type md-token-content)
+         "render.rkt")
+
+;; Main entry point
+(provide markdown->styled-lines
+         ;; Token conversion (exposed for testing)
+         markdown-tokens->styled-lines
+         ;; Helpers
+         styled-line-plain-text)
+
+;; ============================================================
+;; Main entry point
+;; ============================================================
+
+;; markdown->styled-lines : string? integer? -> (listof styled-line?)
+;; Convert a markdown string to a list of styled-lines, width-aware.
+;; This is the primary API for TUI rendering of markdown content.
+(define (markdown->styled-lines text width)
+  (md-format-assistant text width))
+
+;; ============================================================
+;; Token-based rendering (for testing / advanced use)
+;; ============================================================
+
+;; markdown-tokens->styled-lines : (listof md-token?) integer? -> (listof styled-line?)
+;; Convert pre-parsed tokens to styled-lines. Useful when tokens are
+;; already available (e.g., for caching or incremental rendering).
+(define (markdown-tokens->styled-lines tokens width)
+  (render-tokens tokens width))
+
+;; Extract plain text from a styled-line (re-export convenience)
+(define (styled-line-plain-text sl)
+  (styled-line->text sl))
+
+;; ============================================================
+;; Internal: token renderer (same logic as md-format-assistant
+;; but operates on pre-parsed tokens)
+;; ============================================================
+
+(define (render-tokens tokens width)
+  (define (flush-current lines current-segs)
+    (if (null? current-segs)
+        lines
+        (let* ([raw-line (styled-line current-segs)]
+               [wrapped (wrap-styled-line raw-line width)])
+          (append lines wrapped))))
+  (define-values (lines current-segs)
+    (for/fold ([lines '()]
+               [current-segs '()])
+              ([tok (in-list tokens)])
+      (case (md-token-type tok)
+        [(newline) (values (flush-current lines current-segs) '())]
+        [(code-block)
+         (define prev-lines (flush-current lines current-segs))
+         (define code (cdr (md-token-content tok)))
+         (define code-lines
+           (for/list ([line (string-split code "\n" #:trim? #f)])
+             (styled-line (list (styled-segment (string-append "  " line) (theme->style 'md-code))))))
+         (values (append prev-lines code-lines) '())]
+        [(header)
+         (define prev-lines (flush-current lines current-segs))
+         (define header-text (cdr (md-token-content tok)))
+         (values (append prev-lines
+                         (list (styled-line (list (styled-segment header-text
+                                                                  (theme->style 'md-heading
+                                                                                '(bold)))))))
+                 '())]
+        [(hr)
+         (define prev-lines (flush-current lines current-segs))
+         (values (append prev-lines
+                         (list (styled-line (list (styled-segment (make-string (min width 60) #\—)
+                                                                  (theme->style 'muted))))))
+                 '())]
+        [(blockquote)
+         (define prev-lines (flush-current lines current-segs))
+         (define depth (car (md-token-content tok)))
+         (define inner-tokens (cdr (md-token-content tok)))
+         (define prefix (make-string (* depth 2) #\space))
+         (define inner-lines (render-tokens inner-tokens width))
+         (define bq-lines
+           (for/list ([line (in-list inner-lines)])
+             (styled-line (cons (styled-segment (string-append prefix "│ ")
+                                                (theme->style 'md-blockquote))
+                                (styled-line-segments line)))))
+         (values (append prev-lines bq-lines) '())]
+        [(unordered-list)
+         (define prev-lines (flush-current lines current-segs))
+         (define indent (car (md-token-content tok)))
+         (define inner-tokens (cdr (md-token-content tok)))
+         (define prefix (make-string (* indent 2) #\space))
+         (define bullet-line
+           (styled-line (cons (styled-segment (string-append prefix "• ")
+                                              (theme->style 'md-list-bullet))
+                              (for/list ([tok (in-list inner-tokens)])
+                                (md-token->segment tok)))))
+         (values (append prev-lines (list bullet-line)) '())]
+        [(ordered-list)
+         (define prev-lines (flush-current lines current-segs))
+         (define indent (car (md-token-content tok)))
+         (define num (cadr (md-token-content tok)))
+         (define inner-tokens (cddr (md-token-content tok)))
+         (define prefix (make-string (* indent 2) #\space))
+         (define bullet-line
+           (styled-line (cons (styled-segment (string-append prefix (format "~a. " num))
+                                              (theme->style 'md-list-bullet))
+                              (for/list ([tok (in-list inner-tokens)])
+                                (md-token->segment tok)))))
+         (values (append prev-lines (list bullet-line)) '())]
+        [else (values lines (cons (md-token->segment tok) current-segs))])))
+  (flush-current lines current-segs))

--- a/tui/render.rkt
+++ b/tui/render.rkt
@@ -35,6 +35,10 @@
          styled-line->ansi
          styles->sgr
          wrap-styled-line
+
+         ;; FEAT-69: markdown rendering internals
+         theme->style
+         md-token->segment
          wrap-text
          wrap-single-line)
 


### PR DESCRIPTION
## FEAT-69: Markdown rendering

Add tui/markdown.rkt facade module with markdown->styled-lines API.
14 tests. Closes #960