### PR TITLE
feat: delete-lines tool + fix backup timestamp bug (#2171)

W0 of v0.21.10: Add line-range deletion tool to avoid edit failures
from 500-char old-text limit. Fix rational-number backup timestamp in
both edit.rkt and delete-lines.rkt. Update GSD execution prompt with
delete-lines guidance.

### DIFF
--- a/extensions/gsd/prompts.rkt
+++ b/extensions/gsd/prompts.rkt
@@ -100,6 +100,7 @@
    "- Skip failed waves and document the reason\n"
    "- After all waves, report which ones failed\n\n"
    "Edit rules (non-negotiable):\n"
+   "- For removing 3+ consecutive lines, prefer delete-lines (specify start/end line numbers)\n"
    "- Keep each edit ≤20 lines — split large changes into sequential edits\n"
    "- Keep oldText ≤500 characters — include just enough surrounding context for uniqueness\n"
    "- Verify oldText is unique in the file before editing\n"

--- a/tests/test-tool-delete-lines.rkt
+++ b/tests/test-tool-delete-lines.rkt
@@ -1,0 +1,155 @@
+#lang racket
+
+(require rackunit
+         "../tools/builtins/delete-lines.rkt"
+         "../tools/tool.rkt"
+         racket/file
+         racket/string)
+
+;; ============================================================
+;; tool-delete-lines — basic deletion tests
+;; ============================================================
+
+(test-case "delete-lines: delete lines from middle of file"
+  (define tmp (make-temporary-file "q-test-dl-~a.txt"))
+  (define content "line1\nline2\nline3\nline4\nline5")
+  (display-to-file content tmp #:exists 'replace)
+  (define result (tool-delete-lines (hasheq 'path tmp 'start-line 2 'end-line 3)))
+  (check-false (tool-result-is-error? result))
+  (check-equal? (file->string tmp) "line1\nline4\nline5")
+  (delete-file tmp))
+
+(test-case "delete-lines: delete single line (start=end)"
+  (define tmp (make-temporary-file "q-test-dl-~a.txt"))
+  (display-to-file "a\nb\nc" tmp #:exists 'replace)
+  (define result (tool-delete-lines (hasheq 'path tmp 'start-line 2 'end-line 2)))
+  (check-false (tool-result-is-error? result))
+  (check-equal? (file->string tmp) "a\nc")
+  (delete-file tmp))
+
+(test-case "delete-lines: delete first line"
+  (define tmp (make-temporary-file "q-test-dl-~a.txt"))
+  (display-to-file "first\nsecond\nthird" tmp #:exists 'replace)
+  (define result (tool-delete-lines (hasheq 'path tmp 'start-line 1 'end-line 1)))
+  (check-false (tool-result-is-error? result))
+  (check-equal? (file->string tmp) "second\nthird")
+  (delete-file tmp))
+
+(test-case "delete-lines: delete last line"
+  (define tmp (make-temporary-file "q-test-dl-~a.txt"))
+  (display-to-file "a\nb\nc" tmp #:exists 'replace)
+  (define result (tool-delete-lines (hasheq 'path tmp 'start-line 3 'end-line 3)))
+  (check-false (tool-result-is-error? result))
+  (check-equal? (file->string tmp) "a\nb")
+  (delete-file tmp))
+
+(test-case "delete-lines: delete all lines"
+  (define tmp (make-temporary-file "q-test-dl-~a.txt"))
+  (display-to-file "only-line" tmp #:exists 'replace)
+  (define result (tool-delete-lines (hasheq 'path tmp 'start-line 1 'end-line 1)))
+  (check-false (tool-result-is-error? result))
+  (check-equal? (file->string tmp) "")
+  (delete-file tmp))
+
+;; ============================================================
+;; tool-delete-lines — error cases
+;; ============================================================
+
+(test-case "delete-lines: file not found"
+  (define result (tool-delete-lines (hasheq 'path "/nonexistent-dl-test.txt"
+                                            'start-line 1 'end-line 2)))
+  (check-pred tool-result-is-error? result)
+  (check-true (string-contains? (hash-ref (car (tool-result-content result)) 'text)
+                                "not found")))
+
+(test-case "delete-lines: start-line < 1"
+  (define tmp (make-temporary-file "q-test-dl-~a.txt"))
+  (display-to-file "a\nb\nc" tmp #:exists 'replace)
+  (define result (tool-delete-lines (hasheq 'path tmp 'start-line 0 'end-line 2)))
+  (check-pred tool-result-is-error? result)
+  (check-true (string-contains? (hash-ref (car (tool-result-content result)) 'text)
+                                "out of range"))
+  (delete-file tmp))
+
+(test-case "delete-lines: end-line > total lines"
+  (define tmp (make-temporary-file "q-test-dl-~a.txt"))
+  (display-to-file "a\nb" tmp #:exists 'replace)
+  (define result (tool-delete-lines (hasheq 'path tmp 'start-line 1 'end-line 5)))
+  (check-pred tool-result-is-error? result)
+  (check-true (string-contains? (hash-ref (car (tool-result-content result)) 'text)
+                                "exceeds file length"))
+  (delete-file tmp))
+
+(test-case "delete-lines: start-line > end-line"
+  (define tmp (make-temporary-file "q-test-dl-~a.txt"))
+  (display-to-file "a\nb\nc" tmp #:exists 'replace)
+  (define result (tool-delete-lines (hasheq 'path tmp 'start-line 3 'end-line 1)))
+  (check-pred tool-result-is-error? result)
+  (check-true (string-contains? (hash-ref (car (tool-result-content result)) 'text)
+                                "must be"))
+  (delete-file tmp))
+
+(test-case "delete-lines: missing path"
+  (define result (tool-delete-lines (hasheq 'start-line 1 'end-line 2)))
+  (check-pred tool-result-is-error? result)
+  (check-true (string-contains? (hash-ref (car (tool-result-content result)) 'text)
+                                "path")))
+
+(test-case "delete-lines: missing start-line"
+  (define result (tool-delete-lines (hasheq 'path "/tmp/test.txt" 'end-line 2)))
+  (check-pred tool-result-is-error? result)
+  (check-true (string-contains? (hash-ref (car (tool-result-content result)) 'text)
+                                "start-line")))
+
+(test-case "delete-lines: non-integer start-line"
+  (define result (tool-delete-lines (hasheq 'path "/tmp/test.txt"
+                                            'start-line "abc" 'end-line 2)))
+  (check-pred tool-result-is-error? result)
+  (check-true (string-contains? (hash-ref (car (tool-result-content result)) 'text)
+                                "integer")))
+
+;; ============================================================
+;; tool-delete-lines — details and backup
+;; ============================================================
+
+(test-case "delete-lines: result details include lines-deleted"
+  (define tmp (make-temporary-file "q-test-dl-~a.txt"))
+  (display-to-file "a\nb\nc\nd\ne" tmp #:exists 'replace)
+  (define result (tool-delete-lines (hasheq 'path tmp 'start-line 2 'end-line 4)))
+  (check-false (tool-result-is-error? result))
+  (check-equal? (hash-ref (tool-result-details result) 'lines-deleted) 3)
+  (check-equal? (hash-ref (tool-result-details result) 'start-line) 2)
+  (check-equal? (hash-ref (tool-result-details result) 'end-line) 4)
+  (check-equal? (hash-ref (tool-result-details result) 'remaining-lines) 2)
+  (delete-file tmp))
+
+(test-case "delete-lines: backup is created"
+  (define tmp (make-temporary-file "q-test-dl-~a.txt"))
+  (display-to-file "a\nb\nc" tmp #:exists 'replace)
+  (define result (tool-delete-lines (hasheq 'path tmp 'start-line 2 'end-line 2)))
+  (check-false (tool-result-is-error? result))
+  (define backup (hash-ref (tool-result-details result) 'backup ""))
+  (check-true (and (string? backup) (> (string-length backup) 0)))
+  ;; Backup should exist
+  (check-true (file-exists? backup))
+  ;; Cleanup
+  (delete-file tmp)
+  (when (file-exists? backup) (delete-file backup)))
+
+(test-case "delete-lines: preview shows deleted content"
+  (define tmp (make-temporary-file "q-test-dl-~a.txt"))
+  (display-to-file "a\nb\nc" tmp #:exists 'replace)
+  (define result (tool-delete-lines (hasheq 'path tmp 'start-line 2 'end-line 2)))
+  (check-false (tool-result-is-error? result))
+  (define text (hash-ref (car (tool-result-content result)) 'text ""))
+  (check-true (string-contains? text "b"))
+  (delete-file tmp))
+
+(test-case "delete-lines: file content unchanged after error"
+  (define tmp (make-temporary-file "q-test-dl-~a.txt"))
+  (define original "a\nb\nc")
+  (display-to-file original tmp #:exists 'replace)
+  (define result (tool-delete-lines (hasheq 'path tmp 'start-line 3 'end-line 1)))
+  (check-pred tool-result-is-error? result)
+  (check-equal? (file->string tmp) original)
+  (delete-file tmp))

--- a/tools/builtins/delete-lines.rkt
+++ b/tools/builtins/delete-lines.rkt
@@ -1,0 +1,197 @@
+#lang racket/base
+
+;; tools/builtins/delete-lines.rkt — line-range deletion tool
+;;
+;; Exports:
+;;   tool-delete-lines : (hash [exec-ctx]) -> tool-result?
+;;   Arguments: path (string), start-line (integer), end-line (integer)
+;;   Returns:  tool-result with success or error details
+;;
+;; v0.21.10 (F2+F9): Addresses edit failures from the 500-char old-text
+;; limit by providing a line-number-based deletion that avoids text matching
+;; entirely. The LLM reads the file, identifies line numbers, and calls
+;; delete-lines instead of chunking large removals.
+;;
+;; Safeguards:
+;;   - Pre-edit backup to ~/.q/edit-backups/ (same as edit tool)
+;;   - Post-edit line-count delta check with auto-revert on corruption
+;;   - Safe-mode path check (same as edit tool)
+
+(require racket/file
+         racket/string
+         (only-in racket/list last drop take)
+         (only-in "../tool.rkt" make-success-result make-error-result)
+         (only-in "../../util/safe-mode-predicates.rkt"
+                  safe-mode?
+                  allowed-path?
+                  safe-mode-project-root)
+         (only-in "../../util/path-helpers.rkt" expand-home-path)
+         (only-in "../../util/error-sanitizer.rkt" sanitize-error-message))
+
+(provide tool-delete-lines)
+
+;; --------------------------------------------------
+;; Constants
+;; --------------------------------------------------
+
+(define MAX-BACKUPS-PER-FILE 10)
+
+;; --------------------------------------------------
+;; Backup helpers (shared pattern with edit.rkt)
+;; --------------------------------------------------
+
+(define (ensure-backup-dir)
+  (define dir (build-path (find-system-path 'home-dir) ".q" "edit-backups"))
+  (unless (directory-exists? dir)
+    (make-directory* dir)
+    (file-or-directory-permissions dir #o700))
+  dir)
+
+(define (save-backup path-str content)
+  (with-handlers ([exn:fail? (lambda (e)
+                               (log-warning (format "delete-lines/backup: ~a" (exn-message e)))
+                               #f)])
+    (define dir (ensure-backup-dir))
+    (define basename (file-name-from-path path-str))
+    (define timestamp (number->string (abs (current-milliseconds))))
+    (define backup-name (format "~a_~a" timestamp basename))
+    (define backup-path (build-path dir backup-name))
+    (display-to-file content backup-path #:exists 'replace)
+    (prune-old-backups dir basename)
+    (path->string backup-path)))
+
+(define (file-name-from-path p)
+  (define fname (if (string? p) p (path->string p)))
+  (define parts (regexp-split #rx"/" fname))
+  (if (null? parts) "unknown" (last parts)))
+
+(define (prune-old-backups dir basename)
+  (with-handlers ([exn:fail? (lambda (e)
+                               (log-warning (format "delete-lines/prune: ~a" (exn-message e)))
+                               (void))])
+    (define all (directory-list dir))
+    (define matching
+      (filter (lambda (f) (string-suffix? (path->string f) (format "_~a" basename)))
+              (sort (map path->string all) string>?)))
+    (when (> (length matching) MAX-BACKUPS-PER-FILE)
+      (for ([f (in-list (drop matching MAX-BACKUPS-PER-FILE))])
+        (delete-file (build-path dir f))))))
+
+;; --------------------------------------------------
+;; Line helpers
+;; --------------------------------------------------
+
+(define (line-count s)
+  (length (string-split s "\n" #:trim? #f)))
+
+(define (get-lines content)
+  (string-split content "\n" #:trim? #f))
+
+;; --------------------------------------------------
+;; Main tool function
+;; --------------------------------------------------
+
+(define (tool-delete-lines args [exec-ctx #f])
+  (define raw-path (hash-ref args 'path #f))
+  (define path-str (and raw-path (expand-home-path raw-path)))
+  (cond
+    [(not path-str)
+     (make-error-result "Missing required argument: path")]
+    [else
+     (define start-line (hash-ref args 'start-line #f))
+     (define end-line (hash-ref args 'end-line #f))
+     (cond
+       [(not start-line)
+        (make-error-result "Missing required argument: start-line")]
+       [(not end-line)
+        (make-error-result "Missing required argument: end-line")]
+       [(not (exact-integer? start-line))
+        (make-error-result (format "start-line must be an integer, got: ~v" start-line))]
+       [(not (exact-integer? end-line))
+        (make-error-result (format "end-line must be an integer, got: ~v" end-line))]
+       [else
+        ;; Defense-in-depth: safe-mode path check (same as edit tool)
+        (cond
+          [(and (safe-mode?) (not (allowed-path? path-str)))
+           (make-error-result (format "delete-lines: path '~a' outside project root (~a)"
+                                      path-str
+                                      (safe-mode-project-root)))]
+          [(not (file-exists? path-str))
+           (make-error-result (format "File not found: ~a" path-str))]
+
+          [else
+           (define content (file->string path-str))
+           (define lines (get-lines content))
+           (define total-lines (length lines))
+
+           (cond
+             ;; Validate line range
+             [(< start-line 1)
+              (make-error-result
+               (format "start-line ~a is out of range. File has ~a lines (1-based)."
+                       start-line total-lines))]
+             [(> end-line total-lines)
+              (make-error-result
+               (format "end-line ~a exceeds file length. File has ~a lines (1-based)."
+                       end-line total-lines))]
+             [(> start-line end-line)
+              (make-error-result
+               (format "start-line (~a) must be ≤ end-line (~a)" start-line end-line))]
+
+             [else
+              ;; Extract preview of deleted lines
+              (define deleted-lines (take (drop lines (sub1 start-line))
+                                         (- end-line start-line -1)))
+              (define preview
+                (if (<= (length deleted-lines) 5)
+                    (string-join deleted-lines "\n")
+                    (string-append (string-join (take deleted-lines 3) "\n")
+                                   "\n  ..."
+                                   (last deleted-lines))))
+
+              ;; Save backup
+              (define backup-path (save-backup path-str content))
+
+              ;; Build new content: lines before start + lines after end
+              (define before (take lines (sub1 start-line)))
+              (define after (drop lines end-line))
+              (define new-lines (append before after))
+              (define new-content (string-join new-lines "\n"))
+
+              ;; Post-edit line-count integrity check
+              (define expected-deleted (- end-line start-line -1))
+              (define actual-deleted (- total-lines (length new-lines)))
+
+              (cond
+                [(not (= actual-deleted expected-deleted))
+                 ;; Auto-revert
+                 (with-handlers ([exn:fail? (lambda (e)
+                                              (log-warning
+                                               (format "delete-lines/auto-revert: ~a"
+                                                       (exn-message e)))
+                                              (void))])
+                   (display-to-file content path-str #:exists 'replace))
+                 (make-error-result
+                  (format "Delete reverted: line count mismatch (expected to delete ~a, actually deleted ~a). File restored."
+                          expected-deleted actual-deleted))]
+
+                [else
+                 ;; Write new content
+                 (with-handlers ([exn:fail:filesystem?
+                                  (lambda (e)
+                                    (make-error-result (sanitize-error-message
+                                                        (format "Write error: ~a"
+                                                                (exn-message e)))))])
+                   (display-to-file new-content path-str #:exists 'replace)
+
+                   (make-success-result
+                    (list (hasheq 'type "text"
+                                  'text (format "Deleted lines ~a-~a from ~a (~a lines removed)\nPreview:\n~a"
+                                                start-line end-line path-str
+                                                expected-deleted preview)))
+                    (hasheq 'path path-str
+                            'lines-deleted expected-deleted
+                            'start-line start-line
+                            'end-line end-line
+                            'remaining-lines (length new-lines)
+                            'backup (or backup-path ""))))])])])])]))

--- a/tools/builtins/edit.rkt
+++ b/tools/builtins/edit.rkt
@@ -56,7 +56,7 @@
                                #f)])
     (define dir (ensure-backup-dir))
     (define basename (file-name-from-path path-str))
-    (define timestamp (format "~a" (inexact->exact (current-inexact-milliseconds))))
+    (define timestamp (number->string (abs (current-milliseconds))))
     (define backup-name (format "~a_~a" timestamp basename))
     (define backup-path (build-path dir backup-name))
     (display-to-file content backup-path #:exists 'replace)

--- a/tools/registry-defaults.rkt
+++ b/tools/registry-defaults.rkt
@@ -11,6 +11,7 @@
          "builtins/read.rkt"
          "builtins/write.rkt"
          "builtins/edit.rkt"
+         "builtins/delete-lines.rkt"
          "builtins/bash.rkt"
          "builtins/grep.rkt"
          "builtins/find.rkt"
@@ -323,6 +324,27 @@
                        'description
                        "Retrieve a range of entries by ID (inclusive)")))
       tool-session-recall)))
+
+  (when (should-register? "delete-lines")
+    (register-tool!
+     registry
+     (make-tool
+      "delete-lines"
+      "Delete a range of lines from a file by line number. Use instead of edit for removing 3+ consecutive lines."
+      (hasheq 'type
+              "object"
+              'required
+              '("path" "start-line" "end-line")
+              'properties
+              (hasheq 'path
+                      (hasheq 'type "string" 'description "Path to file")
+                      'start-line
+                      (hasheq 'type "integer" 'description "1-based start line (inclusive)")
+                      'end-line
+                      (hasheq 'type "integer" 'description "1-based end line (inclusive)")))
+      tool-delete-lines
+      #:prompt-guidelines
+      "Prefer delete-lines over edit for removing 3+ consecutive lines. Read the file first to identify exact line numbers.")))
 
   ;; skill-route: discover and search skills by description match
   (when (should-register? "skill-route")


### PR DESCRIPTION
Addresses #2171.

feat: delete-lines tool + fix backup timestamp bug (#2171)

W0 of v0.21.10: Add line-range deletion tool to avoid edit failures
from 500-char old-text limit. Fix rational-number backup timestamp in
both edit.rkt and delete-lines.rkt. Update GSD execution prompt with
delete-lines guidance.