### PR TITLE
fix(gsd): /go crash — validate-plan-strict + extract-verify fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,8 +272,8 @@ q/
 |--------|-------|
 | Test files | 432 |
 | Source modules | 288 |
-| Source lines | 57058 |
-| Test lines | 85592 |
+| Source lines | 57073 |
+| Test lines | 85596 |
 | Test assertions | 13130 |
 | `racket scripts/run-tests.rkt` results | 5835+ tests passing |
 

--- a/extensions/gsd/plan-validator.rkt
+++ b/extensions/gsd/plan-validator.rkt
@@ -46,7 +46,7 @@
     (when (null? (gsd-wave-files w))
       (set! warnings (cons (format "~a: no explicit file references" prefix) warnings)))
     ;; Warning: no verify command
-    (when (string=? (gsd-wave-verify w) "")
+    (when (or (not (gsd-wave-verify w)) (string=? (gsd-wave-verify w) ""))
       (set! warnings (cons (format "~a: no verify command" prefix) warnings)))
     ;; Warning: no root-cause/objective
     (when (string=? (gsd-wave-root-cause w) "")

--- a/extensions/gsd/wave-executor.rkt
+++ b/extensions/gsd/wave-executor.rkt
@@ -208,7 +208,22 @@
 
 (define (extract-verify-from-content content)
   (define lines (string-split content "\n"))
-  (for/first ([line lines]
-              #:when (string-contains? (string-trim line) "- Verify:"))
-    (define m (regexp-match-positions #rx"- Verify:" line))
-    (string-trim (substring line (cdar m)))))
+  (define n (length lines))
+  ;; Look for ## Verify heading and capture code block after it
+  (or (for/first ([i (in-range n)]
+                  #:when (string-contains? (string-trim (list-ref lines i)) "## Verify"))
+        ;; Collect non-empty, non-backtick lines after the heading
+        (define after
+          (for/list ([j (in-range (add1 i) (min n (+ i 5)))]
+                     #:when (and (> (string-length (string-trim (list-ref lines j))) 0)
+                                 (not (string-contains? (list-ref lines j) "```"))))
+            (string-trim (list-ref lines j))))
+        (if (null? after)
+            ""
+            (string-join after "; ")))
+      ;; Fallback: look for - Verify: inline
+      (for/first ([line lines]
+                  #:when (string-contains? (string-trim line) "- Verify:"))
+        (define m (regexp-match-positions #rx"- Verify:" line))
+        (string-trim (substring line (cdar m))))
+      ""))

--- a/tests/test-gsd-wave-docs.rkt
+++ b/tests/test-gsd-wave-docs.rkt
@@ -140,7 +140,11 @@
 ;; ============================================================
 
 (define sample-plan-index
-  "# Plan: Fix all the bugs\n\n## Waves\n\n- [Inbox] W0: Fix the bug → waves/W0-fix-the-bug.md\n- [Inbox] W1: Add tests → waves/W1-add-tests.md\n- [Inbox] W2: Update docs → waves/W2-update-docs.md\n")
+  (string-append
+   "# Plan: Fix all the bugs\n\n## Waves\n\n"
+   "- [Inbox] W0: Fix the bug → waves/W0-fix-the-bug.md\n"
+   "- [Inbox] W1: Add tests → waves/W1-add-tests.md\n"
+   "- [Inbox] W2: Update docs → waves/W2-update-docs.md\n"))
 
 (test-case "parse-plan-index: extracts all waves"
   (define entries (parse-plan-index sample-plan-index))


### PR DESCRIPTION
## Fix

Two bugs caused `/go` to crash silently (returning "Unknown command"):

1. **`validate-plan-strict`**: `gsd-wave-verify` could be `#f` (from `extract-verify-from-content` returning `#f`), but the validator called `(string=? field "")` which crashes on `#f`.

2. **`extract-verify-from-content`**: Only matched `- Verify:` inline format. Wave docs use `## Verify` heading with code block below — the extraction returned `#f` instead of parsing the heading + subsequent lines.

## Changes

- `plan-validator.rkt`: Guard `(string=? ... "")` with `(or (not field) ...)` 
- `wave-executor.rkt`: Rewrite `extract-verify-from-content` to parse `## Verify` heading and capture subsequent code block lines
- `test-gsd-wave-docs.rkt`: Fix line-too-long lint error
- `README.md`: Metrics sync