### PR TITLE
W1: v0.29.0 Tool registry contracts (#3402)

### DIFF
--- a/tools/tool.rkt
+++ b/tools/tool.rkt
@@ -58,7 +58,6 @@
          tool-prompt-snippet
          tool-prompt-guidelines
          tool-dangerous?
-         tool->jsexpr
          merge-tool-lists
          validate-tool-schema
          format-tool-schema-hint
@@ -75,7 +74,17 @@
          jsexpr->tool-result ; reserved for SDK consumers
 
          ;; ── Execution context ──
-         make-exec-context
+         (contract-out [make-exec-context
+                        (->* ()
+                             (#:working-directory (or/c path-string? path? #f)
+                                                  #:cancellation-token any/c
+                                                  #:event-publisher (or/c procedure? #f)
+                                                  #:runtime-settings any/c
+                                                  #:call-id string?
+                                                  #:session-metadata any/c
+                                                  #:progress-callback (or/c procedure? #f)
+                                                  #:permission-config any/c)
+                             exec-context?)])
          exec-context?
          exec-context-working-directory
          exec-context-cancellation-token
@@ -102,14 +111,15 @@
          ;; ── Tool registry ──
          make-tool-registry
          tool-registry?
-         register-tool!
-         unregister-tool! ; reserved for SDK consumers
+         (contract-out [register-tool! (-> tool-registry? tool? void?)]
+                       [unregister-tool! (-> tool-registry? string? void?)]
+                       [lookup-tool (-> tool-registry? string? (or/c tool? #f))]
+                       [list-tools (-> tool-registry? (listof tool?))]
+                       [tool->jsexpr (-> tool? hash?)])
          set-active-tools!
          tool-active?
          list-active-tools
          list-active-tools-jsexpr
-         lookup-tool
-         list-tools
          list-tools-jsexpr
          tool-names)
 


### PR DESCRIPTION
Addresses #3402.

feat: v0.29.0 W1 add contract-out to tool registry functions (#3402)

Add contract-out to tool registry surface in tools/tool.rkt:
- register-tool!: (-> tool-registry? tool? void?)
- unregister-tool!: (-> tool-registry? string? void?)
- lookup-tool: (-> tool-registry? string? (or/c tool? #f))
- list-tools: (-> tool-registry? (listof tool?))
- tool->jsexpr: (-> tool? hash?)
- make-exec-context: contracted with keyword args

Move tool->jsexpr from bare export to contract-out.
All existing tests pass. Lint: 17/17."