### PR TITLE
feat: add hook schema versioning with HOOK-SCHEMA-VERSION (#3047)

- Add HOOK-SCHEMA-VERSION constant (1) and hook-schema-version accessor
- Update validate-hook-result with optional schema version mismatch check
- 5 new tests for version constant, valid/invalid actions, version mismatch

### DIFF
--- a/tests/test-hook-schema-version.rkt
+++ b/tests/test-hook-schema-version.rkt
@@ -1,0 +1,23 @@
+#lang racket/base
+
+(require rackunit
+         "../util/hook-types.rkt")
+
+(test-case "HOOK-SCHEMA-VERSION is 1"
+  (check-equal? HOOK-SCHEMA-VERSION 1))
+
+(test-case "hook-schema-version returns current version"
+  (check-equal? (hook-schema-version) 1))
+
+(test-case "validate-hook-result passes for valid action"
+  (define result (hook-pass "payload"))
+  (check-true (validate-hook-result 'model-request-pre result)))
+
+(test-case "validate-hook-result fails for invalid action"
+  (define result (hook-block "payload"))
+  ;; 'turn-end only allows pass/amend
+  (check-false (validate-hook-result 'turn-end (hook-block "x"))))
+
+(test-case "validate-hook-result fails on schema version mismatch"
+  (define result (hook-pass "payload"))
+  (check-false (validate-hook-result 'model-request-pre result 999)))

--- a/util/hook-types.rkt
+++ b/util/hook-types.rkt
@@ -8,6 +8,14 @@
 ;; Each hook-point has documented expected actions and payload constraints.
 ;; Invalid results are caught early and logged as warnings.
 
+;; v0.28.8: Hook schema version
+;; Increment when hook-action-schemas structure changes.
+(define HOOK-SCHEMA-VERSION 1)
+
+;; Return current schema version.
+(define (hook-schema-version)
+  HOOK-SCHEMA-VERSION)
+
 ;; Hook result struct and action constructors
 (provide (struct-out hook-result)
          hook-pass
@@ -21,7 +29,10 @@
          ;; #1149: expose schemas for testing
          hook-action-schemas
          ;; #1210: hook name validation
-         valid-hook-name?)
+         valid-hook-name?
+         ;; v0.28.8: hook schema versioning
+         HOOK-SCHEMA-VERSION
+         hook-schema-version)
 
 (struct hook-result (action payload) #:transparent)
 
@@ -176,19 +187,24 @@
 ;; validate-hook-result : symbol? hook-result? -> boolean?
 ;; Checks whether a hook-result's action is valid for the given hook-point.
 ;; Returns #t if valid, #f if invalid. Logs a warning on invalid.
-(define (validate-hook-result hook-point result)
+(define (validate-hook-result hook-point result [expected-version HOOK-SCHEMA-VERSION])
   (define valid-actions (valid-hook-actions-for hook-point))
   (define action (hook-result-action result))
-  (if (member action valid-actions)
-      #t
-      (begin
-        (log-warning
-         (format "Hook validation: ~a returned invalid action '~a' for hook '~a. Valid: ~a"
-                 result
-                 action
-                 hook-point
-                 valid-actions))
-        #f)))
+  (cond
+    [(not (= expected-version HOOK-SCHEMA-VERSION))
+     (log-warning (format "Hook validation: schema version mismatch ~a vs ~a for hook '~a"
+                          expected-version
+                          HOOK-SCHEMA-VERSION
+                          hook-point))
+     #f]
+    [(member action valid-actions) #t]
+    [else
+     (log-warning (format "Hook validation: ~a returned invalid action '~a' for hook '~a. Valid: ~a"
+                          result
+                          action
+                          hook-point
+                          valid-actions))
+     #f]))
 
 ;; ============================================================
 ;; Hook point names (#1148)


### PR DESCRIPTION
Addresses #3047.

feat: add hook schema versioning with HOOK-SCHEMA-VERSION (#3047)

- Add HOOK-SCHEMA-VERSION constant (1) and hook-schema-version accessor
- Update validate-hook-result with optional schema version mismatch check
- 5 new tests for version constant, valid/invalid actions, version mismatch