### PR TITLE
fix: add execute-command handlers for github and racket extensions (GAP-3) (#1738)

### DIFF
--- a/extensions/github-integration.rkt
+++ b/extensions/github-integration.rkt
@@ -914,10 +914,45 @@
 ;; Extension definition
 ;; ============================================================
 
+(define (handle-github-command payload)
+  (define cmd (hash-ref payload 'command #f))
+  (define input-text (hash-ref payload 'input ""))
+  (cond
+    [(member cmd '("/milestone" "/ms"))
+     (hook-amend
+      (hasheq
+       'text
+       (format
+        "GitHub milestone command.~a\nUsage: /milestone [list|status|create] [args]\n\nUse gh-milestone-list, gh-milestone-status, or gh-milestone-create tools for full functionality."
+        (if (string=? input-text "")
+            ""
+            (format " Input: ~a" input-text)))))]
+    [(member cmd '("/issue" "/i"))
+     (hook-amend
+      (hasheq
+       'text
+       (format
+        "GitHub issue command.~a\nUsage: /issue [get|list|create|close] [number|args]\n\nUse gh-issue-get, gh-issue-list, gh-issue-create, or gh-issue-close tools for full functionality."
+        (if (string=? input-text "")
+            ""
+            (format " Input: ~a" input-text)))))]
+    [(member cmd '("/pr"))
+     (hook-amend
+      (hasheq
+       'text
+       (format
+        "GitHub PR command.~a\nUsage: /pr [list|get|create|merge] [number|args]\n\nUse gh-pr-list, gh-pr-get, gh-pr-create, or gh-pr-merge tools for full functionality."
+        (if (string=? input-text "")
+            ""
+            (format " Input: ~a" input-text)))))]
+    [else (hook-pass payload)]))
+
 (define-q-extension github-integration-extension
                     #:version "1.0.0"
                     #:api-version "1"
                     #:on register-tools
                     register-github-tools
                     #:on register-shortcuts
-                    register-github-commands)
+                    register-github-commands
+                    #:on execute-command
+                    handle-github-command)

--- a/extensions/racket-tooling.rkt
+++ b/extensions/racket-tooling.rkt
@@ -876,12 +876,47 @@
   (ext-register-command! ctx "/expand" "Expand a Racket file" 'general '() '("e"))
   (hook-pass ctx))
 
+(define (handle-racket-command payload)
+  (define cmd (hash-ref payload 'command #f))
+  (define input-text (hash-ref payload 'input ""))
+  (cond
+    [(member cmd '("/fmt" "/f"))
+     (hook-amend
+      (hasheq
+       'text
+       (format
+        "Format a Racket file with raco fmt.~a\nUsage: /fmt <path>\n\nUse the racket-check tool with mode='format' for programmatic access."
+        (if (string=? input-text "")
+            ""
+            (format " File: ~a" input-text)))))]
+    [(member cmd '("/check" "/c"))
+     (hook-amend
+      (hasheq
+       'text
+       (format
+        "Compile-check a Racket file.~a\nUsage: /check <path>\n\nUse the racket-check tool with mode='syntax' for programmatic access."
+        (if (string=? input-text "")
+            ""
+            (format " File: ~a" input-text)))))]
+    [(member cmd '("/expand" "/e"))
+     (hook-amend
+      (hasheq
+       'text
+       (format
+        "Expand macros in a Racket file.~a\nUsage: /expand <path>\n\nUse the racket-check tool with mode='expand' for programmatic access."
+        (if (string=? input-text "")
+            ""
+            (format " File: ~a" input-text)))))]
+    [else (hook-pass payload)]))
+
 (define-q-extension racket-tooling-extension
                     #:version "1.0.0"
                     #:api-version "1"
                     #:on register-tools
                     register-racket-tools
                     #:on register-shortcuts
-                    register-racket-commands)
+                    register-racket-commands
+                    #:on execute-command
+                    handle-racket-command)
 
 (define the-extension racket-tooling-extension)


### PR DESCRIPTION
## Wave 3 — GAP-3 + M1 + M2: Slash Command Handlers + Skill Cleanup

### Code Changes
- **`extensions/github-integration.rkt`**: Add `execute-command` handler for `/milestone`, `/issue`, `/pr` commands
- **`extensions/racket-tooling.rkt`**: Add `execute-command` handler for `/fmt`, `/check`, `/expand` commands
- Unrecognized commands pass through via `hook-pass`

### Skill File Changes (local only, outside git repo)
- `q-racket-guardrails/SKILL.md`: Fixed phantom `racket_find_files` references (M1)
- `q-gsd-github-projects/SKILL.md`: Added note to prefer extension tools over bash+curl (M2)

Closes #1739, #1740, #1741