### PR TITLE
fix: replace hardcoded tool counts with range checks in tests (#1761)

Wave 4 of CI hardening milestone.

Replaced `check-equal? ... 13` with `check-true (>= ... 13)` in:
- tests/test-main.rkt (4 occurrences — tool registration counts)
- tests/test-integration.rkt (1 occurrence — tool name count)

These tests broke on CI when tools were added/removed. Range checks
are resilient to tool additions while still catching regressions.

Sub-issues: #1762, #1763

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ q/
 | Test files | 394 |
 | Source modules | 261 |
 | Source lines | 50807 |
-| Test lines | 79005 |
+| Test lines | 79014 |
 | Test assertions | 12038 |
 | `racket scripts/run-tests.rkt` results | 4,858+ tests passing |
 

--- a/tests/test-integration.rkt
+++ b/tests/test-integration.rkt
@@ -415,7 +415,8 @@
   (define reg (make-tool-registry))
   (register-default-tools! reg)
   (define names (tool-names reg))
-  (check-equal? (length names) 13)
+  ;; Guard: use >= to avoid breakage when tools are added
+  (check-true (>= (length names) 13) (format "expected >= 13 default tools, got ~a" (length names)))
   (check-not-false (member "read" names))
   (check-not-false (member "write" names))
   (check-not-false (member "edit" names))

--- a/tests/test-main.rkt
+++ b/tests/test-main.rkt
@@ -30,10 +30,12 @@
 ;; register-default-tools!
 ;; ============================================================
 
-(test-case "registers all 13 built-in tools"
+(test-case "registers all built-in tools (>= 13)"
   (define reg (make-tool-registry))
   (register-default-tools! reg)
-  (check-equal? (length (list-tools reg)) 13))
+  ;; Guard: use >= to avoid breakage when tools are added
+  (check-true (>= (length (list-tools reg)) 13)
+              (format "expected >= 13 built-in tools, got ~a" (length (list-tools reg)))))
 
 (test-case "each tool is a valid tool struct with executable"
   (define reg (make-tool-registry))
@@ -43,10 +45,12 @@
     (check-pred tool? t)
     (check-true (procedure? (tool-execute t)))))
 
-(test-case "registry has correct count"
+(test-case "registry has correct count (>= 13)"
   (define reg (make-tool-registry))
   (register-default-tools! reg)
-  (check-equal? (length (list-tools reg)) 13))
+  ;; Guard: use >= to avoid breakage when tools are added
+  (check-true (>= (length (list-tools reg)) 13)
+              (format "expected >= 13 built-in tools, got ~a" (length (list-tools reg)))))
 
 ;; ============================================================
 ;; build-runtime-from-cli
@@ -70,11 +74,13 @@
   (check-true (not (false? (member (provider-name (hash-ref rt 'provider))
                                    '("mock" "openai-compatible"))))))
 
-(test-case "tool-registry has all 11 built-in tools"
+(test-case "tool-registry has built-in tools (>= 13)"
   (define cfg (parse-cli-args #()))
   (define rt (build-runtime-from-cli cfg))
   (define reg (hash-ref rt 'tool-registry))
-  (check-equal? (length (list-tools reg)) 13))
+  ;; Guard: use >= to avoid breakage when tools are added
+  (check-true (>= (length (list-tools reg)) 13)
+              (format "expected >= 13 built-in tools, got ~a" (length (list-tools reg)))))
 
 (test-case "event-bus is valid"
   (define cfg (parse-cli-args #()))
@@ -731,10 +737,12 @@
   (register-default-tools! reg #:only '("read" "bash"))
   (check-equal? (sort (tool-names reg) string<?) '("bash" "read")))
 
-(test-case "register-default-tools! #:only #f registers all"
+(test-case "register-default-tools! #:only #f registers all (>= 13)"
   (define reg (make-tool-registry))
   (register-default-tools! reg #:only #f)
-  (check-equal? (length (tool-names reg)) 13))
+  ;; Guard: use >= to avoid breakage when tools are added
+  (check-true (>= (length (tool-names reg)) 13)
+              (format "expected >= 13 tool names, got ~a" (length (tool-names reg)))))
 
 (test-case "register-default-tools! #:only empty list registers none"
   (define reg (make-tool-registry))


### PR DESCRIPTION
Addresses #1761.

fix: replace hardcoded tool counts with range checks in tests (#1761)

Wave 4 of CI hardening milestone.

Replaced `check-equal? ... 13` with `check-true (>= ... 13)` in:
- tests/test-main.rkt (4 occurrences — tool registration counts)
- tests/test-integration.rkt (1 occurrence — tool name count)

These tests broke on CI when tools were added/removed. Range checks
are resilient to tool additions while still catching regressions.

Sub-issues: #1762, #1763