### PR TITLE
fix: translate-stop-reason arity in test-anthropic + test-gemini (#3098)

F1: Add 'anthropic first arg to 7 translate-stop-reason calls in test-anthropic.rkt.
F2: Add 'gemini first arg to 7 translate-stop-reason calls in test-gemini.rkt.
All 133 anthropic tests and 160 gemini tests now pass.

### DIFF
--- a/tests/test-anthropic.rkt
+++ b/tests/test-anthropic.rkt
@@ -587,13 +587,13 @@
 ;; 29. Stop reason translation helper
 ;; ============================================================
 
-(check-equal? (translate-stop-reason "end_turn") 'stop)
-(check-equal? (translate-stop-reason "max_tokens") 'length)
-(check-equal? (translate-stop-reason "stop_sequence") 'stop)
-(check-equal? (translate-stop-reason "tool_use") 'tool-calls)
-(check-equal? (translate-stop-reason "unknown_reason") 'unknown_reason)
-(check-equal? (translate-stop-reason 'already-symbol) 'already-symbol)
-(check-equal? (translate-stop-reason 123) 'stop)
+(check-equal? (translate-stop-reason 'anthropic "end_turn") 'stop)
+(check-equal? (translate-stop-reason 'anthropic "max_tokens") 'length)
+(check-equal? (translate-stop-reason 'anthropic "stop_sequence") 'stop)
+(check-equal? (translate-stop-reason 'anthropic "tool_use") 'tool-calls)
+(check-equal? (translate-stop-reason 'anthropic "unknown_reason") 'unknown_reason)
+(check-equal? (translate-stop-reason 'anthropic 'already-symbol) 'already-symbol)
+(check-equal? (translate-stop-reason 'anthropic 123) 'stop)
 
 ;; ============================================================
 ;; 31. Issue #106 — Anthropic multi-turn tool use: assistant tool_calls

--- a/tests/test-gemini.rkt
+++ b/tests/test-gemini.rkt
@@ -563,13 +563,13 @@
 ;; 22. Stop reason translation helper (all variants)
 ;; ============================================================
 
-(check-equal? (translate-stop-reason "STOP") 'stop)
-(check-equal? (translate-stop-reason "MAX_TOKENS") 'length)
-(check-equal? (translate-stop-reason "SAFETY") 'content-filtered)
-(check-equal? (translate-stop-reason "RECITATION") 'content-filtered)
-(check-equal? (translate-stop-reason "OTHER") 'OTHER "unknown reason → symbol")
-(check-equal? (translate-stop-reason 'already-symbol) 'already-symbol)
-(check-equal? (translate-stop-reason 123) 'stop "non-string/non-symbol → stop")
+(check-equal? (translate-stop-reason 'gemini "STOP") 'stop)
+(check-equal? (translate-stop-reason 'gemini "MAX_TOKENS") 'length)
+(check-equal? (translate-stop-reason 'gemini "SAFETY") 'content-filtered)
+(check-equal? (translate-stop-reason 'gemini "RECITATION") 'content-filtered)
+(check-equal? (translate-stop-reason 'gemini "OTHER") 'OTHER "unknown reason → symbol")
+(check-equal? (translate-stop-reason 'gemini 'already-symbol) 'already-symbol)
+(check-equal? (translate-stop-reason 'gemini 123) 'stop "non-string/non-symbol → stop")
 
 ;; ============================================================
 ;; 23. gemini-build-request-body — streaming flag (accepted but not in body)


### PR DESCRIPTION
Addresses #3098.

fix: translate-stop-reason arity in test-anthropic + test-gemini (#3098)

F1: Add 'anthropic first arg to 7 translate-stop-reason calls in test-anthropic.rkt.
F2: Add 'gemini first arg to 7 translate-stop-reason calls in test-gemini.rkt.
All 133 anthropic tests and 160 gemini tests now pass.