### PR TITLE
docs: v0.30.6 W1 — document event struct coverage status (#3691)

### DIFF
--- a/agent/event-structs.rkt
+++ b/agent/event-structs.rkt
@@ -13,6 +13,16 @@
 ;;
 ;; This file re-exports everything for backward compatibility.
 ;; New code should import the focused sub-modules directly.
+;;
+;; v0.30.6 status: 30 typed event structs across 8 sub-modules.
+;;   - runtime/ files: 15 emit-typed-event! sites (fully migrated)
+;;   - agent/loop*.rkt: 28 raw emit! sites (use dotted event names)
+;;   - These two systems coexist: typed events use hyphenated names
+;;     ("turn-start"), raw emit! uses dotted names ("turn.started").
+;;   - New hook-events.rkt sub-module adds: model-request-blocked,
+;;     message-blocked, turn-cancelled, assistant-message-completed
+;;   - New provider streaming events: model-stream-delta,
+;;     model-stream-thinking, model-stream-completed
 
 (require "event-structs/base.rkt"
          "event-structs/turn-events.rkt"


### PR DESCRIPTION
Addresses #3691.

docs: v0.30.6 W1 — document event struct coverage status (#3691)