### PR TITLE
Wave 5 nice-to-fix: layer placement, contracts, edge cases, error handling

### DIFF
--- a/agent/wait-idle.rkt
+++ b/agent/wait-idle.rkt
@@ -1,17 +1,16 @@
 #lang racket/base
 
-;; util/wait-idle.rkt — FEAT-78: waitForIdle for SDK
+;; agent/wait-idle.rkt — FEAT-78: waitForIdle for SDK
 ;;
 ;; Provides a synchronization primitive that blocks until the agent
 ;; loop completes an iteration (idle state). Uses event bus subscription.
+;; Lives in agent/ because it depends on agent/event-bus.
 
 (require racket/contract
-         "protocol-types.rkt"
-         "../agent/event-bus.rkt")
+         "../util/protocol-types.rkt"
+         "event-bus.rkt")
 
-(provide
- (contract-out
-  [wait-for-idle! (->* (event-bus? string?) ((or/c #f number?)) any)]))
+(provide (contract-out [wait-for-idle! (->* (event-bus? string?) ((or/c #f number?)) any)]))
 
 ;; ============================================================
 ;; wait-for-idle! : event-bus? string? (or/c #f number?) -> any
@@ -25,16 +24,14 @@
 (define (wait-for-idle! bus session-id [timeout-ms #f])
   (define done-channel (make-channel))
   (define sub-id
-    (subscribe!
-     bus
-     (lambda (evt)
-       (when (and (equal? (event-session-id evt) session-id)
-                  (or (equal? (event-ev evt) "iteration.completed")
-                      (equal? (event-ev evt) "iteration.ended")))
-         (channel-put done-channel 'idle)))
-     #:filter (lambda (evt)
-                (member (event-ev evt)
-                        '("iteration.completed" "iteration.ended")))))
+    (subscribe! bus
+                (lambda (evt)
+                  (when (and (equal? (event-session-id evt) session-id)
+                             (or (equal? (event-ev evt) "iteration.completed")
+                                 (equal? (event-ev evt) "iteration.ended")))
+                    (channel-put done-channel 'idle)))
+                #:filter (lambda (evt)
+                           (member (event-ev evt) '("iteration.completed" "iteration.ended")))))
   (define result
     (if timeout-ms
         (sync/timeout (/ timeout-ms 1000.0) done-channel)

--- a/tests/test-event-classes.rkt
+++ b/tests/test-event-classes.rkt
@@ -8,95 +8,113 @@
          "../util/protocol-types.rkt")
 
 (define event-class-tests
-  (test-suite
-   "typed event classes"
+  (test-suite "typed event classes"
 
-   ;; ============================================================
-   ;; Stream events
-   ;; ============================================================
-   (test-case "stream-text-event predicate and constructor"
-     (define evt (make-stream-text-event "s1" (hasheq 'text "hello")))
-     (check-true (stream-text-event? evt))
-     (check-false (tool-start-event? evt))
-     (check-equal? (event-ev evt) "model.stream.text")
-     (check-equal? (hash-ref (event-payload evt) 'text) "hello"))
+    ;; ============================================================
+    ;; Stream events
+    ;; ============================================================
+    (test-case "stream-text-event predicate and constructor"
+      (define evt (make-stream-text-event "s1" (hasheq 'text "hello")))
+      (check-true (stream-text-event? evt))
+      (check-false (tool-start-event? evt))
+      (check-equal? (event-ev evt) "model.stream.text")
+      (check-equal? (hash-ref (event-payload evt) 'text) "hello"))
 
-   (test-case "stream-tool-call-event predicate"
-     (define evt (make-stream-tool-call-event "s1" (hasheq 'name "bash")))
-     (check-true (stream-tool-call-event? evt))
-     (check-equal? (event-ev evt) "model.stream.tool_call"))
+    (test-case "stream-tool-call-event predicate"
+      (define evt (make-stream-tool-call-event "s1" (hasheq 'name "bash")))
+      (check-true (stream-tool-call-event? evt))
+      (check-equal? (event-ev evt) "model.stream.tool_call"))
 
-   (test-case "stream-thinking-event predicate"
-     (define evt (make-stream-thinking-event "s1" (hasheq 'thinking "hmm")))
-     (check-true (stream-thinking-event? evt))
-     (check-equal? (event-ev evt) "model.stream.thinking"))
+    (test-case "stream-thinking-event predicate"
+      (define evt (make-stream-thinking-event "s1" (hasheq 'thinking "hmm")))
+      (check-true (stream-thinking-event? evt))
+      (check-equal? (event-ev evt) "model.stream.thinking"))
 
-   ;; ============================================================
-   ;; Tool lifecycle events
-   ;; ============================================================
-   (test-case "tool-start-event and tool-end-event"
-     (define start (make-tool-start-event "s1" "bash" "tc-1"))
-     (define end (make-tool-end-event "s1" "bash" "tc-1"))
-     (check-true (tool-start-event? start))
-     (check-true (tool-end-event? end))
-     (check-false (tool-end-event? start))
-     (check-equal? (hash-ref (event-payload start) 'tool-name) "bash")
-     (check-equal? (hash-ref (event-payload end) 'tool-call-id) "tc-1"))
+    ;; ============================================================
+    ;; Tool lifecycle events
+    ;; ============================================================
+    (test-case "tool-start-event and tool-end-event"
+      (define start (make-tool-start-event "s1" "bash" "tc-1"))
+      (define end (make-tool-end-event "s1" "bash" "tc-1"))
+      (check-true (tool-start-event? start))
+      (check-true (tool-end-event? end))
+      (check-false (tool-end-event? start))
+      (check-equal? (hash-ref (event-payload start) 'tool-name) "bash")
+      (check-equal? (hash-ref (event-payload end) 'tool-call-id) "tc-1"))
 
-   ;; ============================================================
-   ;; Iteration events
-   ;; ============================================================
-   (test-case "iteration-start-event and iteration-end-event"
-     (define start (make-iteration-start-event "s1" "turn-1"))
-     (define end (make-iteration-end-event "s1" "turn-1" "completed"))
-     (check-true (iteration-start-event? start))
-     (check-true (iteration-end-event? end))
-     (check-equal? (hash-ref (event-payload end) 'reason) "completed"))
+    ;; ============================================================
+    ;; Iteration events
+    ;; ============================================================
+    (test-case "iteration-start-event and iteration-end-event"
+      (define start (make-iteration-start-event "s1" "turn-1"))
+      (define end (make-iteration-end-event "s1" "turn-1" "completed"))
+      (check-true (iteration-start-event? start))
+      (check-true (iteration-end-event? end))
+      (check-equal? (hash-ref (event-payload end) 'reason) "completed"))
 
-   ;; ============================================================
-   ;; Interrupt and error events
-   ;; ============================================================
-   (test-case "interrupt-event"
-     (define evt (make-interrupt-event "s1"))
-     (check-true (interrupt-event? evt))
-     (check-false (error-event? evt))
-     (check-equal? (event-ev evt) "interrupt.requested"))
+    ;; ============================================================
+    ;; Interrupt and error events
+    ;; ============================================================
+    (test-case "interrupt-event"
+      (define evt (make-interrupt-event "s1"))
+      (check-true (interrupt-event? evt))
+      (check-false (error-event? evt))
+      (check-equal? (event-ev evt) "interrupt.requested"))
 
-   (test-case "error-event"
-     (define evt (make-error-event "s1" "something went wrong"))
-     (check-true (error-event? evt))
-     (check-equal? (hash-ref (event-payload evt) 'message) "something went wrong"))
+    (test-case "error-event"
+      (define evt (make-error-event "s1" "something went wrong"))
+      (check-true (error-event? evt))
+      (check-equal? (hash-ref (event-payload evt) 'message) "something went wrong"))
 
-   ;; ============================================================
-   ;; Compaction events
-   ;; ============================================================
-   (test-case "compaction-started-event and compaction-completed-event"
-     (define started (make-compaction-started-event "s1" #:persist? #t))
-     (define completed (make-compaction-completed-event "s1" 15 #:persist? #t))
-     (check-true (compaction-started-event? started))
-     (check-true (compaction-completed-event? completed))
-     (check-equal? (hash-ref (event-payload completed) 'removedCount) 15))
+    ;; ============================================================
+    ;; Compaction events
+    ;; ============================================================
+    (test-case "compaction-started-event and compaction-completed-event"
+      (define started (make-compaction-started-event "s1" #:persist? #t))
+      (define completed (make-compaction-completed-event "s1" 15 #:persist? #t))
+      (check-true (compaction-started-event? started))
+      (check-true (compaction-completed-event? completed))
+      (check-equal? (hash-ref (event-payload completed) 'removedCount) 15))
 
-   ;; ============================================================
-   ;; Topic constants
-   ;; ============================================================
-   (test-case "topic constants match event topics"
-     (check-equal? TOPIC-STREAM-TEXT "model.stream.text")
-     (check-equal? TOPIC-TOOL-START "tool.execution.start")
-     (check-equal? TOPIC-TOOL-END "tool.execution.end")
-     (check-equal? TOPIC-INTERRUPT "interrupt.requested")
-     (check-equal? TOPIC-ERROR "error")
-     (check-equal? TOPIC-COMPACTION-STARTED "compaction.started"))
+    ;; ============================================================
+    ;; Topic constants
+    ;; ============================================================
+    (test-case "topic constants match event topics"
+      (check-equal? TOPIC-STREAM-TEXT "model.stream.text")
+      (check-equal? TOPIC-TOOL-START "tool.execution.start")
+      (check-equal? TOPIC-TOOL-END "tool.execution.end")
+      (check-equal? TOPIC-INTERRUPT "interrupt.requested")
+      (check-equal? TOPIC-ERROR "error")
+      (check-equal? TOPIC-COMPACTION-STARTED "compaction.started"))
 
-   ;; ============================================================
-   ;; Serialization
-   ;; ============================================================
-   (test-case "event classes produce serializable events"
-     (define evt (make-stream-text-event "s1" (hasheq 'text "test")))
-     (define jsexpr (event->jsexpr evt))
-     (check-equal? (hash-ref jsexpr 'event) "model.stream.text")
-     (check-equal? (hash-ref jsexpr 'sessionId) "s1")
-     (define restored (jsexpr->event jsexpr))
-     (check-true (stream-text-event? restored)))))
+    ;; ============================================================
+    ;; Edge cases
+    ;; ============================================================
+    (test-case "stream-text-event with #:turn-id keyword"
+      (define evt (make-stream-text-event "s1" (hasheq 'text "hi") #:turn-id "turn-42"))
+      (check-true (stream-text-event? evt))
+      (check-equal? (event-ev evt) "model.stream.text")
+      (check-equal? (event-turn-id evt) "turn-42"))
+
+    (test-case "predicates return #f for non-event values"
+      (check-false (stream-text-event? "not an event"))
+      (check-false (tool-start-event? 42))
+      (check-false (error-event? #f)))
+
+    (test-case "compaction-started-event defaults persist? to #f"
+      (define evt (make-compaction-started-event "s1"))
+      (check-true (compaction-started-event? evt))
+      (check-equal? (hash-ref (event-payload evt) 'persist?) #f))
+
+    ;; ============================================================
+    ;; Serialization
+    ;; ============================================================
+    (test-case "event classes produce serializable events"
+      (define evt (make-stream-text-event "s1" (hasheq 'text "test")))
+      (define jsexpr (event->jsexpr evt))
+      (check-equal? (hash-ref jsexpr 'event) "model.stream.text")
+      (check-equal? (hash-ref jsexpr 'sessionId) "s1")
+      (define restored (jsexpr->event jsexpr))
+      (check-true (stream-text-event? restored)))))
 
 (run-tests event-class-tests)

--- a/tests/test-rpc-methods.rkt
+++ b/tests/test-rpc-methods.rkt
@@ -122,6 +122,21 @@
       (define req (rpc-request "req-1" 'session_info (hasheq 'sessionId "s1")))
       (define resp (dispatch-rpc-request req handlers))
       (check-false (rpc-response-error resp))
-      (check-not-false (hash-ref (rpc-response-result resp) 'session-id #f)))))
+      (check-not-false (hash-ref (rpc-response-result resp) 'session-id #f)))
+
+    ;; ============================================================
+    ;; Default implementations (no deps)
+    ;; ============================================================
+    (test-case "abort with default cancel-token returns status"
+      (define handlers (make-core-rpc-handlers (hasheq)))
+      (define handler (hash-ref handlers 'abort))
+      (define result (handler (hasheq)))
+      (check-equal? (hash-ref result 'status) "aborted"))
+
+    (test-case "fork default returns error"
+      (define handlers (make-core-rpc-handlers (hasheq)))
+      (define handler (hash-ref handlers 'fork))
+      (define result (handler (hasheq 'entryId "entry-1")))
+      (check-equal? (hash-ref result 'status) "error"))))
 
 (run-tests rpc-method-tests)

--- a/tests/test-sdk-steer-followup.rkt
+++ b/tests/test-sdk-steer-followup.rkt
@@ -73,6 +73,29 @@
       (define all (dequeue-all-followups! q))
       (check-equal? (length all) 2)
       (check-equal? (car all) "step 1")
-      (check-equal? (cadr all) "step 2"))))
+      (check-equal? (cadr all) "step 2"))
+
+    ;; ============================================================
+    ;; Edge cases
+    ;; ============================================================
+    (test-case "steer! with empty string message"
+      (define rt (make-runtime #:provider (make-mock-provider)))
+      (define rt-open (open-session rt))
+      (define rt-steered (steer! rt-open ""))
+      (define sess (runtime-rt-session rt-steered))
+      (define q (agent-session-queue sess))
+      (define msg (dequeue-steering! q))
+      (check-not-false msg)
+      (check-equal? msg ""))
+
+    (test-case "follow-up! with empty string"
+      (define rt (make-runtime #:provider (make-mock-provider)))
+      (define rt-open (open-session rt))
+      (define rt-followed (follow-up! rt-open ""))
+      (define sess (runtime-rt-session rt-followed))
+      (define q (agent-session-queue sess))
+      (define msg (dequeue-followup! q))
+      (check-not-false msg)
+      (check-equal? msg ""))))
 
 (run-tests steer-tests)

--- a/tests/test-wait-idle.rkt
+++ b/tests/test-wait-idle.rkt
@@ -6,71 +6,70 @@
          rackunit/text-ui
          "../agent/event-bus.rkt"
          "../util/protocol-types.rkt"
-         "../util/wait-idle.rkt")
+         "../agent/wait-idle.rkt")
 
 (define wait-idle-tests
-  (test-suite
-   "waitForIdle"
+  (test-suite "waitForIdle"
 
-   (test-case "wait-for-idle! returns idle on iteration.completed"
-     (define bus (make-event-bus))
-     (define sid "test-session-1")
-     ;; Publish completion event in a thread
-     (thread
-      (lambda ()
-        (sleep 0.05)
-        (publish! bus
-                  (make-event "iteration.completed"
-                              (inexact->exact (truncate (/ (current-inexact-milliseconds) 1000)))
-                              sid
-                              #f
-                              (hasheq)))))
-     (define result (wait-for-idle! bus sid))
-     (check-equal? result 'idle))
+    (test-case "wait-for-idle! returns idle on iteration.completed"
+      (define bus (make-event-bus))
+      (define sid "test-session-1")
+      ;; Publish completion event in a thread
+      (thread (lambda ()
+                (sleep 0.05)
+                (publish! bus
+                          (make-event "iteration.completed"
+                                      (inexact->exact (truncate (/ (current-inexact-milliseconds)
+                                                                   1000)))
+                                      sid
+                                      #f
+                                      (hasheq)))))
+      (define result (wait-for-idle! bus sid))
+      (check-equal? result 'idle))
 
-   (test-case "wait-for-idle! returns timeout when no event"
-     (define bus (make-event-bus))
-     (define sid "test-session-2")
-     (define result (wait-for-idle! bus sid 100))
-     (check-equal? result 'timeout))
+    (test-case "wait-for-idle! returns timeout when no event"
+      (define bus (make-event-bus))
+      (define sid "test-session-2")
+      (define result (wait-for-idle! bus sid 100))
+      (check-equal? result 'timeout))
 
-   (test-case "wait-for-idle! ignores events from other sessions"
-     (define bus (make-event-bus))
-     (define sid "correct-session")
-     (thread
-      (lambda ()
-        (sleep 0.05)
-        ;; Publish for wrong session
-        (publish! bus
-                  (make-event "iteration.completed"
-                              (inexact->exact (truncate (/ (current-inexact-milliseconds) 1000)))
-                              "wrong-session"
-                              #f
-                              (hasheq)))
-        (sleep 0.05)
-        ;; Then publish for correct session
-        (publish! bus
-                  (make-event "iteration.completed"
-                              (inexact->exact (truncate (/ (current-inexact-milliseconds) 1000)))
-                              sid
-                              #f
-                              (hasheq)))))
-     (define result (wait-for-idle! bus sid 2000))
-     (check-equal? result 'idle))
+    (test-case "wait-for-idle! ignores events from other sessions"
+      (define bus (make-event-bus))
+      (define sid "correct-session")
+      (thread
+       (lambda ()
+         (sleep 0.05)
+         ;; Publish for wrong session
+         (publish! bus
+                   (make-event "iteration.completed"
+                               (inexact->exact (truncate (/ (current-inexact-milliseconds) 1000)))
+                               "wrong-session"
+                               #f
+                               (hasheq)))
+         (sleep 0.05)
+         ;; Then publish for correct session
+         (publish! bus
+                   (make-event "iteration.completed"
+                               (inexact->exact (truncate (/ (current-inexact-milliseconds) 1000)))
+                               sid
+                               #f
+                               (hasheq)))))
+      (define result (wait-for-idle! bus sid 2000))
+      (check-equal? result 'idle))
 
-   (test-case "wait-for-idle! responds to iteration.ended too"
-     (define bus (make-event-bus))
-     (define sid "test-session-3")
-     (thread
-      (lambda ()
-        (sleep 0.05)
-        (publish! bus
-                  (make-event "iteration.ended"
-                              (inexact->exact (truncate (/ (current-inexact-milliseconds) 1000)))
-                              sid
-                              #f
-                              (hasheq)))))
-     (define result (wait-for-idle! bus sid))
-     (check-equal? result 'idle))))
+    (test-case "wait-for-idle! responds to iteration.ended too"
+      (define bus (make-event-bus))
+      (define sid "test-session-3")
+      (thread (lambda ()
+                (sleep 0.05)
+                (publish! bus
+                          (make-event "iteration.ended"
+                                      (inexact->exact (truncate (/ (current-inexact-milliseconds)
+                                                                   1000)))
+                                      sid
+                                      #f
+                                      (hasheq)))))
+      (define result (wait-for-idle! bus sid))
+      (check-equal? result 'idle))))
 
 (run-tests wait-idle-tests)

--- a/wiring/rpc-methods.rkt
+++ b/wiring/rpc-methods.rkt
@@ -11,7 +11,7 @@
 (require racket/contract
          "../interfaces/rpc-mode.rkt")
 
-(provide (contract-out [make-core-rpc-handlers (-> hash? hash?)]))
+(provide (contract-out [make-core-rpc-handlers (-> hash? (hash/c symbol? procedure?))]))
 
 ;; Sentinel for missing deps
 (define sentinel (gensym 'missing))
@@ -52,30 +52,30 @@
     (let ([v (hash-ref deps 'subscribe-fn sentinel)]) (if (eq? v sentinel) default-subscribe v)))
 
   (make-hash ;; ---- Abort ----
-             (list (cons 'abort
-                         (lambda (params)
-                           (cancel-token)
-                           (hasheq 'status "aborted")))
-                   ;; ---- Subscribe ----
-                   (cons 'subscribe
-                         (lambda (params)
-                           (define filter (hash-ref params 'filter #f))
-                           (define sub-id (subscribe-fn filter))
-                           (hasheq 'subscriptionId sub-id)))
-                   ;; ---- Session Info ----
-                   (cons 'session_info
-                         (lambda (params)
-                           (define info (session-info-fn))
-                           (if info
-                               info
-                               (hasheq 'status "error" 'message "no active session"))))
-                   ;; ---- Compact ----
-                   (cons 'compact
-                         (lambda (params)
-                           (define result (compact-fn))
-                           result))
-                   ;; ---- Fork ----
-                   (cons 'fork
-                         (lambda (params)
-                           (define entry-id (hash-ref params 'entryId #f))
-                           (fork-fn entry-id))))))
+   (list (cons 'abort
+               (lambda (params)
+                 (cancel-token)
+                 (hasheq 'status "aborted")))
+         ;; ---- Subscribe ----
+         (cons 'subscribe
+               (lambda (params)
+                 (define filter (hash-ref params 'filter #f))
+                 (define sub-id (subscribe-fn filter))
+                 (hasheq 'subscriptionId sub-id)))
+         ;; ---- Session Info ----
+         (cons 'session_info
+               (lambda (params)
+                 (define info (session-info-fn))
+                 (if info
+                     info
+                     (hasheq 'status "error" 'message "no active session"))))
+         ;; ---- Compact ----
+         (cons 'compact
+               (lambda (params)
+                 (define result (compact-fn))
+                 result))
+         ;; ---- Fork ----
+         (cons 'fork
+               (lambda (params)
+                 (define entry-id (hash-ref params 'entryId #f))
+                 (fork-fn entry-id))))))

--- a/wiring/rpc-ui-adapter.rkt
+++ b/wiring/rpc-ui-adapter.rkt
@@ -40,20 +40,24 @@
                   (let loop ()
                     (define req (channel-get ui-ch))
                     (when req
-                      (define request-id (format "ui-~a" (eq-hash-code req)))
-                      (define response-ch (ui-request-response-ch req))
-                      ;; Record mapping so the response handler can deliver
-                      (hash-set! pending-requests request-id response-ch)
-                      (define notif
-                        (rpc-notification (string->symbol (format "ui.~a" (ui-request-type req)))
-                                          (hasheq 'requestId
-                                                  request-id
-                                                  'type
-                                                  (symbol->string (ui-request-type req))
-                                                  'prompt
-                                                  (ui-request-prompt req))))
-                      (displayln (rpc-notification->json notif) output-port)
-                      (flush-output output-port)
+                      (with-handlers ([exn:fail? (lambda (e)
+                                                   (displayln (format "rpc-ui-bridge error: ~a"
+                                                                      (exn-message e))
+                                                              (current-error-port)))])
+                        (define request-id (format "ui-~a" (eq-hash-code req)))
+                        (define response-ch (ui-request-response-ch req))
+                        ;; Record mapping so the response handler can deliver
+                        (hash-set! pending-requests request-id response-ch)
+                        (define notif
+                          (rpc-notification (string->symbol (format "ui.~a" (ui-request-type req)))
+                                            (hasheq 'requestId
+                                                    request-id
+                                                    'type
+                                                    (symbol->string (ui-request-type req))
+                                                    'prompt
+                                                    (ui-request-prompt req))))
+                        (displayln (rpc-notification->json notif) output-port)
+                        (flush-output output-port))
                       (loop)))))))
 
 ;; ============================================================


### PR DESCRIPTION
## Wave 5 Nice-to-Fix Items

Addresses all remaining should-fix and nice-to-fix review items:

- **FEAT-78**: Moved `wait-idle.rkt` from `util/` to `agent/` (fixes import direction)
- **FEAT-75**: Tightened contract to `(hash/c symbol? procedure?)`, added default impl tests
- **FEAT-76**: Added empty-string edge case tests for steer!/follow-up!
- **FEAT-77**: Added 3 edge case tests: #:turn-id, negative predicates, persist? defaults
- **FEAT-80**: Added `with-handlers` exception handling in bridge thread

Total Wave 5 tests: 48 (was 41)