### PR TITLE
test: v0.29.17 W0 — integration tests for struct refactor + duration-ms

### DIFF
--- a/runtime/iteration.rkt
+++ b/runtime/iteration.rkt
@@ -707,3 +707,16 @@
                                       ;; on-recurse: callback for recursive loop cases
                                       (lambda (new-ctx new-counters ws2)
                                         (loop new-ctx new-counters ws2)))])])))))
+
+;; ============================================================
+;; for-testing submodule: expose internals for unit testing
+;; v0.29.17 W0: exposed to support integration tests for struct refactor
+;; ============================================================
+(module+ for-testing
+  (provide dispatch-loop-action
+           handle-stop-action
+           compute-next-counters
+           process-tool-results
+           decide-next-action
+           check-cancellation
+           iteration-ctx))

--- a/tests/test-iteration-integration.rkt
+++ b/tests/test-iteration-integration.rkt
@@ -1,0 +1,112 @@
+#lang racket/base
+
+;; tests/test-iteration-integration.rkt — integration tests for struct refactor
+;; v0.29.17 W0: Tests for dispatch-loop-action internals via (module+ for-testing)
+
+(require rackunit
+         racket/set
+         (submod "../runtime/iteration.rkt" for-testing)
+         (only-in "../runtime/iteration/loop-state.rkt"
+                  make-initial-counters
+                  loop-infra
+                  loop-counters
+                  loop-counters-iteration
+                  loop-counters-consecutive-tool-count
+                  loop-counters-seen-paths
+                  loop-counters-explore-count
+                  loop-counters-implement-count
+                  loop-counters-consecutive-error-count
+                  loop-counters-recent-tool-names)
+         (only-in "../util/protocol-types.rkt"
+                  make-message
+                  make-text-part
+                  make-tool-result-part
+                  make-tool-call-part
+                  message-role
+                  message-content
+                  tool-result-part-is-error?)
+         (only-in "../util/loop-result.rkt"
+                  make-loop-result)
+         (only-in "../util/ids.rkt" generate-id)
+         "../agent/event-bus.rkt"
+         "../runtime/working-set.rkt")
+
+;; ============================================================
+;; Helpers
+;; ============================================================
+
+(define (make-mock-infra)
+  (loop-infra '() #f #f (make-event-bus) "test-session" "/tmp/test.log" #f))
+
+(define (make-msg-with-tool-call name args)
+  (make-message (generate-id)
+                #f
+                'assistant
+                'text
+                (list (make-tool-call-part (generate-id) name args))
+                1000
+                (hasheq)))
+
+(define (make-msg-with-tool-result text is-error?)
+  (make-message (generate-id)
+                #f
+                'tool
+                'tool-result
+                (list (make-tool-result-part (generate-id) text is-error?))
+                1000
+                (hasheq)))
+
+;; ============================================================
+;; compute-next-counters tests
+;; ============================================================
+
+(test-case "compute-next-counters: read-only tools increment explore-count"
+  (define counters (make-initial-counters))
+  (define msgs (list (make-msg-with-tool-call "read" (hasheq 'path "/tmp/x.rkt"))))
+  (define new-counters (compute-next-counters counters msgs))
+  (check-equal? (loop-counters-explore-count new-counters) 1)
+  (check-equal? (loop-counters-implement-count new-counters) 0)
+  (check-true (set-member? (loop-counters-seen-paths new-counters) "/tmp/x.rkt")))
+
+(test-case "compute-next-counters: edit/write tools increment implement-count"
+  (define counters (make-initial-counters))
+  (define msgs (list (make-msg-with-tool-call "edit" (hasheq 'path "/tmp/x.rkt"))))
+  (define new-counters (compute-next-counters counters msgs))
+  (check-equal? (loop-counters-implement-count new-counters) 1)
+  (check-equal? (loop-counters-explore-count new-counters) 0))
+
+(test-case "compute-next-counters: tool errors increment consecutive-error-count"
+  (define counters (make-initial-counters))
+  (define msgs (list (make-msg-with-tool-result "error" #t)))
+  (define new-counters (compute-next-counters counters msgs))
+  (check-equal? (loop-counters-consecutive-error-count new-counters) 1))
+
+(test-case "compute-next-counters: consecutive-tool-count increments on new path"
+  (define counters (make-initial-counters))
+  (define msgs (list (make-msg-with-tool-call "read" (hasheq 'path "/tmp/a.rkt"))))
+  (define new-counters (compute-next-counters counters msgs))
+  (check-equal? (loop-counters-consecutive-tool-count new-counters) 1))
+
+;; ============================================================
+;; decide-next-action tests
+;; ============================================================
+
+(test-case "decide-next-action: soft-limit when iteration >= max"
+  (define ctx (iteration-ctx 5 0 0 5 10))
+  (define result (make-loop-result '() 'tool-calls-pending (hasheq)))
+  (check-equal? (decide-next-action ctx result) 'stop-soft-limit))
+
+(test-case "decide-next-action: hard-limit when iteration >= hard-max"
+  (define ctx (iteration-ctx 10 0 0 5 10))
+  (define result (make-loop-result '() 'tool-calls-pending (hasheq)))
+  (check-equal? (decide-next-action ctx result) 'stop-hard-limit))
+
+(test-case "decide-next-action: continue when under limits"
+  (define ctx (iteration-ctx 3 0 0 5 10))
+  (define result (make-loop-result '() 'tool-calls-pending (hasheq)))
+  (check-equal? (decide-next-action ctx result) 'continue))
+
+(test-case "decide-next-action: stop on completed termination"
+  (define ctx (iteration-ctx 3 0 0 5 10))
+  (define result (make-loop-result '() 'completed (hasheq)))
+  (check-equal? (decide-next-action ctx result) 'stop))

--- a/tests/test-tool-coordinator-duration.rkt
+++ b/tests/test-tool-coordinator-duration.rkt
@@ -1,0 +1,101 @@
+#lang racket/base
+
+;; tests/test-tool-coordinator-duration.rkt — duration-ms accuracy tests
+;; v0.29.17 W0: Verify tool-execution-end-event duration-ms is non-zero and
+;; correlates with wall-clock time.
+
+(require rackunit
+         racket/list
+         (only-in "../runtime/tool-coordinator.rkt"
+                  handle-tool-calls-pending)
+         (only-in "../tools/tool.rkt"
+                  make-tool
+                  make-tool-registry
+                  register-tool!
+                  make-success-result)
+         (only-in "../util/protocol-types.rkt"
+                  make-message
+                  make-tool-call-part)
+         (only-in "../util/ids.rkt" generate-id)
+         (only-in "../util/event.rkt" event-event event-payload)
+         "../agent/event-bus.rkt")
+
+;; ============================================================
+;; Helpers
+;; ============================================================
+
+(define (make-sleep-tool ms)
+  (make-tool "sleep"
+             "Sleep for testing"
+             (hasheq 'type "object"
+                     'properties (hasheq 'ms (hasheq 'type "integer"))
+                     'required '("ms"))
+             (lambda (args _ctx)
+               (define delay-ms (hash-ref args 'ms 0))
+               (sleep (/ delay-ms 1000.0))
+               (make-success-result (format "slept ~a ms" delay-ms)))))
+
+(define (make-assistant-msg-with-sleep ms)
+  (make-message (generate-id)
+                #f
+                'assistant
+                'text
+                (list (make-tool-call-part (generate-id) "sleep" (hasheq 'ms ms)))
+                1000
+                (hasheq)))
+
+;; ============================================================
+;; duration-ms tests
+;; ============================================================
+
+(test-case "duration-ms is non-zero after tool execution"
+  (define bus (make-event-bus))
+  (define reg (make-tool-registry))
+  (register-tool! reg (make-sleep-tool 50))
+  (define collected-durations (box '()))
+  (subscribe! bus (lambda (evt)
+                    (when (equal? (event-event evt) "tool-execution-end")
+                      (define payload (event-payload evt))
+                      (set-box! collected-durations
+                                (cons (hash-ref payload 'duration-ms 0)
+                                      (unbox collected-durations))))))
+  (define new-msgs (list (make-assistant-msg-with-sleep 50)))
+  (handle-tool-calls-pending new-msgs
+                             '()
+                             #f
+                             reg
+                             bus
+                             "test-session"
+                             "/tmp/test.log"
+                             #f
+                             (hash))
+  (define durations (unbox collected-durations))
+  (check-equal? (length durations) 1)
+  (check-true (> (car durations) 0)))
+
+(test-case "duration-ms correlates with wall time (±200ms tolerance)"
+  (define bus (make-event-bus))
+  (define reg (make-tool-registry))
+  (register-tool! reg (make-sleep-tool 80))
+  (define collected-durations (box '()))
+  (subscribe! bus (lambda (evt)
+                    (when (equal? (event-event evt) "tool-execution-end")
+                      (define payload (event-payload evt))
+                      (set-box! collected-durations
+                                (cons (hash-ref payload 'duration-ms 0)
+                                      (unbox collected-durations))))))
+  (define new-msgs (list (make-assistant-msg-with-sleep 80)))
+  (handle-tool-calls-pending new-msgs
+                             '()
+                             #f
+                             reg
+                             bus
+                             "test-session"
+                             "/tmp/test.log"
+                             #f
+                             (hash))
+  (define durations (unbox collected-durations))
+  (check-equal? (length durations) 1)
+  (define dur (car durations))
+  (check-true (>= dur 40))
+  (check-true (<= dur 300)))


### PR DESCRIPTION
## v0.29.17 W0: Integration Tests for Struct Refactor + Duration-ms

### G3: Smoke tests for dispatch-loop-action struct integration
- Added `(module+ for-testing ...)` to `runtime/iteration.rkt` exposing internals: `dispatch-loop-action`, `handle-stop-action`, `compute-next-counters`, `process-tool-results`, `decide-next-action`, `check-cancellation`, `iteration-ctx`
- **New file:** `tests/test-iteration-integration.rkt` with 7 test cases:
  - `compute-next-counters`: read-only tools increment explore-count
  - `compute-next-counters`: edit/write tools increment implement-count
  - `compute-next-counters`: tool errors increment consecutive-error-count
  - `compute-next-counters`: consecutive-tool-count increments on new path
  - `decide-next-action`: soft-limit when iteration >= max
  - `decide-next-action`: hard-limit when iteration >= hard-max
  - `decide-next-action`: continue when under limits
  - `decide-next-action`: stop on completed termination

### G4: Test for duration-ms accuracy
- **New file:** `tests/test-tool-coordinator-duration.rkt` with 2 test cases:
  - `duration-ms` is non-zero after tool execution
  - `duration-ms` correlates with wall time (±200ms tolerance)
- Uses mock "sleep" tool (50ms/80ms) + event bus subscription

### Verify
- fast suite: 469/469 files, 2385/2385 tests pass
- Both new test files pass individually

Closes #3667