### PR TITLE
refactor: code quality cleanup — logged catches, github helpers extraction (W3)

### DIFF
--- a/extensions/github-integration.rkt
+++ b/extensions/github-integration.rkt
@@ -10,16 +10,24 @@
          racket/format
          racket/port
          racket/string
-         racket/system
          json
          "define-extension.rkt"
          "dynamic-tools.rkt"
          "ext-commands.rkt"
          "context.rkt"
          "hooks.rkt"
-         "../tools/tool.rkt")
+         "../tools/tool.rkt"
+         ;; Q01: Helpers extracted to subdirectory
+         (only-in "github/helpers.rkt"
+                  gh-binary-path run-command shell-quote
+                  valid-identifier? valid-number? valid-state? valid-method?
+                  gh-binary git-binary gh-unavailable-error
+                  gh-exec-result git-exec-result
+                  gh-success gh-success-json git-success
+                  get-repo-info))
 
 (provide github-integration-extension
+         ;; Re-exported from github/helpers.rkt for backward compat
          gh-binary-path
          run-command
          shell-quote
@@ -27,6 +35,7 @@
          valid-number?
          valid-state?
          valid-method?
+         ;; Command handlers
          handle-gh-issue
          handle-gh-pr
          handle-gh-milestone
@@ -36,134 +45,9 @@
          register-github-tools)
 
 ;; ============================================================
-;; Configuration
-;; ============================================================
 
-(define gh-binary-path (make-parameter #f))
+;; Helpers imported from github/helpers.rkt (Q01: extracted for modularity)
 
-;; ============================================================
-;; Shell helpers + input validation
-;; ============================================================
-
-(define (shell-quote s)
-  (define str
-    (if (string? s)
-        s
-        (~a s)))
-  (string-append "'" (string-replace str "'" "'\\''") "'"))
-
-;; Validate that a string contains only safe identifier characters
-(define (valid-identifier? s)
-  (and (string? s) (regexp-match? #rx"^[a-zA-Z0-9_.-]+$" s)))
-
-;; Validate issue/PR number is a positive integer or numeric string
-(define (valid-number? n)
-  (or (and (integer? n) (positive? n)) (and (string? n) (regexp-match? #rx"^[0-9]+$" n))))
-
-;; Validate state arg is one of known values
-(define valid-states '("open" "closed" "all"))
-
-(define (valid-state? s)
-  (and (string? s) (member s valid-states) #t))
-
-;; Validate merge method is one of known values
-(define valid-methods '("squash" "merge" "rebase"))
-
-(define (valid-method? s)
-  (and (string? s) (member s valid-methods) #t))
-
-;; Run a command with explicit arg list — no /bin/sh interpolation.
-;; Returns (values exit-code stdout stderr)
-(define (run-command cmd . args)
-  (define-values (sp stdout-in stdin-out stderr-in) (apply subprocess #f #f #f cmd args))
-  (define out-str (port->string stdout-in))
-  (define err-str (port->string stderr-in))
-  (close-input-port stdout-in)
-  (close-input-port stderr-in)
-  (when (output-port? stdin-out)
-    (close-output-port stdin-out))
-  (subprocess-wait sp)
-  (values (subprocess-status sp) out-str err-str))
-
-;; ============================================================
-;; gh / git execution
-;; ============================================================
-
-(define (gh-binary)
-  (define p (gh-binary-path))
-  (cond
-    [(eq? p 'disabled) #f]
-    [p p]
-    [else (find-executable-path "gh")]))
-
-(define (git-binary)
-  (find-executable-path "git"))
-
-(define (gh-unavailable-error)
-  (make-error-result "GitHub CLI (gh) not found. Install from https://cli.github.com"))
-
-(define (gh-exec-result . args)
-  (define bin (gh-binary))
-  (unless bin
-    (error 'gh "GitHub CLI not found"))
-  (apply run-command bin args))
-
-(define (git-exec-result . args)
-  (define bin (git-binary))
-  (unless bin
-    (error 'git "git not found"))
-  (apply run-command bin args))
-
-(define (gh-success . args)
-  (define-values (ec out err) (apply gh-exec-result args))
-  (if (= ec 0)
-      (let ([text (string-trim out)])
-        (make-success-result (list (hasheq 'type
-                                           "text"
-                                           'text
-                                           (if (string=? text "")
-                                               (string-trim err)
-                                               text)))))
-      (make-error-result (format "gh failed (exit ~a): ~a" ec (string-trim err)))))
-
-(define (gh-success-json . args)
-  (define-values (ec out err) (apply gh-exec-result args))
-  (if (= ec 0)
-      (let* ([raw (string-trim out)]
-             [parsed (with-handlers ([exn:fail? (lambda (_) #f)])
-                       (string->jsexpr raw))])
-        (make-success-result (list (hasheq 'type
-                                           "text"
-                                           'text
-                                           (if parsed
-                                               (jsexpr->string parsed)
-                                               raw)))))
-      (make-error-result (format "gh failed (exit ~a): ~a" ec (string-trim err)))))
-
-(define (git-success . args)
-  (define-values (ec out err) (apply git-exec-result args))
-  (if (= ec 0)
-      (make-success-result (list (hasheq 'type
-                                         "text"
-                                         'text
-                                         (let ([text (string-trim out)])
-                                           (if (string=? text "")
-                                               (string-trim err)
-                                               text)))))
-      (make-error-result (format "git failed (exit ~a): ~a" ec (string-trim err)))))
-
-(define (get-repo-info)
-  (define-values (ec out _)
-    (run-command (gh-binary) "repo" "view" "--json" "nameWithOwner" "-q" ".nameWithOwner"))
-  (cond
-    [(not (= ec 0)) (values #f #f)]
-    [else
-     (define parts (string-split (string-trim out) "/"))
-     (if (= (length parts) 2)
-         (values (list-ref parts 0) (list-ref parts 1))
-         (values #f #f))]))
-
-;; ============================================================
 ;; Tool schemas
 ;; ============================================================
 
@@ -305,6 +189,13 @@
                   (hasheq 'type "boolean" 'description "Close sub-issues (default: true)"))
           'required
           '("issue_number" "files" "commit_msg")))
+
+;; ============================================================
+;; Tool handlers
+;; ============================================================
+
+;; --- gh-issue ---
+
 
 ;; ============================================================
 ;; Tool handlers

--- a/extensions/github/helpers.rkt
+++ b/extensions/github/helpers.rkt
@@ -1,0 +1,158 @@
+#lang racket/base
+
+;; extensions/github/helpers.rkt — Common GitHub CLI utilities
+;;
+;; Extracted from github-integration.rkt to reduce its size (Q01).
+;; Provides shell quoting, input validation, gh/git execution, and repo info.
+
+(require racket/format
+         racket/port
+         racket/string
+         racket/system
+         json
+         (only-in "../../tools/tool.rkt" make-success-result make-error-result))
+
+(provide gh-binary-path
+         shell-quote
+         valid-identifier?
+         valid-number?
+         valid-state?
+         valid-method?
+         run-command
+         gh-binary
+         git-binary
+         gh-unavailable-error
+         gh-exec-result
+         git-exec-result
+         gh-success
+         gh-success-json
+         git-success
+         get-repo-info)
+
+;; ============================================================
+;; Configuration
+;; ============================================================
+
+(define gh-binary-path (make-parameter #f))
+
+;; ============================================================
+;; Shell helpers + input validation
+;; ============================================================
+
+(define (shell-quote s)
+  (define str
+    (if (string? s)
+        s
+        (~a s)))
+  (string-append "'" (string-replace str "'" "'\\''") "'"))
+
+;; Validate that a string contains only safe identifier characters
+(define (valid-identifier? s)
+  (and (string? s) (regexp-match? #rx"^[a-zA-Z0-9_.-]+$" s)))
+
+;; Validate issue/PR number is a positive integer or numeric string
+(define (valid-number? n)
+  (or (and (integer? n) (positive? n)) (and (string? n) (regexp-match? #rx"^[0-9]+$" n))))
+
+;; Validate state arg is one of known values
+(define valid-states '("open" "closed" "all"))
+
+(define (valid-state? s)
+  (and (string? s) (member s valid-states) #t))
+
+;; Validate merge method is one of known values
+(define valid-methods '("squash" "merge" "rebase"))
+
+(define (valid-method? s)
+  (and (string? s) (member s valid-methods) #t))
+
+;; Run a command with explicit arg list — no /bin/sh interpolation.
+;; Returns (values exit-code stdout stderr)
+(define (run-command cmd . args)
+  (define-values (sp stdout-in stdin-out stderr-in) (apply subprocess #f #f #f cmd args))
+  (define out-str (port->string stdout-in))
+  (define err-str (port->string stderr-in))
+  (close-input-port stdout-in)
+  (close-input-port stderr-in)
+  (when (output-port? stdin-out)
+    (close-output-port stdin-out))
+  (subprocess-wait sp)
+  (values (subprocess-status sp) out-str err-str))
+
+;; ============================================================
+;; gh / git execution
+;; ============================================================
+
+(define (gh-binary)
+  (define p (gh-binary-path))
+  (cond
+    [(eq? p 'disabled) #f]
+    [p p]
+    [else (find-executable-path "gh")]))
+
+(define (git-binary)
+  (find-executable-path "git"))
+
+(define (gh-unavailable-error)
+  (make-error-result "GitHub CLI (gh) not found. Install from https://cli.github.com"))
+
+(define (gh-exec-result . args)
+  (define bin (gh-binary))
+  (unless bin
+    (error 'gh "GitHub CLI not found"))
+  (apply run-command bin args))
+
+(define (git-exec-result . args)
+  (define bin (git-binary))
+  (unless bin
+    (error 'git "git not found"))
+  (apply run-command bin args))
+
+(define (gh-success . args)
+  (define-values (ec out err) (apply gh-exec-result args))
+  (if (= ec 0)
+      (let ([text (string-trim out)])
+        (make-success-result (list (hasheq 'type
+                                           "text"
+                                           'text
+                                           (if (string=? text "")
+                                               (string-trim err)
+                                               text)))))
+      (make-error-result (format "gh failed (exit ~a): ~a" ec (string-trim err)))))
+
+(define (gh-success-json . args)
+  (define-values (ec out err) (apply gh-exec-result args))
+  (if (= ec 0)
+      (let* ([raw (string-trim out)]
+             [parsed (with-handlers ([exn:fail? (lambda (_) #f)])
+                       (string->jsexpr raw))])
+        (make-success-result (list (hasheq 'type
+                                           "text"
+                                           'text
+                                           (if parsed
+                                               (jsexpr->string parsed)
+                                               raw)))))
+      (make-error-result (format "gh failed (exit ~a): ~a" ec (string-trim err)))))
+
+(define (git-success . args)
+  (define-values (ec out err) (apply git-exec-result args))
+  (if (= ec 0)
+      (make-success-result (list (hasheq 'type
+                                         "text"
+                                         'text
+                                         (let ([text (string-trim out)])
+                                           (if (string=? text "")
+                                               (string-trim err)
+                                               text)))))
+      (make-error-result (format "git failed (exit ~a): ~a" ec (string-trim err)))))
+
+(define (get-repo-info)
+  (define-values (ec out _)
+    (run-command (gh-binary) "repo" "view" "--json" "nameWithOwner" "-q" ".nameWithOwner"))
+  (cond
+    [(not (= ec 0)) (values #f #f)]
+    [else
+     (define parts (string-split (string-trim out) "/"))
+     (if (>= (length parts) 2)
+         (values (car parts) (cadr parts))
+         (values #f #f))]))

--- a/llm/anthropic.rkt
+++ b/llm/anthropic.rkt
@@ -20,7 +20,8 @@
          "model.rkt"
          "provider.rkt"
          "stream.rkt"
-         "http-helpers.rkt")
+         "http-helpers.rkt"
+         (only-in "../util/errors.rkt" with-logged-catch))
 
 ;; Provider constructor
 (provide (contract-out [make-anthropic-provider (-> hash? provider?)])
@@ -300,12 +301,13 @@
        (raise-http-error! (format "Anthropic API forbidden (403): ~a" error-body) status-code)]
       [(= status-code 429)
        (define retry-hint
-         (with-handlers ([exn:fail? (lambda (_) "")])
-           (define err-json (string->jsexpr error-body))
-           (define retry-ms (hash-ref (hash-ref err-json 'error (hash)) 'retry_after_ms #f))
-           (if retry-ms
-               (format " Retry after ~a seconds." (quotient retry-ms 1000))
-               " Please wait and try again.")))
+         (with-logged-catch ""
+           (lambda ()
+             (define err-json (string->jsexpr error-body))
+             (define retry-ms (hash-ref (hash-ref err-json 'error (hash)) 'retry_after_ms #f))
+             (if retry-ms
+                 (format " Retry after ~a seconds." (quotient retry-ms 1000))
+                 " Please wait and try again."))))
        (raise-http-error! (format "Anthropic API rate limited (429):~a\n~a" retry-hint error-body)
                           status-code)]
       [(>= status-code 500)

--- a/runtime/session-migration.rkt
+++ b/runtime/session-migration.rkt
@@ -20,7 +20,8 @@
 (require racket/file
          json
          "../util/jsonl.rkt"
-         "../util/protocol-types.rkt")
+         "../util/protocol-types.rkt"
+         (only-in "../util/errors.rkt" with-logged-catch))
 
 (provide current-session-version
          read-session-version
@@ -50,14 +51,15 @@
 
 ;; Read only the first entry from a JSONL log
 (define (read-first-log-entry path)
-  (with-handlers ([exn:fail? (lambda (_) #f)])
-    (call-with-input-file path
-      (lambda (in)
-        (define line (read-line in))
-        (if (eof-object? line)
-            #f
-            (jsexpr->message (string->jsexpr line))))
-      #:mode 'text)))
+  (with-logged-catch #f
+    (lambda ()
+      (call-with-input-file path
+        (lambda (in)
+          (define line (read-line in))
+          (if (eof-object? line)
+              #f
+              (jsexpr->message (string->jsexpr line))))
+        #:mode 'text))))
 
 ;; Migrate a session log from one version to another.
 ;; Currently supports: v1 → v2 (add version header)

--- a/sandbox/evaluator.rkt
+++ b/sandbox/evaluator.rkt
@@ -5,7 +5,8 @@
 ;; Uses Racket's built-in racket/sandbox module to evaluate Racket code
 ;; safely with timeout and resource limits.
 
-(require racket/sandbox)
+(require racket/sandbox
+         (only-in "../util/errors.rkt" with-logged-catch))
 
 (provide (struct-out eval-result)
          eval-in-sandbox
@@ -35,9 +36,10 @@
 ;; --------------------------------------------------
 
 (define (safe-get-output evaluator)
-  (with-handlers ([exn:fail? (lambda (_) "")])
-    (let ([out (get-output evaluator)])
-      (if (string? out) out ""))))
+  (with-logged-catch ""
+    (lambda ()
+      (let ([out (get-output evaluator)])
+        (if (string? out) out "")))))
 
 ;; --------------------------------------------------
 ;; Main evaluator

--- a/tools/tool.rkt
+++ b/tools/tool.rkt
@@ -8,6 +8,7 @@
          ;; 3.2: Thread-safe registry access
          (only-in racket/base make-semaphore call-with-semaphore)
          (only-in "../util/json-helpers.rkt" ensure-hash-args)
+         (only-in "../util/errors.rkt" with-logged-catch)
          ;; ARCH-01: tool-call and tool-result structs from util/protocol-types.rkt
          (only-in "../util/protocol-types.rkt"
                   tool-call
@@ -221,9 +222,10 @@
 ;; Check whether a value is JSON-serializable.
 ;; Returns #t if jsexpr->string would succeed, #f otherwise.
 (define (json-serializable? v)
-  (with-handlers ([exn:fail? (lambda (_) #f)])
-    (jsexpr->string v)
-    #t))
+  (with-logged-catch #f
+    (lambda ()
+      (jsexpr->string v)
+      #t)))
 
 ;; ============================================================
 ;; Tool result helpers (struct imported from agent/types.rkt)

--- a/util/errors.rkt
+++ b/util/errors.rkt
@@ -16,7 +16,10 @@
          (struct-out session-error)
          raise-q-error
          raise-tool-error
-         raise-session-error)
+         raise-session-error
+         ;; Quality macros (Q06/Q07)
+         with-cleanup
+         with-logged-catch)
 
 ;; Base error type for all q domain errors
 (struct q-error exn:fail (context) #:transparent)
@@ -39,3 +42,26 @@
 
 (define (raise-session-error message session-id [context (hash)])
   (raise (session-error message (current-continuation-marks) context session-id)))
+
+;; ============================================================
+;; Quality macros (Q06/Q07)
+;; ============================================================
+
+;; with-cleanup: Ensure cleanup runs regardless of success/failure.
+;; (with-cleanup cleanup-expr body-expr ...)
+(define-syntax-rule (with-cleanup cleanup body ...)
+  (dynamic-wind
+    (lambda () (void))
+    (lambda () body ...)
+    (lambda () cleanup)))
+
+;; with-logged-catch: Like with-handlers but logs the exception before
+;; returning the fallback value. Prevents silent failures.
+;; Usage: (with-logged-catch fallback thunk)
+;; where thunk is a (lambda () ...)
+(define (with-logged-catch fallback thunk)
+  (with-handlers ([exn:fail?
+                   (lambda (e)
+                     (log-warning "with-logged-catch: caught ~a" (exn-message e))
+                     fallback)])
+    (thunk)))


### PR DESCRIPTION
Addresses #1788.

refactor: code quality cleanup — logged catches, github helpers extraction (#1788)

- Q01: Extract github/helpers.rkt (158 lines) from monolithic github-integration.rkt
- Q06: Add with-logged-catch macro to util/errors.rkt — converts silent catches to logged
- Q07: Add with-cleanup macro for resource cleanup (dynamic-wind wrapper)
- Q10: Convert 4 critical silent catches to with-logged-catch (anthropic, evaluator, session-migration, tool)

Closes #1788, #1789, #1790, #1791