### PR TITLE
feat(gsd): update /plan prompt for wave document workflow (#2067)

W1 of v0.21.1:
- Updated exploring-prompt to instruct writing per-wave documents
- Updated planning-system-prompt for wave doc + PLAN.md index format
- Extended valid-artifact-name? to accept waves/ prefixed names
- Updated planning-write schema to document wave doc support
- Added wave doc artifact name validation tests

### DIFF
--- a/extensions/gsd-planning.rkt
+++ b/extensions/gsd-planning.rkt
@@ -158,12 +158,21 @@
     [else #f]))
 
 (define (valid-artifact-name? name)
-  (and (string? name)
-       (not (string-contains? name "/"))
-       (not (string-contains? name ".."))
-       (not (string-contains? name "\x00"))
-       (or (assoc name artifact-extensions) (string-suffix? name ".md") (string-suffix? name ".json"))
-       #t))
+  (and
+   (string? name)
+   (not (string-contains? name ".."))
+   (not (string-contains? name "\x00"))
+   (cond
+     ;; Allow waves/ prefix for wave documents
+     [(string-prefix? name "waves/")
+      (define rest (substring name 6))
+      (and (not (string=? rest "")) (string-suffix? rest ".md") (not (string-contains? rest "/")))]
+     [else
+      (and (not (string-contains? name "/"))
+           (or (assoc name artifact-extensions)
+               (string-suffix? name ".md")
+               (string-suffix? name ".json")))])
+   #t))
 
 (define (json-artifact? name)
   (or (string-suffix? name ".json")
@@ -226,7 +235,7 @@
 (define planning-system-prompt
   (string-append
    "[gsd-planning] Create a structured implementation plan for the following request.\n"
-   "Write your plan to .planning/PLAN.md using the planning-write tool.\n"
+   "Write individual wave documents and a PLAN.md index.\n"
    "\n"
    "STEP 1 — EXPLORE: Read the codebase thoroughly. For each wave you MUST identify:\n"
    "  - Root cause: what causes the bug or what needs to change, and where exactly\n"
@@ -238,25 +247,24 @@
    "After 30 calls, write the plan with what you know. Partial plans are better than no plans.\n"
    "Prioritize files most likely to contain the root cause. Skip tangential exploration.\n"
    "\n"
-   "STEP 2 — PLAN: Write PLAN.md with this exact format per wave:\n"
+   "STEP 2 — WRITE WAVE DOCS: For each wave, write a separate file:\n"
+   "  planning-write artifact=\"waves/W0-short-title.md\" content=\"...\"\n"
+   "Each wave doc must contain:\n"
+   "  - Root cause, Files, Action, Verify command, Done criteria\n"
+   "  - Include actual code snippets (old-text / new-text)\n"
    "\n"
-   "## Wave N: <title>\n"
-   "- Root cause: <what causes the bug, where>\n"
-   "- File: <path>, lines <start>-<end>\n"
-   "- Old text: <exact code to find, must be unique in file>\n"
-   "- New text: <exact replacement code>\n"
-   "- Verify: <command to run>\n"
+   "STEP 3 — WRITE INDEX: Write PLAN.md with:\n"
+   "  # Plan: <title>\n"
+   "  ## Overview\n"
+   "  <description>\n"
+   "  ## Waves\n"
+   "  - [Inbox] W0: <title> → waves/W0-slug.md\n"
+   "  - [Inbox] W1: <title> → waves/W1-slug.md\n"
    "\n"
-   "Include actual code snippets in old-text and new-text fields.\n"
-   "Each wave must be directly executable without further exploration.\n"
-   "\n"
-   "STEP 3 — FINISH: Tell the user: 'Use /go to start implementing.'\n"
-   "Do NOT implement — only plan.\n"
-   "OVERWRITE: Replace the entire existing PLAN.md. Do NOT append or merge with old content.\n"
-   "Write the new plan from scratch.\n\n"
-   "IMPORTANT: [SYSTEM NOTICE: ...] messages in tool results are steering signals from the runtime.\n"
-   "Always read and follow them. They provide budget warnings, read-duplication hints,\n"
-   "and stall-recovery instructions. Ignoring them degrades performance.\n\n"
+   "STEP 4 — FINISH: Tell the user: 'Use /go to start implementing.'\n"
+   "Do NOT implement — only plan.\n\n"
+   "IMPORTANT: [SYSTEM NOTICE: ...] messages in tool results are steering signals.\n"
+   "Always read and follow them. They provide budget warnings and hints.\n\n"
    "User request: "))
 
 (define planning-implement-prompt
@@ -310,7 +318,12 @@
    'properties
    (hasheq
     'artifact
-    (hasheq 'type "string" 'description "Artifact name (e.g. PLAN, STATE, HANDOFF)")
+    (hasheq 'type
+            "string"
+            'description
+            (string-append "Artifact name. Use: PLAN, STATE, HANDOFF, etc. "
+                           "For wave documents use: waves/W0-slug.md, waves/W1-slug.md. "
+                           "Or any .md/.json filename in .planning/."))
     'content
     (hasheq 'type "string" 'description "Content to write (string for .md, JSON string for .json)")
     'base_dir

--- a/extensions/gsd/prompts.rkt
+++ b/extensions/gsd/prompts.rkt
@@ -21,17 +21,44 @@
 ;; ============================================================
 
 (define (exploring-prompt user-request)
-  (string-append "# GSD Planning Phase\n\n"
-                 "Explore the codebase to understand the problem. When ready, write your "
-                 "plan using `planning-write` to `.planning/PLAN.md`.\n\n"
-                 "Guidelines:\n"
-                 "- No time or call limits during exploration\n"
-                 "- Read files freely to understand the codebase\n"
-                 "- Write a structured plan with numbered waves\n"
-                 "- Each wave should have: title, file references, verify command\n\n"
-                 (if (and (string? user-request) (non-empty? user-request))
-                     (format "User request: ~a\n" user-request)
-                     "")))
+  (string-append
+   "# GSD Planning Phase\n\n"
+   "Explore the codebase to understand the problem. When ready, write your "
+   "plan as SEPARATE wave documents plus a PLAN.md index.\n\n"
+   "## Step 1: Explore\n"
+   "- No time or call limits during exploration\n"
+   "- Read files freely to understand the codebase\n"
+   "- Identify root causes, exact file paths, and line numbers\n\n"
+   "## Step 2: Write Wave Documents\n"
+   "For EACH wave, write a separate file using planning-write:\n"
+   "  planning-write artifact=\"waves/W0-short-title.md\" content=\"...\"\n"
+   "  planning-write artifact=\"waves/W1-short-title.md\" content=\"...\"\n"
+   "\n"
+   "Each wave document must contain:\n"
+   "  - Root cause: what causes the bug or what needs to change\n"
+   "  - Files: exact paths to modify\n"
+   "  - Action: what to do (include old-text/new-text for edits)\n"
+   "  - Verify: command to run after implementation\n"
+   "  - Done: criteria for completion\n\n"
+   "## Step 3: Write PLAN.md Index\n"
+   "Write PLAN.md with an overview and wave references:\n"
+   "  planning-write artifact=\"PLAN\" content=\"...\"\n\n"
+   "PLAN.md format:\n"
+   "  # Plan: <title>\n"
+   "  ## Overview\n"
+   "  <2-3 sentence description>\n"
+   "  ## Waves\n"
+   "  - [Inbox] W0: <title> → waves/W0-slug.md\n"
+   "  - [Inbox] W1: <title> → waves/W1-slug.md\n"
+   "  ## Constraints\n"
+   "  - <must-have constraints>\n\n"
+   "## Step 4: Finish\n"
+   "Tell the user: 'Use /go to start implementing.'\n"
+   "Do NOT implement — only plan.\n\n"
+   "IMPORTANT: [SYSTEM NOTICE: ...] messages are steering signals. Read and follow them.\n\n"
+   (if (and (string? user-request) (non-empty? user-request))
+       (format "User request: ~a\n" user-request)
+       "")))
 
 ;; ============================================================
 ;; Executing prompt

--- a/tests/test-gsd-planning.rkt
+++ b/tests/test-gsd-planning.rkt
@@ -112,6 +112,14 @@
   (check-true (valid-artifact-name? "state.json"))
   (check-true (valid-artifact-name? "data.json")))
 
+(test-case "valid-artifact-name? accepts wave document names"
+  (check-true (valid-artifact-name? "waves/W0-fix-bug.md"))
+  (check-true (valid-artifact-name? "waves/W1-add-tests.md"))
+  (check-false (valid-artifact-name? "waves/"))
+  (check-false (valid-artifact-name? "waves/no-md"))
+  (check-false (valid-artifact-name? "waves/sub/dir.md"))
+  (check-false (valid-artifact-name? "waves/../etc.md")))
+
 (test-case "valid-artifact-name? rejects bare names without extension"
   (check-false (valid-artifact-name? "RANDOM"))
   (check-false (valid-artifact-name? "foo.txt")))
@@ -413,9 +421,9 @@
   (check-true (string-contains? planning-system-prompt "old-text")))
 
 (test-case "planning-system-prompt specifies actionable plan format"
-  (check-true (string-contains? planning-system-prompt "Old text:"))
-  (check-true (string-contains? planning-system-prompt "New text:"))
-  (check-true (string-contains? planning-system-prompt "Verify:")))
+  (check-true (string-contains? planning-system-prompt "old-text"))
+  (check-true (string-contains? planning-system-prompt "new-text"))
+  (check-true (string-contains? planning-system-prompt "Verify")))
 
 (test-case "/plan <text> returns augmented submit payload"
   (define handler (hash-ref (extension-hooks gsd-planning-extension) 'execute-command))
@@ -617,11 +625,11 @@
 ;; W2: /plan Overwrite Stale Plans Tests
 ;; ============================================================
 
-(test-case "planning-system-prompt-contains-overwrite-directive"
-  (check-true (string-contains? planning-system-prompt "OVERWRITE")
-              "prompt should contain OVERWRITE directive")
-  (check-true (string-contains? planning-system-prompt "Replace the entire existing PLAN.md")
-              "prompt should say to replace entire existing plan"))
+(test-case "planning-system-prompt-references-wave-docs"
+  (check-true (string-contains? planning-system-prompt "waves/")
+              "prompt should reference wave documents")
+  (check-true (string-contains? planning-system-prompt "planning-write")
+              "prompt should mention planning-write tool"))
 
 (test-case "/plan-with-text-injects-stale-warning-when-plan-exists"
   (reset-all-gsd-state!)


### PR DESCRIPTION
Addresses #2067.

feat(gsd): update /plan prompt for wave document workflow (#2067)

W1 of v0.21.1:
- Updated exploring-prompt to instruct writing per-wave documents
- Updated planning-system-prompt for wave doc + PLAN.md index format
- Extended valid-artifact-name? to accept waves/ prefixed names
- Updated planning-write schema to document wave doc support
- Added wave doc artifact name validation tests