### PR TITLE
feat: expand hook catalog with streaming and lifecycle hooks (#1207)

### DIFF
--- a/extensions/hooks.rkt
+++ b/extensions/hooks.rkt
@@ -41,7 +41,7 @@
 
 ;; Critical hooks default to 'block on error (safety-first).
 ;; Advisory hooks default to 'pass on error (liveness-first).
-(define critical-hooks '(tool-call session-before-fork session-before-compact input))
+(define critical-hooks '(tool-call session-before-switch session-before-fork session-before-compact input))
 
 (define (critical-hook? hook-point)
   (and (member hook-point critical-hooks) #t))

--- a/runtime/iteration.rkt
+++ b/runtime/iteration.rkt
@@ -293,6 +293,12 @@
           (values '() #t)
           (values amended #f))))
 
+  ;; #1208: Dispatch 'tool.execution.start hook before tool batch
+  (when (and ext-reg (not (null? tool-calls-to-run)))
+    (maybe-dispatch-hooks ext-reg 'tool.execution.start
+                          (hasheq 'tools (map tool-call-name tool-calls-to-run)
+                                  'count (length tool-calls-to-run))))
+
   ;; Run tool batch through scheduler (skip if blocked)
   (define sched-result
     (if tool-call-blocked?
@@ -315,6 +321,15 @@
             #:call-id (generate-id)
             #:session-metadata (hasheq 'session-id session-id))
            #:parallel? (hash-ref config 'parallel-tools #t)))))
+
+  ;; #1208: Dispatch 'tool.execution.end hook after tool batch
+  (when (and ext-reg (not tool-call-blocked?))
+    (maybe-dispatch-hooks ext-reg 'tool.execution.end
+                          (hasheq 'tools (for/list ([tc (in-list tool-calls-to-run)]
+                                                    [tr (in-list (scheduler-result-results sched-result))])
+                                           (hasheq 'name (tool-call-name tc)
+                                                   'status (if (tool-result-is-error? tr) 'error 'completed)))
+                                          'count (length tool-calls-to-run))))
 
   ;; Emit tool.call.completed / tool.call.failed events (only for executed calls)
   (for ([tc (in-list tool-calls-to-run)]

--- a/tests/test-hook-catalog.rkt
+++ b/tests/test-hook-catalog.rkt
@@ -1,0 +1,145 @@
+#lang racket/base
+
+;; tests/test-hook-catalog.rkt — Wave 1 tests for Extension Hook Catalog Expansion
+;; Issue #1207, sub-issues #1208, #1209, #1210
+;;
+;; Validates:
+;; - session-before-switch is registered in hook-action-schemas (#1209)
+;; - Streaming hooks (tool.execution.*) are in schemas (#1208)
+;; - message-update alias is in schemas (#1208)
+;; - tool-call-pre and tool-result-post are in schemas (#1208)
+;; - valid-hook-name? rejects unknown hooks with clear error (#1210)
+;; - session-before-switch is classified as critical (#1209)
+;; - All critical hooks are in hook-action-schemas (#1210)
+
+(require rackunit
+         rackunit/text-ui
+         "../util/hook-types.rkt"
+         "../extensions/hooks.rkt"
+         "../extensions/api.rkt")
+
+;; ============================================================
+;; #1209: Session Lifecycle Hook Tests
+;; ============================================================
+
+(define-test-suite session-lifecycle-tests
+  (test-case "session-before-switch is in hook-action-schemas"
+    (check-true (hash-has-key? hook-action-schemas 'session-before-switch)
+                "session-before-switch should be registered in hook-action-schemas"))
+
+  (test-case "session-before-switch allows pass and block"
+    (check-equal? (valid-hook-actions-for 'session-before-switch)
+                  '(pass block)))
+
+  (test-case "session-before-switch is a critical hook (safety-first)"
+    (check-not-false (member 'session-before-switch critical-hooks)
+                     "session-before-switch should be classified as critical"))
+
+  (test-case "session-before-fork is still a critical hook"
+    (check-not-false (member 'session-before-fork critical-hooks)))
+
+  (test-case "session-before-compact is still a critical hook"
+    (check-not-false (member 'session-before-compact critical-hooks))))
+
+;; ============================================================
+;; #1208: Streaming Hook Schema Tests
+;; ============================================================
+
+(define-test-suite streaming-hook-schema-tests
+  (test-case "tool.execution.start is in hook-action-schemas"
+    (check-true (hash-has-key? hook-action-schemas 'tool.execution.start)))
+
+  (test-case "tool.execution.end is in hook-action-schemas"
+    (check-true (hash-has-key? hook-action-schemas 'tool.execution.end)))
+
+  (test-case "tool.execution.update is in hook-action-schemas"
+    (check-true (hash-has-key? hook-action-schemas 'tool.execution.update)))
+
+  (test-case "tool.execution.start only allows 'pass action"
+    (check-equal? (valid-hook-actions-for 'tool.execution.start) '(pass)))
+
+  (test-case "tool.execution.end only allows 'pass action"
+    (check-equal? (valid-hook-actions-for 'tool.execution.end) '(pass)))
+
+  (test-case "tool.execution.update allows 'amend action"
+    (check-equal? (valid-hook-actions-for 'tool.execution.update) '(amend)))
+
+  (test-case "message-update alias is in hook-action-schemas"
+    ;; agent/loop.rkt dispatches 'message-update (hyphen) but schema had 'message.update (dot)
+    ;; Both forms should be recognized
+    (check-true (or (hash-has-key? hook-action-schemas 'message-update)
+                    (hash-has-key? hook-action-schemas 'message.update))
+                "message-update or message.update should be in schemas"))
+
+  (test-case "message-stream.delta is in hook-action-schemas"
+    (check-true (hash-has-key? hook-action-schemas 'message.stream.delta)))
+
+  (test-case "tool-call-pre is in hook-action-schemas"
+    ;; Dispatched from scheduler.rkt
+    (check-true (hash-has-key? hook-action-schemas 'tool-call-pre)))
+
+  (test-case "tool-result-post is in hook-action-schemas"
+    ;; Dispatched from scheduler.rkt
+    (check-true (hash-has-key? hook-action-schemas 'tool-result-post))))
+
+;; ============================================================
+;; #1210: Hook Name Validation Tests
+;; ============================================================
+
+(define-test-suite hook-validation-tests
+  (test-case "valid-hook-name? accepts known hooks"
+    (for ([name (in-list '(turn-start turn-end tool-call tool-result
+                          session-before-switch session-before-fork session-before-compact
+                          tool.execution.start tool.execution.end tool.execution.update
+                          message-start message-end message.update message-update
+                          before-provider-request context input))])
+      (check-true (valid-hook-name? name)
+                  (format "Expected ~a to be a valid hook name" name))))
+
+  (test-case "valid-hook-name? rejects unknown hooks"
+    (check-false (valid-hook-name? 'nonexistent-hook))
+    (check-false (valid-hook-name? 'fake.hook))
+    (check-false (valid-hook-name? 'totally-made-up)))
+
+  (test-case "valid-hook-actions-for returns permissive default for unknown hooks"
+    ;; Unknown hooks should get permissive default for backward compat
+    (check-equal? (valid-hook-actions-for 'totally-unknown-hook)
+                  '(pass amend block)
+                  "Unknown hooks should get permissive default")))
+
+;; ============================================================
+;; #1210: Schema Completeness Tests
+;; ============================================================
+
+(define-test-suite schema-completeness-tests
+  (test-case "hook-point-names returns all registered hooks"
+    (define names (hook-point-names))
+    (for ([expected (in-list '(turn-start turn-end tool-call
+                                     session-before-switch
+                                     tool.execution.start tool.execution.end))])
+      (check-not-false (member expected names)
+                       (format "~a should be in hook-point-names" expected))))
+
+  (test-case "all critical hooks are in hook-action-schemas"
+    (for ([hook (in-list critical-hooks)])
+      (check-true (hash-has-key? hook-action-schemas hook)
+                  (format "Critical hook ~a should be in hook-action-schemas" hook))))
+
+  (test-case "validate-hook-result works for session-before-switch"
+    (define result (hook-block "safety-check"))
+    (check-true (validate-hook-result 'session-before-switch result)))
+
+  (test-case "validate-hook-result rejects invalid action for tool.execution.start"
+    (define bad-result (hook-amend (hasheq 'extra 'data)))
+    (check-false (validate-hook-result 'tool.execution.start bad-result))))
+
+;; ============================================================
+;; Run all tests
+;; ============================================================
+
+(run-tests
+ (make-test-suite "Hook Catalog Expansion Tests"
+   (list session-lifecycle-tests
+         streaming-hook-schema-tests
+         hook-validation-tests
+         schema-completeness-tests)))

--- a/util/hook-types.rkt
+++ b/util/hook-types.rkt
@@ -19,7 +19,9 @@
          ;; Hook point names (#1148)
          hook-point-names
          ;; #1149: expose schemas for testing
-         hook-action-schemas)
+         hook-action-schemas
+         ;; #1210: hook name validation
+         valid-hook-name?)
 
 (struct hook-result (action payload) #:transparent)
 
@@ -49,10 +51,18 @@
           '(pass amend)
           'message-end
           '(pass amend)
+          ;; #1208: message-update alias (hyphen form of message.update)
+          'message-update
+          '(amend)
           ;; Tool execution hooks
           'tool-call
           '(pass amend block)
           'tool-result
+          '(pass amend block)
+          ;; #1208: tool-call-pre / tool-result-post (dispatched from scheduler.rkt)
+          'tool-call-pre
+          '(pass amend block)
+          'tool-result-post
           '(pass amend block)
           ;; Turn lifecycle hooks
           'turn-start
@@ -68,6 +78,8 @@
           'context.assembly
           '(pass amend block)
           ;; Session hooks
+          'session-before-switch
+          '(pass block)
           'session-before-fork
           '(pass block)
           'session-before-compact
@@ -165,3 +177,13 @@
 ;; Useful for testing and introspection.
 (define (hook-point-names)
   (hash-keys hook-action-schemas))
+
+;; ============================================================
+;; #1210: Hook name validation
+;; ============================================================
+
+;; valid-hook-name? : symbol? -> boolean?
+;; Returns #t if the given symbol is a registered hook-point name.
+;; Used at extension registration time to catch typos early.
+(define (valid-hook-name? name)
+  (hash-has-key? hook-action-schemas name))


### PR DESCRIPTION
## Wave 1: Extension Hook Catalog Expansion

Closes #1207, closes #1208, closes #1209, closes #1210

### Changes

**#1209 — Session Lifecycle Hooks**
- Add `session-before-switch` to `hook-action-schemas` (pass/block)
- Add `session-before-switch` to `critical-hooks` list (safety-first)

**#1208 — Streaming Hooks**
- Add `message-update` (hyphen alias) to schemas
- Add `tool-call-pre` and `tool-result-post` to schemas
- Wire `tool.execution.start`/`end` hook dispatch in `iteration.rkt` around tool batch execution

**#1210 — Hook Name Validation**
- Add `valid-hook-name?` function for registration-time typo detection
- 41 hooks now registered in schemas

### Test Results
- 22 new tests (all passing)
- All existing hook tests still passing (test-hook-types, test-session-lifecycle-hooks, test-hooks-complete)

### Files Modified
- `util/hook-types.rkt` — schema entries + valid-hook-name?
- `extensions/hooks.rkt` — critical-hooks update
- `runtime/iteration.rkt` — tool.execution.* hook dispatch
- `tests/test-hook-catalog.rkt` — new test suite