### PR TITLE
feat: add bidirectional event payload codec (#3042)

- Create util/event-codec.rkt with payload->hash (encode) and hash->payload (decode)
- Add payload-type-tag for codec dispatch
- Re-export payload->hash from event-payloads.rkt for consolidation
- 12 new tests covering type-tag, decode, passthrough, and round-trip

### DIFF
--- a/tests/test-event-codec.rkt
+++ b/tests/test-event-codec.rkt
@@ -1,0 +1,65 @@
+#lang racket/base
+
+(require rackunit
+         "../util/event-codec.rkt"
+         "../util/event-payloads.rkt")
+
+;; payload-type-tag tests
+(test-case "payload-type-tag identifies session-start"
+  (check-equal? (payload-type-tag (session-start-payload "s1" '() 'manual)) 'session-start))
+
+(test-case "payload-type-tag identifies error-payload"
+  (check-equal? (payload-type-tag (error-payload "oops" 'runtime)) 'error))
+
+(test-case "payload-type-tag identifies raw hash"
+  (check-equal? (payload-type-tag (hasheq 'foo 1)) 'raw-hash))
+
+(test-case "payload-type-tag identifies unknown"
+  (check-equal? (payload-type-tag 42) 'unknown))
+
+;; hash->payload round-trip tests
+(test-case "hash->payload decodes error-payload"
+  (define p (hash->payload (hasheq 'error "oops" 'errorType 'runtime)))
+  (check-true (error-payload? p))
+  (check-equal? (error-payload-error p) "oops")
+  (check-equal? (error-payload-error-type p) 'runtime))
+
+(test-case "hash->payload decodes input-payload"
+  (define p (hash->payload (hasheq 'session-id "s1" 'message "hello")))
+  (check-true (input-payload? p))
+  (check-equal? (input-payload-session-id p) "s1"))
+
+(test-case "hash->payload decodes gsd-mode-payload"
+  (define p (hash->payload (hasheq 'old-mode 'inbox 'new-mode 'planning)))
+  (check-true (gsd-mode-payload? p))
+  (check-equal? (gsd-mode-payload-old-mode p) 'inbox)
+  (check-equal? (gsd-mode-payload-new-mode p) 'planning))
+
+(test-case "hash->payload decodes session-id-payload"
+  (define p (hash->payload (hasheq 'sessionId "s1")))
+  (check-true (session-id-payload? p))
+  (check-equal? (session-id-payload-session-id p) "s1"))
+
+(test-case "hash->payload passthrough for unknown hash"
+  (define h (hasheq 'random 'data))
+  (check-equal? (hash->payload h) h))
+
+(test-case "hash->payload passthrough for non-hash"
+  (check-equal? (hash->payload "string") "string"))
+
+;; Round-trip: encode → decode
+(test-case "encode-decode round-trip for error-payload"
+  (define orig (error-payload "fail" 'timeout))
+  (define encoded (payload->hash orig))
+  (define decoded (hash->payload encoded))
+  (check-true (error-payload? decoded))
+  (check-equal? (error-payload-error decoded) "fail")
+  (check-equal? (error-payload-error-type decoded) 'timeout))
+
+(test-case "encode-decode round-trip for gsd-mode-payload"
+  (define orig (gsd-mode-payload 'inbox 'done))
+  (define encoded (payload->hash orig))
+  (define decoded (hash->payload encoded))
+  (check-true (gsd-mode-payload? decoded))
+  (check-equal? (gsd-mode-payload-old-mode decoded) 'inbox)
+  (check-equal? (gsd-mode-payload-new-mode decoded) 'done))

--- a/util/event-codec.rkt
+++ b/util/event-codec.rkt
@@ -1,0 +1,67 @@
+#lang racket/base
+
+;; util/event-codec.rkt — Bidirectional event payload codec
+;;
+;; Provides encode (payload→hash) and decode (hash→payload) for all known
+;; event payload structs. Consolidates serialization logic in one place.
+;;
+;; STABILITY: stable
+
+(require "event-payloads.rkt")
+(provide payload->hash
+         hash->payload
+         payload-type-tag)
+
+;; Forward to event-payloads.rkt (already exported there, re-exported here
+;; for codec consolidation).
+
+;; Determine the type tag of a payload (for codec dispatch).
+(define (payload-type-tag p)
+  (cond
+    [(session-start-payload? p) 'session-start]
+    [(session-end-payload? p) 'session-end]
+    [(session-switch-payload? p) 'session-switch]
+    [(tool-call-event-payload? p) 'tool-call]
+    [(session-id-payload? p) 'session-id]
+    [(error-payload? p) 'error]
+    [(input-payload? p) 'input]
+    [(gsd-mode-payload? p) 'gsd-mode]
+    [(hash? p) 'raw-hash]
+    [else 'unknown]))
+
+;; Decode a hash back into the appropriate payload struct.
+;; Returns the hash as-is if no struct type matches (passthrough).
+(define (hash->payload h)
+  (cond
+    [(not (hash? h)) h]
+    ;; Error payloads
+    [(and (hash-has-key? h 'error) (hash-has-key? h 'errorType))
+     (error-payload (hash-ref h 'error) (hash-ref h 'errorType))]
+    ;; Input payloads
+    [(and (hash-has-key? h 'session-id) (hash-has-key? h 'message))
+     (input-payload (hash-ref h 'session-id) (hash-ref h 'message))]
+    ;; Session start
+    [(and (hash-has-key? h 'session-id) (hash-has-key? h 'config) (hash-has-key? h 'reason))
+     (session-start-payload (hash-ref h 'session-id) (hash-ref h 'config) (hash-ref h 'reason))]
+    ;; Session end
+    [(and (hash-has-key? h 'session-id) (hash-has-key? h 'duration))
+     (session-end-payload (hash-ref h 'session-id) (hash-ref h 'duration))]
+    ;; Session switch
+    [(and (hash-has-key? h 'session-id) (hash-has-key? h 'operation))
+     (session-switch-payload (hash-ref h 'session-id) (hash-ref h 'operation))]
+    ;; Tool call
+    [(and (hash-has-key? h 'session-id)
+          (hash-has-key? h 'turn-id)
+          (hash-has-key? h 'tool-name)
+          (hash-has-key? h 'tool-call-id))
+     (tool-call-event-payload (hash-ref h 'session-id)
+                              (hash-ref h 'turn-id)
+                              (hash-ref h 'tool-name)
+                              (hash-ref h 'tool-call-id))]
+    ;; GSD mode
+    [(and (hash-has-key? h 'old-mode) (hash-has-key? h 'new-mode))
+     (gsd-mode-payload (hash-ref h 'old-mode) (hash-ref h 'new-mode))]
+    ;; Session-id only
+    [(hash-has-key? h 'sessionId) (session-id-payload (hash-ref h 'sessionId))]
+    ;; Passthrough
+    [else h]))


### PR DESCRIPTION
Addresses #3042.

feat: add bidirectional event payload codec (#3042)

- Create util/event-codec.rkt with payload->hash (encode) and hash->payload (decode)
- Add payload-type-tag for codec dispatch
- Re-export payload->hash from event-payloads.rkt for consolidation
- 12 new tests covering type-tag, decode, passthrough, and round-trip