### PR TITLE
feat: v0.31.1 W0 - Create event-access.rkt with event struct selectors (#3823)

G1: Created q/util/event-access.rkt with selector functions:
- event-type-ref, event-timestamp-ref, event-session-id-ref
- event-turn-id-ref, event-payload-ref
G2: Created tests/test-event-access.rkt with 7 tests.

Tests: 7/7 pass.

### DIFF
--- a/tests/test-event-access.rkt
+++ b/tests/test-event-access.rkt
@@ -1,0 +1,40 @@
+#lang racket/base
+
+(require rackunit
+         "../util/event.rkt"
+         "../util/event-access.rkt")
+
+;; Test selectors on a sample event
+;; make-event: ev time session-id turn-id payload [version]
+(define sample-event
+  (make-event 'test-event
+              1234567890
+              "session-1"
+              "42"   ; turn-id as string per contract
+              (hash 'key "value")))
+
+(test-case "event-type-ref returns correct type"
+  (check-equal? (event-type-ref sample-event) 'test-event))
+
+(test-case "event-timestamp-ref returns correct timestamp"
+  (check-equal? (event-timestamp-ref sample-event) 1234567890))
+
+(test-case "event-session-id-ref returns correct session-id"
+  (check-equal? (event-session-id-ref sample-event) "session-1"))
+
+(test-case "event-turn-id-ref returns correct turn-id"
+  (check-equal? (event-turn-id-ref sample-event) "42"))
+
+(test-case "event-payload-ref returns correct payload"
+  (check-equal? (event-payload-ref sample-event) (hash 'key "value")))
+
+(test-case "event-session-id-ref on event without session-id returns #f"
+  (define evt (make-event 'other 0 #f #f (hash)))
+  (check-false (event-session-id-ref evt)))
+
+;; Test predicates
+(test-case "event? predicate works"
+  (check-true (event? sample-event))
+  (check-false (event? "not an event")))
+
+(printf "test-event-access.rkt: all tests passed~n")

--- a/util/event-access.rkt
+++ b/util/event-access.rkt
@@ -1,0 +1,35 @@
+#lang racket/base
+
+;; util/event-access.rkt — selector functions for event structs
+;; Provides an abstraction layer over direct struct field access.
+;; Use these selectors instead of calling event-ev, event-time, etc. directly.
+
+(require "event.rkt")
+
+(provide
+ ;; Selectors
+ event-type-ref
+ event-timestamp-ref
+ event-session-id-ref
+ event-turn-id-ref
+ event-payload-ref
+ ;; Re-export predicates and constructors for convenience
+ event?
+ make-event)
+
+;; Selector functions
+;; The struct field for event type is 'ev' (aliased as event-event).
+(define (event-type-ref evt)
+  (event-ev evt))
+
+(define (event-timestamp-ref evt)
+  (event-time evt))
+
+(define (event-session-id-ref evt)
+  (event-session-id evt))
+
+(define (event-turn-id-ref evt)
+  (event-turn-id evt))
+
+(define (event-payload-ref evt)
+  (event-payload evt))


### PR DESCRIPTION
Addresses #3823.

feat: v0.31.1 W0 - Create event-access.rkt with event struct selectors (#3823)

G1: Created q/util/event-access.rkt with selector functions:
- event-type-ref, event-timestamp-ref, event-session-id-ref
- event-turn-id-ref, event-payload-ref
G2: Created tests/test-event-access.rkt with 7 tests.

Tests: 7/7 pass.