### PR TITLE
feat: integrate working set into context assembly pipeline (#2795)

### DIFF
--- a/runtime/context-assembly.rkt
+++ b/runtime/context-assembly.rkt
@@ -32,7 +32,12 @@
                   fit-messages-pair-preserving
                   user-message?
                   system-message?)
-         (only-in "context-pinning.rkt" partition-messages)
+         (only-in "context-pinning.rkt" partition-messages partition-messages/working-set)
+         (only-in "working-set.rkt"
+                  working-set?
+                  working-set-resolve-messages
+                  working-set-entry-count
+                  working-set-token-count)
          (only-in "context-fit.rkt" truncate-messages-to-budget fit-messages-from-recent)
          (only-in "../llm/provider.rkt" provider?)
          (only-in "../util/hook-types.rkt" hook-result-action hook-result-payload hook-result?)
@@ -82,7 +87,8 @@
                              [#:provider (or/c #f provider?)
                               #:model-name (or/c #f string?)
                               #:cache (or/c #f summary-cache?)
-                              #:trace-callback (or/c #f procedure?)]
+                              #:trace-callback (or/c #f procedure?)
+                              #:working-set (or/c #f working-set?)]
                              context-result?)]
                        [build-session-context (-> session-index? (listof message?))]
                        [build-session-context/tokens
@@ -200,7 +206,8 @@
                                  #:cache [cache #f]
                                  #:provider [provider #f]
                                  #:model-name [model-name #f]
-                                 #:trace-callback [trace #f])
+                                 #:trace-callback [trace #f]
+                                 #:working-set [ws #f])
   (define (emit-trace phase data)
     (when trace
       (trace phase data)))
@@ -217,8 +224,18 @@
           (hash-ref! token-memo (message-id msg) (lambda () (estimate-message-tokens msg))))
 
         (define max-tokens (context-assembly-config-recent-tokens config))
-        ;; Phase 1: Identify pinned items (system + first user + compaction summaries)
-        (define-values (pinned removable) (partition-messages raw-messages))
+        ;; Phase 1.5: Resolve working set messages
+        (define ws-messages
+          (if ws
+              (working-set-resolve-messages ws raw-messages message-id)
+              '()))
+        (define ws-message-ids
+          (if ws
+              (map message-id ws-messages)
+              '()))
+        ;; Phase 1: Identify pinned items (system + first user + compaction summaries + ws)
+        (define-values (pinned removable)
+          (partition-messages/working-set raw-messages ws-message-ids))
         (define pinned-tokens (for/sum ([m (in-list pinned)]) (memoized-estimate m)))
         (define pinned-count (length pinned))
         (define removable-count (length removable))
@@ -432,7 +449,8 @@
 
 (define (build-tiered-context messages
                               #:tier-b-count [tier-b-count DEFAULT-TIER-B-COUNT]
-                              #:tier-c-count [tier-c-count DEFAULT-TIER-C-COUNT])
+                              #:tier-c-count [tier-c-count DEFAULT-TIER-C-COUNT]
+                              #:working-set-messages [ws-messages '()])
   (define-values (compaction-summaries regular-msgs)
     (partition (lambda (m) (eq? (message-kind m) 'compaction-summary)) messages))
 
@@ -469,7 +487,7 @@
         (take-right remaining-after-c tier-b-size)
         '()))
 
-  (tiered-context (append sys-protected pinned-user compaction-summaries) tier-b tier-c))
+  (tiered-context (append sys-protected pinned-user compaction-summaries ws-messages) tier-b tier-c))
 
 ;; build-tiered-context-with-hooks: Assemble a tiered context (catalog + summary + recent)
 ;; and dispatch extension hooks at each stage. Returns a tiered-context struct.
@@ -477,9 +495,13 @@
                                          #:hook-dispatcher [hook-dispatcher #f]
                                          #:tier-b-count [tier-b-count DEFAULT-TIER-B-COUNT]
                                          #:tier-c-count [tier-c-count DEFAULT-TIER-C-COUNT]
-                                         #:max-tokens [max-tokens 8192])
+                                         #:max-tokens [max-tokens 8192]
+                                         #:working-set-messages [ws-messages '()])
   (define base-context
-    (build-tiered-context messages #:tier-b-count tier-b-count #:tier-c-count tier-c-count))
+    (build-tiered-context messages
+                          #:tier-b-count tier-b-count
+                          #:tier-c-count tier-c-count
+                          #:working-set-messages ws-messages))
 
   (define payload
     (tiered-context->payload base-context

--- a/runtime/context-pinning.rkt
+++ b/runtime/context-pinning.rkt
@@ -8,24 +8,32 @@
 ;; partitions them from removable messages.
 
 (require racket/list
-         (only-in "../util/protocol-types.rkt" message-role message-kind))
+         racket/set
+         (only-in "../util/protocol-types.rkt" message-role message-kind message-id))
 
-(provide partition-messages)
+(provide partition-messages
+         partition-messages/working-set)
 
 ;; ============================================================
 ;; Phase 1: Pin system prompt + first user + compaction summaries
 ;; ============================================================
 
 (define (partition-messages messages)
+  (partition-messages/working-set messages '()))
+
+;; Variant that also protects working-set message ids
+(define (partition-messages/working-set messages ws-message-ids)
   (define first-user
     (for/first ([m (in-list messages)]
                 #:when (eq? (message-role m) 'user))
       m))
+  (define ws-id-set (list->set ws-message-ids))
   (define-values (protected removable)
     (partition (lambda (m)
                  (or (eq? (message-kind m) 'system-instruction)
                      (eq? (message-kind m) 'compaction-summary)
                      (eq? (message-kind m) 'context-assembly-summary)
-                     (and first-user (eq? m first-user))))
+                     (and first-user (eq? m first-user))
+                     (set-member? ws-id-set (message-id m))))
                messages))
   (values protected removable))

--- a/runtime/turn-orchestrator.rkt
+++ b/runtime/turn-orchestrator.rkt
@@ -25,6 +25,7 @@
          (only-in "../util/json-helpers.rkt" ensure-hash-args)
          (only-in "../util/protocol-types.rkt"
                   message?
+                  message-id
                   message-role
                   message-content
                   make-message
@@ -57,7 +58,13 @@
          "../runtime/tool-coordinator.rkt"
          (only-in "../runtime/context-assembly.rkt"
                   build-tiered-context-with-hooks
-                  tiered-context->message-list)
+                  tiered-context->message-list
+                  build-tiered-context)
+         (only-in "../runtime/working-set.rkt"
+                  working-set?
+                  working-set-resolve-messages
+                  working-set-entry-count
+                  working-set-token-count)
          (only-in "../runtime/tool-coordinator.rkt"
                   handle-tool-calls-pending
                   extract-tool-calls-from-messages)
@@ -87,6 +94,14 @@
   (define tier-b-count (hash-ref config 'tier-b-count 20))
   (define tier-c-count (hash-ref config 'tier-c-count 4))
   (define max-tokens (hash-ref config 'max-tokens 8192))
+  ;; v0.26.0: Extract working set from config
+  (define ws (hash-ref config 'working-set #f))
+  (define ws-messages
+    (if ws
+        (working-set-resolve-messages ws ctx-to-use message-id)
+        '()))
+  (define ws-message-ids
+    (map message-id ws-messages))
 
   ;; R2-6: Create hook dispatcher function for context assembly
   (define ctx-assembly-hook-dispatcher
@@ -101,7 +116,8 @@
                                      #:hook-dispatcher ctx-assembly-hook-dispatcher
                                      #:tier-b-count tier-b-count
                                      #:tier-c-count tier-c-count
-                                     #:max-tokens max-tokens))
+                                     #:max-tokens max-tokens
+                                     #:working-set-messages ws-messages))
 
   ;; Handle block action from context-assembly hook
   (when (and assembly-hook-result (eq? (hook-result-action assembly-hook-result) 'block))
@@ -109,6 +125,16 @@
     (raise (exn:fail "Context assembly blocked by extension" (current-continuation-marks))))
 
   (define ctx-assembled (tiered-context->message-list tc))
+
+  ;; v0.26.0: Emit working-set.injected event
+  (when ws
+    (emit-session-event! bus
+                         session-id
+                         "working-set.injected"
+                         (hasheq 'entries
+                                 (working-set-entry-count ws)
+                                 'tokens
+                                 (working-set-token-count ws))))
 
   ;; Emit context.assembled event (v0.19.12 W1: added tokenCount)
   (define ctx-token-count (estimate-context-tokens ctx-assembled))

--- a/tests/test-context-assembly-ws.rkt
+++ b/tests/test-context-assembly-ws.rkt
@@ -1,0 +1,180 @@
+#lang racket
+;; tests/test-context-assembly-ws.rkt — Working set integration into context assembly
+
+(require rackunit
+         rackunit/text-ui
+         racket/list
+         racket/file
+         "../util/protocol-types.rkt"
+         "../runtime/working-set.rkt"
+         "../runtime/context-pinning.rkt"
+         "../runtime/context-assembly.rkt"
+         "../runtime/session-store.rkt"
+         "../runtime/session-index.rkt")
+
+;; Helper: create a test message
+(define (make-test-msg id role kind text [parent #f])
+  (make-message id parent role kind (list (make-text-part text)) (current-seconds) (hasheq)))
+
+(define (make-temp-dir)
+  (make-temporary-file "q-ctx-ws-test-~a" 'directory))
+
+(define ws-tests
+  (test-suite "Context Assembly Working Set Integration"
+
+    (test-case "T01: working set messages included in assembled context"
+      (define ws (make-working-set))
+      (define tool-msg (make-test-msg "tool-1" 'tool 'tool-result "content of /tmp/foo.rkt"))
+      (working-set-update! ws
+                           (list (hasheq 'name "read" 'arguments (hasheq 'path "/tmp/foo.rkt")))
+                           (list (make-message "tool-1"
+                                               #f
+                                               'tool
+                                               'tool-result
+                                               (list (make-text-part "content of /tmp/foo.rkt"))
+                                               (current-seconds)
+                                               (hasheq)))
+                           message-id
+                           (lambda (m) 20))
+      (define msgs
+        (list (make-test-msg "sys" 'system 'system-instruction "System prompt")
+              (make-test-msg "u1" 'user 'message "Hello")
+              tool-msg))
+      (define tc (build-tiered-context msgs #:working-set-messages (list tool-msg)))
+      (define assembled (tiered-context->message-list tc))
+      (check-not-false (member tool-msg assembled))
+      (check-not-false (member tool-msg (tiered-context-tier-a tc))))
+
+    (test-case "T02: working set messages survive pair-preserving truncation"
+      (define dir (make-temp-dir))
+      (define sp (build-path dir "session.jsonl"))
+      (define ip (build-path dir "session.index"))
+      (define ws (make-working-set))
+      (define tool-msg
+        (make-message "tool-1"
+                      #f
+                      'tool
+                      'tool-result
+                      (list (make-text-part "content of /tmp/foo.rkt"))
+                      (current-seconds)
+                      (hasheq)))
+      (working-set-update! ws
+                           (list (hasheq 'name "read" 'arguments (hasheq 'path "/tmp/foo.rkt")))
+                           (list (make-message "tool-1"
+                                               #f
+                                               'tool
+                                               'tool-result
+                                               (list (make-text-part "content of /tmp/foo.rkt"))
+                                               (current-seconds)
+                                               (hasheq)))
+                           message-id
+                           (lambda (m) 20))
+      (define entries
+        (cons (make-test-msg "sys" 'system 'system-instruction "System")
+              (cons tool-msg
+                    (for/list ([i (in-range 40)])
+                      (make-message (format "m~a" i)
+                                    (if (= i 0)
+                                        #f
+                                        (format "m~a" (sub1 i)))
+                                    (if (even? i) 'user 'assistant)
+                                    'message
+                                    (list (make-text-part (format "Message ~a text" i)))
+                                    (+ 1000 i)
+                                    (hasheq))))))
+      (append-entries! sp entries)
+      (define idx (build-index! sp ip))
+      (define config (make-context-assembly-config #:recent-tokens 100))
+      (define result (build-assembled-context idx config #:working-set ws))
+      (define result-ids (map message-id (context-result-messages result)))
+      (check-not-false (member "tool-1" result-ids)))
+
+    (test-case "T03: working set messages appear after system before recent"
+      (define ws (make-working-set))
+      (define sys-msg (make-test-msg "sys" 'system 'system-instruction "System"))
+      (define tool-msg (make-test-msg "tool-1" 'tool 'tool-result "content"))
+      (working-set-update! ws
+                           (list (hasheq 'name "read" 'arguments (hasheq 'path "/tmp/foo.rkt")))
+                           (list (make-message "tool-1"
+                                               #f
+                                               'tool
+                                               'tool-result
+                                               (list (make-text-part "content"))
+                                               (current-seconds)
+                                               (hasheq)))
+                           message-id
+                           (lambda (m) 10))
+      (define msgs (list sys-msg tool-msg))
+      (define tc (build-tiered-context msgs #:working-set-messages (list tool-msg)))
+      (define tier-a (tiered-context-tier-a tc))
+      (check-equal? (message-id (car tier-a)) "sys")
+      (check-equal? (message-id (cadr tier-a)) "tool-1"))
+
+    (test-case "T04: empty working set produces identical tiered output"
+      (define msgs
+        (list (make-test-msg "sys" 'system 'system-instruction "System")
+              (make-test-msg "u1" 'user 'message "Hello")
+              (make-test-msg "a1" 'assistant 'message "Hi")))
+      (define tc-without (build-tiered-context msgs))
+      (define tc-with (build-tiered-context msgs #:working-set-messages '()))
+      (check-equal? (length (tiered-context-tier-a tc-without))
+                    (length (tiered-context-tier-a tc-with)))
+      (check-equal? (length (tiered-context-tier-b tc-without))
+                    (length (tiered-context-tier-b tc-with)))
+      (check-equal? (length (tiered-context-tier-c tc-without))
+                    (length (tiered-context-tier-c tc-with))))
+
+    (test-case "T05: working-set-resolve-messages finds correct messages"
+      (define ws (make-working-set))
+      (define msg-a (make-test-msg "a" 'tool 'tool-result "content A"))
+      (define msg-b (make-test-msg "b" 'tool 'tool-result "content B"))
+      (working-set-update! ws
+                           (list (hasheq 'name "read" 'arguments (hasheq 'path "/tmp/a.rkt")))
+                           (list (make-message "a"
+                                               #f
+                                               'tool
+                                               'tool-result
+                                               (list (make-text-part "content A"))
+                                               (current-seconds)
+                                               (hasheq)))
+                           message-id
+                           (lambda (m) 10))
+      (working-set-update! ws
+                           (list (hasheq 'name "read" 'arguments (hasheq 'path "/tmp/b.rkt")))
+                           (list (make-message "b"
+                                               #f
+                                               'tool
+                                               'tool-result
+                                               (list (make-text-part "content B"))
+                                               (current-seconds)
+                                               (hasheq)))
+                           message-id
+                           (lambda (m) 10))
+      (define all-msgs (list msg-a msg-b (make-test-msg "c" 'user 'message " unrelated")))
+      (define resolved (working-set-resolve-messages ws all-msgs message-id))
+      (check-equal? (length resolved) 2)
+      (check-not-false (member msg-a resolved))
+      (check-not-false (member msg-b resolved)))
+
+    (test-case "T06: pinned token count includes working set messages"
+      (define ws (make-working-set))
+      (define tool-msg (make-test-msg "tool-1" 'tool 'tool-result (make-string 100 #\x)))
+      (working-set-update! ws
+                           (list (hasheq 'name "read" 'arguments (hasheq 'path "/tmp/foo.rkt")))
+                           (list (make-message "tool-1"
+                                               #f
+                                               'tool
+                                               'tool-result
+                                               (list (make-text-part (make-string 100 #\x)))
+                                               (current-seconds)
+                                               (hasheq)))
+                           message-id
+                           (lambda (m) 100))
+      (define msgs (list (make-test-msg "sys" 'system 'system-instruction "System") tool-msg))
+      (define tc (build-tiered-context msgs #:working-set-messages (list tool-msg)))
+      (check-equal? (length (tiered-context-tier-a tc)) 2))))
+
+(module+ main
+  (run-tests ws-tests))
+(module+ test
+  (run-tests ws-tests))


### PR DESCRIPTION
v0.26.0 W2 — Context Assembly Integration.

Integrates working set memory into the context assembly pipeline:
- context-assembly.rkt: #:working-set keyword param, Phase 1.5 injection
- context-pinning.rkt: partition-messages/working-set variant
- turn-orchestrator.rkt: ws extraction, tiered injection, event emission

Tests: 6 new tests in test-context-assembly-ws.rkt