### PR TITLE
feat: /go prompt hardening — implement-only directives, anti-exploration budget, no re-reading plan (#1865)

### DIFF
--- a/extensions/gsd-planning.rkt
+++ b/extensions/gsd-planning.rkt
@@ -25,7 +25,8 @@
          read-planning-artifact
          write-planning-artifact!
          handle-planning-read
-         handle-planning-write)
+         handle-planning-write
+         planning-implement-prompt)
 
 ;; ============================================================
 ;; Constants
@@ -245,14 +246,20 @@
   (hook-pass #f))
 
 (define planning-implement-prompt
-  (string-append
-   "[gsd-planning] Execute the implementation plan in .planning/PLAN.md.\n"
-   "1. Use planning-read with artifact='PLAN' to read the full plan.\n"
-   "2. Use planning-read with artifact='STATE' to check current progress.\n"
-   "3. Start with the first uncompleted wave. Implement each task.\n"
-   "4. After completing a wave, use planning-write with artifact='STATE' to update progress.\n"
-   "5. Run verify commands listed in the plan after each wave.\n"
-   "Work through all waves. Update STATE.md after each wave completes.\n\n"))
+  (string-append "[gsd-planning] EXECUTE the plan below. IMPLEMENT NOW — do NOT explore.\n"
+                 "\n"
+                 "CRITICAL RULES:\n"
+                 "1. Do NOT re-read the plan. It is provided below in full.\n"
+                 "2. Do NOT write a new plan. Execute the existing one.\n"
+                 "3. Do NOT use planning-read or planning-write during implementation.\n"
+                 "4. Do NOT run read-only tools (read, find, grep, ls) unless a wave's\n"
+                 "   old-text match fails and you need to re-read the target file ONCE.\n"
+                 "5. Use the edit or write tool for EVERY wave. Your budget is:\n"
+                 "   - Max 2 read-only tool calls per wave before you MUST write/edit.\n"
+                 "   - After 5 total read-only calls across all waves, STOP and summarize.\n"
+                 "6. After completing each wave, run its verify command.\n"
+                 "\n"
+                 "The plan follows. Start implementing immediately.\n\n"))
 
 (define (register-gsd-commands ctx)
   (ext-register-command! ctx "/plan" "Display current GSD plan" 'general '() '("p"))

--- a/tests/test-gsd-planning.rkt
+++ b/tests/test-gsd-planning.rkt
@@ -514,9 +514,28 @@
        (define payload (hook-result-payload result))
        (define submit-text (hash-ref payload 'submit))
        (check-true (string-contains? submit-text "[gsd-planning]"))
-       (check-true (string-contains? submit-text "planning-read"))
+       (check-true (string-contains? submit-text "IMPLEMENT NOW"))
        (check-true (string-contains? submit-text "Wave 0"))
        (check-true (string-contains? (hash-ref payload 'text) "Implementing"))))))
+
+;; ============================================================
+;; W1 (#1867): /go anti-exploration tests
+;; ============================================================
+
+(test-case "planning-implement-prompt forbids re-reading the plan"
+  (check-true (string-contains? planning-implement-prompt "Do NOT re-read the plan")))
+
+(test-case "planning-implement-prompt forbids writing a new plan"
+  (check-true (string-contains? planning-implement-prompt "Do NOT write a new plan")))
+
+(test-case "planning-implement-prompt forbids planning-read during implementation"
+  (check-true (string-contains? planning-implement-prompt "Do NOT use planning-read")))
+
+(test-case "planning-implement-prompt sets read-only budget per wave"
+  (check-true (string-contains? planning-implement-prompt "Max 2 read-only tool calls per wave")))
+
+(test-case "planning-implement-prompt does NOT tell agent to use planning-read"
+  (check-false (string-contains? planning-implement-prompt "Use planning-read")))
 
 (test-case "/go includes state when available"
   (with-temp-dir (lambda (dir)


### PR DESCRIPTION
Addresses #1865.

feat: /go prompt hardening — implement-only directives, anti-exploration budget, no re-reading plan (#1865)