### PR TITLE
FEAT-73: Parallel tool execution by default

### DIFF
--- a/runtime/iteration.rkt
+++ b/runtime/iteration.rkt
@@ -305,7 +305,7 @@
                                             (emit-session-event! bus session-id event-type payload))
                                           #:call-id (generate-id)
                                           #:session-metadata (hasheq 'session-id session-id))
-                          #:parallel? (hash-ref config 'parallel-tools #f)))))
+                          #:parallel? (hash-ref config 'parallel-tools #t)))))
 
   ;; Emit tool.call.completed / tool.call.failed events (only for executed calls)
   (for ([tc (in-list tool-calls-to-run)]

--- a/tests/test-parallel-tools.rkt
+++ b/tests/test-parallel-tools.rkt
@@ -1,0 +1,87 @@
+#lang racket
+
+;; tests/test-parallel-tools.rkt — FEAT-73: Parallel tool execution
+
+(require rackunit
+         rackunit/text-ui
+         "../tools/tool.rkt"
+         "../tools/scheduler.rkt")
+
+(define (make-echo-tool name)
+  (make-tool name
+             "echo tool"
+             (hasheq)
+             (lambda (args ctx) (make-tool-result (hash-ref args 'out "") (hasheq) #f))))
+
+(define parallel-tests
+  (test-suite "parallel tool execution"
+
+    (test-case "multiple tool calls execute in parallel"
+      (define reg (make-tool-registry))
+      (register-tool!
+       reg
+       (make-tool "slow-echo"
+                  "slow echo"
+                  (hasheq)
+                  (lambda (args ctx)
+                    (sleep 0.05)
+                    (make-tool-result (format "slow: ~a" (hash-ref args 'msg "hi")) (hasheq) #f))))
+      (register-tool!
+       reg
+       (make-tool "fast-echo"
+                  "fast echo"
+                  (hasheq)
+                  (lambda (args ctx)
+                    (make-tool-result (format "fast: ~a" (hash-ref args 'msg "hi")) (hasheq) #f))))
+
+      (define tool-calls
+        (list (make-tool-call "tc-1" "slow-echo" (hasheq 'msg "A"))
+              (make-tool-call "tc-2" "fast-echo" (hasheq 'msg "B"))))
+
+      (define start-time (current-inexact-milliseconds))
+      (define result (run-tool-batch tool-calls reg #:parallel? #t))
+      (define elapsed (- (current-inexact-milliseconds) start-time))
+
+      (check-true (< elapsed 120) (format "parallel execution took ~ams, should be < 120ms" elapsed))
+      (check-equal? (length (scheduler-result-results result)) 2))
+
+    (test-case "parallel results maintain original order"
+      (define reg (make-tool-registry))
+      (register-tool! reg (make-echo-tool "echo"))
+      (define tool-calls
+        (for/list ([i (in-range 5)])
+          (make-tool-call (format "tc-~a" i) "echo" (hasheq 'out (format "out-~a" i)))))
+
+      (define result (run-tool-batch tool-calls reg #:parallel? #t))
+      (define results (scheduler-result-results result))
+
+      (for ([r (in-list results)]
+            [i (in-naturals)])
+        (check-not-false (string-contains? (tool-result-content r) (format "out-~a" i))
+                         (format "result ~a should contain out-~a" i i))))
+
+    (test-case "serial execution still works"
+      (define reg (make-tool-registry))
+      (register-tool! reg (make-echo-tool "echo"))
+      (define tool-calls
+        (list (make-tool-call "tc-1" "echo" (hasheq 'out "A"))
+              (make-tool-call "tc-2" "echo" (hasheq 'out "B"))))
+
+      (define result (run-tool-batch tool-calls reg #:parallel? #f))
+      (check-equal? (length (scheduler-result-results result)) 2))
+
+    (test-case "single tool call works in parallel mode"
+      (define reg (make-tool-registry))
+      (register-tool! reg (make-echo-tool "echo"))
+      (define tool-calls (list (make-tool-call "tc-1" "echo" (hasheq 'out "only"))))
+
+      (define result (run-tool-batch tool-calls reg #:parallel? #t))
+      (define results (scheduler-result-results result))
+      (check-equal? (length results) 1)
+      (check-not-false (string-contains? (tool-result-content (car results)) "only")))
+
+    (test-case "config parallel-tools defaults to #t"
+      (define config (hasheq))
+      (check-true (hash-ref config 'parallel-tools #t)))))
+
+(run-tests parallel-tests)

--- a/tools/scheduler.rkt
+++ b/tools/scheduler.rkt
@@ -14,29 +14,44 @@
 ;;;   5. emit final results in source order
 
 (require (only-in "tool.rkt"
-                  tool? tool-name tool-schema tool-execute
-                  make-tool make-tool-registry make-exec-context
-                  register-tool! lookup-tool validate-tool-args
-                  tool-result? tool-result-content
-                  tool-result-details tool-result-is-error?
-                  make-error-result make-success-result
+                  tool?
+                  tool-name
+                  tool-schema
+                  tool-execute
+                  make-tool
+                  make-tool-registry
+                  make-exec-context
+                  register-tool!
+                  lookup-tool
+                  validate-tool-args
+                  tool-result?
+                  tool-result-content
+                  tool-result-details
+                  tool-result-is-error?
+                  make-error-result
+                  make-success-result
                   validate-tool-result
-                  exec-context? exec-context-event-publisher
-                  tool-call tool-call? make-tool-call
-                  tool-call-id tool-call-name tool-call-arguments)
-         (only-in "../util/hook-types.rkt"
-                  hook-result? hook-result-action hook-result-payload)
+                  exec-context?
+                  exec-context-event-publisher
+                  tool-call
+                  tool-call?
+                  make-tool-call
+                  tool-call-id
+                  tool-call-name
+                  tool-call-arguments)
+         (only-in "../util/hook-types.rkt" hook-result? hook-result-action hook-result-payload)
          (only-in "../util/safe-mode-predicates.rkt"
-                  safe-mode? allowed-tool? allowed-path? safe-mode-project-root)
-         (only-in "file-mutation-queue.rkt"
-                  with-file-mutation-queue))
+                  safe-mode?
+                  allowed-tool?
+                  allowed-path?
+                  safe-mode-project-root)
+         (only-in "file-mutation-queue.rkt" with-file-mutation-queue))
 
-(provide
- ;; ── Result struct ──
- (struct-out scheduler-result)
+;; ── Result struct ──
+(provide (struct-out scheduler-result)
 
- ;; ── Main entry point ──
- run-tool-batch)
+         ;; ── Main entry point ──
+         run-tool-batch)
 
 ;; ============================================================
 ;; Scheduler result struct
@@ -65,9 +80,7 @@
 ;; ============================================================
 
 (define (extract-path-arg args)
-  (or (hash-ref args 'path #f)
-      (hash-ref args 'root #f)
-      (hash-ref args 'directory #f)))
+  (or (hash-ref args 'path #f) (hash-ref args 'root #f) (hash-ref args 'directory #f)))
 
 ;; ============================================================
 ;; Preflight stage (serial)
@@ -78,16 +91,13 @@
   (for/list ([tc (in-list tool-calls)])
     (define tc-after-hook
       (if hook-dispatcher
-          (with-handlers ([exn:fail?
-                           (lambda (e)
-                             ;; Hook itself threw → treat as block with error
-                             (define msg (format "hook error: ~a" (exn-message e)))
-                             (hasheq 'status 'error
-                                     'tool-call tc
-                                     'error-message msg))])
+          (with-handlers ([exn:fail? (lambda (e)
+                                       ;; Hook itself threw → treat as block with error
+                                       (define msg (format "hook error: ~a" (exn-message e)))
+                                       (hasheq 'status 'error 'tool-call tc 'error-message msg))])
             (define result (hook-dispatcher 'tool-call tc))
             (cond
-              [(not result) tc]  ; no handler → pass through
+              [(not result) tc] ; no handler → pass through
               [(hook-result? result)
                (case (hook-result-action result)
                  [(block) 'blocked]
@@ -98,43 +108,51 @@
     (cond
       ;; Hook returned 'blocked
       [(eq? tc-after-hook 'blocked)
-       (hasheq 'status 'blocked
-               'tool-call tc
-               'error-message (format "tool call '~a' blocked by hook"
-                                      (tool-call-name tc)))]
+       (hasheq 'status
+               'blocked
+               'tool-call
+               tc
+               'error-message
+               (format "tool call '~a' blocked by hook" (tool-call-name tc)))]
       ;; Hook threw an exception (returned as list)
-      [(and (hash? tc-after-hook)
-            (eq? (hash-ref tc-after-hook 'status #f) 'error))
-       tc-after-hook]
+      [(and (hash? tc-after-hook) (eq? (hash-ref tc-after-hook 'status #f) 'error)) tc-after-hook]
       ;; Hook returned a (possibly modified) tool-call
       [(tool-call? tc-after-hook)
        (define t (lookup-tool registry (tool-call-name tc-after-hook)))
        (cond
          [(not t)
           ;; Tool not found in registry
-          (hasheq 'status 'error
-                  'tool-call tc-after-hook
-                  'error-message (format "unknown tool: '~a'"
-                                         (tool-call-name tc-after-hook)))]
+          (hasheq 'status
+                  'error
+                  'tool-call
+                  tc-after-hook
+                  'error-message
+                  (format "unknown tool: '~a'" (tool-call-name tc-after-hook)))]
          [else
           ;; Check safe-mode tool restrictions (SEC-01)
           (cond
             [(and (safe-mode?) (not (allowed-tool? (tool-call-name tc-after-hook))))
-             (hasheq 'status 'blocked
-                     'tool-call tc-after-hook
-                     'error-message (format "tool '~a' blocked by safe-mode"
-                                            (tool-call-name tc-after-hook)))]
+             (hasheq 'status
+                     'blocked
+                     'tool-call
+                     tc-after-hook
+                     'error-message
+                     (format "tool '~a' blocked by safe-mode" (tool-call-name tc-after-hook)))]
             ;; Check safe-mode path restrictions (ARCH-02)
             [(and (safe-mode?)
                   (let ([path-arg (extract-path-arg (tool-call-arguments tc-after-hook))])
                     (and path-arg (not (allowed-path? path-arg)))))
              (define path-arg (extract-path-arg (tool-call-arguments tc-after-hook)))
-             (hasheq 'status 'blocked
-                     'tool-call tc-after-hook
-                     'error-message
-                     (format "Access denied: ~a is outside project root (~a). Safe mode restricts file access to the project directory."
-                             path-arg
-                             (safe-mode-project-root)))]
+             (hasheq
+              'status
+              'blocked
+              'tool-call
+              tc-after-hook
+              'error-message
+              (format
+               "Access denied: ~a is outside project root (~a). Safe mode restricts file access to the project directory."
+               path-arg
+               (safe-mode-project-root)))]
             [else
              ;; Revalidate arguments after potential hook mutation
              (define validated?
@@ -142,19 +160,22 @@
                  (validate-tool-args t (tool-call-arguments tc-after-hook))
                  #t))
              (if validated?
-                 (hasheq 'status 'ready
-                         'tool-call tc-after-hook
-                         'tool t)
-                 (hasheq 'status 'error
-                         'tool-call tc-after-hook
+                 (hasheq 'status 'ready 'tool-call tc-after-hook 'tool t)
+                 (hasheq 'status
+                         'error
+                         'tool-call
+                         tc-after-hook
                          'error-message
                          (format "post-hook validation failed for tool '~a'"
                                  (tool-call-name tc-after-hook))))])])]
       [else
        ;; Unexpected hook return value — treat as error
-       (hasheq 'status 'error
-               'tool-call tc
-               'error-message (format "unexpected hook return: ~v" tc-after-hook))])))
+       (hasheq 'status
+               'error
+               'tool-call
+               tc
+               'error-message
+               (format "unexpected hook return: ~v" tc-after-hook))])))
 
 ;; ============================================================
 ;; Execute a single tool call (with exception handling)
@@ -167,25 +188,25 @@
   (define tc-name (tool-call-name tc))
   (define tc-args (tool-call-arguments tc))
 
-  (define pre-payload
-    (hasheq 'tool-name tc-name
-            'args tc-args
-            'entry-id tc-id))
+  ;; FEAT-73: emit tool.execution.start lifecycle event
+  (define ev-pub (and exec-ctx (exec-context-event-publisher exec-ctx)))
+  (when ev-pub
+    (ev-pub 'tool.execution.start (hasheq 'tool-name tc-name 'tool-call-id tc-id)))
+
+  (define pre-payload (hasheq 'tool-name tc-name 'args tc-args 'entry-id tc-id))
 
   ;; Check if tool-call-pre hook blocks or amends
   (define pre-hook-result
     (if hook-dispatcher
-        (with-handlers ([exn:fail?
-                         (lambda (e)
-                           (log-warning
-                            (format "tool-call-pre hook threw: ~a" (exn-message e)))
-                           #f)])
+        (with-handlers ([exn:fail? (lambda (e)
+                                     (log-warning (format "tool-call-pre hook threw: ~a"
+                                                          (exn-message e)))
+                                     #f)])
           (hook-dispatcher 'tool-call-pre pre-payload))
         #f))
 
   (cond
-    [(and (hook-result? pre-hook-result)
-          (eq? (hook-result-action pre-hook-result) 'block))
+    [(and (hook-result? pre-hook-result) (eq? (hook-result-action pre-hook-result) 'block))
      ;; Return early with blocked result
      (make-error-result (format "tool '~a' blocked by tool-call-pre hook" tc-name))]
     [else
@@ -205,40 +226,28 @@
      ;; Execute the tool (with file mutation queue for write tools)
      (define file-mutating-tools '("write" "edit"))
      (define exec-result
-       (with-handlers ([exn:fail?
-                        (lambda (e)
-                          (make-error-result
-                           (format "tool '~a' raised: ~a"
-                                   tc-name
-                                   (exn-message e))))])
+       (with-handlers ([exn:fail? (lambda (e)
+                                    (make-error-result
+                                     (format "tool '~a' raised: ~a" tc-name (exn-message e))))])
          (define args (tool-call-arguments tc-to-execute))
-         (define path-arg (and (member tc-name file-mutating-tools)
-                               (hash? args)
-                               (hash-ref args 'path #f)))
-         (with-file-mutation-queue
-          path-arg
-          (lambda ()
-            ((tool-execute t) args exec-ctx)))))
+         (define path-arg
+           (and (member tc-name file-mutating-tools) (hash? args) (hash-ref args 'path #f)))
+         (with-file-mutation-queue path-arg (lambda () ((tool-execute t) args exec-ctx)))))
 
      ;; Dispatch 'tool-result-post hook
-     (define post-payload
-       (hasheq 'tool-name tc-name
-               'result exec-result
-               'entry-id tc-id))
+     (define post-payload (hasheq 'tool-name tc-name 'result exec-result 'entry-id tc-id))
 
      (define post-hook-result
        (if hook-dispatcher
-           (with-handlers ([exn:fail?
-                            (lambda (e)
-                              (log-warning
-                               (format "tool-result-post hook threw: ~a" (exn-message e)))
-                              #f)])
+           (with-handlers ([exn:fail? (lambda (e)
+                                        (log-warning (format "tool-result-post hook threw: ~a"
+                                                             (exn-message e)))
+                                        #f)])
              (hook-dispatcher 'tool-result-post post-payload))
            #f))
 
      (cond
-       [(and (hook-result? post-hook-result)
-             (eq? (hook-result-action post-hook-result) 'block))
+       [(and (hook-result? post-hook-result) (eq? (hook-result-action post-hook-result) 'block))
         ;; Treat block as error
         (make-error-result (format "tool '~a' result blocked by tool-result-post hook" tc-name))]
        [(and (hook-result? post-hook-result)
@@ -247,14 +256,9 @@
              (hash-has-key? (hook-result-payload post-hook-result) 'result))
         ;; Validate post-hook amended result is a valid tool-result
         (let ([amended-result (hash-ref (hook-result-payload post-hook-result) 'result)])
-          (if (validate-tool-result amended-result)
-              amended-result
-              exec-result))]
-       [else
-        ;; Return original result
-        exec-result])])
-
-)
+          (if (validate-tool-result amended-result) amended-result exec-result))]
+       ;; Return original result
+       [else exec-result])]))
 
 ;; ============================================================
 ;; Execution stage
@@ -276,16 +280,17 @@
   (define execution-results
     (if parallel?
         ;; Parallel execution using threads
-        (let ([channels (for/list ([ie (in-list indexed-ready)])
-                          (define ch (make-channel))
-                          (define idx (car ie))
-                          (define entry (cdr ie))
-                          (define tc (hash-ref entry 'tool-call))
-                          (define t (hash-ref entry 'tool))
-                          (thread
-                           (lambda ()
-                             (channel-put ch (cons idx (execute-single tc t exec-ctx hook-dispatcher)))))
-                          ch)])
+        (let ([channels
+               (for/list ([ie (in-list indexed-ready)])
+                 (define ch (make-channel))
+                 (define idx (car ie))
+                 (define entry (cdr ie))
+                 (define tc (hash-ref entry 'tool-call))
+                 (define t (hash-ref entry 'tool))
+                 (thread (lambda ()
+                           (channel-put ch
+                                        (cons idx (execute-single tc t exec-ctx hook-dispatcher)))))
+                 ch)])
           (for/list ([ch (in-list channels)])
             (channel-get ch)))
         ;; Serial execution
@@ -307,13 +312,11 @@
     (define status (hash-ref entry 'status))
     (case status
       [(ready)
-       (hash-ref results-by-idx idx
-                  (lambda ()
-                    (make-error-result "internal: missing execution result")))]
-      [(blocked)
-       (make-error-result (hash-ref entry 'error-message "blocked"))]
-      [(error)
-       (make-error-result (hash-ref entry 'error-message "error"))])))
+       (hash-ref results-by-idx
+                 idx
+                 (lambda () (make-error-result "internal: missing execution result")))]
+      [(blocked) (make-error-result (hash-ref entry 'error-message "blocked"))]
+      [(error) (make-error-result (hash-ref entry 'error-message "error"))])))
 
 ;; ============================================================
 ;; Compute metadata
@@ -322,8 +325,7 @@
 (define (compute-metadata results preflight-entries)
   (define total (length results))
   (define blocked
-    (for/sum ([entry (in-list preflight-entries)])
-      (if (eq? (hash-ref entry 'status) 'blocked) 1 0)))
+    (for/sum ([entry (in-list preflight-entries)]) (if (eq? (hash-ref entry 'status) 'blocked) 1 0)))
   ;; Count errors that are NOT from blocked entries
   (define blocked-indices
     (for/list ([entry (in-list preflight-entries)]
@@ -331,22 +333,19 @@
                #:when (eq? (hash-ref entry 'status) 'blocked))
       idx))
   (define errors
-    (for/sum ([r (in-list results)]
-              [idx (in-naturals)]
-              #:when (and (tool-result-is-error? r)
-                          (not (member idx blocked-indices))))
-      1))
+    (for/sum ([r (in-list results)] [idx (in-naturals)]
+                                    #:when (and (tool-result-is-error? r)
+                                                (not (member idx blocked-indices))))
+             1))
   (define executed (- total blocked errors))
-  (hasheq 'total total
-          'executed executed
-          'blocked blocked
-          'errors errors))
+  (hasheq 'total total 'executed executed 'blocked blocked 'errors errors))
 
 ;; ============================================================
 ;; Main entry point
 ;; ============================================================
 
-(define (run-tool-batch tool-calls registry
+(define (run-tool-batch tool-calls
+                        registry
                         #:hook-dispatcher [hook-dispatcher #f]
                         #:exec-context [exec-ctx (make-exec-context)]
                         #:parallel? [parallel? #f])
@@ -356,8 +355,7 @@
   ;; Emit batch preflight started event
   (when ev-pub
     (ev-pub "tool.batch.preflight.started"
-            (hasheq 'toolCount (length tool-calls)
-                    'toolNames (map tool-call-name tool-calls))))
+            (hasheq 'toolCount (length tool-calls) 'toolNames (map tool-call-name tool-calls))))
 
   ;; Step 1: Preflight (serial)
   (define preflight-entries (run-preflight tool-calls registry hook-dispatcher))


### PR DESCRIPTION
## FEAT-73: Parallel tool execution

Default parallel-tools to #t, add lifecycle events. 5 new tests.
Closes #964