### PR TITLE
fix(gsd): fix broken archive tests + eliminate dual event publishing (#2629)

v0.24.5 W0 — Fix Broken Tests + Eliminate Dual Publishing.

ARCH-TEST: Migrated test-gsd-archive.rkt to use gsd-command-result
struct accessors instead of hash-ref. 7 call sites fixed.

DUAL-EVENT: Removed backward-compat (publish! bus ...) from local
emit-gsd-event! wrapper in gsd-planning.rkt. Bridge lambda in
register-gsd-tools already forwards events to session bus.

Updated emit-gsd-event! test to use events.rkt collector directly.

239 GSD tests pass.

### DIFF
--- a/extensions/gsd-planning.rkt
+++ b/extensions/gsd-planning.rkt
@@ -120,12 +120,7 @@
 ;; Event emission: delegates to events.rkt via session bus bridge
 ;; See register-gsd-tools for bus wiring.
 (define (emit-gsd-event! event-sym payload)
-  ;; Try events.rkt telemetry bus first
-  (events:emit-gsd-event! event-sym payload)
-  ;; Also publish directly to session event bus for backward compat
-  (define bus (gsd-event-bus))
-  (when bus
-    (publish! bus (make-event event-sym (current-seconds) #f #f payload))))
+  (events:emit-gsd-event! event-sym payload))
 
 ;; ============================================================
 ;; Constants

--- a/tests/test-gsd-archive.rkt
+++ b/tests/test-gsd-archive.rkt
@@ -10,7 +10,11 @@
          "../extensions/gsd/archive.rkt"
          "../extensions/gsd/state-machine.rkt"
          "../extensions/gsd/wave-docs.rkt"
-         "../extensions/gsd/plan-types.rkt")
+         "../extensions/gsd/plan-types.rkt"
+         (only-in "../extensions/gsd/command-types.rkt"
+                  gsd-command-result-success
+                  gsd-command-result-message
+                  gsd-command-result-data))
 
 ;; ============================================================
 ;; Helpers
@@ -128,12 +132,13 @@
      (write-wave! tmp 1 "implement" "DONE" "## Root Cause\nNeed impl.\n## Action\nImplement.")
 
      (define result (archive-completed-plan! tmp))
-     (check-true (hash-ref result 'success))
-     (check-true (string-contains? (hash-ref result 'archive-path) "archive"))
+     (check-true (gsd-command-result-success result))
+     (check-true (string-contains? (hash-ref (gsd-command-result-data result) 'archive-path)
+                                   "archive"))
      ;; PLAN.md should no longer exist in .planning/
      (check-false (file-exists? (build-path tmp ".planning" "PLAN.md")))
      ;; Archive dir should exist with files
-     (define archive-dir (string->path (hash-ref result 'archive-path)))
+     (define archive-dir (string->path (hash-ref (gsd-command-result-data result) 'archive-path)))
      (check-true (directory-exists? archive-dir))
      (check-true (file-exists? (build-path archive-dir "PLAN.md"))))
    (lambda () (cleanup-tmp tmp))))
@@ -144,8 +149,8 @@
                 (lambda ()
                   (write-plan-incomplete! tmp)
                   (define result (archive-completed-plan! tmp))
-                  (check-false (hash-ref result 'success))
-                  (check-true (string-contains? (hash-ref result 'error) "Not all waves")))
+                  (check-false (gsd-command-result-success result))
+                  (check-true (string-contains? (gsd-command-result-message result) "Not all waves")))
                 (lambda () (cleanup-tmp tmp))))
 
 (test-case "archive-completed-plan!: fails when no PLAN.md"
@@ -153,8 +158,8 @@
   (dynamic-wind void
                 (lambda ()
                   (define result (archive-completed-plan! tmp))
-                  (check-false (hash-ref result 'success))
-                  (check-true (string-contains? (hash-ref result 'error) "No PLAN.md")))
+                  (check-false (gsd-command-result-success result))
+                  (check-true (string-contains? (gsd-command-result-message result) "No PLAN.md")))
                 (lambda () (cleanup-tmp tmp))))
 
 ;; ============================================================

--- a/tests/test-gsd-planning.rkt
+++ b/tests/test-gsd-planning.rkt
@@ -825,16 +825,15 @@
 
 (test-case "W1: emit-gsd-event! publishes when bus is set"
   (with-gsd-cleanup (lambda ()
-                      (define bus (make-event-bus))
-                      (set-gsd-event-bus! bus)
-                      (define received (box '()))
-                      (subscribe! bus (lambda (evt) (set-box! received (cons evt (unbox received)))))
+                      (define-values (collector query) (events:make-event-collector))
+                      (events:set-gsd-event-bus! collector)
                       ;; emit-gsd-event! is defined in gsd-planning.rkt
                       (emit-gsd-event! 'gsd.mode.changed (hasheq 'key 'value))
-                      (check-equal? (length (unbox received)) 1 "should receive one event")
-                      (define evt (car (unbox received)))
-                      (check-equal? (event-event evt) 'gsd.mode.changed)
-                      (check-equal? (hash-ref (event-payload evt) 'key) 'value))))
+                      (define events (events:collector-events query))
+                      (check-equal? (length events) 1 "should receive one event")
+                      (define evt (car events))
+                      (check-equal? (hash-ref evt 'event) 'gsd.mode.changed)
+                      (check-equal? (hash-ref (hash-ref evt 'data) 'key) 'value))))
 
 (test-case "W1: emit-gsd-event! is no-op when bus is #f"
   (with-gsd-cleanup (lambda ()


### PR DESCRIPTION
Addresses #2629.

fix(gsd): fix broken archive tests + eliminate dual event publishing (#2629)

v0.24.5 W0 — Fix Broken Tests + Eliminate Dual Publishing.

ARCH-TEST: Migrated test-gsd-archive.rkt to use gsd-command-result
struct accessors instead of hash-ref. 7 call sites fixed.

DUAL-EVENT: Removed backward-compat (publish! bus ...) from local
emit-gsd-event! wrapper in gsd-planning.rkt. Bridge lambda in
register-gsd-tools already forwards events to session bus.

Updated emit-gsd-event! test to use events.rkt collector directly.

239 GSD tests pass.