### PR TITLE
feat: GSD planning/execution boundary enforcement (#1940)

Adds gsd-mode state machine (#f → planning → plan-written → executing)
with tool-call-pre hook that blocks edit/write/bash after PLAN is written
and blocks planning-write during /go execution.

Closes #1940, #1941, #1942, #1943

### DIFF
--- a/extensions/gsd-planning.rkt
+++ b/extensions/gsd-planning.rkt
@@ -28,7 +28,9 @@
          handle-planning-read
          handle-planning-write
          planning-implement-prompt
-         pinned-planning-dir)
+         pinned-planning-dir
+         gsd-mode
+         gsd-tool-guard)
 
 ;; ============================================================
 ;; Constants
@@ -41,6 +43,12 @@
 ;; same .planning/ folder, even if the LLM guesses a different base_dir.
 ;; Uses a parameter so tests can override it per-scope.
 (define pinned-planning-dir (make-parameter #f))
+
+;; GSD workflow mode: #f | 'planning | 'plan-written | 'executing
+;; Set by /plan (→ 'planning), transitions to 'plan-written after planning-write PLAN
+;; succeeds. Set to 'executing on /go. Used by tool-call-pre hook to block
+;; out-of-scope calls.
+(define gsd-mode (make-parameter #f))
 
 ;; Resolve the project root by walking up from 'start-dir' looking for
 ;; a directory containing .planning/, q/, BLUEPRINT/, or .git/.
@@ -148,7 +156,9 @@
     [(not path) #f]
     [(not (file-exists? path)) #f]
     [(json-artifact? name)
-     (with-handlers ([exn:fail? (lambda (e) (log-warning (format "gsd-planning/read: ~a" (exn-message e))) #f)])
+     (with-handlers ([exn:fail? (lambda (e)
+                                  (log-warning (format "gsd-planning/read: ~a" (exn-message e)))
+                                  #f)])
        (call-with-input-file path (lambda (in) (read-json in))))]
     [else (call-with-input-file path (lambda (in) (port->string in)))]))
 
@@ -256,11 +266,16 @@
           (let ([result-path (write-planning-artifact! base-dir name parsed-content)])
             (if (not result-path)
                 (make-error-result (format "Failed to write artifact '~a'" name))
-                (make-success-result (list (hasheq 'type
-                                                   "text"
-                                                   'text
-                                                   (format "Written: ~a"
-                                                           (path->string result-path)))))))]))]))
+                (begin
+                  ;; Transition from planning to plan-written mode.
+                  ;; This blocks further write/edit/bash calls until /go is invoked.
+                  (when (and (eq? (gsd-mode) 'planning) (string=? name "PLAN"))
+                    (gsd-mode 'plan-written))
+                  (make-success-result (list (hasheq 'type
+                                                     "text"
+                                                     'text
+                                                     (format "Written: ~a"
+                                                             (path->string result-path))))))))]))]))
 
 ;; ============================================================
 ;; Extension definition
@@ -341,6 +356,7 @@
        [(not plan-content)
         (hook-amend (hasheq 'text "No PLAN found in .planning/. Use /plan <task> to create one."))]
        [else
+        (gsd-mode 'executing)
         (define state-content (read-planning-artifact base-dir "STATE"))
         (define state-note
           (if state-content
@@ -383,6 +399,8 @@
                          (and (> (string-length rest) 0) rest)))))
            =>
            (lambda (args)
+             ;; Reset mode for new planning session
+             (gsd-mode 'planning)
              ;; v0.19.12 W2: Detect stale existing PLAN.md and inject warning
              (define existing-plan (read-planning-artifact base-dir "PLAN"))
              (define stale-warning
@@ -402,6 +420,25 @@
                [else content]))
            (hook-amend (hasheq 'text text))])])]))
 
+;; ============================================================
+;; GSD mode tool guard (tool-call-pre hook handler)
+;; ============================================================
+
+;; Block edit/write/bash after PLAN written (awaiting /go).
+;; Block planning-write during /go (plan is frozen during execution).
+;; All other tool calls pass through.
+(define (gsd-tool-guard payload)
+  (define mode (gsd-mode))
+  (define tool-name (hash-ref payload 'tool-name #f))
+  (cond
+    ;; After plan written, block write tools until /go
+    [(and (eq? mode 'plan-written) (member tool-name '("edit" "write" "bash")))
+     (hook-block "Plan written to PLAN.md. Use /go to start implementing.")]
+    ;; During /go, block plan rewrites
+    [(and (eq? mode 'executing) (equal? tool-name "planning-write"))
+     (hook-block "Cannot update plan during /go. Focus on executing the existing plan.")]
+    [else (hook-pass payload)]))
+
 (define-q-extension gsd-planning-extension
                     #:version "1.0.0"
                     #:api-version "1"
@@ -410,6 +447,8 @@
                     #:on register-shortcuts
                     register-gsd-commands
                     #:on execute-command
-                    handle-execute-command)
+                    handle-execute-command
+                    #:on tool-call-pre
+                    gsd-tool-guard)
 
 (define the-extension gsd-planning-extension)

--- a/tests/test-gsd-planning-boundary.rkt
+++ b/tests/test-gsd-planning-boundary.rkt
@@ -1,0 +1,260 @@
+#lang racket
+
+;; tests/test-gsd-planning-boundary.rkt — GSD planning/execution boundary tests
+;;
+;; Tests for v0.20.2 Wave 0: Server-side planning/execution boundary enforcement.
+;; Covers:
+;;   - gsd-mode state machine transitions
+;;   - tool-call-pre hook blocks write tools after PLAN written
+;;   - tool-call-pre hook blocks planning-write during /go
+;;   - Mode resets on new /plan and /go invocations
+
+(require rackunit
+         racket/file
+         racket/string
+         "../extensions/gsd-planning.rkt"
+         "../extensions/context.rkt"
+         "../extensions/api.rkt"
+         "../extensions/hooks.rkt"
+         "../tools/tool.rkt"
+         "../util/hook-types.rkt"
+         "../agent/event-bus.rkt")
+
+;; ============================================================
+;; Helpers
+;; ============================================================
+
+(define (make-temp-planning-dir)
+  (define dir (make-temporary-file "gsd-boundary-test-~a" 'directory))
+  dir)
+
+(define (cleanup-temp-dir dir)
+  (when (directory-exists? dir)
+    (delete-directory/files dir)))
+
+(define (with-temp-dir proc)
+  (define dir (make-temp-planning-dir))
+  (with-handlers ([exn:fail? (lambda (e)
+                               (cleanup-temp-dir dir)
+                               (raise e))])
+    (begin0 (proc dir)
+      (cleanup-temp-dir dir))))
+
+(define (with-mode mode proc)
+  (define saved (gsd-mode))
+  (gsd-mode mode)
+  (with-handlers ([exn:fail? (lambda (e)
+                               (gsd-mode saved)
+                               (raise e))])
+    (begin0 (proc)
+      (gsd-mode saved))))
+
+;; ============================================================
+;; gsd-mode state machine tests
+;; ============================================================
+
+(test-case "gsd-mode defaults to #f"
+  (check-equal? (gsd-mode) #f))
+
+(test-case "gsd-mode can be set to 'planning"
+  (with-mode 'planning (lambda () (check-eq? (gsd-mode) 'planning))))
+
+(test-case "gsd-mode can be set to 'plan-written"
+  (with-mode 'plan-written (lambda () (check-eq? (gsd-mode) 'plan-written))))
+
+(test-case "gsd-mode can be set to 'executing"
+  (with-mode 'executing (lambda () (check-eq? (gsd-mode) 'executing))))
+
+(test-case "gsd-mode can be reset to #f"
+  (with-mode 'planning
+             (lambda ()
+               (gsd-mode #f)
+               (check-equal? (gsd-mode) #f))))
+
+;; ============================================================
+;; gsd-tool-guard tests (tool-call-pre hook)
+;; ============================================================
+
+(test-case "gsd-tool-guard passes when mode is #f (idle)"
+  (with-mode #f
+             (lambda ()
+               (define payload (hasheq 'tool-name "edit"))
+               (define result (gsd-tool-guard payload))
+               (check-eq? (hook-result-action result) 'pass))))
+
+(test-case "gsd-tool-guard passes when mode is 'planning"
+  (with-mode 'planning
+             (lambda ()
+               (define payload (hasheq 'tool-name "edit"))
+               (define result (gsd-tool-guard payload))
+               (check-eq? (hook-result-action result) 'pass))))
+
+(test-case "gsd-tool-guard blocks edit in 'plan-written mode"
+  (with-mode 'plan-written
+             (lambda ()
+               (define payload (hasheq 'tool-name "edit"))
+               (define result (gsd-tool-guard payload))
+               (check-eq? (hook-result-action result) 'block)
+               (check-true (string-contains? (hook-result-payload result) "/go")))))
+
+(test-case "gsd-tool-guard blocks write in 'plan-written mode"
+  (with-mode 'plan-written
+             (lambda ()
+               (define payload (hasheq 'tool-name "write"))
+               (define result (gsd-tool-guard payload))
+               (check-eq? (hook-result-action result) 'block))))
+
+(test-case "gsd-tool-guard blocks bash in 'plan-written mode"
+  (with-mode 'plan-written
+             (lambda ()
+               (define payload (hasheq 'tool-name "bash"))
+               (define result (gsd-tool-guard payload))
+               (check-eq? (hook-result-action result) 'block))))
+
+(test-case "gsd-tool-guard allows read in 'plan-written mode"
+  (with-mode 'plan-written
+             (lambda ()
+               (define payload (hasheq 'tool-name "read"))
+               (define result (gsd-tool-guard payload))
+               (check-eq? (hook-result-action result) 'pass))))
+
+(test-case "gsd-tool-guard allows planning-read in 'plan-written mode"
+  (with-mode 'plan-written
+             (lambda ()
+               (define payload (hasheq 'tool-name "planning-read"))
+               (define result (gsd-tool-guard payload))
+               (check-eq? (hook-result-action result) 'pass))))
+
+(test-case "gsd-tool-guard allows grep in 'plan-written mode"
+  (with-mode 'plan-written
+             (lambda ()
+               (define payload (hasheq 'tool-name "grep"))
+               (define result (gsd-tool-guard payload))
+               (check-eq? (hook-result-action result) 'pass))))
+
+(test-case "gsd-tool-guard allows find in 'plan-written mode"
+  (with-mode 'plan-written
+             (lambda ()
+               (define payload (hasheq 'tool-name "find"))
+               (define result (gsd-tool-guard payload))
+               (check-eq? (hook-result-action result) 'pass))))
+
+(test-case "gsd-tool-guard blocks planning-write in 'executing mode"
+  (with-mode 'executing
+             (lambda ()
+               (define payload (hasheq 'tool-name "planning-write"))
+               (define result (gsd-tool-guard payload))
+               (check-eq? (hook-result-action result) 'block)
+               (check-true (string-contains? (hook-result-payload result) "Cannot update plan")))))
+
+(test-case "gsd-tool-guard allows edit in 'executing mode"
+  (with-mode 'executing
+             (lambda ()
+               (define payload (hasheq 'tool-name "edit"))
+               (define result (gsd-tool-guard payload))
+               (check-eq? (hook-result-action result) 'pass))))
+
+(test-case "gsd-tool-guard allows write in 'executing mode"
+  (with-mode 'executing
+             (lambda ()
+               (define payload (hasheq 'tool-name "write"))
+               (define result (gsd-tool-guard payload))
+               (check-eq? (hook-result-action result) 'pass))))
+
+(test-case "gsd-tool-guard allows bash in 'executing mode"
+  (with-mode 'executing
+             (lambda ()
+               (define payload (hasheq 'tool-name "bash"))
+               (define result (gsd-tool-guard payload))
+               (check-eq? (hook-result-action result) 'pass))))
+
+(test-case "gsd-tool-guard allows planning-read in 'executing mode"
+  (with-mode 'executing
+             (lambda ()
+               (define payload (hasheq 'tool-name "planning-read"))
+               (define result (gsd-tool-guard payload))
+               (check-eq? (hook-result-action result) 'pass))))
+
+;; ============================================================
+;; Mode transition via handle-planning-write tests
+;; ============================================================
+
+(test-case "planning-write PLAN transitions mode from 'planning to 'plan-written"
+  (with-temp-dir
+   (lambda (dir)
+     (parameterize ([pinned-planning-dir dir])
+       (with-mode
+        'planning
+        (lambda ()
+          (define args (hasheq 'artifact "PLAN" 'content "# Test Plan"))
+          (define result (handle-planning-write args))
+          (check-false (tool-result-is-error? result) "planning-write should succeed")
+          (check-eq? (gsd-mode) 'plan-written "mode should transition to plan-written")))))))
+
+(test-case "planning-write non-PLAN artifact does not change mode"
+  (with-temp-dir (lambda (dir)
+                   (parameterize ([pinned-planning-dir dir])
+                     (with-mode 'planning
+                                (lambda ()
+                                  (define args (hasheq 'artifact "STATE" 'content "# State"))
+                                  (define result (handle-planning-write args))
+                                  (check-false (tool-result-is-error? result))
+                                  (check-eq? (gsd-mode) 'planning "mode should remain planning")))))))
+
+(test-case "planning-write PLAN does not change mode when not in 'planning"
+  (with-temp-dir (lambda (dir)
+                   (parameterize ([pinned-planning-dir dir])
+                     ;; Mode is #f by default
+                     (define args (hasheq 'artifact "PLAN" 'content "# Plan"))
+                     (define result (handle-planning-write args))
+                     (check-false (tool-result-is-error? result))
+                     (check-equal? (gsd-mode) #f "mode should remain #f")))))
+
+;; ============================================================
+;; Full workflow integration tests
+;; ============================================================
+
+(test-case "full workflow: /plan → write PLAN → blocked edit → /go → edit allowed"
+  (with-temp-dir (lambda (dir)
+                   (parameterize ([pinned-planning-dir dir])
+                     ;; Step 1: /plan sets mode to 'planning
+                     (gsd-mode 'planning)
+                     (check-eq? (gsd-mode) 'planning)
+
+                     ;; Step 2: writing PLAN transitions to 'plan-written
+                     (define write-result
+                       (handle-planning-write (hasheq 'artifact "PLAN" 'content "# Plan")))
+                     (check-false (tool-result-is-error? write-result))
+                     (check-eq? (gsd-mode) 'plan-written)
+
+                     ;; Step 3: edit is blocked in 'plan-written mode
+                     (define guard-result (gsd-tool-guard (hasheq 'tool-name "edit")))
+                     (check-eq? (hook-result-action guard-result) 'block)
+
+                     ;; Step 4: /go sets mode to 'executing
+                     (gsd-mode 'executing)
+                     (check-eq? (gsd-mode) 'executing)
+
+                     ;; Step 5: edit is allowed in 'executing mode
+                     (define guard-result2 (gsd-tool-guard (hasheq 'tool-name "edit")))
+                     (check-eq? (hook-result-action guard-result2) 'pass)
+
+                     ;; Step 6: planning-write is blocked in 'executing mode
+                     (define guard-result3 (gsd-tool-guard (hasheq 'tool-name "planning-write")))
+                     (check-eq? (hook-result-action guard-result3) 'block)
+
+                     ;; Cleanup
+                     (gsd-mode #f)))))
+
+(test-case "new /plan resets mode from 'plan-written"
+  ;; Simulating starting a fresh planning session
+  (with-mode 'plan-written
+             (lambda ()
+               (gsd-mode 'planning)
+               (check-eq? (gsd-mode) 'planning))))
+
+(test-case "new /go resets mode from 'plan-written"
+  (with-mode 'plan-written
+             (lambda ()
+               (gsd-mode 'executing)
+               (check-eq? (gsd-mode) 'executing))))


### PR DESCRIPTION
Addresses #1940.

feat: GSD planning/execution boundary enforcement (#1940)

Adds gsd-mode state machine (#f → planning → plan-written → executing)
with tool-call-pre hook that blocks edit/write/bash after PLAN is written
and blocks planning-write during /go execution.

Closes #1940, #1941, #1942, #1943