### PR TITLE
W1: v0.29.1 Pure iteration decision extraction (#3419)

### DIFF
--- a/runtime/iteration.rkt
+++ b/runtime/iteration.rkt
@@ -19,6 +19,7 @@
 ;; ───────────────────────────────────────────────────────────────
 
 (require racket/contract
+         racket/match
          racket/list
          racket/set
          racket/path
@@ -121,7 +122,46 @@
          ;; DI resolve functions (LOW-05, v0.22.8)
          resolve-compact-proc
          resolve-estimate-tokens
-         resolve-inject-topic)
+         resolve-inject-topic
+         ;; v0.29.1: Pure decision function exports
+         iteration-ctx
+         decide-next-action
+         known-termination-reasons)
+
+;; ============================================================
+;; Pure decision function (v0.29.1: §10 Match Dispatch, §2 Pure/Effect)
+;;
+;; iteration-ctx captures the pure subset of loop state needed
+;; to decide what to do next. No I/O, no mutation.
+;; ============================================================
+
+(struct iteration-ctx
+        (iteration consecutive-tool-count explore-count max-iterations max-iterations-hard)
+  #:transparent)
+
+(define (known-termination-reasons)
+  '(completed cancelled
+              tool-calls-pending
+              error
+              force-shutdown
+              shutdown
+              max-iterations-exceeded
+              hook-blocked))
+
+(define (decide-next-action ctx result)
+  (define term (loop-result-termination-reason result))
+  (match term
+    [(or 'completed 'cancelled 'force-shutdown 'shutdown) 'stop]
+    ['hook-blocked 'stop]
+    ['max-iterations-exceeded 'stop]
+    ['error 'stop]
+    ['tool-calls-pending
+     (define next-iter (add1 (iteration-ctx-iteration ctx)))
+     (cond
+       [(>= next-iter (iteration-ctx-max-iterations-hard ctx)) 'stop-hard-limit]
+       [(>= next-iter (iteration-ctx-max-iterations ctx)) 'stop-soft-limit]
+       [else 'continue])]
+    [_ 'stop]))
 
 ;; ============================================================
 ;; DI parameters (DI-01, v0.22.7; DI-04, v0.22.8)

--- a/tests/test-iteration-decision.rkt
+++ b/tests/test-iteration-decision.rkt
@@ -10,9 +10,6 @@
                   loop-result-termination-reason)
          (only-in "../runtime/iteration.rkt"
                   iteration-ctx
-                  iteration-ctx-iteration
-                  iteration-ctx-max-iterations
-                  iteration-ctx-max-iterations-hard
                   decide-next-action))
 
 ;; Helper: build an iteration-ctx

--- a/tests/test-termination-reasons.rkt
+++ b/tests/test-termination-reasons.rkt
@@ -23,8 +23,7 @@
   (for ([reason (in-list (known-termination-reasons))])
     (define result (make-loop-result '() reason (hasheq)))
     (define action (decide-next-action ctx result))
-    (check (λ (v) (member v '(stop stop-hard-limit stop-soft-limit continue)))
-           action
+    (check-not-false (member action '(stop stop-hard-limit stop-soft-limit continue))
            (format "Termination reason ~a returned unexpected action ~a" reason action))))
 
 (test-case "known-termination-reasons: list is non-empty"
@@ -34,5 +33,5 @@
 (test-case "known-termination-reasons: includes core reasons"
   (define reasons (known-termination-reasons))
   (for ([required '(completed cancelled tool-calls-pending error)])
-    (check-true (member required reasons)
+    (check-not-false (member required reasons)
                 (format "Missing required termination reason: ~a" required))))


### PR DESCRIPTION
Addresses #3419.

feat: v0.29.1 W1 pure iteration decision function (#3419)

Add pure decide-next-action function to runtime/iteration.rkt:
- iteration-ctx struct captures pure loop state (iteration, counts, limits)
- decide-next-action: match-based pure decision function
- known-termination-reasons: explicit list of all handled terminations

11 decision tests + 3 termination exhaustiveness tests now pass.
All existing iteration/mid-turn-compaction tests pass (no regressions).
Lint: 17/17."