### PR TITLE
feat: working set observability + read-spiral detection (#2801)

### DIFF
--- a/runtime/iteration.rkt
+++ b/runtime/iteration.rkt
@@ -675,6 +675,11 @@
                  ;; v0.26.0: Update working set after tool execution
                  (define tool-result-msgs
                    (filter (lambda (m) (eq? (message-role m) 'tool)) updated-ctx))
+                 ;; Convert tool-call structs to hashes for working-set-update!
+                 (define current-tool-calls-hashes
+                   (for/list ([tc (in-list current-tool-calls)])
+                     (hasheq 'name (tool-call-name tc)
+                             'arguments (tool-call-arguments tc))))
                  (define (estimate-msg-tokens m)
                    (define c (message-content m))
                    (define t (cond [(string? c) c]
@@ -685,7 +690,29 @@
                                              (text-part-text p)))]
                                    [else ""]))
                    (string-length t))
-                 (working-set-update! ws current-tool-calls tool-result-msgs message-id estimate-msg-tokens)
+                 ;; v0.26.0: Detect read spirals (re-reading a file already in working set)
+                 (define read-spiral-paths
+                   (for/list ([tc (in-list current-tool-calls)]
+                              #:when (equal? (tool-call-name tc) "read"))
+                     (define path (extract-tool-target-path tc))
+                     (and path
+                          (member path (map ws-entry-path (working-set-entries ws)))
+                          path)))
+                 (define valid-spiral-paths (filter string? read-spiral-paths))
+                 (when (> (length valid-spiral-paths) 0)
+                   (emit-session-event! bus
+                                        session-id
+                                        "working-set.read-spiral-detected"
+                                        (hasheq 'paths valid-spiral-paths
+                                                'count (length valid-spiral-paths))))
+                 (working-set-update! ws current-tool-calls-hashes tool-result-msgs message-id estimate-msg-tokens)
+                 ;; v0.26.0: Emit working-set.update after each change
+                 (emit-session-event! bus
+                                      session-id
+                                      "working-set.update"
+                                      (hasheq 'entry-count (working-set-entry-count ws)
+                                              'token-count (working-set-token-count ws)
+                                              'paths (map ws-entry-path (working-set-entries ws))))
                  (define-values (new-seen-paths should-increment?)
                    (update-seen-paths current-tool-calls seen-paths))
                  (define effective-tool-count

--- a/runtime/session-lifecycle.rkt
+++ b/runtime/session-lifecycle.rkt
@@ -237,6 +237,7 @@
                                ;; Defense-in-depth: ensure turn.completed is emitted
                                (emit-session-event! bus sid "turn.completed" (hasheq 'reason "error"))
                                (make-loop-result context-with-system 'error payload))])
+    (define ws (hash-ref cfg 'working-set #f))
     (run-iteration-loop context-with-system
                         prov
                         bus
@@ -247,6 +248,7 @@
                         max-iterations
                         #:cancellation-token cancellation-tok
                         #:config cfg
+                        #:working-set ws
                         #:shutdown-check (lambda () (agent-session-shutdown-requested? sess))
                         #:force-shutdown-check (lambda () (agent-session-force-shutdown? sess)))))
 

--- a/runtime/turn-orchestrator.rkt
+++ b/runtime/turn-orchestrator.rkt
@@ -148,7 +148,11 @@
                                'assembled-messages
                                (length ctx-assembled)
                                'tokenCount
-                               ctx-token-count))
+                               ctx-token-count
+                               'working-set-entries
+                               (if ws (working-set-entry-count ws) 0)
+                               'working-set-tokens
+                               (if ws (working-set-token-count ws) 0)))
 
   ;; Dispatch 'context hook — extensions can amend final context
   (define-values (ctx-final _ctx-hook) (maybe-dispatch-hooks ext-reg 'context ctx-assembled))

--- a/tests/test-iteration-observability.rkt
+++ b/tests/test-iteration-observability.rkt
@@ -1,0 +1,203 @@
+#lang racket
+
+;; tests/test-iteration-observability.rkt — Working set observability + read-spiral detection
+
+(require rackunit
+         rackunit/text-ui
+         racket/list
+         racket/file
+         "../runtime/working-set.rkt"
+         "../runtime/iteration.rkt"
+         "../runtime/turn-orchestrator.rkt"
+         "../runtime/agent-session.rkt"
+         "../runtime/session-types.rkt"
+         "../util/protocol-types.rkt"
+         "../agent/event-bus.rkt"
+         "../llm/model.rkt"
+         "../llm/provider.rkt"
+         "../util/ids.rkt"
+         (only-in "../tools/tool.rkt" make-tool make-tool-registry register-tool! make-success-result)
+         (only-in "helpers/mock-provider.rkt"
+                  make-multi-mock-provider
+                  make-tool-call-mock-provider
+                  make-test-config))
+
+;; ── Helpers ──
+
+(define (make-temp-dir)
+  (make-temporary-file "q-obs-test-~a" 'directory))
+
+(define (make-event-collector bus)
+  (define collected (box '()))
+  (subscribe! bus (lambda (evt) (set-box! collected (append (unbox collected) (list evt)))))
+  collected)
+
+(define (event-names collected-box)
+  (map event-ev (unbox collected-box)))
+
+(define (events-with-name collected-box name)
+  (filter (lambda (e) (equal? (event-ev e) name)) (unbox collected-box)))
+
+(define read-dummy-tool
+  (make-tool
+   "read"
+   "read files"
+   (hasheq 'type "object" 'properties (hasheq 'path (hasheq 'type "string")) 'required '(path))
+   (lambda (args ctx) (make-success-result (list "read-content") (hasheq)))))
+
+(define edit-dummy-tool
+  (make-tool "edit"
+             "edit files"
+             (hasheq 'type
+                     "object"
+                     'properties
+                     (hasheq 'path
+                             (hasheq 'type "string")
+                             'old-text
+                             (hasheq 'type "string")
+                             'new-text
+                             (hasheq 'type "string"))
+                     'required
+                     '(path old-text new-text))
+             (lambda (args ctx) (make-success-result (list "edited") (hasheq)))))
+
+(define (make-read-response path)
+  (make-model-response
+   (list (hash 'type "tool-call" 'id (generate-id) 'name "read" 'arguments (hasheq 'path path)))
+   (hasheq 'prompt_tokens 10 'completion_tokens 5 'total_tokens 15)
+   "mock"
+   'tool-calls))
+
+(define text-response
+  (make-model-response (list (hash 'type "text" 'text "done"))
+                       (hasheq 'prompt_tokens 10 'completion_tokens 5 'total_tokens 15)
+                       "mock"
+                       'stop))
+
+(define (make-edit-response path)
+  (make-model-response (list (hash 'type
+                                   "tool-call"
+                                   'id
+                                   (generate-id)
+                                   'name
+                                   "edit"
+                                   'arguments
+                                   (hasheq 'path path 'old-text "old" 'new-text "new")))
+                       (hasheq 'prompt_tokens 10 'completion_tokens 5 'total_tokens 15)
+                       "mock"
+                       'tool-calls))
+
+;; ── Test Suite ──
+
+(define iteration-observability-tests
+  (test-suite "Iteration Observability + Read-Spiral Detection"
+
+    ;; ── T01: context.assembled includes working-set diagnostics ──
+    (test-case "T01: build-assembled-context includes working-set diagnostics"
+      (define bus (make-event-bus))
+      (define collected (make-event-collector bus))
+      (define ws (make-working-set))
+      (working-set-update! ws
+                           (list (hasheq 'name "read" 'arguments (hasheq 'path "/tmp/a.rkt")))
+                           (list (make-message "m1"
+                                               #f
+                                               'tool
+                                               'tool-result
+                                               (list (make-text-part "content"))
+                                               (current-seconds)
+                                               (hasheq)))
+                           message-id
+                           (lambda (m) 20))
+      (define config (hasheq 'working-set ws 'tier-b-count 5 'tier-c-count 1 'max-tokens 10000))
+      (define ctx
+        (list (make-message "u1"
+                            #f
+                            'user
+                            'message
+                            (list (make-text-part "hello"))
+                            (current-seconds)
+                            (hasheq))))
+      (define result (build-assembled-context ctx config #f bus "sess-1" 0))
+      (check-pred list? result)
+      (define assembled-events (events-with-name collected "context.assembled"))
+      (check-equal? (length assembled-events) 1)
+      (define payload (event-payload (first assembled-events)))
+      (check-true (hash-has-key? payload 'working-set-entries))
+      (check-true (hash-has-key? payload 'working-set-tokens))
+      (check-equal? (hash-ref payload 'working-set-entries) 1)
+      (check-true (>= (hash-ref payload 'working-set-tokens) 0)))
+
+    ;; ── T02: working-set.update event after tool execution ──
+    (test-case "T02: working-set.update emitted after read tool execution"
+      (define dir (make-temp-dir))
+      (define bus (make-event-bus))
+      (define collected (make-event-collector bus))
+      (define reg (make-tool-registry))
+      (register-tool! reg read-dummy-tool)
+      (define prov (make-tool-call-mock-provider "read" (hasheq 'path "/tmp/a.rkt") "done"))
+      (define cfg (make-test-config dir bus prov reg))
+      (define sess (make-agent-session cfg))
+      (run-prompt! sess "hello" #:max-iterations 10)
+      (define update-events (events-with-name collected "working-set.update"))
+      (check-true (>= (length update-events) 1)
+                  "working-set.update should be emitted after read tool execution")
+      (define payload (event-payload (first update-events)))
+      (check-true (hash-has-key? payload 'entry-count))
+      (check-true (hash-has-key? payload 'token-count))
+      (check-true (hash-has-key? payload 'paths))
+      (delete-directory/files dir))
+
+    ;; ── T03: read-spiral detected on consecutive same-path reads ──
+    (test-case "T03: read-spiral detected when same path is read twice"
+      (define dir (make-temp-dir))
+      (define bus (make-event-bus))
+      (define collected (make-event-collector bus))
+      (define reg (make-tool-registry))
+      (register-tool! reg read-dummy-tool)
+      ;; Provider: read /tmp/a.rkt, then read /tmp/a.rkt again, then text
+      (define prov
+        (make-multi-mock-provider
+         (list (make-read-response "/tmp/a.rkt") (make-read-response "/tmp/a.rkt") text-response)))
+      (define cfg (make-test-config dir bus prov reg))
+      (define sess (make-agent-session cfg))
+      (run-prompt! sess "hello" #:max-iterations 10)
+      (define spiral-events (events-with-name collected "working-set.read-spiral-detected"))
+      (check-true (>= (length spiral-events) 1)
+                  "read-spiral should be detected on second read of same path")
+      (define payload (event-payload (first spiral-events)))
+      (check-true (hash-has-key? payload 'paths))
+      (check-true (hash-has-key? payload 'count))
+      (delete-directory/files dir))
+
+    ;; ── T04: edit removes entry and prevents read-spiral ──
+    (test-case "T04: edit removes working-set entry and avoids false spiral"
+      (define dir (make-temp-dir))
+      (define bus (make-event-bus))
+      (define collected (make-event-collector bus))
+      (define reg (make-tool-registry))
+      (register-tool! reg read-dummy-tool)
+      (register-tool! reg edit-dummy-tool)
+      ;; Provider: read /tmp/a.rkt, then edit /tmp/a.rkt, then text
+      (define prov
+        (make-multi-mock-provider
+         (list (make-read-response "/tmp/a.rkt") (make-edit-response "/tmp/a.rkt") text-response)))
+      (define cfg (make-test-config dir bus prov reg))
+      (define sess (make-agent-session cfg))
+      (run-prompt! sess "hello" #:max-iterations 10)
+      (define spiral-events (events-with-name collected "working-set.read-spiral-detected"))
+      ;; No read-spiral should be detected because edit consumed the entry
+      (check-equal? (length spiral-events)
+                    0
+                    "edit should remove ws entry and prevent read-spiral detection")
+      (define update-events (events-with-name collected "working-set.update"))
+      ;; Should have at least 2 updates (after read and after edit)
+      (check-true (>= (length update-events) 2))
+      ;; After edit, entry count should be 0
+      (define last-update-payload (event-payload (last update-events)))
+      (check-equal? (hash-ref last-update-payload 'entry-count 999) 0)
+      (delete-directory/files dir))))
+
+(module+ main
+  (run-tests iteration-observability-tests))
+(module+ test
+  (run-tests iteration-observability-tests))


### PR DESCRIPTION
**v0.26.0 W4 — Observability, Diagnostics, and Read-Spiral Detection**

### Changes
- **runtime/iteration.rkt**: 
  - `working-set.update` event emission after each tool execution
  - `working-set.read-spiral-detected` event when re-reading a file already in the working set
  - Fixed tool-call struct → hash conversion for `working-set-update!`
  - Fixed false-positive read-spiral detection when `extract-tool-target-path` returns `#f`
- **runtime/session-lifecycle.rkt**: `dispatch-iteration` passes `#:working-set` from config to `run-iteration-loop`
- **runtime/turn-orchestrator.rkt**: `context.assembled` event includes `working-set-entries` and `working-set-tokens`

### Tests
- T01: `context.assembled` includes working-set diagnostics
- T02: `working-set.update` emitted after read tool execution
- T03: Read-spiral detected on consecutive same-path reads
- T04: Edit removes ws entry and prevents false spiral detection