### PR TITLE
feat: consolidate wave state into FSM + wire executor lifecycle (F4+F5) (#2121)

- Move wave-tracking boxes from gsd-planning-state.rkt into state-machine.rkt
  as a unified hash (mode, wave-executor, total-waves, current-wave, completed-waves)
- Add semaphore-protected wave state accessors (gsm-wave-executor,
  gsm-set-wave-executor!, gsm-total-waves, gsm-mark-wave-complete!, etc.)
- Simplify gsd-planning-state.rkt to thin accessor layer delegating to FSM
- Store wave executor in FSM during /go, clear on transition away from executing
- Wire wave-skip! executor call in /skip handler
- Fix gsd-snapshot to return raw FSM state (mode, not current)
- Fix gsd/core.rkt to use gsm-history directly instead of snapshot
- Add 6 new tests for wave state in FSM
- All 343 GSD tests pass

Wave 3 of v0.21.6 GSD Architecture Remediation.

### DIFF
--- a/extensions/gsd-planning-state.rkt
+++ b/extensions/gsd-planning-state.rkt
@@ -6,8 +6,7 @@
 ;; Only wave tracking
 ;; and mode delegation remain.
 
-(require racket/set
-         "gsd/state-machine.rkt")
+(require "gsd/state-machine.rkt")
 
 (provide gsd-mode
          gsd-mode?
@@ -40,9 +39,6 @@
 
 (define pinned-dir-box (box #f))
 (define edit-limit-box (box 500))
-(define completed-waves-box (box (set)))
-(define total-waves-box (box 0))
-(define current-wave-box (box 0))
 (define gsd-event-bus-box (box #f))
 
 ;; ============================================================
@@ -95,40 +91,25 @@
   (call-with-semaphore state-sem (lambda () (set-box! edit-limit-box v))))
 
 ;; ============================================================
-;; Wave tracking
+;; Wave tracking (delegated to state machine — F4 consolidation)
 ;; ============================================================
 
 (define (completed-waves)
-  (call-with-semaphore state-sem (lambda () (set-copy (unbox completed-waves-box)))))
-
+  (gsm-completed-waves))
 (define (total-waves)
-  (call-with-semaphore state-sem (lambda () (unbox total-waves-box))))
-
+  (gsm-total-waves))
 (define (set-total-waves! n)
-  (call-with-semaphore state-sem (lambda () (set-box! total-waves-box n))))
-
+  (gsm-set-total-waves! n))
 (define (mark-wave-complete! idx)
-  (call-with-semaphore state-sem
-                       (lambda ()
-                         (set-box! completed-waves-box (set-add (unbox completed-waves-box) idx)))))
-
+  (gsm-mark-wave-complete! idx))
 (define (wave-complete? idx)
-  (call-with-semaphore state-sem (lambda () (set-member? (unbox completed-waves-box) idx))))
-
+  (gsm-wave-complete? idx))
 (define (current-wave-index)
-  (call-with-semaphore state-sem (lambda () (unbox current-wave-box))))
-
+  (gsm-current-wave))
 (define (set-current-wave-index! n)
-  (call-with-semaphore state-sem (lambda () (set-box! current-wave-box n))))
-
+  (gsm-set-current-wave! n))
 (define (next-pending-wave)
-  (call-with-semaphore state-sem
-                       (lambda ()
-                         (define tw (unbox total-waves-box))
-                         (define cw (unbox completed-waves-box))
-                         (for/first ([i (in-range tw)]
-                                     #:when (not (set-member? cw i)))
-                           i))))
+  (gsm-next-pending-wave))
 
 ;; ============================================================
 ;; Event bus
@@ -153,20 +134,19 @@
                                  (unbox pinned-dir-box)
                                  'edit-limit
                                  (unbox edit-limit-box)
-                                 'completed-waves
-                                 (set-copy (unbox completed-waves-box))
                                  'total-waves
-                                 (unbox total-waves-box)
+                                 (gsm-total-waves)
                                  'current-wave
-                                 (unbox current-wave-box)))))
+                                 (gsm-current-wave)
+                                 'completed-waves
+                                 (gsm-completed-waves)
+                                 'wave-executor
+                                 (and (gsm-wave-executor) #t)))))
 
 (define (reset-all-gsd-state!)
   (call-with-semaphore state-sem
                        (lambda ()
-                         (gsm-reset!)
+                         (reset-gsm!)
                          (set-box! pinned-dir-box #f)
                          (set-box! edit-limit-box 500)
-                         (set-box! completed-waves-box (set))
-                         (set-box! total-waves-box 0)
-                         (set-box! current-wave-box 0)
                          (set-box! gsd-event-bus-box #f))))

--- a/extensions/gsd-planning.rkt
+++ b/extensions/gsd-planning.rkt
@@ -451,9 +451,14 @@
     [(equal? cmd "/skip")
      (define args-text (extract-cmd-args input-text))
      (define result (cmd-skip args-text))
-     ;; Mark wave as DEFERRED on disk if skip succeeded
-     (when (and (hash-ref result 'success #f) base-dir (string->number (string-trim args-text)))
-       (mark-wave-status! base-dir (string->number (string-trim args-text)) "DEFERRED"))
+     ;; Mark wave as DEFERRED on disk + executor if skip succeeded
+     (when (and (hash-ref result 'success #f) base-dir)
+       (define idx (and (string->number (string-trim args-text))))
+       (when idx
+         (mark-wave-status! base-dir idx "DEFERRED")
+         (define exec (gsm-wave-executor))
+         (when exec
+           (wave-skip! exec idx))))
      (hook-amend (hasheq 'text (hash-ref result 'message "")))]
     [(equal? cmd "/reset")
      (define result (cmd-reset))
@@ -512,6 +517,7 @@
           (set-total-waves! (add1 (apply max wave-indices))))
         (set-current-wave-index! 0)
         (define executor (make-wave-executor plan))
+        (gsm-set-wave-executor! executor)
         (define state-content (read-planning-artifact base-dir "STATE"))
         (define state-note
           (if state-content

--- a/extensions/gsd/core.rkt
+++ b/extensions/gsd/core.rkt
@@ -253,13 +253,12 @@
 (define (gsd-show-status)
   (define mode (gsm-current))
   (define valid-next (gsm-valid-next-states))
-  (define snapshot (gsm-snapshot))
   (hasheq
    'mode
    mode
    'valid-next-states
    valid-next
    'history-length
-   (length (hash-ref snapshot 'history))
+   (length (gsm-history))
    'message
    (format "GSD Status: ~a | Next: ~a" mode (string-join (map symbol->string valid-next) ", "))))

--- a/extensions/gsd/state-machine.rkt
+++ b/extensions/gsd/state-machine.rkt
@@ -12,7 +12,8 @@
 ;; All state is semaphore-protected for thread safety.
 
 (require racket/contract
-         racket/match)
+         racket/match
+         racket/set)
 
 ;; States
 (provide gsm-state?
@@ -36,7 +37,18 @@
          gsm-snapshot
          reset-gsm!
          ;; History
-         gsm-history)
+         gsm-history
+         ;; Wave state (F4)
+         gsm-wave-executor
+         gsm-set-wave-executor!
+         gsm-total-waves
+         gsm-set-total-waves!
+         gsm-current-wave
+         gsm-set-current-wave!
+         gsm-completed-waves
+         gsm-mark-wave-complete!
+         gsm-wave-complete?
+         gsm-next-pending-wave)
 
 ;; ============================================================
 ;; States and transitions
@@ -89,7 +101,9 @@
 ;; ============================================================
 
 (define gsm-sem (make-semaphore 1))
-(define gsm-state-box (box 'idle))
+;; State is a hash: 'mode, 'wave-executor, 'total-waves, 'current-wave, 'completed-waves
+(define gsm-state-box
+  (box (hasheq 'mode 'idle 'wave-executor #f 'total-waves 0 'current-wave 0 'completed-waves (set))))
 (define gsm-history-box (box '()))
 
 ;; ============================================================
@@ -97,7 +111,7 @@
 ;; ============================================================
 
 (define (gsm-current)
-  (call-with-semaphore gsm-sem (lambda () (unbox gsm-state-box))))
+  (call-with-semaphore gsm-sem (lambda () (hash-ref (unbox gsm-state-box) 'mode))))
 
 (define (gsm-history)
   (call-with-semaphore gsm-sem (lambda () (reverse (unbox gsm-history-box)))))
@@ -106,11 +120,17 @@
   (call-with-semaphore
    gsm-sem
    (lambda ()
-     (define current (unbox gsm-state-box))
+     (define current (hash-ref (unbox gsm-state-box) 'mode))
      (cond
        [(not (gsm-state? target)) (err-result (format "invalid state: ~a" target) current target)]
        [(valid-transition? current target)
-        (set-box! gsm-state-box target)
+        ;; Clear executor when leaving executing mode
+        (define state (unbox gsm-state-box))
+        (define state*
+          (if (and (eq? current 'executing) (not (eq? target 'executing)))
+              (hash-set state 'wave-executor #f)
+              state))
+        (set-box! gsm-state-box (hash-set state* 'mode target))
         (set-box! gsm-history-box
                   (cons (list current target (current-seconds)) (unbox gsm-history-box)))
         (ok-result current target)]
@@ -121,29 +141,30 @@
          target)]))))
 
 (define (gsm-reset!)
-  (call-with-semaphore gsm-sem
-                       (lambda ()
-                         (define old (unbox gsm-state-box))
-                         (set-box! gsm-state-box 'idle)
-                         (set-box! gsm-history-box
-                                   (cons (list old 'idle (current-seconds)) (unbox gsm-history-box)))
-                         (ok-result old 'idle))))
+  (call-with-semaphore
+   gsm-sem
+   (lambda ()
+     (define old (hash-ref (unbox gsm-state-box) 'mode))
+     (set-box! gsm-state-box (hash-set* (unbox gsm-state-box) 'mode 'idle 'wave-executor #f))
+     (set-box! gsm-history-box (cons (list old 'idle (current-seconds)) (unbox gsm-history-box)))
+     (ok-result old 'idle))))
 
 (define (reset-gsm!)
-  (call-with-semaphore gsm-sem
-                       (lambda ()
-                         (set-box! gsm-state-box 'idle)
-                         (set-box! gsm-history-box '())
-                         (void))))
+  (call-with-semaphore
+   gsm-sem
+   (lambda ()
+     (set-box!
+      gsm-state-box
+      (hasheq 'mode 'idle 'wave-executor #f 'total-waves 0 'current-wave 0 'completed-waves (set)))
+     (set-box! gsm-history-box '())
+     (void))))
 
 (define (gsm-valid-next-states)
   (define current (gsm-current))
   (valid-targets current))
 
 (define (gsm-snapshot)
-  (call-with-semaphore
-   gsm-sem
-   (lambda () (hasheq 'current (unbox gsm-state-box) 'history (reverse (unbox gsm-history-box))))))
+  (call-with-semaphore gsm-sem (lambda () (unbox gsm-state-box))))
 
 ;; ============================================================
 ;; Tool access
@@ -169,3 +190,56 @@
   (for/list ([t TRANSITIONS]
              #:when (eq? (car t) from))
     (cdr t)))
+
+;; ============================================================
+;; Wave state accessors (F4: consolidated from gsd-planning-state)
+;; ============================================================
+
+(define (gsm-wave-executor)
+  (call-with-semaphore gsm-sem (lambda () (hash-ref (unbox gsm-state-box) 'wave-executor))))
+
+(define (gsm-set-wave-executor! exec)
+  (call-with-semaphore
+   gsm-sem
+   (lambda () (set-box! gsm-state-box (hash-set (unbox gsm-state-box) 'wave-executor exec)))))
+
+(define (gsm-total-waves)
+  (call-with-semaphore gsm-sem (lambda () (hash-ref (unbox gsm-state-box) 'total-waves))))
+
+(define (gsm-set-total-waves! n)
+  (call-with-semaphore gsm-sem
+                       (lambda ()
+                         (set-box! gsm-state-box (hash-set (unbox gsm-state-box) 'total-waves n)))))
+
+(define (gsm-current-wave)
+  (call-with-semaphore gsm-sem (lambda () (hash-ref (unbox gsm-state-box) 'current-wave))))
+
+(define (gsm-set-current-wave! n)
+  (call-with-semaphore gsm-sem
+                       (lambda ()
+                         (set-box! gsm-state-box (hash-set (unbox gsm-state-box) 'current-wave n)))))
+
+(define (gsm-completed-waves)
+  (call-with-semaphore gsm-sem (lambda () (hash-ref (unbox gsm-state-box) 'completed-waves))))
+
+(define (gsm-mark-wave-complete! idx)
+  (call-with-semaphore gsm-sem
+                       (lambda ()
+                         (define state (unbox gsm-state-box))
+                         (define completed (hash-ref state 'completed-waves))
+                         (set-box! gsm-state-box
+                                   (hash-set state 'completed-waves (set-add completed idx))))))
+
+(define (gsm-wave-complete? idx)
+  (call-with-semaphore gsm-sem
+                       (lambda ()
+                         (set-member? (hash-ref (unbox gsm-state-box) 'completed-waves) idx))))
+
+(define (gsm-next-pending-wave)
+  (call-with-semaphore gsm-sem
+                       (lambda ()
+                         (define tw (hash-ref (unbox gsm-state-box) 'total-waves))
+                         (define cw (hash-ref (unbox gsm-state-box) 'completed-waves))
+                         (for/first ([i (in-range tw)]
+                                     #:when (not (set-member? cw i)))
+                           i))))

--- a/tests/test-gsd-state-machine.rkt
+++ b/tests/test-gsd-state-machine.rkt
@@ -231,13 +231,12 @@
 ;; Snapshot
 ;; ============================================================
 
-(test-case "gsm-snapshot captures current state and history"
+(test-case "gsm-snapshot captures current state"
   (reset-gsm!)
   (gsm-transition! 'exploring)
   (gsm-transition! 'plan-written)
   (define snap (gsm-snapshot))
-  (check-eq? (hash-ref snap 'current) 'plan-written)
-  (check-true (list? (hash-ref snap 'history))))
+  (check-eq? (hash-ref snap 'mode) 'plan-written))
 
 ;; ============================================================
 ;; State predicates
@@ -302,3 +301,52 @@
   (check-false (gsm-tool-allowed? "edit"))
   (check-false (gsm-tool-allowed? "write"))
   (check-false (gsm-tool-allowed? "bash")))
+
+;; ============================================================
+;; W3: Wave state in FSM (F4 consolidation)
+;; ============================================================
+
+(test-case "W3: initial state has no executor, 0 waves"
+  (reset-gsm!)
+  (check-false (gsm-wave-executor))
+  (check-equal? (gsm-total-waves) 0)
+  (check-equal? (gsm-current-wave) 0))
+
+(test-case "W3: gsm-set-total-waves! and gsm-total-waves round-trip"
+  (reset-gsm!)
+  (gsm-set-total-waves! 5)
+  (check-equal? (gsm-total-waves) 5))
+
+(test-case "W3: gsm-mark-wave-complete! tracks completed waves"
+  (reset-gsm!)
+  (gsm-set-total-waves! 3)
+  (gsm-mark-wave-complete! 0)
+  (check-true (gsm-wave-complete? 0))
+  (check-false (gsm-wave-complete? 1)))
+
+(test-case "W3: gsm-next-pending-wave skips completed waves"
+  (reset-gsm!)
+  (gsm-set-total-waves! 3)
+  (gsm-mark-wave-complete! 0)
+  (gsm-mark-wave-complete! 1)
+  (check-equal? (gsm-next-pending-wave) 2))
+
+(test-case "W3: reset-gsm! clears all wave state"
+  (reset-gsm!)
+  (gsm-set-total-waves! 5)
+  (gsm-mark-wave-complete! 0)
+  (gsm-set-wave-executor! 'some-executor)
+  (reset-gsm!)
+  (check-false (gsm-wave-executor))
+  (check-equal? (gsm-total-waves) 0)
+  (check-false (gsm-wave-complete? 0)))
+
+(test-case "W3: executor cleared on transition from executing"
+  (reset-gsm!)
+  (gsm-transition! 'exploring)
+  (gsm-transition! 'plan-written)
+  (gsm-transition! 'executing)
+  (gsm-set-wave-executor! 'test-exec)
+  (check-eq? (gsm-wave-executor) 'test-exec)
+  (gsm-transition! 'idle)
+  (check-false (gsm-wave-executor)))


### PR DESCRIPTION
Addresses #2121.

feat: consolidate wave state into FSM + wire executor lifecycle (F4+F5) (#2121)

- Move wave-tracking boxes from gsd-planning-state.rkt into state-machine.rkt
  as a unified hash (mode, wave-executor, total-waves, current-wave, completed-waves)
- Add semaphore-protected wave state accessors (gsm-wave-executor,
  gsm-set-wave-executor!, gsm-total-waves, gsm-mark-wave-complete!, etc.)
- Simplify gsd-planning-state.rkt to thin accessor layer delegating to FSM
- Store wave executor in FSM during /go, clear on transition away from executing
- Wire wave-skip! executor call in /skip handler
- Fix gsd-snapshot to return raw FSM state (mode, not current)
- Fix gsd/core.rkt to use gsm-history directly instead of snapshot
- Add 6 new tests for wave state in FSM
- All 343 GSD tests pass

Wave 3 of v0.21.6 GSD Architecture Remediation.