### PR TITLE
feat: token memoization + catalog O(1) counting (#2444)

W0 of v0.23.2:
- Added per-assembly token memoization in build-assembled-context
- fit-recent accepts optional memoized estimator
- generate-catalog uses O(1) counter instead of (length acc) per iteration
- New test file: test-context-assembly-perf.rkt (4 tests)
- All existing context tests still pass

Closes #2444.

### DIFF
--- a/runtime/context-assembly.rkt
+++ b/runtime/context-assembly.rkt
@@ -31,10 +31,7 @@
                   system-message?)
          (only-in "../runtime/compactor.rkt" llm-summarize)
          (only-in "../llm/provider.rkt" provider?)
-         (only-in "../util/hook-types.rkt"
-                  hook-result-action
-                  hook-result-payload
-                  hook-result?))
+         (only-in "../util/hook-types.rkt" hook-result-action hook-result-payload hook-result?))
 
 ;; Config
 (provide context-assembly-config
@@ -175,17 +172,22 @@
   (if (null? raw-messages)
       (context-result '() 0 0 0 0 #f '() #f)
       (let ()
+        ;; Per-assembly token memoization: estimate each message at most once
+        (define token-memo (make-hash))
+        (define (memoized-estimate msg)
+          (hash-ref! token-memo (message-id msg) (lambda () (estimate-message-tokens msg))))
+
         (define max-tokens (context-assembly-config-recent-tokens config))
         ;; Phase 1: Identify pinned items (system + first user + compaction summaries)
         (define-values (pinned removable) (partition-messages raw-messages))
-        (define pinned-tokens (for/sum ([m (in-list pinned)]) (estimate-message-tokens m)))
+        (define pinned-tokens (for/sum ([m (in-list pinned)]) (memoized-estimate m)))
 
         ;; Phase 3: Fit recent messages within remaining budget
         (define remaining-budget (- max-tokens pinned-tokens))
         (define-values (recent excluded)
           (if (<= remaining-budget 0)
               (values '() removable)
-              (fit-recent removable remaining-budget)))
+              (fit-recent removable remaining-budget memoized-estimate)))
 
         ;; Phase 2: Generate summary for excluded entries
         (define summary-obj (generate-context-summary excluded provider model-name #:cache cache))
@@ -206,7 +208,8 @@
         (define catalog
           (generate-catalog excluded
                             #:max-entries max-entries
-                            #:max-tokens (context-assembly-config-max-catalog-tokens config)))
+                            #:max-tokens (context-assembly-config-max-catalog-tokens config)
+                            #:estimate-text estimate-text-tokens))
 
         ;; Phase 5: Reassemble in original order
         (define pinned-ids
@@ -241,7 +244,7 @@
 
         ;; Ensure first user message is in result (pin guarantee)
         (define result-with-pin (ensure-first-user-pinned result-with-summary raw-messages))
-        (define total-tokens (for/sum ([m (in-list result-with-pin)]) (estimate-message-tokens m)))
+        (define total-tokens (for/sum ([m (in-list result-with-pin)]) (memoized-estimate m)))
         (define over-budget? (> total-tokens max-tokens))
 
         (context-result result-with-pin
@@ -279,7 +282,8 @@
 ;; Phase 3: Fit recent messages
 ;; ============================================================
 
-(define (fit-recent messages budget)
+;; Internal: fit-recent with memoized token estimator
+(define (fit-recent messages budget [estimate-fn estimate-message-tokens])
   (let loop ([remaining (reverse messages)]
              [kept '()]
              [excluded '()]
@@ -288,7 +292,7 @@
       [(null? remaining) (values (reverse kept) (reverse excluded))]
       [else
        (define m (car remaining))
-       (define tokens (estimate-message-tokens m))
+       (define tokens (estimate-fn m))
        (cond
          [(> (+ used tokens) budget) (loop (cdr remaining) kept (cons m excluded) used)]
          [else (loop (cdr remaining) (cons m kept) excluded (+ used tokens))])])))
@@ -297,20 +301,24 @@
 ;; Phase 4: Catalog generation
 ;; ============================================================
 
-(define (generate-catalog entries #:max-entries [max-entries 40] #:max-tokens [max-tokens 2000])
+(define (generate-catalog entries
+                          #:max-entries [max-entries 40]
+                          #:max-tokens [max-tokens 2000]
+                          #:estimate-text [estimate-text-fn estimate-text-tokens])
   (define collapsed (collapse-consecutive-tools entries))
   (let loop ([remaining collapsed]
              [acc '()]
-             [used-tokens 0])
+             [used-tokens 0]
+             [count 0])
     (cond
       [(null? remaining) (reverse acc)]
-      [(>= (length acc) max-entries) (reverse acc)]
+      [(>= count max-entries) (reverse acc)]
       [else
        (define entry (car remaining))
-       (define tokens (estimate-text-tokens (catalog-entry-summary entry)))
+       (define tokens (estimate-text-fn (catalog-entry-summary entry)))
        (if (> (+ used-tokens tokens) max-tokens)
            (reverse acc)
-           (loop (cdr remaining) (cons entry acc) (+ used-tokens tokens)))])))
+           (loop (cdr remaining) (cons entry acc) (+ used-tokens tokens) (add1 count)))])))
 
 (define (collapse-consecutive-tools entries)
   (define-values (result current-group)

--- a/tests/test-context-assembly-perf.rkt
+++ b/tests/test-context-assembly-perf.rkt
@@ -1,0 +1,102 @@
+#lang racket
+
+;; tests/test-context-assembly-perf.rkt — Token memoization benchmark
+;;
+;; Verifies that per-assembly memoization reduces repeated token estimation.
+;; Tests that build-assembled-context produces correct results consistently
+;; and that catalog generation uses O(1) counting.
+
+(require rackunit
+         rackunit/text-ui
+         "../util/protocol-types.rkt"
+         "../runtime/session-store.rkt"
+         "../runtime/session-index.rkt"
+         "../runtime/context-assembly.rkt"
+         "../runtime/context-policy.rkt")
+
+;; ── Helpers ──────────────────────────────────────────────────
+
+(define (make-temp-dir)
+  (make-temporary-file "q-ctx-perf-~a" 'directory))
+
+(define (session-path dir)
+  (build-path dir "session.jsonl"))
+
+(define (index-path dir)
+  (build-path dir "session.index"))
+
+(define (make-msg id parent-id role kind text)
+  (make-message id parent-id role kind (list (make-text-part text)) (current-seconds) (hasheq)))
+
+(define (build-linear-session count #:content [content "Message content for testing assembly"])
+  (define dir (make-temp-dir))
+  (define sp (session-path dir))
+  (define ip (index-path dir))
+  (define entries
+    (for/list ([i (in-range count)])
+      (define id (format "m~a" i))
+      (define parent
+        (if (= i 0)
+            #f
+            (format "m~a" (sub1 i))))
+      (define role
+        (if (= i 0)
+            'system
+            (if (odd? i) 'user 'assistant)))
+      (define kind (if (= i 0) 'system-instruction 'message))
+      (make-msg id parent role kind (format "[~a] ~a" i content))))
+  (append-entries! sp entries)
+  (define idx (build-index! sp ip))
+  (values idx dir))
+
+(define perf-tests
+  (test-suite "context-assembly-perf"
+
+    ;; Memoization produces deterministic results
+    (test-case "memoized assembly produces deterministic output"
+      (define-values (idx dir) (build-linear-session 50 #:content (make-string 80 #\x)))
+      (define cfg (make-context-assembly-config #:recent-tokens 2000))
+      (define cr (build-assembled-context idx cfg))
+      (check-true (context-result? cr))
+      (check-true (>= (length (context-result-messages cr)) 1))
+      (check-true (>= (context-result-total-tokens cr) 0))
+      (delete-directory/files dir))
+
+    ;; Large session performance: 200 messages should complete quickly
+    (test-case "200-message assembly completes within 2 seconds (5 runs)"
+      (define-values (idx dir) (build-linear-session 200 #:content (make-string 120 #\x)))
+      (define cfg (make-context-assembly-config #:recent-tokens 5000))
+      (define start (current-inexact-milliseconds))
+      (for ([_ (in-range 5)])
+        (build-assembled-context idx cfg))
+      (define elapsed (- (current-inexact-milliseconds) start))
+      ;; 5 iterations of 200-message assembly should be < 2s
+      (check-true (< elapsed 2000)
+                  (format "5x 200-msg assembly took ~ams (expected <2000ms)" elapsed))
+      (delete-directory/files dir))
+
+    ;; Memoization consistency: two calls produce identical results
+    (test-case "repeated assemblies produce identical results"
+      (define-values (idx dir) (build-linear-session 100 #:content (make-string 100 #\x)))
+      (define cfg (make-context-assembly-config #:recent-tokens 3000))
+      (define cr1 (build-assembled-context idx cfg))
+      (define cr2 (build-assembled-context idx cfg))
+      (check-equal? (length (context-result-messages cr1)) (length (context-result-messages cr2)))
+      (check-equal? (context-result-total-tokens cr1) (context-result-total-tokens cr2))
+      (check-equal? (context-result-pinned-count cr1) (context-result-pinned-count cr2))
+      (delete-directory/files dir))
+
+    ;; Catalog generation uses O(1) counting (not length per iteration)
+    (test-case "catalog generation respects max-entries with O(1) counting"
+      ;; Create messages that become catalog entries
+      (define-values (idx dir) (build-linear-session 100 #:content (make-string 60 #\y)))
+      ;; Tiny budget forces most into catalog
+      (define cfg
+        (make-context-assembly-config #:recent-tokens 50 #:max-catalog-entries 10 #:max-catalog-tokens 5000))
+      (define cr (build-assembled-context idx cfg))
+      (check-true (<= (length (context-result-catalog cr)) 10)
+                  (format "Expected <= 10 catalog entries, got ~a"
+                          (length (context-result-catalog cr))))
+      (delete-directory/files dir))))
+
+(run-tests perf-tests)


### PR DESCRIPTION
Addresses #2444.

feat: token memoization + catalog O(1) counting (#2444)

W0 of v0.23.2:
- Added per-assembly token memoization in build-assembled-context
- fit-recent accepts optional memoized estimator
- generate-catalog uses O(1) counter instead of (length acc) per iteration
- New test file: test-context-assembly-perf.rkt (4 tests)
- All existing context tests still pass

Closes #2444.