### PR TITLE
feat: integrate working set into iteration loop (#2792)

v0.26.0 W1 — Iteration Loop Integration.

Changes to runtime/iteration.rkt:
- Import message-id from protocol-types and working-set.rkt
- Add #:working-set keyword parameter to run-iteration-loop
- Initialize working set (auto-create if not provided)
- Thread working set through loop state (all continuation calls)
- After tool execution, extract tool-result messages and call
  working-set-update! with message-id and token-estimate helpers
- Pass config-with-ws (hash-set config 'working-set ws) to
  build-assembled-context so the assembly pipeline can inject WS

Tests (5):
- T01: loop accepts #:working-set without error
- T02: loop works without #:working-set (auto-initialization)
- T03: working-set-update! with real message structs (read adds entry)
- T04: working-set-update! with real structs (edit removes path)
- T05: config hash correctly contains working set

### DIFF
--- a/runtime/iteration.rkt
+++ b/runtime/iteration.rkt
@@ -27,6 +27,7 @@
          (only-in "../util/json-helpers.rkt" ensure-hash-args)
          (only-in "../util/protocol-types.rkt"
                   message?
+                  message-id
                   message-role
                   message-content
                   make-message
@@ -86,7 +87,8 @@
          (only-in "turn-orchestrator.rkt"
                   run-provider-turn
                   build-assembled-context
-                  register-session-extensions!))
+                  register-session-extensions!)
+         "working-set.rkt")
 
 (provide run-iteration-loop
          ;; emit-session-event! and maybe-dispatch-hooks re-exported from runtime-helpers
@@ -382,11 +384,15 @@
                             ;; MOD-02 (v0.22.6 W4): DI keyword args for testability
                             #:compact-proc [compact-proc (resolve-compact-proc)]
                             #:estimate-tokens [estimate-tokens (resolve-estimate-tokens)]
-                            #:inject-topic [inject-topic (resolve-inject-topic)])
+                            #:inject-topic [inject-topic (resolve-inject-topic)]
+                            ;; v0.26.0: working set memory
+                            #:working-set [initial-ws #f])
   ;; v0.14.1: Soft limit = max-iterations (warn), Hard limit = max-iterations-hard (stop)
   ;; v0.14.4 Wave 1: Default hard limit = max(max-iterations * 1.6, 80) for slow models
   (define max-iterations-hard
     (hash-ref config 'max-iterations-hard (max (inexact->exact (floor (* max-iterations 1.6))) 80)))
+  ;; v0.26.0: Initialize working set
+  (define ws (or initial-ws (make-working-set)))
   ;; Dispatch 'before-agent-start hook — extensions can block or modify config
   (define agent-start-payload
     (hasheq 'session-id
@@ -411,6 +417,7 @@
                  [iteration 0]
                  [consecutive-tool-count 0]
                  [seen-paths (set)] ;; v0.18.0: same-file dedup tracking
+                 [ws ws] ;; v0.26.0: working set memory
                  [intent-retry-count 0]
                  [consecutive-error-count 0] ;; v0.19.10: spiral breaker
                  [recent-tool-names '()] ;; v0.19.10: bash-only streak detection
@@ -509,8 +516,9 @@
 
              [else
               ;; Build assembled context (tiered + hooks) — from turn-orchestrator.rkt
+              (define config-with-ws (hash-set config 'working-set ws))
               (define ctx-final
-                (build-assembled-context ctx-to-use config ext-reg bus session-id iteration))
+                (build-assembled-context ctx-to-use config-with-ws ext-reg bus session-id iteration))
 
               ;; Run provider turn — from turn-orchestrator.rkt
               (define result
@@ -580,6 +588,7 @@
                                           (add1 iteration)
                                           0
                                           (set)
+                                          ws
                                           intent-retry-count
                                           0
                                           '()
@@ -640,6 +649,7 @@
                        (add1 iteration)
                        (add1 consecutive-tool-count)
                        seen-paths
+                       ws
                        intent-retry-count
                        consecutive-error-count
                        recent-tool-names
@@ -662,6 +672,20 @@
                                               config))
                  ;; v0.21.3: Exploration steering removed. Compute counters without steering.
                  (define current-tool-calls (extract-tool-calls-from-messages new-msgs))
+                 ;; v0.26.0: Update working set after tool execution
+                 (define tool-result-msgs
+                   (filter (lambda (m) (eq? (message-role m) 'tool)) updated-ctx))
+                 (define (estimate-msg-tokens m)
+                   (define c (message-content m))
+                   (define t (cond [(string? c) c]
+                                   [(list? c)
+                                    (apply string-append
+                                           (for/list ([p (in-list c)]
+                                                      #:when (text-part? p))
+                                             (text-part-text p)))]
+                                   [else ""]))
+                   (string-length t))
+                 (working-set-update! ws current-tool-calls tool-result-msgs message-id estimate-msg-tokens)
                  (define-values (new-seen-paths should-increment?)
                    (update-seen-paths current-tool-calls seen-paths))
                  (define effective-tool-count
@@ -690,6 +714,7 @@
                        (add1 iteration)
                        effective-tool-count
                        new-seen-paths
+                       ws
                        intent-retry-count
                        new-error-count
                        new-recent-tools

--- a/tests/test-iteration-working-set.rkt
+++ b/tests/test-iteration-working-set.rkt
@@ -1,0 +1,116 @@
+#lang racket
+
+;; tests/test-iteration-working-set.rkt — Working set integration into iteration loop
+
+(require rackunit
+         rackunit/text-ui
+         racket/list
+         "../runtime/working-set.rkt"
+         "../runtime/iteration.rkt"
+         "../util/protocol-types.rkt"
+         "../agent/event-bus.rkt"
+         "../util/ids.rkt"
+         (only-in "../llm/provider.rkt" make-mock-provider)
+         (only-in "../llm/model.rkt" make-model-response))
+
+;; Helper: create a user message
+(define (make-user-msg text)
+  (make-message (generate-id) #f 'user 'user (list (make-text-part text)) (current-seconds) (hasheq)))
+
+;; Helper: create a tool result message
+(define (make-tool-msg id text)
+  (make-message id #f 'tool 'tool (list (make-text-part text)) (current-seconds) (hasheq)))
+
+;; Helper: estimate tokens from a message (same logic as in iteration.rkt)
+(define (estimate-msg-tokens m)
+  (define c (message-content m))
+  (define t
+    (cond
+      [(string? c) c]
+      [(list? c)
+       (apply string-append
+              (for/list ([p (in-list c)]
+                         #:when (text-part? p))
+                (text-part-text p)))]
+      [else ""]))
+  (string-length t))
+
+;; Helper: create a tool call hash
+(define (make-tool name [path ""])
+  (hasheq 'name name 'arguments (hasheq 'path path)))
+
+(define iteration-ws-tests
+  (test-suite "Iteration Working Set Integration"
+
+    ;; ── T01: Loop accepts #:working-set ──
+    (test-case "T01: iteration loop accepts #:working-set parameter"
+      (define bus (make-event-bus))
+      (define ws (make-working-set))
+      (define ctx (list (make-user-msg "test")))
+      (define mock-prov
+        (make-mock-provider
+         (make-model-response (list (hasheq 'type "text" 'text "done")) (hash) "mock" #f)))
+      (define result
+        (run-iteration-loop ctx
+                            mock-prov
+                            bus
+                            #f
+                            #f
+                            "/tmp/test.log"
+                            "test-session"
+                            10
+                            #:working-set ws))
+      (check-pred loop-result? result)
+      (check-equal? (loop-result-termination-reason result) 'completed))
+
+    ;; ── T02: Loop works without #:working-set ──
+    (test-case "T02: iteration loop initializes working set when not provided"
+      (define bus (make-event-bus))
+      (define ctx (list (make-user-msg "test")))
+      (define mock-prov
+        (make-mock-provider
+         (make-model-response (list (hasheq 'type "text" 'text "done")) (hash) "mock" #f)))
+      (define result (run-iteration-loop ctx mock-prov bus #f #f "/tmp/test.log" "test-session" 10))
+      (check-pred loop-result? result)
+      (check-equal? (loop-result-termination-reason result) 'completed))
+
+    ;; ── T03: read updates ws with real messages ──
+    (test-case "T03: read tool call updates working set with real message structs"
+      (define ws (make-working-set))
+      (define tc (list (make-tool "read" "/tmp/foo.rkt")))
+      (define rm (list (make-tool-msg "m1" "content of foo")))
+      (working-set-update! ws tc rm message-id estimate-msg-tokens)
+      (check-equal? (working-set-entry-count ws) 1)
+      (define e (car (working-set-entries ws)))
+      (check-equal? (ws-entry-path e) "/tmp/foo.rkt")
+      (check-equal? (ws-entry-message-id e) "m1"))
+
+    ;; ── T04: edit removes from ws with real messages ──
+    (test-case "T04: edit tool call removes path from working set"
+      (define ws (make-working-set))
+      (working-set-update! ws
+                           (list (make-tool "read" "/tmp/foo.rkt"))
+                           (list (make-tool-msg "m1" "content"))
+                           message-id
+                           estimate-msg-tokens)
+      (check-equal? (working-set-entry-count ws) 1)
+      (working-set-update! ws
+                           (list (make-tool "edit" "/tmp/foo.rkt"))
+                           (list (make-tool-msg "m2" "edited"))
+                           message-id
+                           estimate-msg-tokens)
+      (check-equal? (working-set-entry-count ws) 0))
+
+    ;; ── T05: config hash contains working set ──
+    (test-case "T05: config hash contains working set after hash-set"
+      (define ws (make-working-set))
+      (define config (hasheq 'max-iterations 10))
+      (define config-with-ws (hash-set config 'working-set ws))
+      (check-true (hash-has-key? config-with-ws 'working-set))
+      (check-eq? (hash-ref config-with-ws 'working-set) ws))))
+
+(module+ main
+  (run-tests iteration-ws-tests))
+
+(module+ test
+  (run-tests iteration-ws-tests))


### PR DESCRIPTION
Addresses #2792.

feat: integrate working set into iteration loop (#2792)

v0.26.0 W1 — Iteration Loop Integration.

Changes to runtime/iteration.rkt:
- Import message-id from protocol-types and working-set.rkt
- Add #:working-set keyword parameter to run-iteration-loop
- Initialize working set (auto-create if not provided)
- Thread working set through loop state (all continuation calls)
- After tool execution, extract tool-result messages and call
  working-set-update! with message-id and token-estimate helpers
- Pass config-with-ws (hash-set config 'working-set ws) to
  build-assembled-context so the assembly pipeline can inject WS

Tests (5):
- T01: loop accepts #:working-set without error
- T02: loop works without #:working-set (auto-initialization)
- T03: working-set-update! with real message structs (read adds entry)
- T04: working-set-update! with real structs (edit removes path)
- T05: config hash correctly contains working set