### PR TITLE
feat(runtime): pre-register extensions on session open (#2026)

W3 of v0.20.5 — Extension Pre-Registration on Session Open

- Extracted register-session-extensions! from run-provider-turn in
  iteration.rkt — standalone function that dispatches 'register-tools
  hook through the extension registry
- open-session in sdk.rkt now calls register-session-extensions!
  immediately after creating the agent session, ensuring extension tools
  and state (event bus, pinned dir) are available before first run-prompt!
- run-provider-turn uses the same shared function (idempotent)
- create-agent-session inherits the behavior via open-session delegation
- New test file tests/test-sdk-extensions.rkt with 5 test cases:
  extension tools available after open-session, event bus initialized,
  idempotent registration, create-agent-session support, no crash
  without extension registry

Closes #2027, closes #2028, closes #2029

### DIFF
--- a/interfaces/sdk.rkt
+++ b/interfaces/sdk.rkt
@@ -22,6 +22,7 @@
          "../agent/event-bus.rkt"
          "../util/protocol-types.rkt"
          (prefix-in session: "../runtime/agent-session.rkt")
+         (only-in "../runtime/iteration.rkt" register-session-extensions!)
          (only-in "../runtime/compactor.rkt"
                   compact-history
                   compact-and-persist!
@@ -294,6 +295,14 @@
     (if session-id
         (session:resume-agent-session session-id agent-cfg)
         (session:make-agent-session agent-cfg)))
+  ;; v0.20.5 W3: Pre-register extensions immediately on session open
+  ;; This ensures extension tools are available and extension state
+  ;; (event bus, pinned dir) is initialized before first run-prompt!
+  (define ext-reg (runtime-config-extension-registry cfg))
+  (define tool-reg (runtime-config-tool-registry cfg))
+  (define bus (runtime-config-event-bus cfg))
+  (when (and ext-reg tool-reg bus sess)
+    (register-session-extensions! tool-reg ext-reg bus (session:session-id sess)))
   (make-runtime-internal cfg sess (rt-token rt)))
 
 ;; ============================================================

--- a/runtime/iteration.rkt
+++ b/runtime/iteration.rkt
@@ -143,7 +143,9 @@
          check-mid-turn-budget!
          ;; v0.20.4 W2: stall detection
          detect-stall?
-         MAX-STALL-RETRIES)
+         MAX-STALL-RETRIES
+         ;; v0.20.5 W3: pre-registration on session open
+         register-session-extensions!)
 
 ;; ============================================================
 ;; Shared helpers
@@ -262,6 +264,38 @@
 
   ctx-final)
 
+;; ============================================================
+;; v0.20.5 W3: Extension Pre-Registration
+;; ============================================================
+
+;;; register-session-extensions! : tool-registry? extension-registry? event-bus?
+;;;                                  string? -> (listof hash?)
+;;;
+;;; Dispatches the 'register-tools hook through the extension registry
+;;; so that extension tools are available and extension state (event bus,
+;;; pinned dir) is initialized BEFORE the first run-prompt! call.
+;;;
+;;; Returns the list of extension-provided tools (as jsexpr hashes),
+;;; or '() if no extensions or no tools registered.
+;;;
+;;; Idempotent: extensions track their own registration state internally.
+;;; Safe to call multiple times.
+(define (register-session-extensions! tool-reg ext-reg bus session-id)
+  (cond
+    [(not ext-reg) '()]
+    [else
+     (define the-ext-ctx
+       (make-extension-ctx #:session-id session-id
+                           #:session-dir #f
+                           #:event-bus bus
+                           #:extension-registry ext-reg
+                           #:tool-registry tool-reg))
+     (define-values (_amended hook-res)
+       (maybe-dispatch-hooks ext-reg 'register-tools (hasheq) #:ctx the-ext-ctx))
+     (if (and hook-res (eq? (hook-result-action hook-res) 'amend))
+         (hash-ref (hook-result-payload hook-res) 'tools '())
+         '())]))
+
 ;; Run the provider turn: dispatch before-provider-request hook, then run agent turn.
 ;; Returns the loop-result from run-agent-turn.
 (define (run-provider-turn ctx-final prov bus reg ext-reg session-id turn-id token config)
@@ -275,27 +309,13 @@
   (define base-tools (and reg (list-tools-jsexpr reg)))
 
   ;; #673: Merge extension-provided tools into the tool list
-  ;; v0.19.4 GAP-2 fix: create proper extension-ctx so register-tools handlers
-  ;; can call ext-register-tool! without contract violations.
+  ;; v0.20.5 W3: Uses shared register-session-extensions! function.
+  ;; Idempotent — extensions track their own state.
+  (define ext-tools (and ext-reg (register-session-extensions! reg ext-reg bus session-id)))
   (define tools
-    (let ([ext-tools
-           (and ext-reg
-                (let ()
-                  ;; Build extension-ctx with available session components
-                  (define the-ext-ctx
-                    (make-extension-ctx #:session-id session-id
-                                        #:session-dir #f
-                                        #:event-bus bus
-                                        #:extension-registry ext-reg
-                                        #:tool-registry reg))
-                  (define-values (amended hook-res)
-                    (maybe-dispatch-hooks ext-reg 'register-tools (hasheq) #:ctx the-ext-ctx))
-                  (if (and hook-res (eq? (hook-result-action hook-res) 'amend))
-                      (hash-ref (hook-result-payload hook-res) 'tools '())
-                      '())))])
-      (if (and base-tools (pair? ext-tools))
-          (merge-tool-lists base-tools ext-tools)
-          base-tools)))
+    (if (and base-tools (pair? ext-tools))
+        (merge-tool-lists base-tools ext-tools)
+        base-tools))
 
   ;; v0.14.4 Wave 2 FIX: Extract ONLY provider-specific settings from config.
   ;; The full config is a mutable hash with event-bus, extension-registry, etc.

--- a/tests/test-sdk-extensions.rkt
+++ b/tests/test-sdk-extensions.rkt
@@ -1,86 +1,125 @@
 #lang racket
 
-;; tests/test-sdk-extensions.rkt — v0.19.4 Wave 4: SDK extension tool wiring
+;; tests/test-sdk-extensions.rkt — tests for v0.20.5 W3: Extension Pre-Registration
 ;;
-;; Verifies that SDK sessions with extension registries work properly
-;; and that extension-registry is passed through to the agent session.
+;; Covers:
+;;   - Extension tools appear in list-tools after open-session
+;;   - Extension state (event bus) is initialized before first run-prompt!
+;;   - register-session-extensions! is idempotent
+;;   - Works with create-agent-session too
 
 (require rackunit
          racket/file
-         "../llm/model.rkt"
-         "../llm/provider.rkt"
-         "../tools/tool.rkt"
-         "../agent/event-bus.rkt"
+         "../interfaces/sdk.rkt"
          "../extensions/api.rkt"
-         "../extensions/loader.rkt"
-         "../interfaces/sdk.rkt")
+         "../extensions/gsd-planning.rkt"
+         "../extensions/hooks.rkt"
+         "../agent/event-bus.rkt"
+         "../tools/tool.rkt"
+         "helpers/mock-provider.rkt"
+         "helpers/temp-fs.rkt")
 
 ;; ============================================================
 ;; Helpers
 ;; ============================================================
 
-(define (make-test-provider)
-  (make-mock-provider (make-model-response (list (hasheq 'type "text" 'text "Done"))
-                                           (hasheq 'inputTokens 5 'outputTokens 5)
-                                           "mock-model"
-                                           'stop)))
+(define (make-ext-runtime)
+  (define tmp (make-temporary-file "/tmp/sdk-ext-test-~a" 'directory))
+  (define prov (make-simple-mock-provider
+                (list (hasheq 'role "assistant"
+                              'content (list (hasheq 'type "text" 'text "ok"))))))
+  (define ext-reg (make-extension-registry))
+  (register-extension! ext-reg the-extension)
+  (define bus (make-event-bus))
+  (define rt (make-runtime #:provider prov
+                           #:session-dir tmp
+                           #:extension-registry ext-reg
+                           #:event-bus bus
+                           #:register-default-tools? #t))
+  (values rt tmp ext-reg bus))
 
-(define (make-temp-session-dir)
-  (make-temporary-file "q-sdk-ext-test-~a" 'directory))
-
-(define (cleanup-dir dir)
-  (with-handlers ([exn:fail? (lambda (_) (void))])
-    (delete-directory/files dir #:must-exist? #f)))
+(define (cleanup-ext! tmp)
+  (delete-directory/files tmp #:must-exist? #f))
 
 ;; ============================================================
 ;; Tests
 ;; ============================================================
 
-(test-case "SDK make-runtime accepts #:extension-registry parameter"
-  (define tmp (make-temp-session-dir))
-  (with-handlers ([exn:fail? (lambda (e)
-                               (cleanup-dir tmp)
-                               (raise e))])
-    (define prov (make-test-provider))
-    (define ext-reg (make-extension-registry))
-    (define rt (make-runtime #:provider prov #:session-dir tmp #:extension-registry ext-reg))
-    (check-pred runtime? rt)
-    (check-equal? (runtime-config-extension-registry (runtime-rt-config rt)) ext-reg)
-    (cleanup-dir tmp)))
+(test-case "W3: extension tools available after open-session (before run-prompt!)"
+  (define-values (rt tmp ext-reg bus) (make-ext-runtime))
+  ;; Before open-session, the tool registry has only default tools
+  (define tools-before (list-tools (runtime-config-tool-registry (runtime-rt-config rt))))
+  ;; Open session — should trigger extension pre-registration
+  (define opened (open-session rt))
+  ;; After open-session, extension tools should be registered
+  (define tools-after (list-tools (runtime-config-tool-registry (runtime-rt-config opened))))
+  (check-true (> (length tools-after) (length tools-before))
+              "extension tools should be added after open-session")
+  ;; Specifically check for planning-read and planning-write
+  (define tool-names (map tool-name tools-after))
+  (check-not-false (member "planning-read" tool-names)
+              "planning-read should be registered")
+  (check-not-false (member "planning-write" tool-names)
+              "planning-write should be registered")
+  (cleanup-ext! tmp))
 
-(test-case "SDK with extension registry creates session and runs prompt"
-  (define tmp (make-temp-session-dir))
-  (with-handlers ([exn:fail? (lambda (e)
-                               (cleanup-dir tmp)
-                               (raise e))])
-    (define prov (make-test-provider))
-    (define ext-reg (make-extension-registry))
-    (define bus (make-event-bus))
-    ;; Load gsd-planning extension — provides planning-read, planning-write tools
-    (define ext-path
-      (build-path (or (current-load-relative-directory) (current-directory))
-                  "../extensions/gsd-planning.rkt"))
-    (when (file-exists? ext-path)
-      (load-extension! ext-reg ext-path #:event-bus bus))
-    (define rt (make-runtime #:provider prov #:session-dir tmp #:extension-registry ext-reg))
-    (define rt-open (open-session rt))
-    ;; Run a prompt to trigger register-tools dispatch
-    (define-values (rt2 result) (run-prompt! rt-open "test"))
-    (check-pred runtime? rt2)
-    (check-not-exn (lambda () result))
-    (cleanup-dir tmp)))
+(test-case "W3: GSD event bus is initialized after open-session"
+  (reset-all-gsd-state!)
+  (define-values (rt tmp ext-reg bus) (make-ext-runtime))
+  ;; Before open-session, gsd-event-bus should be #f
+  (check-false (gsd-event-bus))
+  ;; Open session — extension registration sets the event bus
+  (define opened (open-session rt))
+  ;; After open-session, gsd-event-bus should be the runtime's bus
+  (check-eq? (gsd-event-bus) bus)
+  (reset-all-gsd-state!)
+  (cleanup-ext! tmp))
 
-(test-case "SDK without extension registry still works (graceful degradation)"
-  (define tmp (make-temp-session-dir))
-  (with-handlers ([exn:fail? (lambda (e)
-                               (cleanup-dir tmp)
-                               (raise e))])
-    (define prov (make-test-provider))
-    (define rt (make-runtime #:provider prov #:session-dir tmp))
-    (check-pred runtime? rt)
-    (check-false (runtime-config-extension-registry (runtime-rt-config rt)))
-    (define rt-open (open-session rt))
-    (check-pred runtime? rt-open)
-    (define-values (rt2 result) (run-prompt! rt-open "hello"))
-    (check-pred runtime? rt2)
-    (cleanup-dir tmp)))
+(test-case "W3: register-session-extensions! is idempotent"
+  (reset-all-gsd-state!)
+  (define-values (rt tmp ext-reg bus) (make-ext-runtime))
+  (define opened (open-session rt))
+  (define tools-1 (list-tools (runtime-config-tool-registry (runtime-rt-config opened))))
+  ;; Open another session — tools should still work, no duplicates
+  (define opened2 (open-session rt))
+  (define tools-2 (list-tools (runtime-config-tool-registry (runtime-rt-config opened2))))
+  (check-equal? (length tools-1) (length tools-2)
+                "tool count should be stable after re-registration")
+  (reset-all-gsd-state!)
+  (cleanup-ext! tmp))
+
+(test-case "W3: works with create-agent-session"
+  (reset-all-gsd-state!)
+  (define tmp (make-temporary-file "/tmp/sdk-ext-test-~a" 'directory))
+  (define prov (make-simple-mock-provider
+                (list (hasheq 'role "assistant"
+                              'content (list (hasheq 'type "text" 'text "ok"))))))
+  (define ext-reg (make-extension-registry))
+  (register-extension! ext-reg the-extension)
+  (define bus (make-event-bus))
+  (define rt (create-agent-session #:provider prov
+                                   #:session-dir tmp
+                                   #:extension-registry ext-reg
+                                   #:event-bus bus))
+  ;; Extension tools should be registered
+  (define tools (list-tools (runtime-config-tool-registry (runtime-rt-config rt))))
+  (define tool-names (map tool-name tools))
+  (check-not-false (member "planning-read" tool-names)
+              "planning-read should be registered via create-agent-session")
+  ;; Event bus should be set
+  (check-eq? (gsd-event-bus) bus)
+  (reset-all-gsd-state!)
+  (delete-directory/files tmp #:must-exist? #f))
+
+(test-case "W3: no crash when no extension registry"
+  (define tmp (make-temporary-file "/tmp/sdk-ext-test-~a" 'directory))
+  (define prov (make-simple-mock-provider
+                (list (hasheq 'role "assistant"
+                              'content (list (hasheq 'type "text" 'text "ok"))))))
+  ;; No extension registry — should not crash
+  (define rt (make-runtime #:provider prov
+                           #:session-dir tmp
+                           #:register-default-tools? #t))
+  (define opened (open-session rt))
+  (check-true (runtime? opened))
+  (delete-directory/files tmp #:must-exist? #f))


### PR DESCRIPTION
Addresses #2026.

feat(runtime): pre-register extensions on session open (#2026)

W3 of v0.20.5 — Extension Pre-Registration on Session Open

- Extracted register-session-extensions! from run-provider-turn in
  iteration.rkt — standalone function that dispatches 'register-tools
  hook through the extension registry
- open-session in sdk.rkt now calls register-session-extensions!
  immediately after creating the agent session, ensuring extension tools
  and state (event bus, pinned dir) are available before first run-prompt!
- run-provider-turn uses the same shared function (idempotent)
- create-agent-session inherits the behavior via open-session delegation
- New test file tests/test-sdk-extensions.rkt with 5 test cases:
  extension tools available after open-session, event bus initialized,
  idempotent registration, create-agent-session support, no crash
  without extension registry

Closes #2027, closes #2028, closes #2029