### PR TITLE
feat: HTTP helper consolidation + CI version matrix (QUAL-02, MAT-01, MAT-06) (#1928)

HTTP-01: Add make-provider-http-request and check-provider-status! to http-helpers.rkt
  - Shared HTTP POST helper with timeout, status checking, and JSON parsing
  - Consolidated error text extraction (extract-error-message, safe-extract-error-text)
HTTP-02: Refactor openai-compatible.rkt do-http-request to use shared helper
HTTP-03: Refactor anthropic.rkt anthropic-do-http-request to use shared helper
HTTP-04: Refactor gemini.rkt gemini-do-http-request to use shared helper
HTTP-05: Refactor azure-openai.rkt azure-do-http-request to use shared helper
HTTP-06: All 305+ provider tests passing after refactor
CI-01: Add Racket version matrix [8.10, 8.12] to ci.yml test job
CI-02: Parameterize Racket installer URL in release.yml smoke job via env var
  - Bumped default Racket version in composite action to 8.12

### DIFF
--- a/.github/actions/setup-racket/action.yml
+++ b/.github/actions/setup-racket/action.yml
@@ -4,7 +4,7 @@ inputs:
   racket-version:
     description: 'Racket version to install'
     required: false
-    default: '8.10'
+    default: '8.12'
 runs:
   using: 'composite'
   steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,12 +95,15 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
+        racket-version: ['8.10', '8.12']
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
 
       - name: Setup Racket
         uses: ./.github/actions/setup-racket
+        with:
+          racket-version: ${{ matrix.racket-version }}
 
       - name: Clean bytecode cache
         run: find . -name '*.zo' -delete -o -name 'compiled' -type d -exec rm -rf {} + 2>/dev/null; true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,10 +86,15 @@ jobs:
   smoke:
     needs: release
     runs-on: ubuntu-latest
+    env:
+      # Smoke job installs Racket directly to test the release tarball
+      # against a clean environment. The URL is parameterized here so
+      # it can be updated independently of the composite action version.
+      RACKET_VERSION: '8.12'
     steps:
       - name: Install Racket
         run: |
-          curl -L https://download.racket-lang.org/installers/8.10/racket-8.10-x86_64-linux-cs.sh -o /tmp/racket.sh
+          curl -L https://download.racket-lang.org/installers/${{ env.RACKET_VERSION }}/racket-${{ env.RACKET_VERSION }}-x86_64-linux-cs.sh -o /tmp/racket.sh
           echo "2" | sudo sh /tmp/racket.sh --in-place --create-links /usr/local
 
       - name: Download release tarball

--- a/llm/anthropic.rkt
+++ b/llm/anthropic.rkt
@@ -323,20 +323,14 @@
 
 (define (anthropic-do-http-request base-url api-key path body)
   (define url-str (string-append (string-trim base-url "/") path))
-  (define uri (string->url url-str))
   (define headers
     (list (format "x-api-key: ~a" api-key)
           (format "anthropic-version: ~a" ANTHROPIC-VERSION)
           "Content-Type: application/json"))
-  (define body-bytes (jsexpr->bytes body))
-  ;; Wrap entire request in overall timeout (SEC-11)
-  (call-with-request-timeout (lambda ()
-                               (define-values (status-line response-headers response-port)
-                                 (http-sendrecv uri 'POST #:headers headers #:data body-bytes))
-                               (define response-body (read-response-body response-port))
-                               ;; Check HTTP status
-                               (anthropic-check-http-status! status-line response-body)
-                               (bytes->jsexpr response-body))))
+  (make-provider-http-request url-str
+                              headers
+                              (jsexpr->bytes body)
+                              #:status-checker anthropic-check-http-status!))
 
 ;; ============================================================
 ;; Provider constructor

--- a/llm/azure-openai.rkt
+++ b/llm/azure-openai.rkt
@@ -41,33 +41,11 @@
                    (if (string-contains? path "?") "&" "?")
                    "api-version="
                    api-version))
-  (define uri (string->url url-str))
-  (define host (url-host uri))
-  (define url-port (url-port uri))
-  (define ssl? (equal? (url-scheme uri) "https"))
-  (define path-str
-    (string-append "/" (string-join (map (lambda (p) (path/param-path p)) (url-path uri)) "/")))
   (define headers (list (format "api-key: ~a" api-key) "Content-Type: application/json"))
-  (define body-bytes (jsexpr->bytes body))
-  (call-with-request-timeout (lambda ()
-                               (define-values (status-line response-headers response-port)
-                                 (if url-port
-                                     (http-sendrecv host
-                                                    path-str
-                                                    #:port url-port
-                                                    #:ssl? ssl?
-                                                    #:method "POST"
-                                                    #:headers headers
-                                                    #:data body-bytes)
-                                     (http-sendrecv host
-                                                    path-str
-                                                    #:ssl? ssl?
-                                                    #:method "POST"
-                                                    #:headers headers
-                                                    #:data body-bytes)))
-                               (define response-body (read-response-body/timeout response-port))
-                               (check-azure-status! status-line response-body)
-                               (bytes->jsexpr response-body))))
+  (make-provider-http-request url-str
+                              headers
+                              (jsexpr->bytes body)
+                              #:status-checker check-azure-status!))
 
 (define (check-azure-status! status-line body-bytes)
   (define status-code

--- a/llm/gemini.rkt
+++ b/llm/gemini.rkt
@@ -383,17 +383,11 @@
 (define (gemini-do-http-request base-url api-key model body)
   (define url-str
     (string-append (string-trim base-url "/") "/v1beta/models/" model ":generateContent"))
-  (define uri (string->url url-str))
   (define headers (list "Content-Type: application/json" (format "x-goog-api-key: ~a" api-key)))
-  (define body-bytes (jsexpr->bytes body))
-  ;; Wrap entire request in overall timeout (SEC-11)
-  (call-with-request-timeout (lambda ()
-                               (define-values (status-line response-headers response-port)
-                                 (http-sendrecv uri 'POST #:headers headers #:data body-bytes))
-                               (define response-body (read-response-body response-port))
-                               ;; Check HTTP status
-                               (gemini-check-http-status! status-line response-body)
-                               (bytes->jsexpr response-body))))
+  (make-provider-http-request url-str
+                              headers
+                              (jsexpr->bytes body)
+                              #:status-checker gemini-check-http-status!))
 
 ;; ============================================================
 ;; Provider constructor

--- a/llm/http-helpers.rkt
+++ b/llm/http-helpers.rkt
@@ -1,16 +1,29 @@
 #lang racket/base
 
-;; llm/http-helpers.rkt — Shared HTTP error handling utilities
+;; llm/http-helpers.rkt — Shared HTTP utilities for LLM providers
 ;;
-;; Common helpers for parsing HTTP status lines and raising errors.
-;; Used by anthropic.rkt, gemini.rkt, and openai-compatible.rkt.
+;; Common helpers for:
+;;   - HTTP request execution (make-provider-http-request)
+;;   - Status checking with provider-specific error messages
+;;   - Parsing HTTP status lines and raising structured errors
+;;
+;; Used by anthropic.rkt, gemini.rkt, openai-compatible.rkt, azure-openai.rkt.
 
 (require racket/contract
-         "provider-errors.rkt")
+         racket/string
+         racket/port
+         json
+         net/url
+         net/http-client
+         "provider-errors.rkt"
+         "stream.rkt")
 
 (provide extract-status-code
          http-error?
-         raise-http-error!)
+         raise-http-error!
+         ;; Consolidated HTTP helpers (QUAL-02)
+         make-provider-http-request
+         check-provider-status!)
 
 ;; ============================================================
 ;; Contracts
@@ -21,7 +34,7 @@
 (define response-body/c (or/c bytes? string?))
 
 ;; ============================================================
-;; Helpers
+;; Existing helpers
 ;; ============================================================
 
 ;; Parse "HTTP/N.N NNN ..." → integer status code.
@@ -47,3 +60,124 @@
   (if category
       (raise (provider-error message (current-continuation-marks) status-code category))
       (raise (exn:fail message (current-continuation-marks)))))
+
+;; ============================================================
+;; Consolidated HTTP request (QUAL-02)
+;; ============================================================
+
+;; make-provider-http-request : string? (listof string?) bytes?
+;;   [#:timeout exact-positive-integer?]
+;;   [#:status-checker (bytes? bytes? -> void?)]
+;;   -> jsexpr?
+;;
+;; Shared HTTP POST helper for LLM providers.
+;; Handles URL parsing, http-sendrecv, body reading, status checking, and JSON parsing.
+;; Providers supply their own headers and optional status-checker callback.
+;;
+;; Example:
+;;   (make-provider-http-request
+;;     "https://api.openai.com/v1/chat/completions"
+;;     (list "Authorization: Bearer ..." "Content-Type: application/json")
+;;     (jsexpr->bytes body)
+;;     #:status-checker check-http-status!)
+(define (make-provider-http-request url-str
+                                    headers
+                                    body-bytes
+                                    #:timeout [timeout-secs #f]
+                                    #:status-checker [status-checker #f])
+  (define uri (string->url url-str))
+  (define effective-timeout (or timeout-secs (current-http-request-timeout)))
+  (call-with-request-timeout (lambda ()
+                               (define-values (status-line response-headers response-port)
+                                 (http-sendrecv uri 'POST #:headers headers #:data body-bytes))
+                               (define response-body (read-response-body/timeout response-port))
+                               (when status-checker
+                                 (status-checker status-line response-body))
+                               (bytes->jsexpr response-body))
+                             #:timeout effective-timeout))
+
+;; ============================================================
+;; Consolidated status checker (QUAL-02)
+;; ============================================================
+
+;; check-provider-status! : string? bytes? bytes? -> void?
+;;
+;; Generic HTTP status checker with provider name for error messages.
+;; Handles common status codes (301-303 redirects, 401, 403, 429, 5xx)
+;; with provider-specific messages.
+;;
+;; Example:
+;;   (check-provider-status! "Anthropic" status-line response-body)
+(define (check-provider-status! provider-name status-line response-body)
+  (define status-code (extract-status-code status-line))
+  (define response-bytes
+    (if (bytes? response-body)
+        response-body
+        (string->bytes/utf-8 response-body)))
+  (define status-str
+    (if (bytes? status-line)
+        (bytes->string/utf-8 status-line)
+        status-line))
+  (cond
+    ;; Redirects
+    [(and (>= status-code 300) (< status-code 400))
+     (raise-http-error!
+      (format "~a API request redirected (~a: ~a). Check your base-url in config.json."
+              provider-name
+              status-code
+              status-str))]
+    ;; Authentication
+    [(= status-code 401)
+     (raise-http-error! (format "~a API authentication failed (401)" provider-name) status-code)]
+    ;; Forbidden
+    [(= status-code 403)
+     (raise-http-error! (format "~a API forbidden (403)" provider-name) status-code)]
+    ;; Rate limited
+    [(= status-code 429)
+     (define error-text (safe-extract-error-text response-bytes))
+     (raise-http-error!
+      (format "~a API rate limited (429). Please wait and try again.\n~a" provider-name error-text)
+      status-code)]
+    ;; Bad request
+    [(= status-code 400)
+     (define error-text (safe-extract-error-text response-bytes))
+     (raise-http-error! (format "~a API bad request (400): ~a" provider-name error-text) status-code)]
+    ;; Server errors
+    [(>= status-code 500)
+     (define error-text (safe-extract-error-text response-bytes))
+     (raise-http-error! (format "~a API server error (~a): ~a" provider-name status-code error-text)
+                        status-code)]
+    ;; Other client errors
+    [(http-error? status-code)
+     (define error-text (safe-extract-error-text response-bytes))
+     (raise-http-error! (format "~a API error (~a): ~a" provider-name status-code error-text)
+                        status-code)]))
+
+;; Safe extraction of error text from response body bytes.
+;; Returns a readable string or a fallback message.
+(define (safe-extract-error-text response-bytes)
+  (with-handlers ([exn:fail? (lambda (_)
+                               (format "<binary body ~a bytes>" (bytes-length response-bytes)))])
+    (define jsexpr (bytes->jsexpr response-bytes))
+    (or (extract-error-message jsexpr) (format "~a" jsexpr))))
+
+;; Extract a readable error message from a JSON error response.
+(define (extract-error-message jsexpr)
+  (cond
+    [(not (hash? jsexpr)) #f]
+    [(hash-has-key? jsexpr 'error)
+     (define err (hash-ref jsexpr 'error))
+     (cond
+       [(hash? err)
+        (cond
+          [(hash-has-key? err 'message)
+           (define msg (hash-ref err 'message))
+           (if (string? msg) msg #f)]
+          [(hash-has-key? err 'code) (format "Error code: ~a" (hash-ref err 'code))]
+          [else #f])]
+       [(string? err) err]
+       [else #f])]
+    [(hash-has-key? jsexpr 'message)
+     (define msg (hash-ref jsexpr 'message))
+     (if (string? msg) msg #f)]
+    [else #f]))

--- a/llm/openai-compatible.rkt
+++ b/llm/openai-compatible.rkt
@@ -119,41 +119,18 @@
 
 (define (do-http-request base-url api-key path body)
   (define url-str (string-append (string-trim base-url "/") path))
-  (define uri (string->url url-str))
-  (define host (url-host uri))
-  (define port (url-port uri))
-  (define ssl? (equal? (url-scheme uri) "https"))
-  (define path-str
-    (string-append "/" (string-join (map (lambda (p) (path/param-path p)) (url-path uri)) "/")))
   (define headers (list (format "Authorization: Bearer ~a" api-key) "Content-Type: application/json"))
-  (define body-bytes (jsexpr->bytes body))
   ;; v0.14.2 Wave 3: per-model timeout via effective-request-timeout-for
   (define model-name (and (hash? body) (hash-ref body 'model #f)))
   (define timeout-secs
     (if model-name
         (effective-request-timeout-for model-name)
         (current-http-request-timeout)))
-  ;; Wrap entire request in overall timeout (SEC-11)
-  (call-with-request-timeout (lambda ()
-                               (define-values (status-line response-headers response-port)
-                                 (if port
-                                     (http-sendrecv host
-                                                    path-str
-                                                    #:port port
-                                                    #:ssl? ssl?
-                                                    #:method "POST"
-                                                    #:headers headers
-                                                    #:data body-bytes)
-                                     (http-sendrecv host
-                                                    path-str
-                                                    #:ssl? ssl?
-                                                    #:method "POST"
-                                                    #:headers headers
-                                                    #:data body-bytes)))
-                               (define response-body (read-response-body/timeout response-port))
-                               (check-http-status! status-line response-body)
-                               (bytes->jsexpr response-body))
-                             #:timeout timeout-secs))
+  (make-provider-http-request url-str
+                              headers
+                              (jsexpr->bytes body)
+                              #:timeout timeout-secs
+                              #:status-checker check-http-status!))
 
 ;; ============================================================
 ;; HTTP status check helper


### PR DESCRIPTION
Addresses #1928.

feat: HTTP helper consolidation + CI version matrix (QUAL-02, MAT-01, MAT-06) (#1928)

HTTP-01: Add make-provider-http-request and check-provider-status! to http-helpers.rkt
  - Shared HTTP POST helper with timeout, status checking, and JSON parsing
  - Consolidated error text extraction (extract-error-message, safe-extract-error-text)
HTTP-02: Refactor openai-compatible.rkt do-http-request to use shared helper
HTTP-03: Refactor anthropic.rkt anthropic-do-http-request to use shared helper
HTTP-04: Refactor gemini.rkt gemini-do-http-request to use shared helper
HTTP-05: Refactor azure-openai.rkt azure-do-http-request to use shared helper
HTTP-06: All 305+ provider tests passing after refactor
CI-01: Add Racket version matrix [8.10, 8.12] to ci.yml test job
CI-02: Parameterize Racket installer URL in release.yml smoke job via env var
  - Bumped default Racket version in composite action to 8.12