### PR TITLE
feat(ci): add check-deps to ci_preflight + workflow_dispatch trigger (#2526)

W0 of v0.23.6 — CI Resilience.

T1: Add check-deps.rkt to ci_preflight() in gh_helpers.py so wave_finish
    catches dependency errors before push. Mirrors the CI lint gate.

T2: Add workflow_dispatch trigger to ci.yml for manual re-runs from
    GitHub UI without requiring a new commit.

T3: Both verified locally — check-deps passes, workflow_dispatch present.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:  # Allow manual re-runs from GitHub UI
 
 # Cancel superseded runs on the same branch/PR
 concurrency:


### PR DESCRIPTION
Addresses #2526.

feat(ci): add check-deps to ci_preflight + workflow_dispatch trigger (#2526)

W0 of v0.23.6 — CI Resilience.

T1: Add check-deps.rkt to ci_preflight() in gh_helpers.py so wave_finish
    catches dependency errors before push. Mirrors the CI lint gate.

T2: Add workflow_dispatch trigger to ci.yml for manual re-runs from
    GitHub UI without requiring a new commit.

T3: Both verified locally — check-deps passes, workflow_dispatch present.