### PR TITLE
fix(tools): enhanced edit error hints + version bump to 0.21.2 (#2084)

make-not-found-error now includes contextual hints for common failure
patterns: leading whitespace in old-text and overly long single-line
matches. These speed up agent recovery from edit failures.

Version bumped from 0.21.1 to 0.21.2 (util/version.rkt, info.rkt, README.md).

Wave 3 of v0.21.2 milestone.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.21.1-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.21.2-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 
@@ -199,7 +199,7 @@ racket main.rkt --model gpt-5.4 "write a test"
 ### Verify
 
 ```bash
-racket main.rkt --version  # q version 0.21.1
+racket main.rkt --version  # q version 0.21.2
 raco test tests/           # run the full test suite
 ```
 

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.21.1")
+(define version "0.21.2")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base"))

--- a/tests/test-tool-edit.rkt
+++ b/tests/test-tool-edit.rkt
@@ -206,3 +206,17 @@
   (check-false (tool-result-is-error? result) "edit with & in new-text should succeed")
   (check-equal? (file->string tmp) "x = a & b | c\ny = 1")
   (delete-file tmp))
+
+;; v0.21.2 W3: Enhanced edit error messages with common-cause hints
+(test-case "edit.rkt contains enhanced error hints"
+  (define source
+    (file->string
+     (if (file-exists? "tools/builtins/edit.rkt")
+         "tools/builtins/edit.rkt"
+         "../tools/builtins/edit.rkt")))
+  (check-not-false
+   (regexp-match? #rx"leading whitespace" source)
+   "should hint about leading whitespace")
+  (check-not-false
+   (regexp-match? #rx"smaller unique snippet" source)
+   "should hint about long single-line old-text"))

--- a/tools/builtins/edit.rkt
+++ b/tools/builtins/edit.rkt
@@ -171,15 +171,29 @@
            (values best-line best-num best-score)))]))
 
 ;; Build enhanced error message when old-text is not found.
+;; v0.21.2: Enhanced with common-cause hints to speed up recovery.
 (define (make-not-found-error path-str old-text content)
   (define-values (line-num line-text) (find-nearest-match content old-text))
+  (define hint
+    (cond
+      [(and (string? old-text) (regexp-match? #rx"^ +" old-text))
+       "Hint: old-text has leading whitespace — check indentation."]
+      [(and (string? old-text)
+            (> (string-length old-text) 200)
+            (< (length (string-split old-text "\n")) 2))
+       "Hint: old-text is very long and single-line — try a smaller unique snippet."]
+      [else ""]))
   (cond
     [line-num
      (string-append
       (format "old-text not found in ~a.\nNearest match at line ~a:\n  \"" path-str line-num)
       (string-trim line-text)
-      "\"\nRe-read the file to get exact text.")]
-    [else (format "old-text not found in ~a. Read the file first to get exact text." path-str)]))
+      "\"\nRe-read the file to get exact text.\n"
+      hint)]
+    [else
+     (string-append (format "old-text not found in ~a. Read the file first to get exact text.\n"
+                            path-str)
+                    hint)]))
 
 ;; --------------------------------------------------
 ;; Main tool function

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -7,4 +7,4 @@
 
 (provide q-version)
 
-(define q-version "0.21.1")
+(define q-version "0.21.2")


### PR DESCRIPTION
Addresses #2084.

fix(tools): enhanced edit error hints + version bump to 0.21.2 (#2084)

make-not-found-error now includes contextual hints for common failure
patterns: leading whitespace in old-text and overly long single-line
matches. These speed up agent recovery from edit failures.

Version bumped from 0.21.1 to 0.21.2 (util/version.rkt, info.rkt, README.md).

Wave 3 of v0.21.2 milestone.