### PR TITLE
feat: hardened path guard + version bump to 0.21.6 (F6) (#2122)

- Replace string-based normalize-path/resolve-dotdots/path-targets-plan? with
  simple-form-path canonical path comparison in gsd-write-guard
- Block ALL writes to .planning/ directory during execution (not just PLAN.md)
- Uses racket/path simple-form-path for robust .., ., symlink resolution
- Remove old string-manipulation helpers (normalize-path, resolve-dotdots,
  path-targets-plan?)
- Update test: STATE.md now correctly blocked during executing
- Add 4 new tests for hardened path guard (waves dir, q/foo.rkt, exploring, idle)
- Bump version to 0.21.6 in util/version.rkt, info.rkt, README.md
- All 347 GSD tests pass

Wave 4 of v0.21.6 GSD Architecture Remediation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.21.5-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.21.6-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 
@@ -199,7 +199,7 @@ racket main.rkt --model gpt-5.4 "write a test"
 ### Verify
 
 ```bash
-racket main.rkt --version  # q version 0.21.5
+racket main.rkt --version  # q version 0.21.6
 raco test tests/           # run the full test suite
 ```
 

--- a/extensions/gsd/core.rkt
+++ b/extensions/gsd/core.rkt
@@ -17,6 +17,7 @@
 
 (require racket/string
          racket/format
+         racket/path
          "state-machine.rkt"
          "plan-types.rkt"
          "context-bundle.rkt")
@@ -51,42 +52,42 @@
   (and (string? s) (> (string-length s) 0)))
 
 ;; Normalize a file path: collapse .. and . components.
-(define (normalize-path p)
+;; Canonical path comparison for write guard.
+;; Uses simple-form-path to resolve .., ., symlinks, and relative paths.
+;; Blocks ALL writes to .planning/ directory during execution.
+
+(define (gsd-write-guard target-path planning-dir)
+  (define mode (gsm-current))
+  (define planning-dir-str
+    (if (path? planning-dir)
+        (path->string planning-dir)
+        planning-dir))
   (cond
-    [(not (string? p)) p]
+    [(not (eq? mode 'executing)) #t]
+    [(not (string? target-path)) #t]
+    [(not planning-dir-str) #t]
     [else
-     (define trimmed (string-trim p))
-     (define absolute? (and (> (string-length trimmed) 0) (char=? (string-ref trimmed 0) #\/)))
-     (define parts (string-split trimmed "/"))
-     (define resolved (resolve-dotdots parts))
-     (if absolute?
-         (string-append "/" (string-join resolved "/"))
-         (string-join resolved "/"))]))
-
-;; Resolve .. by folding: each .. pops the last component.
-(define (resolve-dotdots parts)
-  (define rev
-    (foldl (lambda (part acc)
-             (cond
-               [(string=? part "..")
-                (if (null? acc)
-                    acc
-                    (cdr acc))]
-               [(string=? part ".") acc]
-               [(string=? part "") acc]
-               [else (cons part acc)]))
-           '()
-           parts))
-  (reverse rev))
-
-;; Check if a normalized path targets PLAN.md in the planning dir.
-;; Handles suffix matching for relative paths and .. traversal.
-(define (path-targets-plan? normalized plan-path)
-  (cond
-    [(not (non-empty? plan-path)) #f]
-    [(string=? normalized plan-path) #t]
-    ;; Suffix match: does the path end with .planning/PLAN.md?
-    [else (string-suffix? normalized ".planning/PLAN.md")]))
+     ;; Resolve both paths to canonical form
+     (define canonical-target
+       (with-handlers ([exn:fail? (λ (_) target-path)])
+         (path->string (simple-form-path (string->path target-path)))))
+     (define canonical-planning
+       (with-handlers ([exn:fail? (λ (_) planning-dir-str)])
+         (path->string (simple-form-path (string->path planning-dir-str)))))
+     ;; Check if target is inside .planning/ directory
+     (define in-planning-dir?
+       (or (string=? canonical-target canonical-planning)
+           (string-prefix? canonical-target (string-append canonical-planning "/"))))
+     (if in-planning-dir?
+         (hasheq 'blocked
+                 #t
+                 'tool
+                 "write"
+                 'mode
+                 'executing
+                 'reason
+                 (format "Cannot write to ~a during execution (use /replan to modify)" target-path))
+         #t)]))
 
 ;; ============================================================
 ;; Command dispatch
@@ -217,34 +218,6 @@
 ;; ============================================================
 ;; Write guard (hardened — DD-6)
 ;; ============================================================
-
-;; During executing mode, block writes to .planning/PLAN.md.
-;; Uses path normalization to catch .. traversal and other tricks.
-(define (gsd-write-guard target-path planning-dir)
-  (define mode (gsm-current))
-  (define planning-dir-str
-    (if (path? planning-dir)
-        (path->string planning-dir)
-        planning-dir))
-  (cond
-    [(not (eq? mode 'executing)) #t]
-    [(not (string? target-path)) #t]
-    [else
-     (define normalized (normalize-path target-path))
-     (define plan-path
-       (if (string? planning-dir-str)
-           (normalize-path (string-append planning-dir-str "/PLAN.md"))
-           ""))
-     (if (path-targets-plan? normalized plan-path)
-         (hasheq 'blocked
-                 #t
-                 'tool
-                 "write"
-                 'mode
-                 'executing
-                 'reason
-                 (format "Cannot write to ~a during execution (use /replan to modify)" target-path))
-         #t)]))
 
 ;; ============================================================
 ;; Status display

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.21.5")
+(define version "0.21.6")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base"))

--- a/tests/test-gsd-core.rkt
+++ b/tests/test-gsd-core.rkt
@@ -268,12 +268,13 @@
   (check-true (hash? r))
   (check-equal? (hash-ref r 'blocked) #t))
 
-(test-case "write guard: allows other .planning files during executing"
+(test-case "write guard: blocks other .planning files during executing"
   (reset-gsm!)
   (gsm-transition! 'exploring)
   (gsm-transition! 'plan-written)
   (gsm-transition! 'executing)
-  (check-true (gsd-write-guard ".planning/STATE.md" ".planning")))
+  (define r (gsd-write-guard ".planning/STATE.md" ".planning"))
+  (check-true (hash-ref r 'blocked #f)))
 
 (test-case "write guard: allows files outside .planning"
   (reset-gsm!)
@@ -281,3 +282,31 @@
   (gsm-transition! 'plan-written)
   (gsm-transition! 'executing)
   (check-true (gsd-write-guard "src/fix.rkt" ".planning")))
+
+;; ============================================================
+;; W4: Hardened path guard tests (F6)
+;; ============================================================
+
+(test-case "W4: write guard blocks .planning/waves/W0-slug.md during executing"
+  (reset-gsm!)
+  (gsm-transition! 'exploring)
+  (gsm-transition! 'plan-written)
+  (gsm-transition! 'executing)
+  (define r (gsd-write-guard ".planning/waves/W0-slug.md" ".planning"))
+  (check-true (hash-ref r 'blocked #f)))
+
+(test-case "W4: write guard allows q/foo.rkt during executing"
+  (reset-gsm!)
+  (gsm-transition! 'exploring)
+  (gsm-transition! 'plan-written)
+  (gsm-transition! 'executing)
+  (check-true (gsd-write-guard "q/foo.rkt" ".planning")))
+
+(test-case "W4: write guard allows during exploring mode"
+  (reset-gsm!)
+  (gsm-transition! 'exploring)
+  (check-true (gsd-write-guard ".planning/PLAN.md" ".planning")))
+
+(test-case "W4: write guard allows during idle mode"
+  (reset-gsm!)
+  (check-true (gsd-write-guard ".planning/PLAN.md" ".planning")))

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -7,4 +7,4 @@
 
 (provide q-version)
 
-(define q-version "0.21.5")
+(define q-version "0.21.6")


### PR DESCRIPTION
Addresses #2122.

feat: hardened path guard + version bump to 0.21.6 (F6) (#2122)

- Replace string-based normalize-path/resolve-dotdots/path-targets-plan? with
  simple-form-path canonical path comparison in gsd-write-guard
- Block ALL writes to .planning/ directory during execution (not just PLAN.md)
- Uses racket/path simple-form-path for robust .., ., symlink resolution
- Remove old string-manipulation helpers (normalize-path, resolve-dotdots,
  path-targets-plan?)
- Update test: STATE.md now correctly blocked during executing
- Add 4 new tests for hardened path guard (waves dir, q/foo.rkt, exploring, idle)
- Bump version to 0.21.6 in util/version.rkt, info.rkt, README.md
- All 347 GSD tests pass

Wave 4 of v0.21.6 GSD Architecture Remediation.