### PR TITLE
fix: path traversal, XSS, remote injection in 3 extensions (#1540)

M2: gsd-planning.rkt — valid-artifact-name? now rejects names containing
/, .., or null bytes, preventing path traversal via artifact names like
"../../etc/crontab.md".

M3: session-export.rkt — Added html-escape function that escapes &, <, >,
and " characters. Applied to role and content in entry->html, and to the
parse-error fallback <pre> block. Prevents XSS via session data containing
<script> tags.

M7: remote-collab.rkt — Added valid-session-name? that only allows
alphanumeric, hyphen, and underscore characters. Applied at remote-tmux
entry point to prevent shell injection via tmux session names.

Added regression tests: path traversal (2), XSS (1), session validation (2).
66 tests pass across affected test files, 160 across all extension tests.
Wave 4 of v0.17.5 milestone #88.

### DIFF
--- a/extensions/gsd-planning.rkt
+++ b/extensions/gsd-planning.rkt
@@ -17,7 +17,8 @@
          "hooks.rkt"
          "../tools/tool.rkt")
 
-(provide gsd-planning-extension
+(provide the-extension
+         gsd-planning-extension
          planning-artifact-path
          valid-artifact-name?
          read-planning-artifact
@@ -54,7 +55,12 @@
     [else #f]))
 
 (define (valid-artifact-name? name)
-  (or (assoc name artifact-extensions) (string-suffix? name ".md") (string-suffix? name ".json")))
+  (and (string? name)
+       (not (string-contains? name "/"))
+       (not (string-contains? name ".."))
+       (not (string-contains? name "\x00"))
+       (or (assoc name artifact-extensions) (string-suffix? name ".md") (string-suffix? name ".json"))
+       #t))
 
 (define (json-artifact? name)
   (or (string-suffix? name ".json")
@@ -218,3 +224,5 @@
                     register-gsd-tools
                     #:on register-shortcuts
                     register-gsd-commands)
+
+(define the-extension gsd-planning-extension)

--- a/extensions/remote-collab/remote-collab.rkt
+++ b/extensions/remote-collab/remote-collab.rkt
@@ -17,14 +17,22 @@
          "tmux-helpers.rkt")
 
 (provide the-extension
-         handle-remote-q)
+         handle-remote-q
+         valid-session-name?
+         remote-tmux)
 
 ;; ============================================================
 ;; Remote session management
 ;; ============================================================
 
+;; Validate session name: only alphanumeric, hyphens, underscores
+(define (valid-session-name? s)
+  (and (string? s) (regexp-match? #rx"^[a-zA-Z0-9_-]+$" s)))
+
 ;; Build a remote command that wraps tmux operations via SSH
 (define (remote-tmux host session action args)
+  (unless (valid-session-name? session)
+    (error 'remote-q "invalid session name: ~a" session))
   (case action
     [(status)
      (format "tmux has-session -t ~a 2>/dev/null && echo 'running' || echo 'stopped'" session)]
@@ -94,40 +102,41 @@
 (define (register-remote-tools ctx)
   (ext-register-tool!
    ctx
-   "remote-q"
-   (string-append "Control a remote q agent instance via SSH + tmux. "
-                  "Actions: status (check session), start (new session), "
-                  "send (send prompt), capture (read output), "
-                  "wait (wait for idle), interrupt (stop task), stop (kill session).")
-   (hasheq
-    'type
-    "object"
-    'required
-    '("host" "action")
-    'properties
-    (hasheq 'host
-            (hasheq 'type "string" 'description "SSH host (user@host)")
-            'action
-            (hasheq 'type "string" 'description "status|start|send|capture|wait|interrupt|stop")
-            'session
-            (hasheq 'type "string" 'description "Tmux session name (default: q-agent)")
-            'prompt
-            (hasheq 'type "string" 'description "Prompt text (for send)")
-            'lines
-            (hasheq 'type "integer" 'description "Lines to capture (default: 80)")
-            'cwd
-            (hasheq 'type "string" 'description "Working directory (for start)")
-            'provider
-            (hasheq 'type "string" 'description "Pi provider")
-            'model
-            (hasheq 'type "string" 'description "Pi model")
-            'thinking
-            (hasheq 'type "string" 'description "Thinking level")
-            'timeout
-            (hasheq 'type "integer" 'description "Wait timeout seconds (default: 60)")
-            'ssh_options
-            (hasheq 'type "array" 'description "Extra SSH options")))
-   handle-remote-q)
+   (make-tool
+    "remote-q"
+    (string-append "Control a remote q agent instance via SSH + tmux. "
+                   "Actions: status (check session), start (new session), "
+                   "send (send prompt), capture (read output), "
+                   "wait (wait for idle), interrupt (stop task), stop (kill session).")
+    (hasheq
+     'type
+     "object"
+     'required
+     '("host" "action")
+     'properties
+     (hasheq 'host
+             (hasheq 'type "string" 'description "SSH host (user@host)")
+             'action
+             (hasheq 'type "string" 'description "status|start|send|capture|wait|interrupt|stop")
+             'session
+             (hasheq 'type "string" 'description "Tmux session name (default: q-agent)")
+             'prompt
+             (hasheq 'type "string" 'description "Prompt text (for send)")
+             'lines
+             (hasheq 'type "integer" 'description "Lines to capture (default: 80)")
+             'cwd
+             (hasheq 'type "string" 'description "Working directory (for start)")
+             'provider
+             (hasheq 'type "string" 'description "Pi provider")
+             'model
+             (hasheq 'type "string" 'description "Pi model")
+             'thinking
+             (hasheq 'type "string" 'description "Thinking level")
+             'timeout
+             (hasheq 'type "integer" 'description "Wait timeout seconds (default: 60)")
+             'ssh_options
+             (hasheq 'type "array" 'description "Extra SSH options")))
+    handle-remote-q))
   (hook-pass ctx))
 
 (define-q-extension the-extension

--- a/extensions/session-export.rkt
+++ b/extensions/session-export.rkt
@@ -19,6 +19,13 @@
 (define (read-session-lines path)
   (filter non-empty-string? (string-split (file->string path) "\n")))
 
+(define (html-escape s)
+  (let* ([s (string-replace s "&" "&amp;")]
+         [s (string-replace s "<" "&lt;")]
+         [s (string-replace s ">" "&gt;")]
+         [s (string-replace s "\"" "&quot;")])
+    s))
+
 (define (entry->markdown line idx)
   (with-handlers ([exn:fail? (lambda (e) (format "### Entry ~a\n~a\n" idx line))])
     (define obj (string->jsexpr line))
@@ -27,10 +34,13 @@
             (hash-ref obj 'content ""))))
 
 (define (entry->html line)
-  (with-handlers ([exn:fail? (lambda (e) (format "<pre>~a</pre>" line))])
+  (with-handlers ([exn:fail? (lambda (e) (format "<pre>~a</pre>" (html-escape line)))])
     (define obj (string->jsexpr line))
     (define role (hash-ref obj 'role "unknown"))
-    (format "<div class=\"~a\"><h4>~a</h4><pre>~a</pre></div>" role role (hash-ref obj 'content ""))))
+    (format "<div class=\"~a\"><h4>~a</h4><pre>~a</pre></div>"
+            (html-escape role)
+            (html-escape role)
+            (html-escape (hash-ref obj 'content "")))))
 
 (define (handle-session-export args [exec-ctx #f])
   (define path (hash-ref args 'session_path ""))
@@ -66,21 +76,22 @@
     [else (make-success-result (list (hasheq 'type "text" 'text result)))]))
 
 (define (register-export-tools ctx)
-  (ext-register-tool! ctx
-                      "session-export"
-                      "Export session logs to HTML, JSON, or Markdown."
-                      (hasheq 'type
-                              "object"
-                              'required
-                              '("session_path")
-                              'properties
-                              (hasheq 'session_path
-                                      (hasheq 'type "string" 'description "Session JSONL file path")
-                                      'format
-                                      (hasheq 'type "string" 'description "html|json|markdown")
-                                      'output_path
-                                      (hasheq 'type "string" 'description "Output file path")))
-                      handle-session-export)
+  (ext-register-tool!
+   ctx
+   (make-tool "session-export"
+              "Export session logs to HTML, JSON, or Markdown."
+              (hasheq 'type
+                      "object"
+                      'required
+                      '("session_path")
+                      'properties
+                      (hasheq 'session_path
+                              (hasheq 'type "string" 'description "Session JSONL file path")
+                              'format
+                              (hasheq 'type "string" 'description "html|json|markdown")
+                              'output_path
+                              (hasheq 'type "string" 'description "Output file path")))
+              handle-session-export))
   (hook-pass ctx))
 
 (define-q-extension session-export-extension

--- a/tests/test-gsd-planning.rkt
+++ b/tests/test-gsd-planning.rkt
@@ -316,3 +316,29 @@
      (check-false (tool-result-is-error? result))
      ;; Verify content was written
      (check-equal? (read-planning-artifact dir "VALIDATION") "## Tests pass"))))
+
+;; ============================================================
+;; M2 regression: Path traversal in artifact names
+;; ============================================================
+
+(test-case "valid-artifact-name? rejects path traversal"
+  (check-true (valid-artifact-name? "PLAN"))
+  (check-true (valid-artifact-name? "custom.md"))
+  (check-true (valid-artifact-name? "data.json"))
+  (check-false (valid-artifact-name? "../../etc/crontab.md"))
+  (check-false (valid-artifact-name? "foo/bar.md"))
+  (check-false (valid-artifact-name? "..\x00PLAN")))
+
+(test-case "write-planning-artifact rejects path traversal"
+  (define dir (make-temporary-file "q-test-gsd-~a" 'directory))
+  (define reg (make-tool-registry))
+  (define ctx (make-test-ctx #:tool-registry reg))
+  (define handler (hash-ref (extension-hooks gsd-planning-extension) 'register-tools))
+  (handler ctx)
+  (define pw (lookup-tool reg "planning-write"))
+  (define result
+    ((tool-execute pw) (hasheq 'artifact "../../etc/crontab.md" 'content "pwned" 'base_dir dir)))
+  ;; Should fail gracefully (artifact name rejected)
+  (check-true (or (tool-result-is-error? result)
+                  (not (file-exists? (build-path dir ".planning" "../../etc/crontab.md")))))
+  (delete-directory/files dir))

--- a/tests/test-phase-e.rkt
+++ b/tests/test-phase-e.rkt
@@ -141,3 +141,22 @@
   (delete-file tmp)
   (when (file-exists? out-path)
     (delete-file out-path)))
+
+;; ============================================================
+;; M3 regression: XSS in session-export HTML output
+;; ============================================================
+
+(test-case "session-export html escapes script tags"
+  (define tmp (make-temporary-file "session-~a.jsonl"))
+  (call-with-output-file
+   tmp
+   (lambda (out) (displayln "{\"role\":\"user\",\"content\":\"<script>alert(1)</script>\"}" out))
+   #:exists 'replace)
+  (define result (handle-session-export (hasheq 'session_path (path->string tmp) 'format "html")))
+  (check-pred tool-result? result)
+  (define text (hash-ref (car (tool-result-content result)) 'text ""))
+  ;; Raw <script> must NOT appear in output
+  (check-false (string-contains? text "<script>"))
+  ;; Escaped version must appear
+  (check-true (string-contains? text "&lt;script&gt;"))
+  (delete-file tmp))

--- a/tests/test-remote-collab.rkt
+++ b/tests/test-remote-collab.rkt
@@ -13,18 +13,14 @@
 ;; ============================================================
 
 (test-case "handle-remote-q requires host"
-  (with-handlers ([exn:fail?
-                   (lambda (e)
-                     (check-true
-                      (string-contains? (exn-message e) "host is required")))])
+  (with-handlers ([exn:fail? (lambda (e)
+                               (check-true (string-contains? (exn-message e) "host is required")))])
     (handle-remote-q (hasheq 'action "status"))
     (check-false "Should have raised error" #t)))
 
 (test-case "handle-remote-q unknown action raises error"
-  (with-handlers ([exn:fail?
-                   (lambda (e)
-                     (check-true
-                      (string-contains? (exn-message e) "unknown action")))])
+  (with-handlers ([exn:fail? (lambda (e)
+                               (check-true (string-contains? (exn-message e) "unknown action")))])
     (handle-remote-q (hasheq 'host "localhost" 'action "bogus"))
     (check-false "Should have raised error" #t)))
 
@@ -34,67 +30,48 @@
 
 (test-case "ssh-execute fails on unreachable host"
   (define-values (ec out err)
-    (ssh-execute "nonexistent.test.invalid" "echo hello"
-                 #:options (cons "-o"
-                                 (cons "ConnectTimeout=1"
-                                       (default-ssh-options)))))
+    (ssh-execute "nonexistent.test.invalid"
+                 "echo hello"
+                 #:options (cons "-o" (cons "ConnectTimeout=1" (default-ssh-options)))))
   (check-not-equal? ec 0))
 
 (test-case "handle-remote-q send returns error for unreachable host"
   (define result
     (handle-remote-q
-     (hasheq 'host "nonexistent.test.invalid"
-             'action "send"
-             'session "test"
-             'prompt "hello world")))
+     (hasheq 'host "nonexistent.test.invalid" 'action "send" 'session "test" 'prompt "hello world")))
   (check-pred tool-result? result)
   (check-true (tool-result-is-error? result)))
 
 (test-case "handle-remote-q capture returns error for unreachable host"
   (define result
     (handle-remote-q
-     (hasheq 'host "nonexistent.test.invalid"
-             'action "capture"
-             'session "test"
-             'lines 50)))
+     (hasheq 'host "nonexistent.test.invalid" 'action "capture" 'session "test" 'lines 50)))
   (check-pred tool-result? result)
   (check-true (tool-result-is-error? result)))
 
 (test-case "handle-remote-q start returns error for unreachable host"
   (define result
     (handle-remote-q
-     (hasheq 'host "nonexistent.test.invalid"
-             'action "start"
-             'session "test"
-             'cwd "/tmp")))
+     (hasheq 'host "nonexistent.test.invalid" 'action "start" 'session "test" 'cwd "/tmp")))
   (check-pred tool-result? result)
   (check-true (tool-result-is-error? result)))
 
 (test-case "handle-remote-q stop returns error for unreachable host"
   (define result
-    (handle-remote-q
-     (hasheq 'host "nonexistent.test.invalid"
-             'action "stop"
-             'session "test")))
+    (handle-remote-q (hasheq 'host "nonexistent.test.invalid" 'action "stop" 'session "test")))
   (check-pred tool-result? result)
   (check-true (tool-result-is-error? result)))
 
 (test-case "handle-remote-q interrupt returns error for unreachable host"
   (define result
-    (handle-remote-q
-     (hasheq 'host "nonexistent.test.invalid"
-             'action "interrupt"
-             'session "test")))
+    (handle-remote-q (hasheq 'host "nonexistent.test.invalid" 'action "interrupt" 'session "test")))
   (check-pred tool-result? result)
   (check-true (tool-result-is-error? result)))
 
 (test-case "handle-remote-q wait returns error for unreachable host"
   (define result
     (handle-remote-q
-     (hasheq 'host "nonexistent.test.invalid"
-             'action "wait"
-             'session "test"
-             'timeout 5)))
+     (hasheq 'host "nonexistent.test.invalid" 'action "wait" 'session "test" 'timeout 5)))
   (check-pred tool-result? result)
   (check-true (tool-result-is-error? result)))
 
@@ -111,3 +88,20 @@
   (define opts (default-ssh-options))
   (define opts-str (string-join opts " "))
   (check-true (string-contains? opts-str "BatchMode=yes")))
+
+;; ============================================================
+;; M7 regression: Session name validation
+;; ============================================================
+
+(require (only-in "../extensions/remote-collab/remote-collab.rkt" valid-session-name?))
+
+(test-case "valid-session-name? rejects shell metacharacters"
+  (check-true (valid-session-name? "q-agent"))
+  (check-true (valid-session-name? "my_session_123"))
+  (check-false (valid-session-name? "session; rm -rf /"))
+  (check-false (valid-session-name? "session$(pwned)"))
+  (check-false (valid-session-name? "session`id`"))
+  (check-false (valid-session-name? "session|cat")))
+
+(test-case "remote-tmux rejects invalid session name"
+  (check-exn exn:fail? (lambda () (remote-tmux "host" "; rm -rf /" 'status (hasheq)))))


### PR DESCRIPTION
Addresses #1540.

fix: path traversal, XSS, remote injection in 3 extensions (#1540)

M2: gsd-planning.rkt — valid-artifact-name? now rejects names containing
/, .., or null bytes, preventing path traversal via artifact names like
"../../etc/crontab.md".

M3: session-export.rkt — Added html-escape function that escapes &, <, >,
and " characters. Applied to role and content in entry->html, and to the
parse-error fallback <pre> block. Prevents XSS via session data containing
<script> tags.

M7: remote-collab.rkt — Added valid-session-name? that only allows
alphanumeric, hyphen, and underscore characters. Applied at remote-tmux
entry point to prevent shell injection via tmux session names.

Added regression tests: path traversal (2), XSS (1), session validation (2).
66 tests pass across affected test files, 160 across all extension tests.
Wave 4 of v0.17.5 milestone #88.