### PR TITLE
fix: per-session write budget isolation (F4) (#2111)

Wave 1 of v0.21.5 — addresses F4 from audit.

Change session-bytes-written from module-global (box 0) to
(make-parameter (box 0)) so each session gets its own write tracker.

New export: init-session-writes! — call from session lifecycle to
reset the parameter to a fresh box. This ensures per-session isolation
in TUI multi-session runtime.

Tests: 2 new F4 tests verifying fresh counter after init-session-writes!.

### DIFF
--- a/tests/test-tool-write.rkt
+++ b/tests/test-tool-write.rkt
@@ -124,3 +124,37 @@
     (define r (tool-write (hasheq 'path tmp 'content "1234567890")))
     (check-false (tool-result-is-error? r)))
   (when (file-exists? tmp) (delete-file tmp)))
+
+;; ============================================================
+;; F4: Per-session write budget isolation (v0.21.5)
+;; ============================================================
+
+(test-case "F4: init-session-writes! resets to fresh counter"
+  (reset-cumulative-writes!)
+  (parameterize ([cumulative-write-budget 20]
+                 [current-max-write-bytes 100])
+    (define tmp (make-temporary-file "q-write-test-~a"))
+    (delete-file tmp)
+    ;; Write 10 bytes
+    (tool-write (hasheq 'path tmp 'content "1234567890"))
+    ;; Switch to new session — fresh counter
+    (init-session-writes!)
+    ;; Can write again even though previous session had 10 bytes
+    (define r (tool-write (hasheq 'path tmp 'content "123456789012")))
+    (check-false (tool-result-is-error? r))
+    (when (file-exists? tmp) (delete-file tmp))))
+
+(test-case "F4: parameterize isolation between sessions"
+  (init-session-writes!)
+  (parameterize ([cumulative-write-budget 15]
+                 [current-max-write-bytes 100])
+    (define tmp (make-temporary-file "q-write-test-~a"))
+    (delete-file tmp)
+    ;; Session A: write 10 bytes
+    (tool-write (hasheq 'path tmp 'content "1234567890"))
+    ;; Simulate session B with fresh counter
+    (init-session-writes!)
+    ;; Session B should have fresh budget
+    (define r (tool-write (hasheq 'path tmp 'content "123456789012")))
+    (check-false (tool-result-is-error? r))
+    (when (file-exists? tmp) (delete-file tmp))))

--- a/tools/builtins/write.rkt
+++ b/tools/builtins/write.rkt
@@ -5,13 +5,16 @@
          (only-in "../../util/path-helpers.rkt" path-only expand-home-path)
          (only-in "../../util/errors.rkt" raise-tool-error tool-error?)
          (only-in "../../util/safe-mode-predicates.rkt"
-                  safe-mode? allowed-path? safe-mode-project-root)
+                  safe-mode?
+                  allowed-path?
+                  safe-mode-project-root)
          (only-in "../../util/error-sanitizer.rkt" sanitize-error-message))
 
 (provide tool-write
          current-max-write-bytes
          cumulative-write-budget
-         reset-cumulative-writes!)
+         reset-cumulative-writes!
+         init-session-writes!)
 
 ;; Maximum write size in bytes (default 1MB) — SEC-03
 (define current-max-write-bytes (make-parameter 1048576))
@@ -19,11 +22,18 @@
 ;; Cumulative write budget per session (default 50MB) — SEC-14
 (define cumulative-write-budget (make-parameter 52428800))
 
-;; Track cumulative bytes written in current session
-(define session-bytes-written (box 0))
+;; Track cumulative bytes written in current session.
+;; v0.21.5 (F4): Parameter-based for per-session isolation.
+;; Each session gets its own box via init-session-writes!.
+(define session-bytes-written (make-parameter (box 0)))
+
+;; Initialize a fresh write tracker for a new session.
+;; Call from session lifecycle (e.g. agent-session creation).
+(define (init-session-writes!)
+  (session-bytes-written (box 0)))
 
 (define (reset-cumulative-writes!)
-  (set-box! session-bytes-written 0))
+  (set-box! (session-bytes-written) 0))
 
 ;; Main tool function
 (define (tool-write args [exec-ctx #f])
@@ -34,28 +44,29 @@
     [(and (safe-mode?) (not (allowed-path? path-str)))
      ;; Defense-in-depth: verify path even if scheduler already checked (SEC-09)
      (make-error-result
-      (format "write: path '~a' outside project root (~a)"
-              path-str (safe-mode-project-root)))]
+      (format "write: path '~a' outside project root (~a)" path-str (safe-mode-project-root)))]
     [else
      (define content-str (hash-ref args 'content ""))
-     (with-handlers ([exn:fail:filesystem?
-                      (lambda (e) (make-error-result (sanitize-error-message
-                                                         (format "Write error: ~a" (exn-message e)))))]
-                     [tool-error?
-                      (lambda (e) (make-error-result (exn-message e)))])
+     (with-handlers ([exn:fail:filesystem? (lambda (e)
+                                             (make-error-result (sanitize-error-message
+                                                                 (format "Write error: ~a"
+                                                                         (exn-message e)))))]
+                     [tool-error? (lambda (e) (make-error-result (exn-message e)))])
        ;; SEC-03: Enforce per-write max-write-bytes limit
        (define content-bytes (string->bytes/utf-8 content-str))
        (define bytes-count (bytes-length content-bytes))
        (when (> bytes-count (current-max-write-bytes))
          (raise-tool-error (format "write rejected: ~a bytes exceeds limit of ~a"
-                                   bytes-count (current-max-write-bytes))
+                                   bytes-count
+                                   (current-max-write-bytes))
                            'write))
 
        ;; SEC-14: Enforce cumulative write budget
-       (define new-total (+ (unbox session-bytes-written) bytes-count))
+       (define new-total (+ (unbox (session-bytes-written)) bytes-count))
        (when (> new-total (cumulative-write-budget))
          (raise-tool-error (format "write rejected: cumulative ~a bytes exceeds session budget of ~a"
-                                   new-total (cumulative-write-budget))
+                                   new-total
+                                   (cumulative-write-budget))
                            'write))
 
        ;; Create parent directories if needed
@@ -67,9 +78,10 @@
        (call-with-output-file path-str (lambda (out) (display content-str out)) #:exists 'replace)
 
        ;; Track cumulative bytes
-       (set-box! session-bytes-written new-total)
+       (set-box! (session-bytes-written) new-total)
 
-       (make-success-result (list (format "Wrote ~a bytes to ~a" bytes-count path-str))
-                            (hasheq 'path path-str 'bytes-written bytes-count 'session-total new-total)))]))
+       (make-success-result
+        (list (format "Wrote ~a bytes to ~a" bytes-count path-str))
+        (hasheq 'path path-str 'bytes-written bytes-count 'session-total new-total)))]))
 
 ;; path-only imported from util/path-helpers.rkt


### PR DESCRIPTION
Addresses #2111.

fix: per-session write budget isolation (F4) (#2111)

Wave 1 of v0.21.5 — addresses F4 from audit.

Change session-bytes-written from module-global (box 0) to
(make-parameter (box 0)) so each session gets its own write tracker.

New export: init-session-writes! — call from session lifecycle to
reset the parameter to a fresh box. This ensures per-session isolation
in TUI multi-session runtime.

Tests: 2 new F4 tests verifying fresh counter after init-session-writes!.