### PR TITLE
feat: enrich events for trace logging (#1453)

Wave 1: Add observability events for request-cycle diagnostics.

- stream-chunk: added finish-reason field (6th field, stores actual
  "stop"/"length"/"tool_calls" string from API)
- loop.rkt: model.request.started now includes model, max_tokens, settings
- loop.rkt: model.stream.completed now includes finish_reason
- iteration.rkt: new iteration.decision event at each loop iteration with
  termination, consecutive_tools, max_iterations
- make-stream-chunk: added #:finish-reason keyword
- 8 new tests in test-trace-events.rkt
- Fixed test-model-chunk.rkt for 6-field stream-chunk

### DIFF
--- a/agent/loop.rkt
+++ b/agent/loop.rkt
@@ -339,11 +339,15 @@
                 (streaming-message-set-blocked! sm))))
           (when (stream-chunk-done? chunk)
             ;; Stream completed
+            ;; v0.15.0 Wave 1: include finish_reason in event
             (emit! bus
                    session-id
                    turn-id
                    "model.stream.completed"
-                   (hasheq 'usage (or (stream-chunk-usage chunk) (hasheq)))
+                   (hasheq 'usage
+                           (or (stream-chunk-usage chunk) (hasheq))
+                           'finish_reason
+                           (or (stream-chunk-finish-reason chunk) "unknown"))
                    #:state state)
             ;; Emit message.end if we started a message
             (when (streaming-message-message-started? sm)
@@ -690,6 +694,7 @@
             (hasheq 'termination 'hook-blocked 'turnId turn-id 'reason "model-request-pre-blocked"))
      (loop-result raw-messages 'hook-blocked (hasheq 'hook 'model-request-pre))]
     [else
+     ;; v0.15.0 Wave 1: enriched llm.request event for trace logging
      (emit! bus
             session-id
             turn-id
@@ -699,7 +704,13 @@
                     'toolCount
                     (if tools
                         (length tools)
-                        0))
+                        0)
+                    'model
+                    (object-name provider)
+                    'max_tokens
+                    (hash-ref (model-request-settings req) 'max-tokens #f)
+                    'settings
+                    (model-request-settings req))
             #:state st)
 
      ;; Dispatch 'message-start hook

--- a/llm/model.rkt
+++ b/llm/model.rkt
@@ -79,14 +79,16 @@
 ;; stream-chunk
 ;; ============================================================
 
-(struct stream-chunk (delta-text delta-tool-call delta-thinking usage done?) #:transparent)
+(struct stream-chunk (delta-text delta-tool-call delta-thinking usage done? finish-reason)
+  #:transparent)
 
-;; Convenience constructor with optional #:delta-thinking keyword.
-;; v0.12.3 Wave 2.3: Added keyword arg so providers can pass thinking data
-;; without needing the raw 6-field stream-chunk constructor.
+;; Convenience constructor with optional keywords.
+;; v0.12.3 Wave 2.3: Added #:delta-thinking keyword.
+;; v0.15.0 Wave 1: Added #:finish-reason keyword.
 (define (make-stream-chunk delta-text
                            delta-tool-call
                            usage
                            done?
-                           #:delta-thinking [delta-thinking #f])
-  (stream-chunk delta-text delta-tool-call delta-thinking usage done?))
+                           #:delta-thinking [delta-thinking #f]
+                           #:finish-reason [finish-reason #f])
+  (stream-chunk delta-text delta-tool-call delta-thinking usage done? finish-reason))

--- a/llm/stream.rkt
+++ b/llm/stream.rkt
@@ -228,7 +228,11 @@
                 #f))
           #f))
 
-    (make-stream-chunk delta-text delta-tool-call usage (and (string? finish-reason) #t))))
+    (make-stream-chunk delta-text
+                       delta-tool-call
+                       usage
+                       (and (string? finish-reason) #t)
+                       #:finish-reason finish-reason)))
 
 ;; ============================================================
 ;; accumulate-tool-call-deltas
@@ -344,7 +348,11 @@
               (car tcs)
               #f))
         #f))
-  (make-stream-chunk delta-text delta-tool-call usage (and (string? finish-reason) #t)))
+  (make-stream-chunk delta-text
+                     delta-tool-call
+                     usage
+                     (and (string? finish-reason) #t)
+                     #:finish-reason finish-reason))
 
 ;; ============================================================
 ;; read-sse-chunks (incremental generator)

--- a/runtime/iteration.rkt
+++ b/runtime/iteration.rkt
@@ -631,6 +631,21 @@
               (define termination (loop-result-termination-reason result))
               (define new-msgs (loop-result-messages result))
 
+              ;; v0.15.0 Wave 1: emit iteration.decision for trace logging
+              (emit-session-event! bus
+                                   session-id
+                                   "iteration.decision"
+                                   (hasheq 'iteration
+                                           (add1 iteration)
+                                           'termination
+                                           termination
+                                           'consecutive_tools
+                                           consecutive-tool-count
+                                           'max_iterations
+                                           max-iterations
+                                           'max_iterations_hard
+                                           max-iterations-hard))
+
               (cond
                 ;; ── Completed: append and return ──
                 [(eq? termination 'completed)

--- a/tests/test-model-chunk.rkt
+++ b/tests/test-model-chunk.rkt
@@ -18,7 +18,7 @@
       (check-equal? (stream-chunk-delta-thinking c) "hmm"))
 
     (test-case "stream-chunk direct constructor works with 6 fields"
-      (define c (stream-chunk "hi" #f "thinking..." (hasheq 'total_tokens 10) #f))
+      (define c (stream-chunk "hi" #f "thinking..." (hasheq 'total_tokens 10) #f #f))
       (check-equal? (stream-chunk-delta-thinking c) "thinking..."))))
 
 (module+ main

--- a/tests/test-trace-events.rkt
+++ b/tests/test-trace-events.rkt
@@ -1,0 +1,160 @@
+#lang racket
+
+;; tests/test-trace-events.rkt — v0.15.0 Wave 1
+;;
+;; Tests that new/enriched events are emitted correctly.
+
+(require rackunit
+         racket/list
+         racket/generator
+         "../agent/event-bus.rkt"
+         "../agent/state.rkt"
+         "../agent/loop.rkt"
+         "../llm/model.rkt"
+         "../llm/stream.rkt"
+         "../llm/provider.rkt"
+         "../util/protocol-types.rkt"
+         "../util/ids.rkt")
+
+;; Helper: create event collector
+(define (make-event-collector bus [filter-name #f])
+  (define events '())
+  (subscribe! bus
+              (lambda (evt)
+                (set! events (append events (list evt)))
+                evt)
+              #:filter (if filter-name
+                           (lambda (evt) (equal? (event-ev evt) filter-name))
+                           #f))
+  (lambda () events))
+
+(define (make-user-message text)
+  (make-message (generate-id) #f 'user 'text (list (make-text-part text)) (now-seconds) (hasheq)))
+
+;; Helper: make mock provider with specific chunks (including finish-reason)
+(define (make-provider-with-chunks chunks name)
+  (make-provider (lambda () name)
+                 (lambda () (hasheq 'streaming #t))
+                 (lambda (req) (error "not implemented"))
+                 (lambda (req)
+                   ;; Return list of chunks
+                   chunks)))
+
+;; ============================================================
+;; stream-chunk finish-reason field
+;; ============================================================
+
+(test-case "stream-chunk stores finish-reason string"
+  (define chunk (stream-chunk "hello" #f #f (hasheq) #t "stop"))
+  (check-equal? (stream-chunk-finish-reason chunk) "stop"))
+
+(test-case "stream-chunk finish-reason can be #f"
+  (define chunk (stream-chunk "hi" #f #f (hasheq) #f #f))
+  (check-false (stream-chunk-finish-reason chunk)))
+
+(test-case "make-stream-chunk defaults finish-reason to #f"
+  (define chunk (make-stream-chunk "text" #f (hasheq) #t))
+  (check-false (stream-chunk-finish-reason chunk)))
+
+;; ============================================================
+;; model.stream.completed includes finish_reason
+;; ============================================================
+
+(test-case "model.stream.completed includes finish_reason from chunk"
+  (define bus (make-event-bus))
+  (define get-events (make-event-collector bus "model.stream.completed"))
+
+  (define chunks
+    (list (stream-chunk "hello" #f #f (hasheq) #f #f)
+          (stream-chunk ""
+                        #f
+                        #f
+                        (hasheq 'prompt_tokens 10 'completion_tokens 5 'total_tokens 15)
+                        #t
+                        "stop")))
+
+  (define prov (make-provider-with-chunks chunks "test-model"))
+  (define req (make-model-request (list (hasheq 'role "user" 'content "hi")) #f (hasheq)))
+  (define state (make-loop-state "s1" "t1"))
+
+  (define result (stream-from-provider prov req bus "s1" "t1" state #f #f))
+  (define evts (get-events))
+  (check >= (length evts) 1)
+  (define payload (event-payload (car evts)))
+  (check-equal? (hash-ref payload 'finish_reason #f) "stop"))
+
+(test-case "model.stream.completed with 'length finish_reason"
+  (define bus (make-event-bus))
+  (define get-events (make-event-collector bus "model.stream.completed"))
+
+  (define chunks
+    (list (stream-chunk "text" #f #f (hasheq) #f #f) (stream-chunk "" #f #f (hasheq) #t "length")))
+
+  (define prov (make-provider-with-chunks chunks "test-model"))
+  (define req (make-model-request (list (hasheq 'role "user" 'content "hi")) #f (hasheq)))
+  (define state (make-loop-state "s1" "t1"))
+
+  (stream-from-provider prov req bus "s1" "t1" state #f #f)
+  (define evts (get-events))
+  (check >= (length evts) 1)
+  (define payload (event-payload (car evts)))
+  (check-equal? (hash-ref payload 'finish_reason #f) "length"))
+
+(test-case "model.stream.completed with no finish_reason yields 'unknown'"
+  (define bus (make-event-bus))
+  (define get-events (make-event-collector bus "model.stream.completed"))
+
+  ;; Chunk with done?=#t but finish-reason=#f
+  (define chunks (list (stream-chunk "text" #f #f (hasheq) #t #f)))
+
+  (define prov (make-provider-with-chunks chunks "test-model"))
+  (define req (make-model-request (list (hasheq 'role "user" 'content "hi")) #f (hasheq)))
+  (define state (make-loop-state "s1" "t1"))
+
+  (stream-from-provider prov req bus "s1" "t1" state #f #f)
+  (define evts (get-events))
+  (check >= (length evts) 1)
+  (define payload (event-payload (car evts)))
+  (check-equal? (hash-ref payload 'finish_reason #f) "unknown"))
+
+;; ============================================================
+;; model.request.start includes model and max_tokens
+;; ============================================================
+
+(test-case "model.request.start enriched with model and settings"
+  (define bus (make-event-bus))
+  (define get-events (make-event-collector bus "model.request.started"))
+
+  (define chunks (list (stream-chunk "hi" #f #f (hasheq) #t "stop")))
+
+  (define prov (make-provider-with-chunks chunks "test-model"))
+  (define settings (hasheq 'max-tokens 16384))
+
+  (run-agent-turn (list (make-user-message "hello"))
+                  prov
+                  bus
+                  #:session-id "s1"
+                  #:turn-id "t1"
+                  #:provider-settings settings)
+
+  (define evts (get-events))
+  (check >= (length evts) 1)
+  (define payload (event-payload (car evts)))
+  (check-equal? (hash-ref payload 'max_tokens #f) 16384)
+  ;; object-name on provider struct returns 'provider
+  (check-equal? (hash-ref payload 'model #f) 'provider))
+
+(test-case "model.request.start without provider-settings has #f max_tokens"
+  (define bus (make-event-bus))
+  (define get-events (make-event-collector bus "model.request.started"))
+
+  (define chunks (list (stream-chunk "hi" #f #f (hasheq) #t "stop")))
+
+  (define prov (make-provider-with-chunks chunks "mock"))
+
+  (run-agent-turn (list (make-user-message "hello")) prov bus #:session-id "s1" #:turn-id "t1")
+
+  (define evts (get-events))
+  (check >= (length evts) 1)
+  (define payload (event-payload (car evts)))
+  (check-false (hash-ref payload 'max_tokens #f)))


### PR DESCRIPTION
Addresses #1453.

feat: enrich events for trace logging (#1453)

Wave 1: Add observability events for request-cycle diagnostics.

- stream-chunk: added finish-reason field (6th field, stores actual
  "stop"/"length"/"tool_calls" string from API)
- loop.rkt: model.request.started now includes model, max_tokens, settings
- loop.rkt: model.stream.completed now includes finish_reason
- iteration.rkt: new iteration.decision event at each loop iteration with
  termination, consecutive_tools, max_iterations
- make-stream-chunk: added #:finish-reason keyword
- 8 new tests in test-trace-events.rkt
- Fixed test-model-chunk.rkt for 6-field stream-chunk