### PR TITLE
feat: soft iteration limit — warn at max-iterations, hard-stop at max-iterations-hard (#1404)

Backward compatible: when max-iterations-hard is not set in config, it
defaults to max-iterations (no split). Set 'max-iterations-hard in config
to enable soft warning + hard stop split. TUI shows progress hint at
soft limit.

### DIFF
--- a/runtime/iteration.rkt
+++ b/runtime/iteration.rkt
@@ -471,6 +471,9 @@
                             ;; #1158: shutdown check thunks (avoid circular dep on agent-session)
                             #:shutdown-check [shutdown-check #f]
                             #:force-shutdown-check [force-shutdown-check #f])
+  ;; v0.14.1: Soft limit = max-iterations (warn), Hard limit = max-iterations-hard (stop)
+  ;; Default hard limit = max-iterations (backward compatible: no split unless explicitly configured)
+  (define max-iterations-hard (hash-ref config 'max-iterations-hard max-iterations))
   ;; Dispatch 'before-agent-start hook — extensions can block or modify config
   (define agent-start-payload
     (hasheq 'session-id
@@ -621,8 +624,8 @@
                                        (add1 iteration)))))
                          effective-result)))]
 
-                ;; ── Max iterations reached: append and stop ──
-                [(and (eq? termination 'tool-calls-pending) (>= (add1 iteration) max-iterations))
+                ;; ── Hard iteration limit reached: append and stop ──
+                [(and (eq? termination 'tool-calls-pending) (>= (add1 iteration) max-iterations-hard))
                  (append-entries! log-path new-msgs)
                  (emit-session-event! bus
                                       session-id
@@ -632,10 +635,38 @@
                                               'iteration
                                               iteration
                                               'maxIterations
-                                              max-iterations))
+                                              max-iterations-hard))
                  (make-loop-result new-msgs
                                    'max-iterations-exceeded
                                    (hash-set (loop-result-metadata result) 'maxIterationsReached #t))]
+
+                ;; ── Soft iteration limit: warn but continue ──
+                [(and (eq? termination 'tool-calls-pending)
+                      (>= (add1 iteration) max-iterations)
+                      (< (add1 iteration) max-iterations-hard))
+                 (append-entries! log-path new-msgs)
+                 (emit-session-event! bus
+                                      session-id
+                                      "iteration.soft-warning"
+                                      (hasheq 'iteration
+                                              (add1 iteration)
+                                              'soft-limit
+                                              max-iterations
+                                              'hard-limit
+                                              max-iterations-hard
+                                              'remaining
+                                              (- max-iterations-hard (add1 iteration))))
+                 (define updated-ctx
+                   (handle-tool-calls-pending new-msgs
+                                              ctx-with-injected
+                                              ext-reg
+                                              reg
+                                              bus
+                                              session-id
+                                              log-path
+                                              token
+                                              config))
+                 (loop updated-ctx (add1 iteration))]
 
                 ;; ── Tool calls pending: execute tools and re-run ──
                 [(eq? termination 'tool-calls-pending)

--- a/tests/test-soft-iteration.rkt
+++ b/tests/test-soft-iteration.rkt
@@ -1,0 +1,166 @@
+#lang racket
+
+;; tests/test-soft-iteration.rkt — soft iteration limit tests
+;;
+;; Wave 1 (v0.14.1): Agent warns at soft limit, hard-stops at hard limit.
+
+(require rackunit
+         rackunit/text-ui
+         "../util/protocol-types.rkt"
+         "../agent/event-bus.rkt"
+         "../util/ids.rkt"
+         "../llm/model.rkt"
+         "../llm/provider.rkt"
+         (only-in "../tools/tool.rkt" make-tool-registry register-tool! make-tool make-error-result)
+         "../runtime/iteration.rkt")
+
+;; ============================================================
+;; Test helpers
+;; ============================================================
+
+(define (make-user-message text)
+  (make-message (generate-id) #f 'user 'user (list (make-text-part text)) (current-seconds) (hasheq)))
+
+;; Create a mock provider that always returns a tool call, causing infinite looping.
+;; The iteration loop will hit max-iterations limits.
+(define (make-looping-tool-provider)
+  ;; Stream chunks: one tool-call delta chunk, then done
+  (define chunks
+    (list
+     (make-stream-chunk
+      #f
+      (hasheq 'index 0 'id "tc-loop-1" 'name "bash" 'arguments "{\"command\": \"echo test\"}")
+      #f
+      #f)
+     (make-stream-chunk #f #f (hasheq 'prompt-tokens 10 'completion-tokens 10 'total-tokens 20) #t)))
+  (make-mock-provider
+   (make-model-response (list (hasheq 'type "text" 'text ""))
+                        (hasheq 'prompt-tokens 10 'completion-tokens 10 'total-tokens 20)
+                        "test-model"
+                        'stop)
+   #:name "test"
+   #:stream-chunks chunks))
+
+;; Collect events of a given type from the bus
+(define (collect-events bus event-type)
+  (define collected (box '()))
+  (subscribe! bus
+              (lambda (evt)
+                (when (equal? (event-ev evt) event-type)
+                  (set-box! collected (append (unbox collected) (list (event-payload evt))))))
+              #:filter (lambda (evt) (equal? (event-ev evt) event-type)))
+  collected)
+
+;; Create a tool registry with a mock bash tool for tool-call loops
+(define (make-test-registry)
+  (define reg (make-tool-registry))
+  (register-tool! reg
+                  (make-tool "bash"
+                             "mock bash for testing"
+                             (hasheq 'type "object" 'properties (hasheq))
+                             (lambda (args ctx) (make-tool-result "mock output" (hasheq) #f))))
+  reg)
+
+(define tmp-log "/tmp/q-test-soft-iteration.jsonl")
+
+(define (cleanup!)
+  (when (file-exists? tmp-log)
+    (delete-file tmp-log)))
+
+;; ============================================================
+;; Tests
+;; ============================================================
+
+(define soft-iteration-tests
+  (test-suite "soft-iteration-limit"
+
+    (test-case "soft-warning event fires at soft limit"
+      (cleanup!)
+      (define bus (make-event-bus))
+      (define warnings (collect-events bus "iteration.soft-warning"))
+      (define provider (make-looping-tool-provider))
+      (define ctx (list (make-user-message "test")))
+      ;; soft=3, hard=6 — should warn at iterations 3, 4, 5 then stop at 6
+      (run-iteration-loop ctx
+                          provider
+                          bus
+                          (make-test-registry)
+                          #f
+                          tmp-log
+                          "test-session"
+                          3
+                          #:config (hasheq 'max-iterations-hard 6))
+      (define collected (unbox warnings))
+      (check >= (length collected) 1 "Expected at least one soft-warning event")
+      (cleanup!))
+
+    (test-case "hard stop at hard limit"
+      (cleanup!)
+      (define bus (make-event-bus))
+      (define provider (make-looping-tool-provider))
+      (define ctx (list (make-user-message "test")))
+      ;; soft=2, hard=4 — should stop at 4 even though soft limit is 2
+      (define result
+        (run-iteration-loop ctx
+                            provider
+                            bus
+                            (make-test-registry)
+                            #f
+                            tmp-log
+                            "test-session"
+                            2
+                            #:config (hasheq 'max-iterations-hard 4)))
+      (check-equal? (loop-result-termination-reason result)
+                    'max-iterations-exceeded
+                    "Should hard-stop at max-iterations-hard")
+      (cleanup!))
+
+    (test-case "no warning when soft limit is not reached"
+      (cleanup!)
+      (define bus (make-event-bus))
+      (define warnings (collect-events bus "iteration.soft-warning"))
+      ;; Provider that completes immediately (no tool calls)
+      (define provider
+        (make-mock-provider (make-model-response
+                             (list (hasheq 'type "text" 'text "done"))
+                             (hasheq 'prompt-tokens 5 'completion-tokens 5 'total-tokens 10)
+                             "test-model"
+                             'stop)))
+      (define ctx (list (make-user-message "test")))
+      ;; soft=20, hard=50 — completes in 1 iteration, no warning
+      (run-iteration-loop ctx
+                          provider
+                          bus
+                          #f
+                          #f
+                          tmp-log
+                          "test-session"
+                          20
+                          #:config (hasheq 'max-iterations-hard 50))
+      (check-equal? (unbox warnings) '() "No soft-warning should fire when loop completes normally")
+      (cleanup!))
+
+    (test-case "soft warning payload has correct fields"
+      (cleanup!)
+      (define bus (make-event-bus))
+      (define warnings (collect-events bus "iteration.soft-warning"))
+      (define provider (make-looping-tool-provider))
+      (define ctx (list (make-user-message "test")))
+      (run-iteration-loop ctx
+                          provider
+                          bus
+                          (make-test-registry)
+                          #f
+                          tmp-log
+                          "test-session"
+                          2
+                          #:config (hasheq 'max-iterations-hard 5))
+      (define collected (unbox warnings))
+      (when (pair? collected)
+        (define first-warning (car collected))
+        (check-equal? (hash-ref first-warning 'soft-limit #f) 2)
+        (check-equal? (hash-ref first-warning 'hard-limit #f) 5)
+        (check-true (number? (hash-ref first-warning 'iteration #f))))
+      (cleanup!))))
+
+(run-tests soft-iteration-tests)

--- a/tui/state.rkt
+++ b/tui/state.rkt
@@ -488,6 +488,17 @@
 
     [("queue.status-update") (struct-copy ui-state state [queue-counts payload])]
 
+    ;; v0.14.1: soft iteration limit warning
+    [("iteration.soft-warning")
+     (define iter (hash-ref payload 'iteration "?"))
+     (define remaining (hash-ref payload 'remaining "?"))
+     (append-entry
+      state
+      (make-entry 'system
+                  (format "[exploring... iteration ~a, ~a remaining before hard stop]" iter remaining)
+                  (event-time evt)
+                  (hash)))]
+
     ;; BUG-33 fix: auto-retry event from runtime/iteration.rkt
     [("auto-retry.start")
      (define attempt (hash-ref payload 'attempt "?"))


### PR DESCRIPTION
Addresses #1404.

feat: soft iteration limit — warn at max-iterations, hard-stop at max-iterations-hard (#1404)

Backward compatible: when max-iterations-hard is not set in config, it
defaults to max-iterations (no split). Set 'max-iterations-hard in config
to enable soft warning + hard stop split. TUI shows progress hint at
soft limit.