### PR TITLE
feat: /plan overwrite stale plans + overwrite directive (#1882)

Wave 2 of v0.19.12. Adds OVERWRITE directive to planning-system-prompt.
When /plan <text> detects an existing PLAN.md, injects a stale warning
instructing the LLM to replace (not merge) the old plan.

Files changed:
- extensions/gsd-planning.rkt: overwrite directive + stale detection
- tests/test-gsd-planning.rkt: 3 new tests (prompt, stale warning, no warning)

### DIFF
--- a/extensions/gsd-planning.rkt
+++ b/extensions/gsd-planning.rkt
@@ -63,7 +63,9 @@
    "Each wave must be directly executable without further exploration.\n"
    "\n"
    "STEP 3 — FINISH: Tell the user: 'Use /go to start implementing.'\n"
-   "Do NOT implement — only plan.\n\n"
+   "Do NOT implement — only plan.\n"
+   "OVERWRITE: Replace the entire existing PLAN.md. Do NOT append or merge with old content.\n"
+   "Write the new plan from scratch.\n\n"
    "User request: "))
 
 (define artifact-extensions
@@ -330,7 +332,14 @@
                          (and (> (string-length rest) 0) rest)))))
            =>
            (lambda (args)
-             (define augmented-text (string-append planning-system-prompt args))
+             ;; v0.19.12 W2: Detect stale existing PLAN.md and inject warning
+             (define existing-plan (read-planning-artifact base-dir "PLAN"))
+             (define stale-warning
+               (if existing-plan
+                   (format
+                    "\nNOTE: An existing PLAN.md was found. OVERWRITE it completely with the new plan. Do NOT keep or merge old content.\n")
+                   ""))
+             (define augmented-text (string-append planning-system-prompt stale-warning args))
              (hook-amend (hasheq 'submit augmented-text 'text (format "Planning: ~a" args))))]
           [else
            ;; Display artifact content (always for /state, /handoff; no-args /plan)

--- a/tests/test-gsd-planning.rkt
+++ b/tests/test-gsd-planning.rkt
@@ -593,3 +593,40 @@
 (test-case "planning-system-prompt-no-unlimited-exploration"
   (check-false (string-contains? planning-system-prompt "Do NOT limit")
                "prompt should NOT say 'Do NOT limit'"))
+
+;; ============================================================
+;; W2: /plan Overwrite Stale Plans Tests
+;; ============================================================
+
+(test-case "planning-system-prompt-contains-overwrite-directive"
+  (check-true (string-contains? planning-system-prompt "OVERWRITE")
+              "prompt should contain OVERWRITE directive")
+  (check-true (string-contains? planning-system-prompt "Replace the entire existing PLAN.md")
+              "prompt should say to replace entire existing plan"))
+
+(test-case "/plan-with-text-injects-stale-warning-when-plan-exists"
+  (with-temp-dir
+   (lambda (dir)
+     (parameterize ([current-directory dir])
+       (make-directory* (build-path dir ".planning"))
+       (call-with-output-file (build-path dir ".planning" "PLAN.md")
+                              (lambda (out) (display "# Old Plan\nWave 0: old stuff" out))
+                              #:exists 'truncate)
+       (define handler (hash-ref (extension-hooks gsd-planning-extension) 'execute-command))
+       (define result (handler (hasheq 'command "/plan" 'input "/plan fix the bug")))
+       (define submit-text (hash-ref (hook-result-payload result) 'submit))
+       (check-true (string-contains? submit-text "existing PLAN.md was found")
+                   "should inject stale warning when PLAN.md exists")
+       (check-true (string-contains? submit-text "OVERWRITE")
+                   "stale warning should mention OVERWRITE")))))
+
+(test-case "/plan-with-text-no-warning-when-no-plan"
+  (with-temp-dir (lambda (dir)
+                   (parameterize ([current-directory dir])
+                     (make-directory* (build-path dir ".planning"))
+                     (define handler
+                       (hash-ref (extension-hooks gsd-planning-extension) 'execute-command))
+                     (define result (handler (hasheq 'command "/plan" 'input "/plan fix the bug")))
+                     (define submit-text (hash-ref (hook-result-payload result) 'submit))
+                     (check-false (string-contains? submit-text "existing PLAN.md was found")
+                                  "should NOT inject stale warning when no PLAN.md exists")))))


### PR DESCRIPTION
Addresses #1882.

feat: /plan overwrite stale plans + overwrite directive (#1882)

Wave 2 of v0.19.12. Adds OVERWRITE directive to planning-system-prompt.
When /plan <text> detects an existing PLAN.md, injects a stale warning
instructing the LLM to replace (not merge) the old plan.

Files changed:
- extensions/gsd-planning.rkt: overwrite directive + stale detection
- tests/test-gsd-planning.rkt: 3 new tests (prompt, stale warning, no warning)