### PR TITLE
fix: sync doc version refs to 0.27.4 (#2948)

### DIFF
--- a/docs/event-taxonomy.md
+++ b/docs/event-taxonomy.md
@@ -1,6 +1,6 @@
 # Q Event Taxonomy Reference
 
-Complete reference for all event types in Q 0.27.2.
+Complete reference for all event types in Q 0.27.4.
 ## Base Types
 
 ### `event` (protocol-level)
@@ -313,7 +313,7 @@ Key hook points where extensions can intercept:
 
 For the complete list, see `util/hook-types.rkt`.
 
-## Contract-Validated Events (v0.27.2)
+## Contract-Validated Events (v0.27.4)
 
 The following high-value events have payload contracts enforced at emission
 time in `runtime/iteration.rkt`. These events are consumed by extensions and

--- a/docs/extension-guide.md
+++ b/docs/extension-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.27.2 --># Extension Development Guide
+<!-- verified-against: 0.27.4 --># Extension Development Guide
 
 This guide walks you through creating, testing, and activating a custom
 extension for q.

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.27.2 --># Getting Started
+<!-- verified-against: 0.27.4 --># Getting Started
 
 Welcome to q, a Racket-based coding agent.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.27.2 --># Installation Guide
+<!-- verified-against: 0.27.4 --># Installation Guide
 
 <!-- This file is the canonical source. The docs/getting-started/installation.md copy is maintained for the doc site build. -->
 

--- a/docs/sdk-guide.md
+++ b/docs/sdk-guide.md
@@ -206,7 +206,7 @@ The SDK provides convenience functions for GSD (Goal-driven Structured Developme
 
 ### Extension Pre-Registration
 
-As of v0.27.2, `open-session` automatically registers extension tools (like `planning-read` and `planning-write`) before the first `run-prompt!` call. This means:
+As of v0.27.4, `open-session` automatically registers extension tools (like `planning-read` and `planning-write`) before the first `run-prompt!` call. This means:
 - Extension tools appear in `list-tools` immediately after `open-session`
 - GSD event bus is initialized and ready to emit events
 - No need to call `run-prompt!` once just to trigger tool registration

--- a/docs/security-trust-model.md
+++ b/docs/security-trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.27.2 --># Security & Trust Model
+<!-- verified-against: 0.27.4 --># Security & Trust Model
 
 This document provides an honest, per-area assessment of what q enforces
 today and what is planned. It is the authoritative reference for security
@@ -270,7 +270,7 @@ credential leakage into child processes.
 Environment variables matching these case-insensitive patterns are scrubbed:
 
 - `API.?KEY`, `SECRET`, `TOKEN`, `PASSWORD`, `CREDENTIAL`, `PRIVATE`
-- `AUTH` (narrowed in v0.27.2 to match only `AUTH`, `AUTH_*`, `*_AUTH_*`)
+- `AUTH` (narrowed in v0.27.4 to match only `AUTH`, `AUTH_*`, `*_AUTH_*`)
 - `GH_PAT`, and any var ending in `_PAT`
 
 ### Implicit allowlist

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -130,6 +130,6 @@ is the primary self-hosting extension:
 (load-extension! ext-reg "path/to/extension.rkt" #:event-bus bus)
 ```
 
-## Version 0.27.2
+## Version 0.27.4
 
-This documentation reflects q 0.27.2.
+This documentation reflects q 0.27.4.

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.27.2 --># q Source Style Guide
+<!-- verified-against: 0.27.4 --># q Source Style Guide
 
 This document defines formatting and naming conventions for the q Racket codebase.
 All changes to `q/` source files (excluding `tests/`) should follow these rules.

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.27.2 --># Trust Model
+<!-- verified-against: 0.27.4 --># Trust Model
 
 ## Trust Levels
 

--- a/docs/workflow-testing.md
+++ b/docs/workflow-testing.md
@@ -121,6 +121,6 @@ Use relative paths from the test file:
 4. Use `(check-true ...)` for boolean assertions
 5. Keep tests independent — no shared mutable state between test-cases
 
-## Version 0.27.2
+## Version 0.27.4
 
-This documentation reflects q 0.27.2.
+This documentation reflects q 0.27.4.

--- a/wiki-src/Architecture-Overview.md
+++ b/wiki-src/Architecture-Overview.md
@@ -35,7 +35,7 @@ User input → Interface (CLI/TUI/RPC)
     → Events emitted to bus
 ```
 
-## Metrics (0.27.2)
+## Metrics (0.27.4)
 > _See `racket scripts/metrics.rkt` for current numbers._
 
 - 228 source modules, 349 test files


### PR DESCRIPTION
v0.27.4 W3 — CI Green + Release.

Fix stale doc version references (0.27.2/0.27.3 → 0.27.4) that caused CI lint failure.
All lint steps pass locally.