### PR TITLE
fix(ci): use apt-get for Linux + Bogdanp/setup-racket for macOS

### DIFF
--- a/.github/actions/setup-racket/action.yml
+++ b/.github/actions/setup-racket/action.yml
@@ -18,7 +18,7 @@ runs:
 
     - name: Install Racket (macOS via DeLaGuardo)
       if: runner.os == 'macOS'
-      uses: DeLaGuardo/setup-racket@v1
+      uses: Bogdanp/setup-racket@v1
       with:
         racket-version: ${{ inputs.racket-version }}
 


### PR DESCRIPTION
Fix CI by using apt-get on Linux (racket 8.10 from Ubuntu repos) and Bogdanp/setup-racket for macOS. The official Racket mirror has been down for hours.