### PR TITLE
docs(gsd): add user guide + architecture docs, bump to v0.21.0 (Wave 5, #2057)

Wave 5 of v0.21.0 GSD Extension Rewrite — Documentation + Version Bump.

New documentation:
- docs/gsd-guide.md: User-facing guide covering all GSD commands
  (/plan, /go, /replan, /skip, /reset, /gsd), plan format, validation
  rules, state machine diagram, and usage tips.
- docs/gsd-architecture.md: Internal architecture documentation with
  module structure, state machine transitions, plan types, wave executor,
  write guard, bash detection, and migration layer details.

Updated:
- util/version.rkt: Bumped from 0.20.4 to 0.21.0
- CHANGELOG.md: Added v0.21.0 entry with all 5 waves documented

Closes #2057

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,52 @@
 # Changelog
 
+## v0.21.0 — 2026-04-26
+
+### GSD Extension Rewrite (5 waves)
+
+Complete rewrite of scattered GSD state management into a proper state machine
+with structured plan types, validation, and error recovery.
+
+**Wave 0 — State Machine + Structured Plan Types** (PR #2058)
+- `extensions/gsd/state-machine.rkt`: Explicit state transitions, tool guards,
+  semaphore-protected, transition history, snapshot
+- `extensions/gsd/plan-types.rkt`: gsd-plan/gsd-wave/gsd-task structs,
+  markdown parsing, validation, accessor aliases
+- 57 new tests
+
+**Wave 1 — Core Module + Context Assembly** (PR #2059)
+- `extensions/gsd/core.rkt`: Command dispatch (/plan, /go, /replan, /skip,
+  /reset, /gsd), tool guard, write guard
+- `extensions/gsd/context-bundle.rkt`: Role-specific context assembly
+  (explorer/executor/verifier), bundle size warnings
+- `extensions/gsd/steering.rkt`: Mode-aware stall detection, only active
+  during executing, consecutive-identical-reads trigger
+- 48 new tests
+
+**Wave 2 — Plan Validation + Wave Executor** (PR #2060)
+- `extensions/gsd/plan-validator.rkt`: Strict validation before /go.
+  Error rules (no waves, missing title, no files) block execution.
+  Warning rules (no verify, no root-cause) allow with notice.
+- `extensions/gsd/wave-executor.rkt`: Wave lifecycle tracking with error
+  recovery (DD-5). Failed waves don't block subsequent waves.
+- 21 new tests
+
+**Wave 3 — Prompts + Bash Detection + Write Guard Hardening** (PR #2061)
+- `extensions/gsd/prompts.rkt`: 5 prompt templates (exploring, executing,
+  wave-failure, verifying, status)
+- `extensions/gsd/bash-detect.rkt`: File-read bypass detection for sed,
+  cat, head, tail, awk, python open (DD-2)
+- Write guard hardened with path normalization (DD-6)
+- 37 new tests
+
+**Wave 4 — Migration + Backward Compatibility** (PR #2062)
+- `extensions/gsd-planning-state.rkt` rewritten as thin shim over new modules
+- Legacy API preserved: gsd-mode maps idle↔#f, exploring↔planning
+- Multi-step transitions for legacy direct planning→executing paths
+- `interfaces/sdk.rkt`: gsd-status recognizes 'idle as inactive
+- 11 integration tests, all 207 legacy tests pass unchanged
+
+
 ## v0.20.3 — 2026-04-26
 
 ### GSD Planning Architecture Remediation (6 waves)

--- a/docs/gsd-architecture.md
+++ b/docs/gsd-architecture.md
@@ -1,0 +1,115 @@
+# GSD Architecture
+
+Internal architecture documentation for the GSD (Get Shit Done) extension rewrite.
+
+## Module Structure
+
+```
+extensions/gsd/
+├── state-machine.rkt     # Central state machine with explicit transitions
+├── plan-types.rkt        # gsd-plan, gsd-wave, gsd-task structs + parsing
+├── plan-validator.rkt    # Mechanical validation before /go
+├── wave-executor.rkt     # Wave lifecycle tracking + error recovery
+├── core.rkt              # Command dispatch, tool guard, write guard
+├── context-bundle.rkt    # Role-specific context assembly
+├── steering.rkt          # Mode-aware stall detection
+├── prompts.rkt           # Prompt templates for all GSD phases
+└── bash-detect.rkt       # Bash file-reading bypass detection
+
+extensions/
+├── gsd-planning.rkt          # Legacy extension (unchanged API)
+└── gsd-planning-state.rkt    # Thin shim → delegates to gsd/ modules
+```
+
+## State Machine
+
+**Module:** `extensions/gsd/state-machine.rkt`
+
+Single global state machine with semaphore-protected transitions.
+
+```
+States: idle, exploring, plan-written, executing, verifying
+
+Transitions:
+  idle        → exploring
+  exploring   → plan-written
+  exploring   → idle
+  plan-written → executing
+  plan-written → exploring
+  executing   → verifying
+  executing   → exploring
+  verifying   → idle
+  verifying   → executing
+```
+
+All transitions are validated. Invalid transitions return `(err-result reason from to)`.
+
+### API
+
+- `(gsm-current)` — Current state symbol
+- `(gsm-transition! target)` — Attempt transition, returns ok-result or err-result
+- `(gsm-reset!)` — Reset to idle
+- `(gsm-valid-next-states)` — List of valid target states from current
+- `(gsm-tool-allowed? tool-name)` — Check tool against per-state blocklist
+- `(gsm-snapshot)` — Immutable hash of current state + transition history
+
+## Plan Types
+
+**Module:** `extensions/gsd/plan-types.rkt`
+
+| Struct | Fields |
+|--------|--------|
+| `gsd-plan` | waves, raw-markdown, metadata, validation-errors |
+| `gsd-wave` | index, title, status, root-cause, files, dependencies, verify, notes |
+| `gsd-task` | description, file, action-type |
+| `validation-result` | valid?, errors, warnings |
+
+Parsing: `parse-waves-from-markdown` extracts waves from PLAN.md headers.
+
+## Plan Validator
+
+**Module:** `extensions/gsd/plan-validator.rkt`
+
+Strict validation that blocks `/go`:
+
+- **Error rules:** no waves, missing wave title, no file references
+- **Warning rules:** no verify command, no root-cause documentation
+- `valid-plan->go?` — Quick check: valid? and no errors
+
+## Wave Executor
+
+**Module:** `extensions/gsd/wave-executor.rkt`
+
+Mutable executor wrapping a `gsd-plan`:
+
+```
+wave-status states: pending → in-progress → completed | failed | skipped
+```
+
+Key design decision (DD-5): **Failed waves don't block subsequent waves.** The executor tracks each wave independently and provides `next-pending-wave` to find the next executable wave.
+
+## Write Guard
+
+**Module:** `extensions/gsd/core.rkt`
+
+During `executing` mode, the write guard blocks modifications to `.planning/PLAN.md`. Uses path normalization to prevent `..` traversal attacks (DD-6).
+
+## Bash Detection
+
+**Module:** `extensions/gsd/bash-detect.rkt`
+
+Detects bash commands that read file contents (sed, cat, head, tail, awk, python open, etc.), bypassing the read tool's tracking. Safe commands (git, ls, find, raco, make) are excluded.
+
+## Migration Layer
+
+**Module:** `extensions/gsd-planning-state.rkt`
+
+Thin shim that preserves the old public API while delegating to the new modules:
+
+| Old API | New Module |
+|---------|------------|
+| `(gsd-mode)` → `#f / 'planning / 'plan-written / 'executing` | `(gsm-current)` → `'idle / 'exploring / 'plan-written / 'executing` |
+| `(set-gsd-mode! v)` | `(gsm-transition! target)` with multi-step for legacy paths |
+| `(reset-all-gsd-state!)` | `(gsm-reset!)` + clear legacy boxes |
+
+Budget, read-count, and wave-tracking functions remain in the shim for backward compatibility. These will be removed in a future version.

--- a/docs/gsd-guide.md
+++ b/docs/gsd-guide.md
@@ -1,0 +1,122 @@
+# GSD User Guide
+
+**Get Shit Done** — q's structured workflow for complex tasks.
+
+## Overview
+
+GSD is a plan-driven workflow that guides the agent through exploration, execution, and verification phases. It replaces ad-hoc prompting with a structured approach that:
+
+- Separates planning from execution
+- Validates plans before committing
+- Handles failures gracefully (skip + continue)
+- Provides observability at every step
+
+## Commands
+
+### `/plan [description]`
+
+Start the planning phase. The agent explores the codebase freely to understand the problem, then writes a structured plan to `.planning/PLAN.md`.
+
+```
+/plan Fix the login timeout bug in auth.rkt
+```
+
+During planning:
+- **No tool restrictions** — read, edit, bash are all available
+- **No time/call limits** — explore as deeply as needed
+- Write the plan when ready using `planning-write` for `PLAN`
+
+### `/go [wave number]`
+
+Begin executing the plan. The agent follows the plan's waves sequentially.
+
+```
+/go          # Start from first pending wave
+/go 2        # Start from wave 2
+```
+
+During execution:
+- **Write guard active** — cannot modify `.planning/PLAN.md` (use `/replan`)
+- **Tool guard active** — `planning-write` is blocked
+- Each wave is tracked: pending → in-progress → completed/failed/skipped
+
+### `/replan`
+
+Return to planning mode from `plan-written` or `executing` state. Use when the plan needs fundamental changes.
+
+```
+/replan
+```
+
+### `/skip <wave number>`
+
+Skip a failed or unwanted wave during execution. The agent continues to the next wave.
+
+```
+/skip 2
+```
+
+### `/reset`
+
+Reset GSD to idle state. Clears all mode, budget, and tracking state.
+
+```
+/reset
+```
+
+### `/gsd`
+
+Show current GSD status: mode, wave progress, and valid next commands.
+
+```
+/gsd
+```
+
+## Plan Format
+
+Plans are Markdown files in `.planning/PLAN.md`. Each wave has:
+
+```markdown
+## Wave 0: Fix the bug
+
+**Root cause:** The timeout handler uses milliseconds instead of seconds.
+
+**Files:** `auth.rkt`, `auth-test.rkt`
+**Verify:** `raco test tests/test-auth.rkt`
+```
+
+### Validation Rules
+
+Before `/go` is allowed, the plan is validated:
+
+| Rule | Level | Description |
+|------|-------|-------------|
+| Has waves | **Error** | Plan must contain at least one wave |
+| Wave has title | **Error** | Each wave needs a descriptive title |
+| Wave has files | **Error** | Each wave must list file references |
+| Wave has verify | Warning | Each wave should have a verify command |
+| Wave has root-cause | Warning | Each wave should document the root cause |
+
+## State Machine
+
+```
+idle → exploring → plan-written → executing → verifying → idle
+         ↑              ↑             ↑
+         └──────────────┴─────────────┘  (/replan)
+```
+
+| State | Write Guard | Tool Guard |
+|-------|-------------|------------|
+| idle | None | None |
+| exploring | None | None |
+| plan-written | Blocks edit/write/bash | None |
+| executing | Blocks planning-write | Blocks planning-write |
+| verifying | Blocks edit/write/bash | Blocks edit/write/bash + planning-write |
+
+## Tips
+
+1. **Write detailed plans** — the more context in each wave, the better the execution
+2. **Include verify commands** — automated verification catches regressions
+3. **Keep waves small** — 1-3 files per wave is ideal
+4. **Skip, don't retry** — if a wave fails, skip it and fix in a later wave
+5. **Use /gsd frequently** — check progress and valid next states

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -7,4 +7,4 @@
 
 (provide q-version)
 
-(define q-version "0.20.4")
+(define q-version "0.21.0")


### PR DESCRIPTION
Addresses #2057.

docs(gsd): add user guide + architecture docs, bump to v0.21.0 (Wave 5, #2057)

Wave 5 of v0.21.0 GSD Extension Rewrite — Documentation + Version Bump.

New documentation:
- docs/gsd-guide.md: User-facing guide covering all GSD commands
  (/plan, /go, /replan, /skip, /reset, /gsd), plan format, validation
  rules, state machine diagram, and usage tips.
- docs/gsd-architecture.md: Internal architecture documentation with
  module structure, state machine transitions, plan types, wave executor,
  write guard, bash detection, and migration layer details.

Updated:
- util/version.rkt: Bumped from 0.20.4 to 0.21.0
- CHANGELOG.md: Added v0.21.0 entry with all 5 waves documented

Closes #2057