### PR TITLE
feat: progressive skill disclosure (#1175)

Implement two-tier skill loading: summaries in system prompt,
full content available on-demand via read tool.

- Add skill-summary-text and skills-summary-section functions
- Inject skill summaries into system prompt at runtime
- 9 new tests for progressive disclosure
- Wave 0 of v0.11.0

### DIFF
--- a/skills/resource-loader.rkt
+++ b/skills/resource-loader.rkt
@@ -32,6 +32,13 @@
  load-project-resources
  merge-resources
 
+ ;; Progressive skill disclosure
+ skill-summary-text
+ skills-summary-section
+
+ ;; Parsing (exposed for testing)
+ parse-skill
+
  ;; File reading
  try-read-file)
 
@@ -243,6 +250,38 @@
        (hash-set acc k (deep-merge-hash left-v v))]
       [else
        (hash-set acc k v)])))
+
+;; ============================================================
+;; Progressive Skill Disclosure
+;; ============================================================
+
+;; Format a single skill as a one-line summary for the system prompt.
+;; Includes only name and description — never full content.
+(define (skill->summary-line skill)
+  (define name (hash-ref skill 'name "?"))
+  (define desc (hash-ref skill 'description ""))
+  (if (non-empty-string? desc)
+      (format "- **~a**: ~a" name desc)
+      (format "- **~a**" name)))
+
+;; Produce a compact summary text from a list of skills.
+;; Each skill gets one line: name + description only.
+;; Returns a string suitable for injection into system prompt.
+(define (skill-summary-text skills)
+  (string-join (map skill->summary-line skills) "\n"))
+
+;; Produce a full "Available Skills" section for the system prompt.
+;; Returns #f if no skills (so caller can skip injection entirely).
+;; Tells the agent to use `read` tool to load full SKILL.md on-demand.
+(define (skills-summary-section skills)
+  (cond
+    [(null? skills) #f]
+    [else
+     (define summary-lines (skill-summary-text skills))
+     (string-append
+      "## Available Skills\n\n"
+      "Skills provide specialized instructions. Load the full content with the `read` tool when needed.\n\n"
+      summary-lines)]))
 
 (define (merge-resources global-rs project-rs)
   ;; Merge global + project resources with project taking precedence.

--- a/tests/test-progressive-skills.rkt
+++ b/tests/test-progressive-skills.rkt
@@ -1,0 +1,82 @@
+#lang racket
+
+;; tests/test-progressive-skills.rkt — Progressive Skill Disclosure tests
+;;
+;; Tests for two-tier skill loading: summaries in system prompt,
+;; full content available on-demand.
+
+(require rackunit
+         "../skills/resource-loader.rkt")
+
+;; ============================================================
+;; parse-skill produces name + description + content
+;; ============================================================
+
+(test-case "parse-skill extracts name, description, content"
+  (define raw "# My Skill\n\nThis is the description.\n\nFull content here.\nMore lines.")
+  (define skill (parse-skill "my-skill" raw))
+  (check-equal? (hash-ref skill 'name) "my-skill")
+  (check-equal? (hash-ref skill 'description) "This is the description.")
+  (check-equal? (hash-ref skill 'content) "Full content here.\nMore lines."))
+
+(test-case "parse-skill handles header-only skill"
+  (define raw "# Minimal")
+  (define skill (parse-skill "minimal" raw))
+  (check-equal? (hash-ref skill 'name) "minimal")
+  (check-equal? (hash-ref skill 'description) "")
+  (check-equal? (hash-ref skill 'content) ""))
+
+(test-case "parse-skill handles description-only (no body)"
+  (define raw "# Skill Name\n\nJust a description, no body content.")
+  (define skill (parse-skill "desc-only" raw))
+  (check-equal? (hash-ref skill 'name) "desc-only")
+  (check-equal? (hash-ref skill 'description) "Just a description, no body content.")
+  (check-equal? (hash-ref skill 'content) ""))
+
+;; ============================================================
+;; skill-summary-text — compact summary for system prompt
+;; ============================================================
+
+(test-case "skill-summary-text formats single skill"
+  (define skills (list (hasheq 'name "reviewer"
+                               'description "Read-only code review"
+                               'content "Full content ignored")))
+  (define summary (skill-summary-text skills))
+  (check-true (string-contains? summary "reviewer"))
+  (check-true (string-contains? summary "Read-only code review"))
+  (check-false (string-contains? summary "Full content ignored")))
+
+(test-case "skill-summary-text formats multiple skills"
+  (define skills (list (hasheq 'name "builder" 'description "Build things" 'content "x")
+                       (hasheq 'name "reviewer" 'description "Review things" 'content "y")))
+  (define summary (skill-summary-text skills))
+  (check-true (string-contains? summary "builder"))
+  (check-true (string-contains? summary "reviewer"))
+  (check-true (string-contains? summary "Build things"))
+  (check-true (string-contains? summary "Review things")))
+
+(test-case "skill-summary-text handles empty skill list"
+  (define summary (skill-summary-text '()))
+  (check-equal? summary ""))
+
+(test-case "skill-summary-text handles skill with empty description"
+  (define skills (list (hasheq 'name "bare" 'description "" 'content "full")))
+  (define summary (skill-summary-text skills))
+  (check-true (string-contains? summary "bare")))
+
+;; ============================================================
+;; skills-summary-section — full section for system prompt
+;; ============================================================
+
+(test-case "skills-summary-section produces header + summaries"
+  (define skills (list (hasheq 'name "builder" 'description "Build" 'content "x")
+                       (hasheq 'name "reviewer" 'description "Review" 'content "y")))
+  (define section (skills-summary-section skills))
+  (check-true (string-contains? section "Available Skills"))
+  (check-true (string-contains? section "builder"))
+  (check-true (string-contains? section "reviewer"))
+  ;; Must NOT contain full content
+  (check-false (regexp-match? #rx"On-demand" section)))
+
+(test-case "skills-summary-section returns #f for empty skills"
+  (check-false (skills-summary-section '())))

--- a/wiring/run-modes.rkt
+++ b/wiring/run-modes.rkt
@@ -20,6 +20,7 @@
                   close-session!)
          "../runtime/settings.rkt"
          "../skills/types.rkt"
+         (only-in "../skills/resource-loader.rkt" skills-summary-section)
          "../runtime/model-registry.rkt"
          (only-in "../runtime/provider-factory.rkt" build-provider)
          "../tools/tool.rkt"
@@ -79,6 +80,14 @@
   (define all-resources (merge-resources global-resources project-resources))
   (define system-instrs (resource-set-instructions all-resources))
 
+  ;; Progressive skill disclosure: inject skill summaries into system prompt
+  ;; Full SKILL.md content is available on-demand via the `read` tool
+  (define skill-section (skills-summary-section (resource-set-skills all-resources)))
+  (define final-system-instrs
+    (if skill-section
+        (append system-instrs (list skill-section))
+        system-instrs))
+
   ;; Provider uses the shared settings
   (define prov (build-provider base-config settings))
 
@@ -127,7 +136,7 @@
   (hash-set! base-config 'model-registry model-reg)
   (define effective-model-name (or model-name (default-model model-reg)))
   (hash-set! base-config 'model-name effective-model-name)
-  (hash-set! base-config 'system-instructions system-instrs)
+  (hash-set! base-config 'system-instructions final-system-instrs)
   (hash-set! base-config 'verbose? (cli-config-verbose? cfg))
   base-config)
 


### PR DESCRIPTION
Addresses #1175.

feat: progressive skill disclosure (#1175)

Implement two-tier skill loading: summaries in system prompt,
full content available on-demand via read tool.

- Add skill-summary-text and skills-summary-section functions
- Inject skill summaries into system prompt at runtime
- 9 new tests for progressive disclosure
- Wave 0 of v0.11.0