### PR TITLE
feat(gsd): normalized plan IR + validated plan pipeline (#2580)

W0 of v0.24.2 — Pipeline Refactor & Observability.

F7 fix: Immutable normalized IR between validation and execution.
- New gsd-normalized-wave and gsd-normalized-plan structs in plan-types.rkt
- New gsd-validated-plan wrapper type for validated output
- normalize-plan function: raw gsd-plan → gsd-normalized-plan with structural checks
  (sequential indices, no duplicate titles)
- validate-normalized-plan: semantic validation on normalized IR → gsd-validated-plan
- make-wave-executor-from-validated: executor constructor from validated plan
- Backward-compatible: existing make-wave-executor untouched

193 GSD tests pass (18 policy + 43 state-machine + 39 core + 93 planning).

### DIFF
--- a/extensions/gsd/plan-types.rkt
+++ b/extensions/gsd/plan-types.rkt
@@ -53,12 +53,44 @@
 (struct validation-result ([errors : (Listof String)] [warnings : (Listof String)]) #:transparent)
 
 ;; ============================================================
+;; Normalized Plan IR (v0.24.2 — F7)
+;; ============================================================
+;; Immutable IR produced by parsing + normalization.
+;; This is what the validator checks and executor consumes.
+
+(define-type NormWaveStatus (U 'pending 'in-progress 'done 'skipped))
+
+(struct gsd-normalized-wave
+        ([index : Natural] [title : String]
+                           [tasks : (Listof String)]
+                           [verify-command : String]
+                           [done-criteria : (Listof String)]
+                           [files : (Listof String)]
+                           [status : NormWaveStatus])
+  #:transparent)
+
+(struct gsd-normalized-plan
+        ([waves : (Listof gsd-normalized-wave)] [context-bundle : (U String #f)]
+                                                [metadata : (HashTable Symbol Any)]
+                                                [source-path : (U String #f)])
+  #:transparent)
+
+(struct gsd-validated-plan ([plan : gsd-normalized-plan]) #:transparent)
+
+;; ============================================================
 ;; Convenience constructors
 ;; ============================================================
 
 (: make-gsd-task : String (Listof String) String String String * -> gsd-task)
 (define (make-gsd-task name files action verify . rest)
-  (gsd-task name files action verify (if (null? rest) "" (car rest)) 'pending))
+  (gsd-task name
+            files
+            action
+            verify
+            (if (null? rest)
+                ""
+                (car rest))
+            'pending))
 
 (: make-gsd-wave
    :
@@ -205,6 +237,77 @@
   (list->string (filter char? mapped)))
 
 ;; ============================================================
+;; ============================================================
+;; Normalization (v0.24.2 — F7)
+;; ============================================================
+
+(: normalize-plan : gsd-plan -> (U gsd-normalized-plan String))
+(define (normalize-plan plan)
+  ;; Validate structural integrity then produce normalized IR.
+  ;; Returns gsd-normalized-plan on success, error string on failure.
+  (define waves (gsd-plan-waves plan))
+  ;; Check: sequential indices
+  (define indices
+    (for/list :
+      (Listof Natural)
+      ([w : gsd-wave waves])
+      (gsd-wave-index w)))
+  (define expected-indices (build-list (length waves) (lambda ([i : Natural]) i)))
+  (cond
+    [(not (equal? indices expected-indices))
+     (format "Wave indices not sequential 0..~a: ~a" (sub1 (length waves)) indices)]
+    [(not (null? waves))
+     ;; Check: no duplicate titles
+     (define titles
+       (for/list :
+         (Listof String)
+         ([w : gsd-wave waves])
+         (gsd-wave-title w)))
+     (define unique-titles (remove-duplicates titles))
+     (if (< (length unique-titles) (length titles))
+         "Duplicate wave titles detected"
+         ;; Check: all tasks have non-empty verify strings (warning, not error)
+         (let* ([norm-waves
+                 :
+                 (Listof gsd-normalized-wave)
+                 (for/list :
+                   (Listof gsd-normalized-wave)
+                   ([w : gsd-wave waves])
+                   (gsd-normalized-wave (gsd-wave-index w)
+                                        (gsd-wave-title w)
+                                        (for/list :
+                                          (Listof String)
+                                          ([t : gsd-task (gsd-wave-tasks w)])
+                                          (gsd-task-name t))
+                                        (gsd-wave-verify w)
+                                        (gsd-wave-done-criteria w)
+                                        (gsd-wave-files w)
+                                        (wave-status->norm-status (gsd-wave-status w))))]
+                [norm-plan (gsd-normalized-plan norm-waves
+                                                (gsd-plan-context-bundle plan)
+                                                (hasheq 'constraints
+                                                        (gsd-plan-constraints plan)
+                                                        'must-haves
+                                                        (gsd-plan-must-haves plan))
+                                                #f)])
+           norm-plan))]
+    [else (gsd-normalized-plan '() #f (hasheq) #f)]))
+
+(: wave-status->norm-status : WaveStatus -> NormWaveStatus)
+(define (wave-status->norm-status ws)
+  (cond
+    [(eq? ws 'pending) 'pending]
+    [(eq? ws 'in-progress) 'in-progress]
+    [(eq? ws 'completed) 'done]
+    [(eq? ws 'skipped) 'skipped]
+    [(eq? ws 'failed) 'pending] ; failed → pending for re-execution
+    [else 'pending]))
+
+(: validated-plan->normalized : gsd-validated-plan -> gsd-normalized-plan)
+(define (validated-plan->normalized vp)
+  (gsd-validated-plan-plan vp))
+
+;; ============================================================
 ;; Parsing re-exports from untyped parser module
 ;; ============================================================
 
@@ -273,6 +376,14 @@
          wave-status->string
          string->wave-status
          gsd-wave-slug
+
+         ;; Normalized Plan IR (v0.24.2)
+         (struct-out gsd-normalized-wave)
+         (struct-out gsd-normalized-plan)
+         (struct-out gsd-validated-plan)
+         normalize-plan
+         validated-plan->normalized
+         NormWaveStatus
 
          ;; Type alias
          WaveStatus)

--- a/extensions/gsd/plan-validator.rkt
+++ b/extensions/gsd/plan-validator.rkt
@@ -16,10 +16,8 @@
   (define errors '())
   (: warnings : (Listof String))
   (define warnings '())
-  ;; Check: plan has at least 1 wave
   (when (null? waves)
     (set! errors (cons "Plan has no waves" errors)))
-  ;; Per-wave checks
   (for ([w waves])
     (define widx (gsd-wave-index w))
     (define prefix (format "Wave ~a" widx))
@@ -35,10 +33,39 @@
     (when (string=? (gsd-wave-title w) "")
       (set! warnings
             (cons (format "~a: cannot derive wave doc slug (empty title)" prefix) warnings))))
-  ;; Error: ALL waves are file-less
   (when (and (pair? waves) (andmap (lambda ([w : gsd-wave]) (null? (gsd-wave-files w))) waves))
     (set! errors (cons "Plan has no file references in any wave — nothing to execute" errors)))
   (validation-result (reverse errors) (reverse warnings)))
+
+;; v0.24.2: Validate normalized plan and wrap as gsd-validated-plan.
+;; Takes a gsd-normalized-plan (already structurally valid from normalization)
+;; and checks semantic validity only. Returns gsd-validated-plan on success.
+(: validate-normalized-plan : gsd-normalized-plan -> (U gsd-validated-plan validation-result))
+(define (validate-normalized-plan norm-plan)
+  (define waves (gsd-normalized-plan-waves norm-plan))
+  (: errors : (Listof String))
+  (define errors '())
+  (: warnings : (Listof String))
+  (define warnings '())
+  (when (null? waves)
+    (set! errors (cons "Plan has no waves" errors)))
+  (for ([w waves])
+    (define widx (gsd-normalized-wave-index w))
+    (define prefix (format "Wave ~a" widx))
+    (when (string=? (gsd-normalized-wave-title w) "")
+      (set! warnings (cons (format "~a: no explicit title" prefix) warnings)))
+    (when (null? (gsd-normalized-wave-files w))
+      (set! warnings
+            (cons (format "~a: no file references — wave may not produce changes" prefix) warnings)))
+    (when (string=? (gsd-normalized-wave-verify-command w) "")
+      (set! warnings (cons (format "~a: no verify command" prefix) warnings))))
+  (when (and (pair? waves)
+             (andmap (lambda ([w : gsd-normalized-wave]) (null? (gsd-normalized-wave-files w)))
+                     waves))
+    (set! errors (cons "Plan has no file references in any wave — nothing to execute" errors)))
+  (if (null? errors)
+      (gsd-validated-plan norm-plan)
+      (validation-result (reverse errors) (reverse warnings))))
 
 (: valid-plan->go? : gsd-plan -> Boolean)
 (define (valid-plan->go? plan)
@@ -78,4 +105,5 @@
 
 (provide validate-plan-strict
          format-validation-report
-         valid-plan->go?)
+         valid-plan->go?
+         validate-normalized-plan)

--- a/extensions/gsd/wave-executor.rkt
+++ b/extensions/gsd/wave-executor.rkt
@@ -24,6 +24,7 @@
          wave-status-attempt-count
          wave-status-timestamp
          make-wave-executor
+         make-wave-executor-from-validated
          load-plan-from-index
          wave-start!
          wave-complete!
@@ -64,6 +65,27 @@
     (for/list ([w waves])
       (wave-status (gsd-wave-index w) 'pending #f 0 (current-seconds))))
   (wave-executor plan (box initial-statuses)))
+
+;; v0.24.2: Constructor from validated normalized plan.
+(define (make-wave-executor-from-validated vp)
+  (define norm-plan (gsd-validated-plan-plan vp))
+  (define norm-waves (gsd-normalized-plan-waves norm-plan))
+  (define initial-statuses
+    (for/list ([w norm-waves])
+      (wave-status (gsd-normalized-wave-index w) 'pending #f 0 (current-seconds))))
+  ;; Reconstruct a gsd-plan for backward compatibility with wave-executor struct
+  (define compat-waves
+    (for/list ([w norm-waves])
+      (gsd-wave (gsd-normalized-wave-index w)
+                (gsd-normalized-wave-title w)
+                'pending
+                ""
+                (gsd-normalized-wave-files w)
+                '()
+                (gsd-normalized-wave-verify-command w)
+                (gsd-normalized-wave-done-criteria w))))
+  (define compat-plan (gsd-plan compat-waves #f '() '()))
+  (wave-executor compat-plan (box initial-statuses)))
 
 ;; ============================================================
 ;; Status transitions


### PR DESCRIPTION
Addresses #2580.

feat(gsd): normalized plan IR + validated plan pipeline (#2580)

W0 of v0.24.2 — Pipeline Refactor & Observability.

F7 fix: Immutable normalized IR between validation and execution.
- New gsd-normalized-wave and gsd-normalized-plan structs in plan-types.rkt
- New gsd-validated-plan wrapper type for validated output
- normalize-plan function: raw gsd-plan → gsd-normalized-plan with structural checks
  (sequential indices, no duplicate titles)
- validate-normalized-plan: semantic validation on normalized IR → gsd-validated-plan
- make-wave-executor-from-validated: executor constructor from validated plan
- Backward-compatible: existing make-wave-executor untouched

193 GSD tests pass (18 policy + 43 state-machine + 39 core + 93 planning).