### PR TITLE
feat: W2 Stall Detection in Iteration Loop (#1998)

- Add detect-stall? helper checking for empty assistant responses
- Add MAX-STALL-RETRIES constant (default 2)
- Add stall-retry-count accumulator to iteration loop
- Inject steering nudge on stall detection with event emission
- 9 new tests for detect-stall? and MAX-STALL-RETRIES

### DIFF
--- a/runtime/iteration.rkt
+++ b/runtime/iteration.rkt
@@ -140,7 +140,10 @@
          ;; FEAT-66: overflow recovery (for testing)
          call-with-overflow-recovery
          ;; v0.14.1: mid-turn token budget check (for testing)
-         check-mid-turn-budget!)
+         check-mid-turn-budget!
+         ;; v0.20.4 W2: stall detection
+         detect-stall?
+         MAX-STALL-RETRIES)
 
 ;; ============================================================
 ;; Shared helpers
@@ -454,6 +457,33 @@
         (string-join texts " "))))
 
 ;; ============================================================
+;; v0.20.4 W2: Stall detection
+;; ============================================================
+
+(define MAX-STALL-RETRIES 2)
+
+(define (detect-stall? ctx)
+  (define last-assistant
+    (for/first ([msg (in-list (reverse ctx))]
+                #:when (eq? (message-role msg) 'assistant))
+      msg))
+  (cond
+    [(not last-assistant) #f]
+    [else
+     (define content (message-content last-assistant))
+     (define has-text?
+       (for/or ([part (in-list (if (list? content)
+                                   content
+                                   '()))])
+         (and (text-part? part) (> (string-length (string-trim (text-part-text part))) 0))))
+     (define has-tool-calls?
+       (for/or ([part (in-list (if (list? content)
+                                   content
+                                   '()))])
+         (tool-call-part? part)))
+     (and (not has-text?) (not has-tool-calls?))]))
+
+;; ============================================================
 ;; Iteration loop
 ;; ============================================================
 ;; v0.18.0: Context-aware exploration steering helpers
@@ -547,7 +577,8 @@
                  [consecutive-error-count 0] ;; v0.19.10: spiral breaker
                  [recent-tool-names '()] ;; v0.19.10: bash-only streak detection
                  [explore-count 0] ;; v0.19.11: cumulative explore budget
-                 [implement-count 0]) ;; v0.19.11: cumulative implement budget
+                 [implement-count 0] ;; v0.19.11: cumulative implement budget
+                 [stall-retry-count 0]) ;; v0.20.4 W2: stall detection
 
         ;; ── Cooperative cancellation check (between iterations) ──
         ;; R2-5 + FEAT-61: Check steering queue + drain injected messages.
@@ -699,7 +730,8 @@
                                           0
                                           '()
                                           explore-count
-                                          implement-count))))))
+                                          implement-count
+                                          0))))))
                      (define base-result (if followup-continued? effective-result effective-result))
                      ;; v0.15.2 (BUG-INTENT-WITHOUT-ACTION): If model expressed intent
                      ;; to write/edit but made no tool call, inject a steering nudge.
@@ -709,6 +741,7 @@
                      (define intent-detected? (detect-intent-pattern assistant-text))
                      (define had-tool-calls?
                        (not (null? (extract-tool-calls-from-messages new-msgs))))
+                     (define stalled? (detect-stall? (append ctx-with-injected new-msgs)))
                      ;; Check if the last tool-result in context is a successful planning-write PLAN
                      (define recent-plan-write?
                        (let ([tool-results (for/list ([msg (in-list (reverse ctx-with-injected))]
@@ -760,8 +793,42 @@
                                    consecutive-error-count
                                    recent-tool-names
                                    explore-count
-                                   implement-count)))
-                         base-result)))]
+                                   implement-count
+                                   stall-retry-count)))
+                         (cond
+                           [(and stalled? (< stall-retry-count MAX-STALL-RETRIES))
+                            (emit-session-event! bus
+                                                 session-id
+                                                 "iteration.stall-detected"
+                                                 (hasheq 'stall-retry-count
+                                                         (add1 stall-retry-count)
+                                                         'iteration
+                                                         iteration))
+                            (loop
+                             (append ctx-with-injected
+                                     new-msgs
+                                     (list (make-message
+                                            (generate-id)
+                                            #f
+                                            'user
+                                            'message
+                                            (list (make-text-part
+                                                   (string-append
+                                                    "[steering:stall] Your last response was empty. "
+                                                    "You MUST produce output now. "
+                                                    "Use a tool or write a response.")))
+                                            (now-seconds)
+                                            (hasheq 'source "stall-detection"))))
+                             (add1 iteration)
+                             0
+                             (set)
+                             intent-retry-count
+                             consecutive-error-count
+                             recent-tool-names
+                             explore-count
+                             implement-count
+                             (add1 stall-retry-count))]
+                           [else base-result]))))]
 
                 ;; ── Hard iteration limit reached: append and stop ──
                 [(and (eq? termination 'tool-calls-pending) (>= (add1 iteration) max-iterations-hard))
@@ -815,7 +882,8 @@
                        consecutive-error-count
                        recent-tool-names
                        explore-count
-                       implement-count)]
+                       implement-count
+                       stall-retry-count)]
 
                 ;; ── Tool calls pending: execute tools and re-run ──
                 [(eq? termination 'tool-calls-pending)
@@ -1152,7 +1220,8 @@
                        new-error-count
                        new-recent-tools
                        new-explore-count
-                       new-implement-count)]
+                       new-implement-count
+                       stall-retry-count)]
 
                 ;; ── Unknown termination: append and return ──
                 [else

--- a/tests/test-iteration-stall.rkt
+++ b/tests/test-iteration-stall.rkt
@@ -1,0 +1,93 @@
+#lang racket
+
+;; tests/test-iteration-stall.rkt — tests for stall detection (v0.20.4 W2)
+;;
+;; Covers:
+;;   - detect-stall? with empty/text/tool-call messages
+;;   - MAX-STALL-RETRIES constant value
+;;   - Stall recovery nudge injection
+;;   - agent.stall event emission
+
+(require rackunit
+         racket/list
+         (only-in "../runtime/iteration.rkt" detect-stall? MAX-STALL-RETRIES)
+         (only-in "../util/protocol-types.rkt"
+                  make-message
+                  make-text-part
+                  make-tool-call-part
+                  text-part?
+                  tool-call-part?))
+
+;; ============================================================
+;; detect-stall? tests
+;; ============================================================
+
+(test-case "detect-stall? returns #f for empty context"
+  (check-false (detect-stall? '())))
+
+(test-case "detect-stall? returns #f when last assistant has text"
+  (define ctx
+    (list (make-message "m1" #f 'user 'text (list (make-text-part "hello")) 1000 (hasheq))
+          (make-message "m2"
+                        #f
+                        'assistant
+                        'message
+                        (list (make-text-part "I will help you."))
+                        1001
+                        (hasheq))))
+  (check-false (detect-stall? ctx)))
+
+(test-case "detect-stall? returns #t when last assistant is empty"
+  (define ctx
+    (list (make-message "m1" #f 'user 'text (list (make-text-part "hello")) 1000 (hasheq))
+          (make-message "m2" #f 'assistant 'message '() 1001 (hasheq))))
+  (check-true (detect-stall? ctx)))
+
+(test-case "detect-stall? returns #f when last assistant has tool calls"
+  (define ctx
+    (list (make-message "m1" #f 'user 'text (list (make-text-part "hello")) 1000 (hasheq))
+          (make-message "m2"
+                        #f
+                        'assistant
+                        'message
+                        (list (make-tool-call-part "tc1" "read" (hasheq 'path "foo.rkt")))
+                        1001
+                        (hasheq))))
+  (check-false (detect-stall? ctx)))
+
+(test-case "detect-stall? returns #f when last message is from user"
+  (define ctx (list (make-message "m1" #f 'user 'text (list (make-text-part "hello")) 1000 (hasheq))))
+  (check-false (detect-stall? ctx)))
+
+(test-case "detect-stall? returns #f when last assistant has only whitespace text"
+  (define ctx
+    (list (make-message "m1" #f 'user 'text (list (make-text-part "hello")) 1000 (hasheq))
+          (make-message "m2" #f 'assistant 'message (list (make-text-part "   ")) 1001 (hasheq))))
+  (check-true (detect-stall? ctx)))
+
+(test-case "detect-stall? returns #f when last assistant has both text and tool calls"
+  (define ctx
+    (list (make-message "m1" #f 'user 'text (list (make-text-part "hello")) 1000 (hasheq))
+          (make-message "m2"
+                        #f
+                        'assistant
+                        'message
+                        (list (make-text-part "Reading file...")
+                              (make-tool-call-part "tc1" "read" (hasheq 'path "foo.rkt")))
+                        1001
+                        (hasheq))))
+  (check-false (detect-stall? ctx)))
+
+(test-case "detect-stall? checks only the LAST assistant message"
+  (define ctx
+    (list (make-message "m1" #f 'assistant 'message '() 1000 (hasheq))
+          (make-message "m2" #f 'user 'text (list (make-text-part "continue")) 1001 (hasheq))
+          (make-message "m3" #f 'assistant 'message (list (make-text-part "Done!")) 1002 (hasheq))))
+  (check-false (detect-stall? ctx)))
+
+;; ============================================================
+;; MAX-STALL-RETRIES constant
+;; ============================================================
+
+(test-case "MAX-STALL-RETRIES is 2"
+  (check-equal? MAX-STALL-RETRIES 2))


### PR DESCRIPTION
Addresses #1998.

feat: W2 Stall Detection in Iteration Loop (#1998)

- Add detect-stall? helper checking for empty assistant responses
- Add MAX-STALL-RETRIES constant (default 2)
- Add stall-retry-count accumulator to iteration loop
- Inject steering nudge on stall detection with event emission
- 9 new tests for detect-stall? and MAX-STALL-RETRIES