### PR TITLE
feat(runtime): mock provider warning + minimum busy duration (#3206)

T7: Emit system.warning event when mock provider is used, with
guidance message "Check .q/credentials.json". Emitted once per turn.

T8: Test-key guard already done in W0 (sk-test keys rejected).

T9: Add busy-since field to ui-state. On turn.started, record
timestamp. On turn.completed, enforce minimum 500ms busy duration
to prevent status bar flicker for fast providers.

### DIFF
--- a/runtime/turn-orchestrator.rkt
+++ b/runtime/turn-orchestrator.rkt
@@ -76,6 +76,8 @@
          (only-in "../runtime/auto-retry.rkt" with-auto-retry context-overflow-error?)
          ;; Token estimation for context assembly event
          (only-in "../llm/token-budget.rkt" estimate-context-tokens)
+         ;; Mock provider detection
+         (only-in "provider-factory.rkt" provider-is-mock?)
          ;; Shared helpers
          (only-in "runtime-helpers.rkt" emit-session-event! maybe-dispatch-hooks))
 
@@ -100,8 +102,7 @@
     (if ws
         (working-set-resolve-messages ws ctx-to-use message-id)
         '()))
-  (define ws-message-ids
-    (map message-id ws-messages))
+  (define ws-message-ids (map message-id ws-messages))
 
   ;; R2-6: Create hook dispatcher function for context assembly
   (define ctx-assembly-hook-dispatcher
@@ -128,13 +129,11 @@
 
   ;; v0.26.0: Emit working-set.injected event
   (when ws
-    (emit-session-event! bus
-                         session-id
-                         "working-set.injected"
-                         (hasheq 'entries
-                                 (working-set-entry-count ws)
-                                 'tokens
-                                 (working-set-token-count ws))))
+    (emit-session-event!
+     bus
+     session-id
+     "working-set.injected"
+     (hasheq 'entries (working-set-entry-count ws) 'tokens (working-set-token-count ws))))
 
   ;; Emit context.assembled event (v0.19.12 W1: added tokenCount)
   (define ctx-token-count (estimate-context-tokens ctx-assembled))
@@ -150,9 +149,13 @@
                                'tokenCount
                                ctx-token-count
                                'working-set-entries
-                               (if ws (working-set-entry-count ws) 0)
+                               (if ws
+                                   (working-set-entry-count ws)
+                                   0)
                                'working-set-tokens
-                               (if ws (working-set-token-count ws) 0)))
+                               (if ws
+                                   (working-set-token-count ws)
+                                   0)))
 
   ;; Dispatch 'context hook — extensions can amend final context
   (define-values (ctx-final _ctx-hook) (maybe-dispatch-hooks ext-reg 'context ctx-assembled))
@@ -207,6 +210,16 @@
                            token
                            config
                            #:tool-list-proc [tool-list-proc #f])
+  ;; v0.28.20 T7: Emit system.warning if mock provider is being used
+  (when (provider-is-mock? prov)
+    (emit-session-event! bus
+                         session-id
+                         "system.warning"
+                         (hasheq 'message
+                                 "No API key found — using mock provider. Check .q/credentials.json"
+                                 'provider
+                                 "mock")))
+
   ;; Dispatch 'before-provider-request hook (informational)
   (define-values (_bpr-payload _bpr-res)
     (maybe-dispatch-hooks ext-reg

--- a/tui/state-events.rkt
+++ b/tui/state-events.rkt
@@ -182,18 +182,29 @@
      (struct-copy ui-state
                   state
                   [busy? #t]
+                  [busy-since (current-inexact-milliseconds)]
                   [pending-tool-name #f]
                   [streaming-text #f]
                   [streaming-thinking #f]
                   [status-message #f])]
 
     [("turn.completed")
-     (struct-copy ui-state
-                  state
-                  [busy? #f]
-                  [streaming-text #f]
-                  [streaming-thinking #f]
-                  [pending-tool-name #f])]
+     ;; v0.28.20 T9: Enforce minimum 500ms busy duration to prevent flicker
+     (define min-busy-ms 500)
+     (define since (ui-state-busy-since state))
+     (define elapsed
+       (if since
+           (- (current-inexact-milliseconds) since)
+           min-busy-ms))
+     (if (< elapsed min-busy-ms)
+         (struct-copy ui-state state [streaming-text #f] [streaming-thinking #f])
+         (struct-copy ui-state
+                      state
+                      [busy? #f]
+                      [busy-since #f]
+                      [streaming-text #f]
+                      [streaming-thinking #f]
+                      [pending-tool-name #f]))]
 
     [("turn.cancelled")
      (struct-copy ui-state

--- a/tui/state-types.rkt
+++ b/tui/state-types.rkt
@@ -76,7 +76,7 @@
          editor-component ; (or/c #f q-component?) — custom editor for input area (#1150)
          context-tokens ; (or/c #f integer?) — estimated token count from context events (v0.19.12 W1)
          cost-tracker ; (or/c #f cost-tracker?) — mutable cost accumulator (G8.4)
-         )
+         busy-since)
   #:transparent)
 
 ;; Overlay state for modal/popup UI elements (command palette, etc.)
@@ -195,7 +195,7 @@
             #f ; editor-component
             #f ; context-tokens
             (make-cost-tracker) ; cost-tracker
-            ))
+            #f))
 
 ;; ============================================================
 ;; String helpers


### PR DESCRIPTION
Addresses #3206.

feat(runtime): mock provider warning + minimum busy duration (#3206)

T7: Emit system.warning event when mock provider is used, with
guidance message "Check .q/credentials.json". Emitted once per turn.

T8: Test-key guard already done in W0 (sk-test keys rejected).

T9: Add busy-since field to ui-state. On turn.started, record
timestamp. On turn.completed, enforce minimum 500ms busy duration
to prevent status bar flicker for fast providers.