### PR TITLE
release: v0.17.9 — GSD Planning Workflow + Review Cleanup (#1600)

Wave 3 of v0.17.9.

- Bump version to 0.17.9
- Update CHANGELOG.md with v0.17.9 section
- 5609 tests pass, 0 failures (3 pre-existing file-level failures unchanged)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## v0.17.9 — 2026-04-23
+
+### GSD Planning Workflow + Review Cleanup
+
+Milestone #92 — Post-v0.17.8 review follow-ups and planning prompt augmentation.
+
+**Wave 1 — Review cleanup + test coverage (#1596)**
+- Removed all `/tmp/q-cmd-dispatch.log` diagnostic tracing from 4 files.
+- Replaced with `log-debug` where useful, removed entirely where not.
+- Fixed stale `-> void?` contract comment in `loader.rkt` (now returns `boolean?`).
+- Restricted `/plan <text>` submit to `/plan` and `/p` only —
+  `/state` and `/handoff` always display artifact regardless of trailing text.
+- Added 5 tests for execute-command with/without args.
+
+**Wave 2 — Planning prompt augmentation (#1599)**
+- Defined `planning-system-prompt` constant with GSD planning instructions.
+- When `/plan <text>` submits, agent prompt is augmented with planning preamble
+  instructing it to write a structured plan to `.planning/PLAN.md`.
+- Display text shows "Planning: <original>" without full preamble.
+- Added test verifying augmented submit text contains `[gsd-planning]` preamble.
+
 ## v0.17.8 — 2026-04-23
 
 ### Extension Commands & Activation Fix

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -7,4 +7,4 @@
 
 (provide q-version)
 
-(define q-version "0.17.8")
+(define q-version "0.17.9")


### PR DESCRIPTION
Addresses #1600.

release: v0.17.9 — GSD Planning Workflow + Review Cleanup (#1600)

Wave 3 of v0.17.9.

- Bump version to 0.17.9
- Update CHANGELOG.md with v0.17.9 section
- 5609 tests pass, 0 failures (3 pre-existing file-level failures unchanged)