### PR TITLE
fix: v0.30.14 W0 - contract self-blame fix + test regression repair (#3798)

Fixed all contract self-blames in 5 production modules:
- tui/component.rkt: make-q-component, component-compose, component-handle-input, cycle-focus
- tui/tui-keybindings.rkt: make-tui-ctx, selection-text, process-slash-command, input-expand-last-prompt
- tui/tui-render-loop.rkt: render-ubuf-to-terminal!, render-frame!, draw-frame, next-message
- runtime/credential-backend.rkt: make-file-credential-backend, make-env-credential-backend, make-keychain-credential-backend
- extensions/dialog-api.rkt: ctx-select, apply-notification

Fixed 4 test files:
- test-iteration-loop-state.rkt: TR boundary (loop-infra fields)
- test-sdk-ergonomics.rkt: duplicate identifier
- test-session-lifecycle-ws.rkt: duplicate run-prompt! import
- test-tui-init.rkt: hasheq→event struct
- util/tree-entries.rkt: relaxed parent-id to (or/c string? #f)

Result: 470/471 files pass fast suite, 0 contract self-blames

### DIFF
--- a/extensions/dialog-api.rkt
+++ b/extensions/dialog-api.rkt
@@ -33,9 +33,11 @@
                 confirm-result?)]
           [ctx-select
            (->* ((listof select-option?))
-                (#:default (or/c string? #f) #:timeout exact-nonnegative-integer?)
-                select-result?)]
-          [apply-notification (-> notification-state? notification? notification-state?)]
+                (#:prompt string?
+                          #:timeout exact-nonnegative-integer?
+                          #:max-visible exact-nonnegative-integer?)
+                (or/c select-result? #f))]
+          [apply-notification (-> (or/c any/c box?) notification? any/c)]
           [expired-notification? (-> notification-state? boolean?)]
           [notification-state-add (-> notification-state? notification? notification-state?)]
           [notification-state-pop (-> notification-state? notification-state?)]

--- a/runtime/credential-backend.rkt
+++ b/runtime/credential-backend.rkt
@@ -24,12 +24,10 @@
 ;; Backend struct
 (provide (struct-out credential-backend)
          (contract-out
-          [make-file-credential-backend
-           (->* (path-string?) (#:create-if-missing? boolean?) credential-backend?)]
-          [make-env-credential-backend (->* () (#:prefix string?) credential-backend?)]
+          [make-file-credential-backend (->* () ((or/c path-string? #f)) credential-backend?)]
+          [make-env-credential-backend (-> credential-backend?)]
           [make-memory-credential-backend (-> credential-backend?)]
-          [make-keychain-credential-backend
-           (->* () (#:tool-path (or/c path-string? #f)) credential-backend?)]
+          [make-keychain-credential-backend (-> credential-backend?)]
           [make-chained-credential-backend (-> (listof credential-backend?) credential-backend?)]
           [backend-name (-> credential-backend? string?)]
           [backend-store! (-> credential-backend? string? string? void?)]

--- a/tests/test-dialog-api.rkt
+++ b/tests/test-dialog-api.rkt
@@ -126,8 +126,7 @@
   (check-equal? (select-option-description opt) "A description"))
 
 (test-case "ctx-select: returns select-result with first option"
-  (define options (list (select-option "a" "Alpha" "")
-                        (select-option "b" "Beta" "")))
+  (define options (list (select-option "a" "Alpha" "") (select-option "b" "Beta" "")))
   (define result (ctx-select options))
   (check-true (select-result? result))
   (check-equal? (select-result-selected-id result) "a")

--- a/tests/test-iteration-loop-state.rkt
+++ b/tests/test-iteration-loop-state.rkt
@@ -5,6 +5,7 @@
 (require rackunit
          rackunit/text-ui
          "../runtime/iteration/loop-state.rkt"
+         "../agent/event-bus.rkt"
          racket/set)
 
 (define suite
@@ -35,14 +36,14 @@
       (check-equal? (loop-counters-stall-retry-count c) 6))
 
     (test-case "loop-infra accessor round-trip"
-      (define infra (loop-infra 'ctx 'ext-reg 'reg 'bus "sid-1" "/tmp/log" 'token))
-      (check-equal? (loop-infra-ctx infra) 'ctx)
-      (check-equal? (loop-infra-ext-reg infra) 'ext-reg)
-      (check-equal? (loop-infra-reg infra) 'reg)
-      (check-equal? (loop-infra-bus infra) 'bus)
+      (define infra (loop-infra '(ctx) #f #f (make-event-bus) "sid-1" "/tmp/log" #f))
+      (check-equal? (loop-infra-ctx infra) '(ctx))
+      (check-false (loop-infra-ext-reg infra))
+      (check-false (loop-infra-reg infra))
+      (check-true (event-bus? (loop-infra-bus infra)))
       (check-equal? (loop-infra-session-id infra) "sid-1")
       (check-equal? (loop-infra-log-path infra) "/tmp/log")
-      (check-equal? (loop-infra-token infra) 'token))
+      (check-false (loop-infra-token infra)))
 
     (test-case "loop-counters is transparent"
       (define c (loop-counters 1 2 (set) 0 0 '() 0 0 0))
@@ -50,7 +51,7 @@
       (check-false (loop-counters? 42)))
 
     (test-case "loop-infra is transparent"
-      (define infra (loop-infra 'a 'b 'c 'd 'e 'f 'g))
+      (define infra (loop-infra '(a) #f #f (make-event-bus) "s" "/tmp" #f))
       (check-true (loop-infra? infra))
       (check-false (loop-infra? 'not-infra)))
 
@@ -61,10 +62,10 @@
       (check-equal? (loop-counters-consecutive-tool-count c2) 0))
 
     (test-case "struct-copy loop-infra"
-      (define infra (loop-infra 'ctx 'ext-reg 'reg 'bus "sid" "/log" 'tok))
+      (define infra (loop-infra '(ctx) #f #f (make-event-bus) "sid" "/log" #f))
       (define infra2 (struct-copy loop-infra infra [session-id "sid-2"]))
       (check-equal? (loop-infra-session-id infra2) "sid-2")
-      (check-equal? (loop-infra-ctx infra2) 'ctx))))
+      (check-equal? (loop-infra-ctx infra2) '(ctx)))))
 
 (module+ test
   (run-tests suite))

--- a/tests/test-sdk-ergonomics.rkt
+++ b/tests/test-sdk-ergonomics.rkt
@@ -29,8 +29,7 @@
                   context-usage-max-tokens
                   context-usage-usage-percent
                   context-usage-compaction-threshold
-                  get-context-usage
-                  context-usage-near-threshold?)
+                  get-context-usage)
          "../interfaces/sdk.rkt")
 
 ;; ============================================================

--- a/tests/test-session-lifecycle-ws.rkt
+++ b/tests/test-session-lifecycle-ws.rkt
@@ -7,9 +7,12 @@
          racket/file
          racket/path
          "../runtime/working-set.rkt"
-         "../runtime/session-lifecycle.rkt"
+         (only-in "../runtime/session-lifecycle.rkt"
+                  run-prompt!
+                  build-session-context
+                  run-prompt-internal)
          "../runtime/session-types.rkt"
-         "../runtime/agent-session.rkt"
+         (except-in "../runtime/agent-session.rkt" run-prompt!)
          "../util/protocol-types.rkt"
          "../agent/event-bus.rkt"
          "../util/ids.rkt"

--- a/tests/test-tui-init.rkt
+++ b/tests/test-tui-init.rkt
@@ -12,7 +12,8 @@
          "../tui/tui-init.rkt"
          "../tui/tui-keybindings.rkt"
          "../tui/state.rkt"
-         "../agent/event-bus.rkt")
+         "../agent/event-bus.rkt"
+         (only-in "../util/event.rkt" make-event))
 
 (define test-tui-init
   (test-suite "tui/tui-init"
@@ -36,7 +37,7 @@
       (define bus (make-event-bus))
       (define ctx (make-tui-ctx #:event-bus bus))
       (subscribe-runtime-events! ctx)
-      (define test-event (hasheq 'ev "test.event" 'payload (hasheq 'x 1)))
+      (define test-event (make-event "test.event" (current-inexact-milliseconds) #f #f (hasheq 'x 1)))
       (publish! bus test-event)
       ;; publish! calls subscribers synchronously, so event is already on channel
       (define ch (tui-ctx-event-ch ctx))
@@ -69,8 +70,8 @@
       (define ctx (make-tui-ctx #:event-bus bus))
       (subscribe-runtime-events! ctx)
       (define ch (tui-ctx-event-ch ctx))
-      (publish! bus (hasheq 'ev "first" 'payload (hasheq)))
-      (publish! bus (hasheq 'ev "second" 'payload (hasheq)))
+      (publish! bus (make-event "first" (current-inexact-milliseconds) #f #f (hasheq)))
+      (publish! bus (make-event "second" (current-inexact-milliseconds) #f #f (hasheq)))
       ;; Drain both
       (define e1 (sync/timeout 0.5 ch))
       (define e2 (sync/timeout 0.5 ch))

--- a/tui/component.rkt
+++ b/tui/component.rkt
@@ -18,22 +18,30 @@
 
 ;; Struct
 (provide (struct-out q-component)
-         (contract-out
-          [make-q-component (->* (procedure? procedure?) (#:id symbol?) q-component?)]
-          [component-render (-> q-component? any/c exact-nonnegative-integer? any/c)]
-          [component-invalidate! (-> q-component? void?)]
-          [component-compose (->* (q-component?) #:rest (listof q-component?) q-component?)]
-          [component-cached-width (-> q-component? (or/c exact-nonnegative-integer? #f))]
-          [component-handle-input (-> q-component? any/c any/c)]
-          [input-consumed (-> any/c)]
-          [input-bubble (-> any/c)]
-          [input-action (-> any/c any/c)]
-          [input-consumed? (-> any/c boolean?)]
-          [input-bubble? (-> any/c boolean?)]
-          [input-action? (-> any/c boolean?)]
-          [input-action-data (-> any/c any/c)]
-          [focusable-components (-> (listof q-component?) (listof q-component?))]
-          [cycle-focus (-> (listof q-component?) (or/c q-component? #f) (or/c q-component? #f))]))
+         (contract-out [make-q-component
+                        (->* (procedure?)
+                             (#:id symbol?
+                                   #:invalidate-fn procedure?
+                                   #:handle-input (or/c procedure? #f)
+                                   #:wants-focus? boolean?)
+                             q-component?)]
+                       [component-render (-> q-component? any/c exact-nonnegative-integer? any/c)]
+                       [component-invalidate! (-> q-component? void?)]
+                       [component-compose (-> any/c any/c any/c q-component?)]
+                       [component-cached-width (-> q-component? (or/c exact-nonnegative-integer? #f))]
+                       [component-handle-input (-> q-component? any/c any/c (values any/c any/c))]
+                       [input-consumed (-> any/c)]
+                       [input-bubble (-> any/c)]
+                       [input-action (-> any/c any/c)]
+                       [input-consumed? (-> any/c boolean?)]
+                       [input-bubble? (-> any/c boolean?)]
+                       [input-action? (-> any/c boolean?)]
+                       [input-action-data (-> any/c any/c)]
+                       [focusable-components (-> (listof q-component?) (listof q-component?))]
+                       [cycle-focus
+                        (->* ((listof q-component?) (or/c symbol? #f))
+                             (exact-integer?)
+                             (or/c symbol? #f))]))
 
 ;; ═══════════════════════════════════════════════════════════════════
 ;; Struct

--- a/tui/tui-keybindings.rkt
+++ b/tui/tui-keybindings.rkt
@@ -60,22 +60,24 @@
          make-mode-keymap
          mode-overlay->keymap
          (contract-out [make-tui-ctx
-                        (->* (any/c any/c any/c procedure? any/c any/c any/c)
-                             (#:session-dir (or/c path-string? #f)
-                                            #:model-registry-box (or/c any/c #f)
-                                            #:extension-registry-box (or/c any/c #f)
-                                            #:previous-frame-box (or/c any/c #f)
-                                            #:last-prompt-box (or/c any/c #f))
+                        (->* ()
+                             (#:event-bus any/c
+                                          #:session-runner procedure?
+                                          #:session-dir (or/c path-string? #f)
+                                          #:model-registry any/c
+                                          #:extension-registry any/c
+                                          #:session-queue any/c
+                                          #:session-factory-runner any/c)
                              tui-ctx?)]
                        [mark-dirty! (-> tui-ctx? void?)]
                        [handle-key (-> tui-ctx? any/c any/c)]
                        [handle-mouse (-> tui-ctx? any/c any/c)]
-                       [selection-text (-> tui-ctx? (or/c string? #f))]
-                       [process-slash-command (-> tui-ctx? string? any/c)]
+                       [selection-text (-> tui-ctx? any/c (or/c string? #f))]
+                       [process-slash-command (->* (tui-ctx? (or/c string? symbol?)) (string?) any/c)]
                        [tui-ctx->cmd-ctx (-> tui-ctx? any/c)]
                        [reload-keymap! (-> void?)]
                        [current-keybindings-path (-> (or/c path-string? #f))]
-                       [input-expand-last-prompt (-> tui-ctx? void?)]))
+                       [input-expand-last-prompt (-> string? tui-ctx? void?)]))
 
 ;; ============================================================
 ;; TUI context

--- a/tui/tui-render-loop.rkt
+++ b/tui/tui-render-loop.rkt
@@ -45,14 +45,14 @@
 (provide fix-sgr-bg-black
          decode-mouse-x10
          decode-mouse-tui-term
-         (contract-out [render-ubuf-to-terminal! (-> any/c any/c void?)]
+         (contract-out [render-ubuf-to-terminal! (-> any/c void?)]
                        [tui-ctx-init-terminal! (-> any/c void?)]
                        [tui-ctx-resize-ubuf! (-> any/c void?)]
                        [tui-ctx-ubuf (-> any/c any/c)]
                        [tui-ctx-term (-> any/c any/c)]
-                       [render-frame! (-> any/c any/c void?)]
-                       [draw-frame (-> any/c any/c any/c void?)]
-                       [next-message (-> any/c (or/c any/c #f))]
+                       [render-frame! (-> any/c void?)]
+                       [draw-frame (-> any/c void?)]
+                       [next-message (->* (any/c) (#:timeout any/c) (or/c any/c #f))]
                        [tui-main-loop (-> any/c void?)]
                        [drain-events! (-> any/c void?)]))
 

--- a/util/tree-entries.rkt
+++ b/util/tree-entries.rkt
@@ -18,7 +18,7 @@
                        [tree-navigation-entry-target-entry-id (-> any/c (or/c string? #f))]
                        [tree-navigation-entry-from-entry-id (-> any/c (or/c string? #f))]
                        [make-branch-summary-entry
-                        (-> string? string? string? any/c exact-nonnegative-integer? any/c)]
+                        (-> string? (or/c string? #f) string? any/c exact-nonnegative-integer? any/c)]
                        [branch-summary-entry-summary (-> any/c (or/c string? #f))]
                        [branch-summary-entry-entry-range (-> any/c any/c)]
                        [branch-summary-entry-token-count


### PR DESCRIPTION
Addresses #3798.

fix: v0.30.14 W0 - contract self-blame fix + test regression repair (#3798)

Fixed all contract self-blames in 5 production modules:
- tui/component.rkt: make-q-component, component-compose, component-handle-input, cycle-focus
- tui/tui-keybindings.rkt: make-tui-ctx, selection-text, process-slash-command, input-expand-last-prompt
- tui/tui-render-loop.rkt: render-ubuf-to-terminal!, render-frame!, draw-frame, next-message
- runtime/credential-backend.rkt: make-file-credential-backend, make-env-credential-backend, make-keychain-credential-backend
- extensions/dialog-api.rkt: ctx-select, apply-notification

Fixed 4 test files:
- test-iteration-loop-state.rkt: TR boundary (loop-infra fields)
- test-sdk-ergonomics.rkt: duplicate identifier
- test-session-lifecycle-ws.rkt: duplicate run-prompt! import
- test-tui-init.rkt: hasheq→event struct
- util/tree-entries.rkt: relaxed parent-id to (or/c string? #f)

Result: 470/471 files pass fast suite, 0 contract self-blames