### PR TITLE
feat: migrate production callers to context-assembly (#2431)

W1 of v0.23.1:
- session-lifecycle.rkt: imports from context-assembly instead of context-manager
  - Uses build-assembled-context (returns context-result struct)
  - Extracts messages via context-result-messages
- turn-orchestrator.rkt: imports build-tiered-context-with-hooks and
  tiered-context->message-list from context-assembly instead of compactor
- All context tests pass (16+11+14+8+25+4+18)

Closes #2431.

### DIFF
--- a/runtime/session-lifecycle.rkt
+++ b/runtime/session-lifecycle.rkt
@@ -35,10 +35,13 @@
          "../runtime/session-index.rkt"
          (only-in "../extensions/message-inject.rkt" injection-event-topic)
          (only-in "../util/event-payloads.rkt" error-payload input-payload payload->hash)
-         (only-in "../runtime/context-manager.rkt"
-                  assemble-context
-                  context-manager-config?
-                  make-context-manager-config
+         (only-in "../runtime/context-assembly.rkt"
+                  build-assembled-context
+                  context-assembly-config?
+                  make-context-assembly-config
+                  context-result-messages
+                  context-result-catalog
+                  context-result?
                   catalog-entry
                   catalog-entry?)
          (only-in "../runtime/context-builder.rkt"
@@ -139,19 +142,19 @@
   (when idx
     (append-to-leaf! idx user-msg))
 
-  ;; Build context: use context-manager when provider available, else context-builder
+  ;; Build context: use context-assembly when provider available, else context-builder
   (define context-messages
     (if idx
         (cond
           [(agent-session-provider sess)
-           ;; Use context-manager for production pipeline with LLM summarization
-           (define cfg (make-context-manager-config #:recent-tokens DEFAULT-TOKEN-BUDGET-THRESHOLD))
-           (define-values (msgs _catalog)
-             (assemble-context idx
-                               cfg
-                               #:provider (agent-session-provider sess)
-                               #:model-name (agent-session-model-name sess)))
-           msgs]
+           ;; Use context-assembly for production pipeline with LLM summarization
+           (define cfg (make-context-assembly-config #:recent-tokens DEFAULT-TOKEN-BUDGET-THRESHOLD))
+           (define result
+             (build-assembled-context idx
+                                      cfg
+                                      #:provider (agent-session-provider sess)
+                                      #:model-name (agent-session-model-name sess)))
+           (context-result-messages result)]
           ;; Fallback: context-builder tree walk (no LLM summarization)
           [else (context-builder:build-session-context idx)])
         ;; Fallback: no index — use linear history (backward compat)

--- a/runtime/turn-orchestrator.rkt
+++ b/runtime/turn-orchestrator.rkt
@@ -55,7 +55,7 @@
          (only-in "../extensions/context.rkt" make-extension-ctx)
          "../runtime/session-store.rkt"
          "../runtime/tool-coordinator.rkt"
-         (only-in "../runtime/compactor.rkt"
+         (only-in "../runtime/context-assembly.rkt"
                   build-tiered-context-with-hooks
                   tiered-context->message-list)
          (only-in "../runtime/tool-coordinator.rkt"


### PR DESCRIPTION
Addresses #2431.

feat: migrate production callers to context-assembly (#2431)

W1 of v0.23.1:
- session-lifecycle.rkt: imports from context-assembly instead of context-manager
  - Uses build-assembled-context (returns context-result struct)
  - Extracts messages via context-result-messages
- turn-orchestrator.rkt: imports build-tiered-context-with-hooks and
  tiered-context->message-list from context-assembly instead of compactor
- All context tests pass (16+11+14+8+25+4+18)

Closes #2431.