### PR TITLE
fix: DI fixes + LAZY-01 regression (#2356)

W0 of v0.22.8:

LAZY-01: Replaced lazy-require of injection-event-topic (string value)
with direct import in iteration.rkt. lazy-require wraps values as
procedures, breaking the string constant. 15/15 message-inject tests pass.

DI-03: Added DI parameter setting in resume-agent-session (was only in
make-agent-session). Both session creation paths now set current-compact-proc,
current-estimate-tokens, and current-inject-topic.

DI-04: Added thread-local documentation to DI parameter section in iteration.rkt.

LOW-05: Added resolve-* defaults test + exported resolve functions from iteration.rkt.
6/6 DI keyword args tests pass.

Closes #2356. Closes #2357. Closes #2358. Closes #2359.

### DIFF
--- a/runtime/agent-session.rkt
+++ b/runtime/agent-session.rkt
@@ -345,6 +345,11 @@
   ;; Subscribe to fork/compact events from TUI/CLI
   (wire-session-event-handlers! sess fork-session)
 
+  ;; DI-03 (v0.22.8): Set DI parameters for resumed sessions too
+  (current-compact-proc compact-history)
+  (current-estimate-tokens estimate-context-tokens)
+  (current-inject-topic injection-event-topic)
+
   sess)
 
 ;; ============================================================

--- a/runtime/iteration.rkt
+++ b/runtime/iteration.rkt
@@ -99,20 +99,32 @@
          ;; DI parameters for testability (DI-01, v0.22.7)
          current-compact-proc
          current-estimate-tokens
-         current-inject-topic)
+         current-inject-topic
+         ;; DI resolve functions (LOW-05, v0.22.8)
+         resolve-compact-proc
+         resolve-estimate-tokens
+         resolve-inject-topic)
 
 ;; ============================================================
-;; DI parameters (DI-01, v0.22.7)
+;; DI parameters (DI-01, v0.22.7; DI-04, v0.22.8)
 ;;
 ;; These parameters decouple iteration.rkt from concrete imports.
 ;; Callers (agent-session.rkt) set them at session init time.
 ;; Tests can override them with mocks.
+;;
+;; THREAD-LOCAL WARNING: These parameters are thread-local. They are
+;; set by make-agent-session and resume-agent-session in the calling
+;; thread. If run-iteration-loop is called from a different thread,
+;; the parameters will be #f and fall through to lazy-require defaults
+;; (for procedures) or direct imports (for values). This is safe for
+;; TUI/CLI where iteration runs in the session thread. For SDK use
+;; across threads, callers must set parameters before dispatching.
 ;; ============================================================
 
-(require racket/lazy-require)
+(require racket/lazy-require
+         (only-in "../extensions/message-inject.rkt" injection-event-topic))
 (lazy-require ["../runtime/compactor.rkt" (compact-history)]
-              ["../llm/token-budget.rkt" (estimate-context-tokens)]
-              ["../extensions/message-inject.rkt" (injection-event-topic)])
+              ["../llm/token-budget.rkt" (estimate-context-tokens)])
 
 (define current-compact-proc (make-parameter #f))
 (define current-estimate-tokens (make-parameter #f))

--- a/tests/test-di-keyword-args.rkt
+++ b/tests/test-di-keyword-args.rkt
@@ -130,6 +130,19 @@
                            (hash)
                            #:tool-list-proc mock-tool-list))
       (check-pred values result "run-provider-turn returns with mock tool-list-proc")
-      (check-not-false (unbox tool-called-with) "mock tool-list-proc was called"))))
+      (check-not-false (unbox tool-called-with) "mock tool-list-proc was called"))
+
+    ;; LOW-05 (v0.22.8): Verify DI defaults allow iteration to work
+    (test-case "resolve-* defaults match concrete implementations"
+      ;; The resolve-* functions fall through to lazy-require/concrete imports
+      ;; when DI parameters are #f. Verify injection-event-topic value is correct.
+      (parameterize ([current-compact-proc #f]
+                     [current-estimate-tokens #f]
+                     [current-inject-topic #f])
+        ;; injection-event-topic is a direct import, so resolve-inject-topic
+        ;; should return "message.injected" when current-inject-topic is #f
+        (check-equal? (resolve-inject-topic) "message.injected")
+        (check-true (procedure? (resolve-compact-proc)))
+        (check-true (procedure? (resolve-estimate-tokens)))))))
 
 (run-tests di-keyword-args-tests)


### PR DESCRIPTION
Addresses #2356.

fix: DI fixes + LAZY-01 regression (#2356)

W0 of v0.22.8:

LAZY-01: Replaced lazy-require of injection-event-topic (string value)
with direct import in iteration.rkt. lazy-require wraps values as
procedures, breaking the string constant. 15/15 message-inject tests pass.

DI-03: Added DI parameter setting in resume-agent-session (was only in
make-agent-session). Both session creation paths now set current-compact-proc,
current-estimate-tokens, and current-inject-topic.

DI-04: Added thread-local documentation to DI parameter section in iteration.rkt.

LOW-05: Added resolve-* defaults test + exported resolve functions from iteration.rkt.
6/6 DI keyword args tests pass.

Closes #2356. Closes #2357. Closes #2358. Closes #2359.