### PR TITLE
feat: v0.30.13 W1 - parameter hygiene (#3754)

- Convert current-bridge-table from parameter to module-level hash (no parameterize sites)
- Document why remaining 6 parameters are justified (thread-local isolation, testing)
- session-bytes-written already deprecated, retained for backward compat

### DIFF
--- a/agent/loop-stream.rkt
+++ b/agent/loop-stream.rkt
@@ -25,7 +25,8 @@
 
 ;; Maximum number of chunks to process from a provider stream.
 ;; Prevents infinite loops from misbehaving providers.
-;; Parameterized for testing (set to small value in tests).
+;; Parameter justified: tests use `parameterize` to set small values;
+;; production uses default.
 (define MAX-STREAM-CHUNKS (make-parameter 10000))
 
 ;; ============================================================

--- a/llm/gemini.rkt
+++ b/llm/gemini.rkt
@@ -45,8 +45,8 @@
 (define GEMINI-DEFAULT-MAX-TOKENS 4096)
 
 ;; Per-request tool call ID counter (Issue #200)
-;; Uses a parameter so concurrent requests don't share/collide on IDs.
-;; The parameter is bound fresh in each send/stream call.
+;; Parameter justified: thread-local isolation via `parameterize` in stream/send calls;
+;; concurrent requests must not share or collide on IDs.
 (define gemini-tool-id-counter-param (make-parameter 0))
 
 ;; Generate a unique tool call ID within the current request.

--- a/runtime/safe-mode.rkt
+++ b/runtime/safe-mode.rkt
@@ -11,13 +11,20 @@
                   current-safe-mode
                   current-safe-mode-config
                   project-root
-                  safe-mode-config safe-mode-config?
-                  safe-mode-config-active safe-mode-config-allowed-tools
-                  safe-mode-config-allowed-paths safe-mode-config-locked
-                  safe-mode-config-project-root-path make-safe-mode-config
+                  safe-mode-config
+                  safe-mode-config?
+                  safe-mode-config-active
+                  safe-mode-config-allowed-tools
+                  safe-mode-config-allowed-paths
+                  safe-mode-config-locked
+                  safe-mode-config-project-root-path
+                  make-safe-mode-config
                   blocked-tools
-                  safe-mode? allowed-tool? allowed-path?
-                  safe-mode-project-root trust-level))
+                  safe-mode?
+                  allowed-tool?
+                  allowed-path?
+                  safe-mode-project-root
+                  trust-level))
 
 ;; ============================================================
 ;; Re-export everything from safe-mode-state
@@ -63,6 +70,8 @@
 ;; ============================================================
 
 (define safe-mode-lock-one-shot (box #f))
+;; Parameter justified: tests use `parameterize` for isolation;
+;; production sets #t once on lock activation.
 (define safe-mode-locked? (make-parameter #f))
 
 (define (locked?)

--- a/util/lockfile.rkt
+++ b/util/lockfile.rkt
@@ -59,6 +59,7 @@
     [else (zero? (raw-kill pid 0))]))
 
 ;; Lock directory — ~/.q/locks/ (parameterized for testing)
+;; Parameter justified: tests use `parameterize` to isolate lock dirs.
 (define current-locks-dir (make-parameter #f (lambda (v) v)))
 
 (define (locks-dir)

--- a/util/truncation.rkt
+++ b/util/truncation.rkt
@@ -12,6 +12,7 @@
 ;;;   output-exceeds-limits? — check if output exceeds limits
 ;;;   truncate-output-with-overflow — truncate + save full output to temp file
 ;;;   output-overflow-dir — parameter for overflow temp-file directory
+;;;   Parameter justified: tests use `parameterize` to redirect to temp dirs.
 ;;;
 ;;; #774, #1115, G5.2
 

--- a/wiring/rpc-ui-adapter.rkt
+++ b/wiring/rpc-ui-adapter.rkt
@@ -35,7 +35,7 @@
   ;; Store the table where the response handler can find it.
   ;; We attach it as a property on the thread for testability,
   ;; but the response handler receives the same table reference.
-  (hash-set! (current-bridge-table) ui-ch pending-requests)
+  (hash-set! bridge-table ui-ch pending-requests)
   (void (thread (lambda ()
                   (let loop ()
                     (define req (channel-get ui-ch))
@@ -67,8 +67,9 @@
 ;; table for a given UI channel.
 ;; ============================================================
 
-;; Q-21: parameterised bridge table for testability and isolation
-(define current-bridge-table (make-parameter (make-hash)))
+;; Module-level mutable hash: ui-channel → pending-requests hash.
+;; Converted from parameter (single-consumer, no parameterize sites).
+(define bridge-table (make-hash))
 
 ;; ============================================================
 ;; make-rpc-ui-response-handler : channel? -> (hash? -> hash?)
@@ -89,7 +90,7 @@
     (cond
       [(not request-id) (hasheq 'status "error" 'message "requestId required")]
       [else
-       (define pending-table (hash-ref (current-bridge-table) ui-ch #f))
+       (define pending-table (hash-ref bridge-table ui-ch #f))
        (define resp-ch (and pending-table (hash-ref pending-table request-id #f)))
        (cond
          [(not resp-ch) (hasheq 'status "error" 'message (format "unknown requestId: ~a" request-id))]


### PR DESCRIPTION
Addresses #3754.

feat: v0.30.13 W1 - parameter hygiene (#3754)

- Convert current-bridge-table from parameter to module-level hash (no parameterize sites)
- Document why remaining 6 parameters are justified (thread-local isolation, testing)
- session-bytes-written already deprecated, retained for backward compat