### PR TITLE
fix(tui): critical bug fixes for v0.28.17 (#3171)

W0 of v0.28.18:
- D1 CRITICAL: Fix debounce reading oldest transcript entry — use (car entries) for newest-first
- D2 CRITICAL: Remove duplicate user entry from handle-key (keep submit handler as SSOT)
- S1 HIGH: Add /status, /st, /info to command-parse.rkt dispatch table
- S2 HIGH: Verified struct-copy preserves status-message across turn.completed (no change needed)
- A1 HIGH: Remove llm/provider.rkt import from tui-init.rkt, re-export provider-name from provider-factory.rkt
- L1 INFO: Update stale comment in status-line.rkt

### DIFF
--- a/runtime/provider-factory.rkt
+++ b/runtime/provider-factory.rkt
@@ -22,7 +22,8 @@
          build-mock-provider
          local-provider?
          create-provider-for-name ;; for testing
-         provider-is-mock?) ;; v0.14.1: for tui-init without importing llm/
+         provider-is-mock? ;; v0.14.1: for tui-init without importing llm/
+         provider-name) ;; re-export for tui-init.rkt (A1 fix)
 
 ;; Build the appropriate provider based on provider name.
 (define (create-provider-for-name prov-name base-url api-key model-name [max-tokens #f])

--- a/tui/command-parse.rkt
+++ b/tui/command-parse.rkt
@@ -58,6 +58,13 @@
         (cons 'fork 'optional)
         "/sessions"
         (cons 'sessions 'optional)
+        ;; Session status
+        "/status"
+        (cons 'status 'none)
+        "/st"
+        (cons 'status 'none)
+        "/info"
+        (cons 'status 'none)
         ;; Model
         "/tree"
         (cons 'tree 'none)

--- a/tui/render/status-line.rkt
+++ b/tui/render/status-line.rkt
@@ -3,7 +3,7 @@
 ;; q/tui/render/status-line.rkt — status bar and input line rendering
 ;;
 ;; Pure functions that compose status bar and input line.
-;; v0.28.14: Multi-segment status bar — inverse content + normal context/cost.
+;; Single inverse segment covering entire status bar (v0.28.17+).
 
 (require racket/string
          "../../util/cost-tracker.rkt"

--- a/tui/tui-init.rkt
+++ b/tui/tui-init.rkt
@@ -20,7 +20,6 @@
          "../agent/event-bus.rkt"
          "../runtime/agent-session.rkt"
          "../runtime/provider-factory.rkt"
-         "../llm/provider.rkt"
          "../runtime/session-index.rkt"
          "../runtime/session-switch.rkt"
          "../tui/tui-keybindings.rkt"

--- a/tui/tui-keybindings.rkt
+++ b/tui/tui-keybindings.rkt
@@ -332,9 +332,7 @@
            (define cmd (parse-tui-slash-command text))
            (list 'command (or cmd 'unknown) text)]
           [_
-           ;; Add user message to transcript
-           (define user-entry (make-entry 'user text (current-inexact-milliseconds) (hash)))
-           (set-box! (tui-ctx-ui-state-box ctx) (add-transcript-entry state user-entry))
+           ;; User entry added by submit handler in tui-render-loop.rkt
            (list 'submit text)])]
        [(#\newline)
         ;; Ctrl+J → insert newline (multi-line input)
@@ -367,9 +365,7 @@
            (define cmd (parse-tui-slash-command text))
            (list 'command (or cmd 'unknown) text)]
           [_
-           ;; Add user message to transcript
-           (define user-entry (make-entry 'user text (current-inexact-milliseconds) (hash)))
-           (set-box! (tui-ctx-ui-state-box ctx) (add-transcript-entry state user-entry))
+           ;; User entry added by submit handler in tui-render-loop.rkt
            (list 'submit text)])]
        [(left kp-left)
         (set-box! (tui-ctx-input-state-box ctx) (input-cursor-left inp))

--- a/tui/tui-render-loop.rkt
+++ b/tui/tui-render-loop.rkt
@@ -332,7 +332,7 @@
                     ;; B2-D: Double-submit debounce — ignore rapid identical submits
                     (define entries (ui-state-transcript cur-state))
                     (define last-entry
-                      (and (pair? entries) (list-ref entries (- (length entries) 1))))
+                      (and (pair? entries) (car entries)))
                     (define is-duplicate
                       (and last-entry
                            (eq? (transcript-entry-kind last-entry) 'user)


### PR DESCRIPTION
Addresses #3171.

fix(tui): critical bug fixes for v0.28.17 (#3171)

W0 of v0.28.18:
- D1 CRITICAL: Fix debounce reading oldest transcript entry — use (car entries) for newest-first
- D2 CRITICAL: Remove duplicate user entry from handle-key (keep submit handler as SSOT)
- S1 HIGH: Add /status, /st, /info to command-parse.rkt dispatch table
- S2 HIGH: Verified struct-copy preserves status-message across turn.completed (no change needed)
- A1 HIGH: Remove llm/provider.rkt import from tui-init.rkt, re-export provider-name from provider-factory.rkt
- L1 INFO: Update stale comment in status-line.rkt