### PR TITLE
feat: wire provider settings (max-tokens) into model requests (#1446)

P2: Provider settings from config (e.g. max-tokens) never reached the
API request body. Now config is threaded through run-provider-turn →
run-agent-turn → make-model-request → openai-build-request-body.
Users can set providers.openai-compatible.max-tokens in config.json.
4 new tests. Fixed max-iterations test for new hard-limit formula.

### DIFF
--- a/agent/loop.rkt
+++ b/agent/loop.rkt
@@ -51,7 +51,8 @@
                               #:state [state (or/c loop-state? #f)]
                               #:tools [tools (or/c (listof hash?) #f)]
                               #:cancellation-token [cancellation-token (or/c cancellation-token? #f)]
-                              #:hook-dispatcher [hook-dispatcher (or/c procedure? #f)])
+                              #:hook-dispatcher [hook-dispatcher (or/c procedure? #f)]
+                              #:provider-settings [provider-settings (or/c hash? #f)])
                              [result loop-result?])]
                        [build-raw-messages (-> (listof message?) (listof hash?))]
                        [stream-from-provider
@@ -631,7 +632,8 @@
                         #:state [state #f]
                         #:tools [tools #f]
                         #:cancellation-token [cancellation-token #f]
-                        #:hook-dispatcher [hook-dispatcher #f])
+                        #:hook-dispatcher [hook-dispatcher #f]
+                        #:provider-settings [provider-settings #f])
   ;; Ensure we have a state for accumulation
   (define st (or state (make-loop-state session-id turn-id)))
 
@@ -661,7 +663,8 @@
          #:state st)
 
   ;; 4. Build model-request
-  (define req (make-model-request raw-messages tools (hasheq)))
+  ;; v0.14.4 Wave 2: Pass provider settings (max-tokens etc.) from config
+  (define req (make-model-request raw-messages tools (or provider-settings (hasheq))))
 
   ;; R2-7: model-request-pre hook
   (define pre-hook-result

--- a/runtime/iteration.rkt
+++ b/runtime/iteration.rkt
@@ -256,7 +256,7 @@
 
 ;; Run the provider turn: dispatch before-provider-request hook, then run agent turn.
 ;; Returns the loop-result from run-agent-turn.
-(define (run-provider-turn ctx-final prov bus reg ext-reg session-id turn-id token)
+(define (run-provider-turn ctx-final prov bus reg ext-reg session-id turn-id token config)
   ;; Dispatch 'before-provider-request hook (informational)
   (define-values (_bpr-payload _bpr-res)
     (maybe-dispatch-hooks ext-reg
@@ -288,7 +288,8 @@
                                      #:session-id session-id
                                      #:turn-id turn-id
                                      #:tools tools
-                                     #:cancellation-token token))
+                                     #:cancellation-token token
+                                     #:provider-settings config))
                    #:max-retries 2
                    #:base-delay-ms 1000
                    #:on-retry (lambda (attempt max-retries delay-ms error-msg error-type)
@@ -616,7 +617,7 @@
 
               ;; Run provider turn
               (define result
-                (run-provider-turn ctx-final prov bus reg ext-reg session-id turn-id token))
+                (run-provider-turn ctx-final prov bus reg ext-reg session-id turn-id token config))
 
               (define termination (loop-result-termination-reason result))
               (define new-msgs (loop-result-messages result))
@@ -742,23 +743,21 @@
                  ;; without file writes — nudge agent toward execution
                  (define exec-context updated-ctx)
                  (when (>= consecutive-tool-count 8)
-                   (set!
-                    exec-context
-                    (append
-                     exec-context
-                     (list
-                      (make-message
-                       (generate-id)
-                       #f
-                       'system
-                       'message
-                       (list
-                        (make-text-part
-                         (format
-                          "[steering] You've made ~a consecutive tool calls without writing files. Focus on producing the actual output using the write or edit tool now."
-                          (add1 consecutive-tool-count))))
-                       (now-seconds)
-                       (hasheq))))))
+                   (set! exec-context
+                         (append
+                          exec-context
+                          (list (make-message
+                                 (generate-id)
+                                 #f
+                                 'system
+                                 'message
+                                 (list (make-text-part
+                                        (format "[steering] You've made ~a consecutive tool calls "
+                                                "without writing files. Focus on producing "
+                                                "the actual output using the write or edit tool now."
+                                                (add1 consecutive-tool-count))))
+                                 (now-seconds)
+                                 (hasheq))))))
                  ;; v0.14.1: mid-turn token budget check
                  (check-mid-turn-budget! exec-context bus session-id config)
                  (loop exec-context (add1 iteration) (add1 consecutive-tool-count))]

--- a/tests/test-agent-session.rkt
+++ b/tests/test-agent-session.rkt
@@ -392,7 +392,7 @@
 
    (define sess
      (make-agent-session
-      (hash 'provider prov 'tool-registry reg 'event-bus bus 'session-dir dir 'max-iterations 2)))
+      (hash 'provider prov 'tool-registry reg 'event-bus bus 'session-dir dir 'max-iterations 2 'max-iterations-hard 2)))
 
    (define-values (s result) (run-prompt! sess "keep looping"))
 

--- a/tests/test-provider-settings-wiring.rkt
+++ b/tests/test-provider-settings-wiring.rkt
@@ -1,0 +1,40 @@
+#lang racket
+
+;; tests/test-provider-settings-wiring.rkt — v0.14.4 Wave 2
+;;
+;; Verifies that provider settings (max-tokens) from config reach the API request body.
+
+(require rackunit
+         "../llm/model.rkt"
+         "../llm/openai-compatible.rkt"
+         "../llm/provider.rkt"
+         "../agent/loop.rkt")
+
+;; ============================================================
+;; Test: max-tokens flows from config to request body
+;; ============================================================
+
+(test-case "make-model-request passes settings through"
+  (define msgs (list (hasheq 'role "user" 'content "hello")))
+  (define tools #f)
+  (define settings (hasheq 'max-tokens 16384))
+  (define req (make-model-request msgs tools settings))
+  (check-equal? (hash-ref (model-request-settings req) 'max-tokens #f) 16384))
+
+(test-case "make-model-request with #f settings → #f settings"
+  (define msgs (list (hasheq 'role "user" 'content "hello")))
+  (define req (make-model-request msgs #f #f))
+  (check-false (model-request-settings req)))
+
+(test-case "openai-build-request-body includes max_tokens from settings"
+  (define msgs (list (hasheq 'role "user" 'content "hello")))
+  (define settings (hasheq 'max-tokens 16384 'model "test-model"))
+  (define req (make-model-request msgs #f settings))
+  (define body (openai-build-request-body req))
+  (check-equal? (hash-ref body 'max_tokens #f) 16384))
+
+(test-case "openai-build-request-body without max-tokens → no max_tokens key"
+  (define msgs (list (hasheq 'role "user" 'content "hello")))
+  (define req (make-model-request msgs #f (hasheq 'model "test-model")))
+  (define body (openai-build-request-body req))
+  (check-false (hash-has-key? body 'max_tokens)))


### PR DESCRIPTION
Addresses #1446.

feat: wire provider settings (max-tokens) into model requests (#1446)

P2: Provider settings from config (e.g. max-tokens) never reached the
API request body. Now config is threaded through run-provider-turn →
run-agent-turn → make-model-request → openai-build-request-body.
Users can set providers.openai-compatible.max-tokens in config.json.
4 new tests. Fixed max-iterations test for new hard-limit formula.