### PR TITLE
feat(gsd): add plan validator and wave execution engine (Wave 2, #2046)

Wave 2 of v0.21.0 GSD Extension Rewrite — Validation + Execution.

New modules in extensions/gsd/:
- plan-validator.rkt: Strict validation before /go. Errors block: no
  waves, missing title, no file refs. Warnings allow: no verify, no
  root-cause. format-validation-report for display.
- wave-executor.rkt: Wave lifecycle tracking with error recovery (DD-5).
  Status: pending → in-progress → completed/failed/skipped. Failed waves
  don't block subsequent waves. Attempt counting, summaries.

New tests:
- test-gsd-plan-validator.rkt: 9 tests (valid plans, error cases, warnings)
- test-gsd-wave-executor.rkt: 12 tests (lifecycle, failure recovery, skip, summary)

Closes #2046, #2047, #2048

### DIFF
--- a/extensions/gsd/plan-validator.rkt
+++ b/extensions/gsd/plan-validator.rkt
@@ -1,0 +1,89 @@
+#lang racket/base
+
+;; extensions/gsd/plan-validator.rkt — Plan structure validation
+;;
+;; Wave 2a of v0.21.0: Mechanical validation before /go is allowed.
+;; DD-4: Structured plan format with mechanical validation.
+;;
+;; Error rules (block /go):
+;;   - Plan has < 1 wave
+;;   - Wave missing title
+;;   - Wave has no files (was warning, upgraded to error per spec)
+;;
+;; Warning rules (display but allow):
+;;   - Wave missing verify command
+;;   - Wave missing root-cause/objective
+
+(require racket/format
+         racket/string
+         "plan-types.rkt")
+
+(provide validate-plan-strict
+         format-validation-report
+         valid-plan->go?)
+
+;; ============================================================
+;; Strict validation
+;; ============================================================
+
+;; Enhanced validation: files missing is an error (not warning).
+;; Returns validation-result with errors and warnings.
+(define (validate-plan-strict plan)
+  (define waves (gsd-plan-waves plan))
+  (define errors '())
+  (define warnings '())
+  ;; Check: plan has at least 1 wave
+  (when (null? waves)
+    (set! errors (cons "Plan has no waves" errors)))
+  ;; Per-wave checks
+  (for ([w waves])
+    (define widx (gsd-wave-index w))
+    (define prefix (format "Wave ~a" widx))
+    ;; Error: missing title
+    (when (string=? (gsd-wave-title w) "")
+      (set! errors (cons (format "~a: missing title" prefix) errors)))
+    ;; Error: no file references (DD-4: strict)
+    (when (null? (gsd-wave-files w))
+      (set! errors (cons (format "~a: no file references" prefix) errors)))
+    ;; Warning: no verify command
+    (when (string=? (gsd-wave-verify w) "")
+      (set! warnings (cons (format "~a: no verify command" prefix) warnings)))
+    ;; Warning: no root-cause/objective
+    (when (string=? (gsd-wave-root-cause w) "")
+      (set! warnings (cons (format "~a: no root-cause/objective" prefix) warnings))))
+  (validation-result (reverse errors) (reverse warnings)))
+
+;; ============================================================
+;; Helpers
+;; ============================================================
+
+;; Can we proceed to /go? Only if no errors.
+(define (valid-plan->go? plan)
+  (define result (validate-plan-strict plan))
+  (validation-valid? result))
+
+;; Format validation result for display.
+(define (format-validation-report result)
+  (define errors (validation-errors result))
+  (define warnings (validation-warnings result))
+  (define parts '())
+  (when (not (null? errors))
+    (set! parts
+          (cons (format "❌ ERRORS (block /go):\n~a"
+                        (string-join (for/list ([e errors])
+                                       (format "  - ~a" e))
+                                     "\n"))
+                parts)))
+  (when (not (null? warnings))
+    (set! parts
+          (cons (format "⚠️  WARNINGS:\n~a"
+                        (string-join (for/list ([w warnings])
+                                       (format "  - ~a" w))
+                                     "\n"))
+                parts)))
+  (if (null? errors)
+      (string-append "✅ Plan is valid.\n"
+                     (if (null? parts)
+                         ""
+                         (string-join (reverse parts) "\n\n")))
+      (string-join (reverse parts) "\n\n")))

--- a/extensions/gsd/wave-executor.rkt
+++ b/extensions/gsd/wave-executor.rkt
@@ -1,0 +1,147 @@
+#lang racket/base
+
+;; extensions/gsd/wave-executor.rkt — Wave execution engine with error recovery
+;;
+;; Wave 2b of v0.21.0: Tracks wave status through execution lifecycle.
+;; DD-5: Wave-level error recovery — failed waves skip, don't abort.
+;;
+;; Lifecycle: pending → in-progress → completed | failed | skipped
+;; Failed waves do NOT block subsequent waves.
+
+(require racket/format
+         racket/string
+         "plan-types.rkt")
+
+(provide wave-status
+         wave-status?
+         wave-status-index
+         wave-status-state
+         wave-status-error-message
+         wave-status-attempt-count
+         wave-status-timestamp
+         make-wave-executor
+         wave-start!
+         wave-complete!
+         wave-fail!
+         wave-skip!
+         next-pending-wave
+         wave-summary
+         all-waves-done?
+         ;; Exposed for testing
+         wave-executor-statuses
+         wave-executor-plan)
+
+;; ============================================================
+;; Wave status struct
+;; ============================================================
+
+(struct wave-status (index state error-message attempt-count timestamp) #:transparent)
+
+;; ============================================================
+;; Wave executor (mutable box wrapping plan + statuses)
+;; ============================================================
+
+(struct wave-executor (plan statuses-box) #:transparent)
+
+(define (wave-executor-statuses exec)
+  (unbox (wave-executor-statuses-box exec)))
+
+(define (set-executor-statuses! exec statuses)
+  (set-box! (wave-executor-statuses-box exec) statuses))
+
+;; ============================================================
+;; Constructor
+;; ============================================================
+
+(define (make-wave-executor plan)
+  (define waves (gsd-plan-waves plan))
+  (define initial-statuses
+    (for/list ([w waves])
+      (wave-status (gsd-wave-index w) 'pending #f 0 (current-seconds))))
+  (wave-executor plan (box initial-statuses)))
+
+;; ============================================================
+;; Status transitions
+;; ============================================================
+
+(define (update-status! exec idx update-fn)
+  (define statuses (wave-executor-statuses exec))
+  (define new-statuses
+    (for/list ([s statuses])
+      (if (= (wave-status-index s) idx)
+          (update-fn s)
+          s)))
+  (set-executor-statuses! exec new-statuses))
+
+(define (wave-start! exec idx)
+  (update-status!
+   exec
+   idx
+   (lambda (s)
+     (wave-status idx 'in-progress #f (add1 (wave-status-attempt-count s)) (current-seconds)))))
+
+(define (wave-complete! exec idx)
+  (update-status! exec
+                  idx
+                  (lambda (s)
+                    (wave-status idx 'completed #f (wave-status-attempt-count s) (current-seconds)))))
+
+(define (wave-fail! exec idx error-message)
+  (update-status!
+   exec
+   idx
+   (lambda (s)
+     (wave-status idx 'failed error-message (wave-status-attempt-count s) (current-seconds)))))
+
+(define (wave-skip! exec idx)
+  (update-status! exec
+                  idx
+                  (lambda (s)
+                    (wave-status idx 'skipped #f (wave-status-attempt-count s) (current-seconds)))))
+
+;; ============================================================
+;; Queries
+;; ============================================================
+
+(define (next-pending-wave exec)
+  (define statuses (wave-executor-statuses exec))
+  (define pending (filter (lambda (s) (eq? (wave-status-state s) 'pending)) statuses))
+  (if (null? pending)
+      #f
+      (wave-status-index (car pending))))
+
+(define (all-waves-done? exec)
+  (define statuses (wave-executor-statuses exec))
+  (for/and ([s statuses])
+    (and (memq (wave-status-state s) '(completed failed skipped)) #t)))
+
+(define (wave-summary exec)
+  (define statuses (wave-executor-statuses exec))
+  (define by-state
+    (for/fold ([acc (hasheq)]) ([s statuses])
+      (hash-update acc (wave-status-state s) add1 0)))
+  (define n-completed (hash-ref by-state 'completed 0))
+  (define n-failed (hash-ref by-state 'failed 0))
+  (define n-skipped (hash-ref by-state 'skipped 0))
+  (define n-pending (hash-ref by-state 'pending 0))
+  (define n-in-progress (hash-ref by-state 'in-progress 0))
+  (define total (length statuses))
+  (define parts
+    (filter values
+            (list (format "Total: ~a waves" total)
+                  (if (> n-completed 0)
+                      (format "✅ Completed: ~a" n-completed)
+                      #f)
+                  (if (> n-failed 0)
+                      (format "❌ Failed: ~a" n-failed)
+                      #f)
+                  (if (> n-skipped 0)
+                      (format "⏭  Skipped: ~a" n-skipped)
+                      #f)
+                  (if (> n-pending 0)
+                      (format "⏳ Pending: ~a" n-pending)
+                      #f)
+                  (if (> n-in-progress 0)
+                      (format "🔄 In Progress: ~a" n-in-progress)
+                      #f))))
+  (string-join parts "\n"))

--- a/tests/test-gsd-plan-validator.rkt
+++ b/tests/test-gsd-plan-validator.rkt
@@ -1,0 +1,102 @@
+#lang racket
+
+;; tests/test-gsd-plan-validator.rkt — Plan validator tests
+;;
+;; Wave 2a: Strict validation rules that block /go.
+
+(require rackunit
+         "../extensions/gsd/plan-validator.rkt"
+         "../extensions/gsd/plan-types.rkt")
+
+;; ============================================================
+;; Helper: valid wave
+;; ============================================================
+
+(define (valid-wave idx title files verify)
+  (gsd-wave idx title 'pending "root cause" files '() verify '()))
+
+;; ============================================================
+;; Valid plans
+;; ============================================================
+
+(test-case "well-formed plan with 3 waves passes validation"
+  (define plan
+    (gsd-plan
+     (list (valid-wave 0 "Setup" '("a.rkt") "raco test a")
+           (valid-wave 1 "Implement" '("b.rkt") "raco test b")
+           (valid-wave 2 "Verify" '("c.rkt") "raco test c"))
+     "" '() '()))
+  (define result (validate-plan-strict plan))
+  (check-true (validation-valid? result))
+  (check-equal? (length (validation-errors result)) 0))
+
+(test-case "valid-plan->go? returns #t for valid plan"
+  (define plan
+    (gsd-plan (list (valid-wave 0 "Fix" '("x.rkt") "raco test")) "" '() '()))
+  (check-true (valid-plan->go? plan)))
+
+;; ============================================================
+;; Error cases (block /go)
+;; ============================================================
+
+(test-case "plan with 0 waves → error"
+  (define plan (gsd-plan '() "" '() '()))
+  (define result (validate-plan-strict plan))
+  (check-false (validation-valid? result))
+  (check-true (ormap (lambda (e) (string-contains? e "no waves"))
+                     (validation-errors result))))
+
+(test-case "wave without title → error"
+  (define plan
+    (gsd-plan (list (gsd-wave 0 "" 'pending "" '("a.rkt") '() "test" '())) "" '() '()))
+  (define result (validate-plan-strict plan))
+  (check-false (validation-valid? result))
+  (check-true (ormap (lambda (e) (string-contains? e "missing title"))
+                     (validation-errors result))))
+
+(test-case "wave without files → error"
+  (define plan
+    (gsd-plan (list (gsd-wave 0 "Fix" 'pending "" '() '() "test" '())) "" '() '()))
+  (define result (validate-plan-strict plan))
+  (check-false (validation-valid? result))
+  (check-true (ormap (lambda (e) (string-contains? e "no file"))
+                     (validation-errors result))))
+
+;; ============================================================
+;; Warning cases (allow /go)
+;; ============================================================
+
+(test-case "wave without verify → warning, not error"
+  (define plan
+    (gsd-plan (list (valid-wave 0 "Fix" '("a.rkt") "")) "" '() '()))
+  (define result (validate-plan-strict plan))
+  (check-true (validation-valid? result))
+  (check-equal? (length (validation-errors result)) 0)
+  (check-true (ormap (lambda (w) (string-contains? w "verify"))
+                     (validation-warnings result))))
+
+(test-case "wave without root-cause → warning"
+  (define plan
+    (gsd-plan (list (gsd-wave 0 "Fix" 'pending "" '("a.rkt") '() "test" '()))
+              "" '() '()))
+  (define result (validate-plan-strict plan))
+  (check-true (validation-valid? result))
+  (check-true (ormap (lambda (w) (string-contains? w "root-cause"))
+                     (validation-warnings result))))
+
+;; ============================================================
+;; Format report
+;; ============================================================
+
+(test-case "format-validation-report shows checkmark for valid plan"
+  (define plan
+    (gsd-plan (list (valid-wave 0 "Fix" '("a.rkt") "test")) "" '() '()))
+  (define result (validate-plan-strict plan))
+  (define report (format-validation-report result))
+  (check-true (string-contains? report "valid")))
+
+(test-case "format-validation-report shows errors for invalid plan"
+  (define plan (gsd-plan '() "" '() '()))
+  (define result (validate-plan-strict plan))
+  (define report (format-validation-report result))
+  (check-true (string-contains? report "ERRORS")))

--- a/tests/test-gsd-wave-executor.rkt
+++ b/tests/test-gsd-wave-executor.rkt
@@ -1,0 +1,138 @@
+#lang racket
+
+;; tests/test-gsd-wave-executor.rkt — Wave execution engine tests
+;;
+;; Wave 2b: Status lifecycle and error recovery.
+
+(require rackunit
+         "../extensions/gsd/wave-executor.rkt"
+         "../extensions/gsd/plan-types.rkt")
+
+;; ============================================================
+;; Helper
+;; ============================================================
+
+(define (make-test-plan n)
+  (gsd-plan
+   (for/list ([i (in-range n)])
+     (gsd-wave i (format "Wave ~a" i) 'pending "" '("file.rkt") '() "test" '()))
+   "" '() '()))
+
+;; ============================================================
+;; Lifecycle: pending → in-progress → completed
+;; ============================================================
+
+(test-case "status lifecycle: pending → in-progress → completed"
+  (define exec (make-wave-executor (make-test-plan 3)))
+  (check-equal? (next-pending-wave exec) 0)
+  (wave-start! exec 0)
+  (define s0 (car (wave-executor-statuses exec)))
+  (check-eq? (wave-status-state s0) 'in-progress)
+  (check-equal? (wave-status-attempt-count s0) 1)
+  (wave-complete! exec 0)
+  (define s0-done (car (wave-executor-statuses exec)))
+  (check-eq? (wave-status-state s0-done) 'completed))
+
+;; ============================================================
+;; Failed wave recovery
+;; ============================================================
+
+(test-case "failed wave: pending → in-progress → failed"
+  (define exec (make-wave-executor (make-test-plan 3)))
+  (wave-start! exec 0)
+  (wave-fail! exec 0 "compile error in foo.rkt")
+  (define s0 (car (wave-executor-statuses exec)))
+  (check-eq? (wave-status-state s0) 'failed)
+  (check-equal? (wave-status-error-message s0) "compile error in foo.rkt"))
+
+(test-case "failed wave does not block next wave"
+  (define exec (make-wave-executor (make-test-plan 3)))
+  (wave-start! exec 0)
+  (wave-fail! exec 0 "error")
+  ;; Next pending wave should be 1
+  (check-equal? (next-pending-wave exec) 1)
+  ;; And we can execute it
+  (wave-start! exec 1)
+  (wave-complete! exec 1)
+  (define statuses (wave-executor-statuses exec))
+  (check-eq? (wave-status-state (list-ref statuses 0)) 'failed)
+  (check-eq? (wave-status-state (list-ref statuses 1)) 'completed))
+
+;; ============================================================
+;; Skip wave
+;; ============================================================
+
+(test-case "skip wave: marks as skipped"
+  (define exec (make-wave-executor (make-test-plan 3)))
+  (wave-skip! exec 1)
+  (define statuses (wave-executor-statuses exec))
+  (check-eq? (wave-status-state (list-ref statuses 1)) 'skipped)
+  ;; Next pending should skip over wave 1
+  (check-equal? (next-pending-wave exec) 0))
+
+(test-case "skip advances to next pending wave"
+  (define exec (make-wave-executor (make-test-plan 3)))
+  (wave-start! exec 0)
+  (wave-complete! exec 0)
+  (wave-skip! exec 1)
+  (check-equal? (next-pending-wave exec) 2))
+
+;; ============================================================
+;; All done check
+;; ============================================================
+
+(test-case "all-waves-done? returns #f when pending remain"
+  (define exec (make-wave-executor (make-test-plan 3)))
+  (wave-complete! exec 0)
+  (check-false (all-waves-done? exec)))
+
+(test-case "all-waves-done? returns #t when all completed"
+  (define exec (make-wave-executor (make-test-plan 2)))
+  (wave-complete! exec 0)
+  (wave-complete! exec 1)
+  (check-true (all-waves-done? exec)))
+
+(test-case "all-waves-done? returns #t when mix of completed/failed/skipped"
+  (define exec (make-wave-executor (make-test-plan 3)))
+  (wave-complete! exec 0)
+  (wave-fail! exec 1 "error")
+  (wave-skip! exec 2)
+  (check-true (all-waves-done? exec)))
+
+;; ============================================================
+;; Summary
+;; ============================================================
+
+(test-case "wave-summary shows correct counts"
+  (define exec (make-wave-executor (make-test-plan 3)))
+  (wave-complete! exec 0)
+  (wave-fail! exec 1 "error")
+  (wave-skip! exec 2)
+  (define summary (wave-summary exec))
+  (check-true (string-contains? summary "Total: 3"))
+  (check-true (string-contains? summary "Completed: 1"))
+  (check-true (string-contains? summary "Failed: 1"))
+  (check-true (string-contains? summary "Skipped: 1")))
+
+(test-case "wave-summary with all pending"
+  (define exec (make-wave-executor (make-test-plan 2)))
+  (define summary (wave-summary exec))
+  (check-true (string-contains? summary "Total: 2"))
+  (check-true (string-contains? summary "Pending: 2")))
+
+;; ============================================================
+;; next-pending-wave
+;; ============================================================
+
+(test-case "next-pending-wave returns #f when no pending"
+  (define exec (make-wave-executor (make-test-plan 2)))
+  (wave-complete! exec 0)
+  (wave-complete! exec 1)
+  (check-false (next-pending-wave exec)))
+
+(test-case "attempt count increments on wave-start!"
+  (define exec (make-wave-executor (make-test-plan 1)))
+  (wave-start! exec 0)
+  (wave-start! exec 0) ;; restart
+  (define s0 (car (wave-executor-statuses exec)))
+  (check-equal? (wave-status-attempt-count s0) 2))


### PR DESCRIPTION
Addresses #2046.

feat(gsd): add plan validator and wave execution engine (Wave 2, #2046)

Wave 2 of v0.21.0 GSD Extension Rewrite — Validation + Execution.

New modules in extensions/gsd/:
- plan-validator.rkt: Strict validation before /go. Errors block: no
  waves, missing title, no file refs. Warnings allow: no verify, no
  root-cause. format-validation-report for display.
- wave-executor.rkt: Wave lifecycle tracking with error recovery (DD-5).
  Status: pending → in-progress → completed/failed/skipped. Failed waves
  don't block subsequent waves. Attempt counting, summaries.

New tests:
- test-gsd-plan-validator.rkt: 9 tests (valid plans, error cases, warnings)
- test-gsd-wave-executor.rkt: 12 tests (lifecycle, failure recovery, skip, summary)

Closes #2046, #2047, #2048