### PR TITLE
feat(gsd): archive result migration + transaction coverage (#2614)

v0.24.4 W2 — Archive Result Migration + Transaction Coverage.

T1: archive-completed-plan! now returns gsd-command-result
(gsd-ok/gsd-err) instead of hasheq. cmd-done simplified to delegate.

T2: cmd-done wrapped with with-gsd-transaction for atomic archive
with rollback on failure. Emits gsd.archive.failed on rollback.

T3: gsd-write-guard now returns policy-decision directly instead of
hasheq/#t. Consumer in gsd-planning.rkt updated to use
policy-blocked?/policy-allowed? predicates. All core tests migrated.

T5: 3 new tests (cmd-done result types, write guard policy-decision).

221 GSD tests pass (21 policy + 43 state-machine + 42 core + 8 events + 94 planning + 13 fitness).

### DIFF
--- a/extensions/gsd-planning.rkt
+++ b/extensions/gsd-planning.rkt
@@ -51,7 +51,9 @@
                   gsd-result?
                   gsd-success?
                   gsd-failed?
-                  gsd-command-result-mode)
+                  gsd-command-result-mode
+                  with-gsd-transaction)
+         (only-in "gsd/policy.rkt" policy-decision policy-blocked? policy-reason)
 
          "gsd/plan-types.rkt"
          "gsd/plan-validator.rkt"
@@ -351,10 +353,10 @@
      (define guard-result
        (if guard-arg
            (gsd-write-guard guard-arg (pinned-planning-dir))
-           #t))
+           (policy-decision #t #f '())))
      (cond
-       [(hash? guard-result)
-        (make-error-result (format "Blocked: ~a" (hash-ref guard-result 'reason "write blocked")))]
+       [(policy-blocked? guard-result)
+        (make-error-result (format "Blocked: ~a" (policy-reason guard-result)))]
        [else
         (define parsed-content
           (if (json-artifact? name)

--- a/extensions/gsd/archive.rkt
+++ b/extensions/gsd/archive.rkt
@@ -13,7 +13,8 @@
          racket/format
          "plan-types.rkt"
          "wave-docs.rkt"
-         "state-machine.rkt")
+         "state-machine.rkt"
+         "command-types.rkt")
 
 (provide archive-completed-plan!
          all-waves-complete?
@@ -107,15 +108,15 @@
 
 ;; Archive a completed plan.
 ;; Steps: validate → create archive dir → move files → reset state.
-;; When force? is #f and waves are incomplete, returns a warning with incomplete count.
+;; Returns gsd-command-result (gsd-ok on success, gsd-err on failure).
+;; When force? is #f and waves are incomplete, returns gsd-err with incomplete count.
 ;; When force? is #t, archives regardless of wave completion status.
-;; Returns (hasheq 'success #t 'archive-path ...) on success.
-;; Returns (hasheq 'success #f 'error ...) on failure.
 (define (archive-completed-plan! base-dir [force? #f])
   (define planning-dir (build-path base-dir ".planning"))
   (define plan-path (build-path planning-dir "PLAN.md"))
+  (define current-mode (gsm-current))
   (cond
-    [(not (file-exists? plan-path)) (hasheq 'success #f 'error "No PLAN.md found")]
+    [(not (file-exists? plan-path)) (gsd-err #:mode current-mode #:message "No PLAN.md found")]
     [(and (not force?) (not (all-waves-complete? base-dir)))
      (define text (call-with-input-file plan-path port->string))
      (define entries (parse-plan-index text))
@@ -123,10 +124,9 @@
        (for/list ([e entries]
                   #:when (not (member (wave-index-entry-status e) '("DONE" "DEFERRED"))))
          (wave-index-entry-status e)))
-     (hasheq
-      'success
-      #f
-      'error
+     (gsd-err
+      #:mode current-mode
+      #:message
       (format
        "Not all waves are complete (~a/~a have status: ~a). Use /done --force to archive anyway."
        (length incomplete)
@@ -138,10 +138,10 @@
      (update-all-wave-statuses! base-dir)
      (define title (extract-plan-title plan-text))
      (define archive-dir (archive-path-for-plan base-dir title))
-     (define moved-files '())
-     (with-handlers ([exn:fail:filesystem?
-                      (lambda (e)
-                        (hasheq 'success #f 'error (format "Filesystem error: ~a" (exn-message e))))])
+     (with-handlers ([exn:fail:filesystem? (lambda (e)
+                                             (gsd-err #:mode current-mode
+                                                      #:message (format "Filesystem error: ~a"
+                                                                        (exn-message e))))])
        (move-to-archive! base-dir archive-dir)
        (reset-gsd-after-archive!)
        ;; Count archived files
@@ -149,12 +149,10 @@
          (if (directory-exists? archive-dir)
              (length (directory-list archive-dir))
              0))
-       (hasheq 'success
-               #t
-               'archive-path
-               (path->string archive-dir)
-               'files-archived
-               archived-count))]))
+       (gsd-ok #:mode 'idle
+               #:message (format "Plan archived to ~a" (path->string archive-dir))
+               #:data
+               (hasheq 'archive-path (path->string archive-dir) 'files-archived archived-count)))]))
 
 ;; ============================================================
 ;; Helpers

--- a/extensions/gsd/core.rkt
+++ b/extensions/gsd/core.rkt
@@ -84,18 +84,13 @@
         (path->string planning-dir)
         planning-dir))
   ;; Route through policy engine (v0.24.4)
-  (define decision
-    (gsd-decide-action (hasheq 'mode
-                               mode
-                               'target-path
-                               (if (string? target-path) target-path "")
-                               'pinned-dir
-                               (or planning-dir-str ""))
-                       'write-file))
-  (if (policy-allowed? decision)
-      #t
-      ;; Keep hasheq return for backward compat (consumer checks hash?)
-      (hasheq 'blocked #t 'tool "write" 'mode mode 'reason (policy-reason decision))))
+  (gsd-decide-action (hasheq 'mode
+                             mode
+                             'target-path
+                             (if (string? target-path) target-path "")
+                             'pinned-dir
+                             (or planning-dir-str ""))
+                     'write-file))
 
 ;; ============================================================
 ;; Transaction wrapper (F3 fix: failure atomicity)
@@ -282,17 +277,10 @@
 ;; /done → archive completed plan
 ;; force? skips the wave completion check.
 (define (cmd-done base-dir [force? #f])
-  (define result (archive-completed-plan! base-dir force?))
-  (if (hash-ref result 'success #f)
-      (gsd-ok #:mode 'idle
-              #:message (format "\u2705 Plan archived to ~a (~a files)"
-                                (hash-ref result 'archive-path "?")
-                                (hash-ref result 'files-archived 0))
-              #:data (hasheq 'archive-path
-                             (hash-ref result 'archive-path "")
-                             'files-archived
-                             (hash-ref result 'files-archived 0)))
-      (gsd-err #:mode (gsm-current) #:message (hash-ref result 'error "Archive failed"))))
+  (with-gsd-transaction 'archive
+                        (lambda () (archive-completed-plan! base-dir force?))
+                        (lambda (e snapshot)
+                          (emit-gsd-event! 'gsd.archive.failed (hasheq 'error (exn-message e))))))
 
 ;; ============================================================
 ;; Write guard (hardened — DD-6)

--- a/extensions/gsd/events.rkt
+++ b/extensions/gsd/events.rkt
@@ -37,7 +37,8 @@
                          gsd.plan.parsed
                          gsd.plan.normalized
                          gsd.plan.validated
-                         gsd.plan.archived))
+                         gsd.plan.archived
+                         gsd.archive.failed))
 
 ;; ============================================================
 ;; Correlation ID parameter

--- a/tests/test-gsd-core.rkt
+++ b/tests/test-gsd-core.rkt
@@ -10,7 +10,8 @@
          "../extensions/gsd/core.rkt"
          "../extensions/gsd/state-machine.rkt"
          (only-in "../extensions/gsd-planning.rkt" gsd-tool-guard)
-         (only-in "../util/hook-types.rkt" hook-result-action))
+         (only-in "../util/hook-types.rkt" hook-result-action)
+         (only-in "../extensions/gsd/policy.rkt" policy-decision? policy-allowed? policy-blocked?))
 
 ;; ============================================================
 ;; Command dispatch: /plan
@@ -217,24 +218,24 @@
   (gsm-transition! 'plan-written)
   (gsm-transition! 'executing)
   (define r (gsd-write-guard ".planning/PLAN.md" ".planning"))
-  (check-true (hash? r))
-  (check-equal? (hash-ref r 'blocked #f) #t))
+  (check-true (policy-decision? r))
+  (check-true (policy-blocked? r)))
 
 (test-case "write guard: allows non-PLAN.md during executing"
   (reset-gsm!)
   (gsm-transition! 'exploring)
   (gsm-transition! 'plan-written)
   (gsm-transition! 'executing)
-  (check-true (gsd-write-guard "src/fix.rkt" ".planning")))
+  (check-true (policy-allowed? (gsd-write-guard "src/fix.rkt" ".planning"))))
 
 (test-case "write guard: allows PLAN.md during idle"
   (reset-gsm!)
-  (check-true (gsd-write-guard ".planning/PLAN.md" ".planning")))
+  (check-true (policy-allowed? (gsd-write-guard ".planning/PLAN.md" ".planning"))))
 
 (test-case "write guard: allows PLAN.md during exploring"
   (reset-gsm!)
   (gsm-transition! 'exploring)
-  (check-true (gsd-write-guard ".planning/PLAN.md" ".planning")))
+  (check-true (policy-allowed? (gsd-write-guard ".planning/PLAN.md" ".planning"))))
 
 ;; ============================================================
 ;; Status display
@@ -256,8 +257,8 @@
   (gsm-transition! 'plan-written)
   (gsm-transition! 'executing)
   (define r (gsd-write-guard "src/../.planning/PLAN.md" ".planning"))
-  (check-true (hash? r))
-  (check-equal? (hash-ref r 'blocked #f) #t))
+  (check-true (policy-decision? r))
+  (check-true (policy-blocked? r)))
 
 (test-case "write guard: blocks multiple .. traversal"
   (reset-gsm!)
@@ -265,8 +266,8 @@
   (gsm-transition! 'plan-written)
   (gsm-transition! 'executing)
   (define r (gsd-write-guard "a/b/../../.planning/PLAN.md" ".planning"))
-  (check-true (hash? r))
-  (check-equal? (hash-ref r 'blocked #f) #t))
+  (check-true (policy-decision? r))
+  (check-true (policy-blocked? r)))
 
 (test-case "write guard: blocks other .planning files during executing"
   (reset-gsm!)
@@ -274,14 +275,14 @@
   (gsm-transition! 'plan-written)
   (gsm-transition! 'executing)
   (define r (gsd-write-guard ".planning/STATE.md" ".planning"))
-  (check-true (hash-ref r 'blocked #f)))
+  (check-true (policy-blocked? r)))
 
 (test-case "write guard: allows files outside .planning"
   (reset-gsm!)
   (gsm-transition! 'exploring)
   (gsm-transition! 'plan-written)
   (gsm-transition! 'executing)
-  (check-true (gsd-write-guard "src/fix.rkt" ".planning")))
+  (check-true (policy-allowed? (gsd-write-guard "src/fix.rkt" ".planning"))))
 
 ;; ============================================================
 ;; W4: Hardened path guard tests (F6)
@@ -293,23 +294,23 @@
   (gsm-transition! 'plan-written)
   (gsm-transition! 'executing)
   (define r (gsd-write-guard ".planning/waves/W0-slug.md" ".planning"))
-  (check-true (hash-ref r 'blocked #f)))
+  (check-true (policy-blocked? r)))
 
 (test-case "W4: write guard allows q/foo.rkt during executing"
   (reset-gsm!)
   (gsm-transition! 'exploring)
   (gsm-transition! 'plan-written)
   (gsm-transition! 'executing)
-  (check-true (gsd-write-guard "q/foo.rkt" ".planning")))
+  (check-true (policy-allowed? (gsd-write-guard "q/foo.rkt" ".planning"))))
 
 (test-case "W4: write guard allows during exploring mode"
   (reset-gsm!)
   (gsm-transition! 'exploring)
-  (check-true (gsd-write-guard ".planning/PLAN.md" ".planning")))
+  (check-true (policy-allowed? (gsd-write-guard ".planning/PLAN.md" ".planning"))))
 
 (test-case "W4: write guard allows during idle mode"
   (reset-gsm!)
-  (check-true (gsd-write-guard ".planning/PLAN.md" ".planning")))
+  (check-true (policy-allowed? (gsd-write-guard ".planning/PLAN.md" ".planning"))))
 
 ;; ============================================================
 ;; v0.24.1: Transaction wrapper tests
@@ -333,3 +334,44 @@
   (define result (gsd-command-dispatch 'wave-done "-1"))
   (check-false (gsd-command-result-success result))
   (check-not-false (string-contains? (gsd-command-result-message result) "non-negative")))
+
+;; ============================================================
+;; W2: Archive result migration + transaction tests
+;; ============================================================
+
+(test-case "cmd-done returns gsd-command-result on missing plan"
+  (reset-gsm!)
+  (define result (cmd-done "/nonexistent/path"))
+  (check-false (gsd-command-result-success result))
+  (check-not-false (string-contains? (gsd-command-result-message result) "No PLAN.md")))
+
+(test-case "cmd-done returns gsd-command-result on incomplete waves"
+  (reset-gsm!)
+  (gsm-transition! 'exploring)
+  (gsm-transition! 'plan-written)
+  (gsm-transition! 'executing)
+  ;; Create a temp dir with an incomplete plan
+  (define tmp-dir (make-temporary-file "gsd-archive-test-~a" 'directory))
+  (define planning-dir (build-path tmp-dir ".planning"))
+  (make-directory* planning-dir)
+  (call-with-output-file
+   (build-path planning-dir "PLAN.md")
+   (lambda (out)
+     (display "# Plan: Test\n## Wave 0: Fix\n- File: foo.rkt\n<!-- status: [Inbox] -->\n" out))
+   #:exists 'truncate)
+  (define result (cmd-done tmp-dir))
+  (check-false (gsd-command-result-success result))
+  (check-not-false (string-contains? (gsd-command-result-message result) "Not all waves"))
+  (delete-directory/files tmp-dir))
+
+(test-case "write guard returns policy-decision type"
+  (reset-gsm!)
+  (gsm-transition! 'exploring)
+  (gsm-transition! 'plan-written)
+  (gsm-transition! 'executing)
+  (define blocked (gsd-write-guard ".planning/PLAN.md" ".planning"))
+  (check-true (policy-decision? blocked))
+  (check-true (policy-blocked? blocked))
+  (define allowed (gsd-write-guard "src/foo.rkt" ".planning"))
+  (check-true (policy-decision? allowed))
+  (check-true (policy-allowed? allowed)))


### PR DESCRIPTION
Addresses #2614.

feat(gsd): archive result migration + transaction coverage (#2614)

v0.24.4 W2 — Archive Result Migration + Transaction Coverage.

T1: archive-completed-plan! now returns gsd-command-result
(gsd-ok/gsd-err) instead of hasheq. cmd-done simplified to delegate.

T2: cmd-done wrapped with with-gsd-transaction for atomic archive
with rollback on failure. Emits gsd.archive.failed on rollback.

T3: gsd-write-guard now returns policy-decision directly instead of
hasheq/#t. Consumer in gsd-planning.rkt updated to use
policy-blocked?/policy-allowed? predicates. All core tests migrated.

T5: 3 new tests (cmd-done result types, write guard policy-decision).

221 GSD tests pass (21 policy + 43 state-machine + 42 core + 8 events + 94 planning + 13 fitness).