### PR TITLE
fix: exploration steering reset on non-read tools (#1825)

Replace write-tools whitelist ('write 'edit 'replace 'create) with
read-tools blacklist ('read 'find 'grep 'ls 'planning-read). Any tool
not in the read-tools list now resets the steering counter, so extension
tools like planning-write, bash, and gh-* all count as progress.

Added 6 new tests for update-seen-paths covering write, planning-write,
bash, edit, gh-issue, and read tools.

Closes #1825

### DIFF
--- a/runtime/iteration.rkt
+++ b/runtime/iteration.rkt
@@ -464,13 +464,16 @@
 ;; Compute the new seen-paths set and whether to increment the counter.
 ;; Returns (values new-seen-paths should-increment?)
 (define (update-seen-paths tool-calls seen-paths)
-  (define read-tools '("read" "find"))
-  (define write-tools '("write" "edit" "replace" "create"))
-  (define has-write?
+  ;; FIX: Use read-tools blacklist instead of write-tools whitelist.
+  ;; Extension tools (planning-write, bash, gh-*) are not in the old whitelist,
+  ;; so the counter never resets when the agent uses them. With a blacklist,
+  ;; any tool that isn't a read/explore tool resets the counter.
+  (define read-tools '("read" "find" "grep" "ls" "planning-read"))
+  (define has-non-read?
     (for/or ([tc (in-list tool-calls)])
-      (member (tool-call-name tc) write-tools)))
+      (not (member (tool-call-name tc) read-tools))))
   (cond
-    [has-write? (values (set) #f)] ;; Reset on write
+    [has-non-read? (values (set) #f)] ;; Reset on any non-read tool
     [else
      ;; Collect paths from read tools
      (define new-paths
@@ -797,10 +800,12 @@
                        (steering-same-file-dedup? current-settings)
                        #t))
                  (define current-tool-calls (extract-tool-calls-from-messages new-msgs))
-                 ;; Detect write tools (always relevant regardless of dedup setting)
+                 ;; Detect non-read tools — any tool not in read-tools resets counter
+                 ;; FIX: Was write-tools whitelist that missed extension tools.
+                 (define read-tools '("read" "find" "grep" "ls" "planning-read"))
                  (define has-write-now?
                    (for/or ([tc (in-list current-tool-calls)])
-                     (member (tool-call-name tc) '("write" "edit" "replace" "create"))))
+                     (not (member (tool-call-name tc) read-tools))))
                  (define-values (new-seen-paths should-increment?)
                    (cond
                      [has-write-now? (values (set) #f)] ;; Reset: empty set, don't increment

--- a/tests/test-iteration-edge-cases.rkt
+++ b/tests/test-iteration-edge-cases.rkt
@@ -7,9 +7,10 @@
 ;; - check-mid-turn-budget! boundary behavior
 
 (require rackunit
-         racket/hash
+         racket/set
          "../runtime/iteration.rkt"
-         "../agent/event-bus.rkt")
+         "../agent/event-bus.rkt"
+         "../util/protocol-types.rkt")
 
 ;; ============================================================
 ;; ensure-hash-args edge cases
@@ -46,14 +47,49 @@
   ;; ctx = message list, bus = event bus, config with max-context-tokens
   (define bus (make-event-bus))
   (define config (hasheq 'max-context-tokens 1000))
-  (check-not-exn
-   (lambda ()
-     (check-mid-turn-budget! '() bus "test-session" config))))
+  (check-not-exn (lambda () (check-mid-turn-budget! '() bus "test-session" config))))
 
 (test-case "check-mid-turn-budget! uses default when no config key"
   (define bus (make-event-bus))
   (define config (hasheq))
   ;; Empty context, default 128K tokens — should pass easily
-  (check-not-exn
-   (lambda ()
-     (check-mid-turn-budget! '() bus "test-session" config))))
+  (check-not-exn (lambda () (check-mid-turn-budget! '() bus "test-session" config))))
+
+;; ============================================================
+;; update-seen-paths / steering counter reset tests
+;; ============================================================
+
+(test-case "update-seen-paths resets counter on write tool"
+  (define-values (seen inc?)
+    (update-seen-paths (list (make-tool-call "tc1" "write" (hasheq 'path "/tmp/x"))) (set)))
+  (check-equal? (set-count seen) 0 "seen-paths reset on write")
+  (check-false inc? "should not increment on write"))
+
+(test-case "update-seen-paths resets counter on planning-write (extension tool)"
+  (define-values (seen inc?)
+    (update-seen-paths (list (make-tool-call "tc2" "planning-write" (hasheq))) (set)))
+  (check-equal? (set-count seen) 0 "seen-paths reset on planning-write")
+  (check-false inc? "should not increment on planning-write"))
+
+(test-case "update-seen-paths resets counter on bash tool"
+  (define-values (seen inc?)
+    (update-seen-paths (list (make-tool-call "tc3" "bash" (hasheq 'command "mkdir"))) (set)))
+  (check-equal? (set-count seen) 0 "seen-paths reset on bash")
+  (check-false inc? "should not increment on bash"))
+
+(test-case "update-seen-paths increments on read tool with new path"
+  (define-values (seen inc?)
+    (update-seen-paths (list (make-tool-call "tc4" "read" (hasheq 'path "/tmp/new.rkt"))) (set)))
+  (check-true (set-member? seen "/tmp/new.rkt") "path added to seen set")
+  (check-true inc? "should increment on new read path"))
+
+(test-case "update-seen-paths resets counter on edit tool"
+  (define-values (seen inc?) (update-seen-paths (list (make-tool-call "tc5" "edit" (hasheq))) (set)))
+  (check-equal? (set-count seen) 0 "seen-paths reset on edit")
+  (check-false inc? "should not increment on edit"))
+
+(test-case "update-seen-paths resets counter on gh-issue (extension tool)"
+  (define-values (seen inc?)
+    (update-seen-paths (list (make-tool-call "tc6" "gh-issue" (hasheq))) (set)))
+  (check-equal? (set-count seen) 0 "seen-paths reset on gh-issue")
+  (check-false inc? "should not increment on gh-issue"))


### PR DESCRIPTION
Addresses #1825.

fix: exploration steering reset on non-read tools (#1825)

Replace write-tools whitelist ('write 'edit 'replace 'create) with
read-tools blacklist ('read 'find 'grep 'ls 'planning-read). Any tool
not in the read-tools list now resets the steering counter, so extension
tools like planning-write, bash, and gh-* all count as progress.

Added 6 new tests for update-seen-paths covering write, planning-write,
bash, edit, gh-issue, and read tools.

Closes #1825