### PR TITLE
feat: spawn-subagent role loading from skills (#1636)

Wave 3 of v0.18.3.

- resolve-role-prompt: resolves role arg via skill-router context action
- Falls back to literal string if not a skill name
- Includes _shared/ dependencies in resolved role prompts
- 6 new tests (literal, skill name, fallback, empty, shared, task required)
- 358 files, 5714 tests, 0 failures

### DIFF
--- a/tests/test-spawn-subagent-role-loading.rkt
+++ b/tests/test-spawn-subagent-role-loading.rkt
@@ -1,0 +1,95 @@
+#lang racket
+
+;; tests/test-spawn-subagent-role-loading.rkt
+;; v0.18.3 Wave 3: Spawn-subagent role loading tests
+;;
+;; Tests:
+;;   - resolve-role-prompt with literal string
+;;   - resolve-role-prompt with skill name
+;;   - resolve-role-prompt with non-existent skill falls back
+;;   - resolve-role-prompt with empty string uses default
+;;   - Tool invocation with role parameter
+
+(require rackunit
+         racket/file
+         racket/string
+         json
+         "../tools/builtins/spawn-subagent.rkt"
+         "../tools/builtins/skill-router.rkt"
+         "../tools/tool.rkt")
+
+;; ── Helpers ──
+
+(define (make-temp-skill-dir skills-alist)
+  (define dir (make-temporary-file "role-test-~a" 'directory))
+  (define skills-dir (build-path dir ".q" "skills"))
+  (make-directory* skills-dir)
+  (for ([pair (in-list skills-alist)])
+    (define skill-name (car pair))
+    (define content (cdr pair))
+    (define skill-dir (build-path skills-dir skill-name))
+    (make-directory* skill-dir)
+    (call-with-output-file (build-path skill-dir "SKILL.md")
+                           (lambda (out)
+                             (displayln (format "# ~a" skill-name) out)
+                             (displayln "" out)
+                             (displayln content out))))
+  dir)
+
+(define (cleanup-dir dir)
+  (when (directory-exists? dir)
+    (delete-directory/files dir)))
+
+;; ── Tests ──
+
+(test-case "resolve-role-prompt returns literal string when no skill matches"
+  (define result (resolve-role-prompt "You are a helpful assistant."))
+  (check-equal? result "You are a helpful assistant."))
+
+(test-case "resolve-role-prompt loads skill content when name matches"
+  (define dir
+    (make-temp-skill-dir
+     '(("test-role" . "Test role description.\n\nYou must review code carefully."))))
+  (parameterize ([current-directory dir])
+    (define result (resolve-role-prompt "test-role"))
+    (check-true (string-contains? result "review code carefully")
+                (format "Should contain skill content, got: ~a" result)))
+  (cleanup-dir dir))
+
+(test-case "resolve-role-prompt falls back for non-existent skill"
+  (define dir (make-temporary-file "role-test-~a" 'directory))
+  (parameterize ([current-directory dir])
+    ;; A literal prompt that doesn't match any skill
+    (define result (resolve-role-prompt "Just a plain prompt"))
+    (check-equal? result "Just a plain prompt"))
+  (cleanup-dir dir))
+
+(test-case "resolve-role-prompt uses default for empty string"
+  (define result (resolve-role-prompt ""))
+  (check-true (non-empty-string? result) "Default role prompt should not be empty"))
+
+(test-case "resolve-role-prompt resolves skill with _shared content"
+  (define dir (make-temporary-file "role-test-~a" 'directory))
+  (define skills-dir (build-path dir ".q" "skills"))
+  (define skill-dir (build-path skills-dir "reviewer"))
+  (define shared-dir (build-path skill-dir "_shared"))
+  (make-directory* shared-dir)
+  (call-with-output-file (build-path skill-dir "SKILL.md")
+                         (lambda (out)
+                           (displayln "# reviewer" out)
+                           (displayln "" out)
+                           (displayln "A code reviewer skill.\n\nReview code for quality." out)))
+  (call-with-output-file (build-path shared-dir "CHECKLIST.md")
+                         (lambda (out)
+                           (displayln "# Review Checklist" out)
+                           (displayln "- Check test coverage" out)))
+  (parameterize ([current-directory dir])
+    (define result (resolve-role-prompt "reviewer"))
+    (check-true (string-contains? result "code reviewer"))
+    (check-true (string-contains? result "Review Checklist") "Should include _shared content"))
+  (cleanup-dir dir))
+
+(test-case "tool-spawn-subagent requires task"
+  (define result (tool-spawn-subagent (hasheq)))
+  (check-true (tool-result? result))
+  (check-true (tool-result-is-error? result)))

--- a/tools/builtins/spawn-subagent.rkt
+++ b/tools/builtins/spawn-subagent.rkt
@@ -18,19 +18,35 @@
          "../../llm/model.rkt"
          "../../util/ids.rkt"
          (only-in "../../util/protocol-types.rkt" make-message message-role message-content)
-         (only-in "../../runtime/settings.rkt" q-settings? setting-ref))
+         (only-in "../../runtime/settings.rkt" q-settings? setting-ref)
+         (only-in "../builtins/skill-router.rkt" tool-skill-route))
 
 (provide tool-spawn-subagent
-         tool-spawn-subagents)
+         tool-spawn-subagents
+         resolve-role-prompt)
 
 ;; Default role prompt when no role is specified
 (define default-role-prompt
   "You are a focused assistant executing a specific delegated task. Complete the task efficiently and return the result.")
 
+;; Resolve a role value: if it matches a skill name, load that skill as the prompt.
+;; Otherwise use it as a literal prompt string.
+(define (resolve-role-prompt role-value)
+  (if (string? role-value)
+      (let* ([result (tool-skill-route (hasheq 'action "context" 'name role-value))])
+        (if (and (tool-result? result) (not (tool-result-is-error? result)))
+            ;; Skill found — use its content as the role prompt
+            (let ([content (hash-ref (car (tool-result-content result)) 'text "")])
+              (if (non-empty-string? content) content default-role-prompt))
+            ;; Not a skill name — use as literal prompt
+            (if (non-empty-string? role-value) role-value default-role-prompt)))
+      default-role-prompt))
+
 ;; The spawn-subagent tool implementation
 (define (tool-spawn-subagent args [exec-ctx #f])
   (define task (hash-ref args 'task #f))
-  (define role-prompt (hash-ref args 'role default-role-prompt))
+  (define role-arg (hash-ref args 'role default-role-prompt))
+  (define role-prompt (resolve-role-prompt role-arg))
   (define max-turns (hash-ref args 'max-turns 5))
   (define allowed-tools (hash-ref args 'tools #f)) ;; optional list of tool names
 


### PR DESCRIPTION
Addresses #1636.

feat: spawn-subagent role loading from skills (#1636)

Wave 3 of v0.18.3.

- resolve-role-prompt: resolves role arg via skill-router context action
- Falls back to literal string if not a skill name
- Includes _shared/ dependencies in resolved role prompts
- 6 new tests (literal, skill name, fallback, empty, shared, task required)
- 358 files, 5714 tests, 0 failures