### PR TITLE
feat(gsd): add state machine + structured plan types (Wave 0, #2039)

Wave 0 of v0.21.0 GSD Extension Rewrite — Foundation layer.

New modules in extensions/gsd/:
- state-machine.rkt: Central state machine with explicit transitions
  (idle → exploring → plan-written → executing → verifying → idle),
  semaphore-protected state, tool permission guards per state,
  transition history, and snapshot support.
- plan-types.rkt: Structured gsd-plan/gsd-wave/gsd-task types with
  markdown parsing, validation (errors vs warnings), and plan utilities.

New tests:
- test-gsd-state-machine.rkt: 31 tests covering transitions, guards,
  invalid transitions, reset, snapshot, tool permissions.
- test-gsd-plan-types.rkt: 26 tests covering construction, parsing,
  validation, wave lookup, and pending wave queries.

Closes #2039, #2040, #2041

### DIFF
--- a/extensions/gsd/plan-types.rkt
+++ b/extensions/gsd/plan-types.rkt
@@ -1,0 +1,207 @@
+#lang racket/base
+
+;; extensions/gsd/plan-types.rkt — Structured Plan/Task/Wave types
+;;
+;; Wave 0 of v0.21.0: Machine-parseable plan types with validation.
+;; Plans use a structured format with required fields.
+;; The extension validates plan structure before allowing /go.
+
+(require racket/match
+         racket/string
+         racket/list)
+
+;; ============================================================
+;; Core structs (immutable)
+;; ============================================================
+
+(struct gsd-task (name files action verify done status) #:transparent)
+
+(struct gsd-wave (index title status root-cause files tasks verify done-criteria) #:transparent)
+
+(struct gsd-plan (waves context-bundle constraints must-haves) #:transparent)
+
+(struct validation-result (errors warnings) #:transparent)
+
+;; Aliases for cleaner API
+(define validation-errors validation-result-errors)
+(define validation-warnings validation-result-warnings)
+
+;; ============================================================
+;; Convenience constructors
+;; ============================================================
+
+(define (make-gsd-task name files action verify [done ""])
+  (gsd-task name files action verify done 'pending))
+
+(define (make-gsd-wave index title root-cause files tasks verify done-criteria)
+  (gsd-wave index title 'pending root-cause files tasks verify done-criteria))
+
+;; ============================================================
+;; Status setters (return new struct — immutable)
+;; ============================================================
+
+(define (gsd-task-set-status t status)
+  (struct-copy gsd-task t [status status]))
+
+(define (gsd-wave-set-status w status)
+  (struct-copy gsd-wave w [status status]))
+
+;; ============================================================
+;; Validation helpers
+;; ============================================================
+
+(define (validation-valid? vr)
+  (null? (validation-errors vr)))
+
+;; ============================================================
+;; Parsing: markdown → (listof gsd-wave)
+;; ============================================================
+
+;; Parse PLAN.md content into structured waves.
+;; Looks for "## Wave N: Title" headers and extracts fields from
+;; bullet points within each wave section.
+(define (parse-waves-from-markdown md-text)
+  (define lines (string-split md-text "\n"))
+  ;; Find wave header line indices
+  (define wave-starts
+    (for/list ([line lines]
+               [idx (in-naturals)]
+               #:when (regexp-match #rx"^## +[Ww]ave +[0-9]+" line))
+      idx))
+  (define wave-end-idxs
+    (if (< (length wave-starts) 2)
+        (list (sub1 (length lines)))
+        (append (map sub1 (cdr wave-starts)) (list (sub1 (length lines))))))
+  ;; Parse each wave section
+  (for/list ([start wave-starts]
+             [end wave-end-idxs])
+    (parse-wave-section (take (drop lines start) (add1 (- end start))))))
+
+;; Parse a single wave section (list of lines, first is header).
+(define (parse-wave-section lines)
+  (define header (car lines))
+  (define body-lines (cdr lines))
+  ;; Extract index and title from header
+  (define header-match (regexp-match #rx"^## +[Ww]ave +([0-9]+) *: *(.+)$" header))
+  (define idx
+    (if header-match
+        (string->number (cadr header-match))
+        0))
+  (define title
+    (if header-match
+        (string-trim (caddr header-match))
+        ""))
+  ;; Extract fields from bullet points
+  (define root-cause "")
+  (define files '())
+  (define verify-cmd "")
+  (define done-criteria '())
+  (for ([line body-lines])
+    (cond
+      [(regexp-match #rx"^- +[Rr]oot *[Cc]ause *: *(.+)$" line)
+       =>
+       (lambda (m) (set! root-cause (string-trim (cadr m))))]
+      [(regexp-match #rx"^- +[Ff]ile *: *(.+)$" line)
+       =>
+       (lambda (m) (set! files (append files (list (string-trim (cadr m))))))]
+      [(regexp-match #rx"^- +[Vv]erify *: *(.+)$" line)
+       =>
+       (lambda (m) (set! verify-cmd (string-trim (cadr m))))]
+      [(regexp-match #rx"^- +[Dd]one *: *(.+)$" line)
+       =>
+       (lambda (m) (set! done-criteria (append done-criteria (list (string-trim (cadr m))))))]))
+  (gsd-wave idx title 'pending root-cause files '() verify-cmd done-criteria))
+
+;; ============================================================
+;; Validation
+;; ============================================================
+
+(define (validate-plan plan)
+  (define waves (gsd-plan-waves plan))
+  (define errors '())
+  (define warnings '())
+  ;; Check: plan has at least 1 wave
+  (when (null? waves)
+    (set! errors (cons "Plan has no waves" errors)))
+  ;; Per-wave checks
+  (for ([w waves])
+    (define widx (gsd-wave-index w))
+    (define prefix (format "Wave ~a" widx))
+    (when (string=? (gsd-wave-title w) "")
+      (set! errors (cons (format "~a: missing title" prefix) errors)))
+    (when (null? (gsd-wave-files w))
+      (set! warnings (cons (format "~a: no file references" prefix) warnings)))
+    (when (string=? (gsd-wave-verify w) "")
+      (set! warnings (cons (format "~a: no verify command" prefix) warnings))))
+  (validation-result (reverse errors) (reverse warnings)))
+
+;; ============================================================
+;; Plan utilities
+;; ============================================================
+
+(define (plan-wave-ref plan idx)
+  (for/first ([w (gsd-plan-waves plan)]
+              #:when (= (gsd-wave-index w) idx))
+    w))
+
+(define (plan-pending-waves plan)
+  (filter (lambda (w) (eq? (gsd-wave-status w) 'pending)) (gsd-plan-waves plan)))
+
+(define (plan-next-pending-wave plan)
+  (for/first ([w (gsd-plan-waves plan)]
+              #:when (eq? (gsd-wave-status w) 'pending))
+    w))
+
+;; ============================================================
+;; Provide (after all definitions)
+;; ============================================================
+
+;; Struct types + accessors
+(provide gsd-task
+         gsd-task?
+         gsd-task-name
+         gsd-task-files
+         gsd-task-action
+         gsd-task-verify
+         gsd-task-done
+         gsd-task-status
+         gsd-task-set-status
+
+         gsd-wave
+         gsd-wave?
+         gsd-wave-index
+         gsd-wave-title
+         gsd-wave-status
+         gsd-wave-root-cause
+         gsd-wave-files
+         gsd-wave-tasks
+         gsd-wave-verify
+         gsd-wave-done-criteria
+         gsd-wave-set-status
+
+         gsd-plan
+         gsd-plan?
+         gsd-plan-waves
+         gsd-plan-context-bundle
+         gsd-plan-constraints
+         gsd-plan-must-haves
+
+         ;; Constructors with defaults
+         make-gsd-task
+         make-gsd-wave
+
+         ;; Parsing
+         parse-waves-from-markdown
+
+         ;; Validation
+         validation-result
+         validation-result?
+         validation-errors
+         validation-warnings
+         validation-valid?
+         validate-plan
+
+         ;; Plan utilities
+         plan-wave-ref
+         plan-pending-waves
+         plan-next-pending-wave)

--- a/extensions/gsd/state-machine.rkt
+++ b/extensions/gsd/state-machine.rkt
@@ -1,0 +1,171 @@
+#lang racket/base
+
+;; extensions/gsd/state-machine.rkt — GSD State Machine
+;;
+;; Wave 0 of v0.21.0: Central state machine with explicit transitions and guards.
+;; Replaces scattered mode checks across 4 hook handlers.
+;;
+;; States: idle → exploring → plan-written → executing → verifying → idle
+;;                 ↑              ↓
+;;                 └──────────────┘ (re-plan on failure)
+;;
+;; All state is semaphore-protected for thread safety.
+
+(require racket/contract
+         racket/match)
+
+;; States
+(provide gsm-state?
+         GSD-STATES
+         ;; Current state query
+         gsm-current
+         ;; Transition
+         gsm-transition!
+         gsm-reset!
+         ;; Transition result
+         ok?
+         ok-from
+         ok-to
+         err?
+         err-reason
+         ;; Valid transitions query
+         gsm-valid-next-states
+         ;; Tool access
+         gsm-tool-allowed?
+         ;; Snapshot / reset
+         gsm-snapshot
+         reset-gsm!
+         ;; History
+         gsm-history)
+
+;; ============================================================
+;; States and transitions
+;; ============================================================
+
+(define GSD-STATES '(idle exploring plan-written executing verifying))
+
+(define (gsm-state? v)
+  (and (symbol? v) (memq v GSD-STATES) #t))
+
+;; Transition table: (from . to) pairs that are valid.
+(define TRANSITIONS
+  '((idle . exploring) (exploring . plan-written)
+                       (exploring . idle)
+                       (plan-written . executing)
+                       (plan-written . exploring)
+                       (executing . verifying)
+                       (executing . exploring)
+                       (verifying . idle)
+                       (verifying . executing)))
+
+;; Tool permissions per state.
+;; States not listed allow all tools.
+(define BLOCKED-TOOLS
+  '((plan-written . ("edit" "write" "bash")) (executing . ("planning-write"))
+                                             (verifying . ("edit" "write" "bash" "planning-write"))))
+
+;; ============================================================
+;; Transition result types
+;; ============================================================
+
+;; Successful transition
+(struct ok-result (from to) #:transparent)
+;; Failed transition
+(struct err-result (reason from attempted) #:transparent)
+
+(define (ok? r)
+  (ok-result? r))
+(define (ok-from r)
+  (ok-result-from r))
+(define (ok-to r)
+  (ok-result-to r))
+(define (err? r)
+  (err-result? r))
+(define (err-reason r)
+  (err-result-reason r))
+
+;; ============================================================
+;; State storage (semaphore-protected)
+;; ============================================================
+
+(define gsm-sem (make-semaphore 1))
+(define gsm-state-box (box 'idle))
+(define gsm-history-box (box '()))
+
+;; ============================================================
+;; Core API
+;; ============================================================
+
+(define (gsm-current)
+  (call-with-semaphore gsm-sem (lambda () (unbox gsm-state-box))))
+
+(define (gsm-history)
+  (call-with-semaphore gsm-sem (lambda () (reverse (unbox gsm-history-box)))))
+
+(define (gsm-transition! target)
+  (call-with-semaphore
+   gsm-sem
+   (lambda ()
+     (define current (unbox gsm-state-box))
+     (cond
+       [(not (gsm-state? target)) (err-result (format "invalid state: ~a" target) current target)]
+       [(valid-transition? current target)
+        (set-box! gsm-state-box target)
+        (set-box! gsm-history-box
+                  (cons (list current target (current-seconds)) (unbox gsm-history-box)))
+        (ok-result current target)]
+       [else
+        (err-result
+         (format "invalid transition: ~a → ~a (valid: ~a)" current target (valid-targets current))
+         current
+         target)]))))
+
+(define (gsm-reset!)
+  (call-with-semaphore gsm-sem
+                       (lambda ()
+                         (define old (unbox gsm-state-box))
+                         (set-box! gsm-state-box 'idle)
+                         (set-box! gsm-history-box
+                                   (cons (list old 'idle (current-seconds)) (unbox gsm-history-box)))
+                         (ok-result old 'idle))))
+
+(define (reset-gsm!)
+  (call-with-semaphore gsm-sem
+                       (lambda ()
+                         (set-box! gsm-state-box 'idle)
+                         (set-box! gsm-history-box '())
+                         (void))))
+
+(define (gsm-valid-next-states)
+  (define current (gsm-current))
+  (valid-targets current))
+
+(define (gsm-snapshot)
+  (call-with-semaphore
+   gsm-sem
+   (lambda () (hasheq 'current (unbox gsm-state-box) 'history (reverse (unbox gsm-history-box))))))
+
+;; ============================================================
+;; Tool access
+;; ============================================================
+
+(define (gsm-tool-allowed? tool-name)
+  (define current (gsm-current))
+  (define blocked (assq current BLOCKED-TOOLS))
+  (if blocked
+      (not (member tool-name (cdr blocked)))
+      #t))
+
+;; ============================================================
+;; Internal helpers
+;; ============================================================
+
+(define (valid-transition? from to)
+  (or (and (eq? from 'idle) (eq? to 'idle))
+      (for/or ([t TRANSITIONS])
+        (and (eq? (car t) from) (eq? (cdr t) to)))))
+
+(define (valid-targets from)
+  (for/list ([t TRANSITIONS]
+             #:when (eq? (car t) from))
+    (cdr t)))

--- a/tests/test-gsd-plan-types.rkt
+++ b/tests/test-gsd-plan-types.rkt
@@ -1,0 +1,225 @@
+#lang racket
+
+;; tests/test-gsd-plan-types.rkt — Structured Plan/Task/Wave type tests
+;;
+;; Wave 0 of v0.21.0: Tests for structured plan types.
+;; Covers: wave construction, task construction, plan construction,
+;; parsing waves from markdown, validation, serialization.
+
+(require rackunit
+         "../extensions/gsd/plan-types.rkt")
+
+;; ============================================================
+;; gsd-task construction
+;; ============================================================
+
+(test-case "gsd-task construction"
+  (define t
+    (gsd-task "Fix the bug"
+              '("src/fix.rkt")
+              "Replace the broken function"
+              "raco test tests/test-fix.rkt"
+              "Tests pass"
+              'pending))
+  (check-equal? (gsd-task-name t) "Fix the bug")
+  (check-equal? (gsd-task-files t) '("src/fix.rkt"))
+  (check-equal? (gsd-task-action t) "Replace the broken function")
+  (check-equal? (gsd-task-verify t) "raco test tests/test-fix.rkt")
+  (check-equal? (gsd-task-done t) "Tests pass")
+  (check-eq? (gsd-task-status t) 'pending))
+
+(test-case "gsd-task status transitions"
+  (define t (gsd-task "Fix" '() "" "" "" 'pending))
+  (check-eq? (gsd-task-status t) 'pending)
+  (define t2 (gsd-task-set-status t 'in-progress))
+  (check-eq? (gsd-task-status t2) 'in-progress)
+  ;; Original is immutable
+  (check-eq? (gsd-task-status t) 'pending))
+
+(test-case "gsd-task with default status"
+  (define t (make-gsd-task "Task name" '("file.rkt") "Do the thing" "raco test tests/"))
+  (check-eq? (gsd-task-status t) 'pending)
+  (check-equal? (gsd-task-done t) ""))
+
+;; ============================================================
+;; gsd-wave construction
+;; ============================================================
+
+(test-case "gsd-wave construction"
+  (define t (make-gsd-task "Fix" '("f.rkt") "fix it" "test"))
+  (define w
+    (gsd-wave 0
+              "Foundation"
+              'pending
+              "Root cause is X"
+              '("extensions/gsd/state-machine.rkt")
+              (list t)
+              "raco test tests/"
+              '("All tests pass")))
+  (check-equal? (gsd-wave-index w) 0)
+  (check-equal? (gsd-wave-title w) "Foundation")
+  (check-eq? (gsd-wave-status w) 'pending)
+  (check-equal? (gsd-wave-root-cause w) "Root cause is X")
+  (check-equal? (gsd-wave-files w) '("extensions/gsd/state-machine.rkt"))
+  (check-equal? (length (gsd-wave-tasks w)) 1)
+  (check-equal? (gsd-wave-verify w) "raco test tests/")
+  (check-equal? (gsd-wave-done-criteria w) '("All tests pass")))
+
+(test-case "gsd-wave status transitions"
+  (define w (make-gsd-wave 0 "Test" "RC" '("f") '() "test" '("done")))
+  (check-eq? (gsd-wave-status w) 'pending)
+  (define w2 (gsd-wave-set-status w 'in-progress))
+  (check-eq? (gsd-wave-status w2) 'in-progress))
+
+(test-case "gsd-wave-set-status: all valid statuses"
+  (define w (make-gsd-wave 0 "T" "" '() '() "" '()))
+  (for ([s '(pending in-progress completed skipped failed)])
+    (define w2 (gsd-wave-set-status w s))
+    (check-eq? (gsd-wave-status w2) s)))
+
+;; ============================================================
+;; gsd-plan construction
+;; ============================================================
+
+(test-case "gsd-plan construction"
+  (define w1 (make-gsd-wave 0 "W0" "RC" '("f1") '() "test" '("done")))
+  (define w2 (make-gsd-wave 1 "W1" "RC" '("f2") '() "test" '("done")))
+  (define p
+    (gsd-plan (list w1 w2) "PROJECT.md, STATE.md" '("Do not touch foo.rkt") '("REQ-001" "REQ-002")))
+  (check-equal? (length (gsd-plan-waves p)) 2)
+  (check-equal? (gsd-plan-context-bundle p) "PROJECT.md, STATE.md")
+  (check-equal? (gsd-plan-constraints p) '("Do not touch foo.rkt"))
+  (check-equal? (gsd-plan-must-haves p) '("REQ-001" "REQ-002")))
+
+(test-case "gsd-plan with no waves"
+  (define p (gsd-plan '() "" '() '()))
+  (check-equal? (length (gsd-plan-waves p)) 0))
+
+;; ============================================================
+;; Wave parsing from markdown
+;; ============================================================
+
+(test-case "parse-waves-from-markdown: single wave"
+  (define md "## Wave 0: Foundation\n- Root cause: X\n- File: f.rkt\n- Verify: test\n")
+  (define waves (parse-waves-from-markdown md))
+  (check-equal? (length waves) 1)
+  (check-equal? (gsd-wave-index (car waves)) 0)
+  (check-equal? (gsd-wave-title (car waves)) "Foundation"))
+
+(test-case "parse-waves-from-markdown: multiple waves"
+  (define md
+    (string-append "## Wave 0: Foundation\nSome content\n\n"
+                   "## Wave 1: Core Rewrite\nMore content\n\n"
+                   "## Wave 2: Tests\nFinal content\n"))
+  (define waves (parse-waves-from-markdown md))
+  (check-equal? (length waves) 3)
+  (check-equal? (gsd-wave-title (first waves)) "Foundation")
+  (check-equal? (gsd-wave-title (second waves)) "Core Rewrite")
+  (check-equal? (gsd-wave-title (third waves)) "Tests"))
+
+(test-case "parse-waves-from-markdown: extracts verify command"
+  (define md "## Wave 0: Test Wave\n- Verify: raco test tests/test.rkt\n- Root cause: bug\n")
+  (define waves (parse-waves-from-markdown md))
+  (check-equal? (length waves) 1)
+  (check-equal? (gsd-wave-verify (car waves)) "raco test tests/test.rkt"))
+
+(test-case "parse-waves-from-markdown: extracts files"
+  (define md "## Wave 0: Test Wave\n- File: src/fix.rkt\n- File: tests/test.rkt\n- Verify: test\n")
+  (define waves (parse-waves-from-markdown md))
+  (check-equal? (length waves) 1)
+  ;; Files are extracted from "- File: ..." lines
+  (check-equal? (length (gsd-wave-files (car waves))) 2))
+
+(test-case "parse-waves-from-markdown: no waves returns empty"
+  (define md "This is just text.\nNo wave headers here.\n")
+  (define waves (parse-waves-from-markdown md))
+  (check-equal? waves '()))
+
+(test-case "parse-waves-from-markdown: extracts root cause"
+  (define md "## Wave 0: Bug Fix\n- Root cause: off-by-one error in loop\n- Verify: test\n")
+  (define waves (parse-waves-from-markdown md))
+  (check-equal? (gsd-wave-root-cause (car waves)) "off-by-one error in loop"))
+
+(test-case "parse-waves-from-markdown: extracts done criteria"
+  (define md "## Wave 0: Bug Fix\n- Done: All tests pass\n- Done: No regressions\n- Verify: test\n")
+  (define waves (parse-waves-from-markdown md))
+  (check-equal? (gsd-wave-done-criteria (car waves)) '("All tests pass" "No regressions")))
+
+;; ============================================================
+;; Plan validation
+;; ============================================================
+
+(test-case "validate-plan: valid plan returns empty errors"
+  (define w (make-gsd-wave 0 "Fix Bug" "RC" '("f.rkt") '() "raco test" '("Tests pass")))
+  (define p (gsd-plan (list w) "" '() '()))
+  (define result (validate-plan p))
+  (check-equal? (validation-errors result) '()))
+
+(test-case "validate-plan: empty plan has error"
+  (define p (gsd-plan '() "" '() '()))
+  (define result (validate-plan p))
+  (check-not-equal? (validation-errors result) '()))
+
+(test-case "validate-plan: wave with no files has warning"
+  (define w (make-gsd-wave 0 "No Files" "RC" '() '() "test" '("done")))
+  (define p (gsd-plan (list w) "" '() '()))
+  (define result (validate-plan p))
+  (check-equal? (validation-errors result) '())
+  (check-not-equal? (validation-warnings result) '()))
+
+(test-case "validate-plan: wave with no title has error"
+  (define w (make-gsd-wave 0 "" "RC" '("f.rkt") '() "test" '("done")))
+  (define p (gsd-plan (list w) "" '() '()))
+  (define result (validate-plan p))
+  (check-not-equal? (validation-errors result) '()))
+
+(test-case "validate-plan: wave with no verify command has warning"
+  (define w (make-gsd-wave 0 "Wave" "RC" '("f.rkt") '() "" '("done")))
+  (define p (gsd-plan (list w) "" '() '()))
+  (define result (validate-plan p))
+  (check-equal? (validation-errors result) '())
+  (check-not-equal? (validation-warnings result) '()))
+
+(test-case "validation-result: is-valid?"
+  (define vr (validation-result '() '()))
+  (check-true (validation-valid? vr))
+  (define vr2 (validation-result '("error") '()))
+  (check-false (validation-valid? vr2)))
+
+;; ============================================================
+;; Utility: wave index lookup
+;; ============================================================
+
+(test-case "plan-wave-ref: find wave by index"
+  (define w0 (make-gsd-wave 0 "First" "" '("a") '() "t" '()))
+  (define w1 (make-gsd-wave 1 "Second" "" '("b") '() "t" '()))
+  (define p (gsd-plan (list w0 w1) "" '() '()))
+  (check-equal? (gsd-wave-title (plan-wave-ref p 1)) "Second"))
+
+(test-case "plan-wave-ref: missing index returns #f"
+  (define w0 (make-gsd-wave 0 "Only" "" '("a") '() "t" '()))
+  (define p (gsd-plan (list w0) "" '() '()))
+  (check-false (plan-wave-ref p 99)))
+
+(test-case "plan-pending-waves: returns waves with pending status"
+  (define w0 (gsd-wave 0 "A" 'pending "" '("a") '() "t" '()))
+  (define w1 (gsd-wave 1 "B" 'completed "" '("b") '() "t" '()))
+  (define w2 (gsd-wave 2 "C" 'pending "" '("c") '() "t" '()))
+  (define p (gsd-plan (list w0 w1 w2) "" '() '()))
+  (define pending (plan-pending-waves p))
+  (check-equal? (length pending) 2)
+  (check-equal? (gsd-wave-index (first pending)) 0)
+  (check-equal? (gsd-wave-index (second pending)) 2))
+
+(test-case "plan-next-pending-wave: returns first pending"
+  (define w0 (gsd-wave 0 "A" 'completed "" '("a") '() "t" '()))
+  (define w1 (gsd-wave 1 "B" 'pending "" '("b") '() "t" '()))
+  (define p (gsd-plan (list w0 w1) "" '() '()))
+  (define next (plan-next-pending-wave p))
+  (check-not-false next)
+  (check-equal? (gsd-wave-index next) 1))
+
+(test-case "plan-next-pending-wave: returns #f when all complete"
+  (define w0 (gsd-wave 0 "A" 'completed "" '("a") '() "t" '()))
+  (define p (gsd-plan (list w0) "" '() '()))
+  (check-false (plan-next-pending-wave p)))

--- a/tests/test-gsd-state-machine.rkt
+++ b/tests/test-gsd-state-machine.rkt
@@ -1,0 +1,297 @@
+#lang racket
+
+;; tests/test-gsd-state-machine.rkt — GSD State Machine tests
+;;
+;; Wave 0 of v0.21.0: State machine with explicit transitions and guards.
+;; Covers: valid transitions, invalid transitions, reset, snapshot,
+;; transition guards, thread safety.
+
+(require rackunit
+         "../extensions/gsd/state-machine.rkt")
+
+;; ============================================================
+;; Helper: navigate to arbitrary state
+;; ============================================================
+
+;; Navigate to a given state through valid transitions.
+(define (navigate-to-state! target)
+  (case target
+    [(idle) (void)]
+    [(exploring) (gsm-transition! 'exploring)]
+    [(plan-written)
+     (gsm-transition! 'exploring)
+     (gsm-transition! 'plan-written)]
+    [(executing)
+     (gsm-transition! 'exploring)
+     (gsm-transition! 'plan-written)
+     (gsm-transition! 'executing)]
+    [(verifying)
+     (gsm-transition! 'exploring)
+     (gsm-transition! 'plan-written)
+     (gsm-transition! 'executing)
+     (gsm-transition! 'verifying)]))
+
+;; ============================================================
+;; Valid state transitions
+;; ============================================================
+
+(test-case "initial state is idle"
+  (reset-gsm!)
+  (check-eq? (gsm-current) 'idle))
+
+(test-case "idle → exploring via /plan"
+  (reset-gsm!)
+  (define r (gsm-transition! 'exploring))
+  (check-eq? (gsm-current) 'exploring)
+  (check-true (ok? r)))
+
+(test-case "exploring → plan-written via planning-write PLAN"
+  (reset-gsm!)
+  (gsm-transition! 'exploring)
+  (define r (gsm-transition! 'plan-written))
+  (check-eq? (gsm-current) 'plan-written)
+  (check-true (ok? r)))
+
+(test-case "exploring → idle via /reset"
+  (reset-gsm!)
+  (gsm-transition! 'exploring)
+  (define r (gsm-transition! 'idle))
+  (check-eq? (gsm-current) 'idle)
+  (check-true (ok? r)))
+
+(test-case "plan-written → executing via /go"
+  (reset-gsm!)
+  (gsm-transition! 'exploring)
+  (gsm-transition! 'plan-written)
+  (define r (gsm-transition! 'executing))
+  (check-eq? (gsm-current) 'executing)
+  (check-true (ok? r)))
+
+(test-case "plan-written → exploring via /replan"
+  (reset-gsm!)
+  (gsm-transition! 'exploring)
+  (gsm-transition! 'plan-written)
+  (define r (gsm-transition! 'exploring))
+  (check-eq? (gsm-current) 'exploring)
+  (check-true (ok? r)))
+
+(test-case "executing → verifying after all waves attempted"
+  (reset-gsm!)
+  (gsm-transition! 'exploring)
+  (gsm-transition! 'plan-written)
+  (gsm-transition! 'executing)
+  (define r (gsm-transition! 'verifying))
+  (check-eq? (gsm-current) 'verifying)
+  (check-true (ok? r)))
+
+(test-case "executing → exploring on catastrophic plan failure"
+  (reset-gsm!)
+  (gsm-transition! 'exploring)
+  (gsm-transition! 'plan-written)
+  (gsm-transition! 'executing)
+  (define r (gsm-transition! 'exploring))
+  (check-eq? (gsm-current) 'exploring)
+  (check-true (ok? r)))
+
+(test-case "verifying → idle when all verifications pass"
+  (reset-gsm!)
+  (gsm-transition! 'exploring)
+  (gsm-transition! 'plan-written)
+  (gsm-transition! 'executing)
+  (gsm-transition! 'verifying)
+  (define r (gsm-transition! 'idle))
+  (check-eq? (gsm-current) 'idle)
+  (check-true (ok? r)))
+
+(test-case "verifying → executing on verification failures"
+  (reset-gsm!)
+  (gsm-transition! 'exploring)
+  (gsm-transition! 'plan-written)
+  (gsm-transition! 'executing)
+  (gsm-transition! 'verifying)
+  (define r (gsm-transition! 'executing))
+  (check-eq? (gsm-current) 'executing)
+  (check-true (ok? r)))
+
+;; ============================================================
+;; Reset transition (any → idle)
+;; ============================================================
+
+(test-case "reset from any state goes to idle"
+  (for ([from-state '(idle exploring plan-written executing verifying)])
+    (reset-gsm!)
+    (navigate-to-state! from-state)
+    (define r (gsm-reset!))
+    (check-eq? (gsm-current) 'idle)
+    (check-true (ok? r) (format "reset from ~a should succeed" from-state))))
+
+;; ============================================================
+;; Invalid transitions
+;; ============================================================
+
+(test-case "idle → executing is invalid"
+  (reset-gsm!)
+  (define r (gsm-transition! 'executing))
+  (check-eq? (gsm-current) 'idle)
+  (check-false (ok? r)))
+
+(test-case "idle → plan-written is invalid"
+  (reset-gsm!)
+  (define r (gsm-transition! 'plan-written))
+  (check-eq? (gsm-current) 'idle)
+  (check-false (ok? r)))
+
+(test-case "idle → verifying is invalid"
+  (reset-gsm!)
+  (define r (gsm-transition! 'verifying))
+  (check-eq? (gsm-current) 'idle)
+  (check-false (ok? r)))
+
+(test-case "executing → plan-written is invalid"
+  (reset-gsm!)
+  (gsm-transition! 'exploring)
+  (gsm-transition! 'plan-written)
+  (gsm-transition! 'executing)
+  (define r (gsm-transition! 'plan-written))
+  (check-eq? (gsm-current) 'executing)
+  (check-false (ok? r)))
+
+(test-case "verifying → exploring is invalid"
+  (reset-gsm!)
+  (gsm-transition! 'exploring)
+  (gsm-transition! 'plan-written)
+  (gsm-transition! 'executing)
+  (gsm-transition! 'verifying)
+  (define r (gsm-transition! 'exploring))
+  (check-eq? (gsm-current) 'verifying)
+  (check-false (ok? r)))
+
+;; ============================================================
+;; Transition result inspection
+;; ============================================================
+
+(test-case "failed transition result has reason"
+  (reset-gsm!)
+  (define r (gsm-transition! 'executing))
+  (check-false (ok? r))
+  (check-true (err? r))
+  (check-not-false (err-reason r)))
+
+(test-case "successful transition result has from and to"
+  (reset-gsm!)
+  (define r (gsm-transition! 'exploring))
+  (check-true (ok? r))
+  (check-eq? (ok-from r) 'idle)
+  (check-eq? (ok-to r) 'exploring))
+
+;; ============================================================
+;; Valid transitions query
+;; ============================================================
+
+(test-case "valid-next-states returns correct set for idle"
+  (reset-gsm!)
+  (check-equal? (gsm-valid-next-states) '(exploring)))
+
+(test-case "valid-next-states returns correct set for exploring"
+  (reset-gsm!)
+  (gsm-transition! 'exploring)
+  (check-equal? (sort (gsm-valid-next-states) symbol<?) '(idle plan-written)))
+
+(test-case "valid-next-states returns correct set for plan-written"
+  (reset-gsm!)
+  (gsm-transition! 'exploring)
+  (gsm-transition! 'plan-written)
+  (check-equal? (sort (gsm-valid-next-states) symbol<?) '(executing exploring)))
+
+(test-case "valid-next-states returns correct set for executing"
+  (reset-gsm!)
+  (gsm-transition! 'exploring)
+  (gsm-transition! 'plan-written)
+  (gsm-transition! 'executing)
+  (check-equal? (gsm-valid-next-states) '(verifying exploring)))
+
+(test-case "valid-next-states returns correct set for verifying"
+  (reset-gsm!)
+  (gsm-transition! 'exploring)
+  (gsm-transition! 'plan-written)
+  (gsm-transition! 'executing)
+  (gsm-transition! 'verifying)
+  (check-equal? (gsm-valid-next-states) '(idle executing)))
+
+;; ============================================================
+;; Snapshot
+;; ============================================================
+
+(test-case "gsm-snapshot captures current state and history"
+  (reset-gsm!)
+  (gsm-transition! 'exploring)
+  (gsm-transition! 'plan-written)
+  (define snap (gsm-snapshot))
+  (check-eq? (hash-ref snap 'current) 'plan-written)
+  (check-true (list? (hash-ref snap 'history))))
+
+;; ============================================================
+;; State predicates
+;; ============================================================
+
+(test-case "gsm-state? recognizes valid states"
+  (check-true (gsm-state? 'idle))
+  (check-true (gsm-state? 'exploring))
+  (check-true (gsm-state? 'plan-written))
+  (check-true (gsm-state? 'executing))
+  (check-true (gsm-state? 'verifying)))
+
+(test-case "gsm-state? rejects invalid states"
+  (check-false (gsm-state? 'unknown))
+  (check-false (gsm-state? 'planning))
+  (check-false (gsm-state? #f)))
+
+;; ============================================================
+;; Allowed tools per state
+;; ============================================================
+
+(test-case "idle: all tools allowed"
+  (reset-gsm!)
+  (for ([tool '("read" "edit" "write" "bash" "planning-read" "planning-write")])
+    (check-true (gsm-tool-allowed? tool)
+                (format "~a should be allowed in idle" tool))))
+
+(test-case "exploring: all tools allowed (free exploration)"
+  (reset-gsm!)
+  (gsm-transition! 'exploring)
+  (for ([tool '("read" "edit" "write" "bash" "planning-read" "planning-write")])
+    (check-true (gsm-tool-allowed? tool)
+                (format "~a should be allowed in exploring" tool))))
+
+(test-case "plan-written: edit/write/bash blocked, read allowed"
+  (reset-gsm!)
+  (gsm-transition! 'exploring)
+  (gsm-transition! 'plan-written)
+  (check-true (gsm-tool-allowed? "read"))
+  (check-true (gsm-tool-allowed? "planning-read"))
+  (check-false (gsm-tool-allowed? "edit"))
+  (check-false (gsm-tool-allowed? "write"))
+  (check-false (gsm-tool-allowed? "bash")))
+
+(test-case "executing: planning-write blocked, write/edit allowed"
+  (reset-gsm!)
+  (gsm-transition! 'exploring)
+  (gsm-transition! 'plan-written)
+  (gsm-transition! 'executing)
+  (check-false (gsm-tool-allowed? "planning-write"))
+  (check-true (gsm-tool-allowed? "read"))
+  (check-true (gsm-tool-allowed? "edit"))
+  (check-true (gsm-tool-allowed? "write"))
+  (check-true (gsm-tool-allowed? "bash")))
+
+(test-case "verifying: edit/write/bash blocked (read-only)"
+  (reset-gsm!)
+  (gsm-transition! 'exploring)
+  (gsm-transition! 'plan-written)
+  (gsm-transition! 'executing)
+  (gsm-transition! 'verifying)
+  (check-true (gsm-tool-allowed? "read"))
+  (check-true (gsm-tool-allowed? "planning-read"))
+  (check-false (gsm-tool-allowed? "edit"))
+  (check-false (gsm-tool-allowed? "write"))
+  (check-false (gsm-tool-allowed? "bash")))


### PR DESCRIPTION
Addresses #2039.

feat(gsd): add state machine + structured plan types (Wave 0, #2039)

Wave 0 of v0.21.0 GSD Extension Rewrite — Foundation layer.

New modules in extensions/gsd/:
- state-machine.rkt: Central state machine with explicit transitions
  (idle → exploring → plan-written → executing → verifying → idle),
  semaphore-protected state, tool permission guards per state,
  transition history, and snapshot support.
- plan-types.rkt: Structured gsd-plan/gsd-wave/gsd-task types with
  markdown parsing, validation (errors vs warnings), and plan utilities.

New tests:
- test-gsd-state-machine.rkt: 31 tests covering transitions, guards,
  invalid transitions, reset, snapshot, tool permissions.
- test-gsd-plan-types.rkt: 26 tests covering construction, parsing,
  validation, wave lookup, and pending wave queries.

Closes #2039, #2040, #2041