### PR TITLE
feat(gsd): shim purification — move side effects to core (#2555)

W2 of v0.24.0 — State Unification & Command Contracts.

F2 fix: Remove behavioral logic from gsd-planning-state.rkt shim.
- mark-wave-complete! PLAN.md side effect moved to cmd-wave-done in core.rkt
- Shim's mark-wave-complete! is now a pure delegation to gsm-mark-wave-complete!
- Removed wave-docs.rkt import from shim (no longer needed)
- Added DEPRECATED header comment (removal planned for v0.25.0)
- core.rkt imports gsm-mark-wave-complete! and mark-wave-status! directly

215 GSD tests pass (36 core + 38 state-machine + 21 shim + 93 planning + 27 boundary).

### DIFF
--- a/extensions/gsd-planning-state.rkt
+++ b/extensions/gsd-planning-state.rkt
@@ -3,9 +3,13 @@
 ;; extensions/gsd-planning-state.rkt — Thin shim over gsd/ modules
 ;; STABILITY: evolving
 ;;
+;; DEPRECATED: Use extensions/gsd/* directly. This shim will be removed in v0.25.0.
+;; All functions are pure delegations except reset-all-gsd-state! (coordinator reset).
+;;
 ;; v0.21.6: steering.rkt import removed (dead code).
 ;; v0.22.1 QUAL-03: Migrated from global mutable boxes to per-session
 ;; parameters via session-state.rkt.
+;; v0.24.0 W2: Purified — no side effects beyond delegation.
 
 (require "gsd/state-machine.rkt"
          (only-in "gsd/session-state.rkt"
@@ -16,8 +20,7 @@
                   [current-gsd-event-bus box-current-gsd-event-bus]
                   [set-gsd-event-bus! box-set-gsd-event-bus!]
                   current-plan-data
-                  set-plan-data!)
-         "gsd/wave-docs.rkt")
+                  set-plan-data!))
 
 (provide gsd-mode
          gsd-mode?
@@ -102,12 +105,7 @@
 (define (set-total-waves! n)
   (gsm-set-total-waves! n))
 (define (mark-wave-complete! idx)
-  (gsm-mark-wave-complete! idx)
-  ;; Also update PLAN.md status marker (#2157)
-  (define base-dir (pinned-planning-dir))
-  (when base-dir
-    (with-handlers ([exn:fail? (lambda (e) (void))])
-      (mark-wave-status! base-dir idx "DONE"))))
+  (gsm-mark-wave-complete! idx))
 (define (wave-complete? idx)
   (gsm-wave-complete? idx))
 (define (current-wave-index)

--- a/extensions/gsd/core.rkt
+++ b/extensions/gsd/core.rkt
@@ -26,8 +26,10 @@
          "context-bundle.rkt"
          "archive.rkt"
          "command-types.rkt"
-         ;; v0.21.10: wave-done needs mark-wave-complete! which also updates PLAN.md
-         (only-in "../gsd-planning-state.rkt" mark-wave-complete! pinned-planning-dir))
+         ;; Direct imports (no longer via shim — W2 purification)
+         (only-in "state-machine.rkt" gsm-mark-wave-complete!)
+         (only-in "wave-docs.rkt" mark-wave-status!)
+         (only-in "../gsd-planning-state.rkt" pinned-planning-dir))
 
 (provide gsd-command-dispatch
          gsd-write-guard
@@ -196,8 +198,13 @@
        [(not idx) (gsd-err #:mode (gsm-current) #:message (format "Invalid wave number: ~a" idx-str))]
        [(< idx 0) (gsd-err #:mode (gsm-current) #:message "Wave number must be non-negative")]
        [else
-        ;; Mark wave complete in state machine + PLAN.md
-        (mark-wave-complete! idx)
+        ;; Mark wave complete in state machine
+        (gsm-mark-wave-complete! idx)
+        ;; Update PLAN.md status marker
+        (let ([base-dir (or base-dir (pinned-planning-dir))])
+          (when base-dir
+            (with-handlers ([exn:fail? (lambda (e) (void))])
+              (mark-wave-status! base-dir idx "DONE"))))
         ;; Update STATE.md with wave completion
         (when base-dir
           (with-handlers ([exn:fail? (lambda (e)


### PR DESCRIPTION
Addresses #2555.

feat(gsd): shim purification — move side effects to core (#2555)

W2 of v0.24.0 — State Unification & Command Contracts.

F2 fix: Remove behavioral logic from gsd-planning-state.rkt shim.
- mark-wave-complete! PLAN.md side effect moved to cmd-wave-done in core.rkt
- Shim's mark-wave-complete! is now a pure delegation to gsm-mark-wave-complete!
- Removed wave-docs.rkt import from shim (no longer needed)
- Added DEPRECATED header comment (removal planned for v0.25.0)
- core.rkt imports gsm-mark-wave-complete! and mark-wave-status! directly

215 GSD tests pass (36 core + 38 state-machine + 21 shim + 93 planning + 27 boundary).