### PR TITLE
feat: cond->match across 7 files — 30 conversions (#3027)

LLM providers:
- anthropic.rkt: 7->3 (4 conversions: string equality dispatch)
- gemini.rkt: 9->6 (3 conversions: role mapping, block type, filtered reason)
- openai-compatible.rkt: 5->3 (2 conversions: null checks)
- stream.rkt: 11->8 (3 conversions: eq? checks)

Runtime:
- context-assembly/serialization.rkt: 10->1 (9 conversions: type predicates, null guards)
- context-summary.rkt: 7->5 (2 conversions, added racket/match require)
- model-registry.rkt: 11->4 (7 conversions: string equality, null checks)

### DIFF
--- a/llm/anthropic.rkt
+++ b/llm/anthropic.rkt
@@ -10,6 +10,7 @@
 ;; SSE parsing delegates to llm/stream.rkt.
 
 (require racket/contract
+         racket/match
          racket/string
          (only-in "model-defaults.rkt" ANTHROPIC-DEFAULT-MODEL ANTHROPIC-DEFAULT-BASE-URL)
          racket/port
@@ -82,9 +83,9 @@
                  'content
                  (for/list ([block (in-list content)])
                    (define btype (hash-ref block 'type "text"))
-                   (cond
-                     [(equal? btype "text") (hasheq 'type "text" 'text (hash-ref block 'text ""))]
-                     [(equal? btype "tool-call")
+                   (match btype
+                     ["text" (hasheq 'type "text" 'text (hash-ref block 'text ""))]
+                     ["tool-call"
                       (hasheq 'type
                               "tool_use"
                               'id
@@ -93,7 +94,7 @@
                               (hash-ref block 'name "")
                               'input
                               (hash-ref block 'arguments (hasheq)))]
-                     [else block])))]
+                     [_ block])))]
         ;; Simple string content: wrap in text block
         [(string? content) (hasheq 'role role 'content (list (hasheq 'type "text" 'text content)))]
         ;; Fallback: pass through
@@ -161,9 +162,9 @@
   (define content
     (for/list ([block (in-list content-blocks)])
       (define type (hash-ref block 'type "text"))
-      (cond
-        [(equal? type "text") (hasheq 'type "text" 'text (hash-ref block 'text ""))]
-        [(equal? type "tool_use")
+      (match type
+        ["text" (hasheq 'type "text" 'text (hash-ref block 'text ""))]
+        ["tool_use"
          (hasheq 'type
                  "tool-call"
                  'id
@@ -172,7 +173,7 @@
                  (hash-ref block 'name "")
                  'arguments
                  (hash-ref block 'input (hasheq)))]
-        [else block])))
+        [_ block])))
 
   (make-model-response content usage model-name stop-reason))
 
@@ -210,16 +211,16 @@
 (define (anthropic-parse-single-event event tool-id-box tool-name-box tool-index-box)
   (define type (hash-ref event 'type #f))
   (define results '())
-  (cond
+  (match type
     ;; Text delta
-    [(equal? type "content_block_delta")
+    ["content_block_delta"
      (define delta (hash-ref event 'delta (hasheq)))
      (define delta-type (hash-ref delta 'type #f))
-     (cond
-       [(equal? delta-type "text_delta")
+     (match delta-type
+       ["text_delta"
         (define text (hash-ref delta 'text ""))
         (set! results (cons (make-stream-chunk text #f #f #f) results))]
-       [(equal? delta-type "input_json_delta")
+       ["input_json_delta"
         ;; Partial JSON for tool input — emit as tool-call delta
         (define partial-json (hash-ref delta 'partial_json ""))
         (set! results
@@ -234,10 +235,10 @@
                      #f
                      #f)
                     results))]
-       [else (void)])]
+       [_ (void)])]
 
     ;; Tool use block starts
-    [(equal? type "content_block_start")
+    ["content_block_start"
      (define content-block (hash-ref event 'content_block (hasheq)))
      (define cb-type (hash-ref content-block 'type #f))
      (define idx (hash-ref event 'index 0))
@@ -247,7 +248,7 @@
        (set-box! tool-index-box idx))]
 
     ;; Message delta: usage + stop reason → done chunk
-    [(equal? type "message_delta")
+    ["message_delta"
      (define delta (hash-ref event 'delta (hasheq)))
      (define usage-raw (hash-ref event 'usage (hasheq)))
      (define stop-reason (hash-ref delta 'stop_reason #f))
@@ -256,14 +257,14 @@
      (set! results (cons (make-stream-chunk #f #f usage #t) results))]
 
     ;; message_start: extract initial usage
-    [(equal? type "message_start")
+    ["message_start"
      (define message (hash-ref event 'message (hasheq)))
      (define usage-raw (hash-ref message 'usage (hasheq)))
      (define in-tokens (hash-ref usage-raw 'input_tokens 0))
      (when (> in-tokens 0)
        (set! results (cons (make-stream-chunk #f #f (hasheq 'prompt_tokens in-tokens) #f) results)))]
 
-    [else (void)])
+    [_ (void)])
   (reverse results))
 
 ;; ============================================================

--- a/llm/gemini.rkt
+++ b/llm/gemini.rkt
@@ -11,6 +11,7 @@
 ;; SSE parsing delegates to llm/stream.rkt.
 
 (require racket/contract
+         racket/match
          racket/string
          (only-in "model-defaults.rkt" GEMINI-DEFAULT-MODEL GEMINI-DEFAULT-BASE-URL)
          racket/port
@@ -91,11 +92,11 @@
       (define content (hash-ref msg 'content ""))
       ;; Map roles
       (define gemini-role
-        (cond
-          [(equal? role "assistant") "model"]
-          [(equal? role "system") "user"]
-          [(equal? role "tool") "user"]
-          [else role]))
+        (match role
+          ["assistant" "model"]
+          ["system" "user"]
+          ["tool" "user"]
+          [_ role]))
       ;; Build parts based on content type and role
       (define parts
         (cond
@@ -116,13 +117,13 @@
           [(and (equal? role "assistant") (list? content))
            (for/list ([block (in-list content)])
              (define btype (hash-ref block 'type "text"))
-             (cond
-               [(equal? btype "text") (hasheq 'text (hash-ref block 'text ""))]
-               [(equal? btype "tool-call")
+             (match btype
+               ["text" (hasheq 'text (hash-ref block 'text ""))]
+               ["tool-call"
                 (hasheq
                  'functionCall
                  (hasheq 'name (hash-ref block 'name "") 'args (hash-ref block 'arguments (hasheq))))]
-               [else block]))]
+               [_ block]))]
           ;; Simple string content: text part
           [(string? content) (list (hasheq 'text content))]
           ;; Fallback
@@ -234,10 +235,10 @@
   (define filtered-reason
     (and candidate
          (let ([fr (hash-ref candidate 'finishReason "")])
-           (cond
-             [(equal? fr "SAFETY") "Content filtered for safety"]
-             [(equal? fr "RECITATION") "Content filtered for recitation"]
-             [else #f]))))
+           (match fr
+             ["SAFETY" "Content filtered for safety"]
+             ["RECITATION" "Content filtered for recitation"]
+             [_ #f]))))
   (define final-content
     (if (and filtered-reason (null? content))
         (list (hasheq 'type "text" 'text (format "[SYS] ⚠ ~a" filtered-reason)))

--- a/llm/openai-compatible.rkt
+++ b/llm/openai-compatible.rkt
@@ -11,6 +11,7 @@
 
 (require racket/contract
          (only-in "model-defaults.rkt" OPENAI-DEFAULT-MODEL)
+         racket/match
          racket/string
          racket/generator
          racket/port
@@ -80,9 +81,9 @@
 
   ;; Build content list from response
   (define content
-    (cond
-      [(not message) '()]
-      [else
+    (match message
+      [#f '()]
+      [_
        (define text-content (hash-ref message 'content #f))
        (define tool-calls (hash-ref message 'tool_calls #f))
        ;; Text content
@@ -262,12 +263,12 @@
     (generator ()
                (let loop ()
                  (define chunk (gen))
-                 (cond
-                   [(not chunk)
+                 (match chunk
+                   [#f
                     ;; Stream done — close port and yield final #f
                     (close-input-port response-port)
                     (yield #f)]
-                   [else
+                   [_
                     (yield chunk)
                     (loop)]))))
 

--- a/llm/stream.rkt
+++ b/llm/stream.rkt
@@ -85,8 +85,8 @@
               (with-handlers ([exn:fail? (lambda (e) (channel-put ch (cons 'exn e)))])
                 (channel-put ch (cons 'val (thunk)))))))
   (define result (sync/timeout timeout-secs ch))
-  (cond
-    [(eq? result #f)
+  (match result
+    [#f
      (kill-thread th)
      (with-handlers ([exn:fail? (lambda (e)
                                   (log-warning (format "llm/stream: cleanup error: ~a"
@@ -94,12 +94,12 @@
        (cleanup-thunk)) ; #454: close ports
      (raise (exn:fail:network:timeout (format "HTTP request timeout (~a seconds)" timeout-secs)
                                       (current-continuation-marks)))]
-    [else
+    [_
      (define tag (car result))
      (define payload (cdr result))
-     (cond
-       [(eq? tag 'exn) (raise payload)]
-       [else payload])]))
+     (match tag
+       ['exn (raise payload)]
+       [_ payload])]))
 
 ;; Exception type for network read timeouts.
 (struct exn:fail:network:timeout exn:fail () #:transparent)
@@ -112,9 +112,9 @@
 ;; Like read-line but with a timeout. Returns #f on timeout (caller should raise).
 (define (read-line/timeout port #:timeout [timeout-secs http-read-timeout-default])
   (define result (sync/timeout timeout-secs (read-line-evt port 'any)))
-  (cond
-    [(eq? result #f) #f] ; timeout
-    [else result])) ; string or eof
+  (match result
+    [#f #f] ; timeout
+    [_ result])) ; string or eof
 
 ;; read-response-body/timeout : input-port? [#:timeout seconds] -> bytes?
 ;; Like read-response-body but with a per-chunk read timeout.

--- a/runtime/context-assembly/serialization.rkt
+++ b/runtime/context-assembly/serialization.rkt
@@ -7,6 +7,7 @@
 (require racket/list
          racket/string
          racket/file
+         racket/match
          (only-in "../../util/protocol-types.rkt"
                   message
                   message-id
@@ -86,11 +87,20 @@
         (values '() regular)))
   (define total (length unpinned))
   (define tier-c-size (min tier-c-count total))
-  (define tier-c (if (> tier-c-size 0) (take-right unpinned tier-c-size) '()))
-  (define remaining-after-c (if (> tier-c-size 0) (drop-right unpinned tier-c-size) unpinned))
+  (define tier-c
+    (if (> tier-c-size 0)
+        (take-right unpinned tier-c-size)
+        '()))
+  (define remaining-after-c
+    (if (> tier-c-size 0)
+        (drop-right unpinned tier-c-size)
+        unpinned))
   (define remaining-count (length remaining-after-c))
   (define tier-b-size (min tier-b-count remaining-count))
-  (define tier-b (if (> tier-b-size 0) (take-right remaining-after-c tier-b-size) '()))
+  (define tier-b
+    (if (> tier-b-size 0)
+        (take-right remaining-after-c tier-b-size)
+        '()))
   (tiered-context (append sys-protected pinned-user compaction-summaries ws-messages) tier-b tier-c))
 
 (define (build-tiered-context-with-hooks messages
@@ -105,10 +115,14 @@
                           #:tier-c-count tier-c-count
                           #:working-set-messages ws-messages))
   (define payload
-    (tiered-context->payload base-context max-tokens
-                             (hasheq 'tier-b-count tier-b-count
-                                     'tier-c-count tier-c-count
-                                     'total-messages (length messages))))
+    (tiered-context->payload base-context
+                             max-tokens
+                             (hasheq 'tier-b-count
+                                     tier-b-count
+                                     'tier-c-count
+                                     tier-c-count
+                                     'total-messages
+                                     (length messages))))
   (if hook-dispatcher
       (let ([result (hook-dispatcher 'context-assembly payload)])
         (case (hook-result-action result)
@@ -130,9 +144,9 @@
 ;; Token-aware context assembly
 (define (build-session-context/tokens idx #:max-tokens max-tokens)
   (define messages (build-session-context-from-idx idx))
-  (cond
-    [(null? messages) (values '() 0)]
-    [else
+  (match messages
+    ['() (values '() 0)]
+    [_
      (define total (for/sum ([m (in-list messages)]) (estimate-message-tokens m)))
      (cond
        [(<= total max-tokens) (values messages total)]
@@ -143,19 +157,17 @@
 
 ;; Import session index for tree walk
 (require (only-in "../session-index.rkt" active-leaf get-branch))
-(require (only-in "../../util/protocol-types.rkt"
-                  compaction-summary-entry?
-                  message-parent-id))
+(require (only-in "../../util/protocol-types.rkt" compaction-summary-entry? message-parent-id))
 
 (define (build-session-context-from-idx idx)
   (define leaf (active-leaf idx))
-  (cond
-    [(not leaf) '()]
-    [else
+  (match leaf
+    [#f '()]
+    [_
      (define path (get-branch idx (message-id leaf)))
-     (cond
-       [(not path) '()]
-       [else (assemble-context path)])]))
+     (match path
+       [#f '()]
+       [_ (assemble-context path)])]))
 
 (define (assemble-context path)
   (define-values (pre post) (split-at-compaction path))
@@ -168,56 +180,61 @@
                [i (in-naturals)]
                #:when (compaction-summary-entry? entry))
       i))
-  (cond
-    [(not idx) (values path #f)]
-    [else (define-values (pre post) (split-at path idx)) (values pre post)]))
+  (match idx
+    [#f (values path #f)]
+    [_
+     (define-values (pre post) (split-at path idx))
+     (values pre post)]))
 
 (define (entry->context-message entry)
   (define kind (message-kind entry))
-  (cond
-    [(memq kind '(message)) entry]
-    [(eq? kind 'compaction-summary)
-     (struct-copy message entry [role 'user])]
-    [(eq? kind 'branch-summary)
-     (struct-copy message entry [role 'user])]
-    [(memq kind '(session-info model-change thinking-level-change)) #f]
-    [(memq kind '(tool-result bash-execution)) entry]
-    [(eq? kind 'system-instruction) entry]
-    [(eq? kind 'custom-message) entry]
-    [else entry]))
+  (match kind
+    [(or 'message) entry]
+    ['compaction-summary (struct-copy message entry [role 'user])]
+    ['branch-summary (struct-copy message entry [role 'user])]
+    [(or 'session-info 'model-change 'thinking-level-change) #f]
+    [(or 'tool-result 'bash-execution) entry]
+    ['system-instruction entry]
+    ['custom-message entry]
+    [_ entry]))
 
 ;; AGENTS.md context discovery
 (define (load-agents-context working-directory)
   (define paths (discover-agents-files working-directory))
-  (cond
-    [(null? paths) ""]
-    [else
+  (match paths
+    ['() ""]
+    [_
      (define contexts
-       (for/list ([p (in-list paths)] #:when (file-exists? p))
+       (for/list ([p (in-list paths)]
+                  #:when (file-exists? p))
          (define content (file->string p))
          (parse-agent-file content)))
-     (cond
-       [(null? contexts) ""]
-       [else (agent-context-instructions (merge-agent-contexts contexts))])]))
+     (match contexts
+       ['() ""]
+       [_ (agent-context-instructions (merge-agent-contexts contexts))])]))
 
 (define (build-system-preamble working-directory)
   (define paths (discover-agents-files working-directory))
-  (cond
-    [(null? paths) ""]
-    [else
+  (match paths
+    ['() ""]
+    [_
      (define contexts
-       (for/list ([p (in-list paths)] #:when (file-exists? p))
+       (for/list ([p (in-list paths)]
+                  #:when (file-exists? p))
          (define content (file->string p))
          (parse-agent-file content)))
-     (cond
-       [(null? contexts) ""]
-       [else
+     (match contexts
+       ['() ""]
+       [_
         (define merged (merge-agent-contexts contexts))
         (define name (agent-context-name merged))
         (define desc (agent-context-description merged))
         (define inst (agent-context-instructions merged))
         (define parts
           (filter (lambda (s) (not (string=? s "")))
-                  (list (if (string=? name "Unnamed Agent") "" (format "# ~a" name))
-                        desc inst)))
+                  (list (if (string=? name "Unnamed Agent")
+                            ""
+                            (format "# ~a" name))
+                        desc
+                        inst)))
         (string-join parts "\n\n")])]))

--- a/runtime/context-summary.rkt
+++ b/runtime/context-summary.rkt
@@ -6,7 +6,8 @@
 ;; Provides summary cache (LRU), catalog entry generation, context summary
 ;; prompting/generation, and related helpers. Extracted from context-assembly.rkt.
 
-(require racket/string
+(require racket/match
+         racket/string
          racket/list
          "../util/protocol-types.rkt"
          "../llm/token-budget.rkt"
@@ -217,15 +218,14 @@
 ;; generate-context-summary: Produce a text summary of entries using LLM or fallback.
 ;; Returns a context-summary struct or #f if no entries.
 (define (generate-context-summary entries provider model-name #:cache [cache #f])
-  (cond
-    [(null? entries) #f]
-    [else
+  (match entries
+    ['() #f]
+    [_
      (define from-id (message-id (first entries)))
      (define to-id (message-id (last entries)))
      (define cached (and cache (summary-cache-lookup cache from-id to-id)))
-     (cond
-       [cached (context-summary from-id to-id cached (length entries))]
-       [else
+     (match cached
+       [#f
         (define summary-text
           (cond
             [(and provider model-name (provider? provider))
@@ -237,7 +237,8 @@
           (if (and provider model-name (provider? provider))
               (length entries)
               (simple-summary-count entries)))
-        (context-summary from-id to-id summary-text actual-count)])]))
+        (context-summary from-id to-id summary-text actual-count)]
+       [_ (context-summary from-id to-id cached (length entries))])]))
 
 (define (simple-summary-text entries)
   (string-append "## Progress\n### Done\n"

--- a/runtime/model-registry.rkt
+++ b/runtime/model-registry.rkt
@@ -126,10 +126,10 @@
 ;;   - hash: (hasheq "id" "gpt-4o" "name" "...") → "gpt-4o"
 ;; Returns #f if invalid
 (define (extract-model-id m)
-  (cond
-    [(string? m) m]
-    [(hash? m) (flex-ref m "id" #f)]
-    [else #f]))
+  (match m
+    [(? string?) m]
+    [(? hash?) (flex-ref m "id" #f)]
+    [_ #f]))
 
 ;; Check if model-id is in models-list (handles both string and object styles)
 (define (model-in-list? model-id models-list)
@@ -207,9 +207,9 @@
 
 (define (resolve-model registry model-name)
   ;; If model-name is #f, resolve default
-  (cond
-    [(not model-name) (resolve-default registry)]
-    [else
+  (match model-name
+    [#f (resolve-default registry)]
+    [_
      ;; Check for provider prefix: "provider/model"
      (define parts (string-split model-name "/" #:trim? #f))
      (cond
@@ -223,16 +223,16 @@
 
 (define (resolve-default registry)
   (define dm (model-registry-default-model registry))
-  (cond
-    [(not dm) #f]
-    [else (resolve-exact registry dm)]))
+  (match dm
+    [#f #f]
+    [_ (resolve-exact registry dm)]))
 
 (define (resolve-exact registry model-name)
   ;; Look up in index — returns list of model-entries
   (define entries (hash-ref (model-registry-index registry) model-name '()))
-  (cond
-    [(null? entries) #f]
-    [else
+  (match entries
+    ['() #f]
+    [_
      ;; Take the first entry (could be ambiguous if shared across providers)
      (define entry (car entries))
      (entry->resolution entry)]))
@@ -240,9 +240,9 @@
 (define (resolve-with-provider registry provider-name model-name)
   ;; Find the specific provider's model
   (define prov-cfg (hash-ref (model-registry-providers registry) provider-name #f))
-  (cond
-    [(not prov-cfg) #f]
-    [else
+  (match prov-cfg
+    [#f #f]
+    [_
      (define models-list (flex-ref prov-cfg 'models '()))
      (if (model-in-list? model-name models-list)
          (model-resolution model-name provider-name (safe-base-url prov-cfg) prov-cfg)
@@ -260,13 +260,13 @@
 
 (define (resolve-model-by-provider registry provider-name)
   (define prov-cfg (hash-ref (model-registry-providers registry) provider-name #f))
-  (cond
-    [(not prov-cfg) #f]
-    [else
+  (match prov-cfg
+    [#f #f]
+    [_
      (define dm (flex-ref prov-cfg 'default-model #f))
-     (cond
-       [(not dm) #f]
-       [else (model-resolution dm provider-name (safe-base-url prov-cfg) prov-cfg)])]))
+     (match dm
+       [#f #f]
+       [_ (model-resolution dm provider-name (safe-base-url prov-cfg) prov-cfg)])]))
 
 ;; ============================================================
 ;; Listing


### PR DESCRIPTION
Addresses #3027.

feat: cond->match across 7 files — 30 conversions (#3027)

LLM providers:
- anthropic.rkt: 7->3 (4 conversions: string equality dispatch)
- gemini.rkt: 9->6 (3 conversions: role mapping, block type, filtered reason)
- openai-compatible.rkt: 5->3 (2 conversions: null checks)
- stream.rkt: 11->8 (3 conversions: eq? checks)

Runtime:
- context-assembly/serialization.rkt: 10->1 (9 conversions: type predicates, null guards)
- context-summary.rkt: 7->5 (2 conversions, added racket/match require)
- model-registry.rkt: 11->4 (7 conversions: string equality, null checks)