### PR TITLE
feat: /go budget counter for read-only calls (#1951)

30 read-only call budget per /go session. Warns at ≤5 remaining,
blocks at <−3 overage. Tracks read/grep/find/ls/glob. Resets on
/go and /plan transitions.

Closes #1951, #1952, #1953, #1954

### DIFF
--- a/extensions/gsd-planning.rkt
+++ b/extensions/gsd-planning.rkt
@@ -33,7 +33,11 @@
          gsd-mode
          gsd-tool-guard
          reset-read-counts!
-         gsd-read-tracker)
+         gsd-read-tracker
+         go-read-budget
+         reset-go-budget!
+         GO-READ-BUDGET
+         READ-ONLY-TOOLS)
 
 ;; ============================================================
 ;; Constants
@@ -364,6 +368,8 @@
         (current-max-old-text-len 1200)
         ;; Reset read counter for fresh execution
         (reset-read-counts!)
+        ;; Reset read budget for fresh execution
+        (reset-go-budget!)
         (define state-content (read-planning-artifact base-dir "STATE"))
         (define state-note
           (if state-content
@@ -412,6 +418,8 @@
              (current-max-old-text-len 500)
              ;; Reset read counter for fresh planning
              (reset-read-counts!)
+             ;; Reset budget
+             (go-read-budget #f)
              ;; v0.19.12 W2: Detect stale existing PLAN.md and inject warning
              (define existing-plan (read-planning-artifact base-dir "PLAN"))
              (define stale-warning
@@ -476,11 +484,29 @@
   (hash-clear! read-counts))
 
 ;; ============================================================
+;; /go Budget Counter
+;; ============================================================
+
+;; Read-only tools that count against the budget
+(define READ-ONLY-TOOLS '("read" "grep" "find" "ls" "glob"))
+
+;; Budget: 30 read-only calls per /go session
+(define GO-READ-BUDGET 30)
+(define GO-READ-WARN-THRESHOLD 5) ; warn at ≤5 remaining
+(define GO-READ-BLOCK-THRESHOLD -3) ; block at <−3 (i.e., 33+ calls)
+
+(define go-read-budget (make-parameter #f))
+
+(define (reset-go-budget!)
+  (go-read-budget GO-READ-BUDGET))
+
+;; ============================================================
 ;; GSD mode tool guard (tool-call-pre hook handler)
 ;; ============================================================
 
 ;; Block edit/write/bash after PLAN written (awaiting /go).
 ;; Block planning-write during /go (plan is frozen during execution).
+;; Budget enforcement for read-only tools during /go.
 ;; All other tool calls pass through.
 (define (gsd-tool-guard payload)
   (define mode (gsd-mode))
@@ -492,6 +518,27 @@
     ;; During /go, block plan rewrites
     [(and (eq? mode 'executing) (equal? tool-name "planning-write"))
      (hook-block "Cannot update plan during /go. Focus on executing the existing plan.")]
+    ;; During /go, enforce read budget
+    [(and (eq? mode 'executing) (member tool-name READ-ONLY-TOOLS) (go-read-budget))
+     (define remaining (sub1 (go-read-budget)))
+     (go-read-budget remaining)
+     (cond
+       [(< remaining GO-READ-BLOCK-THRESHOLD)
+        ;; Hard block: way over budget
+        (hook-block
+         (format
+          "Read budget exhausted (~a read calls used, budget is ~a). Stop exploring and implement."
+          (- GO-READ-BUDGET remaining)
+          GO-READ-BUDGET))]
+       [(<= remaining GO-READ-WARN-THRESHOLD)
+        ;; Warning: amend tool call args to include a budget reminder
+        (hook-amend (hasheq 'args
+                            (hash-set (hash-ref payload 'args (hasheq))
+                                      '_budget-warning
+                                      (format "[BUDGET WARNING: ~a/~a read calls remaining]"
+                                              remaining
+                                              GO-READ-BUDGET))))]
+       [else (hook-pass payload)])]
     [else (hook-pass payload)]))
 
 (define-q-extension gsd-planning-extension

--- a/tests/test-gsd-planning-budget-counter.rkt
+++ b/tests/test-gsd-planning-budget-counter.rkt
@@ -1,0 +1,125 @@
+#lang racket
+
+;; tests/test-gsd-planning-budget-counter.rkt — /go budget counter tests
+;;
+;; Tests for v0.20.2 Wave 3: Read budget counter during /go execution.
+
+(require rackunit
+         "../extensions/gsd-planning.rkt"
+         "../extensions/hooks.rkt")
+
+;; ============================================================
+;; Parameter tests
+;; ============================================================
+
+(test-case "go-read-budget defaults to #f"
+  (go-read-budget #f)
+  (check-false (go-read-budget)))
+
+(test-case "reset-go-budget! sets budget to 30"
+  (reset-go-budget!)
+  (check-equal? (go-read-budget) 30))
+
+(test-case "GO-READ-BUDGET is 30"
+  (check-equal? GO-READ-BUDGET 30))
+
+(test-case "READ-ONLY-TOOLS includes read/grep/find"
+  (check-not-false (member "read" READ-ONLY-TOOLS))
+  (check-not-false (member "grep" READ-ONLY-TOOLS))
+  (check-not-false (member "find" READ-ONLY-TOOLS)))
+
+;; ============================================================
+;; Budget enforcement in gsd-tool-guard
+;; ============================================================
+
+(test-case "tool-guard passes write tools during executing without budget change"
+  (gsd-mode 'executing)
+  (reset-go-budget!)
+  (define res (gsd-tool-guard (hasheq 'tool-name "edit" 'args (hasheq))))
+  (check-eq? (hook-result-action res) 'pass)
+  ;; Budget should NOT be decremented for write tools
+  (check-equal? (go-read-budget) 30)
+  (gsd-mode #f))
+
+(test-case "tool-guard decrements budget for read during executing"
+  (gsd-mode 'executing)
+  (reset-go-budget!)
+  (gsd-tool-guard (hasheq 'tool-name "read" 'args (hasheq)))
+  (check-equal? (go-read-budget) 29)
+  (gsd-mode #f))
+
+(test-case "tool-guard passes reads with plenty of budget"
+  (gsd-mode 'executing)
+  (reset-go-budget!)
+  (define res (gsd-tool-guard (hasheq 'tool-name "read" 'args (hasheq))))
+  (check-eq? (hook-result-action res) 'pass)
+  (gsd-mode #f))
+
+(test-case "tool-guard warns when budget ≤5"
+  (gsd-mode 'executing)
+  (reset-go-budget!)
+  ;; Burn through 25 calls
+  (for ([_ (in-range 25)])
+    (gsd-tool-guard (hasheq 'tool-name "read" 'args (hasheq))))
+  ;; Budget should be 5 now
+  (check-equal? (go-read-budget) 5)
+  ;; Next read should trigger warning
+  (define res (gsd-tool-guard (hasheq 'tool-name "read" 'args (hasheq))))
+  (check-eq? (hook-result-action res) 'amend)
+  (gsd-mode #f))
+
+(test-case "tool-guard blocks when budget goes below -3"
+  (gsd-mode 'executing)
+  (reset-go-budget!)
+  ;; Burn through 33 calls (30 budget + 3 overage)
+  (for ([_ (in-range 33)])
+    (gsd-tool-guard (hasheq 'tool-name "read" 'args (hasheq))))
+  ;; Budget should be -3
+  (check-equal? (go-read-budget) -3)
+  ;; Next read should pass (block threshold is < -3, not ≤ -3)
+  (define res-at-neg3 (gsd-tool-guard (hasheq 'tool-name "read" 'args (hasheq))))
+  (check-eq? (hook-result-action res-at-neg3) 'block)
+  (gsd-mode #f))
+
+(test-case "tool-guard does not enforce budget when not in executing mode"
+  (gsd-mode 'planning)
+  (reset-go-budget!)
+  ;; Call read many times
+  (for ([_ (in-range 40)])
+    (gsd-tool-guard (hasheq 'tool-name "read" 'args (hasheq))))
+  ;; Budget should still be 30 — not decremented in planning mode
+  (check-equal? (go-read-budget) 30)
+  (gsd-mode #f))
+
+(test-case "tool-guard does not enforce budget when budget is #f"
+  (gsd-mode 'executing)
+  (go-read-budget #f)
+  (define res (gsd-tool-guard (hasheq 'tool-name "read" 'args (hasheq))))
+  (check-eq? (hook-result-action res) 'pass)
+  ;; Budget should still be #f
+  (check-false (go-read-budget))
+  (gsd-mode #f))
+
+(test-case "tool-guard blocks edit during plan-written"
+  (gsd-mode 'plan-written)
+  (define res (gsd-tool-guard (hasheq 'tool-name "edit" 'args (hasheq))))
+  (check-eq? (hook-result-action res) 'block)
+  (gsd-mode #f))
+
+(test-case "tool-guard blocks planning-write during executing"
+  (gsd-mode 'executing)
+  (reset-go-budget!)
+  (define res (gsd-tool-guard (hasheq 'tool-name "planning-write" 'args (hasheq))))
+  (check-eq? (hook-result-action res) 'block)
+  (gsd-mode #f))
+
+(test-case "budget is independent of read counter"
+  (gsd-mode 'executing)
+  (reset-go-budget!)
+  (reset-read-counts!)
+  ;; Budget counts all read-only tools, not just file reads
+  (gsd-tool-guard (hasheq 'tool-name "grep" 'args (hasheq)))
+  (gsd-tool-guard (hasheq 'tool-name "find" 'args (hasheq)))
+  (gsd-tool-guard (hasheq 'tool-name "ls" 'args (hasheq)))
+  (check-equal? (go-read-budget) 27)
+  (gsd-mode #f))


### PR DESCRIPTION
Addresses #1951.

feat: /go budget counter for read-only calls (#1951)

30 read-only call budget per /go session. Warns at ≤5 remaining,
blocks at <−3 overage. Tracks read/grep/find/ls/glob. Resets on
/go and /plan transitions.

Closes #1951, #1952, #1953, #1954