### PR TITLE
feat: hook violation callback + deduplicate with-error-result macro (#3084)

F7: Add current-hook-violation-callback parameter to extensions/hooks.rkt
    for structured violation reporting (enables future quarantine)
F9: Extract with-error-result macro from 3 GitHub handler files to
    shared extensions/github/helpers.rkt
+ 4 new hook violation callback tests

### DIFF
--- a/extensions/github/handlers/issue-ops.rkt
+++ b/extensions/github/handlers/issue-ops.rkt
@@ -6,6 +6,7 @@
          racket/string
          json
          (only-in "../helpers.rkt"
+                  with-error-result
                   gh-binary
                   gh-unavailable-error
                   valid-number?
@@ -16,13 +17,6 @@
          (only-in "../../tool-api.rkt" make-error-result make-success-result))
 
 (provide handle-gh-issue)
-
-;; Local macro: execute body, returning error result on failure
-(define-syntax-rule (with-error-result ctx-msg body ...)
-  (with-handlers ([exn:fail? (lambda (e)
-                               (log-warning (format "~a: ~a" ctx-msg (exn-message e)))
-                               (make-error-result (exn-message e)))])
-    body ...))
 
 (define (handle-gh-issue args [exec-ctx #f])
   (with-error-result

--- a/extensions/github/handlers/milestone-ops.rkt
+++ b/extensions/github/handlers/milestone-ops.rkt
@@ -8,6 +8,7 @@
          racket/string
          json
          (only-in "../helpers.rkt"
+                  with-error-result
                   gh-binary
                   gh-unavailable-error
                   valid-number?
@@ -19,13 +20,6 @@
 (provide handle-gh-milestone
          handle-gh-board
          milestone-create-from-spec)
-
-;; Local macro: execute body, returning error result on failure
-(define-syntax-rule (with-error-result ctx-msg body ...)
-  (with-handlers ([exn:fail? (lambda (e)
-                               (log-warning (format "~a: ~a" ctx-msg (exn-message e)))
-                               (make-error-result (exn-message e)))])
-    body ...))
 
 ;; --- gh-milestone helpers ---
 

--- a/extensions/github/handlers/pr-ops.rkt
+++ b/extensions/github/handlers/pr-ops.rkt
@@ -7,6 +7,7 @@
 (require racket/format
          racket/string
          (only-in "../helpers.rkt"
+                  with-error-result
                   gh-binary
                   gh-unavailable-error
                   valid-number?
@@ -16,13 +17,6 @@
          (only-in "../../tool-api.rkt" make-error-result))
 
 (provide handle-gh-pr)
-
-;; Local macro: execute body, returning error result on failure
-(define-syntax-rule (with-error-result ctx-msg body ...)
-  (with-handlers ([exn:fail? (lambda (e)
-                               (log-warning (format "~a: ~a" ctx-msg (exn-message e)))
-                               (make-error-result (exn-message e)))])
-    body ...))
 
 (define (handle-gh-pr args [exec-ctx #f])
   (with-error-result

--- a/extensions/github/helpers.rkt
+++ b/extensions/github/helpers.rkt
@@ -1,5 +1,13 @@
 #lang racket/base
 
+;; Execute body, returning make-error-result on exception.
+;; Shared macro for all GitHub handler files.
+(define-syntax-rule (with-error-result ctx-msg body ...)
+  (with-handlers ([exn:fail? (lambda (e)
+                               (log-warning (format "~a: ~a" ctx-msg (exn-message e)))
+                               (make-error-result (exn-message e)))])
+    body ...))
+
 ;; extensions/github/helpers.rkt — Common GitHub CLI utilities
 ;;
 ;; Extracted from github-integration.rkt to reduce its size (Q01).
@@ -30,7 +38,8 @@
          gh-success
          gh-success-json
          git-success
-         get-repo-info)
+         get-repo-info
+         with-error-result)
 
 ;; ============================================================
 ;; Configuration

--- a/extensions/hooks.rkt
+++ b/extensions/hooks.rkt
@@ -33,6 +33,7 @@
          ;; Hook dispatch
          (contract-out [dispatch-hooks (->* (symbol? any/c any/c) (#:ctx any/c) hook-result?)])
          current-hook-timeout-ms
+         current-hook-violation-callback
          critical-hook?
          critical-hooks)
 
@@ -79,6 +80,15 @@
 ;; Per-hook timeout in milliseconds (default: 100ms for streaming hooks).
 ;; Set to #f to disable timeout.
 (define current-hook-timeout-ms (make-parameter 500))
+
+;; Violation callback — called when a hook handler returns an invalid action.
+;; Receives (ext-name hook-point action schema-version).
+;; Default: #f (no callback). Set to a procedure to enable structured violation reporting.
+;; Example: (current-hook-violation-callback
+;;           (lambda (ext hp act sv)
+;;             (emit-session-event! bus sid "hook.violation"
+;;               (hasheq 'extension ext 'action act 'hook-point hp 'schema-version sv))))
+(define current-hook-violation-callback (make-parameter #f))
 
 ;; Internal: call handler with or without ctx based on arity.
 ;; If ctx is provided and handler accepts 2 args, call (handler ctx payload).
@@ -135,6 +145,9 @@
                              (hook-result-action raw-result)
                              hook-point
                              (hook-schema-version))
+                (let ([cb (current-hook-violation-callback)])
+                  (when cb
+                    (cb ext-name hook-point (hook-result-action raw-result) (hook-schema-version))))
                 (hook-pass payload))))
         (begin
           (log-warning "Hook handler ~a for ~a returned non-hook-result: ~v [~a]"

--- a/tests/test-hook-violation.rkt
+++ b/tests/test-hook-violation.rkt
@@ -26,3 +26,34 @@
   (define result (dispatch-hooks 'model-request-pre "test" reg))
   (check-equal? (hook-result-action result) 'amend)
   (check-equal? (hook-result-payload result) "test amended"))
+
+;; v0.28.11: Violation callback test
+(test-case "violation callback is invoked on invalid action"
+  (define violations '())
+  (parameterize ([current-hook-violation-callback
+                  (lambda (ext-name hook-point action schema-version)
+                    (set! violations
+                          (cons (list ext-name hook-point action schema-version) violations)))])
+    (define reg (make-extension-registry))
+    (define ext (extension "bad-ext" "1.0" "1.0" (hash 'turn-end (lambda (p) (hook-block "nope")))))
+    (register-extension! reg ext)
+    (define result (dispatch-hooks 'turn-end "payload" reg))
+    (check-equal? (hook-result-action result) 'pass)
+    (check-equal? (length violations) 1)
+    (check-equal? (caar violations) "bad-ext")
+    (check-equal? (cadr (car violations)) 'turn-end)
+    (check-equal? (caddr (car violations)) 'block)))
+
+(test-case "violation callback is not invoked on valid action"
+  (define violations '())
+  (parameterize ([current-hook-violation-callback (lambda args
+                                                    (set! violations (cons args violations)))])
+    (define reg (make-extension-registry))
+    (define ext (extension "good-ext" "1.0" "1.0" (hash 'turn-end (lambda (p) (hook-pass p)))))
+    (register-extension! reg ext)
+    (define result (dispatch-hooks 'turn-end "payload" reg))
+    (check-equal? (hook-result-action result) 'pass)
+    (check-equal? violations '())))
+
+(test-case "default violation callback is #f"
+  (check-false (current-hook-violation-callback)))


### PR DESCRIPTION
Addresses #3084.

feat: hook violation callback + deduplicate with-error-result macro (#3084)

F7: Add current-hook-violation-callback parameter to extensions/hooks.rkt
    for structured violation reporting (enables future quarantine)
F9: Extract with-error-result macro from 3 GitHub handler files to
    shared extensions/github/helpers.rkt
+ 4 new hook violation callback tests