### PR TITLE
chore: bump version to 0.22.3 (#2268)\n\nW2 of v0.22.3.\n\nCI Pipeline Hardening release.\nVersion bump with atomic docs sync via sync-version.rkt --write --all.\n\nCI-01: Fixed wave_finish docs-sync bug\nCI-02: Extended sync-version with --all flag\nCI-03: Simplified ci_preflight\nCI-04: Consolidated CI jobs\nCI-05: Added concurrency group\nCI-06: Removed redundant lint from test matrix\n\nFixes #2268."

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v0.22.3 — 2026-04-28
+
+### CI Pipeline Hardening
+- **CI-01**: Fixed `wave_finish()` docs-sync bug — `git diff --name-only` ran without `cwd=Q_DIR`, so auto-fixed docs were never committed
+- **CI-02**: Extended `sync-version.rkt` with `--all` flag to sync all `.md` files (not just info.rkt + README.md)
+- **CI-03**: Simplified `ci_preflight()` to use `sync-version.rkt --write --all` instead of inline Python regex
+- **CI-04**: Consolidated CI jobs: single lint gate → focused test matrix → smoke/release
+- **CI-05**: Added concurrency group to cancel superseded CI runs
+- **CI-06**: Removed redundant lint checks from test matrix cells
+
 ## v0.22.2 — 2026-04-28
 
 ### Review Remediation

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.22.2-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.22.3-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 
@@ -199,7 +199,7 @@ racket main.rkt --model gpt-5.4 "write a test"
 ### Verify
 
 ```bash
-racket main.rkt --version  # q version 0.22.2
+racket main.rkt --version  # q version 0.22.3
 raco test tests/           # run the full test suite
 ```
 
@@ -333,7 +333,7 @@ When q executes shell commands on behalf of an LLM, arguments are quoted via `sh
 
 ## Status
 
-**v0.22.2** — Execution Architecture Improvements. `delete-lines` tool, `/wave-done` command, planning path resolution hardening, backup timestamp fix. 4 issues across 4 waves.
+**v0.22.3** — Execution Architecture Improvements. `delete-lines` tool, `/wave-done` command, planning path resolution hardening, backup timestamp fix. 4 issues across 4 waves.
 
 **v0.22.2** — GSD Plan Archival + Execution Polish. `/done` command, PLAN.md status auto-update, STATE.md auto-creation, TUI archive notification, iteration label fix, edit chunking guidance. 10 issues across 4 waves.
 

--- a/docs/adr/0011-gsd-state-machine-rewrite.md
+++ b/docs/adr/0011-gsd-state-machine-rewrite.md
@@ -1,6 +1,6 @@
 # ADR-0011: GSD State Machine Rewrite
 
-Date: 2025-01 (v0.22.2)
+Date: 2025-01 (v0.22.3)
 ## Status
 Accepted
 

--- a/docs/adr/0012-context-manager-strategy.md
+++ b/docs/adr/0012-context-manager-strategy.md
@@ -1,6 +1,6 @@
 # ADR-0012: Context Manager Strategy Engine
 
-Date: 2024-11 (v0.22.2)
+Date: 2024-11 (v0.22.3)
 ## Status
 Accepted
 

--- a/docs/event-taxonomy.md
+++ b/docs/event-taxonomy.md
@@ -1,6 +1,6 @@
 # Q Event Taxonomy Reference
 
-Complete reference for all event types in Q 0.22.2.
+Complete reference for all event types in Q 0.22.3.
 ## Base Types
 
 ### `event` (protocol-level)

--- a/docs/extension-guide.md
+++ b/docs/extension-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.22.2 --># Extension Development Guide
+<!-- verified-against: 0.22.3 --># Extension Development Guide
 
 This guide walks you through creating, testing, and activating a custom
 extension for q.

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.22.2 --># Getting Started
+<!-- verified-against: 0.22.3 --># Getting Started
 
 Welcome to q, a Racket-based coding agent.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.22.2 --># Installation Guide
+<!-- verified-against: 0.22.3 --># Installation Guide
 
 <!-- This file is the canonical source. The docs/getting-started/installation.md copy is maintained for the doc site build. -->
 

--- a/docs/sdk-guide.md
+++ b/docs/sdk-guide.md
@@ -206,7 +206,7 @@ The SDK provides convenience functions for GSD (Goal-driven Structured Developme
 
 ### Extension Pre-Registration
 
-As of v0.22.2, `open-session` automatically registers extension tools (like `planning-read` and `planning-write`) before the first `run-prompt!` call. This means:
+As of v0.22.3, `open-session` automatically registers extension tools (like `planning-read` and `planning-write`) before the first `run-prompt!` call. This means:
 - Extension tools appear in `list-tools` immediately after `open-session`
 - GSD event bus is initialized and ready to emit events
 - No need to call `run-prompt!` once just to trigger tool registration

--- a/docs/security-trust-model.md
+++ b/docs/security-trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.22.2 --># Security & Trust Model
+<!-- verified-against: 0.22.3 --># Security & Trust Model
 
 This document provides an honest, per-area assessment of what q enforces
 today and what is planned. It is the authoritative reference for security

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.22.2 --># Security Considerations
+<!-- verified-against: 0.22.3 --># Security Considerations
 
 ## API Key Storage
 

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -130,6 +130,6 @@ is the primary self-hosting extension:
 (load-extension! ext-reg "path/to/extension.rkt" #:event-bus bus)
 ```
 
-## Version 0.22.2
+## Version 0.22.3
 
-This documentation reflects q 0.22.2.
+This documentation reflects q 0.22.3.

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.22.2 --># q Source Style Guide
+<!-- verified-against: 0.22.3 --># q Source Style Guide
 
 This document defines formatting and naming conventions for the q Racket codebase.
 All changes to `q/` source files (excluding `tests/`) should follow these rules.

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.22.2 --># Trust Model
+<!-- verified-against: 0.22.3 --># Trust Model
 
 ## Trust Levels
 

--- a/docs/workflow-testing.md
+++ b/docs/workflow-testing.md
@@ -121,6 +121,6 @@ Use relative paths from the test file:
 4. Use `(check-true ...)` for boolean assertions
 5. Keep tests independent — no shared mutable state between test-cases
 
-## Version 0.22.2
+## Version 0.22.3
 
-This documentation reflects q 0.22.2.
+This documentation reflects q 0.22.3.

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.22.2")
+(define version "0.22.3")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base"))

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -7,4 +7,4 @@
 
 (provide q-version)
 
-(define q-version "0.22.2")
+(define q-version "0.22.3")

--- a/wiki-src/Architecture-Overview.md
+++ b/wiki-src/Architecture-Overview.md
@@ -35,7 +35,7 @@ User input → Interface (CLI/TUI/RPC)
     → Events emitted to bus
 ```
 
-## Metrics (0.22.2)
+## Metrics (0.22.3)
 > _See `racket scripts/metrics.rkt` for current numbers._
 
 - 228 source modules, 349 test files


### PR DESCRIPTION
Addresses #2268.

chore: bump version to 0.22.3 (#2268)\n\nW2 of v0.22.3.\n\nCI Pipeline Hardening release.\nVersion bump with atomic docs sync via sync-version.rkt --write --all.\n\nCI-01: Fixed wave_finish docs-sync bug\nCI-02: Extended sync-version with --all flag\nCI-03: Simplified ci_preflight\nCI-04: Consolidated CI jobs\nCI-05: Added concurrency group\nCI-06: Removed redundant lint from test matrix\n\nFixes #2268."