### PR TITLE
refactor: wire handle-hook-result + tighten contracts + document deferred (#3591)

- Extend handle-hook-result with #:on-amend keyword for amend handling
- Replace 2 inline block patterns in loop-stream.rkt with handle-hook-result calls
- Consolidate amend+block handling in build-stream-result via box + #:on-amend
- Tighten handle-tool-calls-pending contract: list? → (listof message?), any/c → (or/c tool-registry? #f)
- Import tool-registry? in tool-coordinator.rkt for tighter contracts
- Add NOTE comments on deferred components (process-chunk, make-default-pipeline)
- Add DEPRECATED note on session-bytes-written parameter (v0.30.x removal)
- All key tests pass, 17/17 lint checks pass

### DIFF
--- a/agent/loop-messages.rkt
+++ b/agent/loop-messages.rkt
@@ -181,10 +181,14 @@
 ;; Match-based hook dispatch (v0.29.1: §10 Match Dispatch)
 ;; ============================================================
 
-(define (handle-hook-result result on-block on-continue)
+(define (handle-hook-result result on-block on-continue #:on-amend [on-amend #f])
   (cond
     [(not (hook-result? result)) (on-continue)]
     [else
      (match (hook-result-action result)
        ['block (on-block (hook-result-payload result))]
+       ['amend
+        (if on-amend
+            (on-amend (hook-result-payload result))
+            (on-continue))]
        [_ (on-continue)])]))

--- a/agent/loop-stream.rkt
+++ b/agent/loop-stream.rkt
@@ -104,6 +104,10 @@
          stream-accumulator-finish-reason
          stream-accumulator-done?
          make-empty-accumulator
+         ;; NOTE (v0.29.11): process-chunk and stream-accumulator are provided for
+         ;; future use but have 0 production callers. process-chunk is blocked by
+         ;; mutable streaming-message vs immutable stream-accumulator gap.
+         ;; Deferred to v0.30.x — see AUDIT-v0.29.10 for details.
          process-chunk)
 
 ;; ============================================================
@@ -220,8 +224,9 @@
                                          (stream-chunk-delta-text chunk)
                                          'delta-tool-call
                                          #f)))
-              (when (and (hook-result? update-result) (eq? (hook-result-action update-result) 'block))
-                (streaming-message-set-blocked! sm))))
+              (handle-hook-result update-result
+                                  (lambda (payload) (streaming-message-set-blocked! sm))
+                                  void)))
           ;; FEAT-72: Thinking/reasoning delta
           (when (stream-chunk-delta-thinking chunk)
             (streaming-message-append-thinking! sm (stream-chunk-delta-thinking chunk))
@@ -253,8 +258,9 @@
                                          #f
                                          'delta-tool-call
                                          tc-delta)))
-              (when (and (hook-result? update-result) (eq? (hook-result-action update-result) 'block))
-                (streaming-message-set-blocked! sm))))
+              (handle-hook-result update-result
+                                  (lambda (payload) (streaming-message-set-blocked! sm))
+                                  void)))
           (when (stream-chunk-done? chunk)
             ;; v0.15.2: Mark that we received a normal done chunk
             (set-box! received-done? #t)
@@ -420,11 +426,8 @@
             (or effective-usage (hasheq))))
   (define msg-end-result (and hook-dispatcher (hook-dispatcher 'message-end msg-end-payload)))
 
-  ;; Handle message-end result -- hook-dispatcher returns (list action payload) or #f
-  (define final-text
-    (if (and (hook-result? msg-end-result) (eq? (hook-result-action msg-end-result) 'amend))
-        (hash-ref (hook-result-payload msg-end-result) 'content accumulated-text)
-        accumulated-text))
+  ;; Mutable text — may be amended by message-end hook
+  (define final-text-box (box accumulated-text))
 
   (handle-hook-result
    msg-end-result
@@ -440,6 +443,7 @@
                        'hook-blocked
                        (hasheq 'turnId turn-id 'hook 'message-end)))
    (lambda ()
+     (define final-text (unbox final-text-box))
      ;; Rebuild text-part with potentially amended content
      (define final-text-part (make-text-part final-text))
      (define final-content-parts (append (list final-text-part) tool-call-parts))
@@ -523,4 +527,6 @@
                                   'model
                                   "streamed"
                                   'toolCallCount
-                                  (length tool-call-parts)))]))))
+                                  (length tool-call-parts)))]))
+   #:on-amend (lambda (payload)
+                (set-box! final-text-box (hash-ref payload 'content accumulated-text)))))

--- a/runtime/tool-coordinator.rkt
+++ b/runtime/tool-coordinator.rkt
@@ -23,7 +23,7 @@
          racket/path
          json
          (only-in "../util/tool-types.rkt" tool-call?)
-         (only-in "../tools/tool.rkt" tool-result?)
+         (only-in "../tools/tool.rkt" tool-result? tool-registry?)
          (only-in "../util/json-helpers.rkt" ensure-hash-args)
          (only-in "../util/protocol-types.rkt"
                   message?
@@ -62,16 +62,16 @@
                        [make-tool-result-messages
                         (-> (listof tool-call?) (listof tool-result?) string? (listof message?))]
                        [handle-tool-calls-pending
-                        (-> list? ; new-msgs
+                        (-> (listof message?) ; new-msgs
                             list? ; ctx-with-steering
                             any/c ; ext-reg
-                            any/c ; reg
+                            (or/c tool-registry? #f) ; reg
                             any/c ; bus
                             string? ; session-id
                             (or/c path-string? path?) ; log-path
                             any/c ; token
                             hash? ; config
-                            list?)]))
+                            (listof message?))]))
 
 ;; ============================================================
 ;; Helpers (QUAL-01: emit-session-event! and maybe-dispatch-hooks

--- a/tools/builtins/write.rkt
+++ b/tools/builtins/write.rkt
@@ -31,7 +31,8 @@
 
 ;; Track cumulative bytes written in current session.
 ;; v0.29.9: Migrated from make-parameter+box to exec-context field.
-;; Legacy parameter retained for backward compat (tests, direct calls without exec-ctx).
+;; v0.29.11: Parameter retained for backward compat (tests, direct calls without exec-ctx).
+;; DEPRECATED: Will be removed in v0.30.x when all callers provide exec-ctx.
 (define session-bytes-written (make-parameter (box 0)))
 
 (define (init-session-writes!)

--- a/tools/middleware.rkt
+++ b/tools/middleware.rkt
@@ -146,4 +146,7 @@
          make-validation-middleware
          make-permission-middleware
          make-mutation-queue-middleware
+         ;; NOTE (v0.29.11): make-default-pipeline has 0 production callers.
+         ;; Not wired into existing scheduler — provides composable pipeline for future use.
+         ;; Deferred to v0.30.x — see AUDIT-v0.29.10 for details.
          make-default-pipeline)


### PR DESCRIPTION
Addresses #3591.

refactor: wire handle-hook-result + tighten contracts + document deferred (#3591)

- Extend handle-hook-result with #:on-amend keyword for amend handling
- Replace 2 inline block patterns in loop-stream.rkt with handle-hook-result calls
- Consolidate amend+block handling in build-stream-result via box + #:on-amend
- Tighten handle-tool-calls-pending contract: list? → (listof message?), any/c → (or/c tool-registry? #f)
- Import tool-registry? in tool-coordinator.rkt for tighter contracts
- Add NOTE comments on deferred components (process-chunk, make-default-pipeline)
- Add DEPRECATED note on session-bytes-written parameter (v0.30.x removal)
- All key tests pass, 17/17 lint checks pass