### PR TITLE
refactor: extract partition-messages to context-pinning.rkt (RA-3a) (#2708)

v0.24.8 W0 — Extract pinning strategy submodule.

New `runtime/context-pinning.rkt` (34 lines) with `partition-messages`.
context-assembly.rkt: 825 → 809 lines. 21 tests pass.

### DIFF
--- a/runtime/context-assembly.rkt
+++ b/runtime/context-assembly.rkt
@@ -33,6 +33,7 @@
                   user-message?
                   system-message?)
          (only-in "../runtime/compactor.rkt" llm-summarize)
+         (only-in "context-pinning.rkt" partition-messages)
          (only-in "../runtime/compaction-prompts.rkt" format-messages-for-summary)
          (only-in "../llm/provider.rkt" provider?)
          (only-in "../util/hook-types.rkt" hook-result-action hook-result-payload hook-result?)
@@ -437,23 +438,7 @@
 (define (transform-summary-to-user entry)
   (struct-copy message entry [role 'user]))
 
-;; ============================================================
-;; Phase 1: Pin system prompt + first user + compaction summaries
-;; ============================================================
-
-(define (partition-messages messages)
-  (define first-user
-    (for/first ([m (in-list messages)]
-                #:when (eq? (message-role m) 'user))
-      m))
-  (define-values (protected removable)
-    (partition (lambda (m)
-                 (or (eq? (message-kind m) 'system-instruction)
-                     (eq? (message-kind m) 'compaction-summary)
-                     (eq? (message-kind m) 'context-assembly-summary)
-                     (and first-user (eq? m first-user))))
-               messages))
-  (values protected removable))
+;; partition-messages extracted to context-pinning.rkt
 
 ;; ============================================================
 ;; Phase 3: Fit recent messages

--- a/runtime/context-pinning.rkt
+++ b/runtime/context-pinning.rkt
@@ -1,0 +1,31 @@
+#lang racket/base
+;; STABILITY: evolving
+
+;; q/runtime/context-pinning.rkt — Context message pinning/partitioning
+;;
+;; Extracted from context-assembly.rkt. Identifies pinned messages
+;; (system prompt, first user message, compaction summaries) and
+;; partitions them from removable messages.
+
+(require racket/list
+         (only-in "../util/protocol-types.rkt" message-role message-kind))
+
+(provide partition-messages)
+
+;; ============================================================
+;; Phase 1: Pin system prompt + first user + compaction summaries
+;; ============================================================
+
+(define (partition-messages messages)
+  (define first-user
+    (for/first ([m (in-list messages)]
+                #:when (eq? (message-role m) 'user))
+      m))
+  (define-values (protected removable)
+    (partition (lambda (m)
+                 (or (eq? (message-kind m) 'system-instruction)
+                     (eq? (message-kind m) 'compaction-summary)
+                     (eq? (message-kind m) 'context-assembly-summary)
+                     (and first-user (eq? m first-user))))
+               messages))
+  (values protected removable))


### PR DESCRIPTION
Addresses #2708.

refactor: extract partition-messages to context-pinning.rkt (RA-3a) (#2708)

v0.24.8 W0 — Extract pinning strategy submodule.

New `runtime/context-pinning.rkt` (34 lines) with `partition-messages`.
context-assembly.rkt: 825 → 809 lines. 21 tests pass.