### PR TITLE
fix: review cleanup — remove diagnostic logging, restrict /plan submit, add tests (#1596)

Wave 1 of v0.17.9.

- Remove all /tmp/q-cmd-dispatch.log diagnostic tracing from 4 files
- Replace with log-debug where useful, remove otherwise
- Fix stale `-> void?` contract comment in loader.rkt (now boolean?)
- Restrict /plan <text> submit to /plan and /p only;
  /state and /handoff always display artifact
- Add 5 new tests for execute-command with/without args

### DIFF
--- a/extensions/gsd-planning.rkt
+++ b/extensions/gsd-planning.rkt
@@ -222,13 +222,6 @@
   (define cmd (hash-ref payload 'command #f))
   (define input-text (hash-ref payload 'input ""))
   (define base-dir (current-directory))
-  (with-output-to-file "/tmp/q-cmd-dispatch.log"
-                       (lambda ()
-                         (printf "[~a] handle-execute-command: cmd=~a base-dir=~a\n"
-                                 (current-inexact-milliseconds)
-                                 cmd
-                                 base-dir))
-                       #:exists 'append)
   (define artifact
     (cond
       [(member cmd '("/plan" "/p")) "PLAN"]
@@ -238,31 +231,21 @@
   (cond
     [(not artifact) (hook-pass payload)]
     [else
-     ;; Extract arguments after the command
-     (define cmd-prefix
-       (let ([trimmed (string-trim input-text)])
-         (if (and (> (string-length trimmed) 0) (char=? (string-ref trimmed 0) #\/))
-             (let ([parts (string-split trimmed)])
-               (if (pair? parts)
-                   (car parts)
-                   cmd))
-             cmd)))
-     (define args
-       (let ([rest (string-trim (substring input-text (string-length cmd-prefix)))])
-         (if (string=? rest "") #f rest)))
      (cond
-       ;; /plan <text> → submit as prompt to the agent
-       [args (hook-amend (hasheq 'submit args 'text (format "Planning: ~a" args)))]
+       ;; /plan <text> and /p <text> → submit as prompt to the agent
+       [(and (member cmd '("/plan" "/p"))
+             (let* ([trimmed (string-trim input-text)]
+                    [parts (and (> (string-length trimmed) 0)
+                                (char=? (string-ref trimmed 0) #\/)
+                                (string-split trimmed))])
+               (and (pair? parts)
+                    (let ([rest (string-trim (substring input-text (string-length (car parts))))])
+                      (and (> (string-length rest) 0) rest)))))
+        =>
+        (lambda (args) (hook-amend (hasheq 'submit args 'text (format "Planning: ~a" args))))]
        [else
-        ;; /plan (no args) → display current plan
+        ;; Display artifact content (always for /state, /handoff; no-args /plan)
         (define content (read-planning-artifact base-dir artifact))
-        (with-output-to-file "/tmp/q-cmd-dispatch.log"
-                             (lambda ()
-                               (printf "[~a] handle-execute-command: artifact=~a content=~a\n"
-                                       (current-inexact-milliseconds)
-                                       artifact
-                                       (and content #t)))
-                             #:exists 'append)
         (define text
           (cond
             [(not content) (format "No ~a found in .planning/" artifact)]

--- a/extensions/hooks.rkt
+++ b/extensions/hooks.rkt
@@ -60,13 +60,6 @@
 ;; it is skipped and a warning is logged.
 (define (dispatch-hooks hook-point payload registry #:ctx [ctx #f])
   (define handlers (handlers-for-point registry hook-point))
-  (when (eq? hook-point 'execute-command)
-    (with-output-to-file "/tmp/q-cmd-dispatch.log"
-                         (lambda ()
-                           (printf "[~a] dispatch-hooks execute-command: ~a handlers found\n"
-                                   (current-inexact-milliseconds)
-                                   (length handlers)))
-                         #:exists 'append))
   (let loop ([remaining handlers]
              [current-payload payload]
              [amended? #f])
@@ -102,15 +95,11 @@
     (if (critical-hook? hook-point)
         (hook-block (format "handler ~a failed for critical hook ~a" ext-name hook-point))
         (hook-pass payload)))
-  (with-handlers ([exn:fail? (lambda (e)
-                               (when (eq? hook-point 'execute-command)
-                                 (with-output-to-file "/tmp/q-cmd-dispatch.log"
-                                                      (lambda ()
-                                                        (printf "[~a] OUTER-HANDLER-CAUGHT: ~a\n"
-                                                                (current-inexact-milliseconds)
-                                                                (exn-message e)))
-                                                      #:exists 'append))
-                               error-default)])
+  (with-handlers
+      ([exn:fail?
+        (lambda (e)
+          (log-debug "hook handler ~a failed for ~a: ~a" ext-name hook-point (exn-message e))
+          error-default)])
     (define raw-result
       (if timeout-ms
           ;; Run with timeout
@@ -125,21 +114,10 @@
               (kill-thread thd)) ; #447: prevent thread leak
             (cond
               [(not maybe)
-               (when (eq? hook-point 'execute-command)
-                 (with-output-to-file
-                  "/tmp/q-cmd-dispatch.log"
-                  (lambda ()
-                    (printf "[~a] TIMEOUT after ~ams\n" (current-inexact-milliseconds) timeout-ms))
-                  #:exists 'append))
+               (log-debug "hook ~a/~a timed out after ~ams" ext-name hook-point timeout-ms)
                error-default]
               [(eq? (car maybe) 'error)
-               (when (eq? hook-point 'execute-command)
-                 (with-output-to-file "/tmp/q-cmd-dispatch.log"
-                                      (lambda ()
-                                        (printf "[~a] INNER-ERROR: ~a\n"
-                                                (current-inexact-milliseconds)
-                                                (exn-message (cdr maybe))))
-                                      #:exists 'append))
+               (log-debug "hook ~a/~a error: ~a" ext-name hook-point (exn-message (cdr maybe)))
                error-default]
               [else (cdr maybe)]))
           ;; No timeout — direct call

--- a/extensions/loader.rkt
+++ b/extensions/loader.rkt
@@ -89,7 +89,7 @@
                (try-load-extension f)))]))
 
 ;; ============================================================
-;; load-extension! : extension-registry? path-string? #:event-bus -> void?
+;; load-extension! : extension-registry? path-string? #:event-bus -> boolean?
 ;; ============================================================
 
 ;; Dynamically loads a module, extracts `the-extension`, and
@@ -98,13 +98,6 @@
 ;; Returns #t if extension was loaded and registered, #f otherwise.
 (define (load-extension! registry path #:event-bus [event-bus #f])
   (define ext-name (get-extension-name-from-path path))
-  (with-output-to-file "/tmp/q-cmd-dispatch.log"
-                       (lambda ()
-                         (printf "[~a] load-extension! called: path=~a ext-name=~a\n"
-                                 (current-inexact-milliseconds)
-                                 path
-                                 ext-name))
-                       #:exists 'append)
   (define state (extension-state ext-name))
   (cond
     [(or (eq? state 'disabled) (eq? state 'quarantined)) #f]
@@ -127,21 +120,6 @@
                                        'timeout)))
            ;; No timeout — direct call
            (try-load-extension path)))
-     (with-output-to-file "/tmp/q-cmd-dispatch.log"
-                          (lambda ()
-                            (printf "[~a] load-extension! result: ~a\n"
-                                    (current-inexact-milliseconds)
-                                    (cond
-                                      [(extension-load-error? result)
-                                       (format "load-error: ~a [~a]"
-                                               (extension-load-error-message result)
-                                               (extension-load-error-category result))]
-                                      [(extension? result)
-                                       (format "ext ~a hooks ~a"
-                                               (extension-name result)
-                                               (hash-keys (extension-hooks result)))]
-                                      [else result])))
-                          #:exists 'append)
      (cond
        [(extension-load-error? result)
         (log-warning "extension load failed [~a]: ~a \u2014 ~a"
@@ -171,12 +149,6 @@
           (for ([msg (in-list tier-result)])
             (log-warning "extension tier violation [~a]: ~a" (extension-name result) msg)))
         (register-extension! registry result)
-        (with-output-to-file "/tmp/q-cmd-dispatch.log"
-                             (lambda ()
-                               (printf "[~a] register-extension! called for ~a\n"
-                                       (current-inexact-milliseconds)
-                                       (extension-name result)))
-                             #:exists 'append)
         #t]
        [else #f])]))
 

--- a/tests/test-gsd-planning.rkt
+++ b/tests/test-gsd-planning.rkt
@@ -354,8 +354,8 @@
        ;; Write a plan
        (make-directory* (build-path dir ".planning"))
        (call-with-output-file (build-path dir ".planning" "PLAN.md")
-         (lambda (out) (display "# Plan\nWave 1: test" out))
-         #:exists 'truncate)
+                              (lambda (out) (display "# Plan\nWave 1: test" out))
+                              #:exists 'truncate)
        ;; Get the handler from the extension hooks
        (define handler (hash-ref (extension-hooks gsd-planning-extension) 'execute-command))
        (define result (handler (hasheq 'command "/plan" 'input "/plan")))
@@ -368,8 +368,8 @@
      (parameterize ([current-directory dir])
        (make-directory* (build-path dir ".planning"))
        (call-with-output-file (build-path dir ".planning" "STATE.md")
-         (lambda (out) (display "Status: in progress" out))
-         #:exists 'truncate)
+                              (lambda (out) (display "Status: in progress" out))
+                              #:exists 'truncate)
        (define handler (hash-ref (extension-hooks gsd-planning-extension) 'execute-command))
        (define result (handler (hasheq 'command "/state" 'input "/state")))
        (check-equal? (hook-result-action result) 'amend)
@@ -381,11 +381,79 @@
   (check-equal? (hook-result-action result) 'pass))
 
 (test-case "execute-command handler reports missing artifact"
+  (with-temp-dir (lambda (dir)
+                   (parameterize ([current-directory dir])
+                     ;; No .planning/ dir
+                     (define handler
+                       (hash-ref (extension-hooks gsd-planning-extension) 'execute-command))
+                     (define result (handler (hasheq 'command "/plan" 'input "/plan")))
+                     (check-equal? (hook-result-action result) 'amend)
+                     (check-true (string-contains? (hash-ref (hook-result-payload result) 'text)
+                                                   "No PLAN found"))))))
+
+;; ============================================================
+;; execute-command /plan <text> submit tests (Wave 1 v0.17.9)
+;; ============================================================
+
+(test-case "/plan <text> returns submit payload"
+  (define handler (hash-ref (extension-hooks gsd-planning-extension) 'execute-command))
+  (define result (handler (hasheq 'command "/plan" 'input "/plan refactor the module")))
+  (check-equal? (hook-result-action result) 'amend)
+  (define payload (hook-result-payload result))
+  (check-equal? (hash-ref payload 'submit) "refactor the module")
+  (check-true (string-contains? (hash-ref payload 'text) "refactor the module")))
+
+(test-case "/p <text> returns submit payload (shortcut)"
+  (define handler (hash-ref (extension-hooks gsd-planning-extension) 'execute-command))
+  (define result (handler (hasheq 'command "/p" 'input "/p quick fix")))
+  (check-equal? (hook-result-action result) 'amend)
+  (define payload (hook-result-payload result))
+  (check-equal? (hash-ref payload 'submit) "quick fix"))
+
+(test-case "/plan (no args) returns display text"
+  (with-temp-dir (lambda (dir)
+                   (parameterize ([current-directory dir])
+                     (make-directory* (build-path dir ".planning"))
+                     (call-with-output-file (build-path dir ".planning" "PLAN.md")
+                                            (lambda (out) (display "# Test Plan" out))
+                                            #:exists 'truncate)
+                     (define handler
+                       (hash-ref (extension-hooks gsd-planning-extension) 'execute-command))
+                     (define result (handler (hasheq 'command "/plan" 'input "/plan")))
+                     (check-equal? (hook-result-action result) 'amend)
+                     (define payload (hook-result-payload result))
+                     ;; No submit key — display mode
+                     (check-false (hash-ref payload 'submit #f))
+                     (check-equal? (hash-ref payload 'text) "# Test Plan")))))
+
+(test-case "/state <text> ignores args and displays artifact"
   (with-temp-dir
    (lambda (dir)
      (parameterize ([current-directory dir])
-       ;; No .planning/ dir
+       (make-directory* (build-path dir ".planning"))
+       (call-with-output-file (build-path dir ".planning" "STATE.md")
+                              (lambda (out) (display "Status: active" out))
+                              #:exists 'truncate)
        (define handler (hash-ref (extension-hooks gsd-planning-extension) 'execute-command))
-       (define result (handler (hasheq 'command "/plan" 'input "/plan")))
+       (define result (handler (hasheq 'command "/state" 'input "/state some extra text")))
        (check-equal? (hook-result-action result) 'amend)
-       (check-true (string-contains? (hash-ref (hook-result-payload result) 'text) "No PLAN found"))))))
+       (define payload (hook-result-payload result))
+       ;; No submit key — /state always displays
+       (check-false (hash-ref payload 'submit #f))
+       (check-equal? (hash-ref payload 'text) "Status: active")))))
+
+(test-case "/handoff <text> ignores args and displays artifact"
+  (with-temp-dir
+   (lambda (dir)
+     (parameterize ([current-directory dir])
+       (make-directory* (build-path dir ".planning"))
+       (call-with-output-file (build-path dir ".planning" "HANDOFF.json")
+                              (lambda (out) (write-json (hasheq 'machine "local") out))
+                              #:exists 'truncate)
+       (define handler (hash-ref (extension-hooks gsd-planning-extension) 'execute-command))
+       (define result (handler (hasheq 'command "/handoff" 'input "/handoff do something")))
+       (check-equal? (hook-result-action result) 'amend)
+       (define payload (hook-result-payload result))
+       ;; No submit key — /handoff always displays
+       (check-false (hash-ref payload 'submit #f))
+       (check-true (string-contains? (hash-ref payload 'text) "local"))))))

--- a/tui/commands.rkt
+++ b/tui/commands.rkt
@@ -438,47 +438,22 @@
                     (hash))]
        [else
         (with-handlers ([exn:fail? (λ (e)
-                                     (with-output-to-file "/tmp/q-cmd-dispatch.log"
-                                                          (lambda ()
-                                                            (printf "[~a] hot-load FAILED: ~a\n"
-                                                                    (current-inexact-milliseconds)
-                                                                    (exn-message e)))
-                                                          #:exists 'append)
+                                     (log-debug "hot-load failed for ~a: ~a" name (exn-message e))
                                      (make-entry 'system
                                                  (format "  Warning: hot-load failed: ~a"
                                                          (exn-message e))
                                                  (current-inexact-milliseconds)
                                                  (hash)))])
           (define loaded? (load-extension! ext-reg ext-path #:event-bus bus))
-          (with-output-to-file "/tmp/q-cmd-dispatch.log"
-                               (lambda ()
-                                 (printf "[~a] hot-load done, loaded?=~a checking registry...\n"
-                                         (current-inexact-milliseconds)
-                                         loaded?)
-                                 (define exts (list-extensions ext-reg))
-                                 (printf "[~a] registry has ~a extensions: ~a\n"
-                                         (current-inexact-milliseconds)
-                                         (length exts)
-                                         (map extension-name exts))
-                                 (for ([ext exts])
-                                   (define hooks (extension-hooks ext))
-                                   (printf "[~a] ext '~a' hooks: ~a\n"
-                                           (current-inexact-milliseconds)
-                                           (extension-name ext)
-                                           (hash-keys hooks))))
-                               #:exists 'append)
           (if loaded?
               (make-entry 'system
                           (format "  Extension '~a' loaded into running session." name)
                           (current-inexact-milliseconds)
                           (hash))
-              (make-entry
-               'error
-               (format
-                "  Warning: extension '~a' could not be loaded. Check /tmp/q-cmd-dispatch.log for details."
-                name)
-               (current-inexact-milliseconds)
-               (hash))))])]))
+              (make-entry 'error
+                          (format "  Warning: extension '~a' could not be loaded." name)
+                          (current-inexact-milliseconds)
+                          (hash))))])]))
 
 ;; handle-activate-command : cmd-ctx? -> 'continue
 ;; Supports:
@@ -802,25 +777,14 @@
             (and (> (string-length trimmed) 0)
                  (char=? (string-ref trimmed 0) #\/)
                  (let ([parts (string-split trimmed)]) (and (pair? parts) (car parts))))))
-        (with-output-to-file "/tmp/q-cmd-dispatch.log"
-                             (lambda ()
-                               (printf "[~a] cmd-name=~a has-ext-reg=~a input='~a'\n"
-                                       (current-inexact-milliseconds)
-                                       cmd-name
-                                       (and ext-reg #t)
-                                       input-text))
-                             #:exists 'append)
+        (log-debug "command dispatch: cmd=~a has-ext-reg=~a" cmd-name (and ext-reg #t))
         (define ext-result
           (and
            ext-reg
            cmd-name
            (dispatch-hooks 'execute-command (hasheq 'command cmd-name 'input input-text) ext-reg)))
-        (with-output-to-file "/tmp/q-cmd-dispatch.log"
-                             (lambda ()
-                               (printf "[~a] result-action=~a\n"
-                                       (current-inexact-milliseconds)
-                                       (and ext-result (hook-result-action ext-result))))
-                             #:exists 'append)
+        (log-debug "command dispatch result: action=~a"
+                   (and ext-result (hook-result-action ext-result)))
         (cond
           [(and ext-result (hook-result? ext-result) (eq? (hook-result-action ext-result) 'amend))
            ;; Extension handled the command
@@ -844,15 +808,7 @@
                         (add-transcript-entry (unbox (cmd-ctx-state-box cctx)) entry))])
            'continue]
           [else
-           (with-output-to-file "/tmp/q-cmd-dispatch.log"
-                                (lambda ()
-                                  (printf "[~a] FELL-THROUGH: result=~a cmd-name=~a\n"
-                                          (current-inexact-milliseconds)
-                                          (if ext-result
-                                              (hook-result-action ext-result)
-                                              #f)
-                                          cmd-name))
-                                #:exists 'append)
+           (log-debug "command fell through: cmd=~a" cmd-name)
            (define entry (make-entry 'error "Unknown command. Type /help for commands." 0 (hash)))
            (set-box! (cmd-ctx-state-box cctx) (add-transcript-entry state entry))
            'continue])]


### PR DESCRIPTION
Addresses #1596.

fix: review cleanup — remove diagnostic logging, restrict /plan submit, add tests (#1596)

Wave 1 of v0.17.9.

- Remove all /tmp/q-cmd-dispatch.log diagnostic tracing from 4 files
- Replace with log-debug where useful, remove otherwise
- Fix stale `-> void?` contract comment in loader.rkt (now boolean?)
- Restrict /plan <text> submit to /plan and /p only;
  /state and /handoff always display artifact
- Add 5 new tests for execute-command with/without args