### PR TITLE
test: add v0.19.10 safeguard tests — edit integrity + spiral events (#1853)

Wave 2 of v0.19.10 — Edit Tool Hardening (Corruption Prevention)

Edit tests (test-tool-edit.rkt, 6 new, 18 total):
- 500-char old-text limit: rejects >500, accepts exactly 500
- Backup creation: verifies backup file saved before successful edit
- Line-count integrity: normal edits pass, line-adding edits pass
- Prompt-guidelines mention 500-char safeguard

Iteration tests (test-iteration-edge-cases.rkt, 3 new, 16 total):
- Spiral event structure: emit-session-event! for error-warning,
  bash-only-warning, and bash-breaker events captured via event bus
- Multiple tools in one update-seen-paths call
- Already-seen path does not increment steering counter

Full suite: 371 files, 5856 tests, 0 failures.

### DIFF
--- a/tests/test-iteration-edge-cases.rkt
+++ b/tests/test-iteration-edge-cases.rkt
@@ -5,6 +5,8 @@
 ;; Tests boundary conditions:
 ;; - ensure-hash-args edge cases
 ;; - check-mid-turn-budget! boundary behavior
+;; - update-seen-paths steering counter reset
+;; - v0.19.10: spiral breaker event structure
 
 (require rackunit
          racket/set
@@ -43,8 +45,6 @@
 ;; ============================================================
 
 (test-case "check-mid-turn-budget! passes when well under limit"
-  ;; check-mid-turn-budget! takes (ctx bus session-id config)
-  ;; ctx = message list, bus = event bus, config with max-context-tokens
   (define bus (make-event-bus))
   (define config (hasheq 'max-context-tokens 1000))
   (check-not-exn (lambda () (check-mid-turn-budget! '() bus "test-session" config))))
@@ -52,7 +52,6 @@
 (test-case "check-mid-turn-budget! uses default when no config key"
   (define bus (make-event-bus))
   (define config (hasheq))
-  ;; Empty context, default 128K tokens — should pass easily
   (check-not-exn (lambda () (check-mid-turn-budget! '() bus "test-session" config))))
 
 ;; ============================================================
@@ -93,3 +92,44 @@
     (update-seen-paths (list (make-tool-call "tc6" "gh-issue" (hasheq))) (set)))
   (check-equal? (set-count seen) 0 "seen-paths reset on gh-issue")
   (check-false inc? "should not increment on gh-issue"))
+
+;; ============================================================
+;; v0.19.10: Spiral breaker event structure tests
+;; ============================================================
+
+(test-case "event-bus: spiral events have correct structure"
+  (define bus (make-event-bus))
+  (define captured '())
+  (subscribe! bus
+              (lambda (evt) (set! captured (cons evt captured)))
+              #:filter (lambda (e)
+                         (and (event? e)
+                              (member (event-ev e)
+                                      '("spiral.error-warning" "spiral.bash-only-warning"
+                                                               "spiral.bash-breaker")))))
+  (emit-session-event! bus "s1" "spiral.error-warning" (hasheq 'consecutive-errors 7 'iteration 5))
+  (emit-session-event! bus "s1" "spiral.bash-only-warning" (hasheq 'bash-count 12 'iteration 8))
+  (emit-session-event! bus
+                       "s1"
+                       "spiral.bash-breaker"
+                       (hasheq 'action "steering-injected" 'iteration 10))
+  (check-equal? (length captured) 3 "should capture all 3 spiral events")
+  (check-equal? (event-ev (car captured)) "spiral.bash-breaker")
+  (check-equal? (event-ev (cadr captured)) "spiral.bash-only-warning")
+  (check-equal? (event-ev (caddr captured)) "spiral.error-warning"))
+
+(test-case "update-seen-paths: multiple tools in one call"
+  (define-values (seen inc?)
+    (update-seen-paths (list (make-tool-call "tc1" "read" (hasheq 'path "/tmp/a.rkt"))
+                             (make-tool-call "tc2" "read" (hasheq 'path "/tmp/b.rkt")))
+                       (set)))
+  (check-true (set-member? seen "/tmp/a.rkt"))
+  (check-true (set-member? seen "/tmp/b.rkt"))
+  (check-true inc? "should increment when any new read path"))
+
+(test-case "update-seen-paths: read of already-seen path does not increment"
+  (define-values (seen inc?)
+    (update-seen-paths (list (make-tool-call "tc1" "read" (hasheq 'path "/tmp/old.rkt")))
+                       (set "/tmp/old.rkt")))
+  (check-true (set-member? seen "/tmp/old.rkt"))
+  (check-false inc? "should not increment for already-seen path"))

--- a/tests/test-tool-edit.rkt
+++ b/tests/test-tool-edit.rkt
@@ -128,3 +128,72 @@
   (define t (lookup-tool reg "edit"))
   (check-not-false t)
   (check-true (string-contains? (tool-description t) "verbatim")))
+
+;; ============================================================
+;; tool-edit — v0.19.10 safeguards
+;; ============================================================
+
+(test-case "tool-edit: rejects old-text longer than 500 chars"
+  (define tmp (make-temporary-file "q-test-edit-~a.txt"))
+  (display-to-file (make-string 600 #\x) tmp #:exists 'replace)
+  (define long-old-text (make-string 501 #\x))
+  (define result (tool-edit (hasheq 'path tmp 'old-text long-old-text 'new-text "y")))
+  (check-pred tool-result-is-error? result)
+  (define msg (hash-ref (car (tool-result-content result)) 'text))
+  (check-true (string-contains? msg "too long"))
+  (check-true (string-contains? msg "500"))
+  (check-true (string-contains? msg "Break your edit"))
+  ;; File must not be modified
+  (check-equal? (file->string tmp) (make-string 600 #\x))
+  (delete-file tmp))
+
+(test-case "tool-edit: accepts old-text at exactly 500 chars"
+  (define tmp (make-temporary-file "q-test-edit-~a.txt"))
+  (define content (string-append (make-string 500 #\a) "suffix"))
+  (display-to-file content tmp #:exists 'replace)
+  (define result (tool-edit (hasheq 'path tmp 'old-text (make-string 500 #\a) 'new-text "REPLACED")))
+  (check-false (tool-result-is-error? result))
+  (check-equal? (file->string tmp) "REPLACEDsuffix")
+  (delete-file tmp))
+
+(test-case "tool-edit: creates backup before successful edit"
+  (define tmp (make-temporary-file "q-test-edit-~a.txt"))
+  (display-to-file "original content here" tmp #:exists 'replace)
+  (define result (tool-edit (hasheq 'path tmp 'old-text "original" 'new-text "modified")))
+  (check-false (tool-result-is-error? result))
+  ;; Check backup was saved and details include backup path
+  (define details (tool-result-details result))
+  (check-true (hash-has-key? details 'backup))
+  (define backup-path (hash-ref details 'backup))
+  (when (and (string? backup-path) (non-empty-string? backup-path))
+    (check-true (file-exists? backup-path) "backup file should exist")
+    (check-equal? (file->string backup-path) "original content here")
+    (delete-file backup-path))
+  (delete-file tmp))
+
+(test-case "tool-edit: line-count integrity passes for normal edit"
+  (define tmp (make-temporary-file "q-test-edit-~a.txt"))
+  (display-to-file "line1\nline2\nline3" tmp #:exists 'replace)
+  ;; Replace one line — delta should be 0 (same number of lines)
+  (define result (tool-edit (hasheq 'path tmp 'old-text "line2" 'new-text "LINE2")))
+  (check-false (tool-result-is-error? result))
+  (check-equal? (file->string tmp) "line1\nLINE2\nline3")
+  (delete-file tmp))
+
+(test-case "tool-edit: line-count integrity passes when adding lines"
+  (define tmp (make-temporary-file "q-test-edit-~a.txt"))
+  (display-to-file "line1\nline2" tmp #:exists 'replace)
+  ;; Replace single line with two lines — expected delta = +1
+  (define result (tool-edit (hasheq 'path tmp 'old-text "line1" 'new-text "line1a\nline1b")))
+  (check-false (tool-result-is-error? result))
+  (check-equal? (file->string tmp) "line1a\nline1b\nline2")
+  (delete-file tmp))
+
+(test-case "tool-edit: prompt-guidelines mention safeguards"
+  (define reg (make-tool-registry))
+  (register-default-tools! reg)
+  (define t (lookup-tool reg "edit"))
+  (check-not-false t)
+  (define guidelines (tool-prompt-guidelines t))
+  ;; v0.19.10: guidelines should mention the 500-char limit
+  (check-true (string-contains? guidelines "500") "should mention 500-char limit"))


### PR DESCRIPTION
Addresses #1853.

test: add v0.19.10 safeguard tests — edit integrity + spiral events (#1853)

Wave 2 of v0.19.10 — Edit Tool Hardening (Corruption Prevention)

Edit tests (test-tool-edit.rkt, 6 new, 18 total):
- 500-char old-text limit: rejects >500, accepts exactly 500
- Backup creation: verifies backup file saved before successful edit
- Line-count integrity: normal edits pass, line-adding edits pass
- Prompt-guidelines mention 500-char safeguard

Iteration tests (test-iteration-edge-cases.rkt, 3 new, 16 total):
- Spiral event structure: emit-session-event! for error-warning,
  bash-only-warning, and bash-breaker events captured via event bus
- Multiple tools in one update-seen-paths call
- Already-seen path does not increment steering counter

Full suite: 371 files, 5856 tests, 0 failures.