### PR TITLE
FEAT-78: waitForIdle in SDK

### DIFF
--- a/tests/test-wait-idle.rkt
+++ b/tests/test-wait-idle.rkt
@@ -1,0 +1,76 @@
+#lang racket
+
+;; tests/test-wait-idle.rkt — FEAT-78: waitForIdle in SDK
+
+(require rackunit
+         rackunit/text-ui
+         "../agent/event-bus.rkt"
+         "../util/protocol-types.rkt"
+         "../util/wait-idle.rkt")
+
+(define wait-idle-tests
+  (test-suite
+   "waitForIdle"
+
+   (test-case "wait-for-idle! returns idle on iteration.completed"
+     (define bus (make-event-bus))
+     (define sid "test-session-1")
+     ;; Publish completion event in a thread
+     (thread
+      (lambda ()
+        (sleep 0.05)
+        (publish! bus
+                  (make-event "iteration.completed"
+                              (inexact->exact (truncate (/ (current-inexact-milliseconds) 1000)))
+                              sid
+                              #f
+                              (hasheq)))))
+     (define result (wait-for-idle! bus sid))
+     (check-equal? result 'idle))
+
+   (test-case "wait-for-idle! returns timeout when no event"
+     (define bus (make-event-bus))
+     (define sid "test-session-2")
+     (define result (wait-for-idle! bus sid 100))
+     (check-equal? result 'timeout))
+
+   (test-case "wait-for-idle! ignores events from other sessions"
+     (define bus (make-event-bus))
+     (define sid "correct-session")
+     (thread
+      (lambda ()
+        (sleep 0.05)
+        ;; Publish for wrong session
+        (publish! bus
+                  (make-event "iteration.completed"
+                              (inexact->exact (truncate (/ (current-inexact-milliseconds) 1000)))
+                              "wrong-session"
+                              #f
+                              (hasheq)))
+        (sleep 0.05)
+        ;; Then publish for correct session
+        (publish! bus
+                  (make-event "iteration.completed"
+                              (inexact->exact (truncate (/ (current-inexact-milliseconds) 1000)))
+                              sid
+                              #f
+                              (hasheq)))))
+     (define result (wait-for-idle! bus sid 2000))
+     (check-equal? result 'idle))
+
+   (test-case "wait-for-idle! responds to iteration.ended too"
+     (define bus (make-event-bus))
+     (define sid "test-session-3")
+     (thread
+      (lambda ()
+        (sleep 0.05)
+        (publish! bus
+                  (make-event "iteration.ended"
+                              (inexact->exact (truncate (/ (current-inexact-milliseconds) 1000)))
+                              sid
+                              #f
+                              (hasheq)))))
+     (define result (wait-for-idle! bus sid))
+     (check-equal? result 'idle))))
+
+(run-tests wait-idle-tests)

--- a/util/wait-idle.rkt
+++ b/util/wait-idle.rkt
@@ -1,0 +1,43 @@
+#lang racket/base
+
+;; util/wait-idle.rkt — FEAT-78: waitForIdle for SDK
+;;
+;; Provides a synchronization primitive that blocks until the agent
+;; loop completes an iteration (idle state). Uses event bus subscription.
+
+(require racket/contract
+         "protocol-types.rkt"
+         "../agent/event-bus.rkt")
+
+(provide
+ (contract-out
+  [wait-for-idle! (->* (event-bus? string?) ((or/c #f number?)) any)]))
+
+;; ============================================================
+;; wait-for-idle! : event-bus? string? (or/c #f number?) -> any
+;;
+;; Blocks until an iteration.completed or iteration.ended event
+;; is observed for the given session-id.
+;; Optional timeout in milliseconds ( #f = no timeout ).
+;; Returns 'idle on success, 'timeout on timeout.
+;; ============================================================
+
+(define (wait-for-idle! bus session-id [timeout-ms #f])
+  (define done-channel (make-channel))
+  (define sub-id
+    (subscribe!
+     bus
+     (lambda (evt)
+       (when (and (equal? (event-session-id evt) session-id)
+                  (or (equal? (event-ev evt) "iteration.completed")
+                      (equal? (event-ev evt) "iteration.ended")))
+         (channel-put done-channel 'idle)))
+     #:filter (lambda (evt)
+                (member (event-ev evt)
+                        '("iteration.completed" "iteration.ended")))))
+  (define result
+    (if timeout-ms
+        (sync/timeout (/ timeout-ms 1000.0) done-channel)
+        (sync done-channel)))
+  (unsubscribe! bus sub-id)
+  (or result 'timeout))


### PR DESCRIPTION
## FEAT-78: waitForIdle

New `util/wait-idle.rkt` with event-bus-based idle synchronization.
4 new tests.
Closes #970