### PR TITLE
fix: wire max-tokens from provider config to API request body

### DIFF
--- a/llm/openai-compatible.rkt
+++ b/llm/openai-compatible.rkt
@@ -227,14 +227,20 @@
   (define api-key (hash-ref config 'api-key ""))
   (define default-model (hash-ref config 'model "gpt-4"))
 
+  (define default-max-tokens (hash-ref config 'max-tokens #f))
+
   (define (ensure-model-settings req)
-    ;; Merge default-model into request settings if not already set
+    ;; Merge default-model and default-max-tokens into request settings if not set
     (define settings (model-request-settings req))
-    (if (hash-has-key? settings 'model)
-        req
-        (make-model-request (model-request-messages req)
-                            (model-request-tools req)
-                            (hash-set settings 'model default-model))))
+    (define with-model
+      (if (hash-has-key? settings 'model)
+          settings
+          (hash-set settings 'model default-model)))
+    (define with-max-tokens
+      (if (and default-max-tokens (not (hash-has-key? with-model 'max-tokens)))
+          (hash-set with-model 'max-tokens default-max-tokens)
+          with-model))
+    (make-model-request (model-request-messages req) (model-request-tools req) with-max-tokens))
 
   (define (send req)
     (define req-with-model (ensure-model-settings req))

--- a/runtime/provider-factory.rkt
+++ b/runtime/provider-factory.rkt
@@ -23,7 +23,7 @@
          provider-is-mock?) ;; v0.14.1: for tui-init without importing llm/
 
 ;; Build the appropriate provider based on provider name.
-(define (create-provider-for-name prov-name base-url api-key model-name)
+(define (create-provider-for-name prov-name base-url api-key model-name [max-tokens #f])
   ;; Local providers don't need real API keys — use a sentinel to
   ;; pass validation when no credential is available.
   (define effective-key
@@ -31,10 +31,15 @@
         "local-no-auth"
         api-key))
   (define config-base (hasheq 'api-key effective-key 'model model-name))
-  (define config
+  (define config-with-url
     (if (and base-url (not (string=? (string-trim base-url) "")))
         (hash-set config-base 'base-url base-url)
         config-base))
+  ;; v0.14.5: Pass max-tokens from provider config so it reaches the API
+  (define config
+    (if max-tokens
+        (hash-set config-with-url 'max-tokens max-tokens)
+        config-with-url))
   (cond
     [(equal? prov-name "gemini") (make-gemini-provider config)]
     [(equal? prov-name "anthropic") (make-anthropic-provider config)]
@@ -124,7 +129,8 @@
                  (create-provider-for-name prov-name
                                            base-url
                                            ""
-                                           (model-resolution-model-name resolution)))
+                                           (model-resolution-model-name resolution)
+                                           (hash-ref prov-cfg 'max-tokens #f)))
                (begin
                  ;; No credentials and not local -> mock
                  (fprintf (current-error-port)
@@ -135,7 +141,8 @@
            (create-provider-for-name prov-name
                                      base-url
                                      (credential-api-key cred)
-                                     (model-resolution-model-name resolution))])])]))
+                                     (model-resolution-model-name resolution)
+                                     (hash-ref prov-cfg 'max-tokens #f))])])]))
 
 ;; Helper: create a mock provider
 (define (build-mock-provider)

--- a/tests/test-provider-settings-wiring.rkt
+++ b/tests/test-provider-settings-wiring.rkt
@@ -8,7 +8,8 @@
          "../llm/model.rkt"
          "../llm/openai-compatible.rkt"
          "../llm/provider.rkt"
-         "../agent/loop.rkt")
+         "../agent/loop.rkt"
+         "../runtime/provider-factory.rkt")
 
 ;; ============================================================
 ;; Test: max-tokens flows from config to request body
@@ -58,3 +59,39 @@
   (define req (make-model-request msgs #f mutable-cfg))
   ;; This should raise a contract violation
   (check-exn exn:fail:contract? (lambda () (ensure-model-setting req "glm-5.1"))))
+
+;; v0.14.5: Verify max-tokens flows through the full chain:
+;; config → provider-factory → make-openai-compatible-provider → ensure-model-settings → body
+;; Since ensure-model-settings is internal to the provider closure, we test the
+;; provider-factory wiring and the body construction separately.
+(test-case "provider-factory passes max-tokens to create-provider-for-name"
+  ;; Verify that create-provider-for-name with max-tokens creates a working provider
+  (define prov
+    (create-provider-for-name "openai-compatible"
+                              "https://api.example.com/v1"
+                              "test-key"
+                              "glm-5.1"
+                              32768))
+  ;; Provider should not be mock
+  (check-not-equal? (provider-name prov) "mock"))
+
+(test-case "max-tokens in model-request settings → max_tokens in body"
+  ;; This tests what ensure-model-settings produces: request with max-tokens in settings
+  (define req
+    (make-model-request (list (hasheq 'role "user" 'content "hello"))
+                        #f
+                        (hasheq 'model "glm-5.1" 'max-tokens 32768)))
+  (define body (openai-build-request-body req))
+  (check-equal? (hash-ref body 'max_tokens #f) 32768))
+
+(test-case "request-level max-tokens reaches body"
+  (define req
+    (make-model-request (list (hasheq 'role "user" 'content "hello")) #f (hasheq 'max-tokens 8192)))
+  (define body (openai-build-request-body req))
+  (check-equal? (hash-ref body 'max_tokens #f) 8192))
+
+(test-case "no max-tokens in settings → no max_tokens in body"
+  (define req
+    (make-model-request (list (hasheq 'role "user" 'content "hello")) #f (hasheq 'model "glm-5.1")))
+  (define body (openai-build-request-body req))
+  (check-false (hash-has-key? body 'max_tokens)))


### PR DESCRIPTION
## P1 Bugfix: max-tokens never reaches API

User configures `providers.openai-compatible.max-tokens: 32768` in config.json, but glm-5.1 still generates truncated output (~4096 tokens default), causing file rewrites to fail silently — model generates plan text, runs out of tokens, stops without a tool call.

### Root Cause

The `max-tokens` value was correctly loaded into `q-settings-merged` by settings.rkt, but:
1. `create-provider-for-name` only built config with `api-key`/`model`/`base-url` — ignored `max-tokens`
2. `make-openai-compatible-provider` only read those 3 keys from config
3. `ensure-model-settings` only injected `model` — not `max-tokens`
4. Nobody ever put `max-tokens` into `model-request-settings`
5. `openai-build-request-body` reads from request settings — always empty for `max-tokens`

### Fix

Three-part wiring:
- **provider-factory.rkt**: Extract `max-tokens` from `prov-cfg` (model resolution) and pass to `create-provider-for-name` (new optional parameter)
- **openai-compatible.rkt**: `ensure-model-settings` now also injects `default-max-tokens` from provider config into request settings
- Request-level `max-tokens` takes precedence over provider default

### Tests
- `provider-factory passes max-tokens to create-provider-for-name`
- `max-tokens in model-request settings → max_tokens in body`
- `request-level max-tokens reaches body`
- `no max-tokens in settings → no max_tokens in body`

### Verification
- 322 files, 5385 tests, 0 failures