### PR TITLE
chore: version bump 0.19.11 → 0.19.12 (#1885)

Wave 3 of v0.19.12. Updates version in util/version.rkt, info.rkt,
README.md badge, and CHANGELOG.md.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## v0.19.12 — 2026-04-25
+
+### /plan Exploration Cap + Context Usage Visibility (4 waves)
+
+**W0 — /plan Exploration Cap**
+- Replaced 'Do NOT limit exploration' with 30-tool-call budget in `/plan` prompt
+- Prevents 110+ turn exploration spirals (observed in live session)
+
+**W1 — Context Usage in Events + TUI Status Bar**
+- Added `tokenCount` to `context.assembled` and `context.built` events
+- TUI status bar now displays estimated context token usage (e.g. "23K")
+- `ui-state` gains `context-tokens` field
+
+**W2 — /plan Overwrite Stale Plans**
+- Added OVERWRITE directive to planning-system-prompt
+- Detects existing PLAN.md and injects stale warning on `/plan <text>`
+- Prevents LLM from merging old+new plan content
+
+**W3 — Version Bump**
+- Version 0.19.11 → 0.19.12
+
 ## v0.19.10 — 2026-04-25
 
 ### Edit Tool Hardening — Corruption Prevention (4 waves)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.19.11-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.19.12-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 
@@ -199,7 +199,7 @@ racket main.rkt --model gpt-5.4 "write a test"
 ### Verify
 
 ```bash
-racket main.rkt --version  # q version 0.19.11
+racket main.rkt --version  # q version 0.19.12
 raco test tests/           # run the full test suite
 ```
 

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.19.11")
+(define version "0.19.12")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base"))

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -7,4 +7,4 @@
 
 (provide q-version)
 
-(define q-version "0.19.11")
+(define q-version "0.19.12")


### PR DESCRIPTION
Addresses #1885.

chore: version bump 0.19.11 → 0.19.12 (#1885)

Wave 3 of v0.19.12. Updates version in util/version.rkt, info.rkt,
README.md badge, and CHANGELOG.md.