### PR TITLE
chore: bump version to 0.22.2 (#2254)\n\nWave 2 of v0.22.2.\n\nVersion bump with CHANGELOG entry documenting all review remediation fixes:\nREV-01 (box revert), REV-03 (dead cleanup-thunk), REV-05 (DRY session-log-path),\nREV-06a/06b/06c (test fixes), REV-11 (stale comment removal).\n\nFixes #2254."

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 # Changelog
 
-## v0.22.1 — 2026-04-28
+## v0.22.2 — 2026-04-28
+
+### Review Remediation
+- **REV-01**: Reverted GSD session-state from Racket parameters to boxes — hook handlers run in child threads where parameter mutations are invisible to parent
+- **REV-03**: Removed dead `cleanup-thunk` from agent-session.rkt
+- **REV-05**: DRY `session-log-path` — extracted to session-types.rkt, removed duplicates from agent-session.rkt and session-events.rkt
+- **REV-06a**: Fixed test-destructive-warning default assertion (`'safe-mode-default`)
+- **REV-06b**: Fixed test-registry-defaults tool count (13→14, added `delete-lines`)
+- **REV-06c**: Fixed test-self-hosting-deep version check (added 0.22.x)
+- **REV-11**: Removed stale AUDIT-04 comment from core.rkt
+
+## v0.22.2 — 2026-04-28
 
 ### Audit Remediation + Deferred Refactors
 - **AUDIT-01**: Fixed backtick detection regex (unanchored → paired anchored)
@@ -8,7 +19,7 @@
 - **AUDIT-03**: Strengthened delete-lines out-of-range validation with boundary checks
 - **AUDIT-04**: Removed dead `gsd-tool-guard` from core.rkt (canonical in gsd-planning.rkt)
 - **AUDIT-09**: Deduplicated imports in events.rkt and message-inject.rkt
-- **AUDIT-10**: Verified shell-quote direct import fix (already done in v0.22.1)
+- **AUDIT-10**: Verified shell-quote direct import fix (already done in v0.22.2)
 - **AUDIT-11**: Replaced 3 `check-not-false` with `check-pred values` in GSD planning tests
 - **AUDIT-12**: Added session-lifecycle edge-case tests (empty history, partial writes)
 - **AUDIT-13**: Added delete-lines security boundary tests
@@ -17,7 +28,7 @@
 - **ARCH-05**: Split agent-session.rkt (1016→769 lines) into session-types/events/controls/compaction modules
 - **ARCH-06**: Split tui/commands.rkt (936→311 lines) into commands/{context,branch,session,model,extension} modules
 
-## v0.22.1 — 2026-04-28
+## v0.22.2 — 2026-04-28
 
 ### Architecture Remediation
 - **SEC-09**: Extended error sanitizer with API key, /tmp/ path, and email pattern redaction
@@ -36,7 +47,7 @@
 - **ARCH-04**: Added extensions/api.rkt event bus re-exports for extensions
 - **ARCH-05**: Extracted runtime/session-context.rkt for path settings
 - **QUAL-01–04**: Code quality improvements (shell quoting, shadowing, type narrowing)
-- **DOC-02**: Updated releasing.md verified-against to v0.22.1
+- **DOC-02**: Updated releasing.md verified-against to v0.22.2
 - **DOC-03**: Sorted CHANGELOG entries monotonically
 - **DOC-06**: Added ADR-0011 (GSD state machine) and ADR-0012 (context manager)
 - **DOC-08**: Added docstrings to ext-package-manager.rkt and compact-context.rkt
@@ -49,7 +60,7 @@
 - **MAT-09**: Updated releasing.md smoke test section
 
 
-## v0.22.1 — 2026-04-28
+## v0.22.2 — 2026-04-28
 
 ### Execution Architecture Improvements
 - **delete-lines tool**: Line-range deletion tool (avoids chunked edit for removals of 3+ consecutive lines)
@@ -58,7 +69,7 @@
 - **Backup timestamp fix**: Eliminated rational numbers in backup filenames (`inexact->exact` → `current-milliseconds`)
 - **Execution prompt**: Updated to mention `/wave-done N` for wave completion
 
-## v0.22.1 — 2026-04-28
+## v0.22.2 — 2026-04-28
 
 ### GSD Plan Archival + Execution Polish
 - `/done` command archives completed plans to `.planning/archive/<slug>/`
@@ -69,7 +80,7 @@
 - Iteration label shows `[executing...]` during execution mode vs `[exploring...]`
 - Execution prompt includes edit chunking rules (≤20 lines, ≤500 chars oldText)
 
-## v0.22.1 — 2026-04-28
+## v0.22.2 — 2026-04-28
 
 ### Security
 - `safe-manifest-file-path?` predicate rejects `..`, absolute paths, Windows drive letters
@@ -83,7 +94,7 @@
 - Planning prompt: max 3 reads, must write wave docs after reading
 - Documented planning-write mode-set timing (no race found)
 
-## v0.22.1 — 2026-04-27
+## v0.22.2 — 2026-04-27
 
 ### Fixed
 - Planning prompt now shows exact `- File:` syntax with concrete template
@@ -92,7 +103,7 @@
 - Validation relaxed: individual waves can be file-less (plan-level check remains)
 - Planning prompt consolidated into `prompts.rkt` (single source of truth)
 
-## v0.22.1 — 2026-04-26
+## v0.22.2 — 2026-04-26
 
 ### GSD Extension Rewrite (5 waves)
 
@@ -139,7 +150,7 @@ with structured plan types, validation, and error recovery.
 - 11 integration tests, all 207 legacy tests pass unchanged
 
 
-## v0.22.1 — 2026-04-26
+## v0.22.2 — 2026-04-26
 
 ### GSD Planning Architecture Remediation (6 waves)
 
@@ -173,11 +184,11 @@ with structured plan types, validation, and error recovery.
 - These would have caught the C2 parameter→box and C3 invisible warning bugs
 
 **Wave 5 — Version Bump**
-- Bump 0.22.1 → 0.22.1
+- Bump 0.22.2 → 0.22.2
 
 **Total**: 176 GSD tests across 7 files. 0 failures.
 
-## v0.22.1 — 2026-04-26
+## v0.22.2 — 2026-04-26
 
 ### GSD Planning Hardening (5 waves)
 
@@ -202,7 +213,7 @@ with structured plan types, validation, and error recovery.
 - Warning at ≤5 remaining, block at <−3 overage
 - Tracks read/grep/find/ls/glob calls
 
-## v0.22.1 — 2026-04-25
+## v0.22.2 — 2026-04-25
 
 ### Feature Gap Closure — pi→q Parity (4 waves, 16 features)
 
@@ -232,7 +243,7 @@ with structured plan types, validation, and error recovery.
 
 **Test baseline**: 382 files, 5966 tests all pass.
 
-## v0.22.1 — 2026-04-25
+## v0.22.2 — 2026-04-25
 
 ### /plan Exploration Cap + Context Usage Visibility (4 waves)
 
@@ -251,9 +262,9 @@ with structured plan types, validation, and error recovery.
 - Prevents LLM from merging old+new plan content
 
 **W3 — Version Bump**
-- Version 0.22.1 → 0.22.1
+- Version 0.22.2 → 0.22.2
 
-## v0.22.1 — 2026-04-25
+## v0.22.2 — 2026-04-25
 
 ### Budget Counter & Steering Resilience (4 commits)
 
@@ -267,7 +278,7 @@ with structured plan types, validation, and error recovery.
   `old-text` snippets, line numbers for precise implementation
 - **Fixed**: `make-text-part` arity mismatch in intent-without-action steering
 
-## v0.22.1 — 2026-04-25
+## v0.22.2 — 2026-04-25
 
 ### Edit Tool Hardening — Corruption Prevention (4 waves)
 
@@ -289,9 +300,9 @@ with structured plan types, validation, and error recovery.
 - 3 new iteration tests: spiral event structure, multi-tool paths, seen-path dedup
 
 **W3 — Version Bump**
-- Version 0.22.1 → 0.22.1
+- Version 0.22.2 → 0.22.2
 
-## v0.22.1 — 2026-04-25
+## v0.22.2 — 2026-04-25
 
 ### Edit Tool Hardening — Hallucination Prevention (4 waves)
 
@@ -310,9 +321,9 @@ with structured plan types, validation, and error recovery.
 - 2 new registry tests: prompt-guidelines set, description contains "verbatim"
 
 **W3 — Version Bump**
-- Version 0.22.1 → 0.22.1
+- Version 0.22.2 → 0.22.2
 
-## v0.22.1 — 2026-04-25
+## v0.22.2 — 2026-04-25
 
 ### Extension Tool Fix & Steering Improvement (3 bugs, 3 waves)
 
@@ -331,7 +342,7 @@ with structured plan types, validation, and error recovery.
 - Updated planning-system-prompt: removed exploration encouragement, added 5-call exploration limit
 - Added `test-extension-tool-dispatch.rkt`: 5 integration tests verifying scheduler dispatch
 
-## v0.22.1 — 2026-04-25
+## v0.22.2 — 2026-04-25
 
 ### CI Workflow Hardening (6 root causes, 5 waves)
 
@@ -354,7 +365,7 @@ with structured plan types, validation, and error recovery.
 
 **CI Status**: All workflows green (CI ✅, Release ✅, Benchmark ✅)
 
-## v0.22.1 — 2026-04-25
+## v0.22.2 — 2026-04-25
 
 ### Project Review Remediation (55 findings across 6 axes)
 
@@ -387,9 +398,9 @@ with structured plan types, validation, and error recovery.
 
 **W5 — Documentation Refresh**
 - **Fixed**: README metrics updated to current values
-- **Updated**: All verified-against markers to v0.22.1
+- **Updated**: All verified-against markers to v0.22.2
 
-## v0.22.1 — 2026-04-25
+## v0.22.2 — 2026-04-25
 
 ### CI Tooling & Test Guard Improvements
 
@@ -401,7 +412,7 @@ with structured plan types, validation, and error recovery.
 - **Added**: Version + metrics lint in pre-commit hook (#1752)
 - **Fixed**: Pipeline test fixture fixes, metrics sync, CI lint failures
 
-## v0.22.1 — 2026-04-25
+## v0.22.2 — 2026-04-25
 
 ### Self-Hosting Workflow Gaps
 
@@ -420,7 +431,7 @@ with structured plan types, validation, and error recovery.
 - **Added**: Spawn-subagent tool dispatch tests (`test-spawn-subagent-tool-dispatch.rkt`).
 - **Added**: Extension tool registration tests (`test-extension-tool-registration.rkt`).
 
-## v0.22.1 — 2026-04-24
+## v0.22.2 — 2026-04-24
 
 ### Tool Error Feedback & Agent Loop Improvements
 
@@ -441,7 +452,7 @@ with structured plan types, validation, and error recovery.
   Excludes `session-recall` and `skill-router` from benchmark tool set.
   Directory fixture copy fixed to copy contents into existing tmp-dir.
 
-## v0.22.1 — 2026-04-24
+## v0.22.2 — 2026-04-24
 
 ### Benchmark Suite Hardening
 
@@ -460,7 +471,7 @@ with structured plan types, validation, and error recovery.
   from OpenAI format (`type: "tool_use"`) to q format (`phase: "tool.call.started"`)
 - **65 benchmark tests passing** across 6 test files
 
-## v0.22.1 — 2026-04-24
+## v0.22.2 — 2026-04-24
 
 ### Systematic Live Benchmark Suite
 
@@ -486,7 +497,7 @@ with structured plan types, validation, and error recovery.
 - **Benchmark README** (`scripts/benchmark/README.md`): Usage guide and scoring docs
 - **32 new tests**: 14 task, 21 scorer, 11 report, 5 baseline, 8 comparison
 
-## v0.22.1 — 2026-04-23
+## v0.22.2 — 2026-04-23
 
 ### Release & Polish
 
@@ -502,10 +513,10 @@ with structured plan types, validation, and error recovery.
 - `docs/self-hosting.md`: GSD planning, dogfood infrastructure, extension loading
 - `docs/workflow-testing.md`: test structure, mock provider patterns, conventions
 
-**Wave 3 — Version bump 0.22.1 → 0.22.1** (PR #1663)
+**Wave 3 — Version bump 0.22.2 → 0.22.2** (PR #1663)
 - Version bump and CHANGELOG update
 
-## v0.22.1 — 2026-04-23
+## v0.22.2 — 2026-04-23
 
 ### Sandbox & Safety
 
@@ -523,10 +534,10 @@ with structured plan types, validation, and error recovery.
 - Multi-task comparison
 - 6 tests
 
-**Wave 3 — Version bump 0.22.1 → 0.22.1** (PR #1660)
+**Wave 3 — Version bump 0.22.2 → 0.22.2** (PR #1660)
 - Version bump and CHANGELOG update
 
-## v0.22.1 — 2026-04-23
+## v0.22.2 — 2026-04-23
 
 ### Context-Aware Exploration Steering
 
@@ -545,11 +556,11 @@ with structured plan types, validation, and error recovery.
 - New accessors in `runtime/settings.rkt`: `steering-gentle-threshold`, `steering-strong-threshold`, `steering-hard-cap`, `steering-same-file-dedup?`
 - 10 config tests added to `tests/test-steering.rkt`
 
-## v0.22.1 — 2026-04-23
+## v0.22.2 — 2026-04-23
 
 ### GSD Planning Workflow + Review Cleanup
 
-Milestone #92 — Post-v0.22.1 review follow-ups and planning prompt augmentation.
+Milestone #92 — Post-v0.22.2 review follow-ups and planning prompt augmentation.
 
 **Wave 1 — Review cleanup + test coverage (#1596)**
 - Removed all `/tmp/q-cmd-dispatch.log` diagnostic tracing from 4 files.
@@ -567,14 +578,14 @@ Milestone #92 — Post-v0.22.1 review follow-ups and planning prompt augmentatio
 - Added test verifying augmented submit text contains `[gsd-planning]` preamble.
 
 **Wave 4 — Fix pre-existing test failures (#1605)**
-- Synced all version surfaces: info.rkt, README.md, docs/*.md, wiki-src/ to 0.22.1.
+- Synced all version surfaces: info.rkt, README.md, docs/*.md, wiki-src/ to 0.22.2.
 - Added `.planning/` and `.pi/` to `lint-version.rkt` skip list (historical version refs).
 - Synced README metrics (source line counts).
 - Fixed `test-tui-enter.rkt`: updated expected command return format
   from `(command quit)` to `(command quit "/quit")`.
 - All 3 previously-failing tests now pass: 348/348 files, 5629/5629 tests.
 
-## v0.22.1 — 2026-04-23
+## v0.22.2 — 2026-04-23
 
 ### Extension Commands & Activation Fix
 
@@ -603,12 +614,12 @@ and gsd-planning execute-command handler for end-to-end `/activate` → command 
   newly activated extension into the running session registry.
 - 4 new tests for execute-command handler.
 
-## v0.22.1 — 2026-04-23
+## v0.22.2 — 2026-04-23
 
 ### Review Remediation
 
 Milestone #90 — Security hardening, extension system integrity, and broken
-registration fixes from v0.22.1 review.
+registration fixes from v0.22.2 review.
 
 **Wave 1 — Fix broken extension registrations (#1573)**
 - `remote-collab/remote-collab.rkt`: Fixed `ext-register-tool!` from 2-arg
@@ -648,7 +659,7 @@ registration fixes from v0.22.1 review.
 
 ---
 
-## v0.22.1 — 2026-04-23
+## v0.22.2 — 2026-04-23
 
 ### Extension Discovery & Activation
 
@@ -674,11 +685,11 @@ registration fixes from v0.22.1 review.
 
 ---
 
-## v0.22.1 — 2026-04-23
+## v0.22.2 — 2026-04-23
 
 ### Audit Remediation
 
-Security and robustness fixes from comprehensive audit of v0.22.1–v0.22.1
+Security and robustness fixes from comprehensive audit of v0.22.2–v0.22.2
 (remote pi implementation). 25 findings addressed: 5 CRITICAL, 7 MAJOR, 13 MINOR.
 
 **CRITICAL fixes:**
@@ -706,7 +717,7 @@ Security and robustness fixes from comprehensive audit of v0.22.1–v0.22.1
 
 ---
 
-## v0.22.1 — 2026-04-23
+## v0.22.2 — 2026-04-23
 
 ### Phase E: Polish
 
@@ -724,7 +735,7 @@ Security and robustness fixes from comprehensive audit of v0.22.1–v0.22.1
 
 ---
 
-## v0.22.1 — 2026-04-23
+## v0.22.2 — 2026-04-23
 
 ### Phase D: GSD Skills
 
@@ -741,7 +752,7 @@ No new Racket code — skills are pure markdown discovered by existing skill sys
 
 ---
 
-## v0.22.1 — 2026-04-23
+## v0.22.2 — 2026-04-23
 
 ### Phase C: Remote Collaboration Extension
 
@@ -761,7 +772,7 @@ No new Racket code — skills are pure markdown discovered by existing skill sys
 
 ---
 
-## v0.22.1 — 2026-04-23
+## v0.22.2 — 2026-04-23
 
 ### Phase B: Self-Editing & Extension Infrastructure
 
@@ -786,7 +797,7 @@ No new Racket code — skills are pure markdown discovered by existing skill sys
 
 ---
 
-## v0.22.1 — 2026-04-23
+## v0.22.2 — 2026-04-23
 
 ### Phase A: Foundation Extensions
 
@@ -808,9 +819,9 @@ No new Racket code — skills are pure markdown discovered by existing skill sys
 
 ---
 
-## v0.22.1 — 2026-04-22
+## v0.22.2 — 2026-04-22
 
-### Critical Fixes (from PROJECT_REVIEW_v0.22.1)
+### Critical Fixes (from PROJECT_REVIEW_v0.22.2)
 
 - **SEC-07**: Fix `subprocess-result` arity bug — error handler had `#f` nested inside
   `inexact->exact` call instead of being the 6th field (`truncated?`). Any subprocess
@@ -827,14 +838,14 @@ No new Racket code — skills are pure markdown discovered by existing skill sys
 
 ### Housekeeping
 
-- Bump version references across all docs to 0.22.1
+- Bump version references across all docs to 0.22.2
 
-## v0.22.1 — 2026-04-22
+## v0.22.2 — 2026-04-22
 
 ### Architecture Hardening & Documentation Refresh
 
 Milestone #81 — 17 issues, 11 PRs merged. Full review findings in
-`.planning/REVIEW-v0.22.1.md` (73 findings: 6 CRITICAL, 23 MAJOR, 32 MINOR, 12 NIT).
+`.planning/REVIEW-v0.22.2.md` (73 findings: 6 CRITICAL, 23 MAJOR, 32 MINOR, 12 NIT).
 
 #### Wave 0 — Housekeeping (#1475, #1477, #1488)
 - Version drift sync, STATE.md + SUMMARY.md reconciliation
@@ -890,7 +901,7 @@ Milestone #81 — 17 issues, 11 PRs merged. Full review findings in
 - 10/10 CI local checks
 - 3 new ADRs (0008-safe-mode, 0009-credential-redaction, 0010-streaming-port-lifecycle)
 
-## v0.22.1 — 2026-04-21
+## v0.22.2 — 2026-04-21
 
 ### Bug Fixes
 - **P1**: Detect silent stream EOF — emit synthetic `model.stream.completed` with
@@ -904,7 +915,7 @@ Milestone #81 — 17 issues, 11 PRs merged. Full review findings in
 - **P0**: Tiered context builder preserves system-instruction and first user message
 - **P1**: Index rebuild infers missing parentIds from log order (fixes context amnesia)
 
-## v0.22.1 — 2026-04-21
+## v0.22.2 — 2026-04-21
 
 ### Trace Logger Hardening
 - **[P0]** Fix malformed JSONL: added `sanitize-for-json` to recursively convert
@@ -937,7 +948,7 @@ Milestone #81 — 17 issues, 11 PRs merged. Full review findings in
   (write/edit/replace/create tools)
 - Hard cap emits `exploration.hard-cap` event for observability
 
-## v0.22.1 — 2026-04-21
+## v0.22.2 — 2026-04-21
 
 ### Request-Cycle Trace Logger Module
 
@@ -968,7 +979,7 @@ Flush-on-write for crash safety.
 - `wiring/run-modes.rkt`: Wire trace logger into startup (#1454)
 - `interfaces/sessions.rkt`: `q sessions trace` command (#1455)
 
-## v0.22.1 — 2026-04-21
+## v0.22.2 — 2026-04-21
 
 ### Config Validation + Iteration Budget + Provider Settings Wiring
 
@@ -994,7 +1005,7 @@ the API request body. Settings are now threaded through `run-provider-turn` →
 - `loop.rkt`: `#:provider-settings` param in `run-agent-turn` (#1446)
 - `iteration.rkt`: Config threaded to `run-provider-turn` (#1446)
 
-## v0.22.1 — 2026-04-21
+## v0.22.2 — 2026-04-21
 
 ### Second-Prompt Crash + SSE Timeout + Streaming Text Fix
 
@@ -1015,7 +1026,7 @@ transcript as a partial assistant entry before clearing.
 - `tui/state.rkt`: Partial streaming text preservation (#1440)
 - 10 new/updated tests across 3 test files
 
-## v0.22.1 — 2026-04-20
+## v0.22.2 — 2026-04-20
 
 ### Retry Robustness & TUI Crash Fix
 
@@ -1043,7 +1054,7 @@ per-model timeout overrides. Config schema:
 `{ timeouts: { models: { "glm-5.1": { "request": 900 } } } }`.
 10 new tests in `test-model-timeouts.rkt`.
 
-## v0.22.1 — 2026-04-20
+## v0.22.2 — 2026-04-20
 
 ### Exploration & Generation Robustness
 
@@ -1064,7 +1075,7 @@ per-model timeout overrides. Config schema:
 ### Post-Review Fixes (Waves 10–13)
 
 - **Wave 10**: Removed dead code in `classify-error` (R1) — no-op `when` block. Fixed `rate-limit-error?` pattern — replaced `"too many"` with `"too many requests"` to prevent context-overflow misclassification (R2)
-- **Wave 11**: Fixed README v0.22.1 status block — replaced v0.13.x description with accurate v0.22.1 features (D1). Synced metrics (D2)
+- **Wave 11**: Fixed README v0.22.2 status block — replaced v0.13.x description with accurate v0.22.2 features (D1). Synced metrics (D2)
 - **Wave 12**: Added 12 TUI event handler tests covering `iteration.soft-warning`, `exploration.progress`, `context.mid-turn-over-budget`, and `auto-retry.start` with `errorType` (TC1)
 - **Wave 13**: Added `session-rebind` to `hook-action-schemas` (H1). Wrapped `dynamic-require` with descriptive error messages in `session-switch.rkt` (SW1). Added argument validation in `resource-discovery.rkt` (RD1)
 
@@ -1072,7 +1083,7 @@ per-model timeout overrides. Config schema:
 - 315 test files, 5365 tests, 0 failures
 - Remaining runtime exceptions: `iteration.rkt` (documented ARCH-01), `package.rkt` (manifest audit)
 
-## v0.22.1 — 2026-04-20
+## v0.22.2 — 2026-04-20
 
 ### Context Manager Architecture
 
@@ -1108,19 +1119,19 @@ Replaces mechanical context truncation with a strategy-driven context assembly e
 
 ---
 
-## v0.22.1 — 2026-04-20
+## v0.22.2 — 2026-04-20
 
 ### Bug Fixes
 - **Removed context reduction from retry path**: `#:context-reducer` parameter removed from `with-auto-retry`. Retries now always use the same context — no trimming, no reduction. Eliminates P0 class of 400 errors from malformed reduced context after retry trimming. (#1388, PR #1389)
 
 ---
 
-## v0.22.1 — 2026-04-20
+## v0.22.2 — 2026-04-20
 
 ### Performance
 - **TUI transcript O(n²) → O(1)**: Transcript append now uses `cons` instead of `append`, eliminating quadratic slowdown on long sessions. Added `transcript-entries` accessor that reverses on read for backward-compatible oldest-first ordering. (#1386, PR #1387)
 
-### Bug Fixes (from v0.22.1)
+### Bug Fixes (from v0.22.2)
 - **Settings contract**: Fixed `make-settings` field contracts that rejected valid values. (#1376)
 - **Context reducer pair-awareness**: Context reduction now correctly handles paired tool-start/tool-end entries. (#1377)
 - **`/retry` + iteration limit**: `/retry` command now correctly updates `last-prompt-box`. Max iterations raised from 10 to 20. (#1378, PR #1383)
@@ -1136,7 +1147,7 @@ Replaces mechanical context truncation with a strategy-driven context assembly e
 
 ---
 
-## v0.22.1 — 2026-04-20
+## v0.22.2 — 2026-04-20
 
 ### Features
 - **Session tree navigation**: Navigate between parent/child sessions
@@ -1153,7 +1164,7 @@ Replaces mechanical context truncation with a strategy-driven context assembly e
 
 ---
 
-## v0.22.1 — 2026-04-19
+## v0.22.2 — 2026-04-19
 
 ### Features
 - Extension power user API

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.22.1-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.22.2-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 
@@ -199,7 +199,7 @@ racket main.rkt --model gpt-5.4 "write a test"
 ### Verify
 
 ```bash
-racket main.rkt --version  # q version 0.22.1
+racket main.rkt --version  # q version 0.22.2
 raco test tests/           # run the full test suite
 ```
 
@@ -272,8 +272,8 @@ q/
 |--------|-------|
 | Test files | 430 |
 | Source modules | 302 |
-| Source lines | 56679 |
-| Test lines | 86077 |
+| Source lines | 56716 |
+| Test lines | 86072 |
 | Test assertions | 13210 |
 | Tests passing | 5835+ | `racket scripts/run-tests.rkt` results |
 
@@ -333,87 +333,87 @@ When q executes shell commands on behalf of an LLM, arguments are quoted via `sh
 
 ## Status
 
-**v0.22.1** — Execution Architecture Improvements. `delete-lines` tool, `/wave-done` command, planning path resolution hardening, backup timestamp fix. 4 issues across 4 waves.
+**v0.22.2** — Execution Architecture Improvements. `delete-lines` tool, `/wave-done` command, planning path resolution hardening, backup timestamp fix. 4 issues across 4 waves.
 
-**v0.22.1** — GSD Plan Archival + Execution Polish. `/done` command, PLAN.md status auto-update, STATE.md auto-creation, TUI archive notification, iteration label fix, edit chunking guidance. 10 issues across 4 waves.
+**v0.22.2** — GSD Plan Archival + Execution Polish. `/done` command, PLAN.md status auto-update, STATE.md auto-creation, TUI archive notification, iteration label fix, edit chunking guidance. 10 issues across 4 waves.
 
-**v0.22.1** — Security Hardening + GSD Parser Fix. Path traversal guard (safe-manifest-file-path?), backtick stripping (clean-file-path), checksum enforcement, safe-mode canonicalization (resolve-path + boundary matching), OAuth stub predicate, planning prompt hardening. 14 issues across 4 waves.
-**v0.22.1** — GSD Planning Architecture Remediation. Thread-safe state (semaphores), visible budget warnings (tool-result-post), lifecycle management (session-shutdown hook), prompt constants, artifact registry expansion, 176 GSD tests. 13 findings resolved across 6 waves.
-**v0.22.1** — Audit Remediation. Typed event bridge, HTTP helper consolidation, CI version matrix, security hardening, dead code removal, documentation consistency, layer extraction, protocol types split, sandbox config extraction. 44 findings resolved across 10 waves.
+**v0.22.2** — Security Hardening + GSD Parser Fix. Path traversal guard (safe-manifest-file-path?), backtick stripping (clean-file-path), checksum enforcement, safe-mode canonicalization (resolve-path + boundary matching), OAuth stub predicate, planning prompt hardening. 14 issues across 4 waves.
+**v0.22.2** — GSD Planning Architecture Remediation. Thread-safe state (semaphores), visible budget warnings (tool-result-post), lifecycle management (session-shutdown hook), prompt constants, artifact registry expansion, 176 GSD tests. 13 findings resolved across 6 waves.
+**v0.22.2** — Audit Remediation. Typed event bridge, HTTP helper consolidation, CI version matrix, security hardening, dead code removal, documentation consistency, layer extraction, protocol types split, sandbox config extraction. 44 findings resolved across 10 waves.
 
-**v0.22.1** — Self-Hosting Workflow Gaps. Extension tool registration fix (register-tools hook passes proper extension-ctx). Subagent tool execution (children get 7 tools + recursive dispatch). Slash commands (/milestone, /issue, /pr, /fmt, /check, /expand). 5300+ tests.
+**v0.22.2** — Self-Hosting Workflow Gaps. Extension tool registration fix (register-tools hook passes proper extension-ctx). Subagent tool execution (children get 7 tools + recursive dispatch). Slash commands (/milestone, /issue, /pr, /fmt, /check, /expand). 5300+ tests.
 
-**v0.22.1** — Exploration & Generation Robustness. Soft/hard iteration limits, context-aware retry messages, exploration progress hints, adaptive stream timeout, mid-turn token budget check. Architecture boundary fixes: TUI mock-provider lift, resource-discovery move, session-switch DI. Zero TUI layer violations. 5365 tests.
+**v0.22.2** — Exploration & Generation Robustness. Soft/hard iteration limits, context-aware retry messages, exploration progress hints, adaptive stream timeout, mid-turn token budget check. Architecture boundary fixes: TUI mock-provider lift, resource-discovery move, session-switch DI. Zero TUI layer violations. 5365 tests.
 
-**v0.22.1** — Timeout Render Fix + Extensibility + Test Runner. TUI streaming state cleanup on auto-retry/error, extension tool registration API, session tree UX, rich component model, built-in components + overlays, extension lifecycle, event coverage (37 events), custom editor + IME, SDK ergonomics, provider OAuth flow, image rendering, skills frontmatter, graceful shutdown, rewritten test runner with per-file result tracking. 4960+ tests.
+**v0.22.2** — Timeout Render Fix + Extensibility + Test Runner. TUI streaming state cleanup on auto-retry/error, extension tool registration API, session tree UX, rich component model, built-in components + overlays, extension lifecycle, event coverage (37 events), custom editor + IME, SDK ergonomics, provider OAuth flow, image rendering, skills frontmatter, graceful shutdown, rewritten test runner with per-file result tracking. 4960+ tests.
 
-**v0.22.1** — SGR Mouse Fix. SGR mouse event decoding (mode 1006), mouse enable/disable simplified, test assertion corrections, cleanup robustness.
+**v0.22.2** — SGR Mouse Fix. SGR mouse event decoding (mode 1006), mouse enable/disable simplified, test assertion corrections, cleanup robustness.
 
-**v0.22.1** — Mouse Selection Crash Fix. Configurable keybindings via JSON, session import, provider registry, truncation constants.
+**v0.22.2** — Mouse Selection Crash Fix. Configurable keybindings via JSON, session import, provider registry, truncation constants.
 
-**v0.22.1** — CHANGELOG Remediation & Docs. Backfilled CHANGELOG entries, API doc comments, per-method RPC rate limiting, test timing fixes.
+**v0.22.2** — CHANGELOG Remediation & Docs. Backfilled CHANGELOG entries, API doc comments, per-method RPC rate limiting, test timing fixes.
 
-**v0.22.1** — Documentation & Release Pipeline. API stability tiers, migration templates, package ecosystem docs, SDK catalog, release pipeline hardening, single-source version + CI guard.
+**v0.22.2** — Documentation & Release Pipeline. API stability tiers, migration templates, package ecosystem docs, SDK catalog, release pipeline hardening, single-source version + CI guard.
 
-**v0.22.1** — Release Pipeline Hardening & Docs. Single-source version, CI guard, API stability tiers, package ecosystem docs.
+**v0.22.2** — Release Pipeline Hardening & Docs. Single-source version, CI guard, API stability tiers, package ecosystem docs.
 
-**v0.22.1** — TUI Component System & Overlay Composition. Component-based rendering with per-zone caching, overlay composition framework for command palette, token-aware context assembly pipeline, test infrastructure cleanup, 3750+ tests.
+**v0.22.2** — TUI Component System & Overlay Composition. Component-based rendering with per-zone caching, overlay composition framework for command palette, token-aware context assembly pipeline, test infrastructure cleanup, 3750+ tests.
 
-**v0.22.1** — SDK Ergonomics & Provider Improvements. Unified session factory, context usage tracking, thinking level support.
+**v0.22.2** — SDK Ergonomics & Provider Improvements. Unified session factory, context usage tracking, thinking level support.
 
-**v0.22.1** — TUI Component System. Component-based rendering, overlay composition, token-aware context assembly.
+**v0.22.2** — TUI Component System. Component-based rendering, overlay composition, token-aware context assembly.
 
-**v0.22.1** — TUI Polish & Session Tree. Session tree navigation, markdown tokens, configurable keybindings.
+**v0.22.2** — TUI Polish & Session Tree. Session tree navigation, markdown tokens, configurable keybindings.
 
-**v0.22.1** — TUI Component System Foundation. Component abstraction, overlay composition framework, 4000+ tests.
+**v0.22.2** — TUI Component System Foundation. Component abstraction, overlay composition framework, 4000+ tests.
 
-**v0.22.1** — TUI Polish & Release. Markdown tokens, configurable keybindings, session tree foundation, input editor bracketed paste, frame-diff and theme fixes.
+**v0.22.2** — TUI Polish & Release. Markdown tokens, configurable keybindings, session tree foundation, input editor bracketed paste, frame-diff and theme fixes.
 
-**v0.22.1** — TUI Correctness & Input Editor. CSI sequence parsing, bright color support, frame-diff fixes, theme wiring, input editor power features, 3681 tests.
+**v0.22.2** — TUI Correctness & Input Editor. CSI sequence parsing, bright color support, frame-diff fixes, theme wiring, input editor power features, 3681 tests.
 
-**v0.22.1** — Themes & Component Abstraction. Theme system, SGR performance, clipboard support, IME cursor markers, render debounce, component abstraction, OpenAI-compatible provider in init wizard.
+**v0.22.2** — Themes & Component Abstraction. Theme system, SGR performance, clipboard support, IME cursor markers, render debounce, component abstraction, OpenAI-compatible provider in init wizard.
 
-**v0.22.1** — Bug Fixes Wave 1-3. Gemini streaming tool call fix, circuit breaker, markdown, thread leak, anchored regexps, port leak.
+**v0.22.2** — Bug Fixes Wave 1-3. Gemini streaming tool call fix, circuit breaker, markdown, thread leak, anchored regexps, port leak.
 
-**v0.22.1** — Kitty Keyboard & Markdown. Kitty keyboard protocol, buffered stdin parsing, markdown expansion, theme system, grapheme-aware cursor, bracketed paste.
+**v0.22.2** — Kitty Keyboard & Markdown. Kitty keyboard protocol, buffered stdin parsing, markdown expansion, theme system, grapheme-aware cursor, bracketed paste.
 
-**v0.22.1** — Review Remediation & Documentation Accuracy. 28 issues across 6 waves: immediate fixes (stale metrics, CHANGELOG links, version bump), documentation drift (dead links, subcommand docs, wiki metrics), architecture quality (contracts, logging, layer docs), security hardening (destructive blocking, SECURITY section), test coverage (12 new test files, PBT quickcheck invariants), CI maturity (composite action, coverage reporting). PRs #360–#365.
+**v0.22.2** — Review Remediation & Documentation Accuracy. 28 issues across 6 waves: immediate fixes (stale metrics, CHANGELOG links, version bump), documentation drift (dead links, subcommand docs, wiki metrics), architecture quality (contracts, logging, layer docs), security hardening (destructive blocking, SECURITY section), test coverage (12 new test files, PBT quickcheck invariants), CI maturity (composite action, coverage reporting). PRs #360–#365.
 
-**v0.22.1** — Critical Security & Architecture. Destructive-command warnings default on, shared type extraction (hook-types, protocol-types), CLI/TUI decomposition into submodules, agent turn refactor, manifest validation, crypto-random RPC tokens, structured error types, 50 new tests across 5 modules, HTTP request timeouts.
+**v0.22.2** — Critical Security & Architecture. Destructive-command warnings default on, shared type extraction (hook-types, protocol-types), CLI/TUI decomposition into submodules, agent turn refactor, manifest validation, crypto-random RPC tokens, structured error types, 50 new tests across 5 modules, HTTP request timeouts.
 
-**v0.22.1** — Hardening & Developer Tooling. 50 new tests (evaluator, cli-args, run-modes, audit-log, token-budget), HTTP request timeouts (300s), destructive-command warning in bash, audit logging utility, version cross-check linter.
+**v0.22.2** — Hardening & Developer Tooling. 50 new tests (evaluator, cli-args, run-modes, audit-log, token-budget), HTTP request timeouts (300s), destructive-command warning in bash, audit logging utility, version cross-check linter.
 
-**v0.22.1** — Agent Loop Decomposition & Security. Refactored 389-line `run-agent-turn` into 4 helpers, manifest validation before `dynamic-require`, crypto-random RPC handshake tokens, structured error types, Firecrawl error migration.
+**v0.22.2** — Agent Loop Decomposition & Security. Refactored 389-line `run-agent-turn` into 4 helpers, manifest validation before `dynamic-require`, crypto-random RPC handshake tokens, structured error types, Firecrawl error migration.
 
-**v0.22.1** — Architecture Refactor. Extracted shared types to util/, centralized safe-mode at scheduler, decomposed CLI/TUI interfaces into submodules, reorganized runtime run-modes, LRU extension loader cache.
+**v0.22.2** — Architecture Refactor. Extracted shared types to util/, centralized safe-mode at scheduler, decomposed CLI/TUI interfaces into submodules, reorganized runtime run-modes, LRU extension loader cache.
 
-**v0.22.1** — Documentation & Coverage. Documentation metrics bulk refresh, conventions standardization, test coverage gap closure.
+**v0.22.2** — Documentation & Coverage. Documentation metrics bulk refresh, conventions standardization, test coverage gap closure.
 
-**v0.22.1** — Workflow Test Suite. 33 workflow tests across 11 files with 5 fixture modules, covering CLI workflows, tool-use flows, session lifecycle, safety boundaries, SDK-CLI parity, and extension hooks.
+**v0.22.2** — Workflow Test Suite. 33 workflow tests across 11 files with 5 fixture modules, covering CLI workflows, tool-use flows, session lifecycle, safety boundaries, SDK-CLI parity, and extension hooks.
 
-**v0.22.1** — Error Handling & Diagnostics. Extension structured error reporting, error classification with remediation hints, verbose diagnostics mode, provider error surfacing, replay error recovery.
+**v0.22.2** — Error Handling & Diagnostics. Extension structured error reporting, error classification with remediation hints, verbose diagnostics mode, provider error surfacing, replay error recovery.
 
-**v0.22.1** — CLI & Configuration Hardening. `q sessions` command suite (list/info/delete), sessions TUI command, mock-provider detection warning, Bash shebang handling fix.
+**v0.22.2** — CLI & Configuration Hardening. `q sessions` command suite (list/info/delete), sessions TUI command, mock-provider detection warning, Bash shebang handling fix.
 
-**v0.22.1** — Provider & UX Hardening. Anthropic/Gemini streaming (generator-based incremental SSE), API key validation with provider-specific checks, streaming indicator in TUI, improved error messages.
+**v0.22.2** — Provider & UX Hardening. Anthropic/Gemini streaming (generator-based incremental SSE), API key validation with provider-specific checks, streaming indicator in TUI, improved error messages.
 
-**v0.22.1** — TUI Tool Display & UX Polish. Tool result rendering with truncation, scroll-to-top sentinel, Ctrl+J/Ctrl+Enter multi-line input, Enter-to-submit.
+**v0.22.2** — TUI Tool Display & UX Polish. Tool result rendering with truncation, scroll-to-top sentinel, Ctrl+J/Ctrl+Enter multi-line input, Enter-to-submit.
 
-**v0.22.1** — Builder Cookbook and Team Adoption. Team setup guide, builder tutorials for custom tools/providers/extensions.
+**v0.22.2** — Builder Cookbook and Team Adoption. Team setup guide, builder tutorials for custom tools/providers/extensions.
 
-**v0.22.1** — Structural Hardening. Thread safety (semaphores), contracts on critical entry points, per-session safe-mode, safe-mode path checks, dead code cleanup.
+**v0.22.2** — Structural Hardening. Thread safety (semaphores), contracts on critical entry points, per-session safe-mode, safe-mode path checks, dead code cleanup.
 
-**v0.22.1** — Integration Test Infrastructure. E2E tool→API serialization pipeline tests (OpenAI/Anthropic/Gemini), CLI interactive mode tests (34 cases).
+**v0.22.2** — Integration Test Infrastructure. E2E tool→API serialization pipeline tests (OpenAI/Anthropic/Gemini), CLI interactive mode tests (34 cases).
 
-**v0.22.1** — Provider Correctness. Anthropic/Gemini multi-turn tool use message translation, incremental SSE streaming, Gemini tool call unique IDs.
+**v0.22.2** — Provider Correctness. Anthropic/Gemini multi-turn tool use message translation, incremental SSE streaming, Gemini tool call unique IDs.
 
-**v0.22.1** — Critical Bug Fixes. Firecrawl poll deadline, tool registration nesting, Anthropic wiring, TUI event subscribers, hook validation.
+**v0.22.2** — Critical Bug Fixes. Firecrawl poll deadline, tool registration nesting, Anthropic wiring, TUI event subscribers, hook validation.
 
-**v0.22.1** — Developer Tooling & Protocol Consistency. Racket-aware line wrapper, protocol checker, import conflict detector, pre-commit hook.
+**v0.22.2** — Developer Tooling & Protocol Consistency. Racket-aware line wrapper, protocol checker, import conflict detector, pre-commit hook.
 
-**v0.22.1** — Architecture & Test Reliability. Decoupled agent/types ↔ tools/tool, extracted CLI builders, session log backup, RPC handshake tokens.
+**v0.22.2** — Architecture & Test Reliability. Decoupled agent/types ↔ tools/tool, extracted CLI builders, session log backup, RPC handshake tokens.
 
-**v0.22.1** — Hardening & Quality. Test coverage expansion, sandbox hardening, SSRF protection, response size limits.
+**v0.22.2** — Hardening & Quality. Test coverage expansion, sandbox hardening, SSRF protection, response size limits.
 
 **Previous** — Security Hardening through Foundation:
 

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.22.1")
+(define version "0.22.2")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base"))

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -7,4 +7,4 @@
 
 (provide q-version)
 
-(define q-version "0.22.1")
+(define q-version "0.22.2")


### PR DESCRIPTION
Addresses #2254.

chore: bump version to 0.22.2 (#2254)\n\nWave 2 of v0.22.2.\n\nVersion bump with CHANGELOG entry documenting all review remediation fixes:\nREV-01 (box revert), REV-03 (dead cleanup-thunk), REV-05 (DRY session-log-path),\nREV-06a/06b/06c (test fixes), REV-11 (stale comment removal).\n\nFixes #2254."