### PR TITLE
feat(tui): enhanced thinking visual styling — cyan dim italic + separator + truncation (#3227)

Thinking entries now render with:
- Distinct cyan dim italic style for visual differentiation
- Horizontal rule separator prefix (── [thinking])
- 3-line truncation for long reasoning text with indicator

TDD: 3 new test cases in test-render-message-layout.rkt.

### DIFF
--- a/tests/tui/test-render-message-layout.rkt
+++ b/tests/tui/test-render-message-layout.rkt
@@ -4,7 +4,9 @@
 
 (require rackunit
          rackunit/text-ui
-         "../../tui/render/message-layout.rkt")
+         racket/string
+         "../../tui/render/message-layout.rkt"
+         "../../tui/state-types.rkt")
 
 (define layout-tests
   (test-suite "Render Message Layout"
@@ -14,8 +16,7 @@
       (check-equal? (styled-line->text sl) "hello"))
 
     (test-case "styled-line->text concatenates segments"
-      (define sl (styled-line (list (styled-segment "hello " '(bold))
-                                     (styled-segment "world" '()))))
+      (define sl (styled-line (list (styled-segment "hello " '(bold)) (styled-segment "world" '()))))
       (check-equal? (styled-line->text sl) "hello world"))
 
     (test-case "styles->sgr: bold"
@@ -34,7 +35,35 @@
 
     (test-case "theme->style returns list"
       (define style (theme->style 'user))
-      (check-true (list? style)))))
+      (check-true (list? style)))
+
+    ;; v0.28.21 W1: Enhanced thinking visual styling
+    (test-case "format-entry thinking uses dim italic cyan style"
+      (define entry (transcript-entry 'thinking "test thinking text" 0 (hasheq) #f))
+      (define result (format-entry entry))
+      (check-true (andmap styled-line? result))
+      (define all-segments (append-map styled-line-segments result))
+      (define first-style (styled-segment-style (car all-segments)))
+      (check-not-false (member 'dim first-style) "thinking should be dim")
+      (check-not-false (member 'italic first-style) "thinking should be italic")
+      (check-not-false (member 'cyan first-style) "thinking should be cyan"))
+
+    (test-case "format-entry thinking truncates long text to 3 lines"
+      (define long-text
+        (string-join (for/list ([i (in-range 10)])
+                       (format "line ~a of thinking" i))
+                     "\n"))
+      (define entry (transcript-entry 'thinking long-text 0 (hasheq) #f))
+      (define result (format-entry entry))
+      ;; Should have at most 4 lines: 3 content + 1 truncation indicator
+      (check-true (<= (length result) 4) (format "expected ≤4 lines, got ~a" (length result))))
+
+    (test-case "format-entry thinking has visible separator prefix"
+      (define entry (transcript-entry 'thinking "some thought" 0 (hasheq) #f))
+      (define result (format-entry entry))
+      (define first-text (styled-line->text (car result)))
+      (check-not-false (regexp-match #rx"──" first-text)
+                       (format "expected separator prefix in '~a'" first-text)))))
 
 (module+ main
   (run-tests layout-tests))

--- a/tui/render/message-layout.rkt
+++ b/tui/render/message-layout.rkt
@@ -97,8 +97,19 @@
      (list (styled-line (list (styled-segment (format "[FAIL] ~a: ~a" tool-name sanitized) '(red)))))]
     [(error) (list (styled-line (list (styled-segment (format "[ERR] ~a" raw-text) '(bold red)))))]
     [(thinking)
-     ;; v0.28.19: Show reasoning text in dim+italic, distinct from content
-     (list (styled-line (list (styled-segment (format "[thinking] ~a" raw-text) '(dim italic)))))]
+     ;; v0.28.21 W1: Distinct thinking rendering with truncation + separator
+     (define max-lines 3)
+     (define lines (string-split raw-text "\n"))
+     (define visible-lines (take lines (min max-lines (length lines))))
+     (define truncated? (> (length lines) max-lines))
+     (define base-style '(dim italic cyan))
+     (append (for/list ([l (in-list visible-lines)])
+               (styled-line (list (styled-segment (format "── [thinking] ~a" l) base-style))))
+             (if truncated?
+                 (list (styled-line (list (styled-segment (format "... ~a more lines"
+                                                                  (- (length lines) max-lines))
+                                                          base-style))))
+                 '()))]
     [else (list (styled-line (list (styled-segment raw-text '()))))]))
 
 ;; Convert a markdown token to a list of styled segments.


### PR DESCRIPTION
Addresses #3227.

feat(tui): enhanced thinking visual styling — cyan dim italic + separator + truncation (#3227)

Thinking entries now render with:
- Distinct cyan dim italic style for visual differentiation
- Horizontal rule separator prefix (── [thinking])
- 3-line truncation for long reasoning text with indicator

TDD: 3 new test cases in test-render-message-layout.rkt.