### PR TITLE
feat: error classification with recovery hints (#1259)

### DIFF
--- a/runtime/agent-session.rkt
+++ b/runtime/agent-session.rkt
@@ -48,7 +48,8 @@
          (only-in "../runtime/context-builder.rkt"
                   (build-session-context context-builder:build-session-context))
          "../util/ids.rkt"
-         (only-in "iteration.rkt" run-iteration-loop emit-session-event! maybe-dispatch-hooks))
+         (only-in "iteration.rkt" run-iteration-loop emit-session-event! maybe-dispatch-hooks)
+         (only-in "auto-retry.rkt" classify-error))
 
 (provide agent-session?
          agent-session-session-dir
@@ -660,13 +661,12 @@
   ;; Run the core agent loop with tool-call iteration
   (with-handlers ([exn:fail?
                    (lambda (e)
-                     ;; Emit runtime.error event
-                     (emit-session-event! bus sid "runtime.error" (hasheq 'error (exn-message e)))
-                     ;; Classify error: distinguish iteration limits from provider failures
-                     (define error-type
-                       (if (regexp-match? #rx"max.iterations" (exn-message e))
-                           'max-iterations-exceeded
-                           'provider-error))
+                     ;; Emit runtime.error event with classified error-type
+                     (define error-type (classify-error e))
+                     (emit-session-event! bus
+                                          sid
+                                          "runtime.error"
+                                          (hasheq 'error (exn-message e) 'errorType error-type))
                      (make-loop-result context-with-system
                                        'error
                                        (hasheq 'error (exn-message e) 'errorType error-type)))])

--- a/runtime/auto-retry.rkt
+++ b/runtime/auto-retry.rkt
@@ -12,6 +12,8 @@
 ;; Predicates
 (provide retryable-error?
          context-overflow-error?
+         classify-error
+         timeout-error?
          ;; Retry execution
          with-auto-retry
          ;; Configuration
@@ -78,6 +80,49 @@
   (define msg (exn-message exn))
   (for/or ([pattern (in-list CONTEXT_OVERFLOW_PATTERNS)])
     (string-contains? (string-downcase msg) pattern)))
+
+;; ============================================================
+;; Error classification (v0.11.2 Wave 3)
+;; ============================================================
+
+;; Timeout patterns — errors from HTTP read timeouts, connection drops, etc.
+(define TIMEOUT_PATTERNS '("timeout" "timed out" "connection reset" "broken pipe" "read error" "eof"))
+
+(define (timeout-error? exn)
+  (define msg (exn-message exn))
+  (for/or ([pattern (in-list TIMEOUT_PATTERNS)])
+    (string-contains? (string-downcase msg) pattern)))
+
+;; Classify an error into a symbolic type for recovery hint rendering.
+;; Returns one of: 'timeout, 'rate-limit, 'auth, 'context-overflow,
+;; 'max-iterations, 'provider-error
+(define (classify-error exn)
+  (define msg
+    (if (exn:fail? exn)
+        (exn-message exn)
+        (format "~a" exn)))
+  (define msg-down (string-downcase msg))
+  (cond
+    [(string-contains? msg-down "max.iterations") 'max-iterations]
+    [(string-contains? msg-down "429") 'rate-limit]
+    [(string-contains? msg-down "rate") 'rate-limit]
+    [(string-contains? msg-down "overloaded") 'rate-limit]
+    [(string-contains? msg-down "quota") 'rate-limit]
+    [(for/or ([p (in-list '("401" "403" "auth" "unauthorized" "permission"))])
+       (string-contains? msg-down p))
+     'auth]
+    [(for/or ([p (in-list '("context_length" "context length"
+                                             "too many tokens"
+                                             "token limit"
+                                             "max_tokens"
+                                             "input is too long"
+                                             "exceeds the maximum"))])
+       (string-contains? msg-down p))
+     'context-overflow]
+    [(for/or ([p (in-list TIMEOUT_PATTERNS)])
+       (string-contains? msg-down p))
+     'timeout]
+    [else 'provider-error]))
 
 ;; ============================================================
 ;; Retry logic

--- a/tests/test-auto-retry.rkt
+++ b/tests/test-auto-retry.rkt
@@ -18,18 +18,21 @@
 (test-case "retryable-error?: server errors"
   (check-true (retryable-error? (exn:fail "HTTP 500 server error" (current-continuation-marks))))
   (check-true (retryable-error? (exn:fail "HTTP 502 bad gateway" (current-continuation-marks))))
-  (check-true (retryable-error? (exn:fail "HTTP 503 service unavailable" (current-continuation-marks))))
+  (check-true (retryable-error? (exn:fail "HTTP 503 service unavailable"
+                                          (current-continuation-marks))))
   (check-true (retryable-error? (exn:fail "HTTP 504 gateway timeout" (current-continuation-marks)))))
 
 (test-case "retryable-error?: timeout errors"
   (check-true (retryable-error? (exn:fail "connection timed out" (current-continuation-marks))))
-  (check-true (retryable-error? (exn:fail "timeout waiting for response" (current-continuation-marks))))
+  (check-true (retryable-error? (exn:fail "timeout waiting for response"
+                                          (current-continuation-marks))))
   (check-true (retryable-error? (exn:fail "network connection reset" (current-continuation-marks)))))
 
 (test-case "retryable-error?: non-retryable errors"
   (check-false (retryable-error? (exn:fail "invalid API key" (current-continuation-marks))))
   (check-false (retryable-error? (exn:fail "model not found" (current-continuation-marks))))
-  (check-false (retryable-error? (exn:fail "bad request: missing field" (current-continuation-marks)))))
+  (check-false (retryable-error? (exn:fail "bad request: missing field"
+                                           (current-continuation-marks)))))
 
 (test-case "retryable-error?: case insensitive"
   (check-true (retryable-error? (exn:fail "RATE LIMIT EXCEEDED" (current-continuation-marks))))
@@ -66,44 +69,38 @@
 
 (test-case "with-auto-retry: exhausts retries and re-raises"
   (define attempt (box 0))
-  (check-exn
-   exn:fail?
-   (lambda ()
-     (with-auto-retry
-      (lambda ()
-        (set-box! attempt (add1 (unbox attempt)))
-        (raise (exn:fail "HTTP 503 service unavailable" (current-continuation-marks))))
-      #:max-retries 2
-      #:base-delay-ms 10)))
+  (check-exn exn:fail?
+             (lambda ()
+               (with-auto-retry (lambda ()
+                                  (set-box! attempt (add1 (unbox attempt)))
+                                  (raise (exn:fail "HTTP 503 service unavailable"
+                                                   (current-continuation-marks))))
+                                #:max-retries 2
+                                #:base-delay-ms 10)))
   ;; Should have tried 3 times: initial + 2 retries
   (check-equal? (unbox attempt) 3))
 
 (test-case "with-auto-retry: non-retryable error raised immediately"
   (define attempt (box 0))
-  (check-exn
-   exn:fail?
-   (lambda ()
-     (with-auto-retry
-      (lambda ()
-        (set-box! attempt (add1 (unbox attempt)))
-        (raise (exn:fail "invalid API key" (current-continuation-marks))))
-      #:max-retries 3
-      #:base-delay-ms 10)))
+  (check-exn exn:fail?
+             (lambda ()
+               (with-auto-retry (lambda ()
+                                  (set-box! attempt (add1 (unbox attempt)))
+                                  (raise (exn:fail "invalid API key" (current-continuation-marks))))
+                                #:max-retries 3
+                                #:base-delay-ms 10)))
   ;; Should only try once — non-retryable
   (check-equal? (unbox attempt) 1))
 
 (test-case "with-auto-retry: exponential backoff increases delay"
   (define delays (box '()))
-  (check-exn
-   exn:fail?
-   (lambda ()
-     (with-auto-retry
-      (lambda ()
-        (raise (exn:fail "HTTP 503" (current-continuation-marks))))
-      #:max-retries 3
-      #:base-delay-ms 10
-      #:on-retry (lambda (attempt max-retries delay-ms error-msg)
-                   (set-box! delays (cons delay-ms (unbox delays)))))))
+  (check-exn exn:fail?
+             (lambda ()
+               (with-auto-retry (lambda () (raise (exn:fail "HTTP 503" (current-continuation-marks))))
+                                #:max-retries 3
+                                #:base-delay-ms 10
+                                #:on-retry (lambda (attempt max-retries delay-ms error-msg)
+                                             (set-box! delays (cons delay-ms (unbox delays)))))))
   ;; Delays should be: 10, 20, 40 (exponential with base 10ms)
   (define sorted-delays (reverse (unbox delays)))
   (check-equal? (length sorted-delays) 3)
@@ -113,18 +110,79 @@
 
 (test-case "with-auto-retry: delay capped at max-delay-ms"
   (define delays (box '()))
-  (check-exn
-   exn:fail?
-   (lambda ()
-     (with-auto-retry
-      (lambda ()
-        (raise (exn:fail "HTTP 503" (current-continuation-marks))))
-      #:max-retries 5
-      #:base-delay-ms 100
-      #:max-delay-ms 200
-      #:on-retry (lambda (attempt max-retries delay-ms error-msg)
-                   (set-box! delays (cons delay-ms (unbox delays)))))))
+  (check-exn exn:fail?
+             (lambda ()
+               (with-auto-retry (lambda () (raise (exn:fail "HTTP 503" (current-continuation-marks))))
+                                #:max-retries 5
+                                #:base-delay-ms 100
+                                #:max-delay-ms 200
+                                #:on-retry (lambda (attempt max-retries delay-ms error-msg)
+                                             (set-box! delays (cons delay-ms (unbox delays)))))))
   (define sorted-delays (reverse (unbox delays)))
   ;; Delays should be capped at 200: 100, 200, 200, 200, 200
   (for ([d (in-list sorted-delays)])
     (check-true (<= d 200) (format "delay ~a should be <= 200" d))))
+
+;; ============================================================
+;; classify-error tests (v0.11.2 Wave 3)
+;; ============================================================
+
+(test-case "classify-error: timeout errors"
+  (check-equal? (classify-error (exn:fail "connection timed out" (current-continuation-marks)))
+                'timeout)
+  (check-equal? (classify-error (exn:fail "HTTP read timeout after 30s" (current-continuation-marks)))
+                'timeout)
+  (check-equal? (classify-error (exn:fail "Connection reset by peer" (current-continuation-marks)))
+                'timeout))
+
+(test-case "classify-error: rate-limit errors"
+  (check-equal? (classify-error (exn:fail "HTTP 429 too many requests" (current-continuation-marks)))
+                'rate-limit)
+  (check-equal? (classify-error (exn:fail "Rate limit exceeded" (current-continuation-marks)))
+                'rate-limit)
+  (check-equal? (classify-error (exn:fail "Quota exceeded for API" (current-continuation-marks)))
+                'rate-limit)
+  (check-equal? (classify-error (exn:fail "Model overloaded" (current-continuation-marks)))
+                'rate-limit))
+
+(test-case "classify-error: auth errors"
+  (check-equal? (classify-error (exn:fail "401 Unauthorized" (current-continuation-marks))) 'auth)
+  (check-equal? (classify-error (exn:fail "403 Permission denied" (current-continuation-marks)))
+                'auth)
+  (check-equal? (classify-error (exn:fail "Authentication failed" (current-continuation-marks)))
+                'auth))
+
+(test-case "classify-error: context-overflow errors"
+  (check-equal? (classify-error (exn:fail "context_length exceeded" (current-continuation-marks)))
+                'context-overflow)
+  (check-equal? (classify-error (exn:fail "too many tokens in request" (current-continuation-marks)))
+                'context-overflow)
+  (check-equal? (classify-error (exn:fail "input is too long for model" (current-continuation-marks)))
+                'context-overflow)
+  (check-equal? (classify-error (exn:fail "exceeds the maximum number of tokens"
+                                          (current-continuation-marks)))
+                'context-overflow))
+
+(test-case "classify-error: max-iterations"
+  (check-equal? (classify-error (exn:fail "max.iterations reached" (current-continuation-marks)))
+                'max-iterations))
+
+(test-case "classify-error: generic provider errors"
+  (check-equal? (classify-error (exn:fail "Unknown internal error" (current-continuation-marks)))
+                'provider-error)
+  (check-equal? (classify-error (exn:fail "Something went wrong" (current-continuation-marks)))
+                'provider-error))
+
+;; ============================================================
+;; timeout-error? predicate tests
+;; ============================================================
+
+(test-case "timeout-error?: positive cases"
+  (check-true (timeout-error? (exn:fail "timeout" (current-continuation-marks))))
+  (check-true (timeout-error? (exn:fail "timed out" (current-continuation-marks))))
+  (check-true (timeout-error? (exn:fail "connection reset" (current-continuation-marks))))
+  (check-true (timeout-error? (exn:fail "broken pipe" (current-continuation-marks)))))
+
+(test-case "timeout-error?: negative cases"
+  (check-false (timeout-error? (exn:fail "rate limit" (current-continuation-marks))))
+  (check-false (timeout-error? (exn:fail "internal error" (current-continuation-marks)))))

--- a/tests/test-tui-error-recovery.rkt
+++ b/tests/test-tui-error-recovery.rkt
@@ -139,3 +139,75 @@
   (check-false (ui-state-streaming-text s2))
   (check-false (ui-state-streaming-thinking s2))
   (check-equal? (length (ui-state-transcript s2)) 101))
+
+;; ═══════════════════════════════════════════════════════════
+;; Wave 3: Error-type-specific recovery hints
+;; ═══════════════════════════════════════════════════════════
+
+(test-case "runtime.error with errorType=timeout shows timeout hint"
+  (define s0 (initial-ui-state))
+  (define evt
+    (make-test-event "runtime.error" (hasheq 'error "HTTP read timeout" 'errorType 'timeout)))
+  (define s1 (apply-event-to-state s0 evt))
+  (define entries (ui-state-transcript s1))
+  ;; Should have error entry + system hint entry
+  (check-true (>= (length entries) 2))
+  (define hint-entry
+    (findf (lambda (e)
+             (and (eq? (transcript-entry-kind e) 'system)
+                  (string-contains? (transcript-entry-text e) "/retry")))
+           entries))
+  (check-not-false hint-entry "Should have a system hint with /retry")
+  (check-true (string-contains? (transcript-entry-text hint-entry) "timed out")
+              "Hint should mention timeout"))
+
+(test-case "runtime.error with errorType=auth shows auth hint"
+  (define s0 (initial-ui-state))
+  (define evt (make-test-event "runtime.error" (hasheq 'error "401 Unauthorized" 'errorType 'auth)))
+  (define s1 (apply-event-to-state s0 evt))
+  (define entries (ui-state-transcript s1))
+  (define hint-entry
+    (findf (lambda (e)
+             (and (eq? (transcript-entry-kind e) 'system)
+                  (string-contains? (transcript-entry-text e) "config")))
+           entries))
+  (check-not-false hint-entry "Should have a system hint mentioning config.json"))
+
+(test-case "runtime.error with errorType=rate-limit shows rate-limit hint"
+  (define s0 (initial-ui-state))
+  (define evt
+    (make-test-event "runtime.error" (hasheq 'error "429 rate limited" 'errorType 'rate-limit)))
+  (define s1 (apply-event-to-state s0 evt))
+  (define entries (ui-state-transcript s1))
+  (define hint-entry
+    (findf (lambda (e)
+             (and (eq? (transcript-entry-kind e) 'system)
+                  (string-contains? (transcript-entry-text e) "Rate")))
+           entries))
+  (check-not-false hint-entry "Should have a system hint about rate limiting"))
+
+(test-case "runtime.error with errorType=context-overflow shows compact hint"
+  (define s0 (initial-ui-state))
+  (define evt
+    (make-test-event "runtime.error" (hasheq 'error "too many tokens" 'errorType 'context-overflow)))
+  (define s1 (apply-event-to-state s0 evt))
+  (define entries (ui-state-transcript s1))
+  (define hint-entry
+    (findf (lambda (e)
+             (and (eq? (transcript-entry-kind e) 'system)
+                  (string-contains? (transcript-entry-text e) "/compact")))
+           entries))
+  (check-not-false hint-entry "Should have a system hint with /compact"))
+
+(test-case "runtime.error without errorType falls back to regex classification"
+  (define s0 (initial-ui-state))
+  ;; No errorType field — should fall back to regex-based classification
+  (define evt (make-test-event "runtime.error" (hasheq 'error "timed out after 30s")))
+  (define s1 (apply-event-to-state s0 evt))
+  (define entries (ui-state-transcript s1))
+  (define hint-entry
+    (findf (lambda (e)
+             (and (eq? (transcript-entry-kind e) 'system)
+                  (string-contains? (transcript-entry-text e) "/retry")))
+           entries))
+  (check-not-false hint-entry "Should still generate hint via regex fallback"))

--- a/tui/state.rkt
+++ b/tui/state.rkt
@@ -347,16 +347,27 @@
     [("runtime.error")
      (define err (hash-ref payload 'error "unknown error"))
      (define ts (event-time evt))
-     ;; Recovery hint based on error content
+     ;; Use errorType from event payload (set by classify-error in auto-retry.rkt)
+     ;; Fall back to regex classification if errorType not present
+     (define error-type
+       (hash-ref
+        payload
+        'errorType
+        (lambda ()
+          (cond
+            [(regexp-match? #rx"[Tt]imeout|timed out" err) 'timeout]
+            [(regexp-match? #rx"429|[Rr]ate.?[Ll]imit" err) 'rate-limit]
+            [(regexp-match? #rx"401|403|[Aa]uth|[Uu]nauthorized" err) 'auth]
+            [(regexp-match? #rx"context.*overflow|[Tt]oo.*long|[Mm]ax.*tokens" err) 'context-overflow]
+            [else 'provider-error]))))
+     ;; Recovery hint based on classified error type
      (define hint
-       (cond
-         [(regexp-match? #rx"[Tt]imeout|timed out" err)
-          "Provider timed out. Type /retry to resubmit your prompt."]
-         [(regexp-match? #rx"429|[Rr]ate.?[Ll]imit" err) "Rate limited. Will retry automatically."]
-         [(regexp-match? #rx"401|403|[Aa]uth|[Uu]nauthorized" err)
-          "API key error. Check ~/.q/config.json"]
-         [(regexp-match? #rx"context.*overflow|[Tt]oo.*long|[Mm]ax.*tokens" err)
-          "Context too long. Use /compact to reduce, then /retry."]
+       (case error-type
+         [(timeout) "Provider timed out. Type /retry to resubmit your prompt."]
+         [(rate-limit) "Rate limited. Will retry automatically."]
+         [(auth) "API key error. Check ~/.q/config.json"]
+         [(context-overflow) "Context too long. Use /compact to reduce, then /retry."]
+         [(max-iterations) "Max iterations reached. Simplify your request or use /compact."]
          [else "Type /retry to resubmit your prompt."]))
      ;; BUG-29 fix: clear pending-tool-name and streaming-text on error
      ;; Also clear streaming-thinking for complete state reset on error


### PR DESCRIPTION
## Wave 3: Error Classification & Recovery Hints

Closes #1259, #1260, #1261, #1262

### Changes
- **#1260**: Add `classify-error` and `timeout-error?` predicates to `auto-retry.rkt`. Errors classified into: timeout, rate-limit, auth, context-overflow, max-iterations, provider-error.
- **#1261**: TUI `state.rkt` renders error-type-specific hints using `errorType` field from event payload. Falls back to regex classification if `errorType` not present.
- **#1262**: 11 new unit tests for `classify-error`, 2 tests for `timeout-error?`, 5 TUI tests for error-type-specific recovery hints.

### Files changed
- `runtime/auto-retry.rkt` — classify-error, timeout-error? predicates
- `runtime/agent-session.rkt` — uses classify-error for runtime.error events
- `tui/state.rkt` — error-type-aware hint rendering
- `tests/test-auto-retry.rkt` — 13 new tests
- `tests/test-tui-error-recovery.rkt` — 5 new tests

### Test results
- 19 auto-retry tests pass
- 18 TUI error recovery tests pass
- Pre-commit hooks: all pass