### PR TITLE
fix: v0.30.16 W1 - fix latent contract violation in turn-orchestrator.rkt (#3811)

G2: Added session-config? import, fixed 2 contracts:
- run-provider-turn 8th arg: hash? → (or/c hash? session-config?)
- build-assembled-context 2nd arg: hash? → (or/c hash? session-config?)

Result: 18/18 lint pass, 16 tests pass, no contract violations.

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ q/
 |--------|-------|
 | Test files | 516 |
 | Source modules | 393 |
-| Source lines | 62425 |
+| Source lines | 62426 |
 | Test lines | 95319 |
 | Test assertions | 14702 |
 | Tests passing | 5835+ | `racket scripts/run-tests.rkt` results |

--- a/runtime/turn-orchestrator.rkt
+++ b/runtime/turn-orchestrator.rkt
@@ -90,7 +90,8 @@
          (only-in "runtime-helpers.rkt" emit-session-event! maybe-dispatch-hooks)
          ;; G4: typed event emission
          "../agent/event-emitter.rkt"
-         "../agent/event-structs/iteration-events.rkt")
+         "../agent/event-structs/iteration-events.rkt"
+         (only-in "../runtime/session-config.rkt" session-config?))
 
 (provide (contract-out
           [run-provider-turn
@@ -102,11 +103,11 @@
                        string?
                        string?
                        (or/c cancellation-token? #f)
-                       hash?)
+                       (or/c hash? session-config?))
                 (#:tool-list-proc (or/c procedure? #f))
                 loop-result?)]
           [build-assembled-context
-           (-> list? hash? (or/c extension-registry? #f) event-bus? string? exact-nonnegative-integer? list?)]
+           (-> list? (or/c hash? session-config?) (or/c extension-registry? #f) event-bus? string? exact-nonnegative-integer? list?)]
           [register-session-extensions! (-> tool-registry? (or/c extension-registry? #f) event-bus? string? (listof hash?))]))
 
 ;; ============================================================


### PR DESCRIPTION
Addresses #3811.

fix: v0.30.16 W1 - fix latent contract violation in turn-orchestrator.rkt (#3811)

G2: Added session-config? import, fixed 2 contracts:
- run-provider-turn 8th arg: hash? → (or/c hash? session-config?)
- build-assembled-context 2nd arg: hash? → (or/c hash? session-config?)

Result: 18/18 lint pass, 16 tests pass, no contract violations.