### PR TITLE
chore: annotate deprecation TODO with milestone reference (RA-5) (#2722)

v0.24.9 W1 — Deprecation TODO tracking.

Only one TODO in codebase: context-assembly.rkt backward compat aliases.
Annotated with milestone reference (#v0.25.0). Verified no stale TODOs.
21 context-assembly tests pass.

### DIFF
--- a/runtime/context-assembly.rkt
+++ b/runtime/context-assembly.rkt
@@ -77,7 +77,7 @@
          context-assembly-config-summary-window
          make-context-assembly-config
          ;; Backward compat aliases — DEPRECATED, use context-assembly-config-* instead
-         ;; TODO: Remove in v0.25.0
+         ;; TODO(#v0.25.0): Remove in v0.25.0 — tracked for next breaking version
          (rename-out
           [context-assembly-config context-manager-config]
           [context-assembly-config? context-manager-config?]


### PR DESCRIPTION
Addresses #2722.

chore: annotate deprecation TODO with milestone reference (RA-5) (#2722)

v0.24.9 W1 — Deprecation TODO tracking.

Only one TODO in codebase: context-assembly.rkt backward compat aliases.
Annotated with milestone reference (#v0.25.0). Verified no stale TODOs.
21 context-assembly tests pass.