### PR TITLE
feat: catalog token caps, tool collapsing, budget enforcement (#1394)

### DIFF
--- a/runtime/context-manager.rkt
+++ b/runtime/context-manager.rkt
@@ -156,7 +156,10 @@
 
      ;; Phase 4: Generate catalog for excluded entries
      (define max-entries (context-manager-config-max-catalog-entries config))
-     (define catalog (generate-catalog excluded #:max-entries max-entries))
+     (define catalog
+       (generate-catalog excluded
+                         #:max-entries max-entries
+                         #:max-tokens (context-manager-config-max-catalog-tokens config)))
 
      ;; Phase 5: Reassemble in original order
      (define pinned-ids
@@ -233,14 +236,56 @@
 ;; Phase 4: Catalog generation
 ;; ============================================================
 
-(define (generate-catalog entries #:max-entries [max-entries 40])
-  (for/list ([m (in-list entries)]
-             [i (in-naturals)]
-             #:break (>= i max-entries))
-    (define text (extract-message-text m))
-    (define summary (truncate-string text 80))
-    (define role-str (symbol->string (message-role m)))
-    (catalog-entry (message-id m) role-str summary)))
+;; Generate one-line catalog entries for excluded messages.
+;; Consecutive tool-result messages are collapsed to a single entry.
+;; Both entry count and total token budget are enforced.
+(define (generate-catalog entries #:max-entries [max-entries 40] #:max-tokens [max-tokens 2000])
+  (define collapsed (collapse-consecutive-tools entries))
+  (let loop ([remaining collapsed]
+             [acc '()]
+             [used-tokens 0])
+    (cond
+      [(null? remaining) (reverse acc)]
+      [(>= (length acc) max-entries) (reverse acc)]
+      [else
+       (define entry (car remaining))
+       (define tokens (estimate-text-tokens (catalog-entry-summary entry)))
+       (if (> (+ used-tokens tokens) max-tokens)
+           (reverse acc)
+           (loop (cdr remaining) (cons entry acc) (+ used-tokens tokens)))])))
+
+;; Collapse consecutive tool-result messages into single catalog entries.
+;; Non-tool messages get individual entries. Returns (listof catalog-entry?).
+(define (collapse-consecutive-tools entries)
+  (define-values (result current-group)
+    (for/fold ([acc '()]
+               [group '()])
+              ([m (in-list entries)])
+      (cond
+        [(eq? (message-role m) 'tool) (values acc (cons m group))]
+        [(null? group) (values (cons (message->catalog-entry m) acc) '())]
+        [else
+         (values (cons (message->catalog-entry m)
+                       (cons (tool-group->catalog-entry (reverse group)) acc))
+                 '())])))
+  (reverse (if (null? current-group)
+               result
+               (cons (tool-group->catalog-entry (reverse current-group)) result))))
+
+;; Single message → catalog entry
+(define (message->catalog-entry m)
+  (catalog-entry (message-id m)
+                 (symbol->string (message-role m))
+                 (truncate-string (extract-message-text m) 80)))
+
+;; Group of consecutive tool results → single catalog entry
+(define (tool-group->catalog-entry tool-msgs)
+  (define ids (string-join (map message-id tool-msgs) ","))
+  (define texts (map extract-message-text tool-msgs))
+  (catalog-entry
+   ids
+   "tool"
+   (format "[~a tool calls: ~a]" (length tool-msgs) (truncate-string (string-join texts "; ") 50))))
 
 ;; ============================================================
 ;; Summary prompt template (Wave 2A #1395)

--- a/tests/test-context-manager-polish.rkt
+++ b/tests/test-context-manager-polish.rkt
@@ -1,0 +1,214 @@
+#lang racket
+
+;; tests/test-context-manager-polish.rkt — Wave 4 (#1394): Polish & Edge Cases
+;;
+;; Tests for catalog token caps, consecutive tool result collapsing,
+;; budget enforcement drop priority, and pin guarantees.
+
+(require rackunit
+         rackunit/text-ui
+         racket/list
+         "../util/protocol-types.rkt"
+         "../runtime/session-store.rkt"
+         "../runtime/session-index.rkt"
+         "../runtime/context-manager.rkt"
+         "../llm/token-budget.rkt")
+
+;; ── Helpers ──────────────────────────────────────────────────
+
+(define (msg-text m)
+  (string-join (for/list ([part (in-list (message-content m))]
+                          #:when (text-part? part))
+                 (text-part-text part))
+               " "))
+
+(define (build-session old-count
+                       #:old-prefix [old-prefix "old"]
+                       #:old-content
+                       [content-fn (lambda (i) (format "Content ~a with text to pad" i))])
+  (define sys
+    (make-message "sys"
+                  #f
+                  'system
+                  'system-instruction
+                  (list (make-text-part "System prompt"))
+                  (current-seconds)
+                  (hasheq)))
+  (define u1
+    (make-message "u1"
+                  "sys"
+                  'user
+                  'message
+                  (list (make-text-part "First user message"))
+                  (current-seconds)
+                  (hasheq)))
+  (define old-msgs
+    (for/list ([i (in-range old-count)])
+      (make-message (format "~a~a" old-prefix i)
+                    (if (= i 0)
+                        "u1"
+                        (format "~a~a" old-prefix (sub1 i)))
+                    (if (even? i) 'user 'assistant)
+                    'message
+                    (list (make-text-part (content-fn i)))
+                    (current-seconds)
+                    (hasheq))))
+  (define last-id
+    (if (> old-count 0)
+        (format "~a~a" old-prefix (sub1 old-count))
+        "u1"))
+  (define u2
+    (make-message "u2"
+                  last-id
+                  'user
+                  'message
+                  (list (make-text-part "Recent question"))
+                  (current-seconds)
+                  (hasheq)))
+  (define a2
+    (make-message "a2"
+                  "u2"
+                  'assistant
+                  'message
+                  (list (make-text-part "Recent answer"))
+                  (current-seconds)
+                  (hasheq)))
+  (append (list sys u1) old-msgs (list u2 a2)))
+
+(define (with-index msgs thunk)
+  (define dir (make-temporary-file "q-test-~a" 'directory))
+  (define sp (build-path dir "session.jsonl"))
+  (define ip (build-path dir "session.index"))
+  (append-entries! sp msgs)
+  (define idx (build-index! sp ip))
+  (define result (thunk idx))
+  (delete-directory/files dir #:must-exist? #f)
+  result)
+
+(define polish-tests
+  (test-suite "context-manager-polish"
+
+    ;; ── Catalog token cap ─────────────────────────────────────
+    (test-case "generate-catalog respects max-catalog-tokens"
+      ;; Create messages with long content → catalog entries would exceed token cap
+      (define msgs
+        (build-session 50
+                       #:old-content
+                       (lambda (i) (format "Message ~a with lots of text padding content here" i))))
+      (define catalog
+        (with-index msgs
+                    (lambda (idx)
+                      ;; Use very small budget → lots of excluded entries
+                      (define cfg
+                        (make-context-manager-config #:recent-tokens 30
+                                                     #:max-catalog-entries 50
+                                                     #:max-catalog-tokens 100))
+                      (define-values (_result catalog) (assemble-context idx cfg))
+                      catalog)))
+      ;; Total catalog tokens should be under cap
+      (define catalog-tokens
+        (for/sum ([e (in-list catalog)]) (estimate-text-tokens (catalog-entry-summary e))))
+      (check-true (<= catalog-tokens 100)
+                  (format "Catalog tokens ~a exceeds cap 100" catalog-tokens)))
+
+    ;; ── Pin guarantee under extreme budget ────────────────────
+    (test-case "pinned items survive extreme budget pressure"
+      (define msgs (build-session 20))
+      (with-index msgs
+                  (lambda (idx)
+                    ;; Tiny budget: only 10 tokens — way less than pinned messages
+                    (define cfg (make-context-manager-config #:recent-tokens 10))
+                    (define-values (result catalog) (assemble-context idx cfg))
+                    ;; System prompt must be present
+                    (define sys-msgs
+                      (filter (lambda (m) (eq? (message-kind m) 'system-instruction)) result))
+                    (check-equal? (length sys-msgs) 1 "System prompt must survive")
+                    ;; First user message must be present
+                    (define user-msgs (filter (lambda (m) (eq? (message-role m) 'user)) result))
+                    (check-true (>= (length user-msgs) 1) "First user message must survive")
+                    (void))))
+
+    ;; ── Consecutive tool messages collapsed in catalog ───────
+    (test-case "catalog collapses consecutive tool messages"
+      (define sys
+        (make-message "sys"
+                      #f
+                      'system
+                      'system-instruction
+                      (list (make-text-part "System"))
+                      (current-seconds)
+                      (hasheq)))
+      (define u1
+        (make-message "u1"
+                      "sys"
+                      'user
+                      'message
+                      (list (make-text-part "Start"))
+                      (current-seconds)
+                      (hasheq)))
+      ;; Create consecutive tool messages
+      (define tool-msgs
+        (for/list ([i (in-range 6)])
+          (make-message
+           (format "tool~a" i)
+           (if (= i 0)
+               "u1"
+               (format "tool~a" (sub1 i)))
+           'tool
+           'tool-result
+           (list (make-tool-result-part (format "tc~a" i) (format "Tool output ~a" i) #f))
+           (current-seconds)
+           (hasheq))))
+      (define u2
+        (make-message "u2"
+                      "tool5"
+                      'user
+                      'message
+                      (list (make-text-part "Recent"))
+                      (current-seconds)
+                      (hasheq)))
+      (define a2
+        (make-message "a2"
+                      "u2"
+                      'assistant
+                      'message
+                      (list (make-text-part "Reply"))
+                      (current-seconds)
+                      (hasheq)))
+      (define msgs (append (list sys u1) tool-msgs (list u2 a2)))
+      (with-index msgs
+                  (lambda (idx)
+                    (define cfg (make-context-manager-config #:recent-tokens 30))
+                    (define-values (result catalog) (assemble-context idx cfg))
+                    ;; Consecutive tool results should be collapsed to fewer catalog entries
+                    (define tool-entries
+                      (filter (lambda (e) (equal? (catalog-entry-role e) "tool")) catalog))
+                    (check-true (< (length tool-entries) (length tool-msgs))
+                                (format "Expected collapsed tool entries, got ~a for ~a tools"
+                                        (length tool-entries)
+                                        (length tool-msgs)))
+                    (void))))
+
+    ;; ── Empty session edge case ──────────────────────────────
+    (test-case "empty session returns empty"
+      (define dir (make-temporary-file "q-test-~a" 'directory))
+      (define sp (build-path dir "session.jsonl"))
+      (define ip (build-path dir "session.index"))
+      ;; Write empty session
+      (call-with-output-file sp (lambda (p) (void)) #:exists 'replace)
+      (define idx (build-index! sp ip))
+      (define cfg (make-context-manager-config))
+      (define-values (result catalog) (assemble-context idx cfg))
+      (check-equal? result '())
+      (check-equal? catalog '())
+      (delete-directory/files dir #:must-exist? #f))
+
+    ;; ── Config defaults are reasonable ───────────────────────
+    (test-case "config defaults are production-ready"
+      (define cfg (make-context-manager-config))
+      (check-equal? (context-manager-config-recent-tokens cfg) 30000)
+      (check-equal? (context-manager-config-max-catalog-entries cfg) 40)
+      (check-equal? (context-manager-config-max-catalog-tokens cfg) 2000)
+      (check-equal? (context-manager-config-summary-window cfg) 4000))))
+
+(run-tests polish-tests)


### PR DESCRIPTION
Addresses #1394.

feat: catalog token caps, tool collapsing, budget enforcement (#1394)

Wave 4 of v0.14.0 Context Manager Architecture.

Polish and edge cases:
- generate-catalog enforces max-catalog-tokens budget (default 2000)
- Consecutive tool-result messages collapsed to single catalog entry
- assemble-context passes catalog token budget from config
- Pinned items (system + first user) survive extreme budget pressure
- Config defaults verified: 30K recent, 40 entries, 2K catalog tokens

5 new tests in test-context-manager-polish.rkt. All 5350+ tests green.

v0.14.0 Wave 4 milestone.