### PR TITLE
feat: semaphore guard HOFs for registry, event-bus, GSD state (#2961)

v0.28.0 W2 — Semaphore Guard HOFs (Findings A2–A5).

Add thread-safe lock helpers:
- with-registry-lock in tools/tool.rkt (7 call sites → HOF)
- with-event-bus-lock + with-circuit-breaker-lock in agent/event-bus.rkt (6 call sites → HOFs)
- with-gsd-lock in extensions/gsd/session-state.rkt (3 call sites in state-machine.rkt → HOF)

Note: Finding A6 (provider-registry) already has with-lock — no change needed.

Gate criterion: 3+ repetitions per pattern (7, 6, 3).
Tests: event-bus, gsd-state-machine, gsd-core, registry-defaults all pass.

### DIFF
--- a/agent/event-bus.rkt
+++ b/agent/event-bus.rkt
@@ -73,26 +73,24 @@
   (define threshold (current-circuit-breaker-threshold))
   (if (not threshold)
       #f
-      (call-with-semaphore circuit-breaker-semaphore
-                           (lambda ()
-                             (let ([entry (hash-ref (circuit-breaker-state) sub-id #f)])
-                               (and entry
-                                    (>= (car entry) threshold)
-                                    (let ([cooldown (current-circuit-breaker-cooldown-secs)])
-                                      (if (and cooldown
-                                               (> (- (current-seconds) (cdr entry)) cooldown))
-                                          (begin
-                                            ;; Cooldown elapsed, reset
-                                            (hash-remove! (circuit-breaker-state) sub-id)
-                                            #f)
-                                          #t))))))))
+      (with-circuit-breaker-lock (lambda ()
+                                   (let ([entry (hash-ref (circuit-breaker-state) sub-id #f)])
+                                     (and entry
+                                          (>= (car entry) threshold)
+                                          (let ([cooldown (current-circuit-breaker-cooldown-secs)])
+                                            (if (and cooldown
+                                                     (> (- (current-seconds) (cdr entry)) cooldown))
+                                                (begin
+                                                  ;; Cooldown elapsed, reset
+                                                  (hash-remove! (circuit-breaker-state) sub-id)
+                                                  #f)
+                                                #t))))))))
 
 ;; Record a failure for a subscriber (thread-safe)
 (define (record-failure! sub-id)
   (define threshold (current-circuit-breaker-threshold))
   (when threshold
-    (call-with-semaphore
-     circuit-breaker-semaphore
+    (with-circuit-breaker-lock
      (lambda ()
        (define state (circuit-breaker-state))
        (define entry (hash-ref state sub-id (cons 0 0)))
@@ -105,11 +103,10 @@
 
 ;; Reset failure count on success (thread-safe)
 (define (record-success! sub-id)
-  (call-with-semaphore circuit-breaker-semaphore
-                       (lambda ()
-                         (define state (circuit-breaker-state))
-                         (when (hash-has-key? state sub-id)
-                           (hash-remove! state sub-id)))))
+  (with-circuit-breaker-lock (lambda ()
+                               (define state (circuit-breaker-state))
+                               (when (hash-has-key? state sub-id)
+                                 (hash-remove! state sub-id)))))
 
 ;; ============================================================
 ;; Internal subscription record
@@ -131,12 +128,20 @@
 (define (make-event-bus)
   (make-event-bus-internal (box '()) (make-semaphore 1) (box 0) (make-hash)))
 
+;; Thread-safe event bus lock helper (Finding A3)
+(define (with-event-bus-lock bus thunk)
+  (call-with-semaphore (event-bus-semaphore bus) thunk))
+
+;; Thread-safe circuit-breaker lock helper (Finding A5)
+(define (with-circuit-breaker-lock thunk)
+  (call-with-semaphore circuit-breaker-semaphore thunk))
+
 ;; ============================================================
 ;; subscribe! : event-bus? handler [#:filter pred] -> exact-nonnegative-integer?
 ;; ============================================================
 
 (define (subscribe! bus handler #:filter [filter #f])
-  (call-with-semaphore (event-bus-semaphore bus)
+  (with-event-bus-lock bus
                        (lambda ()
                          (define id (unbox (event-bus-next-id-box bus)))
                          (set-box! (event-bus-next-id-box bus) (add1 id))
@@ -150,7 +155,7 @@
 ;; ============================================================
 
 (define (unsubscribe! bus sub-id)
-  (call-with-semaphore (event-bus-semaphore bus)
+  (with-event-bus-lock bus
                        (lambda ()
                          (set-box! (event-bus-subscriptions-box bus)
                                    (filter (lambda (s) (not (= (subscription-id s) sub-id)))
@@ -162,8 +167,7 @@
 
 (define (publish! bus evt)
   (define subs
-    (call-with-semaphore (event-bus-semaphore bus)
-                         (lambda () (reverse (unbox (event-bus-subscriptions-box bus))))))
+    (with-event-bus-lock bus (lambda () (reverse (unbox (event-bus-subscriptions-box bus))))))
   (parameterize ([circuit-breaker-state (event-bus-breaker-state bus)])
     (define err-handler (current-event-bus-error-handler))
     (for ([s (in-list subs)])

--- a/extensions/gsd/session-state.rkt
+++ b/extensions/gsd/session-state.rkt
@@ -39,6 +39,10 @@
 ;; Semaphore for atomic state transitions
 (define gsd-state-sem (make-semaphore 1))
 
+;; Thread-safe GSD state lock helper (Finding A4)
+(define (with-gsd-lock thunk)
+  (call-with-semaphore gsd-state-sem thunk))
+
 ;; ============================================================
 ;; Parameter-compatible accessors (readers)
 ;; ============================================================
@@ -90,18 +94,16 @@
 ;; ============================================================
 
 (define (gsd-state-snapshot)
-  (call-with-semaphore gsd-state-sem (lambda () (unbox gsd-state-box))))
+  (with-gsd-lock (lambda () (unbox gsd-state-box))))
 
 (define (gsd-state-update! update-thunk)
-  (call-with-semaphore gsd-state-sem
-                       (lambda () (set-box! gsd-state-box (update-thunk (unbox gsd-state-box))))))
+  (with-gsd-lock (lambda () (set-box! gsd-state-box (update-thunk (unbox gsd-state-box))))))
 
 (define (gsd-history-snapshot)
-  (call-with-semaphore gsd-state-sem (lambda () (reverse (unbox gsd-history-box)))))
+  (with-gsd-lock (lambda () (reverse (unbox gsd-history-box)))))
 
 (define (gsd-history-update! update-thunk)
-  (call-with-semaphore gsd-state-sem
-                       (lambda () (set-box! gsd-history-box (update-thunk (unbox gsd-history-box))))))
+  (with-gsd-lock (lambda () (set-box! gsd-history-box (update-thunk (unbox gsd-history-box))))))
 
 ;; ============================================================
 ;; Provide
@@ -126,4 +128,5 @@
          gsd-state-snapshot
          gsd-state-update!
          gsd-history-snapshot
-         gsd-history-update!)
+         gsd-history-update!
+         with-gsd-lock)

--- a/extensions/gsd/state-machine.rkt
+++ b/extensions/gsd/state-machine.rkt
@@ -27,7 +27,8 @@
                   gsd-state-snapshot
                   gsd-state-update!
                   gsd-state-sem
-                  gsd-history-snapshot))
+                  gsd-history-snapshot
+                  with-gsd-lock))
 
 ;; States
 (provide gsm-state?
@@ -120,8 +121,7 @@
   (gsd-history-snapshot))
 
 (define (gsm-transition! target)
-  (call-with-semaphore
-   gsd-state-sem
+  (with-gsd-lock
    (lambda ()
      (define state (current-gsd-state))
      (define current (gsd-runtime-state-mode state))
@@ -148,8 +148,7 @@
          target)]))))
 
 (define (gsm-reset!)
-  (call-with-semaphore
-   gsd-state-sem
+  (with-gsd-lock
    (lambda ()
      (define old (gsd-runtime-state-mode (current-gsd-state)))
      (set-gsd-state!
@@ -158,11 +157,10 @@
      (ok-result old 'idle))))
 
 (define (reset-gsm!)
-  (call-with-semaphore gsd-state-sem
-                       (lambda ()
-                         (set-gsd-state! (make-initial-gsd-state))
-                         (set-gsd-history! '())
-                         (void))))
+  (with-gsd-lock (lambda ()
+                   (set-gsd-state! (make-initial-gsd-state))
+                   (set-gsd-history! '())
+                   (void))))
 
 (define (gsm-valid-next-states)
   (define current (gsm-current))

--- a/tools/tool.rkt
+++ b/tools/tool.rkt
@@ -121,7 +121,7 @@
 ;; Tools should call this to report incremental progress.
 (define (emit-progress! ctx percentage message)
   (define cb (exec-context-progress-callback ctx))
-         exec-context-permission-config
+  exec-context-permission-config
   (when cb
     (cb percentage message)))
 
@@ -304,21 +304,23 @@
 (define (make-tool-registry)
   (tool-registry (make-hash) (box #f) (make-semaphore 1)))
 
+;; Thread-safe registry lock helper (Finding A2: 7 call sites)
+(define (with-registry-lock reg thunk)
+  (call-with-semaphore (tool-registry-sem reg) thunk))
+
 (define (register-tool! reg t)
   (unless (tool? t)
     (raise-argument-error 'register-tool! "tool?" t))
-  (call-with-semaphore (tool-registry-sem reg)
-                       (lambda ()
-                         (define tbl (tool-registry-tools-box reg))
-                         (hash-set! tbl (tool-name t) t))))
+  (with-registry-lock reg
+                      (lambda ()
+                        (define tbl (tool-registry-tools-box reg))
+                        (hash-set! tbl (tool-name t) t))))
 
 (define (unregister-tool! reg name)
-  (call-with-semaphore (tool-registry-sem reg)
-                       (lambda () (hash-remove! (tool-registry-tools-box reg) name))))
+  (with-registry-lock reg (lambda () (hash-remove! (tool-registry-tools-box reg) name))))
 
 (define (lookup-tool reg name)
-  (call-with-semaphore (tool-registry-sem reg)
-                       (lambda () (hash-ref (tool-registry-tools-box reg) name #f))))
+  (with-registry-lock reg (lambda () (hash-ref (tool-registry-tools-box reg) name #f))))
 
 ;; tool->jsexpr : tool? -> hash?
 ;; Serialize a tool struct to the OpenAI normalized format.
@@ -343,10 +345,10 @@
 ;; Set which tools are active. #f means all tools are active.
 ;; active-names is (or/c #f (listof string?))
 (define (set-active-tools! reg active-names)
-  (call-with-semaphore (tool-registry-sem reg)
-                       (lambda ()
-                         (set-box! (tool-registry-active-set-box reg)
-                                   (and active-names (list->set active-names))))))
+  (with-registry-lock reg
+                      (lambda ()
+                        (set-box! (tool-registry-active-set-box reg)
+                                  (and active-names (list->set active-names))))))
 
 ;; Check if a tool is active.
 (define (tool-active? reg name)
@@ -355,10 +357,10 @@
 
 ;; List only active tools.
 (define (list-active-tools reg)
-  (call-with-semaphore (tool-registry-sem reg)
-                       (lambda ()
-                         (filter (lambda (t) (tool-active? reg (tool-name t)))
-                                 (hash-values (tool-registry-tools-box reg))))))
+  (with-registry-lock reg
+                      (lambda ()
+                        (filter (lambda (t) (tool-active? reg (tool-name t)))
+                                (hash-values (tool-registry-tools-box reg))))))
 
 ;; List active tools in jsexpr format.
 (define (list-active-tools-jsexpr reg)
@@ -369,11 +371,10 @@
   (map tool->jsexpr (list-active-tools reg)))
 
 (define (list-tools reg)
-  (call-with-semaphore (tool-registry-sem reg)
-                       (lambda () (hash-values (tool-registry-tools-box reg)))))
+  (with-registry-lock reg (lambda () (hash-values (tool-registry-tools-box reg)))))
 
 (define (tool-names reg)
-  (call-with-semaphore (tool-registry-sem reg) (lambda () (hash-keys (tool-registry-tools-box reg)))))
+  (with-registry-lock reg (lambda () (hash-keys (tool-registry-tools-box reg)))))
 
 ;; ============================================================
 ;; Tool-call argument validation (for post-processing)


### PR DESCRIPTION
Addresses #2961.

feat: semaphore guard HOFs for registry, event-bus, GSD state (#2961)

v0.28.0 W2 — Semaphore Guard HOFs (Findings A2–A5).

Add thread-safe lock helpers:
- with-registry-lock in tools/tool.rkt (7 call sites → HOF)
- with-event-bus-lock + with-circuit-breaker-lock in agent/event-bus.rkt (6 call sites → HOFs)
- with-gsd-lock in extensions/gsd/session-state.rkt (3 call sites in state-machine.rkt → HOF)

Note: Finding A6 (provider-registry) already has with-lock — no change needed.

Gate criterion: 3+ repetitions per pattern (7, 6, 3).
Tests: event-bus, gsd-state-machine, gsd-core, registry-defaults all pass.