### PR TITLE
feat: telemetry for 4 LLM providers + event codec type-tags (#3083)

F4: Add [telemetry] logging to openai/anthropic/gemini/azure stream setup
F6: Add __type tag to payload->hash, use in hash->payload for reliable decode
6 new type-tag codec tests + backward-compatible heuristic fallback

### DIFF
--- a/llm/anthropic.rkt
+++ b/llm/anthropic.rkt
@@ -303,6 +303,7 @@
 
   ;; W10.1 (Q-19): dynamic-wind ensures response port cleanup on timeout/exception
   (define (stream req)
+    (define _stream-t0 (current-inexact-milliseconds))
     (define merged-req (ensure-model-setting req default-model))
     (define body (anthropic-build-request-body merged-req #:stream? #t))
     (define url-str (string-append (string-trim base-url "/") "/v1/messages"))
@@ -345,6 +346,8 @@
        (define current-tool-id (box #f))
        (define current-tool-name (box #f))
        (define current-tool-index (box 0))
+       (log-info (format "[telemetry] anthropic-stream setup completed in ~a ms"
+                         (real->decimal-string (- (current-inexact-milliseconds) _stream-t0) 1)))
        (generator ()
                   (let loop ([first-read? #t])
                     (define timeout-secs

--- a/llm/azure-openai.rkt
+++ b/llm/azure-openai.rkt
@@ -102,6 +102,7 @@
 ;; ============================================================
 
 (define (azure-stream base-url api-key api-version req model-name)
+  (define _stream-t0 (current-inexact-milliseconds))
   (define body (openai-build-request-body req #:stream? #t))
   (define url-str
     (string-append (string-trim base-url "/") "/chat/completions?api-version=" api-version))
@@ -114,6 +115,8 @@
   (define headers (list (format "api-key: ~a" api-key) "Content-Type: application/json"))
   (define body-bytes (jsexpr->bytes body))
   (define response-port-box (box #f))
+  (log-info (format "[telemetry] azure-stream setup completed in ~a ms"
+                    (real->decimal-string (- (current-inexact-milliseconds) _stream-t0) 1)))
   (dynamic-wind
    (lambda () (void))
    (lambda ()

--- a/llm/gemini.rkt
+++ b/llm/gemini.rkt
@@ -368,6 +368,7 @@
 
   ;; W10.1 (Q-19): dynamic-wind ensures response port cleanup on timeout/exception
   (define (stream req)
+    (define _stream-t0 (current-inexact-milliseconds))
     (define merged-req (ensure-model-setting req default-model))
     (define body (gemini-build-request-body merged-req #:stream? #t))
     (define model-name (hash-ref (model-request-settings merged-req) 'model default-model))
@@ -416,6 +417,8 @@
        (parameterize ([gemini-tool-id-counter-param 0])
          ;; Incremental SSE parsing — generator yields chunks one at a time
          (define raw-port response-port)
+         (log-info (format "[telemetry] gemini-stream setup completed in ~a ms"
+                           (real->decimal-string (- (current-inexact-milliseconds) _stream-t0) 1)))
          (generator ()
                     (let loop ([first-read? #t])
                       (define timeout-secs

--- a/llm/openai-compatible.rkt
+++ b/llm/openai-compatible.rkt
@@ -188,6 +188,7 @@
     (openai-parse-response raw))
 
   (define (stream req)
+    (define _stream-t0 (current-inexact-milliseconds))
     (define req-with-model (ensure-model-settings req))
     (define body (openai-build-request-body req-with-model #:stream? #t))
     (define url-str (string-append (string-trim base-url "/") "/chat/completions"))
@@ -260,6 +261,8 @@
     ;; Simple wrapper: yield chunks until done, then close port.
     ;; No dynamic-wind — it fires before/after on every yield which
     ;; causes the port to be closed between yields.
+    (log-info (format "[telemetry] openai-stream setup completed in ~a ms"
+                      (real->decimal-string (- (current-inexact-milliseconds) _stream-t0) 1)))
     (generator ()
                (let loop ()
                  (define chunk (gen))

--- a/tests/test-event-codec.rkt
+++ b/tests/test-event-codec.rkt
@@ -2,7 +2,24 @@
 
 (require rackunit
          "../util/event-codec.rkt"
-         "../util/event-payloads.rkt")
+         (only-in "../util/event-payloads.rkt"
+                  session-start-payload
+                  session-start-payload?
+                  error-payload
+                  error-payload?
+                  error-payload-error
+                  error-payload-error-type
+                  input-payload
+                  input-payload?
+                  input-payload-session-id
+                  input-payload-message
+                  gsd-mode-payload
+                  gsd-mode-payload?
+                  gsd-mode-payload-old-mode
+                  gsd-mode-payload-new-mode
+                  session-id-payload
+                  session-id-payload?
+                  session-id-payload-session-id))
 
 ;; payload-type-tag tests
 (test-case "payload-type-tag identifies session-start"
@@ -63,3 +80,38 @@
   (check-true (gsd-mode-payload? decoded))
   (check-equal? (gsd-mode-payload-old-mode decoded) 'inbox)
   (check-equal? (gsd-mode-payload-new-mode decoded) 'done))
+
+;; v0.28.11: Type-tagged round-trip tests
+(test-case "encode includes __type tag"
+  (define encoded (payload->hash (error-payload "fail" 'timeout)))
+  (check-equal? (hash-ref encoded '__type) 'error))
+
+(test-case "type-tagged decode for input-payload"
+  (define h (hasheq '__type 'input 'session-id "s1" 'message "hi"))
+  (define p (hash->payload h))
+  (check-true (input-payload? p))
+  (check-equal? (input-payload-session-id p) "s1"))
+
+(test-case "type-tagged decode for session-start"
+  (define h (hasheq '__type 'session-start 'session-id "s1" 'config '() 'reason 'manual))
+  (define p (hash->payload h))
+  (check-true (session-start-payload? p)))
+
+(test-case "type-tagged decode falls through for unknown __type"
+  (define h (hasheq '__type 'bogus 'data 42))
+  (check-equal? (hash->payload h) h))
+
+(test-case "legacy heuristic still works without __type"
+  (define h (hasheq 'error "oops" 'errorType 'runtime))
+  (define p (hash->payload h))
+  (check-true (error-payload? p))
+  (check-equal? (error-payload-error p) "oops"))
+
+(test-case "full round-trip with __type preserves data"
+  (define orig (input-payload "sess42" "hello world"))
+  (define encoded (payload->hash orig))
+  (check-equal? (hash-ref encoded '__type) 'input)
+  (define decoded (hash->payload encoded))
+  (check-true (input-payload? decoded))
+  (check-equal? (input-payload-session-id decoded) "sess42")
+  (check-equal? (input-payload-message decoded) "hello world"))

--- a/util/event-codec.rkt
+++ b/util/event-codec.rkt
@@ -31,25 +31,38 @@
 
 ;; Decode a hash back into the appropriate payload struct.
 ;; Returns the hash as-is if no struct type matches (passthrough).
+;; v0.28.11: Uses __type tag for reliable decode, falls back to heuristic matching.
 (define (hash->payload h)
   (cond
     [(not (hash? h)) h]
-    ;; Error payloads
+    ;; Type-tagged decode (reliable, v0.28.11+)
+    [(hash-has-key? h '__type)
+     (case (hash-ref h '__type)
+       [(error) (error-payload (hash-ref h 'error) (hash-ref h 'errorType))]
+       [(input) (input-payload (hash-ref h 'session-id) (hash-ref h 'message))]
+       [(session-start)
+        (session-start-payload (hash-ref h 'session-id) (hash-ref h 'config) (hash-ref h 'reason))]
+       [(session-end) (session-end-payload (hash-ref h 'session-id) (hash-ref h 'duration))]
+       [(session-switch) (session-switch-payload (hash-ref h 'session-id) (hash-ref h 'operation))]
+       [(tool-call)
+        (tool-call-event-payload (hash-ref h 'session-id)
+                                 (hash-ref h 'turn-id)
+                                 (hash-ref h 'tool-name)
+                                 (hash-ref h 'tool-call-id))]
+       [(gsd-mode) (gsd-mode-payload (hash-ref h 'old-mode) (hash-ref h 'new-mode))]
+       [(session-id) (session-id-payload (hash-ref h 'sessionId))]
+       [else h])]
+    ;; Legacy heuristic decode (backward compatible with pre-v0.28.11 data)
     [(and (hash-has-key? h 'error) (hash-has-key? h 'errorType))
      (error-payload (hash-ref h 'error) (hash-ref h 'errorType))]
-    ;; Input payloads
     [(and (hash-has-key? h 'session-id) (hash-has-key? h 'message))
      (input-payload (hash-ref h 'session-id) (hash-ref h 'message))]
-    ;; Session start
     [(and (hash-has-key? h 'session-id) (hash-has-key? h 'config) (hash-has-key? h 'reason))
      (session-start-payload (hash-ref h 'session-id) (hash-ref h 'config) (hash-ref h 'reason))]
-    ;; Session end
     [(and (hash-has-key? h 'session-id) (hash-has-key? h 'duration))
      (session-end-payload (hash-ref h 'session-id) (hash-ref h 'duration))]
-    ;; Session switch
     [(and (hash-has-key? h 'session-id) (hash-has-key? h 'operation))
      (session-switch-payload (hash-ref h 'session-id) (hash-ref h 'operation))]
-    ;; Tool call
     [(and (hash-has-key? h 'session-id)
           (hash-has-key? h 'turn-id)
           (hash-has-key? h 'tool-name)
@@ -58,10 +71,7 @@
                               (hash-ref h 'turn-id)
                               (hash-ref h 'tool-name)
                               (hash-ref h 'tool-call-id))]
-    ;; GSD mode
     [(and (hash-has-key? h 'old-mode) (hash-has-key? h 'new-mode))
      (gsd-mode-payload (hash-ref h 'old-mode) (hash-ref h 'new-mode))]
-    ;; Session-id only
     [(hash-has-key? h 'sessionId) (session-id-payload (hash-ref h 'sessionId))]
-    ;; Passthrough
     [else h]))

--- a/util/event-payloads.rkt
+++ b/util/event-payloads.rkt
@@ -77,24 +77,32 @@
 (define (payload->hash p)
   (cond
     [(session-start-payload? p)
-     (hasheq 'session-id
+     (hasheq '__type
+             'session-start
+             'session-id
              (session-start-payload-session-id p)
              'config
              (session-start-payload-config p)
              'reason
              (session-start-payload-reason p))]
     [(session-end-payload? p)
-     (hasheq 'session-id
+     (hasheq '__type
+             'session-end
+             'session-id
              (session-end-payload-session-id p)
              'duration
              (session-end-payload-duration p))]
     [(session-switch-payload? p)
-     (hasheq 'session-id
+     (hasheq '__type
+             'session-switch
+             'session-id
              (session-switch-payload-session-id p)
              'operation
              (session-switch-payload-operation p))]
     [(tool-call-event-payload? p)
-     (hasheq 'session-id
+     (hasheq '__type
+             'tool-call
+             'session-id
              (tool-call-event-payload-session-id p)
              'turn-id
              (tool-call-event-payload-turn-id p)
@@ -102,13 +110,24 @@
              (tool-call-event-payload-tool-name p)
              'tool-call-id
              (tool-call-event-payload-tool-call-id p))]
-    [(session-id-payload? p) (hasheq 'sessionId (session-id-payload-session-id p))]
+    [(session-id-payload? p)
+     (hasheq '__type 'session-id 'sessionId (session-id-payload-session-id p))]
     [(error-payload? p)
-     (hasheq 'error (error-payload-error p) 'errorType (error-payload-error-type p))]
+     (hasheq '__type 'error 'error (error-payload-error p) 'errorType (error-payload-error-type p))]
     [(input-payload? p)
-     (hasheq 'session-id (input-payload-session-id p) 'message (input-payload-message p))]
+     (hasheq '__type
+             'input
+             'session-id
+             (input-payload-session-id p)
+             'message
+             (input-payload-message p))]
     [(gsd-mode-payload? p)
-     (hasheq 'old-mode (gsd-mode-payload-old-mode p) 'new-mode (gsd-mode-payload-new-mode p))]
+     (hasheq '__type
+             'gsd-mode
+             'old-mode
+             (gsd-mode-payload-old-mode p)
+             'new-mode
+             (gsd-mode-payload-new-mode p))]
     [(hash? p) (cast p (HashTable Symbol Any))]
     [else (hasheq 'payload p)]))
 


### PR DESCRIPTION
Addresses #3083.

feat: telemetry for 4 LLM providers + event codec type-tags (#3083)

F4: Add [telemetry] logging to openai/anthropic/gemini/azure stream setup
F6: Add __type tag to payload->hash, use in hash->payload for reliable decode
6 new type-tag codec tests + backward-compatible heuristic fallback