### PR TITLE
test: test hardening — TH-01 write tests, TH-02 GSD cleanup, TH-03 assertions, TH-11 context pair, TH-14 error sanitizer (#2196)

W4 of v0.22.0 (test-only, no production code changes):
- TH-01: 7 new write tool tests (safe-mode, budget boundary, home path, nested dirs, empty content, path canonicalization)
- TH-02: Added with-gsd-cleanup dynamic-wind helper for GSD test isolation
- TH-03: Upgraded check-not-false to check-true/check-pred with type-specific predicates across GSD tests
- TH-11: New system-instruction preservation test under budget pressure
- TH-14: Wrapped all error sanitizer checks in test-case forms + 5 edge cases

### DIFF
--- a/tests/test-context-pair-preserving.rkt
+++ b/tests/test-context-pair-preserving.rkt
@@ -6,6 +6,7 @@
 
 (require rackunit
          racket/list
+         racket/string
          "../util/protocol-types.rkt"
          "../runtime/context-builder.rkt"
          "../llm/token-budget.rkt")
@@ -106,3 +107,27 @@
 
   (check-pairing result "large-budget")
   (check-equal? (length result) (length all-msgs)))
+
+;; Test 4: TH-11 — system-instruction preserved under budget pressure
+(test-case "system-instruction preserved under 95% budget pressure"
+  ;; Build a message list with system-instruction first, then many pairs
+  ;; Set a tight budget (95% of token count)
+  ;; Verify system-instruction message survives truncation
+  (define sys (make-text-msg 'system "You are a helpful coding assistant." 'system-instruction))
+  (define user (make-text-msg 'user "hello"))
+  (define pairs
+    (for/list ([i (in-range 20)])
+      (define tc-id (format "tc-~a" i))
+      (define ass (make-assistant-with-tool-call tc-id "bash" (format "{\"command\":\"echo ~a\"}" i)))
+      (define tr (make-tool-result-msg tc-id (message-id ass) (make-string 500 #\X)))
+      (list ass tr)))
+  (define all-msgs (append (list sys user) (append* pairs)))
+  ;; Tight budget: 3000 tokens — should truncate most pairs
+  (define result (truncate-messages-to-budget all-msgs 3000))
+  ;; System instruction must be present
+  (define sys-msgs (filter (lambda (m) (eq? (message-role m) 'system)) result))
+  (check-true (> (length sys-msgs) 0) "system-instruction must survive truncation")
+  ;; Content preserved
+  (define sys-text (text-part-text (first (message-content (first sys-msgs)))))
+  (check-true (string-contains? sys-text "helpful coding assistant")
+              "system-instruction content must be preserved"))

--- a/tests/test-error-sanitizer.rkt
+++ b/tests/test-error-sanitizer.rkt
@@ -5,18 +5,42 @@
 
 (define home-str (path->string (find-system-path 'home-dir)))
 
-;; Home directory is replaced with ~
-(check-equal? (sanitize-error-message (format "File not found: ~afoo.txt" home-str))
-              "File not found: ~/foo.txt")
+;; ── Existing checks wrapped in test-case ──────────────────────────
 
-;; Non-path messages pass through unchanged
-(check-equal? (sanitize-error-message "no paths here")
-              "no paths here")
+(test-case "home-directory replaced with ~"
+  (check-equal? (sanitize-error-message (format "File not found: ~afoo.txt" home-str))
+                "File not found: ~/foo.txt"))
 
-;; Path in middle of message is sanitized
-(check-equal? (sanitize-error-message (format "Write error: cannot write to ~abar/baz.rkt: permission denied" home-str))
-              "Write error: cannot write to ~/bar/baz.rkt: permission denied")
+(test-case "non-path messages pass through unchanged"
+  (check-equal? (sanitize-error-message "no paths here") "no paths here"))
 
-;; Multiple occurrences are all replaced
-(check-equal? (sanitize-error-message (format "~afoo and ~abar" home-str home-str))
-              "~/foo and ~/bar")
+(test-case "path in middle of message is sanitized"
+  (check-equal? (sanitize-error-message
+                 (format "Write error: cannot write to ~abar/baz.rkt: permission denied" home-str))
+                "Write error: cannot write to ~/bar/baz.rkt: permission denied"))
+
+(test-case "multiple occurrences are all replaced"
+  (check-equal? (sanitize-error-message (format "~afoo and ~abar" home-str home-str))
+                "~/foo and ~/bar"))
+
+;; ── Edge cases (TH-14) ────────────────────────────────────────────
+
+(test-case "empty string input returns empty string"
+  (check-equal? (sanitize-error-message "") ""))
+
+(test-case "bare home dir is replaced with ~"
+  ;; When home-str already has trailing /, the sanitizer replaces it with ~/
+  ;; so sanitize-error-message(home-str) = "~/"
+  (check-equal? (sanitize-error-message home-str) "~/"))
+
+(test-case "home dir with no trailing content becomes ~"
+  ;; home-str already has trailing /, so it matches home-prefix exactly.
+  (check-equal? (sanitize-error-message (string-append home-str)) "~/"))
+
+(test-case "message with no home dir path passes through unchanged"
+  (check-equal? (sanitize-error-message "/tmp/some/other/path error") "/tmp/some/other/path error"))
+
+(test-case "double-slash in path is handled"
+  ;; If the message contains home-dir//something, the home-prefix is
+  ;; replaced with ~/ , leaving the extra slashes intact.
+  (check-equal? (sanitize-error-message (format "~a//double" home-str)) "~///double"))

--- a/tests/test-gsd-planning.rkt
+++ b/tests/test-gsd-planning.rkt
@@ -59,6 +59,13 @@
                  (hash-ref c 'text ""))
                ""))
 
+;; TH-02: Dynamic-wind wrapper ensuring GSD state cleanup even on test failure
+(define (with-gsd-cleanup thunk)
+  (dynamic-wind
+    (lambda () (void))
+    thunk
+    (lambda () (reset-all-gsd-state!))))
+
 ;; ============================================================
 ;; Path resolution tests
 ;; ============================================================
@@ -66,25 +73,25 @@
 (test-case "planning-artifact-path resolves canonical PLAN"
   (with-temp-dir (lambda (dir)
                    (define path (planning-artifact-path dir "PLAN"))
-                   (check-not-false path)
+                   (check-true (path? path))
                    (check-true (string-suffix? (path->string path) ".planning/PLAN.md")))))
 
 (test-case "planning-artifact-path resolves canonical HANDOFF"
   (with-temp-dir (lambda (dir)
                    (define path (planning-artifact-path dir "HANDOFF"))
-                   (check-not-false path)
+                   (check-true (path? path))
                    (check-true (string-suffix? (path->string path) ".planning/HANDOFF.json")))))
 
 (test-case "planning-artifact-path resolves custom .md filename"
   (with-temp-dir (lambda (dir)
                    (define path (planning-artifact-path dir "CUSTOM_PLAN.md"))
-                   (check-not-false path)
+                   (check-true (path? path))
                    (check-true (string-suffix? (path->string path) ".planning/CUSTOM_PLAN.md")))))
 
 (test-case "planning-artifact-path resolves custom .json filename"
   (with-temp-dir (lambda (dir)
                    (define path (planning-artifact-path dir "wave-state.json"))
-                   (check-not-false path)
+                   (check-true (path? path))
                    (check-true (string-suffix? (path->string path) ".planning/wave-state.json")))))
 
 (test-case "planning-artifact-path returns #f for invalid name"
@@ -103,7 +110,7 @@
                        "BUG_STATE"
                        "BUG_VALIDATION"
                        "SUMMARY")])
-    (check-not-false (valid-artifact-name? name) name)))
+    (check-true (valid-artifact-name? name) name)))
 
 (test-case "valid-artifact-name? accepts .md files"
   (check-true (valid-artifact-name? "CUSTOM.md"))
@@ -136,14 +143,14 @@
   (with-temp-dir (lambda (dir)
                    (write-planning-artifact! dir "PLAN" "# Test Plan\nContent here")
                    (define content (read-planning-artifact dir "PLAN"))
-                   (check-not-false content)
+                   (check-true (string? content))
                    (check-true (string-contains? content "# Test Plan")))))
 
 (test-case "read-planning-artifact reads JSON content as hash"
   (with-temp-dir (lambda (dir)
                    (write-planning-artifact! dir "HANDOFF" (hasheq 'machine "local" 'wave "A2"))
                    (define content (read-planning-artifact dir "HANDOFF"))
-                   (check-not-false content)
+                   (check-true (hash? content))
                    (check-true (hash? content))
                    (check-equal? (hash-ref content 'machine) "local"))))
 
@@ -157,7 +164,7 @@
 (test-case "write-planning-artifact! creates .planning dir and writes md"
   (with-temp-dir (lambda (dir)
                    (define result (write-planning-artifact! dir "STATE" "# State\nAll good"))
-                   (check-not-false result)
+                   (check-true (path? result))
                    (check-true (file-exists? (build-path dir ".planning" "STATE.md")))
                    (define content (read-planning-artifact dir "STATE"))
                    (check-true (string-contains? content "All good")))))
@@ -166,7 +173,7 @@
   (with-temp-dir (lambda (dir)
                    (define result
                      (write-planning-artifact! dir "HANDOFF" (hasheq 'machine "vps" 'wave "A2")))
-                   (check-not-false result)
+                   (check-true (path? result))
                    (check-true (file-exists? (build-path dir ".planning" "HANDOFF.json")))
                    (define content (read-planning-artifact dir "HANDOFF"))
                    (check-true (hash? content))
@@ -186,7 +193,7 @@
                    ;; The waves/ subdir doesn't exist yet — write-planning-artifact! must create it
                    (define result
                      (write-planning-artifact! dir "waves/W0-fix-bug.md" "# Wave 0\nFix the bug."))
-                   (check-not-false result)
+                   (check-true (path? result))
                    (check-true (file-exists? (build-path dir ".planning" "waves" "W0-fix-bug.md")))
                    (define content (read-planning-artifact dir "waves/W0-fix-bug.md"))
                    (check-true (string-contains? content "Fix the bug")))))
@@ -298,8 +305,8 @@
   (define ctx (make-test-ctx #:tool-registry reg))
   (define handler (hash-ref (extension-hooks gsd-planning-extension) 'register-tools))
   (handler ctx (hasheq))
-  (check-not-false (lookup-tool reg "planning-read"))
-  (check-not-false (lookup-tool reg "planning-write"))
+  (check-true (tool? (lookup-tool reg "planning-read")))
+  (check-true (tool? (lookup-tool reg "planning-write")))
   ;; Check tools have proper schemas
   (define pr (lookup-tool reg "planning-read"))
   (check-true (hash? (tool-schema pr)))

--- a/tests/test-tool-write.rkt
+++ b/tests/test-tool-write.rkt
@@ -6,7 +6,8 @@
          racket/file
          (only-in "../extensions/gsd-planning-state.rkt"
                   set-pinned-planning-dir!
-                  reset-all-gsd-state!))
+                  reset-all-gsd-state!)
+         (only-in "../util/safe-mode-state.rkt" current-safe-mode-config make-safe-mode-config))
 
 ;; ============================================================
 ;; tool-write — basic write
@@ -230,3 +231,92 @@
   (delete-directory/files tmp-dir)
   (delete-directory/files pinned-dir)
   (reset-all-gsd-state!))
+
+;; ============================================================
+;; TH-01: Additional coverage tests
+;; ============================================================
+
+(test-case "TH-01: safe-mode rejects write outside project root"
+  (init-session-writes!)
+  (define tmpdir (make-temporary-file "q-test-safe-~a" 'directory))
+  (define outside-path "/tmp/outside-root-TH01.txt")
+  (define result
+    (parameterize ([current-safe-mode-config (make-safe-mode-config #:active #t
+                                                                    #:project-root tmpdir)])
+      (tool-write (hasheq 'path outside-path 'content "should fail"))))
+  (check-true (tool-result-is-error? result))
+  (delete-directory/files tmpdir))
+
+(test-case "TH-01: cumulative budget boundary — exact limit succeeds"
+  (init-session-writes!)
+  (define tmp (make-temporary-file "q-write-budget-~a.txt"))
+  (delete-file tmp)
+  (reset-cumulative-writes!)
+  (parameterize ([cumulative-write-budget 10]
+                 [current-max-write-bytes 100])
+    ;; Exactly 10 bytes — should succeed
+    (define r (tool-write (hasheq 'path tmp 'content "1234567890")))
+    (check-false (tool-result-is-error? r)))
+  (when (file-exists? tmp)
+    (delete-file tmp)))
+
+(test-case "TH-01: cumulative budget boundary — one byte over fails"
+  (init-session-writes!)
+  (define tmp (make-temporary-file "q-write-budget-~a.txt"))
+  (delete-file tmp)
+  (reset-cumulative-writes!)
+  (parameterize ([cumulative-write-budget 10]
+                 [current-max-write-bytes 100])
+    ;; Write 10 bytes — fills budget exactly
+    (tool-write (hasheq 'path tmp 'content "1234567890"))
+    ;; One more byte (11 total) — should exceed budget
+    (define r2 (tool-write (hasheq 'path tmp 'content "1")))
+    (check-true (tool-result-is-error? r2)))
+  (when (file-exists? tmp)
+    (delete-file tmp)))
+
+(test-case "TH-01: expand-home-path — write to ~/test-q-write-home.txt"
+  (init-session-writes!)
+  (reset-cumulative-writes!)
+  (define home (find-system-path 'home-dir))
+  (define target (build-path home "test-q-write-home.txt"))
+  (define result (tool-write (hasheq 'path "~/test-q-write-home.txt" 'content "home write")))
+  (check-false (tool-result-is-error? result))
+  (check-pred file-exists? target)
+  (check-equal? (file->string target) "home write")
+  (delete-file target))
+
+(test-case "TH-01: directory creation via deeply nested path"
+  (init-session-writes!)
+  (reset-cumulative-writes!)
+  (define tmpdir (make-temporary-file "q-test-nested-~a" 'directory))
+  (define filepath (build-path tmpdir "a" "b" "c" "file.txt"))
+  (define result (tool-write (hasheq 'path (path->string filepath) 'content "deeply nested")))
+  (check-false (tool-result-is-error? result))
+  (check-pred file-exists? filepath)
+  (check-equal? (file->string filepath) "deeply nested")
+  (delete-directory/files tmpdir))
+
+(test-case "TH-01: empty content write"
+  (init-session-writes!)
+  (reset-cumulative-writes!)
+  (define tmp (make-temporary-file "q-write-empty-~a.txt"))
+  (delete-file tmp)
+  (define result (tool-write (hasheq 'path tmp 'content "")))
+  (check-false (tool-result-is-error? result))
+  (check-pred file-exists? tmp)
+  (check-equal? (file-size tmp) 0)
+  (delete-file tmp))
+
+(test-case "TH-01: path with .. components canonicalizes correctly"
+  (init-session-writes!)
+  (reset-cumulative-writes!)
+  (define tmpdir (make-temporary-file "q-test-dotdot-~a" 'directory))
+  (make-directory (build-path tmpdir "sub"))
+  (define raw-path (path->string (build-path tmpdir "sub" ".." "file.txt")))
+  (define result (tool-write (hasheq 'path raw-path 'content "dotdot write")))
+  (check-false (tool-result-is-error? result))
+  ;; After canonicalization, file should be in tmpdir/file.txt
+  (check-pred file-exists? (build-path tmpdir "file.txt"))
+  (check-equal? (file->string (build-path tmpdir "file.txt")) "dotdot write")
+  (delete-directory/files tmpdir))


### PR DESCRIPTION
Addresses #2196.

test: test hardening — TH-01 write tests, TH-02 GSD cleanup, TH-03 assertions, TH-11 context pair, TH-14 error sanitizer (#2196)

W4 of v0.22.0 (test-only, no production code changes):
- TH-01: 7 new write tool tests (safe-mode, budget boundary, home path, nested dirs, empty content, path canonicalization)
- TH-02: Added with-gsd-cleanup dynamic-wind helper for GSD test isolation
- TH-03: Upgraded check-not-false to check-true/check-pred with type-specific predicates across GSD tests
- TH-11: New system-instruction preservation test under budget pressure
- TH-14: Wrapped all error sanitizer checks in test-case forms + 5 edge cases