### PR TITLE
feat: add error handling to factory and submit threads (W3) (#2131)

- Wrap factory closure in tui-init.rkt with with-handlers
  - Catches exn:fail? and displays error as system message in TUI
- Wrap factory thread, fallback runner, and submit-text thread in commands.rkt
  - All three thread spawns now catch exceptions
  - Error messages shown in transcript instead of silent thread death
- All 357 GSD tests and 756 TUI tests pass

Wave 3 of v0.21.7 Factory Error Handling.

### DIFF
--- a/tui/commands.rkt
+++ b/tui/commands.rkt
@@ -872,12 +872,36 @@
               (define factory (cmd-ctx-session-factory-runner cctx))
               (cond
                 ;; Fresh session: call factory with the prompt
-                [factory (thread (lambda () (factory new-session-text)))]
+                [factory
+                 (thread
+                  (lambda ()
+                    (with-handlers
+                        ([exn:fail?
+                          (lambda (e)
+                            (define err-msg (format "[ERROR] /go failed: ~a" (exn-message e)))
+                            (define entry
+                              (make-entry 'system err-msg (current-inexact-milliseconds) (hash)))
+                            (set-box! (cmd-ctx-state-box cctx)
+                                      (add-transcript-entry (unbox (cmd-ctx-state-box cctx)) entry))
+                            (set-box! (cmd-ctx-needs-redraw-box cctx) #t))])
+                      (factory new-session-text))))]
                 [else
                  ;; Fallback: append to existing session
                  (define runner (cmd-ctx-session-runner cctx))
                  (when runner
-                   (thread (lambda () (runner new-session-text))))])]
+                   (thread
+                    (lambda ()
+                      (with-handlers
+                          ([exn:fail?
+                            (lambda (e)
+                              (define err-msg
+                                (format "[ERROR] Session runner failed: ~a" (exn-message e)))
+                              (define entry
+                                (make-entry 'system err-msg (current-inexact-milliseconds) (hash)))
+                              (set-box! (cmd-ctx-state-box cctx)
+                                        (add-transcript-entry (unbox (cmd-ctx-state-box cctx)) entry))
+                              (set-box! (cmd-ctx-needs-redraw-box cctx) #t))])
+                        (runner new-session-text)))))])]
              [submit-text
               ;; Extension wants to submit text as a prompt to the agent
               (when display-text
@@ -886,7 +910,18 @@
                           (add-transcript-entry (unbox (cmd-ctx-state-box cctx)) entry)))
               (define runner (cmd-ctx-session-runner cctx))
               (when runner
-                (thread (lambda () (runner submit-text))))]
+                (thread
+                 (lambda ()
+                   (with-handlers
+                       ([exn:fail?
+                         (lambda (e)
+                           (define err-msg (format "[ERROR] Prompt failed: ~a" (exn-message e)))
+                           (define entry
+                             (make-entry 'system err-msg (current-inexact-milliseconds) (hash)))
+                           (set-box! (cmd-ctx-state-box cctx)
+                                     (add-transcript-entry (unbox (cmd-ctx-state-box cctx)) entry))
+                           (set-box! (cmd-ctx-needs-redraw-box cctx) #t))])
+                     (runner submit-text)))))]
              [display-text
               ;; Extension provided display text
               (define entry (make-entry 'system display-text (current-inexact-milliseconds) (hash)))

--- a/tui/tui-init.rkt
+++ b/tui/tui-init.rkt
@@ -74,26 +74,35 @@
      #:session-queue (agent-session-queue sess)
      #:session-factory-runner
      (lambda (prompt)
-       ;; v0.21.4: /go creates fresh session with no planning history
-       (define new-sess (make-agent-session rt-config))
-       (define new-sid (session-id new-sess))
-       (define new-dir (or (hash-ref rt-config 'session-dir #f) (hash-ref rt-config 'store-dir #f)))
-       ;; Switch extensions: teardown old, rebind to new
-       (switch-session! #:old-session-id (session-id sess)
-                        #:old-bus bus
-                        #:old-extension-registry (hash-ref rt-config 'extension-registry #f)
-                        #:new-session-id new-sid
-                        #:new-session-dir new-dir
-                        #:new-bus bus
-                        #:new-extension-registry (hash-ref rt-config 'extension-registry #f)
-                        #:reason 'fork)
-       ;; Clear TUI transcript for new session
-       (set-box! (tui-ctx-ui-state-box ctx)
-                 (initial-ui-state #:session-id new-sid
-                                   #:model-name (hash-ref rt-config 'model-name #f)))
-       (set-box! (tui-ctx-needs-redraw-box ctx) #t)
-       ;; Run prompt in new session
-       (run-prompt! new-sess prompt))))
+       (with-handlers ([exn:fail?
+                        (lambda (e)
+                          ;; Display error as system message in TUI transcript
+                          (define err-msg (format "[ERROR] /go failed: ~a" (exn-message e)))
+                          (define entry
+                            (make-entry 'system err-msg (current-inexact-milliseconds) (hash)))
+                          (set-box! (tui-ctx-ui-state-box ctx)
+                                    (add-transcript-entry (unbox (tui-ctx-ui-state-box ctx)) entry))
+                          (set-box! (tui-ctx-needs-redraw-box ctx) #t))])
+         ;; v0.21.4: /go creates fresh session with no planning history
+         (define new-sess (make-agent-session rt-config))
+         (define new-sid (session-id new-sess))
+         (define new-dir (or (hash-ref rt-config 'session-dir #f) (hash-ref rt-config 'store-dir #f)))
+         ;; Switch extensions: teardown old, rebind to new
+         (switch-session! #:old-session-id (session-id sess)
+                          #:old-bus bus
+                          #:old-extension-registry (hash-ref rt-config 'extension-registry #f)
+                          #:new-session-id new-sid
+                          #:new-session-dir new-dir
+                          #:new-bus bus
+                          #:new-extension-registry (hash-ref rt-config 'extension-registry #f)
+                          #:reason 'fork)
+         ;; Clear TUI transcript for new session
+         (set-box! (tui-ctx-ui-state-box ctx)
+                   (initial-ui-state #:session-id new-sid
+                                     #:model-name (hash-ref rt-config 'model-name #f)))
+         (set-box! (tui-ctx-needs-redraw-box ctx) #t)
+         ;; Run prompt in new session
+         (run-prompt! new-sess prompt)))))
 
   ;; Install UI callbacks for extensions (breaks extensions→TUI upward import)
   (install-ui-callbacks!


### PR DESCRIPTION
Addresses #2131.

feat: add error handling to factory and submit threads (W3) (#2131)

- Wrap factory closure in tui-init.rkt with with-handlers
  - Catches exn:fail? and displays error as system message in TUI
- Wrap factory thread, fallback runner, and submit-text thread in commands.rkt
  - All three thread spawns now catch exceptions
  - Error messages shown in transcript instead of silent thread death
- All 357 GSD tests and 756 TUI tests pass

Wave 3 of v0.21.7 Factory Error Handling.