### PR TITLE
fix: W0 — Fix release-blocking test failures + CI caching (#3365)

- Fix turn.started/turn.completed to use event-time instead of wall-clock
  current-inexact-milliseconds, making TUI state transitions deterministic
  in tests (fixes 500ms minimum-busy-duration rule flakiness).
- Fix test-tui-renderer.rkt: use 700ms-spaced timestamps for turn.completed.
- Fix test-tui-tool-cycle.rkt: mock-apply-event now spaces events 600ms apart.
- Fix test-provider-error-recovery.rkt: make-evt now uses incrementing timestamps.
- Add Racket package caching to CI workflow (all 4 jobs).

Fixes C1 (release smoke job failures).

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      - name: Cache Racket packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.local/share/racket
+          key: racket-pkgs-lint-${{ hashFiles('**/info.rkt') }}
+          restore-keys: racket-pkgs-lint-
       - uses: ./.github/actions/setup-racket
         with:
           racket-version: ${{ github.event.inputs.racket-version || '8.10' }}
@@ -72,6 +78,16 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
+      - name: Cache Racket packages
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.local/share/racket
+            ~/Library/Racket
+          key: racket-pkgs-${{ matrix.os }}-${{ matrix.racket-version }}-${{ hashFiles('**/info.rkt') }}
+          restore-keys: |
+            racket-pkgs-${{ matrix.os }}-${{ matrix.racket-version }}-
+            racket-pkgs-${{ matrix.os }}-
       - uses: ./.github/actions/setup-racket
         with:
           racket-version: ${{ github.event.inputs.racket-version || matrix.racket-version }}
@@ -103,6 +119,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      - name: Cache Racket packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.local/share/racket
+          key: racket-pkgs-release-${{ hashFiles('**/info.rkt') }}
+          restore-keys: racket-pkgs-release-
       - uses: ./.github/actions/setup-racket
         with:
           racket-version: ${{ github.event.inputs.racket-version || '8.10' }}
@@ -140,6 +162,14 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
+      - name: Cache Racket packages
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.local/share/racket
+            ~/Library/Racket
+          key: racket-pkgs-smoke-${{ matrix.os }}-${{ hashFiles('**/info.rkt') }}
+          restore-keys: racket-pkgs-smoke-${{ matrix.os }}-
       - uses: ./.github/actions/setup-racket
         with:
           racket-version: ${{ github.event.inputs.racket-version || '8.10' }}

--- a/tests/test-tui-renderer.rkt
+++ b/tests/test-tui-renderer.rkt
@@ -242,7 +242,8 @@
       (run-render-frame! ubuf state input-st layout)
       ;; Status bar should have inverse style: bg=7
       (define status-row-num (tui-layout-status-row layout))
-      (define inverse-count (mock-ubuf-row-style-count ubuf status-row-num (lambda (c) (= (mock-cell-bg c) 7))))
+      (define inverse-count
+        (mock-ubuf-row-style-count ubuf status-row-num (lambda (c) (= (mock-cell-bg c) 7))))
       (check-true (> inverse-count 0) "status bar should have bg=7 (inverse)"))
 
     (test-case "render-frame! clears buffer before drawing"
@@ -691,9 +692,9 @@
   (test-case "turn.completed clears streaming-thinking"
     (define s0 (initial-ui-state))
     (define events
-      (list (make-test-event "turn.started" (hasheq))
-            (make-test-event "model.stream.thinking" (hasheq 'delta "thinking"))
-            (make-test-event "turn.completed" (hasheq))))
+      (list (make-test-event "turn.started" (hasheq) #:time 1000)
+            (make-test-event "model.stream.thinking" (hasheq 'delta "thinking") #:time 1000)
+            (make-test-event "turn.completed" (hasheq) #:time 1700)))
     (define state (simulate-events s0 events))
     (check-false (ui-state-streaming-thinking state))
     (check-false (ui-busy? state)))

--- a/tests/test-tui-tool-cycle.rkt
+++ b/tests/test-tui-tool-cycle.rkt
@@ -13,99 +13,88 @@
          "../tui/state.rkt")
 
 (define tool-cycle-tests
-  (test-suite
-   "Single Tool Call Cycle Tests"
+  (test-suite "Single Tool Call Cycle Tests"
 
-   ;; TC1: Complete tool cycle (start→complete) creates two entries
-   (test-case "TC1: start→complete creates tool-start and tool-end entries"
-     (define ms (make-mock-session))
-     (define ms1
-       (mock-apply-events
-        ms
-        (list
-         (cons "turn.started" (hash))
-         (cons "tool.call.started"
-               (hash 'name "read" 'arguments "{\"path\":\"main.rkt\"}"))
-         (cons "tool.call.completed"
-               (hash 'name "read" 'result "(define x 1)"))
-         (cons "turn.completed" (hash)))))
-     (define texts (mock-entry-texts ms1))
-     ;; Should have 2 entries: tool-start + tool-end
-     (check-equal? (length texts) 2)
-     ;; Tool start includes arg summary
-     (check-not-false
-      (find-entry-by-text (mock-session-state ms1) "[TOOL: read]")
-      "should find tool-start entry")
-     ;; Tool end includes result
-     (check-not-false
-      (find-entry-by-text (mock-session-state ms1) "[OK: read]")
-      "should find tool-end entry")
-     ;; Not busy after turn completed
-     (check-false (mock-busy? ms1)))
+    ;; TC1: Complete tool cycle (start→complete) creates two entries
+    (test-case "TC1: start→complete creates tool-start and tool-end entries"
+      (define ms (make-mock-session))
+      (define ms1
+        (mock-apply-events
+         ms
+         (list (cons "turn.started" (hash))
+               (cons "tool.call.started" (hash 'name "read" 'arguments "{\"path\":\"main.rkt\"}"))
+               (cons "tool.call.completed" (hash 'name "read" 'result "(define x 1)"))
+               (cons "turn.completed" (hash)))))
+      (define texts (mock-entry-texts ms1))
+      ;; Should have 2 entries: tool-start + tool-end
+      (check-equal? (length texts) 2)
+      ;; Tool start includes arg summary
+      (check-not-false (find-entry-by-text (mock-session-state ms1) "[TOOL: read]")
+                       "should find tool-start entry")
+      ;; Tool end includes result
+      (check-not-false (find-entry-by-text (mock-session-state ms1) "[OK: read]")
+                       "should find tool-end entry")
+      ;; Not busy after turn completed
+      (check-false (mock-busy? ms1)))
 
-   ;; TC2: Failed tool cycle creates tool-start and tool-fail entries
-   (test-case "TC2: start→failed creates tool-start and tool-fail entries"
-     (define ms (make-mock-session))
-     (define ms1
-       (mock-apply-events
-        ms
-        (list
-         (cons "turn.started" (hash))
-         (cons "tool.call.started"
-               (hash 'name "bash" 'arguments "{\"command\":\"rm -rf /\"}"))
-         (cons "tool.call.failed"
-               (hash 'name "bash" 'error "permission denied"))
-         (cons "turn.completed" (hash)))))
-     (define texts (mock-entry-texts ms1))
-     (check-equal? (length texts) 2)
-     (check-not-false
-      (find-entry-by-text (mock-session-state ms1) "[TOOL: bash]")
-      "should find tool-start entry")
-     (check-not-false
-      (find-entry-by-text (mock-session-state ms1) "[FAIL: bash]")
-      "should find tool-fail entry"))
+    ;; TC2: Failed tool cycle creates tool-start and tool-fail entries
+    (test-case "TC2: start→failed creates tool-start and tool-fail entries"
+      (define ms (make-mock-session))
+      (define ms1
+        (mock-apply-events
+         ms
+         (list (cons "turn.started" (hash))
+               (cons "tool.call.started" (hash 'name "bash" 'arguments "{\"command\":\"rm -rf /\"}"))
+               (cons "tool.call.failed" (hash 'name "bash" 'error "permission denied"))
+               (cons "turn.completed" (hash)))))
+      (define texts (mock-entry-texts ms1))
+      (check-equal? (length texts) 2)
+      (check-not-false (find-entry-by-text (mock-session-state ms1) "[TOOL: bash]")
+                       "should find tool-start entry")
+      (check-not-false (find-entry-by-text (mock-session-state ms1) "[FAIL: bash]")
+                       "should find tool-fail entry"))
 
-   ;; TC3: Blocked tool creates system entry with reason
-   (test-case "TC3: blocked tool creates system entry"
-     (define ms (make-mock-session))
-     (define ms1
-       (mock-apply-events
-        ms
-        (list
-         (cons "turn.started" (hash))
-         (cons "tool.call.started"
-               (hash 'name "bash" 'arguments "{\"command\":\"ls\"}"))
-         (cons "tool.call.blocked"
-               (hash 'name "bash" 'reason "sandbox policy"))
-         (cons "turn.completed" (hash)))))
-     (define texts (mock-entry-texts ms1))
-     ;; tool-start + blocked system entry = 2 entries
-     (check-equal? (length texts) 2)
-     (check-not-false
-      (find-entry-by-text (mock-session-state ms1) "[tool blocked: bash")
-      "should find blocked tool entry"))
+    ;; TC3: Blocked tool creates system entry with reason
+    (test-case "TC3: blocked tool creates system entry"
+      (define ms (make-mock-session))
+      (define ms1
+        (mock-apply-events
+         ms
+         (list (cons "turn.started" (hash))
+               (cons "tool.call.started" (hash 'name "bash" 'arguments "{\"command\":\"ls\"}"))
+               (cons "tool.call.blocked" (hash 'name "bash" 'reason "sandbox policy"))
+               (cons "turn.completed" (hash)))))
+      (define texts (mock-entry-texts ms1))
+      ;; tool-start + blocked system entry = 2 entries
+      (check-equal? (length texts) 2)
+      (check-not-false (find-entry-by-text (mock-session-state ms1) "[tool blocked: bash")
+                       "should find blocked tool entry"))
 
-   ;; TC4: Tool cycle renders correctly in terminal output
-   (test-case "TC4: tool cycle renders in terminal output"
-     (define state0 (initial-ui-state))
-     (define events
-       (event-sequence
-        "turn.started" (hash)
-        "tool.call.started" (hash 'name "read" 'arguments "{\"path\":\"test.rkt\"}")
-        "tool.call.completed" (hash 'name "read" 'result "ok")
-        "assistant.message.completed" (hash 'content "Done reading.")
-        "turn.completed" (hash)))
-     (define state1 (apply-events state0 events))
-     (define-values (lines _st) (render-state-strings state1 80 24))
-     ;; All 3 entries should appear in rendered output
-     (check-not-false
-      (for/or ([l (in-list lines)]) (string-contains? l "[TOOL: read]"))
-      "tool start should render")
-     (check-not-false
-      (for/or ([l (in-list lines)]) (string-contains? l "[OK: read]"))
-      "tool end should render")
-     (check-not-false
-      (for/or ([l (in-list lines)]) (string-contains? l "Done reading."))
-      "assistant message should render"))))
+    ;; TC4: Tool cycle renders correctly in terminal output
+    (test-case "TC4: tool cycle renders in terminal output"
+      (define state0 (initial-ui-state))
+      (define events
+        (event-sequence "turn.started"
+                        (hash)
+                        "tool.call.started"
+                        (hash 'name "read" 'arguments "{\"path\":\"test.rkt\"}")
+                        "tool.call.completed"
+                        (hash 'name "read" 'result "ok")
+                        "assistant.message.completed"
+                        (hash 'content "Done reading.")
+                        "turn.completed"
+                        (hash)))
+      (define state1 (apply-events state0 events))
+      (define-values (lines _st) (render-state-strings state1 80 24))
+      ;; All 3 entries should appear in rendered output
+      (check-not-false (for/or ([l (in-list lines)])
+                         (string-contains? l "[TOOL: read]"))
+                       "tool start should render")
+      (check-not-false (for/or ([l (in-list lines)])
+                         (string-contains? l "[OK: read]"))
+                       "tool end should render")
+      (check-not-false (for/or ([l (in-list lines)])
+                         (string-contains? l "Done reading."))
+                       "assistant message should render"))))
 
 (run-tests tool-cycle-tests)

--- a/tests/tui/mock-tui-session.rkt
+++ b/tests/tui/mock-tui-session.rkt
@@ -31,9 +31,13 @@
   (mock-session (initial-ui-state #:session-id session-id #:model-name model-name) '()))
 
 ;; Apply a single event (by string name and payload hash) to the mock session.
-;; Returns a new mock-session with updated state and event appended to log.
-(define (mock-apply-event ms ev-str payload)
-  (define evt (make-event ev-str 0 (ui-state-session-id (mock-session-state ms)) #f payload))
+;; Time is computed from the current event count to ensure deterministic
+;; ordering and to avoid the 500ms minimum-busy-duration rule in tests.
+(define (mock-apply-event ms ev-str payload [time-override #f])
+  (define idx (length (mock-session-events ms)))
+  ;; Space events 600ms apart so turn.completed always clears busy?
+  (define t (or time-override (* idx 600)))
+  (define evt (make-event ev-str t (ui-state-session-id (mock-session-state ms)) #f payload))
   (define new-state (apply-event-to-state (mock-session-state ms) evt))
   (mock-session new-state (append (mock-session-events ms) (list ev-str))))
 

--- a/tests/workflows/test-provider-error-recovery.rkt
+++ b/tests/workflows/test-provider-error-recovery.rkt
@@ -19,8 +19,14 @@
 ;; Helpers
 ;; ============================================================
 
+(define evt-counter 0)
 (define (make-evt type payload)
-  (make-test-event type (apply hasheq (append-map (lambda (p) (list (car p) (cdr p))) payload))))
+  (set! evt-counter (add1 evt-counter))
+  ;; Space events 600ms apart so turn.completed always clears busy?
+  (define t (* evt-counter 600))
+  (make-test-event type
+                   (apply hasheq (append-map (lambda (p) (list (car p) (cdr p))) payload))
+                   #:time t))
 
 ;; Count entries of a given kind in the transcript
 (define (count-entries state kind)

--- a/tui/state-events.rkt
+++ b/tui/state-events.rkt
@@ -191,7 +191,7 @@
      (struct-copy ui-state
                   state
                   [busy? #t]
-                  [busy-since (current-inexact-milliseconds)]
+                  [busy-since (event-time evt)]
                   [pending-tool-name #f]
                   [streaming-text #f]
                   [streaming-thinking #f]
@@ -203,7 +203,7 @@
      (define since (ui-state-busy-since state))
      (define elapsed
        (if since
-           (- (current-inexact-milliseconds) since)
+           (- (event-time evt) since)
            min-busy-ms))
      (if (< elapsed min-busy-ms)
          (struct-copy ui-state state [streaming-text #f] [streaming-thinking #f])


### PR DESCRIPTION
Addresses #3365.

fix: W0 — Fix release-blocking test failures + CI caching (#3365)

- Fix turn.started/turn.completed to use event-time instead of wall-clock
  current-inexact-milliseconds, making TUI state transitions deterministic
  in tests (fixes 500ms minimum-busy-duration rule flakiness).
- Fix test-tui-renderer.rkt: use 700ms-spaced timestamps for turn.completed.
- Fix test-tui-tool-cycle.rkt: mock-apply-event now spaces events 600ms apart.
- Fix test-provider-error-recovery.rkt: make-evt now uses incrementing timestamps.
- Add Racket package caching to CI workflow (all 4 jobs).

Fixes C1 (release smoke job failures).