### PR TITLE
feat: dynamic edit limit 500→1200 during /go execution (#1944)

Converts MAX-OLD-TEXT-LEN constant to current-max-old-text-len parameter.
Raised to 1200 when /go starts execution, reset to 500 during /plan.

Closes #1944, #1945, #1946

### DIFF
--- a/extensions/gsd-planning.rkt
+++ b/extensions/gsd-planning.rkt
@@ -16,7 +16,8 @@
          "ext-commands.rkt"
          "context.rkt"
          "hooks.rkt"
-         "../tools/tool.rkt")
+         "../tools/tool.rkt"
+         (only-in "../tools/builtins/edit.rkt" current-max-old-text-len))
 
 (provide the-extension
          gsd-planning-extension
@@ -357,6 +358,8 @@
         (hook-amend (hasheq 'text "No PLAN found in .planning/. Use /plan <task> to create one."))]
        [else
         (gsd-mode 'executing)
+        ;; Raise edit limit during execution mode (500 → 1200)
+        (current-max-old-text-len 1200)
         (define state-content (read-planning-artifact base-dir "STATE"))
         (define state-note
           (if state-content
@@ -401,6 +404,8 @@
            (lambda (args)
              ;; Reset mode for new planning session
              (gsd-mode 'planning)
+             ;; Reset edit limit to default during planning
+             (current-max-old-text-len 500)
              ;; v0.19.12 W2: Detect stale existing PLAN.md and inject warning
              (define existing-plan (read-planning-artifact base-dir "PLAN"))
              (define stale-warning

--- a/tests/test-gsd-planning-edit-limit.rkt
+++ b/tests/test-gsd-planning-edit-limit.rkt
@@ -1,0 +1,95 @@
+#lang racket
+
+;; tests/test-gsd-planning-edit-limit.rkt — Dynamic edit limit tests
+;;
+;; Tests for v0.20.2 Wave 1: Dynamic edit limit (500 default, 1200 during /go).
+
+(require rackunit
+         racket/file
+         racket/string
+         "../tools/builtins/edit.rkt"
+         (only-in "../tools/tool.rkt" tool-result-is-error?))
+
+;; ============================================================
+;; Parameter tests
+;; ============================================================
+
+(test-case "current-max-old-text-len defaults to 500"
+  (check-equal? (current-max-old-text-len) 500))
+
+(test-case "current-max-old-text-len can be raised"
+  (parameterize ([current-max-old-text-len 1200])
+    (check-equal? (current-max-old-text-len) 1200)))
+
+(test-case "current-max-old-text-len resets after parameterize"
+  (parameterize ([current-max-old-text-len 1200])
+    (check-equal? (current-max-old-text-len) 1200))
+  (check-equal? (current-max-old-text-len) 500))
+
+(test-case "current-max-old-text-len can be set and restored"
+  (define saved (current-max-old-text-len))
+  (current-max-old-text-len 1200)
+  (check-equal? (current-max-old-text-len) 1200)
+  (current-max-old-text-len saved)
+  (check-equal? (current-max-old-text-len) saved))
+
+;; ============================================================
+;; Edit tool respects dynamic limit
+;; ============================================================
+
+(define (make-temp-file content)
+  (define dir (make-temporary-file "edit-limit-test-~a" 'directory))
+  (define f (build-path dir "test.txt"))
+  (display-to-file content f #:exists 'replace)
+  f)
+
+(define (cleanup-path p)
+  (when (file-exists? p)
+    (delete-file p))
+  (define dir (path-only p))
+  (when (and dir (directory-exists? dir))
+    (delete-directory/files dir)))
+
+(test-case "edit rejects old-text > 500 at default limit"
+  (define f (make-temp-file (make-string 600 #\x)))
+  (with-handlers ([exn:fail? (lambda (e)
+                               (cleanup-path f)
+                               (raise e))])
+    (define result
+      (tool-edit (hasheq 'path (path->string f) 'old-text (make-string 501 #\x) 'new-text "new")))
+    (check-true (tool-result-is-error? result))
+    (cleanup-path f)))
+
+(test-case "edit accepts old-text ≤ 500 at default limit"
+  (define f (make-temp-file (string-append "prefix" (make-string 500 #\x) "suffix")))
+  (with-handlers ([exn:fail? (lambda (e)
+                               (cleanup-path f)
+                               (raise e))])
+    (define result
+      (tool-edit
+       (hasheq 'path (path->string f) 'old-text (make-string 500 #\x) 'new-text "REPLACED")))
+    (check-false (tool-result-is-error? result))
+    (cleanup-path f)))
+
+(test-case "edit accepts old-text up to 1200 at raised limit"
+  (define long-text (make-string 1000 #\x))
+  (define f (make-temp-file (string-append "prefix" long-text "suffix")))
+  (with-handlers ([exn:fail? (lambda (e)
+                               (cleanup-path f)
+                               (raise e))])
+    (parameterize ([current-max-old-text-len 1200])
+      (define result
+        (tool-edit (hasheq 'path (path->string f) 'old-text long-text 'new-text "REPLACED")))
+      (check-false (tool-result-is-error? result)))
+    (cleanup-path f)))
+
+(test-case "edit rejects old-text > 1200 at raised limit"
+  (define f (make-temp-file (make-string 1300 #\x)))
+  (with-handlers ([exn:fail? (lambda (e)
+                               (cleanup-path f)
+                               (raise e))])
+    (parameterize ([current-max-old-text-len 1200])
+      (define result
+        (tool-edit (hasheq 'path (path->string f) 'old-text (make-string 1201 #\x) 'new-text "new")))
+      (check-true (tool-result-is-error? result)))
+    (cleanup-path f)))

--- a/tools/builtins/edit.rkt
+++ b/tools/builtins/edit.rkt
@@ -23,13 +23,14 @@
          (only-in "../../util/path-helpers.rkt" expand-home-path)
          (only-in "../../util/error-sanitizer.rkt" sanitize-error-message))
 
-(provide tool-edit)
+(provide tool-edit
+         current-max-old-text-len)
 
 ;; --------------------------------------------------
 ;; Constants
 ;; --------------------------------------------------
 
-(define MAX-OLD-TEXT-LEN 500)
+(define current-max-old-text-len (make-parameter 500))
 (define MAX-BACKUPS-PER-FILE 10)
 
 ;; --------------------------------------------------
@@ -45,7 +46,9 @@
   dir)
 
 (define (save-backup path-str content)
-  (with-handlers ([exn:fail? (lambda (e) (log-warning (format "edit/backup: ~a" (exn-message e))) #f)])
+  (with-handlers ([exn:fail? (lambda (e)
+                               (log-warning (format "edit/backup: ~a" (exn-message e)))
+                               #f)])
     (define dir (ensure-backup-dir))
     (define basename (file-name-from-path path-str))
     (define timestamp (format "~a" (inexact->exact (current-inexact-milliseconds))))
@@ -67,7 +70,9 @@
       (last parts)))
 
 (define (prune-old-backups dir basename)
-  (with-handlers ([exn:fail? (lambda (e) (log-warning (format "edit/prune: ~a" (exn-message e))) (void))])
+  (with-handlers ([exn:fail? (lambda (e)
+                               (log-warning (format "edit/prune: ~a" (exn-message e)))
+                               (void))])
     (define all (directory-list dir))
     (define matching
       (filter (lambda (f) (string-contains? (path->string f) basename))
@@ -204,12 +209,12 @@
 
               ;; W0.1: Old-text length limit
               (cond
-                [(> (string-length old-text) MAX-OLD-TEXT-LEN)
+                [(> (string-length old-text) (current-max-old-text-len))
                  (make-error-result
                   (format
                    "old-text is too long (~a chars, max ~a). Break your edit into smaller pieces — each edit should change ≤20 lines."
                    (string-length old-text)
-                   MAX-OLD-TEXT-LEN))]
+                   (current-max-old-text-len)))]
 
                 [else
                  ;; Check for ambiguity (multiple matches)
@@ -240,7 +245,10 @@
                     (cond
                       [(> delta-diff 2)
                        ;; Auto-revert: write back original content
-                       (with-handlers ([exn:fail? (lambda (e) (log-warning (format "edit/auto-revert: ~a" (exn-message e))) (void))])
+                       (with-handlers ([exn:fail? (lambda (e)
+                                                    (log-warning (format "edit/auto-revert: ~a"
+                                                                         (exn-message e)))
+                                                    (void))])
                          (display-to-file content path-str #:exists 'replace))
                        (make-error-result
                         (format
@@ -256,8 +264,8 @@
                        (with-handlers ([exn:fail:filesystem?
                                         (lambda (e)
                                           (make-error-result (sanitize-error-message
-                                                               (format "Write error: ~a"
-                                                                       (exn-message e)))))])
+                                                              (format "Write error: ~a"
+                                                                      (exn-message e)))))])
                          (call-with-output-file path-str
                                                 (lambda (out) (display new-content out))
                                                 #:exists 'replace)


### PR DESCRIPTION
Addresses #1944.

feat: dynamic edit limit 500→1200 during /go execution (#1944)

Converts MAX-OLD-TEXT-LEN constant to current-max-old-text-len parameter.
Raised to 1200 when /go starts execution, reset to 500 during /plan.

Closes #1944, #1945, #1946