### PR TITLE
fix: architecture tests + trace regression (#2294)\n\nW0 of v0.22.5.\n\nFIT-01: Replaced broken line-based extract-requires parser with\nread-based S-expression parser in both arch test files.\n\nFIT-02: Aligned module size threshold to 900 lines with known-large\ntracking for tui/state.rkt and extensions/racket-tooling.rkt.\n\nFIT-03: Updated stale known-exceptions (iteration.rkt → turn-orchestrator.rkt).\n\nGEN-01: Fixed trace regression — replaced object-name with provider-name\nin agent/loop.rkt (4 call sites). Fixes test-trace-events.rkt failure.\n\nVER-01: Version sync verified (already in sync).\n\nAll tests pass: arch-fitness 6/6, arch-boundaries 2/2, trace 8/8.\n\nFixes #2294. Closes #2295, #2296, #2297, #2298, #2299."

### DIFF
--- a/agent/loop.rkt
+++ b/agent/loop.rkt
@@ -548,7 +548,7 @@
   (when hook-dispatcher
     (define post-payload
       (hasheq 'model-name
-              (object-name provider)
+              (provider-name provider)
               'response-content
               accumulated-text
               'usage
@@ -752,7 +752,7 @@
     (and hook-dispatcher
          (hook-dispatcher 'model-request-pre
                           (hasheq 'model-name
-                                  (object-name provider)
+                                  (provider-name provider)
                                   'message-count
                                   (length raw-messages)
                                   'messages
@@ -795,7 +795,7 @@
                     'model
                     (hash-ref (model-request-settings req)
                               'model
-                              (lambda () (format "~a" (object-name provider))))
+                              (lambda () (format "~a" (provider-name provider))))
                     'max_tokens
                     (hash-ref (model-request-settings req) 'max-tokens #f)
                     'settings
@@ -811,7 +811,7 @@
                                      'turn-id
                                      turn-id
                                      'model-name
-                                     (object-name provider)
+                                     (provider-name provider)
                                      'message-count
                                      (length raw-messages)))))
 

--- a/tests/test-arch-boundaries.rkt
+++ b/tests/test-arch-boundaries.rkt
@@ -3,8 +3,8 @@
 ;; tests/test-arch-boundaries.rkt — Architecture layer boundary tests
 ;;
 ;; Verifies that layering constraints are maintained:
-;;   - Only runtime/iteration.rkt may import from tools/ or extensions/
-;;   - TUI modules must not import from llm/, tools/, runtime/, agent/
+;;   - Only known exceptions in runtime/ may import from tools/ or extensions/
+;;   - TUI modules must not import from llm/, tools/
 ;;
 ;; Refs: #432, ARCH-01
 
@@ -14,26 +14,43 @@
          racket/string)
 
 ;; ============================================================
-;; Helpers
+;; Helpers (read-based S-expression parser)
 ;; ============================================================
 
-;; Extract all require paths from a source file
+;; Extract all require-spec sub-forms from a source file.
 (define (extract-requires filepath)
   (with-handlers ([exn:fail? (lambda (e) '())])
     (define src (file->string filepath))
-    (define requires '())
-    (define in-require? #f)
-    (for ([line (in-list (string-split src "\n"))])
-      (define trimmed (string-trim line))
-      (cond
-        [(and (>= (string-length trimmed) 7) (string=? (substring trimmed 0 7) "(require"))
-         (set! in-require? #t)]
-        [(string-contains? trimmed "(require ") (set! in-require? #t)])
-      (when in-require?
-        (set! requires (cons trimmed requires))
-        (when (string-contains? trimmed ")")
-          (set! in-require? #f))))
-    requires))
+    (define lines (string-split src "\n"))
+    (define rest
+      (string-join (if (string-prefix? (car lines) "#lang")
+                       (cdr lines)
+                       lines)
+                   "\n"))
+    (define forms (port->list read (open-input-string rest)))
+    (append* (for/list ([form forms])
+               (cond
+                 [(and (pair? form) (eq? (car form) 'require)) (cdr form)]
+                 [else '()])))))
+
+(define (require-spec->paths spec)
+  (cond
+    [(string? spec) (list spec)]
+    [(symbol? spec) '()]
+    [(pair? spec)
+     (case (car spec)
+       [(only-in prefix-in rename-in except-in)
+        (if (and (pair? (cdr spec)) (string? (cadr spec)))
+            (list (cadr spec))
+            '())]
+       [else (append* (map require-spec->paths (cdr spec)))])]
+    [else '()]))
+
+(define (imports-from? req-specs layer-prefixes)
+  (for*/or ([spec (in-list req-specs)]
+            [path (in-list (require-spec->paths spec))])
+    (for/or ([prefix (in-list layer-prefixes)])
+      (string-contains? path prefix))))
 
 (define q-dir (string->path (or (getenv "Q_DIR") ".")))
 
@@ -43,11 +60,6 @@
               (directory-list (build-path q-dir dir) #:build? #t))
       '()))
 
-;; Check if a require line imports from a forbidden layer
-(define (imports-from? require-line layer-prefixes)
-  (for/or ([prefix (in-list layer-prefixes)])
-    (string-contains? require-line prefix)))
-
 ;; ============================================================
 ;; Boundary tests
 ;; ============================================================
@@ -55,52 +67,33 @@
 (define boundary-tests
   (test-suite "architecture-boundaries"
 
-    (test-case "Only iteration.rkt in runtime/ imports from tools/ or extensions/"
+    (test-case "Only known exceptions in runtime/ import from tools/ or extensions/"
       ;; Known exceptions:
-      ;;   - runtime/package.rkt imports extensions/manifest.rkt for package audit
+      ;;   - runtime/turn-orchestrator.rkt — imports from tools/ for tool execution
+      ;;   - runtime/package.rkt — imports extensions/manifest.rkt for package audit
+      ;;   - runtime/extension-catalog.rkt — imports from extensions/
       (define runtime-files (rkt-files-in "runtime"))
-      (define known-exceptions '("iteration.rkt" "package.rkt" "extension-catalog.rkt"))
+      (define known-exceptions '("turn-orchestrator.rkt" "package.rkt" "extension-catalog.rkt"))
       (define violations
         (for/list ([f (in-list runtime-files)]
                    #:when (not (member (path->string (file-name-from-path f)) known-exceptions)))
-          (define requires (extract-requires f))
-          (define bad-imports
-            (filter (λ (r)
-                      (or (imports-from? r '("\"../tools/" "\"../../tools/"))
-                          (imports-from? r '("\"../extensions/" "\"../../extensions/"))))
-                    requires))
-          (if (null? bad-imports)
-              #f
-              (format "~a: ~a" (file-name-from-path f) bad-imports))))
+          (define reqs (extract-requires f))
+          (if (imports-from? reqs '("../tools/" "../../tools/" "../extensions/" "../../extensions/"))
+              (format "~a: upward imports detected" (file-name-from-path f))
+              #f)))
       (define actual-violations (filter identity violations))
       (check-equal? actual-violations
                     '()
                     (format "Unexpected upward imports in runtime/: ~a" actual-violations)))
 
     (test-case "TUI modules must not import from llm/, tools/"
-      ;; TUI modules importing from runtime/ and agent/ are documented
-      ;; exceptions — the TUI layer sits above runtime and consumes
-      ;; events directly. The hard constraint is: TUI must not import
-      ;; from llm/ or tools/ layers.
-      ;; v0.14.1: tui-init.rkt exception removed — now uses runtime/provider-factory.rkt
-      ;; instead of llm/provider.rkt for mock detection.
       (define tui-files (rkt-files-in "tui"))
-      (define known-tui-exceptions '())
-      (define tui-files-checked
-        (filter (lambda (f)
-                  (not (member (path->string (file-name-from-path f)) known-tui-exceptions)))
-                tui-files))
       (define violations
-        (for/list ([f (in-list tui-files-checked)])
-          (define requires (extract-requires f))
-          (define bad-imports
-            (filter (λ (r)
-                      (or (imports-from? r '("\"../llm/" "\"../../llm/"))
-                          (imports-from? r '("\"../tools/" "\"../../tools/"))))
-                    requires))
-          (if (null? bad-imports)
-              #f
-              (format "~a: ~a" (file-name-from-path f) bad-imports))))
+        (for/list ([f (in-list tui-files)])
+          (define reqs (extract-requires f))
+          (if (imports-from? reqs '("../llm/" "../../llm/" "../tools/" "../../tools/"))
+              (format "~a: imports from forbidden layer" (file-name-from-path f))
+              #f)))
       (define actual-violations (filter identity violations))
       (check-equal? actual-violations
                     '()

--- a/tests/test-arch-fitness.rkt
+++ b/tests/test-arch-fitness.rkt
@@ -3,12 +3,12 @@
 ;; tests/test-arch-fitness.rkt — Architecture fitness tests
 ;;
 ;; Verifies quantitative architecture health:
-;;   1. No module exceeds 900 lines
+;;   1. No module exceeds 900 lines (with known-large tracked items)
 ;;   2. Known runtime layer exceptions are stable
 ;;   3. main.rkt re-export breadth is reasonable (< 200 symbols)
 ;;   4. tui/ does not import from llm/ or tools/
 ;;   5. extensions/ does not import from tui/
-;;   6. llm/ does not import from runtime/, tools/, or extensions/
+;;   6. llm/ does not import from runtime/, tools/, extensions/
 ;;
 ;; Refs: ARCH-FITNESS
 
@@ -18,32 +18,64 @@
          racket/string)
 
 ;; ============================================================
-;; Helpers
+;; Helpers (read-based S-expression parser)
 ;; ============================================================
 
+;; Extract all require-spec sub-forms from a source file.
+;; Returns a list of require-spec items (strings, symbols, or lists like
+;; (only-in "../tools/tool.rkt" ...)).
+;; Uses Racket's `read` for robust multi-line require parsing.
 (define (extract-requires filepath)
   (with-handlers ([exn:fail? (lambda (e) '())])
     (define src (file->string filepath))
-    (define requires '())
-    (define in-require? #f)
-    (for ([line (in-list (string-split src "\n"))])
-      (define trimmed (string-trim line))
-      (cond
-        [(and (>= (string-length trimmed) 7) (string=? (substring trimmed 0 7) "(require"))
-         (set! in-require? #t)]
-        [(string-contains? trimmed "(require ") (set! in-require? #t)])
-      (when in-require?
-        (set! requires (cons trimmed requires))
-        (when (string-contains? trimmed ")")
-          (set! in-require? #f))))
-    requires))
+    ;; Skip #lang line, then read top-level forms
+    (define lines (string-split src "\n"))
+    (define rest
+      (string-join (if (string-prefix? (car lines) "#lang")
+                       (cdr lines)
+                       lines)
+                   "\n"))
+    (define forms (port->list read (open-input-string rest)))
+    (append* (for/list ([form forms])
+               (cond
+                 [(and (pair? form) (eq? (car form) 'require))
+                  ;; Single require form — could be one spec or sub-forms
+                  (if (and (pair? (cdr form)) (pair? (cadr form)))
+                      ;; (require x y z) — multiple specs in parens
+                      (cdr form)
+                      ;; (require x) — single spec
+                      (cdr form))]
+                 ;; Skip submodule forms
+                 [(and (pair? form) (eq? (car form) 'module+)) '()]
+                 [else '()])))))
 
-;; When run via raco test from q/, Q_DIR is '.'; when run from project root,
-;; Q_DIR should be 'q/'. Default to the parent of the tests/ directory.
+;; Extract all string paths from a require-spec.
+;; Handles: strings, (only-in "path" ...), (prefix-in "pref" "path"), etc.
+(define (require-spec->paths spec)
+  (cond
+    [(string? spec) (list spec)]
+    [(symbol? spec) '()] ; e.g. racket/contract
+    [(pair? spec)
+     (case (car spec)
+       [(only-in prefix-in rename-in except-in)
+        ;; Second argument is usually the path
+        (if (and (pair? (cdr spec)) (string? (cadr spec)))
+            (list (cadr spec))
+            '())]
+       [else (append* (map require-spec->paths (cdr spec)))])]
+    [else '()]))
+
+;; Check if any require spec imports from any of the given layer prefixes.
+;; Works on structured require specs (not raw lines).
+(define (imports-from? req-specs layer-prefixes)
+  (for*/or ([spec (in-list req-specs)]
+            [path (in-list (require-spec->paths spec))])
+    (for/or ([prefix (in-list layer-prefixes)])
+      (string-contains? path prefix))))
+
 (define q-dir
   (simplify-path
    (string->path (or (getenv "Q_DIR")
-                     ;; If running from q/tests/ (typical raco test), go up to q/
                      (if (and (directory-exists? "..") (file-exists? "../main.rkt")) ".." ".")))))
 
 (define (rkt-files-in dir)
@@ -52,21 +84,13 @@
               (directory-list (build-path q-dir dir) #:build? #t))
       '()))
 
-(define (imports-from? require-line layer-prefixes)
-  (for/or ([prefix (in-list layer-prefixes)])
-    (string-contains? require-line prefix)))
-
-;; Count lines in a file, returns 0 on error
 (define (line-count filepath)
   (with-handlers ([exn:fail? (lambda (e) 0)])
     (length (string-split (file->string filepath) "\n"))))
 
-;; Count occurrences of a character in a string
 (define (char-count str ch)
   (for/sum ([c (in-string str)]) (if (char=? c ch) 1 0)))
 
-;; Count provided symbols from main.rkt
-;; Strategy: find the (provide ...) form, count identifiers
 (define (count-provides filepath)
   (with-handlers ([exn:fail? (lambda (e) 0)])
     (define src (file->string filepath))
@@ -76,16 +100,13 @@
     (for ([line (in-list (string-split src "\n"))])
       (define trimmed (string-trim line))
       (when (and (not (string-prefix? trimmed ";;")) (> (string-length trimmed) 0))
-        ;; Track provide nesting
         (cond
           [(and (not in-provide?) (regexp-match? #rx"^\\(provide" trimmed))
            (set! in-provide? #t)
            (set! depth (char-count trimmed #\())]
           [in-provide? (set! depth (+ depth (char-count trimmed #\() (- (char-count trimmed #\)))))])
         (when in-provide?
-          ;; Count all-from-out as one re-export each
           (set! count (+ count (length (regexp-match* #rx"all-from-out" trimmed))))
-          ;; Count individual identifiers
           (for ([tok (in-list (regexp-match* #rx"[a-zA-Z_][a-zA-Z0-9_-]*!?" trimmed))])
             (unless (member tok
                             '("provide" "all"
@@ -100,7 +121,6 @@
                                         "except"
                                         "define"))
               (set! count (+ count 1)))))
-        ;; Close provide when depth returns to 0
         (when (and in-provide? (<= depth 0))
           (set! in-provide? #f))))
     count))
@@ -114,47 +134,50 @@
 
     ;; ── Test 1: Module line count ──────────────────────────────
     (test-case "No module exceeds 900 lines"
-      (define max-lines 1200)
+      (define max-lines 900)
+      ;; Known-large modules tracked for future splitting (v0.23.0 target):
+      ;;   tui/state.rkt (~994 lines), extensions/racket-tooling.rkt (~922 lines)
+      (define known-large '(("tui/state.rkt" . 1000) ("extensions/racket-tooling.rkt" . 950)))
       (define dirs-to-check '("runtime" "agent" "llm" "tools" "tui" "interfaces"))
       (define all-files
         (append* (for/list ([d (in-list dirs-to-check)])
                    (rkt-files-in d))))
       (define oversized
         (for/list ([f (in-list all-files)]
-                   #:when (> (line-count f) max-lines))
+                   #:when (let ([lc (line-count f)])
+                            (and (> lc max-lines)
+                                 ;; Not in known-large list
+                                 (not (assoc (path->string (find-relative-path (simplify-path q-dir)
+                                                                               (simplify-path f)))
+                                             known-large)))))
           (cons (path->string (find-relative-path (simplify-path q-dir) (simplify-path f)))
                 (line-count f))))
       (check-equal? oversized
                     '()
-                    (format "Files exceeding ~a lines: ~a"
+                    (format "Files exceeding ~a lines (excluding known-large): ~a"
                             max-lines
                             (for/list ([p oversized])
                               (format "~a (~a lines)" (car p) (cdr p))))))
 
     ;; ── Test 2: Known runtime exceptions are stable ────────────
     (test-case "Known runtime layer exceptions are stable"
-      ;; These files are known to import from tools/ or extensions/
-      ;; v0.22.4 (MOD-01): iteration.rkt upward imports moved to turn-orchestrator.rkt
+      ;; v0.22.4 (MOD-01): iteration.rkt -> turn-orchestrator.rkt
       (define known-exceptions '("turn-orchestrator.rkt" "package.rkt" "extension-catalog.rkt"))
       (for ([name (in-list known-exceptions)])
         (define fpath (build-path q-dir "runtime" name))
         (check-true (file-exists? fpath) (format "Known exception runtime/~a no longer exists" name)))
-      ;; Verify that the known-exceptions set is still the right size:
-      ;; Count how many of these actually still import from tools/ or extensions/
       (define still-importing
         (for/list ([name (in-list known-exceptions)]
                    #:when (let* ([fpath (build-path q-dir "runtime" name)]
                                  [reqs (extract-requires fpath)])
-                            (for/or ([r (in-list reqs)])
-                              (or (imports-from? r '("\"../tools/" "\"../../tools/"))
-                                  (imports-from? r '("\"../extensions/" "\"../../extensions/"))))))
+                            (imports-from?
+                             reqs
+                             '("../tools/" "../../tools/" "../extensions/" "../../extensions/"))))
           name))
-      ;; At least 2 of the 3 known exceptions should still be importing
       (check-true
        (>= (length still-importing) 2)
        (format "Too few known exceptions still importing from tools/extensions: ~a (expected >= 2)"
                still-importing))
-      ;; No more than 3
       (check-true (<= (length still-importing) 3)
                   (format "More than 3 runtime files importing from tools/extensions: ~a"
                           still-importing)))
@@ -171,17 +194,11 @@
       (define tui-files (rkt-files-in "tui"))
       (define violations
         (for/list ([f (in-list tui-files)])
-          (define requires (extract-requires f))
-          (define bad-imports
-            (filter (λ (r)
-                      (or (imports-from? r '("\"../llm/" "\"../../llm/"))
-                          (imports-from? r '("\"../tools/" "\"../../tools/"))))
-                    requires))
-          (if (null? bad-imports)
-              #f
-              (format "~a: ~a"
-                      (path->string (find-relative-path (simplify-path q-dir) (simplify-path f)))
-                      bad-imports))))
+          (define reqs (extract-requires f))
+          (if (imports-from? reqs '("../llm/" "../../llm/" "../tools/" "../../tools/"))
+              (format "~a imports from llm/ or tools/"
+                      (path->string (find-relative-path (simplify-path q-dir) (simplify-path f))))
+              #f)))
       (define actual-violations (filter identity violations))
       (check-equal? actual-violations
                     '()
@@ -190,23 +207,17 @@
     ;; ── Test 5: extensions/ does not import from tui/ ──────────
     (test-case "extensions/ does not import from tui/"
       ;; Known exceptions: dialog-api.rkt and ui-surface.rkt import from tui/state.rkt
-      ;; for UI state types. These are intentional — extensions providing TUI features
-      ;; need TUI types. The rule is that generic extensions (gsd/, hooks, etc.) must
-      ;; not depend on TUI.
       (define known-exceptions '("dialog-api.rkt" "ui-surface.rkt"))
       (define ext-files
         (filter (lambda (f) (not (member (path->string (file-name-from-path f)) known-exceptions)))
                 (rkt-files-in "extensions")))
       (define violations
         (for/list ([f (in-list ext-files)])
-          (define requires (extract-requires f))
-          (define bad-imports
-            (filter (λ (r) (imports-from? r '("\"../tui/" "\"../../tui/"))) requires))
-          (if (null? bad-imports)
-              #f
-              (format "~a: ~a"
-                      (path->string (find-relative-path (simplify-path q-dir) (simplify-path f)))
-                      bad-imports))))
+          (define reqs (extract-requires f))
+          (if (imports-from? reqs '("../tui/" "../../tui/"))
+              (format "~a imports from tui/"
+                      (path->string (find-relative-path (simplify-path q-dir) (simplify-path f))))
+              #f)))
       (define actual-violations (filter identity violations))
       (check-equal? actual-violations
                     '()
@@ -216,20 +227,18 @@
     (test-case "llm/ does not import from runtime/, tools/, or extensions/"
       (define llm-files (rkt-files-in "llm"))
       (define forbidden-prefixes
-        '("\"../runtime/" "\"../../runtime/"
-                          "\"../tools/"
-                          "\"../../tools/"
-                          "\"../extensions/"
-                          "\"../../extensions/"))
+        '("../runtime/" "../../runtime/"
+                        "../tools/"
+                        "../../tools/"
+                        "../extensions/"
+                        "../../extensions/"))
       (define violations
         (for/list ([f (in-list llm-files)])
-          (define requires (extract-requires f))
-          (define bad-imports (filter (λ (r) (imports-from? r forbidden-prefixes)) requires))
-          (if (null? bad-imports)
-              #f
-              (format "~a: ~a"
-                      (path->string (find-relative-path (simplify-path q-dir) (simplify-path f)))
-                      bad-imports))))
+          (define reqs (extract-requires f))
+          (if (imports-from? reqs forbidden-prefixes)
+              (format "~a imports from higher layers"
+                      (path->string (find-relative-path (simplify-path q-dir) (simplify-path f))))
+              #f)))
       (define actual-violations (filter identity violations))
       (check-equal? actual-violations
                     '()

--- a/tests/test-trace-events.rkt
+++ b/tests/test-trace-events.rkt
@@ -141,9 +141,8 @@
   (check >= (length evts) 1)
   (define payload (event-payload (car evts)))
   (check-equal? (hash-ref payload 'max_tokens #f) 16384)
-  ;; v0.15.1: model field now uses (format "~a" (object-name provider))
-  ;; which produces a string, not a symbol, for safe JSON serialization
-  (check-equal? (hash-ref payload 'model #f) "provider"))
+  ;; v0.22.5: model field uses (provider-name provider) as fallback
+  (check-equal? (hash-ref payload 'model #f) "test-model"))
 
 (test-case "model.request.start without provider-settings has #f max_tokens"
   (define bus (make-event-bus))


### PR DESCRIPTION
Addresses #2294.

fix: architecture tests + trace regression (#2294)\n\nW0 of v0.22.5.\n\nFIT-01: Replaced broken line-based extract-requires parser with\nread-based S-expression parser in both arch test files.\n\nFIT-02: Aligned module size threshold to 900 lines with known-large\ntracking for tui/state.rkt and extensions/racket-tooling.rkt.\n\nFIT-03: Updated stale known-exceptions (iteration.rkt → turn-orchestrator.rkt).\n\nGEN-01: Fixed trace regression — replaced object-name with provider-name\nin agent/loop.rkt (4 call sites). Fixes test-trace-events.rkt failure.\n\nVER-01: Version sync verified (already in sync).\n\nAll tests pass: arch-fitness 6/6, arch-boundaries 2/2, trace 8/8.\n\nFixes #2294. Closes #2295, #2296, #2297, #2298, #2299."