### PR TITLE
refactor: move runtime/resource-loader → extensions/resource-discovery (#1410)

- Create extensions/resource-discovery.rkt (moved from runtime/)
- Update test imports to new location
- Remove resource-loader.rkt from arch-boundaries exceptions
- Eliminates runtime→extensions boundary violation for resource discovery

### DIFF
--- a/extensions/resource-discovery.rkt
+++ b/extensions/resource-discovery.rkt
@@ -1,16 +1,20 @@
 #lang racket/base
 
-;; runtime/resource-loader.rkt — extension resource discovery
+;; extensions/resource-discovery.rkt — extension resource discovery
 ;;
+;; Moved from runtime/resource-loader.rkt (v0.14.1 Wave 7).
 ;; Provides:
 ;;   discover-extension-resources — query extensions for additional resource paths
 ;;
 ;; Uses the 'resources-discover hook point to let extensions contribute
 ;; dynamic skill/prompt/config paths at runtime.
+;;
+;; Sits in extensions/ because it dispatches extension hooks — this is the
+;; natural layer for code that interacts with the extension API.
 
 (require racket/list
-         "../extensions/api.rkt"
-         "../extensions/hooks.rkt")
+         "api.rkt"
+         "hooks.rkt")
 
 (provide discover-extension-resources)
 

--- a/tests/test-arch-boundaries.rkt
+++ b/tests/test-arch-boundaries.rkt
@@ -58,13 +58,11 @@
     (test-case "Only iteration.rkt in runtime/ imports from tools/ or extensions/"
       ;; Known exceptions:
       ;;   - runtime/package.rkt imports extensions/manifest.rkt for package audit
-      ;;   - runtime/resource-loader.rkt imports extensions/api.rkt and hooks.rkt
-      ;;     for extension resource discovery (documented exception)
       ;;   - runtime/session-switch.rkt imports extensions/context.rkt and hooks.rkt
       ;;     for extension lifecycle during session switch (documented exception)
       (define runtime-files (rkt-files-in "runtime"))
       (define known-exceptions
-        '("iteration.rkt" "package.rkt" "resource-loader.rkt" "session-switch.rkt"))
+        '("iteration.rkt" "package.rkt" "session-switch.rkt"))
       (define violations
         (for/list ([f (in-list runtime-files)]
                    #:when (not (member (path->string (file-name-from-path f)) known-exceptions)))

--- a/tests/test-extension-lifecycle.rkt
+++ b/tests/test-extension-lifecycle.rkt
@@ -9,7 +9,7 @@
          "../extensions/loader.rkt"
          "../extensions/api.rkt"
          "../runtime/session-store.rkt"
-         "../runtime/resource-loader.rkt"
+         "../extensions/resource-discovery.rkt"
          "../util/hook-types.rkt"
          "../util/protocol-types.rkt")
 

--- a/tests/test-sdk-resource-loader.rkt
+++ b/tests/test-sdk-resource-loader.rkt
@@ -7,7 +7,7 @@
 (require rackunit
          rackunit/text-ui
          "../interfaces/sdk.rkt"
-         "../runtime/resource-loader.rkt"
+         "../extensions/resource-discovery.rkt"
          (only-in "../runtime/session-store.rkt"
                   make-in-memory-session-manager
                   in-memory-session-manager?


### PR DESCRIPTION
Addresses #1410.

refactor: move runtime/resource-loader → extensions/resource-discovery (#1410)

- Create extensions/resource-discovery.rkt (moved from runtime/)
- Update test imports to new location
- Remove resource-loader.rkt from arch-boundaries exceptions
- Eliminates runtime→extensions boundary violation for resource discovery