### PR TITLE
feat: W4 Automated GSD Workflow Testing — benchmark + SDK integration (#2004)

- Add planning-workflow category to benchmark task.rkt
- Add execute-task/gsd-workflow and trace-gsd-events to executor.rkt
- Add wf-gsd-planning and wf-gsd-exploration-cap benchmark task JSON files
- Add 4 SDK integration tests: wave progress, budget depletion, plan-tool-budget, mode transitions
- Total: 11 tests in test-sdk-gsd.rkt

### DIFF
--- a/scripts/benchmark/executor.rkt
+++ b/scripts/benchmark/executor.rkt
@@ -29,13 +29,16 @@
          (only-in "../../llm/model.rkt" make-model-response)
          (only-in "../../util/protocol-types.rkt" message-role message-content text-part-text)
          (only-in "../../util/jsonl.rkt" jsonl-read-all-valid)
+         (only-in "../../extensions/gsd-planning-state.rkt" gsd-snapshot)
          "task.rkt")
 
 (provide (struct-out execution-result)
          execute-task/mock
          execute-task/live
+         execute-task/gsd-workflow
          build-live-provider
-         trace-tool-calls)
+         trace-tool-calls
+         trace-gsd-events)
 
 ;; ============================================================
 ;; Result struct
@@ -210,6 +213,45 @@
                     error-msg
                     tmp-dir
                     raw-result))
+
+;; ============================================================
+;; v0.20.4 W4: GSD workflow execution + event filtering
+;; ============================================================
+
+;; trace-gsd-events : path? -> (listof hash?)
+;; Extracts GSD-related events from trace JSONL.
+(define (trace-gsd-events trace-path)
+  (if (not (and trace-path (file-exists? trace-path)))
+      '()
+      (for/list ([entry (in-list (jsonl-read-all-valid trace-path))]
+                 #:when (and (hash? entry)
+                             (let ([ph (hash-ref entry 'phase #f)])
+                               (and (string? ph)
+                                    (or (string-prefix? ph "gsd.")
+                                        (string-prefix? ph "agent.stall"))))))
+        entry)))
+
+;; execute-task/gsd-workflow : benchmark-task? [(or/c string? #f)] [(or/c path? #f)] -> execution-result?
+;; Specialized execution for planning-workflow tasks.
+;; Captures GSD events and includes snapshot in the result.
+(define (execute-task/gsd-workflow task [provider-override #f] [output-dir #f])
+  (define provider
+    (if provider-override
+        (build-live-provider provider-override)
+        (build-mock-provider-for-task task)))
+  (define result (execute-task-internal task provider provider-override output-dir))
+  (define gsd-events (trace-gsd-events (execution-result-trace-path result)))
+  (if (null? gsd-events)
+      result
+      (struct-copy execution-result
+                   result
+                   [raw-result
+                    (hasheq 'gsd-events
+                            gsd-events
+                            'gsd-snapshot
+                            (gsd-snapshot)
+                            'original-result
+                            (execution-result-raw-result result))])))
 
 ;; trace-tool-call-count : path? -> exact-nonnegative-integer?
 ;; Count tool.call.started events in trace JSONL as iteration proxy.

--- a/scripts/benchmark/task.rkt
+++ b/scripts/benchmark/task.rkt
@@ -115,7 +115,7 @@
     (if (symbol? raw-category)
         raw-category
         (string->symbol raw-category)))
-  (unless (member category '(implementation bug-fix planning full-workflow))
+  (unless (member category '(implementation bug-fix planning planning-workflow full-workflow))
     (error 'validate-benchmark-task
            "Category must be one of: implementation, bug-fix, planning, full-workflow, got: ~a"
            category))

--- a/scripts/benchmark/tasks/wf-gsd-exploration-cap.json
+++ b/scripts/benchmark/tasks/wf-gsd-exploration-cap.json
@@ -1,0 +1,15 @@
+{
+  "name": "wf-gsd-exploration-cap",
+  "category": "planning-workflow",
+  "difficulty": 2,
+  "description": "GSD exploration cap: plan phase should respect read budget",
+  "prompt": "/plan Analyze all modules in src/ and propose a refactoring strategy",
+  "max_iterations": 15,
+  "max_tokens": 80000,
+  "time_limit_seconds": 90,
+  "scoring": {
+    "tools_not_used": ["bash"],
+    "max_iterations": 15
+  },
+  "teardown": []
+}

--- a/scripts/benchmark/tasks/wf-gsd-planning.json
+++ b/scripts/benchmark/tasks/wf-gsd-planning.json
@@ -1,0 +1,15 @@
+{
+  "name": "wf-gsd-planning",
+  "category": "planning-workflow",
+  "difficulty": 1,
+  "description": "Basic GSD planning workflow: /plan → plan written → /go → execute",
+  "prompt": "/plan Create a hello function in hello.rkt that returns 'hello world'",
+  "max_iterations": 10,
+  "max_tokens": 50000,
+  "time_limit_seconds": 60,
+  "scoring": {
+    "tools_used": ["write"],
+    "max_iterations": 10
+  },
+  "teardown": []
+}

--- a/tests/test-sdk-gsd.rkt
+++ b/tests/test-sdk-gsd.rkt
@@ -9,12 +9,16 @@
 ;;   - gsd-status with active session → hash with expected keys
 
 (require rackunit
+         racket/set
          (only-in "../extensions/gsd-planning-state.rkt"
                   gsd-snapshot
                   set-gsd-mode!
                   set-total-waves!
                   mark-wave-complete!
                   reset-plan-budget!
+                  decrement-plan-budget!
+                  decrement-budget!
+                  set-go-read-budget!
                   reset-all-gsd-state!)
          (only-in "../interfaces/sdk.rkt" gsd-status))
 
@@ -89,3 +93,61 @@
   (set-gsd-mode! 'executing)
   (reset-all-gsd-state!)
   (check-equal? (gsd-status) 'no-active-session))
+
+;; ============================================================
+;; v0.20.4 W4: SDK integration tests
+;; ============================================================
+
+(test-case "gsd-snapshot reflects wave progress during execution"
+  (reset-all-gsd-state!)
+  (set-gsd-mode! 'executing)
+  (set-total-waves! 3)
+  ;; Simulate completing waves 0 and 1
+  (mark-wave-complete! 0)
+  (mark-wave-complete! 1)
+  (define snap (gsd-snapshot))
+  (check-equal? (hash-ref snap 'mode) 'executing)
+  (check-equal? (hash-ref snap 'total-waves) 3)
+  (check-true (set=? (hash-ref snap 'completed-waves) (set 0 1)))
+  (check-equal? (gsd-status) snap) ;; gsd-status matches snapshot when mode active
+  (reset-all-gsd-state!))
+
+(test-case "gsd-snapshot reflects budget depletion"
+  (reset-all-gsd-state!)
+  (set-gsd-mode! 'executing)
+  (set-go-read-budget! 5)
+  (decrement-budget!)
+  (decrement-budget!)
+  (define snap (gsd-snapshot))
+  (check-equal? (hash-ref snap 'go-read-budget) 3)
+  (reset-all-gsd-state!))
+
+(test-case "gsd-snapshot reflects plan-tool-budget depletion"
+  (reset-all-gsd-state!)
+  (set-gsd-mode! 'planning)
+  (reset-plan-budget!) ;; sets to EXPLORATION-BUDGET (30)
+  (decrement-plan-budget!)
+  (decrement-plan-budget!)
+  (decrement-plan-budget!)
+  (define snap (gsd-snapshot))
+  (check-equal? (hash-ref snap 'plan-tool-budget) 27)
+  (reset-all-gsd-state!))
+
+(test-case "gsd-snapshot reflects mode transitions"
+  (reset-all-gsd-state!)
+  ;; Start: no mode
+  (check-equal? (hash-ref (gsd-snapshot) 'mode) #f)
+  (check-equal? (gsd-status) 'no-active-session)
+  ;; Transition to planning
+  (set-gsd-mode! 'planning)
+  (check-equal? (hash-ref (gsd-snapshot) 'mode) 'planning)
+  (check-pred hash? (gsd-status))
+  ;; Transition to plan-written
+  (set-gsd-mode! 'plan-written)
+  (check-equal? (hash-ref (gsd-snapshot) 'mode) 'plan-written)
+  ;; Transition to executing
+  (set-gsd-mode! 'executing)
+  (check-equal? (hash-ref (gsd-snapshot) 'mode) 'executing)
+  ;; Reset
+  (reset-all-gsd-state!)
+  (check-equal? (hash-ref (gsd-snapshot) 'mode) #f))


### PR DESCRIPTION
Addresses #2004.

feat: W4 Automated GSD Workflow Testing — benchmark + SDK integration (#2004)

- Add planning-workflow category to benchmark task.rkt
- Add execute-task/gsd-workflow and trace-gsd-events to executor.rkt
- Add wf-gsd-planning and wf-gsd-exploration-cap benchmark task JSON files
- Add 4 SDK integration tests: wave progress, budget depletion, plan-tool-budget, mode transitions
- Total: 11 tests in test-sdk-gsd.rkt