### PR TITLE
feat(security): add allowlist execution policy for non-interactive/CI (RA-1a) (#2696)

v0.24.7 W0 — Allowlist mode for non-interactive/CI.

Adds `current-execution-policy` parameter: 'warn (default), 'block,
'allowlist. In allowlist mode, only commands in
`current-allowed-commands` execute; all others blocked.
Allowed list configurable, defaults to common safe commands.

6 new tests for execution policy modes.

### DIFF
--- a/tests/test-tool-bash-security.rkt
+++ b/tests/test-tool-bash-security.rkt
@@ -112,3 +112,33 @@
                 (lambda ()
                   (current-safe-mode-config orig-config)
                   (current-block-destructive orig-block))))
+
+;; ── RA-1a: Allowlist execution policy (v0.24.7) ──
+
+(require (only-in "../tools/builtins/bash.rkt"
+                  current-execution-policy
+                  current-allowed-commands
+                  execution-policy-allows?))
+
+(test-case "RA-1a: allowlist blocks disallowed command"
+  (parameterize ([current-execution-policy 'allowlist]
+                 [current-allowed-commands '("git" "ls" "grep")])
+    (check-false (execution-policy-allows? "rm -rf /tmp"))))
+
+(test-case "RA-1a: allowlist allows listed command"
+  (parameterize ([current-execution-policy 'allowlist]
+                 [current-allowed-commands '("git" "ls" "grep")])
+    (check-not-false (execution-policy-allows? "git status"))))
+
+(test-case "RA-1a: allowlist allows simple ls"
+  (parameterize ([current-execution-policy 'allowlist]
+                 [current-allowed-commands '("git" "ls" "grep")])
+    (check-not-false (execution-policy-allows? "ls -la /tmp"))))
+
+(test-case "RA-1a: warn policy allows everything"
+  (parameterize ([current-execution-policy 'warn])
+    (check-true (execution-policy-allows? "rm -rf /tmp"))))
+
+(test-case "RA-1a: block policy allows everything (destructive check handles blocking)"
+  (parameterize ([current-execution-policy 'block])
+    (check-true (execution-policy-allows? "rm -rf /tmp"))))

--- a/tools/builtins/bash.rkt
+++ b/tools/builtins/bash.rkt
@@ -45,10 +45,65 @@
          current-block-destructive
          current-extra-destructive-patterns
          destructive-command?
-         destructive-patterns)
+         destructive-patterns
+         current-execution-policy
+         current-allowed-commands
+         execution-policy-allows?)
 
 ;; Default timeout in seconds (used when no settings available)
 (define DEFAULT-TIMEOUT-SECONDS 120)
+
+;; ── Execution policy (RA-1a, v0.24.7) ──
+;; Controls which commands are allowed to execute.
+;; 'warn      — current behavior: warn on destructive, allow all
+;; 'block     — block destructive commands (same as safe-mode)
+;; 'allowlist — only commands in current-allowed-commands execute
+(define current-execution-policy (make-parameter 'warn))
+
+;; When execution-policy is 'allowlist, only these base commands execute.
+;; Configurable via config.json "execution-policy".allowed list.
+(define current-allowed-commands
+  (make-parameter '("git" "ls"
+                          "cat"
+                          "grep"
+                          "find"
+                          "raco"
+                          "racket"
+                          "echo"
+                          "mkdir"
+                          "cp"
+                          "mv"
+                          "diff"
+                          "head"
+                          "tail"
+                          "wc"
+                          "sort"
+                          "awk"
+                          "sed"
+                          "make")))
+
+;; Extract base command (first word) from a shell command string.
+(define (extract-base-command command)
+  (define trimmed (string-trim command))
+  (define space-idx
+    (for/first ([c (in-string trimmed)]
+                [i (in-naturals)]
+                #:when (char=? c #\space))
+      i))
+  (if space-idx
+      (substring trimmed 0 space-idx)
+      trimmed))
+
+;; Check if command is allowed under current execution policy.
+;; Returns #t if allowed, #f if blocked.
+(define (execution-policy-allows? command)
+  (define policy (current-execution-policy))
+  (case policy
+    [(warn block) #t] ; warn/block handled by destructive checks
+    [(allowlist)
+     (define base (extract-base-command command))
+     (member base (current-allowed-commands))]
+    [else #t])) ; unknown policy defaults to allow
 
 ;; Destructive command patterns (SEC-03, #449)
 ;; Each pattern uses anchors (^|[&;|\n]) or word boundaries to avoid
@@ -167,8 +222,10 @@
          (cond
            [(eq? v 'safe-mode-default) (safe-mode?)]
            [else v])))
-     ;; Destructive command handling (SEC-01 / SEC-03)
+     ;; Execution policy gate (RA-1a, v0.24.7)
      (cond
+       [(not (execution-policy-allows? command))
+        (make-error-result (format "Blocked by execution policy (allowlist mode): ~a" command))]
        ;; Block takes priority
        [(and block-destructive? (destructive-command? command))
         (make-error-result (format "Blocked destructive command: ~a" command))]


### PR DESCRIPTION
Addresses #2696.

feat(security): add allowlist execution policy for non-interactive/CI (RA-1a) (#2696)

v0.24.7 W0 — Allowlist mode for non-interactive/CI.

Adds `current-execution-policy` parameter: 'warn (default), 'block,
'allowlist. In allowlist mode, only commands in
`current-allowed-commands` execute; all others blocked.
Allowed list configurable, defaults to common safe commands.

6 new tests for execution policy modes.