### PR TITLE
feat: extension boundary facade — ARCH-03 tool-api, ARCH-04 event bus re-exports, ARCH-02 safe-mode state extraction (#2189)

W2 of v0.22.0:
- ARCH-03: New extensions/tool-api.rkt facade — all 11 extension files now import tool results via facade
- ARCH-04: extensions/api.rkt re-exports publish!/subscribe!/unsubscribe!/make-event-bus — 5 extension files updated
- ARCH-02: Extract safe-mode parameters+struct+predicates to util/safe-mode-state.rkt leaf — eliminates upward import
- 379 tests pass

### DIFF
--- a/extensions/api.rkt
+++ b/extensions/api.rkt
@@ -9,9 +9,17 @@
 ;;   - list-extensions, handlers-for-point
 
 (require racket/contract
-         racket/list)
+         racket/list
+         ;; ARCH-04 (v0.22.0): event bus re-exports for extensions
+         (only-in "../agent/event-bus.rkt"
+                  publish! subscribe! unsubscribe!
+                  make-event-bus event-bus?))
 
 (provide
+ ;; Event bus re-exports (ARCH-04)
+ publish! subscribe! unsubscribe!
+ make-event-bus event-bus?
+
  ;; Extension struct and registry
  (struct-out extension)
  extension-registry?

--- a/extensions/compact-context.rkt
+++ b/extensions/compact-context.rkt
@@ -15,7 +15,7 @@
          "dynamic-tools.rkt"
          "context.rkt"
          "hooks.rkt"
-         "../tools/tool.rkt")
+         "tool-api.rkt")
 
 (provide compact-context-extension
          handle-compact-context

--- a/extensions/dynamic-tools.rkt
+++ b/extensions/dynamic-tools.rkt
@@ -13,7 +13,7 @@
 
 (require racket/contract
          "context.rkt"
-         "../tools/tool.rkt")
+         "tool-api.rkt")
 
 (provide (contract-out [ext-register-tool!
                         (->* (extension-ctx? string? ; name

--- a/extensions/events.rkt
+++ b/extensions/events.rkt
@@ -14,7 +14,7 @@
 ;;   - Safe publish with error isolation
 
 (require racket/contract
-         "../agent/event-bus.rkt"
+         "api.rkt"
          "../util/protocol-types.rkt"
          "api.rkt")
 

--- a/extensions/ext-package-manager.rkt
+++ b/extensions/ext-package-manager.rkt
@@ -11,7 +11,7 @@
          "dynamic-tools.rkt"
          "context.rkt"
          "hooks.rkt"
-         "../tools/tool.rkt"
+         "tool-api.rkt"
          "../runtime/package.rkt"
          "../extensions/manifest.rkt")
 

--- a/extensions/github-integration.rkt
+++ b/extensions/github-integration.rkt
@@ -16,7 +16,7 @@
          "ext-commands.rkt"
          "context.rkt"
          "hooks.rkt"
-         "../tools/tool.rkt"
+         "tool-api.rkt"
          ;; Q01: Helpers extracted to subdirectory
          (only-in "github/helpers.rkt"
                   gh-binary-path

--- a/extensions/github/helpers.rkt
+++ b/extensions/github/helpers.rkt
@@ -12,7 +12,7 @@
          json
          ;; SEC-16 (v0.22.0): consolidated shell-quote
          (only-in "../../util/shell-quote.rkt" shell-quote)
-         (only-in "../../tools/tool.rkt" make-success-result make-error-result))
+         (only-in "../tool-api.rkt" make-success-result make-error-result))
 
 (provide gh-binary-path
          shell-quote

--- a/extensions/gsd-planning.rkt
+++ b/extensions/gsd-planning.rkt
@@ -30,9 +30,9 @@
          "ext-commands.rkt"
          "context.rkt"
          "hooks.rkt"
-         "../tools/tool.rkt"
+         "tool-api.rkt"
          "../util/event.rkt"
-         "../agent/event-bus.rkt"
+         "api.rkt"
          "gsd-planning-state.rkt"
          ;; v0.21.0 new modules
          "gsd/state-machine.rkt"

--- a/extensions/image-input.rkt
+++ b/extensions/image-input.rkt
@@ -13,7 +13,7 @@
          "dynamic-tools.rkt"
          "context.rkt"
          "hooks.rkt"
-         "../tools/tool.rkt")
+         "tool-api.rkt")
 
 (provide the-extension
          image-input-extension

--- a/extensions/loader.rkt
+++ b/extensions/loader.rkt
@@ -19,7 +19,7 @@
          racket/string
          json
          "../util/protocol-types.rkt"
-         "../agent/event-bus.rkt"
+         "api.rkt"
          "../util/checksum.rkt"
          "../util/version.rkt"
          "api.rkt"

--- a/extensions/message-inject.rkt
+++ b/extensions/message-inject.rkt
@@ -17,7 +17,7 @@
 ;;   (inject-user-message! (ctx-event-bus ctx) "session-id" "User note")
 
 (require racket/contract
-         "../agent/event-bus.rkt"
+         "api.rkt"
          "../util/protocol-types.rkt"
          "../util/ids.rkt"
          "../util/protocol-types.rkt")

--- a/extensions/q-sync.rkt
+++ b/extensions/q-sync.rkt
@@ -13,7 +13,7 @@
          "dynamic-tools.rkt"
          "context.rkt"
          "hooks.rkt"
-         "../tools/tool.rkt")
+         "tool-api.rkt")
 
 (provide the-extension
          q-sync-extension

--- a/extensions/racket-tooling.rkt
+++ b/extensions/racket-tooling.rkt
@@ -18,7 +18,7 @@
          "ext-commands.rkt"
          "context.rkt"
          "hooks.rkt"
-         "../tools/tool.rkt")
+         "tool-api.rkt")
 
 (provide the-extension
          racket-tooling-extension

--- a/extensions/remote-collab/remote-collab.rkt
+++ b/extensions/remote-collab/remote-collab.rkt
@@ -12,7 +12,7 @@
          "../dynamic-tools.rkt"
          "../context.rkt"
          "../hooks.rkt"
-         "../../tools/tool.rkt"
+         "../tool-api.rkt"
          "ssh-helpers.rkt"
          "tmux-helpers.rkt")
 

--- a/extensions/session-export.rkt
+++ b/extensions/session-export.rkt
@@ -10,7 +10,7 @@
          "dynamic-tools.rkt"
          "context.rkt"
          "hooks.rkt"
-         "../tools/tool.rkt")
+         "tool-api.rkt")
 
 (provide the-extension
          session-export-extension

--- a/extensions/tool-api.rkt
+++ b/extensions/tool-api.rkt
@@ -1,0 +1,71 @@
+#lang racket/base
+
+;; extensions/tool-api.rkt — Facade for tool result constructors
+;;
+;; ARCH-03 (v0.22.0): Extensions import from HERE, not from
+;; tools/tool.rkt directly. Single indirection point so extensions
+;; never depend on the tools layer's internal structure.
+;;
+;; Re-exports: tool result constructors, tool struct, tool registry,
+;; and execution context helpers.
+
+(require "../tools/tool.rkt")
+
+(provide
+ ;; Tool result constructors (most common need)
+ make-success-result
+ make-error-result
+ make-tool-result
+ tool-result?
+ tool-result-content
+ tool-result-details
+ tool-result-is-error?
+ tool-result->jsexpr
+ jsexpr->tool-result
+
+ ;; Tool struct (dynamic-tools needs this)
+ make-tool
+ tool?
+ tool-name
+ tool-description
+ tool-schema
+ tool-execute
+ tool-prompt-snippet
+ tool-prompt-guidelines
+ tool-dangerous?
+ tool->jsexpr
+ merge-tool-lists
+ validate-tool-schema
+ format-tool-schema-hint
+
+ ;; Tool registry
+ make-tool-registry
+ tool-registry?
+ register-tool!
+ unregister-tool!
+ set-active-tools!
+ tool-active?
+ list-active-tools
+ list-active-tools-jsexpr
+ lookup-tool
+ list-tools
+ list-tools-jsexpr
+ tool-names
+
+ ;; Execution context
+ make-exec-context
+ exec-context?
+ exec-context-working-directory
+ exec-context-cancellation-token
+ exec-context-event-publisher
+ exec-context-runtime-settings
+ exec-context-call-id
+ exec-context-session-metadata
+ exec-context-progress-callback
+ exec-context-permission-config
+ emit-progress!
+
+ ;; Tool call struct
+ tool-call
+ tool-call?
+ tool-call-id)

--- a/extensions/widget-api.rkt
+++ b/extensions/widget-api.rkt
@@ -10,7 +10,7 @@
 
 (require racket/contract
          racket/match
-         "../agent/event-bus.rkt"
+         "api.rkt"
          "../util/protocol-types.rkt"
          "ui-surface.rkt")
 

--- a/runtime/safe-mode.rkt
+++ b/runtime/safe-mode.rkt
@@ -1,19 +1,28 @@
 #lang racket/base
 
-;; runtime/safe-mode.rkt — safe mode restrictions and trust model
+;; runtime/safe-mode.rkt — safe-mode runtime: actions, locking, introspection
 ;;
-;; Provides query functions for safe mode state, tool restrictions,
-;; and path restrictions.  Does NOT enforce anything itself — callers
-;; (tool dispatch, extension loader) check these predicates.
-;;
-;; Predicates are also re-exported via util/safe-mode-predicates.rkt
-;; for backward-compatible imports from tools/scheduler (ARCH-02/QUAL-07).
+;; ARCH-02 (v0.22.0): Parameters, struct, and predicates extracted to
+;; util/safe-mode-state.rkt. This module imports from there and adds
+;; mutation actions, locking, and introspection.
 
 (require racket/string
-         racket/list
-         racket/path)
+         (only-in "../util/safe-mode-state.rkt"
+                  current-safe-mode
+                  current-safe-mode-config
+                  project-root
+                  safe-mode-config safe-mode-config?
+                  safe-mode-config-active safe-mode-config-allowed-tools
+                  safe-mode-config-allowed-paths safe-mode-config-locked
+                  safe-mode-config-project-root-path make-safe-mode-config
+                  blocked-tools
+                  safe-mode? allowed-tool? allowed-path?
+                  safe-mode-project-root trust-level))
 
-;; Parameters
+;; ============================================================
+;; Re-export everything from safe-mode-state
+;; ============================================================
+
 (provide current-safe-mode
          current-safe-mode-config
          project-root
@@ -33,152 +42,29 @@
          allowed-tool?
          allowed-path?
 
-         ;; Actions
+         ;; Introspection
+         safe-mode-project-root
+         trust-level
+
+         ;; Constants
+         blocked-tools
+
+         ;; Actions (defined below)
          safe-mode-active!
          safe-mode-deactivate!
          lock-safe-mode!
          safe-mode-locked?
 
-         ;; Introspection
-         trust-level
-         safe-mode-config-info
-         safe-mode-project-root
-
-         ;; Constants
-         blocked-tools)
+         ;; Introspection (defined below)
+         safe-mode-config-info)
 
 ;; ============================================================
-;; Parameters
+;; Lock state
 ;; ============================================================
 
-;; Current safe mode state: #t = active, #f = inactive.
-;; Set by CLI flag parsing or explicit activation.
-(define current-safe-mode (make-parameter #f))
-
-;; Per-session safe-mode config (#117).
-;; When set, takes precedence over global parameters.
-;; This allows RPC multi-client isolation.
-(define current-safe-mode-config (make-parameter #f))
-
-;; Project root directory for path restriction.
-;; Defaults to current working directory.
-(define project-root (make-parameter (current-directory)))
-
-;; ============================================================
-;; Per-session config struct (#117)
-;; ============================================================
-
-;; safe-mode-config encapsulates all safe-mode state for a session.
-;; This avoids reliance on global parameters for multi-session isolation.
-(struct safe-mode-config (active allowed-tools allowed-paths locked project-root-path) #:transparent)
-
-(define (make-safe-mode-config #:active [active #t]
-                               #:allowed-tools [allowed-tools #f]
-                               #:allowed-paths [allowed-paths #f]
-                               #:locked [locked #f]
-                               #:project-root [proj-root (current-directory)])
-  (safe-mode-config active (or allowed-tools 'default) (or allowed-paths 'default) locked proj-root))
-
-;; ============================================================
-;; Blocked tool set (constant)
-;; ============================================================
-
-(define blocked-tools '("bash" "edit" "write" "firecrawl"))
-
-;; ============================================================
-;; Predicates
-;; ============================================================
-
-;; safe-mode? : -> boolean?
-;; Returns #t if safe mode is currently active.
-;; Checks: (1) per-session config, (2) parameter, (3) env var Q_SAFE_MODE=1
-(define (safe-mode?)
-  (define cfg (current-safe-mode-config))
-  (cond
-    [(safe-mode-config? cfg) (safe-mode-config-active cfg)]
-    [else (or (current-safe-mode) (let ([v (getenv "Q_SAFE_MODE")]) (and v (string=? v "1"))))]))
-
-;; allowed-tool? : string? -> boolean?
-;; Returns #t if the tool is allowed under current mode.
-(define (allowed-tool? tool-name)
-  (define cfg (current-safe-mode-config))
-  (cond
-    [(and (safe-mode-config? cfg) (not (eq? (safe-mode-config-allowed-tools cfg) 'default)))
-     ;; Per-session tool list
-     (define allowed (safe-mode-config-allowed-tools cfg))
-     (and (not (member tool-name blocked-tools string=?))
-          (not (string-prefix? tool-name "extension:"))
-          (or (not (list? allowed)) (member tool-name allowed string=?)))]
-    [(safe-mode?)
-     (and (not (member tool-name blocked-tools string=?))
-          (not (string-prefix? tool-name "extension:")))]
-    [else #t]))
-
-;; allowed-path? : path-string? -> boolean?
-;; In safe mode, path must be under project root.
-;; Uses resolve-path to prevent symlink bypass (SEC-04).
-;; Outside safe mode, always #t.
-(define (allowed-path? path)
-  (cond
-    [(not (safe-mode?)) #t]
-    [else
-     (define cfg (current-safe-mode-config))
-     (define root-path
-       (cond
-         [(and (safe-mode-config? cfg) (safe-mode-config-project-root-path cfg))
-          (safe-mode-config-project-root-path cfg)]
-         [else (project-root)]))
-     (define allowed-paths (and (safe-mode-config? cfg) (safe-mode-config-allowed-paths cfg)))
-     ;; If specific allowed-paths list given, check against that
-     (cond
-       [(and (list? allowed-paths) (not (eq? allowed-paths 'default)))
-        (for/or ([ap (in-list allowed-paths)])
-          (define resolved-path
-            (with-handlers ([exn:fail? (λ (_) #f)])
-              (resolve-path path)))
-          (define resolved-ap
-            (with-handlers ([exn:fail? (λ (_) #f)])
-              (resolve-path ap)))
-          (and resolved-path
-               resolved-ap
-               (let* ([path-str (path->string (if (complete-path? resolved-path)
-                                                  resolved-path
-                                                  (path->complete-path resolved-path)))]
-                      [ap-str (path->string (if (complete-path? resolved-ap)
-                                                resolved-ap
-                                                (path->complete-path resolved-ap)))]
-                      [ap-prefix (if (string-suffix? ap-str "/")
-                                     ap-str
-                                     (string-append ap-str "/"))])
-                 (or (string=? path-str ap-str) (string-prefix? path-str ap-prefix)))))]
-       [else
-        ;; Default: check against project root
-        ;; W3.1 (S4-11): resolve-path failure -> deny (#f), not fallback
-        (and (with-handlers ([exn:fail? (λ (_) #f)])
-               (resolve-path root-path))
-             (with-handlers ([exn:fail? (λ (_) #f)])
-               (resolve-path path))
-             (let* ([resolved-root (resolve-path root-path)]
-                    [resolved-path (resolve-path path)]
-                    [root-str (path->string (if (complete-path? resolved-root)
-                                                resolved-root
-                                                (path->complete-path resolved-root)))]
-                    [path-str (path->string (if (complete-path? resolved-path)
-                                                resolved-path
-                                                (path->complete-path resolved-path)))]
-                    [root-prefix (if (string-suffix? root-str "/")
-                                     root-str
-                                     (string-append root-str "/"))])
-               (or (string=? path-str root-str) (string-prefix? path-str root-prefix))))])]))
-
-;; Whether safe-mode deactivation is locked (one-way switch)
-;; W3.2 (S4-16): One-shot parameter — once locked, cannot be unlocked.
-;; Kept as parameter for backward-compatible parameterize, but guarded.
 (define safe-mode-lock-one-shot (box #f))
-
 (define safe-mode-locked? (make-parameter #f))
 
-;; Internal: check if locked via per-session config or parameter
 (define (locked?)
   (define cfg (current-safe-mode-config))
   (cond
@@ -189,14 +75,9 @@
 ;; Actions
 ;; ============================================================
 
-;; safe-mode-active! : -> void?
-;; Explicitly activate safe mode.
 (define (safe-mode-active!)
   (current-safe-mode #t))
 
-;; safe-mode-deactivate! : -> void?
-;; Explicitly deactivate safe mode.
-;; Raises an error if safe-mode is locked.
 (define (safe-mode-deactivate!)
   (when (locked?)
     (define source (detect-safe-mode-source))
@@ -206,7 +87,6 @@
       "Safe mode is locked and cannot be changed during this session. Safe mode was enabled by: ~a."
       source)))
   (current-safe-mode #f)
-  ;; Also clear per-session config active state
   (when (safe-mode-config? (current-safe-mode-config))
     (define old-cfg (current-safe-mode-config))
     (current-safe-mode-config (safe-mode-config #f
@@ -215,9 +95,6 @@
                                                 (safe-mode-config-locked old-cfg)
                                                 (safe-mode-config-project-root-path old-cfg)))))
 
-;; lock-safe-mode! : -> void?
-;; Lock safe-mode so it cannot be deactivated.
-;; Once locked, only process restart can change the state.
 (define (lock-safe-mode!)
   (set-box! safe-mode-lock-one-shot #t)
   (safe-mode-locked? #t))
@@ -226,7 +103,6 @@
 ;; Introspection
 ;; ============================================================
 
-;; Detect which source activated safe mode
 (define (detect-safe-mode-source)
   (cond
     [(current-safe-mode) "CLI flag (--safe)"]
@@ -235,23 +111,6 @@
     [(safe-mode-config? (current-safe-mode-config)) "session config"]
     [else "unknown source"]))
 
-;; safe-mode-project-root : -> string?
-;; Returns the effective project root as a string, for use in error messages.
-(define (safe-mode-project-root)
-  (define cfg (current-safe-mode-config))
-  (define root-path
-    (cond
-      [(and (safe-mode-config? cfg) (safe-mode-config-project-root-path cfg))
-       (safe-mode-config-project-root-path cfg)]
-      [else (project-root)]))
-  (path->string root-path))
-
-;; trust-level : -> (or/c 'full 'restricted 'sandbox)
-(define (trust-level)
-  (if (safe-mode?) 'restricted 'full))
-
-;; safe-mode-config-info : -> hash?
-;; Returns a hash summarizing current safe mode state.
 (define (safe-mode-config-info)
   (define active (safe-mode?))
   (define source (detect-safe-mode-source))

--- a/util/safe-mode-predicates.rkt
+++ b/util/safe-mode-predicates.rkt
@@ -2,19 +2,13 @@
 
 ;; util/safe-mode-predicates.rkt — canonical import point for safe-mode predicates
 ;;
-;; Re-exports pure safe-mode query functions from runtime/safe-mode.rkt.
-;; Tools and scheduler import predicates from HERE (ARCH-02/QUAL-07).
+;; ARCH-02 (v0.22.0): Re-exports from util/safe-mode-state.rkt (peer import).
+;; No more upward import from runtime/safe-mode.rkt.
 ;;
-;; *** LAYER EXCEPTION (ARCH-02) ***
-;; util/ is normally a leaf layer with zero upward imports.  This file
-;; breaks that rule by reaching into runtime/safe-mode.rkt so that
-;; tool/scheduler modules can query safe-mode state without depending
-;; on the runtime layer directly.  The re-export is narrow (only-in)
-;; and the predicates are pure readers — no mutation leaks upward.
-;; Do NOT add further upward imports from util/ without a documented
-;; exception in this header.
+;; Tools and scheduler import predicates from HERE so they don't
+;; depend on the runtime layer directly.
 
-(require (only-in "../runtime/safe-mode.rkt"
+(require (only-in "safe-mode-state.rkt"
                   safe-mode? allowed-tool? allowed-path?
                   safe-mode-project-root trust-level
                   blocked-tools))

--- a/util/safe-mode-state.rkt
+++ b/util/safe-mode-state.rkt
@@ -1,0 +1,171 @@
+#lang racket/base
+
+;; util/safe-mode-state.rkt — safe-mode parameters, struct, and pure predicates
+;;
+;; ARCH-02 (v0.22.0): Extracted from runtime/safe-mode.rkt to eliminate
+;; the upward import in util/safe-mode-predicates.rkt.  This is a util/
+;; leaf — it has NO upward imports (only racket/base and os-environment).
+;;
+;; Both runtime/safe-mode.rkt and util/safe-mode-predicates.rkt import
+;; from here.
+
+(require racket/string)
+
+;; ============================================================
+;; Parameters
+;; ============================================================
+
+(define current-safe-mode (make-parameter #f))
+(define current-safe-mode-config (make-parameter #f))
+(define project-root (make-parameter (current-directory)))
+
+;; ============================================================
+;; Per-session config struct
+;; ============================================================
+
+(struct safe-mode-config (active allowed-tools allowed-paths locked project-root-path)
+  #:transparent)
+
+(define (make-safe-mode-config #:active [active #t]
+                               #:allowed-tools [allowed-tools #f]
+                               #:allowed-paths [allowed-paths #f]
+                               #:locked [locked #f]
+                               #:project-root [proj-root (current-directory)])
+  (safe-mode-config active (or allowed-tools 'default) (or allowed-paths 'default) locked proj-root))
+
+;; ============================================================
+;; Constants
+;; ============================================================
+
+(define blocked-tools '("bash" "edit" "write" "firecrawl"))
+
+;; ============================================================
+;; Predicates
+;; ============================================================
+
+(define (safe-mode?)
+  (define cfg (current-safe-mode-config))
+  (cond
+    [(safe-mode-config? cfg) (safe-mode-config-active cfg)]
+    [else (or (current-safe-mode)
+              (let ([v (getenv "Q_SAFE_MODE")])
+                (and v (string=? v "1"))))]))
+
+(define (allowed-tool? tool-name)
+  (define cfg (current-safe-mode-config))
+  (cond
+    [(and (safe-mode-config? cfg)
+          (not (eq? (safe-mode-config-allowed-tools cfg) 'default)))
+     (define allowed (safe-mode-config-allowed-tools cfg))
+     (and (not (member tool-name blocked-tools string=?))
+          (not (string-prefix? tool-name "extension:"))
+          (or (not (list? allowed)) (member tool-name allowed string=?)))]
+    [(safe-mode?)
+     (and (not (member tool-name blocked-tools string=?))
+          (not (string-prefix? tool-name "extension:")))]
+    [else #t]))
+
+(define (allowed-path? path)
+  (cond
+    [(not (safe-mode?)) #t]
+    [else
+     (define cfg (current-safe-mode-config))
+     (define root-path
+       (cond
+         [(and (safe-mode-config? cfg) (safe-mode-config-project-root-path cfg))
+          (safe-mode-config-project-root-path cfg)]
+         [else (project-root)]))
+     (define allowed-paths (and (safe-mode-config? cfg)
+                                (safe-mode-config-allowed-paths cfg)))
+     (cond
+       [(and (list? allowed-paths) (not (eq? allowed-paths 'default)))
+        (for/or ([ap (in-list allowed-paths)])
+          (define resolved-path
+            (with-handlers ([exn:fail? (λ (_) #f)])
+              (resolve-path path)))
+          (define resolved-ap
+            (with-handlers ([exn:fail? (λ (_) #f)])
+              (resolve-path ap)))
+          (and resolved-path
+               resolved-ap
+               (let* ([path-str (path->string
+                                 (if (complete-path? resolved-path)
+                                     resolved-path
+                                     (path->complete-path resolved-path)))]
+                      [ap-str (path->string
+                               (if (complete-path? resolved-ap)
+                                   resolved-ap
+                                   (path->complete-path resolved-ap)))]
+                      [ap-prefix (if (string-suffix? ap-str "/")
+                                     ap-str
+                                     (string-append ap-str "/"))])
+                 (or (string=? path-str ap-str)
+                     (string-prefix? path-str ap-prefix)))))]
+       [else
+        (and (with-handlers ([exn:fail? (λ (_) #f)])
+               (resolve-path root-path))
+             (with-handlers ([exn:fail? (λ (_) #f)])
+               (resolve-path path))
+             (let* ([resolved-root (resolve-path root-path)]
+                    [resolved-path (resolve-path path)]
+                    [root-str (path->string
+                               (if (complete-path? resolved-root)
+                                   resolved-root
+                                   (path->complete-path resolved-root)))]
+                    [path-str (path->string
+                               (if (complete-path? resolved-path)
+                                   resolved-path
+                                   (path->complete-path resolved-path)))]
+                    [root-prefix (if (string-suffix? root-str "/")
+                                     root-str
+                                     (string-append root-str "/"))])
+               (or (string=? path-str root-str)
+                   (string-prefix? path-str root-prefix))))])]))
+
+;; ============================================================
+;; Introspection helpers
+;; ============================================================
+
+(define (safe-mode-project-root)
+  (define cfg (current-safe-mode-config))
+  (define root-path
+    (cond
+      [(and (safe-mode-config? cfg) (safe-mode-config-project-root-path cfg))
+       (safe-mode-config-project-root-path cfg)]
+      [else (project-root)]))
+  (path->string root-path))
+
+(define (trust-level)
+  (if (safe-mode?) 'restricted 'full))
+
+;; ============================================================
+;; Provide
+;; ============================================================
+
+(provide
+ ;; Parameters
+ current-safe-mode
+ current-safe-mode-config
+ project-root
+
+ ;; Struct
+ safe-mode-config
+ safe-mode-config?
+ safe-mode-config-active
+ safe-mode-config-allowed-tools
+ safe-mode-config-allowed-paths
+ safe-mode-config-locked
+ safe-mode-config-project-root-path
+ make-safe-mode-config
+
+ ;; Constants
+ blocked-tools
+
+ ;; Predicates
+ safe-mode?
+ allowed-tool?
+ allowed-path?
+
+ ;; Introspection
+ safe-mode-project-root
+ trust-level)


### PR DESCRIPTION
Addresses #2189.

feat: extension boundary facade — ARCH-03 tool-api, ARCH-04 event bus re-exports, ARCH-02 safe-mode state extraction (#2189)

W2 of v0.22.0:
- ARCH-03: New extensions/tool-api.rkt facade — all 11 extension files now import tool results via facade
- ARCH-04: extensions/api.rkt re-exports publish!/subscribe!/unsubscribe!/make-event-bus — 5 extension files updated
- ARCH-02: Extract safe-mode parameters+struct+predicates to util/safe-mode-state.rkt leaf — eliminates upward import
- 379 tests pass