### PR TITLE
fix: wave_finish docs-sync bug + extend sync-version to handle all docs\n\nW0 of v0.22.3.\n\nFix 1: wave_finish() ran git diff --name-only without cwd=Q_DIR,\nso auto-fixed docs were never detected and committed.\n\nFix 2: sync-version.rkt now supports --all flag that syncs all\n.md files (not just info.rkt and README.md). This makes version\nbumps atomic — no separate Python regex fallback needed.\n\nFix 3: ci_preflight() simplified to use sync-version.rkt --write\n--all instead of the inline Python regex, eliminating ~40 lines\nof fragile fallback code.\n\nFixes #2266."

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ q/
 |--------|-------|
 | Test files | 430 |
 | Source modules | 302 |
-| Source lines | 56716 |
+| Source lines | 56804 |
 | Test lines | 86072 |
 | Test assertions | 13210 |
 | Tests passing | 5835+ | `racket scripts/run-tests.rkt` results |

--- a/scripts/sync-version.rkt
+++ b/scripts/sync-version.rkt
@@ -7,16 +7,19 @@
 ;; Targets synced:
 ;;   1. info.rkt           (define version "X.Y.Z")
 ;;   2. README.md          version badge + install/verify snippets
+;;   3. All .md files      (--all mode: version refs in docs/)
 ;;
 ;; Usage:
-;;   racket scripts/sync-version.rkt          # dry-run (report only)
-;;   racket scripts/sync-version.rkt --write  # write changes
+;;   racket scripts/sync-version.rkt              # dry-run (report only)
+;;   racket scripts/sync-version.rkt --write      # write info.rkt + README.md
+;;   racket scripts/sync-version.rkt --write --all  # write all surfaces including docs/
 ;;
 ;; Exit 0 if all in sync, 1 if drift detected (or --write applied fixes).
 
 (require racket/file
          racket/port
-         racket/string)
+         racket/string
+         racket/path)
 
 ;; ---------------------------------------------------------------------------
 ;; Parsing
@@ -39,7 +42,6 @@
 ;; ---------------------------------------------------------------------------
 
 (define (sync-info-rkt info-content version)
-  ;; Replace (define version "OLD") with (define version "NEW")
   (regexp-replace #rx"\\(define version \"[0-9]+\\.[0-9]+\\.[0-9]+\"\\)"
                   info-content
                   (format "(define version \"~a\")" version)))
@@ -48,23 +50,103 @@
 ;; Sync README.md
 ;; ---------------------------------------------------------------------------
 
-(define (sync-readme readME-content version)
+(define (sync-readme readme-content version)
   (define step1
-    ;; Version badge: badge/version-OLD-blue → badge/version-NEW-blue
     (regexp-replace #rx"badge/version-[0-9]+\\.[0-9]+\\.[0-9]+-blue"
-                    readME-content
+                    readme-content
                     (format "badge/version-~a-blue" version)))
   (define step2
-    ;; Verify snippet: "q version OLD" → "q version NEW"
     (regexp-replace #rx"q version [0-9]+\\.[0-9]+\\.[0-9]+" step1 (format "q version ~a" version)))
   step2)
+
+;; ---------------------------------------------------------------------------
+;; Sync all .md files (--all mode)
+;; ---------------------------------------------------------------------------
+
+;; Files where version refs are historical / should NOT be overwritten
+(define EXCLUDED-MD-FILES
+  '("CHANGELOG.md" "releasing.md"
+                   "why-q.md"
+                   "api-stability.md"
+                   "compatibility-matrix.md"
+                   "package-registry-spec.md"
+                   "publish-verify-workflow.md"
+                   "sdk-rpc-catalog.md"
+                   "EXTENSIONS_INVENTORY.md"))
+
+(define (skip-md-path? p)
+  (define s (path->string p))
+  (or (string-contains? s "/compiled/")
+      (string-contains? s "/.git/")
+      (string-contains? s "/.planning/")
+      (string-contains? s "/.pi/")
+      (string-contains? s "/examples/README.md")
+      (string-contains? s "/docs/tutorials/")
+      (string-contains? s "/docs/ecosystem/")
+      (string-contains? s "/docs/demos/")))
+
+(define (historical-line? line)
+  (regexp-match? #rx"^\\*\\*v[0-9]" (string-trim line)))
+
+;; Replace mismatched version strings in .md content, respecting context.
+;; Returns (new-content . num-changes).
+(define (sync-md-content content version filename)
+  (define fname
+    (if (path? filename)
+        (path->string (file-name-from-path filename))
+        filename))
+  (define skip-file? (member fname EXCLUDED-MD-FILES))
+  (define lines (string-split content "\n" #:trim? #f))
+  (define in-code-block #f)
+  (define changes 0)
+  (define new-lines
+    (for/list ([line (in-list lines)])
+      (when (string-prefix? (string-trim line) "```")
+        (set! in-code-block (not in-code-block)))
+      (cond
+        [skip-file? line]
+        [(historical-line? line) line]
+        [in-code-block line]
+        [else
+         (define new-line
+           (regexp-replace* #rx"[0-9]+\\.[0-9]+\\.[0-9]+"
+                            line
+                            (lambda (v)
+                              (if (equal? v version)
+                                  v
+                                  (begin
+                                    (set! changes (add1 changes))
+                                    version)))))
+         new-line])))
+  (cons (string-join new-lines "\n") changes))
+
+(define (sync-all-md-files version write-mode?)
+  (define changes 0)
+  (for ([f (in-directory (current-directory))]
+        #:when (and (not (skip-md-path? f))
+                    (let ([ext (filename-extension f)])
+                      (and ext (equal? (bytes->string/utf-8 ext) "md")))))
+    (define fname (path->string f))
+    (define content (file->string f))
+    (define result (sync-md-content content version f))
+    (define new-content (car result))
+    (define n-changes (cdr result))
+    (when (> n-changes 0)
+      (printf "  ~a: ~a ref(s) outdated~n" (find-relative-path (current-directory) f) n-changes)
+      (when write-mode?
+        (call-with-output-file f (lambda (out) (display new-content out)) #:exists 'truncate)
+        (printf "  ~a: FIXED~n" (find-relative-path (current-directory) f)))
+      (set! changes (+ changes n-changes))))
+  changes)
 
 ;; ---------------------------------------------------------------------------
 ;; Main
 ;; ---------------------------------------------------------------------------
 
 (define (main)
-  (define write-mode? (member "--write" (vector->list (current-command-line-arguments))))
+  (define args (vector->list (current-command-line-arguments)))
+  (define write-mode? (member "--write" args))
+  (define all-mode? (member "--all" args))
 
   ;; --- Read canonical version from util/version.rkt ---
   (define util-path (build-path (current-directory) "util" "version.rkt"))
@@ -110,6 +192,12 @@
             (printf "  README.md: FIXED~n"))
           (set! changes (add1 changes)))))
 
+  ;; --- Sync all .md files (--all mode) ---
+  (when all-mode?
+    (printf "~n--- Syncing docs (*.md) ---~n")
+    (define md-changes (sync-all-md-files version write-mode?))
+    (set! changes (+ changes md-changes)))
+
   ;; --- Summary ---
   (printf "~n---~n")
   (cond
@@ -117,10 +205,10 @@
      (displayln "All targets in sync. No changes needed.")
      (exit 0)]
     [write-mode?
-     (printf "~a target(s) synced.~n" changes)
+     (printf "~a change(s) synced.~n" changes)
      (exit 0)]
     [else
-     (printf "~a target(s) out of sync. Run with --write to fix.~n" changes)
+     (printf "~a change(s) out of sync. Run with --write to fix.~n" changes)
      (exit 1)]))
 
 (main)


### PR DESCRIPTION
Addresses #2266.

fix: wave_finish docs-sync bug + extend sync-version to handle all docs\n\nW0 of v0.22.3.\n\nFix 1: wave_finish() ran git diff --name-only without cwd=Q_DIR,\nso auto-fixed docs were never detected and committed.\n\nFix 2: sync-version.rkt now supports --all flag that syncs all\n.md files (not just info.rkt and README.md). This makes version\nbumps atomic — no separate Python regex fallback needed.\n\nFix 3: ci_preflight() simplified to use sync-version.rkt --write\n--all instead of the inline Python regex, eliminating ~40 lines\nof fragile fallback code.\n\nFixes #2266."