### PR TITLE
feat(gsd): add core extension, context bundle, and steering modules (Wave 1, #2042)

Wave 1 of v0.21.0 GSD Extension Rewrite — Core modules.

New modules in extensions/gsd/:
- core.rkt: Command dispatch (/plan, /go, /replan, /skip, /reset, /gsd),
  tool guard per state, write guard for PLAN.md during execution.
- context-bundle.rkt: Role-specific context assembly for explorer,
  executor, and verifier phases. Bundle size warnings at 4000 chars.
- steering.rkt: Mode-aware stall detection. Only active during executing
  mode. Detects 3+ consecutive identical file reads. No steering during
  exploring (DD-2).

New tests:
- test-gsd-core.rkt: 28 tests covering commands, tool guards, write guard.
- test-gsd-context-bundle.rkt: 12 tests covering all 3 bundle roles.
- test-gsd-steering.rkt: 8 tests covering stall detection and mode guards.

Closes #2042, #2043, #2044, #2045

### DIFF
--- a/extensions/gsd/context-bundle.rkt
+++ b/extensions/gsd/context-bundle.rkt
@@ -1,0 +1,148 @@
+#lang racket/base
+
+;; extensions/gsd/context-bundle.rkt — Context assembly per phase
+;;
+;; Wave 1b of v0.21.0: Role-specific context bundles.
+;; Instead of dumping the full plan + state into the prompt,
+;; assemble a role-specific context bundle with only what the
+;; current phase needs.
+
+(require racket/string
+         racket/match
+         "plan-types.rkt")
+
+(provide assemble-context
+         explorer-bundle
+         executor-bundle
+         verifier-bundle
+         ;; Config
+         max-bundle-size
+         bundle-size-warning?)
+
+;; ============================================================
+;; Configuration
+;; ============================================================
+
+(define max-bundle-size 4000)
+
+(define (bundle-size-warning? bundle)
+  (> (string-length bundle) max-bundle-size))
+
+;; ============================================================
+;; Public API
+;; ============================================================
+
+;; Assemble a context bundle for the given role.
+;; role: 'explorer | 'executor | 'verifier
+;; artifacts: hash with keys like 'plan, 'state, 'summaries
+;; files: hash mapping file-path to file-contents
+(define (assemble-context role artifacts files)
+  (case role
+    [(explorer) (explorer-bundle artifacts files)]
+    [(executor) (executor-bundle artifacts files)]
+    [(verifier) (verifier-bundle artifacts files)]
+    [else (error 'assemble-context "unknown role: ~a" role)]))
+
+;; ============================================================
+;; Explorer bundle
+;; ============================================================
+
+;; Explorer gets: project context + user request
+;; No plan (doesn't exist yet), no summaries.
+(define (explorer-bundle artifacts files)
+  (define user-request (hash-ref artifacts 'user-request ""))
+  (define project-context (hash-ref artifacts 'project-context ""))
+  (define parts
+    (filter-string (list "## Your Task"
+                         (if (non-empty? user-request)
+                             (format "Understand and plan a solution for:\n~a" user-request)
+                             "Explore the codebase and understand the problem.")
+                         (if (non-empty? project-context)
+                             (format "## Project Context\n~a" project-context)
+                             #f))))
+  (string-join parts "\n\n"))
+
+;; ============================================================
+;; Executor bundle
+;; ============================================================
+
+;; Executor gets: plan text + STATE + current wave context + referenced files
+(define (executor-bundle artifacts files)
+  (define plan-text (hash-ref artifacts 'plan ""))
+  (define state-text (hash-ref artifacts 'state ""))
+  (define wave-index (hash-ref artifacts 'wave-index 0))
+  (define wave-text (extract-wave-context plan-text wave-index))
+  (define referenced-files (format-referenced-files files))
+  (define parts
+    (filter-string (list "## Plan (Full)"
+                         (if (non-empty? plan-text) plan-text "(no plan)")
+                         (if (non-empty? state-text)
+                             (format "## Current State\n~a" state-text)
+                             #f)
+                         (if (non-empty? wave-text)
+                             (format "## Current Wave\n~a" wave-text)
+                             #f)
+                         (if (non-empty? referenced-files)
+                             (format "## Referenced Files\n~a" referenced-files)
+                             #f))))
+  (string-join parts "\n\n"))
+
+;; ============================================================
+;; Verifier bundle
+;; ============================================================
+
+;; Verifier gets: plan + summaries + verification commands
+(define (verifier-bundle artifacts files)
+  (define plan-text (hash-ref artifacts 'plan ""))
+  (define summaries (hash-ref artifacts 'summaries ""))
+  (define verify-commands (extract-verify-commands plan-text))
+  (define parts
+    (filter-string (list "## Plan Summary"
+                         (if (non-empty? plan-text) plan-text "(no plan)")
+                         (if (non-empty? summaries)
+                             (format "## Wave Summaries\n~a" summaries)
+                             #f)
+                         (if (non-empty? verify-commands)
+                             (format "## Verification Commands\n~a"
+                                     (string-join verify-commands "\n"))
+                             "## Verification\nRun your test suite to verify all changes."))))
+  (string-join parts "\n\n"))
+
+;; ============================================================
+;; Internal helpers
+;; ============================================================
+
+(define (non-empty? s)
+  (and (string? s) (> (string-length s) 0)))
+
+(define (filter-string parts)
+  (filter values parts))
+
+(define (extract-wave-context plan-text wave-index)
+  (if (non-empty? plan-text)
+      (let ([waves (parse-waves-from-markdown plan-text)])
+        (define w (plan-wave-ref (gsd-plan waves "" '() '()) wave-index))
+        (if w
+            (format "Wave ~a: ~a\n~a"
+                    (gsd-wave-index w)
+                    (gsd-wave-title w)
+                    (if (non-empty? (gsd-wave-root-cause w))
+                        (format "Root cause: ~a" (gsd-wave-root-cause w))
+                        ""))
+            ""))
+      ""))
+
+(define (format-referenced-files files)
+  (if (or (not files) (hash-empty? files))
+      ""
+      (string-join (for/list ([(path content) (in-hash files)])
+                     (format "### ~a\n```\n~a\n```" path content))
+                   "\n\n")))
+
+(define (extract-verify-commands plan-text)
+  (if (non-empty? plan-text)
+      (let ([waves (parse-waves-from-markdown plan-text)])
+        (for/list ([w waves]
+                   #:when (non-empty? (gsd-wave-verify w)))
+          (format "- Wave ~a: ~a" (gsd-wave-index w) (gsd-wave-verify w))))
+      '()))

--- a/extensions/gsd/core.rkt
+++ b/extensions/gsd/core.rkt
@@ -1,0 +1,222 @@
+#lang racket/base
+
+;; extensions/gsd/core.rkt — Core GSD extension module
+;;
+;; Wave 1a of v0.21.0: Main extension with command handlers,
+;; tool guard, and write guard. Uses state-machine for mode
+;; management and delegates steering to steering module.
+;;
+;; Commands:
+;;   /plan  → transition to exploring
+;;   /go    → transition to executing
+;;   /replan → back to exploring from plan-written/executing
+;;   /skip  → mark wave as skipped
+;;   /reset → go to idle
+;;   /gsd   → show status
+
+(require racket/string
+         racket/format
+         "state-machine.rkt"
+         "plan-types.rkt"
+         "context-bundle.rkt"
+         "steering.rkt")
+
+(provide gsd-command-dispatch
+         gsd-tool-guard
+         gsd-write-guard
+         gsd-show-status
+         ;; Command names for registration
+         gsd-commands)
+
+;; ============================================================
+;; Command registry
+;; ============================================================
+
+(define gsd-commands
+  '((plan "/plan" "Start GSD planning phase" ("p")) (go "/go" "Begin executing the plan" ())
+                                                    (replan "/replan" "Return to planning phase" ())
+                                                    (skip "/skip" "Skip current wave" ("s"))
+                                                    (reset "/reset" "Reset GSD to idle state" ())
+                                                    (gsd "/gsd" "Show GSD status" ())))
+
+;; ============================================================
+;; Command dispatch
+;; ============================================================
+
+;; Dispatch a GSD command. Returns a result hash or #f if unknown.
+(define (gsd-command-dispatch command args)
+  (define cmd
+    (if (string? command)
+        (string->symbol command)
+        command))
+  (case cmd
+    [(plan) (cmd-plan args)]
+    [(go) (cmd-go args)]
+    [(replan) (cmd-replan)]
+    [(skip) (cmd-skip args)]
+    [(reset) (cmd-reset)]
+    [(gsd) (gsd-show-status)]
+    [else #f]))
+
+;; /plan <text> → exploring
+(define (cmd-plan args)
+  (define user-text
+    (if (string? args)
+        (string-trim args)
+        ""))
+  (define result (gsm-transition! 'exploring))
+  (if (ok? result)
+      (hasheq 'success
+              #t
+              'mode
+              'exploring
+              'message
+              (if (non-empty? user-text)
+                  (format "Planning: ~a" user-text)
+                  "Planning phase started. Explore freely."))
+      (hasheq 'success
+              #f
+              'mode
+              (gsm-current)
+              'message
+              (format "Cannot enter planning: ~a" (err-reason result)))))
+
+;; /go [wave] → executing
+(define (cmd-go args)
+  (define wave-arg
+    (if (string? args)
+        (string-trim args)
+        ""))
+  (define target-state 'executing)
+  (define result (gsm-transition! target-state))
+  (if (ok? result)
+      (hasheq 'success
+              #t
+              'mode
+              'executing
+              'message
+              (if (non-empty? wave-arg)
+                  (format "Executing from wave ~a" wave-arg)
+                  "Execution started. Follow the plan."))
+      (hasheq 'success
+              #f
+              'mode
+              (gsm-current)
+              'message
+              (format "Cannot start execution: ~a" (err-reason result)))))
+
+;; /replan → exploring from plan-written or executing
+(define (cmd-replan)
+  (define current (gsm-current))
+  (cond
+    [(or (eq? current 'plan-written) (eq? current 'executing))
+     (define result (gsm-transition! 'exploring))
+     (if (ok? result)
+         (hasheq 'success #t 'mode 'exploring 'message "Re-planning. Modify the plan freely.")
+         (hasheq 'success
+                 #f
+                 'mode
+                 (gsm-current)
+                 'message
+                 (format "Cannot re-plan: ~a" (err-reason result))))]
+    [else
+     (hasheq 'success #f 'mode current 'message (format "Cannot re-plan from ~a state" current))]))
+
+;; /skip <wave> → mark wave as skipped
+(define (cmd-skip args)
+  (define current (gsm-current))
+  (if (not (eq? current 'executing))
+      (hasheq 'success #f 'mode current 'message "/skip only works during execution")
+      (let ([wave-num (if (string? args)
+                          (string->number (string-trim args))
+                          #f)])
+        (if wave-num
+            (hasheq 'success
+                    #t
+                    'mode
+                    'executing
+                    'message
+                    (format "Wave ~a marked as skipped" wave-num))
+            (hasheq 'success #f 'mode 'executing 'message "Usage: /skip <wave-number>")))))
+
+;; /reset → idle
+(define (cmd-reset)
+  (define result (gsm-reset!))
+  (reset-steering-state!)
+  (hasheq 'success #t 'mode 'idle 'message "GSD reset to idle."))
+
+;; ============================================================
+;; Tool guard (tool-call-pre)
+;; ============================================================
+
+;; Check if a tool call is allowed in the current state.
+;; Returns #t if allowed, or a hash with 'blocked #t and 'reason.
+(define (gsd-tool-guard tool-name tool-args)
+  (if (gsm-tool-allowed? tool-name)
+      #t
+      (hasheq 'blocked
+              #t
+              'tool
+              tool-name
+              'mode
+              (gsm-current)
+              'reason
+              (format "Tool '~a' is not allowed in ~a mode" tool-name (gsm-current)))))
+
+;; ============================================================
+;; Write guard
+;; ============================================================
+
+;; During executing mode, block writes to .planning/PLAN.md.
+;; Returns #t if allowed, or a hash with 'blocked #t and 'reason.
+(define (gsd-write-guard target-path planning-dir)
+  (define mode (gsm-current))
+  (cond
+    [(not (eq? mode 'executing)) #t]
+    [(not (string? target-path)) #t]
+    [else
+     (define normalized (normalize-path target-path))
+     (define plan-path
+       (if (string? planning-dir)
+           (normalize-path (string-append planning-dir "/PLAN.md"))
+           ""))
+     (if (and (non-empty? plan-path) (string=? normalized plan-path))
+         (hasheq 'blocked
+                 #t
+                 'tool
+                 "write"
+                 'mode
+                 'executing
+                 'reason
+                 (format "Cannot write to ~a during execution (use /replan to modify)" target-path))
+         #t)]))
+
+;; ============================================================
+;; Status display
+;; ============================================================
+
+(define (gsd-show-status)
+  (define mode (gsm-current))
+  (define valid-next (gsm-valid-next-states))
+  (define snapshot (gsm-snapshot))
+  (hasheq
+   'mode
+   mode
+   'valid-next-states
+   valid-next
+   'history-length
+   (length (hash-ref snapshot 'history))
+   'message
+   (format "GSD Status: ~a | Next: ~a" mode (string-join (map symbol->string valid-next) ", "))))
+
+;; ============================================================
+;; Internal helpers
+;; ============================================================
+
+(define (non-empty? s)
+  (and (string? s) (> (string-length s) 0)))
+
+(define (normalize-path p)
+  (define collapsed (regexp-replace* #rx"/\\.\\./" p ""))
+  (define no-dot (regexp-replace* #rx"/\\./" collapsed "/"))
+  (string-trim no-dot))

--- a/extensions/gsd/steering.rkt
+++ b/extensions/gsd/steering.rkt
@@ -1,0 +1,121 @@
+#lang racket/base
+
+;; extensions/gsd/steering.rkt — Mode-aware steering module
+;;
+;; Wave 1c of v0.21.0: Steering logic that only activates during
+;; executing mode. Replaces the ~200 lines of steering in iteration.rkt.
+;;
+;; DD-2: No steering during exploring — LLMs self-regulate.
+;; DD-3: Steering moved into GSD extension, mode-aware.
+
+(require racket/string
+         "state-machine.rkt")
+
+(provide gsd-steering-check
+         reset-steering-state!
+         ;; Exposed for testing
+         stall-threshold)
+
+;; ============================================================
+;; Configuration
+;; ============================================================
+
+;; Number of consecutive identical reads before stall detection
+(define stall-threshold 3)
+
+;; ============================================================
+;; Mutable steering state
+;; ============================================================
+
+;; Track last N (tool-name . argument) pairs for stall detection
+(define steering-history (make-parameter '()))
+(define steering-history-max 10)
+
+;; ============================================================
+;; Public API
+;; ============================================================
+
+;; Called from tool-result-post hook.
+;; Returns #f if no steering needed, or a steering prompt string.
+(define (gsd-steering-check tool-name tool-args result)
+  (define mode (gsm-current))
+  (cond
+    ;; No steering in these modes (DD-2, DD-3)
+    [(eq? mode 'idle) #f]
+    [(eq? mode 'exploring) #f]
+    [(eq? mode 'plan-written) #f]
+    [(eq? mode 'verifying) #f]
+    ;; Only active during executing
+    [(eq? mode 'executing)
+     (update-steering-history! tool-name tool-args)
+     (detect-stall)]
+    [else #f]))
+
+;; Reset steering state (called on mode transition)
+(define (reset-steering-state!)
+  (steering-history '()))
+
+;; ============================================================
+;; Internal: stall detection
+;; ============================================================
+
+(define (update-steering-history! tool-name tool-args)
+  (cond
+    [(string=? tool-name "read")
+     (define entry (cons tool-name (simplify-args tool-name tool-args)))
+     (define current (steering-history))
+     (define new-history (take-at-most (cons entry current) steering-history-max))
+     (steering-history new-history)]
+    ;; Non-read tool: reset stall counter
+    [else (steering-history '())]))
+
+;; Simplify args: for read tool, extract file path; for others, empty
+(define (simplify-args tool-name tool-args)
+  (cond
+    [(string=? tool-name "read")
+     (cond
+       [(hash? tool-args) (hash-ref tool-args 'path (hash-ref tool-args 'file ""))]
+       [(string? tool-args) tool-args]
+       [else ""])]
+    [else ""]))
+
+(define (take-at-most lst n)
+  (if (> (length lst) n)
+      (take lst n)
+      lst))
+
+;; Check if the last stall-threshold reads are all the same file
+(define (detect-stall)
+  (define history (steering-history))
+  (define reads (filter (lambda (e) (string=? (car e) "read")) history))
+  (cond
+    [(< (length reads) stall-threshold) #f]
+    [else
+     (define first-read (car reads))
+     (define first-args (cdr first-read))
+     (define consecutive-same?
+       (for/and ([r (take reads stall-threshold)])
+         (string=? (cdr r) first-args)))
+     (if consecutive-same?
+         (format-stall-prompt first-args)
+         #f)]))
+
+(define (format-stall-prompt file-path)
+  (string-append "⚠️  Stall detected: You've read `"
+                 file-path
+                 "` "
+                 (number->string stall-threshold)
+                 "+ times consecutively.\n"
+                 "Consider:\n"
+                 "- You already have this file's contents — use what you know\n"
+                 "- Proceed to the next task in the wave\n"
+                 "- Use /skip to skip this wave if stuck\n"))
+
+;; ============================================================
+;; take helper (racket/base doesn't have take)
+;; ============================================================
+
+(define (take lst n)
+  (if (or (<= n 0) (null? lst))
+      '()
+      (cons (car lst) (take (cdr lst) (sub1 n)))))

--- a/tests/test-gsd-context-bundle.rkt
+++ b/tests/test-gsd-context-bundle.rkt
@@ -1,0 +1,102 @@
+#lang racket
+
+;; tests/test-gsd-context-bundle.rkt — Context bundle assembly tests
+;;
+;; Wave 1b of v0.21.0: Tests for role-specific context bundles.
+
+(require rackunit
+         "../extensions/gsd/context-bundle.rkt")
+
+;; ============================================================
+;; Explorer bundle
+;; ============================================================
+
+(test-case "explorer bundle: includes user request"
+  (define artifacts (hasheq 'user-request "Fix the login bug"
+                            'project-context "A web app"))
+  (define bundle (assemble-context 'explorer artifacts (hasheq)))
+  (check-true (string-contains? bundle "Fix the login bug")))
+
+(test-case "explorer bundle: includes project context"
+  (define artifacts (hasheq 'user-request ""
+                            'project-context "Racket coding agent"))
+  (define bundle (assemble-context 'explorer artifacts (hasheq)))
+  (check-true (string-contains? bundle "Racket coding agent")))
+
+(test-case "explorer bundle: works with empty artifacts"
+  (define artifacts (hasheq 'user-request "" 'project-context ""))
+  (define bundle (assemble-context 'explorer artifacts (hasheq)))
+  (check-true (string? bundle))
+  (check-true (> (string-length bundle) 0)))
+
+;; ============================================================
+;; Executor bundle
+;; ============================================================
+
+(test-case "executor bundle: includes plan text"
+  (define artifacts (hasheq 'plan "## Wave 0: Fix bug\n- File: src/fix.rkt\n- Verify: test\n"
+                            'state "In progress"
+                            'wave-index 0))
+  (define bundle (assemble-context 'executor artifacts (hasheq)))
+  (check-true (string-contains? bundle "Wave 0")))
+
+(test-case "executor bundle: includes state"
+  (define artifacts (hasheq 'plan "## Wave 0: Fix\n- File: a\n- Verify: t\n"
+                            'state "Wave 0 in progress"
+                            'wave-index 0))
+  (define bundle (assemble-context 'executor artifacts (hasheq)))
+  (check-true (string-contains? bundle "Wave 0 in progress")))
+
+(test-case "executor bundle: includes referenced files"
+  (define artifacts (hasheq 'plan "## Wave 0: Fix\n- File: src/fix.rkt\n- Verify: t\n"
+                            'state ""
+                            'wave-index 0))
+  (define files (hasheq "src/fix.rkt" "(define (fix) 42)"))
+  (define bundle (assemble-context 'executor artifacts files))
+  (check-true (string-contains? bundle "src/fix.rkt"))
+  (check-true (string-contains? bundle "(define (fix) 42)")))
+
+;; ============================================================
+;; Verifier bundle
+;; ============================================================
+
+(test-case "verifier bundle: includes plan"
+  (define artifacts (hasheq 'plan "## Wave 0: Fix\n- Verify: raco test tests/\n"
+                            'summaries "Wave 0: fixed the bug"))
+  (define bundle (assemble-context 'verifier artifacts (hasheq)))
+  (check-true (string-contains? bundle "Wave 0")))
+
+(test-case "verifier bundle: includes summaries"
+  (define artifacts (hasheq 'plan "## Wave 0: Fix\n- Verify: t\n"
+                            'summaries "All waves completed"))
+  (define bundle (assemble-context 'verifier artifacts (hasheq)))
+  (check-true (string-contains? bundle "All waves completed")))
+
+(test-case "verifier bundle: extracts verify commands"
+  (define artifacts (hasheq 'plan "## Wave 0: Fix\n- Verify: raco test tests/\n"
+                            'summaries ""))
+  (define bundle (assemble-context 'verifier artifacts (hasheq)))
+  (check-true (string-contains? bundle "raco test")))
+
+;; ============================================================
+;; Size warnings
+;; ============================================================
+
+(test-case "bundle-size-warning?: returns #f for small bundles"
+  (define artifacts (hasheq 'user-request "Fix bug" 'project-context ""))
+  (define bundle (assemble-context 'explorer artifacts (hasheq)))
+  (check-false (bundle-size-warning? bundle)))
+
+(test-case "bundle-size-warning?: returns #t for large bundles"
+  (define big-plan (make-string 5000 #\X))
+  (define artifacts (hasheq 'plan big-plan 'state big-plan 'wave-index 0))
+  (define bundle (assemble-context 'executor artifacts (hasheq)))
+  (check-true (bundle-size-warning? bundle)))
+
+;; ============================================================
+;; Error cases
+;; ============================================================
+
+(test-case "assemble-context: unknown role raises error"
+  (check-exn exn:fail?
+             (lambda () (assemble-context 'unknown (hasheq) (hasheq)))))

--- a/tests/test-gsd-core.rkt
+++ b/tests/test-gsd-core.rkt
@@ -1,0 +1,247 @@
+#lang racket
+
+;; tests/test-gsd-core.rkt — Core GSD extension tests
+;;
+;; Wave 1 of v0.21.0: Tests for command dispatch, tool guard,
+;; write guard, and status display.
+
+(require rackunit
+         "../extensions/gsd/core.rkt"
+         "../extensions/gsd/state-machine.rkt")
+
+;; ============================================================
+;; Command dispatch: /plan
+;; ============================================================
+
+(test-case "/plan: transitions to exploring"
+  (reset-gsm!)
+  (define r (gsd-command-dispatch 'plan "Fix the bug"))
+  (check-equal? (hash-ref r 'success) #t)
+  (check-eq? (hash-ref r 'mode) 'exploring))
+
+(test-case "/plan: includes user text in message"
+  (reset-gsm!)
+  (define r (gsd-command-dispatch 'plan "Investigate crash"))
+  (check-true (string-contains? (hash-ref r 'message) "Investigate crash")))
+(test-case "/plan: succeeds from plan-written (same as replan)"
+  (reset-gsm!)
+  (gsm-transition! 'exploring)
+  (gsm-transition! 'plan-written)
+  (define r (gsd-command-dispatch 'plan "re-plan"))
+  (check-equal? (hash-ref r 'success) #t)
+  (check-eq? (hash-ref r 'mode) 'exploring))
+
+
+
+
+
+
+
+
+;; ============================================================
+;; Command dispatch: /go
+;; ============================================================
+
+(test-case "/go: transitions to executing from plan-written"
+  (reset-gsm!)
+  (gsm-transition! 'exploring)
+  (gsm-transition! 'plan-written)
+  (define r (gsd-command-dispatch 'go ""))
+  (check-equal? (hash-ref r 'success) #t)
+  (check-eq? (hash-ref r 'mode) 'executing))
+
+(test-case "/go: fails from idle"
+  (reset-gsm!)
+  (define r (gsd-command-dispatch 'go ""))
+  (check-equal? (hash-ref r 'success) #f))
+
+(test-case "/go: fails from exploring"
+  (reset-gsm!)
+  (gsm-transition! 'exploring)
+  (define r (gsd-command-dispatch 'go ""))
+  (check-equal? (hash-ref r 'success) #f))
+
+(test-case "/go: accepts wave argument"
+  (reset-gsm!)
+  (gsm-transition! 'exploring)
+  (gsm-transition! 'plan-written)
+  (define r (gsd-command-dispatch 'go "2"))
+  (check-equal? (hash-ref r 'success) #t)
+  (check-true (string-contains? (hash-ref r 'message) "wave 2")))
+
+;; ============================================================
+;; Command dispatch: /replan
+;; ============================================================
+
+(test-case "/replan: from plan-written to exploring"
+  (reset-gsm!)
+  (gsm-transition! 'exploring)
+  (gsm-transition! 'plan-written)
+  (define r (gsd-command-dispatch 'replan #f))
+  (check-equal? (hash-ref r 'success) #t)
+  (check-eq? (hash-ref r 'mode) 'exploring))
+
+(test-case "/replan: from executing to exploring"
+  (reset-gsm!)
+  (gsm-transition! 'exploring)
+  (gsm-transition! 'plan-written)
+  (gsm-transition! 'executing)
+  (define r (gsd-command-dispatch 'replan #f))
+  (check-equal? (hash-ref r 'success) #t)
+  (check-eq? (hash-ref r 'mode) 'exploring))
+
+(test-case "/replan: fails from idle"
+  (reset-gsm!)
+  (define r (gsd-command-dispatch 'replan #f))
+  (check-equal? (hash-ref r 'success) #f))
+
+(test-case "/replan: fails from exploring"
+  (reset-gsm!)
+  (gsm-transition! 'exploring)
+  (define r (gsd-command-dispatch 'replan #f))
+  (check-equal? (hash-ref r 'success) #f))
+
+;; ============================================================
+;; Command dispatch: /skip
+;; ============================================================
+
+(test-case "/skip: works during executing"
+  (reset-gsm!)
+  (gsm-transition! 'exploring)
+  (gsm-transition! 'plan-written)
+  (gsm-transition! 'executing)
+  (define r (gsd-command-dispatch 'skip "3"))
+  (check-equal? (hash-ref r 'success) #t)
+  (check-true (string-contains? (hash-ref r 'message) "3")))
+
+(test-case "/skip: fails outside executing"
+  (reset-gsm!)
+  (define r (gsd-command-dispatch 'skip "1"))
+  (check-equal? (hash-ref r 'success) #f))
+
+(test-case "/skip: fails with no wave number"
+  (reset-gsm!)
+  (gsm-transition! 'exploring)
+  (gsm-transition! 'plan-written)
+  (gsm-transition! 'executing)
+  (define r (gsd-command-dispatch 'skip "abc"))
+  (check-equal? (hash-ref r 'success) #f))
+
+;; ============================================================
+;; Command dispatch: /reset
+;; ============================================================
+
+(test-case "/reset: goes to idle from any state"
+  (for ([states (list '(exploring plan-written executing verifying))])
+    (reset-gsm!)
+    (for ([s states])
+      (gsm-transition! s))
+    (define r (gsd-command-dispatch 'reset #f))
+    (check-equal? (hash-ref r 'success) #t)
+    (check-eq? (hash-ref r 'mode) 'idle)))
+
+;; ============================================================
+;; Command dispatch: unknown command
+;; ============================================================
+
+(test-case "unknown command returns #f"
+  (reset-gsm!)
+  (check-false (gsd-command-dispatch 'foobar "")))
+
+;; ============================================================
+;; Tool guard
+;; ============================================================
+
+(test-case "tool guard: allows all tools in idle"
+  (reset-gsm!)
+  (for ([tool '("read" "edit" "write" "bash" "planning-read" "planning-write")])
+    (check-true (gsd-tool-guard tool #f) (format "~a in idle" tool))))
+
+(test-case "tool guard: allows all tools in exploring"
+  (reset-gsm!)
+  (gsm-transition! 'exploring)
+  (for ([tool '("read" "edit" "write" "bash" "planning-read" "planning-write")])
+    (check-true (gsd-tool-guard tool #f) (format "~a in exploring" tool))))
+
+(test-case "tool guard: blocks edit/write/bash in plan-written"
+  (reset-gsm!)
+  (gsm-transition! 'exploring)
+  (gsm-transition! 'plan-written)
+  (for ([tool '("edit" "write" "bash")])
+    (define r (gsd-tool-guard tool #f))
+    (check-true (hash? r) (format "~a should be blocked" tool))
+    (check-equal? (hash-ref r 'blocked) #t)))
+
+(test-case "tool guard: allows read/planning-read in plan-written"
+  (reset-gsm!)
+  (gsm-transition! 'exploring)
+  (gsm-transition! 'plan-written)
+  (check-true (gsd-tool-guard "read" #f))
+  (check-true (gsd-tool-guard "planning-read" #f)))
+
+(test-case "tool guard: blocks planning-write in executing"
+  (reset-gsm!)
+  (gsm-transition! 'exploring)
+  (gsm-transition! 'plan-written)
+  (gsm-transition! 'executing)
+  (define r (gsd-tool-guard "planning-write" #f))
+  (check-true (hash? r))
+  (check-equal? (hash-ref r 'blocked) #t))
+
+(test-case "tool guard: allows edit/write/bash in executing"
+  (reset-gsm!)
+  (gsm-transition! 'exploring)
+  (gsm-transition! 'plan-written)
+  (gsm-transition! 'executing)
+  (for ([tool '("edit" "write" "bash" "read")])
+    (check-true (gsd-tool-guard tool #f) (format "~a in executing" tool))))
+
+(test-case "tool guard: blocks edit/write/bash in verifying"
+  (reset-gsm!)
+  (gsm-transition! 'exploring)
+  (gsm-transition! 'plan-written)
+  (gsm-transition! 'executing)
+  (gsm-transition! 'verifying)
+  (for ([tool '("edit" "write" "bash")])
+    (define r (gsd-tool-guard tool #f))
+    (check-true (hash? r) (format "~a should be blocked" tool))
+    (check-equal? (hash-ref r 'blocked) #t)))
+
+;; ============================================================
+;; Write guard
+;; ============================================================
+
+(test-case "write guard: blocks PLAN.md during executing"
+  (reset-gsm!)
+  (gsm-transition! 'exploring)
+  (gsm-transition! 'plan-written)
+  (gsm-transition! 'executing)
+  (define r (gsd-write-guard ".planning/PLAN.md" ".planning"))
+  (check-true (hash? r))
+  (check-equal? (hash-ref r 'blocked) #t))
+
+(test-case "write guard: allows non-PLAN.md during executing"
+  (reset-gsm!)
+  (gsm-transition! 'exploring)
+  (gsm-transition! 'plan-written)
+  (gsm-transition! 'executing)
+  (check-true (gsd-write-guard "src/fix.rkt" ".planning")))
+
+(test-case "write guard: allows PLAN.md during idle"
+  (reset-gsm!)
+  (check-true (gsd-write-guard ".planning/PLAN.md" ".planning")))
+
+(test-case "write guard: allows PLAN.md during exploring"
+  (reset-gsm!)
+  (gsm-transition! 'exploring)
+  (check-true (gsd-write-guard ".planning/PLAN.md" ".planning")))
+
+;; ============================================================
+;; Status display
+;; ============================================================
+
+(test-case "/gsd shows current mode and valid transitions"
+  (reset-gsm!)
+  (define r (gsd-show-status))
+  (check-eq? (hash-ref r 'mode) 'idle)
+  (check-true (list? (hash-ref r 'valid-next-states))))

--- a/tests/test-gsd-steering.rkt
+++ b/tests/test-gsd-steering.rkt
@@ -1,0 +1,99 @@
+#lang racket
+
+;; tests/test-gsd-steering.rkt — Steering module tests
+;;
+;; Wave 1c of v0.21.0: Mode-aware steering.
+
+(require rackunit
+         "../extensions/gsd/steering.rkt"
+         "../extensions/gsd/state-machine.rkt")
+
+;; ============================================================
+;; Steering: returns #f in non-executing modes
+;; ============================================================
+
+(test-case "steering returns #f in idle"
+  (reset-gsm!)
+  (reset-steering-state!)
+  (check-false (gsd-steering-check "read" (hasheq 'path "foo.rkt") "")))
+
+(test-case "steering returns #f in exploring (DD-2)"
+  (reset-gsm!)
+  (reset-steering-state!)
+  (gsm-transition! 'exploring)
+  ;; Even with many reads, no steering
+  (for ([_ (in-range 5)])
+    (check-false (gsd-steering-check "read" (hasheq 'path "foo.rkt") ""))))
+
+(test-case "steering returns #f in plan-written"
+  (reset-gsm!)
+  (reset-steering-state!)
+  (gsm-transition! 'exploring)
+  (gsm-transition! 'plan-written)
+  (check-false (gsd-steering-check "read" (hasheq 'path "foo.rkt") "")))
+
+(test-case "steering returns #f in verifying"
+  (reset-gsm!)
+  (reset-steering-state!)
+  (gsm-transition! 'exploring)
+  (gsm-transition! 'plan-written)
+  (gsm-transition! 'executing)
+  (gsm-transition! 'verifying)
+  (check-false (gsd-steering-check "read" (hasheq 'path "foo.rkt") "")))
+
+;; ============================================================
+;; Steering: activates during executing after stall
+;; ============================================================
+
+(test-case "steering: no stall before threshold"
+  (reset-gsm!)
+  (reset-steering-state!)
+  (gsm-transition! 'exploring)
+  (gsm-transition! 'plan-written)
+  (gsm-transition! 'executing)
+  ;; Below threshold
+  (for ([_ (in-range (sub1 stall-threshold))])
+    (check-false (gsd-steering-check "read" (hasheq 'path "foo.rkt") ""))))
+
+(test-case "steering: detects stall at threshold"
+  (reset-gsm!)
+  (reset-steering-state!)
+  (gsm-transition! 'exploring)
+  (gsm-transition! 'plan-written)
+  (gsm-transition! 'executing)
+  ;; Build up to threshold
+  (for ([_ (in-range (sub1 stall-threshold))])
+    (gsd-steering-check "read" (hasheq 'path "foo.rkt") ""))
+  ;; This one triggers stall
+  (define result (gsd-steering-check "read" (hasheq 'path "foo.rkt") ""))
+  (check-not-false result)
+  (check-true (string-contains? result "Stall detected"))
+  (check-true (string-contains? result "foo.rkt")))
+
+(test-case "steering: resets on non-read tool call"
+  (reset-gsm!)
+  (reset-steering-state!)
+  (gsm-transition! 'exploring)
+  (gsm-transition! 'plan-written)
+  (gsm-transition! 'executing)
+  ;; Build up reads
+  (for ([_ (in-range stall-threshold)])
+    (gsd-steering-check "read" (hasheq 'path "foo.rkt") ""))
+  ;; Non-read resets stall
+  (gsd-steering-check "edit" (hasheq 'file "foo.rkt") "")
+  ;; Now reads shouldn't trigger stall yet
+  (for ([_ (in-range (sub1 stall-threshold))])
+    (check-false (gsd-steering-check "read" (hasheq 'path "foo.rkt") ""))))
+
+(test-case "steering: different files don't cause stall"
+  (reset-gsm!)
+  (reset-steering-state!)
+  (gsm-transition! 'exploring)
+  (gsm-transition! 'plan-written)
+  (gsm-transition! 'executing)
+  ;; Alternate between different files
+  (for ([_ (in-range (* 2 stall-threshold))])
+    (gsd-steering-check "read" (hasheq 'path "foo.rkt") "")
+    (gsd-steering-check "read" (hasheq 'path "bar.rkt") ""))
+  ;; Shouldn't stall because files alternate
+  (check-false (gsd-steering-check "read" (hasheq 'path "foo.rkt") "")))


### PR DESCRIPTION
Addresses #2042.

feat(gsd): add core extension, context bundle, and steering modules (Wave 1, #2042)

Wave 1 of v0.21.0 GSD Extension Rewrite — Core modules.

New modules in extensions/gsd/:
- core.rkt: Command dispatch (/plan, /go, /replan, /skip, /reset, /gsd),
  tool guard per state, write guard for PLAN.md during execution.
- context-bundle.rkt: Role-specific context assembly for explorer,
  executor, and verifier phases. Bundle size warnings at 4000 chars.
- steering.rkt: Mode-aware stall detection. Only active during executing
  mode. Detects 3+ consecutive identical file reads. No steering during
  exploring (DD-2).

New tests:
- test-gsd-core.rkt: 28 tests covering commands, tool guards, write guard.
- test-gsd-context-bundle.rkt: 12 tests covering all 3 bundle roles.
- test-gsd-steering.rkt: 8 tests covering stall detection and mode guards.

Closes #2042, #2043, #2044, #2045