### PR TITLE
W1: v0.29.3 Type llm/model.rkt (#3532)

### DIFF
--- a/llm/model.rkt
+++ b/llm/model.rkt
@@ -1,4 +1,4 @@
-#lang racket/base
+#lang typed/racket
 
 ;; llm/model.rkt — normalized model request/response types
 ;;
@@ -7,24 +7,21 @@
 ;;   - model-response: content parts + usage + model + stop-reason
 ;;   - stream-chunk: delta-text/delta-tool-call/usage/done?
 ;;
-;; All structs are transparent for debugging. JSON helpers provided
-;; for serialization/deserialization.
+;; TR BOUNDARY:
+;; Migrated to #lang typed/racket in v0.29.3 W1.
+;; Untyped consumers receive auto-generated contracts from TR boundary
+;; system. Struct constructors enforce field types at call sites.
 
-(require racket/contract)
-
-;; model-request
 (provide (struct-out model-request)
          make-model-request
          model-request->jsexpr
          jsexpr->model-request
 
-         ;; model-response
          (struct-out model-response)
          make-model-response
          model-response->jsexpr
          jsexpr->model-response
 
-         ;; stream-chunk
          (struct-out stream-chunk)
          make-stream-chunk)
 
@@ -32,32 +29,46 @@
 ;; model-request
 ;; ============================================================
 
-(struct model-request (messages tools settings) #:transparent)
+(struct model-request
+        ([messages : (Listof Any)] [tools : (Option (Listof Any))]
+                                   [settings : (HashTable Symbol Any)])
+  #:transparent)
 
+(: make-model-request ((Listof Any) (Option (Listof Any)) (HashTable Symbol Any) -> model-request))
 (define (make-model-request messages tools settings)
   (model-request messages tools settings))
 
-;; Serialize to jsexpr
+(: model-request->jsexpr (model-request -> (HashTable Symbol Any)))
 (define (model-request->jsexpr req)
-  (define h (hasheq 'messages (model-request-messages req) 'settings (model-request-settings req)))
+  (define h
+    :
+    (HashTable Symbol Any)
+    (hasheq 'messages (model-request-messages req) 'settings (model-request-settings req)))
   (if (model-request-tools req)
       (hash-set h 'tools (model-request-tools req))
       h))
 
-;; Deserialize from jsexpr
+(: jsexpr->model-request ((HashTable Symbol Any) -> model-request))
 (define (jsexpr->model-request h)
-  (make-model-request (hash-ref h 'messages) (hash-ref h 'tools #f) (hash-ref h 'settings)))
+  (make-model-request (cast (hash-ref h 'messages) (Listof Any))
+                      (cast (hash-ref h 'tools #f) (U (Listof Any) #f))
+                      (cast (hash-ref h 'settings) (HashTable Symbol Any))))
 
 ;; ============================================================
 ;; model-response
 ;; ============================================================
 
-(struct model-response (content usage model stop-reason) #:transparent)
+(struct model-response
+        ([content : (Listof Any)] [usage : (HashTable Symbol Any)]
+                                  [model : String]
+                                  [stop-reason : Symbol])
+  #:transparent)
 
+(: make-model-response ((Listof Any) (HashTable Symbol Any) String Symbol -> model-response))
 (define (make-model-response content usage model stop-reason)
   (model-response content usage model stop-reason))
 
-;; Serialize to jsexpr
+(: model-response->jsexpr (model-response -> (HashTable Symbol Any)))
 (define (model-response->jsexpr resp)
   (hasheq 'content
           (model-response-content resp)
@@ -68,27 +79,30 @@
           'stopReason
           (symbol->string (model-response-stop-reason resp))))
 
-;; Deserialize from jsexpr
+(: jsexpr->model-response ((HashTable Symbol Any) -> model-response))
 (define (jsexpr->model-response h)
-  (make-model-response (hash-ref h 'content)
-                       (hash-ref h 'usage)
-                       (hash-ref h 'model)
-                       (string->symbol (hash-ref h 'stopReason))))
+  (make-model-response (cast (hash-ref h 'content) (Listof Any))
+                       (cast (hash-ref h 'usage) (HashTable Symbol Any))
+                       (cast (hash-ref h 'model) String)
+                       (string->symbol (cast (hash-ref h 'stopReason) String))))
 
 ;; ============================================================
 ;; stream-chunk
 ;; ============================================================
 
-(struct stream-chunk (delta-text delta-tool-call delta-thinking usage done? finish-reason)
+(struct stream-chunk
+        ([delta-text : (Option String)] [delta-tool-call : (Option (HashTable Symbol Any))]
+                                        [delta-thinking : (Option String)]
+                                        [usage : (Option (HashTable Symbol Any))]
+                                        [done? : Boolean]
+                                        [finish-reason : (Option (U String Symbol))])
   #:transparent)
 
-;; Convenience constructor with optional keywords.
-;; v0.12.3 Wave 2.3: Added #:delta-thinking keyword.
-;; v0.15.0 Wave 1: Added #:finish-reason keyword.
-(define (make-stream-chunk delta-text
-                           delta-tool-call
-                           usage
-                           done?
-                           #:delta-thinking [delta-thinking #f]
-                           #:finish-reason [finish-reason #f])
-  (stream-chunk delta-text delta-tool-call delta-thinking usage done? finish-reason))
+(define make-stream-chunk
+  (lambda ([delta-text : (Option String) #f]
+           [delta-tool-call : (Option (HashTable Symbol Any)) #f]
+           [usage : (Option (HashTable Symbol Any)) #f]
+           [done? : Boolean #f]
+           #:delta-thinking [delta-thinking : (Option String) #f]
+           #:finish-reason [finish-reason : (Option (U String Symbol)) #f])
+    (stream-chunk delta-text delta-tool-call delta-thinking usage done? finish-reason)))


### PR DESCRIPTION
Addresses #3532.

feat: v0.29.3 W1 type llm/model.rkt (#3532)

Migrate llm/model.rkt to #lang typed/racket:
- model-request: typed fields (Listof Any, Option tools, HashTable settings)
- model-response: typed fields (Listof Any, HashTable, String, Symbol)
- stream-chunk: typed fields including (Option (U String Symbol)) for finish-reason
- Serialization functions use cast for hash-ref type narrowing
- make-stream-chunk uses lambda with type annotations for keyword args

All 23 typed-model tests pass. All existing provider/stream tests pass.
TR module count: 14 → 15. Lint: 17/17."