### PR TITLE
chore: bump version 0.19.10 → 0.19.11 (#1871)

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.19.10")
+(define version "0.19.11")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base"))

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -7,4 +7,4 @@
 
 (provide q-version)
 
-(define q-version "0.19.10")
+(define q-version "0.19.11")


### PR DESCRIPTION
Addresses #1871.

chore: bump version 0.19.10 → 0.19.11 (#1871)