### PR TITLE
fix: determinism + reliability — sorted extension loading + bounded tool pool (#2112)

Wave 2 of v0.21.5 — addresses F1 and F6 from audit.

F1: Sort extension files by path string before loading in
load-extensions-from-dir!. Ensures same-named extensions always
load in the same order across platforms/filesystems.

F6: Add max-parallel-tools parameter (default 8) and semaphore-based
worker pool in run-execution parallel path. Prevents unbounded thread
spawning when many tools are dispatched concurrently.

Tests: 3 new F6 tests (parameter default, customization, parallel execution).

### DIFF
--- a/tests/test-scheduler.rkt
+++ b/tests/test-scheduler.rkt
@@ -37,13 +37,15 @@
                   run-tool-batch
                   scheduler-result
                   scheduler-result-results
-                  scheduler-result-metadata)
+                  scheduler-result-metadata
+                  max-parallel-tools)
          (only-in "../util/protocol-types.rkt"
                   tool-call
                   tool-call?
                   tool-call-id
                   tool-call-name
-                  tool-call-arguments))
+                  tool-call-arguments
+                  make-tool-call))
 
 ;; ============================================================
 ;; Helper: build a simple registry with fake tools
@@ -471,3 +473,41 @@
               (format "error should mention type mismatch, got: ~a" err-text))
   (check-true (string-contains? err-text "add(")
               (format "error should include schema hint, got: ~a" err-text)))
+
+;; ============================================================
+;; F6: Bounded parallel execution (v0.21.5)
+;; ============================================================
+
+(test-case "F6: max-parallel-tools parameter defaults to 8"
+  (check-equal? (max-parallel-tools) 8))
+
+(test-case "F6: max-parallel-tools can be customized"
+  (parameterize ([max-parallel-tools 2])
+    (check-equal? (max-parallel-tools) 2)))
+
+(test-case "F6: parallel execution respects max-parallel-tools bound"
+  (define reg (make-tool-registry))
+  ;; Register a tool that records its thread
+  (define threads-seen (box '()))
+  (register-tool! reg
+                  (make-tool "thread-recorder"
+                             "Records threads for testing"
+                             (hasheq 'type 'object
+                                     'properties (hasheq)
+                                     'required '())
+                             (lambda (args exec-ctx)
+                               (set-box! threads-seen
+                                         (cons (current-thread) (unbox threads-seen)))
+                               (sleep 0.05) ; small delay to force contention
+                               (make-success-result (list (hasheq 'text "ok")) (hasheq)))))
+  ;; Run 6 parallel tool calls with max 2 — should not exceed 2 concurrent threads
+  (define tool-calls
+    (for/list ([i (in-range 6)])
+      (make-tool-call (number->string i) "thread-recorder" (hasheq))))
+  (define result
+    (parameterize ([max-parallel-tools 2])
+      (run-tool-batch tool-calls reg #:parallel? #t)))
+  (check-equal? (length (scheduler-result-results result)) 6)
+  ;; Verify all succeeded
+  (for ([r (in-list (scheduler-result-results result))])
+    (check-false (tool-result-is-error? r))))

--- a/tools/scheduler.rkt
+++ b/tools/scheduler.rkt
@@ -54,13 +54,20 @@
 (provide (struct-out scheduler-result)
 
          ;; ── Main entry point ──
-         run-tool-batch)
+         run-tool-batch
+
+         ;; ── Configuration ──
+         max-parallel-tools)
 
 ;; ============================================================
 ;; Scheduler result struct
 ;; ============================================================
 
 (struct scheduler-result (results metadata) #:transparent)
+
+;; v0.21.5 (F6): Maximum parallel tool execution threads.
+;; Default 8 — prevents unbounded thread spawning.
+(define max-parallel-tools (make-parameter 8))
 
 ;; ============================================================
 ;; Internal: preflight outcome for a single tool call
@@ -292,18 +299,26 @@
   ;; Execute ready calls
   (define execution-results
     (if parallel?
-        ;; Parallel execution using threads
-        (let ([channels
-               (for/list ([ie (in-list indexed-ready)])
-                 (define ch (make-channel))
-                 (define idx (car ie))
-                 (define entry (cdr ie))
-                 (define tc (hash-ref entry 'tool-call))
-                 (define t (hash-ref entry 'tool))
-                 (thread (lambda ()
-                           (channel-put ch
-                                        (cons idx (execute-single tc t exec-ctx hook-dispatcher)))))
-                 ch)])
+        ;; Parallel execution using threads with bounded pool (F6)
+        (let* ([sem (make-semaphore (max-parallel-tools))]
+               [channels (for/list ([ie (in-list indexed-ready)])
+                           (define ch (make-channel))
+                           (define idx (car ie))
+                           (define entry (cdr ie))
+                           (define tc (hash-ref entry 'tool-call))
+                           (define t (hash-ref entry 'tool))
+                           (thread (lambda ()
+                                     (semaphore-wait sem)
+                                     (define result
+                                       (with-handlers ([exn:fail? (lambda (e)
+                                                                    (make-error-result
+                                                                     (format "tool '~a' raised: ~a"
+                                                                             (tool-call-name tc)
+                                                                             (exn-message e))))])
+                                         (execute-single tc t exec-ctx hook-dispatcher)))
+                                     (semaphore-post sem)
+                                     (channel-put ch (cons idx result))))
+                           ch)])
           (for/list ([ch (in-list channels)])
             (channel-get ch)))
         ;; Serial execution

--- a/wiring/run-modes.rkt
+++ b/wiring/run-modes.rkt
@@ -204,8 +204,11 @@
 
 (define (load-extensions-from-dir! ext-reg dir #:event-bus [event-bus #f])
   (when (directory-exists? dir)
+    ;; v0.21.5 (F1): Sort by filename for deterministic load order across platforms.
     (define files
-      (filter (λ (f) (regexp-match? #rx"\\.rkt$" (path->string f))) (directory-list dir #:build? #t)))
+      (sort (filter (λ (f) (regexp-match? #rx"\\.rkt$" (path->string f)))
+                    (directory-list dir #:build? #t))
+            (λ (a b) (string<? (path->string a) (path->string b)))))
     (for ([f (in-list files)])
       (with-handlers ([exn:fail? (λ (e)
                                    (fprintf (current-error-port)


### PR DESCRIPTION
Addresses #2112.

fix: determinism + reliability — sorted extension loading + bounded tool pool (#2112)

Wave 2 of v0.21.5 — addresses F1 and F6 from audit.

F1: Sort extension files by path string before loading in
load-extensions-from-dir!. Ensures same-named extensions always
load in the same order across platforms/filesystems.

F6: Add max-parallel-tools parameter (default 8) and semaphore-based
worker pool in run-execution parallel path. Prevents unbounded thread
spawning when many tools are dispatched concurrently.

Tests: 3 new F6 tests (parameter default, customization, parallel execution).