### PR TITLE
feat: typed racket expansion for plan-types + plan-validator (#2364)

W2 of v0.22.8:

T1: Migrated extensions/gsd/plan-types.rkt to #lang typed/racket.
Struct definitions, constructors, validation, and utilities are fully
typed. Parsing functions extracted to plan-types-parser.rkt (untyped)
to avoid TR complexity with regexp-match + set! patterns.

T2: Migrated extensions/gsd/plan-validator.rkt to #lang typed/racket.
All 3 functions have full type annotations.

T3: Added TR boundary documentation to util/event-payloads.rkt.

T4: Extended test-typed-racket-pilot.rkt with 4 new tests:
- gsd-task construction from untyped context
- gsd-wave and gsd-plan construction
- TR boundary contract enforcement on plan-types
- validate-plan-strict + format-validation-report

14/14 TR tests pass. 129 GSD tests pass. 13 arch tests pass.

Closes #2364. Closes #2365. Closes #2366. Closes #2367.

### DIFF
--- a/extensions/gsd/plan-types-parser.rkt
+++ b/extensions/gsd/plan-types-parser.rkt
@@ -1,0 +1,129 @@
+#lang racket/base
+
+;; extensions/gsd/plan-types-parser.rkt — Markdown parsing for GSD plans
+;;
+;; Extracted from plan-types.rkt to keep the parsing code in untyped Racket
+;; while plan-types.rkt itself is #lang typed/racket.
+;; Returns raw hash tables and values — plan-types.rkt wraps into structs.
+
+(require racket/string
+         racket/list)
+
+;; ============================================================
+;; Parsing helpers
+;; ============================================================
+
+;; Clean file path: strip surrounding backticks and whitespace.
+(define (clean-file-path s)
+  (define trimmed (string-trim s))
+  (cond
+    [(>= (string-length trimmed) 6)
+     (define triple-back (string-prefix? trimmed "```"))
+     (define triple-end (string-suffix? trimmed "```"))
+     (if (and triple-back triple-end)
+         (string-trim (substring trimmed 3 (- (string-length trimmed) 3)))
+         (if (and (string-prefix? trimmed "`") (string-suffix? trimmed "`"))
+             (string-trim (substring trimmed 1 (- (string-length trimmed) 1)))
+             trimmed))]
+    [(>= (string-length trimmed) 2)
+     (if (and (string-prefix? trimmed "`") (string-suffix? trimmed "`"))
+         (string-trim (substring trimmed 1 (- (string-length trimmed) 1)))
+         trimmed)]
+    [else trimmed]))
+
+;; Parse structured fields from wave document content.
+(define (parse-wave-content content)
+  (define lines (string-split content "\n"))
+  (define n (length lines))
+  (define root-cause "")
+  (define files '())
+  (define verify-cmd "")
+  (define done-criteria '())
+  (define in-files-section #f)
+  (for ([line lines]
+        [i (in-naturals)])
+    (define trimmed (string-trim line))
+    (when (regexp-match? #rx"^## " trimmed)
+      (set! in-files-section (string-prefix? trimmed "## Files")))
+    (cond
+      [(string-prefix? trimmed "## Verify")
+       (define after
+         (for/list ([j (in-range (add1 i) (min n (+ i 5)))]
+                    #:when (and (> (string-length (string-trim (list-ref lines j))) 0)
+                                (not (string-contains? (list-ref lines j) "```"))))
+           (string-trim (list-ref lines j))))
+       (when (and (string=? verify-cmd "") (not (null? after)))
+         (set! verify-cmd (string-join after "; ")))]
+      [(regexp-match #rx"^- +[Rr]oot *[Cc]ause *: *(.+)$" line)
+       =>
+       (lambda (m) (set! root-cause (string-trim (cadr m))))]
+      [(regexp-match #rx"^- +[Ff]iles *: *(.+)$" line)
+       =>
+       (lambda (m)
+         (define paths (string-split (string-trim (cadr m)) ","))
+         (set! files (append files (map (lambda (p) (clean-file-path (string-trim p))) paths))))]
+      [(regexp-match #rx"^- +[Ff]ile *: *(.+)$" line)
+       =>
+       (lambda (m) (set! files (append files (list (clean-file-path (string-trim (cadr m)))))))]
+      [(and in-files-section (regexp-match #rx"^- +(.+)$" line))
+       =>
+       (lambda (m) (set! files (append files (list (clean-file-path (string-trim (cadr m)))))))]
+      [(regexp-match #rx"^- +[Vv]erify *: *(.+)$" line)
+       =>
+       (lambda (m) (set! verify-cmd (string-trim (cadr m))))]
+      [(regexp-match #rx"^- +[Dd]one *: *(.+)$" line)
+       =>
+       (lambda (m) (set! done-criteria (append done-criteria (list (string-trim (cadr m))))))]))
+  (hasheq 'root-cause root-cause 'files files 'verify verify-cmd 'done done-criteria))
+
+;; Parse a single wave section → raw data hash (not a gsd-wave struct).
+;; plan-types.rkt wraps this into a gsd-wave.
+(define (parse-wave-section-raw lines)
+  (define header (car lines))
+  (define body-lines (cdr lines))
+  (define header-match (regexp-match #rx"^## +[Ww]ave +([0-9]+) *: *(.+)$" header))
+  (define idx
+    (if header-match
+        (string->number (cadr header-match))
+        0))
+  (define title
+    (if header-match
+        (string-trim (caddr header-match))
+        ""))
+  (define fields (parse-wave-content (string-join body-lines "\n")))
+  (hasheq 'index
+          idx
+          'title
+          title
+          'root-cause
+          (hash-ref fields 'root-cause "")
+          'files
+          (hash-ref fields 'files '())
+          'verify
+          (hash-ref fields 'verify "")
+          'done
+          (hash-ref fields 'done '())))
+
+;; Parse PLAN.md content → list of raw data hashes.
+(define (parse-waves-from-markdown-raw md-text)
+  (define lines (string-split md-text "\n"))
+  (define wave-starts
+    (for/list ([line lines]
+               [idx (in-naturals)]
+               #:when (regexp-match #rx"^## +[Ww]ave +[0-9]+" line))
+      idx))
+  (define wave-end-idxs
+    (if (< (length wave-starts) 2)
+        (list (sub1 (length lines)))
+        (append (map sub1 (cdr wave-starts)) (list (sub1 (length lines))))))
+  (for/list ([start wave-starts]
+             [end wave-end-idxs])
+    (parse-wave-section-raw (take (drop lines start) (add1 (- end start))))))
+
+;; ============================================================
+;; Provide
+;; ============================================================
+
+(provide parse-waves-from-markdown-raw
+         parse-wave-content
+         clean-file-path)

--- a/extensions/gsd/plan-types.rkt
+++ b/extensions/gsd/plan-types.rkt
@@ -1,38 +1,76 @@
-#lang racket/base
+#lang typed/racket
 
 ;; extensions/gsd/plan-types.rkt — Structured Plan/Task/Wave types
 ;;
 ;; Wave 0 of v0.21.0: Machine-parseable plan types with validation.
-;; Plans use a structured format with required fields.
-;; The extension validates plan structure before allowing /go.
+;; Migrated to #lang typed/racket in v0.22.8 W2 (TR expansion).
+;;
+;; ── TR BOUNDARY ──────────────────────────────────────────────
+;; This is a #lang typed/racket module. Untyped consumers receive
+;; auto-generated contracts from TR's boundary system. Struct
+;; constructors enforce field types at call sites in untyped modules.
+;; New consumers should import normally — no require/typed needed.
+;; ──────────────────────────────────────────────────────────────
 
-(require racket/match
-         racket/string
-         racket/list)
+(require racket/string
+         racket/list
+         racket/format)
 
 ;; ============================================================
-;; Core structs (immutable)
+;; Type definitions
 ;; ============================================================
 
-(struct gsd-task (name files action verify done status) #:transparent)
+(define-type WaveStatus (U 'pending 'in-progress 'completed 'failed 'skipped))
 
-(struct gsd-wave (index title status root-cause files tasks verify done-criteria) #:transparent)
+;; ============================================================
+;; Core structs (immutable, typed)
+;; ============================================================
 
-(struct gsd-plan (waves context-bundle constraints must-haves) #:transparent)
+(struct gsd-task
+        ([name : String] [files : (Listof String)]
+                         [action : String]
+                         [verify : String]
+                         [done : String]
+                         [status : WaveStatus])
+  #:transparent)
 
-(struct validation-result (errors warnings) #:transparent)
+(struct gsd-wave
+        ([index : Natural] [title : String]
+                           [status : WaveStatus]
+                           [root-cause : String]
+                           [files : (Listof String)]
+                           [tasks : (Listof gsd-task)]
+                           [verify : String]
+                           [done-criteria : (Listof String)])
+  #:transparent)
 
-;; Aliases for cleaner API
-(define validation-errors validation-result-errors)
-(define validation-warnings validation-result-warnings)
+(struct gsd-plan
+        ([waves : (Listof gsd-wave)] [context-bundle : (U String #f)]
+                                     [constraints : (Listof String)]
+                                     [must-haves : (Listof String)])
+  #:transparent)
+
+(struct validation-result ([errors : (Listof String)] [warnings : (Listof String)]) #:transparent)
 
 ;; ============================================================
 ;; Convenience constructors
 ;; ============================================================
 
+(: make-gsd-task : String (Listof String) String String String -> gsd-task)
 (define (make-gsd-task name files action verify [done ""])
   (gsd-task name files action verify done 'pending))
 
+(: make-gsd-wave
+   :
+   Natural
+   String
+   String
+   (Listof String)
+   (Listof gsd-task)
+   String
+   (Listof String)
+   ->
+   gsd-wave)
 (define (make-gsd-wave index title root-cause files tasks verify done-criteria)
   (gsd-wave index title 'pending root-cause files tasks verify done-criteria))
 
@@ -40,9 +78,11 @@
 ;; Status setters (return new struct — immutable)
 ;; ============================================================
 
+(: gsd-task-set-status : gsd-task WaveStatus -> gsd-task)
 (define (gsd-task-set-status t status)
   (struct-copy gsd-task t [status status]))
 
+(: gsd-wave-set-status : gsd-wave WaveStatus -> gsd-wave)
 (define (gsd-wave-set-status w status)
   (struct-copy gsd-wave w [status status]))
 
@@ -50,141 +90,24 @@
 ;; Validation helpers
 ;; ============================================================
 
+(: validation-valid? : validation-result -> Boolean)
 (define (validation-valid? vr)
-  (null? (validation-errors vr)))
+  (null? (validation-result-errors vr)))
 
-;; ============================================================
-;; Parsing: markdown → (listof gsd-wave)
-;; ============================================================
-
-;; Parse PLAN.md content into structured waves.
-;; Looks for "## Wave N: Title" headers and extracts fields from
-;; bullet points within each wave section.
-(define (parse-waves-from-markdown md-text)
-  (define lines (string-split md-text "\n"))
-  ;; Find wave header line indices
-  (define wave-starts
-    (for/list ([line lines]
-               [idx (in-naturals)]
-               #:when (regexp-match #rx"^## +[Ww]ave +[0-9]+" line))
-      idx))
-  (define wave-end-idxs
-    (if (< (length wave-starts) 2)
-        (list (sub1 (length lines)))
-        (append (map sub1 (cdr wave-starts)) (list (sub1 (length lines))))))
-  ;; Parse each wave section
-  (for/list ([start wave-starts]
-             [end wave-end-idxs])
-    (parse-wave-section (take (drop lines start) (add1 (- end start))))))
-
-;; Clean file path: strip surrounding backticks and whitespace.
-;; Handles: `path` → path, ```path``` → path, path → path
-(define (clean-file-path s)
-  (define trimmed (string-trim s))
-  (cond
-    [(>= (string-length trimmed) 6)
-     ;; Check for triple backticks: ```path```
-     (define triple-back (string-prefix? trimmed "```"))
-     (define triple-end (string-suffix? trimmed "```"))
-     (if (and triple-back triple-end)
-         (string-trim (substring trimmed 3 (- (string-length trimmed) 3)))
-         ;; Check for single backticks: `path`
-         (if (and (string-prefix? trimmed "`") (string-suffix? trimmed "`"))
-             (string-trim (substring trimmed 1 (- (string-length trimmed) 1)))
-             trimmed))]
-    [(>= (string-length trimmed) 2)
-     (if (and (string-prefix? trimmed "`") (string-suffix? trimmed "`"))
-         (string-trim (substring trimmed 1 (- (string-length trimmed) 1)))
-         trimmed)]
-    [else trimmed]))
-
-;; Parse structured fields from wave document content.
-;; Handles both bullet-style and heading-style formats.
-;; Single source of truth for field extraction (F3 consolidation).
-(define (parse-wave-content content)
-  (define lines (string-split content "\n"))
-  (define n (length lines))
-  (define root-cause "")
-  (define files '())
-  (define verify-cmd "")
-  (define done-criteria '())
-  (define in-files-section #f) ; track ## Files heading section
-  (for ([line lines]
-        [i (in-naturals)])
-    (define trimmed (string-trim line))
-    ;; Update section tracking BEFORE cond dispatch
-    (when (regexp-match? #rx"^## " trimmed)
-      (set! in-files-section (string-prefix? trimmed "## Files")))
-    (cond
-      ;; Heading-style: ## Verify — collect non-empty, non-backtick lines after heading
-      [(string-prefix? trimmed "## Verify")
-       (define after
-         (for/list ([j (in-range (add1 i) (min n (+ i 5)))]
-                    #:when (and (> (string-length (string-trim (list-ref lines j))) 0)
-                                (not (string-contains? (list-ref lines j) "```"))))
-           (string-trim (list-ref lines j))))
-       (when (and (string=? verify-cmd "") (not (null? after)))
-         (set! verify-cmd (string-join after "; ")))]
-      ;; Bullet-style Root cause
-      [(regexp-match #rx"^- +[Rr]oot *[Cc]ause *: *(.+)$" line)
-       =>
-       (lambda (m) (set! root-cause (string-trim (cadr m))))]
-      ;; Bullet-style Files (plural, comma-separated)
-      [(regexp-match #rx"^- +[Ff]iles *: *(.+)$" line)
-       =>
-       (lambda (m)
-         (define paths (string-split (string-trim (cadr m)) ","))
-         (set! files (append files (map (lambda (p) (clean-file-path (string-trim p))) paths))))]
-      ;; Bullet-style File (singular)
-      [(regexp-match #rx"^- +[Ff]ile *: *(.+)$" line)
-       =>
-       (lambda (m) (set! files (append files (list (clean-file-path (string-trim (cadr m)))))))]
-      ;; Bare bullets inside ## Files section
-      [(and in-files-section (regexp-match #rx"^- +(.+)$" line))
-       =>
-       (lambda (m) (set! files (append files (list (clean-file-path (string-trim (cadr m)))))))]
-      ;; Bullet-style Verify
-      [(regexp-match #rx"^- +[Vv]erify *: *(.+)$" line)
-       =>
-       (lambda (m) (set! verify-cmd (string-trim (cadr m))))]
-      ;; Bullet-style Done
-      [(regexp-match #rx"^- +[Dd]one *: *(.+)$" line)
-       =>
-       (lambda (m) (set! done-criteria (append done-criteria (list (string-trim (cadr m))))))]))
-  (hasheq 'root-cause root-cause 'files files 'verify verify-cmd 'done done-criteria))
-
-;; Parse a single wave section (list of lines, first is header).
-;; Uses unified parse-wave-content for field extraction.
-(define (parse-wave-section lines)
-  (define header (car lines))
-  (define body-lines (cdr lines))
-  (define header-match (regexp-match #rx"^## +[Ww]ave +([0-9]+) *: *(.+)$" header))
-  (define idx
-    (if header-match
-        (string->number (cadr header-match))
-        0))
-  (define title
-    (if header-match
-        (string-trim (caddr header-match))
-        ""))
-  ;; Use unified parser
-  (define fields (parse-wave-content (string-join body-lines "\n")))
-  (gsd-wave idx
-            title
-            'pending
-            (hash-ref fields 'root-cause "")
-            (hash-ref fields 'files '())
-            '()
-            (hash-ref fields 'verify "")
-            (hash-ref fields 'done '())))
+;; Aliases for cleaner API
+(define validation-errors validation-result-errors)
+(define validation-warnings validation-result-warnings)
 
 ;; ============================================================
 ;; Validation
 ;; ============================================================
 
+(: validate-plan : gsd-plan -> validation-result)
 (define (validate-plan plan)
   (define waves (gsd-plan-waves plan))
+  (: errors : (Listof String))
   (define errors '())
+  (: warnings : (Listof String))
   (define warnings '())
   ;; Check: plan has at least 1 wave
   (when (null? waves)
@@ -199,10 +122,8 @@
       (set! warnings (cons (format "~a: no file references" prefix) warnings)))
     (when (string=? (gsd-wave-verify w) "")
       (set! warnings (cons (format "~a: no verify command" prefix) warnings))))
-  ;; Error: ALL waves are file-less — plan has nothing to execute on
-  (when (and (not (null? waves))
-             (for/and ([w waves])
-               (null? (gsd-wave-files w))))
+  ;; Error: ALL waves are file-less
+  (when (and (pair? waves) (andmap (lambda ([w : gsd-wave]) (null? (gsd-wave-files w))) waves))
     (set! errors (cons "Plan has no file references in any wave — nothing to execute" errors)))
   (validation-result (reverse errors) (reverse warnings)))
 
@@ -210,32 +131,32 @@
 ;; Plan utilities
 ;; ============================================================
 
+(: plan-wave-ref : gsd-plan Natural -> (U gsd-wave #f))
 (define (plan-wave-ref plan idx)
-  (for/first ([w (gsd-plan-waves plan)]
-              #:when (= (gsd-wave-index w) idx))
-    w))
+  (findf (lambda ([w : gsd-wave]) (= (gsd-wave-index w) idx)) (gsd-plan-waves plan)))
 
+(: plan-pending-waves : gsd-plan -> (Listof gsd-wave))
 (define (plan-pending-waves plan)
-  (filter (lambda (w) (eq? (gsd-wave-status w) 'pending)) (gsd-plan-waves plan)))
+  (filter (lambda ([w : gsd-wave]) (eq? (gsd-wave-status w) 'pending)) (gsd-plan-waves plan)))
 
+(: plan-next-pending-wave : gsd-plan -> (U gsd-wave #f))
 (define (plan-next-pending-wave plan)
-  (for/first ([w (gsd-plan-waves plan)]
-              #:when (eq? (gsd-wave-status w) 'pending))
-    w))
+  (findf (lambda ([w : gsd-wave]) (eq? (gsd-wave-status w) 'pending)) (gsd-plan-waves plan)))
 
 ;; ============================================================
 ;; Status conversion helpers
 ;; ============================================================
 
+(: wave-status->string : WaveStatus -> String)
 (define (wave-status->string sym)
   (cond
     [(eq? sym 'pending) "Inbox"]
     [(eq? sym 'in-progress) "In-Progress"]
     [(eq? sym 'completed) "DONE"]
     [(eq? sym 'failed) "FAILED"]
-    [(eq? sym 'skipped) "DEFERRED"]
-    [else (symbol->string sym)]))
+    [(eq? sym 'skipped) "DEFERRED"]))
 
+(: string->wave-status : String -> WaveStatus)
 (define (string->wave-status str)
   (cond
     [(string=? str "Inbox") 'pending]
@@ -245,73 +166,103 @@
     [(string=? str "DEFERRED") 'skipped]
     [else 'pending]))
 
+(: gsd-wave-slug : gsd-wave -> String)
 (define (gsd-wave-slug w)
   (define title (gsd-wave-title w))
-  (if (and (string? title) (> (string-length title) 0))
-      (let* ([s (string-trim title)]
-             [chars (for/list ([c (in-string s)])
-                      (cond
-                        [(char-alphabetic? c) (char-downcase c)]
-                        [(char-numeric? c) c]
-                        [(char=? c #\-) #\-]
-                        [(char=? c #\space) #\-]
-                        [else #f]))]
-             [result (list->string (filter values chars))])
-        (if (> (string-length result) 40)
-            (string-trim (substring result 0 40) "-" #:right? #t)
-            (if (string=? result "") "wave" result)))
+  (if (> (string-length title) 0)
+      (let* ([s
+              :
+              String
+              (string-trim title)]
+             [result
+              :
+              String
+              (slugify-chars s)])
+        (cond
+          [(> (string-length result) 40) (string-trim (substring result 0 40) "-" #:right? #t)]
+          [(string=? result "") "wave"]
+          [else result]))
       "wave"))
 
+(: slugify-chars : String -> String)
+(define (slugify-chars s)
+  (define cs
+    :
+    (Listof Char)
+    (string->list s))
+  (define mapped
+    :
+    (Listof (Option Char))
+    (for/list :
+      (Listof (Option Char))
+      ([c : Char cs])
+      (cond
+        [(char-alphabetic? c) (char-downcase c)]
+        [(char-numeric? c) c]
+        [(char=? c #\-) #\-]
+        [(char=? c #\space) #\-]
+        [else #f])))
+  (list->string (filter char? mapped)))
+
 ;; ============================================================
-;; Provide (after all definitions)
+;; Parsing re-exports from untyped parser module
 ;; ============================================================
 
-;; Struct types + accessors
-(provide gsd-task
-         gsd-task?
-         gsd-task-name
-         gsd-task-files
-         gsd-task-action
-         gsd-task-verify
-         gsd-task-done
-         gsd-task-status
-         gsd-task-set-status
+(require/typed "plan-types-parser.rkt"
+               [parse-waves-from-markdown-raw (String -> (Listof (HashTable Symbol Any)))]
+               [parse-wave-content (String -> (HashTable Symbol Any))]
+               [clean-file-path (String -> String)])
 
-         gsd-wave
-         gsd-wave?
-         gsd-wave-index
-         gsd-wave-title
-         gsd-wave-status
-         gsd-wave-root-cause
-         gsd-wave-files
-         gsd-wave-tasks
-         gsd-wave-verify
-         gsd-wave-done-criteria
-         gsd-wave-set-status
+(: raw-ref : (HashTable Symbol Any) Symbol Any -> Any)
+(define (raw-ref h k default)
+  (if (hash-has-key? h k)
+      (hash-ref h k)
+      default))
 
-         gsd-plan
-         gsd-plan?
-         gsd-plan-waves
-         gsd-plan-context-bundle
-         gsd-plan-constraints
-         gsd-plan-must-haves
+;; Wrap raw parsed data into gsd-wave structs
+(: parse-waves-from-markdown : String -> (Listof gsd-wave))
+(define (parse-waves-from-markdown md-text)
+  (for/list :
+    (Listof gsd-wave)
+    ([raw : (HashTable Symbol Any) (parse-waves-from-markdown-raw md-text)])
+    (gsd-wave (cast (raw-ref raw 'index 0) Natural)
+              (cast (raw-ref raw 'title "") String)
+              'pending
+              (cast (raw-ref raw 'root-cause "") String)
+              (cast (raw-ref raw 'files '()) (Listof String))
+              '()
+              (cast (raw-ref raw 'verify "") String)
+              (cast (raw-ref raw 'done '()) (Listof String)))))
+
+;; ============================================================
+;; Provide
+;; ============================================================
+
+(provide (struct-out gsd-task)
+         (struct-out gsd-wave)
+         (struct-out gsd-plan)
+         (struct-out validation-result)
 
          ;; Constructors with defaults
          make-gsd-task
          make-gsd-wave
 
-         ;; Parsing
+         ;; Status setters
+         gsd-task-set-status
+         gsd-wave-set-status
+
+         ;; Validation
+         validation-valid?
+         validate-plan
+
+         ;; Aliases
+         validation-errors
+         validation-warnings
+
+         ;; Parsing (re-exported from parser module)
          parse-waves-from-markdown
          parse-wave-content
          clean-file-path
-
-         ;; Validation
-         validation-result
-         validation-result?
-         validation-errors
-         validation-warnings
-         validation-valid?
-         validate-plan
 
          ;; Plan utilities
          plan-wave-ref
@@ -321,4 +272,7 @@
          ;; Status conversion helpers
          wave-status->string
          string->wave-status
-         gsd-wave-slug)
+         gsd-wave-slug
+
+         ;; Type alias
+         WaveStatus)

--- a/extensions/gsd/plan-validator.rkt
+++ b/extensions/gsd/plan-validator.rkt
@@ -1,36 +1,20 @@
-#lang racket/base
+#lang typed/racket
 
 ;; extensions/gsd/plan-validator.rkt — Plan structure validation
 ;;
-;; Wave 2a of v0.21.0: Mechanical validation before /go is allowed.
-;; DD-4: Structured plan format with mechanical validation.
-;;
-;; Error rules (block /go):
-;;   - Plan has < 1 wave
-;;   - Wave missing title
-;;   - Wave has no files (F2: upgraded from warning to error)
-;;
-;; Warning rules (display but allow):
-;;   - Wave missing verify command
-;;   - Wave missing root-cause/objective
+;; Migrated to #lang typed/racket in v0.22.8 W2.
+;; Enhanced validation: files missing is an error (not warning).
 
 (require racket/format
          racket/string
          "plan-types.rkt")
 
-(provide validate-plan-strict
-         format-validation-report
-         valid-plan->go?)
-
-;; ============================================================
-;; Strict validation
-;; ============================================================
-
-;; Enhanced validation: files missing is an error (not warning).
-;; Returns validation-result with errors and warnings.
+(: validate-plan-strict : gsd-plan -> validation-result)
 (define (validate-plan-strict plan)
   (define waves (gsd-plan-waves plan))
+  (: errors : (Listof String))
   (define errors '())
+  (: warnings : (Listof String))
   (define warnings '())
   ;; Check: plan has at least 1 wave
   (when (null? waves)
@@ -39,61 +23,59 @@
   (for ([w waves])
     (define widx (gsd-wave-index w))
     (define prefix (format "Wave ~a" widx))
-    ;; Warning: missing title (plans may omit title after wave number)
     (when (string=? (gsd-wave-title w) "")
       (set! warnings (cons (format "~a: no explicit title" prefix) warnings)))
-    ;; Warning: no file references in this wave (some waves are verify-only)
     (when (null? (gsd-wave-files w))
       (set! warnings
             (cons (format "~a: no file references — wave may not produce changes" prefix) warnings)))
-    ;; Warning: no verify command
     (when (or (not (gsd-wave-verify w)) (string=? (gsd-wave-verify w) ""))
       (set! warnings (cons (format "~a: no verify command" prefix) warnings)))
-    ;; Warning: no root-cause/objective
     (when (string=? (gsd-wave-root-cause w) "")
       (set! warnings (cons (format "~a: no root-cause/objective" prefix) warnings)))
-    ;; Warning: no slug for wave doc lookup
     (when (string=? (gsd-wave-title w) "")
       (set! warnings
             (cons (format "~a: cannot derive wave doc slug (empty title)" prefix) warnings))))
-  ;; Error: ALL waves are file-less — plan has nothing to execute on
-  (when (and (not (null? waves))
-             (for/and ([w waves])
-               (null? (gsd-wave-files w))))
+  ;; Error: ALL waves are file-less
+  (when (and (pair? waves) (andmap (lambda ([w : gsd-wave]) (null? (gsd-wave-files w))) waves))
     (set! errors (cons "Plan has no file references in any wave — nothing to execute" errors)))
   (validation-result (reverse errors) (reverse warnings)))
 
-;; ============================================================
-;; Helpers
-;; ============================================================
-
-;; Can we proceed to /go? Only if no errors.
+(: valid-plan->go? : gsd-plan -> Boolean)
 (define (valid-plan->go? plan)
   (define result (validate-plan-strict plan))
   (validation-valid? result))
 
-;; Format validation result for display.
+(: format-validation-report : validation-result -> String)
 (define (format-validation-report result)
-  (define errors (validation-errors result))
-  (define warnings (validation-warnings result))
+  (define errs (validation-result-errors result))
+  (define warns (validation-result-warnings result))
+  (: parts : (Listof String))
   (define parts '())
-  (when (not (null? errors))
+  (when (not (null? errs))
     (set! parts
           (cons (format "❌ ERRORS (block /go):\n~a"
-                        (string-join (for/list ([e errors])
+                        (string-join (for/list :
+                                       (Listof String)
+                                       ([e : String errs])
                                        (format "  - ~a" e))
                                      "\n"))
                 parts)))
-  (when (not (null? warnings))
+  (when (not (null? warns))
     (set! parts
           (cons (format "⚠️  WARNINGS:\n~a"
-                        (string-join (for/list ([w warnings])
+                        (string-join (for/list :
+                                       (Listof String)
+                                       ([w : String warns])
                                        (format "  - ~a" w))
                                      "\n"))
                 parts)))
-  (if (null? errors)
+  (if (null? errs)
       (string-append "✅ Plan is valid.\n"
                      (if (null? parts)
                          ""
                          (string-join (reverse parts) "\n\n")))
       (string-join (reverse parts) "\n\n")))
+
+(provide validate-plan-strict
+         format-validation-report
+         valid-plan->go?)

--- a/tests/test-typed-racket-pilot.rkt
+++ b/tests/test-typed-racket-pilot.rkt
@@ -9,10 +9,12 @@
 (require rackunit
          rackunit/text-ui
          "../util/version.rkt"
-         "../util/event-payloads.rkt")
+         "../util/event-payloads.rkt"
+         "../extensions/gsd/plan-types.rkt"
+         "../extensions/gsd/plan-validator.rkt")
 
 (define tr-pilot-tests
-  (test-suite "Typed Racket Pilot (RKT-01 v0.22.6)"
+  (test-suite "Typed Racket Pilot (RKT-01 v0.22.8)"
 
     ;; -------------------------------------------------------
     ;; util/version.rkt — Typed Racket
@@ -59,17 +61,57 @@
       (check-false (payload-session-id 'unknown)))
 
     (test-case "TR boundary contracts enforce string types for session-id"
-      ;; session-start-payload expects String for session-id.
-      ;; From untyped code, TR auto-generates contracts that enforce this.
       (check-exn exn:fail:contract? (lambda () (session-start-payload 123 #f 'new))))
 
     (test-case "TR boundary contracts enforce symbol types for reason"
-      ;; session-start-payload expects Symbol for reason.
       (check-exn exn:fail:contract? (lambda () (session-start-payload "s1" #f "not-a-symbol"))))
 
     (test-case "struct transparency works"
       (check-pred session-start-payload? (session-start-payload "s" #f 'new))
       (check-pred session-end-payload? (session-end-payload "s" 1))
-      (check-pred gsd-mode-payload? (gsd-mode-payload 'a 'b)))))
+      (check-pred gsd-mode-payload? (gsd-mode-payload 'a 'b)))
+
+    ;; -------------------------------------------------------
+    ;; extensions/gsd/plan-types.rkt — Typed Racket (v0.22.8)
+    ;; -------------------------------------------------------
+    (test-case "plan-types: gsd-task construction from untyped context"
+      (define t (make-gsd-task "test task" '("file1.rkt") "action" "verify" ""))
+      (check-pred gsd-task? t)
+      (check-equal? (gsd-task-name t) "test task")
+      (check-equal? (gsd-task-files t) '("file1.rkt"))
+      (check-equal? (gsd-task-status t) 'pending))
+
+    (test-case "plan-types: gsd-wave and gsd-plan construction"
+      (define w (make-gsd-wave 0 "Test Wave" "root cause" '("f.rkt") '() "verify" '("done")))
+      (check-pred gsd-wave? w)
+      (check-equal? (gsd-wave-index w) 0)
+      (check-equal? (gsd-wave-title w) "Test Wave")
+      (check-equal? (gsd-wave-status w) 'pending)
+      (define p (gsd-plan (list w) #f '() '()))
+      (check-pred gsd-plan? p)
+      (check-equal? (length (gsd-plan-waves p)) 1))
+
+    (test-case "plan-types: TR boundary contract enforcement"
+      ;; gsd-task expects String for name field.
+      ;; Passing wrong type from untyped should raise contract error.
+      (check-exn exn:fail:contract? (lambda () (gsd-task 123 '() "action" "verify" "" 'pending))))
+
+    ;; -------------------------------------------------------
+    ;; extensions/gsd/plan-validator.rkt — Typed Racket (v0.22.8)
+    ;; -------------------------------------------------------
+    (test-case "validate-plan-strict returns validation-result"
+      (define w (make-gsd-wave 0 "Wave 0" "cause" '("f.rkt") '() "verify" '("done")))
+      (define p (gsd-plan (list w) #f '() '()))
+      (define result (validate-plan-strict p))
+      (check-pred validation-result? result)
+      (check-true (validation-valid? result)))
+
+    (test-case "format-validation-report produces non-empty string"
+      (define w (make-gsd-wave 0 "Wave 0" "cause" '("f.rkt") '() "verify" '()))
+      (define p (gsd-plan (list w) #f '() '()))
+      (define result (validate-plan-strict p))
+      (define report (format-validation-report result))
+      (check-pred string? report)
+      (check-true (> (string-length report) 0)))))
 
 (run-tests tr-pilot-tests)

--- a/util/event-payloads.rkt
+++ b/util/event-payloads.rkt
@@ -7,6 +7,14 @@
 ;; optional wrappers that provide type safety and better error messages.
 ;;
 ;; Migrated to Typed Racket in v0.22.6 W5 (RKT-01 pilot).
+;;
+;; ── TR BOUNDARY ──────────────────────────────────────────────
+;; This is a #lang typed/racket module. Untyped consumers receive
+;; auto-generated contracts from TR's boundary system. Struct
+;; constructors enforce field types at call sites in untyped modules.
+;; New consumers should import normally — no require/typed needed.
+;; See ADR-0013 (planned) for TR migration strategy.
+;; ──────────────────────────────────────────────────────────────
 
 (provide (struct-out session-start-payload)
          (struct-out session-end-payload)


### PR DESCRIPTION
Addresses #2364.

feat: typed racket expansion for plan-types + plan-validator (#2364)

W2 of v0.22.8:

T1: Migrated extensions/gsd/plan-types.rkt to #lang typed/racket.
Struct definitions, constructors, validation, and utilities are fully
typed. Parsing functions extracted to plan-types-parser.rkt (untyped)
to avoid TR complexity with regexp-match + set! patterns.

T2: Migrated extensions/gsd/plan-validator.rkt to #lang typed/racket.
All 3 functions have full type annotations.

T3: Added TR boundary documentation to util/event-payloads.rkt.

T4: Extended test-typed-racket-pilot.rkt with 4 new tests:
- gsd-task construction from untyped context
- gsd-wave and gsd-plan construction
- TR boundary contract enforcement on plan-types
- validate-plan-strict + format-validation-report

14/14 TR tests pass. 129 GSD tests pass. 13 arch tests pass.

Closes #2364. Closes #2365. Closes #2366. Closes #2367.