### PR TITLE
feat: session factory mechanism for fresh /go sessions (#2098)

Wave 0 of v0.21.4 — adds session-factory-runner to TUI context structs
and handles {new-session: text} hook result in command dispatch.

Changes:
- tui-ctx: added session-factory-runner field (or/c (string->void) #f)
- cmd-ctx: added session-factory-runner field
- commands.rkt: dispatch 'new-session key to factory (fallback to runner)
- tui-init.rkt: wired factory in run-tui-with-runtime with switch-session!
- Updated 5 test files for new cmd-ctx arity (11 fields)

### DIFF
--- a/tests/test-model-command.rkt
+++ b/tests/test-model-command.rkt
@@ -52,7 +52,8 @@
            (box #f) ; last-prompt-box
            #f ; session-runner
            (box "") ; input-text-box
-           (box #f))) ; extension-registry-box
+           (box #f)
+           #f)) ; extension-registry-box + session-factory-runner
 
 ;; Extract transcript text from a cmd-ctx
 (define (cctx-transcript-text cctx)

--- a/tests/test-reload-command.rkt
+++ b/tests/test-reload-command.rkt
@@ -63,7 +63,8 @@
            (box #f) ; last-prompt-box
            #f ; session-runner
            (box #f) ; input-text-box
-           (box ext-reg))) ; extension-registry-box
+           (box ext-reg)
+           #f)) ; session-factory-runner
 
 ;; ============================================================
 ;; Test suite

--- a/tests/test-tui-activate-command.rkt
+++ b/tests/test-tui-activate-command.rkt
@@ -28,7 +28,8 @@
            (box #f) ; last-prompt
            (lambda (prompt) (void))
            (box input-text)
-           (box #f))) ; extension-registry-box
+           (box #f)
+           #f)) ; extension-registry-box + session-factory-runner
 
 ;; ============================================================
 ;; Tests

--- a/tests/tui/commands.rkt
+++ b/tests/tui/commands.rkt
@@ -22,7 +22,8 @@
            (box #f) ;; last-prompt-box
            #f ;; session-runner
            (box "") ;; input-text-box
-           (box #f))) ;; extension-registry-box
+           (box #f) ;; extension-registry-box
+           #f)) ;; session-factory-runner
 
 (define commands-tests
   (test-suite "TUI Commands"
@@ -154,6 +155,31 @@
       (define transcript (ui-state-transcript state))
       (check-equal? (length transcript) 1)
       (check-equal? (transcript-entry-kind (first transcript)) 'system)
-      (check-true (string-contains? (transcript-entry-text (first transcript)) "retry")))))
+      (check-true (string-contains? (transcript-entry-text (first transcript)) "retry")))
+
+    ;; ============================================================
+    ;; session-factory-runner dispatch (v0.21.4)
+    ;; ============================================================
+
+    (test-case "cmd-ctx-session-factory-runner is #f by default"
+      (define cctx (make-test-cctx))
+      (check-false (cmd-ctx-session-factory-runner cctx)))
+
+    (test-case "cmd-ctx-session-factory-runner can be set to a procedure"
+      (define called-with (box #f))
+      (define factory (lambda (prompt) (set-box! called-with prompt)))
+      (define cctx
+        (cmd-ctx (box (initial-ui-state))
+                 (box #t)
+                 #f
+                 #f
+                 (box #f)
+                 #f
+                 (box #f)
+                 #f
+                 (box "")
+                 (box #f)
+                 factory))
+      (check-true (procedure? (cmd-ctx-session-factory-runner cctx))))))
 
 (run-tests commands-tests)

--- a/tests/tui/test-command-integration.rkt
+++ b/tests/tui/test-command-integration.rkt
@@ -26,7 +26,8 @@
            (box #f) ;; last-prompt-box
            #f ;; session-runner
            (box "") ;; input-text-box
-           (box #f))) ;; extension-registry-box
+           (box #f) ;; extension-registry-box
+           #f)) ;; session-factory-runner
 
 ;; Helper: get transcript text entries from cctx state
 (define (get-transcript-texts cctx)

--- a/tui/commands.rkt
+++ b/tui/commands.rkt
@@ -47,7 +47,8 @@
          cmd-ctx-extension-registry-box
 
          ;; Main command dispatcher
-         process-slash-command)
+         process-slash-command
+         cmd-ctx-session-factory-runner)
 
 ;; ============================================================
 ;; Command context — lightweight alternative to tui-ctx
@@ -65,7 +66,8 @@
          last-prompt-box ; (boxof (or/c string? #f)) — last user prompt for /retry
          session-runner ; (string -> void) or #f — for /retry resubmission
          input-text-box ; (boxof string?) — raw input text for commands like /activate
-         extension-registry-box) ; (or/c (boxof (or/c extension-registry? #f)) #f) — for ext command dispatch
+         extension-registry-box
+         session-factory-runner) ; (or/c (boxof (or/c extension-registry? #f)) #f) — for ext command dispatch
   #:transparent)
 
 ;; ============================================================
@@ -857,9 +859,25 @@
           [(and ext-result (hook-result? ext-result) (eq? (hook-result-action ext-result) 'amend))
            ;; Extension handled the command
            (define payload (hook-result-payload ext-result))
+           (define new-session-text (hash-ref payload 'new-session #f))
            (define submit-text (hash-ref payload 'submit #f))
            (define display-text (hash-ref payload 'text #f))
            (cond
+             [new-session-text
+              ;; Extension wants a fresh session (e.g. /go)
+              (when display-text
+                (define entry (make-entry 'system display-text (current-inexact-milliseconds) (hash)))
+                (set-box! (cmd-ctx-state-box cctx)
+                          (add-transcript-entry (unbox (cmd-ctx-state-box cctx)) entry)))
+              (define factory (cmd-ctx-session-factory-runner cctx))
+              (cond
+                ;; Fresh session: call factory with the prompt
+                [factory (thread (lambda () (factory new-session-text)))]
+                [else
+                 ;; Fallback: append to existing session
+                 (define runner (cmd-ctx-session-runner cctx))
+                 (when runner
+                   (thread (lambda () (runner new-session-text))))])]
              [submit-text
               ;; Extension wants to submit text as a prompt to the agent
               (when display-text

--- a/tui/tui-init.rkt
+++ b/tui/tui-init.rkt
@@ -21,6 +21,7 @@
          "../runtime/agent-session.rkt"
          "../runtime/provider-factory.rkt"
          "../runtime/session-index.rkt"
+         "../runtime/session-switch.rkt"
          "../tui/tui-keybindings.rkt"
          "../tui/tui-render-loop.rkt"
          "../cli/args.rkt"
@@ -64,12 +65,35 @@
   (define sess-dir (or (hash-ref rt-config 'session-dir #f) (hash-ref rt-config 'store-dir #f)))
 
   (define ctx
-    (make-tui-ctx #:event-bus bus
-                  #:session-runner (lambda (prompt) (run-prompt! sess prompt))
-                  #:session-dir sess-dir
-                  #:model-registry (hash-ref rt-config 'model-registry #f)
-                  #:extension-registry (hash-ref rt-config 'extension-registry #f)
-                  #:session-queue (agent-session-queue sess)))
+    (make-tui-ctx
+     #:event-bus bus
+     #:session-runner (lambda (prompt) (run-prompt! sess prompt))
+     #:session-dir sess-dir
+     #:model-registry (hash-ref rt-config 'model-registry #f)
+     #:extension-registry (hash-ref rt-config 'extension-registry #f)
+     #:session-queue (agent-session-queue sess)
+     #:session-factory-runner
+     (lambda (prompt)
+       ;; v0.21.4: /go creates fresh session with no planning history
+       (define new-sess (make-agent-session rt-config))
+       (define new-sid (session-id new-sess))
+       (define new-dir (or (hash-ref rt-config 'session-dir #f) (hash-ref rt-config 'store-dir #f)))
+       ;; Switch extensions: teardown old, rebind to new
+       (switch-session! #:old-session-id (session-id sess)
+                        #:old-bus bus
+                        #:old-extension-registry (hash-ref rt-config 'extension-registry #f)
+                        #:new-session-id new-sid
+                        #:new-session-dir new-dir
+                        #:new-bus bus
+                        #:new-extension-registry (hash-ref rt-config 'extension-registry #f)
+                        #:reason 'fork)
+       ;; Clear TUI transcript for new session
+       (set-box! (tui-ctx-ui-state-box ctx)
+                 (initial-ui-state #:session-id new-sid
+                                   #:model-name (hash-ref rt-config 'model-name #f)))
+       (set-box! (tui-ctx-needs-redraw-box ctx) #t)
+       ;; Run prompt in new session
+       (run-prompt! new-sess prompt))))
 
   ;; Install UI callbacks for extensions (breaks extensions→TUI upward import)
   (install-ui-callbacks!
@@ -87,8 +111,7 @@
            styled-segment
            ;; LAYER-01: status message callback for dialog-api
            'set-status-message
-           (lambda (box msg)
-             (set-box! box (struct-copy ui-state (unbox box) [status-message msg])))
+           (lambda (box msg) (set-box! box (struct-copy ui-state (unbox box) [status-message msg])))
            ;; LAYER-02: widget callbacks for widget-api
            'set-extension-widget
            set-extension-widget

--- a/tui/tui-keybindings.rkt
+++ b/tui/tui-keybindings.rkt
@@ -87,7 +87,8 @@
          previous-frame-box ; (boxof (or/c (listof string) #f)) — last rendered frame for diffing
          last-prompt-box ; (boxof (or/c string? #f)) — last user prompt for /retry
          extension-registry-box ; (or/c (boxof (or/c extension-registry? #f)) #f)
-         session-queue-box) ; (boxof (or/c queue? #f)) — agent queue for followup during streaming (G3.1)
+         session-queue-box ; (boxof (or/c queue? #f)) — agent queue for followup during streaming (G3.1)
+         session-factory-runner) ; (or/c (string -> void) #f) — creates fresh session for /go
   #:transparent)
 
 (define (make-tui-ctx #:event-bus [bus #f]
@@ -95,7 +96,8 @@
                       #:session-dir [sess-dir #f]
                       #:model-registry [reg #f]
                       #:extension-registry [ext-reg #f]
-                      #:session-queue [sess-queue #f])
+                      #:session-queue [sess-queue #f]
+                      #:session-factory-runner [factory #f])
   (tui-ctx (box (initial-ui-state))
            (box (initial-input-state))
            bus
@@ -110,7 +112,8 @@
            (box #f) ; previous-frame-box - #f means no previous frame
            (box #f) ; last-prompt-box - #f until first submit
            (box ext-reg) ; extension-registry-box
-           (box sess-queue))) ; session-queue-box
+           (box sess-queue) ; session-queue-box
+           factory))
 
 ;; ============================================================
 ;; mark-dirty!
@@ -198,7 +201,8 @@
                     (tui-ctx-last-prompt-box ctx)
                     (tui-ctx-session-runner ctx)
                     (box "")
-                    (tui-ctx-extension-registry-box ctx)))
+                    (tui-ctx-extension-registry-box ctx)
+                    (tui-ctx-session-factory-runner ctx)))
 
 ;; Process a slash command. Returns 'continue | 'quit
 ;; cmd can be: symbol | (list symbol args...)


### PR DESCRIPTION
Addresses #2098.

feat: session factory mechanism for fresh /go sessions (#2098)

Wave 0 of v0.21.4 — adds session-factory-runner to TUI context structs
and handles {new-session: text} hook result in command dispatch.

Changes:
- tui-ctx: added session-factory-runner field (or/c (string->void) #f)
- cmd-ctx: added session-factory-runner field
- commands.rkt: dispatch 'new-session key to factory (fallback to runner)
- tui-init.rkt: wired factory in run-tui-with-runtime with switch-session!
- Updated 5 test files for new cmd-ctx arity (11 fields)