### PR TITLE
feat(core): tool result summarization for context overflow prevention (#3240)

- T12: 2 test cases for summarize-tool-result (short unchanged, long truncated)
- T13: Add summarize-tool-result to context-assembly/serialization.rkt
  - Tool/bash results > 8000 chars get head/tail truncation
  - Keeps first 10 + last 10 lines with "... N lines truncated ..." indicator
  - Wired into entry->context-message for automatic application

Prevents large tool outputs from bloating context during long sessions.

### DIFF
--- a/runtime/context-assembly/serialization.rkt
+++ b/runtime/context-assembly/serialization.rkt
@@ -13,8 +13,10 @@
                   message-id
                   message-kind
                   message-role
+                  message-content
                   make-message
                   make-text-part)
+         (only-in "../../util/content-parts.rkt" text-part text-part? text-part-text)
          (only-in "../context-policy.rkt" estimate-message-tokens)
          (only-in "../context-fit.rkt" truncate-messages-to-budget)
          (only-in "../../llm/provider.rkt" provider?)
@@ -31,6 +33,7 @@
          tiered-context->message-list
          build-tiered-context-with-hooks
          compute-dynamic-tier-b-count
+         summarize-tool-result
          context-assembly-payload
          context-assembly-payload?
          context-assembly-payload-tier-a-messages
@@ -196,6 +199,32 @@
      (define-values (pre post) (split-at path idx))
      (values pre post)]))
 
+;; v0.28.21 W5: Tool result summarization
+;; Truncates tool/bash results exceeding max-chars to a summary.
+;; Preserves first and last lines with a [... N lines truncated ...] indicator.
+(define MAX-TOOL-RESULT-CHARS 8000)
+
+(define (summarize-tool-result entry)
+  (define content (message-content entry))
+  (define text
+    (string-join (for/list ([part (in-list content)]
+                            #:when (text-part? part))
+                   (text-part-text part))
+                 "\n"))
+  (cond
+    [(<= (string-length text) MAX-TOOL-RESULT-CHARS) entry]
+    [else
+     (define lines (string-split text "\n"))
+     (cond
+       [(<= (length lines) 40) entry]
+       [else
+        (define head (take lines 10))
+        (define tail (take-right lines 10))
+        (define dropped (- (length lines) 20))
+        (define summary-text
+          (string-join (append head (list (format "... ~a lines truncated ..." dropped)) tail) "\n"))
+        (struct-copy message entry [content (list (text-part "text" summary-text))])])]))
+
 (define (entry->context-message entry)
   (define kind (message-kind entry))
   (match kind
@@ -203,7 +232,7 @@
     ['compaction-summary (struct-copy message entry [role 'user])]
     ['branch-summary (struct-copy message entry [role 'user])]
     [(or 'session-info 'model-change 'thinking-level-change) #f]
-    [(or 'tool-result 'bash-execution) entry]
+    [(or 'tool-result 'bash-execution) (summarize-tool-result entry)]
     ['system-instruction entry]
     ['custom-message entry]
     [_ entry]))

--- a/tests/test-context-assembly.rkt
+++ b/tests/test-context-assembly.rkt
@@ -5,8 +5,10 @@
 
 (require rackunit
          racket/list
+         racket/string
          racket/file
          "../util/protocol-types.rkt"
+         "../util/content-parts.rkt"
          "../runtime/session-store.rkt"
          "../runtime/session-index.rkt"
          "../runtime/context-assembly.rkt")
@@ -256,3 +258,30 @@
   (define tiered (build-tiered-context msgs #:tier-b-count 5 #:tier-c-count 4))
   (check-true (<= (length (tiered-context-tier-b tiered)) 5)
               "explicit tier-b-count overrides dynamic"))
+
+;; ============================================================
+;; v0.28.21 W5: Tool result summarization
+;; ============================================================
+
+(test-case "summarize-tool-result: short result unchanged"
+  (define short-msg
+    (make-test-msg "tr1" 'tool 'tool-result "short output"))
+  (define result (summarize-tool-result short-msg))
+  (check-equal? result short-msg "short tool result not modified"))
+
+(test-case "summarize-tool-result: long result gets truncated"
+  (define long-text
+    (string-join (for/list ([i (in-range 100)]) (format "Line ~a: ~a" i (make-string 100 #\x))) "\n"))
+  (define long-msg
+    (make-test-msg "tr2" 'tool 'tool-result long-text))
+  (define result (summarize-tool-result long-msg))
+  (define result-text
+    (string-join
+     (for/list ([part (in-list (message-content result))]
+                #:when (text-part? part))
+       (text-part-text part))
+     "\n"))
+  (check-true (< (string-length result-text) (string-length long-text))
+              "long tool result truncated")
+  (check-true (string-contains? result-text "lines truncated")
+              "truncation indicator present"))


### PR DESCRIPTION
Addresses #3240.

feat(core): tool result summarization for context overflow prevention (#3240)

- T12: 2 test cases for summarize-tool-result (short unchanged, long truncated)
- T13: Add summarize-tool-result to context-assembly/serialization.rkt
  - Tool/bash results > 8000 chars get head/tail truncation
  - Keeps first 10 + last 10 lines with "... N lines truncated ..." indicator
  - Wired into entry->context-message for automatic application

Prevents large tool outputs from bloating context during long sessions.