### PR TITLE
chore: bump version to 0.23.6, CHANGELOG, maintenance docs (#2534)

W2 of v0.23.6 — CI Resilience.

T1: Add version-awareness comment to check-deps.rkt base-packages.
T2: Bump version from 0.23.5 → 0.23.6, sync-version --write --all.
T3: Add v0.23.6 CHANGELOG entry with all changes.
T4: Key files compile, tests pass.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## v0.23.6 — 2026-04-29
+
+### CI Resilience & Push Safety Net
+
+**Goal**: Make CI green whenever local pre-commit passes. Addresses v0.23.5
+incident requiring 4 CI runs and ~2 hours of debugging.
+
+- **ci_preflight parity**: Added `check-deps.rkt` to `ci_preflight()` in
+  `gh_helpers.py` so dependency errors are caught before push.
+- **workflow_dispatch**: Added manual re-run trigger to `.github/workflows/ci.yml`
+  so CI can be re-triggered without a new commit.
+- **Safe test-check-deps**: Added git-restore safety net to
+  `test-check-deps.rkt` cleanup to prevent info.rkt corruption on
+  timeout/interrupt.
+- **Post-rebase guard**: Added `_post_rebase_fix()` to `wave_finish()` that
+  re-syncs version refs and metrics after git operations.
+- **Maintenance comment**: Added version-awareness comment to
+  `check-deps.rkt` base-packages set.
+
 ## v0.23.5 — 2026-04-29
 
 ### Performance Fix & Code Hygiene

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.23.5-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.23.6-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 
@@ -199,7 +199,7 @@ racket main.rkt --model gpt-5.4 "write a test"
 ### Verify
 
 ```bash
-racket main.rkt --version  # q version 0.23.5
+racket main.rkt --version  # q version 0.23.6
 raco test tests/           # run the full test suite
 ```
 
@@ -272,8 +272,8 @@ q/
 |--------|-------|
 | Test files | 442 |
 | Source modules | 320 |
-| Source lines | 57642 |
-| Test lines | 87607 |
+| Source lines | 57644 |
+| Test lines | 87612 |
 | Test assertions | 13432 |
 | Tests passing | 5835+ | `racket scripts/run-tests.rkt` results |
 
@@ -333,7 +333,7 @@ When q executes shell commands on behalf of an LLM, arguments are quoted via `sh
 
 ## Status
 
-**v0.23.5** — Execution Architecture Improvements. `delete-lines` tool, `/wave-done` command, planning path resolution hardening, backup timestamp fix. 4 issues across 4 waves.
+**v0.23.6** — Execution Architecture Improvements. `delete-lines` tool, `/wave-done` command, planning path resolution hardening, backup timestamp fix. 4 issues across 4 waves.
 
 **v0.23.2** — GSD Plan Archival + Execution Polish. `/done` command, PLAN.md status auto-update, STATE.md auto-creation, TUI archive notification, iteration label fix, edit chunking guidance. 10 issues across 4 waves.
 

--- a/scripts/check-deps.rkt
+++ b/scripts/check-deps.rkt
@@ -30,7 +30,9 @@
     [(or (string=? arg "-v") (string=? arg "--verbose")) (set! verbose? #t)]
     [(not (string=? arg "")) (printf "Unknown flag: ~a~n" arg)]))
 
-;; Packages bundled with "base" — no explicit dep needed
+;; Packages bundled with "base" — no explicit dep needed.
+;; Last verified: 2026-04-29 (Racket 8.12).
+;; Update when: upgrading Racket version or adding new bundled packages.
 (define base-packages
   (set "racket"
        "rackunit"

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -10,4 +10,4 @@
 (provide q-version)
 
 (: q-version String)
-(define q-version "0.23.5")
+(define q-version "0.23.6")


### PR DESCRIPTION
Addresses #2534.

chore: bump version to 0.23.6, CHANGELOG, maintenance docs (#2534)

W2 of v0.23.6 — CI Resilience.

T1: Add version-awareness comment to check-deps.rkt base-packages.
T2: Bump version from 0.23.5 → 0.23.6, sync-version --write --all.
T3: Add v0.23.6 CHANGELOG entry with all changes.
T4: Key files compile, tests pass.