### PR TITLE
fix: handle-hook-result amend regression + widen 3 contracts (#3596)

Wave 0 of v0.29.12 — Test Health Restoration.

- Fix handle-hook-result #:on-amend to call on-continue after side effect
  (was returning void, breaking test-hooks-complete — NEW regression)
- Widen lookup-tool contract to accept (or/c string? #f)
  (fixes test-soft-iteration contract violation)
- Widen make-model-request settings type to Option (HashTable Symbol Any)
  (fixes test-provider-settings-wiring TR violation)
- Widen model-response usage type to Option (HashTable Symbol Any)
  (fixes test-self-hosting-workflow TR violation)

All 4 previously failing test files now pass:
- test-hooks-complete: 29/29 (was 28/29 + 1 error)
- test-soft-iteration: 4/4 (was 3 errors)
- test-provider-settings-wiring: 10/10 (was 1 failure)
- test-self-hosting-workflow: 20/20 (was 1 failure)

### DIFF
--- a/agent/loop-messages.rkt
+++ b/agent/loop-messages.rkt
@@ -188,7 +188,7 @@
      (match (hook-result-action result)
        ['block (on-block (hook-result-payload result))]
        ['amend
-        (if on-amend
-            (on-amend (hook-result-payload result))
-            (on-continue))]
+        (when on-amend
+          (on-amend (hook-result-payload result)))
+        (on-continue)]
        [_ (on-continue)])]))

--- a/llm/model.rkt
+++ b/llm/model.rkt
@@ -31,10 +31,11 @@
 
 (struct model-request
         ([messages : (Listof Any)] [tools : (Option (Listof Any))]
-                                   [settings : (HashTable Symbol Any)])
+                                   [settings : (Option (HashTable Symbol Any))])
   #:transparent)
 
-(: make-model-request ((Listof Any) (Option (Listof Any)) (HashTable Symbol Any) -> model-request))
+(: make-model-request
+   ((Listof Any) (Option (Listof Any)) (Option (HashTable Symbol Any)) -> model-request))
 (define (make-model-request messages tools settings)
   (model-request messages tools settings))
 
@@ -43,7 +44,10 @@
   (define h
     :
     (HashTable Symbol Any)
-    (hasheq 'messages (model-request-messages req) 'settings (model-request-settings req)))
+    (hasheq 'messages
+            (model-request-messages req)
+            'settings
+            (or (model-request-settings req) (hasheq))))
   (if (model-request-tools req)
       (hash-set h 'tools (model-request-tools req))
       h))
@@ -59,12 +63,13 @@
 ;; ============================================================
 
 (struct model-response
-        ([content : (Listof Any)] [usage : (HashTable Symbol Any)]
+        ([content : (Listof Any)] [usage : (Option (HashTable Symbol Any))]
                                   [model : String]
                                   [stop-reason : (U Symbol #f)])
   #:transparent)
 
-(: make-model-response ((Listof Any) (HashTable Symbol Any) String (U Symbol #f) -> model-response))
+(: make-model-response
+   ((Listof Any) (Option (HashTable Symbol Any)) String (U Symbol #f) -> model-response))
 (define (make-model-response content usage model stop-reason)
   (model-response content usage model stop-reason))
 
@@ -73,7 +78,7 @@
   (hasheq 'content
           (model-response-content resp)
           'usage
-          (model-response-usage resp)
+          (or (model-response-usage resp) (hasheq))
           'model
           (model-response-model resp)
           'stopReason
@@ -85,7 +90,7 @@
 (: jsexpr->model-response ((HashTable Symbol Any) -> model-response))
 (define (jsexpr->model-response h)
   (make-model-response (cast (hash-ref h 'content) (Listof Any))
-                       (cast (hash-ref h 'usage) (HashTable Symbol Any))
+                       (cast (hash-ref h 'usage #f) (HashTable Symbol Any))
                        (cast (hash-ref h 'model) String)
                        (let ([sr (hash-ref h 'stopReason #f)])
                          (if sr

--- a/tools/tool.rkt
+++ b/tools/tool.rkt
@@ -114,7 +114,7 @@
          tool-registry?
          (contract-out [register-tool! (-> tool-registry? tool? void?)]
                        [unregister-tool! (-> tool-registry? string? void?)]
-                       [lookup-tool (-> tool-registry? string? (or/c tool? #f))]
+                       [lookup-tool (-> tool-registry? (or/c string? #f) (or/c tool? #f))]
                        [list-tools (-> tool-registry? (listof tool?))]
                        [tool->jsexpr (-> tool? hash?)])
          set-active-tools!
@@ -333,7 +333,9 @@
   (with-registry-lock reg (lambda () (hash-remove! (tool-registry-tools-box reg) name))))
 
 (define (lookup-tool reg name)
-  (with-registry-lock reg (lambda () (hash-ref (tool-registry-tools-box reg) name #f))))
+  (if (not name)
+      #f
+      (with-registry-lock reg (lambda () (hash-ref (tool-registry-tools-box reg) name #f)))))
 
 ;; tool->jsexpr : tool? -> hash?
 ;; Serialize a tool struct to the OpenAI normalized format.


### PR DESCRIPTION
Addresses #3596.

fix: handle-hook-result amend regression + widen 3 contracts (#3596)

Wave 0 of v0.29.12 — Test Health Restoration.

- Fix handle-hook-result #:on-amend to call on-continue after side effect
  (was returning void, breaking test-hooks-complete — NEW regression)
- Widen lookup-tool contract to accept (or/c string? #f)
  (fixes test-soft-iteration contract violation)
- Widen make-model-request settings type to Option (HashTable Symbol Any)
  (fixes test-provider-settings-wiring TR violation)
- Widen model-response usage type to Option (HashTable Symbol Any)
  (fixes test-self-hosting-workflow TR violation)

All 4 previously failing test files now pass:
- test-hooks-complete: 29/29 (was 28/29 + 1 error)
- test-soft-iteration: 4/4 (was 3 errors)
- test-provider-settings-wiring: 10/10 (was 1 failure)
- test-self-hosting-workflow: 20/20 (was 1 failure)