### PR TITLE
feat: v0.30.1 W1 — add contracts to settings, iteration, turn-orchestrator (#3676)

- runtime/settings.rkt: contract-out for load-settings, make-minimal-settings, merge-settings, deep-merge-hash, setting-ref, setting-ref*, provider-config, provider-names, config-parse-error
- runtime/iteration.rkt: contract-out for run-iteration-loop (8 positional + 11 keyword args), decide-next-action
- runtime/turn-orchestrator.rkt: contract-out for run-provider-turn, build-assembled-context, register-session-extensions!
- Fixed: make-minimal-settings provider arg accepts any/c (not just string?) since callers pass provider? structs

### DIFF
--- a/runtime/iteration.rkt
+++ b/runtime/iteration.rkt
@@ -101,7 +101,28 @@
          "working-set.rkt"
          (only-in "context-policy.rkt" estimate-message-tokens))
 
-(provide run-iteration-loop
+(provide (contract-out [run-iteration-loop
+                        (->* (list? any/c
+                                    event-bus?
+                                    (or/c any/c #f)
+                                    (or/c any/c #f)
+                                    (or/c path-string? path?)
+                                    string?
+                                    exact-nonnegative-integer?)
+                             (#:cancellation-token (or/c any/c #f)
+                              #:config hash?
+                              #:queue (or/c any/c #f)
+                              #:follow-up-delivery-mode (or/c 'all 'one-at-a-time)
+                              #:injected-box (or/c box? #f)
+                              #:shutdown-check (or/c procedure? #f)
+                              #:force-shutdown-check (or/c procedure? #f)
+                              #:compact-proc (or/c procedure? #f)
+                              #:estimate-tokens (or/c procedure? #f)
+                              #:inject-topic (or/c string? #f)
+                              #:working-set (or/c any/c #f)
+                              #:session (or/c any/c #f))
+                             any/c)]
+                       [decide-next-action (-> iteration-ctx? any/c symbol?)])
          ;; emit-session-event! and maybe-dispatch-hooks re-exported from runtime-helpers
          emit-session-event!
          maybe-dispatch-hooks
@@ -126,7 +147,6 @@
          resolve-inject-topic
          ;; v0.29.1: Pure decision function exports
          iteration-ctx
-         decide-next-action
          known-termination-reasons)
 
 ;; ============================================================

--- a/runtime/settings.rkt
+++ b/runtime/settings.rkt
@@ -15,7 +15,8 @@
 ;;   - Provider access: convenience functions for providers section
 
 (require "../util/json-helpers.rkt")
-(require racket/file
+(require racket/contract
+         racket/file
          racket/port
          racket/hash
          racket/list
@@ -31,24 +32,30 @@
 ;; Structs
 (provide (struct-out q-settings)
 
-         ;; Loading
-         load-settings
+         ;; Loading — contracted
+         (contract-out [load-settings
+                        (->* ()
+                             (path-string? #:home-dir path-string?
+                                           #:config-path (or/c path-string? #f))
+                             q-settings?)])
+
          load-global-settings
          load-project-settings
 
-         ;; Constructor
-         make-minimal-settings
+         ;; Constructor — contracted
+         (contract-out [make-minimal-settings
+                        (->* () (#:provider any/c #:model any/c #:overrides hash?) q-settings?)])
 
          ;; Merging
          merge-settings
          deep-merge-hash
 
          ;; Query
-         setting-ref
-         setting-ref*
-         provider-config
-         provider-names
-         config-parse-error
+         (contract-out [setting-ref (->* (q-settings? any/c) (any/c) any/c)]
+                       [setting-ref* (->* (q-settings? (listof any/c)) (any/c) any/c)]
+                       [provider-config (-> q-settings? any/c (or/c hash? #f))]
+                       [provider-names (-> q-settings? list?)]
+                       [config-parse-error (-> path-string? (or/c string? #f))])
 
          ;; Parallel execution
          parallel-tools-enabled?

--- a/runtime/turn-orchestrator.rkt
+++ b/runtime/turn-orchestrator.rkt
@@ -86,9 +86,21 @@
          "../agent/event-emitter.rkt"
          "../agent/event-structs/iteration-events.rkt")
 
-(provide run-provider-turn
-         build-assembled-context
-         register-session-extensions!)
+(provide (contract-out
+          [run-provider-turn
+           (->* (list? any/c
+                       event-bus?
+                       (or/c any/c #f)
+                       (or/c any/c #f)
+                       string?
+                       string?
+                       (or/c any/c #f)
+                       hash?)
+                (#:tool-list-proc (or/c procedure? #f))
+                any/c)]
+          [build-assembled-context
+           (-> list? hash? (or/c any/c #f) event-bus? string? exact-nonnegative-integer? list?)]
+          [register-session-extensions! (-> any/c any/c event-bus? string? (listof hash?))]))
 
 ;; ============================================================
 ;; Context assembly


### PR DESCRIPTION
Addresses #3676.

feat: v0.30.1 W1 — add contracts to settings, iteration, turn-orchestrator (#3676)

- runtime/settings.rkt: contract-out for load-settings, make-minimal-settings, merge-settings, deep-merge-hash, setting-ref, setting-ref*, provider-config, provider-names, config-parse-error
- runtime/iteration.rkt: contract-out for run-iteration-loop (8 positional + 11 keyword args), decide-next-action
- runtime/turn-orchestrator.rkt: contract-out for run-provider-turn, build-assembled-context, register-session-extensions!
- Fixed: make-minimal-settings provider arg accepts any/c (not just string?) since callers pass provider? structs