### PR TITLE
feat: extract GSD state into semaphore-protected module (Wave 0, #1961)

Wave 0 of v0.20.3 — Thread-Safe State Foundation (C1, C2, W2).

- NEW: extensions/gsd-planning-state.rkt — semaphore-protected shared state
  with atomic accessors for gsd-mode, pinned-planning-dir, go-read-budget,
  read-counts, and current-max-old-text-len.
- Convert pinned-planning-dir from make-parameter to box with semaphore (C2).
- Move current-max-old-text-len from tools/builtins/edit.rkt to state module.
- Add decrement-budget! for atomic read-modify-write (C1).
- Add reset-all-gsd-state! for atomic full-reset (W2).
- NEW: tests/test-gsd-planning-state.rkt — 23 tests including concurrent
  decrement (no lost updates), cross-thread visibility, atomic reset.
- Update all existing test files to use new setter API.
- All 144 GSD tests pass, 6095 total tests pass (0 failures).

Milestone: v0.20.3 — GSD Planning Architecture Remediation (#119).

### DIFF
--- a/extensions/gsd-planning-state.rkt
+++ b/extensions/gsd-planning-state.rkt
@@ -1,0 +1,154 @@
+#lang racket/base
+
+;; extensions/gsd-planning-state.rkt — Semaphore-protected shared state for GSD planning
+;;
+;; Extracted from gsd-planning.rkt and tools/builtins/edit.rkt.
+;; All cross-thread shared mutable state lives here with semaphore protection.
+;;
+;; Wave 0 of v0.20.3: Addresses C1 (race condition), C2 (pinned-planning-dir parameter),
+;; W2 (non-atomic resets).
+
+(require racket/contract)
+
+(provide gsd-mode
+         gsd-mode?
+         set-gsd-mode!
+         pinned-planning-dir
+         set-pinned-planning-dir!
+         go-read-budget
+         set-go-read-budget!
+         decrement-budget!
+         reset-go-budget!
+         GO-READ-BUDGET
+         GO-READ-WARN-THRESHOLD
+         GO-READ-BLOCK-THRESHOLD
+         read-counts
+         get-read-count
+         increment-read-count!
+         clear-read-counts!
+         current-max-old-text-len
+         set-current-max-old-text-len!
+         reset-all-gsd-state!
+         READ-ONLY-TOOLS)
+
+;; ============================================================
+;; Internal state storage
+;; ============================================================
+
+;; Single semaphore protects all state below.
+;; This is simpler and more correct than per-value semaphores because
+;; cross-thread operations (e.g. budget check + decrement) need to be atomic.
+(define state-sem (make-semaphore 1))
+
+;; GSD workflow mode: #f | 'planning | 'plan-written | 'executing
+(define gsd-mode-box (box #f))
+
+;; Pinned planning directory — set once during tool registration.
+;; Was a parameter (C2: thread-isolated); now a box for cross-thread visibility.
+(define pinned-dir-box (box #f))
+
+;; Read budget for /go execution sessions.
+(define budget-box (box #f))
+
+;; Dynamic edit limit (moved from tools/builtins/edit.rkt).
+(define edit-limit-box (box 500))
+
+;; Per-file read count for redundant-read detection.
+(define read-counts-box (box (make-hash)))
+
+;; ============================================================
+;; Constants
+;; ============================================================
+
+(define GO-READ-BUDGET 30)
+(define GO-READ-WARN-THRESHOLD 5)
+(define GO-READ-BLOCK-THRESHOLD -3)
+
+(define READ-ONLY-TOOLS '("read" "grep" "find" "ls" "glob"))
+
+;; ============================================================
+;; Semaphore-protected accessors
+;; ============================================================
+
+;; --- gsd-mode ---
+
+(define (gsd-mode)
+  (call-with-semaphore state-sem (lambda () (unbox gsd-mode-box))))
+
+(define (gsd-mode? v)
+  (eq? (gsd-mode) v))
+
+(define (set-gsd-mode! v)
+  (call-with-semaphore state-sem (lambda () (set-box! gsd-mode-box v))))
+
+;; --- pinned-planning-dir ---
+
+(define (pinned-planning-dir)
+  (call-with-semaphore state-sem (lambda () (unbox pinned-dir-box))))
+
+(define (set-pinned-planning-dir! v)
+  (call-with-semaphore state-sem (lambda () (set-box! pinned-dir-box v))))
+
+;; --- go-read-budget ---
+
+(define (go-read-budget)
+  (call-with-semaphore state-sem (lambda () (unbox budget-box))))
+
+(define (set-go-read-budget! v)
+  (call-with-semaphore state-sem (lambda () (set-box! budget-box v))))
+
+;; Atomic decrement-and-read: returns the NEW value after decrement.
+(define (decrement-budget!)
+  (call-with-semaphore state-sem
+                       (lambda ()
+                         (define new-val (sub1 (unbox budget-box)))
+                         (set-box! budget-box new-val)
+                         new-val)))
+
+(define (reset-go-budget!)
+  (call-with-semaphore state-sem (lambda () (set-box! budget-box GO-READ-BUDGET))))
+
+;; --- read-counts ---
+
+;; Returns a snapshot of the current read-counts hash.
+;; NOTE: This returns a COPY, not the live hash. For mutation, use
+;; get-read-count / increment-read-count! / clear-read-counts!.
+(define (read-counts)
+  (call-with-semaphore state-sem (lambda () (hash-copy (unbox read-counts-box)))))
+
+(define (get-read-count key)
+  (call-with-semaphore state-sem (lambda () (hash-ref (unbox read-counts-box) key 0))))
+
+(define (increment-read-count! key)
+  (call-with-semaphore state-sem
+                       (lambda ()
+                         (define h (unbox read-counts-box))
+                         (define new-count (add1 (hash-ref h key 0)))
+                         (hash-set! h key new-count)
+                         new-count)))
+
+(define (clear-read-counts!)
+  (call-with-semaphore state-sem (lambda () (set-box! read-counts-box (make-hash)))))
+
+;; --- current-max-old-text-len ---
+
+(define (current-max-old-text-len)
+  (call-with-semaphore state-sem (lambda () (unbox edit-limit-box))))
+
+(define (set-current-max-old-text-len! v)
+  (call-with-semaphore state-sem (lambda () (set-box! edit-limit-box v))))
+
+;; ============================================================
+;; Atomic reset
+;; ============================================================
+
+;; Resets ALL GSD state atomically under the semaphore.
+;; Called on session-shutdown and between test runs.
+(define (reset-all-gsd-state!)
+  (call-with-semaphore state-sem
+                       (lambda ()
+                         (set-box! gsd-mode-box #f)
+                         (set-box! pinned-dir-box #f)
+                         (set-box! budget-box #f)
+                         (set-box! edit-limit-box 500)
+                         (set-box! read-counts-box (make-hash)))))

--- a/extensions/gsd-planning.rkt
+++ b/extensions/gsd-planning.rkt
@@ -17,7 +17,7 @@
          "context.rkt"
          "hooks.rkt"
          "../tools/tool.rkt"
-         (only-in "../tools/builtins/edit.rkt" current-max-old-text-len))
+         "gsd-planning-state.rkt")
 
 (provide the-extension
          gsd-planning-extension
@@ -29,15 +29,30 @@
          handle-planning-read
          handle-planning-write
          planning-implement-prompt
-         pinned-planning-dir
          gsd-mode
+         set-gsd-mode!
          gsd-tool-guard
          reset-read-counts!
          gsd-read-tracker
          go-read-budget
+         set-go-read-budget!
          reset-go-budget!
          GO-READ-BUDGET
-         READ-ONLY-TOOLS)
+         GO-READ-WARN-THRESHOLD
+         GO-READ-BLOCK-THRESHOLD
+         READ-ONLY-TOOLS
+         ;; Re-export state module accessors for backward compat
+         pinned-planning-dir
+         set-pinned-planning-dir!
+         current-max-old-text-len
+         set-current-max-old-text-len!
+         reset-all-gsd-state!
+         gsd-mode?
+         decrement-budget!
+         read-counts
+         get-read-count
+         increment-read-count!
+         clear-read-counts!)
 
 ;; ============================================================
 ;; Constants
@@ -45,22 +60,11 @@
 
 (define planning-dir-name ".planning")
 
-;; Pinned planning directory — set once during tool registration from ctx-cwd.
-;; Ensures all planning-read/planning-write calls within a session use the
-;; same .planning/ folder, even if the LLM guesses a different base_dir.
-;; Uses a parameter so tests can override it per-scope.
-(define pinned-planning-dir (make-parameter #f))
+;; pinned-planning-dir is now in gsd-planning-state.rkt (box with semaphore).
+;; Tests and call sites use (pinned-planning-dir) / (set-pinned-planning-dir! v).
 
 ;; GSD workflow mode: #f | 'planning | 'plan-written | 'executing
-;; Set by /plan (→ 'planning), transitions to 'plan-written after planning-write PLAN
-;; succeeds. Set to 'executing on /go. Used by tool-call-pre hook to block
-;; out-of-scope calls.
-(define gsd-mode-box (box #f))
-
-(define (gsd-mode . v)
-  (if (null? v)
-      (unbox gsd-mode-box)
-      (set-box! gsd-mode-box (car v))))
+;; NOW in gsd-planning-state.rkt — semaphore-protected.
 
 ;; Resolve the project root by walking up from 'start-dir' looking for
 ;; a directory containing .planning/, q/, BLUEPRINT/, or .git/.
@@ -282,7 +286,7 @@
                   ;; Transition from planning to plan-written mode.
                   ;; This blocks further write/edit/bash calls until /go is invoked.
                   (when (and (eq? (gsd-mode) 'planning) (string=? name "PLAN"))
-                    (gsd-mode 'plan-written))
+                    (set-gsd-mode! 'plan-written))
                   (make-success-result (list (hasheq 'type
                                                      "text"
                                                      'text
@@ -300,7 +304,7 @@
   (unless (pinned-planning-dir)
     (define cwd (ctx-cwd ctx))
     (when cwd
-      (pinned-planning-dir (resolve-project-root cwd))))
+      (set-pinned-planning-dir! (resolve-project-root cwd))))
   (ext-register-tool!
    ctx
    "planning-read"
@@ -368,9 +372,9 @@
        [(not plan-content)
         (hook-amend (hasheq 'text "No PLAN found in .planning/. Use /plan <task> to create one."))]
        [else
-        (gsd-mode 'executing)
+        (set-gsd-mode! 'executing)
         ;; Raise edit limit during execution mode (500 → 1200)
-        (current-max-old-text-len 1200)
+        (set-current-max-old-text-len! 1200)
         ;; Reset read counter for fresh execution
         (reset-read-counts!)
         ;; Reset read budget for fresh execution
@@ -418,13 +422,13 @@
            =>
            (lambda (args)
              ;; Reset mode for new planning session
-             (gsd-mode 'planning)
+             (set-gsd-mode! 'planning)
              ;; Reset edit limit to default during planning
-             (current-max-old-text-len 500)
+             (set-current-max-old-text-len! 500)
              ;; Reset read counter for fresh planning
              (reset-read-counts!)
              ;; Reset budget
-             (go-read-budget #f)
+             (set-go-read-budget! #f)
              ;; v0.19.12 W2: Detect stale existing PLAN.md and inject warning
              (define existing-plan (read-planning-artifact base-dir "PLAN"))
              (define stale-warning
@@ -449,7 +453,7 @@
 ;; ============================================================
 
 ;; Tracks per-file read count to detect redundant reads.
-(define read-counts (make-hash))
+;; State lives in gsd-planning-state.rkt.
 
 (define READ_HINT_THRESHOLD 3)
 
@@ -464,8 +468,7 @@
      (cond
        [(not file-path) (hook-pass payload)]
        [else
-        (define new-count (add1 (hash-ref read-counts file-path 0)))
-        (hash-set! read-counts file-path new-count)
+        (define new-count (increment-read-count! file-path))
         (cond
           [(and (>= new-count READ_HINT_THRESHOLD) (= 0 (modulo new-count READ_HINT_THRESHOLD)))
            (define hint-text
@@ -486,29 +489,15 @@
 
 ;; Reset read counts when entering a new mode
 (define (reset-read-counts!)
-  (hash-clear! read-counts))
+  (clear-read-counts!))
 
 ;; ============================================================
 ;; /go Budget Counter
 ;; ============================================================
 
-;; Read-only tools that count against the budget
-(define READ-ONLY-TOOLS '("read" "grep" "find" "ls" "glob"))
-
-;; Budget: 30 read-only calls per /go session
-(define GO-READ-BUDGET 30)
-(define GO-READ-WARN-THRESHOLD 5) ; warn at ≤5 remaining
-(define GO-READ-BLOCK-THRESHOLD -3) ; block at <−3 (i.e., 33+ calls)
-
-(define go-read-budget-box (box #f))
-
-(define (go-read-budget . v)
-  (if (null? v)
-      (unbox go-read-budget-box)
-      (set-box! go-read-budget-box (car v))))
-
-(define (reset-go-budget!)
-  (go-read-budget GO-READ-BUDGET))
+;; Budget constants now in gsd-planning-state.rkt.
+;; READ-ONLY-TOOLS, GO-READ-BUDGET, GO-READ-WARN-THRESHOLD, GO-READ-BLOCK-THRESHOLD
+;; are imported from there.
 
 ;; ============================================================
 ;; GSD mode tool guard (tool-call-pre hook handler)
@@ -530,8 +519,7 @@
      (hook-block "Cannot update plan during /go. Focus on executing the existing plan.")]
     ;; During /go, enforce read budget
     [(and (eq? mode 'executing) (member tool-name READ-ONLY-TOOLS) (go-read-budget))
-     (define remaining (sub1 (go-read-budget)))
-     (go-read-budget remaining)
+     (define remaining (decrement-budget!))
      (cond
        [(< remaining GO-READ-BLOCK-THRESHOLD)
         ;; Hard block: way over budget

--- a/tests/test-gsd-planning-boundary.rkt
+++ b/tests/test-gsd-planning-boundary.rkt
@@ -42,12 +42,21 @@
 
 (define (with-mode mode proc)
   (define saved (gsd-mode))
-  (gsd-mode mode)
+  (set-gsd-mode! mode)
   (with-handlers ([exn:fail? (lambda (e)
-                               (gsd-mode saved)
+                               (set-gsd-mode! saved)
                                (raise e))])
     (begin0 (proc)
-      (gsd-mode saved))))
+      (set-gsd-mode! saved))))
+
+(define (with-pinned-dir dir proc)
+  (define saved (pinned-planning-dir))
+  (set-pinned-planning-dir! dir)
+  (with-handlers ([exn:fail? (lambda (e)
+                               (set-pinned-planning-dir! saved)
+                               (raise e))])
+    (begin0 (proc)
+      (set-pinned-planning-dir! saved))))
 
 ;; ============================================================
 ;; gsd-mode state machine tests
@@ -68,7 +77,7 @@
 (test-case "gsd-mode can be reset to #f"
   (with-mode 'planning
              (lambda ()
-               (gsd-mode #f)
+               (set-gsd-mode! #f)
                (check-equal? (gsd-mode) #f))))
 
 ;; ============================================================
@@ -182,33 +191,39 @@
 (test-case "planning-write PLAN transitions mode from 'planning to 'plan-written"
   (with-temp-dir
    (lambda (dir)
-     (parameterize ([pinned-planning-dir dir])
-       (with-mode
-        'planning
-        (lambda ()
-          (define args (hasheq 'artifact "PLAN" 'content "# Test Plan"))
-          (define result (handle-planning-write args))
-          (check-false (tool-result-is-error? result) "planning-write should succeed")
-          (check-eq? (gsd-mode) 'plan-written "mode should transition to plan-written")))))))
+     (with-pinned-dir
+      dir
+      (lambda ()
+        (with-mode
+         'planning
+         (lambda ()
+           (define args (hasheq 'artifact "PLAN" 'content "# Test Plan"))
+           (define result (handle-planning-write args))
+           (check-false (tool-result-is-error? result) "planning-write should succeed")
+           (check-eq? (gsd-mode) 'plan-written "mode should transition to plan-written"))))))))
 
 (test-case "planning-write non-PLAN artifact does not change mode"
-  (with-temp-dir (lambda (dir)
-                   (parameterize ([pinned-planning-dir dir])
-                     (with-mode 'planning
-                                (lambda ()
-                                  (define args (hasheq 'artifact "STATE" 'content "# State"))
-                                  (define result (handle-planning-write args))
-                                  (check-false (tool-result-is-error? result))
-                                  (check-eq? (gsd-mode) 'planning "mode should remain planning")))))))
+  (with-temp-dir
+   (lambda (dir)
+     (with-pinned-dir
+      dir
+      (lambda ()
+        (with-mode 'planning
+                   (lambda ()
+                     (define args (hasheq 'artifact "STATE" 'content "# State"))
+                     (define result (handle-planning-write args))
+                     (check-false (tool-result-is-error? result))
+                     (check-eq? (gsd-mode) 'planning "mode should remain planning"))))))))
 
 (test-case "planning-write PLAN does not change mode when not in 'planning"
   (with-temp-dir (lambda (dir)
-                   (parameterize ([pinned-planning-dir dir])
-                     ;; Mode is #f by default
-                     (define args (hasheq 'artifact "PLAN" 'content "# Plan"))
-                     (define result (handle-planning-write args))
-                     (check-false (tool-result-is-error? result))
-                     (check-equal? (gsd-mode) #f "mode should remain #f")))))
+                   (with-pinned-dir dir
+                                    (lambda ()
+                                      ;; Mode is #f by default
+                                      (define args (hasheq 'artifact "PLAN" 'content "# Plan"))
+                                      (define result (handle-planning-write args))
+                                      (check-false (tool-result-is-error? result))
+                                      (check-equal? (gsd-mode) #f "mode should remain #f"))))))
 
 ;; ============================================================
 ;; Full workflow integration tests
@@ -216,45 +231,47 @@
 
 (test-case "full workflow: /plan → write PLAN → blocked edit → /go → edit allowed"
   (with-temp-dir (lambda (dir)
-                   (parameterize ([pinned-planning-dir dir])
-                     ;; Step 1: /plan sets mode to 'planning
-                     (gsd-mode 'planning)
-                     (check-eq? (gsd-mode) 'planning)
+                   (with-pinned-dir
+                    dir
+                    (lambda ()
+                      ;; Step 1: /plan sets mode to 'planning
+                      (set-gsd-mode! 'planning)
+                      (check-eq? (gsd-mode) 'planning)
 
-                     ;; Step 2: writing PLAN transitions to 'plan-written
-                     (define write-result
-                       (handle-planning-write (hasheq 'artifact "PLAN" 'content "# Plan")))
-                     (check-false (tool-result-is-error? write-result))
-                     (check-eq? (gsd-mode) 'plan-written)
+                      ;; Step 2: writing PLAN transitions to 'plan-written
+                      (define write-result
+                        (handle-planning-write (hasheq 'artifact "PLAN" 'content "# Plan")))
+                      (check-false (tool-result-is-error? write-result))
+                      (check-eq? (gsd-mode) 'plan-written)
 
-                     ;; Step 3: edit is blocked in 'plan-written mode
-                     (define guard-result (gsd-tool-guard (hasheq 'tool-name "edit")))
-                     (check-eq? (hook-result-action guard-result) 'block)
+                      ;; Step 3: edit is blocked in 'plan-written mode
+                      (define guard-result (gsd-tool-guard (hasheq 'tool-name "edit")))
+                      (check-eq? (hook-result-action guard-result) 'block)
 
-                     ;; Step 4: /go sets mode to 'executing
-                     (gsd-mode 'executing)
-                     (check-eq? (gsd-mode) 'executing)
+                      ;; Step 4: /go sets mode to 'executing
+                      (set-gsd-mode! 'executing)
+                      (check-eq? (gsd-mode) 'executing)
 
-                     ;; Step 5: edit is allowed in 'executing mode
-                     (define guard-result2 (gsd-tool-guard (hasheq 'tool-name "edit")))
-                     (check-eq? (hook-result-action guard-result2) 'pass)
+                      ;; Step 5: edit is allowed in 'executing mode
+                      (define guard-result2 (gsd-tool-guard (hasheq 'tool-name "edit")))
+                      (check-eq? (hook-result-action guard-result2) 'pass)
 
-                     ;; Step 6: planning-write is blocked in 'executing mode
-                     (define guard-result3 (gsd-tool-guard (hasheq 'tool-name "planning-write")))
-                     (check-eq? (hook-result-action guard-result3) 'block)
+                      ;; Step 6: planning-write is blocked in 'executing mode
+                      (define guard-result3 (gsd-tool-guard (hasheq 'tool-name "planning-write")))
+                      (check-eq? (hook-result-action guard-result3) 'block)
 
-                     ;; Cleanup
-                     (gsd-mode #f)))))
+                      ;; Cleanup
+                      (set-gsd-mode! #f))))))
 
 (test-case "new /plan resets mode from 'plan-written"
   ;; Simulating starting a fresh planning session
   (with-mode 'plan-written
              (lambda ()
-               (gsd-mode 'planning)
+               (set-gsd-mode! 'planning)
                (check-eq? (gsd-mode) 'planning))))
 
 (test-case "new /go resets mode from 'plan-written"
   (with-mode 'plan-written
              (lambda ()
-               (gsd-mode 'executing)
+               (set-gsd-mode! 'executing)
                (check-eq? (gsd-mode) 'executing))))

--- a/tests/test-gsd-planning-budget-counter.rkt
+++ b/tests/test-gsd-planning-budget-counter.rkt
@@ -13,7 +13,7 @@
 ;; ============================================================
 
 (test-case "go-read-budget defaults to #f"
-  (go-read-budget #f)
+  (set-go-read-budget! #f)
   (check-false (go-read-budget)))
 
 (test-case "reset-go-budget! sets budget to 30"
@@ -33,30 +33,30 @@
 ;; ============================================================
 
 (test-case "tool-guard passes write tools during executing without budget change"
-  (gsd-mode 'executing)
+  (set-gsd-mode! 'executing)
   (reset-go-budget!)
   (define res (gsd-tool-guard (hasheq 'tool-name "edit" 'args (hasheq))))
   (check-eq? (hook-result-action res) 'pass)
   ;; Budget should NOT be decremented for write tools
   (check-equal? (go-read-budget) 30)
-  (gsd-mode #f))
+  (set-gsd-mode! #f))
 
 (test-case "tool-guard decrements budget for read during executing"
-  (gsd-mode 'executing)
+  (set-gsd-mode! 'executing)
   (reset-go-budget!)
   (gsd-tool-guard (hasheq 'tool-name "read" 'args (hasheq)))
   (check-equal? (go-read-budget) 29)
-  (gsd-mode #f))
+  (set-gsd-mode! #f))
 
 (test-case "tool-guard passes reads with plenty of budget"
-  (gsd-mode 'executing)
+  (set-gsd-mode! 'executing)
   (reset-go-budget!)
   (define res (gsd-tool-guard (hasheq 'tool-name "read" 'args (hasheq))))
   (check-eq? (hook-result-action res) 'pass)
-  (gsd-mode #f))
+  (set-gsd-mode! #f))
 
 (test-case "tool-guard warns when budget ≤5"
-  (gsd-mode 'executing)
+  (set-gsd-mode! 'executing)
   (reset-go-budget!)
   ;; Burn through 25 calls
   (for ([_ (in-range 25)])
@@ -66,10 +66,10 @@
   ;; Next read should trigger warning
   (define res (gsd-tool-guard (hasheq 'tool-name "read" 'args (hasheq))))
   (check-eq? (hook-result-action res) 'amend)
-  (gsd-mode #f))
+  (set-gsd-mode! #f))
 
 (test-case "tool-guard blocks when budget goes below -3"
-  (gsd-mode 'executing)
+  (set-gsd-mode! 'executing)
   (reset-go-budget!)
   ;; Burn through 33 calls (30 budget + 3 overage)
   (for ([_ (in-range 33)])
@@ -79,42 +79,42 @@
   ;; Next read should pass (block threshold is < -3, not ≤ -3)
   (define res-at-neg3 (gsd-tool-guard (hasheq 'tool-name "read" 'args (hasheq))))
   (check-eq? (hook-result-action res-at-neg3) 'block)
-  (gsd-mode #f))
+  (set-gsd-mode! #f))
 
 (test-case "tool-guard does not enforce budget when not in executing mode"
-  (gsd-mode 'planning)
+  (set-gsd-mode! 'planning)
   (reset-go-budget!)
   ;; Call read many times
   (for ([_ (in-range 40)])
     (gsd-tool-guard (hasheq 'tool-name "read" 'args (hasheq))))
   ;; Budget should still be 30 — not decremented in planning mode
   (check-equal? (go-read-budget) 30)
-  (gsd-mode #f))
+  (set-gsd-mode! #f))
 
 (test-case "tool-guard does not enforce budget when budget is #f"
-  (gsd-mode 'executing)
-  (go-read-budget #f)
+  (set-gsd-mode! 'executing)
+  (set-go-read-budget! #f)
   (define res (gsd-tool-guard (hasheq 'tool-name "read" 'args (hasheq))))
   (check-eq? (hook-result-action res) 'pass)
   ;; Budget should still be #f
   (check-false (go-read-budget))
-  (gsd-mode #f))
+  (set-gsd-mode! #f))
 
 (test-case "tool-guard blocks edit during plan-written"
-  (gsd-mode 'plan-written)
+  (set-gsd-mode! 'plan-written)
   (define res (gsd-tool-guard (hasheq 'tool-name "edit" 'args (hasheq))))
   (check-eq? (hook-result-action res) 'block)
-  (gsd-mode #f))
+  (set-gsd-mode! #f))
 
 (test-case "tool-guard blocks planning-write during executing"
-  (gsd-mode 'executing)
+  (set-gsd-mode! 'executing)
   (reset-go-budget!)
   (define res (gsd-tool-guard (hasheq 'tool-name "planning-write" 'args (hasheq))))
   (check-eq? (hook-result-action res) 'block)
-  (gsd-mode #f))
+  (set-gsd-mode! #f))
 
 (test-case "budget is independent of read counter"
-  (gsd-mode 'executing)
+  (set-gsd-mode! 'executing)
   (reset-go-budget!)
   (reset-read-counts!)
   ;; Budget counts all read-only tools, not just file reads
@@ -122,4 +122,4 @@
   (gsd-tool-guard (hasheq 'tool-name "find" 'args (hasheq)))
   (gsd-tool-guard (hasheq 'tool-name "ls" 'args (hasheq)))
   (check-equal? (go-read-budget) 27)
-  (gsd-mode #f))
+  (set-gsd-mode! #f))

--- a/tests/test-gsd-planning-edit-limit.rkt
+++ b/tests/test-gsd-planning-edit-limit.rkt
@@ -20,19 +20,19 @@
 
 (test-case "current-max-old-text-len can be raised and restored"
   (define saved (current-max-old-text-len))
-  (current-max-old-text-len 1200)
+  (set-current-max-old-text-len! 1200)
   (check-equal? (current-max-old-text-len) 1200)
-  (current-max-old-text-len saved)
+  (set-current-max-old-text-len! saved)
   (check-equal? (current-max-old-text-len) 500))
 
 (test-case "current-max-old-text-len persists across threads"
   (define saved (current-max-old-text-len))
-  (current-max-old-text-len 1200)
+  (set-current-max-old-text-len! 1200)
   (define result-box (box #f))
   (thread (lambda () (set-box! result-box (current-max-old-text-len))))
   (sync (system-idle-evt))
   (check-equal? (unbox result-box) 1200)
-  (current-max-old-text-len saved))
+  (set-current-max-old-text-len! saved))
 
 ;; ============================================================
 ;; Edit tool respects dynamic limit
@@ -79,11 +79,11 @@
                                (cleanup-path f)
                                (raise e))])
     (define saved (current-max-old-text-len))
-    (current-max-old-text-len 1200)
+    (set-current-max-old-text-len! 1200)
     (define result
       (tool-edit (hasheq 'path (path->string f) 'old-text long-text 'new-text "REPLACED")))
     (check-false (tool-result-is-error? result))
-    (current-max-old-text-len saved)
+    (set-current-max-old-text-len! saved)
     (cleanup-path f)))
 
 (test-case "edit rejects old-text > 1200 at raised limit"
@@ -92,9 +92,9 @@
                                (cleanup-path f)
                                (raise e))])
     (define saved (current-max-old-text-len))
-    (current-max-old-text-len 1200)
+    (set-current-max-old-text-len! 1200)
     (define result
       (tool-edit (hasheq 'path (path->string f) 'old-text (make-string 1201 #\x) 'new-text "new")))
     (check-true (tool-result-is-error? result))
-    (current-max-old-text-len saved)
+    (set-current-max-old-text-len! saved)
     (cleanup-path f)))

--- a/tests/test-gsd-planning-state.rkt
+++ b/tests/test-gsd-planning-state.rkt
@@ -1,0 +1,207 @@
+#lang racket
+
+;; tests/test-gsd-planning-state.rkt — Semaphore-protected state module tests
+;;
+;; Wave 0 of v0.20.3: Tests for gsd-planning-state.rkt.
+;; Covers: semaphore-protected concurrent access, atomic reset,
+;; pinned-dir cross-thread visibility, edit-limit, budget, read-counts.
+
+(require rackunit
+         "../extensions/gsd-planning-state.rkt")
+
+;; ============================================================
+;; gsd-mode tests
+;; ============================================================
+
+(test-case "gsd-mode defaults to #f"
+  (reset-all-gsd-state!)
+  (check-equal? (gsd-mode) #f))
+
+(test-case "set-gsd-mode! sets and reads back"
+  (reset-all-gsd-state!)
+  (set-gsd-mode! 'planning)
+  (check-eq? (gsd-mode) 'planning)
+  (set-gsd-mode! 'executing)
+  (check-eq? (gsd-mode) 'executing))
+
+(test-case "gsd-mode? checks current mode"
+  (reset-all-gsd-state!)
+  (set-gsd-mode! 'planning)
+  (check-true (gsd-mode? 'planning))
+  (check-false (gsd-mode? 'executing)))
+
+;; ============================================================
+;; pinned-planning-dir tests
+;; ============================================================
+
+(test-case "pinned-planning-dir defaults to #f"
+  (reset-all-gsd-state!)
+  (check-false (pinned-planning-dir)))
+
+(test-case "set-pinned-planning-dir! sets and reads back"
+  (reset-all-gsd-state!)
+  (set-pinned-planning-dir! "/tmp/test")
+  (check-equal? (pinned-planning-dir) "/tmp/test"))
+
+(test-case "pinned-planning-dir visible across threads"
+  (reset-all-gsd-state!)
+  (set-pinned-planning-dir! "/tmp/cross-thread")
+  (define result-box (box #f))
+  (thread (lambda () (set-box! result-box (pinned-planning-dir))))
+  (sync (system-idle-evt))
+  (check-equal? (unbox result-box) "/tmp/cross-thread"))
+
+;; ============================================================
+;; go-read-budget tests
+;; ============================================================
+
+(test-case "go-read-budget defaults to #f"
+  (reset-all-gsd-state!)
+  (check-false (go-read-budget)))
+
+(test-case "reset-go-budget! sets budget to GO-READ-BUDGET"
+  (reset-all-gsd-state!)
+  (reset-go-budget!)
+  (check-equal? (go-read-budget) GO-READ-BUDGET)
+  (check-equal? (go-read-budget) 30))
+
+(test-case "set-go-read-budget! sets arbitrary value"
+  (reset-all-gsd-state!)
+  (set-go-read-budget! 10)
+  (check-equal? (go-read-budget) 10))
+
+(test-case "decrement-budget! decrements and returns new value"
+  (reset-all-gsd-state!)
+  (reset-go-budget!)
+  (define v1 (decrement-budget!))
+  (check-equal? v1 29)
+  (check-equal? (go-read-budget) 29)
+  (define v2 (decrement-budget!))
+  (check-equal? v2 28))
+
+;; ============================================================
+;; current-max-old-text-len tests
+;; ============================================================
+
+(test-case "current-max-old-text-len defaults to 500"
+  (reset-all-gsd-state!)
+  (check-equal? (current-max-old-text-len) 500))
+
+(test-case "set-current-max-old-text-len! sets and reads back"
+  (reset-all-gsd-state!)
+  (set-current-max-old-text-len! 1200)
+  (check-equal? (current-max-old-text-len) 1200))
+
+(test-case "current-max-old-text-len visible across threads"
+  (reset-all-gsd-state!)
+  (set-current-max-old-text-len! 999)
+  (define result-box (box #f))
+  (thread (lambda () (set-box! result-box (current-max-old-text-len))))
+  (sync (system-idle-evt))
+  (check-equal? (unbox result-box) 999))
+
+;; ============================================================
+;; read-counts tests
+;; ============================================================
+
+(test-case "read-counts starts empty"
+  (reset-all-gsd-state!)
+  (define counts (read-counts))
+  (check-equal? (hash-count counts) 0))
+
+(test-case "increment-read-count! adds and returns count"
+  (reset-all-gsd-state!)
+  (define c1 (increment-read-count! "/tmp/a.txt"))
+  (check-equal? c1 1)
+  (define c2 (increment-read-count! "/tmp/a.txt"))
+  (check-equal? c2 2)
+  (check-equal? (get-read-count "/tmp/a.txt") 2))
+
+(test-case "get-read-count returns 0 for unknown keys"
+  (reset-all-gsd-state!)
+  (check-equal? (get-read-count "/tmp/unknown.txt") 0))
+
+(test-case "clear-read-counts! removes all entries"
+  (reset-all-gsd-state!)
+  (increment-read-count! "/tmp/a.txt")
+  (increment-read-count! "/tmp/b.txt")
+  (clear-read-counts!)
+  (check-equal? (get-read-count "/tmp/a.txt") 0)
+  (check-equal? (get-read-count "/tmp/b.txt") 0)
+  (check-equal? (hash-count (read-counts)) 0))
+
+(test-case "read-counts tracks different files independently"
+  (reset-all-gsd-state!)
+  (increment-read-count! "/tmp/a.txt")
+  (increment-read-count! "/tmp/a.txt")
+  (increment-read-count! "/tmp/b.txt")
+  (check-equal? (get-read-count "/tmp/a.txt") 2)
+  (check-equal? (get-read-count "/tmp/b.txt") 1))
+
+;; ============================================================
+;; reset-all-gsd-state! tests
+;; ============================================================
+
+(test-case "reset-all-gsd-state! resets everything atomically"
+  (reset-all-gsd-state!)
+  ;; Set all state to non-default values
+  (set-gsd-mode! 'executing)
+  (set-pinned-planning-dir! "/some/dir")
+  (reset-go-budget!)
+  (set-current-max-old-text-len! 1200)
+  (increment-read-count! "/tmp/x.txt")
+  ;; Reset
+  (reset-all-gsd-state!)
+  ;; Verify all cleared
+  (check-equal? (gsd-mode) #f)
+  (check-false (pinned-planning-dir))
+  (check-false (go-read-budget))
+  (check-equal? (current-max-old-text-len) 500)
+  (check-equal? (hash-count (read-counts)) 0))
+
+;; ============================================================
+;; Concurrent access tests
+;; ============================================================
+
+(test-case "concurrent budget decrement has no lost updates"
+  (reset-all-gsd-state!)
+  (set-go-read-budget! 1000)
+  (define n-threads 10)
+  (define decrements-per-thread 100)
+  (define threads
+    (for/list ([_ (in-range n-threads)])
+      (thread (lambda ()
+                (for ([_ (in-range decrements-per-thread)])
+                  (decrement-budget!))))))
+  (for-each sync threads)
+  ;; Expected: 1000 - (10 * 100) = 0
+  (check-equal? (go-read-budget) 0))
+
+(test-case "concurrent read-count increment has no lost updates"
+  (reset-all-gsd-state!)
+  (define n-threads 10)
+  (define increments-per-thread 100)
+  (define threads
+    (for/list ([_ (in-range n-threads)])
+      (thread (lambda ()
+                (for ([_ (in-range increments-per-thread)])
+                  (increment-read-count! "/tmp/concurrent.txt"))))))
+  (for-each sync threads)
+  ;; Expected: 10 * 100 = 1000
+  (check-equal? (get-read-count "/tmp/concurrent.txt") 1000))
+
+(test-case "concurrent gsd-mode writes — last writer wins"
+  (reset-all-gsd-state!)
+  (define threads
+    (for/list ([i (in-range 100)])
+      (thread (lambda () (set-gsd-mode! (if (even? i) 'planning 'executing))))))
+  (for-each sync threads)
+  ;; Value must be one of the two valid modes
+  (check-true (or (eq? (gsd-mode) 'planning) (eq? (gsd-mode) 'executing))
+              "mode must be a valid symbol after concurrent writes"))
+
+(test-case "constants have expected values"
+  (check-equal? GO-READ-BUDGET 30)
+  (check-equal? GO-READ-WARN-THRESHOLD 5)
+  (check-equal? GO-READ-BLOCK-THRESHOLD -3)
+  (check-equal? READ-ONLY-TOOLS '("read" "grep" "find" "ls" "glob")))

--- a/tools/builtins/edit.rkt
+++ b/tools/builtins/edit.rkt
@@ -16,6 +16,9 @@
          racket/string
          (only-in racket/list last drop)
          (only-in "../tool.rkt" make-success-result make-error-result)
+         (only-in "../../extensions/gsd-planning-state.rkt"
+                  current-max-old-text-len
+                  set-current-max-old-text-len!)
          (only-in "../../util/safe-mode-predicates.rkt"
                   safe-mode?
                   allowed-path?
@@ -24,22 +27,19 @@
          (only-in "../../util/error-sanitizer.rkt" sanitize-error-message))
 
 (provide tool-edit
-         current-max-old-text-len)
+         current-max-old-text-len
+         set-current-max-old-text-len!)
 
+;; --------------------------------------------------
+;; Backup helpers
 ;; --------------------------------------------------
 ;; Constants
 ;; --------------------------------------------------
 
-(define current-max-old-text-len-box (box 500))
-
-(define (current-max-old-text-len . v)
-  (if (null? v)
-      (unbox current-max-old-text-len-box)
-      (set-box! current-max-old-text-len-box (car v))))
 (define MAX-BACKUPS-PER-FILE 10)
 
 ;; --------------------------------------------------
-;; Backup helpers
+;; Helpers
 ;; --------------------------------------------------
 
 (define (ensure-backup-dir)


### PR DESCRIPTION
Addresses #1961.

feat: extract GSD state into semaphore-protected module (Wave 0, #1961)

Wave 0 of v0.20.3 — Thread-Safe State Foundation (C1, C2, W2).

- NEW: extensions/gsd-planning-state.rkt — semaphore-protected shared state
  with atomic accessors for gsd-mode, pinned-planning-dir, go-read-budget,
  read-counts, and current-max-old-text-len.
- Convert pinned-planning-dir from make-parameter to box with semaphore (C2).
- Move current-max-old-text-len from tools/builtins/edit.rkt to state module.
- Add decrement-budget! for atomic read-modify-write (C1).
- Add reset-all-gsd-state! for atomic full-reset (W2).
- NEW: tests/test-gsd-planning-state.rkt — 23 tests including concurrent
  decrement (no lost updates), cross-thread visibility, atomic reset.
- Update all existing test files to use new setter API.
- All 144 GSD tests pass, 6095 total tests pass (0 failures).

Milestone: v0.20.3 — GSD Planning Architecture Remediation (#119).