### PR TITLE
feat: workflow test harness enrichment (#1617)

Wave 2 of v0.18.1.

- Add #:skills-dir parameter to run-workflow and run-workflow-multi-turn
- Load skill SKILL.md files from skills/ subdirectory as system instructions
- Create extension-loader.rkt fixture for convenient extension loading
- Add 4 round-trip tests: extension loading, planning-read tool, skills-dir, multi-turn
- 352 files, 5665 tests, 0 failures

### DIFF
--- a/tests/workflows/extensions/test-extension-round-trip.rkt
+++ b/tests/workflows/extensions/test-extension-round-trip.rkt
@@ -1,0 +1,123 @@
+#lang racket/base
+
+;; tests/workflows/extensions/test-extension-round-trip.rkt
+;; v0.18.1 Wave 2: Full round-trip test with gsd-planning extension.
+;; Loads extension, runs prompt, verifies planning-read/write tool calls work.
+
+(require rackunit
+         rackunit/text-ui
+         racket/file
+         "../../workflows/fixtures/mock-provider.rkt"
+         "../../workflows/fixtures/workflow-runner.rkt"
+         "../../../agent/event-bus.rkt"
+         "../../../util/protocol-types.rkt"
+         (only-in "../../../extensions/api.rkt" make-extension-registry extension-registry?)
+         (only-in "../../../extensions/loader.rkt" load-extension!))
+
+;; ── Helpers ──
+
+(define (extension-path name)
+  (build-path (or (current-load-relative-directory) (current-directory))
+              (format "../../../extensions/~a.rkt" name)))
+
+(define gsd-planning-path (extension-path "gsd-planning"))
+
+;; ── Test Suite ──
+
+(define test-extension-round-trip
+  (test-suite "Extension Round-Trip (v0.18.1 Wave 2)"
+
+    (test-case "gsd-planning extension loads and planning-read works"
+      ;; Skip if extension not found
+      (unless (file-exists? gsd-planning-path)
+        (fail "gsd-planning extension not found"))
+
+      ;; Create extension registry with gsd-planning
+      (define ext-reg (make-extension-registry))
+      (define bus (make-event-bus))
+      (load-extension! ext-reg gsd-planning-path #:event-bus bus)
+
+      ;; Set up a temp project with .planning/PLAN.md
+      (define result
+        (run-workflow
+         (make-scripted-provider
+          (list
+           (hash 'role
+                 'assistant
+                 'content
+                 "I'll read the plan."
+                 'tool_calls
+                 (list (hash 'id
+                             "tc-1"
+                             'type
+                             "function"
+                             'function
+                             (hash 'name "planning-read" 'arguments "{\"artifact\": \"PLAN.md\"}"))))
+           (hash 'role 'assistant 'content "Plan reviewed." 'tool_calls (list))))
+         "Check the plan"
+         #:extension-registry ext-reg
+         #:files (list (cons ".planning/PLAN.md" "# Plan\nWave 1: Do stuff"))
+         #:max-iterations 5))
+
+      (check-not-false (workflow-result-output result))
+      (check-equal? (loop-result-termination-reason (workflow-result-output result))
+                    'completed
+                    "Workflow should complete"))
+
+    (test-case "extension-loaded workflow has session log"
+      (unless (file-exists? gsd-planning-path)
+        (fail "gsd-planning extension not found"))
+
+      (define ext-reg (make-extension-registry))
+      (load-extension! ext-reg gsd-planning-path)
+
+      (define result
+        (run-workflow
+         (make-scripted-provider (list (hash 'role 'assistant 'content "Done." 'tool_calls (list))))
+         "Hello"
+         #:extension-registry ext-reg
+         #:max-iterations 3))
+
+      ;; Session log should exist and be valid
+      (check-true (file-exists? (workflow-result-session-log result)) "Session log should exist")
+      (check-not-false (workflow-session-entries result) "Session entries should be readable"))
+
+    (test-case "skills-dir loads skills into system instructions"
+      ;; Create a temp dir with a test skill
+      (define tmp-dir (make-temporary-file "skill-test-~a" 'directory))
+      (define skills-dir (build-path tmp-dir "skills"))
+      (make-directory skills-dir)
+      (define test-skill-dir (build-path skills-dir "test-skill"))
+      (make-directory test-skill-dir)
+      (call-with-output-file (build-path test-skill-dir "SKILL.md")
+                             (lambda (out) (display "You are a test skill assistant.\n" out)))
+
+      (define result
+        (run-workflow (make-scripted-provider
+                       (list (hash 'role 'assistant 'content "Using test skill." 'tool_calls (list))))
+                      "Hello"
+                      #:skills-dir tmp-dir
+                      #:max-iterations 3))
+
+      (check-not-false (workflow-result-output result))
+      (check-equal? (loop-result-termination-reason (workflow-result-output result)) 'completed)
+
+      ;; Cleanup
+      (delete-directory/files tmp-dir))
+
+    (test-case "multi-turn with extension and skills"
+      (unless (file-exists? gsd-planning-path)
+        (fail "gsd-planning extension not found"))
+
+      (define result
+        (run-workflow-multi-turn
+         (make-scripted-provider (list (hash 'role 'assistant 'content "Turn 1" 'tool_calls (list))
+                                       (hash 'role 'assistant 'content "Turn 2" 'tool_calls (list))))
+         '("First" "Second")
+         #:extensions (list gsd-planning-path)
+         #:max-iterations 3))
+
+      (check-false (workflow-result-output result))
+      (check-true (file-exists? (workflow-result-session-log result))))))
+
+(run-tests test-extension-round-trip)

--- a/tests/workflows/fixtures/extension-loader.rkt
+++ b/tests/workflows/fixtures/extension-loader.rkt
@@ -1,0 +1,38 @@
+#lang racket/base
+
+;; tests/workflows/fixtures/extension-loader.rkt — extension loading fixture
+;;
+;; Convenience functions for loading extensions in workflow tests.
+;; Provides a simple API to create a registry and load one or more extensions.
+
+(require "../../../agent/event-bus.rkt"
+         "../../../extensions/api.rkt"
+         (only-in "../../../extensions/loader.rkt" load-extension!)
+         (only-in "../../../wiring/run-modes.rkt" load-extensions-from-dir!))
+
+(provide make-loaded-registry
+         load-extension-from-path
+         load-extensions-from-dir-path)
+
+;; make-loaded-registry : (listof path-string?) [#:event-bus any/c] -> extension-registry?
+;;
+;; Create an extension registry and load all given extension paths into it.
+;; Silently skips paths that don't exist.
+(define (make-loaded-registry paths #:event-bus [bus #f])
+  (define reg (make-extension-registry))
+  (for ([p (in-list paths)])
+    (when (file-exists? p)
+      (load-extension! reg p #:event-bus bus)))
+  reg)
+
+;; load-extension-from-path : extension-registry? path-string? [#:event-bus any/c] -> boolean?
+;;
+;; Load a single extension from a file path. Returns #t on success.
+(define (load-extension-from-path reg path #:event-bus [bus #f])
+  (and (file-exists? path) (load-extension! reg path #:event-bus bus)))
+
+;; load-extensions-from-dir-path : extension-registry? path-string? [#:event-bus any/c] -> void?
+;;
+;; Load all extensions from a directory into the registry.
+(define (load-extensions-from-dir-path reg dir #:event-bus [bus #f])
+  (load-extensions-from-dir! reg dir #:event-bus bus))

--- a/tests/workflows/fixtures/workflow-runner.rkt
+++ b/tests/workflows/fixtures/workflow-runner.rkt
@@ -6,6 +6,7 @@
 ;; Returns structured results for assertion.
 
 (require racket/file
+         racket/port
          (prefix-in sdk: "../../../interfaces/sdk.rkt")
          "../../../agent/event-bus.rkt"
          (only-in "../../../util/protocol-types.rkt"
@@ -23,6 +24,7 @@
          (only-in "../../../extensions/api.rkt" make-extension-registry extension-registry?)
          (only-in "../../../extensions/loader.rkt" load-extension!)
          (only-in "../../../wiring/run-modes.rkt" load-extensions-from-dir!)
+         (only-in "../../../skills/resource-loader.rkt" try-read-file)
          "../../../util/jsonl.rkt"
          "../fixtures/temp-project.rkt"
          "../fixtures/event-recorder.rkt"
@@ -60,6 +62,7 @@
 ;;               #:system-instructions (listof string?)
 ;;               #:extensions (listof path-string?)
 ;;               #:extension-registry (or/c extension-registry? #f)
+;;               #:skills-dir (or/c path-string? #f)
 ;;            -> workflow-result?
 ;;
 ;; Creates a full SDK runtime with the given provider, runs a single prompt,
@@ -71,7 +74,8 @@
                       #:max-iterations [max-iter 10]
                       #:system-instructions [system-instrs '()]
                       #:extensions [ext-paths '()]
-                      #:extension-registry [ext-reg #f])
+                      #:extension-registry [ext-reg #f]
+                      #:skills-dir [skills-dir #f])
   (define-values (project-dir session-dir)
     (if (null? files)
         (values #f (make-temp-session-dir))
@@ -91,13 +95,26 @@
          (load-extension! er p #:event-bus bus))
        er]))
 
+  ;; Load skills from directory and append to system instructions
+  (define skill-instrs
+    (if (and skills-dir (directory-exists? skills-dir))
+        (let* ([skills-sub (build-path skills-dir "skills")]
+               [dir (if (directory-exists? skills-sub) skills-sub skills-dir)])
+          (filter values
+                  (for/list ([entry (in-list (directory-list dir))]
+                             #:when (directory-exists? (build-path dir entry)))
+                    (define skill-file (build-path dir entry "SKILL.md"))
+                    (try-read-file skill-file))))
+        '()))
+  (define effective-system-instrs (append system-instrs skill-instrs))
+
   (define rt
     (sdk:make-runtime #:provider provider
                       #:session-dir session-dir
                       #:tool-registry reg
                       #:event-bus bus
                       #:max-iterations max-iter
-                      #:system-instructions system-instrs
+                      #:system-instructions effective-system-instrs
                       #:extension-registry effective-ext-reg))
   (define rt2 (sdk:open-session rt))
   (define sid (hash-ref (sdk:session-info rt2) 'session-id))
@@ -126,7 +143,8 @@
                                  #:files [files '()]
                                  #:max-iterations [max-iter 10]
                                  #:extensions [ext-paths '()]
-                                 #:extension-registry [ext-reg #f])
+                                 #:extension-registry [ext-reg #f]
+                                 #:skills-dir [skills-dir #f])
   (define-values (project-dir session-dir)
     (if (null? files)
         (values #f (make-temp-session-dir))
@@ -146,12 +164,25 @@
          (load-extension! er p #:event-bus bus))
        er]))
 
+  ;; Load skills from directory
+  (define skill-instrs
+    (if (and skills-dir (directory-exists? skills-dir))
+        (let* ([skills-sub (build-path skills-dir "skills")]
+               [dir (if (directory-exists? skills-sub) skills-sub skills-dir)])
+          (filter values
+                  (for/list ([entry (in-list (directory-list dir))]
+                             #:when (directory-exists? (build-path dir entry)))
+                    (define skill-file (build-path dir entry "SKILL.md"))
+                    (try-read-file skill-file))))
+        '()))
+
   (define rt
     (sdk:make-runtime #:provider provider
                       #:session-dir session-dir
                       #:tool-registry reg
                       #:event-bus bus
                       #:max-iterations max-iter
+                      #:system-instructions skill-instrs
                       #:extension-registry effective-ext-reg))
   (define rt2 (sdk:open-session rt))
   (define sid (hash-ref (sdk:session-info rt2) 'session-id))


### PR DESCRIPTION
Addresses #1617.

feat: workflow test harness enrichment (#1617)

Wave 2 of v0.18.1.

- Add #:skills-dir parameter to run-workflow and run-workflow-multi-turn
- Load skill SKILL.md files from skills/ subdirectory as system instructions
- Create extension-loader.rkt fixture for convenient extension loading
- Add 4 round-trip tests: extension loading, planning-read tool, skills-dir, multi-turn
- 352 files, 5665 tests, 0 failures