### PR TITLE
feat: migrate test files from context-manager to context-assembly (#2436)

W2 of v0.23.1:
- test-context-summary.rkt: import from context-assembly, use build-assembled-context
- test-summary-integration.rkt: import from context-assembly, use context-result-* accessors
- test-context-manager-polish.rkt: import from context-assembly, update config accessors
- All 92 context tests pass (16+10+4+5+11+8+14+6+18)

Closes #2436.

### DIFF
--- a/tests/test-context-manager-polish.rkt
+++ b/tests/test-context-manager-polish.rkt
@@ -11,7 +11,7 @@
          "../util/protocol-types.rkt"
          "../runtime/session-store.rkt"
          "../runtime/session-index.rkt"
-         "../runtime/context-manager.rkt"
+         "../runtime/context-assembly.rkt"
          "../llm/token-budget.rkt")
 
 ;; ── Helpers ──────────────────────────────────────────────────
@@ -100,11 +100,11 @@
                     (lambda (idx)
                       ;; Use very small budget → lots of excluded entries
                       (define cfg
-                        (make-context-manager-config #:recent-tokens 30
-                                                     #:max-catalog-entries 50
-                                                     #:max-catalog-tokens 100))
-                      (define-values (_result catalog) (assemble-context idx cfg))
-                      catalog)))
+                        (make-context-assembly-config #:recent-tokens 30
+                                                      #:max-catalog-entries 50
+                                                      #:max-catalog-tokens 100))
+                      (define _cr (build-assembled-context idx cfg))
+                      (context-result-catalog _cr))))
       ;; Total catalog tokens should be under cap
       (define catalog-tokens
         (for/sum ([e (in-list catalog)]) (estimate-text-tokens (catalog-entry-summary e))))
@@ -117,14 +117,16 @@
       (with-index msgs
                   (lambda (idx)
                     ;; Tiny budget: only 10 tokens — way less than pinned messages
-                    (define cfg (make-context-manager-config #:recent-tokens 10))
-                    (define-values (result catalog) (assemble-context idx cfg))
+                    (define cfg (make-context-assembly-config #:recent-tokens 10))
+                    (define cr (build-assembled-context idx cfg))
                     ;; System prompt must be present
                     (define sys-msgs
-                      (filter (lambda (m) (eq? (message-kind m) 'system-instruction)) result))
+                      (filter (lambda (m) (eq? (message-kind m) 'system-instruction))
+                              (context-result-messages cr)))
                     (check-equal? (length sys-msgs) 1 "System prompt must survive")
                     ;; First user message must be present
-                    (define user-msgs (filter (lambda (m) (eq? (message-role m) 'user)) result))
+                    (define user-msgs
+                      (filter (lambda (m) (eq? (message-role m) 'user)) (context-result-messages cr)))
                     (check-true (>= (length user-msgs) 1) "First user message must survive")
                     (void))))
 
@@ -178,11 +180,12 @@
       (define msgs (append (list sys u1) tool-msgs (list u2 a2)))
       (with-index msgs
                   (lambda (idx)
-                    (define cfg (make-context-manager-config #:recent-tokens 30))
-                    (define-values (result catalog) (assemble-context idx cfg))
+                    (define cfg (make-context-assembly-config #:recent-tokens 30))
+                    (define cr (build-assembled-context idx cfg))
                     ;; Consecutive tool results should be collapsed to fewer catalog entries
                     (define tool-entries
-                      (filter (lambda (e) (equal? (catalog-entry-role e) "tool")) catalog))
+                      (filter (lambda (e) (equal? (catalog-entry-role e) "tool"))
+                              (context-result-catalog cr)))
                     (check-true (< (length tool-entries) (length tool-msgs))
                                 (format "Expected collapsed tool entries, got ~a for ~a tools"
                                         (length tool-entries)
@@ -197,18 +200,18 @@
       ;; Write empty session
       (call-with-output-file sp (lambda (p) (void)) #:exists 'replace)
       (define idx (build-index! sp ip))
-      (define cfg (make-context-manager-config))
-      (define-values (result catalog) (assemble-context idx cfg))
-      (check-equal? result '())
-      (check-equal? catalog '())
+      (define cfg (make-context-assembly-config))
+      (define cr (build-assembled-context idx cfg))
+      (check-equal? (context-result-messages cr) '())
+      (check-equal? (context-result-catalog cr) '())
       (delete-directory/files dir #:must-exist? #f))
 
     ;; ── Config defaults are reasonable ───────────────────────
     (test-case "config defaults are production-ready"
-      (define cfg (make-context-manager-config))
-      (check-equal? (context-manager-config-recent-tokens cfg) 30000)
-      (check-equal? (context-manager-config-max-catalog-entries cfg) 40)
-      (check-equal? (context-manager-config-max-catalog-tokens cfg) 2000)
-      (check-equal? (context-manager-config-summary-window cfg) 4000))))
+      (define cfg (make-context-assembly-config))
+      (check-equal? (context-assembly-config-recent-tokens cfg) 30000)
+      (check-equal? (context-assembly-config-max-catalog-entries cfg) 40)
+      (check-equal? (context-assembly-config-max-catalog-tokens cfg) 2000)
+      (check-equal? (context-assembly-config-summary-window cfg) 4000))))
 
 (run-tests polish-tests)

--- a/tests/test-context-summary.rkt
+++ b/tests/test-context-summary.rkt
@@ -19,7 +19,7 @@
                   message-content)
          "../runtime/session-store.rkt"
          "../runtime/session-index.rkt"
-         "../runtime/context-manager.rkt")
+         "../runtime/context-assembly.rkt")
 
 (define summary-tests
   (test-suite "context-summary"
@@ -153,11 +153,11 @@
                             (hasheq))))
       (append-entries! sp msgs)
       (define idx (build-index! sp ip))
-      (define cfg (make-context-manager-config #:recent-tokens 10000))
-      (define-values (result catalog) (assemble-context idx cfg))
+      (define cfg (make-context-assembly-config #:recent-tokens 10000))
+      (define cr (build-assembled-context idx cfg))
       ;; Small session fits entirely — no summary needed
-      (check-equal? (length result) 3)
-      (check-equal? (length catalog) 0)
+      (check-equal? (length (context-result-messages cr)) 3)
+      (check-equal? (length (context-result-catalog cr)) 0)
       (delete-directory/files dir #:must-exist? #f))))
 
 (run-tests summary-tests)

--- a/tests/test-summary-integration.rkt
+++ b/tests/test-summary-integration.rkt
@@ -15,7 +15,7 @@
          "../util/protocol-types.rkt"
          "../runtime/session-store.rkt"
          "../runtime/session-index.rkt"
-         "../runtime/context-manager.rkt")
+         "../runtime/context-assembly.rkt")
 
 ;; Helper: extract text from a message
 (define (msg-text m)
@@ -93,57 +93,64 @@
       (define msgs (build-chain "System" "Hello" 0 "x" "Recent" "Reply"))
       (with-session msgs
                     (lambda (idx)
-                      (define cfg (make-context-manager-config #:recent-tokens 10000))
-                      (define-values (result catalog) (assemble-context idx cfg))
-                      (check-false (for/or ([m (in-list result)])
-                                     (eq? (message-kind m) 'compaction-summary)))
-                      (check-equal? (length result) 4) ; sys + u1 + u2 + a2
-                      (check-equal? (length catalog) 0)
+                      (define cfg (make-context-assembly-config #:recent-tokens 10000))
+                      (define cr (build-assembled-context idx cfg))
+                      (check-false (for/or ([m (in-list (context-result-messages cr))])
+                                     (eq? (message-kind m) 'context-assembly-summary)))
+                      (check-equal? (length (context-result-messages cr)) 4) ; sys + u1 + u2 + a2
+                      (check-equal? (length (context-result-catalog cr)) 0)
                       (void))))
 
     ;; Large session: summary generated for excluded entries
     (test-case "large session generates summary for excluded entries"
       (define msgs (build-chain "System" "Start" 20 "old" "Recent user" "Recent reply"))
-      (with-session
-       msgs
-       (lambda (idx)
-         (define cfg (make-context-manager-config #:recent-tokens 50))
-         (define-values (result catalog) (assemble-context idx cfg))
-         (check-true (>= (length result) 3) (format "Expected >= 3 messages, got ~a" (length result)))
-         (define summary-msgs (filter (lambda (m) (eq? (message-kind m) 'compaction-summary)) result))
-         (check-true (>= (length summary-msgs) 1)
-                     (format "Expected >= 1 summary, got ~a" (length summary-msgs)))
-         (void))))
+      (with-session msgs
+                    (lambda (idx)
+                      (define cfg (make-context-assembly-config #:recent-tokens 50))
+                      (define cr (build-assembled-context idx cfg))
+                      (check-true (>= (length (context-result-messages cr)) 3)
+                                  (format "Expected >= 3 messages, got ~a"
+                                          (length (context-result-messages cr))))
+                      (define summary-msgs
+                        (filter (lambda (m) (eq? (message-kind m) 'context-assembly-summary))
+                                (context-result-messages cr)))
+                      (check-true (>= (length summary-msgs) 1)
+                                  (format "Expected >= 1 summary, got ~a" (length summary-msgs)))
+                      (void))))
 
     ;; Cache is used when provided
     (test-case "assemble-context uses provided cache"
       (define msgs (build-chain "System" "First" 10 "old" "Recent" "Reply"))
-      (with-session
-       msgs
-       (lambda (idx)
-         (define cfg (make-context-manager-config #:recent-tokens 50))
-         (define cache (make-summary-cache))
-         (define-values (result1 catalog1) (assemble-context idx cfg #:cache cache))
-         (define-values (result2 catalog2) (assemble-context idx cfg #:cache cache))
-         (define summary1 (filter (lambda (m) (eq? (message-kind m) 'compaction-summary)) result1))
-         (define summary2 (filter (lambda (m) (eq? (message-kind m) 'compaction-summary)) result2))
-         (when (and (pair? summary1) (pair? summary2))
-           (check-equal? (msg-text (car summary1)) (msg-text (car summary2))))
-         (void))))
+      (with-session msgs
+                    (lambda (idx)
+                      (define cfg (make-context-assembly-config #:recent-tokens 50))
+                      (define cache (make-summary-cache))
+                      (define cr1 (build-assembled-context idx cfg #:cache cache))
+                      (define cr2 (build-assembled-context idx cfg #:cache cache))
+                      (define summary1
+                        (filter (lambda (m) (eq? (message-kind m) 'context-assembly-summary))
+                                (context-result-messages cr1)))
+                      (define summary2
+                        (filter (lambda (m) (eq? (message-kind m) 'context-assembly-summary))
+                                (context-result-messages cr2)))
+                      (when (and (pair? summary1) (pair? summary2))
+                        (check-equal? (msg-text (car summary1)) (msg-text (car summary2))))
+                      (void))))
 
     ;; Summary message has correct structure
     (test-case "summary message has compaction-summary kind and user role"
       (define msgs (build-chain "System" "Start" 10 "old" "Recent" "Reply"))
       (with-session msgs
                     (lambda (idx)
-                      (define cfg (make-context-manager-config #:recent-tokens 50))
-                      (define-values (result catalog) (assemble-context idx cfg))
+                      (define cfg (make-context-assembly-config #:recent-tokens 50))
+                      (define cr (build-assembled-context idx cfg))
                       (define summary-msgs
-                        (filter (lambda (m) (eq? (message-kind m) 'compaction-summary)) result))
+                        (filter (lambda (m) (eq? (message-kind m) 'context-assembly-summary))
+                                (context-result-messages cr)))
                       (when (pair? summary-msgs)
                         (define sm (car summary-msgs))
                         (check-eq? (message-role sm) 'user)
-                        (check-eq? (message-kind sm) 'compaction-summary))
+                        (check-eq? (message-kind sm) 'context-assembly-summary))
                       (void))))))
 
 (run-tests integration-tests)


### PR DESCRIPTION
Addresses #2436.

feat: migrate test files from context-manager to context-assembly (#2436)

W2 of v0.23.1:
- test-context-summary.rkt: import from context-assembly, use build-assembled-context
- test-summary-integration.rkt: import from context-assembly, use context-result-* accessors
- test-context-manager-polish.rkt: import from context-assembly, update config accessors
- All 92 context tests pass (16+10+4+5+11+8+14+6+18)

Closes #2436.