### PR TITLE
chore: bump version to 0.22.4 (#2287)\n\nW5 (final) of v0.22.4.\n\nVersion bump 0.22.3 → 0.22.4.\nSynced info.rkt, README.md, and 14 doc files.\nUpdated CHANGELOG with all W0-W4 changes.\n\nFixes #2287."

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## v0.22.4 — 2026-04-28
+
+### Architecture Modularity & Racket Idiom Remediation
+- **MOD-01**: Extracted `runtime/turn-orchestrator.rkt` (250 lines) from `runtime/iteration.rkt` (801→601 lines), eliminated upward imports
+- **MOD-03**: Created `interfaces/sdk-public.rkt` with curated SDK exports + `contract-out` on 20+ public functions
+- **MOD-04**: Declarative tool registry: `tools/registry-table.rkt` with 14-tool spec table + `register-tools-from-specs!`
+- **MOD-05**: Architecture fitness tests in `tests/test-arch-fitness.rkt` (module coupling, size, API surface checks)
+- **RKT-02**: Replaced symbol-dispatch provider with `racket/generic` (`define-generics gen:provider`)
+- **RKT-03**: Explicit struct payloads for event types (`util/event-payloads.rkt`)
+- **RKT-04**: Contract enforcement at SDK boundary via `sdk-public.rkt`
+- **RKT-05**: Schema macro: `tools/schema-macro.rkt` with `define-tool-schema` + `tool-schema` + `build-properties-hash`
+- **FIX-01**: Fixed SDK GSD live test — save/restore `gsd-event-bus` and `pinned-planning-dir` around `reset-all-gsd-state!`
+- Simplified `tools/registry-defaults.rkt` from 374→15 lines (delegates to registry-table)
+- Added 37 new tests across 4 test files
+
 ## v0.22.3 — 2026-04-28
 
 ### CI Pipeline Hardening

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.22.3-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.22.4-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 
@@ -199,7 +199,7 @@ racket main.rkt --model gpt-5.4 "write a test"
 ### Verify
 
 ```bash
-racket main.rkt --version  # q version 0.22.3
+racket main.rkt --version  # q version 0.22.4
 raco test tests/           # run the full test suite
 ```
 
@@ -259,7 +259,7 @@ q/
 ├── runtime/        Agent session, compaction, resource loading, auth
 ├── sandbox/        Subprocess management, execution limits
 ├── skills/         Skill loading, context files, prompt templates
-├── tests/          Full test suite (430 files)
+├── tests/          Full test suite (433 files)
 ├── tools/          Tool registry, scheduler, 13 built-in tools
 ├── tui/            Terminal UI: rendering, input, state, clipboard
 ├── util/           JSONL, ANSI, markdown, IDs, cancellation, paths
@@ -270,10 +270,10 @@ q/
 
 | Metric | Value |
 |--------|-------|
-| Test files | 430 |
-| Source modules | 302 |
-| Source lines | 56804 |
-| Test lines | 86072 |
+| Test files | 433 |
+| Source modules | 307 |
+| Source lines | 57204 |
+| Test lines | 86228 |
 | Test assertions | 13210 |
 | Tests passing | 5835+ | `racket scripts/run-tests.rkt` results |
 
@@ -333,7 +333,7 @@ When q executes shell commands on behalf of an LLM, arguments are quoted via `sh
 
 ## Status
 
-**v0.22.3** — Execution Architecture Improvements. `delete-lines` tool, `/wave-done` command, planning path resolution hardening, backup timestamp fix. 4 issues across 4 waves.
+**v0.22.4** — Execution Architecture Improvements. `delete-lines` tool, `/wave-done` command, planning path resolution hardening, backup timestamp fix. 4 issues across 4 waves.
 
 **v0.22.2** — GSD Plan Archival + Execution Polish. `/done` command, PLAN.md status auto-update, STATE.md auto-creation, TUI archive notification, iteration label fix, edit chunking guidance. 10 issues across 4 waves.
 

--- a/docs/adr/0011-gsd-state-machine-rewrite.md
+++ b/docs/adr/0011-gsd-state-machine-rewrite.md
@@ -1,6 +1,6 @@
 # ADR-0011: GSD State Machine Rewrite
 
-Date: 2025-01 (v0.22.3)
+Date: 2025-01 (v0.22.4)
 ## Status
 Accepted
 

--- a/docs/adr/0012-context-manager-strategy.md
+++ b/docs/adr/0012-context-manager-strategy.md
@@ -1,6 +1,6 @@
 # ADR-0012: Context Manager Strategy Engine
 
-Date: 2024-11 (v0.22.3)
+Date: 2024-11 (v0.22.4)
 ## Status
 Accepted
 

--- a/docs/event-taxonomy.md
+++ b/docs/event-taxonomy.md
@@ -1,6 +1,6 @@
 # Q Event Taxonomy Reference
 
-Complete reference for all event types in Q 0.22.3.
+Complete reference for all event types in Q 0.22.4.
 ## Base Types
 
 ### `event` (protocol-level)

--- a/docs/extension-guide.md
+++ b/docs/extension-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.22.3 --># Extension Development Guide
+<!-- verified-against: 0.22.4 --># Extension Development Guide
 
 This guide walks you through creating, testing, and activating a custom
 extension for q.

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.22.3 --># Getting Started
+<!-- verified-against: 0.22.4 --># Getting Started
 
 Welcome to q, a Racket-based coding agent.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.22.3 --># Installation Guide
+<!-- verified-against: 0.22.4 --># Installation Guide
 
 <!-- This file is the canonical source. The docs/getting-started/installation.md copy is maintained for the doc site build. -->
 

--- a/docs/sdk-guide.md
+++ b/docs/sdk-guide.md
@@ -206,7 +206,7 @@ The SDK provides convenience functions for GSD (Goal-driven Structured Developme
 
 ### Extension Pre-Registration
 
-As of v0.22.3, `open-session` automatically registers extension tools (like `planning-read` and `planning-write`) before the first `run-prompt!` call. This means:
+As of v0.22.4, `open-session` automatically registers extension tools (like `planning-read` and `planning-write`) before the first `run-prompt!` call. This means:
 - Extension tools appear in `list-tools` immediately after `open-session`
 - GSD event bus is initialized and ready to emit events
 - No need to call `run-prompt!` once just to trigger tool registration

--- a/docs/security-trust-model.md
+++ b/docs/security-trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.22.3 --># Security & Trust Model
+<!-- verified-against: 0.22.4 --># Security & Trust Model
 
 This document provides an honest, per-area assessment of what q enforces
 today and what is planned. It is the authoritative reference for security

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.22.3 --># Security Considerations
+<!-- verified-against: 0.22.4 --># Security Considerations
 
 ## API Key Storage
 

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -130,6 +130,6 @@ is the primary self-hosting extension:
 (load-extension! ext-reg "path/to/extension.rkt" #:event-bus bus)
 ```
 
-## Version 0.22.3
+## Version 0.22.4
 
-This documentation reflects q 0.22.3.
+This documentation reflects q 0.22.4.

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.22.3 --># q Source Style Guide
+<!-- verified-against: 0.22.4 --># q Source Style Guide
 
 This document defines formatting and naming conventions for the q Racket codebase.
 All changes to `q/` source files (excluding `tests/`) should follow these rules.

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.22.3 --># Trust Model
+<!-- verified-against: 0.22.4 --># Trust Model
 
 ## Trust Levels
 

--- a/docs/workflow-testing.md
+++ b/docs/workflow-testing.md
@@ -121,6 +121,6 @@ Use relative paths from the test file:
 4. Use `(check-true ...)` for boolean assertions
 5. Keep tests independent — no shared mutable state between test-cases
 
-## Version 0.22.3
+## Version 0.22.4
 
-This documentation reflects q 0.22.3.
+This documentation reflects q 0.22.4.

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.22.3")
+(define version "0.22.4")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base"))

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -7,4 +7,4 @@
 
 (provide q-version)
 
-(define q-version "0.22.3")
+(define q-version "0.22.4")

--- a/wiki-src/Architecture-Overview.md
+++ b/wiki-src/Architecture-Overview.md
@@ -35,7 +35,7 @@ User input → Interface (CLI/TUI/RPC)
     → Events emitted to bus
 ```
 
-## Metrics (0.22.3)
+## Metrics (0.22.4)
 > _See `racket scripts/metrics.rkt` for current numbers._
 
 - 228 source modules, 349 test files


### PR DESCRIPTION
Addresses #2287.

chore: bump version to 0.22.4 (#2287)\n\nW5 (final) of v0.22.4.\n\nVersion bump 0.22.3 → 0.22.4.\nSynced info.rkt, README.md, and 14 doc files.\nUpdated CHANGELOG with all W0-W4 changes.\n\nFixes #2287."