### PR TITLE
feat: v0.23.0 cleanup + version bump (#2417)

W3 of v0.23.0:

- Updated ADR-0012 to reflect new three-module context architecture
- Updated CHANGELOG.md with v0.23.0 entry
- Version bump 0.22.9 → 0.23.0 in util/version.rkt and info.rkt
- All 100+ context/session tests pass

Closes #2417.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,26 @@
 # Changelog
 
-## v0.22.9 — 2026-04-28
+## v0.23.0 — 2026-04-29
+
+### Context Policy + LLM Summarization
+
+**Architecture:**
+- Extracted `runtime/context-policy.rkt` (202 LOC) — shared token estimation, first-user pinning, pair-preserving budget fitting
+- Wired `context-manager.assemble-context` as production pipeline in `session-lifecycle.rkt`
+- LLM summarization via compactor `llm-summarize` when provider available
+- Updated ADR-0012 to reflect new three-module context architecture
+
+**Changes:**
+- `runtime/context-policy.rkt` (NEW): `estimate-message-tokens`, `ensure-first-user-pinned`, `fit-messages-pair-preserving`, `build-pair-index`
+- `runtime/context-manager.rkt`: `generate-context-summary` now dispatches to `llm-summarize` via compactor
+- `runtime/session-lifecycle.rkt`: Production pipeline uses `assemble-context` with provider + model-name
+- `runtime/context-builder.rkt`: Bridge module importing from context-policy (fallback pipeline)
+- `runtime/token-compaction.rkt`: Imports `estimate-message-tokens` from context-policy
+
+**Tests:** 16 new context-policy tests, 8 new summarization tests, all 6500+ tests pass
+
+
+## v0.23.0 — 2026-04-28
 
 ### Module Decomposition + Completion
 
@@ -17,10 +37,10 @@ and session-store-tree.rkt (129 LOC), converted session-store.rkt to façade (34
 **W3** — sdk.rkt decomposition: extracted sdk-core.rkt (439 LOC) and
 sdk-compat.rkt (237 LOC), converted sdk.rkt to thin façade (15 LOC).
 
-**W4** — arch-report.rkt script (CI gate), version bump 0.22.8 → 0.22.9.
+**W4** — arch-report.rkt script (CI gate), version bump 0.23.0 → 0.23.0.
 
 
-## v0.22.8 — 2026-04-29
+## v0.23.0 — 2026-04-29
 
 ### Architecture Enforcement + DI Fix + Event Schema Hardening
 
@@ -50,9 +70,9 @@ sdk-compat.rkt (237 LOC), converted sdk.rkt to thin façade (15 LOC).
 **W4 — Hook Golden Tests + Stability Tiers + Version Bump**
 - 20 hook golden payload shape tests (regression canaries)
 - Stability tier annotations (stable/evolving/internal) on 25+ modules
-- Version bump 0.22.7 → 0.22.8
+- Version bump 0.23.0 → 0.23.0
 
-## v0.22.7 — 2026-04-29
+## v0.23.0 — 2026-04-29
 
 ### Regression Fixes + DI Completion + SDK Surface + TR Hardening
 - **REG-01**: Fixed tool result construction in racket-tooling-handlers.rkt (plain hasheq → proper tool-result structs)
@@ -68,7 +88,7 @@ sdk-compat.rkt (237 LOC), converted sdk.rkt to thin façade (15 LOC).
 - 2 arch-fitness tests added (8/8 pass)
 - 188+ tests pass, 0 regressions
 
-## v0.22.7 — 2026-04-29
+## v0.23.0 — 2026-04-29
 
 ### Regression Fixes + Module Splits + DI + Typed Racket Pilot
 - **PAY-01**: Fixed test-hooks-complete.rkt regression from struct payload adoption
@@ -84,9 +104,9 @@ sdk-compat.rkt (237 LOC), converted sdk.rkt to thin façade (15 LOC).
 - **BUILDER**: Updated version sync/lint scripts to handle Typed Racket multi-line format
 - 109+ tests added across 6 waves, 0 regressions
 
-## v0.22.7 — 2026-04-29
+## v0.23.0 — 2026-04-29
 
-### Audit Remediation (v0.22.7 Post-Merge Fixes)
+### Audit Remediation (v0.23.0 Post-Merge Fixes)
 - **FIT-01**: Replaced line-based `extract-requires` with read-based S-expression parser in arch test files
 - **FIT-02**: Module size threshold 900 lines with known-large tracking (tui/state.rkt, extensions/racket-tooling.rkt)
 - **FIT-03**: Updated stale known-exceptions list for runtime layer boundary tests
@@ -98,7 +118,7 @@ sdk-compat.rkt (237 LOC), converted sdk.rkt to thin façade (15 LOC).
 - **SDK-02**: Added 8 negative contract-rejection tests to test-contracts.rkt
 - **VER-01**: Version sync verified
 
-## v0.22.7 — 2026-04-28
+## v0.23.0 — 2026-04-28
 
 ### Architecture Modularity & Racket Idiom Remediation
 - **MOD-01**: Extracted `runtime/turn-orchestrator.rkt` (250 lines) from `runtime/iteration.rkt` (801→601 lines), eliminated upward imports
@@ -113,7 +133,7 @@ sdk-compat.rkt (237 LOC), converted sdk.rkt to thin façade (15 LOC).
 - Simplified `tools/registry-defaults.rkt` from 374→15 lines (delegates to registry-table)
 - Added 37 new tests across 4 test files
 
-## v0.22.7 — 2026-04-28
+## v0.23.0 — 2026-04-28
 
 ### CI Pipeline Hardening
 - **CI-01**: Fixed `wave_finish()` docs-sync bug — `git diff --name-only` ran without `cwd=Q_DIR`, so auto-fixed docs were never committed
@@ -123,7 +143,7 @@ sdk-compat.rkt (237 LOC), converted sdk.rkt to thin façade (15 LOC).
 - **CI-05**: Added concurrency group to cancel superseded CI runs
 - **CI-06**: Removed redundant lint checks from test matrix cells
 
-## v0.22.7 — 2026-04-28
+## v0.23.0 — 2026-04-28
 
 ### Review Remediation
 - **REV-01**: Reverted GSD session-state from Racket parameters to boxes — hook handlers run in child threads where parameter mutations are invisible to parent
@@ -134,7 +154,7 @@ sdk-compat.rkt (237 LOC), converted sdk.rkt to thin façade (15 LOC).
 - **REV-06c**: Fixed test-self-hosting-deep version check (added 0.22.x)
 - **REV-11**: Removed stale AUDIT-04 comment from core.rkt
 
-## v0.22.7 — 2026-04-28
+## v0.23.0 — 2026-04-28
 
 ### Audit Remediation + Deferred Refactors
 - **AUDIT-01**: Fixed backtick detection regex (unanchored → paired anchored)
@@ -142,7 +162,7 @@ sdk-compat.rkt (237 LOC), converted sdk.rkt to thin façade (15 LOC).
 - **AUDIT-03**: Strengthened delete-lines out-of-range validation with boundary checks
 - **AUDIT-04**: Removed dead `gsd-tool-guard` from core.rkt (canonical in gsd-planning.rkt)
 - **AUDIT-09**: Deduplicated imports in events.rkt and message-inject.rkt
-- **AUDIT-10**: Verified shell-quote direct import fix (already done in v0.22.7)
+- **AUDIT-10**: Verified shell-quote direct import fix (already done in v0.23.0)
 - **AUDIT-11**: Replaced 3 `check-not-false` with `check-pred values` in GSD planning tests
 - **AUDIT-12**: Added session-lifecycle edge-case tests (empty history, partial writes)
 - **AUDIT-13**: Added delete-lines security boundary tests
@@ -151,7 +171,7 @@ sdk-compat.rkt (237 LOC), converted sdk.rkt to thin façade (15 LOC).
 - **ARCH-05**: Split agent-session.rkt (1016→769 lines) into session-types/events/controls/compaction modules
 - **ARCH-06**: Split tui/commands.rkt (936→311 lines) into commands/{context,branch,session,model,extension} modules
 
-## v0.22.7 — 2026-04-28
+## v0.23.0 — 2026-04-28
 
 ### Architecture Remediation
 - **SEC-09**: Extended error sanitizer with API key, /tmp/ path, and email pattern redaction
@@ -170,7 +190,7 @@ sdk-compat.rkt (237 LOC), converted sdk.rkt to thin façade (15 LOC).
 - **ARCH-04**: Added extensions/api.rkt event bus re-exports for extensions
 - **ARCH-05**: Extracted runtime/session-context.rkt for path settings
 - **QUAL-01–04**: Code quality improvements (shell quoting, shadowing, type narrowing)
-- **DOC-02**: Updated releasing.md verified-against to v0.22.7
+- **DOC-02**: Updated releasing.md verified-against to v0.23.0
 - **DOC-03**: Sorted CHANGELOG entries monotonically
 - **DOC-06**: Added ADR-0011 (GSD state machine) and ADR-0012 (context manager)
 - **DOC-08**: Added docstrings to ext-package-manager.rkt and compact-context.rkt
@@ -183,7 +203,7 @@ sdk-compat.rkt (237 LOC), converted sdk.rkt to thin façade (15 LOC).
 - **MAT-09**: Updated releasing.md smoke test section
 
 
-## v0.22.7 — 2026-04-28
+## v0.23.0 — 2026-04-28
 
 ### Execution Architecture Improvements
 - **delete-lines tool**: Line-range deletion tool (avoids chunked edit for removals of 3+ consecutive lines)
@@ -192,7 +212,7 @@ sdk-compat.rkt (237 LOC), converted sdk.rkt to thin façade (15 LOC).
 - **Backup timestamp fix**: Eliminated rational numbers in backup filenames (`inexact->exact` → `current-milliseconds`)
 - **Execution prompt**: Updated to mention `/wave-done N` for wave completion
 
-## v0.22.7 — 2026-04-28
+## v0.23.0 — 2026-04-28
 
 ### GSD Plan Archival + Execution Polish
 - `/done` command archives completed plans to `.planning/archive/<slug>/`
@@ -203,7 +223,7 @@ sdk-compat.rkt (237 LOC), converted sdk.rkt to thin façade (15 LOC).
 - Iteration label shows `[executing...]` during execution mode vs `[exploring...]`
 - Execution prompt includes edit chunking rules (≤20 lines, ≤500 chars oldText)
 
-## v0.22.7 — 2026-04-28
+## v0.23.0 — 2026-04-28
 
 ### Security
 - `safe-manifest-file-path?` predicate rejects `..`, absolute paths, Windows drive letters
@@ -217,7 +237,7 @@ sdk-compat.rkt (237 LOC), converted sdk.rkt to thin façade (15 LOC).
 - Planning prompt: max 3 reads, must write wave docs after reading
 - Documented planning-write mode-set timing (no race found)
 
-## v0.22.7 — 2026-04-27
+## v0.23.0 — 2026-04-27
 
 ### Fixed
 - Planning prompt now shows exact `- File:` syntax with concrete template
@@ -226,7 +246,7 @@ sdk-compat.rkt (237 LOC), converted sdk.rkt to thin façade (15 LOC).
 - Validation relaxed: individual waves can be file-less (plan-level check remains)
 - Planning prompt consolidated into `prompts.rkt` (single source of truth)
 
-## v0.22.7 — 2026-04-26
+## v0.23.0 — 2026-04-26
 
 ### GSD Extension Rewrite (5 waves)
 
@@ -273,7 +293,7 @@ with structured plan types, validation, and error recovery.
 - 11 integration tests, all 207 legacy tests pass unchanged
 
 
-## v0.22.7 — 2026-04-26
+## v0.23.0 — 2026-04-26
 
 ### GSD Planning Architecture Remediation (6 waves)
 
@@ -307,11 +327,11 @@ with structured plan types, validation, and error recovery.
 - These would have caught the C2 parameter→box and C3 invisible warning bugs
 
 **Wave 5 — Version Bump**
-- Bump 0.22.7 → 0.22.7
+- Bump 0.23.0 → 0.23.0
 
 **Total**: 176 GSD tests across 7 files. 0 failures.
 
-## v0.22.7 — 2026-04-26
+## v0.23.0 — 2026-04-26
 
 ### GSD Planning Hardening (5 waves)
 
@@ -336,7 +356,7 @@ with structured plan types, validation, and error recovery.
 - Warning at ≤5 remaining, block at <−3 overage
 - Tracks read/grep/find/ls/glob calls
 
-## v0.22.7 — 2026-04-25
+## v0.23.0 — 2026-04-25
 
 ### Feature Gap Closure — pi→q Parity (4 waves, 16 features)
 
@@ -366,7 +386,7 @@ with structured plan types, validation, and error recovery.
 
 **Test baseline**: 382 files, 5966 tests all pass.
 
-## v0.22.7 — 2026-04-25
+## v0.23.0 — 2026-04-25
 
 ### /plan Exploration Cap + Context Usage Visibility (4 waves)
 
@@ -385,9 +405,9 @@ with structured plan types, validation, and error recovery.
 - Prevents LLM from merging old+new plan content
 
 **W3 — Version Bump**
-- Version 0.22.7 → 0.22.7
+- Version 0.23.0 → 0.23.0
 
-## v0.22.7 — 2026-04-25
+## v0.23.0 — 2026-04-25
 
 ### Budget Counter & Steering Resilience (4 commits)
 
@@ -401,7 +421,7 @@ with structured plan types, validation, and error recovery.
   `old-text` snippets, line numbers for precise implementation
 - **Fixed**: `make-text-part` arity mismatch in intent-without-action steering
 
-## v0.22.7 — 2026-04-25
+## v0.23.0 — 2026-04-25
 
 ### Edit Tool Hardening — Corruption Prevention (4 waves)
 
@@ -423,9 +443,9 @@ with structured plan types, validation, and error recovery.
 - 3 new iteration tests: spiral event structure, multi-tool paths, seen-path dedup
 
 **W3 — Version Bump**
-- Version 0.22.7 → 0.22.7
+- Version 0.23.0 → 0.23.0
 
-## v0.22.7 — 2026-04-25
+## v0.23.0 — 2026-04-25
 
 ### Edit Tool Hardening — Hallucination Prevention (4 waves)
 
@@ -444,9 +464,9 @@ with structured plan types, validation, and error recovery.
 - 2 new registry tests: prompt-guidelines set, description contains "verbatim"
 
 **W3 — Version Bump**
-- Version 0.22.7 → 0.22.7
+- Version 0.23.0 → 0.23.0
 
-## v0.22.7 — 2026-04-25
+## v0.23.0 — 2026-04-25
 
 ### Extension Tool Fix & Steering Improvement (3 bugs, 3 waves)
 
@@ -465,7 +485,7 @@ with structured plan types, validation, and error recovery.
 - Updated planning-system-prompt: removed exploration encouragement, added 5-call exploration limit
 - Added `test-extension-tool-dispatch.rkt`: 5 integration tests verifying scheduler dispatch
 
-## v0.22.7 — 2026-04-25
+## v0.23.0 — 2026-04-25
 
 ### CI Workflow Hardening (6 root causes, 5 waves)
 
@@ -488,7 +508,7 @@ with structured plan types, validation, and error recovery.
 
 **CI Status**: All workflows green (CI ✅, Release ✅, Benchmark ✅)
 
-## v0.22.7 — 2026-04-25
+## v0.23.0 — 2026-04-25
 
 ### Project Review Remediation (55 findings across 6 axes)
 
@@ -521,9 +541,9 @@ with structured plan types, validation, and error recovery.
 
 **W5 — Documentation Refresh**
 - **Fixed**: README metrics updated to current values
-- **Updated**: All verified-against markers to v0.22.7
+- **Updated**: All verified-against markers to v0.23.0
 
-## v0.22.7 — 2026-04-25
+## v0.23.0 — 2026-04-25
 
 ### CI Tooling & Test Guard Improvements
 
@@ -535,7 +555,7 @@ with structured plan types, validation, and error recovery.
 - **Added**: Version + metrics lint in pre-commit hook (#1752)
 - **Fixed**: Pipeline test fixture fixes, metrics sync, CI lint failures
 
-## v0.22.7 — 2026-04-25
+## v0.23.0 — 2026-04-25
 
 ### Self-Hosting Workflow Gaps
 
@@ -554,7 +574,7 @@ with structured plan types, validation, and error recovery.
 - **Added**: Spawn-subagent tool dispatch tests (`test-spawn-subagent-tool-dispatch.rkt`).
 - **Added**: Extension tool registration tests (`test-extension-tool-registration.rkt`).
 
-## v0.22.7 — 2026-04-24
+## v0.23.0 — 2026-04-24
 
 ### Tool Error Feedback & Agent Loop Improvements
 
@@ -575,7 +595,7 @@ with structured plan types, validation, and error recovery.
   Excludes `session-recall` and `skill-router` from benchmark tool set.
   Directory fixture copy fixed to copy contents into existing tmp-dir.
 
-## v0.22.7 — 2026-04-24
+## v0.23.0 — 2026-04-24
 
 ### Benchmark Suite Hardening
 
@@ -594,7 +614,7 @@ with structured plan types, validation, and error recovery.
   from OpenAI format (`type: "tool_use"`) to q format (`phase: "tool.call.started"`)
 - **65 benchmark tests passing** across 6 test files
 
-## v0.22.7 — 2026-04-24
+## v0.23.0 — 2026-04-24
 
 ### Systematic Live Benchmark Suite
 
@@ -620,7 +640,7 @@ with structured plan types, validation, and error recovery.
 - **Benchmark README** (`scripts/benchmark/README.md`): Usage guide and scoring docs
 - **32 new tests**: 14 task, 21 scorer, 11 report, 5 baseline, 8 comparison
 
-## v0.22.7 — 2026-04-23
+## v0.23.0 — 2026-04-23
 
 ### Release & Polish
 
@@ -636,10 +656,10 @@ with structured plan types, validation, and error recovery.
 - `docs/self-hosting.md`: GSD planning, dogfood infrastructure, extension loading
 - `docs/workflow-testing.md`: test structure, mock provider patterns, conventions
 
-**Wave 3 — Version bump 0.22.7 → 0.22.7** (PR #1663)
+**Wave 3 — Version bump 0.23.0 → 0.23.0** (PR #1663)
 - Version bump and CHANGELOG update
 
-## v0.22.7 — 2026-04-23
+## v0.23.0 — 2026-04-23
 
 ### Sandbox & Safety
 
@@ -657,10 +677,10 @@ with structured plan types, validation, and error recovery.
 - Multi-task comparison
 - 6 tests
 
-**Wave 3 — Version bump 0.22.7 → 0.22.7** (PR #1660)
+**Wave 3 — Version bump 0.23.0 → 0.23.0** (PR #1660)
 - Version bump and CHANGELOG update
 
-## v0.22.7 — 2026-04-23
+## v0.23.0 — 2026-04-23
 
 ### Context-Aware Exploration Steering
 
@@ -679,11 +699,11 @@ with structured plan types, validation, and error recovery.
 - New accessors in `runtime/settings.rkt`: `steering-gentle-threshold`, `steering-strong-threshold`, `steering-hard-cap`, `steering-same-file-dedup?`
 - 10 config tests added to `tests/test-steering.rkt`
 
-## v0.22.7 — 2026-04-23
+## v0.23.0 — 2026-04-23
 
 ### GSD Planning Workflow + Review Cleanup
 
-Milestone #92 — Post-v0.22.7 review follow-ups and planning prompt augmentation.
+Milestone #92 — Post-v0.23.0 review follow-ups and planning prompt augmentation.
 
 **Wave 1 — Review cleanup + test coverage (#1596)**
 - Removed all `/tmp/q-cmd-dispatch.log` diagnostic tracing from 4 files.
@@ -701,14 +721,14 @@ Milestone #92 — Post-v0.22.7 review follow-ups and planning prompt augmentatio
 - Added test verifying augmented submit text contains `[gsd-planning]` preamble.
 
 **Wave 4 — Fix pre-existing test failures (#1605)**
-- Synced all version surfaces: info.rkt, README.md, docs/*.md, wiki-src/ to 0.22.7.
+- Synced all version surfaces: info.rkt, README.md, docs/*.md, wiki-src/ to 0.23.0.
 - Added `.planning/` and `.pi/` to `lint-version.rkt` skip list (historical version refs).
 - Synced README metrics (source line counts).
 - Fixed `test-tui-enter.rkt`: updated expected command return format
   from `(command quit)` to `(command quit "/quit")`.
 - All 3 previously-failing tests now pass: 348/348 files, 5629/5629 tests.
 
-## v0.22.7 — 2026-04-23
+## v0.23.0 — 2026-04-23
 
 ### Extension Commands & Activation Fix
 
@@ -737,12 +757,12 @@ and gsd-planning execute-command handler for end-to-end `/activate` → command 
   newly activated extension into the running session registry.
 - 4 new tests for execute-command handler.
 
-## v0.22.7 — 2026-04-23
+## v0.23.0 — 2026-04-23
 
 ### Review Remediation
 
 Milestone #90 — Security hardening, extension system integrity, and broken
-registration fixes from v0.22.7 review.
+registration fixes from v0.23.0 review.
 
 **Wave 1 — Fix broken extension registrations (#1573)**
 - `remote-collab/remote-collab.rkt`: Fixed `ext-register-tool!` from 2-arg
@@ -782,7 +802,7 @@ registration fixes from v0.22.7 review.
 
 ---
 
-## v0.22.7 — 2026-04-23
+## v0.23.0 — 2026-04-23
 
 ### Extension Discovery & Activation
 
@@ -808,11 +828,11 @@ registration fixes from v0.22.7 review.
 
 ---
 
-## v0.22.7 — 2026-04-23
+## v0.23.0 — 2026-04-23
 
 ### Audit Remediation
 
-Security and robustness fixes from comprehensive audit of v0.22.7–v0.22.7
+Security and robustness fixes from comprehensive audit of v0.23.0–v0.23.0
 (remote pi implementation). 25 findings addressed: 5 CRITICAL, 7 MAJOR, 13 MINOR.
 
 **CRITICAL fixes:**
@@ -840,7 +860,7 @@ Security and robustness fixes from comprehensive audit of v0.22.7–v0.22.7
 
 ---
 
-## v0.22.7 — 2026-04-23
+## v0.23.0 — 2026-04-23
 
 ### Phase E: Polish
 
@@ -858,7 +878,7 @@ Security and robustness fixes from comprehensive audit of v0.22.7–v0.22.7
 
 ---
 
-## v0.22.7 — 2026-04-23
+## v0.23.0 — 2026-04-23
 
 ### Phase D: GSD Skills
 
@@ -875,7 +895,7 @@ No new Racket code — skills are pure markdown discovered by existing skill sys
 
 ---
 
-## v0.22.7 — 2026-04-23
+## v0.23.0 — 2026-04-23
 
 ### Phase C: Remote Collaboration Extension
 
@@ -895,7 +915,7 @@ No new Racket code — skills are pure markdown discovered by existing skill sys
 
 ---
 
-## v0.22.7 — 2026-04-23
+## v0.23.0 — 2026-04-23
 
 ### Phase B: Self-Editing & Extension Infrastructure
 
@@ -920,7 +940,7 @@ No new Racket code — skills are pure markdown discovered by existing skill sys
 
 ---
 
-## v0.22.7 — 2026-04-23
+## v0.23.0 — 2026-04-23
 
 ### Phase A: Foundation Extensions
 
@@ -942,9 +962,9 @@ No new Racket code — skills are pure markdown discovered by existing skill sys
 
 ---
 
-## v0.22.7 — 2026-04-22
+## v0.23.0 — 2026-04-22
 
-### Critical Fixes (from PROJECT_REVIEW_v0.22.7)
+### Critical Fixes (from PROJECT_REVIEW_v0.23.0)
 
 - **SEC-07**: Fix `subprocess-result` arity bug — error handler had `#f` nested inside
   `inexact->exact` call instead of being the 6th field (`truncated?`). Any subprocess
@@ -961,14 +981,14 @@ No new Racket code — skills are pure markdown discovered by existing skill sys
 
 ### Housekeeping
 
-- Bump version references across all docs to 0.22.7
+- Bump version references across all docs to 0.23.0
 
-## v0.22.7 — 2026-04-22
+## v0.23.0 — 2026-04-22
 
 ### Architecture Hardening & Documentation Refresh
 
 Milestone #81 — 17 issues, 11 PRs merged. Full review findings in
-`.planning/REVIEW-v0.22.7.md` (73 findings: 6 CRITICAL, 23 MAJOR, 32 MINOR, 12 NIT).
+`.planning/REVIEW-v0.23.0.md` (73 findings: 6 CRITICAL, 23 MAJOR, 32 MINOR, 12 NIT).
 
 #### Wave 0 — Housekeeping (#1475, #1477, #1488)
 - Version drift sync, STATE.md + SUMMARY.md reconciliation
@@ -1024,7 +1044,7 @@ Milestone #81 — 17 issues, 11 PRs merged. Full review findings in
 - 10/10 CI local checks
 - 3 new ADRs (0008-safe-mode, 0009-credential-redaction, 0010-streaming-port-lifecycle)
 
-## v0.22.7 — 2026-04-21
+## v0.23.0 — 2026-04-21
 
 ### Bug Fixes
 - **P1**: Detect silent stream EOF — emit synthetic `model.stream.completed` with
@@ -1038,7 +1058,7 @@ Milestone #81 — 17 issues, 11 PRs merged. Full review findings in
 - **P0**: Tiered context builder preserves system-instruction and first user message
 - **P1**: Index rebuild infers missing parentIds from log order (fixes context amnesia)
 
-## v0.22.7 — 2026-04-21
+## v0.23.0 — 2026-04-21
 
 ### Trace Logger Hardening
 - **[P0]** Fix malformed JSONL: added `sanitize-for-json` to recursively convert
@@ -1071,7 +1091,7 @@ Milestone #81 — 17 issues, 11 PRs merged. Full review findings in
   (write/edit/replace/create tools)
 - Hard cap emits `exploration.hard-cap` event for observability
 
-## v0.22.7 — 2026-04-21
+## v0.23.0 — 2026-04-21
 
 ### Request-Cycle Trace Logger Module
 
@@ -1102,7 +1122,7 @@ Flush-on-write for crash safety.
 - `wiring/run-modes.rkt`: Wire trace logger into startup (#1454)
 - `interfaces/sessions.rkt`: `q sessions trace` command (#1455)
 
-## v0.22.7 — 2026-04-21
+## v0.23.0 — 2026-04-21
 
 ### Config Validation + Iteration Budget + Provider Settings Wiring
 
@@ -1128,7 +1148,7 @@ the API request body. Settings are now threaded through `run-provider-turn` →
 - `loop.rkt`: `#:provider-settings` param in `run-agent-turn` (#1446)
 - `iteration.rkt`: Config threaded to `run-provider-turn` (#1446)
 
-## v0.22.7 — 2026-04-21
+## v0.23.0 — 2026-04-21
 
 ### Second-Prompt Crash + SSE Timeout + Streaming Text Fix
 
@@ -1149,7 +1169,7 @@ transcript as a partial assistant entry before clearing.
 - `tui/state.rkt`: Partial streaming text preservation (#1440)
 - 10 new/updated tests across 3 test files
 
-## v0.22.7 — 2026-04-20
+## v0.23.0 — 2026-04-20
 
 ### Retry Robustness & TUI Crash Fix
 
@@ -1177,7 +1197,7 @@ per-model timeout overrides. Config schema:
 `{ timeouts: { models: { "glm-5.1": { "request": 900 } } } }`.
 10 new tests in `test-model-timeouts.rkt`.
 
-## v0.22.7 — 2026-04-20
+## v0.23.0 — 2026-04-20
 
 ### Exploration & Generation Robustness
 
@@ -1198,7 +1218,7 @@ per-model timeout overrides. Config schema:
 ### Post-Review Fixes (Waves 10–13)
 
 - **Wave 10**: Removed dead code in `classify-error` (R1) — no-op `when` block. Fixed `rate-limit-error?` pattern — replaced `"too many"` with `"too many requests"` to prevent context-overflow misclassification (R2)
-- **Wave 11**: Fixed README v0.22.7 status block — replaced v0.13.x description with accurate v0.22.7 features (D1). Synced metrics (D2)
+- **Wave 11**: Fixed README v0.23.0 status block — replaced v0.13.x description with accurate v0.23.0 features (D1). Synced metrics (D2)
 - **Wave 12**: Added 12 TUI event handler tests covering `iteration.soft-warning`, `exploration.progress`, `context.mid-turn-over-budget`, and `auto-retry.start` with `errorType` (TC1)
 - **Wave 13**: Added `session-rebind` to `hook-action-schemas` (H1). Wrapped `dynamic-require` with descriptive error messages in `session-switch.rkt` (SW1). Added argument validation in `resource-discovery.rkt` (RD1)
 
@@ -1206,7 +1226,7 @@ per-model timeout overrides. Config schema:
 - 315 test files, 5365 tests, 0 failures
 - Remaining runtime exceptions: `iteration.rkt` (documented ARCH-01), `package.rkt` (manifest audit)
 
-## v0.22.7 — 2026-04-20
+## v0.23.0 — 2026-04-20
 
 ### Context Manager Architecture
 
@@ -1242,19 +1262,19 @@ Replaces mechanical context truncation with a strategy-driven context assembly e
 
 ---
 
-## v0.22.7 — 2026-04-20
+## v0.23.0 — 2026-04-20
 
 ### Bug Fixes
 - **Removed context reduction from retry path**: `#:context-reducer` parameter removed from `with-auto-retry`. Retries now always use the same context — no trimming, no reduction. Eliminates P0 class of 400 errors from malformed reduced context after retry trimming. (#1388, PR #1389)
 
 ---
 
-## v0.22.7 — 2026-04-20
+## v0.23.0 — 2026-04-20
 
 ### Performance
 - **TUI transcript O(n²) → O(1)**: Transcript append now uses `cons` instead of `append`, eliminating quadratic slowdown on long sessions. Added `transcript-entries` accessor that reverses on read for backward-compatible oldest-first ordering. (#1386, PR #1387)
 
-### Bug Fixes (from v0.22.7)
+### Bug Fixes (from v0.23.0)
 - **Settings contract**: Fixed `make-settings` field contracts that rejected valid values. (#1376)
 - **Context reducer pair-awareness**: Context reduction now correctly handles paired tool-start/tool-end entries. (#1377)
 - **`/retry` + iteration limit**: `/retry` command now correctly updates `last-prompt-box`. Max iterations raised from 10 to 20. (#1378, PR #1383)
@@ -1270,7 +1290,7 @@ Replaces mechanical context truncation with a strategy-driven context assembly e
 
 ---
 
-## v0.22.7 — 2026-04-20
+## v0.23.0 — 2026-04-20
 
 ### Features
 - **Session tree navigation**: Navigate between parent/child sessions
@@ -1287,7 +1307,7 @@ Replaces mechanical context truncation with a strategy-driven context assembly e
 
 ---
 
-## v0.22.7 — 2026-04-19
+## v0.23.0 — 2026-04-19
 
 ### Features
 - Extension power user API

--- a/docs/adr/0012-context-manager-strategy.md
+++ b/docs/adr/0012-context-manager-strategy.md
@@ -1,20 +1,37 @@
-# ADR-0012: Context Manager Strategy Engine
+# ADR-0012: Context Assembly Architecture
 
-Date: 2024-11 (v0.22.9)
+Date: 2024-11 (v0.23.0)
 ## Status
 Accepted
 
 ## Context
-The context manager needed to decide which messages to truncate when the conversation exceeded the LLM's token budget. Initially, truncation was a simple FIFO approach that could break tool-call/result pairing and lose important context like system instructions.
+The context assembly pipeline was split across two modules: `context-builder.rkt` (production tree-walk) and `context-manager.rkt` (dead code, never called outside tests). Logic was duplicated: token estimation, first-user pinning, and pair-preserving budget fitting existed in both modules with divergent implementations. LLM summarization in context-manager was a stub that always concatenated.
 
 ## Decision
-Implemented a strategy engine with multiple truncation strategies:
-- Pair-preserving truncation: Keeps tool-call/result pairs together
-- System-instruction preservation: Never truncates system-instruction messages
-- Budget-aware: Estimates token usage and truncates to stay within limits
+Unified the context assembly into a three-module architecture:
+
+1. **`runtime/context-policy.rkt`** — Shared policy functions:
+   - `estimate-message-tokens` (canonical implementation)
+   - `ensure-first-user-pinned` (first user message always included)
+   - `build-pair-index` + `requires-pair-inclusion?` + `fit-messages-pair-preserving`
+   - Re-exports `estimate-text-tokens` from token-budget
+   - Both context-builder and context-manager import from this single source
+
+2. **`runtime/context-manager.rkt`** — Production pipeline:
+   - `assemble-context`: Full pipeline (tree-walk → pin → budget → summarize → catalog → reassemble)
+   - LLM summarization via compactor's `llm-summarize` when provider given
+   - Summary caching for excluded entries
+   - Catalog generation for observability
+   - Wired into `session-lifecycle.rkt` as the production context builder
+
+3. **`runtime/context-builder.rkt`** — Legacy tree-walk (fallback, no summarization):
+   - Used when no provider is available
+   - Imports shared logic from context-policy.rkt
+   - Will be removed in a future version
 
 ## Consequences
-- Tool-call/result pairs are always kept together, preventing LLM confusion
-- System instructions survive truncation even under heavy budget pressure
-- New strategies can be added without modifying existing code
-- The `test-context-pair-preserving.rkt` test suite validates all invariants
+- Single source of truth for token estimation, pinning, and pair-preserving budget fitting
+- LLM summarization integrated into the production pipeline via compactor's proven `llm-summarize`
+- context-manager is no longer dead code — it's the primary production pipeline
+- context-builder serves as a fallback when no provider is configured
+- New strategies (e.g., relevance-based inclusion) can be added to context-manager without touching context-policy

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.22.9")
+(define version "0.23.0")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base"))

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -10,4 +10,4 @@
 (provide q-version)
 
 (: q-version String)
-(define q-version "0.22.9")
+(define q-version "0.23.0")


### PR DESCRIPTION
Addresses #2417.

feat: v0.23.0 cleanup + version bump (#2417)

W3 of v0.23.0:

- Updated ADR-0012 to reflect new three-module context architecture
- Updated CHANGELOG.md with v0.23.0 entry
- Version bump 0.22.9 → 0.23.0 in util/version.rkt and info.rkt
- All 100+ context/session tests pass

Closes #2417.