### PR TITLE
fix: TR boundary hardening + lint fixes (#2341)

W2 of v0.22.7:

FMT-01: Updated lint-format.rkt to accept #lang typed/racket and #lang info
as valid language variants. Pre-commit lint now shows 0 warnings (was 3).

ARCH-02: Added TR boundary contract enforcement tests — verified that
session-start-payload raises exn:fail:contract? when called with wrong types
from untyped code. Added documentation comment in agent-session.rkt about
TR's auto-generated boundary contracts.

9/9 Typed Racket tests pass (was 7/9 — added 2 contract enforcement tests).

Closes #2341.

### DIFF
--- a/runtime/agent-session.rkt
+++ b/runtime/agent-session.rkt
@@ -44,6 +44,10 @@
          (only-in "../extensions/message-inject.rkt" injection-event-topic)
          "../runtime/compactor.rkt"
          (only-in "../extensions/api.rkt" extension-name list-extensions)
+         ;; TR BOUNDARY: event-payloads.rkt is #lang typed/racket. Untyped consumers
+         ;; like this module receive auto-generated contracts from TR's boundary.
+         ;; Struct accessors are contract-wrapped at the module boundary,
+         ;; providing runtime type safety for all payload constructors.
          (only-in "../util/event-payloads.rkt"
                   session-start-payload
                   session-end-payload

--- a/scripts/lint-format.rkt
+++ b/scripts/lint-format.rkt
@@ -83,7 +83,9 @@
        (unless (or (string=? lang canonical-lang)
                    ;; These are acceptable alternatives
                    (string=? lang "racket")
-                   (string-prefix? lang "at-exp "))
+                   (string-prefix? lang "at-exp ")
+                   (string-prefix? lang "typed/racket")
+                   (string=? lang "info"))
          (add-warning! (format "WARNING: ~a:~a: non-standard #lang ~a (expected #lang ~a)"
                                filepath
                                lineno

--- a/tests/test-typed-racket-pilot.rkt
+++ b/tests/test-typed-racket-pilot.rkt
@@ -12,57 +12,64 @@
          "../util/event-payloads.rkt")
 
 (define tr-pilot-tests
-  (test-suite
-   "Typed Racket Pilot (RKT-01 v0.22.6)"
+  (test-suite "Typed Racket Pilot (RKT-01 v0.22.6)"
 
-   ;; -------------------------------------------------------
-   ;; util/version.rkt — Typed Racket
-   ;; -------------------------------------------------------
-   (test-case "q-version is a string"
-     (check-pred string? q-version)
-     (check-true (regexp-match? #rx"^0\\.22\\." q-version)))
+    ;; -------------------------------------------------------
+    ;; util/version.rkt — Typed Racket
+    ;; -------------------------------------------------------
+    (test-case "q-version is a string"
+      (check-pred string? q-version)
+      (check-true (regexp-match? #rx"^0\\.22\\." q-version)))
 
-   ;; -------------------------------------------------------
-   ;; util/event-payloads.rkt — Typed Racket
-   ;; -------------------------------------------------------
-   (test-case "session-start-payload constructs and accesses"
-     (define p (session-start-payload "s1" (hash 'model "gpt") 'new))
-     (check-equal? (session-start-payload-session-id p) "s1")
-     (check-equal? (session-start-payload-reason p) 'new)
-     (check-pred hash? (session-start-payload-config p)))
+    ;; -------------------------------------------------------
+    ;; util/event-payloads.rkt — Typed Racket
+    ;; -------------------------------------------------------
+    (test-case "session-start-payload constructs and accesses"
+      (define p (session-start-payload "s1" (hash 'model "gpt") 'new))
+      (check-equal? (session-start-payload-session-id p) "s1")
+      (check-equal? (session-start-payload-reason p) 'new)
+      (check-pred hash? (session-start-payload-config p)))
 
-   (test-case "payload->hash works for all payload types"
-     (check-pred hash? (payload->hash (session-start-payload "s1" #f 'new)))
-     (check-pred hash? (payload->hash (session-end-payload "s1" 42.0)))
-     (check-pred hash? (payload->hash (session-switch-payload "s1" 'resume)))
-     (check-pred hash? (payload->hash (tool-call-event-payload "s1" "t1" "read" "c1")))
-     (check-pred hash? (payload->hash (session-id-payload "s1")))
-     (check-pred hash? (payload->hash (error-payload "oops" 'runtime)))
-     (check-pred hash? (payload->hash (input-payload "s1" "hello")))
-     (check-pred hash? (payload->hash (gsd-mode-payload 'plan 'implement))))
+    (test-case "payload->hash works for all payload types"
+      (check-pred hash? (payload->hash (session-start-payload "s1" #f 'new)))
+      (check-pred hash? (payload->hash (session-end-payload "s1" 42.0)))
+      (check-pred hash? (payload->hash (session-switch-payload "s1" 'resume)))
+      (check-pred hash? (payload->hash (tool-call-event-payload "s1" "t1" "read" "c1")))
+      (check-pred hash? (payload->hash (session-id-payload "s1")))
+      (check-pred hash? (payload->hash (error-payload "oops" 'runtime)))
+      (check-pred hash? (payload->hash (input-payload "s1" "hello")))
+      (check-pred hash? (payload->hash (gsd-mode-payload 'plan 'implement))))
 
-   (test-case "payload->hash passes through plain hashes"
-     (define h (hasheq 'foo 'bar))
-     (check-equal? (payload->hash h) h))
+    (test-case "payload->hash passes through plain hashes"
+      (define h (hasheq 'foo 'bar))
+      (check-equal? (payload->hash h) h))
 
-   (test-case "payload->hash wraps unknown values"
-     (define h (payload->hash 42))
-     (check-equal? (hash-ref h 'payload) 42))
+    (test-case "payload->hash wraps unknown values"
+      (define h (payload->hash 42))
+      (check-equal? (hash-ref h 'payload) 42))
 
-   (test-case "payload-session-id extracts from all payload types"
-     (check-equal? (payload-session-id (session-start-payload "s1" #f 'new)) "s1")
-     (check-equal? (payload-session-id (session-end-payload "s2" 1.0)) "s2")
-     (check-equal? (payload-session-id (session-switch-payload "s3" 'pause)) "s3")
-     (check-equal? (payload-session-id (tool-call-event-payload "s4" "t" "r" "c")) "s4")
-     (check-equal? (payload-session-id (session-id-payload "s5")) "s5")
-     (check-equal? (payload-session-id (input-payload "s6" "hi")) "s6")
-     (check-equal? (payload-session-id (hasheq 'session-id "s7")) "s7")
-     (check-false (payload-session-id 'unknown)))
+    (test-case "payload-session-id extracts from all payload types"
+      (check-equal? (payload-session-id (session-start-payload "s1" #f 'new)) "s1")
+      (check-equal? (payload-session-id (session-end-payload "s2" 1.0)) "s2")
+      (check-equal? (payload-session-id (session-switch-payload "s3" 'pause)) "s3")
+      (check-equal? (payload-session-id (tool-call-event-payload "s4" "t" "r" "c")) "s4")
+      (check-equal? (payload-session-id (session-id-payload "s5")) "s5")
+      (check-equal? (payload-session-id (input-payload "s6" "hi")) "s6")
+      (check-equal? (payload-session-id (hasheq 'session-id "s7")) "s7")
+      (check-false (payload-session-id 'unknown)))
 
-   (test-case "struct transparency works"
-     (check-pred session-start-payload? (session-start-payload "s" #f 'new))
-     (check-pred session-end-payload? (session-end-payload "s" 1))
-     (check-pred gsd-mode-payload? (gsd-mode-payload 'a 'b)))
-   ))
+    (test-case "TR boundary contracts enforce string types for session-id"
+      ;; session-start-payload expects String for session-id.
+      ;; From untyped code, TR auto-generates contracts that enforce this.
+      (check-exn exn:fail:contract? (lambda () (session-start-payload 123 #f 'new))))
+
+    (test-case "TR boundary contracts enforce symbol types for reason"
+      ;; session-start-payload expects Symbol for reason.
+      (check-exn exn:fail:contract? (lambda () (session-start-payload "s1" #f "not-a-symbol"))))
+
+    (test-case "struct transparency works"
+      (check-pred session-start-payload? (session-start-payload "s" #f 'new))
+      (check-pred session-end-payload? (session-end-payload "s" 1))
+      (check-pred gsd-mode-payload? (gsd-mode-payload 'a 'b)))))
 
 (run-tests tr-pilot-tests)


### PR DESCRIPTION
Addresses #2341.

fix: TR boundary hardening + lint fixes (#2341)

W2 of v0.22.7:

FMT-01: Updated lint-format.rkt to accept #lang typed/racket and #lang info
as valid language variants. Pre-commit lint now shows 0 warnings (was 3).

ARCH-02: Added TR boundary contract enforcement tests — verified that
session-start-payload raises exn:fail:contract? when called with wrong types
from untyped code. Added documentation comment in agent-session.rkt about
TR's auto-generated boundary contracts.

9/9 Typed Racket tests pass (was 7/9 — added 2 contract enforcement tests).

Closes #2341.