### PR TITLE
feat(gsd): wire /go through normalized pipeline (#2609)

v0.24.4 W1 — Wire /go Through Normalized Pipeline.

F7 fix: /go now uses normalize-plan → validate-normalized-plan →
make-wave-executor-from-validated instead of raw make-wave-executor.

Changes:
- handle-go-command refactored to 3-step normalized pipeline
- Emits gsd.plan.parsed, gsd.plan.normalized, gsd.plan.validated events
- Handles normalization errors (structural) and validation errors (semantic)
- Falls back gracefully with error messages for invalid plans
- New test: verifies all 4 pipeline events emitted during /go

218 GSD tests pass (21 policy + 43 state-machine + 39 core + 8 events + 94 planning + 13 fitness).

### DIFF
--- a/extensions/gsd-planning.rkt
+++ b/extensions/gsd-planning.rkt
@@ -522,63 +522,95 @@
     [(not plan-content)
      (hook-amend (hasheq 'text "No PLAN found in .planning/. Use /plan <task> to create one."))]
     [else
+     ;; v0.24.4: Use normalized pipeline (parse → normalize → validate → executor)
      ;; v0.21.1: Try loading from wave doc index first, fall back to inline parse
      (define plan-from-index (load-plan-from-index base-dir))
      (define plan
        (or plan-from-index
            (let ([waves (parse-waves-from-markdown plan-content)]) (gsd-plan waves "" '() '()))))
-     ;; Validate
-     (define validation (validate-plan-strict plan))
+     ;; Emit gsd.plan.parsed event
+     (emit-gsd-event! 'gsd.plan.parsed (hasheq 'wave-count (length (gsd-plan-waves plan))))
+     ;; Step 1: Normalize plan to canonical IR
+     (define norm-result (normalize-plan plan))
      (cond
-       [(not (validation-valid? validation))
-        (define report (format-validation-report validation))
+       [(string? norm-result)
+        ;; Normalization failed (structural error)
         (hook-amend (hasheq 'text
-                            (string-append "Plan validation failed:\n"
-                                           report
+                            (string-append "Plan normalization failed:\n"
+                                           norm-result
                                            "\n\nFix the plan before using /go.")))]
        [else
-        (set-gsd-mode! 'executing)
-        (emit-gsd-event! (quote gsd.mode.changed) (hasheq 'mode 'executing))
-        (set-current-max-old-text-len! 1200)
-        ;; v0.21.3: No more budget resets
-        (define wave-indices
-          (for/list ([w (gsd-plan-waves plan)])
-            (gsd-wave-index w)))
-        (when (not (null? wave-indices))
-          (set-total-waves! (add1 (apply max wave-indices))))
-        (set-current-wave-index! 0)
-        (define executor (make-wave-executor plan))
-        (gsm-set-wave-executor! executor)
-        (define state-content (read-planning-artifact base-dir "STATE"))
-        (define state-note
-          (if state-content
-              (format "\nCurrent state:\n~a\n" state-content)
-              ""))
-        (define wave-arg
-          (let* ([trimmed (string-trim input-text)]
-                 [parts (string-split trimmed)])
-            (if (>= (length parts) 2)
-                (let ([maybe-num (string-trim (string-join (cdr parts) " "))])
-                  (if (and (> (string-length maybe-num) 0) (regexp-match? #rx"^[0-9]+$" maybe-num))
-                      (format "\nStart with wave ~a." maybe-num)
-                      ""))
-                "")))
-        ;; Build plan text from wave docs or inline content
-        (define plan-text-for-prompt
-          (if plan-from-index
-              (string-append plan-content "\n\n" (wave-docs-summary plan-from-index))
-              plan-content))
-        (define exec-prompt (executing-prompt plan executor))
-        (define augmented-text
-          (string-append planning-implement-prompt
-                         exec-prompt
-                         "\nPlan:\n"
-                         plan-text-for-prompt
-                         "\n"
-                         state-note
-                         wave-arg))
-        (hook-amend
-         (hasheq 'new-session augmented-text 'text (format "Implementing plan~a..." wave-arg)))])]))
+        ;; Emit gsd.plan.normalized event
+        (emit-gsd-event! 'gsd.plan.normalized
+                         (hasheq 'wave-count (length (gsd-normalized-plan-waves norm-result))))
+        ;; Step 2: Validate normalized plan
+        (define validation (validate-normalized-plan norm-result))
+        (define validated-plan? (gsd-validated-plan? validation))
+        ;; Emit gsd.plan.validated event
+        (emit-gsd-event! 'gsd.plan.validated
+                         (hasheq 'valid?
+                                 validated-plan?
+                                 'error-count
+                                 (if validated-plan?
+                                     0
+                                     (length (validation-errors validation)))
+                                 'warning-count
+                                 (if validated-plan?
+                                     0
+                                     (length (validation-warnings validation)))))
+        (cond
+          [(not validated-plan?)
+           (define report (format-validation-report validation))
+           (hook-amend (hasheq 'text
+                               (string-append "Plan validation failed:\n"
+                                              report
+                                              "\n\nFix the plan before using /go.")))]
+          [else
+           (set-gsd-mode! 'executing)
+           (emit-gsd-event! 'gsd.mode.changed (hasheq 'mode 'executing))
+           (set-current-max-old-text-len! 1200)
+           ;; v0.21.3: No more budget resets
+           (define wave-indices
+             (for/list ([w (gsd-plan-waves plan)])
+               (gsd-wave-index w)))
+           (when (not (null? wave-indices))
+             (set-total-waves! (add1 (apply max wave-indices))))
+           (set-current-wave-index! 0)
+           ;; Step 3: Create executor from validated plan
+           (define executor (make-wave-executor-from-validated validation))
+           (gsm-set-wave-executor! executor)
+           (define state-content (read-planning-artifact base-dir "STATE"))
+           (define state-note
+             (if state-content
+                 (format "\nCurrent state:\n~a\n" state-content)
+                 ""))
+           (define wave-arg
+             (let* ([trimmed (string-trim input-text)]
+                    [parts (string-split trimmed)])
+               (if (>= (length parts) 2)
+                   (let ([maybe-num (string-trim (string-join (cdr parts) " "))])
+                     (if (and (> (string-length maybe-num) 0) (regexp-match? #rx"^[0-9]+$" maybe-num))
+                         (format "\nStart with wave ~a." maybe-num)
+                         ""))
+                   "")))
+           ;; Build plan text from wave docs or inline content
+           (define plan-text-for-prompt
+             (if plan-from-index
+                 (string-append plan-content "\n\n" (wave-docs-summary plan-from-index))
+                 plan-content))
+           (define exec-prompt (executing-prompt plan executor))
+           (define augmented-text
+             (string-append planning-implement-prompt
+                            exec-prompt
+                            "\nPlan:\n"
+                            plan-text-for-prompt
+                            "\n"
+                            state-note
+                            wave-arg))
+           (hook-amend (hasheq 'new-session
+                               augmented-text
+                               'text
+                               (format "Implementing plan~a..." wave-arg)))])])]))
 
 ;; Handler for /gsd status
 (define (handle-gsd-status)

--- a/tests/test-gsd-planning.rkt
+++ b/tests/test-gsd-planning.rkt
@@ -29,7 +29,8 @@
                   gsd-failed?)
          "../tools/tool.rkt"
          "../agent/event-bus.rkt"
-         "../util/event.rkt")
+         "../util/event.rkt"
+         (prefix-in events: "../extensions/gsd/events.rkt"))
 
 ;; ============================================================
 ;; Helpers
@@ -625,6 +626,36 @@
           (define result (handler (hasheq 'command "/go" 'input "/go 2")))
           (define submit-text (hash-ref (hook-result-payload result) 'new-session))
           (check-true (string-contains? submit-text "wave 2"))))))))
+
+(test-case "/go emits normalized pipeline events via events.rkt bus"
+  (with-gsd-cleanup
+   (lambda ()
+     (with-temp-dir
+      (lambda (dir)
+        (parameterize ([current-directory dir])
+          (set-pinned-planning-dir! dir)
+          (make-directory* (build-path dir ".planning"))
+          (call-with-output-file
+           (build-path dir ".planning" "PLAN.md")
+           (lambda (out)
+             (display "# Plan\n## Wave 0: Fix\n- File: foo.rkt\n## Wave 1: Polish\n- File: bar.rkt"
+                      out))
+           #:exists 'truncate)
+          ;; Set up events.rkt event collector
+          (define-values (collector get-events) (events:make-event-collector))
+          (events:set-gsd-event-bus! collector)
+          (define handler (hash-ref (extension-hooks gsd-planning-extension) 'execute-command))
+          (define result (handler (hasheq 'command "/go" 'input "/go")))
+          (check-equal? (hook-result-action result) 'amend)
+          ;; Check that pipeline events were emitted
+          (define evts (events:collector-events get-events))
+          (define event-names (map (lambda (e) (hash-ref e 'event #f)) evts))
+          (check-not-false (member 'gsd.plan.parsed event-names) "should emit gsd.plan.parsed")
+          (check-not-false (member 'gsd.plan.normalized event-names)
+                           "should emit gsd.plan.normalized")
+          (check-not-false (member 'gsd.plan.validated event-names) "should emit gsd.plan.validated")
+          (check-not-false (member 'gsd.mode.changed event-names) "should emit gsd.mode.changed")
+          (delete-directory/files dir)))))))
 
 (test-case "/implement alias works"
   (with-gsd-cleanup


### PR DESCRIPTION
Addresses #2609.

feat(gsd): wire /go through normalized pipeline (#2609)

v0.24.4 W1 — Wire /go Through Normalized Pipeline.

F7 fix: /go now uses normalize-plan → validate-normalized-plan →
make-wave-executor-from-validated instead of raw make-wave-executor.

Changes:
- handle-go-command refactored to 3-step normalized pipeline
- Emits gsd.plan.parsed, gsd.plan.normalized, gsd.plan.validated events
- Handles normalization errors (structural) and validation errors (semantic)
- Falls back gracefully with error messages for invalid plans
- New test: verifies all 4 pipeline events emitted during /go

218 GSD tests pass (21 policy + 43 state-machine + 39 core + 8 events + 94 planning + 13 fitness).