### PR TITLE
fix(gsd): write-planning-artifact auto-creates parent directories (#2081)

The write-planning-artifact! function now uses (path-only path) with
make-directory* instead of only ensuring the base .planning/ directory.
This fixes planning-write failures when writing wave docs to
.planning/waves/ which didn't exist yet.

Wave 0 of v0.21.2 milestone.

### DIFF
--- a/extensions/gsd-planning.rkt
+++ b/extensions/gsd-planning.rkt
@@ -205,9 +205,10 @@
   (define path (planning-artifact-path base-dir name))
   (if (not path)
       #f
-      (let ([dir (build-path base-dir planning-dir-name)])
-        (unless (directory-exists? dir)
-          (make-directory* dir))
+      (let ([parent (path-only path)])
+        (when parent
+          (unless (directory-exists? parent)
+            (make-directory* parent)))
         (if (json-artifact? name)
             (call-with-output-file path
                                    (lambda (out)

--- a/tests/test-gsd-planning.rkt
+++ b/tests/test-gsd-planning.rkt
@@ -180,6 +180,23 @@
 (test-case "write-planning-artifact! returns #f for invalid name"
   (with-temp-dir (lambda (dir) (check-false (write-planning-artifact! dir "BADNAME" "content")))))
 
+(test-case "write-planning-artifact! auto-creates waves/ subdirectory"
+  (with-temp-dir (lambda (dir)
+                   ;; The waves/ subdir doesn't exist yet — write-planning-artifact! must create it
+                   (define result
+                     (write-planning-artifact! dir "waves/W0-fix-bug.md" "# Wave 0\nFix the bug."))
+                   (check-not-false result)
+                   (check-true (file-exists? (build-path dir ".planning" "waves" "W0-fix-bug.md")))
+                   (define content (read-planning-artifact dir "waves/W0-fix-bug.md"))
+                   (check-true (string-contains? content "Fix the bug")))))
+
+(test-case "write-planning-artifact! writes multiple wave docs to new waves/ dir"
+  (with-temp-dir (lambda (dir)
+                   (write-planning-artifact! dir "waves/W0-first.md" "# W0")
+                   (write-planning-artifact! dir "waves/W1-second.md" "# W1")
+                   (check-true (file-exists? (build-path dir ".planning" "waves" "W0-first.md")))
+                   (check-true (file-exists? (build-path dir ".planning" "waves" "W1-second.md"))))))
+
 ;; ============================================================
 ;; planning-read tool handler tests
 ;; ============================================================


### PR DESCRIPTION
Addresses #2081.

fix(gsd): write-planning-artifact auto-creates parent directories (#2081)

The write-planning-artifact! function now uses (path-only path) with
make-directory* instead of only ensuring the base .planning/ directory.
This fixes planning-write failures when writing wave docs to
.planning/waves/ which didn't exist yet.

Wave 0 of v0.21.2 milestone.