### PR TITLE
feat: add with-telemetry effect policy wrapper (#3038)

- Add with-telemetry macro to util/error-helpers.rkt
  - Times operation, logs [telemetry] op completed in X.X ms
  - Returns body result unchanged, errors propagate
- Instrument compact-and-persist! in runtime/compactor.rkt
- Instrument dispatch-iteration call in runtime/session-lifecycle.rkt
- 4 new tests for with-telemetry (success, complex value, error propagation, let body)

### DIFF
--- a/runtime/compactor.rkt
+++ b/runtime/compactor.rkt
@@ -25,6 +25,7 @@
          racket/set
          "../util/protocol-types.rkt"
          "../util/message-helpers.rkt"
+         (only-in "../util/error-helpers.rkt" with-telemetry)
          "../runtime/session-store.rkt"
          (only-in "../runtime/compaction-prompts.rkt"
                   summary-prompt
@@ -421,16 +422,16 @@
                               #:previous-summary [prev-summary #f]
                               #:hook-dispatcher [hook-dispatcher #f]
                               #:token-config [token-config (default-token-compaction-config)])
-  (define result
-    (compact-history messages
-                     #:summarize-fn summarize-fn
-                     #:provider provider
-                     #:model-name model-name
-                     #:previous-summary prev-summary
-                     #:hook-dispatcher hook-dispatcher
-                     #:token-config token-config))
-  (write-compaction-entry! session-log-path result)
-  result)
+  (with-telemetry "compact-and-persist"
+                  (let ([result (compact-history messages
+                                                 #:summarize-fn summarize-fn
+                                                 #:provider provider
+                                                 #:model-name model-name
+                                                 #:previous-summary prev-summary
+                                                 #:hook-dispatcher hook-dispatcher
+                                                 #:token-config token-config)])
+                    (write-compaction-entry! session-log-path result)
+                    result)))
 
 ;; ============================================================
 ;; write-compaction-entry!

--- a/runtime/session-lifecycle.rkt
+++ b/runtime/session-lifecycle.rkt
@@ -35,6 +35,7 @@
          "../runtime/session-index.rkt"
          (only-in "../extensions/message-inject.rkt" injection-event-topic)
          (only-in "../util/event-payloads.rkt" error-payload input-payload payload->hash)
+         (only-in "../util/error-helpers.rkt" with-telemetry)
          (only-in "../runtime/context-assembly.rkt"
                   build-assembled-context
                   context-assembly-config?
@@ -288,7 +289,9 @@
   (ensure-persisted!-fn sess)
 
   ;; 4. Run the core agent loop (model-select hook + iteration dispatch)
-  (define final-result (dispatch-iteration sess context-after-compact max-iterations))
+  (define final-result
+    (with-telemetry "dispatch-iteration"
+                    (dispatch-iteration sess context-after-compact max-iterations)))
 
   ;; 5. Rebuild index
   (set-agent-session-index! sess (build-index! log-path idx-path))

--- a/tests/test-error-helpers.rkt
+++ b/tests/test-error-helpers.rkt
@@ -34,3 +34,20 @@
 ;; with-logged-error actually logs (smoke test — just ensure no crash)
 (test-case "with-logged-error logs without crashing"
   (check-false (with-logged-error "test logging" (error "something went wrong"))))
+
+;; with-telemetry returns body value on success
+(test-case "with-telemetry returns body value on success"
+  (check-equal? (with-telemetry "test-op" (+ 1 2)) 3))
+
+;; with-telemetry returns complex value
+(test-case "with-telemetry returns complex value"
+  (define result (with-telemetry "hash-op" (hasheq 'a 1 'b 2)))
+  (check-equal? (hash-ref result 'a) 1))
+
+;; with-telemetry propagates errors (does not catch)
+(test-case "with-telemetry propagates errors"
+  (check-exn exn:fail? (lambda () (with-telemetry "failing-op" (error "boom")))))
+
+;; with-telemetry works with let binding inside
+(test-case "with-telemetry with let body"
+  (check-equal? (with-telemetry "let-op" (let ([x 10]) (+ x 5))) 15))

--- a/util/error-helpers.rkt
+++ b/util/error-helpers.rkt
@@ -8,7 +8,8 @@
 
 (require racket/logging)
 (provide with-safe-fallback
-         with-logged-error)
+         with-logged-error
+         with-telemetry)
 
 ;; with-safe-fallback — Execute body, returning DEFAULT on any exn:fail.
 ;;
@@ -28,3 +29,17 @@
                                (log-warning (format "~a: ~a" msg (exn-message e)))
                                #f)])
     body ...))
+
+;; with-telemetry — Execute body, logging operation name and elapsed time (ms).
+;; Returns the body result unchanged. Errors propagate to caller.
+;;
+;; (with-telemetry "compaction"
+;;   (expensive-operation ...))
+;; => logs "[telemetry] compaction completed in 42.3 ms"
+(define-syntax-rule (with-telemetry op-name body ...)
+  (let ([t0 (current-inexact-milliseconds)])
+    (begin0 (begin
+              body ...)
+      (log-info (format "[telemetry] ~a completed in ~a ms"
+                        op-name
+                        (real->decimal-string (- (current-inexact-milliseconds) t0) 1))))))


### PR DESCRIPTION
Addresses #3038.

feat: add with-telemetry effect policy wrapper (#3038)

- Add with-telemetry macro to util/error-helpers.rkt
  - Times operation, logs [telemetry] op completed in X.X ms
  - Returns body result unchanged, errors propagate
- Instrument compact-and-persist! in runtime/compactor.rkt
- Instrument dispatch-iteration call in runtime/session-lifecycle.rkt
- 4 new tests for with-telemetry (success, complex value, error propagation, let body)