### PR TITLE
refactor: extract summary/catalog to context-summary.rkt (RA-3c) (#2712)

v0.24.8 W2 — Extract summary/catalog submodule.

New `runtime/context-summary.rkt` (272 lines) with catalog-entry,
context-summary structs, summary-cache, generate-catalog,
context-summary-prompt, generate-context-summary, simple-summary-text,
simple-summary-count, and helpers.

context-assembly.rkt: 775 → 587 lines. 21 tests pass.

### DIFF
--- a/runtime/context-assembly.rkt
+++ b/runtime/context-assembly.rkt
@@ -32,13 +32,41 @@
                   fit-messages-pair-preserving
                   user-message?
                   system-message?)
-         (only-in "../runtime/compactor.rkt" llm-summarize)
          (only-in "context-pinning.rkt" partition-messages)
          (only-in "context-fit.rkt" truncate-messages-to-budget fit-messages-from-recent)
-         (only-in "../runtime/compaction-prompts.rkt" format-messages-for-summary)
          (only-in "../llm/provider.rkt" provider?)
          (only-in "../util/hook-types.rkt" hook-result-action hook-result-payload hook-result?)
-         "../skills/context-files.rkt")
+         "../skills/context-files.rkt"
+         (only-in "context-summary.rkt"
+                  DEFAULT-CACHE-MAX-ENTRIES
+                  make-summary-cache
+                  summary-cache
+                  summary-cache?
+                  summary-cache-lookup
+                  summary-cache-store!
+                  summary-cache-count
+                  summary-cache-max-entries
+                  catalog-entry
+                  catalog-entry?
+                  catalog-entry-id
+                  catalog-entry-role
+                  catalog-entry-summary
+                  generate-catalog
+                  collapse-consecutive-tools
+                  message->catalog-entry
+                  tool-group->catalog-entry
+                  context-summary
+                  context-summary?
+                  context-summary-from-id
+                  context-summary-to-id
+                  context-summary-text
+                  context-summary-entry-count
+                  context-summary-prompt
+                  generate-context-summary
+                  simple-summary-text
+                  simple-summary-count
+                  extract-message-text
+                  truncate-string))
 
 ;; Config
 (provide context-assembly-config
@@ -170,65 +198,6 @@
          catalog ; (listof catalog-entry?) — summaries of excluded
          summary) ; (or/c context-summary? #f) — generated summary
   #:transparent)
-
-;; ============================================================
-;; Catalog entry struct
-;; ============================================================
-
-(struct catalog-entry (id role summary) #:transparent)
-
-;; ============================================================
-;; Summary struct
-;; ============================================================
-
-(struct context-summary (from-id to-id text entry-count) #:transparent)
-
-;; ============================================================
-;; Summary cache — LRU eviction when capacity exceeded
-;; ============================================================
-
-;; Default maximum cache entries before LRU eviction
-(define DEFAULT-CACHE-MAX-ENTRIES 50)
-
-(struct summary-cache
-        ([table #:mutable] ; hash: key=(from-id . to-id) → value=text
-         [order #:mutable] ; list of keys in LRU order (newest first)
-         [max-entries #:mutable]) ; capacity limit
-  #:transparent)
-
-(define (make-summary-cache #:max-entries [max DEFAULT-CACHE-MAX-ENTRIES])
-  (summary-cache (hash) '() max))
-
-(define (summary-cache-lookup cache from-id to-id)
-  (define key (cons from-id to-id))
-  (define result (hash-ref (summary-cache-table cache) key #f))
-  ;; Promote to front of LRU on hit
-  (when result
-    (set-summary-cache-order! cache (cons key (remove key (summary-cache-order cache) equal?))))
-  result)
-
-(define (summary-cache-store! cache from-id to-id text)
-  (define key (cons from-id to-id))
-  (define current-table (summary-cache-table cache))
-  (define current-order (summary-cache-order cache))
-  ;; If key already exists, just update and promote
-  (cond
-    [(hash-has-key? current-table key)
-     (set-summary-cache-table! cache (hash-set current-table key text))
-     (set-summary-cache-order! cache (cons key (remove key current-order equal?)))]
-    [else
-     ;; Evict oldest if at capacity
-     (when (>= (hash-count current-table) (summary-cache-max-entries cache))
-       (define oldest-key (last current-order))
-       (set-summary-cache-table! cache (hash-remove current-table oldest-key))
-       (set-summary-cache-order! cache (remove oldest-key current-order equal?)))
-     ;; Insert new entry at front
-     (set-summary-cache-table! cache (hash-set (summary-cache-table cache) key text))
-     (set-summary-cache-order! cache (cons key (summary-cache-order cache)))]))
-
-;; Query cache size (for testing)
-(define (summary-cache-count cache)
-  (hash-count (summary-cache-table cache)))
 
 ;; ============================================================
 ;; Core: build-assembled-context
@@ -446,150 +415,6 @@
 ;; ============================================================
 
 ;; ============================================================
-;; Phase 4: Catalog generation
-;; ============================================================
-;; generate-catalog: Build a summary catalog from older entries.
-;; Returns a list of (text . entry) pairs fitting within token budget.
-(define (generate-catalog entries
-                          #:max-entries [max-entries 40]
-                          #:max-tokens [max-tokens 2000]
-                          #:estimate-text [estimate-text-fn estimate-text-tokens])
-  (define collapsed (collapse-consecutive-tools entries))
-  (let loop ([remaining collapsed]
-             [acc '()]
-             [used-tokens 0]
-             [count 0])
-    (cond
-      [(null? remaining) (reverse acc)]
-      [(>= count max-entries) (reverse acc)]
-      [else
-       (define entry (car remaining))
-       (define tokens (estimate-text-fn (catalog-entry-summary entry)))
-       (if (> (+ used-tokens tokens) max-tokens)
-           (reverse acc)
-           (loop (cdr remaining) (cons entry acc) (+ used-tokens tokens) (add1 count)))])))
-
-;; collapse-consecutive-tools: Merge adjacent tool-call/tool-result sequences
-;; into a single summary entry to reduce context size.
-(define (collapse-consecutive-tools entries)
-  (define-values (result current-group)
-    (for/fold ([acc '()]
-               [group '()])
-              ([m (in-list entries)])
-      (cond
-        [(eq? (message-role m) 'tool) (values acc (cons m group))]
-        [(null? group) (values (cons (message->catalog-entry m) acc) '())]
-        [else
-         (values (cons (message->catalog-entry m)
-                       (cons (tool-group->catalog-entry (reverse group)) acc))
-                 '())])))
-  (reverse (if (null? current-group)
-               result
-               (cons (tool-group->catalog-entry (reverse current-group)) result))))
-
-(define (message->catalog-entry m)
-  (catalog-entry (message-id m)
-                 (symbol->string (message-role m))
-                 (truncate-string (extract-message-text m) 80)))
-
-(define (tool-group->catalog-entry tool-msgs)
-  (define ids (string-join (map message-id tool-msgs) ","))
-  (define texts (map extract-message-text tool-msgs))
-  (catalog-entry
-   ids
-   "tool"
-   (format "[~a tool calls: ~a]" (length tool-msgs) (truncate-string (string-join texts "; ") 50))))
-
-;; ============================================================
-;; Summary prompt template
-;; ============================================================
-
-(define (context-summary-prompt messages #:previous-summary [prev-summary #f])
-  (define formatted (format-messages-for-summary messages))
-  (cond
-    [prev-summary
-     (string-append "You are updating an existing session summary with new information. "
-                    "Merge the new messages into the existing summary.\n\n"
-                    "EXISTING SUMMARY:\n"
-                    prev-summary
-                    "\n\nNEW MESSAGES SINCE LAST SUMMARY:\n"
-                    formatted
-                    "\n\nProduce an UPDATED summary with these EXACT sections:\n"
-                    "## Goal\n"
-                    "## Progress\n### Done\n### In Progress\n### Blocked\n"
-                    "## Key Decisions\n"
-                    "## Next Steps\n"
-                    "## Critical Context\n\n"
-                    "RULES:\n"
-                    "- Maximum ~500 words\n"
-                    "- Preserve all information from existing summary that is still relevant\n"
-                    "- Add new information from new messages\n"
-                    "- Update Progress sections (move items between Done/In Progress/Blocked)\n"
-                    "- Keep the Goal to ONE line\n")]
-    [else
-     (string-append
-      "You are summarizing a coding assistant session. "
-      "Produce a structured summary with these EXACT sections:\n\n"
-      "## Goal\n<one-line description of what the user is trying to accomplish>\n\n"
-      "## Progress\n### Done\n- [x] <completed items>\n\n"
-      "### In Progress\n- <current work if any>\n\n"
-      "### Blocked\n- <blockers if any>\n\n"
-      "## Key Decisions\n- <important decisions made during the session>\n\n"
-      "## Next Steps\n1. <next actions>\n\n"
-      "## Critical Context\n- <must-preserve information: file paths, variable names, API details, error states>\n\n"
-      "RULES:\n"
-      "- Maximum ~500 words\n"
-      "- Preserve specific file paths, function names, variable names exactly\n"
-      "- Include any error messages or states being debugged\n"
-      "- Keep the Goal to ONE line\n\n"
-      "SESSION MESSAGES:\n"
-      formatted)]))
-
-;; ============================================================
-;; Generate context summary
-;; ============================================================
-
-;; generate-context-summary: Produce a text summary of entries using LLM or fallback.
-;; Returns a context-summary struct or #f if no entries.
-(define (generate-context-summary entries provider model-name #:cache [cache #f])
-  (cond
-    [(null? entries) #f]
-    [else
-     (define from-id (message-id (first entries)))
-     (define to-id (message-id (last entries)))
-     (define cached (and cache (summary-cache-lookup cache from-id to-id)))
-     (cond
-       [cached (context-summary from-id to-id cached (length entries))]
-       [else
-        (define summary-text
-          (cond
-            [(and provider model-name (provider? provider))
-             (llm-summarize entries provider model-name)]
-            [else (simple-summary-text entries)]))
-        (when cache
-          (summary-cache-store! cache from-id to-id summary-text))
-        (define actual-count
-          (if (and provider model-name (provider? provider))
-              (length entries)
-              (simple-summary-count entries)))
-        (context-summary from-id to-id summary-text actual-count)])]))
-
-(define (simple-summary-text entries)
-  (string-append "## Progress\n### Done\n"
-                 (string-join (for/list ([m (in-list entries)]
-                                         [i (in-naturals)]
-                                         #:break (>= i 20))
-                                (format "- [~a] ~a: ~a"
-                                        (message-id m)
-                                        (symbol->string (message-role m))
-                                        (truncate-string (extract-message-text m) 100)))
-                              "\n")))
-
-;; Count of entries actually represented in simple-summary-text
-(define (simple-summary-count entries)
-  (min (length entries) 20))
-
-;; ============================================================
 ;; Tiered Context Assembly (from compactor.rkt)
 ;; ============================================================
 
@@ -758,18 +583,5 @@
         (string-join parts "\n\n")])]))
 
 ;; ============================================================
-;; Helpers
+;; Helpers (extract-message-text, truncate-string moved to context-summary.rkt)
 ;; ============================================================
-
-(define (extract-message-text msg)
-  (define parts (message-content msg))
-  (define texts
-    (for/list ([part (in-list parts)]
-               #:when (text-part? part))
-      (text-part-text part)))
-  (string-join texts " "))
-
-(define (truncate-string s max-len)
-  (if (<= (string-length s) max-len)
-      s
-      (string-append (substring s 0 (- max-len 3)) "...")))

--- a/runtime/context-summary.rkt
+++ b/runtime/context-summary.rkt
@@ -1,0 +1,272 @@
+#lang racket/base
+;; STABILITY: evolving
+
+;; q/runtime/context-summary.rkt — Summary and catalog generation for context assembly
+;;
+;; Provides summary cache (LRU), catalog entry generation, context summary
+;; prompting/generation, and related helpers. Extracted from context-assembly.rkt.
+
+(require racket/string
+         racket/list
+         "../util/protocol-types.rkt"
+         "../llm/token-budget.rkt"
+         (only-in "../runtime/compaction-prompts.rkt" format-messages-for-summary)
+         (only-in "../runtime/compactor.rkt" llm-summarize)
+         (only-in "../llm/provider.rkt" provider?))
+
+;; Summary cache
+(provide summary-cache
+         summary-cache?
+         summary-cache-table
+         summary-cache-order
+         summary-cache-max-entries
+         make-summary-cache
+         summary-cache-lookup
+         summary-cache-store!
+         summary-cache-count
+         DEFAULT-CACHE-MAX-ENTRIES
+         ;; Catalog
+         catalog-entry
+         catalog-entry?
+         catalog-entry-id
+         catalog-entry-role
+         catalog-entry-summary
+         generate-catalog
+         collapse-consecutive-tools
+         message->catalog-entry
+         tool-group->catalog-entry
+         ;; Context summary
+         context-summary
+         context-summary?
+         context-summary-from-id
+         context-summary-to-id
+         context-summary-text
+         context-summary-entry-count
+         context-summary-prompt
+         generate-context-summary
+         simple-summary-text
+         simple-summary-count
+         ;; Helpers
+         extract-message-text
+         truncate-string)
+
+;; ============================================================
+;; Catalog entry struct
+;; ============================================================
+
+(struct catalog-entry (id role summary) #:transparent)
+
+;; ============================================================
+;; Summary struct
+;; ============================================================
+
+(struct context-summary (from-id to-id text entry-count) #:transparent)
+
+;; ============================================================
+;; Summary cache — LRU eviction when capacity exceeded
+;; ============================================================
+
+;; Default maximum cache entries before LRU eviction
+(define DEFAULT-CACHE-MAX-ENTRIES 50)
+
+(struct summary-cache
+        ([table #:mutable] ; hash: key=(from-id . to-id) → value=text
+         [order #:mutable] ; list of keys in LRU order (newest first)
+         [max-entries #:mutable]) ; capacity limit
+  #:transparent)
+
+(define (make-summary-cache #:max-entries [max DEFAULT-CACHE-MAX-ENTRIES])
+  (summary-cache (hash) '() max))
+
+(define (summary-cache-lookup cache from-id to-id)
+  (define key (cons from-id to-id))
+  (define result (hash-ref (summary-cache-table cache) key #f))
+  ;; Promote to front of LRU on hit
+  (when result
+    (set-summary-cache-order! cache (cons key (remove key (summary-cache-order cache) equal?))))
+  result)
+
+(define (summary-cache-store! cache from-id to-id text)
+  (define key (cons from-id to-id))
+  (define current-table (summary-cache-table cache))
+  (define current-order (summary-cache-order cache))
+  ;; If key already exists, just update and promote
+  (cond
+    [(hash-has-key? current-table key)
+     (set-summary-cache-table! cache (hash-set current-table key text))
+     (set-summary-cache-order! cache (cons key (remove key current-order equal?)))]
+    [else
+     ;; Evict oldest if at capacity
+     (when (>= (hash-count current-table) (summary-cache-max-entries cache))
+       (define oldest-key (last current-order))
+       (set-summary-cache-table! cache (hash-remove current-table oldest-key))
+       (set-summary-cache-order! cache (remove oldest-key current-order equal?)))
+     ;; Insert new entry at front
+     (set-summary-cache-table! cache (hash-set (summary-cache-table cache) key text))
+     (set-summary-cache-order! cache (cons key (summary-cache-order cache)))]))
+
+;; Query cache size (for testing)
+(define (summary-cache-count cache)
+  (hash-count (summary-cache-table cache)))
+
+;; ============================================================
+;; Catalog generation
+;; ============================================================
+
+;; generate-catalog: Build a summary catalog from older entries.
+;; Returns a list of catalog-entry fitting within token budget.
+(define (generate-catalog entries
+                          #:max-entries [max-entries 40]
+                          #:max-tokens [max-tokens 2000]
+                          #:estimate-text [estimate-text-fn estimate-text-tokens])
+  (define collapsed (collapse-consecutive-tools entries))
+  (let loop ([remaining collapsed]
+             [acc '()]
+             [used-tokens 0]
+             [count 0])
+    (cond
+      [(null? remaining) (reverse acc)]
+      [(>= count max-entries) (reverse acc)]
+      [else
+       (define entry (car remaining))
+       (define tokens (estimate-text-fn (catalog-entry-summary entry)))
+       (if (> (+ used-tokens tokens) max-tokens)
+           (reverse acc)
+           (loop (cdr remaining) (cons entry acc) (+ used-tokens tokens) (add1 count)))])))
+
+;; collapse-consecutive-tools: Merge adjacent tool-call/tool-result sequences
+;; into a single summary entry to reduce context size.
+(define (collapse-consecutive-tools entries)
+  (define-values (result current-group)
+    (for/fold ([acc '()]
+               [group '()])
+              ([m (in-list entries)])
+      (cond
+        [(eq? (message-role m) 'tool) (values acc (cons m group))]
+        [(null? group) (values (cons (message->catalog-entry m) acc) '())]
+        [else
+         (values (cons (message->catalog-entry m)
+                       (cons (tool-group->catalog-entry (reverse group)) acc))
+                 '())])))
+  (reverse (if (null? current-group)
+               result
+               (cons (tool-group->catalog-entry (reverse current-group)) result))))
+
+(define (message->catalog-entry m)
+  (catalog-entry (message-id m)
+                 (symbol->string (message-role m))
+                 (truncate-string (extract-message-text m) 80)))
+
+(define (tool-group->catalog-entry tool-msgs)
+  (define ids (string-join (map message-id tool-msgs) ","))
+  (define texts (map extract-message-text tool-msgs))
+  (catalog-entry
+   ids
+   "tool"
+   (format "[~a tool calls: ~a]" (length tool-msgs) (truncate-string (string-join texts "; ") 50))))
+
+;; ============================================================
+;; Summary prompt template
+;; ============================================================
+
+(define (context-summary-prompt messages #:previous-summary [prev-summary #f])
+  (define formatted (format-messages-for-summary messages))
+  (cond
+    [prev-summary
+     (string-append "You are updating an existing session summary with new information. "
+                    "Merge the new messages into the existing summary.\n\n"
+                    "EXISTING SUMMARY:\n"
+                    prev-summary
+                    "\n\nNEW MESSAGES SINCE LAST SUMMARY:\n"
+                    formatted
+                    "\n\nProduce an UPDATED summary with these EXACT sections:\n"
+                    "## Goal\n"
+                    "## Progress\n### Done\n### In Progress\n### Blocked\n"
+                    "## Key Decisions\n"
+                    "## Next Steps\n"
+                    "## Critical Context\n\n"
+                    "RULES:\n"
+                    "- Maximum ~500 words\n"
+                    "- Preserve all information from existing summary that is still relevant\n"
+                    "- Add new information from new messages\n"
+                    "- Update Progress sections (move items between Done/In Progress/Blocked)\n"
+                    "- Keep the Goal to ONE line\n")]
+    [else
+     (string-append
+      "You are summarizing a coding assistant session. "
+      "Produce a structured summary with these EXACT sections:\n\n"
+      "## Goal\n<one-line description of what the user is trying to accomplish>\n\n"
+      "## Progress\n### Done\n- [x] <completed items>\n\n"
+      "### In Progress\n- <current work if any>\n\n"
+      "### Blocked\n- <blockers if any>\n\n"
+      "## Key Decisions\n- <important decisions made during the session>\n\n"
+      "## Next Steps\n1. <next actions>\n\n"
+      "## Critical Context\n- <must-preserve information: file paths, variable names, API details, error states>\n\n"
+      "RULES:\n"
+      "- Maximum ~500 words\n"
+      "- Preserve specific file paths, function names, variable names exactly\n"
+      "- Include any error messages or states being debugged\n"
+      "- Keep the Goal to ONE line\n\n"
+      "SESSION MESSAGES:\n"
+      formatted)]))
+
+;; ============================================================
+;; Generate context summary
+;; ============================================================
+
+;; generate-context-summary: Produce a text summary of entries using LLM or fallback.
+;; Returns a context-summary struct or #f if no entries.
+(define (generate-context-summary entries provider model-name #:cache [cache #f])
+  (cond
+    [(null? entries) #f]
+    [else
+     (define from-id (message-id (first entries)))
+     (define to-id (message-id (last entries)))
+     (define cached (and cache (summary-cache-lookup cache from-id to-id)))
+     (cond
+       [cached (context-summary from-id to-id cached (length entries))]
+       [else
+        (define summary-text
+          (cond
+            [(and provider model-name (provider? provider))
+             (llm-summarize entries provider model-name)]
+            [else (simple-summary-text entries)]))
+        (when cache
+          (summary-cache-store! cache from-id to-id summary-text))
+        (define actual-count
+          (if (and provider model-name (provider? provider))
+              (length entries)
+              (simple-summary-count entries)))
+        (context-summary from-id to-id summary-text actual-count)])]))
+
+(define (simple-summary-text entries)
+  (string-append "## Progress\n### Done\n"
+                 (string-join (for/list ([m (in-list entries)]
+                                         [i (in-naturals)]
+                                         #:break (>= i 20))
+                                (format "- [~a] ~a: ~a"
+                                        (message-id m)
+                                        (symbol->string (message-role m))
+                                        (truncate-string (extract-message-text m) 100)))
+                              "\n")))
+
+;; Count of entries actually represented in simple-summary-text
+(define (simple-summary-count entries)
+  (min (length entries) 20))
+
+;; ============================================================
+;; Helpers
+;; ============================================================
+
+(define (extract-message-text msg)
+  (define parts (message-content msg))
+  (define texts
+    (for/list ([part (in-list parts)]
+               #:when (text-part? part))
+      (text-part-text part)))
+  (string-join texts " "))
+
+(define (truncate-string s max-len)
+  (if (<= (string-length s) max-len)
+      s
+      (string-append (substring s 0 (- max-len 3)) "...")))


### PR DESCRIPTION
Addresses #2712.

refactor: extract summary/catalog to context-summary.rkt (RA-3c) (#2712)

v0.24.8 W2 — Extract summary/catalog submodule.

New `runtime/context-summary.rkt` (272 lines) with catalog-entry,
context-summary structs, summary-cache, generate-catalog,
context-summary-prompt, generate-context-summary, simple-summary-text,
simple-summary-count, and helpers.

context-assembly.rkt: 775 → 587 lines. 21 tests pass.