### PR TITLE
feat: redundant read detection with per-file hints (#1947)

Tracks per-file read counts via tool-result-post hook. After 3+ reads
of the same file, appends a hint to use memory instead of re-reading.
Resets on /plan and /go mode transitions.

Closes #1947, #1948, #1949, #1950

### DIFF
--- a/extensions/gsd-planning.rkt
+++ b/extensions/gsd-planning.rkt
@@ -31,7 +31,9 @@
          planning-implement-prompt
          pinned-planning-dir
          gsd-mode
-         gsd-tool-guard)
+         gsd-tool-guard
+         reset-read-counts!
+         gsd-read-tracker)
 
 ;; ============================================================
 ;; Constants
@@ -360,6 +362,8 @@
         (gsd-mode 'executing)
         ;; Raise edit limit during execution mode (500 → 1200)
         (current-max-old-text-len 1200)
+        ;; Reset read counter for fresh execution
+        (reset-read-counts!)
         (define state-content (read-planning-artifact base-dir "STATE"))
         (define state-note
           (if state-content
@@ -406,6 +410,8 @@
              (gsd-mode 'planning)
              ;; Reset edit limit to default during planning
              (current-max-old-text-len 500)
+             ;; Reset read counter for fresh planning
+             (reset-read-counts!)
              ;; v0.19.12 W2: Detect stale existing PLAN.md and inject warning
              (define existing-plan (read-planning-artifact base-dir "PLAN"))
              (define stale-warning
@@ -424,6 +430,50 @@
                [(hash? content) (jsexpr->string content)]
                [else content]))
            (hook-amend (hasheq 'text text))])])]))
+
+;; ============================================================
+;; Redundant read detection (tool-result-post hook)
+;; ============================================================
+
+;; Tracks per-file read count to detect redundant reads.
+(define read-counts (make-hash))
+
+(define READ_HINT_THRESHOLD 3)
+
+(define (gsd-read-tracker payload)
+  (define tool-name (hash-ref payload 'tool-name #f))
+  (define result (hash-ref payload 'result #f))
+  (cond
+    ;; Only track successful reads with path info
+    [(and (equal? tool-name "read") result (tool-result? result) (not (tool-result-is-error? result)))
+     (define details (tool-result-details result))
+     (define file-path (and (hash? details) (hash-ref details 'path #f)))
+     (cond
+       [(not file-path) (hook-pass payload)]
+       [else
+        (define new-count (add1 (hash-ref read-counts file-path 0)))
+        (hash-set! read-counts file-path new-count)
+        (cond
+          [(and (>= new-count READ_HINT_THRESHOLD) (= 0 (modulo new-count READ_HINT_THRESHOLD)))
+           (define hint-text
+             (format
+              "\n\n[HINT: You have read '~a' ~a times. Consider using your memory of previous reads instead of re-reading.]"
+              file-path
+              new-count))
+           (define content (tool-result-content result))
+           (define new-content
+             (append (if (list? content)
+                         content
+                         (list content))
+                     (list (hasheq 'type "text" 'text hint-text))))
+           (hook-amend (hasheq 'result
+                               (make-success-result new-content (tool-result-details result))))]
+          [else (hook-pass payload)])])]
+    [else (hook-pass payload)]))
+
+;; Reset read counts when entering a new mode
+(define (reset-read-counts!)
+  (hash-clear! read-counts))
 
 ;; ============================================================
 ;; GSD mode tool guard (tool-call-pre hook handler)
@@ -454,6 +504,8 @@
                     #:on execute-command
                     handle-execute-command
                     #:on tool-call-pre
-                    gsd-tool-guard)
+                    gsd-tool-guard
+                    #:on tool-result-post
+                    gsd-read-tracker)
 
 (define the-extension gsd-planning-extension)

--- a/tests/test-gsd-planning-read-tracker.rkt
+++ b/tests/test-gsd-planning-read-tracker.rkt
@@ -1,0 +1,124 @@
+#lang racket
+
+;; tests/test-gsd-planning-read-tracker.rkt — Redundant read detection tests
+;;
+;; Tests for v0.20.2 Wave 2: Per-file read count tracking with hints.
+
+(require rackunit
+         racket/file
+         "../extensions/gsd-planning.rkt"
+         "../tools/tool.rkt"
+         "../extensions/hooks.rkt")
+
+;; ============================================================
+;; Helpers
+;; ============================================================
+
+(define (make-success-read-result file-path text)
+  (make-success-result (list (hasheq 'type "text" 'text text)) (hasheq 'path file-path)))
+
+;; ============================================================
+;; Read counter state tests
+;; ============================================================
+
+(test-case "reset-read-counts! clears all counters"
+  (reset-read-counts!)
+  ;; Simulate some reads by calling tracker directly
+  (define result (make-success-read-result "/tmp/test.txt" "content"))
+  (gsd-read-tracker (hasheq 'tool-name "read" 'result result))
+  (gsd-read-tracker (hasheq 'tool-name "read" 'result result))
+  ;; Reset
+  (reset-read-counts!)
+  ;; After reset, next read should be count 1 again
+  (gsd-read-tracker (hasheq 'tool-name "read" 'result result))
+  ;; The tracker should pass through (not amend) since count is now 1
+  (check-true #t "completed without error"))
+
+(test-case "gsd-read-tracker ignores non-read tools"
+  (reset-read-counts!)
+  (define result (make-success-read-result "/tmp/test.txt" "content"))
+  (define hook-res (gsd-read-tracker (hasheq 'tool-name "edit" 'result result)))
+  (check-eq? (hook-result-action hook-res) 'pass))
+
+(test-case "gsd-read-tracker ignores error results"
+  (reset-read-counts!)
+  (define err-result (make-error-result "file not found"))
+  (define hook-res (gsd-read-tracker (hasheq 'tool-name "read" 'result err-result)))
+  (check-eq? (hook-result-action hook-res) 'pass))
+
+(test-case "gsd-read-tracker passes reads below threshold"
+  (reset-read-counts!)
+  (define result (make-success-read-result "/tmp/below.txt" "content"))
+  ;; Read twice (below threshold of 3)
+  (gsd-read-tracker (hasheq 'tool-name "read" 'result result))
+  (define hook-res (gsd-read-tracker (hasheq 'tool-name "read" 'result result)))
+  (check-eq? (hook-result-action hook-res) 'pass))
+
+(test-case "gsd-read-tracker amends result at threshold"
+  (reset-read-counts!)
+  (define result (make-success-read-result "/tmp/threshold.txt" "content"))
+  ;; Read 3 times to hit threshold
+  (gsd-read-tracker (hasheq 'tool-name "read" 'result result))
+  (gsd-read-tracker (hasheq 'tool-name "read" 'result result))
+  (define hook-res (gsd-read-tracker (hasheq 'tool-name "read" 'result result)))
+  (check-eq? (hook-result-action hook-res) 'amend))
+
+(test-case "gsd-read-tracker hint mentions file path and count"
+  (reset-read-counts!)
+  (define result (make-success-read-result "/tmp/hint-path.txt" "content"))
+  (gsd-read-tracker (hasheq 'tool-name "read" 'result result))
+  (gsd-read-tracker (hasheq 'tool-name "read" 'result result))
+  (define hook-res (gsd-read-tracker (hasheq 'tool-name "read" 'result result)))
+  (define amended-result (hash-ref (hook-result-payload hook-res) 'result))
+  ;; The amended result content should contain the hint
+  (define content (tool-result-content amended-result))
+  (define all-text (apply string-append (map (lambda (p) (hash-ref p 'text "")) content)))
+  (check-true (string-contains? all-text "hint-path.txt"))
+  (check-true (string-contains? all-text "3 times")))
+
+(test-case "gsd-read-tracker hints at multiples of threshold"
+  (reset-read-counts!)
+  (define result (make-success-read-result "/tmp/multi.txt" "content"))
+  ;; Reads 1-2: no hint
+  (gsd-read-tracker (hasheq 'tool-name "read" 'result result))
+  (gsd-read-tracker (hasheq 'tool-name "read" 'result result))
+  ;; Read 3: hint
+  (define res3 (gsd-read-tracker (hasheq 'tool-name "read" 'result result)))
+  (check-eq? (hook-result-action res3) 'amend)
+  ;; Reads 4-5: no hint
+  (check-eq? (hook-result-action (gsd-read-tracker (hasheq 'tool-name "read" 'result result))) 'pass)
+  (check-eq? (hook-result-action (gsd-read-tracker (hasheq 'tool-name "read" 'result result))) 'pass)
+  ;; Read 6: hint again
+  (define res6 (gsd-read-tracker (hasheq 'tool-name "read" 'result result)))
+  (check-eq? (hook-result-action res6) 'amend)
+  (define amended6 (hash-ref (hook-result-payload res6) 'result))
+  (define content6 (tool-result-content amended6))
+  (define all-text6 (apply string-append (map (lambda (p) (hash-ref p 'text "")) content6)))
+  (check-true (string-contains? all-text6 "6 times")))
+
+(test-case "gsd-read-tracker tracks different files independently"
+  (reset-read-counts!)
+  (define result-a (make-success-read-result "/tmp/file-a.txt" "a"))
+  (define result-b (make-success-read-result "/tmp/file-b.txt" "b"))
+  ;; Read file-a twice
+  (gsd-read-tracker (hasheq 'tool-name "read" 'result result-a))
+  (gsd-read-tracker (hasheq 'tool-name "read" 'result result-a))
+  ;; Read file-b twice
+  (gsd-read-tracker (hasheq 'tool-name "read" 'result result-b))
+  (gsd-read-tracker (hasheq 'tool-name "read" 'result result-b))
+  ;; Both at count 2, neither should hint
+  (check-eq? (hook-result-action (gsd-read-tracker (hasheq 'tool-name "read" 'result result-a)))
+             'amend)
+  (check-eq? (hook-result-action (gsd-read-tracker (hasheq 'tool-name "read" 'result result-b)))
+             'amend))
+
+(test-case "gsd-read-tracker ignores results without path in details"
+  (reset-read-counts!)
+  (define result-no-path (make-success-result (list (hasheq 'type "text" 'text "content")) (hasheq)))
+  (define hook-res (gsd-read-tracker (hasheq 'tool-name "read" 'result result-no-path)))
+  (check-eq? (hook-result-action hook-res) 'pass))
+
+(test-case "gsd-read-tracker ignores non-tool-result values"
+  (reset-read-counts!)
+  (define hook-res (gsd-read-tracker (hasheq 'tool-name "read" 'result "not a result")))
+  (check-eq? (hook-result-action hook-res) 'pass))


### PR DESCRIPTION
Addresses #1947.

feat: redundant read detection with per-file hints (#1947)

Tracks per-file read counts via tool-result-post hook. After 3+ reads
of the same file, appends a hint to use memory instead of re-reading.
Resets on /plan and /go mode transitions.

Closes #1947, #1948, #1949, #1950