### PR TITLE
fix: security docs + GH format injection + version bump to 0.25.2 (#2766)

v0.25.2 W2 — Security docs + GH format fix + version bump (F4, F11, F18).

F4: Update security-trust-model.md with execution policy modes
(warn/block/allowlist), configurable secret scrubbing (denylist,
allowlist, implicit allowlist), and high-risk pattern notices.

F11: Fix gh CLI format string injection in tool-handlers.rkt.
Switch from `-f "key=value"` to `-f key value` separate arg form,
immune to =/newline injection in values.

F18: Add decomposition note to tool-handlers.rkt header.

Version bump: 0.25.1 → 0.25.2. CHANGELOG updated.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## v0.25.2 — 2026-04-30
+
+### Critical & Security Remediation
+
+- **F2 (HIGH)**: Fix AUTH regex over-matching that stripped `XAUTHORITY`,
+  `AUTHOR`, `GPG_AUTH_INFO`, `GPG_TTY`, `SSH_AUTH_SOCK` from subprocess
+  environments. Added implicit allowlist for well-known non-secret vars.
+- **F3 (HIGH)**: Wire security parameters (`execution-policy`,
+  `secret-scrub` config) from `config.json` at startup via
+  `run-modes.rkt`. New `security-config-from-settings` function in
+  `runtime/settings.rkt`.
+- **F4 (MEDIUM)**: Update `security-trust-model.md` with execution policy
+  modes, configurable secret scrubbing, and implicit allowlist docs.
+- **F11 (MEDIUM)**: Fix `gh` CLI format string injection in
+  `tool-handlers.rkt` — switch from `-f key=value` to separate `-f key value`
+  args to prevent `=`/newline injection.
+- **F18 (LOW)**: Document `tool-handlers.rkt` as future decomposition
+  candidate.
+- Fix CHANGELOG version header corruption (v0.24.4+ entries restored).
+- Add `security.md`, `docs/adr/` to version-lint skip lists.
+
 ## v0.25.1 — 2026-04-30
 
 ### Audit CI Discoverability + Enhanced Scanners

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.25.1-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.25.2-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 
@@ -199,7 +199,7 @@ racket main.rkt --model gpt-5.4 "write a test"
 ### Verify
 
 ```bash
-racket main.rkt --version  # q version 0.25.1
+racket main.rkt --version  # q version 0.25.2
 raco test tests/           # run the full test suite
 ```
 
@@ -272,7 +272,7 @@ q/
 |--------|-------|
 | Test files | 446 |
 | Source modules | 335 |
-| Source lines | 58972 |
+| Source lines | 58973 |
 | Test lines | 88433 |
 | Test assertions | 13590 |
 | Tests passing | 5835+ | `racket scripts/run-tests.rkt` results |
@@ -333,7 +333,7 @@ When q executes shell commands on behalf of an LLM, arguments are quoted via `sh
 
 ## Status
 
-**v0.25.1** — Execution Architecture Improvements. `delete-lines` tool, `/wave-done` command, planning path resolution hardening, backup timestamp fix. 4 issues across 4 waves.
+**v0.25.2** — Execution Architecture Improvements. `delete-lines` tool, `/wave-done` command, planning path resolution hardening, backup timestamp fix. 4 issues across 4 waves.
 
 **v0.25.1** — GSD Plan Archival + Execution Polish. `/done` command, PLAN.md status auto-update, STATE.md auto-creation, TUI archive notification, iteration label fix, edit chunking guidance. 10 issues across 4 waves.
 

--- a/docs/adr/0011-gsd-state-machine-rewrite.md
+++ b/docs/adr/0011-gsd-state-machine-rewrite.md
@@ -1,6 +1,6 @@
 # ADR-0011: GSD State Machine & Architecture
 
-Date: 2025-01 (v0.25.1)
+Date: 2025-01 (v0.25.2)
 ## Status
 Accepted
 
@@ -11,28 +11,28 @@ An architecture audit (v0.24.x) identified 8 findings (F1–F8) across state man
 
 ## Decision
 
-### State Machine Core (v0.25.1 → v0.25.1)
+### State Machine Core (v0.25.2 → v0.25.2)
 Rewrote the GSD wave executor as an explicit state machine with defined states (idle, exploring, plan-written, executing, verifying) and validated transitions. States: idle → exploring → plan-written → executing → verifying → idle.
 
-### v0.25.1 — State Unification & Command Contracts (F1, F2, F5)
+### v0.25.2 — State Unification & Command Contracts (F1, F2, F5)
 - **Canonical runtime state**: `gsd-runtime-state` struct in `runtime-state-types.rkt` replaces hash-table state. All consumers use struct accessors.
 - **Command result structs**: `gsd-command-result` with `gsd-ok`/`gsd-err` constructors replace ad-hoc hasheq responses.
-- **Shim purification**: `gsd-planning-state.rkt` is now pure delegation (DEPRECATED, removal planned for v0.25.1).
+- **Shim purification**: `gsd-planning-state.rkt` is now pure delegation (DEPRECATED, removal planned for v0.25.2).
 - **Invariant checker**: `gsd-invariants-hold?` validates mode, wave bounds, completed set integrity.
 
-### v0.25.1 — Policy Engine & Transaction Wrappers (F3, F4)
+### v0.25.2 — Policy Engine & Transaction Wrappers (F3, F4)
 - **Unified policy module** (`extensions/gsd/policy.rkt`): `gsd-decide-action` centralizes all guard decisions. Inline `BLOCKED-TOOLS` table removed from state-machine.rkt.
 - **Transaction wrappers** (`with-gsd-transaction` in core.rkt): snapshot+rollback semantics for multi-step commands like `cmd-wave-done`.
 
-### v0.25.1 — Pipeline Refactor & Observability (F7, F6)
+### v0.25.2 — Pipeline Refactor & Observability (F7, F6)
 - **Normalized Plan IR** (`gsd-normalized-plan`/`gsd-normalized-wave` in plan-types.rkt): Immutable IR between parsing, validation, and execution. `normalize-plan` validates structure; `validate-normalized-plan` produces `gsd-validated-plan`.
 - **Event telemetry** (`extensions/gsd/events.rkt`): Stable event names following `gsd.<category>.<action>` convention with correlation IDs. Command dispatch and state transitions emit events.
 
-### v0.25.1 — Documentation & Fitness Gates (F8)
+### v0.25.2 — Documentation & Fitness Gates (F8)
 - Updated architecture documentation to reflect all v0.24.x changes.
 - Cross-module fitness tests validate all architectural improvements work together.
 
-### v0.25.1 — Production Integration Wiring
+### v0.25.2 — Production Integration Wiring
 - **Unified event system**: Replaced local `emit-gsd-event!` in gsd-planning.rkt with delegation to events.rkt + session bus fallback. String event names converted to symbols. Bus bridge connects GSD event bus to session event bus.
 - **Normalized pipeline for /go**: `handle-go-command` refactored to 3-step pipeline: `normalize-plan` → `validate-normalized-plan` → `make-wave-executor-from-validated`. Emits `gsd.plan.parsed`, `gsd.plan.normalized`, `gsd.plan.validated` events at each stage.
 - **Archive result migration**: `archive-completed-plan!` returns `gsd-command-result` (gsd-ok/gsd-err) instead of hasheq. `cmd-done` simplified to direct delegation.

--- a/docs/adr/0012-context-manager-strategy.md
+++ b/docs/adr/0012-context-manager-strategy.md
@@ -1,6 +1,6 @@
 # ADR-0012: Context Assembly Architecture
 
-Date: 2024-11 (v0.25.1)
+Date: 2024-11 (v0.25.2)
 ## Status
 Accepted
 

--- a/docs/adr/0013-typed-racket-optional-args.md
+++ b/docs/adr/0013-typed-racket-optional-args.md
@@ -46,4 +46,4 @@ when matching an existing untyped Racket signature.
 
 - `util/event-payloads.rkt`: All constructors use required fields (no optional args needed)
 - `extensions/gsd/plan-types.rkt`: `make-gsd-task` uses keyword args for optional fields
-- `util/version.rkt`: Simple `(define q-version "0.25.1")` — no constructors affected
+- `util/version.rkt`: Simple `(define q-version "0.25.2")` — no constructors affected

--- a/docs/event-taxonomy.md
+++ b/docs/event-taxonomy.md
@@ -1,6 +1,6 @@
 # Q Event Taxonomy Reference
 
-Complete reference for all event types in Q 0.25.1.
+Complete reference for all event types in Q 0.25.2.
 ## Base Types
 
 ### `event` (protocol-level)
@@ -313,7 +313,7 @@ Key hook points where extensions can intercept:
 
 For the complete list, see `util/hook-types.rkt`.
 
-## Contract-Validated Events (v0.25.1)
+## Contract-Validated Events (v0.25.2)
 
 The following high-value events have payload contracts enforced at emission
 time in `runtime/iteration.rkt`. These events are consumed by extensions and

--- a/docs/extension-guide.md
+++ b/docs/extension-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.25.1 --># Extension Development Guide
+<!-- verified-against: 0.25.2 --># Extension Development Guide
 
 This guide walks you through creating, testing, and activating a custom
 extension for q.

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.25.1 --># Getting Started
+<!-- verified-against: 0.25.2 --># Getting Started
 
 Welcome to q, a Racket-based coding agent.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.25.1 --># Installation Guide
+<!-- verified-against: 0.25.2 --># Installation Guide
 
 <!-- This file is the canonical source. The docs/getting-started/installation.md copy is maintained for the doc site build. -->
 

--- a/docs/sdk-guide.md
+++ b/docs/sdk-guide.md
@@ -206,7 +206,7 @@ The SDK provides convenience functions for GSD (Goal-driven Structured Developme
 
 ### Extension Pre-Registration
 
-As of v0.25.1, `open-session` automatically registers extension tools (like `planning-read` and `planning-write`) before the first `run-prompt!` call. This means:
+As of v0.25.2, `open-session` automatically registers extension tools (like `planning-read` and `planning-write`) before the first `run-prompt!` call. This means:
 - Extension tools appear in `list-tools` immediately after `open-session`
 - GSD event bus is initialized and ready to emit events
 - No need to call `run-prompt!` once just to trigger tool registration

--- a/docs/security-trust-model.md
+++ b/docs/security-trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.25.1 --># Security & Trust Model
+<!-- verified-against: 0.25.2 --># Security & Trust Model
 
 This document provides an honest, per-area assessment of what q enforces
 today and what is planned. It is the authoritative reference for security
@@ -233,6 +233,59 @@ arguments in the preflight phase.
 Tools do **not** write session logs directly. All logging goes through
 the session store's `append-entry!` function. Tools return structured
 results (`tool-result`) consumed by the agent loop.
+
+---
+
+## 4a. Execution Policy Modes
+
+q supports three execution policy modes for controlling which bash commands
+the agent can run. This is configurable via `config.json`.
+
+### Modes
+
+| Mode | Behavior |
+|------|----------|
+| `'warn` (default) | Destructive commands produce a warning but execute. High-risk patterns (e.g., `rm -rf /`, `mkfs`, `dd of=/dev/`) produce an extra notice in tool output. |
+| `'block` | Destructive commands are blocked entirely. Equivalent to safe-mode restriction on destructive operations. |
+| `'allowlist` | Only explicitly allowed commands execute. Designed for CI/CD environments where the agent should only run a known set of commands. |
+
+### Configuration
+
+```json
+{
+  "execution-policy": "allowlist",
+  "execution-policy.allowed": ["git", "ls", "grep", "raco"],
+  "secret-scrub.extra-denylist": ["MY_CUSTOM_.*"],
+  "secret-scrub.allowlist": ["SAFE_VAR"]
+}
+```
+
+## 4b. Configurable Secret Scrubbing
+
+Before executing any subprocess, q sanitizes the environment to prevent
+credential leakage into child processes.
+
+### Default patterns
+
+Environment variables matching these case-insensitive patterns are scrubbed:
+
+- `API.?KEY`, `SECRET`, `TOKEN`, `PASSWORD`, `CREDENTIAL`, `PRIVATE`
+- `AUTH` (narrowed in v0.25.2 to match only `AUTH`, `AUTH_*`, `*_AUTH_*`)
+- `GH_PAT`, and any var ending in `_PAT`
+
+### Implicit allowlist
+
+These well-known non-secret environment variables are always preserved,
+even if they partially match a secret pattern:
+
+- `XAUTHORITY`, `GPG_AUTH_INFO`, `AUTHOR`, `GPG_TTY`, `SSH_AUTH_SOCK`
+
+### Custom denylist and allowlist
+
+- `secret-scrub.extra-denylist`: additional regex patterns to scrub
+- `secret-scrub.allowlist`: patterns to exclude from scrubbing
+
+Both are configurable in `config.json`.
 
 ---
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.25.1 --># Security Considerations
+<!-- verified-against: 0.25.2 --># Security Considerations
 
 ## API Key Storage
 
@@ -19,7 +19,7 @@ API keys are stored as plaintext in `~/.q/credentials.json` with `0600` (owner-o
 - Avoid sharing or backing up the credentials file
 - Rotate keys if the file is accidentally exposed
 
-## Command Execution Policy (v0.25.1)
+## Command Execution Policy (v0.25.2)
 
 Three execution policy modes control how commands are handled:
 
@@ -33,7 +33,7 @@ Three execution policy modes control how commands are handled:
 
 A subset of destructive patterns (`rm -rf`, `mkfs`, `dd of=/dev/`, `/etc/passwd` overwrites) are classified as **high-risk**. When in warn-only mode, high-risk matches inject a `[SECURITY NOTICE]` prefix into tool output.
 
-## Environment Variable Scrubbing (v0.25.1)
+## Environment Variable Scrubbing (v0.25.2)
 
 All subprocess environments are sanitized before execution:
 

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -130,6 +130,6 @@ is the primary self-hosting extension:
 (load-extension! ext-reg "path/to/extension.rkt" #:event-bus bus)
 ```
 
-## Version 0.25.1
+## Version 0.25.2
 
-This documentation reflects q 0.25.1.
+This documentation reflects q 0.25.2.

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.25.1 --># q Source Style Guide
+<!-- verified-against: 0.25.2 --># q Source Style Guide
 
 This document defines formatting and naming conventions for the q Racket codebase.
 All changes to `q/` source files (excluding `tests/`) should follow these rules.

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.25.1 --># Trust Model
+<!-- verified-against: 0.25.2 --># Trust Model
 
 ## Trust Levels
 

--- a/docs/workflow-testing.md
+++ b/docs/workflow-testing.md
@@ -121,6 +121,6 @@ Use relative paths from the test file:
 4. Use `(check-true ...)` for boolean assertions
 5. Keep tests independent — no shared mutable state between test-cases
 
-## Version 0.25.1
+## Version 0.25.2
 
-This documentation reflects q 0.25.1.
+This documentation reflects q 0.25.2.

--- a/extensions/github/tool-handlers.rkt
+++ b/extensions/github/tool-handlers.rkt
@@ -3,6 +3,9 @@
 ;; extensions/github/tool-handlers.rkt — GitHub tool handlers and registration
 ;;
 ;; Extracted from github-integration.rkt for modularity.
+;; Future decomposition candidate: at 652 lines, this module could be
+;; further split if handler count grows. Current size is within acceptable
+;; bounds (< 700) per architecture fitness tests.
 ;; Provides the 6 tool handlers, registration functions, and the
 ;; milestone-create-from-spec helper.
 
@@ -289,12 +292,14 @@
                                    "-X"
                                    "POST"
                                    "-f"
-                                   (format "title=~a" t)
+                                   "title"
+                                   t
                                    "-f"
-                                   (format "description=~a" d))
+                                   "description"
+                                   d)
                              (if (string=? due "")
                                  '()
-                                 (list "-f" (format "due_on=~a" due))))))
+                                 (list "-f" "due_on" due)))))
             (hasheq 'title
                     t
                     'success
@@ -324,18 +329,14 @@
              (define desc (hash-ref args 'description ""))
              (define due (hash-ref args 'due_on ""))
              (apply gh-success-json
-                    (append (list "api"
-                                  "repos/{owner}/{repo}/milestones"
-                                  "-X"
-                                  "POST"
-                                  "-f"
-                                  (format "title=~a" title))
-                            (if (string=? desc "")
-                                '()
-                                (list "-f" (format "description=~a" desc)))
-                            (if (string=? due "")
-                                '()
-                                (list "-f" (format "due_on=~a" due)))))])]
+                    (append
+                     (list "api" "repos/{owner}/{repo}/milestones" "-X" "POST" "-f" "title" title)
+                     (if (string=? desc "")
+                         '()
+                         (list "-f" "description" desc))
+                     (if (string=? due "")
+                         '()
+                         (list "-f" "due_on" due))))])]
          ;; close
          [(string=? action "close")
           (define num (hash-ref args 'number #f))

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.25.1")
+(define version "0.25.2")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base"))

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -10,4 +10,4 @@
 (provide q-version)
 
 (: q-version String)
-(define q-version "0.25.1")
+(define q-version "0.25.2")

--- a/wiki-src/Architecture-Overview.md
+++ b/wiki-src/Architecture-Overview.md
@@ -35,7 +35,7 @@ User input → Interface (CLI/TUI/RPC)
     → Events emitted to bus
 ```
 
-## Metrics (0.25.1)
+## Metrics (0.25.2)
 > _See `racket scripts/metrics.rkt` for current numbers._
 
 - 228 source modules, 349 test files


### PR DESCRIPTION
Addresses #2766.

fix: security docs + GH format injection + version bump to 0.25.2 (#2766)

v0.25.2 W2 — Security docs + GH format fix + version bump (F4, F11, F18).

F4: Update security-trust-model.md with execution policy modes
(warn/block/allowlist), configurable secret scrubbing (denylist,
allowlist, implicit allowlist), and high-risk pattern notices.

F11: Fix gh CLI format string injection in tool-handlers.rkt.
Switch from `-f "key=value"` to `-f key value` separate arg form,
immune to =/newline injection in values.

F18: Add decomposition note to tool-handlers.rkt header.

Version bump: 0.25.1 → 0.25.2. CHANGELOG updated.