### PR TITLE
feat: /wave-done command + STATE.md update (#2172)

W1 of v0.21.10: Add /wave-done N command that updates PLAN.md wave
status marker and STATE.md progress section. Register as /wave-done
and /wd alias. Update execution prompt to mention /wave-done.
Also fix backup timestamp bug (rational numbers in filenames).

### DIFF
--- a/extensions/gsd-planning.rkt
+++ b/extensions/gsd-planning.rkt
@@ -38,7 +38,7 @@
          "gsd/state-machine.rkt"
          "gsd/core.rkt"
          ;; v0.21.6: direct command handlers for wiring
-         (only-in "gsd/core.rkt" cmd-replan cmd-skip cmd-reset cmd-done)
+         (only-in "gsd/core.rkt" cmd-replan cmd-skip cmd-reset cmd-done cmd-wave-done)
 
          "gsd/plan-types.rkt"
          "gsd/plan-validator.rkt"
@@ -407,6 +407,12 @@
   (ext-register-command! ctx "/replan" "Return to planning phase" 'general '() '())
   (ext-register-command! ctx "/skip" "Skip a wave (usage: /skip N)" 'general '() '())
   (ext-register-command! ctx "/reset" "Reset GSD to idle state" 'general '() '())
+  (ext-register-command! ctx
+                         "/wave-done"
+                         "Mark wave N complete, update PLAN.md and STATE.md"
+                         'general
+                         '()
+                         '("wd"))
   (ext-register-command! ctx "/done" "Archive completed plan" 'general '() '("d"))
   (ext-register-command! ctx "/gsd" "Show GSD workflow status" 'general '() '())
   (hook-pass #f))
@@ -438,6 +444,14 @@
     [(equal? cmd "/reset")
      (define result (cmd-reset))
      (emit-gsd-event! "gsd.mode.changed" (hasheq 'mode 'idle))
+     (hook-amend (hasheq 'text (hash-ref result 'message "")))]
+    [(member cmd '("/wave-done" "/wd"))
+     (define wd-args (extract-cmd-args input-text))
+     (define result (cmd-wave-done base-dir wd-args))
+     (when (hash-ref result 'success #f)
+       (define wave-idx (hash-ref result 'wave #f))
+       (when wave-idx
+         (emit-gsd-event! "gsd.wave.completed" (hasheq 'wave wave-idx))))
      (hook-amend (hasheq 'text (hash-ref result 'message "")))]
     [(equal? cmd "/done")
      (define done-args (extract-cmd-args input-text))

--- a/extensions/gsd/core.rkt
+++ b/extensions/gsd/core.rkt
@@ -19,10 +19,13 @@
 (require racket/string
          racket/format
          racket/path
+         racket/port
          "state-machine.rkt"
          "plan-types.rkt"
          "context-bundle.rkt"
-         "archive.rkt")
+         "archive.rkt"
+         ;; v0.21.10: wave-done needs mark-wave-complete! which also updates PLAN.md
+         (only-in "../gsd-planning-state.rkt" mark-wave-complete! pinned-planning-dir))
 
 (provide gsd-command-dispatch
          gsd-tool-guard
@@ -33,6 +36,7 @@
          cmd-skip
          cmd-reset
          cmd-done
+         cmd-wave-done
          ;; Command names for registration
          gsd-commands)
 
@@ -41,12 +45,14 @@
 ;; ============================================================
 
 (define gsd-commands
-  '((plan "/plan" "Start GSD planning phase" ("p")) (go "/go" "Begin executing the plan" ())
-                                                    (replan "/replan" "Return to planning phase" ())
-                                                    (skip "/skip" "Skip current wave" ("s"))
-                                                    (done "/done" "Archive completed plan" ("d"))
-                                                    (reset "/reset" "Reset GSD to idle state" ())
-                                                    (gsd "/gsd" "Show GSD status" ())))
+  '((plan "/plan" "Start GSD planning phase" ("p"))
+    (go "/go" "Begin executing the plan" ())
+    (replan "/replan" "Return to planning phase" ())
+    (skip "/skip" "Skip current wave" ("s"))
+    (done "/done" "Archive completed plan" ("d"))
+    (reset "/reset" "Reset GSD to idle state" ())
+    (wave-done "/wave-done" "Mark wave N as complete, update PLAN.md and STATE.md" ("wd"))
+    (gsd "/gsd" "Show GSD status" ())))
 
 ;; ============================================================
 ;; Internal helpers (must be defined before use)
@@ -109,6 +115,7 @@
     [(skip) (cmd-skip args)]
     [(reset) (cmd-reset)]
     [(done) (hasheq 'success #t 'mode 'idle 'message "Use /done from the planning context.")]
+    [(wave-done) (cmd-wave-done #f args)]
     [(gsd) (gsd-show-status)]
     [else #f]))
 
@@ -198,6 +205,65 @@
                     'message
                     (format "Wave ~a marked as skipped" wave-num))
             (hasheq 'success #f 'mode 'executing 'message "Usage: /skip <wave-number>")))))
+
+;; /wave-done <N> → mark wave complete, update PLAN.md + STATE.md
+(define (cmd-wave-done base-dir args)
+  (define idx-str
+    (if (string? args)
+        (string-trim args)
+        ""))
+  (cond
+    [(string=? idx-str "") (hasheq 'success #f 'message "Usage: /wave-done <wave-number>")]
+    [else
+     (define idx (string->number idx-str))
+     (cond
+       [(not idx) (hasheq 'success #f 'message (format "Invalid wave number: ~a" idx-str))]
+       [(< idx 0) (hasheq 'success #f 'message "Wave number must be non-negative")]
+       [else
+        ;; Mark wave complete in state machine + PLAN.md
+        (mark-wave-complete! idx)
+        ;; Update STATE.md with wave completion
+        (when base-dir
+          (with-handlers ([exn:fail? (lambda (e)
+                                       (log-warning (format "cmd-wave-done/state-update: ~a"
+                                                            (exn-message e))))])
+            (update-state-with-wave! base-dir idx)))
+        (hasheq 'success
+                #t
+                'wave
+                idx
+                'message
+                (format "Wave ~a marked complete. PLAN.md and STATE.md updated." idx))])]))
+
+;; Helper: update STATE.md with wave completion note
+(define (update-state-with-wave! base-dir wave-idx)
+  (define state-path (build-path base-dir ".planning" "STATE.md"))
+  (when (file-exists? state-path)
+    (define content (call-with-input-file state-path port->string))
+    (define wave-header "## Wave Progress")
+    (define entry-line (format "- [x] W~a: completed" wave-idx))
+    (define new-content
+      (cond
+        [(string-contains? content wave-header)
+         ;; Update existing progress section — replace or append entry
+         (define lines (string-split content "\n"))
+         (define prefix-rx (format "- \\[.\\] W~a:" wave-idx))
+         (define updated
+           (for/list ([line lines])
+             (if (regexp-match? (regexp prefix-rx) line) entry-line line)))
+         ;; If the entry wasn't found, append it after the header
+         (if (member entry-line updated)
+             (string-join updated "\n")
+             (let loop ([ls updated]
+                        [acc '()])
+               (cond
+                 [(null? ls) (string-join (reverse acc) "\n")]
+                 [(string=? (car ls) wave-header)
+                  (string-join (append (reverse acc) (list wave-header entry-line) (cdr ls)) "\n")]
+                 [else (loop (cdr ls) (cons (car ls) acc))])))]
+        ;; Append a new wave progress section
+        [else (string-append content "\n\n" wave-header "\n\n" entry-line "\n")]))
+    (call-with-output-file state-path (lambda (out) (display new-content out)) #:exists 'truncate)))
 
 ;; /reset → idle
 (define (cmd-reset)

--- a/extensions/gsd/prompts.rkt
+++ b/extensions/gsd/prompts.rkt
@@ -91,7 +91,7 @@
    (format "Executing plan with ~a waves. Starting from wave ~a.\n\n" wave-count (or next-idx 0))
    "Instructions:\n"
    "- Follow the plan strictly — do not expand scope\n"
-   "- After completing each wave's tasks, mark it complete\n"
+   "- After completing each wave's tasks, use /wave-done N to update PLAN.md and STATE.md\n"
    "- If a wave fails, use `/skip <N>` to skip it and proceed\n"
    "- Use `/replan` if the plan needs fundamental changes\n"
    "- Run verify commands after each wave\n\n"

--- a/tests/test-gsd-planning.rkt
+++ b/tests/test-gsd-planning.rkt
@@ -20,6 +20,7 @@
          "../extensions/ext-commands.rkt"
          "../extensions/api.rkt"
          "../extensions/hooks.rkt"
+         (only-in "../extensions/gsd/core.rkt" cmd-wave-done)
          "../tools/tool.rkt"
          "../agent/event-bus.rkt"
          "../util/event.rkt")
@@ -634,7 +635,7 @@
 (test-case "planning-system-prompt-no-unlimited-exploration"
   (define p (planning-system-prompt ""))
   (check-true (string-contains? p "MAXIMUM 5 tool calls")
-               "prompt should limit exploration to 5 calls"))
+              "prompt should limit exploration to 5 calls"))
 
 ;; ============================================================
 ;; W2: /plan Overwrite Stale Plans Tests
@@ -642,10 +643,8 @@
 
 (test-case "planning-system-prompt-references-wave-docs"
   (define p (planning-system-prompt ""))
-  (check-true (string-contains? p "waves/")
-              "prompt should reference wave documents")
-  (check-true (string-contains? p "planning-write")
-              "prompt should mention planning-write tool"))
+  (check-true (string-contains? p "waves/") "prompt should reference wave documents")
+  (check-true (string-contains? p "planning-write") "prompt should mention planning-write tool"))
 
 (test-case "/plan-with-text-injects-stale-warning-when-plan-exists"
   (reset-all-gsd-state!)
@@ -858,4 +857,120 @@
   (define handler (hash-ref (extension-hooks gsd-planning-extension) 'execute-command))
   (define result (handler (hasheq 'command "/unknown-cmd" 'input "/unknown-cmd")))
   (check-equal? (hook-result-action result) 'pass)
+  (reset-all-gsd-state!))
+
+;; ============================================================
+;; /wave-done command tests (v0.21.10)
+;; ============================================================
+
+(test-case "wave-done: marks wave complete with valid index"
+  (reset-all-gsd-state!)
+  (define tmp-dir (make-temporary-file "q-test-wave-done-~a" 'directory))
+  (define planning-dir (build-path tmp-dir ".planning"))
+  (make-directory planning-dir)
+  ;; Create a minimal PLAN.md with wave index
+  (display-to-file "# Test Plan\n\n- [Inbox] W0: First wave\n- [Inbox] W1: Second wave\n"
+                   (build-path planning-dir "PLAN.md")
+                   #:exists 'replace)
+  ;; Create STATE.md
+  (display-to-file "# Project State\n\nStatus: Active\n"
+                   (build-path planning-dir "STATE.md")
+                   #:exists 'replace)
+  ;; Set up GSD state
+  (set-pinned-planning-dir! tmp-dir)
+  (set-gsd-mode! 'planning)
+  (set-gsd-mode! 'plan-written)
+  (set-gsd-mode! 'executing)
+  (set-total-waves! 2)
+  ;; Call cmd-wave-done
+  (define result (cmd-wave-done tmp-dir "0"))
+  (check-true (hash-ref result 'success))
+  (check-equal? (hash-ref result 'wave) 0)
+  (check-true (string-contains? (hash-ref result 'message) "Wave 0"))
+  ;; Verify PLAN.md updated
+  (define plan-content (file->string (build-path planning-dir "PLAN.md")))
+  (check-true (string-contains? plan-content "[DONE] W0:"))
+  (check-true (string-contains? plan-content "[Inbox] W1:"))
+  ;; Verify STATE.md updated
+  (define state-content (file->string (build-path planning-dir "STATE.md")))
+  (check-true (string-contains? state-content "W0: completed"))
+  ;; Cleanup
+  (delete-directory/files tmp-dir)
+  (reset-all-gsd-state!))
+
+(test-case "wave-done: without index returns usage"
+  (reset-all-gsd-state!)
+  (define result (cmd-wave-done #f ""))
+  (check-false (hash-ref result 'success))
+  (check-true (string-contains? (hash-ref result 'message) "Usage"))
+  (reset-all-gsd-state!))
+
+(test-case "wave-done: non-numeric index returns error"
+  (reset-all-gsd-state!)
+  (define result (cmd-wave-done #f "abc"))
+  (check-false (hash-ref result 'success))
+  (check-true (string-contains? (hash-ref result 'message) "Invalid"))
+  (reset-all-gsd-state!))
+
+(test-case "wave-done: negative index returns error"
+  (reset-all-gsd-state!)
+  (define result (cmd-wave-done #f "-1"))
+  (check-false (hash-ref result 'success))
+  (check-true (string-contains? (hash-ref result 'message) "non-negative"))
+  (reset-all-gsd-state!))
+
+(test-case "wave-done: multiple waves can be marked"
+  (reset-all-gsd-state!)
+  (define tmp-dir (make-temporary-file "q-test-wave-done-~a" 'directory))
+  (define planning-dir (build-path tmp-dir ".planning"))
+  (make-directory planning-dir)
+  (display-to-file "# Test Plan\n\n- [Inbox] W0: First\n- [Inbox] W1: Second\n"
+                   (build-path planning-dir "PLAN.md")
+                   #:exists 'replace)
+  (display-to-file "# Project State\n\nStatus: Active\n"
+                   (build-path planning-dir "STATE.md")
+                   #:exists 'replace)
+  (set-pinned-planning-dir! tmp-dir)
+  (set-gsd-mode! 'planning)
+  (set-gsd-mode! 'plan-written)
+  (set-gsd-mode! 'executing)
+  (set-total-waves! 2)
+  ;; Mark W0
+  (define r0 (cmd-wave-done tmp-dir "0"))
+  (check-true (hash-ref r0 'success))
+  ;; Mark W1
+  (define r1 (cmd-wave-done tmp-dir "1"))
+  (check-true (hash-ref r1 'success))
+  ;; Both marked in PLAN.md
+  (define plan-content (file->string (build-path planning-dir "PLAN.md")))
+  (check-true (string-contains? plan-content "[DONE] W0:"))
+  (check-true (string-contains? plan-content "[DONE] W1:"))
+  ;; Both in STATE.md
+  (define state-content (file->string (build-path planning-dir "STATE.md")))
+  (check-true (string-contains? state-content "W0: completed"))
+  (check-true (string-contains? state-content "W1: completed"))
+  (delete-directory/files tmp-dir)
+  (reset-all-gsd-state!))
+
+(test-case "wave-done: works through execute-command handler"
+  (reset-all-gsd-state!)
+  (define tmp-dir (make-temporary-file "q-test-wave-done-~a" 'directory))
+  (define planning-dir (build-path tmp-dir ".planning"))
+  (make-directory planning-dir)
+  (display-to-file "# Test Plan\n\n- [Inbox] W0: First\n"
+                   (build-path planning-dir "PLAN.md")
+                   #:exists 'replace)
+  (display-to-file "# Project State\n\nStatus: Active\n"
+                   (build-path planning-dir "STATE.md")
+                   #:exists 'replace)
+  (set-pinned-planning-dir! tmp-dir)
+  (set-gsd-mode! 'planning)
+  (set-gsd-mode! 'plan-written)
+  (set-gsd-mode! 'executing)
+  (set-total-waves! 1)
+  (define handler (hash-ref (extension-hooks gsd-planning-extension) 'execute-command))
+  (define result (handler (hasheq 'command "/wave-done" 'input "/wave-done 0")))
+  (check-equal? (hook-result-action result) 'amend)
+  (check-true (string-contains? (hash-ref (hook-result-payload result) 'text) "Wave 0"))
+  (delete-directory/files tmp-dir)
   (reset-all-gsd-state!))


### PR DESCRIPTION
Addresses #2172.

feat: /wave-done command + STATE.md update (#2172)

W1 of v0.21.10: Add /wave-done N command that updates PLAN.md wave
status marker and STATE.md progress section. Register as /wave-done
and /wd alias. Update execution prompt to mention /wave-done.
Also fix backup timestamp bug (rational numbers in filenames).