### PR TITLE
feat: config integration for trace logger (#1454)

Wave 2: Wire trace logger into runtime startup.

- settings.rkt: Added trace-enabled? and trace-max-files config accessors
  that read from logging.trace.enabled and logging.trace.max-files
- run-modes.rkt: In build-runtime-from-cli, create and start trace logger
  when logging.trace.enabled is true in config.json. Stores logger in
  runtime config for lifecycle management.
- 7 new tests in test-trace-config.rkt

### DIFF
--- a/runtime/settings.rkt
+++ b/runtime/settings.rkt
@@ -66,7 +66,11 @@
          default-session-dir
          default-project-dir
          session-dir-from-settings
-         project-dir-from-settings)
+         project-dir-from-settings
+
+         ;; Trace logging config (v0.15.0)
+         trace-enabled?
+         trace-max-files)
 
 ;; ============================================================
 ;; Struct
@@ -327,3 +331,20 @@
 ;; Get effective request timeout: per-model override or global default.
 (define (effective-request-timeout settings model-name)
   (or (get-model-timeout settings model-name 'request) (http-request-timeout settings)))
+
+;; ============================================================
+;; Trace logging config (v0.15.0)
+;; ============================================================
+
+;; Is trace logging enabled? Reads logging.trace.enabled from config.
+;; Default: #f (disabled — zero overhead when off)
+(define (trace-enabled? settings)
+  (define trace-cfg (setting-ref* settings '(logging trace) #f))
+  (and (hash? trace-cfg) (hash-ref trace-cfg 'enabled #f)))
+
+;; Maximum trace files to keep (rotation). Default: 10.
+(define (trace-max-files settings)
+  (define trace-cfg (setting-ref* settings '(logging trace) #f))
+  (if (hash? trace-cfg)
+      (hash-ref trace-cfg 'max-files 10)
+      10))

--- a/tests/test-trace-config.rkt
+++ b/tests/test-trace-config.rkt
@@ -1,0 +1,48 @@
+#lang racket
+
+;; tests/test-trace-config.rkt — v0.15.0 Wave 2
+;;
+;; TDD tests for trace config parsing.
+
+(require rackunit
+         "../runtime/settings.rkt")
+
+;; Helper: build a q-settings with a specific merged hash
+(define (settings-with-merged merged-hash)
+  (q-settings (hash) (hash) merged-hash))
+
+;; ============================================================
+;; trace-enabled?
+;; ============================================================
+
+(test-case "trace-enabled? returns #f when logging section absent"
+  (define s (settings-with-merged (hash)))
+  (check-false (trace-enabled? s)))
+
+(test-case "trace-enabled? returns #f when logging.trace absent"
+  (define s (settings-with-merged (hash 'logging (hash 'level "info"))))
+  (check-false (trace-enabled? s)))
+
+(test-case "trace-enabled? returns #f when trace.enabled is false"
+  (define s (settings-with-merged (hash 'logging (hash 'trace (hash 'enabled #f)))))
+  (check-false (trace-enabled? s)))
+
+(test-case "trace-enabled? returns #t when logging.trace.enabled is true"
+  (define s (settings-with-merged (hash 'logging (hash 'trace (hash 'enabled #t)))))
+  (check-true (trace-enabled? s)))
+
+;; ============================================================
+;; trace-max-files
+;; ============================================================
+
+(test-case "trace-max-files defaults to 10"
+  (define s (settings-with-merged (hash)))
+  (check-equal? (trace-max-files s) 10))
+
+(test-case "trace-max-files reads from config"
+  (define s (settings-with-merged (hash 'logging (hash 'trace (hash 'enabled #t 'max-files 5)))))
+  (check-equal? (trace-max-files s) 5))
+
+(test-case "trace-max-files defaults to 10 when only enabled set"
+  (define s (settings-with-merged (hash 'logging (hash 'trace (hash 'enabled #t)))))
+  (check-equal? (trace-max-files s) 10))

--- a/wiring/run-modes.rkt
+++ b/wiring/run-modes.rkt
@@ -35,7 +35,8 @@
                   merge-extension-commands
                   make-command-registry)
          (only-in "../tui/keymap.rkt" shortcut-specs->keymap keymap-merge)
-         (only-in "../llm/stream.rkt" current-http-request-timeout current-model-timeouts))
+         (only-in "../llm/stream.rkt" current-http-request-timeout current-model-timeouts)
+         (only-in "../runtime/trace-logger.rkt" make-trace-logger start-trace-logger!))
 
 ;; Re-export mode runners from sub-modules
 (require "run-interactive.rkt"
@@ -161,6 +162,13 @@
           acc)))
   (current-model-timeouts model-timeouts)
   (current-http-request-timeout (http-request-timeout settings))
+
+  ;; v0.15.0 Wave 2: Wire trace logger if enabled in config
+  (when (trace-enabled? settings)
+    (define trace-log (make-trace-logger bus session-dir #:enabled? #t))
+    (hash-set! base-config 'trace-logger trace-log)
+    (start-trace-logger! trace-log))
+
   base-config)
 
 ;; ============================================================


### PR DESCRIPTION
Addresses #1454.

feat: config integration for trace logger (#1454)

Wave 2: Wire trace logger into runtime startup.

- settings.rkt: Added trace-enabled? and trace-max-files config accessors
  that read from logging.trace.enabled and logging.trace.max-files
- run-modes.rkt: In build-runtime-from-cli, create and start trace logger
  when logging.trace.enabled is true in config.json. Stores logger in
  runtime config for lifecycle management.
- 7 new tests in test-trace-config.rkt