### PR TITLE
DOC-03: Add API doc comments to 5 core modules

### DIFF
--- a/agent/loop.rkt
+++ b/agent/loop.rkt
@@ -109,6 +109,14 @@
 ;; build-raw-messages : (listof message?) -> (listof hash?)
 ;; PURE function — converts a list of message? structs into raw OpenAI-format
 ;; hash messages. No side effects, no bus/state needed.
+;;; build-raw-messages : (listof message?) -> (listof hash?)
+;;;
+;;; Converts internal message structs to raw OpenAI-format message hashes.
+;;; Handles all roles:
+;;;   'user     -> {role: "user", content: <text>}
+;;;   'assistant -> {role: "assistant", content: <text>, tool_calls: [...]}
+;;;   'tool     -> {role: "tool", tool_call_id: ..., content: ...}
+;;; Pure function — no side effects.
 (define (build-raw-messages context)
   (append*
    (for/list ([msg (in-list context)])
@@ -176,6 +184,14 @@
 ;;   'all-chunks      — list of all stream chunks
 ;;   'cancelled?      — boolean
 ;;   'stream-blocked? — boolean (from message-update hook block)
+;;; stream-from-provider : provider? model-request? event-bus? string? string?
+;;;                         loop-state? (or/c procedure? #f) (or/c cancellation-token? #f)
+;;;                         -> hash?
+;;;
+;;; Wraps the streaming loop. Pulls chunks from the provider's stream
+;;; generator, emits message.start/delta/end events, supports cancellation
+;;; via token and blocking via message-update hook. Returns a hash with
+;;; keys: 'text, 'tool-calls, 'all-chunks, 'cancelled?, 'stream-blocked?.
 (define (stream-from-provider provider
                               req
                               bus
@@ -309,6 +325,11 @@
 
 ;; handle-cancellation : event-bus string string loop-state -> loop-result?
 ;; Emits turn.cancelled and turn.completed events, returns a cancelled loop-result.
+;;; handle-cancellation : event-bus? string? string? loop-state? -> loop-result?
+;;;
+;;; Cancellation cleanup helper. Dispatches agent-end hook with 'cancelled
+;;; termination, emits turn.completed with 'cancelled, and returns a
+;;; loop-result with status 'cancelled.
 (define (handle-cancellation bus session-id turn-id state #:hook-dispatcher [hook-dispatcher #f])
   ;; #667: Dispatch agent-end hook on cancellation
   (when hook-dispatcher
@@ -338,6 +359,15 @@
 ;;   - message-end hook (amend/block)
 ;;   - Building the final assistant message
 ;;   - Checking for tool calls → completed vs tool-calls-pending
+;;; build-stream-result : hash? (listof hash?) event-bus? string? string?
+;;;                       loop-state? (or/c (listof hash?) #f) provider?
+;;;                       (or/c procedure? #f) -> loop-result?
+;;;
+;;; Post-stream result builder. Extracts text and tool calls from stream
+;;; data, resolves usage, dispatches model-response-post and message-end
+;;; hooks, builds the final assistant message, and emits completion events.
+;;; Returns 'completed if no tool calls, or 'tool-calls-pending if tools
+;;; need execution.
 (define (build-stream-result stream-data
                              raw-messages
                              bus
@@ -521,6 +551,23 @@
 ;;                  #:cancellation-token (or/c cancellation-token? #f)
 ;;                  #:hook-dispatcher (or/c procedure? #f)
 ;;               -> loop-result?
+;;; run-agent-turn : (listof message?) provider? event-bus?
+;;;                  #:session-id string?
+;;;                  #:turn-id string?
+;;;                  #:state (or/c loop-state? #f)
+;;;                  #:tools (or/c (listof hash?) #f)
+;;;                  #:cancellation-token (or/c cancellation-token? #f)
+;;;                  #:hook-dispatcher (or/c procedure? #f)
+;;;                  -> loop-result?
+;;;
+;;; Main entry point for a single agent turn. Orchestrates the pipeline:
+;;;   1. Emits turn.started event
+;;;   2. Dispatches agent-start hook
+;;;   3. Builds normalized model context via build-raw-messages
+;;;   4. Emits context.built event
+;;;   5. Streams from provider via stream-from-provider
+;;;   6. On cancellation: handle-cancellation
+;;;   7. Otherwise: build-stream-result for final assembly
 (define (run-agent-turn context
                         provider
                         bus

--- a/extensions/api.rkt
+++ b/extensions/api.rkt
@@ -49,6 +49,8 @@
 ;;   ordered-list : (listof extension?) in registration order
 ;;   hash         : (hash/c string? extension?) for O(1) lookup
 
+;;; make-extension-registry : -> extension-registry?
+;;; Creates a new empty thread-safe extension registry.
 (define (make-extension-registry)
   (make-extension-registry-internal (box (cons '() (hasheq))) (make-semaphore 1)))
 
@@ -56,6 +58,11 @@
 ;; register-extension! : extension-registry? extension? -> void?
 ;; ============================================================
 
+;;; register-extension! : extension-registry? extension? -> void?
+;;;
+;;; Registers an extension. If an extension with the same name exists, it
+;;; is replaced (overwrite semantics). New entries are appended to preserve
+;;; insertion order. Thread-safe.
 (define (register-extension! registry ext)
   (call-with-semaphore (extension-registry-semaphore registry)
     (λ ()
@@ -75,6 +82,9 @@
 ;; unregister-extension! : extension-registry? string? -> void?
 ;; ============================================================
 
+;;; unregister-extension! : extension-registry? string? -> void?
+;;; Removes an extension by name from both the ordered list and the hash.
+;;; Thread-safe.
 (define (unregister-extension! registry name)
   (call-with-semaphore (extension-registry-semaphore registry)
     (λ ()
@@ -90,6 +100,8 @@
 ;; lookup-extension : extension-registry? string? -> (or/c extension? #f)
 ;; ============================================================
 
+;;; lookup-extension : extension-registry? string? -> (or/c #f extension?)
+;;; O(1) lookup by name. Returns the extension or #f. Thread-safe.
 (define (lookup-extension registry name)
   (call-with-semaphore (extension-registry-semaphore registry)
     (lambda ()
@@ -100,6 +112,8 @@
 ;; list-extensions : extension-registry? -> (listof extension?)
 ;; ============================================================
 
+;;; list-extensions : extension-registry? -> (listof extension?)
+;;; Returns all extensions in registration (insertion) order. Thread-safe.
 (define (list-extensions registry)
   (call-with-semaphore (extension-registry-semaphore registry)
     (lambda ()
@@ -111,6 +125,10 @@
 ;; in registration order.
 ;; ============================================================
 
+;;; handlers-for-point : extension-registry? symbol? -> (listof pair?)
+;;;
+;;; Returns (extension-name . handler) pairs for all extensions that have
+;;; a hook registered for the given hook point symbol, in registration order.
 (define (handlers-for-point registry hook-point)
   (define exts (list-extensions registry))
   (for*/list ([ext exts]

--- a/interfaces/sdk.rkt
+++ b/interfaces/sdk.rkt
@@ -131,6 +131,12 @@
 ;; make-runtime
 ;; ============================================================
 
+;;; make-runtime : #:provider any/c [#:session-dir ...] [#:tool-registry ...]
+;;;               ... -> runtime?
+;;;
+;;; Constructs a runtime handle with sensible defaults. Creates a new tool
+;;; registry, event bus, session directory, and cancellation token if not
+;;; provided. The runtime wraps all components needed for agent execution.
 (define (make-runtime #:provider provider
                       #:session-dir [session-dir (default-session-dir)]
                       #:tool-registry [tool-registry (make-tool-registry)]
@@ -157,6 +163,11 @@
 ;; open-session
 ;; ============================================================
 
+;;; open-session : runtime? [(or/c string? #f)] -> runtime?
+;;;
+;;; Creates a new agent session or resumes an existing one by ID.
+;;; Returns a new runtime with the session attached. If session-id is
+;;; #f, creates a fresh session; otherwise resumes the session with that ID.
 (define (open-session rt [session-id #f])
   (define cfg (rt-cfg rt))
   (define agent-cfg
@@ -203,6 +214,12 @@
 ;; subscribe-events!
 ;; ============================================================
 
+;;; subscribe-events! : (runtime? procedure? [(or/c procedure? #f)])
+;;;                     -> exact-nonnegative-integer?
+;;;
+;;; Registers an event handler on the runtime's event bus. Optional filter
+;;; predicate narrows which events are delivered. Returns subscription ID
+;;; for later unsubscription.
 (define (subscribe-events! rt handler [filter #f])
   (define bus (runtime-config-event-bus (rt-cfg rt)))
   (if filter
@@ -213,6 +230,9 @@
 ;; interrupt!
 ;; ============================================================
 
+;;; interrupt! : runtime? -> runtime?
+;;; Cancels the runtime's cancellation token and emits an interrupt.requested
+;;; event. Returns the same runtime for chaining.
 (define (interrupt! rt)
   (define sess (rt-sess rt))
   (define bus (runtime-config-event-bus (rt-cfg rt)))
@@ -235,6 +255,12 @@
 ;; fork-session!
 ;; ============================================================
 
+;;; fork-session! : (runtime? [(or/c string? #f)])
+;;;               -> (or/c runtime? 'no-active-session)
+;;;
+;;; Forks the active session, optionally at a specific entry ID. Returns
+;;; a new runtime with the forked session, or 'no-active-session if no
+;;; session is currently open.
 (define (fork-session! rt [entry-id #f])
   (define sess (rt-sess rt))
   (cond
@@ -260,6 +286,11 @@
 ;;   - Original messages remain in the log (append-only)
 ;;   - Future context assembly can use summary + recent messages
 
+;;; compact-session! : (runtime? [#:persist? boolean?]) -> any
+;;;
+;;; Compacts session history. With #:persist? #f (default) is advisory-only;
+;;; with #:persist? #t appends a summary entry to the session log.
+;;; Returns (values rt compaction-result).
 (define (compact-session! rt #:persist? [persist? #f])
   (define sess (rt-sess rt))
   (cond
@@ -304,6 +335,11 @@
 ;; session-info
 ;; ============================================================
 
+;;; session-info : runtime? -> (or/c #f hash?)
+;;;
+;;; Returns a hash with session metadata (session-id, active?, history-length,
+;;; model-name, extension-registry-count, system-instructions, max-iterations,
+;;; token-budget-threshold), or #f if no session is open.
 (define (session-info rt)
   (define sess (rt-sess rt))
   (define cfg (rt-cfg rt))
@@ -334,6 +370,9 @@
 ;; steer!
 ;; ============================================================
 
+;;; steer! : runtime? string? -> runtime?
+;;; Enqueues a steering message into the session's agent queue for
+;;; mid-turn guidance. No-op if no session is active.
 (define (steer! rt message)
   (define sess (rt-sess rt))
   (cond
@@ -347,6 +386,9 @@
 ;; follow-up!
 ;; ============================================================
 
+;;; follow-up! : runtime? string? -> runtime?
+;;; Enqueues a follow-up message into the session's agent queue for
+;;; post-turn continuation. No-op if no session is active.
 (define (follow-up! rt message)
   (define sess (rt-sess rt))
   (cond

--- a/llm/provider.rkt
+++ b/llm/provider.rkt
@@ -34,6 +34,9 @@
 ;; ============================================================
 
 ;; Ensure the model-request has a 'model setting; if missing, set it to default-model.
+;;; ensure-model-setting : model-request? string? -> model-request?
+;;; If the request has no 'model key in its settings, returns a new request
+;;; with default-model set; otherwise returns the request unchanged.
 (define (ensure-model-setting req default-model)
   (if (hash-has-key? (model-request-settings req) 'model)
       req
@@ -47,6 +50,11 @@
 
 ;; Validates that the API key is present and non-empty.
 ;; Raises exn:fail with a provider-specific message if missing.
+;;; validate-api-key! : string? string? hash? -> void?
+;;;
+;;; Takes (provider-name env-var config). Checks that config['api-key] is
+;;; a non-empty string; raises exn:fail with a setup message if missing.
+;;; Used by provider implementations to fail fast on missing credentials.
 (define (validate-api-key! provider-name env-var config)
   (define api-key (hash-ref config 'api-key ""))
   (when (or (not api-key) (not (string? api-key)) (string=? (string-trim api-key) ""))
@@ -70,17 +78,26 @@
 ;; Generic interface
 ;; ============================================================
 
+;; provider-name : provider? -> string?
+;; Returns the provider's display name.
 (define (provider-name p)
   ((provider-dispatch p) 'name))
 
+;; provider-send : provider? model-request? -> any/c
+;; Sends a non-streaming request. Returns a model-response.
 (define (provider-send p req)
   (define send-proc ((provider-dispatch p) 'send))
   (send-proc req))
 
+;; provider-stream : provider? model-request? -> any/c
+;; Sends a streaming request. Returns a generator that yields
+;; stream-chunk? values then #f.
 (define (provider-stream p req)
   (define stream-proc ((provider-dispatch p) 'stream))
   (stream-proc req))
 
+;; provider-capabilities : provider? -> hash?
+;; Returns the provider's capability map (e.g., #hasheq((streaming . #t))).
 (define (provider-capabilities p)
   ((provider-dispatch p) 'capabilities))
 
@@ -109,6 +126,15 @@
             "expected generator or list of stream-chunks, got: ~a"
             result)]))
 
+;;; make-provider : procedure? procedure? procedure? procedure? -> provider?
+;;;
+;;; Creates a provider from four procedures:
+;;;   name-proc  : thunk -> string (display name)
+;;;   caps-proc  : thunk -> hash (capability map)
+;;;   send-proc  : model-request -> model-response (non-streaming)
+;;;   stream-proc: model-request -> generator-or-list (streaming)
+;;; The stream result is automatically wrapped in a generator if a list is
+;;; returned.
 (define (make-provider name-proc caps-proc send-proc stream-proc)
   (provider (lambda (op)
               (case op
@@ -125,6 +151,9 @@
 
 ;; Returns #f for providers that don't support token counting,
 ;; or an integer count for providers that do.
+;; provider-count-tokens : provider? any/c -> (or/c #f integer?)
+;; Returns token count for the given request, or #f if the provider
+;; doesn't support counting. Default implementation returns #f.
 (define (provider-count-tokens p req)
   (define count-proc ((provider-dispatch p) 'count-tokens))
   (count-proc req))
@@ -133,6 +162,13 @@
 ;; Mock provider (for testing)
 ;; ============================================================
 
+;;; make-mock-provider : any/c [#:name string?] [#:stream-chunks (or/c #f list?)]
+;;;                    -> provider?
+;;;
+;;; Creates a mock provider for testing. Always returns the given response
+;;; for send. For stream, yields either the provided #:stream-chunks or
+;;; auto-generated chunks derived from the response content text parts,
+;;; followed by a final chunk with usage + done?.
 (define (make-mock-provider response #:name [name "mock"] #:stream-chunks [stream-chunks #f])
   (define chunks
     (or stream-chunks

--- a/runtime/agent-session.rkt
+++ b/runtime/agent-session.rkt
@@ -111,6 +111,10 @@
   (build-path dir "session.jsonl"))
 
 ;; #771: Ensure session directory exists and flush pending entries.
+;; ensure-persisted! : agent-session? -> void?
+;; Idempotently creates the session directory, writes the version header,
+;; and flushes all buffered pending-entries to session.jsonl. No-op if
+;; already persisted.
 ;; Called before the first write to the session log.
 ;; Idempotent — no-op if already persisted.
 (define (ensure-persisted! sess)
@@ -127,6 +131,9 @@
       (set-agent-session-pending-entries! sess '()))))
 
 ;; #771: Buffer an entry for later persistence, or write immediately if already persisted.
+;; buffer-or-append! : agent-session? message? -> void?
+;; If the session is already persisted, appends the entry to session.jsonl
+;; immediately. Otherwise, pushes it onto pending-entries for later flush.
 (define (buffer-or-append! sess entry)
   (if (agent-session-persisted? sess)
       (append-entry! (session-log-path (agent-session-session-dir sess)) entry)
@@ -147,6 +154,14 @@
 ;;   'max-iterations → integer (optional, default 10)
 ;;   'token-budget-threshold → integer (optional, default 100000)
 
+;;; make-agent-session : (hash/c symbol? any/c) -> agent-session?
+;;;
+;;; Creates a new agent session from a config hash. Required keys:
+;;;   'provider, 'tool-registry, 'event-bus, 'session-dir
+;;; Optional keys: 'max-iterations, 'token-budget-threshold, 'model-name,
+;;;   'system-instructions, 'extension-registry
+;;; Generates a unique session ID, emits session.started, dispatches
+;;; 'session-start hook, wires event handlers, and emits resources.discover.
 (define (make-agent-session config)
   (define sid (generate-id))
   (define base-dir (hash-ref config 'session-dir))
@@ -210,6 +225,12 @@
 ;; resume-agent-session
 ;; ============================================================
 
+;;; resume-agent-session : string? (hash/c symbol? any/c) -> agent-session?
+;;;
+;;; Resumes an existing session by ID. Validates directory exists,
+;;; rebuilds session index from log, dispatches 'session-before-switch hook
+;;; (extensions can block), emits session.resumed, dispatches 'session-start
+;;; with reason 'resume, and wires event handlers.
 (define (resume-agent-session session-id config)
   (define base-dir (hash-ref config 'session-dir))
   (define dir (build-path base-dir session-id))
@@ -279,6 +300,12 @@
 ;; fork-session
 ;; ============================================================
 
+;;; fork-session : agent-session? [(or/c string? #f)] -> agent-session?
+;;;
+;;; Forks the session at a given entry ID (or latest point). Creates a new
+;;; session directory, copies log entries up to fork point, builds fresh
+;;; index, emits session.forked, dispatches 'session-before-fork and
+;;; 'session-start hooks. Raises error if source session is closed.
 (define (fork-session sess [parent-entry-id #f])
   ;; Guard — refuse fork on closed session
   (unless (session-active? sess)
@@ -491,6 +518,14 @@
 ;; maybe-compact-context — token budget check and compaction triggering.
 ;;   May mutate context (return a compacted version). Returns the
 ;;   (possibly compacted) context message list.
+;;; maybe-compact-context : agent-session? (listof message?) integer?
+;;;                        -> (listof message?)
+;;;
+;;; Checks if context token count exceeds budget threshold. If so (and
+;;; not in recursive-compaction guard or stale-usage cooldown), dispatches
+;;; 'session-before-compact hook, runs compact-history, emits compaction
+;;; events, and returns compacted message list. Otherwise returns input
+;;; unchanged.
 (define (maybe-compact-context sess context-with-system token-budget-threshold)
   (define bus (agent-session-event-bus sess))
   (define sid (agent-session-session-id sess))
@@ -623,6 +658,16 @@
 ;; run-prompt!
 ;; ============================================================
 
+;;; run-prompt! : agent-session? (or/c string? message?)
+;;;              [#:max-iterations (or/c integer? #f)]
+;;;              -> (values agent-session? loop-result?)
+;;;
+;;; Main entry point for running a user prompt. Guards against closed
+;;; sessions, dispatches 'input hook (extensions can block/amend input),
+;;; builds context from history + system instructions, checks token budget
+;;; and compacts if needed, ensures persistence, dispatches 'model-select
+;;; hook and runs the iteration loop, rebuilds session index, emits
+;;; session.updated. Returns updated session and loop-result.
 (define (run-prompt! sess user-message #:max-iterations [max-iter-override #f])
   ;; B4: Guard — refuse operations on closed sessions
   (unless (session-active? sess)
@@ -660,6 +705,8 @@
 ;; Accessors
 ;; ============================================================
 
+;; session-id : agent-session? -> string?
+;; Returns the session's unique ID string.
 (define (session-id sess)
   (agent-session-session-id sess))
 
@@ -695,6 +742,10 @@
 
   (values sess final-result))
 
+;; session-history : agent-session? -> (listof message?)
+;; Loads and returns the full message history from session.jsonl,
+;; filtering out session-info (version header) entries. Returns '() if
+;; no log file exists.
 (define (session-history sess)
   (define log-path (session-log-path (agent-session-session-dir sess)))
   (if (file-exists? log-path)
@@ -702,9 +753,16 @@
       (filter (lambda (m) (not (eq? (message-kind m) 'session-info))) (load-session-log log-path))
       '()))
 
+;; session-active? : agent-session? -> boolean?
+;; Returns #t if the session has not been closed.
 (define (session-active? sess)
   (agent-session-active? sess))
 
+;;; close-session! : agent-session? -> void?
+;;;
+;;; Closes/deactivates the session. Flushes pending entries, emits
+;;; session.closed, dispatches 'session-shutdown hook with duration,
+;;; and sets active? to #f. Idempotent — no-op if already closed.
 (define (close-session! sess)
   ;; B5: Idempotency guard — only close once
   (when (session-active? sess)
@@ -785,6 +843,9 @@
 
 ;; set-model! : agent-session? string? -> void?
 ;; Switch the active model for this session.
+;;; set-model! : agent-session? string? -> void?
+;;; Sets the active model name for the session.
+;;; Raises argument-error if model-name is not a string.
 (define (set-model! sess model-name)
   (unless (string? model-name)
     (raise-argument-error 'set-model! "string?" model-name))
@@ -793,6 +854,9 @@
 ;; cycle-model! : agent-session? model-registry? -> (or/c string? #f)
 ;; Cycle to the next available model. Returns the new model name, or #f if
 ;; no models are available.
+;;; cycle-model! : agent-session? model-registry? -> (or/c string? #f)
+;;; Cycles to the next model in the registry's available models list
+;;; (wrapping around). Returns the new model name, or #f if no models.
 (define (cycle-model! sess registry)
   (define models (available-models registry))
   (if (null? models)


### PR DESCRIPTION
## Wave 6: API Documentation (DOC-03)

### Changes
- **#1092**: `agent/loop.rkt` — doc comments for all 5 public functions
- **#1093**: `runtime/agent-session.rkt` — doc comments for 13 public functions
- **#1094**: `interfaces/sdk.rkt` — doc comments for all 9 SDK functions
- **#1095**: `extensions/api.rkt` — doc comments for all 6 registry functions
- **#1096**: `llm/provider.rkt` — doc comments for all 9 provider functions

### Stats
- 207 lines of API doc comments added across 5 core modules
- All comments include type signatures and behavioral descriptions

### Verification
- 4586 tests pass, 0 failures

Closes #1092, #1093, #1094, #1095, #1096
Part of #1077 (Wave 6), milestone #57 (v0.10.5)
