### PR TITLE
chore: version bump 0.28.25 + CHANGELOG + STATE.md + docs sync (#3326)

- Version bump 0.28.24 → 0.28.25 in util/version.rkt.
- CHANGELOG entry for v0.28.25 (CHANGELOG-based Status generation + 7-pattern guard).
- STATE.md updated to v0.28.25 with all 3 waves marked complete.
- sync-version.rkt --write --all: 14 docs + info.rkt + README.md synced.
- sync-readme-status.rkt --sync: Status entry generated from CHANGELOG.
- metrics.rkt --sync-all: README metrics/prose synced.

Closes #3326, #3327, #3328, #3329, #3330.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## v0.28.25 — 2026-05-02
+
+### Audit Remediation — Docs Integrity + Tooling Hardening
+
+Fixes the 5th occurrence of D1 (README Status divergence) with a CHANGELOG-based
+generation approach. Adds 7-pattern historical guard to prevent sync-version.rkt
+from mangling historical version references in documentation.
+
+**W0 — sync-readme-status from CHANGELOG + pre-commit hook:**
+- `sync-readme-status.rkt --sync` now generates Status entry description from
+  CHANGELOG top entry instead of using a generic placeholder.
+- `sync-readme-status.rkt --check` now validates description matches CHANGELOG
+  (not just version number).
+- `run-status-sync-check` added to `pre-commit.rkt` as step 3b.
+- 3 new CHANGELOG-based tests in `test-sync-readme-status.rkt`.
+
+**W1 — sync-version.rkt historical guard + lint-version.rkt + doc reverts:**
+- Replace single-pattern `historical-line?` with 7-pattern context-aware guard
+  in both `sync-version.rkt` and `lint-version.rkt`: Status bold entries, "in vX.Y.Z",
+  wave labels, "As of vX.Y.Z", parenthetical EOL, temporal references (case-insensitive),
+  section headers.
+- Revert 4 mangled historical refs in docs: `security-trust-model.md`,
+  `exn-fail-migration-analysis.md`, `event-taxonomy.md`, `sdk-guide.md`.
+- 9 test cases in `test-sync-version-historical.rkt` (7 positive + 2 negative).
+
 ## v0.28.24 — 2026-05-05
 
 ### Audit Remediation (1 Critical, 4 Warnings from v0.28.23)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.28.24-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.28.25-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 
@@ -199,7 +199,7 @@ racket main.rkt --model gpt-5.4 "write a test"
 ### Verify
 
 ```bash
-racket main.rkt --version  # q version 0.28.24
+racket main.rkt --version  # q version 0.28.25
 raco test tests/           # run the full test suite
 ```
 
@@ -334,6 +334,9 @@ When q executes shell commands on behalf of an LLM, arguments are quoted via `sh
 
 <!-- DO NOT EDIT: Status section is historical. Use sync-version.rkt for version bumps. -->
 ## Status
+
+
+**v0.28.25** — Fixes the 5th occurrence of D1 (README Status divergence) with a CHANGELOG-based generation approach. Adds 7-pattern historical guard to prevent sync-version.rkt from mangling historical version references in documentation. **W0 — sync-readme-status from CHANGELOG + pre-commit hook:** - `sync-readme-status.rkt --sync` now generates Status entry description from CHANGELOG top entry instead of using a generic placeholder. - `sync-readme-status.rkt --check` now validates description matches CHANGELOG (not just version number). - `run-status-sync-check` added to `pre-commit.rkt` as step 3b. - 3 new CHANGELOG-based tests in `test-sync-readme-status.rkt`. **W1 — sync-version.rkt historical guard + lint-version.rkt + doc reverts:** - Replace single-pattern `historical-line?` with 7-pattern context-aware guard in both `sync-version.rkt` and `lint-version.rkt`: Status bold entries, "in vX.Y.Z", wave labels, "As of vX.Y.Z", parenthetical EOL, temporal references (case-insensitive), section headers. - Revert 4 mangled historical refs in docs: `security-trust-model.md`, `exn-fail-migration-analysis.md`, `event-taxonomy.md`, `sdk-guide.md`. - 9 test cases in `test-sync-version-historical.rkt` (7 positive + 2 negative).
 
 **v0.28.24** — Fixes README Status section (4× recurring critical finding) with correct v0.28.24–v0.28.24 descriptions. Extracts shared `compute-mid-turn-estimate` helper to eliminate token estimation duplication in retry-policy.rkt. **D1 fix (critical):** README Status section now has correct descriptions for v0.28.24, v0.28.24, and v0.28.24. Previous description was from v0.28.24, copied forward unchanged for 4 consecutive milestones. **A1 fix:** Token estimation logic extracted into `compute-mid-turn-estimate` helper returning `(values estimated budget-threshold max-tokens)`. Both `estimate-mid-turn-tokens` and `maybe-compact-mid-turn` call the shared helper, eliminating 12-line duplication. **Tests:** 9 mid-turn integration tests (1 new for shared helper).
 

--- a/docs/event-taxonomy.md
+++ b/docs/event-taxonomy.md
@@ -1,6 +1,6 @@
 # Q Event Taxonomy Reference
 
-Complete reference for all event types in Q 0.28.24.
+Complete reference for all event types in Q 0.28.25.
 ## Base Types
 
 ### `event` (protocol-level)

--- a/docs/extension-guide.md
+++ b/docs/extension-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.28.24 --># Extension Development Guide
+<!-- verified-against: 0.28.25 --># Extension Development Guide
 
 This guide walks you through creating, testing, and activating a custom
 extension for q.

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.28.24 --># Getting Started
+<!-- verified-against: 0.28.25 --># Getting Started
 
 Welcome to q, a Racket-based coding agent.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.28.24 --># Installation Guide
+<!-- verified-against: 0.28.25 --># Installation Guide
 
 <!-- This file is the canonical source. The docs/getting-started/installation.md copy is maintained for the doc site build. -->
 

--- a/docs/security-trust-model.md
+++ b/docs/security-trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.28.24 --># Security & Trust Model
+<!-- verified-against: 0.28.25 --># Security & Trust Model
 
 This document provides an honest, per-area assessment of what q enforces
 today and what is planned. It is the authoritative reference for security

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -130,6 +130,6 @@ is the primary self-hosting extension:
 (load-extension! ext-reg "path/to/extension.rkt" #:event-bus bus)
 ```
 
-## Version 0.28.24
+## Version 0.28.25
 
-This documentation reflects q 0.28.24.
+This documentation reflects q 0.28.25.

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.28.24 --># q Source Style Guide
+<!-- verified-against: 0.28.25 --># q Source Style Guide
 
 This document defines formatting and naming conventions for the q Racket codebase.
 All changes to `q/` source files (excluding `tests/`) should follow these rules.

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.28.24 --># Trust Model
+<!-- verified-against: 0.28.25 --># Trust Model
 
 ## Trust Levels
 

--- a/docs/workflow-testing.md
+++ b/docs/workflow-testing.md
@@ -121,6 +121,6 @@ Use relative paths from the test file:
 4. Use `(check-true ...)` for boolean assertions
 5. Keep tests independent — no shared mutable state between test-cases
 
-## Version 0.28.24
+## Version 0.28.25
 
-This documentation reflects q 0.28.24.
+This documentation reflects q 0.28.25.

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.28.24")
+(define version "0.28.25")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base"))

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -10,4 +10,4 @@
 (provide q-version)
 
 (: q-version String)
-(define q-version "0.28.24")
+(define q-version "0.28.25")

--- a/wiki-src/Architecture-Overview.md
+++ b/wiki-src/Architecture-Overview.md
@@ -35,7 +35,7 @@ User input → Interface (CLI/TUI/RPC)
     → Events emitted to bus
 ```
 
-## Metrics (0.28.24)
+## Metrics (0.28.25)
 > _See `racket scripts/metrics.rkt` for current numbers._
 
 - 228 source modules, 349 test files


### PR DESCRIPTION
Addresses #3326.

chore: version bump 0.28.25 + CHANGELOG + STATE.md + docs sync (#3326)

- Version bump 0.28.24 → 0.28.25 in util/version.rkt.
- CHANGELOG entry for v0.28.25 (CHANGELOG-based Status generation + 7-pattern guard).
- STATE.md updated to v0.28.25 with all 3 waves marked complete.
- sync-version.rkt --write --all: 14 docs + info.rkt + README.md synced.
- sync-readme-status.rkt --sync: Status entry generated from CHANGELOG.
- metrics.rkt --sync-all: README metrics/prose synced.

Closes #3326, #3327, #3328, #3329, #3330.