### PR TITLE
fix: hash-set on mutable config causes TUI no response (#3222)

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,8 +271,8 @@ q/
 | Metric | Value |
 |--------|-------|
 | Test files | 480 |
-| Source modules | 377 |
-| Source lines | 60193 |
+| Source modules | 378 |
+| Source lines | 60868 |
 | Test lines | 91315 |
 | Test assertions | 14150 |
 | Tests passing | 5835+ | `racket scripts/run-tests.rkt` results |

--- a/runtime/iteration.rkt
+++ b/runtime/iteration.rkt
@@ -362,7 +362,12 @@
 
              [else
               ;; Build assembled context (tiered + hooks) — from turn-orchestrator.rkt
-              (define config-with-ws (hash-set config 'working-set ws))
+              ;; v0.28.21: Handle both mutable and immutable config hashes
+              ;; (build-runtime-from-cli uses hash-set!, making config mutable)
+              (define config-with-ws
+                (if (immutable? config)
+                    (hash-set config 'working-set ws)
+                    (begin (hash-set! config 'working-set ws) config)))
               (define ctx-final
                 (build-assembled-context ctx-to-use config-with-ws ext-reg bus session-id iteration))
 


### PR DESCRIPTION
Fixes #3222

## Bug

TUI silently fails with no response on every prompt. `[thinking...]` appears briefly then the status bar resets without showing any response.

## Root Cause

`runtime/iteration.rkt:367` called `(hash-set config working-set ws)` on a **mutable** hash. `build-runtime-from-cli` uses `hash-set!` to build the runtime config, making it mutable. `hash-set` requires an immutable hash, triggering `exn:fail:contract` on every prompt.

## Fix

Check `(immutable? config)` and use `hash-set!` for mutable hashes:

```racket
(define config-with-ws
  (if (immutable? config)
      (hash-set config (quote working-set) ws)
      (begin (hash-set! config (quote working-set) ws) config)))
```

## Verification

- **Live TUI test** (tmux, glm-5.1): 3 prompts all responded correctly
- **Test suite**: 448/452 files, 6857/6857 tests pass
- **1 file changed**: `runtime/iteration.rkt` (+6/-1)
- README metrics synced (377->378 modules)