### PR TITLE
feat: remove header, enhance status bar, fix HTTP 400 regex (#3106)

F3: Remove header row from layout (frees 1 line for transcript). 
    Guard header rendering with (when header-row ...) for backwards compat.
F3b: Enhanced multi-segment status bar — inverse content only (not full line),
     context tokens (ctx:12K), cost tracker ($0.04), busy/thinking/streaming indicators.
F3c: Inverse video covers only content portion; rest of line is plain spaces.
P1: Fix HTTP 400 regex test — #rx"[(]400[)]" matches actual error message.

Wave 1 of v0.28.14.

### DIFF
--- a/tests/test-anthropic.rkt
+++ b/tests/test-anthropic.rkt
@@ -527,7 +527,7 @@
              (λ () (check-provider-status! "Anthropic" #"HTTP/1.1 502 Bad Gateway" #"Bad Gateway"))))
 
 (test-case "HTTP 400 raises generic error"
-  (check-exn #rx"error [(]400[)]"
+  (check-exn #rx"[(]400[)]"
              (λ ()
                (check-provider-status! "Anthropic"
                                        #"HTTP/1.1 400 Bad Request"

--- a/tui/layout.rkt
+++ b/tui/layout.rkt
@@ -25,8 +25,7 @@
 
 ;; Compute layout given screen dimensions
 ;; Layout (0-based row numbers):
-;;   Row 0:        Header (1 line) — "q | session | model"
-;;   Row 1..H-3:   Transcript (H-3 lines)
+;;   Row 0..H-3:   Transcript (H-2 lines)
 ;;   Row H-2:      Status bar (1 line)
 ;;   Row H-1:      Input line (1 line)
 (define (compute-layout cols rows)
@@ -35,15 +34,15 @@
 ;; Compute layout accounting for widget container rows.
 ;; widget-rows-above: number of widget lines above input.
 (define (compute-layout-with-widgets cols rows [widget-rows-above 0])
-  (define min-height 4) ; Need at least header + 1 transcript + status + input
+  (define min-height 3) ; Need at least 1 transcript + status + input
   (define actual-rows (max min-height rows))
-  (define non-transcript (+ 3 widget-rows-above))
+  (define non-transcript (+ 2 widget-rows-above)) ; status + input (no header)
   (define transcript-h (max 1 (- actual-rows non-transcript)))
   (tui-layout cols
               actual-rows
-              0 ; header-row
-              1 ; transcript-start-row
+              #f ; header-row: #f = no header (v0.28.14)
+              0 ; transcript-start-row
               transcript-h ; transcript-height
-              (+ 1 transcript-h widget-rows-above) ; status-row
-              (+ 2 transcript-h widget-rows-above) ; input-row
+              (+ transcript-h widget-rows-above) ; status-row
+              (+ 1 transcript-h widget-rows-above) ; input-row
               ))

--- a/tui/render/status-line.rkt
+++ b/tui/render/status-line.rkt
@@ -3,8 +3,10 @@
 ;; q/tui/render/status-line.rkt — status bar and input line rendering
 ;;
 ;; Pure functions that compose status bar and input line.
+;; v0.28.14: Multi-segment status bar — inverse content + normal context/cost.
 
 (require racket/string
+         "../../util/cost-tracker.rkt"
          "../state.rkt"
          "../input.rkt"
          "../char-width.rkt"
@@ -14,33 +16,53 @@
 (provide render-status-bar
          render-input-line)
 
-;; Render the status bar.
-;; Always uses inverse style (bg=7) for visibility.
-;; Composes: prefix | session | model [tool] [thinking] [queues] [scroll] [No API key]
+;; ── Token formatting helper ──
+
+(define (format-tokens n)
+  (cond
+    [(>= n 1000000) (format "~aM" (exact->inexact (/ (round (/ n 1000)) 1000)))]
+    [(>= n 1000) (format "~aK" (exact->inexact (/ (round (/ n 100)) 100)))]
+    [else (format "~a" n)]))
+
+;; ── Status bar ──
+
+;; Render the status bar as a multi-segment styled-line.
+;; Inverse video covers ONLY the content portion; the rest of the line
+;; is plain spaces (no inverse fill to end of line).
+;; Segments: prefix | session | model | state | [ctx] [cost] [scroll]
 (define (render-status-bar state width)
-  (define session-name (or (ui-state-session-id state) "q"))
+  (define session-name (ui-state-session-id state))
+  (define session-label
+    (if (and session-name (> (string-length session-name) 8))
+        (substring session-name (- (string-length session-name) 8))
+        (or session-name "q")))
   (define model-name (or (ui-state-model-name state) ""))
   (define busy (ui-state-busy? state))
   (define status-msg (ui-state-status-message state))
   (define pending-tool (ui-state-pending-tool-name state))
+  (define streaming (ui-state-streaming-text state))
   (define queue-cts (ui-state-queue-counts state))
   (define scroll-off (ui-state-scroll-offset state))
-  ;; Build status text
-  (define base-text
+  (define ctx-tokens (ui-state-context-tokens state))
+  (define cost-trk (ui-state-cost-tracker state))
+
+  ;; Build state indicator based on busy state
+  (define state-indicator
     (cond
-      ;; Status message takes priority when set
-      [(and status-msg (not (string=? status-msg "")))
-       (format " q * ~a | ~a" session-name status-msg)]
-      [busy
-       (define tool-part
-         (if pending-tool
-             (format " [~a]" pending-tool)
-             ""))
-       (define think-part (if (ui-state-streaming-text state) "" " [thinking...]"))
-       (format " q * ~a | ~a~a~a" session-name model-name tool-part think-part)]
-      [(string=? model-name "") (format " q   ~a [No API key]" session-name)]
-      [else (format " q   ~a | ~a" session-name model-name)]))
-  ;; Append queue counts if present
+      [(and status-msg (not (string=? status-msg ""))) (format " | ~a" status-msg)]
+      [(and busy pending-tool) (format " | ~a [~a]" model-name pending-tool)]
+      [(and busy (not streaming))
+       (if (string=? model-name "")
+           " [thinking...]"
+           (format " | ~a [thinking...]" model-name))]
+      [(and busy streaming)
+       (if (string=? model-name "")
+           " [streaming...]"
+           (format " | ~a [streaming...]" model-name))]
+      [(string=? model-name "") ""]
+      [else (format " | ~a" model-name)]))
+
+  ;; Queue counts
   (define queue-text
     (if (and queue-cts (hash? queue-cts) (positive? (hash-count queue-cts)))
         (let* ([parts (for/list ([(k v) (in-hash queue-cts)])
@@ -48,11 +70,34 @@
                [joined (string-join parts " ")])
           (format " [~a]" joined))
         ""))
-  ;; Append scroll indicator if scrolled
+
+  ;; Inverse segment (prefix + session + model + state)
+  (define busy-marker (if busy " *" "  "))
+  (define inv-text (string-append " q" busy-marker " " session-label state-indicator queue-text))
+
+  ;; Normal-style segments (context + cost + scroll)
+  (define ctx-part
+    (if ctx-tokens
+        (format " ctx:~a" (format-tokens ctx-tokens))
+        ""))
+  (define cost-part
+    (if (and cost-trk (positive? (cost-tracker-input-tokens-total cost-trk)))
+        (format " ~a" (format-cost (cost-tracker-total cost-trk)))
+        ""))
   (define scroll-text (if (and scroll-off (positive? scroll-off)) " \u2191" ""))
-  (define full-text (string-append base-text queue-text scroll-text))
-  (define style (theme->style 'status-busy '(inverse)))
-  (styled-line (list (styled-segment full-text style))))
+  (define normal-text (string-append ctx-part cost-part scroll-text))
+
+  ;; Padding to fill remaining width (plain spaces, no inverse)
+  (define used (+ (string-length inv-text) (string-length normal-text)))
+  (define padding (make-string (max 0 (- width used)) #\space))
+
+  ;; Build styled-line with 3 segments: inverse-content, normal-info, padding
+  (define inv-style (theme->style 'status-busy '(inverse)))
+  (styled-line (list (styled-segment inv-text inv-style)
+                     (styled-segment normal-text '())
+                     (styled-segment padding '()))))
+
+;; ── Input line ──
 
 ;; Render the input line with prompt.
 (define (render-input-line input-st width)

--- a/tui/renderer.rkt
+++ b/tui/renderer.rkt
@@ -248,7 +248,6 @@
   (define ubuf-putstring! (current-ubuf-putstring))
 
   ;; Layout rows are 0-based, matching ubuf's 0-based indexing.
-  (define header-y header-row)
   (define trans-y transcript-start-row)
   (define status-y status-row)
   (define input-y input-row)
@@ -256,14 +255,17 @@
   ;; 1. Clear the buffer
   (ubuf-clear! ubuf)
 
-  ;; 2. Draw header row (inverse = fg=0, bg=7)
-  (define header-text (format " q ~a" (make-string (max 0 (- cols 3)) #\space)))
-  (ubuf-putstring! ubuf 0 header-y header-text #:fg 0 #:bg 7)
+  ;; 2. Draw header row (only if header-row is not #f)
+  (when header-row
+    (define header-text (format " q ~a" (make-string (max 0 (- cols 3)) #\space)))
+    (ubuf-putstring! ubuf 0 header-row header-text #:fg 0 #:bg 7))
 
   ;; Build frame-lines for diffing
   (define frame-vec (make-vector rows ""))
   ;; Header: store ANSI-encoded (inverse video) for correct incremental diff
-  (vector-set! frame-vec header-y (string-append "\x1b[0m\x1b[30;47m" header-text "\x1b[0m"))
+  (when header-row
+    (define header-text (format " q ~a" (make-string (max 0 (- cols 3)) #\space)))
+    (vector-set! frame-vec header-row (string-append "\x1b[0m\x1b[30;47m" header-text "\x1b[0m")))
 
   ;; 3. Draw transcript entries (with render cache)
   (define-values (trans-lines-raw ui-state*) (render-transcript ui-state transcript-height cols))


### PR DESCRIPTION
Addresses #3106.

feat: remove header, enhance status bar, fix HTTP 400 regex (#3106)

F3: Remove header row from layout (frees 1 line for transcript). 
    Guard header rendering with (when header-row ...) for backwards compat.
F3b: Enhanced multi-segment status bar — inverse content only (not full line),
     context tokens (ctx:12K), cost tracker ($0.04), busy/thinking/streaming indicators.
F3c: Inverse video covers only content portion; rest of line is plain spaces.
P1: Fix HTTP 400 regex test — #rx"[(]400[)]" matches actual error message.

Wave 1 of v0.28.14.