### PR TITLE
fix(ci): use apt-get for Linux Racket (verbose)

### DIFF
--- a/.github/actions/setup-racket/action.yml
+++ b/.github/actions/setup-racket/action.yml
@@ -12,9 +12,11 @@ runs:
       if: runner.os == 'Linux'
       shell: bash
       run: |
-        sudo apt-get update -qq
-        sudo apt-get install -y -qq racket racket-common
-        echo "Installed: $(racket --version)"
+        sudo apt-get update
+        sudo apt-get install -y racket racket-common
+        which racket || echo "racket not in PATH"
+        which raco || echo "raco not in PATH"
+        racket --version
         raco --version
 
     - name: Install Racket (macOS)


### PR DESCRIPTION
Debug CI failure. Verbose apt-get install of racket on Linux.