### PR TITLE
feat: /go creates fresh session instead of appending to planning context (#2099)

Wave 1 of v0.21.4 — changes handle-go-command to return {new-session: text}
instead of {submit: text}, ensuring execution starts with a clean context
separate from the planning phase.

Changes:
- gsd-planning.rkt: handle-go-command returns 'new-session key (not 'submit)
- gsd-planning.rkt: updated planning-implement-prompt to instruct reading
  target files before editing (replaces "do NOT run read-only tools")
- tests: updated 4 test assertions from 'submit to 'new-session for /go
- tests: added test for "Read each target file BEFORE editing" prompt text

### DIFF
--- a/extensions/gsd-planning.rkt
+++ b/extensions/gsd-planning.rkt
@@ -250,10 +250,9 @@
                  "2. Do NOT write a new plan. Execute the existing one.\n"
                  "3. Do NOT use planning-write during implementation.\n"
                  "   planning-read is allowed to check STATE or VALIDATION.\n"
-                 "4. Do NOT run read-only tools (read, find, grep, ls) unless a wave's\n"
-                 "   old-text match fails and you need to re-read the target file ONCE.\n"
-                 "5. Use the edit or write tool for EVERY wave.\n"
-                 "   Re-read a file ONLY if the old-text match fails.\n"
+                 "4. Read each target file BEFORE editing it. You need the current content\n"
+                 "   to apply edits correctly. Read is necessary and expected.\n"
+                 "5. After reading, apply the edits specified in the wave doc actions.\n"
                  "6. After completing each wave, run its verify command.\n"
                  "\n"
                  "The plan follows. Start implementing immediately.\n\n"))
@@ -514,7 +513,7 @@
                          state-note
                          wave-arg))
         (hook-amend
-         (hasheq 'submit augmented-text 'text (format "Implementing plan~a..." wave-arg)))])]))
+         (hasheq 'new-session augmented-text 'text (format "Implementing plan~a..." wave-arg)))])]))
 
 ;; Handler for /gsd status
 (define (handle-gsd-status)

--- a/tests/test-gsd-planning.rkt
+++ b/tests/test-gsd-planning.rkt
@@ -526,7 +526,7 @@
                      (check-false (hash-ref payload 'submit #f) "no submit without plan")
                      (check-true (string-contains? (hash-ref payload 'text) "No PLAN found"))))))
 
-(test-case "/go submits implementation prompt with plan content"
+(test-case "/go returns new-session payload with plan content"
   (reset-all-gsd-state!)
   (with-temp-dir
    (lambda (dir)
@@ -541,10 +541,10 @@
        (define result (handler (hasheq 'command "/go" 'input "/go")))
        (check-equal? (hook-result-action result) 'amend)
        (define payload (hook-result-payload result))
-       (define submit-text (hash-ref payload 'submit))
-       (check-true (string-contains? submit-text "[gsd-planning]"))
-       (check-true (string-contains? submit-text "IMPLEMENT NOW"))
-       (check-true (string-contains? submit-text "Wave 0"))
+       (define new-session-text (hash-ref payload 'new-session))
+       (check-true (string-contains? new-session-text "[gsd-planning]"))
+       (check-true (string-contains? new-session-text "IMPLEMENT NOW"))
+       (check-true (string-contains? new-session-text "Wave 0"))
        (check-true (string-contains? (hash-ref payload 'text) "Implementing"))))))
 
 ;; ============================================================
@@ -553,6 +553,9 @@
 
 (test-case "planning-implement-prompt forbids re-reading the plan"
   (check-true (string-contains? planning-implement-prompt "Do NOT re-read the plan")))
+
+(test-case "planning-implement-prompt instructs to read target files before editing"
+  (check-true (string-contains? planning-implement-prompt "Read each target file BEFORE editing")))
 
 (test-case "planning-implement-prompt forbids writing a new plan"
   (check-true (string-contains? planning-implement-prompt "Do NOT write a new plan")))
@@ -582,7 +585,7 @@
                               #:exists 'truncate)
        (define handler (hash-ref (extension-hooks gsd-planning-extension) 'execute-command))
        (define result (handler (hasheq 'command "/go" 'input "/go")))
-       (define submit-text (hash-ref (hook-result-payload result) 'submit))
+       (define submit-text (hash-ref (hook-result-payload result) 'new-session))
        (check-true (string-contains? submit-text "W0: done"))))))
 
 (test-case "/go N starts at specified wave"
@@ -601,7 +604,7 @@
         #:exists 'truncate)
        (define handler (hash-ref (extension-hooks gsd-planning-extension) 'execute-command))
        (define result (handler (hasheq 'command "/go" 'input "/go 2")))
-       (define submit-text (hash-ref (hook-result-payload result) 'submit))
+       (define submit-text (hash-ref (hook-result-payload result) 'new-session))
        (check-true (string-contains? submit-text "wave 2"))))))
 
 (test-case "/implement alias works"
@@ -617,7 +620,7 @@
        (define handler (hash-ref (extension-hooks gsd-planning-extension) 'execute-command))
        (define result (handler (hasheq 'command "/implement" 'input "/implement")))
        (check-equal? (hook-result-action result) 'amend)
-       (define submit-text (hash-ref (hook-result-payload result) 'submit))
+       (define submit-text (hash-ref (hook-result-payload result) 'new-session))
        (check-true (string-contains? submit-text "[gsd-planning]"))))))
 
 ;; ============================================================


### PR DESCRIPTION
Addresses #2099.

feat: /go creates fresh session instead of appending to planning context (#2099)

Wave 1 of v0.21.4 — changes handle-go-command to return {new-session: text}
instead of {submit: text}, ensuring execution starts with a clean context
separate from the planning phase.

Changes:
- gsd-planning.rkt: handle-go-command returns 'new-session key (not 'submit)
- gsd-planning.rkt: updated planning-implement-prompt to instruct reading
  target files before editing (replaces "do NOT run read-only tools")
- tests: updated 4 test assertions from 'submit to 'new-session for /go
- tests: added test for "Read each target file BEFORE editing" prompt text