### PR TITLE
fix: remove dead code in classify-error + fix rate-limit pattern (R1, R2) (#1423)

- auto-retry.rkt: remove no-op (when cat (set! cat cat)) dead code block
- auto-retry.rkt: replace 'too many' with 'too many requests' in RATE_LIMIT_PATTERNS
  to prevent context-overflow errors being misclassified as rate-limit
- test-auto-retry.rkt: add regression tests for both fixes

### DIFF
--- a/runtime/auto-retry.rkt
+++ b/runtime/auto-retry.rkt
@@ -103,7 +103,7 @@
   (for/or ([pattern (in-list TIMEOUT_PATTERNS)])
     (string-contains? (string-downcase msg) pattern)))
 
-(define RATE_LIMIT_PATTERNS '("429" "rate" "overloaded" "quota" "too many"))
+(define RATE_LIMIT_PATTERNS '("429" "rate" "overloaded" "quota" "too many requests"))
 
 (define (rate-limit-error? exn)
   (define msg (exn-message exn))
@@ -115,10 +115,6 @@
 ;; 'max-iterations, 'provider-error
 (define (classify-error exn)
   ;; Fast path: structured provider-error carries its own category.
-  (when (provider-error? exn)
-    (define cat (provider-error-category exn))
-    (when cat
-      (set! cat cat))) ; already correct
   (cond
     [(provider-error? exn)
      (define cat (provider-error-category exn))

--- a/tests/test-auto-retry.rkt
+++ b/tests/test-auto-retry.rkt
@@ -312,13 +312,15 @@
 (test-case "rate-limit-error?: positive cases"
   (check-true (rate-limit-error? (exn:fail "HTTP 429" (current-continuation-marks))))
   (check-true (rate-limit-error? (exn:fail "rate limit exceeded" (current-continuation-marks))))
-  (check-true (rate-limit-error? (exn:fail "Quota exceeded" (current-continuation-marks)))))
+  (check-true (rate-limit-error? (exn:fail "Quota exceeded" (current-continuation-marks))))
+  (check-true (rate-limit-error? (exn:fail "too many requests" (current-continuation-marks)))))
 
 (test-case "rate-limit-error?: negative cases"
   (check-false (rate-limit-error? (exn:fail "timeout" (current-continuation-marks))))
   (check-false (rate-limit-error? (exn:fail "internal error" (current-continuation-marks))))
-  (check-false (rate-limit-error? (exn:fail "invalid API key" (current-continuation-marks)))))
-
+  (check-false (rate-limit-error? (exn:fail "invalid API key" (current-continuation-marks))))
+  ;; v0.14.1 R2: "too many tokens" must NOT match rate-limit
+  (check-false (rate-limit-error? (exn:fail "too many tokens in request" (current-continuation-marks)))))
 ;; ============================================================
 ;; context-reducer tests removed (v0.13.2)
 ;; ============================================================


### PR DESCRIPTION
Addresses #1423.

fix: remove dead code in classify-error + fix rate-limit pattern (R1, R2) (#1423)

- auto-retry.rkt: remove no-op (when cat (set! cat cat)) dead code block
- auto-retry.rkt: replace 'too many' with 'too many requests' in RATE_LIMIT_PATTERNS
  to prevent context-overflow errors being misclassified as rate-limit
- test-auto-retry.rkt: add regression tests for both fixes