### PR TITLE
feat: context seeding with project file tree (#1715)

Wave 3 of v0.19.3: Injects a shallow project file tree into the
system prompt so the LLM can skip initial exploration iterations.

- New runtime/project-tree.rkt for shallow directory tree generation
- Ignores .git, node_modules, compiled/, and binary extensions
- Respects max-depth (3) and max-entries (200) limits
- Integrated into system prompt via run-modes.rkt
- Closes #1715, #1716, #1717, #1718

### DIFF
--- a/runtime/project-tree.rkt
+++ b/runtime/project-tree.rkt
@@ -1,0 +1,91 @@
+#lang racket/base
+
+;; q/runtime/project-tree.rkt — Shallow project file tree generation
+;;
+;; Generates a compact file tree listing of the project directory
+;; for injection into the system prompt, so the LLM can skip
+;; initial exploration iterations.
+;;
+;; v0.19.3 Wave 3: Context Seeding with Project File Tree (C4)
+
+(require racket/list
+         racket/match
+         racket/string
+         racket/set
+         racket/path)
+
+(provide generate-project-tree
+         project-tree->string
+         DEFAULT_TREE_MAX_DEPTH
+         DEFAULT_TREE_MAX_ENTRIES
+         IGNORED-DIRS
+         IGNORED-EXTENSIONS)
+
+;; ============================================================
+;; Configuration
+;; ============================================================
+
+(define DEFAULT_TREE_MAX_DEPTH 3)
+(define DEFAULT_TREE_MAX_ENTRIES 200)
+
+(define IGNORED-DIRS
+  (set ".git" "node_modules" "__pycache__" ".racket" "compiled"
+       "dist" "build" ".next" ".cache" "target" "vendor" ".tox"
+       ".mypy_cache" ".pytest_cache" "egg-info" ".eggs"))
+
+(define IGNORED-EXTENSIONS
+  (set ".zo" ".dep" ".elc" ".pyc" ".o" ".so" ".class" ".jar"))
+
+;; ============================================================
+;; Tree generation
+;; ============================================================
+
+;; generate-project-tree : path? #:max-depth integer? #:max-entries integer? -> (listof string?)
+;; Returns a sorted list of relative file paths within the project directory.
+;; Respects max-depth and max-entry limits, ignores common noise directories.
+(define (generate-project-tree project-dir
+                                #:max-depth [max-depth DEFAULT_TREE_MAX_DEPTH]
+                                #:max-entries [max-entries DEFAULT_TREE_MAX_ENTRIES])
+  (define entries
+    (let loop ([dir project-dir] [depth 0])
+      (if (> depth max-depth)
+          '()
+          (with-handlers ([exn:fail:filesystem? (lambda (e) '())])
+            (define children (directory-list dir))
+            (append*
+             (for/list ([child (in-list children)])
+               (define full-path (build-path dir child))
+               (define name (path->string child))
+               (cond
+                 [(and (directory-exists? full-path)
+                       (set-member? IGNORED-DIRS name))
+                  '()]
+                 [(directory-exists? full-path)
+                  (loop full-path (add1 depth))]
+                 [else
+                  ;; Skip ignored extensions
+                  (define ext (path-get-extension child))
+                  (if (and ext (set-member? IGNORED-EXTENSIONS (bytes->string/utf-8 ext)))
+                      '()
+                      (list (path->string (find-relative-path project-dir full-path))))])))))))
+  ;; Sort and truncate
+  (take (sort entries string<?) (min (length entries) max-entries)))
+
+;; project-tree->string : path? #:max-depth integer? #:max-entries integer? -> string?
+;; Generates a formatted file tree string suitable for system prompt injection.
+(define (project-tree->string project-dir
+                               #:max-depth [max-depth DEFAULT_TREE_MAX_DEPTH]
+                               #:max-entries [max-entries DEFAULT_TREE_MAX_ENTRIES])
+  (define entries (generate-project-tree project-dir
+                                          #:max-depth max-depth
+                                          #:max-entries max-entries))
+  (define tree-lines
+    (for/list ([entry (in-list entries)])
+      (define parts (string-split entry "/"))
+      (define depth (sub1 (length parts)))
+      (define indent (make-string (* depth 2) #\space))
+      (define fname (last parts))
+      (format "~a~a" indent fname)))
+  (if (null? tree-lines)
+      ""
+      (format "Project file tree:\n~a" (string-join tree-lines "\n"))))

--- a/tests/test-project-tree.rkt
+++ b/tests/test-project-tree.rkt
@@ -1,0 +1,95 @@
+#lang racket
+
+;;; tests/test-project-tree.rkt — Tests for runtime/project-tree.rkt
+;;; v0.19.3 Wave 3: Context Seeding with Project File Tree
+
+(require rackunit
+         racket/port
+         racket/file
+         "../runtime/project-tree.rkt")
+
+;; ============================================================
+;; Helpers: create temp project trees
+;; ============================================================
+
+(define (make-temp-project-tree entries)
+  (define tmp-dir (make-temporary-file "q-tree-test-~a" 'directory))
+  (for ([entry (in-list entries)])
+    (define full-path (build-path tmp-dir entry))
+    (make-directory* (path-only full-path))
+    (if (string-suffix? entry "/")
+        (make-directory* full-path)
+        (call-with-output-file full-path void)))
+  tmp-dir)
+
+(define (cleanup tmp-dir)
+  (with-handlers ([exn:fail? void])
+    (delete-directory/files tmp-dir)))
+
+;; ============================================================
+;; Tests
+;; ============================================================
+
+(test-case "generate-project-tree: flat directory"
+  (define tmp (make-temp-project-tree '("foo.rkt" "bar.rkt" "README.md")))
+  (define tree (generate-project-tree tmp))
+  (check-equal? (sort tree string<?) '("README.md" "bar.rkt" "foo.rkt"))
+  (cleanup tmp))
+
+(test-case "generate-project-tree: nested directories"
+  (define tmp (make-temp-project-tree '("a.rkt" "src/b.rkt" "src/sub/c.rkt")))
+  (define tree (generate-project-tree tmp))
+  (check-not-false (member "a.rkt" tree))
+  (check-not-false (member "src/b.rkt" tree))
+  (check-not-false (member "src/sub/c.rkt" tree))
+  (cleanup tmp))
+
+(test-case "generate-project-tree: ignores .git and node_modules"
+  (define tmp (make-temp-project-tree '("foo.rkt" ".git/config" "node_modules/bar.js")))
+  (define tree (generate-project-tree tmp))
+  (check-equal? tree '("foo.rkt"))
+  (cleanup tmp))
+
+(test-case "generate-project-tree: respects max-depth"
+  (define tmp (make-temp-project-tree '("a.rkt" "src/b.rkt" "src/sub/c.rkt" "src/sub/deep/d.rkt")))
+  (define tree (generate-project-tree tmp #:max-depth 2))
+  ;; depth 2 means: root, src, src/sub — src/sub/deep is depth 3
+  (check-not-false (member "a.rkt" tree))
+  (check-not-false (member "src/b.rkt" tree))
+  (check-not-false (member "src/sub/c.rkt" tree))
+  (check-false (member "src/sub/deep/d.rkt" tree))
+  (cleanup tmp))
+
+(test-case "generate-project-tree: respects max-entries"
+  (define entries (for/list ([i (in-range 50)]) (format "file~a.rkt" i)))
+  (define tmp (make-temp-project-tree entries))
+  (define tree (generate-project-tree tmp #:max-entries 10))
+  (check-equal? (length tree) 10)
+  (cleanup tmp))
+
+(test-case "generate-project-tree: ignores .zo files"
+  (define tmp (make-temp-project-tree '("foo.rkt" "compiled/foo_rkt.zo" "compiled/foo_rkt.dep")))
+  (define tree (generate-project-tree tmp))
+  (check-equal? tree '("foo.rkt"))
+  (cleanup tmp))
+
+(test-case "generate-project-tree: empty directory"
+  (define tmp (make-temporary-file "q-tree-empty-~a" 'directory))
+  (define tree (generate-project-tree tmp))
+  (check-equal? tree '())
+  (delete-directory tmp))
+
+(test-case "project-tree->string: produces formatted output"
+  (define tmp (make-temp-project-tree '("a.rkt" "src/b.rkt")))
+  (define str (project-tree->string tmp))
+  (check-true (string-contains? str "Project file tree:"))
+  (check-true (string-contains? str "a.rkt"))
+  (check-true (string-contains? str "b.rkt"))
+  (check-false (string-contains? str "src/"))  ;; only shows filenames with indent
+  (cleanup tmp))
+
+(test-case "project-tree->string: empty dir returns empty string"
+  (define tmp (make-temporary-file "q-tree-empty2-~a" 'directory))
+  (define str (project-tree->string tmp))
+  (check-equal? str "")
+  (delete-directory tmp))

--- a/wiring/run-modes.rkt
+++ b/wiring/run-modes.rkt
@@ -36,7 +36,8 @@
                   make-command-registry)
          (only-in "../tui/keymap.rkt" shortcut-specs->keymap keymap-merge)
          (only-in "../llm/stream.rkt" current-http-request-timeout current-model-timeouts)
-         (only-in "../runtime/trace-logger.rkt" make-trace-logger start-trace-logger!))
+         (only-in "../runtime/trace-logger.rkt" make-trace-logger start-trace-logger!)
+         (only-in "../runtime/project-tree.rkt" project-tree->string))
 
 ;; Re-export mode runners from sub-modules
 (require "run-interactive.rkt"
@@ -89,10 +90,20 @@
   ;; Progressive skill disclosure: inject skill summaries into system prompt
   ;; Full SKILL.md content is available on-demand via the `read` tool
   (define skill-section (skills-summary-section (resource-set-skills all-resources)))
+
+  ;; v0.19.3 Wave 3: Inject project file tree into system prompt
+  ;; This saves 1-2 exploration iterations per session.
+  (define project-tree-section
+    (let ([tree-str (project-tree->string project-dir)]) (if (string=? tree-str "") #f tree-str)))
+
   (define final-system-instrs
-    (if skill-section
-        (append system-instrs (list skill-section))
-        system-instrs))
+    (append system-instrs
+            (if skill-section
+                (list skill-section)
+                '())
+            (if project-tree-section
+                (list project-tree-section)
+                '())))
 
   ;; Provider uses the shared settings
   (define prov (build-provider base-config settings))


### PR DESCRIPTION
Addresses #1715.

feat: context seeding with project file tree (#1715)

Wave 3 of v0.19.3: Injects a shallow project file tree into the
system prompt so the LLM can skip initial exploration iterations.

- New runtime/project-tree.rkt for shallow directory tree generation
- Ignores .git, node_modules, compiled/, and binary extensions
- Respects max-depth (3) and max-entries (200) limits
- Integrated into system prompt via run-modes.rkt
- Closes #1715, #1716, #1717, #1718