### PR TITLE
feat: tool error feedback with schema hints (#1705)

Wave 1 of v0.19.3: When tool calls fail validation, the error message
now includes the specific validation error and a parameter schema hint.

- Add format-tool-schema-hint to tools/tool.rkt for one-line param hints
- Capture validate-tool-args exception detail in scheduler preflight
- Error messages now guide LLM to correct tool usage on next turn
- Closes #1705, #1706, #1707, #1708, #1709

### DIFF
--- a/tests/test-scheduler.rkt
+++ b/tests/test-scheduler.rkt
@@ -26,6 +26,7 @@
                   register-tool!
                   lookup-tool
                   validate-tool-args
+                  format-tool-schema-hint
                   tool-result?
                   tool-result-content
                   tool-result-details
@@ -209,7 +210,8 @@
   (define tcs (list (tool-call "tc-1" "add" (hasheq 'a 1 'b 2))))
   (define sr (run-tool-batch tcs reg #:hook-dispatcher hook))
   (check-true (tool-result-is-error? (car (scheduler-result-results sr))))
-  (check-true (string-contains? (result-text (car (scheduler-result-results sr))) "validation")))
+  (check-true (string-contains? (result-text (car (scheduler-result-results sr)))
+                                "validate-tool-args")))
 
 ;; ============================================================
 ;; 7. Tool exception caught → error result (not crash)
@@ -376,3 +378,96 @@
   (check-equal? (result-text (car results))
                 "post-resilient"
                 "result content should be from tool execution"))
+
+;; ============================================================
+;; v0.19.3 Wave 1: Tool error feedback tests
+;; ============================================================
+
+(test-case "format-tool-schema-hint formats read tool"
+  (define t
+    (make-tool "read"
+               "Read file"
+               (hasheq 'type
+                       "object"
+                       'properties
+                       (hasheq 'path
+                               (hasheq 'type "string")
+                               'offset
+                               (hasheq 'type "integer")
+                               'limit
+                               (hasheq 'type "integer"))
+                       'required
+                       '("path"))
+               (lambda (args ctx) (make-success-result 'ok))))
+  (define hint (format-tool-schema-hint t))
+  (check-true (string-contains? hint "read("))
+  (check-true (string-contains? hint "path: string"))
+  (check-true (string-contains? hint "offset?: integer")))
+
+(test-case "format-tool-schema-hint formats tool with no optional params"
+  (define t
+    (make-tool "add"
+               "Add"
+               (hasheq 'type
+                       "object"
+                       'properties
+                       (hasheq 'a (hasheq 'type "integer") 'b (hasheq 'type "integer"))
+                       'required
+                       '("a" "b"))
+               (lambda (args ctx) (make-success-result 'ok))))
+  (define hint (format-tool-schema-hint t))
+  (check-true (string-contains? hint "a: integer"))
+  (check-true (string-contains? hint "b: integer")))
+
+(test-case "Missing required arg produces actionable error with schema hint"
+  (define reg (make-tool-registry))
+  ;; Register a tool with required param
+  (register-tool!
+   reg
+   (make-tool "read"
+              "Read file"
+              (hasheq 'type
+                      "object"
+                      'properties
+                      (hasheq 'path (hasheq 'type "string") 'offset (hasheq 'type "integer"))
+                      'required
+                      '("path"))
+              (lambda (args ctx) (make-success-result 'ok))))
+  ;; Call with empty args — should get error with 'path' and schema hint
+  (define tc (tool-call "tc-missing" "read" (hasheq)))
+  (define sr (run-tool-batch (list tc) reg))
+  (define results (scheduler-result-results sr))
+  (check-equal? (length results) 1)
+  (define tr (car results))
+  (check-true (tool-result-is-error? tr) "should be error result")
+  (define err-text (result-text tr))
+  (check-true (string-contains? err-text "path")
+              (format "error should mention 'path', got: ~a" err-text))
+  (check-true (string-contains? err-text "required")
+              (format "error should mention 'required', got: ~a" err-text))
+  (check-true (string-contains? err-text "read(")
+              (format "error should include schema hint, got: ~a" err-text)))
+
+(test-case "Wrong type arg produces actionable error with schema hint"
+  (define reg (make-tool-registry))
+  (register-tool! reg
+                  (make-tool "add"
+                             "Add"
+                             (hasheq 'type
+                                     "object"
+                                     'properties
+                                     (hasheq 'a (hasheq 'type "integer") 'b (hasheq 'type "integer"))
+                                     'required
+                                     '("a" "b"))
+                             (lambda (args ctx) (make-success-result 'ok))))
+  ;; Call with wrong type — should get error with type info and schema hint
+  (define tc (tool-call "tc-wrong-type" "add" (hasheq 'a "not-int" 'b 1)))
+  (define sr (run-tool-batch (list tc) reg))
+  (define results (scheduler-result-results sr))
+  (define tr (car results))
+  (check-true (tool-result-is-error? tr))
+  (define err-text (result-text tr))
+  (check-true (string-contains? err-text "expected type")
+              (format "error should mention type mismatch, got: ~a" err-text))
+  (check-true (string-contains? err-text "add(")
+              (format "error should include schema hint, got: ~a" err-text)))

--- a/tests/test-tool.rkt
+++ b/tests/test-tool.rkt
@@ -8,35 +8,27 @@
 ;; ============================================================
 
 (test-case "make-tool creates a valid tool"
-  (define t (make-tool "test"
-                       "A test tool"
-                       (hasheq 'type "object")
-                       (λ (args) 'ok)))
+  (define t (make-tool "test" "A test tool" (hasheq 'type "object") (λ (args) 'ok)))
   (check-pred tool? t)
   (check-equal? (tool-name t) "test")
   (check-equal? (tool-description t) "A test tool")
   (check-equal? (tool-schema t) (hasheq 'type "object")))
 
 (test-case "make-tool rejects bad name"
-  (check-exn exn:fail?
-    (λ () (make-tool 123 "desc" (hasheq) (λ (_) 'ok)))))
+  (check-exn exn:fail? (λ () (make-tool 123 "desc" (hasheq) (λ (_) 'ok)))))
 
 (test-case "make-tool rejects bad description"
-  (check-exn exn:fail?
-    (λ () (make-tool "name" 42 (hasheq) (λ (_) 'ok)))))
+  (check-exn exn:fail? (λ () (make-tool "name" 42 (hasheq) (λ (_) 'ok)))))
 
 (test-case "make-tool rejects bad schema"
-  (check-exn exn:fail?
-    (λ () (make-tool "name" "desc" "not-a-hash" (λ (_) 'ok)))))
+  (check-exn exn:fail? (λ () (make-tool "name" "desc" "not-a-hash" (λ (_) 'ok)))))
 
 (test-case "make-tool rejects bad execute"
-  (check-exn exn:fail?
-    (λ () (make-tool "name" "desc" (hasheq) "not-a-proc"))))
+  (check-exn exn:fail? (λ () (make-tool "name" "desc" (hasheq) "not-a-proc"))))
 
 (test-case "tool execute can be called"
-  (define t (make-tool "add" "addition"
-                       (hasheq)
-                       (λ (args) (+ (hash-ref args 'a) (hash-ref args 'b)))))
+  (define t
+    (make-tool "add" "addition" (hasheq) (λ (args) (+ (hash-ref args 'a) (hash-ref args 'b)))))
   (check-equal? ((tool-execute t) (hasheq 'a 3 'b 4)) 7))
 
 ;; ============================================================
@@ -52,8 +44,7 @@
 (test-case "make-error-result has is-error #t"
   (define tr (make-error-result "something broke"))
   (check-pred tool-result-is-error? tr)
-  (check-equal? (tool-result-content tr)
-                (list (hasheq 'type "text" 'text "something broke"))))
+  (check-equal? (tool-result-content tr) (list (hasheq 'type "text" 'text "something broke"))))
 
 (test-case "make-success-result defaults details to empty hash"
   (define tr (make-success-result "ok"))
@@ -85,9 +76,10 @@
   (check-equal? (exec-context-call-id ctx) ""))
 
 (test-case "make-exec-context with all keywords"
-  (define ctx (make-exec-context #:working-directory "/tmp"
-                                 #:call-id "call-123"
-                                 #:session-metadata (hasheq 'key "val")))
+  (define ctx
+    (make-exec-context #:working-directory "/tmp"
+                       #:call-id "call-123"
+                       #:session-metadata (hasheq 'key "val")))
   (check-equal? (exec-context-call-id ctx) "call-123"))
 
 ;; ============================================================
@@ -110,13 +102,11 @@
 (test-case "register-tool! rejects duplicates"
   (define reg (make-tool-registry))
   (register-tool! reg (make-tool "x" "first" (hasheq) (λ (_) 'ok)))
-  (check-exn exn:fail?
-    (λ () (register-tool! reg (make-tool "x" "second" (hasheq) (λ (_) 'ok))))))
+  (check-exn exn:fail? (λ () (register-tool! reg (make-tool "x" "second" (hasheq) (λ (_) 'ok))))))
 
 (test-case "register-tool! rejects non-tool"
   (define reg (make-tool-registry))
-  (check-exn exn:fail?
-    (λ () (register-tool! reg "not-a-tool"))))
+  (check-exn exn:fail? (λ () (register-tool! reg "not-a-tool"))))
 
 (test-case "unregister-tool! removes a tool"
   (define reg (make-tool-registry))
@@ -146,31 +136,64 @@
 ;; ============================================================
 
 (test-case "validate-tool-args passes for valid args"
-  (define t (make-tool "echo" "echo"
-                       (hasheq 'type "object"
-                               'required '(name)
-                               'properties (hasheq 'name (hasheq 'type "string")))
-                       (λ (_) 'ok)))
+  (define t
+    (make-tool
+     "echo"
+     "echo"
+     (hasheq 'type "object" 'required '(name) 'properties (hasheq 'name (hasheq 'type "string")))
+     (λ (_) 'ok)))
   (check-true (validate-tool-args t (hasheq 'name "hello"))))
 
 (test-case "validate-tool-args rejects missing required"
-  (define t (make-tool "echo" "echo"
-                       (hasheq 'type "object"
-                               'required '(name)
-                               'properties (hasheq 'name (hasheq 'type "string")))
-                       (λ (_) 'ok)))
-  (check-exn exn:fail?
-    (λ () (validate-tool-args t (hasheq)))))
+  (define t
+    (make-tool
+     "echo"
+     "echo"
+     (hasheq 'type "object" 'required '(name) 'properties (hasheq 'name (hasheq 'type "string")))
+     (λ (_) 'ok)))
+  (check-exn exn:fail? (λ () (validate-tool-args t (hasheq)))))
 
 (test-case "validate-tool-args rejects wrong type"
-  (define t (make-tool "echo" "echo"
-                       (hasheq 'type "object"
-                               'properties (hasheq 'count (hasheq 'type "integer")))
-                       (λ (_) 'ok)))
-  (check-exn exn:fail?
-    (λ () (validate-tool-args t (hasheq 'count "not-int")))))
+  (define t
+    (make-tool "echo"
+               "echo"
+               (hasheq 'type "object" 'properties (hasheq 'count (hasheq 'type "integer")))
+               (λ (_) 'ok)))
+  (check-exn exn:fail? (λ () (validate-tool-args t (hasheq 'count "not-int")))))
 
 (test-case "validate-tool-args rejects non-hash args"
   (define t (make-tool "echo" "echo" (hasheq) (λ (_) 'ok)))
-  (check-exn exn:fail?
-    (λ () (validate-tool-args t "not-a-hash"))))
+  (check-exn exn:fail? (λ () (validate-tool-args t "not-a-hash"))))
+
+;; ============================================================
+;; v0.19.3 Wave 1: format-tool-schema-hint tests
+;; ============================================================
+
+(test-case "format-tool-schema-hint: required and optional params"
+  (define t
+    (make-tool "read"
+               "Read"
+               (hasheq 'type
+                       "object"
+                       'properties
+                       (hasheq 'path
+                               (hasheq 'type "string")
+                               'offset
+                               (hasheq 'type "integer")
+                               'limit
+                               (hasheq 'type "integer"))
+                       'required
+                       '("path"))
+               (λ (_) 'ok)))
+  (define hint (format-tool-schema-hint t))
+  ;; Required param should NOT have ?
+  (check-true (string-contains? hint "path: string") (format "required param without ?: ~a" hint))
+  ;; Optional params should have ?
+  (check-true (string-contains? hint "offset?: integer") (format "optional param with ?: ~a" hint))
+  ;; Should start with tool name
+  (check-true (string-contains? hint "read(") (format "should start with tool name: ~a" hint)))
+
+(test-case "format-tool-schema-hint: no params"
+  (define t (make-tool "noop" "Noop" (hasheq 'type "object" 'properties (hasheq)) (λ (_) 'ok)))
+  (define hint (format-tool-schema-hint t))
+  (check-equal? hint "noop()"))

--- a/tools/scheduler.rkt
+++ b/tools/scheduler.rkt
@@ -24,6 +24,7 @@
                   register-tool!
                   lookup-tool
                   validate-tool-args
+                  format-tool-schema-hint
                   tool-result?
                   tool-result-content
                   tool-result-details
@@ -154,20 +155,22 @@
                path-arg
                (safe-mode-project-root)))]
             [else
-             ;; Revalidate arguments after potential hook mutation
-             (define validated?
-               (with-handlers ([exn:fail? (lambda (e) #f)])
+             ;; Revalidate arguments after potential hook mutation (v0.19.3 W1)
+             ;; Capture exception detail to produce actionable error feedback
+             (define validation-result
+               (with-handlers ([exn:fail? (lambda (e) e)])
                  (validate-tool-args t (tool-call-arguments tc-after-hook))
-                 #t))
-             (if validated?
+                 #f))
+             (if (not validation-result)
                  (hasheq 'status 'ready 'tool-call tc-after-hook 'tool t)
                  (hasheq 'status
                          'error
                          'tool-call
                          tc-after-hook
                          'error-message
-                         (format "post-hook validation failed for tool '~a'"
-                                 (tool-call-name tc-after-hook))))])])]
+                         (format "~a. Usage: ~a"
+                                 (exn-message validation-result)
+                                 (format-tool-schema-hint t))))])])]
       [else
        ;; Unexpected hook return value — treat as error
        (hasheq 'status

--- a/tools/tool.rkt
+++ b/tools/tool.rkt
@@ -3,7 +3,7 @@
 (require racket/contract
          racket/hash
          racket/set
-         (only-in racket/string string-trim)
+         (only-in racket/string string-trim string-contains? string-join)
          json
          ;; 3.2: Thread-safe registry access
          (only-in racket/base make-semaphore call-with-semaphore)
@@ -58,6 +58,7 @@
          tool->jsexpr
          merge-tool-lists
          validate-tool-schema
+         format-tool-schema-hint
 
          ;; ── Tool result (re-exported from agent/types.rkt) ──
          tool-result?
@@ -428,6 +429,43 @@
     [("object") (hash? v)]
     [("array") (list? v)]
     [else #t])) ; unknown type spec -> pass
+
+;; ============================================================
+;; Tool schema hint formatting (v0.19.3 Wave 1)
+;; ============================================================
+
+;; format-tool-schema-hint : tool? -> string?
+;; Format a one-line parameter hint from a tool's JSON schema.
+;; Example: "read(path: string, offset?: integer, limit?: integer)"
+(define (format-tool-schema-hint t)
+  (define schema (tool-schema t))
+  (define props (hash-ref schema 'properties (hasheq)))
+  (define required
+    (for/set ([r (in-list (hash-ref schema 'required '()))])
+      (if (string? r)
+          (string->symbol r)
+          r)))
+  (define param-strs
+    (for/list ([(k v) (in-hash props)])
+      (define key-sym
+        (if (string? k)
+            (string->symbol k)
+            k))
+      (define type-str (hash-ref v 'type "any"))
+      (if (set-member? required key-sym)
+          (format "~a: ~a" key-sym type-str)
+          (format "~a?: ~a" key-sym type-str))))
+  ;; Sort: required first, then optional, alphabetically within each group
+  (define sorted
+    (sort param-strs
+          (lambda (a b)
+            (define a-req? (not (string-contains? a "?")))
+            (define b-req? (not (string-contains? b "?")))
+            (cond
+              [(and a-req? (not b-req?)) #t]
+              [(and (not a-req?) b-req?) #f]
+              [else (string<? a b)]))))
+  (format "~a(~a)" (tool-name t) (string-join sorted ", ")))
 
 ;; ============================================================
 ;; Tool result validation


### PR DESCRIPTION
Addresses #1705.

feat: tool error feedback with schema hints (#1705)

Wave 1 of v0.19.3: When tool calls fail validation, the error message
now includes the specific validation error and a parameter schema hint.

- Add format-tool-schema-hint to tools/tool.rkt for one-line param hints
- Capture validate-tool-args exception detail in scheduler preflight
- Error messages now guide LLM to correct tool usage on next turn
- Closes #1705, #1706, #1707, #1708, #1709