### PR TITLE
fix(ci): use apt-get for Linux Racket install

### DIFF
--- a/.github/actions/setup-racket/action.yml
+++ b/.github/actions/setup-racket/action.yml
@@ -8,7 +8,16 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - name: Install Racket
+    - name: Install Racket (Linux via apt)
+      if: runner.os == 'Linux'
+      shell: bash
+      run: |
+        sudo apt-get update -qq
+        sudo apt-get install -y -qq racket
+        racket --version
+
+    - name: Install Racket (macOS via DeLaGuardo)
+      if: runner.os == 'macOS'
       uses: DeLaGuardo/setup-racket@v1
       with:
         racket-version: ${{ inputs.racket-version }}


### PR DESCRIPTION
The official Racket mirror (mirror.racket-lang.org) has been down for hours.

Use apt-get on Linux runners (Ubuntu 22.04 ships racket 8.10 natively).
Keep DeLaGuardo/setup-racket for macOS runners as fallback.