### PR TITLE
feat: extension command dispatch plumbing (#1589)

Wave 2 of v0.17.8.

- Add extension-registry-box field to cmd-ctx (10th field) and tui-ctx (14th field)
- Wire extension-registry from run-modes.rkt through tui-init.rkt to tui-ctx
- In process-slash-command, dispatch unknown commands via 'execute-command hook
- Update all test cmd-ctx constructors for new field
- Extension commands like /plan will now dispatch to registered handlers

### DIFF
--- a/tests/test-model-command.rkt
+++ b/tests/test-model-command.rkt
@@ -51,7 +51,8 @@
            (and reg (box reg)) ; model-registry-box
            (box #f) ; last-prompt-box
            #f ; session-runner
-           (box ""))) ; input-text-box
+           (box "") ; input-text-box
+           (box #f))) ; extension-registry-box
 
 ;; Extract transcript text from a cmd-ctx
 (define (cctx-transcript-text cctx)

--- a/tests/test-tui-activate-command.rkt
+++ b/tests/test-tui-activate-command.rkt
@@ -27,7 +27,8 @@
            (box #f) ; model-registry
            (box #f) ; last-prompt
            (lambda (prompt) (void))
-           (box input-text)))
+           (box input-text)
+           (box #f))) ; extension-registry-box
 
 ;; ============================================================
 ;; Tests

--- a/tests/tui/commands.rkt
+++ b/tests/tui/commands.rkt
@@ -21,7 +21,8 @@
            #f ;; model-registry-box
            (box #f) ;; last-prompt-box
            #f ;; session-runner
-           (box ""))) ;; input-text-box
+           (box "") ;; input-text-box
+           (box #f))) ;; extension-registry-box
 
 (define commands-tests
   (test-suite "TUI Commands"

--- a/tests/tui/test-command-integration.rkt
+++ b/tests/tui/test-command-integration.rkt
@@ -25,7 +25,8 @@
            #f ;; model-registry-box
            (box #f) ;; last-prompt-box
            #f ;; session-runner
-           (box ""))) ;; input-text-box
+           (box "") ;; input-text-box
+           (box #f))) ;; extension-registry-box
 
 ;; Helper: get transcript text entries from cctx state
 (define (get-transcript-texts cctx)

--- a/tui/commands.rkt
+++ b/tui/commands.rkt
@@ -26,7 +26,8 @@
          "../runtime/settings.rkt"
          "../interfaces/sessions.rkt"
          "../runtime/model-registry.rkt"
-         "../runtime/extension-catalog.rkt")
+         "../runtime/extension-catalog.rkt"
+         "../extensions/hooks.rkt")
 
 ;; Command context struct (lightweight, avoids circular dep with interfaces/tui)
 (provide cmd-ctx
@@ -40,6 +41,7 @@
          cmd-ctx-last-prompt-box
          cmd-ctx-session-runner
          cmd-ctx-input-text-box
+         cmd-ctx-extension-registry-box
 
          ;; Main command dispatcher
          process-slash-command)
@@ -59,7 +61,8 @@
          model-registry-box ; (or/c (boxof (or/c model-registry? #f)) #f)
          last-prompt-box ; (boxof (or/c string? #f)) — last user prompt for /retry
          session-runner ; (string -> void) or #f — for /retry resubmission
-         input-text-box) ; (boxof string?) — raw input text for commands like /activate
+         input-text-box ; (boxof string?) — raw input text for commands like /activate
+         extension-registry-box) ; (or/c (boxof (or/c extension-registry? #f)) #f) — for ext command dispatch
   #:transparent)
 
 ;; ============================================================
@@ -714,7 +717,32 @@
         (set-box! (cmd-ctx-running-box cctx) #f)
         'quit]
        [(unknown)
-        (define entry (make-entry 'error "Unknown command. Type /help for commands." 0 (hash)))
-        (set-box! (cmd-ctx-state-box cctx) (add-transcript-entry state entry))
-        'continue]
+        ;; Try extension command dispatch before showing error
+        (define ext-reg-box (cmd-ctx-extension-registry-box cctx))
+        (define ext-reg (and ext-reg-box (unbox ext-reg-box)))
+        (define input-text (unbox (cmd-ctx-input-text-box cctx)))
+        (define cmd-name
+          (let ([trimmed (string-trim input-text)])
+            (and (> (string-length trimmed) 0)
+                 (char=? (string-ref trimmed 0) #\/)
+                 (let ([parts (string-split trimmed)]) (and (pair? parts) (car parts))))))
+        (define ext-result
+          (and
+           ext-reg
+           cmd-name
+           (dispatch-hooks 'execute-command (hasheq 'command cmd-name 'input input-text) ext-reg)))
+        (cond
+          [(and ext-result (hook-result? ext-result) (eq? (hook-result-action ext-result) 'amend))
+           ;; Extension handled the command — display result text
+           (define payload (hook-result-payload ext-result))
+           (define text (hash-ref payload 'text #f))
+           (when text
+             (define entry (make-entry 'system text (current-inexact-milliseconds) (hash)))
+             (set-box! (cmd-ctx-state-box cctx)
+                       (add-transcript-entry (unbox (cmd-ctx-state-box cctx)) entry)))
+           'continue]
+          [else
+           (define entry (make-entry 'error "Unknown command. Type /help for commands." 0 (hash)))
+           (set-box! (cmd-ctx-state-box cctx) (add-transcript-entry state entry))
+           'continue])]
        [else 'continue])]))

--- a/tui/tui-init.rkt
+++ b/tui/tui-init.rkt
@@ -65,7 +65,8 @@
     (make-tui-ctx #:event-bus bus
                   #:session-runner (lambda (prompt) (run-prompt! sess prompt))
                   #:session-dir sess-dir
-                  #:model-registry (hash-ref rt-config 'model-registry #f)))
+                  #:model-registry (hash-ref rt-config 'model-registry #f)
+                  #:extension-registry (hash-ref rt-config 'extension-registry #f)))
 
   ;; Subscribe to events
   (subscribe-runtime-events! ctx)

--- a/tui/tui-keybindings.rkt
+++ b/tui/tui-keybindings.rkt
@@ -83,13 +83,15 @@
          ubuf-box ; (boxof any) — ubuf buffer for output
          model-registry-box ; (boxof (or/c model-registry? #f)) — model registry for /model
          previous-frame-box ; (boxof (or/c (listof string) #f)) — last rendered frame for diffing
-         last-prompt-box) ; (boxof (or/c string? #f)) — last user prompt for /retry
+         last-prompt-box ; (boxof (or/c string? #f)) — last user prompt for /retry
+         extension-registry-box) ; (or/c (boxof (or/c extension-registry? #f)) #f)
   #:transparent)
 
 (define (make-tui-ctx #:event-bus [bus #f]
                       #:session-runner [runner (lambda (prompt) (void))]
                       #:session-dir [sess-dir #f]
-                      #:model-registry [reg #f])
+                      #:model-registry [reg #f]
+                      #:extension-registry [ext-reg #f])
   (tui-ctx (box (initial-ui-state))
            (box (initial-input-state))
            bus
@@ -102,7 +104,8 @@
            (box #f) ; ubuf-box - set when buffer created
            (box reg) ; model-registry-box
            (box #f) ; previous-frame-box - #f means no previous frame
-           (box #f))) ; last-prompt-box - #f until first submit
+           (box #f) ; last-prompt-box - #f until first submit
+           (box ext-reg))) ; extension-registry-box
 
 ;; ============================================================
 ;; mark-dirty!
@@ -189,7 +192,8 @@
                     (tui-ctx-model-registry-box ctx)
                     (tui-ctx-last-prompt-box ctx)
                     (tui-ctx-session-runner ctx)
-                    (box "")))
+                    (box "")
+                    (tui-ctx-extension-registry-box ctx)))
 
 ;; Process a slash command. Returns 'continue | 'quit
 ;; cmd can be: symbol | (list symbol args...)


### PR DESCRIPTION
Addresses #1589.

feat: extension command dispatch plumbing (#1589)

Wave 2 of v0.17.8.

- Add extension-registry-box field to cmd-ctx (10th field) and tui-ctx (14th field)
- Wire extension-registry from run-modes.rkt through tui-init.rkt to tui-ctx
- In process-slash-command, dispatch unknown commands via 'execute-command hook
- Update all test cmd-ctx constructors for new field
- Extension commands like /plan will now dispatch to registered handlers