### PR TITLE
fix: pre-existing test failures + code quality (REV-05/06a/06b/06c/11)\n\nWave 1 of v0.22.2.\n\nREV-06a: Update test-destructive-warning to expect 'safe-mode-default\nREV-06b: Update test-registry-defaults to expect 14 tools (add delete-lines)\nREV-06c: Update test-self-hosting-deep to accept 0.22.x versions\nREV-05: DRY session-log-path — extract to session-types.rkt\nREV-11: Remove stale AUDIT-04 comment from core.rkt\n\nFixes #2257, fixes #2258, fixes #2259, fixes #2260, fixes #2262."

### DIFF
--- a/extensions/gsd/core.rkt
+++ b/extensions/gsd/core.rkt
@@ -285,13 +285,6 @@
       (hasheq 'success #f 'mode (gsm-current) 'message (hash-ref result 'error "Archive failed"))))
 
 ;; ============================================================
-;; AUDIT-04: gsd-tool-guard removed from core.rkt.
-;; The canonical implementation lives in gsd-planning.rkt as a
-;; tool-call-pre hook handler with the correct (payload) signature.
-;; The core.rkt version had a stale (tool-name tool-args) signature
-;; and was not imported by any module.
-
-;; ============================================================
 ;; Write guard (hardened — DD-6)
 ;; ============================================================
 

--- a/runtime/agent-session.rkt
+++ b/runtime/agent-session.rkt
@@ -127,9 +127,7 @@
 ;; ============================================================
 ;; Helpers
 ;; ============================================================
-
-(define (session-log-path dir)
-  (build-path dir "session.jsonl"))
+;; session-log-path imported from session-types.rkt (REV-05 DRY)
 
 ;; #771: Ensure session directory exists and flush pending entries.
 ;; ensure-persisted! : agent-session? -> void?

--- a/runtime/session-events.rkt
+++ b/runtime/session-events.rkt
@@ -71,6 +71,4 @@
 ;; ============================================================
 ;; Helpers
 ;; ============================================================
-
-(define (session-log-path dir)
-  (build-path dir "session.jsonl"))
+;; session-log-path imported from session-types.rkt (REV-05 DRY)

--- a/runtime/session-types.rkt
+++ b/runtime/session-types.rkt
@@ -6,7 +6,8 @@
 ;; Shared types module so extracted sub-modules can access the session
 ;; struct without creating circular dependencies.
 
-(provide (struct-out agent-session))
+(provide (struct-out agent-session)
+         session-log-path)
 
 ;; ============================================================
 ;; agent-session struct
@@ -35,3 +36,10 @@
          [force-shutdown? #:mutable]
          [prompt-running? #:mutable]) ; boolean — concurrent prompt execution guard
   #:transparent)
+
+;; ============================================================
+;; Shared helper: session log path
+;; ============================================================
+
+(define (session-log-path dir)
+  (build-path dir "session.jsonl"))

--- a/tests/test-destructive-warning.rkt
+++ b/tests/test-destructive-warning.rkt
@@ -18,20 +18,15 @@
 ;; --------------------------------------------------
 ;; Test 1: Parameter defaults to #t
 ;; --------------------------------------------------
-(check-eq? (current-warn-on-destructive) #t
-           "current-warn-on-destructive should default to #t")
+(check-eq? (current-warn-on-destructive) #t "current-warn-on-destructive should default to #t")
 
 ;; --------------------------------------------------
 ;; Test 2: destructive-command? correctly identifies destructive commands
 ;; --------------------------------------------------
-(check-true (destructive-command? "rm -rf /tmp/test")
-            "rm -rf should be detected as destructive")
-(check-true (destructive-command? "shutdown -h now")
-            "shutdown should be detected as destructive")
-(check-false (destructive-command? "ls -la /tmp")
-             "ls should NOT be detected as destructive")
-(check-false (destructive-command? "echo hello")
-             "echo should NOT be detected as destructive")
+(check-true (destructive-command? "rm -rf /tmp/test") "rm -rf should be detected as destructive")
+(check-true (destructive-command? "shutdown -h now") "shutdown should be detected as destructive")
+(check-false (destructive-command? "ls -la /tmp") "ls should NOT be detected as destructive")
+(check-false (destructive-command? "echo hello") "echo should NOT be detected as destructive")
 
 ;; --------------------------------------------------
 ;; Test 3: Destructive commands trigger a warning on stderr
@@ -41,10 +36,9 @@
                  [current-warn-on-destructive #t])
     (tool-bash (hasheq 'command "rm -rf /tmp/nonexistent_test_path_for_sec02")))
   (define stderr-str (get-output-string captured-stderr))
-  (check-not-false
-   (and (string-contains? stderr-str "WARNING")
-        (string-contains? stderr-str "Destructive command detected"))
-   "rm -rf should produce a WARNING on stderr"))
+  (check-not-false (and (string-contains? stderr-str "WARNING")
+                        (string-contains? stderr-str "Destructive command detected"))
+                   "rm -rf should produce a WARNING on stderr"))
 
 ;; --------------------------------------------------
 ;; Test 4: Non-destructive commands do NOT trigger a warning
@@ -54,9 +48,8 @@
                  [current-warn-on-destructive #t])
     (tool-bash (hasheq 'command "ls")))
   (define stderr-str (get-output-string captured-stderr))
-  (check-false
-   (string-contains? stderr-str "Destructive command detected")
-   "ls should NOT produce a destructive-command warning on stderr"))
+  (check-false (string-contains? stderr-str "Destructive command detected")
+               "ls should NOT produce a destructive-command warning on stderr"))
 
 ;; --------------------------------------------------
 ;; Test 5: Setting parameter to #f suppresses warnings on destructive commands
@@ -66,38 +59,37 @@
                  [current-warn-on-destructive #f])
     (tool-bash (hasheq 'command "rm -rf /tmp/nonexistent_test_path_for_sec02")))
   (define stderr-str (get-output-string captured-stderr))
-  (check-false
-   (string-contains? stderr-str "Destructive command detected")
-   "rm -rf with warning disabled should NOT produce a warning"))
+  (check-false (string-contains? stderr-str "Destructive command detected")
+               "rm -rf with warning disabled should NOT produce a warning"))
 
 ;; ==================================================
 ;; SEC-01: current-block-destructive tests
 ;; ==================================================
 
 ;; --------------------------------------------------
-;; Test 6: current-block-destructive defaults to #f
+;; Test 6: current-block-destructive defaults to 'safe-mode-default
 ;; --------------------------------------------------
-(check-eq? (current-block-destructive) #f
-           "current-block-destructive should default to #f")
+(check-eq? (current-block-destructive)
+           'safe-mode-default
+           "current-block-destructive should default to 'safe-mode-default")
 
 ;; --------------------------------------------------
 ;; Test 7: current-block-destructive #t blocks destructive commands
 ;; --------------------------------------------------
 (let ([result (parameterize ([current-block-destructive #t])
-                 (tool-bash (hasheq 'command "rm -rf /tmp/blocked_test_path")))])
+                (tool-bash (hasheq 'command "rm -rf /tmp/blocked_test_path")))])
   (check-true (tool-result-is-error? result)
               "blocked destructive command should return error tool-result")
   (define content (tool-result-content result))
-  (check-not-false
-   (string-contains? (hash-ref (car content) 'text "") "Blocked destructive command")
-   "error message should mention blocked destructive command"))
+  (check-not-false (string-contains? (hash-ref (car content) 'text "") "Blocked destructive command")
+                   "error message should mention blocked destructive command"))
 
 ;; --------------------------------------------------
 ;; Test 8: current-block-destructive #f allows non-destructive commands
 ;; --------------------------------------------------
 (let ([result (parameterize ([current-block-destructive #f]
-                              [current-warn-on-destructive #f])
-                 (tool-bash (hasheq 'command "echo blocked_test")))])
+                             [current-warn-on-destructive #f])
+                (tool-bash (hasheq 'command "echo blocked_test")))])
   (check-false (tool-result-is-error? result)
                "non-destructive command should succeed regardless of block setting"))
 
@@ -113,6 +105,5 @@
                 "blocked destructive command should return error even with warning on")
     (define stderr-str (get-output-string captured-stderr))
     ;; When blocking, no subprocess runs so no warning should be emitted
-    (check-false
-     (string-contains? stderr-str "WARNING")
-     "blocking should prevent warning from being emitted")))
+    (check-false (string-contains? stderr-str "WARNING")
+                 "blocking should prevent warning from being emitted")))

--- a/tests/test-registry-defaults.rkt
+++ b/tests/test-registry-defaults.rkt
@@ -8,7 +8,7 @@
 ;; register-default-tools! — registers all tools
 ;; ============================================================
 
-(test-case "register-default-tools! registers all 13 built-in tools"
+(test-case "register-default-tools! registers all 14 built-in tools"
   (define reg (make-tool-registry))
   (register-default-tools! reg)
   (define names (sort (tool-names reg) string<?))
@@ -21,6 +21,7 @@
                         "find"
                         "ls"
                         "date"
+                        "delete-lines"
                         "firecrawl"
                         "spawn-subagent"
                         "spawn-subagents"

--- a/tests/test-self-hosting-deep.rkt
+++ b/tests/test-self-hosting-deep.rkt
@@ -191,7 +191,10 @@
   (define ver-path (build-path project-root "q" "util" "version.rkt"))
   (check-true (file-exists? ver-path))
   (define content (file->string ver-path))
-  (check-true (or (string-contains? content "0.20") (string-contains? content "0.21")) "version must be in 0.20.x or 0.21.x series"))
+  (check-true (or (string-contains? content "0.20")
+                  (string-contains? content "0.21")
+                  (string-contains? content "0.22"))
+              "version must be in 0.20.x/0.21.x/0.22.x series"))
 
 ;; ============================================================
 ;; Deep Test 10: Benchmark suite infrastructure


### PR DESCRIPTION
Addresses #2256.

fix: pre-existing test failures + code quality (REV-05/06a/06b/06c/11)\n\nWave 1 of v0.22.2.\n\nREV-06a: Update test-destructive-warning to expect 'safe-mode-default\nREV-06b: Update test-registry-defaults to expect 14 tools (add delete-lines)\nREV-06c: Update test-self-hosting-deep to accept 0.22.x versions\nREV-05: DRY session-log-path — extract to session-types.rkt\nREV-11: Remove stale AUDIT-04 comment from core.rkt\n\nFixes #2257, fixes #2258, fixes #2259, fixes #2260, fixes #2262."