### PR TITLE
feat: unified lint runner, Racket caching, smoke independence (#3119)

C1: New scripts/lint-all.rkt — runs all 16 lint checks via subprocess
    in a single process with structured summary output.
C2: Add actions/cache to setup-racket for ~/.racket and compiled/.
    Cache key: OS + racket version + info.rkt hash.
C3: Decouple smoke from test matrix (needs: lint instead of needs: test).
    Replace 16 individual lint steps with single lint-all.rkt invocation.

Wave 0 of v0.28.15.

### DIFF
--- a/.github/actions/setup-racket/action.yml
+++ b/.github/actions/setup-racket/action.yml
@@ -8,6 +8,16 @@ inputs:
 runs:
   using: 'composite'
   steps:
+    - name: Cache Racket packages
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.racket
+          ./compiled
+        key: racket-${{ runner.os }}-${{ inputs.racket-version }}-${{ hashFiles('info.rkt') }}
+        restore-keys: |
+          racket-${{ runner.os }}-${{ inputs.racket-version }}-
+
     - name: Install Racket via apt (Linux)
       if: runner.os == 'Linux'
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,52 +25,6 @@ jobs:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-racket
 
-      - name: Format lint
-        run: racket scripts/lint-format.rkt
-
-      - name: Version sync check (all docs)
-        run: racket scripts/sync-version.rkt --all
-
-      - name: README status validation
-        run: racket scripts/sync-version.rkt --validate
-
-      - name: Version cross-check
-        run: racket scripts/lint-version.rkt
-
-      - name: Protocol consistency
-        run: racket scripts/check-protocols.rkt
-
-      - name: Import conflicts
-        run: racket scripts/check-imports.rkt
-
-      - name: Dependency completeness
-        run: racket scripts/check-deps.rkt
-
-      - name: Metrics sync
-        run: racket scripts/metrics.rkt --sync-all && racket scripts/metrics.rkt --lint
-
-      - name: Prose metrics
-        run: racket scripts/metrics.rkt --lint-prose
-
-      - name: README status block
-        run: racket scripts/sync-readme-status.rkt --check
-
-      - name: Project audit
-        run: racket scripts/audit-project.rkt --ci
-        continue-on-error: true
-
-      - name: Test portability
-        run: racket scripts/lint-tests.rkt
-
-      - name: Deprecation deadline check
-        run: racket scripts/lint-deprecation-deadlines.rkt --ci
-
-      - name: CI readiness
-        run: racket scripts/lint-ci-readiness.rkt
-
-      - name: Architecture fitness gate
-        run: racket scripts/arch-report.rkt --ci
-
       - name: Workflow YAML validation
         run: |
           pip install pyyaml
@@ -88,6 +42,9 @@ jobs:
             sys.exit(1)
           print('All workflows and actions valid YAML')
           "
+
+      - name: Run all lint checks
+        run: racket scripts/lint-all.rkt
 
   # ────────────────────────────────────────────────────────────
   # Gate 2: Test matrix — depends on lint passing
@@ -161,10 +118,10 @@ jobs:
           echo "Release notes generated ($(wc -l < /tmp/notes.md) lines)"
 
   # ────────────────────────────────────────────────────────────
-  # Gate 4: Smoke — depends on test matrix passing
+  # Gate 4: Smoke — depends on lint only (not test)
   # ────────────────────────────────────────────────────────────
   smoke:
-    needs: test
+    needs: lint
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]

--- a/scripts/lint-all.rkt
+++ b/scripts/lint-all.rkt
@@ -1,0 +1,148 @@
+#!/usr/bin/env racket
+#lang racket/base
+
+;; scripts/lint-all.rkt — Unified CI lint runner
+;;
+;; Runs all lint/check scripts in a single process via subprocess.
+;; Zero refactoring of existing scripts needed.
+;;
+;; Exit codes:
+;;   0 — all checks pass
+;;   1 — one or more failures
+;;
+;; Usage:
+;;   racket scripts/lint-all.rkt            # run all checks
+;;   racket scripts/lint-all.rkt --list     # list checks without running
+;;   racket scripts/lint-all.rkt --only format,version  # run subset
+
+(require racket/list
+         racket/string
+         racket/system
+         racket/port)
+
+;; ── Check definitions ──
+;; Each check: (name script-path args continue-on-error?)
+
+(define checks
+  (list
+   (list "format"            "scripts/lint-format.rkt"              '()              #f)
+   (list "version-sync"      "scripts/sync-version.rkt"             '("--all")        #f)
+   (list "version-validate"  "scripts/sync-version.rkt"             '("--validate")   #f)
+   (list "version-cross"     "scripts/lint-version.rkt"             '()               #f)
+   (list "protocols"         "scripts/check-protocols.rkt"          '()               #f)
+   (list "imports"           "scripts/check-imports.rkt"            '()               #f)
+   (list "deps"              "scripts/check-deps.rkt"               '()               #f)
+   (list "metrics-sync"      "scripts/metrics.rkt"                  '("--sync-all")   #f)
+   (list "metrics-lint"      "scripts/metrics.rkt"                  '("--lint")       #f)
+   (list "prose"             "scripts/metrics.rkt"                  '("--lint-prose") #f)
+   (list "readme-status"     "scripts/sync-readme-status.rkt"       '("--check")      #f)
+   (list "audit"             "scripts/audit-project.rkt"            '("--ci")         #t)
+   (list "tests"             "scripts/lint-tests.rkt"               '()               #f)
+   (list "deprecation"       "scripts/lint-deprecation-deadlines.rkt" '("--ci")       #f)
+   (list "ci-readiness"      "scripts/lint-ci-readiness.rkt"        '()               #f)
+   (list "arch"              "scripts/arch-report.rkt"              '("--ci")         #f)))
+
+;; ── Helpers ──
+
+(define (find-racket)
+  (or (find-executable-path "racket")
+      (find-executable-path "raco")
+      (error "racket not found in PATH")))
+
+(define (run-check name script args)
+  (define racket-path (find-racket))
+  (define cmd-args (append (list script) args))
+  (define-values (sp child-stdout child-stdin child-stderr)
+    (apply subprocess #f #f #f racket-path cmd-args))
+  (close-output-port child-stdin)
+  (define stdout-text (port->string child-stdout))
+  (define stderr-text (port->string child-stderr))
+  (close-input-port child-stdout)
+  (close-input-port child-stderr)
+  (define code (subprocess-status sp))
+  (values code stdout-text stderr-text))
+
+(define (print-banner n)
+  (printf "~n── q CI Lint (~a checks) ──~n" n))
+
+(define (print-summary passed failed warned)
+  (printf "~n── Summary: ~a passed" passed)
+  (when (positive? failed)
+    (printf ", ~a failed" failed))
+  (when (positive? warned)
+    (printf ", ~a warnings" warned))
+  (displayln " ──"))
+
+;; ── Main ──
+
+(define (main)
+  (define argv (vector->list (current-command-line-arguments)))
+
+  ;; --list mode
+  (when (member "--list" argv)
+    (for ([c (in-list checks)])
+      (printf "  ~a — ~a ~a~n" (car c) (cadr c)
+              (if (null? (caddr c)) "" (string-join (caddr c) " "))))
+    (exit 0))
+
+  ;; --only filter
+  (define only-arg (findf (λ (a) (string-prefix? a "--only=")) argv))
+  (define only-names
+    (if only-arg
+        (string-split (substring only-arg (string-length "--only=")) ",")
+        #f))
+
+  (define active-checks
+    (if only-names
+        (filter (λ (c) (member (car c) only-names)) checks)
+        checks))
+
+  (print-banner (length active-checks))
+
+  (define passed 0)
+  (define failed 0)
+  (define warned 0)
+
+  (for ([c (in-list active-checks)])
+    (define name (car c))
+    (define script (cadr c))
+    (define args (caddr c))
+    (define continue? (cadddr c))
+
+    ;; Check script exists
+    (unless (file-exists? script)
+      (printf "  [SKIP] ~a — script not found: ~a~n" name script)
+      (set! warned (add1 warned)))
+
+    (when (file-exists? script)
+      (define-values (code stdout stderr) (run-check name script args))
+      (cond
+        [(zero? code)
+         (printf "  [PASS] ~a~n" name)
+         (set! passed (add1 passed))]
+        [continue?
+         (printf "  [WARN] ~a (non-blocking)~n" name)
+         (when (and stderr (not (string=? stderr "")))
+           (for ([line (in-list (string-split stderr "\n"))])
+             (when (non-empty-string? line)
+               (printf "         ~a~n" line))))
+         (set! warned (add1 warned))]
+        [else
+         (printf "  [FAIL] ~a~n" name)
+         ;; Show relevant output lines (last 5 of stdout + any stderr)
+         (when (and stdout (not (string=? stdout "")))
+           (define lines (filter non-empty-string? (string-split stdout "\n")))
+           (define tail (take-right lines (min 5 (length lines))))
+           (for ([line (in-list tail)])
+             (printf "         ~a~n" line)))
+         (when (and stderr (not (string=? stderr "")))
+           (for ([line (in-list (string-split stderr "\n"))])
+             (when (non-empty-string? line)
+               (printf "         ~a~n" line))))
+         (set! failed (add1 failed))])))
+
+  (print-summary passed failed warned)
+
+  (exit (if (positive? failed) 1 0)))
+
+(main)


### PR DESCRIPTION
Addresses #3119.

feat: unified lint runner, Racket caching, smoke independence (#3119)

C1: New scripts/lint-all.rkt — runs all 16 lint checks via subprocess
    in a single process with structured summary output.
C2: Add actions/cache to setup-racket for ~/.racket and compiled/.
    Cache key: OS + racket version + info.rkt hash.
C3: Decouple smoke from test matrix (needs: lint instead of needs: test).
    Replace 16 individual lint steps with single lint-all.rkt invocation.

Wave 0 of v0.28.15.