### PR TITLE
fix: Remove context-reducer from retry path (#1388)

### DIFF
--- a/runtime/auto-retry.rkt
+++ b/runtime/auto-retry.rkt
@@ -165,13 +165,11 @@
                          #:rate-limit-base-delay-ms
                          [rl-base-delay-ms default-rate-limit-base-delay-ms]
                          #:max-delay-ms [max-delay-ms default-max-delay-ms]
-                         #:on-retry [on-retry #f]
-                         #:context-reducer [context-reducer #f])
+                         #:on-retry [on-retry #f])
   (let loop ([attempt 0]
              [delay-ms 0]
              [total-delay 0]
-             [last-error-type #f]
-             [current-thunk thunk])
+             [last-error-type #f])
     (with-handlers
         ([exn:fail?
           (lambda (exn)
@@ -181,16 +179,13 @@
                ;; A1: Use longer backoff for rate-limit errors
                (define rl-base (if (eq? err-type 'rate-limit) rl-base-delay-ms base-delay-ms))
                (define next-delay (min (* rl-base (expt 2 attempt)) max-delay-ms))
-               ;; For timeout errors, apply context reduction if available
-               (define next-thunk
-                 (let ([reduced
-                        (and context-reducer (timeout-error? exn) (context-reducer (add1 attempt)))])
-                   (or reduced current-thunk)))
+               ;; v0.13.2: No context reduction on retry — retries use same thunk.
+               ;; Context management is a separate concern (v0.14.0 context manager).
                ;; Call retry callback if provided
                (when on-retry
                  (on-retry (add1 attempt) max-retries next-delay (exn-message exn)))
                (sleep (/ next-delay 1000.0))
-               (loop (add1 attempt) next-delay (+ total-delay next-delay) err-type next-thunk)]
+               (loop (add1 attempt) next-delay (+ total-delay next-delay) err-type)]
               [else
                ;; A3: Wrap in retry-exhausted if we attempted retries
                (if (> attempt 0)
@@ -201,4 +196,4 @@
                                            last-error-type
                                            total-delay))
                    (raise exn))]))])
-      (current-thunk))))
+      (thunk))))

--- a/runtime/iteration.rkt
+++ b/runtime/iteration.rkt
@@ -101,9 +101,7 @@
                   context-overflow-error?
                   timeout-error?)
          ;; FEAT-61: message injection support
-         (only-in "../extensions/message-inject.rkt" injection-event-topic)
-         ;; #1329: pair-aware context reduction for retry
-         (only-in "../runtime/context-reducer.rkt" trim-context-pair-aware))
+         (only-in "../extensions/message-inject.rkt" injection-event-topic))
 
 (provide run-iteration-loop
          emit-session-event!
@@ -261,41 +259,6 @@
                      #:cancellation-token token))
    #:max-retries 2
    #:base-delay-ms 1000
-   #:context-reducer (lambda (attempt)
-                       ;; On timeout retry: pair-aware trim that keeps tool_call/result pairs atomic.
-                       ;; Ensures first non-system message is always 'user (#1329).
-                       (define ctx (unbox ctx-for-retry))
-                       (define n (length ctx))
-                       (define keep-count (max 4 (quotient n 2)))
-                       (define reduced-ctx (trim-context-pair-aware ctx keep-count))
-                       (define reduced-n (length reduced-ctx))
-                       ;; A2: No-op guard — if no meaningful reduction happened, don't waste a retry
-                       (define effective? (> (- n reduced-n) 1))
-                       (publish! bus
-                                 (make-event "auto-retry.context-reduced"
-                                             (current-inexact-milliseconds)
-                                             session-id
-                                             turn-id
-                                             (hasheq 'original-messages
-                                                     n
-                                                     'reduced-messages
-                                                     reduced-n
-                                                     'attempt
-                                                     attempt
-                                                     'effective?
-                                                     effective?)))
-                       (cond
-                         [effective?
-                          (set-box! ctx-for-retry reduced-ctx)
-                          (lambda ()
-                            (run-agent-turn (unbox ctx-for-retry)
-                                            prov
-                                            bus
-                                            #:session-id session-id
-                                            #:turn-id turn-id
-                                            #:tools tools
-                                            #:cancellation-token token))]
-                         [else #f]))
    #:on-retry
    (lambda (attempt max-retries delay-ms error-msg)
      (publish!

--- a/tests/test-auto-retry.rkt
+++ b/tests/test-auto-retry.rkt
@@ -188,45 +188,22 @@
   (check-false (timeout-error? (exn:fail "internal error" (current-continuation-marks)))))
 
 ;; ============================================================
-;; Context reduction on timeout retry tests (v0.11.2 Wave 4)
+;; No context reduction on retry (v0.13.2)
 ;; ============================================================
 
-(test-case "with-auto-retry: context-reducer called on timeout"
-  (define reduction-log (box '()))
+(test-case "with-auto-retry: retries use same thunk on timeout (no context reduction)"
+  ;; v0.13.2: #:context-reducer removed. Retries always use original thunk.
   (define call-count (box 0))
-  (check-exn exn:fail?
-             (lambda ()
-               (with-auto-retry
-                (lambda ()
-                  (set-box! call-count (add1 (unbox call-count)))
-                  (raise (exn:fail "HTTP read timeout" (current-continuation-marks))))
-                #:max-retries 2
-                #:base-delay-ms 1
-                #:context-reducer
-                (lambda (attempt)
-                  (set-box! reduction-log (cons attempt (unbox reduction-log)))
-                  ;; Return same thunk (context reduction is tested in iteration.rkt integration)
-                  (lambda ()
-                    (set-box! call-count (add1 (unbox call-count)))
-                    (raise (exn:fail "HTTP read timeout" (current-continuation-marks))))))))
-  ;; Context reducer should have been called for timeout errors
-  (check-equal? (reverse (unbox reduction-log)) '(1 2)))
-
-(test-case "with-auto-retry: context-reducer NOT called on non-timeout errors"
-  (define reduction-log (box '()))
-  (check-exn exn:fail?
-             (lambda ()
-               (with-auto-retry
-                (lambda () (raise (exn:fail "HTTP 429 rate limit" (current-continuation-marks))))
-                #:max-retries 1
-                #:base-delay-ms 1
-                #:context-reducer (lambda (attempt)
-                                    (set-box! reduction-log (cons attempt (unbox reduction-log)))
-                                    (lambda ()
-                                      (raise (exn:fail "HTTP 429 rate limit"
-                                                       (current-continuation-marks))))))))
-  ;; Context reducer should NOT have been called for rate-limit errors
-  (check-equal? (unbox reduction-log) '()))
+  (define result
+    (with-auto-retry (lambda ()
+                       (set-box! call-count (add1 (unbox call-count)))
+                       (if (= (unbox call-count) 1)
+                           (raise (exn:fail "timeout" (current-continuation-marks)))
+                           'success))
+                     #:max-retries 1
+                     #:base-delay-ms 1))
+  (check-equal? result 'success)
+  (check-equal? (unbox call-count) 2))
 
 ;; ============================================================
 ;; A1: Rate-limit-specific backoff tests (v0.12.2)
@@ -343,21 +320,8 @@
   (check-false (rate-limit-error? (exn:fail "invalid API key" (current-continuation-marks)))))
 
 ;; ============================================================
-;; context-reducer #f return (no-op) tests (v0.12.2)
+;; context-reducer tests removed (v0.13.2)
 ;; ============================================================
-
-(test-case "context-reducer returning #f keeps original thunk"
-  (define call-count (box 0))
-  (define original-value 'original-result)
-  (define result
-    (with-auto-retry (lambda ()
-                       (set-box! call-count (add1 (unbox call-count)))
-                       (if (= (unbox call-count) 1)
-                           (raise (exn:fail "timeout" (current-continuation-marks)))
-                           'retry-result))
-                     #:max-retries 1
-                     #:base-delay-ms 1
-                     #:context-reducer (lambda (attempt) #f)))
-  ;; Should succeed — reducer returned #f so original thunk is used
-  (check-equal? result 'retry-result)
-  (check-equal? (unbox call-count) 2))
+;; The #:context-reducer parameter was removed in v0.13.2.
+;; Retries now always use the same thunk without any context reduction.
+;; See "retries use same thunk on timeout" test above.


### PR DESCRIPTION
Addresses #1388.

fix: remove context-reducer from retry path (#1388)

Retries now always use the same context — no trimming, no reduction.
The #:context-reducer parameter is removed from with-auto-retry in
auto-retry.rkt and the caller lambda in iteration.rkt. This eliminates
the P0 class of 400 errors from malformed reduced context after retry.

context-reducer.rkt module preserved for other callers (v0.14.0 removal).

v0.13.2 milestone: Remove Context Reduction from Retry