### PR TITLE
feat: context-aware retry messages with error type (#1405)

- auto-retry.rkt: pass classified error-type to on-retry callback
- iteration.rkt: include errorType in auto-retry.start event payload
- tui/state.rkt: render type-aware messages (timeout, rate-limit, etc.)

### DIFF
--- a/runtime/auto-retry.rkt
+++ b/runtime/auto-retry.rkt
@@ -181,9 +181,9 @@
                (define next-delay (min (* rl-base (expt 2 attempt)) max-delay-ms))
                ;; v0.13.2: No context reduction on retry — retries use same thunk.
                ;; Context management is a separate concern (v0.14.0 context manager).
-               ;; Call retry callback if provided
+               ;; Call retry callback if provided (include error-type)
                (when on-retry
-                 (on-retry (add1 attempt) max-retries next-delay (exn-message exn)))
+                 (on-retry (add1 attempt) max-retries next-delay (exn-message exn) err-type))
                (sleep (/ next-delay 1000.0))
                (loop (add1 attempt) next-delay (+ total-delay next-delay) err-type)]
               [else

--- a/runtime/iteration.rkt
+++ b/runtime/iteration.rkt
@@ -248,27 +248,32 @@
 
   (define ctx-for-retry (box ctx-final))
 
-  (with-auto-retry
-   (lambda ()
-     (run-agent-turn (unbox ctx-for-retry)
-                     prov
-                     bus
-                     #:session-id session-id
-                     #:turn-id turn-id
-                     #:tools tools
-                     #:cancellation-token token))
-   #:max-retries 2
-   #:base-delay-ms 1000
-   #:on-retry
-   (lambda (attempt max-retries delay-ms error-msg)
-     (publish!
-      bus
-      (make-event
-       "auto-retry.start"
-       (current-inexact-milliseconds)
-       session-id
-       turn-id
-       (hasheq 'attempt attempt 'max-retries max-retries 'delay-ms delay-ms 'error error-msg))))))
+  (with-auto-retry (lambda ()
+                     (run-agent-turn (unbox ctx-for-retry)
+                                     prov
+                                     bus
+                                     #:session-id session-id
+                                     #:turn-id turn-id
+                                     #:tools tools
+                                     #:cancellation-token token))
+                   #:max-retries 2
+                   #:base-delay-ms 1000
+                   #:on-retry (lambda (attempt max-retries delay-ms error-msg error-type)
+                                (publish! bus
+                                          (make-event "auto-retry.start"
+                                                      (current-inexact-milliseconds)
+                                                      session-id
+                                                      turn-id
+                                                      (hasheq 'attempt
+                                                              attempt
+                                                              'max-retries
+                                                              max-retries
+                                                              'delay-ms
+                                                              delay-ms
+                                                              'error
+                                                              error-msg
+                                                              'errorType
+                                                              error-type))))))
 
 ;; Handle tool-calls-pending: extract calls, run through scheduler, emit events,
 ;; and return (values tool-result-messages updated-ctx) for the next loop iteration.

--- a/tests/test-auto-retry.rkt
+++ b/tests/test-auto-retry.rkt
@@ -58,7 +58,7 @@
            "success"))
      #:max-retries 2
      #:base-delay-ms 10
-     #:on-retry (lambda (attempt max-retries delay-ms error-msg)
+     #:on-retry (lambda (attempt max-retries delay-ms error-msg error-type)
                   (set-box! retries (cons (list attempt delay-ms error-msg) (unbox retries))))))
   (check-equal? result "success")
   (check-equal? (unbox attempt) 2)
@@ -99,7 +99,7 @@
                (with-auto-retry (lambda () (raise (exn:fail "HTTP 503" (current-continuation-marks))))
                                 #:max-retries 3
                                 #:base-delay-ms 10
-                                #:on-retry (lambda (attempt max-retries delay-ms error-msg)
+                                #:on-retry (lambda (attempt max-retries delay-ms error-msg error-type)
                                              (set-box! delays (cons delay-ms (unbox delays)))))))
   ;; Delays should be: 10, 20, 40 (exponential with base 10ms)
   (define sorted-delays (reverse (unbox delays)))
@@ -116,7 +116,7 @@
                                 #:max-retries 5
                                 #:base-delay-ms 100
                                 #:max-delay-ms 200
-                                #:on-retry (lambda (attempt max-retries delay-ms error-msg)
+                                #:on-retry (lambda (attempt max-retries delay-ms error-msg error-type)
                                              (set-box! delays (cons delay-ms (unbox delays)))))))
   (define sorted-delays (reverse (unbox delays)))
   ;; Delays should be capped at 200: 100, 200, 200, 200, 200
@@ -218,7 +218,7 @@
                 #:max-retries 2
                 #:base-delay-ms 10
                 #:rate-limit-base-delay-ms 50
-                #:on-retry (lambda (attempt max-retries delay-ms error-msg)
+                #:on-retry (lambda (attempt max-retries delay-ms error-msg error-type)
                              (set-box! delays (cons delay-ms (unbox delays)))))))
   (define sorted-delays (reverse (unbox delays)))
   ;; Should use rate-limit base (50ms): 50, 100
@@ -235,7 +235,7 @@
                                                    (current-continuation-marks))))
                                 #:max-retries 2
                                 #:base-delay-ms 10
-                                #:on-retry (lambda (attempt max-retries delay-ms error-msg)
+                                #:on-retry (lambda (attempt max-retries delay-ms error-msg error-type)
                                              (set-box! delays (cons delay-ms (unbox delays)))))))
   (define sorted-delays (reverse (unbox delays)))
   ;; Should use normal base (10ms): 10, 20
@@ -254,7 +254,7 @@
                                 #:base-delay-ms 10
                                 #:rate-limit-base-delay-ms 50
                                 #:max-delay-ms 150
-                                #:on-retry (lambda (attempt max-retries delay-ms error-msg)
+                                #:on-retry (lambda (attempt max-retries delay-ms error-msg error-type)
                                              (set-box! delays (cons delay-ms (unbox delays)))))))
   ;; 50, 100, 150(cap), 150(cap)
   (for ([d (in-list (reverse (unbox delays)))])

--- a/tui/state.rkt
+++ b/tui/state.rkt
@@ -503,12 +503,20 @@
     [("auto-retry.start")
      (define attempt (hash-ref payload 'attempt "?"))
      (define max-attempts (hash-ref payload 'max-retries "?"))
+     (define error-type (hash-ref payload 'errorType #f))
+     (define type-label
+       (case error-type
+         [(timeout) "LLM timeout"]
+         [(rate-limit) "rate limited"]
+         [(context-overflow) "context too large"]
+         [(provider-error) "server error"]
+         [else #f]))
+     (define msg
+       (if type-label
+           (format "[retry: ~a, ~a/~a...]" type-label attempt max-attempts)
+           (format "[retry: attempt ~a/~a]" attempt max-attempts)))
      (struct-copy ui-state
-                  (append-entry state
-                                (make-entry 'system
-                                            (format "[retry: attempt ~a/~a]" attempt max-attempts)
-                                            (event-time evt)
-                                            (hash)))
+                  (append-entry state (make-entry 'system msg (event-time evt) (hash)))
                   [streaming-text #f]
                   [streaming-thinking #f])]
 


### PR DESCRIPTION
Addresses #1405.

feat: context-aware retry messages with error type (#1405)

- auto-retry.rkt: pass classified error-type to on-retry callback
- iteration.rkt: include errorType in auto-retry.start event payload
- tui/state.rkt: render type-aware messages (timeout, rate-limit, etc.)