### PR TITLE
fix: provider test arity mismatches (P1-P4) (#3092)

Fix check-provider-status! calls in 4 test files to use exactly 3 args:
(provider-name status-line response-body). Fix translate-stop-reason
calls to use 2 args: (provider stop-reason). All 4 test files now pass
with 0 failures: test-anthropic (133/133), test-gemini (160/160),
test-provider (28/28), test-provider-conformance (75/75).

### DIFF
--- a/tests/test-anthropic.rkt
+++ b/tests/test-anthropic.rkt
@@ -488,12 +488,13 @@
 ;; ============================================================
 
 (test-case "HTTP 200 passes without error"
-  (check-not-exn (λ () (check-provider-status! "Anthropic" "Anthropic" #"HTTP/1.1 200 OK" #"{}"))))
+  (check-not-exn (λ () (check-provider-status! "Anthropic" #"HTTP/1.1 200 OK" #"{}"))))
 
 (test-case "HTTP 401 raises authentication error"
   (check-exn #rx"authentication failed [(]401[)]"
              (λ ()
                (check-provider-status!
+                "Anthropic"
                 #"HTTP/1.1 401 Unauthorized"
                 #"{\"error\":{\"type\":\"authentication_error\",\"message\":\"Invalid API key\"}}"))))
 
@@ -501,6 +502,7 @@
   (check-exn #rx"forbidden [(]403[)]"
              (λ ()
                (check-provider-status!
+                "Anthropic"
                 #"HTTP/1.1 403 Forbidden"
                 #"{\"error\":{\"type\":\"permission_error\",\"message\":\"Access denied\"}}"))))
 
@@ -508,6 +510,7 @@
   (check-exn #rx"rate limited [(]429[)]"
              (λ ()
                (check-provider-status!
+                "Anthropic"
                 #"HTTP/1.1 429 Too Many Requests"
                 #"{\"error\":{\"type\":\"rate_limit_error\",\"message\":\"Rate limited\"}}"))))
 
@@ -515,20 +518,18 @@
   (check-exn #rx"server error [(]500[)]"
              (λ ()
                (check-provider-status!
+                "Anthropic"
                 #"HTTP/1.1 500 Internal Server Error"
                 #"{\"error\":{\"type\":\"api_error\",\"message\":\"Internal error\"}}"))))
 
 (test-case "HTTP 502 raises server error"
-  (check-exn
-   #rx"server error [(]502[)]"
-   (λ ()
-     (check-provider-status! "Anthropic" "Anthropic" #"HTTP/1.1 502 Bad Gateway" #"Bad Gateway"))))
+  (check-exn #rx"server error [(]502[)]"
+             (λ () (check-provider-status! "Anthropic" #"HTTP/1.1 502 Bad Gateway" #"Bad Gateway"))))
 
 (test-case "HTTP 400 raises generic error"
   (check-exn #rx"error [(]400[)]"
              (λ ()
                (check-provider-status! "Anthropic"
-                                       "Anthropic"
                                        #"HTTP/1.1 400 Bad Request"
                                        #"{\"error\":{\"type\":\"invalid_request_error\"}}"))))
 
@@ -915,6 +916,7 @@
   (define exn
     (with-handlers ([exn:fail? identity])
       (check-provider-status!
+       "Anthropic"
        #"HTTP/1.1 429 Too Many Requests"
        #"{\"error\":{\"type\":\"rate_limit_error\",\"message\":\"Rate limited\"}}")))
   (check-pred exn? exn)
@@ -927,6 +929,7 @@
   (define exn
     (with-handlers ([exn:fail? identity])
       (check-provider-status!
+       "Anthropic"
        #"HTTP/1.1 429 Too Many Requests"
        #"{\"error\":{\"type\":\"rate_limit_error\",\"retry_after_ms\":30000,\"message\":\"Slow down\"}}")))
   (check-pred exn? exn)

--- a/tests/test-gemini.rkt
+++ b/tests/test-gemini.rkt
@@ -492,13 +492,12 @@
 ;; ============================================================
 
 (test-case "HTTP 200 passes without error"
-  (check-not-exn (lambda () (check-provider-status! "Gemini" "Gemini" #"HTTP/1.1 200 OK" #"{}"))))
+  (check-not-exn (lambda () (check-provider-status! "Gemini" #"HTTP/1.1 200 OK" #"{}"))))
 
 (test-case "HTTP 400 raises bad request error"
   (check-exn #rx"bad request [(]400[)]"
              (lambda ()
                (check-provider-status! "Gemini"
-                                       "Gemini"
                                        #"HTTP/1.1 400 Bad Request"
                                        #"{\"error\":{\"message\":\"Invalid\"}}"))))
 
@@ -506,7 +505,6 @@
   (check-exn #rx"authentication failed [(]401[)]"
              (lambda ()
                (check-provider-status! "Gemini"
-                                       "Gemini"
                                        #"HTTP/1.1 401 Unauthorized"
                                        #"{\"error\":{\"message\":\"Invalid API key\"}}"))))
 
@@ -514,7 +512,6 @@
   (check-exn #rx"forbidden [(]403[)]"
              (lambda ()
                (check-provider-status! "Gemini"
-                                       "Gemini"
                                        #"HTTP/1.1 403 Forbidden"
                                        #"{\"error\":{\"message\":\"Access denied\"}}"))))
 
@@ -522,7 +519,6 @@
   (check-exn #rx"rate limited [(]429[)]"
              (lambda ()
                (check-provider-status! "Gemini"
-                                       "Gemini"
                                        #"HTTP/1.1 429 Too Many Requests"
                                        #"{\"error\":{\"message\":\"Rate limited\"}}"))))
 
@@ -530,14 +526,13 @@
   (check-exn #rx"server error [(]500[)]"
              (lambda ()
                (check-provider-status! "Gemini"
-                                       "Gemini"
                                        #"HTTP/1.1 500 Internal Server Error"
                                        #"{\"error\":{\"message\":\"Internal error\"}}"))))
 
 (test-case "HTTP 502 raises server error"
-  (check-exn
-   #rx"server error [(]502[)]"
-   (lambda () (check-provider-status! "Gemini" "Gemini" #"HTTP/1.1 502 Bad Gateway" #"Bad Gateway"))))
+  (check-exn #rx"server error [(]502[)]"
+             (lambda ()
+               (check-provider-status! "Gemini" #"HTTP/1.1 502 Bad Gateway" #"Bad Gateway"))))
 
 (test-case "String status-line also works"
   (check-not-exn (lambda () (check-provider-status! "Gemini" "HTTP/1.1 200 OK" "{}"))))
@@ -1014,7 +1009,6 @@
   (define exn
     (with-handlers ([exn:fail? identity])
       (check-provider-status! "Gemini"
-                              "Gemini"
                               #"HTTP/1.1 429 Too Many Requests"
                               #"{\"error\":{\"message\":\"Rate limited\"}}")))
   (check-pred exn? exn)

--- a/tests/test-provider-conformance.rkt
+++ b/tests/test-provider-conformance.rkt
@@ -268,7 +268,7 @@
                                       'translate-tool
                                       anthropic-translate-tool
                                       'translate-stop
-                                      translate-stop-reason
+                                      (lambda (r) (translate-stop-reason 'anthropic r))
                                       'stop-translations
                                       '(("end_turn" . stop) ("tool_use" . tool-calls)
                                                             ("max_tokens" . length))))
@@ -297,7 +297,7 @@
         'usage
         (hash 'prompt_tokens 10 'completion_tokens 5 'total_tokens 15))
   'check-status
-  check-provider-status!
+  (lambda (sl rb) (check-provider-status! "OpenAI-compatible" sl rb))
   'expected-stop
   'stop
   'expected-model
@@ -352,7 +352,7 @@
   'translate-tool
   gemini-translate-tool
   'translate-stop
-  translate-stop-reason
+  (lambda (r) (translate-stop-reason 'gemini r))
   'stop-translations
   '(("STOP" . stop) ("MAX_TOKENS" . length))))
 
@@ -439,15 +439,21 @@
     (check-true (symbol? (model-response-stop-reason parsed)))))
 
 (test-case "All providers: HTTP 401 raises exn:fail?"
-  (for ([check-fn (list check-provider-status! check-provider-status! check-provider-status!)])
+  (for ([check-fn (list (lambda (sl rb) (check-provider-status! "test" sl rb))
+                        (lambda (sl rb) (check-provider-status! "test" sl rb))
+                        (lambda (sl rb) (check-provider-status! "test" sl rb)))])
     (check-exn exn:fail? (lambda () (check-fn #"HTTP/1.1 401 Unauthorized" #"error")))))
 
 (test-case "All providers: HTTP 500 raises exn:fail?"
-  (for ([check-fn (list check-provider-status! check-provider-status! check-provider-status!)])
+  (for ([check-fn (list (lambda (sl rb) (check-provider-status! "test" sl rb))
+                        (lambda (sl rb) (check-provider-status! "test" sl rb))
+                        (lambda (sl rb) (check-provider-status! "test" sl rb)))])
     (check-exn exn:fail? (lambda () (check-fn #"HTTP/1.1 500 Internal Server Error" #"error")))))
 
 (test-case "All providers: HTTP 200 passes without exception"
-  (for ([check-fn (list check-provider-status! check-provider-status! check-provider-status!)])
+  (for ([check-fn (list (lambda (sl rb) (check-provider-status! "test" sl rb))
+                        (lambda (sl rb) (check-provider-status! "test" sl rb))
+                        (lambda (sl rb) (check-provider-status! "test" sl rb)))])
     (check-not-exn (lambda () (check-fn #"HTTP/1.1 200 OK" #"{}")))))
 
 (test-case "Mock provider: stream returns generator yielding stream-chunk? then #f"

--- a/tests/test-provider.rkt
+++ b/tests/test-provider.rkt
@@ -339,44 +339,39 @@
 ;; ============================================================
 
 (test-case "BUG-16: HTTP 200 passes without error"
-  (check-not-exn (λ () (check-provider-status! "Test" "Test" #"HTTP/1.1 200 OK" #"{}"))))
+  (check-not-exn (λ () (check-provider-status! "Test" #"HTTP/1.1 200 OK" #"{}"))))
 
 (test-case "BUG-16: HTTP 201 passes without error"
-  (check-not-exn (λ () (check-provider-status! "Test" "Test" #"HTTP/1.1 201 Created" #"{}"))))
+  (check-not-exn (λ () (check-provider-status! "Test" #"HTTP/1.1 201 Created" #"{}"))))
 
 (test-case "BUG-16: HTTP 401 raises error"
   (check-exn exn:fail?
              (λ ()
                (check-provider-status! "Test"
-                                       "Test"
                                        #"HTTP/1.1 401 Unauthorized"
                                        #"{\"error\":{\"message\":\"Invalid API key\"}}"))))
 
 (test-case "BUG-16: HTTP 403 raises error"
-  (check-exn exn:fail?
-             (λ () (check-provider-status! "Test" "Test" #"HTTP/1.1 403 Forbidden" #"forbidden"))))
+  (check-exn exn:fail? (λ () (check-provider-status! "Test" #"HTTP/1.1 403 Forbidden" #"forbidden"))))
 
 (test-case "BUG-16: HTTP 404 raises error"
-  (check-exn exn:fail?
-             (λ () (check-provider-status! "Test" "Test" #"HTTP/1.1 404 Not Found" #"not found"))))
+  (check-exn exn:fail? (λ () (check-provider-status! "Test" #"HTTP/1.1 404 Not Found" #"not found"))))
 
 (test-case "BUG-16: HTTP 500 raises error"
   (check-exn
    exn:fail?
-   (λ ()
-     (check-provider-status! "Test" "Test" #"HTTP/2 500 Internal Server Error" #"internal error"))))
+   (λ () (check-provider-status! "Test" #"HTTP/2 500 Internal Server Error" #"internal error"))))
 
 (test-case "BUG-16: HTTP 429 raises error with JSON body"
   (check-exn #rx"API rate limited [(]429[)]"
              (λ ()
                (check-provider-status! "Test"
-                                       "Test"
                                        #"HTTP/1.1 429 Too Many Requests"
                                        #"{\"error\":{\"message\":\"Rate limited\"}}"))))
 
 (test-case "BUG-16: HTTP 301 redirect raises error"
   (check-exn #rx"redirected"
-             (λ () (check-provider-status! "Test" "Test" #"HTTP/1.1 301 Moved Permanently" #""))))
+             (λ () (check-provider-status! "Test" #"HTTP/1.1 301 Moved Permanently" #""))))
 
 (test-case "BUG-16: String status-line also works"
   (check-not-exn (λ () (check-provider-status! "Test" "HTTP/1.1 200 OK" #"{}"))))


### PR DESCRIPTION
Addresses #3092.

fix: provider test arity mismatches (P1-P4) (#3092)

Fix check-provider-status! calls in 4 test files to use exactly 3 args:
(provider-name status-line response-body). Fix translate-stop-reason
calls to use 2 args: (provider stop-reason). All 4 test files now pass
with 0 failures: test-anthropic (133/133), test-gemini (160/160),
test-provider (28/28), test-provider-conformance (75/75).