### PR TITLE
feat: W3 SDK Observability — gsd-snapshot + gsd-status (#2001)

- Add gsd-snapshot to gsd-planning-state.rkt: immutable hash of all GSD state
- Add gsd-status to interfaces/sdk.rkt: returns snapshot or 'no-active-session
- 7 new tests for snapshot immutability, keys, state reflection, and status

### DIFF
--- a/extensions/gsd-planning-state.rkt
+++ b/extensions/gsd-planning-state.rkt
@@ -41,6 +41,8 @@
          decrement-plan-budget!
          reset-plan-budget!
          EXPLORATION-BUDGET
+         ;; v0.20.4 W3: observability
+         gsd-snapshot
          reset-all-gsd-state!
          READ-ONLY-TOOLS)
 
@@ -219,6 +221,32 @@
 
 ;; Resets ALL GSD state atomically under the semaphore.
 ;; Called on session-shutdown and between test runs.
+;; ============================================================
+;; v0.20.4 W3: Observability — immutable snapshot of all GSD state
+;; ============================================================
+
+(define (gsd-snapshot)
+  (call-with-semaphore state-sem
+                       (lambda ()
+                         (hasheq 'mode
+                                 (unbox gsd-mode-box)
+                                 'pinned-dir
+                                 (unbox pinned-dir-box)
+                                 'go-read-budget
+                                 (unbox budget-box)
+                                 'edit-limit
+                                 (unbox edit-limit-box)
+                                 'read-counts
+                                 (hash-copy (unbox read-counts-box))
+                                 'completed-waves
+                                 (set-copy (unbox completed-waves-box))
+                                 'total-waves
+                                 (unbox total-waves-box)
+                                 'last-edit-wave
+                                 (unbox last-edit-wave-box)
+                                 'plan-tool-budget
+                                 (unbox plan-tool-budget-box)))))
+
 (define (reset-all-gsd-state!)
   (call-with-semaphore state-sem
                        (lambda ()

--- a/interfaces/sdk.rkt
+++ b/interfaces/sdk.rkt
@@ -37,6 +37,7 @@
                   context-usage-compaction-threshold
                   context-usage-near-threshold?)
          (only-in "../extensions/api.rkt" list-extensions)
+         (only-in "../extensions/gsd-planning-state.rkt" gsd-snapshot)
          (only-in "../agent/queue.rkt" enqueue-steering! enqueue-followup!)
          (only-in "../runtime/session-index.rkt"
                   navigate-to-entry!
@@ -141,7 +142,10 @@
          q:session-info
          q:session-branch
          q:session-navigate
-         q:session-tree-info)
+         q:session-tree-info
+
+         ;; v0.20.4 W3: GSD observability
+         gsd-status)
 
 ;; ============================================================
 ;; Cancellation token — imported from util/cancellation.rkt
@@ -624,3 +628,14 @@
        [(not (file-exists? log-path))
         (hasheq 'total-entries 0 'branch-count 0 'navigation-count 0 'summary-count 0 'leaf-ids '())]
        [else (store:tree-info (store:load-tree log-path))])]))
+
+;; ============================================================
+;; v0.20.4 W3: GSD Observability
+;; ============================================================
+
+;;; gsd-status : -> (or/c 'no-active-session hash?)
+;;; Returns an immutable snapshot of all GSD state, or 'no-active-session
+;;; if no GSD mode is active.
+(define (gsd-status)
+  (define snap (gsd-snapshot))
+  (if (hash-ref snap 'mode #f) snap 'no-active-session))

--- a/tests/test-sdk-gsd.rkt
+++ b/tests/test-sdk-gsd.rkt
@@ -1,0 +1,91 @@
+#lang racket
+
+;; tests/test-sdk-gsd.rkt — tests for GSD observability via SDK (v0.20.4 W3)
+;;
+;; Covers:
+;;   - gsd-snapshot returns immutable hash with expected keys
+;;   - gsd-snapshot doesn't expose internal boxes
+;;   - gsd-status with no session → 'no-active-session
+;;   - gsd-status with active session → hash with expected keys
+
+(require rackunit
+         (only-in "../extensions/gsd-planning-state.rkt"
+                  gsd-snapshot
+                  set-gsd-mode!
+                  set-total-waves!
+                  mark-wave-complete!
+                  reset-plan-budget!
+                  reset-all-gsd-state!)
+         (only-in "../interfaces/sdk.rkt" gsd-status))
+
+;; ============================================================
+;; gsd-snapshot tests
+;; ============================================================
+
+(test-case "gsd-snapshot returns immutable hash"
+  (reset-all-gsd-state!)
+  (define snap (gsd-snapshot))
+  (check-pred hash? snap)
+  ;; Immutable? Writing should fail
+  (check-exn exn:fail? (lambda () (hash-set! snap 'foo 'bar))))
+
+(test-case "gsd-snapshot has expected keys"
+  (reset-all-gsd-state!)
+  (define snap (gsd-snapshot))
+  (for ([key '(mode pinned-dir
+                    go-read-budget
+                    edit-limit
+                    read-counts
+                    completed-waves
+                    total-waves
+                    last-edit-wave
+                    plan-tool-budget)])
+    (check-true (hash-has-key? snap key) (format "missing key: ~a" key))))
+
+(test-case "gsd-snapshot doesn't expose internal boxes"
+  (reset-all-gsd-state!)
+  (define snap (gsd-snapshot))
+  ;; All values should be plain data, not boxes
+  (check-false (box? (hash-ref snap 'mode)))
+  (check-false (box? (hash-ref snap 'go-read-budget)))
+  (check-false (box? (hash-ref snap 'edit-limit)))
+  (check-false (box? (hash-ref snap 'total-waves)))
+  (check-false (box? (hash-ref snap 'plan-tool-budget))))
+
+(test-case "gsd-snapshot reflects state changes"
+  (reset-all-gsd-state!)
+  (set-gsd-mode! 'executing)
+  (set-total-waves! 5)
+  (mark-wave-complete! 0)
+  (mark-wave-complete! 1)
+  (reset-plan-budget!)
+  (define snap (gsd-snapshot))
+  (check-equal? (hash-ref snap 'mode) 'executing)
+  (check-equal? (hash-ref snap 'total-waves) 5)
+  (check-true (set=? (hash-ref snap 'completed-waves) (set 0 1)))
+  (check-equal? (hash-ref snap 'plan-tool-budget) 30)
+  ;; Clean up
+  (reset-all-gsd-state!))
+
+;; ============================================================
+;; gsd-status tests
+;; ============================================================
+
+(test-case "gsd-status returns 'no-active-session when no GSD mode"
+  (reset-all-gsd-state!)
+  (check-equal? (gsd-status) 'no-active-session))
+
+(test-case "gsd-status returns hash when GSD mode is active"
+  (reset-all-gsd-state!)
+  (set-gsd-mode! 'planning)
+  (define status (gsd-status))
+  (check-pred hash? status)
+  (check-equal? (hash-ref status 'mode) 'planning)
+  ;; Clean up
+  (reset-all-gsd-state!))
+
+(test-case "gsd-status returns 'no-active-session after reset"
+  (reset-all-gsd-state!)
+  (set-gsd-mode! 'executing)
+  (reset-all-gsd-state!)
+  (check-equal? (gsd-status) 'no-active-session))


### PR DESCRIPTION
Addresses #2001.

feat: W3 SDK Observability — gsd-snapshot + gsd-status (#2001)

- Add gsd-snapshot to gsd-planning-state.rkt: immutable hash of all GSD state
- Add gsd-status to interfaces/sdk.rkt: returns snapshot or 'no-active-session
- 7 new tests for snapshot immutability, keys, state reflection, and status