### PR TITLE
fix: extension registration arity bugs in remote-collab and session-export (#1573)

- Unwrap make-tool calls into 5-arg ext-register-tool! form
- Add tool-registration tests for both extensions

Fixes #1574, fixes #1575

### DIFF
--- a/extensions/remote-collab/remote-collab.rkt
+++ b/extensions/remote-collab/remote-collab.rkt
@@ -102,41 +102,40 @@
 (define (register-remote-tools ctx)
   (ext-register-tool!
    ctx
-   (make-tool
-    "remote-q"
-    (string-append "Control a remote q agent instance via SSH + tmux. "
-                   "Actions: status (check session), start (new session), "
-                   "send (send prompt), capture (read output), "
-                   "wait (wait for idle), interrupt (stop task), stop (kill session).")
-    (hasheq
-     'type
-     "object"
-     'required
-     '("host" "action")
-     'properties
-     (hasheq 'host
-             (hasheq 'type "string" 'description "SSH host (user@host)")
-             'action
-             (hasheq 'type "string" 'description "status|start|send|capture|wait|interrupt|stop")
-             'session
-             (hasheq 'type "string" 'description "Tmux session name (default: q-agent)")
-             'prompt
-             (hasheq 'type "string" 'description "Prompt text (for send)")
-             'lines
-             (hasheq 'type "integer" 'description "Lines to capture (default: 80)")
-             'cwd
-             (hasheq 'type "string" 'description "Working directory (for start)")
-             'provider
-             (hasheq 'type "string" 'description "Pi provider")
-             'model
-             (hasheq 'type "string" 'description "Pi model")
-             'thinking
-             (hasheq 'type "string" 'description "Thinking level")
-             'timeout
-             (hasheq 'type "integer" 'description "Wait timeout seconds (default: 60)")
-             'ssh_options
-             (hasheq 'type "array" 'description "Extra SSH options")))
-    handle-remote-q))
+   "remote-q"
+   (string-append "Control a remote q agent instance via SSH + tmux. "
+                  "Actions: status (check session), start (new session), "
+                  "send (send prompt), capture (read output), "
+                  "wait (wait for idle), interrupt (stop task), stop (kill session).")
+   (hasheq
+    'type
+    "object"
+    'required
+    '("host" "action")
+    'properties
+    (hasheq 'host
+            (hasheq 'type "string" 'description "SSH host (user@host)")
+            'action
+            (hasheq 'type "string" 'description "status|start|send|capture|wait|interrupt|stop")
+            'session
+            (hasheq 'type "string" 'description "Tmux session name (default: q-agent)")
+            'prompt
+            (hasheq 'type "string" 'description "Prompt text (for send)")
+            'lines
+            (hasheq 'type "integer" 'description "Lines to capture (default: 80)")
+            'cwd
+            (hasheq 'type "string" 'description "Working directory (for start)")
+            'provider
+            (hasheq 'type "string" 'description "Pi provider")
+            'model
+            (hasheq 'type "string" 'description "Pi model")
+            'thinking
+            (hasheq 'type "string" 'description "Thinking level")
+            'timeout
+            (hasheq 'type "integer" 'description "Wait timeout seconds (default: 60)")
+            'ssh_options
+            (hasheq 'type "array" 'description "Extra SSH options")))
+   handle-remote-q)
   (hook-pass ctx))
 
 (define-q-extension the-extension

--- a/extensions/session-export.rkt
+++ b/extensions/session-export.rkt
@@ -76,22 +76,21 @@
     [else (make-success-result (list (hasheq 'type "text" 'text result)))]))
 
 (define (register-export-tools ctx)
-  (ext-register-tool!
-   ctx
-   (make-tool "session-export"
-              "Export session logs to HTML, JSON, or Markdown."
-              (hasheq 'type
-                      "object"
-                      'required
-                      '("session_path")
-                      'properties
-                      (hasheq 'session_path
-                              (hasheq 'type "string" 'description "Session JSONL file path")
-                              'format
-                              (hasheq 'type "string" 'description "html|json|markdown")
-                              'output_path
-                              (hasheq 'type "string" 'description "Output file path")))
-              handle-session-export))
+  (ext-register-tool! ctx
+                      "session-export"
+                      "Export session logs to HTML, JSON, or Markdown."
+                      (hasheq 'type
+                              "object"
+                              'required
+                              '("session_path")
+                              'properties
+                              (hasheq 'session_path
+                                      (hasheq 'type "string" 'description "Session JSONL file path")
+                                      'format
+                                      (hasheq 'type "string" 'description "html|json|markdown")
+                                      'output_path
+                                      (hasheq 'type "string" 'description "Output file path")))
+                      handle-session-export)
   (hook-pass ctx))
 
 (define-q-extension session-export-extension

--- a/tests/test-remote-collab.rkt
+++ b/tests/test-remote-collab.rkt
@@ -90,6 +90,31 @@
   (check-true (string-contains? opts-str "BatchMode=yes")))
 
 ;; ============================================================
+;; Tool registration test
+;; ============================================================
+
+(require "../extensions/context.rkt"
+         "../extensions/dynamic-tools.rkt"
+         "../extensions/api.rkt"
+         "../extensions/hooks.rkt"
+         "../agent/event-bus.rkt")
+
+(test-case "remote-collab extension registers remote-q tool"
+  (define reg (make-tool-registry))
+  (define ctx
+    (make-extension-ctx #:session-id "test"
+                        #:session-dir "/tmp"
+                        #:event-bus (make-event-bus)
+                        #:extension-registry (make-extension-registry)
+                        #:tool-registry reg
+                        #:command-registry (box (hash))))
+  (define hook (hash-ref (extension-hooks the-extension) 'register-tools #f))
+  (check-not-false hook "register-tools hook exists")
+  (when hook
+    (hook ctx))
+  (check-not-false (lookup-tool reg "remote-q") "remote-q tool registered"))
+
+;; ============================================================
 ;; M7 regression: Session name validation
 ;; ============================================================
 

--- a/tests/test-session-export.rkt
+++ b/tests/test-session-export.rkt
@@ -1,0 +1,109 @@
+#lang racket/base
+
+;; tests/test-session-export.rkt — Tests for session-export extension
+
+(require rackunit
+         racket/file
+         racket/string
+         json
+         "../extensions/session-export.rkt"
+         "../extensions/context.rkt"
+         "../extensions/dynamic-tools.rkt"
+         "../extensions/api.rkt"
+         "../extensions/hooks.rkt"
+         "../tools/tool.rkt"
+         "../agent/event-bus.rkt")
+
+;; ============================================================
+;; Tool registration test
+;; ============================================================
+
+(test-case "session-export extension registers session-export tool"
+  (define reg (make-tool-registry))
+  (define ctx
+    (make-extension-ctx #:session-id "test"
+                        #:session-dir "/tmp"
+                        #:event-bus (make-event-bus)
+                        #:extension-registry (make-extension-registry)
+                        #:tool-registry reg
+                        #:command-registry (box (hash))))
+  (define hook (hash-ref (extension-hooks the-extension) 'register-tools #f))
+  (check-not-false hook "register-tools hook exists")
+  (when hook
+    (hook ctx))
+  (check-not-false (lookup-tool reg "session-export") "session-export tool registered"))
+
+;; ============================================================
+;; Handler tests
+;; ============================================================
+
+(test-case "handle-session-export requires session_path"
+  (check-exn exn:fail? (lambda () (handle-session-export (hasheq 'format "html")))))
+
+(test-case "handle-session-export errors on missing file"
+  (check-exn exn:fail?
+             (lambda () (handle-session-export (hasheq 'session_path "/tmp/nonexistent.jsonl")))))
+
+(test-case "handle-session-export exports markdown"
+  (define tmp (make-temporary-file "sess-~a.jsonl"))
+  (call-with-output-file tmp
+                         (lambda (out)
+                           (displayln (jsexpr->string (hasheq 'role "user" 'content "Hello")) out)
+                           (displayln (jsexpr->string (hasheq 'role "assistant" 'content "Hi there"))
+                                      out))
+                         #:exists 'replace)
+  (define result (handle-session-export (hasheq 'session_path (path->string tmp) 'format "markdown")))
+  (check-pred tool-result? result)
+  (check-false (tool-result-is-error? result))
+  (define text (hash-ref (car (tool-result-content result)) 'text ""))
+  (check-true (string-contains? text "User"))
+  (check-true (string-contains? text "Hello"))
+  (delete-file tmp))
+
+(test-case "handle-session-export exports html"
+  (define tmp (make-temporary-file "sess-~a.jsonl"))
+  (call-with-output-file
+   tmp
+   (lambda (out)
+     (displayln (jsexpr->string (hasheq 'role "user" 'content "<script>alert(1)</script>")) out))
+   #:exists 'replace)
+  (define result (handle-session-export (hasheq 'session_path (path->string tmp) 'format "html")))
+  (check-pred tool-result? result)
+  (check-false (tool-result-is-error? result))
+  (define text (hash-ref (car (tool-result-content result)) 'text ""))
+  (check-true (string-contains? text "&lt;script&gt;"))
+  (delete-file tmp))
+
+(test-case "handle-session-export exports json"
+  (define tmp (make-temporary-file "sess-~a.jsonl"))
+  (call-with-output-file tmp
+                         (lambda (out)
+                           (displayln (jsexpr->string (hasheq 'role "user" 'content "Hello")) out))
+                         #:exists 'replace)
+  (define result (handle-session-export (hasheq 'session_path (path->string tmp) 'format "json")))
+  (check-pred tool-result? result)
+  (check-false (tool-result-is-error? result))
+  (define text (hash-ref (car (tool-result-content result)) 'text ""))
+  (check-true (string-contains? text "Hello"))
+  (delete-file tmp))
+
+(test-case "handle-session-export writes to output_path"
+  (define tmp (make-temporary-file "sess-~a.jsonl"))
+  (define out-tmp (make-temporary-file "out-~a.md"))
+  (call-with-output-file tmp
+                         (lambda (out)
+                           (displayln (jsexpr->string (hasheq 'role "user" 'content "Hello")) out))
+                         #:exists 'replace)
+  (define result
+    (handle-session-export (hasheq 'session_path
+                                   (path->string tmp)
+                                   'format
+                                   "markdown"
+                                   'output_path
+                                   (path->string out-tmp))))
+  (check-pred tool-result? result)
+  (check-false (tool-result-is-error? result))
+  (check-true (file-exists? out-tmp))
+  (check-true (string-contains? (file->string out-tmp) "Hello"))
+  (delete-file tmp)
+  (delete-file out-tmp))


### PR DESCRIPTION
Addresses #1573.

fix: extension registration arity bugs in remote-collab and session-export (#1573)

- Unwrap make-tool calls into 5-arg ext-register-tool! form
- Add tool-registration tests for both extensions

Fixes #1574, fixes #1575