### PR TITLE
fix(gsd): wave progress tracking advances per-wave not per-edit (#2082)

handle-wave-progress now detects wave index from file paths (e.g., 
W1-fix-bug.md → wave 1) and only marks the previous wave complete when
the assistant moves to a new wave. Multiple edits within the same wave
no longer incorrectly advance the wave counter.

Adds current-wave-index state tracking with snapshot/reset support.

Wave 1 of v0.21.2 milestone.

### DIFF
--- a/extensions/gsd-planning-state.rkt
+++ b/extensions/gsd-planning-state.rkt
@@ -45,6 +45,8 @@
          mark-wave-complete!
          wave-complete?
          next-pending-wave
+         current-wave-index
+         set-current-wave-index!
          ;; Plan tool budget
          plan-tool-budget
          decrement-plan-budget!
@@ -70,6 +72,7 @@
 (define read-counts-box (box (make-hash)))
 (define completed-waves-box (box (set)))
 (define total-waves-box (box 0))
+(define current-wave-box (box 0))
 (define EXPLORATION-BUDGET 30)
 (define plan-tool-budget-box (box #f))
 (define gsd-event-bus-box (box #f))
@@ -185,6 +188,12 @@
 (define (wave-complete? idx)
   (call-with-semaphore state-sem (lambda () (set-member? (unbox completed-waves-box) idx))))
 
+(define (current-wave-index)
+  (call-with-semaphore state-sem (lambda () (unbox current-wave-box))))
+
+(define (set-current-wave-index! n)
+  (call-with-semaphore state-sem (lambda () (set-box! current-wave-box n))))
+
 (define (next-pending-wave)
   (call-with-semaphore state-sem
                        (lambda ()
@@ -243,6 +252,8 @@
                                  (set-copy (unbox completed-waves-box))
                                  'total-waves
                                  (unbox total-waves-box)
+                                 'current-wave
+                                 (unbox current-wave-box)
                                  'plan-tool-budget
                                  (unbox plan-tool-budget-box)))))
 
@@ -257,5 +268,6 @@
                          (set-box! read-counts-box (make-hash))
                          (set-box! completed-waves-box (set))
                          (set-box! total-waves-box 0)
+                         (set-box! current-wave-box 0)
                          (set-box! plan-tool-budget-box #f)
                          (set-box! gsd-event-bus-box #f))))

--- a/extensions/gsd-planning.rkt
+++ b/extensions/gsd-planning.rkt
@@ -92,13 +92,18 @@
          mark-wave-complete!
          wave-complete?
          next-pending-wave
+         current-wave-index
+         set-current-wave-index!
          plan-tool-budget
          decrement-plan-budget!
          reset-plan-budget!
          gsd-session-cleanup
          gsd-event-bus
          set-gsd-event-bus!
-         emit-gsd-event!)
+         emit-gsd-event!
+         handle-wave-progress
+         current-wave-index
+         set-current-wave-index!)
 
 ;; ============================================================
 ;; Event emission helper
@@ -514,6 +519,7 @@
             (gsd-wave-index w)))
         (when (not (null? wave-indices))
           (set-total-waves! (add1 (apply max wave-indices))))
+        (set-current-wave-index! 0)
         (reset-plan-budget!)
         (define executor (make-wave-executor plan))
         (define state-content (read-planning-artifact base-dir "STATE"))
@@ -750,18 +756,42 @@
     [else (hook-pass payload)]))
 
 ;; Handle wave progress after successful edit/write during executing
+;;
+;; v0.21.2 fix: No longer auto-advances waves on every edit.
+;; Instead, detects the current wave from the file path being edited
+;; (e.g., editing W2-something.rkt means wave 2). Only marks a wave
+;; complete when we detect the assistant has moved to the NEXT wave.
+;; Progress shows 'Wave N/T in progress' instead of 'complete'.
 (define (handle-wave-progress payload result)
-  (define npw (next-pending-wave))
-  (when npw
-    (mark-wave-complete! npw)
-    (emit-gsd-event! "gsd.wave.complete" (hasheq 'wave npw)))
+  (define args (or (hash-ref payload 'arguments #f) (hash-ref payload 'tool-args #f)))
+  (define path-arg (and (hash? args) (hash-ref args 'path #f)))
+  ;; Try to detect wave index from file path
+  (define detected-wave
+    (and path-arg
+         (let ([m (regexp-match? #rx"[Ww]ave[-_ ]?([0-9]+)|W([0-9]+)[-_.]" path-arg)])
+           (and m
+                (let ([num-match (regexp-match #rx"[Ww]ave[-_ ]?([0-9]+)|W([0-9]+)[-_.]" path-arg)])
+                  (and num-match
+                       (or (and (cadr num-match) (string->number (cadr num-match)))
+                           (and (caddr num-match) (string->number (caddr num-match))))))))))
+  ;; Update current wave if detected and different from tracked
+  (define prev-wave (current-wave-index))
+  (when (and detected-wave (not (= detected-wave prev-wave)))
+    ;; Assistant moved to a new wave — mark the previous one complete
+    (when (and (>= prev-wave 0) (not (wave-complete? prev-wave)))
+      (mark-wave-complete! prev-wave)
+      (emit-gsd-event! "gsd.wave.complete" (hasheq 'wave prev-wave)))
+    (set-current-wave-index! detected-wave)
+    (emit-gsd-event! "gsd.wave.started" (hasheq 'wave detected-wave)))
   (define tw (total-waves))
   (define cw (completed-waves))
+  (define cur (current-wave-index))
   (define progress-text
     (if (> tw 0)
-        (format "\n\n[PROGRESS: Wave ~a/~a complete. ~a remaining.]"
-                (set-count cw)
+        (format "\n\n[PROGRESS: Wave ~a/~a in progress. ~a completed. ~a remaining.]"
+                cur
                 tw
+                (set-count cw)
                 (- tw (set-count cw)))
         ""))
   (if (string=? progress-text "")

--- a/tests/test-gsd-planning-state.rkt
+++ b/tests/test-gsd-planning-state.rkt
@@ -248,6 +248,21 @@
   (reset-all-gsd-state!)
   (check-equal? (next-pending-wave) #f))
 
+(test-case "current-wave-index defaults to 0"
+  (reset-all-gsd-state!)
+  (check-equal? (current-wave-index) 0))
+
+(test-case "set-current-wave-index! sets and reads back"
+  (reset-all-gsd-state!)
+  (set-current-wave-index! 2)
+  (check-equal? (current-wave-index) 2))
+
+(test-case "current-wave-index included in snapshot"
+  (reset-all-gsd-state!)
+  (set-current-wave-index! 3)
+  (define snap (gsd-snapshot))
+  (check-equal? (hash-ref snap 'current-wave) 3))
+
 ;; ============================================================
 ;; Plan tool budget tests (v0.20.4 W0)
 ;; ============================================================

--- a/tests/test-gsd-planning.rkt
+++ b/tests/test-gsd-planning.rkt
@@ -881,3 +881,70 @@
   ;; Should not raise an error
   (emit-gsd-event! "gsd.test.noop" (hasheq 'key 'value))
   (check-false (gsd-event-bus) "bus should still be #f"))
+
+;; ============================================================
+;; Wave progress tracking tests (v0.21.2 W1)
+;; ============================================================
+
+(test-case "W1: handle-wave-progress does not auto-advance on edit"
+  (reset-all-gsd-state!)
+  (set-gsd-mode! 'executing)
+  (set-total-waves! 4)
+  (set-current-wave-index! 0)
+  ;; Simulate edit on a file with no wave marker
+  (define result (make-success-result (list (hasheq 'type "text" 'text "ok")) (hasheq)))
+  (define payload (hasheq 'tool-name "edit" 'result result 'arguments (hasheq 'path "some-file.rkt")))
+  (handle-wave-progress payload result)
+  ;; Wave 0 should NOT be marked complete just from an edit
+  (check-false (wave-complete? 0))
+  (check-equal? (current-wave-index) 0))
+
+(test-case "W1: handle-wave-progress detects wave from file path and advances"
+  (reset-all-gsd-state!)
+  (set-gsd-mode! 'executing)
+  (set-total-waves! 4)
+  (set-current-wave-index! 0)
+  ;; Simulate edit on W1 file — should mark W0 complete and move to W1
+  (define result (make-success-result (list (hasheq 'type "text" 'text "ok")) (hasheq)))
+  (define payload
+    (hasheq 'tool-name "edit" 'result result 'arguments (hasheq 'path "waves/W1-fix-bug.md")))
+  (handle-wave-progress payload result)
+  (check-true (wave-complete? 0))
+  (check-false (wave-complete? 1))
+  (check-equal? (current-wave-index) 1))
+
+(test-case "W1: handle-wave-progress advances through multiple waves"
+  (reset-all-gsd-state!)
+  (set-gsd-mode! 'executing)
+  (set-total-waves! 4)
+  (set-current-wave-index! 0)
+  (define result (make-success-result (list (hasheq 'type "text" 'text "ok")) (hasheq)))
+  ;; Edit W1 file → W0 complete, current=1
+  (handle-wave-progress
+   (hasheq 'tool-name "edit" 'result result 'arguments (hasheq 'path "waves/W1-first.md"))
+   result)
+  (check-true (wave-complete? 0))
+  (check-equal? (current-wave-index) 1)
+  ;; Edit W2 file → W1 complete, current=2
+  (handle-wave-progress
+   (hasheq 'tool-name "edit" 'result result 'arguments (hasheq 'path "waves/W2-second.md"))
+   result)
+  (check-true (wave-complete? 1))
+  (check-equal? (current-wave-index) 2))
+
+(test-case "W1: multiple edits within same wave don't advance"
+  (reset-all-gsd-state!)
+  (set-gsd-mode! 'executing)
+  (set-total-waves! 3)
+  (set-current-wave-index! 1)
+  (define result (make-success-result (list (hasheq 'type "text" 'text "ok")) (hasheq)))
+  ;; Three edits on the same wave
+  (for ([_ (in-range 3)])
+    (handle-wave-progress
+     (hasheq 'tool-name "edit" 'result result 'arguments (hasheq 'path "src/core.rkt"))
+     result))
+  ;; Still on wave 1
+  (check-equal? (current-wave-index) 1)
+  (check-false (wave-complete? 1))
+  ;; Only 0 completed waves (none explicitly completed yet)
+  (check-equal? (set-count (completed-waves)) 0))


### PR DESCRIPTION
Addresses #2082.

fix(gsd): wave progress tracking advances per-wave not per-edit (#2082)

handle-wave-progress now detects wave index from file paths (e.g., 
W1-fix-bug.md → wave 1) and only marks the previous wave complete when
the assistant moves to a new wave. Multiple edits within the same wave
no longer incorrectly advance the wave counter.

Adds current-wave-index state tracking with snapshot/reset support.

Wave 1 of v0.21.2 milestone.