### PR TITLE
GC-17/GC-18: RPC methods + in-memory session manager

### DIFF
--- a/interfaces/sdk.rkt
+++ b/interfaces/sdk.rkt
@@ -28,6 +28,14 @@
          (only-in "../llm/token-budget.rkt" DEFAULT-TOKEN-BUDGET-THRESHOLD)
          (only-in "../extensions/api.rkt" list-extensions)
          (only-in "../agent/queue.rkt" enqueue-steering! enqueue-followup!)
+         (only-in "../runtime/session-store.rkt"
+                  make-in-memory-session-manager
+                  in-memory-session-manager?
+                  in-memory-append!
+                  in-memory-append-entries!
+                  in-memory-load
+                  in-memory-list-sessions
+                  in-memory-fork!)
          "../util/cancellation.rkt")
 
 ;; Structs
@@ -67,7 +75,16 @@
                        [follow-up! (runtime? string? . -> . runtime?)])
 
          ;; Compaction types
-         compaction-result?)
+         compaction-result?
+
+         ;; In-memory session manager (GC-18)
+         make-in-memory-session-manager
+         in-memory-session-manager?
+         in-memory-append!
+         in-memory-append-entries!
+         in-memory-load
+         in-memory-list-sessions
+         in-memory-fork!)
 
 ;; ============================================================
 ;; Cancellation token — imported from util/cancellation.rkt

--- a/runtime/session-store.rkt
+++ b/runtime/session-store.rkt
@@ -42,7 +42,15 @@
          ;; Session forking (#500)
          fork-session!
          ;; Session naming
-         write-session-name!)
+         write-session-name!
+         ;; In-memory session manager (GC-18)
+         in-memory-session-manager?
+         make-in-memory-session-manager
+         in-memory-append!
+         in-memory-append-entries!
+         in-memory-load
+         in-memory-list-sessions
+         in-memory-fork!)
 
 ;; ── Write-ahead marker ──
 
@@ -476,3 +484,54 @@
              to-version
              (length entries)
              bak-path)))
+
+;; ============================================================
+;; In-memory session manager (GC-18)
+;; ============================================================
+
+;; In-memory store: maps session-id -> (box (listof message?))
+;; Provides the same interface as file-backed storage but no disk I/O.
+;; Useful for SDK unit tests and extension testing.
+
+(struct in-memory-session-manager (sessions-box) #:transparent)
+
+(define (make-in-memory-session-manager)
+  (in-memory-session-manager (box (hash))))
+
+;; Append a message to an in-memory session.
+(define (in-memory-append! mgr session-id msg)
+  (define box (in-memory-session-manager-sessions-box mgr))
+  (define sessions (unbox box))
+  (define existing (hash-ref sessions session-id '()))
+  (set-box! box (hash-set sessions session-id (append existing (list msg)))))
+
+;; Append multiple messages atomically.
+(define (in-memory-append-entries! mgr session-id msgs)
+  (for ([msg (in-list msgs)])
+    (in-memory-append! mgr session-id msg)))
+
+;; Load all messages from an in-memory session.
+(define (in-memory-load mgr session-id)
+  (define sessions (unbox (in-memory-session-manager-sessions-box mgr)))
+  (hash-ref sessions session-id '()))
+
+;; List all session IDs.
+(define (in-memory-list-sessions mgr)
+  (hash-keys (unbox (in-memory-session-manager-sessions-box mgr))))
+
+;; Fork: copy entries up to entry-id (or all) into a new session.
+(define (in-memory-fork! mgr src-id dest-id [entry-id #f])
+  (define entries (in-memory-load mgr src-id))
+  (define to-copy
+    (if entry-id
+        (let loop ([es entries]
+                   [acc '()])
+          (cond
+            [(null? es) (reverse acc)]
+            [(equal? (message-id (car es)) entry-id) (reverse (cons (car es) acc))]
+            [else (loop (cdr es) (cons (car es) acc))]))
+        entries))
+  (define box (in-memory-session-manager-sessions-box mgr))
+  (define sessions (unbox box))
+  (set-box! box (hash-set sessions dest-id to-copy))
+  dest-id)

--- a/tests/test-in-memory-session.rkt
+++ b/tests/test-in-memory-session.rkt
@@ -1,0 +1,121 @@
+#lang racket
+
+;; tests/test-in-memory-session.rkt — GC-18: In-memory session manager
+;;
+;; Tests the in-memory session manager that provides the same interface
+;; as file-backed storage but without disk I/O. Useful for SDK testing.
+
+(require rackunit
+         rackunit/text-ui
+         "../runtime/session-store.rkt"
+         "../util/protocol-types.rkt")
+
+(define in-memory-tests
+  (test-suite "in-memory session manager"
+
+    (test-case "make-in-memory-session-manager creates empty manager"
+      (define mgr (make-in-memory-session-manager))
+      (check-true (in-memory-session-manager? mgr))
+      (check-equal? (in-memory-list-sessions mgr) '()))
+
+    (test-case "append and load single message"
+      (define mgr (make-in-memory-session-manager))
+      (define msg (make-message "m1" #f "user" "text" (list (make-text-part "hello")) 1000 (hash)))
+      (in-memory-append! mgr "s1" msg)
+      (define loaded (in-memory-load mgr "s1"))
+      (check-equal? (length loaded) 1)
+      (check-equal? (message-id (car loaded)) "m1"))
+
+    (test-case "append-entries! appends multiple messages atomically"
+      (define mgr (make-in-memory-session-manager))
+      (define msgs
+        (for/list ([i (in-range 5)])
+          (make-message (format "m~a" i)
+                        #f
+                        "user"
+                        "text"
+                        (list (make-text-part (format "msg ~a" i)))
+                        (+ 1000 i)
+                        (hash))))
+      (in-memory-append-entries! mgr "s1" msgs)
+      (define loaded (in-memory-load mgr "s1"))
+      (check-equal? (length loaded) 5)
+      (check-equal? (message-id (car loaded)) "m0")
+      (check-equal? (message-id (list-ref loaded 4)) "m4"))
+
+    (test-case "load returns empty list for unknown session"
+      (define mgr (make-in-memory-session-manager))
+      (check-equal? (in-memory-load mgr "nonexistent") '()))
+
+    (test-case "list-sessions returns all session IDs"
+      (define mgr (make-in-memory-session-manager))
+      (define msg (make-message "m1" #f "user" "text" (list (make-text-part "x")) 1000 (hash)))
+      (in-memory-append! mgr "s1" msg)
+      (in-memory-append! mgr "s2" msg)
+      (in-memory-append! mgr "s3" msg)
+      (define sessions (in-memory-list-sessions mgr))
+      (check-equal? (length sessions) 3)
+      (check-not-false (member "s1" sessions))
+      (check-not-false (member "s2" sessions))
+      (check-not-false (member "s3" sessions)))
+
+    (test-case "fork copies entries to new session"
+      (define mgr (make-in-memory-session-manager))
+      (for ([i (in-range 5)])
+        (define msg
+          (make-message (format "m~a" i)
+                        #f
+                        "user"
+                        "text"
+                        (list (make-text-part (format "msg ~a" i)))
+                        (+ 1000 i)
+                        (hash)))
+        (in-memory-append! mgr "src" msg))
+      (in-memory-fork! mgr "src" "dest" "m2")
+      (define forked (in-memory-load mgr "dest"))
+      (check-equal? (length forked) 3)
+      (check-equal? (message-id (list-ref forked 2)) "m2"))
+
+    (test-case "fork without entry-id copies all"
+      (define mgr (make-in-memory-session-manager))
+      (for ([i (in-range 3)])
+        (define msg
+          (make-message (format "m~a" i)
+                        #f
+                        "user"
+                        "text"
+                        (list (make-text-part (format "msg ~a" i)))
+                        (+ 1000 i)
+                        (hash)))
+        (in-memory-append! mgr "src" msg))
+      (in-memory-fork! mgr "src" "full-copy")
+      (define forked (in-memory-load mgr "full-copy"))
+      (check-equal? (length forked) 3))
+
+    (test-case "append preserves order across multiple calls"
+      (define mgr (make-in-memory-session-manager))
+      (for ([i (in-range 3)])
+        (define msg
+          (make-message (format "m~a" i)
+                        #f
+                        "user"
+                        "text"
+                        (list (make-text-part (format "msg ~a" i)))
+                        (+ 1000 i)
+                        (hash)))
+        (in-memory-append! mgr "s1" msg))
+      (define loaded (in-memory-load mgr "s1"))
+      (check-equal? (map message-id loaded) '("m0" "m1" "m2")))
+
+    (test-case "multiple sessions are independent"
+      (define mgr (make-in-memory-session-manager))
+      (define msg1 (make-message "m1" #f "user" "text" (list (make-text-part "a")) 1000 (hash)))
+      (define msg2 (make-message "m2" #f "user" "text" (list (make-text-part "b")) 2000 (hash)))
+      (in-memory-append! mgr "s1" msg1)
+      (in-memory-append! mgr "s2" msg2)
+      (check-equal? (length (in-memory-load mgr "s1")) 1)
+      (check-equal? (length (in-memory-load mgr "s2")) 1)
+      (check-equal? (message-id (car (in-memory-load mgr "s1"))) "m1")
+      (check-equal? (message-id (car (in-memory-load mgr "s2"))) "m2"))))
+
+(run-tests in-memory-tests)

--- a/tests/test-rpc-methods.rkt
+++ b/tests/test-rpc-methods.rkt
@@ -137,6 +137,118 @@
       (define handlers (make-core-rpc-handlers (hasheq)))
       (define handler (hash-ref handlers 'fork))
       (define result (handler (hasheq 'entryId "entry-1")))
-      (check-equal? (hash-ref result 'status) "error"))))
+      (check-equal? (hash-ref result 'status) "error"))
+
+    ;; ============================================================
+    ;; GC-17: New RPC methods
+    ;; ============================================================
+
+    (test-case "registry includes new GC-17 methods"
+      (define handlers (make-core-rpc-handlers (hasheq)))
+      (for ([method (in-list '(prompt steer follow_up navigate send_message))])
+        (check-not-false (hash-ref handlers method #f) (format "method ~a missing" method))))
+
+    (test-case "prompt with message delegates to prompt-fn"
+      (define received (box #f))
+      (define handlers
+        (make-core-rpc-handlers (hasheq 'prompt-fn
+                                        (lambda (msg)
+                                          (set-box! received msg)
+                                          (hasheq 'status "ok" 'turn-id "t1")))))
+      (define handler (hash-ref handlers 'prompt))
+      (define result (handler (hasheq 'message "Hello")))
+      (check-equal? (hash-ref result 'status) "ok")
+      (check-equal? (unbox received) "Hello"))
+
+    (test-case "prompt without message returns error"
+      (define handlers (make-core-rpc-handlers (hasheq)))
+      (define handler (hash-ref handlers 'prompt))
+      (define result (handler (hasheq)))
+      (check-equal? (hash-ref result 'status) "error"))
+
+    (test-case "steer with message delegates to steer-fn"
+      (define received (box #f))
+      (define handlers
+        (make-core-rpc-handlers (hasheq 'steer-fn
+                                        (lambda (msg)
+                                          (set-box! received msg)
+                                          (hasheq 'status "steered")))))
+      (define handler (hash-ref handlers 'steer))
+      (define result (handler (hasheq 'message "Change approach")))
+      (check-equal? (hash-ref result 'status) "steered")
+      (check-equal? (unbox received) "Change approach"))
+
+    (test-case "steer without message returns error"
+      (define handlers (make-core-rpc-handlers (hasheq)))
+      (define handler (hash-ref handlers 'steer))
+      (define result (handler (hasheq)))
+      (check-equal? (hash-ref result 'status) "error"))
+
+    (test-case "follow_up with message delegates to follow-up-fn"
+      (define received (box #f))
+      (define handlers
+        (make-core-rpc-handlers (hasheq 'follow-up-fn
+                                        (lambda (msg)
+                                          (set-box! received msg)
+                                          (hasheq 'status "queued")))))
+      (define handler (hash-ref handlers 'follow_up))
+      (define result (handler (hasheq 'message "Next question")))
+      (check-equal? (hash-ref result 'status) "queued")
+      (check-equal? (unbox received) "Next question"))
+
+    (test-case "navigate with target delegates to navigate-fn"
+      (define received (box #f))
+      (define handlers
+        (make-core-rpc-handlers (hasheq 'navigate-fn
+                                        (lambda (target)
+                                          (set-box! received target)
+                                          (hasheq 'status "ok" 'target target)))))
+      (define handler (hash-ref handlers 'navigate))
+      (define result (handler (hasheq 'target "entry-5")))
+      (check-equal? (hash-ref result 'status) "ok")
+      (check-equal? (unbox received) "entry-5"))
+
+    (test-case "navigate without target returns error"
+      (define handlers (make-core-rpc-handlers (hasheq)))
+      (define handler (hash-ref handlers 'navigate))
+      (define result (handler (hasheq)))
+      (check-equal? (hash-ref result 'status) "error"))
+
+    (test-case "send_message with role and text delegates"
+      (define received-role (box #f))
+      (define received-text (box #f))
+      (define handlers
+        (make-core-rpc-handlers (hasheq 'send-message-fn
+                                        (lambda (role text)
+                                          (set-box! received-role role)
+                                          (set-box! received-text text)
+                                          (hasheq 'status "ok")))))
+      (define handler (hash-ref handlers 'send_message))
+      (define result (handler (hasheq 'role "user" 'text "Injected")))
+      (check-equal? (hash-ref result 'status) "ok")
+      (check-equal? (unbox received-role) "user")
+      (check-equal? (unbox received-text) "Injected"))
+
+    (test-case "send_message without required params returns error"
+      (define handlers (make-core-rpc-handlers (hasheq)))
+      (define handler (hash-ref handlers 'send_message))
+      (define result1 (handler (hasheq 'role "user")))
+      (check-equal? (hash-ref result1 'status) "error")
+      (define result2 (handler (hasheq 'text "hello")))
+      (check-equal? (hash-ref result2 'status) "error"))
+
+    (test-case "new methods default to error when no deps provided"
+      (define handlers (make-core-rpc-handlers (hasheq)))
+      (for ([method (in-list '(prompt steer follow_up navigate send_message))])
+        (define handler (hash-ref handlers method))
+        (define params
+          (case method
+            [(prompt steer follow_up) (hasheq 'message "test")]
+            [(navigate) (hasheq 'target "t")]
+            [(send_message) (hasheq 'role "user" 'text "test")]))
+        (define result (handler params))
+        (check-equal? (hash-ref result 'status)
+                      "error"
+                      (format "~a should error without handler" method))))))
 
 (run-tests rpc-method-tests)

--- a/wiring/rpc-methods.rkt
+++ b/wiring/rpc-methods.rkt
@@ -3,7 +3,8 @@
 ;; wiring/rpc-methods.rkt — FEAT-75: Core RPC method registry
 ;;
 ;; Registers the standard set of RPC methods:
-;;   abort, subscribe, session_info, compact, fork
+;;   abort, subscribe, session_info, compact, fork,
+;;   prompt, steer, follow_up, navigate, send_message
 ;;
 ;; Each handler receives params (hash) and returns a result (hash).
 ;; Dependencies are injected via a deps hash for testability.
@@ -27,6 +28,16 @@
   (hasheq 'status "error" 'message "fork not available"))
 (define (default-subscribe filter)
   0)
+(define (default-prompt msg)
+  (hasheq 'status "error" 'message "no prompt handler"))
+(define (default-steer msg)
+  (hasheq 'status "error" 'message "no steer handler"))
+(define (default-follow-up msg)
+  (hasheq 'status "error" 'message "no follow-up handler"))
+(define (default-navigate target)
+  (hasheq 'status "error" 'message "no navigate handler"))
+(define (default-send-message role text)
+  (hasheq 'status "error" 'message "no send-message handler"))
 
 ;; ============================================================
 ;; make-core-rpc-handlers : hash? -> (hash/c symbol? procedure?)
@@ -37,21 +48,31 @@
 ;;   'compact-fn        — thunk performing compaction, returns result hash
 ;;   'fork-fn           — (or/c string? #f) -> hash with 'newSessionId
 ;;   'subscribe-fn      — (or/c list? #f) -> subscription-id
+;;   'prompt-fn         — string? -> hash (send prompt / start turn)
+;;   'steer-fn          — string? -> hash (steer during tool exec)
+;;   'follow-up-fn      — string? -> hash (queue follow-up)
+;;   'navigate-fn       — (or/c string? integer?) -> hash (tree nav)
+;;   'send-message-fn   — string? string? -> hash (inject message)
 ;; ============================================================
 
-(define (make-core-rpc-handlers deps)
-  (define cancel-token
-    (let ([v (hash-ref deps 'cancel-token sentinel)]) (if (eq? v sentinel) default-cancel-token v)))
-  (define session-info-fn
-    (let ([v (hash-ref deps 'session-info-fn sentinel)])
-      (if (eq? v sentinel) default-session-info v)))
-  (define compact-fn
-    (let ([v (hash-ref deps 'compact-fn sentinel)]) (if (eq? v sentinel) default-compact v)))
-  (define fork-fn (let ([v (hash-ref deps 'fork-fn sentinel)]) (if (eq? v sentinel) default-fork v)))
-  (define subscribe-fn
-    (let ([v (hash-ref deps 'subscribe-fn sentinel)]) (if (eq? v sentinel) default-subscribe v)))
+(define (resolve-dep deps key default)
+  (define v (hash-ref deps key sentinel))
+  (if (eq? v sentinel) default v))
 
-  (make-hash ;; ---- Abort ----
+(define (make-core-rpc-handlers deps)
+  (define cancel-token (resolve-dep deps 'cancel-token default-cancel-token))
+  (define session-info-fn (resolve-dep deps 'session-info-fn default-session-info))
+  (define compact-fn (resolve-dep deps 'compact-fn default-compact))
+  (define fork-fn (resolve-dep deps 'fork-fn default-fork))
+  (define subscribe-fn (resolve-dep deps 'subscribe-fn default-subscribe))
+  (define prompt-fn (resolve-dep deps 'prompt-fn default-prompt))
+  (define steer-fn (resolve-dep deps 'steer-fn default-steer))
+  (define follow-up-fn (resolve-dep deps 'follow-up-fn default-follow-up))
+  (define navigate-fn (resolve-dep deps 'navigate-fn default-navigate))
+  (define send-message-fn (resolve-dep deps 'send-message-fn default-send-message))
+
+  (make-hash
+   ;; ---- Abort ----
    (list (cons 'abort
                (lambda (params)
                  (cancel-token)
@@ -70,12 +91,46 @@
                      info
                      (hasheq 'status "error" 'message "no active session"))))
          ;; ---- Compact ----
-         (cons 'compact
-               (lambda (params)
-                 (define result (compact-fn))
-                 result))
+         (cons 'compact (lambda (params) (compact-fn)))
          ;; ---- Fork ----
          (cons 'fork
                (lambda (params)
                  (define entry-id (hash-ref params 'entryId #f))
-                 (fork-fn entry-id))))))
+                 (fork-fn entry-id)))
+         ;; ---- Prompt (GC-17) ----
+         (cons 'prompt
+               (lambda (params)
+                 (define msg (hash-ref params 'message #f))
+                 (cond
+                   [(not msg) (hasheq 'status "error" 'message "missing 'message' parameter")]
+                   [else (prompt-fn msg)])))
+         ;; ---- Steer (GC-17) ----
+         (cons 'steer
+               (lambda (params)
+                 (define msg (hash-ref params 'message #f))
+                 (cond
+                   [(not msg) (hasheq 'status "error" 'message "missing 'message' parameter")]
+                   [else (steer-fn msg)])))
+         ;; ---- Follow-up (GC-17) ----
+         (cons 'follow_up
+               (lambda (params)
+                 (define msg (hash-ref params 'message #f))
+                 (cond
+                   [(not msg) (hasheq 'status "error" 'message "missing 'message' parameter")]
+                   [else (follow-up-fn msg)])))
+         ;; ---- Navigate (GC-17) ----
+         (cons 'navigate
+               (lambda (params)
+                 (define target (hash-ref params 'target #f))
+                 (cond
+                   [(not target) (hasheq 'status "error" 'message "missing 'target' parameter")]
+                   [else (navigate-fn target)])))
+         ;; ---- Send Message (GC-17) ----
+         (cons 'send_message
+               (lambda (params)
+                 (define role (hash-ref params 'role #f))
+                 (define text (hash-ref params 'text #f))
+                 (cond
+                   [(not role) (hasheq 'status "error" 'message "missing 'role' parameter")]
+                   [(not text) (hasheq 'status "error" 'message "missing 'text' parameter")]
+                   [else (send-message-fn role text)]))))))


### PR DESCRIPTION
Closes #1051, Closes #1052

- GC-17: Add prompt, steer, follow_up, navigate, send_message RPC methods
- GC-18: Add in-memory session manager for SDK testing
- 20 new tests