### PR TITLE
[v0.12.3 Wave 0] Stream error boundary + O(n) append fixes

### DIFF
--- a/agent/loop.rkt
+++ b/agent/loop.rkt
@@ -35,6 +35,15 @@
          (only-in "../util/content-helpers.rkt" result-content->string)
          "streaming-message.rkt")
 
+;; ============================================================
+;; Configurable chunk limit (v0.12.3 Wave 0.1)
+;; ============================================================
+
+;; Maximum number of chunks to process from a provider stream.
+;; Prevents infinite loops from misbehaving providers.
+;; Parameterized for testing (set to small value in tests).
+(define MAX-STREAM-CHUNKS (make-parameter 10000))
+
 (provide (contract-out [run-agent-turn
                         (->i ([ctx (listof message?)] [prov provider?] [bus event-bus?])
                              (#:session-id [session-id string?]
@@ -66,7 +75,8 @@
                             (or/c (listof hash?) #f)
                             provider?
                             (or/c procedure? #f)
-                            loop-result?)]))
+                            loop-result?)])
+         MAX-STREAM-CHUNKS)
 
 ;; ============================================================
 ;; Helpers (shared utilities)
@@ -204,118 +214,163 @@
   (define message-id (streaming-message-message-id sm))
 
   (define stream-gen (provider-stream provider req))
+  (define chunk-count (box 0))
+  (define limit (MAX-STREAM-CHUNKS))
 
-  (let stream-loop ()
-    (define chunk (stream-gen))
-    (when (and chunk (not (eq? chunk #f)))
-      (streaming-message-append-chunk! sm chunk)
-      (when (stream-chunk-delta-text chunk)
-        ;; Emit message.start on first text delta
-        (unless (streaming-message-message-started? sm)
-          (streaming-message-set-message-started! sm)
+  ;; v0.12.3 Wave 0.1: Error boundary — emit cleanup events on provider crash.
+  ;; Without this, a mid-stream exception leaves TUI in busy?=#t forever.
+  (with-handlers ([exn:fail?
+                   (lambda (e)
+                     ;; Emit cleanup events so subscribers (TUI) don't hang
+                     (when (streaming-message-message-started? sm)
+                       (emit! bus
+                              session-id
+                              turn-id
+                              "message.end"
+                              (hasheq 'message-id message-id 'usage (hasheq))
+                              #:state state))
+                     (emit!
+                      bus
+                      session-id
+                      turn-id
+                      "turn.completed"
+                      (hasheq 'termination 'error 'turnId turn-id 'reason "provider-stream-error")
+                      #:state state)
+                     (raise e))])
+    (let stream-loop ()
+      (define chunk (stream-gen))
+      (when (and chunk (not (eq? chunk #f)))
+        ;; v0.12.3 Wave 0.1: Chunk limit — prevent infinite streams
+        (set-box! chunk-count (+ 1 (unbox chunk-count)))
+        (when (> (unbox chunk-count) limit)
+          (log-warning
+           (format "stream-from-provider: exceeded ~a chunks, truncating session=~a turn=~a"
+                   limit
+                   session-id
+                   turn-id))
+          ;; Emit stream completion + message.end as if done
           (emit! bus
                  session-id
                  turn-id
-                 "message.start"
-                 (hasheq 'message-id message-id)
-                 #:state state))
-        ;; Text delta
-        (streaming-message-append-text! sm (stream-chunk-delta-text chunk))
-        (emit! bus
-               session-id
-               turn-id
-               "model.stream.delta"
-               (hasheq 'delta (stream-chunk-delta-text chunk))
-               #:state state)
-        ;; Emit message.delta with message-id for extension consumption
-        (emit! bus
-               session-id
-               turn-id
-               "message.delta"
-               (hasheq 'text (stream-chunk-delta-text chunk) 'message-id message-id)
-               #:state state)
-        ;; Dispatch message-update hook for text delta
-        (when hook-dispatcher
-          (define update-result
-            (hook-dispatcher 'message-update
-                             (hasheq 'session-id
-                                     session-id
-                                     'turn-id
-                                     turn-id
-                                     'delta-text
-                                     (stream-chunk-delta-text chunk)
-                                     'delta-tool-call
-                                     #f)))
-          (when (and (hook-result? update-result) (eq? (hook-result-action update-result) 'block))
-            (streaming-message-set-blocked! sm))))
-      ;; FEAT-72: Thinking/reasoning delta
-      (when (stream-chunk-delta-thinking chunk)
-        (streaming-message-append-thinking! sm (stream-chunk-delta-thinking chunk))
-        (emit! bus
-               session-id
-               turn-id
-               "model.stream.thinking"
-               (hasheq 'delta (stream-chunk-delta-thinking chunk))
-               #:state state))
-      (when (stream-chunk-delta-tool-call chunk)
-        ;; Tool call delta
-        (define tc-delta (stream-chunk-delta-tool-call chunk))
-        (streaming-message-append-tool-call! sm tc-delta)
-        (emit! bus
-               session-id
-               turn-id
-               "model.stream.delta"
-               (hasheq 'delta-tool-call tc-delta)
-               #:state state)
-        ;; Dispatch message-update hook for tool-call delta
-        (when hook-dispatcher
-          (define update-result
-            (hook-dispatcher 'message-update
-                             (hasheq 'session-id
-                                     session-id
-                                     'turn-id
-                                     turn-id
-                                     'delta-text
-                                     #f
-                                     'delta-tool-call
-                                     tc-delta)))
-          (when (and (hook-result? update-result) (eq? (hook-result-action update-result) 'block))
-            (streaming-message-set-blocked! sm))))
-      (when (stream-chunk-done? chunk)
-        ;; Stream completed
-        (emit! bus
-               session-id
-               turn-id
-               "model.stream.completed"
-               (hasheq 'usage (or (stream-chunk-usage chunk) (hasheq)))
-               #:state state)
-        ;; Emit message.end if we started a message
-        (when (streaming-message-message-started? sm)
-          (emit! bus
-                 session-id
-                 turn-id
-                 "message.end"
-                 (hasheq 'message-id message-id 'usage (or (stream-chunk-usage chunk) (hasheq)))
-                 #:state state)))
-      ;; Check cancellation after processing chunk
-      (cond
-        [(and cancellation-token (cancellation-token-cancelled? cancellation-token))
-         (streaming-message-set-cancelled! sm)
-         (emit! bus
-                session-id
-                turn-id
-                "turn.cancelled"
-                (hasheq 'reason "cancellation-token")
-                #:state state)]
-        [(streaming-message-blocked? sm)
-         ;; message-update hook blocked -- emit model.stream.completed then stop streaming
-         (emit! bus
-                session-id
-                turn-id
-                "model.stream.completed"
-                (hasheq 'usage (hasheq))
-                #:state state)]
-        [else (stream-loop)])))
+                 "model.stream.completed"
+                 (hasheq 'usage (hasheq) 'truncated? #t)
+                 #:state state)
+          (when (streaming-message-message-started? sm)
+            (emit! bus
+                   session-id
+                   turn-id
+                   "message.end"
+                   (hasheq 'message-id message-id 'usage (hasheq))
+                   #:state state)))
+        (unless (> (unbox chunk-count) limit)
+          (streaming-message-append-chunk! sm chunk)
+          (when (stream-chunk-delta-text chunk)
+            ;; Emit message.start on first text delta
+            (unless (streaming-message-message-started? sm)
+              (streaming-message-set-message-started! sm)
+              (emit! bus
+                     session-id
+                     turn-id
+                     "message.start"
+                     (hasheq 'message-id message-id)
+                     #:state state))
+            ;; Text delta
+            (streaming-message-append-text! sm (stream-chunk-delta-text chunk))
+            (emit! bus
+                   session-id
+                   turn-id
+                   "model.stream.delta"
+                   (hasheq 'delta (stream-chunk-delta-text chunk))
+                   #:state state)
+            ;; Emit message.delta with message-id for extension consumption
+            (emit! bus
+                   session-id
+                   turn-id
+                   "message.delta"
+                   (hasheq 'text (stream-chunk-delta-text chunk) 'message-id message-id)
+                   #:state state)
+            ;; Dispatch message-update hook for text delta
+            (when hook-dispatcher
+              (define update-result
+                (hook-dispatcher 'message-update
+                                 (hasheq 'session-id
+                                         session-id
+                                         'turn-id
+                                         turn-id
+                                         'delta-text
+                                         (stream-chunk-delta-text chunk)
+                                         'delta-tool-call
+                                         #f)))
+              (when (and (hook-result? update-result) (eq? (hook-result-action update-result) 'block))
+                (streaming-message-set-blocked! sm))))
+          ;; FEAT-72: Thinking/reasoning delta
+          (when (stream-chunk-delta-thinking chunk)
+            (streaming-message-append-thinking! sm (stream-chunk-delta-thinking chunk))
+            (emit! bus
+                   session-id
+                   turn-id
+                   "model.stream.thinking"
+                   (hasheq 'delta (stream-chunk-delta-thinking chunk))
+                   #:state state))
+          (when (stream-chunk-delta-tool-call chunk)
+            ;; Tool call delta
+            (define tc-delta (stream-chunk-delta-tool-call chunk))
+            (streaming-message-append-tool-call! sm tc-delta)
+            (emit! bus
+                   session-id
+                   turn-id
+                   "model.stream.delta"
+                   (hasheq 'delta-tool-call tc-delta)
+                   #:state state)
+            ;; Dispatch message-update hook for tool-call delta
+            (when hook-dispatcher
+              (define update-result
+                (hook-dispatcher 'message-update
+                                 (hasheq 'session-id
+                                         session-id
+                                         'turn-id
+                                         turn-id
+                                         'delta-text
+                                         #f
+                                         'delta-tool-call
+                                         tc-delta)))
+              (when (and (hook-result? update-result) (eq? (hook-result-action update-result) 'block))
+                (streaming-message-set-blocked! sm))))
+          (when (stream-chunk-done? chunk)
+            ;; Stream completed
+            (emit! bus
+                   session-id
+                   turn-id
+                   "model.stream.completed"
+                   (hasheq 'usage (or (stream-chunk-usage chunk) (hasheq)))
+                   #:state state)
+            ;; Emit message.end if we started a message
+            (when (streaming-message-message-started? sm)
+              (emit! bus
+                     session-id
+                     turn-id
+                     "message.end"
+                     (hasheq 'message-id message-id 'usage (or (stream-chunk-usage chunk) (hasheq)))
+                     #:state state)))
+          ;; Check cancellation after processing chunk
+          (cond
+            [(and cancellation-token (cancellation-token-cancelled? cancellation-token))
+             (streaming-message-set-cancelled! sm)
+             (emit! bus
+                    session-id
+                    turn-id
+                    "turn.cancelled"
+                    (hasheq 'reason "cancellation-token")
+                    #:state state)]
+            [(streaming-message-blocked? sm)
+             ;; message-update hook blocked -- emit model.stream.completed then stop streaming
+             (emit! bus
+                    session-id
+                    turn-id
+                    "model.stream.completed"
+                    (hasheq 'usage (hasheq))
+                    #:state state)]
+            [else (stream-loop)])))))
 
   (streaming-message->hash sm))
 

--- a/agent/state.rkt
+++ b/agent/state.rkt
@@ -7,23 +7,21 @@
 
 (require racket/contract)
 
-(provide
- ;; Agent loop mutable state
- make-loop-state
- loop-state?
- loop-state-session-id
- loop-state-turn-id
- loop-state-messages
- loop-state-events
- state-add-message!
- state-add-event!)
+;; Agent loop mutable state
+(provide make-loop-state
+         loop-state?
+         loop-state-session-id
+         loop-state-turn-id
+         loop-state-messages
+         loop-state-events
+         state-add-message!
+         state-add-event!)
 
 ;; ============================================================
 ;; Internal struct — mutable boxes for accumulation
 ;; ============================================================
 
-(struct loop-state (session-id turn-id messages-box events-box)
-  #:transparent)
+(struct loop-state (session-id turn-id messages-box events-box) #:transparent)
 
 ;; ============================================================
 ;; Constructor
@@ -37,25 +35,26 @@
 ;; ============================================================
 
 ;; Access accumulated messages (snapshot)
+;; v0.12.3 Wave 0.3: Messages stored in reverse (cons), reversed on read.
+;; This changes O(n²) append to O(1) per add.
 (define (loop-state-messages st)
-  (unbox (loop-state-messages-box st)))
+  (reverse (unbox (loop-state-messages-box st))))
 
 ;; Access accumulated events (snapshot)
 (define (loop-state-events st)
-  (unbox (loop-state-events-box st)))
+  (reverse (unbox (loop-state-events-box st))))
 
 ;; ============================================================
 ;; Mutation helpers
 ;; ============================================================
 
-;; Add a message to the end of the accumulated messages
+;; Add a message — O(1) cons instead of O(n) append
+;; v0.12.3 Wave 0.3: Fixed O(n²) pattern.
 (define (state-add-message! st msg)
-  (set-box! (loop-state-messages-box st)
-            (append (unbox (loop-state-messages-box st)) (list msg)))
+  (set-box! (loop-state-messages-box st) (cons msg (unbox (loop-state-messages-box st))))
   (void))
 
-;; Add an event to the end of the accumulated events
+;; Add an event — O(1) cons instead of O(n) append
 (define (state-add-event! st evt)
-  (set-box! (loop-state-events-box st)
-            (append (unbox (loop-state-events-box st)) (list evt)))
+  (set-box! (loop-state-events-box st) (cons evt (unbox (loop-state-events-box st))))
   (void))

--- a/agent/streaming-message.rkt
+++ b/agent/streaming-message.rkt
@@ -69,7 +69,10 @@
 
 (define (streaming-message-append-tool-call! sm tc)
   (define b (streaming-message-tool-calls-box sm))
-  (set-box! b (append (unbox b) (list tc))))
+  ;; v0.12.3 Wave 0.4: O(1) cons instead of O(n) append.
+  ;; Tool calls are reversed when accessed via streaming-message-finalize
+  ;; and streaming-message->hash.
+  (set-box! b (cons tc (unbox b))))
 
 (define (streaming-message-append-thinking! sm text)
   (define b (streaming-message-thinking-box sm))
@@ -96,7 +99,8 @@
   (unbox (streaming-message-text-box sm)))
 
 (define (streaming-message-tool-calls sm)
-  (unbox (streaming-message-tool-calls-box sm)))
+  ;; v0.12.3 Wave 0.4: reverse to restore insertion order
+  (reverse (unbox (streaming-message-tool-calls-box sm))))
 
 (define (streaming-message-thinking sm)
   (unbox (streaming-message-thinking-box sm)))

--- a/tests/test-loop-edge-cases.rkt
+++ b/tests/test-loop-edge-cases.rkt
@@ -1,14 +1,16 @@
 #lang racket
 
-;; tests/test-loop-edge-cases.rkt — Wave 8: A4-A6 edge case tests
+;; tests/test-loop-edge-cases.rkt — Wave 8 + v0.12.3 Wave 0 edge case tests
 ;;
 ;; Tests edge cases in the agent loop:
 ;; - A4: Stream blocked on first chunk (tool-call delta, no text)
 ;; - A5: message-end hook returns 'amend with empty content + tool calls
 ;; - A6: model-response-post hook raises exception
+;; - 0.1a/b/c: Stream error boundary + chunk limit (v0.12.3 Wave 0)
 
 (require rackunit
          rackunit/text-ui
+         racket/generator
          "../util/protocol-types.rkt"
          "../util/hook-types.rkt"
          "../agent/event-bus.rkt"
@@ -17,138 +19,255 @@
          "../llm/provider.rkt")
 
 (define edge-case-tests
-  (test-suite
-   "Agent Loop Edge Case Tests"
+  (test-suite "Agent Loop Edge Case Tests"
 
-   ;; ============================================================
-   ;; A4: Stream with tool-call delta, no text at all
-   ;; ============================================================
-   ;; When the stream only produces tool-call deltas (no text),
-   ;; the tool calls should still be extracted and returned.
-   (test-case
-    "A4: stream with only tool-call delta, no text"
-    (define events (box '()))
-    (define bus (make-event-bus))
-    (subscribe! bus (lambda (e) (set-box! events (cons e (unbox events)))))
+    ;; ============================================================
+    ;; A4: Stream with tool-call delta, no text at all
+    ;; ============================================================
+    (test-case "A4: stream with only tool-call delta, no text"
+      (define events (box '()))
+      (define bus (make-event-bus))
+      (subscribe! bus (lambda (e) (set-box! events (cons e (unbox events)))))
 
-    ;; Provider that returns only tool-call
-    (define prov
-      (make-provider
-       (lambda () "tool-only-mock")
-       (lambda () (hash 'streaming #t 'token-counting #t))
-       (lambda (req) (make-model-response '() (hasheq) "mock" 'stop))
-       (lambda (req)
-         (list (make-stream-chunk #f
-                             (hasheq 'index 0 'id "tc-1"
-                                     'function (hasheq 'name "read"
-                                                       'arguments "/tmp/file"))
-                             #f #f)
-               (make-stream-chunk #f #f
-                             (hasheq 'prompt-tokens 10 'completion-tokens 5 'total-tokens 15)
-                             #t)))))
+      ;; Provider that returns only tool-call
+      (define prov
+        (make-provider
+         (lambda () "tool-only-mock")
+         (lambda () (hash 'streaming #t 'token-counting #t))
+         (lambda (req) (make-model-response '() (hasheq) "mock" 'stop))
+         (lambda (req)
+           (list (make-stream-chunk
+                  #f
+                  (hasheq 'index 0 'id "tc-1" 'function (hasheq 'name "read" 'arguments "/tmp/file"))
+                  #f
+                  #f)
+                 (make-stream-chunk #f
+                                    #f
+                                    (hasheq 'prompt-tokens 10 'completion-tokens 5 'total-tokens 15)
+                                    #t)))))
 
-    (define ctx (list (make-message "m-1" #f 'user 'message
-                                    (list (make-text-part "Read the file"))
-                                    1000 '#hash())))
-    (define result (run-agent-turn ctx prov bus
-                                   #:session-id "s1" #:turn-id "t1"))
-    (define evts (reverse (unbox events)))
-    (define evt-names (map event-event evts))
+      (define ctx
+        (list (make-message "m-1"
+                            #f
+                            'user
+                            'message
+                            (list (make-text-part "Read the file"))
+                            1000
+                            '#hash())))
+      (define result (run-agent-turn ctx prov bus #:session-id "s1" #:turn-id "t1"))
+      (define evts (reverse (unbox events)))
+      (define evt-names (map event-event evts))
 
-    ;; Should complete normally
-    (check-not-false (member "turn.completed" evt-names)
-                     "turn.completed emitted")
-    ;; No text delta was emitted (no message.start because no text)
-    (check-false (member "message.start" evt-names)
-                 "no message.start for tool-only stream")
-    ;; Should have tool-calls-pending status
-    (check-equal? (loop-result-termination-reason result) 'tool-calls-pending
-                  "result has tool-calls-pending"))
+      ;; Should complete normally
+      (check-not-false (member "turn.completed" evt-names) "turn.completed emitted")
 
-   ;; ============================================================
-   ;; A5: Empty stream (no content, no tool calls) completes normally
-   ;; ============================================================
-   ;; When the stream produces no text and no tool calls,
-   ;; the turn should still complete.
-   (test-case
-    "A5: empty stream (no content, no tool calls) completes"
-    (define events (box '()))
-    (define bus (make-event-bus))
-    (subscribe! bus (lambda (e) (set-box! events (cons e (unbox events)))))
+      ;; No text delta was emitted (no message.start because no text)
+      (check-false (member "message.start" evt-names) "no message.start for tool-only stream")
+      ;; Should have tool-calls-pending status
+      (check-equal? (loop-result-termination-reason result)
+                    'tool-calls-pending
+                    "result has tool-calls-pending"))
 
-    ;; Provider that returns empty stream
-    (define prov
-      (make-provider
-       (lambda () "empty-mock")
-       (lambda () (hash 'streaming #t 'token-counting #t))
-       (lambda (req) (make-model-response '() (hasheq) "mock" 'stop))
-       (lambda (req)
-         (list (make-stream-chunk #f #f
-                             (hasheq 'prompt-tokens 5 'completion-tokens 0 'total-tokens 5)
-                             #t)))))
+    ;; ============================================================
+    ;; A5: Empty stream (no content, no tool calls) completes normally
+    ;; ============================================================
+    (test-case "A5: empty stream (no content, no tool calls) completes"
+      (define events (box '()))
+      (define bus (make-event-bus))
+      (subscribe! bus (lambda (e) (set-box! events (cons e (unbox events)))))
 
-    (define ctx (list (make-message "m-1" #f 'user 'message
-                                    (list (make-text-part "hi"))
-                                    1000 '#hash())))
-    (define result (run-agent-turn ctx prov bus
-                                   #:session-id "s1" #:turn-id "t1"))
-    (define evts (reverse (unbox events)))
-    (define evt-names (map event-event evts))
+      ;; Provider that returns empty stream
+      (define prov
+        (make-provider (lambda () "empty-mock")
+                       (lambda () (hash 'streaming #t 'token-counting #t))
+                       (lambda (req) (make-model-response '() (hasheq) "mock" 'stop))
+                       (lambda (req)
+                         (list (make-stream-chunk
+                                #f
+                                #f
+                                (hasheq 'prompt-tokens 5 'completion-tokens 0 'total-tokens 5)
+                                #t)))))
 
-    ;; Should complete normally
-    (check-not-false (member "turn.completed" evt-names)
-                     "turn.completed emitted on empty stream")
-    (check-equal? (loop-result-termination-reason result) 'completed
-                  "result status is completed")
-    ;; No message events (no text content)
-    (check-false (member "message.start" evt-names)
-                 "no message.start for empty stream"))
+      (define ctx
+        (list (make-message "m-1" #f 'user 'message (list (make-text-part "hi")) 1000 '#hash())))
+      (define result (run-agent-turn ctx prov bus #:session-id "s1" #:turn-id "t1"))
+      (define evts (reverse (unbox events)))
+      (define evt-names (map event-event evts))
 
-   ;; ============================================================
-   ;; A6: model-response-post hook raises exception
-   ;; ============================================================
-   ;; If a hook raises during post-processing, the turn should still
-   ;; emit turn.completed (or at least not hang).
-   (test-case
-    "A6: hook exception during post-processing"
-    (define events (box '()))
-    (define bus (make-event-bus))
-    (subscribe! bus (lambda (e) (set-box! events (cons e (unbox events)))))
+      ;; Should complete normally
+      (check-not-false (member "turn.completed" evt-names) "turn.completed emitted on empty stream")
+      (check-equal? (loop-result-termination-reason result) 'completed "result status is completed")
+      ;; No message events (no text content)
+      (check-false (member "message.start" evt-names) "no message.start for empty stream"))
 
-    ;; Hook dispatcher that raises on message-end
-    (define (failing-hook-dispatcher hook-type data)
-      (if (eq? hook-type 'message-end)
-          (error 'failing-hook "simulated hook failure")
-          (hook-pass)))
+    ;; ============================================================
+    ;; A6: model-response-post hook raises exception
+    ;; ============================================================
+    (test-case "A6: hook exception during post-processing"
+      (define events (box '()))
+      (define bus (make-event-bus))
+      (subscribe! bus (lambda (e) (set-box! events (cons e (unbox events)))))
 
-    ;; Provider with simple text
-    (define prov
-      (make-provider
-       (lambda () "failing-hook-mock")
-       (lambda () (hash 'streaming #t 'token-counting #t))
-       (lambda (req) (make-model-response '() (hasheq) "mock" 'stop))
-       (lambda (req)
-         (list (make-stream-chunk "Hello" #f #f #f)
-               (make-stream-chunk #f #f
-                             (hasheq 'prompt-tokens 5 'completion-tokens 2 'total-tokens 7)
-                             #t)))))
+      ;; Hook dispatcher that raises on message-end
+      (define (failing-hook-dispatcher hook-type data)
+        (if (eq? hook-type 'message-end)
+            (error 'failing-hook "simulated hook failure")
+            (hook-pass)))
 
-    (define ctx (list (make-message "m-1" #f 'user 'message
-                                    (list (make-text-part "hi"))
-                                    1000 '#hash())))
+      ;; Provider with simple text
+      (define prov
+        (make-provider (lambda () "failing-hook-mock")
+                       (lambda () (hash 'streaming #t 'token-counting #t))
+                       (lambda (req) (make-model-response '() (hasheq) "mock" 'stop))
+                       (lambda (req)
+                         (list (make-stream-chunk "Hello" #f #f #f)
+                               (make-stream-chunk
+                                #f
+                                #f
+                                (hasheq 'prompt-tokens 5 'completion-tokens 2 'total-tokens 7)
+                                #t)))))
 
-    ;; The hook exception should propagate (unhandled) — this documents
-    ;; current behavior: hook failures are not caught by the loop
-    (check-exn
-     exn:fail?
-     (lambda ()
-       (run-agent-turn ctx prov bus
-                       #:session-id "s1" #:turn-id "t1"
-                       #:hook-dispatcher failing-hook-dispatcher))))
-  ))
+      (define ctx
+        (list (make-message "m-1" #f 'user 'message (list (make-text-part "hi")) 1000 '#hash())))
+
+      ;; The hook exception should propagate (unhandled) — this documents
+      ;; current behavior: hook failures are not caught by the loop
+      (check-exn exn:fail?
+                 (lambda ()
+                   (run-agent-turn ctx
+                                   prov
+                                   bus
+                                   #:session-id "s1"
+                                   #:turn-id "t1"
+                                   #:hook-dispatcher failing-hook-dispatcher))))))
+
+;; ============================================================
+;; v0.12.3 Wave 0.1: Stream error boundary + chunk limit
+;; ============================================================
+;; These tests verify that:
+;; - Provider crashes mid-stream emit cleanup events (message.end, turn.completed)
+;; - Infinite streams are broken by the chunk limit
+;; - Provider crashes before any text don't emit message.start but still emit turn.completed
+
+(define stream-safety-tests
+  (test-suite "Stream Error Boundary + Chunk Limit"
+
+    ;; ============================================================
+    ;; 0.1a: Provider throws mid-stream → cleanup events emitted
+    ;; ============================================================
+    (test-case "0.1a: provider throws mid-stream, cleanup events emitted"
+      (define events (box '()))
+      (define bus (make-event-bus))
+      (subscribe! bus (lambda (e) (set-box! events (cons e (unbox events)))))
+
+      ;; Provider that yields one text chunk then throws on second call
+      (define call-count (box 0))
+      (define prov
+        (make-provider (lambda () "crashing-mock")
+                       (lambda () (hash 'streaming #t 'token-counting #t))
+                       (lambda (req) (make-model-response '() (hasheq) "mock" 'stop))
+                       (lambda (req)
+                         ;; Return a generator that crashes on 2nd yield
+                         (generator ()
+                                    (set-box! call-count (+ 1 (unbox call-count)))
+                                    (yield (make-stream-chunk "Hello" #f #f #f))
+                                    (set-box! call-count (+ 1 (unbox call-count)))
+                                    (yield (raise (exn:fail "simulated crash"
+                                                            (current-continuation-marks))))))))
+
+      (define ctx
+        (list (make-message "m-1" #f 'user 'message (list (make-text-part "hi")) 1000 '#hash())))
+
+      ;; The provider error should propagate, but cleanup events must be emitted
+      (check-exn exn:fail? (lambda () (run-agent-turn ctx prov bus #:session-id "s1" #:turn-id "t1")))
+
+      (define evts (reverse (unbox events)))
+      (define evt-names (map event-event evts))
+
+      ;; message.start should have been emitted (first chunk had text)
+      (check-not-false (member "message.start" evt-names) "message.start emitted before crash")
+      ;; message.end must be emitted as cleanup
+      (check-not-false (member "message.end" evt-names) "message.end emitted as cleanup after crash")
+      ;; turn.completed must be emitted as cleanup
+      (check-not-false (member "turn.completed" evt-names)
+                       "turn.completed emitted as cleanup after crash"))
+
+    ;; ============================================================
+    ;; 0.1b: Provider that never sends done → chunk limit breaks out
+    ;; ============================================================
+    (test-case "0.1b: infinite stream hits chunk limit and terminates"
+      (define events (box '()))
+      (define bus (make-event-bus))
+      (subscribe! bus (lambda (e) (set-box! events (cons e (unbox events)))))
+
+      ;; Provider that yields text chunks forever, never sends done?=#t
+      (define call-count (box 0))
+      (define prov
+        (make-provider (lambda () "infinite-mock")
+                       (lambda () (hash 'streaming #t 'token-counting #t))
+                       (lambda (req) (make-model-response '() (hasheq) "mock" 'stop))
+                       (lambda (req)
+                         (generator ()
+                                    (let loop ()
+                                      (set-box! call-count (+ 1 (unbox call-count)))
+                                      (yield (make-stream-chunk "x" #f #f #f))
+                                      (loop))))))
+
+      ;; Use parameterized small chunk limit for testing
+      (parameterize ([MAX-STREAM-CHUNKS 100])
+        (define ctx
+          (list (make-message "m-1" #f 'user 'message (list (make-text-part "hi")) 1000 '#hash())))
+        (define result (run-agent-turn ctx prov bus #:session-id "s1" #:turn-id "t1"))
+
+        ;; Should complete (not hang forever)
+        (check-equal? (loop-result-termination-reason result)
+                      'completed
+                      "turn completes even with infinite stream")
+
+        (define evts (reverse (unbox events)))
+        (define evt-names (map event-event evts))
+        ;; Should have message.start, message.end, turn.completed
+        (check-not-false (member "message.start" evt-names))
+        (check-not-false (member "message.end" evt-names))
+        (check-not-false (member "turn.completed" evt-names))
+        ;; Chunk count should be limited
+        (check-true (<= (unbox call-count) 105)
+                    (format "chunk count ~a is within limit" (unbox call-count)))))
+
+    ;; ============================================================
+    ;; 0.1c: Provider throws before first text → no message.start
+    ;; ============================================================
+    (test-case "0.1c: provider throws before any text, no message.start"
+      (define events (box '()))
+      (define bus (make-event-bus))
+      (subscribe! bus (lambda (e) (set-box! events (cons e (unbox events)))))
+
+      (define prov
+        (make-provider (lambda () "early-crash-mock")
+                       (lambda () (hash 'streaming #t 'token-counting #t))
+                       (lambda (req) (make-model-response '() (hasheq) "mock" 'stop))
+                       (lambda (req)
+                         (generator ()
+                                    (yield (raise (exn:fail "crash on first chunk"
+                                                            (current-continuation-marks))))))))
+
+      (define ctx
+        (list (make-message "m-1" #f 'user 'message (list (make-text-part "hi")) 1000 '#hash())))
+
+      (check-exn exn:fail? (lambda () (run-agent-turn ctx prov bus #:session-id "s1" #:turn-id "t1")))
+
+      (define evts (reverse (unbox events)))
+      (define evt-names (map event-event evts))
+
+      ;; No message.start was emitted
+      (check-false (member "message.start" evt-names) "no message.start when crash before text")
+      ;; But turn.completed should still be emitted as cleanup
+      (check-not-false (member "turn.completed" evt-names) "turn.completed emitted as cleanup"))))
 
 (module+ main
-  (run-tests edge-case-tests))
+  (run-tests edge-case-tests)
+  (run-tests stream-safety-tests))
 
 (module+ test
-  (run-tests edge-case-tests))
+  (run-tests edge-case-tests)
+  (run-tests stream-safety-tests))

--- a/tui/render.rkt
+++ b/tui/render.rkt
@@ -80,9 +80,10 @@
   ;; BUG-NEWLINE-BLEED fix: sanitize newlines in tool results/errors
   ;; Newlines in styled-line text cause terminal row overflow.
   ;; Replace with ⏎ visual indicator.
-  (define text (if (memq kind '(tool-end tool-fail tool-start))
-                    (string-replace raw-text "\n" " \u23ce ")
-                    raw-text))
+  (define text
+    (if (memq kind '(tool-end tool-fail tool-start))
+        (string-replace raw-text "\n" " \u23ce ")
+        raw-text))
   ;; BUG-37 fix: skip whitespace-only assistant entries
   (case kind
     [(assistant)


### PR DESCRIPTION
Wave 0: Critical Correctness (P0)

Addresses #1358 #1360 #1361 from milestone #68.

Changes:
- Error boundary around stream-from-provider
- MAX-STREAM-CHUNKS parameter prevents infinite streams
- O(1) cons in agent/state.rkt and streaming-message.rkt

302 files, 5302 tests, 0 failures