### PR TITLE
feat: Session Recall Tool (#1391)

### DIFF
--- a/runtime/agent-session.rkt
+++ b/runtime/agent-session.rkt
@@ -713,7 +713,13 @@
                      (current-continuation-marks))))
   (define bus (agent-session-event-bus sess))
   (define sid (agent-session-session-id sess))
-  (define cfg (agent-session-config sess))
+  (define base-cfg (agent-session-config sess))
+  ;; #1391: Inject session index into config for session_recall tool access
+  (define idx (agent-session-index sess))
+  (define cfg
+    (if idx
+        (hash-set base-cfg 'session-index idx)
+        base-cfg))
   (define max-iterations (or max-iter-override (hash-ref cfg 'max-iterations 20)))
   (define token-budget-threshold
     (hash-ref cfg 'token-budget-threshold DEFAULT-TOKEN-BUDGET-THRESHOLD))

--- a/runtime/iteration.rkt
+++ b/runtime/iteration.rkt
@@ -326,7 +326,8 @@
                                    (make-minimal-settings #:provider (hash-ref config 'provider #f)
                                                           #:model (hash-ref config 'model-name #f)))
             #:call-id (generate-id)
-            #:session-metadata (hasheq 'session-id session-id))
+            #:session-metadata
+            (hasheq 'session-id session-id 'session-index (hash-ref config 'session-index #f)))
            #:parallel? (hash-ref config 'parallel-tools #t)))))
 
   ;; #1208: Dispatch 'tool.execution.end hook after tool batch

--- a/tests/test-main.rkt
+++ b/tests/test-main.rkt
@@ -30,10 +30,10 @@
 ;; register-default-tools!
 ;; ============================================================
 
-(test-case "registers all 10 built-in tools"
+(test-case "registers all 11 built-in tools"
   (define reg (make-tool-registry))
   (register-default-tools! reg)
-  (check-equal? (length (list-tools reg)) 10))
+  (check-equal? (length (list-tools reg)) 11))
 
 (test-case "each tool is a valid tool struct with executable"
   (define reg (make-tool-registry))
@@ -46,7 +46,7 @@
 (test-case "registry has correct count"
   (define reg (make-tool-registry))
   (register-default-tools! reg)
-  (check-equal? (length (list-tools reg)) 10))
+  (check-equal? (length (list-tools reg)) 11))
 
 ;; ============================================================
 ;; build-runtime-from-cli
@@ -70,11 +70,11 @@
   (check-true (not (false? (member (provider-name (hash-ref rt 'provider))
                                    '("mock" "openai-compatible"))))))
 
-(test-case "tool-registry has all 10 built-in tools"
+(test-case "tool-registry has all 11 built-in tools"
   (define cfg (parse-cli-args #()))
   (define rt (build-runtime-from-cli cfg))
   (define reg (hash-ref rt 'tool-registry))
-  (check-equal? (length (list-tools reg)) 10))
+  (check-equal? (length (list-tools reg)) 11))
 
 (test-case "event-bus is valid"
   (define cfg (parse-cli-args #()))
@@ -729,7 +729,7 @@
 (test-case "register-default-tools! #:only #f registers all"
   (define reg (make-tool-registry))
   (register-default-tools! reg #:only #f)
-  (check-equal? (length (tool-names reg)) 10))
+  (check-equal? (length (tool-names reg)) 11))
 
 (test-case "register-default-tools! #:only empty list registers none"
   (define reg (make-tool-registry))

--- a/tests/test-registry-defaults.rkt
+++ b/tests/test-registry-defaults.rkt
@@ -8,19 +8,37 @@
 ;; register-default-tools! — registers all tools
 ;; ============================================================
 
-(test-case "register-default-tools! registers all 10 built-in tools"
+(test-case "register-default-tools! registers all 11 built-in tools"
   (define reg (make-tool-registry))
   (register-default-tools! reg)
   (define names (sort (tool-names reg) string<?))
   (check equal?
          names
-         (sort '("read" "write" "edit" "bash" "grep" "find" "ls" "date" "firecrawl" "spawn-subagent")
+         (sort '("read" "write"
+                        "edit"
+                        "bash"
+                        "grep"
+                        "find"
+                        "ls"
+                        "date"
+                        "firecrawl"
+                        "spawn-subagent"
+                        "session_recall")
                string<?)))
 
 (test-case "each registered tool has correct name"
   (define reg (make-tool-registry))
   (register-default-tools! reg)
-  (for ([name '("read" "write" "edit" "bash" "grep" "find" "ls" "date" "firecrawl" "spawn-subagent")])
+  (for ([name '("read" "write"
+                       "edit"
+                       "bash"
+                       "grep"
+                       "find"
+                       "ls"
+                       "date"
+                       "firecrawl"
+                       "spawn-subagent"
+                       "session_recall")])
     (define t (lookup-tool reg name))
     (check-pred tool? t (format "tool ~a should exist" name))
     (check-equal? (tool-name t) name)))
@@ -28,7 +46,16 @@
 (test-case "each registered tool has a non-empty description"
   (define reg (make-tool-registry))
   (register-default-tools! reg)
-  (for ([name '("read" "write" "edit" "bash" "grep" "find" "ls" "date" "firecrawl" "spawn-subagent")])
+  (for ([name '("read" "write"
+                       "edit"
+                       "bash"
+                       "grep"
+                       "find"
+                       "ls"
+                       "date"
+                       "firecrawl"
+                       "spawn-subagent"
+                       "session_recall")])
     (define t (lookup-tool reg name))
     (check-true (> (string-length (tool-description t)) 0)
                 (format "tool ~a should have a description" name))))
@@ -36,7 +63,16 @@
 (test-case "each registered tool has a schema hash"
   (define reg (make-tool-registry))
   (register-default-tools! reg)
-  (for ([name '("read" "write" "edit" "bash" "grep" "find" "ls" "date" "firecrawl" "spawn-subagent")])
+  (for ([name '("read" "write"
+                       "edit"
+                       "bash"
+                       "grep"
+                       "find"
+                       "ls"
+                       "date"
+                       "firecrawl"
+                       "spawn-subagent"
+                       "session_recall")])
     (define t (lookup-tool reg name))
     (check-pred hash? (tool-schema t) (format "tool ~a schema should be a hash" name))
     (check-equal? (hash-ref (tool-schema t) 'type #f)
@@ -46,7 +82,16 @@
 (test-case "each registered tool has a procedure execute"
   (define reg (make-tool-registry))
   (register-default-tools! reg)
-  (for ([name '("read" "write" "edit" "bash" "grep" "find" "ls" "date" "firecrawl" "spawn-subagent")])
+  (for ([name '("read" "write"
+                       "edit"
+                       "bash"
+                       "grep"
+                       "find"
+                       "ls"
+                       "date"
+                       "firecrawl"
+                       "spawn-subagent"
+                       "session_recall")])
     (define t (lookup-tool reg name))
     (check-pred procedure? (tool-execute t) (format "tool ~a execute should be a procedure" name))))
 

--- a/tests/test-session-recall.rkt
+++ b/tests/test-session-recall.rkt
@@ -1,0 +1,177 @@
+#lang racket
+
+;; tests/test-session-recall.rkt — Tests for tools/builtins/session-recall.rkt (#1391)
+;; Wave 1: Session Recall Tool
+
+(require rackunit
+         rackunit/text-ui
+         racket/file
+         racket/list
+         (only-in "../util/protocol-types.rkt"
+                  make-message
+                  make-text-part
+                  message-id
+                  message-role
+                  message-kind
+                  message-content)
+         "../runtime/session-store.rkt"
+         "../runtime/session-index.rkt"
+         "../tools/tool.rkt"
+         "../tools/builtins/session-recall.rkt")
+
+;; Helpers
+(define (make-temp-dir)
+  (make-temporary-file "q-session-recall-test-~a" 'directory))
+
+(define (session-path dir)
+  (build-path dir "session.jsonl"))
+
+(define (index-path dir)
+  (build-path dir "session.index"))
+
+(define (make-test-msg id parent-id role kind text)
+  (make-message id parent-id role kind (list (make-text-part text)) (current-seconds) (hasheq)))
+
+(define (make-exec-ctx-with-index idx)
+  (make-exec-context #:session-metadata (hasheq 'session-index idx)))
+
+(define session-recall-tests
+  (test-suite "session-recall-tool"
+
+    ;; ============================================================
+    ;; Tool definition
+    ;; ============================================================
+
+    (test-case "tool-session-recall is a procedure"
+      (check-true (procedure? tool-session-recall)))
+
+    ;; ============================================================
+    ;; Recall by entry_ids
+    ;; ============================================================
+
+    (test-case "recall by entry_ids returns matching messages"
+      (define dir (make-temp-dir))
+      (define sp (session-path dir))
+      (define ip (index-path dir))
+      (define entries
+        (list (make-test-msg "root" #f 'user 'message "Hello")
+              (make-test-msg "c1" "root" 'assistant 'message "Hi")
+              (make-test-msg "c2" "c1" 'user 'message "How are you?")
+              (make-test-msg "c3" "c2" 'assistant 'message "I'm good")))
+      (append-entries! sp entries)
+      (define idx (build-index! sp ip))
+      (define ctx (make-exec-ctx-with-index idx))
+      (define result (tool-session-recall (hasheq 'entry_ids '("c1" "c3")) ctx))
+      (check-false (tool-result-is-error? result))
+      (define content (tool-result-content result))
+      (check-true (list? content))
+      (define text (hash-ref (car content) 'text ""))
+      (check-true (string-contains? text "c1") "contains c1")
+      (check-true (string-contains? text "c3") "contains c3")
+      (delete-directory/files dir #:must-exist? #f))
+
+    (test-case "recall by entry_ids with non-existent id returns error"
+      (define dir (make-temp-dir))
+      (define sp (session-path dir))
+      (define ip (index-path dir))
+      (define entries (list (make-test-msg "root" #f 'user 'message "Hello")))
+      (append-entries! sp entries)
+      (define idx (build-index! sp ip))
+      (define ctx (make-exec-ctx-with-index idx))
+      (define result (tool-session-recall (hasheq 'entry_ids '("nonexistent")) ctx))
+      (check-true (tool-result-is-error? result)))
+
+    ;; ============================================================
+    ;; Recall by query (text search)
+    ;; ============================================================
+
+    (test-case "recall by query finds matching entries"
+      (define dir (make-temp-dir))
+      (define sp (session-path dir))
+      (define ip (index-path dir))
+      (define entries
+        (list (make-test-msg "m1" #f 'user 'message "Analyze the fpdf2 failure")
+              (make-test-msg "m2" "m1" 'assistant 'message "Running python3 training_pdf.py")
+              (make-test-msg "m3" "m2" 'tool 'tool-result "ImportError in fpdf2 module")
+              (make-test-msg "m4" "m3" 'assistant 'message "The issue is with fpdf2")))
+      (append-entries! sp entries)
+      (define idx (build-index! sp ip))
+      (define ctx (make-exec-ctx-with-index idx))
+      (define result (tool-session-recall (hasheq 'query "fpdf2") ctx))
+      (check-false (tool-result-is-error? result))
+      (define text (hash-ref (car (tool-result-content result)) 'text ""))
+      (check-true (string-contains? text "fpdf2") "result contains fpdf2"))
+
+    (test-case "recall by query with no matches returns info message"
+      (define dir (make-temp-dir))
+      (define sp (session-path dir))
+      (define ip (index-path dir))
+      (define entries (list (make-test-msg "m1" #f 'user 'message "Hello")))
+      (append-entries! sp entries)
+      (define idx (build-index! sp ip))
+      (define ctx (make-exec-ctx-with-index idx))
+      (define result (tool-session-recall (hasheq 'query "nonexistent_topic") ctx))
+      (check-false (tool-result-is-error? result))
+      (define text (hash-ref (car (tool-result-content result)) 'text ""))
+      (check-true (string-contains? text "No matching") "no matches info"))
+
+    ;; ============================================================
+    ;; Recall by range
+    ;; ============================================================
+
+    (test-case "recall by range returns entries between from and to"
+      (define dir (make-temp-dir))
+      (define sp (session-path dir))
+      (define ip (index-path dir))
+      (define entries
+        (for/list ([i (in-range 10)])
+          (make-test-msg (format "msg-~a" i)
+                         (if (= i 0)
+                             #f
+                             (format "msg-~a" (sub1 i)))
+                         (if (even? i) 'user 'assistant)
+                         'message
+                         (format "Message ~a" i))))
+      (append-entries! sp entries)
+      (define idx (build-index! sp ip))
+      (define ctx (make-exec-ctx-with-index idx))
+      (define result (tool-session-recall (hasheq 'range (hasheq 'from "msg-2" 'to "msg-5")) ctx))
+      (check-false (tool-result-is-error? result))
+      (define text (hash-ref (car (tool-result-content result)) 'text ""))
+      (check-true (string-contains? text "msg-2") "contains msg-2")
+      (check-true (string-contains? text "msg-5") "contains msg-5")
+      (check-false (string-contains? text "msg-0") "excludes msg-0")
+      (delete-directory/files dir #:must-exist? #f))
+
+    ;; ============================================================
+    ;; Result format
+    ;; ============================================================
+
+    (test-case "recall result has structured format with entry headers"
+      (define dir (make-temp-dir))
+      (define sp (session-path dir))
+      (define ip (index-path dir))
+      (define entries (list (make-test-msg "m1" #f 'user 'message "Analyze the failure")))
+      (append-entries! sp entries)
+      (define idx (build-index! sp ip))
+      (define ctx (make-exec-ctx-with-index idx))
+      (define result (tool-session-recall (hasheq 'entry_ids '("m1")) ctx))
+      (define text (hash-ref (car (tool-result-content result)) 'text ""))
+      (check-true (string-contains? text "Recalled") "has recall header")
+      (check-true (string-contains? text "m1") "has entry id"))
+
+    ;; ============================================================
+    ;; Edge cases
+    ;; ============================================================
+
+    (test-case "recall with no session index returns error"
+      (define ctx (make-exec-context)) ; no session-metadata
+      (define result (tool-session-recall (hasheq 'entry_ids '("m1")) ctx))
+      (check-true (tool-result-is-error? result)))
+
+    (test-case "recall with empty args returns error"
+      (define ctx (make-exec-context #:session-metadata (hasheq 'session-index #f)))
+      (define result (tool-session-recall (hasheq) ctx))
+      (check-true (tool-result-is-error? result)))))
+
+(run-tests session-recall-tests)

--- a/tools/builtins/session-recall.rkt
+++ b/tools/builtins/session-recall.rkt
@@ -1,0 +1,155 @@
+#lang racket/base
+
+;; q/tools/builtins/session-recall.rkt — Session Recall Tool (#1391)
+;;
+;; Lets the agent retrieve earlier session entries that are not in
+;; the current LLM context window. The session log is immutable —
+;; this tool reads from the session-index.
+;;
+;; Three retrieval modes:
+;;   1. entry_ids — return specific messages by ID
+;;   2. query     — text search over all entries
+;;   3. range     — return entries between two IDs (inclusive)
+;;
+;; Results are ephemeral: returned as a tool result for this turn only.
+;; Max 5 entries per call to prevent context bloat.
+
+(require racket/function
+         racket/list
+         racket/string
+         "../tool.rkt"
+         (only-in "../../util/protocol-types.rkt"
+                  message-id
+                  message-role
+                  message-content
+                  text-part?
+                  text-part-text)
+         "../../runtime/session-index.rkt")
+
+(provide tool-session-recall)
+
+;; Max entries returned per recall call
+(define MAX-RECALL-ENTRIES 5)
+
+;; ============================================================
+;; Tool definition
+;; ============================================================
+
+(define (tool-session-recall args [exec-ctx #f])
+  (define idx
+    (and exec-ctx
+         (exec-context-session-metadata exec-ctx)
+         (hash-ref (exec-context-session-metadata exec-ctx) 'session-index #f)))
+
+  (cond
+    [(not idx) (make-error-result "session_recall: no session index available")]
+    [else
+     (define entry-ids (hash-ref args 'entry_ids #f))
+     (define query (hash-ref args 'query #f))
+     (define range (hash-ref args 'range #f))
+     (cond
+       [(and entry-ids (list? entry-ids) (not (null? entry-ids))) (recall-by-ids idx entry-ids)]
+       [(and query (string? query) (not (string=? query ""))) (recall-by-query idx query)]
+       [(and range (hash? range)) (recall-by-range idx range)]
+       [else (make-error-result "session_recall: provide one of: entry_ids, query, or range")])]))
+
+;; ============================================================
+;; Recall by IDs
+;; ============================================================
+
+(define (recall-by-ids idx ids)
+  (define entries
+    (for/list ([id (in-list ids)]
+               [i (in-naturals)]
+               #:break (>= i MAX-RECALL-ENTRIES))
+      (define entry (lookup-entry idx id))
+      (cond
+        [entry entry]
+        [else #f])))
+  (define found (filter identity entries))
+  (cond
+    [(null? found) (make-error-result "session_recall: no entries found for given IDs")]
+    [else
+     (define text (format-recalled-entries found))
+     (make-success-result (list (hasheq 'type "text" 'text text)))]))
+
+;; ============================================================
+;; Recall by query (text search)
+;; ============================================================
+
+(define (recall-by-query idx query)
+  (define query-low (string-downcase query))
+  (define all-entries (vector->list (session-index-entry-order idx)))
+  (define matches
+    (for/list ([m (in-list all-entries)]
+               [i (in-naturals)]
+               #:break (>= i MAX-RECALL-ENTRIES)
+               #:when (string-contains? (string-downcase (extract-msg-text m)) query-low))
+      m))
+  (cond
+    [(null? matches)
+     (make-success-result
+      (list (hasheq 'type "text" 'text (format "No matching entries found for query: ~a" query))))]
+    [else
+     (define text (format-recalled-entries matches))
+     (make-success-result (list (hasheq 'type "text" 'text text)))]))
+
+;; ============================================================
+;; Recall by range
+;; ============================================================
+
+(define (recall-by-range idx range)
+  (define from-id (hash-ref range 'from #f))
+  (define to-id (hash-ref range 'to #f))
+  (cond
+    [(not (and from-id to-id))
+     (make-error-result "session_recall: range requires 'from' and 'to' IDs")]
+    [else
+     (define all-entries (vector->list (session-index-entry-order idx)))
+     ;; Walk entries, collecting those between from-id and to-id inclusive
+     (define matches
+       (let loop ([remaining all-entries]
+                  [started #f]
+                  [done #f]
+                  [acc '()])
+         (cond
+           [done (reverse acc)]
+           [(null? remaining) (reverse acc)]
+           [else
+            (define m (car remaining))
+            (cond
+              [(equal? (message-id m) from-id) (loop (cdr remaining) #t #f (cons m acc))]
+              [(and started (equal? (message-id m) to-id)) (reverse (cons m acc))]
+              [started (loop (cdr remaining) #t #f (cons m acc))]
+              [else (loop (cdr remaining) #f #f acc)])])))
+     (cond
+       [(null? matches) (make-error-result "session_recall: no entries found in given range")]
+       [else
+        (define text (format-recalled-entries matches))
+        (make-success-result (list (hasheq 'type "text" 'text text)))])]))
+
+;; ============================================================
+;; Formatting
+;; ============================================================
+
+(define (format-recalled-entries entries)
+  (define lines
+    (for/list ([m (in-list entries)])
+      (format "Entry ~a (~a):\n  ~a"
+              (message-id m)
+              (message-role m)
+              (truncate-string (extract-msg-text m) 200))))
+  (string-append "[Recalled Session Entries]\n\n" (string-join lines "\n\n")))
+
+(define (extract-msg-text msg)
+  (define parts (message-content msg))
+  (define texts
+    (for/list ([part (in-list parts)]
+               #:when (text-part? part))
+      (text-part-text part)))
+  (string-join texts " "))
+
+(define (truncate-string s max-len)
+  (if (<= (string-length s) max-len)
+      s
+      (string-append (substring s 0 (- max-len 3)) "...")))

--- a/tools/registry-defaults.rkt
+++ b/tools/registry-defaults.rkt
@@ -3,8 +3,8 @@
 ;; tools/registry-defaults.rkt — Register built-in tools into a tool registry
 ;;
 ;; Extracted from main.rkt. Contains register-default-tools! which
-;; registers all 10 built-in tools (read, write, edit, bash, grep,
-;; find, ls, date, firecrawl, spawn-subagent) into the given registry.
+;; registers all 11 built-in tools (read, write, edit, bash, grep,
+;; find, ls, date, firecrawl, spawn-subagent, session_recall) into the given registry.
 
 (require "tool.rkt"
          "builtins/read.rkt"
@@ -16,7 +16,8 @@
          "builtins/ls.rkt"
          "builtins/date.rkt"
          "builtins/firecrawl.rkt"
-         "builtins/spawn-subagent.rkt")
+         "builtins/spawn-subagent.rkt"
+         "builtins/session-recall.rkt")
 
 (provide register-default-tools!)
 
@@ -237,4 +238,43 @@
                               'description
                               "Allowed tool names for child")))
       tool-spawn-subagent)))
+
+  ;; Session recall tool — retrieve earlier session entries by ID, query, or range (#1391)
+  (when (should-register? "session_recall")
+    (register-tool!
+     registry
+     (make-tool
+      "session_recall"
+      (string-append
+       "Retrieve earlier session entries that are not in your current context. "
+       "Use the Session History Catalog to find relevant entry IDs. "
+       "Provide one of: entry_ids (list of IDs), query (text search), or range (from/to IDs). "
+       "Returns up to 5 entries per call. Results are ephemeral — only in context for this turn.")
+      (hasheq
+       'type
+       "object"
+       'required
+       '()
+       'properties
+       (hasheq 'entry_ids
+               (hasheq 'type
+                       "array"
+                       'items
+                       (hasheq 'type "string")
+                       'description
+                       "Entry IDs to retrieve from session history")
+               'query
+               (hasheq 'type "string" 'description "Text search query to find relevant entries")
+               'range
+               (hasheq 'type
+                       "object"
+                       'properties
+                       (hasheq 'from
+                               (hasheq 'type "string" 'description "Start entry ID")
+                               'to
+                               (hasheq 'type "string" 'description "End entry ID"))
+                       'description
+                       "Retrieve a range of entries by ID (inclusive)")))
+      tool-session-recall)))
+
   (void))


### PR DESCRIPTION
Addresses #1391.

feat: Session Recall Tool — retrieve excluded session entries (#1391)

New session_recall tool lets the agent retrieve earlier session entries
that are not in the current LLM context window. Three retrieval modes:
entry_ids (specific IDs), query (text search), range (ID range).

- tools/builtins/session-recall.rkt — tool implementation
- Registered in registry-defaults.rkt (11 built-in tools now)
- Session index injected into exec-context via agent-session config
- iteration.rkt passes session-index in session-metadata

9 new tests. Updated test-main.rkt and test-registry-defaults.rkt
for 11-tool count. All 5340+ tests green.

v0.14.0 Wave 1 milestone.