### PR TITLE
fix(tui,steering): #hasheq display + suppress intent nudge during planning (#2083)

Bug A: TUI tool.call.completed handler now uses tool-result-content->string
to extract text from results instead of raw (format "~a"). Hash content
parts are properly unwrapped, eliminating #hasheq(...) in the prompt line.

Bug B: Iteration loop now checks for planning-completion markers (STEP 4,
"/go", "plan complete") in assistant text before injecting steering intent
nudge. Prevents the LLM from being pushed to implement during /plan mode.

Wave 2 of v0.21.2 milestone.

### DIFF
--- a/runtime/iteration.rkt
+++ b/runtime/iteration.rkt
@@ -781,10 +781,21 @@
                                   (and (hash? c)
                                        (equal? (hash-ref c 'type #f) "text")
                                        (string-contains? (hash-ref c 'text "") "PLAN")))))))
+                     ;; v0.21.2 (BUG-3): Also suppress intent nudge when the assistant
+                     ;; text indicates planning is complete (STEP 4, "use /go").
+                     ;; Prevents steering from nudging the LLM to implement during planning.
+                     (define planning-complete-text?
+                       (and (string? assistant-text)
+                            (or (string-contains? assistant-text "STEP 4")
+                                (string-contains? assistant-text "/go")
+                                (string-contains? assistant-text "use /go")
+                                (regexp-match? #rx"(?i:plan(?:ning)? +(?:is +)?complete)"
+                                               assistant-text))))
                      (if (and intent-detected?
                               (not had-tool-calls?)
                               (< intent-retry-count 1)
-                              (not recent-plan-write?))
+                              (not recent-plan-write?)
+                              (not planning-complete-text?))
                          (begin
                            (emit-session-event!
                             bus

--- a/tests/test-intent-detection.rkt
+++ b/tests/test-intent-detection.rkt
@@ -25,67 +25,69 @@
 ;; ============================================================
 
 (define intent-tests
-  (test-suite
-   "Intent-Without-Action Detection (BUG-INTENT-WITHOUT-ACTION)"
+  (test-suite "Intent-Without-Action Detection (BUG-INTENT-WITHOUT-ACTION)"
 
-   ;; ── Positive cases: intent patterns ──
-   (test-case "detect-intent-pattern matches: I'll rewrite the file"
-     (check-true (detect-intent-pattern "I'll rewrite the file")))
+    ;; ── Positive cases: intent patterns ──
+    (test-case "detect-intent-pattern matches: I'll rewrite the file"
+      (check-true (detect-intent-pattern "I'll rewrite the file")))
 
-   (test-case "detect-intent-pattern matches: I will create a new script"
-     (check-true (detect-intent-pattern "I will create a new script")))
+    (test-case "detect-intent-pattern matches: I will create a new script"
+      (check-true (detect-intent-pattern "I will create a new script")))
 
-   (test-case "detect-intent-pattern matches: Let me edit the configuration"
-     (check-true (detect-intent-pattern "Let me edit the configuration")))
+    (test-case "detect-intent-pattern matches: Let me edit the configuration"
+      (check-true (detect-intent-pattern "Let me edit the configuration")))
 
-   (test-case "detect-intent-pattern matches: Now I'll implement the fix"
-     (check-true (detect-intent-pattern "Now I'll implement the fix")))
+    (test-case "detect-intent-pattern matches: Now I'll implement the fix"
+      (check-true (detect-intent-pattern "Now I'll implement the fix")))
 
-   (test-case "detect-intent-pattern matches: Now let me build the module"
-     (check-true (detect-intent-pattern "Now let me build the module")))
+    (test-case "detect-intent-pattern matches: Now let me build the module"
+      (check-true (detect-intent-pattern "Now let me build the module")))
 
-   (test-case "detect-intent-pattern matches: I'll update the version"
-     (check-true (detect-intent-pattern "I'll update the version")))
+    (test-case "detect-intent-pattern matches: I'll update the version"
+      (check-true (detect-intent-pattern "I'll update the version")))
 
-   ;; ── Negative cases: no intent ──
-   (test-case "detect-intent-pattern rejects: The task is complete"
-     (check-false (detect-intent-pattern "The task is complete")))
+    ;; ── Negative cases: no intent ──
+    (test-case "detect-intent-pattern rejects: The task is complete"
+      (check-false (detect-intent-pattern "The task is complete")))
 
-   (test-case "detect-intent-pattern rejects: I'll think about it"
-     (check-false (detect-intent-pattern "I'll think about it")))
+    (test-case "detect-intent-pattern rejects: I'll think about it"
+      (check-false (detect-intent-pattern "I'll think about it")))
 
-   (test-case "detect-intent-pattern rejects: empty string"
-     (check-false (detect-intent-pattern "")))
+    (test-case "detect-intent-pattern rejects: empty string"
+      (check-false (detect-intent-pattern "")))
 
-   (test-case "detect-intent-pattern rejects: #f"
-     (check-false (detect-intent-pattern #f)))
+    (test-case "detect-intent-pattern rejects: #f"
+      (check-false (detect-intent-pattern #f)))
 
-   ;; ── Case insensitive ──
-   (test-case "detect-intent-pattern is case-insensitive"
-     (check-true (detect-intent-pattern "I'LL REWRITE THE FILE"))
-     (check-true (detect-intent-pattern "LET ME CREATE the module")))
+    ;; ── Case insensitive ──
+    (test-case "detect-intent-pattern is case-insensitive"
+      (check-true (detect-intent-pattern "I'LL REWRITE THE FILE"))
+      (check-true (detect-intent-pattern "LET ME CREATE the module")))
 
-   ;; ── Structural test: verify intent detection code exists in iteration.rkt ──
-   (test-case "iteration.rkt contains detect-intent-pattern helper"
-     (define source
-       (file->string
-        (if (file-exists? "runtime/iteration.rkt")
-            "runtime/iteration.rkt"
-            "../runtime/iteration.rkt")))
-     (check-not-false
-      (regexp-match? #rx"detect-intent-pattern" source)
-      "iteration.rkt should contain detect-intent-pattern"))
+    ;; ── Structural test: verify intent detection code exists in iteration.rkt ──
+    (test-case "iteration.rkt contains detect-intent-pattern helper"
+      (define source
+        (file->string (if (file-exists? "runtime/iteration.rkt")
+                          "runtime/iteration.rkt"
+                          "../runtime/iteration.rkt")))
+      (check-not-false (regexp-match? #rx"detect-intent-pattern" source)
+                       "iteration.rkt should contain detect-intent-pattern"))
 
-   (test-case "iteration.rkt contains intent steering nudge injection"
-     (define source
-       (file->string
-        (if (file-exists? "runtime/iteration.rkt")
-            "runtime/iteration.rkt"
-            "../runtime/iteration.rkt")))
-     (check-not-false
-      (regexp-match? #rx"intent-without-action|intent\\.nudge" source)
-      "iteration.rkt should contain intent-without-action or intent.nudge event"))
+    (test-case "iteration.rkt contains intent steering nudge injection"
+      (define source
+        (file->string (if (file-exists? "runtime/iteration.rkt")
+                          "runtime/iteration.rkt"
+                          "../runtime/iteration.rkt")))
+      (check-not-false (regexp-match? #rx"intent-without-action|intent\\.nudge" source)
+                       "iteration.rkt should contain intent-without-action or intent.nudge event"))
 
-   ))
+    ;; v0.21.2 W2 Bug B: planning-complete text should suppress intent nudge
+    (test-case "iteration.rkt suppresses intent nudge during planning completion"
+      (define source
+        (file->string (if (file-exists? "runtime/iteration.rkt")
+                          "runtime/iteration.rkt"
+                          "../runtime/iteration.rkt")))
+      (check-not-false (regexp-match? #rx"planning-complete-text" source)
+                       "iteration.rkt should have planning-complete-text? guard"))))
 
 (run-tests intent-tests)

--- a/tests/tui/state.rkt
+++ b/tests/tui/state.rkt
@@ -494,6 +494,17 @@
              [s2 (apply-event-to-state s evt)])
         (define entry (first (ui-state-transcript s2)))
         (check-equal? (transcript-entry-kind entry) 'tool-fail)
+        ;; v0.21.2 W2 Bug A fix: tool result with hash content shows text, not #hasheq
+        (test-case "apply-event: tool.call.completed with hash content shows text not hasheq"
+          (let* ([s (initial-ui-state)]
+                 [result-raw (list (hash 'type "text" 'text "Edited file successfully"))]
+                 [evt (make-test-event "tool.call.completed" (hash 'name "edit" 'result result-raw))]
+                 [s2 (apply-event-to-state s evt)])
+            (define entry (first (ui-state-transcript s2)))
+            (check-false (string-contains? (transcript-entry-text entry) "#hasheq")
+                         "should not show raw #hasheq")
+            (check-true (string-contains? (transcript-entry-text entry) "Edited file successfully")
+                        "should show extracted text")))
         (check-true (string-contains? (transcript-entry-text entry) "[FAIL: bash]"))
         (check-true (string-contains? (transcript-entry-text entry) "exit 1") "error shown in text")))
 

--- a/tui/state.rkt
+++ b/tui/state.rkt
@@ -9,7 +9,8 @@
          racket/list
          json
          "../util/protocol-types.rkt"
-         "../util/cost-tracker.rkt")
+         "../util/cost-tracker.rkt"
+         "../util/content-helpers.rkt")
 
 ;; Structs
 (provide (struct-out transcript-entry)
@@ -338,7 +339,9 @@
      (define result-raw (hash-ref payload 'result #f))
      (define result-summary
        (if result-raw
-           (string-replace (truncate-string (format "~a" result-raw) 80) "\n" " \u23ce ")
+           (string-replace (truncate-string (tool-result-content->string result-raw) 80)
+                           "\n"
+                           " \u23ce ")
            ""))
      (define text
        (if (string=? result-summary "")


### PR DESCRIPTION
Addresses #2083.

fix(tui,steering): #hasheq display + suppress intent nudge during planning (#2083)

Bug A: TUI tool.call.completed handler now uses tool-result-content->string
to extract text from results instead of raw (format "~a"). Hash content
parts are properly unwrapped, eliminating #hasheq(...) in the prompt line.

Bug B: Iteration loop now checks for planning-completion markers (STEP 4,
"/go", "plan complete") in assistant text before injecting steering intent
nudge. Prevents the LLM from being pushed to implement during /plan mode.

Wave 2 of v0.21.2 milestone.