### PR TITLE
feat: unified parse-wave-content + strict file validation (F3+F2) (#2120)

- Add parse-wave-content to plan-types.rkt as single source of truth
  for wave field extraction (root-cause, files, verify, done criteria)
- Refactor parse-wave-section to use unified parser
- Replace extract-files-from-content and extract-verify-from-content
  in wave-executor.rkt to delegate to parse-wave-content
- Upgrade "no files" validation from warning to error (F2)
- Fix /go edit-limit test to include files in plan (now required)
- Add 5 new tests for unified parser
- Update 1 test for validation enforcement change
- All 337 GSD tests pass

Wave 2 of v0.21.6 GSD Architecture Remediation.

### DIFF
--- a/extensions/gsd/plan-types.rkt
+++ b/extensions/gsd/plan-types.rkt
@@ -77,27 +77,20 @@
              [end wave-end-idxs])
     (parse-wave-section (take (drop lines start) (add1 (- end start))))))
 
-;; Parse a single wave section (list of lines, first is header).
-(define (parse-wave-section lines)
-  (define header (car lines))
-  (define body-lines (cdr lines))
-  ;; Extract index and title from header
-  (define header-match (regexp-match #rx"^## +[Ww]ave +([0-9]+) *: *(.+)$" header))
-  (define idx
-    (if header-match
-        (string->number (cadr header-match))
-        0))
-  (define title
-    (if header-match
-        (string-trim (caddr header-match))
-        ""))
-  ;; Extract fields from bullet points
+;; Parse structured fields from wave document content.
+;; Handles both bullet-style and heading-style formats.
+;; Single source of truth for field extraction (F3 consolidation).
+(define (parse-wave-content content)
+  (define lines (string-split content "\n"))
+  (define n (length lines))
   (define root-cause "")
   (define files '())
   (define verify-cmd "")
   (define done-criteria '())
-  (for ([line body-lines])
+  (for ([line lines]
+        [i (in-naturals)])
     (cond
+      ;; Bullet-style fields
       [(regexp-match #rx"^- +[Rr]oot *[Cc]ause *: *(.+)$" line)
        =>
        (lambda (m) (set! root-cause (string-trim (cadr m))))]
@@ -109,8 +102,42 @@
        (lambda (m) (set! verify-cmd (string-trim (cadr m))))]
       [(regexp-match #rx"^- +[Dd]one *: *(.+)$" line)
        =>
-       (lambda (m) (set! done-criteria (append done-criteria (list (string-trim (cadr m))))))]))
-  (gsd-wave idx title 'pending root-cause files '() verify-cmd done-criteria))
+       (lambda (m) (set! done-criteria (append done-criteria (list (string-trim (cadr m))))))]
+      ;; Heading-style: ## Verify — collect non-empty, non-backtick lines after heading
+      [(string-prefix? (string-trim line) "## Verify")
+       (define after
+         (for/list ([j (in-range (add1 i) (min n (+ i 5)))]
+                    #:when (and (> (string-length (string-trim (list-ref lines j))) 0)
+                                (not (string-contains? (list-ref lines j) "```"))))
+           (string-trim (list-ref lines j))))
+       (when (and (string=? verify-cmd "") (not (null? after)))
+         (set! verify-cmd (string-join after "; ")))]))
+  (hasheq 'root-cause root-cause 'files files 'verify verify-cmd 'done done-criteria))
+
+;; Parse a single wave section (list of lines, first is header).
+;; Uses unified parse-wave-content for field extraction.
+(define (parse-wave-section lines)
+  (define header (car lines))
+  (define body-lines (cdr lines))
+  (define header-match (regexp-match #rx"^## +[Ww]ave +([0-9]+) *: *(.+)$" header))
+  (define idx
+    (if header-match
+        (string->number (cadr header-match))
+        0))
+  (define title
+    (if header-match
+        (string-trim (caddr header-match))
+        ""))
+  ;; Use unified parser
+  (define fields (parse-wave-content (string-join body-lines "\n")))
+  (gsd-wave idx
+            title
+            'pending
+            (hash-ref fields 'root-cause "")
+            (hash-ref fields 'files '())
+            '()
+            (hash-ref fields 'verify "")
+            (hash-ref fields 'done '())))
 
 ;; ============================================================
 ;; Validation
@@ -231,6 +258,7 @@
 
          ;; Parsing
          parse-waves-from-markdown
+         parse-wave-content
 
          ;; Validation
          validation-result

--- a/extensions/gsd/plan-validator.rkt
+++ b/extensions/gsd/plan-validator.rkt
@@ -8,7 +8,7 @@
 ;; Error rules (block /go):
 ;;   - Plan has < 1 wave
 ;;   - Wave missing title
-;;   - Wave has no files (was warning, upgraded to error per spec)
+;;   - Wave has no files (F2: upgraded from warning to error)
 ;;
 ;; Warning rules (display but allow):
 ;;   - Wave missing verify command
@@ -42,9 +42,9 @@
     ;; Warning: missing title (plans may omit title after wave number)
     (when (string=? (gsd-wave-title w) "")
       (set! warnings (cons (format "~a: no explicit title" prefix) warnings)))
-    ;; Warning: no file references (often implicit in plan text)
+    ;; Error: no file references — waves must specify files to modify
     (when (null? (gsd-wave-files w))
-      (set! warnings (cons (format "~a: no explicit file references" prefix) warnings)))
+      (set! errors (cons (format "~a: no files — wave must specify files to modify" prefix) errors)))
     ;; Warning: no verify command
     (when (or (not (gsd-wave-verify w)) (string=? (gsd-wave-verify w) ""))
       (set! warnings (cons (format "~a: no verify command" prefix) warnings)))

--- a/extensions/gsd/wave-executor.rkt
+++ b/extensions/gsd/wave-executor.rkt
@@ -200,30 +200,7 @@
     [else 'pending]))
 
 (define (extract-files-from-content content)
-  (define lines (string-split content "\n"))
-  (for/list ([line lines]
-             #:when (string-contains? (string-trim line) "- File:"))
-    (define m (regexp-match-positions #rx"- File:" line))
-    (string-trim (substring line (cdar m)))))
+  (hash-ref (parse-wave-content content) 'files '()))
 
 (define (extract-verify-from-content content)
-  (define lines (string-split content "\n"))
-  (define n (length lines))
-  ;; Look for ## Verify heading and capture code block after it
-  (or (for/first ([i (in-range n)]
-                  #:when (string-contains? (string-trim (list-ref lines i)) "## Verify"))
-        ;; Collect non-empty, non-backtick lines after the heading
-        (define after
-          (for/list ([j (in-range (add1 i) (min n (+ i 5)))]
-                     #:when (and (> (string-length (string-trim (list-ref lines j))) 0)
-                                 (not (string-contains? (list-ref lines j) "```"))))
-            (string-trim (list-ref lines j))))
-        (if (null? after)
-            ""
-            (string-join after "; ")))
-      ;; Fallback: look for - Verify: inline
-      (for/first ([line lines]
-                  #:when (string-contains? (string-trim line) "- Verify:"))
-        (define m (regexp-match-positions #rx"- Verify:" line))
-        (string-trim (substring line (cdar m))))
-      ""))
+  (hash-ref (parse-wave-content content) 'verify ""))

--- a/tests/test-gsd-plan-types.rkt
+++ b/tests/test-gsd-plan-types.rkt
@@ -223,3 +223,41 @@
   (define w0 (gsd-wave 0 "A" 'completed "" '("a") '() "t" '()))
   (define p (gsd-plan (list w0) "" '() '()))
   (check-false (plan-next-pending-wave p)))
+
+;; ============================================================
+;; W2: Unified parse-wave-content tests (F3 consolidation)
+;; ============================================================
+
+(test-case "W2: parse-wave-content extracts bullet-style fields"
+  (define content "- Root cause: missing import\n- File: q/foo.rkt\n- File: q/bar.rkt\n- Verify: raco test q/tests/foo.rkt\n- Done: tests pass")
+  (define result (parse-wave-content content))
+  (check-equal? (hash-ref result 'root-cause) "missing import")
+  (check-equal? (hash-ref result 'files) '("q/foo.rkt" "q/bar.rkt"))
+  (check-equal? (hash-ref result 'verify) "raco test q/tests/foo.rkt")
+  (check-equal? (hash-ref result 'done) '("tests pass")))
+
+(test-case "W2: parse-wave-content extracts heading-style ## Verify"
+  (define content "## Verify\nbash test.sh\n")
+  (define result (parse-wave-content content))
+  (check-equal? (hash-ref result 'verify) "bash test.sh"))
+
+(test-case "W2: parse-wave-content captures non-fence lines in ## Verify"
+  (define content "## Verify\n```bash\nraco test\n```\n")
+  (define result (parse-wave-content content))
+  ;; raco test is captured (not a fence line), fence lines are skipped
+  (check-equal? (hash-ref result 'verify) "raco test"))
+
+(test-case "W2: parse-wave-content empty content returns empty fields"
+  (define result (parse-wave-content ""))
+  (check-equal? (hash-ref result 'root-cause) "")
+  (check-equal? (hash-ref result 'files) '())
+  (check-equal? (hash-ref result 'verify) "")
+  (check-equal? (hash-ref result 'done) '()))
+
+(test-case "W2: parse-wave-content mixed bullet + heading formats"
+  (define content "- Root cause: bug\n- Verify: inline check\n## Verify\nraco test\n- File: q/baz.rkt")
+  (define result (parse-wave-content content))
+  (check-equal? (hash-ref result 'root-cause) "bug")
+  (check-equal? (hash-ref result 'files) '("q/baz.rkt"))
+  ;; bullet-style - Verify: takes priority since it appears first
+  (check-equal? (hash-ref result 'verify) "inline check"))

--- a/tests/test-gsd-plan-validator.rkt
+++ b/tests/test-gsd-plan-validator.rkt
@@ -51,11 +51,11 @@
   (check-true (validation-valid? result))
   (check-true (ormap (lambda (w) (string-contains? w "title")) (validation-warnings result))))
 
-(test-case "wave without files → warning, not error"
+(test-case "wave without files → error (F2: upgraded from warning)"
   (define plan (gsd-plan (list (gsd-wave 0 "Fix" 'pending "" '() '() "test" '())) "" '() '()))
   (define result (validate-plan-strict plan))
-  (check-true (validation-valid? result))
-  (check-true (ormap (lambda (w) (string-contains? w "file")) (validation-warnings result))))
+  (check-false (validation-valid? result))
+  (check-true (ormap (lambda (e) (string-contains? e "no files")) (validation-errors result))))
 
 ;; ============================================================
 ;; Warning cases (allow /go)

--- a/tests/test-gsd-planning-integration.rkt
+++ b/tests/test-gsd-planning-integration.rkt
@@ -130,7 +130,7 @@
      (with-temp-planning-dir
       (lambda (dir)
         (call-with-output-file (build-path dir ".planning" "PLAN.md")
-                               (lambda (out) (display "## Wave 0\n" out))
+                               (lambda (out) (display "## Wave 0: Test\n- File: q/test.rkt\n- Verify: raco test\n" out))
                                #:exists 'truncate)
         (check-equal? (current-max-old-text-len) 500 "default should be 500")
         (define handler (hash-ref (extension-hooks gsd-planning-extension) 'execute-command))


### PR DESCRIPTION
Addresses #2120.

feat: unified parse-wave-content + strict file validation (F3+F2) (#2120)

- Add parse-wave-content to plan-types.rkt as single source of truth
  for wave field extraction (root-cause, files, verify, done criteria)
- Refactor parse-wave-section to use unified parser
- Replace extract-files-from-content and extract-verify-from-content
  in wave-executor.rkt to delegate to parse-wave-content
- Upgrade "no files" validation from warning to error (F2)
- Fix /go edit-limit test to include files in plan (now required)
- Add 5 new tests for unified parser
- Update 1 test for validation enforcement change
- All 337 GSD tests pass

Wave 2 of v0.21.6 GSD Architecture Remediation.