### PR TITLE
feat: v0.30.15 W0 - contract safety, any/c elimination, event field restore (#3804)

G1: Fixed test-sdk-ergonomics.rkt duplicate import (471/471 pass)
G2: Fixed 3 contract self-blames (component-compose, input-expand-last-prompt, tui-ctx-init-terminal!)
G3: Replaced 16 any/c pseudo-tightenings with real predicates (provider?, tool-registry?, extension-registry?, cancellation-token?, queue?, working-set?, agent-session?, session-config?)
G4: Added iteration field to turn-cancelled-event struct + updated 3 callers

Result: 471/471 tests pass, 0 self-blames, 0 any/c in iteration.rkt + turn-orchestrator.rkt

### DIFF
--- a/agent/event-emitter.rkt
+++ b/agent/event-emitter.rkt
@@ -44,7 +44,7 @@
           'agent-end-event
           '(reason duration-ms)
           'turn-cancelled-event
-          '(reason)
+          '(reason iteration)
           'context-event
           '(token-count window-size)
           'tool-execution-start-event

--- a/agent/event-structs/hook-events.rkt
+++ b/agent/event-structs/hook-events.rkt
@@ -49,13 +49,14 @@
 ;; Turn cancelled
 ;; ============================================================
 
-(struct turn-cancelled-event typed-event (reason) #:transparent)
+(struct turn-cancelled-event typed-event (reason iteration) #:transparent)
 
 (define (make-turn-cancelled-event #:session-id session-id
                                    #:turn-id turn-id
                                    #:timestamp timestamp
-                                   #:reason reason)
-  (turn-cancelled-event "turn.cancelled" timestamp session-id turn-id reason))
+                                   #:reason reason
+                                   #:iteration [iteration #f])
+  (turn-cancelled-event "turn.cancelled" timestamp session-id turn-id reason iteration))
 
 ;; ============================================================
 ;; Assistant message completed

--- a/runtime/iteration.rkt
+++ b/runtime/iteration.rkt
@@ -63,7 +63,8 @@
                   dequeue-steering!
                   dequeue-followup!
                   dequeue-all-followups!
-                  queue-status)
+                  queue-status
+                  queue?)
          "../agent/loop.rkt"
          ;; Settings struct for exec-context runtime-settings (#1240)
          (only-in "../runtime/settings.rkt" make-minimal-settings)
@@ -96,6 +97,11 @@
          ;; QUAL-01 (v0.22.0): shared runtime helpers
          (only-in "runtime-helpers.rkt" emit-session-event! maybe-dispatch-hooks)
          (only-in "../agent/event-emitter.rkt" emit-typed-event!)
+         (only-in "../llm/provider.rkt" provider?)
+         (only-in "../tools/registry.rkt" tool-registry?)
+         (only-in "../extensions/api.rkt" extension-registry?)
+         (only-in "../runtime/session-types.rkt" agent-session?)
+         (only-in "../runtime/session-config.rkt" session-config?)
          (only-in "../agent/event-structs/hook-events.rkt" turn-cancelled-event)
          ;; v0.22.4 (MOD-01): provider turn + context assembly + extension registration
          (only-in "turn-orchestrator.rkt"
@@ -107,16 +113,16 @@
 
 (provide (contract-out [run-iteration-loop
                         (->* (list?
-                                    (or/c any/c #f)
+                                    (or/c provider? #f)
                                     event-bus?
-                                    (or/c any/c #f)
-                                    (or/c any/c #f)
+                                    (or/c tool-registry? #f)
+                                    (or/c extension-registry? #f)
                                     (or/c path-string? path?)
                                     string?
                                     exact-nonnegative-integer?)
-                             (#:cancellation-token (or/c any/c #f)
-                              #:config (or/c any/c hash?)
-                              #:queue (or/c any/c #f)
+                             (#:cancellation-token (or/c cancellation-token? #f)
+                              #:config (or/c hash? session-config?)
+                              #:queue (or/c queue? #f)
                               #:follow-up-delivery-mode (or/c 'all 'one-at-a-time)
                               #:injected-box (or/c box? #f)
                               #:shutdown-check (or/c procedure? #f)
@@ -124,8 +130,8 @@
                               #:compact-proc (or/c procedure? #f)
                               #:estimate-tokens (or/c procedure? #f)
                               #:inject-topic (or/c string? #f)
-                              #:working-set (or/c any/c #f)
-                              #:session (or/c any/c #f))
+                              #:working-set (or/c working-set? #f)
+                              #:session (or/c agent-session? #f))
                              list?)]
                        [decide-next-action (-> iteration-ctx? loop-result? symbol?)])
          ;; emit-session-event! and maybe-dispatch-hooks re-exported from runtime-helpers
@@ -287,14 +293,14 @@
   (cond
     ;; Forced shutdown (double Ctrl+C) — immediate abort
     [(and force-shutdown-check (force-shutdown-check))
-     (emit-typed-event! bus (turn-cancelled-event "turn.cancelled" (current-inexact-milliseconds) session-id #f "force-shutdown"))
+     (emit-typed-event! bus (turn-cancelled-event "turn.cancelled" (current-inexact-milliseconds) session-id #f "force-shutdown" iteration))
      (make-loop-result ctx 'cancelled (hasheq 'reason "force-shutdown" 'iteration iteration))]
     [(and token (cancellation-token-cancelled? token))
-     (emit-typed-event! bus (turn-cancelled-event "turn.cancelled" (current-inexact-milliseconds) session-id #f "cancellation-token"))
+     (emit-typed-event! bus (turn-cancelled-event "turn.cancelled" (current-inexact-milliseconds) session-id #f "cancellation-token" iteration))
      (make-loop-result ctx 'cancelled (hasheq 'reason "cancellation-token" 'iteration iteration))]
     ;; Graceful shutdown — finish after current iteration
     [(and shutdown-check (shutdown-check))
-     (emit-typed-event! bus (turn-cancelled-event "turn.cancelled" (current-inexact-milliseconds) session-id #f "graceful-shutdown"))
+     (emit-typed-event! bus (turn-cancelled-event "turn.cancelled" (current-inexact-milliseconds) session-id #f "graceful-shutdown" iteration))
      (make-loop-result ctx 'completed (hasheq 'reason "graceful-shutdown" 'iteration iteration))]
     [else #f]))
 

--- a/runtime/turn-orchestrator.rkt
+++ b/runtime/turn-orchestrator.rkt
@@ -48,6 +48,10 @@
                   tool-result-part-is-error?)
          "../agent/event-bus.rkt"
          (only-in "../util/loop-result.rkt" loop-result?)
+         (only-in "../util/cancellation.rkt" cancellation-token?)
+         (only-in "../llm/provider.rkt" provider?)
+         (only-in "../tools/registry.rkt" tool-registry?)
+         (only-in "../extensions/api.rkt" extension-registry?)
          "../agent/loop.rkt"
          ;; ARCH-01: tool registry queries for LLM tool definitions
          (only-in "../tools/tool.rkt" list-tools-jsexpr merge-tool-lists)
@@ -90,19 +94,20 @@
 
 (provide (contract-out
           [run-provider-turn
-           (->* (list? any/c
+           (->* (list?
+                       (or/c provider? #f)
                        event-bus?
-                       (or/c any/c #f)
-                       (or/c any/c #f)
+                       (or/c tool-registry? #f)
+                       (or/c extension-registry? #f)
                        string?
                        string?
-                       (or/c any/c #f)
-                       (or/c hash? any/c))
+                       (or/c cancellation-token? #f)
+                       hash?)
                 (#:tool-list-proc (or/c procedure? #f))
                 loop-result?)]
           [build-assembled-context
-           (-> list? (or/c hash? any/c) (or/c any/c #f) event-bus? string? exact-nonnegative-integer? list?)]
-          [register-session-extensions! (-> any/c any/c event-bus? string? (listof hash?))]))
+           (-> list? hash? (or/c extension-registry? #f) event-bus? string? exact-nonnegative-integer? list?)]
+          [register-session-extensions! (-> tool-registry? (or/c extension-registry? #f) event-bus? string? (listof hash?))]))
 
 ;; ============================================================
 ;; Context assembly

--- a/tests/test-sdk-ergonomics.rkt
+++ b/tests/test-sdk-ergonomics.rkt
@@ -23,13 +23,7 @@
                   thinking-levels
                   session-id)
          (only-in "../llm/token-budget.rkt"
-                  context-usage
-                  context-usage?
-                  context-usage-total-tokens
-                  context-usage-max-tokens
-                  context-usage-usage-percent
-                  context-usage-compaction-threshold
-                  get-context-usage)
+                  context-usage)
          "../interfaces/sdk.rkt")
 
 ;; ============================================================

--- a/tui/component.rkt
+++ b/tui/component.rkt
@@ -14,7 +14,8 @@
 (require racket/contract
          racket/list
          "render.rkt"
-         "state.rkt")
+         "state.rkt"
+         (only-in "render/message-layout.rkt" styled-line?))
 
 ;; Struct
 (provide (struct-out q-component)
@@ -27,7 +28,7 @@
                              q-component?)]
                        [component-render (-> q-component? any/c exact-nonnegative-integer? any/c)]
                        [component-invalidate! (-> q-component? void?)]
-                       [component-compose (-> any/c any/c any/c q-component?)]
+                       [component-compose (-> any/c any/c any/c (listof styled-line?))]
                        [component-cached-width (-> q-component? (or/c exact-nonnegative-integer? #f))]
                        [component-handle-input (-> q-component? any/c any/c (values any/c any/c))]
                        [input-consumed (-> any/c)]

--- a/tui/tui-keybindings.rkt
+++ b/tui/tui-keybindings.rkt
@@ -77,7 +77,7 @@
                        [tui-ctx->cmd-ctx (-> tui-ctx? any/c)]
                        [reload-keymap! (-> void?)]
                        [current-keybindings-path (-> (or/c path-string? #f))]
-                       [input-expand-last-prompt (-> string? tui-ctx? void?)]))
+                       [input-expand-last-prompt (-> string? tui-ctx? string?)]))
 
 ;; ============================================================
 ;; TUI context

--- a/tui/tui-render-loop.rkt
+++ b/tui/tui-render-loop.rkt
@@ -134,7 +134,7 @@
   (enable-mouse-tracking)
   ;; Detect synchronized output support
   (detect-sync-mode-support!)
-  term)
+  (void))
 
 ;; Resize ubuf when terminal size changes
 (define (tui-ctx-resize-ubuf! ctx)


### PR DESCRIPTION
Addresses #3804.

feat: v0.30.15 W0 - contract safety, any/c elimination, event field restore (#3804)

G1: Fixed test-sdk-ergonomics.rkt duplicate import (471/471 pass)
G2: Fixed 3 contract self-blames (component-compose, input-expand-last-prompt, tui-ctx-init-terminal!)
G3: Replaced 16 any/c pseudo-tightenings with real predicates (provider?, tool-registry?, extension-registry?, cancellation-token?, queue?, working-set?, agent-session?, session-config?)
G4: Added iteration field to turn-cancelled-event struct + updated 3 callers

Result: 471/471 tests pass, 0 self-blames, 0 any/c in iteration.rkt + turn-orchestrator.rkt