### PR TITLE
feat: GSD archive module + /done command + PLAN.md status update (#2154)

- #2155: Create extensions/gsd/archive.rkt with archive-completed-plan!
  - Validates all waves complete, creates archive dir, moves files, resets state
  - Handles collision by appending epoch timestamp
- #2156: Register /done command in core.rkt and gsd-planning.rkt
  - Add cmd-done handler that calls archive-completed-plan!
  - Wire execute-command dispatcher with archive event emission
- #2157: Update PLAN.md status markers on wave completion
  - mark-wave-complete! now also calls mark-wave-status! to update [Inbox]→[DONE]
- #2158: Add 13 tests in tests/test-gsd-archive.rkt
  - Tests: all-waves-complete?, archive-path collision, archive success/failure,
    state reset, waves dir move, missing files, PLAN.md status marker update

### DIFF
--- a/extensions/gsd-planning-state.rkt
+++ b/extensions/gsd-planning-state.rkt
@@ -6,7 +6,8 @@
 ;; Only wave tracking
 ;; and mode delegation remain.
 
-(require "gsd/state-machine.rkt")
+(require "gsd/state-machine.rkt"
+         "gsd/wave-docs.rkt")
 
 (provide gsd-mode
          gsd-mode?
@@ -101,7 +102,12 @@
 (define (set-total-waves! n)
   (gsm-set-total-waves! n))
 (define (mark-wave-complete! idx)
-  (gsm-mark-wave-complete! idx))
+  (gsm-mark-wave-complete! idx)
+  ;; Also update PLAN.md status marker (#2157)
+  (define base-dir (pinned-planning-dir))
+  (when base-dir
+    (with-handlers ([exn:fail? (lambda (e) (void))])
+      (mark-wave-status! base-dir idx "DONE"))))
 (define (wave-complete? idx)
   (gsm-wave-complete? idx))
 (define (current-wave-index)

--- a/extensions/gsd-planning.rkt
+++ b/extensions/gsd-planning.rkt
@@ -38,7 +38,7 @@
          "gsd/state-machine.rkt"
          "gsd/core.rkt"
          ;; v0.21.6: direct command handlers for wiring
-         (only-in "gsd/core.rkt" cmd-replan cmd-skip cmd-reset)
+         (only-in "gsd/core.rkt" cmd-replan cmd-skip cmd-reset cmd-done)
 
          "gsd/plan-types.rkt"
          "gsd/plan-validator.rkt"
@@ -406,6 +406,7 @@
   (ext-register-command! ctx "/replan" "Return to planning phase" 'general '() '())
   (ext-register-command! ctx "/skip" "Skip a wave (usage: /skip N)" 'general '() '())
   (ext-register-command! ctx "/reset" "Reset GSD to idle state" 'general '() '())
+  (ext-register-command! ctx "/done" "Archive completed plan" 'general '() '("d"))
   (ext-register-command! ctx "/gsd" "Show GSD workflow status" 'general '() '())
   (hook-pass #f))
 
@@ -436,6 +437,11 @@
     [(equal? cmd "/reset")
      (define result (cmd-reset))
      (emit-gsd-event! "gsd.mode.changed" (hasheq 'mode 'idle))
+     (hook-amend (hasheq 'text (hash-ref result 'message "")))]
+    [(equal? cmd "/done")
+     (define result (cmd-done base-dir))
+     (when (hash-ref result 'success #f)
+       (emit-gsd-event! "gsd.plan.archived" (hasheq 'path (hash-ref result 'archive-path ""))))
      (hook-amend (hasheq 'text (hash-ref result 'message "")))]
     [else (handle-artifact-command cmd input-text base-dir payload)]))
 

--- a/extensions/gsd/archive.rkt
+++ b/extensions/gsd/archive.rkt
@@ -1,0 +1,151 @@
+#lang racket/base
+
+;; extensions/gsd/archive.rkt — GSD Plan Archival
+;;
+;; v0.21.9 #2155: Archive completed plans.
+;; Validates all waves complete, creates archive directory,
+;; moves plan files, resets GSD state.
+
+(require racket/file
+         racket/path
+         racket/port
+         racket/string
+         racket/format
+         "plan-types.rkt"
+         "wave-docs.rkt"
+         "state-machine.rkt")
+
+(provide archive-completed-plan!
+         all-waves-complete?
+         archive-path-for-plan
+         move-to-archive!
+         reset-gsd-after-archive!)
+
+;; ============================================================
+;; Validation
+;; ============================================================
+
+;; Check if all waves in PLAN.md are complete (DONE or DEFERRED).
+(define (all-waves-complete? base-dir)
+  (define plan-path (build-path base-dir ".planning" "PLAN.md"))
+  (cond
+    [(not (file-exists? plan-path)) #f]
+    [else
+     (define text (call-with-input-file plan-path port->string))
+     (define entries (parse-plan-index text))
+     (cond
+       [(null? entries) #f]
+       [else
+        (for/and ([e entries])
+          (define status (wave-index-entry-status e))
+          (or (string=? status "DONE") (string=? status "DEFERRED")))])]))
+
+;; ============================================================
+;; Archive path
+;; ============================================================
+
+;; Generate archive directory path from plan title.
+;; Format: .planning/archive/<slug>/
+;; If collision, append epoch timestamp.
+(define (archive-path-for-plan base-dir plan-title)
+  (define slug (slugify plan-title))
+  (define archive-root (build-path base-dir ".planning" "archive"))
+  (define candidate (build-path archive-root slug))
+  (cond
+    [(not (directory-exists? candidate)) candidate]
+    ;; Collision: append epoch timestamp
+    [else (build-path archive-root (format "~a-~a" slug (current-seconds)))]))
+
+;; ============================================================
+;; File movement
+;; ============================================================
+
+;; Move planning files to archive directory.
+;; Moves: PLAN.md, STATE.md, HANDOFF.json, wave docs in waves/
+;; Returns the archive directory path.
+(define (move-to-archive! base-dir archive-dir)
+  (define planning-dir (build-path base-dir ".planning"))
+  (unless (directory-exists? archive-dir)
+    (make-directory* archive-dir))
+
+  ;; Files to move from .planning/
+  (define files-to-move
+    (for/list ([f '("PLAN.md" "STATE.md" "HANDOFF.json" "VALIDATION.md" "SUMMARY.md")]
+               #:when (file-exists? (build-path planning-dir f)))
+      f))
+
+  ;; Move top-level files
+  (for ([f files-to-move])
+    (define src (build-path planning-dir f))
+    (define dst (build-path archive-dir f))
+    (rename-file-or-directory src dst))
+
+  ;; Move waves/ directory if it exists
+  (define waves-dir (build-path planning-dir "waves"))
+  (when (directory-exists? waves-dir)
+    (define dst-waves (build-path archive-dir "waves"))
+    (rename-file-or-directory waves-dir dst-waves))
+
+  archive-dir)
+
+;; ============================================================
+;; Reset
+;; ============================================================
+
+;; Reset GSD state machine after archival.
+(define (reset-gsd-after-archive!)
+  (reset-gsm!))
+
+;; ============================================================
+;; Main entry point
+;; ============================================================
+
+;; Archive a completed plan.
+;; Steps: validate → create archive dir → move files → reset state.
+;; Returns (hasheq 'success #t 'archive-path ...) on success.
+;; Returns (hasheq 'success #f 'error ...) on failure.
+(define (archive-completed-plan! base-dir)
+  (define planning-dir (build-path base-dir ".planning"))
+  (define plan-path (build-path planning-dir "PLAN.md"))
+  (cond
+    [(not (file-exists? plan-path)) (hasheq 'success #f 'error "No PLAN.md found")]
+    [(not (all-waves-complete? base-dir)) (hasheq 'success #f 'error "Not all waves are complete")]
+    [else
+     (define plan-text (call-with-input-file plan-path port->string))
+     (define title (extract-plan-title plan-text))
+     (define archive-dir (archive-path-for-plan base-dir title))
+     (define moved-files '())
+     (with-handlers ([exn:fail:filesystem?
+                      (lambda (e)
+                        (hasheq 'success #f 'error (format "Filesystem error: ~a" (exn-message e))))])
+       (move-to-archive! base-dir archive-dir)
+       (reset-gsd-after-archive!)
+       ;; Count archived files
+       (define archived-count
+         (if (directory-exists? archive-dir)
+             (length (directory-list archive-dir))
+             0))
+       (hasheq 'success
+               #t
+               'archive-path
+               (path->string archive-dir)
+               'files-archived
+               archived-count))]))
+
+;; ============================================================
+;; Helpers
+;; ============================================================
+
+(define (extract-plan-title plan-text)
+  (define lines (string-split plan-text "\n"))
+  (define title-line
+    (for/first ([line lines]
+                #:when (regexp-match? #rx"^# +Plan:" line))
+      line))
+  (cond
+    [(not title-line) "archived-plan"]
+    [else
+     (define m (regexp-match #rx"^# +Plan: +(.+)$" title-line))
+     (if m
+         (string-trim (cadr m))
+         "archived-plan")]))

--- a/extensions/gsd/core.rkt
+++ b/extensions/gsd/core.rkt
@@ -12,6 +12,7 @@
 ;;   /go    → transition to executing
 ;;   /replan → back to exploring from plan-written/executing
 ;;   /skip  → mark wave as skipped
+;;   /done  → archive completed plan
 ;;   /reset → go to idle
 ;;   /gsd   → show status
 
@@ -20,7 +21,8 @@
          racket/path
          "state-machine.rkt"
          "plan-types.rkt"
-         "context-bundle.rkt")
+         "context-bundle.rkt"
+         "archive.rkt")
 
 (provide gsd-command-dispatch
          gsd-tool-guard
@@ -30,6 +32,7 @@
          cmd-replan
          cmd-skip
          cmd-reset
+         cmd-done
          ;; Command names for registration
          gsd-commands)
 
@@ -41,6 +44,7 @@
   '((plan "/plan" "Start GSD planning phase" ("p")) (go "/go" "Begin executing the plan" ())
                                                     (replan "/replan" "Return to planning phase" ())
                                                     (skip "/skip" "Skip current wave" ("s"))
+                                                    (done "/done" "Archive completed plan" ("d"))
                                                     (reset "/reset" "Reset GSD to idle state" ())
                                                     (gsd "/gsd" "Show GSD status" ())))
 
@@ -104,6 +108,7 @@
     [(replan) (cmd-replan)]
     [(skip) (cmd-skip args)]
     [(reset) (cmd-reset)]
+    [(done) (hasheq 'success #t 'mode 'idle 'message "Use /done from the planning context.")]
     [(gsd) (gsd-show-status)]
     [else #f]))
 
@@ -198,6 +203,20 @@
 (define (cmd-reset)
   (define result (gsm-reset!))
   (hasheq 'success #t 'mode 'idle 'message "GSD reset to idle."))
+
+;; /done → archive completed plan
+(define (cmd-done base-dir)
+  (define result (archive-completed-plan! base-dir))
+  (if (hash-ref result 'success #f)
+      (hasheq 'success
+              #t
+              'mode
+              'idle
+              'message
+              (format "✅ Plan archived to ~a (~a files)"
+                      (hash-ref result 'archive-path "?")
+                      (hash-ref result 'files-archived 0)))
+      (hasheq 'success #f 'mode (gsm-current) 'message (hash-ref result 'error "Archive failed"))))
 
 ;; ============================================================
 ;; Tool guard (tool-call-pre)

--- a/tests/test-gsd-archive.rkt
+++ b/tests/test-gsd-archive.rkt
@@ -1,0 +1,225 @@
+#lang racket
+
+;; tests/test-gsd-archive.rkt — Tests for GSD archive workflow
+;; Issues #2155, #2156, #2157, #2158
+
+(require rackunit
+         racket/file
+         racket/path
+         racket/string
+         "../extensions/gsd/archive.rkt"
+         "../extensions/gsd/state-machine.rkt"
+         "../extensions/gsd/wave-docs.rkt"
+         "../extensions/gsd/plan-types.rkt")
+
+;; ============================================================
+;; Helpers
+;; ============================================================
+
+(define (make-tmp-planning-dir)
+  (define tmp (make-temporary-file "gsd-archive-test-~a" 'directory))
+  (define planning (build-path tmp ".planning"))
+  (make-directory planning)
+  tmp)
+
+(define (write-plan! base-dir #:status-lines [status-lines #f])
+  (define plan-path (build-path base-dir ".planning" "PLAN.md"))
+  (define content
+    (string-append
+     "# Plan: Test Archive Plan\n\n## Overview\nTest.\n\n## Waves\n"
+     (or status-lines
+         "- [DONE] W0: setup → waves/W0-setup.md\n- [DONE] W1: implement → waves/W1-implement.md\n")))
+  (call-with-output-file plan-path (lambda (out) (display content out)) #:exists 'truncate))
+
+(define (write-plan-incomplete! base-dir)
+  (write-plan!
+   base-dir
+   #:status-lines
+   "- [DONE] W0: setup → waves/W0-setup.md\n- [Inbox] W1: implement → waves/W1-implement.md\n"))
+
+(define (write-state! base-dir)
+  (define state-path (build-path base-dir ".planning" "STATE.md"))
+  (call-with-output-file state-path
+                         (lambda (out) (display "# State\nAll done." out))
+                         #:exists 'truncate))
+
+(define (write-wave! base-dir idx slug status content)
+  (write-wave-doc! base-dir idx slug content status))
+
+(define (cleanup-tmp base-dir)
+  (when (directory-exists? base-dir)
+    (delete-directory/files base-dir)))
+
+;; ============================================================
+;; Tests: all-waves-complete? (#2155)
+;; ============================================================
+
+(test-case "all-waves-complete?: #t when all DONE"
+  (define tmp (make-tmp-planning-dir))
+  (dynamic-wind void
+                (lambda ()
+                  (write-plan! tmp)
+                  (check-true (all-waves-complete? tmp)))
+                (lambda () (cleanup-tmp tmp))))
+
+(test-case "all-waves-complete?: #f when some Inbox"
+  (define tmp (make-tmp-planning-dir))
+  (dynamic-wind void
+                (lambda ()
+                  (write-plan-incomplete! tmp)
+                  (check-false (all-waves-complete? tmp)))
+                (lambda () (cleanup-tmp tmp))))
+
+(test-case "all-waves-complete?: #f when no PLAN.md"
+  (define tmp (make-tmp-planning-dir))
+  (dynamic-wind void
+                (lambda () (check-false (all-waves-complete? tmp)))
+                (lambda () (cleanup-tmp tmp))))
+
+(test-case "all-waves-complete?: #t with DONE + DEFERRED"
+  (define tmp (make-tmp-planning-dir))
+  (dynamic-wind
+   void
+   (lambda ()
+     (write-plan!
+      tmp
+      #:status-lines
+      "- [DONE] W0: setup → waves/W0-setup.md\n- [DEFERRED] W1: optional → waves/W1-optional.md\n")
+     (check-true (all-waves-complete? tmp)))
+   (lambda () (cleanup-tmp tmp))))
+
+;; ============================================================
+;; Tests: archive-path-for-plan (#2155)
+;; ============================================================
+
+(test-case "archive-path-for-plan: generates correct path"
+  (define tmp (make-tmp-planning-dir))
+  (dynamic-wind void
+                (lambda ()
+                  (define result (archive-path-for-plan tmp "My Cool Plan"))
+                  (check-true (string-suffix? (path->string result) "my-cool-plan")))
+                (lambda () (cleanup-tmp tmp))))
+
+(test-case "archive-path-for-plan: collision appends timestamp"
+  (define tmp (make-tmp-planning-dir))
+  (dynamic-wind void
+                (lambda ()
+                  ;; Create existing archive dir
+                  (define first-path (archive-path-for-plan tmp "Test Plan"))
+                  (make-directory* first-path)
+                  ;; Now ask for same plan — should get timestamp suffix
+                  (define second-path (archive-path-for-plan tmp "Test Plan"))
+                  (check-not-equal? first-path second-path)
+                  (check-true (string-contains? (path->string second-path) "test-plan-")))
+                (lambda () (cleanup-tmp tmp))))
+
+;; ============================================================
+;; Tests: archive-completed-plan! (#2155)
+;; ============================================================
+
+(test-case "archive-completed-plan!: archives all files"
+  (define tmp (make-tmp-planning-dir))
+  (dynamic-wind
+   void
+   (lambda ()
+     (write-plan! tmp)
+     (write-state! tmp)
+     (write-wave! tmp 0 "setup" "DONE" "## Root Cause\nSetup needed.\n## Action\nDo setup.")
+     (write-wave! tmp 1 "implement" "DONE" "## Root Cause\nNeed impl.\n## Action\nImplement.")
+
+     (define result (archive-completed-plan! tmp))
+     (check-true (hash-ref result 'success))
+     (check-true (string-contains? (hash-ref result 'archive-path) "archive"))
+     ;; PLAN.md should no longer exist in .planning/
+     (check-false (file-exists? (build-path tmp ".planning" "PLAN.md")))
+     ;; Archive dir should exist with files
+     (define archive-dir (string->path (hash-ref result 'archive-path)))
+     (check-true (directory-exists? archive-dir))
+     (check-true (file-exists? (build-path archive-dir "PLAN.md"))))
+   (lambda () (cleanup-tmp tmp))))
+
+(test-case "archive-completed-plan!: fails when incomplete"
+  (define tmp (make-tmp-planning-dir))
+  (dynamic-wind void
+                (lambda ()
+                  (write-plan-incomplete! tmp)
+                  (define result (archive-completed-plan! tmp))
+                  (check-false (hash-ref result 'success))
+                  (check-true (string-contains? (hash-ref result 'error) "Not all waves")))
+                (lambda () (cleanup-tmp tmp))))
+
+(test-case "archive-completed-plan!: fails when no PLAN.md"
+  (define tmp (make-tmp-planning-dir))
+  (dynamic-wind void
+                (lambda ()
+                  (define result (archive-completed-plan! tmp))
+                  (check-false (hash-ref result 'success))
+                  (check-true (string-contains? (hash-ref result 'error) "No PLAN.md")))
+                (lambda () (cleanup-tmp tmp))))
+
+;; ============================================================
+;; Tests: reset-gsd-after-archive! (#2155)
+;; ============================================================
+
+(test-case "reset-gsd-after-archive!: resets state machine"
+  ;; Transition to exploring first
+  (reset-gsm!)
+  (gsm-transition! 'exploring)
+  (check-eq? (gsm-current) 'exploring)
+  ;; Reset
+  (reset-gsd-after-archive!)
+  (check-eq? (gsm-current) 'idle))
+
+;; ============================================================
+;; Tests: move-to-archive! (#2160)
+;; ============================================================
+
+(test-case "move-to-archive!: moves waves/ dir"
+  (define tmp (make-tmp-planning-dir))
+  (dynamic-wind void
+                (lambda ()
+                  (write-plan! tmp)
+                  (write-state! tmp)
+                  (write-wave! tmp 0 "setup" "DONE" "Root cause.\nAction.\nVerify.")
+
+                  (define archive-dir (build-path tmp ".planning" "archive" "test"))
+                  (move-to-archive! tmp archive-dir)
+
+                  ;; waves/ should have moved to archive
+                  (check-true (directory-exists? (build-path archive-dir "waves")))
+                  (check-false (directory-exists? (build-path tmp ".planning" "waves"))))
+                (lambda () (cleanup-tmp tmp))))
+
+(test-case "move-to-archive!: handles missing files gracefully"
+  (define tmp (make-tmp-planning-dir))
+  (dynamic-wind void
+                (lambda ()
+                  (write-plan! tmp)
+                  ;; No STATE.md, no wave docs
+                  (define archive-dir (build-path tmp ".planning" "archive" "minimal"))
+                  (move-to-archive! tmp archive-dir)
+                  ;; Just PLAN.md moved
+                  (check-true (file-exists? (build-path archive-dir "PLAN.md")))
+                  (check-false (file-exists? (build-path archive-dir "STATE.md"))))
+                (lambda () (cleanup-tmp tmp))))
+
+;; ============================================================
+;; Tests: mark-wave-status! updates PLAN.md (#2157)
+;; ============================================================
+
+(test-case "mark-wave-status! updates PLAN.md status marker"
+  (define tmp (make-tmp-planning-dir))
+  (dynamic-wind
+   void
+   (lambda ()
+     (write-plan!
+      tmp
+      #:status-lines
+      "- [Inbox] W0: setup → waves/W0-setup.md\n- [Inbox] W1: implement → waves/W1-implement.md\n")
+     ;; Mark W0 as DONE
+     (mark-wave-status! tmp 0 "DONE")
+     ;; Read PLAN.md and verify marker changed
+     (define plan-text (file->string (build-path tmp ".planning" "PLAN.md")))
+     (check-true (string-contains? plan-text "[DONE] W0:"))
+     (check-true (string-contains? plan-text "[Inbox] W1:")))
+   (lambda () (cleanup-tmp tmp))))


### PR DESCRIPTION
Addresses #2154.

feat: GSD archive module + /done command + PLAN.md status update (#2154)

- #2155: Create extensions/gsd/archive.rkt with archive-completed-plan!
  - Validates all waves complete, creates archive dir, moves files, resets state
  - Handles collision by appending epoch timestamp
- #2156: Register /done command in core.rkt and gsd-planning.rkt
  - Add cmd-done handler that calls archive-completed-plan!
  - Wire execute-command dispatcher with archive event emission
- #2157: Update PLAN.md status markers on wave completion
  - mark-wave-complete! now also calls mark-wave-status! to update [Inbox]→[DONE]
- #2158: Add 13 tests in tests/test-gsd-archive.rkt
  - Tests: all-waves-complete?, archive-path collision, archive success/failure,
    state reset, waves dir move, missing files, PLAN.md status marker update