### PR TITLE
fix: runtime integration plumbing — overflow recovery, injected collector, phase4 trace, audit version (#2910)

v0.27.2 W2 — Runtime Integration Plumbing.

F4: call-with-overflow-recovery now catches both context-overflow-error? and
plain exn:fail with overflow messages (context_length, context window, etc.).
Added default compact-proc that keeps last 50% of messages.

F5: make-injected-collector! now defaults inject-topic to
injection-event-topic from message-inject.rkt instead of #f, so event
filter matches correctly.

F6: Added phase4-catalog trace emission after catalog generation in
selection.rkt with catalog-entries and has-catalog? data.

F7: Fixed test-audit-script.rkt — q-version is a string not a function,
changed (q-version) to q-version.

Tests: test-context-overflow (18/18), test-message-inject (all),
test-audit-script (12/12) pass.

### DIFF
--- a/runtime/context-assembly/selection.rkt
+++ b/runtime/context-assembly/selection.rkt
@@ -21,9 +21,7 @@
                   ensure-first-user-pinned
                   fit-messages-pair-preserving)
          (only-in "../context-pinning.rkt" partition-messages/working-set)
-         (only-in "../working-set.rkt"
-                  working-set?
-                  working-set-resolve-messages)
+         (only-in "../working-set.rkt" working-set? working-set-resolve-messages)
          "budgeting.rkt")
 
 (provide build-assembled-context
@@ -40,7 +38,8 @@
                                  #:generate-catalog-proc [generate-catalog-proc #f]
                                  #:estimate-text-proc [estimate-text-proc #f])
   (define (emit-trace phase data)
-    (when trace (trace phase data)))
+    (when trace
+      (trace phase data)))
   (define raw-messages (build-session-context idx))
   (emit-trace 'start (hash 'raw-count (length raw-messages)))
   (if (null? raw-messages)
@@ -54,42 +53,57 @@
 
         (define max-tokens (context-assembly-config-recent-tokens config))
         (define ws-messages
-          (if ws (working-set-resolve-messages ws raw-messages message-id) '()))
-        (define ws-message-ids (if ws (map message-id ws-messages) '()))
+          (if ws
+              (working-set-resolve-messages ws raw-messages message-id)
+              '()))
+        (define ws-message-ids
+          (if ws
+              (map message-id ws-messages)
+              '()))
         (define-values (pinned removable)
           (partition-messages/working-set raw-messages ws-message-ids))
         (define pinned-tokens (for/sum ([m (in-list pinned)]) (memoized-estimate m)))
         (define pinned-count (length pinned))
         (define removable-count (length removable))
         (emit-trace 'phase1-pinned
-                    (hash 'pinned-count pinned-count
-                          'removable-count removable-count
-                          'pinned-tokens pinned-tokens))
+                    (hash 'pinned-count
+                          pinned-count
+                          'removable-count
+                          removable-count
+                          'pinned-tokens
+                          pinned-tokens))
 
         (define remaining-budget (- max-tokens pinned-tokens))
         (define-values (recent excluded)
           (if (<= remaining-budget 0)
               (values '() removable)
               (let ()
-                (define kept (fit-messages-pair-preserving removable remaining-budget memoized-estimate))
-                (define kept-ids (for/hash ([m (in-list kept)]) (values (message-id m) #t)))
-                (define exc (filter (lambda (m) (not (hash-has-key? kept-ids (message-id m)))) removable))
+                (define kept
+                  (fit-messages-pair-preserving removable remaining-budget memoized-estimate))
+                (define kept-ids
+                  (for/hash ([m (in-list kept)])
+                    (values (message-id m) #t)))
+                (define exc
+                  (filter (lambda (m) (not (hash-has-key? kept-ids (message-id m)))) removable))
                 (values kept exc))))
         (define recent-count (length recent))
         (define excluded-count (length excluded))
         (emit-trace 'phase3-fitted
-                    (hash 'recent-count recent-count
-                          'excluded-count excluded-count
-                          'remaining-budget remaining-budget))
+                    (hash 'recent-count
+                          recent-count
+                          'excluded-count
+                          excluded-count
+                          'remaining-budget
+                          remaining-budget))
 
         ;; Phase 2: Generate summary for excluded entries
         (define summary-obj
-          (and generate-summary-proc
-               (generate-summary-proc excluded provider model-name cache)))
+          (and generate-summary-proc (generate-summary-proc excluded provider model-name cache)))
         (emit-trace 'phase2-summary
-                    (hash 'has-summary? (and summary-obj #t)
-                          'entry-count (and summary-obj
-                                            ((hash-ref summary-obj 'entry-count (lambda () 0))))))
+                    (hash 'has-summary?
+                          (and summary-obj #t)
+                          'entry-count
+                          (and summary-obj ((hash-ref summary-obj 'entry-count (lambda () 0))))))
 
         (define summary-msg #f) ;; Summary msg construction delegated to caller
         ;; Phase 4: Generate catalog
@@ -100,9 +114,16 @@
                                      (context-assembly-config-max-catalog-tokens config))
               '()))
 
+        (emit-trace 'phase4-catalog
+                    (hash 'catalog-entries (length catalog) 'has-catalog? (not (null? catalog))))
+
         ;; Phase 5: Reassemble in original order
-        (define pinned-ids (for/hash ([m (in-list pinned)]) (values (message-id m) #t)))
-        (define recent-ids (for/hash ([m (in-list recent)]) (values (message-id m) #t)))
+        (define pinned-ids
+          (for/hash ([m (in-list pinned)])
+            (values (message-id m) #t)))
+        (define recent-ids
+          (for/hash ([m (in-list recent)])
+            (values (message-id m) #t)))
         (define result-messages
           (for/list ([m (in-list raw-messages)]
                      #:when (or (hash-has-key? pinned-ids (message-id m))
@@ -146,8 +167,9 @@
       i))
   (cond
     [(not compaction-idx) (values path #f)]
-    [else (define-values (pre post) (split-at path compaction-idx))
-          (values pre post)]))
+    [else
+     (define-values (pre post) (split-at path compaction-idx))
+     (values pre post)]))
 
 (define (entry->context-message entry)
   (define kind (message-kind entry))

--- a/runtime/iteration/retry-policy.rkt
+++ b/runtime/iteration/retry-policy.rkt
@@ -4,9 +4,11 @@
 ;;
 ;; Pure policy functions for retry and recovery.
 
-(require (only-in racket/string string-join)
+(require racket/list
+         (only-in racket/string string-join string-contains?)
          (only-in "../auto-retry.rkt" context-overflow-error?)
          (only-in "../compactor.rkt"
+                  compaction-result
                   compaction-result-removed-count
                   compaction-result-kept-messages)
          (only-in "../../util/protocol-types.rkt"
@@ -57,29 +59,39 @@
      (hasheq 'estimated-tokens estimated 'budget budget-threshold 'max-tokens max-tokens)))
   estimated)
 
+;; Check if an exception message indicates context overflow.
+(define (overflow-message? e)
+  (define msg (exn-message e))
+  (or (string-contains? msg "context_length")
+      (string-contains? msg "context window")
+      (string-contains? msg "maximum context")
+      (string-contains? msg "token limit")))
+
 ;; Handle context overflow by compacting the context and retrying once.
-(define (call-with-overflow-recovery thunk
-                                     ctx
-                                     bus
-                                     session-id
-                                     #:compact-proc [compact-proc #f])
-  (with-handlers ([context-overflow-error?
-                   (lambda (e)
-                     (emit-session-event! bus
-                                          session-id
-                                          "context.overflow.detected"
-                                          (hasheq 'error (exn-message e)))
-                     (define compact-result (compact-proc ctx))
-                     (emit-session-event!
-                      bus
-                      session-id
-                      "context.overflow.compacted"
-                      (hasheq 'original-size
-                              (length ctx)
-                              'removed-count
-                              (compaction-result-removed-count compact-result)
-                              'kept-count
-                              (length (compaction-result-kept-messages compact-result))))
-                     (thunk))]
-                  [exn:fail? (lambda (e) (raise e))])
+;; Catches both context-overflow-error? and plain exn:fail with overflow messages.
+(define (call-with-overflow-recovery thunk ctx bus session-id #:compact-proc [compact-proc #f])
+  (define do-compact
+    (or compact-proc
+        (lambda (msgs)
+          (define half (max 1 (quotient (length msgs) 2)))
+          (compaction-result #f (- (length msgs) half) (take-right msgs half)))))
+  (with-handlers
+      ([(lambda (e) (or (context-overflow-error? e) (and (exn:fail? e) (overflow-message? e))))
+        (lambda (e)
+          (emit-session-event! bus
+                               session-id
+                               "context.overflow.detected"
+                               (hasheq 'error (exn-message e)))
+          (define compact-result (do-compact ctx))
+          (emit-session-event! bus
+                               session-id
+                               "context.overflow.compacted"
+                               (hasheq 'original-size
+                                       (length ctx)
+                                       'removed-count
+                                       (compaction-result-removed-count compact-result)
+                                       'kept-count
+                                       (length (compaction-result-kept-messages compact-result))))
+          (thunk))]
+       [exn:fail? (lambda (e) (raise e))])
     (thunk)))

--- a/runtime/iteration/tool-turn-bridge.rkt
+++ b/runtime/iteration/tool-turn-bridge.rkt
@@ -22,12 +22,10 @@
                   event-ev
                   event-payload)
          "../../agent/event-bus.rkt"
-         (only-in "../../agent/queue.rkt"
-                  dequeue-steering!
-                  dequeue-followup!
-                  dequeue-all-followups!)
+         (only-in "../../agent/queue.rkt" dequeue-steering! dequeue-followup! dequeue-all-followups!)
          "../working-set.rkt"
-         (only-in "../context-policy.rkt" estimate-message-tokens))
+         (only-in "../context-policy.rkt" estimate-message-tokens)
+         (only-in "../../extensions/message-inject.rkt" injection-event-topic))
 
 (provide extract-tool-target-path
          take-at-most
@@ -78,28 +76,24 @@
 (define (update-working-set-after-tools! ws tool-calls tool-result-msgs)
   (define tool-calls-hashes
     (for/list ([tc (in-list tool-calls)])
-      (hasheq 'name (tool-call-name tc)
-              'arguments (tool-call-arguments tc))))
+      (hasheq 'name (tool-call-name tc) 'arguments (tool-call-arguments tc))))
   (working-set-update! ws tool-calls-hashes tool-result-msgs message-id estimate-message-tokens)
   ws)
 
 ;; Count errors in tool result messages.
 (define (count-tool-errors messages)
-  (for/sum
-   ([tr (filter tool-result-part?
-                (apply append (map message-content messages)))])
-   (if (tool-result-part-is-error? tr) 1 0)))
+  (for/sum ([tr (filter tool-result-part? (apply append (map message-content messages)))])
+           (if (tool-result-part-is-error? tr) 1 0)))
 
 ;; Compute exploration and implementation counters from tool calls.
 (define (compute-tool-counters tool-calls explore-count implement-count)
   (define new-explore
     (+ explore-count
        (for/sum ([tc (in-list tool-calls)])
-         (if (member (tool-call-name tc) '("read" "grep" "find" "ls")) 1 0))))
+                (if (member (tool-call-name tc) '("read" "grep" "find" "ls")) 1 0))))
   (define new-implement
     (+ implement-count
-       (for/sum ([tc (in-list tool-calls)])
-         (if (member (tool-call-name tc) '("edit" "write")) 1 0))))
+       (for/sum ([tc (in-list tool-calls)]) (if (member (tool-call-name tc) '("edit" "write")) 1 0))))
   (values new-explore new-implement))
 
 ;; Extract the last assistant text from context.
@@ -133,7 +127,7 @@
         (filter message? msgs))))
 
 ;; Create an injected-message collector: subscribes to message.injected events.
-(define (make-injected-collector! bus #:inject-topic [inject-topic #f])
+(define (make-injected-collector! bus #:inject-topic [inject-topic injection-event-topic])
   (define collected (box '()))
   (subscribe! bus
               (lambda (evt)
@@ -154,7 +148,5 @@
     (for/list ([tc (in-list tool-calls)]
                #:when (equal? (tool-call-name tc) "read"))
       (define path (extract-tool-target-path tc))
-      (and path
-           (member path (map ws-entry-path (working-set-entries ws)))
-           path)))
+      (and path (member path (map ws-entry-path (working-set-entries ws))) path)))
   (filter string? read-spiral-paths))

--- a/tests/test-audit-script.rkt
+++ b/tests/test-audit-script.rkt
@@ -93,7 +93,7 @@
       (define m (regexp-match #rx"version.*?([0-9]+\\.[0-9]+\\.[0-9]+)" output))
       (check-not-false m)
       (when m
-        (check-true (string=? (cadr m) (q-version)))))
+        (check-true (string=? (cadr m) q-version))))
 
     (test-case "ci mode exits 0 when no critical findings"
       (define-values (out err exit-code) (run-audit-args "--ci"))


### PR DESCRIPTION
Addresses #2910.

fix: runtime integration plumbing — overflow recovery, injected collector, phase4 trace, audit version (#2910)

v0.27.2 W2 — Runtime Integration Plumbing.

F4: call-with-overflow-recovery now catches both context-overflow-error? and
plain exn:fail with overflow messages (context_length, context window, etc.).
Added default compact-proc that keeps last 50% of messages.

F5: make-injected-collector! now defaults inject-topic to
injection-event-topic from message-inject.rkt instead of #f, so event
filter matches correctly.

F6: Added phase4-catalog trace emission after catalog generation in
selection.rkt with catalog-entries and has-catalog? data.

F7: Fixed test-audit-script.rkt — q-version is a string not a function,
changed (q-version) to q-version.

Tests: test-context-overflow (18/18), test-message-inject (all),
test-audit-script (12/12) pass.