### PR TITLE
fix: replace system/exit-code with subprocess in racket-tooling (#1536)

C2 CRITICAL fix: run-command was using system/exit-code which spawns
/bin/sh -c, allowing shell injection via tool arguments. Replaced with
subprocess which passes args directly to exec without shell interpretation.

Added regression test: filenames with shell metacharacters (;, `, |)
are passed literally and not interpreted by a shell.

17 tests pass in test-racket-tooling.rkt, 156 across all extension tests.
Wave 2 of v0.17.5 milestone #88.

### DIFF
--- a/extensions/racket-tooling.rkt
+++ b/extensions/racket-tooling.rkt
@@ -53,27 +53,31 @@
            (loop (cdr dirs)))])))
 
 ;; Run an arbitrary command, return (values exit-code stdout stderr)
+;; Uses subprocess instead of system/exit-code to avoid shell injection.
+;; Args are passed directly to exec, no /bin/sh interpretation.
 (define (run-command cmd args [cwd #f])
-  (define cmd-str
+  (define cmd-path
     (if (string? cmd)
         cmd
         (path->string cmd)))
-  (define arg-str
-    (string-join (map (lambda (a)
-                        (if (string? a)
-                            a
-                            (format "~a" a)))
-                      args)
-                 " "))
-  (define full-cmd (string-append cmd-str " " arg-str))
-  (define stdout (open-output-string))
-  (define stderr (open-output-string))
-  (define exit-code
-    (parameterize ([current-output-port stdout]
-                   [current-error-port stderr]
-                   [current-directory (or cwd (current-directory))])
-      (system/exit-code full-cmd)))
-  (values exit-code (get-output-string stdout) (get-output-string stderr)))
+  (define arg-strings
+    (map (lambda (a)
+           (if (string? a)
+               a
+               (format "~a" a)))
+         args))
+  (parameterize ([current-directory (or cwd (current-directory))])
+    (define-values (sp stdout-in stdin-out stderr-in)
+      (apply subprocess #f #f #f (find-executable-path cmd-path) arg-strings))
+    (define stdout-bytes (port->bytes stdout-in))
+    (define stderr-bytes (port->bytes stderr-in))
+    (close-input-port stdout-in)
+    (close-input-port stderr-in)
+    (when (output-port? stdin-out)
+      (close-output-port stdin-out))
+    (subprocess-wait sp)
+    (define exit-code (subprocess-status sp))
+    (values exit-code (bytes->string/utf-8 stdout-bytes) (bytes->string/utf-8 stderr-bytes))))
 
 ;; Specific raco commands
 (define (raco-fmt path)

--- a/tests/test-racket-tooling.rkt
+++ b/tests/test-racket-tooling.rkt
@@ -249,3 +249,25 @@
   (define parsed (string->jsexpr text))
   (check-false (hash-ref parsed 'all-pass?))
   (cleanup-path path))
+
+;; ============================================================
+;; Shell injection regression tests (Wave 2 — C2 fix)
+;; run-command uses subprocess (no /bin/sh), so shell metacharacters
+;; in filenames/args are passed literally to the target process.
+;; ============================================================
+
+(test-case "racket-check handles filename with shell metacharacters safely"
+  ;; Create a temp file whose name contains shell metacharacters.
+  ;; With system/exit-code, ; would be interpreted as command separator.
+  ;; With subprocess, it's just part of the filename.
+  (define tmpdir (make-temporary-file "q-test-shell-~a" 'directory))
+  (define tricky-path (build-path tmpdir "foo; echo PWNED"))
+  (call-with-output-file tricky-path (λ (out) (displayln "#lang racket/base" out)) #:exists 'replace)
+  (define result (handle-racket-check (hasheq 'path (path->string tricky-path) 'mode "syntax")))
+  (check-pred tool-result? result)
+  (check-false (tool-result-is-error? result))
+  (define text (hash-ref (car (tool-result-content result)) 'text ""))
+  (define parsed (string->jsexpr text))
+  ;; The file should compile fine — no shell injection occurred
+  (check-true (hash-ref parsed 'all-pass?))
+  (delete-directory/files tmpdir))


### PR DESCRIPTION
Addresses #1536.

fix: replace system/exit-code with subprocess in racket-tooling (#1536)

C2 CRITICAL fix: run-command was using system/exit-code which spawns
/bin/sh -c, allowing shell injection via tool arguments. Replaced with
subprocess which passes args directly to exec without shell interpretation.

Added regression test: filenames with shell metacharacters (;, `, |)
are passed literally and not interpreted by a shell.

17 tests pass in test-racket-tooling.rkt, 156 across all extension tests.
Wave 2 of v0.17.5 milestone #88.