### PR TITLE
fix: source-scanning test paths + accept TR lang in skeleton (#3552)

- test-di-explicit.rkt: use define-runtime-path for CWD-independent path resolution
- test-facade-surface.rkt: use define-runtime-path + simplify-path for find-files compatibility
- test-lazy-context-assembly.rkt: use define-runtime-path for turn-orchestrator.rkt path
- test-skeleton.rkt: accept #lang typed/racket as valid module language
- Fixes 3 path-resolution failures + 1 skeleton assertion failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ q/
 |--------|-------|
 | Test files | 505 |
 | Source modules | 384 |
-| Source lines | 61432 |
+| Source lines | 61438 |
 | Test lines | 94314 |
 | Test assertions | 14526 |
 | Tests passing | 5835+ | `racket scripts/run-tests.rkt` results |

--- a/tests/test-di-explicit.rkt
+++ b/tests/test-di-explicit.rkt
@@ -6,12 +6,19 @@
 
 (require rackunit
          racket/port
+         racket/runtime-path
          (only-in "../runtime/iteration/loop-state.rkt"
                   resolve-compact-proc
                   resolve-estimate-tokens
                   resolve-inject-topic)
          (only-in "../runtime/compactor.rkt" compact-history)
          (only-in "../llm/token-budget.rkt" estimate-context-tokens))
+
+;; Resolve paths relative to q/ root (works from both q/ and q/tests/ CWD)
+(define-runtime-path q-root-raw "..")
+(define q-root (simplify-path q-root-raw))
+(define (q-file . parts)
+  (apply build-path q-root parts))
 
 ;; ============================================================
 ;; 1. Resolve functions return correct implementations
@@ -41,13 +48,13 @@
 ;; ============================================================
 
 (test-case "loop-state.rkt has no make-parameter"
-  (define source-file "runtime/iteration/loop-state.rkt")
+  (define source-file (q-file "runtime" "iteration" "loop-state.rkt"))
   (define content (call-with-input-file source-file port->string))
   (check-false (regexp-match? #rx"make-parameter" content)
                "loop-state.rkt should not contain make-parameter"))
 
 (test-case "loop-state.rkt has no lazy-require"
-  (define source-file "runtime/iteration/loop-state.rkt")
+  (define source-file (q-file "runtime" "iteration" "loop-state.rkt"))
   (define content (call-with-input-file source-file port->string))
   (check-false (regexp-match? #rx"[(]lazy-require" content)
                "loop-state.rkt should not contain lazy-require"))
@@ -57,16 +64,16 @@
 ;; ============================================================
 
 (test-case "loop-state.rkt does not export current-compact-proc"
-  (define content (call-with-input-file "runtime/iteration/loop-state.rkt" port->string))
+  (define content (call-with-input-file (q-file "runtime" "iteration" "loop-state.rkt") port->string))
   (check-false (regexp-match? #rx"current-compact-proc" content)
                "current-compact-proc should not be in loop-state.rkt"))
 
 (test-case "loop-state.rkt does not export current-estimate-tokens"
-  (define content (call-with-input-file "runtime/iteration/loop-state.rkt" port->string))
+  (define content (call-with-input-file (q-file "runtime" "iteration" "loop-state.rkt") port->string))
   (check-false (regexp-match? #rx"current-estimate-tokens" content)
                "current-estimate-tokens should not be in loop-state.rkt"))
 
 (test-case "loop-state.rkt does not export current-inject-topic"
-  (define content (call-with-input-file "runtime/iteration/loop-state.rkt" port->string))
+  (define content (call-with-input-file (q-file "runtime" "iteration" "loop-state.rkt") port->string))
   (check-false (regexp-match? #rx"current-inject-topic" content)
                "current-inject-topic should not be in loop-state.rkt"))

--- a/tests/test-facade-surface.rkt
+++ b/tests/test-facade-surface.rkt
@@ -6,26 +6,32 @@
 
 (require rackunit
          racket/port
-         racket/file)
+         racket/file
+         racket/runtime-path)
+
+(define-runtime-path q-root-raw "..")
+(define q-root (simplify-path q-root-raw))
+(define (q-file . parts)
+  (apply build-path q-root parts))
 
 ;; ============================================================
 ;; 1. Facade modules with all-from-out are intentional
 ;; ============================================================
 
 (test-case "protocol-types.rkt re-exports 8 sub-modules (intentional facade)"
-  (define content (call-with-input-file "util/protocol-types.rkt" port->string))
+  (define content (call-with-input-file (q-file "util" "protocol-types.rkt") port->string))
   (define count (length (regexp-match* #rx"all-from-out" content)))
   (check-true (>= count 8)
               (format "expected >= 8 all-from-out in protocol-types.rkt, found ~a" count)))
 
 (test-case "context-assembly.rkt re-exports 3 sub-modules (intentional facade)"
-  (define content (call-with-input-file "runtime/context-assembly.rkt" port->string))
+  (define content (call-with-input-file (q-file "runtime" "context-assembly.rkt") port->string))
   (define count (length (regexp-match* #rx"all-from-out" content)))
   (check-true (>= count 3)
               (format "expected >= 3 all-from-out in context-assembly.rkt, found ~a" count)))
 
 (test-case "event-structs.rkt re-exports 6 sub-modules (intentional facade)"
-  (define content (call-with-input-file "agent/event-structs.rkt" port->string))
+  (define content (call-with-input-file (q-file "agent" "event-structs.rkt") port->string))
   (define count (length (regexp-match* #rx"all-from-out" content)))
   (check-true (>= count 6)
               (format "expected >= 6 all-from-out in event-structs.rkt, found ~a" count)))
@@ -35,17 +41,17 @@
 ;; ============================================================
 
 (test-case "agent/loop.rkt does not use all-from-out"
-  (define content (call-with-input-file "agent/loop.rkt" port->string))
+  (define content (call-with-input-file (q-file "agent" "loop.rkt") port->string))
   (check-false (regexp-match? #rx"all-from-out" content)
                "agent/loop.rkt should have explicit provides"))
 
 (test-case "runtime/iteration.rkt does not use all-from-out"
-  (define content (call-with-input-file "runtime/iteration.rkt" port->string))
+  (define content (call-with-input-file (q-file "runtime" "iteration.rkt") port->string))
   (check-false (regexp-match? #rx"all-from-out" content)
                "runtime/iteration.rkt should have explicit provides"))
 
 (test-case "tools/scheduler.rkt does not use all-from-out"
-  (define content (call-with-input-file "tools/scheduler.rkt" port->string))
+  (define content (call-with-input-file (q-file "tools" "scheduler.rkt") port->string))
   (check-false (regexp-match? #rx"all-from-out" content)
                "tools/scheduler.rkt should have explicit provides"))
 
@@ -54,12 +60,12 @@
 ;; ============================================================
 
 (test-case "interfaces/sdk.rkt re-exports sdk-core and sdk-compat"
-  (define content (call-with-input-file "interfaces/sdk.rkt" port->string))
+  (define content (call-with-input-file (q-file "interfaces" "sdk.rkt") port->string))
   (check-not-false (regexp-match? #rx"all-from-out.*sdk-core" content))
   (check-not-false (regexp-match? #rx"all-from-out.*sdk-compat" content)))
 
 (test-case "interfaces/sdk-public.rkt has explicit provides"
-  (define content (call-with-input-file "interfaces/sdk-public.rkt" port->string))
+  (define content (call-with-input-file (q-file "interfaces" "sdk-public.rkt") port->string))
   (check-not-false (regexp-match? #rx"provide" content)))
 
 ;; ============================================================
@@ -67,17 +73,25 @@
 ;; ============================================================
 
 (test-case "total all-from-out count is documented"
-  (define source-dirs '("runtime/" "interfaces/" "agent/" "tools/" "extensions/" "util/"))
+  (define source-dirs
+    (list (build-path q-root "runtime")
+          (build-path q-root "interfaces")
+          (build-path q-root "agent")
+          (build-path q-root "tools")
+          (build-path q-root "extensions")
+          (build-path q-root "util")))
   (define total
     (for/sum ([dir source-dirs])
-      (for/sum ([f (in-list (find-files (lambda (p)
-                                           (and (regexp-match? #rx"\\.rkt$" (path->string p))
-                                                (not (regexp-match? #rx"test" (path->string p)))
-                                                (not (regexp-match? #rx"compiled" (path->string p)))))
-                                       dir))])
-        (with-handlers ([exn:fail? (lambda (_) 0)])
-          (define content (call-with-input-file f port->string))
-          (length (regexp-match* #rx"all-from-out" content))))))
+             (for/sum ([f
+                        (in-list (find-files (lambda (p)
+                                               (and (regexp-match? #rx"\\.rkt$" (path->string p))
+                                                    (not (regexp-match? #rx"test" (path->string p)))
+                                                    (not (regexp-match? #rx"compiled"
+                                                                        (path->string p)))))
+                                             dir))])
+                      (with-handlers ([exn:fail? (lambda (_) 0)])
+                        (define content (call-with-input-file f port->string))
+                        (length (regexp-match* #rx"all-from-out" content))))))
   ;; Baseline: ~30-50 all-from-out (mostly in facades)
   (check-true (and (>= total 20) (<= total 100))
               (format "all-from-out total: ~a (expected 20-100 range)" total)))

--- a/tests/test-lazy-context-assembly.rkt
+++ b/tests/test-lazy-context-assembly.rkt
@@ -7,24 +7,30 @@
 
 (require rackunit
          racket/port
-         racket/promise)
+         racket/promise
+         racket/runtime-path)
+
+(define-runtime-path q-root-raw "..")
+(define q-root (simplify-path q-root-raw))
+(define (q-file . parts)
+  (apply build-path q-root parts))
 
 ;; ============================================================
 ;; 1. turn-orchestrator.rkt uses delay/force
 ;; ============================================================
 
 (test-case "turn-orchestrator.rkt uses delay for token estimation"
-  (define content (call-with-input-file "runtime/turn-orchestrator.rkt" port->string))
+  (define content (call-with-input-file (q-file "runtime" "turn-orchestrator.rkt") port->string))
   (check-not-false (regexp-match? #rx"delay.*estimate-context-tokens" content)
                    "should have delay wrapping estimate-context-tokens"))
 
 (test-case "turn-orchestrator.rkt uses force for deferred computation"
-  (define content (call-with-input-file "runtime/turn-orchestrator.rkt" port->string))
+  (define content (call-with-input-file (q-file "runtime" "turn-orchestrator.rkt") port->string))
   (check-not-false (regexp-match? #rx"force" content)
                    "should use force to realize deferred computation"))
 
 (test-case "turn-orchestrator.rkt defers ws-message resolution"
-  (define content (call-with-input-file "runtime/turn-orchestrator.rkt" port->string))
+  (define content (call-with-input-file (q-file "runtime" "turn-orchestrator.rkt") port->string))
   (check-not-false (regexp-match? #rx"delay.*working-set-resolve" content)
                    "should defer working-set message resolution"))
 
@@ -34,7 +40,10 @@
 
 (test-case "deferred result is cached after first force"
   (let* ([call-count 0]
-         [p (delay (begin (set! call-count (add1 call-count)) 42))])
+         [p (delay
+              (begin
+                (set! call-count (add1 call-count))
+                42))])
     (check-equal? call-count 0 "not computed yet")
     (check-equal? (force p) 42)
     (check-equal? call-count 1 "computed once")
@@ -46,7 +55,9 @@
 ;; ============================================================
 
 (test-case "deferred computation propagates errors"
-  (define p (delay (error 'test "boom")))
+  (define p
+    (delay
+      (error 'test "boom")))
   (check-exn exn:fail? (lambda () (force p))))
 
 ;; ============================================================
@@ -56,11 +67,12 @@
 (test-case "deferred token count matches eager computation"
   ;; Verify that delay(force ...) produces same result as direct call
   (define result 42)
-  (define p (delay result))
+  (define p
+    (delay
+      result))
   (check-equal? (force p) result))
 
 (test-case "at least 2 deferred operations in turn-orchestrator"
-  (define content (call-with-input-file "runtime/turn-orchestrator.rkt" port->string))
+  (define content (call-with-input-file (q-file "runtime" "turn-orchestrator.rkt") port->string))
   (define delay-count (length (regexp-match* #rx"delay " content)))
-  (check-true (>= delay-count 2)
-              (format "expected at least 2 delay forms, found ~a" delay-count)))
+  (check-true (>= delay-count 2) (format "expected at least 2 delay forms, found ~a" delay-count)))

--- a/tests/test-skeleton.rkt
+++ b/tests/test-skeleton.rkt
@@ -6,62 +6,60 @@
 ;; All planned module paths from BLUEPRINT/MODULES.md
 ;; Paths relative to q/ root directory
 (define planned-module-paths
-  '("main.rkt"
-    ;; llm/
-    "llm/model.rkt"
-    "llm/provider.rkt"
-    "llm/openai-compatible.rkt"
-    "llm/anthropic.rkt"
-    "llm/stream.rkt"
-    "llm/token-budget.rkt"
-    ;; agent/
-    "util/protocol-types.rkt"
-    "agent/state.rkt"
-    "agent/event-bus.rkt"
-    "agent/queue.rkt"
-    "agent/loop.rkt"
-    ;; runtime/
-    "runtime/agent-session.rkt"
-    "runtime/session-store.rkt"
-    "runtime/session-index.rkt"
-    "runtime/compactor.rkt"
-    "skills/types.rkt"
-    "runtime/model-registry.rkt"
-    "runtime/auth-store.rkt"
-    "runtime/settings.rkt"
-    ;; tools/
-    "tools/tool.rkt"
-    "tools/scheduler.rkt"
-    "tools/builtins/read.rkt"
-    "tools/builtins/write.rkt"
-    "tools/builtins/edit.rkt"
-    "tools/builtins/bash.rkt"
-    "tools/builtins/grep.rkt"
-    "tools/builtins/find.rkt"
-    "tools/builtins/ls.rkt"
-    ;; extensions/
-    "extensions/api.rkt"
-    "extensions/hooks.rkt"
-    "extensions/loader.rkt"
-    "extensions/define-extension.rkt"
-    ;; skills/
-    "skills/skill-loader.rkt"
-    "skills/prompt-template.rkt"
-    "skills/context-files.rkt"
-    ;; interfaces/
-    "interfaces/cli.rkt"
-    "interfaces/tui.rkt"
-    "interfaces/json-mode.rkt"
-    "interfaces/rpc-mode.rkt"
-    "interfaces/sdk.rkt"
-    ;; sandbox/
-    "sandbox/subprocess.rkt"
-    "sandbox/evaluator.rkt"
-    "sandbox/limits.rkt"
-    ;; util/
-    "util/jsonl.rkt"
-    "util/ids.rkt"
-    ))
+  ;; llm/
+  '("main.rkt" "llm/model.rkt"
+               "llm/provider.rkt"
+               "llm/openai-compatible.rkt"
+               "llm/anthropic.rkt"
+               "llm/stream.rkt"
+               "llm/token-budget.rkt"
+               ;; agent/
+               "util/protocol-types.rkt"
+               "agent/state.rkt"
+               "agent/event-bus.rkt"
+               "agent/queue.rkt"
+               "agent/loop.rkt"
+               ;; runtime/
+               "runtime/agent-session.rkt"
+               "runtime/session-store.rkt"
+               "runtime/session-index.rkt"
+               "runtime/compactor.rkt"
+               "skills/types.rkt"
+               "runtime/model-registry.rkt"
+               "runtime/auth-store.rkt"
+               "runtime/settings.rkt"
+               ;; tools/
+               "tools/tool.rkt"
+               "tools/scheduler.rkt"
+               "tools/builtins/read.rkt"
+               "tools/builtins/write.rkt"
+               "tools/builtins/edit.rkt"
+               "tools/builtins/bash.rkt"
+               "tools/builtins/grep.rkt"
+               "tools/builtins/find.rkt"
+               "tools/builtins/ls.rkt"
+               ;; extensions/
+               "extensions/api.rkt"
+               "extensions/hooks.rkt"
+               "extensions/loader.rkt"
+               "extensions/define-extension.rkt"
+               ;; skills/
+               "skills/skill-loader.rkt"
+               "skills/prompt-template.rkt"
+               "skills/context-files.rkt"
+               ;; interfaces/
+               "interfaces/cli.rkt"
+               "interfaces/tui.rkt"
+               "interfaces/json-mode.rkt"
+               "interfaces/rpc-mode.rkt"
+               "interfaces/sdk.rkt"
+               ;; sandbox/
+               "sandbox/subprocess.rkt"
+               "sandbox/evaluator.rkt"
+               "sandbox/limits.rkt"
+               ;; util/
+               "util/jsonl.rkt"
+               "util/ids.rkt"))
 
 ;; The test file is at q/tests/test-skeleton.rkt
 ;; Module files are at q/<rel-path> relative to the q/ directory
@@ -72,24 +70,29 @@
 ;; Test: all planned module files exist on disk
 (for ([rel (in-list planned-module-paths)])
   (define full-path (build-path q-root rel))
-  (check-true (file-exists? full-path)
-              (format "Module file missing: ~a" rel)))
+  (check-true (file-exists? full-path) (format "Module file missing: ~a" rel)))
 
 ;; Test: each module file starts with #lang racket or #lang racket/base
 (for ([rel (in-list planned-module-paths)])
   (define full-path (build-path q-root rel))
-  (with-input-from-file full-path
-    (lambda ()
-      (define first-line (read-line))
-      (check-true (or (equal? first-line "#lang racket")
-                      (equal? first-line "#lang racket/base"))
-                  (format "Module ~a does not start with #lang racket or #lang racket/base (got: ~a)"
-                          rel first-line)))))
+  (with-input-from-file
+   full-path
+   (lambda ()
+     (define first-line (read-line))
+     (check-true
+      (or (equal? first-line "#lang racket")
+          (equal? first-line "#lang racket/base")
+          (equal? first-line "#lang typed/racket"))
+      (format
+       "Module ~a does not start with #lang racket, #lang racket/base, or #lang typed/racket (got: ~a)"
+       rel
+       first-line)))))
 
 ;; Test: info.rkt exists at project root
 (define info-path (build-path q-root "info.rkt"))
 (check-pred file-exists? info-path "info.rkt missing at project root")
 
 ;; Test: total module count matches BLUEPRINT plan
-(check-equal? (length planned-module-paths) 46
+(check-equal? (length planned-module-paths)
+              46
               "Planned module count should be 46 (from BLUEPRINT/MODULES.md)")


### PR DESCRIPTION
Addresses #3552.

fix: source-scanning test paths + accept TR lang in skeleton (#3552)

- test-di-explicit.rkt: use define-runtime-path for CWD-independent path resolution
- test-facade-surface.rkt: use define-runtime-path + simplify-path for find-files compatibility
- test-lazy-context-assembly.rkt: use define-runtime-path for turn-orchestrator.rkt path
- test-skeleton.rkt: accept #lang typed/racket as valid module language
- Fixes 3 path-resolution failures + 1 skeleton assertion failure