### PR TITLE
feat: v0.30.0 W1 — tighten any/c in provider, tool-coordinator, hooks, message-inject (#3673)

- llm/provider.rkt: provider-send → model-response?, provider-stream → generator?, provider-count-tokens → model-request?, make-mock-provider → model-response?
- runtime/tool-coordinator.rkt: ext-reg → extension-registry?, bus → event-bus?, token → cancellation-token?
- extensions/hooks.rkt: dispatch-hooks registry → extension-registry?, ctx → extension-ctx?
- extensions/message-inject.rkt: all inject fns return event?

### DIFF
--- a/extensions/hooks.rkt
+++ b/extensions/hooks.rkt
@@ -31,7 +31,9 @@
          ;; Re-export extension-ctx for convenience
          (all-from-out "context.rkt")
          ;; Hook dispatch
-         (contract-out [dispatch-hooks (->* (symbol? any/c any/c) (#:ctx any/c) hook-result?)])
+         (contract-out
+          [dispatch-hooks
+           (->* (symbol? any/c extension-registry?) (#:ctx (or/c extension-ctx? #f)) hook-result?)])
          current-hook-timeout-ms
          current-hook-violation-callback
          critical-hook?

--- a/extensions/message-inject.rkt
+++ b/extensions/message-inject.rkt
@@ -20,12 +20,13 @@
          "api.rkt"
          "../util/protocol-types.rkt"
          "../util/ids.rkt"
+         "../util/event.rkt"
          "../agent/event-emitter.rkt"
          "../agent/event-structs/iteration-events.rkt")
 
-(provide (contract-out [inject-system-message! (-> event-bus? string? string? any/c)]
-                       [inject-user-message! (-> event-bus? string? string? any/c)]
-                       [inject-assistant-message! (-> event-bus? string? string? any/c)])
+(provide (contract-out [inject-system-message! (-> event-bus? string? string? event?)]
+                       [inject-user-message! (-> event-bus? string? string? event?)]
+                       [inject-assistant-message! (-> event-bus? string? string? event?)])
          ;; Low-level: create injection message
          make-injection-message
          ;; Event topic constant

--- a/llm/provider.rkt
+++ b/llm/provider.rkt
@@ -23,15 +23,15 @@
          validate-api-key!
          ensure-model-setting
          gen:provider
-         (contract-out [provider-name (-> provider? string?)]
-                       [provider-send (-> provider? model-request? any/c)]
-                       [provider-stream (-> provider? model-request? any/c)]
-                       [provider-capabilities (-> provider? hash?)]
-                       [provider-count-tokens
-                        (-> provider? any/c (or/c #f exact-nonnegative-integer?))]
-                       [make-provider (-> procedure? procedure? procedure? procedure? provider?)]
-                       [make-mock-provider
-                        (->* (any/c) (#:name string? #:stream-chunks (or/c #f list?)) provider?)]))
+         (contract-out
+          [provider-name (-> provider? string?)]
+          [provider-send (-> provider? model-request? model-response?)]
+          [provider-stream (-> provider? model-request? generator?)]
+          [provider-capabilities (-> provider? hash?)]
+          [provider-count-tokens (-> provider? model-request? (or/c #f exact-nonnegative-integer?))]
+          [make-provider (-> procedure? procedure? procedure? procedure? provider?)]
+          [make-mock-provider
+           (->* (model-response?) (#:name string? #:stream-chunks (or/c #f list?)) provider?)]))
 
 ;; ============================================================
 ;; Model-setting helper (ARCH-08)

--- a/runtime/tool-coordinator.rkt
+++ b/runtime/tool-coordinator.rkt
@@ -49,6 +49,8 @@
          (only-in "../tools/scheduler.rkt" run-tool-batch scheduler-result scheduler-result-results)
          ;; ARCH-01 upward import — runtime→extensions: hooks
          (only-in "../extensions/hooks.rkt" dispatch-hooks)
+         (only-in "../extensions/api.rkt" extension-registry?)
+         (only-in "../agent/event-bus.rkt" event-bus?)
          (only-in "../runtime/session-store.rkt" append-entries!)
          (only-in "../runtime/settings.rkt" make-minimal-settings setting-ref setting-ref*)
          (only-in "../util/content-helpers.rkt" tool-result-content->string)
@@ -69,12 +71,12 @@
                        [handle-tool-calls-pending
                         (-> (listof message?) ; new-msgs
                             list? ; ctx-with-steering
-                            any/c ; ext-reg
+                            (or/c extension-registry? #f) ; ext-reg
                             (or/c tool-registry? #f) ; reg
-                            any/c ; bus
+                            event-bus? ; bus
                             string? ; session-id
                             (or/c path-string? path?) ; log-path
-                            any/c ; token
+                            (or/c cancellation-token? #f) ; token
                             hash? ; config
                             (listof message?))]))
 


### PR DESCRIPTION
Addresses #3673.

feat: v0.30.0 W1 — tighten any/c in provider, tool-coordinator, hooks, message-inject (#3673)

- llm/provider.rkt: provider-send → model-response?, provider-stream → generator?, provider-count-tokens → model-request?, make-mock-provider → model-response?
- runtime/tool-coordinator.rkt: ext-reg → extension-registry?, bus → event-bus?, token → cancellation-token?
- extensions/hooks.rkt: dispatch-hooks registry → extension-registry?, ctx → extension-ctx?
- extensions/message-inject.rkt: all inject fns return event?