### PR TITLE
feat: per-type retry budgets with error history tracking (#1431)

- auto-retry.rkt: replace single attempt counter with per-type budgets
  (timeout=2, rate-limit=4, provider-error=2 by default)
- auto-retry.rkt: add error-history field to retry-exhausted struct
- agent-session.rkt: include errorHistory in runtime.error payload
- state.rkt: render recovery hints from full error history (mixed types)
- Tests: 4 new test cases for per-type budgets and error history

### DIFF
--- a/runtime/agent-session.rkt
+++ b/runtime/agent-session.rkt
@@ -53,7 +53,8 @@
                   classify-error
                   retry-exhausted?
                   retry-exhausted-attempts
-                  retry-exhausted-total-delay-ms))
+                  retry-exhausted-total-delay-ms
+                  retry-exhausted-error-history))
 
 (provide agent-session?
          agent-session-session-dir
@@ -675,7 +676,9 @@
                                                 'retries-attempted
                                                 (retry-exhausted-attempts e)
                                                 'total-retry-delay-ms
-                                                (retry-exhausted-total-delay-ms e))
+                                                (retry-exhausted-total-delay-ms e)
+                                                'errorHistory
+                                                (retry-exhausted-error-history e))
                                      base-payload))
                                (emit-session-event! bus sid "runtime.error" payload)
                                ;; Defense-in-depth: ensure turn.completed is emitted

--- a/runtime/auto-retry.rkt
+++ b/runtime/auto-retry.rkt
@@ -45,7 +45,8 @@
 
 ;; Raised when retries are exhausted. Wraps the original exception with metadata
 ;; so callers (agent-session, TUI) can distinguish exhaustion from first failure.
-(struct retry-exhausted exn:fail (original-exn attempts last-error-type total-delay-ms) #:transparent)
+(struct retry-exhausted exn:fail (original-exn attempts last-error-type total-delay-ms error-history)
+  #:transparent)
 
 ;; ============================================================
 ;; Predicates
@@ -155,23 +156,31 @@
 ;; Execute a thunk with automatic retry on retryable errors.
 ;; Returns the thunk result on success, or re-raises on non-retryable
 ;; error or after max-retries exhausted.
-(define (with-auto-retry thunk
-                         #:max-retries [max-retries default-max-retries]
-                         #:base-delay-ms [base-delay-ms default-base-delay-ms]
-                         #:rate-limit-base-delay-ms
-                         [rl-base-delay-ms default-rate-limit-base-delay-ms]
-                         #:max-delay-ms [max-delay-ms default-max-delay-ms]
-                         #:on-retry [on-retry #f])
+(define (with-auto-retry
+         thunk
+         #:max-retries [max-retries default-max-retries]
+         #:base-delay-ms [base-delay-ms default-base-delay-ms]
+         #:rate-limit-base-delay-ms [rl-base-delay-ms default-rate-limit-base-delay-ms]
+         #:max-delay-ms [max-delay-ms default-max-delay-ms]
+         #:on-retry [on-retry #f]
+         #:per-type-budgets [per-type-budgets (hash 'timeout 2 'rate-limit 4 'provider-error 2)])
+  ;; v0.14.2: Per-type retry budget. Each error type has its own budget.
+  ;; Rate-limit retries don't consume timeout budget, etc.
   (let loop ([attempt 0]
              [delay-ms 0]
              [total-delay 0]
-             [last-error-type #f])
+             [last-error-type #f]
+             [type-attempts (hash)] ; hash of error-type -> count
+             [error-history '()]) ; list of error types encountered
     (with-handlers
         ([exn:fail?
           (lambda (exn)
             (define err-type (classify-error exn))
+            (define current-type-count (hash-ref type-attempts err-type 0))
+            (define type-budget (hash-ref per-type-budgets err-type max-retries))
+            ;; Can retry if: globally under max-retries AND per-type under budget
             (cond
-              [(and (retryable-error? exn) (< attempt max-retries))
+              [(and (retryable-error? exn) (< attempt max-retries) (< current-type-count type-budget))
                ;; A1: Use longer backoff for rate-limit errors
                (define rl-base (if (eq? err-type 'rate-limit) rl-base-delay-ms base-delay-ms))
                (define next-delay (min (* rl-base (expt 2 attempt)) max-delay-ms))
@@ -181,15 +190,22 @@
                (when on-retry
                  (on-retry (add1 attempt) max-retries next-delay (exn-message exn) err-type))
                (sleep (/ next-delay 1000.0))
-               (loop (add1 attempt) next-delay (+ total-delay next-delay) err-type)]
+               (loop (add1 attempt)
+                     next-delay
+                     (+ total-delay next-delay)
+                     err-type
+                     (hash-set type-attempts err-type (add1 current-type-count))
+                     (append error-history (list err-type)))]
               [else
                ;; A3: Wrap in retry-exhausted if we attempted retries
+               (define final-history (append error-history (list err-type)))
                (if (> attempt 0)
                    (raise (retry-exhausted (format "~a (after ~a retries)" (exn-message exn) attempt)
                                            (current-continuation-marks)
                                            exn
                                            attempt
                                            last-error-type
-                                           total-delay))
+                                           total-delay
+                                           final-history))
                    (raise exn))]))])
       (thunk))))

--- a/tests/test-auto-retry.rkt
+++ b/tests/test-auto-retry.rkt
@@ -99,6 +99,7 @@
                (with-auto-retry (lambda () (raise (exn:fail "HTTP 503" (current-continuation-marks))))
                                 #:max-retries 3
                                 #:base-delay-ms 10
+                                #:per-type-budgets (hash 'timeout 3 'rate-limit 4 'provider-error 3)
                                 #:on-retry (lambda (attempt max-retries delay-ms error-msg error-type)
                                              (set-box! delays (cons delay-ms (unbox delays)))))))
   ;; Delays should be: 10, 20, 40 (exponential with base 10ms)
@@ -116,6 +117,7 @@
                                 #:max-retries 5
                                 #:base-delay-ms 100
                                 #:max-delay-ms 200
+                                #:per-type-budgets (hash 'timeout 3 'rate-limit 4 'provider-error 5)
                                 #:on-retry (lambda (attempt max-retries delay-ms error-msg error-type)
                                              (set-box! delays (cons delay-ms (unbox delays)))))))
   (define sorted-delays (reverse (unbox delays)))
@@ -320,10 +322,91 @@
   (check-false (rate-limit-error? (exn:fail "internal error" (current-continuation-marks))))
   (check-false (rate-limit-error? (exn:fail "invalid API key" (current-continuation-marks))))
   ;; v0.14.1 R2: "too many tokens" must NOT match rate-limit
-  (check-false (rate-limit-error? (exn:fail "too many tokens in request" (current-continuation-marks)))))
+  (check-false (rate-limit-error? (exn:fail "too many tokens in request"
+                                            (current-continuation-marks)))))
 ;; ============================================================
 ;; context-reducer tests removed (v0.13.2)
 ;; ============================================================
 ;; The #:context-reducer parameter was removed in v0.13.2.
 ;; Retries now always use the same thunk without any context reduction.
 ;; See "retries use same thunk on timeout" test above.
+
+;; ============================================================
+;; v0.14.2 Wave 1: Per-type retry budgets + error history
+;; ============================================================
+
+(test-case "v0.14.2: per-type budget — rate-limit doesn't consume timeout budget"
+  ;; With default budgets: timeout=2, rate-limit=4, provider-error=2
+  ;; If we get 1 rate-limit then 2 timeouts, the timeouts should use their own budget
+  (define errors-thrown (box '()))
+  (define exn-result (box #f))
+  (with-handlers ([retry-exhausted? (lambda (e) (set-box! exn-result e))])
+    (with-auto-retry (lambda ()
+                       ;; Always throw: rate-limit first, then timeouts
+                       (define n (length (unbox errors-thrown)))
+                       (cond
+                         [(= n 0)
+                          (set-box! errors-thrown (cons 'rate-limit (unbox errors-thrown)))
+                          (raise (exn:fail "HTTP 429 rate limit" (current-continuation-marks)))]
+                         [else
+                          (set-box! errors-thrown (cons 'timeout (unbox errors-thrown)))
+                          (raise (exn:fail "connection timed out" (current-continuation-marks)))]))
+                     #:max-retries 5
+                     #:base-delay-ms 1
+                     #:rate-limit-base-delay-ms 1
+                     #:per-type-budgets (hash 'timeout 2 'rate-limit 4 'provider-error 2)))
+  (check-true (retry-exhausted? (unbox exn-result)))
+  ;; 1 rate-limit + 2 timeouts = 3 retries (4th attempt hits per-type budget)
+  (check-equal? (length (unbox errors-thrown)) 4)
+  ;; Error history: rate-limit + 2 timeout retries + final timeout
+  (define hist (retry-exhausted-error-history (unbox exn-result)))
+  (check-equal? hist '(rate-limit timeout timeout timeout)))
+
+(test-case "v0.14.2: error-history tracks all error types"
+  (define exn-result (box #f))
+  (define call-n (box 0))
+  (with-handlers ([retry-exhausted? (lambda (e) (set-box! exn-result e))])
+    (with-auto-retry
+     (lambda ()
+       ;; Deterministic sequence: provider-error, timeout, rate-limit, ...
+       (define n (modulo (unbox call-n) 3))
+       (set-box! call-n (add1 (unbox call-n)))
+       (cond
+         [(= n 0) (raise (exn:fail "HTTP 503 server error" (current-continuation-marks)))]
+         [(= n 1) (raise (exn:fail "connection timed out" (current-continuation-marks)))]
+         [else (raise (exn:fail "HTTP 429 rate limit" (current-continuation-marks)))]))
+     #:max-retries 10
+     #:base-delay-ms 1
+     #:rate-limit-base-delay-ms 1
+     #:per-type-budgets (hash 'timeout 2 'rate-limit 2 'provider-error 2)))
+  (check-true (retry-exhausted? (unbox exn-result)))
+  (define hist (retry-exhausted-error-history (unbox exn-result)))
+  ;; History should have entries from all types
+  (check-true (> (length hist) 0) (format "history should be non-empty: ~a" hist)))
+
+(test-case "v0.14.2: single error type fills its own budget"
+  (define attempt-count (box 0))
+  (define exn-result (box #f))
+  (with-handlers ([retry-exhausted? (lambda (e) (set-box! exn-result e))])
+    (with-auto-retry (lambda ()
+                       (set-box! attempt-count (add1 (unbox attempt-count)))
+                       (raise (exn:fail "connection timed out" (current-continuation-marks))))
+                     #:max-retries 5
+                     #:base-delay-ms 1
+                     #:rate-limit-base-delay-ms 1
+                     #:per-type-budgets (hash 'timeout 2 'rate-limit 4 'provider-error 2)))
+  (check-true (retry-exhausted? (unbox exn-result)))
+  ;; With timeout budget of 2, should try 3 times (1 initial + 2 retries)
+  (check-equal? (unbox attempt-count) 3)
+  (check-equal? (retry-exhausted-error-history (unbox exn-result)) '(timeout timeout timeout)))
+
+(test-case "v0.14.2: default per-type-budgets when not specified"
+  ;; Should use max-retries as fallback budget for all types
+  (define exn-result (box #f))
+  (with-handlers ([retry-exhausted? (lambda (e) (set-box! exn-result e))])
+    (with-auto-retry (lambda ()
+                       (raise (exn:fail "connection timed out" (current-continuation-marks))))
+                     #:max-retries 2
+                     #:base-delay-ms 1))
+  (check-true (retry-exhausted? (unbox exn-result)))
+  (check-equal? (retry-exhausted-error-history (unbox exn-result)) '(timeout timeout timeout)))

--- a/tui/state.rkt
+++ b/tui/state.rkt
@@ -364,20 +364,33 @@
             [else 'provider-error]))))
      ;; Recovery hint based on classified error type
      ;; B1: Show different hint when retries were attempted
+     ;; v0.14.2: Use errorHistory for accurate multi-type retry hints
      (define retries-attempted (hash-ref payload 'retries-attempted #f))
+     (define error-history (hash-ref payload 'errorHistory '()))
+     (define history-types (remove-duplicates error-history))
      (define hint
        (cond
          [(and retries-attempted (> retries-attempted 0))
-          (case error-type
-            [(rate-limit)
-             (format "Rate limit persisted after ~a retries. Wait a moment, then type /retry."
+          (cond
+            ;; Mixed error types
+            [(and (member 'timeout history-types) (member 'rate-limit history-types))
+             (format "Provider timed out, then rate limited (~a retries). Wait 30s, then type /retry."
                      retries-attempted)]
-            [(timeout)
-             (format "Provider timed out after ~a retries. Type /retry to resubmit."
+            [(> (length history-types) 1)
+             (format "Mixed errors after ~a retries. Wait a moment, then type /retry."
                      retries-attempted)]
+            ;; Single error type
             [else
-             (format "Error persisted after ~a retries. Type /retry to resubmit."
-                     retries-attempted)])]
+             (case error-type
+               [(rate-limit)
+                (format "Rate limit persisted after ~a retries. Wait a moment, then type /retry."
+                        retries-attempted)]
+               [(timeout)
+                (format "Provider timed out after ~a retries. Type /retry to resubmit."
+                        retries-attempted)]
+               [else
+                (format "Error persisted after ~a retries. Type /retry to resubmit."
+                        retries-attempted)])])]
          [else
           (case error-type
             [(timeout) "Provider timed out. Type /retry to resubmit your prompt."]


### PR DESCRIPTION
Addresses #1431.

feat: per-type retry budgets with error history tracking (#1431)

- auto-retry.rkt: replace single attempt counter with per-type budgets
  (timeout=2, rate-limit=4, provider-error=2 by default)
- auto-retry.rkt: add error-history field to retry-exhausted struct
- agent-session.rkt: include errorHistory in runtime.error payload
- state.rkt: render recovery hints from full error history (mixed types)
- Tests: 4 new test cases for per-type budgets and error history