### PR TITLE
fix(stream): parse reasoning_content + fix test-tui-enter regression (#3184)

R1 CRITICAL: Add reasoning_content → delta-thinking extraction in both
normalize-openai-chunk (singular) and normalize-openai-chunks (batch).
Fixes invisible thinking tokens from glm-5.1 and DeepSeek-R1.

F1 HIGH: Update test-tui-enter.rkt tests 7+8 to expect 0 transcript
entries after D2 fix (handle-key no longer adds user entries).

### DIFF
--- a/llm/stream.rkt
+++ b/llm/stream.rkt
@@ -224,6 +224,12 @@
     ;; JSON null is represented as 'null symbol in Racket - filter it out
     (define delta-text (if (string? delta-content) delta-content #f))
 
+    ;; v0.28.19: Extract reasoning_content for thinking models (glm-5.1, DeepSeek-R1)
+    (define delta-thinking
+      (if delta
+          (hash-ref delta 'reasoning_content #f)
+          #f))
+
     ;; Extract tool-call delta
     (define delta-tool-call
       (if delta
@@ -237,6 +243,7 @@
                        delta-tool-call
                        usage
                        (and (string? finish-reason) #t)
+                       #:delta-thinking delta-thinking
                        #:finish-reason finish-reason)))
 
 ;; ============================================================
@@ -348,6 +355,11 @@
         (hash-ref delta 'content #f)
         #f))
   (define delta-text (if (string? delta-content) delta-content #f))
+  ;; v0.28.19: Extract reasoning_content for thinking models (glm-5.1, DeepSeek-R1)
+  (define delta-thinking
+    (if delta
+        (hash-ref delta 'reasoning_content #f)
+        #f))
   (define delta-tool-call
     (if delta
         (let ([tcs (hash-ref delta 'tool_calls #f)])
@@ -359,6 +371,7 @@
                      delta-tool-call
                      usage
                      (and (string? finish-reason) #t)
+                     #:delta-thinking delta-thinking
                      #:finish-reason finish-reason))
 
 ;; ============================================================

--- a/tests/test-stream.rkt
+++ b/tests/test-stream.rkt
@@ -34,6 +34,37 @@
 (check-equal? (stream-chunk-delta-text chunk1) "Hello")
 (check-false (stream-chunk-delta-tool-call chunk1))
 
+;; v0.28.19: reasoning_content → delta-thinking (singular)
+(define reasoning-chunk
+  (normalize-openai-chunk
+   (hash
+    'id
+    "chatcmpl-r1"
+    'choices
+    (list (hash 'delta (hash 'reasoning_content "Let me think about this...") 'finish_reason 'null))
+    'usage
+    (hash))))
+(check-pred stream-chunk? reasoning-chunk)
+(check-false (stream-chunk-delta-text reasoning-chunk)) ;; no content during reasoning
+(check-equal? (stream-chunk-delta-thinking reasoning-chunk) "Let me think about this...")
+
+;; v0.28.19: reasoning_content → delta-thinking (batch)
+(define reasoning-batch
+  (normalize-openai-chunks
+   (list (hash 'id
+               "c1"
+               'choices
+               (list (hash 'delta (hash 'reasoning_content "Step 1") 'finish_reason 'null)))
+         (hash 'id
+               "c2"
+               'choices
+               (list (hash 'delta (hash 'content "The answer is 42") 'finish_reason 'null))))))
+(check-equal? (length reasoning-batch) 2)
+(check-equal? (stream-chunk-delta-thinking (car reasoning-batch)) "Step 1")
+(check-false (stream-chunk-delta-text (car reasoning-batch)))
+(check-equal? (stream-chunk-delta-text (cadr reasoning-batch)) "The answer is 42")
+(check-false (stream-chunk-delta-thinking (cadr reasoning-batch)))
+
 (define chunk2
   (normalize-openai-chunk
    (hash

--- a/tests/test-tui-enter.rkt
+++ b/tests/test-tui-enter.rkt
@@ -85,23 +85,21 @@
       (check-equal? (input-state-buffer (unbox (tui-ctx-input-state-box ctx))) ""))
 
     ;; --------------------------------------------------
-    ;; Test 7: 'return adds user message to transcript
+    ;; Test 7: 'return does NOT add user entry (D2 fix)
     ;; --------------------------------------------------
-    (test-case "handle-key 'return adds user entry to transcript"
+    (test-case "handle-key 'return does NOT add user entry (D2 fix)"
       (define ctx (make-test-ctx))
       (type-text ctx "test message")
       (handle-key ctx 'return)
       (define state (unbox (tui-ctx-ui-state-box ctx)))
       (define transcript (ui-state-transcript state))
-      (check-equal? (length transcript) 1)
-      (define entry (car transcript))
-      (check-equal? (transcript-entry-kind entry) 'user)
-      (check-equal? (transcript-entry-text entry) "test message"))
+      ;; D2 fix: handle-key no longer adds user entries — submit handler does
+      (check-equal? (length transcript) 0))
 
     ;; --------------------------------------------------
-    ;; Test 8: Multiple enters work correctly
+    ;; Test 8: Multiple enters — no transcript entries (D2 fix)
     ;; --------------------------------------------------
-    (test-case "handle-key multiple enters work"
+    (test-case "handle-key multiple enters — no transcript entries (D2 fix)"
       (define ctx (make-test-ctx))
       (type-text ctx "first")
       (handle-key ctx 'return)
@@ -109,7 +107,7 @@
       (define result (handle-key ctx 'return))
       (check-equal? result '(submit "second"))
       (define state (unbox (tui-ctx-ui-state-box ctx)))
-      (check-equal? (length (ui-state-transcript state)) 2))
+      (check-equal? (length (ui-state-transcript state)) 0))
 
     ;; --------------------------------------------------
     ;; Test 9: 'return with whitespace-only input continues


### PR DESCRIPTION
Addresses #3184.

fix(stream): parse reasoning_content + fix test-tui-enter regression (#3184)

R1 CRITICAL: Add reasoning_content → delta-thinking extraction in both
normalize-openai-chunk (singular) and normalize-openai-chunks (batch).
Fixes invisible thinking tokens from glm-5.1 and DeepSeek-R1.

F1 HIGH: Update test-tui-enter.rkt tests 7+8 to expect 0 transcript
entries after D2 fix (handle-key no longer adds user entries).