### PR TITLE
feat: migrate GitHub handler exn:fail catches to with-error-result (#3049)

- Add with-error-result macro to 4 GitHub handler files as local definition
- Replace broad exn:fail? catches with structured error logging + result
- Files: issue-ops, pr-ops, milestone-ops, tool-handlers
- All existing tests pass

### DIFF
--- a/extensions/github/handlers/issue-ops.rkt
+++ b/extensions/github/handlers/issue-ops.rkt
@@ -17,103 +17,131 @@
 
 (provide handle-gh-issue)
 
+;; Local macro: execute body, returning error result on failure
+(define-syntax-rule (with-error-result ctx-msg body ...)
+  (with-handlers ([exn:fail? (lambda (e)
+                               (log-warning (format "~a: ~a" ctx-msg (exn-message e)))
+                               (make-error-result (exn-message e)))])
+    body ...))
+
 (define (handle-gh-issue args [exec-ctx #f])
-  (with-handlers ([exn:fail? (lambda (e) (make-error-result (exn-message e)))])
-    (cond
-      [(not (gh-binary)) (gh-unavailable-error)]
-      [else
-       (define action (hash-ref args 'action ""))
-       (cond
-         [(string=? action "") (make-error-result "Missing required argument: action")]
-         ;; create
-         [(string=? action "create")
-          (define title (hash-ref args 'title #f))
-          (cond
-            [(not title) (make-error-result "create requires 'title'")]
-            [else
-             (define body (hash-ref args 'body ""))
-             (define labels (hash-ref args 'labels '()))
-             (define label-val
-               (if (null? labels) #f (string-join labels ",")))
-             (define ms-id (hash-ref args 'milestone_id #f))
-             (apply gh-success-json
-                    (append
-                     (list "issue" "create" "--title" title "--body" body "--json" "number,title,url")
-                     (if label-val (list "--label" label-val) '())
-                     (if ms-id (list "--milestone" ms-id) '())))])]
-         ;; close
-         [(string=? action "close")
-          (define num (hash-ref args 'number #f))
-          (cond
-            [(not num) (make-error-result "close requires 'number'")]
-            [(not (valid-number? num)) (make-error-result (format "invalid number: ~a" num))]
-            [else (gh-success "issue" "close" (~a num))])]
-         ;; update
-         [(string=? action "update")
-          (define num (hash-ref args 'number #f))
-          (cond
-            [(not num) (make-error-result "update requires 'number'")]
-            [(not (valid-number? num)) (make-error-result (format "invalid number: ~a" num))]
-            [else
-             (define t (hash-ref args 'title #f))
-             (define b (hash-ref args 'body #f))
-             (apply gh-success-json
-                    (append (list "issue" "edit" (~a num) "--json" "number,title,state")
-                            (if t (list "--title" t) '())
-                            (if b (list "--body" b) '())))])]
-         ;; get
-         [(string=? action "get")
-          (define num (hash-ref args 'number #f))
-          (cond
-            [(not num) (make-error-result "get requires 'number'")]
-            [(not (valid-number? num)) (make-error-result (format "invalid number: ~a" num))]
-            [else
-             (gh-success-json "issue" "view" (~a num)
-                              "--json" "number,title,state,body,labels,milestone")])]
-         ;; list
-         [(string=? action "list")
-          (define raw-state (hash-ref args 'state "open"))
-          (unless (valid-state? raw-state)
-            (raise-user-error 'github-issues "invalid state: ~a" raw-state))
-          (define mn (hash-ref args 'milestone_number #f))
-          (apply gh-success-json
-                 (append (list "issue" "list" "--state" raw-state
-                               "--limit" "100" "--json" "number,title,state,labels")
-                         (if mn (list "--milestone" (~a mn)) '())))]
-         ;; close_tree
-         [(string=? action "close_tree")
-          (define num (hash-ref args 'number #f))
-          (cond
-            [(not num) (make-error-result "close_tree requires 'number'")]
-            [(not (valid-number? num)) (make-error-result (format "invalid number: ~a" num))]
-            [else
-             (define-values (ec-main _out-main err-main)
-               (gh-exec-result "issue" "close" (~a num)))
-             (cond
-               [(not (= ec-main 0))
-                (make-error-result
-                 (format "Failed to close #~a: ~a" num (string-trim err-main)))]
-               [else
-                (define-values (ec-view out-view _)
-                  (gh-exec-result "issue" "view" (~a num) "--json" "body" "-q" ".body"))
-                (define sub-nums
-                  (if (= ec-view 0)
-                      (map string->number
-                           (regexp-match* #px"(?:closes?|fixes?|resolves?)\\s+#(\\d+)"
-                                          (string-trim out-view)
-                                          #:match-select cadr))
-                      '()))
-                (define closed-subs
-                  (for/list ([sn sub-nums])
-                    (define-values (ec-s _out-s _err-s)
-                      (gh-exec-result "issue" "close" (~a sn)))
-                    (hasheq 'number sn 'closed (= ec-s 0))))
-                (make-success-result
-                 (list (hasheq 'type "text"
-                               'text (format "Issue #~a closed. Sub-issues: ~a"
-                                             num (jsexpr->string closed-subs)))))])])]
-         ;; unknown
-         [else
-          (make-error-result
-           (format "Unknown action: ~a. Valid: create, close, update, get, list, close_tree"
-                   action))])])))
+  (with-error-result
+   "github operation"
+   (cond
+     [(not (gh-binary)) (gh-unavailable-error)]
+     [else
+      (define action (hash-ref args 'action ""))
+      (cond
+        [(string=? action "") (make-error-result "Missing required argument: action")]
+        ;; create
+        [(string=? action "create")
+         (define title (hash-ref args 'title #f))
+         (cond
+           [(not title) (make-error-result "create requires 'title'")]
+           [else
+            (define body (hash-ref args 'body ""))
+            (define labels (hash-ref args 'labels '()))
+            (define label-val
+              (if (null? labels)
+                  #f
+                  (string-join labels ",")))
+            (define ms-id (hash-ref args 'milestone_id #f))
+            (apply gh-success-json
+                   (append
+                    (list "issue" "create" "--title" title "--body" body "--json" "number,title,url")
+                    (if label-val
+                        (list "--label" label-val)
+                        '())
+                    (if ms-id
+                        (list "--milestone" ms-id)
+                        '())))])]
+        ;; close
+        [(string=? action "close")
+         (define num (hash-ref args 'number #f))
+         (cond
+           [(not num) (make-error-result "close requires 'number'")]
+           [(not (valid-number? num)) (make-error-result (format "invalid number: ~a" num))]
+           [else (gh-success "issue" "close" (~a num))])]
+        ;; update
+        [(string=? action "update")
+         (define num (hash-ref args 'number #f))
+         (cond
+           [(not num) (make-error-result "update requires 'number'")]
+           [(not (valid-number? num)) (make-error-result (format "invalid number: ~a" num))]
+           [else
+            (define t (hash-ref args 'title #f))
+            (define b (hash-ref args 'body #f))
+            (apply gh-success-json
+                   (append (list "issue" "edit" (~a num) "--json" "number,title,state")
+                           (if t
+                               (list "--title" t)
+                               '())
+                           (if b
+                               (list "--body" b)
+                               '())))])]
+        ;; get
+        [(string=? action "get")
+         (define num (hash-ref args 'number #f))
+         (cond
+           [(not num) (make-error-result "get requires 'number'")]
+           [(not (valid-number? num)) (make-error-result (format "invalid number: ~a" num))]
+           [else
+            (gh-success-json "issue"
+                             "view"
+                             (~a num)
+                             "--json"
+                             "number,title,state,body,labels,milestone")])]
+        ;; list
+        [(string=? action "list")
+         (define raw-state (hash-ref args 'state "open"))
+         (unless (valid-state? raw-state)
+           (raise-user-error 'github-issues "invalid state: ~a" raw-state))
+         (define mn (hash-ref args 'milestone_number #f))
+         (apply gh-success-json
+                (append (list "issue"
+                              "list"
+                              "--state"
+                              raw-state
+                              "--limit"
+                              "100"
+                              "--json"
+                              "number,title,state,labels")
+                        (if mn
+                            (list "--milestone" (~a mn))
+                            '())))]
+        ;; close_tree
+        [(string=? action "close_tree")
+         (define num (hash-ref args 'number #f))
+         (cond
+           [(not num) (make-error-result "close_tree requires 'number'")]
+           [(not (valid-number? num)) (make-error-result (format "invalid number: ~a" num))]
+           [else
+            (define-values (ec-main _out-main err-main) (gh-exec-result "issue" "close" (~a num)))
+            (cond
+              [(not (= ec-main 0))
+               (make-error-result (format "Failed to close #~a: ~a" num (string-trim err-main)))]
+              [else
+               (define-values (ec-view out-view _)
+                 (gh-exec-result "issue" "view" (~a num) "--json" "body" "-q" ".body"))
+               (define sub-nums
+                 (if (= ec-view 0)
+                     (map string->number
+                          (regexp-match* #px"(?:closes?|fixes?|resolves?)\\s+#(\\d+)"
+                                         (string-trim out-view)
+                                         #:match-select cadr))
+                     '()))
+               (define closed-subs
+                 (for/list ([sn sub-nums])
+                   (define-values (ec-s _out-s _err-s) (gh-exec-result "issue" "close" (~a sn)))
+                   (hasheq 'number sn 'closed (= ec-s 0))))
+               (make-success-result (list (hasheq 'type
+                                                  "text"
+                                                  'text
+                                                  (format "Issue #~a closed. Sub-issues: ~a"
+                                                          num
+                                                          (jsexpr->string closed-subs)))))])])]
+        ;; unknown
+        [else
+         (make-error-result
+          (format "Unknown action: ~a. Valid: create, close, update, get, list, close_tree"
+                  action))])])))

--- a/extensions/github/handlers/milestone-ops.rkt
+++ b/extensions/github/handlers/milestone-ops.rkt
@@ -20,6 +20,13 @@
          handle-gh-board
          milestone-create-from-spec)
 
+;; Local macro: execute body, returning error result on failure
+(define-syntax-rule (with-error-result ctx-msg body ...)
+  (with-handlers ([exn:fail? (lambda (e)
+                               (log-warning (format "~a: ~a" ctx-msg (exn-message e)))
+                               (make-error-result (exn-message e)))])
+    body ...))
+
 ;; --- gh-milestone helpers ---
 
 (define (milestone-create-from-spec spec-file dry-run?)
@@ -79,162 +86,164 @@
 ;; --- gh-milestone ---
 
 (define (handle-gh-milestone args [exec-ctx #f])
-  (with-handlers ([exn:fail? (lambda (e) (make-error-result (exn-message e)))])
-    (cond
-      [(not (gh-binary)) (gh-unavailable-error)]
-      [else
-       (define action (hash-ref args 'action ""))
-       (cond
-         [(string=? action "") (make-error-result "Missing required argument: action")]
-         ;; create
-         [(string=? action "create")
-          (define title (hash-ref args 'title #f))
-          (cond
-            [(not title) (make-error-result "create requires 'title'")]
-            [else
-             (define desc (hash-ref args 'description ""))
-             (define due (hash-ref args 'due_on ""))
-             (apply gh-success-json
-                    (append
-                     (list "api" "repos/{owner}/{repo}/milestones" "-X" "POST" "-f" "title" title)
-                     (if (string=? desc "")
-                         '()
-                         (list "-f" "description" desc))
-                     (if (string=? due "")
-                         '()
-                         (list "-f" "due_on" due))))])]
-         ;; close
-         [(string=? action "close")
-          (define num (hash-ref args 'number #f))
-          (cond
-            [(not num) (make-error-result "close requires 'number'")]
-            [(not (valid-number? num)) (make-error-result (format "invalid number: ~a" num))]
-            [else
-             (gh-success-json "api"
-                              "repos/{owner}/{repo}/milestones"
-                              (~a num)
-                              "-X"
-                              "PATCH"
-                              "-f"
-                              "state=closed")])]
-         ;; list
-         [(string=? action "list")
-          (define state-arg (hash-ref args 'state "open"))
-          (unless (valid-state? state-arg)
-            (raise-user-error 'github-milestone "invalid state: ~a" state-arg))
-          (gh-success-json "api"
-                           (format "repos/{owner}/{repo}/milestones?state=~a" state-arg)
-                           "--paginate")]
-         ;; create_from_spec
-         [(string=? action "create_from_spec")
-          (define spec-file (hash-ref args 'spec_file #f))
-          (cond
-            [(not spec-file) (make-error-result "create_from_spec requires 'spec_file'")]
-            [else (milestone-create-from-spec spec-file (hash-ref args 'dry_run #f))])]
-         ;; unknown
-         [else
-          (make-error-result
-           (format "Unknown action: ~a. Valid: create, close, list, create_from_spec" action))])])))
+  (with-error-result
+   "github operation"
+   (cond
+     [(not (gh-binary)) (gh-unavailable-error)]
+     [else
+      (define action (hash-ref args 'action ""))
+      (cond
+        [(string=? action "") (make-error-result "Missing required argument: action")]
+        ;; create
+        [(string=? action "create")
+         (define title (hash-ref args 'title #f))
+         (cond
+           [(not title) (make-error-result "create requires 'title'")]
+           [else
+            (define desc (hash-ref args 'description ""))
+            (define due (hash-ref args 'due_on ""))
+            (apply gh-success-json
+                   (append
+                    (list "api" "repos/{owner}/{repo}/milestones" "-X" "POST" "-f" "title" title)
+                    (if (string=? desc "")
+                        '()
+                        (list "-f" "description" desc))
+                    (if (string=? due "")
+                        '()
+                        (list "-f" "due_on" due))))])]
+        ;; close
+        [(string=? action "close")
+         (define num (hash-ref args 'number #f))
+         (cond
+           [(not num) (make-error-result "close requires 'number'")]
+           [(not (valid-number? num)) (make-error-result (format "invalid number: ~a" num))]
+           [else
+            (gh-success-json "api"
+                             "repos/{owner}/{repo}/milestones"
+                             (~a num)
+                             "-X"
+                             "PATCH"
+                             "-f"
+                             "state=closed")])]
+        ;; list
+        [(string=? action "list")
+         (define state-arg (hash-ref args 'state "open"))
+         (unless (valid-state? state-arg)
+           (raise-user-error 'github-milestone "invalid state: ~a" state-arg))
+         (gh-success-json "api"
+                          (format "repos/{owner}/{repo}/milestones?state=~a" state-arg)
+                          "--paginate")]
+        ;; create_from_spec
+        [(string=? action "create_from_spec")
+         (define spec-file (hash-ref args 'spec_file #f))
+         (cond
+           [(not spec-file) (make-error-result "create_from_spec requires 'spec_file'")]
+           [else (milestone-create-from-spec spec-file (hash-ref args 'dry_run #f))])]
+        ;; unknown
+        [else
+         (make-error-result (format "Unknown action: ~a. Valid: create, close, list, create_from_spec"
+                                    action))])])))
 
 ;; --- gh-board ---
 
 (define (handle-gh-board args [exec-ctx #f])
-  (with-handlers ([exn:fail? (lambda (e) (make-error-result (exn-message e)))])
-    (cond
-      [(not (gh-binary)) (gh-unavailable-error)]
-      [else
-       (define action (hash-ref args 'action ""))
-       (cond
-         [(string=? action "") (make-error-result "Missing required argument: action")]
-         ;; status
-         [(string=? action "status")
-          (define mn (hash-ref args 'milestone_number #f))
-          (cond
-            [(not mn) (make-error-result "status requires 'milestone_number'")]
-            [else
-             (gh-success-json "issue"
+  (with-error-result
+   "github operation"
+   (cond
+     [(not (gh-binary)) (gh-unavailable-error)]
+     [else
+      (define action (hash-ref args 'action ""))
+      (cond
+        [(string=? action "") (make-error-result "Missing required argument: action")]
+        ;; status
+        [(string=? action "status")
+         (define mn (hash-ref args 'milestone_number #f))
+         (cond
+           [(not mn) (make-error-result "status requires 'milestone_number'")]
+           [else
+            (gh-success-json "issue"
+                             "list"
+                             "--milestone"
+                             (~a mn)
+                             "--state"
+                             "all"
+                             "--limit"
+                             "100"
+                             "--json"
+                             "number,title,state,labels")])]
+        ;; verify
+        [(string=? action "verify")
+         (define mn (hash-ref args 'milestone_number #f))
+         (cond
+           [(not mn) (make-error-result "verify requires 'milestone_number'")]
+           [else
+            (define-values (ec out err)
+              (gh-exec-result "issue"
                               "list"
                               "--milestone"
                               (~a mn)
                               "--state"
-                              "all"
+                              "open"
                               "--limit"
                               "100"
                               "--json"
-                              "number,title,state,labels")])]
-         ;; verify
-         [(string=? action "verify")
-          (define mn (hash-ref args 'milestone_number #f))
-          (cond
-            [(not mn) (make-error-result "verify requires 'milestone_number'")]
-            [else
-             (define-values (ec out err)
-               (gh-exec-result "issue"
-                               "list"
-                               "--milestone"
-                               (~a mn)
-                               "--state"
-                               "open"
-                               "--limit"
-                               "100"
-                               "--json"
-                               "number,title"))
-             (cond
-               [(not (= ec 0))
-                (make-error-result (format "Failed to check milestone: ~a" (string-trim err)))]
-               [else
-                (define issues (with-safe-fallback '() (string->jsexpr (string-trim out))))
-                (if (null? issues)
-                    (make-success-result
-                     (list (hasheq 'type "text" 'text (format "Milestone ~a: all issues closed" mn))))
-                    (make-success-result
-                     (list (hasheq 'type
-                                   "text"
-                                   'text
-                                   (format "Milestone ~a: ~a open issues remain:\n~a"
-                                           mn
-                                           (length issues)
-                                           (jsexpr->string issues))))))])])]
-         ;; stale / autofix
-         [(or (string=? action "stale") (string=? action "autofix"))
-          (define mn (hash-ref args 'milestone_number #f))
-          (cond
-            [(not mn) (make-error-result (format "~a requires 'milestone_number'" action))]
-            [else
-             (gh-success-json "issue"
-                              "list"
-                              "--milestone"
-                              (~a mn)
-                              "--state"
-                              "all"
-                              "--limit"
-                              "100"
-                              "--json"
-                              "number,title,state,updatedAt")])]
-         ;; batch_set
-         [(string=? action "batch_set")
-          (define nums (hash-ref args 'issue_numbers '()))
-          (cond
-            [(null? nums) (make-error-result "batch_set requires 'issue_numbers'")]
-            [else
-             (define results
-               (for/list ([n nums])
-                 (hasheq 'number n 'processed #t)))
-             (make-success-result (list (hasheq 'type
-                                                "text"
-                                                'text
-                                                (format "batch_set acknowledged for ~a issues: ~a"
-                                                        (length nums)
-                                                        (jsexpr->string results)))))])]
-         ;; reconfigure
-         [(string=? action "reconfigure")
-          (define num (hash-ref args 'issue_number #f))
-          (cond
-            [(not num) (make-error-result "reconfigure requires 'issue_number'")]
-            [(not (valid-number? num)) (make-error-result (format "invalid number: ~a" num))]
-            [else (gh-success-json "issue" "view" (~a num) "--json" "number,title,state,labels")])]
-         ;; unknown
-         [else
-          (make-error-result
-           (format "Unknown action: ~a. Valid: status, stale, autofix, verify, batch_set, reconfigure"
-                   action))])])))
+                              "number,title"))
+            (cond
+              [(not (= ec 0))
+               (make-error-result (format "Failed to check milestone: ~a" (string-trim err)))]
+              [else
+               (define issues (with-safe-fallback '() (string->jsexpr (string-trim out))))
+               (if (null? issues)
+                   (make-success-result
+                    (list (hasheq 'type "text" 'text (format "Milestone ~a: all issues closed" mn))))
+                   (make-success-result
+                    (list (hasheq 'type
+                                  "text"
+                                  'text
+                                  (format "Milestone ~a: ~a open issues remain:\n~a"
+                                          mn
+                                          (length issues)
+                                          (jsexpr->string issues))))))])])]
+        ;; stale / autofix
+        [(or (string=? action "stale") (string=? action "autofix"))
+         (define mn (hash-ref args 'milestone_number #f))
+         (cond
+           [(not mn) (make-error-result (format "~a requires 'milestone_number'" action))]
+           [else
+            (gh-success-json "issue"
+                             "list"
+                             "--milestone"
+                             (~a mn)
+                             "--state"
+                             "all"
+                             "--limit"
+                             "100"
+                             "--json"
+                             "number,title,state,updatedAt")])]
+        ;; batch_set
+        [(string=? action "batch_set")
+         (define nums (hash-ref args 'issue_numbers '()))
+         (cond
+           [(null? nums) (make-error-result "batch_set requires 'issue_numbers'")]
+           [else
+            (define results
+              (for/list ([n nums])
+                (hasheq 'number n 'processed #t)))
+            (make-success-result (list (hasheq 'type
+                                               "text"
+                                               'text
+                                               (format "batch_set acknowledged for ~a issues: ~a"
+                                                       (length nums)
+                                                       (jsexpr->string results)))))])]
+        ;; reconfigure
+        [(string=? action "reconfigure")
+         (define num (hash-ref args 'issue_number #f))
+         (cond
+           [(not num) (make-error-result "reconfigure requires 'issue_number'")]
+           [(not (valid-number? num)) (make-error-result (format "invalid number: ~a" num))]
+           [else (gh-success-json "issue" "view" (~a num) "--json" "number,title,state,labels")])]
+        ;; unknown
+        [else
+         (make-error-result
+          (format "Unknown action: ~a. Valid: status, stale, autofix, verify, batch_set, reconfigure"
+                  action))])])))

--- a/extensions/github/handlers/pr-ops.rkt
+++ b/extensions/github/handlers/pr-ops.rkt
@@ -17,50 +17,82 @@
 
 (provide handle-gh-pr)
 
+;; Local macro: execute body, returning error result on failure
+(define-syntax-rule (with-error-result ctx-msg body ...)
+  (with-handlers ([exn:fail? (lambda (e)
+                               (log-warning (format "~a: ~a" ctx-msg (exn-message e)))
+                               (make-error-result (exn-message e)))])
+    body ...))
+
 (define (handle-gh-pr args [exec-ctx #f])
-  (with-handlers ([exn:fail? (lambda (e) (make-error-result (exn-message e)))])
-    (cond
-      [(not (gh-binary)) (gh-unavailable-error)]
-      [else
-       (define action (hash-ref args 'action ""))
-       (cond
-         [(string=? action "") (make-error-result "Missing required argument: action")]
-         [(string=? action "create")
-          (define title (hash-ref args 'title #f))
-          (cond
-            [(not title) (make-error-result "create requires 'title'")]
-            [else
-             (define body (hash-ref args 'body ""))
-             (define head (hash-ref args 'head #f))
-             (define base (hash-ref args 'base "main"))
-             (apply gh-success-json
-                    (append (list "pr" "create" "--title" title "--body" body "--base" base "--json" "number,title,url")
-                            (if head (list "--head" head) '())))])]
-         [(string=? action "merge")
-          (define num (hash-ref args 'number #f))
-          (cond
-            [(not num) (make-error-result "merge requires 'number'")]
-            [(not (valid-number? num)) (make-error-result (format "invalid number: ~a" num))]
-            [else
-             (define method (hash-ref args 'method "squash"))
-             (unless (valid-method? method)
-               (raise-user-error 'github-pr "invalid merge method: ~a" method))
-             (define commit-title (hash-ref args 'commit_title #f))
-             (apply gh-success-json
-                    (append (list "pr" "merge" (~a num) (string-append "--" method) "--json" "url")
-                            (if commit-title (list "--subject" commit-title) '())))])]
-         [(string=? action "list")
-          (define raw-state (hash-ref args 'state "open"))
-          (unless (valid-state? raw-state)
-            (raise-user-error 'github-pr "invalid state: ~a" raw-state))
-          (gh-success-json "pr" "list" "--state" raw-state "--limit" "100"
-                           "--json" "number,title,state,headRefName")]
-         [(string=? action "get")
-          (define num (hash-ref args 'number #f))
-          (cond
-            [(not num) (make-error-result "get requires 'number'")]
-            [(not (valid-number? num)) (make-error-result (format "invalid number: ~a" num))]
-            [else
-             (gh-success-json "pr" "view" (~a num) "--json" "number,title,state,headRefName,baseRefName,url")])]
-         [else
-          (make-error-result (format "Unknown action: ~a. Valid: create, merge, list, get" action))])])))
+  (with-error-result
+   "github operation"
+   (cond
+     [(not (gh-binary)) (gh-unavailable-error)]
+     [else
+      (define action (hash-ref args 'action ""))
+      (cond
+        [(string=? action "") (make-error-result "Missing required argument: action")]
+        [(string=? action "create")
+         (define title (hash-ref args 'title #f))
+         (cond
+           [(not title) (make-error-result "create requires 'title'")]
+           [else
+            (define body (hash-ref args 'body ""))
+            (define head (hash-ref args 'head #f))
+            (define base (hash-ref args 'base "main"))
+            (apply gh-success-json
+                   (append (list "pr"
+                                 "create"
+                                 "--title"
+                                 title
+                                 "--body"
+                                 body
+                                 "--base"
+                                 base
+                                 "--json"
+                                 "number,title,url")
+                           (if head
+                               (list "--head" head)
+                               '())))])]
+        [(string=? action "merge")
+         (define num (hash-ref args 'number #f))
+         (cond
+           [(not num) (make-error-result "merge requires 'number'")]
+           [(not (valid-number? num)) (make-error-result (format "invalid number: ~a" num))]
+           [else
+            (define method (hash-ref args 'method "squash"))
+            (unless (valid-method? method)
+              (raise-user-error 'github-pr "invalid merge method: ~a" method))
+            (define commit-title (hash-ref args 'commit_title #f))
+            (apply gh-success-json
+                   (append (list "pr" "merge" (~a num) (string-append "--" method) "--json" "url")
+                           (if commit-title
+                               (list "--subject" commit-title)
+                               '())))])]
+        [(string=? action "list")
+         (define raw-state (hash-ref args 'state "open"))
+         (unless (valid-state? raw-state)
+           (raise-user-error 'github-pr "invalid state: ~a" raw-state))
+         (gh-success-json "pr"
+                          "list"
+                          "--state"
+                          raw-state
+                          "--limit"
+                          "100"
+                          "--json"
+                          "number,title,state,headRefName")]
+        [(string=? action "get")
+         (define num (hash-ref args 'number #f))
+         (cond
+           [(not num) (make-error-result "get requires 'number'")]
+           [(not (valid-number? num)) (make-error-result (format "invalid number: ~a" num))]
+           [else
+            (gh-success-json "pr"
+                             "view"
+                             (~a num)
+                             "--json"
+                             "number,title,state,headRefName,baseRefName,url")])]
+        [else
+         (make-error-result (format "Unknown action: ~a. Valid: create, merge, list, get"
+                                    action))])])))

--- a/extensions/github/tool-handlers.rkt
+++ b/extensions/github/tool-handlers.rkt
@@ -12,11 +12,7 @@
          "../hooks.rkt"
          "../tool-api.rkt"
          "../ext-commands.rkt"
-         (only-in "helpers.rkt"
-                  gh-binary
-                  gh-unavailable-error
-                  gh-exec-result
-                  git-exec-result)
+         (only-in "helpers.rkt" gh-binary gh-unavailable-error gh-exec-result git-exec-result)
          "tool-schemas.rkt"
          "handlers/issue-ops.rkt"
          "handlers/pr-ops.rkt"
@@ -31,130 +27,137 @@
          register-github-tools
          register-github-commands)
 
+;; Local macro: execute body, returning error result on failure
+(define-syntax-rule (with-error-result ctx-msg body ...)
+  (with-handlers ([exn:fail? (lambda (e)
+                               (log-warning (format "~a: ~a" ctx-msg (exn-message e)))
+                               (make-error-result (exn-message e)))])
+    body ...))
+
 ;; ============================================================
 ;; Wave handlers
 ;; ============================================================
 
 (define (handle-gh-wave-start args [exec-ctx #f])
-  (with-handlers ([exn:fail? (lambda (e) (make-error-result (exn-message e)))])
-    (define issue-num (hash-ref args 'issue_number #f))
-    (cond
-      [(not issue-num) (make-error-result "Missing required argument: issue_number")]
-      [(not (gh-binary)) (gh-unavailable-error)]
-      [else
-       (define branch-name
-         (or (hash-ref args 'branch_name #f) (format "feature/issue-~a-wave" issue-num)))
-       ;; Sync main
-       (define-values (ec-co _out-co err-co) (git-exec-result "checkout" "main"))
-       (cond
-         [(not (= ec-co 0))
-          (make-error-result (format "Cannot checkout main: ~a" (string-trim err-co)))]
-         [else
-          (git-exec-result "pull" "origin" "main")
-          ;; Create feature branch
-          (define-values (ec-branch _out-br err-br) (git-exec-result "checkout" "-b" branch-name))
-          (cond
-            [(not (= ec-branch 0))
-             (make-error-result
-              (format "Failed to create branch ~a: ~a" branch-name (string-trim err-br)))]
-            [else
-             (make-success-result
-              (list (hasheq 'type
-                            "text"
-                            'text
-                            (format "Wave started: branch '~a' created for issue #~a"
-                                    branch-name
-                                    issue-num))))])])])))
+  (with-error-result
+   "github operation"
+   (define issue-num (hash-ref args 'issue_number #f))
+   (cond
+     [(not issue-num) (make-error-result "Missing required argument: issue_number")]
+     [(not (gh-binary)) (gh-unavailable-error)]
+     [else
+      (define branch-name
+        (or (hash-ref args 'branch_name #f) (format "feature/issue-~a-wave" issue-num)))
+      ;; Sync main
+      (define-values (ec-co _out-co err-co) (git-exec-result "checkout" "main"))
+      (cond
+        [(not (= ec-co 0))
+         (make-error-result (format "Cannot checkout main: ~a" (string-trim err-co)))]
+        [else
+         (git-exec-result "pull" "origin" "main")
+         ;; Create feature branch
+         (define-values (ec-branch _out-br err-br) (git-exec-result "checkout" "-b" branch-name))
+         (cond
+           [(not (= ec-branch 0))
+            (make-error-result
+             (format "Failed to create branch ~a: ~a" branch-name (string-trim err-br)))]
+           [else
+            (make-success-result
+             (list (hasheq 'type
+                           "text"
+                           'text
+                           (format "Wave started: branch '~a' created for issue #~a"
+                                   branch-name
+                                   issue-num))))])])])))
 
 (define (handle-gh-wave-finish args [exec-ctx #f])
-  (with-handlers ([exn:fail? (lambda (e) (make-error-result (exn-message e)))])
-    (define issue-num (hash-ref args 'issue_number #f))
-    (define files (hash-ref args 'files '()))
-    (define commit-msg (hash-ref args 'commit_msg #f))
-    (cond
-      [(not issue-num) (make-error-result "Missing required argument: issue_number")]
-      [(null? files) (make-error-result "Missing or empty required argument: files")]
-      [(not commit-msg) (make-error-result "Missing required argument: commit_msg")]
-      [(not (gh-binary)) (gh-unavailable-error)]
-      [else
-       ;; Step 1: git add + commit
-       (define-values (ec-add _out-add err-add) (apply git-exec-result "add" files))
-       (cond
-         [(not (= ec-add 0)) (make-error-result (format "git add failed: ~a" (string-trim err-add)))]
-         [else
-          (define-values (ec-commit _out-commit err-commit)
-            (git-exec-result "commit" "-m" commit-msg))
-          (cond
-            [(not (= ec-commit 0))
-             (make-error-result (format "git commit failed: ~a" (string-trim err-commit)))]
-            [else
-             ;; Step 2: detect branch, push
-             (define-values (ec-br out-br _) (git-exec-result "branch" "--show-current"))
-             (define branch
-               (or (hash-ref args 'branch #f) (and (= ec-br 0) (string-trim out-br)) "main"))
-             (define-values (ec-push _out-push err-push)
-               (git-exec-result "push" "-u" "origin" branch))
-             (cond
-               [(not (= ec-push 0))
-                (make-error-result (format "git push failed: ~a" (string-trim err-push)))]
-               [else
-                ;; Step 3: create PR
-                (define pr-title (hash-ref args 'pr_title commit-msg))
-                (define pr-body (hash-ref args 'pr_body (format "(#~a)" issue-num)))
-                (define-values (ec-pr out-pr err-pr)
-                  (gh-exec-result "pr"
-                                  "create"
-                                  "--title"
-                                  pr-title
-                                  "--body"
-                                  pr-body
-                                  "--head"
-                                  branch
-                                  "--base"
-                                  "main"
-                                  "--json"
-                                  "number,url"))
-                (define pr-num
-                  (if (= ec-pr 0)
-                      (hash-ref (with-handlers ([exn:fail? (lambda (_) (hasheq))])
-                                  (string->jsexpr (string-trim out-pr)))
-                                'number
-                                #f)
-                      #f))
-                ;; Step 4: merge PR
-                (when pr-num
-                  (define-values (ec-merge _out-merge err-merge)
-                    (gh-exec-result "pr" "merge" (~a pr-num) "--squash"))
-                  (unless (= ec-merge 0)
-                    (make-error-result
-                     (format
-                      "PR merge failed (exit ~a): ~a. Files committed and pushed but PR not merged."
-                      ec-merge
-                      (string-trim err-merge)))))
-                ;; Step 5: sync main
-                (define-values (ec-co _out-co err-co) (git-exec-result "checkout" "main"))
-                (define-values (ec-pull _out-pull err-pull) (git-exec-result "pull" "origin" "main"))
-                (unless (= ec-co 0)
-                  (make-error-result (format "git checkout main failed: ~a" (string-trim err-co))))
-                (unless (= ec-pull 0)
-                  (make-error-result (format "git pull failed: ~a" (string-trim err-pull))))
-                ;; Step 6: close issue
-                (define-values (ec-close _out-close err-close)
-                  (gh-exec-result "issue" "close" (~a issue-num)))
-                (unless (= ec-close 0)
-                  (make-error-result
-                   (format "Issue close failed (exit ~a): ~a. PR merged but issue not closed."
-                           ec-close
-                           (string-trim err-close))))
-                (make-success-result
-                 (list (hasheq
-                        'type
-                        "text"
-                        'text
-                        (format "Wave finished: ~a files committed, PR #~a merged, issue #~a closed"
-                                (length files)
-                                pr-num
-                                issue-num))))])])])])))
+  (with-error-result
+   "github operation"
+   (define issue-num (hash-ref args 'issue_number #f))
+   (define files (hash-ref args 'files '()))
+   (define commit-msg (hash-ref args 'commit_msg #f))
+   (cond
+     [(not issue-num) (make-error-result "Missing required argument: issue_number")]
+     [(null? files) (make-error-result "Missing or empty required argument: files")]
+     [(not commit-msg) (make-error-result "Missing required argument: commit_msg")]
+     [(not (gh-binary)) (gh-unavailable-error)]
+     [else
+      ;; Step 1: git add + commit
+      (define-values (ec-add _out-add err-add) (apply git-exec-result "add" files))
+      (cond
+        [(not (= ec-add 0)) (make-error-result (format "git add failed: ~a" (string-trim err-add)))]
+        [else
+         (define-values (ec-commit _out-commit err-commit) (git-exec-result "commit" "-m" commit-msg))
+         (cond
+           [(not (= ec-commit 0))
+            (make-error-result (format "git commit failed: ~a" (string-trim err-commit)))]
+           [else
+            ;; Step 2: detect branch, push
+            (define-values (ec-br out-br _) (git-exec-result "branch" "--show-current"))
+            (define branch
+              (or (hash-ref args 'branch #f) (and (= ec-br 0) (string-trim out-br)) "main"))
+            (define-values (ec-push _out-push err-push) (git-exec-result "push" "-u" "origin" branch))
+            (cond
+              [(not (= ec-push 0))
+               (make-error-result (format "git push failed: ~a" (string-trim err-push)))]
+              [else
+               ;; Step 3: create PR
+               (define pr-title (hash-ref args 'pr_title commit-msg))
+               (define pr-body (hash-ref args 'pr_body (format "(#~a)" issue-num)))
+               (define-values (ec-pr out-pr err-pr)
+                 (gh-exec-result "pr"
+                                 "create"
+                                 "--title"
+                                 pr-title
+                                 "--body"
+                                 pr-body
+                                 "--head"
+                                 branch
+                                 "--base"
+                                 "main"
+                                 "--json"
+                                 "number,url"))
+               (define pr-num
+                 (if (= ec-pr 0)
+                     (hash-ref (with-handlers ([exn:fail? (lambda (_) (hasheq))])
+                                 (string->jsexpr (string-trim out-pr)))
+                               'number
+                               #f)
+                     #f))
+               ;; Step 4: merge PR
+               (when pr-num
+                 (define-values (ec-merge _out-merge err-merge)
+                   (gh-exec-result "pr" "merge" (~a pr-num) "--squash"))
+                 (unless (= ec-merge 0)
+                   (make-error-result
+                    (format
+                     "PR merge failed (exit ~a): ~a. Files committed and pushed but PR not merged."
+                     ec-merge
+                     (string-trim err-merge)))))
+               ;; Step 5: sync main
+               (define-values (ec-co _out-co err-co) (git-exec-result "checkout" "main"))
+               (define-values (ec-pull _out-pull err-pull) (git-exec-result "pull" "origin" "main"))
+               (unless (= ec-co 0)
+                 (make-error-result (format "git checkout main failed: ~a" (string-trim err-co))))
+               (unless (= ec-pull 0)
+                 (make-error-result (format "git pull failed: ~a" (string-trim err-pull))))
+               ;; Step 6: close issue
+               (define-values (ec-close _out-close err-close)
+                 (gh-exec-result "issue" "close" (~a issue-num)))
+               (unless (= ec-close 0)
+                 (make-error-result
+                  (format "Issue close failed (exit ~a): ~a. PR merged but issue not closed."
+                          ec-close
+                          (string-trim err-close))))
+               (make-success-result
+                (list (hasheq
+                       'type
+                       "text"
+                       'text
+                       (format "Wave finished: ~a files committed, PR #~a merged, issue #~a closed"
+                               (length files)
+                               pr-num
+                               issue-num))))])])])])))
 
 ;; ============================================================
 ;; Registration

--- a/util/error-helpers.rkt
+++ b/util/error-helpers.rkt
@@ -9,7 +9,8 @@
 (require racket/logging)
 (provide with-safe-fallback
          with-logged-error
-         with-telemetry)
+         with-telemetry
+)
 
 ;; with-safe-fallback — Execute body, returning DEFAULT on any exn:fail.
 ;;


### PR DESCRIPTION
Addresses #3049.

feat: migrate GitHub handler exn:fail catches to with-error-result (#3049)

- Add with-error-result macro to 4 GitHub handler files as local definition
- Replace broad exn:fail? catches with structured error logging + result
- Files: issue-ops, pr-ops, milestone-ops, tool-handlers
- All existing tests pass