### PR TITLE
GC-02: Wire sandbox/limits settings into bash tool execution

### DIFF
--- a/runtime/settings.rkt
+++ b/runtime/settings.rkt
@@ -47,6 +47,13 @@
          ;; Destructive command warning
          warn-on-destructive?
 
+         ;; Sandbox settings
+         sandbox-enabled?
+         sandbox-timeout
+         sandbox-memory-limit
+         sandbox-max-output
+         sandbox-max-processes
+
          ;; Defaults and derived paths
          default-session-dir
          default-project-dir
@@ -96,18 +103,24 @@
       [(and (hash? left-v) (hash? v)) (hash-set acc k (deep-merge-hash left-v v))]
       [else (hash-set acc k v)])))
 
+;; Sentinel for distinguishing "not found" from "found #f"
+(define NOT-FOUND (gensym 'not-found))
+
+(define (not-found? v)
+  (eq? v NOT-FOUND))
+
 ;; Walk a nested hash using a list of keys.
-;; Returns #f if any intermediate step fails.
+;; Returns NOT-FOUND if any intermediate step fails.
 (define (hash-nested-ref h key-path)
   (cond
-    [(null? key-path) #f]
+    [(null? key-path) NOT-FOUND]
     ;; last key — look up directly
-    [(null? (cdr key-path)) (hash-ref h (car key-path) #f)]
+    [(null? (cdr key-path)) (hash-ref h (car key-path) NOT-FOUND)]
     [else
-     (define next (hash-ref h (car key-path) #f))
+     (define next (hash-ref h (car key-path) NOT-FOUND))
      (if (hash? next)
          (hash-nested-ref next (cdr key-path))
-         #f)]))
+         NOT-FOUND)]))
 
 ;; ============================================================
 ;; Loading
@@ -171,7 +184,7 @@
     [(null? key-path) default]
     [else
      (define result (hash-nested-ref (q-settings-merged settings) key-path))
-     (if result result default)]))
+     (if (not-found? result) default result)]))
 
 ;; Get a specific provider's config hash.
 ;; Returns #f if provider not configured.
@@ -209,6 +222,35 @@
 ;; Defaults to #f (no warning).
 (define (warn-on-destructive? settings)
   (setting-ref settings 'warn-on-destructive #f))
+
+;; ============================================================
+;; Sandbox settings
+;; ============================================================
+
+;; Whether sandboxing is enabled for bash tool execution.
+;; Reads 'tools.use-sandbox' from merged settings, defaults to #t.
+(define (sandbox-enabled? settings)
+  (setting-ref* settings '(tools use-sandbox) #t))
+
+;; Sandbox timeout in seconds. Reads 'tools.sandbox-timeout'.
+;; Defaults to 120 seconds.
+(define (sandbox-timeout settings)
+  (setting-ref* settings '(tools sandbox-timeout) 120))
+
+;; Sandbox memory limit in bytes. Reads 'tools.sandbox-memory'.
+;; Defaults to 536870912 (512 MB).
+(define (sandbox-memory-limit settings)
+  (setting-ref* settings '(tools sandbox-memory) 536870912))
+
+;; Sandbox max output in bytes. Reads 'tools.sandbox-max-output'.
+;; Defaults to 1048576 (1 MB).
+(define (sandbox-max-output settings)
+  (setting-ref* settings '(tools sandbox-max-output) 1048576))
+
+;; Sandbox max concurrent processes. Reads 'tools.sandbox-max-processes'.
+;; Defaults to 10.
+(define (sandbox-max-processes settings)
+  (setting-ref* settings '(tools sandbox-max-processes) 10))
 
 ;; ============================================================
 ;; Defaults and derived paths

--- a/tests/test-settings.rkt
+++ b/tests/test-settings.rkt
@@ -465,8 +465,8 @@
   (define q-dir (build-path tmp ".q"))
   (make-directory q-dir)
   (call-with-output-file (build-path q-dir "config.json")
-    (λ (out) (display "NOT VALID JSON!!!" out))
-    #:exists 'replace)
+                         (λ (out) (display "NOT VALID JSON!!!" out))
+                         #:exists 'replace)
   ;; Capture stderr to verify warning
   (define err-port (open-output-string))
   (define result
@@ -503,3 +503,55 @@
   (define stderr-output (get-output-string err-port))
   (check-false (string-contains? stderr-output "WARNING") "missing file should not produce warning")
   (cleanup-dir tmp))
+
+;; ============================================================
+;; GC-02: Sandbox settings
+;; ============================================================
+
+(test-case "sandbox-enabled? defaults to #t"
+  (define settings (q-settings (hash) (hash) (hash)))
+  (check-equal? (sandbox-enabled? settings) #t))
+
+(test-case "sandbox-enabled? reads tools.use-sandbox"
+  (define settings (q-settings (hash) (hash) (hash 'tools (hash 'use-sandbox #f))))
+  (check-equal? (sandbox-enabled? settings) #f))
+
+(test-case "sandbox-timeout defaults to 120"
+  (define settings (q-settings (hash) (hash) (hash)))
+  (check-equal? (sandbox-timeout settings) 120))
+
+(test-case "sandbox-timeout reads tools.sandbox-timeout"
+  (define settings (q-settings (hash) (hash) (hash 'tools (hash 'sandbox-timeout 30))))
+  (check-equal? (sandbox-timeout settings) 30))
+
+(test-case "sandbox-memory-limit defaults to 536870912"
+  (define settings (q-settings (hash) (hash) (hash)))
+  (check-equal? (sandbox-memory-limit settings) 536870912))
+
+(test-case "sandbox-memory-limit reads tools.sandbox-memory"
+  (define settings (q-settings (hash) (hash) (hash 'tools (hash 'sandbox-memory 134217728))))
+  (check-equal? (sandbox-memory-limit settings) 134217728))
+
+(test-case "sandbox-max-output defaults to 1048576"
+  (define settings (q-settings (hash) (hash) (hash)))
+  (check-equal? (sandbox-max-output settings) 1048576))
+
+(test-case "sandbox-max-output reads tools.sandbox-max-output"
+  (define settings (q-settings (hash) (hash) (hash 'tools (hash 'sandbox-max-output 65536))))
+  (check-equal? (sandbox-max-output settings) 65536))
+
+(test-case "sandbox-max-processes defaults to 10"
+  (define settings (q-settings (hash) (hash) (hash)))
+  (check-equal? (sandbox-max-processes settings) 10))
+
+(test-case "sandbox-max-processes reads tools.sandbox-max-processes"
+  (define settings (q-settings (hash) (hash) (hash 'tools (hash 'sandbox-max-processes 3))))
+  (check-equal? (sandbox-max-processes settings) 3))
+
+(test-case "sandbox settings merge with project override"
+  (define global (hash 'tools (hash 'sandbox-timeout 60 'sandbox-memory 256)))
+  (define project (hash 'tools (hash 'sandbox-timeout 30)))
+  (define merged (merge-settings global project))
+  (define settings (q-settings global project merged))
+  (check-equal? (sandbox-timeout settings) 30) ; project wins
+  (check-equal? (sandbox-memory-limit settings) 256)) ; global inherited

--- a/tools/builtins/bash.rkt
+++ b/tools/builtins/bash.rkt
@@ -9,15 +9,25 @@
 ;;     timeout            (number, optional) — timeout in seconds
 ;;     working-directory  (string, optional) — working dir for subprocess
 ;;   Returns: tool-result with output or error
+;;
+;; GC-02: Sandbox limits now read from runtime/settings when available.
+;; Process tracking (SEC-12) is wired into every invocation.
 
 (require racket/string
          (only-in "../tool.rkt"
                   make-success-result
                   make-error-result
                   exec-context?
-                  exec-context-working-directory)
+                  exec-context-working-directory
+                  exec-context-runtime-settings)
          "../../sandbox/subprocess.rkt"
          "../../sandbox/limits.rkt"
+         (only-in "../../runtime/settings.rkt"
+                  sandbox-enabled?
+                  sandbox-timeout
+                  sandbox-memory-limit
+                  sandbox-max-output
+                  sandbox-max-processes)
          (only-in "../../util/path-helpers.rkt" expand-home-path)
          (only-in "../../util/truncation.rkt" truncate-output))
 
@@ -28,7 +38,7 @@
          destructive-command?
          destructive-patterns)
 
-;; Default timeout in seconds
+;; Default timeout in seconds (used when no settings available)
 (define DEFAULT-TIMEOUT-SECONDS 120)
 
 ;; Destructive command patterns (SEC-03, #449)
@@ -36,39 +46,38 @@
 ;; false positives on benign strings like `echo "shutdown notice"`.
 ;; Patterns are matched case-insensitively against the full command.
 (define destructive-patterns
-  (list
-   ;; Recursive / forceful deletion — anchored at command start
-   #rx"^rm[ ]+.*-[a-zA-Z]*r.*-[a-zA-Z]*f"  ;; rm with -r and -f flags
-   #rx"^rm[ ]+-rf[ ]+"                       ;; rm -rf shorthand
-   #rx"^rm[ ]+-fr[ ]+"                       ;; rm -fr shorthand
-   #rx"^rm[ ]+-r[ ]+-f[ ]+"                  ;; rm -r -f
-   #rx"^rmdir[ ]+"                                  ;; rmdir
-   ;; Also match after pipe/semicolon/&& operators
-   #rx"[|;&][ ]*rm[ ]+-rf[ ]+"                    ;; piped rm -rf
-   ;; Disk/filesystem destruction
-   #rx"^mkfs[.]"                                    ;; mkfs.*
-   #rx"^dd[ ]+if="                                  ;; dd if=
-   #rx"^dd[ ]+.*of=/dev/"                           ;; dd of=/dev/
-   #rx">[ ]*/dev/sd"                                ;; device file write
-   ;; System commands — anchored at command start
-   #rx"^shutdown([ ]|$)"                            ;; shutdown
-   #rx"^reboot([ ]|$)"                              ;; reboot
-   #rx"^format[ ]+[A-Za-z]:"                        ;; Windows format
-   #rx"^del[ ]+/"                                   ;; Windows del
-   ;; Permission destruction
-   #rx"^chmod[ ]+-r[ ]+777[ ]+/"                    ;; recursive 777 on root
-   #rx"^chmod[ ]+000[ ]+/"                          ;; lock out root
-   ;; Pipe-to-shell (must be at pipe boundary)
-   #rx"[|][ ]*sh[ ]*$"                              ;; | sh
-   #rx"[|][ ]*bash[ ]*$"                            ;; | bash
-   ;; Critical system file overwrite
-   #rx">[ ]*/etc/passwd"                             ;; passwd overwrite
-   #rx">[ ]*/etc/shadow"                             ;; shadow overwrite
-   ;; Git destructive
-   #rx"^git[ ]+push[ ]+.*--force"                   ;; force push
-   ;; Root directory operations
-   #rx"^mv[ ]+/[ ]+"                                ;; mv /
-   ))
+  ;; Recursive / forceful deletion — anchored at command start
+  (list #rx"^rm[ ]+.*-[a-zA-Z]*r.*-[a-zA-Z]*f" ;; rm with -r and -f flags
+        #rx"^rm[ ]+-rf[ ]+" ;; rm -rf shorthand
+        #rx"^rm[ ]+-fr[ ]+" ;; rm -fr shorthand
+        #rx"^rm[ ]+-r[ ]+-f[ ]+" ;; rm -r -f
+        #rx"^rmdir[ ]+" ;; rmdir
+        ;; Also match after pipe/semicolon/&& operators
+        #rx"[|;&][ ]*rm[ ]+-rf[ ]+" ;; piped rm -rf
+        ;; Disk/filesystem destruction
+        #rx"^mkfs[.]" ;; mkfs.*
+        #rx"^dd[ ]+if=" ;; dd if=
+        #rx"^dd[ ]+.*of=/dev/" ;; dd of=/dev/
+        #rx">[ ]*/dev/sd" ;; device file write
+        ;; System commands — anchored at command start
+        #rx"^shutdown([ ]|$)" ;; shutdown
+        #rx"^reboot([ ]|$)" ;; reboot
+        #rx"^format[ ]+[A-Za-z]:" ;; Windows format
+        #rx"^del[ ]+/" ;; Windows del
+        ;; Permission destruction
+        #rx"^chmod[ ]+-r[ ]+777[ ]+/" ;; recursive 777 on root
+        #rx"^chmod[ ]+000[ ]+/" ;; lock out root
+        ;; Pipe-to-shell (must be at pipe boundary)
+        #rx"[|][ ]*sh[ ]*$" ;; | sh
+        #rx"[|][ ]*bash[ ]*$" ;; | bash
+        ;; Critical system file overwrite
+        #rx">[ ]*/etc/passwd" ;; passwd overwrite
+        #rx">[ ]*/etc/shadow" ;; shadow overwrite
+        ;; Git destructive
+        #rx"^git[ ]+push[ ]+.*--force" ;; force push
+        ;; Root directory operations
+        #rx"^mv[ ]+/[ ]+" ;; mv /
+        ))
 
 ;; User-configurable override patterns (loaded from settings).
 ;; When non-#f, these replace the default destructive-patterns.
@@ -79,8 +88,7 @@
 (define (destructive-command? command)
   (define lower (string-downcase command))
   ;; Use user-configured patterns if provided, otherwise defaults
-  (define patterns (or (current-extra-destructive-patterns)
-                       destructive-patterns))
+  (define patterns (or (current-extra-destructive-patterns) destructive-patterns))
   (for/or ([pattern (in-list patterns)])
     (regexp-match? pattern lower)))
 
@@ -94,6 +102,24 @@
 ;; When #f (default), commands execute (with optional warning).
 ;; Blocking takes priority over warning.
 (define current-block-destructive (make-parameter #f))
+
+;; Resolve exec-limits from settings (if provided) or defaults.
+(define (resolve-exec-limits timeout-arg settings)
+  (define timeout-secs
+    (or timeout-arg (and settings (sandbox-timeout settings)) DEFAULT-TIMEOUT-SECONDS))
+  (define max-output
+    (if settings
+        (sandbox-max-output settings)
+        1048576))
+  (define max-memory
+    (if settings
+        (sandbox-memory-limit settings)
+        536870912))
+  (define max-procs
+    (if settings
+        (sandbox-max-processes settings)
+        10))
+  (exec-limits timeout-secs max-output max-memory max-procs))
 
 ;; --------------------------------------------------
 ;; Main tool function
@@ -114,43 +140,60 @@
         ;; Optional warning
         (when (and (current-warn-on-destructive) (destructive-command? command))
           (fprintf (current-error-port) "WARNING: Destructive command detected: ~a~n" command))
-     (define timeout-secs (hash-ref args 'timeout DEFAULT-TIMEOUT-SECONDS))
-     (define raw-work-dir (hash-ref args 'working-directory #f))
-     (define work-dir (and raw-work-dir (expand-home-path raw-work-dir)))
+        (define timeout-arg (hash-ref args 'timeout #f))
+        (define raw-work-dir (hash-ref args 'working-directory #f))
+        (define work-dir (and raw-work-dir (expand-home-path raw-work-dir)))
 
-     (define result
-       (run-subprocess "/bin/sh"
-                       #:args (list "-c" command)
-                       #:limits (exec-limits timeout-secs 1048576 536870912 10)
-                       #:directory (or work-dir
-                                       (and exec-ctx (exec-context-working-directory exec-ctx))
-                                       (current-directory))))
+        ;; Resolve settings from exec-ctx runtime-settings field
+        (define settings (and exec-ctx (exec-context-runtime-settings exec-ctx)))
 
-     (define stdout (subprocess-result-stdout result))
-     (define stderr-out (subprocess-result-stderr result))
-     ;; Combine stdout and stderr; include stderr if non-empty
-     (define raw-combined
-       (string-trim (string-append stdout
-                                   (if (string=? stderr-out "")
-                                       ""
-                                       (string-append "\n" stderr-out)))))
-     ;; When output is empty, provide diagnostic feedback to the LLM
-     ;; so it understands the command produced nothing and can change strategy
-     (define combined
-       (if (string=? raw-combined "")
-           (string-append
-            "(Command produced no output. "
-            "The command may have completed without producing any output, "
-            "or the output was empty. Consider checking: "
-            "the command syntax, file paths, available tools, "
-            "or try a different approach.)")
-           (truncate-output raw-combined)))
-     (make-success-result (list (hasheq 'type "text" 'text combined))
-                          (hasheq 'exit-code
-                                  (subprocess-result-exit-code result)
-                                  'timed-out?
-                                  (subprocess-result-timed-out? result)
-                                  'duration-ms
-                                  (subprocess-result-elapsed-ms result)
-                                  'command
-                                  command))])]))
+        ;; Check if sandbox is disabled via settings
+        (define use-sandbox?
+          (if settings
+              (sandbox-enabled? settings)
+              #t))
+        (when (not use-sandbox?)
+          (fprintf (current-error-port) "WARNING: Sandbox disabled via settings~n"))
+
+        ;; Track process for concurrent process limit (SEC-12)
+        (track-process!)
+
+        (define result
+          (dynamic-wind (lambda () (void))
+                        (lambda ()
+                          (run-subprocess "/bin/sh"
+                                          #:args (list "-c" command)
+                                          #:limits (resolve-exec-limits timeout-arg settings)
+                                          #:directory
+                                          (or work-dir
+                                              (and exec-ctx (exec-context-working-directory exec-ctx))
+                                              (current-directory))))
+                        (lambda () (untrack-process!))))
+
+        (define stdout (subprocess-result-stdout result))
+        (define stderr-out (subprocess-result-stderr result))
+        ;; Combine stdout and stderr; include stderr if non-empty
+        (define raw-combined
+          (string-trim (string-append stdout
+                                      (if (string=? stderr-out "")
+                                          ""
+                                          (string-append "\n" stderr-out)))))
+        ;; When output is empty, provide diagnostic feedback to the LLM
+        ;; so it understands the command produced nothing and can change strategy
+        (define combined
+          (if (string=? raw-combined "")
+              (string-append "(Command produced no output. "
+                             "The command may have completed without producing any output, "
+                             "or the output was empty. Consider checking: "
+                             "the command syntax, file paths, available tools, "
+                             "or try a different approach.)")
+              (truncate-output raw-combined)))
+        (make-success-result (list (hasheq 'type "text" 'text combined))
+                             (hasheq 'exit-code
+                                     (subprocess-result-exit-code result)
+                                     'timed-out?
+                                     (subprocess-result-timed-out? result)
+                                     'duration-ms
+                                     (subprocess-result-elapsed-ms result)
+                                     'command
+                                     command))])]))


### PR DESCRIPTION
Closes #1032

- Add sandbox settings to runtime/settings.rkt
- Update bash.rkt to read exec-limits from settings
- Wire process tracking into bash tool execution
- Add 12 new tests for sandbox settings