### PR TITLE
feat: migrate util/hook-types.rkt to Typed Racket (#3053)

- Convert #lang racket/base → #lang typed/racket
- Add type annotations for hook-result struct, constructors, validation
- Fix make-event ev type to Any (callers pass strings, not symbols)
- Use lambda default for TR-compatible hash-ref
- 5 new TR boundary tests for hook-types (10 total in test-tr-event.rkt)

### DIFF
--- a/tests/test-tr-event.rkt
+++ b/tests/test-tr-event.rkt
@@ -31,3 +31,26 @@
 (test-case "CURRENT-EVENT-VERSION is defined"
   (check-true (integer? CURRENT-EVENT-VERSION))
   (check-equal? CURRENT-EVENT-VERSION 1))
+
+;; Test that util/hook-types.rkt (now #lang typed/racket) exports work from untyped
+(require "../util/hook-types.rkt")
+
+(test-case "hook-pass creates pass result"
+  (define r (hook-pass "data"))
+  (check-equal? (hook-result-action r) 'pass)
+  (check-equal? (hook-result-payload r) "data"))
+
+(test-case "hook-amend creates amend result"
+  (define r (hook-amend "new-data"))
+  (check-equal? (hook-result-action r) 'amend))
+
+(test-case "hook-block creates block result"
+  (define r (hook-block "reason"))
+  (check-equal? (hook-result-action r) 'block))
+
+(test-case "validate-hook-result TR boundary"
+  (check-true (validate-hook-result 'model-request-pre (hook-pass "x")))
+  (check-false (validate-hook-result 'turn-end (hook-block "x"))))
+
+(test-case "hook-schema-version from TR"
+  (check-equal? (hook-schema-version) 1))

--- a/util/event.rkt
+++ b/util/event.rkt
@@ -23,19 +23,19 @@
 ;; ============================================================
 
 (struct event ([version : Integer]
-               [ev : Symbol]
+               [ev : Any]
                [time : Integer]
                [session-id : String]
                [turn-id : (Option String)]
                [payload : Any]) #:transparent)
 
-(: make-event (->* (Symbol Integer String (Option String) Any) (Integer) event))
+(: make-event (->* (Any Integer String (Option String) Any) (Integer) event))
 (define (make-event ev time session-id turn-id payload [version 1])
   (event version ev time session-id turn-id payload))
 
 ;; Accessor alias: the field is called `ev` internally to avoid
 ;; name collision with the struct, but the logical name is `event`.
-(: event-event : (-> event Symbol))
+(: event-event : (-> event Any))
 (define event-event event-ev)
 
 ;; Serialize event to jsexpr (hash)
@@ -67,7 +67,7 @@
                  CURRENT-EVENT-VERSION
                  (cast (hash-ref h (quote event) (lambda () "<unknown>")) String)))
   (event ver
-         (cast (hash-ref h (quote event)) Symbol)
+         (hash-ref h (quote event))
          (cast (hash-ref h (quote time)) Integer)
          (cast (hash-ref h (quote sessionId)) String)
          (cast (hash-ref h (quote turnId) (lambda () #f)) (Option String))

--- a/util/hook-types.rkt
+++ b/util/hook-types.rkt
@@ -1,47 +1,45 @@
-#lang racket/base
+#lang typed/racket
 
 ;; util/hook-types.rkt — canonical hook result types and per-hook validation
 ;; Shared between extensions layer and agent core.
-;; ARCH-01: extracted from extensions/hooks.rkt to eliminate layer violations.
+;; Migrated to #lang typed/racket in v0.28.9 W1 (TR expansion).
 ;;
-;; FEAT-63: Per-hook-point result validation schemas.
-;; Each hook-point has documented expected actions and payload constraints.
-;; Invalid results are caught early and logged as warnings.
+;; TR BOUNDARY:
+;; This is a #lang typed/racket module. Untyped consumers receive
+;; auto-generated contracts from TR boundary system.
 
-;; v0.28.8: Hook schema version
-;; Increment when hook-action-schemas structure changes.
-(define HOOK-SCHEMA-VERSION 1)
-
-;; Return current schema version.
-(define (hook-schema-version)
-  HOOK-SCHEMA-VERSION)
-
-;; Hook result struct and action constructors
 (provide (struct-out hook-result)
          hook-pass
          hook-amend
          hook-block
-         ;; FEAT-63: Per-hook-point validation
          valid-hook-actions-for
          validate-hook-result
-         ;; Hook point names (#1148)
          hook-point-names
-         ;; #1149: expose schemas for testing
          hook-action-schemas
-         ;; #1210: hook name validation
          valid-hook-name?
-         ;; v0.28.8: hook schema versioning
          HOOK-SCHEMA-VERSION
          hook-schema-version)
 
-(struct hook-result (action payload) #:transparent)
+;; v0.28.8: Hook schema version
+(: HOOK-SCHEMA-VERSION Integer)
+(define HOOK-SCHEMA-VERSION 1)
 
+(: hook-schema-version (-> Integer))
+(define (hook-schema-version)
+  HOOK-SCHEMA-VERSION)
+
+;; Hook result struct
+(struct hook-result ([action : Symbol] [payload : Any]) #:transparent)
+
+(: hook-pass (->* () (Any) hook-result))
 (define (hook-pass [payload #f])
   (hook-result 'pass payload))
 
+(: hook-amend (-> Any hook-result))
 (define (hook-amend payload)
   (hook-result 'amend payload))
 
+(: hook-block (->* () (Any) hook-result))
 (define (hook-block [reason #f])
   (hook-result 'block reason))
 
@@ -49,122 +47,94 @@
 ;; FEAT-63: Per-hook-point result validation
 ;; ============================================================
 
-;; Maps hook-point symbols to their valid actions.
-;; Extensions returning actions outside this set are warned.
+(: hook-action-schemas (HashTable Symbol (Listof Symbol)))
 (define hook-action-schemas
-  ;; Model request hooks
   (hasheq 'model-request-pre
           '(pass amend block)
           'before-provider-request
           '(pass amend block)
-          ;; Message hooks
           'message-start
           '(pass amend block)
           'message-end
           '(pass amend block)
-          ;; #1208: message-update alias (hyphen form of message.update)
           'message-update
           '(amend)
-          ;; Tool execution hooks
           'tool-call
           '(pass amend block)
           'tool-result
           '(pass amend block)
-          ;; #1208: tool-call-pre / tool-result-post (dispatched from scheduler.rkt)
           'tool-call-pre
           '(pass amend block)
           'tool-result-post
           '(pass amend block)
-          ;; Turn lifecycle hooks
           'turn-start
           '(pass amend block)
           'turn-end
           '(pass amend)
-          ;; Agent lifecycle hooks
           'before-agent-start
           '(pass amend block)
-          ;; Context assembly hooks
           'context
           '(pass amend block)
           'context.assembly
           '(pass amend block)
-          ;; Session hooks
           'session-before-switch
           '(pass block)
           'session-before-fork
           '(pass block)
           'session-before-compact
           '(pass block)
-          ;; Input hooks
           'input
           '(pass amend block)
-          ;; Extension registration hooks
           'register-tools
           '(pass amend)
-          ;; Steering/queue hooks
           'before-send
           '(pass amend)
-          ;; Resource discovery hooks (#1148)
           'resources-discover
           '(pass amend block)
-          ;; ============================================================
-          ;; #1149: Fine-grained lifecycle events
-          ;; ============================================================
-          ;; Tool lifecycle (fine-grained)
           'tool.execution.start
           '(pass)
           'tool.execution.update
           '(amend)
           'tool.execution.end
           '(pass)
-          ;; Message lifecycle (fine-grained)
           'message.update
           '(amend)
           'message.stream.delta
           '(pass)
-          ;; Context events
           'context.window.changed
           '(pass)
           'context.tokens.used
           '(amend)
-          ;; Provider events
           'provider.response.after
           '(amend)
           'provider.stream.delta
           '(pass)
           'provider.error
           '(pass)
-          ;; Model events
           'model.selected
           '(pass)
           'model.changed
           '(pass)
-          ;; Session lifecycle additions
           'session.created
           '(pass)
           'session.loaded
           '(pass)
           'session.compacted
           '(pass)
-          ;; Extension lifecycle
           'extension.loaded
           '(pass)
           'extension.unloaded
           '(pass)
-          ;; Shortcut registration
           'register-shortcuts
           '(pass amend)
-          ;; Command dispatch
           'execute-command
           '(pass amend)
-          ;; Agent lifecycle
           'agent.started
           '(pass)
           'agent.idle
           '(pass)
           'agent.error
           '(pass)
-          ;; #1310: New hook points
           'agent.end
           '(pass)
           'session-shutdown
@@ -178,15 +148,14 @@
           'session-rebind
           '(pass)))
 
-;; valid-hook-actions-for : symbol? -> (listof symbol?)
-;; Returns the valid actions for a given hook-point.
-;; Defaults to '(pass amend block) for unknown hook-points (permissive).
-(define (valid-hook-actions-for hook-point)
-  (hash-ref hook-action-schemas hook-point '(pass amend block)))
+(: default-actions (Listof Symbol))
+(define default-actions '(pass amend block))
 
-;; validate-hook-result : symbol? hook-result? -> boolean?
-;; Checks whether a hook-result's action is valid for the given hook-point.
-;; Returns #t if valid, #f if invalid. Logs a warning on invalid.
+(: valid-hook-actions-for (-> Symbol (Listof Symbol)))
+(define (valid-hook-actions-for hook-point)
+  (hash-ref hook-action-schemas hook-point (lambda () default-actions)))
+
+(: validate-hook-result (->* (Symbol hook-result) (Integer) Boolean))
 (define (validate-hook-result hook-point result [expected-version HOOK-SCHEMA-VERSION])
   (define valid-actions (valid-hook-actions-for hook-point))
   (define action (hook-result-action result))
@@ -206,21 +175,10 @@
                           valid-actions))
      #f]))
 
-;; ============================================================
-;; Hook point names (#1148)
-;; ============================================================
-
-;; Returns a list of all registered hook-point symbols.
-;; Useful for testing and introspection.
+(: hook-point-names (-> (Listof Symbol)))
 (define (hook-point-names)
   (hash-keys hook-action-schemas))
 
-;; ============================================================
-;; #1210: Hook name validation
-;; ============================================================
-
-;; valid-hook-name? : symbol? -> boolean?
-;; Returns #t if the given symbol is a registered hook-point name.
-;; Used at extension registration time to catch typos early.
+(: valid-hook-name? (-> Symbol Boolean))
 (define (valid-hook-name? name)
   (hash-has-key? hook-action-schemas name))


### PR DESCRIPTION
Addresses #3053.

feat: migrate util/hook-types.rkt to Typed Racket (#3053)

- Convert #lang racket/base → #lang typed/racket
- Add type annotations for hook-result struct, constructors, validation
- Fix make-event ev type to Any (callers pass strings, not symbols)
- Use lambda default for TR-compatible hash-ref
- 5 new TR boundary tests for hook-types (10 total in test-tr-event.rkt)