### PR TITLE
fix: ext-register-tool! arity mismatch in 7 extensions (#1532)

C1 CRITICAL fix: All 7 extensions were calling ext-register-tool!
with (ctx (make-tool ...)) — 2 args. The API requires
(ctx name desc schema handler) — 5 positional args.

Fixed extensions: compact-context, image-input, session-export,
ext-package-manager, remote-collab, q-sync, racket-tooling.

Added hook-dispatch regression tests in test-extension-loader.rkt.
Fixed duplicate the-extension provide conflict in test-phase-e.rkt.

157 tests pass across all affected test files.

Wave 1 of v0.17.5 milestone #88.

### DIFF
--- a/extensions/compact-context.rkt
+++ b/extensions/compact-context.rkt
@@ -28,8 +28,7 @@
 ;; Read a planning artifact if it exists, returns #f otherwise
 (define (read-artifact-if-exists base-dir name)
   (define p (build-path base-dir name))
-  (and (file-exists? p)
-       (call-with-input-file p port->string)))
+  (and (file-exists? p) (call-with-input-file p port->string)))
 
 ;; Gather planning summary from .planning/ directory
 (define (gather-planning-summary [project-dir (current-directory)])
@@ -66,34 +65,40 @@
 
   ;; Build compaction context
   (define context-info
-    (string-append
-     "## Compaction Request\n"
-     "Reason: " reason "\n"
-     (if (non-empty-string? instructions)
-         (format "Instructions: ~a\n" instructions)
-         "")
-     "\n"
-     "## Planning State to Preserve\n"
-     planning-summary))
+    (string-append "## Compaction Request\n"
+                   "Reason: "
+                   reason
+                   "\n"
+                   (if (non-empty-string? instructions)
+                       (format "Instructions: ~a\n" instructions)
+                       "")
+                   "\n"
+                   "## Planning State to Preserve\n"
+                   planning-summary))
 
   ;; Return a result that the runtime can use to trigger compaction
   ;; The agent loop checks for this tool result and initiates compaction
   (make-success-result
-   (list
-    (hasheq 'type "text"
-            'text (string-append
-                   "Compaction triggered.\n\n"
-                   "Planning summary gathered for preservation.\n"
-                   "The agent will compact its context and resume.\n\n"
-                   "## Context Summary\n"
-                   (if (> (string-length planning-summary) 500)
-                       (string-append (substring planning-summary 0 500) "...")
-                       planning-summary)))
-    (hasheq 'type "compaction-trigger"
-            'reason reason
-            'instructions instructions
-            'min_percent min-percent
-            'planning_summary planning-summary))))
+   (list (hasheq 'type
+                 "text"
+                 'text
+                 (string-append "Compaction triggered.\n\n"
+                                "Planning summary gathered for preservation.\n"
+                                "The agent will compact its context and resume.\n\n"
+                                "## Context Summary\n"
+                                (if (> (string-length planning-summary) 500)
+                                    (string-append (substring planning-summary 0 500) "...")
+                                    planning-summary)))
+         (hasheq 'type
+                 "compaction-trigger"
+                 'reason
+                 reason
+                 'instructions
+                 instructions
+                 'min_percent
+                 min-percent
+                 'planning_summary
+                 planning-summary))))
 
 ;; ============================================================
 ;; Extension definition
@@ -102,36 +107,30 @@
 (define (register-compact-tools ctx)
   (ext-register-tool!
    ctx
-   (make-tool
-    "compact-context"
-    (string-append
-     "Trigger context compaction with planning state preservation. "
-     "Reads .planning/ artifacts (PLAN.md, STATE.md, HANDOFF.json, etc.) "
-     "and injects them into the compaction context so the agent "
-     "resumes with full project state awareness.")
-    (hasheq 'type
-            "object"
-            'required
-            '()
-            'properties
-            (hasheq
-             'reason
-             (hasheq 'type "string"
-                     'description "Why compaction is needed")
-             'instructions
-             (hasheq 'type "string"
-                     'description "Extra instructions for post-compaction resume")
-             'min_percent
-             (hasheq 'type "integer"
-                     'description "Min context % to trigger (default 0 = always)")
-             'project_dir
-             (hasheq 'type "string"
-                     'description "Project root directory (default: cwd)")))
-    handle-compact-context))
+   "compact-context"
+   (string-append "Trigger context compaction with planning state preservation. "
+                  "Reads .planning/ artifacts (PLAN.md, STATE.md, HANDOFF.json, etc.) "
+                  "and injects them into the compaction context so the agent "
+                  "resumes with full project state awareness.")
+   (hasheq
+    'type
+    "object"
+    'required
+    '()
+    'properties
+    (hasheq 'reason
+            (hasheq 'type "string" 'description "Why compaction is needed")
+            'instructions
+            (hasheq 'type "string" 'description "Extra instructions for post-compaction resume")
+            'min_percent
+            (hasheq 'type "integer" 'description "Min context % to trigger (default 0 = always)")
+            'project_dir
+            (hasheq 'type "string" 'description "Project root directory (default: cwd)")))
+   handle-compact-context)
   (hook-pass ctx))
 
 (define-q-extension compact-context-extension
-  #:version "1.0.0"
-  #:api-version "1"
-  #:on register-tools
-  register-compact-tools)
+                    #:version "1.0.0"
+                    #:api-version "1"
+                    #:on register-tools
+                    register-compact-tools)

--- a/extensions/ext-package-manager.rkt
+++ b/extensions/ext-package-manager.rkt
@@ -19,11 +19,10 @@
          handle-ext-pkg)
 
 (define (format-pkg-list pkgs)
-  (string-join
-   (for/list ([p pkgs])
-     (define m (qpm-package-manifest p))
-     (format "- ~a (~a)" (qpm-manifest-name m) (qpm-manifest-version m)))
-   "\n"))
+  (string-join (for/list ([p pkgs])
+                 (define m (qpm-package-manifest p))
+                 (format "- ~a (~a)" (qpm-manifest-name m) (qpm-manifest-version m)))
+               "\n"))
 
 (define (handle-ext-pkg args [exec-ctx #f])
   (define action (hash-ref args 'action "list"))
@@ -31,9 +30,10 @@
   (cond
     [(string=? action "list")
      (define pkgs (list-packages))
-     (define text (if (null? pkgs)
-                      "No packages installed."
-                      (format-pkg-list pkgs)))
+     (define text
+       (if (null? pkgs)
+           "No packages installed."
+           (format-pkg-list pkgs)))
      (make-success-result (list (hasheq 'type "text" 'text text)))]
     [(string=? action "info")
      (define name (hash-ref args 'name ""))
@@ -45,46 +45,42 @@
      (define path (hash-ref args 'path ""))
      (define result (install-package-from-dir path))
      (if (qpm-package? result)
-         (make-success-result
-          (list (hasheq 'type
-                        "text"
-                        'text
-                        (format "Installed ~a (~a)"
-                                (qpm-manifest-name (qpm-package-manifest result))
-                                (qpm-manifest-version (qpm-package-manifest result))))))
+         (make-success-result (list (hasheq 'type
+                                            "text"
+                                            'text
+                                            (format "Installed ~a (~a)"
+                                                    (qpm-manifest-name (qpm-package-manifest result))
+                                                    (qpm-manifest-version
+                                                     (qpm-package-manifest result))))))
          (make-error-result (format "Install failed: ~a" result)))]
     [(string=? action "remove")
      (define name (hash-ref args 'name ""))
      (if (remove-package name)
-         (make-success-result
-          (list (hasheq 'type "text" 'text (format "Removed ~a." name))))
+         (make-success-result (list (hasheq 'type "text" 'text (format "Removed ~a." name))))
          (make-error-result (format "Failed to remove ~a." name)))]
-    [else
-     (make-error-result (format "Unknown action: ~a" action))]))
+    [else (make-error-result (format "Unknown action: ~a" action))]))
 
 (define (register-ext-pkg-tools ctx)
   (ext-register-tool!
    ctx
-   (make-tool
-    "ext-package"
-    (string-append "Extension package manager. "
-                   "Actions: list, install (from path), remove, info.")
-    (hasheq 'type
-            "object"
-            'required
-            '("action")
-            'properties
-            (hasheq 'action
-                    (hasheq 'type "string" 'description "list|install|remove|info")
-                    'name
-                    (hasheq 'type "string" 'description "Package name (for info/remove)")
-                    'path
-                    (hasheq 'type "string" 'description "Local path (for install)")))
-    handle-ext-pkg))
+   "ext-package"
+   (string-append "Extension package manager. " "Actions: list, install (from path), remove, info.")
+   (hasheq 'type
+           "object"
+           'required
+           '("action")
+           'properties
+           (hasheq 'action
+                   (hasheq 'type "string" 'description "list|install|remove|info")
+                   'name
+                   (hasheq 'type "string" 'description "Package name (for info/remove)")
+                   'path
+                   (hasheq 'type "string" 'description "Local path (for install)")))
+   handle-ext-pkg)
   (hook-pass ctx))
 
 (define-q-extension ext-package-manager-extension
-  #:version "1.0.0"
-  #:api-version "1"
-  #:on register-tools
-  register-ext-pkg-tools)
+                    #:version "1.0.0"
+                    #:api-version "1"
+                    #:on register-tools
+                    register-ext-pkg-tools)

--- a/extensions/image-input.rkt
+++ b/extensions/image-input.rkt
@@ -15,7 +15,8 @@
          "hooks.rkt"
          "../tools/tool.rkt")
 
-(provide image-input-extension
+(provide the-extension
+         image-input-extension
          handle-image-input
          image->base64
          extension->media-type
@@ -37,14 +38,13 @@
 (define (make-image-message text image-path)
   (define b64 (image->base64 image-path))
   (define mt (extension->media-type image-path))
-  (hasheq 'type
-          "multi-modal"
-          'content
-          (list (hasheq 'type "text" 'text text)
-                (hasheq 'type
-                        "image_url"
-                        'image_url
-                        (hasheq 'url (string-append "data:" mt ";base64," b64))))))
+  (hasheq
+   'type
+   "multi-modal"
+   'content
+   (list
+    (hasheq 'type "text" 'text text)
+    (hasheq 'type "image_url" 'image_url (hasheq 'url (string-append "data:" mt ";base64," b64))))))
 
 (define (handle-image-input args [exec-ctx #f])
   (define action (hash-ref args 'action "encode"))
@@ -56,14 +56,13 @@
      (unless (file-exists? path)
        (error 'image-input (format "File not found: ~a" path)))
      (define b64 (image->base64 path))
-     (make-success-result
-      (list (hasheq 'type
-                    "text"
-                    'text
-                    (format "Encoded ~a (~a, ~a chars base64)"
-                            path
-                            (extension->media-type path)
-                            (string-length b64)))))]
+     (make-success-result (list (hasheq 'type
+                                        "text"
+                                        'text
+                                        (format "Encoded ~a (~a, ~a chars base64)"
+                                                path
+                                                (extension->media-type path)
+                                                (string-length b64)))))]
     [(string=? action "message")
      (define text (hash-ref args 'text ""))
      (define path (hash-ref args 'path ""))
@@ -71,39 +70,34 @@
        (error 'image-input "path is required for message"))
      (define msg (make-image-message text path))
      (make-success-result
-      (list (hasheq 'type
-                    "text"
-                    'text
-                    (format "Multi-modal message created with image ~a" path))
+      (list (hasheq 'type "text" 'text (format "Multi-modal message created with image ~a" path))
             msg))]
-    [else
-     (make-error-result (format "Unknown action: ~a" action))]))
+    [else (make-error-result (format "Unknown action: ~a" action))]))
 
 (define (register-image-tools ctx)
-  (ext-register-tool!
-   ctx
-   (make-tool
-    "image-input"
-    (string-append
-     "Multi-modal image input. "
-     "Actions: encode (base64), message (multi-modal). "
-     "PNG, JPEG, GIF, WebP.")
-    (hasheq 'type
-            "object"
-            'required
-            '("action" "path")
-            'properties
-            (hasheq 'action
-                    (hasheq 'type "string" 'description "encode|message")
-                    'path
-                    (hasheq 'type "string" 'description "Image file path")
-                    'text
-                    (hasheq 'type "string" 'description "Text for message")))
-    handle-image-input))
+  (ext-register-tool! ctx
+                      "image-input"
+                      (string-append "Multi-modal image input. "
+                                     "Actions: encode (base64), message (multi-modal). "
+                                     "PNG, JPEG, GIF, WebP.")
+                      (hasheq 'type
+                              "object"
+                              'required
+                              '("action" "path")
+                              'properties
+                              (hasheq 'action
+                                      (hasheq 'type "string" 'description "encode|message")
+                                      'path
+                                      (hasheq 'type "string" 'description "Image file path")
+                                      'text
+                                      (hasheq 'type "string" 'description "Text for message")))
+                      handle-image-input)
   (hook-pass ctx))
 
 (define-q-extension image-input-extension
-  #:version "1.0.0"
-  #:api-version "1"
-  #:on register-tools
-  register-image-tools)
+                    #:version "1.0.0"
+                    #:api-version "1"
+                    #:on register-tools
+                    register-image-tools)
+
+(define the-extension image-input-extension)

--- a/extensions/q-sync.rkt
+++ b/extensions/q-sync.rkt
@@ -15,7 +15,8 @@
          "hooks.rkt"
          "../tools/tool.rkt")
 
-(provide q-sync-extension
+(provide the-extension
+         q-sync-extension
          handle-q-sync
          sync-planning
          sync-pi-config
@@ -53,14 +54,8 @@
   (define remote-path (string-append remote-host ":~/src/q-agent/.planning/"))
   (define-values (ec out err)
     (case (string->symbol direction)
-      [(push) (run-cmd "rsync"
-                       (list "-avz" "--delete"
-                             (path->string planning-dir) "/"
-                             remote-path))]
-      [(pull) (run-cmd "rsync"
-                       (list "-avz" "--delete"
-                             remote-path
-                             (path->string planning-dir) "/"))]
+      [(push) (run-cmd "rsync" (list "-avz" "--delete" (path->string planning-dir) "/" remote-path))]
+      [(pull) (run-cmd "rsync" (list "-avz" "--delete" remote-path (path->string planning-dir) "/"))]
       [else (values 1 "" (format "Unknown direction: ~a" direction))]))
   (values ec (string-trim out) (string-trim err)))
 
@@ -70,11 +65,8 @@
   (define remote-path (string-append remote-host ":~/src/q-agent/.pi/"))
   (define-values (ec out err)
     (case (string->symbol direction)
-      [(push) (run-cmd "rsync"
-                       (list "-avz" (path->string pi-dir) "/" remote-path))]
-      [(pull) (run-cmd "rsync"
-                       (list "-avz" remote-path
-                             (path->string pi-dir) "/"))]
+      [(push) (run-cmd "rsync" (list "-avz" (path->string pi-dir) "/" remote-path))]
+      [(pull) (run-cmd "rsync" (list "-avz" remote-path (path->string pi-dir) "/"))]
       [else (values 1 "" (format "Unknown direction: ~a" direction))]))
   (values ec (string-trim out) (string-trim err)))
 
@@ -84,11 +76,8 @@
   (define remote-path (string-append remote-host ":~/src/q-agent/scripts/"))
   (define-values (ec out err)
     (case (string->symbol direction)
-      [(push) (run-cmd "rsync"
-                       (list "-avz" (path->string scripts-dir) "/" remote-path))]
-      [(pull) (run-cmd "rsync"
-                       (list "-avz" remote-path
-                             (path->string scripts-dir) "/"))]
+      [(push) (run-cmd "rsync" (list "-avz" (path->string scripts-dir) "/" remote-path))]
+      [(pull) (run-cmd "rsync" (list "-avz" remote-path (path->string scripts-dir) "/"))]
       [else (values 1 "" (format "Unknown direction: ~a" direction))]))
   (values ec (string-trim out) (string-trim err)))
 
@@ -117,12 +106,10 @@
                   "✗ .pi/ missing locally")
               parts))
   ;; Check git status
-  (define-values (git-ec git-out _)
-    (run-cmd "git" '("status" "--short")))
+  (define-values (git-ec git-out _) (run-cmd "git" '("status" "--short")))
   (set! parts
         (cons (if (non-empty-string? (string-trim git-out))
-                  (format "⚠ git: uncommitted changes\n~a"
-                          (string-trim git-out))
+                  (format "⚠ git: uncommitted changes\n~a" (string-trim git-out))
                   "✓ git: clean")
               parts))
   (string-join (reverse parts) "\n"))
@@ -142,38 +129,27 @@
   (case (string->symbol direction)
     [(status)
      (define status-text (sync-status remote-host local-dir))
-     (make-success-result
-      (list (hasheq 'type "text"
-                    'text (format "Sync Status:\n~a" status-text))))]
+     (make-success-result (list (hasheq 'type "text" 'text (format "Sync Status:\n~a" status-text))))]
     [(push pull)
      ;; Sync requested domains
      (when (member domain '("planning" "all"))
-       (define-values (ec out err)
-         (sync-planning remote-host local-dir direction))
-       (set! results
-             (cons (format "planning: ~a" (if (zero? ec) "OK" err)) results)))
+       (define-values (ec out err) (sync-planning remote-host local-dir direction))
+       (set! results (cons (format "planning: ~a" (if (zero? ec) "OK" err)) results)))
      (when (member domain '("pi" "config" "all"))
-       (define-values (ec out err)
-         (sync-pi-config remote-host local-dir direction))
-       (set! results
-             (cons (format "pi-config: ~a" (if (zero? ec) "OK" err)) results)))
+       (define-values (ec out err) (sync-pi-config remote-host local-dir direction))
+       (set! results (cons (format "pi-config: ~a" (if (zero? ec) "OK" err)) results)))
      (when (member domain '("scripts" "all"))
-       (define-values (ec out err)
-         (sync-scripts remote-host local-dir direction))
-       (set! results
-             (cons (format "scripts: ~a" (if (zero? ec) "OK" err)) results)))
+       (define-values (ec out err) (sync-scripts remote-host local-dir direction))
+       (set! results (cons (format "scripts: ~a" (if (zero? ec) "OK" err)) results)))
      (when (member domain '("git" "all"))
        (define-values (ec out err) (sync-git local-dir direction))
-       (set! results
-             (cons (format "git: ~a" (if (zero? ec) "OK" err)) results)))
+       (set! results (cons (format "git: ~a" (if (zero? ec) "OK" err)) results)))
      (make-success-result
-      (list (hasheq 'type
-                     "text"
-                     'text
-                     (format "Sync ~a (~a):\n~a"
-                             direction
-                             domain
-                             (string-join (reverse results) "\n")))))]
+      (list (hasheq
+             'type
+             "text"
+             'text
+             (format "Sync ~a (~a):\n~a" direction domain (string-join (reverse results) "\n")))))]
     [(handoff)
      ;; Push everything then update HANDOFF.json
      (for ([d '("planning" "pi" "scripts" "git")])
@@ -183,16 +159,13 @@
            [(pi) (sync-pi-config remote-host local-dir "push")]
            [(scripts) (sync-scripts remote-host local-dir "push")]
            [(git) (sync-git local-dir "push")]))
-       (set! results
-             (cons (format "~a: ~a" d (if (zero? ec) "OK" err)) results)))
-     (make-success-result
-      (list (hasheq 'type
-                     "text"
-                     'text
-                     (format "Handoff complete:\n~a"
-                             (string-join (reverse results) "\n")))))]
-    [else
-     (make-error-result (format "Unknown direction: ~a" direction))]))
+       (set! results (cons (format "~a: ~a" d (if (zero? ec) "OK" err)) results)))
+     (make-success-result (list (hasheq 'type
+                                        "text"
+                                        'text
+                                        (format "Handoff complete:\n~a"
+                                                (string-join (reverse results) "\n")))))]
+    [else (make-error-result (format "Unknown direction: ~a" direction))]))
 
 ;; ============================================================
 ;; Extension definition
@@ -201,35 +174,31 @@
 (define (register-sync-tools ctx)
   (ext-register-tool!
    ctx
-   (make-tool
-    "q-sync"
-    (string-append
-     "Sync project state between local and remote machines. "
-     "Domains: planning, pi, scripts, git, all. "
-     "Directions: push, pull, status, handoff. "
-     "Uses rsync for file sync, git for version control.")
-    (hasheq 'type
-            "object"
-            'required
-            '()
-            'properties
-            (hasheq 'direction
-                    (hasheq 'type "string"
-                            'description "push|pull|status|handoff (default: status)")
-                    'domain
-                    (hasheq 'type "string"
-                            'description "planning|pi|scripts|git|all (default: all)")
-                    'remote_host
-                    (hasheq 'type "string"
-                            'description "SSH remote host (default: from config)")
-                    'project_dir
-                    (hasheq 'type "string"
-                            'description "Project root directory (default: cwd)")))
-    handle-q-sync))
+   "q-sync"
+   (string-append "Sync project state between local and remote machines. "
+                  "Domains: planning, pi, scripts, git, all. "
+                  "Directions: push, pull, status, handoff. "
+                  "Uses rsync for file sync, git for version control.")
+   (hasheq 'type
+           "object"
+           'required
+           '()
+           'properties
+           (hasheq 'direction
+                   (hasheq 'type "string" 'description "push|pull|status|handoff (default: status)")
+                   'domain
+                   (hasheq 'type "string" 'description "planning|pi|scripts|git|all (default: all)")
+                   'remote_host
+                   (hasheq 'type "string" 'description "SSH remote host (default: from config)")
+                   'project_dir
+                   (hasheq 'type "string" 'description "Project root directory (default: cwd)")))
+   handle-q-sync)
   (hook-pass ctx))
 
 (define-q-extension q-sync-extension
-  #:version "1.0.0"
-  #:api-version "1"
-  #:on register-tools
-  register-sync-tools)
+                    #:version "1.0.0"
+                    #:api-version "1"
+                    #:on register-tools
+                    register-sync-tools)
+
+(define the-extension q-sync-extension)

--- a/extensions/racket-tooling.rkt
+++ b/extensions/racket-tooling.rkt
@@ -20,7 +20,8 @@
          "hooks.rkt"
          "../tools/tool.rkt")
 
-(provide racket-tooling-extension
+(provide the-extension
+         racket-tooling-extension
          handle-racket-check
          handle-racket-edit
          handle-racket-codemod
@@ -752,93 +753,95 @@
 (define (register-racket-tools ctx)
   (ext-register-tool!
    ctx
-   (make-tool
-    "racket-check"
-    (string-append "Run Racket validation on a file. "
-                   "Modes: format (raco fmt), syntax/compile (raco make), "
-                   "test (raco test), expand (raco expand), all. "
-                   "Default: syntax.")
-    (hasheq
-     'type
-     "object"
-     'required
-     '("path")
-     'properties
-     (hasheq 'path
-             (hasheq 'type "string" 'description "Path to .rkt file")
-             'mode
-             (hasheq 'type "string" 'description "Check mode: format, syntax, test, expand, all")))
-    handle-racket-check)
-   (make-tool
-    "racket-edit"
-    (string-append "Structural s-expression editing for Racket files. "
-                   "Modes: replace (exact text), form (pattern/template), "
-                   "skeleton (new file), struct-add-field, provide-append, "
-                   "cond-insert-clause, match-insert-clause, rewrite-form. "
-                   "Validates with raco fmt + raco make after edit, reverts on failure.")
-    (hasheq 'type
-            "object"
-            'required
-            '("file")
-            'properties
-            (hasheq 'file
-                    (hasheq 'type "string" 'description "Path to .rkt file")
-                    'mode
-                    (hasheq 'type "string" 'description "Edit mode")
-                    'oldText
-                    (hasheq 'type "string" 'description "Text to find (replace mode)")
-                    'newText
-                    (hasheq 'type "string" 'description "Replacement text")
-                    'pattern
-                    (hasheq 'type "string" 'description "S-expression pattern (form mode)")
-                    'template
-                    (hasheq 'type "string" 'description "S-expression template (form mode)")
-                    'startLine
-                    (hasheq 'type "integer" 'description "Start line (rewrite-form)")
-                    'endLine
-                    (hasheq 'type "integer" 'description "End line (rewrite-form)")
-                    'content
-                    (hasheq 'type "string" 'description "New content (rewrite-form, skeleton)")
-                    'structName
-                    (hasheq 'type "string" 'description "Struct name (struct-add-field)")
-                    'fieldName
-                    (hasheq 'type "string" 'description "Field name (struct-add-field)")
-                    'ids
-                    (hasheq 'type "string" 'description "Comma-separated IDs (provide-append)")
-                    'clause
-                    (hasheq 'type "string" 'description "Clause to insert (cond/match-insert)")
-                    'anchorClause
-                    (hasheq 'type "string" 'description "Anchor clause text")
-                    'insertPosition
-                    (hasheq 'type "string" 'description "before or after")
-                    'lang
-                    (hasheq 'type "string" 'description "Language for skeleton")
-                    'requires
-                    (hasheq 'type "string" 'description "Comma-separated requires (skeleton)")
-                    'provides
-                    (hasheq 'type "string" 'description "Comma-separated provides (skeleton)")
-                    'signatures
-                    (hasheq 'type "string" 'description "Newline-separated signatures (skeleton)")))
-    handle-racket-edit)
-   (make-tool "racket-codemod"
-              (string-append "Pattern/template codemod for Racket files. "
-                             "Uses bar-quoted @@PLACEHOLDER atoms to match any subtree. "
-                             "Dry run by default; set write=true to apply. "
-                             "Validates with raco fmt + raco make, reverts on failure.")
-              (hasheq 'type
-                      "object"
-                      'required
-                      '("file" "pattern" "template")
-                      'properties
-                      (hasheq 'file
-                              (hasheq 'type "string" 'description "Path to .rkt file")
-                              'pattern
-                              (hasheq 'type "string" 'description "Pattern with @@PLACEHOLDER atoms")
-                              'template
-                              (hasheq 'type "string" 'description "Replacement template")
-                              'write
-                              (hasheq 'type "boolean" 'description "Apply changes (default: false)")))
-              handle-racket-codemod))
+   "racket-check"
+   (string-append "Run Racket validation on a file. "
+                  "Modes: format (raco fmt), syntax/compile (raco make), "
+                  "test (raco test), expand (raco expand), all. "
+                  "Default: syntax.")
+   (hasheq
+    'type
+    "object"
+    'required
+    '("path")
+    'properties
+    (hasheq 'path
+            (hasheq 'type "string" 'description "Path to .rkt file")
+            'mode
+            (hasheq 'type "string" 'description "Check mode: format, syntax, test, expand, all")))
+   handle-racket-check)
+  (ext-register-tool!
+   ctx
+   "racket-edit"
+   (string-append "Structural s-expression editing for Racket files. "
+                  "Modes: replace (exact text), form (pattern/template), "
+                  "skeleton (new file), struct-add-field, provide-append, "
+                  "cond-insert-clause, match-insert-clause, rewrite-form. "
+                  "Validates with raco fmt + raco make after edit, reverts on failure.")
+   (hasheq 'type
+           "object"
+           'required
+           '("file")
+           'properties
+           (hasheq 'file
+                   (hasheq 'type "string" 'description "Path to .rkt file")
+                   'mode
+                   (hasheq 'type "string" 'description "Edit mode")
+                   'oldText
+                   (hasheq 'type "string" 'description "Text to find (replace mode)")
+                   'newText
+                   (hasheq 'type "string" 'description "Replacement text")
+                   'pattern
+                   (hasheq 'type "string" 'description "S-expression pattern (form mode)")
+                   'template
+                   (hasheq 'type "string" 'description "S-expression template (form mode)")
+                   'startLine
+                   (hasheq 'type "integer" 'description "Start line (rewrite-form)")
+                   'endLine
+                   (hasheq 'type "integer" 'description "End line (rewrite-form)")
+                   'content
+                   (hasheq 'type "string" 'description "New content (rewrite-form, skeleton)")
+                   'structName
+                   (hasheq 'type "string" 'description "Struct name (struct-add-field)")
+                   'fieldName
+                   (hasheq 'type "string" 'description "Field name (struct-add-field)")
+                   'ids
+                   (hasheq 'type "string" 'description "Comma-separated IDs (provide-append)")
+                   'clause
+                   (hasheq 'type "string" 'description "Clause to insert (cond/match-insert)")
+                   'anchorClause
+                   (hasheq 'type "string" 'description "Anchor clause text")
+                   'insertPosition
+                   (hasheq 'type "string" 'description "before or after")
+                   'lang
+                   (hasheq 'type "string" 'description "Language for skeleton")
+                   'requires
+                   (hasheq 'type "string" 'description "Comma-separated requires (skeleton)")
+                   'provides
+                   (hasheq 'type "string" 'description "Comma-separated provides (skeleton)")
+                   'signatures
+                   (hasheq 'type "string" 'description "Newline-separated signatures (skeleton)")))
+   handle-racket-edit)
+  (ext-register-tool!
+   ctx
+   "racket-codemod"
+   (string-append "Pattern/template codemod for Racket files. "
+                  "Uses bar-quoted @@PLACEHOLDER atoms to match any subtree. "
+                  "Dry run by default; set write=true to apply. "
+                  "Validates with raco fmt + raco make, reverts on failure.")
+   (hasheq 'type
+           "object"
+           'required
+           '("file" "pattern" "template")
+           'properties
+           (hasheq 'file
+                   (hasheq 'type "string" 'description "Path to .rkt file")
+                   'pattern
+                   (hasheq 'type "string" 'description "Pattern with @@PLACEHOLDER atoms")
+                   'template
+                   (hasheq 'type "string" 'description "Replacement template")
+                   'write
+                   (hasheq 'type "boolean" 'description "Apply changes (default: false)")))
+   handle-racket-codemod)
   (hook-pass ctx))
 
 (define (register-racket-commands ctx)
@@ -854,3 +857,5 @@
                     register-racket-tools
                     #:on register-shortcuts
                     register-racket-commands)
+
+(define the-extension racket-tooling-extension)

--- a/extensions/remote-collab/remote-collab.rkt
+++ b/extensions/remote-collab/remote-collab.rkt
@@ -34,9 +34,10 @@
      (define model (hash-ref args 'model ""))
      (define thinking (hash-ref args 'thinking "medium"))
      (define base-cmd "pi")
-     (define cmd (if (non-empty-string? model)
-                     (format "~a --model ~a --thinking ~a" base-cmd model thinking)
-                     base-cmd))
+     (define cmd
+       (if (non-empty-string? model)
+           (format "~a --model ~a --thinking ~a" base-cmd model thinking)
+           base-cmd))
      (format "tmux new-session -d -s ~a -c ~a '~a'" session cwd cmd)]
     [(send)
      (define prompt (hash-ref args 'prompt ""))
@@ -49,11 +50,12 @@
     [(wait)
      ;; Wait for prompt to appear (simple: sleep + check for prompt marker)
      (define timeout (hash-ref args 'timeout 60))
-     (format "for i in $(seq 1 ~a); do tmux capture-pane -t ~a -p | tail -5 | grep -q '> ' && exit 0; sleep 2; done; echo 'timeout'" timeout session)]
-    [(interrupt)
-     (format "tmux send-keys -t ~a Escape" session)]
-    [(stop)
-     (format "tmux kill-session -t ~a 2>/dev/null; echo 'stopped'" session)]
+     (format
+      "for i in $(seq 1 ~a); do tmux capture-pane -t ~a -p | tail -5 | grep -q '> ' && exit 0; sleep 2; done; echo 'timeout'"
+      timeout
+      session)]
+    [(interrupt) (format "tmux send-keys -t ~a Escape" session)]
+    [(stop) (format "tmux kill-session -t ~a 2>/dev/null; echo 'stopped'" session)]
     [else (error 'remote-q "unknown action: ~a" action)]))
 
 ;; ============================================================
@@ -77,16 +79,13 @@
     (ssh-execute host cmd #:options (append (default-ssh-options) opts)))
 
   (if (zero? ec)
-      (make-success-result
-       (list (hasheq 'type "text"
-                     'text (string-trim stdout))))
-      (make-error-result
-       (format "remote-q error (exit ~a): ~a~a"
-               ec
-               (string-trim stdout)
-               (if (non-empty-string? (string-trim stderr))
-                   (format "\n~a" (string-trim stderr))
-                   "")))))
+      (make-success-result (list (hasheq 'type "text" 'text (string-trim stdout))))
+      (make-error-result (format "remote-q error (exit ~a): ~a~a"
+                                 ec
+                                 (string-trim stdout)
+                                 (if (non-empty-string? (string-trim stderr))
+                                     (format "\n~a" (string-trim stderr))
+                                     "")))))
 
 ;; ============================================================
 ;; Extension definition
@@ -95,46 +94,44 @@
 (define (register-remote-tools ctx)
   (ext-register-tool!
    ctx
-   (make-tool
-    "remote-q"
-    (string-append
-     "Control a remote q agent instance via SSH + tmux. "
-     "Actions: status (check session), start (new session), "
-     "send (send prompt), capture (read output), "
-     "wait (wait for idle), interrupt (stop task), stop (kill session).")
-    (hasheq 'type
-            "object"
-            'required
-            '("host" "action")
-            'properties
-            (hasheq 'host
-                    (hasheq 'type "string" 'description "SSH host (user@host)")
-                    'action
-                    (hasheq 'type "string"
-                            'description "status|start|send|capture|wait|interrupt|stop")
-                    'session
-                    (hasheq 'type "string" 'description "Tmux session name (default: q-agent)")
-                    'prompt
-                    (hasheq 'type "string" 'description "Prompt text (for send)")
-                    'lines
-                    (hasheq 'type "integer" 'description "Lines to capture (default: 80)")
-                    'cwd
-                    (hasheq 'type "string" 'description "Working directory (for start)")
-                    'provider
-                    (hasheq 'type "string" 'description "Pi provider")
-                    'model
-                    (hasheq 'type "string" 'description "Pi model")
-                    'thinking
-                    (hasheq 'type "string" 'description "Thinking level")
-                    'timeout
-                    (hasheq 'type "integer" 'description "Wait timeout seconds (default: 60)")
-                    'ssh_options
-                    (hasheq 'type "array" 'description "Extra SSH options")))
-    handle-remote-q))
+   "remote-q"
+   (string-append "Control a remote q agent instance via SSH + tmux. "
+                  "Actions: status (check session), start (new session), "
+                  "send (send prompt), capture (read output), "
+                  "wait (wait for idle), interrupt (stop task), stop (kill session).")
+   (hasheq
+    'type
+    "object"
+    'required
+    '("host" "action")
+    'properties
+    (hasheq 'host
+            (hasheq 'type "string" 'description "SSH host (user@host)")
+            'action
+            (hasheq 'type "string" 'description "status|start|send|capture|wait|interrupt|stop")
+            'session
+            (hasheq 'type "string" 'description "Tmux session name (default: q-agent)")
+            'prompt
+            (hasheq 'type "string" 'description "Prompt text (for send)")
+            'lines
+            (hasheq 'type "integer" 'description "Lines to capture (default: 80)")
+            'cwd
+            (hasheq 'type "string" 'description "Working directory (for start)")
+            'provider
+            (hasheq 'type "string" 'description "Pi provider")
+            'model
+            (hasheq 'type "string" 'description "Pi model")
+            'thinking
+            (hasheq 'type "string" 'description "Thinking level")
+            'timeout
+            (hasheq 'type "integer" 'description "Wait timeout seconds (default: 60)")
+            'ssh_options
+            (hasheq 'type "array" 'description "Extra SSH options")))
+   handle-remote-q)
   (hook-pass ctx))
 
 (define-q-extension the-extension
-  #:version "1.0.0"
-  #:api-version "1"
-  #:on register-tools
-  register-remote-tools)
+                    #:version "1.0.0"
+                    #:api-version "1"
+                    #:on register-tools
+                    register-remote-tools)

--- a/extensions/session-export.rkt
+++ b/extensions/session-export.rkt
@@ -12,7 +12,8 @@
          "hooks.rkt"
          "../tools/tool.rkt")
 
-(provide session-export-extension
+(provide the-extension
+         session-export-extension
          handle-session-export)
 
 (define (read-session-lines path)
@@ -29,10 +30,7 @@
   (with-handlers ([exn:fail? (lambda (e) (format "<pre>~a</pre>" line))])
     (define obj (string->jsexpr line))
     (define role (hash-ref obj 'role "unknown"))
-    (format "<div class=\"~a\"><h4>~a</h4><pre>~a</pre></div>"
-            role
-            role
-            (hash-ref obj 'content ""))))
+    (format "<div class=\"~a\"><h4>~a</h4><pre>~a</pre></div>" role role (hash-ref obj 'content ""))))
 
 (define (handle-session-export args [exec-ctx #f])
   (define path (hash-ref args 'session_path ""))
@@ -52,49 +50,43 @@
                       (string-join (map entry->html lines) "\n")
                       "</body></html>")]
       [(string=? fmt "json")
-       (jsexpr->string
-        (for/list ([l lines])
-          (with-handlers ([exn:fail? (lambda (e) (hasheq 'raw l))])
-            (string->jsexpr l))))]
+       (jsexpr->string (for/list ([l lines])
+                         (with-handlers ([exn:fail? (lambda (e) (hasheq 'raw l))])
+                           (string->jsexpr l))))]
       [else
-       (string-join
-        (for/list ([l lines] [i (in-naturals 1)])
-          (entry->markdown l i))
-        "\n")]))
+       (string-join (for/list ([l lines]
+                               [i (in-naturals 1)])
+                      (entry->markdown l i))
+                    "\n")]))
 
   (cond
     [(non-empty-string? output)
-     (call-with-output-file output
-       (lambda (out) (display result out))
-       #:exists 'replace)
-     (make-success-result
-      (list (hasheq 'type "text" 'text (format "Exported to ~a" output))))]
-    [else
-     (make-success-result
-      (list (hasheq 'type "text" 'text result)))]))
+     (call-with-output-file output (lambda (out) (display result out)) #:exists 'replace)
+     (make-success-result (list (hasheq 'type "text" 'text (format "Exported to ~a" output))))]
+    [else (make-success-result (list (hasheq 'type "text" 'text result)))]))
 
 (define (register-export-tools ctx)
-  (ext-register-tool!
-   ctx
-   (make-tool
-    "session-export"
-    "Export session logs to HTML, JSON, or Markdown."
-    (hasheq 'type
-            "object"
-            'required
-            '("session_path")
-            'properties
-            (hasheq 'session_path
-                    (hasheq 'type "string" 'description "Session JSONL file path")
-                    'format
-                    (hasheq 'type "string" 'description "html|json|markdown")
-                    'output_path
-                    (hasheq 'type "string" 'description "Output file path")))
-    handle-session-export))
+  (ext-register-tool! ctx
+                      "session-export"
+                      "Export session logs to HTML, JSON, or Markdown."
+                      (hasheq 'type
+                              "object"
+                              'required
+                              '("session_path")
+                              'properties
+                              (hasheq 'session_path
+                                      (hasheq 'type "string" 'description "Session JSONL file path")
+                                      'format
+                                      (hasheq 'type "string" 'description "html|json|markdown")
+                                      'output_path
+                                      (hasheq 'type "string" 'description "Output file path")))
+                      handle-session-export)
   (hook-pass ctx))
 
 (define-q-extension session-export-extension
-  #:version "1.0.0"
-  #:api-version "1"
-  #:on register-tools
-  register-export-tools)
+                    #:version "1.0.0"
+                    #:api-version "1"
+                    #:on register-tools
+                    register-export-tools)
+
+(define the-extension session-export-extension)

--- a/tests/test-extension-loader.rkt
+++ b/tests/test-extension-loader.rkt
@@ -132,12 +132,11 @@
   (call-with-output-file
    mod-file
    (λ (out)
-           (displayln "#lang racket/base" out)
-           (displayln "(provide the-extension)" out)
-           (displayln (format "(require (file \"~a\"))" api-abs-path) out)
-           (displayln (format "(define the-extension (extension \"~a\" \"1.0\" \"1\" (hasheq)))"
-                              ext-name)
-                      out))
+     (displayln "#lang racket/base" out)
+     (displayln "(provide the-extension)" out)
+     (displayln (format "(require (file \"~a\"))" api-abs-path) out)
+     (displayln (format "(define the-extension (extension \"~a\" \"1.0\" \"1\" (hasheq)))" ext-name)
+                out))
    #:exists 'replace)
   mod-file)
 
@@ -172,3 +171,48 @@
   (define exts (discover-extensions tmpdir))
   (check-equal? exts '())
   (delete-directory/files tmpdir))
+
+;; ============================================================
+;; Hook dispatch regression tests (Wave 1 — C1 fix)
+;; Verifies ext-register-tool! arity is correct (5 args, not 2).
+;; If extensions pass (make-tool ...) instead of (name desc schema handler),
+;; this test catches the arity mismatch.
+;; ============================================================
+
+(require "../extensions/dynamic-tools.rkt"
+         "../extensions/context.rkt"
+         "../extensions/api.rkt"
+         "../agent/event-bus.rkt"
+         "../tools/tool.rkt")
+
+(define (make-test-ctx)
+  (define reg (make-tool-registry))
+  (define ext-reg (make-extension-registry))
+  (define bus (make-event-bus))
+  (make-extension-ctx #:session-id "test-session"
+                      #:session-dir (find-system-path 'temp-dir)
+                      #:event-bus bus
+                      #:extension-registry ext-reg
+                      #:tool-registry reg))
+
+(test-case "ext-register-tool! accepts 5 positional args (ctx name desc schema handler)"
+  (define ctx (make-test-ctx))
+  (define reg (ctx-tool-registry ctx))
+  (ext-register-tool! ctx
+                      "test-tool"
+                      "A test tool for arity regression"
+                      (hasheq 'type "object" 'required '() 'properties (hasheq))
+                      (λ (args) (make-tool-result '() (hasheq) #f)))
+  (check-not-exn (λ () (lookup-tool reg "test-tool"))))
+
+(test-case "ext-register-tool! rejects make-tool wrapper (2-arg form)"
+  ;; This documents the bug pattern: passing (make-tool ...) as 2nd arg
+  ;; should fail because ext-register-tool! expects a string as 2nd arg.
+  (define ctx (make-test-ctx))
+  (check-exn exn:fail?
+             (λ ()
+               (ext-register-tool! ctx
+                                   (make-tool "bad"
+                                              "desc"
+                                              (hasheq 'type "object")
+                                              (λ (args) (make-tool-result '() (hasheq) #f)))))))

--- a/tests/test-phase-e.rkt
+++ b/tests/test-phase-e.rkt
@@ -5,9 +5,12 @@
 (require rackunit
          racket/file
          racket/string
-         "../extensions/ext-package-manager.rkt"
-         "../extensions/image-input.rkt"
-         "../extensions/session-export.rkt"
+         (only-in "../extensions/ext-package-manager.rkt" handle-ext-pkg)
+         (only-in "../extensions/image-input.rkt"
+                  handle-image-input
+                  image->base64
+                  extension->media-type)
+         (only-in "../extensions/session-export.rkt" handle-session-export)
          "../tools/tool.rkt")
 
 ;; ============================================================
@@ -34,16 +37,13 @@
 ;; ============================================================
 
 (test-case "image-input encode requires path"
-  (with-handlers ([exn:fail?
-                   (lambda (e)
-                     (check-true (string-contains? (exn-message e) "path")))])
+  (with-handlers ([exn:fail? (lambda (e) (check-true (string-contains? (exn-message e) "path")))])
     (handle-image-input (hasheq 'action "encode"))
     (check-false "Should have raised" #t)))
 
 (test-case "image-input file not found errors"
-  (with-handlers ([exn:fail?
-                   (lambda (e)
-                     (check-true (string-contains? (exn-message e) "not found")))])
+  (with-handlers ([exn:fail? (lambda (e)
+                               (check-true (string-contains? (exn-message e) "not found")))])
     (handle-image-input (hasheq 'action "encode" 'path "/nonexistent.png"))
     (check-false "Should have raised" #t)))
 
@@ -73,28 +73,25 @@
 ;; ============================================================
 
 (test-case "session-export requires session_path"
-  (with-handlers ([exn:fail?
-                   (lambda (e)
-                     (check-true (string-contains? (exn-message e) "session_path")))])
+  (with-handlers ([exn:fail? (lambda (e)
+                               (check-true (string-contains? (exn-message e) "session_path")))])
     (handle-session-export (hasheq 'format "markdown"))
     (check-false "Should have raised" #t)))
 
 (test-case "session-export file not found errors"
-  (with-handlers ([exn:fail?
-                   (lambda (e)
-                     (check-true (string-contains? (exn-message e) "not found")))])
+  (with-handlers ([exn:fail? (lambda (e)
+                               (check-true (string-contains? (exn-message e) "not found")))])
     (handle-session-export (hasheq 'session_path "/nonexistent.jsonl"))
     (check-false "Should have raised" #t)))
 
 (test-case "session-export markdown export works"
   (define tmp (make-temporary-file "session-~a.jsonl"))
   (call-with-output-file tmp
-    (lambda (out)
-      (displayln "{\"role\":\"user\",\"content\":\"hello\"}" out)
-      (displayln "{\"role\":\"assistant\",\"content\":\"world\"}" out))
-    #:exists 'replace)
-  (define result (handle-session-export
-                  (hasheq 'session_path (path->string tmp) 'format "markdown")))
+                         (lambda (out)
+                           (displayln "{\"role\":\"user\",\"content\":\"hello\"}" out)
+                           (displayln "{\"role\":\"assistant\",\"content\":\"world\"}" out))
+                         #:exists 'replace)
+  (define result (handle-session-export (hasheq 'session_path (path->string tmp) 'format "markdown")))
   (check-pred tool-result? result)
   (check-false (tool-result-is-error? result))
   (define text (hash-ref (car (tool-result-content result)) 'text ""))
@@ -105,11 +102,9 @@
 (test-case "session-export json export works"
   (define tmp (make-temporary-file "session-~a.jsonl"))
   (call-with-output-file tmp
-    (lambda (out)
-      (displayln "{\"role\":\"user\",\"content\":\"test\"}" out))
-    #:exists 'replace)
-  (define result (handle-session-export
-                  (hasheq 'session_path (path->string tmp) 'format "json")))
+                         (lambda (out) (displayln "{\"role\":\"user\",\"content\":\"test\"}" out))
+                         #:exists 'replace)
+  (define result (handle-session-export (hasheq 'session_path (path->string tmp) 'format "json")))
   (check-pred tool-result? result)
   (check-false (tool-result-is-error? result))
   (delete-file tmp))
@@ -117,11 +112,10 @@
 (test-case "session-export html export works"
   (define tmp (make-temporary-file "session-~a.jsonl"))
   (call-with-output-file tmp
-    (lambda (out)
-      (displayln "{\"role\":\"assistant\",\"content\":\"response\"}" out))
-    #:exists 'replace)
-  (define result (handle-session-export
-                  (hasheq 'session_path (path->string tmp) 'format "html")))
+                         (lambda (out)
+                           (displayln "{\"role\":\"assistant\",\"content\":\"response\"}" out))
+                         #:exists 'replace)
+  (define result (handle-session-export (hasheq 'session_path (path->string tmp) 'format "html")))
   (check-pred tool-result? result)
   (check-false (tool-result-is-error? result))
   (define text (hash-ref (car (tool-result-content result)) 'text ""))
@@ -133,15 +127,17 @@
   (define out-path (make-temporary-file "out-~a.md"))
   (delete-file out-path)
   (call-with-output-file tmp
-    (lambda (out) (displayln "{\"role\":\"user\",\"content\":\"hi\"}" out))
-    #:exists 'replace)
-  (define result (handle-session-export
-                  (hasheq 'session_path (path->string tmp)
-                          'format "markdown"
-                          'output_path (path->string out-path))))
+                         (lambda (out) (displayln "{\"role\":\"user\",\"content\":\"hi\"}" out))
+                         #:exists 'replace)
+  (define result
+    (handle-session-export (hasheq 'session_path
+                                   (path->string tmp)
+                                   'format
+                                   "markdown"
+                                   'output_path
+                                   (path->string out-path))))
   (check-pred tool-result? result)
-  (check-true (string-contains?
-               (hash-ref (car (tool-result-content result)) 'text "")
-               "Exported to"))
+  (check-true (string-contains? (hash-ref (car (tool-result-content result)) 'text "") "Exported to"))
   (delete-file tmp)
-  (when (file-exists? out-path) (delete-file out-path)))
+  (when (file-exists? out-path)
+    (delete-file out-path)))


### PR DESCRIPTION
Addresses #1532.

fix: ext-register-tool! arity mismatch in 7 extensions (#1532)

C1 CRITICAL fix: All 7 extensions were calling ext-register-tool!
with (ctx (make-tool ...)) — 2 args. The API requires
(ctx name desc schema handler) — 5 positional args.

Fixed extensions: compact-context, image-input, session-export,
ext-package-manager, remote-collab, q-sync, racket-tooling.

Added hook-dispatch regression tests in test-extension-loader.rkt.
Fixed duplicate the-extension provide conflict in test-phase-e.rkt.

157 tests pass across all affected test files.

Wave 1 of v0.17.5 milestone #88.