### PR TITLE
refactor: v0.31.0 W2 - Refactor event-bus.rkt + CHANGELOG (#3818)

G1: Replaced cond in publish! with match for pattern consistency.
G2: Added racket/match import to event-bus.rkt.
G3: Updated CHANGELOG.md with v0.31.0 entry.

Changes:
- agent/event-bus.rkt: refactored to use match in publish!
- CHANGELOG.md: added v0.31.0 entry documenting HOF combinators work

Tests: 18/18 event-bus tests pass.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## v0.31.0 — 2026-05-07
+
+### Architecture Abstraction: HOF Combinators for Hook System
+
+**Goal:** Introduce higher-order function combinators to reduce inline pattern repetition in hook dispatch and event handling.
+
+**W0 — Create HOF combinators (2 files):**
+- Created `extensions/combinators.rkt` with 3 combinators:
+  - `with-timeout`: wraps computation with timeout + thread management
+  - `with-error-policy`: wraps computation with criticality-based error handling
+  - `with-hook-validation`: validates hook results + handles violations
+- Added `current-hook-violation-callback` parameter (moved from hooks.rkt)
+- Tests: 12/12 pass in `tests/test-hof-combinators.rkt`
+
+**W1 — Refactor hooks.rkt (2 files):**
+- Refactored `extensions/hooks.rkt` to use HOF combinators
+- Replaced inline timeout/error/validation patterns with combinator calls
+- Replaced `case`+`cond` in `dispatch-hooks` with `match`
+- Fixed contract to accept `(or/c symbol? string?)` for extension names
+
+**W2 — Refactor event-bus.rkt (1 file):**
+- Replaced `cond` in `publish!` with `match` for pattern consistency
+- All 18/18 event-bus tests pass
+
+**Impact:** Reduced code duplication in hook dispatch, improved error handling consistency, established HOF combinator pattern for future abstraction waves.
+
+---
+
+
 ## v0.30.16 — 2026-05-06
 
 ### Audit Remediation: Version Sync + Contract Safety

--- a/agent/event-bus.rkt
+++ b/agent/event-bus.rkt
@@ -12,6 +12,7 @@
 ;;   - publish! returns the event for chaining
 
 (require racket/contract
+         racket/match
          "../util/protocol-types.rkt"
          "../util/event.rkt"
          "event-types.rkt")
@@ -175,15 +176,15 @@
     (for ([s (in-list subs)])
       (define sub-id (subscription-id s))
       (define pred (subscription-filter s))
-      (cond
-        [(circuit-broken? sub-id) (void)]
-        [(or (not pred) (pred evt))
+      (match (cons (circuit-broken? sub-id) (or (not pred) (pred evt)))
+        [(cons #t _) (void)] ; circuit broken
+        [(cons #f #t) ; not broken and predicate true (or no predicate)
          (with-handlers ([exn:fail? (lambda (exn)
                                       (record-failure! sub-id)
                                       (err-handler evt (subscription-handler s) exn))])
            ((subscription-handler s) evt)
            (record-success! sub-id))]
-        [else (void)])))
+        [_ (void)]))) ; not broken but predicate false
   evt)
 
 ;; ============================================================


### PR DESCRIPTION
Addresses #3818.

refactor: v0.31.0 W2 - Refactor event-bus.rkt + CHANGELOG (#3818)

G1: Replaced cond in publish! with match for pattern consistency.
G2: Added racket/match import to event-bus.rkt.
G3: Updated CHANGELOG.md with v0.31.0 entry.

Changes:
- agent/event-bus.rkt: refactored to use match in publish!
- CHANGELOG.md: added v0.31.0 entry documenting HOF combinators work

Tests: 18/18 event-bus tests pass.