### PR TITLE
fix(ci): use apt-get for Linux + Bogdanp/setup-racket v1.15

### DIFF
--- a/.github/actions/setup-racket/action.yml
+++ b/.github/actions/setup-racket/action.yml
@@ -18,7 +18,7 @@ runs:
 
     - name: Install Racket (macOS via DeLaGuardo)
       if: runner.os == 'macOS'
-      uses: Bogdanp/setup-racket@v1
+      uses: Bogdanp/setup-racket@v1.15
       with:
         racket-version: ${{ inputs.racket-version }}
 


### PR DESCRIPTION
Fix CI: apt-get for Linux runners, Bogdanp/setup-racket@v1.15 for macOS.
Racket mirror has been down for hours.