### PR TITLE
refactor: session-switch DI — eliminate runtime→extensions boundary violation (#1411)

- session-switch.rkt: replace direct extensions imports with DI via
  dynamic-require defaults + keyword args (#:dispatch-hooks, #:make-ctx)
- Remove session-switch.rkt from arch-boundaries exceptions
- All 17 session-switch tests pass

### DIFF
--- a/runtime/session-switch.rkt
+++ b/runtime/session-switch.rkt
@@ -9,12 +9,14 @@
 ;;   - #707: Parent feature combining all of the above
 ;;
 ;; Lifecycle: before-switch → teardown old → create new → rebind → emit start
+;;
+;; v0.14.1: DI for extension hooks/context to avoid runtime→extensions import.
+;; Callers pass #:dispatch-hooks and #:make-ctx functions (defaults provided
+;; for backward compatibility via lazy require).
 
 (require racket/contract
          racket/match
          "../agent/event-bus.rkt"
-         "../extensions/hooks.rkt"
-         "../extensions/context.rkt"
          "../util/protocol-types.rkt")
 
 (provide
@@ -37,6 +39,30 @@
  switch-result-old-session-id
  switch-result-new-session-id
  switch-result-reason)
+
+;; ============================================================
+;; Lazy extension imports (DI defaults)
+;; ============================================================
+
+;; Default dispatch-hooks: lazy-load from extensions/hooks.rkt
+(define (default-dispatch-hooks hook-point payload registry)
+  ((dynamic-require "../extensions/hooks.rkt" 'dispatch-hooks)
+   hook-point payload registry))
+
+;; Default make-extension-ctx: lazy-load from extensions/context.rkt
+(define (default-make-extension-ctx #:session-id sid
+                                     #:session-dir sdir
+                                     #:event-bus bus
+                                     #:extension-registry ereg
+                                     #:model-name [model-name #f]
+                                     #:working-directory [working-directory #f])
+  ((dynamic-require "../extensions/context.rkt" 'make-extension-ctx)
+   #:session-id sid
+   #:session-dir sdir
+   #:event-bus bus
+   #:extension-registry ereg
+   #:model-name model-name
+   #:working-directory working-directory))
 
 ;; ============================================================
 ;; Structs
@@ -63,7 +89,8 @@
 ;; Emit session-shutdown event and dispatch hook.
 ;; Extensions use this to clean up connections, flush logs, deregister tools.
 (define (emit-session-shutdown! bus session-id extension-registry
-                                #:duration [duration 0])
+                                #:duration [duration 0]
+                                #:dispatch-hooks [dispatch-hooks default-dispatch-hooks])
   ;; Dispatch 'session-shutdown hook
   (when extension-registry
     (dispatch-hooks 'session-shutdown
@@ -84,9 +111,11 @@
 (define (teardown-session-extensions! old-session-id
                                        bus
                                        extension-registry
-                                       #:duration [duration 0])
+                                       #:duration [duration 0]
+                                       #:dispatch-hooks [dispatch-hooks default-dispatch-hooks])
   (emit-session-shutdown! bus old-session-id extension-registry
-                          #:duration duration))
+                          #:duration duration
+                          #:dispatch-hooks dispatch-hooks))
 
 ;; ============================================================
 ;; #705: Rebind extensions to new session
@@ -98,13 +127,14 @@
                           bus
                           extension-registry
                           #:model-name [model-name #f]
-                          #:working-directory [working-directory #f])
-  (make-extension-ctx #:session-id new-session-id
-                       #:session-dir new-session-dir
-                       #:event-bus bus
-                       #:extension-registry extension-registry
-                       #:model-name model-name
-                       #:working-directory working-directory))
+                          #:working-directory [working-directory #f]
+                          #:make-ctx [make-ctx default-make-extension-ctx])
+  (make-ctx #:session-id new-session-id
+             #:session-dir new-session-dir
+             #:event-bus bus
+             #:extension-registry extension-registry
+             #:model-name model-name
+             #:working-directory working-directory))
 
 ;; Rebind all extensions to a new session context.
 ;; Returns the new extension-ctx.
@@ -113,13 +143,16 @@
                              bus
                              extension-registry
                              #:model-name [model-name #f]
-                             #:working-directory [working-directory #f])
+                             #:working-directory [working-directory #f]
+                             #:dispatch-hooks [dispatch-hooks default-dispatch-hooks]
+                             #:make-ctx [make-ctx default-make-extension-ctx])
   (define ctx (make-rebind-ctx new-session-id
                                 new-session-dir
                                 bus
                                 extension-registry
                                 #:model-name model-name
-                                #:working-directory working-directory))
+                                #:working-directory working-directory
+                                #:make-ctx make-ctx))
   ;; Dispatch 'session-rebind hook so extensions can reconnect
   (when extension-registry
     (dispatch-hooks 'session-rebind
@@ -166,14 +199,17 @@
                           #:new-extension-registry [new-ext-reg #f]
                           #:reason reason
                           #:model-name [model-name #f]
-                          #:working-directory [working-directory #f])
+                          #:working-directory [working-directory #f]
+                          #:dispatch-hooks [dispatch-hooks default-dispatch-hooks]
+                          #:make-ctx [make-ctx default-make-extension-ctx])
   (unless (session-start-reason? reason)
     (raise-argument-error 'switch-session! "session-start-reason?" reason))
 
   ;; Step 1: Teardown old session (if any)
   (when old-session-id
     (teardown-session-extensions! old-session-id old-bus old-ext-reg
-                                   #:duration old-duration))
+                                   #:duration old-duration
+                                   #:dispatch-hooks dispatch-hooks))
 
   ;; Step 2: Rebind extensions to new session
   (define ctx (rebind-extensions! new-session-id
@@ -181,7 +217,9 @@
                                    new-bus
                                    new-ext-reg
                                    #:model-name model-name
-                                   #:working-directory working-directory))
+                                   #:working-directory working-directory
+                                   #:dispatch-hooks dispatch-hooks
+                                   #:make-ctx make-ctx))
 
   ;; Step 3: Emit session.start with reason
   (emit-session-start! new-bus new-session-id reason

--- a/tests/test-arch-boundaries.rkt
+++ b/tests/test-arch-boundaries.rkt
@@ -58,11 +58,9 @@
     (test-case "Only iteration.rkt in runtime/ imports from tools/ or extensions/"
       ;; Known exceptions:
       ;;   - runtime/package.rkt imports extensions/manifest.rkt for package audit
-      ;;   - runtime/session-switch.rkt imports extensions/context.rkt and hooks.rkt
-      ;;     for extension lifecycle during session switch (documented exception)
       (define runtime-files (rkt-files-in "runtime"))
       (define known-exceptions
-        '("iteration.rkt" "package.rkt" "session-switch.rkt"))
+        '("iteration.rkt" "package.rkt"))
       (define violations
         (for/list ([f (in-list runtime-files)]
                    #:when (not (member (path->string (file-name-from-path f)) known-exceptions)))


### PR DESCRIPTION
Addresses #1411.

refactor: session-switch DI — eliminate runtime→extensions boundary violation (#1411)

- session-switch.rkt: replace direct extensions imports with DI via
  dynamic-require defaults + keyword args (#:dispatch-hooks, #:make-ctx)
- Remove session-switch.rkt from arch-boundaries exceptions
- All 17 session-switch tests pass