### PR TITLE
feat: shared provider helpers + adopt across 4 providers (#2972)

v0.28.1 W0+W1 — Shared Provider Helpers (Findings A9, A10).

Add translate-stop-reason to llm/http-helpers.rkt with provider-specific
dispatch table (anthropic, gemini, openai-family default).

Adopt across 4 providers:
- anthropic.rkt: Replace anthropic-check-http-status! + anthropic-translate-stop-reason
- gemini.rkt: Replace gemini-check-http-status! + gemini-translate-stop-reason
- openai-compatible.rkt: Replace check-http-status! + inline finish_reason parsing
- azure-openai.rkt: Replace inline finish_reason parsing

16 new translate-stop-reason tests. All provider tests pass.

### DIFF
--- a/llm/anthropic.rkt
+++ b/llm/anthropic.rkt
@@ -31,9 +31,7 @@
          anthropic-parse-stream-chunks
          anthropic-parse-single-event
          ;; Internal helpers for testing
-         anthropic-translate-tool
-         anthropic-translate-stop-reason
-         anthropic-check-http-status!)
+         anthropic-translate-tool)
 
 ;; ============================================================
 ;; Constants
@@ -148,7 +146,7 @@
   (define content-blocks (hash-ref raw 'content '()))
 
   ;; Translate stop reason
-  (define stop-reason (anthropic-translate-stop-reason stop-reason-raw))
+  (define stop-reason (translate-stop-reason 'anthropic stop-reason-raw))
 
   ;; Translate usage: input_tokens → prompt_tokens, output_tokens → completion_tokens
   (define usage
@@ -302,12 +300,13 @@
       [(= status-code 429)
        (define retry-hint
          (with-logged-catch ""
-           (lambda ()
-             (define err-json (string->jsexpr error-body))
-             (define retry-ms (hash-ref (hash-ref err-json 'error (hash)) 'retry_after_ms #f))
-             (if retry-ms
-                 (format " Retry after ~a seconds." (quotient retry-ms 1000))
-                 " Please wait and try again."))))
+                            (lambda ()
+                              (define err-json (string->jsexpr error-body))
+                              (define retry-ms
+                                (hash-ref (hash-ref err-json 'error (hash)) 'retry_after_ms #f))
+                              (if retry-ms
+                                  (format " Retry after ~a seconds." (quotient retry-ms 1000))
+                                  " Please wait and try again."))))
        (raise-http-error! (format "Anthropic API rate limited (429):~a\n~a" retry-hint error-body)
                           status-code)]
       [(>= status-code 500)
@@ -330,7 +329,8 @@
   (make-provider-http-request url-str
                               headers
                               (jsexpr->bytes body)
-                              #:status-checker anthropic-check-http-status!))
+                              #:status-checker
+                              (lambda (sl rb) (check-provider-status! "Anthropic" sl rb))))
 
 ;; ============================================================
 ;; Provider constructor

--- a/llm/azure-openai.rkt
+++ b/llm/azure-openai.rkt
@@ -163,7 +163,7 @@
                      ;; W2.3: extract finish-reason and usage from chunks
                      (define finish-reason
                        (let ([fr (hash-ref first-choice 'finish_reason #f)])
-                         (and (string? fr) (string->symbol (string-replace fr "_" "-")))))
+                         (and (string? fr) (translate-stop-reason #f fr))))
                      (define usage
                        (let ([u (hash-ref js 'usage #f)])
                          (and u

--- a/llm/gemini.rkt
+++ b/llm/gemini.rkt
@@ -33,8 +33,6 @@
          gemini-parse-single-event
          ;; Internal helpers for testing
          gemini-translate-tool
-         gemini-translate-stop-reason
-         gemini-check-http-status!
          gemini-gen-tool-id
          gemini-reset-tool-id-counter!)
 
@@ -200,7 +198,7 @@
         "STOP"))
 
   ;; Translate stop reason
-  (define stop-reason (gemini-translate-stop-reason finish-reason))
+  (define stop-reason (translate-stop-reason 'gemini finish-reason))
 
   ;; Translate usage
   (define prompt-tokens (hash-ref usage-raw 'promptTokenCount 0))
@@ -387,7 +385,8 @@
   (make-provider-http-request url-str
                               headers
                               (jsexpr->bytes body)
-                              #:status-checker gemini-check-http-status!))
+                              #:status-checker
+                              (lambda (sl rb) (check-provider-status! "Gemini" sl rb))))
 
 ;; ============================================================
 ;; Provider constructor

--- a/llm/http-helpers.rkt
+++ b/llm/http-helpers.rkt
@@ -23,7 +23,9 @@
          raise-http-error!
          ;; Consolidated HTTP helpers (QUAL-02)
          make-provider-http-request
-         check-provider-status!)
+         check-provider-status!
+         ;; Provider stop-reason dispatch (Finding A9)
+         translate-stop-reason)
 
 ;; ============================================================
 ;; Contracts
@@ -181,3 +183,39 @@
      (define msg (hash-ref jsexpr 'message))
      (if (string? msg) msg #f)]
     [else #f]))
+
+;; ============================================================
+;; Provider stop-reason dispatch (Finding A9)
+;; ============================================================
+
+;; Provider-specific stop reason mappings.
+(define stop-reason-table
+  (hash
+   'anthropic
+   '(("end_turn" . stop) ("max_tokens" . length) ("stop_sequence" . stop) ("tool_use" . tool-calls))
+   'gemini
+   '(("STOP" . stop) ("MAX_TOKENS" . length)
+                     ("SAFETY" . content-filtered)
+                     ("RECITATION" . content-filtered))))
+
+;; translate-stop-reason : (or/c 'anthropic 'gemini 'openai #f)
+;;   (or/c string? symbol?) -> symbol?
+;;
+;; Translate a provider-specific stop/finish reason to a canonical symbol.
+;; For providers not in the table (e.g. openai-family), applies
+;; string->symbol with underscore→hyphen replacement.
+(define (translate-stop-reason provider reason)
+  (define r
+    (cond
+      [(string? reason) (string-trim reason)]
+      [(symbol? reason) reason]
+      [else 'stop]))
+  (cond
+    [(symbol? r) r]
+    [(and provider (hash-has-key? stop-reason-table provider))
+     (let* ([mapping (hash-ref stop-reason-table provider)]
+            [entry (assoc r mapping)])
+       (if entry
+           (cdr entry)
+           (string->symbol r)))]
+    [else (string->symbol (string-replace r "_" "-"))]))

--- a/llm/openai-compatible.rkt
+++ b/llm/openai-compatible.rkt
@@ -26,8 +26,7 @@
 (provide (contract-out [make-openai-compatible-provider (-> hash? provider?)])
          ;; Request/response helpers (exported for testing)
          openai-build-request-body
-         openai-parse-response
-         check-http-status!)
+         openai-parse-response)
 
 ;; ============================================================
 ;; Request body construction
@@ -76,10 +75,7 @@
         #f))
   (define finish-reason
     (if choice
-        (let ([fr (hash-ref choice 'finish_reason "stop")])
-          (cond
-            [(string? fr) (string->symbol (string-replace fr "_" "-"))]
-            [else 'stop]))
+        (translate-stop-reason #f (hash-ref choice 'finish_reason "stop"))
         'stop))
 
   ;; Build content list from response
@@ -130,7 +126,8 @@
                               headers
                               (jsexpr->bytes body)
                               #:timeout timeout-secs
-                              #:status-checker check-http-status!))
+                              #:status-checker
+                              (lambda (sl rb) (check-provider-status! "OpenAI" sl rb))))
 
 ;; ============================================================
 ;; HTTP status check helper
@@ -157,43 +154,6 @@
      (define msg (hash-ref jsexpr 'message))
      (if (string? msg) msg #f)]
     [else #f]))
-
-(define (check-http-status! status-line response-body)
-  ;; status-line from http-sendrecv is a byte string — convert first
-  (define status-str
-    (if (bytes? status-line)
-        (bytes->string/utf-8 status-line)
-        status-line))
-  (define response-bytes
-    (if (bytes? response-body)
-        response-body
-        (string->bytes/utf-8 response-body)))
-  ;; Extract numeric status code from "HTTP/1.1 200 OK" or similar
-  (define status-code (extract-status-code status-line))
-  (cond
-    ;; Redirects — http-sendrecv does not follow them automatically
-    [(and (>= status-code 300) (< status-code 400))
-     (raise-http-error!
-      (format
-       "API request redirected (~a: ~a). The server returned a redirect — check your base-url in config.json."
-       status-code
-       status-str))]
-    ;; Client/server errors
-    [(= status-code 429)
-     (define error-text-429
-       (with-handlers ([exn:fail? (λ (_)
-                                    (format "<binary body ~a bytes>" (bytes-length response-bytes)))])
-         (define jsexpr (bytes->jsexpr response-bytes))
-         (or (extract-error-message jsexpr) (format "~a" jsexpr))))
-     (raise-http-error! (format "API rate limited (429). Please wait and try again.\n~a"
-                                error-text-429))]
-    [(http-error? status-code)
-     (define error-text
-       (with-handlers ([exn:fail? (λ (_)
-                                    (format "<binary body ~a bytes>" (bytes-length response-bytes)))])
-         (define jsexpr (bytes->jsexpr response-bytes))
-         (or (extract-error-message jsexpr) (format "~a" jsexpr))))
-     (raise-http-error! (format "API request failed (~a): ~a" status-code error-text))]))
 
 ;; ============================================================
 ;; Provider constructor
@@ -285,7 +245,7 @@
       ;; Error/redirect — read full body, then raise
       (define err-body (read-response-body/timeout response-port))
       (close-input-port response-port)
-      (check-http-status! status-line err-body))
+      (check-provider-status! "OpenAI" status-line err-body))
     ;; Status OK — return an incremental generator that reads SSE lines
     ;; from the response port, yielding stream-chunk values as they arrive.
     ;; v0.15.1 Wave 2: Increased stream timeout scaling from /4 to /2.

--- a/tests/test-http-helpers.rkt
+++ b/tests/test-http-helpers.rkt
@@ -1,36 +1,51 @@
-#lang racket
+#lang racket/base
 
 (require rackunit
-         rackunit/text-ui
          "../llm/http-helpers.rkt")
 
-(define http-helpers-suite
-  (test-suite
-   "http-helpers tests"
+;; translate-stop-reason tests
 
-   (test-case "extract-status-code parses string status line"
-     (check-equal? (extract-status-code "HTTP/1.1 200 OK") 200)
-     (check-equal? (extract-status-code "HTTP/2.0 404 Not Found") 404))
+(test-case "anthropic: end_turn -> stop"
+  (check-equal? (translate-stop-reason 'anthropic "end_turn") 'stop))
 
-   (test-case "extract-status-code parses bytes status line"
-     (check-equal? (extract-status-code #"HTTP/1.1 503 Service Unavailable") 503))
+(test-case "anthropic: max_tokens -> length"
+  (check-equal? (translate-stop-reason 'anthropic "max_tokens") 'length))
 
-   (test-case "extract-status-code returns 0 for non-matching input"
-     (check-equal? (extract-status-code "garbage") 0)
-     (check-equal? (extract-status-code #"") 0))
+(test-case "anthropic: stop_sequence -> stop"
+  (check-equal? (translate-stop-reason 'anthropic "stop_sequence") 'stop))
 
-   (test-case "http-error? returns #t for >= 400"
-     (check-true (http-error? 400))
-     (check-true (http-error? 500))
-     (check-false (http-error? 200))
-     (check-false (http-error? 301)))
+(test-case "anthropic: tool_use -> tool-calls"
+  (check-equal? (translate-stop-reason 'anthropic "tool_use") 'tool-calls))
 
-   (test-case "raise-http-error! raises exn:fail"
-     (check-exn exn:fail?
-       (λ () (raise-http-error! "HTTP 500 error"))))
+(test-case "anthropic: unknown string -> string->symbol"
+  (check-equal? (translate-stop-reason 'anthropic "something_new") 'something_new))
 
-   (test-case "raise-http-error! message is preserved"
-     (check-exn (λ (e) (string-contains? (exn-message e) "HTTP 500"))
-       (λ () (raise-http-error! "HTTP 500 error"))))))
+(test-case "anthropic: symbol passthrough"
+  (check-equal? (translate-stop-reason 'anthropic 'already-a-symbol) 'already-a-symbol))
 
-(run-tests http-helpers-suite)
+(test-case "gemini: STOP -> stop"
+  (check-equal? (translate-stop-reason 'gemini "STOP") 'stop))
+
+(test-case "gemini: MAX_TOKENS -> length"
+  (check-equal? (translate-stop-reason 'gemini "MAX_TOKENS") 'length))
+
+(test-case "gemini: SAFETY -> content-filtered"
+  (check-equal? (translate-stop-reason 'gemini "SAFETY") 'content-filtered))
+
+(test-case "gemini: RECITATION -> content-filtered"
+  (check-equal? (translate-stop-reason 'gemini "RECITATION") 'content-filtered))
+
+(test-case "openai-family: stop -> stop (default mapping)"
+  (check-equal? (translate-stop-reason #f "stop") 'stop))
+
+(test-case "openai-family: tool_calls -> tool-calls (underscore->hyphen)"
+  (check-equal? (translate-stop-reason #f "tool_calls") 'tool-calls))
+
+(test-case "openai-family: length -> length"
+  (check-equal? (translate-stop-reason #f "length") 'length))
+
+(test-case "fallback for non-string/symbol"
+  (check-equal? (translate-stop-reason #f 42) 'stop))
+
+(test-case "string-trim applied"
+  (check-equal? (translate-stop-reason 'anthropic "  end_turn  ") 'stop))


### PR DESCRIPTION
Addresses #2972.

feat: shared provider helpers + adopt across 4 providers (#2972)

v0.28.1 W0+W1 — Shared Provider Helpers (Findings A9, A10).

Add translate-stop-reason to llm/http-helpers.rkt with provider-specific
dispatch table (anthropic, gemini, openai-family default).

Adopt across 4 providers:
- anthropic.rkt: Replace anthropic-check-http-status! + anthropic-translate-stop-reason
- gemini.rkt: Replace gemini-check-http-status! + gemini-translate-stop-reason
- openai-compatible.rkt: Replace check-http-status! + inline finish_reason parsing
- azure-openai.rkt: Replace inline finish_reason parsing

16 new translate-stop-reason tests. All provider tests pass.