### PR TITLE
feat: pair-preserving budget fitting + merge tree-walk, delete context-builder (#2471)

W0 Critical Fixes:
- T1: Replace fit-recent with fit-messages-pair-preserving in build-assembled-context
- T2: Merge tree-walk from context-builder into context-assembly (build-session-context,
  assemble-context, split-at-compaction, entry->context-message, transform-summary-to-user)
- T3: Remove context-builder import from context-assembly
- T4: Update session-lifecycle to import build-session-context from context-assembly
- T5: Delete context-builder.rkt - single unified context module achieved
- T6: Update all test imports from context-builder to context-assembly
- Add optional estimate-fn param to fit-messages-pair-preserving in context-policy

Also merged: build-session-context/tokens, truncate-messages-to-budget,
load-agents-context, build-system-preamble into context-assembly.

Fixes: C1 (pair-preserving in production), C2 (delete context-builder)

### DIFF
--- a/runtime/compactor.rkt
+++ b/runtime/compactor.rkt
@@ -62,7 +62,7 @@
          merge-file-trackers
          format-messages-for-summary
          ;; Tiered Context Assembly (WP-37) — DEPRECATED (#648)
-         ;; Use build-session-context/tokens from context-builder.rkt instead.
+         ;; Use build-session-context/tokens from context-assembly.rkt instead.
          (struct-out tiered-context)
          build-tiered-context
          tiered-context->message-list
@@ -469,7 +469,7 @@
 
 ;; ============================================================
 ;; Tiered Context Assembly (WP-37)
-;; DEPRECATED (#648): Use build-session-context/tokens from context-builder.rkt
+;; DEPRECATED (#648): Use build-session-context/tokens from context-assembly.rkt
 ;; instead. build-tiered-context remains for backward compatibility but will
 ;; be removed in a future version.
 

--- a/runtime/context-assembly.rkt
+++ b/runtime/context-assembly.rkt
@@ -7,7 +7,7 @@
 ;; and consolidates tiered-context from compactor.rkt.
 ;;
 ;; Pipeline:
-;;   1. Tree walk from session index (via context-builder)
+;;   1. Tree walk from session index
 ;;   2. Pin system prompt + first user + compaction summaries
 ;;   3. Fit recent messages within budget (pair-preserving)
 ;;   4. Summarize excluded entries (LLM or fallback)
@@ -16,22 +16,25 @@
 ;;   7. Return context-result with diagnostics
 ;;
 ;; v0.23.1 W0: Created from context-manager.rkt + compactor tiered-context
+;; v0.23.3 W0: Merged tree-walk from context-builder.rkt, deleted context-builder
 
-(require racket/list
+(require racket/file
+         racket/list
          racket/string
+         racket/set
          "../util/protocol-types.rkt"
          "../runtime/session-index.rkt"
-         (only-in "../runtime/context-builder.rkt"
-                  (build-session-context context-builder:build-session-context))
          "../llm/token-budget.rkt"
          (only-in "../runtime/context-policy.rkt"
                   estimate-message-tokens
                   ensure-first-user-pinned
+                  fit-messages-pair-preserving
                   user-message?
                   system-message?)
          (only-in "../runtime/compactor.rkt" llm-summarize)
          (only-in "../llm/provider.rkt" provider?)
-         (only-in "../util/hook-types.rkt" hook-result-action hook-result-payload hook-result?))
+         (only-in "../util/hook-types.rkt" hook-result-action hook-result-payload hook-result?)
+         "../skills/context-files.rkt")
 
 ;; Config
 (provide context-assembly-config
@@ -53,6 +56,13 @@
          ;; Core API
          build-assembled-context
          build-session-context
+         ;; Token-aware context assembly
+         build-session-context/tokens
+         truncate-messages-to-budget
+         entry->context-message
+         ;; AGENTS.md context discovery
+         load-agents-context
+         build-system-preamble
          ;; Result struct
          context-result
          context-result?
@@ -232,12 +242,20 @@
                           'pinned-tokens
                           pinned-tokens))
 
-        ;; Phase 3: Fit recent messages within remaining budget
+        ;; Phase 3: Fit recent messages within remaining budget (pair-preserving)
         (define remaining-budget (- max-tokens pinned-tokens))
         (define-values (recent excluded)
           (if (<= remaining-budget 0)
               (values '() removable)
-              (fit-recent removable remaining-budget memoized-estimate)))
+              (let ()
+                (define kept
+                  (fit-messages-pair-preserving removable remaining-budget memoized-estimate))
+                (define kept-ids
+                  (for/hash ([m (in-list kept)])
+                    (values (message-id m) #t)))
+                (define exc
+                  (filter (lambda (m) (not (hash-has-key? kept-ids (message-id m)))) removable))
+                (values kept exc))))
         (emit-trace 'phase3-fitted
                     (hash 'recent-count
                           (length recent)
@@ -331,8 +349,62 @@
                         summary-obj))))
 
 ;; Backward-compatible entry point: returns just messages list
+;; v0.23.3: Merged tree-walk from context-builder.rkt
 (define (build-session-context idx)
-  (context-builder:build-session-context idx)) ; from context-builder (tree walk)
+  ;; Build a provider-ready message list from the session index.
+  ;; Algorithm:
+  ;;   1. Get active leaf from index
+  ;;   2. Walk leaf→root collecting path entries
+  ;;   3. Find latest compaction-summary on path
+  ;;   4. If compaction found → include summary + messages after compaction point
+  ;;   5. If no compaction → include all path messages
+  ;;   6. Filter out settings/label/bookmark entries
+  ;;   7. Transform summaries to user-role messages
+  ;;   8. Return provider-ready message list (reversed to root→leaf order)
+  (define leaf (active-leaf idx))
+  (cond
+    [(not leaf) '()]
+    [else
+     (define path (get-branch idx (message-id leaf)))
+     (cond
+       [(not path) '()]
+       ;; path is root→leaf order from get-branch
+       [else (assemble-context path)])]))
+
+(define (assemble-context path)
+  ;; Process a root→leaf path into context messages.
+  (define-values (pre-compaction post-compaction) (split-at-compaction path))
+  (define relevant-entries (if post-compaction post-compaction path))
+  (filter-map entry->context-message relevant-entries))
+
+(define (split-at-compaction path)
+  ;; Split path at the last compaction summary.
+  (define compaction-idx
+    (for/last ([entry (in-list path)]
+               [i (in-naturals)]
+               #:when (compaction-summary-entry? entry))
+      i))
+  (cond
+    [(not compaction-idx) (values path #f)]
+    [else
+     (define-values (pre post) (split-at path compaction-idx))
+     (values pre post)]))
+
+(define (entry->context-message entry)
+  ;; Convert a session entry to a context message for LLM consumption.
+  (define kind (message-kind entry))
+  (cond
+    [(memq kind '(message)) entry]
+    [(eq? kind 'compaction-summary) (transform-summary-to-user entry)]
+    [(eq? kind 'branch-summary) (transform-summary-to-user entry)]
+    [(memq kind '(session-info model-change thinking-level-change)) #f]
+    [(memq kind '(tool-result bash-execution)) entry]
+    [(eq? kind 'system-instruction) entry]
+    [(eq? kind 'custom-message) entry]
+    [else entry]))
+
+(define (transform-summary-to-user entry)
+  (struct-copy message entry [role 'user]))
 
 ;; ============================================================
 ;; Phase 1: Pin system prompt + first user + compaction summaries
@@ -613,6 +685,126 @@
   (append (tiered-context-tier-a tc) (tiered-context-tier-b tc) (tiered-context-tier-c tc)))
 
 ;; ============================================================
+;; Token-aware context assembly (from context-builder.rkt)
+;; ============================================================
+
+(define (build-session-context/tokens idx #:max-tokens max-tokens)
+  (define messages (build-session-context idx))
+  (cond
+    [(null? messages) (values '() 0)]
+    [else
+     (define total (for/sum ([m (in-list messages)]) (estimate-message-tokens m)))
+     (cond
+       [(<= total max-tokens) (values messages total)]
+       [else
+        (define truncated (truncate-messages-to-budget messages max-tokens))
+        (define new-total (for/sum ([m (in-list truncated)]) (estimate-message-tokens m)))
+        (values truncated new-total)])]))
+
+(define (truncate-messages-to-budget messages max-tokens)
+  (cond
+    [(null? messages) '()]
+    [(<= (for/sum ([m (in-list messages)]) (estimate-message-tokens m)) max-tokens) messages]
+    [else
+     (define-values (protected removable)
+       (partition (lambda (m) (memq (message-kind m) '(system-instruction compaction-summary)))
+                  messages))
+     (define first-user-msg
+       (for/first ([m (in-list messages)]
+                   #:when (eq? (message-role m) 'user))
+         m))
+     (define protected-tokens (for/sum ([m (in-list protected)]) (estimate-message-tokens m)))
+     (define pinned-tokens
+       (if (and first-user-msg (not (member first-user-msg protected)))
+           (estimate-message-tokens first-user-msg)
+           0))
+     (define remaining-budget (- max-tokens protected-tokens pinned-tokens))
+     (cond
+       [(<= remaining-budget 0) (pin-first-user-internal protected first-user-msg messages)]
+       [else
+        (define kept-removable (fit-messages-from-recent removable remaining-budget))
+        (define kept-ids
+          (for/set ([m (in-list kept-removable)])
+            (message-id m)))
+        (pin-first-user-internal (for/list ([m (in-list messages)]
+                                            #:when (or (memq (message-kind m)
+                                                             '(system-instruction compaction-summary))
+                                                       (set-member? kept-ids (message-id m))))
+                                   m)
+                                 first-user-msg
+                                 messages)])]))
+
+;; Ensure first user message is in the result list.
+(define (pin-first-user-internal lst first-user-msg original-messages)
+  (cond
+    [(not first-user-msg) lst]
+    [(member first-user-msg lst) lst]
+    [else
+     (define target-id (message-id first-user-msg))
+     (define after-id
+       (for/first ([m (in-list (dropf original-messages
+                                      (lambda (m) (not (equal? (message-id m) target-id)))))]
+                   #:when (member m lst))
+         (message-id m)))
+     (if after-id
+         (let loop ([result '()]
+                    [remaining lst])
+           (cond
+             [(null? remaining) (reverse (cons first-user-msg result))]
+             [(equal? (message-id (car remaining)) after-id)
+              (loop (cons (car remaining) (cons first-user-msg result)) (cdr remaining))]
+             [else (loop (cons (car remaining) result) (cdr remaining))]))
+         (cons first-user-msg lst))]))
+
+;; Fit messages from recent end within budget (pair-preserving).
+(define (fit-messages-from-recent messages budget)
+  (fit-messages-pair-preserving messages budget))
+
+;; ============================================================
+;; AGENTS.md context discovery (from context-builder.rkt)
+;; ============================================================
+
+(define (load-agents-context working-directory)
+  (define paths (discover-agents-files working-directory))
+  (cond
+    [(null? paths) ""]
+    [else
+     (define contexts
+       (for/list ([p (in-list paths)]
+                  #:when (file-exists? p))
+         (define content (file->string p))
+         (parse-agent-file content)))
+     (cond
+       [(null? contexts) ""]
+       [else (agent-context-instructions (merge-agent-contexts contexts))])]))
+
+(define (build-system-preamble working-directory)
+  (define paths (discover-agents-files working-directory))
+  (cond
+    [(null? paths) ""]
+    [else
+     (define contexts
+       (for/list ([p (in-list paths)]
+                  #:when (file-exists? p))
+         (define content (file->string p))
+         (parse-agent-file content)))
+     (cond
+       [(null? contexts) ""]
+       [else
+        (define merged (merge-agent-contexts contexts))
+        (define name (agent-context-name merged))
+        (define desc (agent-context-description merged))
+        (define inst (agent-context-instructions merged))
+        (define parts
+          (filter (λ (s) (not (string=? s "")))
+                  (list (if (string=? name "Unnamed Agent")
+                            ""
+                            (format "# ~a" name))
+                        desc
+                        inst)))
+        (string-join parts "\n\n")])]))
+
+;; ============================================================
 ;; Helpers
 ;; ============================================================
 
@@ -628,3 +820,14 @@
   (if (<= (string-length s) max-len)
       s
       (string-append (substring s 0 (- max-len 3)) "...")))
+
+(define (filter-map f lst)
+  (let loop ([lst lst]
+             [acc '()])
+    (cond
+      [(null? lst) (reverse acc)]
+      [else
+       (let ([r (f (car lst))])
+         (if r
+             (loop (cdr lst) (cons r acc))
+             (loop (cdr lst) acc)))])))

--- a/runtime/context-policy.rkt
+++ b/runtime/context-policy.rkt
@@ -121,8 +121,9 @@
 
 ;; Fit as many messages as possible from the recent end within a token budget,
 ;; preserving tool-call/tool-result pairing.
-;; Returns messages in their original order.
-(define (fit-messages-pair-preserving messages budget)
+;; Returns two values: (values kept-messages excluded-messages).
+;; Optional estimate-fn overrides the token estimation function.
+(define (fit-messages-pair-preserving messages budget [estimate-fn estimate-message-tokens])
   (define-values (tr->assistant assistant->trs) (build-pair-index messages))
   (let loop ([remaining (reverse messages)]
              [acc '()]
@@ -137,7 +138,7 @@
          ;; Already included (as pair dependency)
          [(set-member? acc-ids mid) (loop (cdr remaining) acc acc-ids used)]
          [else
-          (define tokens (estimate-message-tokens m))
+          (define tokens (estimate-fn m))
           ;; Calculate pair tokens
           (define pair-tokens 0)
           ;; Tool result → include parent assistant
@@ -149,7 +150,7 @@
                             #:when (equal? (message-id mm) required-assistant))
                   mm))
               (when ass-msg
-                (set! pair-tokens (+ pair-tokens (estimate-message-tokens ass-msg))))))
+                (set! pair-tokens (+ pair-tokens (estimate-fn ass-msg))))))
           ;; Assistant with tool_calls → include child tool results
           (define child-trs (hash-ref assistant->trs mid #f))
           (when child-trs
@@ -160,7 +161,7 @@
                               #:when (equal? (message-id mm) tr-id))
                     mm))
                 (when tr-msg
-                  (set! pair-tokens (+ pair-tokens (estimate-message-tokens tr-msg)))))))
+                  (set! pair-tokens (+ pair-tokens (estimate-fn tr-msg)))))))
           (define total-needed (+ used tokens pair-tokens))
           (cond
             [(> total-needed budget) (reverse acc)]
@@ -178,7 +179,7 @@
                      (if ass-msg
                          (values (cons ass-msg new-acc)
                                  (set-add new-ids required-assistant)
-                                 (+ new-used (estimate-message-tokens ass-msg)))
+                                 (+ new-used (estimate-fn ass-msg)))
                          (values new-acc new-ids new-used)))
                    (values new-acc new-ids new-used)))
              ;; Include child tool results if needed
@@ -196,7 +197,7 @@
                            (if tr-msg
                                (values (cons tr-msg fa)
                                        (set-add fi tr-id)
-                                       (+ fu (estimate-message-tokens tr-msg)))
+                                       (+ fu (estimate-fn tr-msg)))
                                (values fa fi fu)))))
                    (values final-acc final-ids final-used)))
              (loop (cdr remaining) final-acc2 final-ids2 final-used2)])])])))

--- a/runtime/session-lifecycle.rkt
+++ b/runtime/session-lifecycle.rkt
@@ -43,9 +43,8 @@
                   context-result-catalog
                   context-result?
                   catalog-entry
-                  catalog-entry?)
-         (only-in "../runtime/context-builder.rkt"
-                  (build-session-context context-builder:build-session-context))
+                  catalog-entry?
+                  build-session-context)
          (only-in "../runtime/session-context.rkt" extract-path-settings)
          "../util/ids.rkt"
          (only-in "iteration.rkt"
@@ -89,10 +88,10 @@
 
 ;; build-session-context — context preparation:
 ;;   converts user-message, appends to log, builds/updates index,
-;;   walks tree via context-builder, injects system instructions.
+;;   walks tree via context-assembly, injects system instructions.
 ;;   Returns the context message list.
 ;;
-;;   Wave 1 (#520): Uses session-index + context-builder tree walk
+;;   Wave 1 (#520): Uses session-index + context-assembly tree walk
 ;;   instead of linear load-session-log.
 (define (build-session-context sess user-message ensure-persisted!-fn buffer-or-append!-fn)
   (define log-path (session-log-path (agent-session-session-dir sess)))
@@ -142,7 +141,7 @@
   (when idx
     (append-to-leaf! idx user-msg))
 
-  ;; Build context: use context-assembly when provider available, else context-builder
+  ;; Build context: use context-assembly when provider available, else tree walk
   (define context-messages
     (if idx
         (cond
@@ -155,8 +154,8 @@
                                       #:provider (agent-session-provider sess)
                                       #:model-name (agent-session-model-name sess)))
            (context-result-messages result)]
-          ;; Fallback: context-builder tree walk (no LLM summarization)
-          [else (context-builder:build-session-context idx)])
+          ;; Fallback: context-assembly tree walk (no LLM summarization)
+          [else (build-session-context idx)])
         ;; Fallback: no index — use linear history (backward compat)
         (let ([existing (if (file-exists? log-path)
                             (load-session-log log-path)

--- a/tests/test-compaction-edge-cases.rkt
+++ b/tests/test-compaction-edge-cases.rkt
@@ -14,8 +14,17 @@
 (require rackunit
          rackunit/text-ui
          racket/file
-         "../runtime/compactor.rkt"
-         "../runtime/context-builder.rkt"
+         (only-in "../runtime/compactor.rkt"
+                  compact-and-persist!
+                  compact-history
+                  compaction-result
+                  compaction-result-kept-messages
+                  compaction-result-removed-count
+                  compaction-result-summary-message
+                  compaction-result->message-list
+                  build-summary-window
+                  default-strategy)
+         "../runtime/context-assembly.rkt"
          "../runtime/session-index.rkt"
          "../runtime/session-store.rkt"
          "../runtime/token-compaction.rkt"

--- a/tests/test-context-builder-agents.rkt
+++ b/tests/test-context-builder-agents.rkt
@@ -12,7 +12,7 @@
          rackunit/text-ui
          racket/file
          racket/path
-         "../runtime/context-builder.rkt")
+         "../runtime/context-assembly.rkt")
 
 ;; Helpers
 

--- a/tests/test-context-builder.rkt
+++ b/tests/test-context-builder.rkt
@@ -9,7 +9,7 @@
          "../util/protocol-types.rkt"
          "../runtime/session-store.rkt"
          "../runtime/session-index.rkt"
-         "../runtime/context-builder.rkt"
+         "../runtime/context-assembly.rkt"
          (only-in "../runtime/context-policy.rkt" estimate-message-tokens))
 
 ;; Helpers

--- a/tests/test-context-pair-preserving.rkt
+++ b/tests/test-context-pair-preserving.rkt
@@ -8,7 +8,7 @@
          racket/list
          racket/string
          "../util/protocol-types.rkt"
-         "../runtime/context-builder.rkt"
+         "../runtime/context-assembly.rkt"
          "../llm/token-budget.rkt")
 
 (define (make-text-msg role text [kind 'message])

--- a/tests/test-prompt-pinning.rkt
+++ b/tests/test-prompt-pinning.rkt
@@ -5,7 +5,7 @@
 
 (require rackunit
          "../util/protocol-types.rkt"
-         "../runtime/context-builder.rkt")
+         "../runtime/context-assembly.rkt")
 
 ;; Helper: create a simple message
 (define (make-test-msg role kind text [id (format "msg-~a" (random 100000))])
@@ -23,39 +23,39 @@
   ;; Truncate to a tiny budget that will drop most messages
   (define result (truncate-messages-to-budget msgs 50))
   ;; First user message must be in result
-  (define first-user (for/first ([m (in-list msgs)]
-                                  #:when (eq? (message-role m) 'user))
-                       m))
-  (check-not-false (member first-user result)
-                   "first user message must survive truncation"))
+  (define first-user
+    (for/first ([m (in-list msgs)]
+                #:when (eq? (message-role m) 'user))
+      m))
+  (check-not-false (member first-user result) "first user message must survive truncation"))
 
 ;; ── Test 2: First user message present when no truncation needed ──
 (test-case "first user message present when no truncation needed"
-  (define msgs (list (make-test-msg 'user 'message "hello")
-                     (make-test-msg 'assistant 'message "hi")))
+  (define msgs (list (make-test-msg 'user 'message "hello") (make-test-msg 'assistant 'message "hi")))
   (define result (truncate-messages-to-budget msgs 10000))
   (check-equal? result msgs "no truncation when within budget"))
 
 ;; ── Test 3: System messages still protected ──
 (test-case "system messages and compaction summaries still protected"
-  (define msgs (list (make-test-msg 'system 'system-instruction "system prompt")
-                     (make-test-msg 'system 'compaction-summary "summary")
-                     (make-test-msg 'user 'message "task")
-                     (make-test-msg 'assistant 'message "response")))
+  (define msgs
+    (list (make-test-msg 'system 'system-instruction "system prompt")
+          (make-test-msg 'system 'compaction-summary "summary")
+          (make-test-msg 'user 'message "task")
+          (make-test-msg 'assistant 'message "response")))
   (define result (truncate-messages-to-budget msgs 50))
   ;; System and compaction-summary should be present
   (check-true (for/or ([m (in-list result)]
-                        #:when (eq? (message-kind m) 'system-instruction))
+                       #:when (eq? (message-kind m) 'system-instruction))
                 #t)
               "system-instruction preserved")
   (check-true (for/or ([m (in-list result)]
-                        #:when (eq? (message-kind m) 'compaction-summary))
+                       #:when (eq? (message-kind m) 'compaction-summary))
                 #t)
               "compaction-summary preserved"))
 
 ;; ── Test 4: Pinning is identity when first user already present ──
 (test-case "pinning is identity when first user already present"
-  (define msgs (list (make-test-msg 'user 'message "first")
-                     (make-test-msg 'assistant 'message "response")))
+  (define msgs
+    (list (make-test-msg 'user 'message "first") (make-test-msg 'assistant 'message "response")))
   (define result (truncate-messages-to-budget msgs 10000))
   (check-equal? (length result) 2))

--- a/tests/test-wave2-runtime-ergonomics.rkt
+++ b/tests/test-wave2-runtime-ergonomics.rkt
@@ -14,7 +14,7 @@
          "../runtime/settings.rkt"
          "../runtime/model-registry.rkt"
          "../runtime/session-store.rkt"
-         "../runtime/context-builder.rkt")
+         "../runtime/context-assembly.rkt")
 
 ;; ============================================================
 ;; Helpers
@@ -48,44 +48,37 @@
      (check-not-eq? (current-output-port) real-out)
      ;; call-with-raw-output should restore the real port
      (call-with-raw-output
-      (lambda ()
-        (check-eq? (current-output-port) real-out "raw output should use real port"))))))
+      (lambda () (check-eq? (current-output-port) real-out "raw output should use real port"))))))
 
 (test-case "#1181: stray writes are silently discarded"
   (define captured "")
-  (call-with-output-guard
-   (lambda ()
-     ;; These writes go to the null sink
-     (display "garbage" (current-output-port))
-     (display "more garbage" (current-output-port))
-     ;; Nothing should have been written
-     (void))
-   #:redirect-to (open-output-string))
+  (call-with-output-guard (lambda ()
+                            ;; These writes go to the null sink
+                            (display "garbage" (current-output-port))
+                            (display "more garbage" (current-output-port))
+                            ;; Nothing should have been written
+                            (void))
+                          #:redirect-to (open-output-string))
   ;; No error means the null sink handled the writes
   (check-true #t))
 
 (test-case "#1181: guard can redirect to stderr"
   ;; This just verifies the #:redirect-to option works
   (define buf (open-output-string))
-  (call-with-output-guard
-   (lambda ()
-     (display "redirected" (current-output-port)))
-   #:redirect-to buf)
+  (call-with-output-guard (lambda () (display "redirected" (current-output-port))) #:redirect-to buf)
   (check-equal? (get-output-string buf) "redirected"))
 
 (test-case "#1181: call-with-raw-output outside guard is passthrough"
   (define result
-    (call-with-raw-output
-     (lambda ()
-       (current-output-port)
-       "ok")))
+    (call-with-raw-output (lambda ()
+                            (current-output-port)
+                            "ok")))
   (check-equal? result "ok"))
 
 (test-case "#1181: output guard does not affect error port"
-  (call-with-output-guard
-   (lambda ()
-     ;; Error port should still work
-     (check-true (output-port? (current-error-port))))))
+  (call-with-output-guard (lambda ()
+                            ;; Error port should still work
+                            (check-true (output-port? (current-error-port))))))
 
 ;; ============================================================
 ;; #1182: Model Config Hot Reload
@@ -94,11 +87,10 @@
 (test-case "#1182: reload-config! refreshes model registry"
   ;; Create a settings with one provider with models list
   (define config1
-    (hasheq 'providers
-            (hasheq 'test-provider
-                    (hasheq 'type 'openai
-                            'models (list (hasheq 'id "model-a"
-                                                   'api-key "test-key"))))))
+    (hasheq
+     'providers
+     (hasheq 'test-provider
+             (hasheq 'type 'openai 'models (list (hasheq 'id "model-a" 'api-key "test-key"))))))
   (define reg1 (make-model-registry-from-config config1))
   (define models1 (map model-entry-name (available-models reg1)))
   (check-not-false (member "model-a" models1))
@@ -107,11 +99,11 @@
   (define config2
     (hasheq 'providers
             (hasheq 'test-provider
-                    (hasheq 'type 'openai
-                            'models (list (hasheq 'id "model-b"
-                                                   'api-key "test-key")
-                                          (hasheq 'id "model-c"
-                                                   'api-key "test-key"))))))
+                    (hasheq 'type
+                            'openai
+                            'models
+                            (list (hasheq 'id "model-b" 'api-key "test-key")
+                                  (hasheq 'id "model-c" 'api-key "test-key"))))))
   (define reg2 (make-model-registry-from-config config2))
   (define models2 (map model-entry-name (available-models reg2)))
   (check-false (member "model-a" models2) "old model should be gone")


### PR DESCRIPTION
Addresses #2471.

feat: pair-preserving budget fitting + merge tree-walk, delete context-builder (#2471)

W0 Critical Fixes:
- T1: Replace fit-recent with fit-messages-pair-preserving in build-assembled-context
- T2: Merge tree-walk from context-builder into context-assembly (build-session-context,
  assemble-context, split-at-compaction, entry->context-message, transform-summary-to-user)
- T3: Remove context-builder import from context-assembly
- T4: Update session-lifecycle to import build-session-context from context-assembly
- T5: Delete context-builder.rkt - single unified context module achieved
- T6: Update all test imports from context-builder to context-assembly
- Add optional estimate-fn param to fit-messages-pair-preserving in context-policy

Also merged: build-session-context/tokens, truncate-messages-to-budget,
load-agents-context, build-system-preamble into context-assembly.

Fixes: C1 (pair-preserving in production), C2 (delete context-builder)