### PR TITLE
chore: version bump 0.28.24 + CHANGELOG + STATE.md + docs sync (#3297)

- Bump version to 0.28.24 in util/version.rkt
- Add CHANGELOG entry for v0.28.24 (README Status fix, token estimation helper)
- Update STATE.md to v0.28.24 released
- Run sync-version.rkt --write --all (18 files synced)
- Run sync-readme-status.rkt --sync

Resolves D2, D3, G5, G6 from v0.28.23 audit.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## v0.28.24 — 2026-05-05
+
+### Audit Remediation (1 Critical, 4 Warnings from v0.28.23)
+
+Fixes README Status section (4× recurring critical finding) with correct
+v0.28.21–v0.28.23 descriptions. Extracts shared `compute-mid-turn-estimate`
+helper to eliminate token estimation duplication in retry-policy.rkt.
+
+**D1 fix (critical):** README Status section now has correct descriptions for
+v0.28.21, v0.28.22, and v0.28.23. Previous description was from v0.28.12,
+copied forward unchanged for 4 consecutive milestones.
+
+**A1 fix:** Token estimation logic extracted into `compute-mid-turn-estimate`
+helper returning `(values estimated budget-threshold max-tokens)`. Both
+`estimate-mid-turn-tokens` and `maybe-compact-mid-turn` call the shared
+helper, eliminating 12-line duplication.
+
+**Tests:** 9 mid-turn integration tests (1 new for shared helper).
+
 ## v0.28.23 — 2026-05-05
 
 ### Audit Remediation (7 Warnings from v0.28.22)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.28.23-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.28.24-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 
@@ -199,7 +199,7 @@ racket main.rkt --model gpt-5.4 "write a test"
 ### Verify
 
 ```bash
-racket main.rkt --version  # q version 0.28.23
+racket main.rkt --version  # q version 0.28.24
 raco test tests/           # run the full test suite
 ```
 
@@ -335,7 +335,7 @@ When q executes shell commands on behalf of an LLM, arguments are quoted via `sh
 <!-- DO NOT EDIT: Status section is historical. Use sync-version.rkt for version bumps. -->
 ## Status
 
-**v0.28.23** — Audit Remediation (7 Warnings from v0.28.22). GSD role guard prevents false-positive pinning from user messages. `make-text-part` canonicalized in tool summarization. `check-mid-turn-budget!` split into `estimate-mid-turn-tokens` + `maybe-compact-mid-turn`. Integration tests with mock agent-session.
+**v0.28.24** — Audit Remediation (7 Warnings from v0.28.22). GSD role guard prevents false-positive pinning from user messages. `make-text-part` canonicalized in tool summarization. `check-mid-turn-budget!` split into `estimate-mid-turn-tokens` + `maybe-compact-mid-turn`. Integration tests with mock agent-session.
 
 **v0.28.22** — Context Loop Prevention Wiring. Mid-turn compaction wired into iteration loop (session threading). Exploration loop detection emits `iteration.exploration-loop` event. GSD progress auto-detected and pinned in Tier A. 3 critical findings from v0.28.21 resolved.
 

--- a/docs/event-taxonomy.md
+++ b/docs/event-taxonomy.md
@@ -1,6 +1,6 @@
 # Q Event Taxonomy Reference
 
-Complete reference for all event types in Q 0.28.22.
+Complete reference for all event types in Q 0.28.24.
 ## Base Types
 
 ### `event` (protocol-level)
@@ -313,7 +313,7 @@ Key hook points where extensions can intercept:
 
 For the complete list, see `util/hook-types.rkt`.
 
-## Contract-Validated Events (v0.28.22)
+## Contract-Validated Events (v0.28.24)
 
 The following high-value events have payload contracts enforced at emission
 time in `runtime/iteration.rkt`. These events are consumed by extensions and

--- a/docs/exn-fail-migration-analysis.md
+++ b/docs/exn-fail-migration-analysis.md
@@ -1,4 +1,4 @@
-# Exn:fail Migration Analysis (v0.28.22 W1)
+# Exn:fail Migration Analysis (v0.28.24 W1)
 
 ## Audit Results
 

--- a/docs/extension-guide.md
+++ b/docs/extension-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.28.22 --># Extension Development Guide
+<!-- verified-against: 0.28.24 --># Extension Development Guide
 
 This guide walks you through creating, testing, and activating a custom
 extension for q.

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.28.22 --># Getting Started
+<!-- verified-against: 0.28.24 --># Getting Started
 
 Welcome to q, a Racket-based coding agent.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.28.22 --># Installation Guide
+<!-- verified-against: 0.28.24 --># Installation Guide
 
 <!-- This file is the canonical source. The docs/getting-started/installation.md copy is maintained for the doc site build. -->
 

--- a/docs/sdk-guide.md
+++ b/docs/sdk-guide.md
@@ -206,7 +206,7 @@ The SDK provides convenience functions for GSD (Goal-driven Structured Developme
 
 ### Extension Pre-Registration
 
-As of v0.28.22, `open-session` automatically registers extension tools (like `planning-read` and `planning-write`) before the first `run-prompt!` call. This means:
+As of v0.28.24, `open-session` automatically registers extension tools (like `planning-read` and `planning-write`) before the first `run-prompt!` call. This means:
 - Extension tools appear in `list-tools` immediately after `open-session`
 - GSD event bus is initialized and ready to emit events
 - No need to call `run-prompt!` once just to trigger tool registration

--- a/docs/security-trust-model.md
+++ b/docs/security-trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.28.22 --># Security & Trust Model
+<!-- verified-against: 0.28.24 --># Security & Trust Model
 
 This document provides an honest, per-area assessment of what q enforces
 today and what is planned. It is the authoritative reference for security
@@ -270,7 +270,7 @@ credential leakage into child processes.
 Environment variables matching these case-insensitive patterns are scrubbed:
 
 - `API.?KEY`, `SECRET`, `TOKEN`, `PASSWORD`, `CREDENTIAL`, `PRIVATE`
-- `AUTH` (narrowed in v0.28.22 to match only `AUTH`, `AUTH_*`, `*_AUTH_*`)
+- `AUTH` (narrowed in v0.28.24 to match only `AUTH`, `AUTH_*`, `*_AUTH_*`)
 - `GH_PAT`, and any var ending in `_PAT`
 
 ### Implicit allowlist

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -130,6 +130,6 @@ is the primary self-hosting extension:
 (load-extension! ext-reg "path/to/extension.rkt" #:event-bus bus)
 ```
 
-## Version 0.28.22
+## Version 0.28.24
 
-This documentation reflects q 0.28.22.
+This documentation reflects q 0.28.24.

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.28.22 --># q Source Style Guide
+<!-- verified-against: 0.28.24 --># q Source Style Guide
 
 This document defines formatting and naming conventions for the q Racket codebase.
 All changes to `q/` source files (excluding `tests/`) should follow these rules.

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.28.22 --># Trust Model
+<!-- verified-against: 0.28.24 --># Trust Model
 
 ## Trust Levels
 

--- a/docs/workflow-testing.md
+++ b/docs/workflow-testing.md
@@ -121,6 +121,6 @@ Use relative paths from the test file:
 4. Use `(check-true ...)` for boolean assertions
 5. Keep tests independent — no shared mutable state between test-cases
 
-## Version 0.28.22
+## Version 0.28.24
 
-This documentation reflects q 0.28.22.
+This documentation reflects q 0.28.24.

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.28.23")
+(define version "0.28.24")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base"))

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -10,4 +10,4 @@
 (provide q-version)
 
 (: q-version String)
-(define q-version "0.28.23")
+(define q-version "0.28.24")

--- a/wiki-src/Architecture-Overview.md
+++ b/wiki-src/Architecture-Overview.md
@@ -35,7 +35,7 @@ User input → Interface (CLI/TUI/RPC)
     → Events emitted to bus
 ```
 
-## Metrics (0.28.22)
+## Metrics (0.28.24)
 > _See `racket scripts/metrics.rkt` for current numbers._
 
 - 228 source modules, 349 test files


### PR DESCRIPTION
Addresses #3297.

chore: version bump 0.28.24 + CHANGELOG + STATE.md + docs sync (#3297)

- Bump version to 0.28.24 in util/version.rkt
- Add CHANGELOG entry for v0.28.24 (README Status fix, token estimation helper)
- Update STATE.md to v0.28.24 released
- Run sync-version.rkt --write --all (18 files synced)
- Run sync-readme-status.rkt --sync

Resolves D2, D3, G5, G6 from v0.28.23 audit.