### PR TITLE
refactor: dead export removal, explicit import, docstrings (#2508)

W1 Dead Export + Explicit Import + Docstrings:
- T1: Removed requires-pair-inclusion? from provide in context-policy.rkt,
  removed 2 dedicated tests (14 tests, down from 16)
- T2: Verified estimate-text-tokens already imported directly from token-budget.rkt
- T3: Added docstrings to 5 functions in context-assembly.rkt:
  generate-catalog, collapse-consecutive-tools, generate-context-summary,
  build-tiered-context-with-hooks, truncate-messages-to-budget
- All 67 context tests pass

Closes: #2508, #2519, #2520, #2521, #2522

### DIFF
--- a/runtime/context-assembly.rkt
+++ b/runtime/context-assembly.rkt
@@ -460,7 +460,8 @@
 ;; ============================================================
 ;; Phase 4: Catalog generation
 ;; ============================================================
-
+;; generate-catalog: Build a summary catalog from older entries.
+;; Returns a list of (text . entry) pairs fitting within token budget.
 (define (generate-catalog entries
                           #:max-entries [max-entries 40]
                           #:max-tokens [max-tokens 2000]
@@ -480,6 +481,8 @@
            (reverse acc)
            (loop (cdr remaining) (cons entry acc) (+ used-tokens tokens) (add1 count)))])))
 
+;; collapse-consecutive-tools: Merge adjacent tool-call/tool-result sequences
+;; into a single summary entry to reduce context size.
 (define (collapse-consecutive-tools entries)
   (define-values (result current-group)
     (for/fold ([acc '()]
@@ -565,6 +568,8 @@
 ;; Generate context summary
 ;; ============================================================
 
+;; generate-context-summary: Produce a text summary of entries using LLM or fallback.
+;; Returns a context-summary struct or #f if no entries.
 (define (generate-context-summary entries provider model-name #:cache [cache #f])
   (cond
     [(null? entries) #f]
@@ -670,6 +675,8 @@
 
   (tiered-context (append sys-protected pinned-user compaction-summaries) tier-b tier-c))
 
+;; build-tiered-context-with-hooks: Assemble a tiered context (catalog + summary + recent)
+;; and dispatch extension hooks at each stage. Returns a tiered-context struct.
 (define (build-tiered-context-with-hooks messages
                                          #:hook-dispatcher [hook-dispatcher #f]
                                          #:tier-b-count [tier-b-count DEFAULT-TIER-B-COUNT]
@@ -723,6 +730,8 @@
         (define new-total (for/sum ([m (in-list truncated)]) (estimate-message-tokens m)))
         (values truncated new-total)])]))
 
+;; truncate-messages-to-budget: Trim messages from the front to fit within token budget.
+;; Returns truncated message list with first-user pinning preserved.
 (define (truncate-messages-to-budget messages max-tokens)
   (cond
     [(null? messages) '()]

--- a/runtime/context-policy.rkt
+++ b/runtime/context-policy.rkt
@@ -28,7 +28,6 @@
                        [user-message? (-> message? boolean?)])
          ;; Internal helpers (not contracted — used by context-assembly only)
          build-pair-index
-         requires-pair-inclusion?
          ;; Re-export from token-budget
          estimate-text-tokens)
 

--- a/tests/test-context-policy.rkt
+++ b/tests/test-context-policy.rkt
@@ -159,20 +159,3 @@
   ;; Result ids should be a subsequence of original, in order
   (for ([rid (in-list result-ids)])
     (check-pred values (member rid original-ids) (format "~a should be in original" rid))))
-
-;; ============================================================
-;; requires-pair-inclusion?
-;; ============================================================
-
-(test-case "requires-pair-inclusion?: no pairs"
-  (define msgs (list (make-test-message "u" 'user 'message "hi")))
-  (define-values (tr->a a->tr) (build-pair-index msgs))
-  (check-false (requires-pair-inclusion? "u" tr->a a->tr)))
-
-(test-case "requires-pair-inclusion?: tool result has pair"
-  (define msgs
-    (list (make-tool-call-msg "a1" "call" "tc1")
-          (make-tool-result-msg "t1" "tc1" "result" #:parent-id "a1")))
-  (define-values (tr->a a->tr) (build-pair-index msgs))
-  (check-true (requires-pair-inclusion? "t1" tr->a a->tr))
-  (check-true (requires-pair-inclusion? "a1" tr->a a->tr)))


### PR DESCRIPTION
Addresses #2508.

refactor: dead export removal, explicit import, docstrings (#2508)

W1 Dead Export + Explicit Import + Docstrings:
- T1: Removed requires-pair-inclusion? from provide in context-policy.rkt,
  removed 2 dedicated tests (14 tests, down from 16)
- T2: Verified estimate-text-tokens already imported directly from token-budget.rkt
- T3: Added docstrings to 5 functions in context-assembly.rkt:
  generate-catalog, collapse-consecutive-tools, generate-context-summary,
  build-tiered-context-with-hooks, truncate-messages-to-budget
- All 67 context tests pass

Closes: #2508, #2519, #2520, #2521, #2522