### PR TITLE
refactor: Wave 1 — replace log-warning(format...) with native format args

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ q/
 |--------|-------|
 | Test files | 349 |
 | Source modules | 227 |
-| Source lines | 43544 |
+| Source lines | 43556 |
 | Test lines | 71526 |
 | Test assertions | 11057 |
 | `racket scripts/run-tests.rkt` results | 4,858+ tests passing |

--- a/extensions/hooks.rkt
+++ b/extensions/hooks.rkt
@@ -41,7 +41,8 @@
 
 ;; Critical hooks default to 'block on error (safety-first).
 ;; Advisory hooks default to 'pass on error (liveness-first).
-(define critical-hooks '(tool-call session-before-switch session-before-fork session-before-compact input))
+(define critical-hooks
+  '(tool-call session-before-switch session-before-fork session-before-compact input))
 
 (define (critical-hook? hook-point)
   (and (member hook-point critical-hooks) #t))
@@ -94,15 +95,14 @@
     (if (critical-hook? hook-point)
         (hook-block (format "handler ~a failed for critical hook ~a" ext-name hook-point))
         (hook-pass payload)))
-  (with-handlers ([exn:fail? (lambda (e)
-                               (log-warning (format "Hook handler ~a for ~a threw: ~a [~a]"
-                                                    ext-name
-                                                    hook-point
-                                                    (exn-message e)
-                                                    (if (critical-hook? hook-point)
-                                                        "CRITICAL->block"
-                                                        "advisory->pass")))
-                               error-default)])
+  (with-handlers ([exn:fail?
+                   (lambda (e)
+                     (log-warning "Hook handler ~a for ~a threw: ~a [~a]"
+                                  ext-name
+                                  hook-point
+                                  (exn-message e)
+                                  (if (critical-hook? hook-point) "CRITICAL->block" "advisory->pass"))
+                     error-default)])
     (define raw-result
       (if timeout-ms
           ;; Run with timeout
@@ -143,9 +143,9 @@
               ;; M1: Invalid action — downgrade to 'pass instead of propagating
               (hook-pass payload)))
         (begin
-          (log-warning (format "Hook handler ~a for ~a returned non-hook-result: ~v [~a]"
-                               ext-name
-                               hook-point
-                               raw-result
-                               (if (critical-hook? hook-point) "CRITICAL->block" "advisory->pass")))
+          (log-warning "Hook handler ~a for ~a returned non-hook-result: ~v [~a]"
+                       ext-name
+                       hook-point
+                       raw-result
+                       (if (critical-hook? hook-point) "CRITICAL->block" "advisory->pass"))
           error-default))))

--- a/extensions/loader.rkt
+++ b/extensions/loader.rkt
@@ -101,10 +101,10 @@
           (try-load-extension path)))
     (cond
       [(extension-load-error? result)
-       (log-warning (format "extension load failed [~a]: ~a \u2014 ~a"
-                            (extension-load-error-category result)
-                            path
-                            (extension-load-error-message result)))
+       (log-warning "extension load failed [~a]: ~a \u2014 ~a"
+                    (extension-load-error-category result)
+                    path
+                    (extension-load-error-message result))
        (when event-bus
          (publish! event-bus
                    (make-event "extension.load.failed"
@@ -186,10 +186,10 @@
             (define min-v (hash-ref compat-hash 'min-q-version #f))
             (define max-v (hash-ref compat-hash 'max-q-version #f))
             (when (and min-v (version<? q-version min-v))
-              (log-warning (format "extension '~a' requires q >= ~a, current version is ~a"
-                                   ext-name
-                                   min-v
-                                   q-version)))
+              (log-warning "extension '~a' requires q >= ~a, current version is ~a"
+                           ext-name
+                           min-v
+                           q-version))
             (when (and max-v (string? max-v) (version<=? max-v q-version))
               (log-warning
                (format

--- a/extensions/quarantine.rkt
+++ b/extensions/quarantine.rkt
@@ -21,17 +21,16 @@
          racket/string
          json)
 
-(provide
- ;; Quarantine state
- current-quarantine-dir
- quarantine-state-file
- ;; Extension state queries and mutations
- extension-state
- disable-extension!
- quarantine-extension!
- restore-extension!
- list-quarantined
- format-extension-status)
+;; Quarantine state
+(provide current-quarantine-dir
+         quarantine-state-file
+         ;; Extension state queries and mutations
+         extension-state
+         disable-extension!
+         quarantine-extension!
+         restore-extension!
+         list-quarantined
+         format-extension-status)
 
 ;; ============================================================
 ;; Parameters
@@ -60,20 +59,18 @@
     (make-directory* qdir))
   (define lock-path (quarantine-lock-file))
   (define got-lock #f)
-  (with-handlers ([exn:fail:filesystem?
-                   (lambda (e)
-                     (when got-lock (delete-file lock-path))
-                     (raise e))]
-                  [exn:fail?
-                   (lambda (e)
-                     (when got-lock (delete-file lock-path))
-                     (raise e))])
+  (with-handlers ([exn:fail:filesystem? (lambda (e)
+                                          (when got-lock
+                                            (delete-file lock-path))
+                                          (raise e))]
+                  [exn:fail? (lambda (e)
+                               (when got-lock
+                                 (delete-file lock-path))
+                               (raise e))])
     ;; Try to create lock file exclusively (atomic on POSIX)
-    (with-output-to-file lock-path #:exists 'error
-      (lambda () (write (current-inexact-milliseconds))))
+    (with-output-to-file lock-path #:exists 'error (lambda () (write (current-inexact-milliseconds))))
     (set! got-lock #t)
-    (begin0
-      (thunk)
+    (begin0 (thunk)
       (delete-file lock-path)
       (set! got-lock #f))))
 
@@ -93,17 +90,19 @@
 (define (read-state)
   (define sf (quarantine-state-file))
   (cond
-    [(not (file-exists? sf))
-     (hasheq 'disabled '() 'quarantined (hasheq) 'active '())]
+    [(not (file-exists? sf)) (hasheq 'disabled '() 'quarantined (hasheq) 'active '())]
     [else
      (with-handlers ([exn:fail? (lambda (e)
-                                  (log-warning (format "quarantine state corrupted, resetting: ~a"
-                                                       (exn-message e)))
+                                  (log-warning "quarantine state corrupted, resetting: ~a"
+                                               (exn-message e))
                                   (hasheq 'disabled '() 'quarantined (hasheq) 'active '()))])
        (define data (call-with-input-file sf read-json))
-       (hasheq 'disabled (hash-ref data 'disabled '())
-             'quarantined (hash-ref data 'quarantined (hasheq))
-             'active (hash-ref data 'active '())))]))
+       (hasheq 'disabled
+               (hash-ref data 'disabled '())
+               'quarantined
+               (hash-ref data 'quarantined (hasheq))
+               'active
+               (hash-ref data 'active '())))]))
 
 (define (write-state! state)
   (define qdir (current-quarantine-dir))
@@ -112,31 +111,36 @@
   (define sf (quarantine-state-file))
   (define tmp (build-path qdir ".state.json.tmp"))
   (call-with-output-file tmp
-    (lambda (p)
-      (write-json state p)
-      (newline p))
-    #:exists 'truncate/replace)
+                         (lambda (p)
+                           (write-json state p)
+                           (newline p))
+                         #:exists 'truncate/replace)
   (rename-file-or-directory tmp sf #t))
 
 ;; Helper: convert string name to symbol for use as quarantined hash key
-(define (name->sym n) (string->symbol n))
-(define (sym->name s) (symbol->string s))
+(define (name->sym n)
+  (string->symbol n))
+(define (sym->name s)
+  (symbol->string s))
 
 ;; ============================================================
 ;; extension-state : string? -> (or/c 'active 'disabled 'quarantined 'unknown)
 ;; ============================================================
 
 (define (extension-state name)
-  (with-quarantine-lock
-    (lambda ()
-      (define state (read-state))
-      (define disabled (hash-ref state 'disabled '()))
-      (define quarantined (hash-ref state 'quarantined (hasheq)))
-      (cond
-        [(member name (if (list? disabled) disabled '())) 'disabled]
-        [(hash-has-key? quarantined (name->sym name)) 'quarantined]
-        [(member name (hash-ref state 'active '())) 'active]
-        [else 'unknown]))))
+  (with-quarantine-lock (lambda ()
+                          (define state (read-state))
+                          (define disabled (hash-ref state 'disabled '()))
+                          (define quarantined (hash-ref state 'quarantined (hasheq)))
+                          (cond
+                            [(member name
+                                     (if (list? disabled)
+                                         disabled
+                                         '()))
+                             'disabled]
+                            [(hash-has-key? quarantined (name->sym name)) 'quarantined]
+                            [(member name (hash-ref state 'active '())) 'active]
+                            [else 'unknown]))))
 
 ;; ============================================================
 ;; disable-extension! : string? -> void?
@@ -144,21 +148,17 @@
 
 (define (disable-extension! name)
   (with-quarantine-lock
-    (lambda ()
-      (define state (read-state))
-      (define disabled (hash-ref state 'disabled '()))
-      (define quarantined (hash-ref state 'quarantined (hasheq)))
-      (define new-disabled
-        (if (member name disabled)
-            disabled
-            (append disabled (list name))))
-      (define new-quarantined (hash-remove quarantined (name->sym name)))
-      (define new-active
-        (filter (lambda (n) (not (equal? n name)))
-                (hash-ref state 'active '())))
-      (write-state! (hasheq 'disabled new-disabled
-                            'quarantined new-quarantined
-                            'active new-active)))))
+   (lambda ()
+     (define state (read-state))
+     (define disabled (hash-ref state 'disabled '()))
+     (define quarantined (hash-ref state 'quarantined (hasheq)))
+     (define new-disabled
+       (if (member name disabled)
+           disabled
+           (append disabled (list name))))
+     (define new-quarantined (hash-remove quarantined (name->sym name)))
+     (define new-active (filter (lambda (n) (not (equal? n name))) (hash-ref state 'active '())))
+     (write-state! (hasheq 'disabled new-disabled 'quarantined new-quarantined 'active new-active)))))
 
 ;; ============================================================
 ;; quarantine-extension! : string? path-string? -> void?
@@ -166,27 +166,26 @@
 
 (define (quarantine-extension! name src-path)
   (with-quarantine-lock
-    (lambda ()
-      (define state (read-state))
-      (define disabled (hash-ref state 'disabled '()))
-      (define quarantined (hash-ref state 'quarantined (hasheq)))
-      (define qdir (current-quarantine-dir))
-      (unless (directory-exists? qdir)
-        (make-directory* qdir))
-      (define dest (build-path qdir name))
-      (when (directory-exists? src-path)
-        (rename-file-or-directory src-path dest #t))
-      (define new-disabled (filter (lambda (n) (not (equal? n name))) disabled))
-      (define new-quarantined
-        (hash-set quarantined (name->sym name)
-                  (hasheq 'original-path (path->string (path->complete-path src-path))
-                          'quarantined-at (seconds->iso8601 (current-seconds)))))
-      (define new-active
-        (filter (lambda (n) (not (equal? n name)))
-                (hash-ref state 'active '())))
-      (write-state! (hasheq 'disabled new-disabled
-                            'quarantined new-quarantined
-                            'active new-active)))))
+   (lambda ()
+     (define state (read-state))
+     (define disabled (hash-ref state 'disabled '()))
+     (define quarantined (hash-ref state 'quarantined (hasheq)))
+     (define qdir (current-quarantine-dir))
+     (unless (directory-exists? qdir)
+       (make-directory* qdir))
+     (define dest (build-path qdir name))
+     (when (directory-exists? src-path)
+       (rename-file-or-directory src-path dest #t))
+     (define new-disabled (filter (lambda (n) (not (equal? n name))) disabled))
+     (define new-quarantined
+       (hash-set quarantined
+                 (name->sym name)
+                 (hasheq 'original-path
+                         (path->string (path->complete-path src-path))
+                         'quarantined-at
+                         (seconds->iso8601 (current-seconds)))))
+     (define new-active (filter (lambda (n) (not (equal? n name))) (hash-ref state 'active '())))
+     (write-state! (hasheq 'disabled new-disabled 'quarantined new-quarantined 'active new-active)))))
 
 ;; ============================================================
 ;; restore-extension! : string? path-string? -> void?
@@ -194,45 +193,43 @@
 
 (define (restore-extension! name dest-path)
   (with-quarantine-lock
-    (lambda ()
-      (define state (read-state))
-      (define disabled (hash-ref state 'disabled '()))
-      (define quarantined (hash-ref state 'quarantined (hasheq)))
-      (define qdir (current-quarantine-dir))
-      (define src (build-path qdir name))
-      ;; If quarantined dir exists, move it back
-      (when (directory-exists? src)
-        (define dest-parent
-          (let-values ([(base _name _must-be-dir?) (split-path dest-path)])
-            base))
-        (when (and dest-parent (not (directory-exists? dest-parent)))
-          (make-directory* dest-parent))
-        (rename-file-or-directory src dest-path #t))
-      (define new-disabled (filter (lambda (n) (not (equal? n name))) disabled))
-      (define new-quarantined (hash-remove quarantined (name->sym name)))
-      (define active (hash-ref state 'active '()))
-      (define new-active
-        (if (member name active)
-            active
-            (append active (list name))))
-      (write-state! (hasheq 'disabled new-disabled
-                            'quarantined new-quarantined
-                            'active new-active)))))
+   (lambda ()
+     (define state (read-state))
+     (define disabled (hash-ref state 'disabled '()))
+     (define quarantined (hash-ref state 'quarantined (hasheq)))
+     (define qdir (current-quarantine-dir))
+     (define src (build-path qdir name))
+     ;; If quarantined dir exists, move it back
+     (when (directory-exists? src)
+       (define dest-parent
+         (let-values ([(base _name _must-be-dir?) (split-path dest-path)])
+           base))
+       (when (and dest-parent (not (directory-exists? dest-parent)))
+         (make-directory* dest-parent))
+       (rename-file-or-directory src dest-path #t))
+     (define new-disabled (filter (lambda (n) (not (equal? n name))) disabled))
+     (define new-quarantined (hash-remove quarantined (name->sym name)))
+     (define active (hash-ref state 'active '()))
+     (define new-active
+       (if (member name active)
+           active
+           (append active (list name))))
+     (write-state! (hasheq 'disabled new-disabled 'quarantined new-quarantined 'active new-active)))))
 
 ;; ============================================================
 ;; list-quarantined : -> (listof hash?)
 ;; ============================================================
 
 (define (list-quarantined)
-  (with-quarantine-lock
-    (lambda ()
-      (define state (read-state))
-      (define quarantined (hash-ref state 'quarantined (hasheq)))
-      (for/list ([(sym-key meta) (in-hash quarantined)])
-        (make-hash (list (cons 'name (sym->name sym-key))
-                         (cons 'state "quarantined")
-                         (cons 'original-path (hash-ref meta 'original-path ""))
-                         (cons 'quarantined-at (hash-ref meta 'quarantined-at ""))))))))
+  (with-quarantine-lock (lambda ()
+                          (define state (read-state))
+                          (define quarantined (hash-ref state 'quarantined (hasheq)))
+                          (for/list ([(sym-key meta) (in-hash quarantined)])
+                            (make-hash (list (cons 'name (sym->name sym-key))
+                                             (cons 'state "quarantined")
+                                             (cons 'original-path (hash-ref meta 'original-path ""))
+                                             (cons 'quarantined-at
+                                                   (hash-ref meta 'quarantined-at ""))))))))
 
 ;; ============================================================
 ;; format-extension-status : string? -> string?
@@ -241,19 +238,18 @@
 (define (format-extension-status name)
   (define st (extension-state name))
   (match st
-    ['active   (format "~a: active" name)]
+    ['active (format "~a: active" name)]
     ['disabled (format "~a: disabled" name)]
     ['quarantined
-     (with-quarantine-lock
-       (lambda ()
-         (define state (read-state))
-         (define quarantined (hash-ref state 'quarantined (hasheq)))
-         (define meta (hash-ref quarantined (name->sym name) (hash)))
-         (format "~a: quarantined (from ~a at ~a)"
-                 name
-                 (hash-ref meta 'original-path "?")
-                 (hash-ref meta 'quarantined-at "?"))))]
-    ['unknown  (format "~a: unknown" name)]))
+     (with-quarantine-lock (lambda ()
+                             (define state (read-state))
+                             (define quarantined (hash-ref state 'quarantined (hasheq)))
+                             (define meta (hash-ref quarantined (name->sym name) (hash)))
+                             (format "~a: quarantined (from ~a at ~a)"
+                                     name
+                                     (hash-ref meta 'original-path "?")
+                                     (hash-ref meta 'quarantined-at "?"))))]
+    ['unknown (format "~a: unknown" name)]))
 
 ;; ============================================================
 ;; Internal helpers
@@ -263,8 +259,8 @@
   (define d (seconds->date secs #f))
   (format "~a-~a-~aT~a:~a:~aZ"
           (date-year d)
-          (~r (date-month d)  #:min-width 2 #:pad-string "0")
-          (~r (date-day d)    #:min-width 2 #:pad-string "0")
-          (~r (date-hour d)   #:min-width 2 #:pad-string "0")
+          (~r (date-month d) #:min-width 2 #:pad-string "0")
+          (~r (date-day d) #:min-width 2 #:pad-string "0")
+          (~r (date-hour d) #:min-width 2 #:pad-string "0")
           (~r (date-minute d) #:min-width 2 #:pad-string "0")
           (~r (date-second d) #:min-width 2 #:pad-string "0")))

--- a/runtime/auth-store.rkt
+++ b/runtime/auth-store.rkt
@@ -255,8 +255,8 @@
 ;; are not encrypted at rest. On shared systems, consider using
 ;; environment variables or a dedicated secrets manager instead.
 (define (save-credential-file! provider-name api-key [path (credential-file-path)])
-  (with-handlers ([exn:fail?
-                   (λ (e) (log-warning (format "save-credential-file! failed: ~a" (exn-message e))))])
+  (with-handlers ([exn:fail? (λ (e)
+                               (log-warning "save-credential-file! failed: ~a" (exn-message e)))])
     (define dir (path-only path))
     (when (and dir (not (directory-exists? dir)))
       (make-directory* dir))
@@ -297,8 +297,7 @@
 ;; are not encrypted at rest. On shared systems, consider using
 ;; environment variables or a dedicated secrets manager instead.
 (define (write-credential-to-config! config-path provider-name api-key)
-  (with-handlers ([exn:fail? (lambda (e)
-                               (log-warning (format "credential save failed: ~a" (exn-message e))))])
+  (with-handlers ([exn:fail? (lambda (e) (log-warning "credential save failed: ~a" (exn-message e)))])
     (internal-write-credential-to-config! config-path provider-name api-key)))
 
 ;; Actual implementation (separated for clarity)
@@ -346,13 +345,12 @@
                          (if dir
                              dir
                              (find-system-path 'temp-dir))))
-  (with-handlers ([exn:fail?
-                   (lambda (e)
-                     (with-handlers ([exn:fail? (lambda (e)
-                                                  (log-warning (format "credential load failed: ~a"
-                                                                       (exn-message e))))])
-                       (delete-file tmp))
-                     (raise e))])
+  (with-handlers ([exn:fail? (lambda (e)
+                               (with-handlers ([exn:fail? (lambda (e)
+                                                            (log-warning "credential load failed: ~a"
+                                                                         (exn-message e)))])
+                                 (delete-file tmp))
+                               (raise e))])
     (call-with-output-file tmp (lambda (out) (write-json data out)) #:exists 'truncate)
     (rename-file-or-directory tmp path #t)
     (file-or-directory-permissions path #o600)))

--- a/runtime/oauth.rkt
+++ b/runtime/oauth.rkt
@@ -166,8 +166,7 @@
 ;; Save all OAuth tokens to the token file.
 (define (save-oauth-token-file! tokens [path (oauth-token-file-path)])
   (with-handlers ([exn:fail? (lambda (e)
-                               (log-warning (format "save-oauth-token-file! failed: ~a"
-                                                    (exn-message e))))])
+                               (log-warning "save-oauth-token-file! failed: ~a" (exn-message e)))])
     (define dir (path-only path))
     (when (and dir (not (directory-exists? dir)))
       (make-directory* dir))

--- a/tools/scheduler.rkt
+++ b/tools/scheduler.rkt
@@ -199,8 +199,7 @@
   (define pre-hook-result
     (if hook-dispatcher
         (with-handlers ([exn:fail? (lambda (e)
-                                     (log-warning (format "tool-call-pre hook threw: ~a"
-                                                          (exn-message e)))
+                                     (log-warning "tool-call-pre hook threw: ~a" (exn-message e))
                                      #f)])
           (hook-dispatcher 'tool-call-pre pre-payload))
         #f))
@@ -240,8 +239,8 @@
      (define post-hook-result
        (if hook-dispatcher
            (with-handlers ([exn:fail? (lambda (e)
-                                        (log-warning (format "tool-result-post hook threw: ~a"
-                                                             (exn-message e)))
+                                        (log-warning "tool-result-post hook threw: ~a"
+                                                     (exn-message e))
                                         #f)])
              (hook-dispatcher 'tool-result-post post-payload))
            #f))

--- a/tui/keymap.rkt
+++ b/tui/keymap.rkt
@@ -83,37 +83,59 @@
 
 ;; Check if an action symbol uses dot-namespace format (e.g. 'tui.editor.copy)
 (define (namespaced-action? action)
-  (and (symbol? action)
-       (regexp-match? #rx"^[a-z][a-z0-9-]*\\." (symbol->string action))))
+  (and (symbol? action) (regexp-match? #rx"^[a-z][a-z0-9-]*\\." (symbol->string action))))
 
 ;; Build a namespaced action from parts: (namespace 'editor 'copy) → 'app.editor.copy
 (define (namespace-action . parts)
   (string->symbol (string-join (map (lambda (p)
-                                      (if (symbol? p) (symbol->string p) p))
-                                    parts) ".")))
+                                      (if (symbol? p)
+                                          (symbol->string p)
+                                          p))
+                                    parts)
+                               ".")))
 
 ;; Migration table: flat action → namespaced equivalent
 (define flat->namespaced
-  (hasheq 'history-up 'tui.navigation.history-up
-          'history-down 'tui.navigation.history-down
-          'page-up 'tui.navigation.page-up
-          'page-down 'tui.navigation.page-down
-          'home 'tui.navigation.home
-          'end 'tui.navigation.end
-          'scroll-up 'tui.navigation.scroll-up
-          'scroll-down 'tui.navigation.scroll-down
-          'submit 'tui.input.submit
-          'backspace 'tui.input.backspace
-          'delete 'tui.input.delete
-          'cancel 'tui.input.cancel
-          'word-left 'tui.editor.word-left
-          'word-right 'tui.editor.word-right
-          'copy 'tui.editor.copy
-          'cut 'tui.editor.cut
-          'paste 'tui.editor.paste
-          'select-all 'tui.editor.select-all
-          'clear-input 'tui.editor.clear-input
-          'clear-screen 'tui.display.clear-screen))
+  (hasheq 'history-up
+          'tui.navigation.history-up
+          'history-down
+          'tui.navigation.history-down
+          'page-up
+          'tui.navigation.page-up
+          'page-down
+          'tui.navigation.page-down
+          'home
+          'tui.navigation.home
+          'end
+          'tui.navigation.end
+          'scroll-up
+          'tui.navigation.scroll-up
+          'scroll-down
+          'tui.navigation.scroll-down
+          'submit
+          'tui.input.submit
+          'backspace
+          'tui.input.backspace
+          'delete
+          'tui.input.delete
+          'cancel
+          'tui.input.cancel
+          'word-left
+          'tui.editor.word-left
+          'word-right
+          'tui.editor.word-right
+          'copy
+          'tui.editor.copy
+          'cut
+          'tui.editor.cut
+          'paste
+          'tui.editor.paste
+          'select-all
+          'tui.editor.select-all
+          'clear-input
+          'tui.editor.clear-input
+          'clear-screen
+          'tui.display.clear-screen))
 
 ;; Auto-migrate a flat action to its namespaced equivalent.
 ;; Returns the namespaced symbol if a mapping exists, otherwise the original.
@@ -282,10 +304,9 @@
 ;; is not significant.
 
 (define (load-keybindings-file path)
-  (with-handlers ([exn:fail?
-                   (lambda (e)
-                     (log-warning (format "keymap: failed to load ~a: ~a" path (exn-message e)))
-                     #f)])
+  (with-handlers ([exn:fail? (lambda (e)
+                               (log-warning "keymap: failed to load ~a: ~a" path (exn-message e))
+                               #f)])
     (if (file-exists? path)
         (let ([content (file->string path)]) (parse-keybindings-content content path))
         #f)))
@@ -307,7 +328,7 @@
         (if (and (string? key-str) (string? action-str))
             (cons (parse-key-string key-str) (migrate-action (string->symbol action-str)))
             (begin
-              (log-warning (format "keymap: skipping invalid entry in ~a: ~v" source-path entry))
+              (log-warning "keymap: skipping invalid entry in ~a: ~v" source-path entry)
               #f))))
     (define valid-bindings (filter identity bindings))
     (if (null? valid-bindings) #f valid-bindings)))
@@ -331,10 +352,9 @@
   (define base (default-keymap))
   (define kb-path (or path (build-path (global-config-dir) "keybindings.json")))
   (define user-bindings
-    (with-handlers ([exn:fail?
-                     (lambda (e)
-                       (log-warning (format "keymap: failed to load ~a: ~a" kb-path (exn-message e)))
-                       #f)])
+    (with-handlers ([exn:fail? (lambda (e)
+                                 (log-warning "keymap: failed to load ~a: ~a" kb-path (exn-message e))
+                                 #f)])
       (and (file-exists? kb-path) (load-keybindings-file kb-path))))
   (when user-bindings
     (define user-km (make-keymap))

--- a/tui/tui-keybindings.rkt
+++ b/tui/tui-keybindings.rkt
@@ -486,7 +486,7 @@
   ;; Error guard (#1121): catch any exception from mouse handling
   ;; to prevent crashes from corrupt or unexpected mouse data.
   (with-handlers ([exn:fail? (lambda (e)
-                               (log-warning (format "TUI: mouse handler error: ~a" (exn-message e)))
+                               (log-warning "TUI: mouse handler error: ~a" (exn-message e))
                                'continue)])
     (define state (unbox (tui-ctx-ui-state-box ctx)))
     (define mouse-type (car msg-data))

--- a/util/protocol-types.rkt
+++ b/util/protocol-types.rkt
@@ -378,10 +378,10 @@
 (define (jsexpr->event h)
   (define ver (hash-ref h 'version 1))
   (when (> ver CURRENT-EVENT-VERSION)
-    (log-warning (format "jsexpr->event: event version ~a exceeds current ~a (event: ~a)"
-                         ver
-                         CURRENT-EVENT-VERSION
-                         (hash-ref h 'event "<unknown>"))))
+    (log-warning "jsexpr->event: event version ~a exceeds current ~a (event: ~a)"
+                 ver
+                 CURRENT-EVENT-VERSION
+                 (hash-ref h 'event "<unknown>")))
   (event ver
          (hash-ref h 'event)
          (hash-ref h 'time)


### PR DESCRIPTION
Addresses #1502.

refactor: Wave 1 — replace log-warning(format...) with native format args (Q-10) (#1502)

Replace 16 (log-warning (format "..." args)) calls with native (log-warning "..." args)
across 9 files. No behavior change — log-warning accepts format args natively.