### PR TITLE
feat: gsd-planning execute-command handler + hot-load after activation (#1590)

Wave 3 of v0.17.8.

- Add execute-command hook point to hook-action-schemas
- Add handle-execute-command to gsd-planning.rkt for /plan, /state, /handoff
- Add try-hot-load-extension helper in commands.rkt
- Hot-load extensions into running registry after /activate
- 4 new tests for execute-command handler (plan content, state content, unknown pass, missing artifact)

### DIFF
--- a/extensions/gsd-planning.rkt
+++ b/extensions/gsd-planning.rkt
@@ -217,12 +217,35 @@
   (ext-register-command! ctx "/handoff" "Display handoff status" 'general '() '("ho"))
   (hook-pass #f))
 
+;; Execute command handler: responds to /plan, /state, /handoff dispatch
+(define (handle-execute-command payload)
+  (define cmd (hash-ref payload 'command #f))
+  (define base-dir (current-directory))
+  (define artifact
+    (cond
+      [(member cmd '("/plan" "/p")) "PLAN"]
+      [(member cmd '("/state" "/s")) "STATE"]
+      [(member cmd '("/handoff" "/ho")) "HANDOFF"]
+      [else #f]))
+  (cond
+    [(not artifact) (hook-pass payload)]
+    [else
+     (define content (read-planning-artifact base-dir artifact))
+     (define text
+       (cond
+         [(not content) (format "No ~a found in .planning/" artifact)]
+         [(hash? content) (jsexpr->string content)]
+         [else content]))
+     (hook-amend (hasheq 'text text))]))
+
 (define-q-extension gsd-planning-extension
                     #:version "1.0.0"
                     #:api-version "1"
                     #:on register-tools
                     register-gsd-tools
                     #:on register-shortcuts
-                    register-gsd-commands)
+                    register-gsd-commands
+                    #:on execute-command
+                    handle-execute-command)
 
 (define the-extension gsd-planning-extension)

--- a/tests/test-gsd-planning.rkt
+++ b/tests/test-gsd-planning.rkt
@@ -342,3 +342,50 @@
   (check-true (or (tool-result-is-error? result)
                   (not (file-exists? (build-path dir ".planning" "../../etc/crontab.md")))))
   (delete-directory/files dir))
+
+;; ============================================================
+;; execute-command handler tests
+;; ============================================================
+
+(test-case "execute-command handler returns plan content"
+  (with-temp-dir
+   (lambda (dir)
+     (parameterize ([current-directory dir])
+       ;; Write a plan
+       (make-directory* (build-path dir ".planning"))
+       (call-with-output-file (build-path dir ".planning" "PLAN.md")
+         (lambda (out) (display "# Plan\nWave 1: test" out))
+         #:exists 'truncate)
+       ;; Get the handler from the extension hooks
+       (define handler (hash-ref (extension-hooks gsd-planning-extension) 'execute-command))
+       (define result (handler (hasheq 'command "/plan" 'input "/plan")))
+       (check-equal? (hook-result-action result) 'amend)
+       (check-equal? (hash-ref (hook-result-payload result) 'text) "# Plan\nWave 1: test")))))
+
+(test-case "execute-command handler returns state content"
+  (with-temp-dir
+   (lambda (dir)
+     (parameterize ([current-directory dir])
+       (make-directory* (build-path dir ".planning"))
+       (call-with-output-file (build-path dir ".planning" "STATE.md")
+         (lambda (out) (display "Status: in progress" out))
+         #:exists 'truncate)
+       (define handler (hash-ref (extension-hooks gsd-planning-extension) 'execute-command))
+       (define result (handler (hasheq 'command "/state" 'input "/state")))
+       (check-equal? (hook-result-action result) 'amend)
+       (check-true (string-contains? (hash-ref (hook-result-payload result) 'text) "in progress"))))))
+
+(test-case "execute-command handler passes unknown commands"
+  (define handler (hash-ref (extension-hooks gsd-planning-extension) 'execute-command))
+  (define result (handler (hasheq 'command "/unknown" 'input "/unknown")))
+  (check-equal? (hook-result-action result) 'pass))
+
+(test-case "execute-command handler reports missing artifact"
+  (with-temp-dir
+   (lambda (dir)
+     (parameterize ([current-directory dir])
+       ;; No .planning/ dir
+       (define handler (hash-ref (extension-hooks gsd-planning-extension) 'execute-command))
+       (define result (handler (hasheq 'command "/plan" 'input "/plan")))
+       (check-equal? (hook-result-action result) 'amend)
+       (check-true (string-contains? (hash-ref (hook-result-payload result) 'text) "No PLAN found"))))))

--- a/tui/commands.rkt
+++ b/tui/commands.rkt
@@ -27,7 +27,8 @@
          "../interfaces/sessions.rkt"
          "../runtime/model-registry.rkt"
          "../runtime/extension-catalog.rkt"
-         "../extensions/hooks.rkt")
+         "../extensions/hooks.rkt"
+         "../extensions/loader.rkt")
 
 ;; Command context struct (lightweight, avoids circular dep with interfaces/tui)
 (provide cmd-ctx
@@ -418,6 +419,35 @@
 ;; /activate command — extension management
 ;; ============================================================
 
+;; Try to hot-load a newly activated extension into the running registry.
+;; Returns a status entry (success or warning) or #f if no registry available.
+(define (try-hot-load-extension cctx name target-dir)
+  (define ext-reg-box (cmd-ctx-extension-registry-box cctx))
+  (define ext-reg (and ext-reg-box (unbox ext-reg-box)))
+  (define bus (cmd-ctx-event-bus cctx))
+  (cond
+    [(not ext-reg) #f]
+    [else
+     (define ext-path (build-path target-dir (string-append name ".rkt")))
+     (cond
+       [(not (file-exists? ext-path))
+        (make-entry 'system
+                    (format "  Warning: extension file not found for hot-load: ~a" ext-path)
+                    (current-inexact-milliseconds)
+                    (hash))]
+       [else
+        (with-handlers ([exn:fail? (λ (e)
+                                     (make-entry 'system
+                                                 (format "  Warning: hot-load failed: ~a"
+                                                         (exn-message e))
+                                                 (current-inexact-milliseconds)
+                                                 (hash)))])
+          (load-extension! ext-reg ext-path #:event-bus bus)
+          (make-entry 'system
+                      (format "  Extension '~a' loaded into running session." name)
+                      (current-inexact-milliseconds)
+                      (hash)))])]))
+
 ;; handle-activate-command : cmd-ctx? -> 'continue
 ;; Supports:
 ;;   /activate              — show status (active + available)
@@ -452,10 +482,17 @@
              (define target-dir (build-path q-home "extensions"))
              (with-handlers ([exn:fail? (λ (e) (list (make-entry 'error (exn-message e) 0 (hash))))])
                (activate-extension! name target-dir)
-               (list (make-entry 'system
-                                 (format "Extension '~a' activated globally (~a)" name target-dir)
-                                 (current-inexact-milliseconds)
-                                 (hash))))])]
+               (define hot-load-entry (try-hot-load-extension cctx name target-dir))
+               (if hot-load-entry
+                   (list (make-entry 'system
+                                     (format "Extension '~a' activated globally (~a)" name target-dir)
+                                     (current-inexact-milliseconds)
+                                     (hash))
+                         hot-load-entry)
+                   (list (make-entry 'system
+                                     (format "Extension '~a' activated globally (~a)" name target-dir)
+                                     (current-inexact-milliseconds)
+                                     (hash)))))])]
          ;; /activate <name> — activate in project-local dir
          [(and (pair? args) (not (string-prefix? (car args) "--")))
           (define name (car args))
@@ -466,10 +503,17 @@
              (define target-dir (build-path project-dir ".q" "extensions"))
              (with-handlers ([exn:fail? (λ (e) (list (make-entry 'error (exn-message e) 0 (hash))))])
                (activate-extension! name target-dir)
-               (list (make-entry 'system
-                                 (format "Extension '~a' activated locally (~a)" name target-dir)
-                                 (current-inexact-milliseconds)
-                                 (hash))))])]
+               (define hot-load-entry (try-hot-load-extension cctx name target-dir))
+               (if hot-load-entry
+                   (list (make-entry 'system
+                                     (format "Extension '~a' activated locally (~a)" name target-dir)
+                                     (current-inexact-milliseconds)
+                                     (hash))
+                         hot-load-entry)
+                   (list (make-entry 'system
+                                     (format "Extension '~a' activated locally (~a)" name target-dir)
+                                     (current-inexact-milliseconds)
+                                     (hash)))))])]
          ;; /activate with no args — show status
          [else (list-status-entries project-dir)])]))
   (define new-state

--- a/util/hook-types.rkt
+++ b/util/hook-types.rkt
@@ -143,6 +143,9 @@
           ;; Shortcut registration
           'register-shortcuts
           '(pass amend)
+          ;; Command dispatch
+          'execute-command
+          '(pass amend)
           ;; Agent lifecycle
           'agent.started
           '(pass)


### PR DESCRIPTION
Addresses #1590.

feat: gsd-planning execute-command handler + hot-load after activation (#1590)

Wave 3 of v0.17.8.

- Add execute-command hook point to hook-action-schemas
- Add handle-execute-command to gsd-planning.rkt for /plan, /state, /handoff
- Add try-hot-load-extension helper in commands.rkt
- Hot-load extensions into running registry after /activate
- 4 new tests for execute-command handler (plan content, state content, unknown pass, missing artifact)