### PR TITLE
feat(gsd): add plan-types status helpers, validator wave doc warnings, executor disk loading (#2070)

W2 of v0.21.1:
- plan-types.rkt: add wave-status->string, string->wave-status, gsd-wave-slug
- plan-validator.rkt: warn on empty titles (can't derive wave doc slug)
- wave-executor.rkt: add load-plan-from-index (reads PLAN.md + wave docs from disk)
- New tests for load-plan-from-index with temp directories
- All 5994 tests pass

### DIFF
--- a/extensions/gsd/plan-types.rkt
+++ b/extensions/gsd/plan-types.rkt
@@ -153,6 +153,45 @@
     w))
 
 ;; ============================================================
+;; Status conversion helpers
+;; ============================================================
+
+(define (wave-status->string sym)
+  (cond
+    [(eq? sym 'pending) "Inbox"]
+    [(eq? sym 'in-progress) "In-Progress"]
+    [(eq? sym 'completed) "DONE"]
+    [(eq? sym 'failed) "FAILED"]
+    [(eq? sym 'skipped) "DEFERRED"]
+    [else (symbol->string sym)]))
+
+(define (string->wave-status str)
+  (cond
+    [(string=? str "Inbox") 'pending]
+    [(string=? str "In-Progress") 'in-progress]
+    [(string=? str "DONE") 'completed]
+    [(string=? str "FAILED") 'failed]
+    [(string=? str "DEFERRED") 'skipped]
+    [else 'pending]))
+
+(define (gsd-wave-slug w)
+  (define title (gsd-wave-title w))
+  (if (and (string? title) (> (string-length title) 0))
+      (let* ([s (string-trim title)]
+             [chars (for/list ([c (in-string s)])
+                      (cond
+                        [(char-alphabetic? c) (char-downcase c)]
+                        [(char-numeric? c) c]
+                        [(char=? c #\-) #\-]
+                        [(char=? c #\space) #\-]
+                        [else #f]))]
+             [result (list->string (filter values chars))])
+        (if (> (string-length result) 40)
+            (string-trim (substring result 0 40) "-" #:right? #t)
+            (if (string=? result "") "wave" result)))
+      "wave"))
+
+;; ============================================================
 ;; Provide (after all definitions)
 ;; ============================================================
 
@@ -204,4 +243,9 @@
          ;; Plan utilities
          plan-wave-ref
          plan-pending-waves
-         plan-next-pending-wave)
+         plan-next-pending-wave
+
+         ;; Status conversion helpers
+         wave-status->string
+         string->wave-status
+         gsd-wave-slug)

--- a/extensions/gsd/plan-validator.rkt
+++ b/extensions/gsd/plan-validator.rkt
@@ -50,7 +50,11 @@
       (set! warnings (cons (format "~a: no verify command" prefix) warnings)))
     ;; Warning: no root-cause/objective
     (when (string=? (gsd-wave-root-cause w) "")
-      (set! warnings (cons (format "~a: no root-cause/objective" prefix) warnings))))
+      (set! warnings (cons (format "~a: no root-cause/objective" prefix) warnings)))
+    ;; Warning: no slug for wave doc lookup
+    (when (string=? (gsd-wave-title w) "")
+      (set! warnings
+            (cons (format "~a: cannot derive wave doc slug (empty title)" prefix) warnings))))
   (validation-result (reverse errors) (reverse warnings)))
 
 ;; ============================================================

--- a/extensions/gsd/wave-executor.rkt
+++ b/extensions/gsd/wave-executor.rkt
@@ -10,7 +10,10 @@
 
 (require racket/format
          racket/string
-         "plan-types.rkt")
+         racket/file
+         racket/port
+         "plan-types.rkt"
+         "../gsd/wave-docs.rkt")
 
 (provide wave-status
          wave-status?
@@ -20,6 +23,7 @@
          wave-status-attempt-count
          wave-status-timestamp
          make-wave-executor
+         load-plan-from-index
          wave-start!
          wave-complete!
          wave-fail!
@@ -145,3 +149,66 @@
                       (format "🔄 In Progress: ~a" n-in-progress)
                       #f))))
   (string-join parts "\n"))
+
+;; ============================================================
+;; Load plan from disk (PLAN.md index + wave docs)
+
+;; ============================================================
+;; Load plan from disk (PLAN.md index + wave docs)
+;; ============================================================
+
+(define (load-plan-from-index base-dir)
+  (define plan-path (build-path base-dir ".planning" "PLAN.md"))
+  (if (not (file-exists? plan-path))
+      #f
+      (let* ([text (call-with-input-file plan-path port->string)]
+             [entries (parse-plan-index text)])
+        (if (null? entries)
+            #f
+            (let* ([title (extract-plan-title text)]
+                   [waves (for/list ([e entries])
+                            (define idx (wave-index-entry-idx e))
+                            (define slug (wave-index-entry-slug e))
+                            (define wave-data (read-wave-doc base-dir idx slug))
+                            (define wave-content
+                              (if wave-data
+                                  (hash-ref wave-data 'content)
+                                  ""))
+                            (gsd-wave idx
+                                      (wave-index-entry-title e)
+                                      (string->wave-status-from-entry e)
+                                      wave-content
+                                      (extract-files-from-content wave-content)
+                                      '()
+                                      (extract-verify-from-content wave-content)
+                                      ""))])
+              (gsd-plan waves '() '() '()))))))
+
+(define (extract-plan-title text)
+  (define lines (string-split text "\n"))
+  (for/first ([line lines]
+              #:when (string-prefix? line "# Plan:"))
+    (string-trim (substring line 7))))
+
+(define (string->wave-status-from-entry e)
+  (define s (wave-index-entry-status e))
+  (cond
+    [(string=? s "DONE") 'completed]
+    [(string=? s "FAILED") 'failed]
+    [(string=? s "DEFERRED") 'skipped]
+    [(string=? s "In-Progress") 'in-progress]
+    [else 'pending]))
+
+(define (extract-files-from-content content)
+  (define lines (string-split content "\n"))
+  (for/list ([line lines]
+             #:when (string-contains? (string-trim line) "- File:"))
+    (define m (regexp-match-positions #rx"- File:" line))
+    (string-trim (substring line (cdar m)))))
+
+(define (extract-verify-from-content content)
+  (define lines (string-split content "\n"))
+  (for/first ([line lines]
+              #:when (string-contains? (string-trim line) "- Verify:"))
+    (define m (regexp-match-positions #rx"- Verify:" line))
+    (string-trim (substring line (cdar m)))))

--- a/tests/test-gsd-wave-executor.rkt
+++ b/tests/test-gsd-wave-executor.rkt
@@ -6,17 +6,19 @@
 
 (require rackunit
          "../extensions/gsd/wave-executor.rkt"
-         "../extensions/gsd/plan-types.rkt")
+         "../extensions/gsd/plan-types.rkt"
+         "../extensions/gsd/wave-docs.rkt")
 
 ;; ============================================================
 ;; Helper
 ;; ============================================================
 
 (define (make-test-plan n)
-  (gsd-plan
-   (for/list ([i (in-range n)])
-     (gsd-wave i (format "Wave ~a" i) 'pending "" '("file.rkt") '() "test" '()))
-   "" '() '()))
+  (gsd-plan (for/list ([i (in-range n)])
+              (gsd-wave i (format "Wave ~a" i) 'pending "" '("file.rkt") '() "test" '()))
+            ""
+            '()
+            '()))
 
 ;; ============================================================
 ;; Lifecycle: pending → in-progress → completed
@@ -136,3 +138,57 @@
   (wave-start! exec 0) ;; restart
   (define s0 (car (wave-executor-statuses exec)))
   (check-equal? (wave-status-attempt-count s0) 2))
+
+;; ============================================================
+;; load-plan-from-index
+;; ============================================================
+
+(test-case "load-plan-from-index returns #f when no PLAN.md"
+  (check-false (load-plan-from-index "/tmp/nonexistent-dir-for-test")))
+
+(test-case "load-plan-from-index loads waves from disk"
+  (define dir (make-temporary-file "gsd-index-test-~a" 'directory))
+  (define planning-dir (build-path dir ".planning"))
+  (make-directory planning-dir)
+  (make-directory (build-path planning-dir "waves"))
+  ;; Write PLAN.md index
+  (define plan-md
+    (string-append "# Plan: Test Plan\n\n"
+                   "## Waves\n"
+                   "- [Inbox] W0: Fix bug → waves/W0-fix-bug.md\n"
+                   "- [Inbox] W1: Add tests → waves/W1-add-tests.md\n"))
+  (call-with-output-file (build-path planning-dir "PLAN.md")
+                         (lambda (out) (display plan-md out))
+                         #:exists 'truncate)
+  ;; Write wave docs
+  (write-wave-doc! dir 0 "fix-bug" "- File: foo.rkt\n- Verify: raco test\n" "Inbox")
+  (write-wave-doc! dir 1 "add-tests" "- File: test-foo.rkt\n- Verify: raco test\n" "Inbox")
+  ;; Load and verify
+  (define plan (load-plan-from-index dir))
+  (check-not-false plan)
+  (check-equal? (length (gsd-plan-waves plan)) 2)
+  (define w0 (list-ref (gsd-plan-waves plan) 0))
+  (check-equal? (gsd-wave-index w0) 0)
+  (check-true (string-contains? (gsd-wave-title w0) "Fix bug"))
+  ;; Cleanup
+  (delete-directory/files dir #:must-exist? #f))
+
+(test-case "load-plan-from-index preserves completed status"
+  (define dir (make-temporary-file "gsd-index-status-~a" 'directory))
+  (define planning-dir (build-path dir ".planning"))
+  (make-directory planning-dir)
+  (make-directory (build-path planning-dir "waves"))
+  (define plan-md
+    "# Plan: Status Test\n\n## Waves\n- [DONE] W0: Done wave → waves/W0-done-wave.md\n- [Inbox] W1: Todo wave → waves/W1-todo-wave.md\n")
+  (call-with-output-file (build-path planning-dir "PLAN.md")
+                         (lambda (out) (display plan-md out))
+                         #:exists 'truncate)
+  (write-wave-doc! dir 0 "done-wave" "Content" "DONE")
+  (write-wave-doc! dir 1 "todo-wave" "Content" "Inbox")
+  (define plan (load-plan-from-index dir))
+  (check-not-false plan)
+  (define w0 (list-ref (gsd-plan-waves plan) 0))
+  (check-eq? (gsd-wave-status w0) 'completed)
+  (define w1 (list-ref (gsd-plan-waves plan) 1))
+  (check-eq? (gsd-wave-status w1) 'pending)
+  (delete-directory/files dir #:must-exist? #f))


### PR DESCRIPTION
Addresses #2070.

feat(gsd): add plan-types status helpers, validator wave doc warnings, executor disk loading (#2070)

W2 of v0.21.1:
- plan-types.rkt: add wave-status->string, string->wave-status, gsd-wave-slug
- plan-validator.rkt: warn on empty titles (can't derive wave doc slug)
- wave-executor.rkt: add load-plan-from-index (reads PLAN.md + wave docs from disk)
- New tests for load-plan-from-index with temp directories
- All 5994 tests pass