### PR TITLE
feat: auto-retry skips permanent tool errors + benchmark selective tools (#1710)

Wave 2 of v0.19.3: Prevents auto-retry from burning iterations on
tool-call validation failures that will never succeed on retry.

- Add permanent-tool-error? predicate to auto-retry.rkt
- retryable-error? now returns #f for permanent tool errors
- Benchmark executor uses selective tool registration (#:only)
- Excludes session-recall and skill-router from benchmark tool set
- Closes #1710, #1711, #1712, #1713, #1714

### DIFF
--- a/runtime/auto-retry.rkt
+++ b/runtime/auto-retry.rkt
@@ -13,6 +13,7 @@
 ;; Predicates
 (provide retryable-error?
          context-overflow-error?
+         permanent-tool-error?
          classify-error
          timeout-error?
          rate-limit-error?
@@ -53,26 +54,34 @@
 ;; ============================================================
 
 ;; Check if an error is retryable (transient / rate-limit / server error).
+;; Permanent tool errors (validation failures) are NEVER retryable.
 (define (retryable-error? exn)
-  (define msg (exn-message exn))
-  (define retryable-patterns
-    '("429" "rate"
-            "overloaded"
-            "quota"
-            "too many"
-            "500"
-            "502"
-            "503"
-            "504"
-            "server error"
-            "timeout"
-            "timed out"
-            "connection"
-            "network"
-            "retry"
-            "backoff"))
-  (for/or ([pattern (in-list retryable-patterns)])
-    (string-contains? (string-downcase msg) pattern)))
+  (when (permanent-tool-error? exn)
+    (for/or ([pattern (in-list PERMANENT_TOOL_PATTERNS)])
+      (string-contains? (string-downcase (exn-message exn)) (string-downcase pattern))
+      #f)) ; matched but return #f via cond below
+  (cond
+    [(permanent-tool-error? exn) #f]
+    [else
+     (define msg (exn-message exn))
+     (define retryable-patterns
+       '("429" "rate"
+               "overloaded"
+               "quota"
+               "too many"
+               "500"
+               "502"
+               "503"
+               "504"
+               "server error"
+               "timeout"
+               "timed out"
+               "connection"
+               "network"
+               "retry"
+               "backoff"))
+     (for/or ([pattern (in-list retryable-patterns)])
+       (string-contains? (string-downcase msg) pattern))]))
 
 ;; FEAT-66: Check if an error is a context overflow / token limit error.
 ;; These errors indicate the context was too long for the model.
@@ -91,6 +100,25 @@
   (define msg (exn-message exn))
   (for/or ([pattern (in-list CONTEXT_OVERFLOW_PATTERNS)])
     (string-contains? (string-downcase msg) pattern)))
+
+;; ============================================================
+;; Permanent tool error predicate (v0.19.3 Wave 2)
+;; ============================================================
+
+;; A permanent tool error is one where retrying will never succeed.
+;; Tool-call validation failures (missing/wrong-type args) are permanent:
+;; the LLM must be given the error feedback immediately to correct its call.
+(define PERMANENT_TOOL_PATTERNS
+  '("validate-tool-args" "missing required argument"
+                         "expected type"
+                         "args must be a hash"
+                         "post-hook validation failed"
+                         "unknown tool:"))
+
+(define (permanent-tool-error? exn)
+  (define msg (exn-message exn))
+  (for/or ([pattern (in-list PERMANENT_TOOL_PATTERNS)])
+    (string-contains? (string-downcase msg) (string-downcase pattern))))
 
 ;; ============================================================
 ;; Error classification (v0.11.2 Wave 3)

--- a/scripts/benchmark/executor.rkt
+++ b/scripts/benchmark/executor.rkt
@@ -135,9 +135,10 @@
   (when (directory-exists? project-ext-dir)
     (load-extensions-from-dir! ext-reg project-ext-dir #:event-bus bus))
 
-  ;; Build runtime with default tools
+  ;; Build runtime with selective tools (exclude session-recall, skill-router in benchmark mode)
+  (define benchmark-tools '("read" "write" "edit" "bash" "grep" "find" "ls" "spawn-subagent"))
   (define reg (make-tool-registry))
-  (register-default-tools! reg)
+  (register-default-tools! reg #:only benchmark-tools)
   (define rt
     (sdk:make-runtime #:provider provider
                       #:session-dir (build-path tmp-dir "sessions")

--- a/tests/test-auto-retry.rkt
+++ b/tests/test-auto-retry.rkt
@@ -410,3 +410,50 @@
                      #:base-delay-ms 1))
   (check-true (retry-exhausted? (unbox exn-result)))
   (check-equal? (retry-exhausted-error-history (unbox exn-result)) '(timeout timeout timeout)))
+
+;; ============================================================
+;; v0.19.3 Wave 2: permanent-tool-error? tests
+;; ============================================================
+
+(test-case "permanent-tool-error?: validation failure is permanent"
+  (check-true (permanent-tool-error?
+               (exn:fail "validate-tool-args: missing required argument 'path' for tool 'read'"
+                         (current-continuation-marks)))))
+
+(test-case "permanent-tool-error?: wrong type is permanent"
+  (check-true
+   (permanent-tool-error?
+    (exn:fail
+     "validate-tool-args: argument 'count' expected type 'integer', got \"hello\" for tool 'add'"
+     (current-continuation-marks)))))
+
+(test-case "permanent-tool-error?: unknown tool is permanent"
+  (check-true (permanent-tool-error? (exn:fail "unknown tool: 'nonexistent'"
+                                               (current-continuation-marks)))))
+
+(test-case "permanent-tool-error?: rate limit is NOT permanent"
+  (check-false (permanent-tool-error? (exn:fail "HTTP 429 rate limit exceeded"
+                                                (current-continuation-marks)))))
+
+(test-case "permanent-tool-error?: timeout is NOT permanent"
+  (check-false (permanent-tool-error? (exn:fail "connection timed out after 30s"
+                                                (current-continuation-marks)))))
+
+(test-case "retryable-error?: permanent tool errors are never retried"
+  (check-false (retryable-error?
+                (exn:fail "validate-tool-args: missing required argument 'path' for tool 'read'"
+                          (current-continuation-marks)))))
+
+(test-case "with-auto-retry: permanent tool error raises immediately without retries"
+  (define attempt-count (box 0))
+  (define raised-exn (box #f))
+  (with-handlers ([exn:fail? (lambda (e) (set-box! raised-exn e))])
+    (with-auto-retry (lambda ()
+                       (set-box! attempt-count (add1 (unbox attempt-count)))
+                       (raise (exn:fail "validate-tool-args: missing required argument 'path'"
+                                        (current-continuation-marks))))
+                     #:max-retries 3
+                     #:base-delay-ms 1))
+  (check-equal? (unbox attempt-count) 1 "should not retry permanent tool error")
+  (check-true (exn:fail? (unbox raised-exn)) "should raise the original error")
+  (check-false (retry-exhausted? (unbox raised-exn)) "should NOT be retry-exhausted"))

--- a/tests/test-benchmark-executor.rkt
+++ b/tests/test-benchmark-executor.rkt
@@ -152,3 +152,10 @@
 
 (test-case "exec: trace-tool-calls returns empty for #f path"
   (check-equal? (trace-tool-calls #f) '()))
+
+(test-case "benchmark tool set excludes session-recall and skill-router"
+  ;; Verify that the standard benchmark tool list doesn't include meta-tools
+  (define benchmark-tools '("read" "write" "edit" "bash" "grep" "find" "ls" "spawn-subagent"))
+  (check-false (member "session-recall" benchmark-tools))
+  (check-false (member "skill-router" benchmark-tools))
+  (check-equal? (length benchmark-tools) 8))


### PR DESCRIPTION
Addresses #1710.

feat: auto-retry skips permanent tool errors + benchmark selective tools (#1710)

Wave 2 of v0.19.3: Prevents auto-retry from burning iterations on
tool-call validation failures that will never succeed on retry.

- Add permanent-tool-error? predicate to auto-retry.rkt
- retryable-error? now returns #f for permanent tool errors
- Benchmark executor uses selective tool registration (#:only)
- Excludes session-recall and skill-router from benchmark tool set
- Closes #1710, #1711, #1712, #1713, #1714