### PR TITLE
feat: wire scoring into CLI + fix trace schema (#1695)

Wave 3 of v0.19.2: Fix GAP 7-8.

- GAP 7: Wire score-execution into run-benchmark.rkt CLI runner
  - Each task now scored across 5 dimensions after execution
  - Human output shows verdict (PASS/PARTIAL/FAIL) per task
  - JSON output includes full score breakdown
  - Summary shows PASS/PARTIAL/FAIL counts + average score
- GAP 8: Fix extract-tool-names-from-trace to match q's trace schema
  - Old: looked for 'type "tool_use" (OpenAI format)
  - New: reads 'phase "tool.call.started" with 'data.name (q format)
- Update scorer tests to use correct q trace format

Co-authored-by: q-agent <q@coinerd>"

### DIFF
--- a/scripts/benchmark/scorer.rkt
+++ b/scripts/benchmark/scorer.rkt
@@ -262,23 +262,18 @@
                    trace-tools))]))
 
 ;; extract-tool-names-from-trace : path? -> (listof string?)
-;; Reads trace JSONL and extracts tool_use event names.
+;; Reads trace JSONL and extracts tool names from q's trace format.
+;; q trace entries have 'phase "tool.call.started" and 'data with 'name field.
 (define (extract-tool-names-from-trace trace-path)
   (define entries
     (with-handlers ([exn:fail? (lambda (e) '())])
       (jsonl-read-all-valid trace-path)))
-  (append*
-   (for/list ([entry (in-list entries)]
-              #:when (hash? entry))
-     (cond
-       ;; Direct tool_use event with 'name' field
-       [(equal? (hash-ref entry 'type #f) "tool_use")
-        (list (hash-ref entry 'name "unknown"))]
-       ;; Assistant message with tool_calls array
-       [(equal? (hash-ref entry 'role #f) "assistant")
-        (for/list ([tc (in-list (hash-ref entry 'tool_calls '()))])
-          (hash-ref (hash-ref tc 'function (hasheq)) 'name "unknown"))]
-       [else '()]))))
+  (filter string?
+          (for/list ([entry (in-list entries)]
+                     #:when (hash? entry)
+                     #:when (equal? (hash-ref entry 'phase #f) "tool.call.started"))
+            (define data (hash-ref entry 'data (hasheq)))
+            (hash-ref data 'name #f))))
 
 ;; ============================================================
 ;; Dimension 3: Efficiency (15%)

--- a/scripts/run-benchmark.rkt
+++ b/scripts/run-benchmark.rkt
@@ -21,7 +21,9 @@
          racket/string
          json
          "benchmark/task.rkt"
-         "benchmark/executor.rkt")
+         "benchmark/executor.rkt"
+         "benchmark/scorer.rkt"
+         "benchmark/report.rkt")
 
 ;; ============================================================
 ;; CLI parameters
@@ -93,11 +95,14 @@
     (printf "Running task: ~a (~a) ... " (benchmark-task-name task) (benchmark-task-category task))
     (flush-output)
     (define result (run-single-task task))
-    (printf "~a (~a ms, ~a iterations)~n"
+    ;; Score the execution
+    (define scores (score-execution result task))
+    (printf "~a | ~a (~a ms, ~a iter)~n"
             (execution-result-outcome result)
+            (score-result-verdict scores)
             (execution-result-duration-ms result)
             (execution-result-iterations-used result))
-    (cons task result)))
+    (list task result scores)))
 
 ;; ============================================================
 ;; Output formatting
@@ -112,32 +117,44 @@
 (define (format-results-human results-list)
   (define lines
     (for/list ([r (in-list results-list)])
-      (match-define (cons task result) r)
-      (format "  ~a ~a | ~a | ~a ms | ~a iter | ~a"
+      (match-define (list task result scores) r)
+      (format "  ~a ~a | ~a | ~a | ~a ms | ~a iter | ~a"
               (benchmark-task-name task)
               (difficulty-str (benchmark-task-difficulty task))
+              (score-result-verdict scores)
               (execution-result-outcome result)
               (execution-result-duration-ms result)
               (execution-result-iterations-used result)
               (or (execution-result-error-msg result) ""))))
+  ;; Summary stats
+  (define verdicts (map (lambda (r) (score-result-verdict (third r))) results-list))
+  (define n-pass (count (lambda (v) (eq? v 'PASS)) verdicts))
+  (define n-partial (count (lambda (v) (eq? v 'PARTIAL)) verdicts))
+  (define n-fail (count (lambda (v) (eq? v 'FAIL)) verdicts))
+  (define avg-score
+    (if (null? results-list)
+        0
+        (exact->inexact (/ (for/sum ([r (in-list results-list)]) (score-result-total-score (third r)))
+                           (length results-list)))))
   (string-join (append (list "══════════════════════════════════════════════════════════════"
                              "  BENCHMARK RESULTS"
                              "══════════════════════════════════════════════════════════════"
                              "")
                        lines
                        (list ""
-                             (format "  Total tasks: ~a" (length results-list))
-                             (format "  Completed: ~a"
-                                     (count (lambda (r)
-                                              (eq? (execution-result-outcome (cdr r)) 'completed))
-                                            results-list))
+                             (format "  Total: ~a | PASS: ~a | PARTIAL: ~a | FAIL: ~a"
+                                     (length results-list)
+                                     n-pass
+                                     n-partial
+                                     n-fail)
+                             (format "  Average score: ~a/100" (real->decimal-string avg-score 1))
                              "══════════════════════════════════════════════════════════════"))
                "\n"))
 
 (define (results->json results-list)
   (define results-data
     (for/list ([r (in-list results-list)])
-      (match-define (cons task result) r)
+      (match-define (list task result scores) r)
       (hasheq 'task
               (benchmark-task-name task)
               'category
@@ -146,6 +163,20 @@
               (benchmark-task-difficulty task)
               'outcome
               (symbol->string (execution-result-outcome result))
+              'verdict
+              (symbol->string (score-result-verdict scores))
+              'total_score
+              (score-result-total-score scores)
+              'correctness
+              (score-result-correctness scores)
+              'tool_discipline
+              (score-result-tool-discipline scores)
+              'efficiency
+              (score-result-efficiency scores)
+              'skill_compliance
+              (score-result-skill-compliance scores)
+              'no_regressions
+              (score-result-no-regressions scores)
               'duration_ms
               (execution-result-duration-ms result)
               'iterations

--- a/tests/test-benchmark-scorer.rkt
+++ b/tests/test-benchmark-scorer.rkt
@@ -151,9 +151,9 @@
   (define tmp-file (make-temporary-file "bench-trace-~a.jsonl"))
   (call-with-output-file tmp-file
     (lambda (out)
-      (write-json (hasheq 'type "tool_use" 'name "write") out)
+      (write-json (hasheq 'phase "tool.call.started" 'data (hasheq 'name "write")) out)
       (newline out)
-      (write-json (hasheq 'type "tool_use" 'name "read") out)
+      (write-json (hasheq 'phase "tool.call.started" 'data (hasheq 'name "read")) out)
       (newline out))
     #:exists 'replace)
   (define exec (make-test-exec-result #:trace-path tmp-file))
@@ -166,7 +166,7 @@
   (define tmp-file (make-temporary-file "bench-trace-~a.jsonl"))
   (call-with-output-file tmp-file
     (lambda (out)
-      (write-json (hasheq 'type "tool_use" 'name "read") out)
+      (write-json (hasheq 'phase "tool.call.started" 'data (hasheq 'name "read")) out)
       (newline out))
     #:exists 'replace)
   (define exec (make-test-exec-result #:trace-path tmp-file))
@@ -179,9 +179,9 @@
   (define tmp-file (make-temporary-file "bench-trace-~a.jsonl"))
   (call-with-output-file tmp-file
     (lambda (out)
-      (write-json (hasheq 'type "tool_use" 'name "bash") out)
+      (write-json (hasheq 'phase "tool.call.started" 'data (hasheq 'name "bash")) out)
       (newline out)
-      (write-json (hasheq 'type "tool_use" 'name "write") out)
+      (write-json (hasheq 'phase "tool.call.started" 'data (hasheq 'name "write")) out)
       (newline out))
     #:exists 'replace)
   (define exec (make-test-exec-result #:trace-path tmp-file))


### PR DESCRIPTION
Addresses #1695.

feat: wire scoring into CLI + fix trace schema (#1695)

Wave 3 of v0.19.2: Fix GAP 7-8.

- GAP 7: Wire score-execution into run-benchmark.rkt CLI runner
  - Each task now scored across 5 dimensions after execution
  - Human output shows verdict (PASS/PARTIAL/FAIL) per task
  - JSON output includes full score breakdown
  - Summary shows PASS/PARTIAL/FAIL counts + average score
- GAP 8: Fix extract-tool-names-from-trace to match q's trace schema
  - Old: looked for 'type "tool_use" (OpenAI format)
  - New: reads 'phase "tool.call.started" with 'data.name (q format)
- Update scorer tests to use correct q trace format

Co-authored-by: q-agent <q@coinerd>"