### PR TITLE
refactor: Wave 2 — model defaults extraction + bridge-table parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,8 +269,8 @@ q/
 | Metric | Value |
 |--------|-------|
 | Test files | 349 |
-| Source modules | 227 |
-| Source lines | 43556 |
+| Source modules | 228 |
+| Source lines | 43582 |
 | Test lines | 71526 |
 | Test assertions | 11057 |
 | `racket scripts/run-tests.rkt` results | 4,858+ tests passing |

--- a/llm/anthropic.rkt
+++ b/llm/anthropic.rkt
@@ -11,6 +11,7 @@
 
 (require racket/contract
          racket/string
+         (only-in "../runtime/model-defaults.rkt" ANTHROPIC-DEFAULT-MODEL ANTHROPIC-DEFAULT-BASE-URL)
          racket/port
          racket/generator
          json
@@ -37,10 +38,9 @@
 ;; Constants
 ;; ============================================================
 
-(define ANTHROPIC-DEFAULT-MODEL "claude-sonnet-4-20250514")
+;; model defaults now in runtime/model-defaults.rkt
 (define ANTHROPIC-DEFAULT-MAX-TOKENS 4096)
 (define ANTHROPIC-VERSION "2023-06-01")
-(define ANTHROPIC-DEFAULT-BASE-URL "https://api.anthropic.com")
 
 ;; ============================================================
 ;; Request body construction

--- a/llm/azure-openai.rkt
+++ b/llm/azure-openai.rkt
@@ -13,6 +13,7 @@
 ;; #1195: Additional LLM Provider Adapters
 
 (require racket/contract
+         (only-in "../runtime/model-defaults.rkt" OPENAI-DEFAULT-MODEL)
          racket/string
          racket/generator
          racket/port
@@ -90,7 +91,7 @@
 
 (define (make-azure-openai-provider config)
   (define api-key (hash-ref config 'api-key ""))
-  (define model-name (hash-ref config 'model "gpt-4"))
+  (define model-name (hash-ref config 'model OPENAI-DEFAULT-MODEL))
   (define base-url (hash-ref config 'base-url ""))
   (define api-version (hash-ref config 'api-version "2024-02-15-preview"))
   (when (string=? api-key "")

--- a/llm/gemini.rkt
+++ b/llm/gemini.rkt
@@ -12,6 +12,7 @@
 
 (require racket/contract
          racket/string
+         (only-in "../runtime/model-defaults.rkt" GEMINI-DEFAULT-MODEL GEMINI-DEFAULT-BASE-URL)
          racket/port
          racket/format
          racket/generator
@@ -41,7 +42,7 @@
 ;; Constants
 ;; ============================================================
 
-(define GEMINI-DEFAULT-MODEL "gemini-2.5-pro")
+;; model defaults now in runtime/model-defaults.rkt
 (define GEMINI-DEFAULT-MAX-TOKENS 4096)
 
 ;; Per-request tool call ID counter (Issue #200)
@@ -58,7 +59,6 @@
 ;; Reset the parameter for a fresh request.
 (define (gemini-reset-tool-id-counter!)
   (gemini-tool-id-counter-param 0))
-(define GEMINI-DEFAULT-BASE-URL "https://generativelanguage.googleapis.com")
 
 ;; ============================================================
 ;; Request body construction

--- a/llm/openai-compatible.rkt
+++ b/llm/openai-compatible.rkt
@@ -10,6 +10,7 @@
 ;; SSE parsing delegates to llm/stream.rkt.
 
 (require racket/contract
+         (only-in "../runtime/model-defaults.rkt" OPENAI-DEFAULT-MODEL)
          racket/string
          racket/generator
          racket/port
@@ -36,7 +37,7 @@
   (define settings (model-request-settings req))
   (define base
     (hasheq 'model
-            (hash-ref settings 'model "gpt-4")
+            (hash-ref settings 'model OPENAI-DEFAULT-MODEL)
             'messages
             (model-request-messages req)
             'stream
@@ -225,7 +226,7 @@
   (validate-api-key! "OpenAI" "OPENAI_API_KEY" config)
   (define base-url (hash-ref config 'base-url "https://api.openai.com/v1"))
   (define api-key (hash-ref config 'api-key ""))
-  (define default-model (hash-ref config 'model "gpt-4"))
+  (define default-model (hash-ref config 'model OPENAI-DEFAULT-MODEL))
 
   (define default-max-tokens (hash-ref config 'max-tokens #f))
 

--- a/runtime/model-defaults.rkt
+++ b/runtime/model-defaults.rkt
@@ -1,0 +1,26 @@
+#lang racket/base
+
+;; runtime/model-defaults.rkt — centralised model name / base URL constants
+;;
+;; Q-12: Extracted from individual LLM provider modules so that
+;;       version bumps and model name changes are made in one place.
+
+;; Anthropic
+(provide ANTHROPIC-DEFAULT-MODEL
+         ANTHROPIC-DEFAULT-BASE-URL
+         ;; Gemini
+         GEMINI-DEFAULT-MODEL
+         GEMINI-DEFAULT-BASE-URL
+         ;; OpenAI / Azure OpenAI
+         OPENAI-DEFAULT-MODEL)
+
+;; ── Anthropic ──────────────────────────────────────────────
+(define ANTHROPIC-DEFAULT-MODEL "claude-sonnet-4-20250514")
+(define ANTHROPIC-DEFAULT-BASE-URL "https://api.anthropic.com")
+
+;; ── Google Gemini ──────────────────────────────────────────
+(define GEMINI-DEFAULT-MODEL "gemini-2.5-pro")
+(define GEMINI-DEFAULT-BASE-URL "https://generativelanguage.googleapis.com")
+
+;; ── OpenAI / Azure OpenAI ─────────────────────────────────
+(define OPENAI-DEFAULT-MODEL "gpt-4")

--- a/wiring/rpc-ui-adapter.rkt
+++ b/wiring/rpc-ui-adapter.rkt
@@ -35,7 +35,7 @@
   ;; Store the table where the response handler can find it.
   ;; We attach it as a property on the thread for testability,
   ;; but the response handler receives the same table reference.
-  (hash-set! (get-global-bridge-table) ui-ch pending-requests)
+  (hash-set! (current-bridge-table) ui-ch pending-requests)
   (void (thread (lambda ()
                   (let loop ()
                     (define req (channel-get ui-ch))
@@ -67,10 +67,8 @@
 ;; table for a given UI channel.
 ;; ============================================================
 
-(define global-bridge-table (make-hash))
-
-(define (get-global-bridge-table)
-  global-bridge-table)
+;; Q-21: parameterised bridge table for testability and isolation
+(define current-bridge-table (make-parameter (make-hash)))
 
 ;; ============================================================
 ;; make-rpc-ui-response-handler : channel? -> (hash? -> hash?)
@@ -91,7 +89,7 @@
     (cond
       [(not request-id) (hasheq 'status "error" 'message "requestId required")]
       [else
-       (define pending-table (hash-ref global-bridge-table ui-ch #f))
+       (define pending-table (hash-ref (current-bridge-table) ui-ch #f))
        (define resp-ch (and pending-table (hash-ref pending-table request-id #f)))
        (cond
          [(not resp-ch) (hasheq 'status "error" 'message (format "unknown requestId: ~a" request-id))]


### PR DESCRIPTION
Addresses #1503.

refactor: Wave 2 — model defaults extraction + bridge-table parameter (Q-12, Q-21) (#1503)

Q-12: Extract model default names/URLs to runtime/model-defaults.rkt.
  Anthropic, Gemini, OpenAI, Azure all import from central location.
Q-21: Convert global-bridge-table mutable global to current-bridge-table parameter.
  Enables test isolation and per-session bridge tables.