### PR TITLE
fix: audit code quality + architecture — AUDIT-04/09/10/11 (#2222)

W1 of v0.22.1:
- AUDIT-04: Remove dead gsd-tool-guard from gsd/core.rkt (canonical in gsd-planning.rkt)
- AUDIT-09: Remove duplicate requires in events.rkt and message-inject.rkt
- AUDIT-10: Already fixed in v0.22.0 SEC-16 (shell-quote direct import)
- AUDIT-11: Replace 3 check-not-false with check-pred values in GSD tests

### DIFF
--- a/extensions/events.rkt
+++ b/extensions/events.rkt
@@ -15,8 +15,7 @@
 
 (require racket/contract
          "api.rkt"
-         "../util/protocol-types.rkt"
-         "api.rkt")
+         "../util/protocol-types.rkt")
 
 (define-logger ext-events)
 

--- a/extensions/gsd/core.rkt
+++ b/extensions/gsd/core.rkt
@@ -28,7 +28,6 @@
          (only-in "../gsd-planning-state.rkt" mark-wave-complete! pinned-planning-dir))
 
 (provide gsd-command-dispatch
-         gsd-tool-guard
          gsd-write-guard
          gsd-show-status
          ;; Individual command handlers for direct wiring
@@ -286,20 +285,11 @@
       (hasheq 'success #f 'mode (gsm-current) 'message (hash-ref result 'error "Archive failed"))))
 
 ;; ============================================================
-;; Tool guard (tool-call-pre)
-;; ============================================================
-
-(define (gsd-tool-guard tool-name tool-args)
-  (if (gsm-tool-allowed? tool-name)
-      #t
-      (hasheq 'blocked
-              #t
-              'tool
-              tool-name
-              'mode
-              (gsm-current)
-              'reason
-              (format "Tool '~a' is not allowed in ~a mode" tool-name (gsm-current)))))
+;; AUDIT-04: gsd-tool-guard removed from core.rkt.
+;; The canonical implementation lives in gsd-planning.rkt as a
+;; tool-call-pre hook handler with the correct (payload) signature.
+;; The core.rkt version had a stale (tool-name tool-args) signature
+;; and was not imported by any module.
 
 ;; ============================================================
 ;; Write guard (hardened — DD-6)

--- a/extensions/message-inject.rkt
+++ b/extensions/message-inject.rkt
@@ -19,8 +19,7 @@
 (require racket/contract
          "api.rkt"
          "../util/protocol-types.rkt"
-         "../util/ids.rkt"
-         "../util/protocol-types.rkt")
+         "../util/ids.rkt")
 
 (provide (contract-out [inject-system-message! (-> event-bus? string? string? any/c)]
                        [inject-user-message! (-> event-bus? string? string? any/c)]

--- a/tests/test-gsd-planning.rkt
+++ b/tests/test-gsd-planning.rkt
@@ -317,9 +317,9 @@
     (handler ctx)
     ;; Commands should be registered
     (define cmd (ext-lookup-command ctx "/plan"))
-    (check-not-false cmd)
-    (check-not-false (ext-lookup-command ctx "/state"))
-    (check-not-false (ext-lookup-command ctx "/handoff"))))
+    (check-pred values cmd)
+    (check-pred values (ext-lookup-command ctx "/state"))
+    (check-pred values (ext-lookup-command ctx "/handoff"))))
 
 (test-case "registered planning-read tool is callable"
   (with-temp-dir (lambda (dir)


### PR DESCRIPTION
Addresses #2222.

fix: audit code quality + architecture — AUDIT-04/09/10/11 (#2222)

W1 of v0.22.1:
- AUDIT-04: Remove dead gsd-tool-guard from gsd/core.rkt (canonical in gsd-planning.rkt)
- AUDIT-09: Remove duplicate requires in events.rkt and message-inject.rkt
- AUDIT-10: Already fixed in v0.22.0 SEC-16 (shell-quote direct import)
- AUDIT-11: Replace 3 check-not-false with check-pred values in GSD tests