### PR TITLE
feat: trace logger core — subscribe to event bus, write trace.jsonl (#1452)

New runtime/trace-logger.rkt module that subscribes to the event bus
and writes structured JSONL entries with sequence numbers and ISO 8601
timestamps to <session-dir>/trace.jsonl. Config-gated via #:enabled?.
Flush-on-write for crash safety. 5 tests.

### DIFF
--- a/runtime/trace-logger.rkt
+++ b/runtime/trace-logger.rkt
@@ -1,0 +1,107 @@
+#lang racket/base
+
+;; runtime/trace-logger.rkt — v0.15.0
+;;
+;; Structured trace logger for request-cycle diagnostics.
+;; Subscribes to the event bus and writes trace.jsonl entries
+;; with sequence numbers, ISO timestamps, and event data.
+
+(require racket/date
+         json
+         racket/file
+         "../agent/event-bus.rkt"
+         "../util/protocol-types.rkt")
+
+(provide make-trace-logger
+         trace-logger?
+         start-trace-logger!
+         stop-trace-logger!)
+
+;; ============================================================
+;; Trace logger struct
+;; ============================================================
+
+(struct trace-logger
+        (bus session-dir enabled? [seq #:mutable] [sub-id #:mutable] [out-port #:mutable])
+  #:transparent)
+
+;; ============================================================
+;; Constructor
+;; ============================================================
+
+(define (make-trace-logger bus session-dir #:enabled? [enabled? #t])
+  (trace-logger bus session-dir enabled? 0 #f #f))
+
+;; ============================================================
+;; Start / Stop
+;; ============================================================
+
+(define (start-trace-logger! logger)
+  (when (trace-logger-enabled? logger)
+    (define bus (trace-logger-bus logger))
+    (define session-dir (trace-logger-session-dir logger))
+    (define trace-path (build-path session-dir "trace.jsonl"))
+    ;; Ensure parent dir exists
+    (make-directory* session-dir)
+    ;; Open output port in append mode
+    (define out (open-output-file trace-path #:exists 'append))
+    (set-trace-logger-out-port! logger out)
+    ;; Subscribe to all events
+    (define sub-id (subscribe! bus (lambda (evt) (handle-event! logger evt))))
+    (set-trace-logger-sub-id! logger sub-id)))
+
+(define (stop-trace-logger! logger)
+  (when (trace-logger-enabled? logger)
+    (define sub-id (trace-logger-sub-id logger))
+    (when sub-id
+      (unsubscribe! (trace-logger-bus logger) sub-id)
+      (set-trace-logger-sub-id! logger #f))
+    (define out (trace-logger-out-port logger))
+    (when out
+      (close-output-port out)
+      (set-trace-logger-out-port! logger #f))))
+
+;; ============================================================
+;; Event handler
+;; ============================================================
+
+(define (handle-event! logger evt)
+  (define out (trace-logger-out-port logger))
+  (when out
+    (define seq (add1 (trace-logger-seq logger)))
+    (set-trace-logger-seq! logger seq)
+    (define entry
+      (hasheq 'ts
+              (seconds->iso8601 (event-time evt))
+              'seq
+              seq
+              'phase
+              (event-ev evt)
+              'sessionId
+              (event-session-id evt)
+              'turnId
+              (or (event-turn-id evt) 'null)
+              'data
+              (event-payload evt)))
+    (write-json entry out)
+    (newline out)
+    (flush-output out)))
+
+;; ============================================================
+;; Helpers
+;; ============================================================
+
+(define (seconds->iso8601 secs)
+  (define d (seconds->date secs #f))
+  (format "~a-~a-~aT~a:~a:~aZ"
+          (date-year d)
+          (~pad2 (date-month d))
+          (~pad2 (date-day d))
+          (~pad2 (date-hour d))
+          (~pad2 (date-minute d))
+          (~pad2 (date-second d))))
+
+(define (~pad2 n)
+  (if (< n 10)
+      (format "0~a" n)
+      (number->string n)))

--- a/tests/test-trace-logger.rkt
+++ b/tests/test-trace-logger.rkt
@@ -1,0 +1,112 @@
+#lang racket
+
+;; tests/test-trace-logger.rkt — v0.15.0 Wave 0
+;;
+;; TDD tests for the trace logger core module.
+
+(require rackunit
+         racket/file
+         racket/port
+         racket/string
+         json
+         "../agent/event-bus.rkt"
+         "../runtime/trace-logger.rkt"
+         "../util/protocol-types.rkt")
+
+(define (make-temp-dir)
+  (define tmp (find-system-path 'temp-dir))
+  (define dir (make-temporary-file "trace-test-~a" 'directory tmp))
+  dir)
+
+(define (read-trace-jsonl dir)
+  (define path (build-path dir "trace.jsonl"))
+  (if (file-exists? path)
+      (filter-map (lambda (line)
+                    (if (and (string? line) (> (string-length line) 0))
+                        (string->jsexpr line)
+                        #f))
+                  (file->lines path))
+      '()))
+
+;; ============================================================
+;; Core: make-trace-logger subscribes to bus and writes JSONL
+;; ============================================================
+
+(test-case "trace-logger writes events to trace.jsonl"
+  (define dir (make-temp-dir))
+  (define bus (make-event-bus))
+  (define logger (make-trace-logger bus dir #:enabled? #t))
+  (start-trace-logger! logger)
+  ;; Publish a test event
+  (publish! bus (make-event "test.event" (current-seconds) "sess-1" #f (hasheq 'key "value")))
+  (sleep 0.1) ; allow async write
+  (stop-trace-logger! logger)
+  (define entries (read-trace-jsonl dir))
+  (check >= (length entries) 1 "should have at least one trace entry")
+  (define entry (car entries))
+  (check-equal? (hash-ref entry 'phase "test.event") "test.event")
+  (check-equal? (hash-ref entry 'sessionId #f) "sess-1")
+  (delete-directory/files dir))
+
+(test-case "trace entries have sequence numbers"
+  (define dir (make-temp-dir))
+  (define bus (make-event-bus))
+  (define logger (make-trace-logger bus dir #:enabled? #t))
+  (start-trace-logger! logger)
+  (publish! bus (make-event "evt.1" (current-seconds) "s1" #f (hasheq)))
+  (publish! bus (make-event "evt.2" (current-seconds) "s1" #f (hasheq)))
+  (publish! bus (make-event "evt.3" (current-seconds) "s1" #f (hasheq)))
+  (sleep 0.1)
+  (stop-trace-logger! logger)
+  (define entries (read-trace-jsonl dir))
+  (check >= (length entries) 3)
+  ;; Sequence numbers should be 1, 2, 3
+  (check-equal? (hash-ref (first entries) 'seq #f) 1)
+  (check-equal? (hash-ref (second entries) 'seq #f) 2)
+  (check-equal? (hash-ref (third entries) 'seq #f) 3)
+  (delete-directory/files dir))
+
+(test-case "trace entries have ISO timestamps"
+  (define dir (make-temp-dir))
+  (define bus (make-event-bus))
+  (define logger (make-trace-logger bus dir #:enabled? #t))
+  (start-trace-logger! logger)
+  (publish! bus (make-event "test.ts" (current-seconds) "s1" #f (hasheq)))
+  (sleep 0.1)
+  (stop-trace-logger! logger)
+  (define entries (read-trace-jsonl dir))
+  (check >= (length entries) 1)
+  (define ts (hash-ref (car entries) 'ts #f))
+  (check-not-false ts "should have ts field")
+  ;; ISO format check: starts with year
+  (check-not-false (regexp-match #rx"^202[0-9]-" ts))
+  (delete-directory/files dir))
+
+(test-case "disabled logger does not write any file"
+  (define dir (make-temp-dir))
+  (define bus (make-event-bus))
+  (define logger (make-trace-logger bus dir #:enabled? #f))
+  (start-trace-logger! logger)
+  (publish! bus (make-event "test.disabled" (current-seconds) "s1" #f (hasheq)))
+  (sleep 0.1)
+  (stop-trace-logger! logger)
+  (define trace-path (build-path dir "trace.jsonl"))
+  (check-false (file-exists? trace-path) "disabled logger should not create file")
+  (delete-directory/files dir))
+
+(test-case "trace entry preserves payload data"
+  (define dir (make-temp-dir))
+  (define bus (make-event-bus))
+  (define logger (make-trace-logger bus dir #:enabled? #t))
+  (start-trace-logger! logger)
+  (publish!
+   bus
+   (make-event "tool.call.started" (current-seconds) "s1" #f (hasheq 'tool "write" 'arguments '())))
+  (sleep 0.1)
+  (stop-trace-logger! logger)
+  (define entries (read-trace-jsonl dir))
+  (check >= (length entries) 1)
+  (define data (hash-ref (car entries) 'data #f))
+  (check-not-false data)
+  (check-equal? (hash-ref data 'tool #f) "write")
+  (delete-directory/files dir))


### PR DESCRIPTION
Addresses #1452.

feat: trace logger core — subscribe to event bus, write trace.jsonl (#1452)

New runtime/trace-logger.rkt module that subscribes to the event bus
and writes structured JSONL entries with sequence numbers and ISO 8601
timestamps to <session-dir>/trace.jsonl. Config-gated via #:enabled?.
Flush-on-write for crash safety. 5 tests.