### PR TITLE
fix(tui): audit minor findings — thinking docs, stream test, state cleanup (#3210)

T10: Add 'thinking to transcript-entry kind docstring in state-types.rkt.

T11: Add co-located content+reasoning_content stream test for
DeepSeek-R1 edge case where both fields present in single chunk.

T12: Clear streaming-thinking on assistant.message.completed in
state-events.rkt — prevents stale thinking text on protocol anomaly.

### DIFF
--- a/tests/test-stream.rkt
+++ b/tests/test-stream.rkt
@@ -65,6 +65,23 @@
 (check-equal? (stream-chunk-delta-text (cadr reasoning-batch)) "The answer is 42")
 (check-false (stream-chunk-delta-thinking (cadr reasoning-batch)))
 
+;; v0.28.20 T11: Co-located content + reasoning_content in single chunk (DeepSeek-R1 edge case)
+(define co-located-chunk
+  (normalize-openai-chunks
+   (list (hash 'id
+               "chatcmpl-coloc"
+               'object
+               "chat.completion.chunk"
+               'choices
+               (list (hash 'delta
+                           (hash 'reasoning_content "thinking..." 'content "hello")
+                           'finish_reason
+                           'null))))))
+(check-equal? (length co-located-chunk) 1)
+(define coloc (car co-located-chunk))
+(check-equal? (stream-chunk-delta-thinking coloc) "thinking...")
+(check-equal? (stream-chunk-delta-text coloc) "hello")
+
 (define chunk2
   (normalize-openai-chunk
    (hash

--- a/tui/state-events.rkt
+++ b/tui/state-events.rkt
@@ -47,7 +47,8 @@
                   (append-entry state (make-entry 'assistant content ts (hash)))
                   [busy? #f]
                   [pending-tool-name #f]
-                  [streaming-text #f])]
+                  [streaming-text #f]
+                  [streaming-thinking #f])]
 
     [("tool.call.started")
      (let* ([name (hash-ref payload 'name "?")]

--- a/tui/state-types.rkt
+++ b/tui/state-types.rkt
@@ -39,7 +39,7 @@
 
 ;; A single line in the transcript display
 (struct transcript-entry
-        (kind ; symbol: 'assistant | 'tool-start | 'tool-end | 'tool-fail | 'system | 'error | 'user
+        (kind ; symbol: 'assistant | 'tool-start | 'tool-end | 'tool-fail | 'system | 'error | 'user | 'thinking
          text ; string — the display text
          timestamp ; number — epoch seconds (or 0)
          meta ; hash — extra data (tool name, error message, etc.)


### PR DESCRIPTION
Addresses #3210.

fix(tui): audit minor findings — thinking docs, stream test, state cleanup (#3210)

T10: Add 'thinking to transcript-entry kind docstring in state-types.rkt.

T11: Add co-located content+reasoning_content stream test for
DeepSeek-R1 edge case where both fields present in single chunk.

T12: Clear streaming-thinking on assistant.message.completed in
state-events.rkt — prevents stale thinking text on protocol anomaly.