### PR TITLE
fix(gsd): wrap /go in transaction + deprecate cmd-go (#2632)

v0.24.5 W1 — /go Transaction + cmd-go Unification.

GO-NO-TXN: Wrapped handle-go-command state mutations in snapshot/restore
transaction using with-handlers. On exception, all state is rolled back
and gsd.mode.changed event is emitted with rollback reason.

GO-DUPE: Added deprecation comment to cmd-go in core.rkt. Exported cmd-go
for test visibility. Added deprecation test confirming cmd-go still works
as bare state transition.

240 GSD tests pass.

### DIFF
--- a/extensions/gsd-planning.rkt
+++ b/extensions/gsd-planning.rkt
@@ -65,7 +65,8 @@
          (only-in "gsd/events.rkt"
                   [gsd-event-bus-box events:event-bus-box]
                   [set-gsd-event-bus! events:set-event-bus!]
-                  [emit-gsd-event! events:emit-gsd-event!]))
+                  [emit-gsd-event! events:emit-gsd-event!])
+         (only-in "gsd/session-state.rkt" set-gsd-state! gsd-state-sem))
 
 (provide the-extension
          gsd-planning-extension
@@ -563,51 +564,63 @@
                                               report
                                               "\n\nFix the plan before using /go.")))]
           [else
-           (set-gsd-mode! 'executing)
-           (emit-gsd-event! 'gsd.mode.changed (hasheq 'mode 'executing))
-           (set-current-max-old-text-len! 1200)
-           ;; v0.21.3: No more budget resets
-           (define wave-indices
-             (for/list ([w (gsd-plan-waves plan)])
-               (gsd-wave-index w)))
-           (when (not (null? wave-indices))
-             (set-total-waves! (add1 (apply max wave-indices))))
-           (set-current-wave-index! 0)
-           ;; Step 3: Create executor from validated plan
-           (define executor (make-wave-executor-from-validated validation))
-           (gsm-set-wave-executor! executor)
-           (define state-content (read-planning-artifact base-dir "STATE"))
-           (define state-note
-             (if state-content
-                 (format "\nCurrent state:\n~a\n" state-content)
-                 ""))
-           (define wave-arg
-             (let* ([trimmed (string-trim input-text)]
-                    [parts (string-split trimmed)])
-               (if (>= (length parts) 2)
-                   (let ([maybe-num (string-trim (string-join (cdr parts) " "))])
-                     (if (and (> (string-length maybe-num) 0) (regexp-match? #rx"^[0-9]+$" maybe-num))
-                         (format "\nStart with wave ~a." maybe-num)
-                         ""))
-                   "")))
-           ;; Build plan text from wave docs or inline content
-           (define plan-text-for-prompt
-             (if plan-from-index
-                 (string-append plan-content "\n\n" (wave-docs-summary plan-from-index))
-                 plan-content))
-           (define exec-prompt (executing-prompt plan executor))
-           (define augmented-text
-             (string-append planning-implement-prompt
-                            exec-prompt
-                            "\nPlan:\n"
-                            plan-text-for-prompt
-                            "\n"
-                            state-note
-                            wave-arg))
-           (hook-amend (hasheq 'new-session
-                               augmented-text
-                               'text
-                               (format "Implementing plan~a..." wave-arg)))])])]))
+           ;; v0.24.5: Wrap mutations in snapshot/restore transaction
+           (define go-snapshot (gsm-snapshot))
+           (with-handlers
+               ([exn:fail?
+                 (lambda (e)
+                   ;; Rollback all state mutations
+                   (call-with-semaphore gsd-state-sem (lambda () (set-gsd-state! go-snapshot)))
+                   (emit-gsd-event! 'gsd.mode.changed
+                                    (hasheq 'reason "transaction-rollback" 'error (exn-message e)))
+                   (hook-amend (hasheq 'text
+                                       (format "Failed to start execution: ~a" (exn-message e)))))])
+             (set-gsd-mode! 'executing)
+             (emit-gsd-event! 'gsd.mode.changed (hasheq 'mode 'executing))
+             (set-current-max-old-text-len! 1200)
+             ;; v0.21.3: No more budget resets
+             (define wave-indices
+               (for/list ([w (gsd-plan-waves plan)])
+                 (gsd-wave-index w)))
+             (when (not (null? wave-indices))
+               (set-total-waves! (add1 (apply max wave-indices))))
+             (set-current-wave-index! 0)
+             ;; Step 3: Create executor from validated plan
+             (define executor (make-wave-executor-from-validated validation))
+             (gsm-set-wave-executor! executor)
+             (define state-content (read-planning-artifact base-dir "STATE"))
+             (define state-note
+               (if state-content
+                   (format "\nCurrent state:\n~a\n" state-content)
+                   ""))
+             (define wave-arg
+               (let* ([trimmed (string-trim input-text)]
+                      [parts (string-split trimmed)])
+                 (if (>= (length parts) 2)
+                     (let ([maybe-num (string-trim (string-join (cdr parts) " "))])
+                       (if (and (> (string-length maybe-num) 0)
+                                (regexp-match? #rx"^[0-9]+$" maybe-num))
+                           (format "\nStart with wave ~a." maybe-num)
+                           ""))
+                     "")))
+             ;; Build plan text from wave docs or inline content
+             (define plan-text-for-prompt
+               (if plan-from-index
+                   (string-append plan-content "\n\n" (wave-docs-summary plan-from-index))
+                   plan-content))
+             (define exec-prompt (executing-prompt plan executor))
+             (define augmented-text
+               (string-append planning-implement-prompt
+                              exec-prompt
+                              "\nPlan:\n"
+                              plan-text-for-prompt
+                              "\n"
+                              state-note
+                              wave-arg))
+             (hook-amend (hasheq 'new-session
+                                 augmented-text
+                                 'text
+                                 (format "Implementing plan~a..." wave-arg))))])])]))
 
 ;; Handler for /gsd status
 (define (handle-gsd-status)

--- a/extensions/gsd/core.rkt
+++ b/extensions/gsd/core.rkt
@@ -40,6 +40,7 @@
          gsd-show-status
          ;; Individual command handlers for direct wiring
          cmd-replan
+         cmd-go
          cmd-skip
          cmd-reset
          cmd-done
@@ -164,6 +165,9 @@
 
 ;; /go [wave] → executing
 (define (cmd-go args)
+  ;; DEPRECATED (v0.24.5): Use handle-go-command in gsd-planning.rkt for the
+  ;; full normalized pipeline (parse → normalize → validate → execute).
+  ;; This function only does a bare state transition with no plan validation.
   (define wave-arg
     (if (string? args)
         (string-trim args)

--- a/tests/test-gsd-core.rkt
+++ b/tests/test-gsd-core.rkt
@@ -375,3 +375,12 @@
   (define allowed (gsd-write-guard "src/foo.rkt" ".planning"))
   (check-true (policy-decision? allowed))
   (check-true (policy-allowed? allowed)))
+
+(test-case "cmd-go is deprecated — bare state transition only"
+  ;; cmd-go only does a bare state transition; TUI /go uses normalized pipeline
+  (reset-gsm!)
+  (gsm-transition! 'exploring)
+  (gsm-transition! 'plan-written)
+  (define result (cmd-go ""))
+  (check-true (gsd-command-result-success result))
+  (check-not-false (string-contains? (gsd-command-result-message result) "Execution started")))


### PR DESCRIPTION
Addresses #2632.

fix(gsd): wrap /go in transaction + deprecate cmd-go (#2632)

v0.24.5 W1 — /go Transaction + cmd-go Unification.

GO-NO-TXN: Wrapped handle-go-command state mutations in snapshot/restore
transaction using with-handlers. On exception, all state is rolled back
and gsd.mode.changed event is emitted with rollback reason.

GO-DUPE: Added deprecation comment to cmd-go in core.rkt. Exported cmd-go
for test visibility. Added deprecation test confirming cmd-go still works
as bare state transition.

240 GSD tests pass.