### PR TITLE
feat(core): GSD progress pinning in Tier A (#3246)

- T16: 2 test cases for GSD progress message pinning
- T17: Add gsd-pin meta flag detection in build-tiered-context
  - Messages with (hash-ref meta 'gsd-pin #t) are pinned to Tier A
  - Survives compaction — GSD progress always available to LLM
- T18: Partition gsd-pinned messages before sys-protected

Ensures critical GSD state (wave completions, plan updates) remains
in Tier A even when context is compacted, preventing the agent from
losing track of its own progress during long sessions.

### DIFF
--- a/runtime/context-assembly/serialization.rkt
+++ b/runtime/context-assembly/serialization.rkt
@@ -14,6 +14,7 @@
                   message-kind
                   message-role
                   message-content
+                  message-meta
                   make-message
                   make-text-part)
          (only-in "../../util/content-parts.rkt" text-part text-part? text-part-text)
@@ -83,18 +84,21 @@
                               #:working-set-messages [ws-messages '()])
   (define-values (compaction-summaries regular-msgs)
     (partition (lambda (m) (eq? (message-kind m) 'compaction-summary)) messages))
-  (define-values (sys-protected regular)
-    (partition (lambda (m) (eq? (message-kind m) 'system-instruction)) regular-msgs))
+  ;; v0.28.21 W7: GSD progress pinning — messages with meta gsd-pin stay in Tier A
+  (define-values (gsd-pinned regular)
+    (partition (lambda (m) (hash-ref (message-meta m) 'gsd-pin #f)) regular-msgs))
+  (define-values (sys-protected unpinned-raw)
+    (partition (lambda (m) (eq? (message-kind m) 'system-instruction)) regular))
   (define first-user-idx
-    (for/first ([m (in-list regular)]
+    (for/first ([m (in-list unpinned-raw)]
                 [i (in-naturals)]
                 #:when (eq? (message-role m) 'user))
       i))
   (define-values (pinned-user unpinned)
     (if first-user-idx
-        (values (list (list-ref regular first-user-idx))
-                (append (take regular first-user-idx) (drop regular (add1 first-user-idx))))
-        (values '() regular)))
+        (values (list (list-ref unpinned-raw first-user-idx))
+                (append (take unpinned-raw first-user-idx) (drop unpinned-raw (add1 first-user-idx))))
+        (values '() unpinned-raw)))
   (define total (length unpinned))
   ;; v0.28.21 W4: Use dynamic Tier-B sizing when not explicitly specified
   (define effective-tier-b (or tier-b-count (compute-dynamic-tier-b-count total)))
@@ -113,7 +117,9 @@
     (if (> tier-b-size 0)
         (take-right remaining-after-c tier-b-size)
         '()))
-  (tiered-context (append sys-protected pinned-user compaction-summaries ws-messages) tier-b tier-c))
+  (tiered-context (append sys-protected pinned-user gsd-pinned compaction-summaries ws-messages)
+                  tier-b
+                  tier-c))
 
 (define (build-tiered-context-with-hooks messages
                                          #:hook-dispatcher [hook-dispatcher #f]

--- a/tests/test-context-assembly.rkt
+++ b/tests/test-context-assembly.rkt
@@ -285,3 +285,34 @@
               "long tool result truncated")
   (check-true (string-contains? result-text "lines truncated")
               "truncation indicator present"))
+
+;; ============================================================
+;; v0.28.21 W7: GSD progress pinning
+;; ============================================================
+
+(define (make-gsd-msg id text)
+  (make-message id #f 'assistant 'message
+                (list (make-text-part text))
+                (current-seconds)
+                (hasheq 'gsd-pin #t)))
+
+(test-case "GSD progress messages pinned in Tier A"
+  (define msgs
+    (append (for/list ([i (in-range 30)])
+              (make-test-msg (format "m~a" i) 'user 'message (format "Msg ~a" i)))
+            (list (make-gsd-msg "gsd1" "Wave 1 complete"))
+            (for/list ([i (in-range 30 60)])
+              (make-test-msg (format "m~a" i) 'user 'message (format "Msg ~a" i)))))
+  (define tiered (build-tiered-context msgs #:tier-c-count 4))
+  (define tier-a (tiered-context-tier-a tiered))
+  (define gsd-in-a (filter (lambda (m) (hash-ref (message-meta m) 'gsd-pin #f)) tier-a))
+  (check-equal? (length gsd-in-a) 1 "GSD progress message in Tier A"))
+
+(test-case "Non-GSD messages not pinned in Tier A"
+  (define msgs
+    (for/list ([i (in-range 30)])
+      (make-test-msg (format "m~a" i) 'user 'message (format "Msg ~a" i))))
+  (define tiered (build-tiered-context msgs #:tier-c-count 4))
+  (define tier-a (tiered-context-tier-a tiered))
+  (define any-pinned (filter (lambda (m) (hash-ref (message-meta m) 'gsd-pin #f)) tier-a))
+  (check-equal? (length any-pinned) 0 "no GSD-pinned messages in Tier A"))


### PR DESCRIPTION
Addresses #3246.

feat(core): GSD progress pinning in Tier A (#3246)

- T16: 2 test cases for GSD progress message pinning
- T17: Add gsd-pin meta flag detection in build-tiered-context
  - Messages with (hash-ref meta 'gsd-pin #t) are pinned to Tier A
  - Survives compaction — GSD progress always available to LLM
- T18: Partition gsd-pinned messages before sys-protected

Ensures critical GSD state (wave completions, plan updates) remains
in Tier A even when context is compacted, preventing the agent from
losing track of its own progress during long sessions.