### PR TITLE
feat: context usage visibility — tokenCount in events + TUI status bar (#1879)

Wave 1 of v0.19.12. Adds estimated token count to context.assembled
and context.built events. TUI status bar now shows context tokens
(e.g. "23K") when available. ui-state gains context-tokens field.

Files changed:
- runtime/iteration.rkt: tokenCount in context.assembled event
- agent/loop.rkt: tokenCount in context.built event + import
- tui/state.rkt: context-tokens field on ui-state, event handler
- tui/render.rkt: token display in status bar
- tests/tui/state.rkt: updated context.built test + new passthrough test

### DIFF
--- a/agent/loop.rkt
+++ b/agent/loop.rkt
@@ -30,7 +30,7 @@
          "../llm/model.rkt"
          "../llm/provider.rkt"
          (only-in "../llm/stream.rkt" accumulate-tool-call-deltas)
-         (only-in "../llm/token-budget.rkt" estimate-turn-tokens)
+         (only-in "../llm/token-budget.rkt" estimate-turn-tokens estimate-context-tokens)
          (only-in "../util/cancellation.rkt" cancellation-token? cancellation-token-cancelled?)
          (only-in "../util/hook-types.rkt" hook-result? hook-result-action hook-result-payload)
          (only-in "../util/content-helpers.rkt" result-content->string)
@@ -717,12 +717,13 @@
   ;; 2. Build normalized model context (pure function)
   (define raw-messages (build-raw-messages context))
 
-  ;; 3. Emit context.built
+  ;; 3. Emit context.built (v0.19.12 W1: added tokenCount)
+  (define ctx-built-token-count (estimate-context-tokens raw-messages))
   (emit! bus
          session-id
          turn-id
          "context.built"
-         (hasheq 'messageCount (length raw-messages))
+         (hasheq 'messageCount (length raw-messages) 'tokenCount ctx-built-token-count)
          #:state st)
 
   ;; 4. Build model-request

--- a/runtime/iteration.rkt
+++ b/runtime/iteration.rkt
@@ -239,7 +239,8 @@
 
   (define ctx-assembled (tiered-context->message-list tc))
 
-  ;; Emit context.assembled event
+  ;; Emit context.assembled event (v0.19.12 W1: added tokenCount)
+  (define ctx-token-count (estimate-context-tokens ctx-assembled))
   (emit-session-event! bus
                        session-id
                        "context.assembled"
@@ -248,7 +249,9 @@
                                'total-messages
                                (length ctx-to-use)
                                'assembled-messages
-                               (length ctx-assembled)))
+                               (length ctx-assembled)
+                               'tokenCount
+                               ctx-token-count))
 
   ;; Dispatch 'context hook — extensions can amend final context
   (define-values (ctx-final _ctx-hook) (maybe-dispatch-hooks ext-reg 'context ctx-assembled))

--- a/tests/tui/state.rkt
+++ b/tests/tui/state.rkt
@@ -718,11 +718,18 @@
   (check-equal? (transcript-entry-kind last-entry) 'system)
   (check-not-false (string-contains? (transcript-entry-text last-entry) "tool blocked")))
 
-(test-case "context.built is passthrough"
+(test-case "context.built stores tokenCount"
   (define s0 (struct-copy ui-state (initial-ui-state) [busy? #t] [session-id "s1"]))
   (define evt (make-test-event "context.built" (hash 'tokenCount 42)))
   (define s1 (apply-event-to-state s0 evt))
-  (check-eq? s1 s0 "context.built returns state unchanged"))
+  (check-equal? (ui-state-context-tokens s1) 42) ; v0.19.12 W1: stores token count
+  (check-not-equal? s1 s0 "context.built now returns new state with token count"))
+
+(test-case "context.built without tokenCount is passthrough"
+  (define s0 (struct-copy ui-state (initial-ui-state) [busy? #t] [session-id "s1"]))
+  (define evt (make-test-event "context.built" (hash)))
+  (define s1 (apply-event-to-state s0 evt))
+  (check-eq? s1 s0 "context.built without tokenCount returns state unchanged"))
 
 ;; ============================================================
 ;; W4-2: Additional event handler edge cases

--- a/tui/render.rkt
+++ b/tui/render.rkt
@@ -545,8 +545,15 @@
       [else ""]))
   ;; BUG-55: Show mock provider warning in status bar
   (define mock-warning (if (ui-state-mock-provider? state) " [No API key]" ""))
+  ;; v0.19.12 W1: Show context token count in status bar
+  (define ctx-tok (ui-state-context-tokens state))
+  (define tok-str
+    (if ctx-tok
+        (format " ~aK" (quotient (max 1 ctx-tok) 1000))
+        ""))
   (define left (format " ~a q | ~a | ~a " busy-marker session model))
-  (define right (format "~a~a~a~a " status mock-warning thinking-indicator scroll-indicator))
+  (define right
+    (format "~a~a~a~a~a " status mock-warning tok-str thinking-indicator scroll-indicator))
   ;; Pad to width
   (define pad-len (max 0 (- width (string-visible-width left) (string-visible-width right))))
   (define padded (string-append left (make-string pad-len #\ ) right))

--- a/tui/state.rkt
+++ b/tui/state.rkt
@@ -144,6 +144,7 @@
          mock-provider? ; boolean — #t when using mock/fallback provider (BUG-55)
          focused-component ; (or/c #f symbol?) — id of component with focus
          editor-component ; (or/c #f q-component?) — custom editor for input area (#1150)
+         context-tokens ; (or/c #f integer?) — estimated token count from context events (v0.19.12 W1)
          )
   #:transparent)
 
@@ -264,6 +265,7 @@
             #f ; mock-provider?
             #f ; focused-component
             #f ; editor-component
+            #f ; context-tokens
             ))
 
 ;; ============================================================
@@ -495,8 +497,12 @@
     ;; Model request initiated — mark busy if not already
     [("model.request.started") (struct-copy ui-state state [busy? #t])]
 
-    ;; Context was assembled — informational, keep state
-    [("context.built") state]
+    ;; Context built — store token count (v0.19.12 W1)
+    [("context.built")
+     (define tok (hash-ref payload 'tokenCount #f))
+     (if tok
+         (struct-copy ui-state state [context-tokens tok])
+         state)]
 
     [("tool.call.blocked")
      (define name (hash-ref payload 'name "?"))


### PR DESCRIPTION
Addresses #1879.

feat: context usage visibility — tokenCount in events + TUI status bar (#1879)

Wave 1 of v0.19.12. Adds estimated token count to context.assembled
and context.built events. TUI status bar now shows context tokens
(e.g. "23K") when available. ui-state gains context-tokens field.

Files changed:
- runtime/iteration.rkt: tokenCount in context.assembled event
- agent/loop.rkt: tokenCount in context.built event + import
- tui/state.rkt: context-tokens field on ui-state, event handler
- tui/render.rkt: token display in status bar
- tests/tui/state.rkt: updated context.built test + new passthrough test