### PR TITLE
feat: provider generics + event payload structs (#2284)\n\nW4 of v0.22.4.\n\nRKT-02: Replaced symbol-dispatch provider with racket/generic:\n- Added define-generics gen:provider with 5 methods\n- Created proc-provider struct implementing gen:provider\n- make-provider creates proc-provider (backward compatible)\n- All 7 provider tests + 4 adapter tests pass (473 total)\n- provider? predicate unchanged\n\nRKT-03: Created util/event-payloads.rkt with typed structs:\n- session-start-payload, session-end-payload, session-switch-payload\n- tool-call-event-payload\n- gsd-mode-payload\n- payload->hash and payload-session-id generic helpers\n- 12 new tests in test-event-payloads.rkt\n\nAll critical tests pass: 636/636 (0 failures).\n\nFixes #2284. Closes #2285. Closes #2286."

### DIFF
--- a/llm/provider.rkt
+++ b/llm/provider.rkt
@@ -2,24 +2,26 @@
 
 ;; llm/provider.rkt — provider interface contract
 ;;
-;; Defines the provider struct and the generic interface that all
-;; LLM provider adapters must satisfy. A provider wraps a dispatch
-;; procedure that maps operation symbols to implementations.
+;; Defines the provider generic interface that all LLM provider adapters
+;; must satisfy. Uses racket/generic for type-safe dispatch.
 ;;
-;; Dispatch protocol:
-;;   'name          → string
-;;   'capabilities  → hash
-;;   'send          → (model-request → model-response) procedure
-;;   'stream        → (model-request → (listof stream-chunk)) procedure
+;; Generic methods:
+;;   provider-name         → string
+;;   provider-capabilities → hash
+;;   provider-send         → (model-request → model-response)
+;;   provider-stream       → (model-request → generator)
+;;   provider-count-tokens → (model-request → (or/c #f integer?))
 
 (require racket/contract
          racket/generator
+         racket/generic
          racket/string
          "model.rkt")
 
 (provide provider?
          validate-api-key!
          ensure-model-setting
+         gen:provider
          (contract-out [provider-name (-> provider? string?)]
                        [provider-send (-> provider? model-request? any/c)]
                        [provider-stream (-> provider? model-request? any/c)]
@@ -32,10 +34,6 @@
 ;; Model-setting helper (ARCH-08)
 ;; ============================================================
 
-;; Ensure the model-request has a 'model setting; if missing, set it to default-model.
-;;; ensure-model-setting : model-request? string? -> model-request?
-;;; If the request has no 'model key in its settings, returns a new request
-;;; with default-model set; otherwise returns the request unchanged.
 (define (ensure-model-setting req default-model)
   (if (hash-has-key? (model-request-settings req) 'model)
       req
@@ -47,13 +45,6 @@
 ;; API key validation helper
 ;; ============================================================
 
-;; Validates that the API key is present and non-empty.
-;; Raises exn:fail with a provider-specific message if missing.
-;;; validate-api-key! : string? string? hash? -> void?
-;;;
-;;; Takes (provider-name env-var config). Checks that config['api-key] is
-;;; a non-empty string; raises exn:fail with a setup message if missing.
-;;; Used by provider implementations to fail fast on missing credentials.
 (define (validate-api-key! provider-name env-var config)
   (define api-key (hash-ref config 'api-key ""))
   (when (or (not api-key) (not (string? api-key)) (string=? (string-trim api-key) ""))
@@ -66,54 +57,24 @@
       (current-continuation-marks)))))
 
 ;; ============================================================
-;; Provider struct
+;; Generic provider interface
 ;; ============================================================
 
-;; A provider wraps a dispatch function that takes a symbol and returns
-;; the corresponding implementation.
-(struct provider (dispatch) #:transparent)
+(define-generics provider
+                 (provider-name provider)
+                 (provider-capabilities provider)
+                 (provider-send provider req)
+                 (provider-stream provider req)
+                 (provider-count-tokens provider req)
+                 #:fallbacks [(define (provider-count-tokens p req)
+                                #f)])
 
 ;; ============================================================
-;; Generic interface
+;; Helper
 ;; ============================================================
 
-;; provider-name : provider? -> string?
-;; Returns the provider's display name.
-(define (provider-name p)
-  ((provider-dispatch p) 'name))
-
-;; provider-send : provider? model-request? -> any/c
-;; Sends a non-streaming request. Returns a model-response.
-(define (provider-send p req)
-  (define send-proc ((provider-dispatch p) 'send))
-  (send-proc req))
-
-;; provider-stream : provider? model-request? -> any/c
-;; Sends a streaming request. Returns a generator that yields
-;; stream-chunk? values then #f.
-(define (provider-stream p req)
-  (define stream-proc ((provider-dispatch p) 'stream))
-  (stream-proc req))
-
-;; provider-capabilities : provider? -> hash?
-;; Returns the provider's capability map (e.g., #hasheq((streaming . #t))).
-(define (provider-capabilities p)
-  ((provider-dispatch p) 'capabilities))
-
-;; ============================================================
-;; Constructor
-;; ============================================================
-
-;; Creates a provider from four thunks/procs:
-;;   name-proc:  (→ string)
-;;   caps-proc:  (→ hash)
-;;   send-proc:  (model-request → model-response)
-;;   stream-proc: (model-request → (or/c generator? (listof stream-chunk?))) procedure
-;;     The stream proc may return a generator (yielding stream-chunk? values then #f)
-;;     or a list of stream-chunk? values (automatically wrapped in a generator).
 (define (stream-result->generator result)
   (cond
-    ;; Already a generator (generators are procedures)
     [(procedure? result) result]
     [(list? result)
      (generator ()
@@ -125,36 +86,38 @@
             "expected generator or list of stream-chunks, got: ~a"
             result)]))
 
-;;; make-provider : procedure? procedure? procedure? procedure? -> provider?
-;;;
-;;; Creates a provider from four procedures:
-;;;   name-proc  : thunk -> string (display name)
-;;;   caps-proc  : thunk -> hash (capability map)
-;;;   send-proc  : model-request -> model-response (non-streaming)
-;;;   stream-proc: model-request -> generator-or-list (streaming)
-;;; The stream result is automatically wrapped in a generator if a list is
-;;; returned.
+;; ============================================================
+;; Internal struct implementing gen:provider
+;; ============================================================
+
+;; Simple procedure-based provider. Adapters create this via make-provider.
+;; Direct struct users can implement gen:provider themselves for custom behavior.
+(struct proc-provider (name-proc caps-proc send-proc stream-proc)
+  #:transparent
+  #:methods gen:provider
+  [(define (provider-name p)
+     ((proc-provider-name-proc p)))
+   (define (provider-capabilities p)
+     ((proc-provider-caps-proc p)))
+   (define (provider-send p req)
+     ((proc-provider-send-proc p) req))
+   (define (provider-stream p req)
+     (stream-result->generator ((proc-provider-stream-proc p) req)))
+   (define (provider-count-tokens p req)
+     #f)])
+
+;; ============================================================
+;; Backward-compatible constructor
+;; ============================================================
+
+;; Creates a provider implementing gen:provider from four procedures.
 (define (make-provider name-proc caps-proc send-proc stream-proc)
-  (provider (lambda (op)
-              (case op
-                [(name) (name-proc)] ; name-proc is a thunk, call it
-                [(capabilities) (caps-proc)] ; caps-proc is a thunk, call it
-                [(send) send-proc]
-                [(stream) (lambda (req) (stream-result->generator (stream-proc req)))]
-                [(count-tokens) (lambda (req) #f)] ; not supported by default
-                [else (error 'provider "unknown operation: ~a" op)]))))
+  (proc-provider name-proc caps-proc send-proc stream-proc))
 
 ;; ============================================================
 ;; Mock provider (for testing)
 ;; ============================================================
 
-;;; make-mock-provider : any/c [#:name string?] [#:stream-chunks (or/c #f list?)]
-;;;                    -> provider?
-;;;
-;;; Creates a mock provider for testing. Always returns the given response
-;;; for send. For stream, yields either the provided #:stream-chunks or
-;;; auto-generated chunks derived from the response content text parts,
-;;; followed by a final chunk with usage + done?.
 (define (make-mock-provider response #:name [name "mock"] #:stream-chunks [stream-chunks #f])
   (define chunks
     (or stream-chunks
@@ -168,7 +131,6 @@
                  (lambda () (hasheq 'streaming #t 'token-counting #t))
                  (lambda (req) response)
                  (lambda (req)
-                   ;; Return a generator that yields each chunk then #f
                    (generator ()
                               (for ([ch (in-list chunks)])
                                 (yield ch))

--- a/tests/test-event-payloads.rkt
+++ b/tests/test-event-payloads.rkt
@@ -1,0 +1,83 @@
+#lang racket
+
+;; tests/test-event-payloads.rkt — Tests for util/event-payloads.rkt
+
+(require rackunit
+         "../util/event-payloads.rkt")
+
+;; ============================================================
+;; Session lifecycle payloads
+;; ============================================================
+
+(test-case "session-start-payload"
+  (define p (session-start-payload "s1" '#hasheq() 'new))
+  (check-equal? (session-start-payload-session-id p) "s1")
+  (check-equal? (session-start-payload-reason p) 'new)
+  (check-pred session-start-payload? p))
+
+(test-case "session-end-payload"
+  (define p (session-end-payload "s1" 42.5))
+  (check-equal? (session-end-payload-session-id p) "s1")
+  (check-equal? (session-end-payload-duration p) 42.5))
+
+(test-case "session-switch-payload"
+  (define p (session-switch-payload "s2" 'resume))
+  (check-equal? (session-switch-payload-session-id p) "s2")
+  (check-equal? (session-switch-payload-operation p) 'resume))
+
+;; ============================================================
+;; Tool call payloads
+;; ============================================================
+
+(test-case "tool-call-event-payload"
+  (define p (tool-call-event-payload "s1" "t1" "read" "call-1"))
+  (check-equal? (tool-call-event-payload-session-id p) "s1")
+  (check-equal? (tool-call-event-payload-turn-id p) "t1")
+  (check-equal? (tool-call-event-payload-tool-name p) "read")
+  (check-equal? (tool-call-event-payload-tool-call-id p) "call-1"))
+
+;; ============================================================
+;; GSD mode change payloads
+;; ============================================================
+
+(test-case "gsd-mode-payload"
+  (define p (gsd-mode-payload 'idle 'planning))
+  (check-equal? (gsd-mode-payload-old-mode p) 'idle)
+  (check-equal? (gsd-mode-payload-new-mode p) 'planning))
+
+;; ============================================================
+;; Generic helpers
+;; ============================================================
+
+(test-case "payload->hash converts struct to hasheq"
+  (define p (session-start-payload "s1" '#hasheq() 'new))
+  (define h (payload->hash p))
+  (check-equal? (hash-ref h 'session-id) "s1")
+  (check-equal? (hash-ref h 'reason) 'new))
+
+(test-case "payload->hash passes through existing hash"
+  (define h (hasheq 'foo "bar"))
+  (check-equal? (payload->hash h) h))
+
+(test-case "payload-session-id extracts from struct"
+  (check-equal? (payload-session-id (session-end-payload "s3" 10)) "s3")
+  (check-equal? (payload-session-id (session-start-payload "s4" #f 'resume)) "s4"))
+
+(test-case "payload-session-id extracts from hash"
+  (check-equal? (payload-session-id (hasheq 'session-id "h1")) "h1")
+  (check-false (payload-session-id (hasheq 'other "x"))))
+
+(test-case "payload-session-id returns #f for unknown types"
+  (check-false (payload-session-id "not a payload")))
+
+(test-case "tool-call-event-payload -> hash roundtrip"
+  (define p (tool-call-event-payload "s1" "t1" "write" "c1"))
+  (define h (payload->hash p))
+  (check-equal? (hash-ref h 'tool-name) "write")
+  (check-equal? (hash-ref h 'tool-call-id) "c1"))
+
+(test-case "gsd-mode-payload -> hash roundtrip"
+  (define p (gsd-mode-payload 'planning 'executing))
+  (define h (payload->hash p))
+  (check-equal? (hash-ref h 'old-mode) 'planning)
+  (check-equal? (hash-ref h 'new-mode) 'executing))

--- a/util/event-payloads.rkt
+++ b/util/event-payloads.rkt
@@ -1,0 +1,87 @@
+#lang racket/base
+
+;; util/event-payloads.rkt — Explicit struct types for event payloads
+;;
+;; Replaces ad-hoc hasheq payloads on critical event paths with typed
+;; structs. Existing hasheq payloads continue to work — these are
+;; optional wrappers that provide type safety and better error messages.
+;;
+;; Usage:
+;;   (emit-event bus "session.start" (session-start-payload sid config 'new))
+;;   (emit-event bus "tool.call" (tool-call-event-payload sid turn-id tool-name call-id))
+
+(provide (struct-out session-start-payload)
+         (struct-out session-end-payload)
+         (struct-out tool-call-event-payload)
+         (struct-out gsd-mode-payload)
+         (struct-out session-switch-payload)
+         payload->hash
+         payload-session-id)
+
+;; ============================================================
+;; Session lifecycle payloads
+;; ============================================================
+
+(struct session-start-payload (session-id config reason) #:transparent)
+(struct session-end-payload (session-id duration) #:transparent)
+(struct session-switch-payload (session-id operation) #:transparent)
+
+;; ============================================================
+;; Tool call payloads
+;; ============================================================
+
+(struct tool-call-event-payload (session-id turn-id tool-name tool-call-id) #:transparent)
+
+;; ============================================================
+;; GSD mode change payloads
+;; ============================================================
+
+(struct gsd-mode-payload (old-mode new-mode) #:transparent)
+
+;; ============================================================
+;; Generic helpers
+;; ============================================================
+
+;; Convert any known payload struct to a hasheq (for serialization/legacy consumers).
+(define (payload->hash p)
+  (cond
+    [(session-start-payload? p)
+     (hasheq 'session-id
+             (session-start-payload-session-id p)
+             'config
+             (session-start-payload-config p)
+             'reason
+             (session-start-payload-reason p))]
+    [(session-end-payload? p)
+     (hasheq 'session-id
+             (session-end-payload-session-id p)
+             'duration
+             (session-end-payload-duration p))]
+    [(session-switch-payload? p)
+     (hasheq 'session-id
+             (session-switch-payload-session-id p)
+             'operation
+             (session-switch-payload-operation p))]
+    [(tool-call-event-payload? p)
+     (hasheq 'session-id
+             (tool-call-event-payload-session-id p)
+             'turn-id
+             (tool-call-event-payload-turn-id p)
+             'tool-name
+             (tool-call-event-payload-tool-name p)
+             'tool-call-id
+             (tool-call-event-payload-tool-call-id p))]
+    [(gsd-mode-payload? p)
+     (hasheq 'old-mode (gsd-mode-payload-old-mode p) 'new-mode (gsd-mode-payload-new-mode p))]
+    [(hash? p) p]
+    [else (hasheq 'payload p)]))
+
+;; Extract session-id from any payload that has one.
+(define (payload-session-id p)
+  (cond
+    [(session-start-payload? p) (session-start-payload-session-id p)]
+    [(session-end-payload? p) (session-end-payload-session-id p)]
+    [(session-switch-payload? p) (session-switch-payload-session-id p)]
+    [(tool-call-event-payload? p) (tool-call-event-payload-session-id p)]
+    [(hash? p) (hash-ref p 'session-id #f)]
+    [else #f]))


### PR DESCRIPTION
Addresses #2284.

feat: provider generics + event payload structs (#2284)\n\nW4 of v0.22.4.\n\nRKT-02: Replaced symbol-dispatch provider with racket/generic:\n- Added define-generics gen:provider with 5 methods\n- Created proc-provider struct implementing gen:provider\n- make-provider creates proc-provider (backward compatible)\n- All 7 provider tests + 4 adapter tests pass (473 total)\n- provider? predicate unchanged\n\nRKT-03: Created util/event-payloads.rkt with typed structs:\n- session-start-payload, session-end-payload, session-switch-payload\n- tool-call-event-payload\n- gsd-mode-payload\n- payload->hash and payload-session-id generic helpers\n- 12 new tests in test-event-payloads.rkt\n\nAll critical tests pass: 636/636 (0 failures).\n\nFixes #2284. Closes #2285. Closes #2286."