### PR TITLE
refactor: remove backward-compat aliases from context-assembly.rkt (F4) (#2738)

v0.25.0 W3 — Remove deprecated context-manager-config aliases.

- Remove 7 rename-out backward-compat aliases from runtime/context-assembly.rkt
- Remove TODO(#v0.25.0) annotation
- Remove backward-compat test case from tests/test-context-assembly.rkt
- No remaining consumers of the old aliases in the codebase
- 20 context-assembly tests pass

### DIFF
--- a/runtime/context-assembly.rkt
+++ b/runtime/context-assembly.rkt
@@ -76,16 +76,6 @@
          context-assembly-config-max-catalog-tokens
          context-assembly-config-summary-window
          make-context-assembly-config
-         ;; Backward compat aliases — DEPRECATED, use context-assembly-config-* instead
-         ;; TODO(#v0.25.0): Remove in v0.25.0 — tracked for next breaking version
-         (rename-out
-          [context-assembly-config context-manager-config]
-          [context-assembly-config? context-manager-config?]
-          [context-assembly-config-recent-tokens context-manager-config-recent-tokens]
-          [context-assembly-config-max-catalog-entries context-manager-config-max-catalog-entries]
-          [context-assembly-config-max-catalog-tokens context-manager-config-max-catalog-tokens]
-          [context-assembly-config-summary-window context-manager-config-summary-window]
-          [make-context-assembly-config make-context-manager-config])
          ;; Core API with contracts
          (contract-out [build-assembled-context
                         (->* [session-index? context-assembly-config?]

--- a/tests/test-context-assembly.rkt
+++ b/tests/test-context-assembly.rkt
@@ -40,11 +40,6 @@
 (test-case "exports: make-context-assembly-config is procedure"
   (check-true (procedure? make-context-assembly-config)))
 
-(test-case "exports: backward-compat make-context-manager-config"
-  (check-true (procedure? make-context-manager-config))
-  (define cfg (make-context-manager-config))
-  (check-true (context-assembly-config? cfg)))
-
 (test-case "config rejects negative recent-tokens"
   (check-exn exn:fail? (lambda () (make-context-assembly-config #:recent-tokens -1))))
 


### PR DESCRIPTION
Addresses #2738.

refactor: remove backward-compat aliases from context-assembly.rkt (F4) (#2738)

v0.25.0 W3 — Remove deprecated context-manager-config aliases.

- Remove 7 rename-out backward-compat aliases from runtime/context-assembly.rkt
- Remove TODO(#v0.25.0) annotation
- Remove backward-compat test case from tests/test-context-assembly.rkt
- No remaining consumers of the old aliases in the codebase
- 20 context-assembly tests pass