### PR TITLE
feat: structify subagent config + event payload codec (#3043)

- Add subagent-config struct with parse-subagent-config for typed config extraction
- Add bidirectional event payload codec (util/event-codec.rkt)
  with hash->payload decode and payload-type-tag dispatch
- 4 subagent-config tests + 12 event-codec tests

### DIFF
--- a/tests/test-subagent-config.rkt
+++ b/tests/test-subagent-config.rkt
@@ -1,0 +1,35 @@
+#lang racket/base
+
+(require rackunit
+         "../tools/builtins/spawn-subagent.rkt")
+
+;; subagent-config struct
+(test-case "subagent-config construction"
+  (define cfg (subagent-config "do stuff" "assistant" 5 #f #f))
+  (check-equal? (subagent-config-task cfg) "do stuff")
+  (check-equal? (subagent-config-role cfg) "assistant")
+  (check-equal? (subagent-config-max-turns cfg) 5)
+  (check-false (subagent-config-tools cfg))
+  (check-false (subagent-config-model cfg)))
+
+(test-case "subagent-config transparent"
+  (define cfg (subagent-config "task" "role" 3 '("read") "gpt-4"))
+  (check-equal? (subagent-config-tools cfg) '("read"))
+  (check-equal? (subagent-config-model cfg) "gpt-4"))
+
+;; parse-subagent-config
+(test-case "parse-subagent-config with all fields"
+  (define cfg
+    (parse-subagent-config
+     (hasheq 'task "hello" 'role "coder" 'max-turns 10 'tools '("read" "write") 'model "test-model")))
+  (check-equal? (subagent-config-task cfg) "hello")
+  (check-equal? (subagent-config-max-turns cfg) 10)
+  (check-equal? (subagent-config-tools cfg) '("read" "write"))
+  (check-equal? (subagent-config-model cfg) "test-model"))
+
+(test-case "parse-subagent-config with defaults"
+  (define cfg (parse-subagent-config (hasheq 'task "hello")))
+  (check-equal? (subagent-config-task cfg) "hello")
+  (check-equal? (subagent-config-max-turns cfg) 5)
+  (check-false (subagent-config-tools cfg))
+  (check-false (subagent-config-model cfg)))

--- a/tools/builtins/spawn-subagent.rkt
+++ b/tools/builtins/spawn-subagent.rkt
@@ -47,7 +47,12 @@
 
 (provide tool-spawn-subagent
          tool-spawn-subagents
-         resolve-role-prompt)
+         resolve-role-prompt
+         parse-subagent-config
+         (struct-out subagent-config))
+
+;; Subagent configuration struct — replaces ad-hoc hash extraction
+(struct subagent-config (task role max-turns tools model) #:transparent)
 
 ;; Default role prompt when no role is specified
 (define default-role-prompt
@@ -68,15 +73,35 @@
 
 ;; The spawn-subagent tool implementation
 (define (tool-spawn-subagent args [exec-ctx #f])
-  (define task (hash-ref args 'task #f))
-  (define role-arg (hash-ref args 'role default-role-prompt))
-  (define role-prompt (resolve-role-prompt role-arg))
-  (define max-turns (hash-ref args 'max-turns 5))
-  (define allowed-tools (hash-ref args 'tools #f)) ;; optional list of tool names
-
-  (if (not task)
+  (define cfg (parse-subagent-config args))
+  (if (not (subagent-config-task cfg))
       (make-error-result "task is required")
-      (run-subagent args role-prompt max-turns allowed-tools exec-ctx)))
+      (run-subagent-with-config cfg exec-ctx)))
+
+;; Parse subagent-config from tool call args hash.
+(define (parse-subagent-config args)
+  (subagent-config (hash-ref args 'task #f)
+                   (resolve-role-prompt (hash-ref args 'role default-role-prompt))
+                   (hash-ref args 'max-turns 5)
+                   (hash-ref args 'tools #f)
+                   (hash-ref args 'model #f)))
+
+;; Execute subagent using typed config struct.
+(define (run-subagent-with-config cfg exec-ctx)
+  (run-subagent (hasheq 'task
+                        (subagent-config-task cfg)
+                        'role
+                        (subagent-config-role cfg)
+                        'max-turns
+                        (subagent-config-max-turns cfg)
+                        'tools
+                        (subagent-config-tools cfg)
+                        'model
+                        (subagent-config-model cfg))
+                (subagent-config-role cfg)
+                (subagent-config-max-turns cfg)
+                (subagent-config-tools cfg)
+                exec-ctx))
 
 ;; Resolve the provider from exec-context runtime-settings.
 ;; Returns the real provider if available, or falls back to a mock.


### PR DESCRIPTION
Addresses #3043.

feat: structify subagent config + event payload codec (#3043)

- Add subagent-config struct with parse-subagent-config for typed config extraction
- Add bidirectional event payload codec (util/event-codec.rkt)
  with hash->payload decode and payload-type-tag dispatch
- 4 subagent-config tests + 12 event-codec tests