### PR TITLE
fix: critical audit findings — duplicate registry, read safe-mode, stale docs (#1916)

FIX-01: Remove duplicate custom-renderer registry from custom-ui-api.rkt
FIX-02: Add safe-mode defense-in-depth path check to read tool
FIX-03: Update README Status block to v0.20.0
FIX-04: Fix api-stability.md reference to deleted agent/types.rkt

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,8 +269,8 @@ q/
 | Metric | Value |
 |--------|-------|
 | Test files | 409 |
-| Source modules | 265 |
-| Source lines | 53043 |
+| Source modules | 264 |
+| Source lines | 52607 |
 | Test lines | 81041 |
 | Test assertions | 12376 |
 | `racket scripts/run-tests.rkt` results | 5835+ tests passing |
@@ -331,7 +331,7 @@ When q executes shell commands on behalf of an LLM, arguments are quoted via `sh
 
 ## Status
 
-**v0.19.9** — CI Hardening. Pre-commit version sync + metrics lint. Dependency parity check (info.rkt + build-deps). CI-aware test guards for out-of-repo paths. Assertion guardrails (range checks replacing exact counts). Gitignore hygiene (stray file detection). CI log preservation + failure summary artifact. 5300+ tests.
+**v0.20.0** — Feature Gap Closure. Truncation overflow handling, AGENTS.md discovery, TUI queue wiring, interactive tree browser, @ file reference, !! inline bash, cost tracker, print mode, /reload command, permission gates. 5966+ tests.
 
 **v0.19.4** — Self-Hosting Workflow Gaps. Extension tool registration fix (register-tools hook passes proper extension-ctx). Subagent tool execution (children get 7 tools + recursive dispatch). Slash commands (/milestone, /issue, /pr, /fmt, /check, /expand). 5300+ tests.
 

--- a/docs/api-stability.md
+++ b/docs/api-stability.md
@@ -31,7 +31,7 @@ These modules form the public API contract. Breaking changes require:
 | `interfaces/sdk.rkt` | `make-runtime`, `runtime-config` | v0.10.0 |
 | `wiring/rpc-methods.rkt` | `make-core-rpc-handlers` | v0.10.0 |
 | `extensions/api.rkt` | `make-extension`, `extension?` | v0.10.0 |
-| `agent/types.rkt` | Core message/event types | v0.10.0 |
+| `util/protocol-types.rkt` | Core message/event types (formerly `agent/types.rkt`) | v0.10.0 |
 | `tools/tool.rkt` | `make-tool`, `tool-registry?` | v0.10.0 |
 
 ### Evolving

--- a/extensions/custom-ui-api.rkt
+++ b/extensions/custom-ui-api.rkt
@@ -15,7 +15,10 @@
                   custom-renderer-tool-name
                   custom-renderer-render-call
                   custom-renderer-render-result
-                  lookup-custom-renderer))
+                  register-custom-renderer!
+                  unregister-custom-renderer!
+                  lookup-custom-renderer
+                  lookup-custom-renderer-for-tool))
 
 ;; #717: Header/footer API
 (provide ctx-set-footer
@@ -28,7 +31,9 @@
          render-tool-result
 
          ;; #720: Struct for registered custom renderer
-         )
+         register-custom-renderer!
+         unregister-custom-renderer!
+         lookup-custom-renderer-for-tool)
 
 ;; Re-export registry functions from custom-renderer-registry.rkt
 
@@ -62,7 +67,8 @@
   (if (and renderer (custom-renderer-render-call renderer))
       ((custom-renderer-render-call renderer) args-text)
       ;; Default rendering
-      (list (ui-make-styled-line (list (ui-make-styled-segment (format "[TOOL: ~a] ~a" tool-name args-text) '()))))))
+      (list (ui-make-styled-line
+             (list (ui-make-styled-segment (format "[TOOL: ~a] ~a" tool-name args-text) '()))))))
 
 ;; Render a tool result using custom renderer if available, else default.
 (define (render-tool-result tool-name result custom-renderers)
@@ -74,39 +80,5 @@
       (list (ui-make-styled-line (list (ui-make-styled-segment (format "[OK: ~a]" tool-name) '()))))))
 
 ;; ============================================================
-;; FEAT-70: Custom renderer registry
+;; FEAT-70: Custom renderer registry — imported from custom-renderer-registry.rkt
 ;; ============================================================
-
-;; Global registry: box of (listof custom-renderer)
-(define custom-renderer-registry (box '()))
-
-;; register-custom-renderer! : custom-renderer? -> void?
-(define (register-custom-renderer! renderer)
-  (define existing (unbox custom-renderer-registry))
-  ;; Remove any previous renderer for same tool
-  (define filtered
-    (filter (lambda (r)
-              (not (equal? (custom-renderer-tool-name r) (custom-renderer-tool-name renderer))))
-            existing))
-  (set-box! custom-renderer-registry (cons renderer filtered)))
-
-;; unregister-custom-renderer! : string? -> void?
-(define (unregister-custom-renderer! tool-name)
-  (define existing (unbox custom-renderer-registry))
-  (set-box! custom-renderer-registry
-            (filter (lambda (r) (not (equal? (custom-renderer-tool-name r) tool-name))) existing)))
-
-;; lookup-custom-renderer : string? -> (or/c custom-renderer? #f)
-(define (lookup-custom-renderer tool-name)
-  (findf (lambda (r) (equal? (custom-renderer-tool-name r) tool-name))
-         (unbox custom-renderer-registry)))
-
-;; lookup-custom-renderer-for-tool : string? symbol? -> (or/c procedure? #f)
-;; Look up a custom renderer for a tool name and type (:call or :result).
-(define (lookup-custom-renderer-for-tool tool-name render-type)
-  (define r (lookup-custom-renderer tool-name))
-  (and r
-       (case render-type
-         [(call) (custom-renderer-render-call r)]
-         [(result) (custom-renderer-render-result r)]
-         [else #f])))

--- a/tools/builtins/read.rkt
+++ b/tools/builtins/read.rkt
@@ -10,6 +10,10 @@
                   contains-null-bytes?
                   bytes->display-lines
                   expand-home-path)
+         (only-in "../../util/safe-mode-predicates.rkt"
+                  safe-mode?
+                  allowed-path?
+                  safe-mode-project-root)
          (only-in "../../util/truncation.rkt" truncate-output MAX-OUTPUT-BYTES MAX-OUTPUT-LINES))
 
 (provide tool-read)
@@ -31,9 +35,12 @@
      (define offset (hash-ref args 'offset 1))
      (define limit (hash-ref args 'limit #f))
 
-     ;; 1. File existence check
-     ;; (safe-mode path check is done by scheduler, not here)
+     ;; 1. Safe-mode defense-in-depth path check (SEC-01)
      (cond
+       [(and (safe-mode?) (not (allowed-path? path-str)))
+        (make-error-result (format "read: path '~a' outside project root (~a)"
+                                   path-str
+                                   (safe-mode-project-root)))]
        [(not (file-exists? path-str)) (make-error-result (format "File not found: ~a" path-str))]
 
        [else


### PR DESCRIPTION
Addresses #1916.

fix: critical audit findings — duplicate registry, read safe-mode, stale docs (#1916)

FIX-01: Remove duplicate custom-renderer registry from custom-ui-api.rkt
FIX-02: Add safe-mode defense-in-depth path check to read tool
FIX-03: Update README Status block to v0.20.0
FIX-04: Fix api-stability.md reference to deleted agent/types.rkt