### PR TITLE
fix(ci): safe test-check-deps + post-rebase guard (#2530)

W1 of v0.23.6 — CI Resilience.

T1: Add git-restore safety net to test-check-deps.rkt cleanup.
    If dynamic-wind restore fails, falls back to git checkout.
    Prevents REMOVED-FAKE corruption on timeout/interrupt.

T2: Add _post_rebase_fix() to wave_finish that re-syncs version
    refs + metrics after git sync-main. Prevents rebase damage
    to generated files (README.md metrics, version refs).

T3: Both verified — test passes, info.rkt clean after run.

### DIFF
--- a/tests/test-check-deps.rkt
+++ b/tests/test-check-deps.rkt
@@ -32,7 +32,12 @@
          (system/exit-code "racket scripts/check-deps.rkt")))
      (check-not-equal? exit-code 0 "Should fail when dep is missing"))
    (lambda ()
-     (call-with-output-file info-path (lambda (o) (display original o)) #:exists 'truncate))))
+     ;; Restore original content
+     (call-with-output-file info-path (lambda (o) (display original o)) #:exists 'truncate)
+     ;; Safety net: if restore somehow failed, restore from git
+     (unless (string-contains? (file->string info-path) "\"quickcheck\"")
+       (parameterize ([current-directory q-dir])
+         (system "git checkout -- info.rkt"))))))
 
 (test-case "check-deps-verbose-mode"
   (define cmd (format "cd ~a && racket scripts/check-deps.rkt -v" q-dir))


### PR DESCRIPTION
Addresses #2530.

fix(ci): safe test-check-deps + post-rebase guard (#2530)

W1 of v0.23.6 — CI Resilience.

T1: Add git-restore safety net to test-check-deps.rkt cleanup.
    If dynamic-wind restore fails, falls back to git checkout.
    Prevents REMOVED-FAKE corruption on timeout/interrupt.

T2: Add _post_rebase_fix() to wave_finish that re-syncs version
    refs + metrics after git sync-main. Prevents rebase damage
    to generated files (README.md metrics, version refs).

T3: Both verified — test passes, info.rkt clean after run.