### PR TITLE
chore: v0.11.1 release hygiene (#1225)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,41 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.11.1] — 2026-04-19
+
+### Added — Wave 0: Subagent Real Provider (#1203)
+- **Provider injection** (#1204): Parent LLM provider injected into subagent exec-context via `runtime-settings`, replacing mock fallback with real provider resolution.
+- **Scoped tools + max-turns** (#1205): Subagent sessions use parent provider with scoped tool access and configurable max-turns limit.
+- **Return-error fix** (#1206): Fixed `return-error` content structure bug — now returns proper `(list (hasheq 'type "text" 'text msg))` format.
+- 10 new integration tests for subagent provider wiring.
+
+### Added — Wave 1: Hook Catalog Expansion (#1207)
+- **Streaming hooks** (#1208): `tool.execution.start` and `tool.execution.end` hook dispatch wired in iteration loop; `tool-call-pre` and `tool-result-post` hook schemas; `message-update` alias (hyphen form) in schemas.
+- **Session lifecycle hooks** (#1209): `session-before-switch` added to `hook-action-schemas` and `critical-hooks` list.
+- **Hook validation** (#1210): `valid-hook-name?` predicate for hook name validation at registration time.
+- 22 new tests covering hook catalog expansion.
+
+### Added — Wave 2: Extension Example Gallery (#1211)
+- **12 canonical examples**: hello-world, custom-tool, custom-command, context-enricher, tool-guard, response-logger, session-lifecycle, streaming-observer, provider-hook, multi-hook, define-extension-dsl (macro DSL), error-handler.
+- **4 advanced examples** (#1215): custom-provider (`register-provider!`/`register-model!`), session-state (`append-custom-entry!`/`load-custom-entries`), tui-widget (`ctx-set-widget`/footer rendering), keyboard-shortcut (`register-shortcuts` hook).
+- `register-shortcuts` added to `hook-action-schemas`.
+- README.md with index and getting-started guide for all examples.
+- 70 tests validating all examples.
+
+### Added — Wave 3: Dynamic Provider Registration (#1219)
+- **Provider registration API** (#1220): `register-provider!` with validation and duplicate detection in `provider-registry.rkt`.
+- **Provider RPC endpoints** (#1221): `providers/list`, `models`, `find` RPC methods in new `wiring/provider-rpc.rkt`.
+- 36 new tests for provider registration and discovery.
+
+### Added — Wave 4: SDK Surface Expansion (#1219)
+- **Session state queries** (#1223): Extension-ctx exposes session state query API via expanded `extensions/context.rkt`.
+- **Extension telemetry** (#1224): Performance telemetry module `extensions/telemetry.rkt` for extension monitoring.
+- 36 new tests (shared with Wave 3 test suite).
+
+### Internal
+- 29 files changed, 2,259 insertions across 5 waves.
+- 138+ new tests, 5,100+ total tests passing.
+
 ## [0.11.0] — 2026-04-18
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.11.0-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.11.1-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 
@@ -199,7 +199,7 @@ racket main.rkt --model gpt-5.4 "write a test"
 ### Verify
 
 ```bash
-racket main.rkt --version  # q version 0.10.8
+racket main.rkt --version  # q version 0.11.1
 raco test tests/           # run the full test suite
 ```
 
@@ -327,6 +327,8 @@ When q executes shell commands on behalf of an LLM, arguments are quoted via `sh
 | [Architecture](docs/adr/) | Architecture decision records |
 
 ## Status
+
+**v0.11.1** — Ecosystem Foundations. 12 canonical extension examples, expanded hook catalog (streaming + lifecycle hooks), dynamic provider registration with RPC endpoints, SDK surface expansion (session state queries, telemetry), real provider wiring for subagents, 138+ new tests across 5 waves. 5100+ tests.
 
 **v0.10.8** — Timeout Render Fix + Extensibility + Test Runner. TUI streaming state cleanup on auto-retry/error, extension tool registration API, session tree UX, rich component model, built-in components + overlays, extension lifecycle, event coverage (37 events), custom editor + IME, SDK ergonomics, provider OAuth flow, image rendering, skills frontmatter, graceful shutdown, rewritten test runner with per-file result tracking. 4960+ tests.
 

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.11.0")
+(define version "0.11.1")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base"))

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -7,4 +7,4 @@
 
 (provide q-version)
 
-(define q-version "0.11.0")
+(define q-version "0.11.1")


### PR DESCRIPTION
## v0.11.1 Release Hygiene

Version bump, CHANGELOG, and release preparation for v0.11.1 Ecosystem Foundations.

### Changes
- Version bumped to 0.11.1 in `util/version.rkt` (canonical source)
- Synced `info.rkt` and `README.md` version badge
- Added comprehensive CHANGELOG entry covering all 5 waves
- Updated README Status section with v0.11.1 summary

### Verification
- `racket scripts/sync-version.rkt` — all targets in sync
- `racket scripts/lint-format.rkt` — 0 errors, format lint PASSED
- `racket scripts/run-tests.rkt` — 0 failures, 0 errors

Closes #1225
Closes #1226
Closes #1227