### PR TITLE
feat: audit with-handlers void sites, migrate 4 files to domain helpers (#3039)

Migrate silent with-handlers void patterns to logged/domain-specific helpers:
- util/audit-log.rkt: log rotation → with-logged-error
- util/readline.rkt: history write → with-safe-fallback
- runtime/credential-backend.rkt: file deletion → with-logged-error
- runtime/package.rkt: cleanup (2 sites) → with-logged-error

LLM port-close and TUI cleanup sites left as-is (silent cleanup is correct).

### DIFF
--- a/util/audit-log.rkt
+++ b/util/audit-log.rkt
@@ -11,7 +11,8 @@
 (require racket/date
          racket/port
          racket/file
-         racket/path)
+         racket/path
+         (only-in "error-helpers.rkt" with-logged-error))
 
 (provide audit-log!
          with-audit-log
@@ -37,7 +38,9 @@
   (define d (current-date))
   (define (~2 n)
     (define s (number->string n))
-    (if (< n 10) (string-append "0" s) s))
+    (if (< n 10)
+        (string-append "0" s)
+        s))
   (format "~a-~a-~aT~a:~a:~a"
           (date-year d)
           (~2 (date-month d))
@@ -54,8 +57,11 @@
 ;; Appends a single audit entry to the log file.
 ;; Format: TIMESTAMP SESSION-ID ACTION PATH
 (define (audit-log! session-id action path #:log-path [log-path (audit-log-path)])
-  (define dir (let-values ([(base _name _must-be-dir?) (split-path log-path)])
-                (if (path? base) base (current-directory))))
+  (define dir
+    (let-values ([(base _name _must-be-dir?) (split-path log-path)])
+      (if (path? base)
+          base
+          (current-directory))))
   ;; Ensure directory exists
   (unless (directory-exists? dir)
     (make-directory* dir))
@@ -63,16 +69,13 @@
   (unless (file-exists? log-path)
     (close-output-port (open-output-file log-path #:exists 'truncate)))
   ;; SEC-04: Rotate log if it exceeds max size
-  (when (and (file-exists? log-path)
-             (> (file-size log-path) (current-audit-log-max-bytes)))
-    (with-handlers ([exn:fail? void])
-      (rename-file-or-directory log-path
-                                (path-replace-suffix log-path ".1")
-                                #t)))
+  (when (and (file-exists? log-path) (> (file-size log-path) (current-audit-log-max-bytes)))
+    (with-logged-error "audit-log rotation failed"
+                       (rename-file-or-directory log-path (path-replace-suffix log-path ".1") #t)))
   (call-with-output-file log-path
-    (lambda (out)
-      (fprintf out "~a ~a ~a ~a\n" (iso8601-now) session-id action path))
-    #:exists 'append))
+                         (lambda (out)
+                           (fprintf out "~a ~a ~a ~a\n" (iso8601-now) session-id action path))
+                         #:exists 'append))
 
 ;; ============================================================
 ;; Convenience wrapper


### PR DESCRIPTION
Addresses #3039.

feat: audit with-handlers void sites, migrate 4 files to domain helpers (#3039)

Migrate silent with-handlers void patterns to logged/domain-specific helpers:
- util/audit-log.rkt: log rotation → with-logged-error
- util/readline.rkt: history write → with-safe-fallback
- runtime/credential-backend.rkt: file deletion → with-logged-error
- runtime/package.rkt: cleanup (2 sites) → with-logged-error

LLM port-close and TUI cleanup sites left as-is (silent cleanup is correct).