### PR TITLE
feat: config.json validation with clear error messages (#1444)

P1: Invalid config.json silently fell back to mock provider with only a
WARNING to stderr. Now config-parse-error in settings.rkt detects broken
JSON and provider-factory.rkt prints a clear ERROR with file path and
details before falling back to mock. 5 new tests.

### DIFF
--- a/runtime/provider-factory.rkt
+++ b/runtime/provider-factory.rkt
@@ -74,6 +74,21 @@
 ;;   6. Create make-openai-compatible-provider with config hash
 (define (build-provider config settings)
   (define project-dir (or (hash-ref config 'project-dir #f) (current-directory)))
+  ;; v0.14.4 Wave 0: Check for config parse errors before falling back to mock
+  (define global-cfg-path (build-path (find-system-path 'home-dir) ".q" "config.json"))
+  (define project-cfg-path (build-path project-dir ".q" "config.json"))
+  (define global-parse-err (config-parse-error global-cfg-path))
+  (define project-parse-err (config-parse-error project-cfg-path))
+  (when global-parse-err
+    (fprintf (current-error-port)
+             "ERROR: Config file ~a has invalid JSON: ~a\nFix the syntax error and restart q.\n"
+             global-cfg-path
+             global-parse-err))
+  (when project-parse-err
+    (fprintf (current-error-port)
+             "ERROR: Config file ~a has invalid JSON: ~a\nFix the syntax error and restart q.\n"
+             project-cfg-path
+             project-parse-err))
   (define merged (q-settings-merged settings))
   (cond
     [(hash-empty? merged)

--- a/runtime/settings.rkt
+++ b/runtime/settings.rkt
@@ -40,6 +40,7 @@
          setting-ref*
          provider-config
          provider-names
+         config-parse-error
 
          ;; Parallel execution
          parallel-tools-enabled?
@@ -81,6 +82,17 @@
 ;; ============================================================
 ;; Internal helpers
 ;; ============================================================
+
+;; v0.14.4 Wave 0: Detect config file that exists but has invalid JSON.
+;; Returns #f if file is missing or valid, or an error message string if broken.
+(define (config-parse-error path)
+  (if (file-exists? path)
+      (with-handlers ([exn:fail? (λ (e) (exn-message e))])
+        (call-with-input-file path
+                              (λ (in)
+                                (define result (read-json in))
+                                (if (hash? result) #f "top-level value is not a JSON object"))))
+      #f))
 
 ;; Safely parse a JSON file, returning #f on any failure
 ;; or if the top-level value is not a JSON object (hash).

--- a/tests/test-settings-config-validation.rkt
+++ b/tests/test-settings-config-validation.rkt
@@ -1,0 +1,56 @@
+#lang racket
+
+;; tests/test-settings-config-validation.rkt — v0.14.4 Wave 0
+;;
+;; Verifies config-parse-error detects broken JSON in config files.
+
+(require rackunit
+         racket/port
+         "../runtime/settings.rkt")
+
+;; ============================================================
+;; config-parse-error tests
+;; ============================================================
+
+(test-case "config-parse-error returns #f for missing file"
+  (define nonexistent "/tmp/q-test-config-nonexistent-xyz.json")
+  (check-false (config-parse-error nonexistent)))
+
+(test-case "config-parse-error returns #f for valid JSON object"
+  (define tmp (make-temporary-file "q-test-config-~a.json"))
+  (with-output-to-file tmp (lambda () (display "{\"providers\":{}}")) #:exists 'replace)
+  (check-false (config-parse-error tmp))
+  (delete-file tmp))
+
+(test-case "config-parse-error returns message for invalid JSON"
+  (define tmp (make-temporary-file "q-test-config-~a.json"))
+  (with-output-to-file tmp (lambda () (display "{\"bad json")) #:exists 'replace)
+  (define err (config-parse-error tmp))
+  (check-not-false err)
+  (check-true (string? err))
+  (check-true (or (string-contains? err "expected")
+                  (string-contains? err "Unexpected")
+                  (string-contains? err "end of file")
+                  (string-contains? err "unterminated")
+                  (string-contains? err "read-json"))
+              (format "Error message should mention JSON parse issue: ~a" err))
+  (delete-file tmp))
+
+(test-case "config-parse-error returns message for non-object top level"
+  (define tmp (make-temporary-file "q-test-config-~a.json"))
+  (with-output-to-file tmp (lambda () (display "[1,2,3]")) #:exists 'replace)
+  (define err (config-parse-error tmp))
+  (check-not-false err)
+  (check-true (string-contains? err "not a JSON object") (format "Should mention non-object: ~a" err))
+  (delete-file tmp))
+
+(test-case "config-parse-error returns #f for valid nested config"
+  (define tmp (make-temporary-file "q-test-config-~a.json"))
+  (with-output-to-file
+   tmp
+   (lambda ()
+     (display
+      "{\"timeouts\":{\"models\":{\"glm-5.1\":{\"request\":900}}},\"providers\":{\"openai-compatible\":{\"max-tokens\":16384}}}"))
+   #:exists 'replace)
+  (check-false (config-parse-error tmp))
+  (delete-file tmp))


### PR DESCRIPTION
Addresses #1444.

feat: config.json validation with clear error messages (#1444)

P1: Invalid config.json silently fell back to mock provider with only a
WARNING to stderr. Now config-parse-error in settings.rkt detects broken
JSON and provider-factory.rkt prints a clear ERROR with file path and
details before falling back to mock. 5 new tests.