### PR TITLE
fix: benchmark executor pipeline — tool registration, timeout, concurrency, session-info (#1687)

Wave 1 of v0.19.2: Fix GAP 1–4 in executor.

- GAP 1: Register default tools via register-default-tools! (agent had zero tools)
- GAP 2: Fix timeout arithmetic — time-limit-seconds is already in seconds, not ms
- GAP 3: Replace thread+sync/timeout with channel-based concurrency (thread doesn't return values)
- GAP 4: Use 'history-length from session-info instead of non-existent 'iterations
- Also fix trace-tool-calls to match q's actual trace schema (phase: tool.call.started)
- Add tests/test-benchmark-executor.rkt with 6 tests

Co-authored-by: q-agent <q@coinerd>"

### DIFF
--- a/scripts/benchmark/executor.rkt
+++ b/scripts/benchmark/executor.rkt
@@ -16,15 +16,15 @@
          (prefix-in sdk: "../../interfaces/sdk.rkt")
          (only-in "../../agent/event-bus.rkt" make-event-bus)
          (only-in "../../tools/tool.rkt" make-tool-registry)
+         (only-in "../../tools/registry-defaults.rkt" register-default-tools!)
          (only-in "../../extensions/api.rkt" make-extension-registry)
-         (only-in "../../extensions/loader.rkt" load-extension!)
          (only-in "../../wiring/run-modes.rkt" load-extensions-from-dir!)
          (only-in "../../runtime/trace-logger.rkt"
                   make-trace-logger
                   start-trace-logger!
                   stop-trace-logger!)
          (only-in "../../runtime/provider-factory.rkt" build-provider)
-         (only-in "../../runtime/settings.rkt" load-settings q-settings-merged)
+         (only-in "../../runtime/settings.rkt" load-settings)
          (only-in "../../llm/provider.rkt" make-mock-provider)
          (only-in "../../llm/model.rkt" make-model-response)
          (only-in "../../util/protocol-types.rkt" message-role message-content text-part-text)
@@ -87,14 +87,15 @@
 
 ;; trace-tool-calls : path? -> (listof string?)
 ;; Extracts tool call names from a trace JSONL file.
+;; q's trace format: {"phase": "tool.call.started", "data": {"name": "read", ...}}
 (define (trace-tool-calls trace-path)
   (if (not (and trace-path (file-exists? trace-path)))
       '()
       (for*/list ([entry (in-list (jsonl-read-all-valid trace-path))]
                   #:when (hash? entry)
-                  #:when (equal? (hash-ref entry 'role #f) "assistant")
-                  [tc (in-list (hash-ref entry 'tool_calls '()))])
-        (hash-ref (hash-ref tc 'function (hasheq)) 'name "unknown"))))
+                  #:when (equal? (hash-ref entry 'phase #f) "tool.call.started"))
+        (define data (hash-ref entry 'data (hasheq)))
+        (hash-ref data 'name "unknown"))))
 
 ;; ============================================================
 ;; Core execution
@@ -134,8 +135,9 @@
   (when (directory-exists? project-ext-dir)
     (load-extensions-from-dir! ext-reg project-ext-dir #:event-bus bus))
 
-  ;; Build runtime
+  ;; Build runtime with default tools
   (define reg (make-tool-registry))
+  (register-default-tools! reg)
   (define rt
     (sdk:make-runtime #:provider provider
                       #:session-dir (build-path tmp-dir "sessions")
@@ -149,25 +151,37 @@
     (with-handlers ([exn:fail? (lambda (e) (values 'error 0 (exn-message e) #f))])
       (define rt2 (sdk:open-session rt))
 
-      ;; Execute with timeout if specified
+      ;; Execute with timeout via channel
       (define time-limit (benchmark-task-time-limit-seconds task))
-      (define-values (rt3 result)
-        (if time-limit
-            (sync/timeout (/ time-limit 1000.0)
-                          (thread (lambda ()
-                                    (parameterize ([current-directory tmp-dir])
-                                      (sdk:run-prompt! rt2 (benchmark-task-prompt task))))))
-            (parameterize ([current-directory tmp-dir])
-              (sdk:run-prompt! rt2 (benchmark-task-prompt task)))))
+      (define ch (make-channel))
+      (define exec-thread
+        (thread (lambda ()
+                  (channel-put ch
+                               (with-handlers ([exn:fail? (lambda (e) (list 'error e))])
+                                 (define-values (rt3 result)
+                                   (parameterize ([current-directory tmp-dir])
+                                     (sdk:run-prompt! rt2 (benchmark-task-prompt task))))
+                                 (list 'ok rt3 result))))))
+      (define exec-result (sync/timeout time-limit ch))
 
       (cond
-        ;; Timeout — the sync/timeout returned #f
-        [(not rt3) (values 'timeout 0 "Time limit exceeded" #f)]
+        ;; Timeout — sync/timeout returned #f
+        [(not exec-result)
+         (kill-thread exec-thread)
+         (values 'timeout 0 "Time limit exceeded" #f)]
+        ;; Error from inside the thread
+        [(and (list? exec-result) (eq? (car exec-result) 'error))
+         (values 'error 0 (exn-message (cadr exec-result)) #f)]
         [else
-         ;; Count iterations from session log
-         (define sess-info (sdk:session-info rt3))
-         (define iter-count (hash-ref sess-info 'iterations 1))
-         (values 'completed iter-count #f result)])))
+         (match exec-result
+           [(list 'ok rt3 result)
+            (define sess-info (sdk:session-info rt3))
+            (define iter-count
+              (if sess-info
+                  (hash-ref sess-info 'history-length 1)
+                  1))
+            (values 'completed iter-count #f result)]
+           [_ (values 'error 0 "Unexpected channel result" #f)])])))
 
   ;; Stop trace logger
   (stop-trace-logger! tlogger)

--- a/tests/test-benchmark-executor.rkt
+++ b/tests/test-benchmark-executor.rkt
@@ -1,0 +1,153 @@
+#lang racket
+
+;; tests/test-benchmark-executor.rkt — Tests for benchmark executor pipeline
+;;
+;; Tests the fixed executor: tool registration, timeout handling,
+;; channel-based concurrency, and session-info API usage.
+
+(require rackunit
+         racket/file
+         racket/path
+         json
+         (only-in "../scripts/benchmark/task.rkt"
+                  benchmark-task
+                  benchmark-task-name
+                  benchmark-task-prompt
+                  benchmark-task-category
+                  benchmark-task-difficulty
+                  benchmark-task-max-iterations
+                  benchmark-task-time-limit-seconds
+                  benchmark-task-setup
+                  benchmark-task-scoring
+                  task-setup
+                  task-teardown
+                  task-setup-spec
+                  scoring-spec)
+         (only-in "../scripts/benchmark/executor.rkt"
+                  execution-result
+                  execution-result-outcome
+                  execution-result-task-name
+                  execution-result-duration-ms
+                  execution-result-iterations-used
+                  execution-result-error-msg
+                  execution-result-project-dir
+                  execution-result-trace-path
+                  execute-task/mock
+                  trace-tool-calls))
+
+;; ============================================================
+;; Test helper: create a minimal benchmark task
+;; ============================================================
+
+(define (make-test-task #:name [name "test-task"]
+                        #:prompt [prompt "Test prompt"]
+                        #:max-iterations [max-iter 5]
+                        #:time-limit [time-limit 30])
+  (benchmark-task name
+                  'implementation
+                  1
+                  "Test task for executor"
+                  prompt
+                  max-iter
+                  1000
+                  time-limit
+                  (task-setup-spec (hasheq) '() '())
+                  (scoring-spec '() '() '() '() '() #f #f)
+                  '()))
+
+;; ============================================================
+;; Tests
+;; ============================================================
+
+(test-case "exec: mock execution completes successfully"
+  (define task (make-test-task))
+  (define result (execute-task/mock task))
+  (check-equal? (execution-result-task-name result) "test-task")
+  (check-equal? (execution-result-outcome result) 'completed)
+  (check-true (>= (execution-result-duration-ms result) 0))
+  ;; Cleanup
+  (when (execution-result-project-dir result)
+    (with-handlers ([exn:fail? void])
+      (delete-directory/files (execution-result-project-dir result)))))
+
+(test-case "exec: mock execution returns positive iterations"
+  (define task (make-test-task))
+  (define result (execute-task/mock task))
+  (check-true (>= (execution-result-iterations-used result) 0))
+  ;; Cleanup
+  (when (execution-result-project-dir result)
+    (with-handlers ([exn:fail? void])
+      (delete-directory/files (execution-result-project-dir result)))))
+
+(test-case "exec: timeout triggers correctly"
+  (define task (make-test-task #:time-limit 1 #:max-iterations 1000))
+  ;; With a 1-second timeout and a mock provider that completes instantly,
+  ;; this should complete normally (mock is fast).
+  ;; But verify the timeout code path doesn't crash.
+  (define result (execute-task/mock task))
+  (check-not-false (member (execution-result-outcome result) '(completed timeout)))
+  ;; Cleanup
+  (when (execution-result-project-dir result)
+    (with-handlers ([exn:fail? void])
+      (delete-directory/files (execution-result-project-dir result)))))
+
+(test-case "exec: trace-tool-calls reads q trace format"
+  (define tmp-dir (make-temporary-file "trace-test-~a" 'directory))
+  (define trace-file (build-path tmp-dir "test.jsonl"))
+  ;; Write q-format trace entries
+  (call-with-output-file trace-file
+                         (lambda (out)
+                           ;; Non-tool event (should be skipped)
+                           (write-json (hasheq 'ts
+                                               "2026-01-01T00:00:00Z"
+                                               'seq
+                                               1
+                                               'phase
+                                               "assistant.message.completed"
+                                               'sessionId
+                                               "s1"
+                                               'turnId
+                                               "t1"
+                                               'data
+                                               (hasheq 'content "hello"))
+                                       out)
+                           (newline out)
+                           ;; Tool call event (should be captured)
+                           (write-json (hasheq 'ts
+                                               "2026-01-01T00:00:01Z"
+                                               'seq
+                                               2
+                                               'phase
+                                               "tool.call.started"
+                                               'sessionId
+                                               "s1"
+                                               'turnId
+                                               "t1"
+                                               'data
+                                               (hasheq 'id "call_1" 'name "read" 'arguments "{}"))
+                                       out)
+                           (newline out)
+                           ;; Another tool call
+                           (write-json (hasheq 'ts
+                                               "2026-01-01T00:00:02Z"
+                                               'seq
+                                               3
+                                               'phase
+                                               "tool.call.started"
+                                               'sessionId
+                                               "s1"
+                                               'turnId
+                                               "t1"
+                                               'data
+                                               (hasheq 'id "call_2" 'name "edit" 'arguments "{}"))
+                                       out)
+                           (newline out)))
+  (define tools (trace-tool-calls trace-file))
+  (check-equal? tools '("read" "edit"))
+  (delete-directory/files tmp-dir))
+
+(test-case "exec: trace-tool-calls returns empty for missing file"
+  (check-equal? (trace-tool-calls "/nonexistent/path.jsonl") '()))
+
+(test-case "exec: trace-tool-calls returns empty for #f path"
+  (check-equal? (trace-tool-calls #f) '()))


### PR DESCRIPTION
Addresses #1687.

fix: benchmark executor pipeline — tool registration, timeout, concurrency, session-info (#1687)

Wave 1 of v0.19.2: Fix GAP 1–4 in executor.

- GAP 1: Register default tools via register-default-tools! (agent had zero tools)
- GAP 2: Fix timeout arithmetic — time-limit-seconds is already in seconds, not ms
- GAP 3: Replace thread+sync/timeout with channel-based concurrency (thread doesn't return values)
- GAP 4: Use 'history-length from session-info instead of non-existent 'iterations
- Also fix trace-tool-calls to match q's actual trace schema (phase: tool.call.started)
- Add tests/test-benchmark-executor.rkt with 6 tests

Co-authored-by: q-agent <q@coinerd>"