### PR TITLE
feat(tui): show thinking text in transcript during reasoning phase (#3189)

R2 HIGH: render-transcript now shows streaming-thinking as a dim [thinking]
entry when no content streaming yet. Added 'thinking entry kind rendering
in message-layout with dim+italic style. Content always takes priority
over thinking during reasoning→content transition.

### DIFF
--- a/tui/render/diff-render.rkt
+++ b/tui/render/diff-render.rkt
@@ -95,13 +95,27 @@
   (define entries (ui-state-transcript state))
   (define scroll (ui-state-scroll-offset state))
   (define streaming-text (ui-state-streaming-text state))
+  (define streaming-thinking (ui-state-streaming-thinking state))
   (define chronological-entries (reverse entries))
+  ;; v0.28.19: Show thinking entry during reasoning phase (when no content yet)
   (define all-entries
-    (if streaming-text
-        (append
-         chronological-entries
-         (list (transcript-entry 'assistant streaming-text (current-inexact-milliseconds) (hash) #f)))
-        chronological-entries))
+    (let* ([with-thinking (if (and streaming-thinking (not streaming-text))
+                              (append chronological-entries
+                                      (list (transcript-entry 'thinking
+                                                              streaming-thinking
+                                                              (current-inexact-milliseconds)
+                                                              (hash)
+                                                              #f)))
+                              chronological-entries)]
+           [with-text (if streaming-text
+                          (append with-thinking
+                                  (list (transcript-entry 'assistant
+                                                          streaming-text
+                                                          (current-inexact-milliseconds)
+                                                          (hash)
+                                                          #f)))
+                          with-thinking)])
+      with-text))
   (define styled-lines (apply append (map (lambda (e) (format-entry e width)) all-entries)))
   ;; Apply scroll offset — scroll=0 means show bottom (newest), positive = scrolled up
   (define total-lines (length styled-lines))

--- a/tui/render/message-layout.rkt
+++ b/tui/render/message-layout.rkt
@@ -96,6 +96,9 @@
      (define sanitized (string-replace raw-text "\n" " "))
      (list (styled-line (list (styled-segment (format "[FAIL] ~a: ~a" tool-name sanitized) '(red)))))]
     [(error) (list (styled-line (list (styled-segment (format "[ERR] ~a" raw-text) '(bold red)))))]
+    [(thinking)
+     ;; v0.28.19: Show reasoning text in dim+italic, distinct from content
+     (list (styled-line (list (styled-segment (format "[thinking] ~a" raw-text) '(dim italic)))))]
     [else (list (styled-line (list (styled-segment raw-text '()))))]))
 
 ;; Convert a markdown token to a list of styled segments.


### PR DESCRIPTION
Addresses #3189.

feat(tui): show thinking text in transcript during reasoning phase (#3189)

R2 HIGH: render-transcript now shows streaming-thinking as a dim [thinking]
entry when no content streaming yet. Added 'thinking entry kind rendering
in message-layout with dim+italic style. Content always takes priority
over thinking during reasoning→content transition.