### PR TITLE
fix: extension tool handler arity mismatch (#1822)

8/16 extension tool handlers crashed with arity mismatch — they accept
1 arg (args) but scheduler calls with 2 args (args + exec-ctx).

Two-layer fix:
1. Central wrapper in dynamic-tools.rkt wraps all handlers to accept
   (args exec-ctx) — covers all current and future extension tools
2. Defense-in-depth: added [exec-ctx #f] to all 8 broken handlers in
   gsd-planning.rkt and github-integration.rkt

Updated test calls from ((tool-execute t) args) to
((tool-execute t) args #f) where tests invoke extension handlers directly.

Closes #1822, #1823, #1824

### DIFF
--- a/extensions/dynamic-tools.rkt
+++ b/extensions/dynamic-tools.rkt
@@ -32,6 +32,11 @@
 
 ;; Register a tool dynamically from an extension.
 ;; The tool-registry in the extension context must be set (not #f).
+;;
+;; FIX: The tool scheduler always calls handlers with (args exec-ctx), but
+;; extension handlers typically take only (args). We wrap the handler to
+;; accept both arguments, making all extension tools work without requiring
+;; every handler to add [exec-ctx #f].
 (define (ext-register-tool! ctx
                             name
                             description
@@ -44,7 +49,10 @@
      'ext-register-tool!
      "no tool-registry available in extension context. \
             Ensure #:tool-registry is set when creating the context."))
-  (define t (make-tool name description schema handler #:prompt-guidelines prompt-guidelines))
+  ;; Wrap handler to always accept (args exec-ctx) — defense against arity mismatch
+  ;; when the scheduler calls ((tool-execute t) args exec-ctx).
+  (define wrapped-handler (lambda (args exec-ctx) (handler args)))
+  (define t (make-tool name description schema wrapped-handler #:prompt-guidelines prompt-guidelines))
   (register-tool! reg t))
 
 ;; ============================================================

--- a/extensions/github-integration.rkt
+++ b/extensions/github-integration.rkt
@@ -19,11 +19,21 @@
          "../tools/tool.rkt"
          ;; Q01: Helpers extracted to subdirectory
          (only-in "github/helpers.rkt"
-                  gh-binary-path run-command shell-quote
-                  valid-identifier? valid-number? valid-state? valid-method?
-                  gh-binary git-binary gh-unavailable-error
-                  gh-exec-result git-exec-result
-                  gh-success gh-success-json git-success
+                  gh-binary-path
+                  run-command
+                  shell-quote
+                  valid-identifier?
+                  valid-number?
+                  valid-state?
+                  valid-method?
+                  gh-binary
+                  git-binary
+                  gh-unavailable-error
+                  gh-exec-result
+                  git-exec-result
+                  gh-success
+                  gh-success-json
+                  git-success
                   get-repo-info))
 
 (provide github-integration-extension
@@ -196,14 +206,13 @@
 
 ;; --- gh-issue ---
 
-
 ;; ============================================================
 ;; Tool handlers
 ;; ============================================================
 
 ;; --- gh-issue ---
 
-(define (handle-gh-issue args)
+(define (handle-gh-issue args [exec-ctx #f])
   (with-handlers ([exn:fail? (lambda (e) (make-error-result (exn-message e)))])
     (cond
       [(not (gh-binary)) (gh-unavailable-error)]
@@ -326,7 +335,7 @@
 
 ;; --- gh-pr ---
 
-(define (handle-gh-pr args)
+(define (handle-gh-pr args [exec-ctx #f])
   (with-handlers ([exn:fail? (lambda (e) (make-error-result (exn-message e)))])
     (cond
       [(not (gh-binary)) (gh-unavailable-error)]
@@ -457,7 +466,7 @@
 
 ;; --- gh-milestone ---
 
-(define (handle-gh-milestone args)
+(define (handle-gh-milestone args [exec-ctx #f])
   (with-handlers ([exn:fail? (lambda (e) (make-error-result (exn-message e)))])
     (cond
       [(not (gh-binary)) (gh-unavailable-error)]
@@ -521,7 +530,7 @@
 
 ;; --- gh-board ---
 
-(define (handle-gh-board args)
+(define (handle-gh-board args [exec-ctx #f])
   (with-handlers ([exn:fail? (lambda (e) (make-error-result (exn-message e)))])
     (cond
       [(not (gh-binary)) (gh-unavailable-error)]
@@ -626,7 +635,7 @@
 
 ;; --- gh-wave-start ---
 
-(define (handle-gh-wave-start args)
+(define (handle-gh-wave-start args [exec-ctx #f])
   (with-handlers ([exn:fail? (lambda (e) (make-error-result (exn-message e)))])
     (define issue-num (hash-ref args 'issue_number #f))
     (cond
@@ -659,7 +668,7 @@
 
 ;; --- gh-wave-finish ---
 
-(define (handle-gh-wave-finish args)
+(define (handle-gh-wave-finish args [exec-ctx #f])
   (with-handlers ([exn:fail? (lambda (e) (make-error-result (exn-message e)))])
     (define issue-num (hash-ref args 'issue_number #f))
     (define files (hash-ref args 'files '()))

--- a/extensions/gsd-planning.rkt
+++ b/extensions/gsd-planning.rkt
@@ -151,7 +151,7 @@
 ;; Tool handlers
 ;; ============================================================
 
-(define (handle-planning-read args)
+(define (handle-planning-read args [exec-ctx #f])
   (define name (hash-ref args 'artifact ""))
   (define base-dir (hash-ref args 'base_dir (current-directory)))
   (cond
@@ -169,7 +169,7 @@
           (make-success-result (list (hasheq 'type "text" 'text (jsexpr->string content))))]
          [else (make-success-result (list (hasheq 'type "text" 'text content)))]))]))
 
-(define (handle-planning-write args)
+(define (handle-planning-write args [exec-ctx #f])
   (define name (hash-ref args 'artifact ""))
   (define content-str (hash-ref args 'content ""))
   (define base-dir (hash-ref args 'base_dir (current-directory)))

--- a/tests/test-ext-dynamic-tools.rkt
+++ b/tests/test-ext-dynamic-tools.rkt
@@ -59,7 +59,7 @@
                                                 (hash-ref args 'b 0)
                                                 (+ (hash-ref args 'a 0) (hash-ref args 'b 0))))))))
   (define t (lookup-tool reg "adder"))
-  (define result ((tool-execute t) (hasheq 'a 3 'b 4)))
+  (define result ((tool-execute t) (hasheq 'a 3 'b 4) #f))
   (check-false (tool-result-is-error? result)))
 
 (test-case "ext-register-tool! errors when tool-registry is #f"

--- a/tests/test-gsd-planning.rkt
+++ b/tests/test-gsd-planning.rkt
@@ -299,7 +299,7 @@
                      (hash-ref (extension-hooks gsd-planning-extension) 'register-tools))
                    (handler ctx (hasheq))
                    (define pr (lookup-tool reg "planning-read"))
-                   (define result ((tool-execute pr) (hasheq 'artifact "STATE" 'base_dir dir)))
+                   (define result ((tool-execute pr) (hasheq 'artifact "STATE" 'base_dir dir) #f))
                    (check-false (tool-result-is-error? result))
                    (check-true (string-contains? (result-text result) "Active")))))
 
@@ -312,7 +312,7 @@
      (handler ctx (hasheq))
      (define pw (lookup-tool reg "planning-write"))
      (define result
-       ((tool-execute pw) (hasheq 'artifact "VALIDATION" 'content "## Tests pass" 'base_dir dir)))
+       ((tool-execute pw) (hasheq 'artifact "VALIDATION" 'content "## Tests pass" 'base_dir dir) #f))
      (check-false (tool-result-is-error? result))
      ;; Verify content was written
      (check-equal? (read-planning-artifact dir "VALIDATION") "## Tests pass"))))
@@ -337,7 +337,7 @@
   (handler ctx (hasheq))
   (define pw (lookup-tool reg "planning-write"))
   (define result
-    ((tool-execute pw) (hasheq 'artifact "../../etc/crontab.md" 'content "pwned" 'base_dir dir)))
+    ((tool-execute pw) (hasheq 'artifact "../../etc/crontab.md" 'content "pwned" 'base_dir dir) #f))
   ;; Should fail gracefully (artifact name rejected)
   (check-true (or (tool-result-is-error? result)
                   (not (file-exists? (build-path dir ".planning" "../../etc/crontab.md")))))


### PR DESCRIPTION
Addresses #1822.

fix: extension tool handler arity mismatch (#1822)

8/16 extension tool handlers crashed with arity mismatch — they accept
1 arg (args) but scheduler calls with 2 args (args + exec-ctx).

Two-layer fix:
1. Central wrapper in dynamic-tools.rkt wraps all handlers to accept
   (args exec-ctx) — covers all current and future extension tools
2. Defense-in-depth: added [exec-ctx #f] to all 8 broken handlers in
   gsd-planning.rkt and github-integration.rkt

Updated test calls from ((tool-execute t) args) to
((tool-execute t) args #f) where tests invoke extension handlers directly.

Closes #1822, #1823, #1824