### PR TITLE
feat: v0.30.13 W0 - macro cleanup + HOF adoption (#3753)

- Deduplicate with-error-result: 2 copies → 1 shared in helpers.rkt
- Migrate define-q-extension from syntax-case to syntax-parse (~45 LOC saved)
- Adopt with-safe-fallback in credential-backend.rkt (10 handler sites)

### DIFF
--- a/extensions/define-extension.rkt
+++ b/extensions/define-extension.rkt
@@ -14,78 +14,45 @@
 ;;     ...)
 
 (require (for-syntax racket/base
+                     syntax/parse
                      (only-in "../util/hook-types.rkt" valid-hook-name?))
          "api.rkt")
 
 (provide define-q-extension)
 
 ;; ============================================================
-;; define-q-extension macro
+;; define-q-extension macro (syntax-parse)
 ;; ============================================================
 
 (define-syntax (define-q-extension stx)
-  (syntax-case stx ()
-    [(_ name-sym opts ...)
-     (identifier? #'name-sym)
-     (let* ([args (syntax->list #'(opts ...))]
-            [ext-name (symbol->string (syntax-e #'name-sym))])
-       ;; Parse keyword arguments
-       (define-values (version api-version hook-pairs)
-         (let loop ([remaining args]
-                    [version "0.1.0"]
-                    [api-version "1"]
-                    [hooks '()])
-           (cond
-             [(null? remaining)
-              (values version api-version (reverse hooks))]
-             [(null? (cdr remaining))
-              (raise-syntax-error 'define-q-extension
-                                  "expected value after keyword"
-                                  (car remaining))]
-             [else
-              (define kw (syntax-e (car remaining)))
-              (case kw
-                [(#:version)
-                 (loop (cddr remaining)
-                       (syntax-e (cadr remaining))
-                       api-version hooks)]
-                [(#:api-version)
-                 (loop (cddr remaining)
-                       version
-                       (syntax-e (cadr remaining))
-                       hooks)]
-                [(#:on)
-                 (when (null? (cddr remaining))
-                   (raise-syntax-error 'define-q-extension
-                                       "expected handler after #:on hook-point"
-                                       (cadr remaining)))
-                 (define point-stx (cadr remaining))
-                 ;; H4: Validate hook-point name at macro expansion time
-                 (define point-sym (syntax-e point-stx))
-                 (unless (valid-hook-name? point-sym)
-                   (raise-syntax-error 'define-q-extension
-                                       (format "unknown hook point '~a'" point-sym)
-                                       point-stx))
-                 (define handler-stx (caddr remaining))
-                 (loop (cdddr remaining)
-                       version api-version
-                       (cons (cons point-stx handler-stx) hooks))]
-                [else
-                 (raise-syntax-error 'define-q-extension
-                                     "unknown keyword"
-                                     (car remaining))])])))
-       ;; Build pairs of (quoted-symbol handler-expr) for hasheq
-       (define hasheq-args
-         (apply append
-                (for/list ([hp hook-pairs])
-                  (list (datum->syntax stx (list 'quote (syntax-e (car hp))))
-                        (cdr hp)))))
-       (with-syntax ([ext-name ext-name]
-                     [ext-version version]
-                     [ext-api-version api-version]
-                     [(hasheq-arg ...) hasheq-args])
-         #'(define name-sym
-             (extension ext-name
-                        ext-version
-                        ext-api-version
-                        (hasheq hasheq-arg ...)))))]))
+  (syntax-parse stx
+    [(_ name-sym:id
+        (~alt (~optional (~seq #:version version:str))
+              (~optional (~seq #:api-version api-version:str))
+              (~seq #:on hook-point:id handler-expr)) ...)
+     (define ext-name (symbol->string (syntax-e #'name-sym)))
+     (define ext-version
+       (if (attribute version)
+           (syntax-e #'version)
+           "0.1.0"))
+     (define ext-api-version
+       (if (attribute api-version)
+           (syntax-e #'api-version)
+           "1"))
+     ;; Validate hook points at expansion time
+     (for ([hp (in-list (syntax->list #'(hook-point ...)))])
+       (define point-sym (syntax-e hp))
+       (unless (valid-hook-name? point-sym)
+         (raise-syntax-error 'define-q-extension (format "unknown hook point '~a'" point-sym) hp)))
+     ;; Build hasheq args from hook pairs
+     (define hasheq-args
+       (apply append
+              (for/list ([hp (in-list (syntax->list #'(hook-point ...)))]
+                         [he (in-list (syntax->list #'(handler-expr ...)))])
+                (list (datum->syntax stx (list 'quote (syntax-e hp))) he))))
+     (with-syntax ([ext-name-str ext-name]
+                   [ext-version-str ext-version]
+                   [ext-api-version-str ext-api-version]
+                   [(hasheq-arg ...) hasheq-args])
+       #'(define name-sym
+           (extension ext-name-str ext-version-str ext-api-version-str (hasheq hasheq-arg ...))))]))

--- a/extensions/github/tool-handlers.rkt
+++ b/extensions/github/tool-handlers.rkt
@@ -12,7 +12,12 @@
          "../hooks.rkt"
          "../tool-api.rkt"
          "../ext-commands.rkt"
-         (only-in "helpers.rkt" gh-binary gh-unavailable-error gh-exec-result git-exec-result)
+         (only-in "helpers.rkt"
+                  gh-binary
+                  gh-unavailable-error
+                  gh-exec-result
+                  git-exec-result
+                  with-error-result)
          "tool-schemas.rkt"
          "handlers/issue-ops.rkt"
          "handlers/pr-ops.rkt"
@@ -27,12 +32,7 @@
          register-github-tools
          register-github-commands)
 
-;; Local macro: execute body, returning error result on failure
-(define-syntax-rule (with-error-result ctx-msg body ...)
-  (with-handlers ([exn:fail? (lambda (e)
-                               (log-warning (format "~a: ~a" ctx-msg (exn-message e)))
-                               (make-error-result (exn-message e)))])
-    body ...))
+;; with-error-result imported from helpers.rkt
 
 ;; ============================================================
 ;; Wave handlers

--- a/runtime/credential-backend.rkt
+++ b/runtime/credential-backend.rkt
@@ -9,7 +9,8 @@
 ;; different backends: file (JSON), environment variables, memory (testing),
 ;; OS keychain (secret-tool / macOS security), and chained (fallback chain).
 
-(require "../util/json-helpers.rkt")
+(require "../util/json-helpers.rkt"
+         "../util/error-helpers.rkt")
 (require "../util/errors.rkt")
 (require racket/contract
          json
@@ -100,16 +101,16 @@
   (cond
     [(not (file-exists? path)) (hash)]
     [else
-     (with-handlers ([exn:fail? (λ (e) (hash))])
-       (define content (read-json-file path))
-       (if (eof-object? content)
-           (hash)
-           (let ([providers (hash-ref content 'providers (hash))])
-             (for/hash ([(k v) (in-hash providers)])
-               (values (if (symbol? k)
-                           (symbol->string k)
-                           k)
-                       v)))))]))
+     (with-safe-fallback (hash)
+                         (define content (read-json-file path))
+                         (if (eof-object? content)
+                             (hash)
+                             (let ([providers (hash-ref content 'providers (hash))])
+                               (for/hash ([(k v) (in-hash providers)])
+                                 (values (if (symbol? k)
+                                             (symbol->string k)
+                                             k)
+                                         v)))))]))
 
 (define (file-store! path provider-name api-key)
   (define existing (file-load-raw path))
@@ -154,11 +155,7 @@
     [(file-exists? path) #t]
     [else
      (define dir (path-only path))
-     (and dir
-          (or (directory-exists? dir)
-              (with-handlers ([exn:fail? (λ (e) #f)])
-                (make-directory* dir)
-                #t)))]))
+     (and dir (or (directory-exists? dir) (with-safe-fallback #f (make-directory* dir) #t)))]))
 
 (define (file-write-atomic! path data)
   (define dir (path-only path))
@@ -166,8 +163,7 @@
     (make-directory* dir))
   (define tmp (make-temporary-file "credential-~a.tmp" #f (or dir (find-system-path 'temp-dir))))
   (with-handlers ([exn:fail? (λ (e)
-                               (with-handlers ([exn:fail? void])
-                                 (delete-file tmp))
+                               (with-safe-fallback (void) (delete-file tmp))
                                (raise e))])
     (write-json-file tmp data)
     (rename-file-or-directory tmp path #t)
@@ -238,22 +234,20 @@
 ;; Run secret-tool with argument vector (no shell interpolation).
 ;; Returns (values exit-code stdout-string).
 (define (run-secret-tool args #:stdin [stdin-str #f])
-  (with-handlers ([exn:fail? (λ (e) (values 1 ""))])
-    (define-values (sp out-port in-port err-port)
-      (subprocess #f #f #f (find-executable-path "secret-tool") args))
-    (when stdin-str
-      (display stdin-str in-port)
-      (close-output-port in-port))
-    (define out (open-output-string))
-    (copy-port out-port out)
-    (close-input-port out-port)
-    (close-input-port err-port)
-    (values (subprocess-status sp) (get-output-string out))))
+  (with-safe-fallback (values 1 "")
+                      (define-values (sp out-port in-port err-port)
+                        (subprocess #f #f #f (find-executable-path "secret-tool") args))
+                      (when stdin-str
+                        (display stdin-str in-port)
+                        (close-output-port in-port))
+                      (define out (open-output-string))
+                      (copy-port out-port out)
+                      (close-input-port out-port)
+                      (close-input-port err-port)
+                      (values (subprocess-status sp) (get-output-string out))))
 
 (define (secret-tool-available?)
-  (with-handlers ([exn:fail? (λ (e) #f)])
-    (define-values (status _) (run-secret-tool '("--version")))
-    (= status 0)))
+  (with-safe-fallback #f (define-values (status _) (run-secret-tool '("--version"))) (= status 0)))
 
 (define (make-keychain-credential-backend)
   (credential-backend "keychain"
@@ -332,32 +326,26 @@
      (define stored #f)
      (for ([sub (in-list backends)]
            #:break stored)
-       (with-handlers ([exn:fail? (λ (e) (void))])
-         (backend-store! sub provider-name api-key)
-         (set! stored #t)))
+       (with-safe-fallback (void) (backend-store! sub provider-name api-key) (set! stored #t)))
      (unless stored
        (raise-credential-error "No writable backend available" "chained" "all-backends-readonly")))
    ;; load — tries each backend in order, returns first hit
    (λ (be provider-name env-var)
      (for/or ([sub (in-list backends)])
-       (with-handlers ([exn:fail? (λ (e) #f)])
-         (backend-load sub provider-name #:env-var (or env-var #f)))))
+       (with-safe-fallback #f (backend-load sub provider-name #:env-var (or env-var #f)))))
    ;; delete! — deletes from all backends
    (λ (be provider-name)
      (for ([sub (in-list backends)])
-       (with-handlers ([exn:fail? (λ (e) (void))])
-         (backend-delete! sub provider-name))))
+       (with-safe-fallback (void) (backend-delete! sub provider-name))))
    ;; list — merges from all backends
    (λ (be)
      (remove-duplicates (apply append
                                (for/list ([sub (in-list backends)])
-                                 (with-handlers ([exn:fail? (λ (e) '())])
-                                   (backend-list-providers sub))))))
+                                 (with-safe-fallback '() (backend-list-providers sub))))))
    ;; available? — true if any backend available
    (λ (be)
      (for/or ([sub (in-list backends)])
-       (with-handlers ([exn:fail? (λ (e) #f)])
-         (backend-available? sub))))))
+       (with-safe-fallback #f (backend-available? sub))))))
 
 ;; ═══════════════════════════════════════════════════════════════════
 ;; Helpers


### PR DESCRIPTION
Addresses #3753.

feat: v0.30.13 W0 - macro cleanup + HOF adoption (#3753)

- Deduplicate with-error-result: 2 copies → 1 shared in helpers.rkt
- Migrate define-q-extension from syntax-case to syntax-parse (~45 LOC saved)
- Adopt with-safe-fallback in credential-backend.rkt (10 handler sites)