### PR TITLE
feat: JSON file I/O helpers + adopt across 10 files (#2955)

v0.28.0 W0 — JSON File I/O Helpers (Finding A1).

Add read-json-file and write-json-file to existing util/json-helpers.rkt.
Replace raw call-with-input-file/read-json and call-with-output-file/write-json
patterns across 10 source files: runtime/auth-store, runtime/credential-backend,
runtime/extension-catalog, runtime/oauth, runtime/settings, runtime/session-index/mutations,
extensions/quarantine, extensions/github/handlers/milestone-ops, pkg/registry,
tools/builtins/firecrawl.

Gate criterion: 3+ repetitions (34 occurrences across codebase).
Tests: test-json-helpers 4/4, all consumer tests pass.

### DIFF
--- a/extensions/github/handlers/milestone-ops.rkt
+++ b/extensions/github/handlers/milestone-ops.rkt
@@ -2,6 +2,7 @@
 
 ;; extensions/github/handlers/milestone-ops.rkt — GitHub milestone + board handlers
 
+(require "../../util/json-helpers.rkt")
 (require racket/format
          racket/string
          json
@@ -30,7 +31,7 @@
        (with-handlers ([exn:fail? (lambda (e)
                                     (log-warning (format "github/spec-read: ~a" (exn-message e)))
                                     #f)])
-         (call-with-input-file spec-path read-json)))
+         (read-json-file spec-path)))
      (cond
        [(not spec-data) (make-error-result (format "Invalid JSON in spec file: ~a" spec-file))]
        [dry-run?

--- a/extensions/quarantine.rkt
+++ b/extensions/quarantine.rkt
@@ -12,6 +12,7 @@
 ;;   - list-quarantined       : list all quarantined extensions with metadata
 ;;   - format-extension-status : human-readable status string
 
+(require "../util/json-helpers.rkt")
 (require racket/contract
          racket/file
          racket/format
@@ -96,7 +97,7 @@
                                   (log-warning "quarantine state corrupted, resetting: ~a"
                                                (exn-message e))
                                   (hasheq 'disabled '() 'quarantined (hasheq) 'active '()))])
-       (define data (call-with-input-file sf read-json))
+       (define data (read-json-file sf))
        (hasheq 'disabled
                (hash-ref data 'disabled '())
                'quarantined

--- a/pkg/registry.rkt
+++ b/pkg/registry.rkt
@@ -7,6 +7,7 @@
 ;;
 ;; Provides functions to search, resolve, and query the package index.
 
+(require "../util/json-helpers.rkt")
 (require json
          racket/string
          racket/list
@@ -73,7 +74,7 @@
     (cond
       [(not (file-exists? p)) (hash 'version 1 'updated "" 'packages '())]
       [else
-       (define content (call-with-input-file p read-json))
+       (define content (read-json-file p))
        (if (eof-object? content)
            (hash 'version 1 'updated "" 'packages '())
            content)])))

--- a/runtime/auth-store.rkt
+++ b/runtime/auth-store.rkt
@@ -6,6 +6,7 @@
 ;;; first, then falling back to config. No coupling to settings.rkt —
 ;;; all config is received as parameter hashes.
 
+(require "../util/json-helpers.rkt")
 (require json
          racket/file
          racket/string
@@ -238,7 +239,7 @@
     [(not (file-exists? path)) (hash)]
     [else
      (with-handlers ([exn:fail? (λ (e) (hash))])
-       (define content (call-with-input-file path read-json))
+       (define content (read-json-file path))
        (if (eof-object? content)
            (hash)
            (let ([providers (hash-ref content 'providers (hash))])
@@ -309,7 +310,7 @@
   ;; Read existing config or start fresh
   (define existing
     (if (file-exists? config-path)
-        (let ([content (call-with-input-file config-path read-json)])
+        (let ([content (read-json-file config-path)])
           (if (eof-object? content)
               (hasheq)
               content))
@@ -351,6 +352,6 @@
                                                                          (exn-message e)))])
                                  (delete-file tmp))
                                (raise e))])
-    (call-with-output-file tmp (lambda (out) (write-json data out)) #:exists 'truncate)
+    (write-json-file tmp data)
     (rename-file-or-directory tmp path #t)
     (file-or-directory-permissions path #o600)))

--- a/runtime/credential-backend.rkt
+++ b/runtime/credential-backend.rkt
@@ -9,6 +9,7 @@
 ;; different backends: file (JSON), environment variables, memory (testing),
 ;; OS keychain (secret-tool / macOS security), and chained (fallback chain).
 
+(require "../util/json-helpers.rkt")
 (require json
          racket/file
          racket/string
@@ -98,7 +99,7 @@
     [(not (file-exists? path)) (hash)]
     [else
      (with-handlers ([exn:fail? (λ (e) (hash))])
-       (define content (call-with-input-file path read-json))
+       (define content (read-json-file path))
        (if (eof-object? content)
            (hash)
            (let ([providers (hash-ref content 'providers (hash))])
@@ -166,7 +167,7 @@
                                (with-handlers ([exn:fail? void])
                                  (delete-file tmp))
                                (raise e))])
-    (call-with-output-file tmp (λ (out) (write-json data out)) #:exists 'truncate)
+    (write-json-file tmp data)
     (rename-file-or-directory tmp path #t)
     (file-or-directory-permissions path #o600)))
 

--- a/runtime/extension-catalog.rkt
+++ b/runtime/extension-catalog.rkt
@@ -11,6 +11,7 @@
 ;; - activate-extension!: create symlink in target directory
 ;; - deactivate-extension!: remove symlink
 
+(require "../util/json-helpers.rkt")
 (require racket/file
          racket/path
          json
@@ -52,7 +53,7 @@
   (define cfg-path (build-path home-dir ".q" "config.json"))
   (and (file-exists? cfg-path)
        (with-handlers ([exn:fail? (λ (_) #f)])
-         (define cfg (call-with-input-file cfg-path (λ (in) (read-json in))))
+         (define cfg (read-json-file cfg-path))
          (define dir-str (hash-ref cfg 'extensions (hash)))
          (define source-dir
            (if (hash? dir-str)

--- a/runtime/oauth.rkt
+++ b/runtime/oauth.rkt
@@ -6,6 +6,7 @@
 ;; for SSO/corporate auth flows. Token exchange and refresh are
 ;; stub implementations pending an HTTP client library.
 
+(require "../util/json-helpers.rkt")
 (require racket/string
          racket/format
          json
@@ -165,7 +166,7 @@
     [(not (file-exists? path)) (hash)]
     [else
      (with-handlers ([exn:fail? (lambda (e) (hash))])
-       (define content (call-with-input-file path read-json))
+       (define content (read-json-file path))
        (if (eof-object? content)
            (hash)
            (for/hash ([(k v) (in-hash content)])
@@ -192,7 +193,7 @@
                                  (with-handlers ([exn:fail? (lambda (_) (void))])
                                    (delete-file tmp))
                                  (raise e))])
-      (call-with-output-file tmp (lambda (out) (write-json file-content out)) #:exists 'truncate)
+      (write-json-file tmp file-content)
       (rename-file-or-directory tmp path #t)
       (file-or-directory-permissions path #o600))))
 

--- a/runtime/session-index/mutations.rkt
+++ b/runtime/session-index/mutations.rkt
@@ -10,6 +10,7 @@
          racket/path
          racket/list
          json
+         "../../util/json-helpers.rkt"
          (only-in "../../util/protocol-types.rkt"
                   message-id
                   message-parent-id
@@ -108,7 +109,8 @@
   (define blob
     (with-output-to-string (lambda ()
                              (for ([entry (in-list lines)])
-                               (write-json entry) (newline)))))
+                               (write-json entry)
+                               (newline)))))
   (call-with-output-file path (lambda (out) (display blob out)) #:mode 'text #:exists 'truncate))
 
 (define (load-index path)
@@ -132,7 +134,12 @@
              (define pid (message-parent-id msg))
              (when (and pid (hash-has-key? children pid))
                (hash-update! children pid (lambda (lst) (append lst (list msg))))))
-           (session-index by-id children (list->vector entries) (make-hash) (box #f) (make-semaphore 1))]))))
+           (session-index by-id
+                          children
+                          (list->vector entries)
+                          (make-hash)
+                          (box #f)
+                          (make-semaphore 1))]))))
 
 ;; ============================================================
 ;; Active leaf
@@ -140,12 +147,16 @@
 
 (define (switch-leaf! idx entry-id)
   (if (lookup-entry idx entry-id)
-      (begin (set-box! (session-index-active-leaf-id idx) entry-id) entry-id)
+      (begin
+        (set-box! (session-index-active-leaf-id idx) entry-id)
+        entry-id)
       #f))
 
 (define (mark-active-leaf! idx entry-id)
   (if (lookup-entry idx entry-id)
-      (begin (set-box! (session-index-active-leaf-id idx) entry-id) entry-id)
+      (begin
+        (set-box! (session-index-active-leaf-id idx) entry-id)
+        entry-id)
       #f))
 
 ;; ============================================================
@@ -175,7 +186,9 @@
              [current-pos (if current-id
                               (or (for/first ([id (in-list leaf-ids)]
                                               [i (in-naturals)]
-                                              #:when (equal? id current-id)) i) -1)
+                                              #:when (equal? id current-id))
+                                    i)
+                                  -1)
                               -1)]
              [next-pos (modulo (add1 current-pos) (length leaves))]
              [next-entry (list-ref leaves next-pos)])
@@ -191,7 +204,9 @@
              [current-pos (if current-id
                               (or (for/first ([id (in-list leaf-ids)]
                                               [i (in-naturals)]
-                                              #:when (equal? id current-id)) i) 0)
+                                              #:when (equal? id current-id))
+                                    i)
+                                  0)
                               0)]
              [prev-pos (modulo (sub1 current-pos) n)]
              [prev-entry (list-ref leaves prev-pos)])
@@ -216,7 +231,9 @@
     [else
      (define summary-msg
        (make-message (format "branch-summary-~a" (current-inexact-milliseconds))
-                     entry-id 'system 'branch-summary
+                     entry-id
+                     'system
+                     'branch-summary
                      (list (make-text-part summary-text))
                      (current-seconds)
                      (hasheq 'type "branch-summary" 'from-id entry-id)))
@@ -229,14 +246,19 @@
 
 (define (append-to-leaf! idx entry)
   (define parent (active-leaf idx))
-  (define parent-id (if parent (message-id parent) #f))
+  (define parent-id
+    (if parent
+        (message-id parent)
+        #f))
   (define fixed-entry
     (if (and parent-id (not (message-parent-id entry)))
         (struct-copy message entry [parent-id parent-id])
         entry))
   (hash-set! (session-index-by-id idx) (message-id fixed-entry) fixed-entry)
   (when parent-id
-    (hash-update! (session-index-children idx) parent-id (lambda (lst) (append lst (list fixed-entry)))))
+    (hash-update! (session-index-children idx)
+                  parent-id
+                  (lambda (lst) (append lst (list fixed-entry)))))
   (hash-set! (session-index-children idx) (message-id fixed-entry) '())
   (set-box! (session-index-active-leaf-id idx) (message-id fixed-entry))
   fixed-entry)
@@ -247,23 +269,26 @@
 
 (define (add-bookmark! idx entry-id label)
   (call-with-semaphore (session-index-bookmark-sem idx)
-    (lambda ()
-      (define bookmarks (session-index-bookmarks idx))
-      (define existing (find-bookmark-by-label idx label))
-      (when existing (hash-remove! bookmarks (bookmark-id existing)))
-      (define id (generate-bookmark-id))
-      (define ts (current-seconds))
-      (define bm (make-bookmark id entry-id label ts))
-      (hash-set! bookmarks id bm)
-      id)))
+                       (lambda ()
+                         (define bookmarks (session-index-bookmarks idx))
+                         (define existing (find-bookmark-by-label idx label))
+                         (when existing
+                           (hash-remove! bookmarks (bookmark-id existing)))
+                         (define id (generate-bookmark-id))
+                         (define ts (current-seconds))
+                         (define bm (make-bookmark id entry-id label ts))
+                         (hash-set! bookmarks id bm)
+                         id)))
 
 (define (remove-bookmark! idx bookmark-id)
   (call-with-semaphore (session-index-bookmark-sem idx)
-    (lambda ()
-      (define bookmarks (session-index-bookmarks idx))
-      (if (hash-has-key? bookmarks bookmark-id)
-          (begin (hash-remove! bookmarks bookmark-id) #t)
-          #f))))
+                       (lambda ()
+                         (define bookmarks (session-index-bookmarks idx))
+                         (if (hash-has-key? bookmarks bookmark-id)
+                             (begin
+                               (hash-remove! bookmarks bookmark-id)
+                               #t)
+                             #f))))
 
 (define (list-bookmarks idx)
   (hash-values (session-index-bookmarks idx)))
@@ -292,10 +317,14 @@
   (build-path dir (format "~a-bookmarks.json" name)))
 
 (define (bookmark->jsexpr bm)
-  (hasheq 'id (bookmark-id bm)
-          'entryId (bookmark-entry-id bm)
-          'label (bookmark-label bm)
-          'timestamp (bookmark-timestamp bm)))
+  (hasheq 'id
+          (bookmark-id bm)
+          'entryId
+          (bookmark-entry-id bm)
+          'label
+          (bookmark-label bm)
+          'timestamp
+          (bookmark-timestamp bm)))
 
 (define (jsexpr->bookmark h)
   (make-bookmark (hash-ref h 'id) (hash-ref h 'entryId) (hash-ref h 'label) (hash-ref h 'timestamp)))
@@ -306,8 +335,9 @@
   (define data (map bookmark->jsexpr bookmarks))
   (ensure-parent-dirs! bpath)
   (define temp-path (format "~a.tmp" bpath))
-  (call-with-output-file temp-path (lambda (out) (write-json data out)) #:mode 'text #:exists 'truncate)
-  (when (file-exists? bpath) (delete-file bpath))
+  (write-json-file temp-path data)
+  (when (file-exists? bpath)
+    (delete-file bpath))
   (rename-file-or-directory temp-path bpath))
 
 (define (load-bookmarks session-path)
@@ -317,13 +347,16 @@
     [else
      (with-handlers ([exn:fail? (lambda (e) '())])
        (define data (call-with-input-file bpath (lambda (in) (read-json in)) #:mode 'text))
-       (if (list? data) (map jsexpr->bookmark data) '()))]))
+       (if (list? data)
+           (map jsexpr->bookmark data)
+           '()))]))
 
 (define (load-index-with-bookmarks session-path index-path)
   (define idx (load-index index-path))
   (define bookmarks (load-bookmarks session-path))
   (define bm-hash (make-hash))
-  (for ([bm (in-list bookmarks)]) (hash-set! bm-hash (bookmark-id bm) bm))
+  (for ([bm (in-list bookmarks)])
+    (hash-set! bm-hash (bookmark-id bm) bm))
   (session-index (session-index-by-id idx)
                  (session-index-children idx)
                  (session-index-entry-order idx)

--- a/runtime/settings.rkt
+++ b/runtime/settings.rkt
@@ -14,6 +14,7 @@
 ;;   - Query: setting-ref (flat), setting-ref* (nested path)
 ;;   - Provider access: convenience functions for providers section
 
+(require "../util/json-helpers.rkt")
 (require racket/file
          racket/port
          racket/hash
@@ -193,7 +194,7 @@
     (if config-path
         (if (file-exists? config-path)
             (with-handlers ([exn:fail? (λ (_) (hash))])
-              (let ([result (call-with-input-file config-path (λ (in) (read-json in)))])
+              (let ([result (read-json-file config-path)])
                 (if (hash? result)
                     result
                     (hash))))

--- a/tests/test-json-helpers.rkt
+++ b/tests/test-json-helpers.rkt
@@ -1,33 +1,43 @@
-#lang racket
+#lang racket/base
 
 (require rackunit
+         racket/file
+         json
          "../util/json-helpers.rkt")
 
-;; ============================================================
-;; Test suite: util/json-helpers.rkt — ensure-hash-args
-;; ============================================================
+(define tmp-dir (make-temporary-file "json-helpers-test-~a" 'directory))
 
-(test-case "ensure-hash-args: hash input returns same hash"
-  (define h (hasheq 'a 1 'b 2))
-  (check-equal? (ensure-hash-args h) h))
+(define (tmp-path name)
+  (build-path tmp-dir name))
 
-(test-case "ensure-hash-args: valid JSON string parses to hash"
-  (define result (ensure-hash-args "{\"key\": \"val\"}"))
-  (check-true (hash? result))
-  (check-equal? (hash-ref result 'key #f) "val"))
+;; Basic read/write round-trip
+(test-case "read-json-file / write-json-file round-trip"
+  (define p (tmp-path "basic.json"))
+  (define data (hasheq 'name "test" 'value 42 'items '(1 2 3)))
+  (write-json-file p data)
+  (check-equal? (read-json-file p) data)
+  (delete-file p))
 
-(test-case "ensure-hash-args: empty string returns empty hash"
-  (define result (ensure-hash-args ""))
-  (check-true (hash? result))
-  (check-true (hash-empty? result)))
+;; write with #:exists 'replace
+(test-case "write-json-file #:exists 'replace"
+  (define p (tmp-path "replace.json"))
+  (write-json-file p (hasheq 'v 1))
+  (write-json-file p (hasheq 'v 2) #:exists 'replace)
+  (check-equal? (read-json-file p) (hasheq 'v 2))
+  (delete-file p))
 
-(test-case "ensure-hash-args: empty JSON object string returns empty hash"
-  (define result (ensure-hash-args "{}"))
-  (check-true (hash? result))
-  (check-true (hash-empty? result)))
+;; read non-existent file raises exception
+(test-case "read-json-file missing file"
+  (define p (tmp-path "nonexistent.json"))
+  (check-exn exn:fail:filesystem? (lambda () (read-json-file p))))
 
-(test-case "ensure-hash-args: invalid JSON string returns _parse_failed hash"
-  (define result (ensure-hash-args "not json"))
-  (check-true (hash? result))
-  (check-true (hash-ref result '_parse_failed #f))
-  (check-equal? (hash-ref result '_raw_args #f) "not json"))
+;; write nested structures
+(test-case "write-json-file nested structures"
+  (define p (tmp-path "nested.json"))
+  (define data (hasheq 'outer (hasheq 'inner (list (hasheq 'x 1) (hasheq 'y 2)))))
+  (write-json-file p data)
+  (check-equal? (read-json-file p) data)
+  (delete-file p))
+
+;; Cleanup
+(delete-directory/files tmp-dir)

--- a/tools/builtins/firecrawl.rkt
+++ b/tools/builtins/firecrawl.rkt
@@ -1,5 +1,6 @@
 #lang racket/base
 
+(require "../../util/json-helpers.rkt")
 (require racket/string
          racket/format
          racket/port
@@ -63,7 +64,7 @@
       (let ([cfg-path (build-path (find-system-path 'home-dir) ".q" "config.json")])
         (and (file-exists? cfg-path)
              (let ([cfg (with-handlers ([exn:fail? (lambda (_) #f)])
-                          (call-with-input-file cfg-path (lambda (port) (read-json port))))])
+                          (read-json-file cfg-path))])
                (and (hash? cfg)
                     (let ([fc (hash-ref cfg 'firecrawl #f)])
                       (and (hash? fc)

--- a/util/json-helpers.rkt
+++ b/util/json-helpers.rkt
@@ -9,8 +9,11 @@
          racket/string
          json)
 
-(provide ;; JSON argument normalization
- ensure-hash-args)
+;; JSON argument normalization
+(provide ensure-hash-args
+         ;; JSON file I/O
+         read-json-file
+         write-json-file)
 
 ;; Parse tool-call arguments from string to hash if needed.
 ;; Streaming produces arguments as JSON strings; tools expect hashes.
@@ -21,16 +24,23 @@
      (define cleaned (string-trim args))
      (if (or (string=? cleaned "") (string=? cleaned "{}"))
          (hash)
-         (with-handlers ([exn:fail? (lambda (e)
-                                       (fprintf (current-error-port)
-                                                "warning: ensure-hash-args: failed to parse JSON args: ~a~n"
-                                                args)
-                                       (hasheq '_parse_failed #t
-                                               '_raw_args args))])
+         (with-handlers ([exn:fail?
+                          (lambda (e)
+                            (fprintf (current-error-port)
+                                     "warning: ensure-hash-args: failed to parse JSON args: ~a~n"
+                                     args)
+                            (hasheq '_parse_failed #t '_raw_args args))])
            (define parsed (string->jsexpr cleaned))
            (if (hash? parsed)
                parsed
-               (hasheq '_parse_failed #t
-                       '_raw_args args))))]
-    [else (hasheq '_parse_failed #t
-                  '_raw_args (format "~a" args))]))
+               (hasheq '_parse_failed #t '_raw_args args))))]
+    [else (hasheq '_parse_failed #t '_raw_args (format "~a" args))]))
+
+;; Read and parse a JSON file, returning the parsed value.
+(define (read-json-file path)
+  (call-with-input-file path (lambda (in) (read-json in)) #:mode 'text))
+
+;; Write a value as JSON to a file.
+;; #:exists controls the file-exists behavior (default 'truncate).
+(define (write-json-file path data #:exists [mode 'truncate])
+  (call-with-output-file path (lambda (out) (write-json data out)) #:mode 'text #:exists mode))


### PR DESCRIPTION
Addresses #2955.

feat: JSON file I/O helpers + adopt across 10 files (#2955)

v0.28.0 W0 — JSON File I/O Helpers (Finding A1).

Add read-json-file and write-json-file to existing util/json-helpers.rkt.
Replace raw call-with-input-file/read-json and call-with-output-file/write-json
patterns across 10 source files: runtime/auth-store, runtime/credential-backend,
runtime/extension-catalog, runtime/oauth, runtime/settings, runtime/session-index/mutations,
extensions/quarantine, extensions/github/handlers/milestone-ops, pkg/registry,
tools/builtins/firecrawl.

Gate criterion: 3+ repetitions (34 occurrences across codebase).
Tests: test-json-helpers 4/4, all consumer tests pass.