### PR TITLE
fix: wave-finish error checking, remove hardcoded host, rsync safety, find-form-end robustness (#1544)

### DIFF
--- a/extensions/github-integration.rkt
+++ b/extensions/github-integration.rkt
@@ -753,12 +753,29 @@
                       #f))
                 ;; Step 4: merge PR
                 (when pr-num
-                  (gh-exec-result (format "pr merge ~a --squash" pr-num)))
+                  (define-values (ec-merge _out-merge err-merge)
+                    (gh-exec-result (format "pr merge ~a --squash" pr-num)))
+                  (unless (= ec-merge 0)
+                    (make-error-result
+                     (format
+                      "PR merge failed (exit ~a): ~a. Files committed and pushed but PR not merged."
+                      ec-merge
+                      (string-trim err-merge)))))
                 ;; Step 5: sync main
-                (git-exec-result "checkout main")
-                (git-exec-result "pull origin main")
+                (define-values (ec-co _out-co err-co) (git-exec-result "checkout main"))
+                (define-values (ec-pull _out-pull err-pull) (git-exec-result "pull origin main"))
+                (unless (= ec-co 0)
+                  (make-error-result (format "git checkout main failed: ~a" (string-trim err-co))))
+                (unless (= ec-pull 0)
+                  (make-error-result (format "git pull failed: ~a" (string-trim err-pull))))
                 ;; Step 6: close issue
-                (gh-exec-result (format "issue close ~a" issue-num))
+                (define-values (ec-close _out-close err-close)
+                  (gh-exec-result (format "issue close ~a" issue-num)))
+                (unless (= ec-close 0)
+                  (make-error-result
+                   (format "Issue close failed (exit ~a): ~a. PR merged but issue not closed."
+                           ec-close
+                           (string-trim err-close))))
                 (make-success-result
                  (list (hasheq
                         'type

--- a/extensions/q-sync.rkt
+++ b/extensions/q-sync.rkt
@@ -40,22 +40,37 @@
   (close-input-port err-in)
   (values (subprocess-status sp) stdout-str stderr-str))
 
-;; Get remote host from args or default
+;; Get remote host from args — no default, must be provided
 (define (get-remote-host args)
-  (hash-ref args 'remote_host "user@vps2402959.fastwebserver.de"))
+  (define host (hash-ref args 'remote_host #f))
+  (unless host
+    (error 'q-sync "remote_host is required. No default provided."))
+  host)
 
 ;; Get project dir
 (define (get-project-dir args)
   (hash-ref args 'project_dir (path->string (current-directory))))
 
-;; Sync planning state via rsync
+;; Sync planning state via rsync (with --backup-dir for safety)
 (define (sync-planning remote-host local-dir direction)
   (define planning-dir (build-path local-dir ".planning"))
   (define remote-path (string-append remote-host ":~/src/q-agent/.planning/"))
   (define-values (ec out err)
     (case (string->symbol direction)
-      [(push) (run-cmd "rsync" (list "-avz" "--delete" (path->string planning-dir) "/" remote-path))]
-      [(pull) (run-cmd "rsync" (list "-avz" "--delete" remote-path (path->string planning-dir) "/"))]
+      [(push)
+       (run-cmd "rsync"
+                (list "-avz"
+                      "--backup"
+                      "--backup-dir=.rsync-backup"
+                      (string-append (path->string planning-dir) "/")
+                      remote-path))]
+      [(pull)
+       (run-cmd "rsync"
+                (list "-avz"
+                      "--backup"
+                      "--backup-dir=.rsync-backup"
+                      remote-path
+                      (string-append (path->string planning-dir) "/")))]
       [else (values 1 "" (format "Unknown direction: ~a" direction))]))
   (values ec (string-trim out) (string-trim err)))
 

--- a/extensions/racket-tooling.rkt
+++ b/extensions/racket-tooling.rkt
@@ -30,7 +30,8 @@
          raco-fmt
          raco-make
          raco-test
-         run-raco)
+         run-raco
+         find-form-end)
 
 ;; ============================================================
 ;; Raco command helpers
@@ -715,41 +716,62 @@
 ;; ============================================================
 
 (define (find-form-end lines start-idx)
-  (define depth 0)
   (let loop ([i start-idx]
              [col 0]
-             [in-string #f])
+             [in-string #f]
+             [escape-next #f]
+             [cur-depth 0])
     (cond
-      [(>= i (length lines)) (values i depth)]
+      [(>= i (length lines)) (values i cur-depth)]
       [else
        (define line (list-ref lines i))
        (define chars (string->list line))
        (let char-loop ([cs (if (= i start-idx)
                                (drop chars col)
                                chars)]
-                       [d depth]
-                       [in-str in-string])
+                       [d cur-depth]
+                       [in-str in-string]
+                       [esc escape-next])
          (cond
            [(null? cs)
             (if (zero? d)
                 (values (+ i 1) d)
-                (loop (+ i 1) 0 in-str))]
+                (loop (+ i 1) 0 in-str esc d))]
            [else
             (define c (car cs))
-            (define new-d
-              (cond
-                [in-str d]
-                [(char=? c #\() (+ d 1)]
-                [(char=? c #\)) (- d 1)]
-                [else d]))
-            (if (and (= i start-idx) (= new-d 0) (char=? c #\)))
-                (values (+ i 1) 0)
-                (char-loop (cdr cs)
-                           new-d
-                           (if (and (not in-str) (char=? c #\"))
-                               #t
-                               (if (and in-str (char=? c #\")) #f in-str))))]))])))
-
+            (cond
+              ;; Inside a string
+              [in-str
+               (cond
+                 [esc (char-loop (cdr cs) d in-str #f)]
+                 [(char=? c #\\) (char-loop (cdr cs) d in-str #t)]
+                 [(char=? c #\") (char-loop (cdr cs) d #f #f)]
+                 [else (char-loop (cdr cs) d in-str #f)])]
+              ;; Not in a string
+              [else
+               (cond
+                 ;; Comment — skip rest of line
+                 [(char=? c #\;)
+                  (if (zero? d)
+                      (values (+ i 1) 0)
+                      (loop (+ i 1) 0 #f #f d))]
+                 ;; String start
+                 [(char=? c #\") (char-loop (cdr cs) d #t #f)]
+                 ;; Parens
+                 [(char=? c #\() (char-loop (cdr cs) (+ d 1) #f #f)]
+                 [(char=? c #\))
+                  (define new-d (- d 1))
+                  (if (and (= i start-idx) (= new-d 0))
+                      (values (+ i 1) 0)
+                      (char-loop (cdr cs) new-d #f #f))]
+                 ;; Brackets — same as parens for depth tracking
+                 [(char=? c #\[) (char-loop (cdr cs) (+ d 1) #f #f)]
+                 [(char=? c #\])
+                  (define new-d (- d 1))
+                  (if (and (= i start-idx) (= new-d 0))
+                      (values (+ i 1) 0)
+                      (char-loop (cdr cs) new-d #f #f))]
+                 [else (char-loop (cdr cs) d #f #f)])])]))])))
 ;; ============================================================
 ;; Extension definition
 ;; ============================================================

--- a/tests/test-q-sync-extension.rkt
+++ b/tests/test-q-sync-extension.rkt
@@ -13,55 +13,56 @@
 ;; ============================================================
 
 (test-case "handle-q-sync status returns success"
-  (define result (handle-q-sync (hasheq 'direction "status")))
+  (define result (handle-q-sync (hasheq 'direction "status" 'remote_host "user@localhost")))
   (check-pred tool-result? result)
   (check-false (tool-result-is-error? result)))
 
 (test-case "handle-q-sync status includes sync status text"
-  (define result (handle-q-sync (hasheq 'direction "status")))
+  (define result (handle-q-sync (hasheq 'direction "status" 'remote_host "user@localhost")))
   (define text (hash-ref (car (tool-result-content result)) 'text ""))
   (check-true (string-contains? text "Sync Status")))
 
 (test-case "handle-q-sync unknown direction returns error"
-  (define result
-    (handle-q-sync (hasheq 'direction "sideways")))
+  (define result (handle-q-sync (hasheq 'direction "sideways" 'remote_host "user@localhost")))
   (check-pred tool-result? result)
   (check-true (tool-result-is-error? result)))
 
 (test-case "handle-q-sync push returns tool result"
   ;; Push will fail without remote, but should return a result
   (define result
-    (handle-q-sync (hasheq 'direction "push"
-                           'domain "planning"
-                           'remote_host "nonexistent.test.invalid")))
+    (handle-q-sync
+     (hasheq 'direction "push" 'domain "planning" 'remote_host "nonexistent.test.invalid")))
   (check-pred tool-result? result))
 
 (test-case "handle-q-sync pull returns tool result"
   (define result
-    (handle-q-sync (hasheq 'direction "pull"
-                           'domain "planning"
-                           'remote_host "nonexistent.test.invalid")))
+    (handle-q-sync
+     (hasheq 'direction "pull" 'domain "planning" 'remote_host "nonexistent.test.invalid")))
   (check-pred tool-result? result))
 
 (test-case "handle-q-sync handoff returns tool result"
   (define result
-    (handle-q-sync (hasheq 'direction "handoff"
-                           'remote_host "nonexistent.test.invalid")))
+    (handle-q-sync (hasheq 'direction "handoff" 'remote_host "nonexistent.test.invalid")))
   (check-pred tool-result? result))
 
 (test-case "handle-q-sync domain planning only"
   (define result
-    (handle-q-sync (hasheq 'direction "push"
-                           'domain "planning"
-                           'remote_host "nonexistent.test.invalid")))
+    (handle-q-sync
+     (hasheq 'direction "push" 'domain "planning" 'remote_host "nonexistent.test.invalid")))
   (check-pred tool-result? result)
   (define text (hash-ref (car (tool-result-content result)) 'text ""))
   (check-true (string-contains? text "planning")))
 
 (test-case "handle-q-sync domain git only"
   (define result
-    (handle-q-sync (hasheq 'direction "push"
-                           'domain "git")))
+    (handle-q-sync (hasheq 'direction "push" 'domain "git" 'remote_host "user@localhost")))
   (check-pred tool-result? result)
   (define text (hash-ref (car (tool-result-content result)) 'text ""))
   (check-true (string-contains? text "git")))
+
+;; M5 regression: no default host -- must provide remote_host
+(test-case "handle-q-sync requires remote_host for push"
+  (check-exn exn:fail? (lambda () (handle-q-sync (hasheq 'direction "push" 'domain "git")))))
+
+(test-case "handle-q-sync requires remote_host for pull"
+  (check-exn exn:fail? (lambda () (handle-q-sync (hasheq 'direction "pull" 'domain "git")))))

--- a/tests/test-racket-tooling.rkt
+++ b/tests/test-racket-tooling.rkt
@@ -271,3 +271,27 @@
   ;; The file should compile fine — no shell injection occurred
   (check-true (hash-ref parsed 'all-pass?))
   (delete-directory/files tmpdir))
+
+;; ============================================================
+;; m1 regression: find-form-end handles strings, comments, brackets
+;; ============================================================
+
+(require (only-in "../extensions/racket-tooling.rkt" find-form-end))
+
+(test-case "find-form-end handles escaped quotes in strings"
+  (define lines '("(define s \"hello \\\"world\\\" foo\")"))
+  (define-values (end-idx depth) (find-form-end lines 0))
+  (check-equal? end-idx 1)
+  (check-equal? depth 0))
+
+(test-case "find-form-end skips comment lines"
+  (define lines '("(define (foo)" "  ;; this is a comment with (parens)" "  42)"))
+  (define-values (end-idx depth) (find-form-end lines 0))
+  (check-equal? end-idx 3)
+  (check-equal? depth 0))
+
+(test-case "find-form-end tracks square brackets"
+  (define lines '("(define (foo)" "  (let ([x 1]" "        [y 2])" "    (+ x y)))"))
+  (define-values (end-idx depth) (find-form-end lines 0))
+  (check-equal? end-idx 4)
+  (check-equal? depth 0))


### PR DESCRIPTION
M4: gh-wave-finish error checking. M5: remove hardcoded host. M6: rsync --backup safety. m1: find-form-end robustness (strings, comments, brackets). 168 tests pass. Wave 5 of v0.17.5 milestone #88.