### PR TITLE
feat: event payload adoption + contract test expansion (#2304)

W2 of v0.22.5.

GEN-02: Replaced 4 raw hasheq payloads in runtime/agent-session.rkt
with typed struct constructors from util/event-payloads.rkt:
- session-start-payload (new + resume paths)
- session-switch-payload (resume path)
- session-end-payload (shutdown path)

SDK-02: Added 8 negative contract-rejection tests to test-contracts.rkt
covering open-session, interrupt!, fork-session!, steer!,
dispatch-command!, subscribe-events!, session:set-thinking-level!,
and get-context-usage.

Fixes #2304. Closes #2305, #2306.

### DIFF
--- a/runtime/agent-session.rkt
+++ b/runtime/agent-session.rkt
@@ -43,6 +43,10 @@
          "../runtime/session-index.rkt"
          "../runtime/compactor.rkt"
          (only-in "../extensions/api.rkt" extension-name list-extensions)
+         (only-in "../util/event-payloads.rkt"
+                  session-start-payload
+                  session-end-payload
+                  session-switch-payload)
          (only-in "../runtime/context-builder.rkt"
                   (build-session-context context-builder:build-session-context))
          (only-in "../runtime/session-context.rkt" extract-path-settings)
@@ -221,11 +225,10 @@
   (ensure-persisted! sess)
 
   ;; Dispatch 'session-start hook (R2-7: payload with session-id, config, and reason)
-  (define session-start-payload (hasheq 'session-id sid 'config config 'reason 'new))
-  (define-values (_session-start-payload _session-start-res)
+  (define-values (_start-payload _session-start-res)
     (maybe-dispatch-hooks (hash-ref config 'extension-registry #f)
                           'session-start
-                          session-start-payload))
+                          (session-start-payload sid config 'new)))
 
   ;; Subscribe to fork.requested and compact.requested events from TUI/CLI
   (wire-session-event-handlers! sess fork-session)
@@ -277,7 +280,7 @@
         #f))
 
   ;; Dispatch 'session-before-switch hook — extensions can block session resume
-  (define switch-payload (hasheq 'session-id session-id 'operation 'resume))
+  (define switch-payload (session-switch-payload session-id 'resume))
   (define-values (_amended-switch switch-res)
     (maybe-dispatch-hooks (hash-ref config 'extension-registry #f)
                           'session-before-switch
@@ -315,7 +318,7 @@
                        (hasheq 'sessionId session-id))
 
   ;; Dispatch 'session-start hook with reason 'resume
-  (define resume-start-payload (hasheq 'session-id session-id 'config config 'reason 'resume))
+  (define resume-start-payload (session-start-payload session-id config 'resume))
   (maybe-dispatch-hooks (hash-ref config 'extension-registry #f) 'session-start resume-start-payload)
 
   ;; Subscribe to fork/compact events from TUI/CLI
@@ -748,8 +751,7 @@
                          (hasheq 'sessionId (agent-session-session-id sess)))
     ;; Dispatch 'session-shutdown hook (R2-7: payload with session-id and duration)
     (define session-duration (- (now-seconds) (agent-session-start-time sess)))
-    (define shutdown-payload
-      (hasheq 'session-id (agent-session-session-id sess) 'duration session-duration))
+    (define shutdown-payload (session-end-payload (agent-session-session-id sess) session-duration))
     (define-values (_shutdown-payload _shutdown-res)
       (maybe-dispatch-hooks (agent-session-extension-registry sess)
                             'session-shutdown

--- a/tests/test-contracts.rkt
+++ b/tests/test-contracts.rkt
@@ -90,3 +90,31 @@
   (check-true (procedure? q:go))
   (check-true (procedure? q:gsd-status))
   (check-true (procedure? q:reset-gsd!)))
+
+;; ============================================================
+;; Negative contract-rejection tests (SDK-02)
+;; ============================================================
+
+(test-case "sdk-public: open-session rejects non-runtime"
+  (check-exn exn:fail:contract? (lambda () (open-session "not-a-runtime"))))
+
+(test-case "sdk-public: interrupt! rejects non-runtime"
+  (check-exn exn:fail:contract? (lambda () (interrupt! 42))))
+
+(test-case "sdk-public: fork-session! rejects non-runtime"
+  (check-exn exn:fail:contract? (lambda () (fork-session! 'nope))))
+
+(test-case "sdk-public: steer! rejects non-runtime"
+  (check-exn exn:fail:contract? (lambda () (steer! "not-runtime" "prompt"))))
+
+(test-case "sdk-public: dispatch-command! rejects non-runtime"
+  (check-exn exn:fail:contract? (lambda () (dispatch-command! #f "cmd" "arg"))))
+
+(test-case "sdk-public: subscribe-events! rejects non-procedure callback"
+  (check-exn exn:fail:contract? (lambda () (subscribe-events! "not-runtime" 42))))
+
+(test-case "sdk-public: session:set-thinking-level! rejects invalid level"
+  (check-exn exn:fail:contract? (lambda () (session:set-thinking-level! 'not-a-session 'invalid))))
+
+(test-case "sdk-public: get-context-usage rejects non-integer"
+  (check-exn exn:fail:contract? (lambda () (get-context-usage "not-a-number" -1))))


### PR DESCRIPTION
Addresses #2304.

feat: event payload adoption + contract test expansion (#2304)

W2 of v0.22.5.

GEN-02: Replaced 4 raw hasheq payloads in runtime/agent-session.rkt
with typed struct constructors from util/event-payloads.rkt:
- session-start-payload (new + resume paths)
- session-switch-payload (resume path)
- session-end-payload (shutdown path)

SDK-02: Added 8 negative contract-rejection tests to test-contracts.rkt
covering open-session, interrupt!, fork-session!, steer!,
dispatch-command!, subscribe-events!, session:set-thinking-level!,
and get-context-usage.

Fixes #2304. Closes #2305, #2306.