### PR TITLE
feat: add session-shutdown cleanup + mode transition logging (Wave 2, #1970)

Wave 2 of v0.20.3 — Lifecycle Management & Logging (W1, I4).

- ADD gsd-session-cleanup handler registered on session-shutdown hook.
  Calls reset-all-gsd-state! to clean up mode, budget, read-counts.
- ADD log-debug at every mode transition in set-gsd-mode!.
  Logs "gsd-planning: mode <old> → <new>" for easier debugging.
- NEW: 4 tests for session-shutdown cleanup in boundary tests.
- All 153 GSD tests pass.

Milestone: v0.20.3 — GSD Planning Architecture Remediation (#119).

### DIFF
--- a/extensions/gsd-planning-state.rkt
+++ b/extensions/gsd-planning-state.rkt
@@ -79,7 +79,10 @@
   (eq? (gsd-mode) v))
 
 (define (set-gsd-mode! v)
-  (call-with-semaphore state-sem (lambda () (set-box! gsd-mode-box v))))
+  (call-with-semaphore state-sem
+                       (lambda ()
+                         (log-debug (format "gsd-planning: mode ~a → ~a" (unbox gsd-mode-box) v))
+                         (set-box! gsd-mode-box v))))
 
 ;; --- pinned-planning-dir ---
 

--- a/extensions/gsd-planning.rkt
+++ b/extensions/gsd-planning.rkt
@@ -52,7 +52,8 @@
          read-counts
          get-read-count
          increment-read-count!
-         clear-read-counts!)
+         clear-read-counts!
+         gsd-session-cleanup)
 
 ;; ============================================================
 ;; Constants
@@ -569,6 +570,11 @@
        [else (hook-pass payload)])]
     [else (hook-pass payload)]))
 
+(define (gsd-session-cleanup payload)
+  (log-debug "gsd-planning: session shutdown, resetting state")
+  (reset-all-gsd-state!)
+  (hook-pass payload))
+
 (define-q-extension gsd-planning-extension
                     #:version "1.0.0"
                     #:api-version "1"
@@ -581,6 +587,8 @@
                     #:on tool-call-pre
                     gsd-tool-guard
                     #:on tool-result-post
-                    gsd-read-tracker)
+                    gsd-read-tracker
+                    #:on session-shutdown
+                    gsd-session-cleanup)
 
 (define the-extension gsd-planning-extension)

--- a/tests/test-gsd-planning-boundary.rkt
+++ b/tests/test-gsd-planning-boundary.rkt
@@ -275,3 +275,28 @@
              (lambda ()
                (set-gsd-mode! 'executing)
                (check-eq? (gsd-mode) 'executing))))
+
+;; ============================================================
+;; Session shutdown cleanup (W1 fix)
+;; ============================================================
+
+(test-case "gsd-session-cleanup resets mode to #f"
+  (set-gsd-mode! 'executing)
+  (gsd-session-cleanup (hasheq))
+  (check-equal? (gsd-mode) #f))
+
+(test-case "gsd-session-cleanup resets budget to #f"
+  (set-gsd-mode! 'executing)
+  (reset-go-budget!)
+  (gsd-session-cleanup (hasheq))
+  (check-false (go-read-budget)))
+
+(test-case "gsd-session-cleanup resets read counts"
+  (reset-read-counts!)
+  (increment-read-count! "/tmp/test.txt")
+  (gsd-session-cleanup (hasheq))
+  (check-equal? (hash-count (read-counts)) 0))
+
+(test-case "gsd-session-cleanup returns hook-pass"
+  (define result (gsd-session-cleanup (hasheq 'session-id "test-session" 'duration 100)))
+  (check-eq? (hook-result-action result) 'pass))


### PR DESCRIPTION
Addresses #1970.

feat: add session-shutdown cleanup + mode transition logging (Wave 2, #1970)

Wave 2 of v0.20.3 — Lifecycle Management & Logging (W1, I4).

- ADD gsd-session-cleanup handler registered on session-shutdown hook.
  Calls reset-all-gsd-state! to clean up mode, budget, read-counts.
- ADD log-debug at every mode transition in set-gsd-mode!.
  Logs "gsd-planning: mode <old> → <new>" for easier debugging.
- NEW: 4 tests for session-shutdown cleanup in boundary tests.
- All 153 GSD tests pass.

Milestone: v0.20.3 — GSD Planning Architecture Remediation (#119).