### PR TITLE
feat: edit tool near-match hints + stronger descriptions (#1835)

Wave 1 of v0.19.9:
- Add find-nearest-match helper using LCS for fuzzy line matching
- Enhanced error messages show nearest line when old-text not found
- Updated edit tool description: must copy verbatim from read result
- Added prompt-guidelines to edit tool registration

Sub-issues: #1836 #1837

### DIFF
--- a/tools/builtins/edit.rkt
+++ b/tools/builtins/edit.rkt
@@ -1,6 +1,6 @@
 #lang racket/base
 
-;; tools/builtins/edit.rkt — exact replacement edits with ambiguity checks
+;; tools/builtins/edit.rkt — exact replacement edits with near-match hints
 ;;
 ;; Exports:
 ;;   tool-edit : (hash [exec-ctx]) -> tool-result?
@@ -8,9 +8,12 @@
 ;;   Returns:  tool-result with success or error details
 
 (require racket/file
+         racket/string
          (only-in "../tool.rkt" make-success-result make-error-result)
          (only-in "../../util/safe-mode-predicates.rkt"
-                  safe-mode? allowed-path? safe-mode-project-root)
+                  safe-mode?
+                  allowed-path?
+                  safe-mode-project-root)
          (only-in "../../util/path-helpers.rkt" expand-home-path))
 
 (provide tool-edit)
@@ -38,6 +41,72 @@
             count))))
 
 ;; --------------------------------------------------
+;; Near-match helper for better error messages
+;; --------------------------------------------------
+
+;; Compute length of longest common substring between two strings.
+;; Uses a simple dynamic programming approach, bounded for performance.
+(define (longest-common-substring-len a b)
+  (define la (string-length a))
+  (define lb (string-length b))
+  (cond
+    [(or (zero? la) (zero? lb)) 0]
+    [else
+     ;; Use sliding window approach for memory efficiency
+     (for/fold ([best 0]) ([i (in-range la)])
+       (for/fold ([best best]) ([j (in-range lb)])
+         (let loop ([di 0]
+                    [dj 0]
+                    [len 0])
+           (cond
+             [(or (>= (+ i di) la) (>= (+ j dj) lb)) (max best len)]
+             [(char=? (string-ref a (+ i di)) (string-ref b (+ j dj)))
+              (loop (add1 di) (add1 dj) (add1 len))]
+             [else (max best len)]))))]))
+
+;; Extract a search key from old-text: trimmed, up to 60 chars.
+(define (extract-search-key old-text)
+  (define trimmed (string-trim old-text))
+  (if (<= (string-length trimmed) 60)
+      trimmed
+      (substring trimmed 0 60)))
+
+;; Find the nearest matching line in content to old-text.
+;; Returns (values line-number line-text) or (values #f #f).
+;; line-number is 1-indexed. Only returns if similarity > 40%.
+(define (find-nearest-match content old-text)
+  (define lines (string-split content "\n" #:trim? #f))
+  (define key (extract-search-key old-text))
+  (define key-len (string-length key))
+  (cond
+    [(zero? key-len) (values #f #f)]
+    [else
+     (for/fold ([best-line #f]
+                [best-num #f]
+                [best-score 0]
+                #:result (if (> best-score (* key-len 0.4))
+                             (values best-num best-line)
+                             (values #f #f)))
+               ([line (in-list lines)]
+                [idx (in-naturals 1)])
+       (define trimmed (string-trim line))
+       (define lcs (longest-common-substring-len key trimmed))
+       (if (> lcs best-score)
+           (values line idx lcs)
+           (values best-line best-num best-score)))]))
+
+;; Build enhanced error message when old-text is not found.
+(define (make-not-found-error path-str old-text content)
+  (define-values (line-num line-text) (find-nearest-match content old-text))
+  (cond
+    [line-num
+     (string-append
+      (format "old-text not found in ~a.\nNearest match at line ~a:\n  \"" path-str line-num)
+      (string-trim line-text)
+      "\"\nRe-read the file to get exact text.")]
+    [else (format "old-text not found in ~a. Read the file first to get exact text." path-str)]))
+
+;; --------------------------------------------------
 ;; Main tool function
 ;; --------------------------------------------------
 
@@ -58,31 +127,32 @@
            ;; Defense-in-depth: verify path even if scheduler already checked (SEC-09)
            (cond
              [(and (safe-mode?) (not (allowed-path? path-str)))
-              (make-error-result
-               (format "edit: path '~a' outside project root (~a)"
-                       path-str (safe-mode-project-root)))]
+              (make-error-result (format "edit: path '~a' outside project root (~a)"
+                                         path-str
+                                         (safe-mode-project-root)))]
              [(not (file-exists? path-str))
               (make-error-result (format "File not found: ~a" path-str))]
 
              [else
-              ;; 2. Read file content
+              ;; Read file content
               (define content (file->string path-str))
 
-              ;; 3. Check for ambiguity (multiple matches)
+              ;; Check for ambiguity (multiple matches)
               (define occurrences (count-occurrences content old-text))
 
               (cond
-                [(zero? occurrences) (make-error-result (format "old-text not found in ~a" path-str))]
+                [(zero? occurrences)
+                 (make-error-result (make-not-found-error path-str old-text content))]
 
                 [(> occurrences 1)
                  (make-error-result
                   (format "old-text appears ~a times in ~a; be more specific" occurrences path-str))]
 
                 [else
-                 ;; 4. Perform replacement
+                 ;; Perform replacement
                  (define new-content (regexp-replace (regexp-quote old-text) content new-text))
 
-                 ;; 5. Write back
+                 ;; Write back
                  (with-handlers ([exn:fail:filesystem?
                                   (lambda (e)
                                     (make-error-result (format "Write error: ~a" (exn-message e))))])

--- a/tools/registry-defaults.rkt
+++ b/tools/registry-defaults.rkt
@@ -63,20 +63,28 @@
   (when (should-register? "edit")
     (register-tool!
      registry
-     (make-tool "edit"
-                "Edit a file with exact text replacement"
-                (hasheq 'type
-                        "object"
-                        'required
-                        '("path" "old-text" "new-text")
-                        'properties
-                        (hasheq 'path
-                                (hasheq 'type "string" 'description "Path to file to edit")
-                                'old-text
-                                (hasheq 'type "string" 'description "Exact text to find")
-                                'new-text
-                                (hasheq 'type "string" 'description "Replacement text")))
-                tool-edit)))
+     (make-tool
+      "edit"
+      "Edit a file by replacing exact text. old-text MUST be copied verbatim from a prior read result — do not guess."
+      (hasheq
+       'type
+       "object"
+       'required
+       '("path" "old-text" "new-text")
+       'properties
+       (hasheq
+        'path
+        (hasheq 'type "string" 'description "Path to file to edit")
+        'old-text
+        (hasheq 'type
+                "string"
+                'description
+                "EXACT text to replace, copied verbatim from a read result. Do not type from memory.")
+        'new-text
+        (hasheq 'type "string" 'description "Replacement text")))
+      tool-edit
+      #:prompt-guidelines
+      "IMPORTANT: old-text must match the file content exactly. Copy it verbatim from a prior read tool result. If edit fails, re-read the file first.")))
   (when (should-register? "bash")
     (register-tool!
      registry


### PR DESCRIPTION
Addresses #1835.

feat: edit tool near-match hints + stronger descriptions (#1835)

Wave 1 of v0.19.9:
- Add find-nearest-match helper using LCS for fuzzy line matching
- Enhanced error messages show nearest line when old-text not found
- Updated edit tool description: must copy verbatim from read result
- Added prompt-guidelines to edit tool registration

Sub-issues: #1836 #1837