### PR TITLE
feat: add reproducible audit script (RA-4) (#2720)

v0.24.9 W0 — Reproducible project audit script.

New `scripts/audit-project.rkt`:
- Module inventory (774 modules, 147k lines, by-layer breakdown)
- Risky API usage scanner (eval, system, set!, error swallowing)
- TODO/FIXME/HACK marker scanner
- Oversized module detector (threshold: 900 lines)
- Markdown report output to docs/audits/
- CI mode (--ci): exits non-zero on critical findings
- 4 tests pass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ dist/
 
 # Internal analysis — never push
 docs/COMPETITOR-ANALYSIS.md
+docs/audits/

--- a/scripts/audit-project.rkt
+++ b/scripts/audit-project.rkt
@@ -1,0 +1,245 @@
+#lang racket
+
+;; scripts/audit-project.rkt — Reproducible project audit (RA-4, v0.24.9)
+;;
+;; Automated module inventory, risky API usage scan, TODO/deprecation check.
+;; Output: timestamped markdown report to docs/audits/.
+;; CI mode: --ci exits non-zero on critical findings.
+;;
+;; Usage:
+;;   racket scripts/audit-project.rkt              # full report
+;;   racket scripts/audit-project.rkt --ci         # CI mode: exit 1 on critical
+;;   racket scripts/audit-project.rkt --stdout     # print to stdout
+
+(require racket/port
+         racket/string
+         racket/list
+         racket/file
+         racket/match
+         racket/date
+         racket/path)
+
+;; ── Configuration ──
+
+(define Q-DIR
+  (simplify-path (let ([try (current-directory)])
+                   (if (directory-exists? (build-path try "runtime"))
+                       try
+                       (build-path try "q")))))
+
+(define AUDITS-DIR (build-path Q-DIR "docs" "audits"))
+(define SIZE-THRESHOLD 900)
+
+;; ── Helpers ──
+
+(define SKIP-DIRS '("compiled" ".git" "node_modules"))
+
+(define (in-skip-dir? p skip-list)
+  (define rel (path->string (find-relative-path Q-DIR p)))
+  (for/or ([d (in-list skip-list)])
+    (string-contains? rel (string-append d "/"))))
+
+(define (find-rkt-files #:skip-dirs [skip-dirs SKIP-DIRS])
+  (define raw (find-files (lambda (p) #t) Q-DIR))
+  (filter (lambda (f)
+            (and (file-exists? f)
+                 (let ([ext (path-get-extension f)])
+                   (and ext (member (bytes->string/utf-8 ext) '(".rkt" ".rktl"))))
+                 (not (in-skip-dir? f skip-dirs))))
+          raw))
+
+;; ── Finding data ──
+
+(struct finding (severity category file line message) #:transparent)
+
+(define (finding->md f)
+  (match-define (finding sev cat file line msg) f)
+  (format "- **[~a]** ~a: `~a` (line ~a): ~a" sev cat (find-relative-path Q-DIR file) line msg))
+
+;; ── Scanners ──
+
+;; Scanner 1: Module inventory (informational)
+(define (scan-module-inventory)
+  (define rkt-files (find-rkt-files))
+  (define total-modules (length rkt-files))
+  (define total-lines
+    (for/sum ([f (in-list rkt-files)]) (length (string-split (file->string f) "\n"))))
+  (define by-layer
+    (for/fold ([acc (hash)]) ([f (in-list rkt-files)])
+      (define rel (path->string (find-relative-path Q-DIR f)))
+      (define layer
+        (cond
+          [(string-prefix? rel "runtime/") "runtime"]
+          [(string-prefix? rel "agent/") "agent"]
+          [(string-prefix? rel "llm/") "llm"]
+          [(string-prefix? rel "tools/") "tools"]
+          [(string-prefix? rel "tui/") "tui"]
+          [(string-prefix? rel "interfaces/") "interfaces"]
+          [(string-prefix? rel "extensions/") "extensions"]
+          [(string-prefix? rel "sandbox/") "sandbox"]
+          [(string-prefix? rel "util/") "util"]
+          [(string-prefix? rel "cli/") "cli"]
+          [(string-prefix? rel "tests/") "tests"]
+          [(string-prefix? rel "scripts/") "scripts"]
+          [else "other"]))
+      (hash-update acc layer add1 0)))
+  (hasheq 'total-modules total-modules 'total-lines total-lines 'by-layer by-layer))
+
+;; Scanner 2: Risky API usage
+(define RISKY-PATTERNS
+  (list (list #rx"\\(eval\\b" "eval usage — potential code injection risk")
+        (list #rx"\\(dynamic-require\\b" "dynamic-require — consider static require")
+        (list #rx"\\(system\\b" "raw system call — prefer subprocess sandbox")
+        (list #rx"\\(process\\b" "raw process call — verify resource limits")
+        (list #rx"\\(set!\\b" "mutation — prefer functional style")
+        (list #rx"\\(with-handlers.*#f" "handler returning #f may swallow errors")))
+
+(define (scan-risky-api)
+  (define rkt-files
+    (find-rkt-files #:skip-dirs '("compiled" ".git" "node_modules" "tests" "scripts")))
+  (apply append
+         (for/list ([f (in-list rkt-files)])
+           (define lines (string-split (file->string f) "\n"))
+           (apply append
+                  (for/list ([line-text (in-list lines)]
+                             [line-num (in-naturals 1)]
+                             #:when #t
+                             [pattern (in-list RISKY-PATTERNS)])
+                    (match-define (list rx msg) pattern)
+                    (if (regexp-match? rx line-text)
+                        (list (finding 'warning "risky-api" f line-num msg))
+                        '()))))))
+
+;; Scanner 3: TODO/deprecation check
+(define TODO-PATTERNS
+  (list (list #rx";;.*TODO.*remove" "TODO with 'remove' — track for cleanup")
+        (list #rx";;.*TODO.*deprecat" "TODO with 'deprecate' — track for cleanup")
+        (list #rx";;.*TODO.*v0\\." "TODO with version gate — verify target milestone")
+        (list #rx";;.*FIXME" "FIXME marker — needs resolution")
+        (list #rx";;.*HACK" "HACK marker — needs proper fix")
+        (list #rx";;.*XXX" "XXX marker — needs review")))
+
+(define (scan-todos)
+  (define rkt-files (find-rkt-files))
+  (apply
+   append
+   (for/list ([f (in-list rkt-files)])
+     (define lines (string-split (file->string f) "\n"))
+     (apply
+      append
+      (for/list ([line-text (in-list lines)]
+                 [line-num (in-naturals 1)]
+                 #:when #t
+                 [pattern (in-list TODO-PATTERNS)])
+        (match-define (list rx msg) pattern)
+        (if (regexp-match? rx line-text)
+            (list
+             (finding 'info "todo-marker" f line-num (format "~a: ~a" msg (string-trim line-text))))
+            '()))))))
+
+;; Scanner 4: Oversized modules
+(define (scan-oversized)
+  (define rkt-files
+    (find-rkt-files #:skip-dirs '("compiled" ".git" "node_modules" "tests" "scripts" "benchmark")))
+  (filter identity
+          (for/list ([f (in-list rkt-files)])
+            (define line-count (length (string-split (file->string f) "\n")))
+            (if (> line-count SIZE-THRESHOLD)
+                (finding 'warning
+                         "oversized"
+                         f
+                         line-count
+                         (format "~a lines (threshold: ~a)" line-count SIZE-THRESHOLD))
+                #f))))
+
+;; ── Report generation ──
+
+(define (generate-report)
+  (define inv (scan-module-inventory))
+  (define risky (scan-risky-api))
+  (define todos (scan-todos))
+  (define oversized (scan-oversized))
+  (define all-findings (append risky todos oversized))
+
+  (define ts
+    (parameterize ([date-display-format 'iso-8601])
+      (date->string (current-date) #t)))
+
+  (define critical-count (count (lambda (f) (eq? (finding-severity f) 'critical)) all-findings))
+  (define warning-count (count (lambda (f) (eq? (finding-severity f) 'warning)) all-findings))
+  (define info-count (count (lambda (f) (eq? (finding-severity f) 'info)) all-findings))
+
+  (define inventory-md
+    (string-append "## Module Inventory\n\n"
+                   (format "- **Total modules**: ~a\n- **Total lines**: ~a\n- **By layer**:\n"
+                           (hash-ref inv 'total-modules)
+                           (hash-ref inv 'total-lines))
+                   (string-join (for/list ([(k v) (in-hash (hash-ref inv 'by-layer))])
+                                  (format "  - `~a`: ~a modules" k v))
+                                "\n")
+                   "\n"))
+
+  (define findings-md
+    (cond
+      [(null? all-findings) "## Findings\n\nNo findings.\n"]
+      [else
+       (string-append "## Findings\n\n"
+                      (format "- **Critical**: ~a\n- **Warning**: ~a\n- **Info**: ~a\n\n"
+                              critical-count
+                              warning-count
+                              info-count)
+                      (if (pair? risky)
+                          (string-append "### Risky API Usage\n\n"
+                                         (string-join (map finding->md risky) "\n")
+                                         "\n\n")
+                          "")
+                      (if (pair? oversized)
+                          (string-append "### Oversized Modules\n\n"
+                                         (string-join (map finding->md oversized) "\n")
+                                         "\n\n")
+                          "")
+                      (if (pair? todos)
+                          (string-append "### TODO/FIXME Markers\n\n"
+                                         (string-join (map finding->md todos) "\n")
+                                         "\n\n")
+                          ""))]))
+
+  (define report
+    (string-append (format "# Q Project Audit Report\n\nGenerated: ~a\n\n" ts)
+                   inventory-md
+                   findings-md
+                   (format "## Summary\n\nTotal findings: ~a (critical: ~a, warning: ~a, info: ~a)\n"
+                           (length all-findings)
+                           critical-count
+                           warning-count
+                           info-count)))
+
+  (values report critical-count all-findings))
+
+;; ── Main ──
+
+(define ci-mode? (member "--ci" (vector->list (current-command-line-arguments))))
+(define stdout-mode? (member "--stdout" (vector->list (current-command-line-arguments))))
+
+(define-values (report critical-count findings) (generate-report))
+
+(cond
+  [stdout-mode? (displayln report)]
+  [else
+   (make-directory* AUDITS-DIR)
+   (define out-ts
+     (string-replace (parameterize ([date-display-format 'iso-8601])
+                       (date->string (current-date) #t))
+                     ":"
+                     "-"))
+   (define out-path (build-path AUDITS-DIR (format "audit-~a.md" out-ts)))
+   (call-with-output-file out-path (lambda (out) (display report out)) #:exists 'replace)
+   (printf "Audit report written to: ~a\n" (find-relative-path Q-DIR out-path))
+   (printf "Findings: ~a total (~a critical)\n" (length findings) critical-count)])
+
+(when ci-mode?
+  (if (> critical-count 0)
+      (begin
+        (printf "CI FAIL: ~a critical findings\n" critical-count)
+        (exit 1))
+      (printf "CI PASS: no critical findings\n")))

--- a/tests/test-audit-script.rkt
+++ b/tests/test-audit-script.rkt
@@ -1,0 +1,56 @@
+#lang racket
+
+;; tests/test-audit-script.rkt — Tests for scripts/audit-project.rkt (RA-4)
+
+(require rackunit
+         rackunit/text-ui
+         racket/string
+         racket/file
+         racket/path
+         racket/port)
+
+;; Resolve q-dir: go up from tests/ directory
+(define q-dir
+  (let* ([test-dir (current-directory)]
+         [parent (simplify-path (build-path test-dir ".."))])
+    (if (directory-exists? (build-path parent "runtime"))
+        parent
+        (simplify-path (build-path parent "q")))))
+
+(define audit-script (build-path q-dir "scripts" "audit-project.rkt"))
+
+(define (run-audit-stdout)
+  (define-values (sp out in err)
+    (parameterize ([current-directory q-dir])
+      (subprocess #f #f #f (find-executable-path "racket") (path->string audit-script) "--stdout")))
+  (define output (port->string out))
+  (close-input-port out)
+  (close-input-port err)
+  (close-output-port in)
+  (subprocess-wait sp)
+  output)
+
+(define audit-tests
+  (test-suite "Audit Script Tests"
+
+    (test-case "audit script exists and is readable"
+      (check-true (file-exists? audit-script)))
+
+    (test-case "audit --stdout produces valid markdown report"
+      (define output (run-audit-stdout))
+      (check-true (string-contains? output "# Q Project Audit Report"))
+      (check-true (string-contains? output "## Module Inventory"))
+      (check-true (string-contains? output "## Findings"))
+      (check-true (string-contains? output "## Summary")))
+
+    (test-case "audit report contains module count"
+      (define output (run-audit-stdout))
+      (check-true (string-contains? output "Total modules"))
+      (check-true (regexp-match? #rx"Total modules.*: [0-9]+" output)))
+
+    (test-case "audit report includes layer breakdown"
+      (define output (run-audit-stdout))
+      (check-true (string-contains? output "runtime"))
+      (check-true (string-contains? output "tests")))))
+
+(run-tests audit-tests)


### PR DESCRIPTION
Addresses #2720.

feat: add reproducible audit script (RA-4) (#2720)

v0.24.9 W0 — Reproducible project audit script.

New `scripts/audit-project.rkt`:
- Module inventory (774 modules, 147k lines, by-layer breakdown)
- Risky API usage scanner (eval, system, set!, error swallowing)
- TODO/FIXME/HACK marker scanner
- Oversized module detector (threshold: 900 lines)
- Markdown report output to docs/audits/
- CI mode (--ci): exits non-zero on critical findings
- 4 tests pass