### PR TITLE
chore: version bump to 0.21.10 (#2174)

W3 of v0.21.10: Update version in util/version.rkt, CHANGELOG.md,
and README.md. Add v0.21.10 changelog entry with delete-lines tool,
/wave-done command, planning path resolution, and backup timestamp fix.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v0.21.10 — 2026-04-28
+
+### Execution Architecture Improvements
+- **delete-lines tool**: Line-range deletion tool (avoids chunked edit for removals of 3+ consecutive lines)
+- **/wave-done command**: Marks wave complete in PLAN.md + STATE.md, emits `gsd.wave.completed` event
+- **Planning path resolution**: `.planning/` write paths auto-rewrite to pinned project root
+- **Backup timestamp fix**: Eliminated rational numbers in backup filenames (`inexact->exact` → `current-milliseconds`)
+- **Execution prompt**: Updated to mention `/wave-done N` for wave completion
+
 ## v0.21.9 — 2026-04-28
 
 ### GSD Plan Archival + Execution Polish

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.21.9-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.21.10-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 
@@ -199,7 +199,7 @@ racket main.rkt --model gpt-5.4 "write a test"
 ### Verify
 
 ```bash
-racket main.rkt --version  # q version 0.21.9
+racket main.rkt --version  # q version 0.21.10
 raco test tests/           # run the full test suite
 ```
 
@@ -332,6 +332,8 @@ When q executes shell commands on behalf of an LLM, arguments are quoted via `sh
 | [Architecture](docs/adr/) | Architecture decision records |
 
 ## Status
+
+**v0.21.10** — Execution Architecture Improvements. `delete-lines` tool, `/wave-done` command, planning path resolution hardening, backup timestamp fix. 4 issues across 4 waves.
 
 **v0.21.9** — GSD Plan Archival + Execution Polish. `/done` command, PLAN.md status auto-update, STATE.md auto-creation, TUI archive notification, iteration label fix, edit chunking guidance. 10 issues across 4 waves.
 

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -7,4 +7,4 @@
 
 (provide q-version)
 
-(define q-version "0.21.9")
+(define q-version "0.21.10")


### PR DESCRIPTION
Addresses #2174.

chore: version bump to 0.21.10 (#2174)

W3 of v0.21.10: Update version in util/version.rkt, CHANGELOG.md,
and README.md. Add v0.21.10 changelog entry with delete-lines tool,
/wave-done command, planning path resolution, and backup timestamp fix.