### PR TITLE
feat: wire LLM summarization in context-manager via compactor llm-summarize (#2411)

W1 of v0.23.0:

- context-manager.rkt: generate-context-summary now calls compactor's
  llm-summarize when a real provider is given (checked via provider?),
  falls back to simple-summary-text otherwise
- Added imports: llm-summarize from compactor, provider? from llm/provider
- Removed estimate-message-tokens from context-builder provides
  (now lives in context-policy)
- Updated token-compaction.rkt to import from context-policy
- Updated test-context-builder.rkt to import estimate-message-tokens
  from context-policy
- New tests/test-context-manager-summarization.rkt: 8 tests for
  summarization fallback, caching, and dispatch logic

Closes #2411.

### DIFF
--- a/runtime/context-builder.rkt
+++ b/runtime/context-builder.rkt
@@ -25,7 +25,6 @@
 (provide build-session-context
          build-session-context/tokens
          truncate-messages-to-budget
-         estimate-message-tokens
          entry->context-message
          load-agents-context
          build-system-preamble)

--- a/runtime/context-manager.rkt
+++ b/runtime/context-manager.rkt
@@ -24,7 +24,9 @@
                   estimate-message-tokens
                   ensure-first-user-pinned
                   user-message?
-                  system-message?))
+                  system-message?)
+         (only-in "../runtime/compactor.rkt" llm-summarize)
+         (only-in "../llm/provider.rkt" provider?))
 
 (provide context-manager-config
          context-manager-config?
@@ -343,8 +345,8 @@
 ;; Generate context summary (Wave 2A #1395)
 ;; ============================================================
 
-;; Summarize excluded entries. When provider+model are given, uses LLM.
-;; Otherwise returns a simple concatenation summary.
+;; Summarize excluded entries. When provider+model are given, uses LLM
+;; via compactor's llm-summarize. Otherwise returns a simple concatenation.
 ;; Checks cache first; only generates if cache miss.
 ;; Returns context-summary? or #f.
 (define (generate-context-summary entries provider model-name #:cache [cache #f])
@@ -358,12 +360,13 @@
      (cond
        [cached (context-summary from-id to-id cached (length entries))]
        [else
-        ;; Generate summary
+        ;; Generate summary — use LLM when provider available
         (define summary-text
           (cond
-            ;; LLM summarization would go here — requires provider-send
-            ;; For now, use concatenation fallback
-            [(and provider model-name) (simple-summary-text entries)]
+            [(and provider model-name (provider? provider))
+             ;; Real LLM summarization via compactor
+             (llm-summarize entries provider model-name)]
+            ;; Fallback: simple concatenation
             [else (simple-summary-text entries)]))
         ;; Store in cache
         (when cache

--- a/runtime/token-compaction.rkt
+++ b/runtime/token-compaction.rkt
@@ -19,19 +19,18 @@
          racket/list
          "../util/protocol-types.rkt"
          "../llm/token-budget.rkt"
-         "context-builder.rkt")
+         "context-policy.rkt")
 
-(provide
- (struct-out token-compaction-config)
- ;; Token-based window split
- build-token-summary-window
- ;; Backward token walk
- backward-token-walk
- ;; Token estimation for message lists
- estimate-messages-tokens
- ;; Configuration helpers
- default-token-compaction-config
- make-token-compaction-config)
+(provide (struct-out token-compaction-config)
+         ;; Token-based window split
+         build-token-summary-window
+         ;; Backward token walk
+         backward-token-walk
+         ;; Token estimation for message lists
+         estimate-messages-tokens
+         ;; Configuration helpers
+         default-token-compaction-config
+         make-token-compaction-config)
 
 ;; ============================================================
 ;; #687: Token compaction configuration
@@ -41,10 +40,7 @@
 ;; keep-recent-tokens : how many tokens of recent messages to keep verbatim
 ;; reserve-tokens     : tokens reserved for system prompt + response headroom
 ;; max-context-tokens : total context window size (default: 100k)
-(struct token-compaction-config (keep-recent-tokens
-                                 reserve-tokens
-                                 max-context-tokens)
-  #:transparent)
+(struct token-compaction-config (keep-recent-tokens reserve-tokens max-context-tokens) #:transparent)
 
 ;; Default: keep 30k tokens of recent messages, reserve 10k for system/response
 (define (default-token-compaction-config)
@@ -61,11 +57,10 @@
 ;; ============================================================
 
 ;; Estimate total tokens for a list of messages.
-;; Uses estimate-message-tokens from context-builder which handles
+;; Uses estimate-message-tokens from context-policy which handles
 ;; text-part extraction and heuristic token estimation.
 (define (estimate-messages-tokens messages)
-  (for/sum ([m (in-list messages)])
-    (estimate-message-tokens m)))
+  (for/sum ([m (in-list messages)]) (estimate-message-tokens m)))
 
 ;; ============================================================
 ;; #686: Backward token walk for compaction boundary
@@ -84,17 +79,15 @@
   (let loop ([i (sub1 n)]
              [used-tokens 0])
     (cond
-      [(< i 0)
-       ;; All messages fit within budget
-       (values messages '())]
+      ;; All messages fit within budget
+      [(< i 0) (values messages '())]
       [else
        (define msg (list-ref messages i))
        (define msg-tokens (estimate-message-tokens msg))
        (define new-total (+ used-tokens msg-tokens))
        (cond
          ;; Still within budget — include this message and continue walking
-         [(<= new-total keep-recent-tokens)
-          (loop (sub1 i) new-total)]
+         [(<= new-total keep-recent-tokens) (loop (sub1 i) new-total)]
          ;; Budget exceeded — messages[0..i] are overflow, messages[i+1..n-1] are kept
          [else
           (define overflow (take messages (add1 i)))
@@ -124,8 +117,7 @@
   ;; If total messages fit within effective budget, nothing to summarize
   (define total-tokens (estimate-messages-tokens messages))
   (cond
-    [(<= total-tokens effective-budget)
-     (values '() messages)]
+    [(<= total-tokens effective-budget) (values '() messages)]
     [else
      ;; Use backward token walk to find the split point
      (define-values (kept overflow) (backward-token-walk messages keep-recent))

--- a/tests/test-context-builder.rkt
+++ b/tests/test-context-builder.rkt
@@ -9,7 +9,8 @@
          "../util/protocol-types.rkt"
          "../runtime/session-store.rkt"
          "../runtime/session-index.rkt"
-         "../runtime/context-builder.rkt")
+         "../runtime/context-builder.rkt"
+         (only-in "../runtime/context-policy.rkt" estimate-message-tokens))
 
 ;; Helpers
 (define (make-temp-dir)

--- a/tests/test-context-manager-summarization.rkt
+++ b/tests/test-context-manager-summarization.rkt
@@ -1,0 +1,121 @@
+#lang racket/base
+
+;; tests/test-context-manager-summarization.rkt — LLM summarization integration tests
+;; STABILITY: testing
+;;
+;; Issue #2411: W1 — Fix LLM Summarization
+
+(require rackunit
+         racket/string
+         racket/list
+         "../util/protocol-types.rkt"
+         "../runtime/context-manager.rkt")
+
+;; ============================================================
+;; Tests
+;; ============================================================
+
+(test-case "generate-context-summary: empty entries returns #f"
+  (define result (generate-context-summary '() #f #f))
+  (check-false result))
+
+(test-case "generate-context-summary: fallback without provider"
+  (define msgs
+    (list (make-message "m1"
+                        #f
+                        'user
+                        'message
+                        (list (make-text-part "Hello world"))
+                        (current-seconds)
+                        (hasheq))))
+  (define result (generate-context-summary msgs #f #f))
+  (check-true (context-summary? result))
+  (check-equal? (context-summary-from-id result) "m1")
+  (check-equal? (context-summary-to-id result) "m1")
+  (check-true (string-contains? (context-summary-text result) "## Progress")))
+
+(test-case "generate-context-summary: cache hit"
+  (define msgs
+    (list (make-message "m1"
+                        #f
+                        'user
+                        'message
+                        (list (make-text-part "Hello"))
+                        (current-seconds)
+                        (hasheq))))
+  (define cache (make-summary-cache))
+  ;; First call populates cache
+  (define result1 (generate-context-summary msgs #f #f #:cache cache))
+  (check-true (context-summary? result1))
+  ;; Second call should be cache hit
+  (define result2 (generate-context-summary msgs #f #f #:cache cache))
+  (check-true (context-summary? result2))
+  (check-equal? (context-summary-text result1) (context-summary-text result2)))
+
+(test-case "summary-cache: store and lookup"
+  (define cache (make-summary-cache))
+  (summary-cache-store! cache "a" "b" "test summary")
+  (check-equal? (summary-cache-lookup cache "a" "b") "test summary")
+  (check-false (summary-cache-lookup cache "x" "y")))
+
+(test-case "generate-context-summary: multiple entries"
+  (define msgs
+    (list
+     (make-message "m1" #f 'user 'message (list (make-text-part "First")) (current-seconds) (hasheq))
+     (make-message "m2"
+                   #f
+                   'assistant
+                   'message
+                   (list (make-text-part "Second"))
+                   (current-seconds)
+                   (hasheq))
+     (make-message "m3"
+                   #f
+                   'user
+                   'message
+                   (list (make-text-part "Third"))
+                   (current-seconds)
+                   (hasheq))))
+  (define result (generate-context-summary msgs #f #f))
+  (check-true (context-summary? result))
+  (check-equal? (context-summary-from-id result) "m1")
+  (check-equal? (context-summary-to-id result) "m3")
+  (check-equal? (context-summary-entry-count result) 3))
+
+(test-case "context-summary-prompt: produces non-empty string"
+  (define msgs
+    (list (make-message "m1"
+                        #f
+                        'user
+                        'message
+                        (list (make-text-part "Hello"))
+                        (current-seconds)
+                        (hasheq))))
+  (define prompt (context-summary-prompt msgs))
+  (check-true (string? prompt))
+  (check-true (> (string-length prompt) 0))
+  (check-true (string-contains? prompt "SESSION MESSAGES:")))
+
+(test-case "context-summary-prompt: with previous summary"
+  (define msgs
+    (list (make-message "m1"
+                        #f
+                        'user
+                        'message
+                        (list (make-text-part "New info"))
+                        (current-seconds)
+                        (hasheq))))
+  (define prompt (context-summary-prompt msgs #:previous-summary "Old summary"))
+  (check-true (string-contains? prompt "EXISTING SUMMARY:"))
+  (check-true (string-contains? prompt "Old summary")))
+
+(test-case "generate-context-summary: non-provider falls back to simple"
+  ;; Passing a non-provider value should fall back to simple-summary-text
+  (define msgs
+    (list
+     (make-message "m1" #f 'user 'message (list (make-text-part "Test")) (current-seconds) (hasheq))))
+  ;; "not-a-provider" is not a provider?, so should use fallback
+  (define result (generate-context-summary msgs "not-a-provider" "model"))
+  (check-true (context-summary? result))
+  ;; Should use simple-summary-text (fallback), not crash
+  (check-true (string-contains? (context-summary-text result) "## Progress")))


### PR DESCRIPTION
Addresses #2411.

feat: wire LLM summarization in context-manager via compactor llm-summarize (#2411)

W1 of v0.23.0:

- context-manager.rkt: generate-context-summary now calls compactor's
  llm-summarize when a real provider is given (checked via provider?),
  falls back to simple-summary-text otherwise
- Added imports: llm-summarize from compactor, provider? from llm/provider
- Removed estimate-message-tokens from context-builder provides
  (now lives in context-policy)
- Updated token-compaction.rkt to import from context-policy
- Updated test-context-builder.rkt to import estimate-message-tokens
  from context-policy
- New tests/test-context-manager-summarization.rkt: 8 tests for
  summarization fallback, caching, and dispatch logic

Closes #2411.