### PR TITLE
docs: Wave 7 — documentation refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -225,6 +225,23 @@ Replaces mechanical context truncation with a strategy-driven context assembly e
 
 ---
 
+## v0.13.0 — 2026-04-20
+
+### Features
+- **Session tree navigation**: Navigate between parent/child sessions
+- **Context reducer**: Progressive context trimming for long conversations
+- **Extension power-user API**: Advanced extension hooks for tool/loop interception
+- **Provider improvements**: Better error handling, retry logic, timeout tuning
+
+### Bug Fixes
+- Settings contract fixes for `make-settings` field validation
+- Context reducer pair-awareness for tool-start/tool-end entries
+- `/retry` + iteration limit interaction
+- Newline bleed in assistant message rendering
+- First user message prompt pinning
+
+---
+
 ## v0.13.1 — 2026-04-20
 
 ### Performance
@@ -243,6 +260,22 @@ Replaces mechanical context truncation with a strategy-driven context assembly e
 - 325 test files, 68,903 test lines, 10,786 assertions
 - 224 source modules, 41,753 source lines
 - 5,330+ tests passing (full suite)
+
+---
+
+## v0.11.x — 2026-04-19
+
+### Features
+- **Tool scheduler**: Priority-based tool execution with concurrency limits
+- **Extension hooks v2**: Lifecycle hooks for tool dispatch, loop iteration, and session events
+- **Credential store**: Centralized API key management with environment variable support
+- **OAuth framework**: OAuth 2.0 authorization flow (stubs for token exchange/refresh)
+- **Safe-mode guard**: One-shot safe-mode lock for restricting dangerous operations
+
+### Infrastructure
+- CI local lint suite (8 checks)
+- Security lint for hardcoded secrets
+- Compatibility matrix documentation
 
 ---
 

--- a/docs/adr/0008-safe-mode-enforcement.md
+++ b/docs/adr/0008-safe-mode-enforcement.md
@@ -1,0 +1,38 @@
+# ADR-0008: Safe-Mode Enforcement
+
+## Status
+Accepted
+
+## Context
+q tools can execute arbitrary shell commands and modify files. In production
+use, operators need a way to lock the agent into a read-only or restricted mode
+that cannot be reversed during a session — for example, during code review,
+CI runs, or when auditing a third-party extension.
+
+The tool struct already has a `dangerous?` flag, but there was no mechanism to
+prevent dangerous tools from executing at runtime once safe mode is activated.
+
+## Decision
+Add a one-shot safe-mode lock backed by a guarded parameter:
+
+1. **`safe-mode-locked?`** — A parameter wrapping a one-shot box. Once
+   `lock-safe-mode!` is called, no further changes to safe-mode state are
+   possible for the remainder of the Racket process.
+2. **`dangerous?` field** — The `tool` struct carries a `dangerous?` boolean.
+   When safe mode is active, the tool scheduler refuses to dispatch tools
+   marked as dangerous.
+3. **Irreversible** — Safe-mode lock is one-shot: `lock-safe-mode!` can be
+   called exactly once. Attempts to re-lock or unlock raise an error.
+
+This is enforced at the tool scheduler level, before tool dispatch.
+
+## Consequences
+**Easier:** Operators can confidently restrict agent behavior. Extensions cannot
+bypass the lock. The scheduler check is a single boolean test.
+
+**Harder:** Extensions that need to perform dangerous operations (e.g., file
+writes) must either run before safe-mode is locked or use the extension hook
+system to negotiate elevated access.
+
+**Risks:** If safe mode is locked too early (e.g., during initialization),
+legitimate setup tools may fail. The lock should be applied after bootstrap.

--- a/docs/adr/0009-credential-redaction.md
+++ b/docs/adr/0009-credential-redaction.md
@@ -1,0 +1,34 @@
+# ADR-0009: Credential Redaction
+
+## Status
+Accepted
+
+## Context
+q stores API keys and OAuth tokens for LLM providers. These credentials appear
+in several places: environment variables, config files, session logs, and
+in-memory structs. If credential structs use `#:transparent`, Racket's default
+printer will display the full API key in error messages, REPL output, and debug
+logs — a security risk.
+
+## Decision
+Credential structs use opaque printing with redaction:
+
+1. **`credential` struct** — No `#:transparent`. Custom `gen:custom-write`
+   masks the API key to `****`. Implements `gen:equal+hash` for test comparison
+   without exposing the key in printed output.
+2. **`redacted-credential` struct** — Opaque. Stores only the last-4 chars of
+   the key for display purposes.
+3. **No raw key logging** — The auth store never writes raw keys to session
+   logs or trace files. Only `redacted-credential` values appear in events.
+
+## Consequences
+**Easier:** API keys are never accidentally exposed in logs, error reports, or
+debug output. Tests can still compare credentials via `equal?`.
+
+**Harder:** Debugging credential issues requires explicit accessor calls rather
+than printing the struct. The `gen:equal+hash` implementation must stay in sync
+with the struct fields.
+
+**Risks:** If a future developer adds `#:transparent` back for "convenience",
+the protection is lost. A security lint rule (`scripts/lint-security.rkt`)
+catches this pattern.

--- a/docs/adr/0010-streaming-port-lifecycle.md
+++ b/docs/adr/0010-streaming-port-lifecycle.md
@@ -1,0 +1,35 @@
+# ADR-0010: Streaming Port Lifecycle
+
+## Status
+Accepted
+
+## Context
+q's LLM providers consume HTTP response ports for streaming (SSE). If a
+streaming request is interrupted — by timeout, cancellation, or an exception —
+the response port may be leaked. Accumulated leaked ports waste file
+descriptors and can eventually exhaust system resources.
+
+In the Azure OpenAI provider specifically, the `http-sendrecv` call opens three
+ports (input, output, response) that all need guaranteed cleanup.
+
+## Decision
+Use `dynamic-wind` for guaranteed port cleanup in all streaming providers:
+
+1. **`call-with-request-timeout`** wraps the HTTP request with a deadline.
+2. **`dynamic-wind`** ensures the response port is always closed — even on
+   timeout, exception, or custodian shutdown.
+3. **Port cleanup in thunk** — The streaming generator reads from the port
+   inside the dynamic-wind body. The post-thunk closes the port.
+
+This pattern is applied consistently across all providers: OpenAI, Azure
+OpenAI, Anthropic, and Gemini.
+
+## Consequences
+**Easier:** No port leaks regardless of failure mode. Timeout behavior is
+predictable. The pattern is the same across all providers.
+
+**Harder:** Slightly more nesting in the streaming code. Developers must
+remember to use `dynamic-wind` rather than simple `with-handlers`.
+
+**Risks:** If the port is closed before the generator finishes reading, the
+generator must handle `read-string` errors gracefully.

--- a/docs/api-stability.md
+++ b/docs/api-stability.md
@@ -1,7 +1,7 @@
-<!-- verified-against: v0.10.2 -->
+<!-- verified-against: v0.15.2 -->
 # API Stability Tiers
 
-<!-- verified-against: v0.10.2 -->
+<!-- verified-against: v0.15.2 -->
 
 This document defines the stability tiers for q's public interfaces. Each module
 is assigned a tier that determines the backwards-compatibility guarantees and

--- a/docs/compatibility-matrix.md
+++ b/docs/compatibility-matrix.md
@@ -1,6 +1,6 @@
 # Compatibility Matrix
 
-<!-- verified-against: v0.10.2 -->
+<!-- verified-against: v0.15.2 -->
 
 This document tracks compatibility between q versions, Racket versions, and
 extension API versions.
@@ -9,6 +9,11 @@ extension API versions.
 
 | q Version | Min Racket | Tested Racket | Notes |
 |-----------|-----------|---------------|-------|
+| 0.15.x | 8.10 | 8.10 | Event-driven core, sandboxing, extensions, TUI |
+| 0.14.x | 8.10 | 8.10 | Trace logger, steering fixes, max_tokens resolution |
+| 0.13.x | 8.10 | 8.10 | Session tree, provider improvements |
+| 0.12.x | 8.10 | 8.10 | OAuth framework, credential store |
+| 0.11.x | 8.10 | 8.10 | Tool scheduler, extension hooks v2 |
 | 0.10.x | 8.10 | 8.10 | Requires `racket/base`, `rackunit` |
 | 0.9.x | 8.10 | 8.10 | Same as above |
 | 0.8.x | 8.9 | 8.9, 8.10 | Backward compatible with 8.9 |
@@ -17,6 +22,8 @@ extension API versions.
 
 | q Version | Extension API | Breaking? | Migration |
 |-----------|--------------|-----------|-----------|
+| 0.15.0+ | `0.5` | No | Additive — safe-mode hooks, quarantine |
+| 0.13.0+ | `0.4` | No | Additive — session-tree hooks |
 | 0.10.0+ | `0.3` | No | Additive — new hook types |
 | 0.9.0+ | `0.2` | No | Additive — extension context fields |
 | 0.8.0+ | `0.1` | Yes | Changed `extension` struct to 4-arg |

--- a/docs/package-registry-spec.md
+++ b/docs/package-registry-spec.md
@@ -1,6 +1,6 @@
 # Package Registry Specification
 
-<!-- verified-against: v0.10.2 -->
+<!-- verified-against: v0.15.2 -->
 
 This document specifies the q extension package registry format and conventions.
 

--- a/docs/publish-verify-workflow.md
+++ b/docs/publish-verify-workflow.md
@@ -1,6 +1,6 @@
 # Publish & Verify Workflow
 
-<!-- verified-against: v0.10.2 -->
+<!-- verified-against: v0.15.2 -->
 
 This document describes the workflow for publishing a q extension package
 and verifying it works correctly.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,4 +1,4 @@
-<!-- verified-against: v0.10.2 -->
+<!-- verified-against: v0.15.2 -->
 # Release Process
 
 This document describes how to cut a new release of **q**.

--- a/docs/sdk-rpc-catalog.md
+++ b/docs/sdk-rpc-catalog.md
@@ -1,6 +1,6 @@
 # q SDK & RPC Catalog
 
-<!-- verified-against: v0.10.2 -->
+<!-- verified-against: v0.15.2 -->
 
 This document catalogs all public SDK and RPC interfaces provided by q.
 

--- a/docs/why-q.md
+++ b/docs/why-q.md
@@ -1,4 +1,4 @@
-<!-- verified-against: v0.10.2 -->
+<!-- verified-against: v0.15.2 -->
 # Why q?
 
 A candid look at who q is for, what it prioritizes, and where it's intentionally narrow.
@@ -34,15 +34,15 @@ q doesn't try to be everything. These are deliberate scope boundaries:
 - **Single-user, single-session focus** — No multi-user or concurrent-session architecture.
 - **Racket ecosystem** — Not Python, not Node.js. This is a deliberate choice for a small, coherent language with excellent macro and module systems, but it means fewer existing libraries and a smaller talent pool.
 
-## Current maturity (v0.8.0)
+## Current maturity (v0.15.x)
 
 Be realistic about where things stand:
 
-- **Core architecture** — Stable and tested (run `racket scripts/metrics.rkt --tests` for current count). The agent loop, session management, and provider abstraction are production-quality.
+- **Core architecture** — Stable and well-tested (~850+ tests). The agent loop, session management, and provider abstraction are production-quality. Iteration engine handles multi-turn tool calls with escalation.
 - **Interfaces** — Working CLI, TUI, JSON mode, RPC, and SDK interfaces. All functional, all terminal-based.
-- **Provider support** — OpenAI and Anthropic providers are solid. Local model support works via compatible endpoints (Ollama, llama.cpp, etc.).
-- **Extension system** — Functional and growing. The hooks and tool registry work; extension quarantine and safe-mode enforcement are now in place.
-- **Security hardening** — Safe-mode/quarantine enforcement, path validation, API key protection, env sanitization, and test isolation.
+- **Provider support** — OpenAI, Azure OpenAI, Anthropic, and Gemini providers with streaming. Local model support via compatible endpoints (Ollama, llama.cpp, etc.).
+- **Extension system** — Mature hook system with extension quarantine, safe-mode enforcement, and tool registration. Extension API v0.5 with context expansion.
+- **Security hardening** — Sandboxed subprocess execution, env sanitization, path validation, API key protection (non-transparent structs), credential redaction, process count limits, and security lint in CI.
 
 ### Packaging roadmap
 
@@ -76,4 +76,4 @@ Don't pick q if:
 
 ---
 
-*This document reflects q v0.8.0. Maturity and capabilities will evolve. Revisit this page as the project grows.*
+*This document reflects q v0.15.x. Maturity and capabilities will evolve. Revisit this page as the project grows.*


### PR DESCRIPTION
Addresses #1476.

docs: Wave 7 — documentation refresh (#1476)

- W7.1: Sync README status block to v0.15.2
- W7.2: Update why-q.md maturity for v0.15.x
- W7.3: Add v0.11–v0.15 to compatibility matrix
- W7.4: Update verified-against markers (v0.10.2 → v0.15.2) in 7 doc files
- W7.5: Write ADR-0008 (safe-mode), ADR-0009 (credential redaction), ADR-0010 (streaming port lifecycle)
- W7.7: Backfill CHANGELOG v0.11.x and v0.13.0 entries