### PR TITLE
feat: enrich /retry with previous turn tool summary (#1432)

- state.rkt: add get-last-turn-tool-summary to scan transcript for
  tool-end entries from the last user turn
- commands.rkt: /retry includes [Context from previous attempt: ...]
  with tool names and result summaries when available
- New test file: test-retry-enrichment.rkt (8 tests)
- Falls back to plain prompt when no tool results found

### DIFF
--- a/tests/test-retry-enrichment.rkt
+++ b/tests/test-retry-enrichment.rkt
@@ -1,0 +1,100 @@
+#lang racket/base
+
+;; test-retry-enrichment.rkt — Tests for v0.14.2 Wave 2: enriched /retry
+;;
+;; Tests that get-last-turn-tool-summary extracts tool results from the
+;; last turn in the transcript for inclusion in retry prompts.
+
+(require rackunit
+         racket/string
+         "../tui/state.rkt")
+
+;; Helper: build a ui-state with given transcript entries
+(define (state-with-entries . entries)
+  (for/fold ([st (initial-ui-state)]) ([e (in-list entries)])
+    (add-transcript-entry st e)))
+
+;; ============================================================
+;; get-last-turn-tool-summary tests
+;; ============================================================
+
+(test-case "no entries → #f"
+  (check-false (get-last-turn-tool-summary (initial-ui-state))))
+
+(test-case "user message only, no tools → #f"
+  (define st (state-with-entries (make-entry 'user "hello" 1000 (hash))))
+  (check-false (get-last-turn-tool-summary st)))
+
+(test-case "user + one tool-end → summary with tool name and result"
+  (define st
+    (state-with-entries (make-entry 'user "read the file" 1000 (hash))
+                        (make-entry 'tool-end
+                                    "[OK: read_file] 185 lines"
+                                    1001
+                                    (hasheq 'name "read_file" 'result "185 lines of Python code"))))
+  (define summary (get-last-turn-tool-summary st))
+  (check-true (string? summary) (format "expected string, got: ~a" summary))
+  (check-true (string-contains? summary "read_file")
+              (format "summary should contain tool name: ~a" summary))
+  (check-true (string-contains? summary "185 lines")
+              (format "summary should contain result: ~a" summary)))
+
+(test-case "user + multiple tools → summary joined with semicolons"
+  (define st
+    (state-with-entries (make-entry 'user "analyze" 1000 (hash))
+                        (make-entry 'tool-end
+                                    "[OK: read_file] 185 lines"
+                                    1001
+                                    (hasheq 'name "read_file" 'result "185 lines"))
+                        (make-entry 'tool-end
+                                    "[OK: list_fonts] DejaVu"
+                                    1002
+                                    (hasheq 'name "list_fonts" 'result "DejaVu family"))))
+  (define summary (get-last-turn-tool-summary st))
+  (check-true (string-contains? summary "read_file"))
+  (check-true (string-contains? summary "list_fonts"))
+  (check-true (string-contains? summary ";")
+              (format "multiple tools should be joined with ';': ~a" summary)))
+
+(test-case "assistant text between user and tools → still picks up tools"
+  (define st
+    (state-with-entries
+     (make-entry 'user "do stuff" 1000 (hash))
+     (make-entry 'assistant "I will help" 1001 (hash))
+     (make-entry 'tool-end "[OK: bash] done" 1002 (hasheq 'name "bash" 'result "success"))))
+  (define summary (get-last-turn-tool-summary st))
+  (check-true (string? summary))
+  (check-true (string-contains? summary "bash")))
+
+(test-case "tool-fail entries are excluded from summary"
+  (define st
+    (state-with-entries (make-entry 'user "do stuff" 1000 (hash))
+                        (make-entry 'tool-fail
+                                    "[FAIL: bash] error"
+                                    1001
+                                    (hasheq 'name "bash" 'result "permission denied"))))
+  (check-false (get-last-turn-tool-summary st)))
+
+(test-case "long result is truncated to 100 chars"
+  (define long-result (make-string 200 #\x))
+  (define st
+    (state-with-entries
+     (make-entry 'user "analyze" 1000 (hash))
+     (make-entry 'tool-end "[OK: tool] ..." 1001 (hasheq 'name "tool" 'result long-result))))
+  (define summary (get-last-turn-tool-summary st))
+  (check-true (string? summary))
+  ;; The result part should be truncated (100 chars + "…")
+  (check-true (< (string-length summary) 150)
+              (format "summary should be truncated: len=~a" (string-length summary))))
+
+(test-case "two turns — only picks up tools from last turn"
+  (define st
+    (state-with-entries
+     (make-entry 'user "first prompt" 1000 (hash))
+     (make-entry 'tool-end "[OK: old_tool] old result" 1001 (hasheq 'name "old_tool" 'result "old"))
+     (make-entry 'user "second prompt" 2000 (hash))
+     (make-entry 'tool-end "[OK: new_tool] new result" 2001 (hasheq 'name "new_tool" 'result "new"))))
+  (define summary (get-last-turn-tool-summary st))
+  (check-true (string-contains? summary "new_tool"))
+  (check-false (string-contains? summary "old_tool")
+               (format "should not contain old tool: ~a" summary)))

--- a/tui/commands.rkt
+++ b/tui/commands.rkt
@@ -496,7 +496,7 @@
        [(name) (handle-name-command cctx)]
        [(sessions) (handle-sessions-tui-command cctx #f)]
        [(retry)
-        ;; /retry: resubmit last prompt
+        ;; /retry: resubmit last prompt, enriched with previous turn context
         (define last-prompt (unbox (cmd-ctx-last-prompt-box cctx)))
         (cond
           [last-prompt
@@ -506,6 +506,12 @@
                          (current-inexact-milliseconds)
                          (hash)))
            (set-box! (cmd-ctx-state-box cctx) (add-transcript-entry state entry))
+           ;; v0.14.2 Wave 2: Enrich retry with tool summary from previous turn
+           (define tool-summary (get-last-turn-tool-summary (unbox (cmd-ctx-state-box cctx))))
+           (define enriched-prompt
+             (if tool-summary
+                 (format "~a\n\n[Context from previous attempt: ~a]" last-prompt tool-summary)
+                 last-prompt))
            (define runner (cmd-ctx-session-runner cctx))
            (when runner
              (thread
@@ -529,7 +535,7 @@
                                                            sid
                                                            #f
                                                            (hasheq 'reason "error")))))])
-                  (runner last-prompt)))))]
+                  (runner enriched-prompt)))))]
           [else
            (define entry
              (make-entry 'error "No previous prompt to retry." (current-inexact-milliseconds) (hash)))

--- a/tui/state.rkt
+++ b/tui/state.rkt
@@ -98,6 +98,9 @@
          set-editor-component
          clear-editor-component
 
+         ;; Retry enrichment (v0.14.2)
+         get-last-turn-tool-summary
+
          ;; Selection
          set-selection-anchor
          set-selection-end
@@ -903,3 +906,43 @@
            "(no args)"
            (truncate-string (format "~a" (car vals)) 60))]
       [else (truncate-string (format "~a" h) 60)])))
+
+;; ============================================================
+;; v0.14.2 Wave 2: Previous-turn tool summary for enriched /retry
+;; ============================================================
+
+;; Extract a summary of tool calls from the most recent turn.
+;; Scans transcript for tool-end entries after the last user message.
+;; Returns #f if no tool calls found, or a string summary.
+(define (get-last-turn-tool-summary state)
+  (define entries (transcript-entries state))
+  ;; Find the LAST user message (entries are oldest-first)
+  (define user-idx
+    (for/last ([e (in-list entries)]
+               [i (in-naturals)]
+               #:when (eq? (transcript-entry-kind e) 'user))
+      i))
+  (cond
+    [(not user-idx) #f]
+    [else
+     ;; Collect tool-end entries AFTER the last user message
+     (define after-user (drop entries (add1 user-idx)))
+     (define tool-entries
+       (for/list ([e (in-list after-user)]
+                  #:when (eq? (transcript-entry-kind e) 'tool-end))
+         e))
+     (cond
+       [(null? tool-entries) #f]
+       [else
+        (define parts
+          (for/list ([e (in-list tool-entries)])
+            (define meta (transcript-entry-meta e))
+            (define name (hash-ref meta 'name "unknown"))
+            (define result (hash-ref meta 'result ""))
+            (define result-str
+              (truncate-string (if (string? result)
+                                   result
+                                   (format "~a" result))
+                               100))
+            (format "~a: ~a" name result-str)))
+        (string-join parts "; ")])]))


### PR DESCRIPTION
Addresses #1432.

feat: enrich /retry with previous turn tool summary (#1432)

- state.rkt: add get-last-turn-tool-summary to scan transcript for
  tool-end entries from the last user turn
- commands.rkt: /retry includes [Context from previous attempt: ...]
  with tool names and result summaries when available
- New test file: test-retry-enrichment.rkt (8 tests)
- Falls back to plain prompt when no tool results found