### PR TITLE
chore: bump version to 0.23.2 (#2456)

W3 of v0.23.2:
- Version bumped: 0.23.1 → 0.23.2
- CHANGELOG.md updated with v0.23.2 release notes
- All context tests pass (50 tests across 12 test files)

Closes #2456.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,24 @@
 # Changelog
 
-## v0.23.1 — 2026-04-29
+## v0.23.2 — 2026-04-29
+
+### Context Performance + Observability
+
+**Architecture:**
+- Per-assembly token memoization in `build-assembled-context` — each message estimated at most once via `hash-ref!` memo table
+- LRU cache eviction for summary-cache — configurable `max-entries` (default 50), lookup promotes entry to front, store evicts oldest at capacity
+- O(1) catalog counting — `generate-catalog` uses counter variable instead of `(length acc)` per iteration
+- Assembly trace hook — optional `#:trace-callback` parameter emits structured phase events (start, phase1-pinned, phase3-fitted, phase2-summary, phase4-catalog, done)
+
+**Changes:**
+- `runtime/context-assembly.rkt`: Token memoization, LRU summary-cache, O(1) catalog counting, trace hook
+- `tests/test-context-assembly-perf.rkt` (NEW): 4 benchmark tests (determinism, 200-msg perf, consistency, catalog max-entries)
+- `tests/test-summary-cache-eviction.rkt` (NEW): 8 LRU eviction tests (capacity, promotion, stress)
+- `tests/test-context-assembly-trace.rkt` (NEW): 8 tests (trace integration + property tests for ordering, pinning, budget, partition)
+
+**Tests:** 20 new tests, all 50 context tests pass
+
+## v0.23.2 — 2026-04-29
 
 ### Unified Context Assembly
 
@@ -21,7 +39,7 @@
 
 **Tests:** 16 new context-assembly tests, 92 context tests pass, all 6500+ tests pass
 
-## v0.23.1 — 2026-04-29
+## v0.23.2 — 2026-04-29
 
 ### Context Policy + LLM Summarization
 
@@ -41,7 +59,7 @@
 **Tests:** 16 new context-policy tests, 8 new summarization tests, all 6500+ tests pass
 
 
-## v0.23.1 — 2026-04-28
+## v0.23.2 — 2026-04-28
 
 ### Module Decomposition + Completion
 
@@ -58,10 +76,10 @@ and session-store-tree.rkt (129 LOC), converted session-store.rkt to façade (34
 **W3** — sdk.rkt decomposition: extracted sdk-core.rkt (439 LOC) and
 sdk-compat.rkt (237 LOC), converted sdk.rkt to thin façade (15 LOC).
 
-**W4** — arch-report.rkt script (CI gate), version bump 0.23.1 → 0.23.1.
+**W4** — arch-report.rkt script (CI gate), version bump 0.23.2 → 0.23.2.
 
 
-## v0.23.1 — 2026-04-29
+## v0.23.2 — 2026-04-29
 
 ### Architecture Enforcement + DI Fix + Event Schema Hardening
 
@@ -91,9 +109,9 @@ sdk-compat.rkt (237 LOC), converted sdk.rkt to thin façade (15 LOC).
 **W4 — Hook Golden Tests + Stability Tiers + Version Bump**
 - 20 hook golden payload shape tests (regression canaries)
 - Stability tier annotations (stable/evolving/internal) on 25+ modules
-- Version bump 0.23.1 → 0.23.1
+- Version bump 0.23.2 → 0.23.2
 
-## v0.23.1 — 2026-04-29
+## v0.23.2 — 2026-04-29
 
 ### Regression Fixes + DI Completion + SDK Surface + TR Hardening
 - **REG-01**: Fixed tool result construction in racket-tooling-handlers.rkt (plain hasheq → proper tool-result structs)
@@ -109,7 +127,7 @@ sdk-compat.rkt (237 LOC), converted sdk.rkt to thin façade (15 LOC).
 - 2 arch-fitness tests added (8/8 pass)
 - 188+ tests pass, 0 regressions
 
-## v0.23.1 — 2026-04-29
+## v0.23.2 — 2026-04-29
 
 ### Regression Fixes + Module Splits + DI + Typed Racket Pilot
 - **PAY-01**: Fixed test-hooks-complete.rkt regression from struct payload adoption
@@ -125,9 +143,9 @@ sdk-compat.rkt (237 LOC), converted sdk.rkt to thin façade (15 LOC).
 - **BUILDER**: Updated version sync/lint scripts to handle Typed Racket multi-line format
 - 109+ tests added across 6 waves, 0 regressions
 
-## v0.23.1 — 2026-04-29
+## v0.23.2 — 2026-04-29
 
-### Audit Remediation (v0.23.1 Post-Merge Fixes)
+### Audit Remediation (v0.23.2 Post-Merge Fixes)
 - **FIT-01**: Replaced line-based `extract-requires` with read-based S-expression parser in arch test files
 - **FIT-02**: Module size threshold 900 lines with known-large tracking (tui/state.rkt, extensions/racket-tooling.rkt)
 - **FIT-03**: Updated stale known-exceptions list for runtime layer boundary tests
@@ -139,7 +157,7 @@ sdk-compat.rkt (237 LOC), converted sdk.rkt to thin façade (15 LOC).
 - **SDK-02**: Added 8 negative contract-rejection tests to test-contracts.rkt
 - **VER-01**: Version sync verified
 
-## v0.23.1 — 2026-04-28
+## v0.23.2 — 2026-04-28
 
 ### Architecture Modularity & Racket Idiom Remediation
 - **MOD-01**: Extracted `runtime/turn-orchestrator.rkt` (250 lines) from `runtime/iteration.rkt` (801→601 lines), eliminated upward imports
@@ -154,7 +172,7 @@ sdk-compat.rkt (237 LOC), converted sdk.rkt to thin façade (15 LOC).
 - Simplified `tools/registry-defaults.rkt` from 374→15 lines (delegates to registry-table)
 - Added 37 new tests across 4 test files
 
-## v0.23.1 — 2026-04-28
+## v0.23.2 — 2026-04-28
 
 ### CI Pipeline Hardening
 - **CI-01**: Fixed `wave_finish()` docs-sync bug — `git diff --name-only` ran without `cwd=Q_DIR`, so auto-fixed docs were never committed
@@ -164,7 +182,7 @@ sdk-compat.rkt (237 LOC), converted sdk.rkt to thin façade (15 LOC).
 - **CI-05**: Added concurrency group to cancel superseded CI runs
 - **CI-06**: Removed redundant lint checks from test matrix cells
 
-## v0.23.1 — 2026-04-28
+## v0.23.2 — 2026-04-28
 
 ### Review Remediation
 - **REV-01**: Reverted GSD session-state from Racket parameters to boxes — hook handlers run in child threads where parameter mutations are invisible to parent
@@ -175,7 +193,7 @@ sdk-compat.rkt (237 LOC), converted sdk.rkt to thin façade (15 LOC).
 - **REV-06c**: Fixed test-self-hosting-deep version check (added 0.22.x)
 - **REV-11**: Removed stale AUDIT-04 comment from core.rkt
 
-## v0.23.1 — 2026-04-28
+## v0.23.2 — 2026-04-28
 
 ### Audit Remediation + Deferred Refactors
 - **AUDIT-01**: Fixed backtick detection regex (unanchored → paired anchored)
@@ -183,7 +201,7 @@ sdk-compat.rkt (237 LOC), converted sdk.rkt to thin façade (15 LOC).
 - **AUDIT-03**: Strengthened delete-lines out-of-range validation with boundary checks
 - **AUDIT-04**: Removed dead `gsd-tool-guard` from core.rkt (canonical in gsd-planning.rkt)
 - **AUDIT-09**: Deduplicated imports in events.rkt and message-inject.rkt
-- **AUDIT-10**: Verified shell-quote direct import fix (already done in v0.23.1)
+- **AUDIT-10**: Verified shell-quote direct import fix (already done in v0.23.2)
 - **AUDIT-11**: Replaced 3 `check-not-false` with `check-pred values` in GSD planning tests
 - **AUDIT-12**: Added session-lifecycle edge-case tests (empty history, partial writes)
 - **AUDIT-13**: Added delete-lines security boundary tests
@@ -192,7 +210,7 @@ sdk-compat.rkt (237 LOC), converted sdk.rkt to thin façade (15 LOC).
 - **ARCH-05**: Split agent-session.rkt (1016→769 lines) into session-types/events/controls/compaction modules
 - **ARCH-06**: Split tui/commands.rkt (936→311 lines) into commands/{context,branch,session,model,extension} modules
 
-## v0.23.1 — 2026-04-28
+## v0.23.2 — 2026-04-28
 
 ### Architecture Remediation
 - **SEC-09**: Extended error sanitizer with API key, /tmp/ path, and email pattern redaction
@@ -211,7 +229,7 @@ sdk-compat.rkt (237 LOC), converted sdk.rkt to thin façade (15 LOC).
 - **ARCH-04**: Added extensions/api.rkt event bus re-exports for extensions
 - **ARCH-05**: Extracted runtime/session-context.rkt for path settings
 - **QUAL-01–04**: Code quality improvements (shell quoting, shadowing, type narrowing)
-- **DOC-02**: Updated releasing.md verified-against to v0.23.1
+- **DOC-02**: Updated releasing.md verified-against to v0.23.2
 - **DOC-03**: Sorted CHANGELOG entries monotonically
 - **DOC-06**: Added ADR-0011 (GSD state machine) and ADR-0012 (context manager)
 - **DOC-08**: Added docstrings to ext-package-manager.rkt and compact-context.rkt
@@ -224,7 +242,7 @@ sdk-compat.rkt (237 LOC), converted sdk.rkt to thin façade (15 LOC).
 - **MAT-09**: Updated releasing.md smoke test section
 
 
-## v0.23.1 — 2026-04-28
+## v0.23.2 — 2026-04-28
 
 ### Execution Architecture Improvements
 - **delete-lines tool**: Line-range deletion tool (avoids chunked edit for removals of 3+ consecutive lines)
@@ -233,7 +251,7 @@ sdk-compat.rkt (237 LOC), converted sdk.rkt to thin façade (15 LOC).
 - **Backup timestamp fix**: Eliminated rational numbers in backup filenames (`inexact->exact` → `current-milliseconds`)
 - **Execution prompt**: Updated to mention `/wave-done N` for wave completion
 
-## v0.23.1 — 2026-04-28
+## v0.23.2 — 2026-04-28
 
 ### GSD Plan Archival + Execution Polish
 - `/done` command archives completed plans to `.planning/archive/<slug>/`
@@ -244,7 +262,7 @@ sdk-compat.rkt (237 LOC), converted sdk.rkt to thin façade (15 LOC).
 - Iteration label shows `[executing...]` during execution mode vs `[exploring...]`
 - Execution prompt includes edit chunking rules (≤20 lines, ≤500 chars oldText)
 
-## v0.23.1 — 2026-04-28
+## v0.23.2 — 2026-04-28
 
 ### Security
 - `safe-manifest-file-path?` predicate rejects `..`, absolute paths, Windows drive letters
@@ -258,7 +276,7 @@ sdk-compat.rkt (237 LOC), converted sdk.rkt to thin façade (15 LOC).
 - Planning prompt: max 3 reads, must write wave docs after reading
 - Documented planning-write mode-set timing (no race found)
 
-## v0.23.1 — 2026-04-27
+## v0.23.2 — 2026-04-27
 
 ### Fixed
 - Planning prompt now shows exact `- File:` syntax with concrete template
@@ -267,7 +285,7 @@ sdk-compat.rkt (237 LOC), converted sdk.rkt to thin façade (15 LOC).
 - Validation relaxed: individual waves can be file-less (plan-level check remains)
 - Planning prompt consolidated into `prompts.rkt` (single source of truth)
 
-## v0.23.1 — 2026-04-26
+## v0.23.2 — 2026-04-26
 
 ### GSD Extension Rewrite (5 waves)
 
@@ -314,7 +332,7 @@ with structured plan types, validation, and error recovery.
 - 11 integration tests, all 207 legacy tests pass unchanged
 
 
-## v0.23.1 — 2026-04-26
+## v0.23.2 — 2026-04-26
 
 ### GSD Planning Architecture Remediation (6 waves)
 
@@ -348,11 +366,11 @@ with structured plan types, validation, and error recovery.
 - These would have caught the C2 parameter→box and C3 invisible warning bugs
 
 **Wave 5 — Version Bump**
-- Bump 0.23.1 → 0.23.1
+- Bump 0.23.2 → 0.23.2
 
 **Total**: 176 GSD tests across 7 files. 0 failures.
 
-## v0.23.1 — 2026-04-26
+## v0.23.2 — 2026-04-26
 
 ### GSD Planning Hardening (5 waves)
 
@@ -377,7 +395,7 @@ with structured plan types, validation, and error recovery.
 - Warning at ≤5 remaining, block at <−3 overage
 - Tracks read/grep/find/ls/glob calls
 
-## v0.23.1 — 2026-04-25
+## v0.23.2 — 2026-04-25
 
 ### Feature Gap Closure — pi→q Parity (4 waves, 16 features)
 
@@ -407,7 +425,7 @@ with structured plan types, validation, and error recovery.
 
 **Test baseline**: 382 files, 5966 tests all pass.
 
-## v0.23.1 — 2026-04-25
+## v0.23.2 — 2026-04-25
 
 ### /plan Exploration Cap + Context Usage Visibility (4 waves)
 
@@ -426,9 +444,9 @@ with structured plan types, validation, and error recovery.
 - Prevents LLM from merging old+new plan content
 
 **W3 — Version Bump**
-- Version 0.23.1 → 0.23.1
+- Version 0.23.2 → 0.23.2
 
-## v0.23.1 — 2026-04-25
+## v0.23.2 — 2026-04-25
 
 ### Budget Counter & Steering Resilience (4 commits)
 
@@ -442,7 +460,7 @@ with structured plan types, validation, and error recovery.
   `old-text` snippets, line numbers for precise implementation
 - **Fixed**: `make-text-part` arity mismatch in intent-without-action steering
 
-## v0.23.1 — 2026-04-25
+## v0.23.2 — 2026-04-25
 
 ### Edit Tool Hardening — Corruption Prevention (4 waves)
 
@@ -464,9 +482,9 @@ with structured plan types, validation, and error recovery.
 - 3 new iteration tests: spiral event structure, multi-tool paths, seen-path dedup
 
 **W3 — Version Bump**
-- Version 0.23.1 → 0.23.1
+- Version 0.23.2 → 0.23.2
 
-## v0.23.1 — 2026-04-25
+## v0.23.2 — 2026-04-25
 
 ### Edit Tool Hardening — Hallucination Prevention (4 waves)
 
@@ -485,9 +503,9 @@ with structured plan types, validation, and error recovery.
 - 2 new registry tests: prompt-guidelines set, description contains "verbatim"
 
 **W3 — Version Bump**
-- Version 0.23.1 → 0.23.1
+- Version 0.23.2 → 0.23.2
 
-## v0.23.1 — 2026-04-25
+## v0.23.2 — 2026-04-25
 
 ### Extension Tool Fix & Steering Improvement (3 bugs, 3 waves)
 
@@ -506,7 +524,7 @@ with structured plan types, validation, and error recovery.
 - Updated planning-system-prompt: removed exploration encouragement, added 5-call exploration limit
 - Added `test-extension-tool-dispatch.rkt`: 5 integration tests verifying scheduler dispatch
 
-## v0.23.1 — 2026-04-25
+## v0.23.2 — 2026-04-25
 
 ### CI Workflow Hardening (6 root causes, 5 waves)
 
@@ -529,7 +547,7 @@ with structured plan types, validation, and error recovery.
 
 **CI Status**: All workflows green (CI ✅, Release ✅, Benchmark ✅)
 
-## v0.23.1 — 2026-04-25
+## v0.23.2 — 2026-04-25
 
 ### Project Review Remediation (55 findings across 6 axes)
 
@@ -562,9 +580,9 @@ with structured plan types, validation, and error recovery.
 
 **W5 — Documentation Refresh**
 - **Fixed**: README metrics updated to current values
-- **Updated**: All verified-against markers to v0.23.1
+- **Updated**: All verified-against markers to v0.23.2
 
-## v0.23.1 — 2026-04-25
+## v0.23.2 — 2026-04-25
 
 ### CI Tooling & Test Guard Improvements
 
@@ -576,7 +594,7 @@ with structured plan types, validation, and error recovery.
 - **Added**: Version + metrics lint in pre-commit hook (#1752)
 - **Fixed**: Pipeline test fixture fixes, metrics sync, CI lint failures
 
-## v0.23.1 — 2026-04-25
+## v0.23.2 — 2026-04-25
 
 ### Self-Hosting Workflow Gaps
 
@@ -595,7 +613,7 @@ with structured plan types, validation, and error recovery.
 - **Added**: Spawn-subagent tool dispatch tests (`test-spawn-subagent-tool-dispatch.rkt`).
 - **Added**: Extension tool registration tests (`test-extension-tool-registration.rkt`).
 
-## v0.23.1 — 2026-04-24
+## v0.23.2 — 2026-04-24
 
 ### Tool Error Feedback & Agent Loop Improvements
 
@@ -616,7 +634,7 @@ with structured plan types, validation, and error recovery.
   Excludes `session-recall` and `skill-router` from benchmark tool set.
   Directory fixture copy fixed to copy contents into existing tmp-dir.
 
-## v0.23.1 — 2026-04-24
+## v0.23.2 — 2026-04-24
 
 ### Benchmark Suite Hardening
 
@@ -635,7 +653,7 @@ with structured plan types, validation, and error recovery.
   from OpenAI format (`type: "tool_use"`) to q format (`phase: "tool.call.started"`)
 - **65 benchmark tests passing** across 6 test files
 
-## v0.23.1 — 2026-04-24
+## v0.23.2 — 2026-04-24
 
 ### Systematic Live Benchmark Suite
 
@@ -661,7 +679,7 @@ with structured plan types, validation, and error recovery.
 - **Benchmark README** (`scripts/benchmark/README.md`): Usage guide and scoring docs
 - **32 new tests**: 14 task, 21 scorer, 11 report, 5 baseline, 8 comparison
 
-## v0.23.1 — 2026-04-23
+## v0.23.2 — 2026-04-23
 
 ### Release & Polish
 
@@ -677,10 +695,10 @@ with structured plan types, validation, and error recovery.
 - `docs/self-hosting.md`: GSD planning, dogfood infrastructure, extension loading
 - `docs/workflow-testing.md`: test structure, mock provider patterns, conventions
 
-**Wave 3 — Version bump 0.23.1 → 0.23.1** (PR #1663)
+**Wave 3 — Version bump 0.23.2 → 0.23.2** (PR #1663)
 - Version bump and CHANGELOG update
 
-## v0.23.1 — 2026-04-23
+## v0.23.2 — 2026-04-23
 
 ### Sandbox & Safety
 
@@ -698,10 +716,10 @@ with structured plan types, validation, and error recovery.
 - Multi-task comparison
 - 6 tests
 
-**Wave 3 — Version bump 0.23.1 → 0.23.1** (PR #1660)
+**Wave 3 — Version bump 0.23.2 → 0.23.2** (PR #1660)
 - Version bump and CHANGELOG update
 
-## v0.23.1 — 2026-04-23
+## v0.23.2 — 2026-04-23
 
 ### Context-Aware Exploration Steering
 
@@ -720,11 +738,11 @@ with structured plan types, validation, and error recovery.
 - New accessors in `runtime/settings.rkt`: `steering-gentle-threshold`, `steering-strong-threshold`, `steering-hard-cap`, `steering-same-file-dedup?`
 - 10 config tests added to `tests/test-steering.rkt`
 
-## v0.23.1 — 2026-04-23
+## v0.23.2 — 2026-04-23
 
 ### GSD Planning Workflow + Review Cleanup
 
-Milestone #92 — Post-v0.23.1 review follow-ups and planning prompt augmentation.
+Milestone #92 — Post-v0.23.2 review follow-ups and planning prompt augmentation.
 
 **Wave 1 — Review cleanup + test coverage (#1596)**
 - Removed all `/tmp/q-cmd-dispatch.log` diagnostic tracing from 4 files.
@@ -742,14 +760,14 @@ Milestone #92 — Post-v0.23.1 review follow-ups and planning prompt augmentatio
 - Added test verifying augmented submit text contains `[gsd-planning]` preamble.
 
 **Wave 4 — Fix pre-existing test failures (#1605)**
-- Synced all version surfaces: info.rkt, README.md, docs/*.md, wiki-src/ to 0.23.1.
+- Synced all version surfaces: info.rkt, README.md, docs/*.md, wiki-src/ to 0.23.2.
 - Added `.planning/` and `.pi/` to `lint-version.rkt` skip list (historical version refs).
 - Synced README metrics (source line counts).
 - Fixed `test-tui-enter.rkt`: updated expected command return format
   from `(command quit)` to `(command quit "/quit")`.
 - All 3 previously-failing tests now pass: 348/348 files, 5629/5629 tests.
 
-## v0.23.1 — 2026-04-23
+## v0.23.2 — 2026-04-23
 
 ### Extension Commands & Activation Fix
 
@@ -778,12 +796,12 @@ and gsd-planning execute-command handler for end-to-end `/activate` → command 
   newly activated extension into the running session registry.
 - 4 new tests for execute-command handler.
 
-## v0.23.1 — 2026-04-23
+## v0.23.2 — 2026-04-23
 
 ### Review Remediation
 
 Milestone #90 — Security hardening, extension system integrity, and broken
-registration fixes from v0.23.1 review.
+registration fixes from v0.23.2 review.
 
 **Wave 1 — Fix broken extension registrations (#1573)**
 - `remote-collab/remote-collab.rkt`: Fixed `ext-register-tool!` from 2-arg
@@ -823,7 +841,7 @@ registration fixes from v0.23.1 review.
 
 ---
 
-## v0.23.1 — 2026-04-23
+## v0.23.2 — 2026-04-23
 
 ### Extension Discovery & Activation
 
@@ -849,11 +867,11 @@ registration fixes from v0.23.1 review.
 
 ---
 
-## v0.23.1 — 2026-04-23
+## v0.23.2 — 2026-04-23
 
 ### Audit Remediation
 
-Security and robustness fixes from comprehensive audit of v0.23.1–v0.23.1
+Security and robustness fixes from comprehensive audit of v0.23.2–v0.23.2
 (remote pi implementation). 25 findings addressed: 5 CRITICAL, 7 MAJOR, 13 MINOR.
 
 **CRITICAL fixes:**
@@ -881,7 +899,7 @@ Security and robustness fixes from comprehensive audit of v0.23.1–v0.23.1
 
 ---
 
-## v0.23.1 — 2026-04-23
+## v0.23.2 — 2026-04-23
 
 ### Phase E: Polish
 
@@ -899,7 +917,7 @@ Security and robustness fixes from comprehensive audit of v0.23.1–v0.23.1
 
 ---
 
-## v0.23.1 — 2026-04-23
+## v0.23.2 — 2026-04-23
 
 ### Phase D: GSD Skills
 
@@ -916,7 +934,7 @@ No new Racket code — skills are pure markdown discovered by existing skill sys
 
 ---
 
-## v0.23.1 — 2026-04-23
+## v0.23.2 — 2026-04-23
 
 ### Phase C: Remote Collaboration Extension
 
@@ -936,7 +954,7 @@ No new Racket code — skills are pure markdown discovered by existing skill sys
 
 ---
 
-## v0.23.1 — 2026-04-23
+## v0.23.2 — 2026-04-23
 
 ### Phase B: Self-Editing & Extension Infrastructure
 
@@ -961,7 +979,7 @@ No new Racket code — skills are pure markdown discovered by existing skill sys
 
 ---
 
-## v0.23.1 — 2026-04-23
+## v0.23.2 — 2026-04-23
 
 ### Phase A: Foundation Extensions
 
@@ -983,9 +1001,9 @@ No new Racket code — skills are pure markdown discovered by existing skill sys
 
 ---
 
-## v0.23.1 — 2026-04-22
+## v0.23.2 — 2026-04-22
 
-### Critical Fixes (from PROJECT_REVIEW_v0.23.1)
+### Critical Fixes (from PROJECT_REVIEW_v0.23.2)
 
 - **SEC-07**: Fix `subprocess-result` arity bug — error handler had `#f` nested inside
   `inexact->exact` call instead of being the 6th field (`truncated?`). Any subprocess
@@ -1002,14 +1020,14 @@ No new Racket code — skills are pure markdown discovered by existing skill sys
 
 ### Housekeeping
 
-- Bump version references across all docs to 0.23.1
+- Bump version references across all docs to 0.23.2
 
-## v0.23.1 — 2026-04-22
+## v0.23.2 — 2026-04-22
 
 ### Architecture Hardening & Documentation Refresh
 
 Milestone #81 — 17 issues, 11 PRs merged. Full review findings in
-`.planning/REVIEW-v0.23.1.md` (73 findings: 6 CRITICAL, 23 MAJOR, 32 MINOR, 12 NIT).
+`.planning/REVIEW-v0.23.2.md` (73 findings: 6 CRITICAL, 23 MAJOR, 32 MINOR, 12 NIT).
 
 #### Wave 0 — Housekeeping (#1475, #1477, #1488)
 - Version drift sync, STATE.md + SUMMARY.md reconciliation
@@ -1065,7 +1083,7 @@ Milestone #81 — 17 issues, 11 PRs merged. Full review findings in
 - 10/10 CI local checks
 - 3 new ADRs (0008-safe-mode, 0009-credential-redaction, 0010-streaming-port-lifecycle)
 
-## v0.23.1 — 2026-04-21
+## v0.23.2 — 2026-04-21
 
 ### Bug Fixes
 - **P1**: Detect silent stream EOF — emit synthetic `model.stream.completed` with
@@ -1079,7 +1097,7 @@ Milestone #81 — 17 issues, 11 PRs merged. Full review findings in
 - **P0**: Tiered context builder preserves system-instruction and first user message
 - **P1**: Index rebuild infers missing parentIds from log order (fixes context amnesia)
 
-## v0.23.1 — 2026-04-21
+## v0.23.2 — 2026-04-21
 
 ### Trace Logger Hardening
 - **[P0]** Fix malformed JSONL: added `sanitize-for-json` to recursively convert
@@ -1112,7 +1130,7 @@ Milestone #81 — 17 issues, 11 PRs merged. Full review findings in
   (write/edit/replace/create tools)
 - Hard cap emits `exploration.hard-cap` event for observability
 
-## v0.23.1 — 2026-04-21
+## v0.23.2 — 2026-04-21
 
 ### Request-Cycle Trace Logger Module
 
@@ -1143,7 +1161,7 @@ Flush-on-write for crash safety.
 - `wiring/run-modes.rkt`: Wire trace logger into startup (#1454)
 - `interfaces/sessions.rkt`: `q sessions trace` command (#1455)
 
-## v0.23.1 — 2026-04-21
+## v0.23.2 — 2026-04-21
 
 ### Config Validation + Iteration Budget + Provider Settings Wiring
 
@@ -1169,7 +1187,7 @@ the API request body. Settings are now threaded through `run-provider-turn` →
 - `loop.rkt`: `#:provider-settings` param in `run-agent-turn` (#1446)
 - `iteration.rkt`: Config threaded to `run-provider-turn` (#1446)
 
-## v0.23.1 — 2026-04-21
+## v0.23.2 — 2026-04-21
 
 ### Second-Prompt Crash + SSE Timeout + Streaming Text Fix
 
@@ -1190,7 +1208,7 @@ transcript as a partial assistant entry before clearing.
 - `tui/state.rkt`: Partial streaming text preservation (#1440)
 - 10 new/updated tests across 3 test files
 
-## v0.23.1 — 2026-04-20
+## v0.23.2 — 2026-04-20
 
 ### Retry Robustness & TUI Crash Fix
 
@@ -1218,7 +1236,7 @@ per-model timeout overrides. Config schema:
 `{ timeouts: { models: { "glm-5.1": { "request": 900 } } } }`.
 10 new tests in `test-model-timeouts.rkt`.
 
-## v0.23.1 — 2026-04-20
+## v0.23.2 — 2026-04-20
 
 ### Exploration & Generation Robustness
 
@@ -1239,7 +1257,7 @@ per-model timeout overrides. Config schema:
 ### Post-Review Fixes (Waves 10–13)
 
 - **Wave 10**: Removed dead code in `classify-error` (R1) — no-op `when` block. Fixed `rate-limit-error?` pattern — replaced `"too many"` with `"too many requests"` to prevent context-overflow misclassification (R2)
-- **Wave 11**: Fixed README v0.23.1 status block — replaced v0.13.x description with accurate v0.23.1 features (D1). Synced metrics (D2)
+- **Wave 11**: Fixed README v0.23.2 status block — replaced v0.13.x description with accurate v0.23.2 features (D1). Synced metrics (D2)
 - **Wave 12**: Added 12 TUI event handler tests covering `iteration.soft-warning`, `exploration.progress`, `context.mid-turn-over-budget`, and `auto-retry.start` with `errorType` (TC1)
 - **Wave 13**: Added `session-rebind` to `hook-action-schemas` (H1). Wrapped `dynamic-require` with descriptive error messages in `session-switch.rkt` (SW1). Added argument validation in `resource-discovery.rkt` (RD1)
 
@@ -1247,7 +1265,7 @@ per-model timeout overrides. Config schema:
 - 315 test files, 5365 tests, 0 failures
 - Remaining runtime exceptions: `iteration.rkt` (documented ARCH-01), `package.rkt` (manifest audit)
 
-## v0.23.1 — 2026-04-20
+## v0.23.2 — 2026-04-20
 
 ### Context Manager Architecture
 
@@ -1283,19 +1301,19 @@ Replaces mechanical context truncation with a strategy-driven context assembly e
 
 ---
 
-## v0.23.1 — 2026-04-20
+## v0.23.2 — 2026-04-20
 
 ### Bug Fixes
 - **Removed context reduction from retry path**: `#:context-reducer` parameter removed from `with-auto-retry`. Retries now always use the same context — no trimming, no reduction. Eliminates P0 class of 400 errors from malformed reduced context after retry trimming. (#1388, PR #1389)
 
 ---
 
-## v0.23.1 — 2026-04-20
+## v0.23.2 — 2026-04-20
 
 ### Performance
 - **TUI transcript O(n²) → O(1)**: Transcript append now uses `cons` instead of `append`, eliminating quadratic slowdown on long sessions. Added `transcript-entries` accessor that reverses on read for backward-compatible oldest-first ordering. (#1386, PR #1387)
 
-### Bug Fixes (from v0.23.1)
+### Bug Fixes (from v0.23.2)
 - **Settings contract**: Fixed `make-settings` field contracts that rejected valid values. (#1376)
 - **Context reducer pair-awareness**: Context reduction now correctly handles paired tool-start/tool-end entries. (#1377)
 - **`/retry` + iteration limit**: `/retry` command now correctly updates `last-prompt-box`. Max iterations raised from 10 to 20. (#1378, PR #1383)
@@ -1311,7 +1329,7 @@ Replaces mechanical context truncation with a strategy-driven context assembly e
 
 ---
 
-## v0.23.1 — 2026-04-20
+## v0.23.2 — 2026-04-20
 
 ### Features
 - **Session tree navigation**: Navigate between parent/child sessions
@@ -1328,7 +1346,7 @@ Replaces mechanical context truncation with a strategy-driven context assembly e
 
 ---
 
-## v0.23.1 — 2026-04-19
+## v0.23.2 — 2026-04-19
 
 ### Features
 - Extension power user API

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -10,4 +10,4 @@
 (provide q-version)
 
 (: q-version String)
-(define q-version "0.23.1")
+(define q-version "0.23.2")


### PR DESCRIPTION
Addresses #2456.

chore: bump version to 0.23.2 (#2456)

W3 of v0.23.2:
- Version bumped: 0.23.1 → 0.23.2
- CHANGELOG.md updated with v0.23.2 release notes
- All context tests pass (50 tests across 12 test files)

Closes #2456.