### PR TITLE
feat: simplify state machine — forward-only transitions from executing (#2100)

Wave 2 of v0.21.4 — removes backward transitions from executing/exploring
so the state machine only allows forward progress.

Changes:
- state-machine.rkt: removed (executing . exploring) and (plan-written . exploring)
  transitions; added (executing . idle) and (plan-written . idle) instead
- Updated test-gsd-state-machine.rkt: replaced backward transition tests with
  new forward-only tests + added executing→exploring invalid transition test
- Updated test-gsd-planning-boundary.rkt: /plan reset now goes via idle first

### DIFF
--- a/extensions/gsd/state-machine.rkt
+++ b/extensions/gsd/state-machine.rkt
@@ -52,9 +52,9 @@
   '((idle . exploring) (exploring . plan-written)
                        (exploring . idle)
                        (plan-written . executing)
-                       (plan-written . exploring)
+                       (plan-written . idle)
                        (executing . verifying)
-                       (executing . exploring)
+                       (executing . idle)
                        (verifying . idle)
                        (verifying . executing)))
 

--- a/tests/test-gsd-planning-boundary.rkt
+++ b/tests/test-gsd-planning-boundary.rkt
@@ -263,10 +263,13 @@
                       ;; Cleanup
                       (set-gsd-mode! #f))))))
 
-(test-case "new /plan resets mode from 'plan-written"
-  ;; Simulating starting a fresh planning session
+(test-case "new /plan resets mode from 'plan-written (via reset then exploring)"
+  ;; Starting a fresh planning session requires reset first
   (with-mode 'plan-written
              (lambda ()
+               ;; Cannot go directly plan-written → exploring (v0.21.4)
+               ;; Must reset to idle first
+               (set-gsd-mode! #f)
                (set-gsd-mode! 'planning)
                (check-eq? (gsd-mode) 'planning))))
 

--- a/tests/test-gsd-state-machine.rkt
+++ b/tests/test-gsd-state-machine.rkt
@@ -67,12 +67,12 @@
   (check-eq? (gsm-current) 'executing)
   (check-true (ok? r)))
 
-(test-case "plan-written → exploring via /replan"
+(test-case "plan-written → idle via /reset"
   (reset-gsm!)
   (gsm-transition! 'exploring)
   (gsm-transition! 'plan-written)
-  (define r (gsm-transition! 'exploring))
-  (check-eq? (gsm-current) 'exploring)
+  (define r (gsm-transition! 'idle))
+  (check-eq? (gsm-current) 'idle)
   (check-true (ok? r)))
 
 (test-case "executing → verifying after all waves attempted"
@@ -84,13 +84,13 @@
   (check-eq? (gsm-current) 'verifying)
   (check-true (ok? r)))
 
-(test-case "executing → exploring on catastrophic plan failure"
+(test-case "executing → idle on completion or failure"
   (reset-gsm!)
   (gsm-transition! 'exploring)
   (gsm-transition! 'plan-written)
   (gsm-transition! 'executing)
-  (define r (gsm-transition! 'exploring))
-  (check-eq? (gsm-current) 'exploring)
+  (define r (gsm-transition! 'idle))
+  (check-eq? (gsm-current) 'idle)
   (check-true (ok? r)))
 
 (test-case "verifying → idle when all verifications pass"
@@ -156,6 +156,15 @@
   (check-eq? (gsm-current) 'executing)
   (check-false (ok? r)))
 
+(test-case "executing → exploring is invalid (v0.21.4: forward-only)"
+  (reset-gsm!)
+  (gsm-transition! 'exploring)
+  (gsm-transition! 'plan-written)
+  (gsm-transition! 'executing)
+  (define r (gsm-transition! 'exploring))
+  (check-eq? (gsm-current) 'executing)
+  (check-false (ok? r)))
+
 (test-case "verifying → exploring is invalid"
   (reset-gsm!)
   (gsm-transition! 'exploring)
@@ -201,14 +210,14 @@
   (reset-gsm!)
   (gsm-transition! 'exploring)
   (gsm-transition! 'plan-written)
-  (check-equal? (sort (gsm-valid-next-states) symbol<?) '(executing exploring)))
+  (check-equal? (sort (gsm-valid-next-states) symbol<?) '(executing idle)))
 
 (test-case "valid-next-states returns correct set for executing"
   (reset-gsm!)
   (gsm-transition! 'exploring)
   (gsm-transition! 'plan-written)
   (gsm-transition! 'executing)
-  (check-equal? (gsm-valid-next-states) '(verifying exploring)))
+  (check-equal? (gsm-valid-next-states) '(verifying idle)))
 
 (test-case "valid-next-states returns correct set for verifying"
   (reset-gsm!)
@@ -253,15 +262,13 @@
 (test-case "idle: all tools allowed"
   (reset-gsm!)
   (for ([tool '("read" "edit" "write" "bash" "planning-read" "planning-write")])
-    (check-true (gsm-tool-allowed? tool)
-                (format "~a should be allowed in idle" tool))))
+    (check-true (gsm-tool-allowed? tool) (format "~a should be allowed in idle" tool))))
 
 (test-case "exploring: all tools allowed (free exploration)"
   (reset-gsm!)
   (gsm-transition! 'exploring)
   (for ([tool '("read" "edit" "write" "bash" "planning-read" "planning-write")])
-    (check-true (gsm-tool-allowed? tool)
-                (format "~a should be allowed in exploring" tool))))
+    (check-true (gsm-tool-allowed? tool) (format "~a should be allowed in exploring" tool))))
 
 (test-case "plan-written: edit/write/bash blocked, read allowed"
   (reset-gsm!)


### PR DESCRIPTION
Addresses #2100.

feat: simplify state machine — forward-only transitions from executing (#2100)

Wave 2 of v0.21.4 — removes backward transitions from executing/exploring
so the state machine only allows forward progress.

Changes:
- state-machine.rkt: removed (executing . exploring) and (plan-written . exploring)
  transitions; added (executing . idle) and (plan-written . idle) instead
- Updated test-gsd-state-machine.rkt: replaced backward transition tests with
  new forward-only tests + added executing→exploring invalid transition test
- Updated test-gsd-planning-boundary.rkt: /plan reset now goes via idle first