### PR TITLE
fix: AUTH regex over-matching + security config wiring (#2762)

v0.25.2 W1 — AUTH regex fix + config.json wiring (F2, F3).

F2: Fix AUTH regex to exclude false positives (AUTHOR, XAUTHORITY,
GPG_AUTH_INFO, GPG_TTY, SSH_AUTH_SOCK). Add implicit allowlist
checked before pattern matching. Regex changed from (?i:AUTH) to
(?i:^AUTH$|^AUTH_|_AUTH_) with built-in non-secret allowlist.

F3: Add security-config-from-settings in runtime/settings.rkt to
extract execution-policy, allowed commands, and scrub lists from
config.json. Wire these in wiring/run-modes.rkt at startup.
Update bash.rkt comment to reflect wiring.

Tests: 7 new AUTH regex tests, 3 new config wiring tests.

### DIFF
--- a/runtime/settings.rkt
+++ b/runtime/settings.rkt
@@ -83,7 +83,8 @@
          steering-gentle-threshold
          steering-strong-threshold
          steering-hard-cap
-         steering-same-file-dedup?)
+         steering-same-file-dedup?
+         security-config-from-settings)
 
 ;; ============================================================
 ;; Struct
@@ -288,6 +289,21 @@
 ;; Defaults to #f (no warning).
 (define (warn-on-destructive? settings)
   (setting-ref settings 'warn-on-destructive #f))
+
+;; ============================================================
+;; Security config loader (v0.25.2 — F3)
+;; ============================================================
+
+(define (security-config-from-settings settings)
+  (define merged (q-settings-merged settings))
+  (hasheq 'execution-policy-mode
+          (hash-ref merged 'execution-policy (hash-ref merged 'execution-policy.mode #f))
+          'execution-policy-allowed
+          (hash-ref merged 'execution-policy.allowed '())
+          'secret-scrub-extra-denylist
+          (hash-ref merged 'secret-scrub.extra-denylist '())
+          'secret-scrub-allowlist
+          (hash-ref merged 'secret-scrub.allowlist '())))
 
 ;; ============================================================
 ;; Sandbox settings — re-exported from util/sandbox-config.rkt

--- a/sandbox/subprocess.rkt
+++ b/sandbox/subprocess.rkt
@@ -123,9 +123,13 @@
         #rx"(?i:TOKEN)"
         #rx"(?i:PASSWORD)"
         #rx"(?i:CREDENTIAL)"
-        #rx"(?i:AUTH)"
+        #rx"(?i:^AUTH$|^AUTH_|_AUTH_)"
         #rx"(?i:GH_PAT)"
         #rx"(?i:_PAT$)"))
+
+;; Built-in implicit allowlist: well-known non-secret env vars that should
+;; never be scrubbed even if they partially match a secret pattern.
+(define SECRET-IMPLICIT-ALLOWLIST '("XAUTHORITY" "GPG_AUTH_INFO" "AUTHOR" "GPG_TTY" "SSH_AUTH_SOCK"))
 
 ;; ── RA-2 (v0.24.7): Configurable secret scrubbing ──
 ;; Extra denylist: additional regex patterns to scrub (extends secret-patterns).
@@ -139,17 +143,21 @@
     (if (bytes? name)
         (bytes->string/utf-8 name)
         name))
-  ;; Check allowlist first — if matched, never scrub
-  (define allowed?
-    (for/or ([pat (in-list (current-secret-scrub-allowlist))])
-      (regexp-match? pat name-str)))
+  ;; Check implicit allowlist first — well-known non-secret vars
   (cond
-    [allowed? #f]
+    [(member name-str SECRET-IMPLICIT-ALLOWLIST) #f]
     [else
-     ;; Check default patterns + extra denylist
-     (define all-patterns (append secret-patterns (current-secret-scrub-denylist)))
-     (for/or ([pat (in-list all-patterns)])
-       (regexp-match? pat name-str))]))
+     ;; Check user allowlist — if matched, never scrub
+     (define allowed?
+       (for/or ([pat (in-list (current-secret-scrub-allowlist))])
+         (regexp-match? pat name-str)))
+     (cond
+       [allowed? #f]
+       [else
+        ;; Check default patterns + extra denylist
+        (define all-patterns (append secret-patterns (current-secret-scrub-denylist)))
+        (for/or ([pat (in-list all-patterns)])
+          (regexp-match? pat name-str))])]))
 
 (define (sanitize-env [env (current-environment-variables)])
   (define clean (make-environment-variables))

--- a/tests/test-settings.rkt
+++ b/tests/test-settings.rkt
@@ -555,3 +555,24 @@
   (define settings (q-settings global project merged))
   (check-equal? (sandbox-timeout settings) 30) ; project wins
   (check-equal? (sandbox-memory-limit settings) 256)) ; global inherited
+
+(test-case "security-config-from-settings extracts execution policy"
+  (define settings (q-settings (hash) (hash) (hash 'execution-policy "allowlist"
+                                                    'execution-policy.allowed '("git" "ls"))))
+  (define config (security-config-from-settings settings))
+  (check-equal? (hash-ref config 'execution-policy-mode) "allowlist")
+  (check-equal? (hash-ref config 'execution-policy-allowed) '("git" "ls")))
+
+(test-case "security-config-from-settings defaults to empty"
+  (define settings (q-settings (hash) (hash) (hash)))
+  (define config (security-config-from-settings settings))
+  (check-false (hash-ref config 'execution-policy-mode #f))
+  (check-equal? (hash-ref config 'execution-policy-allowed) '()))
+
+(test-case "security-config-from-settings extracts secret-scrub config"
+  (define settings (q-settings (hash) (hash)
+                               (hash 'secret-scrub.extra-denylist '("CUSTOM_.*")
+                                     'secret-scrub.allowlist '("SAFE_VAR"))))
+  (define config (security-config-from-settings settings))
+  (check-equal? (hash-ref config 'secret-scrub-extra-denylist) '("CUSTOM_.*"))
+  (check-equal? (hash-ref config 'secret-scrub-allowlist) '("SAFE_VAR")))

--- a/tests/test-subprocess.rkt
+++ b/tests/test-subprocess.rkt
@@ -175,4 +175,26 @@
     (check-false (environment-variables-ref clean #"API_KEY"))
     (check-equal? (environment-variables-ref clean #"PATH") #"/usr/bin")))
 
+
+(test-case "AUTH regex: non-secret vars not scrubbed"
+  (check-false (secret-env-var? "AUTHOR"))
+  (check-false (secret-env-var? "XAUTHORITY"))
+  (check-false (secret-env-var? "GPG_AUTH_INFO"))
+  (check-false (secret-env-var? "GPG_TTY"))
+  (check-false (secret-env-var? "SSH_AUTH_SOCK")))
+
+(test-case "AUTH regex: actual secrets still matched"
+  (check-true (secret-env-var? "AUTH"))
+  (check-true (secret-env-var? "MY_AUTH_TOKEN"))
+  (check-true (secret-env-var? "AWS_AUTH_USER"))
+  (check-true (secret-env-var? "AUTH_PASSWORD")))
+
+(test-case "implicit allowlist takes precedence over patterns"
+  (define env (make-environment-variables))
+  (environment-variables-set! env #"XAUTHORITY" #"/home/user/.Xauthority")
+  (environment-variables-set! env #"GPG_AUTH_INFO" #"/run/user/1000/gpg")
+  (define clean (sanitize-env env))
+  (check-equal? (environment-variables-ref clean #"XAUTHORITY") #"/home/user/.Xauthority")
+  (check-equal? (environment-variables-ref clean #"GPG_AUTH_INFO") #"/run/user/1000/gpg"))
+
 (run-tests subprocess-tests)

--- a/tools/builtins/bash.rkt
+++ b/tools/builtins/bash.rkt
@@ -62,7 +62,7 @@
 (define current-execution-policy (make-parameter 'warn))
 
 ;; When execution-policy is 'allowlist, only these base commands execute.
-;; Configurable via config.json "execution-policy".allowed list.
+;; Configurable via config.json "execution-policy" key (wired in run-modes.rkt).
 (define current-allowed-commands
   (make-parameter '("git" "ls"
                           "cat"

--- a/wiring/run-modes.rkt
+++ b/wiring/run-modes.rkt
@@ -38,6 +38,10 @@
          (only-in "../tui/keymap.rkt" shortcut-specs->keymap keymap-merge)
          (only-in "../llm/stream.rkt" current-http-request-timeout current-model-timeouts)
          (only-in "../runtime/trace-logger.rkt" make-trace-logger start-trace-logger!)
+         (only-in "../tools/builtins/bash.rkt" current-execution-policy current-allowed-commands)
+         (only-in "../sandbox/subprocess.rkt"
+                  current-secret-scrub-denylist
+                  current-secret-scrub-allowlist)
          (only-in "../runtime/project-tree.rkt" project-tree->string)
          (only-in "../util/protocol-types.rkt"
                   event-ev
@@ -198,6 +202,31 @@
     (define trace-log (make-trace-logger bus session-dir #:enabled? #t))
     (hash-set! base-config 'trace-logger trace-log)
     (start-trace-logger! trace-log))
+
+  ;; v0.25.2 (F3): Wire security config from config.json
+  (define sec-config (security-config-from-settings settings))
+  (define policy-mode (hash-ref sec-config 'execution-policy-mode #f))
+  (when policy-mode
+    (current-execution-policy (if (string? policy-mode)
+                                  (string->symbol policy-mode)
+                                  policy-mode)))
+  (define allowed-cmds (hash-ref sec-config 'execution-policy-allowed '()))
+  (when (and (pair? allowed-cmds) (eq? (current-execution-policy) 'allowlist))
+    (current-allowed-commands allowed-cmds))
+  (define extra-denylist (hash-ref sec-config 'secret-scrub-extra-denylist '()))
+  (when (pair? extra-denylist)
+    (current-secret-scrub-denylist (map (lambda (s)
+                                          (if (regexp? s)
+                                              s
+                                              (regexp s)))
+                                        extra-denylist)))
+  (define scrub-allowlist (hash-ref sec-config 'secret-scrub-allowlist '()))
+  (when (pair? scrub-allowlist)
+    (current-secret-scrub-allowlist (map (lambda (s)
+                                           (if (regexp? s)
+                                               s
+                                               (regexp s)))
+                                         scrub-allowlist)))
 
   base-config)
 


### PR DESCRIPTION
Addresses #2762.

fix: AUTH regex over-matching + security config wiring (#2762)

v0.25.2 W1 — AUTH regex fix + config.json wiring (F2, F3).

F2: Fix AUTH regex to exclude false positives (AUTHOR, XAUTHORITY,
GPG_AUTH_INFO, GPG_TTY, SSH_AUTH_SOCK). Add implicit allowlist
checked before pattern matching. Regex changed from (?i:AUTH) to
(?i:^AUTH$|^AUTH_|_AUTH_) with built-in non-secret allowlist.

F3: Add security-config-from-settings in runtime/settings.rkt to
extract execution-policy, allowed commands, and scrub lists from
config.json. Wire these in wiring/run-modes.rkt at startup.
Update bash.rkt comment to reflect wiring.

Tests: 7 new AUTH regex tests, 3 new config wiring tests.