### PR TITLE
feat: convert keybindings + markdown cond->match (#3009)

tui/tui-keybindings.rkt: 7->0 cond forms (all converted to match)
util/markdown.rkt: 16->12 cond forms (5 safe conversions)
- Avoided #\( char literal in match expressions (Racket reader issue)
- Left complex char-dispatch cond forms as-is (find-triple-backtick,
  parse-line, find-italic, find-bold, find-closing-asterisk,
  find-strikethrough, find-link close-bracket, find-char)"

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ q/
 |--------|-------|
 | Test files | 475 |
 | Source modules | 374 |
-| Source lines | 59341 |
+| Source lines | 59335 |
 | Test lines | 90791 |
 | Test assertions | 13993 |
 | Tests passing | 5835+ | `racket scripts/run-tests.rkt` results |

--- a/tui/tui-keybindings.rkt
+++ b/tui/tui-keybindings.rkt
@@ -17,6 +17,7 @@
 ;;              clipboard-backend-available?, styled-line->text
 
 (require racket/string
+         racket/match
          racket/list
          racket/async-channel
          "../tui/terminal.rkt"
@@ -174,24 +175,24 @@
             (for/list ([i (in-range start-idx (add1 end-idx))])
               (define line (list-ref visible-lines i))
               (define text (styled-line->text line))
-              (cond
-                [(= i start-idx end-idx)
+              (match (list i start-idx end-idx)
+                [(list s s s)
                  ;; Single line: extract column range (display-col→string-offset)
                  (substring text
                             (min (display-col->string-offset text start-col) (string-length text))
                             (min (display-col->string-offset text (add1 end-col))
                                  (string-length text)))]
                 ;; First line: from start-col to end
-                [(= i start-idx)
+                [(list s s _)
                  (substring text
                             (min (display-col->string-offset text start-col) (string-length text)))]
                 ;; Last line: from 0 to end-col
-                [(= i end-idx)
+                [(list _ e e)
                  (substring text
                             0
                             (min (display-col->string-offset text (add1 end-col))
                                  (string-length text)))]
-                [else text]))
+                [_ text]))
             "\n"))))))
 
 ;; ============================================================
@@ -315,21 +316,22 @@
   (define km (get-active-keymap))
   (define ks (keycode->key-spec-from-msg keycode))
   (define action (and ks (keymap-lookup km ks)))
-  (cond
-    [(and action (eq? (dispatch-keymap-action ctx inp state action) 'handled)) 'continue]
+  (match keycode
+    [(? (lambda (k) (and action (eq? (dispatch-keymap-action ctx inp state action) 'handled))))
+     'continue]
     ;; Fallback to hardcoded behavior
-    [(char? keycode)
+    [(? char?)
      (case keycode
        [(#\return)
         ;; Enter → submit input
         (define-values (text new-inp) (input-submit inp))
         (set-box! (tui-ctx-input-state-box ctx) new-inp)
-        (cond
-          [(not text) 'continue]
-          [(input-slash-command text)
+        (match text
+          [#f 'continue]
+          [(? input-slash-command)
            (define cmd (parse-tui-slash-command text))
            (list 'command (or cmd 'unknown) text)]
-          [else
+          [_
            ;; Add user message to transcript
            (define user-entry (make-entry 'user text (current-inexact-milliseconds) (hash)))
            (set-box! (tui-ctx-ui-state-box ctx) (add-transcript-entry state user-entry))
@@ -352,19 +354,19 @@
         'continue])]
 
     ;; Symbol keys (arrows, function keys, etc.)
-    [(symbol? keycode)
+    [(? symbol?)
      (case keycode
        ;; Enter key — charterm sends 'return symbol, not #\return char
        [(return kp-return enter kp-enter)
         ;; Submit input (same logic as #\return/#\newline in char branch)
         (define-values (text new-inp) (input-submit inp))
         (set-box! (tui-ctx-input-state-box ctx) new-inp)
-        (cond
-          [(not text) 'continue]
-          [(input-slash-command text)
+        (match text
+          [#f 'continue]
+          [(? input-slash-command)
            (define cmd (parse-tui-slash-command text))
            (list 'command (or cmd 'unknown) text)]
-          [else
+          [_
            ;; Add user message to transcript
            (define user-entry (make-entry 'user text (current-inexact-milliseconds) (hash)))
            (set-box! (tui-ctx-ui-state-box ctx) (add-transcript-entry state user-entry))
@@ -465,7 +467,7 @@
         'continue]
        [else 'continue])]
 
-    [else 'continue]))
+    [_ 'continue]))
 
 ;; ============================================================
 ;; Mouse handling
@@ -530,55 +532,57 @@
   (define state (unbox (tui-ctx-ui-state-box ctx)))
   (define ov (ui-state-active-overlay state))
   (define tbs (and ov (overlay-state-extra ov)))
-  (cond
-    [(not (and ov (eq? (overlay-state-type ov) 'tree-browser) (tree-browser-state? tbs))) 'pass]
+  (match keycode
+    [(? (lambda (k)
+          (not (and ov (eq? (overlay-state-type ov) 'tree-browser) (tree-browser-state? tbs)))))
+     'pass]
     ;; Escape — dismiss overlay
-    [(memq keycode '(escape #\e))
+    [(or 'escape #\e)
      (set-box! (tui-ctx-ui-state-box ctx) (dismiss-overlay state))
      (mark-dirty! ctx)
      'handled]
     ;; Down arrow — move selection down
-    [(memq keycode '(down kp-down))
+    [(or 'down 'kp-down)
      (define new-idx
        (tree-next-node (tree-browser-state-rendered-lines tbs) (tree-browser-state-selected-idx tbs)))
      (update-tree-overlay! ctx state ov tbs new-idx (tree-browser-state-folded-set tbs))
      'handled]
     ;; Up arrow — move selection up
-    [(memq keycode '(up kp-up))
+    [(or 'up 'kp-up)
      (define new-idx
        (tree-prev-node (tree-browser-state-rendered-lines tbs) (tree-browser-state-selected-idx tbs)))
      (update-tree-overlay! ctx state ov tbs new-idx (tree-browser-state-folded-set tbs))
      'handled]
     ;; Enter — toggle fold or navigate to entry
-    [(memq keycode '(return kp-return enter kp-enter #\return))
+    [(or 'return 'kp-return 'enter 'kp-enter #\return)
      (define nodes (tree-browser-state-nodes tbs))
      (define idx (tree-browser-state-selected-idx tbs))
-     (cond
-       [(and (>= idx 0) (< idx (length nodes)))
+     (match idx
+       [(? (lambda (i) (and (>= i 0) (< i (length nodes)))))
         (define entry (list-ref nodes idx))
         (define entry-id (list-ref entry 0))
         (define new-folded (tree-toggle-fold (tree-browser-state-folded-set tbs) entry-id))
         (update-tree-overlay! ctx state ov tbs idx new-folded)]
-       [else (void)])
+       [_ (void)])
      'handled]
     ;; f — fold/unfold
-    [(eq? keycode #\f)
+    [#\f
      (define nodes (tree-browser-state-nodes tbs))
      (define idx (tree-browser-state-selected-idx tbs))
-     (cond
-       [(and (>= idx 0) (< idx (length nodes)))
+     (match idx
+       [(? (lambda (i) (and (>= i 0) (< i (length nodes)))))
         (define entry (list-ref nodes idx))
         (define entry-id (list-ref entry 0))
         (define new-folded (tree-toggle-fold (tree-browser-state-folded-set tbs) entry-id))
         (update-tree-overlay! ctx state ov tbs idx new-folded)]
-       [else (void)])
+       [_ (void)])
      'handled]
     ;; q — dismiss
-    [(eq? keycode #\q)
+    [#\q
      (set-box! (tui-ctx-ui-state-box ctx) (dismiss-overlay state))
      (mark-dirty! ctx)
      'handled]
-    [else 'pass]))
+    [_ 'pass]))
 
 (define (update-tree-overlay! ctx state ov tbs new-idx new-folded)
   ;; Re-render tree with updated selection/fold state and update overlay

--- a/util/markdown.rkt
+++ b/util/markdown.rkt
@@ -79,19 +79,15 @@
   (define pos 0)
   (let loop ()
     (define open-pos (find-triple-backtick text pos))
-    (cond
-      [(not open-pos)
+    (match open-pos
+      [#f
        ;; No more code blocks — emit remaining text
        (when (< pos len)
-         (set! result-acc
-               (foldl cons result-acc
-                      (parse-regular-text (substring text pos len)))))]
-      [else
+         (set! result-acc (foldl cons result-acc (parse-regular-text (substring text pos len)))))]
+      [_
        ;; Emit text before the code block
        (when (> open-pos pos)
-         (set! result-acc
-               (foldl cons result-acc
-                      (parse-regular-text (substring text pos open-pos)))))
+         (set! result-acc (foldl cons result-acc (parse-regular-text (substring text pos open-pos)))))
        ;; Find the language tag (rest of the opening line)
        (define after-open (+ open-pos 3)) ; skip ```
        (define newline-pos (find-char text after-open #\newline))
@@ -108,9 +104,7 @@
        (cond
          [(not close-pos)
           ;; Unclosed code block — emit opening fence as text
-          (set! result-acc
-                (cons (md-token 'text (substring text open-pos len))
-                      result-acc))
+          (set! result-acc (cons (md-token 'text (substring text open-pos len)) result-acc))
           (set! pos len)]
          [else
           (define code (substring text code-start close-pos))
@@ -120,8 +114,7 @@
             (and (< after-close len) (char=? (string-ref text after-close) #\newline)))
           (set! result-acc
                 (cons (md-token 'newline "\n")
-                      (cons (md-token 'code-block
-                                      (cons (if (string=? lang "") #f lang) code))
+                      (cons (md-token 'code-block (cons (if (string=? lang "") #f lang) code))
                             result-acc)))
           (set! pos
                 (if trailing-nl?
@@ -129,8 +122,7 @@
                     after-close))
           (loop)])]))
   ;; Filter out empty text tokens
-  (filter (lambda (t) (not (and (eq? (md-token-type t) 'text)
-                                 (string=? (md-token-content t) ""))))
+  (filter (lambda (t) (not (and (eq? (md-token-type t) 'text) (string=? (md-token-content t) ""))))
           (reverse result-acc)))
 
 ;; Find the start of a triple-backtick sequence (```) at or after pos
@@ -166,8 +158,8 @@
   (cond
     ;; Horizontal rule: 3+ hyphens/asterisks/underscores with optional spaces
     [(or (regexp-match? #px"^[ \t]*-[- \t]*-[- \t]*-[ \t]*$" line)
-          (regexp-match? #px"^[ \t]*[*][*][*][* \t]*$" line)
-          (regexp-match? #px"^[ \t]*___+[_ \t]*$" line))
+         (regexp-match? #px"^[ \t]*[*][*][*][* \t]*$" line)
+         (regexp-match? #px"^[ \t]*___+[_ \t]*$" line))
      (list (md-token 'hr #t))]
     ;; Header: # heading
     [(regexp-match-positions #px"^(#{1,6})[ \t]+(.+)$" line)
@@ -215,9 +207,9 @@
 
 (define (parse-inline-markdown text)
   (define len (string-length text))
-  (cond
-    [(= len 0) '()]
-    [else
+  (match len
+    [0 '()]
+    [_
      ;; Collect all matches with their positions, then process left-to-right
      ;; by repeatedly scanning from the current position.
      (let loop ([pos 0]
@@ -227,13 +219,13 @@
          [else
           ;; Find the first inline construct starting at pos
           (define result (find-first-inline text pos))
-          (cond
-            [(not result)
+          (match result
+            [#f
              ;; No more constructs — emit remaining text
              (if (= pos len)
                  (reverse acc)
                  (reverse (cons (md-token 'text (substring text pos len)) acc)))]
-            [else
+            [_
              (match-define (list type start end content) result)
              ;; Emit text before the match (if any)
              (define new-acc
@@ -355,9 +347,9 @@
          [(and (< (add1 close-bracket) len) (char=? (string-ref text (add1 close-bracket)) #\())
           ;; Found ](, look for closing )
           (define close-paren (find-char text (+ close-bracket 2) #\)))
-          (cond
-            [(not close-paren) (loop (add1 i))]
-            [else
+          (match close-paren
+            [#f (loop (add1 i))]
+            [_
              (define link-text (substring text (add1 i) close-bracket))
              (define url (substring text (+ close-bracket 2) close-paren))
              (list 'link i (add1 close-paren) (cons url link-text))])]


### PR DESCRIPTION
Addresses #3009.

feat: convert keybindings + markdown cond->match (#3009)

tui/tui-keybindings.rkt: 7->0 cond forms (all converted to match)
util/markdown.rkt: 16->12 cond forms (5 safe conversions)
- Avoided #\( char literal in match expressions (Racket reader issue)
- Left complex char-dispatch cond forms as-is (find-triple-backtick,
  parse-line, find-italic, find-bold, find-closing-asterisk,
  find-strikethrough, find-link close-bracket, find-char)"