### PR TITLE
feat(sdk): add register-default-tools?, dispatch-command!, and auto-load-extensions (#2015)

W0 of v0.20.5 — SDK Foundation: Tool Registry + Extension Auto-Setup

- make-runtime now accepts #:register-default-tools? (default #t) to
  auto-register all 13 built-in tools on the fresh registry
- make-runtime now accepts #:auto-load-extensions? and #:project-dir
  for auto-discovering and loading extensions from project-dir/extensions/
- New dispatch-command! function dispatches 'execute-command hooks
  through the extension registry for SDK-level command support
- Returns 'no-extension-registry when no extension registry is configured
- Added 6 new test cases covering all new functionality

Closes #2016, closes #2017, closes #2018

### DIFF
--- a/interfaces/sdk.rkt
+++ b/interfaces/sdk.rkt
@@ -15,8 +15,10 @@
 (require racket/contract
          racket/math
          racket/list
+         racket/string
          "../llm/provider.rkt"
          (only-in "../tools/tool.rkt" make-tool-registry tool-registry?)
+         (only-in "../tools/registry-defaults.rkt" register-default-tools!)
          "../agent/event-bus.rkt"
          "../util/protocol-types.rkt"
          (prefix-in session: "../runtime/agent-session.rkt")
@@ -36,7 +38,13 @@
                   context-usage-usage-percent
                   context-usage-compaction-threshold
                   context-usage-near-threshold?)
-         (only-in "../extensions/api.rkt" list-extensions)
+         (only-in "../extensions/api.rkt" list-extensions make-extension-registry)
+         (only-in "../extensions/hooks.rkt"
+                  dispatch-hooks
+                  hook-result?
+                  hook-result-action
+                  hook-result-payload)
+         (only-in "../extensions/loader.rkt" discover-extensions load-extension!)
          (only-in "../extensions/gsd-planning-state.rkt" gsd-snapshot)
          (only-in "../agent/queue.rkt" enqueue-steering! enqueue-followup!)
          (only-in "../runtime/session-index.rkt"
@@ -80,8 +88,12 @@
                                             #:max-iterations exact-positive-integer?
                                             #:system-instructions (listof string?)
                                             #:token-budget-threshold exact-positive-integer?
-                                            #:cancellation-token any/c)
+                                            #:cancellation-token any/c
+                                            #:register-default-tools? any/c
+                                            #:auto-load-extensions? any/c
+                                            #:project-dir (or/c path-string? path? #f))
                              runtime?)]
+                       [dispatch-command! (-> runtime? string? string? (values runtime? any/c))]
                        [open-session (->* (runtime?) ((or/c string? #f)) runtime?)]
                        [run-prompt! (runtime? string? . -> . (values runtime? any/c))]
                        [subscribe-events!
@@ -211,7 +223,21 @@
                       #:token-budget-threshold [token-budget-threshold DEFAULT-TOKEN-BUDGET-THRESHOLD]
                       #:cancellation-token [cancellation-token #f]
                       #:resource-loader [resource-loader #f]
-                      #:session-manager [session-mgr #f])
+                      #:session-manager [session-mgr #f]
+                      #:register-default-tools? [register-default-tools? #t]
+                      #:auto-load-extensions? [auto-load-extensions? #f]
+                      #:project-dir [project-dir #f])
+  ;; v0.20.5 W0: Auto-register default tools unless disabled
+  (when register-default-tools?
+    (register-default-tools! tool-registry))
+  ;; v0.20.5 W0: Auto-load extensions from project-dir when requested
+  (when (and auto-load-extensions? project-dir)
+    (define ext-dir (build-path project-dir "extensions"))
+    (when (directory-exists? ext-dir)
+      (for ([ext (in-list (discover-extensions ext-dir))])
+        (load-extension! (or extension-registry (make-extension-registry))
+                         ext
+                         #:event-bus event-bus))))
   (make-runtime-internal (runtime-config provider
                                          tool-registry
                                          extension-registry
@@ -639,3 +665,25 @@
 (define (gsd-status)
   (define snap (gsd-snapshot))
   (if (hash-ref snap 'mode #f) snap 'no-active-session))
+
+;; ============================================================
+;; v0.20.5 W0: SDK Command Dispatch
+;; ============================================================
+
+;;; dispatch-command! : runtime? string? string? -> (values runtime? any/c)
+;;;
+;;; Dispatches an 'execute-command hook through the extension registry.
+;;; This enables SDK users to trigger extension-registered commands
+;;; (e.g., GSD /plan, /go) without manually wiring hook dispatch.
+;;;
+;;; Returns (values runtime? hook-result-or-symbol) where the second value
+;;; is either a hook-result from the extension or 'no-extension-registry.
+(define (dispatch-command! rt command input)
+  (define cfg (rt-cfg rt))
+  (define ext-reg (runtime-config-extension-registry cfg))
+  (cond
+    [(not ext-reg) (values rt 'no-extension-registry)]
+    [else
+     (define payload (hasheq 'command command 'input input))
+     (define result (dispatch-hooks 'execute-command payload ext-reg))
+     (values rt result)]))

--- a/tests/test-sdk.rkt
+++ b/tests/test-sdk.rkt
@@ -10,7 +10,7 @@
          racket/string
          "../llm/model.rkt"
          "../llm/provider.rkt"
-         (only-in "../tools/tool.rkt" make-tool-registry tool-registry? register-tool!)
+         (only-in "../tools/tool.rkt" make-tool-registry tool-registry? register-tool! list-tools)
          "../agent/event-bus.rkt"
          "../util/protocol-types.rkt"
          (only-in "../extensions/api.rkt"
@@ -18,6 +18,12 @@
                   extension-registry?
                   extension
                   register-extension!)
+         (only-in "../extensions/hooks.rkt"
+                  dispatch-hooks
+                  hook-result?
+                  hook-result-action
+                  hook-result-payload)
+         (only-in "../util/hook-types.rkt" hook-amend)
          (only-in "../runtime/compactor.rkt" compaction-result-removed-count compact-and-persist!)
          (only-in "../runtime/token-compaction.rkt" token-compaction-config)
          "helpers/compaction-helpers.rkt"
@@ -946,4 +952,85 @@
       (check-equal? (hash-ref (event-payload e) 'persist? #f)
                     #t
                     (format "event ~a should have persist?=#t" (event-event e))))
+    (cleanup-dir tmp)))
+
+;; ============================================================
+;; v0.20.5 W0: register-default-tools? and dispatch-command!
+;; ============================================================
+
+(test-case "W0: make-runtime with #:register-default-tools? #t registers default tools"
+  (define tmp (make-temp-session-dir))
+  (with-handlers ([exn:fail? (lambda (e)
+                               (cleanup-dir tmp)
+                               (raise e))])
+    (define prov (make-test-provider))
+    (define rt (make-runtime #:provider prov #:session-dir tmp #:register-default-tools? #t))
+    (define reg (runtime-config-tool-registry (runtime-rt-config rt)))
+    (define tools (list-tools reg))
+    (check-true (> (length tools) 0) "make-runtime with register-default-tools? #t should have tools")
+    (cleanup-dir tmp)))
+
+(test-case "W0: make-runtime default registers default tools (#t is default)"
+  (define tmp (make-temp-session-dir))
+  (with-handlers ([exn:fail? (lambda (e)
+                               (cleanup-dir tmp)
+                               (raise e))])
+    (define prov (make-test-provider))
+    (define rt (make-runtime #:provider prov #:session-dir tmp))
+    (define reg (runtime-config-tool-registry (runtime-rt-config rt)))
+    (define tools (list-tools reg))
+    (check-true (> (length tools) 0) "make-runtime defaults to register-default-tools? #t")
+    (cleanup-dir tmp)))
+
+(test-case "W0: make-runtime with #:register-default-tools? #f has empty registry"
+  (define tmp (make-temp-session-dir))
+  (with-handlers ([exn:fail? (lambda (e)
+                               (cleanup-dir tmp)
+                               (raise e))])
+    (define prov (make-test-provider))
+    (define rt (make-runtime #:provider prov #:session-dir tmp #:register-default-tools? #f))
+    (define reg (runtime-config-tool-registry (runtime-rt-config rt)))
+    (define tools (list-tools reg))
+    (check-equal? (length tools)
+                  0
+                  "make-runtime with register-default-tools? #f should have no tools")
+    (cleanup-dir tmp)))
+
+(test-case "W0: dispatch-command! returns 'no-extension-registry when no ext-reg"
+  (define tmp (make-temp-session-dir))
+  (with-handlers ([exn:fail? (lambda (e)
+                               (cleanup-dir tmp)
+                               (raise e))])
+    (define prov (make-test-provider))
+    (define rt (make-runtime #:provider prov #:session-dir tmp))
+    (define-values (rt2 result) (dispatch-command! rt "/plan" "test task"))
+    (check-pred runtime? rt2)
+    (check-equal? result 'no-extension-registry)
+    (cleanup-dir tmp)))
+
+(test-case "W0: dispatch-command! dispatches through extension registry"
+  (define tmp (make-temp-session-dir))
+  (with-handlers ([exn:fail? (lambda (e)
+                               (cleanup-dir tmp)
+                               (raise e))])
+    (define prov (make-test-provider))
+    (define ext-reg (make-extension-registry))
+    ;; Register a test extension that handles execute-command
+    (register-extension! ext-reg
+                         (extension "test-cmd-handler"
+                                    "1.0"
+                                    "0.1"
+                                    (hasheq 'execute-command
+                                            (lambda (payload)
+                                              (hook-amend (hash-set payload 'handled #t))))))
+    (define rt
+      (make-runtime #:provider prov
+                    #:session-dir tmp
+                    #:extension-registry ext-reg
+                    #:register-default-tools? #f))
+    (define-values (rt2 result) (dispatch-command! rt "/test" "input"))
+    (check-pred runtime? rt2)
+    (check-pred hook-result? result)
+    (check-equal? (hook-result-action result) 'amend)
+    (check-true (hash-ref (hook-result-payload result) 'handled #f))
     (cleanup-dir tmp)))


### PR DESCRIPTION
Addresses #2015.

feat(sdk): add register-default-tools?, dispatch-command!, and auto-load-extensions (#2015)

W0 of v0.20.5 — SDK Foundation: Tool Registry + Extension Auto-Setup

- make-runtime now accepts #:register-default-tools? (default #t) to
  auto-register all 13 built-in tools on the fresh registry
- make-runtime now accepts #:auto-load-extensions? and #:project-dir
  for auto-discovering and loading extensions from project-dir/extensions/
- New dispatch-command! function dispatches 'execute-command hooks
  through the extension registry for SDK-level command support
- Returns 'no-extension-registry when no extension registry is configured
- Added 6 new test cases covering all new functionality

Closes #2016, closes #2017, closes #2018