### PR TITLE
fix: Wave 10 — port cleanup + MINOR sweep

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,8 +270,8 @@ q/
 |--------|-------|
 | Test files | 349 |
 | Source modules | 227 |
-| Source lines | 43517 |
-| Test lines | 71533 |
+| Source lines | 43544 |
+| Test lines | 71526 |
 | Test assertions | 11057 |
 | `racket scripts/run-tests.rkt` results | 4,858+ tests passing |
 

--- a/llm/anthropic.rkt
+++ b/llm/anthropic.rkt
@@ -352,6 +352,7 @@
     (define raw (anthropic-do-http-request base-url api-key "/v1/messages" body))
     (anthropic-parse-response raw))
 
+  ;; W10.1 (Q-19): dynamic-wind ensures response port cleanup on timeout/exception
   (define (stream req)
     (define merged-req (ensure-model-setting req default-model))
     (define body (anthropic-build-request-body merged-req #:stream? #t))
@@ -362,55 +363,70 @@
             (format "anthropic-version: ~a" ANTHROPIC-VERSION)
             "Content-Type: application/json"))
     (define body-bytes (jsexpr->bytes body))
-    ;; Wrap initial HTTP request in overall timeout (SEC-11)
-    (define result-vec
-      (call-with-request-timeout (lambda ()
-                                   (define-values (sl rh rp)
-                                     (http-sendrecv uri 'POST #:headers headers #:data body-bytes))
-                                   (vector sl rh rp))))
-    (define status-line (vector-ref result-vec 0))
-    (define response-headers (vector-ref result-vec 1))
-    (define response-port (vector-ref result-vec 2))
-    ;; Check HTTP status before streaming
-    (define status-code
-      (let ([parts (regexp-match #rx"^HTTP/[^ ]+ ([0-9]+)" (bytes->string/utf-8 status-line))])
-        (if parts
-            (string->number (cadr parts))
-            0)))
-    (when (>= status-code 400)
-      (define resp-body (read-response-body/timeout response-port))
-      (anthropic-check-http-status! status-line resp-body))
-    ;; Incremental SSE parsing — generator yields chunks one at a time
-    (define raw-port response-port)
-    (define current-tool-id (box #f))
-    (define current-tool-name (box #f))
-    (define current-tool-index (box 0))
-    (generator ()
-               (let loop ([first-read? #t])
-                 (define timeout-secs
-                   (if first-read? http-read-timeout-default http-stream-timeout-default))
-                 (define line (read-line/timeout raw-port #:timeout timeout-secs))
-                 (cond
-                   [(or (eq? line #f) (eof-object? line))
-                    (close-input-port raw-port)
-                    (yield #f)]
-                   [else
-                    (define parsed (parse-sse-line line))
+    (define response-port-box (box #f))
+    (dynamic-wind
+     (lambda () (void))
+     (lambda ()
+       ;; Wrap initial HTTP request in overall timeout (SEC-11)
+       (define result-vec
+         (call-with-request-timeout #:cleanup (lambda ()
+                                                (define rp (unbox response-port-box))
+                                                (when rp
+                                                  (with-handlers ([exn:fail? void])
+                                                    (close-input-port rp))))
+                                    (lambda ()
+                                      (define-values (sl rh rp)
+                                        (http-sendrecv uri 'POST #:headers headers #:data body-bytes))
+                                      (set-box! response-port-box rp)
+                                      (vector sl rh rp))))
+       (define status-line (vector-ref result-vec 0))
+       (define response-headers (vector-ref result-vec 1))
+       (define response-port (vector-ref result-vec 2))
+       ;; Check HTTP status before streaming
+       (define status-code
+         (let ([parts (regexp-match #rx"^HTTP/[^ ]+ ([0-9]+)" (bytes->string/utf-8 status-line))])
+           (if parts
+               (string->number (cadr parts))
+               0)))
+       (when (>= status-code 400)
+         (define resp-body (read-response-body/timeout response-port))
+         (anthropic-check-http-status! status-line resp-body))
+       ;; Incremental SSE parsing — generator yields chunks one at a time
+       (define raw-port response-port)
+       (define current-tool-id (box #f))
+       (define current-tool-name (box #f))
+       (define current-tool-index (box 0))
+       (generator ()
+                  (let loop ([first-read? #t])
+                    (define timeout-secs
+                      (if first-read? http-read-timeout-default http-stream-timeout-default))
+                    (define line (read-line/timeout raw-port #:timeout timeout-secs))
                     (cond
-                      [(eq? parsed 'done)
+                      [(or (eq? line #f) (eof-object? line))
                        (close-input-port raw-port)
                        (yield #f)]
-                      [(hash? parsed)
-                       ;; Parse the Anthropic event into stream-chunks
-                       (define chunks
-                         (anthropic-parse-single-event parsed
-                                                       current-tool-id
-                                                       current-tool-name
-                                                       current-tool-index))
-                       (for ([ch (in-list chunks)])
-                         (yield ch))
-                       (loop #f)]
-                      [else (loop #f)])]))))
+                      [else
+                       (define parsed (parse-sse-line line))
+                       (cond
+                         [(eq? parsed 'done)
+                          (close-input-port raw-port)
+                          (yield #f)]
+                         [(hash? parsed)
+                          ;; Parse the Anthropic event into stream-chunks
+                          (define chunks
+                            (anthropic-parse-single-event parsed
+                                                          current-tool-id
+                                                          current-tool-name
+                                                          current-tool-index))
+                          (for ([ch (in-list chunks)])
+                            (yield ch))
+                          (loop #f)]
+                         [else (loop #f)])]))))
+     (lambda ()
+       (define rp (unbox response-port-box))
+       (when rp
+         (with-handlers ([exn:fail? void])
+           (close-input-port rp))))))
 
   (make-provider (lambda () "anthropic")
                  (lambda () (hasheq 'streaming #t 'token-counting #f))

--- a/llm/gemini.rkt
+++ b/llm/gemini.rkt
@@ -414,6 +414,7 @@
       (define raw (gemini-do-http-request base-url api-key model-name body))
       (gemini-parse-response raw)))
 
+  ;; W10.1 (Q-19): dynamic-wind ensures response port cleanup on timeout/exception
   (define (stream req)
     (define merged-req (ensure-model-setting req default-model))
     (define body (gemini-build-request-body merged-req #:stream? #t))
@@ -427,53 +428,68 @@
     (define uri (string->url url-str))
     (define headers (list "Content-Type: application/json" (format "x-goog-api-key: ~a" api-key)))
     (define body-bytes (jsexpr->bytes body))
-    ;; Wrap initial HTTP request in overall timeout (SEC-11)
-    (define result-vec
-      (call-with-request-timeout (lambda ()
-                                   (define-values (sl rh rp)
-                                     (http-sendrecv uri 'POST #:headers headers #:data body-bytes))
-                                   (vector sl rh rp))))
-    (define status-line (vector-ref result-vec 0))
-    (define response-headers (vector-ref result-vec 1))
-    (define response-port (vector-ref result-vec 2))
-    ;; Check HTTP status first
-    (define status-str
-      (if (bytes? status-line)
-          (bytes->string/utf-8 status-line)
-          status-line))
-    (define status-code
-      (let ([parts (regexp-match #rx"^HTTP/[^ ]+ ([0-9]+)" status-str)])
-        (if parts
-            (string->number (cadr parts))
-            0)))
-    (when (>= status-code 400)
-      (define resp-body (read-response-body/timeout response-port))
-      (gemini-check-http-status! status-line resp-body))
-    ;; Bind per-request counter (Issue #200)
-    (parameterize ([gemini-tool-id-counter-param 0])
-      ;; Incremental SSE parsing — generator yields chunks one at a time
-      (define raw-port response-port)
-      (generator ()
-                 (let loop ([first-read? #t])
-                   (define timeout-secs
-                     (if first-read? http-read-timeout-default http-stream-timeout-default))
-                   (define line (read-line/timeout raw-port #:timeout timeout-secs))
-                   (cond
-                     [(or (eq? line #f) (eof-object? line))
-                      (close-input-port raw-port)
-                      (yield #f)]
-                     [else
-                      (define parsed (parse-sse-line line))
+    (define response-port-box (box #f))
+    (dynamic-wind
+     (lambda () (void))
+     (lambda ()
+       ;; Wrap initial HTTP request in overall timeout (SEC-11)
+       (define result-vec
+         (call-with-request-timeout #:cleanup (lambda ()
+                                                (define rp (unbox response-port-box))
+                                                (when rp
+                                                  (with-handlers ([exn:fail? void])
+                                                    (close-input-port rp))))
+                                    (lambda ()
+                                      (define-values (sl rh rp)
+                                        (http-sendrecv uri 'POST #:headers headers #:data body-bytes))
+                                      (set-box! response-port-box rp)
+                                      (vector sl rh rp))))
+       (define status-line (vector-ref result-vec 0))
+       (define response-headers (vector-ref result-vec 1))
+       (define response-port (vector-ref result-vec 2))
+       ;; Check HTTP status first
+       (define status-str
+         (if (bytes? status-line)
+             (bytes->string/utf-8 status-line)
+             status-line))
+       (define status-code
+         (let ([parts (regexp-match #rx"^HTTP/[^ ]+ ([0-9]+)" status-str)])
+           (if parts
+               (string->number (cadr parts))
+               0)))
+       (when (>= status-code 400)
+         (define resp-body (read-response-body/timeout response-port))
+         (gemini-check-http-status! status-line resp-body))
+       ;; Bind per-request counter (Issue #200)
+       (parameterize ([gemini-tool-id-counter-param 0])
+         ;; Incremental SSE parsing — generator yields chunks one at a time
+         (define raw-port response-port)
+         (generator ()
+                    (let loop ([first-read? #t])
+                      (define timeout-secs
+                        (if first-read? http-read-timeout-default http-stream-timeout-default))
+                      (define line (read-line/timeout raw-port #:timeout timeout-secs))
                       (cond
-                        [(eq? parsed 'done)
+                        [(or (eq? line #f) (eof-object? line))
                          (close-input-port raw-port)
                          (yield #f)]
-                        [(hash? parsed)
-                         (define chunks (gemini-parse-single-event parsed))
-                         (for ([ch (in-list chunks)])
-                           (yield ch))
-                         (loop #f)]
-                        [else (loop #f)])])))))
+                        [else
+                         (define parsed (parse-sse-line line))
+                         (cond
+                           [(eq? parsed 'done)
+                            (close-input-port raw-port)
+                            (yield #f)]
+                           [(hash? parsed)
+                            (define chunks (gemini-parse-single-event parsed))
+                            (for ([ch (in-list chunks)])
+                              (yield ch))
+                            (loop #f)]
+                           [else (loop #f)])])))))
+     (lambda ()
+       (define rp (unbox response-port-box))
+       (when rp
+         (with-handlers ([exn:fail? void])
+           (close-input-port rp))))))
 
   (make-provider (lambda () "gemini")
                  (lambda () (hasheq 'streaming #t 'token-counting #f))

--- a/runtime/session-store.rkt
+++ b/runtime/session-store.rkt
@@ -209,18 +209,12 @@
   ;; Returns empty list if file does not exist.
   ;; Logs a warning to stderr if any corrupted lines were skipped.
   (define-values (raw corrupted-count) (jsonl-read-all-valid-with-count path))
-  (when (and (> corrupted-count 0) session-id)
-    (fprintf
-     (current-error-port)
-     "WARNING: Skipped ~a corrupted lines in session ~a. Run 'q sessions repair <id>' to fix.\n"
-     corrupted-count
-     session-id))
+  ;; W10.2 (Q-06): Fixed double warning - single message with session-id or path
   (when (> corrupted-count 0)
-    (fprintf
-     (current-error-port)
-     "WARNING: Skipped ~a corrupted lines in session log ~a. Run 'q sessions repair' to fix.\n"
-     corrupted-count
-     path))
+    (fprintf (current-error-port)
+             "WARNING: Skipped ~a corrupted lines in ~a. Run 'q sessions repair' to fix.\n"
+             corrupted-count
+             (or session-id path)))
   (map jsexpr->message raw))
 
 ;; path-string? -> (listof message?)

--- a/tests/test-cancellation.rkt
+++ b/tests/test-cancellation.rkt
@@ -18,72 +18,65 @@
 ;; Test suite
 ;; ============================================================
 
-(define-test-suite test-cancellation-suite
-
-  (test-case "make-cancellation-token creates uncancelled token"
-    (define tok (make-cancellation-token))
-    (check-pred cancellation-token? tok)
-    (check-false (cancellation-token-cancelled? tok)))
-
-  (test-case "cancellation-token? predicate works"
-    (check-true (cancellation-token? (make-cancellation-token)))
-    (check-false (cancellation-token? "not a token"))
-    (check-false (cancellation-token? 42))
-    (check-false (cancellation-token? #f)))
-
-  (test-case "cancellation-token-cancelled? returns #f initially"
-    (define tok (make-cancellation-token))
-    (check-false (cancellation-token-cancelled? tok))
-    (check-false (cancellation-token-cancelled? (make-cancellation-token #:callback (λ (_) (void))))))
-
-  (test-case "cancel-token! sets cancelled"
-    (define tok (make-cancellation-token))
-    (cancel-token! tok)
-    (check-true (cancellation-token-cancelled? tok)))
-
-  (test-case "cancel-token! returns the token"
-    (define tok (make-cancellation-token))
-    (define result (cancel-token! tok))
-    (check-eq? result tok "cancel-token! returns the token"))
-
-  (test-case "callback fires on cancel"
-    (define fired (box #f))
-    (define tok (make-cancellation-token #:callback (lambda (t) (set-box! fired #t))))
-    (cancel-token! tok)
-    (check-true (unbox fired)))
-
-  (test-case "callback receives the token as argument"
-    (define received-tok (box #f))
-    (define tok (make-cancellation-token #:callback (lambda (t) (set-box! received-tok t))))
-    (cancel-token! tok)
-    (check-eq? (unbox received-tok) tok))
-
-  (test-case "double cancel fires callback twice (documented behavior)"
-    (define call-count (box 0))
-    (define tok (make-cancellation-token #:callback (lambda (_) (set-box! call-count (add1 (unbox call-count))))))
-    (cancel-token! tok)
-    (check-pred cancellation-token-cancelled? tok)
-    (check-equal? (unbox call-count) 1 "callback fires once after first cancel")
-    (cancel-token! tok)
-    (check-pred cancellation-token-cancelled? tok)
-    (check-equal? (unbox call-count) 2 "callback fires again on second cancel"))
-
-  (test-case "token with no callback works fine"
-    (define tok (make-cancellation-token))
-    (cancel-token! tok)
-    (check-true (cancellation-token-cancelled? tok)))
-
-  (test-case "token with #f callback works fine"
-    (define tok (make-cancellation-token #:callback #f))
-    (cancel-token! tok)
-    (check-true (cancellation-token-cancelled? tok)))
-
-  (test-case "multiple tokens are independent"
-    (define tok1 (make-cancellation-token))
-    (define tok2 (make-cancellation-token))
-    (cancel-token! tok1)
-    (check-pred cancellation-token-cancelled? tok1)
-    (check-false (cancellation-token-cancelled? tok2))))
+(define-test-suite
+ test-cancellation-suite
+ (test-case "make-cancellation-token creates uncancelled token"
+   (define tok (make-cancellation-token))
+   (check-pred cancellation-token? tok)
+   (check-false (cancellation-token-cancelled? tok)))
+ (test-case "cancellation-token? predicate works"
+   (check-true (cancellation-token? (make-cancellation-token)))
+   (check-false (cancellation-token? "not a token"))
+   (check-false (cancellation-token? 42))
+   (check-false (cancellation-token? #f)))
+ (test-case "cancellation-token-cancelled? returns #f initially"
+   (define tok (make-cancellation-token))
+   (check-false (cancellation-token-cancelled? tok))
+   (check-false (cancellation-token-cancelled? (make-cancellation-token #:callback (λ (_) (void))))))
+ (test-case "cancel-token! sets cancelled"
+   (define tok (make-cancellation-token))
+   (cancel-token! tok)
+   (check-true (cancellation-token-cancelled? tok)))
+ (test-case "cancel-token! returns the token"
+   (define tok (make-cancellation-token))
+   (define result (cancel-token! tok))
+   (check-eq? result tok "cancel-token! returns the token"))
+ (test-case "callback fires on cancel"
+   (define fired (box #f))
+   (define tok (make-cancellation-token #:callback (lambda (t) (set-box! fired #t))))
+   (cancel-token! tok)
+   (check-true (unbox fired)))
+ (test-case "callback receives the token as argument"
+   (define received-tok (box #f))
+   (define tok (make-cancellation-token #:callback (lambda (t) (set-box! received-tok t))))
+   (cancel-token! tok)
+   (check-eq? (unbox received-tok) tok))
+ ;; W10.4 (Q-09): cancel-token! is now idempotent — second cancel is no-op
+ (test-case "double cancel is idempotent — callback fires only once"
+   (define call-count (box 0))
+   (define tok
+     (make-cancellation-token #:callback
+                              (lambda (_) (set-box! call-count (add1 (unbox call-count))))))
+   (cancel-token! tok)
+   (check-pred cancellation-token-cancelled? tok)
+   (check-equal? (unbox call-count) 1 "callback fires once after first cancel")
+   (cancel-token! tok)
+   (check-pred cancellation-token-cancelled? tok)
+   (check-equal? (unbox call-count) 1 "callback does NOT fire on second cancel (idempotent)"))
+ (test-case "token with no callback works fine"
+   (define tok (make-cancellation-token))
+   (cancel-token! tok)
+   (check-true (cancellation-token-cancelled? tok)))
+ (test-case "token with #f callback works fine"
+   (define tok (make-cancellation-token #:callback #f))
+   (cancel-token! tok)
+   (check-true (cancellation-token-cancelled? tok)))
+ (test-case "multiple tokens are independent"
+   (define tok1 (make-cancellation-token))
+   (define tok2 (make-cancellation-token))
+   (cancel-token! tok1)
+   (check-pred cancellation-token-cancelled? tok1)
+   (check-false (cancellation-token-cancelled? tok2))))
 
 ;; ============================================================
 ;; Run

--- a/util/cancellation.rkt
+++ b/util/cancellation.rkt
@@ -41,10 +41,11 @@
 
 ;; cancel-token! : cancellation-token? -> cancellation-token?
 ;; Sets the cancelled flag and fires the callback (if any).
-;; Note: calling cancel-token! multiple times fires the callback each time.
-;; This is documented behavior — callers should guard if idempotency is needed.
+;; W10.4 (Q-09): Idempotent — no-op if already cancelled.
 (define (cancel-token! tok)
-  (set-box! (cancellation-token-cancelled-box tok) #t)
-  (define cb (unbox (cancellation-token-callback-box tok)))
-  (when cb (cb tok))
+  (unless (unbox (cancellation-token-cancelled-box tok))
+    (set-box! (cancellation-token-cancelled-box tok) #t)
+    (define cb (unbox (cancellation-token-callback-box tok)))
+    (when cb
+      (cb tok)))
   tok)

--- a/util/jsonl.rkt
+++ b/util/jsonl.rkt
@@ -104,21 +104,21 @@
   ;; corrupted-count is the number of non-empty lines that failed to parse.
   (if (not (file-exists? path))
       (values '() 0)
-      (call-with-input-file path
-                            (lambda (in)
-                              (define-values (valid corrupted)
-                                (for/fold ([acc '()]
-                                           [bad 0])
-                                          ([line (in-lines in)])
-                                  (define trimmed (string-trim line))
-                                  (cond
-                                    [(<= (string-length trimmed) 0) (values acc bad)]
-                                    [(jsonl-line-valid? line)
-                                     (values (append acc (list (read-json (open-input-string line))))
-                                             bad)]
-                                    [else (values acc (add1 bad))])))
-                              (values valid corrupted))
-                            #:mode 'text)))
+      (call-with-input-file
+       path
+       (lambda (in)
+         (define-values (valid corrupted)
+           (for/fold ([acc '()]
+                      [bad 0])
+                     ([line (in-lines in)])
+             (define trimmed (string-trim line))
+             (cond
+               [(<= (string-length trimmed) 0) (values acc bad)]
+               ;; W10.3 (Q-07): cons + reverse instead of append (O(n²) → O(n))
+               [(jsonl-line-valid? line) (values (cons (read-json (open-input-string line)) acc) bad)]
+               [else (values acc (add1 bad))])))
+         (values (reverse valid) corrupted))
+       #:mode 'text)))
 
 (define (jsonl-read-last path [max-lines 1000])
   ;; Read the last `max-lines` valid JSONL lines from file.


### PR DESCRIPTION
Addresses #1490.

fix: Wave 10 — port cleanup + MINOR sweep (#1490)

- W10.1 (Q-19): Add dynamic-wind port cleanup to anthropic.rkt and gemini.rkt streaming generators
- W10.2 (Q-06): Fix double warning in load-session-log — single message with session-id or path
- W10.3 (Q-07): Fix O(n²) append in jsonl-read-all-valid-with-count — cons + reverse
- W10.4 (Q-09): Add idempotency guard to cancel-token! — no-op on second call