### PR TITLE
feat: v0.29.15 W0 — credential-error domain type + test

### DIFF
--- a/tests/test-errors.rkt
+++ b/tests/test-errors.rkt
@@ -104,10 +104,27 @@
             (raise-fn)))
         (check-pred exn:fail? e)))
 
+    ;; credential-error has backend and details
+    (test-case "credential-error has backend and details"
+      (define e
+        (with-handlers ([credential-error? identity])
+          (raise-credential-error "auth failed" "oauth" "token expired")))
+      (check-equal? (exn-message e) "auth failed")
+      (check-equal? (credential-error-backend e) "oauth")
+      (check-equal? (credential-error-details e) "token expired"))
+
+    ;; credential-error defaults details to #f
+    (test-case "credential-error defaults details to #f"
+      (define e
+        (with-handlers ([credential-error? identity])
+          (raise-credential-error "no key" "api-key")))
+      (check-equal? (credential-error-details e) #f))
+
     ;; New errors are q-error subtypes
     (test-case "new domain errors are q-error subtypes"
       (check-exn q-error? (lambda () (raise-ui-error "x" "c")))
       (check-exn q-error? (lambda () (raise-extension-error "x" "e" "h")))
-      (check-exn q-error? (lambda () (raise-policy-error "x" "p" "v"))))))
+      (check-exn q-error? (lambda () (raise-policy-error "x" "p" "v")))
+      (check-exn q-error? (lambda () (raise-credential-error "x" "b" "d"))))))
 
 (run-tests errors-tests 'verbose)

--- a/util/errors.rkt
+++ b/util/errors.rkt
@@ -17,12 +17,14 @@
          (struct-out ui-error)
          (struct-out extension-error)
          (struct-out policy-error)
+         (struct-out credential-error)
          raise-q-error
          raise-tool-error
          raise-session-error
          raise-ui-error
          raise-extension-error
          raise-policy-error
+         raise-credential-error
          ;; Quality macros (Q06/Q07)
          with-cleanup
          with-logged-catch)
@@ -48,6 +50,9 @@
 ;; GSD policy violation errors (blocked tools, budget exceeded)
 (struct policy-error q-error (policy-name violation) #:transparent)
 
+;; Credential/authentication errors (OAuth, API keys, backend auth)
+(struct credential-error q-error (backend details) #:transparent)
+
 ;; Convenience constructors
 (define (raise-q-error message [context (hash)])
   (raise (q-error message (current-continuation-marks) context)))
@@ -66,6 +71,9 @@
 
 (define (raise-policy-error message policy-name violation [context (hash)])
   (raise (policy-error message (current-continuation-marks) context policy-name violation)))
+
+(define (raise-credential-error message backend [details #f] [context (hash)])
+  (raise (credential-error message (current-continuation-marks) context backend details)))
 
 ;; ============================================================
 ;; Quality macros (Q06/Q07)


### PR DESCRIPTION
## v0.29.15 W0: New Error Type + Process Documentation

### Changes
- **util/errors.rkt**: Added `credential-error` struct (inherits from `q-error`) with `backend` and `details` fields. Added `raise-credential-error` constructor.
- **tests/test-errors.rkt**: Added 2 test cases for credential-error (construction with details, default #f).

### Verify
- `racket tests/test-errors.rkt` → 15/15 pass
- `raco make util/errors.rkt` → compile OK

Closes #3653