### PR TITLE
feat(runtime): emergency persist + crash log + scrollback fallback (#3157)

W2 of v0.28.17:
- B3-A: Emergency persist in dynamic-wind cleanup (defense-in-depth)
- B3-A: Crash log written to ~/.q/crash-<ts>.jsonl on unhandled exceptions
- B3-C: Scrollback always saved — fallback to /tmp/q-scrollback-<ts>.jsonl
- Double-submit debounce: wire crash log into TUI runner error handler

### DIFF
--- a/runtime/session-lifecycle.rkt
+++ b/runtime/session-lifecycle.rkt
@@ -72,7 +72,8 @@
          build-session-context
          dispatch-iteration
          ensure-persisted!
-         buffer-or-append!)
+         buffer-or-append!
+         write-crash-log!)
 
 ;; ============================================================
 ;; Helpers
@@ -384,7 +385,32 @@
               user-message))
         (run-prompt-internal sess effective-input max-iterations token-budget-threshold ep! ba!)]))
    ;; Cleanup: always reset prompt-running? even on error
-   (lambda () (set-agent-session-prompt-running?! sess #f))))
+   ;; B3-A: Emergency persist — defense-in-depth if session not yet persisted
+   (lambda ()
+     (set-agent-session-prompt-running?! sess #f)
+     (unless (agent-session-persisted? sess)
+       (with-handlers ([exn:fail? void])
+         (ensure-persisted! sess))))))
+
+;; ============================================================
+;; Crash logging (B3-A)
+;; ============================================================
+
+;; Write crash log entry to ~/.q/crash-<timestamp>.jsonl
+(define (write-crash-log! sid error-msg phase)
+  (with-handlers ([exn:fail? void])
+    (define q-dir (build-path (find-system-path 'home-dir) ".q"))
+    (make-directory* q-dir)
+    (define crash-path (build-path q-dir (format "crash-~a.jsonl" (current-seconds))))
+    (call-with-output-file crash-path
+      (lambda (out)
+        (fprintf out "{\"ts\":~a,\"session\":\"~a\",\"error\":\"~a\",\"phase\":\"~a\"}\n"
+                 (current-seconds)
+                 (or sid "unknown")
+                 error-msg
+                 phase))
+      #:mode 'text
+      #:exists 'append)))
 
 ;; ============================================================
 ;; Persistence helpers (re-exported for agent-session.rkt)

--- a/tui/tui-init.rkt
+++ b/tui/tui-init.rkt
@@ -134,7 +134,14 @@
   (subscribe-runtime-events! ctx)
 
   ;; Determine scrollback file path from session dir
-  (define scrollback-path (and sess-dir (build-path sess-dir "scrollback.jsonl")))
+  ;; B3-C: Fallback scrollback — never silently lose transcript
+  (define scrollback-path
+    (cond
+      [(and sess-dir (directory-exists? sess-dir))
+       (build-path sess-dir "scrollback.jsonl")]
+      [else
+       (build-path "/tmp"
+                   (format "q-scrollback-~a.jsonl" (current-seconds)))]))
 
   ;; First-run welcome detection
   (define q-config-dir (build-path (find-system-path 'home-dir) ".q"))

--- a/tui/tui-render-loop.rkt
+++ b/tui/tui-render-loop.rkt
@@ -33,6 +33,7 @@
          "../tui/terminal-input.rkt"
          "../util/output-guard.rkt"
          "../agent/queue.rkt"
+         (only-in "../runtime/session-lifecycle.rkt" write-crash-log!)
          "../tui/tree-view.rkt"
          racket/set)
 
@@ -375,6 +376,8 @@
                                          (define bus (tui-ctx-event-bus ctx))
                                          (define sid
                                            (ui-state-session-id (unbox (tui-ctx-ui-state-box ctx))))
+                                         ;; B3-A: Write crash log for unhandled exceptions
+                                         (write-crash-log! sid (exn-message e) "run-prompt")
                                          (when (and bus sid)
                                            (publish! bus
                                                      (make-event "runtime.error"


### PR DESCRIPTION
Addresses #3157.

feat(runtime): emergency persist + crash log + scrollback fallback (#3157)

W2 of v0.28.17:
- B3-A: Emergency persist in dynamic-wind cleanup (defense-in-depth)
- B3-A: Crash log written to ~/.q/crash-<ts>.jsonl on unhandled exceptions
- B3-C: Scrollback always saved — fallback to /tmp/q-scrollback-<ts>.jsonl
- Double-submit debounce: wire crash log into TUI runner error handler