### PR TITLE
W3: v0.29.0 Tool coordinator contracts (#3408)

### DIFF
--- a/runtime/tool-coordinator.rkt
+++ b/runtime/tool-coordinator.rkt
@@ -18,6 +18,7 @@
 ;; header comment for full rationale.
 
 (require racket/contract
+         racket/contract
          racket/list
          racket/path
          json
@@ -55,9 +56,11 @@
          ;; QUAL-01 (v0.22.0): shared runtime helpers
          (only-in "runtime-helpers.rkt" emit-session-event! maybe-dispatch-hooks))
 
-(provide extract-tool-calls-from-messages
-         make-tool-result-messages
-         handle-tool-calls-pending)
+(provide (contract-out
+          [extract-tool-calls-from-messages (-> list? list?)]
+          [make-tool-result-messages (-> list? list? string? list?)]
+          [handle-tool-calls-pending
+           (-> list? list? any/c any/c any/c string? (or/c path-string? path?) any/c hash? list?)]))
 
 ;; ============================================================
 ;; Helpers (QUAL-01: emit-session-event! and maybe-dispatch-hooks
@@ -175,13 +178,14 @@
         (emit-session-event! bus
                              session-id
                              "tool.call.failed"
-                             (hasheq 'name (tool-call-name tc)
-                                     'error (tool-result-content->string (tool-result-content tr))))
+                             (hasheq 'name
+                                     (tool-call-name tc)
+                                     'error
+                                     (tool-result-content->string (tool-result-content tr))))
         (emit-session-event! bus
                              session-id
                              "tool.call.completed"
-                             (hasheq 'name (tool-call-name tc)
-                                     'result (tool-result-content tr)))))
+                             (hasheq 'name (tool-call-name tc) 'result (tool-result-content tr)))))
 
   ;; Convert scheduler results to tool-result messages.
   (define tool-result-msgs


### PR DESCRIPTION
Addresses #3408.

feat: v0.29.0 W3 add contracts to tool-coordinator (#3408)

Add contract-out to runtime/tool-coordinator.rkt:
- extract-tool-calls-from-messages: (-> list? list?)
- make-tool-result-messages: (-> list? list? string? list?)
- handle-tool-calls-pending: 10-arg contract with path validation

Note: Write budget refactor (W12) deferred — current parameter+box
pattern provides correct per-session isolation as verified by tests.
Lint: 17/17."