### PR TITLE
feat(gsd): unify event system + route write guard through policy (#2602)

v0.24.4 W0 — Unify Event System + Route Write Guard Through Policy.

N1 fix: Eliminate dual event system.
- gsd-planning.rkt now delegates emit-gsd-event! to events.rkt (symbol taxonomy)
- All 7 string event calls converted to symbols (gsd.mode.changed, gsd.wave.completed, etc.)
- Bridge wired in register-gsd-tools: events.rkt bus → session event bus
- New event names: gsd.mode.changed, gsd.plan.archived in taxonomy
- Backward compat: emit-gsd-event! still publishes to session bus for existing consumers

N2/F4 fix: Write guard routes through policy engine.
- gsd-write-guard delegates to gsd-decide-action with 'write-file action
- Policy in-planning-dir? hardened with path normalization (prevents .. traversal)
- Returns hasheq for blocked case (consumer compat preserved for now)

217 GSD tests pass (21 policy + 43 state-machine + 39 core + 8 events + 93 planning + 13 fitness).

### DIFF
--- a/extensions/gsd-planning.rkt
+++ b/extensions/gsd-planning.rkt
@@ -59,7 +59,11 @@
          "gsd/prompts.rkt"
          "gsd/context-bundle.rkt"
          "gsd/wave-docs.rkt"
-         (only-in "gsd/archive.rkt" ensure-state-md!))
+         (only-in "gsd/archive.rkt" ensure-state-md!)
+         (only-in "gsd/events.rkt"
+                  [gsd-event-bus-box events:event-bus-box]
+                  [set-gsd-event-bus! events:set-event-bus!]
+                  [emit-gsd-event! events:emit-gsd-event!]))
 
 (provide the-extension
          gsd-planning-extension
@@ -111,10 +115,15 @@
 ;; Event emission helper
 ;; ============================================================
 
-(define (emit-gsd-event! type payload)
+;; Event emission: delegates to events.rkt via session bus bridge
+;; See register-gsd-tools for bus wiring.
+(define (emit-gsd-event! event-sym payload)
+  ;; Try events.rkt telemetry bus first
+  (events:emit-gsd-event! event-sym payload)
+  ;; Also publish directly to session event bus for backward compat
   (define bus (gsd-event-bus))
   (when bus
-    (publish! bus (make-event type (current-seconds) #f #f payload))))
+    (publish! bus (make-event event-sym (current-seconds) #f #f payload))))
 
 ;; ============================================================
 ;; Constants
@@ -362,7 +371,7 @@
                (begin
                  (when (and (eq? (gsd-mode) 'planning) (string=? name "PLAN"))
                    (set-gsd-mode! 'plan-written)
-                   (emit-gsd-event! "gsd.mode.changed" (hasheq 'mode 'plan-written)))
+                   (emit-gsd-event! (quote gsd.mode.changed) (hasheq 'mode 'plan-written)))
                  (make-success-result (list (hasheq 'type
                                                     "text"
                                                     'text
@@ -379,7 +388,14 @@
     (define cwd (ctx-cwd ctx))
     (when cwd
       (set-pinned-planning-dir! (resolve-project-root cwd))))
-  (set-gsd-event-bus! (ctx-event-bus ctx))
+  ;; Wire events.rkt bus into session event bus
+  (define session-bus (ctx-event-bus ctx))
+  (set-gsd-event-bus! session-bus) ; backward compat shim
+  (events:set-event-bus!
+   (lambda (event-name wrapped-event)
+     ;; Bridge: forward events.rkt events to the session event bus
+     (when session-bus
+       (publish! session-bus (make-event event-name (current-seconds) #f #f wrapped-event)))))
   (ext-register-tool!
    ctx
    "planning-read"
@@ -440,7 +456,7 @@
     [(equal? cmd "/gsd") (handle-gsd-status)]
     [(equal? cmd "/replan")
      (define result (cmd-replan))
-     (emit-gsd-event! "gsd.mode.changed" (hasheq 'mode 'exploring))
+     (emit-gsd-event! (quote gsd.mode.changed) (hasheq 'mode 'exploring))
      (hook-amend (hasheq 'text (or (gsd-command-result-message result) "")))]
     [(equal? cmd "/skip")
      (define args-text (extract-cmd-args input-text))
@@ -456,7 +472,7 @@
      (hook-amend (hasheq 'text (or (gsd-command-result-message result) "")))]
     [(equal? cmd "/reset")
      (define result (cmd-reset))
-     (emit-gsd-event! "gsd.mode.changed" (hasheq 'mode 'idle))
+     (emit-gsd-event! (quote gsd.mode.changed) (hasheq 'mode 'idle))
      (hook-amend (hasheq 'text (or (gsd-command-result-message result) "")))]
     [(member cmd '("/wave-done" "/wd"))
      (define wd-args (extract-cmd-args input-text))
@@ -465,7 +481,7 @@
        (define data (gsd-command-result-data result))
        (define wave-idx (and (hash? data) (hash-ref data 'wave #f)))
        (when wave-idx
-         (emit-gsd-event! "gsd.wave.completed" (hasheq 'wave wave-idx))))
+         (emit-gsd-event! (quote gsd.wave.completed) (hasheq 'wave wave-idx))))
      (hook-amend (hasheq 'text (or (gsd-command-result-message result) "")))]
     [(equal? cmd "/done")
      (define done-args (extract-cmd-args input-text))
@@ -473,7 +489,7 @@
      (define result (cmd-done base-dir force?))
      (when (gsd-success? result)
        (define data (gsd-command-result-data result))
-       (emit-gsd-event! "gsd.plan.archived"
+       (emit-gsd-event! (quote gsd.plan.archived)
                         (hasheq 'path
                                 (if (hash? data)
                                     (hash-ref data 'archive-path "")
@@ -522,7 +538,7 @@
                                            "\n\nFix the plan before using /go.")))]
        [else
         (set-gsd-mode! 'executing)
-        (emit-gsd-event! "gsd.mode.changed" (hasheq 'mode 'executing))
+        (emit-gsd-event! (quote gsd.mode.changed) (hasheq 'mode 'executing))
         (set-current-max-old-text-len! 1200)
         ;; v0.21.3: No more budget resets
         (define wave-indices
@@ -606,7 +622,7 @@
         (when saved-dir
           (set-pinned-planning-dir! saved-dir))
         (set-gsd-mode! 'planning)
-        (emit-gsd-event! "gsd.mode.changed" (hasheq 'mode 'planning))
+        (emit-gsd-event! (quote gsd.mode.changed) (hasheq 'mode 'planning))
         (set-current-max-old-text-len! 500)
         ;; Auto-create STATE.md if missing (#2164)
         (ensure-state-md! base-dir)

--- a/extensions/gsd/core.rkt
+++ b/extensions/gsd/core.rkt
@@ -32,6 +32,7 @@
          (only-in "session-state.rkt" set-gsd-state! gsd-state-sem)
          (only-in "runtime-state-types.rkt" gsd-runtime-state-mode)
          (only-in "events.rkt" emit-gsd-event! current-gsd-correlation-id)
+         (only-in "policy.rkt" gsd-decide-action policy-allowed? policy-blocked? policy-reason)
          (only-in "../gsd-planning-state.rkt" pinned-planning-dir))
 
 (provide gsd-command-dispatch
@@ -82,32 +83,19 @@
     (if (path? planning-dir)
         (path->string planning-dir)
         planning-dir))
-  (cond
-    [(not (eq? mode 'executing)) #t]
-    [(not (string? target-path)) #t]
-    [(not planning-dir-str) #t]
-    [else
-     ;; Resolve both paths to canonical form
-     (define canonical-target
-       (with-handlers ([exn:fail? (λ (_) target-path)])
-         (path->string (simple-form-path (string->path target-path)))))
-     (define canonical-planning
-       (with-handlers ([exn:fail? (λ (_) planning-dir-str)])
-         (path->string (simple-form-path (string->path planning-dir-str)))))
-     ;; Check if target is inside .planning/ directory
-     (define in-planning-dir?
-       (or (string=? canonical-target canonical-planning)
-           (string-prefix? canonical-target (string-append canonical-planning "/"))))
-     (if in-planning-dir?
-         (hasheq 'blocked
-                 #t
-                 'tool
-                 "write"
-                 'mode
-                 'executing
-                 'reason
-                 (format "Cannot write to ~a during execution (use /replan to modify)" target-path))
-         #t)]))
+  ;; Route through policy engine (v0.24.4)
+  (define decision
+    (gsd-decide-action (hasheq 'mode
+                               mode
+                               'target-path
+                               (if (string? target-path) target-path "")
+                               'pinned-dir
+                               (or planning-dir-str ""))
+                       'write-file))
+  (if (policy-allowed? decision)
+      #t
+      ;; Keep hasheq return for backward compat (consumer checks hash?)
+      (hasheq 'blocked #t 'tool "write" 'mode mode 'reason (policy-reason decision))))
 
 ;; ============================================================
 ;; Transaction wrapper (F3 fix: failure atomicity)

--- a/extensions/gsd/events.rkt
+++ b/extensions/gsd/events.rkt
@@ -27,6 +27,7 @@
                          gsd.transition.attempted
                          gsd.transition.succeeded
                          gsd.transition.failed
+                         gsd.mode.changed
                          gsd.wave.started
                          gsd.wave.completed
                          gsd.wave.failed
@@ -35,7 +36,8 @@
                          gsd.guard.allowed
                          gsd.plan.parsed
                          gsd.plan.normalized
-                         gsd.plan.validated))
+                         gsd.plan.validated
+                         gsd.plan.archived))
 
 ;; ============================================================
 ;; Correlation ID parameter

--- a/extensions/gsd/policy.rkt
+++ b/extensions/gsd/policy.rkt
@@ -87,9 +87,16 @@
 ;; Internal helpers
 ;; ============================================================
 
+;; Path normalization for security (prevents .. traversal)
+(require racket/path)
+
 (define (in-planning-dir? target pinned)
   (and (string? target)
        (non-empty-string? target)
        (string? pinned)
        (non-empty-string? pinned)
-       (string-prefix? target pinned)))
+       (let ([ct (with-handlers ([exn:fail? (λ (_) target)])
+                   (path->string (simple-form-path (string->path target))))]
+             [cp (with-handlers ([exn:fail? (λ (_) pinned)])
+                   (path->string (simple-form-path (string->path pinned))))])
+         (or (string=? ct cp) (string-prefix? ct (string-append cp "/"))))))

--- a/tests/test-gsd-events.rkt
+++ b/tests/test-gsd-events.rkt
@@ -98,6 +98,8 @@
                                        gsd.transition.attempted
                                        gsd.transition.succeeded
                                        gsd.transition.failed
+                                       gsd.mode.changed
                                        gsd.wave.started
-                                       gsd.wave.completed)])
+                                       gsd.wave.completed
+                                       gsd.plan.archived)])
       (check-not-false (member name gsd-event-names) (format "~a not in gsd-event-names" name)))))

--- a/tests/test-gsd-planning.rkt
+++ b/tests/test-gsd-planning.rkt
@@ -799,16 +799,16 @@
                       (define received (box '()))
                       (subscribe! bus (lambda (evt) (set-box! received (cons evt (unbox received)))))
                       ;; emit-gsd-event! is defined in gsd-planning.rkt
-                      (emit-gsd-event! "gsd.test.event" (hasheq 'key 'value))
+                      (emit-gsd-event! 'gsd.mode.changed (hasheq 'key 'value))
                       (check-equal? (length (unbox received)) 1 "should receive one event")
                       (define evt (car (unbox received)))
-                      (check-equal? (event-event evt) "gsd.test.event")
+                      (check-equal? (event-event evt) 'gsd.mode.changed)
                       (check-equal? (hash-ref (event-payload evt) 'key) 'value))))
 
 (test-case "W1: emit-gsd-event! is no-op when bus is #f"
   (with-gsd-cleanup (lambda ()
                       ;; Should not raise an error
-                      (emit-gsd-event! "gsd.test.noop" (hasheq 'key 'value))
+                      (emit-gsd-event! 'gsd.mode.changed (hasheq 'key 'value))
                       (check-false (gsd-event-bus) "bus should still be #f"))))
 
 ;; ============================================================

--- a/tests/test-gsd-policy.rkt
+++ b/tests/test-gsd-policy.rkt
@@ -136,3 +136,29 @@
   (check-true (policy-allowed? d))
   (check-false (policy-blocked? d))
   (check-false (policy-reason d)))
+
+(test-case "write-file policy: blocks writing to planning dir during execution"
+  (define d (gsd-decide-action
+             (hasheq 'mode 'executing
+                     'target-path "/project/.planning/PLAN.md"
+                     'pinned-dir "/project/.planning")
+             'write-file))
+  (check-true (policy-blocked? d))
+  (check-not-false (policy-reason d)))
+
+(test-case "write-file policy: allows writing outside planning dir during execution"
+  (define d (gsd-decide-action
+             (hasheq 'mode 'executing
+                     'target-path "/project/src/foo.rkt"
+                     'pinned-dir "/project/.planning")
+             'write-file))
+  (check-true (policy-allowed? d)))
+
+(test-case "write-file policy: allows writing in non-executing mode"
+  (for ([mode '(idle exploring plan-written verifying)])
+    (define d (gsd-decide-action
+               (hasheq 'mode mode
+                       'target-path "/project/.planning/PLAN.md"
+                       'pinned-dir "/project/.planning")
+               'write-file))
+    (check-true (policy-allowed? d) (format "write should be allowed in ~a" mode))))


### PR DESCRIPTION
Addresses #2602.

feat(gsd): unify event system + route write guard through policy (#2602)

v0.24.4 W0 — Unify Event System + Route Write Guard Through Policy.

N1 fix: Eliminate dual event system.
- gsd-planning.rkt now delegates emit-gsd-event! to events.rkt (symbol taxonomy)
- All 7 string event calls converted to symbols (gsd.mode.changed, gsd.wave.completed, etc.)
- Bridge wired in register-gsd-tools: events.rkt bus → session event bus
- New event names: gsd.mode.changed, gsd.plan.archived in taxonomy
- Backward compat: emit-gsd-event! still publishes to session bus for existing consumers

N2/F4 fix: Write guard routes through policy engine.
- gsd-write-guard delegates to gsd-decide-action with 'write-file action
- Policy in-planning-dir? hardened with path normalization (prevents .. traversal)
- Returns hasheq for blocked case (consumer compat preserved for now)

217 GSD tests pass (21 policy + 43 state-machine + 39 core + 8 events + 93 planning + 13 fitness).