### PR TITLE
fix: Critical regression fixes for v0.22.6 post-merge issues (#2332)

W0 of v0.22.7:

REG-01: Deleted local make-success-result/make-error-result hasheq defs from
racket-tooling-handlers.rkt. Handlers now use tool-api.rkt imports that
return proper tool-result structs. 20/20 racket-tooling tests pass.

REG-02: Fixed util/version.rkt TR annotation format. Changed from multi-line
(define q-version : String "...") to single-line (: q-version String) +
(define q-version "..."). Both raco fmt and regex parsers handle this correctly.

REG-03: Wrapped loop-result-metadata with payload->hash in
test-agent-session-basic.rkt. Error-payload struct is now properly converted
to hash before hash-has-key?/hash-ref operations. 18/18 tests pass.

DOC-01: Synced README status block to v0.22.6.

Closes #2332.

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,8 +272,8 @@ q/
 |--------|-------|
 | Test files | 436 |
 | Source modules | 312 |
-| Source lines | 57265 |
-| Test lines | 86509 |
+| Source lines | 57260 |
+| Test lines | 86510 |
 | Test assertions | 13253 |
 | Tests passing | 5835+ | `racket scripts/run-tests.rkt` results |
 
@@ -333,7 +333,7 @@ When q executes shell commands on behalf of an LLM, arguments are quoted via `sh
 
 ## Status
 
-**v0.22.5** — Execution Architecture Improvements. `delete-lines` tool, `/wave-done` command, planning path resolution hardening, backup timestamp fix. 4 issues across 4 waves.
+**v0.22.6** — Execution Architecture Improvements. `delete-lines` tool, `/wave-done` command, planning path resolution hardening, backup timestamp fix. 4 issues across 4 waves.
 
 **v0.22.5** — GSD Plan Archival + Execution Polish. `/done` command, PLAN.md status auto-update, STATE.md auto-creation, TUI archive notification, iteration label fix, edit chunking guidance. 10 issues across 4 waves.
 

--- a/extensions/racket-tooling-handlers.rkt
+++ b/extensions/racket-tooling-handlers.rkt
@@ -19,11 +19,8 @@
 ;; Success/error result helpers (from tool-api)
 ;; ============================================================
 
-(define (make-success-result items)
-  (hasheq 'success #t 'items items))
-
-(define (make-error-result msg)
-  (hasheq 'success #f 'error msg))
+;; make-success-result and make-error-result are imported from tool-api.rkt
+;; (which re-exports from tools/tool.rkt). They return tool-result structs.
 
 ;; ============================================================
 ;; Handler: racket-check

--- a/tests/test-agent-session-basic.rkt
+++ b/tests/test-agent-session-basic.rkt
@@ -53,6 +53,7 @@
                   event-ev
                   make-event
                   content-part->jsexpr)
+         (only-in "../util/event-payloads.rkt" payload->hash)
          "../agent/event-bus.rkt"
          "../llm/model.rkt"
          "../llm/provider.rkt"
@@ -442,7 +443,7 @@
                  "should return 'error termination reason")
 
    ;; Verify metadata contains error info
-   (define meta (loop-result-metadata result))
+   (define meta (payload->hash (loop-result-metadata result)))
    (check-not-false (hash-has-key? meta 'error) "metadata should contain error key")
    (check-equal? (hash-ref meta 'errorType)
                  'provider-error

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -8,7 +8,5 @@
 
 (provide q-version)
 
-(define q-version
-  :
-  String
-  "0.22.6")
+(: q-version String)
+(define q-version "0.22.6")


### PR DESCRIPTION
Addresses #2332.

fix: Critical regression fixes for v0.22.6 post-merge issues (#2332)

W0 of v0.22.7:

REG-01: Deleted local make-success-result/make-error-result hasheq defs from
racket-tooling-handlers.rkt. Handlers now use tool-api.rkt imports that
return proper tool-result structs. 20/20 racket-tooling tests pass.

REG-02: Fixed util/version.rkt TR annotation format. Changed from multi-line
(define q-version : String "...") to single-line (: q-version String) +
(define q-version "..."). Both raco fmt and regex parsers handle this correctly.

REG-03: Wrapped loop-result-metadata with payload->hash in
test-agent-session-basic.rkt. Error-payload struct is now properly converted
to hash before hash-has-key?/hash-ref operations. 18/18 tests pass.

DOC-01: Synced README status block to v0.22.6.

Closes #2332.