### PR TITLE
release: v0.19.2 — Benchmark Suite Hardening (#1698)

Wave 4 of v0.19.2: Live smoke test + release.

- Verify end-to-end mock benchmark pipeline (execute → score → report)
- Fix progress messages to stderr for clean JSON piping
- Bump version 0.19.1 → 0.19.2
- Update CHANGELOG.md with v0.19.2 entry
- All 65 benchmark tests passing across 6 test files

Fixes GAP 1–9 from v0.19.1 benchmark suite analysis.

Co-authored-by: q-agent <q@coinerd>"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## v0.19.2 — 2026-04-24
+
+### Benchmark Suite Hardening
+
+- **Executor pipeline fixes** (`scripts/benchmark/executor.rkt`): Register default tools
+  after making tool registry, fix timeout arithmetic (seconds not ms), channel-based
+  concurrency for thread-safe result passing, use correct `history-length` field
+- **Task fixture wiring** (`scripts/benchmark/task.rkt`): New `fixtures_dir` field on
+  `benchmark-task` struct, auto-copies fixture files (single file or directory) into temp
+  project dir before execution
+- **Tool name migration**: All 12 task JSONs updated from pi tool names
+  (`read_file`, `edit_file`, `run_shell`) to q tool names (`read`, `edit`, `bash`)
+- **CLI scoring pipeline** (`scripts/run-benchmark.rkt`): Scoring wired into CLI runner —
+  each task scored across 5 dimensions, verdicts shown in human and JSON output,
+  progress messages on stderr for clean JSON piping
+- **Trace schema fix** (`scripts/benchmark/scorer.rkt`): Tool name extraction updated
+  from OpenAI format (`type: "tool_use"`) to q format (`phase: "tool.call.started"`)
+- **65 benchmark tests passing** across 6 test files
+
 ## v0.19.1 — 2026-04-24
 
 ### Systematic Live Benchmark Suite

--- a/scripts/run-benchmark.rkt
+++ b/scripts/run-benchmark.rkt
@@ -92,16 +92,16 @@
 
 (define results
   (for/list ([task (in-list tasks)])
-    (printf "Running task: ~a (~a) ... " (benchmark-task-name task) (benchmark-task-category task))
-    (flush-output)
+    (eprintf "Running task: ~a (~a) ... " (benchmark-task-name task) (benchmark-task-category task))
+    (flush-output (current-error-port))
     (define result (run-single-task task))
     ;; Score the execution
     (define scores (score-execution result task))
-    (printf "~a | ~a (~a ms, ~a iter)~n"
-            (execution-result-outcome result)
-            (score-result-verdict scores)
-            (execution-result-duration-ms result)
-            (execution-result-iterations-used result))
+    (eprintf "~a | ~a (~a ms, ~a iter)~n"
+             (execution-result-outcome result)
+             (score-result-verdict scores)
+             (execution-result-duration-ms result)
+             (execution-result-iterations-used result))
     (list task result scores)))
 
 ;; ============================================================

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -7,4 +7,4 @@
 
 (provide q-version)
 
-(define q-version "0.19.1")
+(define q-version "0.19.2")


### PR DESCRIPTION
Addresses #1698.

release: v0.19.2 — Benchmark Suite Hardening (#1698)

Wave 4 of v0.19.2: Live smoke test + release.

- Verify end-to-end mock benchmark pipeline (execute → score → report)
- Fix progress messages to stderr for clean JSON piping
- Bump version 0.19.1 → 0.19.2
- Update CHANGELOG.md with v0.19.2 entry
- All 65 benchmark tests passing across 6 test files

Fixes GAP 1–9 from v0.19.1 benchmark suite analysis.

Co-authored-by: q-agent <q@coinerd>"