### PR TITLE
fix: extension register-tools dispatch with proper extension-ctx (GAP-2) (#1730)

### DIFF
--- a/extensions/compact-context.rkt
+++ b/extensions/compact-context.rkt
@@ -104,7 +104,7 @@
 ;; Extension definition
 ;; ============================================================
 
-(define (register-compact-tools ctx)
+(define (register-compact-tools ctx _payload)
   (ext-register-tool!
    ctx
    "compact-context"

--- a/extensions/ext-package-manager.rkt
+++ b/extensions/ext-package-manager.rkt
@@ -60,7 +60,7 @@
          (make-error-result (format "Failed to remove ~a." name)))]
     [else (make-error-result (format "Unknown action: ~a" action))]))
 
-(define (register-ext-pkg-tools ctx)
+(define (register-ext-pkg-tools ctx _payload)
   (ext-register-tool!
    ctx
    "ext-package"

--- a/extensions/github-integration.rkt
+++ b/extensions/github-integration.rkt
@@ -862,7 +862,7 @@
 ;; Registration
 ;; ============================================================
 
-(define (register-github-tools ctx)
+(define (register-github-tools ctx _payload)
   (ext-register-tool!
    ctx
    "gh-issue"

--- a/extensions/gsd-planning.rkt
+++ b/extensions/gsd-planning.rkt
@@ -202,7 +202,7 @@
 ;; Extension definition
 ;; ============================================================
 
-(define (register-gsd-tools ctx)
+(define (register-gsd-tools ctx _payload)
   (ext-register-tool!
    ctx
    "planning-read"

--- a/extensions/image-input.rkt
+++ b/extensions/image-input.rkt
@@ -74,7 +74,7 @@
             msg))]
     [else (make-error-result (format "Unknown action: ~a" action))]))
 
-(define (register-image-tools ctx)
+(define (register-image-tools ctx _payload)
   (ext-register-tool! ctx
                       "image-input"
                       (string-append "Multi-modal image input. "

--- a/extensions/q-sync.rkt
+++ b/extensions/q-sync.rkt
@@ -210,7 +210,7 @@
 ;; Extension definition
 ;; ============================================================
 
-(define (register-sync-tools ctx)
+(define (register-sync-tools ctx _payload)
   (ext-register-tool!
    ctx
    "q-sync"

--- a/extensions/racket-tooling.rkt
+++ b/extensions/racket-tooling.rkt
@@ -776,7 +776,7 @@
 ;; Extension definition
 ;; ============================================================
 
-(define (register-racket-tools ctx)
+(define (register-racket-tools ctx _payload)
   (ext-register-tool!
    ctx
    "racket-check"

--- a/extensions/remote-collab/remote-collab.rkt
+++ b/extensions/remote-collab/remote-collab.rkt
@@ -99,7 +99,7 @@
 ;; Extension definition
 ;; ============================================================
 
-(define (register-remote-tools ctx)
+(define (register-remote-tools ctx _payload)
   (ext-register-tool!
    ctx
    "remote-q"

--- a/extensions/session-export.rkt
+++ b/extensions/session-export.rkt
@@ -75,7 +75,7 @@
      (make-success-result (list (hasheq 'type "text" 'text (format "Exported to ~a" output))))]
     [else (make-success-result (list (hasheq 'type "text" 'text result)))]))
 
-(define (register-export-tools ctx)
+(define (register-export-tools ctx _payload)
   (ext-register-tool! ctx
                       "session-export"
                       "Export session logs to HTML, JSON, or Markdown."

--- a/runtime/iteration.rkt
+++ b/runtime/iteration.rkt
@@ -94,6 +94,7 @@
          ;; dispatches lifecycle hooks (turn-start, tool-call, tool-result,
          ;; turn-end, etc.) so extensions can observe/amend/block each step.
          "../extensions/hooks.rkt"
+         (only-in "../extensions/context.rkt" make-extension-ctx)
          "../runtime/session-store.rkt"
          "../runtime/tool-coordinator.rkt"
          (only-in "../runtime/compactor.rkt"
@@ -265,14 +266,24 @@
   (define base-tools (and reg (list-tools-jsexpr reg)))
 
   ;; #673: Merge extension-provided tools into the tool list
+  ;; v0.19.4 GAP-2 fix: create proper extension-ctx so register-tools handlers
+  ;; can call ext-register-tool! without contract violations.
   (define tools
-    (let ([ext-tools (and ext-reg
-                          (let ()
-                            (define-values (amended hook-res)
-                              (maybe-dispatch-hooks ext-reg 'register-tools (hasheq)))
-                            (if (and hook-res (eq? (hook-result-action hook-res) 'amend))
-                                (hash-ref (hook-result-payload hook-res) 'tools '())
-                                '())))])
+    (let ([ext-tools
+           (and ext-reg
+                (let ()
+                  ;; Build extension-ctx with available session components
+                  (define the-ext-ctx
+                    (make-extension-ctx #:session-id session-id
+                                        #:session-dir #f
+                                        #:event-bus bus
+                                        #:extension-registry ext-reg
+                                        #:tool-registry reg))
+                  (define-values (amended hook-res)
+                    (maybe-dispatch-hooks ext-reg 'register-tools (hasheq) #:ctx the-ext-ctx))
+                  (if (and hook-res (eq? (hook-result-action hook-res) 'amend))
+                      (hash-ref (hook-result-payload hook-res) 'tools '())
+                      '())))])
       (if (and base-tools (pair? ext-tools))
           (merge-tool-lists base-tools ext-tools)
           base-tools)))

--- a/tests/test-extension-tool-registration.rkt
+++ b/tests/test-extension-tool-registration.rkt
@@ -1,0 +1,123 @@
+#lang racket/base
+
+;; tests/test-extension-tool-registration.rkt — v0.19.4 GAP-2 fix verification
+;;
+;; Verifies that extension tools actually register when the register-tools
+;; hook is dispatched with a proper extension-ctx (not a bare hasheq).
+
+(require rackunit
+         racket/port
+         "../extensions/context.rkt"
+         "../extensions/hooks.rkt"
+         "../extensions/api.rkt"
+         "../extensions/dynamic-tools.rkt"
+         (only-in "../extensions/gsd-planning.rkt" gsd-planning-extension)
+         (only-in "../extensions/racket-tooling.rkt" racket-tooling-extension)
+         (only-in "../extensions/github-integration.rkt" github-integration-extension)
+         (only-in "../extensions/compact-context.rkt" compact-context-extension)
+         (only-in "../extensions/q-sync.rkt" q-sync-extension)
+         (only-in "../extensions/session-export.rkt" session-export-extension)
+         (only-in "../extensions/image-input.rkt" image-input-extension)
+         (only-in "../extensions/ext-package-manager.rkt" ext-package-manager-extension)
+         "../tools/tool.rkt"
+         "../agent/event-bus.rkt")
+
+;; Helper: create a test extension-ctx with a real tool-registry
+(define (make-test-ext-ctx reg)
+  (make-extension-ctx #:session-id "test-session"
+                      #:session-dir "/tmp"
+                      #:event-bus (make-event-bus)
+                      #:extension-registry (make-extension-registry)
+                      #:tool-registry reg))
+
+;; Helper: list all extensions we expect to register tools
+(define test-extensions
+  (list gsd-planning-extension
+        racket-tooling-extension
+        github-integration-extension
+        compact-context-extension
+        q-sync-extension
+        session-export-extension
+        image-input-extension
+        ext-package-manager-extension))
+
+;; Helper: register all test extensions into a registry
+(define (register-all-extensions! ext-reg)
+  (for ([ext (in-list test-extensions)])
+    (register-extension! ext-reg ext)))
+
+(test-case "register-tools handlers accept 2 args (ctx payload)"
+  ;; Verify each extension's register-tools handler has arity >= 2
+  (define ext-reg (make-extension-registry))
+  (register-all-extensions! ext-reg)
+  (for ([ext (in-list test-extensions)])
+    (define handler (hash-ref (extension-hooks ext) 'register-tools #f))
+    (check-not-false handler (format "extension ~a has register-tools handler" (extension-name ext)))
+    (check-true (procedure-arity-includes? handler 2)
+                (format "~a register-tools handler accepts 2 args" (extension-name ext)))))
+
+(test-case "extension tools register via hook dispatch with proper extension-ctx"
+  ;; Create registry, extension registry, register extensions
+  (define tool-reg (make-tool-registry))
+  (define ext-reg (make-extension-registry))
+  (register-all-extensions! ext-reg)
+
+  ;; Build extension-ctx with real tool-registry
+  (define ext-ctx (make-test-ext-ctx tool-reg))
+
+  ;; Dispatch register-tools hook with proper ctx
+  (define hook-res (dispatch-hooks 'register-tools (hasheq) ext-reg #:ctx ext-ctx))
+
+  ;; Verify tools were actually registered in the tool-registry
+  (define registered-names (sort (tool-names tool-reg) string<?))
+  (check-true
+   (>= (length registered-names) 10)
+   (format "Expected 10+ extension tools, got ~a: ~a" (length registered-names) registered-names))
+
+  ;; Verify specific expected tools
+  (for ([name '("planning-read" "planning-write"
+                                "racket-check"
+                                "racket-edit"
+                                "racket-codemod"
+                                "gh-issue"
+                                "gh-pr"
+                                "gh-milestone"
+                                "gh-board"
+                                "gh-wave-start"
+                                "gh-wave-finish"
+                                "compact-context"
+                                "q-sync"
+                                "session-export"
+                                "image-input"
+                                "ext-package")])
+    (check-not-false (lookup-tool tool-reg name) (format "tool '~a' registered" name))))
+
+(test-case "old 1-arg dispatch still works (backward compat)"
+  ;; The hooks system should fall back to 1-arg call for backward compat
+  ;; This test verifies the call-handler path
+  (define tool-reg (make-tool-registry))
+  (define ext-reg (make-extension-registry))
+  (register-all-extensions! ext-reg)
+  (define ext-ctx (make-test-ext-ctx tool-reg))
+
+  ;; Dispatch should work even if we pass ctx and some handlers accept 2 args
+  ;; The call-handler in hooks.rkt checks arity: if ctx provided and handler
+  ;; accepts 2 args, call (handler ctx payload); else call (handler payload)
+  (define hook-res (dispatch-hooks 'register-tools (hasheq) ext-reg #:ctx ext-ctx))
+
+  ;; Should succeed without error — tools registered
+  (check-not-false hook-res "hook returned a result")
+  (check-true (>= (length (tool-names tool-reg)) 10)
+              (format "10+ tools registered via compat path, got ~a" (length (tool-names tool-reg)))))
+
+(test-case "extension-ctx requires tool-registry for ext-register-tool!"
+  ;; Verify that without tool-registry, ext-register-tool! raises an error
+  (define ext-ctx-no-reg
+    (make-extension-ctx #:session-id "test"
+                        #:session-dir "/tmp"
+                        #:event-bus (make-event-bus)
+                        #:extension-registry (make-extension-registry)))
+  (check-exn exn:fail?
+             (lambda ()
+               (ext-register-tool! ext-ctx-no-reg "test-tool" "desc" (hasheq) (lambda (args) '())))
+             "ext-register-tool! should fail when no tool-registry in ctx"))

--- a/tests/test-github-integration.rkt
+++ b/tests/test-github-integration.rkt
@@ -145,7 +145,7 @@
   (define reg (make-tool-registry))
   (define ctx (make-test-ctx #:tool-registry reg))
   ;; Register extension tools
-  (register-github-tools ctx)
+  (register-github-tools ctx (hasheq))
   ;; Check all 6 tools are registered
   (for ([name '("gh-issue" "gh-pr" "gh-milestone" "gh-board" "gh-wave-start" "gh-wave-finish")])
     (check-not-false (lookup-tool reg name) (format "Tool ~a should be registered" name))))

--- a/tests/test-gsd-planning.rkt
+++ b/tests/test-gsd-planning.rkt
@@ -270,7 +270,7 @@
   (define reg (make-tool-registry))
   (define ctx (make-test-ctx #:tool-registry reg))
   (define handler (hash-ref (extension-hooks gsd-planning-extension) 'register-tools))
-  (handler ctx)
+  (handler ctx (hasheq))
   (check-not-false (lookup-tool reg "planning-read"))
   (check-not-false (lookup-tool reg "planning-write"))
   ;; Check tools have proper schemas
@@ -297,7 +297,7 @@
                    (define ctx (make-test-ctx #:tool-registry reg))
                    (define handler
                      (hash-ref (extension-hooks gsd-planning-extension) 'register-tools))
-                   (handler ctx)
+                   (handler ctx (hasheq))
                    (define pr (lookup-tool reg "planning-read"))
                    (define result ((tool-execute pr) (hasheq 'artifact "STATE" 'base_dir dir)))
                    (check-false (tool-result-is-error? result))
@@ -309,7 +309,7 @@
      (define reg (make-tool-registry))
      (define ctx (make-test-ctx #:tool-registry reg))
      (define handler (hash-ref (extension-hooks gsd-planning-extension) 'register-tools))
-     (handler ctx)
+     (handler ctx (hasheq))
      (define pw (lookup-tool reg "planning-write"))
      (define result
        ((tool-execute pw) (hasheq 'artifact "VALIDATION" 'content "## Tests pass" 'base_dir dir)))
@@ -334,7 +334,7 @@
   (define reg (make-tool-registry))
   (define ctx (make-test-ctx #:tool-registry reg))
   (define handler (hash-ref (extension-hooks gsd-planning-extension) 'register-tools))
-  (handler ctx)
+  (handler ctx (hasheq))
   (define pw (lookup-tool reg "planning-write"))
   (define result
     ((tool-execute pw) (hasheq 'artifact "../../etc/crontab.md" 'content "pwned" 'base_dir dir)))

--- a/tests/test-remote-collab.rkt
+++ b/tests/test-remote-collab.rkt
@@ -111,7 +111,7 @@
   (define hook (hash-ref (extension-hooks the-extension) 'register-tools #f))
   (check-not-false hook "register-tools hook exists")
   (when hook
-    (hook ctx))
+    (hook ctx (hasheq)))
   (check-not-false (lookup-tool reg "remote-q") "remote-q tool registered"))
 
 ;; ============================================================

--- a/tests/test-session-export.rkt
+++ b/tests/test-session-export.rkt
@@ -30,7 +30,7 @@
   (define hook (hash-ref (extension-hooks the-extension) 'register-tools #f))
   (check-not-false hook "register-tools hook exists")
   (when hook
-    (hook ctx))
+    (hook ctx (hasheq)))
   (check-not-false (lookup-tool reg "session-export") "session-export tool registered"))
 
 ;; ============================================================


### PR DESCRIPTION
## Wave 1 — GAP-2: Extension Tool Registration Fix

Fixes the critical gap where extension tools were never registered because `register-tools` hook was dispatched with a bare `(hasheq)` instead of a proper `extension-ctx`.

### Changes
- **`runtime/iteration.rkt`**: Creates `extension-ctx` with `session-id`, `bus`, `ext-reg`, and `reg` before dispatching `register-tools` hook, passing it as `#:ctx`
- **9 extension handlers** updated from 1-arg `(ctx)` to 2-arg `(ctx payload)` signature to match hook dispatch protocol
- **New test** `test-extension-tool-registration.rkt` — verifies 16+ tools actually register
- **Updated existing tests** in test-gsd-planning, test-github-integration, test-session-export, test-remote-collab

Closes #1731, #1732, #1733