### PR TITLE
feat: v0.30.2 W1 — migrate retry-policy.rkt to Typed Racket (#3679)

- runtime/iteration/retry-policy.rkt: #lang racket/base → #lang typed/racket
- 6 exported functions fully typed: compute-mid-turn-estimate, estimate-mid-turn-tokens,
  maybe-compact-mid-turn, check-mid-turn-budget!, call-with-overflow-recovery,
  detect-exploration-loop
- require/typed boundaries for: auto-retry, compactor, protocol-types, runtime-helpers,
  session-compaction, loop-state
- TR issues resolved: hash-ref polymorphism (thunk defaults), exn-message casts,
  for/first with in-hash-keys (replaced with for/or), exact-floor for budget-threshold
- tests/test-arch-fitness.rkt: added retry-policy.rkt to tr-module-files (7 TR modules now)

### DIFF
--- a/runtime/iteration/retry-policy.rkt
+++ b/runtime/iteration/retry-policy.rkt
@@ -1,32 +1,17 @@
-#lang racket/base
+#lang typed/racket
 
 ;; runtime/iteration/retry-policy.rkt — overflow recovery, budget checking, error detection
 ;;
 ;; Pure policy functions for retry and recovery.
+;; v0.30.2 W1: Migrated to Typed Racket (TR beachhead).
+;;
+;; TR BOUNDARY:
+;; This is a #lang typed/racket module. Untyped consumers receive
+;; auto-generated contracts from TR boundary system.
 
 (require racket/list
-         (only-in racket/string string-join)
-         (only-in "../auto-retry.rkt" context-overflow-error?)
-         (only-in "../compactor.rkt"
-                  compaction-result
-                  compaction-result-removed-count
-                  compaction-result-kept-messages)
-         (only-in "../../util/protocol-types.rkt"
-                  message?
-                  message-id
-                  message-role
-                  message-content
-                  text-part?
-                  text-part-text
-                  tool-result-part?
-                  tool-result-part-is-error?)
-         (only-in "../../util/event-contracts.rkt"
-                  budget-payload/c
-                  compact-result-payload/c
-                  error-detail-payload/c)
-         (only-in "../runtime-helpers.rkt" emit-session-event!)
-         (only-in "../session-compaction.rkt" compact-context-mid-turn)
-         (only-in "loop-state.rkt" resolve-estimate-tokens))
+         racket/string
+         racket/match)
 
 (provide compute-mid-turn-estimate
          check-mid-turn-budget!
@@ -35,28 +20,68 @@
          call-with-overflow-recovery
          detect-exploration-loop)
 
+;; ── Typed imports from untyped modules ──────────────────────────
+
+(require/typed "../auto-retry.rkt"
+               [context-overflow-error? (-> Any Boolean)])
+
+(require/typed "../compactor.rkt"
+               [#:struct compaction-result
+                         ([summary-message : (U String #f)]
+                          [removed-count : Integer]
+                          [kept-messages : (Listof Any)])])
+
+(require/typed "../../util/protocol-types.rkt"
+               [message-content (-> Any Any)]
+               [text-part? (-> Any Boolean)]
+               [text-part-text (-> Any String)])
+
+(require/typed "../runtime-helpers.rkt"
+               [emit-session-event! (-> Any String String Any Any)])
+
+(require/typed "../session-compaction.rkt"
+               [compact-context-mid-turn (-> Any (Listof Any) (Listof Any))])
+
+(require/typed "loop-state.rkt"
+               [resolve-estimate-tokens (-> (-> (Listof Any) Nonnegative-Integer))])
+
 ;; ── Shared token estimation logic ──
 ;; Returns (values estimated budget-threshold max-tokens).
+(: compute-mid-turn-estimate
+   (-> (Listof Any)
+       (HashTable Symbol Any)
+       (-> (Listof Any) Nonnegative-Integer)
+       (Values Nonnegative-Integer Nonnegative-Integer Nonnegative-Integer)))
 (define (compute-mid-turn-estimate ctx config estimate-tokens)
-  (define max-tokens (hash-ref config 'max-context-tokens 128000))
-  (define budget-threshold (inexact->exact (floor (* max-tokens 0.9))))
+  (define max-tokens : Nonnegative-Integer
+    (let ([v (hash-ref config 'max-context-tokens #f)])
+      (if (exact-nonnegative-integer? v) v 128000)))
+  (define budget-threshold : Nonnegative-Integer
+    (cast (exact-floor (* max-tokens 9/10)) Nonnegative-Integer))
   (define texts
-    (for/list ([msg (in-list ctx)])
+    (for/list : (Listof String)
+              ([msg (in-list ctx)])
       (define content (message-content msg))
       (cond
         [(string? content) content]
         [(list? content)
          (apply string-append
-                (for/list ([part (in-list content)]
+                (for/list : (Listof String)
+                          ([part (in-list content)]
                            #:when (text-part? part))
                   (text-part-text part)))]
         [else ""])))
-  (define estimated (for/sum ([t (in-list texts)]) (estimate-tokens (list (hasheq 'content t)))))
+  (define estimated
+    (for/sum : Nonnegative-Integer
+             ([t (in-list texts)])
+      (estimate-tokens (list (hasheq 'content t)))))
   (values estimated budget-threshold max-tokens))
 
 ;; ── Estimate token count for mid-turn context ──
-;; Returns integer token estimate. Emits context.mid-turn-over-budget event
-;; when context exceeds 90% of max budget.
+(: estimate-mid-turn-tokens
+   (->* ((Listof Any) Any (U String #f) (HashTable Symbol Any))
+        (#:estimate-tokens (-> (Listof Any) Nonnegative-Integer))
+        Nonnegative-Integer))
 (define (estimate-mid-turn-tokens ctx
                                   bus
                                   session-id
@@ -69,12 +94,16 @@
      bus
      session-id
      "context.mid-turn-over-budget"
-     (hasheq 'estimated-tokens estimated 'budget budget-threshold 'max-tokens max-tokens)))
+     (hasheq 'estimated-tokens estimated
+             'budget budget-threshold
+             'max-tokens max-tokens)))
   estimated)
 
 ;; ── Compact context mid-turn if over budget ──
-;; Returns (listof message?) — compacted context if over 90% budget,
-;; or original context if under budget.
+(: maybe-compact-mid-turn
+   (->* (Any (Listof Any) Any (U String #f) (HashTable Symbol Any))
+        (#:estimate-tokens (-> (Listof Any) Nonnegative-Integer))
+        (Listof Any)))
 (define (maybe-compact-mid-turn sess
                                 ctx
                                 bus
@@ -91,11 +120,17 @@
         bus
         session-id
         "context.mid-turn-over-budget"
-        (hasheq 'estimated-tokens estimated 'budget budget-threshold 'max-tokens max-tokens)))
+        (hasheq 'estimated-tokens estimated
+                'budget budget-threshold
+                'max-tokens max-tokens)))
      (compact-context-mid-turn sess ctx)]))
 
 ;; ── Backward-compat wrapper ──
-;; Returns (listof message?) if session provided, or integer? if not.
+(: check-mid-turn-budget!
+   (->* ((Listof Any) Any (U String #f) (HashTable Symbol Any))
+        (#:estimate-tokens (-> (Listof Any) Nonnegative-Integer)
+         #:session (U Any #f))
+        Any))
 (define (check-mid-turn-budget! ctx
                                 bus
                                 session-id
@@ -103,23 +138,33 @@
                                 #:estimate-tokens [estimate-tokens (resolve-estimate-tokens)]
                                 #:session [sess #f])
   (if sess
-      (maybe-compact-mid-turn sess ctx bus session-id config #:estimate-tokens estimate-tokens)
-      (estimate-mid-turn-tokens ctx bus session-id config #:estimate-tokens estimate-tokens)))
+      (maybe-compact-mid-turn sess ctx bus session-id config
+                              #:estimate-tokens estimate-tokens)
+      (estimate-mid-turn-tokens ctx bus session-id config
+                               #:estimate-tokens estimate-tokens)))
 
 ;; Handle context overflow by compacting the context and retrying once.
-;; Catches both context-overflow-error? and plain exn:fail with overflow messages.
-(define (call-with-overflow-recovery thunk ctx bus session-id #:compact-proc [compact-proc #f])
+(: call-with-overflow-recovery
+   (->* ((-> Any) (Listof Any) Any String)
+        (#:compact-proc (U (-> (Listof Any) compaction-result) #f))
+        Any))
+(define (call-with-overflow-recovery
+         thunk ctx bus session-id
+         #:compact-proc [compact-proc #f])
   (define do-compact
+    : (-> (Listof Any) compaction-result)
     (or compact-proc
-        (lambda (msgs)
+        (lambda ([msgs : (Listof Any)])
           (define half (max 1 (quotient (length msgs) 2)))
-          (compaction-result #f (- (length msgs) half) (take-right msgs half)))))
-  (with-handlers ([(lambda (e) (context-overflow-error? e))
-                   (lambda (e)
+          (compaction-result #f
+                             (- (length msgs) half)
+                             (take-right msgs half)))))
+  (with-handlers ([(lambda ([e : Any]) (context-overflow-error? e))
+                   (lambda ([e : Any])
                      (emit-session-event! bus
                                           session-id
                                           "context.overflow.detected"
-                                          (hasheq 'error (exn-message e)))
+                                          (hasheq 'error (exn-message (cast e exn))))
                      (define compact-result (do-compact ctx))
                      (emit-session-event! bus
                                           session-id
@@ -127,23 +172,21 @@
                                           (hasheq 'original-size
                                                   (length ctx)
                                                   'removed-count
-                                                  (compaction-result-removed-count compact-result)
+                                                  (compaction-result-removed-count
+                                                   compact-result)
                                                   'kept-count
                                                   (length (compaction-result-kept-messages
                                                            compact-result))))
                      (thunk))]
-                  [exn:fail? (lambda (e) (raise e))])
+                  [exn:fail? (lambda ([e : Any]) (raise (cast e exn:fail)))])
     (thunk)))
 
 ;; ============================================================
 ;; v0.28.21 W6: Exploration loop detection
 ;; ============================================================
 
-;;; detect-exploration-loop : (listof string?) integer? -> (or/c #f string?)
-;;;
-;;; Checks recent tool names for repeating patterns that indicate
-;;; an exploration loop (e.g., read-grep-read-grep cycles).
-;;; Returns #f if no loop detected, or a string describing the loop.
+(: detect-exploration-loop (->* ((Listof String)) (Nonnegative-Integer)
+                                (U String #f)))
 (define (detect-exploration-loop recent-tool-names [min-repeats 3])
   (define n (length recent-tool-names))
   (cond
@@ -152,14 +195,17 @@
      ;; Check for repeating 2-tool patterns in the last N tool calls
      (define recent (take-at-most recent-tool-names (* min-repeats 4)))
      (define pairs
-       (for/list ([i (in-range (sub1 (length recent)))])
+       (for/list : (Listof (List String String))
+                 ([i (in-range (sub1 (length recent)))])
          (list (list-ref recent i) (list-ref recent (add1 i)))))
      (define pair-counts (count-occurrences pairs))
      ;; Find any pair repeated 3+ times
      (define looping-pair
-       (for/first ([pair (in-hash-keys pair-counts)]
-                   #:when (>= (hash-ref pair-counts pair) min-repeats))
-         pair))
+       (for/or : (U (List String String) #f)
+               ([pair : (List String String) (in-list pairs)])
+         (if (>= (hash-ref pair-counts pair (lambda () 0)) min-repeats)
+             pair
+             #f)))
      (cond
        [looping-pair
         (format "exploration loop detected: ~a repeated ~a times"
@@ -168,13 +214,15 @@
        [else #f])]))
 
 ;; Helper: count occurrences in a list of items
+(: count-occurrences (-> (Listof Any) (HashTable Any Nonnegative-Integer)))
 (define (count-occurrences items)
-  (define counts (make-hash))
+  (define counts : (HashTable Any Nonnegative-Integer) (make-hash))
   (for ([item (in-list items)])
-    (hash-update! counts item add1 0))
+    (hash-set! counts item (add1 (hash-ref counts item (lambda () 0)))))
   counts)
 
 ;; Helper: take at most N from list
+(: take-at-most (All (A) (-> (Listof A) Nonnegative-Integer (Listof A))))
 (define (take-at-most lst n)
   (if (> (length lst) n)
       (take lst n)

--- a/tests/test-arch-fitness.rkt
+++ b/tests/test-arch-fitness.rkt
@@ -281,7 +281,8 @@
         "util/event-payloads.rkt"
         "extensions/gsd/plan-types.rkt"
         "extensions/gsd/plan-validator.rkt"
-        "runtime/iteration/loop-state.rkt"))
+        "runtime/iteration/loop-state.rkt"
+        "runtime/iteration/retry-policy.rkt"))
 
 (define v02810-suite
   (test-suite "v0.28.10-features"


### PR DESCRIPTION
Addresses #3679.

feat: v0.30.2 W1 — migrate retry-policy.rkt to Typed Racket (#3679)

- runtime/iteration/retry-policy.rkt: #lang racket/base → #lang typed/racket
- 6 exported functions fully typed: compute-mid-turn-estimate, estimate-mid-turn-tokens,
  maybe-compact-mid-turn, check-mid-turn-budget!, call-with-overflow-recovery,
  detect-exploration-loop
- require/typed boundaries for: auto-retry, compactor, protocol-types, runtime-helpers,
  session-compaction, loop-state
- TR issues resolved: hash-ref polymorphism (thunk defaults), exn-message casts,
  for/first with in-hash-keys (replaced with for/or), exact-floor for budget-threshold
- tests/test-arch-fitness.rkt: added retry-policy.rkt to tr-module-files (7 TR modules now)