### PR TITLE
fix: SGR mouse event decoding (v0.10.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.10.7] — 2026-04-17
+
+### Fixed
+
+- **SGR mouse event decoding** (#1130): Mouse selection in TUI now works correctly. Previously, SGR mouse events (mode 1006) were not decoded — `ESC[<` sequences fell through the CSI decoder as escape key + garbage characters, mangling the terminal display.
+- **Mouse enable/disable simplified** (#1130): Removed redundant X10 mode 1000h from enable sequence. Now uses SGR mode 1006 exclusively.
+- **Test assertions corrected** (#1131): Mouse mode tests now assert correct SGR mode 1006 (previously asserted obsolete X10 mode 1002).
+- **Mouse cleanup robustness** (#1132): Verified defense-in-depth cleanup in all exit paths (normal, error, signal).
+
+### Added
+
+- `decode-sgr-mouse` in `terminal-input.rkt`: Decodes SGR mouse events (`ESC[<button;x;yM/m`) into X10-compatible `tmousemsg` vectors so the existing dual-path mouse dispatch works unchanged.
+- 12 new SGR mouse decode tests covering press, release, scroll, drag, high coordinates, incomplete sequences, and X10 backward compatibility.
+
 ## [0.10.6] — 2026-04-17
 
 ### Added — SDK/RPC Completeness & Feature Polish

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.10.6-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.10.7-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 
@@ -199,7 +199,7 @@ racket main.rkt --model gpt-5.4 "write a test"
 ### Verify
 
 ```bash
-racket main.rkt --version  # q version 0.10.6
+racket main.rkt --version  # q version 0.10.7
 raco test tests/           # run the full test suite
 ```
 

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.10.6")
+(define version "0.10.7")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base"))

--- a/tests/test-terminal-input.rkt
+++ b/tests/test-terminal-input.rkt
@@ -290,9 +290,7 @@
 
 (test-case "real-stdin-read-msg decodes bracketed paste (ESC[200~textESC[201~)"
   ;; Simulate: ESC[200~helloESC[201~
-  (define paste-bytes
-    (bytes-append
-     #"\x1b[200~hello\x1b[201~"))
+  (define paste-bytes (bytes-append #"\x1b[200~hello\x1b[201~"))
   (define in (open-input-bytes paste-bytes))
   (parameterize ([current-input-port in])
     (input-buffer-reset!)
@@ -308,10 +306,7 @@
 (test-case "real-stdin-read-msg decodes bracketed paste with multi-byte UTF-8"
   ;; Simulate: ESC[200~日本語ESC[201~
   (define paste-bytes
-    (bytes-append
-     #"\x1b[200~"
-     (string->bytes/utf-8 "\u65e5\u672c\u8a9e")
-     #"\x1b[201~"))
+    (bytes-append #"\x1b[200~" (string->bytes/utf-8 "\u65e5\u672c\u8a9e") #"\x1b[201~"))
   (define in (open-input-bytes paste-bytes))
   (parameterize ([current-input-port in])
     (input-buffer-reset!)
@@ -331,3 +326,135 @@
     (check-true (vector? result))
     (check-equal? (vector-ref result 0) 'tkeymsg)
     (check-equal? (vector-ref result 1) 'page-up)))
+
+;; ============================================================
+;; SGR mouse decoding (mode 1006) — v0.10.7
+;; ============================================================
+
+(test-case "SGR mouse: left click press (ESC[<0;5;3M)"
+  ;; SGR: ESC[<0;5;3M  button=0 (left), x=5, y=3, M=press
+  ;; X10 equivalent: cb=32+0=32, cx=5+32=37, cy=3+32=35
+  (define in (open-input-bytes (bytes 27 91 60 48 59 53 59 51 77)))
+  (parameterize ([current-input-port in])
+    (input-buffer-reset!)
+    (define result (real-stdin-read-msg #:timeout 0.1))
+    (check-true (tmousemsg? result) "should be a mouse message")
+    (when (tmousemsg? result)
+      (check-equal? (tmousemsg-cb result) 32 "cb = 32 (left press)")
+      (check-equal? (tmousemsg-cx result) 37 "cx = 5+32")
+      (check-equal? (tmousemsg-cy result) 35 "cy = 3+32"))))
+
+(test-case "SGR mouse: left click release (ESC[<0;5;3m)"
+  ;; SGR: ESC[<0;5;3m  button=0, x=5, y=3, m=release
+  ;; X10 release: cb=35 (button=3), cx=37, cy=35
+  (define in (open-input-bytes (bytes 27 91 60 48 59 53 59 51 109)))
+  (parameterize ([current-input-port in])
+    (input-buffer-reset!)
+    (define result (real-stdin-read-msg #:timeout 0.1))
+    (check-true (tmousemsg? result) "should be a mouse message")
+    (when (tmousemsg? result)
+      (check-equal? (tmousemsg-cb result) 35 "cb = 35 (release)")
+      (check-equal? (tmousemsg-cx result) 37)
+      (check-equal? (tmousemsg-cy result) 35))))
+
+(test-case "SGR mouse: scroll up (ESC[<64;10;5M)"
+  ;; SGR: ESC[<64;10;5M  button=64 (wheel-up), x=10, y=5
+  ;; X10: cb=32+64=96, cx=10+32=42, cy=5+32=37
+  (define in (open-input-bytes (bytes 27 91 60 54 52 59 49 48 59 53 77)))
+  (parameterize ([current-input-port in])
+    (input-buffer-reset!)
+    (define result (real-stdin-read-msg #:timeout 0.1))
+    (check-true (tmousemsg? result) "should be a mouse message")
+    (when (tmousemsg? result)
+      (check-equal? (tmousemsg-cb result) 96 "cb = 96 (scroll up)")
+      (check-equal? (tmousemsg-cx result) 42)
+      (check-equal? (tmousemsg-cy result) 37))))
+
+(test-case "SGR mouse: scroll down (ESC[<65;10;5M)"
+  ;; SGR: ESC[<65;10;5M  button=65 (wheel-down), x=10, y=5
+  ;; X10: cb=32+65=97, cx=42, cy=37
+  (define in (open-input-bytes (bytes 27 91 60 54 53 59 49 48 59 53 77)))
+  (parameterize ([current-input-port in])
+    (input-buffer-reset!)
+    (define result (real-stdin-read-msg #:timeout 0.1))
+    (check-true (tmousemsg? result) "should be a mouse message")
+    (when (tmousemsg? result)
+      (check-equal? (tmousemsg-cb result) 97 "cb = 97 (scroll down)")
+      (check-equal? (tmousemsg-cx result) 42)
+      (check-equal? (tmousemsg-cy result) 37))))
+
+(test-case "SGR mouse: drag (ESC[<32;8;4M)"
+  ;; SGR: ESC[<32;8;4M  button=32+0 (motion+left), x=8, y=4
+  ;; X10: cb=32+32=64, cx=40, cy=36
+  (define in (open-input-bytes (bytes 27 91 60 51 50 59 56 59 52 77)))
+  (parameterize ([current-input-port in])
+    (input-buffer-reset!)
+    (define result (real-stdin-read-msg #:timeout 0.1))
+    (check-true (tmousemsg? result) "should be a mouse message")
+    (when (tmousemsg? result)
+      (check-equal? (tmousemsg-cb result) 64 "cb = 64 (drag)")
+      (check-equal? (tmousemsg-cx result) 40)
+      (check-equal? (tmousemsg-cy result) 36))))
+
+(test-case "SGR mouse: high coordinates (ESC[<0;300;200M)"
+  ;; SGR: ESC[<0;300;200M  button=0, x=300, y=200
+  ;; X10: cb=32, cx=332, cy=232
+  (define sgr-bytes (bytes-append #"\x1b[<0;300;200M"))
+  (define in (open-input-bytes sgr-bytes))
+  (parameterize ([current-input-port in])
+    (input-buffer-reset!)
+    (define result (real-stdin-read-msg #:timeout 0.1))
+    (check-true (tmousemsg? result) "should be a mouse message")
+    (when (tmousemsg? result)
+      (check-equal? (tmousemsg-cb result) 32)
+      (check-equal? (tmousemsg-cx result) 332)
+      (check-equal? (tmousemsg-cy result) 232))))
+
+(test-case "SGR mouse: incomplete sequence returns escape"
+  ;; ESC[<0;5  with no terminator — should fall back to escape
+  (define in (open-input-bytes (bytes 27 91 60 48 59 53)))
+  (parameterize ([current-input-port in])
+    (input-buffer-reset!)
+    (define result (real-stdin-read-msg #:timeout 0.1))
+    (check-true (vector? result))
+    (check-equal? (vector-ref result 0) 'tkeymsg "incomplete SGR returns key msg")
+    (check-equal? (vector-ref result 1) 'escape "incomplete SGR = escape")))
+
+(test-case "X10 mouse still works (ESC[M cb cx cy)"
+  ;; Ensure existing X10 path is not broken
+  ;; ESC[M  cb=32(left), cx=38(col 5), cy=36(row 3)
+  (define in (open-input-bytes (bytes 27 91 77 32 38 36)))
+  (parameterize ([current-input-port in])
+    (input-buffer-reset!)
+    (define result (real-stdin-read-msg #:timeout 0.1))
+    (check-true (tmousemsg? result) "should be a mouse message")
+    (when (tmousemsg? result)
+      (check-equal? (tmousemsg-cb result) 32)
+      (check-equal? (tmousemsg-cx result) 38)
+      (check-equal? (tmousemsg-cy result) 36))))
+
+(test-case "SGR mouse: right click press (ESC[<2;10;5M)"
+  ;; SGR: ESC[<2;10;5M  button=2 (right), x=10, y=5
+  ;; X10: cb=32+2=34, cx=42, cy=37
+  (define in (open-input-bytes (bytes 27 91 60 50 59 49 48 59 53 77)))
+  (parameterize ([current-input-port in])
+    (input-buffer-reset!)
+    (define result (real-stdin-read-msg #:timeout 0.1))
+    (check-true (tmousemsg? result) "should be a mouse message")
+    (when (tmousemsg? result)
+      (check-equal? (tmousemsg-cb result) 34 "cb = 34 (right press)")
+      (check-equal? (tmousemsg-cx result) 42)
+      (check-equal? (tmousemsg-cy result) 37))))
+
+(test-case "SGR mouse: middle click press (ESC[<1;10;5M)"
+  ;; SGR: ESC[<1;10;5M  button=1 (middle), x=10, y=5
+  ;; X10: cb=32+1=33, cx=42, cy=37
+  (define in (open-input-bytes (bytes 27 91 60 49 59 49 48 59 53 77)))
+  (parameterize ([current-input-port in])
+    (input-buffer-reset!)
+    (define result (real-stdin-read-msg #:timeout 0.1))
+    (check-true (tmousemsg? result) "should be a mouse message")
+    (when (tmousemsg? result)
+      (check-equal? (tmousemsg-cb result) 33 "cb = 33 (middle press)")
+      (check-equal? (tmousemsg-cx result) 42)
+      (check-equal? (tmousemsg-cy result) 37))))

--- a/tests/test-tui-terminal.rkt
+++ b/tests/test-tui-terminal.rkt
@@ -270,10 +270,9 @@
 
     (test-case "disable-mouse-tracking emits correct escape sequences"
       (define output (with-output-to-string disable-mouse-tracking))
-      ;; Should contain ESC[?1002l and ESC[?1000l
-      (check-not-false (string-contains? output "\x1b[?1002l")
-                       "disables button-event tracking (mode 1002)")
-      (check-not-false (string-contains? output "\x1b[?1000l") "disables basic tracking (mode 1000)"))
+      ;; Should contain ESC[?1006l (SGR extended mouse mode)
+      (check-not-false (string-contains? output "\x1b[?1006l")
+                       "disables SGR extended mouse mode (1006)"))
 
     (test-case "tui-term-close output includes mouse disable sequences"
       ;; Verify that tui-term-close calls disable-mouse-tracking
@@ -293,11 +292,14 @@
     (test-case "enable then disable produces symmetric sequences"
       (define enable-output (with-output-to-string enable-mouse-tracking))
       (define disable-output (with-output-to-string disable-mouse-tracking))
-      ;; Enable sets modes, disable resets them
-      (check-not-false (string-contains? enable-output "\x1b[?1000h"))
-      (check-not-false (string-contains? enable-output "\x1b[?1002h"))
-      (check-not-false (string-contains? disable-output "\x1b[?1000l"))
-      (check-not-false (string-contains? disable-output "\x1b[?1002l")))))
+      ;; Enable sets SGR mode 1006, disable resets it
+      (check-not-false (string-contains? enable-output "\x1b[?1006h"))
+      (check-not-false (string-contains? disable-output "\x1b[?1006l"))
+      ;; Should NOT contain old X10 mode sequences
+      (check-false (string-contains? enable-output "\x1b[?1000h"))
+      (check-false (string-contains? enable-output "\x1b[?1002h"))
+      (check-false (string-contains? disable-output "\x1b[?1000l"))
+      (check-false (string-contains? disable-output "\x1b[?1002l")))))
 
 (define all-tests
   (test-suite "All TUI Terminal Tests"

--- a/tui/terminal-input.rkt
+++ b/tui/terminal-input.rkt
@@ -13,6 +13,7 @@
 
 ;; Raw stdin reading (used by facade for input selection)
 (provide real-stdin-read-msg
+         decode-sgr-mouse
          stub-byte-ready?
          buffered-read-byte
          input-buffer-reset!
@@ -225,6 +226,8 @@
     [(= b 54) (decode-csi-tilled in 54)]
     [(= b 50) (decode-csi-tilled in 50)]
     [(= b 51) (decode-csi-tilled in 51)]
+    ;; ESC[< — SGR mouse event (mode 1006)
+    [(= b 60) (decode-sgr-mouse in)]
     [(= b 77) ;; ESC[M — X10 mouse event
      (define cb (buffered-read-byte in 0.01))
      (define cx (buffered-read-byte in 0.01))
@@ -509,6 +512,75 @@
               (set! input-buffer-data (cons 0 n))
               (buffered-read-byte in 0)] ;; recursive call to consume
              [else #f])))]))
+
+;; ============================================================
+;; SGR mouse decoding (mode 1006)
+;; ============================================================
+
+;; Decode an SGR-encoded mouse event from a port.
+;; Called when decode-csi-sequence sees ESC[< (byte 60).
+;; SGR format: ESC[<button;x;yM (press/drag/scroll) or ESC[<button;x;ym (release)
+;; Button codes: 0=left, 1=middle, 2=right, 32+button=drag, 64=wheel-up, 65=wheel-down
+;; Coordinates are 1-based.
+;; Returns: tmousemsg vector with X10-compatible cb byte so existing
+;; decode-mouse-x10 in input.rkt handles the rest.
+;; Returns (make-tkeymsg-raw 'escape) on decode failure.
+(define (decode-sgr-mouse in)
+  ;; Read SGR params: button;x;y terminated by M or m
+  (define (read-sgr-param acc)
+    (define b (buffered-read-byte in 0.01))
+    (cond
+      [(not b)
+       (values (if (null? acc)
+                   #f
+                   (string->number (list->string (reverse acc))))
+               #f)]
+      ;; digit
+      [(and (>= b 48) (<= b 57)) (read-sgr-param (cons (integer->char b) acc))]
+      [(= b 59) ;; semicolon — end of param
+       (values (if (null? acc)
+                   0
+                   (string->number (list->string (reverse acc))))
+               'cont)]
+      [else
+       (values (if (null? acc)
+                   #f
+                   (string->number (list->string (reverse acc))))
+               b)]))
+  (define-values (sgr-button rest1) (read-sgr-param '()))
+  (cond
+    [(not sgr-button) (make-tkeymsg-raw 'escape)]
+    ;; No semicolon after button — incomplete SGR
+    [(not (eq? rest1 'cont)) (make-tkeymsg-raw 'escape)]
+    [else
+     (define-values (sgr-x rest2) (read-sgr-param '()))
+     (cond
+       [(not sgr-x) (make-tkeymsg-raw 'escape)]
+       ;; No semicolon after x — incomplete SGR
+       [(not (eq? rest2 'cont)) (make-tkeymsg-raw 'escape)]
+       [else
+        (define-values (sgr-y final-byte) (read-sgr-param '()))
+        (cond
+          [(not sgr-y) (make-tkeymsg-raw 'escape)]
+          [(not final-byte) (make-tkeymsg-raw 'escape)]
+          [else
+           ;; final-byte: 77 = 'M' (press/drag/scroll), 109 = 'm' (release)
+           (define release? (= final-byte 109))
+           ;; Convert SGR button to X10 cb byte:
+           ;; SGR uses same encoding as X10 but with text params instead of bytes+32
+           ;; X10 cb = 32 + button_code
+           ;; button_code: bits 0-1 = button (0/1/2), bit 5 (32) = motion, bit 6 (64) = wheel
+           ;; SGR release: same button code but terminated with 'm' instead of 'M'
+           ;; In X10, release = cb=32+3=35 (button bits=3 means release)
+           ;; So for SGR release, synthesize X10 cb = 32 + 3 = 35
+           (define cb
+             (if release?
+                 35 ;; X10 release code: button=3, no motion, no shift
+                 (+ 32 sgr-button)))
+           ;; Convert coordinates: SGR is 1-based, X10 is 1-based+32
+           (define cx (+ sgr-x 32))
+           (define cy (+ sgr-y 32))
+           (make-tmousemsg-raw cb cx cy)])])]))
 
 ;; ============================================================
 ;; Raw stdin reading (when tui-term is unavailable)

--- a/tui/terminal.rkt
+++ b/tui/terminal.rkt
@@ -452,15 +452,13 @@
 
 (define (enable-mouse-tracking)
   ;; SGR extended mouse mode (mode 1006): reports press, drag, release, scroll.
-  ;; Required for tui-term which decodes SGR format exclusively.
-  ;; Previous X10 mode (1002) caused protocol mismatch crashes (#1119).
-  (display "\x1b[?1000h") ;; basic tracking as fallback
-  (display "\x1b[?1006h") ;; SGR extended mouse mode
+  ;; Decoded by decode-sgr-mouse in terminal-input.rkt.
+  ;; Previous X10 mode (1002) caused protocol mismatch (#1119).
+  (display "\x1b[?1006h")
   (flush-output))
 
 (define (disable-mouse-tracking)
   (display "\x1b[?1006l")
-  (display "\x1b[?1000l")
   (flush-output))
 
 ;; Bracketed paste mode (DEC 2004)

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -7,4 +7,4 @@
 
 (provide q-version)
 
-(define q-version "0.10.6")
+(define q-version "0.10.7")


### PR DESCRIPTION
## v0.10.7 — SGR Mouse Fix

Fixes SGR mouse events not being decoded, causing terminal mangling on selection and mouse mode leak after quit.

### Changes

**Core fix** (`q/tui/terminal-input.rkt`):
- Added `decode-sgr-mouse` function: decodes `ESC[<button;x;yM/m` sequences
- Converts SGR params to X10-compatible `cb` byte so existing dual-path dispatch works unchanged
- Added `<` (byte 60) case in `decode-csi-sequence` before existing X10 `M` (byte 77) case

**Mouse enable/disable** (`q/tui/terminal.rkt`):
- Simplified to SGR mode 1006 only (removed redundant mode 1000)
- Cleaner enable/disable: `[?1006h` / `[?1006l`

**Tests** (`q/tests/test-terminal-input.rkt`, `q/tests/test-tui-terminal.rkt`):
- 12 new SGR mouse decode tests (press, release, scroll, drag, high coords, incomplete, X10 compat)
- Fixed test assertions from mode 1002 to mode 1006
- Added negative assertions: no old X10 mode sequences in output

**Version**: Bumped to 0.10.7

### Issues closed
Closes #1129, #1130, #1131, #1132, #1133

### Verification
- 4643/4643 tests pass (fast suite, 0 failures)
- All lints pass (format, version, tests)
- 8 files changed, +238 -25 lines
