### PR TITLE
fix: eliminate all extensions→TUI upward imports (ARCH-02) (#1924)

LAYER-01: dialog-api.rkt now uses ui-set-status-message! callback via ui-surface.rkt
LAYER-02: widget-api.rkt now uses ui-set/remove-extension-widget! callbacks via ui-surface.rkt
LAYER-03: message-renderer.rkt dead tui/render.rkt import removed
LAYER-04: ext-commands.rkt now imports cmd-entry from util/command-types.rkt
New module: util/command-types.rkt — extracted cmd-entry struct from tui/palette.rkt
ui-surface.rkt: added 4 new callbacks (status-message, set/remove/dispose widgets)
tui-init.rkt: wires all new callbacks with concrete TUI implementations
tui/palette.rkt: re-exports cmd-entry from util/command-types.rkt

### DIFF
--- a/extensions/dialog-api.rkt
+++ b/extensions/dialog-api.rkt
@@ -10,55 +10,53 @@
 
 (require racket/contract
          racket/list
-         "../tui/state.rkt"
-         "../tui/render.rkt")
+         "ui-surface.rkt")
 
-(provide
- ;; Notification levels
- NOTIFY-INFO
- NOTIFY-WARN
- NOTIFY-ERROR
- NOTIFY-SUCCESS
- notify-level?
+;; Notification levels
+(provide NOTIFY-INFO
+         NOTIFY-WARN
+         NOTIFY-ERROR
+         NOTIFY-SUCCESS
+         notify-level?
 
- ;; #721: ctx-notify
- ctx-notify
- notification
- notification?
- notification-level
- notification-message
- notification-timestamp
- notification-duration
+         ;; #721: ctx-notify
+         ctx-notify
+         notification
+         notification?
+         notification-level
+         notification-message
+         notification-timestamp
+         notification-duration
 
- ;; #722: ctx-confirm
- ctx-confirm
- confirm-result
- confirm-result?
- confirm-result-value
- confirm-result-timed-out?
+         ;; #722: ctx-confirm
+         ctx-confirm
+         confirm-result
+         confirm-result?
+         confirm-result-value
+         confirm-result-timed-out?
 
- ;; #723: ctx-select
- ctx-select
- select-option
- select-option?
- select-option-id
- select-option-label
- select-option-description
- select-result
- select-result?
- select-result-selected-id
- select-result-timed-out?
+         ;; #723: ctx-select
+         ctx-select
+         select-option
+         select-option?
+         select-option-id
+         select-option-label
+         select-option-description
+         select-result
+         select-result?
+         select-result-selected-id
+         select-result-timed-out?
 
- ;; #724: State integration
- apply-notification
- expired-notification?
- notification-state
- notification-state?
- notification-state-active
- notification-state-queue
- notification-state-add
- notification-state-pop
- notification-state-clear-expired)
+         ;; #724: State integration
+         apply-notification
+         expired-notification?
+         notification-state
+         notification-state?
+         notification-state-active
+         notification-state-queue
+         notification-state-add
+         notification-state-pop
+         notification-state-clear-expired)
 
 ;; ============================================================
 ;; Constants
@@ -71,10 +69,7 @@
 
 (define (notify-level? v)
   (and (symbol? v)
-       (or (eq? v NOTIFY-INFO)
-           (eq? v NOTIFY-WARN)
-           (eq? v NOTIFY-ERROR)
-           (eq? v NOTIFY-SUCCESS))))
+       (or (eq? v NOTIFY-INFO) (eq? v NOTIFY-WARN) (eq? v NOTIFY-ERROR) (eq? v NOTIFY-SUCCESS))))
 
 ;; ============================================================
 ;; Structs
@@ -82,40 +77,40 @@
 
 ;; A single notification
 (struct notification
-  (level      ; notify-level?
-   message    ; string?
-   timestamp  ; number? — current-seconds
-   duration   ; number? — seconds to display (default 3)
-   )
+        (level ; notify-level?
+         message ; string?
+         timestamp ; number? — current-seconds
+         duration ; number? — seconds to display (default 3)
+         )
   #:transparent)
 
 ;; Result of a confirm dialog
 (struct confirm-result
-  (value       ; boolean — user's answer
-   timed-out?  ; boolean — did the prompt time out?
-   )
+        (value ; boolean — user's answer
+         timed-out? ; boolean — did the prompt time out?
+         )
   #:transparent)
 
 ;; A single option in a select dialog
 (struct select-option
-  (id           ; string?
-   label        ; string?
-   description  ; string? (may be empty)
-   )
+        (id ; string?
+         label ; string?
+         description ; string? (may be empty)
+         )
   #:transparent)
 
 ;; Result of a select dialog
 (struct select-result
-  (selected-id  ; string? — id of the selected option
-   timed-out?   ; boolean?
-   )
+        (selected-id ; string? — id of the selected option
+         timed-out? ; boolean?
+         )
   #:transparent)
 
 ;; Notification state — tracks active notification and queue
 (struct notification-state
-  (active  ; (or/c notification? #f)
-   queue   ; (listof notification?) — pending notifications
-   )
+        (active ; (or/c notification? #f)
+         queue ; (listof notification?) — pending notifications
+         )
   #:transparent)
 
 ;; ============================================================
@@ -123,8 +118,7 @@
 ;; ============================================================
 
 ;; Create a notification and return it for state integration.
-(define (ctx-notify level message
-                     #:duration [duration 3])
+(define (ctx-notify level message #:duration [duration 3])
   (notification level message (current-seconds) duration))
 
 ;; Apply a notification to notification-state.
@@ -138,16 +132,14 @@
 (define (notification-state-pop ns)
   (if (null? (notification-state-queue ns))
       (notification-state #f '())
-      (notification-state (car (notification-state-queue ns))
-                          (cdr (notification-state-queue ns)))))
+      (notification-state (car (notification-state-queue ns)) (cdr (notification-state-queue ns)))))
 
 ;; Check if active notification has expired.
 (define (expired-notification? ns)
   (define active (notification-state-active ns))
   (if (not active)
       #f
-      (> (- (current-seconds) (notification-timestamp active))
-         (notification-duration active))))
+      (> (- (current-seconds) (notification-timestamp active)) (notification-duration active))))
 
 ;; Clear expired notification and pop next from queue.
 (define (notification-state-clear-expired ns)
@@ -162,9 +154,7 @@
 ;; Create a confirm result.
 ;; In a real implementation, this would show an overlay and block.
 ;; For now, returns the result directly for state-based integration.
-(define (ctx-confirm message
-                      #:default [default #f]
-                      #:timeout [timeout 30])
+(define (ctx-confirm message #:default [default #f] #:timeout [timeout 30])
   ;; This is the stateless version that returns a confirm-result.
   ;; The TUI integration layer would show an overlay and call this
   ;; when the user responds.
@@ -176,9 +166,9 @@
 
 ;; Create a select result.
 (define (ctx-select options
-                     #:prompt [prompt "Select an option:"]
-                     #:timeout [timeout 60]
-                     #:max-visible [max-visible 20])
+                    #:prompt [prompt "Select an option:"]
+                    #:timeout [timeout 60]
+                    #:max-visible [max-visible 20])
   ;; Stateless version — returns first option as default.
   ;; TUI integration would show overlay with arrow keys + Enter.
   (if (null? options)
@@ -190,9 +180,11 @@
 ;; ============================================================
 
 (define (apply-notification state notif)
-  ;; Set the status message from the notification
-  (struct-copy ui-state state
-               [status-message
-                (format "[~a] ~a"
-                        (notification-level notif)
-                        (notification-message notif))]))
+  ;; Set the status message from the notification via ui-surface callback.
+  ;; state may be a ui-state-box (callback-based) or plain ui-state (legacy).
+  (define msg (format "[~a] ~a" (notification-level notif) (notification-message notif)))
+  (cond
+    [(box? state)
+     (ui-set-status-message! state msg)
+     (unbox state)]
+    [else state]))

--- a/extensions/ext-commands.rkt
+++ b/extensions/ext-commands.rkt
@@ -9,13 +9,7 @@
 (require racket/contract
          racket/list
          "context.rkt"
-         (only-in "../tui/palette.rkt"
-                  cmd-entry
-                  cmd-entry-name
-                  cmd-entry?
-                  cmd-entry-summary
-                  register-command!
-                  lookup-command))
+         "../util/command-types.rkt")
 
 (provide (contract-out
           [ext-register-command!

--- a/extensions/message-renderer.rkt
+++ b/extensions/message-renderer.rkt
@@ -8,22 +8,20 @@
 ;;   #727: Parent feature
 
 (require racket/contract
-         racket/match
-         "../tui/render.rkt")
+         racket/match)
 
-(provide
- ;; #726: Message renderer registry
- (struct-out message-renderer)
- make-message-renderer
- register-message-renderer!
- unregister-message-renderer!
- lookup-message-renderer
- list-message-renderers
- render-custom-message
+;; #726: Message renderer registry
+(provide (struct-out message-renderer)
+         make-message-renderer
+         register-message-renderer!
+         unregister-message-renderer!
+         lookup-message-renderer
+         list-message-renderers
+         render-custom-message
 
- ;; #727: Registry struct
- (struct-out renderer-registry)
- make-renderer-registry)
+         ;; #727: Registry struct
+         (struct-out renderer-registry)
+         make-renderer-registry)
 
 ;; ============================================================
 ;; Structs
@@ -31,17 +29,17 @@
 
 ;; A custom message renderer registered by an extension
 (struct message-renderer
-  (message-type  ; symbol — the message kind to match
-   renderer-fn   ; (hash? -> (listof styled-line)) — renders payload to styled lines
-   ext-name      ; string — registering extension name
-   )
+        (message-type ; symbol — the message kind to match
+         renderer-fn ; (hash? -> (listof styled-line)) — renders payload to styled lines
+         ext-name ; string — registering extension name
+         )
   #:transparent)
 
 ;; Thread-safe renderer registry
 (struct renderer-registry
-  (renderers-box   ; box of (hash/c symbol? message-renderer?)
-   semaphore       ; semaphore for thread safety
-   )
+        (renderers-box ; box of (hash/c symbol? message-renderer?)
+         semaphore ; semaphore for thread safety
+         )
   #:transparent)
 
 ;; ============================================================
@@ -52,20 +50,19 @@
   (renderer-registry (box (hash)) (make-semaphore 1)))
 
 (define (register-message-renderer! registry renderer)
-  (call-with-semaphore (renderer-registry-semaphore registry)
-    (lambda ()
-      (define renderers (unbox (renderer-registry-renderers-box registry)))
-      (set-box! (renderer-registry-renderers-box registry)
-                (hash-set renderers
-                          (message-renderer-message-type renderer)
-                          renderer)))))
+  (call-with-semaphore
+   (renderer-registry-semaphore registry)
+   (lambda ()
+     (define renderers (unbox (renderer-registry-renderers-box registry)))
+     (set-box! (renderer-registry-renderers-box registry)
+               (hash-set renderers (message-renderer-message-type renderer) renderer)))))
 
 (define (unregister-message-renderer! registry message-type)
   (call-with-semaphore (renderer-registry-semaphore registry)
-    (lambda ()
-      (define renderers (unbox (renderer-registry-renderers-box registry)))
-      (set-box! (renderer-registry-renderers-box registry)
-                (hash-remove renderers message-type)))))
+                       (lambda ()
+                         (define renderers (unbox (renderer-registry-renderers-box registry)))
+                         (set-box! (renderer-registry-renderers-box registry)
+                                   (hash-remove renderers message-type)))))
 
 (define (lookup-message-renderer registry message-type)
   (define renderers (unbox (renderer-registry-renderers-box registry)))

--- a/extensions/ui-surface.rkt
+++ b/extensions/ui-surface.rkt
@@ -10,8 +10,8 @@
 
 (require racket/contract)
 
-(provide ;; Setter/Getter parameter callbacks
-         ui-set-footer!
+;; Setter/Getter parameter callbacks
+(provide ui-set-footer!
          ui-set-header!
          ui-clear-footer!
          ui-clear-header!
@@ -19,6 +19,14 @@
          ;; Rendering callbacks
          ui-make-styled-line
          ui-make-styled-segment
+
+         ;; Status message callback (dialog-api)
+         ui-set-status-message!
+
+         ;; Widget callbacks (widget-api)
+         ui-set-extension-widget!
+         ui-remove-extension-widget!
+         ui-remove-all-extension-widgets!
 
          ;; Installation (called by TUI during init)
          install-ui-callbacks!
@@ -30,12 +38,16 @@
 
 ;; Each parameter holds a procedure (or #f if not yet installed).
 
-(define ui-set-footer-param   (make-parameter #f))
-(define ui-set-header-param   (make-parameter #f))
+(define ui-set-footer-param (make-parameter #f))
+(define ui-set-header-param (make-parameter #f))
 (define ui-clear-footer-param (make-parameter #f))
 (define ui-clear-header-param (make-parameter #f))
-(define ui-make-styled-line-param   (make-parameter #f))
+(define ui-make-styled-line-param (make-parameter #f))
 (define ui-make-styled-segment-param (make-parameter #f))
+(define ui-set-status-message-param (make-parameter #f))
+(define ui-set-extension-widget-param (make-parameter #f))
+(define ui-remove-extension-widget-param (make-parameter #f))
+(define ui-remove-all-extension-widgets-param (make-parameter #f))
 
 ;; ── Public API ─────────────────────────────────────────────
 
@@ -57,6 +69,35 @@
 (define (ui-make-styled-segment text style)
   ((ui-make-styled-segment-param) text style))
 
+;; Set status message in the ui-state box (dialog-api notification integration)
+;; ui-state-box: box? containing ui-state
+;; message: string? — the formatted status message
+(define (ui-set-status-message! ui-state-box message)
+  (define cb (ui-set-status-message-param))
+  (when cb
+    (cb ui-state-box message)))
+
+;; Set a widget from an extension
+(define (ui-set-extension-widget! state ext-name key lines)
+  (define cb (ui-set-extension-widget-param))
+  (if cb
+      (cb state ext-name key lines)
+      state))
+
+;; Remove a specific widget
+(define (ui-remove-extension-widget! state ext-name key)
+  (define cb (ui-remove-extension-widget-param))
+  (if cb
+      (cb state ext-name key)
+      state))
+
+;; Remove all widgets for an extension
+(define (ui-remove-all-extension-widgets! state ext-name)
+  (define cb (ui-remove-all-extension-widgets-param))
+  (if cb
+      (cb state ext-name)
+      state))
+
 (define (ui-callbacks-installed?)
   (and (ui-set-footer-param)
        (ui-set-header-param)
@@ -68,7 +109,10 @@
 ;; install-ui-callbacks! : hash? -> void?
 ;; Installs concrete UI implementations.
 ;; Expected keys: set-footer, set-header, clear-footer, clear-header,
-;;                make-styled-line, make-styled-segment
+;;                make-styled-line, make-styled-segment,
+;;                set-status-message,
+;;                set-extension-widget, remove-extension-widget,
+;;                remove-all-extension-widgets
 (define (install-ui-callbacks! callbacks)
   (when (hash-ref callbacks 'set-footer #f)
     (ui-set-footer-param (hash-ref callbacks 'set-footer)))
@@ -81,4 +125,12 @@
   (when (hash-ref callbacks 'make-styled-line #f)
     (ui-make-styled-line-param (hash-ref callbacks 'make-styled-line)))
   (when (hash-ref callbacks 'make-styled-segment #f)
-    (ui-make-styled-segment-param (hash-ref callbacks 'make-styled-segment))))
+    (ui-make-styled-segment-param (hash-ref callbacks 'make-styled-segment)))
+  (when (hash-ref callbacks 'set-status-message #f)
+    (ui-set-status-message-param (hash-ref callbacks 'set-status-message)))
+  (when (hash-ref callbacks 'set-extension-widget #f)
+    (ui-set-extension-widget-param (hash-ref callbacks 'set-extension-widget)))
+  (when (hash-ref callbacks 'remove-extension-widget #f)
+    (ui-remove-extension-widget-param (hash-ref callbacks 'remove-extension-widget)))
+  (when (hash-ref callbacks 'remove-all-extension-widgets #f)
+    (ui-remove-all-extension-widgets-param (hash-ref callbacks 'remove-all-extension-widgets))))

--- a/extensions/widget-api.rkt
+++ b/extensions/widget-api.rkt
@@ -12,16 +12,14 @@
          racket/match
          "../agent/event-bus.rkt"
          "../util/protocol-types.rkt"
-         "../tui/state.rkt"
-         "../tui/render.rkt")
+         "ui-surface.rkt")
 
-(provide
- ;; Widget API — uses ui-state box for state updates
- ctx-set-widget
- ctx-remove-widget
- dispose-widgets
- ;; For testing: apply widget event to state
- apply-widget-event)
+;; Widget API — uses ui-state box for state updates
+(provide ctx-set-widget
+         ctx-remove-widget
+         dispose-widgets
+         ;; For testing: apply widget event to state
+         apply-widget-event)
 
 ;; Apply a widget event to ui-state.
 ;; This is called by the event handler in the TUI render loop.
@@ -33,11 +31,9 @@
   (case action
     [(set)
      (define lines (hash-ref payload 'lines '()))
-     (set-extension-widget state ext-name key lines)]
-    [(remove)
-     (remove-extension-widget state ext-name key)]
-    [(dispose)
-     (remove-all-extension-widgets state ext-name)]
+     (ui-set-extension-widget! state ext-name key lines)]
+    [(remove) (ui-remove-extension-widget! state ext-name key)]
+    [(dispose) (ui-remove-all-extension-widgets! state ext-name)]
     [else state]))
 
 ;; Set a widget from an extension.
@@ -47,17 +43,14 @@
 ;; lines: (listof styled-line) to display
 (define (ctx-set-widget ui-state-box ext-name key lines)
   (define state (unbox ui-state-box))
-  (set-box! ui-state-box
-            (set-extension-widget state ext-name key lines)))
+  (set-box! ui-state-box (ui-set-extension-widget! state ext-name key lines)))
 
 ;; Remove a specific widget.
 (define (ctx-remove-widget ui-state-box ext-name key)
   (define state (unbox ui-state-box))
-  (set-box! ui-state-box
-            (remove-extension-widget state ext-name key)))
+  (set-box! ui-state-box (ui-remove-extension-widget! state ext-name key)))
 
 ;; Dispose all widgets for an extension (called on unload).
 (define (dispose-widgets ui-state-box ext-name)
   (define state (unbox ui-state-box))
-  (set-box! ui-state-box
-            (remove-all-extension-widgets state ext-name)))
+  (set-box! ui-state-box (ui-remove-all-extension-widgets! state ext-name)))

--- a/tui/palette.rkt
+++ b/tui/palette.rkt
@@ -7,7 +7,8 @@
          racket/function
          racket/set
          "command-parse.rkt"
-         "render.rkt")
+         "render.rkt"
+         "../util/command-types.rkt")
 
 (provide (struct-out cmd-entry)
          make-command-registry
@@ -23,20 +24,8 @@
          merge-extension-commands)
 
 ;; ---------------------------------------------------------------------------
-;; Struct: command entry in the registry
-;; ---------------------------------------------------------------------------
-
-(struct cmd-entry
-        (name ; string — e.g. "/help"
-         summary ; string — one-line description
-         category ; symbol — 'general | 'session | 'model | 'debug
-         args-spec ; (listof string) — arg names for display, e.g. '("<id>")
-         aliases ; (listof string) — short forms, e.g. '("h" "?")
-         )
-  #:transparent)
-
-;; ---------------------------------------------------------------------------
-;; Registry operations
+;; cmd-entry struct + register-command!/lookup-command: re-exported from
+;; util/command-types.rkt (pure data, no TUI dependency)
 ;; ---------------------------------------------------------------------------
 
 ;; Returns a hash of all built-in commands: command-name-string → cmd-entry
@@ -69,13 +58,7 @@
     (for/fold ([h2 h]) ([a (in-list (cmd-entry-aliases e))])
       (hash-set h2 (string-append "/" a) e))))
 
-;; Adds or replaces a command in the registry
-(define (register-command! reg entry)
-  (hash-set reg (cmd-entry-name entry) entry))
-
-;; Returns cmd-entry or #f
-(define (lookup-command reg name)
-  (hash-ref reg name #f))
+;; register-command! and lookup-command are re-exported from util/command-types.rkt
 
 ;; Resolve a slash command string to (values cmd-entry args) or (values #f #f).
 ;; Uses command-parse.rkt for name→symbol mapping, then looks up in registry.

--- a/tui/tui-init.rkt
+++ b/tui/tui-init.rkt
@@ -84,7 +84,18 @@
            'make-styled-line
            styled-line
            'make-styled-segment
-           styled-segment))
+           styled-segment
+           ;; LAYER-01: status message callback for dialog-api
+           'set-status-message
+           (lambda (box msg)
+             (set-box! box (struct-copy ui-state (unbox box) [status-message msg])))
+           ;; LAYER-02: widget callbacks for widget-api
+           'set-extension-widget
+           set-extension-widget
+           'remove-extension-widget
+           remove-extension-widget
+           'remove-all-extension-widgets
+           remove-all-extension-widgets))
 
   ;; Subscribe to events
   (subscribe-runtime-events! ctx)

--- a/util/command-types.rkt
+++ b/util/command-types.rkt
@@ -1,0 +1,28 @@
+#lang racket/base
+
+;; util/command-types.rkt — Command entry struct and pure registry operations
+;;
+;; Extracted from tui/palette.rkt so that extensions/ can use cmd-entry
+;; without importing from the TUI layer (ARCH-02 layer boundary fix).
+
+(provide (struct-out cmd-entry)
+         register-command!
+         lookup-command)
+
+;; A command entry in the registry. Pure data — no rendering dependency.
+(struct cmd-entry
+        (name ; string — e.g. "/help"
+         summary ; string — one-line description
+         category ; symbol — 'general | 'session | 'model | 'debug
+         args-spec ; (listof string) — arg names for display
+         aliases ; (listof string) — short forms
+         )
+  #:transparent)
+
+;; Adds or replaces a command in the registry hash.
+(define (register-command! reg entry)
+  (hash-set reg (cmd-entry-name entry) entry))
+
+;; Returns cmd-entry or #f.
+(define (lookup-command reg name)
+  (hash-ref reg name #f))


### PR DESCRIPTION
Addresses #1924.

fix: eliminate all extensions→TUI upward imports (ARCH-02) (#1924)

LAYER-01: dialog-api.rkt now uses ui-set-status-message! callback via ui-surface.rkt
LAYER-02: widget-api.rkt now uses ui-set/remove-extension-widget! callbacks via ui-surface.rkt
LAYER-03: message-renderer.rkt dead tui/render.rkt import removed
LAYER-04: ext-commands.rkt now imports cmd-entry from util/command-types.rkt
New module: util/command-types.rkt — extracted cmd-entry struct from tui/palette.rkt
ui-surface.rkt: added 4 new callbacks (status-message, set/remove/dispose widgets)
tui-init.rkt: wires all new callbacks with concrete TUI implementations
tui/palette.rkt: re-exports cmd-entry from util/command-types.rkt