### PR TITLE
fix(auth): project-local credential resolution + test isolation (#3199)

C1 CRITICAL: credential-from-file now checks project-local
.q/credentials.json before global ~/.q/credentials.json. Wire
#:project-dir through lookup-credential and provider-factory.

C2 CRITICAL: Isolate 4 test files from real ~/.q/:
- test-init-wizard.rkt: temp-dir isolation via #:config-dir
- test-cli.rkt: temp-dir isolation for init-wizard tests
- test-auth-store.rkt: project-local .q/ for file credential tests
- test-lockfile.rkt: parameterized current-locks-dir for temp dir

Also adds test-key guard (sk-test keys rejected with warning).

### DIFF
--- a/cli/init-wizard.rkt
+++ b/cli/init-wizard.rkt
@@ -22,9 +22,11 @@
 
 ;; Guided setup wizard that creates ~/.q/config.json.
 ;; For testability, accepts optional input/output ports.
-(define (run-init-wizard #:in [in (current-input-port)] #:out [out (current-output-port)])
-  (define config-dir (build-path (find-system-path 'home-dir) ".q"))
-  (define config-path (build-path config-dir "config.json"))
+(define (run-init-wizard #:in [in (current-input-port)]
+                         #:out [out (current-output-port)]
+                         #:config-dir [config-dir #f])
+  (define effective-config-dir (or config-dir (build-path (find-system-path 'home-dir) ".q")))
+  (define config-path (build-path effective-config-dir "config.json"))
 
   ;; Helper: read a line, handling EOF
   (define (read-input)
@@ -61,8 +63,7 @@
              (begin
                (display "Base URL (e.g. http://localhost:11434/v1): " out)
                (flush-output out)
-               (let ([url (read-input)])
-                 (if (string=? url "") #f url)))
+               (let ([url (read-input)]) (if (string=? url "") #f url)))
              #f))
 
        ;; Ask for API key (optional for local providers)
@@ -95,11 +96,7 @@
 
        ;; Build provider config (no secrets)
        (define provider-hash-base
-         (list
-          (cons 'default-model
-                (if (and model (not (string=? model "")))
-                    model
-                    default-model))))
+         (list (cons 'default-model (if (and model (not (string=? model ""))) model default-model))))
        ;; Add base-url for openai-compatible providers
        (define provider-hash-entries
          (if base-url
@@ -110,25 +107,18 @@
        ;; Build non-secret config
        (define config
          (make-hash
-          (list
-           (cons 'default-provider
-                 (if (string=? provider "openai-compatible")
-                     "openai-compatible"
-                     provider))
-           (cons 'providers
-                 (make-hash
-                  (list
-                   (cons config-provider-name provider-hash)))))))
+          (list (cons 'default-provider
+                      (if (string=? provider "openai-compatible") "openai-compatible" provider))
+                (cons 'providers (make-hash (list (cons config-provider-name provider-hash)))))))
 
        ;; Write config
-       (make-directory* config-dir)
-       (call-with-output-file config-path
-         (lambda (port) (write-json config port))
-         #:exists 'replace)
+       (make-directory* effective-config-dir)
+       (call-with-output-file config-path (lambda (port) (write-json config port)) #:exists 'replace)
 
        ;; Store API key in dedicated credentials file with restricted permissions (#455)
        (when (and api-key (not (string=? api-key "")))
-         (save-credential-file! (symbol->string config-provider-name) api-key))
+         (define cred-path (build-path effective-config-dir "credentials.json"))
+         (save-credential-file! (symbol->string config-provider-name) api-key cred-path))
 
        (displayln "Configuration saved to ~/.q/config.json." out)
        (when (and api-key (not (string=? api-key "")))

--- a/runtime/auth-store.rkt
+++ b/runtime/auth-store.rkt
@@ -112,7 +112,9 @@
 ;;      (key: 'api-key-env or "api-key-env")
 ;;   2. Config file: check provider-config for 'api-key or "api-key"
 ;;   3. Return #f if not found
-(define (lookup-credential provider-name provider-config)
+(define (lookup-credential provider-name
+                           provider-config
+                           #:project-dir [project-dir (current-directory)])
   ;; Normalize provider-name to string (JSON keys may be symbols)
   (define norm-name
     (if (symbol? provider-name)
@@ -120,7 +122,7 @@
         provider-name))
   ;; Guard: if provider-config is #f, try credential file only
   (cond
-    [(not provider-config) (credential-from-file norm-name)]
+    [(not provider-config) (credential-from-file norm-name #:project-dir project-dir)]
     [else
      (let* ([env-var-name (config-ref provider-config 'api-key-env "api-key-env")]
             [env-val (and env-var-name (getenv env-var-name))])
@@ -131,29 +133,50 @@
             (cond
               [(and config-key (non-empty-string? config-key))
                (credential norm-name config-key 'config)]
-              ;; Fall back to credential file (~/.q/credentials.json)
-              [else (credential-from-file norm-name)]))]))]))
+              ;; Fall back to credential file (project-local first, then global)
+              [else (credential-from-file norm-name #:project-dir project-dir)]))]))]))
 
-;; Lookup credential from the dedicated credential file.
+;; v0.28.20: Known test keys that should never be used in production.
+(define test-api-keys '("sk-test" "sk-test-key-123" "sk-ant-test" "sk-ant-test-key"))
+
+;; Check if a key looks like a test key.
+(define (test-key? key)
+  (and (string? key) (member key test-api-keys)))
+
+;; Try to load a credential from a specific file path.
 ;; Returns #<credential ...> or #f.
-(define (credential-from-file provider-name)
-  (define file-creds (load-credential-file))
+;; Rejects test keys with a warning.
+(define (try-credential-from-file provider-name path)
+  (define file-creds (load-credential-file path))
   (define prov-cfg (hash-ref file-creds provider-name #f))
   (cond
     [(not prov-cfg) #f]
     [else
      (define key (hash-ref prov-cfg 'api-key #f))
-     (if (and key (non-empty-string? key))
-         (credential provider-name key 'stored)
-         #f)]))
+     (cond
+       [(test-key? key)
+        (log-warning "credential-from-file: ~a has test key in ~a — ignoring" provider-name path)
+        #f]
+       [(and key (non-empty-string? key)) (credential provider-name key 'stored)]
+       [else #f])]))
+
+;; Lookup credential from the dedicated credential file.
+;; v0.28.20: Resolution order — project-local first, then global.
+;; Returns #<credential ...> or #f.
+(define (credential-from-file provider-name #:project-dir [project-dir (current-directory)])
+  (define project-cred-path (build-path project-dir ".q" "credentials.json"))
+  (or (try-credential-from-file provider-name project-cred-path)
+      (try-credential-from-file provider-name (credential-file-path))))
 
 ;; ═══════════════════════════════════════════════════════════════════
 ;; credential-present?
 ;; ═══════════════════════════════════════════════════════════════════
 
 ;; Check if a credential is available (without returning it)
-(define (credential-present? provider-name provider-config)
-  (and (lookup-credential provider-name provider-config) #t))
+(define (credential-present? provider-name
+                             provider-config
+                             #:project-dir [project-dir (current-directory)])
+  (and (lookup-credential provider-name provider-config #:project-dir project-dir) #t))
 
 ;; ═══════════════════════════════════════════════════════════════════
 ;; store-credential!

--- a/runtime/provider-factory.rkt
+++ b/runtime/provider-factory.rkt
@@ -127,7 +127,7 @@
         (define prov-name (model-resolution-provider-name resolution))
         (define prov-cfg (model-resolution-provider-config resolution))
         (define base-url (model-resolution-base-url resolution))
-        (define cred (lookup-credential prov-name prov-cfg))
+        (define cred (lookup-credential prov-name prov-cfg #:project-dir project-dir))
         (cond
           [(not cred)
            ;; No credentials - check if local provider (no auth needed)

--- a/tests/test-auth-store.rkt
+++ b/tests/test-auth-store.rkt
@@ -39,8 +39,10 @@
                               #:api-key [api-key #f]
                               #:base-url [base-url "https://api.example.com"])
   (define h (make-hash))
-  (when env-var (hash-set! h 'api-key-env env-var))
-  (when api-key (hash-set! h 'api-key api-key))
+  (when env-var
+    (hash-set! h 'api-key-env env-var))
+  (when api-key
+    (hash-set! h 'api-key api-key))
   (hash-set! h 'base-url base-url)
   ;; Return immutable hash
   (for/hash ([(k v) (in-hash h)])
@@ -48,528 +50,441 @@
 
 ;; Same but with string keys (module must handle both)
 (define (make-provider-config/string-keys #:env-var [env-var #f]
-                                           #:api-key [api-key #f]
-                                           #:base-url [base-url "https://api.example.com"])
+                                          #:api-key [api-key #f]
+                                          #:base-url [base-url "https://api.example.com"])
   (define h (make-hash))
-  (when env-var (hash-set! h "api-key-env" env-var))
-  (when api-key (hash-set! h "api-key" api-key))
+  (when env-var
+    (hash-set! h "api-key-env" env-var))
+  (when api-key
+    (hash-set! h "api-key" api-key))
   (hash-set! h "base-url" base-url)
   (for/hash ([(k v) (in-hash h)])
     (values k v)))
 
 ;; ── Test suite ──
 
-(define-test-suite test-auth-store
-
-  ;; ──────────────────────────────
-  ;; credential struct
-  ;; ──────────────────────────────
-
-  (test-case "credential struct is transparent"
-    (define c (credential "openai" "sk-abc" 'environment))
-    (check-equal? (credential-provider-name c) "openai")
-    (check-equal? (credential-api-key c) "sk-abc")
-    (check-equal? (credential-source c) 'environment))
-
-  (test-case "credential struct supports equal? comparison"
-    (define c1 (credential "openai" "sk-abc" 'environment))
-    (define c2 (credential "openai" "sk-abc" 'environment))
-    (check-equal? c1 c2))
-
-  ;; ──────────────────────────────
-  ;; lookup-credential — env var resolution
-  ;; ──────────────────────────────
-
-  (test-case "lookup-credential finds key from env var"
-    (define env-var (set-test-env! "LOOKUP1" "sk-from-env-123"))
-    (define cfg (make-provider-config #:env-var env-var #:api-key "sk-from-config"))
-    (define result (lookup-credential "test-provider" cfg))
-    (clear-test-env! "LOOKUP1")
-    (check-not-false result)
-    (check-equal? (credential-api-key result) "sk-from-env-123")
-    (check-equal? (credential-source result) 'environment)
-    (check-equal? (credential-provider-name result) "test-provider"))
-
-  (test-case "lookup-credential env var takes priority over config api-key"
-    (define env-var (set-test-env! "PRIORITY1" "sk-env-priority"))
-    (define cfg (make-provider-config #:env-var env-var #:api-key "sk-config-priority"))
-    (define result (lookup-credential "test-provider" cfg))
-    (clear-test-env! "PRIORITY1")
-    (check-equal? (credential-api-key result) "sk-env-priority")
-    (check-equal? (credential-source result) 'environment))
-
-  (test-case "lookup-credential falls back to config api-key when env var is not set"
-    (clear-test-env! "NOTSET1")
-    (define cfg (make-provider-config #:env-var (test-env-var "NOTSET1") #:api-key "sk-config-fallback"))
-    (define result (lookup-credential "test-provider" cfg))
-    (check-not-false result)
-    (check-equal? (credential-api-key result) "sk-config-fallback")
-    (check-equal? (credential-source result) 'config))
-
-  ;; ──────────────────────────────
-  ;; lookup-credential — graceful failure
-  ;; ──────────────────────────────
-
-  (test-case "lookup-credential returns #f when neither env nor config has key"
-    (clear-test-env! "MISSING1")
-    (define cfg (make-provider-config #:env-var (test-env-var "MISSING1")))
-    (define result (lookup-credential "test-provider" cfg))
-    (check-false result))
-
-  (test-case "lookup-credential returns #f when env var is empty string"
-    (define env-var (set-test-env! "EMPTY1" ""))
-    (define cfg (make-provider-config #:env-var env-var))
-    (define result (lookup-credential "test-provider" cfg))
-    (clear-test-env! "EMPTY1")
-    (check-false result))
-
-  (test-case "lookup-credential returns #f when config api-key is empty string"
-    (clear-test-env! "EMPTYCFG")
-    (define cfg (make-provider-config #:env-var (test-env-var "EMPTYCFG") #:api-key ""))
-    (define result (lookup-credential "test-provider" cfg))
-    (check-false result))
-
-  (test-case "lookup-credential returns #f when provider-config is empty hash"
-    (define result (lookup-credential "test-provider" (hash)))
-    (check-false result))
-
-  ;; ──────────────────────────────
-  ;; lookup-credential — string keys support
-  ;; ──────────────────────────────
-
-  (test-case "lookup-credential handles string keys in provider-config"
-    (define env-var (set-test-env! "STRKEY1" "sk-str-key-env"))
-    (define cfg (make-provider-config/string-keys #:env-var env-var #:api-key "sk-str-key-cfg"))
-    (define result (lookup-credential "test-provider" cfg))
-    (clear-test-env! "STRKEY1")
-    (check-not-false result)
-    (check-equal? (credential-api-key result) "sk-str-key-env")
-    (check-equal? (credential-source result) 'environment))
-
-  (test-case "lookup-credential falls back to string api-key when env not set"
-    (clear-test-env! "STRKEY2")
-    (define cfg (make-provider-config/string-keys #:env-var (test-env-var "STRKEY2") #:api-key "sk-str-cfg-key"))
-    (define result (lookup-credential "test-provider" cfg))
-    (check-not-false result)
-    (check-equal? (credential-api-key result) "sk-str-cfg-key")
-    (check-equal? (credential-source result) 'config))
-
-  ;; ──────────────────────────────
-  ;; lookup-credential — credential file fallback
-  ;; ──────────────────────────────
-
-  (test-case "lookup-credential falls back to credential file"
-    (clear-test-env! "NOFILE")
-    (define dir (make-temp-dir))
-    (define cred-path (build-path dir "credentials.json"))
-    ;; Write a credential file
-    (call-with-output-file cred-path
-      (lambda (out)
-        (write-json (hasheq 'providers
-                            (hasheq 'file-provider (hasheq 'api-key "sk-from-file")))
-                    out))
-      #:exists 'replace)
-    ;; Override credential-file-path by testing the fallback chain
-    ;; We test by calling lookup-credential with empty config
-    ;; It will try to load from the default credential file
-    ;; So we need a provider that exists in the file but not in env/config
-    ;; Since we cannot override credential-file-path, test with
-    ;; a temp approach: write to actual credential file, then restore
-    (define real-cred-path (credential-file-path))
-    (define backup
-      (if (file-exists? real-cred-path)
-          (call-with-input-file real-cred-path port->string)
-          #f))
-    (with-handlers ([exn:fail? (lambda (e)
-                                  ;; Restore on error
-                                  (when backup
-                                    (call-with-output-file real-cred-path
-                                     (lambda (out) (display backup out))
-                                      #:exists 'replace)))])
-      ;; Write test credentials
-      (save-credential-file! "file-test-provider" "sk-file-key-123")
-      ;; Lookup with empty config — should fall back to file
-      (define result (lookup-credential "file-test-provider" (hash)))
-      (check-not-false result)
-      (check-equal? (credential-api-key result) "sk-file-key-123")
-      (check-equal? (credential-source result) 'stored)
-      ;; Cleanup: restore original credentials
-      (if backup
-          (call-with-output-file real-cred-path
-            (lambda (out) (display backup out))
-            #:exists 'replace)
-          (delete-file real-cred-path)))
-    (delete-directory/files dir #:must-exist? #f))
-
-  (test-case "lookup-credential returns #f when provider not in credential file"
-    (clear-test-env! "MISSINGPROV")
-    ;; Use a provider name that definitely won't be in any credential file
-    (define result (lookup-credential "nonexistent-provider-xyz-999" (hash)))
-    (check-false result))
-
-  (test-case "lookup-credential with #f provider-config tries credential file"
-    (define result (lookup-credential "nonexistent-provider-xyz-998" #f))
-    (check-false result))
-
-  ;; ──────────────────────────────
-  ;; credential-present?
-  ;; ──────────────────────────────
-
-  (test-case "credential-present? returns #t when env var key exists"
-    (define env-var (set-test-env! "PRESENT1" "sk-present"))
-    (define cfg (make-provider-config #:env-var env-var))
-    (check-true (credential-present? "test-provider" cfg))
-    (clear-test-env! "PRESENT1"))
-
-  (test-case "credential-present? returns #t when config key exists"
-    (clear-test-env! "PRESENTCFG")
-    (define cfg (make-provider-config #:env-var (test-env-var "PRESENTCFG") #:api-key "sk-cfg-present"))
-    (check-true (credential-present? "test-provider" cfg)))
-
-  (test-case "credential-present? returns #f when no key available"
-    (clear-test-env! "NOTPRESENT")
-    (define cfg (make-provider-config #:env-var (test-env-var "NOTPRESENT")))
-    (check-false (credential-present? "test-provider" cfg)))
-
-  ;; ──────────────────────────────
-  ;; store-credential!
-  ;; ──────────────────────────────
-
-  (test-case "store-credential! updates config hash with api-key"
-    (define cfg (make-provider-config #:base-url "https://api.test.com"))
-    (define updated (store-credential! "openai" "sk-new-key"
-                                        #:provider-config cfg))
-    (check-equal? (hash-ref updated 'api-key) "sk-new-key")
-    ;; Original base-url preserved
-    (check-equal? (hash-ref updated 'base-url) "https://api.test.com"))
-
-  (test-case "store-credential! without config-path does not touch filesystem"
-    (define cfg (hash 'base-url "https://api.test.com"))
-    (define updated (store-credential! "openai" "sk-new-key"
-                                        #:provider-config cfg))
-    (check-equal? (hash-ref updated 'api-key) "sk-new-key"))
-
-  (test-case "store-credential! writes to file when config-path given"
-    (define dir (make-temp-dir))
-    (define config-path (build-path dir "config.json"))
-    ;; Write initial config
-    (define initial-config
-      (hasheq 'providers
-              (hasheq 'openai (hasheq 'api-key "old-key" 'base-url "https://api.openai.com"))
-              'settings (hasheq 'model "gpt-4")))
-    (call-with-output-file config-path
-      (lambda (out) (write-json initial-config out))
-      #:exists 'replace)
-
-    ;; Store new credential
-    (define cfg (make-provider-config #:base-url "https://api.openai.com"))
-    (define updated (store-credential! "openai" "sk-updated-key"
-                                        #:provider-config cfg
-                                        #:config-path config-path))
-
-    ;; Read back file (read-json returns hasheq with symbol keys)
-    (define file-content (call-with-input-file config-path read-json))
-    (define providers (hash-ref file-content 'providers))
-    (define openai-cfg (hash-ref providers 'openai))
-    (check-equal? (hash-ref openai-cfg 'api-key) "sk-updated-key")
-    ;; Other config preserved
-    (check-equal? (hash-ref file-content 'settings) (hasheq 'model "gpt-4"))
-
-    (delete-directory/files dir #:must-exist? #f))
-
-  (test-case "store-credential! creates config file if it doesn't exist"
-    (define dir (make-temp-dir))
-    (define config-path (build-path dir "new-config.json"))
-    (define cfg (hash 'base-url "https://api.test.com"))
-    (store-credential! "test-provider" "sk-brand-new"
-                       #:provider-config cfg
-                       #:config-path config-path)
-    (check-pred file-exists? config-path)
-    (define file-content (call-with-input-file config-path read-json))
-    (check-equal? (hash-ref (hash-ref file-content 'providers (hasheq)) 'test-provider (hasheq))
-                  (hasheq 'api-key "sk-brand-new"))
-    (delete-directory/files dir #:must-exist? #f))
-
-  ;; ──────────────────────────────
-  ;; resolve-provider-credentials
-  ;; ──────────────────────────────
-
-  (test-case "resolve-provider-credentials resolves all providers"
-    (define env-var (set-test-env! "BATCH1" "sk-batch-env"))
-    (define providers-hash
-      (hash "openai" (make-provider-config #:env-var env-var)
-            "anthropic" (make-provider-config #:api-key "sk-ant-cfg")
-            "local" (make-provider-config #:base-url "http://localhost:8000")))
-    (define results (resolve-provider-credentials providers-hash))
-    (clear-test-env! "BATCH1")
-
-    ;; openai resolved from env
-    (define openai-cred (hash-ref results "openai"))
-    (check-not-false openai-cred)
-    (check-equal? (credential-api-key openai-cred) "sk-batch-env")
-    (check-equal? (credential-source openai-cred) 'environment)
-
-    ;; anthropic resolved from config
-    (define anthro-cred (hash-ref results "anthropic"))
-    (check-not-false anthro-cred)
-    (check-equal? (credential-api-key anthro-cred) "sk-ant-cfg")
-    (check-equal? (credential-source anthro-cred) 'config)
-
-    ;; local has no key
-    (define local-cred (hash-ref results "local"))
-    (check-false local-cred))
-
-  (test-case "resolve-provider-credentials returns empty hash for no providers"
-    (define results (resolve-provider-credentials (hash)))
-    (check-equal? (hash-count results) 0))
-
-  ;; ──────────────────────────────
-  ;; Edge cases
-  ;; ──────────────────────────────
-
-  (test-case "lookup-credential with only api-key in config (no api-key-env)"
-    (define cfg (hash 'api-key "sk-only-config"))
-    (define result (lookup-credential "test" cfg))
-    (check-not-false result)
-    (check-equal? (credential-api-key result) "sk-only-config")
-    (check-equal? (credential-source result) 'config))
-
-  (test-case "lookup-credential with only api-key-env but missing env var"
-    (clear-test-env! "EDGECASE")
-    (define cfg (hash 'api-key-env (test-env-var "EDGECASE")))
-    (define result (lookup-credential "test" cfg))
-    (check-false result))
-
-  (test-case "env var with whitespace-only value returns #f"
-    (define env-var (set-test-env! "WHITESPACE" "   "))
-    (define cfg (make-provider-config #:env-var env-var))
-    (define result (lookup-credential "test" cfg))
-    (clear-test-env! "WHITESPACE")
-    (check-false result))
-
-  ;; ──────────────────────────────
-  ;; mask-api-key
-  ;; ──────────────────────────────
-
-  (test-case "mask-api-key masks long keys"
-    (check-equal? (mask-api-key "sk-proj-abc123XYZ789")
-                  "sk-...Z789"))
-
-  (test-case "mask-api-key returns **** for short keys"
-    (check-equal? (mask-api-key "short") "****")
-    (check-equal? (mask-api-key "1234567") "****"))
-
-  (test-case "mask-api-key handles exactly 8 chars"
-    (check-equal? (mask-api-key "12345678") "123...5678"))
-
-  (test-case "mask-api-key handles non-string input"
-    (check-equal? (mask-api-key #f) "****")
-    (check-equal? (mask-api-key 42) "****"))
-
-  ;; ──────────────────────────────
-  ;; redacted-credential
-  ;; ──────────────────────────────
-
-  (test-case "cred->redacted creates safe display credential"
-    (define c (credential "openai" "sk-proj-longkey123abc" 'config))
-    (define r (cred->redacted c))
-    (check-equal? (redacted-credential-provider-name r) "openai")
-    (check-equal? (redacted-credential-masked-api-key r) "sk-...3abc")
-    (check-equal? (redacted-credential-source r) 'config)
-    ;; Verify the raw key is NOT in the redacted credential
-    (check-false (string-contains? (redacted-credential-masked-api-key r) "longkey123")))
-
-  (test-case "redacted-credential struct is transparent"
-    (define r (redacted-credential "test" "sk-...xyz" 'environment))
-    (check-equal? (redacted-credential-provider-name r) "test")
-    (check-equal? (redacted-credential-masked-api-key r) "sk-...xyz"))
-
-  ;; ──────────────────────────────
-  ;; validate-credential-format
-  ;; ──────────────────────────────
-
-  (test-case "validate-credential-format accepts valid OpenAI key"
-    (check-true (validate-credential-format "openai" "sk-proj-abc123")))
-
-  (test-case "validate-credential-format rejects invalid OpenAI key"
-    (check-false (validate-credential-format "openai" "invalid-key")))
-
-  (test-case "validate-credential-format accepts valid Anthropic key"
-    (check-true (validate-credential-format "anthropic" "sk-ant-api03-xyz")))
-
-  (test-case "validate-credential-format rejects invalid Anthropic key"
-    (check-false (validate-credential-format "anthropic" "sk-wrong-prefix")))
-
-  (test-case "validate-credential-format accepts any key for unknown provider"
-    (check-true (validate-credential-format "my-custom-llm" "any-key-format")))
-
-  (test-case "validate-credential-format rejects non-string inputs"
-    (check-false (validate-credential-format 42 "key"))
-    (check-false (validate-credential-format "openai" #f)))
-
-  ;; ──────────────────────────────
-  ;; Credential file operations
-  ;; ──────────────────────────────
-
-  (test-case "load-credential-file returns empty hash when file missing"
-    (define dir (make-temp-dir))
-    (define path (build-path dir "credentials.json"))
-    (define result (load-credential-file path))
-    (check-equal? result (hash))
-    (delete-directory/files dir #:must-exist? #f))
-
-  (test-case "save-credential-file! creates and load reads back"
-    (define dir (make-temp-dir))
-    (define path (build-path dir "credentials.json"))
-    (save-credential-file! "openai" "sk-test-12345" path)
-    (check-pred file-exists? path)
-    (define loaded (load-credential-file path))
-    (define openai-cfg (hash-ref loaded "openai" #f))
-    (check-not-false openai-cfg)
-    (check-equal? (hash-ref openai-cfg 'api-key) "sk-test-12345")
-    (delete-directory/files dir #:must-exist? #f))
-
-  (test-case "save-credential-file! preserves existing providers"
-    (define dir (make-temp-dir))
-    (define path (build-path dir "credentials.json"))
-    (save-credential-file! "openai" "sk-test-111" path)
-    (save-credential-file! "anthropic" "sk-ant-test-222" path)
-    (define loaded (load-credential-file path))
-    (check-equal? (hash-ref (hash-ref loaded "openai") 'api-key) "sk-test-111")
-    (check-equal? (hash-ref (hash-ref loaded "anthropic") 'api-key) "sk-ant-test-222")
-    (delete-directory/files dir #:must-exist? #f))
-
-  (test-case "credential-file-path returns path under ~/.q"
-    (define p (credential-file-path))
-    (check-true (string? (path->string p)))
-    (check-true (string-contains? (path->string p) ".q"))
-    (check-true (string-contains? (path->string p) "credentials.json")))
-
-  ;; ──────────────────────────────
-  ;; with-credential macro
-  ;; ──────────────────────────────
-
-  (test-case "with-credential provides scoped key access"
-    (define env-var (set-test-env! "WC1" "sk-scoped-test"))
-    (define cfg (make-provider-config #:env-var env-var))
-    (define result
-      (with-credential "test-provider" cfg k
-        (string-append "key-is:" k)))
-    (clear-test-env! "WC1")
-    (check-equal? result "key-is:sk-scoped-test"))
-
-  (test-case "with-credential returns #f when no credential"
-    (clear-test-env! "WCMISS")
-    (define cfg (make-provider-config #:env-var (test-env-var "WCMISS")))
-    (define result
-      (with-credential "test-provider" cfg k
-        (string-append "key-is:" k)))
-    (check-false result))
-
-  ;; ──────────────────────────────
-  ;; Integration: resolve + redact
-  ;; ──────────────────────────────
-
-  (test-case "resolve-provider-credentials can be redacted for display"
-    (define env-var (set-test-env! "INTEG1" "sk-integration-test-key"))
-    (define providers-hash
-      (hash "openai" (make-provider-config #:env-var env-var)
-            "local" (make-provider-config #:base-url "http://localhost")))
-    (define results (resolve-provider-credentials providers-hash))
-    (clear-test-env! "INTEG1")
-
-    ;; Redact all credentials
-    (define redacted
-      (for/hash ([(name cred) (in-hash results)])
-        (values name (and cred (cred->redacted cred)))))
-
-    ;; openai is redacted
-    (define openai-redacted (hash-ref redacted "openai"))
-    (check-not-false openai-redacted)
-    (check-pred redacted-credential? openai-redacted)
-    (check-false (string-contains? (redacted-credential-masked-api-key openai-redacted) "integration-test-key"))
-
-    ;; local has no credential
-    (check-false (hash-ref redacted "local")))
-
-  ;; ──────────────────────────────
-  ;; F4: credential custom write masks API key
-  ;; ──────────────────────────────
-
-  (test-case "credential prints with masked key (custom write)"
-    (define c (credential "openai" "sk-proj-longsecretkey123" 'config))
-    (define printed (format "~a" c))
-    ;; Should NOT contain the raw key
-    (check-false (string-contains? printed "longsecretkey123"))
-    ;; Should contain the masked version
-    (check-true (string-contains? printed "...")))
-
-  (test-case "credential equal? still works for tests"
-    (define c1 (credential "test" "sk-key" 'environment))
-    (define c2 (credential "test" "sk-key" 'environment))
-    (check-equal? c1 c2))
-
-  ;; ──────────────────────────────
-  ;; F5: atomic write crash safety
-  ;; ──────────────────────────────
-
-  (test-case "save-credential-file! uses atomic write (creates valid file)"
-    (define dir (make-temp-dir))
-    (define path (build-path dir "credentials.json"))
-    (save-credential-file! "openai" "sk-test-atomic" path)
-    (check-pred file-exists? path)
-    ;; Verify no leftover temp file
-    (define files (directory-list dir))
-    (check-equal? (length (filter (lambda (f) (string-suffix? (path->string f) ".tmp")) files)) 0)
-    ;; Verify content is valid
-    (define loaded (load-credential-file path))
-    (check-equal? (hash-ref (hash-ref loaded "openai") 'api-key) "sk-test-atomic")
-    (delete-directory/files dir #:must-exist? #f))
-
-  (test-case "save-credential-file! preserves existing data through atomic write"
-    (define dir (make-temp-dir))
-    (define path (build-path dir "credentials.json"))
-    (save-credential-file! "openai" "sk-first-key" path)
-    (save-credential-file! "anthropic" "sk-ant-second-key" path)
-    (define loaded (load-credential-file path))
-    (check-equal? (hash-ref (hash-ref loaded "openai") 'api-key) "sk-first-key")
-    (check-equal? (hash-ref (hash-ref loaded "anthropic") 'api-key) "sk-ant-second-key")
-    (delete-directory/files dir #:must-exist? #f))
-
-  ;; ──────────────────────────────
-  ;; SEC-07: File permissions on credential files
-  ;; ──────────────────────────────
-
-  (test-case "save-credential-file! sets file permissions to 0600"
-    (define dir (make-temp-dir))
-    (define path (build-path dir "credentials.json"))
-    (save-credential-file! "openai" "sk-perm-test-key" path)
-    (check-pred file-exists? path)
-    ;; Read the file permissions back
-    (define perms (file-or-directory-permissions path))
-    ;; On Unix, file-or-directory-permissions returns an integer like #o100600
-    ;; or a list like '(read write execute). Check it's restrictive.
-    (when (integer? perms)
-      (define mode (bitwise-and perms #o777))
-    ;; Owner read/write only (0600)
-      (check-equal? mode #o600
-                    (format "credential file should be 0600, got ~o" mode)))
-    (delete-directory/files dir #:must-exist? #f))
-
-  (test-case "atomic-write-json! sets restrictive permissions"
-    (define dir (make-temp-dir))
-    (define path (build-path dir "test-atomic.json"))
-    ;; Use save-credential-file! which calls atomic-write-json! internally
-    (save-credential-file! "test" "sk-atomic-perm" path)
-    (check-pred file-exists? path)
-    (define perms (file-or-directory-permissions path))
-    (when (integer? perms)
-      (define mode (bitwise-and perms #o777))
-      (check-equal? mode #o600
-                    (format "atomic-write file should be 0600, got ~o" mode)))
-    (delete-directory/files dir #:must-exist? #f))
-
-  )
+(define-test-suite
+ test-auth-store
+ ;; ──────────────────────────────
+ ;; credential struct
+ ;; ──────────────────────────────
+ (test-case "credential struct is transparent"
+   (define c (credential "openai" "sk-abc" 'environment))
+   (check-equal? (credential-provider-name c) "openai")
+   (check-equal? (credential-api-key c) "sk-abc")
+   (check-equal? (credential-source c) 'environment))
+ (test-case "credential struct supports equal? comparison"
+   (define c1 (credential "openai" "sk-abc" 'environment))
+   (define c2 (credential "openai" "sk-abc" 'environment))
+   (check-equal? c1 c2))
+ ;; ──────────────────────────────
+ ;; lookup-credential — env var resolution
+ ;; ──────────────────────────────
+ (test-case "lookup-credential finds key from env var"
+   (define env-var (set-test-env! "LOOKUP1" "sk-from-env-123"))
+   (define cfg (make-provider-config #:env-var env-var #:api-key "sk-from-config"))
+   (define result (lookup-credential "test-provider" cfg))
+   (clear-test-env! "LOOKUP1")
+   (check-not-false result)
+   (check-equal? (credential-api-key result) "sk-from-env-123")
+   (check-equal? (credential-source result) 'environment)
+   (check-equal? (credential-provider-name result) "test-provider"))
+ (test-case "lookup-credential env var takes priority over config api-key"
+   (define env-var (set-test-env! "PRIORITY1" "sk-env-priority"))
+   (define cfg (make-provider-config #:env-var env-var #:api-key "sk-config-priority"))
+   (define result (lookup-credential "test-provider" cfg))
+   (clear-test-env! "PRIORITY1")
+   (check-equal? (credential-api-key result) "sk-env-priority")
+   (check-equal? (credential-source result) 'environment))
+ (test-case "lookup-credential falls back to config api-key when env var is not set"
+   (clear-test-env! "NOTSET1")
+   (define cfg
+     (make-provider-config #:env-var (test-env-var "NOTSET1") #:api-key "sk-config-fallback"))
+   (define result (lookup-credential "test-provider" cfg))
+   (check-not-false result)
+   (check-equal? (credential-api-key result) "sk-config-fallback")
+   (check-equal? (credential-source result) 'config))
+ ;; ──────────────────────────────
+ ;; lookup-credential — graceful failure
+ ;; ──────────────────────────────
+ (test-case "lookup-credential returns #f when neither env nor config has key"
+   (clear-test-env! "MISSING1")
+   (define cfg (make-provider-config #:env-var (test-env-var "MISSING1")))
+   (define result (lookup-credential "test-provider" cfg))
+   (check-false result))
+ (test-case "lookup-credential returns #f when env var is empty string"
+   (define env-var (set-test-env! "EMPTY1" ""))
+   (define cfg (make-provider-config #:env-var env-var))
+   (define result (lookup-credential "test-provider" cfg))
+   (clear-test-env! "EMPTY1")
+   (check-false result))
+ (test-case "lookup-credential returns #f when config api-key is empty string"
+   (clear-test-env! "EMPTYCFG")
+   (define cfg (make-provider-config #:env-var (test-env-var "EMPTYCFG") #:api-key ""))
+   (define result (lookup-credential "test-provider" cfg))
+   (check-false result))
+ (test-case "lookup-credential returns #f when provider-config is empty hash"
+   (define result (lookup-credential "test-provider" (hash)))
+   (check-false result))
+ ;; ──────────────────────────────
+ ;; lookup-credential — string keys support
+ ;; ──────────────────────────────
+ (test-case "lookup-credential handles string keys in provider-config"
+   (define env-var (set-test-env! "STRKEY1" "sk-str-key-env"))
+   (define cfg (make-provider-config/string-keys #:env-var env-var #:api-key "sk-str-key-cfg"))
+   (define result (lookup-credential "test-provider" cfg))
+   (clear-test-env! "STRKEY1")
+   (check-not-false result)
+   (check-equal? (credential-api-key result) "sk-str-key-env")
+   (check-equal? (credential-source result) 'environment))
+ (test-case "lookup-credential falls back to string api-key when env not set"
+   (clear-test-env! "STRKEY2")
+   (define cfg
+     (make-provider-config/string-keys #:env-var (test-env-var "STRKEY2") #:api-key "sk-str-cfg-key"))
+   (define result (lookup-credential "test-provider" cfg))
+   (check-not-false result)
+   (check-equal? (credential-api-key result) "sk-str-cfg-key")
+   (check-equal? (credential-source result) 'config))
+ ;; ──────────────────────────────
+ ;; lookup-credential — credential file fallback
+ ;; ──────────────────────────────
+ (test-case "lookup-credential falls back to credential file"
+   (clear-test-env! "NOFILE")
+   (define dir (make-temp-dir))
+   (define cred-path (build-path dir "credentials.json"))
+   ;; Write a credential file
+   (call-with-output-file
+    cred-path
+    (lambda (out)
+      (write-json (hasheq 'providers (hasheq 'file-provider (hasheq 'api-key "sk-from-file"))) out))
+    #:exists 'replace)
+   ;; v0.28.20: Use temp dir with project-local .q/ — no ~/.q/ pollution
+   (define project-tmp (make-temporary-file "q-auth-project-~a" 'directory))
+   (define project-q-dir (build-path project-tmp ".q"))
+   (make-directory* project-q-dir)
+   (define tmp-cred-path (build-path project-q-dir "credentials.json"))
+   (with-handlers ([exn:fail? (lambda (e) (delete-directory/files project-tmp #:must-exist? #f))])
+     ;; Write test credentials to project-local .q/credentials.json
+     (save-credential-file! "file-test-provider" "sk-file-key-123" tmp-cred-path)
+     ;; Lookup with project-dir — should find project-local credential
+     (define result (lookup-credential "file-test-provider" (hash) #:project-dir project-tmp))
+     (check-not-false result)
+     (check-equal? (credential-api-key result) "sk-file-key-123")
+     (check-equal? (credential-source result) 'stored)
+     (delete-directory/files project-tmp #:must-exist? #f))
+   (delete-directory/files dir #:must-exist? #f))
+ (test-case "lookup-credential returns #f when provider not in credential file"
+   (clear-test-env! "MISSINGPROV")
+   ;; Use a provider name that definitely won't be in any credential file
+   (define result (lookup-credential "nonexistent-provider-xyz-999" (hash)))
+   (check-false result))
+ (test-case "lookup-credential with #f provider-config tries credential file"
+   (define result (lookup-credential "nonexistent-provider-xyz-998" #f))
+   (check-false result))
+ ;; ──────────────────────────────
+ ;; credential-present?
+ ;; ──────────────────────────────
+ (test-case "credential-present? returns #t when env var key exists"
+   (define env-var (set-test-env! "PRESENT1" "sk-present"))
+   (define cfg (make-provider-config #:env-var env-var))
+   (check-true (credential-present? "test-provider" cfg))
+   (clear-test-env! "PRESENT1"))
+ (test-case "credential-present? returns #t when config key exists"
+   (clear-test-env! "PRESENTCFG")
+   (define cfg
+     (make-provider-config #:env-var (test-env-var "PRESENTCFG") #:api-key "sk-cfg-present"))
+   (check-true (credential-present? "test-provider" cfg)))
+ (test-case "credential-present? returns #f when no key available"
+   (clear-test-env! "NOTPRESENT")
+   (define cfg (make-provider-config #:env-var (test-env-var "NOTPRESENT")))
+   (check-false (credential-present? "test-provider" cfg)))
+ ;; ──────────────────────────────
+ ;; store-credential!
+ ;; ──────────────────────────────
+ (test-case "store-credential! updates config hash with api-key"
+   (define cfg (make-provider-config #:base-url "https://api.test.com"))
+   (define updated (store-credential! "openai" "sk-new-key" #:provider-config cfg))
+   (check-equal? (hash-ref updated 'api-key) "sk-new-key")
+   ;; Original base-url preserved
+   (check-equal? (hash-ref updated 'base-url) "https://api.test.com"))
+ (test-case "store-credential! without config-path does not touch filesystem"
+   (define cfg (hash 'base-url "https://api.test.com"))
+   (define updated (store-credential! "openai" "sk-new-key" #:provider-config cfg))
+   (check-equal? (hash-ref updated 'api-key) "sk-new-key"))
+ (test-case "store-credential! writes to file when config-path given"
+   (define dir (make-temp-dir))
+   (define config-path (build-path dir "config.json"))
+   ;; Write initial config
+   (define initial-config
+     (hasheq 'providers
+             (hasheq 'openai (hasheq 'api-key "old-key" 'base-url "https://api.openai.com"))
+             'settings
+             (hasheq 'model "gpt-4")))
+   (call-with-output-file config-path
+                          (lambda (out) (write-json initial-config out))
+                          #:exists 'replace)
+
+   ;; Store new credential
+   (define cfg (make-provider-config #:base-url "https://api.openai.com"))
+   (define updated
+     (store-credential! "openai" "sk-updated-key" #:provider-config cfg #:config-path config-path))
+
+   ;; Read back file (read-json returns hasheq with symbol keys)
+   (define file-content (call-with-input-file config-path read-json))
+   (define providers (hash-ref file-content 'providers))
+   (define openai-cfg (hash-ref providers 'openai))
+   (check-equal? (hash-ref openai-cfg 'api-key) "sk-updated-key")
+   ;; Other config preserved
+   (check-equal? (hash-ref file-content 'settings) (hasheq 'model "gpt-4"))
+
+   (delete-directory/files dir #:must-exist? #f))
+ (test-case "store-credential! creates config file if it doesn't exist"
+   (define dir (make-temp-dir))
+   (define config-path (build-path dir "new-config.json"))
+   (define cfg (hash 'base-url "https://api.test.com"))
+   (store-credential! "test-provider" "sk-brand-new" #:provider-config cfg #:config-path config-path)
+   (check-pred file-exists? config-path)
+   (define file-content (call-with-input-file config-path read-json))
+   (check-equal? (hash-ref (hash-ref file-content 'providers (hasheq)) 'test-provider (hasheq))
+                 (hasheq 'api-key "sk-brand-new"))
+   (delete-directory/files dir #:must-exist? #f))
+ ;; ──────────────────────────────
+ ;; resolve-provider-credentials
+ ;; ──────────────────────────────
+ (test-case "resolve-provider-credentials resolves all providers"
+   (define env-var (set-test-env! "BATCH1" "sk-batch-env"))
+   (define providers-hash
+     (hash "openai"
+           (make-provider-config #:env-var env-var)
+           "anthropic"
+           (make-provider-config #:api-key "sk-ant-cfg")
+           "local"
+           (make-provider-config #:base-url "http://localhost:8000")))
+   (define results (resolve-provider-credentials providers-hash))
+   (clear-test-env! "BATCH1")
+
+   ;; openai resolved from env
+   (define openai-cred (hash-ref results "openai"))
+   (check-not-false openai-cred)
+   (check-equal? (credential-api-key openai-cred) "sk-batch-env")
+   (check-equal? (credential-source openai-cred) 'environment)
+
+   ;; anthropic resolved from config
+   (define anthro-cred (hash-ref results "anthropic"))
+   (check-not-false anthro-cred)
+   (check-equal? (credential-api-key anthro-cred) "sk-ant-cfg")
+   (check-equal? (credential-source anthro-cred) 'config)
+
+   ;; local has no key
+   (define local-cred (hash-ref results "local"))
+   (check-false local-cred))
+ (test-case "resolve-provider-credentials returns empty hash for no providers"
+   (define results (resolve-provider-credentials (hash)))
+   (check-equal? (hash-count results) 0))
+ ;; ──────────────────────────────
+ ;; Edge cases
+ ;; ──────────────────────────────
+ (test-case "lookup-credential with only api-key in config (no api-key-env)"
+   (define cfg (hash 'api-key "sk-only-config"))
+   (define result (lookup-credential "test" cfg))
+   (check-not-false result)
+   (check-equal? (credential-api-key result) "sk-only-config")
+   (check-equal? (credential-source result) 'config))
+ (test-case "lookup-credential with only api-key-env but missing env var"
+   (clear-test-env! "EDGECASE")
+   (define cfg (hash 'api-key-env (test-env-var "EDGECASE")))
+   (define result (lookup-credential "test" cfg))
+   (check-false result))
+ (test-case "env var with whitespace-only value returns #f"
+   (define env-var (set-test-env! "WHITESPACE" "   "))
+   (define cfg (make-provider-config #:env-var env-var))
+   (define result (lookup-credential "test" cfg))
+   (clear-test-env! "WHITESPACE")
+   (check-false result))
+ ;; ──────────────────────────────
+ ;; mask-api-key
+ ;; ──────────────────────────────
+ (test-case "mask-api-key masks long keys"
+   (check-equal? (mask-api-key "sk-proj-abc123XYZ789") "sk-...Z789"))
+ (test-case "mask-api-key returns **** for short keys"
+   (check-equal? (mask-api-key "short") "****")
+   (check-equal? (mask-api-key "1234567") "****"))
+ (test-case "mask-api-key handles exactly 8 chars"
+   (check-equal? (mask-api-key "12345678") "123...5678"))
+ (test-case "mask-api-key handles non-string input"
+   (check-equal? (mask-api-key #f) "****")
+   (check-equal? (mask-api-key 42) "****"))
+ ;; ──────────────────────────────
+ ;; redacted-credential
+ ;; ──────────────────────────────
+ (test-case "cred->redacted creates safe display credential"
+   (define c (credential "openai" "sk-proj-longkey123abc" 'config))
+   (define r (cred->redacted c))
+   (check-equal? (redacted-credential-provider-name r) "openai")
+   (check-equal? (redacted-credential-masked-api-key r) "sk-...3abc")
+   (check-equal? (redacted-credential-source r) 'config)
+   ;; Verify the raw key is NOT in the redacted credential
+   (check-false (string-contains? (redacted-credential-masked-api-key r) "longkey123")))
+ (test-case "redacted-credential struct is transparent"
+   (define r (redacted-credential "test" "sk-...xyz" 'environment))
+   (check-equal? (redacted-credential-provider-name r) "test")
+   (check-equal? (redacted-credential-masked-api-key r) "sk-...xyz"))
+ ;; ──────────────────────────────
+ ;; validate-credential-format
+ ;; ──────────────────────────────
+ (test-case "validate-credential-format accepts valid OpenAI key"
+   (check-true (validate-credential-format "openai" "sk-proj-abc123")))
+ (test-case "validate-credential-format rejects invalid OpenAI key"
+   (check-false (validate-credential-format "openai" "invalid-key")))
+ (test-case "validate-credential-format accepts valid Anthropic key"
+   (check-true (validate-credential-format "anthropic" "sk-ant-api03-xyz")))
+ (test-case "validate-credential-format rejects invalid Anthropic key"
+   (check-false (validate-credential-format "anthropic" "sk-wrong-prefix")))
+ (test-case "validate-credential-format accepts any key for unknown provider"
+   (check-true (validate-credential-format "my-custom-llm" "any-key-format")))
+ (test-case "validate-credential-format rejects non-string inputs"
+   (check-false (validate-credential-format 42 "key"))
+   (check-false (validate-credential-format "openai" #f)))
+ ;; ──────────────────────────────
+ ;; Credential file operations
+ ;; ──────────────────────────────
+ (test-case "load-credential-file returns empty hash when file missing"
+   (define dir (make-temp-dir))
+   (define path (build-path dir "credentials.json"))
+   (define result (load-credential-file path))
+   (check-equal? result (hash))
+   (delete-directory/files dir #:must-exist? #f))
+ (test-case "save-credential-file! creates and load reads back"
+   (define dir (make-temp-dir))
+   (define path (build-path dir "credentials.json"))
+   (save-credential-file! "openai" "sk-test-12345" path)
+   (check-pred file-exists? path)
+   (define loaded (load-credential-file path))
+   (define openai-cfg (hash-ref loaded "openai" #f))
+   (check-not-false openai-cfg)
+   (check-equal? (hash-ref openai-cfg 'api-key) "sk-test-12345")
+   (delete-directory/files dir #:must-exist? #f))
+ (test-case "save-credential-file! preserves existing providers"
+   (define dir (make-temp-dir))
+   (define path (build-path dir "credentials.json"))
+   (save-credential-file! "openai" "sk-test-111" path)
+   (save-credential-file! "anthropic" "sk-ant-test-222" path)
+   (define loaded (load-credential-file path))
+   (check-equal? (hash-ref (hash-ref loaded "openai") 'api-key) "sk-test-111")
+   (check-equal? (hash-ref (hash-ref loaded "anthropic") 'api-key) "sk-ant-test-222")
+   (delete-directory/files dir #:must-exist? #f))
+ (test-case "credential-file-path returns path under ~/.q"
+   (define p (credential-file-path))
+   (check-true (string? (path->string p)))
+   (check-true (string-contains? (path->string p) ".q"))
+   (check-true (string-contains? (path->string p) "credentials.json")))
+ ;; ──────────────────────────────
+ ;; with-credential macro
+ ;; ──────────────────────────────
+ (test-case "with-credential provides scoped key access"
+   (define env-var (set-test-env! "WC1" "sk-scoped-test"))
+   (define cfg (make-provider-config #:env-var env-var))
+   (define result (with-credential "test-provider" cfg k (string-append "key-is:" k)))
+   (clear-test-env! "WC1")
+   (check-equal? result "key-is:sk-scoped-test"))
+ (test-case "with-credential returns #f when no credential"
+   (clear-test-env! "WCMISS")
+   (define cfg (make-provider-config #:env-var (test-env-var "WCMISS")))
+   (define result (with-credential "test-provider" cfg k (string-append "key-is:" k)))
+   (check-false result))
+ ;; ──────────────────────────────
+ ;; Integration: resolve + redact
+ ;; ──────────────────────────────
+ (test-case "resolve-provider-credentials can be redacted for display"
+   (define env-var (set-test-env! "INTEG1" "sk-integration-test-key"))
+   (define providers-hash
+     (hash "openai"
+           (make-provider-config #:env-var env-var)
+           "local"
+           (make-provider-config #:base-url "http://localhost")))
+   (define results (resolve-provider-credentials providers-hash))
+   (clear-test-env! "INTEG1")
+
+   ;; Redact all credentials
+   (define redacted
+     (for/hash ([(name cred) (in-hash results)])
+       (values name (and cred (cred->redacted cred)))))
+
+   ;; openai is redacted
+   (define openai-redacted (hash-ref redacted "openai"))
+   (check-not-false openai-redacted)
+   (check-pred redacted-credential? openai-redacted)
+   (check-false (string-contains? (redacted-credential-masked-api-key openai-redacted)
+                                  "integration-test-key"))
+
+   ;; local has no credential
+   (check-false (hash-ref redacted "local")))
+ ;; ──────────────────────────────
+ ;; F4: credential custom write masks API key
+ ;; ──────────────────────────────
+ (test-case "credential prints with masked key (custom write)"
+   (define c (credential "openai" "sk-proj-longsecretkey123" 'config))
+   (define printed (format "~a" c))
+   ;; Should NOT contain the raw key
+   (check-false (string-contains? printed "longsecretkey123"))
+   ;; Should contain the masked version
+   (check-true (string-contains? printed "...")))
+ (test-case "credential equal? still works for tests"
+   (define c1 (credential "test" "sk-key" 'environment))
+   (define c2 (credential "test" "sk-key" 'environment))
+   (check-equal? c1 c2))
+ ;; ──────────────────────────────
+ ;; F5: atomic write crash safety
+ ;; ──────────────────────────────
+ (test-case "save-credential-file! uses atomic write (creates valid file)"
+   (define dir (make-temp-dir))
+   (define path (build-path dir "credentials.json"))
+   (save-credential-file! "openai" "sk-test-atomic" path)
+   (check-pred file-exists? path)
+   ;; Verify no leftover temp file
+   (define files (directory-list dir))
+   (check-equal? (length (filter (lambda (f) (string-suffix? (path->string f) ".tmp")) files)) 0)
+   ;; Verify content is valid
+   (define loaded (load-credential-file path))
+   (check-equal? (hash-ref (hash-ref loaded "openai") 'api-key) "sk-test-atomic")
+   (delete-directory/files dir #:must-exist? #f))
+ (test-case "save-credential-file! preserves existing data through atomic write"
+   (define dir (make-temp-dir))
+   (define path (build-path dir "credentials.json"))
+   (save-credential-file! "openai" "sk-first-key" path)
+   (save-credential-file! "anthropic" "sk-ant-second-key" path)
+   (define loaded (load-credential-file path))
+   (check-equal? (hash-ref (hash-ref loaded "openai") 'api-key) "sk-first-key")
+   (check-equal? (hash-ref (hash-ref loaded "anthropic") 'api-key) "sk-ant-second-key")
+   (delete-directory/files dir #:must-exist? #f))
+ ;; ──────────────────────────────
+ ;; SEC-07: File permissions on credential files
+ ;; ──────────────────────────────
+ (test-case "save-credential-file! sets file permissions to 0600"
+   (define dir (make-temp-dir))
+   (define path (build-path dir "credentials.json"))
+   (save-credential-file! "openai" "sk-perm-test-key" path)
+   (check-pred file-exists? path)
+   ;; Read the file permissions back
+   (define perms (file-or-directory-permissions path))
+   ;; On Unix, file-or-directory-permissions returns an integer like #o100600
+   ;; or a list like '(read write execute). Check it's restrictive.
+   (when (integer? perms)
+     (define mode (bitwise-and perms #o777))
+     ;; Owner read/write only (0600)
+     (check-equal? mode #o600 (format "credential file should be 0600, got ~o" mode)))
+   (delete-directory/files dir #:must-exist? #f))
+ (test-case "atomic-write-json! sets restrictive permissions"
+   (define dir (make-temp-dir))
+   (define path (build-path dir "test-atomic.json"))
+   ;; Use save-credential-file! which calls atomic-write-json! internally
+   (save-credential-file! "test" "sk-atomic-perm" path)
+   (check-pred file-exists? path)
+   (define perms (file-or-directory-permissions path))
+   (when (integer? perms)
+     (define mode (bitwise-and perms #o777))
+     (check-equal? mode #o600 (format "atomic-write file should be 0600, got ~o" mode)))
+   (delete-directory/files dir #:must-exist? #f)))
 
 ;; ── Run ──
 

--- a/tests/test-cli.rkt
+++ b/tests/test-cli.rkt
@@ -991,45 +991,27 @@
  (test-suite "Issue #143: run-init-wizard"
 
    (test-case "wizard creates config with valid provider"
-     ;; Save and restore ~/.q/config.json to avoid polluting other tests
-     (define config-path (build-path (find-system-path 'home-dir) ".q" "config.json"))
-     (define backup-path (make-temporary-file "q-init-backup-~a"))
-     (define had-config? (file-exists? config-path))
-     (when had-config?
-       (copy-file config-path backup-path #t))
-     (dynamic-wind (lambda () (void))
-                   (lambda ()
-                     (check-not-exn (lambda ()
-                                      (run-init-wizard #:in (open-input-string "openai\nsk-test\n\n")
-                                                       #:out (open-output-string)))))
-                   (lambda ()
-                     (if had-config?
-                         (copy-file backup-path config-path #t)
-                         (when (file-exists? config-path)
-                           (delete-file config-path)))
-                     (when (file-exists? backup-path)
-                       (delete-file backup-path)))))
+     ;; v0.28.20: Use temp dir instead of backing up real ~/.q/
+     (define tmp (make-temporary-file "q-cli-wizard-~a" 'directory))
+     (dynamic-wind
+      (lambda () (void))
+      (lambda ()
+        (check-not-exn (lambda ()
+                         (run-init-wizard #:in (open-input-string "openai\nsk-real-key-not-test\n\n")
+                                          #:out (open-output-string)
+                                          #:config-dir tmp))))
+      (lambda () (delete-directory/files tmp #:must-exist? #f))))
 
    (test-case "wizard rejects invalid provider"
-     (define config-path (build-path (find-system-path 'home-dir) ".q" "config.json"))
-     (define backup-path (make-temporary-file "q-init-backup-~a"))
-     (define had-config? (file-exists? config-path))
-     (when had-config?
-       (copy-file config-path backup-path #t))
-     (dynamic-wind (lambda () (void))
-                   (lambda ()
-                     (define out (open-output-string))
-                     (run-init-wizard #:in (open-input-string "y\ninvalid\n") #:out out)
-                     (define output (get-output-string out))
-                     (check-true (string-contains? output "Invalid provider")
-                                 "should reject invalid provider"))
-                   (lambda ()
-                     (if had-config?
-                         (copy-file backup-path config-path #t)
-                         (when (file-exists? config-path)
-                           (delete-file config-path)))
-                     (when (file-exists? backup-path)
-                       (delete-file backup-path)))))))
+     (define tmp (make-temporary-file "q-cli-wizard-~a" 'directory))
+     (dynamic-wind
+      (lambda () (void))
+      (lambda ()
+        (define out (open-output-string))
+        (run-init-wizard #:in (open-input-string "y\ninvalid\n") #:out out #:config-dir tmp)
+        (define output (get-output-string out))
+        (check-true (string-contains? output "Invalid provider") "should reject invalid provider"))
+      (lambda () (delete-directory/files tmp #:must-exist? #f))))))
 ;; ═══════════════════════════════════════════
 ;; Issue #160: 'sessions' subcommand parsing
 ;; ═══════════════════════════════════════════

--- a/tests/test-init-wizard.rkt
+++ b/tests/test-init-wizard.rkt
@@ -3,8 +3,7 @@
 ;; tests/test-init-wizard.rkt — Tests for cli/init-wizard.rkt
 ;;
 ;; Tests run-init-wizard using string ports for input/output.
-;; Note: the wizard writes to ~/.q/config.json via find-system-path.
-;; Tests clean up after themselves.
+;; v0.28.20: All tests use temp-dir isolation — no ~/.q/ pollution.
 
 (require rackunit
          racket/port
@@ -16,121 +15,125 @@
 ;; Helpers
 ;; ============================================================
 
-(define (run-wizard-with-input input-str)
+(define (run-wizard-with-input input-str #:config-dir [config-dir #f])
   ;; Run the wizard with string input, capture output.
   (define in (open-input-string input-str))
   (define out (open-output-string))
-  (run-init-wizard #:in in #:out out)
+  (run-init-wizard #:in in #:out out #:config-dir config-dir)
   (get-output-string out))
 
-(define (cleanup-config)
-  (define q-dir (build-path (find-system-path 'home-dir) ".q"))
-  (when (directory-exists? q-dir)
-    (delete-directory/files q-dir)))
+(define (with-isolated-config thunk)
+  ;; Create a temp dir, run thunk with it, clean up.
+  (define tmp (make-temporary-file "q-wizard-test-~a" 'directory))
+  (dynamic-wind (lambda () (void))
+                (lambda () (thunk tmp))
+                (lambda () (delete-directory/files tmp #:must-exist? #f))))
 
-(define (config-exists?)
-  (file-exists? (build-path (find-system-path 'home-dir) ".q" "config.json")))
+(define (config-exists? dir)
+  (file-exists? (build-path dir "config.json")))
 
-(define (read-config)
-  (call-with-input-file
-      (build-path (find-system-path 'home-dir) ".q" "config.json")
-    read-json))
+(define (read-config dir)
+  (call-with-input-file (build-path dir "config.json") read-json))
 
 ;; ============================================================
-;; Test cases
+;; Test cases — all isolated to temp dirs
 ;; ============================================================
 
 (test-case "run-init-wizard writes config for valid openai input"
-  (cleanup-config)
-  (define output (run-wizard-with-input "openai\nsk-test-key-123\ngpt-4o\n"))
-  (check-true (string-contains? output "Configuration saved"))
-  (check-true (string-contains? output "Run 'q' to start"))
-  (when (config-exists?)
-    (define cfg (read-config))
-    (check-equal? (hash-ref cfg 'default-provider) "openai"))
-  (cleanup-config))
+  (with-isolated-config
+   (lambda (tmp)
+     (define output (run-wizard-with-input "openai\nsk-real-key-not-test\ngpt-4o\n" #:config-dir tmp))
+     (check-true (string-contains? output "Configuration saved"))
+     (check-true (string-contains? output "Run 'q' to start"))
+     (when (config-exists? tmp)
+       (define cfg (read-config tmp))
+       (check-equal? (hash-ref cfg 'default-provider) "openai")))))
 
 (test-case "run-init-wizard rejects invalid provider"
-  (cleanup-config)
-  (define output (run-wizard-with-input "bad-provider\n"))
-  (check-true (string-contains? output "Invalid provider"))
-  (cleanup-config))
+  (with-isolated-config (lambda (tmp)
+                          (define output (run-wizard-with-input "bad-provider\n" #:config-dir tmp))
+                          (check-true (string-contains? output "Invalid provider")))))
 
 (test-case "run-init-wizard accepts openai-compatible provider with base URL"
-  (cleanup-config)
-  (define output (run-wizard-with-input "openai-compatible\nhttp://localhost:11434/v1\n\nllama3\n"))
-  (check-true (string-contains? output "Configuration saved"))
-  (when (config-exists?)
-    (define cfg (read-config))
-    (check-equal? (hash-ref cfg 'default-provider) "openai-compatible")
-    (define providers (hash-ref cfg 'providers))
-    (define compat-cfg (hash-ref providers 'openai-compatible))
-    (check-equal? (hash-ref compat-cfg 'base-url) "http://localhost:11434/v1")
-    (check-equal? (hash-ref compat-cfg 'default-model) "llama3"))
-  (cleanup-config))
+  (with-isolated-config
+   (lambda (tmp)
+     (define output
+       (run-wizard-with-input "openai-compatible\nhttp://localhost:11434/v1\n\nllama3\n"
+                              #:config-dir tmp))
+     (check-true (string-contains? output "Configuration saved"))
+     (when (config-exists? tmp)
+       (define cfg (read-config tmp))
+       (check-equal? (hash-ref cfg 'default-provider) "openai-compatible")
+       (define providers (hash-ref cfg 'providers))
+       (define compat-cfg (hash-ref providers 'openai-compatible))
+       (check-equal? (hash-ref compat-cfg 'base-url) "http://localhost:11434/v1")
+       (check-equal? (hash-ref compat-cfg 'default-model) "llama3")))))
 
 (test-case "run-init-wizard openai-compatible with empty base URL"
-  (cleanup-config)
-  (define output (run-wizard-with-input "openai-compatible\n\nsk-test\nmodel-x\n"))
-  (check-true (string-contains? output "Configuration saved"))
-  (when (config-exists?)
-    (define cfg (read-config))
-    (define providers (hash-ref cfg 'providers))
-    (define compat-cfg (hash-ref providers 'openai-compatible))
-    ;; No base-url key when empty
-    (check-false (hash-ref compat-cfg 'base-url #f))
-    (check-equal? (hash-ref compat-cfg 'default-model) "model-x"))
-  (cleanup-config))
+  (with-isolated-config
+   (lambda (tmp)
+     (define output
+       (run-wizard-with-input "openai-compatible\n\nsk-real-key-not-test\nmodel-x\n"
+                              #:config-dir tmp))
+     (check-true (string-contains? output "Configuration saved"))
+     (when (config-exists? tmp)
+       (define cfg (read-config tmp))
+       (define providers (hash-ref cfg 'providers))
+       (define compat-cfg (hash-ref providers 'openai-compatible))
+       ;; No base-url key when empty
+       (check-false (hash-ref compat-cfg 'base-url #f))
+       (check-equal? (hash-ref compat-cfg 'default-model) "model-x")))))
 
 (test-case "run-init-wizard accepts anthropic provider"
-  (cleanup-config)
-  (define output (run-wizard-with-input "anthropic\nsk-ant-test\nclaude-3\n"))
-  (check-true (string-contains? output "Configuration saved"))
-  (cleanup-config))
+  (with-isolated-config
+   (lambda (tmp)
+     (define output (run-wizard-with-input "anthropic\nsk-ant-real-key\nclaude-3\n" #:config-dir tmp))
+     (check-true (string-contains? output "Configuration saved")))))
 
 (test-case "run-init-wizard accepts gemini provider"
-  (cleanup-config)
-  (define output (run-wizard-with-input "gemini\nAIza-test\n\n"))
-  (check-true (string-contains? output "Configuration saved"))
-  (cleanup-config))
+  (with-isolated-config (lambda (tmp)
+                          (define output
+                            (run-wizard-with-input "gemini\nAIza-real-key\n\n" #:config-dir tmp))
+                          (check-true (string-contains? output "Configuration saved")))))
 
 (test-case "run-init-wizard uses provider default when model is empty"
-  (cleanup-config)
-  (define output (run-wizard-with-input "openai\nsk-test\n\n"))
-  (check-true (string-contains? output "Configuration saved"))
-  (when (config-exists?)
-    (define cfg (read-config))
-    (define providers (hash-ref cfg 'providers))
-    (define openai-cfg (hash-ref providers 'openai))
-    ;; Now always sets a sensible default (#455)
-    (check-equal? (hash-ref openai-cfg 'default-model) "gpt-4o"))
-  (cleanup-config))
+  (with-isolated-config
+   (lambda (tmp)
+     (define output (run-wizard-with-input "openai\nsk-real-key-not-test\n\n" #:config-dir tmp))
+     (check-true (string-contains? output "Configuration saved"))
+     (when (config-exists? tmp)
+       (define cfg (read-config tmp))
+       (define providers (hash-ref cfg 'providers))
+       (define openai-cfg (hash-ref providers 'openai))
+       ;; Now always sets a sensible default (#455)
+       (check-equal? (hash-ref openai-cfg 'default-model) "gpt-4o")))))
 
 (test-case "run-init-wizard sets default-model when provided"
-  (cleanup-config)
-  (define output (run-wizard-with-input "openai\nsk-test\ngpt-4o-mini\n"))
-  (check-true (string-contains? output "Configuration saved"))
-  (when (config-exists?)
-    (define cfg (read-config))
-    (define providers (hash-ref cfg 'providers))
-    (define openai-cfg (hash-ref providers 'openai))
-    (check-equal? (hash-ref openai-cfg 'default-model) "gpt-4o-mini"))
-  (cleanup-config))
+  (with-isolated-config (lambda (tmp)
+                          (define output
+                            (run-wizard-with-input "openai\nsk-real-key-not-test\ngpt-4o-mini\n"
+                                                   #:config-dir tmp))
+                          (check-true (string-contains? output "Configuration saved"))
+                          (when (config-exists? tmp)
+                            (define cfg (read-config tmp))
+                            (define providers (hash-ref cfg 'providers))
+                            (define openai-cfg (hash-ref providers 'openai))
+                            (check-equal? (hash-ref openai-cfg 'default-model) "gpt-4o-mini")))))
 
 (test-case "run-init-wizard overwrites existing config when user says y"
-  (cleanup-config)
-  ;; First run: create config
-  (run-wizard-with-input "openai\nsk-first\ngpt-4\n")
-  ;; Second run: overwrite
-  (define output (run-wizard-with-input "y\nanthropic\nsk-second\nclaude-3\n"))
-  (check-true (string-contains? output "Configuration saved"))
-  (cleanup-config))
+  (with-isolated-config
+   (lambda (tmp)
+     ;; First run: create config
+     (run-wizard-with-input "openai\nsk-first-real-key\ngpt-4\n" #:config-dir tmp)
+     ;; Second run: overwrite
+     (define output
+       (run-wizard-with-input "y\nanthropic\nsk-second-real-key\nclaude-3\n" #:config-dir tmp))
+     (check-true (string-contains? output "Configuration saved")))))
 
 (test-case "run-init-wizard aborts when user declines overwrite"
-  (cleanup-config)
-  ;; First run: create config
-  (run-wizard-with-input "openai\nsk-first\n\n")
-  ;; Second run: decline overwrite
-  (define output (run-wizard-with-input "n\n"))
-  (check-true (string-contains? output "Aborted"))
-  (cleanup-config))
+  (with-isolated-config (lambda (tmp)
+                          ;; First run: create config
+                          (run-wizard-with-input "openai\nsk-first-real-key\n\n" #:config-dir tmp)
+                          ;; Second run: decline overwrite
+                          (define output (run-wizard-with-input "n\n" #:config-dir tmp))
+                          (check-true (string-contains? output "Aborted")))))

--- a/tests/test-lockfile.rkt
+++ b/tests/test-lockfile.rkt
@@ -55,16 +55,19 @@
  ;; --- Stale lock detection ---
  (test-case "stale lock from dead PID is cleaned up"
    (define tmp-name (format "locktest-stale-~a" (current-milliseconds)))
-   ;; Manually create a lock file with a dead PID
-   (define lf (build-path (find-system-path 'home-dir) ".q" "locks" (string-append "lock-" tmp-name)))
-   (make-directory* (build-path (find-system-path 'home-dir) ".q" "locks"))
-   (call-with-output-file lf
-                          (lambda (out)
-                            (display 4194303 out)
-                            (newline out))
-                          #:exists 'truncate)
-   ;; Now try to acquire — should detect stale lock and succeed
-   (define result (with-lock-result tmp-name (lambda () 'stale-cleaned)))
-   (check-equal? result '(ok stale-cleaned))))
+   ;; v0.28.20: Use temp dir for lock files — no ~/.q/ pollution
+   (define tmp-locks (make-temporary-file "q-locks-test-~a" 'directory))
+   (parameterize ([current-locks-dir tmp-locks])
+     ;; Manually create a lock file with a dead PID
+     (define lf (build-path tmp-locks (string-append "lock-" tmp-name)))
+     (call-with-output-file lf
+                            (lambda (out)
+                              (display 4194303 out)
+                              (newline out))
+                            #:exists 'truncate)
+     ;; Now try to acquire — should detect stale lock and succeed
+     (define result (with-lock-result tmp-name (lambda () 'stale-cleaned)))
+     (check-equal? result '(ok stale-cleaned)))
+   (delete-directory/files tmp-locks #:must-exist? #f)))
 
 (run-tests lockfile-tests)

--- a/util/lockfile.rkt
+++ b/util/lockfile.rkt
@@ -27,7 +27,8 @@
                                      #:stale-ms (or/c #f exact-nonnegative-integer?))
                              (or/c (list/c 'ok any/c) (list/c 'timeout #f)))]
                        [pid-alive? (-> exact-positive-integer? boolean?)])
-         getpid)
+         getpid
+         current-locks-dir)
 
 ;; ══════════════════════════════════════════════════════════════
 ;; Get PID — uses FFI direct syscall (no shell)
@@ -57,9 +58,11 @@
     ;; Returns 0 on success (process exists), -1 on error (no such process)
     [else (zero? (raw-kill pid 0))]))
 
-;; Lock directory — ~/.q/locks/
+;; Lock directory — ~/.q/locks/ (parameterized for testing)
+(define current-locks-dir (make-parameter #f (lambda (v) v)))
+
 (define (locks-dir)
-  (build-path (find-system-path 'home-dir) ".q" "locks"))
+  (or (current-locks-dir) (build-path (find-system-path 'home-dir) ".q" "locks")))
 
 ;; Ensure lock directory exists
 (define (ensure-locks-dir!)


### PR DESCRIPTION
Addresses #3199.

fix(auth): project-local credential resolution + test isolation (#3199)

C1 CRITICAL: credential-from-file now checks project-local
.q/credentials.json before global ~/.q/credentials.json. Wire
#:project-dir through lookup-credential and provider-factory.

C2 CRITICAL: Isolate 4 test files from real ~/.q/:
- test-init-wizard.rkt: temp-dir isolation via #:config-dir
- test-cli.rkt: temp-dir isolation for init-wizard tests
- test-auth-store.rkt: project-local .q/ for file credential tests
- test-lockfile.rkt: parameterized current-locks-dir for temp dir

Also adds test-key guard (sk-test keys rejected with warning).