### PR TITLE
fix(ci): remove 'raco --version' that fails on Ubuntu racket

### DIFF
--- a/.github/actions/setup-racket/action.yml
+++ b/.github/actions/setup-racket/action.yml
@@ -17,7 +17,6 @@ runs:
         which racket || echo "racket not in PATH"
         which raco || echo "raco not in PATH"
         racket --version
-        raco --version
 
     - name: Install Racket (macOS)
       if: runner.os == 'macOS'


### PR DESCRIPTION
Ubuntu's racket package returns exit code 1 for `raco --version`.
Remove it since `racket --version` already verifies the install.

apt-get install of racket 8.10 works fine on ubuntu-latest.