### PR TITLE
chore: bump version to 0.28.18 + sync all docs (#3178)

W1 of v0.28.18:
- Version bump to 0.28.18 in util/version.rkt, info.rkt, README.md
- CHANGELOG entry for v0.28.18 critical bug fixes
- Sync version refs in 12 doc files + wiki

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## v0.28.18 — 2026-05-03
+
+### v0.28.17 Critical Bug Fixes
+
+- **D1 (CRITICAL):** Fix debounce reading oldest transcript entry instead of newest — duplicate prompts never detected
+- **D2 (CRITICAL):** Remove duplicate user entry insertion from handle-key (was adding entry in both keybindings and submit handler)
+- **S1 (HIGH):** Add `/status`, `/st`, `/info` to command parse table — was unreachable ("Unknown command")
+- **S2 (HIGH):** Verified status-message persistence across `turn.completed` (struct-copy semantics — no change needed)
+- **A1 (HIGH):** Remove `llm/provider.rkt` import from `tui-init.rkt` — re-export `provider-name` from `runtime/provider-factory.rkt` (arch boundary restored)
+- **L1 (INFO):** Update stale comment in `status-line.rkt`
+
 ## v0.28.17 — 2026-05-02
 
 ### TUI Visibility + Session Persistence

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.28.17-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.28.18-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 
@@ -199,7 +199,7 @@ racket main.rkt --model gpt-5.4 "write a test"
 ### Verify
 
 ```bash
-racket main.rkt --version  # q version 0.28.17
+racket main.rkt --version  # q version 0.28.18
 raco test tests/           # run the full test suite
 ```
 
@@ -272,7 +272,7 @@ q/
 |--------|-------|
 | Test files | 480 |
 | Source modules | 377 |
-| Source lines | 60119 |
+| Source lines | 60122 |
 | Test lines | 91366 |
 | Test assertions | 14141 |
 | Tests passing | 5835+ | `racket scripts/run-tests.rkt` results |
@@ -335,7 +335,7 @@ When q executes shell commands on behalf of an LLM, arguments are quoted via `sh
 <!-- DO NOT EDIT: Status section is historical. Use sync-version.rkt for version bumps. -->
 ## Status
 
-**v0.28.17** — Audit Remediation. Fix `translate-stop-reason` arity in test-anthropic/gemini (14 calls), correct inaccurate CHANGELOG/README claims, fix 429 test expectation.
+**v0.28.18** — Audit Remediation. Fix `translate-stop-reason` arity in test-anthropic/gemini (14 calls), correct inaccurate CHANGELOG/README claims, fix 429 test expectation.
 
 **v0.28.12** — Audit Remediation + Pre-existing Test Fixes. Fix README corruption guard, `check-provider-status!` arity in 4 test files, ADR completion, test-types keyword fix.
 

--- a/docs/event-taxonomy.md
+++ b/docs/event-taxonomy.md
@@ -1,6 +1,6 @@
 # Q Event Taxonomy Reference
 
-Complete reference for all event types in Q 0.28.17.
+Complete reference for all event types in Q 0.28.18.
 ## Base Types
 
 ### `event` (protocol-level)
@@ -313,7 +313,7 @@ Key hook points where extensions can intercept:
 
 For the complete list, see `util/hook-types.rkt`.
 
-## Contract-Validated Events (v0.28.17)
+## Contract-Validated Events (v0.28.18)
 
 The following high-value events have payload contracts enforced at emission
 time in `runtime/iteration.rkt`. These events are consumed by extensions and

--- a/docs/exn-fail-migration-analysis.md
+++ b/docs/exn-fail-migration-analysis.md
@@ -1,4 +1,4 @@
-# Exn:fail Migration Analysis (v0.28.17 W1)
+# Exn:fail Migration Analysis (v0.28.18 W1)
 
 ## Audit Results
 

--- a/docs/extension-guide.md
+++ b/docs/extension-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.28.17 --># Extension Development Guide
+<!-- verified-against: 0.28.18 --># Extension Development Guide
 
 This guide walks you through creating, testing, and activating a custom
 extension for q.

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.28.17 --># Getting Started
+<!-- verified-against: 0.28.18 --># Getting Started
 
 Welcome to q, a Racket-based coding agent.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.28.17 --># Installation Guide
+<!-- verified-against: 0.28.18 --># Installation Guide
 
 <!-- This file is the canonical source. The docs/getting-started/installation.md copy is maintained for the doc site build. -->
 

--- a/docs/sdk-guide.md
+++ b/docs/sdk-guide.md
@@ -206,7 +206,7 @@ The SDK provides convenience functions for GSD (Goal-driven Structured Developme
 
 ### Extension Pre-Registration
 
-As of v0.28.17, `open-session` automatically registers extension tools (like `planning-read` and `planning-write`) before the first `run-prompt!` call. This means:
+As of v0.28.18, `open-session` automatically registers extension tools (like `planning-read` and `planning-write`) before the first `run-prompt!` call. This means:
 - Extension tools appear in `list-tools` immediately after `open-session`
 - GSD event bus is initialized and ready to emit events
 - No need to call `run-prompt!` once just to trigger tool registration

--- a/docs/security-trust-model.md
+++ b/docs/security-trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.28.17 --># Security & Trust Model
+<!-- verified-against: 0.28.18 --># Security & Trust Model
 
 This document provides an honest, per-area assessment of what q enforces
 today and what is planned. It is the authoritative reference for security
@@ -270,7 +270,7 @@ credential leakage into child processes.
 Environment variables matching these case-insensitive patterns are scrubbed:
 
 - `API.?KEY`, `SECRET`, `TOKEN`, `PASSWORD`, `CREDENTIAL`, `PRIVATE`
-- `AUTH` (narrowed in v0.28.17 to match only `AUTH`, `AUTH_*`, `*_AUTH_*`)
+- `AUTH` (narrowed in v0.28.18 to match only `AUTH`, `AUTH_*`, `*_AUTH_*`)
 - `GH_PAT`, and any var ending in `_PAT`
 
 ### Implicit allowlist

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -130,6 +130,6 @@ is the primary self-hosting extension:
 (load-extension! ext-reg "path/to/extension.rkt" #:event-bus bus)
 ```
 
-## Version 0.28.17
+## Version 0.28.18
 
-This documentation reflects q 0.28.17.
+This documentation reflects q 0.28.18.

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.28.17 --># q Source Style Guide
+<!-- verified-against: 0.28.18 --># q Source Style Guide
 
 This document defines formatting and naming conventions for the q Racket codebase.
 All changes to `q/` source files (excluding `tests/`) should follow these rules.

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.28.17 --># Trust Model
+<!-- verified-against: 0.28.18 --># Trust Model
 
 ## Trust Levels
 

--- a/docs/workflow-testing.md
+++ b/docs/workflow-testing.md
@@ -121,6 +121,6 @@ Use relative paths from the test file:
 4. Use `(check-true ...)` for boolean assertions
 5. Keep tests independent — no shared mutable state between test-cases
 
-## Version 0.28.17
+## Version 0.28.18
 
-This documentation reflects q 0.28.17.
+This documentation reflects q 0.28.18.

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.28.17")
+(define version "0.28.18")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base"))

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -10,4 +10,4 @@
 (provide q-version)
 
 (: q-version String)
-(define q-version "0.28.17")
+(define q-version "0.28.18")

--- a/wiki-src/Architecture-Overview.md
+++ b/wiki-src/Architecture-Overview.md
@@ -35,7 +35,7 @@ User input → Interface (CLI/TUI/RPC)
     → Events emitted to bus
 ```
 
-## Metrics (0.28.17)
+## Metrics (0.28.18)
 > _See `racket scripts/metrics.rkt` for current numbers._
 
 - 228 source modules, 349 test files


### PR DESCRIPTION
Addresses #3178.

chore: bump version to 0.28.18 + sync all docs (#3178)

W1 of v0.28.18:
- Version bump to 0.28.18 in util/version.rkt, info.rkt, README.md
- CHANGELOG entry for v0.28.18 critical bug fixes
- Sync version refs in 12 doc files + wiki