### PR TITLE
feat(gsd): add wave document I/O module with PLAN.md index management (#2064)

W0 of v0.21.1: New wave-docs.rkt module providing:
- Per-wave document files in .planning/waves/W{N}-{slug}.md
- PLAN.md index parsing with status markers ([Inbox]/[DONE]/[DEFERRED]/[FAILED])
- Dual-write status transitions (wave doc + PLAN.md index)
- Wave queries: next-inbox-wave, plan-overall-status
- Slug generation from wave titles
- 35 comprehensive tests covering all functions

### DIFF
--- a/extensions/gsd/wave-docs.rkt
+++ b/extensions/gsd/wave-docs.rkt
@@ -1,0 +1,267 @@
+#lang racket/base
+
+;; extensions/gsd/wave-docs.rkt — Wave document I/O and PLAN.md index management
+;;
+;; v0.21.1 W0: Per-wave document files in .planning/waves/.
+;; PLAN.md index with status markers ([Inbox], [DONE], [DEFERRED], [FAILED]).
+;; Dual-write: wave doc + PLAN.md index on status transitions.
+
+(require racket/format
+         racket/string
+         racket/file
+         racket/path
+         racket/port)
+
+(provide wave-doc-path
+         write-wave-doc!
+         read-wave-doc
+         slugify
+         parse-plan-index
+         update-wave-in-index!
+         next-inbox-wave
+         mark-wave-status!
+         plan-overall-status
+         wave-exists?
+         wave-status-markers
+         wave-index-entry
+         wave-index-entry?
+         wave-index-entry-idx
+         wave-index-entry-title
+         wave-index-entry-slug
+         wave-index-entry-status)
+
+;; ============================================================
+;; Constants
+;; ============================================================
+
+(define WAVE-STATUS-MARKERS
+  '(("Inbox" . "[Inbox]") ("In-Progress" . "[In-Progress]")
+                          ("DONE" . "[DONE]")
+                          ("DEFERRED" . "[DEFERRED]")
+                          ("FAILED" . "[FAILED]")))
+
+(define (wave-status-markers)
+  WAVE-STATUS-MARKERS)
+
+;; Pre-compiled regex patterns (using #rx for proper \n handling)
+(define wave-header-rx #rx"^# Wave [0-9]+\nStatus: ([^\n]+)\n")
+(define wave-header-full-rx #rx"^# Wave [0-9]+\nStatus: [^\n]+\n\n(.*)$")
+(define index-line-rx #rx"^[-*] +\\[([A-Za-z-]+)\\] +W([0-9]+): +(.+?)(?: +\u2192 +(.+))?$")
+(define slug-from-target-rx #rx"waves/W[0-9]+-(.+?)\\.md")
+
+;; ============================================================
+;; Slug generation
+;; ============================================================
+
+(define (slugify title)
+  (define s (string-trim title))
+  (define slug-chars
+    (for/list ([c (in-string s)])
+      (cond
+        [(char-alphabetic? c) (char-downcase c)]
+        [(char-numeric? c) c]
+        [(char=? c #\-) #\-]
+        [(char=? c #\space) #\-]
+        [else #f])))
+  (define cleaned (collapse-hyphens (filter values slug-chars)))
+  (define result (list->string cleaned))
+  (define truncated
+    (if (> (string-length result) 40)
+        (let ([s40 (substring result 0 40)]) (string-trim s40 "-" #:right? #t))
+        result))
+  (if (string=? truncated "") "wave" truncated))
+
+(define (collapse-hyphens chars)
+  (let loop ([cs chars]
+             [prev-hyphen? #f]
+             [acc '()])
+    (cond
+      [(null? cs) (reverse acc)]
+      [(and prev-hyphen? (char=? (car cs) #\-)) (loop (cdr cs) #t acc)]
+      [(char=? (car cs) #\-) (loop (cdr cs) #t (cons #\- acc))]
+      [else (loop (cdr cs) #f (cons (car cs) acc))])))
+
+;; ============================================================
+;; Wave document path
+;; ============================================================
+
+(define (wave-doc-path base-dir idx slug)
+  (build-path base-dir ".planning" "waves" (format "W~a-~a.md" idx slug)))
+
+;; ============================================================
+;; Wave document I/O
+;; ============================================================
+
+(define (wave-exists? base-dir idx slug)
+  (file-exists? (wave-doc-path base-dir idx slug)))
+
+(define (write-wave-doc! base-dir idx slug content status)
+  (define path (wave-doc-path base-dir idx slug))
+  (define dir (path-only path))
+  (unless (directory-exists? dir)
+    (make-directory* dir))
+  (define header (format "# Wave ~a\nStatus: ~a\n\n" idx status))
+  (call-with-output-file path
+                         (lambda (out)
+                           (display header out)
+                           (display content out))
+                         #:exists 'truncate)
+  path)
+
+(define (read-wave-doc base-dir idx slug)
+  (define path (wave-doc-path base-dir idx slug))
+  (cond
+    [(not (file-exists? path)) #f]
+    [else
+     (define text (call-with-input-file path port->string))
+     (define status (extract-status text))
+     (define content (strip-status-header text))
+     (hasheq 'index idx 'slug slug 'status status 'content content 'path (path->string path))]))
+
+(define (extract-status text)
+  (define m (regexp-match wave-header-rx text))
+  (if m
+      (string-trim (cadr m))
+      "Inbox"))
+
+(define (strip-status-header text)
+  (define m (regexp-match wave-header-full-rx text))
+  (if m
+      (cadr m)
+      text))
+
+;; ============================================================
+;; PLAN.md index parsing
+;; ============================================================
+
+(struct wave-index-entry (idx title slug status) #:transparent)
+
+(define (parse-plan-index md-text)
+  (define lines (string-split md-text "\n"))
+  (for/fold ([entries '()]) ([line lines])
+    (define m (regexp-match index-line-rx line))
+    (if m
+        (let* ([status (cadr m)]
+               [idx (string->number (caddr m))]
+               [title (string-trim (cadddr m))]
+               [target (and (list? m) (> (length m) 4) (list-ref m 4))]
+               [slug (if target
+                         (extract-slug-from-target target)
+                         (slugify title))])
+          (append entries (list (wave-index-entry idx title slug status))))
+        entries)))
+
+(define (extract-slug-from-target target)
+  (define m (regexp-match slug-from-target-rx target))
+  (if m
+      (cadr m)
+      (slugify target)))
+
+;; ============================================================
+;; PLAN.md index status update
+;; ============================================================
+
+(define (update-wave-in-index! base-dir wave-idx new-status)
+  (define plan-path (build-path base-dir ".planning" "PLAN.md"))
+  (cond
+    [(not (file-exists? plan-path)) #f]
+    [else
+     (define text (call-with-input-file plan-path port->string))
+     (define marker (status->marker new-status))
+     (define new-text (update-index-line text wave-idx marker))
+     (call-with-output-file plan-path (lambda (out) (display new-text out)) #:exists 'truncate)
+     #t]))
+
+(define (status->marker status)
+  (cond
+    [(string? status)
+     (define entry (assoc status WAVE-STATUS-MARKERS))
+     (if entry
+         (cdr entry)
+         (format "[~a]" status))]
+    [(symbol? status) (status->marker (symbol->string status))]
+    [else "[Inbox]"]))
+
+(define (update-index-line text wave-idx new-marker)
+  (define lines (string-split text "\n"))
+  (define update-rx
+    (regexp (string-append "^([-*] +)\\[([A-Za-z-]+)\\]( +W" (number->string wave-idx) ":.*)$")))
+  (define new-lines
+    (for/list ([line lines])
+      (define m (regexp-match update-rx line))
+      (if m
+          (string-append (cadr m) new-marker (list-ref m 3))
+          line)))
+  (string-join new-lines "\n"))
+
+;; ============================================================
+;; Wave queries
+;; ============================================================
+
+(define (next-inbox-wave base-dir)
+  (define plan-path (build-path base-dir ".planning" "PLAN.md"))
+  (cond
+    [(not (file-exists? plan-path)) #f]
+    [else
+     (define text (call-with-input-file plan-path port->string))
+     (define entries (parse-plan-index text))
+     (for/first ([e entries]
+                 #:when (or (string=? (wave-index-entry-status e) "Inbox")
+                            (string=? (wave-index-entry-status e) "FAILED")))
+       e)]))
+
+;; ============================================================
+;; Dual-write status transition
+;; ============================================================
+
+(define (mark-wave-status! base-dir wave-idx new-status)
+  (define plan-path (build-path base-dir ".planning" "PLAN.md"))
+  (cond
+    [(not (file-exists? plan-path)) #f]
+    [else
+     (define text (call-with-input-file plan-path port->string))
+     (define entries (parse-plan-index text))
+     (define entry
+       (for/first ([e entries]
+                   #:when (= (wave-index-entry-idx e) wave-idx))
+         e))
+     (cond
+       [(not entry) #f]
+       [else
+        (define slug (wave-index-entry-slug entry))
+        (define wave-path (wave-doc-path base-dir wave-idx slug))
+        (when (file-exists? wave-path)
+          (define wave-text (call-with-input-file wave-path port->string))
+          (define content (strip-status-header wave-text))
+          (write-wave-doc! base-dir wave-idx slug content new-status))
+        (update-wave-in-index! base-dir wave-idx new-status)
+        #t])]))
+
+;; ============================================================
+;; Plan overall status
+;; ============================================================
+
+(define (plan-overall-status base-dir)
+  (define plan-path (build-path base-dir ".planning" "PLAN.md"))
+  (cond
+    [(not (file-exists? plan-path)) 'not-started]
+    [else
+     (define text (call-with-input-file plan-path port->string))
+     (define entries (parse-plan-index text))
+     (cond
+       [(null? entries) 'not-started]
+       [else
+        (define statuses (map wave-index-entry-status entries))
+        (define all-done?
+          (for/and ([s statuses])
+            (or (string=? s "DONE") (string=? s "DEFERRED"))))
+        (define any-done?
+          (for/or ([s statuses])
+            (or (string=? s "DONE")
+                (string=? s "DEFERRED")
+                (string=? s "FAILED")
+                (string=? s "In-Progress"))))
+        (cond
+          [all-done? 'all-done]
+          [any-done? 'partly-done]
+          [else 'in-progress])])]))

--- a/tests/test-gsd-wave-docs.rkt
+++ b/tests/test-gsd-wave-docs.rkt
@@ -1,0 +1,334 @@
+#lang racket/base
+
+;; tests/test-gsd-wave-docs.rkt — Tests for wave document I/O and PLAN.md index
+;;
+;; v0.21.1 W0: Tests for the wave-docs module covering:
+;; - Slug generation
+;; - Wave document write/read roundtrip
+;; - PLAN.md index parsing and updating
+;; - Status transitions with dual-write
+;; - Wave queries (next-inbox, overall status)
+
+(require rackunit
+         racket/file
+         racket/string
+         racket/path
+         racket/port
+         "../extensions/gsd/wave-docs.rkt")
+
+;; ============================================================
+;; Test helpers
+;; ============================================================
+
+(define (make-temp-planning-dir)
+  (define dir (make-temporary-file "wave-docs-test-~a" 'directory))
+  (make-directory* (build-path dir ".planning"))
+  dir)
+
+(define (cleanup-dir dir)
+  (delete-directory/files dir #:must-exist? #f))
+
+(define test-dir #f)
+
+(define (setup)
+  (set! test-dir (make-temp-planning-dir)))
+
+(define (teardown)
+  (when test-dir
+    (cleanup-dir test-dir)
+    (set! test-dir #f)))
+
+;; ============================================================
+;; Slug generation
+;; ============================================================
+
+(test-case "slugify: basic title"
+  (setup)
+  (check-equal? (slugify "Fix the bug") "fix-the-bug")
+  (teardown))
+
+(test-case "slugify: special characters"
+  (check-equal? (slugify "Read/write (v2) & more!") "readwrite-v2-more")
+  (teardown))
+
+(test-case "slugify: truncation to 40 chars"
+  (define long-title (make-string 100 #\a))
+  (check-true (<= (string-length (slugify long-title)) 40)))
+
+(test-case "slugify: empty string"
+  (check-equal? (slugify "") "wave"))
+
+(test-case "slugify: consecutive hyphens collapsed"
+  (check-equal? (slugify "a---b---c") "a-b-c"))
+
+(test-case "slugify: leading/trailing hyphens trimmed"
+  (check-equal? (slugify " hello world ") "hello-world"))
+
+(test-case "slugify: numeric preserved"
+  (check-equal? (slugify "Fix bug #123") "fix-bug-123"))
+
+;; ============================================================
+;; Wave document path
+;; ============================================================
+
+(test-case "wave-doc-path: correct structure"
+  (setup)
+  (define p (wave-doc-path test-dir 0 "fix-bug"))
+  (check-true (string? (path->string p)))
+  (check-true (string-contains? (path->string p) ".planning/waves/W0-fix-bug.md"))
+  (teardown))
+
+(test-case "wave-doc-path: different indices"
+  (setup)
+  (define p0 (wave-doc-path test-dir 0 "a"))
+  (define p3 (wave-doc-path test-dir 3 "b"))
+  (check-true (string-contains? (path->string p0) "W0-a.md"))
+  (check-true (string-contains? (path->string p3) "W3-b.md"))
+  (teardown))
+
+;; ============================================================
+;; Wave document write + read roundtrip
+;; ============================================================
+
+(test-case "write-wave-doc!: creates file"
+  (setup)
+  (define path (write-wave-doc! test-dir 0 "fix-bug" "## Tasks\nDo stuff" "Inbox"))
+  (check-true (file-exists? path))
+  (teardown))
+
+(test-case "write-wave-doc!: creates waves directory"
+  (setup)
+  (write-wave-doc! test-dir 0 "fix-bug" "content" "Inbox")
+  (check-true (directory-exists? (build-path test-dir ".planning" "waves")))
+  (teardown))
+
+(test-case "read-wave-doc: roundtrip"
+  (setup)
+  (write-wave-doc! test-dir 0 "fix-bug" "## Tasks\nDo stuff" "Inbox")
+  (define doc (read-wave-doc test-dir 0 "fix-bug"))
+  (check-not-false doc)
+  (check-equal? (hash-ref doc 'status) "Inbox")
+  (check-equal? (hash-ref doc 'index) 0)
+  (check-equal? (hash-ref doc 'slug) "fix-bug")
+  (check-true (string-contains? (hash-ref doc 'content) "## Tasks"))
+  (teardown))
+
+(test-case "read-wave-doc: nonexistent returns #f"
+  (setup)
+  (check-false (read-wave-doc test-dir 99 "nope"))
+  (teardown))
+
+(test-case "wave-exists?: true after write"
+  (setup)
+  (write-wave-doc! test-dir 0 "fix-bug" "content" "Inbox")
+  (check-true (wave-exists? test-dir 0 "fix-bug"))
+  (check-false (wave-exists? test-dir 1 "nope"))
+  (teardown))
+
+(test-case "write-wave-doc!: overwrite updates content"
+  (setup)
+  (write-wave-doc! test-dir 0 "fix-bug" "v1" "Inbox")
+  (write-wave-doc! test-dir 0 "fix-bug" "v2" "DONE")
+  (define doc (read-wave-doc test-dir 0 "fix-bug"))
+  (check-equal? (hash-ref doc 'status) "DONE")
+  (check-true (string-contains? (hash-ref doc 'content) "v2"))
+  (check-false (string-contains? (hash-ref doc 'content) "v1"))
+  (teardown))
+
+;; ============================================================
+;; PLAN.md index parsing
+;; ============================================================
+
+(define sample-plan-index
+  "# Plan: Fix all the bugs\n\n## Waves\n\n- [Inbox] W0: Fix the bug → waves/W0-fix-the-bug.md\n- [Inbox] W1: Add tests → waves/W1-add-tests.md\n- [Inbox] W2: Update docs → waves/W2-update-docs.md\n")
+
+(test-case "parse-plan-index: extracts all waves"
+  (define entries (parse-plan-index sample-plan-index))
+  (check-equal? (length entries) 3)
+  (check-equal? (wave-index-entry-idx (car entries)) 0)
+  (check-equal? (wave-index-entry-status (car entries)) "Inbox")
+  (check-equal? (wave-index-entry-title (car entries)) "Fix the bug"))
+
+(test-case "parse-plan-index: mixed statuses"
+  (define mixed-plan
+    (string-append "- [DONE] W0: Fix the bug → waves/W0-fix-the-bug.md\n"
+                   "- [In-Progress] W1: Add tests → waves/W1-add-tests.md\n"
+                   "- [FAILED] W2: Bad wave → waves/W2-bad-wave.md\n"
+                   "- [DEFERRED] W3: Later → waves/W3-later.md\n"))
+  (define entries (parse-plan-index mixed-plan))
+  (check-equal? (length entries) 4)
+  (check-equal? (wave-index-entry-status (list-ref entries 0)) "DONE")
+  (check-equal? (wave-index-entry-status (list-ref entries 1)) "In-Progress")
+  (check-equal? (wave-index-entry-status (list-ref entries 2)) "FAILED")
+  (check-equal? (wave-index-entry-status (list-ref entries 3)) "DEFERRED"))
+
+(test-case "parse-plan-index: no waves returns empty"
+  (define entries (parse-plan-index "# Just a doc\nNo waves here\n"))
+  (check-equal? entries '()))
+
+(test-case "parse-plan-index: slug from target path"
+  (define entries (parse-plan-index "- [Inbox] W0: Title → waves/W0-my-slug.md\n"))
+  (check-equal? (length entries) 1)
+  (check-equal? (wave-index-entry-slug (car entries)) "my-slug"))
+
+;; ============================================================
+;; PLAN.md index status update
+;; ============================================================
+
+(test-case "update-wave-in-index!: changes status marker"
+  (setup)
+  (define plan-path (build-path test-dir ".planning" "PLAN.md"))
+  (call-with-output-file plan-path (lambda (out) (display sample-plan-index out)) #:exists 'truncate)
+  (update-wave-in-index! test-dir 0 "DONE")
+  (define new-text (call-with-input-file plan-path port->string))
+  (check-true (string-contains? new-text "[DONE] W0:"))
+  (check-true (string-contains? new-text "[Inbox] W1:"))
+  (teardown))
+
+(test-case "update-wave-in-index!: nonexistent plan returns #f"
+  (setup)
+  (check-false (update-wave-in-index! test-dir 0 "DONE"))
+  (teardown))
+
+(test-case "update-wave-in-index!: nonexistent wave returns #t"
+  ;; Should still succeed — just no line matches
+  (setup)
+  (define plan-path (build-path test-dir ".planning" "PLAN.md"))
+  (call-with-output-file plan-path (lambda (out) (display sample-plan-index out)) #:exists 'truncate)
+  (check-true (update-wave-in-index! test-dir 99 "DONE"))
+  (teardown))
+
+;; ============================================================
+;; Wave queries
+;; ============================================================
+
+(test-case "next-inbox-wave: returns first Inbox wave"
+  (setup)
+  (define plan-path (build-path test-dir ".planning" "PLAN.md"))
+  (call-with-output-file plan-path (lambda (out) (display sample-plan-index out)) #:exists 'truncate)
+  (define next (next-inbox-wave test-dir))
+  (check-not-false next)
+  (check-equal? (wave-index-entry-idx next) 0)
+  (teardown))
+
+(test-case "next-inbox-wave: skips DONE waves"
+  (setup)
+  (define plan-path (build-path test-dir ".planning" "PLAN.md"))
+  (call-with-output-file plan-path (lambda (out) (display sample-plan-index out)) #:exists 'truncate)
+  (update-wave-in-index! test-dir 0 "DONE")
+  (define next (next-inbox-wave test-dir))
+  (check-not-false next)
+  (check-equal? (wave-index-entry-idx next) 1)
+  (teardown))
+
+(test-case "next-inbox-wave: returns FAILED waves for retry"
+  (setup)
+  (define plan-path (build-path test-dir ".planning" "PLAN.md"))
+  (define plan-text
+    "- [DONE] W0: First → waves/W0-first.md\n- [FAILED] W1: Bad → waves/W1-bad.md\n- [Inbox] W2: Next → waves/W2-next.md\n")
+  (call-with-output-file plan-path (lambda (out) (display plan-text out)) #:exists 'truncate)
+  ;; FAILED wave (W1) comes before Inbox (W2)
+  (define next (next-inbox-wave test-dir))
+  (check-not-false next)
+  (check-equal? (wave-index-entry-idx next) 1)
+  (teardown))
+
+(test-case "next-inbox-wave: #f when all done"
+  (setup)
+  (define plan-path (build-path test-dir ".planning" "PLAN.md"))
+  (define plan-text
+    "- [DONE] W0: First → waves/W0-first.md\n- [DEFERRED] W1: Skip → waves/W1-skip.md\n")
+  (call-with-output-file plan-path (lambda (out) (display plan-text out)) #:exists 'truncate)
+  (check-false (next-inbox-wave test-dir))
+  (teardown))
+
+(test-case "next-inbox-wave: #f when no plan file"
+  (setup)
+  (check-false (next-inbox-wave test-dir))
+  (teardown))
+
+;; ============================================================
+;; Dual-write status transition
+;; ============================================================
+
+(test-case "mark-wave-status!: dual write updates both files"
+  (setup)
+  ;; Create wave docs
+  (write-wave-doc! test-dir 0 "fix-bug" "## Tasks\nFix it" "Inbox")
+  (write-wave-doc! test-dir 1 "add-tests" "## Tasks\nTest it" "Inbox")
+  ;; Create PLAN.md index
+  (define plan-path (build-path test-dir ".planning" "PLAN.md"))
+  (call-with-output-file plan-path
+                         (lambda (out)
+                           (display "- [Inbox] W0: Fix the bug → waves/W0-fix-bug.md\n" out)
+                           (display "- [Inbox] W1: Add tests → waves/W1-add-tests.md\n" out))
+                         #:exists 'truncate)
+  ;; Mark W0 as DONE
+  (mark-wave-status! test-dir 0 "DONE")
+  ;; Check wave doc updated
+  (define doc (read-wave-doc test-dir 0 "fix-bug"))
+  (check-equal? (hash-ref doc 'status) "DONE")
+  ;; Check PLAN.md index updated
+  (define new-plan (call-with-input-file plan-path port->string))
+  (check-true (string-contains? new-plan "[DONE] W0:"))
+  (check-true (string-contains? new-plan "[Inbox] W1:"))
+  (teardown))
+
+(test-case "mark-wave-status!: #f for nonexistent wave"
+  (setup)
+  (define plan-path (build-path test-dir ".planning" "PLAN.md"))
+  (call-with-output-file plan-path
+                         (lambda (out) (display "- [Inbox] W0: Fix → waves/W0-fix.md\n" out))
+                         #:exists 'truncate)
+  (check-false (mark-wave-status! test-dir 99 "DONE"))
+  (teardown))
+
+;; ============================================================
+;; Plan overall status
+;; ============================================================
+
+(test-case "plan-overall-status: not-started when no plan"
+  (setup)
+  (check-equal? (plan-overall-status test-dir) 'not-started)
+  (teardown))
+
+(test-case "plan-overall-status: not-started when empty plan"
+  (setup)
+  (define plan-path (build-path test-dir ".planning" "PLAN.md"))
+  (call-with-output-file plan-path (lambda (out) (display "# No waves yet\n" out)) #:exists 'truncate)
+  (check-equal? (plan-overall-status test-dir) 'not-started)
+  (teardown))
+
+(test-case "plan-overall-status: in-progress when all Inbox"
+  (setup)
+  (define plan-path (build-path test-dir ".planning" "PLAN.md"))
+  (call-with-output-file plan-path (lambda (out) (display sample-plan-index out)) #:exists 'truncate)
+  (check-equal? (plan-overall-status test-dir) 'in-progress)
+  (teardown))
+
+(test-case "plan-overall-status: partly-done when some done"
+  (setup)
+  (define plan-path (build-path test-dir ".planning" "PLAN.md"))
+  (call-with-output-file plan-path (lambda (out) (display sample-plan-index out)) #:exists 'truncate)
+  (update-wave-in-index! test-dir 0 "DONE")
+  (check-equal? (plan-overall-status test-dir) 'partly-done)
+  (teardown))
+
+(test-case "plan-overall-status: all-done when all DONE or DEFERRED"
+  (setup)
+  (define plan-path (build-path test-dir ".planning" "PLAN.md"))
+  (call-with-output-file plan-path (lambda (out) (display sample-plan-index out)) #:exists 'truncate)
+  (update-wave-in-index! test-dir 0 "DONE")
+  (update-wave-in-index! test-dir 1 "DONE")
+  (update-wave-in-index! test-dir 2 "DEFERRED")
+  (check-equal? (plan-overall-status test-dir) 'all-done)
+  (teardown))
+
+(test-case "plan-overall-status: partly-done with FAILED"
+  (setup)
+  (define plan-path (build-path test-dir ".planning" "PLAN.md"))
+  (call-with-output-file plan-path (lambda (out) (display sample-plan-index out)) #:exists 'truncate)
+  (update-wave-in-index! test-dir 0 "DONE")
+  (update-wave-in-index! test-dir 1 "FAILED")
+  (check-equal? (plan-overall-status test-dir) 'partly-done)
+  (teardown))


### PR DESCRIPTION
Addresses #2064.

feat(gsd): add wave document I/O module with PLAN.md index management (#2064)

W0 of v0.21.1: New wave-docs.rkt module providing:
- Per-wave document files in .planning/waves/W{N}-{slug}.md
- PLAN.md index parsing with status markers ([Inbox]/[DONE]/[DEFERRED]/[FAILED])
- Dual-write status transitions (wave doc + PLAN.md index)
- Wave queries: next-inbox-wave, plan-overall-status
- Slug generation from wave titles
- 35 comprehensive tests covering all functions