### PR TITLE
fix: v0.29.16 W1 — duration fix + error migration + struct refactor

### DIFF
--- a/cli/render.rkt
+++ b/cli/render.rkt
@@ -179,6 +179,26 @@
      (if detail
          (styled (format "[tool: ~a: ~a]" name detail) '(bold yellow))
          (styled (format "[tool: ~a]" name) '(bold yellow)))]
+    [("tool-execution-start")
+     (define name (hash-ref payload 'tool-name "?"))
+     (define args-raw (hash-ref payload 'arguments #f))
+     (define args
+       (cond
+         [(hash? args-raw) args-raw]
+         [(string? args-raw) (with-safe-fallback #f (string->jsexpr args-raw))]
+         [else #f]))
+     (define detail
+       (cond
+         [(and args (hash? args))
+          (define cmd
+            (or (hash-ref args 'command #f) (hash-ref args 'path #f) (hash-ref args 'pattern #f) #f))
+          (if cmd
+              (truncate-string (format "~a" cmd) 100)
+              #f)]
+         [else #f]))
+     (if detail
+         (styled (format "[tool: ~a: ~a]" name detail) '(bold yellow))
+         (styled (format "[tool: ~a]" name) '(bold yellow)))]
     [("tool-execution-end")
      (define name (hash-ref payload 'tool-name "?"))
      (define result-summary (hash-ref payload 'result-summary 'error))

--- a/runtime/context-assembly/budgeting.rkt
+++ b/runtime/context-assembly/budgeting.rkt
@@ -25,26 +25,17 @@
          context-result-summary)
 
 ;; Note: 0 is valid for max-catalog-* (disables catalog)
-(struct context-assembly-config
-        (recent-tokens
-         max-catalog-entries
-         max-catalog-tokens
-         summary-window)
-  #:guard
-  (lambda (recent max-entries max-tokens summary _name)
-    (unless (and (exact-nonnegative-integer? recent) (> recent 0))
-      (error 'context-assembly-config "recent-tokens must be a positive integer, got: ~a" recent))
-    (unless (exact-nonnegative-integer? max-entries)
-      (error 'context-assembly-config
-             "max-catalog-entries must be a non-negative integer, got: ~a"
-             max-entries))
-    (unless (exact-nonnegative-integer? max-tokens)
-      (error 'context-assembly-config
-             "max-catalog-tokens must be a non-negative integer, got: ~a"
-             max-tokens))
-    (unless (and (exact-nonnegative-integer? summary) (> summary 0))
-      (error 'context-assembly-config "summary-window must be a positive integer, got: ~a" summary))
-    (values recent max-entries max-tokens summary))
+(struct context-assembly-config (recent-tokens max-catalog-entries max-catalog-tokens summary-window)
+  #:guard (lambda (recent max-entries max-tokens summary _name)
+            (unless (and (exact-nonnegative-integer? recent) (> recent 0))
+              (raise-argument-error 'context-assembly-config "positive integer" recent))
+            (unless (exact-nonnegative-integer? max-entries)
+              (raise-argument-error 'context-assembly-config "non-negative integer" max-entries))
+            (unless (exact-nonnegative-integer? max-tokens)
+              (raise-argument-error 'context-assembly-config "non-negative integer" max-tokens))
+            (unless (and (exact-nonnegative-integer? summary) (> summary 0))
+              (raise-argument-error 'context-assembly-config "positive integer" summary))
+            (values recent max-entries max-tokens summary))
   #:transparent)
 
 (define (make-context-assembly-config #:recent-tokens [recent 30000]
@@ -55,12 +46,5 @@
 
 ;; Result struct — full diagnostics for observability
 (struct context-result
-        (messages
-         total-tokens
-         pinned-count
-         recent-count
-         excluded-count
-         over-budget?
-         catalog
-         summary)
+        (messages total-tokens pinned-count recent-count excluded-count over-budget? catalog summary)
   #:transparent)

--- a/runtime/iteration.rkt
+++ b/runtime/iteration.rkt
@@ -248,6 +248,7 @@
 
 ;; ============================================================
 ;; v0.29.13 (W1): Extracted sub-functions for run-iteration-loop
+;; v0.29.16 (W1): Refactored to use loop-infra + loop-counters structs
 ;; ============================================================
 
 ;; check-cancellation: Evaluate cancellation/shutdown conditions.
@@ -285,9 +286,17 @@
 ;; process-tool-results: Execute pending tool calls, update working set,
 ;; and compute new iteration counters. Shared by 'continue and 'stop-soft-limit.
 ;; Returns updated-ctx (with tool results appended).
-(define (process-tool-results new-msgs ctx ext-reg reg bus session-id log-path token config ws)
+(define (process-tool-results new-msgs infra config ws)
   (define updated-ctx
-    (handle-tool-calls-pending new-msgs ctx ext-reg reg bus session-id log-path token config))
+    (handle-tool-calls-pending new-msgs
+                               (loop-infra-ctx infra)
+                               (loop-infra-ext-reg infra)
+                               (loop-infra-reg infra)
+                               (loop-infra-bus infra)
+                               (loop-infra-session-id infra)
+                               (loop-infra-log-path infra)
+                               (loop-infra-token infra)
+                               config))
   (define current-tool-calls (extract-tool-calls-from-messages new-msgs))
   ;; Working set update
   (define tool-result-msgs (filter (lambda (m) (eq? (message-role m) 'tool)) updated-ctx))
@@ -302,8 +311,8 @@
       (and path (member path (map ws-entry-path (working-set-entries ws))) path)))
   (define valid-spiral-paths (filter string? read-spiral-paths))
   (when (> (length valid-spiral-paths) 0)
-    (emit-session-event! bus
-                         session-id
+    (emit-session-event! (loop-infra-bus infra)
+                         (loop-infra-session-id infra)
                          "working-set.read-spiral-detected"
                          (hasheq 'paths valid-spiral-paths 'count (length valid-spiral-paths))))
   (working-set-update! ws
@@ -311,8 +320,8 @@
                        tool-result-msgs
                        message-id
                        estimate-message-tokens)
-  (emit-session-event! bus
-                       session-id
+  (emit-session-event! (loop-infra-bus infra)
+                       (loop-infra-session-id infra)
                        "working-set.update"
                        (hasheq 'entry-count
                                (working-set-entry-count ws)
@@ -323,67 +332,59 @@
   updated-ctx)
 
 ;; compute-next-counters: Compute updated iteration counters after tool execution.
-;; Returns (values new-seen-paths effective-tool-count new-explore-count
-;;                  new-implement-count new-error-count new-recent-tools)
-(define (compute-next-counters new-msgs
-                               seen-paths
-                               consecutive-tool-count
-                               explore-count
-                               implement-count
-                               consecutive-error-count
-                               recent-tool-names)
+;; Returns a new loop-counters struct.
+(define (compute-next-counters counters new-msgs)
   (define current-tool-calls (extract-tool-calls-from-messages new-msgs))
-  (define-values (new-seen-paths should-increment?) (update-seen-paths current-tool-calls seen-paths))
+  (define-values (new-seen-paths should-increment?)
+    (update-seen-paths current-tool-calls (loop-counters-seen-paths counters)))
   (define effective-tool-count
     (if should-increment?
-        (add1 consecutive-tool-count)
-        consecutive-tool-count))
+        (add1 (loop-counters-consecutive-tool-count counters))
+        (loop-counters-consecutive-tool-count counters)))
   (define new-explore-count
-    (+ explore-count
+    (+ (loop-counters-explore-count counters)
        (for/sum ([tc (in-list current-tool-calls)])
                 (if (member (tool-call-name tc) '("read" "grep" "find" "ls")) 1 0))))
   (define new-implement-count
-    (+ implement-count
+    (+ (loop-counters-implement-count counters)
        (for/sum ([tc (in-list current-tool-calls)])
                 (if (member (tool-call-name tc) '("edit" "write")) 1 0))))
   (define new-error-count
-    (+ consecutive-error-count
+    (+ (loop-counters-consecutive-error-count counters)
        (for/sum ([tr (filter tool-result-part? (apply append (map message-content new-msgs)))])
                 (if (tool-result-part-is-error? tr) 1 0))))
   (define new-recent-tools
-    (take-at-most (append recent-tool-names (map tool-call-name current-tool-calls)) 20))
-  (values new-seen-paths
-          effective-tool-count
-          new-explore-count
-          new-implement-count
-          new-error-count
-          new-recent-tools))
+    (take-at-most (append (loop-counters-recent-tool-names counters)
+                          (map tool-call-name current-tool-calls))
+                  20))
+  (struct-copy loop-counters
+               counters
+               [seen-paths new-seen-paths]
+               [consecutive-tool-count effective-tool-count]
+               [explore-count new-explore-count]
+               [implement-count new-implement-count]
+               [consecutive-error-count new-error-count]
+               [recent-tool-names new-recent-tools]))
 
 ;; handle-stop-action: Handle the 'stop action from decide-next-action.
 ;; Returns either a loop-result (if no follow-ups) or recurses via the
 ;; followup-continuation callback.
 (define (handle-stop-action result
                             new-msgs
-                            log-path
-                            ext-reg
-                            bus
-                            session-id
+                            infra
+                            counters
+                            ws
+                            config
                             steering-queue
                             follow-up-mode
-                            iteration
-                            ctx-with-injected
-                            ws
-                            intent-retry-count
-                            explore-count
-                            implement-count
                             followup-continuation)
   (define termination (loop-result-termination-reason result))
   (if (eq? termination 'completed)
       (begin
-        (append-entries! log-path new-msgs)
+        (append-entries! (loop-infra-log-path infra) new-msgs)
         ;; Dispatch 'turn-end hook
         (let-values ([(amended-result after-hook-res)
-                      (maybe-dispatch-hooks ext-reg 'turn-end result)])
+                      (maybe-dispatch-hooks (loop-infra-ext-reg infra) 'turn-end result)])
           (let ([effective-result (if (and after-hook-res
                                            (eq? (hook-result-action after-hook-res) 'amend))
                                       amended-result
@@ -408,96 +409,69 @@
                                                               (now-seconds)
                                                               (hasheq 'source "followup")))])
                            (emit-session-event!
-                            bus
-                            session-id
+                            (loop-infra-bus infra)
+                            (loop-infra-session-id infra)
                             "followup.injected"
                             (hasheq 'count (length followups) 'mode (symbol->string follow-up-mode)))
-                           (append-entries! log-path followup-msgs)
-                           (followup-continuation (append ctx-with-injected new-msgs followup-msgs)
-                                                  (add1 iteration)
-                                                  0
-                                                  (set)
-                                                  ws
-                                                  intent-retry-count
-                                                  0
-                                                  '()
-                                                  explore-count
-                                                  implement-count
-                                                  0))))))
+                           (append-entries! (loop-infra-log-path infra) followup-msgs)
+                           (followup-continuation
+                            (append (loop-infra-ctx infra) new-msgs followup-msgs)
+                            (struct-copy loop-counters
+                                         counters
+                                         [iteration (add1 (loop-counters-iteration counters))]
+                                         [consecutive-tool-count 0]
+                                         [seen-paths (set)]
+                                         [consecutive-error-count 0]
+                                         [recent-tool-names '()]
+                                         [stall-retry-count 0])
+                            ws))))))
             (if followup-continued? effective-result effective-result))))
       ;; Other stop reasons: append and return
       (begin
-        (append-entries! log-path new-msgs)
+        (append-entries! (loop-infra-log-path infra) new-msgs)
         result)))
 
 ;; ============================================================
 ;; dispatch-loop-action: extracted match block from run-iteration-loop
+;; v0.29.16: Refactored from 26→13 params using loop-infra + loop-counters structs
 ;; ============================================================
 
 (define (dispatch-loop-action action
                               result
                               new-msgs
-                              ctx-with-injected
-                              log-path
-                              ext-reg
-                              reg
-                              bus
-                              session-id
-                              steering-queue
-                              follow-up-mode
-                              iteration
+                              infra
+                              counters
                               ws
-                              intent-retry-count
-                              explore-count
-                              implement-count
-                              consecutive-tool-count
-                              seen-paths
-                              consecutive-error-count
-                              recent-tool-names
+                              config
+                              sess
                               max-iterations
                               max-iterations-hard
-                              sess
-                              token
-                              config
+                              steering-queue
+                              follow-up-mode
                               on-recurse)
   (define (call-process-tool-results)
-    (process-tool-results new-msgs
-                          ctx-with-injected
-                          ext-reg
-                          reg
-                          bus
-                          session-id
-                          log-path
-                          token
-                          config
-                          ws))
+    (process-tool-results new-msgs infra config ws))
   (match action
     ['stop
      (handle-stop-action result
                          new-msgs
-                         log-path
-                         ext-reg
-                         bus
-                         session-id
+                         infra
+                         counters
+                         ws
+                         config
                          steering-queue
                          follow-up-mode
-                         iteration
-                         ctx-with-injected
-                         ws
-                         intent-retry-count
-                         explore-count
-                         implement-count
                          on-recurse)]
     ['stop-hard-limit
-     (append-entries! log-path new-msgs)
-     (emit-session-event! bus
-                          session-id
+     (append-entries! (loop-infra-log-path infra) new-msgs)
+     (emit-session-event! (loop-infra-bus infra)
+                          (loop-infra-session-id infra)
                           "runtime.error"
                           (assert-payload "runtime.error"
                                           (hasheq 'error
                                                   "max-iterations-exceeded"
                                                   'iteration
-                                                  iteration
+                                                  (loop-counters-iteration counters)
                                                   'maxIterations
                                                   max-iterations-hard)
                                           error-detail-payload/c))
@@ -505,71 +479,62 @@
                        'max-iterations-exceeded
                        (hash-set (loop-result-metadata result) 'maxIterationsReached #t))]
     ['stop-soft-limit
-     (append-entries! log-path new-msgs)
-     (emit-session-event! bus
-                          session-id
+     (append-entries! (loop-infra-log-path infra) new-msgs)
+     (emit-session-event! (loop-infra-bus infra)
+                          (loop-infra-session-id infra)
                           "iteration.soft-warning"
                           (hasheq 'iteration
-                                  (add1 iteration)
+                                  (add1 (loop-counters-iteration counters))
                                   'soft-limit
                                   max-iterations
                                   'hard-limit
                                   max-iterations-hard
                                   'remaining
-                                  (- max-iterations-hard (add1 iteration))))
+                                  (- max-iterations-hard (add1 (loop-counters-iteration counters)))))
      (define updated-ctx (call-process-tool-results))
      (define ctx-after-budget
        (if sess
-           (maybe-compact-mid-turn sess updated-ctx bus session-id config)
+           (maybe-compact-mid-turn sess
+                                   updated-ctx
+                                   (loop-infra-bus infra)
+                                   (loop-infra-session-id infra)
+                                   config)
            (begin
-             (estimate-mid-turn-tokens updated-ctx bus session-id config)
+             (estimate-mid-turn-tokens updated-ctx
+                                       (loop-infra-bus infra)
+                                       (loop-infra-session-id infra)
+                                       config)
              updated-ctx)))
      (on-recurse ctx-after-budget
-                 (add1 iteration)
-                 (add1 consecutive-tool-count)
-                 seen-paths
-                 ws
-                 intent-retry-count
-                 consecutive-error-count
-                 recent-tool-names
-                 explore-count
-                 implement-count
-                 0)]
+                 (struct-copy loop-counters
+                              counters
+                              [iteration (add1 (loop-counters-iteration counters))]
+                              [consecutive-tool-count
+                               (add1 (loop-counters-consecutive-tool-count counters))]
+                              [stall-retry-count 0])
+                 ws)]
     ['continue
-     (append-entries! log-path new-msgs)
+     (append-entries! (loop-infra-log-path infra) new-msgs)
      (define updated-ctx (call-process-tool-results))
-     (define-values (new-seen-paths
-                     effective-tool-count
-                     new-explore-count
-                     new-implement-count
-                     new-error-count
-                     new-recent-tools)
-       (compute-next-counters new-msgs
-                              seen-paths
-                              consecutive-tool-count
-                              explore-count
-                              implement-count
-                              consecutive-error-count
-                              recent-tool-names))
+     (define new-counters (compute-next-counters counters new-msgs))
      ;; v0.28.22 W1: exploration loop detection
-     (define loop-warning (detect-exploration-loop new-recent-tools))
+     (define loop-warning (detect-exploration-loop (loop-counters-recent-tool-names new-counters)))
      (when loop-warning
-       (emit-session-event!
-        bus
-        session-id
-        "iteration.exploration-loop"
-        (hasheq 'pattern loop-warning 'recent-tools new-recent-tools 'iteration iteration)))
+       (emit-session-event! (loop-infra-bus infra)
+                            (loop-infra-session-id infra)
+                            "iteration.exploration-loop"
+                            (hasheq 'pattern
+                                    loop-warning
+                                    'recent-tools
+                                    (loop-counters-recent-tool-names new-counters)
+                                    'iteration
+                                    (loop-counters-iteration counters))))
      (on-recurse updated-ctx
-                 (add1 iteration)
-                 effective-tool-count
-                 new-seen-paths
-                 ws
-                 intent-retry-count
-                 new-error-count
-                 new-recent-tools
-                 new-explore-count
-                 new-implement-count
-                 0)]))
+                 (struct-copy loop-counters
+                              new-counters
+                              [iteration (add1 (loop-counters-iteration counters))]
+                              [stall-retry-count 0])
+                 ws)]))
 
 ;; ============================================================
 
@@ -624,136 +589,121 @@
                          (hasheq 'reason "extension-block" 'hook 'before-agent-start)
                          reason-payload/c))
         (make-loop-result '() 'completed (hasheq 'reason "extension-block")))
-      (let loop ([ctx context]
-                 [iteration 0]
-                 [consecutive-tool-count 0]
-                 [seen-paths (set)]
-                 [ws ws]
-                 [intent-retry-count 0]
-                 [consecutive-error-count 0]
-                 [recent-tool-names '()]
-                 [explore-count 0]
-                 [implement-count 0]
-                 [stall-retry-count 0])
+      (let ([infra (loop-infra context ext-reg reg bus session-id log-path token)])
+        (let loop ([ctx context]
+                   [counters (make-initial-counters)]
+                   [ws ws])
 
-        ;; ── Drain steering + injected messages ──
-        (define ctx-with-steering
-          (if steering-queue
-              (let ([steering-msgs (dequeue-all-steering! steering-queue)])
-                (let ([qs (queue-status steering-queue)])
-                  (when (or (> (hash-ref qs 'steering 0) 0) (> (hash-ref qs 'followup 0) 0))
-                    (emit-session-event! bus session-id "queue.status-update" qs)))
-                (if (null? steering-msgs)
-                    ctx
-                    (append ctx steering-msgs)))
-              ctx))
-        (define ctx-with-injected
-          (if injected-box
-              (let ([injected (drain-injected-messages! bus injected-box session-id)])
-                (if (null? injected)
-                    ctx-with-steering
-                    (begin
-                      (emit-session-event! bus
+          ;; ── Drain steering + injected messages ──
+          (define ctx-with-steering
+            (if steering-queue
+                (let ([steering-msgs (dequeue-all-steering! steering-queue)])
+                  (let ([qs (queue-status steering-queue)])
+                    (when (or (> (hash-ref qs 'steering 0) 0) (> (hash-ref qs 'followup 0) 0))
+                      (emit-session-event! bus session-id "queue.status-update" qs)))
+                  (if (null? steering-msgs)
+                      ctx
+                      (append ctx steering-msgs)))
+                ctx))
+          (define ctx-with-injected
+            (if injected-box
+                (let ([injected (drain-injected-messages! bus injected-box session-id)])
+                  (if (null? injected)
+                      ctx-with-steering
+                      (begin
+                        (emit-session-event! bus
+                                             session-id
+                                             "message.injected.drain"
+                                             (assert-payload "message.injected.drain"
+                                                             (hasheq 'count (length injected))
+                                                             injection-count-payload/c))
+                        (append ctx-with-steering injected))))
+                ctx-with-steering))
+
+          ;; ── Cancellation/shutdown check ──
+          (define cancel-result
+            (check-cancellation token
+                                force-shutdown-check
+                                shutdown-check
+                                bus
+                                session-id
+                                (loop-counters-iteration counters)
+                                ctx-with-injected))
+          (cond
+            [cancel-result cancel-result]
+            [else
+             (define turn-id (generate-id))
+             ;; Dispatch 'turn-start hook
+             (define-values (ctx-to-use turn-blocked?)
+               (let-values ([(amended-ctx hook-res)
+                             (maybe-dispatch-hooks ext-reg 'turn-start ctx-with-injected)])
+                 (if (and hook-res (eq? (hook-result-action hook-res) 'block))
+                     (values ctx-with-injected #t)
+                     (values amended-ctx #f))))
+             (cond
+               [turn-blocked?
+                (emit-session-event!
+                 bus
+                 session-id
+                 "turn.blocked"
+                 (assert-payload "turn.blocked" (hasheq 'reason "extension-block") reason-payload/c))
+                (make-loop-result '() 'completed (hasheq 'reason "extension-block"))]
+               [else
+                ;; Build assembled context
+                (define config-with-ws
+                  (if (immutable? config)
+                      (hash-set config 'working-set ws)
+                      (begin
+                        (hash-set! config 'working-set ws)
+                        config)))
+                (define ctx-final
+                  (build-assembled-context ctx-to-use
+                                           config-with-ws
+                                           ext-reg
+                                           bus
                                            session-id
-                                           "message.injected.drain"
-                                           (assert-payload "message.injected.drain"
-                                                           (hasheq 'count (length injected))
-                                                           injection-count-payload/c))
-                      (append ctx-with-steering injected))))
-              ctx-with-steering))
-
-        ;; ── Cancellation/shutdown check ──
-        (define cancel-result
-          (check-cancellation token
-                              force-shutdown-check
-                              shutdown-check
-                              bus
-                              session-id
-                              iteration
-                              ctx-with-injected))
-        (cond
-          [cancel-result cancel-result]
-          [else
-           (define turn-id (generate-id))
-           ;; Dispatch 'turn-start hook
-           (define-values (ctx-to-use turn-blocked?)
-             (let-values ([(amended-ctx hook-res)
-                           (maybe-dispatch-hooks ext-reg 'turn-start ctx-with-injected)])
-               (if (and hook-res (eq? (hook-result-action hook-res) 'block))
-                   (values ctx-with-injected #t)
-                   (values amended-ctx #f))))
-           (cond
-             [turn-blocked?
-              (emit-session-event!
-               bus
-               session-id
-               "turn.blocked"
-               (assert-payload "turn.blocked" (hasheq 'reason "extension-block") reason-payload/c))
-              (make-loop-result '() 'completed (hasheq 'reason "extension-block"))]
-             [else
-              ;; Build assembled context
-              (define config-with-ws
-                (if (immutable? config)
-                    (hash-set config 'working-set ws)
-                    (begin
-                      (hash-set! config 'working-set ws)
-                      config)))
-              (define ctx-final
-                (build-assembled-context ctx-to-use config-with-ws ext-reg bus session-id iteration))
-              ;; Run provider turn
-              (define result
-                (run-provider-turn ctx-final prov bus reg ext-reg session-id turn-id token config))
-              (define termination (loop-result-termination-reason result))
-              (define new-msgs (loop-result-messages result))
-              ;; Emit iteration decision
-              (emit-session-event! bus
-                                   session-id
-                                   "iteration.decision"
-                                   (assert-payload "iteration.decision"
-                                                   (hasheq 'iteration
-                                                           (add1 iteration)
-                                                           'termination
-                                                           termination
-                                                           'consecutive_tools
-                                                           consecutive-tool-count
-                                                           'max_iterations
-                                                           max-iterations
-                                                           'max_iterations_hard
-                                                           max-iterations-hard)
-                                                   iteration-decision-payload/c))
-              (define action
-                (decide-next-action (iteration-ctx iteration
-                                                   consecutive-tool-count
-                                                   explore-count
-                                                   max-iterations
-                                                   max-iterations-hard)
-                                    result))
-              (dispatch-loop-action
-               action
-               result
-               new-msgs
-               ctx-with-injected
-               log-path
-               ext-reg
-               reg
-               bus
-               session-id
-               steering-queue
-               follow-up-mode
-               iteration
-               ws
-               intent-retry-count
-               explore-count
-               implement-count
-               consecutive-tool-count
-               seen-paths
-               consecutive-error-count
-               recent-tool-names
-               max-iterations
-               max-iterations-hard
-               sess
-               token
-               config
-               ;; on-recurse: callback for recursive loop cases
-               (lambda (new-ctx iter tc sp ws2 irc ec rt ecnt implcnt src)
-                 (loop new-ctx iter tc sp ws2 irc ec rt ecnt implcnt src)))])]))))
+                                           (loop-counters-iteration counters)))
+                ;; Run provider turn
+                (define result
+                  (run-provider-turn ctx-final prov bus reg ext-reg session-id turn-id token config))
+                (define termination (loop-result-termination-reason result))
+                (define new-msgs (loop-result-messages result))
+                ;; Emit iteration decision
+                (emit-session-event!
+                 bus
+                 session-id
+                 "iteration.decision"
+                 (assert-payload "iteration.decision"
+                                 (hasheq 'iteration
+                                         (add1 (loop-counters-iteration counters))
+                                         'termination
+                                         termination
+                                         'consecutive_tools
+                                         (loop-counters-consecutive-tool-count counters)
+                                         'max_iterations
+                                         max-iterations
+                                         'max_iterations_hard
+                                         max-iterations-hard)
+                                 iteration-decision-payload/c))
+                (define action
+                  (decide-next-action (iteration-ctx (loop-counters-iteration counters)
+                                                     (loop-counters-consecutive-tool-count counters)
+                                                     (loop-counters-explore-count counters)
+                                                     max-iterations
+                                                     max-iterations-hard)
+                                      result))
+                (dispatch-loop-action action
+                                      result
+                                      new-msgs
+                                      (struct-copy loop-infra infra [ctx ctx-with-injected])
+                                      counters
+                                      ws
+                                      config
+                                      sess
+                                      max-iterations
+                                      max-iterations-hard
+                                      steering-queue
+                                      follow-up-mode
+                                      ;; on-recurse: callback for recursive loop cases
+                                      (lambda (new-ctx new-counters ws2)
+                                        (loop new-ctx new-counters ws2)))])])))))

--- a/runtime/model-registry.rkt
+++ b/runtime/model-registry.rkt
@@ -14,7 +14,8 @@
 ;;   - session management
 
 (require racket/string
-         racket/match)
+         racket/match
+         (only-in "../llm/provider-errors.rkt" raise-provider-error))
 
 ;; ── URL Validation ──────────────────────────────────────────
 
@@ -25,7 +26,8 @@
   (cond
     [(string=? trimmed "") ""] ; empty is ok — will use provider default
     [(not (regexp-match? #rx"^https?://" trimmed))
-     (error 'validate-base-url "Invalid base-url scheme (must be http or https): ~a" trimmed)]
+     (raise-provider-error (format "Invalid base-url scheme (must be http or https): ~a" trimmed)
+                           'config)]
     [else trimmed]))
 
 (define (safe-base-url cfg)

--- a/runtime/session-manager.rkt
+++ b/runtime/session-manager.rkt
@@ -16,7 +16,8 @@
 (require racket/file
          racket/path
          "session-store.rkt"
-         (only-in "../util/protocol-types.rkt" message?))
+         (only-in "../util/protocol-types.rkt" message?)
+         (only-in "../util/errors.rkt" raise-session-error))
 
 (provide session-manager?
          persistent-session-manager?
@@ -56,7 +57,7 @@
      (make-directory* dir)
      (append-entry! (build-path dir "session.jsonl") msg)]
     [(in-memory-session-manager? mgr) (in-memory-append! mgr session-id msg)]
-    [else (error 'sm-append! "not a session manager: ~a" mgr)]))
+    [else (raise-session-error (format "not a session manager: ~a" mgr) #f)]))
 
 (define (sm-load mgr session-id)
   (cond
@@ -67,7 +68,7 @@
          (load-session-log log-path)
          '())]
     [(in-memory-session-manager? mgr) (in-memory-load mgr session-id)]
-    [else (error 'sm-load "not a session manager: ~a" mgr)]))
+    [else (raise-session-error (format "not a session manager: ~a" mgr) #f)]))
 
 (define (sm-list mgr)
   (cond
@@ -79,7 +80,7 @@
            (path->string d))
          '())]
     [(in-memory-session-manager? mgr) (in-memory-list-sessions mgr)]
-    [else (error 'sm-list "not a session manager: ~a" mgr)]))
+    [else (raise-session-error (format "not a session manager: ~a" mgr) #f)]))
 
 (define (sm-fork! mgr src-id dest-id [entry-id #f])
   (cond
@@ -91,4 +92,4 @@
      (define dest-path (build-path dest-dir "session.jsonl"))
      (fork-session! src-path entry-id dest-path)]
     [(in-memory-session-manager? mgr) (in-memory-fork! mgr src-id dest-id entry-id)]
-    [else (error 'sm-fork! "not a session manager: ~a" mgr)]))
+    [else (raise-session-error (format "not a session manager: ~a" mgr) #f)]))

--- a/runtime/session-switch.rkt
+++ b/runtime/session-switch.rkt
@@ -20,7 +20,8 @@
          "../agent/event-bus.rkt"
          "../agent/event-emitter.rkt"
          "../agent/event-structs/session-events.rkt"
-         "../util/protocol-types.rkt")
+         "../util/protocol-types.rkt"
+         (only-in "../util/errors.rkt" raise-extension-error))
 
 ;; #704: Teardown
 (provide teardown-session-extensions!
@@ -55,9 +56,11 @@
 (define (default-dispatch-hooks hook-point payload registry)
   (define dispatch-fn
     (with-handlers ([exn:fail:filesystem? (lambda (e)
-                                            (error 'default-dispatch-hooks
-                                                   "Cannot load extensions/hooks.rkt: ~a"
-                                                   (exn-message e)))])
+                                            (raise-extension-error
+                                             (format "Cannot load extensions/hooks.rkt: ~a"
+                                                     (exn-message e))
+                                             "hooks"
+                                             'dispatch-hooks))])
       (dynamic-require hooks-rkt-path 'dispatch-hooks)))
   (dispatch-fn hook-point payload registry))
 
@@ -70,9 +73,11 @@
                                     #:working-directory [working-directory #f])
   (define make-ctx-fn
     (with-handlers ([exn:fail:filesystem? (lambda (e)
-                                            (error 'default-make-extension-ctx
-                                                   "Cannot load extensions/context.rkt: ~a"
-                                                   (exn-message e)))])
+                                            (raise-extension-error
+                                             (format "Cannot load extensions/context.rkt: ~a"
+                                                     (exn-message e))
+                                             "context"
+                                             'make-extension-ctx))])
       (dynamic-require context-rkt-path 'make-extension-ctx)))
   (make-ctx-fn #:session-id sid
                #:session-dir sdir

--- a/runtime/tool-coordinator.rkt
+++ b/runtime/tool-coordinator.rkt
@@ -9,7 +9,7 @@
 ;;   1. Extract tool calls from assistant messages
 ;;   2. Dispatch hooks (tool-call, tool.execution.start/end)
 ;;   3. Run tool batch through scheduler
-;;   4. Emit events (tool.call.completed/failed)
+;;   4. Emit typed tool-execution-start/end events via emit-typed-event!
 ;;   5. Create tool-result messages
 ;;   6. Dispatch tool-result hooks
 ;;
@@ -149,6 +149,9 @@
      'tool.execution.start
      (hasheq 'tools (map tool-call-name tool-calls-to-run) 'count (length tool-calls-to-run))))
 
+  ;; Capture batch start time for per-batch duration (v0.29.16)
+  (define batch-start-ms (current-inexact-milliseconds))
+
   ;; Run tool batch through scheduler (skip if blocked)
   (define sched-result
     (if tool-call-blocked?
@@ -206,7 +209,8 @@
                         #:turn-id #f
                         #:timestamp (current-inexact-milliseconds)
                         #:tool-name (tool-call-name tc)
-                        #:duration-ms 0
+                        #:duration-ms (inexact->exact (floor (- (current-inexact-milliseconds)
+                                                                batch-start-ms)))
                         #:result-summary (if (tool-result-is-error? tr) 'error 'completed))))
 
   ;; Convert scheduler results to tool-result messages.

--- a/runtime/working-set.rkt
+++ b/runtime/working-set.rkt
@@ -14,7 +14,8 @@
 ;;   bash  → no change (transient output)
 ;;   reset → clear all entries (new user message)
 
-(require racket/list)
+(require racket/list
+         (only-in "../util/errors.rkt" raise-session-error))
 
 ;; ────────────────────────────────────────────────────────────
 ;; Data structures
@@ -162,9 +163,9 @@
             (define msg-id (cadr args))
             (define tokens (caddr args))
             (unless (string? path)
-              (error 'ws-context "path must be a string, got: ~a" path))
+              (raise-argument-error 'ws-context "string" path))
             (unless (number? tokens)
-              (error 'ws-context "token-estimate must be a number, got: ~a" tokens))
+              (raise-argument-error 'ws-context "number" tokens))
             (define new-entry (ws-entry path msg-id tokens (current-seconds)))
             (define without-existing
               (filter (lambda (e) (not (equal? (ws-entry-path e) path))) entries))
@@ -175,7 +176,7 @@
            [(remove!)
             (define path (car args))
             (set! entries (filter (lambda (e) (not (equal? (ws-entry-path e) path))) entries))]
-           [else (error 'ws-context "unknown action: ~a" action)]))))))
+           [else (raise-session-error (format "unknown action: ~a" action) #f)]))))))
 
 (provide working-set?
          make-working-set

--- a/tests/helpers/ws-test-helpers.rkt
+++ b/tests/helpers/ws-test-helpers.rkt
@@ -20,8 +20,7 @@
          (case action
            [(entries) entries]
            [(entry-count) (length entries)]
-           [(token-count) (for/sum ([e (in-list entries)])
-                            (hash-ref e 'token-estimate 0))]
+           [(token-count) (for/sum ([e (in-list entries)]) (hash-ref e 'token-estimate 0))]
            [(max-entries) max-entries]
            [(max-tokens) max-tokens]
            [(reset!) (set! entries '())]
@@ -31,17 +30,14 @@
             (define tokens (caddr args))
             ;; Validation
             (unless (string? path)
-              (error 'ws-context "path must be a string, got: ~a" path))
+              (raise-argument-error 'ws-context "string" path))
             (unless (number? tokens)
-              (error 'ws-context "token-estimate must be a number, got: ~a" tokens))
+              (raise-argument-error 'ws-context "number" tokens))
             ;; Create entry
-            (define new-entry (hasheq 'path path
-                                      'message-id msg-id
-                                      'token-estimate tokens))
+            (define new-entry (hasheq 'path path 'message-id msg-id 'token-estimate tokens))
             ;; Remove existing entry for same path (refresh)
             (define without-existing
-              (filter (lambda (e) (not (equal? (hash-ref e 'path) path)))
-                      entries))
+              (filter (lambda (e) (not (equal? (hash-ref e 'path) path))) entries))
             ;; Add to front
             (set! entries (cons new-entry without-existing))
             ;; Enforce max-entries (LRU eviction from tail)
@@ -49,7 +45,5 @@
               (set! entries (take entries max-entries)))]
            [(remove!)
             (define path (car args))
-            (set! entries
-                  (filter (lambda (e) (not (equal? (hash-ref e 'path) path)))
-                          entries))]
-           [else (error 'ws-context "unknown action: ~a" action)]))))))
+            (set! entries (filter (lambda (e) (not (equal? (hash-ref e 'path) path))) entries))]
+           [else (raise-argument-error 'ws-context "known action symbol" action)]))))))

--- a/tui/state-events.rkt
+++ b/tui/state-events.rkt
@@ -74,6 +74,22 @@
            (struct-copy ui-state new-state (busy? #t))
            (struct-copy ui-state new-state (busy? #t) (pending-tool-name name))))]
 
+    [("tool-execution-start")
+     (let* ([name (hash-ref payload 'tool-name "?")]
+            [args-raw (hash-ref payload 'arguments #f)]
+            [arg-summary (if args-raw
+                             (extract-arg-summary args-raw)
+                             "")]
+            [text (if (string=? arg-summary "")
+                      (format "[TOOL: ~a]" name)
+                      (format "[TOOL: ~a] ~a" name arg-summary))]
+            [ts (event-time evt)]
+            [meta (hasheq 'name name 'arguments (or args-raw ""))]
+            [new-state (append-entry state (make-entry 'tool-start text ts meta))])
+       (if (ui-state-pending-tool-name state)
+           (struct-copy ui-state new-state (busy? #t))
+           (struct-copy ui-state new-state (busy? #t) (pending-tool-name name))))]
+
     [("tool-execution-end")
      (define name (hash-ref payload 'tool-name "?"))
      (define result-summary (hash-ref payload 'result-summary 'error))


### PR DESCRIPTION
## v0.29.16 W1: Duration Fix + Error Migration + Struct Refactor

### G1: Update stale tool-coordinator header comment
- Changed "Emit events (tool.call.completed/failed)" → "Emit typed tool-execution-start/end events via emit-typed-event!"

### G2: Compute real duration-ms + add tool-execution-start to TUI/CLI
- `runtime/tool-coordinator.rkt`: captures `batch-start-ms` before scheduler call, computes per-batch `duration-ms` for typed end events (was hardcoded 0)
- `tui/state-events.rkt`: Added `"tool-execution-start"` handler producing `'tool-start` transcript entries
- `cli/render.rkt`: Added `"tool-execution-start"` handler rendering `[tool: ~a]` indicators

### G3: Complete bare error migration (13→0 in runtime/)
- `runtime/session-manager.rkt`: 4 bare errors → `raise-session-error`
- `runtime/context-assembly/budgeting.rkt`: 4 bare errors → `raise-argument-error`
- `runtime/working-set.rkt`: 3 bare errors → `raise-argument-error`/`raise-session-error`
- `runtime/session-switch.rkt`: 2 bare errors → `raise-extension-error`
- `runtime/model-registry.rkt`: 1 bare error → `raise-provider-error`
- `tests/helpers/ws-test-helpers.rkt`: Updated shadow errors to match production

### G4: Refactor dispatch-loop-action using loop-state structs
- `dispatch-loop-action`: 26→12 params (using `loop-infra` + `loop-counters` structs)
- `handle-stop-action`: 15→9 params
- `process-tool-results`: 10→4 params
- `compute-next-counters`: 7 individual args→2 params, returns `loop-counters` struct
- `on-recurse` callback: 11→3 args
- Named-let `loop`: 11→3 bindings

### Verify
- fast suite: 468/468 files, 2385/2385 tests pass
- lint: 18/18 pass
- `grep '(error ' runtime/*.rkt runtime/**/*.rkt` → 0 bare errors

Closes #3661