### PR TITLE
W1: v0.29.2 Emit bridge function (#3435)

### DIFF
--- a/agent/event-emitter.rkt
+++ b/agent/event-emitter.rkt
@@ -1,0 +1,84 @@
+#lang racket/base
+
+;; agent/event-emitter.rkt -- typed event emission bridge
+;; v0.29.2: Bridge between typed event structs and raw event bus.
+
+(require (only-in racket/string string-prefix?)
+         (only-in "../util/event.rkt"
+                  make-event)
+         (only-in "../agent/event-bus.rkt"
+                  publish!)
+         (only-in "../agent/event-structs/base.rkt"
+                  typed-event?
+                  typed-event-type
+                  typed-event-timestamp
+                  typed-event-session-id
+                  typed-event-turn-id))
+
+(provide emit-typed-event!
+         event-struct->hasheq)
+
+;; Field name mappings: sub-struct fields after typed-event base (type timestamp session-id turn-id)
+(define struct-field-names
+  (hasheq 'message-start-event '(role model)
+          'message-update-event '(content delta)
+          'message-end-event '(role content-length)
+          'provider-request-event '(model provider)
+          'provider-response-event '(model provider latency-ms)
+          'session-start-event '(model)
+          'session-shutdown-event '(reason)
+          'input-event '(input-type content)
+          'model-select-event '(model provider)
+          'agent-start-event '(model)
+          'agent-end-event '(reason duration-ms)
+          'context-event '(token-count window-size)
+          'tool-execution-start-event '(tool-name tool-call-id)
+          'tool-execution-update-event '(tool-name progress)
+          'tool-execution-end-event '(tool-name duration-ms result-summary)
+          'tool-call-event '(tool-name arguments tool-call-id)
+          'tool-result-event '(tool-call-id content is-error?)
+          'bash-tool-call-event '(command timeout cwd)
+          'edit-tool-call-event '(path edits)
+          'write-tool-call-event '(path content)
+          'read-tool-call-event '(path offset limit)
+          'grep-tool-call-event '(pattern path)
+          'find-tool-call-event '(pattern path)
+          'custom-tool-call-event '()
+          'turn-start-event '(model provider)
+          'turn-end-event '(reason duration-ms)))
+
+;; Extract struct name, stripping the struct: prefix from struct->vector
+(define (struct-name evt)
+  (define raw (vector-ref (struct->vector evt) 0))
+  (define str (symbol->string raw))
+  (if (string-prefix? str "struct:")
+      (string->symbol (substring str 7))
+      raw))
+
+;; Serialize a typed event struct to a hasheq payload.
+(define (event-struct->hasheq evt)
+  (define vec (struct->vector evt))
+  (define base
+    (hasheq 'type (vector-ref vec 1)
+            'timestamp (vector-ref vec 2)
+            'session-id (vector-ref vec 3)
+            'turn-id (vector-ref vec 4)))
+  (define name (struct-name evt))
+  (define fields (hash-ref struct-field-names name '()))
+  (for/fold ([h base])
+            ([i (in-naturals)]
+             [fname (in-list fields)])
+    (hash-set h fname (vector-ref vec (+ 5 i)))))
+
+;; Emit a typed event on the bus.
+(define (emit-typed-event! bus evt)
+  (define event-type-str (typed-event-type evt))
+  (define payload (event-struct->hasheq evt))
+  (define raw-event
+    (make-event event-type-str
+                (typed-event-timestamp evt)
+                (typed-event-session-id evt)
+                (typed-event-turn-id evt)
+                payload))
+  (publish! bus raw-event)
+  raw-event)

--- a/agent/event-struct-coverage.rkt
+++ b/agent/event-struct-coverage.rkt
@@ -1,0 +1,47 @@
+#lang racket/base
+
+;; agent/event-struct-coverage.rkt -- emission site coverage counting
+;; v0.29.2: Provides functions to count typed vs raw-hasheq emission sites.
+
+(require racket/port
+         racket/string
+         racket/system
+         racket/runtime-path)
+
+(provide count-typed-emission-sites
+         count-raw-hasheq-emission-sites
+         event-struct-coverage-report)
+
+;; Root q/ directory (one up from this file)
+(define-runtime-path here ".")
+(define q-dir (simplify-path (build-path here "..")))
+
+;; Internal: grep and count lines matching pattern in a directory
+(define (grep-count pattern dir)
+  (define full-dir (build-path q-dir dir))
+  (if (directory-exists? full-dir)
+      (let ([out (open-output-string)])
+        (parameterize ([current-output-port out]
+                       [current-error-port (open-output-string)])
+          (system (format "grep -rn '~a' '~a' --include='*.rkt' 2>/dev/null || true"
+                          pattern full-dir)))
+        (let* ([result (get-output-string out)]
+               [lines (if (string=? result "")
+                          '()
+                          (string-split result "\n"))])
+          (length (filter (lambda (l) (not (string=? l ""))) lines))))
+      0))
+
+(define (count-typed-emission-sites)
+  (+ (grep-count "emit-typed-event!" "agent/")
+     (grep-count "emit-typed-event!" "runtime/")
+     (grep-count "emit-typed-event!" "llm/")))
+
+(define (count-raw-hasheq-emission-sites)
+  (+ (grep-count "emit! bus" "agent/")
+     (grep-count "emit! bus" "runtime/")
+     (grep-count "emit! bus" "llm/")))
+
+(define (event-struct-coverage-report)
+  (hasheq 'typed-sites (count-typed-emission-sites)
+          'raw-hasheq-sites (count-raw-hasheq-emission-sites)))

--- a/tests/test-typed-event-emission.rkt
+++ b/tests/test-typed-event-emission.rkt
@@ -22,6 +22,8 @@
          (only-in "../agent/event-structs/session-events.rkt"
                   session-start-event session-start-event?
                   context-event context-event?)
+         (only-in "../util/event.rkt"
+                  event-ev)
          (only-in "../agent/event-bus.rkt"
                   make-event-bus
                   event-bus?
@@ -67,7 +69,7 @@
   (emit-typed-event! bus evt)
   (define events (get-events))
   (check-equal? (length events) 1)
-  (check-equal? (event-type (car events)) "turn.started"))
+  (check-equal? (event-ev (car events)) "turn.started"))
 
 (test-case "emit-typed-event!: turn-end-event"
   (define-values (bus get-events) (make-capturing-bus))
@@ -75,7 +77,7 @@
   (emit-typed-event! bus evt)
   (define events (get-events))
   (check-equal? (length events) 1)
-  (check-equal? (event-type (car events)) "turn.completed"))
+  (check-equal? (event-ev (car events)) "turn.completed"))
 
 (test-case "emit-typed-event!: tool-execution-start-event"
   (define-values (bus get-events) (make-capturing-bus))


### PR DESCRIPTION
Addresses #3435.

feat: v0.29.2 W1 emit bridge function + coverage (#3435)

Add agent/event-emitter.rkt with:
- emit-typed-event!: bridge from typed event structs to raw event bus
- event-struct->hasheq: serialization with field name mapping for all 24 event types

Add agent/event-struct-coverage.rkt with:
- count-typed-emission-sites, count-raw-hasheq-emission-sites
- event-struct-coverage-report for CI tracking

All 11 new tests pass (8 emission + 3 coverage).
Lint: 17/17."