### PR TITLE
GC-27: Context overflow recovery tests + bugfix (#1065)

### DIFF
--- a/runtime/iteration.rkt
+++ b/runtime/iteration.rkt
@@ -102,7 +102,9 @@
          ensure-hash-args ;; for testing
          ;; FEAT-61: message injection support
          make-injected-collector!
-         drain-injected-messages!)
+         drain-injected-messages!
+         ;; FEAT-66: overflow recovery (for testing)
+         call-with-overflow-recovery)
 
 ;; ============================================================
 ;; Shared helpers
@@ -362,10 +364,9 @@
                                           "context.overflow.detected"
                                           (hasheq 'error (exn-message e)))
                      ;; Compact and retry
-                     (define compacted
+                     (define-values (compacted _extra)
                        (build-tiered-context-with-hooks
-                        (takef ctx (lambda (m) (not (eq? (message-role m) 'system))))
-                        (hasheq 'max-messages 10)))
+                        (takef ctx (lambda (m) (not (eq? (message-role m) 'system))))))
                      (emit-session-event! bus
                                           session-id
                                           "context.overflow.compacted"

--- a/tests/test-context-overflow.rkt
+++ b/tests/test-context-overflow.rkt
@@ -1,50 +1,164 @@
 #lang racket
 
-;; tests/test-context-overflow.rkt — FEAT-66: context overflow recovery
+;; tests/test-context-overflow.rkt — tests for context overflow recovery (GC-27)
+;;
+;; Tests:
+;; 1. context-overflow-error? — pattern detection
+;; 2. call-with-overflow-recovery — compact and retry on overflow
+;; 3. Event emission during overflow recovery
 
 (require rackunit
-         "../runtime/auto-retry.rkt")
+         rackunit/text-ui
+         racket/exn
+         "../runtime/auto-retry.rkt"
+         "../runtime/iteration.rkt"
+         "../runtime/compactor.rkt"
+         "../agent/event-bus.rkt"
+         "../agent/types.rkt")
 
-;; ============================================================
-;; context-overflow-error? predicate
-;; ============================================================
+;; Helper: create a simple message for testing
+(define (make-test-msg [role 'user] [content "test"])
+  (define id (symbol->string (gensym 'msg)))
+  (message id #f role 'text (list (hasheq 'type 'text 'text content)) (current-seconds) (hasheq)))
 
-(test-case "context-overflow-error? detects context_length_exceeded"
-  (check-true (context-overflow-error? (exn:fail "context_length_exceeded: too many tokens"
-                                                 (current-continuation-marks)))))
+(define context-overflow-tests
+  (test-suite "Context Overflow Recovery (GC-27)"
 
-(test-case "context-overflow-error? detects maximum context"
-  (check-true (context-overflow-error? (exn:fail "Maximum context length exceeded"
-                                                 (current-continuation-marks)))))
+    ;; -------------------------------------------------------
+    ;; context-overflow-error? — pattern matching
+    ;; -------------------------------------------------------
+    (test-case "context-overflow-error?: detects context_length"
+      (check-true (context-overflow-error? (exn:fail "context_length exceeded"
+                                                     (current-continuation-marks)))))
 
-(test-case "context-overflow-error? detects input too long"
-  (check-true (context-overflow-error? (exn:fail "Input is too long for this model"
-                                                 (current-continuation-marks)))))
+    (test-case "context-overflow-error?: detects context length (with space)"
+      (check-true (context-overflow-error? (exn:fail "This model has a maximum context length of 4096"
+                                                     (current-continuation-marks)))))
 
-(test-case "context-overflow-error? detects request too large"
-  (check-true (context-overflow-error? (exn:fail "Request too large, reduce the length of messages"
-                                                 (current-continuation-marks)))))
+    (test-case "context-overflow-error?: detects maximum context"
+      (check-true (context-overflow-error? (exn:fail "Request exceeds maximum context size"
+                                                     (current-continuation-marks)))))
 
-(test-case "context-overflow-error? detects token limit"
-  (check-true (context-overflow-error? (exn:fail "Token limit exceeded"
-                                                 (current-continuation-marks)))))
+    (test-case "context-overflow-error?: detects too many tokens"
+      (check-true (context-overflow-error? (exn:fail "too many tokens in request"
+                                                     (current-continuation-marks)))))
 
-(test-case "context-overflow-error? returns #f for rate limit error"
-  (check-false (context-overflow-error? (exn:fail "429 Rate limit exceeded"
-                                                  (current-continuation-marks)))))
+    (test-case "context-overflow-error?: detects token limit"
+      (check-true (context-overflow-error? (exn:fail "token limit reached"
+                                                     (current-continuation-marks)))))
 
-(test-case "context-overflow-error? returns #f for server error"
-  (check-false (context-overflow-error? (exn:fail "500 Internal server error"
-                                                  (current-continuation-marks)))))
+    (test-case "context-overflow-error?: detects max_tokens"
+      (check-true (context-overflow-error? (exn:fail "input exceeds max_tokens"
+                                                     (current-continuation-marks)))))
 
-(test-case "context-overflow-error? returns #f for timeout"
-  (check-false (context-overflow-error? (exn:fail "Connection timed out"
-                                                  (current-continuation-marks)))))
+    (test-case "context-overflow-error?: detects input is too long"
+      (check-true (context-overflow-error? (exn:fail "input is too long for this model"
+                                                     (current-continuation-marks)))))
 
-(test-case "context-overflow-error? returns #f for generic error"
-  (check-false (context-overflow-error? (exn:fail "Something else went wrong"
-                                                  (current-continuation-marks)))))
+    (test-case "context-overflow-error?: detects request too large"
+      (check-true (context-overflow-error? (exn:fail "request too large"
+                                                     (current-continuation-marks)))))
 
-(test-case "context-overflow-error? is case-insensitive"
-  (check-true (context-overflow-error? (exn:fail "CONTEXT_LENGTH EXCEEDED"
-                                                 (current-continuation-marks)))))
+    (test-case "context-overflow-error?: detects reduce the length"
+      (check-true (context-overflow-error? (exn:fail "Please reduce the length of your input"
+                                                     (current-continuation-marks)))))
+
+    (test-case "context-overflow-error?: detects exceeds the maximum"
+      (check-true (context-overflow-error? (exn:fail "content exceeds the maximum allowed"
+                                                     (current-continuation-marks)))))
+
+    (test-case "context-overflow-error?: case insensitive"
+      (check-true (context-overflow-error? (exn:fail "CONTEXT_LENGTH EXCEEDED"
+                                                     (current-continuation-marks)))))
+
+    (test-case "context-overflow-error?: returns #f for non-overflow errors"
+      (check-false (context-overflow-error? (exn:fail "connection refused"
+                                                      (current-continuation-marks)))))
+
+    (test-case "context-overflow-error?: returns #f for unrelated errors"
+      (check-false (context-overflow-error? (exn:fail "file not found"
+                                                      (current-continuation-marks)))))
+
+    ;; -------------------------------------------------------
+    ;; call-with-overflow-recovery — compact and retry
+    ;; -------------------------------------------------------
+    (test-case "call-with-overflow-recovery: succeeds when no overflow"
+      (define bus (make-event-bus))
+      (define ctx (list (make-test-msg)))
+      (define result (call-with-overflow-recovery (lambda () 'success) ctx bus "test-session"))
+      (check-equal? result 'success))
+
+    (test-case "call-with-overflow-recovery: recovers from overflow error"
+      (define bus (make-event-bus))
+      (define ctx
+        (for/list ([i (in-range 20)])
+          (make-test-msg 'user (format "msg ~a" i))))
+      (define attempt-box (box 0))
+      (define result
+        (call-with-overflow-recovery (lambda ()
+                                       (set-box! attempt-box (add1 (unbox attempt-box)))
+                                       (if (= (unbox attempt-box) 1)
+                                           (raise (exn:fail "context_length exceeded"
+                                                            (current-continuation-marks)))
+                                           'recovered))
+                                     ctx
+                                     bus
+                                     "test-session"))
+      (check-equal? result 'recovered)
+      (check-equal? (unbox attempt-box) 2))
+
+    (test-case "call-with-overflow-recovery: re-raises non-overflow errors"
+      (define bus (make-event-bus))
+      (define ctx (list (make-test-msg)))
+      (check-exn (lambda (e) (and (exn:fail? e) (string-contains? (exn-message e) "unrelated error")))
+                 (lambda ()
+                   (call-with-overflow-recovery
+                    (lambda () (raise (exn:fail "unrelated error" (current-continuation-marks))))
+                    ctx
+                    bus
+                    "test-session"))))
+
+    ;; -------------------------------------------------------
+    ;; Event emission during overflow recovery
+    ;; -------------------------------------------------------
+    (test-case "call-with-overflow-recovery: emits overflow detected event"
+      (define bus (make-event-bus))
+      (define recorded-events '())
+      (define sub-id
+        (subscribe! bus
+                    (lambda (evt) (set! recorded-events (append recorded-events (list evt))))
+))
+      (define ctx
+        (for/list ([i (in-range 20)])
+          (make-test-msg 'user (format "msg ~a" i))))
+      (define attempt-box (box 0))
+      (call-with-overflow-recovery (lambda ()
+                                     (set-box! attempt-box (add1 (unbox attempt-box)))
+                                     (when (= (unbox attempt-box) 1)
+                                       (raise (exn:fail "too many tokens"
+                                                        (current-continuation-marks)))))
+                                   ctx
+                                   bus
+                                   "test-session")
+      (unsubscribe! bus sub-id)
+      ;; Should have emitted detected + compacted events
+      (define event-names (map event-ev recorded-events))
+      (check-not-false (member "context.overflow.detected" event-names))
+      (check-not-false (member "context.overflow.compacted" event-names)))
+
+    (test-case "call-with-overflow-recovery: no events when no overflow"
+      (define bus (make-event-bus))
+      (define recorded-events '())
+      (define sub-id
+        (subscribe! bus
+                    (lambda (evt) (set! recorded-events (append recorded-events (list evt))))
+))
+      (define ctx (list (make-test-msg)))
+      (call-with-overflow-recovery (lambda () 'ok) ctx bus "test-session")
+      (unsubscribe! bus sub-id)
+      ;; No overflow events
+      (define overflow-events
+        (filter (lambda (e) (string-contains? (event-ev e) "overflow")) recorded-events))
+      (check-equal? overflow-events '()))))
+
+(run-tests context-overflow-tests)


### PR DESCRIPTION
Addresses #1065

**Tests** (18/18 pass):
- `context-overflow-error?`: all 9 patterns, case insensitive, negatives
- `call-with-overflow-recovery`: no-overflow success, overflow recovery, non-overflow re-raise
- Event emission: detected/compacted events, no spurious events

**Bugfix** in `runtime/iteration.rkt`:
- `build-tiered-context-with-hooks` returns 2 values (context + hook-result)
- Changed `define` to `define-values` to properly capture both values
- Old code also passed a positional hash arg that was rejected by the keyword-only signature
- Exported `call-with-overflow-recovery` for testability