### PR TITLE
feat: TUI status bar always shows ctx:0 and error state (#3138)

S1/S4: Always show ctx:N in normal segment (defaults to 0 when no context).
S2: Error messages persist in status bar via status-message field. Cleared
    on turn.started (next prompt). truncate-status-msg helper limits to 40 chars.
S1: Add tests for ctx:0 default and error state display.

Wave 1 of v0.28.16.

### DIFF
--- a/tests/tui/render.rkt
+++ b/tests/tui/render.rkt
@@ -955,6 +955,19 @@
       (define line (render-status-bar s 80))
       (define text (styled-line->text line))
       ;; The warning should contain "[No API key]"
-      (check-not-false (string-contains? text "[No API key]") "formatted warning visible"))))
+      (check-not-false (string-contains? text "[No API key]") "formatted warning visible"))
+
+    (test-case "status bar shows ctx:0 when no context built"
+      (define s (initial-ui-state #:session-id "s1" #:model-name "gpt-4"))
+      (define line (render-status-bar s 80))
+      (define text (styled-line->text line))
+      (check-true (string-contains? text "ctx:0") "shows ctx:0 when no context"))
+
+    (test-case "status bar shows error in status-message"
+      (define s (struct-copy ui-state (initial-ui-state #:session-id "s1")
+                              [status-message "API key error"]))
+      (define line (render-status-bar s 80))
+      (define text (styled-line->text line))
+      (check-true (string-contains? text "API key error") "error shown in status bar"))))
 
 (run-tests bug55-tests)

--- a/tui/render/status-line.rkt
+++ b/tui/render/status-line.rkt
@@ -76,10 +76,8 @@
   (define inv-text (string-append " q" busy-marker " " session-label state-indicator queue-text))
 
   ;; Normal-style segments (context + cost + scroll)
-  (define ctx-part
-    (if ctx-tokens
-        (format " ctx:~a" (format-tokens ctx-tokens))
-        ""))
+  ;; Always show context tokens — default to 0 when not yet built
+  (define ctx-part (format " ctx:~a" (format-tokens (or ctx-tokens 0))))
   (define cost-part
     (if (and cost-trk (positive? (cost-tracker-input-tokens-total cost-trk)))
         (format " ~a" (format-cost (cost-tracker-total cost-trk)))

--- a/tui/state-events.rkt
+++ b/tui/state-events.rkt
@@ -19,6 +19,13 @@
 (define (ui-model-label state)
   (or (ui-state-model-name state) "no model"))
 
+;; Truncate error messages for status bar display
+(define (truncate-status-msg msg)
+  (define clean (string-replace (string-trim msg) "\n" " "))
+  (if (> (string-length clean) 40)
+      (string-append (substring clean 0 37) "...")
+      clean))
+
 ;; ============================================================
 ;; Event reduction
 ;; ============================================================
@@ -148,7 +155,8 @@
                     [busy? #f]
                     [pending-tool-name #f]
                     [streaming-text #f]
-                    [streaming-thinking #f]))
+                    [streaming-thinking #f]
+                    [status-message (truncate-status-msg err)]))
      (define s2 (append-entry s1 (make-entry 'error (format "Error: ~a" err) ts (hash))))
      (append-entry s2 (make-entry 'system hint ts (hash)))]
 
@@ -176,7 +184,8 @@
                   [busy? #t]
                   [pending-tool-name #f]
                   [streaming-text #f]
-                  [streaming-thinking #f])]
+                  [streaming-thinking #f]
+                  [status-message #f])]
 
     [("turn.completed")
      (struct-copy ui-state


### PR DESCRIPTION
Addresses #3138.

feat: TUI status bar always shows ctx:0 and error state (#3138)

S1/S4: Always show ctx:N in normal segment (defaults to 0 when no context).
S2: Error messages persist in status bar via status-message field. Cleared
    on turn.started (next prompt). truncate-status-msg helper limits to 40 chars.
S1: Add tests for ctx:0 default and error state display.

Wave 1 of v0.28.16.