### PR TITLE
feat: code quality — QUAL-01 runtime helpers, QUAL-04 shadowed imports, QUAL-05 provider contracts, SEC-16 shell-quote consolidation (#2184)

W1 of v0.22.0:
- QUAL-01: Extract runtime-helpers.rkt from iteration.rkt + tool-coordinator.rkt (emit-session-event!, maybe-dispatch-hooks)
- QUAL-04: Replace bare gsd/core.rkt require with only-in in gsd-planning.rkt
- QUAL-05: Add contract-out for make-openai-compatible-provider and make-azure-openai-provider
- SEC-16: Consolidate shell-quote into util/shell-quote.rkt, import from subprocess.rkt and github/helpers.rkt
- NEW: tests/test-runtime-helpers.rkt (2 tests)
- 316 tests pass

### DIFF
--- a/extensions/github/helpers.rkt
+++ b/extensions/github/helpers.rkt
@@ -10,6 +10,8 @@
          racket/string
          racket/system
          json
+         ;; SEC-16 (v0.22.0): consolidated shell-quote
+         (only-in "../../util/shell-quote.rkt" shell-quote)
          (only-in "../../tools/tool.rkt" make-success-result make-error-result))
 
 (provide gh-binary-path
@@ -39,12 +41,7 @@
 ;; Shell helpers + input validation
 ;; ============================================================
 
-(define (shell-quote s)
-  (define str
-    (if (string? s)
-        s
-        (~a s)))
-  (string-append "'" (string-replace str "'" "'\\''") "'"))
+;; shell-quote imported from util/shell-quote.rkt (SEC-16 consolidation)
 
 ;; Validate that a string contains only safe identifier characters
 (define (valid-identifier? s)

--- a/extensions/gsd-planning.rkt
+++ b/extensions/gsd-planning.rkt
@@ -36,9 +36,10 @@
          "gsd-planning-state.rkt"
          ;; v0.21.0 new modules
          "gsd/state-machine.rkt"
-         "gsd/core.rkt"
-         ;; v0.21.6: direct command handlers for wiring
-         (only-in "gsd/core.rkt" cmd-replan cmd-skip cmd-reset cmd-done cmd-wave-done)
+         (only-in "gsd/core.rkt"
+                  gsd-write-guard
+                  gsd-show-status
+                  cmd-replan cmd-skip cmd-reset cmd-done cmd-wave-done)
 
          "gsd/plan-types.rkt"
          "gsd/plan-validator.rkt"

--- a/llm/azure-openai.rkt
+++ b/llm/azure-openai.rkt
@@ -26,7 +26,7 @@
          "http-helpers.rkt"
          (only-in "openai-compatible.rkt" openai-build-request-body openai-parse-response))
 
-(provide make-azure-openai-provider
+(provide (contract-out [make-azure-openai-provider (-> hash? provider?)])
          openai-parse-response-from-jsexpr
          check-azure-status!)
 

--- a/llm/openai-compatible.rkt
+++ b/llm/openai-compatible.rkt
@@ -23,7 +23,7 @@
          "http-helpers.rkt")
 
 ;; Provider constructor
-(provide make-openai-compatible-provider
+(provide (contract-out [make-openai-compatible-provider (-> hash? provider?)])
          ;; Request/response helpers (exported for testing)
          openai-build-request-body
          openai-parse-response

--- a/runtime/iteration.rkt
+++ b/runtime/iteration.rkt
@@ -118,9 +118,12 @@
          ;; FEAT-61: message injection support
          (only-in "../extensions/message-inject.rkt" injection-event-topic)
          ;; v0.14.1: mid-turn token budget check
-         (only-in "../llm/token-budget.rkt" estimate-context-tokens))
+         (only-in "../llm/token-budget.rkt" estimate-context-tokens)
+         ;; QUAL-01 (v0.22.0): shared runtime helpers
+         (only-in "runtime-helpers.rkt" emit-session-event! maybe-dispatch-hooks))
 
 (provide run-iteration-loop
+         ;; emit-session-event! and maybe-dispatch-hooks re-exported from runtime-helpers
          emit-session-event!
          maybe-dispatch-hooks
          ensure-hash-args ;; for testing
@@ -138,21 +141,8 @@
          register-session-extensions!)
 
 ;; ============================================================
-;; Shared helpers
+;; Shared helpers (QUAL-01: re-exported from runtime-helpers.rkt)
 ;; ============================================================
-
-(define (emit-session-event! bus sid event-name payload)
-  (define evt (make-event event-name (now-seconds) sid #f payload))
-  (publish! bus evt)
-  evt)
-
-;; Safely dispatch hooks if extension-registry is present.
-;; Returns (values amended-payload hook-result) or (values payload #f) if no registry.
-(define (maybe-dispatch-hooks ext-reg hook-point payload #:ctx [ctx #f])
-  (if ext-reg
-      (let ([result (dispatch-hooks hook-point payload ext-reg #:ctx ctx)])
-        (values (hook-result-payload result) result))
-      (values payload #f)))
 
 ;; v0.14.1: Check if context exceeds mid-turn token budget.
 ;; Returns estimated token count. Emits event if over budget.

--- a/runtime/runtime-helpers.rkt
+++ b/runtime/runtime-helpers.rkt
@@ -1,0 +1,32 @@
+#lang racket/base
+
+;; runtime/runtime-helpers.rkt — shared runtime helper functions
+;;
+;; QUAL-01 (v0.22.0): Extracted from iteration.rkt and tool-coordinator.rkt
+;; to eliminate duplication. Both files had identical copies of
+;; emit-session-event! and maybe-dispatch-hooks.
+;;
+;; Dependencies: event-bus, protocol-types, hooks, ids.
+
+(require (only-in "../agent/event-bus.rkt" publish!)
+         (only-in "../util/protocol-types.rkt" make-event)
+         (only-in "../util/ids.rkt" now-seconds)
+         (only-in "../extensions/hooks.rkt" dispatch-hooks)
+         (only-in "../util/hook-types.rkt" hook-result-payload))
+
+(provide emit-session-event!
+         maybe-dispatch-hooks)
+
+;; Publish a session-scoped event to the event bus.
+(define (emit-session-event! bus sid event-name payload)
+  (define evt (make-event event-name (now-seconds) sid #f payload))
+  (publish! bus evt)
+  evt)
+
+;; Safely dispatch hooks if extension-registry is present.
+;; Returns (values amended-payload hook-result) or (values payload #f) if no registry.
+(define (maybe-dispatch-hooks ext-reg hook-point payload #:ctx [ctx #f])
+  (if ext-reg
+      (let ([result (dispatch-hooks hook-point payload ext-reg #:ctx ctx)])
+        (values (hook-result-payload result) result))
+      (values payload #f)))

--- a/runtime/tool-coordinator.rkt
+++ b/runtime/tool-coordinator.rkt
@@ -50,29 +50,20 @@
          (only-in "../util/content-helpers.rkt" tool-result-content->string)
          (only-in "../util/ids.rkt" generate-id now-seconds)
          (only-in "../util/cancellation.rkt" cancellation-token?)
-         (only-in "../util/hook-types.rkt" hook-result-action hook-result-payload hook-result?))
+         (only-in "../util/hook-types.rkt" hook-result-action hook-result-payload hook-result?)
+         ;; QUAL-01 (v0.22.0): shared runtime helpers
+         (only-in "runtime-helpers.rkt" emit-session-event! maybe-dispatch-hooks))
 
 (provide extract-tool-calls-from-messages
          make-tool-result-messages
          handle-tool-calls-pending)
 
 ;; ============================================================
-;; Helpers
+;; Helpers (QUAL-01: emit-session-event! and maybe-dispatch-hooks
+;;           now imported from runtime-helpers.rkt)
 ;; ============================================================
 
 ;; now-seconds imported from util/ids.rkt
-
-(define (emit-session-event! bus sid event-name payload)
-  (define evt (make-event event-name (now-seconds) sid #f payload))
-  (publish! bus evt)
-  evt)
-
-;; Safely dispatch hooks if extension-registry is present.
-(define (maybe-dispatch-hooks ext-reg hook-point payload #:ctx [ctx #f])
-  (if ext-reg
-      (let ([result (dispatch-hooks hook-point payload ext-reg #:ctx ctx)])
-        (values (hook-result-payload result) result))
-      (values payload #f)))
 
 ;; ============================================================
 ;; Exported functions

--- a/sandbox/subprocess.rkt
+++ b/sandbox/subprocess.rkt
@@ -8,7 +8,9 @@
 
 (require racket/port
          racket/string
-         "limits.rkt")
+         "limits.rkt"
+         ;; SEC-16 (v0.22.0): consolidated shell-quote
+         (only-in "../util/shell-quote.rkt" shell-quote))
 
 (define-logger subprocess)
 
@@ -96,14 +98,8 @@
 ;; --------------------------------------------------
 
 ;; shell-quote — POSIX single-quote escaping for command arguments.
-;;
-;; SECURITY NOTE: This function is designed for quoting LLM-generated arguments
-;; within a trusted agent loop. It is NOT intended as a defense against
-;; adversarial input. The sandbox layer (custodians, timeouts, environment
-;; sanitization, output limits) provides defense-in-depth, but callers must
-;; not rely on shell-quote alone to prevent injection from untrusted sources.
-(define (shell-quote s)
-  (format "'~a'" (string-replace s "'" "'\\''")))
+;; SEC-16 (v0.22.0): Consolidated into util/shell-quote.rkt.
+;; This file imports from there; no local definition needed.
 
 ;; --------------------------------------------------
 ;; Resolve command to executable path

--- a/tests/test-runtime-helpers.rkt
+++ b/tests/test-runtime-helpers.rkt
@@ -1,0 +1,25 @@
+#lang racket/base
+
+;; tests/test-runtime-helpers.rkt — QUAL-01: runtime helper extraction
+
+(require rackunit
+         (only-in "../agent/event-bus.rkt" make-event-bus subscribe!)
+         (only-in "../util/protocol-types.rkt" event-ev event-payload)
+         (only-in "../runtime/runtime-helpers.rkt"
+                  emit-session-event!
+                  maybe-dispatch-hooks))
+
+(test-case "QUAL-01: emit-session-event! publishes event to bus"
+  (define bus (make-event-bus))
+  (define received (box #f))
+  (subscribe! bus (lambda (evt) (set-box! received evt)))
+  (emit-session-event! bus "test-session" "test.event" (hasheq 'key "value"))
+  (define r (unbox received))
+  (check-not-false r)
+  (check-equal? (event-ev r) "test.event")
+  (check-equal? (hash-ref (event-payload r) 'key) "value"))
+
+(test-case "QUAL-01: maybe-dispatch-hooks returns payload+false when no registry"
+  (define-values (amended hook-res) (maybe-dispatch-hooks #f 'test "payload"))
+  (check-equal? amended "payload")
+  (check-false hook-res))

--- a/util/shell-quote.rkt
+++ b/util/shell-quote.rkt
@@ -1,0 +1,22 @@
+#lang racket/base
+
+;; util/shell-quote.rkt — POSIX single-quote shell escaping
+;;
+;; SEC-16 (v0.22.0): Consolidated from sandbox/subprocess.rkt and
+;; extensions/github/helpers.rkt to eliminate duplication.
+;;
+;; SECURITY NOTE: This function is designed for quoting LLM-generated arguments
+;; within a trusted agent loop. It is NOT intended as a defense against
+;; adversarial input. The sandbox layer provides defense-in-depth, but callers
+;; must not rely on shell-quote alone to prevent injection from untrusted sources.
+
+(require racket/format
+         racket/string)
+
+(provide shell-quote)
+
+;; POSIX single-quote escaping for command arguments.
+;; Converts non-string inputs to string via ~a before quoting.
+(define (shell-quote s)
+  (define str (if (string? s) s (~a s)))
+  (string-append "'" (string-replace str "'" "'\\''") "'"))


### PR DESCRIPTION
Addresses #2184.

feat: code quality — QUAL-01 runtime helpers, QUAL-04 shadowed imports, QUAL-05 provider contracts, SEC-16 shell-quote consolidation (#2184)

W1 of v0.22.0:
- QUAL-01: Extract runtime-helpers.rkt from iteration.rkt + tool-coordinator.rkt (emit-session-event!, maybe-dispatch-hooks)
- QUAL-04: Replace bare gsd/core.rkt require with only-in in gsd-planning.rkt
- QUAL-05: Add contract-out for make-openai-compatible-provider and make-azure-openai-provider
- SEC-16: Consolidate shell-quote into util/shell-quote.rkt, import from subprocess.rkt and github/helpers.rkt
- NEW: tests/test-runtime-helpers.rkt (2 tests)
- 316 tests pass