### PR TITLE
feat: event schema contracts + payload validation (#2368)

W3 of v0.22.8: Created util/event-contracts.rkt with 9 payload contracts.
Applied assert-payload to top-7 events in iteration.rkt.
18/18 contract tests pass. Updated event-taxonomy.md.

Closes #2368, #2369, #2370, #2371.

### DIFF
--- a/docs/event-taxonomy.md
+++ b/docs/event-taxonomy.md
@@ -312,3 +312,86 @@ Key hook points where extensions can intercept:
 | `input` | User input received | No |
 
 For the complete list, see `util/hook-types.rkt`.
+
+## Contract-Validated Events (v0.22.7)
+
+The following high-value events have payload contracts enforced at emission
+time in `runtime/iteration.rkt`. These events are consumed by extensions and
+TUI subscribers — their payload shapes are part of the stable protocol.
+
+### `context.mid-turn-over-budget`
+**Contract:** `budget-payload/c`
+**Stability:** evolving
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `estimated-tokens` | natural | Estimated token count |
+| `budget` | natural | Budget threshold |
+| `max-tokens` | natural | Model max context tokens |
+
+### `context.overflow.compacted`
+**Contract:** `compact-result-payload/c`
+**Stability:** evolving
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `original-size` | natural | Messages before compaction |
+| `new-size` | natural | Messages after compaction |
+| `removed-count` | natural | Messages removed |
+| `kept-count` | natural | Messages retained |
+
+### `agent.blocked`
+**Contract:** `reason-payload/c`
+**Stability:** evolving
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `reason` | string | Block reason (e.g., "extension-block") |
+| `hook` | symbol | Hook point that triggered the block |
+
+### `message.injected.drain`
+**Contract:** `injection-count-payload/c`
+**Stability:** evolving
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `count` | natural | Number of injected messages |
+
+### `turn.cancelled`
+**Contract:** `turn-cancelled-payload/c`
+**Stability:** evolving
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `reason` | string | Cancellation reason ("force-shutdown", "cancellation-token", "graceful-shutdown") |
+| `iteration` | natural | Iteration number when cancelled |
+
+### `iteration.decision`
+**Contract:** `iteration-decision-payload/c`
+**Stability:** evolving
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `iteration` | natural | Current iteration number |
+| `termination` | symbol | Termination reason |
+| `consecutive_tools` | natural | Consecutive tool calls |
+| `max_iterations` | natural | Soft iteration limit |
+| `max_iterations_hard` | natural | Hard iteration limit |
+
+### `runtime.error`
+**Contract:** `error-detail-payload/c`
+**Stability:** evolving
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `error` | string | Error message |
+| `iteration` | natural | Iteration number |
+| `maxIterations` | natural | Hard limit |
+
+## Payload Contract Module
+
+All contracts are defined in `util/event-contracts.rkt`. Contracts are applied
+via `assert-payload` in `runtime/iteration.rkt` before event emission.
+
+**Forward-compatible:** Adding new keys to payloads is safe. Removing or
+renaming keys will cause contract assertion failures at runtime.

--- a/runtime/iteration.rkt
+++ b/runtime/iteration.rkt
@@ -19,6 +19,15 @@
 
 (require racket/contract
          racket/list
+         (only-in "../util/event-contracts.rkt"
+                  budget-payload/c
+                  compact-result-payload/c
+                  error-detail-payload/c
+                  injection-count-payload/c
+                  iteration-payload/c
+                  iteration-decision-payload/c
+                  reason-payload/c
+                  turn-cancelled-payload/c)
          racket/set
          racket/path
          json
@@ -141,6 +150,18 @@
   (or (current-inject-topic) injection-event-topic))
 
 ;; ============================================================
+;; Event payload contract assertions (T2, v0.22.8 W3)
+;;
+;; Lightweight inline validation for high-value events consumed
+;; by extensions and TUI. Only applied to top-7 events.
+;; ============================================================
+
+(define (assert-payload topic-name payload ctrct)
+  (unless (ctrct payload)
+    (raise-argument-error topic-name "valid event payload" payload))
+  payload)
+
+;; ============================================================
 ;; Shared helpers (QUAL-01: re-exported from runtime-helpers.rkt)
 ;; ============================================================
 
@@ -171,7 +192,10 @@
      bus
      session-id
      "context.mid-turn-over-budget"
-     (hasheq 'estimated-tokens estimated 'budget budget-threshold 'max-tokens max-tokens)))
+     (assert-payload
+      "context.mid-turn-over-budget"
+      (hasheq 'estimated-tokens estimated 'budget budget-threshold 'max-tokens max-tokens)
+      budget-payload/c)))
   estimated)
 
 ;; ============================================================
@@ -215,16 +239,19 @@
                                           (hasheq 'error (exn-message e)))
                      ;; Compact the context properly
                      (define compact-result (compact-proc ctx))
-                     (emit-session-event! bus
-                                          session-id
-                                          "context.overflow.compacted"
-                                          (hasheq 'original-size
-                                                  (length ctx)
-                                                  'removed-count
-                                                  (compaction-result-removed-count compact-result)
-                                                  'kept-count
-                                                  (length (compaction-result-kept-messages
-                                                           compact-result))))
+                     (emit-session-event!
+                      bus
+                      session-id
+                      "context.overflow.compacted"
+                      (assert-payload
+                       "context.overflow.compacted"
+                       (hasheq 'original-size
+                               (length ctx)
+                               'removed-count
+                               (compaction-result-removed-count compact-result)
+                               'kept-count
+                               (length (compaction-result-kept-messages compact-result)))
+                       compact-result-payload/c))
                      (thunk))]
                   [exn:fail? (lambda (e)
                                ;; Re-raise non-overflow errors
@@ -372,7 +399,9 @@
     (emit-session-event! bus
                          session-id
                          "agent.blocked"
-                         (hasheq 'reason "extension-block" 'hook 'before-agent-start)))
+                         (assert-payload "agent.blocked"
+                                         (hasheq 'reason "extension-block" 'hook 'before-agent-start)
+                                         reason-payload/c)))
   (if (and start-hook-res (eq? (hook-result-action start-hook-res) 'block))
       (make-loop-result '() 'completed (hasheq 'reason "extension-block"))
       (let loop ([ctx context]
@@ -410,244 +439,258 @@
                       (emit-session-event! bus
                                            session-id
                                            "message.injected.drain"
-                                           (hasheq 'count (length injected)))
-                      (append ctx-with-steering injected))))
-              ctx-with-steering))
+                                           (assert-payload "message.injected.drain"
+                                                           (hasheq 'count (length injected))
+                                                           injection-count-payload/c)))
+                    (append ctx-with-steering injected))))
+          ctx-with-steering))
 
-        (cond
-          ;; #1158: Forced shutdown (double Ctrl+C) — immediate abort
-          [(and force-shutdown-check (force-shutdown-check))
-           (emit-session-event! bus
-                                session-id
-                                "turn.cancelled"
-                                (hasheq 'reason "force-shutdown" 'iteration iteration))
-           (make-loop-result (append ctx-with-injected '())
-                             'cancelled
-                             (hasheq 'reason "force-shutdown" 'iteration iteration))]
+      (cond
+        ;; #1158: Forced shutdown (double Ctrl+C) — immediate abort
+        [(and force-shutdown-check (force-shutdown-check))
+         (emit-session-event! bus
+                              session-id
+                              "turn.cancelled"
+                              (assert-payload "turn.cancelled"
+                                              (hasheq 'reason "force-shutdown" 'iteration iteration)
+                                              turn-cancelled-payload/c))
+         (make-loop-result (append ctx-with-injected '())
+                           'cancelled
+                           (hasheq 'reason "force-shutdown" 'iteration iteration))]
 
-          [(and token (cancellation-token-cancelled? token))
-           (emit-session-event! bus
-                                session-id
-                                "turn.cancelled"
-                                (hasheq 'reason "cancellation-token" 'iteration iteration))
-           (make-loop-result (append ctx-with-injected '())
-                             'cancelled
-                             (hasheq 'reason "cancellation-token" 'iteration iteration))]
+        [(and token (cancellation-token-cancelled? token))
+         (emit-session-event!
+          bus
+          session-id
+          "turn.cancelled"
+          (assert-payload "turn.cancelled"
+                          (hasheq 'reason "cancellation-token" 'iteration iteration)
+                          turn-cancelled-payload/c))
+         (make-loop-result (append ctx-with-injected '())
+                           'cancelled
+                           (hasheq 'reason "cancellation-token" 'iteration iteration))]
 
-          ;; #1158: Graceful shutdown — finish after current iteration
-          [(and shutdown-check (shutdown-check))
-           (emit-session-event! bus
-                                session-id
-                                "turn.cancelled"
-                                (hasheq 'reason "graceful-shutdown" 'iteration iteration))
-           (make-loop-result (append ctx-with-injected '())
-                             'completed
-                             (hasheq 'reason "graceful-shutdown" 'iteration iteration))]
+        ;; #1158: Graceful shutdown — finish after current iteration
+        [(and shutdown-check (shutdown-check))
+         (emit-session-event!
+          bus
+          session-id
+          "turn.cancelled"
+          (assert-payload "turn.cancelled"
+                          (hasheq 'reason "graceful-shutdown" 'iteration iteration)
+                          turn-cancelled-payload/c))
+         (make-loop-result (append ctx-with-injected '())
+                           'completed
+                           (hasheq 'reason "graceful-shutdown" 'iteration iteration))]
 
-          [else
-           (define turn-id (generate-id))
+        [else
+         (define turn-id (generate-id))
 
-           ;; Dispatch 'turn-start hook — extensions can amend context or block
-           (define-values (ctx-to-use turn-blocked?)
-             (let-values ([(amended-ctx hook-res)
-                           (maybe-dispatch-hooks ext-reg 'turn-start ctx-with-injected)])
-               (if (and hook-res (eq? (hook-result-action hook-res) 'block))
-                   (values ctx-with-injected #t)
-                   (values amended-ctx #f))))
+         ;; Dispatch 'turn-start hook — extensions can amend context or block
+         (define-values (ctx-to-use turn-blocked?)
+           (let-values ([(amended-ctx hook-res)
+                         (maybe-dispatch-hooks ext-reg 'turn-start ctx-with-injected)])
+             (if (and hook-res (eq? (hook-result-action hook-res) 'block))
+                 (values ctx-with-injected #t)
+                 (values amended-ctx #f))))
 
-           (cond
-             ;; ── Turn blocked by extension ──
-             [turn-blocked?
-              (emit-session-event! bus session-id "turn.blocked" (hasheq 'reason "extension-block"))
-              (make-loop-result '() 'completed (hasheq 'reason "extension-block"))]
+         (cond
+           ;; ── Turn blocked by extension ──
+           [turn-blocked?
+            (emit-session-event! bus session-id "turn.blocked" (hasheq 'reason "extension-block"))
+            (make-loop-result '() 'completed (hasheq 'reason "extension-block"))]
 
-             [else
-              ;; Build assembled context (tiered + hooks) — from turn-orchestrator.rkt
-              (define ctx-final
-                (build-assembled-context ctx-to-use config ext-reg bus session-id iteration))
+           [else
+            ;; Build assembled context (tiered + hooks) — from turn-orchestrator.rkt
+            (define ctx-final
+              (build-assembled-context ctx-to-use config ext-reg bus session-id iteration))
 
-              ;; Run provider turn — from turn-orchestrator.rkt
-              (define result
-                (run-provider-turn ctx-final prov bus reg ext-reg session-id turn-id token config))
+            ;; Run provider turn — from turn-orchestrator.rkt
+            (define result
+              (run-provider-turn ctx-final prov bus reg ext-reg session-id turn-id token config))
 
-              (define termination (loop-result-termination-reason result))
-              (define new-msgs (loop-result-messages result))
+            (define termination (loop-result-termination-reason result))
+            (define new-msgs (loop-result-messages result))
 
-              ;; v0.15.0 Wave 1: emit iteration.decision for trace logging
-              (emit-session-event! bus
-                                   session-id
-                                   "iteration.decision"
-                                   (hasheq 'iteration
-                                           (add1 iteration)
-                                           'termination
-                                           termination
-                                           'consecutive_tools
-                                           consecutive-tool-count
-                                           'max_iterations
-                                           max-iterations
-                                           'max_iterations_hard
-                                           max-iterations-hard))
+            ;; v0.15.0 Wave 1: emit iteration.decision for trace logging
+            (emit-session-event! bus
+                                 session-id
+                                 "iteration.decision"
+                                 (assert-payload "iteration.decision"
+                                                 (hasheq 'iteration
+                                                         (add1 iteration)
+                                                         'termination
+                                                         termination
+                                                         'consecutive_tools
+                                                         consecutive-tool-count
+                                                         'max_iterations
+                                                         max-iterations
+                                                         'max_iterations_hard
+                                                         max-iterations-hard)
+                                                 iteration-decision-payload/c))
 
-              (cond
-                ;; ── Completed: append and return ──
-                [(eq? termination 'completed)
-                 (append-entries! log-path new-msgs)
-                 ;; Dispatch 'turn-end hook
-                 (let-values ([(amended-result after-hook-res)
-                               (maybe-dispatch-hooks ext-reg 'turn-end result)])
-                   (let ([effective-result (if (and after-hook-res
-                                                    (eq? (hook-result-action after-hook-res) 'amend))
-                                               amended-result
-                                               result)])
-                     ;; #662: Drain follow-up queue — if follow-ups exist,
-                     ;; inject as user messages and continue the loop.
-                     ;; #763: Support 'all (drain all) and 'one-at-a-time modes.
-                     (define followup-continued?
-                       (and steering-queue
-                            (let ([followups (if (eq? follow-up-mode 'one-at-a-time)
-                                                 (let ([one (dequeue-followup! steering-queue)])
-                                                   (if one
-                                                       (list one)
-                                                       '()))
-                                                 (dequeue-all-followups! steering-queue))])
-                              (if (null? followups)
-                                  #f
-                                  (let ([followup-msgs (for/list ([fu (in-list followups)])
-                                                         (make-message (generate-id)
-                                                                       #f
-                                                                       'user
-                                                                       'text
-                                                                       (list (make-text-part fu))
-                                                                       (now-seconds)
-                                                                       (hasheq 'source "followup")))])
-                                    (emit-session-event! bus
-                                                         session-id
-                                                         "followup.injected"
-                                                         (hasheq 'count
-                                                                 (length followups)
-                                                                 'mode
-                                                                 (symbol->string follow-up-mode)))
-                                    (append-entries! log-path followup-msgs)
-                                    (loop (append ctx-with-injected new-msgs followup-msgs)
-                                          (add1 iteration)
-                                          0
-                                          (set)
-                                          intent-retry-count
-                                          0
-                                          '()
-                                          explore-count
-                                          implement-count
-                                          0))))))
-                     (define base-result (if followup-continued? effective-result effective-result))
-                     ;; v0.21.3: Intent/stall detection removed.
-                     ;; The prompt is self-correcting by design - no runtime nudging.
-                     base-result))]
-                ;; ── Hard iteration limit reached: append and stop ──
-                [(and (eq? termination 'tool-calls-pending) (>= (add1 iteration) max-iterations-hard))
-                 (append-entries! log-path new-msgs)
-                 (emit-session-event! bus
-                                      session-id
-                                      "runtime.error"
-                                      (hasheq 'error
-                                              "max-iterations-exceeded"
-                                              'iteration
-                                              iteration
-                                              'maxIterations
-                                              max-iterations-hard))
-                 (make-loop-result new-msgs
-                                   'max-iterations-exceeded
-                                   (hash-set (loop-result-metadata result) 'maxIterationsReached #t))]
+            (cond
+              ;; ── Completed: append and return ──
+              [(eq? termination 'completed)
+               (append-entries! log-path new-msgs)
+               ;; Dispatch 'turn-end hook
+               (let-values ([(amended-result after-hook-res)
+                             (maybe-dispatch-hooks ext-reg 'turn-end result)])
+                 (let ([effective-result (if (and after-hook-res
+                                                  (eq? (hook-result-action after-hook-res) 'amend))
+                                             amended-result
+                                             result)])
+                   ;; #662: Drain follow-up queue — if follow-ups exist,
+                   ;; inject as user messages and continue the loop.
+                   ;; #763: Support 'all (drain all) and 'one-at-a-time modes.
+                   (define followup-continued?
+                     (and steering-queue
+                          (let ([followups (if (eq? follow-up-mode 'one-at-a-time)
+                                               (let ([one (dequeue-followup! steering-queue)])
+                                                 (if one
+                                                     (list one)
+                                                     '()))
+                                               (dequeue-all-followups! steering-queue))])
+                            (if (null? followups)
+                                #f
+                                (let ([followup-msgs (for/list ([fu (in-list followups)])
+                                                       (make-message (generate-id)
+                                                                     #f
+                                                                     'user
+                                                                     'text
+                                                                     (list (make-text-part fu))
+                                                                     (now-seconds)
+                                                                     (hasheq 'source "followup")))])
+                                  (emit-session-event! bus
+                                                       session-id
+                                                       "followup.injected"
+                                                       (hasheq 'count
+                                                               (length followups)
+                                                               'mode
+                                                               (symbol->string follow-up-mode)))
+                                  (append-entries! log-path followup-msgs)
+                                  (loop (append ctx-with-injected new-msgs followup-msgs)
+                                        (add1 iteration)
+                                        0
+                                        (set)
+                                        intent-retry-count
+                                        0
+                                        '()
+                                        explore-count
+                                        implement-count
+                                        0))))))
+                   (define base-result (if followup-continued? effective-result effective-result))
+                   ;; v0.21.3: Intent/stall detection removed.
+                   ;; The prompt is self-correcting by design - no runtime nudging.
+                   base-result))]
+              ;; ── Hard iteration limit reached: append and stop ──
+              [(and (eq? termination 'tool-calls-pending) (>= (add1 iteration) max-iterations-hard))
+               (append-entries! log-path new-msgs)
+               (emit-session-event! bus
+                                    session-id
+                                    "runtime.error"
+                                    (assert-payload "runtime.error"
+                                                    (hasheq 'error
+                                                            "max-iterations-exceeded"
+                                                            'iteration
+                                                            iteration
+                                                            'maxIterations
+                                                            max-iterations-hard)
+                                                    error-detail-payload/c))
+               (make-loop-result new-msgs
+                                 'max-iterations-exceeded
+                                 (hash-set (loop-result-metadata result) 'maxIterationsReached #t))]
 
-                ;; ── Soft iteration limit: warn but continue ──
-                [(and (eq? termination 'tool-calls-pending)
-                      (>= (add1 iteration) max-iterations)
-                      (< (add1 iteration) max-iterations-hard))
-                 (append-entries! log-path new-msgs)
-                 (emit-session-event! bus
-                                      session-id
-                                      "iteration.soft-warning"
-                                      (hasheq 'iteration
-                                              (add1 iteration)
-                                              'soft-limit
-                                              max-iterations
-                                              'hard-limit
-                                              max-iterations-hard
-                                              'remaining
-                                              (- max-iterations-hard (add1 iteration))))
-                 (define updated-ctx
-                   (handle-tool-calls-pending new-msgs
-                                              ctx-with-injected
-                                              ext-reg
-                                              reg
-                                              bus
-                                              session-id
-                                              log-path
-                                              token
-                                              config))
-                 ;; v0.14.1: mid-turn token budget check
-                 (check-mid-turn-budget! updated-ctx bus session-id config)
-                 (loop updated-ctx
-                       (add1 iteration)
-                       (add1 consecutive-tool-count)
-                       seen-paths
-                       intent-retry-count
-                       consecutive-error-count
-                       recent-tool-names
-                       explore-count
-                       implement-count
-                       stall-retry-count)]
+              ;; ── Soft iteration limit: warn but continue ──
+              [(and (eq? termination 'tool-calls-pending)
+                    (>= (add1 iteration) max-iterations)
+                    (< (add1 iteration) max-iterations-hard))
+               (append-entries! log-path new-msgs)
+               (emit-session-event! bus
+                                    session-id
+                                    "iteration.soft-warning"
+                                    (hasheq 'iteration
+                                            (add1 iteration)
+                                            'soft-limit
+                                            max-iterations
+                                            'hard-limit
+                                            max-iterations-hard
+                                            'remaining
+                                            (- max-iterations-hard (add1 iteration))))
+               (define updated-ctx
+                 (handle-tool-calls-pending new-msgs
+                                            ctx-with-injected
+                                            ext-reg
+                                            reg
+                                            bus
+                                            session-id
+                                            log-path
+                                            token
+                                            config))
+               ;; v0.14.1: mid-turn token budget check
+               (check-mid-turn-budget! updated-ctx bus session-id config)
+               (loop updated-ctx
+                     (add1 iteration)
+                     (add1 consecutive-tool-count)
+                     seen-paths
+                     intent-retry-count
+                     consecutive-error-count
+                     recent-tool-names
+                     explore-count
+                     implement-count
+                     stall-retry-count)]
 
-                ;; ── Tool calls pending: execute tools and re-run ──
-                [(eq? termination 'tool-calls-pending)
-                 (append-entries! log-path new-msgs)
-                 (define updated-ctx
-                   (handle-tool-calls-pending new-msgs
-                                              ctx-with-injected
-                                              ext-reg
-                                              reg
-                                              bus
-                                              session-id
-                                              log-path
-                                              token
-                                              config))
-                 ;; v0.21.3: Exploration steering removed. Compute counters without steering.
-                 (define current-tool-calls (extract-tool-calls-from-messages new-msgs))
-                 (define-values (new-seen-paths should-increment?)
-                   (update-seen-paths current-tool-calls seen-paths))
-                 (define effective-tool-count
-                   (if should-increment?
-                       (add1 consecutive-tool-count)
-                       consecutive-tool-count))
-                 (define new-explore-count
-                   (+ explore-count
-                      (for/sum ([tc (extract-tool-calls-from-messages new-msgs)])
-                               (if (member (tool-call-name tc) '("read" "grep" "find" "ls")) 1 0))))
-                 (define new-implement-count
-                   (+ implement-count
-                      (for/sum ([tc (extract-tool-calls-from-messages new-msgs)])
-                               (if (member (tool-call-name tc) '("edit" "write")) 1 0))))
-                 (define new-error-count
-                   (+ consecutive-error-count
-                      (for/sum
-                       ([tr (filter tool-result-part? (apply append (map message-content new-msgs)))])
-                       (if (tool-result-part-is-error? tr) 1 0))))
-                 (define new-recent-tools
-                   (take-at-most (append recent-tool-names
-                                         (map tool-call-name
-                                              (extract-tool-calls-from-messages new-msgs)))
-                                 20))
-                 (loop updated-ctx
-                       (add1 iteration)
-                       effective-tool-count
-                       new-seen-paths
-                       intent-retry-count
-                       new-error-count
-                       new-recent-tools
-                       new-explore-count
-                       new-implement-count
-                       stall-retry-count)]
+              ;; ── Tool calls pending: execute tools and re-run ──
+              [(eq? termination 'tool-calls-pending)
+               (append-entries! log-path new-msgs)
+               (define updated-ctx
+                 (handle-tool-calls-pending new-msgs
+                                            ctx-with-injected
+                                            ext-reg
+                                            reg
+                                            bus
+                                            session-id
+                                            log-path
+                                            token
+                                            config))
+               ;; v0.21.3: Exploration steering removed. Compute counters without steering.
+               (define current-tool-calls (extract-tool-calls-from-messages new-msgs))
+               (define-values (new-seen-paths should-increment?)
+                 (update-seen-paths current-tool-calls seen-paths))
+               (define effective-tool-count
+                 (if should-increment?
+                     (add1 consecutive-tool-count)
+                     consecutive-tool-count))
+               (define new-explore-count
+                 (+ explore-count
+                    (for/sum ([tc (extract-tool-calls-from-messages new-msgs)])
+                             (if (member (tool-call-name tc) '("read" "grep" "find" "ls")) 1 0))))
+               (define new-implement-count
+                 (+ implement-count
+                    (for/sum ([tc (extract-tool-calls-from-messages new-msgs)])
+                             (if (member (tool-call-name tc) '("edit" "write")) 1 0))))
+               (define new-error-count
+                 (+ consecutive-error-count
+                    (for/sum
+                     ([tr (filter tool-result-part? (apply append (map message-content new-msgs)))])
+                     (if (tool-result-part-is-error? tr) 1 0))))
+               (define new-recent-tools
+                 (take-at-most (append recent-tool-names
+                                       (map tool-call-name
+                                            (extract-tool-calls-from-messages new-msgs)))
+                               20))
+               (loop updated-ctx
+                     (add1 iteration)
+                     effective-tool-count
+                     new-seen-paths
+                     intent-retry-count
+                     new-error-count
+                     new-recent-tools
+                     new-explore-count
+                     new-implement-count
+                     stall-retry-count)]
 
-                ;; ── Unknown termination: append and return ──
-                [else
-                 (append-entries! log-path new-msgs)
-                 result])])]))))
+              ;; ── Unknown termination: append and return ──
+              [else
+               (append-entries! log-path new-msgs)
+               result])])])))

--- a/tests/test-event-payload-contracts.rkt
+++ b/tests/test-event-payload-contracts.rkt
@@ -1,0 +1,114 @@
+#lang racket
+
+;; tests/test-event-payload-contracts.rkt — Event payload contract validation
+;; v0.22.8 W3 (T3)
+;;
+;; Golden payloads — version these as the event protocol evolves.
+;; Adding new keys is OK. Removing or renaming keys will fail tests.
+
+(require rackunit
+         rackunit/text-ui
+         "../util/event-contracts.rkt")
+
+(define event-contract-tests
+  (test-suite "Event Payload Contracts (v0.22.8 W3)"
+
+    ;; -------------------------------------------------------
+    ;; reason-payload/c
+    ;; -------------------------------------------------------
+    (test-case "reason-payload/c accepts valid payloads"
+      (check-true (reason-payload/c (hasheq 'reason "extension-block")))
+      (check-true (reason-payload/c (hasheq 'reason "extension-block" 'hook 'before-agent-start)))
+      (check-true (reason-payload/c (hasheq 'reason "force-shutdown" 'iteration 3))))
+
+    (test-case "reason-payload/c rejects missing reason"
+      (check-false (reason-payload/c (hasheq 'foo "bar")))
+      (check-false (reason-payload/c (hasheq))))
+
+    ;; -------------------------------------------------------
+    ;; session-id-payload/c
+    ;; -------------------------------------------------------
+    (test-case "session-id-payload/c accepts valid payloads"
+      (check-true (session-id-payload/c (hasheq 'session-id "s1")))
+      (check-true (session-id-payload/c (hasheq 'session-id "s1" 'extra "data"))))
+
+    (test-case "session-id-payload/c rejects missing session-id"
+      (check-false (session-id-payload/c (hasheq 'id "s1"))))
+
+    ;; -------------------------------------------------------
+    ;; iteration-payload/c
+    ;; -------------------------------------------------------
+    (test-case "iteration-payload/c accepts valid payloads"
+      (check-true (iteration-payload/c (hasheq 'iteration 0)))
+      (check-true (iteration-payload/c (hasheq 'iteration 5 'extra 'data))))
+
+    (test-case "iteration-payload/c rejects missing iteration"
+      (check-false (iteration-payload/c (hasheq 'count 5))))
+
+    ;; -------------------------------------------------------
+    ;; budget-payload/c
+    ;; -------------------------------------------------------
+    (test-case "budget-payload/c accepts valid payloads"
+      (check-true (budget-payload/c (hasheq 'estimated-tokens 5000 'budget 8000 'max-tokens 128000))))
+
+    (test-case "budget-payload/c rejects missing keys"
+      (check-false (budget-payload/c (hasheq 'estimated-tokens 5000 'budget 8000)))
+      (check-false (budget-payload/c (hasheq 'budget 8000 'max-tokens 128000)))
+      (check-false (budget-payload/c (hasheq 'estimated-tokens 5000))))
+
+    ;; -------------------------------------------------------
+    ;; compact-result-payload/c
+    ;; -------------------------------------------------------
+    (test-case "compact-result-payload/c accepts valid payloads"
+      (check-true (compact-result-payload/c (hasheq 'original-size 100 'new-size 50)))
+      (check-true (compact-result-payload/c
+                   (hasheq 'original-size 100 'new-size 50 'removed-count 50))))
+
+    (test-case "compact-result-payload/c rejects missing keys"
+      (check-false (compact-result-payload/c (hasheq 'original-size 100)))
+      (check-false (compact-result-payload/c (hasheq 'new-size 50))))
+
+    ;; -------------------------------------------------------
+    ;; error-detail-payload/c
+    ;; -------------------------------------------------------
+    (test-case "error-detail-payload/c accepts valid payloads"
+      (check-true (error-detail-payload/c (hasheq 'error "something went wrong")))
+      (check-true (error-detail-payload/c (hasheq 'error "overflow" 'iteration 5))))
+
+    (test-case "error-detail-payload/c rejects missing error key"
+      (check-false (error-detail-payload/c (hasheq 'message "not error key"))))
+
+    ;; -------------------------------------------------------
+    ;; injection-count-payload/c
+    ;; -------------------------------------------------------
+    (test-case "injection-count-payload/c accepts valid payloads"
+      (check-true (injection-count-payload/c (hasheq 'count 3)))
+      (check-true (injection-count-payload/c (hasheq 'count 0 'source "drain"))))
+
+    (test-case "injection-count-payload/c rejects missing count"
+      (check-false (injection-count-payload/c (hasheq 'injected 3))))
+
+    ;; -------------------------------------------------------
+    ;; turn-cancelled-payload/c
+    ;; -------------------------------------------------------
+    (test-case "turn-cancelled-payload/c accepts valid payloads"
+      (check-true (turn-cancelled-payload/c (hasheq 'reason "force-shutdown" 'iteration 3)))
+      (check-true (turn-cancelled-payload/c (hasheq 'reason "cancellation-token" 'iteration 1))))
+
+    (test-case "turn-cancelled-payload/c rejects missing keys"
+      (check-false (turn-cancelled-payload/c (hasheq 'reason "force-shutdown")))
+      (check-false (turn-cancelled-payload/c (hasheq 'iteration 3))))
+
+    ;; -------------------------------------------------------
+    ;; iteration-decision-payload/c
+    ;; -------------------------------------------------------
+    (test-case "iteration-decision-payload/c accepts valid payloads"
+      (check-true (iteration-decision-payload/c (hasheq 'iteration 1 'termination 'completed)))
+      (check-true (iteration-decision-payload/c
+                   (hasheq 'iteration 5 'termination 'tool-calls-pending 'extra 'data))))
+
+    (test-case "iteration-decision-payload/c rejects missing keys"
+      (check-false (iteration-decision-payload/c (hasheq 'iteration 1)))
+      (check-false (iteration-decision-payload/c (hasheq 'termination 'completed))))))
+
+(run-tests event-contract-tests)

--- a/util/event-contracts.rkt
+++ b/util/event-contracts.rkt
@@ -1,0 +1,70 @@
+#lang racket/base
+
+;; util/event-contracts.rkt — Reusable contracts for structured event payloads
+;;
+;; These catch payload shape regressions at emission time.
+;; Priority: events consumed by extensions and TUI subscribers.
+;;
+;; Policy: Adding new keys to payloads is OK (forward-compatible).
+;; Removing or renaming keys will cause contract failures.
+;; Only the top events consumed by extensions need contracts —
+;; internal-only events remain uncontracted for performance.
+
+(require racket/contract)
+
+(provide reason-payload/c
+         session-id-payload/c
+         iteration-payload/c
+         budget-payload/c
+         compact-result-payload/c
+         error-detail-payload/c
+         injection-count-payload/c
+         turn-cancelled-payload/c
+         iteration-decision-payload/c)
+
+;; Simple reason payloads: (hasheq 'reason String ...)
+(define reason-payload/c
+  (and/c hash? (hash/c symbol? any/c #:immutable #t) (lambda (h) (hash-has-key? h 'reason))))
+
+;; Session ID payloads: (hasheq 'session-id String ...)
+(define session-id-payload/c
+  (and/c hash? (hash/c symbol? any/c #:immutable #t) (lambda (h) (hash-has-key? h 'session-id))))
+
+;; Iteration tracking: (hasheq 'iteration Natural ...)
+(define iteration-payload/c
+  (and/c hash? (hash/c symbol? any/c #:immutable #t) (lambda (h) (hash-has-key? h 'iteration))))
+
+;; Budget check: (hasheq 'estimated-tokens Natural 'budget Natural 'max-tokens Natural)
+(define budget-payload/c
+  (and/c hash?
+         (hash/c symbol? any/c #:immutable #t)
+         (lambda (h)
+           (and (hash-has-key? h 'estimated-tokens)
+                (hash-has-key? h 'budget)
+                (hash-has-key? h 'max-tokens)))))
+
+;; Compact result: (hasheq 'original-size Natural 'new-size Natural ...)
+(define compact-result-payload/c
+  (and/c hash?
+         (hash/c symbol? any/c #:immutable #t)
+         (lambda (h) (and (hash-has-key? h 'original-size) (hash-has-key? h 'new-size)))))
+
+;; Error detail: (hasheq 'error String ...)
+(define error-detail-payload/c
+  (and/c hash? (hash/c symbol? any/c #:immutable #t) (lambda (h) (hash-has-key? h 'error))))
+
+;; Injection count: (hasheq 'count Natural ...)
+(define injection-count-payload/c
+  (and/c hash? (hash/c symbol? any/c #:immutable #t) (lambda (h) (hash-has-key? h 'count))))
+
+;; Turn cancelled: (hasheq 'reason String 'iteration Natural ...)
+(define turn-cancelled-payload/c
+  (and/c hash?
+         (hash/c symbol? any/c #:immutable #t)
+         (lambda (h) (and (hash-has-key? h 'reason) (hash-has-key? h 'iteration)))))
+
+;; Iteration decision: (hasheq 'iteration Natural 'termination Any ...)
+(define iteration-decision-payload/c
+  (and/c hash?
+         (hash/c symbol? any/c #:immutable #t)
+         (lambda (h) (and (hash-has-key? h 'iteration) (hash-has-key? h 'termination)))))


### PR DESCRIPTION
Addresses #2368.

feat: event schema contracts + payload validation (#2368)

W3 of v0.22.8: Created util/event-contracts.rkt with 9 payload contracts.
Applied assert-payload to top-7 events in iteration.rkt.
18/18 contract tests pass. Updated event-taxonomy.md.

Closes #2368, #2369, #2370, #2371.