### PR TITLE
feat(security): configurable secret scrubbing with extra-denylist/allowlist (RA-2) (#2700)

v0.24.7 W2 — Configurable environment variable scrubbing.

Adds `current-secret-scrub-denylist` (extra patterns to block) and
`current-secret-scrub-allowlist` (patterns to preserve). Allowlist
takes priority over denylist. Audit log emitted when vars are scrubbed.

4 new tests for denylist, allowlist, priority, and defaults.

### DIFF
--- a/sandbox/subprocess.rkt
+++ b/sandbox/subprocess.rkt
@@ -20,7 +20,9 @@
          default-timeout-seconds
          default-max-output-bytes
          sanitize-env
-         secret-env-var?)
+         secret-env-var?
+         current-secret-scrub-denylist
+         current-secret-scrub-allowlist)
 
 ;; --------------------------------------------------
 ;; Result struct
@@ -125,20 +127,49 @@
         #rx"(?i:GH_PAT)"
         #rx"(?i:_PAT$)"))
 
+;; ── RA-2 (v0.24.7): Configurable secret scrubbing ──
+;; Extra denylist: additional regex patterns to scrub (extends secret-patterns).
+(define current-secret-scrub-denylist (make-parameter '()))
+
+;; Allowlist: env vars matching these patterns are kept even if they match deny.
+(define current-secret-scrub-allowlist (make-parameter '()))
+
 (define (secret-env-var? name)
   (define name-str
     (if (bytes? name)
         (bytes->string/utf-8 name)
         name))
-  (for/or ([pat (in-list secret-patterns)])
-    (regexp-match? pat name-str)))
+  ;; Check allowlist first — if matched, never scrub
+  (define allowed?
+    (for/or ([pat (in-list (current-secret-scrub-allowlist))])
+      (regexp-match? pat name-str)))
+  (cond
+    [allowed? #f]
+    [else
+     ;; Check default patterns + extra denylist
+     (define all-patterns (append secret-patterns (current-secret-scrub-denylist)))
+     (for/or ([pat (in-list all-patterns)])
+       (regexp-match? pat name-str))]))
 
 (define (sanitize-env [env (current-environment-variables)])
   (define clean (make-environment-variables))
+  (define scrubbed-names '())
   (for ([name (in-list (environment-variables-names env))])
-    (unless (secret-env-var? name)
-      (define val (environment-variables-ref env name))
-      (environment-variables-set! clean name val)))
+    (cond
+      [(secret-env-var? name)
+       (define name-str
+         (if (bytes? name)
+             (bytes->string/utf-8 name)
+             name))
+       (set! scrubbed-names (cons name-str scrubbed-names))]
+      [else
+       (define val (environment-variables-ref env name))
+       (environment-variables-set! clean name val)]))
+  ;; RA-2: Emit audit log when vars are scrubbed
+  (unless (null? scrubbed-names)
+    (log-subprocess-info "sanitize-env: scrubbed ~a env vars: ~a"
+                         (length scrubbed-names)
+                         (string-join (sort scrubbed-names string<?) ", ")))
   clean)
 
 ;; --------------------------------------------------

--- a/tests/test-subprocess.rkt
+++ b/tests/test-subprocess.rkt
@@ -134,4 +134,45 @@
    (check-false (string-contains? (subprocess-result-stdout result) "should-be-stripped")
                 "secret env var should not appear in subprocess env")))
 
+;; ── RA-2 (v0.24.7): Configurable secret scrubbing ──
+(test-case "RA-2: extra denylist scrubs additional patterns"
+  (define env (make-environment-variables))
+  (environment-variables-set! env #"MY_CUSTOM_SECRET" #"val123")
+  (environment-variables-set! env #"PATH" #"/usr/bin")
+  (parameterize ([current-secret-scrub-denylist (list #rx"(?i:CUSTOM)")])
+    (define clean (sanitize-env env))
+    (check-equal? (environment-variables-ref clean #"PATH") #"/usr/bin")
+    (check-false (environment-variables-ref clean #"MY_CUSTOM_SECRET")
+                 "extra denylist should scrub CUSTOM vars")))
+
+(test-case "RA-2: allowlist preserves vars that would be scrubbed"
+  (define env (make-environment-variables))
+  (environment-variables-set! env #"MY_TOKEN_COUNT" #"42")
+  (environment-variables-set! env #"SECRET_KEY" #"abc")
+  (parameterize ([current-secret-scrub-allowlist (list #rx"(?i:TOKEN_COUNT)")])
+    (define clean (sanitize-env env))
+    ;; TOKEN_COUNT is allowed despite matching TOKEN pattern
+    (check-equal? (environment-variables-ref clean #"MY_TOKEN_COUNT") #"42")
+    ;; SECRET_KEY still scrubbed (not in allowlist)
+    (check-false (environment-variables-ref clean #"SECRET_KEY"))))
+
+(test-case "RA-2: allowlist takes priority over extra denylist"
+  (define env (make-environment-variables))
+  (environment-variables-set! env #"CUSTOM_AUTH_FLAG" #"yes")
+  (parameterize ([current-secret-scrub-denylist (list #rx"(?i:CUSTOM)")]
+                 [current-secret-scrub-allowlist (list #rx"(?i:AUTH_FLAG)")])
+    (define clean (sanitize-env env))
+    ;; AUTH_FLAG is allowed despite matching CUSTOM denylist
+    (check-equal? (environment-variables-ref clean #"CUSTOM_AUTH_FLAG") #"yes")))
+
+(test-case "RA-2: empty denylist and allowlist uses defaults"
+  (define env (make-environment-variables))
+  (environment-variables-set! env #"API_KEY" #"secret")
+  (environment-variables-set! env #"PATH" #"/usr/bin")
+  (parameterize ([current-secret-scrub-denylist '()]
+                 [current-secret-scrub-allowlist '()])
+    (define clean (sanitize-env env))
+    (check-false (environment-variables-ref clean #"API_KEY"))
+    (check-equal? (environment-variables-ref clean #"PATH") #"/usr/bin")))
+
 (run-tests subprocess-tests)


### PR DESCRIPTION
Addresses #2700.

feat(security): configurable secret scrubbing with extra-denylist/allowlist (RA-2) (#2700)

v0.24.7 W2 — Configurable environment variable scrubbing.

Adds `current-secret-scrub-denylist` (extra patterns to block) and
`current-secret-scrub-allowlist` (patterns to preserve). Allowlist
takes priority over denylist. Audit log emitted when vars are scrubbed.

4 new tests for denylist, allowlist, priority, and defaults.