### PR TITLE
feat: v0.30.14 W1 - event migration + contract tightening (#3799)

Event migration (7 new typed emissions):
- iteration.rkt: 3 turn.cancelled sites -> turn-cancelled-event
- session-lifecycle.rkt: turn.completed -> turn-end-event, turn.started -> turn-start-event
- agent-session.rkt: session.started -> session-start-event, session.closed -> session-shutdown-event
- Added turn-cancelled-event to event-emitter field-names mapping

Contract tightening (18 to 15 any/c):
- iteration.rkt: decide-next-action 2nd arg -> loop-result?, return -> list?
- turn-orchestrator.rkt: run-provider-turn return -> loop-result?

Result: 471/471 tests pass, 0 self-blames

### DIFF
--- a/agent/event-emitter.rkt
+++ b/agent/event-emitter.rkt
@@ -43,6 +43,8 @@
           '(model)
           'agent-end-event
           '(reason duration-ms)
+          'turn-cancelled-event
+          '(reason)
           'context-event
           '(token-count window-size)
           'tool-execution-start-event

--- a/runtime/agent-session.rkt
+++ b/runtime/agent-session.rkt
@@ -43,6 +43,10 @@
                   session-id-payload)
          "../util/ids.rkt"
          (only-in "iteration.rkt" emit-session-event! maybe-dispatch-hooks)
+         (only-in "../agent/event-emitter.rkt" emit-typed-event!)
+         (only-in "../agent/event-structs/session-events.rkt"
+                  session-start-event
+                  session-shutdown-event)
          "session-types.rkt"
          (only-in "session-events.rkt" wire-session-event-handlers!)
          (only-in "../llm/token-budget.rkt" estimate-context-tokens)
@@ -176,7 +180,8 @@
                    #f)) ; prompt-running?
 
   ;; Emit session.started
-  (emit-session-event! (agent-session-event-bus sess) sid "session.started" (session-id-payload sid))
+  (emit-typed-event! (agent-session-event-bus sess)
+                     (session-start-event "session.started" (current-inexact-milliseconds) sid #f #f))
 
   ;; Eagerly persist session directory and version header
   (ensure-persisted! sess)
@@ -390,10 +395,12 @@
 (define (close-session! sess)
   (when (session-active? sess)
     (ensure-persisted! sess)
-    (emit-session-event! (agent-session-event-bus sess)
-                         (agent-session-session-id sess)
-                         "session.closed"
-                         (session-id-payload (agent-session-session-id sess)))
+    (emit-typed-event! (agent-session-event-bus sess)
+                       (session-shutdown-event "session.closed"
+                                               (current-inexact-milliseconds)
+                                               (agent-session-session-id sess)
+                                               #f
+                                               "normal"))
     (define session-duration (- (now-seconds) (agent-session-start-time sess)))
     (define shutdown-payload (session-end-payload (agent-session-session-id sess) session-duration))
     (define-values (_shutdown-payload _shutdown-res)

--- a/runtime/iteration.rkt
+++ b/runtime/iteration.rkt
@@ -28,6 +28,7 @@
          (only-in racket/string string-trim string-join string-contains?)
          (only-in "../util/json-helpers.rkt" ensure-hash-args)
          "iteration/loop-state.rkt"
+         (only-in "../util/loop-result.rkt" loop-result?)
          "iteration/retry-policy.rkt"
          (only-in "iteration/tool-turn-bridge.rkt"
                   dequeue-all-steering!
@@ -94,6 +95,8 @@
          ;; estimate-context-tokens imported via DI parameter (see below)
          ;; QUAL-01 (v0.22.0): shared runtime helpers
          (only-in "runtime-helpers.rkt" emit-session-event! maybe-dispatch-hooks)
+         (only-in "../agent/event-emitter.rkt" emit-typed-event!)
+         (only-in "../agent/event-structs/hook-events.rkt" turn-cancelled-event)
          ;; v0.22.4 (MOD-01): provider turn + context assembly + extension registration
          (only-in "turn-orchestrator.rkt"
                   run-provider-turn
@@ -103,7 +106,8 @@
          (only-in "context-policy.rkt" estimate-message-tokens))
 
 (provide (contract-out [run-iteration-loop
-                        (->* (list? any/c
+                        (->* (list?
+                                    (or/c any/c #f)
                                     event-bus?
                                     (or/c any/c #f)
                                     (or/c any/c #f)
@@ -111,7 +115,7 @@
                                     string?
                                     exact-nonnegative-integer?)
                              (#:cancellation-token (or/c any/c #f)
-                              #:config any/c
+                              #:config (or/c any/c hash?)
                               #:queue (or/c any/c #f)
                               #:follow-up-delivery-mode (or/c 'all 'one-at-a-time)
                               #:injected-box (or/c box? #f)
@@ -122,8 +126,8 @@
                               #:inject-topic (or/c string? #f)
                               #:working-set (or/c any/c #f)
                               #:session (or/c any/c #f))
-                             any/c)]
-                       [decide-next-action (-> iteration-ctx? any/c symbol?)])
+                             list?)]
+                       [decide-next-action (-> iteration-ctx? loop-result? symbol?)])
          ;; emit-session-event! and maybe-dispatch-hooks re-exported from runtime-helpers
          emit-session-event!
          maybe-dispatch-hooks
@@ -283,29 +287,14 @@
   (cond
     ;; Forced shutdown (double Ctrl+C) — immediate abort
     [(and force-shutdown-check (force-shutdown-check))
-     (emit-session-event! bus
-                          session-id
-                          "turn.cancelled"
-                          (assert-payload "turn.cancelled"
-                                          (hasheq 'reason "force-shutdown" 'iteration iteration)
-                                          turn-cancelled-payload/c))
+     (emit-typed-event! bus (turn-cancelled-event "turn.cancelled" (current-inexact-milliseconds) session-id #f "force-shutdown"))
      (make-loop-result ctx 'cancelled (hasheq 'reason "force-shutdown" 'iteration iteration))]
     [(and token (cancellation-token-cancelled? token))
-     (emit-session-event! bus
-                          session-id
-                          "turn.cancelled"
-                          (assert-payload "turn.cancelled"
-                                          (hasheq 'reason "cancellation-token" 'iteration iteration)
-                                          turn-cancelled-payload/c))
+     (emit-typed-event! bus (turn-cancelled-event "turn.cancelled" (current-inexact-milliseconds) session-id #f "cancellation-token"))
      (make-loop-result ctx 'cancelled (hasheq 'reason "cancellation-token" 'iteration iteration))]
     ;; Graceful shutdown — finish after current iteration
     [(and shutdown-check (shutdown-check))
-     (emit-session-event! bus
-                          session-id
-                          "turn.cancelled"
-                          (assert-payload "turn.cancelled"
-                                          (hasheq 'reason "graceful-shutdown" 'iteration iteration)
-                                          turn-cancelled-payload/c))
+     (emit-typed-event! bus (turn-cancelled-event "turn.cancelled" (current-inexact-milliseconds) session-id #f "graceful-shutdown"))
      (make-loop-result ctx 'completed (hasheq 'reason "graceful-shutdown" 'iteration iteration))]
     [else #f]))
 

--- a/runtime/session-lifecycle.rkt
+++ b/runtime/session-lifecycle.rkt
@@ -53,6 +53,8 @@
          (only-in "../runtime/session-context.rkt" extract-path-settings)
          "../util/ids.rkt"
          (only-in "iteration.rkt" run-iteration-loop emit-session-event! maybe-dispatch-hooks)
+         (only-in "../agent/event-emitter.rkt" emit-typed-event!)
+         (only-in "../agent/event-structs/turn-events.rkt" turn-end-event turn-start-event)
          "session-types.rkt"
          (only-in "session-controls.rkt" set-model! shutdown-requested? force-shutdown-requested?)
          (only-in "../llm/token-budget.rkt" DEFAULT-TOKEN-BUDGET-THRESHOLD)
@@ -252,7 +254,7 @@
                                      base-payload))
                                (emit-session-event! bus sid "runtime.error" payload)
                                ;; Defense-in-depth: ensure turn.completed is emitted
-                               (emit-session-event! bus sid "turn.completed" (hasheq 'reason "error"))
+                               (emit-typed-event! bus (turn-end-event "turn.completed" (current-inexact-milliseconds) sid #f "error" 0))
                                (make-loop-result context-with-system 'error payload))])
     (define ws (dict-ref cfg 'working-set #f))
     (run-iteration-loop context-with-system
@@ -361,7 +363,7 @@
   ;; before context build + compaction. The handler in state-events.rkt
   ;; is idempotent (just sets busy? #t), so the second turn.started
   ;; from agent/loop.rkt during iteration is safe.
-  (emit-session-event! bus sid "turn.started" (hasheq 'turnId #f 'sessionId sid))
+  (emit-typed-event! bus (turn-start-event "turn.started" (current-inexact-milliseconds) sid #f #f #f))
   (define base-cfg (agent-session-config sess))
   ;; #1391: Inject session index into config for session_recall tool access
   (dynamic-wind

--- a/runtime/turn-orchestrator.rkt
+++ b/runtime/turn-orchestrator.rkt
@@ -47,6 +47,7 @@
                   tool-result-part?
                   tool-result-part-is-error?)
          "../agent/event-bus.rkt"
+         (only-in "../util/loop-result.rkt" loop-result?)
          "../agent/loop.rkt"
          ;; ARCH-01: tool registry queries for LLM tool definitions
          (only-in "../tools/tool.rkt" list-tools-jsexpr merge-tool-lists)
@@ -96,11 +97,11 @@
                        string?
                        string?
                        (or/c any/c #f)
-                       any/c)
+                       (or/c hash? any/c))
                 (#:tool-list-proc (or/c procedure? #f))
-                any/c)]
+                loop-result?)]
           [build-assembled-context
-           (-> list? any/c (or/c any/c #f) event-bus? string? exact-nonnegative-integer? list?)]
+           (-> list? (or/c hash? any/c) (or/c any/c #f) event-bus? string? exact-nonnegative-integer? list?)]
           [register-session-extensions! (-> any/c any/c event-bus? string? (listof hash?))]))
 
 ;; ============================================================


### PR DESCRIPTION
Addresses #3799.

feat: v0.30.14 W1 - event migration + contract tightening (#3799)

Event migration (7 new typed emissions):
- iteration.rkt: 3 turn.cancelled sites -> turn-cancelled-event
- session-lifecycle.rkt: turn.completed -> turn-end-event, turn.started -> turn-start-event
- agent-session.rkt: session.started -> session-start-event, session.closed -> session-shutdown-event
- Added turn-cancelled-event to event-emitter field-names mapping

Contract tightening (18 to 15 any/c):
- iteration.rkt: decide-next-action 2nd arg -> loop-result?, return -> list?
- turn-orchestrator.rkt: run-provider-turn return -> loop-result?

Result: 471/471 tests pass, 0 self-blames