### PR TITLE
refactor: remove remaining budget references from implementing prompt (#2091)

v0.21.3 Wave 2: Clean up leftover budget language.

Changes:
- gsd-planning.rkt: removed "Your budget is:" from implementing prompt
  (W0 already removed budget enforcement from tool guard)

All budget/steering references now gone from prompts and guards.
118 tests passing.

### DIFF
--- a/extensions/gsd-planning.rkt
+++ b/extensions/gsd-planning.rkt
@@ -252,8 +252,8 @@
                  "   planning-read is allowed to check STATE or VALIDATION.\n"
                  "4. Do NOT run read-only tools (read, find, grep, ls) unless a wave's\n"
                  "   old-text match fails and you need to re-read the target file ONCE.\n"
-                 "5. Use the edit or write tool for EVERY wave. Your budget is:\n"
-                 "   - Re-read a file ONLY if the old-text match fails.\n"
+                 "5. Use the edit or write tool for EVERY wave.\n"
+                 "   Re-read a file ONLY if the old-text match fails.\n"
                  "6. After completing each wave, run its verify command.\n"
                  "\n"
                  "The plan follows. Start implementing immediately.\n\n"))


### PR DESCRIPTION
Addresses #2091.

refactor: remove remaining budget references from implementing prompt (#2091)

v0.21.3 Wave 2: Clean up leftover budget language.

Changes:
- gsd-planning.rkt: removed "Your budget is:" from implementing prompt
  (W0 already removed budget enforcement from tool guard)

All budget/steering references now gone from prompts and guards.
118 tests passing.