### PR TITLE
fix: code quality — silent catches, dead code, test isolation (#1922)

ERR-01: Added log-warning to 12+ silent catch sites (llm/stream, runtime/session-store, tools/grep, tools/edit, extensions/gsd-planning, extensions/github-integration)
DEAD-01: Removed dead event-bus serialization code (~60 lines, queue-item, drain-signal, enable-serialization!, drain-event-queue!, serialization-enabled?)
DEAD-02: Removed dead provider-count-tokens method from llm/provider.rkt
TEST-01: Wrapped putenv/process-count-box in dynamic-wind in test-credential-backend.rkt and test-sandbox-limits.rkt
TEST-02: Added path traversal, symlink, large file, and missing-arg tests to test-tool-read.rkt
TEST-03: New test-dynamic-tools-arity.rkt verifying ext-register-tool! wraps 1-arg handlers

### DIFF
--- a/agent/event-bus.rkt
+++ b/agent/event-bus.rkt
@@ -25,11 +25,7 @@
          ;; Circuit breaker configuration
          current-circuit-breaker-threshold
          current-circuit-breaker-cooldown-secs
-         circuit-breaker-state
-         ;; #775: Event serialization queue
-         enable-serialization!
-         drain-event-queue!
-         serialization-enabled?)
+         circuit-breaker-state)
 
 ;; ============================================================
 ;; Error handler parameter
@@ -121,12 +117,7 @@
 ;; Event bus struct
 ;; ============================================================
 
-(struct event-bus
-        (subscriptions-box semaphore
-                           next-id-box
-                           breaker-state
-                           [queue-ch #:mutable]
-                           [queue-thread #:mutable])
+(struct event-bus (subscriptions-box semaphore next-id-box breaker-state)
   #:constructor-name make-event-bus-internal)
 
 ;; ============================================================
@@ -134,15 +125,7 @@
 ;; ============================================================
 
 (define (make-event-bus)
-  (define ch (make-channel))
-  (define bus
-    (make-event-bus-internal (box '())
-                             (make-semaphore 1)
-                             (box 0)
-                             (make-hash)
-                             #f ; queue-ch (enabled on demand)
-                             #f)) ; queue-thread
-  bus)
+  (make-event-bus-internal (box '()) (make-semaphore 1) (box 0) (make-hash)))
 
 ;; ============================================================
 ;; subscribe! : event-bus? handler [#:filter pred] -> exact-nonnegative-integer?
@@ -174,71 +157,6 @@
 ;; ============================================================
 
 (define (publish! bus evt)
-  ;; #775: If serialization enabled, enqueue; otherwise direct dispatch
-  (if (serialization-enabled? bus)
-      (begin
-        (channel-put (event-bus-queue-ch bus) (queue-item evt #f))
-        evt)
-      (publish-internal! bus evt)))
-
-;; ============================================================
-;; #775: Event Serialization Queue
-;; ============================================================
-;; When enabled, publish! enqueues events to a channel processed
-;; by a dedicated background thread. This ensures events are
-;; processed sequentially even if handlers are slow or async.
-
-(struct queue-item (evt reply-ch) #:transparent)
-
-;; Sentinel for drain operations (not dispatched to subscribers)
-(struct drain-signal () #:transparent)
-
-;; Enable serialization mode — starts background processing thread.
-;; event-bus? -> void?
-(define (enable-serialization! bus)
-  (when (not (event-bus-queue-thread bus))
-    (define ch (make-channel))
-    (set-event-bus-queue-ch! bus ch)
-    (define thread-id
-      (thread (lambda ()
-                (let loop ()
-                  (define item (channel-get ch))
-                  (cond
-                    [(eq? item 'shutdown) (void)]
-                    [(queue-item? item)
-                     (cond
-                       [(drain-signal? (queue-item-evt item))
-                        ;; Drain signal — just reply, don't dispatch
-                        (when (queue-item-reply-ch item)
-                          (channel-put (queue-item-reply-ch item) 'done))]
-                       [else
-                        ;; Process the event synchronously using the existing logic
-                        (define result (publish-internal! bus (queue-item-evt item)))
-                        ;; Send reply if requested
-                        (when (queue-item-reply-ch item)
-                          (channel-put (queue-item-reply-ch item) result))])
-                     (loop)]
-                    [else (loop)])))))
-    (set-event-bus-queue-thread! bus thread-id)))
-
-;; Drain all pending events and return.
-;; Blocks until all queued events have been processed.
-;; event-bus? -> void?
-(define (drain-event-queue! bus)
-  (when (serialization-enabled? bus)
-    ;; Send a sync item through the queue — when it completes,
-    ;; all previously queued items have been processed.
-    (define reply-ch (make-channel))
-    (channel-put (event-bus-queue-ch bus) (queue-item (drain-signal) reply-ch))
-    (channel-get reply-ch)))
-
-;; Check if serialization is enabled.
-;; event-bus? -> boolean?
-(define (serialization-enabled? bus)
-  (and (event-bus-queue-ch bus) (event-bus-queue-thread bus) #t))
-
-;; Internal: the actual synchronous publish logic (extracted from publish!)
-(define (publish-internal! bus evt)
   (define subs
     (call-with-semaphore (event-bus-semaphore bus)
                          (lambda () (reverse (unbox (event-bus-subscriptions-box bus))))))

--- a/extensions/github-integration.rkt
+++ b/extensions/github-integration.rkt
@@ -421,7 +421,7 @@
     [(not (file-exists? spec-path)) (make-error-result (format "Spec file not found: ~a" spec-file))]
     [else
      (define spec-data
-       (with-handlers ([exn:fail? (lambda (e) #f)])
+       (with-handlers ([exn:fail? (lambda (e) (log-warning (format "github/spec-read: ~a" (exn-message e))) #f)])
          (call-with-input-file spec-path read-json)))
      (cond
        [(not spec-data) (make-error-result (format "Invalid JSON in spec file: ~a" spec-file))]

--- a/extensions/gsd-planning.rkt
+++ b/extensions/gsd-planning.rkt
@@ -148,7 +148,7 @@
     [(not path) #f]
     [(not (file-exists? path)) #f]
     [(json-artifact? name)
-     (with-handlers ([exn:fail? (lambda (e) #f)])
+     (with-handlers ([exn:fail? (lambda (e) (log-warning (format "gsd-planning/read: ~a" (exn-message e))) #f)])
        (call-with-input-file path (lambda (in) (read-json in))))]
     [else (call-with-input-file path (lambda (in) (port->string in)))]))
 

--- a/llm/provider.rkt
+++ b/llm/provider.rkt
@@ -24,7 +24,6 @@
                        [provider-send (-> provider? model-request? any/c)]
                        [provider-stream (-> provider? model-request? any/c)]
                        [provider-capabilities (-> provider? hash?)]
-                       [provider-count-tokens (-> provider? any/c (or/c #f integer?))]
                        [make-provider (-> procedure? procedure? procedure? procedure? provider?)]
                        [make-mock-provider
                         (->* (any/c) (#:name string? #:stream-chunks (or/c #f list?)) provider?)]))
@@ -144,19 +143,6 @@
                 [(stream) (lambda (req) (stream-result->generator (stream-proc req)))]
                 [(count-tokens) (lambda (req) #f)] ; not supported by default
                 [else (error 'provider "unknown operation: ~a" op)]))))
-
-;; ============================================================
-;; count-tokens protocol method
-;; ============================================================
-
-;; Returns #f for providers that don't support token counting,
-;; or an integer count for providers that do.
-;; provider-count-tokens : provider? any/c -> (or/c #f integer?)
-;; Returns token count for the given request, or #f if the provider
-;; doesn't support counting. Default implementation returns #f.
-(define (provider-count-tokens p req)
-  (define count-proc ((provider-dispatch p) 'count-tokens))
-  (count-proc req))
 
 ;; ============================================================
 ;; Mock provider (for testing)

--- a/llm/stream.rkt
+++ b/llm/stream.rkt
@@ -88,7 +88,9 @@
   (cond
     [(eq? result #f)
      (kill-thread th)
-     (with-handlers ([exn:fail? void])
+     (with-handlers ([exn:fail? (lambda (e)
+                                  (log-warning (format "llm/stream: cleanup error: ~a"
+                                                       (exn-message e))))])
        (cleanup-thunk)) ; #454: close ports
      (raise (exn:fail:network:timeout (format "HTTP request timeout (~a seconds)" timeout-secs)
                                       (current-continuation-marks)))]
@@ -183,7 +185,10 @@
         [(not data-str) acc] ; non-data line
         [(sse-done? data-str) acc] ; termination
         [else
-         (with-handlers ([exn:fail? (lambda (e) acc)]) ; skip malformed
+         (with-handlers ([exn:fail? (lambda (e)
+                                      (log-warning (format "llm/stream: malformed SSE data: ~a"
+                                                           (exn-message e)))
+                                      acc)]) ; skip malformed
            (define parsed (string->jsexpr data-str))
            (cons parsed acc))])))
   (reverse results))
@@ -291,7 +296,9 @@
     [(not data-str) #f]
     [(sse-done? data-str) 'done]
     [else
-     (with-handlers ([exn:fail? (lambda (e) #f)])
+     (with-handlers ([exn:fail? (lambda (e)
+                                  (log-warning (format "llm/stream: parse error: ~a" (exn-message e)))
+                                  #f)])
        (string->jsexpr data-str))]))
 
 ;; ============================================================

--- a/runtime/session-store.rkt
+++ b/runtime/session-store.rkt
@@ -285,7 +285,9 @@
                     seen)]
            [else
             (define parsed
-              (with-handlers ([exn:fail? (lambda (e) #f)])
+              (with-handlers ([exn:fail? (lambda (e)
+                                           (log-warning (format "session-store: ~a" (exn-message e)))
+                                           #f)])
                 (read-json (open-input-string line-text))))
             (define required-fields '(id role kind content timestamp))
             (define missing
@@ -368,7 +370,9 @@
            [(not (jsonl-line-valid? line)) (values valid (+ rmvd 1) seen)]
            [else
             (define parsed
-              (with-handlers ([exn:fail? (lambda (e) #f)])
+              (with-handlers ([exn:fail? (lambda (e)
+                                           (log-warning (format "session-store: ~a" (exn-message e)))
+                                           #f)])
                 (read-json (open-input-string line))))
             (define required-fields '(id role kind content timestamp))
             (define missing
@@ -621,7 +625,9 @@
 (define (read-first-log-entry log-path)
   ;; Read only the first line of a JSONL log file.
   ;; Returns the first message or #f if file is empty/missing.
-  (with-handlers ([exn:fail? (lambda (e) #f)])
+  (with-handlers ([exn:fail? (lambda (e)
+                               (log-warning (format "session-store: ~a" (exn-message e)))
+                               #f)])
     (call-with-input-file log-path
                           (lambda (in)
                             (define line (read-line in))

--- a/tests/test-credential-backend.rkt
+++ b/tests/test-credential-backend.rkt
@@ -115,12 +115,20 @@
 (test-case "env-backend: load from environment variable"
   (define be (make-env-credential-backend))
   (check-equal? (backend-name be) "env")
-  ;; Set env var
-  (putenv "Q_TEST_PROVIDER_API_KEY" "sk-env-test-key")
-  (define cred (backend-load be "test_provider" #:env-var "Q_TEST_PROVIDER_API_KEY"))
-  (check-not-false cred)
-  (check-equal? (hash-ref cred 'api-key) "sk-env-test-key")
-  (check-equal? (hash-ref cred 'source) "environment"))
+  ;; Set env var with guaranteed cleanup (TEST-01)
+  (define old-val (environment-variables-ref (current-environment-variables)
+                                              #"Q_TEST_PROVIDER_API_KEY"))
+  (dynamic-wind
+    (lambda () (putenv "Q_TEST_PROVIDER_API_KEY" "sk-env-test-key"))
+    (lambda ()
+      (define cred (backend-load be "test_provider" #:env-var "Q_TEST_PROVIDER_API_KEY"))
+      (check-not-false cred)
+      (check-equal? (hash-ref cred 'api-key) "sk-env-test-key")
+      (check-equal? (hash-ref cred 'source) "environment"))
+    (lambda ()
+      (if old-val
+          (putenv "Q_TEST_PROVIDER_API_KEY" (bytes->string/utf-8 old-val))
+          (putenv "Q_TEST_PROVIDER_API_KEY" "")))))
 
 (test-case "env-backend: load returns #f for unset variable"
   (define be (make-env-credential-backend))
@@ -169,14 +177,22 @@
   (check-equal? (backend-name chained) "chained")
   ;; Store in memory backend
   (backend-store! mem "test_provider" "sk-memory-key")
-  ;; env should take priority (set env var)
-  (putenv "Q_TEST_PROVIDER_API_KEY" "sk-env-key")
-  (define cred-env (backend-load chained "test_provider" #:env-var "Q_TEST_PROVIDER_API_KEY"))
-  (check-equal? (hash-ref cred-env 'api-key) "sk-env-key")
-  ;; Remove env, should fall through to memory
-  (putenv "Q_TEST_PROVIDER_API_KEY" "")
-  (define cred-mem (backend-load chained "test_provider"))
-  (check-equal? (hash-ref cred-mem 'api-key) "sk-memory-key"))
+  ;; env should take priority — use dynamic-wind for cleanup (TEST-01)
+  (define old-val (environment-variables-ref (current-environment-variables)
+                                              #"Q_TEST_PROVIDER_API_KEY"))
+  (dynamic-wind
+    (lambda () (putenv "Q_TEST_PROVIDER_API_KEY" "sk-env-key"))
+    (lambda ()
+      (define cred-env (backend-load chained "test_provider" #:env-var "Q_TEST_PROVIDER_API_KEY"))
+      (check-equal? (hash-ref cred-env 'api-key) "sk-env-key")
+      ;; Remove env, should fall through to memory
+      (putenv "Q_TEST_PROVIDER_API_KEY" "")
+      (define cred-mem (backend-load chained "test_provider"))
+      (check-equal? (hash-ref cred-mem 'api-key) "sk-memory-key"))
+    (lambda ()
+      (if old-val
+          (putenv "Q_TEST_PROVIDER_API_KEY" (bytes->string/utf-8 old-val))
+          (putenv "Q_TEST_PROVIDER_API_KEY" "")))))
 
 (test-case "chained-backend: store! writes to first writable backend"
   (define mem (make-memory-credential-backend))

--- a/tests/test-dynamic-tools-arity.rkt
+++ b/tests/test-dynamic-tools-arity.rkt
@@ -1,0 +1,34 @@
+#lang racket/base
+
+;; TEST-03: ext-register-tool! wraps 1-arg handlers to accept (args exec-ctx)
+
+(require rackunit
+         (only-in "../extensions/dynamic-tools.rkt" ext-register-tool!)
+         (only-in "../extensions/context.rkt" make-extension-ctx)
+         (only-in "../tools/tool.rkt" make-tool-registry lookup-tool tool-execute tool?)
+         (only-in "../agent/event-bus.rkt" make-event-bus))
+
+(define (make-test-ctx reg)
+  (make-extension-ctx #:session-id "test-session"
+                      #:session-dir "/tmp"
+                      #:event-bus (make-event-bus)
+                      #:extension-registry #f
+                      #:tool-registry reg))
+
+(test-case "1-arg handler is wrapped to accept (args exec-ctx)"
+  (define reg (make-tool-registry))
+  (define ctx (make-test-ctx reg))
+  (ext-register-tool! ctx "test-1arg" "desc" (hasheq)
+                      (lambda (args) "result-from-1arg"))
+  (define t (lookup-tool reg "test-1arg"))
+  (check-true (tool? t))
+  ;; The wrapped handler should accept 2 args (args + exec-ctx)
+  (check-equal? ((tool-execute t) (hasheq) 'fake-exec-ctx) "result-from-1arg"))
+
+(test-case "handler receives correct args map"
+  (define reg (make-tool-registry))
+  (define ctx (make-test-ctx reg))
+  (ext-register-tool! ctx "test-args" "desc" (hasheq)
+                      (lambda (args) (hash-ref args 'x)))
+  (define t (lookup-tool reg "test-args"))
+  (check-equal? ((tool-execute t) (hasheq 'x 42) 'fake-ctx) 42))

--- a/tests/test-sandbox-limits.rkt
+++ b/tests/test-sandbox-limits.rkt
@@ -85,28 +85,34 @@
   (check-false (within-limits? lim #:processes 6)))
 
 (test-case "track-process! increments counter (#452)"
-  ;; Save/restore box state instead of parameterize
+  ;; dynamic-wind for guaranteed restore (TEST-01)
   (define saved (unbox process-count-box))
-  (set-box! process-count-box 0)
-  (track-process!)
-  (check-equal? (get-process-count) 1)
-  (track-process!)
-  (check-equal? (get-process-count) 2)
-  (set-box! process-count-box saved))
+  (dynamic-wind
+    (lambda () (set-box! process-count-box 0))
+    (lambda ()
+      (track-process!)
+      (check-equal? (get-process-count) 1)
+      (track-process!)
+      (check-equal? (get-process-count) 2))
+    (lambda () (set-box! process-count-box saved))))
 
 (test-case "untrack-process! decrements counter (#452)"
   (define saved (unbox process-count-box))
-  (set-box! process-count-box 2)
-  (untrack-process!)
-  (check-equal? (get-process-count) 1)
-  (set-box! process-count-box saved))
+  (dynamic-wind
+    (lambda () (set-box! process-count-box 2))
+    (lambda ()
+      (untrack-process!)
+      (check-equal? (get-process-count) 1))
+    (lambda () (set-box! process-count-box saved))))
 
 (test-case "untrack-process! never goes below zero (#452)"
   (define saved (unbox process-count-box))
-  (set-box! process-count-box 0)
-  (untrack-process!)
-  (check-equal? (get-process-count) 0)
-  (set-box! process-count-box saved))
+  (dynamic-wind
+    (lambda () (set-box! process-count-box 0))
+    (lambda ()
+      (untrack-process!)
+      (check-equal? (get-process-count) 0))
+    (lambda () (set-box! process-count-box saved))))
 
 (test-case "process count over limit fails within-limits?"
   (define lim (exec-limits 10 1000 10000 3))

--- a/tests/test-tool-read.rkt
+++ b/tests/test-tool-read.rkt
@@ -66,3 +66,36 @@
   (check-false (tool-result-is-error? result))
   (check-equal? (hash-ref (tool-result-details result) 'total-lines) 3)
   (delete-file tmp))
+
+;; ============================================================
+;; TEST-02: Additional coverage — path traversal, symlink, large file
+;; ============================================================
+
+(test-case "tool-read: path traversal returns error"
+  (define result (tool-read (hasheq 'path "../../etc/passwd")))
+  (check-pred tool-result-is-error? result))
+
+(test-case "tool-read: symlink resolves correctly"
+  (define tmp (make-temporary-file "q-test-symlink-~a.txt"))
+  (display-to-file "symlink-target-content" tmp #:exists 'replace)
+  (define link-path (make-temporary-file "q-test-link-~a.txt"))
+  (delete-file link-path)
+  (make-file-or-directory-link tmp link-path)
+  (define result (tool-read (hasheq 'path link-path)))
+  (check-false (tool-result-is-error? result))
+  (check-true (string-contains? (car (tool-result-content result)) "symlink-target-content"))
+  (delete-file link-path)
+  (delete-file tmp))
+
+(test-case "tool-read: large file (1000+ lines) works"
+  (define tmp (make-temporary-file "q-test-large-~a.txt"))
+  (define lines (for/list ([i (in-range 1200)]) (format "line ~a" i)))
+  (display-to-file (string-join lines "\n") tmp #:exists 'replace)
+  (define result (tool-read (hasheq 'path tmp)))
+  (check-false (tool-result-is-error? result))
+  (check-equal? (hash-ref (tool-result-details result) 'total-lines) 1200)
+  (delete-file tmp))
+
+(test-case "tool-read: missing path arg returns error"
+  (define result (tool-read (hasheq)))
+  (check-pred tool-result-is-error? result))

--- a/tools/builtins/edit.rkt
+++ b/tools/builtins/edit.rkt
@@ -45,7 +45,7 @@
   dir)
 
 (define (save-backup path-str content)
-  (with-handlers ([exn:fail? (lambda (e) #f)])
+  (with-handlers ([exn:fail? (lambda (e) (log-warning (format "edit/backup: ~a" (exn-message e))) #f)])
     (define dir (ensure-backup-dir))
     (define basename (file-name-from-path path-str))
     (define timestamp (format "~a" (inexact->exact (current-inexact-milliseconds))))
@@ -67,7 +67,7 @@
       (last parts)))
 
 (define (prune-old-backups dir basename)
-  (with-handlers ([exn:fail? (lambda (e) (void))])
+  (with-handlers ([exn:fail? (lambda (e) (log-warning (format "edit/prune: ~a" (exn-message e))) (void))])
     (define all (directory-list dir))
     (define matching
       (filter (lambda (f) (string-contains? (path->string f) basename))
@@ -240,7 +240,7 @@
                     (cond
                       [(> delta-diff 2)
                        ;; Auto-revert: write back original content
-                       (with-handlers ([exn:fail? (lambda (e) (void))])
+                       (with-handlers ([exn:fail? (lambda (e) (log-warning (format "edit/auto-revert: ~a" (exn-message e))) (void))])
                          (display-to-file content path-str #:exists 'replace))
                        (make-error-result
                         (format

--- a/tools/builtins/grep.rkt
+++ b/tools/builtins/grep.rkt
@@ -7,7 +7,10 @@
          racket/path
          (only-in "../tool.rkt" make-success-result make-error-result)
          (only-in "../../util/glob.rkt" glob->regexp)
-         (only-in "../../util/path-helpers.rkt" contains-null-bytes? bytes->display-lines expand-home-path)
+         (only-in "../../util/path-helpers.rkt"
+                  contains-null-bytes?
+                  bytes->display-lines
+                  expand-home-path)
          (only-in "../../util/path-filters.rkt" hidden-name? should-skip-entry? skip-dirs))
 
 (provide tool-grep)
@@ -50,7 +53,9 @@
     [(not (file-exists? file-path)) (values '() #f)]
     [else
      (define raw-bytes
-       (with-handlers ([exn:fail? (lambda (e) #f)])
+       (with-handlers ([exn:fail? (lambda (e)
+                                    (log-warning (format "grep: ~a" (exn-message e)))
+                                    #f)])
          (file->bytes file-path)))
      (cond
        [(not raw-bytes) (values '() #t)] ; unreadable → skip
@@ -108,7 +113,9 @@
   (define dir-path (string->path dir-path-str))
   ;; Use in-directory for recursive walk
   (define all-paths
-    (with-handlers ([exn:fail? (lambda (e) '())])
+    (with-handlers ([exn:fail? (lambda (e)
+                                 (log-warning (format "grep: ~a" (exn-message e)))
+                                 '())])
       (for/list ([p (in-directory dir-path)]
                  #:when (file-exists? p))
         p)))
@@ -161,7 +168,9 @@
 
 (define (search-single-file the-path path-str pattern-rx context-lines max-results files-searched)
   (define raw-bytes
-    (with-handlers ([exn:fail? (lambda (e) #f)])
+    (with-handlers ([exn:fail? (lambda (e)
+                                 (log-warning (format "grep: ~a" (exn-message e)))
+                                 #f)])
       (file->bytes the-path)))
   (cond
     [(not raw-bytes)
@@ -229,7 +238,9 @@
               ([f (in-list files)])
       (define f-str (path->string f))
       (define raw-bytes
-        (with-handlers ([exn:fail? (lambda (e) #f)])
+        (with-handlers ([exn:fail? (lambda (e)
+                                     (log-warning (format "grep: ~a" (exn-message e)))
+                                     #f)])
           (file->bytes f)))
       (cond
         [(not raw-bytes) acc] ; unreadable → skip
@@ -264,7 +275,9 @@
       (define match-info (second entry))
       (define match-line-num (first match-info))
       (define raw-bytes
-        (with-handlers ([exn:fail? (lambda (e) #f)])
+        (with-handlers ([exn:fail? (lambda (e)
+                                     (log-warning (format "grep: ~a" (exn-message e)))
+                                     #f)])
           (file->bytes f-str)))
       (if (not raw-bytes)
           acc


### PR DESCRIPTION
Addresses #1922.

fix: code quality — silent catches, dead code, test isolation (#1922)

ERR-01: Added log-warning to 12+ silent catch sites (llm/stream, runtime/session-store, tools/grep, tools/edit, extensions/gsd-planning, extensions/github-integration)
DEAD-01: Removed dead event-bus serialization code (~60 lines, queue-item, drain-signal, enable-serialization!, drain-event-queue!, serialization-enabled?)
DEAD-02: Removed dead provider-count-tokens method from llm/provider.rkt
TEST-01: Wrapped putenv/process-count-box in dynamic-wind in test-credential-backend.rkt and test-sandbox-limits.rkt
TEST-02: Added path traversal, symlink, large file, and missing-arg tests to test-tool-read.rkt
TEST-03: New test-dynamic-tools-arity.rkt verifying ext-register-tool! wraps 1-arg handlers