### PR TITLE
feat: execution prompt polish + minor fixes (#2162)

- #2163: Fix iteration label in tui/state.rkt — show [executing...]
  during execution mode and [exploring...] during planning
  - Updated both iteration.soft-warning and exploration.progress handlers
  - Added gsm-current require from gsd/state-machine.rkt
- #2164: Auto-create STATE.md during /plan initialization
  - Added ensure-state-md! to archive.rkt (shared planning file helper)
  - Called from /plan handler in gsd-planning.rkt before planning starts
  - Does not overwrite existing STATE.md
- #2165: Add edit chunking + unique-matching guidance to execution prompt
  - ≤20-line edits, ≤500-char oldText, unique matching, racket_edit preference
- Added 5 new tests (18 in test-gsd-archive.rkt, 21 in test-gsd-prompts.rkt)

### DIFF
--- a/extensions/gsd-planning.rkt
+++ b/extensions/gsd-planning.rkt
@@ -45,7 +45,8 @@
          (except-in "gsd/wave-executor.rkt" next-pending-wave)
          "gsd/prompts.rkt"
          "gsd/context-bundle.rkt"
-         "gsd/wave-docs.rkt")
+         "gsd/wave-docs.rkt"
+         (only-in "gsd/archive.rkt" ensure-state-md!))
 
 (provide the-extension
          gsd-planning-extension
@@ -565,6 +566,8 @@
         (set-gsd-mode! 'planning)
         (emit-gsd-event! "gsd.mode.changed" (hasheq 'mode 'planning))
         (set-current-max-old-text-len! 500)
+        ;; Auto-create STATE.md if missing (#2164)
+        (ensure-state-md! base-dir)
         (define existing-plan (read-planning-artifact base-dir "PLAN"))
         (define stale-warning
           (if existing-plan

--- a/extensions/gsd/archive.rkt
+++ b/extensions/gsd/archive.rkt
@@ -20,7 +20,8 @@
          archive-path-for-plan
          move-to-archive!
          reset-gsd-after-archive!
-         cleanup-empty-subdirs!)
+         cleanup-empty-subdirs!
+         ensure-state-md!)
 
 ;; ============================================================
 ;; Validation
@@ -164,3 +165,17 @@
         (with-handlers ([exn:fail? (lambda (e) (void))])
           (when (null? (directory-list sub-path))
             (delete-directory sub-path)))))))
+
+;; Auto-create minimal STATE.md if it doesn't exist (#2164).
+;; Called from /plan initialization.
+(define (ensure-state-md! base-dir)
+  (define state-path (build-path base-dir ".planning" "STATE.md"))
+  (unless (file-exists? state-path)
+    (define planning-dir (build-path base-dir ".planning"))
+    (unless (directory-exists? planning-dir)
+      (make-directory* planning-dir))
+    (call-with-output-file
+     state-path
+     (lambda (out)
+       (display "# Project State\n\nStatus: Active\n\n## Progress\n\n- [ ] Initial state\n" out))
+     #:exists 'error)))

--- a/extensions/gsd/prompts.rkt
+++ b/extensions/gsd/prompts.rkt
@@ -99,6 +99,12 @@
    "- Failed waves do NOT block subsequent waves\n"
    "- Skip failed waves and document the reason\n"
    "- After all waves, report which ones failed\n\n"
+   "Edit rules (non-negotiable):\n"
+   "- Keep each edit ≤20 lines — split large changes into sequential edits\n"
+   "- Keep oldText ≤500 characters — include just enough surrounding context for uniqueness\n"
+   "- Verify oldText is unique in the file before editing\n"
+   "- For Racket files, prefer racket_edit over raw edit for structural changes\n"
+   "- After each edit, run format + syntax check before proceeding\n\n"
    "Wave overview:\n"
    (format-wave-list waves)))
 

--- a/tests/test-gsd-archive.rkt
+++ b/tests/test-gsd-archive.rkt
@@ -267,3 +267,30 @@
                   ;; archive should still exist even though empty
                   (check-true (directory-exists? archive-dir)))
                 (lambda () (cleanup-tmp tmp))))
+
+;; ============================================================
+;; Tests: ensure-state-md! auto-creates STATE.md (#2164)
+;; ============================================================
+
+(test-case "ensure-state-md! creates STATE.md when missing"
+  (define tmp (make-tmp-planning-dir))
+  (dynamic-wind void
+                (lambda ()
+                  (define state-path (build-path tmp ".planning" "STATE.md"))
+                  (check-false (file-exists? state-path))
+                  (ensure-state-md! tmp)
+                  (check-true (file-exists? state-path))
+                  (define content (file->string state-path))
+                  (check-true (string-contains? content "# Project State")))
+                (lambda () (cleanup-tmp tmp))))
+
+(test-case "ensure-state-md! does not overwrite existing STATE.md"
+  (define tmp (make-tmp-planning-dir))
+  (dynamic-wind void
+                (lambda ()
+                  (define state-path (build-path tmp ".planning" "STATE.md"))
+                  (call-with-output-file state-path (lambda (out) (display "existing content" out)))
+                  (ensure-state-md! tmp)
+                  (define content (file->string state-path))
+                  (check-equal? content "existing content"))
+                (lambda () (cleanup-tmp tmp))))

--- a/tests/test-gsd-prompts.rkt
+++ b/tests/test-gsd-prompts.rkt
@@ -82,6 +82,14 @@
   (define p (executing-prompt plan exec))
   (check-true (string-contains? p "/replan") "mentions replan"))
 
+(test-case "executing-prompt includes edit rules (#2165)"
+  (define plan (gsd-plan (list (gsd-wave 0 "Fix" 'pending "" '("a.rkt") '() "test" '())) "" '() '()))
+  (define exec (make-wave-executor plan))
+  (define p (executing-prompt plan exec))
+  (check-true (string-contains? p "Edit rules") "mentions edit rules")
+  (check-true (string-contains? p "\u226420") "mentions 20-line limit")
+  (check-true (string-contains? p "\u2264500") "mentions 500-char limit"))
+
 ;; ============================================================
 ;; Wave failure prompt
 ;; ============================================================

--- a/tui/state.rkt
+++ b/tui/state.rkt
@@ -10,7 +10,8 @@
          json
          "../util/protocol-types.rkt"
          "../util/cost-tracker.rkt"
-         "../util/content-helpers.rkt")
+         "../util/content-helpers.rkt"
+         (only-in "../extensions/gsd/state-machine.rkt" gsm-current))
 
 ;; Structs
 (provide (struct-out transcript-entry)
@@ -537,10 +538,11 @@
     [("iteration.soft-warning")
      (define iter (hash-ref payload 'iteration "?"))
      (define remaining (hash-ref payload 'remaining "?"))
+     (define label (if (eq? (gsm-current) 'executing) "executing" "exploring"))
      (append-entry
       state
       (make-entry 'system
-                  (format "[exploring... iteration ~a, ~a remaining before hard stop]" iter remaining)
+                  (format "[~a... iteration ~a, ~a remaining before hard stop]" label iter remaining)
                   (event-time evt)
                   (hash)))]
 
@@ -548,10 +550,11 @@
     [("exploration.progress")
      (define count (hash-ref payload 'consecutive-tools "?"))
      (define tool-names (hash-ref payload 'tool-names '()))
+     (define label (if (eq? (gsm-current) 'executing) "executing" "exploring"))
      (append-entry state
                    (make-entry 'system
-                               (format "[exploring... ~a tool calls: ~a]"
-                                       count
+                               (format "[~a... ~a tool calls: ~a]"
+                                       label
                                        (string-join (map (lambda (s)
                                                            (if (string? s)
                                                                s


### PR DESCRIPTION
Addresses #2162.

feat: execution prompt polish + minor fixes (#2162)

- #2163: Fix iteration label in tui/state.rkt — show [executing...]
  during execution mode and [exploring...] during planning
  - Updated both iteration.soft-warning and exploration.progress handlers
  - Added gsm-current require from gsd/state-machine.rkt
- #2164: Auto-create STATE.md during /plan initialization
  - Added ensure-state-md! to archive.rkt (shared planning file helper)
  - Called from /plan handler in gsd-planning.rkt before planning starts
  - Does not overwrite existing STATE.md
- #2165: Add edit chunking + unique-matching guidance to execution prompt
  - ≤20-line edits, ≤500-char oldText, unique matching, racket_edit preference
- Added 5 new tests (18 in test-gsd-archive.rkt, 21 in test-gsd-prompts.rkt)