### PR TITLE
TEST-05 + QUAL-08: Wrap scheduler assertions + rename is-error param

### DIFF
--- a/tests/test-scheduler.rkt
+++ b/tests/test-scheduler.rkt
@@ -16,18 +16,33 @@
 
 (require rackunit
          (only-in "../tools/tool.rkt"
-                  tool? tool-name tool-schema tool-execute
-                  make-tool make-tool-registry make-exec-context
-                  register-tool! lookup-tool validate-tool-args
-                  tool-result? tool-result-content
-                  tool-result-details tool-result-is-error?
-                  make-error-result make-success-result)
+                  tool?
+                  tool-name
+                  tool-schema
+                  tool-execute
+                  make-tool
+                  make-tool-registry
+                  make-exec-context
+                  register-tool!
+                  lookup-tool
+                  validate-tool-args
+                  tool-result?
+                  tool-result-content
+                  tool-result-details
+                  tool-result-is-error?
+                  make-error-result
+                  make-success-result)
          (only-in "../tools/scheduler.rkt"
-                  run-tool-batch scheduler-result
-                  scheduler-result-results scheduler-result-metadata)
+                  run-tool-batch
+                  scheduler-result
+                  scheduler-result-results
+                  scheduler-result-metadata)
          (only-in "../util/protocol-types.rkt"
-                  tool-call tool-call?
-                  tool-call-id tool-call-name tool-call-arguments))
+                  tool-call
+                  tool-call?
+                  tool-call-id
+                  tool-call-name
+                  tool-call-arguments))
 
 ;; ============================================================
 ;; Helper: build a simple registry with fake tools
@@ -39,53 +54,43 @@
   ;; echo tool — returns the 'msg argument as text content
   (register-tool!
    reg
-   (make-tool "echo"
-              "Echo tool"
-              (hasheq 'type "object"
-                      'properties (hasheq 'msg (hasheq 'type "string"))
-                      'required '("msg"))
-              (lambda (args ctx)
-                (make-success-result
-                 (list (hasheq 'type "text"
-                               'text (hash-ref args 'msg)))))))
+   (make-tool
+    "echo"
+    "Echo tool"
+    (hasheq 'type "object" 'properties (hasheq 'msg (hasheq 'type "string")) 'required '("msg"))
+    (lambda (args ctx)
+      (make-success-result (list (hasheq 'type "text" 'text (hash-ref args 'msg)))))))
 
   ;; add tool — returns sum of 'a and 'b as text
-  (register-tool!
-   reg
-   (make-tool "add"
-              "Add two numbers"
-              (hasheq 'type "object"
-                      'properties (hasheq 'a (hasheq 'type "integer")
-                                          'b (hasheq 'type "integer"))
-                      'required '("a" "b"))
-              (lambda (args ctx)
-                (define sum (+ (hash-ref args 'a) (hash-ref args 'b)))
-                (make-success-result
-                 (list (hasheq 'type "text"
-                               'text (number->string sum)))))))
+  (register-tool! reg
+                  (make-tool "add"
+                             "Add two numbers"
+                             (hasheq 'type
+                                     "object"
+                                     'properties
+                                     (hasheq 'a (hasheq 'type "integer") 'b (hasheq 'type "integer"))
+                                     'required
+                                     '("a" "b"))
+                             (lambda (args ctx)
+                               (define sum (+ (hash-ref args 'a) (hash-ref args 'b)))
+                               (make-success-result
+                                (list (hasheq 'type "text" 'text (number->string sum)))))))
 
   ;; fail tool — always throws an exception
   (register-tool!
    reg
-   (make-tool "fail"
-              "Always fails"
-              (hasheq)
-              (lambda (args ctx)
-                (error 'fail "deliberate failure"))))
+   (make-tool "fail" "Always fails" (hasheq) (lambda (args ctx) (error 'fail "deliberate failure"))))
 
   ;; slow-echo tool — sleeps then echoes (for parallel order testing)
   (register-tool!
    reg
-   (make-tool "slow-echo"
-              "Slow echo"
-              (hasheq 'type "object"
-                      'properties (hasheq 'msg (hasheq 'type "string"))
-                      'required '("msg"))
-              (lambda (args ctx)
-                (sleep 0.05) ; 50ms delay
-                (make-success-result
-                 (list (hasheq 'type "text"
-                               'text (hash-ref args 'msg)))))))
+   (make-tool
+    "slow-echo"
+    "Slow echo"
+    (hasheq 'type "object" 'properties (hasheq 'msg (hasheq 'type "string")) 'required '("msg"))
+    (lambda (args ctx)
+      (sleep 0.05) ; 50ms delay
+      (make-success-result (list (hasheq 'type "text" 'text (hash-ref args 'msg)))))))
   reg)
 
 ;; Helper: extract text from a tool-result's content
@@ -99,10 +104,11 @@
 ;; 1. Single tool call executes correctly
 ;; ============================================================
 
-(let* ([reg (make-test-registry)]
-       [tc (tool-call "tc-1" "echo" (hasheq 'msg "hello"))]
-       [sr (run-tool-batch (list tc) reg)]
-       [results (scheduler-result-results sr)])
+(test-case "Single tool call executes correctly"
+  (define reg (make-test-registry))
+  (define tc (tool-call "tc-1" "echo" (hasheq 'msg "hello")))
+  (define sr (run-tool-batch (list tc) reg))
+  (define results (scheduler-result-results sr))
   (check-equal? (length results) 1)
   (check-equal? (result-text (car results)) "hello")
   (check-false (tool-result-is-error? (car results))))
@@ -111,55 +117,59 @@
 ;; 2. Multiple tool calls execute in order (serial)
 ;; ============================================================
 
-(let* ([reg (make-test-registry)]
-       [tcs (list (tool-call "tc-1" "echo" (hasheq 'msg "first"))
-                  (tool-call "tc-2" "echo" (hasheq 'msg "second"))
-                  (tool-call "tc-3" "echo" (hasheq 'msg "third")))]
-       [sr (run-tool-batch tcs reg #:parallel? #f)])
-  (check-equal? (map result-text (scheduler-result-results sr))
-                '("first" "second" "third")))
+(test-case "Multiple tool calls execute in order (serial)"
+  (define reg (make-test-registry))
+  (define tcs
+    (list (tool-call "tc-1" "echo" (hasheq 'msg "first"))
+          (tool-call "tc-2" "echo" (hasheq 'msg "second"))
+          (tool-call "tc-3" "echo" (hasheq 'msg "third"))))
+  (define sr (run-tool-batch tcs reg #:parallel? #f))
+  (check-equal? (map result-text (scheduler-result-results sr)) '("first" "second" "third")))
 
 ;; ============================================================
 ;; 3. Scheduler preserves commit order under parallel execution
 ;; ============================================================
 
-(let* ([reg (make-test-registry)]
-       ;; slow-echo first, fast echo second — if parallel,
-       ;; slow finishes last, but results should still be in input order
-       [tcs (list (tool-call "tc-1" "slow-echo" (hasheq 'msg "slow"))
-                  (tool-call "tc-2" "echo" (hasheq 'msg "fast")))]
-       [sr (run-tool-batch tcs reg #:parallel? #t)])
-  (check-equal? (map result-text (scheduler-result-results sr))
-                '("slow" "fast")))
+(test-case "Parallel execution preserves commit order"
+  (define reg (make-test-registry))
+  ;; slow-echo first, fast echo second — if parallel,
+  ;; slow finishes last, but results should still be in input order
+  (define tcs
+    (list (tool-call "tc-1" "slow-echo" (hasheq 'msg "slow"))
+          (tool-call "tc-2" "echo" (hasheq 'msg "fast"))))
+  (define sr (run-tool-batch tcs reg #:parallel? #t))
+  (check-equal? (map result-text (scheduler-result-results sr)) '("slow" "fast")))
 
 ;; ============================================================
 ;; 3a. Larger parallel batch also preserves order
 ;; ============================================================
 
-(let* ([reg (make-test-registry)]
-       [tcs (list (tool-call "tc-1" "slow-echo" (hasheq 'msg "A"))
-                  (tool-call "tc-2" "echo" (hasheq 'msg "B"))
-                  (tool-call "tc-3" "slow-echo" (hasheq 'msg "C"))
-                  (tool-call "tc-4" "echo" (hasheq 'msg "D")))]
-       [sr (run-tool-batch tcs reg #:parallel? #t)])
-  (check-equal? (map result-text (scheduler-result-results sr))
-                '("A" "B" "C" "D")))
+(test-case "Larger parallel batch preserves order"
+  (define reg (make-test-registry))
+  (define tcs
+    (list (tool-call "tc-1" "slow-echo" (hasheq 'msg "A"))
+          (tool-call "tc-2" "echo" (hasheq 'msg "B"))
+          (tool-call "tc-3" "slow-echo" (hasheq 'msg "C"))
+          (tool-call "tc-4" "echo" (hasheq 'msg "D"))))
+  (define sr (run-tool-batch tcs reg #:parallel? #t))
+  (check-equal? (map result-text (scheduler-result-results sr)) '("A" "B" "C" "D")))
 
 ;; ============================================================
 ;; 4. Hook that blocks a tool call produces blocked error result
 ;; ============================================================
 
-(let* ([reg (make-test-registry)]
-       [hook (lambda (hook-point data)
-               (if (and (eq? hook-point 'tool-call)
-                        (tool-call? data)
-                        (equal? (tool-call-name data) "echo"))
-                   'blocked
-                   data))]
-       [tcs (list (tool-call "tc-1" "echo" (hasheq 'msg "blocked"))
-                  (tool-call "tc-2" "add" (hasheq 'a 1 'b 2)))]
-       [sr (run-tool-batch tcs reg #:hook-dispatcher hook)]
-       [results (scheduler-result-results sr)])
+(test-case "Hook blocks tool call → error result"
+  (define reg (make-test-registry))
+  (define hook
+    (lambda (hook-point data)
+      (if (and (eq? hook-point 'tool-call) (tool-call? data) (equal? (tool-call-name data) "echo"))
+          'blocked
+          data)))
+  (define tcs
+    (list (tool-call "tc-1" "echo" (hasheq 'msg "blocked"))
+          (tool-call "tc-2" "add" (hasheq 'a 1 'b 2))))
+  (define sr (run-tool-batch tcs reg #:hook-dispatcher hook))
+  (define results (scheduler-result-results sr))
   ;; First is blocked → error
   (check-true (tool-result-is-error? (first results)))
   (check-true (string-contains? (result-text (first results)) "blocked"))
@@ -171,17 +181,16 @@
 ;; 5. Hook that mutates args + revalidation passes → executes with new args
 ;; ============================================================
 
-(let* ([reg (make-test-registry)]
-       ;; Hook changes 'msg from "original" to "mutated"
-       [hook (lambda (hook-point data)
-               (if (and (eq? hook-point 'tool-call)
-                        (tool-call? data)
-                        (equal? (tool-call-name data) "echo"))
-                   (struct-copy tool-call data
-                                [arguments (hasheq 'msg "mutated")])
-                   data))]
-       [tcs (list (tool-call "tc-1" "echo" (hasheq 'msg "original")))]
-       [sr (run-tool-batch tcs reg #:hook-dispatcher hook)])
+(test-case "Hook mutates args → revalidation passes → executes with new args"
+  (define reg (make-test-registry))
+  ;; Hook changes 'msg from "original" to "mutated"
+  (define hook
+    (lambda (hook-point data)
+      (if (and (eq? hook-point 'tool-call) (tool-call? data) (equal? (tool-call-name data) "echo"))
+          (struct-copy tool-call data [arguments (hasheq 'msg "mutated")])
+          data)))
+  (define tcs (list (tool-call "tc-1" "echo" (hasheq 'msg "original"))))
+  (define sr (run-tool-batch tcs reg #:hook-dispatcher hook))
   (check-equal? (result-text (car (scheduler-result-results sr))) "mutated")
   (check-false (tool-result-is-error? (car (scheduler-result-results sr)))))
 
@@ -189,29 +198,27 @@
 ;; 6. Hook that mutates args + revalidation fails → error result
 ;; ============================================================
 
-(let* ([reg (make-test-registry)]
-       ;; Hook changes 'a to a string, but schema requires integer
-       [hook (lambda (hook-point data)
-               (if (and (eq? hook-point 'tool-call)
-                        (tool-call? data)
-                        (equal? (tool-call-name data) "add"))
-                   (struct-copy tool-call data
-                                [arguments (hasheq 'a "not-a-number" 'b 2)])
-                   data))]
-       [tcs (list (tool-call "tc-1" "add" (hasheq 'a 1 'b 2)))]
-       [sr (run-tool-batch tcs reg #:hook-dispatcher hook)])
+(test-case "Hook mutates args → revalidation fails → error result"
+  (define reg (make-test-registry))
+  ;; Hook changes 'a to a string, but schema requires integer
+  (define hook
+    (lambda (hook-point data)
+      (if (and (eq? hook-point 'tool-call) (tool-call? data) (equal? (tool-call-name data) "add"))
+          (struct-copy tool-call data [arguments (hasheq 'a "not-a-number" 'b 2)])
+          data)))
+  (define tcs (list (tool-call "tc-1" "add" (hasheq 'a 1 'b 2))))
+  (define sr (run-tool-batch tcs reg #:hook-dispatcher hook))
   (check-true (tool-result-is-error? (car (scheduler-result-results sr))))
-  (check-true (string-contains?
-               (result-text (car (scheduler-result-results sr)))
-               "validation")))
+  (check-true (string-contains? (result-text (car (scheduler-result-results sr))) "validation")))
 
 ;; ============================================================
 ;; 7. Tool exception caught → error result (not crash)
 ;; ============================================================
 
-(let* ([reg (make-test-registry)]
-       [tcs (list (tool-call "tc-1" "fail" (hasheq)))]
-       [sr (run-tool-batch tcs reg)])
+(test-case "Tool exception caught → error result"
+  (define reg (make-test-registry))
+  (define tcs (list (tool-call "tc-1" "fail" (hasheq))))
+  (define sr (run-tool-batch tcs reg))
   (check-equal? (length (scheduler-result-results sr)) 1)
   (check-true (tool-result-is-error? (car (scheduler-result-results sr)))))
 
@@ -219,17 +226,19 @@
 ;; 8. Unknown tool name → error result
 ;; ============================================================
 
-(let* ([reg (make-test-registry)]
-       [tcs (list (tool-call "tc-1" "nonexistent_tool" (hasheq)))]
-       [sr (run-tool-batch tcs reg)])
+(test-case "Unknown tool name → error result"
+  (define reg (make-test-registry))
+  (define tcs (list (tool-call "tc-1" "nonexistent_tool" (hasheq))))
+  (define sr (run-tool-batch tcs reg))
   (check-true (tool-result-is-error? (car (scheduler-result-results sr)))))
 
 ;; ============================================================
 ;; 9. Empty tool-calls list → empty results
 ;; ============================================================
 
-(let* ([reg (make-test-registry)]
-       [sr (run-tool-batch '() reg)])
+(test-case "Empty tool-calls list → empty results with zero metadata"
+  (define reg (make-test-registry))
+  (define sr (run-tool-batch '() reg))
   (check-equal? (length (scheduler-result-results sr)) 0)
   (check-equal? (hash-ref (scheduler-result-metadata sr) 'total) 0)
   (check-equal? (hash-ref (scheduler-result-metadata sr) 'executed) 0)
@@ -240,64 +249,66 @@
 ;; 10. Metadata counters are correct
 ;; ============================================================
 
-(let* ([reg (make-test-registry)]
-       [hook (lambda (hook-point data)
-               (if (and (eq? hook-point 'tool-call)
-                        (equal? (tool-call-name data) "echo"))
-                   'blocked
-                   data))]
-       [tcs (list (tool-call "tc-1" "echo" (hasheq 'msg "blocked"))  ; blocked
-                  (tool-call "tc-2" "add" (hasheq 'a 3 'b 4))        ; success
-                  (tool-call "tc-3" "fail" (hasheq))                  ; exception
-                  (tool-call "tc-4" "nonexistent" (hasheq)))]         ; unknown
-       [sr (run-tool-batch tcs reg #:hook-dispatcher hook)]
-       [meta (scheduler-result-metadata sr)])
+(test-case "Metadata counters track total/executed/blocked/errors"
+  (define reg (make-test-registry))
+  (define hook
+    (lambda (hook-point data)
+      (if (and (eq? hook-point 'tool-call) (equal? (tool-call-name data) "echo")) 'blocked data)))
+  (define tcs
+    (list (tool-call "tc-1" "echo" (hasheq 'msg "blocked")) ; blocked
+          (tool-call "tc-2" "add" (hasheq 'a 3 'b 4)) ; success
+          (tool-call "tc-3" "fail" (hasheq)) ; exception
+          (tool-call "tc-4" "nonexistent" (hasheq)))) ; unknown
+  (define sr (run-tool-batch tcs reg #:hook-dispatcher hook))
+  (define meta (scheduler-result-metadata sr))
   (check-equal? (hash-ref meta 'total) 4)
-  (check-equal? (hash-ref meta 'executed) 1)    ; add succeeded
-  (check-equal? (hash-ref meta 'blocked) 1)     ; echo blocked
-  (check-equal? (hash-ref meta 'errors) 2))     ; fail exception + nonexistent unknown
+  (check-equal? (hash-ref meta 'executed) 1) ; add succeeded
+  (check-equal? (hash-ref meta 'blocked) 1) ; echo blocked
+  (check-equal? (hash-ref meta 'errors) 2)) ; fail exception + nonexistent unknown
 
 ;; ============================================================
 ;; 11. Mixed batch: block, mutate-pass, mutate-fail, execute, exception
 ;; ============================================================
 
-(let* ([reg (make-test-registry)]
-       [hook (lambda (hook-point data)
-               (cond
-                 ;; Only handle 'tool-call (preflight), not tool-call-pre/post
-                 [(not (eq? hook-point 'tool-call)) data]
-                 [(equal? (tool-call-name data) "echo")
-                  'blocked]
-                 [(equal? (tool-call-name data) "add")
-                  ;; mutate: change a to string → validation will fail
-                  (struct-copy tool-call data
-                               [arguments (hasheq 'a "bad" 'b 2)])]
-                 [(equal? (tool-call-name data) "slow-echo")
-                  ;; mutate: valid change
-                  (struct-copy tool-call data
-                               [arguments (hasheq 'msg "hooked")])]
-                 [else data]))]
-       [tcs (list (tool-call "tc-1" "echo" (hasheq 'msg "x"))      ; blocked
-                  (tool-call "tc-2" "add" (hasheq 'a 1 'b 2))      ; mutated-invalid
-                  (tool-call "tc-3" "slow-echo" (hasheq 'msg "x")) ; mutated-valid
-                  (tool-call "tc-4" "fail" (hasheq)))]             ; exception
-       [sr (run-tool-batch tcs reg #:hook-dispatcher hook)]
-       [results (scheduler-result-results sr)])
+(test-case "Mixed batch: block, mutate-pass, mutate-fail, exception"
+  (define reg (make-test-registry))
+  (define hook
+    (lambda (hook-point data)
+      (cond
+        ;; Only handle 'tool-call (preflight), not tool-call-pre/post
+        [(not (eq? hook-point 'tool-call)) data]
+        [(equal? (tool-call-name data) "echo") 'blocked]
+        [(equal? (tool-call-name data) "add")
+         ;; mutate: change a to string → validation will fail
+         (struct-copy tool-call data [arguments (hasheq 'a "bad" 'b 2)])]
+        [(equal? (tool-call-name data) "slow-echo")
+         ;; mutate: valid change
+         (struct-copy tool-call data [arguments (hasheq 'msg "hooked")])]
+        [else data])))
+  (define tcs
+    (list (tool-call "tc-1" "echo" (hasheq 'msg "x")) ; blocked
+          (tool-call "tc-2" "add" (hasheq 'a 1 'b 2)) ; mutated-invalid
+          (tool-call "tc-3" "slow-echo" (hasheq 'msg "x")) ; mutated-valid
+          (tool-call "tc-4" "fail" (hasheq)))) ; exception
+  (define sr (run-tool-batch tcs reg #:hook-dispatcher hook))
+  (define results (scheduler-result-results sr))
   ;; All but slow-echo are errors
-  (check-true (tool-result-is-error? (first results)))   ; blocked
-  (check-true (tool-result-is-error? (second results)))  ; validation fail
-  (check-false (tool-result-is-error? (third results)))  ; mutated-valid success
-  (check-equal? (result-text (third results)) "hooked")  ; got mutated text
+  (check-true (tool-result-is-error? (first results))) ; blocked
+  (check-true (tool-result-is-error? (second results))) ; validation fail
+  (check-false (tool-result-is-error? (third results))) ; mutated-valid success
+  (check-equal? (result-text (third results)) "hooked") ; got mutated text
   (check-true (tool-result-is-error? (fourth results)))) ; exception
 
 ;; ============================================================
 ;; 12. No hook dispatcher — tools execute normally
 ;; ============================================================
 
-(let* ([reg (make-test-registry)]
-       [tcs (list (tool-call "tc-1" "echo" (hasheq 'msg "no-hook"))
-                  (tool-call "tc-2" "add" (hasheq 'a 10 'b 20)))]
-       [sr (run-tool-batch tcs reg)])
+(test-case "No hook dispatcher → tools execute normally"
+  (define reg (make-test-registry))
+  (define tcs
+    (list (tool-call "tc-1" "echo" (hasheq 'msg "no-hook"))
+          (tool-call "tc-2" "add" (hasheq 'a 10 'b 20))))
+  (define sr (run-tool-batch tcs reg))
   (check-equal? (result-text (first (scheduler-result-results sr))) "no-hook")
   (check-equal? (result-text (second (scheduler-result-results sr))) "30"))
 
@@ -305,63 +316,63 @@
 ;; 13. FUNC-07 (#105): Parallel tool execution doesn't deadlock on hook exception
 ;; ============================================================
 
-(let* ([reg (make-test-registry)]
-       ;; Hook that throws for 'tool-call-pre, passes for everything else
-       [hook (lambda (hook-point data)
-               (cond
-                 [(eq? hook-point 'tool-call-pre)
-                  (error 'test-hook "deliberate pre-hook crash")]
-                 [else data]))]
-       [tcs (list (tool-call "tc-1" "echo" (hasheq 'msg "parallel-resilient")))]
-       [sr (run-tool-batch tcs reg #:hook-dispatcher hook #:parallel? #t)])
+(test-case "Parallel execution survives pre-hook exception"
+  (define reg (make-test-registry))
+  ;; Hook that throws for 'tool-call-pre, passes for everything else
+  (define hook
+    (lambda (hook-point data)
+      (cond
+        [(eq? hook-point 'tool-call-pre) (error 'test-hook "deliberate pre-hook crash")]
+        [else data])))
+  (define tcs (list (tool-call "tc-1" "echo" (hasheq 'msg "parallel-resilient"))))
+  (define sr (run-tool-batch tcs reg #:hook-dispatcher hook #:parallel? #t))
   (define results (scheduler-result-results sr))
   (check-equal? (length results) 1 "parallel with throwing pre-hook should return results")
   ;; Tool should still execute (hook error is caught, treated as #f)
   (check-false (tool-result-is-error? (car results))
                "parallel execution should succeed despite pre-hook exception")
-  (check-equal? (result-text (car results)) "parallel-resilient"
+  (check-equal? (result-text (car results))
+                "parallel-resilient"
                 "result content should be from tool execution"))
 
 ;; ============================================================
 ;; 13a. FUNC-07 (#105): Serial mode also survives hook exception
 ;; ============================================================
 
-(let* ([reg (make-test-registry)]
-       [hook (lambda (hook-point data)
-               (cond
-                 [(eq? hook-point 'tool-call-pre)
-                  (error 'test-hook "deliberate pre-hook crash")]
-                 [else data]))]
-       [tcs (list (tool-call "tc-1" "echo" (hasheq 'msg "serial-resilient")))]
-       [sr (run-tool-batch tcs reg #:hook-dispatcher hook #:parallel? #f)])
+(test-case "Serial execution survives pre-hook exception"
+  (define reg (make-test-registry))
+  (define hook
+    (lambda (hook-point data)
+      (cond
+        [(eq? hook-point 'tool-call-pre) (error 'test-hook "deliberate pre-hook crash")]
+        [else data])))
+  (define tcs (list (tool-call "tc-1" "echo" (hasheq 'msg "serial-resilient"))))
+  (define sr (run-tool-batch tcs reg #:hook-dispatcher hook #:parallel? #f))
   (define results (scheduler-result-results sr))
   (check-equal? (length results) 1 "serial with throwing pre-hook should return results")
   (check-false (tool-result-is-error? (car results))
                "serial execution should succeed despite pre-hook exception")
-  (check-equal? (result-text (car results)) "serial-resilient"
+  (check-equal? (result-text (car results))
+                "serial-resilient"
                 "result content should be from tool execution"))
 
 ;; ============================================================
 ;; 13b. FUNC-07 (#105): Parallel with throwing post-hook also survives
 ;; ============================================================
 
-(let* ([reg (make-test-registry)]
-       [hook (lambda (hook-point data)
-               (cond
-                 [(eq? hook-point 'tool-result-post)
-                  (error 'test-hook "deliberate post-hook crash")]
-                 [else data]))]
-       [tcs (list (tool-call "tc-1" "echo" (hasheq 'msg "post-resilient")))]
-       [sr (run-tool-batch tcs reg #:hook-dispatcher hook #:parallel? #t)])
+(test-case "Parallel execution survives post-hook exception"
+  (define reg (make-test-registry))
+  (define hook
+    (lambda (hook-point data)
+      (cond
+        [(eq? hook-point 'tool-result-post) (error 'test-hook "deliberate post-hook crash")]
+        [else data])))
+  (define tcs (list (tool-call "tc-1" "echo" (hasheq 'msg "post-resilient"))))
+  (define sr (run-tool-batch tcs reg #:hook-dispatcher hook #:parallel? #t))
   (define results (scheduler-result-results sr))
   (check-equal? (length results) 1 "parallel with throwing post-hook should return results")
   (check-false (tool-result-is-error? (car results))
                "parallel execution should succeed despite post-hook exception")
-  (check-equal? (result-text (car results)) "post-resilient"
+  (check-equal? (result-text (car results))
+                "post-resilient"
                 "result content should be from tool execution"))
-
-;; ============================================================
-;; Summary
-;; ============================================================
-
-(displayln "All scheduler tests passed.")

--- a/util/protocol-types.rkt
+++ b/util/protocol-types.rkt
@@ -17,53 +17,52 @@
 
 (require racket/contract)
 
-(provide
- ;; Content parts
- (struct-out text-part)
- (struct-out tool-call-part)
- (struct-out tool-result-part)
- make-text-part
- make-tool-call-part
- make-tool-result-part
- content-part->jsexpr
- jsexpr->content-part
- content-part-type
+;; Content parts
+(provide (struct-out text-part)
+         (struct-out tool-call-part)
+         (struct-out tool-result-part)
+         make-text-part
+         make-tool-call-part
+         make-tool-result-part
+         content-part->jsexpr
+         jsexpr->content-part
+         content-part-type
 
- ;; Message
- (struct-out message)
- make-message
- message->jsexpr
- jsexpr->message
+         ;; Message
+         (struct-out message)
+         make-message
+         message->jsexpr
+         jsexpr->message
 
- ;; Entry kind predicates (#497)
- message-entry?
- model-change-entry?
- thinking-level-change-entry?
- branch-summary-entry?
- custom-message-entry?
- session-info-entry?
- compaction-summary-entry?
- tool-result-entry?
+         ;; Entry kind predicates (#497)
+         message-entry?
+         model-change-entry?
+         thinking-level-change-entry?
+         branch-summary-entry?
+         custom-message-entry?
+         session-info-entry?
+         compaction-summary-entry?
+         tool-result-entry?
 
- ;; Event envelope
- (struct-out event)
- event-event
- make-event
- event->jsexpr
- jsexpr->event
+         ;; Event envelope
+         (struct-out event)
+         event-event
+         make-event
+         event->jsexpr
+         jsexpr->event
 
- ;; Versioning
- CURRENT-EVENT-VERSION
+         ;; Versioning
+         CURRENT-EVENT-VERSION
 
- ;; Tool-call (standalone — canonical definition)
- (struct-out tool-call)
+         ;; Tool-call (standalone — canonical definition)
+         (struct-out tool-call)
 
- ;; Tool-result (standalone — canonical definition)
- (struct-out tool-result)
+         ;; Tool-result (standalone — canonical definition)
+         (struct-out tool-result)
 
- ;; Loop-result
- (struct-out loop-result)
- make-loop-result)
+         ;; Loop-result
+         (struct-out loop-result)
+         make-loop-result)
 
 ;; ============================================================
 ;; Content parts
@@ -88,77 +87,85 @@
 (define (make-tool-call-part id name arguments)
   (tool-call-part "tool-call" id name arguments))
 
-(define (make-tool-result-part tool-call-id content is-error)
-  (tool-result-part "tool-result" tool-call-id content is-error))
+(define (make-tool-result-part tool-call-id content is-error?)
+  (tool-result-part "tool-result" tool-call-id content is-error?))
 
 ;; Serialization
 (define (content-part->jsexpr cp)
   (cond
-    [(text-part? cp)
-     (hasheq 'type "text"
-             'text (text-part-text cp))]
+    [(text-part? cp) (hasheq 'type "text" 'text (text-part-text cp))]
     [(tool-call-part? cp)
-     (hasheq 'type "tool-call"
-             'id (tool-call-part-id cp)
-             'name (tool-call-part-name cp)
-             'arguments (tool-call-part-arguments cp))]
+     (hasheq 'type
+             "tool-call"
+             'id
+             (tool-call-part-id cp)
+             'name
+             (tool-call-part-name cp)
+             'arguments
+             (tool-call-part-arguments cp))]
     [(tool-result-part? cp)
-     (hasheq 'type "tool-result"
-             'toolCallId (tool-result-part-tool-call-id cp)
-             'content (tool-result-part-content cp)
-             'isError (tool-result-part-is-error? cp))]
-    [else
-     (error 'content-part->jsexpr "unknown content part type: ~a" cp)]))
+     (hasheq 'type
+             "tool-result"
+             'toolCallId
+             (tool-result-part-tool-call-id cp)
+             'content
+             (tool-result-part-content cp)
+             'isError
+             (tool-result-part-is-error? cp))]
+    [else (error 'content-part->jsexpr "unknown content part type: ~a" cp)]))
 
 ;; Deserialization
 (define (jsexpr->content-part h)
   (define tp (hash-ref h 'type))
   (case tp
-    [("text")
-     (make-text-part (hash-ref h 'text))]
-    [("tool-call")
-     (make-tool-call-part (hash-ref h 'id)
-                          (hash-ref h 'name)
-                          (hash-ref h 'arguments))]
+    [("text") (make-text-part (hash-ref h 'text))]
+    [("tool-call") (make-tool-call-part (hash-ref h 'id) (hash-ref h 'name) (hash-ref h 'arguments))]
     [("tool-result")
-     (make-tool-result-part (hash-ref h 'toolCallId)
-                            (hash-ref h 'content)
-                            (hash-ref h 'isError))]
-    [else
-     (error 'jsexpr->content-part "unknown content part type: ~a" tp)]))
+     (make-tool-result-part (hash-ref h 'toolCallId) (hash-ref h 'content) (hash-ref h 'isError))]
+    [else (error 'jsexpr->content-part "unknown content part type: ~a" tp)]))
 
 ;; ============================================================
 ;; Message struct
 ;; ============================================================
 
-(struct message (id parent-id role kind content timestamp meta)
-  #:transparent)
+(struct message (id parent-id role kind content timestamp meta) #:transparent)
 
 (define (make-message id parent-id role kind content timestamp meta)
   (message id parent-id role kind content timestamp meta))
 
 ;; Symbol -> string for JSON
 (define (symbol->string* s)
-  (if (symbol? s) (symbol->string s) s))
+  (if (symbol? s)
+      (symbol->string s)
+      s))
 
 ;; String -> symbol from JSON
 (define (string->symbol* s)
-  (if (string? s) (string->symbol s) s))
+  (if (string? s)
+      (string->symbol s)
+      s))
 
 ;; Serialize message to jsexpr (hash)
 (define (message->jsexpr msg)
-  (hasheq 'id (message-id msg)
-          'parentId (message-parent-id msg)  ; #f -> JSON null
-          'role (symbol->string* (message-role msg))
-          'kind (symbol->string* (message-kind msg))
-          'content (map content-part->jsexpr (message-content msg))
-          'timestamp (message-timestamp msg)
-          'meta (message-meta msg)))
+  (hasheq 'id
+          (message-id msg)
+          'parentId
+          (message-parent-id msg) ; #f -> JSON null
+          'role
+          (symbol->string* (message-role msg))
+          'kind
+          (symbol->string* (message-kind msg))
+          'content
+          (map content-part->jsexpr (message-content msg))
+          'timestamp
+          (message-timestamp msg)
+          'meta
+          (message-meta msg)))
 
 ;; Deserialize jsexpr (hash) to message
 (define (jsexpr->message h)
   (make-message (hash-ref h 'id)
-                (hash-ref h 'parentId)  ; JSON null -> #f
+                (hash-ref h 'parentId) ; JSON null -> #f
                 (string->symbol* (hash-ref h 'role))
                 (string->symbol* (hash-ref h 'kind))
                 (map jsexpr->content-part (hash-ref h 'content))
@@ -173,53 +180,43 @@
 
 (define (message-entry? msg)
   ;; Standard message entry (user or assistant)
-  (and (message? msg)
-       (memq (message-kind msg) '(message)) #t))
+  (and (message? msg) (memq (message-kind msg) '(message)) #t))
 
 (define (model-change-entry? msg)
   ;; Records a model change mid-session
-  (and (message? msg)
-       (eq? (message-kind msg) 'model-change)))
+  (and (message? msg) (eq? (message-kind msg) 'model-change)))
 
 (define (thinking-level-change-entry? msg)
   ;; Records a thinking level change mid-session
-  (and (message? msg)
-       (eq? (message-kind msg) 'thinking-level-change)))
+  (and (message? msg) (eq? (message-kind msg) 'thinking-level-change)))
 
 (define (branch-summary-entry? msg)
   ;; Summary of a branched path (used in context assembly)
-  (and (message? msg)
-       (eq? (message-kind msg) 'branch-summary)))
+  (and (message? msg) (eq? (message-kind msg) 'branch-summary)))
 
 (define (custom-message-entry? msg)
   ;; Custom/labeled message for extensions
-  (and (message? msg)
-       (eq? (message-kind msg) 'custom-message)))
+  (and (message? msg) (eq? (message-kind msg) 'custom-message)))
 
 (define (session-info-entry? msg)
   ;; Session metadata (version, settings, etc.)
-  (and (message? msg)
-       (eq? (message-kind msg) 'session-info)))
+  (and (message? msg) (eq? (message-kind msg) 'session-info)))
 
 (define (compaction-summary-entry? msg)
   ;; Compaction summary entry
-  (and (message? msg)
-       (eq? (message-kind msg) 'compaction-summary)))
+  (and (message? msg) (eq? (message-kind msg) 'compaction-summary)))
 
 (define (tool-result-entry? msg)
   ;; Tool result entry
-  (and (message? msg)
-       (eq? (message-kind msg) 'tool-result)))
+  (and (message? msg) (eq? (message-kind msg) 'tool-result)))
 
 ;; ============================================================
 ;; Event envelope struct
 ;; ============================================================
 
-(struct event (version ev time session-id turn-id payload)
-  #:transparent)
+(struct event (version ev time session-id turn-id payload) #:transparent)
 
-(define (make-event ev time session-id turn-id payload
-                    #:version [version 1])
+(define (make-event ev time session-id turn-id payload #:version [version 1])
   (event version ev time session-id turn-id payload))
 
 ;; Accessor alias: the field is called `ev` internally to avoid
@@ -229,12 +226,18 @@
 
 ;; Serialize event to jsexpr (hash)
 (define (event->jsexpr evt)
-  (hasheq 'version (event-version evt)
-          'event (event-ev evt)
-          'time (event-time evt)
-          'sessionId (event-session-id evt)
-          'turnId (event-turn-id evt)  ; #f -> JSON null
-          'payload (event-payload evt)))
+  (hasheq 'version
+          (event-version evt)
+          'event
+          (event-ev evt)
+          'time
+          (event-time evt)
+          'sessionId
+          (event-session-id evt)
+          'turnId
+          (event-turn-id evt) ; #f -> JSON null
+          'payload
+          (event-payload evt)))
 
 ;; Current event schema version produced by this runtime.
 (define CURRENT-EVENT-VERSION 1)
@@ -243,10 +246,10 @@
 (define (jsexpr->event h)
   (define ver (hash-ref h 'version 1))
   (when (> ver CURRENT-EVENT-VERSION)
-    (log-warning
-     (format "jsexpr->event: event version ~a exceeds current ~a (event: ~a)"
-             ver CURRENT-EVENT-VERSION
-             (hash-ref h 'event "<unknown>"))))
+    (log-warning (format "jsexpr->event: event version ~a exceeds current ~a (event: ~a)"
+                         ver
+                         CURRENT-EVENT-VERSION
+                         (hash-ref h 'event "<unknown>"))))
   (event ver
          (hash-ref h 'event)
          (hash-ref h 'time)
@@ -267,12 +270,12 @@
 ;; Tool-call struct (standalone — canonical definition)
 ;; ============================================================
 
-(struct tool-call (id name arguments) #:transparent
-           #:extra-constructor-name make-tool-call)
+(struct tool-call (id name arguments) #:transparent #:extra-constructor-name make-tool-call)
 
 ;; ============================================================
 ;; Tool-result struct (standalone — canonical definition)
 ;; ============================================================
 
-(struct tool-result (content details is-error?) #:transparent
-           #:extra-constructor-name make-tool-result)
+(struct tool-result (content details is-error?)
+  #:transparent
+  #:extra-constructor-name make-tool-result)


### PR DESCRIPTION
## Wave 2: Code Quality Fixes (TEST-05, QUAL-08)

### Changes
- **TEST-05** (#1082): Wrapped 42 bare assertions in `test-scheduler.rkt` into 16 named `test-case` forms for proper test runner tracking
- **QUAL-08** (#1083): Renamed `is-error` → `is-error?` parameter in `make-tool-result-part` (`util/protocol-types.rkt`) following Racket boolean naming conventions

### Verification
- 4527 tests pass, 0 failures
- Both files compile clean

Closes #1082, #1083
Part of #1073 (Wave 2), milestone #57 (v0.10.5)
