### PR TITLE
fix(gsd): replace current-gsd-event-bus parameter with semaphore-protected box (#2019)

W1 of v0.20.5 — GSD Event Bus Fix: Parameter → Registry-Stored

- Moved current-gsd-event-bus from thread-local Racket parameter to
  a semaphore-protected box in gsd-planning-state.rkt
- New accessors: gsd-event-bus, set-gsd-event-bus! (re-exported from gsd-planning.rkt)
- register-gsd-tools now stores bus via set-gsd-event-bus! instead of parameter mutation
- emit-gsd-event! reads from the shared box instead of parameter
- reset-all-gsd-state! clears the event bus box
- emit-gsd-event! exported for testing
- Added 3 test cases covering roundtrip, publish, and no-op behavior

Fixes cross-thread event loss when hook handlers are dispatched from
TUI or SDK at different times than the original tool registration.

Closes #2020, closes #2021, closes #2022

### DIFF
--- a/extensions/gsd-planning-state.rkt
+++ b/extensions/gsd-planning-state.rkt
@@ -44,7 +44,10 @@
          ;; v0.20.4 W3: observability
          gsd-snapshot
          reset-all-gsd-state!
-         READ-ONLY-TOOLS)
+         READ-ONLY-TOOLS
+         ;; v0.20.5 W1: event bus (parameter → registry-stored)
+         gsd-event-bus
+         set-gsd-event-bus!)
 
 ;; ============================================================
 ;; Internal state storage
@@ -54,6 +57,10 @@
 ;; This is simpler and more correct than per-value semaphores because
 ;; cross-thread operations (e.g. budget check + decrement) need to be atomic.
 (define state-sem (make-semaphore 1))
+
+;; v0.20.5 W1: Event bus stored in shared state (not parameter).
+;; Was a thread-local parameter; now a semaphore-protected box for cross-thread access.
+(define gsd-event-bus-box (box #f))
 
 ;; GSD workflow mode: #f | 'planning | 'plan-written | 'executing
 (define gsd-mode-box (box #f))
@@ -67,6 +74,13 @@
 
 ;; Dynamic edit limit (moved from tools/builtins/edit.rkt).
 (define edit-limit-box (box 500))
+
+;; v0.20.5 W1: Event bus accessors (semaphore-protected)
+(define (gsd-event-bus)
+  (call-with-semaphore state-sem (lambda () (unbox gsd-event-bus-box))))
+
+(define (set-gsd-event-bus! v)
+  (call-with-semaphore state-sem (lambda () (set-box! gsd-event-bus-box v))))
 
 ;; Per-file read count for redundant-read detection.
 (define read-counts-box (box (make-hash)))
@@ -259,4 +273,6 @@
                          (set-box! completed-waves-box (set))
                          (set-box! total-waves-box 0)
                          (set-box! last-edit-wave-box #f)
-                         (set-box! plan-tool-budget-box #f))))
+                         (set-box! plan-tool-budget-box #f)
+                         ;; v0.20.5 W1: clear event bus on reset
+                         (set-box! gsd-event-bus-box #f))))

--- a/extensions/gsd-planning.rkt
+++ b/extensions/gsd-planning.rkt
@@ -69,7 +69,12 @@
          plan-tool-budget
          decrement-plan-budget!
          reset-plan-budget!
-         gsd-session-cleanup)
+         gsd-session-cleanup
+         ;; v0.20.5 W1: re-exported from gsd-planning-state
+         gsd-event-bus
+         set-gsd-event-bus!
+         ;; v0.20.5 W1: exported for testing
+         emit-gsd-event!)
 
 ;; ============================================================
 ;; Event emission helper (v0.20.4 W1)
@@ -77,13 +82,11 @@
 
 ;; Emit a GSD event to the current session's event bus.
 ;; No-op if no event bus is available (e.g. during tests).
+;; v0.20.5 W1: reads from semaphore-protected box instead of thread-local parameter.
 (define (emit-gsd-event! type payload)
-  (define bus (current-gsd-event-bus))
+  (define bus (gsd-event-bus))
   (when bus
     (publish! bus (make-event type (current-seconds) #f #f payload))))
-
-;; Lazy reference to the current event bus — resolved at call time.
-(define current-gsd-event-bus (make-parameter #f))
 
 ;; ============================================================
 ;; Constants
@@ -364,8 +367,8 @@
     (define cwd (ctx-cwd ctx))
     (when cwd
       (set-pinned-planning-dir! (resolve-project-root cwd))))
-  ;; v0.20.4 W1: capture event bus for later event emission
-  (current-gsd-event-bus (ctx-event-bus ctx))
+  ;; v0.20.5 W1: store event bus in shared state (not parameter)
+  (set-gsd-event-bus! (ctx-event-bus ctx))
   (ext-register-tool!
    ctx
    "planning-read"

--- a/tests/test-gsd-planning.rkt
+++ b/tests/test-gsd-planning.rkt
@@ -21,7 +21,8 @@
          "../extensions/api.rkt"
          "../extensions/hooks.rkt"
          "../tools/tool.rkt"
-         "../agent/event-bus.rkt")
+         "../agent/event-bus.rkt"
+         "../util/event.rkt")
 
 ;; ============================================================
 ;; Helpers
@@ -805,3 +806,36 @@
   (define res (gsd-tool-guard (hasheq 'tool-name "planning-read" 'args (hasheq))))
   (check-eq? (hook-result-action res) 'block)
   (set-gsd-mode! #f))
+
+;; ============================================================
+;; v0.20.5 W1: Event bus — parameter → registry-stored
+;; ============================================================
+
+(test-case "W1: set-gsd-event-bus! and gsd-event-bus roundtrip"
+  (reset-all-gsd-state!)
+  (check-false (gsd-event-bus) "event bus should start as #f")
+  (define bus (make-event-bus))
+  (set-gsd-event-bus! bus)
+  (check-eq? (gsd-event-bus) bus "event bus should be the one we set")
+  (reset-all-gsd-state!)
+  (check-false (gsd-event-bus) "event bus should be #f after reset"))
+
+(test-case "W1: emit-gsd-event! publishes when bus is set"
+  (reset-all-gsd-state!)
+  (define bus (make-event-bus))
+  (set-gsd-event-bus! bus)
+  (define received (box '()))
+  (subscribe! bus (lambda (evt) (set-box! received (cons evt (unbox received)))))
+  ;; emit-gsd-event! is defined in gsd-planning.rkt
+  (emit-gsd-event! "gsd.test.event" (hasheq 'key 'value))
+  (check-equal? (length (unbox received)) 1 "should receive one event")
+  (define evt (car (unbox received)))
+  (check-equal? (event-event evt) "gsd.test.event")
+  (check-equal? (hash-ref (event-payload evt) 'key) 'value)
+  (reset-all-gsd-state!))
+
+(test-case "W1: emit-gsd-event! is no-op when bus is #f"
+  (reset-all-gsd-state!)
+  ;; Should not raise an error
+  (emit-gsd-event! "gsd.test.noop" (hasheq 'key 'value))
+  (check-false (gsd-event-bus) "bus should still be #f"))


### PR DESCRIPTION
Addresses #2019.

fix(gsd): replace current-gsd-event-bus parameter with semaphore-protected box (#2019)

W1 of v0.20.5 — GSD Event Bus Fix: Parameter → Registry-Stored

- Moved current-gsd-event-bus from thread-local Racket parameter to
  a semaphore-protected box in gsd-planning-state.rkt
- New accessors: gsd-event-bus, set-gsd-event-bus! (re-exported from gsd-planning.rkt)
- register-gsd-tools now stores bus via set-gsd-event-bus! instead of parameter mutation
- emit-gsd-event! reads from the shared box instead of parameter
- reset-all-gsd-state! clears the event bus box
- emit-gsd-event! exported for testing
- Added 3 test cases covering roundtrip, publish, and no-op behavior

Fixes cross-thread event loss when hook handlers are dispatched from
TUI or SDK at different times than the original tool registration.

Closes #2020, closes #2021, closes #2022