### PR TITLE
feat: wire decide-next-action into iteration loop (#3554)

- Replace inline cond on termination with match on decide-next-action result
- Build iteration-ctx from loop state to call pure decision function
- Completed branch preserved with all followup/hook logic
- Other stop reasons (cancelled, error, etc.) merged into 'stop else branch
- Hard limit → 'stop-hard-limit, soft limit → 'stop-soft-limit, normal → 'continue
- New test: test-iteration-wiring.rkt verifies production wiring
- All existing iteration tests pass (5/5 + related suites)

### DIFF
--- a/runtime/iteration.rkt
+++ b/runtime/iteration.rkt
@@ -437,63 +437,83 @@
                                                            max-iterations-hard)
                                                    iteration-decision-payload/c))
 
-              (cond
-                ;; ── Completed: append and return ──
-                [(eq? termination 'completed)
-                 (append-entries! log-path new-msgs)
-                 ;; Dispatch 'turn-end hook
-                 (let-values ([(amended-result after-hook-res)
-                               (maybe-dispatch-hooks ext-reg 'turn-end result)])
-                   (let ([effective-result (if (and after-hook-res
-                                                    (eq? (hook-result-action after-hook-res) 'amend))
-                                               amended-result
-                                               result)])
-                     ;; #662: Drain follow-up queue — if follow-ups exist,
-                     ;; inject as user messages and continue the loop.
-                     ;; #763: Support 'all (drain all) and 'one-at-a-time modes.
-                     (define followup-continued?
-                       (and steering-queue
-                            (let ([followups (if (eq? follow-up-mode 'one-at-a-time)
-                                                 (let ([one (dequeue-followup! steering-queue)])
-                                                   (if one
-                                                       (list one)
-                                                       '()))
-                                                 (dequeue-all-followups! steering-queue))])
-                              (if (null? followups)
-                                  #f
-                                  (let ([followup-msgs (for/list ([fu (in-list followups)])
-                                                         (make-message (generate-id)
-                                                                       #f
-                                                                       'user
-                                                                       'text
-                                                                       (list (make-text-part fu))
-                                                                       (now-seconds)
-                                                                       (hasheq 'source "followup")))])
-                                    (emit-session-event! bus
-                                                         session-id
-                                                         "followup.injected"
-                                                         (hasheq 'count
-                                                                 (length followups)
-                                                                 'mode
-                                                                 (symbol->string follow-up-mode)))
-                                    (append-entries! log-path followup-msgs)
-                                    (loop (append ctx-with-injected new-msgs followup-msgs)
-                                          (add1 iteration)
-                                          0
-                                          (set)
-                                          ws
-                                          intent-retry-count
-                                          0
-                                          '()
-                                          explore-count
-                                          implement-count
-                                          0))))))
-                     (define base-result (if followup-continued? effective-result effective-result))
-                     ;; v0.21.3: Intent/stall detection removed.
-                     ;; The prompt is self-correcting by design - no runtime nudging.
-                     base-result))]
+              ;; v0.29.8 W0: Use pure decision function for dispatch
+              (define action
+                (decide-next-action (iteration-ctx iteration
+                                                   consecutive-tool-count
+                                                   explore-count
+                                                   max-iterations
+                                                   max-iterations-hard)
+                                    result))
+
+              (match action
+                ;; ── Stop: check if completed or other termination ──
+                ['stop
+                 (if (eq? termination 'completed)
+                     (begin
+                       (append-entries! log-path new-msgs)
+                       ;; Dispatch 'turn-end hook
+                       (let-values ([(amended-result after-hook-res)
+                                     (maybe-dispatch-hooks ext-reg 'turn-end result)])
+                         (let ([effective-result (if (and after-hook-res
+                                                          (eq? (hook-result-action after-hook-res)
+                                                               'amend))
+                                                     amended-result
+                                                     result)])
+                           ;; #662: Drain follow-up queue — if follow-ups exist,
+                           ;; inject as user messages and continue the loop.
+                           ;; #763: Support 'all (drain all) and 'one-at-a-time modes.
+                           (define followup-continued?
+                             (and
+                              steering-queue
+                              (let ([followups (if (eq? follow-up-mode 'one-at-a-time)
+                                                   (let ([one (dequeue-followup! steering-queue)])
+                                                     (if one
+                                                         (list one)
+                                                         '()))
+                                                   (dequeue-all-followups! steering-queue))])
+                                (if (null? followups)
+                                    #f
+                                    (let ([followup-msgs (for/list ([fu (in-list followups)])
+                                                           (make-message (generate-id)
+                                                                         #f
+                                                                         'user
+                                                                         'text
+                                                                         (list (make-text-part fu))
+                                                                         (now-seconds)
+                                                                         (hasheq 'source
+                                                                                 "followup")))])
+                                      (emit-session-event! bus
+                                                           session-id
+                                                           "followup.injected"
+                                                           (hasheq 'count
+                                                                   (length followups)
+                                                                   'mode
+                                                                   (symbol->string follow-up-mode)))
+                                      (append-entries! log-path followup-msgs)
+                                      (loop (append ctx-with-injected new-msgs followup-msgs)
+                                            (add1 iteration)
+                                            0
+                                            (set)
+                                            ws
+                                            intent-retry-count
+                                            0
+                                            '()
+                                            explore-count
+                                            implement-count
+                                            0))))))
+                           (define base-result
+                             (if followup-continued? effective-result effective-result))
+                           ;; v0.21.3: Intent/stall detection removed.
+                           ;; The prompt is self-correcting by design - no runtime nudging.
+                           base-result)))
+                     ;; Other stop reasons: append and return
+                     (begin
+                       (append-entries! log-path new-msgs)
+                       result))]
+
                 ;; ── Hard iteration limit reached: append and stop ──
-                [(and (eq? termination 'tool-calls-pending) (>= (add1 iteration) max-iterations-hard))
+                ['stop-hard-limit
                  (append-entries! log-path new-msgs)
                  (emit-session-event! bus
                                       session-id
@@ -511,9 +531,7 @@
                                    (hash-set (loop-result-metadata result) 'maxIterationsReached #t))]
 
                 ;; ── Soft iteration limit: warn but continue ──
-                [(and (eq? termination 'tool-calls-pending)
-                      (>= (add1 iteration) max-iterations)
-                      (< (add1 iteration) max-iterations-hard))
+                ['stop-soft-limit
                  (append-entries! log-path new-msgs)
                  (emit-session-event! bus
                                       session-id
@@ -557,7 +575,7 @@
                        stall-retry-count)]
 
                 ;; ── Tool calls pending: execute tools and re-run ──
-                [(eq? termination 'tool-calls-pending)
+                ['continue
                  (append-entries! log-path new-msgs)
                  (define updated-ctx
                    (handle-tool-calls-pending new-msgs
@@ -653,9 +671,4 @@
                        new-recent-tools
                        new-explore-count
                        new-implement-count
-                       stall-retry-count)]
-
-                ;; ── Unknown termination: append and return ──
-                [else
-                 (append-entries! log-path new-msgs)
-                 result])])]))))
+                       stall-retry-count)])])]))))

--- a/tests/test-iteration-wiring.rkt
+++ b/tests/test-iteration-wiring.rkt
@@ -1,0 +1,47 @@
+#lang racket/base
+
+;; tests/test-iteration-wiring.rkt — Verify decide-next-action is wired into production loop
+;;
+;; v0.29.8 W0: Integration verification that the pure decision function
+;; is called from the iteration loop's main dispatch.
+
+(require rackunit
+         racket/port
+         racket/runtime-path
+         (only-in "../runtime/iteration.rkt" decide-next-action))
+
+(define-runtime-path q-root-raw "..")
+(define q-root (simplify-path q-root-raw))
+
+;; ============================================================
+;; 1. decide-next-action is imported and used in iteration.rkt
+;; ============================================================
+
+(test-case "decide-next-action is exported from iteration.rkt"
+  (check-not-false (procedure? decide-next-action)
+                   "decide-next-action should be a procedure"))
+
+(test-case "iteration.rkt source contains decide-next-action call in loop body"
+  (define content (call-with-input-file (build-path q-root "runtime" "iteration.rkt") port->string))
+  ;; The function is defined once and called at least once in the loop
+  (define def-count (length (regexp-match* #rx"decide-next-action [(]iteration-ctx" content)))
+  (check-true (>= def-count 1)
+              (format "expected >= 1 decide-next-action call with iteration-ctx, found ~a" def-count)))
+
+(test-case "iteration-ctx struct is used to construct decision context"
+  (define content (call-with-input-file (build-path q-root "runtime" "iteration.rkt") port->string))
+  (define ctx-usage (length (regexp-match* #rx"[(]iteration-ctx " content)))
+  ;; At least 1 usage in the loop body (beyond the struct definition)
+  (check-true (>= ctx-usage 1)
+              (format "expected >= 1 iteration-ctx call site (beyond definition), found ~a" ctx-usage)))
+
+(test-case "cond on termination is replaced by match on action"
+  (define content (call-with-input-file (build-path q-root "runtime" "iteration.rkt") port->string))
+  ;; The loop should use match on action, not direct cond on termination
+  (check-not-false (regexp-match? #rx"[(]match action" content)
+                   "loop should use (match action ...) for dispatch"))
+
+(test-case "termination-decision has no production callers"
+  (define loop-content (call-with-input-file (build-path q-root "runtime" "iteration.rkt") port->string))
+  (check-false (regexp-match? #rx"termination-decision" loop-content)
+               "iteration.rkt should not call termination-decision (replaced by decide-next-action)"))


### PR DESCRIPTION
Addresses #3554.

feat: wire decide-next-action into iteration loop (#3554)

- Replace inline cond on termination with match on decide-next-action result
- Build iteration-ctx from loop state to call pure decision function
- Completed branch preserved with all followup/hook logic
- Other stop reasons (cancelled, error, etc.) merged into 'stop else branch
- Hard limit → 'stop-hard-limit, soft limit → 'stop-soft-limit, normal → 'continue
- New test: test-iteration-wiring.rkt verifies production wiring
- All existing iteration tests pass (5/5 + related suites)