### PR TITLE
feat: LRU cache eviction + O(1) catalog counting (#2448)

W1 of v0.23.2:
- Converted summary-cache to LRU with configurable max-entries (default 50)
- Lookup promotes entry to front of LRU order
- Store evicts oldest entry when at capacity
- summary-cache-count and summary-cache-max-entries exported for testing
- New test file: test-summary-cache-eviction.rkt (8 tests)
- All existing context tests still pass

Closes #2448.

### DIFF
--- a/runtime/context-assembly.rkt
+++ b/runtime/context-assembly.rkt
@@ -93,10 +93,14 @@
          context-summary-prompt
          generate-context-summary
          ;; Summary cache
+         ;; Summary cache
          summary-cache
          make-summary-cache
          summary-cache-lookup
-         summary-cache-store!)
+         summary-cache-store!
+         summary-cache-count
+         summary-cache-max-entries
+         DEFAULT-CACHE-MAX-ENTRIES)
 
 ;; ============================================================
 ;; Configuration
@@ -143,19 +147,51 @@
 (struct context-summary (from-id to-id text entry-count) #:transparent)
 
 ;; ============================================================
-;; Summary cache
+;; Summary cache — LRU eviction when capacity exceeded
 ;; ============================================================
 
-(struct summary-cache ([table #:mutable]) #:transparent)
+;; Default maximum cache entries before LRU eviction
+(define DEFAULT-CACHE-MAX-ENTRIES 50)
 
-(define (make-summary-cache)
-  (summary-cache (hash)))
+(struct summary-cache
+        ([table #:mutable] ; hash: key=(from-id . to-id) → value=text
+         [order #:mutable] ; list of keys in LRU order (newest first)
+         [max-entries #:mutable]) ; capacity limit
+  #:transparent)
+
+(define (make-summary-cache #:max-entries [max DEFAULT-CACHE-MAX-ENTRIES])
+  (summary-cache (hash) '() max))
 
 (define (summary-cache-lookup cache from-id to-id)
-  (hash-ref (summary-cache-table cache) (cons from-id to-id) #f))
+  (define key (cons from-id to-id))
+  (define result (hash-ref (summary-cache-table cache) key #f))
+  ;; Promote to front of LRU on hit
+  (when result
+    (set-summary-cache-order! cache (cons key (remove key (summary-cache-order cache) equal?))))
+  result)
 
 (define (summary-cache-store! cache from-id to-id text)
-  (set-summary-cache-table! cache (hash-set (summary-cache-table cache) (cons from-id to-id) text)))
+  (define key (cons from-id to-id))
+  (define current-table (summary-cache-table cache))
+  (define current-order (summary-cache-order cache))
+  ;; If key already exists, just update and promote
+  (cond
+    [(hash-has-key? current-table key)
+     (set-summary-cache-table! cache (hash-set current-table key text))
+     (set-summary-cache-order! cache (cons key (remove key current-order equal?)))]
+    [else
+     ;; Evict oldest if at capacity
+     (when (>= (hash-count current-table) (summary-cache-max-entries cache))
+       (define oldest-key (last current-order))
+       (set-summary-cache-table! cache (hash-remove current-table oldest-key))
+       (set-summary-cache-order! cache (remove oldest-key current-order equal?)))
+     ;; Insert new entry at front
+     (set-summary-cache-table! cache (hash-set (summary-cache-table cache) key text))
+     (set-summary-cache-order! cache (cons key (summary-cache-order cache)))]))
+
+;; Query cache size (for testing)
+(define (summary-cache-count cache)
+  (hash-count (summary-cache-table cache)))
 
 ;; ============================================================
 ;; Core: build-assembled-context

--- a/tests/test-summary-cache-eviction.rkt
+++ b/tests/test-summary-cache-eviction.rkt
@@ -1,0 +1,83 @@
+#lang racket
+
+;; tests/test-summary-cache-eviction.rkt — LRU eviction for summary cache
+;;
+;; Verifies that the summary-cache evicts oldest entries when at capacity
+;; and promotes accessed entries to prevent premature eviction.
+
+(require rackunit
+         rackunit/text-ui
+         "../runtime/context-assembly.rkt")
+
+(define eviction-tests
+  (test-suite "summary-cache-eviction"
+
+    (test-case "empty cache has count 0"
+      (define c (make-summary-cache))
+      (check-equal? (summary-cache-count c) 0))
+
+    (test-case "store and lookup"
+      (define c (make-summary-cache))
+      (summary-cache-store! c "a" "b" "summary-ab")
+      (check-equal? (summary-cache-lookup c "a" "b") "summary-ab")
+      (check-equal? (summary-cache-count c) 1))
+
+    (test-case "lookup misses return #f"
+      (define c (make-summary-cache))
+      (check-false (summary-cache-lookup c "x" "y")))
+
+    (test-case "LRU eviction at capacity"
+      (define c (make-summary-cache #:max-entries 3))
+      (summary-cache-store! c "a" "b" "s1")
+      (summary-cache-store! c "c" "d" "s2")
+      (summary-cache-store! c "e" "f" "s3")
+      ;; Cache is full (3 entries). Adding a 4th evicts oldest.
+      (summary-cache-store! c "g" "h" "s4")
+      (check-equal? (summary-cache-count c) 3)
+      ;; Oldest (a/b) should be evicted
+      (check-false (summary-cache-lookup c "a" "b"))
+      ;; Others remain
+      (check-equal? (summary-cache-lookup c "c" "d") "s2")
+      (check-equal? (summary-cache-lookup c "e" "f") "s3")
+      (check-equal? (summary-cache-lookup c "g" "h") "s4"))
+
+    (test-case "lookup promotes entry (prevents eviction)"
+      (define c (make-summary-cache #:max-entries 3))
+      (summary-cache-store! c "a" "b" "s1")
+      (summary-cache-store! c "c" "d" "s2")
+      (summary-cache-store! c "e" "f" "s3")
+      ;; Access a/b to promote it (now newest)
+      (summary-cache-lookup c "a" "b")
+      ;; Add new entry — should evict c/d (oldest not accessed)
+      (summary-cache-store! c "g" "h" "s4")
+      (check-equal? (summary-cache-count c) 3)
+      ;; a/b survives because it was promoted
+      (check-equal? (summary-cache-lookup c "a" "b") "s1")
+      ;; c/d was evicted (was oldest before promotion of a/b)
+      (check-false (summary-cache-lookup c "c" "d")))
+
+    (test-case "update existing key does not increase count"
+      (define c (make-summary-cache #:max-entries 3))
+      (summary-cache-store! c "a" "b" "original")
+      (summary-cache-store! c "a" "b" "updated")
+      (check-equal? (summary-cache-count c) 1)
+      (check-equal? (summary-cache-lookup c "a" "b") "updated"))
+
+    (test-case "default capacity is 50"
+      (define c (make-summary-cache))
+      (check-equal? (summary-cache-max-entries c) DEFAULT-CACHE-MAX-ENTRIES))
+
+    (test-case "stress: fill to capacity and verify eviction"
+      (define c (make-summary-cache #:max-entries 10))
+      (for ([i (in-range 20)])
+        (summary-cache-store! c (format "f~a" i) (format "t~a" i) (format "s~a" i)))
+      ;; Should only have last 10 entries
+      (check-equal? (summary-cache-count c) 10)
+      ;; First 10 should be evicted
+      (check-false (summary-cache-lookup c "f0" "t0"))
+      (check-false (summary-cache-lookup c "f9" "t9"))
+      ;; Last 10 should remain
+      (check-equal? (summary-cache-lookup c "f10" "t10") "s10")
+      (check-equal? (summary-cache-lookup c "f19" "t19") "s19"))))
+
+(run-tests eviction-tests)


### PR DESCRIPTION
Addresses #2448.

feat: LRU cache eviction + O(1) catalog counting (#2448)

W1 of v0.23.2:
- Converted summary-cache to LRU with configurable max-entries (default 50)
- Lookup promotes entry to front of LRU order
- Store evicts oldest entry when at capacity
- summary-cache-count and summary-cache-max-entries exported for testing
- New test file: test-summary-cache-eviction.rkt (8 tests)
- All existing context tests still pass

Closes #2448.