### PR TITLE
fix: polish state-types comment + fix check-mid-turn-budget! signature (#2879)

v0.27.1 W5 — Polish + Low-Hanging Fruit.

- state-types.rkt: Updated header comment to accurately describe
  contents (data types + cache/entry utility logic, not "pure data").
- check-mid-turn-budget!: Removed duplicate definition from
  iteration.rkt (31 lines). Now lives only in retry-policy.rkt with
  optional #:estimate-tokens keyword (matching the facade signature).
  iteration.rkt: 623→592 LOC.
- All iteration tests pass.

### DIFF
--- a/runtime/iteration.rkt
+++ b/runtime/iteration.rkt
@@ -155,38 +155,7 @@
 ;; Shared helpers (QUAL-01: re-exported from runtime-helpers.rkt)
 ;; ============================================================
 
-;; v0.14.1: Check if context exceeds mid-turn token budget.
-;; Returns estimated token count. Emits event if over budget.
-(define (check-mid-turn-budget! ctx
-                                bus
-                                session-id
-                                config
-                                #:estimate-tokens [estimate-tokens (resolve-estimate-tokens)])
-  (define max-tokens (hash-ref config 'max-context-tokens 128000))
-  (define budget-threshold (inexact->exact (floor (* max-tokens 0.9))))
-  ;; Extract text from message? structs for token estimation
-  (define texts
-    (for/list ([msg (in-list ctx)])
-      (define content (message-content msg))
-      (cond
-        [(string? content) content]
-        [(list? content)
-         (apply string-append
-                (for/list ([part (in-list content)]
-                           #:when (text-part? part))
-                  (text-part-text part)))]
-        [else ""])))
-  (define estimated (for/sum ([t (in-list texts)]) (estimate-tokens (list (hasheq 'content t)))))
-  (when (> estimated budget-threshold)
-    (emit-session-event!
-     bus
-     session-id
-     "context.mid-turn-over-budget"
-     (assert-payload
-      "context.mid-turn-over-budget"
-      (hasheq 'estimated-tokens estimated 'budget budget-threshold 'max-tokens max-tokens)
-      budget-payload/c)))
-  estimated)
+;; check-mid-turn-budget!: delegated to iteration/retry-policy.rkt
 
 ;; ============================================================
 ;; Iteration-loop helpers (private)

--- a/runtime/iteration/retry-policy.rkt
+++ b/runtime/iteration/retry-policy.rkt
@@ -22,7 +22,8 @@
                   budget-payload/c
                   compact-result-payload/c
                   error-detail-payload/c)
-         (only-in "../runtime-helpers.rkt" emit-session-event!))
+         (only-in "../runtime-helpers.rkt" emit-session-event!)
+         (only-in "loop-state.rkt" resolve-estimate-tokens))
 
 (provide check-mid-turn-budget!
          call-with-overflow-recovery)
@@ -33,7 +34,7 @@
                                 bus
                                 session-id
                                 config
-                                #:estimate-tokens estimate-tokens)
+                                #:estimate-tokens [estimate-tokens (resolve-estimate-tokens)])
   (define max-tokens (hash-ref config 'max-context-tokens 128000))
   (define budget-threshold (inexact->exact (floor (* max-tokens 0.9))))
   (define texts

--- a/tui/state-types.rkt
+++ b/tui/state-types.rkt
@@ -2,7 +2,8 @@
 
 ;; tui/state-types.rkt — UI state structs, constructors, entry/cache helpers
 ;;
-;; Pure data types for the TUI state machine. No event processing logic.
+;; TUI state types, render cache management, and entry helpers.
+;; Contains both data definitions and cache/entry utility logic.
 ;; Split from state.rkt (v0.22.6 W2) to keep each module under 400 lines.
 
 (require racket/string


### PR DESCRIPTION
Addresses #2879.

fix: polish state-types comment + fix check-mid-turn-budget! signature (#2879)

v0.27.1 W5 — Polish + Low-Hanging Fruit.

- state-types.rkt: Updated header comment to accurately describe
  contents (data types + cache/entry utility logic, not "pure data").
- check-mid-turn-budget!: Removed duplicate definition from
  iteration.rkt (31 lines). Now lives only in retry-policy.rkt with
  optional #:estimate-tokens keyword (matching the facade signature).
  iteration.rkt: 623→592 LOC.
- All iteration tests pass.