### PR TITLE
fix(security): Wave 3 — Safe-mode hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ q/
 |--------|-------|
 | Test files | 349 |
 | Source modules | 226 |
-| Source lines | 43393 |
+| Source lines | 43417 |
 | Test lines | 71557 |
 | Test assertions | 11059 |
 | `racket scripts/run-tests.rkt` results | 4,858+ tests passing |

--- a/runtime/safe-mode.rkt
+++ b/runtime/safe-mode.rkt
@@ -141,23 +141,29 @@
                               ap)))]
        [else
         ;; Default: check against project root
-        (let* ([resolved-root (with-handlers ([exn:fail? (λ (_) (simplify-path root-path))])
-                                (resolve-path root-path))]
-               [resolved-path (with-handlers ([exn:fail? (λ (_) (simplify-path path))])
-                                (resolve-path path))]
-               [root-str (path->string (if (complete-path? resolved-root)
-                                           resolved-root
-                                           (path->complete-path resolved-root)))]
-               [path-str (path->string (if (complete-path? resolved-path)
-                                           resolved-path
-                                           (path->complete-path resolved-path)))]
-               ;; Ensure root ends with separator for prefix matching
-               [root-prefix (if (string-suffix? root-str "/")
-                                root-str
-                                (string-append root-str "/"))])
-          (or (string=? path-str root-str) (string-prefix? path-str root-prefix)))])]))
+        ;; W3.1 (S4-11): resolve-path failure -> deny (#f), not fallback
+        (and (with-handlers ([exn:fail? (λ (_) #f)])
+               (resolve-path root-path))
+             (with-handlers ([exn:fail? (λ (_) #f)])
+               (resolve-path path))
+             (let* ([resolved-root (resolve-path root-path)]
+                    [resolved-path (resolve-path path)]
+                    [root-str (path->string (if (complete-path? resolved-root)
+                                                resolved-root
+                                                (path->complete-path resolved-root)))]
+                    [path-str (path->string (if (complete-path? resolved-path)
+                                                resolved-path
+                                                (path->complete-path resolved-path)))]
+                    [root-prefix (if (string-suffix? root-str "/")
+                                     root-str
+                                     (string-append root-str "/"))])
+               (or (string=? path-str root-str) (string-prefix? path-str root-prefix))))])]))
 
 ;; Whether safe-mode deactivation is locked (one-way switch)
+;; W3.2 (S4-16): One-shot parameter — once locked, cannot be unlocked.
+;; Kept as parameter for backward-compatible parameterize, but guarded.
+(define safe-mode-lock-one-shot (box #f))
+
 (define safe-mode-locked? (make-parameter #f))
 
 ;; Internal: check if locked via per-session config or parameter
@@ -165,7 +171,7 @@
   (define cfg (current-safe-mode-config))
   (cond
     [(safe-mode-config? cfg) (safe-mode-config-locked cfg)]
-    [else (safe-mode-locked?)]))
+    [else (or (unbox safe-mode-lock-one-shot) (safe-mode-locked?))]))
 
 ;; ============================================================
 ;; Actions
@@ -201,6 +207,7 @@
 ;; Lock safe-mode so it cannot be deactivated.
 ;; Once locked, only process restart can change the state.
 (define (lock-safe-mode!)
+  (set-box! safe-mode-lock-one-shot #t)
   (safe-mode-locked? #t))
 
 ;; ============================================================
@@ -243,20 +250,20 @@
          (safe-mode-config-project-root-path cfg)]
         [else (project-root)])))
   (hasheq 'active?
-        active
-        'trust-level
-        (trust-level)
-        'blocked-tools
-        (if active
-            blocked-tools
-            '())
-        'project-root
-        (path->string root)
-        'source
-        source
-        'reason
-        (if active
-            (format "Safe mode active (enabled by: ~a). File access restricted to: ~a"
-                    source
-                    (path->string root))
-            #f)))
+          active
+          'trust-level
+          (trust-level)
+          'blocked-tools
+          (if active
+              blocked-tools
+              '())
+          'project-root
+          (path->string root)
+          'source
+          source
+          'reason
+          (if active
+              (format "Safe mode active (enabled by: ~a). File access restricted to: ~a"
+                      source
+                      (path->string root))
+              #f)))

--- a/tools/tool.rkt
+++ b/tools/tool.rkt
@@ -54,6 +54,7 @@
          tool-execute
          tool-prompt-snippet
          tool-prompt-guidelines
+         tool-dangerous?
          tool->jsexpr
          merge-tool-lists
          validate-tool-schema
@@ -123,7 +124,14 @@
 ;; ============================================================
 
 (struct tool
-        (name description schema execute prompt-snippet prompt-guidelines render-call render-result)
+        (name description
+              schema
+              execute
+              prompt-snippet
+              prompt-guidelines
+              render-call
+              render-result
+              dangerous?)
   #:transparent)
 
 (define (make-tool name
@@ -133,7 +141,8 @@
                    #:prompt-snippet [prompt-snippet #f]
                    #:render-call [render-call #f]
                    #:render-result [render-result #f]
-                   #:prompt-guidelines [prompt-guidelines #f])
+                   #:prompt-guidelines [prompt-guidelines #f]
+                   #:dangerous? [dangerous? #f])
   (unless (string? name)
     (raise-argument-error 'make-tool "string?" name))
   (unless (string? description)
@@ -142,7 +151,15 @@
     (raise-argument-error 'make-tool "hash?" schema))
   (unless (procedure? execute)
     (raise-argument-error 'make-tool "procedure?" execute))
-  (tool name description schema execute prompt-snippet prompt-guidelines render-call render-result))
+  (tool name
+        description
+        schema
+        execute
+        prompt-snippet
+        prompt-guidelines
+        render-call
+        render-result
+        dangerous?))
 
 ;; ============================================================
 ;; Tool schema validation (#672)


### PR DESCRIPTION
Addresses #1482.

fix(security): harden safe-mode — deny on resolve-path failure, one-shot lock, dangerous? flag (#1482)

- W3.1 (S4-11): allowed-path? now returns #f (deny) when resolve-path fails instead of falling back to simplify-path
- W3.2 (S4-16): safe-mode lock uses one-shot box guard — once locked via lock-safe-mode!, the parameter cannot be reset to #f even with parameterize
- W3.3 (S4-12): Add #:dangerous? field to tool struct for future tool self-declaration of danger level