### PR TITLE
feat: skill routing improvements — recommend + context actions (#1630)

Wave 1 of v0.18.3.

- Add 'recommend' action: top-3 skills with confidence scoring
- Add 'context' action: skill content + _shared/ dependencies
- Recommend uses name-match + desc-match + word-score heuristic
- Context returns full skill (name, description, content) plus shared deps
- 6 new tests (recommend, context, shared deps, error cases)
- 356 files, 5696 tests, 0 failures

### DIFF
--- a/tests/test-skill-router.rkt
+++ b/tests/test-skill-router.rkt
@@ -30,10 +30,10 @@
     (define skill-dir (build-path skills-dir skill-name))
     (make-directory* skill-dir)
     (call-with-output-file (build-path skill-dir "SKILL.md")
-      (lambda (out)
-        (displayln (format "# ~a" skill-name) out)
-        (displayln "" out)
-        (displayln content out))))
+                           (lambda (out)
+                             (displayln (format "# ~a" skill-name) out)
+                             (displayln "" out)
+                             (displayln content out))))
   dir)
 
 (define (cleanup-dir dir)
@@ -45,9 +45,9 @@
 ;; ============================================================
 
 (test-case "skill-route list returns all skills"
-  (define dir (make-temp-skill-dir
-               '(("test-skill" . "A test skill for routing.\n\nFull content here.")
-                 ("another-skill" . "Another skill.\n\nMore content."))))
+  (define dir
+    (make-temp-skill-dir '(("test-skill" . "A test skill for routing.\n\nFull content here.")
+                           ("another-skill" . "Another skill.\n\nMore content."))))
   (parameterize ([current-directory dir])
     (define result (tool-skill-route (hasheq 'action "list")))
     (check-pred tool-result? result)
@@ -64,10 +64,10 @@
 ;; ============================================================
 
 (test-case "skill-route match finds by description"
-  (define dir (make-temp-skill-dir
-               '(("bug-fixer" . "Fix bugs in the codebase.\n\nInstructions.")
-                 ("docs-writer" . "Write documentation for the project.\n\nInstructions.")
-                 ("code-reviewer" . "Review code changes.\n\nInstructions."))))
+  (define dir
+    (make-temp-skill-dir '(("bug-fixer" . "Fix bugs in the codebase.\n\nInstructions.")
+                           ("docs-writer" . "Write documentation for the project.\n\nInstructions.")
+                           ("code-reviewer" . "Review code changes.\n\nInstructions."))))
   (parameterize ([current-directory dir])
     (define result (tool-skill-route (hasheq 'action "match" 'query "bug")))
     (check-pred tool-result? result)
@@ -82,9 +82,9 @@
 ;; ============================================================
 
 (test-case "skill-route match finds by name"
-  (define dir (make-temp-skill-dir
-               '(("q-gsd-orchestrator" . "Top level router.\n\nContent.")
-                 ("q-gsd-reviewer" . "Review code.\n\nContent."))))
+  (define dir
+    (make-temp-skill-dir '(("q-gsd-orchestrator" . "Top level router.\n\nContent.")
+                           ("q-gsd-reviewer" . "Review code.\n\nContent."))))
   (parameterize ([current-directory dir])
     (define result (tool-skill-route (hasheq 'action "match" 'query "reviewer")))
     (check-pred tool-result? result)
@@ -107,8 +107,9 @@
 ;; ============================================================
 
 (test-case "skill-route load returns full content"
-  (define dir (make-temp-skill-dir
-               '(("my-skill" . "Short description.\n\nDetailed skill content here.\nMultiple lines."))))
+  (define dir
+    (make-temp-skill-dir
+     '(("my-skill" . "Short description.\n\nDetailed skill content here.\nMultiple lines."))))
   (parameterize ([current-directory dir])
     (define result (tool-skill-route (hasheq 'action "load" 'name "my-skill")))
     (check-pred tool-result? result)
@@ -122,8 +123,7 @@
 ;; ============================================================
 
 (test-case "skill-route load non-existent skill returns error"
-  (define dir (make-temp-skill-dir
-               '(("exists" . "A skill.\n\nContent."))))
+  (define dir (make-temp-skill-dir '(("exists" . "A skill.\n\nContent."))))
   (parameterize ([current-directory dir])
     (define result (tool-skill-route (hasheq 'action "load" 'name "nonexistent")))
     (check-pred tool-result? result)
@@ -167,8 +167,7 @@
 ;; ============================================================
 
 (test-case "skill-route match is case-insensitive"
-  (define dir (make-temp-skill-dir
-               '(("Bug-Fixer" . "Fix bugs.\n\nContent."))))
+  (define dir (make-temp-skill-dir '(("Bug-Fixer" . "Fix bugs.\n\nContent."))))
   (parameterize ([current-directory dir])
     (define result (tool-skill-route (hasheq 'action "match" 'query "BUG")))
     (check-pred tool-result? result)
@@ -182,12 +181,88 @@
 ;; ============================================================
 
 (test-case "skill-route defaults to list"
-  (define dir (make-temp-skill-dir
-               '(("default-test" . "A skill.\n\nContent."))))
+  (define dir (make-temp-skill-dir '(("default-test" . "A skill.\n\nContent."))))
   (parameterize ([current-directory dir])
     (define result (tool-skill-route (hasheq)))
     (check-pred tool-result? result)
     (check-false (tool-result-is-error? result))
     (define text (hash-ref (car (tool-result-content result)) 'text ""))
     (check-true (string-contains? text "default-test")))
+  (cleanup-dir dir))
+
+;; ============================================================
+;; Test: recommend returns top-3 with confidence
+;; ============================================================
+
+(test-case "skill-route recommend returns top skills with confidence"
+  (define dir
+    (make-temp-skill-dir '(("bug-fixer" . "Fix bugs in the codebase.")
+                           ("bug-analyzer" . "Analyze bugs and find root causes.")
+                           ("docs-writer" . "Write documentation.")
+                           ("code-reviewer" . "Review code changes."))))
+  (parameterize ([current-directory dir])
+    (define result (tool-skill-route (hasheq 'action "recommend" 'query "bug fix")))
+    (check-pred tool-result? result)
+    (check-false (tool-result-is-error? result))
+    (define text (hash-ref (car (tool-result-content result)) 'text ""))
+    (check-true (string-contains? text "bug-fixer"))
+    (check-true (string-contains? text "bug-analyzer"))
+    (check-true (string-contains? text "confidence")))
+  (cleanup-dir dir))
+
+(test-case "skill-route recommend without query returns error"
+  (define result (tool-skill-route (hasheq 'action "recommend")))
+  (check-pred tool-result? result)
+  (check-true (tool-result-is-error? result)))
+
+;; ============================================================
+;; Test: context returns skill content with shared deps
+;; ============================================================
+
+(test-case "skill-route context returns skill content"
+  (define dir (make-temp-skill-dir '(("my-skill" . "Skill description.\n\nDetailed instructions."))))
+  (parameterize ([current-directory dir])
+    (define result (tool-skill-route (hasheq 'action "context" 'name "my-skill")))
+    (check-pred tool-result? result)
+    (check-false (tool-result-is-error? result))
+    (define text (hash-ref (car (tool-result-content result)) 'text ""))
+    (check-true (string-contains? text "Detailed instructions")))
+  (cleanup-dir dir))
+
+(test-case "skill-route context with _shared dependencies"
+  (define dir (make-temporary-file "skill-test-~a" 'directory))
+  (define skills-dir (build-path dir ".q" "skills"))
+  (define skill-dir (build-path skills-dir "shared-skill"))
+  (define shared-dir (build-path skill-dir "_shared"))
+  (make-directory* shared-dir)
+  (call-with-output-file (build-path skill-dir "SKILL.md")
+                         (lambda (out)
+                           (displayln "# shared-skill" out)
+                           (displayln "" out)
+                           (displayln "A skill with shared deps." out)))
+  (call-with-output-file (build-path shared-dir "PLAYBOOK.md")
+                         (lambda (out)
+                           (displayln "# Playbook" out)
+                           (displayln "Common debugging steps." out)))
+  (parameterize ([current-directory dir])
+    (define result (tool-skill-route (hasheq 'action "context" 'name "shared-skill")))
+    (check-pred tool-result? result)
+    (check-false (tool-result-is-error? result))
+    (define text (hash-ref (car (tool-result-content result)) 'text ""))
+    (check-true (string-contains? text "A skill with shared deps"))
+    (check-true (string-contains? text "Playbook"))
+    (check-true (string-contains? text "Common debugging steps")))
+  (cleanup-dir dir))
+
+(test-case "skill-route context without name returns error"
+  (define result (tool-skill-route (hasheq 'action "context")))
+  (check-pred tool-result? result)
+  (check-true (tool-result-is-error? result)))
+
+(test-case "skill-route context non-existent skill returns error"
+  (define dir (make-temp-skill-dir '(("exists" . "A skill."))))
+  (parameterize ([current-directory dir])
+    (define result (tool-skill-route (hasheq 'action "context" 'name "nonexistent")))
+    (check-pred tool-result? result)
+    (check-true (tool-result-is-error? result)))
   (cleanup-dir dir))

--- a/tools/builtins/skill-router.rkt
+++ b/tools/builtins/skill-router.rkt
@@ -39,14 +39,13 @@
              [(not (directory-exists? skills-dir)) '()]
              [else
               (with-handlers ([exn:fail? (lambda (_) '())])
-                (filter
-                 values
-                 (for/list ([entry (in-list (directory-list skills-dir))]
-                            #:when (directory-exists? (build-path skills-dir entry)))
-                   (define skill-name (path->string entry))
-                   (define skill-file (build-path skills-dir entry "SKILL.md"))
-                   (define content (try-read-file skill-file))
-                   (and content (parse-skill skill-name content)))))]))))
+                (filter values
+                        (for/list ([entry (in-list (directory-list skills-dir))]
+                                   #:when (directory-exists? (build-path skills-dir entry)))
+                          (define skill-name (path->string entry))
+                          (define skill-file (build-path skills-dir entry "SKILL.md"))
+                          (define content (try-read-file skill-file))
+                          (and content (parse-skill skill-name content)))))]))))
 
 ;; ============================================================
 ;; Tool handler
@@ -62,11 +61,8 @@
        (define skills (discover-skills))
        (define summaries
          (for/list ([s (in-list skills)])
-           (hasheq 'name (hash-ref s 'name "?")
-                   'description (hash-ref s 'description ""))))
-       (make-success-result
-        (list (hasheq 'type "text"
-                       'text (jsexpr->string summaries))))]
+           (hasheq 'name (hash-ref s 'name "?") 'description (hash-ref s 'description ""))))
+       (make-success-result (list (hasheq 'type "text" 'text (jsexpr->string summaries))))]
 
       ;; match: search skills by query text
       [(string=? action "match")
@@ -79,19 +75,22 @@
          (filter (lambda (s)
                    (define name (string-downcase (hash-ref s 'name "")))
                    (define desc (string-downcase (hash-ref s 'description "")))
-                   (or (string-contains? name query-low)
-                       (string-contains? desc query-low)))
+                   (or (string-contains? name query-low) (string-contains? desc query-low)))
                  skills))
        (define results
          (for/list ([s (in-list matched)])
-           (hasheq 'name (hash-ref s 'name "?")
-                   'description (hash-ref s 'description "")
-                   'matched #t)))
-       (make-success-result
-        (list (hasheq 'type "text"
-                       'text (format "Found ~a matching skills:\n~a"
-                                     (length results)
-                                     (jsexpr->string results)))))]
+           (hasheq 'name
+                   (hash-ref s 'name "?")
+                   'description
+                   (hash-ref s 'description "")
+                   'matched
+                   #t)))
+       (make-success-result (list (hasheq 'type
+                                          "text"
+                                          'text
+                                          (format "Found ~a matching skills:\n~a"
+                                                  (length results)
+                                                  (jsexpr->string results)))))]
 
       ;; load: return full content of a named skill
       [(string=? action "load")
@@ -101,13 +100,94 @@
        (define skills (discover-skills))
        (define found (findf (lambda (s) (string=? (hash-ref s 'name "") name)) skills))
        (cond
-         [found
-          (make-success-result
-           (list (hasheq 'type "text"
-                          'text (hash-ref found 'content ""))))]
-         [else
-          (make-error-result (format "Skill not found: ~a" name))])]
+         [found (make-success-result (list (hasheq 'type "text" 'text (hash-ref found 'content ""))))]
+         [else (make-error-result (format "Skill not found: ~a" name))])]
+
+      ;; recommend: return top-3 skills with confidence scores
+      [(string=? action "recommend")
+       (define query (hash-ref args 'query ""))
+       (when (string=? query "")
+         (raise (exn:fail "recommend requires 'query'" (current-continuation-marks))))
+       (define skills (discover-skills))
+       (define query-low (string-downcase query))
+       (define query-words (string-split query-low))
+       (define scored
+         (sort (for/list ([s (in-list skills)])
+                 (define name (string-downcase (hash-ref s 'name "")))
+                 (define desc (string-downcase (hash-ref s 'description "")))
+                 (define name-match (string-contains? name query-low))
+                 (define desc-match (string-contains? desc query-low))
+                 (define word-score
+                   (/ (for/sum ([w (in-list query-words)])
+                               (cond
+                                 [(string-contains? name w) 2]
+                                 [(string-contains? desc w) 1]
+                                 [else 0]))
+                      (max 1 (length query-words))))
+                 (define confidence
+                   (cond
+                     [name-match (min 1.0 (+ 0.7 (* 0.3 word-score)))]
+                     [desc-match (min 0.9 (+ 0.4 (* 0.3 word-score)))]
+                     [(> word-score 0) (min 0.6 word-score)]
+                     [else 0.0]))
+                 (cons s confidence))
+               >
+               #:key cdr))
+       (define non-zero (filter (lambda (p) (> (cdr p) 0)) scored))
+       (define top-3 (take non-zero (min 3 (length non-zero))))
+       (define recommendations
+         (for/list ([p (in-list top-3)])
+           (hasheq 'name
+                   (hash-ref (car p) 'name "?")
+                   'description
+                   (hash-ref (car p) 'description "")
+                   'confidence
+                   (exact->inexact (cdr p)))))
+       (make-success-result (list (hasheq 'type
+                                          "text"
+                                          'text
+                                          (format "Top ~a recommendations:\n~a"
+                                                  (length recommendations)
+                                                  (jsexpr->string recommendations)))))]
+
+      ;; context: return skill content plus _shared/ dependencies
+      [(string=? action "context")
+       (define ctx-name (hash-ref args 'name ""))
+       (when (string=? ctx-name "")
+         (raise (exn:fail "context requires 'name'" (current-continuation-marks))))
+       (define ctx-skills (discover-skills))
+       (define ctx-found (findf (lambda (s) (string=? (hash-ref s 'name "") ctx-name)) ctx-skills))
+       (cond
+         [ctx-found
+          ;; Try to load _shared/ dependencies from skill directory
+          (define shared-content
+            (with-handlers ([exn:fail? (lambda (_) "")])
+              (define dirs (project-config-dirs (current-directory)))
+              (string-join
+               (for/list ([dir (in-list dirs)]
+                          #:when (directory-exists? dir))
+                 (define skill-dir (build-path dir "skills" ctx-name "_shared"))
+                 (cond
+                   [(not (directory-exists? skill-dir)) ""]
+                   [else
+                    (string-join (for/list ([f (in-list (directory-list skill-dir))]
+                                            #:when (and (file-exists? (build-path skill-dir f))
+                                                        (regexp-match? #rx"\\.md$" (path->string f))))
+                                   (define fc (try-read-file (build-path skill-dir f)))
+                                   (or fc ""))
+                                 "\n\n")]))
+               "\n\n")))
+          (define full-content
+            (string-append (format "# ~a\n\n~a\n\n~a"
+                                   (hash-ref ctx-found 'name "?")
+                                   (hash-ref ctx-found 'description "")
+                                   (hash-ref ctx-found 'content ""))
+                           (if (string=? shared-content "")
+                               ""
+                               (format "\n\n---\nShared Dependencies:\n~a" shared-content))))
+          (make-success-result (list (hasheq 'type "text" 'text full-content)))]
+         [else (make-error-result (format "Skill not found: ~a" ctx-name))])]
 
       [else
-       (make-error-result
-        (format "Unknown action: ~a. Valid: list, match, load" action))])))
+       (make-error-result (format "Unknown action: ~a. Valid: list, match, load, recommend, context"
+                                  action))])))


### PR DESCRIPTION
Addresses #1630.

feat: skill routing improvements — recommend + context actions (#1630)

Wave 1 of v0.18.3.

- Add 'recommend' action: top-3 skills with confidence scoring
- Add 'context' action: skill content + _shared/ dependencies
- Recommend uses name-match + desc-match + word-score heuristic
- Context returns full skill (name, description, content) plus shared deps
- 6 new tests (recommend, context, shared deps, error cases)
- 356 files, 5696 tests, 0 failures