### PR TITLE
feat: security fixes — URL-aware local-provider? + config shape validation (#2110)

Wave 0 of v0.21.5 — addresses F2 and F3 from audit.

F2: Rewrite local-provider? with proper URL parsing (net/url).
Parses URL, extracts host, matches against localhost/127.0.0.1/::1/private
ranges on HOST ONLY. Prevents false positives from private-network strings
in path/query components (e.g. https://api.example.com/proxy/localhost/v1).

F3: Config shape validation — load-settings config-path branch validates
read-json result is a hash before merge (returns empty hash for non-object).
deep-merge-hash now has defensive guards for non-hash arguments.

Tests: 6 new F2 tests (URL host matching), 5 new F3 tests (config validation).

### DIFF
--- a/runtime/provider-factory.rkt
+++ b/runtime/provider-factory.rkt
@@ -14,7 +14,8 @@
          "../llm/gemini.rkt"
          "../llm/anthropic.rkt"
          "../llm/azure-openai.rkt"
-         racket/string)
+         racket/string
+         net/url)
 
 (provide build-provider
          build-mock-provider
@@ -53,20 +54,27 @@
 
 ;; Helper: Check if a URL points to a local/self-hosted provider.
 ;; Local providers don't require API keys.
+;; v0.21.5 (F2): URL-aware host matching — parses URL and checks host only.
 (define (local-provider? base-url)
   (and (string? base-url)
        (> (string-length base-url) 0)
-       (or (string-contains? base-url "localhost")
-           (string-contains? base-url "127.0.0.1")
-           (string-contains? base-url "192.168.")
-           (string-contains? base-url "10.")
-           (rfc1918-172? base-url))))
+       (with-handlers ([exn:fail? (λ (_) #f)])
+         (define parsed (string->url base-url))
+         (define host (url-host parsed))
+         (and host
+              (> (string-length host) 0)
+              (or (string=? host "localhost")
+                  (string=? host "127.0.0.1")
+                  (string=? host "::1")
+                  (string-prefix? host "192.168.")
+                  (string-prefix? host "10.")
+                  (rfc1918-172-host? host))))))
 
 ;; RFC 1918 172.16.0.0/12 check — only 172.16.x.x through 172.31.x.x
-(define (rfc1918-172? url-str)
-  (and (string-contains? url-str "172.")
-       (regexp-match? #rx"172\\.([0-9]+)\\." url-str)
-       (let ([m (regexp-match #rx"172\\.([0-9]+)\\." url-str)])
+;; v0.21.5 (F2): Host-only check (not full URL string)
+(define (rfc1918-172-host? host)
+  (and (string-prefix? host "172.")
+       (let ([m (regexp-match #rx"^172\\.([0-9]+)\\." host)])
          (and m (let ([octet (string->number (cadr m))]) (and octet (<= 16 octet 31)))))))
 
 ;; Build the provider from CLI config + settings.

--- a/runtime/settings.rkt
+++ b/runtime/settings.rkt
@@ -40,6 +40,7 @@
 
          ;; Merging
          merge-settings
+         deep-merge-hash
 
          ;; Query
          setting-ref
@@ -132,11 +133,16 @@
 ;; Only hashes are merged recursively — scalars, lists, etc. are
 ;; replaced outright by the right-hand value.
 (define (deep-merge-hash left right)
-  (for/fold ([acc left]) ([(k v) (in-hash right)])
-    (define left-v (hash-ref acc k #f))
-    (cond
-      [(and (hash? left-v) (hash? v)) (hash-set acc k (deep-merge-hash left-v v))]
-      [else (hash-set acc k v)])))
+  (cond
+    [(and (hash? left) (not (hash? right))) left]
+    [(and (not (hash? left)) (hash? right)) right]
+    [(not (and (hash? left) (hash? right))) (hash)]
+    [else
+     (for/fold ([acc left]) ([(k v) (in-hash right)])
+       (define left-v (hash-ref acc k #f))
+       (cond
+         [(and (hash? left-v) (hash? v)) (hash-set acc k (deep-merge-hash left-v v))]
+         [else (hash-set acc k v)]))]))
 
 ;; Sentinel for distinguishing "not found" from "found #f"
 (define NOT-FOUND (gensym 'not-found))
@@ -186,7 +192,10 @@
     (if config-path
         (if (file-exists? config-path)
             (with-handlers ([exn:fail? (λ (_) (hash))])
-              (call-with-input-file config-path (λ (in) (read-json in))))
+              (let ([result (call-with-input-file config-path (λ (in) (read-json in)))])
+                (if (hash? result)
+                    result
+                    (hash))))
             (hash))
         (load-global-settings home-dir)))
   (define project-hash (load-project-settings project-dir))

--- a/tests/test-provider-factory.rkt
+++ b/tests/test-provider-factory.rkt
@@ -100,3 +100,25 @@
   (define p (create-provider-for-name "openai" "https://api.openai.com/v1" "test-key" "gpt-4o"))
   (check-pred provider? p)
   (check-equal? (provider-name p) "openai-compatible"))
+
+;; ============================================================
+;; F2: URL-aware host matching (v0.21.5)
+;; ============================================================
+
+(test-case "F2: local-provider? rejects URL with localhost in path"
+  (check-false (local-provider? "https://api.example.com/proxy/localhost/v1")))
+
+(test-case "F2: local-provider? rejects URL with 127.0.0.1 in query"
+  (check-false (local-provider? "https://remote.host.com/api?host=127.0.0.1")))
+
+(test-case "F2: local-provider? rejects URL with 10. in path"
+  (check-false (local-provider? "https://example.com/10.data/file")))
+
+(test-case "F2: local-provider? recognizes ::1 (IPv6 loopback)"
+  (check-true (local-provider? "http://[::1]:8080/v1")))
+
+(test-case "F2: local-provider? rejects malformed URL"
+  (check-false (local-provider? "not-a-url")))
+
+(test-case "F2: local-provider? rejects #f"
+  (check-false (local-provider? #f)))

--- a/tests/test-settings-config-validation.rkt
+++ b/tests/test-settings-config-validation.rkt
@@ -54,3 +54,30 @@
    #:exists 'replace)
   (check-false (config-parse-error tmp))
   (delete-file tmp))
+
+;; ============================================================
+;; F3: Config shape validation (v0.21.5)
+;; ============================================================
+
+(test-case "F3: load-settings with non-object config file returns empty merged"
+  (define tmp (make-temporary-file "q-test-config-~a.json"))
+  (with-output-to-file tmp (lambda () (display "[1,2,3]")) #:exists 'replace)
+  (define settings (load-settings "/tmp" #:config-path tmp))
+  (check-true (hash? (q-settings-merged settings)))
+  (delete-file tmp))
+
+(test-case "F3: load-settings with scalar config file returns empty merged"
+  (define tmp (make-temporary-file "q-test-config-~a.json"))
+  (with-output-to-file tmp (lambda () (display "\"hello\"")) #:exists 'replace)
+  (define settings (load-settings "/tmp" #:config-path tmp))
+  (check-true (hash? (q-settings-merged settings)))
+  (delete-file tmp))
+
+(test-case "F3: deep-merge-hash with non-hash left returns right"
+  (check-equal? (deep-merge-hash "not-a-hash" (hash 'a 1)) (hash 'a 1)))
+
+(test-case "F3: deep-merge-hash with non-hash right returns left"
+  (check-equal? (deep-merge-hash (hash 'a 1) "not-a-hash") (hash 'a 1)))
+
+(test-case "F3: deep-merge-hash with both non-hash returns empty"
+  (check-equal? (deep-merge-hash 42 "string") (hash)))


### PR DESCRIPTION
Addresses #2110.

feat: security fixes — URL-aware local-provider? + config shape validation (#2110)

Wave 0 of v0.21.5 — addresses F2 and F3 from audit.

F2: Rewrite local-provider? with proper URL parsing (net/url).
Parses URL, extracts host, matches against localhost/127.0.0.1/::1/private
ranges on HOST ONLY. Prevents false positives from private-network strings
in path/query components (e.g. https://api.example.com/proxy/localhost/v1).

F3: Config shape validation — load-settings config-path branch validates
read-json result is a hash before merge (returns empty hash for non-object).
deep-merge-hash now has defensive guards for non-hash arguments.

Tests: 6 new F2 tests (URL host matching), 5 new F3 tests (config validation).