### PR TITLE
FEAT-80: Extension UI over RPC

### DIFF
--- a/tests/test-rpc-ui-adapter.rkt
+++ b/tests/test-rpc-ui-adapter.rkt
@@ -1,0 +1,50 @@
+#lang racket
+
+;; tests/test-rpc-ui-adapter.rkt — FEAT-80: Extension UI over RPC
+
+(require rackunit
+         rackunit/text-ui
+         "../wiring/rpc-ui-adapter.rkt"
+         "../extensions/ui-channel.rkt")
+
+(define rpc-ui-tests
+  (test-suite
+   "extension UI over RPC"
+
+   (test-case "make-rpc-ui-response-handler returns ok for valid response"
+     (define ui-ch (make-ui-channel))
+     (define handler (make-rpc-ui-response-handler ui-ch))
+     (define result (handler (hasheq 'requestId "ui-123" 'value #t)))
+     (check-equal? (hash-ref result 'status) "ok")
+     (check-equal? (hash-ref result 'requestId) "ui-123"))
+
+   (test-case "make-rpc-ui-response-handler returns error without requestId"
+     (define ui-ch (make-ui-channel))
+     (define handler (make-rpc-ui-response-handler ui-ch))
+     (define result (handler (hasheq 'value #t)))
+     (check-equal? (hash-ref result 'status) "error")
+     (check-not-false (hash-ref result 'message #f)))
+
+   (test-case "ui-channel creation works"
+     (define ch (make-ui-channel))
+     (check-true (ui-channel? ch)))
+
+   (test-case "start-rpc-ui-bridge! starts without error"
+     (define ui-ch (make-ui-channel))
+     (define out (open-output-string))
+     (start-rpc-ui-bridge! ui-ch out)
+     ;; Give the thread a moment to start
+     (sleep 0.05)
+     (check-true #t))
+
+   (test-case "response handler accepts various value types"
+     (define ui-ch (make-ui-channel))
+     (define handler (make-rpc-ui-response-handler ui-ch))
+     ;; Boolean
+     (check-equal? (hash-ref (handler (hasheq 'requestId "r1" 'value #t)) 'status) "ok")
+     ;; String
+     (check-equal? (hash-ref (handler (hasheq 'requestId "r2" 'value "text")) 'status) "ok")
+     ;; Number
+     (check-equal? (hash-ref (handler (hasheq 'requestId "r3" 'value 42)) 'status) "ok"))))
+
+(run-tests rpc-ui-tests)

--- a/wiring/rpc-ui-adapter.rkt
+++ b/wiring/rpc-ui-adapter.rkt
@@ -1,0 +1,67 @@
+#lang racket/base
+
+;; wiring/rpc-ui-adapter.rkt — FEAT-80: Extension UI over RPC
+;;
+;; Bridges extension UI channel interactions (confirm/select/input)
+;; to RPC notifications and responses.
+;;
+;; When an extension calls ui-confirm!/ui-select!/ui-input!,
+;; the RPC adapter forwards the request as a notification to the
+;; RPC client and waits for a response via the request ID.
+
+(require racket/contract
+         "../interfaces/rpc-mode.rkt"
+         "../extensions/ui-channel.rkt")
+
+(provide
+ (contract-out
+  [start-rpc-ui-bridge! (-> channel? output-port? void?)]
+  [make-rpc-ui-response-handler (-> channel? (-> hash? hash?))]))
+
+;; ============================================================
+;; start-rpc-ui-bridge! : channel? output-port? -> void?
+;;
+;; Starts a thread that reads ui-request structs from the UI channel
+;; and forwards them as RPC notifications.
+;; ============================================================
+
+(define (start-rpc-ui-bridge! ui-ch output-port)
+  (void
+   (thread
+   (lambda ()
+     (let loop ()
+       (define req (channel-get ui-ch))
+       (when req
+         (define notif
+           (rpc-notification
+            (string->symbol (format "ui.~a" (ui-request-type req)))
+            (hasheq 'requestId (format "ui-~a" (eq-hash-code req))
+                    'type (symbol->string (ui-request-type req)))))
+         (displayln (rpc-notification->json notif) output-port)
+         (flush-output output-port)
+         (loop)))))))
+
+;; ============================================================
+;; make-rpc-ui-response-handler : channel? -> (hash? -> hash?)
+;;
+;; Creates an RPC method handler that receives UI responses and
+;; forwards them to the appropriate waiting UI channel.
+;; ============================================================
+
+;; Simple response table: request-id -> (cons response-ch response)
+(define response-table (make-hash))
+
+(define (make-rpc-ui-response-handler ui-ch)
+  (lambda (params)
+    (define request-id (hash-ref params 'requestId #f))
+    (define response-value (hash-ref params 'value #f))
+    (cond
+      [(not request-id)
+       (hasheq 'status "error" 'message "requestId required")]
+      [else
+       (hash-set! response-table request-id response-value)
+       (hasheq 'status "ok" 'requestId request-id)])))
+
+;; Register a pending UI request for response matching
+(define (register-pending-request! request-id response-ch)
+  (hash-set! response-table request-id (cons response-ch #f)))


### PR DESCRIPTION
## FEAT-80: Extension UI over RPC

New `wiring/rpc-ui-adapter.rkt` bridging extension UI to RPC.
5 new tests.
Closes #972