### PR TITLE
feat: immediate feedback on submit — busy? flag + turn.started early + user transcript entry (#3102)

F1: Set busy?=#t immediately on submit so status bar shows [thinking...] before LLM responds.
F2: Emit turn.started event in run-prompt! before context build/compaction (idempotent).
F1: Add user message to TUI transcript immediately on submit (display-only, no JSONL duplicate).

Wave 0 of v0.28.14.

### DIFF
--- a/runtime/session-lifecycle.rkt
+++ b/runtime/session-lifecycle.rkt
@@ -342,6 +342,12 @@
   (set-agent-session-prompt-running?! sess #t)
   (define bus (agent-session-event-bus sess))
   (define sid (agent-session-session-id sess))
+  ;; F2: Emit turn.started immediately so TUI shows activity
+  ;; before context build + compaction. The handler in state-events.rkt
+  ;; is idempotent (just sets busy? #t), so the second turn.started
+  ;; from agent/loop.rkt during iteration is safe.
+  (emit-session-event! bus sid "turn.started"
+                       (hasheq 'turnId #f 'sessionId sid))
   (define base-cfg (agent-session-config sess))
   ;; #1391: Inject session index into config for session_recall tool access
   (dynamic-wind

--- a/tui/tui-render-loop.rkt
+++ b/tui/tui-render-loop.rkt
@@ -328,6 +328,21 @@
                     (mark-dirty! ctx)]
                    [else
                     ;; Not busy (or no queue) — submit to runtime (non-blocking)
+                    ;; F1: Immediately set busy? so status bar shows [thinking...]
+                    ;; before the LLM responds (was waiting for turn.started event)
+                    (set-box! (tui-ctx-ui-state-box ctx)
+                              (struct-copy ui-state
+                                           cur-state
+                                           [busy? #t]
+                                           [streaming-text #f]
+                                           [pending-tool-name #f]))
+                    (mark-dirty! ctx)
+                    ;; F1: Show user message in transcript immediately
+                    ;; (don't wait for JSONL events — the TUI transcript is display-only)
+                    (define user-entry (make-entry 'user text (current-inexact-milliseconds) (hash)))
+                    (set-box! (tui-ctx-ui-state-box ctx)
+                              (add-transcript-entry (unbox (tui-ctx-ui-state-box ctx)) user-entry))
+                    (mark-dirty! ctx)
                     (define runner (tui-ctx-session-runner ctx))
                     ;; Wrap runner thread with exception handler to prevent TUI hang
                     (thread (lambda ()


### PR DESCRIPTION
Addresses #3102.

feat: immediate feedback on submit — busy? flag + turn.started early + user transcript entry (#3102)

F1: Set busy?=#t immediately on submit so status bar shows [thinking...] before LLM responds.
F2: Emit turn.started event in run-prompt! before context build/compaction (idempotent).
F1: Add user message to TUI transcript immediately on submit (display-only, no JSONL duplicate).

Wave 0 of v0.28.14.