### PR TITLE
feat: add ui-error, extension-error, policy-error domain types (#3037)

Add 3 new error domain types to util/errors.rkt:
- ui-error: TUI rendering/input errors (component field)
- extension-error: extension lifecycle/hook violations (extension-name, hook-point)
- policy-error: GSD policy violations (policy-name, violation)

All inherit from q-error. 5 new tests (13 total pass).

### DIFF
--- a/tests/test-errors.rkt
+++ b/tests/test-errors.rkt
@@ -66,6 +66,48 @@
       (define e
         (with-handlers ([q-error? identity])
           (raise-q-error "t" (hasheq))))
-      (check-not-exn (lambda () (format "~a" e))))))
+      (check-not-exn (lambda () (format "~a" e))))
+
+    ;; ui-error has component
+    (test-case "ui-error has component"
+      (define e
+        (with-handlers ([ui-error? identity])
+          (raise-ui-error "render failed" "status-bar")))
+      (check-equal? (exn-message e) "render failed")
+      (check-equal? (ui-error-component e) "status-bar"))
+
+    ;; extension-error has extension-name and hook-point
+    (test-case "extension-error has extension-name and hook-point"
+      (define e
+        (with-handlers ([extension-error? identity])
+          (raise-extension-error "hook crashed" "github" "pre-tool-call")))
+      (check-equal? (exn-message e) "hook crashed")
+      (check-equal? (extension-error-extension-name e) "github")
+      (check-equal? (extension-error-hook-point e) "pre-tool-call"))
+
+    ;; policy-error has policy-name and violation
+    (test-case "policy-error has policy-name and violation"
+      (define e
+        (with-handlers ([policy-error? identity])
+          (raise-policy-error "budget exceeded" "tool-budget" "max-turns-10")))
+      (check-equal? (exn-message e) "budget exceeded")
+      (check-equal? (policy-error-policy-name e) "tool-budget")
+      (check-equal? (policy-error-violation e) "max-turns-10"))
+
+    ;; New error types are also exn:fail?
+    (test-case "new domain errors are exn:fail?"
+      (for ([raise-fn (list (lambda () (raise-ui-error "x" "comp"))
+                            (lambda () (raise-extension-error "x" "ext" "hook"))
+                            (lambda () (raise-policy-error "x" "pol" "viol")))])
+        (define e
+          (with-handlers ([exn:fail? identity])
+            (raise-fn)))
+        (check-pred exn:fail? e)))
+
+    ;; New errors are q-error subtypes
+    (test-case "new domain errors are q-error subtypes"
+      (check-exn q-error? (lambda () (raise-ui-error "x" "c")))
+      (check-exn q-error? (lambda () (raise-extension-error "x" "e" "h")))
+      (check-exn q-error? (lambda () (raise-policy-error "x" "p" "v"))))))
 
 (run-tests errors-tests 'verbose)

--- a/util/errors.rkt
+++ b/util/errors.rkt
@@ -14,9 +14,15 @@
 (provide (struct-out q-error)
          (struct-out tool-error)
          (struct-out session-error)
+         (struct-out ui-error)
+         (struct-out extension-error)
+         (struct-out policy-error)
          raise-q-error
          raise-tool-error
          raise-session-error
+         raise-ui-error
+         raise-extension-error
+         raise-policy-error
          ;; Quality macros (Q06/Q07)
          with-cleanup
          with-logged-catch)
@@ -33,6 +39,15 @@
 ;; Session lifecycle errors
 (struct session-error q-error (session-id) #:transparent)
 
+;; TUI rendering/input errors (recoverable, don't crash session)
+(struct ui-error q-error (component) #:transparent)
+
+;; Extension lifecycle/hook violation errors
+(struct extension-error q-error (extension-name hook-point) #:transparent)
+
+;; GSD policy violation errors (blocked tools, budget exceeded)
+(struct policy-error q-error (policy-name violation) #:transparent)
+
 ;; Convenience constructors
 (define (raise-q-error message [context (hash)])
   (raise (q-error message (current-continuation-marks) context)))
@@ -43,6 +58,15 @@
 (define (raise-session-error message session-id [context (hash)])
   (raise (session-error message (current-continuation-marks) context session-id)))
 
+(define (raise-ui-error message component [context (hash)])
+  (raise (ui-error message (current-continuation-marks) context component)))
+
+(define (raise-extension-error message extension-name hook-point [context (hash)])
+  (raise (extension-error message (current-continuation-marks) context extension-name hook-point)))
+
+(define (raise-policy-error message policy-name violation [context (hash)])
+  (raise (policy-error message (current-continuation-marks) context policy-name violation)))
+
 ;; ============================================================
 ;; Quality macros (Q06/Q07)
 ;; ============================================================
@@ -50,18 +74,17 @@
 ;; with-cleanup: Ensure cleanup runs regardless of success/failure.
 ;; (with-cleanup cleanup-expr body-expr ...)
 (define-syntax-rule (with-cleanup cleanup body ...)
-  (dynamic-wind
-    (lambda () (void))
-    (lambda () body ...)
-    (lambda () cleanup)))
+  (dynamic-wind (lambda () (void))
+                (lambda ()
+                  body ...)
+                (lambda () cleanup)))
 
 ;; with-logged-catch: Like with-handlers but logs the exception before
 ;; returning the fallback value. Prevents silent failures.
 ;; Usage: (with-logged-catch fallback thunk)
 ;; where thunk is a (lambda () ...)
 (define (with-logged-catch fallback thunk)
-  (with-handlers ([exn:fail?
-                   (lambda (e)
-                     (log-warning "with-logged-catch: caught ~a" (exn-message e))
-                     fallback)])
+  (with-handlers ([exn:fail? (lambda (e)
+                               (log-warning "with-logged-catch: caught ~a" (exn-message e))
+                               fallback)])
     (thunk)))


### PR DESCRIPTION
Addresses #3037.

feat: add ui-error, extension-error, policy-error domain types (#3037)

Add 3 new error domain types to util/errors.rkt:
- ui-error: TUI rendering/input errors (component field)
- extension-error: extension lifecycle/hook violations (extension-name, hook-point)
- policy-error: GSD policy violations (policy-name, violation)

All inherit from q-error. 5 new tests (13 total pass).