### PR TITLE
feat: Context Manager Core — strategy-driven assembly (#1390)

### DIFF
--- a/runtime/context-manager.rkt
+++ b/runtime/context-manager.rkt
@@ -1,0 +1,211 @@
+#lang racket/base
+
+;; q/runtime/context-manager.rkt — Context assembly from session log
+;;
+;; Replaces context-builder.rkt truncation with strategy-driven assembly.
+;; The session log is immutable — this module decides what goes into the
+;; LLM context window using pluggable strategies:
+;;   1. Pin: system prompt + first user message (always)
+;;   2. Summary: placeholder for LLM-generated summaries (Wave 2A)
+;;   3. Recent: last N tokens kept verbatim
+;;   4. Catalog: one-line-per-entry summary of excluded entries
+;;   5. Budget enforcement: total ≤ token budget
+;;
+;; Issue #1390: Wave 0 — Context Manager Core
+
+(require racket/list
+         racket/string
+         "../util/protocol-types.rkt"
+         "../runtime/session-index.rkt"
+         "../runtime/context-builder.rkt"
+         "../llm/token-budget.rkt")
+
+(provide context-manager-config
+         context-manager-config?
+         context-manager-config-recent-tokens
+         context-manager-config-max-catalog-entries
+         context-manager-config-max-catalog-tokens
+         context-manager-config-summary-window
+         make-context-manager-config
+         ;; Core API
+         assemble-context
+         generate-catalog
+         ;; Catalog entry struct
+         catalog-entry
+         catalog-entry?
+         catalog-entry-id
+         catalog-entry-role
+         catalog-entry-summary
+         ;; Token estimation (re-exported for tests)
+         estimate-cm-message-tokens)
+
+;; ============================================================
+;; Configuration
+;; ============================================================
+
+(struct context-manager-config
+        (recent-tokens ; tokens for the recent window (default 30000)
+         max-catalog-entries ; max catalog entries (default 40)
+         max-catalog-tokens ; max catalog token budget (default 2000)
+         summary-window) ; tokens for summary window (default 4000, Wave 2A placeholder)
+  #:transparent)
+
+(define (make-context-manager-config #:recent-tokens [recent 30000]
+                                     #:max-catalog-entries [max-entries 40]
+                                     #:max-catalog-tokens [max-tokens 2000]
+                                     #:summary-window [summary 4000])
+  (context-manager-config recent max-entries max-tokens summary))
+
+;; ============================================================
+;; Catalog entry struct
+;; ============================================================
+
+(struct catalog-entry (id role summary) #:transparent)
+
+;; ============================================================
+;; Token estimation
+;; ============================================================
+
+(define (estimate-cm-message-tokens msg)
+  (define text-parts
+    (for/list ([part (in-list (message-content msg))]
+               #:when (text-part? part))
+      (text-part-text part)))
+  (estimate-text-tokens (string-join text-parts " ")))
+
+;; ============================================================
+;; Core: assemble-context
+;; ============================================================
+
+;; Assemble a provider-ready message list from the session index.
+;; Returns (values messages catalog-entries).
+;;   messages: (listof message?) — the context window for the LLM
+;;   catalog-entries: (listof catalog-entry?) — summaries of excluded entries
+(define (assemble-context idx config)
+  (define raw-messages (build-session-context idx))
+  (cond
+    [(null? raw-messages) (values '() '())]
+    [else
+     (define max-tokens (context-manager-config-recent-tokens config))
+     ;; Phase 1: Identify pinned items (system prompt + first user message)
+     (define-values (pinned removable) (partition-messages raw-messages))
+     (define pinned-tokens (for/sum ([m (in-list pinned)]) (estimate-cm-message-tokens m)))
+
+     ;; Phase 3: Fit recent messages within remaining budget
+     (define remaining-budget (- max-tokens pinned-tokens))
+     (define-values (recent excluded)
+       (if (<= remaining-budget 0)
+           (values '() removable)
+           (fit-recent removable remaining-budget)))
+
+     ;; Phase 4: Generate catalog for excluded entries
+     (define max-entries (context-manager-config-max-catalog-entries config))
+     (define catalog (generate-catalog excluded #:max-entries max-entries))
+
+     ;; Phase 5: Reassemble in original order
+     (define pinned-ids
+       (for/hash ([m (in-list pinned)])
+         (values (message-id m) #t)))
+     (define recent-ids
+       (for/hash ([m (in-list recent)])
+         (values (message-id m) #t)))
+     (define result-messages
+       (for/list ([m (in-list raw-messages)]
+                  #:when (or (hash-has-key? pinned-ids (message-id m))
+                             (hash-has-key? recent-ids (message-id m))))
+         m))
+
+     ;; Ensure first user message is in result (pin guarantee)
+     (define result-with-pin (ensure-first-user-pinned result-messages raw-messages))
+
+     (values result-with-pin catalog)]))
+
+;; ============================================================
+;; Phase 1: Pin system prompt + first user message
+;; ============================================================
+
+(define (partition-messages messages)
+  (define first-user
+    (for/first ([m (in-list messages)]
+                #:when (eq? (message-role m) 'user))
+      m))
+  (define-values (protected removable)
+    (partition (lambda (m)
+                 (or (eq? (message-kind m) 'system-instruction)
+                     (eq? (message-kind m) 'compaction-summary)
+                     (and first-user (eq? m first-user))))
+               messages))
+  (values protected removable))
+
+;; ============================================================
+;; Phase 3: Fit recent messages
+;; ============================================================
+
+(define (fit-recent messages budget)
+  (let loop ([remaining (reverse messages)]
+             [kept '()]
+             [excluded '()]
+             [used 0])
+    (cond
+      [(null? remaining) (values (reverse kept) (reverse excluded))]
+      [else
+       (define m (car remaining))
+       (define tokens (estimate-cm-message-tokens m))
+       (cond
+         [(> (+ used tokens) budget) (loop (cdr remaining) kept (cons m excluded) used)]
+         [else (loop (cdr remaining) (cons m kept) excluded (+ used tokens))])])))
+
+;; ============================================================
+;; Phase 4: Catalog generation
+;; ============================================================
+
+(define (generate-catalog entries #:max-entries [max-entries 40])
+  (for/list ([m (in-list entries)]
+             [i (in-naturals)]
+             #:break (>= i max-entries))
+    (define text (extract-message-text m))
+    (define summary (truncate-string text 80))
+    (define role-str (symbol->string (message-role m)))
+    (catalog-entry (message-id m) role-str summary)))
+
+;; ============================================================
+;; Helpers
+;; ============================================================
+
+(define (extract-message-text msg)
+  (define parts (message-content msg))
+  (define texts
+    (for/list ([part (in-list parts)]
+               #:when (text-part? part))
+      (text-part-text part)))
+  (string-join texts " "))
+
+(define (truncate-string s max-len)
+  (if (<= (string-length s) max-len)
+      s
+      (string-append (substring s 0 (- max-len 3)) "...")))
+
+(define (ensure-first-user-pinned result original)
+  (define first-user
+    (for/first ([m (in-list original)]
+                #:when (eq? (message-role m) 'user))
+      m))
+  (cond
+    [(not first-user) result]
+    [(member first-user result) result]
+    [else
+     (define target-id (message-id first-user))
+     (define after-id
+       (for/first ([m (in-list (dropf original (lambda (m) (not (equal? (message-id m) target-id)))))]
+                   #:when (member m result))
+         (message-id m)))
+     (cond
+       [after-id
+        (let loop ([acc '()]
+                   [rem result])
+          (cond
+            [(null? rem) (reverse (cons first-user acc))]
+            [(equal? (message-id (car rem)) after-id)
+             (loop (cons (car rem) (cons first-user acc)) (cdr rem))]
+            [else (loop (cons (car rem) acc) (cdr rem))]))]
+       [else (cons first-user result)])]))

--- a/tests/test-context-manager.rkt
+++ b/tests/test-context-manager.rkt
@@ -1,0 +1,204 @@
+#lang racket
+
+;; tests/test-context-manager.rkt — Tests for runtime/context-manager.rkt (#1390)
+;; Wave 0: Context Manager Core — replace truncation with assembly
+
+(require rackunit
+         rackunit/text-ui
+         racket/file
+         racket/list
+         "../util/protocol-types.rkt"
+         "../runtime/session-store.rkt"
+         "../runtime/session-index.rkt"
+         "../runtime/context-manager.rkt")
+
+;; Helpers
+(define (make-temp-dir)
+  (make-temporary-file "q-ctx-mgr-test-~a" 'directory))
+
+(define (session-path dir)
+  (build-path dir "session.jsonl"))
+
+(define (index-path dir)
+  (build-path dir "session.index"))
+
+(define (make-test-msg id parent-id role kind text)
+  (make-message id parent-id role kind (list (make-text-part text)) (current-seconds) (hasheq)))
+
+(define context-manager-tests
+  (test-suite "context-manager"
+
+    ;; ============================================================
+    ;; Config tests
+    ;; ============================================================
+
+    (test-case "config: default construction"
+      (define cfg (make-context-manager-config))
+      (check-true (context-manager-config? cfg))
+      (check-equal? (context-manager-config-recent-tokens cfg) 30000)
+      (check-equal? (context-manager-config-max-catalog-entries cfg) 40)
+      (check-equal? (context-manager-config-max-catalog-tokens cfg) 2000))
+
+    (test-case "config: custom values"
+      (define cfg
+        (make-context-manager-config #:recent-tokens 10000
+                                     #:max-catalog-entries 20
+                                     #:max-catalog-tokens 1000))
+      (check-equal? (context-manager-config-recent-tokens cfg) 10000)
+      (check-equal? (context-manager-config-max-catalog-entries cfg) 20))
+
+    ;; ============================================================
+    ;; assemble-context tests
+    ;; ============================================================
+
+    (test-case "assemble-context: empty session returns empty"
+      (define dir (make-temp-dir))
+      (define sp (session-path dir))
+      (define ip (index-path dir))
+      (append-entries! sp '())
+      (define idx (build-index! sp ip))
+      (define cfg (make-context-manager-config #:recent-tokens 5000))
+      (define-values (messages catalog) (assemble-context idx cfg))
+      (check-equal? messages '())
+      (check-equal? catalog '())
+      (delete-directory/files dir #:must-exist? #f))
+
+    (test-case "assemble-context: small session fits entirely in recent window"
+      (define dir (make-temp-dir))
+      (define sp (session-path dir))
+      (define ip (index-path dir))
+      (define entries
+        (list (make-test-msg "sys" #f 'system 'system-instruction "You are a helpful assistant.")
+              (make-test-msg "u1" "sys" 'user 'message "Hello")
+              (make-test-msg "a1" "u1" 'assistant 'message "Hi there!")))
+      (append-entries! sp entries)
+      (define idx (build-index! sp ip))
+      (define cfg (make-context-manager-config #:recent-tokens 5000))
+      (define-values (messages catalog) (assemble-context idx cfg))
+      (check-equal? (length messages) 3)
+      (check-equal? (message-id (first messages)) "sys")
+      (check-equal? (message-id (last messages)) "a1")
+      (check-equal? catalog '())
+      (delete-directory/files dir #:must-exist? #f))
+
+    (test-case "assemble-context: pins system prompt and first user message"
+      (define dir (make-temp-dir))
+      (define sp (session-path dir))
+      (define ip (index-path dir))
+      (define entries
+        (cons (make-test-msg "sys" #f 'system 'system-instruction "System prompt")
+              (for/list ([i (in-range 50)])
+                (make-test-msg (format "msg-~a" i)
+                               (if (= i 0)
+                                   "sys"
+                                   (format "msg-~a" (sub1 i)))
+                               (if (even? i) 'user 'assistant)
+                               'message
+                               (format "Message ~a with enough text to use tokens" i)))))
+      (append-entries! sp entries)
+      (define idx (build-index! sp ip))
+      (define cfg (make-context-manager-config #:recent-tokens 200))
+      (define-values (messages catalog) (assemble-context idx cfg))
+      (define ids (map message-id messages))
+      (check-not-false (member "sys" ids) "system prompt is pinned")
+      ;; First user msg should be pinned (msg-0)
+      (check-not-false (member "msg-0" ids) "first user message is pinned")
+      (delete-directory/files dir #:must-exist? #f))
+
+    (test-case "assemble-context: generates catalog for excluded entries"
+      (define dir (make-temp-dir))
+      (define sp (session-path dir))
+      (define ip (index-path dir))
+      (define entries
+        (cons (make-test-msg "sys" #f 'system 'system-instruction "System")
+              (for/list ([i (in-range 20)])
+                (make-test-msg (format "msg-~a" i)
+                               (if (= i 0)
+                                   "sys"
+                                   (format "msg-~a" (sub1 i)))
+                               (if (even? i) 'user 'assistant)
+                               'message
+                               (format "Message number ~a content here" i)))))
+      (append-entries! sp entries)
+      (define idx (build-index! sp ip))
+      (define cfg (make-context-manager-config #:recent-tokens 100))
+      (define-values (messages catalog) (assemble-context idx cfg))
+      (check-true (> (length catalog) 0) "catalog contains excluded entries")
+      (for ([c (in-list catalog)])
+        (check-true (catalog-entry? c))
+        (check-true (string? (catalog-entry-id c)))
+        (check-true (string? (catalog-entry-summary c))))
+      (delete-directory/files dir #:must-exist? #f))
+
+    (test-case "assemble-context: budget enforcement — total within bounds"
+      (define dir (make-temp-dir))
+      (define sp (session-path dir))
+      (define ip (index-path dir))
+      (define entries
+        (cons (make-test-msg "sys" #f 'system 'system-instruction "System")
+              (for/list ([i (in-range 30)])
+                (make-test-msg (format "msg-~a" i)
+                               (if (= i 0)
+                                   "sys"
+                                   (format "msg-~a" (sub1 i)))
+                               (if (even? i) 'user 'assistant)
+                               'message
+                               (format "A somewhat longer message ~a to consume budget" i)))))
+      (append-entries! sp entries)
+      (define idx (build-index! sp ip))
+      (define cfg (make-context-manager-config #:recent-tokens 500))
+      (define-values (messages catalog) (assemble-context idx cfg))
+      (define total-tokens (for/sum ([m (in-list messages)]) (estimate-cm-message-tokens m)))
+      (check-true (<= total-tokens 800)
+                  (format "total tokens ~a within budget+overhead" total-tokens))
+      (delete-directory/files dir #:must-exist? #f))
+
+    (test-case "assemble-context: respects max-catalog-entries cap"
+      (define dir (make-temp-dir))
+      (define sp (session-path dir))
+      (define ip (index-path dir))
+      (define entries
+        (cons (make-test-msg "sys" #f 'system 'system-instruction "System")
+              (for/list ([i (in-range 100)])
+                (make-test-msg (format "msg-~a" i)
+                               (if (= i 0)
+                                   "sys"
+                                   (format "msg-~a" (sub1 i)))
+                               (if (even? i) 'user 'assistant)
+                               'message
+                               (format "Message ~a" i)))))
+      (append-entries! sp entries)
+      (define idx (build-index! sp ip))
+      (define cfg (make-context-manager-config #:recent-tokens 100 #:max-catalog-entries 10))
+      (define-values (messages catalog) (assemble-context idx cfg))
+      (check-true (<= (length catalog) 10) (format "catalog ~a ≤ 10" (length catalog)))
+      (delete-directory/files dir #:must-exist? #f))
+
+    ;; ============================================================
+    ;; generate-catalog tests
+    ;; ============================================================
+
+    (test-case "generate-catalog: one-line-per-entry summary"
+      (define entries
+        (list (make-test-msg "m1" #f 'user 'message "Analyze the training_pdf.py failure")
+              (make-test-msg "m2" "m1" 'assistant 'message "Called bash python3 ~/training_pdf.py")
+              (make-test-msg "m3" "m2" 'tool 'tool-result "3 errors found in fpdf2")))
+      (define catalog (generate-catalog entries))
+      (check-equal? (length catalog) 3)
+      (for ([c (in-list catalog)])
+        (check-true (<= (string-length (catalog-entry-summary c)) 80))))
+
+    (test-case "generate-catalog: empty entries returns empty catalog"
+      (check-equal? (generate-catalog '()) '()))
+
+    ;; ============================================================
+    ;; catalog-entry struct tests
+    ;; ============================================================
+
+    (test-case "catalog-entry struct: fields"
+      (define ce (catalog-entry "msg-001" "user" "Analyze the failure"))
+      (check-equal? (catalog-entry-id ce) "msg-001")
+      (check-equal? (catalog-entry-role ce) "user")
+      (check-equal? (catalog-entry-summary ce) "Analyze the failure"))))
+
+(run-tests context-manager-tests)


### PR DESCRIPTION
Addresses #1390.

feat: Context Manager Core — strategy-driven assembly (#1390)

New context-manager.rkt replaces context-builder.rkt truncation with
strategy-driven context assembly: pin (system + first user) → recent
window → catalog generation → budget enforcement.

- context-manager-config struct with tunable parameters
- assemble-context returns (values messages catalog-entries)
- generate-catalog produces one-line-per-entry summaries
- Pinned items (system prompt, first user message) always included
- Budget enforcement: recent window fits within token limit

11 new tests, all passing. Existing tests unaffected.

v0.14.0 Wave 0 milestone.