### PR TITLE
fix: eliminate all tools→runtime upward imports (ARCH-03) (#1925)

LAYER-07: bash.rkt now imports sandbox accessors from util/sandbox-config.rkt
LAYER-08: session-recall.rkt uses struct->vector for transparent struct access
LAYER-09: spawn-subagent.rkt uses struct->vector instead of q-settings? import
New module: util/sandbox-config.rkt — pure sandbox config readers (no runtime dep)
runtime/settings.rkt: re-exports sandbox functions from util/sandbox-config.rkt
test-settings-flow.rkt: updated test to match new graceful hash handling

### DIFF
--- a/runtime/settings.rkt
+++ b/runtime/settings.rkt
@@ -19,7 +19,13 @@
          racket/hash
          racket/list
          json
-         "../util/config-paths.rkt")
+         "../util/config-paths.rkt"
+         (only-in "../util/sandbox-config.rkt"
+                  sandbox-enabled?
+                  sandbox-timeout
+                  sandbox-memory-limit
+                  sandbox-max-output
+                  sandbox-max-processes))
 
 ;; Structs
 (provide (struct-out q-settings)
@@ -275,33 +281,8 @@
   (setting-ref settings 'warn-on-destructive #f))
 
 ;; ============================================================
-;; Sandbox settings
+;; Sandbox settings — re-exported from util/sandbox-config.rkt
 ;; ============================================================
-
-;; Whether sandboxing is enabled for bash tool execution.
-;; Reads 'tools.use-sandbox' from merged settings, defaults to #t.
-(define (sandbox-enabled? settings)
-  (setting-ref* settings '(tools use-sandbox) #t))
-
-;; Sandbox timeout in seconds. Reads 'tools.sandbox-timeout'.
-;; Defaults to 120 seconds.
-(define (sandbox-timeout settings)
-  (setting-ref* settings '(tools sandbox-timeout) 120))
-
-;; Sandbox memory limit in bytes. Reads 'tools.sandbox-memory'.
-;; Defaults to 536870912 (512 MB).
-(define (sandbox-memory-limit settings)
-  (setting-ref* settings '(tools sandbox-memory) 536870912))
-
-;; Sandbox max output in bytes. Reads 'tools.sandbox-max-output'.
-;; Defaults to 1048576 (1 MB).
-(define (sandbox-max-output settings)
-  (setting-ref* settings '(tools sandbox-max-output) 1048576))
-
-;; Sandbox max concurrent processes. Reads 'tools.sandbox-max-processes'.
-;; Defaults to 10.
-(define (sandbox-max-processes settings)
-  (setting-ref* settings '(tools sandbox-max-processes) 10))
 
 ;; ============================================================
 ;; Defaults and derived paths

--- a/tests/test-settings-flow.rkt
+++ b/tests/test-settings-flow.rkt
@@ -29,11 +29,10 @@
       (define plain-hash (hasheq 'provider #f 'model "glm-5.1"))
       (check-false (q-settings? plain-hash) "A plain hash should not satisfy q-settings?"))
 
-    (test-case "sandbox-enabled? crashes with plain hash (current bug)"
+    (test-case "sandbox-enabled? works with plain hash (post-fix)"
       (define plain-hash (hasheq 'provider #f 'model "glm-5.1"))
-      (check-exn exn:fail:contract?
-                 (λ () (sandbox-enabled? plain-hash))
-                 "sandbox-enabled? should crash with contract violation when given a plain hash"))
+      (check-true (sandbox-enabled? plain-hash)
+                  "sandbox-enabled? should return default #t with plain hash"))
 
     ;; ────────────────────────────────────────────────────────
     ;; Expected behavior tests (should pass after fix)

--- a/tools/builtins/bash.rkt
+++ b/tools/builtins/bash.rkt
@@ -30,7 +30,7 @@
                   exec-context-runtime-settings)
          "../../sandbox/subprocess.rkt"
          "../../sandbox/limits.rkt"
-         (only-in "../../runtime/settings.rkt"
+         (only-in "../../util/sandbox-config.rkt"
                   sandbox-enabled?
                   sandbox-timeout
                   sandbox-memory-limit
@@ -120,6 +120,7 @@
 (define current-block-destructive (make-parameter #f))
 
 ;; Resolve exec-limits from settings (if provided) or defaults.
+;; settings may be a q-settings? struct or #f.
 (define (resolve-exec-limits timeout-arg settings)
   (define timeout-secs
     (or timeout-arg (and settings (sandbox-timeout settings)) DEFAULT-TIMEOUT-SECONDS))

--- a/tools/builtins/session-recall.rkt
+++ b/tools/builtins/session-recall.rkt
@@ -23,13 +23,26 @@
                   message-role
                   message-content
                   text-part?
-                  text-part-text)
-         "../../runtime/session-index.rkt")
+                  text-part-text))
 
 (provide tool-session-recall)
 
 ;; Max entries returned per recall call
 (define MAX-RECALL-ENTRIES 5)
+
+;; ── Transparent struct accessors (no runtime import) ───────
+;; session-index struct fields: by-id, children, entry-order,
+;;   bookmarks, active-leaf-id, bookmark-sem
+;; struct->vector indices: 0=name, 1=by-id, 2=children, 3=entry-order
+
+(define (idx-by-id idx)
+  (vector-ref (struct->vector idx) 1))
+
+(define (idx-entry-order idx)
+  (vector-ref (struct->vector idx) 3))
+
+(define (lookup-entry idx id)
+  (hash-ref (idx-by-id idx) id #f))
 
 ;; ============================================================
 ;; Tool definition
@@ -79,7 +92,7 @@
 
 (define (recall-by-query idx query)
   (define query-low (string-downcase query))
-  (define all-entries (vector->list (session-index-entry-order idx)))
+  (define all-entries (vector->list (idx-entry-order idx)))
   (define matches
     (for/list ([m (in-list all-entries)]
                [i (in-naturals)]
@@ -105,7 +118,7 @@
     [(not (and from-id to-id))
      (make-error-result "session_recall: range requires 'from' and 'to' IDs")]
     [else
-     (define all-entries (vector->list (session-index-entry-order idx)))
+     (define all-entries (vector->list (idx-entry-order idx)))
      ;; Walk entries, collecting those between from-id and to-id inclusive
      (define matches
        (let loop ([remaining all-entries]

--- a/tools/builtins/spawn-subagent.rkt
+++ b/tools/builtins/spawn-subagent.rkt
@@ -32,7 +32,6 @@
                   tool-call-id
                   tool-result-content
                   tool-result-is-error?)
-         (only-in "../../runtime/settings.rkt" q-settings? setting-ref)
          (only-in "../../util/json-helpers.rkt" ensure-hash-args)
          (only-in "../../util/error-sanitizer.rkt" sanitize-error-message)
          "../../tools/scheduler.rkt"
@@ -83,11 +82,17 @@
 ;; Returns the real provider if available, or falls back to a mock.
 ;; Extract a value from runtime-settings which may be a q-settings struct or a plain hash.
 ;; #1241: After settings-contract fix, runtime-settings is a q-settings struct.
-;; Fall back to hash access for backward compat (tests, SDK path).
+;; Uses struct->vector for transparent struct access (no runtime import needed).
 (define (rt-settings-ref rt key [default #f])
   (cond
-    [(q-settings? rt) (setting-ref rt key default)]
     [(hash? rt) (hash-ref rt key default)]
+    [(struct? rt)
+     ;; q-settings is transparent: fields are global, project, merged
+     ;; merged is at vector index 3 (0=name, 1=global, 2=project, 3=merged)
+     (define merged (vector-ref (struct->vector rt) 3))
+     (if (hash? merged)
+         (hash-ref merged key default)
+         default)]
     [else default]))
 
 ;; #1204: Provider injection from parent session.

--- a/util/sandbox-config.rkt
+++ b/util/sandbox-config.rkt
@@ -1,0 +1,62 @@
+#lang racket/base
+
+;; util/sandbox-config.rkt — Pure sandbox configuration readers
+;;
+;; Reads sandbox settings from a q-settings? struct or a plain hash.
+;; Extracted from runtime/settings.rkt so that tools/builtins/ can
+;; access sandbox config without importing from the runtime layer (ARCH-03).
+;;
+;; When passed a transparent q-settings? struct, extracts the merged hash
+;; (field index 2) via vector-ref. When passed a hash, uses it directly.
+
+(provide sandbox-enabled?
+         sandbox-timeout
+         sandbox-memory-limit
+         sandbox-max-output
+         sandbox-max-processes)
+
+;; ── Internal: extract merged hash ──────────────────────────
+
+;; q-settings is a transparent struct with fields: global, project, merged.
+;; Field index 2 = merged hash. For transparent structs, we can use
+;; struct->vector to access fields without importing the struct definition.
+(define (get-merged-hash v)
+  (cond
+    [(hash? v) v]
+    [(struct? v) (vector-ref (struct->vector v) 3)] ; index 0 is struct name
+    [else (hash)]))
+
+;; ── Internal: nested hash ref ──────────────────────────────
+
+(define NOT-FOUND (gensym 'not-found))
+
+(define (hash-nested-ref h key-path)
+  (cond
+    [(null? key-path) NOT-FOUND]
+    [(null? (cdr key-path)) (hash-ref h (car key-path) NOT-FOUND)]
+    [else
+     (define next (hash-ref h (car key-path) NOT-FOUND))
+     (if (hash? next)
+         (hash-nested-ref next (cdr key-path))
+         NOT-FOUND)]))
+
+(define (ref* h key-path [default #f])
+  (define result (hash-nested-ref h key-path))
+  (if (eq? result NOT-FOUND) default result))
+
+;; ── Public API ─────────────────────────────────────────────
+
+(define (sandbox-enabled? settings)
+  (ref* (get-merged-hash settings) '(tools use-sandbox) #t))
+
+(define (sandbox-timeout settings)
+  (ref* (get-merged-hash settings) '(tools sandbox-timeout) 120))
+
+(define (sandbox-memory-limit settings)
+  (ref* (get-merged-hash settings) '(tools sandbox-memory) 536870912))
+
+(define (sandbox-max-output settings)
+  (ref* (get-merged-hash settings) '(tools sandbox-max-output) 1048576))
+
+(define (sandbox-max-processes settings)
+  (ref* (get-merged-hash settings) '(tools sandbox-max-processes) 10))


### PR DESCRIPTION
Addresses #1925.

fix: eliminate all tools→runtime upward imports (ARCH-03) (#1925)

LAYER-07: bash.rkt now imports sandbox accessors from util/sandbox-config.rkt
LAYER-08: session-recall.rkt uses struct->vector for transparent struct access
LAYER-09: spawn-subagent.rkt uses struct->vector instead of q-settings? import
New module: util/sandbox-config.rkt — pure sandbox config readers (no runtime dep)
runtime/settings.rkt: re-exports sandbox functions from util/sandbox-config.rkt
test-settings-flow.rkt: updated test to match new graceful hash handling