### PR TITLE
feat: extension polish — RPC UI bridge, bash message type, templates (#1184)

Wave 3 of v0.11.0: three extension and session polish items.

- Wire RPC UI bridge into run-rpc: UI channel + response handler for
  extension dialogs over RPC (confirm/select/input)
- Add bash-execution message kind distinct from tool-result with
  any-tool-result-entry? shared predicate; update cutpoints
- Wire templates into runtime config; add render-template-with-positional-args
  for bash-style $1, $@, ${@:N:L} expansion
- 16 tests across all three sub-issues

Sub-issues: #1185, #1186, #1187

### DIFF
--- a/runtime/compactor.rkt
+++ b/runtime/compactor.rkt
@@ -259,9 +259,9 @@
   (define content (message-content msg))
   (and (list? content) (ormap tool-call-part? content)))
 
-;; Check if a message is a tool-result.
+;; Check if a message is a tool-result or bash-execution.
 (define (tool-result-message? msg)
-  (eq? (message-kind msg) 'tool-result))
+  (memq (message-kind msg) '(tool-result bash-execution)))
 
 ;; Check if placing a cut BEFORE index `idx` is valid.
 ;; A cut at N means messages[0..N) are old, messages[N..] are recent.

--- a/runtime/context-builder.rkt
+++ b/runtime/context-builder.rkt
@@ -108,8 +108,8 @@
     [(eq? kind 'branch-summary) (transform-summary-to-user entry)]
     ;; Filter out metadata entries
     [(memq kind '(session-info model-change thinking-level-change)) #f]
-    ;; Tool results pass through
-    [(eq? kind 'tool-result) entry]
+    ;; Tool results and bash executions pass through
+    [(memq kind '(tool-result bash-execution)) entry]
     ;; System instructions pass through
     [(eq? kind 'system-instruction) entry]
     ;; Custom messages pass through

--- a/runtime/cutpoint-rules.rkt
+++ b/runtime/cutpoint-rules.rkt
@@ -58,9 +58,9 @@
   (and (list? content)
        (ormap tool-call-part? content)))
 
-;; Check if a message is a tool-result.
+;; Check if a message is a tool-result or bash-execution.
 (define (tool-result-message? msg)
-  (eq? (message-kind msg) 'tool-result))
+  (memq (message-kind msg) '(tool-result bash-execution)))
 
 ;; Check if a message is a user message (valid cut point).
 (define (user-message? msg)

--- a/skills/template.rkt
+++ b/skills/template.rkt
@@ -5,10 +5,12 @@
 ;; Split from skills/types.rkt (Issue #205, QUAL-09).
 ;; Contains:
 ;;   render-template — substitute {{var}} placeholders in a template string
+;;   render-template-with-positional-args — bash-style $1, $@, ${@:N:L} expansion
 
 (require racket/string)
 
-(provide render-template)
+(provide render-template
+         render-template-with-positional-args)
 
 ;; ============================================================
 ;; Template rendering
@@ -26,3 +28,47 @@
    template-string
    (λ (match var-name)
      (hash-ref var-map (string-trim var-name) match))))
+
+;; ============================================================
+;; Bash-style positional arg expansion (#1187)
+;; ============================================================
+
+;; Expand bash-style positional arguments in a template string.
+;; Supports: $1, $2, ... $9, $@, ${@:N:L}
+;; - $N → Nth positional arg (1-indexed)
+;; - $@ → all args joined with space
+;; - ${@:N:L} → L args starting from position N (1-indexed)
+;; Missing args expand to empty string.
+(define (render-template-with-positional-args template-string args)
+  (define args-vec (list->vector args))
+  (define args-count (vector-length args-vec))
+  ;; Build regex for ${@:N:L} using string-append to avoid escape issues
+  (define slice-rx (string-append "\\$" "\\{@:([0-9]+):([0-9]+)\\}"))
+  ;; ${@:N:L} → L args starting from 1-indexed N
+  (define expanded
+    (regexp-replace*
+     (regexp slice-rx)
+     template-string
+     (lambda (match start-str len-str)
+       (define start (string->number start-str))
+       (define len (string->number len-str))
+       (string-join
+        (for/list ([i (in-range (sub1 start) (min (+ (sub1 start) len) args-count))])
+          (vector-ref args-vec i))
+        " "))))
+  ;; $@ → all args
+  (define expanded2
+    (regexp-replace*
+     #rx"\\$@"
+     expanded
+     (lambda (match)
+       (string-join args " "))))
+  ;; $N → Nth arg (1-9)
+  (regexp-replace*
+   #rx"\\$([1-9])"
+   expanded2
+   (lambda (match n-str)
+     (define n (string->number n-str))
+     (if (<= n args-count)
+         (vector-ref args-vec (sub1 n))
+         ""))))

--- a/tests/test-wave3-extension-polish.rkt
+++ b/tests/test-wave3-extension-polish.rkt
@@ -1,0 +1,146 @@
+#lang racket
+
+;; tests/test-wave3-extension-polish.rkt — Wave 3 extension & session polish tests
+;;
+;; Tests for v0.11.0 Wave 3 sub-issues:
+;;   #1185: RPC Extension UI Sub-Protocol
+;;   #1186: Bash Execution as First-Class Message Type
+;;   #1187: Prompt Templates with Argument Expansion
+
+(require rackunit
+         racket/port
+         "../util/protocol-types.rkt"
+         "../skills/template.rkt"
+         "../extensions/ui-channel.rkt"
+         "../wiring/rpc-ui-adapter.rkt")
+
+;; ============================================================
+;; Helpers
+;; ============================================================
+
+(define (make-msg id role kind content [meta (hasheq)])
+  (make-message id #f role kind content (current-seconds) meta))
+
+;; ============================================================
+;; #1185: RPC Extension UI Sub-Protocol
+;; ============================================================
+;; The RPC UI bridge wiring is tested in test-rpc-ui-adapter.rkt.
+;; Here we verify the wiring is importable and the handler map is complete.
+
+(test-case "#1185: rpc-ui-adapter provides expected functions"
+  (check-true (procedure? start-rpc-ui-bridge!))
+  (check-true (procedure? make-rpc-ui-response-handler)))
+
+;; ============================================================
+;; #1186: Bash Execution Message Type
+;; ============================================================
+
+(test-case "#1186: bash-execution-entry? recognizes bash-execution kind"
+  (define msg (make-msg "b1" 'tool 'bash-execution '()))
+  (check-true (bash-execution-entry? msg))
+  (check-false (bash-execution-entry? (make-msg "b2" 'tool 'tool-result '())))
+  (check-false (bash-execution-entry? (make-msg "b3" 'user 'message '()))))
+
+(test-case "#1186: bash-execution preserves metadata in meta field"
+  (define msg (make-msg "b1" 'tool 'bash-execution
+                        '()
+                        (hasheq 'command "ls -la"
+                                'exit-code 0
+                                'duration-ms 150
+                                'timed-out? #f)))
+  (check-true (bash-execution-entry? msg))
+  (check-equal? (hash-ref (message-meta msg) 'command) "ls -la")
+  (check-equal? (hash-ref (message-meta msg) 'exit-code) 0)
+  (check-equal? (hash-ref (message-meta msg) 'duration-ms) 150)
+  (check-equal? (hash-ref (message-meta msg) 'timed-out?) #f))
+
+(test-case "#1186: any-tool-result-entry? matches both kinds"
+  (define tool-msg (make-msg "t1" 'tool 'tool-result '()))
+  (define bash-msg (make-msg "b1" 'tool 'bash-execution '()))
+  (define user-msg (make-msg "u1" 'user 'message '()))
+  (check-not-false (any-tool-result-entry? tool-msg) "tool-result should match")
+  (check-not-false (any-tool-result-entry? bash-msg) "bash-execution should match")
+  (check-false (any-tool-result-entry? user-msg) "user message should not match"))
+
+(test-case "#1186: tool-result-entry? still works for backward compat"
+  (define msg (make-msg "t1" 'tool 'tool-result '()))
+  (check-true (tool-result-entry? msg))
+  ;; bash-execution is NOT tool-result — they're distinct
+  (define bash-msg (make-msg "b1" 'tool 'bash-execution '()))
+  (check-false (tool-result-entry? bash-msg)))
+
+(test-case "#1186: bash-execution message round-trips through serialization"
+  (define msg (make-msg "b1" 'tool 'bash-execution
+                        '()
+                        (hasheq 'command "make test" 'exit-code 1)))
+  (define jsexpr (message->jsexpr msg))
+  (define restored (jsexpr->message jsexpr))
+  (check-true (bash-execution-entry? restored))
+  (check-equal? (message-kind restored) 'bash-execution)
+  (check-equal? (hash-ref (message-meta restored) 'command) "make test")
+  (check-equal? (hash-ref (message-meta restored) 'exit-code) 1))
+
+;; ============================================================
+;; #1187: Prompt Templates with Argument Expansion
+;; ============================================================
+
+(test-case "#1187: $1 $2 positional expansion"
+  (define tpl "Hello $1, you are $2!")
+  (check-equal? (render-template-with-positional-args tpl '("Alice" "awesome"))
+                "Hello Alice, you are awesome!"))
+
+(test-case "#1187: $@ expands to all args"
+  (define tpl "Files: $@")
+  (check-equal? (render-template-with-positional-args tpl '("a.rkt" "b.rkt" "c.rkt"))
+                "Files: a.rkt b.rkt c.rkt"))
+
+(test-case "#1187: ${@:N:L} slice expansion"
+  (define tpl "Selected: ${@:2:2}")
+  (check-equal? (render-template-with-positional-args tpl '("a" "b" "c" "d"))
+                "Selected: b c"))
+
+(test-case "#1187: missing $N expands to empty"
+  (define tpl "Only $1 and $3 here")
+  (check-equal? (render-template-with-positional-args tpl '("first"))
+                "Only first and  here"))
+
+(test-case "#1187: empty args"
+  (define tpl "No args: $@ and $1")
+  (check-equal? (render-template-with-positional-args tpl '())
+                "No args:  and "))
+
+(test-case "#1187: combined $@ and $1"
+  (define tpl "All: $@ | First: $1")
+  (check-equal? (render-template-with-positional-args tpl '("x" "y" "z"))
+                "All: x y z | First: x"))
+
+(test-case "#1187: ${@:N:L} at end of range"
+  (define tpl "Last two: ${@:3:2}")
+  (check-equal? (render-template-with-positional-args tpl '("a" "b" "c" "d"))
+                "Last two: c d"))
+
+(test-case "#1187: ${@:N:L} exceeds available args"
+  (define tpl "Overflow: ${@:2:5}")
+  (check-equal? (render-template-with-positional-args tpl '("a" "b" "c"))
+                "Overflow: b c"))
+
+(test-case "#1187: render-template {{var}} still works"
+  (define tpl "Hello {{name}}, welcome to {{place}}!")
+  (check-equal? (render-template tpl (hasheq 'name "Alice" 'place "Racket"))
+                "Hello Alice, welcome to Racket!"))
+
+(test-case "#1185: bridge can start and accept requests"
+  (define ui-ch (make-channel))
+  (define buf (open-output-string))
+  ;; Start the bridge (it reads from ui-ch in a background thread)
+  (start-rpc-ui-bridge! ui-ch buf)
+  ;; Send a confirm request through the channel
+  (define resp-ch (make-channel))
+  (define req (ui-request 'confirm resp-ch "Do you want to proceed?"))
+  (thread (lambda () (channel-put ui-ch req)))
+  ;; Give the bridge time to process
+  (sleep 0.1)
+  ;; Check that a notification was written to buf
+  (define output (get-output-string buf))
+  (check-true (string-contains? output "ui.confirm")
+              (format "expected ui.confirm in output, got: ~a" output)))

--- a/util/protocol-types.rkt
+++ b/util/protocol-types.rkt
@@ -49,6 +49,8 @@
          session-info-entry?
          compaction-summary-entry?
          tool-result-entry?
+         bash-execution-entry?
+         any-tool-result-entry?
 
          ;; Event envelope
          (struct-out event)
@@ -246,6 +248,15 @@
 (define (tool-result-entry? msg)
   ;; Tool result entry
   (and (message? msg) (eq? (message-kind msg) 'tool-result)))
+
+(define (bash-execution-entry? msg)
+  ;; Bash execution entry — preserves command metadata (exit-code, duration, etc.)
+  (and (message? msg) (eq? (message-kind msg) 'bash-execution)))
+
+(define (any-tool-result-entry? msg)
+  ;; Matches both generic tool-result and bash-execution entries
+  (and (message? msg)
+       (memq (message-kind msg) '(tool-result bash-execution))))
 
 ;; ============================================================
 ;; Event envelope struct

--- a/wiring/run-json-rpc.rkt
+++ b/wiring/run-json-rpc.rkt
@@ -22,6 +22,7 @@
          "../agent/event-bus.rkt"
          "../extensions/api.rkt"
          "./rpc-methods.rkt"
+         "./rpc-ui-adapter.rkt"
          (only-in "../agent/queue.rkt" enqueue-steering! enqueue-followup!)
          (only-in "../util/cancellation.rkt" cancellation-token? cancel-token!))
 
@@ -164,6 +165,16 @@
                              (hash-remove! sessions sid)
                              (hasheq 'sessionId sid 'status "closed"))))))
 
-  ;; ---- Merge core + session/utility handlers ----
-  (define handlers (hash-union core-handlers session-handlers #:combine (lambda (a b) b)))
+  ;; ---- #1185: Extension UI bridge ----
+  ;; Create a UI channel for extensions and wire it to RPC notifications
+  (define ui-ch (make-channel))
+  (hash-set! rt-config 'ui-channel ui-ch)
+  (start-rpc-ui-bridge! ui-ch (current-output-port))
+  (define ui-response-handler (make-rpc-ui-response-handler ui-ch))
+
+  ;; ---- Merge core + session + UI handlers ----
+  (define ui-handlers
+    (make-hash (list (cons 'ui.respond ui-response-handler)
+                     (cons 'ui_response ui-response-handler))))
+  (define handlers (hash-union core-handlers session-handlers ui-handlers #:combine (lambda (a b) b)))
   (run-rpc-loop handlers))

--- a/wiring/run-modes.rkt
+++ b/wiring/run-modes.rkt
@@ -138,6 +138,8 @@
   (define effective-model-name (or model-name (default-model model-reg)))
   (hash-set! base-config 'model-name effective-model-name)
   (hash-set! base-config 'system-instructions final-system-instrs)
+  ;; #1187: Wire templates into runtime config for /template command
+  (hash-set! base-config 'templates (resource-set-templates all-resources))
   (hash-set! base-config 'verbose? (cli-config-verbose? cfg))
   base-config)
 


### PR DESCRIPTION
Addresses #1184.

feat: extension polish — RPC UI bridge, bash message type, templates (#1184)

Wave 3 of v0.11.0: three extension and session polish items.

- Wire RPC UI bridge into run-rpc: UI channel + response handler for
  extension dialogs over RPC (confirm/select/input)
- Add bash-execution message kind distinct from tool-result with
  any-tool-result-entry? shared predicate; update cutpoints
- Wire templates into runtime config; add render-template-with-positional-args
  for bash-style $1, $@, ${@:N:L} expansion
- 16 tests across all three sub-issues

Sub-issues: #1185, #1186, #1187