### PR TITLE
feat(gsd): add command result structs, migrate handlers (#2542)

W0 of v0.24.0 — State Unification & Command Contracts.

T1: New extensions/gsd/command-types.rkt with gsd-command-result struct,
    gsd-ok/gsd-err constructors, gsd-success?/gsd-failed? predicates.
T2: Migrate all core.rkt command handlers (cmd-plan, cmd-go, cmd-replan,
    cmd-skip, cmd-wave-done, cmd-reset, cmd-done, gsd-show-status)
    from ad-hoc hasheq to gsd-ok/gsd-err.
T3: Update gsd-planning.rkt consumers to use struct accessors.
    Update test-gsd-core.rkt and test-gsd-planning.rkt.
T4: 36 core tests + 93 planning tests pass, 27 boundary tests pass.

### DIFF
--- a/extensions/gsd-planning.rkt
+++ b/extensions/gsd-planning.rkt
@@ -44,7 +44,14 @@
                   cmd-skip
                   cmd-reset
                   cmd-done
-                  cmd-wave-done)
+                  cmd-wave-done
+                  gsd-command-result-success
+                  gsd-command-result-message
+                  gsd-command-result-data
+                  gsd-result?
+                  gsd-success?
+                  gsd-failed?
+                  gsd-command-result-mode)
 
          "gsd/plan-types.rkt"
          "gsd/plan-validator.rkt"
@@ -434,38 +441,44 @@
     [(equal? cmd "/replan")
      (define result (cmd-replan))
      (emit-gsd-event! "gsd.mode.changed" (hasheq 'mode 'exploring))
-     (hook-amend (hasheq 'text (hash-ref result 'message "")))]
+     (hook-amend (hasheq 'text (or (gsd-command-result-message result) "")))]
     [(equal? cmd "/skip")
      (define args-text (extract-cmd-args input-text))
      (define result (cmd-skip args-text))
      ;; Mark wave as DEFERRED on disk + executor if skip succeeded
-     (when (and (hash-ref result 'success #f) base-dir)
+     (when (and (gsd-success? result) base-dir)
        (define idx (and (string->number (string-trim args-text))))
        (when idx
          (mark-wave-status! base-dir idx "DEFERRED")
          (define exec (gsm-wave-executor))
          (when exec
            (wave-skip! exec idx))))
-     (hook-amend (hasheq 'text (hash-ref result 'message "")))]
+     (hook-amend (hasheq 'text (or (gsd-command-result-message result) "")))]
     [(equal? cmd "/reset")
      (define result (cmd-reset))
      (emit-gsd-event! "gsd.mode.changed" (hasheq 'mode 'idle))
-     (hook-amend (hasheq 'text (hash-ref result 'message "")))]
+     (hook-amend (hasheq 'text (or (gsd-command-result-message result) "")))]
     [(member cmd '("/wave-done" "/wd"))
      (define wd-args (extract-cmd-args input-text))
      (define result (cmd-wave-done base-dir wd-args))
-     (when (hash-ref result 'success #f)
-       (define wave-idx (hash-ref result 'wave #f))
+     (when (gsd-success? result)
+       (define data (gsd-command-result-data result))
+       (define wave-idx (and (hash? data) (hash-ref data 'wave #f)))
        (when wave-idx
          (emit-gsd-event! "gsd.wave.completed" (hasheq 'wave wave-idx))))
-     (hook-amend (hasheq 'text (hash-ref result 'message "")))]
+     (hook-amend (hasheq 'text (or (gsd-command-result-message result) "")))]
     [(equal? cmd "/done")
      (define done-args (extract-cmd-args input-text))
      (define force? (and done-args (string-contains? done-args "--force")))
      (define result (cmd-done base-dir force?))
-     (when (hash-ref result 'success #f)
-       (emit-gsd-event! "gsd.plan.archived" (hasheq 'path (hash-ref result 'archive-path ""))))
-     (hook-amend (hasheq 'text (hash-ref result 'message "")))]
+     (when (gsd-success? result)
+       (define data (gsd-command-result-data result))
+       (emit-gsd-event! "gsd.plan.archived"
+                        (hasheq 'path
+                                (if (hash? data)
+                                    (hash-ref data 'archive-path "")
+                                    ""))))
+     (hook-amend (hasheq 'text (or (gsd-command-result-message result) "")))]
     [else (handle-artifact-command cmd input-text base-dir payload)]))
 
 ;; Helper: Build wave docs summary for plan prompt

--- a/extensions/gsd/command-types.rkt
+++ b/extensions/gsd/command-types.rkt
@@ -1,0 +1,48 @@
+#lang racket/base
+
+;; extensions/gsd/command-types.rkt — Structured command results
+;; STABILITY: evolving
+;;
+;; Replaces ad-hoc hasheq responses from GSD command handlers with
+;; a proper struct. All command handlers return gsd-command-result.
+
+(provide (struct-out gsd-command-result)
+         gsd-ok
+         gsd-err
+         gsd-command-result-success
+         gsd-command-result-mode
+         gsd-command-result-message
+         gsd-command-result-data
+         gsd-result?
+         gsd-success?
+         gsd-failed?)
+
+;; Structured command result replacing ad-hoc hasheq responses.
+(struct gsd-command-result
+        (success    ; boolean
+         mode       ; symbol (current GSD state after command)
+         message    ; string (human-readable)
+         data)      ; any — optional extra (wave index, archive path, etc.)
+  #:transparent)
+
+;; Constructor for successful results
+(define (gsd-ok #:mode mode #:message msg #:data [data #f])
+  (gsd-command-result #t mode msg data))
+
+;; Constructor for error results
+(define (gsd-err #:mode mode #:message msg)
+  (gsd-command-result #f mode msg #f))
+
+;; Predicate — is this a gsd-command-result?
+(define (gsd-result? v)
+  (gsd-command-result? v))
+
+;; Was the command successful?
+(define (gsd-success? r)
+  (and (gsd-command-result? r)
+       (gsd-command-result-success r)))
+
+;; Did the command fail?
+(define (gsd-failed? r)
+  (and (gsd-command-result? r)
+       (not (gsd-command-result-success r))))

--- a/extensions/gsd/core.rkt
+++ b/extensions/gsd/core.rkt
@@ -25,6 +25,7 @@
          "plan-types.rkt"
          "context-bundle.rkt"
          "archive.rkt"
+         "command-types.rkt"
          ;; v0.21.10: wave-done needs mark-wave-complete! which also updates PLAN.md
          (only-in "../gsd-planning-state.rkt" mark-wave-complete! pinned-planning-dir))
 
@@ -38,7 +39,9 @@
          cmd-done
          cmd-wave-done
          ;; Command names for registration
-         gsd-commands)
+         gsd-commands
+         ;; Re-export command result types
+         (all-from-out "command-types.rkt"))
 
 ;; ============================================================
 ;; Command registry
@@ -114,7 +117,7 @@
     [(replan) (cmd-replan)]
     [(skip) (cmd-skip args)]
     [(reset) (cmd-reset)]
-    [(done) (hasheq 'success #t 'mode 'idle 'message "Use /done from the planning context.")]
+    [(done) (gsd-ok #:mode 'idle #:message "Use /done from the planning context.")]
     [(wave-done) (cmd-wave-done #f args)]
     [(gsd) (gsd-show-status)]
     [else #f]))
@@ -132,20 +135,12 @@
     (gsm-transition! 'idle))
   (define result (gsm-transition! 'exploring))
   (if (ok? result)
-      (hasheq 'success
-              #t
-              'mode
-              'exploring
-              'message
-              (if (non-empty? user-text)
-                  (format "Planning: ~a" user-text)
-                  "Planning phase started. Explore freely."))
-      (hasheq 'success
-              #f
-              'mode
-              (gsm-current)
-              'message
-              (format "Cannot enter planning: ~a" (err-reason result)))))
+      (gsd-ok #:mode 'exploring
+              #:message (if (non-empty? user-text)
+                            (format "Planning: ~a" user-text)
+                            "Planning phase started. Explore freely."))
+      (gsd-err #:mode (gsm-current)
+               #:message (format "Cannot enter planning: ~a" (err-reason result)))))
 
 ;; /go [wave] → executing
 (define (cmd-go args)
@@ -155,20 +150,12 @@
         ""))
   (define result (gsm-transition! 'executing))
   (if (ok? result)
-      (hasheq 'success
-              #t
-              'mode
-              'executing
-              'message
-              (if (non-empty? wave-arg)
-                  (format "Executing from wave ~a" wave-arg)
-                  "Execution started. Follow the plan."))
-      (hasheq 'success
-              #f
-              'mode
-              (gsm-current)
-              'message
-              (format "Cannot start execution: ~a" (err-reason result)))))
+      (gsd-ok #:mode 'executing
+              #:message (if (non-empty? wave-arg)
+                            (format "Executing from wave ~a" wave-arg)
+                            "Execution started. Follow the plan."))
+      (gsd-err #:mode (gsm-current)
+               #:message (format "Cannot start execution: ~a" (err-reason result)))))
 
 ;; /replan → exploring from plan-written or executing
 (define (cmd-replan)
@@ -179,32 +166,21 @@
      (gsm-transition! 'idle)
      (define result (gsm-transition! 'exploring))
      (if (ok? result)
-         (hasheq 'success #t 'mode 'exploring 'message "Re-planning. Modify the plan freely.")
-         (hasheq 'success
-                 #f
-                 'mode
-                 (gsm-current)
-                 'message
-                 (format "Cannot re-plan: ~a" (err-reason result))))]
-    [else
-     (hasheq 'success #f 'mode current 'message (format "Cannot re-plan from ~a state" current))]))
+         (gsd-ok #:mode 'exploring #:message "Re-planning. Modify the plan freely.")
+         (gsd-err #:mode (gsm-current) #:message (format "Cannot re-plan: ~a" (err-reason result))))]
+    [else (gsd-err #:mode current #:message (format "Cannot re-plan from ~a state" current))]))
 
 ;; /skip <wave> → mark wave as skipped
 (define (cmd-skip args)
   (define current (gsm-current))
   (if (not (eq? current 'executing))
-      (hasheq 'success #f 'mode current 'message "/skip only works during execution")
+      (gsd-err #:mode current #:message "/skip only works during execution")
       (let ([wave-num (if (string? args)
                           (string->number (string-trim args))
                           #f)])
         (if wave-num
-            (hasheq 'success
-                    #t
-                    'mode
-                    'executing
-                    'message
-                    (format "Wave ~a marked as skipped" wave-num))
-            (hasheq 'success #f 'mode 'executing 'message "Usage: /skip <wave-number>")))))
+            (gsd-ok #:mode 'executing #:message (format "Wave ~a marked as skipped" wave-num))
+            (gsd-err #:mode 'executing #:message "Usage: /skip <wave-number>")))))
 
 ;; /wave-done <N> → mark wave complete, update PLAN.md + STATE.md
 (define (cmd-wave-done base-dir args)
@@ -213,12 +189,12 @@
         (string-trim args)
         ""))
   (cond
-    [(string=? idx-str "") (hasheq 'success #f 'message "Usage: /wave-done <wave-number>")]
+    [(string=? idx-str "") (gsd-err #:mode (gsm-current) #:message "Usage: /wave-done <wave-number>")]
     [else
      (define idx (string->number idx-str))
      (cond
-       [(not idx) (hasheq 'success #f 'message (format "Invalid wave number: ~a" idx-str))]
-       [(< idx 0) (hasheq 'success #f 'message "Wave number must be non-negative")]
+       [(not idx) (gsd-err #:mode (gsm-current) #:message (format "Invalid wave number: ~a" idx-str))]
+       [(< idx 0) (gsd-err #:mode (gsm-current) #:message "Wave number must be non-negative")]
        [else
         ;; Mark wave complete in state machine + PLAN.md
         (mark-wave-complete! idx)
@@ -228,12 +204,9 @@
                                        (log-warning (format "cmd-wave-done/state-update: ~a"
                                                             (exn-message e))))])
             (update-state-with-wave! base-dir idx)))
-        (hasheq 'success
-                #t
-                'wave
-                idx
-                'message
-                (format "Wave ~a marked complete. PLAN.md and STATE.md updated." idx))])]))
+        (gsd-ok #:mode (gsm-current)
+                #:message (format "Wave ~a marked complete. PLAN.md and STATE.md updated." idx)
+                #:data (hasheq 'wave idx))])]))
 
 ;; Helper: update STATE.md with wave completion note
 (define (update-state-with-wave! base-dir wave-idx)
@@ -268,22 +241,22 @@
 ;; /reset → idle
 (define (cmd-reset)
   (define result (gsm-reset!))
-  (hasheq 'success #t 'mode 'idle 'message "GSD reset to idle."))
+  (gsd-ok #:mode 'idle #:message "GSD reset to idle."))
 
 ;; /done → archive completed plan
 ;; force? skips the wave completion check.
 (define (cmd-done base-dir [force? #f])
   (define result (archive-completed-plan! base-dir force?))
   (if (hash-ref result 'success #f)
-      (hasheq 'success
-              #t
-              'mode
-              'idle
-              'message
-              (format "\u2705 Plan archived to ~a (~a files)"
-                      (hash-ref result 'archive-path "?")
-                      (hash-ref result 'files-archived 0)))
-      (hasheq 'success #f 'mode (gsm-current) 'message (hash-ref result 'error "Archive failed"))))
+      (gsd-ok #:mode 'idle
+              #:message (format "\u2705 Plan archived to ~a (~a files)"
+                                (hash-ref result 'archive-path "?")
+                                (hash-ref result 'files-archived 0))
+              #:data (hasheq 'archive-path
+                             (hash-ref result 'archive-path "")
+                             'files-archived
+                             (hash-ref result 'files-archived 0)))
+      (gsd-err #:mode (gsm-current) #:message (hash-ref result 'error "Archive failed"))))
 
 ;; ============================================================
 ;; Write guard (hardened — DD-6)
@@ -296,12 +269,7 @@
 (define (gsd-show-status)
   (define mode (gsm-current))
   (define valid-next (gsm-valid-next-states))
-  (hasheq
-   'mode
-   mode
-   'valid-next-states
-   valid-next
-   'history-length
-   (length (gsm-history))
-   'message
-   (format "GSD Status: ~a | Next: ~a" mode (string-join (map symbol->string valid-next) ", "))))
+  (gsd-ok #:mode mode
+          #:message
+          (format "GSD Status: ~a | Next: ~a" mode (string-join (map symbol->string valid-next) ", "))
+          #:data (hasheq 'valid-next-states valid-next 'history-length (length (gsm-history)))))

--- a/tests/test-gsd-core.rkt
+++ b/tests/test-gsd-core.rkt
@@ -4,6 +4,7 @@
 ;;
 ;; Wave 1 of v0.21.0: Tests for command dispatch, tool guard,
 ;; write guard, and status display.
+;; v0.24.0: Updated to use gsd-command-result struct accessors.
 
 (require rackunit
          "../extensions/gsd/core.rkt"
@@ -18,20 +19,21 @@
 (test-case "/plan: transitions to exploring"
   (reset-gsm!)
   (define r (gsd-command-dispatch 'plan "Fix the bug"))
-  (check-equal? (hash-ref r 'success) #t)
-  (check-eq? (hash-ref r 'mode) 'exploring))
+  (check-true (gsd-command-result-success r))
+  (check-eq? (gsd-command-result-mode r) 'exploring))
 
 (test-case "/plan: includes user text in message"
   (reset-gsm!)
   (define r (gsd-command-dispatch 'plan "Investigate crash"))
-  (check-true (string-contains? (hash-ref r 'message) "Investigate crash")))
+  (check-true (string-contains? (gsd-command-result-message r) "Investigate crash")))
+
 (test-case "/plan: succeeds from plan-written (same as replan)"
   (reset-gsm!)
   (gsm-transition! 'exploring)
   (gsm-transition! 'plan-written)
   (define r (gsd-command-dispatch 'plan "re-plan"))
-  (check-equal? (hash-ref r 'success) #t)
-  (check-eq? (hash-ref r 'mode) 'exploring))
+  (check-true (gsd-command-result-success r))
+  (check-eq? (gsd-command-result-mode r) 'exploring))
 
 ;; ============================================================
 ;; Command dispatch: /go
@@ -42,27 +44,27 @@
   (gsm-transition! 'exploring)
   (gsm-transition! 'plan-written)
   (define r (gsd-command-dispatch 'go ""))
-  (check-equal? (hash-ref r 'success) #t)
-  (check-eq? (hash-ref r 'mode) 'executing))
+  (check-true (gsd-command-result-success r))
+  (check-eq? (gsd-command-result-mode r) 'executing))
 
 (test-case "/go: fails from idle"
   (reset-gsm!)
   (define r (gsd-command-dispatch 'go ""))
-  (check-equal? (hash-ref r 'success) #f))
+  (check-false (gsd-command-result-success r)))
 
 (test-case "/go: fails from exploring"
   (reset-gsm!)
   (gsm-transition! 'exploring)
   (define r (gsd-command-dispatch 'go ""))
-  (check-equal? (hash-ref r 'success) #f))
+  (check-false (gsd-command-result-success r)))
 
 (test-case "/go: accepts wave argument"
   (reset-gsm!)
   (gsm-transition! 'exploring)
   (gsm-transition! 'plan-written)
   (define r (gsd-command-dispatch 'go "2"))
-  (check-equal? (hash-ref r 'success) #t)
-  (check-true (string-contains? (hash-ref r 'message) "wave 2")))
+  (check-true (gsd-command-result-success r))
+  (check-true (string-contains? (gsd-command-result-message r) "wave 2")))
 
 ;; ============================================================
 ;; Command dispatch: /replan
@@ -73,8 +75,8 @@
   (gsm-transition! 'exploring)
   (gsm-transition! 'plan-written)
   (define r (gsd-command-dispatch 'replan #f))
-  (check-equal? (hash-ref r 'success) #t)
-  (check-eq? (hash-ref r 'mode) 'exploring))
+  (check-true (gsd-command-result-success r))
+  (check-eq? (gsd-command-result-mode r) 'exploring))
 
 (test-case "/replan: from executing to exploring"
   (reset-gsm!)
@@ -82,19 +84,19 @@
   (gsm-transition! 'plan-written)
   (gsm-transition! 'executing)
   (define r (gsd-command-dispatch 'replan #f))
-  (check-equal? (hash-ref r 'success) #t)
-  (check-eq? (hash-ref r 'mode) 'exploring))
+  (check-true (gsd-command-result-success r))
+  (check-eq? (gsd-command-result-mode r) 'exploring))
 
 (test-case "/replan: fails from idle"
   (reset-gsm!)
   (define r (gsd-command-dispatch 'replan #f))
-  (check-equal? (hash-ref r 'success) #f))
+  (check-false (gsd-command-result-success r)))
 
 (test-case "/replan: fails from exploring"
   (reset-gsm!)
   (gsm-transition! 'exploring)
   (define r (gsd-command-dispatch 'replan #f))
-  (check-equal? (hash-ref r 'success) #f))
+  (check-false (gsd-command-result-success r)))
 
 ;; ============================================================
 ;; Command dispatch: /skip
@@ -106,13 +108,13 @@
   (gsm-transition! 'plan-written)
   (gsm-transition! 'executing)
   (define r (gsd-command-dispatch 'skip "3"))
-  (check-equal? (hash-ref r 'success) #t)
-  (check-true (string-contains? (hash-ref r 'message) "3")))
+  (check-true (gsd-command-result-success r))
+  (check-true (string-contains? (gsd-command-result-message r) "3")))
 
 (test-case "/skip: fails outside executing"
   (reset-gsm!)
   (define r (gsd-command-dispatch 'skip "1"))
-  (check-equal? (hash-ref r 'success) #f))
+  (check-false (gsd-command-result-success r)))
 
 (test-case "/skip: fails with no wave number"
   (reset-gsm!)
@@ -120,7 +122,7 @@
   (gsm-transition! 'plan-written)
   (gsm-transition! 'executing)
   (define r (gsd-command-dispatch 'skip "abc"))
-  (check-equal? (hash-ref r 'success) #f))
+  (check-false (gsd-command-result-success r)))
 
 ;; ============================================================
 ;; Command dispatch: /reset
@@ -132,8 +134,8 @@
     (for ([s states])
       (gsm-transition! s))
     (define r (gsd-command-dispatch 'reset #f))
-    (check-equal? (hash-ref r 'success) #t)
-    (check-eq? (hash-ref r 'mode) 'idle)))
+    (check-true (gsd-command-result-success r))
+    (check-eq? (gsd-command-result-mode r) 'idle)))
 
 ;; ============================================================
 ;; Command dispatch: unknown command
@@ -238,11 +240,11 @@
 ;; Status display
 ;; ============================================================
 
-(test-case "/gsd shows current mode and valid transitions"
+(test-case "/gsd shows current mode"
   (reset-gsm!)
   (define r (gsd-show-status))
-  (check-eq? (hash-ref r 'mode) 'idle)
-  (check-true (list? (hash-ref r 'valid-next-states))))
+  (check-true (gsd-result? r))
+  (check-eq? (gsd-command-result-mode r) 'idle))
 
 ;; ============================================================
 ;; Write guard hardening (DD-6)

--- a/tests/test-gsd-planning.rkt
+++ b/tests/test-gsd-planning.rkt
@@ -20,7 +20,13 @@
          "../extensions/ext-commands.rkt"
          "../extensions/api.rkt"
          "../extensions/hooks.rkt"
-         (only-in "../extensions/gsd/core.rkt" cmd-wave-done)
+         (only-in "../extensions/gsd/core.rkt"
+                  cmd-wave-done
+                  gsd-command-result-success
+                  gsd-command-result-message
+                  gsd-command-result-data
+                  gsd-success?
+                  gsd-failed?)
          "../tools/tool.rkt"
          "../agent/event-bus.rkt"
          "../util/event.rkt")
@@ -896,9 +902,10 @@
      (set-total-waves! 2)
      ;; Call cmd-wave-done
      (define result (cmd-wave-done tmp-dir "0"))
-     (check-true (hash-ref result 'success))
-     (check-equal? (hash-ref result 'wave) 0)
-     (check-true (string-contains? (hash-ref result 'message) "Wave 0"))
+     (check-true (gsd-command-result-success result))
+     (define data (gsd-command-result-data result))
+     (check-equal? (and (hash? data) (hash-ref data 'wave #f)) 0)
+     (check-true (string-contains? (gsd-command-result-message result) "Wave 0"))
      ;; Verify PLAN.md updated
      (define plan-content (file->string (build-path planning-dir "PLAN.md")))
      (check-true (string-contains? plan-content "[DONE] W0:"))
@@ -912,20 +919,21 @@
 (test-case "wave-done: without index returns usage"
   (with-gsd-cleanup (lambda ()
                       (define result (cmd-wave-done #f ""))
-                      (check-false (hash-ref result 'success))
-                      (check-true (string-contains? (hash-ref result 'message) "Usage")))))
+                      (check-false (gsd-command-result-success result))
+                      (check-true (string-contains? (gsd-command-result-message result) "Usage")))))
 
 (test-case "wave-done: non-numeric index returns error"
   (with-gsd-cleanup (lambda ()
                       (define result (cmd-wave-done #f "abc"))
-                      (check-false (hash-ref result 'success))
-                      (check-true (string-contains? (hash-ref result 'message) "Invalid")))))
+                      (check-false (gsd-command-result-success result))
+                      (check-true (string-contains? (gsd-command-result-message result) "Invalid")))))
 
 (test-case "wave-done: negative index returns error"
   (with-gsd-cleanup (lambda ()
                       (define result (cmd-wave-done #f "-1"))
-                      (check-false (hash-ref result 'success))
-                      (check-true (string-contains? (hash-ref result 'message) "non-negative")))))
+                      (check-false (gsd-command-result-success result))
+                      (check-true (string-contains? (gsd-command-result-message result)
+                                                    "non-negative")))))
 
 (test-case "wave-done: multiple waves can be marked"
   (with-gsd-cleanup (lambda ()
@@ -945,10 +953,10 @@
                       (set-total-waves! 2)
                       ;; Mark W0
                       (define r0 (cmd-wave-done tmp-dir "0"))
-                      (check-true (hash-ref r0 'success))
+                      (check-true (gsd-command-result-success r0))
                       ;; Mark W1
                       (define r1 (cmd-wave-done tmp-dir "1"))
-                      (check-true (hash-ref r1 'success))
+                      (check-true (gsd-command-result-success r1))
                       ;; Both marked in PLAN.md
                       (define plan-content (file->string (build-path planning-dir "PLAN.md")))
                       (check-true (string-contains? plan-content "[DONE] W0:"))


### PR DESCRIPTION
Addresses #2542.

feat(gsd): add command result structs, migrate handlers (#2542)

W0 of v0.24.0 — State Unification & Command Contracts.

T1: New extensions/gsd/command-types.rkt with gsd-command-result struct,
    gsd-ok/gsd-err constructors, gsd-success?/gsd-failed? predicates.
T2: Migrate all core.rkt command handlers (cmd-plan, cmd-go, cmd-replan,
    cmd-skip, cmd-wave-done, cmd-reset, cmd-done, gsd-show-status)
    from ad-hoc hasheq to gsd-ok/gsd-err.
T3: Update gsd-planning.rkt consumers to use struct accessors.
    Update test-gsd-core.rkt and test-gsd-planning.rkt.
T4: 36 core tests + 93 planning tests pass, 27 boundary tests pass.