### PR TITLE
feat: v0.30.1 W0 — add contracts to provider-registry + agent-session (#3675)

- runtime/provider-registry.rkt: contract-out for 13 functions (make-provider-registry, register/unregister/lookup/list providers, register/unregister/list models, find-model/find-models, provider-metadata, provider-summary)
- runtime/agent-session.rkt: contract-out for 8 lifecycle functions (make-agent-session, resume-agent-session, fork-session, run-prompt!, session-id, session-history, session-active?, close-session!)

### DIFF
--- a/runtime/agent-session.rkt
+++ b/runtime/agent-session.rkt
@@ -26,7 +26,7 @@
          racket/list
          racket/path
          (only-in "../util/errors.rkt" raise-session-error)
-         (only-in "../util/protocol-types.rkt" message-id message-kind make-loop-result)
+         (only-in "../util/protocol-types.rkt" message-id message-kind make-loop-result message?)
          "../agent/queue.rkt"
          "../agent/event-bus.rkt"
          (only-in "../util/hook-types.rkt" hook-result-action hook-result-payload)
@@ -85,14 +85,14 @@
          set-agent-session-config!
          ensure-persisted!
          buffer-or-append!
-         make-agent-session
-         resume-agent-session
-         fork-session
-         run-prompt!
-         session-id
-         session-history
-         session-active?
-         close-session!
+         (contract-out [make-agent-session (-> hash? agent-session?)]
+                       [resume-agent-session (-> string? hash? agent-session?)]
+                       [fork-session (->* (agent-session?) ((or/c string? #f)) agent-session?)]
+                       [run-prompt! (-> agent-session? (or/c string? message?) any)]
+                       [session-id (-> agent-session? string?)]
+                       [session-history (-> agent-session? list?)]
+                       [session-active? (-> agent-session? boolean?)]
+                       [close-session! (-> agent-session? void?)])
          maybe-compact-context
          ;; Thinking level control (#1153)
          thinking-levels

--- a/runtime/provider-registry.rkt
+++ b/runtime/provider-registry.rkt
@@ -17,28 +17,30 @@
          "../llm/provider.rkt"
          "../llm/model.rkt")
 
-(provide
- ;; Registry
- make-provider-registry
- provider-registry?
- ;; #700: Provider management
- register-provider!
- unregister-provider!
- lookup-provider
- list-providers
- ;; #701: Model registration
- register-model!
- unregister-model!
- list-models-for-provider
- ;; #702: Model search
- find-model
- find-models
- ;; Model info struct
- (struct-out provider-info)
- (struct-out registered-model)
- ;; #1220: Metadata and query helpers
- provider-metadata
- provider-summary)
+;; Registry
+(provide (contract-out
+          [make-provider-registry (-> provider-registry?)]
+          [register-provider!
+           (->* (provider-registry? string? provider?) (#:config hash?) (or/c 'registered 'updated))]
+          [unregister-provider! (-> provider-registry? string? void?)]
+          [lookup-provider (-> provider-registry? string? (or/c provider-info? #f))]
+          [list-providers (-> provider-registry? (listof provider-info?))]
+          [register-model!
+           (->* (provider-registry? #:id string? #:name string? #:provider-name string?)
+                (#:context-window (or/c exact-positive-integer? #f)
+                                  #:max-tokens (or/c exact-positive-integer? #f)
+                                  #:capabilities hash?)
+                void?)]
+          [unregister-model! (-> provider-registry? string? string? void?)]
+          [list-models-for-provider (-> provider-registry? string? (listof registered-model?))]
+          [find-model (-> provider-registry? string? (or/c registered-model? #f))]
+          [find-models (-> provider-registry? string? (listof registered-model?))]
+          [provider-metadata (-> provider-info? hash?)]
+          [provider-summary (-> provider-registry? string? (or/c hash? #f))])
+         provider-registry?
+         ;; Model info struct
+         (struct-out provider-info)
+         (struct-out registered-model))
 
 ;; ============================================================
 ;; Structs
@@ -46,30 +48,30 @@
 
 ;; Info about a registered provider
 (struct provider-info
-  (name          ; string
-   provider      ; provider? instance
-   config        ; hash — merged config
-   registered-at ; exact-positive-integer — timestamp
-   )
+        (name ; string
+         provider ; provider? instance
+         config ; hash — merged config
+         registered-at ; exact-positive-integer — timestamp
+         )
   #:transparent)
 
 ;; A dynamically registered model
 (struct registered-model
-  (id              ; string — unique model id (e.g. "gpt-4o")
-   name            ; string — display name
-   provider-name   ; string — which provider owns this model
-   context-window  ; positive-integer or #f
-   max-tokens      ; positive-integer or #f
-   capabilities    ; hash — model capabilities
-   )
+        (id ; string — unique model id (e.g. "gpt-4o")
+         name ; string — display name
+         provider-name ; string — which provider owns this model
+         context-window ; positive-integer or #f
+         max-tokens ; positive-integer or #f
+         capabilities ; hash — model capabilities
+         )
   #:transparent)
 
 ;; Internal registry struct
 (struct provider-registry
-  (providers-box    ; box of hash: provider-name → provider-info
-   models-box       ; box of hash: "provider:model-id" → registered-model
-   semaphore        ; semaphore for thread safety
-   )
+        (providers-box ; box of hash: provider-name → provider-info
+         models-box ; box of hash: "provider:model-id" → registered-model
+         semaphore ; semaphore for thread safety
+         )
   #:transparent)
 
 ;; ============================================================
@@ -77,9 +79,7 @@
 ;; ============================================================
 
 (define (make-provider-registry)
-  (provider-registry (box (hash))
-                     (box (hash))
-                     (make-semaphore 1)))
+  (provider-registry (box (hash)) (box (hash)) (make-semaphore 1)))
 
 ;; ============================================================
 ;; Thread-safety helper
@@ -96,8 +96,7 @@
 ;; #1220: Validates that provider-instance satisfies provider? predicate.
 ;; Raises exn:fail:contract if validation fails.
 ;; Returns 'registered for new, 'updated for re-registration.
-(define (register-provider! registry name provider-instance
-                             #:config [config (hasheq)])
+(define (register-provider! registry name provider-instance #:config [config (hasheq)])
   ;; #1220: Provider validation — must be a valid provider? instance
   (unless (provider? provider-instance)
     (raise (exn:fail:contract
@@ -106,49 +105,45 @@
             (current-continuation-marks))))
   (define pinfo (provider-info name provider-instance config (current-seconds)))
   (with-lock registry
-    (lambda ()
-      (define current (unbox (provider-registry-providers-box registry)))
-      ;; Merge config if provider already exists
-      (define existing (hash-ref current name #f))
-      (define merged-config
-        (if existing
-            (hash-merge (provider-info-config existing) config)
-            config))
-      (define merged-info (struct-copy provider-info pinfo
-                                        [config merged-config]))
-      (set-box! (provider-registry-providers-box registry)
-                (hash-set current name merged-info))
-      ;; #1220: Return indicator for duplicate detection
-      (if existing 'updated 'registered))))
+             (lambda ()
+               (define current (unbox (provider-registry-providers-box registry)))
+               ;; Merge config if provider already exists
+               (define existing (hash-ref current name #f))
+               (define merged-config
+                 (if existing
+                     (hash-merge (provider-info-config existing) config)
+                     config))
+               (define merged-info (struct-copy provider-info pinfo [config merged-config]))
+               (set-box! (provider-registry-providers-box registry)
+                         (hash-set current name merged-info))
+               ;; #1220: Return indicator for duplicate detection
+               (if existing 'updated 'registered))))
 
 ;; Unregister a provider and all its models.
 (define (unregister-provider! registry name)
   (with-lock registry
-    (lambda ()
-      ;; Remove provider
-      (define current (unbox (provider-registry-providers-box registry)))
-      (set-box! (provider-registry-providers-box registry)
-                (hash-remove current name))
-      ;; Remove all models for this provider
-      (define current-models (unbox (provider-registry-models-box registry)))
-      (define filtered
-        (for/hash ([(k v) (in-hash current-models)]
-                   #:unless (string=? (registered-model-provider-name v) name))
-          (values k v)))
-      (set-box! (provider-registry-models-box registry) filtered))))
+             (lambda ()
+               ;; Remove provider
+               (define current (unbox (provider-registry-providers-box registry)))
+               (set-box! (provider-registry-providers-box registry) (hash-remove current name))
+               ;; Remove all models for this provider
+               (define current-models (unbox (provider-registry-models-box registry)))
+               (define filtered
+                 (for/hash ([(k v) (in-hash current-models)]
+                            #:unless (string=? (registered-model-provider-name v) name))
+                   (values k v)))
+               (set-box! (provider-registry-models-box registry) filtered))))
 
 ;; Look up a provider by name. Returns provider-info or #f.
 (define (lookup-provider registry name)
   (with-lock registry
-    (lambda ()
-      (define providers (unbox (provider-registry-providers-box registry)))
-      (hash-ref providers name #f))))
+             (lambda ()
+               (define providers (unbox (provider-registry-providers-box registry)))
+               (hash-ref providers name #f))))
 
 ;; List all registered providers.
 (define (list-providers registry)
-  (with-lock registry
-    (lambda ()
-      (hash-values (unbox (provider-registry-providers-box registry))))))
+  (with-lock registry (lambda () (hash-values (unbox (provider-registry-providers-box registry))))))
 
 ;; ============================================================
 ;; #701: Model registration
@@ -156,38 +151,36 @@
 
 ;; Register a model on a provider.
 (define (register-model! registry
-                          #:id id
-                          #:name name
-                          #:provider-name provider-name
-                          #:context-window [context-window #f]
-                          #:max-tokens [max-tokens #f]
-                          #:capabilities [capabilities (hasheq)])
+                         #:id id
+                         #:name name
+                         #:provider-name provider-name
+                         #:context-window [context-window #f]
+                         #:max-tokens [max-tokens #f]
+                         #:capabilities [capabilities (hasheq)])
   (define model-key (format "~a:~a" provider-name id))
-  (define model (registered-model id name provider-name
-                                   context-window max-tokens capabilities))
+  (define model (registered-model id name provider-name context-window max-tokens capabilities))
   (with-lock registry
-    (lambda ()
-      (define current (unbox (provider-registry-models-box registry)))
-      (set-box! (provider-registry-models-box registry)
-                (hash-set current model-key model)))))
+             (lambda ()
+               (define current (unbox (provider-registry-models-box registry)))
+               (set-box! (provider-registry-models-box registry)
+                         (hash-set current model-key model)))))
 
 ;; Unregister a specific model.
 (define (unregister-model! registry provider-name model-id)
   (define model-key (format "~a:~a" provider-name model-id))
   (with-lock registry
-    (lambda ()
-      (define current (unbox (provider-registry-models-box registry)))
-      (set-box! (provider-registry-models-box registry)
-                (hash-remove current model-key)))))
+             (lambda ()
+               (define current (unbox (provider-registry-models-box registry)))
+               (set-box! (provider-registry-models-box registry) (hash-remove current model-key)))))
 
 ;; List all models for a specific provider.
 (define (list-models-for-provider registry provider-name)
   (with-lock registry
-    (lambda ()
-      (define all-models (unbox (provider-registry-models-box registry)))
-      (for/list ([(k v) (in-hash all-models)]
-                 #:when (string=? (registered-model-provider-name v) provider-name))
-        v))))
+             (lambda ()
+               (define all-models (unbox (provider-registry-models-box registry)))
+               (for/list ([(k v) (in-hash all-models)]
+                          #:when (string=? (registered-model-provider-name v) provider-name))
+                 v))))
 
 ;; ============================================================
 ;; #702: Model search
@@ -196,36 +189,31 @@
 ;; Find a single model by ID or name. Returns first match or #f.
 (define (find-model registry query)
   (define all-models
-    (with-lock registry
-      (lambda ()
-        (hash-values (unbox (provider-registry-models-box registry))))))
+    (with-lock registry (lambda () (hash-values (unbox (provider-registry-models-box registry))))))
   (define q (string-downcase query))
-  (or
-   ;; Exact ID match
-   (for/first ([m (in-list all-models)]
-               #:when (string=? (string-downcase (registered-model-id m)) q))
-     m)
-   ;; Exact name match
-   (for/first ([m (in-list all-models)]
-               #:when (string=? (string-downcase (registered-model-name m)) q))
-     m)
-   ;; Prefix ID match
-   (for/first ([m (in-list all-models)]
-               #:when (string-prefix? (string-downcase (registered-model-id m)) q))
-     m)
-   ;; Substring name match
-   (for/first ([m (in-list all-models)]
-               #:when (string-contains? (string-downcase (registered-model-name m)) q))
-     m)
-   ;; Not found
-   #f))
+  ;; Exact ID match
+  (or (for/first ([m (in-list all-models)]
+                  #:when (string=? (string-downcase (registered-model-id m)) q))
+        m)
+      ;; Exact name match
+      (for/first ([m (in-list all-models)]
+                  #:when (string=? (string-downcase (registered-model-name m)) q))
+        m)
+      ;; Prefix ID match
+      (for/first ([m (in-list all-models)]
+                  #:when (string-prefix? (string-downcase (registered-model-id m)) q))
+        m)
+      ;; Substring name match
+      (for/first ([m (in-list all-models)]
+                  #:when (string-contains? (string-downcase (registered-model-name m)) q))
+        m)
+      ;; Not found
+      #f))
 
 ;; Find all models matching a query. Returns list of registered-model.
 (define (find-models registry query)
   (define all-models
-    (with-lock registry
-      (lambda ()
-        (hash-values (unbox (provider-registry-models-box registry))))))
+    (with-lock registry (lambda () (hash-values (unbox (provider-registry-models-box registry))))))
   (define q (string-downcase query))
   (filter (lambda (m)
             (or (string-contains? (string-downcase (registered-model-id m)) q)
@@ -239,23 +227,34 @@
 ;; Extract metadata from a provider-info for SDK/RPC consumption.
 ;; Returns a hash with name, capabilities, registered-at, model-count.
 (define (provider-metadata pinfo)
-  (hasheq 'name (provider-info-name pinfo)
-          'config (provider-info-config pinfo)
-          'registered-at (provider-info-registered-at pinfo)
-          'provider-valid? (provider? (provider-info-provider pinfo))))
+  (hasheq 'name
+          (provider-info-name pinfo)
+          'config
+          (provider-info-config pinfo)
+          'registered-at
+          (provider-info-registered-at pinfo)
+          'provider-valid?
+          (provider? (provider-info-provider pinfo))))
 
 ;; Get full provider summary: metadata + model list for RPC/SDK.
 ;; Returns a hash suitable for JSON serialization.
 (define (provider-summary registry name)
   (define pinfo (lookup-provider registry name))
   (if pinfo
-      (hasheq 'info (provider-metadata pinfo)
-              'models (for/list ([m (list-models-for-provider registry name)])
-                        (hasheq 'id (registered-model-id m)
-                                'name (registered-model-name m)
-                                'context-window (registered-model-context-window m)
-                                'max-tokens (registered-model-max-tokens m)
-                                'capabilities (registered-model-capabilities m))))
+      (hasheq 'info
+              (provider-metadata pinfo)
+              'models
+              (for/list ([m (list-models-for-provider registry name)])
+                (hasheq 'id
+                        (registered-model-id m)
+                        'name
+                        (registered-model-name m)
+                        'context-window
+                        (registered-model-context-window m)
+                        'max-tokens
+                        (registered-model-max-tokens m)
+                        'capabilities
+                        (registered-model-capabilities m))))
       #f))
 
 ;; ============================================================
@@ -264,6 +263,5 @@
 
 ;; Merge two hashes, right-biased.
 (define (hash-merge h1 h2)
-  (for/fold ([result h1])
-            ([(k v) (in-hash h2)])
+  (for/fold ([result h1]) ([(k v) (in-hash h2)])
     (hash-set result k v)))


### PR DESCRIPTION
Addresses #3675.

feat: v0.30.1 W0 — add contracts to provider-registry + agent-session (#3675)

- runtime/provider-registry.rkt: contract-out for 13 functions (make-provider-registry, register/unregister/lookup/list providers, register/unregister/list models, find-model/find-models, provider-metadata, provider-summary)
- runtime/agent-session.rkt: contract-out for 8 lifecycle functions (make-agent-session, resume-agent-session, fork-session, run-prompt!, session-id, session-history, session-active?, close-session!)