### PR TITLE
W2: v0.29.1 Hook match dispatch (#3423)

### DIFF
--- a/agent/loop.rkt
+++ b/agent/loop.rkt
@@ -11,6 +11,7 @@
 ;;   loop.rkt          — facade: re-exports + run-agent-turn orchestrator
 
 (require racket/contract
+         racket/match
          racket/string
          racket/list
          racket/date
@@ -66,7 +67,21 @@
          MAX-STREAM-CHUNKS
          usage-empty?
          parts->text-string
-         emit!)
+         emit!
+         ;; v0.29.1: match-based hook dispatch
+         handle-hook-result)
+
+;; ============================================================
+;; Match-based hook dispatch (v0.29.1: §10 Match Dispatch)
+;; ============================================================
+
+(define (handle-hook-result result on-block on-continue)
+  (cond
+    [(not (hook-result? result)) (on-continue)]
+    [else
+     (match (hook-result-action result)
+       ['block (on-block (hook-result-payload result))]
+       [_ (on-continue)])]))
 
 ;; ============================================================
 ;; Main entry point — thin orchestrator


### PR DESCRIPTION
Addresses #3423.

feat: v0.29.1 W2 hook match dispatch (#3423)

Add handle-hook-result to agent/loop.rkt:
- Match-based dispatch on hook-result-action ('block → on-block, else → on-continue)
- Handles #f (no hook) gracefully
- Exported for testing and reuse

6 hook-match-dispatch tests now pass.
Lint: 17/17."