### PR TITLE
fix: move budget warning from tool-call-pre to tool-result-post (Wave 1, #1966)

Wave 1 of v0.20.3 — Invisible Budget Warning Fix (C3).

- REMOVE budget warning (hook-amend args) from gsd-tool-guard (tool-call-pre).
  The warning was injected into tool call args which the LLM never sees.
- ADD budget warning injection to gsd-read-tracker (tool-result-post).
  The warning now appears in the tool result content, visible to the LLM.
- gsd-tool-guard only handles pass/block decisions now (single responsibility).
- Budget warning fires at ≤5 remaining, shows "X/30 read calls remaining".
- Works for all read-only tools (read, grep, find, ls, glob).
- NEW: 5 tests for budget warning in result content.
- UPDATE: 1 existing test changed from 'amend to 'pass (tool-guard no longer warns).
- All 149 GSD tests pass.

Milestone: v0.20.3 — GSD Planning Architecture Remediation (#119).

### DIFF
--- a/extensions/gsd-planning.rkt
+++ b/extensions/gsd-planning.rkt
@@ -449,13 +449,43 @@
            (hook-amend (hasheq 'text text))])])]))
 
 ;; ============================================================
-;; Redundant read detection (tool-result-post hook)
+;; Budget warning injection + Redundant read detection (tool-result-post hook)
 ;; ============================================================
 
 ;; Tracks per-file read count to detect redundant reads.
 ;; State lives in gsd-planning-state.rkt.
+;; Also injects budget warnings into tool results so the LLM can see them.
 
 (define READ_HINT_THRESHOLD 3)
+
+;; Helper: inject budget warning into tool result via tool-result-post.
+;; This makes the warning visible to the LLM in the result content.
+(define (budget-warning-text)
+  (define remaining (go-read-budget))
+  (if (and remaining (<= remaining GO-READ-WARN-THRESHOLD))
+      (format "\n\n[BUDGET WARNING: ~a/~a read calls remaining. Focus on implementation.]"
+              remaining
+              GO-READ-BUDGET)
+      #f))
+
+(define (maybe-append-budget-warning content-list)
+  (define warn (budget-warning-text))
+  (if warn
+      (append content-list (list (hasheq 'type "text" 'text warn)))
+      content-list))
+
+(define (maybe-inject-budget-warning payload)
+  (define warn (budget-warning-text))
+  (if warn
+      (let* ([result (hash-ref payload 'result #f)]
+             [content (and result (tool-result? result) (tool-result-content result))]
+             [base-content (if (list? content)
+                               content
+                               (list content))]
+             [final-content (append base-content (list (hasheq 'type "text" 'text warn)))])
+        (hook-amend (hasheq 'result
+                            (make-success-result final-content (tool-result-details result)))))
+      (hook-pass payload)))
 
 (define (gsd-read-tracker payload)
   (define tool-name (hash-ref payload 'tool-name #f))
@@ -466,25 +496,33 @@
      (define details (tool-result-details result))
      (define file-path (and (hash? details) (hash-ref details 'path #f)))
      (cond
-       [(not file-path) (hook-pass payload)]
+       [(not file-path) (maybe-inject-budget-warning payload)]
        [else
         (define new-count (increment-read-count! file-path))
         (cond
           [(and (>= new-count READ_HINT_THRESHOLD) (= 0 (modulo new-count READ_HINT_THRESHOLD)))
+           ;; Inject both read hint and budget warning if applicable
            (define hint-text
              (format
               "\n\n[HINT: You have read '~a' ~a times. Consider using your memory of previous reads instead of re-reading.]"
               file-path
               new-count))
            (define content (tool-result-content result))
-           (define new-content
+           (define base-content
              (append (if (list? content)
                          content
                          (list content))
                      (list (hasheq 'type "text" 'text hint-text))))
+           (define final-content (maybe-append-budget-warning base-content))
            (hook-amend (hasheq 'result
-                               (make-success-result new-content (tool-result-details result))))]
-          [else (hook-pass payload)])])]
+                               (make-success-result final-content (tool-result-details result))))]
+          [else (maybe-inject-budget-warning payload)])])]
+    ;; For other read-only tools (grep, find, ls, glob), still inject budget warning
+    [(and (member tool-name READ-ONLY-TOOLS)
+          result
+          (tool-result? result)
+          (not (tool-result-is-error? result)))
+     (maybe-inject-budget-warning payload)]
     [else (hook-pass payload)]))
 
 ;; Reset read counts when entering a new mode
@@ -528,14 +566,6 @@
           "Read budget exhausted (~a read calls used, budget is ~a). Stop exploring and implement."
           (- GO-READ-BUDGET remaining)
           GO-READ-BUDGET))]
-       [(<= remaining GO-READ-WARN-THRESHOLD)
-        ;; Warning: amend tool call args to include a budget reminder
-        (hook-amend (hasheq 'args
-                            (hash-set (hash-ref payload 'args (hasheq))
-                                      '_budget-warning
-                                      (format "[BUDGET WARNING: ~a/~a read calls remaining]"
-                                              remaining
-                                              GO-READ-BUDGET))))]
        [else (hook-pass payload)])]
     [else (hook-pass payload)]))
 

--- a/tests/test-gsd-planning-budget-counter.rkt
+++ b/tests/test-gsd-planning-budget-counter.rkt
@@ -55,7 +55,7 @@
   (check-eq? (hook-result-action res) 'pass)
   (set-gsd-mode! #f))
 
-(test-case "tool-guard warns when budget ≤5"
+(test-case "tool-guard passes reads at warning threshold (warning now in result)"
   (set-gsd-mode! 'executing)
   (reset-go-budget!)
   ;; Burn through 25 calls
@@ -63,9 +63,9 @@
     (gsd-tool-guard (hasheq 'tool-name "read" 'args (hasheq))))
   ;; Budget should be 5 now
   (check-equal? (go-read-budget) 5)
-  ;; Next read should trigger warning
+  ;; Next read should still pass (warning is now in tool-result-post)
   (define res (gsd-tool-guard (hasheq 'tool-name "read" 'args (hasheq))))
-  (check-eq? (hook-result-action res) 'amend)
+  (check-eq? (hook-result-action res) 'pass)
   (set-gsd-mode! #f))
 
 (test-case "tool-guard blocks when budget goes below -3"

--- a/tests/test-gsd-planning-read-tracker.rkt
+++ b/tests/test-gsd-planning-read-tracker.rkt
@@ -122,3 +122,87 @@
   (reset-read-counts!)
   (define hook-res (gsd-read-tracker (hasheq 'tool-name "read" 'result "not a result")))
   (check-eq? (hook-result-action hook-res) 'pass))
+
+;; ============================================================
+;; Budget warning injection via tool-result-post (C3 fix)
+;; ============================================================
+;; Budget warnings are now injected into tool results (visible to LLM),
+;; not into tool call args (invisible to LLM).
+
+(test-case "budget warning appears in result when budget ≤5"
+  (reset-read-counts!)
+  (set-gsd-mode! 'executing)
+  (reset-go-budget!)
+  ;; Burn through 25 calls via tool-guard (decrements budget)
+  (for ([_ (in-range 25)])
+    (gsd-tool-guard (hasheq 'tool-name "read" 'args (hasheq))))
+  (check-equal? (go-read-budget) 5)
+  ;; Now read-tracker should inject budget warning into result
+  (define result (make-success-read-result "/tmp/budget-warn.txt" "content"))
+  (define hook-res (gsd-read-tracker (hasheq 'tool-name "read" 'result result)))
+  (check-eq? (hook-result-action hook-res) 'amend)
+  (define amended-result (hash-ref (hook-result-payload hook-res) 'result))
+  (define content (tool-result-content amended-result))
+  (define all-text (apply string-append (map (lambda (p) (hash-ref p 'text "")) content)))
+  (check-true (string-contains? all-text "BUDGET WARNING")
+              (format "Expected BUDGET WARNING in result, got: ~a" all-text))
+  (set-gsd-mode! #f))
+
+(test-case "no budget warning when budget > 5"
+  (reset-read-counts!)
+  (set-gsd-mode! 'executing)
+  (reset-go-budget!)
+  ;; Only 20 calls used, budget = 10
+  (for ([_ (in-range 20)])
+    (gsd-tool-guard (hasheq 'tool-name "read" 'args (hasheq))))
+  (check-equal? (go-read-budget) 10)
+  ;; read-tracker should NOT inject budget warning
+  (define result (make-success-read-result "/tmp/no-warn.txt" "content"))
+  (define hook-res (gsd-read-tracker (hasheq 'tool-name "read" 'result result)))
+  ;; Should pass (not amend) since no hint threshold hit and budget OK
+  (check-eq? (hook-result-action hook-res) 'pass)
+  (set-gsd-mode! #f))
+
+(test-case "budget warning shows remaining count"
+  (reset-read-counts!)
+  (set-gsd-mode! 'executing)
+  (reset-go-budget!)
+  (for ([_ (in-range 28)])
+    (gsd-tool-guard (hasheq 'tool-name "read" 'args (hasheq))))
+  (check-equal? (go-read-budget) 2)
+  (define result (make-success-read-result "/tmp/remaining.txt" "content"))
+  (define hook-res (gsd-read-tracker (hasheq 'tool-name "read" 'result result)))
+  (check-eq? (hook-result-action hook-res) 'amend)
+  (define amended-result (hash-ref (hook-result-payload hook-res) 'result))
+  (define content (tool-result-content amended-result))
+  (define all-text (apply string-append (map (lambda (p) (hash-ref p 'text "")) content)))
+  (check-true (string-contains? all-text "2/30")
+              (format "Expected '2/30' in warning, got: ~a" all-text))
+  (set-gsd-mode! #f))
+
+(test-case "budget warning works for grep and find (non-read tools)"
+  (reset-read-counts!)
+  (set-gsd-mode! 'executing)
+  (reset-go-budget!)
+  (for ([_ (in-range 26)])
+    (gsd-tool-guard (hasheq 'tool-name "grep" 'args (hasheq))))
+  ;; Budget should be 4 now
+  (check-equal? (go-read-budget) 4)
+  (define result (make-success-result (list (hasheq 'type "text" 'text "grep output")) (hasheq)))
+  (define hook-res (gsd-read-tracker (hasheq 'tool-name "grep" 'result result)))
+  (check-eq? (hook-result-action hook-res) 'amend)
+  (define amended-result (hash-ref (hook-result-payload hook-res) 'result))
+  (define content (tool-result-content amended-result))
+  (define all-text (apply string-append (map (lambda (p) (hash-ref p 'text "")) content)))
+  (check-true (string-contains? all-text "BUDGET WARNING")
+              (format "Expected BUDGET WARNING for grep, got: ~a" all-text))
+  (set-gsd-mode! #f))
+
+(test-case "no budget warning when budget is #f"
+  (reset-read-counts!)
+  (set-gsd-mode! 'executing)
+  (set-go-read-budget! #f)
+  (define result (make-success-read-result "/tmp/no-budget.txt" "content"))
+  (define hook-res (gsd-read-tracker (hasheq 'tool-name "read" 'result result)))
+  (check-eq? (hook-result-action hook-res) 'pass)
+  (set-gsd-mode! #f))


### PR DESCRIPTION
Addresses #1966.

fix: move budget warning from tool-call-pre to tool-result-post (Wave 1, #1966)

Wave 1 of v0.20.3 — Invisible Budget Warning Fix (C3).

- REMOVE budget warning (hook-amend args) from gsd-tool-guard (tool-call-pre).
  The warning was injected into tool call args which the LLM never sees.
- ADD budget warning injection to gsd-read-tracker (tool-result-post).
  The warning now appears in the tool result content, visible to the LLM.
- gsd-tool-guard only handles pass/block decisions now (single responsibility).
- Budget warning fires at ≤5 remaining, shows "X/30 read calls remaining".
- Works for all read-only tools (read, grep, find, ls, glob).
- NEW: 5 tests for budget warning in result content.
- UPDATE: 1 existing test changed from 'amend to 'pass (tool-guard no longer warns).
- All 149 GSD tests pass.

Milestone: v0.20.3 — GSD Planning Architecture Remediation (#119).