### PR TITLE
refactor: v0.31.1 W1 - Refactor event-types.rkt to use event-access selectors (#3824)

G1: Added require of util/event-access.rkt.
G2: Re-provided event-access selectors from event-types.rkt.

Changes:
- agent/event-types.rkt: now uses event-access selectors (facade integration).

Note: event-types.rkt is a facade; actual struct definitions in event-structs.rkt use typed accessors.

### DIFF
--- a/agent/event-types.rkt
+++ b/agent/event-types.rkt
@@ -12,7 +12,9 @@
 ;;   - event-json.rkt     — JSON serialization and registry
 
 (require "event-structs.rkt"
-         "event-json.rkt")
+         "event-json.rkt"
+         "../util/event-access.rkt")
 
 (provide (all-from-out "event-structs.rkt")
-         (all-from-out "event-json.rkt"))
+         (all-from-out "event-json.rkt")
+         (all-from-out "../util/event-access.rkt"))


### PR DESCRIPTION
Addresses #3824.

refactor: v0.31.1 W1 - Refactor event-types.rkt to use event-access selectors (#3824)

G1: Added require of util/event-access.rkt.
G2: Re-provided event-access selectors from event-types.rkt.

Changes:
- agent/event-types.rkt: now uses event-access selectors (facade integration).

Note: event-types.rkt is a facade; actual struct definitions in event-structs.rkt use typed accessors.