### PR TITLE
feat: wire /replan, /skip, /reset commands through execute-command (F1) (#2119)

- Export cmd-replan, cmd-skip, cmd-reset from gsd/core.rkt
- Register /replan, /skip, /reset in register-gsd-commands
- Wire dispatch in handle-execute-command for new commands
- /skip marks wave as DEFERRED on disk via mark-wave-status!
- Add extract-cmd-args helper for argument extraction
- Add 6 new tests for command wiring (replan, skip, reset, unknown)
- All 332 GSD tests pass

Wave 1 of v0.21.6 GSD Architecture Remediation.

### DIFF
--- a/extensions/gsd-planning.rkt
+++ b/extensions/gsd-planning.rkt
@@ -37,6 +37,8 @@
          ;; v0.21.0 new modules
          "gsd/state-machine.rkt"
          "gsd/core.rkt"
+         ;; v0.21.6: direct command handlers for wiring
+         (only-in "gsd/core.rkt" cmd-replan cmd-skip cmd-reset)
 
          "gsd/plan-types.rkt"
          "gsd/plan-validator.rkt"
@@ -78,6 +80,18 @@
          gsd-event-bus
          set-gsd-event-bus!
          emit-gsd-event!)
+
+;; ============================================================
+;; Argument extraction helper
+;; ============================================================
+
+(define (extract-cmd-args input-text)
+  (define trimmed (string-trim input-text))
+  (define parts
+    (and (> (string-length trimmed) 0) (char=? (string-ref trimmed 0) #\/) (string-split trimmed)))
+  (if (and (pair? parts) (> (length parts) 1))
+      (string-trim (string-join (cdr parts) " "))
+      ""))
 
 ;; ============================================================
 ;; Event emission helper
@@ -416,6 +430,9 @@
                          'general
                          '()
                          '("implement" "i"))
+  (ext-register-command! ctx "/replan" "Return to planning phase" 'general '() '())
+  (ext-register-command! ctx "/skip" "Skip a wave (usage: /skip N)" 'general '() '())
+  (ext-register-command! ctx "/reset" "Reset GSD to idle state" 'general '() '())
   (ext-register-command! ctx "/gsd" "Show GSD workflow status" 'general '() '())
   (hook-pass #f))
 
@@ -427,6 +444,21 @@
   (cond
     [(member cmd '("/go" "/implement" "/i")) (handle-go-command base-dir input-text)]
     [(equal? cmd "/gsd") (handle-gsd-status)]
+    [(equal? cmd "/replan")
+     (define result (cmd-replan))
+     (emit-gsd-event! "gsd.mode.changed" (hasheq 'mode 'exploring))
+     (hook-amend (hasheq 'text (hash-ref result 'message "")))]
+    [(equal? cmd "/skip")
+     (define args-text (extract-cmd-args input-text))
+     (define result (cmd-skip args-text))
+     ;; Mark wave as DEFERRED on disk if skip succeeded
+     (when (and (hash-ref result 'success #f) base-dir (string->number (string-trim args-text)))
+       (mark-wave-status! base-dir (string->number (string-trim args-text)) "DEFERRED"))
+     (hook-amend (hasheq 'text (hash-ref result 'message "")))]
+    [(equal? cmd "/reset")
+     (define result (cmd-reset))
+     (emit-gsd-event! "gsd.mode.changed" (hasheq 'mode 'idle))
+     (hook-amend (hasheq 'text (hash-ref result 'message "")))]
     [else (handle-artifact-command cmd input-text base-dir payload)]))
 
 ;; Helper: Build wave docs summary for plan prompt

--- a/extensions/gsd/core.rkt
+++ b/extensions/gsd/core.rkt
@@ -25,6 +25,10 @@
          gsd-tool-guard
          gsd-write-guard
          gsd-show-status
+         ;; Individual command handlers for direct wiring
+         cmd-replan
+         cmd-skip
+         cmd-reset
          ;; Command names for registration
          gsd-commands)
 

--- a/tests/test-gsd-planning.rkt
+++ b/tests/test-gsd-planning.rkt
@@ -792,3 +792,64 @@
 ;; ============================================================
 ;; Wave progress tracking tests (v0.21.2 W1)
 ;; ============================================================
+
+;; ============================================================
+;; W1: Command Unification — wired dispatch tests (v0.21.6)
+;; ============================================================
+
+(test-case "W1: /replan wired through execute-command from plan-written"
+  (reset-all-gsd-state!)
+  (set-gsd-mode! 'planning)
+  (set-gsd-mode! 'plan-written)
+  (define handler (hash-ref (extension-hooks gsd-planning-extension) 'execute-command))
+  (define result (handler (hasheq 'command "/replan" 'input "/replan")))
+  (check-equal? (hook-result-action result) 'amend)
+  (check-true (string-contains? (hash-ref (hook-result-payload result) 'text) "Re-planning"))
+  (reset-all-gsd-state!))
+
+(test-case "W1: /replan from idle returns error through execute-command"
+  (reset-all-gsd-state!)
+  (define handler (hash-ref (extension-hooks gsd-planning-extension) 'execute-command))
+  (define result (handler (hasheq 'command "/replan" 'input "/replan")))
+  (check-equal? (hook-result-action result) 'amend)
+  (check-true (string-contains? (hash-ref (hook-result-payload result) 'text) "Cannot re-plan"))
+  (reset-all-gsd-state!))
+
+(test-case "W1: /skip wired through execute-command during executing"
+  (reset-all-gsd-state!)
+  (set-gsd-mode! 'planning)
+  (set-gsd-mode! 'plan-written)
+  (set-gsd-mode! 'executing)
+  (define handler (hash-ref (extension-hooks gsd-planning-extension) 'execute-command))
+  (define result (handler (hasheq 'command "/skip" 'input "/skip 1")))
+  (check-equal? (hook-result-action result) 'amend)
+  (check-true (string-contains? (hash-ref (hook-result-payload result) 'text) "skipped"))
+  (reset-all-gsd-state!))
+
+(test-case "W1: /skip without arg returns usage through execute-command"
+  (reset-all-gsd-state!)
+  (set-gsd-mode! 'planning)
+  (set-gsd-mode! 'plan-written)
+  (set-gsd-mode! 'executing)
+  (define handler (hash-ref (extension-hooks gsd-planning-extension) 'execute-command))
+  (define result (handler (hasheq 'command "/skip" 'input "/skip")))
+  (check-equal? (hook-result-action result) 'amend)
+  (check-true (string-contains? (hash-ref (hook-result-payload result) 'text) "Usage"))
+  (reset-all-gsd-state!))
+
+(test-case "W1: /reset wired through execute-command"
+  (reset-all-gsd-state!)
+  (set-gsd-mode! 'planning)
+  (set-gsd-mode! 'plan-written)
+  (define handler (hash-ref (extension-hooks gsd-planning-extension) 'execute-command))
+  (define result (handler (hasheq 'command "/reset" 'input "/reset")))
+  (check-equal? (hook-result-action result) 'amend)
+  (check-true (string-contains? (hash-ref (hook-result-payload result) 'text) "reset"))
+  (reset-all-gsd-state!))
+
+(test-case "W1: unknown command returns hook-pass through execute-command"
+  (reset-all-gsd-state!)
+  (define handler (hash-ref (extension-hooks gsd-planning-extension) 'execute-command))
+  (define result (handler (hasheq 'command "/unknown-cmd" 'input "/unknown-cmd")))
+  (check-equal? (hook-result-action result) 'pass)
+  (reset-all-gsd-state!))


### PR DESCRIPTION
Addresses #2119.

feat: wire /replan, /skip, /reset commands through execute-command (F1) (#2119)

- Export cmd-replan, cmd-skip, cmd-reset from gsd/core.rkt
- Register /replan, /skip, /reset in register-gsd-commands
- Wire dispatch in handle-execute-command for new commands
- /skip marks wave as DEFERRED on disk via mark-wave-status!
- Add extract-cmd-args helper for argument extraction
- Add 6 new tests for command wiring (replan, skip, reset, unknown)
- All 332 GSD tests pass

Wave 1 of v0.21.6 GSD Architecture Remediation.