### PR TITLE
feat: CI self-healing, version matrix, manual dispatch (#3123)

C4: Add --fix flag to sync-version.rkt — applies fixes, stages, commits,
    and pushes. Falls back gracefully on fork PRs (read-only token).
C5: Add Racket 8.11 to test matrix (ubuntu+8.11). Switch Linux from
    apt-get to Bogdanp/setup-racket for version pinning. 3 matrix cells.
C6: Add workflow_dispatch with racket-version input override. Enables
    manual testing against Racket 8.12+ from GitHub Actions UI.

Wave 1 of v0.28.15.

### DIFF
--- a/.github/actions/setup-racket/action.yml
+++ b/.github/actions/setup-racket/action.yml
@@ -18,18 +18,7 @@ runs:
         restore-keys: |
           racket-${{ runner.os }}-${{ inputs.racket-version }}-
 
-    - name: Install Racket via apt (Linux)
-      if: runner.os == 'Linux'
-      shell: bash
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y racket racket-common
-        which racket || echo "racket not in PATH"
-        which raco || echo "raco not in PATH"
-        racket --version
-
-    - name: Install Racket (macOS)
-      if: runner.os == 'macOS'
+    - name: Install Racket
       uses: Bogdanp/setup-racket@v1.15
       with:
         racket-version: ${{ inputs.racket-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,13 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-  workflow_dispatch:  # Allow manual re-runs from GitHub UI
+  workflow_dispatch:
+    inputs:
+      racket-version:
+        description: 'Racket version override (e.g. 8.11, 8.12)'
+        required: false
+        default: ''
+        type: string
 
 # Cancel superseded runs on the same branch/PR
 concurrency:
@@ -24,6 +30,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-racket
+        with:
+          racket-version: ${{ github.event.inputs.racket-version || '8.10' }}
 
       - name: Workflow YAML validation
         run: |
@@ -57,6 +65,8 @@ jobs:
         include:
           - os: ubuntu-latest
             racket-version: '8.10'
+          - os: ubuntu-latest
+            racket-version: '8.11'
           - os: macos-latest
             racket-version: '8.10'
     runs-on: ${{ matrix.os }}
@@ -64,7 +74,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-racket
         with:
-          racket-version: ${{ matrix.racket-version }}
+          racket-version: ${{ github.event.inputs.racket-version || matrix.racket-version }}
 
       - name: Run tests
         run: racket scripts/run-tests.rkt 2>&1 | tee test-output.log
@@ -94,6 +104,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-racket
+        with:
+          racket-version: ${{ github.event.inputs.racket-version || '8.10' }}
 
       - name: Build tarball (dry-run)
         run: |
@@ -129,6 +141,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-racket
+        with:
+          racket-version: ${{ github.event.inputs.racket-version || '8.10' }}
 
       - name: Version smoke check
         run: |

--- a/scripts/sync-version.rkt
+++ b/scripts/sync-version.rkt
@@ -13,8 +13,11 @@
 ;;   racket scripts/sync-version.rkt              # dry-run (report only)
 ;;   racket scripts/sync-version.rkt --write      # write info.rkt + README.md
 ;;   racket scripts/sync-version.rkt --write --all  # write all surfaces including docs/
+;;   racket scripts/sync-version.rkt --fix          # auto-fix + git commit + push
+;;   racket scripts/sync-version.rkt --fix --all    # auto-fix all docs + git commit + push
 ;;
 ;; Exit 0 if all in sync, 1 if drift detected (or --write applied fixes).
+;; --fix mode: applies fixes, stages changed files, commits, and pushes.
 
 (require racket/file
          racket/list
@@ -185,9 +188,10 @@
 
 (define (main)
   (define args (vector->list (current-command-line-arguments)))
-  (define write-mode? (member "--write" args))
+  (define write-mode? (or (member "--write" args) (member "--fix" args)))
   (define all-mode? (member "--all" args))
   (define validate-mode? (member "--validate" args))
+  (define fix-mode? (member "--fix" args))
 
   ;; --- Read canonical version from util/version.rkt ---
   (define util-path (build-path (current-directory) "util" "version.rkt"))
@@ -262,8 +266,37 @@
     [(= changes 0)
      (displayln "All targets in sync. No changes needed.")
      (exit 0)]
-    [write-mode?
+    [(or write-mode? fix-mode?)
      (printf "~a change(s) synced.~n" changes)
+     ;; --fix mode: git add + commit + push
+     (when fix-mode?
+       (printf "~n--- Auto-fix: committing changes ---~n")
+       (define git "git")
+       (define (git-run . cmd-args)
+         (define-values (sp stdout-pipe stdin-pipe stderr-pipe)
+           (apply subprocess #f #f #f (find-executable-path git) cmd-args))
+         (close-output-port stdin-pipe)
+         (define out (port->string stdout-pipe))
+         (close-input-port stdout-pipe)
+         (close-input-port stderr-pipe)
+         (define code (subprocess-status sp))
+         (values code out))
+       (define-values (add-code add-out) (git-run "add" "info.rkt" "README.md"))
+       (when all-mode?
+         ;; Stage all changed .md files in docs/ and wiki-src/
+         (git-run "add" "docs/" "wiki-src/"))
+       (define commit-msg (format "chore: sync version refs to ~a [auto]" version))
+       (define-values (commit-code commit-out) (git-run "commit" "-m" commit-msg))
+       (cond
+         [(zero? commit-code)
+          (printf "  Committed: ~a~n" commit-msg)
+          (define-values (push-code push-out) (git-run "push"))
+          (cond
+            [(zero? push-code) (printf "  Pushed to remote.~n")]
+            [else
+             (printf "  WARNING: git push failed (may be read-only token): ~a~n"
+                     (string-trim push-out))])]
+         [else (printf "  Nothing to commit (changes already committed).~n")]))
      (exit 0)]
     [else
      (printf "~a change(s) out of sync. Run with --write to fix.~n" changes)


### PR DESCRIPTION
Addresses #3123.

feat: CI self-healing, version matrix, manual dispatch (#3123)

C4: Add --fix flag to sync-version.rkt — applies fixes, stages, commits,
    and pushes. Falls back gracefully on fork PRs (read-only token).
C5: Add Racket 8.11 to test matrix (ubuntu+8.11). Switch Linux from
    apt-get to Bogdanp/setup-racket for version pinning. 3 matrix cells.
C6: Add workflow_dispatch with racket-version input override. Enables
    manual testing against Racket 8.12+ from GitHub Actions UI.

Wave 1 of v0.28.15.