### PR TITLE
feat: W0 GSD State Foundation — wave tracking + plan budget counter (#1989)

Add wave tracking state (completed-waves, total-waves, last-edit-wave)
and plan tool budget counter (EXPLORATION-BUDGET=30, atomic decrement)
to gsd-planning-state.rkt with semaphore-protected accessors.
Extend reset-all-gsd-state! to reset new state. 15 new tests.

### DIFF
--- a/extensions/gsd-planning-state.rkt
+++ b/extensions/gsd-planning-state.rkt
@@ -8,7 +8,8 @@
 ;; Wave 0 of v0.20.3: Addresses C1 (race condition), C2 (pinned-planning-dir parameter),
 ;; W2 (non-atomic resets).
 
-(require racket/contract)
+(require racket/contract
+         racket/set)
 
 (provide gsd-mode
          gsd-mode?
@@ -28,6 +29,18 @@
          clear-read-counts!
          current-max-old-text-len
          set-current-max-old-text-len!
+         ;; Wave tracking
+         completed-waves
+         total-waves
+         set-total-waves!
+         mark-wave-complete!
+         wave-complete?
+         next-pending-wave
+         ;; Plan tool budget
+         plan-tool-budget
+         decrement-plan-budget!
+         reset-plan-budget!
+         EXPLORATION-BUDGET
          reset-all-gsd-state!
          READ-ONLY-TOOLS)
 
@@ -55,6 +68,15 @@
 
 ;; Per-file read count for redundant-read detection.
 (define read-counts-box (box (make-hash)))
+
+;; Wave tracking state (v0.20.4 W0).
+(define completed-waves-box (box (set)))
+(define total-waves-box (box 0))
+(define last-edit-wave-box (box #f))
+
+;; Plan tool budget counter (v0.20.4 W0).
+(define EXPLORATION-BUDGET 30)
+(define plan-tool-budget-box (box #f))
 
 ;; ============================================================
 ;; Constants
@@ -147,6 +169,56 @@
 
 ;; Resets ALL GSD state atomically under the semaphore.
 ;; Called on session-shutdown and between test runs.
+;; --- wave tracking ---
+
+(define (completed-waves)
+  (call-with-semaphore state-sem (lambda () (set-copy (unbox completed-waves-box)))))
+
+(define (total-waves)
+  (call-with-semaphore state-sem (lambda () (unbox total-waves-box))))
+
+(define (set-total-waves! n)
+  (call-with-semaphore state-sem (lambda () (set-box! total-waves-box n))))
+
+(define (mark-wave-complete! idx)
+  (call-with-semaphore state-sem
+                       (lambda ()
+                         (set-box! completed-waves-box (set-add (unbox completed-waves-box) idx)))))
+
+(define (wave-complete? idx)
+  (call-with-semaphore state-sem (lambda () (set-member? (unbox completed-waves-box) idx))))
+
+(define (next-pending-wave)
+  (call-with-semaphore state-sem
+                       (lambda ()
+                         (define tw (unbox total-waves-box))
+                         (define cw (unbox completed-waves-box))
+                         (for/first ([i (in-range tw)]
+                                     #:when (not (set-member? cw i)))
+                           i))))
+
+;; --- plan tool budget ---
+
+(define (plan-tool-budget)
+  (call-with-semaphore state-sem (lambda () (unbox plan-tool-budget-box))))
+
+(define (decrement-plan-budget!)
+  (call-with-semaphore state-sem
+                       (lambda ()
+                         (define cur (unbox plan-tool-budget-box))
+                         (when cur
+                           (set-box! plan-tool-budget-box (sub1 cur)))
+                         (unbox plan-tool-budget-box))))
+
+(define (reset-plan-budget!)
+  (call-with-semaphore state-sem (lambda () (set-box! plan-tool-budget-box EXPLORATION-BUDGET))))
+
+;; ============================================================
+;; Atomic reset
+;; ============================================================
+
+;; Resets ALL GSD state atomically under the semaphore.
+;; Called on session-shutdown and between test runs.
 (define (reset-all-gsd-state!)
   (call-with-semaphore state-sem
                        (lambda ()
@@ -154,4 +226,9 @@
                          (set-box! pinned-dir-box #f)
                          (set-box! budget-box #f)
                          (set-box! edit-limit-box 500)
-                         (set-box! read-counts-box (make-hash)))))
+                         (set-box! read-counts-box (make-hash))
+                         ;; v0.20.4 W0: wave + budget state
+                         (set-box! completed-waves-box (set))
+                         (set-box! total-waves-box 0)
+                         (set-box! last-edit-wave-box #f)
+                         (set-box! plan-tool-budget-box #f))))

--- a/tests/test-gsd-planning-state.rkt
+++ b/tests/test-gsd-planning-state.rkt
@@ -205,3 +205,131 @@
   (check-equal? GO-READ-WARN-THRESHOLD 5)
   (check-equal? GO-READ-BLOCK-THRESHOLD -3)
   (check-equal? READ-ONLY-TOOLS '("read" "grep" "find" "ls" "glob")))
+
+;; ============================================================
+;; Wave tracking tests (v0.20.4 W0)
+;; ============================================================
+
+(test-case "completed-waves starts empty"
+  (reset-all-gsd-state!)
+  (check-equal? (set-count (completed-waves)) 0))
+
+(test-case "total-waves defaults to 0"
+  (reset-all-gsd-state!)
+  (check-equal? (total-waves) 0))
+
+(test-case "set-total-waves! sets and reads back"
+  (reset-all-gsd-state!)
+  (set-total-waves! 5)
+  (check-equal? (total-waves) 5))
+
+(test-case "mark-wave-complete! adds wave to completed set"
+  (reset-all-gsd-state!)
+  (set-total-waves! 3)
+  (mark-wave-complete! 0)
+  (check-true (wave-complete? 0))
+  (check-false (wave-complete? 1))
+  (mark-wave-complete! 2)
+  (check-true (wave-complete? 2)))
+
+(test-case "next-pending-wave returns first incomplete wave"
+  (reset-all-gsd-state!)
+  (set-total-waves! 4)
+  (check-equal? (next-pending-wave) 0)
+  (mark-wave-complete! 0)
+  (check-equal? (next-pending-wave) 1)
+  (mark-wave-complete! 1)
+  (mark-wave-complete! 2)
+  (check-equal? (next-pending-wave) 3)
+  (mark-wave-complete! 3)
+  (check-equal? (next-pending-wave) #f))
+
+(test-case "next-pending-wave returns #f when total-waves is 0"
+  (reset-all-gsd-state!)
+  (check-equal? (next-pending-wave) #f))
+
+;; ============================================================
+;; Plan tool budget tests (v0.20.4 W0)
+;; ============================================================
+
+(test-case "plan-tool-budget defaults to #f"
+  (reset-all-gsd-state!)
+  (check-false (plan-tool-budget)))
+
+(test-case "reset-plan-budget! sets budget to EXPLORATION-BUDGET"
+  (reset-all-gsd-state!)
+  (reset-plan-budget!)
+  (check-equal? (plan-tool-budget) 30)
+  (check-equal? (plan-tool-budget) EXPLORATION-BUDGET))
+
+(test-case "decrement-plan-budget! decrements and returns new value"
+  (reset-all-gsd-state!)
+  (reset-plan-budget!)
+  (check-equal? (decrement-plan-budget!) 29)
+  (check-equal? (decrement-plan-budget!) 28)
+  (check-equal? (plan-tool-budget) 28))
+
+(test-case "decrement-plan-budget! does nothing when budget is #f"
+  (reset-all-gsd-state!)
+  (check-false (decrement-plan-budget!))
+  (check-false (plan-tool-budget)))
+
+(test-case "reset-plan-budget! can be called multiple times"
+  (reset-all-gsd-state!)
+  (reset-plan-budget!)
+  (decrement-plan-budget!)
+  (decrement-plan-budget!)
+  (check-equal? (plan-tool-budget) 28)
+  (reset-plan-budget!)
+  (check-equal? (plan-tool-budget) 30))
+
+;; ============================================================
+;; reset-all-gsd-state! resets wave + budget state (v0.20.4 W0)
+;; ============================================================
+
+(test-case "reset-all-gsd-state! resets wave tracking"
+  (reset-all-gsd-state!)
+  (set-total-waves! 5)
+  (mark-wave-complete! 0)
+  (mark-wave-complete! 3)
+  (reset-all-gsd-state!)
+  (check-equal? (total-waves) 0)
+  (check-equal? (set-count (completed-waves)) 0)
+  (check-false (next-pending-wave)))
+
+(test-case "reset-all-gsd-state! resets plan budget"
+  (reset-all-gsd-state!)
+  (reset-plan-budget!)
+  (decrement-plan-budget!)
+  (reset-all-gsd-state!)
+  (check-false (plan-tool-budget)))
+
+(test-case "EXPLORATION-BUDGET constant is 30"
+  (check-equal? EXPLORATION-BUDGET 30))
+
+;; ============================================================
+;; Concurrent wave tracking tests
+;; ============================================================
+
+(test-case "concurrent mark-wave-complete! has no lost updates"
+  (reset-all-gsd-state!)
+  (set-total-waves! 50)
+  (define threads
+    (for/list ([i (in-range 50)])
+      (thread (lambda () (mark-wave-complete! i)))))
+  (for-each sync threads)
+  ;; All 50 waves should be complete
+  (for ([i (in-range 50)])
+    (check-true (wave-complete? i) (format "wave ~a should be complete" i))))
+
+(test-case "concurrent decrement-plan-budget! has no lost updates"
+  (reset-all-gsd-state!)
+  (reset-plan-budget!)
+  (define threads
+    (for/list ([_ (in-range 10)])
+      (thread (lambda ()
+                (for ([_ (in-range 3)])
+                  (decrement-plan-budget!))))))
+  (for-each sync threads)
+  ;; Expected: 30 - 30 = 0
+  (check-equal? (plan-tool-budget) 0))


### PR DESCRIPTION
Addresses #1989.

feat: W0 GSD State Foundation — wave tracking + plan budget counter (#1989)

Add wave tracking state (completed-waves, total-waves, last-edit-wave)
and plan tool budget counter (EXPLORATION-BUDGET=30, atomic decrement)
to gsd-planning-state.rkt with semaphore-protected accessors.
Extend reset-all-gsd-state! to reset new state. 15 new tests.