### PR TITLE
feat(v0.12.0): Wave 5 — Examples, docs, version bump (#1326-#1328)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,49 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.12.0] — 2026-04-19
+
+### Added — Wave 0: Event Taxonomy Foundation (#1308-#1313)
+- **Typed event structs** (#1308): 26 typed event structs in `agent/event-types.rkt` with JSON roundtrip serialization and event registry. Covers turn, message, tool execution, provider, session, input, model-select, agent, and context lifecycle.
+- **Extension context enrichment** (#1309): Extension context already has 14 typed fields (session-id, model-name, event-bus, etc.). Verified — no code changes needed.
+- **Hook point expansion** (#1310): 5 new hook points (47 total) in `util/hook-types.rkt`.
+- **Per-tool typed events** (#1311): Tool-specific structs (bash, edit, write, read, grep, find, custom) inheriting from tool-call-event.
+- **Hook dispatch context** (#1312): dispatch-hooks already accepts `#:ctx`. Verified — no code changes needed.
+- **Extension context factory** (#1313): make-extension-ctx factory already exists. Verified — no code changes needed.
+- 38 new tests in `tests/test-event-types.rkt`, 4 in `tests/test-hook-types.rkt`.
+
+### Added — Wave 1: Session Tree Model (#1314-#1316)
+- **Tree entry types** (#1314): `branch-entry`, `tree-navigation-entry`, `branch-summary-entry` with JSON roundtrip and predicates in `util/protocol-types.rkt`.
+- **Tree store operations** (#1315): `append-tree-entry!`, `load-tree`, `get-tree-branch`, `get-children`, `resolve-active-branch` in `runtime/session-store.rkt`.
+- **Navigation events** (#1316): `#:before-hook`/`#:after-hook` callbacks on `append-tree-entry!` for `session-before-tree`/`session-tree` events.
+- 13 tests in `tests/test-protocol-types.rkt`, 14 in `tests/test-session-tree.rkt`.
+
+### Added — Wave 2: Agent-session Tree Integration (#1317-#1319)
+- **Tree info function** (#1317): `tree-info` returns tree metadata (entries, branch-count, navigation-count, leaf-ids).
+- **Branch summaries** (#1318): `branch-summary-entry` roundtrips through JSONL with text, entry-range, token-count.
+- **SDK tree API** (#1319): `q:session-branch`, `q:session-navigate`, `q:session-tree-info` in `interfaces/sdk.rkt`.
+- 8 tests in `tests/test-agent-session-tree.rkt`.
+
+### Added — Wave 3: Resource Loader + Session Manager + SDK Examples (#1320-#1322)
+- **Resource loader injection** (#1320): `create-agent-session` accepts `#:resource-loader` and `#:session-manager`. `runtime-config` gains both fields.
+- **Session manager abstraction** (#1321): `runtime/session-manager.rkt` with unified interface (persistent + in-memory): `sm-append!`, `sm-load`, `sm-list`, `sm-fork!`.
+- **SDK examples** (#1322): 8 graduated examples in `examples/sdk/` (01-minimal through 08-full-control) with README.
+- 3 tests in `tests/test-sdk-resource-loader.rkt`, 8 in `tests/test-session-manager.rkt`.
+
+### Added — Wave 4: Typed Events + Per-tool Events + Extension Context (#1323-#1325)
+- **Typed event tests** (#1323): 5 tests for typed event construction, bus publishing, and payload inspection.
+- **Per-tool typed events** (#1324): Tests for all 7 per-tool typed events (bash, edit, write, read, grep, find, custom).
+- **Extension context in hooks** (#1325): `maybe-dispatch-hooks` accepts `#:ctx` keyword and passes through to `dispatch-hooks`.
+- 5 tests in `tests/test-loop-events.rkt`, 4 in `tests/test-extension-context-hooks.rkt`.
+
+### Added — Wave 5: Examples + Docs + Version Bump (#1326-#1328)
+- **Extension examples** (#1326): New `typed-event-observer.rkt` example demonstrating per-tool typed event observation.
+- **Documentation** (#1327): `docs/sdk-guide.md`, `docs/event-taxonomy.md`, `docs/session-tree.md`.
+- **Version bump** (#1328): Version bumped to 0.12.0.
+
+### Metrics
+- 216+ source modules, 309+ test files, 40568+ source lines, 67463+ test lines, 10618+ assertions.
+
 ## [0.11.3] — 2026-04-19
 
 ### Added — Wave 0: README & Metrics Consistency (#1283)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.11.3-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.12.0-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 
@@ -199,7 +199,7 @@ racket main.rkt --model gpt-5.4 "write a test"
 ### Verify
 
 ```bash
-racket main.rkt --version  # q version 0.11.3
+racket main.rkt --version  # q version 0.12.0
 raco test tests/           # run the full test suite
 ```
 
@@ -269,8 +269,8 @@ q/
 | Metric | Value |
 |--------|-------|
 | Test files | 309 |
-| Source modules | 216 |
-| Source lines | 40568 |
+| Source modules | 217 |
+| Source lines | 40614 |
 | Test lines | 67463 |
 | Test assertions | 10618 |
 | `racket scripts/run-tests.rkt` results | 4,858+ tests passing |

--- a/docs/event-taxonomy.md
+++ b/docs/event-taxonomy.md
@@ -1,0 +1,223 @@
+# Q Event Taxonomy Reference
+
+Complete reference for all event types in Q v0.12.0.
+
+## Base Types
+
+### `event` (protocol-level)
+All events on the bus are wrapped in an `event` struct:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `version` | integer | Protocol version (currently 1) |
+| `ev` | string | Event name (e.g., "turn.started") |
+| `time` | real | Unix timestamp |
+| `session-id` | string | Session identifier |
+| `turn-id` | string | Turn identifier |
+| `payload` | any | Event-specific data (hash or typed-event struct) |
+
+### `typed-event` (structural base)
+Typed event structs inherit from `typed-event`:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `type` | string | Event category name |
+| `timestamp` | real | Unix timestamp |
+| `session-id` | string | Session identifier |
+| `turn-id` | string | Turn identifier |
+
+## Turn Lifecycle
+
+### `turn-start-event`
+Emitted when an agent turn begins.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `model` | string | Model name |
+| `provider` | string | Provider name |
+
+### `turn-end-event`
+Emitted when a turn completes.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `termination` | symbol | `'completed`, `'cancelled`, `'tool-calls-pending` |
+
+## Message Streaming
+
+### `message-start-event`
+Emitted when a message begins streaming.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `role` | symbol | `'assistant`, `'user` |
+| `model` | string | Model name |
+
+### `message-update-event`
+Emitted for each streaming chunk.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `content` | symbol | Content type |
+| `delta` | string | Text delta |
+
+### `message-end-event`
+Emitted when a message completes streaming.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `role` | symbol | Message role |
+| `reason` | string | Stop reason |
+
+## Tool Execution
+
+### `tool-execution-start-event`
+Emitted before a tool begins execution.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `tool-name` | string | Tool name |
+| `tool-call-id` | string | Unique call ID |
+
+### `tool-execution-update-event`
+Emitted during tool execution with progress.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `tool-name` | string | Tool name |
+| `progress` | string | Progress info |
+
+### `tool-execution-end-event`
+Emitted when a tool completes.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `tool-name` | string | Tool name |
+| `duration-ms` | real | Execution duration |
+| `result-summary` | any | Result data |
+
+## Per-Tool Typed Events
+
+All per-tool events inherit from `tool-call-event`:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `tool-name` | string | Tool name |
+| `arguments` | any | Tool arguments |
+| `tool-call-id` | string | Call ID |
+
+### `bash-tool-call-event`
+| Field | Type | Description |
+|-------|------|-------------|
+| `command` | string | Shell command |
+| `timeout` | real | Timeout in seconds |
+| `cwd` | string | Working directory |
+
+### `edit-tool-call-event`
+| Field | Type | Description |
+|-------|------|-------------|
+| `path` | string | File path |
+| `edits` | list | Edit operations |
+
+### `write-tool-call-event`
+| Field | Type | Description |
+|-------|------|-------------|
+| `path` | string | File path |
+| `content` | string | File content |
+
+### `read-tool-call-event`
+| Field | Type | Description |
+|-------|------|-------------|
+| `path` | string | File path |
+| `offset` | integer | Start line |
+| `limit` | integer | Max lines |
+
+### `grep-tool-call-event`
+| Field | Type | Description |
+|-------|------|-------------|
+| `pattern` | string | Search pattern |
+| `path` | string | Search directory |
+| `glob` | string | File glob |
+
+### `find-tool-call-event`
+| Field | Type | Description |
+|-------|------|-------------|
+| `pattern` | string | File pattern |
+| `path` | string | Search directory |
+
+### `custom-tool-call-event`
+No additional fields. Use `tool-call-event-tool-name` and `tool-call-event-arguments` from parent.
+
+## Provider Events
+
+### `provider-request-event`
+| Field | Type | Description |
+|-------|------|-------------|
+| `model` | string | Requested model |
+| `messages` | integer | Message count |
+
+### `provider-response-event`
+| Field | Type | Description |
+|-------|------|-------------|
+| `model` | string | Responding model |
+| `status` | symbol | Response status |
+
+## Session Events
+
+### `session-start-event`
+| Field | Type | Description |
+|-------|------|-------------|
+| `session-id` | string | Session ID |
+| `model` | string | Model name |
+
+### `session-shutdown-event`
+| Field | Type | Description |
+|-------|------|-------------|
+| `session-id` | string | Session ID |
+| `reason` | symbol | Shutdown reason |
+
+## Tree Events
+
+### `tree-navigation-entry`
+| Field | Type | Description |
+|-------|------|-------------|
+| `entry-id` | string | Entry ID |
+| `parent-entry-id` | string | Source entry |
+| `target-entry-id` | string | Target entry |
+
+### `branch-entry`
+| Field | Type | Description |
+|-------|------|-------------|
+| `entry-id` | string | Branch ID |
+| `parent-entry-id` | string | Parent entry |
+| `branch-name` | string | Branch name |
+
+### `branch-summary-entry`
+| Field | Type | Description |
+|-------|------|-------------|
+| `text` | string | Summary text |
+| `entry-range` | list | Start/end entries |
+| `token-count` | integer | Token count |
+
+## Hook Points (47 total)
+
+Key hook points where extensions can intercept:
+
+| Hook | When | Can Block? |
+|------|------|-----------|
+| `agent-start` | Before LLM call | Yes |
+| `agent-end` | After LLM call | No |
+| `message-start` | Before message stream | Yes |
+| `message-update` | During streaming | Yes |
+| `message-end` | After message complete | No |
+| `tool-call` | Before tool execution | Yes |
+| `tool-result` | After tool execution | No |
+| `session-start` | Session opened | No |
+| `session-shutdown` | Session closed | No |
+| `session-before-fork` | Before fork | Yes |
+| `session-rebind` | Session switch | No |
+| `context-reduce` | Before compaction | Yes |
+| `resources-discover` | Extension resource scan | No |
+| `input` | User input received | No |
+
+For the complete list, see `util/hook-types.rkt`.

--- a/docs/sdk-guide.md
+++ b/docs/sdk-guide.md
@@ -1,0 +1,175 @@
+# Q SDK Guide
+
+Programmatic usage of the Q agent as an embeddable library.
+
+## Quick Start
+
+```racket
+#lang racket
+
+(require "interfaces/sdk.rkt")
+
+;; Create a session with defaults
+(define rt (create-agent-session
+            #:provider (hasheq 'type 'test)))
+
+;; Get session info
+(session-info rt)
+;; => #hasheq((session-id . "...") (active? . #t) ...)
+```
+
+## Configuration Options
+
+### Provider Selection
+
+```racket
+(create-agent-session
+ #:provider (hasheq 'type 'openai
+                    'api-key "sk-..."
+                    'model "gpt-4"))
+```
+
+### Custom Model and Thinking Level
+
+```racket
+(create-agent-session
+ #:provider (hasheq 'type 'test)
+ #:model-name "claude-sonnet-4-20250514"
+ #:thinking-level 'high)
+```
+
+Options: `'off`, `'low`, `'medium`, `'high`
+
+### System Instructions
+
+```racket
+(create-agent-session
+ #:provider (hasheq 'type 'test)
+ #:system-instructions
+ '("You are a helpful coding assistant."
+   "Always write tests first."))
+```
+
+### Custom Tool Registry
+
+```racket
+(require "tools/tool.rkt")
+
+(define registry (make-tool-registry))
+(register-tool! registry
+                (hash 'name 'my-tool
+                      'description "A custom tool"
+                      'parameters '()))
+
+(create-agent-session
+ #:provider (hasheq 'type 'test)
+ #:tool-registry registry)
+```
+
+## Event Subscription
+
+```racket
+;; Subscribe to all events
+(define sub-id
+  (subscribe-events! rt
+                     (lambda (event)
+                       (printf "Event: ~a\n" (event-ev event)))))
+
+;; Unsubscribe
+(unsubscribe! (runtime-config-event-bus (rt-cfg rt)) sub-id)
+```
+
+## Session Management
+
+### In-Memory Sessions
+
+```racket
+(require "runtime/session-manager.rkt")
+
+(define mgr (make-in-memory-session-manager))
+
+(create-agent-session
+ #:provider (hasheq 'type 'test)
+ #:session-manager mgr)
+
+;; List sessions
+(sm-list mgr) ;; => '("session-1" "session-2")
+
+;; Load session entries
+(sm-load mgr "session-1")
+
+;; Fork a session
+(sm-fork! mgr "session-1" "fork-1" "entry-id")
+```
+
+### Persistent Sessions
+
+```racket
+(define mgr (make-persistent-session-manager "/path/to/sessions"))
+
+(sm-append! mgr "my-session"
+            (make-message "m1" #f 'user 'message '() 0 (hasheq)))
+```
+
+## Session Tree Operations
+
+### Branch
+
+```racket
+(q:session-branch rt)
+;; => #hasheq((branch-id . "...") (parent-entry-id . "...") (branch-name . "unnamed"))
+
+(q:session-branch rt "some-entry-id" "my-branch")
+;; => #hasheq((branch-id . "...") (parent-entry-id . "...") (branch-name . "my-branch"))
+```
+
+### Navigate
+
+```racket
+(q:session-navigate rt "target-entry-id")
+;; => #hasheq((navigation-id . "...") (from-entry-id . "...") (target-entry-id . "..."))
+```
+
+### Tree Info
+
+```racket
+(q:session-tree-info rt)
+;; => #hasheq((total-entries . 5) (branch-count . 2) (navigation-count . 1)
+;;            (summary-count . 0) (leaf-ids . '("id1" "id2")))
+```
+
+## Full Dependency Injection
+
+```racket
+(define bus (make-event-bus))
+(define registry (make-tool-registry))
+(define mgr (make-in-memory-session-manager))
+
+(create-agent-session
+ #:provider (hasheq 'type 'test)
+ #:event-bus bus
+ #:tool-registry registry
+ #:session-manager mgr
+ #:max-iterations 20
+ #:system-instructions '("You are an expert coder.")
+ #:token-budget-threshold 80000)
+```
+
+## SDK API Reference
+
+| Function | Description |
+|----------|-------------|
+| `create-agent-session` | Create session with full config |
+| `run-prompt!` | Send prompt and get response |
+| `session-info` | Get session metadata |
+| `subscribe-events!` | Subscribe to event bus |
+| `unsubscribe!` | Remove subscription |
+| `interrupt!` | Cancel current operation |
+| `fork-session!` | Fork at entry |
+| `q:session-branch` | Create branch |
+| `q:session-navigate` | Navigate to entry |
+| `q:session-tree-info` | Tree metadata |
+
+## Examples
+
+See `examples/sdk/` for 8 graduated examples from minimal to full control.

--- a/docs/session-tree.md
+++ b/docs/session-tree.md
@@ -1,0 +1,156 @@
+# Q Session Tree Guide
+
+The session tree model enables branching, navigation, and summarization
+of agent sessions. This allows exploration of alternative approaches,
+backtracking, and efficient context management.
+
+## Concepts
+
+### Tree Structure
+Each session is a tree of entries:
+- **Branch entries** mark fork points where the session diverged
+- **Navigation entries** record movements between branches
+- **Summary entries** store condensed branch content
+
+### Entry Types
+
+| Type | Description |
+|------|-------------|
+| `message` | User/assistant messages |
+| `tool-call` | Tool invocations and results |
+| `branch-entry` | Branch creation marker |
+| `tree-navigation-entry` | Branch navigation record |
+| `branch-summary-entry` | Condensed branch content |
+
+## SDK Operations
+
+### Branch a Session
+
+Create a new branch at the current position:
+
+```racket
+(require "interfaces/sdk.rkt")
+
+;; Branch at current position
+(q:session-branch rt)
+;; => #hasheq((branch-id . "branch-1700000000")
+;;            (parent-entry-id . "session-123")
+;;            (branch-name . "unnamed"))
+
+;; Branch at specific entry with name
+(q:session-branch rt "entry-456" "exploration-branch")
+```
+
+### Navigate Between Branches
+
+Move to a different entry in the tree:
+
+```racket
+(q:session-navigate rt "target-entry-id")
+;; => #hasheq((navigation-id . "nav-1700000001")
+;;            (from-entry-id . "session-123")
+;;            (target-entry-id . "target-entry-id"))
+```
+
+### Query Tree Structure
+
+Get metadata about the session tree:
+
+```racket
+(q:session-tree-info rt)
+;; => #hasheq((total-entries . 42)
+;;            (branch-count . 3)
+;;            (navigation-count . 5)
+;;            (summary-count . 1)
+;;            (leaf-ids . ("id1" "id2" "id3")))
+```
+
+## Low-Level Operations
+
+### Append Tree Entries
+
+```racket
+(require "runtime/session-store.rkt"
+         "util/protocol-types.rkt")
+
+;; Create a branch entry
+(define branch (make-branch-entry "b1" "parent-id" "my-branch"))
+(append-tree-entry! "/path/to/session.jsonl" branch)
+
+;; Create a navigation entry
+(define nav (make-tree-navigation-entry "n1" "from-id" "to-id"))
+(append-tree-entry! "/path/to/session.jsonl" nav
+                    #:before-hook (lambda (e) (printf "Before: ~a\n" e))
+                    #:after-hook (lambda (e) (printf "After: ~a\n" e)))
+```
+
+### Load Tree Structure
+
+```racket
+(define tree (load-tree "/path/to/session.jsonl"))
+;; tree is a hash with tree metadata
+
+(tree-info tree)
+;; => #hasheq((total-entries . 42) (branch-count . 3) ...)
+```
+
+### Fork a Session
+
+```racket
+(fork-session! "/path/to/source.jsonl" "entry-id" "/path/to/fork.jsonl")
+;; Copies root→entry path to a new session file
+```
+
+## Session Manager Integration
+
+The unified session manager supports tree operations:
+
+```racket
+(require "runtime/session-manager.rkt")
+
+;; In-memory tree operations
+(define mgr (make-in-memory-session-manager))
+(sm-append! mgr "s1" (make-branch-entry "b1" "root" "branch-a"))
+(sm-fork! mgr "s1" "s2" "b1")
+
+;; Persistent tree operations
+(define pmgr (make-persistent-session-manager "/sessions"))
+(sm-append! pmgr "s1" (make-message "m1" #f 'user 'message '() 0 (hasheq)))
+```
+
+## Hook Events
+
+Tree operations emit events when hooks are provided:
+
+| Event | When |
+|-------|------|
+| `session-before-tree` | Before tree entry appended |
+| `session-tree` | After tree entry appended |
+
+Wire to dispatch-hooks at the orchestration layer:
+
+```racket
+(append-tree-entry! log-path entry
+  #:before-hook (lambda (e)
+    (dispatch-hooks 'session-before-tree e ext-reg #:ctx ctx))
+  #:after-hook (lambda (e)
+    (dispatch-hooks 'session-tree e ext-reg #:ctx ctx)))
+```
+
+## Use Cases
+
+### 1. Exploration Branching
+Branch before trying a risky refactoring approach. If it doesn't work,
+navigate back and try a different approach.
+
+### 2. Checkpoint + Summarize
+Branch at a stable point, summarize the branch, then continue. The
+summary replaces the full context in future turns.
+
+### 3. A/B Testing Prompts
+Branch the session, apply different system prompts to each branch,
+and compare results.
+
+## Examples
+
+See `examples/sdk/07-tree.rkt` for a complete tree operations example.

--- a/examples/extensions/typed-event-observer.rkt
+++ b/examples/extensions/typed-event-observer.rkt
@@ -1,0 +1,46 @@
+#lang racket/base
+
+;; examples/extensions/typed-event-observer.rkt — Per-tool typed event observer (#1326)
+;;
+;; Demonstrates how to subscribe to events and inspect typed event payloads.
+;; This extension subscribes to the event bus and logs typed tool-call events.
+
+(require "../../agent/event-bus.rkt"
+         "../../agent/event-types.rkt"
+         "../../util/protocol-types.rkt")
+
+;; Example: observe all events on the bus and log typed tool-call events.
+;; Usage: Call (start-observer! bus) to begin, returns subscription ID.
+
+(define (start-observer! bus)
+  (subscribe!
+   bus
+   (lambda (evt)
+     (define payload (event-payload evt))
+     (define ev-name (event-ev evt))
+     (cond
+       ;; Check for typed tool-call events
+       [(bash-tool-call-event? payload)
+        (printf "[typed-event] bash: ~a in ~a (~ams)\n"
+                (bash-tool-call-event-command payload)
+                (bash-tool-call-event-cwd payload)
+                (bash-tool-call-event-timeout payload))]
+       [(edit-tool-call-event? payload)
+        (printf "[typed-event] edit: ~a\n"
+                (edit-tool-call-event-path payload))]
+       [(write-tool-call-event? payload)
+        (printf "[typed-event] write: ~a (~a bytes)\n"
+                (write-tool-call-event-path payload)
+                (string-length (write-tool-call-event-content payload)))]
+       [(read-tool-call-event? payload)
+        (printf "[typed-event] read: ~a\n"
+                (read-tool-call-event-path payload))]
+       [(custom-tool-call-event? payload)
+        (printf "[typed-event] custom: ~a\n"
+                (tool-call-event-tool-name payload))]
+       ;; Non-typed events: just log name
+       [else
+        (printf "[event] ~a\n" ev-name)]))
+   #:filter (lambda (evt) #t)))
+
+(provide start-observer!)

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.11.3")
+(define version "0.12.0")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base"))

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -7,4 +7,4 @@
 
 (provide q-version)
 
-(define q-version "0.11.3")
+(define q-version "0.12.0")


### PR DESCRIPTION
Issues: #1326, #1327, #1328

## Summary
Extension examples, documentation, and version bump to 0.12.0.

### #1326: Extension examples
- New `typed-event-observer.rkt` demonstrating per-tool typed event observation

### #1327: Documentation
- `docs/sdk-guide.md` — Programmatic SDK usage guide with code examples
- `docs/event-taxonomy.md` — Reference for all 47+ event types
- `docs/session-tree.md` — Branching, navigation, summarization guide
- `CHANGELOG.md` — Full v0.12.0 entry with per-wave breakdown

### #1328: Version bump
- `info.rkt`: version → 0.12.0
- `util/version.rkt`: q-version → 0.12.0
- `README.md`: version badge updated, metrics synced

### Tests
- 5242/5242 total tests, 293/293 files, 0 failures