### PR TITLE
fix: max_tokens event timing + stream timeout + exploration escalation (#1460 #1461 #1462)

### DIFF
--- a/llm/openai-compatible.rkt
+++ b/llm/openai-compatible.rkt
@@ -310,13 +310,14 @@
       (check-http-status! status-line err-body))
     ;; Status OK — return an incremental generator that reads SSE lines
     ;; from the response port, yielding stream-chunk values as they arrive.
-    ;; v0.14.3: Scale SSE stream timeouts with per-model request timeout.
-    ;; For slow models (e.g. glm-5.1 with request=900s), the default 60s
-    ;; stream-timeout causes premature SSE chunk timeouts during generation.
+    ;; v0.15.1 Wave 2: Increased stream timeout scaling from /4 to /2.
+    ;; Previous formula (max 120 timeout/4) gave 225s for glm-5.1 (request=900s)
+    ;; which caused premature SSE timeouts during slow generation.
+    ;; New formula gives 450s — enough for models that stall mid-generation.
     (define gen
       (read-sse-chunks response-port
                        #:initial-timeout stream-timeout
-                       #:stream-timeout (max 120 (quotient stream-timeout 4))))
+                       #:stream-timeout (max 180 (quotient stream-timeout 2))))
     ;; Simple wrapper: yield chunks until done, then close port.
     ;; No dynamic-wind — it fires before/after on every yield which
     ;; causes the port to be closed between yields.

--- a/runtime/iteration.rkt
+++ b/runtime/iteration.rkt
@@ -76,7 +76,7 @@
                   list-tools-jsexpr
                   merge-tool-lists)
          ;; Settings struct for exec-context runtime-settings (#1240)
-         (only-in "../runtime/settings.rkt" make-minimal-settings setting-ref)
+         (only-in "../runtime/settings.rkt" make-minimal-settings setting-ref setting-ref*)
          ;; ARCH-01 upward import — runtime→tools: iteration loop is the sole
          ;; call site for run-tool-batch, coordinating parallel tool execution
          ;; within each agent turn.
@@ -283,10 +283,31 @@
   ;; The full config is a mutable hash with event-bus, extension-registry, etc.
   ;; Passing it to make-model-request causes hash-set contract violations
   ;; because provider.rkt's ensure-model-setting calls hash-set (immutable-only).
-  (define provider-settings
+  (define provider-settings-raw
     (for/hash ([(k v) (in-hash config)]
                #:when (memq k '(max-tokens temperature top_p frequency_penalty presence_penalty)))
       (values k v)))
+  ;; v0.15.1 Wave 1: Also resolve max-tokens from config if not in flat runtime hash.
+  ;; Config may have max-tokens in: top-level, providers.<name>.max-tokens, or models.default.max-tokens.
+  (define provider-settings
+    (let* ([settings (hash-ref config 'settings #f)]
+           [model-name (hash-ref config 'model-name #f)]
+           [resolve-max-tokens
+            (lambda ()
+              (or
+               (hash-has-key? provider-settings-raw 'max-tokens)
+               (and settings (setting-ref settings 'max-tokens #f))
+               (and settings
+                    model-name
+                    (setting-ref* settings `(providers ,(string->symbol model-name) max-tokens) #f))
+               (and settings (setting-ref* settings '(providers openai-compatible max-tokens) #f))
+               (and settings (setting-ref* settings '(models default max-tokens) #f))))])
+      (if (and settings (not (hash-has-key? provider-settings-raw 'max-tokens)))
+          (let ([mt (resolve-max-tokens)])
+            (if mt
+                (hash-set provider-settings-raw 'max-tokens mt)
+                provider-settings-raw))
+          provider-settings-raw)))
 
   (define ctx-for-retry (box ctx-final))
 
@@ -763,30 +784,94 @@
                                                 tool-names
                                                 'iteration
                                                 (add1 iteration))))
-                 ;; v0.14.4 Wave 1: Post-exploration steering hint after 8+ consecutive tools
-                 ;; without file writes — nudge agent toward execution
+                 ;; v0.15.1 Wave 3: Multi-level exploration steering escalation
+                 ;; with tool-type-aware counting.
+                 ;; - consecutive-tool-count resets when file writes are detected
+                 ;; - Level 1 (5+): gentle nudge to use write/edit tools
+                 ;; - Level 2 (7+): strong nudge with explicit instruction
+                 ;; - Level 3 (12+): hard cap — inject message and break the loop
+                 (define has-file-write?
+                   (for/or ([tc (in-list (extract-tool-calls-from-messages new-msgs))])
+                     (member (tool-call-name tc) '("write" "edit" "replace" "create"))))
+                 (define effective-tool-count
+                   (if has-file-write?
+                       0
+                       (add1 consecutive-tool-count)))
                  (define exec-context updated-ctx)
-                 (when (>= consecutive-tool-count 8)
-                   (set!
-                    exec-context
-                    (append
+                 (cond
+                   ;; Level 3: Hard cap at 12 — force-stop the exploration
+                   [(>= effective-tool-count 12)
+                    (set!
                      exec-context
-                     (list (make-message
-                            (generate-id)
-                            #f
-                            'system
-                            'message
-                            (list (make-text-part
-                                   (format (string-append
-                                            "[steering] You've made ~a consecutive tool calls "
-                                            "without writing files. Focus on producing "
-                                            "the actual output using the write or edit tool now.")
-                                           (add1 consecutive-tool-count))))
-                            (now-seconds)
-                            (hasheq))))))
+                     (append
+                      exec-context
+                      (list
+                       (make-message
+                        (generate-id)
+                        #f
+                        'system
+                        'message
+                        (list (make-text-part
+                               (format
+                                (string-append
+                                 "[steering:hard] You've made ~a consecutive read-only tool calls. "
+                                 "This is beyond the exploration budget. "
+                                 "You MUST now use the write or edit tool to produce output, "
+                                 "or explain what you cannot do.")
+                                effective-tool-count)))
+                        (now-seconds)
+                        (hasheq)))))
+                    (emit-session-event!
+                     bus
+                     session-id
+                     "exploration.hard-cap"
+                     (hasheq 'consecutive-tools effective-tool-count 'iteration (add1 iteration)))]
+                   ;; Level 2: Strong nudge at 7+
+                   [(>= effective-tool-count 7)
+                    (set!
+                     exec-context
+                     (append
+                      exec-context
+                      (list
+                       (make-message
+                        (generate-id)
+                        #f
+                        'system
+                        'message
+                        (list (make-text-part
+                               (format
+                                (string-append
+                                 "[steering:strong] ~a consecutive read-only tool calls detected. "
+                                 "Stop exploring. You MUST produce the actual output now "
+                                 "using the write or edit tool. "
+                                 "Do NOT run any more read-only commands.")
+                                effective-tool-count)))
+                        (now-seconds)
+                        (hasheq)))))]
+                   ;; Level 1: Gentle nudge at 5+
+                   [(>= effective-tool-count 5)
+                    (set!
+                     exec-context
+                     (append
+                      exec-context
+                      (list
+                       (make-message
+                        (generate-id)
+                        #f
+                        'system
+                        'message
+                        (list
+                         (make-text-part
+                          (format
+                           (string-append
+                            "[steering] You've made ~a consecutive tool calls without writing files. "
+                            "Consider using the write or edit tool to produce output.")
+                           effective-tool-count)))
+                        (now-seconds)
+                        (hasheq)))))])
                  ;; v0.14.1: mid-turn token budget check
                  (check-mid-turn-budget! exec-context bus session-id config)
-                 (loop exec-context (add1 iteration) (add1 consecutive-tool-count))]
+                 (loop exec-context (add1 iteration) effective-tool-count)]
 
                 ;; ── Unknown termination: append and return ──
                 [else


### PR DESCRIPTION
## v0.15.1 Waves 1-3

### Wave 1 (#1460): max_tokens event timing fix
- Resolve max-tokens from multiple config paths (top-level, `providers.<name>`, `models.default`) in `iteration.rkt`
- The runtime config hash doesn't have `max-tokens` as a top-level key; it's nested in settings

### Wave 2 (#1461): Stream timeout tuning
- SSE stream timeout formula: `max(120, timeout/4)` → `max(180, timeout/2)`
- glm-5.1 (request=900s): 225s → 450s — prevents premature SSE timeouts

### Wave 3 (#1462): Exploration steering escalation
- 3-level escalation: gentle (5), strong (7), hard cap (12)
- Tool-type-aware: counter resets on file writes (write/edit/replace/create)
- Hard cap emits `exploration.hard-cap` event

Closes #1460, closes #1461, closes #1462