### PR TITLE
feat: wire handle-hook-result into loop.rkt + loop-stream.rkt (#3555)

- Move handle-hook-result from loop.rkt to loop-messages.rkt (shared module)
- Replace 2 cond-on-hook-result patterns in loop.rkt with handle-hook-result calls
- Replace 1 cond-on-hook-result pattern in loop-stream.rkt with handle-hook-result call
- process-chunk wiring deferred (needs accumulator/streaming-message bridge design)
- All existing tests pass (stream, iteration, provider smoke, SDK contracts)

### DIFF
--- a/agent/loop-messages.rkt
+++ b/agent/loop-messages.rkt
@@ -11,18 +11,21 @@
 (require racket/string
          racket/list
          racket/set
+         racket/match
          "../util/protocol-types.rkt"
          "event-bus.rkt"
          "state.rkt"
          "../util/ids.rkt"
-         (only-in "../util/content-helpers.rkt" result-content->string))
+         (only-in "../util/content-helpers.rkt" result-content->string)
+         (only-in "../util/hook-types.rkt" hook-result? hook-result-action hook-result-payload))
 
 (provide usage-empty?
          parts->text-string
          emit!
          valid-api-message-sequence?
          merge-consecutive-roles
-         build-raw-messages)
+         build-raw-messages
+         handle-hook-result)
 
 ;; ============================================================
 ;; Helpers
@@ -173,3 +176,15 @@
   ;; Safety net: merge consecutive user messages.
   ;; Some providers (GLM) reject consecutive same-role messages.
   (merge-consecutive-roles raw-msgs))
+
+;; ============================================================
+;; Match-based hook dispatch (v0.29.1: §10 Match Dispatch)
+;; ============================================================
+
+(define (handle-hook-result result on-block on-continue)
+  (cond
+    [(not (hook-result? result)) (on-continue)]
+    [else
+     (match (hook-result-action result)
+       ['block (on-block (hook-result-payload result))]
+       [_ (on-continue)])]))

--- a/agent/loop-stream.rkt
+++ b/agent/loop-stream.rkt
@@ -426,8 +426,9 @@
         (hash-ref (hook-result-payload msg-end-result) 'content accumulated-text)
         accumulated-text))
 
-  (cond
-    [(and (hook-result? msg-end-result) (eq? (hook-result-action msg-end-result) 'block))
+  (handle-hook-result
+   msg-end-result
+   (lambda (payload)
      ;; message-end blocked -- return completed with empty content
      (emit! bus
             session-id
@@ -437,8 +438,8 @@
             #:state state)
      (make-loop-result (loop-state-messages state)
                        'hook-blocked
-                       (hasheq 'turnId turn-id 'hook 'message-end))]
-    [else
+                       (hasheq 'turnId turn-id 'hook 'message-end)))
+   (lambda ()
      ;; Rebuild text-part with potentially amended content
      (define final-text-part (make-text-part final-text))
      (define final-content-parts (append (list final-text-part) tool-call-parts))
@@ -522,4 +523,4 @@
                                   'model
                                   "streamed"
                                   'toolCallCount
-                                  (length tool-call-parts)))])]))
+                                  (length tool-call-parts)))]))))

--- a/agent/loop.rkt
+++ b/agent/loop.rkt
@@ -68,20 +68,7 @@
          usage-empty?
          parts->text-string
          emit!
-         ;; v0.29.1: match-based hook dispatch
          handle-hook-result)
-
-;; ============================================================
-;; Match-based hook dispatch (v0.29.1: §10 Match Dispatch)
-;; ============================================================
-
-(define (handle-hook-result result on-block on-continue)
-  (cond
-    [(not (hook-result? result)) (on-continue)]
-    [else
-     (match (hook-result-action result)
-       ['block (on-block (hook-result-payload result))]
-       [_ (on-continue)])]))
 
 ;; ============================================================
 ;; Main entry point — thin orchestrator
@@ -150,16 +137,17 @@
                                   'settings
                                   (model-request-settings req)))))
 
-  (cond
-    [(and (hook-result? pre-hook-result) (eq? (hook-result-action pre-hook-result) 'block))
+  (handle-hook-result
+   pre-hook-result
+   (lambda (payload)
      (emit! bus session-id turn-id "model.request.blocked" (hasheq 'reason "hook"))
      (emit! bus
             session-id
             turn-id
             "turn.completed"
             (hasheq 'termination 'hook-blocked 'turnId turn-id 'reason "model-request-pre-blocked"))
-     (loop-result raw-messages 'hook-blocked (hasheq 'hook 'model-request-pre))]
-    [else
+     (loop-result raw-messages 'hook-blocked (hasheq 'hook 'model-request-pre)))
+   (lambda ()
      ;; DEBUG: validate raw-messages before sending
      (unless (valid-api-message-sequence? raw-messages)
        (log-warning "INVALID message sequence detected! Dumping raw messages:")
@@ -200,16 +188,17 @@
                                      'message-count
                                      (length raw-messages)))))
 
-     (cond
-       [(and (hook-result? msg-start-result) (eq? (hook-result-action msg-start-result) 'block))
+     (handle-hook-result
+      msg-start-result
+      (lambda (payload)
         (emit! bus session-id turn-id "message.blocked" (hasheq 'hook 'message-start))
         (emit! bus
                session-id
                turn-id
                "turn.completed"
                (hasheq 'termination 'hook-blocked 'turnId turn-id 'reason "message-start-blocked"))
-        (loop-result raw-messages 'hook-blocked (hasheq 'hook 'message-start))]
-       [else
+        (loop-result raw-messages 'hook-blocked (hasheq 'hook 'message-start)))
+      (lambda ()
         ;; 5-7. Stream from provider
         (define stream-data
           (stream-from-provider provider
@@ -233,4 +222,4 @@
                                 st
                                 tools
                                 provider
-                                hook-dispatcher)])])]))
+                                hook-dispatcher)]))))))


### PR DESCRIPTION
Addresses #3555.

feat: wire handle-hook-result into loop.rkt + loop-stream.rkt (#3555)

- Move handle-hook-result from loop.rkt to loop-messages.rkt (shared module)
- Replace 2 cond-on-hook-result patterns in loop.rkt with handle-hook-result calls
- Replace 1 cond-on-hook-result pattern in loop-stream.rkt with handle-hook-result call
- process-chunk wiring deferred (needs accumulator/streaming-message bridge design)
- All existing tests pass (stream, iteration, provider smoke, SDK contracts)