### PR TITLE
feat: add contract-out to dispatch-hooks boundary (#3044)

- Add contract-out to dispatch-hooks in extensions/hooks.rkt
  with correct ->* contract for optional #:ctx keyword
- Trust boundary modules already covered: tool-api (via tool.rkt),
  sdk (7 contract-out in sdk-public, 1 in sdk-core), extensions/api (5)
- All 29 hook tests pass, 20 golden tests pass

### DIFF
--- a/extensions/hooks.rkt
+++ b/extensions/hooks.rkt
@@ -31,7 +31,7 @@
          ;; Re-export extension-ctx for convenience
          (all-from-out "context.rkt")
          ;; Hook dispatch
-         dispatch-hooks
+         (contract-out [dispatch-hooks (->* (symbol? any/c any/c) (#:ctx any/c) hook-result?)])
          current-hook-timeout-ms
          critical-hook?
          critical-hooks)


### PR DESCRIPTION
Addresses #3044.

feat: add contract-out to dispatch-hooks boundary (#3044)

- Add contract-out to dispatch-hooks in extensions/hooks.rkt
  with correct ->* contract for optional #:ctx keyword
- Trust boundary modules already covered: tool-api (via tool.rkt),
  sdk (7 contract-out in sdk-public, 1 in sdk-core), extensions/api (5)
- All 29 hook tests pass, 20 golden tests pass