### PR TITLE
refactor: lift TUI mock-provider detection to provider-factory (#1409)

- provider-factory.rkt: add provider-is-mock? predicate
- tui-init.rkt: replace llm/provider.rkt import with runtime/provider-factory.rkt
- Eliminates tui → llm/ layer violation

### DIFF
--- a/runtime/provider-factory.rkt
+++ b/runtime/provider-factory.rkt
@@ -19,7 +19,8 @@
 (provide build-provider
          build-mock-provider
          local-provider?
-         create-provider-for-name) ;; for testing
+         create-provider-for-name ;; for testing
+         provider-is-mock?) ;; v0.14.1: for tui-init without importing llm/
 
 ;; Build the appropriate provider based on provider name.
 (define (create-provider-for-name prov-name base-url api-key model-name)
@@ -39,6 +40,11 @@
     [(equal? prov-name "anthropic") (make-anthropic-provider config)]
     [(equal? prov-name "azure") (make-azure-openai-provider config)]
     [else (make-openai-compatible-provider config)]))
+
+;; Helper: Check if a provider is a mock provider (name = "mock").
+;; v0.14.1: Moves mock detection out of tui/tui-init.rkt to avoid tui→llm import.
+(define (provider-is-mock? prov)
+  (and (provider? prov) (equal? (provider-name prov) "mock")))
 
 ;; Helper: Check if a URL points to a local/self-hosted provider.
 ;; Local providers don't require API keys.

--- a/tui/tui-init.rkt
+++ b/tui/tui-init.rkt
@@ -18,7 +18,7 @@
          "../util/protocol-types.rkt"
          "../agent/event-bus.rkt"
          "../runtime/agent-session.rkt"
-         "../llm/provider.rkt"
+         "../runtime/provider-factory.rkt"
          "../runtime/session-index.rkt"
          "../tui/tui-keybindings.rkt"
          "../tui/tui-render-loop.rkt"
@@ -85,7 +85,7 @@
                       #:model-name (hash-ref rt-config 'model-name #f)))
   ;; BUG-55: Detect mock provider and set warning flag
   (define prov (hash-ref rt-config 'provider #f))
-  (define mock? (and prov (provider? prov) (equal? (provider-name prov) "mock")))
+  (define mock? (provider-is-mock? prov))
   (define base-state-with-mock
     (if mock?
         (struct-copy ui-state base-state [mock-provider? #t])


### PR DESCRIPTION
Addresses #1409.

refactor: lift TUI mock-provider detection to provider-factory (#1409)

- provider-factory.rkt: add provider-is-mock? predicate
- tui-init.rkt: replace llm/provider.rkt import with runtime/provider-factory.rkt
- Eliminates tui → llm/ layer violation