### PR TITLE
feat: v0.30.0 W0 — tighten any/c contracts in SDK core + event bus (#3672)

- Replace any/c with typed predicates in 4 files
- agent/event-bus.rkt: subscribe!/unsubscribe!/publish! contracts
- extensions/events.rkt: ext-publish! contract
- interfaces/sdk-core.rkt: make-runtime + run-prompt! contracts
- interfaces/sdk-public.rkt: publish! contract
- Add tests/test-sdk-contracts.rkt with 9 contract-blame tests

### DIFF
--- a/agent/event-bus.rkt
+++ b/agent/event-bus.rkt
@@ -13,14 +13,16 @@
 
 (require racket/contract
          "../util/protocol-types.rkt"
+         "../util/event.rkt"
          "event-types.rkt")
 
 ;; Pub/sub event bus
-(provide (contract-out [make-event-bus (-> event-bus?)]
-                       [subscribe!
-                        (->* (event-bus? procedure?) (#:filter (or/c procedure? #f)) any/c)]
-                       [unsubscribe! (-> event-bus? any/c void?)]
-                       [publish! (-> event-bus? any/c any/c)])
+(provide (contract-out
+          [make-event-bus (-> event-bus?)]
+          [subscribe!
+           (->* (event-bus? procedure?) (#:filter (or/c procedure? #f)) exact-nonnegative-integer?)]
+          [unsubscribe! (-> event-bus? exact-nonnegative-integer? void?)]
+          [publish! (-> event-bus? event? event?)])
          event-bus?
          bus-emit-typed!
          typed-event->event

--- a/extensions/events.rkt
+++ b/extensions/events.rkt
@@ -15,7 +15,8 @@
 
 (require racket/contract
          "api.rkt"
-         "../util/protocol-types.rkt")
+         "../util/protocol-types.rkt"
+         "../util/event.rkt")
 
 (define-logger ext-events)
 
@@ -23,7 +24,7 @@
                         (->* (event-bus? string? procedure?)
                              (#:filter (or/c procedure? #f))
                              exact-nonnegative-integer?)]
-                       [ext-publish! (-> event-bus? any/c any/c)]
+                       [ext-publish! (-> event-bus? event? event?)]
                        [ext-unsubscribe! (-> event-bus? string? exact-nonnegative-integer? void?)])
          ;; Bulk cleanup
          ext-unsubscribe-all!

--- a/interfaces/sdk-core.rkt
+++ b/interfaces/sdk-core.rkt
@@ -36,7 +36,7 @@
                   context-usage-usage-percent
                   context-usage-compaction-threshold
                   context-usage-near-threshold?)
-         (only-in "../extensions/api.rkt" list-extensions make-extension-registry)
+         (only-in "../extensions/api.rkt" list-extensions make-extension-registry extension-registry?)
          (only-in "../extensions/hooks.rkt"
                   dispatch-hooks
                   hook-result?
@@ -68,39 +68,39 @@
          cancellation-token-cancelled?
 
          ;; Core API
-         (contract-out [make-runtime
-                        (->* (#:provider any/c)
-                             (#:session-dir (or/c path-string? path? #f)
-                                            #:tool-registry any/c
-                                            #:extension-registry any/c
-                                            #:event-bus any/c
-                                            #:model-name (or/c string? #f)
-                                            #:max-iterations exact-positive-integer?
-                                            #:system-instructions (listof string?)
-                                            #:token-budget-threshold exact-positive-integer?
-                                            #:cancellation-token any/c
-                                            #:register-default-tools? any/c
-                                            #:auto-load-extensions? any/c
-                                            #:project-dir (or/c path-string? path? #f))
-                             runtime?)]
-                       [open-session (->* (runtime?) ((or/c string? #f)) runtime?)]
-                       [run-prompt! (runtime? string? . -> . (values runtime? any/c))]
-                       [make-cancellation-token
-                        (->* () (#:callback (or/c (-> any/c any/c) #f)) cancellation-token?)]
-                       [make-in-memory-session-manager (-> in-memory-session-manager?)]
-                       [subscribe-events!
-                        (->* (runtime? procedure?) ((or/c procedure? #f)) exact-nonnegative-integer?)]
-                       [interrupt! (runtime? . -> . runtime?)]
-                       [fork-session!
-                        (->* (runtime?) ((or/c string? #f)) (or/c runtime? 'no-active-session))]
-                       [compact-session! (->* (runtime?) (#:persist? boolean?) any)]
-                       [session-info (runtime? . -> . (or/c #f hash?))]
-                       [steer! (runtime? string? . -> . runtime?)]
-                       [follow-up! (runtime? string? . -> . runtime?)]
-                       [navigate!
-                        (-> runtime?
-                            (or/c string? exact-integer?)
-                            (or/c navigate-result? 'no-active-session 'invalid-target))])
+         (contract-out
+          [make-runtime
+           (->* (#:provider provider?)
+                (#:session-dir (or/c path-string? path? #f)
+                               #:tool-registry tool-registry?
+                               #:extension-registry (or/c extension-registry? #f)
+                               #:event-bus event-bus?
+                               #:model-name (or/c string? #f)
+                               #:max-iterations exact-positive-integer?
+                               #:system-instructions (listof string?)
+                               #:token-budget-threshold exact-positive-integer?
+                               #:cancellation-token (or/c cancellation-token? #f)
+                               #:register-default-tools? boolean?
+                               #:auto-load-extensions? boolean?
+                               #:project-dir (or/c path-string? path? #f))
+                runtime?)]
+          [open-session (->* (runtime?) ((or/c string? #f)) runtime?)]
+          [run-prompt! (runtime? string? . -> . (values runtime? (or/c hash? #f 'no-active-session)))]
+          [make-cancellation-token
+           (->* () (#:callback (or/c (-> any/c any/c) #f)) cancellation-token?)]
+          [make-in-memory-session-manager (-> in-memory-session-manager?)]
+          [subscribe-events!
+           (->* (runtime? procedure?) ((or/c procedure? #f)) exact-nonnegative-integer?)]
+          [interrupt! (runtime? . -> . runtime?)]
+          [fork-session! (->* (runtime?) ((or/c string? #f)) (or/c runtime? 'no-active-session))]
+          [compact-session! (->* (runtime?) (#:persist? boolean?) any)]
+          [session-info (runtime? . -> . (or/c #f hash?))]
+          [steer! (runtime? string? . -> . runtime?)]
+          [follow-up! (runtime? string? . -> . runtime?)]
+          [navigate!
+           (-> runtime?
+               (or/c string? exact-integer?)
+               (or/c navigate-result? 'no-active-session 'invalid-target))])
 
          ;; Compaction types
          compaction-result?

--- a/interfaces/sdk-public.rkt
+++ b/interfaces/sdk-public.rkt
@@ -93,6 +93,7 @@
          (only-in "../llm/provider.rkt" provider? make-mock-provider)
          (only-in "../runtime/provider-factory.rkt" build-provider)
          (only-in "../agent/event-bus.rkt" make-event-bus event-bus? subscribe! publish!)
+         (only-in "../util/event.rkt" event?)
          (only-in "../extensions/api.rkt"
                   make-extension-registry
                   register-extension!
@@ -162,7 +163,7 @@
           [make-event-bus (-> event-bus?)]
           [subscribe!
            (->* (event-bus? procedure?) (#:filter (or/c procedure? #f)) exact-nonnegative-integer?)]
-          [publish! (-> event-bus? any/c any/c)]
+          [publish! (-> event-bus? event? event?)]
           ;; Extension registration
           [make-extension-registry (-> extension-registry?)]
           [register-extension! (-> extension-registry? extension? extension-registry?)]

--- a/tests/test-sdk-contracts.rkt
+++ b/tests/test-sdk-contracts.rkt
@@ -1,76 +1,59 @@
-#lang racket/base
+#lang racket
 
-;; tests/test-sdk-contracts.rkt — Contract enforcement tests for SDK public API
+;; tests/test-sdk-contracts.rkt — Contract blame verification for v0.30.0
 ;;
-;; W0 scaffolding for v0.29.0 milestone: Verify that SDK boundary functions
-;; enforce type contracts (reject wrong argument types).
+;; Verifies that tightened contracts in sdk-core.rkt, sdk-public.rkt,
+;; event-bus.rkt, and extensions/events.rkt raise proper blame when
+;; given wrong-type arguments.
 
 (require rackunit
-         (only-in "../interfaces/sdk-public.rkt"
-                  make-runtime
-                  make-event-bus
-                  event-bus?
-                  subscribe!
-                  publish!
-                  make-tool-registry
-                  register-tool!
-                  list-tools
-                  make-cancellation-token
-                  cancellation-token?
-                  cancel-token!
-                  make-extension-registry
-                  register-extension!
-                  make-mock-provider
-                  provider?))
+         rackunit/text-ui
+         (only-in "../interfaces/sdk-public.rkt" make-runtime runtime? publish!)
+         (only-in "../agent/event-bus.rkt" make-event-bus subscribe! unsubscribe!)
+         (only-in "../extensions/events.rkt" ext-publish!)
+         (only-in "../llm/provider.rkt" make-mock-provider)
+         (only-in "../llm/model.rkt" make-model-response))
 
-;; ── make-runtime contracts ──
+(define mock-provider (make-mock-provider (make-model-response '() #f "mock" 'done)))
 
-(test-case "make-runtime-requires-valid-args"
-  ;; Will tighten to provider? once any/c is replaced
-  ;; For now just verify the function exists and rejects completely wrong types
-  (check-true (procedure? make-runtime)))
+(define sdk-contract-tests
+  (test-suite "SDK contract blame tests"
 
-(test-case "make-runtime-is-exported"
-  ;; Verify make-runtime is available as a contracted function
-  (check-true (procedure? make-runtime)))
+    (test-case "make-runtime rejects non-provider for #:provider"
+      (check-exn #rx"expected: provider\\?" (lambda () (make-runtime #:provider "not-a-provider"))))
 
-;; ── Event bus contracts ──
+    (test-case "make-runtime rejects non-tool-registry for #:tool-registry"
+      (check-exn #rx"expected: tool-registry\\?"
+                 (lambda () (make-runtime #:provider mock-provider #:tool-registry "bad"))))
 
-(test-case "make-event-bus-returns-event-bus"
-  (define bus (make-event-bus))
-  (check-true (event-bus? bus)))
+    (test-case "make-runtime rejects non-boolean for #:register-default-tools?"
+      (check-exn #rx"expected: boolean\\?"
+                 (lambda () (make-runtime #:provider mock-provider #:register-default-tools? "yes"))))
 
-(test-case "subscribe!-rejects-non-procedure"
-  (define bus (make-event-bus))
-  (check-exn exn:fail:contract? (lambda () (subscribe! bus "not-a-procedure"))))
+    (test-case "make-runtime rejects non-boolean for #:auto-load-extensions?"
+      (check-exn #rx"expected: boolean\\?"
+                 (lambda () (make-runtime #:provider mock-provider #:auto-load-extensions? "yes"))))
 
-(test-case "subscribe!-accepts-procedure"
-  (define bus (make-event-bus))
-  (check-not-exn (lambda () (subscribe! bus (lambda (evt) (void))))))
+    (test-case "event-bus subscribe! rejects non-procedure handler"
+      (define bus (make-event-bus))
+      (check-exn #rx"expected: procedure\\?" (lambda () (subscribe! bus "not-a-proc"))))
 
-;; ── Cancellation token contracts ──
+    (test-case "event-bus unsubscribe! rejects non-integer sub-id"
+      (define bus (make-event-bus))
+      (check-exn #rx"expected: exact-nonnegative-integer\\?"
+                 (lambda () (unsubscribe! bus "not-an-id"))))
 
-(test-case "make-cancellation-token-returns-token"
-  (define tok (make-cancellation-token))
-  (check-true (cancellation-token? tok)))
+    (test-case "event-bus publish! rejects non-event payload"
+      (define bus (make-event-bus))
+      (check-exn #rx"expected: event\\?" (lambda () (publish! bus "not-an-event"))))
 
-(test-case "cancel-token!-works"
-  (define tok (make-cancellation-token))
-  (check-not-exn (lambda () (cancel-token! tok))))
+    (test-case "ext-publish! rejects non-event payload"
+      (define bus (make-event-bus))
+      (check-exn #rx"expected: event\\?" (lambda () (ext-publish! bus "not-an-event"))))
 
-;; ── Extension registry contracts ──
+    (test-case "make-runtime accepts valid optional arguments"
+      (define rt (make-runtime #:provider mock-provider))
+      (check-true (runtime? rt)))))
 
-(test-case "make-extension-registry-returns-registry"
-  (define reg (make-extension-registry))
-  (check-not-false reg))
-
-;; ── Tool registry contracts ──
-
-(test-case "sdk-make-tool-registry-returns-registry"
-  (define reg (make-tool-registry))
-  (check-not-false reg))
-
-(test-case "sdk-list-tools-returns-list"
-  (define reg (make-tool-registry))
-  (define tools (list-tools reg))
-  (check-true (list? tools)))
+(module+ main
+  (run-tests sdk-contract-tests 'verbose))


### PR DESCRIPTION
Addresses #3672.

feat: v0.30.0 W0 — tighten any/c contracts in SDK core + event bus (#3672)

- Replace any/c with typed predicates in 4 files
- agent/event-bus.rkt: subscribe!/unsubscribe!/publish! contracts
- extensions/events.rkt: ext-publish! contract
- interfaces/sdk-core.rkt: make-runtime + run-prompt! contracts
- interfaces/sdk-public.rkt: publish! contract
- Add tests/test-sdk-contracts.rkt with 9 contract-blame tests