### PR TITLE
feat: configurable steering thresholds via config.json (#1609)

Wave 2 of v0.18.0.

- Add steering config accessors to settings.rkt
- Read thresholds from config with sensible defaults (8/12/20)
- Support steering.same_file_dedup toggle
- Replace hardcoded thresholds with config lookups
- Add 10 config tests to test-steering.rkt
- All 349 files pass, 5657 tests, 0 failures

### DIFF
--- a/runtime/iteration.rkt
+++ b/runtime/iteration.rkt
@@ -78,7 +78,14 @@
                   list-tools-jsexpr
                   merge-tool-lists)
          ;; Settings struct for exec-context runtime-settings (#1240)
-         (only-in "../runtime/settings.rkt" make-minimal-settings setting-ref setting-ref*)
+         (only-in "../runtime/settings.rkt"
+                  make-minimal-settings
+                  setting-ref
+                  setting-ref*
+                  steering-gentle-threshold
+                  steering-strong-threshold
+                  steering-hard-cap
+                  steering-same-file-dedup?)
          ;; ARCH-01 upward import — runtime→tools: iteration loop is the sole
          ;; call site for run-tool-batch, coordinating parallel tool execution
          ;; within each agent turn.
@@ -758,21 +765,41 @@
                                               config))
                  ;; v0.18.0: Context-aware exploration steering with same-file dedup.
                  ;; - Tracks seen file paths across consecutive read-only tool calls
-                 ;; - Same file reads don't increment the counter
+                 ;; - Same file reads don't increment the counter (configurable)
                  ;; - Counter resets on any write tool call
-                 ;; - Level 1 (8+): gentle nudge to use write/edit tools
-                 ;; - Level 2 (12+): strong nudge with explicit instruction
-                 ;; - Level 3 (20+): hard cap — inject message and break the loop
+                 ;; - Thresholds configurable via steering.gentle_threshold etc.
+                 (define current-settings (hash-ref config 'settings #f))
+                 (define gentle-at
+                   (if current-settings
+                       (steering-gentle-threshold current-settings)
+                       8))
+                 (define strong-at
+                   (if current-settings
+                       (steering-strong-threshold current-settings)
+                       12))
+                 (define hard-at
+                   (if current-settings
+                       (steering-hard-cap current-settings)
+                       20))
+                 (define same-file-dedup?
+                   (if current-settings
+                       (steering-same-file-dedup? current-settings)
+                       #t))
                  (define current-tool-calls (extract-tool-calls-from-messages new-msgs))
+                 ;; Detect write tools (always relevant regardless of dedup setting)
+                 (define has-write-now?
+                   (for/or ([tc (in-list current-tool-calls)])
+                     (member (tool-call-name tc) '("write" "edit" "replace" "create"))))
                  (define-values (new-seen-paths should-increment?)
-                   (update-seen-paths current-tool-calls seen-paths))
+                   (cond
+                     [has-write-now? (values (set) #f)] ;; Reset: empty set, don't increment
+                     [(not same-file-dedup?)
+                      (values seen-paths #t)] ;; No dedup: keep set, always increment
+                     [else (update-seen-paths current-tool-calls seen-paths)]))
                  (define effective-tool-count
                    (cond
-                     ;; Write detected: reset counter and paths
-                     [(set-empty? new-seen-paths) 0]
-                     ;; Same file(s): don't increment
+                     [has-write-now? 0]
                      [(not should-increment?) consecutive-tool-count]
-                     ;; New file(s): increment
                      [else (add1 consecutive-tool-count)]))
                  ;; v0.14.1: emit exploration progress after 4+ consecutive tool-only turns
                  (when (>= effective-tool-count 4)
@@ -794,8 +821,8 @@
                    (let ([base-ctx updated-ctx]
                          [steering-msg
                           (cond
-                            ;; Level 3: Hard cap at 20 — force-stop the exploration
-                            [(>= effective-tool-count 20)
+                            ;; Level 3: Hard cap — force-stop the exploration
+                            [(>= effective-tool-count hard-at)
                              (emit-session-event! bus
                                                   session-id
                                                   "exploration.hard-cap"
@@ -819,8 +846,8 @@
                                  effective-tool-count)))
                               (now-seconds)
                               (hasheq))]
-                            ;; Level 2: Strong nudge at 12+
-                            [(>= effective-tool-count 12)
+                            ;; Level 2: Strong nudge
+                            [(>= effective-tool-count strong-at)
                              (make-message
                               (generate-id)
                               #f
@@ -837,8 +864,8 @@
                                  effective-tool-count)))
                               (now-seconds)
                               (hasheq))]
-                            ;; Level 1: Gentle nudge at 8+
-                            [(>= effective-tool-count 8)
+                            ;; Level 1: Gentle nudge
+                            [(>= effective-tool-count gentle-at)
                              (make-message
                               (generate-id)
                               #f

--- a/runtime/settings.rkt
+++ b/runtime/settings.rkt
@@ -70,7 +70,13 @@
 
          ;; Trace logging config (v0.15.0)
          trace-enabled?
-         trace-max-files)
+         trace-max-files
+
+         ;; Steering config (v0.18.0)
+         steering-gentle-threshold
+         steering-strong-threshold
+         steering-hard-cap
+         steering-same-file-dedup?)
 
 ;; ============================================================
 ;; Struct
@@ -348,3 +354,23 @@
   (if (hash? trace-cfg)
       (hash-ref trace-cfg 'max-files 10)
       10))
+
+;; ============================================================
+;; Steering config (v0.18.0)
+;; ============================================================
+
+;; Gentle steering threshold. Default: 8 (raised from 5 in v0.18.0).
+(define (steering-gentle-threshold settings)
+  (setting-ref* settings '(steering gentle_threshold) 8))
+
+;; Strong steering threshold. Default: 12 (raised from 7 in v0.18.0).
+(define (steering-strong-threshold settings)
+  (setting-ref* settings '(steering strong_threshold) 12))
+
+;; Hard cap for steering. Default: 20 (raised from 12 in v0.18.0).
+(define (steering-hard-cap settings)
+  (setting-ref* settings '(steering hard_cap) 20))
+
+;; Whether same-file dedup is enabled. Default: #t.
+(define (steering-same-file-dedup? settings)
+  (setting-ref* settings '(steering same_file_dedup) #t))

--- a/tests/test-steering.rkt
+++ b/tests/test-steering.rkt
@@ -227,4 +227,59 @@
       (check-false inc? "Already-seen file should not increment")
       (check-equal? (set-count sp) 1))))
 
+;; ══════════════════════════════════════════════════════════
+;; Configurable thresholds (Wave 2)
+;; ══════════════════════════════════════════════════════════
+
 (run-tests test-steering)
+
+(require "../runtime/settings.rkt")
+
+(define test-steering-config
+  (test-suite "Steering Config (v0.18.0 Wave 2)"
+
+    (test-case "default gentle threshold is 8"
+      (define s (make-minimal-settings))
+      (check-equal? (steering-gentle-threshold s) 8))
+
+    (test-case "default strong threshold is 12"
+      (define s (make-minimal-settings))
+      (check-equal? (steering-strong-threshold s) 12))
+
+    (test-case "default hard cap is 20"
+      (define s (make-minimal-settings))
+      (check-equal? (steering-hard-cap s) 20))
+
+    (test-case "default same-file dedup is #t"
+      (define s (make-minimal-settings))
+      (check-true (steering-same-file-dedup? s)))
+
+    (test-case "custom gentle threshold via steering config"
+      (define s (make-minimal-settings #:overrides (hash 'steering (hash 'gentle_threshold 15))))
+      (check-equal? (steering-gentle-threshold s) 15))
+
+    (test-case "custom strong threshold via steering config"
+      (define s (make-minimal-settings #:overrides (hash 'steering (hash 'strong_threshold 25))))
+      (check-equal? (steering-strong-threshold s) 25))
+
+    (test-case "custom hard cap via steering config"
+      (define s (make-minimal-settings #:overrides (hash 'steering (hash 'hard_cap 50))))
+      (check-equal? (steering-hard-cap s) 50))
+
+    (test-case "disable same-file dedup via steering config"
+      (define s (make-minimal-settings #:overrides (hash 'steering (hash 'same_file_dedup #f))))
+      (check-false (steering-same-file-dedup? s)))
+
+    (test-case "partial config: only override gentle, others default"
+      (define s (make-minimal-settings #:overrides (hash 'steering (hash 'gentle_threshold 3))))
+      (check-equal? (steering-gentle-threshold s) 3)
+      (check-equal? (steering-strong-threshold s) 12)
+      (check-equal? (steering-hard-cap s) 20))
+
+    (test-case "empty settings: defaults apply"
+      (check-equal? (steering-gentle-threshold (make-minimal-settings)) 8)
+      (check-equal? (steering-strong-threshold (make-minimal-settings)) 12)
+      (check-equal? (steering-hard-cap (make-minimal-settings)) 20)
+      (check-true (steering-same-file-dedup? (make-minimal-settings))))))
+
+(run-tests test-steering-config)


### PR DESCRIPTION
Addresses #1609.

feat: configurable steering thresholds via config.json (#1609)

Wave 2 of v0.18.0.

- Add steering config accessors to settings.rkt
- Read thresholds from config with sensible defaults (8/12/20)
- Support steering.same_file_dedup toggle
- Replace hardcoded thresholds with config lookups
- Add 10 config tests to test-steering.rkt
- All 349 files pass, 5657 tests, 0 failures