### PR TITLE
feat: test label update, config comment, version bump to 0.23.5 (#2513)

W2 Test Labels + Config Comment + Version Bump:
- T1: Updated suite names: context-builder → context-assembly-tree,
  context-builder-agents (G2.3) → context-assembly-agents
- T2: Added config guard comment (0 disables catalog)
- T3: Version bump to 0.23.5 + sync-version (20 docs synced)
- T4: Full regression — 124 tests pass
- T5: CHANGELOG.md updated for v0.23.5

Closes: #2513, #2514, #2515, #2516

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## v0.23.5 — 2026-04-29
+
+### Performance Fix & Code Hygiene
+
+**CRITICAL — O(n²) → O(n) fix:**
+- Built id→msg hash in `fit-messages-pair-preserving`, replaced 4× `for/first` linear scans with O(1) `hash-ref` lookups
+- Function complexity reduced from O(n²) to O(n) for pair resolution
+
+**Dedup — format-messages-for-summary:**
+- Moved canonical implementation to `compaction-prompts.rkt`
+- Deleted local copies from `compactor.rkt` and `context-assembly.rkt` (2 → 1)
+
+**Dead export cleanup:**
+- Removed `requires-pair-inclusion?` from provide in `context-policy.rkt`
+- Removed 2 dedicated tests (no production callers)
+
+**Docstrings added to 5 functions:**
+- `generate-catalog`, `collapse-consecutive-tools`, `generate-context-summary`
+- `build-tiered-context-with-hooks`, `truncate-messages-to-budget`
+
+**Other:**
+- Updated test suite names: `context-builder` → `context-assembly-tree`, `context-builder-agents` → `context-assembly-agents`
+- Added config guard comment for zero max-catalog values
+
+**Tests:** 101 context+compactor tests, 67 assembly+policy tests pass
+
 ## v0.23.4 — 2026-04-29
 
 ### Combined Audit Remediation & Hardening

--- a/runtime/context-assembly.rkt
+++ b/runtime/context-assembly.rkt
@@ -124,6 +124,7 @@
 ;; Configuration
 ;; ============================================================
 
+;; Note: 0 is valid for max-catalog-* (disables catalog)
 (struct context-assembly-config
         (recent-tokens ; tokens for the recent window (default 30000)
          max-catalog-entries ; max catalog entries (default 40)

--- a/tests/test-context-assembly-agents.rkt
+++ b/tests/test-context-assembly-agents.rkt
@@ -28,7 +28,7 @@
   (make-directory (build-path dir ".git")))
 
 (define context-builder-agents-tests
-  (test-suite "context-builder-agents (G2.3)"
+  (test-suite "context-assembly-agents"
 
     ;; -------------------------------------------------------
     ;; load-agents-context: no AGENTS.md → empty string

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -10,4 +10,4 @@
 (provide q-version)
 
 (: q-version String)
-(define q-version "0.23.4")
+(define q-version "0.23.5")


### PR DESCRIPTION
Addresses #2513.

feat: test label update, config comment, version bump to 0.23.5 (#2513)

W2 Test Labels + Config Comment + Version Bump:
- T1: Updated suite names: context-builder → context-assembly-tree,
  context-builder-agents (G2.3) → context-assembly-agents
- T2: Added config guard comment (0 disables catalog)
- T3: Version bump to 0.23.5 + sync-version (20 docs synced)
- T4: Full regression — 124 tests pass
- T5: CHANGELOG.md updated for v0.23.5

Closes: #2513, #2514, #2515, #2516