### PR TITLE
chore: v0.30.16 release — version bump + CHANGELOG (#3812)

G3: Full infra verification — 471/471 tests pass (2134 total), 18/18 lint, 10/10 IVG
G4: Version bump 0.30.15 → 0.30.16 + CHANGELOG entry
G5: Latent contract violation resolved (16/16 iteration tests pass)

Milestone v0.30.16 complete: 17 version mismatches fixed, 2 contracts fixed, 0 lint failures.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## v0.30.16 — 2026-05-06
+
+### Audit Remediation: Version Sync + Contract Safety
+
+**Goal:** Address all actionable findings from v0.30.15 audit (6.5/10 → 8.0/10).
+
+**W0 — Version sync (15 files):**
+- Fixed 17 version mismatches: `info.rkt`, `README.md`, 12 doc files, wiki
+- All files now at `0.30.15` (matching `util/version.rkt`)
+- Lint 18/18 restored (was 15/18)
+
+**W1 — Contract fix (1 file):**
+- Fixed latent contract violation in `turn-orchestrator.rkt`
+- Added `session-config?` import
+- Changed 2× `hash?` → `(or/c hash? session-config?)` for config parameters
+- `session-config` structs now pass contracts without blame
+
+**W2 — Infrastructure + version bump:**
+- 471/471 tests pass, 18/18 lint, 10/10 IVG
+- Version bumped to 0.30.16
+- All downstream files synced to 0.30.16
+
+**Impact:** 471/471 tests pass, 18/18 lint, 0 contract self-blames, 0 latent violations, 0 version drift.
+
+---
+
 ## v0.30.15 — 2026-05-05
 
 ### Audit Remediation: Contract Safety + Version Sync + Event Cleanup

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.30.15-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.30.16-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 
@@ -199,7 +199,7 @@ racket main.rkt --model gpt-5.4 "write a test"
 ### Verify
 
 ```bash
-racket main.rkt --version  # q version 0.30.15
+racket main.rkt --version  # q version 0.30.16
 raco test tests/           # run the full test suite
 ```
 
@@ -337,7 +337,7 @@ When q executes shell commands on behalf of an LLM, arguments are quoted via `sh
 
 
 
-**v0.30.15** — Audit Remediation: Contract Safety + Version Sync + Event Cleanup
+**v0.30.16** — Audit Remediation: Version Sync + Contract Safety
 
 **v0.30.14** — Test Regression Fix + Contract Repair + Event Migration
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -2,7 +2,7 @@
 
 ## Version
 
-v0.30.15
+v0.30.16
 
 ## Layer Diagram
 
@@ -64,7 +64,7 @@ See `docs/architecture/dependency-policy.rktd` for layering rules and known viol
 
 Two tiers:
 1. **Raw events**: `make-event` + `emit-event!` (legacy, being phased out)
-2. **Typed events**: 27 structs in `agent/event-structs/` + `emit-typed-event!` (v0.30.15+)
+2. **Typed events**: 27 structs in `agent/event-structs/` + `emit-typed-event!` (v0.30.16+)
 
 ## Testing
 

--- a/docs/event-taxonomy.md
+++ b/docs/event-taxonomy.md
@@ -1,6 +1,6 @@
 # Q Event Taxonomy Reference
 
-Complete reference for all event types in Q 0.30.15.
+Complete reference for all event types in Q 0.30.16.
 ## Base Types
 
 ### `event` (protocol-level)

--- a/docs/extension-guide.md
+++ b/docs/extension-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.30.15 --># Extension Development Guide
+<!-- verified-against: 0.30.16 --># Extension Development Guide
 
 This guide walks you through creating, testing, and activating a custom
 extension for q.

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.30.15 --># Getting Started
+<!-- verified-against: 0.30.16 --># Getting Started
 
 Welcome to q, a Racket-based coding agent.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.30.15 --># Installation Guide
+<!-- verified-against: 0.30.16 --># Installation Guide
 
 <!-- This file is the canonical source. The docs/getting-started/installation.md copy is maintained for the doc site build. -->
 

--- a/docs/security-trust-model.md
+++ b/docs/security-trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.30.15 --># Security & Trust Model
+<!-- verified-against: 0.30.16 --># Security & Trust Model
 
 This document provides an honest, per-area assessment of what q enforces
 today and what is planned. It is the authoritative reference for security

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.30.15 --># Security Considerations
+<!-- verified-against: 0.30.16 --># Security Considerations
 
 ## API Key Storage
 

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -130,6 +130,6 @@ is the primary self-hosting extension:
 (load-extension! ext-reg "path/to/extension.rkt" #:event-bus bus)
 ```
 
-## Version 0.30.15
+## Version 0.30.16
 
-This documentation reflects q 0.30.15.
+This documentation reflects q 0.30.16.

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.30.15 --># q Source Style Guide
+<!-- verified-against: 0.30.16 --># q Source Style Guide
 
 This document defines formatting and naming conventions for the q Racket codebase.
 All changes to `q/` source files (excluding `tests/`) should follow these rules.

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.30.15 --># Trust Model
+<!-- verified-against: 0.30.16 --># Trust Model
 
 ## Trust Levels
 

--- a/docs/workflow-testing.md
+++ b/docs/workflow-testing.md
@@ -121,6 +121,6 @@ Use relative paths from the test file:
 4. Use `(check-true ...)` for boolean assertions
 5. Keep tests independent — no shared mutable state between test-cases
 
-## Version 0.30.15
+## Version 0.30.16
 
-This documentation reflects q 0.30.15.
+This documentation reflects q 0.30.16.

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.30.15")
+(define version "0.30.16")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base"))

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -10,4 +10,4 @@
 (provide q-version)
 
 (: q-version String)
-(define q-version "0.30.15")
+(define q-version "0.30.16")

--- a/wiki-src/Architecture-Overview.md
+++ b/wiki-src/Architecture-Overview.md
@@ -35,7 +35,7 @@ User input → Interface (CLI/TUI/RPC)
     → Events emitted to bus
 ```
 
-## Metrics (0.30.15)
+## Metrics (0.30.16)
 > _See `racket scripts/metrics.rkt` for current numbers._
 
 - 228 source modules, 349 test files


### PR DESCRIPTION
Addresses #3812.

chore: v0.30.16 release — version bump + CHANGELOG (#3812)

G3: Full infra verification — 471/471 tests pass (2134 total), 18/18 lint, 10/10 IVG
G4: Version bump 0.30.15 → 0.30.16 + CHANGELOG entry
G5: Latent contract violation resolved (16/16 iteration tests pass)

Milestone v0.30.16 complete: 17 version mismatches fixed, 2 contracts fixed, 0 lint failures.