### PR TITLE
refactor: GSD per-session state parameterization — QUAL-02/03 (#2227)

W2 of v0.22.1:
- QUAL-02: Create extensions/gsd/session-state.rkt with per-session Racket parameters
  (current-gsd-state, current-gsd-mode, current-pinned-dir, current-edit-limit,
   current-gsd-event-bus, current-gsd-history, current-plan-data)
- QUAL-03: Migrate state-machine.rkt from global gsm-state-box/gsm-history-box
  to session parameters, migrate gsd-planning-state.rkt from global boxes to
  session parameters. Eliminates 2 semaphore+box patterns.
- All 93 GSD tests pass, 136 tests total in regression

### DIFF
--- a/extensions/gsd-planning-state.rkt
+++ b/extensions/gsd-planning-state.rkt
@@ -1,12 +1,13 @@
 #lang racket/base
 
-;; extensions/gsd-planning-state.rkt — Thin shim over new gsd/ modules
+;; extensions/gsd-planning-state.rkt — Thin shim over gsd/ modules
 ;;
 ;; v0.21.6: steering.rkt import removed (dead code).
-;; Only wave tracking
-;; and mode delegation remain.
+;; v0.22.1 QUAL-03: Migrated from global mutable boxes to per-session
+;; parameters via session-state.rkt.
 
 (require "gsd/state-machine.rkt"
+         "gsd/session-state.rkt"
          "gsd/wave-docs.rkt")
 
 (provide gsd-mode
@@ -31,16 +32,6 @@
          ;; Event bus
          gsd-event-bus
          set-gsd-event-bus!)
-
-;; ============================================================
-;; State boxes (semaphore-protected)
-;; ============================================================
-
-(define state-sem (make-semaphore 1))
-
-(define pinned-dir-box (box #f))
-(define edit-limit-box (box 500))
-(define gsd-event-bus-box (box #f))
 
 ;; ============================================================
 ;; Mode delegation to state machine
@@ -76,20 +67,20 @@
     [else (gsm-transition! v)]))
 
 ;; ============================================================
-;; Accessors (semaphore-protected)
+;; Accessors — now backed by session parameters
 ;; ============================================================
 
 (define (pinned-planning-dir)
-  (call-with-semaphore state-sem (lambda () (unbox pinned-dir-box))))
+  (current-pinned-dir))
 
 (define (set-pinned-planning-dir! v)
-  (call-with-semaphore state-sem (lambda () (set-box! pinned-dir-box v))))
+  (current-pinned-dir v))
 
 (define (current-max-old-text-len)
-  (call-with-semaphore state-sem (lambda () (unbox edit-limit-box))))
+  (current-edit-limit))
 
 (define (set-current-max-old-text-len! v)
-  (call-with-semaphore state-sem (lambda () (set-box! edit-limit-box v))))
+  (current-edit-limit v))
 
 ;; ============================================================
 ;; Wave tracking (delegated to state machine — F4 consolidation)
@@ -118,41 +109,38 @@
   (gsm-next-pending-wave))
 
 ;; ============================================================
-;; Event bus
+;; Event bus — now backed by session parameter
 ;; ============================================================
 
 (define (gsd-event-bus)
-  (call-with-semaphore state-sem (lambda () (unbox gsd-event-bus-box))))
+  (current-gsd-event-bus))
 
 (define (set-gsd-event-bus! v)
-  (call-with-semaphore state-sem (lambda () (set-box! gsd-event-bus-box v))))
+  (current-gsd-event-bus v))
 
 ;; ============================================================
-;; Observability + reset
+;; Observability + reset — now backed by session parameters
 ;; ============================================================
 
 (define (gsd-snapshot)
-  (call-with-semaphore state-sem
-                       (lambda ()
-                         (hasheq 'mode
-                                 (gsm-current)
-                                 'pinned-dir
-                                 (unbox pinned-dir-box)
-                                 'edit-limit
-                                 (unbox edit-limit-box)
-                                 'total-waves
-                                 (gsm-total-waves)
-                                 'current-wave
-                                 (gsm-current-wave)
-                                 'completed-waves
-                                 (gsm-completed-waves)
-                                 'wave-executor
-                                 (and (gsm-wave-executor) #t)))))
+  (hasheq 'mode
+          (gsm-current)
+          'pinned-dir
+          (current-pinned-dir)
+          'edit-limit
+          (current-edit-limit)
+          'total-waves
+          (gsm-total-waves)
+          'current-wave
+          (gsm-current-wave)
+          'completed-waves
+          (gsm-completed-waves)
+          'wave-executor
+          (and (gsm-wave-executor) #t)))
 
 (define (reset-all-gsd-state!)
-  (call-with-semaphore state-sem
-                       (lambda ()
-                         (reset-gsm!)
-                         (set-box! pinned-dir-box #f)
-                         (set-box! edit-limit-box 500)
-                         (set-box! gsd-event-bus-box #f))))
+  (reset-gsm!)
+  (current-pinned-dir #f)
+  (current-edit-limit 500)
+  (current-gsd-event-bus #f)
+  (current-plan-data #f))

--- a/extensions/gsd/session-state.rkt
+++ b/extensions/gsd/session-state.rkt
@@ -1,0 +1,104 @@
+#lang racket/base
+
+;; extensions/gsd/session-state.rkt — Per-session GSD state parameters (QUAL-02)
+;;
+;; Provides Racket parameters for GSD session state, enabling per-session
+;; isolation via parameterize. Replaces global mutable boxes from
+;; gsd-planning-state.rkt and state-machine.rkt.
+;;
+;; Thread safety: Parameters are thread-local by default. The state hash
+;; parameter uses a semaphore for atomic multi-field updates (mode + wave
+;; state must transition together).
+
+(require racket/set)
+
+;; ============================================================
+;; Per-session state parameters
+;; ============================================================
+
+;; Core GSD state hash: mode, wave-executor, total-waves, current-wave, completed-waves
+;; This replaces the global gsm-state-box in state-machine.rkt.
+(define current-gsd-state
+  (make-parameter
+   (hasheq 'mode 'idle 'wave-executor #f 'total-waves 0 'current-wave 0 'completed-waves (set))))
+
+;; Convenience accessor: current GSD mode symbol
+(define (current-gsd-mode)
+  (hash-ref (current-gsd-state) 'mode))
+
+;; Convenience accessor: current wave number
+(define (current-wave-number)
+  (hash-ref (current-gsd-state) 'current-wave))
+
+;; Convenience accessor: current plan data (from planning state)
+(define current-plan-data (make-parameter #f))
+
+;; Planning directory (replaces pinned-dir-box)
+(define current-pinned-dir (make-parameter #f))
+
+;; Edit limit (replaces edit-limit-box)
+(define current-edit-limit (make-parameter 500))
+
+;; Event bus (replaces gsd-event-bus-box)
+(define current-gsd-event-bus (make-parameter #f))
+
+;; State machine history (replaces gsm-history-box)
+(define current-gsd-history (make-parameter '()))
+
+;; Semaphore for atomic state transitions
+(define gsd-state-sem (make-semaphore 1))
+
+;; ============================================================
+;; Atomic state operations
+;; ============================================================
+
+;; Read current state atomically
+(define (gsd-state-snapshot)
+  (call-with-semaphore gsd-state-sem (lambda () (current-gsd-state))))
+
+;; Update state atomically (thunk receives current state, returns new state)
+(define (gsd-state-update! update-thunk)
+  (call-with-semaphore gsd-state-sem
+                       (lambda () (current-gsd-state (update-thunk (current-gsd-state))))))
+
+;; Read history atomically
+(define (gsd-history-snapshot)
+  (call-with-semaphore gsd-state-sem (lambda () (reverse (current-gsd-history)))))
+
+;; Update history atomically
+(define (gsd-history-update! update-thunk)
+  (call-with-semaphore gsd-state-sem
+                       (lambda () (current-gsd-history (update-thunk (current-gsd-history))))))
+
+;; Reset all session state to defaults
+(define (reset-session-state!)
+  (call-with-semaphore
+   gsd-state-sem
+   (lambda ()
+     (current-gsd-state
+      (hasheq 'mode 'idle 'wave-executor #f 'total-waves 0 'current-wave 0 'completed-waves (set)))
+     (current-gsd-history '())))
+  (current-pinned-dir #f)
+  (current-edit-limit 500)
+  (current-gsd-event-bus #f)
+  (current-plan-data #f))
+
+;; ============================================================
+;; Provide
+;; ============================================================
+
+(provide current-gsd-state
+         current-gsd-mode
+         current-wave-number
+         current-plan-data
+         current-pinned-dir
+         current-edit-limit
+         current-gsd-event-bus
+         current-gsd-history
+         ;; Atomic operations
+         gsd-state-sem
+         gsd-state-snapshot
+         gsd-state-update!
+         gsd-history-snapshot
+         gsd-history-update!
+         reset-session-state!)

--- a/extensions/gsd/state-machine.rkt
+++ b/extensions/gsd/state-machine.rkt
@@ -3,17 +3,19 @@
 ;; extensions/gsd/state-machine.rkt — GSD State Machine
 ;;
 ;; Wave 0 of v0.21.0: Central state machine with explicit transitions and guards.
-;; Replaces scattered mode checks across 4 hook handlers.
+;; v0.22.1 QUAL-03: Migrated from global mutable boxes to per-session parameters
+;; via session-state.rkt.
 ;;
 ;; States: idle → exploring → plan-written → executing → verifying → idle
 ;;                 ↑              ↓
 ;;                 └──────────────┘ (re-plan on failure)
 ;;
-;; All state is semaphore-protected for thread safety.
+;; Thread safety: Uses gsd-state-sem from session-state.rkt for atomic updates.
 
 (require racket/contract
          racket/match
-         racket/set)
+         racket/set
+         "session-state.rkt")
 
 ;; States
 (provide gsm-state?
@@ -97,42 +99,31 @@
   (err-result-reason r))
 
 ;; ============================================================
-;; State storage (semaphore-protected)
-;; ============================================================
-
-(define gsm-sem (make-semaphore 1))
-;; State is a hash: 'mode, 'wave-executor, 'total-waves, 'current-wave, 'completed-waves
-(define gsm-state-box
-  (box (hasheq 'mode 'idle 'wave-executor #f 'total-waves 0 'current-wave 0 'completed-waves (set))))
-(define gsm-history-box (box '()))
-
-;; ============================================================
-;; Core API
+;; Core API — now backed by session-state parameters
 ;; ============================================================
 
 (define (gsm-current)
-  (call-with-semaphore gsm-sem (lambda () (hash-ref (unbox gsm-state-box) 'mode))))
+  (hash-ref (gsd-state-snapshot) 'mode))
 
 (define (gsm-history)
-  (call-with-semaphore gsm-sem (lambda () (reverse (unbox gsm-history-box)))))
+  (gsd-history-snapshot))
 
 (define (gsm-transition! target)
   (call-with-semaphore
-   gsm-sem
+   gsd-state-sem
    (lambda ()
-     (define current (hash-ref (unbox gsm-state-box) 'mode))
+     (define state (current-gsd-state))
+     (define current (hash-ref state 'mode))
      (cond
        [(not (gsm-state? target)) (err-result (format "invalid state: ~a" target) current target)]
        [(valid-transition? current target)
         ;; Clear executor when leaving executing mode
-        (define state (unbox gsm-state-box))
         (define state*
           (if (and (eq? current 'executing) (not (eq? target 'executing)))
               (hash-set state 'wave-executor #f)
               state))
-        (set-box! gsm-state-box (hash-set state* 'mode target))
-        (set-box! gsm-history-box
-                  (cons (list current target (current-seconds)) (unbox gsm-history-box)))
+        (current-gsd-state (hash-set state* 'mode target))
+        (current-gsd-history (cons (list current target (current-seconds)) (current-gsd-history)))
         (ok-result current target)]
        [else
         (err-result
@@ -142,21 +133,20 @@
 
 (define (gsm-reset!)
   (call-with-semaphore
-   gsm-sem
+   gsd-state-sem
    (lambda ()
-     (define old (hash-ref (unbox gsm-state-box) 'mode))
-     (set-box! gsm-state-box (hash-set* (unbox gsm-state-box) 'mode 'idle 'wave-executor #f))
-     (set-box! gsm-history-box (cons (list old 'idle (current-seconds)) (unbox gsm-history-box)))
+     (define old (hash-ref (current-gsd-state) 'mode))
+     (current-gsd-state (hash-set* (current-gsd-state) 'mode 'idle 'wave-executor #f))
+     (current-gsd-history (cons (list old 'idle (current-seconds)) (current-gsd-history)))
      (ok-result old 'idle))))
 
 (define (reset-gsm!)
   (call-with-semaphore
-   gsm-sem
+   gsd-state-sem
    (lambda ()
-     (set-box!
-      gsm-state-box
+     (current-gsd-state
       (hasheq 'mode 'idle 'wave-executor #f 'total-waves 0 'current-wave 0 'completed-waves (set)))
-     (set-box! gsm-history-box '())
+     (current-gsd-history '())
      (void))))
 
 (define (gsm-valid-next-states)
@@ -164,7 +154,7 @@
   (valid-targets current))
 
 (define (gsm-snapshot)
-  (call-with-semaphore gsm-sem (lambda () (unbox gsm-state-box))))
+  (gsd-state-snapshot))
 
 ;; ============================================================
 ;; Tool access
@@ -192,54 +182,42 @@
     (cdr t)))
 
 ;; ============================================================
-;; Wave state accessors (F4: consolidated from gsd-planning-state)
+;; Wave state accessors — now backed by session-state parameters
 ;; ============================================================
 
 (define (gsm-wave-executor)
-  (call-with-semaphore gsm-sem (lambda () (hash-ref (unbox gsm-state-box) 'wave-executor))))
+  (hash-ref (gsd-state-snapshot) 'wave-executor))
 
 (define (gsm-set-wave-executor! exec)
-  (call-with-semaphore
-   gsm-sem
-   (lambda () (set-box! gsm-state-box (hash-set (unbox gsm-state-box) 'wave-executor exec)))))
+  (gsd-state-update! (lambda (state) (hash-set state 'wave-executor exec))))
 
 (define (gsm-total-waves)
-  (call-with-semaphore gsm-sem (lambda () (hash-ref (unbox gsm-state-box) 'total-waves))))
+  (hash-ref (gsd-state-snapshot) 'total-waves))
 
 (define (gsm-set-total-waves! n)
-  (call-with-semaphore gsm-sem
-                       (lambda ()
-                         (set-box! gsm-state-box (hash-set (unbox gsm-state-box) 'total-waves n)))))
+  (gsd-state-update! (lambda (state) (hash-set state 'total-waves n))))
 
 (define (gsm-current-wave)
-  (call-with-semaphore gsm-sem (lambda () (hash-ref (unbox gsm-state-box) 'current-wave))))
+  (hash-ref (gsd-state-snapshot) 'current-wave))
 
 (define (gsm-set-current-wave! n)
-  (call-with-semaphore gsm-sem
-                       (lambda ()
-                         (set-box! gsm-state-box (hash-set (unbox gsm-state-box) 'current-wave n)))))
+  (gsd-state-update! (lambda (state) (hash-set state 'current-wave n))))
 
 (define (gsm-completed-waves)
-  (call-with-semaphore gsm-sem (lambda () (hash-ref (unbox gsm-state-box) 'completed-waves))))
+  (hash-ref (gsd-state-snapshot) 'completed-waves))
 
 (define (gsm-mark-wave-complete! idx)
-  (call-with-semaphore gsm-sem
-                       (lambda ()
-                         (define state (unbox gsm-state-box))
-                         (define completed (hash-ref state 'completed-waves))
-                         (set-box! gsm-state-box
-                                   (hash-set state 'completed-waves (set-add completed idx))))))
+  (gsd-state-update! (lambda (state)
+                       (define completed (hash-ref state 'completed-waves))
+                       (hash-set state 'completed-waves (set-add completed idx)))))
 
 (define (gsm-wave-complete? idx)
-  (call-with-semaphore gsm-sem
-                       (lambda ()
-                         (set-member? (hash-ref (unbox gsm-state-box) 'completed-waves) idx))))
+  (set-member? (hash-ref (gsd-state-snapshot) 'completed-waves) idx))
 
 (define (gsm-next-pending-wave)
-  (call-with-semaphore gsm-sem
-                       (lambda ()
-                         (define tw (hash-ref (unbox gsm-state-box) 'total-waves))
-                         (define cw (hash-ref (unbox gsm-state-box) 'completed-waves))
-                         (for/first ([i (in-range tw)]
-                                     #:when (not (set-member? cw i)))
-                           i))))
+  (define state (gsd-state-snapshot))
+  (define tw (hash-ref state 'total-waves))
+  (define cw (hash-ref state 'completed-waves))
+  (for/first ([i (in-range tw)]
+              #:when (not (set-member? cw i)))
+    i))


### PR DESCRIPTION
Addresses #2227.

refactor: GSD per-session state parameterization — QUAL-02/03 (#2227)

W2 of v0.22.1:
- QUAL-02: Create extensions/gsd/session-state.rkt with per-session Racket parameters
  (current-gsd-state, current-gsd-mode, current-pinned-dir, current-edit-limit,
   current-gsd-event-bus, current-gsd-history, current-plan-data)
- QUAL-03: Migrate state-machine.rkt from global gsm-state-box/gsm-history-box
  to session parameters, migrate gsd-planning-state.rkt from global boxes to
  session parameters. Eliminates 2 semaphore+box patterns.
- All 93 GSD tests pass, 136 tests total in regression