### PR TITLE
release: v0.11.2 — Provider Resilience & Error Recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.11.2] — 2026-04-19
+
+### Added — Wave 5: Error Scenario Test Catalog (#1267)
+- **State assertion library** (#1268): `tests/tui/state-assertions.rkt` with 13 reusable assertion functions and 4 predicates for TUI state verification.
+- **Error scenario catalog** (#1269): `tests/tui/error-scenarios.rkt` with 6 pre-built failure event sequences (provider-timeout, rate-limit-retry, auth-failure, context-overflow, max-iterations, tool-failure).
+- 16 tests passing across both modules.
+
+### Added — Wave 6: Mock Failure Provider & Integration Tests (#1270)
+- **Mock failure provider** (#1271): `tests/helpers/mock-failure-provider.rkt` with configurable failure injection (6 modes: timeout, rate-limit, auth, context-overflow, partial-response, max-iterations).
+- **TUI error recovery integration tests** (#1272): 12 integration tests in `tests/workflows/test-provider-error-recovery.rkt` covering timeout retry, rate limit, auth failure, context overflow, max iterations, tool failure, partial response, retry resubmit, consecutive timeouts, streaming interrupt, error clears streaming, retry count display.
+
+### Internal
+- 28 tests added across Waves 5-6.
+- Mock failure provider supports `#:failure-mode`, `#:fail-times`, `#:timeout-secs`, `#:partial-chunks` parameters.
+- All 12 TUI error recovery tests pass.
+
 ## [0.11.1] — 2026-04-19
 
 ### Added — Wave 0: Subagent Real Provider (#1203)
@@ -1114,7 +1130,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Session branching, forking, compaction
 - 2189 tests, 0 failures
 
-[Unreleased]: https://github.com/coinerd/q/compare/v0.10.8...HEAD
+[Unreleased]: https://github.com/coinerd/q/compare/v0.11.2...HEAD
+[0.11.2]: https://github.com/coinerd/q/compare/v0.11.1...v0.11.2
 [0.10.4]: https://github.com/coinerd/q/compare/v0.10.3...v0.10.4
 [0.10.3]: https://github.com/coinerd/q/compare/v0.10.2...v0.10.3
 [0.10.2]: https://github.com/coinerd/q/compare/v0.10.1...v0.10.2

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.11.1-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.11.2-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 
@@ -199,7 +199,7 @@ racket main.rkt --model gpt-5.4 "write a test"
 ### Verify
 
 ```bash
-racket main.rkt --version  # q version 0.11.1
+racket main.rkt --version  # q version 0.11.2
 raco test tests/           # run the full test suite
 ```
 

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.11.1")
+(define version "0.11.2")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base"))

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -7,4 +7,4 @@
 
 (provide q-version)
 
-(define q-version "0.11.1")
+(define q-version "0.11.2")


### PR DESCRIPTION
## v0.11.2 Release — Provider Resilience & Error Recovery

### Changes
- Version bump 0.11.1 → 0.11.2
- CHANGELOG updated with Waves 5-6 entries
- 4858 total tests passing, 0 failures

Refs: #1273, #1274, #1275