### PR TITLE
feat: v0.29.13 W2 — typed event adoption + error types + SDK contracts (#3618)

### DIFF
--- a/interfaces/sdk-compat.rkt
+++ b/interfaces/sdk-compat.rkt
@@ -28,7 +28,6 @@
          (only-in "../extensions/gsd/runtime-state-types.rkt" gsd-runtime-state-mode)
          (prefix-in store: "../runtime/session-store.rkt")
          "../agent/event-bus.rkt"
-         "../util/cancellation.rkt"
          ;; Core SDK types
          "sdk-core.rkt")
 

--- a/interfaces/sdk-core.rkt
+++ b/interfaces/sdk-core.rkt
@@ -63,11 +63,9 @@
          (struct-out runtime)
          runtime?
 
-         ;; Cancellation token
-         make-cancellation-token
+         cancel-token!
          cancellation-token?
          cancellation-token-cancelled?
-         cancel-token!
 
          ;; Core API
          (contract-out [make-runtime
@@ -87,6 +85,9 @@
                              runtime?)]
                        [open-session (->* (runtime?) ((or/c string? #f)) runtime?)]
                        [run-prompt! (runtime? string? . -> . (values runtime? any/c))]
+                       [make-cancellation-token
+                        (->* () (#:callback (or/c (-> any/c any/c) #f)) cancellation-token?)]
+                       [make-in-memory-session-manager (-> in-memory-session-manager?)]
                        [subscribe-events!
                         (->* (runtime? procedure?) ((or/c procedure? #f)) exact-nonnegative-integer?)]
                        [interrupt! (runtime? . -> . runtime?)]
@@ -108,7 +109,6 @@
          navigate-result?
 
          ;; In-memory session manager (GC-18)
-         make-in-memory-session-manager
          in-memory-session-manager?
          in-memory-append!
          in-memory-append-entries!

--- a/runtime/agent-session.rkt
+++ b/runtime/agent-session.rkt
@@ -25,6 +25,7 @@
          racket/file
          racket/list
          racket/path
+         (only-in "../util/errors.rkt" raise-session-error)
          (only-in "../util/protocol-types.rkt" message-id message-kind make-loop-result)
          "../agent/queue.rkt"
          "../agent/event-bus.rkt"
@@ -256,8 +257,8 @@
 
 (define (fork-session sess [parent-entry-id #f])
   (unless (session-active? sess)
-    (raise (exn:fail (format "fork-session: session ~a is closed" (agent-session-session-id sess))
-                     (current-continuation-marks))))
+    (raise-session-error (format "fork-session: session ~a is closed" (agent-session-session-id sess))
+                         (agent-session-session-id sess)))
   (let* ([ext-reg (agent-session-extension-registry sess)]
          [fork-payload (hasheq 'session-id
                                (agent-session-session-id sess)

--- a/runtime/session-lifecycle.rkt
+++ b/runtime/session-lifecycle.rkt
@@ -31,6 +31,7 @@
                   make-loop-result)
          "../agent/event-bus.rkt"
          (only-in "../util/hook-types.rkt" hook-result-action hook-result-payload)
+         (only-in "../util/errors.rkt" raise-session-error)
          "../runtime/session-store.rkt"
          "../runtime/session-index.rkt"
          (only-in "../extensions/message-inject.rkt" injection-event-topic)
@@ -327,17 +328,17 @@
   (define ba! (or buffer-or-append!-fn buffer-or-append!))
   ;; B4: Guard — refuse operations on closed sessions
   (unless (agent-session-active? sess)
-    (raise (exn:fail (format "run-prompt!: session ~a is closed" (agent-session-session-id sess))
-                     (current-continuation-marks))))
+    (raise-session-error (format "run-prompt!: session ~a is closed" (agent-session-session-id sess))
+                         (agent-session-session-id sess)))
   ;; Guard against concurrent prompt execution
   (when (agent-session-prompt-running? sess)
     (emit-session-event! (agent-session-event-bus sess)
                          (agent-session-session-id sess)
                          "runtime.error"
                          (hasheq 'error "Prompt already running — ignoring concurrent submission"))
-    (raise (exn:fail (format "run-prompt!: session ~a already has a prompt running"
-                             (agent-session-session-id sess))
-                     (current-continuation-marks))))
+    (raise-session-error (format "run-prompt!: session ~a already has a prompt running"
+                                 (agent-session-session-id sess))
+                         (agent-session-session-id sess)))
   (set-agent-session-prompt-running?! sess #t)
   (define bus (agent-session-event-bus sess))
   (define sid (agent-session-session-id sess))

--- a/runtime/session-switch.rkt
+++ b/runtime/session-switch.rkt
@@ -18,6 +18,8 @@
          racket/match
          racket/runtime-path
          "../agent/event-bus.rkt"
+         "../agent/event-emitter.rkt"
+         "../agent/event-structs/session-events.rkt"
          "../util/protocol-types.rkt")
 
 ;; #704: Teardown
@@ -112,13 +114,12 @@
                     extension-registry))
   ;; Publish session.shutdown event
   (when bus
-    (define evt
-      (make-event "session.shutdown"
-                  (current-seconds)
-                  session-id
-                  #f
-                  (hasheq 'session-id session-id 'duration duration)))
-    (publish! bus evt)))
+    (emit-typed-event! bus
+                       (make-session-shutdown-event
+                        #:session-id session-id
+                        #:timestamp (current-seconds)
+                        #:turn-id #f
+                        #:reason (hasheq 'session-id session-id 'duration duration)))))
 
 ;; Full teardown: emit shutdown + close old session extensions.
 (define (teardown-session-extensions! old-session-id
@@ -198,7 +199,11 @@
               prev-id
               'session-dir
               session-dir))
-    (publish! bus (make-event "session.started" (current-seconds) session-id #f payload))))
+    (emit-typed-event! bus
+                       (make-session-start-event #:session-id session-id
+                                                 #:timestamp (current-seconds)
+                                                 #:turn-id #f
+                                                 #:model payload))))
 
 ;; ============================================================
 ;; #707: Full atomic session switch lifecycle

--- a/runtime/turn-orchestrator.rkt
+++ b/runtime/turn-orchestrator.rkt
@@ -23,6 +23,7 @@
          racket/promise
          json
          (only-in racket/string string-contains?)
+         (only-in "../util/errors.rkt" raise-extension-error)
          (only-in "../util/json-helpers.rkt" ensure-hash-args)
          (only-in "../util/protocol-types.rkt"
                   message?
@@ -126,7 +127,7 @@
   ;; Handle block action from context-assembly hook
   (when (and assembly-hook-result (eq? (hook-result-action assembly-hook-result) 'block))
     (emit-session-event! bus session-id "context.assembly.blocked" (hasheq 'reason "extension-block"))
-    (raise (exn:fail "Context assembly blocked by extension" (current-continuation-marks))))
+    (raise-extension-error "Context assembly blocked by extension" "unknown" "turn-start"))
 
   (define ctx-assembled (tiered-context->message-list tc))
 

--- a/scripts/lint-ivg.rkt
+++ b/scripts/lint-ivg.rkt
@@ -83,7 +83,12 @@
    (list "session-bytes-written-deprecated"
          (lambda ()
            (>= (grep-count "DEPRECATED.*session-bytes-written" "tools/builtins/write.rkt") 1))
-         "session-bytes-written missing DEPRECATED comment")))
+         "session-bytes-written missing DEPRECATED comment")
+   ;; v0.29.13 W2: session-switch must use emit-typed-event! (not raw make-event)
+   (list "session-switch-typed-events"
+         (lambda ()
+           (>= (grep-count "emit-typed-event!" "runtime/session-switch.rkt") 2))
+         "session-switch.rkt must use emit-typed-event! (≥2 calls)")))
 
 ;; ── Runner ──
 

--- a/tests/test-context-fit.rkt
+++ b/tests/test-context-fit.rkt
@@ -1,0 +1,22 @@
+#lang racket
+
+;; tests/test-context-fit.rkt — W2-D3: Test scaffold for runtime/context-fit.rkt
+;; v0.29.13: Smoke tests for message truncation within token budgets.
+
+(require rackunit
+         "../runtime/context-fit.rkt"
+         "../util/protocol-types.rkt")
+
+(test-case "truncate-messages-to-budget returns empty for empty input"
+  (check-equal? (truncate-messages-to-budget '() 1000) '()))
+
+(test-case "truncate-messages-to-budget keeps messages within budget"
+  (define msgs (for/list ([i (in-range 10)])
+                 (make-message (number->string i) #f 'user 'text
+                               (list (make-text-part (make-string 50 #\a)))
+                               i (hasheq))))
+  (define result (truncate-messages-to-budget msgs 200))
+  (check-true (<= (length result) 10)))
+
+(test-case "fit-messages-from-recent returns empty for empty input"
+  (check-equal? (fit-messages-from-recent '() 1000) '()))

--- a/tests/test-event-json.rkt
+++ b/tests/test-event-json.rkt
@@ -1,0 +1,37 @@
+#lang racket
+
+;; tests/test-event-json.rkt — W2-D1: Test scaffold for agent/event-json.rkt
+;; v0.29.13: Round-trip smoke tests for typed event JSON serialization.
+
+(require rackunit
+         "../agent/event-json.rkt"
+         "../agent/event-structs/base.rkt"
+         "../agent/event-structs/session-events.rkt"
+         "../agent/event-structs/turn-events.rkt")
+
+(test-case "session-start-event round-trip"
+  (define evt (make-session-start-event #:session-id "test-sess"
+                                        #:timestamp 1000
+                                        #:turn-id #f
+                                        #:model (hasheq 'model "gpt-4")))
+  (define jx (typed-event->jsexpr evt))
+  (check-equal? (hash-ref jx 'type) "session-start")
+  (check-equal? (hash-ref jx 'sessionId) "test-sess")
+  (define restored (jsexpr->typed-event jx))
+  (check-true (session-start-event? restored))
+  (check-equal? (typed-event-session-id restored) "test-sess"))
+
+(test-case "session-shutdown-event round-trip"
+  (define evt (make-session-shutdown-event #:session-id "test-sess"
+                                           #:timestamp 2000
+                                           #:turn-id "t1"
+                                           #:reason "graceful"))
+  (define jx (typed-event->jsexpr evt))
+  (check-equal? (hash-ref jx 'type) "session-shutdown")
+  (define restored (jsexpr->typed-event jx))
+  (check-true (session-shutdown-event? restored)))
+
+(test-case "all-known-event-types is callable and returns a list"
+  (define types (all-known-event-types))
+  (check-true (list? types))
+  (check-true (> (length types) 0)))

--- a/tests/test-loop-messages.rkt
+++ b/tests/test-loop-messages.rkt
@@ -1,0 +1,21 @@
+#lang racket
+
+;; tests/test-loop-messages.rkt — W2-D2: Test scaffold for agent/loop-messages.rkt
+;; v0.29.13: Smoke tests for usage helpers and message utilities.
+
+(require rackunit
+         "../agent/loop-messages.rkt"
+         "../util/protocol-types.rkt")
+
+(test-case "usage-empty? returns #t for empty hash"
+  (check-true (usage-empty? (hasheq))))
+
+(test-case "usage-empty? returns #f for non-empty hash"
+  (check-false (usage-empty? (hasheq 'prompt_tokens 10 'completion_tokens 5))))
+
+(test-case "parts->text-string extracts text from text-parts"
+  (define parts (list (make-text-part "Hello ") (make-text-part "World")))
+  (check-equal? (parts->text-string parts) "Hello World"))
+
+(test-case "parts->text-string returns empty for empty list"
+  (check-equal? (parts->text-string '()) ""))

--- a/tests/test-session-controls.rkt
+++ b/tests/test-session-controls.rkt
@@ -1,0 +1,22 @@
+#lang racket
+
+;; tests/test-session-controls.rkt — W2-D4: Test scaffold for runtime/session-controls.rkt
+;; v0.29.13: Smoke tests for session control functions.
+
+(require rackunit
+         "../runtime/session-controls.rkt")
+
+(test-case "thinking-levels is a non-empty list of symbols"
+  (check-true (list? thinking-levels))
+  (check-true (> (length thinking-levels) 0))
+  (for ([level (in-list thinking-levels)])
+    (check-true (symbol? level))))
+
+(test-case "thinking-level? accepts valid levels"
+  (check-true (thinking-level? 'medium))
+  (check-true (thinking-level? 'high))
+  (check-true (thinking-level? 'off)))
+
+(test-case "thinking-level? rejects invalid levels"
+  (check-false (thinking-level? 'invalid))
+  (check-false (thinking-level? "medium")))

--- a/tests/test-session-store-integrity.rkt
+++ b/tests/test-session-store-integrity.rkt
@@ -1,0 +1,36 @@
+#lang racket
+
+;; tests/test-session-store-integrity.rkt — W2-D5: Test scaffold for runtime/session-store-integrity.rkt
+;; v0.29.13: Smoke tests for hash-chain creation and verification.
+
+(require rackunit
+         "../runtime/session-store-integrity.rkt")
+
+(test-case "GENESIS-HASH is a non-empty string"
+  (check-true (string? GENESIS-HASH))
+  (check-true (> (string-length GENESIS-HASH) 0)))
+
+(test-case "compute-event-hash returns a string"
+  (define entry (hasheq 'type "test" 'data "hello"))
+  (define h (compute-event-hash entry GENESIS-HASH))
+  (check-true (string? h))
+  (check-true (> (string-length h) 0)))
+
+(test-case "compute-event-hash is deterministic"
+  (define entry (hasheq 'type "test" 'data "hello"))
+  (define h1 (compute-event-hash entry GENESIS-HASH))
+  (define h2 (compute-event-hash entry GENESIS-HASH))
+  (check-equal? h1 h2))
+
+(test-case "compute-event-hash changes with different inputs"
+  (define entry1 (hasheq 'type "test" 'data "hello"))
+  (define entry2 (hasheq 'type "test" 'data "world"))
+  (define h1 (compute-event-hash entry1 GENESIS-HASH))
+  (define h2 (compute-event-hash entry2 GENESIS-HASH))
+  (check-not-equal? h1 h2))
+
+(test-case "canonical-jsexpr->string produces consistent output"
+  (define entry (hasheq 'a 1 'b 2))
+  (define s1 (canonical-jsexpr->string entry))
+  (define s2 (canonical-jsexpr->string entry))
+  (check-equal? s1 s2))


### PR DESCRIPTION
W2-A: Wire session typed events in session-switch.rkt\nW2-B: Migrate 4 bare exn:fail sites to domain errors\nW2-C: Tighten SDK contracts\nW2-D: Create 5 test scaffolds for uncovered modules