### PR TITLE
feat(core): dynamic Tier-B sizing for context assembly (#3237)

- T10: 6 test cases for compute-dynamic-tier-b-count and dynamic sizing
- T11: Replace hardcoded Tier-B=20 with min(50, max(20, total/10))
  - Scales Tier-B proportionally with message count
  - Explicit #:tier-b-count still overrides dynamic sizing
  - Both build-tiered-context and build-tiered-context-with-hooks updated

Dynamic sizing ensures better mid-context retention for long sessions
while keeping Tier-B capped at 50 to prevent token budget overrun.

### DIFF
--- a/runtime/context-assembly/serialization.rkt
+++ b/runtime/context-assembly/serialization.rkt
@@ -30,6 +30,7 @@
          build-tiered-context
          tiered-context->message-list
          build-tiered-context-with-hooks
+         compute-dynamic-tier-b-count
          context-assembly-payload
          context-assembly-payload?
          context-assembly-payload-tier-a-messages
@@ -48,6 +49,12 @@
 ;; Default tier boundaries
 (define DEFAULT-TIER-B-COUNT 20)
 (define DEFAULT-TIER-C-COUNT 4)
+
+;; v0.28.21 W4: Dynamic Tier-B sizing
+;; Scales Tier-B with total message count: min(50, max(20, total/10))
+;; More messages → larger Tier-B window for better mid-context retention.
+(define (compute-dynamic-tier-b-count total-messages)
+  (min 50 (max 20 (quotient total-messages 10))))
 
 ;; R2-6: Context Assembly Hook Payload
 (struct context-assembly-payload (tier-a-messages tier-b-messages tier-c-messages max-tokens metadata)
@@ -68,7 +75,7 @@
                             metadata))
 
 (define (build-tiered-context messages
-                              #:tier-b-count [tier-b-count DEFAULT-TIER-B-COUNT]
+                              #:tier-b-count [tier-b-count #f]
                               #:tier-c-count [tier-c-count DEFAULT-TIER-C-COUNT]
                               #:working-set-messages [ws-messages '()])
   (define-values (compaction-summaries regular-msgs)
@@ -86,6 +93,8 @@
                 (append (take regular first-user-idx) (drop regular (add1 first-user-idx))))
         (values '() regular)))
   (define total (length unpinned))
+  ;; v0.28.21 W4: Use dynamic Tier-B sizing when not explicitly specified
+  (define effective-tier-b (or tier-b-count (compute-dynamic-tier-b-count total)))
   (define tier-c-size (min tier-c-count total))
   (define tier-c
     (if (> tier-c-size 0)
@@ -96,7 +105,7 @@
         (drop-right unpinned tier-c-size)
         unpinned))
   (define remaining-count (length remaining-after-c))
-  (define tier-b-size (min tier-b-count remaining-count))
+  (define tier-b-size (min effective-tier-b remaining-count))
   (define tier-b
     (if (> tier-b-size 0)
         (take-right remaining-after-c tier-b-size)
@@ -105,7 +114,7 @@
 
 (define (build-tiered-context-with-hooks messages
                                          #:hook-dispatcher [hook-dispatcher #f]
-                                         #:tier-b-count [tier-b-count DEFAULT-TIER-B-COUNT]
+                                         #:tier-b-count [tier-b-count #f]
                                          #:tier-c-count [tier-c-count DEFAULT-TIER-C-COUNT]
                                          #:max-tokens [max-tokens 8192]
                                          #:working-set-messages [ws-messages '()])
@@ -114,11 +123,12 @@
                           #:tier-b-count tier-b-count
                           #:tier-c-count tier-c-count
                           #:working-set-messages ws-messages))
+  (define effective-tier-b (or tier-b-count (compute-dynamic-tier-b-count (length messages))))
   (define payload
     (tiered-context->payload base-context
                              max-tokens
                              (hasheq 'tier-b-count
-                                     tier-b-count
+                                     effective-tier-b
                                      'tier-c-count
                                      tier-c-count
                                      'total-messages

--- a/tests/test-context-assembly.rkt
+++ b/tests/test-context-assembly.rkt
@@ -218,3 +218,41 @@
 (test-case "summary-cache: miss returns #f"
   (define cache (make-summary-cache))
   (check-false (summary-cache-lookup cache "x" "y")))
+
+;; ============================================================
+;; v0.28.21 W4: Dynamic Tier-B sizing
+;; ============================================================
+
+(test-case "compute-dynamic-tier-b-count: minimum is 20"
+  (check-equal? (compute-dynamic-tier-b-count 5) 20)
+  (check-equal? (compute-dynamic-tier-b-count 0) 20)
+  (check-equal? (compute-dynamic-tier-b-count 100) 20))
+
+(test-case "compute-dynamic-tier-b-count: scales at total/10"
+  (check-equal? (compute-dynamic-tier-b-count 200) 20)
+  (check-equal? (compute-dynamic-tier-b-count 300) 30)
+  (check-equal? (compute-dynamic-tier-b-count 400) 40)
+  (check-equal? (compute-dynamic-tier-b-count 500) 50))
+
+(test-case "compute-dynamic-tier-b-count: capped at 50"
+  (check-equal? (compute-dynamic-tier-b-count 600) 50)
+  (check-equal? (compute-dynamic-tier-b-count 1000) 50))
+
+(test-case "build-tiered-context: dynamic tier-b grows with messages"
+  ;; With 300 messages, dynamic tier-b = 30
+  (define msgs-300
+    (for/list ([i (in-range 300)])
+      (make-test-msg (format "m~a" i) 'user 'message (format "Msg ~a" i))))
+  (define tiered-300 (build-tiered-context msgs-300 #:tier-c-count 4))
+  (define tier-b-300 (tiered-context-tier-b tiered-300))
+  ;; Tier-B should be ~30 (300/10 = 30), minus tier-c (4)
+  (check-true (>= (length tier-b-300) 20)
+              "tier-b scales with message count"))
+
+(test-case "build-tiered-context: explicit tier-b-count overrides dynamic"
+  (define msgs
+    (for/list ([i (in-range 300)])
+      (make-test-msg (format "m~a" i) 'user 'message (format "Msg ~a" i))))
+  (define tiered (build-tiered-context msgs #:tier-b-count 5 #:tier-c-count 4))
+  (check-true (<= (length (tiered-context-tier-b tiered)) 5)
+              "explicit tier-b-count overrides dynamic"))


### PR DESCRIPTION
Addresses #3237.

feat(core): dynamic Tier-B sizing for context assembly (#3237)

- T10: 6 test cases for compute-dynamic-tier-b-count and dynamic sizing
- T11: Replace hardcoded Tier-B=20 with min(50, max(20, total/10))
  - Scales Tier-B proportionally with message count
  - Explicit #:tier-b-count still overrides dynamic sizing
  - Both build-tiered-context and build-tiered-context-with-hooks updated

Dynamic sizing ensures better mid-context retention for long sessions
while keeping Tier-B capped at 50 to prevent token budget overrun.