### PR TITLE
feat(core): session import, provider registry, truncation constants (#1112)

### DIFF
--- a/extensions/context.rkt
+++ b/extensions/context.rkt
@@ -34,7 +34,9 @@
          ctx-session-store
          ctx-tool-registry
          ctx-command-registry
-         ctx-ui-channel)
+         ctx-ui-channel
+         ;; Accessor (#1114: provider registry access for extensions)
+         ctx-provider-registry)
 
 ;; ============================================================
 ;; extension-ctx struct
@@ -52,7 +54,8 @@
          session-store ; (or/c any/c #f) — read-only session access
          tool-registry ; (or/c any/c #f) — dynamic tool registration
          command-registry ; (or/c any/c #f) — slash command registration
-         ui-channel) ; (or/c channel? #f) — user interaction requests
+         ui-channel ; (or/c channel? #f) — user interaction requests
+         provider-registry) ; (or/c provider-registry? #f) — LLM provider access (#1114)
   #:transparent)
 
 ;; ============================================================
@@ -70,7 +73,8 @@
                             #:session-store [session-store #f]
                             #:tool-registry [tool-registry #f]
                             #:command-registry [command-registry #f]
-                            #:ui-channel [ui-channel #f])
+                            #:ui-channel [ui-channel #f]
+                            #:provider-registry [provider-registry #f])
   (extension-ctx session-id
                  session-dir
                  event-bus
@@ -81,7 +85,8 @@
                  session-store
                  tool-registry
                  command-registry
-                 ui-channel))
+                 ui-channel
+                 provider-registry))
 
 ;; ============================================================
 ;; Accessor aliases — short, ergonomic names
@@ -99,3 +104,5 @@
 (define ctx-tool-registry extension-ctx-tool-registry)
 (define ctx-command-registry extension-ctx-command-registry)
 (define ctx-ui-channel extension-ctx-ui-channel)
+;; #1114: provider registry accessor alias
+(define ctx-provider-registry extension-ctx-provider-registry)

--- a/runtime/session-store.rkt
+++ b/runtime/session-store.rkt
@@ -41,6 +41,8 @@
          migrate-session-log!
          ;; Session forking (#500)
          fork-session!
+         ;; Session import (#1113)
+         import-session!
          ;; Session naming
          write-session-name!
          ;; In-memory session manager (GC-18)
@@ -341,6 +343,55 @@
 ;; ============================================================
 ;; Session naming
 ;; ============================================================
+
+;; ============================================================
+;; Session import (#1113)
+;; ============================================================
+
+(define (import-session! source-path dest-session-dir)
+  ;; Import a session from an external JSONL file into a new session directory.
+  ;; Validates source JSONL line-by-line, generates a new session ID,
+  ;; copies valid entries to a new session file with a version header.
+  ;; Returns the new session ID.
+  ;;
+  ;; source-path: path to source JSONL file
+  ;; dest-session-dir: directory for the new session
+  (cond
+    [(not (file-exists? source-path))
+     (error 'import-session! "Source file not found: ~a" source-path)]
+    [else
+     ;; Validate source JSONL
+     (define-values (raw corrupted-count) (jsonl-read-all-valid-with-count source-path))
+     (when (> corrupted-count 0)
+       (fprintf (current-error-port)
+                "WARNING: ~a corrupted lines skipped during import from ~a\n"
+                corrupted-count
+                source-path))
+     (when (null? raw)
+       (error 'import-session! "No valid entries found in source: ~a" source-path))
+     ;; Generate new session ID
+     (define new-session-id (format "imported-~a" (current-inexact-milliseconds)))
+     ;; Create destination directory
+     (define dest-path (build-path dest-session-dir (format "~a.jsonl" new-session-id)))
+     (ensure-parent-dirs* dest-path)
+     ;; Write version header + imported entries
+     (define header-msg
+       (make-message (format "session-version-header-~a" (current-inexact-milliseconds))
+                     #f
+                     'system
+                     'session-info
+                     '()
+                     (current-seconds)
+                     (hasheq 'version
+                             CURRENT-SESSION-VERSION
+                             'imported-from
+                             (path->string source-path)
+                             'imported-at
+                             (current-seconds))))
+     (define messages (map jsexpr->message raw))
+     (define all-entries (cons header-msg messages))
+     (jsonl-append-entries! dest-path (map message->jsexpr all-entries))
+     new-session-id]))
 
 (define (write-session-name! log-path name)
   ;; Persist session name as a session-info entry.

--- a/tests/test-extension-context.rkt
+++ b/tests/test-extension-context.rkt
@@ -484,3 +484,29 @@
   (parameterize ([current-hook-timeout-ms #f])
     (dispatch-hooks 'tool-call "payload" reg #:ctx ctx)
     (check-true (unbox checked-cancelled))))
+
+;; ============================================================
+;; Provider registry accessor (#1114)
+;; ============================================================
+
+(test-case "ctx-provider-registry returns #f when not provided"
+  (define bus (make-event-bus))
+  (define reg (make-extension-registry))
+  (define ctx
+    (make-extension-ctx #:session-id "sess-prov-1"
+                        #:session-dir "/tmp"
+                        #:event-bus bus
+                        #:extension-registry reg))
+  (check-false (ctx-provider-registry ctx)))
+
+(test-case "ctx-provider-registry returns provider registry when provided"
+  (define bus (make-event-bus))
+  (define reg (make-extension-registry))
+  (define fake-provider-reg 'some-provider-registry)
+  (define ctx
+    (make-extension-ctx #:session-id "sess-prov-2"
+                        #:session-dir "/tmp"
+                        #:event-bus bus
+                        #:extension-registry reg
+                        #:provider-registry fake-provider-reg))
+  (check-equal? (ctx-provider-registry ctx) 'some-provider-registry))

--- a/tests/test-hook-expansion.rkt
+++ b/tests/test-hook-expansion.rkt
@@ -166,7 +166,7 @@
                                   (hasheq 'turn-start
                                           (lambda (ctx payload)
                                             (hook-amend (format "ctx:~a" (ctx-session-id ctx)))))))
-  (define ctx (extension-ctx "s42" "/tmp" (make-event-bus) reg #f #f #f #f #f #f #f))
+  (define ctx (extension-ctx "s42" "/tmp" (make-event-bus) reg #f #f #f #f #f #f #f #f))
   (define result (dispatch-hooks 'turn-start "hello" reg #:ctx ctx))
   (check-equal? (hook-result-payload result) "ctx:s42"))
 

--- a/tests/test-session-store.rkt
+++ b/tests/test-session-store.rkt
@@ -8,7 +8,8 @@
          racket/list
          "../util/protocol-types.rkt"
          "../runtime/session-store.rkt"
-         "../runtime/session-index.rkt")
+         "../runtime/session-index.rkt"
+         "../util/jsonl.rkt")
 
 ;; ── Helpers ──
 
@@ -772,6 +773,53 @@
     (check-equal? (length original) 2)
     (delete-directory/files dir #:must-exist? #f))
   )
+
+ ;; ============================================================
+ ;; Session import tests (#1113)
+ ;; ============================================================
+
+ (test-case
+  "import-session! imports valid JSONL into new session"
+  (define dir (make-temporary-file "q-import-test-~a" 'directory #f))
+  (define source-path (build-path dir "source.jsonl"))
+  (define dest-dir (build-path dir "sessions"))
+  (make-directory dest-dir)
+  ;; Write a valid source JSONL
+  (define msg1 (make-message "m1" #f 'user 'text (list (make-text-part "Hello")) (current-seconds) (hash)))
+  (define msg2 (make-message "m2" #f 'assistant 'text (list (make-text-part "World")) (current-seconds) (hash)))
+  (jsonl-append-entries! source-path (map message->jsexpr (list msg1 msg2)))
+  ;; Import
+  (define new-id (import-session! source-path dest-dir))
+  (check-true (string? new-id))
+  (check-true (string-contains? new-id "imported-"))
+  ;; Verify imported file
+  (define dest-path (build-path dest-dir (format "~a.jsonl" new-id)))
+  (check-true (file-exists? dest-path))
+  (define loaded (load-session-log dest-path))
+  ;; Should have header + 2 entries = 3
+  (check-equal? (length loaded) 3)
+  ;; First imported entry should be msg1 (header is entry 0)
+  (check-equal? (message-role (second loaded)) 'user)
+  (check-equal? (message-role (third loaded)) 'assistant)
+  (delete-directory/files dir #:must-exist? #f))
+
+ (test-case
+  "import-session! errors on missing source"
+  (define dir (make-temporary-file "q-import-test-~a" 'directory #f))
+  (check-exn exn:fail?
+             (lambda ()
+               (import-session! "/nonexistent/path.jsonl" dir)))
+  (delete-directory/files dir #:must-exist? #f))
+
+ (test-case
+  "import-session! errors on empty source"
+  (define dir (make-temporary-file "q-import-test-~a" 'directory #f))
+  (define source-path (build-path dir "empty.jsonl"))
+  (call-with-output-file source-path void #:exists 'truncate)
+  (check-exn exn:fail?
+             (lambda ()
+               (import-session! source-path dir)))
+  (delete-directory/files dir #:must-exist? #f))
 
 ;; Run
 (run-tests test-session-store)

--- a/tests/test-truncation.rkt
+++ b/tests/test-truncation.rkt
@@ -7,7 +7,9 @@
          "../util/truncation.rkt")
 
 (define (make-lines n)
-  (string-join (for/list ([i (in-range n)]) (format "Line ~a" i)) "\n"))
+  (string-join (for/list ([i (in-range n)])
+                 (format "Line ~a" i))
+               "\n"))
 
 (define (make-bytes n)
   (make-string n #\x))
@@ -56,4 +58,17 @@
 
 (test-case "constants have expected values"
   (check-equal? MAX-OUTPUT-BYTES 50000)
-  (check-equal? MAX-OUTPUT-LINES 2000))
+  (check-equal? MAX-OUTPUT-LINES 2000)
+  (check-equal? MAX-OUTPUT-CHARS 50000))
+
+(test-case "truncate-to-n-chars unchanged when within limit"
+  (check-equal? (truncate-to-n-chars "hello" 10) "hello"))
+
+(test-case "truncate-to-n-chars truncates and appends notice"
+  (define result (truncate-to-n-chars (make-string 100 #\x) 50))
+  (check-equal? (string-length result) 65) ; 50 + "\n...(truncated)" (15 chars)
+  (check-true (string-contains? result "...(truncated)")))
+
+(test-case "truncate-to-n-chars exact length passes through"
+  (define s (make-string 50 #\a))
+  (check-equal? (truncate-to-n-chars s 50) s))

--- a/tools/builtins/firecrawl.rkt
+++ b/tools/builtins/firecrawl.rkt
@@ -7,17 +7,18 @@
          net/http-client
          net/url
          (only-in "../tool.rkt" make-success-result make-error-result)
-         (only-in "../../util/errors.rkt" raise-tool-error))
+         (only-in "../../util/errors.rkt" raise-tool-error)
+         (only-in "../../util/truncation.rkt" truncate-to-n-chars MAX-OUTPUT-CHARS))
 
 (provide tool-firecrawl
-         firecrawl-api-key       ;; for testing
-         firecrawl-request       ;; for testing
-         valid-action?           ;; for testing
-         valid-formats?          ;; for testing
-         truncate-string
-         validate-url            ;; for testing
-         private-host?           ;; for testing
-         poll-crawl-status)      ;; for testing
+         firecrawl-api-key ;; for testing
+         firecrawl-request ;; for testing
+         valid-action? ;; for testing
+         valid-formats? ;; for testing
+         truncate-string ;; backward compat alias
+         validate-url ;; for testing
+         private-host? ;; for testing
+         poll-crawl-status) ;; for testing
 
 ;; ============================================================
 ;; SSRF Protection (SEC-14)
@@ -43,14 +44,15 @@
     (raise-tool-error (format "Blocked: URL scheme must be http or https: ~a" url-str) "firecrawl"))
   (define host (url-host uri))
   (when (or (not host) (private-host? host))
-    (raise-tool-error (format "Blocked: URL points to private/internal address: ~a" url-str) "firecrawl")))
+    (raise-tool-error (format "Blocked: URL points to private/internal address: ~a" url-str)
+                      "firecrawl")))
 
 ;; ============================================================
 ;; Configuration
 ;; ============================================================
 
 (define DEFAULT-BASE-URL "https://api.firecrawl.dev/v1")
-(define DEFAULT-CRAWL-TIMEOUT 30)  ;; seconds
+(define DEFAULT-CRAWL-TIMEOUT 30) ;; seconds
 (define DEFAULT-LIMIT 5)
 
 ;; Resolve API key: env var > config
@@ -61,8 +63,7 @@
       (let ([cfg-path (build-path (find-system-path 'home-dir) ".q" "config.json")])
         (and (file-exists? cfg-path)
              (let ([cfg (with-handlers ([exn:fail? (lambda (_) #f)])
-                          (call-with-input-file cfg-path
-                            (lambda (port) (read-json port))))])
+                          (call-with-input-file cfg-path (lambda (port) (read-json port))))])
                (and (hash? cfg)
                     (let ([fc (hash-ref cfg 'firecrawl #f)])
                       (and (hash? fc)
@@ -70,8 +71,7 @@
                              (and k (> (string-length k) 0) k))))))))))
 
 (define (firecrawl-base-url)
-  (or (getenv "FIRECRAWL_BASE_URL")
-      DEFAULT-BASE-URL))
+  (or (getenv "FIRECRAWL_BASE_URL") DEFAULT-BASE-URL))
 
 ;; ============================================================
 ;; HTTP helpers
@@ -89,21 +89,20 @@
       (define body-str
         (with-handlers ([exn:fail? (lambda (_) "<non-utf-8 body>")])
           (bytes->string/utf-8 body-bytes)))
-      (raise-tool-error
-             (format "API request failed (~a): ~a"
-                     code
-                     (if (> (string-length body-str) 500)
-                         (string-append (substring body-str 0 500) "...")
-                         body-str))
-             "firecrawl"))))
+      (raise-tool-error (format "API request failed (~a): ~a"
+                                code
+                                (if (> (string-length body-str) 500)
+                                    (string-append (substring body-str 0 500) "...")
+                                    body-str))
+                        "firecrawl"))))
 
 (define (firecrawl-request method path [body #f])
   ;; Make an HTTP request to the Firecrawl API. Returns parsed JSON response.
   (define api-key (firecrawl-api-key))
   (unless (and api-key (> (string-length api-key) 0))
     (raise-tool-error
-           "No API key found. Set FIRECRAWL_API_KEY environment variable or add firecrawl.api-key to $HOME/.q/config.json"
-           "firecrawl"))
+     "No API key found. Set FIRECRAWL_API_KEY environment variable or add firecrawl.api-key to $HOME/.q/config.json"
+     "firecrawl"))
   (define url-str (string-append (string-trim (firecrawl-base-url) "/") path))
   (define uri (string->url url-str))
   (define host (url-host uri))
@@ -116,27 +115,20 @@
           "Accept: application/json"))
   (define-values (status-line response-headers response-port)
     (if body
-        (http-sendrecv host path-str
+        (http-sendrecv host
+                       path-str
                        #:port req-port
                        #:ssl? ssl?
                        #:method method
                        #:headers headers
                        #:data (jsexpr->bytes body))
-        (http-sendrecv host path-str
-                       #:port req-port
-                       #:ssl? ssl?
-                       #:method method
-                       #:headers headers)))
+        (http-sendrecv host path-str #:port req-port #:ssl? ssl? #:method method #:headers headers)))
   (define response-body (port->bytes response-port))
   (check-status! status-line response-body)
   (bytes->jsexpr response-body))
 
 (define (url-path->string uri)
-  (string-append "/"
-                 (string-join
-                  (map (lambda (p) (path/param-path p))
-                       (url-path uri))
-                 "/")))
+  (string-append "/" (string-join (map (lambda (p) (path/param-path p)) (url-path uri)) "/")))
 
 ;; ============================================================
 ;; Action implementations
@@ -144,106 +136,96 @@
 
 (define (do-search query formats limit only-main-content)
   (define body
-    (make-hash
-     (list (cons 'query query)
-           (cons 'limit limit)
-           (cons 'scrapeOptions
-                 (make-hash
-                  (list (cons 'formats (or formats '("markdown")))
-                        (cons 'onlyMainContent only-main-content)))))))
+    (make-hash (list (cons 'query query)
+                     (cons 'limit limit)
+                     (cons 'scrapeOptions
+                           (make-hash (list (cons 'formats (or formats '("markdown")))
+                                            (cons 'onlyMainContent only-main-content)))))))
   (define resp (firecrawl-request "POST" "/search" body))
   (define success? (hash-ref resp 'success #t))
   (if (not success?)
-      (make-error-result
-       (format "Search failed: ~a" (hash-ref resp 'error "unknown error")))
+      (make-error-result (format "Search failed: ~a" (hash-ref resp 'error "unknown error")))
       (let* ([data (hash-ref resp 'data '())]
-             [results (if (list? data) data '())]
+             [results (if (list? data)
+                          data
+                          '())]
              [formatted (format-search-results results)])
-        (make-success-result
-         (list (hasheq 'type "text" 'text formatted))
-         (hasheq 'action "search"
-                 'result-count (length results)
-                 'query query)))))
+        (make-success-result (list (hasheq 'type "text" 'text formatted))
+                             (hasheq 'action "search" 'result-count (length results) 'query query)))))
 
 (define (format-search-results results)
   (if (null? results)
       "No results found."
-      (string-join
-       (for/list ([r (in-list results)]
-                  [i (in-naturals 1)])
-         (define title (hash-ref r 'title "(no title)"))
-         (define url (hash-ref r 'url ""))
-         (define desc (hash-ref r 'description ""))
-         (define content (hash-ref r 'markdown (hash-ref r 'content "")))
-         (format "[~a] ~a\n~a\n~a\n~a"
-                 i title url desc
-                 (if (and content (not (string=? content "")))
-                     (string-append "\n" (truncate-string content 10000))
-                     "")))
-       "\n\n---\n\n")))
+      (string-join (for/list ([r (in-list results)]
+                              [i (in-naturals 1)])
+                     (define title (hash-ref r 'title "(no title)"))
+                     (define url (hash-ref r 'url ""))
+                     (define desc (hash-ref r 'description ""))
+                     (define content (hash-ref r 'markdown (hash-ref r 'content "")))
+                     (format "[~a] ~a\n~a\n~a\n~a"
+                             i
+                             title
+                             url
+                             desc
+                             (if (and content (not (string=? content "")))
+                                 (string-append "\n" (truncate-string content 10000))
+                                 "")))
+                   "\n\n---\n\n")))
 
 (define (do-scrape url formats only-main-content)
-  (with-handlers ([exn:fail? (lambda (e)
-                               (make-error-result (exn-message e)))])
+  (with-handlers ([exn:fail? (lambda (e) (make-error-result (exn-message e)))])
     (validate-url url)
     (define body
-      (make-hash
-       (list (cons 'url url)
-             (cons 'formats (or formats '("markdown")))
-             (cons 'onlyMainContent only-main-content))))
+      (make-hash (list (cons 'url url)
+                       (cons 'formats (or formats '("markdown")))
+                       (cons 'onlyMainContent only-main-content))))
     (define resp (firecrawl-request "POST" "/scrape" body))
     (define success? (hash-ref resp 'success #t))
     (if (not success?)
-        (make-error-result
-         (format "Scrape failed: ~a" (hash-ref resp 'error "unknown error")))
+        (make-error-result (format "Scrape failed: ~a" (hash-ref resp 'error "unknown error")))
         (let* ([data (hash-ref resp 'data (hasheq))]
                [markdown (hash-ref data 'markdown "")]
                [html (hash-ref data 'html "")]
                [metadata (hash-ref data 'metadata (hasheq))]
                [title (hash-ref metadata 'title "")]
                [desc (hash-ref metadata 'description "")]
-               [chosen-content (cond
-                                 [(and formats (member "html" formats)) html]
-                                 [(and formats (member "rawHtml" formats))
-                                  (hash-ref data 'rawHtml "")]
-                                 [else markdown])])
-          (make-success-result
-           (list (hasheq 'type "text"
-                         'text (format "Title: ~a\nURL: ~a\nDescription: ~a\n\n~a"
-                                       title url desc
-                                       (truncate-string chosen-content 50000))))
-           (hasheq 'action "scrape"
-                   'url url
-                   'title title))))))
+               [chosen-content
+                (cond
+                  [(and formats (member "html" formats)) html]
+                  [(and formats (member "rawHtml" formats)) (hash-ref data 'rawHtml "")]
+                  [else markdown])])
+          (make-success-result (list (hasheq 'type
+                                             "text"
+                                             'text
+                                             (format "Title: ~a\nURL: ~a\nDescription: ~a\n\n~a"
+                                                     title
+                                                     url
+                                                     desc
+                                                     (truncate-string chosen-content 50000))))
+                               (hasheq 'action "scrape" 'url url 'title title))))))
 
 (define (do-crawl url formats limit timeout-secs only-main-content)
-  (with-handlers ([exn:fail? (lambda (e)
-                               (make-error-result (exn-message e)))])
+  (with-handlers ([exn:fail? (lambda (e) (make-error-result (exn-message e)))])
     ;; Validate URL before starting crawl
     (validate-url url)
     ;; Start crawl job
-  (define body
-    (make-hash
-     (list (cons 'url url)
-           (cons 'limit limit)
-           (cons 'scrapeOptions
-                 (make-hash
-                  (list (cons 'formats (or formats '("markdown")))
-                        (cons 'onlyMainContent only-main-content)))))))
-  (define start-resp (firecrawl-request "POST" "/crawl" body))
-  (define job-id (hash-ref start-resp 'id #f))
-  (unless job-id
-    (raise-tool-error (format "Crawl did not return a job ID: ~a" start-resp) "firecrawl"))
-  ;; Poll for completion
-  (define deadline (+ (current-seconds) timeout-secs))
-  (define results (poll-crawl-status job-id deadline))
-  (define formatted (format-crawl-results results))
-  (make-success-result
-   (list (hasheq 'type "text" 'text formatted))
-   (hasheq 'action "crawl"
-           'url url
-           'job-id job-id
-           'result-count (length results)))))
+    (define body
+      (make-hash (list (cons 'url url)
+                       (cons 'limit limit)
+                       (cons 'scrapeOptions
+                             (make-hash (list (cons 'formats (or formats '("markdown")))
+                                              (cons 'onlyMainContent only-main-content)))))))
+    (define start-resp (firecrawl-request "POST" "/crawl" body))
+    (define job-id (hash-ref start-resp 'id #f))
+    (unless job-id
+      (raise-tool-error (format "Crawl did not return a job ID: ~a" start-resp) "firecrawl"))
+    ;; Poll for completion
+    (define deadline (+ (current-seconds) timeout-secs))
+    (define results (poll-crawl-status job-id deadline))
+    (define formatted (format-crawl-results results))
+    (make-success-result
+     (list (hasheq 'type "text" 'text formatted))
+     (hasheq 'action "crawl" 'url url 'job-id job-id 'result-count (length results)))))
 
 (define (poll-crawl-status job-id deadline)
   (if (> (current-seconds) deadline)
@@ -254,67 +236,59 @@
                        (firecrawl-request "GET" (format "/crawl/~a" job-id)))]
                [status (hash-ref resp 'status "unknown")])
           (cond
-            [(equal? status "completed")
-             (hash-ref resp 'data '())]
-            [(equal? status "failed")
-             '()]
-            [(> (current-seconds) deadline)
-             (hash-ref resp 'data '())]
-            [else
-             (poll-crawl-status job-id deadline)])))))
+            [(equal? status "completed") (hash-ref resp 'data '())]
+            [(equal? status "failed") '()]
+            [(> (current-seconds) deadline) (hash-ref resp 'data '())]
+            [else (poll-crawl-status job-id deadline)])))))
 
 (define (format-crawl-results results)
   (if (null? results)
       "Crawl completed but no results were returned."
-      (string-join
-       (for/list ([r (in-list results)]
-                  [i (in-naturals 1)])
-         (define metadata (hash-ref r 'metadata (hasheq)))
-         (define title (hash-ref metadata 'title "(no title)"))
-         (define url (hash-ref metadata 'sourceURL (hash-ref metadata 'url "")))
-         (define content (hash-ref r 'markdown (hash-ref r 'content "")))
-         (format "[~a] ~a\n~a\n~a"
-                 i title url
-                 (if (and content (not (string=? content "")))
-                     (string-append "\n" (truncate-string content 10000))
-                     "")))
-       "\n\n---\n\n")))
+      (string-join (for/list ([r (in-list results)]
+                              [i (in-naturals 1)])
+                     (define metadata (hash-ref r 'metadata (hasheq)))
+                     (define title (hash-ref metadata 'title "(no title)"))
+                     (define url (hash-ref metadata 'sourceURL (hash-ref metadata 'url "")))
+                     (define content (hash-ref r 'markdown (hash-ref r 'content "")))
+                     (format "[~a] ~a\n~a\n~a"
+                             i
+                             title
+                             url
+                             (if (and content (not (string=? content "")))
+                                 (string-append "\n" (truncate-string content 10000))
+                                 "")))
+                   "\n\n---\n\n")))
 
 (define (do-map url)
-  (with-handlers ([exn:fail? (lambda (e)
-                               (make-error-result (exn-message e)))])
+  (with-handlers ([exn:fail? (lambda (e) (make-error-result (exn-message e)))])
     (validate-url url)
     (define body (make-hash (list (cons 'url url))))
     (define resp (firecrawl-request "POST" "/map" body))
     (define success? (hash-ref resp 'success #t))
     (if (not success?)
-        (make-error-result
-         (format "Map failed: ~a" (hash-ref resp 'error "unknown error")))
+        (make-error-result (format "Map failed: ~a" (hash-ref resp 'error "unknown error")))
         (let* ([links (hash-ref resp 'links '())]
                [formatted (string-join links "\n")])
           (make-success-result
-           (list (hasheq 'type "text"
-                         'text (format "Found ~a URLs at ~a:\n~a"
-                                       (length links) url formatted)))
-           (hasheq 'action "map"
-                   'url url
-                   'link-count (length links)))))))
+           (list (hasheq 'type
+                         "text"
+                         'text
+                         (format "Found ~a URLs at ~a:\n~a" (length links) url formatted)))
+           (hasheq 'action "map" 'url url 'link-count (length links)))))))
 
 ;; ============================================================
 ;; Helpers
 ;; ============================================================
 
+;; Backward-compatible alias using shared truncation
 (define (truncate-string s max-len)
-  (if (> (string-length s) max-len)
-      (string-append (substring s 0 max-len) "\n...(truncated)")
-      s))
+  (truncate-to-n-chars s max-len))
 
 (define (valid-action? s)
   (member s '("search" "scrape" "crawl" "map")))
 
 (define (valid-formats? fmts)
-  (and (list? fmts)
-       (andmap (lambda (f) (member f '("markdown" "html" "rawHtml"))) fmts)))
+  (and (list? fmts) (andmap (lambda (f) (member f '("markdown" "html" "rawHtml"))) fmts)))
 
 ;; ============================================================
 ;; Main tool function
@@ -329,8 +303,7 @@
      (make-error-result "Missing required parameter 'action'. Use: search, scrape, crawl, or map")]
 
     [(not (valid-action? action))
-     (make-error-result
-      (format "Invalid action '~a'. Use: search, scrape, crawl, or map" action))]
+     (make-error-result (format "Invalid action '~a'. Use: search, scrape, crawl, or map" action))]
 
     ;; ---- SEARCH ----
     [(string=? action "search")
@@ -375,5 +348,4 @@
        (raise-tool-error "map requires 'url' parameter" "firecrawl"))
      (do-map url)]
 
-    [else
-     (make-error-result (format "Unhandled action: ~a" action))]))
+    [else (make-error-result (format "Unhandled action: ~a" action))]))

--- a/tools/builtins/read.rkt
+++ b/tools/builtins/read.rkt
@@ -6,16 +6,13 @@
          racket/list
          racket/dict
          (only-in "../tool.rkt" make-success-result make-error-result)
-         (only-in "../../util/path-helpers.rkt" contains-null-bytes? bytes->display-lines expand-home-path)
-         (only-in "../../util/truncation.rkt" truncate-output))
+         (only-in "../../util/path-helpers.rkt"
+                  contains-null-bytes?
+                  bytes->display-lines
+                  expand-home-path)
+         (only-in "../../util/truncation.rkt" truncate-output MAX-OUTPUT-BYTES MAX-OUTPUT-LINES))
 
 (provide tool-read)
-
-;; Default maximum number of lines to return
-(define DEFAULT-MAX-LINES 2000)
-
-;; Maximum total bytes for output content
-(define DEFAULT-MAX-BYTES 50000)
 
 ;; Format a single numbered line
 (define (format-line n text)
@@ -59,7 +56,7 @@
 
              [else
               ;; 5. Apply offset/limit
-              (define max-lines (or limit DEFAULT-MAX-LINES))
+              (define max-lines (or limit MAX-OUTPUT-LINES))
               (define start-idx (max 0 (sub1 offset)))
               (define end-idx (min total-lines (+ start-idx max-lines)))
 
@@ -80,11 +77,10 @@
 
                  (define joined (string-join formatted "\n"))
                  (define result-text
-                   (if (> (string-length joined) DEFAULT-MAX-BYTES)
-                       (string-append (substring joined 0 DEFAULT-MAX-BYTES)
-                                      "\n[SYS] Output truncated at "
-                                      (number->string DEFAULT-MAX-BYTES)
-                                      " bytes]")
+                   (if (> (string-length joined) MAX-OUTPUT-BYTES)
+                       (string-append (substring joined 0 MAX-OUTPUT-BYTES)
+                                      (format "\n[Output truncated. ~a bytes omitted]"
+                                              (- (string-length joined) MAX-OUTPUT-BYTES)))
                        joined))
 
                  (make-success-result (list (string-append result-text "\n"))

--- a/util/truncation.rkt
+++ b/util/truncation.rkt
@@ -5,30 +5,34 @@
 ;;; Provides:
 ;;;   MAX-OUTPUT-BYTES  — maximum output size in bytes (50KB)
 ;;;   MAX-OUTPUT-LINES  — maximum number of output lines (2000)
+;;;   MAX-OUTPUT-CHARS  — maximum output size in characters (50K)
 ;;;   truncate-output   — truncate to limits with notice
 ;;;   truncate-to-n-lines — keep first N lines with notice
+;;;   truncate-to-n-chars — keep first N chars with notice
 ;;;   output-exceeds-limits? — check if output exceeds limits
 ;;;
-;;; #774
+;;; #774, #1115
 
 (require racket/string
          racket/match)
 
 (provide MAX-OUTPUT-BYTES
          MAX-OUTPUT-LINES
+         MAX-OUTPUT-CHARS
          truncate-output
          truncate-to-n-lines
+         truncate-to-n-chars
          output-exceeds-limits?)
 
 ;; Constants
-(define MAX-OUTPUT-BYTES 50000)   ; 50KB
+(define MAX-OUTPUT-BYTES 50000) ; 50KB
 (define MAX-OUTPUT-LINES 2000)
+(define MAX-OUTPUT-CHARS 50000) ; 50K characters
 
 ;; Check if output exceeds limits
 ;; string? -> boolean?
 (define (output-exceeds-limits? str)
-  (or (> (string-length str) MAX-OUTPUT-BYTES)
-      (> (count-lines str) MAX-OUTPUT-LINES)))
+  (or (> (string-length str) MAX-OUTPUT-BYTES) (> (count-lines str) MAX-OUTPUT-LINES)))
 
 ;; Truncate output to standard limits.
 ;; If within limits, returns str unchanged.
@@ -38,16 +42,13 @@
   (define byte-count (string-length str))
   (define line-count (count-lines str))
   (cond
-    [(and (<= byte-count MAX-OUTPUT-BYTES) (<= line-count MAX-OUTPUT-LINES))
-     str]
-    [(> line-count MAX-OUTPUT-LINES)
-     (truncate-to-n-lines str MAX-OUTPUT-LINES)]
+    [(and (<= byte-count MAX-OUTPUT-BYTES) (<= line-count MAX-OUTPUT-LINES)) str]
+    [(> line-count MAX-OUTPUT-LINES) (truncate-to-n-lines str MAX-OUTPUT-LINES)]
     [else
      ;; Over byte limit but within line limit — truncate bytes
      (define truncated (substring str 0 MAX-OUTPUT-BYTES))
      (define omitted (- byte-count MAX-OUTPUT-BYTES))
-     (string-append truncated
-                    (format "\n[Output truncated. ~a bytes omitted]" omitted))]))
+     (string-append truncated (format "\n[Output truncated. ~a bytes omitted]" omitted))]))
 
 ;; Truncate to first N lines with notice.
 ;; string? exact-nonnegative-integer? -> string?
@@ -59,8 +60,14 @@
       (let* ([kept (take lines n)]
              [omitted (- total-lines n)]
              [result (string-join kept "\n")])
-        (string-append result
-                       (format "\n[Output truncated. ~a lines omitted]" omitted)))))
+        (string-append result (format "\n[Output truncated. ~a lines omitted]" omitted)))))
+
+;; Truncate to first N characters with notice.
+;; string? exact-nonnegative-integer? -> string?
+(define (truncate-to-n-chars str max-chars)
+  (if (<= (string-length str) max-chars)
+      str
+      (string-append (substring str 0 max-chars) "\n...(truncated)")))
 
 ;; Count lines in a string
 (define (count-lines str)


### PR DESCRIPTION
## Wave 2 of v0.10.6

### Changes
- #1113: Add import-session! to session store
- #1114: Expose provider-registry through extension context
- #1115: Centralize output truncation constants
- Fix test-hook-expansion.rkt for 12-field extension-ctx struct

### Testing
- All Wave 2 tests pass
- Pre-commit hooks pass
- 13 pre-existing TUI selection failures (not from this PR)

Refs: #1112, #1113, #1114, #1115