### PR TITLE
feat: SDK contract-out completion + payload adoption + header fix (#2315)

W1 of v0.22.6.

SDK-01a: Moved 5 in-memory session helpers to contract-out in sdk-public.rkt.
PAY-02: Added session-id-payload, error-payload, input-payload structs.
        Migrated 6 hasheq sites to struct constructors in agent-session.rkt.
        Updated payload->hash for new types with retry-metadata fallback.
DEF-01: Fixed iteration.rkt header comment (reflects remaining upward import).
DEF-02: Fixed sdk-gsd-integration-test to use provider-name (not object-name).

Closes #2315, #2316, #2317, #2318, #2319.

### DIFF
--- a/interfaces/sdk-public.rkt
+++ b/interfaces/sdk-public.rkt
@@ -160,6 +160,13 @@
           ;; Cancellation tokens
           [make-cancellation-token (-> any/c)]
           [cancel-token! (-> any/c any)]
+          ;; In-memory session helpers (v0.22.6: moved into contract-out)
+          [in-memory-append! (-> in-memory-session-manager? string? any/c void?)]
+          [in-memory-append-entries! (-> in-memory-session-manager? string? (listof any/c) void?)]
+          [in-memory-load (-> in-memory-session-manager? string? (listof any/c))]
+          [in-memory-list-sessions (-> in-memory-session-manager? (listof string?))]
+          [in-memory-fork!
+           (->* (in-memory-session-manager? string? string?) ((or/c #f string?)) string?)]
           ;; Context usage (v0.22.5: moved into contract-out)
           [get-context-usage
            (-> exact-nonnegative-integer? exact-nonnegative-integer? context-usage?)]
@@ -218,9 +225,4 @@
 
          ;; In-memory session manager
          make-in-memory-session-manager
-         in-memory-session-manager?
-         in-memory-append!
-         in-memory-append-entries!
-         in-memory-load
-         in-memory-list-sessions
-         in-memory-fork!)
+         in-memory-session-manager?)

--- a/runtime/agent-session.rkt
+++ b/runtime/agent-session.rkt
@@ -46,7 +46,11 @@
          (only-in "../util/event-payloads.rkt"
                   session-start-payload
                   session-end-payload
-                  session-switch-payload)
+                  session-switch-payload
+                  session-id-payload
+                  error-payload
+                  input-payload
+                  payload->hash)
          (only-in "../runtime/context-builder.rkt"
                   (build-session-context context-builder:build-session-context))
          (only-in "../runtime/session-context.rkt" extract-path-settings)
@@ -219,7 +223,7 @@
                    #f)) ; prompt-running?
 
   ;; Emit session.started
-  (emit-session-event! (agent-session-event-bus sess) sid "session.started" (hasheq 'sessionId sid))
+  (emit-session-event! (agent-session-event-bus sess) sid "session.started" (session-id-payload sid))
 
   ;; Eagerly persist session directory and version header so resume works immediately.
   (ensure-persisted! sess)
@@ -315,7 +319,7 @@
   (emit-session-event! (agent-session-event-bus sess)
                        session-id
                        "session.resumed"
-                       (hasheq 'sessionId session-id))
+                       (session-id-payload session-id))
 
   ;; Dispatch 'session-start hook with reason 'resume
   (define resume-start-payload (session-start-payload session-id config 'resume))
@@ -568,11 +572,10 @@
                                ;; Emit runtime.error event with classified error-type
                                (define error-type (classify-error e))
                                ;; A3: Include retry metadata if retries were attempted
-                               (define base-payload
-                                 (hasheq 'error (exn-message e) 'errorType error-type))
+                               (define base-payload (error-payload (exn-message e) error-type))
                                (define payload
                                  (if (retry-exhausted? e)
-                                     (hash-set* base-payload
+                                     (hash-set* (payload->hash base-payload)
                                                 'retries-attempted
                                                 (retry-exhausted-attempts e)
                                                 'total-retry-delay-ms
@@ -656,7 +659,7 @@
      ;; #666: Dispatch 'input hook — intercept/transform user input before processing
      (define ext-reg (agent-session-extension-registry sess))
      (define-values (_processed-input input-hook-res)
-       (maybe-dispatch-hooks ext-reg 'input (hasheq 'session-id sid 'message user-message)))
+       (maybe-dispatch-hooks ext-reg 'input (input-payload sid user-message)))
      (cond
        [(and input-hook-res (eq? (hook-result-action input-hook-res) 'block))
         ;; Input blocked by extension
@@ -748,7 +751,7 @@
     (emit-session-event! (agent-session-event-bus sess)
                          (agent-session-session-id sess)
                          "session.closed"
-                         (hasheq 'sessionId (agent-session-session-id sess)))
+                         (session-id-payload (agent-session-session-id sess)))
     ;; Dispatch 'session-shutdown hook (R2-7: payload with session-id and duration)
     (define session-duration (- (now-seconds) (agent-session-start-time sess)))
     (define shutdown-payload (session-end-payload (agent-session-session-id sess) session-duration))

--- a/runtime/iteration.rkt
+++ b/runtime/iteration.rkt
@@ -12,8 +12,9 @@
 ;; This module re-exports those symbols for backward compatibility.
 ;;
 ;; ── LAYER NOTE ────────────────────────────────────────────────
-;; Since v0.22.4 (MOD-01): This module NO LONGER imports upward into
-;; tools/ or extensions/. All upward imports moved to turn-orchestrator.rkt.
+;; Since v0.22.4 (MOD-01): Upward imports limited to a single constant from
+;; extensions/message-inject.rkt. All behavioral upward imports moved to
+;; turn-orchestrator.rkt. Listed as known exception in arch-boundaries tests.
 ;; ───────────────────────────────────────────────────────────────
 
 (require racket/contract

--- a/scripts/sdk-gsd-integration-test.rkt
+++ b/scripts/sdk-gsd-integration-test.rkt
@@ -15,6 +15,7 @@
          (only-in "../interfaces/sdk.rkt" make-runtime open-session)
          "../runtime/settings.rkt"
          "../runtime/provider-factory.rkt"
+         (only-in "../llm/provider.rkt" provider-name)
          racket/file
          racket/port)
 
@@ -275,7 +276,7 @@
   (define settings (load-settings))
   (printf "  Settings: OK\n")
   (define provider (build-provider (hasheq) settings))
-  (printf "  Provider: ~a\n" (object-name provider))
+  (printf "  Provider: ~a\n" (provider-name provider))
   (define sdk-dir (make-temporary-file "sdk-sess-~a" (quote directory)))
   (define rt
     (make-runtime #:provider provider

--- a/util/event-payloads.rkt
+++ b/util/event-payloads.rkt
@@ -15,6 +15,9 @@
          (struct-out tool-call-event-payload)
          (struct-out gsd-mode-payload)
          (struct-out session-switch-payload)
+         (struct-out session-id-payload)
+         (struct-out error-payload)
+         (struct-out input-payload)
          payload->hash
          payload-session-id)
 
@@ -31,6 +34,24 @@
 ;; ============================================================
 
 (struct tool-call-event-payload (session-id turn-id tool-name tool-call-id) #:transparent)
+
+;; ============================================================
+;; Simple session-id payloads
+;; ============================================================
+
+(struct session-id-payload (session-id) #:transparent)
+
+;; ============================================================
+;; Error payloads
+;; ============================================================
+
+(struct error-payload (error error-type) #:transparent)
+
+;; ============================================================
+;; Input payloads
+;; ============================================================
+
+(struct input-payload (session-id message) #:transparent)
 
 ;; ============================================================
 ;; GSD mode change payloads
@@ -71,6 +92,11 @@
              (tool-call-event-payload-tool-name p)
              'tool-call-id
              (tool-call-event-payload-tool-call-id p))]
+    [(session-id-payload? p) (hasheq 'sessionId (session-id-payload-session-id p))]
+    [(error-payload? p)
+     (hasheq 'error (error-payload-error p) 'errorType (error-payload-error-type p))]
+    [(input-payload? p)
+     (hasheq 'session-id (input-payload-session-id p) 'message (input-payload-message p))]
     [(gsd-mode-payload? p)
      (hasheq 'old-mode (gsd-mode-payload-old-mode p) 'new-mode (gsd-mode-payload-new-mode p))]
     [(hash? p) p]


### PR DESCRIPTION
Addresses #2315.

feat: SDK contract-out completion + payload adoption + header fix (#2315)

W1 of v0.22.6.

SDK-01a: Moved 5 in-memory session helpers to contract-out in sdk-public.rkt.
PAY-02: Added session-id-payload, error-payload, input-payload structs.
        Migrated 6 hasheq sites to struct constructors in agent-session.rkt.
        Updated payload->hash for new types with retry-metadata fallback.
DEF-01: Fixed iteration.rkt header comment (reflects remaining upward import).
DEF-02: Fixed sdk-gsd-integration-test to use provider-name (not object-name).

Closes #2315, #2316, #2317, #2318, #2319.