### PR TITLE
feat: augment /plan <text> with GSD planning instructions (#1599)

Wave 2 of v0.17.9.

- Define planning-system-prompt constant with structured planning instructions
- When /plan <text> submits, prepend planning preamble to agent prompt
- Display text shows 'Planning: <original>' without full preamble
- Export planning-system-prompt for testing
- Add test verifying augmented submit text contains [gsd-planning] preamble
- Add test verifying planning-system-prompt has all required GSD instructions

### DIFF
--- a/extensions/gsd-planning.rkt
+++ b/extensions/gsd-planning.rkt
@@ -19,6 +19,7 @@
 
 (provide the-extension
          gsd-planning-extension
+         planning-system-prompt
          planning-artifact-path
          valid-artifact-name?
          read-planning-artifact
@@ -31,6 +32,21 @@
 ;; ============================================================
 
 (define planning-dir-name ".planning")
+
+;; Planning preamble prepended to user text when /plan <text> submits.
+;; Gives the agent explicit GSD planning instructions.
+(define planning-system-prompt
+  (string-append "[gsd-planning] Create a structured implementation plan for the following request.\n"
+                 "Write your plan to .planning/PLAN.md using the planning-write tool.\n"
+                 "Plan format:\n"
+                 "  - Goal: what this accomplishes\n"
+                 "  - Scope: files/modules affected\n"
+                 "  - Waves: 1-3 atomic task groups, each with verify commands\n"
+                 "  - Dependencies: what must be done first\n"
+                 "  - Risks: what could go wrong\n"
+                 "First explore the codebase to understand the current state, then write the plan.\n"
+                 "Do NOT implement — only plan.\n\n"
+                 "User request: "))
 
 (define artifact-extensions
   '(("PLAN" . ".md") ("STATE" . ".md")
@@ -242,7 +258,9 @@
                     (let ([rest (string-trim (substring input-text (string-length (car parts))))])
                       (and (> (string-length rest) 0) rest)))))
         =>
-        (lambda (args) (hook-amend (hasheq 'submit args 'text (format "Planning: ~a" args))))]
+        (lambda (args)
+          (define augmented-text (string-append planning-system-prompt args))
+          (hook-amend (hasheq 'submit augmented-text 'text (format "Planning: ~a" args))))]
        [else
         ;; Display artifact content (always for /state, /handoff; no-args /plan)
         (define content (read-planning-artifact base-dir artifact))

--- a/tests/test-gsd-planning.rkt
+++ b/tests/test-gsd-planning.rkt
@@ -391,24 +391,32 @@
                      (check-true (string-contains? (hash-ref (hook-result-payload result) 'text)
                                                    "No PLAN found"))))))
 
-;; ============================================================
-;; execute-command /plan <text> submit tests (Wave 1 v0.17.9)
-;; ============================================================
+(test-case "planning-system-prompt has GSD planning instructions"
+  (check-true (string-contains? planning-system-prompt "[gsd-planning]"))
+  (check-true (string-contains? planning-system-prompt "planning-write"))
+  (check-true (string-contains? planning-system-prompt "PLAN.md"))
+  (check-true (string-contains? planning-system-prompt "Do NOT implement")))
 
-(test-case "/plan <text> returns submit payload"
+(test-case "/plan <text> returns augmented submit payload"
   (define handler (hash-ref (extension-hooks gsd-planning-extension) 'execute-command))
   (define result (handler (hasheq 'command "/plan" 'input "/plan refactor the module")))
   (check-equal? (hook-result-action result) 'amend)
   (define payload (hook-result-payload result))
-  (check-equal? (hash-ref payload 'submit) "refactor the module")
+  ;; Submit text is augmented with planning preamble
+  (define submit-text (hash-ref payload 'submit))
+  (check-true (string-contains? submit-text "[gsd-planning]"))
+  (check-true (string-contains? submit-text "planning-write"))
+  (check-true (string-contains? submit-text "refactor the module"))
   (check-true (string-contains? (hash-ref payload 'text) "refactor the module")))
 
-(test-case "/p <text> returns submit payload (shortcut)"
+(test-case "/p <text> returns augmented submit payload (shortcut)"
   (define handler (hash-ref (extension-hooks gsd-planning-extension) 'execute-command))
   (define result (handler (hasheq 'command "/p" 'input "/p quick fix")))
   (check-equal? (hook-result-action result) 'amend)
   (define payload (hook-result-payload result))
-  (check-equal? (hash-ref payload 'submit) "quick fix"))
+  (define submit-text (hash-ref payload 'submit))
+  (check-true (string-contains? submit-text "[gsd-planning]"))
+  (check-true (string-contains? submit-text "quick fix")))
 
 (test-case "/plan (no args) returns display text"
   (with-temp-dir (lambda (dir)


### PR DESCRIPTION
Addresses #1599.

feat: augment /plan <text> with GSD planning instructions (#1599)

Wave 2 of v0.17.9.

- Define planning-system-prompt constant with structured planning instructions
- When /plan <text> submits, prepend planning preamble to agent prompt
- Display text shows 'Planning: <original>' without full preamble
- Export planning-system-prompt for testing
- Add test verifying augmented submit text contains [gsd-planning] preamble
- Add test verifying planning-system-prompt has all required GSD instructions