### PR TITLE
feat: prompt constants, artifact registry, planning-read fix (Wave 3, #1974)

Wave 3 of v0.20.3 — Prompt Constants & Artifact Registry (W4, I1, I6).

- W4: Extract EXPLORATION-BUDGET (30), IMPL-READ-PER-WAVE (2),
  IMPL-READ-TOTAL-WARN (5) as named constants. Prompts now reference
  these constants instead of hardcoded magic numbers.
- I1: Allow planning-read during /go execution mode. The prompt now
  says "planning-read is allowed to check STATE or VALIDATION" instead
  of incorrectly prohibiting it. Tool guard already allowed it; this
  aligns the prompt with the actual behavior.
- I6: Add REVIEW and ANALYSIS to valid artifact registry.
- NEW: 8 tests for prompt constants, artifact names, and I1 fix.
- UPDATE: 1 existing test updated for I1 behavior change.
- All 161 GSD tests pass.

Milestone: v0.20.3 — GSD Planning Architecture Remediation (#119).

### DIFF
--- a/extensions/gsd-planning.rkt
+++ b/extensions/gsd-planning.rkt
@@ -41,6 +41,9 @@
          GO-READ-WARN-THRESHOLD
          GO-READ-BLOCK-THRESHOLD
          READ-ONLY-TOOLS
+         EXPLORATION-BUDGET
+         IMPL-READ-PER-WAVE
+         IMPL-READ-TOTAL-WARN
          ;; Re-export state module accessors for backward compat
          pinned-planning-dir
          set-pinned-planning-dir!
@@ -89,6 +92,12 @@
 
 ;; Planning preamble prepended to user text when /plan <text> submits.
 ;; Gives the agent explicit GSD planning instructions.
+
+;; Prompt constants (W4 fix: avoid hardcoded magic numbers)
+(define EXPLORATION-BUDGET 30)
+(define IMPL-READ-PER-WAVE 2)
+(define IMPL-READ-TOTAL-WARN 5)
+
 (define planning-system-prompt
   (string-append
    "[gsd-planning] Create a structured implementation plan for the following request.\n"
@@ -99,7 +108,8 @@
    "  - Exact file path and line numbers\n"
    "  - The old-text that the edit tool will match\n"
    "  - The new-text replacement code\n"
-   "EXPLORATION BUDGET: Maximum 30 tool calls (read, grep, find, planning-read).\n"
+   (format "EXPLORATION BUDGET: Maximum ~a tool calls (read, grep, find, planning-read).\n"
+           EXPLORATION-BUDGET)
    "After 30 calls, write the plan with what you know. Partial plans are better than no plans.\n"
    "Prioritize files most likely to contain the root cause. Skip tangential exploration.\n"
    "\n"
@@ -129,7 +139,9 @@
                      ("BUG_PLAN" . ".md")
                      ("BUG_STATE" . ".md")
                      ("BUG_VALIDATION" . ".md")
-                     ("SUMMARY" . ".md")))
+                     ("SUMMARY" . ".md")
+                     ("REVIEW" . ".md")
+                     ("ANALYSIS" . ".md")))
 
 ;; ============================================================
 ;; Path helpers
@@ -338,12 +350,16 @@
                  "CRITICAL RULES:\n"
                  "1. Do NOT re-read the plan. It is provided below in full.\n"
                  "2. Do NOT write a new plan. Execute the existing one.\n"
-                 "3. Do NOT use planning-read or planning-write during implementation.\n"
+                 "3. Do NOT use planning-write during implementation.\n"
+                 ;; I1 fix: planning-read IS allowed during /go (harmless, may need to re-check STATE)
+                 "   planning-read is allowed to check STATE or VALIDATION.\n"
                  "4. Do NOT run read-only tools (read, find, grep, ls) unless a wave's\n"
                  "   old-text match fails and you need to re-read the target file ONCE.\n"
                  "5. Use the edit or write tool for EVERY wave. Your budget is:\n"
-                 "   - Max 2 read-only tool calls per wave before you MUST write/edit.\n"
-                 "   - After 5 total read-only calls across all waves, STOP and summarize.\n"
+                 (format "   - Max ~a read-only tool calls per wave before you MUST write/edit.\n"
+                         IMPL-READ-PER-WAVE)
+                 (format "   - After ~a total read-only calls across all waves, STOP and summarize.\n"
+                         IMPL-READ-TOTAL-WARN)
                  "6. After completing each wave, run its verify command.\n"
                  "\n"
                  "The plan follows. Start implementing immediately.\n\n"))

--- a/tests/test-gsd-planning.rkt
+++ b/tests/test-gsd-planning.rkt
@@ -528,11 +528,16 @@
 (test-case "planning-implement-prompt forbids writing a new plan"
   (check-true (string-contains? planning-implement-prompt "Do NOT write a new plan")))
 
-(test-case "planning-implement-prompt forbids planning-read during implementation"
-  (check-true (string-contains? planning-implement-prompt "Do NOT use planning-read")))
+(test-case "planning-implement-prompt allows planning-read but blocks planning-write"
+  (check-false (string-contains? planning-implement-prompt
+                                 "Do NOT use planning-read or planning-write")
+               "prompt should NOT say planning-read is prohibited")
+  (check-true (string-contains? planning-implement-prompt "Do NOT use planning-write")
+              "prompt should say planning-write is prohibited"))
 
 (test-case "planning-implement-prompt sets read-only budget per wave"
-  (check-true (string-contains? planning-implement-prompt "Max 2 read-only tool calls per wave")))
+  (check-true (string-contains? planning-implement-prompt
+                                (format "Max ~a read-only" IMPL-READ-PER-WAVE))))
 
 (test-case "planning-implement-prompt does NOT tell agent to use planning-read"
   (check-false (string-contains? planning-implement-prompt "Use planning-read")))
@@ -630,3 +635,41 @@
                      (define submit-text (hash-ref (hook-result-payload result) 'submit))
                      (check-false (string-contains? submit-text "existing PLAN.md was found")
                                   "should NOT inject stale warning when no PLAN.md exists")))))
+
+;; ============================================================
+;; Wave 3 tests: Prompt constants, artifact registry, I1 fix
+;; ============================================================
+
+(test-case "planning-system-prompt references EXPLORATION-BUDGET constant"
+  (check-true (string-contains? planning-system-prompt (format "~a" EXPLORATION-BUDGET))
+              "prompt should contain the exploration budget number"))
+
+(test-case "planning-implement-prompt references IMPL-READ-PER-WAVE"
+  (check-true (string-contains? planning-implement-prompt (format "~a" IMPL-READ-PER-WAVE))
+              "implement prompt should contain per-wave read limit"))
+
+(test-case "planning-implement-prompt references IMPL-READ-TOTAL-WARN"
+  (check-true (string-contains? planning-implement-prompt (format "~a" IMPL-READ-TOTAL-WARN))
+              "implement prompt should contain total read warning threshold"))
+
+(test-case "planning-implement-prompt allows planning-read during execution (I1 fix)"
+  (check-true (string-contains? planning-implement-prompt "planning-read is allowed")
+              "prompt should say planning-read is allowed during /go")
+  (check-false (string-contains? planning-implement-prompt
+                                 "Do NOT use planning-read or planning-write")
+               "prompt should NOT say planning-read is prohibited"))
+
+(test-case "valid-artifact-name? accepts BUG_REPORT"
+  (check-true (valid-artifact-name? "BUG_REPORT")))
+
+(test-case "valid-artifact-name? accepts REVIEW"
+  (check-true (valid-artifact-name? "REVIEW")))
+
+(test-case "valid-artifact-name? accepts ANALYSIS"
+  (check-true (valid-artifact-name? "ANALYSIS")))
+
+(test-case "gsd-tool-guard allows planning-read during executing (I1 fix)"
+  (set-gsd-mode! 'executing)
+  (define res (gsd-tool-guard (hasheq 'tool-name "planning-read" 'args (hasheq))))
+  (check-eq? (hook-result-action res) 'pass)
+  (set-gsd-mode! #f))


### PR DESCRIPTION
Addresses #1974.

feat: prompt constants, artifact registry, planning-read fix (Wave 3, #1974)

Wave 3 of v0.20.3 — Prompt Constants & Artifact Registry (W4, I1, I6).

- W4: Extract EXPLORATION-BUDGET (30), IMPL-READ-PER-WAVE (2),
  IMPL-READ-TOTAL-WARN (5) as named constants. Prompts now reference
  these constants instead of hardcoded magic numbers.
- I1: Allow planning-read during /go execution mode. The prompt now
  says "planning-read is allowed to check STATE or VALIDATION" instead
  of incorrectly prohibiting it. Tool guard already allowed it; this
  aligns the prompt with the actual behavior.
- I6: Add REVIEW and ANALYSIS to valid artifact registry.
- NEW: 8 tests for prompt constants, artifact names, and I1 fix.
- UPDATE: 1 existing test updated for I1 behavior change.
- All 161 GSD tests pass.

Milestone: v0.20.3 — GSD Planning Architecture Remediation (#119).