### PR TITLE
feat: mid-turn token budget check during tool execution (#1408)

- iteration.rkt: add check-mid-turn-budget! helper, emits context.mid-turn-over-budget event when context exceeds 90% of max-context-tokens
- tui/state.rkt: render [context growing: N/M tokens used] warning
- tests/test-midturn-budget.rkt: 3 tests covering under-budget, over-budget, and return value

### DIFF
--- a/runtime/iteration.rkt
+++ b/runtime/iteration.rkt
@@ -41,6 +41,8 @@
                   make-message
                   make-tool-result-part
                   make-text-part
+                  text-part?
+                  text-part-text
                   tool-call-part?
                   tool-call-part-id
                   tool-call-part-name
@@ -101,7 +103,9 @@
                   context-overflow-error?
                   timeout-error?)
          ;; FEAT-61: message injection support
-         (only-in "../extensions/message-inject.rkt" injection-event-topic))
+         (only-in "../extensions/message-inject.rkt" injection-event-topic)
+         ;; v0.14.1: mid-turn token budget check
+         (only-in "../llm/token-budget.rkt" estimate-context-tokens))
 
 (provide run-iteration-loop
          emit-session-event!
@@ -111,7 +115,9 @@
          make-injected-collector!
          drain-injected-messages!
          ;; FEAT-66: overflow recovery (for testing)
-         call-with-overflow-recovery)
+         call-with-overflow-recovery
+         ;; v0.14.1: mid-turn token budget check (for testing)
+         check-mid-turn-budget!)
 
 ;; ============================================================
 ;; Shared helpers
@@ -129,6 +135,33 @@
       (let ([result (dispatch-hooks hook-point payload ext-reg #:ctx ctx)])
         (values (hook-result-payload result) result))
       (values payload #f)))
+
+;; v0.14.1: Check if context exceeds mid-turn token budget.
+;; Returns estimated token count. Emits event if over budget.
+(define (check-mid-turn-budget! ctx bus session-id config)
+  (define max-tokens (hash-ref config 'max-context-tokens 128000))
+  (define budget-threshold (inexact->exact (floor (* max-tokens 0.9))))
+  ;; Extract text from message? structs for token estimation
+  (define texts
+    (for/list ([msg (in-list ctx)])
+      (define content (message-content msg))
+      (cond
+        [(string? content) content]
+        [(list? content)
+         (apply string-append
+                (for/list ([part (in-list content)]
+                           #:when (text-part? part))
+                  (text-part-text part)))]
+        [else ""])))
+  (define estimated
+    (for/sum ([t (in-list texts)]) (estimate-context-tokens (list (hasheq 'content t)))))
+  (when (> estimated budget-threshold)
+    (emit-session-event!
+     bus
+     session-id
+     "context.mid-turn-over-budget"
+     (hasheq 'estimated-tokens estimated 'budget budget-threshold 'max-tokens max-tokens)))
+  estimated)
 
 ;; ============================================================
 ;; Iteration-loop helpers (private)
@@ -673,6 +706,8 @@
                                               log-path
                                               token
                                               config))
+                 ;; v0.14.1: mid-turn token budget check
+                 (check-mid-turn-budget! updated-ctx bus session-id config)
                  (loop updated-ctx (add1 iteration) (add1 consecutive-tool-count))]
 
                 ;; ── Tool calls pending: execute tools and re-run ──
@@ -702,6 +737,8 @@
                                                 tool-names
                                                 'iteration
                                                 (add1 iteration))))
+                 ;; v0.14.1: mid-turn token budget check
+                 (check-mid-turn-budget! updated-ctx bus session-id config)
                  (loop updated-ctx (add1 iteration) (add1 consecutive-tool-count))]
 
                 ;; ── Unknown termination: append and return ──

--- a/tests/test-midturn-budget.rkt
+++ b/tests/test-midturn-budget.rkt
@@ -1,0 +1,68 @@
+#lang racket
+
+;;; tests/test-midturn-budget.rkt — mid-turn token budget check (v0.14.1 Wave 5)
+;;;
+;;; Tests that check-mid-turn-budget! emits context.mid-turn-over-budget
+;;; events when the context grows past 90% of max-context-tokens.
+
+(require rackunit
+         "../agent/event-bus.rkt"
+         "../util/protocol-types.rkt"
+         "../runtime/iteration.rkt")
+
+;; ============================================================
+;; Helpers
+;; ============================================================
+
+(define (make-test-message text)
+  (make-message (symbol->string (gensym 'midturn-test))
+                #f
+                'assistant
+                'text
+                (list (make-text-part text))
+                0
+                (hasheq)))
+
+;; ============================================================
+;; Test suite
+;; ============================================================
+
+(test-case
+ "check-mid-turn-budget: no event when under budget"
+ (define bus (make-event-bus))
+ (define events '())
+ (subscribe! bus (lambda (evt) (set! events (cons evt events))))
+ ;; Small context, large budget → no event
+ (define ctx (list (make-test-message "hello")))
+ (define config (hash 'max-context-tokens 128000))
+ (define result (check-mid-turn-budget! ctx bus "test-session" config))
+ (check-true (> result 0))
+ (check-equal? (length events) 0))
+
+(test-case
+ "check-mid-turn-budget: event emitted when over 90% budget"
+ (define bus (make-event-bus))
+ (define events '())
+ (subscribe! bus (lambda (evt) (set! events (cons evt events))))
+ ;; Create a large context that exceeds 90% of a tiny budget
+ (define big-text (make-string 5000 #\x))
+ (define ctx (for/list ([_ (in-range 10)]) (make-test-message big-text)))
+ ;; Budget = 500 tokens → 90% = 450 → definitely over
+ (define config (hash 'max-context-tokens 500))
+ (define result (check-mid-turn-budget! ctx bus "test-session" config))
+ (check-true (> result 0))
+ (check-equal? (length events) 1)
+ (define evt (car events))
+ (check-equal? (event-ev evt) "context.mid-turn-over-budget")
+ (define payload (event-payload evt))
+ (check-true (hash-has-key? payload 'estimated-tokens))
+ (check-true (hash-has-key? payload 'budget)))
+
+(test-case
+ "check-mid-turn-budget: estimated tokens returned correctly"
+ (define bus (make-event-bus))
+ (define ctx (list (make-test-message "test message")))
+ (define config (hash 'max-context-tokens 128000))
+ (define result (check-mid-turn-budget! ctx bus "test-session" config))
+ ;; Should return positive integer
+ (check-true (and (integer? result) (positive? result))))

--- a/tui/state.rkt
+++ b/tui/state.rkt
@@ -516,6 +516,16 @@
                                (event-time evt)
                                (hash)))]
 
+    ;; v0.14.1: mid-turn token budget warning
+    [("context.mid-turn-over-budget")
+     (define estimated (hash-ref payload 'estimated-tokens "?"))
+     (define budget (hash-ref payload 'budget "?"))
+     (append-entry state
+                   (make-entry 'system
+                               (format "[context growing: ~a/~a tokens used]" estimated budget)
+                               (event-time evt)
+                               (hash)))]
+
     ;; BUG-33 fix: auto-retry event from runtime/iteration.rkt
     [("auto-retry.start")
      (define attempt (hash-ref payload 'attempt "?"))


### PR DESCRIPTION
Addresses #1408.

feat: mid-turn token budget check during tool execution (#1408)

- iteration.rkt: add check-mid-turn-budget! helper, emits context.mid-turn-over-budget event when context exceeds 90% of max-context-tokens
- tui/state.rkt: render [context growing: N/M tokens used] warning
- tests/test-midturn-budget.rkt: 3 tests covering under-budget, over-budget, and return value