### PR TITLE
chore: bump version to 0.27.2 + full regression pass (#2915)

v0.27.2 W3 — Version Bump + Full Regression Suite.

Bump version to 0.27.2 across util/version.rkt, info.rkt, README.md,
CHANGELOG.md, and all docs/ markdown files. Version lint passes with 0
errors.

All test suites green:
- test-context-overflow: 18/18
- test-message-inject: all pass
- test-iteration-retry: 2/2
- test-iteration-tool-bridge: 8/8
- test-iteration-transition: 11/11
- test-gsd-* (22 files): all pass
- tui/* (38 files): all pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## v0.27.2 — 2026-05-01
+
+### Test Regression Remediation
+
+- **W0**: TUI Status Bar Completion. Fix status-line inverse style for idle
+  state, ensure "q" prefix renders in all modes, custom-renderer registry
+  dispatch for tool-start/tool-end events.
+- **W1**: Markdown + Branch + Custom Renderers. Rewrite md-token->segments
+  using cond (not case) for all token types, branch-info accessors for TUI
+  branch list, custom renderer dispatch with call/result signatures.
+- **W2**: Runtime Integration Plumbing. call-with-overflow-recovery catches
+  plain exn:fail with overflow messages, make-injected-collector! defaults
+  topic, phase4-catalog trace emission, audit script version check fix.
+
+
 ## v0.27.0 — 2026-04-29
 
 ### Deep Module Refactoring + v0.26.0 Remediation

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.27.1-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.27.2-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 
@@ -199,7 +199,7 @@ racket main.rkt --model gpt-5.4 "write a test"
 ### Verify
 
 ```bash
-racket main.rkt --version  # q version 0.27.1
+racket main.rkt --version  # q version 0.27.2
 raco test tests/           # run the full test suite
 ```
 
@@ -272,7 +272,7 @@ q/
 |--------|-------|
 | Test files | 474 |
 | Source modules | 373 |
-| Source lines | 59177 |
+| Source lines | 59307 |
 | Test lines | 90718 |
 | Test assertions | 13978 |
 | Tests passing | 5835+ | `racket scripts/run-tests.rkt` results |
@@ -334,7 +334,7 @@ When q executes shell commands on behalf of an LLM, arguments are quoted via `sh
 
 ## Status
 
-**v0.27.0** — Audit Tooling Quality & Test Coverage. Audit script fixes (safe reads, skip-lists, help flag, no double scan), test expansion (+19 tests), with-handlers noise fix, tooling docs, decomposition fitness tests. 3 issues across 3 waves.
+**v0.27.2** — Audit Tooling Quality & Test Coverage. Audit script fixes (safe reads, skip-lists, help flag, no double scan), test expansion (+19 tests), with-handlers noise fix, tooling docs, decomposition fitness tests. 3 issues across 3 waves.
 
 **v0.27.0** — Execution Architecture Improvements. `delete-lines` tool, `/wave-done` command, planning path resolution hardening, backup timestamp fix. 4 issues across 4 waves.
 

--- a/docs/event-taxonomy.md
+++ b/docs/event-taxonomy.md
@@ -1,6 +1,6 @@
 # Q Event Taxonomy Reference
 
-Complete reference for all event types in Q 0.27.1.
+Complete reference for all event types in Q 0.27.2.
 ## Base Types
 
 ### `event` (protocol-level)
@@ -313,7 +313,7 @@ Key hook points where extensions can intercept:
 
 For the complete list, see `util/hook-types.rkt`.
 
-## Contract-Validated Events (v0.27.1)
+## Contract-Validated Events (v0.27.2)
 
 The following high-value events have payload contracts enforced at emission
 time in `runtime/iteration.rkt`. These events are consumed by extensions and

--- a/docs/extension-guide.md
+++ b/docs/extension-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.27.1 --># Extension Development Guide
+<!-- verified-against: 0.27.2 --># Extension Development Guide
 
 This guide walks you through creating, testing, and activating a custom
 extension for q.

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.27.1 --># Getting Started
+<!-- verified-against: 0.27.2 --># Getting Started
 
 Welcome to q, a Racket-based coding agent.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.27.1 --># Installation Guide
+<!-- verified-against: 0.27.2 --># Installation Guide
 
 <!-- This file is the canonical source. The docs/getting-started/installation.md copy is maintained for the doc site build. -->
 

--- a/docs/sdk-guide.md
+++ b/docs/sdk-guide.md
@@ -206,7 +206,7 @@ The SDK provides convenience functions for GSD (Goal-driven Structured Developme
 
 ### Extension Pre-Registration
 
-As of v0.27.1, `open-session` automatically registers extension tools (like `planning-read` and `planning-write`) before the first `run-prompt!` call. This means:
+As of v0.27.2, `open-session` automatically registers extension tools (like `planning-read` and `planning-write`) before the first `run-prompt!` call. This means:
 - Extension tools appear in `list-tools` immediately after `open-session`
 - GSD event bus is initialized and ready to emit events
 - No need to call `run-prompt!` once just to trigger tool registration

--- a/docs/security-trust-model.md
+++ b/docs/security-trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.27.1 --># Security & Trust Model
+<!-- verified-against: 0.27.2 --># Security & Trust Model
 
 This document provides an honest, per-area assessment of what q enforces
 today and what is planned. It is the authoritative reference for security
@@ -270,7 +270,7 @@ credential leakage into child processes.
 Environment variables matching these case-insensitive patterns are scrubbed:
 
 - `API.?KEY`, `SECRET`, `TOKEN`, `PASSWORD`, `CREDENTIAL`, `PRIVATE`
-- `AUTH` (narrowed in v0.27.1 to match only `AUTH`, `AUTH_*`, `*_AUTH_*`)
+- `AUTH` (narrowed in v0.27.2 to match only `AUTH`, `AUTH_*`, `*_AUTH_*`)
 - `GH_PAT`, and any var ending in `_PAT`
 
 ### Implicit allowlist

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -130,6 +130,6 @@ is the primary self-hosting extension:
 (load-extension! ext-reg "path/to/extension.rkt" #:event-bus bus)
 ```
 
-## Version 0.27.1
+## Version 0.27.2
 
-This documentation reflects q 0.27.1.
+This documentation reflects q 0.27.2.

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.27.1 --># q Source Style Guide
+<!-- verified-against: 0.27.2 --># q Source Style Guide
 
 This document defines formatting and naming conventions for the q Racket codebase.
 All changes to `q/` source files (excluding `tests/`) should follow these rules.

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.27.1 --># Trust Model
+<!-- verified-against: 0.27.2 --># Trust Model
 
 ## Trust Levels
 

--- a/docs/workflow-testing.md
+++ b/docs/workflow-testing.md
@@ -121,6 +121,6 @@ Use relative paths from the test file:
 4. Use `(check-true ...)` for boolean assertions
 5. Keep tests independent — no shared mutable state between test-cases
 
-## Version 0.27.1
+## Version 0.27.2
 
-This documentation reflects q 0.27.1.
+This documentation reflects q 0.27.2.

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.27.1")
+(define version "0.27.2")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base"))

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -10,4 +10,4 @@
 (provide q-version)
 
 (: q-version String)
-(define q-version "0.27.1")
+(define q-version "0.27.2")

--- a/wiki-src/Architecture-Overview.md
+++ b/wiki-src/Architecture-Overview.md
@@ -35,7 +35,7 @@ User input → Interface (CLI/TUI/RPC)
     → Events emitted to bus
 ```
 
-## Metrics (0.27.1)
+## Metrics (0.27.2)
 > _See `racket scripts/metrics.rkt` for current numbers._
 
 - 228 source modules, 349 test files


### PR DESCRIPTION
Addresses #2915.

chore: bump version to 0.27.2 + full regression pass (#2915)

v0.27.2 W3 — Version Bump + Full Regression Suite.

Bump version to 0.27.2 across util/version.rkt, info.rkt, README.md,
CHANGELOG.md, and all docs/ markdown files. Version lint passes with 0
errors.

All test suites green:
- test-context-overflow: 18/18
- test-message-inject: all pass
- test-iteration-retry: 2/2
- test-iteration-tool-bridge: 8/8
- test-iteration-transition: 11/11
- test-gsd-* (22 files): all pass
- tui/* (38 files): all pass