### PR TITLE
feat(core): tighten GSD guard + canonicalize make-text-part + split check-mid-turn-budget! (#3278)

- gsd-progress-message? now restricted to tool/assistant roles only
- Removed overly broad wave-done regex (false-positive on user messages)
- Changed (text-part "text" x) to (make-text-part x) in summarize-tool-result
- Split check-mid-turn-budget! into estimate-mid-turn-tokens (returns integer)
  and maybe-compact-mid-turn (returns message list)
- Updated iteration.rkt call site to use split functions directly
- Kept backward-compat wrapper for existing tests
- Removed fragile (if (list? ...) ...) guard at call site

Resolves audit warnings A3, A4, C1, C2 from v0.28.22 audit.

### DIFF
--- a/runtime/context-assembly/serialization.rkt
+++ b/runtime/context-assembly/serialization.rkt
@@ -85,17 +85,17 @@
   (define-values (compaction-summaries regular-msgs)
     (partition (lambda (m) (eq? (message-kind m) 'compaction-summary)) messages))
   ;; v0.28.21 W7 + v0.28.22 W2: GSD progress pinning
-  ;; Messages with meta gsd-pin=#t OR containing GSD progress markers stay in Tier A
+  ;; v0.28.23 W0: tightened to tool/assistant roles only, removed broad wave-done regex
   (define (gsd-progress-message? m)
     (or (hash-ref (message-meta m) 'gsd-pin #f)
-        (let ([txt (string-join (for/list ([part (message-content m)]
-                                           #:when (text-part? part))
-                                  (text-part-text part)))])
-          (and (non-empty-string? txt)
-               (or (regexp-match? #rx"wave [0-9]+ marked complete" txt)
-                   (regexp-match? #rx"PLAN.md.*updated" txt)
-                   (regexp-match? #rx"STATE.md.*updated" txt)
-                   (regexp-match? #rx"wave-done" txt))))))
+        (and (memq (message-role m) '(tool assistant))
+             (let ([txt (string-join (for/list ([part (message-content m)]
+                                                #:when (text-part? part))
+                                       (text-part-text part)))])
+               (and (non-empty-string? txt)
+                    (or (regexp-match? #rx"wave [0-9]+ marked complete" txt)
+                        (regexp-match? #rx"PLAN.md.*updated" txt)
+                        (regexp-match? #rx"STATE.md.*updated" txt)))))))
   (define-values (gsd-pinned regular) (partition gsd-progress-message? regular-msgs))
   (define-values (sys-protected unpinned-raw)
     (partition (lambda (m) (eq? (message-kind m) 'system-instruction)) regular))
@@ -239,7 +239,7 @@
         (define dropped (- (length lines) 20))
         (define summary-text
           (string-join (append head (list (format "... ~a lines truncated ..." dropped)) tail) "\n"))
-        (struct-copy message entry [content (list (text-part "text" summary-text))])])]))
+        (struct-copy message entry [content (list (make-text-part summary-text))])])]))
 
 (define (entry->context-message entry)
   (define kind (message-kind entry))

--- a/runtime/iteration.rkt
+++ b/runtime/iteration.rkt
@@ -110,6 +110,8 @@
          call-with-overflow-recovery
          ;; v0.14.1: mid-turn token budget check (for testing)
          check-mid-turn-budget!
+         estimate-mid-turn-tokens
+         maybe-compact-mid-turn
          ;; v0.20.5 W3: pre-registration on session open (now from turn-orchestrator)
          register-session-extensions!
          ;; DI parameters for testability (DI-01, v0.22.7)
@@ -499,10 +501,14 @@
                                               token
                                               config))
                  ;; v0.14.1: mid-turn token budget check
-                 ;; v0.28.22 W0: wire session for mid-turn compaction
+                 ;; v0.28.23 W0: use split functions directly
                  (define ctx-after-budget
-                   (check-mid-turn-budget! updated-ctx bus session-id config #:session sess))
-                 (loop (if (list? ctx-after-budget) ctx-after-budget updated-ctx)
+                   (if sess
+                       (maybe-compact-mid-turn sess updated-ctx bus session-id config)
+                       (begin
+                         (estimate-mid-turn-tokens updated-ctx bus session-id config)
+                         updated-ctx)))
+                 (loop ctx-after-budget
                        (add1 iteration)
                        (add1 consecutive-tool-count)
                        seen-paths

--- a/runtime/iteration/retry-policy.rkt
+++ b/runtime/iteration/retry-policy.rkt
@@ -29,19 +29,50 @@
          (only-in "loop-state.rkt" resolve-estimate-tokens))
 
 (provide check-mid-turn-budget!
+         estimate-mid-turn-tokens
+         maybe-compact-mid-turn
          call-with-overflow-recovery
          detect-exploration-loop)
 
-;; Check if context exceeds mid-turn token budget.
-;; When session is provided and over budget, triggers mid-turn compaction.
-;; Returns (listof message?) if session provided (possibly compacted),
-;; or integer token estimate if no session.
-(define (check-mid-turn-budget! ctx
+;; ── Estimate token count for mid-turn context ──
+;; Returns integer token estimate. Emits context.mid-turn-over-budget event
+;; when context exceeds 90% of max budget.
+(define (estimate-mid-turn-tokens ctx
+                                  bus
+                                  session-id
+                                  config
+                                  #:estimate-tokens [estimate-tokens (resolve-estimate-tokens)])
+  (define max-tokens (hash-ref config 'max-context-tokens 128000))
+  (define budget-threshold (inexact->exact (floor (* max-tokens 0.9))))
+  (define texts
+    (for/list ([msg (in-list ctx)])
+      (define content (message-content msg))
+      (cond
+        [(string? content) content]
+        [(list? content)
+         (apply string-append
+                (for/list ([part (in-list content)]
+                           #:when (text-part? part))
+                  (text-part-text part)))]
+        [else ""])))
+  (define estimated (for/sum ([t (in-list texts)]) (estimate-tokens (list (hasheq 'content t)))))
+  (when (and (> estimated budget-threshold) bus session-id)
+    (emit-session-event!
+     bus
+     session-id
+     "context.mid-turn-over-budget"
+     (hasheq 'estimated-tokens estimated 'budget budget-threshold 'max-tokens max-tokens)))
+  estimated)
+
+;; ── Compact context mid-turn if over budget ──
+;; Returns (listof message?) — compacted context if over 90% budget,
+;; or original context if under budget.
+(define (maybe-compact-mid-turn sess
+                                ctx
                                 bus
                                 session-id
                                 config
-                                #:estimate-tokens [estimate-tokens (resolve-estimate-tokens)]
-                                #:session [sess #f])
+                                #:estimate-tokens [estimate-tokens (resolve-estimate-tokens)])
   (define max-tokens (hash-ref config 'max-context-tokens 128000))
   (define budget-threshold (inexact->exact (floor (* max-tokens 0.9))))
   (define texts
@@ -57,20 +88,27 @@
         [else ""])))
   (define estimated (for/sum ([t (in-list texts)]) (estimate-tokens (list (hasheq 'content t)))))
   (cond
-    ;; Under budget: return ctx if session, else estimate
-    [(<= estimated budget-threshold) (if sess ctx estimated)]
+    [(<= estimated budget-threshold) ctx]
     [else
-     ;; Over budget
      (when (and bus session-id)
        (emit-session-event!
         bus
         session-id
         "context.mid-turn-over-budget"
         (hasheq 'estimated-tokens estimated 'budget budget-threshold 'max-tokens max-tokens)))
-     (if sess
-         ;; v0.28.21 W3: Trigger mid-turn compaction when session available
-         (compact-context-mid-turn sess ctx)
-         estimated)]))
+     (compact-context-mid-turn sess ctx)]))
+
+;; ── Backward-compat wrapper ──
+;; Returns (listof message?) if session provided, or integer? if not.
+(define (check-mid-turn-budget! ctx
+                                bus
+                                session-id
+                                config
+                                #:estimate-tokens [estimate-tokens (resolve-estimate-tokens)]
+                                #:session [sess #f])
+  (if sess
+      (maybe-compact-mid-turn sess ctx bus session-id config #:estimate-tokens estimate-tokens)
+      (estimate-mid-turn-tokens ctx bus session-id config #:estimate-tokens estimate-tokens)))
 
 ;; Handle context overflow by compacting the context and retrying once.
 ;; Catches both context-overflow-error? and plain exn:fail with overflow messages.


### PR DESCRIPTION
Addresses #3278.

feat(core): tighten GSD guard + canonicalize make-text-part + split check-mid-turn-budget! (#3278)

- gsd-progress-message? now restricted to tool/assistant roles only
- Removed overly broad wave-done regex (false-positive on user messages)
- Changed (text-part "text" x) to (make-text-part x) in summarize-tool-result
- Split check-mid-turn-budget! into estimate-mid-turn-tokens (returns integer)
  and maybe-compact-mid-turn (returns message list)
- Updated iteration.rkt call site to use split functions directly
- Kept backward-compat wrapper for existing tests
- Removed fragile (if (list? ...) ...) guard at call site

Resolves audit warnings A3, A4, C1, C2 from v0.28.22 audit.