### PR TITLE
fix: audit security + test quality — AUDIT-01/02/03/12/13 (#2216)

W0 of v0.22.1:
- AUDIT-01: Replace single backtick regex with paired backtick pattern
- AUDIT-02: Document $() regex tradeoff with intentional false-positive test
- AUDIT-03: Wire up with-gsd-cleanup in 29 state-mutating GSD tests
- AUDIT-12: Add nil-input edge case to error sanitizer tests
- AUDIT-13: Add SEC-02/SEC-03 path canonicalization tests (4 test cases)
- Fix info.rkt version sync (0.21.10 → 0.22.0)

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.21.10")
+(define version "0.22.0")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base"))

--- a/tests/test-error-sanitizer.rkt
+++ b/tests/test-error-sanitizer.rkt
@@ -74,3 +74,9 @@
                  (format "key=sk-abc email=user@example.com tmp=/tmp/secret/dir home=~astuff"
                          home-str))
                 "key=[REDACTED] email=[REDACTED] tmp=[REDACTED] home=~/stuff"))
+
+;; ── AUDIT-12: non-string input edge case ──────────────────────────
+
+(test-case "sanitize-error-message handles non-string input gracefully"
+  ;; If called with #f, should raise a clear error
+  (check-exn exn:fail? (lambda () (sanitize-error-message #f))))

--- a/tests/test-gsd-planning.rkt
+++ b/tests/test-gsd-planning.rkt
@@ -61,10 +61,7 @@
 
 ;; TH-02: Dynamic-wind wrapper ensuring GSD state cleanup even on test failure
 (define (with-gsd-cleanup thunk)
-  (dynamic-wind
-    (lambda () (void))
-    thunk
-    (lambda () (reset-all-gsd-state!))))
+  (dynamic-wind (lambda () (void)) thunk (lambda () (reset-all-gsd-state!))))
 
 ;; ============================================================
 ;; Path resolution tests
@@ -539,25 +536,26 @@
                      (check-true (string-contains? (hash-ref payload 'text) "No PLAN found"))))))
 
 (test-case "/go returns new-session payload with plan content"
-  (reset-all-gsd-state!)
-  (with-temp-dir
-   (lambda (dir)
-     (parameterize ([current-directory dir])
-       (set-pinned-planning-dir! dir)
-       (make-directory* (build-path dir ".planning"))
-       (call-with-output-file (build-path dir ".planning" "PLAN.md")
-                              (lambda (out)
-                                (display "# Plan\n## Wave 0: Fix bug\n- File: foo.rkt" out))
-                              #:exists 'truncate)
-       (define handler (hash-ref (extension-hooks gsd-planning-extension) 'execute-command))
-       (define result (handler (hasheq 'command "/go" 'input "/go")))
-       (check-equal? (hook-result-action result) 'amend)
-       (define payload (hook-result-payload result))
-       (define new-session-text (hash-ref payload 'new-session))
-       (check-true (string-contains? new-session-text "[gsd-planning]"))
-       (check-true (string-contains? new-session-text "IMPLEMENT NOW"))
-       (check-true (string-contains? new-session-text "Wave 0"))
-       (check-true (string-contains? (hash-ref payload 'text) "Implementing"))))))
+  (with-gsd-cleanup
+   (lambda ()
+     (with-temp-dir
+      (lambda (dir)
+        (parameterize ([current-directory dir])
+          (set-pinned-planning-dir! dir)
+          (make-directory* (build-path dir ".planning"))
+          (call-with-output-file (build-path dir ".planning" "PLAN.md")
+                                 (lambda (out)
+                                   (display "# Plan\n## Wave 0: Fix bug\n- File: foo.rkt" out))
+                                 #:exists 'truncate)
+          (define handler (hash-ref (extension-hooks gsd-planning-extension) 'execute-command))
+          (define result (handler (hasheq 'command "/go" 'input "/go")))
+          (check-equal? (hook-result-action result) 'amend)
+          (define payload (hook-result-payload result))
+          (define new-session-text (hash-ref payload 'new-session))
+          (check-true (string-contains? new-session-text "[gsd-planning]"))
+          (check-true (string-contains? new-session-text "IMPLEMENT NOW"))
+          (check-true (string-contains? new-session-text "Wave 0"))
+          (check-true (string-contains? (hash-ref payload 'text) "Implementing"))))))))
 
 ;; ============================================================
 ;; W1 (#1867): /go anti-exploration tests
@@ -583,57 +581,62 @@
   (check-false (string-contains? planning-implement-prompt "Use planning-read")))
 
 (test-case "/go includes state when available"
-  (reset-all-gsd-state!)
-  (with-temp-dir
-   (lambda (dir)
-     (parameterize ([current-directory dir])
-       (set-pinned-planning-dir! dir)
-       (make-directory* (build-path dir ".planning"))
-       (call-with-output-file (build-path dir ".planning" "PLAN.md")
-                              (lambda (out) (display "# Plan\n## Wave 0: Fix\n- File: foo.rkt" out))
-                              #:exists 'truncate)
-       (call-with-output-file (build-path dir ".planning" "STATE.md")
-                              (lambda (out) (display "W0: done" out))
-                              #:exists 'truncate)
-       (define handler (hash-ref (extension-hooks gsd-planning-extension) 'execute-command))
-       (define result (handler (hasheq 'command "/go" 'input "/go")))
-       (define submit-text (hash-ref (hook-result-payload result) 'new-session))
-       (check-true (string-contains? submit-text "W0: done"))))))
+  (with-gsd-cleanup
+   (lambda ()
+     (with-temp-dir
+      (lambda (dir)
+        (parameterize ([current-directory dir])
+          (set-pinned-planning-dir! dir)
+          (make-directory* (build-path dir ".planning"))
+          (call-with-output-file (build-path dir ".planning" "PLAN.md")
+                                 (lambda (out)
+                                   (display "# Plan\n## Wave 0: Fix\n- File: foo.rkt" out))
+                                 #:exists 'truncate)
+          (call-with-output-file (build-path dir ".planning" "STATE.md")
+                                 (lambda (out) (display "W0: done" out))
+                                 #:exists 'truncate)
+          (define handler (hash-ref (extension-hooks gsd-planning-extension) 'execute-command))
+          (define result (handler (hasheq 'command "/go" 'input "/go")))
+          (define submit-text (hash-ref (hook-result-payload result) 'new-session))
+          (check-true (string-contains? submit-text "W0: done"))))))))
 
 (test-case "/go N starts at specified wave"
-  (reset-all-gsd-state!)
-  (with-temp-dir
-   (lambda (dir)
-     (parameterize ([current-directory dir])
-       (set-pinned-planning-dir! dir)
-       (make-directory* (build-path dir ".planning"))
-       (call-with-output-file
-        (build-path dir ".planning" "PLAN.md")
-        (lambda (out)
-          (display
-           "# Plan\n## Wave 0: Fix\n- File: foo.rkt\n## Wave 1: Core\n- File: bar.rkt\n## Wave 2: Test\n- File: baz.rkt"
-           out))
-        #:exists 'truncate)
-       (define handler (hash-ref (extension-hooks gsd-planning-extension) 'execute-command))
-       (define result (handler (hasheq 'command "/go" 'input "/go 2")))
-       (define submit-text (hash-ref (hook-result-payload result) 'new-session))
-       (check-true (string-contains? submit-text "wave 2"))))))
+  (with-gsd-cleanup
+   (lambda ()
+     (with-temp-dir
+      (lambda (dir)
+        (parameterize ([current-directory dir])
+          (set-pinned-planning-dir! dir)
+          (make-directory* (build-path dir ".planning"))
+          (call-with-output-file
+           (build-path dir ".planning" "PLAN.md")
+           (lambda (out)
+             (display
+              "# Plan\n## Wave 0: Fix\n- File: foo.rkt\n## Wave 1: Core\n- File: bar.rkt\n## Wave 2: Test\n- File: baz.rkt"
+              out))
+           #:exists 'truncate)
+          (define handler (hash-ref (extension-hooks gsd-planning-extension) 'execute-command))
+          (define result (handler (hasheq 'command "/go" 'input "/go 2")))
+          (define submit-text (hash-ref (hook-result-payload result) 'new-session))
+          (check-true (string-contains? submit-text "wave 2"))))))))
 
 (test-case "/implement alias works"
-  (reset-all-gsd-state!)
-  (with-temp-dir
-   (lambda (dir)
-     (parameterize ([current-directory dir])
-       (set-pinned-planning-dir! dir)
-       (make-directory* (build-path dir ".planning"))
-       (call-with-output-file (build-path dir ".planning" "PLAN.md")
-                              (lambda (out) (display "# Plan\n## Wave 0: Fix\n- File: foo.rkt" out))
-                              #:exists 'truncate)
-       (define handler (hash-ref (extension-hooks gsd-planning-extension) 'execute-command))
-       (define result (handler (hasheq 'command "/implement" 'input "/implement")))
-       (check-equal? (hook-result-action result) 'amend)
-       (define submit-text (hash-ref (hook-result-payload result) 'new-session))
-       (check-true (string-contains? submit-text "[gsd-planning]"))))))
+  (with-gsd-cleanup
+   (lambda ()
+     (with-temp-dir
+      (lambda (dir)
+        (parameterize ([current-directory dir])
+          (set-pinned-planning-dir! dir)
+          (make-directory* (build-path dir ".planning"))
+          (call-with-output-file (build-path dir ".planning" "PLAN.md")
+                                 (lambda (out)
+                                   (display "# Plan\n## Wave 0: Fix\n- File: foo.rkt" out))
+                                 #:exists 'truncate)
+          (define handler (hash-ref (extension-hooks gsd-planning-extension) 'execute-command))
+          (define result (handler (hasheq 'command "/implement" 'input "/implement")))
+          (check-equal? (hook-result-action result) 'amend)
+          (define submit-text (hash-ref (hook-result-payload result) 'new-session))
+          (check-true (string-contains? submit-text "[gsd-planning]"))))))))
 
 ;; ============================================================
 ;; W0: /plan Exploration Cap Tests
@@ -654,35 +657,37 @@
   (check-true (string-contains? p "planning-write") "prompt should mention planning-write tool"))
 
 (test-case "/plan-with-text-injects-stale-warning-when-plan-exists"
-  (reset-all-gsd-state!)
-  (with-temp-dir
-   (lambda (dir)
-     (parameterize ([current-directory dir])
-       (set-pinned-planning-dir! dir)
-       (make-directory* (build-path dir ".planning"))
-       (call-with-output-file (build-path dir ".planning" "PLAN.md")
-                              (lambda (out) (display "# Old Plan\nWave 0: old stuff" out))
-                              #:exists 'truncate)
-       (define handler (hash-ref (extension-hooks gsd-planning-extension) 'execute-command))
-       (define result (handler (hasheq 'command "/plan" 'input "/plan fix the bug")))
-       (define submit-text (hash-ref (hook-result-payload result) 'submit))
-       (check-true (string-contains? submit-text "existing PLAN.md was found")
-                   "should inject stale warning when PLAN.md exists")
-       (check-true (string-contains? submit-text "OVERWRITE")
-                   "stale warning should mention OVERWRITE")))))
+  (with-gsd-cleanup
+   (lambda ()
+     (with-temp-dir
+      (lambda (dir)
+        (parameterize ([current-directory dir])
+          (set-pinned-planning-dir! dir)
+          (make-directory* (build-path dir ".planning"))
+          (call-with-output-file (build-path dir ".planning" "PLAN.md")
+                                 (lambda (out) (display "# Old Plan\nWave 0: old stuff" out))
+                                 #:exists 'truncate)
+          (define handler (hash-ref (extension-hooks gsd-planning-extension) 'execute-command))
+          (define result (handler (hasheq 'command "/plan" 'input "/plan fix the bug")))
+          (define submit-text (hash-ref (hook-result-payload result) 'submit))
+          (check-true (string-contains? submit-text "existing PLAN.md was found")
+                      "should inject stale warning when PLAN.md exists")
+          (check-true (string-contains? submit-text "OVERWRITE")
+                      "stale warning should mention OVERWRITE")))))))
 
 (test-case "/plan-with-text-no-warning-when-no-plan"
-  (reset-all-gsd-state!)
-  (with-temp-dir (lambda (dir)
-                   (parameterize ([current-directory dir])
-                     (set-pinned-planning-dir! dir)
-                     (make-directory* (build-path dir ".planning"))
-                     (define handler
-                       (hash-ref (extension-hooks gsd-planning-extension) 'execute-command))
-                     (define result (handler (hasheq 'command "/plan" 'input "/plan fix the bug")))
-                     (define submit-text (hash-ref (hook-result-payload result) 'submit))
-                     (check-false (string-contains? submit-text "existing PLAN.md was found")
-                                  "should NOT inject stale warning when no PLAN.md exists")))))
+  (with-gsd-cleanup
+   (lambda ()
+     (with-temp-dir (lambda (dir)
+                      (parameterize ([current-directory dir])
+                        (set-pinned-planning-dir! dir)
+                        (make-directory* (build-path dir ".planning"))
+                        (define handler
+                          (hash-ref (extension-hooks gsd-planning-extension) 'execute-command))
+                        (define result (handler (hasheq 'command "/plan" 'input "/plan fix the bug")))
+                        (define submit-text (hash-ref (hook-result-payload result) 'submit))
+                        (check-false (string-contains? submit-text "existing PLAN.md was found")
+                                     "should NOT inject stale warning when no PLAN.md exists")))))))
 
 ;; ============================================================
 ;; Wave 3 tests: Prompt constants, artifact registry, I1 fix
@@ -705,10 +710,10 @@
   (check-true (valid-artifact-name? "ANALYSIS")))
 
 (test-case "gsd-tool-guard allows planning-read during executing (I1 fix)"
-  (set-gsd-mode! 'executing)
-  (define res (gsd-tool-guard (hasheq 'tool-name "planning-read" 'args (hasheq))))
-  (check-eq? (hook-result-action res) 'pass)
-  (set-gsd-mode! #f))
+  (with-gsd-cleanup (lambda ()
+                      (set-gsd-mode! 'executing)
+                      (define res (gsd-tool-guard (hasheq 'tool-name "planning-read" 'args (hasheq))))
+                      (check-eq? (hook-result-action res) 'pass))))
 
 ;; ============================================================
 ;; W1 (v0.20.4): parse-wave-headers tests
@@ -745,24 +750,26 @@
 ;; ============================================================
 
 (test-case "/gsd shows status when inactive"
-  (reset-all-gsd-state!)
-  (define handler (hash-ref (extension-hooks gsd-planning-extension) 'execute-command))
-  (define result (handler (hasheq 'command "/gsd" 'input "/gsd")))
-  (check-eq? (hook-result-action result) 'amend)
-  (define text (hash-ref (hook-result-payload result) 'text))
-  (check-true (string-contains? text "Mode: inactive")))
+  (with-gsd-cleanup (lambda ()
+                      (define handler
+                        (hash-ref (extension-hooks gsd-planning-extension) 'execute-command))
+                      (define result (handler (hasheq 'command "/gsd" 'input "/gsd")))
+                      (check-eq? (hook-result-action result) 'amend)
+                      (define text (hash-ref (hook-result-payload result) 'text))
+                      (check-true (string-contains? text "Mode: inactive")))))
 
 (test-case "/gsd shows wave progress during execution"
-  (reset-all-gsd-state!)
-  (set-gsd-mode! 'executing)
-  (set-total-waves! 4)
-  (mark-wave-complete! 0)
-  (mark-wave-complete! 1)
-  (define handler (hash-ref (extension-hooks gsd-planning-extension) 'execute-command))
-  (define result (handler (hasheq 'command "/gsd" 'input "/gsd")))
-  (define text (hash-ref (hook-result-payload result) 'text))
-  (check-true (string-contains? text "Mode: executing"))
-  (check-true (string-contains? text "Waves: 2/4 complete")))
+  (with-gsd-cleanup (lambda ()
+                      (set-gsd-mode! 'executing)
+                      (set-total-waves! 4)
+                      (mark-wave-complete! 0)
+                      (mark-wave-complete! 1)
+                      (define handler
+                        (hash-ref (extension-hooks gsd-planning-extension) 'execute-command))
+                      (define result (handler (hasheq 'command "/gsd" 'input "/gsd")))
+                      (define text (hash-ref (hook-result-payload result) 'text))
+                      (check-true (string-contains? text "Mode: executing"))
+                      (check-true (string-contains? text "Waves: 2/4 complete")))))
 
 ;; ============================================================
 ;; W1 (v0.20.4): /plan budget enforcement
@@ -773,33 +780,30 @@
 ;; ============================================================
 
 (test-case "W1: set-gsd-event-bus! and gsd-event-bus roundtrip"
-  (reset-all-gsd-state!)
-  (check-false (gsd-event-bus) "event bus should start as #f")
-  (define bus (make-event-bus))
-  (set-gsd-event-bus! bus)
-  (check-eq? (gsd-event-bus) bus "event bus should be the one we set")
-  (reset-all-gsd-state!)
-  (check-false (gsd-event-bus) "event bus should be #f after reset"))
+  (with-gsd-cleanup (lambda ()
+                      (check-false (gsd-event-bus) "event bus should start as #f")
+                      (define bus (make-event-bus))
+                      (set-gsd-event-bus! bus)
+                      (check-eq? (gsd-event-bus) bus "event bus should be the one we set"))))
 
 (test-case "W1: emit-gsd-event! publishes when bus is set"
-  (reset-all-gsd-state!)
-  (define bus (make-event-bus))
-  (set-gsd-event-bus! bus)
-  (define received (box '()))
-  (subscribe! bus (lambda (evt) (set-box! received (cons evt (unbox received)))))
-  ;; emit-gsd-event! is defined in gsd-planning.rkt
-  (emit-gsd-event! "gsd.test.event" (hasheq 'key 'value))
-  (check-equal? (length (unbox received)) 1 "should receive one event")
-  (define evt (car (unbox received)))
-  (check-equal? (event-event evt) "gsd.test.event")
-  (check-equal? (hash-ref (event-payload evt) 'key) 'value)
-  (reset-all-gsd-state!))
+  (with-gsd-cleanup (lambda ()
+                      (define bus (make-event-bus))
+                      (set-gsd-event-bus! bus)
+                      (define received (box '()))
+                      (subscribe! bus (lambda (evt) (set-box! received (cons evt (unbox received)))))
+                      ;; emit-gsd-event! is defined in gsd-planning.rkt
+                      (emit-gsd-event! "gsd.test.event" (hasheq 'key 'value))
+                      (check-equal? (length (unbox received)) 1 "should receive one event")
+                      (define evt (car (unbox received)))
+                      (check-equal? (event-event evt) "gsd.test.event")
+                      (check-equal? (hash-ref (event-payload evt) 'key) 'value))))
 
 (test-case "W1: emit-gsd-event! is no-op when bus is #f"
-  (reset-all-gsd-state!)
-  ;; Should not raise an error
-  (emit-gsd-event! "gsd.test.noop" (hasheq 'key 'value))
-  (check-false (gsd-event-bus) "bus should still be #f"))
+  (with-gsd-cleanup (lambda ()
+                      ;; Should not raise an error
+                      (emit-gsd-event! "gsd.test.noop" (hasheq 'key 'value))
+                      (check-false (gsd-event-bus) "bus should still be #f"))))
 
 ;; ============================================================
 ;; Wave progress tracking tests (v0.21.2 W1)
@@ -810,174 +814,170 @@
 ;; ============================================================
 
 (test-case "W1: /replan wired through execute-command from plan-written"
-  (reset-all-gsd-state!)
-  (set-gsd-mode! 'planning)
-  (set-gsd-mode! 'plan-written)
-  (define handler (hash-ref (extension-hooks gsd-planning-extension) 'execute-command))
-  (define result (handler (hasheq 'command "/replan" 'input "/replan")))
-  (check-equal? (hook-result-action result) 'amend)
-  (check-true (string-contains? (hash-ref (hook-result-payload result) 'text) "Re-planning"))
-  (reset-all-gsd-state!))
+  (with-gsd-cleanup
+   (lambda ()
+     (set-gsd-mode! 'planning)
+     (set-gsd-mode! 'plan-written)
+     (define handler (hash-ref (extension-hooks gsd-planning-extension) 'execute-command))
+     (define result (handler (hasheq 'command "/replan" 'input "/replan")))
+     (check-equal? (hook-result-action result) 'amend)
+     (check-true (string-contains? (hash-ref (hook-result-payload result) 'text) "Re-planning")))))
 
 (test-case "W1: /replan from idle returns error through execute-command"
-  (reset-all-gsd-state!)
-  (define handler (hash-ref (extension-hooks gsd-planning-extension) 'execute-command))
-  (define result (handler (hasheq 'command "/replan" 'input "/replan")))
-  (check-equal? (hook-result-action result) 'amend)
-  (check-true (string-contains? (hash-ref (hook-result-payload result) 'text) "Cannot re-plan"))
-  (reset-all-gsd-state!))
+  (with-gsd-cleanup
+   (lambda ()
+     (define handler (hash-ref (extension-hooks gsd-planning-extension) 'execute-command))
+     (define result (handler (hasheq 'command "/replan" 'input "/replan")))
+     (check-equal? (hook-result-action result) 'amend)
+     (check-true (string-contains? (hash-ref (hook-result-payload result) 'text) "Cannot re-plan")))))
 
 (test-case "W1: /skip wired through execute-command during executing"
-  (reset-all-gsd-state!)
-  (set-gsd-mode! 'planning)
-  (set-gsd-mode! 'plan-written)
-  (set-gsd-mode! 'executing)
-  (define handler (hash-ref (extension-hooks gsd-planning-extension) 'execute-command))
-  (define result (handler (hasheq 'command "/skip" 'input "/skip 1")))
-  (check-equal? (hook-result-action result) 'amend)
-  (check-true (string-contains? (hash-ref (hook-result-payload result) 'text) "skipped"))
-  (reset-all-gsd-state!))
+  (with-gsd-cleanup
+   (lambda ()
+     (set-gsd-mode! 'planning)
+     (set-gsd-mode! 'plan-written)
+     (set-gsd-mode! 'executing)
+     (define handler (hash-ref (extension-hooks gsd-planning-extension) 'execute-command))
+     (define result (handler (hasheq 'command "/skip" 'input "/skip 1")))
+     (check-equal? (hook-result-action result) 'amend)
+     (check-true (string-contains? (hash-ref (hook-result-payload result) 'text) "skipped")))))
 
 (test-case "W1: /skip without arg returns usage through execute-command"
-  (reset-all-gsd-state!)
-  (set-gsd-mode! 'planning)
-  (set-gsd-mode! 'plan-written)
-  (set-gsd-mode! 'executing)
-  (define handler (hash-ref (extension-hooks gsd-planning-extension) 'execute-command))
-  (define result (handler (hasheq 'command "/skip" 'input "/skip")))
-  (check-equal? (hook-result-action result) 'amend)
-  (check-true (string-contains? (hash-ref (hook-result-payload result) 'text) "Usage"))
-  (reset-all-gsd-state!))
+  (with-gsd-cleanup
+   (lambda ()
+     (set-gsd-mode! 'planning)
+     (set-gsd-mode! 'plan-written)
+     (set-gsd-mode! 'executing)
+     (define handler (hash-ref (extension-hooks gsd-planning-extension) 'execute-command))
+     (define result (handler (hasheq 'command "/skip" 'input "/skip")))
+     (check-equal? (hook-result-action result) 'amend)
+     (check-true (string-contains? (hash-ref (hook-result-payload result) 'text) "Usage")))))
 
 (test-case "W1: /reset wired through execute-command"
-  (reset-all-gsd-state!)
-  (set-gsd-mode! 'planning)
-  (set-gsd-mode! 'plan-written)
-  (define handler (hash-ref (extension-hooks gsd-planning-extension) 'execute-command))
-  (define result (handler (hasheq 'command "/reset" 'input "/reset")))
-  (check-equal? (hook-result-action result) 'amend)
-  (check-true (string-contains? (hash-ref (hook-result-payload result) 'text) "reset"))
-  (reset-all-gsd-state!))
+  (with-gsd-cleanup
+   (lambda ()
+     (set-gsd-mode! 'planning)
+     (set-gsd-mode! 'plan-written)
+     (define handler (hash-ref (extension-hooks gsd-planning-extension) 'execute-command))
+     (define result (handler (hasheq 'command "/reset" 'input "/reset")))
+     (check-equal? (hook-result-action result) 'amend)
+     (check-true (string-contains? (hash-ref (hook-result-payload result) 'text) "reset")))))
 
 (test-case "W1: unknown command returns hook-pass through execute-command"
-  (reset-all-gsd-state!)
-  (define handler (hash-ref (extension-hooks gsd-planning-extension) 'execute-command))
-  (define result (handler (hasheq 'command "/unknown-cmd" 'input "/unknown-cmd")))
-  (check-equal? (hook-result-action result) 'pass)
-  (reset-all-gsd-state!))
+  (with-gsd-cleanup (lambda ()
+                      (define handler
+                        (hash-ref (extension-hooks gsd-planning-extension) 'execute-command))
+                      (define result (handler (hasheq 'command "/unknown-cmd" 'input "/unknown-cmd")))
+                      (check-equal? (hook-result-action result) 'pass))))
 
 ;; ============================================================
 ;; /wave-done command tests (v0.21.10)
 ;; ============================================================
 
 (test-case "wave-done: marks wave complete with valid index"
-  (reset-all-gsd-state!)
-  (define tmp-dir (make-temporary-file "q-test-wave-done-~a" 'directory))
-  (define planning-dir (build-path tmp-dir ".planning"))
-  (make-directory planning-dir)
-  ;; Create a minimal PLAN.md with wave index
-  (display-to-file "# Test Plan\n\n- [Inbox] W0: First wave\n- [Inbox] W1: Second wave\n"
-                   (build-path planning-dir "PLAN.md")
-                   #:exists 'replace)
-  ;; Create STATE.md
-  (display-to-file "# Project State\n\nStatus: Active\n"
-                   (build-path planning-dir "STATE.md")
-                   #:exists 'replace)
-  ;; Set up GSD state
-  (set-pinned-planning-dir! tmp-dir)
-  (set-gsd-mode! 'planning)
-  (set-gsd-mode! 'plan-written)
-  (set-gsd-mode! 'executing)
-  (set-total-waves! 2)
-  ;; Call cmd-wave-done
-  (define result (cmd-wave-done tmp-dir "0"))
-  (check-true (hash-ref result 'success))
-  (check-equal? (hash-ref result 'wave) 0)
-  (check-true (string-contains? (hash-ref result 'message) "Wave 0"))
-  ;; Verify PLAN.md updated
-  (define plan-content (file->string (build-path planning-dir "PLAN.md")))
-  (check-true (string-contains? plan-content "[DONE] W0:"))
-  (check-true (string-contains? plan-content "[Inbox] W1:"))
-  ;; Verify STATE.md updated
-  (define state-content (file->string (build-path planning-dir "STATE.md")))
-  (check-true (string-contains? state-content "W0: completed"))
-  ;; Cleanup
-  (delete-directory/files tmp-dir)
-  (reset-all-gsd-state!))
+  (with-gsd-cleanup
+   (lambda ()
+     (define tmp-dir (make-temporary-file "q-test-wave-done-~a" 'directory))
+     (define planning-dir (build-path tmp-dir ".planning"))
+     (make-directory planning-dir)
+     ;; Create a minimal PLAN.md with wave index
+     (display-to-file "# Test Plan\n\n- [Inbox] W0: First wave\n- [Inbox] W1: Second wave\n"
+                      (build-path planning-dir "PLAN.md")
+                      #:exists 'replace)
+     ;; Create STATE.md
+     (display-to-file "# Project State\n\nStatus: Active\n"
+                      (build-path planning-dir "STATE.md")
+                      #:exists 'replace)
+     ;; Set up GSD state
+     (set-pinned-planning-dir! tmp-dir)
+     (set-gsd-mode! 'planning)
+     (set-gsd-mode! 'plan-written)
+     (set-gsd-mode! 'executing)
+     (set-total-waves! 2)
+     ;; Call cmd-wave-done
+     (define result (cmd-wave-done tmp-dir "0"))
+     (check-true (hash-ref result 'success))
+     (check-equal? (hash-ref result 'wave) 0)
+     (check-true (string-contains? (hash-ref result 'message) "Wave 0"))
+     ;; Verify PLAN.md updated
+     (define plan-content (file->string (build-path planning-dir "PLAN.md")))
+     (check-true (string-contains? plan-content "[DONE] W0:"))
+     (check-true (string-contains? plan-content "[Inbox] W1:"))
+     ;; Verify STATE.md updated
+     (define state-content (file->string (build-path planning-dir "STATE.md")))
+     (check-true (string-contains? state-content "W0: completed"))
+     ;; Cleanup
+     (delete-directory/files tmp-dir))))
 
 (test-case "wave-done: without index returns usage"
-  (reset-all-gsd-state!)
-  (define result (cmd-wave-done #f ""))
-  (check-false (hash-ref result 'success))
-  (check-true (string-contains? (hash-ref result 'message) "Usage"))
-  (reset-all-gsd-state!))
+  (with-gsd-cleanup (lambda ()
+                      (define result (cmd-wave-done #f ""))
+                      (check-false (hash-ref result 'success))
+                      (check-true (string-contains? (hash-ref result 'message) "Usage")))))
 
 (test-case "wave-done: non-numeric index returns error"
-  (reset-all-gsd-state!)
-  (define result (cmd-wave-done #f "abc"))
-  (check-false (hash-ref result 'success))
-  (check-true (string-contains? (hash-ref result 'message) "Invalid"))
-  (reset-all-gsd-state!))
+  (with-gsd-cleanup (lambda ()
+                      (define result (cmd-wave-done #f "abc"))
+                      (check-false (hash-ref result 'success))
+                      (check-true (string-contains? (hash-ref result 'message) "Invalid")))))
 
 (test-case "wave-done: negative index returns error"
-  (reset-all-gsd-state!)
-  (define result (cmd-wave-done #f "-1"))
-  (check-false (hash-ref result 'success))
-  (check-true (string-contains? (hash-ref result 'message) "non-negative"))
-  (reset-all-gsd-state!))
+  (with-gsd-cleanup (lambda ()
+                      (define result (cmd-wave-done #f "-1"))
+                      (check-false (hash-ref result 'success))
+                      (check-true (string-contains? (hash-ref result 'message) "non-negative")))))
 
 (test-case "wave-done: multiple waves can be marked"
-  (reset-all-gsd-state!)
-  (define tmp-dir (make-temporary-file "q-test-wave-done-~a" 'directory))
-  (define planning-dir (build-path tmp-dir ".planning"))
-  (make-directory planning-dir)
-  (display-to-file "# Test Plan\n\n- [Inbox] W0: First\n- [Inbox] W1: Second\n"
-                   (build-path planning-dir "PLAN.md")
-                   #:exists 'replace)
-  (display-to-file "# Project State\n\nStatus: Active\n"
-                   (build-path planning-dir "STATE.md")
-                   #:exists 'replace)
-  (set-pinned-planning-dir! tmp-dir)
-  (set-gsd-mode! 'planning)
-  (set-gsd-mode! 'plan-written)
-  (set-gsd-mode! 'executing)
-  (set-total-waves! 2)
-  ;; Mark W0
-  (define r0 (cmd-wave-done tmp-dir "0"))
-  (check-true (hash-ref r0 'success))
-  ;; Mark W1
-  (define r1 (cmd-wave-done tmp-dir "1"))
-  (check-true (hash-ref r1 'success))
-  ;; Both marked in PLAN.md
-  (define plan-content (file->string (build-path planning-dir "PLAN.md")))
-  (check-true (string-contains? plan-content "[DONE] W0:"))
-  (check-true (string-contains? plan-content "[DONE] W1:"))
-  ;; Both in STATE.md
-  (define state-content (file->string (build-path planning-dir "STATE.md")))
-  (check-true (string-contains? state-content "W0: completed"))
-  (check-true (string-contains? state-content "W1: completed"))
-  (delete-directory/files tmp-dir)
-  (reset-all-gsd-state!))
+  (with-gsd-cleanup (lambda ()
+                      (define tmp-dir (make-temporary-file "q-test-wave-done-~a" 'directory))
+                      (define planning-dir (build-path tmp-dir ".planning"))
+                      (make-directory planning-dir)
+                      (display-to-file "# Test Plan\n\n- [Inbox] W0: First\n- [Inbox] W1: Second\n"
+                                       (build-path planning-dir "PLAN.md")
+                                       #:exists 'replace)
+                      (display-to-file "# Project State\n\nStatus: Active\n"
+                                       (build-path planning-dir "STATE.md")
+                                       #:exists 'replace)
+                      (set-pinned-planning-dir! tmp-dir)
+                      (set-gsd-mode! 'planning)
+                      (set-gsd-mode! 'plan-written)
+                      (set-gsd-mode! 'executing)
+                      (set-total-waves! 2)
+                      ;; Mark W0
+                      (define r0 (cmd-wave-done tmp-dir "0"))
+                      (check-true (hash-ref r0 'success))
+                      ;; Mark W1
+                      (define r1 (cmd-wave-done tmp-dir "1"))
+                      (check-true (hash-ref r1 'success))
+                      ;; Both marked in PLAN.md
+                      (define plan-content (file->string (build-path planning-dir "PLAN.md")))
+                      (check-true (string-contains? plan-content "[DONE] W0:"))
+                      (check-true (string-contains? plan-content "[DONE] W1:"))
+                      ;; Both in STATE.md
+                      (define state-content (file->string (build-path planning-dir "STATE.md")))
+                      (check-true (string-contains? state-content "W0: completed"))
+                      (check-true (string-contains? state-content "W1: completed"))
+                      (delete-directory/files tmp-dir))))
 
 (test-case "wave-done: works through execute-command handler"
-  (reset-all-gsd-state!)
-  (define tmp-dir (make-temporary-file "q-test-wave-done-~a" 'directory))
-  (define planning-dir (build-path tmp-dir ".planning"))
-  (make-directory planning-dir)
-  (display-to-file "# Test Plan\n\n- [Inbox] W0: First\n"
-                   (build-path planning-dir "PLAN.md")
-                   #:exists 'replace)
-  (display-to-file "# Project State\n\nStatus: Active\n"
-                   (build-path planning-dir "STATE.md")
-                   #:exists 'replace)
-  (set-pinned-planning-dir! tmp-dir)
-  (set-gsd-mode! 'planning)
-  (set-gsd-mode! 'plan-written)
-  (set-gsd-mode! 'executing)
-  (set-total-waves! 1)
-  (define handler (hash-ref (extension-hooks gsd-planning-extension) 'execute-command))
-  (define result (handler (hasheq 'command "/wave-done" 'input "/wave-done 0")))
-  (check-equal? (hook-result-action result) 'amend)
-  (check-true (string-contains? (hash-ref (hook-result-payload result) 'text) "Wave 0"))
-  (delete-directory/files tmp-dir)
-  (reset-all-gsd-state!))
+  (with-gsd-cleanup
+   (lambda ()
+     (define tmp-dir (make-temporary-file "q-test-wave-done-~a" 'directory))
+     (define planning-dir (build-path tmp-dir ".planning"))
+     (make-directory planning-dir)
+     (display-to-file "# Test Plan\n\n- [Inbox] W0: First\n"
+                      (build-path planning-dir "PLAN.md")
+                      #:exists 'replace)
+     (display-to-file "# Project State\n\nStatus: Active\n"
+                      (build-path planning-dir "STATE.md")
+                      #:exists 'replace)
+     (set-pinned-planning-dir! tmp-dir)
+     (set-gsd-mode! 'planning)
+     (set-gsd-mode! 'plan-written)
+     (set-gsd-mode! 'executing)
+     (set-total-waves! 1)
+     (define handler (hash-ref (extension-hooks gsd-planning-extension) 'execute-command))
+     (define result (handler (hasheq 'command "/wave-done" 'input "/wave-done 0")))
+     (check-equal? (hook-result-action result) 'amend)
+     (check-true (string-contains? (hash-ref (hook-result-payload result) 'text) "Wave 0"))
+     (delete-directory/files tmp-dir))))

--- a/tests/test-path-canonicalization.rkt
+++ b/tests/test-path-canonicalization.rkt
@@ -1,0 +1,70 @@
+#lang racket
+
+;; tests/test-path-canonicalization.rkt — SEC-02/SEC-03 path canonicalization tests
+;;
+;; Verifies that tool-write and tool-edit canonicalize paths containing
+;; .. components and handle absolute / deeply nested paths correctly.
+
+(require rackunit
+         racket/file
+         (only-in "../tools/builtins/write.rkt"
+                  tool-write
+                  reset-cumulative-writes!
+                  init-session-writes!)
+         (only-in "../tools/builtins/edit.rkt" tool-edit)
+         (only-in "../tools/tool.rkt" tool-result-is-error? tool-result-details))
+
+;; ============================================================
+;; SEC-02/SEC-03: Path canonicalization tests
+;; ============================================================
+
+(test-case "write to path with .. resolves correctly (SEC-02)"
+  (init-session-writes!)
+  (reset-cumulative-writes!)
+  (define tmpdir (make-temporary-file "q-test-canonical-~a" 'directory))
+  (make-directory (build-path tmpdir "sub"))
+  (define raw-path (path->string (build-path tmpdir "sub" ".." "canonical.txt")))
+  (define result (tool-write (hasheq 'path raw-path 'content "canonicalized")))
+  (check-false (tool-result-is-error? result))
+  ;; After canonicalization, file should be at tmpdir/canonical.txt (not tmpdir/sub/../canonical.txt)
+  (check-pred file-exists? (build-path tmpdir "canonical.txt"))
+  (check-equal? (file->string (build-path tmpdir "canonical.txt")) "canonicalized")
+  (delete-directory/files tmpdir))
+
+(test-case "edit with .. path canonicalizes (SEC-03)"
+  (init-session-writes!)
+  (reset-cumulative-writes!)
+  (define tmpdir (make-temporary-file "q-test-canonical-edit-~a" 'directory))
+  (make-directory (build-path tmpdir "sub"))
+  (define target (build-path tmpdir "edit-me.txt"))
+  ;; Write initial content
+  (display-to-file "hello world" target #:exists 'replace)
+  ;; Edit via .. path: tmpdir/sub/../edit-me.txt
+  (define raw-path (path->string (build-path tmpdir "sub" ".." "edit-me.txt")))
+  (define result (tool-edit (hasheq 'path raw-path 'old-text "hello" 'new-text "goodbye")))
+  (check-false (tool-result-is-error? result))
+  (check-equal? (file->string target) "goodbye world")
+  (delete-directory/files tmpdir))
+
+(test-case "write to absolute path works (SEC-02)"
+  (init-session-writes!)
+  (reset-cumulative-writes!)
+  (define tmpdir (make-temporary-file "q-test-abs-~a" 'directory))
+  (define target (build-path tmpdir "abs-write.txt"))
+  (define abs-path (path->string target))
+  (define result (tool-write (hasheq 'path abs-path 'content "absolute path")))
+  (check-false (tool-result-is-error? result))
+  (check-pred file-exists? target)
+  (check-equal? (file->string target) "absolute path")
+  (delete-directory/files tmpdir))
+
+(test-case "write to deeply nested path creates dirs (SEC-02)"
+  (init-session-writes!)
+  (reset-cumulative-writes!)
+  (define tmpdir (make-temporary-file "q-test-deep-~a" 'directory))
+  (define target (build-path tmpdir "a" "b" "c" "d" "deep.txt"))
+  (define result (tool-write (hasheq 'path (path->string target) 'content "deeply nested")))
+  (check-false (tool-result-is-error? result))
+  (check-pred file-exists? target)
+  (check-equal? (file->string target) "deeply nested")
+  (delete-directory/files tmpdir))

--- a/tests/test-tool-bash-security.rkt
+++ b/tests/test-tool-bash-security.rkt
@@ -30,6 +30,30 @@
 (test-case "SEC-01: backtick command substitution is destructive"
   (check-true (destructive-command? "echo `rm -rf /`")))
 
+;; ── AUDIT-01: Backtick regex false-positive fix ──
+;; The backtick pattern was changed from #rx"`" (matches any single backtick)
+;; to #rx"`[^`]+`" (matches only paired backticks like `command`).
+;; This prevents false positives from markdown inline code or lone backticks.
+
+(test-case "AUDIT-01: paired backticks with benign content IS flagged (intentional)"
+  ;; In bash, backticks always trigger command substitution regardless of content.
+  ;; `code` would run the command "code". This is a deliberate false positive.
+  (check-true (destructive-command? "echo \"use `code` blocks\"")))
+
+(test-case "AUDIT-01: single backtick is NOT destructive"
+  (check-false (destructive-command? "echo 'single backtick: `'")))
+
+(test-case "AUDIT-01: paired backticks with command IS destructive"
+  (check-true (destructive-command? "echo `ls`")))
+
+;; ── AUDIT-02: $() regex tradeoff documentation ──
+;; AUDIT-02: The $() regex intentionally matches broadly. Commands like
+;; echo "$(date)" would be flagged. This is a deliberate tradeoff:
+;; false positives are safer than false negatives for command substitution.
+
+(test-case "AUDIT-02: echo with $(date) is flagged (intentional false positive)"
+  (check-true (destructive-command? "echo \"result: $(date)\"")))
+
 (test-case "SEC-01: eval indirection is destructive"
   (check-true (destructive-command? "eval $(echo boom)")))
 

--- a/tools/builtins/bash.rkt
+++ b/tools/builtins/bash.rkt
@@ -56,50 +56,51 @@
 ;; Patterns are matched case-insensitively against the full command.
 (define destructive-patterns
   ;; Recursive / forceful deletion — anchored at command start
-  (list #rx"^rm[ ]+.*-[a-zA-Z]*r.*-[a-zA-Z]*f" ;; rm with -r and -f flags
-        #rx"^rm[ ]+-rf[ ]+" ;; rm -rf shorthand
-        #rx"^rm[ ]+-fr[ ]+" ;; rm -fr shorthand
-        #rx"^rm[ ]+-r[ ]+-f[ ]+" ;; rm -r -f
-        #rx"^rmdir[ ]+" ;; rmdir
-        ;; Also match after pipe/semicolon/&& operators
-        #rx"[|;&][ ]*rm[ ]+-rf[ ]+" ;; piped rm -rf
-        ;; Disk/filesystem destruction
-        #rx"^mkfs[.]" ;; mkfs.*
-        #rx"^dd[ ]+if=" ;; dd if=
-        #rx"^dd[ ]+.*of=/dev/" ;; dd of=/dev/
-        #rx">[ ]*/dev/sd" ;; device file write
-        ;; System commands — anchored at command start
-        #rx"^shutdown([ ]|$)" ;; shutdown
-        #rx"^reboot([ ]|$)" ;; reboot
-        #rx"^format[ ]+[A-Za-z]:" ;; Windows format
-        #rx"^del[ ]+/" ;; Windows del
-        ;; Permission destruction
-        #rx"^chmod[ ]+-r[ ]+777[ ]+/" ;; recursive 777 on root
-        #rx"^chmod[ ]+000[ ]+/" ;; lock out root
-        ;; Pipe-to-shell (must be at pipe boundary)
-        #rx"[|][ ]*sh[ ]*$" ;; | sh
-        #rx"[|][ ]*bash[ ]*$" ;; | bash
-        ;; Critical system file overwrite
-        #rx">[ ]*/etc/passwd" ;; passwd overwrite
-        #rx">[ ]*/etc/shadow" ;; shadow overwrite
-        ;; Git destructive
-        #rx"^git[ ]+push[ ]+.*--force" ;; force push
-        ;; Root directory operations
-        #rx"^mv[ ]+/[ ]+" ;; mv /
-        ;; Download-to-shell combos (SEC-A)
-        #rx"curl[ ]+.*[|][ ]*sh[ ]*$" ;; curl ... | sh
-        #rx"wget[ ]+.*[|][ ]*sh[ ]*$" ;; wget ... | sh
-        #rx"eval[ ]+\"[$][(]curl" ;; eval "$(curl ...)"
-        #rx"source[ ]+/tmp/" ;; source from temp
-        ;; SEC-01 (v0.22.0): Bypass-vector patterns — encoding tricks,
-        ;; substitution, and indirection that evade simple pattern matching.
-        #rx"[|].*base64" ;; base64 decode pipe bypass
-        #rx"[|].*xxd" ;; xxd hex decode pipe bypass
-        #rx"\\$\\(" ;; $(...) command substitution
-        #rx"`" ;; backtick command substitution
-        #rx"^eval[ ]+" ;; eval indirection
-        #rx"^exec[ ]+" ;; exec replacement
-        ))
+  (list
+   #rx"^rm[ ]+.*-[a-zA-Z]*r.*-[a-zA-Z]*f" ;; rm with -r and -f flags
+   #rx"^rm[ ]+-rf[ ]+" ;; rm -rf shorthand
+   #rx"^rm[ ]+-fr[ ]+" ;; rm -fr shorthand
+   #rx"^rm[ ]+-r[ ]+-f[ ]+" ;; rm -r -f
+   #rx"^rmdir[ ]+" ;; rmdir
+   ;; Also match after pipe/semicolon/&& operators
+   #rx"[|;&][ ]*rm[ ]+-rf[ ]+" ;; piped rm -rf
+   ;; Disk/filesystem destruction
+   #rx"^mkfs[.]" ;; mkfs.*
+   #rx"^dd[ ]+if=" ;; dd if=
+   #rx"^dd[ ]+.*of=/dev/" ;; dd of=/dev/
+   #rx">[ ]*/dev/sd" ;; device file write
+   ;; System commands — anchored at command start
+   #rx"^shutdown([ ]|$)" ;; shutdown
+   #rx"^reboot([ ]|$)" ;; reboot
+   #rx"^format[ ]+[A-Za-z]:" ;; Windows format
+   #rx"^del[ ]+/" ;; Windows del
+   ;; Permission destruction
+   #rx"^chmod[ ]+-r[ ]+777[ ]+/" ;; recursive 777 on root
+   #rx"^chmod[ ]+000[ ]+/" ;; lock out root
+   ;; Pipe-to-shell (must be at pipe boundary)
+   #rx"[|][ ]*sh[ ]*$" ;; | sh
+   #rx"[|][ ]*bash[ ]*$" ;; | bash
+   ;; Critical system file overwrite
+   #rx">[ ]*/etc/passwd" ;; passwd overwrite
+   #rx">[ ]*/etc/shadow" ;; shadow overwrite
+   ;; Git destructive
+   #rx"^git[ ]+push[ ]+.*--force" ;; force push
+   ;; Root directory operations
+   #rx"^mv[ ]+/[ ]+" ;; mv /
+   ;; Download-to-shell combos (SEC-A)
+   #rx"curl[ ]+.*[|][ ]*sh[ ]*$" ;; curl ... | sh
+   #rx"wget[ ]+.*[|][ ]*sh[ ]*$" ;; wget ... | sh
+   #rx"eval[ ]+\"[$][(]curl" ;; eval "$(curl ...)"
+   #rx"source[ ]+/tmp/" ;; source from temp
+   ;; SEC-01 (v0.22.0): Bypass-vector patterns — encoding tricks,
+   ;; substitution, and indirection that evade simple pattern matching.
+   #rx"[|].*base64" ;; base64 decode pipe bypass
+   #rx"[|].*xxd" ;; xxd hex decode pipe bypass
+   #rx"\\$\\(" ;; $(...) command substitution
+   #rx"`[^`]+`" ;; AUDIT-01: paired backtick command substitution (avoids false positives on lone backticks)
+   #rx"^eval[ ]+" ;; eval indirection
+   #rx"^exec[ ]+" ;; exec replacement
+   ))
 
 ;; User-configurable extra patterns (loaded from settings).
 ;; When non-#f, these EXTEND the default destructive-patterns (SEC-A).


### PR DESCRIPTION
Addresses #2216.

fix: audit security + test quality — AUDIT-01/02/03/12/13 (#2216)

W0 of v0.22.1:
- AUDIT-01: Replace single backtick regex with paired backtick pattern
- AUDIT-02: Document $() regex tradeoff with intentional false-positive test
- AUDIT-03: Wire up with-gsd-cleanup in 29 state-mutating GSD tests
- AUDIT-12: Add nil-input edge case to error sanitizer tests
- AUDIT-13: Add SEC-02/SEC-03 path canonicalization tests (4 test cases)
- Fix info.rkt version sync (0.21.10 → 0.22.0)