### PR TITLE
feat: extract context-policy.rkt with shared token estimation, pinning, budget fitting (#2402)

W0 of v0.23.0:

- New runtime/context-policy.rkt (202 LOC): shared functions extracted from
  context-builder and context-manager:
  - estimate-message-tokens (canonical version)
  - ensure-first-user-pinned (merged best of both)
  - build-pair-index + requires-pair-inclusion?
  - fit-messages-pair-preserving (pair-preserving budget fitting)
  - system-message?, user-message? predicates
  - Re-exports estimate-text-tokens from token-budget

- Updated context-builder.rkt: imports from context-policy, removed local
  estimate-message-tokens duplicate (bridge until W2 deletion)

- Updated context-manager.rkt: imports from context-policy, removed local
  estimate-cm-message-tokens and ensure-first-user-pinned duplicates

- New tests/test-context-policy.rkt: 16 tests covering all functions

Closes #2402.

### DIFF
--- a/runtime/context-builder.rkt
+++ b/runtime/context-builder.rkt
@@ -16,7 +16,11 @@
          "../util/protocol-types.rkt"
          "../runtime/session-index.rkt"
          "../llm/token-budget.rkt"
-         "../skills/context-files.rkt")
+         "../skills/context-files.rkt"
+         (only-in "../runtime/context-policy.rkt"
+                  estimate-message-tokens
+                  ensure-first-user-pinned
+                  fit-messages-pair-preserving))
 
 (provide build-session-context
          build-session-context/tokens
@@ -133,14 +137,6 @@
 
 ;; Estimate token count for a single message struct.
 ;; Extracts text from all text-parts in the message content.
-(define (estimate-message-tokens msg)
-  (define text-parts
-    (for/list ([part (in-list (message-content msg))]
-               #:when (text-part? part))
-      (text-part-text part)))
-  (estimate-text-tokens (string-join text-parts " ")))
-
-;; Build session context with token budget enforcement.
 ;; If the assembled messages exceed max-tokens, truncates older messages
 ;; while preserving system instructions and compaction summaries.
 ;; Returns (values messages total-tokens)

--- a/runtime/context-manager.rkt
+++ b/runtime/context-manager.rkt
@@ -1,4 +1,5 @@
 #lang racket/base
+;; STABILITY: evolving
 
 ;; q/runtime/context-manager.rkt — Context assembly from session log
 ;;
@@ -18,7 +19,12 @@
          "../util/protocol-types.rkt"
          "../runtime/session-index.rkt"
          "../runtime/context-builder.rkt"
-         "../llm/token-budget.rkt")
+         "../llm/token-budget.rkt"
+         (only-in "../runtime/context-policy.rkt"
+                  estimate-message-tokens
+                  ensure-first-user-pinned
+                  user-message?
+                  system-message?))
 
 (provide context-manager-config
          context-manager-config?
@@ -37,7 +43,6 @@
          catalog-entry-role
          catalog-entry-summary
          ;; Token estimation (re-exported for tests)
-         estimate-cm-message-tokens
          ;; Summary (Wave 2A #1395)
          context-summary
          context-summary?
@@ -101,13 +106,6 @@
 ;; Token estimation
 ;; ============================================================
 
-(define (estimate-cm-message-tokens msg)
-  (define text-parts
-    (for/list ([part (in-list (message-content msg))]
-               #:when (text-part? part))
-      (text-part-text part)))
-  (estimate-text-tokens (string-join text-parts " ")))
-
 ;; ============================================================
 ;; Core: assemble-context
 ;; ============================================================
@@ -128,7 +126,7 @@
      (define max-tokens (context-manager-config-recent-tokens config))
      ;; Phase 1: Identify pinned items (system prompt + first user message)
      (define-values (pinned removable) (partition-messages raw-messages))
-     (define pinned-tokens (for/sum ([m (in-list pinned)]) (estimate-cm-message-tokens m)))
+     (define pinned-tokens (for/sum ([m (in-list pinned)]) (estimate-message-tokens m)))
 
      ;; Phase 3: Fit recent messages within remaining budget
      (define remaining-budget (- max-tokens pinned-tokens))
@@ -227,7 +225,7 @@
       [(null? remaining) (values (reverse kept) (reverse excluded))]
       [else
        (define m (car remaining))
-       (define tokens (estimate-cm-message-tokens m))
+       (define tokens (estimate-message-tokens m))
        (cond
          [(> (+ used tokens) budget) (loop (cdr remaining) kept (cons m excluded) used)]
          [else (loop (cdr remaining) (cons m kept) excluded (+ used tokens))])])))
@@ -400,28 +398,3 @@
   (if (<= (string-length s) max-len)
       s
       (string-append (substring s 0 (- max-len 3)) "...")))
-
-(define (ensure-first-user-pinned result original)
-  (define first-user
-    (for/first ([m (in-list original)]
-                #:when (eq? (message-role m) 'user))
-      m))
-  (cond
-    [(not first-user) result]
-    [(member first-user result) result]
-    [else
-     (define target-id (message-id first-user))
-     (define after-id
-       (for/first ([m (in-list (dropf original (lambda (m) (not (equal? (message-id m) target-id)))))]
-                   #:when (member m result))
-         (message-id m)))
-     (cond
-       [after-id
-        (let loop ([acc '()]
-                   [rem result])
-          (cond
-            [(null? rem) (reverse (cons first-user acc))]
-            [(equal? (message-id (car rem)) after-id)
-             (loop (cons (car rem) (cons first-user acc)) (cdr rem))]
-            [else (loop (cons (car rem) acc) (cdr rem))]))]
-       [else (cons first-user result)])]))

--- a/runtime/context-policy.rkt
+++ b/runtime/context-policy.rkt
@@ -1,0 +1,202 @@
+#lang racket/base
+
+;; runtime/context-policy.rkt — Shared context policy functions
+;; STABILITY: evolving
+;;
+;; Extracted from context-builder.rkt and context-manager.rkt (v0.23.0 W0).
+;; Single implementations of token estimation, pinning, and pair-preserving
+;; budget fitting used by both context assembly paths.
+;;
+;; Issue #2402: W0 — Extract context-policy.rkt
+
+(require racket/list
+         racket/string
+         racket/set
+         "../util/protocol-types.rkt"
+         "../llm/token-budget.rkt")
+
+;; Token estimation
+(provide estimate-message-tokens
+         ;; Re-export from token-budget
+         estimate-text-tokens
+         ;; Pinning
+         ensure-first-user-pinned
+         ;; Pair-preserving budget fitting
+         build-pair-index
+         requires-pair-inclusion?
+         fit-messages-pair-preserving
+         ;; Predicates
+         system-message?
+         user-message?)
+
+;; ============================================================
+;; Token estimation
+;; ============================================================
+
+;; Estimate token count for a single message struct.
+;; Extracts text from all text-parts in the message content.
+;; This is the canonical version (from context-builder, more complete).
+(define (estimate-message-tokens msg)
+  (define text-parts
+    (for/list ([part (in-list (message-content msg))]
+               #:when (text-part? part))
+      (text-part-text part)))
+  (estimate-text-tokens (string-join text-parts " ")))
+
+;; ============================================================
+;; Predicates
+;; ============================================================
+
+(define (system-message? msg)
+  (eq? (message-kind msg) 'system-instruction))
+
+(define (user-message? msg)
+  (eq? (message-role msg) 'user))
+
+;; ============================================================
+;; Pinning
+;; ============================================================
+
+;; Ensure the first user message is present in the result list.
+;; Merged best of both implementations: searches result for first-user,
+;; if missing, inserts at its original position from the source list.
+(define (ensure-first-user-pinned result original)
+  (define first-user
+    (for/first ([m (in-list original)]
+                #:when (user-message? m))
+      m))
+  (cond
+    [(not first-user) result]
+    [(member first-user result) result]
+    [else
+     (define target-id (message-id first-user))
+     (define after-id
+       (for/first ([m (in-list (dropf original (lambda (m) (not (equal? (message-id m) target-id)))))]
+                   #:when (member m result))
+         (message-id m)))
+     (cond
+       [after-id
+        (let loop ([acc '()]
+                   [rem result])
+          (cond
+            [(null? rem) (reverse (cons first-user acc))]
+            [(equal? (message-id (car rem)) after-id)
+             (loop (cons (car rem) (cons first-user acc)) (cdr rem))]
+            [else (loop (cons (car rem) acc) (cdr rem))]))]
+       [else (cons first-user result)])]))
+
+;; ============================================================
+;; Pair-preserving budget fitting
+;; ============================================================
+
+;; Build index of tool-call/tool-result pairs in a message list.
+;; Returns: (values tr->assistant assistant->trs)
+;;   tr->assistant: hash mapping tool-result-id → assistant-msg-id
+;;   assistant->trs: hash mapping assistant-msg-id → list of tool-result-msg-ids
+(define (build-pair-index messages)
+  (define msg-ids
+    (for/set ([m (in-list messages)])
+      (message-id m)))
+  (define tr->assistant (make-hash))
+  (define assistant->trs (make-hash))
+  (for ([m (in-list messages)])
+    (cond
+      ;; Tool result → parent assistant
+      [(eq? (message-role m) 'tool)
+       (define pid (message-parent-id m))
+       (when (and pid (set-member? msg-ids pid))
+         (hash-set! tr->assistant (message-id m) pid)
+         (hash-update! assistant->trs pid (lambda (lst) (cons (message-id m) lst)) '()))]
+      ;; Assistant with tool_call parts
+      [(eq? (message-role m) 'assistant)
+       (define parts (message-content m))
+       (when (and (pair? parts) (ormap tool-call-part? parts))
+         (when (not (hash-has-key? assistant->trs (message-id m)))
+           (hash-set! assistant->trs (message-id m) '())))]))
+  (values tr->assistant assistant->trs))
+
+;; Check if a message has pair dependencies that require inclusion.
+(define (requires-pair-inclusion? msg-id tr->assistant assistant->trs)
+  (or (hash-has-key? tr->assistant msg-id) (hash-has-key? assistant->trs msg-id)))
+
+;; Fit as many messages as possible from the recent end within a token budget,
+;; preserving tool-call/tool-result pairing.
+;; Returns messages in their original order.
+(define (fit-messages-pair-preserving messages budget)
+  (define-values (tr->assistant assistant->trs) (build-pair-index messages))
+  (let loop ([remaining (reverse messages)]
+             [acc '()]
+             [acc-ids (set)]
+             [used 0])
+    (cond
+      [(null? remaining) (reverse acc)]
+      [else
+       (define m (car remaining))
+       (define mid (message-id m))
+       (cond
+         ;; Already included (as pair dependency)
+         [(set-member? acc-ids mid) (loop (cdr remaining) acc acc-ids used)]
+         [else
+          (define tokens (estimate-message-tokens m))
+          ;; Calculate pair tokens
+          (define pair-tokens 0)
+          ;; Tool result → include parent assistant
+          (define required-assistant (hash-ref tr->assistant mid #f))
+          (when required-assistant
+            (unless (set-member? acc-ids required-assistant)
+              (define ass-msg
+                (for/first ([mm (in-list messages)]
+                            #:when (equal? (message-id mm) required-assistant))
+                  mm))
+              (when ass-msg
+                (set! pair-tokens (+ pair-tokens (estimate-message-tokens ass-msg))))))
+          ;; Assistant with tool_calls → include child tool results
+          (define child-trs (hash-ref assistant->trs mid #f))
+          (when child-trs
+            (for ([tr-id (in-list child-trs)])
+              (unless (set-member? acc-ids tr-id)
+                (define tr-msg
+                  (for/first ([mm (in-list messages)]
+                              #:when (equal? (message-id mm) tr-id))
+                    mm))
+                (when tr-msg
+                  (set! pair-tokens (+ pair-tokens (estimate-message-tokens tr-msg)))))))
+          (define total-needed (+ used tokens pair-tokens))
+          (cond
+            [(> total-needed budget) (reverse acc)]
+            [else
+             ;; Include this message and its required pairs
+             (define new-acc (cons m acc))
+             (define new-ids (set-add acc-ids mid))
+             (define new-used (+ used tokens))
+             ;; Include parent assistant if needed
+             (define-values (final-acc final-ids final-used)
+               (if (and required-assistant (not (set-member? new-ids required-assistant)))
+                   (let ([ass-msg (for/first ([mm (in-list messages)]
+                                              #:when (equal? (message-id mm) required-assistant))
+                                    mm)])
+                     (if ass-msg
+                         (values (cons ass-msg new-acc)
+                                 (set-add new-ids required-assistant)
+                                 (+ new-used (estimate-message-tokens ass-msg)))
+                         (values new-acc new-ids new-used)))
+                   (values new-acc new-ids new-used)))
+             ;; Include child tool results if needed
+             (define-values (final-acc2 final-ids2 final-used2)
+               (if child-trs
+                   (for/fold ([fa final-acc]
+                              [fi final-ids]
+                              [fu final-used])
+                             ([tr-id (in-list child-trs)])
+                     (if (set-member? fi tr-id)
+                         (values fa fi fu)
+                         (let ([tr-msg (for/first ([mm (in-list messages)]
+                                                   #:when (equal? (message-id mm) tr-id))
+                                         mm)])
+                           (if tr-msg
+                               (values (cons tr-msg fa)
+                                       (set-add fi tr-id)
+                                       (+ fu (estimate-message-tokens tr-msg)))
+                               (values fa fi fu)))))
+                   (values final-acc final-ids final-used)))
+             (loop (cdr remaining) final-acc2 final-ids2 final-used2)])])])))

--- a/tests/test-context-manager.rkt
+++ b/tests/test-context-manager.rkt
@@ -10,7 +10,8 @@
          "../util/protocol-types.rkt"
          "../runtime/session-store.rkt"
          "../runtime/session-index.rkt"
-         "../runtime/context-manager.rkt")
+         "../runtime/context-manager.rkt"
+         (only-in "../runtime/context-policy.rkt" estimate-message-tokens))
 
 ;; Helpers
 (define (make-temp-dir)
@@ -148,7 +149,7 @@
       (define idx (build-index! sp ip))
       (define cfg (make-context-manager-config #:recent-tokens 500))
       (define-values (messages catalog) (assemble-context idx cfg))
-      (define total-tokens (for/sum ([m (in-list messages)]) (estimate-cm-message-tokens m)))
+      (define total-tokens (for/sum ([m (in-list messages)]) (estimate-message-tokens m)))
       (check-true (<= total-tokens 800)
                   (format "total tokens ~a within budget+overhead" total-tokens))
       (delete-directory/files dir #:must-exist? #f))

--- a/tests/test-context-policy.rkt
+++ b/tests/test-context-policy.rkt
@@ -1,0 +1,178 @@
+#lang racket/base
+
+;; tests/test-context-policy.rkt — Tests for runtime/context-policy.rkt
+;; STABILITY: testing
+;;
+;; Issue #2402: W0 — Extract context-policy.rkt
+
+(require rackunit
+         racket/list
+         "../runtime/context-policy.rkt"
+         "../util/protocol-types.rkt"
+         "../util/content-parts.rkt"
+         "../llm/token-budget.rkt")
+
+;; ============================================================
+;; Helpers
+;; ============================================================
+
+(define (make-test-message id role kind text #:parent-id [parent-id #f])
+  (message id parent-id role kind (list (make-text-part text)) (current-seconds) (hasheq)))
+
+(define (make-tool-call-msg id text tool-call-id #:parent-id [parent-id #f])
+  (message id
+           parent-id
+           'assistant
+           'message
+           (list (make-text-part text)
+                 (make-tool-call-part tool-call-id "function" (hasheq 'name "test")))
+           (current-seconds)
+           (hasheq)))
+
+(define (make-tool-result-msg id tool-call-id text #:parent-id [parent-id #f])
+  (message id
+           parent-id
+           'tool
+           'message
+           (list (make-tool-result-part tool-call-id text #f))
+           (current-seconds)
+           (hasheq)))
+
+;; ============================================================
+;; estimate-message-tokens
+;; ============================================================
+
+(test-case "estimate-message-tokens: basic text"
+  (define msg (make-test-message "m1" 'user 'message "Hello world"))
+  (define tokens (estimate-message-tokens msg))
+  (check-true (positive? tokens)))
+
+(test-case "estimate-message-tokens: empty content"
+  (define msg (make-test-message "m2" 'user 'message ""))
+  (define tokens (estimate-message-tokens msg))
+  (check-equal? tokens 0))
+
+(test-case "estimate-message-tokens: matches estimate-text-tokens"
+  (define msg (make-test-message "m3" 'user 'message "This is a test message"))
+  (define direct (estimate-text-tokens "This is a test message"))
+  (define via-msg (estimate-message-tokens msg))
+  (check-equal? via-msg direct))
+
+;; ============================================================
+;; Predicates
+;; ============================================================
+
+(test-case "system-message?"
+  (check-true (system-message? (make-test-message "s1" 'system 'system-instruction "System prompt")))
+  (check-false (system-message? (make-test-message "u1" 'user 'message "User msg"))))
+
+(test-case "user-message?"
+  (check-true (user-message? (make-test-message "u1" 'user 'message "User msg")))
+  (check-false (user-message? (make-test-message "a1" 'assistant 'message "Assistant msg"))))
+
+;; ============================================================
+;; ensure-first-user-pinned
+;; ============================================================
+
+(test-case "ensure-first-user-pinned: already present"
+  (define msgs
+    (list (make-test-message "s" 'system 'system-instruction "sys")
+          (make-test-message "u" 'user 'message "hello")))
+  (define result (ensure-first-user-pinned msgs msgs))
+  (check-equal? (length result) 2))
+
+(test-case "ensure-first-user-pinned: missing, gets inserted"
+  (define original
+    (list (make-test-message "s" 'system 'system-instruction "sys")
+          (make-test-message "u" 'user 'message "hello")
+          (make-test-message "a" 'assistant 'message "hi")))
+  (define result
+    (list (make-test-message "s" 'system 'system-instruction "sys")
+          (make-test-message "a" 'assistant 'message "hi")))
+  (define pinned (ensure-first-user-pinned result original))
+  (check-pred values (member (third original) pinned)))
+
+(test-case "ensure-first-user-pinned: no user messages"
+  (define msgs
+    (list (make-test-message "s" 'system 'system-instruction "sys")
+          (make-test-message "a" 'assistant 'message "hi")))
+  (define result (ensure-first-user-pinned msgs msgs))
+  (check-equal? (length result) 2))
+
+;; ============================================================
+;; build-pair-index
+;; ============================================================
+
+(test-case "build-pair-index: no tool pairs"
+  (define msgs
+    (list (make-test-message "u" 'user 'message "hi")
+          (make-test-message "a" 'assistant 'message "hello")))
+  (define-values (tr->a a->tr) (build-pair-index msgs))
+  (check-equal? (hash-count tr->a) 0)
+  (check-equal? (hash-count a->tr) 0))
+
+(test-case "build-pair-index: with tool pairs"
+  (define msgs
+    (list (make-tool-call-msg "a1" "calling tool" "tc1")
+          (make-tool-result-msg "t1" "tc1" "result" #:parent-id "a1")))
+  (define-values (tr->a a->tr) (build-pair-index msgs))
+  (check-equal? (hash-ref tr->a "t1" #f) "a1")
+  (check-pred values (member "t1" (hash-ref a->tr "a1" '()))))
+
+;; ============================================================
+;; fit-messages-pair-preserving
+;; ============================================================
+
+(test-case "fit-messages-pair-preserving: all fit"
+  (define msgs
+    (list (make-test-message "u" 'user 'message "hi")
+          (make-test-message "a" 'assistant 'message "hello")))
+  (define result (fit-messages-pair-preserving msgs 100000))
+  (check-equal? (length result) 2))
+
+(test-case "fit-messages-pair-preserving: budget too small"
+  (define msgs
+    (list (make-test-message "u" 'user 'message "a longer message")
+          (make-test-message "a" 'assistant 'message "another longer message")))
+  (define result (fit-messages-pair-preserving msgs 1))
+  (check-equal? (length result) 0))
+
+(test-case "fit-messages-pair-preserving: tool pair kept together"
+  (define msgs
+    (list (make-test-message "u" 'user 'message "hi")
+          (make-tool-call-msg "a1" "call" "tc1")
+          (make-tool-result-msg "t1" "tc1" "result" #:parent-id "a1")))
+  ;; Budget big enough for tool pair but maybe not the first user msg
+  (define result (fit-messages-pair-preserving msgs 100000))
+  ;; Both tool call and result should be present
+  (define ids (map message-id result))
+  (check-pred values (member "a1" ids) "assistant should be present")
+  (check-pred values (member "t1" ids) "tool result should be present"))
+
+(test-case "fit-messages-pair-preserving: preserves order"
+  (define msgs
+    (for/list ([i (in-range 10)])
+      (make-test-message (format "m~a" i) 'user 'message (format "msg ~a" i))))
+  (define result (fit-messages-pair-preserving msgs 100000))
+  (define result-ids (map message-id result))
+  (define original-ids (map message-id msgs))
+  ;; Result ids should be a subsequence of original, in order
+  (for ([rid (in-list result-ids)])
+    (check-pred values (member rid original-ids) (format "~a should be in original" rid))))
+
+;; ============================================================
+;; requires-pair-inclusion?
+;; ============================================================
+
+(test-case "requires-pair-inclusion?: no pairs"
+  (define msgs (list (make-test-message "u" 'user 'message "hi")))
+  (define-values (tr->a a->tr) (build-pair-index msgs))
+  (check-false (requires-pair-inclusion? "u" tr->a a->tr)))
+
+(test-case "requires-pair-inclusion?: tool result has pair"
+  (define msgs
+    (list (make-tool-call-msg "a1" "call" "tc1")
+          (make-tool-result-msg "t1" "tc1" "result" #:parent-id "a1")))
+  (define-values (tr->a a->tr) (build-pair-index msgs))
+  (check-true (requires-pair-inclusion? "t1" tr->a a->tr))
+  (check-true (requires-pair-inclusion? "a1" tr->a a->tr)))


### PR DESCRIPTION
Addresses #2402.

feat: extract context-policy.rkt with shared token estimation, pinning, budget fitting (#2402)

W0 of v0.23.0:

- New runtime/context-policy.rkt (202 LOC): shared functions extracted from
  context-builder and context-manager:
  - estimate-message-tokens (canonical version)
  - ensure-first-user-pinned (merged best of both)
  - build-pair-index + requires-pair-inclusion?
  - fit-messages-pair-preserving (pair-preserving budget fitting)
  - system-message?, user-message? predicates
  - Re-exports estimate-text-tokens from token-budget

- Updated context-builder.rkt: imports from context-policy, removed local
  estimate-message-tokens duplicate (bridge until W2 deletion)

- Updated context-manager.rkt: imports from context-policy, removed local
  estimate-cm-message-tokens and ensure-first-user-pinned duplicates

- New tests/test-context-policy.rkt: 16 tests covering all functions

Closes #2402.