### PR TITLE
feat: migrate util/event.rkt to Typed Racket (#3052)

- Convert #lang racket/base → #lang typed/racket
- Add type annotations for event struct, make-event, event->jsexpr, jsexpr->event
- Use ->* for optional positional version arg (was keyword)
- Use cast for TR-compatible hash-ref on (HashTable Symbol Any)
- 5 new TR boundary tests verifying untyped consumer compatibility

### DIFF
--- a/tests/test-tr-event.rkt
+++ b/tests/test-tr-event.rkt
@@ -1,0 +1,33 @@
+#lang racket/base
+
+;; Test that util/event.rkt (now #lang typed/racket) exports work from untyped
+(require rackunit
+         "../util/event.rkt")
+
+(test-case "make-event creates event with positional args"
+  (define evt (make-event 'test-event 1000 "sess1" #f (hasheq 'key "val")))
+  (check-equal? (event-ev evt) 'test-event)
+  (check-equal? (event-version evt) 1)
+  (check-equal? (event-session-id evt) "sess1"))
+
+(test-case "make-event with explicit version"
+  (define evt (make-event 'test-event 1000 "sess1" "turn1" 'payload 2))
+  (check-equal? (event-version evt) 2)
+  (check-equal? (event-turn-id evt) "turn1"))
+
+(test-case "event->jsexpr and jsexpr->event round-trip"
+  (define evt (make-event 'round-trip 42 "s" "t" 'data))
+  (define js (event->jsexpr evt))
+  (define evt2 (jsexpr->event js))
+  (check-equal? (event-ev evt2) 'round-trip)
+  (check-equal? (event-time evt2) 42)
+  (check-equal? (event-session-id evt2) "s")
+  (check-equal? (event-turn-id evt2) "t"))
+
+(test-case "event-event accessor alias works"
+  (define evt (make-event 'alias-test 0 "s" #f 'p))
+  (check-equal? (event-event evt) 'alias-test))
+
+(test-case "CURRENT-EVENT-VERSION is defined"
+  (check-true (integer? CURRENT-EVENT-VERSION))
+  (check-equal? CURRENT-EVENT-VERSION 1))

--- a/util/event.rkt
+++ b/util/event.rkt
@@ -1,11 +1,15 @@
-#lang racket/base
+#lang typed/racket
 
 ;; util/event.rkt — Event envelope struct and serialization
 ;;
 ;; Extracted from protocol-types.rkt (ARCH-05 split).
 ;; Event struct with JSON serialization/deserialization.
-
-(require racket/contract)
+;; Migrated to #lang typed/racket in v0.28.9 W0 (TR expansion).
+;;
+;; TR BOUNDARY:
+;; This is a #lang typed/racket module. Untyped consumers receive
+;; auto-generated contracts from TR boundary system. Struct
+;; constructors enforce field types at call sites in untyped modules.
 
 (provide (struct-out event)
          event-event
@@ -18,17 +22,24 @@
 ;; Event envelope struct
 ;; ============================================================
 
-(struct event (version ev time session-id turn-id payload) #:transparent)
+(struct event ([version : Integer]
+               [ev : Symbol]
+               [time : Integer]
+               [session-id : String]
+               [turn-id : (Option String)]
+               [payload : Any]) #:transparent)
 
-(define (make-event ev time session-id turn-id payload #:version [version 1])
+(: make-event (->* (Symbol Integer String (Option String) Any) (Integer) event))
+(define (make-event ev time session-id turn-id payload [version 1])
   (event version ev time session-id turn-id payload))
 
 ;; Accessor alias: the field is called `ev` internally to avoid
 ;; name collision with the struct, but the logical name is `event`.
-;; Racket generates `event-ev`; we re-export as a procedure.
+(: event-event : (-> event Symbol))
 (define event-event event-ev)
 
 ;; Serialize event to jsexpr (hash)
+(: event->jsexpr : (-> event (HashTable Symbol Any)))
 (define (event->jsexpr evt)
   (hasheq 'version
           (event-version evt)
@@ -47,18 +58,17 @@
 (define CURRENT-EVENT-VERSION 1)
 
 ;; Deserialize jsexpr (hash) to event.
-;; For typed event deserialization, see agent/event-types.rkt:jsexpr->typed-event
-;; which handles type-tagged events with structured fields.
+(: jsexpr->event : (-> (HashTable Symbol Any) event))
 (define (jsexpr->event h)
-  (define ver (hash-ref h 'version 1))
+  (define ver : Integer (cast (hash-ref h 'version (lambda () 1)) Integer))
   (when (> ver CURRENT-EVENT-VERSION)
     (log-warning "jsexpr->event: event version ~a exceeds current ~a (event: ~a)"
                  ver
                  CURRENT-EVENT-VERSION
-                 (hash-ref h 'event "<unknown>")))
+                 (cast (hash-ref h (quote event) (lambda () "<unknown>")) String)))
   (event ver
-         (hash-ref h 'event)
-         (hash-ref h 'time)
-         (hash-ref h 'sessionId)
-         (hash-ref h 'turnId)
-         (hash-ref h 'payload)))
+         (cast (hash-ref h (quote event)) Symbol)
+         (cast (hash-ref h (quote time)) Integer)
+         (cast (hash-ref h (quote sessionId)) String)
+         (cast (hash-ref h (quote turnId) (lambda () #f)) (Option String))
+         (hash-ref h (quote payload))))


### PR DESCRIPTION
Addresses #3052.

feat: migrate util/event.rkt to Typed Racket (#3052)

- Convert #lang racket/base → #lang typed/racket
- Add type annotations for event struct, make-event, event->jsexpr, jsexpr->event
- Use ->* for optional positional version arg (was keyword)
- Use cast for TR-compatible hash-ref on (HashTable Symbol Any)
- 5 new TR boundary tests verifying untyped consumer compatibility