### PR TITLE
feat(core): exploration loop detection for context circular loop prevention (#3243)

- T14: 4 test cases for detect-exploration-loop
- T15: Add detect-exploration-loop to retry-policy.rkt
  - Detects repeating 2-tool patterns (read-grep, ls-read) in recent tool calls
  - Returns descriptive string when loop detected, #f otherwise
  - Uses equal?-based hash for pair counting
  - Threshold: min 3 repeats of same pair pattern

Helps identify when agent is stuck in exploration cycles
without making progress on implementation.

### DIFF
--- a/runtime/iteration/retry-policy.rkt
+++ b/runtime/iteration/retry-policy.rkt
@@ -29,7 +29,8 @@
          (only-in "loop-state.rkt" resolve-estimate-tokens))
 
 (provide check-mid-turn-budget!
-         call-with-overflow-recovery)
+         call-with-overflow-recovery
+         detect-exploration-loop)
 
 ;; Check if context exceeds mid-turn token budget.
 ;; When session is provided and over budget, triggers mid-turn compaction.
@@ -99,3 +100,48 @@
                      (thunk))]
                   [exn:fail? (lambda (e) (raise e))])
     (thunk)))
+
+;; ============================================================
+;; v0.28.21 W6: Exploration loop detection
+;; ============================================================
+
+;;; detect-exploration-loop : (listof string?) integer? -> (or/c #f string?)
+;;;
+;;; Checks recent tool names for repeating patterns that indicate
+;;; an exploration loop (e.g., read-grep-read-grep cycles).
+;;; Returns #f if no loop detected, or a string describing the loop.
+(define (detect-exploration-loop recent-tool-names [min-repeats 3])
+  (define n (length recent-tool-names))
+  (cond
+    [(< n (* min-repeats 2)) #f]
+    [else
+     ;; Check for repeating 2-tool patterns in the last N tool calls
+     (define recent (take-at-most recent-tool-names (* min-repeats 4)))
+     (define pairs
+       (for/list ([i (in-range (sub1 (length recent)))])
+         (list (list-ref recent i) (list-ref recent (add1 i)))))
+     (define pair-counts (count-occurrences pairs))
+     ;; Find any pair repeated 3+ times
+     (define looping-pair
+       (for/first ([pair (in-hash-keys pair-counts)]
+                   #:when (>= (hash-ref pair-counts pair) min-repeats))
+         pair))
+     (cond
+       [looping-pair
+        (format "exploration loop detected: ~a repeated ~a times"
+                looping-pair
+                (hash-ref pair-counts looping-pair))]
+       [else #f])]))
+
+;; Helper: count occurrences in a list of items
+(define (count-occurrences items)
+  (define counts (make-hash))
+  (for ([item (in-list items)])
+    (hash-update! counts item add1 0))
+  counts)
+
+;; Helper: take at most N from list
+(define (take-at-most lst n)
+  (if (> (length lst) n)
+      (take lst n)
+      lst))

--- a/tests/test-mid-turn-compaction.rkt
+++ b/tests/test-mid-turn-compaction.rkt
@@ -17,68 +17,84 @@
 
 ;; Helper: build a mock message with text content
 (define (make-mock-msg role text)
-  (message "id" #f role 'message
-           (list (text-part "text" text))
-           0 (hasheq)))
+  (message "id" #f role 'message (list (text-part "text" text)) 0 (hasheq)))
 
 ;; Helper: build a context with N messages
 (define (make-mock-context msg-count)
   (for/list ([i (in-range msg-count)])
-    (make-mock-msg 'user
-                   (format "Message ~a ~a" i (make-string 200 #\x)))))
+    (make-mock-msg 'user (format "Message ~a ~a" i (make-string 200 #\x)))))
 
 (define mid-turn-suite
-  (test-suite
-   "Mid-turn compaction"
+  (test-suite "Mid-turn compaction"
 
-   ;; T7-1: Under budget — returns token estimate
-   (test-case
-    "under budget returns estimated token count"
-    (define ctx (make-mock-context 3))
-    (define result (check-mid-turn-budget! ctx #f #f (hasheq 'max-context-tokens 128000)))
-    (check-true (integer? result) "returns estimated token count")
-    (check-true (> result 0) "has positive token estimate"))
+    ;; T7-1: Under budget — returns token estimate
+    (test-case "under budget returns estimated token count"
+      (define ctx (make-mock-context 3))
+      (define result (check-mid-turn-budget! ctx #f #f (hasheq 'max-context-tokens 128000)))
+      (check-true (integer? result) "returns estimated token count")
+      (check-true (> result 0) "has positive token estimate"))
 
-   ;; T7-2: Over budget triggers compaction (compact-history works)
-   (test-case
-    "over budget context produces compaction result"
-    (define ctx (make-mock-context 50))
-    (define config (hasheq 'max-context-tokens 100))
-    ;; Verify compact-history produces a valid result
-    (define result (compact-history ctx))
-    (check-true (compaction-result? result))
-    (check-true (list? (compaction-result-kept-messages result))
-                "compaction result has kept messages"))
+    ;; T7-2: Over budget triggers compaction (compact-history works)
+    (test-case "over budget context produces compaction result"
+      (define ctx (make-mock-context 50))
+      (define config (hasheq 'max-context-tokens 100))
+      ;; Verify compact-history produces a valid result
+      (define result (compact-history ctx))
+      (check-true (compaction-result? result))
+      (check-true (list? (compaction-result-kept-messages result))
+                  "compaction result has kept messages"))
 
-   ;; T7-3: Compaction preserves system messages
-   (test-case
-    "compact-history preserves system message"
-    (define sys-msg (make-mock-msg 'system "You are a helpful assistant."))
-    (define ctx (cons sys-msg (make-mock-context 30)))
-    (define result (compact-history ctx))
-    (check-true (compaction-result? result))
-    (define kept (compaction-result-kept-messages result))
-    (define sys-kept (filter (lambda (m) (eq? (message-role m) 'system)) kept))
-    (check >= (length sys-kept) 1 "system message preserved after compaction"))
+    ;; T7-3: Compaction preserves system messages
+    (test-case "compact-history preserves system message"
+      (define sys-msg (make-mock-msg 'system "You are a helpful assistant."))
+      (define ctx (cons sys-msg (make-mock-context 30)))
+      (define result (compact-history ctx))
+      (check-true (compaction-result? result))
+      (define kept (compaction-result-kept-messages result))
+      (define sys-kept (filter (lambda (m) (eq? (message-role m) 'system)) kept))
+      (check >= (length sys-kept) 1 "system message preserved after compaction"))
 
-   ;; T7-4: maybe-compact-context has cooldown guard
-   (test-case
-    "maybe-compact-context available for mid-turn use"
-    (check-true (procedure? maybe-compact-context)
-                "maybe-compact-context is available for mid-turn use"))
+    ;; T7-4: maybe-compact-context has cooldown guard
+    (test-case "maybe-compact-context available for mid-turn use"
+      (check-true (procedure? maybe-compact-context)
+                  "maybe-compact-context is available for mid-turn use"))
 
-   ;; T7-5: check-mid-turn-budget! emits event when over budget
-   (test-case
-    "check-mid-turn-budget! emits event when over budget"
-    (define bus (make-event-bus))
-    (define events '())
-    (subscribe! bus (lambda (evt) (set! events (cons evt events))))
-    (define ctx (make-mock-context 50))
-    (define config (hasheq 'max-context-tokens 100))
-    (define result (check-mid-turn-budget! ctx bus "test-session" config))
-    (check-true (integer? result))
-    ;; Should have emitted context.mid-turn-over-budget event
-    (check-true (> (length events) 0)
-                "emitted event when over budget"))))
+    ;; T7-5: check-mid-turn-budget! emits event when over budget
+    (test-case "check-mid-turn-budget! emits event when over budget"
+      (define bus (make-event-bus))
+      (define events '())
+      (subscribe! bus (lambda (evt) (set! events (cons evt events))))
+      (define ctx (make-mock-context 50))
+      (define config (hasheq 'max-context-tokens 100))
+      (define result (check-mid-turn-budget! ctx bus "test-session" config))
+      (check-true (integer? result))
+      ;; Should have emitted context.mid-turn-over-budget event
+      (check-true (> (length events) 0) "emitted event when over budget"))))
 
 (run-tests mid-turn-suite)
+
+;; ============================================================
+;; v0.28.21 W6: Exploration loop detection tests
+;; ============================================================
+
+(define exploration-loop-suite
+  (test-suite "Exploration loop detection"
+
+    (test-case "no loop with few tool calls"
+      (check-false (detect-exploration-loop '("read" "grep")) "too few tools to form loop"))
+
+    (test-case "no loop with varied tools"
+      (check-false (detect-exploration-loop '("read" "grep" "edit" "bash" "write" "read" "ls"))
+                   "varied tools not a loop"))
+
+    (test-case "detect read-grep loop"
+      (define result (detect-exploration-loop '("read" "grep" "read" "grep" "read" "grep")))
+      (check-true (string? result) "read-grep loop detected")
+      (check-true (string-contains? result "read") "mentions read")
+      (check-true (string-contains? result "grep") "mentions grep"))
+
+    (test-case "detect ls-read loop"
+      (define result (detect-exploration-loop '("ls" "read" "ls" "read" "ls" "read" "ls" "read")))
+      (check-true (string? result) "ls-read loop detected"))))
+
+(run-tests exploration-loop-suite)


### PR DESCRIPTION
Addresses #3243.

feat(core): exploration loop detection for context circular loop prevention (#3243)

- T14: 4 test cases for detect-exploration-loop
- T15: Add detect-exploration-loop to retry-policy.rkt
  - Detects repeating 2-tool patterns (read-grep, ls-read) in recent tool calls
  - Returns descriptive string when loop detected, #f otherwise
  - Uses equal?-based hash for pair counting
  - Threshold: min 3 repeats of same pair pattern

Helps identify when agent is stuck in exploration cycles
without making progress on implementation.