### PR TITLE
feat: benchmark scoring improvements + trace iteration counting (#1719)

Wave 4 of v0.19.3: Improves benchmark scoring accuracy with partial
credit, negative content checks, and trace-based iteration counting.

- Add must_not_contain to file-check for negative content checks
- Partial credit: N/M scoring when some must_contain checks pass
- Trace-based iteration counting on timeout (counts tool.call.started)
- Fix directory fixture copy (contents into existing tmp-dir)
- Closes #1719, #1720, #1721, #1722, #1723

### DIFF
--- a/scripts/benchmark/executor.rkt
+++ b/scripts/benchmark/executor.rkt
@@ -203,8 +203,20 @@
                     trace-path
                     (build-path tmp-dir "sessions")
                     duration-ms
-                    iterations
+                    (if (and (eq? outcome 'timeout) trace-path (file-exists? trace-path))
+                        (max iterations (trace-tool-call-count trace-path))
+                        iterations)
                     outcome
                     error-msg
                     tmp-dir
                     raw-result))
+
+;; trace-tool-call-count : path? -> exact-nonnegative-integer?
+;; Count tool.call.started events in trace JSONL as iteration proxy.
+(define (trace-tool-call-count trace-path)
+  (define entries
+    (with-handlers ([exn:fail? (lambda (e) '())])
+      (jsonl-read-all-valid trace-path)))
+  (for/sum ([e (in-list entries)] #:when (and (hash? e)
+                                              (equal? (hash-ref e 'phase #f) "tool.call.started")))
+           1))

--- a/scripts/benchmark/scorer.rkt
+++ b/scripts/benchmark/scorer.rkt
@@ -108,35 +108,52 @@
        (for/list ([fc (in-list checks)])
          (define rel-path (file-check-path fc))
          (define must-contain (file-check-must-contain fc))
+         (define must-not-contain (file-check-must-not-contain fc))
          (define full-path
            (if project-dir
                (build-path project-dir rel-path)
                rel-path))
          (define exists? (file-exists? full-path))
          (cond
-           [(not exists?) (hash 'path rel-path 'exists? #f 'content-ok? #f 'reason "file missing")]
-           [(null? must-contain)
-            (hash 'path rel-path 'exists? #t 'content-ok? #t 'reason "no content requirements")]
+           [(not exists?) (hash 'path rel-path 'exists? #f 'score 0.0 'reason "file missing")]
            [else
             (define content (file->string full-path))
-            (define content-ok?
-              (for/and ([needle (in-list must-contain)])
-                (string-contains? content needle)))
+            ;; Positive checks (must-contain)
+            (define n-positive (length must-contain))
+            (define positive-pass
+              (for/sum ([needle (in-list must-contain)]) (if (string-contains? content needle) 1 0)))
+            ;; Negative checks (must-not-contain)
+            (define n-negative (length must-not-contain))
+            (define negative-pass
+              (for/sum ([forbidden (in-list must-not-contain)])
+                       (if (string-contains? content forbidden) 0 1)))
+            ;; Combined score: average of positive and negative ratios
+            (define n-total-checks (+ n-positive n-negative))
+            (define raw-score
+              (cond
+                [(zero? n-total-checks) 1.0]
+                [else (/ (+ positive-pass negative-pass) n-total-checks)]))
             (hash 'path
                   rel-path
                   'exists?
                   #t
-                  'content-ok?
-                  content-ok?
+                  'score
+                  raw-score
+                  'positive-pass
+                  positive-pass
+                  'n-positive
+                  n-positive
+                  'negative-pass
+                  negative-pass
+                  'n-negative
+                  n-negative
                   'reason
-                  (if content-ok? "ok" "missing required content"))])))
+                  (if (= raw-score 1.0) "ok" "partial match"))])))
 
      (define file-score
        (if (zero? n-file-checks)
            1.0
-           (/ (for/sum ([r (in-list file-results)])
-                       (if (and (hash-ref r 'exists? #f) (hash-ref r 'content-ok? #f)) 1 0))
-              n-file-checks)))
+           (/ (for/sum ([r (in-list file-results)]) (hash-ref r 'score 0.0)) n-file-checks)))
 
      ;; --- Test checks ---
      (define test-results

--- a/scripts/benchmark/task.rkt
+++ b/scripts/benchmark/task.rkt
@@ -30,7 +30,7 @@
 ;; Structs
 ;; ============================================================
 
-(struct file-check (path must-contain) #:transparent)
+(struct file-check (path must-contain must-not-contain) #:transparent)
 
 (struct scoring-spec
         (files-created ; (listof file-check?)
@@ -136,7 +136,9 @@
   (define raw-scoring (hash-ref j 'scoring (hasheq)))
   (define scoring-spec-val
     (scoring-spec (for/list ([fc (in-list (hash-ref raw-scoring 'files_created '()))])
-                    (file-check (hash-ref fc 'path "") (hash-ref fc 'must_contain '())))
+                    (file-check (hash-ref fc 'path "")
+                                (hash-ref fc 'must_contain '())
+                                (hash-ref fc 'must_not_contain '())))
                   (hash-ref raw-scoring 'files_not_modified '())
                   (hash-ref raw-scoring 'tests_pass '())
                   (hash-ref raw-scoring 'tools_used '())
@@ -185,7 +187,13 @@
           (build-path (task-fixture-paths) fixtures-dir)))
     (cond
       [(directory-exists? fixtures-path)
-       (copy-directory/files fixtures-path tmp-dir #:keep-modification-seconds? #t)]
+       ;; Copy contents of fixtures dir into tmp-dir (which already exists)
+       (for ([child (in-list (directory-list fixtures-path))])
+         (define src (build-path fixtures-path child))
+         (define dst (build-path tmp-dir child))
+         (cond
+           [(directory-exists? src) (copy-directory/files src dst)]
+           [(file-exists? src) (copy-file src dst)]))]
       [(file-exists? fixtures-path)
        ;; Single fixture file — copy into tmp-dir preserving name
        (copy-file fixtures-path (build-path tmp-dir (file-name-from-path fixtures-path)))]))

--- a/tests/test-benchmark-executor.rkt
+++ b/tests/test-benchmark-executor.rkt
@@ -159,3 +159,21 @@
   (check-false (member "session-recall" benchmark-tools))
   (check-false (member "skill-router" benchmark-tools))
   (check-equal? (length benchmark-tools) 8))
+
+(test-case "exec: trace-tool-call-count counts tool events"
+  (define tmp-dir (make-temporary-file "bench-trace-~a" 'directory))
+  (define trace-file (build-path tmp-dir "trace.jsonl"))
+  ;; Write trace JSONL with 3 tool call events and 2 other events
+  (call-with-output-file
+   trace-file
+   (lambda (out)
+     (displayln "{\"phase\":\"session.start\",\"data\":{}}" out)
+     (displayln "{\"phase\":\"tool.call.started\",\"data\":{\"name\":\"read\"}}" out)
+     (displayln "{\"phase\":\"tool.call.started\",\"data\":{\"name\":\"edit\"}}" out)
+     (displayln "{\"phase\":\"llm.response\",\"data\":{}}" out)
+     (displayln "{\"phase\":\"tool.call.started\",\"data\":{\"name\":\"bash\"}}" out)))
+  ;; We test by importing from executor module
+  ;; Since trace-tool-call-count is not exported, test via trace-tool-calls
+  (define tools (trace-tool-calls trace-file))
+  (check-equal? (length tools) 3 "should find 3 tool calls")
+  (delete-directory/files tmp-dir))

--- a/tests/test-benchmark-scorer.rkt
+++ b/tests/test-benchmark-scorer.rkt
@@ -7,44 +7,49 @@
          racket/format
          racket/path
          json
-         (only-in "../scripts/benchmark/executor.rkt"
-                  execution-result execution-result?)
-         (only-in "../scripts/benchmark/task.rkt"
-                  validate-benchmark-task)
+         (only-in "../scripts/benchmark/executor.rkt" execution-result execution-result?)
+         (only-in "../scripts/benchmark/task.rkt" validate-benchmark-task)
          "../scripts/benchmark/scorer.rkt")
 
 ;; ============================================================
 ;; Helpers
 ;; ============================================================
 
-(define (make-test-exec-result
-         #:task-name [name "test-task"]
-         #:trace-path [trace-path #f]
-         #:session-dir [session-dir (make-temporary-file "bench-session-~a" 'directory)]
-         #:duration-ms [duration-ms 5000]
-         #:iterations-used [iterations 5]
-         #:outcome [outcome 'completed]
-         #:error-msg [error-msg #f]
-         #:project-dir [project-dir #f]
-         #:raw-result [raw-result #f])
-  (execution-result name trace-path session-dir duration-ms
-                    iterations outcome error-msg project-dir raw-result))
+(define (make-test-exec-result #:task-name [name "test-task"]
+                               #:trace-path [trace-path #f]
+                               #:session-dir
+                               [session-dir (make-temporary-file "bench-session-~a" 'directory)]
+                               #:duration-ms [duration-ms 5000]
+                               #:iterations-used [iterations 5]
+                               #:outcome [outcome 'completed]
+                               #:error-msg [error-msg #f]
+                               #:project-dir [project-dir #f]
+                               #:raw-result [raw-result #f])
+  (execution-result name
+                    trace-path
+                    session-dir
+                    duration-ms
+                    iterations
+                    outcome
+                    error-msg
+                    project-dir
+                    raw-result))
 
-(define (make-test-task
-         #:name [name "test-task"]
-         #:max-iterations [max-iters 20]
-         #:files-created [fc '()]
-         #:files-not-modified [fnm '()]
-         #:tools-used [tu '()]
-         #:tools-not-used [tnu '()])
+(define (make-test-task #:name [name "test-task"]
+                        #:max-iterations [max-iters 20]
+                        #:files-created [fc '()]
+                        #:files-not-modified [fnm '()]
+                        #:tools-used [tu '()]
+                        #:tools-not-used [tnu '()])
   (validate-benchmark-task
-   (hasheq 'name name
-           'prompt "test prompt"
-           'max_iterations max-iters
-           'scoring (hasheq 'files_created fc
-                            'files_not_modified fnm
-                            'tools_used tu
-                            'tools_not_used tnu))))
+   (hasheq 'name
+           name
+           'prompt
+           "test prompt"
+           'max_iterations
+           max-iters
+           'scoring
+           (hasheq 'files_created fc 'files_not_modified fnm 'tools_used tu 'tools_not_used tnu))))
 
 ;; ============================================================
 ;; score->verdict
@@ -107,9 +112,9 @@
 (test-case "correctness: 0 when required files don't exist"
   (define tmp-dir (make-temporary-file "bench-correctness-~a" 'directory))
   (define exec (make-test-exec-result #:project-dir tmp-dir))
-  (define task (make-test-task
-                #:files-created (list (hasheq 'path "nonexistent.rkt"
-                                               'must_contain '("define")))))
+  (define task
+    (make-test-task #:files-created
+                    (list (hasheq 'path "nonexistent.rkt" 'must_contain '("define")))))
   (let-values ([(score _) (score-correctness exec task)])
     (check-true (< score 100)))
   (delete-directory/files tmp-dir))
@@ -117,11 +122,10 @@
 (test-case "correctness: high when required files exist with content"
   (define tmp-dir (make-temporary-file "bench-correctness-~a" 'directory))
   (call-with-output-file (build-path tmp-dir "hello.rkt")
-    (lambda (out) (display "(define (foo) 42)" out)))
+                         (lambda (out) (display "(define (foo) 42)" out)))
   (define exec (make-test-exec-result #:project-dir tmp-dir))
-  (define task (make-test-task
-                #:files-created (list (hasheq 'path "hello.rkt"
-                                               'must_contain '("define")))))
+  (define task
+    (make-test-task #:files-created (list (hasheq 'path "hello.rkt" 'must_contain '("define")))))
   (let-values ([(score _) (score-correctness exec task)])
     (check-true (>= score 80)))
   (delete-directory/files tmp-dir))
@@ -138,9 +142,7 @@
 
 (test-case "tool-discipline: 100 when empty trace and no requirements"
   (define tmp-file (make-temporary-file "bench-trace-~a.jsonl"))
-  (call-with-output-file tmp-file
-    (lambda (out) (void))
-    #:exists 'replace)
+  (call-with-output-file tmp-file (lambda (out) (void)) #:exists 'replace)
   (define exec (make-test-exec-result #:trace-path tmp-file))
   (define task (make-test-task))
   (let-values ([(score _) (score-tool-discipline exec task)])
@@ -149,13 +151,14 @@
 
 (test-case "tool-discipline: detects tools used from trace"
   (define tmp-file (make-temporary-file "bench-trace-~a.jsonl"))
-  (call-with-output-file tmp-file
-    (lambda (out)
-      (write-json (hasheq 'phase "tool.call.started" 'data (hasheq 'name "write")) out)
-      (newline out)
-      (write-json (hasheq 'phase "tool.call.started" 'data (hasheq 'name "read")) out)
-      (newline out))
-    #:exists 'replace)
+  (call-with-output-file
+   tmp-file
+   (lambda (out)
+     (write-json (hasheq 'phase "tool.call.started" 'data (hasheq 'name "write")) out)
+     (newline out)
+     (write-json (hasheq 'phase "tool.call.started" 'data (hasheq 'name "read")) out)
+     (newline out))
+   #:exists 'replace)
   (define exec (make-test-exec-result #:trace-path tmp-file))
   (define task (make-test-task #:tools-used '("write" "read")))
   (let-values ([(score _) (score-tool-discipline exec task)])
@@ -165,10 +168,11 @@
 (test-case "tool-discipline: penalizes missing tools"
   (define tmp-file (make-temporary-file "bench-trace-~a.jsonl"))
   (call-with-output-file tmp-file
-    (lambda (out)
-      (write-json (hasheq 'phase "tool.call.started" 'data (hasheq 'name "read")) out)
-      (newline out))
-    #:exists 'replace)
+                         (lambda (out)
+                           (write-json (hasheq 'phase "tool.call.started" 'data (hasheq 'name "read"))
+                                       out)
+                           (newline out))
+                         #:exists 'replace)
   (define exec (make-test-exec-result #:trace-path tmp-file))
   (define task (make-test-task #:tools-used '("write" "read")))
   (let-values ([(score _) (score-tool-discipline exec task)])
@@ -177,13 +181,14 @@
 
 (test-case "tool-discipline: penalizes forbidden tools"
   (define tmp-file (make-temporary-file "bench-trace-~a.jsonl"))
-  (call-with-output-file tmp-file
-    (lambda (out)
-      (write-json (hasheq 'phase "tool.call.started" 'data (hasheq 'name "bash")) out)
-      (newline out)
-      (write-json (hasheq 'phase "tool.call.started" 'data (hasheq 'name "write")) out)
-      (newline out))
-    #:exists 'replace)
+  (call-with-output-file
+   tmp-file
+   (lambda (out)
+     (write-json (hasheq 'phase "tool.call.started" 'data (hasheq 'name "bash")) out)
+     (newline out)
+     (write-json (hasheq 'phase "tool.call.started" 'data (hasheq 'name "write")) out)
+     (newline out))
+   #:exists 'replace)
   (define exec (make-test-exec-result #:trace-path tmp-file))
   (define task (make-test-task #:tools-used '("write") #:tools-not-used '("bash")))
   (let-values ([(score _) (score-tool-discipline exec task)])
@@ -235,3 +240,52 @@
   (check-true (>= (score-result-total-score result) 0))
   (check-true (<= (score-result-total-score result) 100))
   (check-not-false (member (score-result-verdict result) '(PASS PARTIAL FAIL))))
+
+;; ============================================================
+;; v0.19.3 Wave 4: Partial credit + must_not_contain tests
+;; ============================================================
+
+(test-case "correctness: partial credit for 2 of 3 must-contain"
+  (define tmp-dir (make-temporary-file "bench-correct-~a" 'directory))
+  ;; Create a file with 2 of 3 required strings
+  (call-with-output-file (build-path tmp-dir "output.rkt")
+                         (lambda (out) (display "#lang racket\n(define (foo x) (+ x 1))\n" out)))
+  (define exec (make-test-exec-result #:project-dir tmp-dir))
+  (define task
+    (make-test-task #:files-created (list (hasheq 'path
+                                                  "output.rkt"
+                                                  'must_contain
+                                                  '("#lang racket" "define (foo" "MISSING-STRING")))))
+  (define-values (score details) (score-correctness exec task))
+  ;; 2 of 3 positive checks pass → 2/3 ≈ 67%
+  (check-true (> score 50) "partial credit should be > 50")
+  (check-true (< score 100) "partial credit should be < 100")
+  (delete-directory/files tmp-dir))
+
+(test-case "correctness: must_not_contain violation reduces score"
+  (define tmp-dir (make-temporary-file "bench-neg-~a" 'directory))
+  (call-with-output-file
+   (build-path tmp-dir "output.rkt")
+   (lambda (out) (display "#lang racket\n(define (foo x) (error \"not implemented\"))\n" out)))
+  (define exec (make-test-exec-result #:project-dir tmp-dir))
+  (define task
+    (make-test-task
+     #:files-created
+     (list (hasheq 'path "output.rkt" 'must_contain '("#lang racket") 'must_not_contain '("error")))))
+  (define-values (score details) (score-correctness exec task))
+  ;; 1 positive + 0 negative pass = 1/2 = 50%
+  (check-equal? score 50)
+  (delete-directory/files tmp-dir))
+
+(test-case "correctness: all must_not_contain pass gives full credit"
+  (define tmp-dir (make-temporary-file "bench-neg2-~a" 'directory))
+  (call-with-output-file (build-path tmp-dir "output.rkt")
+                         (lambda (out) (display "#lang racket\n(define (foo x) (+ x 1))\n" out)))
+  (define exec (make-test-exec-result #:project-dir tmp-dir))
+  (define task
+    (make-test-task
+     #:files-created
+     (list (hasheq 'path "output.rkt" 'must_contain '("#lang racket") 'must_not_contain '("error")))))
+  (define-values (score details) (score-correctness exec task))
+  (check-equal? score 100)
+  (delete-directory/files tmp-dir))

--- a/tests/test-benchmark-task.rkt
+++ b/tests/test-benchmark-task.rkt
@@ -37,9 +37,7 @@
 
 (define (make-temp-task-file content)
   (define tmp (make-temporary-file "bench-task-~a.json"))
-  (call-with-output-file tmp
-    (lambda (out) (write-json content out))
-    #:exists 'replace)
+  (call-with-output-file tmp (lambda (out) (write-json content out)) #:exists 'replace)
   tmp)
 
 ;; ============================================================
@@ -47,9 +45,7 @@
 ;; ============================================================
 
 (test-case "load valid minimal task"
-  (define tmp (make-temp-task-file
-               (hasheq 'name "test-task"
-                       'prompt "Do something")))
+  (define tmp (make-temp-task-file (hasheq 'name "test-task" 'prompt "Do something")))
   (define task (load-benchmark-task tmp))
   (check-equal? (benchmark-task-name task) "test-task")
   (check-equal? (benchmark-task-prompt task) "Do something")
@@ -60,10 +56,13 @@
 (test-case "load valid full task"
   (define tmp (make-temporary-file "bench-task-~a.json"))
   ;; Write JSON manually since write-json can't handle string keys in nested hashes
-  (call-with-output-file tmp
-    (lambda (out)
-      (display "{\"name\":\"full-task\",\"prompt\":\"Implement X\",\"category\":\"bug-fix\",\"difficulty\":3,\"description\":\"A complex bug fix\",\"max_iterations\":20,\"max_tokens\":50000,\"time_limit_seconds\":300,\"setup\":{\"files\":{\"foo.rkt\":\"#lang racket\"},\"extensions\":[\"racket-tooling\"],\"skills\":[\"q-racket-guardrails\"]},\"scoring\":{\"files_created\":[{\"path\":\"q/foo.rkt\",\"must_contain\":[\"define\",\"provide\"]}],\"tools_used\":[\"write\",\"racket-check\"],\"max_iterations\":15},\"teardown\":[\"q/foo.rkt\"]}" out))
-    #:exists 'replace)
+  (call-with-output-file
+   tmp
+   (lambda (out)
+     (display
+      "{\"name\":\"full-task\",\"prompt\":\"Implement X\",\"category\":\"bug-fix\",\"difficulty\":3,\"description\":\"A complex bug fix\",\"max_iterations\":20,\"max_tokens\":50000,\"time_limit_seconds\":300,\"setup\":{\"files\":{\"foo.rkt\":\"#lang racket\"},\"extensions\":[\"racket-tooling\"],\"skills\":[\"q-racket-guardrails\"]},\"scoring\":{\"files_created\":[{\"path\":\"q/foo.rkt\",\"must_contain\":[\"define\",\"provide\"]}],\"tools_used\":[\"write\",\"racket-check\"],\"max_iterations\":15},\"teardown\":[\"q/foo.rkt\"]}"
+      out))
+   #:exists 'replace)
   (define task (load-benchmark-task tmp))
   (check-equal? (benchmark-task-name task) "full-task")
   (check-equal? (benchmark-task-category task) 'bug-fix)
@@ -74,10 +73,8 @@
   ;; Setup — keys come through as strings from JSON
   (check-equal? (hash-ref (task-setup-spec-files (benchmark-task-setup task)) 'foo.rkt)
                 "#lang racket")
-  (check-equal? (task-setup-spec-extensions (benchmark-task-setup task))
-                '("racket-tooling"))
-  (check-equal? (task-setup-spec-skills (benchmark-task-setup task))
-                '("q-racket-guardrails"))
+  (check-equal? (task-setup-spec-extensions (benchmark-task-setup task)) '("racket-tooling"))
+  (check-equal? (task-setup-spec-skills (benchmark-task-setup task)) '("q-racket-guardrails"))
   ;; Scoring
   (define scoring (benchmark-task-scoring task))
   (check-equal? (length (scoring-spec-files-created scoring)) 1)
@@ -94,46 +91,39 @@
 ;; ============================================================
 
 (test-case "reject task without name"
-  (check-exn exn:fail?
-             (lambda ()
-               (validate-benchmark-task (hasheq 'prompt "Do something")))))
+  (check-exn exn:fail? (lambda () (validate-benchmark-task (hasheq 'prompt "Do something")))))
 
 (test-case "reject task without prompt"
-  (check-exn exn:fail?
-             (lambda ()
-               (validate-benchmark-task (hasheq 'name "test")))))
+  (check-exn exn:fail? (lambda () (validate-benchmark-task (hasheq 'name "test")))))
 
 (test-case "reject task with empty name"
   (check-exn exn:fail?
-             (lambda ()
-               (validate-benchmark-task (hasheq 'name "" 'prompt "Do something")))))
+             (lambda () (validate-benchmark-task (hasheq 'name "" 'prompt "Do something")))))
 
 (test-case "reject task with invalid category"
   (check-exn exn:fail?
              (lambda ()
-               (validate-benchmark-task
-                (hasheq 'name "test" 'prompt "x" 'category "invalid")))))
+               (validate-benchmark-task (hasheq 'name "test" 'prompt "x" 'category "invalid")))))
 
 (test-case "reject task with invalid difficulty"
   (check-exn exn:fail?
-             (lambda ()
-               (validate-benchmark-task
-                (hasheq 'name "test" 'prompt "x" 'difficulty 5)))))
+             (lambda () (validate-benchmark-task (hasheq 'name "test" 'prompt "x" 'difficulty 5)))))
 
 (test-case "reject non-hash input"
-  (check-exn exn:fail?
-             (lambda ()
-               (validate-benchmark-task "not a hash"))))
+  (check-exn exn:fail? (lambda () (validate-benchmark-task "not a hash"))))
 
 ;; ============================================================
 ;; Setup and teardown
 ;; ============================================================
 
 (test-case "setup creates temp directory"
-  (define task (validate-benchmark-task
-                (hasheq 'name "setup-test"
-                        'prompt "test"
-                        'setup (hasheq 'files (hasheq 'hello.rkt "#lang racket")))))
+  (define task
+    (validate-benchmark-task (hasheq 'name
+                                     "setup-test"
+                                     'prompt
+                                     "test"
+                                     'setup
+                                     (hasheq 'files (hasheq 'hello.rkt "#lang racket")))))
   (define tmp-dir (task-setup task))
   (check-true (directory-exists? tmp-dir))
   (check-true (file-exists? (build-path tmp-dir "hello.rkt")))
@@ -141,27 +131,28 @@
   (check-false (directory-exists? tmp-dir)))
 
 (test-case "setup with multiple files"
-  (define task (validate-benchmark-task
-                (hasheq 'name "multi-file"
-                        'prompt "test"
-                        'setup (hasheq 'files (hasheq 'a.rkt "content-a"
-                                                       'dir/b.rkt "content-b")))))
+  (define task
+    (validate-benchmark-task (hasheq 'name
+                                     "multi-file"
+                                     'prompt
+                                     "test"
+                                     'setup
+                                     (hasheq 'files
+                                             (hasheq 'a.rkt "content-a" 'dir/b.rkt "content-b")))))
   (define tmp-dir (task-setup task))
   (check-true (file-exists? (build-path tmp-dir "a.rkt")))
   (check-true (file-exists? (build-path tmp-dir "dir" "b.rkt")))
   (task-teardown task tmp-dir))
 
 (test-case "teardown with keep? preserves directory"
-  (define task (validate-benchmark-task
-                (hasheq 'name "keep-test" 'prompt "test")))
+  (define task (validate-benchmark-task (hasheq 'name "keep-test" 'prompt "test")))
   (define tmp-dir (task-setup task))
   (task-teardown task tmp-dir #t)
   (check-true (directory-exists? tmp-dir))
   (delete-directory/files tmp-dir))
 
 (test-case "teardown nonexistent dir is safe"
-  (define task (validate-benchmark-task
-                (hasheq 'name "safe-test" 'prompt "test")))
+  (define task (validate-benchmark-task (hasheq 'name "safe-test" 'prompt "test")))
   ;; Should not raise
   (task-teardown task "/tmp/nonexistent-benchmark-dir-xyz123"))
 
@@ -172,9 +163,9 @@
 (test-case "all-benchmark-tasks loads from directory"
   (define tmp-dir (make-temporary-file "bench-tasks-~a" 'directory))
   (for ([name '("task-a.json" "task-b.json")])
-    (call-with-output-file (build-path tmp-dir name)
-      (lambda (out)
-        (write-json (hasheq 'name name 'prompt (format "Prompt for ~a" name)) out))))
+    (call-with-output-file
+     (build-path tmp-dir name)
+     (lambda (out) (write-json (hasheq 'name name 'prompt (format "Prompt for ~a" name)) out))))
   (define tasks (all-benchmark-tasks tmp-dir))
   (check-equal? (length tasks) 2)
   (check-true (andmap benchmark-task? tasks))
@@ -183,9 +174,32 @@
 (test-case "all-benchmark-tasks ignores non-JSON files"
   (define tmp-dir (make-temporary-file "bench-tasks-~a" 'directory))
   (call-with-output-file (build-path tmp-dir "task.json")
-    (lambda (out) (write-json (hasheq 'name "only-task" 'prompt "x") out)))
-  (call-with-output-file (build-path tmp-dir "readme.md")
-    (lambda (out) (display "ignore me" out)))
+                         (lambda (out) (write-json (hasheq 'name "only-task" 'prompt "x") out)))
+  (call-with-output-file (build-path tmp-dir "readme.md") (lambda (out) (display "ignore me" out)))
   (define tasks (all-benchmark-tasks tmp-dir))
   (check-equal? (length tasks) 1)
   (delete-directory/files tmp-dir))
+
+(test-case "task-setup: directory fixture copies all files"
+  (define fixture-dir (make-temporary-file "bench-fix-~a" 'directory))
+  ;; Create a multi-file fixture
+  (call-with-output-file (build-path fixture-dir "main.rkt")
+                         (lambda (out) (display "#lang racket\n(require \"lib.rkt\")\n" out)))
+  (call-with-output-file (build-path fixture-dir "lib.rkt")
+                         (lambda (out)
+                           (display "#lang racket\n(provide foo)\n(define (foo x) x)\n" out)))
+  (make-directory (build-path fixture-dir "sub"))
+  (call-with-output-file (build-path fixture-dir "sub" "util.rkt")
+                         (lambda (out) (display "#lang racket\n(define (bar) 42)\n" out)))
+  ;; Create task with fixtures-dir pointing to the fixture directory
+  (define task
+    (validate-benchmark-task
+     (hasheq 'name "fixture-test" 'prompt "fix the bug" 'fixtures_dir (path->string fixture-dir))))
+  (define project-dir (task-setup task))
+  ;; Verify all files were copied
+  (check-true (file-exists? (build-path project-dir "main.rkt")))
+  (check-true (file-exists? (build-path project-dir "lib.rkt")))
+  (check-true (file-exists? (build-path project-dir "sub" "util.rkt")))
+  (check-true (string-contains? (file->string (build-path project-dir "main.rkt")) "require"))
+  (task-teardown task project-dir)
+  (delete-directory/files fixture-dir))


### PR DESCRIPTION
Addresses #1719.

feat: benchmark scoring improvements + trace iteration counting (#1719)

Wave 4 of v0.19.3: Improves benchmark scoring accuracy with partial
credit, negative content checks, and trace-based iteration counting.

- Add must_not_contain to file-check for negative content checks
- Partial credit: N/M scoring when some must_contain checks pass
- Trace-based iteration counting on timeout (counts tool.call.started)
- Fix directory fixture copy (contents into existing tmp-dir)
- Closes #1719, #1720, #1721, #1722, #1723