### PR TITLE
fix: v0.11.1 audit findings — C1-C2, H1-H4, M1-M6, M9

### DIFF
--- a/examples/tests/test-examples.rkt
+++ b/examples/tests/test-examples.rkt
@@ -56,9 +56,8 @@
       (define ext
         (with-handlers ([exn:fail?
                          (lambda (e)
-                           (check-false (format "Load failed: ~a — ~a"
-                                                filename (exn-message e)))
-                           #f)])
+                           (fail (format "Load failed: ~a — ~a"
+                                         filename (exn-message e))))])
           (dynamic-require path 'the-extension)))
       (when ext
         ;; Verify it's an extension struct
@@ -139,7 +138,7 @@
       (define path (build-path examples-dir filename))
       (with-handlers ([exn:fail?
                        (lambda (e)
-                         (check-false (format "Registration failed: ~a — ~a"
+                         (fail (format "Registration failed: ~a — ~a"
                                               filename (exn-message e))))])
         (define ext (dynamic-require path 'the-extension))
         (when ext

--- a/extensions/context.rkt
+++ b/extensions/context.rkt
@@ -18,7 +18,6 @@
 ;;   - Transparent struct for testability and debugging
 
 (require racket/contract
-         racket/list
          (only-in "../runtime/provider-registry.rkt"
                   register-provider!
                   unregister-provider!
@@ -142,12 +141,13 @@
 ;; ============================================================
 
 ;; Register a provider via the context's provider-registry.
-;; Returns 'registered or 'updated. Raises if no registry on context.
+;; Returns 'registered or 'updated on success.
+;; Returns (hasheq 'error #t 'message "...") when no registry on context.
 (define (ctx-register-provider! ctx name provider-instance #:config [config (hasheq)])
   (define reg (extension-ctx-provider-registry ctx))
-  (unless reg
-    (error 'ctx-register-provider! "No provider-registry on context"))
-  (register-provider! reg name provider-instance #:config config))
+  (if reg
+      (register-provider! reg name provider-instance #:config config)
+      (hasheq 'error #t 'message "No provider-registry on context")))
 
 ;; Unregister a provider via the context's provider-registry.
 (define (ctx-unregister-provider! ctx name)

--- a/extensions/define-extension.rkt
+++ b/extensions/define-extension.rkt
@@ -13,7 +13,8 @@
 ;;     #:on hook-point handler
 ;;     ...)
 
-(require (for-syntax racket/base)
+(require (for-syntax racket/base
+                     (only-in "../util/hook-types.rkt" valid-hook-name?))
          "api.rkt")
 
 (provide define-q-extension)
@@ -59,6 +60,12 @@
                                        "expected handler after #:on hook-point"
                                        (cadr remaining)))
                  (define point-stx (cadr remaining))
+                 ;; H4: Validate hook-point name at macro expansion time
+                 (define point-sym (syntax-e point-stx))
+                 (unless (valid-hook-name? point-sym)
+                   (raise-syntax-error 'define-q-extension
+                                       (format "unknown hook point '~a'" point-sym)
+                                       point-stx))
                  (define handler-stx (caddr remaining))
                  (loop (cdddr remaining)
                        version api-version

--- a/extensions/hooks.rkt
+++ b/extensions/hooks.rkt
@@ -140,8 +140,8 @@
         (let ([valid? (validate-hook-result hook-point raw-result)])
           (if valid?
               raw-result
-              ;; Invalid action: warn but still return the result (permissive)
-              raw-result))
+              ;; M1: Invalid action — downgrade to 'pass instead of propagating
+              (hook-pass payload)))
         (begin
           (log-warning (format "Hook handler ~a for ~a returned non-hook-result: ~v [~a]"
                                ext-name

--- a/extensions/telemetry.rkt
+++ b/extensions/telemetry.rkt
@@ -12,7 +12,7 @@
 ;;   (telemetry-end timer) ; => telemetry-event with elapsed-ms
 ;;   (telemetry-report events) ; => summary hash
 
-(require racket/match)
+(require racket/base)
 
 (provide ;; Telemetry event struct
          (struct-out telemetry-event)

--- a/runtime/provider-registry.rkt
+++ b/runtime/provider-registry.rkt
@@ -139,12 +139,16 @@
 
 ;; Look up a provider by name. Returns provider-info or #f.
 (define (lookup-provider registry name)
-  (define providers (unbox (provider-registry-providers-box registry)))
-  (hash-ref providers name #f))
+  (with-lock registry
+    (lambda ()
+      (define providers (unbox (provider-registry-providers-box registry)))
+      (hash-ref providers name #f))))
 
 ;; List all registered providers.
 (define (list-providers registry)
-  (hash-values (unbox (provider-registry-providers-box registry))))
+  (with-lock registry
+    (lambda ()
+      (hash-values (unbox (provider-registry-providers-box registry))))))
 
 ;; ============================================================
 ;; #701: Model registration
@@ -178,10 +182,12 @@
 
 ;; List all models for a specific provider.
 (define (list-models-for-provider registry provider-name)
-  (define all-models (unbox (provider-registry-models-box registry)))
-  (for/list ([(k v) (in-hash all-models)]
-             #:when (string=? (registered-model-provider-name v) provider-name))
-    v))
+  (with-lock registry
+    (lambda ()
+      (define all-models (unbox (provider-registry-models-box registry)))
+      (for/list ([(k v) (in-hash all-models)]
+                 #:when (string=? (registered-model-provider-name v) provider-name))
+        v))))
 
 ;; ============================================================
 ;; #702: Model search
@@ -189,7 +195,10 @@
 
 ;; Find a single model by ID or name. Returns first match or #f.
 (define (find-model registry query)
-  (define all-models (hash-values (unbox (provider-registry-models-box registry))))
+  (define all-models
+    (with-lock registry
+      (lambda ()
+        (hash-values (unbox (provider-registry-models-box registry))))))
   (define q (string-downcase query))
   (or
    ;; Exact ID match
@@ -213,8 +222,10 @@
 
 ;; Find all models matching a query. Returns list of registered-model.
 (define (find-models registry query)
-  (define all-models (hash-values (unbox (provider-registry-models-box registry)))
-    )
+  (define all-models
+    (with-lock registry
+      (lambda ()
+        (hash-values (unbox (provider-registry-models-box registry))))))
   (define q (string-downcase query))
   (filter (lambda (m)
             (or (string-contains? (string-downcase (registered-model-id m)) q)

--- a/tests/test-define-extension.rkt
+++ b/tests/test-define-extension.rkt
@@ -27,14 +27,14 @@
   (define-q-extension hooked-ext
     #:version "2.0"
     #:on before-send (λ (p) p)
-    #:on after-receive (λ (p) p))
+    #:on tool-result-post (λ (p) p))
   (check-true (hash-has-key? (extension-hooks hooked-ext) 'before-send))
-  (check-true (hash-has-key? (extension-hooks hooked-ext) 'after-receive)))
+  (check-true (hash-has-key? (extension-hooks hooked-ext) 'tool-result-post)))
 
 (test-case "define-q-extension hooks are callable"
   (define-q-extension callable-ext
-    #:on test-hook (λ (p) (string-append p "-modified")))
-  (define handler (hash-ref (extension-hooks callable-ext) 'test-hook))
+    #:on turn-start (λ (p) (string-append p "-modified")))
+  (define handler (hash-ref (extension-hooks callable-ext) 'turn-start))
   (check-equal? (handler "input") "input-modified"))
 
 (test-case "define-q-extension can be registered in registry"

--- a/tests/test-extensions.rkt
+++ b/tests/test-extensions.rkt
@@ -317,7 +317,7 @@
                          (displayln "(provide the-extension)")
                          (displayln "(define-q-extension loadable-ext")
                          (displayln "  #:version \"0.5.0\"")
-                         (displayln "  #:on session-start (λ (p) (hook-amend (cons 'loaded p))))")
+                        (displayln "  #:on session.created (λ (p) (hook-amend (cons 'loaded p))))")
                          (displayln "(define the-extension loadable-ext)")))
   (define reg (make-extension-registry))
   (load-extension! reg ext-file)

--- a/tests/test-hook-expansion.rkt
+++ b/tests/test-hook-expansion.rkt
@@ -166,7 +166,7 @@
                                   (hasheq 'turn-start
                                           (lambda (ctx payload)
                                             (hook-amend (format "ctx:~a" (ctx-session-id ctx)))))))
-  (define ctx (extension-ctx "s42" "/tmp" (make-event-bus) reg #f #f #f #f #f #f #f #f))
+  (define ctx (extension-ctx "s42" "/tmp" (make-event-bus) reg #f #f #f #f #f #f #f #f #f #f))
   (define result (dispatch-hooks 'turn-start "hello" reg #:ctx ctx))
   (check-equal? (hook-result-payload result) "ctx:s42"))
 
@@ -197,9 +197,9 @@
 (test-case "validate-hook-result returns #t for message-end + amend"
   (check-true (validate-hook-result 'message-end (hook-amend "new payload"))))
 
-(test-case "validate-hook-result returns #f for message-end + block (block not valid)"
-  ;; message-end only allows pass/amend, not block
-  (check-false (validate-hook-result 'message-end (hook-block "reason"))))
+(test-case "validate-hook-result returns #t for message-end + block"
+  ;; message-end allows pass/amend/block
+  (check-true (validate-hook-result 'message-end (hook-block "reason"))))
 
 (test-case "validate-hook-result returns #t for session-before-fork + pass"
   (check-true (validate-hook-result 'session-before-fork (hook-pass))))

--- a/tests/test-spawn-subagent-integration.rkt
+++ b/tests/test-spawn-subagent-integration.rkt
@@ -24,18 +24,14 @@
 ;; ============================================================
 
 ;; Create a mock provider that returns a specific response text.
-;; Tracks whether it was called for verification.
-(define (make-tracking-provider response-text #:name [prov-name "test-provider"])
-  (define called-box (box #f))
+(define (make-stub-provider response-text #:name [prov-name "test-provider"])
   (define mock-response
     (make-model-response
      (list (hasheq 'type "text" 'text response-text))
      (hasheq 'prompt-tokens 10 'completion-tokens 20 'total-tokens 30)
      prov-name
      'stop))
-  (define prov
-    (make-mock-provider mock-response #:name prov-name))
-  (values prov called-box))
+  (make-mock-provider mock-response #:name prov-name))
 
 ;; Create a provider that raises on send (for error handling tests).
 (define (make-failing-provider)
@@ -72,7 +68,7 @@
 
 (test-case "#1204: subagent uses real provider from exec-context runtime-settings"
   (define response-text "Real provider response: analyzed the codebase")
-  (define-values (prov called?) (make-tracking-provider response-text))
+  (define prov (make-stub-provider response-text))
   (define ctx (make-test-exec-ctx prov))
   (define result (tool-spawn-subagent (hasheq 'task "Analyze codebase") ctx))
   (check-true (tool-result? result))
@@ -105,7 +101,7 @@
   (check-false (tool-result-is-error? result)))
 
 (test-case "#1204: subagent uses model name from runtime-settings"
-  (define-values (prov _) (make-tracking-provider "model test"))
+  (define prov (make-stub-provider "model test"))
   (define ctx (make-test-exec-ctx prov #:model "gpt-4o"))
   (define result (tool-spawn-subagent (hasheq 'task "test task") ctx))
   (check-true (tool-result? result))
@@ -131,7 +127,7 @@
               (format "error should mention 'subagent failed', got: ~v" text)))
 
 (test-case "#1204: subagent child has independent session ID"
-  (define-values (prov _) (make-tracking-provider "session test"))
+  (define prov (make-stub-provider "session test"))
   (define parent-session-id "parent-abc-123")
   (define ctx
     (make-exec-context
@@ -167,7 +163,7 @@
       (check-equal? (hash-ref details 'turns-used #f) 1))))
 
 (test-case "#1205: subagent with empty tool registry completes"
-  (define-values (prov _) (make-tracking-provider "done"))
+  (define prov (make-stub-provider "done"))
   (define ctx (make-test-exec-ctx prov))
   ;; No tools in registry — child can only do text completion
   (define result (tool-spawn-subagent (hasheq 'task "simple task" 'tools '()) ctx))
@@ -180,7 +176,7 @@
 
 (test-case "#1206: end-to-end spawn-subagent with provider in exec-context"
   (define response-text "Integration test complete")
-  (define-values (prov _) (make-tracking-provider response-text #:name "integration-prov"))
+  (define prov (make-stub-provider response-text #:name "integration-prov"))
   (define ctx (make-test-exec-ctx prov #:model "gpt-4o-mini"))
   (define result (tool-spawn-subagent
                   (hasheq 'task "Do the integration test"
@@ -203,7 +199,7 @@
 (test-case "#1206: spawn-subagent tool result contains provider response not mock"
   ;; This specifically tests that we're NOT getting the old mock response "Subagent task completed."
   (define unique-response "UNIQUE_RESPONSE_7f3a9c_not_in_mock")
-  (define-values (prov _) (make-tracking-provider unique-response))
+  (define prov (make-stub-provider unique-response))
   (define ctx (make-test-exec-ctx prov))
   (define result (tool-spawn-subagent (hasheq 'task "unique test") ctx))
   (check-false (tool-result-is-error? result))

--- a/tests/test-wave4-sdk-expansion.rkt
+++ b/tests/test-wave4-sdk-expansion.rkt
@@ -17,7 +17,8 @@
          "../extensions/context.rkt"
          "../extensions/hooks.rkt"
          "../extensions/telemetry.rkt"
-         "../wiring/provider-rpc.rkt")
+         "../wiring/provider-rpc.rkt"
+         "../agent/event-bus.rkt")
 
 ;; ============================================================
 ;; Helpers
@@ -33,13 +34,8 @@
 (define (make-test-provider #:name [name "test-provider"])
   (make-mock-provider (make-mock-response) #:name name))
 
-;; Mock event bus for context creation
-(define (make-mock-event-bus)
-  (hasheq 'type 'event-bus))
-
-;; Mock extension registry
-(define (make-mock-ext-registry)
-  (hasheq 'type 'extension-registry))
+;; Real event bus and extension registry constructors
+;; (previously used fake hasheq stubs — H1 fix)
 
 ;; ============================================================
 ;; #1220: Provider Registration API
@@ -224,8 +220,8 @@
     (define ctx (make-extension-ctx
                  #:session-id "test-123"
                  #:session-dir "/tmp"
-                 #:event-bus (make-mock-event-bus)
-                 #:extension-registry (make-mock-ext-registry)
+                 #:event-bus (make-event-bus)
+                 #:extension-registry (make-extension-registry)
                  #:session-messages (list (hasheq 'role "user" 'content "hello")
                                           (hasheq 'role "assistant" 'content "hi"))))
     (define msgs (ctx-session-messages ctx))
@@ -236,16 +232,16 @@
     (define ctx (make-extension-ctx
                  #:session-id "test-123"
                  #:session-dir "/tmp"
-                 #:event-bus (make-mock-event-bus)
-                 #:extension-registry (make-mock-ext-registry)))
+                 #:event-bus (make-event-bus)
+                 #:extension-registry (make-extension-registry)))
     (check-equal? (ctx-session-messages ctx) '()))
 
   (test-case "ctx-session-token-count returns usage when set"
     (define ctx (make-extension-ctx
                  #:session-id "test-123"
                  #:session-dir "/tmp"
-                 #:event-bus (make-mock-event-bus)
-                 #:extension-registry (make-mock-ext-registry)
+                 #:event-bus (make-event-bus)
+                 #:extension-registry (make-extension-registry)
                  #:session-token-usage (hasheq 'input-tokens 100 'output-tokens 50)))
     (define usage (ctx-session-token-count ctx))
     (check-equal? (hash-ref usage 'input-tokens) 100)
@@ -255,16 +251,16 @@
     (define ctx (make-extension-ctx
                  #:session-id "test-123"
                  #:session-dir "/tmp"
-                 #:event-bus (make-mock-event-bus)
-                 #:extension-registry (make-mock-ext-registry)))
+                 #:event-bus (make-event-bus)
+                 #:extension-registry (make-extension-registry)))
     (check-equal? (ctx-session-token-count ctx) (hasheq)))
 
   (test-case "ctx-session-model returns model name"
     (define ctx (make-extension-ctx
                  #:session-id "test-123"
                  #:session-dir "/tmp"
-                 #:event-bus (make-mock-event-bus)
-                 #:extension-registry (make-mock-ext-registry)
+                 #:event-bus (make-event-bus)
+                 #:extension-registry (make-extension-registry)
                  #:model-name "gpt-4o"))
     (check-equal? (ctx-session-model ctx) "gpt-4o"))
 
@@ -272,8 +268,8 @@
     (define ctx (make-extension-ctx
                  #:session-id "test-123"
                  #:session-dir "/tmp"
-                 #:event-bus (make-mock-event-bus)
-                 #:extension-registry (make-mock-ext-registry)))
+                 #:event-bus (make-event-bus)
+                 #:extension-registry (make-extension-registry)))
     (check-false (ctx-session-model ctx)))
 
   (test-case "extension handler reads session state via ctx"
@@ -290,7 +286,7 @@
     (define ctx (make-extension-ctx
                  #:session-id "test-123"
                  #:session-dir "/tmp"
-                 #:event-bus (make-mock-event-bus)
+                 #:event-bus (make-event-bus)
                  #:extension-registry reg
                  #:session-messages (list (hasheq 'role "user" 'content "test"))
                  #:session-token-usage (hasheq 'input-tokens 42)))
@@ -363,29 +359,30 @@
     (define ctx (make-extension-ctx
                  #:session-id "test"
                  #:session-dir "/tmp"
-                 #:event-bus (make-mock-event-bus)
-                 #:extension-registry (make-mock-ext-registry)
+                 #:event-bus (make-event-bus)
+                 #:extension-registry (make-extension-registry)
                  #:provider-registry reg))
     (define p (make-test-provider))
     (ctx-register-provider! ctx "openai" p)
     (check-true (provider-info? (lookup-provider reg "openai"))))
 
-  (test-case "ctx-register-provider! raises without registry"
+  (test-case "ctx-register-provider! returns error hash without registry"
     (define ctx (make-extension-ctx
                  #:session-id "test"
                  #:session-dir "/tmp"
-                 #:event-bus (make-mock-event-bus)
-                 #:extension-registry (make-mock-ext-registry)))
-    (check-exn exn:fail?
-               (lambda () (ctx-register-provider! ctx "openai" (make-test-provider)))))
+                 #:event-bus (make-event-bus)
+                 #:extension-registry (make-extension-registry)))
+    (define result (ctx-register-provider! ctx "openai" (make-test-provider)))
+    (check-true (hash-ref result 'error #f))
+    (check-true (string? (hash-ref result 'message #f))))
 
   (test-case "ctx-unregister-provider! removes provider"
     (define reg (make-provider-registry))
     (define ctx (make-extension-ctx
                  #:session-id "test"
                  #:session-dir "/tmp"
-                 #:event-bus (make-mock-event-bus)
-                 #:extension-registry (make-mock-ext-registry)
+                 #:event-bus (make-event-bus)
+                 #:extension-registry (make-extension-registry)
                  #:provider-registry reg))
     (ctx-register-provider! ctx "openai" (make-test-provider))
     (ctx-unregister-provider! ctx "openai")
@@ -396,8 +393,8 @@
     (define ctx (make-extension-ctx
                  #:session-id "test"
                  #:session-dir "/tmp"
-                 #:event-bus (make-mock-event-bus)
-                 #:extension-registry (make-mock-ext-registry)
+                 #:event-bus (make-event-bus)
+                 #:extension-registry (make-extension-registry)
                  #:provider-registry reg))
     (ctx-register-provider! ctx "openai" (make-test-provider))
     (ctx-register-provider! ctx "anthropic" (make-test-provider))
@@ -407,8 +404,8 @@
     (define ctx (make-extension-ctx
                  #:session-id "test"
                  #:session-dir "/tmp"
-                 #:event-bus (make-mock-event-bus)
-                 #:extension-registry (make-mock-ext-registry)))
+                 #:event-bus (make-event-bus)
+                 #:extension-registry (make-extension-registry)))
     (check-equal? (ctx-list-providers ctx) '()))
 
   (test-case "ctx-lookup-provider finds provider by name"
@@ -416,8 +413,8 @@
     (define ctx (make-extension-ctx
                  #:session-id "test"
                  #:session-dir "/tmp"
-                 #:event-bus (make-mock-event-bus)
-                 #:extension-registry (make-mock-ext-registry)
+                 #:event-bus (make-event-bus)
+                 #:extension-registry (make-extension-registry)
                  #:provider-registry reg))
     (ctx-register-provider! ctx "openai" (make-test-provider))
     (check-true (provider-info? (ctx-lookup-provider ctx "openai")))

--- a/tools/builtins/spawn-subagent.rkt
+++ b/tools/builtins/spawn-subagent.rkt
@@ -31,13 +31,8 @@
   (define max-turns (hash-ref args 'max-turns 5))
   (define allowed-tools (hash-ref args 'tools #f)) ;; optional list of tool names
 
-  (unless task
-    (return-error "task is required"))
-
-  ;; When task is #f, we already returned via return-error but Racket doesn't
-  ;; know that — use a conditional instead
   (if (not task)
-      (return-error "task is required")
+      (make-error-result "task is required")
       (run-subagent args role-prompt max-turns allowed-tools exec-ctx)))
 
 ;; Resolve the provider from exec-context runtime-settings.
@@ -59,8 +54,8 @@
 ;; Internal: run the subagent
 (define (run-subagent args role-prompt max-turns allowed-tools exec-ctx)
   (define task (hash-ref args 'task))
-  (with-handlers ([exn:fail? (lambda (e)
-                               (return-error (format "subagent failed: ~a" (exn-message e))))])
+    (with-handlers ([exn:fail? (lambda (e)
+                               (make-error-result (format "subagent failed: ~a" (exn-message e))))])
     ;; #1204: Resolve real provider from parent's runtime-settings
     (define provider (resolve-provider exec-ctx))
     (define model-name (resolve-model-name exec-ctx args))
@@ -141,7 +136,3 @@
                          "mock-model"
                          'stop))
   (make-mock-provider mock-response #:name "subagent-mock"))
-
-;; Helper: return error result with proper content structure
-(define (return-error msg)
-  (make-tool-result (list (hasheq 'type "text" 'text msg)) (hasheq 'error #t) #t))

--- a/util/hook-types.rkt
+++ b/util/hook-types.rkt
@@ -48,9 +48,9 @@
           '(pass amend block)
           ;; Message hooks
           'message-start
-          '(pass amend)
+          '(pass amend block)
           'message-end
-          '(pass amend)
+          '(pass amend block)
           ;; #1208: message-update alias (hyphen form of message.update)
           'message-update
           '(amend)
@@ -166,7 +166,8 @@
   (if (member action valid-actions)
       #t
       (begin
-        (log-warning (format "Hook validation: ~a returned invalid action '~a for hook '~a. Valid: ~a"
+        (log-warning (format "Hook validation: ~a returned invalid action '~a' for hook '~a. Valid: ~a"
+                             result
                              action
                              hook-point
                              valid-actions))

--- a/wiring/provider-rpc.rkt
+++ b/wiring/provider-rpc.rkt
@@ -8,6 +8,10 @@
 ;;   providers/find   — find a model by ID or name query
 ;;
 ;; Each handler receives params (hash) and returns a result (hash).
+;;
+;; Error convention: handlers return (hasheq 'status "error" 'message "...")
+;; on failure rather than raising exceptions. This keeps RPC callers in
+;; control and avoids leaking internal exceptions across the wire.
 
 (require racket/list
          (only-in "../runtime/provider-registry.rkt"


### PR DESCRIPTION
Post-implementation audit fixes for v0.11.1.

Fixes all critical, high, and medium findings from V0111_REVIEW_AUDIT.md.
14 files changed, 101 insertions, 95 deletions.