### PR TITLE
feat: remove dead termination-decision + cleanup GSD locking + middleware import (#3559)

- Remove termination-decision from transition-logic.rkt (replaced by decide-next-action)
- Document GSD two-level locking pattern (outer sem for compound ops, inner for individual)
- Remove dead get-workflow/set-workflow actions from GSD closure
- Remove unused tool-call-id import from middleware.rkt
- All existing tests pass

### DIFF
--- a/extensions/gsd/session-state.rkt
+++ b/extensions/gsd/session-state.rkt
@@ -9,7 +9,6 @@
 ;; isolated contexts.
 ;;
 ;; Thread safety: Each context has its own semaphore for atomic updates.
-;; The default context uses gsd-default-sem.
 
 (require racket/set
          "runtime-state-types.rkt")
@@ -50,9 +49,6 @@
            ;; Plan data
            [(get-plan) plan-data]
            [(set-plan) (set! plan-data (car args))]
-           ;; Workflow
-           [(get-workflow) #f] ;; stored in gsd-runtime-state
-           [(set-workflow) (void)]
            ;; Busy flag
            [(busy?) busy]
            [(set-busy!) (set! busy (car args))]
@@ -82,13 +78,11 @@
 
 (define gsd-default-ctx (make-gsd-context))
 
-;; Semaphore for atomic operations on default context
+;; Outer semaphore for compound operations (with-gsd-lock).
+;; The closure has its own inner semaphore for individual operations.
+;; Two-level locking: outer serializes compound ops, inner serializes individual ops.
+;; No deadlock risk since outer is always acquired before inner.
 (define gsd-state-sem (make-semaphore 1))
-
-;; ============================================================
-;; Parameter-compatible accessors (readers/writers)
-;; All use the default global context.
-;; ============================================================
 
 (define (current-gsd-state)
   (gsd-default-ctx 'get-state))
@@ -133,7 +127,7 @@
   (gsd-default-ctx 'set-history! v))
 
 ;; ============================================================
-;; Thread-safe lock helper (uses default semaphore)
+;; Thread-safe lock helper (outer semaphore for compound ops)
 ;; ============================================================
 
 (define (with-gsd-lock thunk)

--- a/runtime/iteration/transition-logic.rkt
+++ b/runtime/iteration/transition-logic.rkt
@@ -5,46 +5,25 @@
 ;; Pure decision functions for loop transitions: cancellation, shutdown,
 ;; soft/hard limits, turn blocking.
 
-(require (only-in "../../util/cancellation.rkt"
-                  cancellation-token?
-                  cancellation-token-cancelled?))
+(require (only-in "../../util/cancellation.rkt" cancellation-token? cancellation-token-cancelled?))
 
 (provide check-cancellation
          check-soft-limit
-         check-hard-limit
-         termination-decision)
+         check-hard-limit)
 
 ;; Check if the loop should terminate due to cancellation or shutdown.
 ;; Returns (values should-stop? reason-symbol) or (values #f #f).
 (define (check-cancellation token shutdown-check force-shutdown-check)
   (cond
-    [(and force-shutdown-check (force-shutdown-check))
-     (values #t 'force-shutdown)]
-    [(and token (cancellation-token-cancelled? token))
-     (values #t 'cancellation-token)]
-    [(and shutdown-check (shutdown-check))
-     (values #t 'graceful-shutdown)]
+    [(and force-shutdown-check (force-shutdown-check)) (values #t 'force-shutdown)]
+    [(and token (cancellation-token-cancelled? token)) (values #t 'cancellation-token)]
+    [(and shutdown-check (shutdown-check)) (values #t 'graceful-shutdown)]
     [else (values #f #f)]))
 
 ;; Check if soft iteration limit is reached.
 (define (check-soft-limit iteration max-iterations max-iterations-hard)
-  (and (>= (add1 iteration) max-iterations)
-       (< (add1 iteration) max-iterations-hard)))
+  (and (>= (add1 iteration) max-iterations) (< (add1 iteration) max-iterations-hard)))
 
 ;; Check if hard iteration limit is reached.
 (define (check-hard-limit iteration max-iterations-hard)
   (>= (add1 iteration) max-iterations-hard))
-
-;; Decide termination action given current state.
-;; Returns: 'stop | 'warn | 'continue
-(define (termination-decision iteration max-iterations max-iterations-hard termination)
-  (cond
-    [(eq? termination 'completed) 'stop]
-    [(and (eq? termination 'tool-calls-pending)
-          (check-hard-limit iteration max-iterations-hard))
-     'hard-stop]
-    [(and (eq? termination 'tool-calls-pending)
-          (check-soft-limit iteration max-iterations max-iterations-hard))
-     'warn]
-    [(eq? termination 'tool-calls-pending) 'continue]
-    [else 'stop]))

--- a/tests/test-iteration-transition.rkt
+++ b/tests/test-iteration-transition.rkt
@@ -15,14 +15,12 @@
       (check-false reason))
 
     (test-case "check-cancellation: force shutdown"
-      (define-values (stop? reason)
-        (check-cancellation #f #f (lambda () #t)))
+      (define-values (stop? reason) (check-cancellation #f #f (lambda () #t)))
       (check-true stop?)
       (check-equal? reason 'force-shutdown))
 
     (test-case "check-cancellation: graceful shutdown"
-      (define-values (stop? reason)
-        (check-cancellation #f (lambda () #t) #f))
+      (define-values (stop? reason) (check-cancellation #f (lambda () #t) #f))
       (check-true stop?)
       (check-equal? reason 'graceful-shutdown))
 
@@ -36,19 +34,7 @@
       (check-false (check-hard-limit 5 16)))
 
     (test-case "check-hard-limit: at limit"
-      (check-true (check-hard-limit 15 16)))
-
-    (test-case "termination-decision: completed stops"
-      (check-equal? (termination-decision 0 10 16 'completed) 'stop))
-
-    (test-case "termination-decision: tool-calls at hard limit"
-      (check-equal? (termination-decision 15 10 16 'tool-calls-pending) 'hard-stop))
-
-    (test-case "termination-decision: tool-calls at soft limit"
-      (check-equal? (termination-decision 9 10 16 'tool-calls-pending) 'warn))
-
-    (test-case "termination-decision: tool-calls below limits"
-      (check-equal? (termination-decision 5 10 16 'tool-calls-pending) 'continue))))
+      (check-true (check-hard-limit 15 16)))))
 
 (module+ main
   (run-tests transition-tests))

--- a/tests/test-iteration-wiring.rkt
+++ b/tests/test-iteration-wiring.rkt
@@ -18,22 +18,23 @@
 ;; ============================================================
 
 (test-case "decide-next-action is exported from iteration.rkt"
-  (check-not-false (procedure? decide-next-action)
-                   "decide-next-action should be a procedure"))
+  (check-not-false (procedure? decide-next-action) "decide-next-action should be a procedure"))
 
 (test-case "iteration.rkt source contains decide-next-action call in loop body"
   (define content (call-with-input-file (build-path q-root "runtime" "iteration.rkt") port->string))
   ;; The function is defined once and called at least once in the loop
   (define def-count (length (regexp-match* #rx"decide-next-action [(]iteration-ctx" content)))
   (check-true (>= def-count 1)
-              (format "expected >= 1 decide-next-action call with iteration-ctx, found ~a" def-count)))
+              (format "expected >= 1 decide-next-action call with iteration-ctx, found ~a"
+                      def-count)))
 
 (test-case "iteration-ctx struct is used to construct decision context"
   (define content (call-with-input-file (build-path q-root "runtime" "iteration.rkt") port->string))
   (define ctx-usage (length (regexp-match* #rx"[(]iteration-ctx " content)))
   ;; At least 1 usage in the loop body (beyond the struct definition)
   (check-true (>= ctx-usage 1)
-              (format "expected >= 1 iteration-ctx call site (beyond definition), found ~a" ctx-usage)))
+              (format "expected >= 1 iteration-ctx call site (beyond definition), found ~a"
+                      ctx-usage)))
 
 (test-case "cond on termination is replaced by match on action"
   (define content (call-with-input-file (build-path q-root "runtime" "iteration.rkt") port->string))
@@ -41,7 +42,9 @@
   (check-not-false (regexp-match? #rx"[(]match action" content)
                    "loop should use (match action ...) for dispatch"))
 
-(test-case "termination-decision has no production callers"
-  (define loop-content (call-with-input-file (build-path q-root "runtime" "iteration.rkt") port->string))
-  (check-false (regexp-match? #rx"termination-decision" loop-content)
-               "iteration.rkt should not call termination-decision (replaced by decide-next-action)"))
+(test-case "termination-decision removed from codebase"
+  (define tl-content
+    (call-with-input-file (build-path q-root "runtime" "iteration" "transition-logic.rkt")
+                          port->string))
+  (check-false (regexp-match? #rx"termination-decision" tl-content)
+               "termination-decision should be removed (replaced by decide-next-action)"))

--- a/tools/middleware.rkt
+++ b/tools/middleware.rkt
@@ -15,11 +15,7 @@
 ;;       (make-block-middleware block-fn)))
 ;;   (pipeline tool-call exec-ctx base-executor)
 
-(require (only-in "../util/protocol-types.rkt"
-                  tool-call?
-                  tool-call-name
-                  tool-call-arguments
-                  tool-call-id))
+(require (only-in "../util/protocol-types.rkt" tool-call? tool-call-name tool-call-arguments))
 
 ;; ============================================================
 ;; Middleware type
@@ -43,9 +39,7 @@
 (define (compose-middleware . middlewares)
   (lambda (tool-call exec-ctx base-executor)
     (define pipeline
-      (foldr (lambda (mw next-executor)
-               (lambda (tc ctx)
-                 (mw tc ctx next-executor)))
+      (foldr (lambda (mw next-executor) (lambda (tc ctx) (mw tc ctx next-executor)))
              base-executor
              middlewares))
     (pipeline tool-call exec-ctx)))
@@ -61,17 +55,18 @@
   (lambda (tc exec-ctx next)
     (define hook-result
       (and hook-dispatcher
-           (with-handlers ([exn:fail? (lambda (e)
-                                        (hasheq 'status 'error
-                                                'error-message (format "hook error: ~a" (exn-message e))))])
+           (with-handlers
+               ([exn:fail?
+                 (lambda (e)
+                   (hasheq 'status 'error 'error-message (format "hook error: ~a" (exn-message e))))])
              (hook-dispatcher phase tc))))
     (cond
-      [(and (hash? hook-result) (eq? (hash-ref hook-result 'status #f) 'error))
-       hook-result]
+      [(and (hash? hook-result) (eq? (hash-ref hook-result 'status #f) 'error)) hook-result]
       [(and (hash? hook-result) (eq? (hash-ref hook-result 'action #f) 'block))
-       (hasheq 'status 'blocked
-               'error-message (format "tool call '~a' blocked by ~a hook"
-                                      (tool-call-name tc) phase))]
+       (hasheq 'status
+               'blocked
+               'error-message
+               (format "tool call '~a' blocked by ~a hook" (tool-call-name tc) phase))]
       [(and (hash? hook-result) (eq? (hash-ref hook-result 'action #f) 'amend))
        (next (hash-ref hook-result 'payload tc) exec-ctx)]
       [else (next tc exec-ctx)])))
@@ -82,8 +77,7 @@
     (define name (tool-call-name tc))
     (cond
       [(and (safe-mode?) (not (allowed-tool? name)))
-       (hasheq 'status 'blocked
-               'error-message (format "tool '~a' blocked by safe-mode" name))]
+       (hasheq 'status 'blocked 'error-message (format "tool '~a' blocked by safe-mode" name))]
       [else (next tc exec-ctx)])))
 
 ;; Middleware that validates tool arguments against a schema.
@@ -92,8 +86,7 @@
     (define t (lookup-fn (tool-call-name tc)))
     (cond
       [(not t)
-       (hasheq 'status 'error
-               'error-message (format "unknown tool: '~a'" (tool-call-name tc)))]
+       (hasheq 'status 'error 'error-message (format "unknown tool: '~a'" (tool-call-name tc)))]
       [else
        (define validation-result
          (with-handlers ([exn:fail? (lambda (e) e)])
@@ -101,8 +94,7 @@
            #f))
        (if (not validation-result)
            (next tc exec-ctx)
-           (hasheq 'status 'error
-                   'error-message (format "~a" (exn-message validation-result))))])))
+           (hasheq 'status 'error 'error-message (format "~a" (exn-message validation-result))))])))
 
 ;; Middleware that checks a permission gate.
 (define (make-permission-middleware permission-check)
@@ -111,17 +103,17 @@
     (cond
       [(eq? check-result 'allowed) (next tc exec-ctx)]
       [(eq? check-result 'blocked)
-       (hasheq 'status 'blocked
-               'error-message (format "tool '~a' blocked by permission gate"
-                                      (tool-call-name tc)))]
+       (hasheq 'status
+               'blocked
+               'error-message
+               (format "tool '~a' blocked by permission gate" (tool-call-name tc)))]
       [else (next tc exec-ctx)])))
 
 ;; Middleware that queues mutations for sequential execution.
 (define (make-mutation-queue-middleware is-mutation? enqueue!)
   (lambda (tc exec-ctx next)
     (cond
-      [(is-mutation? (tool-call-name tc))
-       (enqueue! tc exec-ctx next)]
+      [(is-mutation? (tool-call-name tc)) (enqueue! tc exec-ctx next)]
       [else (next tc exec-ctx)])))
 
 ;; ============================================================
@@ -130,21 +122,19 @@
 
 ;; Build a standard tool execution pipeline with all built-in middleware.
 ;; Returns a procedure: (tool-call exec-ctx base-executor) → result
-(define (make-default-pipeline
-         #:hook-dispatcher [hook-dispatcher #f]
-         #:safe-mode? [safe-mode? (lambda () #f)]
-         #:allowed-tool? [allowed-tool? (lambda (_) #t)]
-         #:validate-fn [validate-fn (lambda (t args) (void))]
-         #:lookup-fn [lookup-fn (lambda (_) #f)]
-         #:permission-check [permission-check (lambda (_) 'allowed)]
-         #:is-mutation? [is-mutation? (lambda (_) #f)]
-         #:enqueue! [enqueue! (lambda (tc ctx next) (next tc ctx))])
-  (compose-middleware
-   (make-hook-middleware hook-dispatcher 'preflight)
-   (make-safe-mode-middleware safe-mode? allowed-tool?)
-   (make-validation-middleware validate-fn lookup-fn)
-   (make-permission-middleware permission-check)
-   (make-mutation-queue-middleware is-mutation? enqueue!)))
+(define (make-default-pipeline #:hook-dispatcher [hook-dispatcher #f]
+                               #:safe-mode? [safe-mode? (lambda () #f)]
+                               #:allowed-tool? [allowed-tool? (lambda (_) #t)]
+                               #:validate-fn [validate-fn (lambda (t args) (void))]
+                               #:lookup-fn [lookup-fn (lambda (_) #f)]
+                               #:permission-check [permission-check (lambda (_) 'allowed)]
+                               #:is-mutation? [is-mutation? (lambda (_) #f)]
+                               #:enqueue! [enqueue! (lambda (tc ctx next) (next tc ctx))])
+  (compose-middleware (make-hook-middleware hook-dispatcher 'preflight)
+                      (make-safe-mode-middleware safe-mode? allowed-tool?)
+                      (make-validation-middleware validate-fn lookup-fn)
+                      (make-permission-middleware permission-check)
+                      (make-mutation-queue-middleware is-mutation? enqueue!)))
 
 ;; ============================================================
 ;; Provide


### PR DESCRIPTION
Addresses #3559.

feat: remove dead termination-decision + cleanup GSD locking + middleware import (#3559)

- Remove termination-decision from transition-logic.rkt (replaced by decide-next-action)
- Document GSD two-level locking pattern (outer sem for compound ops, inner for individual)
- Remove dead get-workflow/set-workflow actions from GSD closure
- Remove unused tool-call-id import from middleware.rkt
- All existing tests pass