### PR TITLE
feat: SDK extension loading support in workflow tests (#1614)

Wave 1 of v0.18.1.

- Add #:extensions and #:extension-registry parameters to run-workflow
- Add #:extensions and #:extension-registry parameters to run-workflow-multi-turn
- Load extensions from path list into registry
- Wire extension-registry through to sdk:make-runtime
- Add 4 SDK extension loading tests
- All 350 files pass, 5656 tests, 0 failures

### DIFF
--- a/tests/workflows/extensions/test-sdk-extension-loading.rkt
+++ b/tests/workflows/extensions/test-sdk-extension-loading.rkt
@@ -1,0 +1,84 @@
+#lang racket/base
+
+;; tests/workflows/extensions/test-sdk-extension-loading.rkt
+;; v0.18.1 Wave 1: Verify extensions load through SDK runtime in workflow tests.
+
+(require rackunit
+         rackunit/text-ui
+         "../../workflows/fixtures/mock-provider.rkt"
+         "../../workflows/fixtures/workflow-runner.rkt"
+         "../../../agent/event-bus.rkt"
+         "../../../extensions/api.rkt"
+         (only-in "../../../extensions/loader.rkt" load-extension!)
+         "../../../tools/tool.rkt")
+
+;; ── Helpers ──
+
+(define (extension-path name)
+  (build-path (or (current-load-relative-directory) (current-directory))
+              (format "../../../extensions/~a.rkt" name)))
+
+;; ── Test Suite ──
+
+(define test-sdk-extension-loading
+  (test-suite "SDK Extension Loading (v0.18.1)"
+
+    (test-case "workflow-runner accepts #:extension-registry"
+      ;; Create registry with gsd-planning extension loaded
+      (define ext-reg (make-extension-registry))
+      (define bus (make-event-bus))
+      (define gsd-path (extension-path "gsd-planning"))
+      (when (file-exists? gsd-path)
+        (load-extension! ext-reg gsd-path #:event-bus bus))
+
+      ;; Run workflow with the extension registry
+      (define prov
+        (make-scripted-provider
+         (list (hash 'role 'assistant 'content "I'll check the planning state." 'tool_calls (list)))))
+      (define result
+        (run-workflow prov "Check planning state" #:extension-registry ext-reg #:max-iterations 3))
+
+      ;; Verify workflow completed
+      (check-not-false (workflow-result-output result) "Workflow should produce output"))
+
+    (test-case "workflow-runner accepts #:extensions with path list"
+      ;; Load extensions via path list
+      (define gsd-path (extension-path "gsd-planning"))
+      (unless (file-exists? gsd-path)
+        ((error 'test "Extension not found:" gsd-path)))
+
+      (define prov
+        (make-scripted-provider
+         (list (hash 'role 'assistant 'content "Planning check done." 'tool_calls (list)))))
+      (define result
+        (run-workflow prov "Check planning" #:extensions (list gsd-path) #:max-iterations 3))
+
+      (check-not-false (workflow-result-output result)))
+
+    (test-case "no extensions: backward compatible"
+      ;; Should work without any extensions (default behavior)
+      (define prov
+        (make-scripted-provider (list (hash 'role 'assistant 'content "Hello!" 'tool_calls (list)))))
+      (define result (run-workflow prov "Hello" #:max-iterations 3))
+
+      (check-not-false (workflow-result-output result)))
+
+    (test-case "multi-turn accepts #:extensions"
+      (define gsd-path (extension-path "gsd-planning"))
+      (define prov
+        (make-scripted-provider (list (hash 'role 'assistant 'content "Step 1" 'tool_calls (list))
+                                      (hash 'role 'assistant 'content "Step 2" 'tool_calls (list)))))
+
+      (define result
+        (run-workflow-multi-turn prov
+                                 '("First prompt" "Second prompt")
+                                 #:extensions (if (file-exists? gsd-path)
+                                                  (list gsd-path)
+                                                  '())
+                                 #:max-iterations 3))
+
+      ;; Multi-turn returns #f for output (by design)
+      (check-false (workflow-result-output result))
+      (check-not-false (workflow-result-events result)))))
+
+(run-tests test-sdk-extension-loading)

--- a/tests/workflows/fixtures/workflow-runner.rkt
+++ b/tests/workflows/fixtures/workflow-runner.rkt
@@ -9,12 +9,20 @@
          (prefix-in sdk: "../../../interfaces/sdk.rkt")
          "../../../agent/event-bus.rkt"
          (only-in "../../../util/protocol-types.rkt"
-                  message? message-role message-content message-id message-parent-id
+                  message?
+                  message-role
+                  message-content
+                  message-id
+                  message-parent-id
                   message-timestamp
-                  text-part? text-part-text
-                  tool-call-part? tool-call-part-name)
-         (only-in "../../../tools/tool.rkt"
-                  make-tool-registry)
+                  text-part?
+                  text-part-text
+                  tool-call-part?
+                  tool-call-part-name)
+         (only-in "../../../tools/tool.rkt" make-tool-registry)
+         (only-in "../../../extensions/api.rkt" make-extension-registry extension-registry?)
+         (only-in "../../../extensions/loader.rkt" load-extension!)
+         (only-in "../../../wiring/run-modes.rkt" load-extensions-from-dir!)
          "../../../util/jsonl.rkt"
          "../fixtures/temp-project.rkt"
          "../fixtures/event-recorder.rkt"
@@ -31,14 +39,14 @@
 ;; ============================================================
 
 (struct workflow-result
-  (output         ; loop-result? from SDK
-   events         ; event-recorder? with captured events
-   session-log    ; path? to session.jsonl
-   session-id     ; string?
-   project-dir    ; path? (or #f if no project)
-   session-dir    ; path? to session base dir
-   runtime        ; sdk:runtime? (for further operations)
-   side-effects)  ; (listof string) — descriptions of side effects
+        (output ; loop-result? from SDK
+         events ; event-recorder? with captured events
+         session-log ; path? to session.jsonl
+         session-id ; string?
+         project-dir ; path? (or #f if no project)
+         session-dir ; path? to session base dir
+         runtime ; sdk:runtime? (for further operations)
+         side-effects) ; (listof string) — descriptions of side effects
   #:transparent)
 
 ;; ============================================================
@@ -50,15 +58,20 @@
 ;;               #:files (listof (cons path-string? string?))
 ;;               #:max-iterations exact-positive-integer?
 ;;               #:system-instructions (listof string?)
+;;               #:extensions (listof path-string?)
+;;               #:extension-registry (or/c extension-registry? #f)
 ;;            -> workflow-result?
 ;;
 ;; Creates a full SDK runtime with the given provider, runs a single prompt,
 ;; and returns a structured result for assertion.
-(define (run-workflow provider prompt
-                       #:tools [tool-reg #f]
-                       #:files [files '()]
-                       #:max-iterations [max-iter 10]
-                       #:system-instructions [system-instrs '()])
+(define (run-workflow provider
+                      prompt
+                      #:tools [tool-reg #f]
+                      #:files [files '()]
+                      #:max-iterations [max-iter 10]
+                      #:system-instructions [system-instrs '()]
+                      #:extensions [ext-paths '()]
+                      #:extension-registry [ext-reg #f])
   (define-values (project-dir session-dir)
     (if (null? files)
         (values #f (make-temp-session-dir))
@@ -66,13 +79,26 @@
   (define reg (or tool-reg (make-tool-registry)))
   (define bus (make-event-bus))
   (define recorder (make-event-recorder bus))
+
+  ;; Build extension registry: use provided one, or create and load from paths
+  (define effective-ext-reg
+    (cond
+      [ext-reg ext-reg]
+      [(null? ext-paths) #f]
+      [else
+       (define er (make-extension-registry))
+       (for ([p (in-list ext-paths)])
+         (load-extension! er p #:event-bus bus))
+       er]))
+
   (define rt
     (sdk:make-runtime #:provider provider
                       #:session-dir session-dir
                       #:tool-registry reg
                       #:event-bus bus
                       #:max-iterations max-iter
-                      #:system-instructions system-instrs))
+                      #:system-instructions system-instrs
+                      #:extension-registry effective-ext-reg))
   (define rt2 (sdk:open-session rt))
   (define sid (hash-ref (sdk:session-info rt2) 'session-id))
   (define-values (rt3 result)
@@ -81,14 +107,7 @@
 
   (define log-path (build-path session-dir sid "session.jsonl"))
 
-  (workflow-result result
-                   recorder
-                   log-path
-                   sid
-                   project-dir
-                   session-dir
-                   rt3
-                   '()))
+  (workflow-result result recorder log-path sid project-dir session-dir rt3 '()))
 
 ;; ============================================================
 ;; run-workflow-multi-turn
@@ -101,10 +120,13 @@
 ;;                       -> workflow-result?
 ;;
 ;; Runs multiple prompts through the same session.
-(define (run-workflow-multi-turn provider prompts
-                                  #:tools [tool-reg #f]
-                                  #:files [files '()]
-                                  #:max-iterations [max-iter 10])
+(define (run-workflow-multi-turn provider
+                                 prompts
+                                 #:tools [tool-reg #f]
+                                 #:files [files '()]
+                                 #:max-iterations [max-iter 10]
+                                 #:extensions [ext-paths '()]
+                                 #:extension-registry [ext-reg #f])
   (define-values (project-dir session-dir)
     (if (null? files)
         (values #f (make-temp-session-dir))
@@ -112,20 +134,32 @@
   (define reg (or tool-reg (make-tool-registry)))
   (define bus (make-event-bus))
   (define recorder (make-event-recorder bus))
+
+  ;; Build extension registry
+  (define effective-ext-reg
+    (cond
+      [ext-reg ext-reg]
+      [(null? ext-paths) #f]
+      [else
+       (define er (make-extension-registry))
+       (for ([p (in-list ext-paths)])
+         (load-extension! er p #:event-bus bus))
+       er]))
+
   (define rt
     (sdk:make-runtime #:provider provider
                       #:session-dir session-dir
                       #:tool-registry reg
                       #:event-bus bus
-                      #:max-iterations max-iter))
+                      #:max-iterations max-iter
+                      #:extension-registry effective-ext-reg))
   (define rt2 (sdk:open-session rt))
   (define sid (hash-ref (sdk:session-info rt2) 'session-id))
 
   ;; Run each prompt sequentially, accumulating results
   (define final-rt
     (parameterize ([current-directory (or project-dir (current-directory))])
-      (for/fold ([current-rt rt2])
-                ([prompt (in-list prompts)])
+      (for/fold ([current-rt rt2]) ([prompt (in-list prompts)])
         (define-values (next-rt _result) (sdk:run-prompt! current-rt prompt))
         next-rt)))
 


### PR DESCRIPTION
Addresses #1614.

feat: SDK extension loading support in workflow tests (#1614)

Wave 1 of v0.18.1.

- Add #:extensions and #:extension-registry parameters to run-workflow
- Add #:extensions and #:extension-registry parameters to run-workflow-multi-turn
- Load extensions from path list into registry
- Wire extension-registry through to sdk:make-runtime
- Add 4 SDK extension loading tests
- All 350 files pass, 5656 tests, 0 failures