### PR TITLE
fix: /activate and /deactivate use session-dir instead of project-dir (#1588)

Wave 1 of v0.17.8.

Both handle-activate-command and handle-deactivate-command derived project-dir
from (path-only session-dir) which gives the session storage parent (~/.q/sessions/)
instead of the project root. Changed to (current-directory) which q sets to the
project root at startup.

Updated tests to parameterize current-directory.

### DIFF
--- a/tests/test-tui-activate-command.rkt
+++ b/tests/test-tui-activate-command.rkt
@@ -33,74 +33,84 @@
 ;; Tests
 ;; ============================================================
 
-(test-case "/activate with no session-dir shows error"
-  (define cctx (make-test-cctx))
-  (define result (process-slash-command cctx 'activate))
-  (check-equal? result 'continue)
-  (define state (unbox (cmd-ctx-state-box cctx)))
-  (define text (transcript-entry-text (car (ui-state-transcript state))))
-  (check-true (string-contains? text "no project directory")))
+(test-case "/activate with no args shows status (no session-dir needed)"
+  (define tmp-dir (make-temporary-file "q-activate-nosess-~a" 'directory))
+  (parameterize ([current-directory tmp-dir])
+    (define cctx (make-test-cctx))
+    (define result (process-slash-command cctx 'activate))
+    (check-equal? result 'continue)
+    (define state (unbox (cmd-ctx-state-box cctx)))
+    (define texts (map transcript-entry-text (ui-state-transcript state)))
+    ;; Should show Extension Status heading (not an error)
+    (check-not-false (for/or ([t (in-list texts)])
+                       (string-contains? t "Extension Status"))))
+  (delete-directory/files tmp-dir))
 
 (test-case "/activate with no args shows status"
   (define tmp-dir (make-temporary-file "q-activate-cmd-~a" 'directory))
-  (define cctx (make-test-cctx #:input-text "/activate" #:session-dir (build-path tmp-dir "session")))
-  (make-directory* (build-path tmp-dir "session"))
-  (define result (process-slash-command cctx 'activate))
-  (check-equal? result 'continue)
-  (define state (unbox (cmd-ctx-state-box cctx)))
-  (define texts (map transcript-entry-text (ui-state-transcript state)))
-  ;; Should show Extension Status heading
-  (check-not-false (for/or ([t (in-list texts)])
-                     (string-contains? t "Extension Status")))
-  ;; Should show available extensions
-  (check-not-false (for/or ([t (in-list texts)])
-                     (string-contains? t "Available extensions")))
+  (parameterize ([current-directory tmp-dir])
+    (define cctx
+      (make-test-cctx #:input-text "/activate" #:session-dir (build-path tmp-dir "session")))
+    (make-directory* (build-path tmp-dir "session"))
+    (define result (process-slash-command cctx 'activate))
+    (check-equal? result 'continue)
+    (define state (unbox (cmd-ctx-state-box cctx)))
+    (define texts (map transcript-entry-text (ui-state-transcript state)))
+    ;; Should show Extension Status heading
+    (check-not-false (for/or ([t (in-list texts)])
+                       (string-contains? t "Extension Status")))
+    ;; Should show available extensions
+    (check-not-false (for/or ([t (in-list texts)])
+                       (string-contains? t "Available extensions"))))
   (delete-directory/files tmp-dir))
 
 (test-case "/activate --available lists extensions"
   (define tmp-dir (make-temporary-file "q-activate-avail-~a" 'directory))
-  (define cctx
-    (make-test-cctx #:input-text "/activate --available"
-                    #:session-dir (build-path tmp-dir "session")))
-  (make-directory* (build-path tmp-dir "session"))
-  (define result (process-slash-command cctx 'activate))
-  (check-equal? result 'continue)
-  (define state (unbox (cmd-ctx-state-box cctx)))
-  (define texts (map transcript-entry-text (ui-state-transcript state)))
-  ;; Should list known extensions
-  (check-not-false (for/or ([t (in-list texts)])
-                     (string-contains? t "gsd-planning")))
+  (parameterize ([current-directory tmp-dir])
+    (define cctx
+      (make-test-cctx #:input-text "/activate --available"
+                      #:session-dir (build-path tmp-dir "session")))
+    (make-directory* (build-path tmp-dir "session"))
+    (define result (process-slash-command cctx 'activate))
+    (check-equal? result 'continue)
+    (define state (unbox (cmd-ctx-state-box cctx)))
+    (define texts (map transcript-entry-text (ui-state-transcript state)))
+    ;; Should list known extensions
+    (check-not-false (for/or ([t (in-list texts)])
+                       (string-contains? t "gsd-planning"))))
   (delete-directory/files tmp-dir))
 
 (test-case "/activate <name> creates symlink"
   (define tmp-dir (make-temporary-file "q-activate-name-~a" 'directory))
-  (define cctx
-    (make-test-cctx #:input-text "/activate gsd-planning"
-                    #:session-dir (build-path tmp-dir "session")))
-  (make-directory* (build-path tmp-dir "session"))
-  (define result (process-slash-command cctx 'activate))
-  (check-equal? result 'continue)
-  (define state (unbox (cmd-ctx-state-box cctx)))
-  (define texts (map transcript-entry-text (ui-state-transcript state)))
-  ;; Should confirm activation
-  (check-not-false (for/or ([t (in-list texts)])
-                     (and (string-contains? t "gsd-planning") (string-contains? t "activated"))))
-  ;; Should have created .q/extensions/ in project dir
-  (define ext-dir (build-path tmp-dir ".q" "extensions"))
-  (check-true (directory-exists? ext-dir))
+  (parameterize ([current-directory tmp-dir])
+    (define cctx
+      (make-test-cctx #:input-text "/activate gsd-planning"
+                      #:session-dir (build-path tmp-dir "session")))
+    (make-directory* (build-path tmp-dir "session"))
+    (define result (process-slash-command cctx 'activate))
+    (check-equal? result 'continue)
+    (define state (unbox (cmd-ctx-state-box cctx)))
+    (define texts (map transcript-entry-text (ui-state-transcript state)))
+    ;; Should confirm activation
+    (check-not-false (for/or ([t (in-list texts)])
+                       (and (string-contains? t "gsd-planning") (string-contains? t "activated"))))
+    ;; Should have created .q/extensions/ in project dir (= current-directory)
+    (define ext-dir (build-path tmp-dir ".q" "extensions"))
+    (check-true (directory-exists? ext-dir)))
   (delete-directory/files tmp-dir))
 
 (test-case "/activate <unknown> shows error"
   (define tmp-dir (make-temporary-file "q-activate-unk-~a" 'directory))
-  (define cctx
-    (make-test-cctx #:input-text "/activate nonexistent-extension"
-                    #:session-dir (build-path tmp-dir "session")))
-  (make-directory* (build-path tmp-dir "session"))
-  (define result (process-slash-command cctx 'activate))
-  (check-equal? result 'continue)
-  (define state (unbox (cmd-ctx-state-box cctx)))
-  (define texts (map transcript-entry-text (ui-state-transcript state)))
-  ;; Should show error
-  (check-not-false (for/or ([t (in-list texts)])
-                     (string-contains? t "not found")))
+  (parameterize ([current-directory tmp-dir])
+    (define cctx
+      (make-test-cctx #:input-text "/activate nonexistent-extension"
+                      #:session-dir (build-path tmp-dir "session")))
+    (make-directory* (build-path tmp-dir "session"))
+    (define result (process-slash-command cctx 'activate))
+    (check-equal? result 'continue)
+    (define state (unbox (cmd-ctx-state-box cctx)))
+    (define texts (map transcript-entry-text (ui-state-transcript state)))
+    ;; Should show error
+    (check-not-false (for/or ([t (in-list texts)])
+                       (string-contains? t "not found"))))
   (delete-directory/files tmp-dir))

--- a/tui/commands.rkt
+++ b/tui/commands.rkt
@@ -423,15 +423,9 @@
 ;;   /activate --global <name> — activate in ~/.q/extensions/
 (define (handle-activate-command cctx)
   (define state (unbox (cmd-ctx-state-box cctx)))
-  (define session-dir (cmd-ctx-session-dir cctx))
-  (define project-dir (and session-dir (path-only session-dir)))
+  (define project-dir (current-directory))
   (define entries
     (cond
-      [(not project-dir)
-       (list (make-entry 'error
-                         "/activate: no project directory available (start a session first)"
-                         (current-inexact-milliseconds)
-                         (hash)))]
       [else
        ;; Parse args from raw input text (after /activate)
        (define input (unbox (cmd-ctx-input-text-box cctx)))
@@ -519,15 +513,9 @@
 
 (define (handle-deactivate-command cctx)
   (define state (unbox (cmd-ctx-state-box cctx)))
-  (define session-dir (cmd-ctx-session-dir cctx))
-  (define project-dir (and session-dir (path-only session-dir)))
+  (define project-dir (current-directory))
   (define entries
     (cond
-      [(not project-dir)
-       (list (make-entry 'error
-                         "/deactivate: no project directory available (start a session first)"
-                         (current-inexact-milliseconds)
-                         (hash)))]
       [else
        ;; Parse args from raw input text (after /deactivate)
        (define input (unbox (cmd-ctx-input-text-box cctx)))


### PR DESCRIPTION
Addresses #1588.

fix: /activate and /deactivate use session-dir instead of project-dir (#1588)

Wave 1 of v0.17.8.

Both handle-activate-command and handle-deactivate-command derived project-dir
from (path-only session-dir) which gives the session storage parent (~/.q/sessions/)
instead of the project root. Changed to (current-directory) which q sets to the
project root at startup.

Updated tests to parameterize current-directory.