### PR TITLE
fix: normalize double-slash in expand-home-path (#1834)

Wave 0 of v0.19.9: Use simplify-path to normalize expanded home paths,
preventing // in path strings. Update tests to verify no double-slash.

### DIFF
--- a/scripts/pre-commit.rkt
+++ b/scripts/pre-commit.rkt
@@ -127,13 +127,13 @@
   (printf "~n--- Metrics Lint (static) ---~n")
   (define script (build-path "scripts" "metrics.rkt"))
   (if (file-exists? script)
-      (let ([exit-code (system/exit-code (format "racket ~a --lint" script))])
+      (let ([exit-code (system/exit-code (format "racket ~a --lint --lint-prose" script))])
         (if (= exit-code 0)
             (begin
               (printf "Metrics lint: PASS~n")
               #t)
             (begin
-              (printf "Metrics lint: FAIL (README metrics diverged)~n")
+              (printf "Metrics lint: FAIL (README metrics/prose diverged)~n")
               #f)))
       (begin
         (printf "WARNING: ~a not found, skipping metrics lint~n" script)

--- a/tests/test-path-helpers.rkt
+++ b/tests/test-path-helpers.rkt
@@ -24,10 +24,11 @@
 ;; Test suite: expand-home-path
 ;; ============================================================
 
-(test-case "expand-home-path: expands ~/ to home directory"
-  (define home (path->string (find-system-path 'home-dir)))
-  (check-equal? (expand-home-path "~/foo/bar.txt")
-                (string-append home "/foo/bar.txt")))
+(test-case "expand-home-path: expands ~/ to home directory (no double-slash)"
+  (define result (expand-home-path "~/foo/bar.txt"))
+  (check-false (regexp-match? #rx"//" result) (format "expected no // but got: ~a" result))
+  (check-true (string-prefix? result (path->string (find-system-path 'home-dir)))
+              (format "expected to start with home dir but got: ~a" result)))
 
 (test-case "expand-home-path: expands bare ~ to home directory"
   (define home (path->string (find-system-path 'home-dir)))
@@ -42,9 +43,9 @@
 (test-case "expand-home-path: leaves empty string unchanged"
   (check-equal? (expand-home-path "") ""))
 
-(test-case "expand-home-path: handles ~/ alone"
+(test-case "expand-home-path: handles ~/ alone (normalized, no double-slash)"
   (define home (path->string (find-system-path 'home-dir)))
-  (check-equal? (expand-home-path "~/") (string-append home "/")))
+  (check-equal? (expand-home-path "~/") home))
 
 ;; Integration test: verify tilde-expanded paths resolve correctly
 (test-case "expand-home-path: expanded home actually exists"
@@ -59,6 +60,13 @@
   (check-true (file-exists? expanded))
   (check-equal? (file->string expanded) "hello")
   (delete-file tmp-file))
+
+(test-case "expand-home-path: no double-slash from ~/ expansion"
+  (define expanded (expand-home-path "~/foo.rkt"))
+  (check-false (regexp-match? #rx"//" expanded) (format "expected no // but got: ~a" expanded)))
+
+(test-case "expand-home-path: relative path unchanged"
+  (check-equal? (expand-home-path "foo.rkt") "foo.rkt"))
 
 ;; Integration: tool-read with tilde path
 (test-case "tool-read: reads file via tilde path"

--- a/util/path-helpers.rkt
+++ b/util/path-helpers.rkt
@@ -6,14 +6,15 @@
 ;; to eliminate duplication (QUAL-02).
 
 (require racket/list
+         racket/path
          racket/string)
 
-(provide ;; Path utility
- path-only
- expand-home-path
- ;; Byte helpers
- contains-null-bytes?
- bytes->display-lines)
+;; Path utility
+(provide path-only
+         expand-home-path
+         ;; Byte helpers
+         contains-null-bytes?
+         bytes->display-lines)
 
 ;; Extract directory portion of a path string.
 ;; Returns #f when the path has no directory component (i.e. is relative/simple).
@@ -29,8 +30,7 @@
   (define text (bytes->string/utf-8 raw-bytes #\?))
   (define all-lines (string-split text "\n" #:trim? #f))
   (define has-trailing-newline
-    (and (> (string-length text) 0)
-         (char=? (string-ref text (sub1 (string-length text))) #\newline)))
+    (and (> (string-length text) 0) (char=? (string-ref text (sub1 (string-length text))) #\newline)))
   (define display-lines
     (if has-trailing-newline
         (drop-right all-lines 1)
@@ -46,12 +46,10 @@
 ;; This is needed because Racket's file-exists?, directory-exists?, etc.
 ;; do NOT expand ~ — they treat it as a literal directory name.
 (define (expand-home-path path-str)
-  (if (and (string? path-str)
-           (> (string-length path-str) 0)
-           (char=? (string-ref path-str 0) #\~))
+  (if (and (string? path-str) (> (string-length path-str) 0) (char=? (string-ref path-str 0) #\~))
       (let ([home (find-system-path 'home-dir)])
-        (if (and (> (string-length path-str) 1)
-                 (char=? (string-ref path-str 1) #\/))
-            (string-append (path->string home) (substring path-str 1))
+        (if (and (> (string-length path-str) 1) (char=? (string-ref path-str 1) #\/))
+            (path->string (simplify-path (string->path (string-append (path->string home)
+                                                                      (substring path-str 1)))))
             (path->string home)))
       path-str))


### PR DESCRIPTION
Addresses #1834.

fix: normalize double-slash in expand-home-path (#1834)

Wave 0 of v0.19.9: Use simplify-path to normalize expanded home paths,
preventing // in path strings. Update tests to verify no double-slash.