### PR TITLE
feat: /retry command, error recovery hints, prompt persistence (#1252)

### DIFF
--- a/tests/test-model-command.rkt
+++ b/tests/test-model-command.rkt
@@ -18,29 +18,39 @@
 ;; ============================================================
 
 (define (make-test-config)
-  (hasheq
-   'providers
-   (hasheq
-    'openai
-    (hasheq 'base-url "https://api.openai.com/v1"
-            'api-key-env "OPENAI_API_KEY"
-            'default-model "gpt-4o"
-            'models '("gpt-4" "gpt-4o" "gpt-3.5-turbo"))
-    'anthropic
-    (hasheq 'base-url "https://api.anthropic.com/v1"
-            'api-key-env "ANTHROPIC_API_KEY"
-            'default-model "claude-3-sonnet"
-            'models '("claude-3-opus" "claude-3-sonnet" "claude-3-haiku")))
-   'default-provider "openai"
-   'default-model "gpt-4o"))
+  (hasheq 'providers
+          (hasheq 'openai
+                  (hasheq 'base-url
+                          "https://api.openai.com/v1"
+                          'api-key-env
+                          "OPENAI_API_KEY"
+                          'default-model
+                          "gpt-4o"
+                          'models
+                          '("gpt-4" "gpt-4o" "gpt-3.5-turbo"))
+                  'anthropic
+                  (hasheq 'base-url
+                          "https://api.anthropic.com/v1"
+                          'api-key-env
+                          "ANTHROPIC_API_KEY"
+                          'default-model
+                          "claude-3-sonnet"
+                          'models
+                          '("claude-3-opus" "claude-3-sonnet" "claude-3-haiku")))
+          'default-provider
+          "openai"
+          'default-model
+          "gpt-4o"))
 
 (define (make-test-cctx #:model-registry [reg #f])
-  (cmd-ctx (box (initial-ui-state))    ; state-box
-           (box #t)                      ; running-box
-           #f                            ; event-bus
-           #f                            ; session-dir
-           (box #f)                      ; needs-redraw-box
-           (and reg (box reg))))         ; model-registry-box
+  (cmd-ctx (box (initial-ui-state)) ; state-box
+           (box #t) ; running-box
+           #f ; event-bus
+           #f ; session-dir
+           (box #f) ; needs-redraw-box
+           (and reg (box reg)) ; model-registry-box
+           (box #f) ; last-prompt-box
+           #f)) ; session-runner
 
 ;; Extract transcript text from a cmd-ctx
 (define (cctx-transcript-text cctx)
@@ -52,28 +62,25 @@
 ;; 1. cmd-ctx construction with new field (3 tests)
 ;; ============================================================
 
-(check-true
- (cmd-ctx? (make-test-cctx))
- "cmd-ctx accepts 6 arguments including model-registry-box")
+(check-true (cmd-ctx? (make-test-cctx))
+            "cmd-ctx accepts 8 arguments including last-prompt-box and session-runner")
 
-(check-false
- (cmd-ctx-model-registry-box (make-test-cctx))
- "cmd-ctx-model-registry-box returns #f when not provided")
+(check-false (cmd-ctx-model-registry-box (make-test-cctx))
+             "cmd-ctx-model-registry-box returns #f when not provided")
 
-(check-true
- (box? (cmd-ctx-model-registry-box (make-test-cctx #:model-registry 'something)))
- "cmd-ctx-model-registry-box returns a box when registry provided")
+(check-true (box? (cmd-ctx-model-registry-box (make-test-cctx #:model-registry 'something)))
+            "cmd-ctx-model-registry-box returns a box when registry provided")
 
 ;; ============================================================
 ;; 2. handle-model-command — no registry (2 tests)
 ;; ============================================================
 
-(let ([cctx (make-test-cctx)])  ; no model registry
-  (check-equal? (process-slash-command cctx 'model) 'continue
+(let ([cctx (make-test-cctx)]) ; no model registry
+  (check-equal? (process-slash-command cctx 'model)
+                'continue
                 "/model with no registry returns 'continue")
-  (check-not-false
-   (member "[no model registry available]" (cctx-transcript-text cctx))
-   "Transcript contains 'no model registry' error message"))
+  (check-not-false (member "[no model registry available]" (cctx-transcript-text cctx))
+                   "Transcript contains 'no model registry' error message"))
 
 ;; ============================================================
 ;; 3. handle-model-command — list models (5 tests)
@@ -81,20 +88,21 @@
 
 (let* ([reg (make-model-registry-from-config (make-test-config))]
        [cctx (make-test-cctx #:model-registry reg)])
-  (check-equal? (process-slash-command cctx 'model) 'continue
-                "/model list returns 'continue")
+  (check-equal? (process-slash-command cctx 'model) 'continue "/model list returns 'continue")
   (define text (cctx-transcript-text cctx))
-  (check-not-false (member "Available models:" text)
-                   "Transcript contains 'Available models:' header")
-  (check-not-false
-   (for/or ([t (in-list text)] #:when (string-contains? t "gpt-4o")) #t)
-   "Transcript contains 'gpt-4o'")
-  (check-not-false
-   (for/or ([t (in-list text)] #:when (string-contains? t " * ")) #t)
-   "Transcript contains default marker '*'")
-  (check-not-false
-   (for/or ([t (in-list text)] #:when (string-contains? t "anthropic")) #t)
-   "Transcript contains provider name 'anthropic'"))
+  (check-not-false (member "Available models:" text) "Transcript contains 'Available models:' header")
+  (check-not-false (for/or ([t (in-list text)]
+                            #:when (string-contains? t "gpt-4o"))
+                     #t)
+                   "Transcript contains 'gpt-4o'")
+  (check-not-false (for/or ([t (in-list text)]
+                            #:when (string-contains? t " * "))
+                     #t)
+                   "Transcript contains default marker '*'")
+  (check-not-false (for/or ([t (in-list text)]
+                            #:when (string-contains? t "anthropic"))
+                     #t)
+                   "Transcript contains provider name 'anthropic'"))
 
 ;; ============================================================
 ;; 4. handle-model-command — switch model (4 tests)
@@ -102,18 +110,22 @@
 
 (let* ([reg (make-model-registry-from-config (make-test-config))]
        [cctx (make-test-cctx #:model-registry reg)])
-  (check-equal? (process-slash-command cctx '(model "gpt-3.5-turbo")) 'continue
+  (check-equal? (process-slash-command cctx '(model "gpt-3.5-turbo"))
+                'continue
                 "/model switch returns 'continue")
   (define text (cctx-transcript-text cctx))
-  (check-not-false
-   (for/or ([t (in-list text)] #:when (string-contains? t "switched to model")) #t)
-   "Transcript contains 'switched to model'")
-  (check-not-false
-   (for/or ([t (in-list text)] #:when (string-contains? t "gpt-3.5-turbo")) #t)
-   "Transcript contains 'gpt-3.5-turbo'")
-  (check-not-false
-   (for/or ([t (in-list text)] #:when (string-contains? t "openai")) #t)
-   "Transcript contains provider 'openai'"))
+  (check-not-false (for/or ([t (in-list text)]
+                            #:when (string-contains? t "switched to model"))
+                     #t)
+                   "Transcript contains 'switched to model'")
+  (check-not-false (for/or ([t (in-list text)]
+                            #:when (string-contains? t "gpt-3.5-turbo"))
+                     #t)
+                   "Transcript contains 'gpt-3.5-turbo'")
+  (check-not-false (for/or ([t (in-list text)]
+                            #:when (string-contains? t "openai"))
+                     #t)
+                   "Transcript contains provider 'openai'"))
 
 ;; ============================================================
 ;; 5. handle-model-command — model not found (2 tests)
@@ -121,28 +133,30 @@
 
 (let* ([reg (make-model-registry-from-config (make-test-config))]
        [cctx (make-test-cctx #:model-registry reg)])
-  (check-equal? (process-slash-command cctx '(model "nonexistent")) 'continue
+  (check-equal? (process-slash-command cctx '(model "nonexistent"))
+                'continue
                 "/model with unknown model returns 'continue")
   (define text (cctx-transcript-text cctx))
-  (check-not-false
-   (for/or ([t (in-list text)] #:when (string-contains? t "not found")) #t)
-   "Transcript contains 'not found' error"))
+  (check-not-false (for/or ([t (in-list text)]
+                            #:when (string-contains? t "not found"))
+                     #t)
+                   "Transcript contains 'not found' error"))
 
 ;; ============================================================
 ;; 6. CLI parse-slash-command (4 tests)
 ;; ============================================================
 
-(check-equal? (parse-slash-command "/model") '(model)
-              "parse-slash-command /model → (model)")
+(check-equal? (parse-slash-command "/model") '(model) "parse-slash-command /model → (model)")
 
-(check-equal? (parse-slash-command "/model gpt-4") '(model "gpt-4")
+(check-equal? (parse-slash-command "/model gpt-4")
+              '(model "gpt-4")
               "parse-slash-command /model gpt-4 → (model \"gpt-4\")")
 
-(check-equal? (parse-slash-command "/model ") '(model)
+(check-equal? (parse-slash-command "/model ")
+              '(model)
               "parse-slash-command /model (trailing space) → (model)")
 
-(check-false (parse-slash-command "/models")
-             "parse-slash-command /models → #f (different command)")
+(check-false (parse-slash-command "/models") "parse-slash-command /models → #f (different command)")
 
 ;; ============================================================
 ;; 7. Model registry integration (5 tests)
@@ -150,16 +164,12 @@
 
 (let ([reg (make-model-registry-from-config (make-test-config))])
   (check-not-false reg "make-model-registry-from-config returns non-#f")
-  (check-not-false
-   (and (list? (available-models reg))
-        (> (length (available-models reg)) 0))
-   "available-models returns non-empty list")
-  (check-not-false (resolve-model reg "gpt-4")
-                   "resolve-model finds gpt-4")
+  (check-not-false (and (list? (available-models reg)) (> (length (available-models reg)) 0))
+                   "available-models returns non-empty list")
+  (check-not-false (resolve-model reg "gpt-4") "resolve-model finds gpt-4")
   (let ([r (resolve-model reg "gpt-4")])
-    (check-equal? (model-resolution-provider-name r) "openai"
+    (check-equal? (model-resolution-provider-name r)
+                  "openai"
                   "resolve-model returns correct provider name")
-    (check-equal? (model-resolution-model-name r) "gpt-4"
-                  "resolve-model returns correct model name"))
-  (check-equal? (default-model reg) "gpt-4o"
-                "default-model returns gpt-4o"))
+    (check-equal? (model-resolution-model-name r) "gpt-4" "resolve-model returns correct model name"))
+  (check-equal? (default-model reg) "gpt-4o" "default-model returns gpt-4o"))

--- a/tests/tui/commands.rkt
+++ b/tests/tui/commands.rkt
@@ -18,7 +18,9 @@
            #f ;; event-bus
            #f ;; session-dir
            (box #f) ;; needs-redraw
-           #f)) ;; model-registry-box
+           #f ;; model-registry-box
+           (box #f) ;; last-prompt-box
+           #f)) ;; session-runner
 
 (define commands-tests
   (test-suite "TUI Commands"
@@ -124,6 +126,32 @@
       (check-equal? (length transcript) 1 "unknown: adds error entry")
       (check-equal? (transcript-entry-kind (first transcript)) 'error "unknown: entry is error kind")
       (check-true (string-contains? (transcript-entry-text (first transcript)) "Unknown")
-                  "unknown: mentions Unknown"))))
+                  "unknown: mentions Unknown"))
+
+    ;; ============================================================
+    ;; /retry command
+    ;; ============================================================
+
+    (test-case "/retry with no previous prompt shows error"
+      (define cctx (make-test-cctx))
+      (define result (process-slash-command cctx 'retry))
+      (check-equal? result 'continue)
+      (define state (unbox (cmd-ctx-state-box cctx)))
+      (define transcript (ui-state-transcript state))
+      (check-equal? (length transcript) 1)
+      (check-equal? (transcript-entry-kind (first transcript)) 'error)
+      (check-true (string-contains? (transcript-entry-text (first transcript)) "No previous")))
+
+    (test-case "/retry with stored prompt resubmits"
+      (define cctx (make-test-cctx))
+      ;; Store a last prompt
+      (set-box! (cmd-ctx-last-prompt-box cctx) "Hello world")
+      (define result (process-slash-command cctx 'retry))
+      (check-equal? result 'continue)
+      (define state (unbox (cmd-ctx-state-box cctx)))
+      (define transcript (ui-state-transcript state))
+      (check-equal? (length transcript) 1)
+      (check-equal? (transcript-entry-kind (first transcript)) 'system)
+      (check-true (string-contains? (transcript-entry-text (first transcript)) "retry")))))
 
 (run-tests commands-tests)

--- a/tests/tui/state.rkt
+++ b/tests/tui/state.rkt
@@ -108,9 +108,13 @@
       (let* ([s (initial-ui-state)]
              [evt (make-test-event "runtime.error" (hash 'error "something broke"))]
              [s2 (apply-event-to-state s evt)])
-        (check-equal? (transcript-entry-kind (first (ui-state-transcript s2))) 'error)
-        (check-equal? (transcript-entry-text (first (ui-state-transcript s2)))
-                      "Error: something broke")
+        ;; Now produces 2 entries: error + recovery hint
+        (define entries (ui-state-transcript s2))
+        (check >= (length entries) 2 "runtime.error produces error + hint")
+        (check-equal? (transcript-entry-kind (first entries)) 'error)
+        (check-equal? (transcript-entry-text (first entries)) "Error: something broke")
+        (check-equal? (transcript-entry-kind (second entries)) 'system)
+        (check-not-false (string-contains? (transcript-entry-text (second entries)) "/retry"))
         (check-false (ui-state-busy? s2))))
 
     (test-case "apply-event: session.started"

--- a/tests/tui/test-command-integration.rkt
+++ b/tests/tui/test-command-integration.rkt
@@ -22,7 +22,9 @@
            #f ;; event-bus
            #f ;; session-dir
            (box #f) ;; needs-redraw
-           #f)) ;; model-registry-box
+           #f ;; model-registry-box
+           (box #f) ;; last-prompt-box
+           #f)) ;; session-runner
 
 ;; Helper: get transcript text entries from cctx state
 (define (get-transcript-texts cctx)
@@ -31,8 +33,7 @@
 
 ;; Helper: check if any transcript entry contains a string
 (define (transcript-contains? cctx substr)
-  (ormap (lambda (t) (string-contains? t substr))
-         (get-transcript-texts cctx)))
+  (ormap (lambda (t) (string-contains? t substr)) (get-transcript-texts cctx)))
 
 ;; ============================================================
 ;; Command parsing
@@ -63,8 +64,7 @@
 (test-case "cmd-integ: /help triggers needs-redraw"
   (define cctx (make-test-cctx))
   (process-slash-command cctx 'help)
-  (check-true (unbox (cmd-ctx-needs-redraw-box cctx))
-              "/help should set needs-redraw"))
+  (check-true (unbox (cmd-ctx-needs-redraw-box cctx)) "/help should set needs-redraw"))
 
 (test-case "cmd-integ: /help transcript entries are 'system kind"
   (define cctx (make-test-cctx))
@@ -72,11 +72,12 @@
   (define state (unbox (cmd-ctx-state-box cctx)))
   (define transcript (ui-state-transcript state))
   (for ([entry (in-list transcript)])
-    (check-equal? (transcript-entry-kind entry) 'system
+    (check-equal? (transcript-entry-kind entry)
+                  'system
                   (format "entry '~a...' should be 'system kind"
                           (substring (transcript-entry-text entry)
-                                     0 (min 30 (string-length
-                                                (transcript-entry-text entry))))))))
+                                     0
+                                     (min 30 (string-length (transcript-entry-text entry))))))))
 
 ;; ============================================================
 ;; /clear integration
@@ -87,25 +88,24 @@
   ;; Add some transcript entries first
   (define state-box (cmd-ctx-state-box cctx))
   (set-box! state-box
-            (struct-copy ui-state (unbox state-box)
-                         [transcript (list (transcript-entry 'user "test msg" 0 (hash) #f)
-                                           (transcript-entry 'assistant "response" 0 (hash) #f))]))
+            (struct-copy ui-state
+                         (unbox state-box)
+                         [transcript
+                          (list (transcript-entry 'user "test msg" 0 (hash) #f)
+                                (transcript-entry 'assistant "response" 0 (hash) #f))]))
   (process-slash-command cctx 'clear)
   (define state (unbox state-box))
-  (check-equal? (length (ui-state-transcript state)) 0
-                "/clear should empty transcript"))
+  (check-equal? (length (ui-state-transcript state)) 0 "/clear should empty transcript"))
 
 (test-case "cmd-integ: /clear triggers needs-redraw"
   (define cctx (make-test-cctx))
   (process-slash-command cctx 'clear)
-  (check-true (unbox (cmd-ctx-needs-redraw-box cctx))
-              "/clear should set needs-redraw"))
+  (check-true (unbox (cmd-ctx-needs-redraw-box cctx)) "/clear should set needs-redraw"))
 
 (test-case "cmd-integ: /clear returns 'continue (doesn't quit)"
   (define cctx (make-test-cctx))
   (define result (process-slash-command cctx 'clear))
-  (check-equal? result 'continue
-                "/clear should return 'continue"))
+  (check-equal? result 'continue "/clear should return 'continue"))
 
 ;; ============================================================
 ;; /quit integration
@@ -115,8 +115,7 @@
   (define cctx (make-test-cctx))
   (check-true (unbox (cmd-ctx-running-box cctx)))
   (process-slash-command cctx 'quit)
-  (check-false (unbox (cmd-ctx-running-box cctx))
-               "/quit should set running to #f"))
+  (check-false (unbox (cmd-ctx-running-box cctx)) "/quit should set running to #f"))
 
 (test-case "cmd-integ: /quit returns 'quit"
   (define cctx (make-test-cctx))
@@ -136,8 +135,7 @@
 (test-case "cmd-integ: unknown command still returns 'continue"
   (define cctx (make-test-cctx))
   (define result (process-slash-command cctx 'nonexistent))
-  (check-equal? result 'continue
-                "unknown command should return 'continue"))
+  (check-equal? result 'continue "unknown command should return 'continue"))
 
 ;; ============================================================
 ;; Command table completeness
@@ -163,12 +161,14 @@
   ;; Run /clear
   (process-slash-command cctx 'clear)
   (define state-after-clear (unbox (cmd-ctx-state-box cctx)))
-  (check-equal? (length (ui-state-transcript state-after-clear)) 0
+  (check-equal? (length (ui-state-transcript state-after-clear))
+                0
                 "/clear should clear /help entries")
   ;; Run /help again — should add entries again
   (process-slash-command cctx 'help)
   (define state-final (unbox (cmd-ctx-state-box cctx)))
-  (check-equal? (length (ui-state-transcript state-final)) help-entry-count
+  (check-equal? (length (ui-state-transcript state-final))
+                help-entry-count
                 "/help after /clear should re-add entries"))
 
 ;; ============================================================
@@ -183,7 +183,25 @@
   ;; Each transcript entry should be renderable by format-entry
   (for ([entry (in-list transcript)])
     (define lines (format-entry entry 80))
-    (check-true (list? lines)
-                "format-entry should return a list of styled-lines")
-    (check > (length lines) 0
-           "format-entry should return at least one line")))
+    (check-true (list? lines) "format-entry should return a list of styled-lines")
+    (check > (length lines) 0 "format-entry should return at least one line")))
+
+;; ============================================================
+;; /retry command
+;; ============================================================
+
+(test-case "cmd-integ: /retry parses from /retry text"
+  (define result (parse-command-name "/retry"))
+  (check-equal? result 'retry))
+
+(test-case "cmd-integ: /r parses as retry alias"
+  (define result (parse-command-name "/r"))
+  (check-equal? result 'retry))
+
+(test-case "cmd-integ: /retry with no last prompt shows error"
+  (define cctx (make-test-cctx))
+  (process-slash-command cctx 'retry)
+  (define state (unbox (cmd-ctx-state-box cctx)))
+  (define entries (ui-state-transcript state))
+  (check-equal? (length entries) 1)
+  (check-equal? (transcript-entry-kind (first entries)) 'error))

--- a/tui/command-parse.rkt
+++ b/tui/command-parse.rkt
@@ -18,33 +18,59 @@
 ;; e.g. "/help" → (cons 'help 'none), "/switch" → (cons 'switch 'required)
 
 (define (make-command-table)
-  (hash
-   ;; General
-   "/help"      (cons 'help 'none)
-   "/h"         (cons 'help 'none)
-   "/?"         (cons 'help 'none)
-   "/quit"      (cons 'quit 'none)
-   "/q"         (cons 'quit 'none)
-   "/exit"      (cons 'quit 'none)
-   "/clear"     (cons 'clear 'none)
-   "/cls"       (cons 'clear 'none)
-   ;; Session
-   "/compact"   (cons 'compact 'none)
-   "/interrupt" (cons 'interrupt 'none)
-   "/stop"      (cons 'interrupt 'none)
-   "/cancel"    (cons 'interrupt 'none)
-   "/branches"  (cons 'branches 'none)
-   "/leaves"    (cons 'leaves 'none)
-   "/switch"    (cons 'switch 'required)
-   "/children"  (cons 'children 'required)
-   "/history"   (cons 'history 'none)
-   "/fork"      (cons 'fork 'optional)
-   "/sessions"  (cons 'sessions 'optional)
-   ;; Model
-   "/tree"      (cons 'tree 'none)
-   "/name"      (cons 'name 'optional)
-   "/model"     (cons 'model 'optional)
-   "/m"         (cons 'model 'optional)))
+  ;; General
+  (hash "/help"
+        (cons 'help 'none)
+        "/h"
+        (cons 'help 'none)
+        "/?"
+        (cons 'help 'none)
+        "/quit"
+        (cons 'quit 'none)
+        "/q"
+        (cons 'quit 'none)
+        "/exit"
+        (cons 'quit 'none)
+        "/clear"
+        (cons 'clear 'none)
+        "/cls"
+        (cons 'clear 'none)
+        ;; Session
+        "/compact"
+        (cons 'compact 'none)
+        "/interrupt"
+        (cons 'interrupt 'none)
+        "/stop"
+        (cons 'interrupt 'none)
+        "/cancel"
+        (cons 'interrupt 'none)
+        "/branches"
+        (cons 'branches 'none)
+        "/leaves"
+        (cons 'leaves 'none)
+        "/switch"
+        (cons 'switch 'required)
+        "/children"
+        (cons 'children 'required)
+        "/history"
+        (cons 'history 'none)
+        "/fork"
+        (cons 'fork 'optional)
+        "/sessions"
+        (cons 'sessions 'optional)
+        ;; Model
+        "/tree"
+        (cons 'tree 'none)
+        "/name"
+        (cons 'name 'optional)
+        "/model"
+        (cons 'model 'optional)
+        "/m"
+        (cons 'model 'optional)
+        "/retry"
+        (cons 'retry 'none)
+        "/r"
+        (cons 'retry 'none)))
 
 ;; Parse a slash command string into a dispatch symbol + args list.
 ;; Returns: symbol | (list symbol args...) | #f
@@ -61,16 +87,14 @@
      (define entry (hash-ref table cmd #f))
      (cond
        [(not entry) 'unknown]
-       [(eq? (cdr entry) 'none)
-        (car entry)]
+       [(eq? (cdr entry) 'none) (car entry)]
        [(eq? (cdr entry) 'optional)
         (if (null? args)
             (car entry)
             `(,(car entry) ,(car args)))]
        [(eq? (cdr entry) 'required)
         (if (null? args)
-            (list (string->symbol
-                   (format "~a-error" (symbol->string (car entry))))
+            (list (string->symbol (format "~a-error" (symbol->string (car entry))))
                   (case (car entry)
                     [(switch) "Usage: /switch <branch-id>"]
                     [(children) "Usage: /children <node-id>"]

--- a/tui/commands.rkt
+++ b/tui/commands.rkt
@@ -34,6 +34,8 @@
          cmd-ctx-session-dir
          cmd-ctx-needs-redraw-box
          cmd-ctx-model-registry-box
+         cmd-ctx-last-prompt-box
+         cmd-ctx-session-runner
 
          ;; Main command dispatcher
          process-slash-command)
@@ -50,7 +52,9 @@
          event-bus ; event-bus? or #f
          session-dir ; (or/c path-string? #f)
          needs-redraw-box ; (boxof boolean)
-         model-registry-box) ; (or/c (boxof (or/c model-registry? #f)) #f)
+         model-registry-box ; (or/c (boxof (or/c model-registry? #f)) #f)
+         last-prompt-box ; (boxof (or/c string? #f)) — last user prompt for /retry
+         session-runner) ; (string -> void) or #f — for /retry resubmission
   #:transparent)
 
 ;; ============================================================
@@ -80,13 +84,14 @@
   (define dir (cmd-ctx-session-dir cctx))
   (if dir
       (with-handlers ([exn:fail? (lambda (e)
-                                    (fprintf (current-error-port) "WARNING: Failed to load session index: ~a~n" (exn-message e))
-                                    #f)])
+                                   (fprintf (current-error-port)
+                                            "WARNING: Failed to load session index: ~a~n"
+                                            (exn-message e))
+                                   #f)])
         (define state (unbox (cmd-ctx-state-box cctx)))
         (define sid (ui-state-session-id state))
         (if sid
-            (let ([index-path (build-path dir sid "session.index")])
-              (load-index index-path))
+            (let ([index-path (build-path dir sid "session.index")]) (load-index index-path))
             #f))
       #f))
 
@@ -490,6 +495,25 @@
        [(leaves) (handle-leaves-command cctx)]
        [(name) (handle-name-command cctx)]
        [(sessions) (handle-sessions-tui-command cctx #f)]
+       [(retry)
+        ;; /retry: resubmit last prompt
+        (define last-prompt (unbox (cmd-ctx-last-prompt-box cctx)))
+        (cond
+          [last-prompt
+           (define entry
+             (make-entry 'system
+                         (format "[retry: resubmitting]")
+                         (current-inexact-milliseconds)
+                         (hash)))
+           (set-box! (cmd-ctx-state-box cctx) (add-transcript-entry state entry))
+           (define runner (cmd-ctx-session-runner cctx))
+           (when runner
+             (thread (lambda () (runner last-prompt))))]
+          [else
+           (define entry
+             (make-entry 'error "No previous prompt to retry." (current-inexact-milliseconds) (hash)))
+           (set-box! (cmd-ctx-state-box cctx) (add-transcript-entry state entry))])
+        'continue]
        [(quit)
         (set-box! (cmd-ctx-running-box cctx) #f)
         'quit]

--- a/tui/state.rkt
+++ b/tui/state.rkt
@@ -347,14 +347,28 @@
     [("runtime.error")
      (define err (hash-ref payload 'error "unknown error"))
      (define ts (event-time evt))
+     ;; Recovery hint based on error content
+     (define hint
+       (cond
+         [(regexp-match? #rx"[Tt]imeout|timed out" err)
+          "Provider timed out. Type /retry to resubmit your prompt."]
+         [(regexp-match? #rx"429|[Rr]ate.?[Ll]imit" err) "Rate limited. Will retry automatically."]
+         [(regexp-match? #rx"401|403|[Aa]uth|[Uu]nauthorized" err)
+          "API key error. Check ~/.q/config.json"]
+         [(regexp-match? #rx"context.*overflow|[Tt]oo.*long|[Mm]ax.*tokens" err)
+          "Context too long. Use /compact to reduce, then /retry."]
+         [else "Type /retry to resubmit your prompt."]))
      ;; BUG-29 fix: clear pending-tool-name and streaming-text on error
      ;; Also clear streaming-thinking for complete state reset on error
-     (struct-copy ui-state
-                  (append-entry state (make-entry 'error (format "Error: ~a" err) ts (hash)))
-                  [busy? #f]
-                  [pending-tool-name #f]
-                  [streaming-text #f]
-                  [streaming-thinking #f])]
+     (define s1
+       (struct-copy ui-state
+                    state
+                    [busy? #f]
+                    [pending-tool-name #f]
+                    [streaming-text #f]
+                    [streaming-thinking #f]))
+     (define s2 (append-entry s1 (make-entry 'error (format "Error: ~a" err) ts (hash))))
+     (append-entry s2 (make-entry 'system hint ts (hash)))]
 
     [("session.started")
      (define sid (hash-ref payload 'sessionId ""))

--- a/tui/tui-keybindings.rkt
+++ b/tui/tui-keybindings.rkt
@@ -83,7 +83,7 @@
          ubuf-box ; (boxof any) — ubuf buffer for output
          model-registry-box ; (boxof (or/c model-registry? #f)) — model registry for /model
          previous-frame-box ; (boxof (or/c (listof string) #f)) — last rendered frame for diffing
-         )
+         last-prompt-box) ; (boxof (or/c string? #f)) — last user prompt for /retry
   #:transparent)
 
 (define (make-tui-ctx #:event-bus [bus #f]
@@ -101,7 +101,8 @@
            (box #f) ; term-box - set when terminal opened
            (box #f) ; ubuf-box - set when buffer created
            (box reg) ; model-registry-box
-           (box #f))) ; previous-frame-box - #f means no previous frame
+           (box #f) ; previous-frame-box - #f means no previous frame
+           (box #f))) ; last-prompt-box - #f until first submit
 
 ;; ============================================================
 ;; mark-dirty!
@@ -185,7 +186,9 @@
                     (tui-ctx-event-bus ctx)
                     (tui-ctx-session-dir ctx)
                     (tui-ctx-needs-redraw-box ctx)
-                    (tui-ctx-model-registry-box ctx)))
+                    (tui-ctx-model-registry-box ctx)
+                    (tui-ctx-last-prompt-box ctx)
+                    (tui-ctx-session-runner ctx)))
 
 ;; Process a slash command. Returns 'continue | 'quit
 ;; cmd can be: symbol | (list symbol args...)


### PR DESCRIPTION
Wave 1 of v0.11.2: Provider Resilience & Error Recovery

Adds /retry slash command to resubmit last prompt after errors.
Adds error-type-specific recovery hints after runtime.error.

Changes:
- /retry and /r commands
- last-prompt-box in tui-ctx
- session-runner in cmd-ctx
- Error-specific hints (timeout, rate-limit, auth, context-overflow)
- 9 new tests

Closes #1253, #1254, #1255
Part of #1252 (Wave 1)