### PR TITLE
FEAT-77: Typed event classes for SDK/RPC

### DIFF
--- a/tests/test-event-classes.rkt
+++ b/tests/test-event-classes.rkt
@@ -1,0 +1,102 @@
+#lang racket
+
+;; tests/test-event-classes.rkt — FEAT-77: Typed event classes
+
+(require rackunit
+         rackunit/text-ui
+         "../util/event-classes.rkt"
+         "../util/protocol-types.rkt")
+
+(define event-class-tests
+  (test-suite
+   "typed event classes"
+
+   ;; ============================================================
+   ;; Stream events
+   ;; ============================================================
+   (test-case "stream-text-event predicate and constructor"
+     (define evt (make-stream-text-event "s1" (hasheq 'text "hello")))
+     (check-true (stream-text-event? evt))
+     (check-false (tool-start-event? evt))
+     (check-equal? (event-ev evt) "model.stream.text")
+     (check-equal? (hash-ref (event-payload evt) 'text) "hello"))
+
+   (test-case "stream-tool-call-event predicate"
+     (define evt (make-stream-tool-call-event "s1" (hasheq 'name "bash")))
+     (check-true (stream-tool-call-event? evt))
+     (check-equal? (event-ev evt) "model.stream.tool_call"))
+
+   (test-case "stream-thinking-event predicate"
+     (define evt (make-stream-thinking-event "s1" (hasheq 'thinking "hmm")))
+     (check-true (stream-thinking-event? evt))
+     (check-equal? (event-ev evt) "model.stream.thinking"))
+
+   ;; ============================================================
+   ;; Tool lifecycle events
+   ;; ============================================================
+   (test-case "tool-start-event and tool-end-event"
+     (define start (make-tool-start-event "s1" "bash" "tc-1"))
+     (define end (make-tool-end-event "s1" "bash" "tc-1"))
+     (check-true (tool-start-event? start))
+     (check-true (tool-end-event? end))
+     (check-false (tool-end-event? start))
+     (check-equal? (hash-ref (event-payload start) 'tool-name) "bash")
+     (check-equal? (hash-ref (event-payload end) 'tool-call-id) "tc-1"))
+
+   ;; ============================================================
+   ;; Iteration events
+   ;; ============================================================
+   (test-case "iteration-start-event and iteration-end-event"
+     (define start (make-iteration-start-event "s1" "turn-1"))
+     (define end (make-iteration-end-event "s1" "turn-1" "completed"))
+     (check-true (iteration-start-event? start))
+     (check-true (iteration-end-event? end))
+     (check-equal? (hash-ref (event-payload end) 'reason) "completed"))
+
+   ;; ============================================================
+   ;; Interrupt and error events
+   ;; ============================================================
+   (test-case "interrupt-event"
+     (define evt (make-interrupt-event "s1"))
+     (check-true (interrupt-event? evt))
+     (check-false (error-event? evt))
+     (check-equal? (event-ev evt) "interrupt.requested"))
+
+   (test-case "error-event"
+     (define evt (make-error-event "s1" "something went wrong"))
+     (check-true (error-event? evt))
+     (check-equal? (hash-ref (event-payload evt) 'message) "something went wrong"))
+
+   ;; ============================================================
+   ;; Compaction events
+   ;; ============================================================
+   (test-case "compaction-started-event and compaction-completed-event"
+     (define started (make-compaction-started-event "s1" #:persist? #t))
+     (define completed (make-compaction-completed-event "s1" 15 #:persist? #t))
+     (check-true (compaction-started-event? started))
+     (check-true (compaction-completed-event? completed))
+     (check-equal? (hash-ref (event-payload completed) 'removedCount) 15))
+
+   ;; ============================================================
+   ;; Topic constants
+   ;; ============================================================
+   (test-case "topic constants match event topics"
+     (check-equal? TOPIC-STREAM-TEXT "model.stream.text")
+     (check-equal? TOPIC-TOOL-START "tool.execution.start")
+     (check-equal? TOPIC-TOOL-END "tool.execution.end")
+     (check-equal? TOPIC-INTERRUPT "interrupt.requested")
+     (check-equal? TOPIC-ERROR "error")
+     (check-equal? TOPIC-COMPACTION-STARTED "compaction.started"))
+
+   ;; ============================================================
+   ;; Serialization
+   ;; ============================================================
+   (test-case "event classes produce serializable events"
+     (define evt (make-stream-text-event "s1" (hasheq 'text "test")))
+     (define jsexpr (event->jsexpr evt))
+     (check-equal? (hash-ref jsexpr 'event) "model.stream.text")
+     (check-equal? (hash-ref jsexpr 'sessionId) "s1")
+     (define restored (jsexpr->event jsexpr))
+     (check-true (stream-text-event? restored)))))
+
+(run-tests event-class-tests)

--- a/util/event-classes.rkt
+++ b/util/event-classes.rkt
@@ -1,0 +1,158 @@
+#lang racket/base
+
+;; util/event-classes.rkt — FEAT-77: Typed event classes for SDK/RPC
+;;
+;; Provides typed constructors and predicates for common event types.
+;; Each constructor wraps make-event with the correct topic and payload shape.
+;; Each predicate checks the event topic.
+
+(require racket/contract
+         "protocol-types.rkt")
+
+(provide
+ ;; Event class predicates
+ stream-text-event?
+ stream-tool-call-event?
+ stream-thinking-event?
+ tool-start-event?
+ tool-end-event?
+ iteration-start-event?
+ iteration-end-event?
+ interrupt-event?
+ error-event?
+ compaction-started-event?
+ compaction-completed-event?
+
+ ;; Event class constructors
+ make-stream-text-event
+ make-stream-tool-call-event
+ make-stream-thinking-event
+ make-tool-start-event
+ make-tool-end-event
+ make-iteration-start-event
+ make-iteration-end-event
+ make-interrupt-event
+ make-error-event
+ make-compaction-started-event
+ make-compaction-completed-event
+
+ ;; Event topic constants
+ TOPIC-STREAM-TEXT
+ TOPIC-STREAM-TOOL-CALL
+ TOPIC-STREAM-THINKING
+ TOPIC-TOOL-START
+ TOPIC-TOOL-END
+ TOPIC-ITERATION-START
+ TOPIC-ITERATION-END
+ TOPIC-INTERRUPT
+ TOPIC-ERROR
+ TOPIC-COMPACTION-STARTED
+ TOPIC-COMPACTION-COMPLETED)
+
+;; ============================================================
+;; Topic constants
+;; ============================================================
+
+(define TOPIC-STREAM-TEXT "model.stream.text")
+(define TOPIC-STREAM-TOOL-CALL "model.stream.tool_call")
+(define TOPIC-STREAM-THINKING "model.stream.thinking")
+(define TOPIC-TOOL-START "tool.execution.start")
+(define TOPIC-TOOL-END "tool.execution.end")
+(define TOPIC-ITERATION-START "iteration.started")
+(define TOPIC-ITERATION-END "iteration.completed")
+(define TOPIC-INTERRUPT "interrupt.requested")
+(define TOPIC-ERROR "error")
+(define TOPIC-COMPACTION-STARTED "compaction.started")
+(define TOPIC-COMPACTION-COMPLETED "compaction.completed")
+
+;; ============================================================
+;; Helpers
+;; ============================================================
+
+(define (current-time-seconds)
+  (inexact->exact (truncate (/ (current-inexact-milliseconds) 1000))))
+
+(define (event-topic=? evt topic)
+  (equal? (event-ev evt) topic))
+
+;; ============================================================
+;; Predicates
+;; ============================================================
+
+(define (stream-text-event? evt)
+  (and (event? evt) (event-topic=? evt TOPIC-STREAM-TEXT)))
+
+(define (stream-tool-call-event? evt)
+  (and (event? evt) (event-topic=? evt TOPIC-STREAM-TOOL-CALL)))
+
+(define (stream-thinking-event? evt)
+  (and (event? evt) (event-topic=? evt TOPIC-STREAM-THINKING)))
+
+(define (tool-start-event? evt)
+  (and (event? evt) (event-topic=? evt TOPIC-TOOL-START)))
+
+(define (tool-end-event? evt)
+  (and (event? evt) (event-topic=? evt TOPIC-TOOL-END)))
+
+(define (iteration-start-event? evt)
+  (and (event? evt) (event-topic=? evt TOPIC-ITERATION-START)))
+
+(define (iteration-end-event? evt)
+  (and (event? evt) (event-topic=? evt TOPIC-ITERATION-END)))
+
+(define (interrupt-event? evt)
+  (and (event? evt) (event-topic=? evt TOPIC-INTERRUPT)))
+
+(define (error-event? evt)
+  (and (event? evt) (event-topic=? evt TOPIC-ERROR)))
+
+(define (compaction-started-event? evt)
+  (and (event? evt) (event-topic=? evt TOPIC-COMPACTION-STARTED)))
+
+(define (compaction-completed-event? evt)
+  (and (event? evt) (event-topic=? evt TOPIC-COMPACTION-COMPLETED)))
+
+;; ============================================================
+;; Constructors
+;; ============================================================
+
+(define (make-stream-text-event session-id payload #:turn-id [turn-id #f])
+  (make-event TOPIC-STREAM-TEXT (current-time-seconds) session-id turn-id payload))
+
+(define (make-stream-tool-call-event session-id payload #:turn-id [turn-id #f])
+  (make-event TOPIC-STREAM-TOOL-CALL (current-time-seconds) session-id turn-id payload))
+
+(define (make-stream-thinking-event session-id payload #:turn-id [turn-id #f])
+  (make-event TOPIC-STREAM-THINKING (current-time-seconds) session-id turn-id payload))
+
+(define (make-tool-start-event session-id tool-name tool-call-id)
+  (make-event TOPIC-TOOL-START (current-time-seconds) session-id #f
+              (hasheq 'tool-name tool-name 'tool-call-id tool-call-id)))
+
+(define (make-tool-end-event session-id tool-name tool-call-id)
+  (make-event TOPIC-TOOL-END (current-time-seconds) session-id #f
+              (hasheq 'tool-name tool-name 'tool-call-id tool-call-id)))
+
+(define (make-iteration-start-event session-id turn-id)
+  (make-event TOPIC-ITERATION-START (current-time-seconds) session-id turn-id
+              (hasheq 'sessionId session-id)))
+
+(define (make-iteration-end-event session-id turn-id reason)
+  (make-event TOPIC-ITERATION-END (current-time-seconds) session-id turn-id
+              (hasheq 'sessionId session-id 'reason reason)))
+
+(define (make-interrupt-event session-id)
+  (make-event TOPIC-INTERRUPT (current-time-seconds) session-id #f
+              (hasheq 'sessionId session-id)))
+
+(define (make-error-event session-id message #:turn-id [turn-id #f])
+  (make-event TOPIC-ERROR (current-time-seconds) session-id turn-id
+              (hasheq 'message message)))
+
+(define (make-compaction-started-event session-id #:persist? [persist? #f])
+  (make-event TOPIC-COMPACTION-STARTED (current-time-seconds) session-id #f
+              (hasheq 'sessionId session-id 'persist? persist?)))
+
+(define (make-compaction-completed-event session-id removed-count #:persist? [persist? #f])
+  (make-event TOPIC-COMPACTION-COMPLETED (current-time-seconds) session-id #f
+              (hasheq 'sessionId session-id 'persist? persist? 'removedCount removed-count)))


### PR DESCRIPTION
## FEAT-77: Typed event classes

New `util/event-classes.rkt` with typed predicates, constructors, and topic constants.
10 new tests.
Closes #969