### PR TITLE
refactor: split protocol-types.rkt god module into 6 focused sub-modules (ARCH-05) (#1926)

SPLIT-01: util/content-parts.rkt — text-part, tool-call-part, tool-result-part, serialization
SPLIT-02: util/message.rkt — message struct, JSON serialization/deserialization
SPLIT-03: util/event.rkt — event envelope, serialization, CURRENT-EVENT-VERSION
SPLIT-04: util/entry-predicates.rkt — message-entry?, tool-result-entry?, etc.
SPLIT-05: util/tree-entries.rkt — branch-entry, tree-navigation-entry, branch-summary-entry
SPLIT-06: util/loop-result.rkt — loop-result struct
SPLIT-07: util/protocol-types.rkt — backward-compat re-export facade (all-from-out)
SPLIT-08: tests/test-protocol-types-split.rkt — verifies all exports still available

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,9 +271,9 @@ q/
 | Metric | Value |
 |--------|-------|
 | Test files | 410 |
-| Source modules | 265 |
-| Source lines | 52576 |
-| Test lines | 81088 |
+| Source modules | 273 |
+| Source lines | 52726 |
+| Test lines | 81087 |
 | Test assertions | 12387 |
 | `racket scripts/run-tests.rkt` results | 5835+ tests passing |
 

--- a/tests/test-protocol-types-split.rkt
+++ b/tests/test-protocol-types-split.rkt
@@ -1,0 +1,86 @@
+#lang racket/base
+
+;; tests/test-protocol-types-split.rkt
+;;
+;; Verify that protocol-types.rkt facade re-exports all sub-module exports
+;; and that sub-modules can be imported independently (ARCH-05).
+
+(require rackunit
+         "../util/protocol-types.rkt"
+         ;; Also test direct sub-module imports
+         "../util/content-parts.rkt"
+         "../util/message.rkt"
+         "../util/event.rkt"
+         "../util/entry-predicates.rkt"
+         "../util/tree-entries.rkt"
+         "../util/loop-result.rkt")
+
+;; ── Content parts (from facade and direct) ─────────────────
+(check-equal? (text-part-text (make-text-part "hello")) "hello")
+(check-equal? (tool-call-part-name (make-tool-call-part "1" "bash" '{})) "bash")
+(check-equal? (tool-result-part-tool-call-id (make-tool-result-part "1" "ok" #f)) "1")
+
+;; JSON round-trip
+(define tp (make-text-part "test"))
+(check-equal? (jsexpr->content-part (content-part->jsexpr tp)) tp)
+
+;; ── Message (from facade and direct) ───────────────────────
+(define msg (make-message "m1" #f 'user 'message (list tp) 1000 (hash)))
+(check-equal? (message-id msg) "m1")
+(check-equal? (message-role msg) 'user)
+(check-equal? (jsexpr->message (message->jsexpr msg)) msg)
+
+;; ── Event (from facade and direct) ─────────────────────────
+(define evt (make-event "test-event" 1000 "sess1" "t1" (hash 'key "value")))
+(check-equal? (event-ev evt) "test-event")
+(check-equal? (event-event evt) "test-event")
+(check-equal? (jsexpr->event (event->jsexpr evt)) evt)
+(check-equal? CURRENT-EVENT-VERSION 1)
+
+;; ── Entry predicates ───────────────────────────────────────
+(check-true (message-entry? msg))
+(check-false (tool-result-entry? msg))
+(define tr-msg (make-message "m2" #f 'system 'tool-result '() 1000 (hash)))
+(check-pred tool-result-entry? tr-msg)
+(check-pred any-tool-result-entry? tr-msg)
+(define bash-msg (make-message "m3" #f 'system 'bash-execution '() 1000 (hash)))
+(check-pred bash-execution-entry? bash-msg)
+(check-pred any-tool-result-entry? bash-msg)
+
+;; ── Tree entries ───────────────────────────────────────────
+(define be (make-branch-entry "b1" "parent1" "my-branch"))
+(check-true (branch-entry? be))
+(check-true (tree-entry? be))
+(check-equal? (branch-entry-name be) "my-branch")
+(check-equal? (branch-entry-parent-entry-id be) "parent1")
+
+(define tne (make-tree-navigation-entry "n1" "from1" "to1"))
+(check-true (tree-navigation-entry? tne))
+(check-true (tree-entry? tne))
+(check-equal? (tree-navigation-entry-target-entry-id tne) "to1")
+
+(define bse (make-branch-summary-entry "s1" #f "summary text" '(1 . 10) 500))
+(check-true (branch-summary-entry? bse))
+(check-true (tree-entry? bse))
+(check-equal? (branch-summary-entry-summary bse) "summary text")
+
+;; ── Loop result ────────────────────────────────────────────
+(define lr (make-loop-result '(msg1 msg2) 'max-turns (hash)))
+(check-equal? (loop-result-messages lr) '(msg1 msg2))
+(check-equal? (loop-result-termination-reason lr) 'max-turns)
+
+;; ── Custom entry ───────────────────────────────────────────
+(define ce (make-custom-entry "ext1" "key1" "data1"))
+(check-true (custom-entry? ce))
+(check-equal? (custom-entry-extension ce) "ext1")
+(check-equal? (custom-entry-key ce) "key1")
+(check-equal? (custom-entry-data ce) "data1")
+
+;; ── Tool-call / tool-result (still in facade) ──────────────
+(define tc (tool-call "tc1" "read" (hash 'path "/tmp")))
+(check-equal? (tool-call-id tc) "tc1")
+(check-equal? (tool-call-name tc) "read")
+
+(define tr (tool-result "result content" (hash 'duration 1.5) #f))
+(check-equal? (tool-result-content tr) "result content")
+(check-false (tool-result-is-error? tr))

--- a/util/content-parts.rkt
+++ b/util/content-parts.rkt
@@ -1,0 +1,78 @@
+#lang racket/base
+
+;; util/content-parts.rkt — Content part structs for messages
+;;
+;; Extracted from protocol-types.rkt (ARCH-05 split).
+;; Text, tool-call, and tool-result content parts with JSON serialization.
+
+(require racket/contract)
+
+(provide (struct-out text-part)
+         (struct-out tool-call-part)
+         (struct-out tool-result-part)
+         ;; Re-export parent struct accessors
+         content-part?
+         content-part-type
+         make-text-part
+         make-tool-call-part
+         make-tool-result-part
+         content-part->jsexpr
+         jsexpr->content-part)
+
+;; Base struct — not exported directly; use type-specific constructors.
+(struct content-part (type) #:transparent)
+
+;; Text content part
+(struct text-part content-part (text) #:transparent)
+
+;; Tool-call content part
+(struct tool-call-part content-part (id name arguments) #:transparent)
+
+;; Tool-result content part
+(struct tool-result-part content-part (tool-call-id content is-error?) #:transparent)
+
+;; Convenience constructors
+(define (make-text-part text)
+  (text-part "text" text))
+
+(define (make-tool-call-part id name arguments)
+  (tool-call-part "tool-call" id name arguments))
+
+(define (make-tool-result-part tool-call-id content is-error?)
+  (tool-result-part "tool-result" tool-call-id content is-error?))
+
+;; Serialization
+(define (content-part->jsexpr cp)
+  (cond
+    [(text-part? cp) (hasheq 'type "text" 'text (text-part-text cp))]
+    [(tool-call-part? cp)
+     (hasheq 'type
+             "tool-call"
+             'id
+             (tool-call-part-id cp)
+             'name
+             (tool-call-part-name cp)
+             'arguments
+             (tool-call-part-arguments cp))]
+    [(tool-result-part? cp)
+     (hasheq 'type
+             "tool-result"
+             'toolCallId
+             (tool-result-part-tool-call-id cp)
+             'content
+             (tool-result-part-content cp)
+             'isError
+             (tool-result-part-is-error? cp))]
+    [else (error 'content-part->jsexpr "unknown content part type: ~a" cp)]))
+
+;; Deserialization
+(define (jsexpr->content-part h)
+  (define tp (hash-ref h 'type))
+  (case tp
+    [("text") (make-text-part (hash-ref h 'text))]
+    [("tool-call") (make-tool-call-part (hash-ref h 'id) (hash-ref h 'name) (hash-ref h 'arguments))]
+    [("tool-result")
+     (make-tool-result-part (hash-ref h 'toolCallId) (hash-ref h 'content) (hash-ref h 'isError))]
+    [else (error 'jsexpr->content-part "unknown content part type: ~a" tp)]))
+
+;; Get the type tag from a content part (struct accessor from content-part)

--- a/util/entry-predicates.rkt
+++ b/util/entry-predicates.rkt
@@ -1,0 +1,56 @@
+#lang racket/base
+
+;; util/entry-predicates.rkt — Entry kind predicates
+;;
+;; Extracted from protocol-types.rkt (ARCH-05 split).
+;; Predicates for different message entry kinds.
+
+(require racket/contract
+         "message.rkt")
+
+(provide message-entry?
+         model-change-entry?
+         thinking-level-change-entry?
+         branch-summary-entry?
+         custom-message-entry?
+         session-info-entry?
+         compaction-summary-entry?
+         tool-result-entry?
+         bash-execution-entry?
+         any-tool-result-entry?)
+
+;; ============================================================
+;; Entry kind predicates (#497)
+;; ============================================================
+;; Entry kinds extend the message struct's `kind` field to support
+;; session metadata and special entries beyond user/assistant messages.
+
+(define (message-entry? msg)
+  (and (message? msg) (memq (message-kind msg) '(message)) #t))
+
+(define (model-change-entry? msg)
+  (and (message? msg) (eq? (message-kind msg) 'model-change)))
+
+(define (thinking-level-change-entry? msg)
+  (and (message? msg) (eq? (message-kind msg) 'thinking-level-change)))
+
+(define (branch-summary-entry? msg)
+  (and (message? msg) (eq? (message-kind msg) 'branch-summary)))
+
+(define (custom-message-entry? msg)
+  (and (message? msg) (eq? (message-kind msg) 'custom-message)))
+
+(define (session-info-entry? msg)
+  (and (message? msg) (eq? (message-kind msg) 'session-info)))
+
+(define (compaction-summary-entry? msg)
+  (and (message? msg) (eq? (message-kind msg) 'compaction-summary)))
+
+(define (tool-result-entry? msg)
+  (and (message? msg) (eq? (message-kind msg) 'tool-result)))
+
+(define (bash-execution-entry? msg)
+  (and (message? msg) (eq? (message-kind msg) 'bash-execution)))
+
+(define (any-tool-result-entry? msg)
+  (and (message? msg) (memq (message-kind msg) '(tool-result bash-execution))))

--- a/util/event.rkt
+++ b/util/event.rkt
@@ -1,0 +1,62 @@
+#lang racket/base
+
+;; util/event.rkt — Event envelope struct and serialization
+;;
+;; Extracted from protocol-types.rkt (ARCH-05 split).
+;; Event struct with JSON serialization/deserialization.
+
+(require racket/contract)
+
+(provide (struct-out event)
+         event-event
+         make-event
+         event->jsexpr
+         jsexpr->event
+         CURRENT-EVENT-VERSION)
+
+;; ============================================================
+;; Event envelope struct
+;; ============================================================
+
+(struct event (version ev time session-id turn-id payload) #:transparent)
+
+(define (make-event ev time session-id turn-id payload #:version [version 1])
+  (event version ev time session-id turn-id payload))
+
+;; Accessor alias: the field is called `ev` internally to avoid
+;; name collision with the struct, but the logical name is `event`.
+;; Racket generates `event-ev`; we re-export as a procedure.
+(define event-event event-ev)
+
+;; Serialize event to jsexpr (hash)
+(define (event->jsexpr evt)
+  (hasheq 'version
+          (event-version evt)
+          'event
+          (event-ev evt)
+          'time
+          (event-time evt)
+          'sessionId
+          (event-session-id evt)
+          'turnId
+          (event-turn-id evt)
+          'payload
+          (event-payload evt)))
+
+;; Current event schema version produced by this runtime.
+(define CURRENT-EVENT-VERSION 1)
+
+;; Deserialize jsexpr (hash) to event.
+(define (jsexpr->event h)
+  (define ver (hash-ref h 'version 1))
+  (when (> ver CURRENT-EVENT-VERSION)
+    (log-warning "jsexpr->event: event version ~a exceeds current ~a (event: ~a)"
+                 ver
+                 CURRENT-EVENT-VERSION
+                 (hash-ref h 'event "<unknown>")))
+  (event ver
+         (hash-ref h 'event)
+         (hash-ref h 'time)
+         (hash-ref h 'sessionId)
+         (hash-ref h 'turnId)
+         (hash-ref h 'payload)))

--- a/util/loop-result.rkt
+++ b/util/loop-result.rkt
@@ -1,0 +1,13 @@
+#lang racket/base
+
+;; util/loop-result.rkt — Loop result struct
+;;
+;; Extracted from protocol-types.rkt (ARCH-05 split).
+
+(provide (struct-out loop-result)
+         make-loop-result)
+
+(struct loop-result (messages termination-reason metadata) #:transparent)
+
+(define (make-loop-result messages termination-reason metadata)
+  (loop-result messages termination-reason metadata))

--- a/util/message.rkt
+++ b/util/message.rkt
@@ -1,0 +1,62 @@
+#lang racket/base
+
+;; util/message.rkt — Message struct and serialization
+;;
+;; Extracted from protocol-types.rkt (ARCH-05 split).
+;; Message struct with JSON serialization/deserialization.
+
+(require racket/contract
+         "content-parts.rkt")
+
+(provide (struct-out message)
+         make-message
+         message->jsexpr
+         jsexpr->message)
+
+;; ============================================================
+;; Message struct
+;; ============================================================
+
+(struct message (id parent-id role kind content timestamp meta) #:transparent)
+
+(define (make-message id parent-id role kind content timestamp meta)
+  (message id parent-id role kind content timestamp meta))
+
+;; Symbol -> string for JSON
+(define (symbol->string* s)
+  (if (symbol? s)
+      (symbol->string s)
+      s))
+
+;; String -> symbol from JSON
+(define (string->symbol* s)
+  (if (string? s)
+      (string->symbol s)
+      s))
+
+;; Serialize message to jsexpr (hash)
+(define (message->jsexpr msg)
+  (hasheq 'id
+          (message-id msg)
+          'parentId
+          (message-parent-id msg)
+          'role
+          (symbol->string* (message-role msg))
+          'kind
+          (symbol->string* (message-kind msg))
+          'content
+          (map content-part->jsexpr (message-content msg))
+          'timestamp
+          (message-timestamp msg)
+          'meta
+          (message-meta msg)))
+
+;; Deserialize jsexpr (hash) to message
+(define (jsexpr->message h)
+  (make-message (hash-ref h 'id)
+                (hash-ref h 'parentId)
+                (string->symbol* (hash-ref h 'role))
+                (string->symbol* (hash-ref h 'kind))
+                (map jsexpr->content-part (hash-ref h 'content))
+                (hash-ref h 'timestamp)
+                (hash-ref h 'meta)))

--- a/util/protocol-types.rkt
+++ b/util/protocol-types.rkt
@@ -1,38 +1,34 @@
 #lang racket/base
 
-;; util/protocol-types.rkt — canonical runtime structs and enums
+;; util/protocol-types.rkt — Backward-compat re-export facade
 ;;
-;; Defines the core data types for q:
-;;   - content parts (text, tool-call, tool-result)
-;;   - messages
-;;   - event envelopes
-;;   - tool-call / tool-result (standalone — canonical definitions)
-;;   - loop-result
+;; ARCH-05: This module was split into focused sub-modules:
+;;   - content-parts.rkt — text-part, tool-call-part, tool-result-part
+;;   - message.rkt       — message struct, serialization
+;;   - event.rkt         — event envelope, serialization
+;;   - entry-predicates.rkt — entry kind predicates
+;;   - tree-entries.rkt  — branch-entry, tree-navigation-entry, etc.
+;;   - loop-result.rkt   — loop-result struct
 ;;
-;; All structs provide JSON serialization/deserialization via
-;; message->jsexpr / jsexpr->message and event->jsexpr / jsexpr->event.
-;;
-;; ARCH-01/04/05: extracted from agent/types.rkt to eliminate layer violations.
-;; Re-exported from agent/types.rkt for backward compatibility.
+;; This file re-exports everything for backward compatibility.
+;; New code should import the focused sub-modules directly.
 
-(require racket/contract)
+(require racket/contract
+         "content-parts.rkt"
+         "message.rkt"
+         "event.rkt"
+         "entry-predicates.rkt"
+         "tree-entries.rkt"
+         "loop-result.rkt")
 
 ;; Content parts
-(provide (struct-out text-part)
-         (struct-out tool-call-part)
-         (struct-out tool-result-part)
-         make-text-part
-         make-tool-call-part
-         make-tool-result-part
-         content-part->jsexpr
-         jsexpr->content-part
-         content-part-type
-
-         ;; Message
-         (struct-out message)
-         make-message
-         message->jsexpr
-         jsexpr->message
+;; Re-export all from sub-modules
+(provide (all-from-out "content-parts.rkt")
+         (all-from-out "message.rkt")
+         (all-from-out "event.rkt")
+         (all-from-out "entry-predicates.rkt")
+         (all-from-out "tree-entries.rkt")
+         (all-from-out "loop-result.rkt")
 
          ;; Custom entry for extension state persistence (#1147)
          make-custom-entry
@@ -40,158 +36,12 @@
          custom-entry-extension
          custom-entry-key
          custom-entry-data
-         ;; Entry kind predicates (#497)
-         message-entry?
-         model-change-entry?
-         thinking-level-change-entry?
-         branch-summary-entry?
-         custom-message-entry?
-         session-info-entry?
-         compaction-summary-entry?
-         tool-result-entry?
-         bash-execution-entry?
-         any-tool-result-entry?
-         ;; Tree entry types (#1314)
-         make-branch-entry
-         branch-entry?
-         branch-entry-parent-entry-id
-         branch-entry-name
-         make-tree-navigation-entry
-         tree-navigation-entry?
-         tree-navigation-entry-target-entry-id
-         tree-navigation-entry-from-entry-id
-         make-branch-summary-entry
-         branch-summary-entry-summary
-         branch-summary-entry-entry-range
-         branch-summary-entry-token-count
-         tree-entry?
-         ;; Event envelope
-         (struct-out event)
-         event-event
-         make-event
-         event->jsexpr
-         jsexpr->event
-
-         ;; Versioning
-         CURRENT-EVENT-VERSION
 
          ;; Tool-call (standalone — canonical definition)
          (struct-out tool-call)
 
          ;; Tool-result (standalone — canonical definition)
-         (struct-out tool-result)
-
-         ;; Loop-result
-         (struct-out loop-result)
-         make-loop-result)
-
-;; ============================================================
-;; Content parts
-;; ============================================================
-
-;; Base struct — not exported directly; use type-specific constructors.
-(struct content-part (type) #:transparent)
-
-;; Text content part
-(struct text-part content-part (text) #:transparent)
-
-;; Tool-call content part
-(struct tool-call-part content-part (id name arguments) #:transparent)
-
-;; Tool-result content part
-(struct tool-result-part content-part (tool-call-id content is-error?) #:transparent)
-
-;; Convenience constructors
-(define (make-text-part text)
-  (text-part "text" text))
-
-(define (make-tool-call-part id name arguments)
-  (tool-call-part "tool-call" id name arguments))
-
-(define (make-tool-result-part tool-call-id content is-error?)
-  (tool-result-part "tool-result" tool-call-id content is-error?))
-
-;; Serialization
-(define (content-part->jsexpr cp)
-  (cond
-    [(text-part? cp) (hasheq 'type "text" 'text (text-part-text cp))]
-    [(tool-call-part? cp)
-     (hasheq 'type
-             "tool-call"
-             'id
-             (tool-call-part-id cp)
-             'name
-             (tool-call-part-name cp)
-             'arguments
-             (tool-call-part-arguments cp))]
-    [(tool-result-part? cp)
-     (hasheq 'type
-             "tool-result"
-             'toolCallId
-             (tool-result-part-tool-call-id cp)
-             'content
-             (tool-result-part-content cp)
-             'isError
-             (tool-result-part-is-error? cp))]
-    [else (error 'content-part->jsexpr "unknown content part type: ~a" cp)]))
-
-;; Deserialization
-(define (jsexpr->content-part h)
-  (define tp (hash-ref h 'type))
-  (case tp
-    [("text") (make-text-part (hash-ref h 'text))]
-    [("tool-call") (make-tool-call-part (hash-ref h 'id) (hash-ref h 'name) (hash-ref h 'arguments))]
-    [("tool-result")
-     (make-tool-result-part (hash-ref h 'toolCallId) (hash-ref h 'content) (hash-ref h 'isError))]
-    [else (error 'jsexpr->content-part "unknown content part type: ~a" tp)]))
-
-;; ============================================================
-;; Message struct
-;; ============================================================
-
-(struct message (id parent-id role kind content timestamp meta) #:transparent)
-
-(define (make-message id parent-id role kind content timestamp meta)
-  (message id parent-id role kind content timestamp meta))
-
-;; Symbol -> string for JSON
-(define (symbol->string* s)
-  (if (symbol? s)
-      (symbol->string s)
-      s))
-
-;; String -> symbol from JSON
-(define (string->symbol* s)
-  (if (string? s)
-      (string->symbol s)
-      s))
-
-;; Serialize message to jsexpr (hash)
-(define (message->jsexpr msg)
-  (hasheq 'id
-          (message-id msg)
-          'parentId
-          (message-parent-id msg) ; #f -> JSON null
-          'role
-          (symbol->string* (message-role msg))
-          'kind
-          (symbol->string* (message-kind msg))
-          'content
-          (map content-part->jsexpr (message-content msg))
-          'timestamp
-          (message-timestamp msg)
-          'meta
-          (message-meta msg)))
-
-;; Deserialize jsexpr (hash) to message
-(define (jsexpr->message h)
-  (make-message (hash-ref h 'id)
-                (hash-ref h 'parentId) ; JSON null -> #f
-                (string->symbol* (hash-ref h 'role))
-                (string->symbol* (hash-ref h 'kind))
-                (map jsexpr->content-part (hash-ref h 'content))
-                (hash-ref h 'timestamp)
-                (hash-ref h 'meta)))
+         (struct-out tool-result))
 
 ;; ============================================================
 ;; Custom entry for extension state persistence (#1147)
@@ -223,180 +73,6 @@
 ;; Accessor: get data from a custom entry
 (define (custom-entry-data msg)
   (hash-ref (message-meta msg) 'data #f))
-
-;; ============================================================
-;; Entry kind predicates (#497)
-;; ============================================================
-;; Entry kinds extend the message struct's `kind` field to support
-;; session metadata and special entries beyond user/assistant messages.
-
-(define (message-entry? msg)
-  ;; Standard message entry (user or assistant)
-  (and (message? msg) (memq (message-kind msg) '(message)) #t))
-
-(define (model-change-entry? msg)
-  ;; Records a model change mid-session
-  (and (message? msg) (eq? (message-kind msg) 'model-change)))
-
-(define (thinking-level-change-entry? msg)
-  ;; Records a thinking level change mid-session
-  (and (message? msg) (eq? (message-kind msg) 'thinking-level-change)))
-
-(define (branch-summary-entry? msg)
-  ;; Summary of a branched path (used in context assembly)
-  (and (message? msg) (eq? (message-kind msg) 'branch-summary)))
-
-(define (custom-message-entry? msg)
-  ;; Custom/labeled message for extensions
-  (and (message? msg) (eq? (message-kind msg) 'custom-message)))
-
-(define (session-info-entry? msg)
-  ;; Session metadata (version, settings, etc.)
-  (and (message? msg) (eq? (message-kind msg) 'session-info)))
-
-(define (compaction-summary-entry? msg)
-  ;; Compaction summary entry
-  (and (message? msg) (eq? (message-kind msg) 'compaction-summary)))
-
-(define (tool-result-entry? msg)
-  ;; Tool result entry
-  (and (message? msg) (eq? (message-kind msg) 'tool-result)))
-
-(define (bash-execution-entry? msg)
-  ;; Bash execution entry — preserves command metadata (exit-code, duration, etc.)
-  (and (message? msg) (eq? (message-kind msg) 'bash-execution)))
-
-(define (any-tool-result-entry? msg)
-  ;; Matches both generic tool-result and bash-execution entries
-  (and (message? msg) (memq (message-kind msg) '(tool-result bash-execution))))
-
-;; ============================================================
-;; Tree entry types (#1314)
-;; ============================================================
-;; Tree entries are message structs with specific kinds and metadata.
-;; They support session branching and navigation within the JSONL log.
-
-;; branch-entry: marks where a branch was created
-;;   - id: unique entry id
-;;   - parent-id: the entry being branched from
-;;   - branch-name: human-readable branch name
-(define (make-branch-entry id parent-entry-id branch-name)
-  (make-message id
-                parent-entry-id
-                'system
-                'branch
-                '()
-                (current-seconds)
-                (hasheq 'branchName branch-name 'parentEntryId parent-entry-id)))
-
-(define (branch-entry? msg)
-  (and (message? msg) (eq? (message-kind msg) 'branch)))
-
-(define (branch-entry-parent-entry-id msg)
-  (hash-ref (message-meta msg) 'parentEntryId #f))
-
-(define (branch-entry-name msg)
-  (hash-ref (message-meta msg) 'branchName #f))
-
-;; tree-navigation-entry: marks navigation to a different branch
-(define (make-tree-navigation-entry id from-entry-id target-entry-id)
-  (make-message id
-                from-entry-id
-                'system
-                'tree-navigation
-                '()
-                (current-seconds)
-                (hasheq 'targetEntryId target-entry-id 'fromEntryId from-entry-id)))
-
-(define (tree-navigation-entry? msg)
-  (and (message? msg) (eq? (message-kind msg) 'tree-navigation)))
-
-(define (tree-navigation-entry-target-entry-id msg)
-  (hash-ref (message-meta msg) 'targetEntryId #f))
-
-(define (tree-navigation-entry-from-entry-id msg)
-  (hash-ref (message-meta msg) 'fromEntryId #f))
-
-;; branch-summary-entry: LLM-generated summary of a branch
-;; Note: branch-summary-entry? predicate already exists above, but
-;; this constructor adds structured fields (summary, entry-range, token-count).
-(define (make-branch-summary-entry id parent-id summary entry-range token-count)
-  (make-message id
-                parent-id
-                'system
-                'branch-summary
-                '()
-                (current-seconds)
-                (hasheq 'summary summary 'entryRange entry-range 'tokenCount token-count)))
-
-(define (branch-summary-entry-summary msg)
-  (hash-ref (message-meta msg) 'summary #f))
-
-(define (branch-summary-entry-entry-range msg)
-  (hash-ref (message-meta msg) 'entryRange #f))
-
-(define (branch-summary-entry-token-count msg)
-  (hash-ref (message-meta msg) 'tokenCount #f))
-
-;; tree-entry? — matches any tree entry type
-(define (tree-entry? msg)
-  (and (message? msg) (memq (message-kind msg) '(branch tree-navigation branch-summary)) #t))
-
-;; ============================================================
-;; Event envelope struct
-;; ============================================================
-
-(struct event (version ev time session-id turn-id payload) #:transparent)
-
-(define (make-event ev time session-id turn-id payload #:version [version 1])
-  (event version ev time session-id turn-id payload))
-
-;; Accessor alias: the field is called `ev` internally to avoid
-;; name collision with the struct, but the logical name is `event`.
-;; Racket generates `event-ev`; we re-export as a procedure.
-(define event-event event-ev)
-
-;; Serialize event to jsexpr (hash)
-(define (event->jsexpr evt)
-  (hasheq 'version
-          (event-version evt)
-          'event
-          (event-ev evt)
-          'time
-          (event-time evt)
-          'sessionId
-          (event-session-id evt)
-          'turnId
-          (event-turn-id evt) ; #f -> JSON null
-          'payload
-          (event-payload evt)))
-
-;; Current event schema version produced by this runtime.
-(define CURRENT-EVENT-VERSION 1)
-
-;; Deserialize jsexpr (hash) to event.
-(define (jsexpr->event h)
-  (define ver (hash-ref h 'version 1))
-  (when (> ver CURRENT-EVENT-VERSION)
-    (log-warning "jsexpr->event: event version ~a exceeds current ~a (event: ~a)"
-                 ver
-                 CURRENT-EVENT-VERSION
-                 (hash-ref h 'event "<unknown>")))
-  (event ver
-         (hash-ref h 'event)
-         (hash-ref h 'time)
-         (hash-ref h 'sessionId)
-         (hash-ref h 'turnId)
-         (hash-ref h 'payload)))
-
-;; ============================================================
-;; Loop-result struct
-;; ============================================================
-
-(struct loop-result (messages termination-reason metadata) #:transparent)
-
-(define (make-loop-result messages termination-reason metadata)
-  (loop-result messages termination-reason metadata))
 
 ;; ============================================================
 ;; Tool-call struct (standalone — canonical definition)

--- a/util/tree-entries.rkt
+++ b/util/tree-entries.rkt
@@ -1,0 +1,91 @@
+#lang racket/base
+
+;; util/tree-entries.rkt — Tree entry types for session branching
+;;
+;; Extracted from protocol-types.rkt (ARCH-05 split).
+;; Branch-entry, tree-navigation-entry, branch-summary-entry constructors,
+;; predicates, and accessors.
+
+(require racket/contract
+         "message.rkt")
+
+(provide make-branch-entry
+         branch-entry?
+         branch-entry-parent-entry-id
+         branch-entry-name
+         make-tree-navigation-entry
+         tree-navigation-entry?
+         tree-navigation-entry-target-entry-id
+         tree-navigation-entry-from-entry-id
+         make-branch-summary-entry
+         branch-summary-entry-summary
+         branch-summary-entry-entry-range
+         branch-summary-entry-token-count
+         tree-entry?)
+
+;; ============================================================
+;; Tree entry types (#1314)
+;; ============================================================
+;; Tree entries are message structs with specific kinds and metadata.
+;; They support session branching and navigation within the JSONL log.
+
+;; branch-entry: marks where a branch was created
+(define (make-branch-entry id parent-entry-id branch-name)
+  (make-message id
+                parent-entry-id
+                'system
+                'branch
+                '()
+                (current-seconds)
+                (hasheq 'branchName branch-name 'parentEntryId parent-entry-id)))
+
+(define (branch-entry? msg)
+  (and (message? msg) (eq? (message-kind msg) 'branch)))
+
+(define (branch-entry-parent-entry-id msg)
+  (hash-ref (message-meta msg) 'parentEntryId #f))
+
+(define (branch-entry-name msg)
+  (hash-ref (message-meta msg) 'branchName #f))
+
+;; tree-navigation-entry: marks navigation to a different branch
+(define (make-tree-navigation-entry id from-entry-id target-entry-id)
+  (make-message id
+                from-entry-id
+                'system
+                'tree-navigation
+                '()
+                (current-seconds)
+                (hasheq 'targetEntryId target-entry-id 'fromEntryId from-entry-id)))
+
+(define (tree-navigation-entry? msg)
+  (and (message? msg) (eq? (message-kind msg) 'tree-navigation)))
+
+(define (tree-navigation-entry-target-entry-id msg)
+  (hash-ref (message-meta msg) 'targetEntryId #f))
+
+(define (tree-navigation-entry-from-entry-id msg)
+  (hash-ref (message-meta msg) 'fromEntryId #f))
+
+;; branch-summary-entry: LLM-generated summary of a branch
+(define (make-branch-summary-entry id parent-id summary entry-range token-count)
+  (make-message id
+                parent-id
+                'system
+                'branch-summary
+                '()
+                (current-seconds)
+                (hasheq 'summary summary 'entryRange entry-range 'tokenCount token-count)))
+
+(define (branch-summary-entry-summary msg)
+  (hash-ref (message-meta msg) 'summary #f))
+
+(define (branch-summary-entry-entry-range msg)
+  (hash-ref (message-meta msg) 'entryRange #f))
+
+(define (branch-summary-entry-token-count msg)
+  (hash-ref (message-meta msg) 'tokenCount #f))
+
+;; tree-entry? — matches any tree entry type
+(define (tree-entry? msg)
+  (and (message? msg) (memq (message-kind msg) '(branch tree-navigation branch-summary)) #t))


### PR DESCRIPTION
Addresses #1926.

refactor: split protocol-types.rkt god module into 6 focused sub-modules (ARCH-05) (#1926)

SPLIT-01: util/content-parts.rkt — text-part, tool-call-part, tool-result-part, serialization
SPLIT-02: util/message.rkt — message struct, JSON serialization/deserialization
SPLIT-03: util/event.rkt — event envelope, serialization, CURRENT-EVENT-VERSION
SPLIT-04: util/entry-predicates.rkt — message-entry?, tool-result-entry?, etc.
SPLIT-05: util/tree-entries.rkt — branch-entry, tree-navigation-entry, branch-summary-entry
SPLIT-06: util/loop-result.rkt — loop-result struct
SPLIT-07: util/protocol-types.rkt — backward-compat re-export facade (all-from-out)
SPLIT-08: tests/test-protocol-types-split.rkt — verifies all exports still available