### PR TITLE
feat: v0.31.2 W0 - Create typed-event-predicates.rkt with typed event predicates (#3829)

G1: Created q/util/typed-event-predicates.rkt re-exporting all predicates from event-structs.
G2: Created tests/test-typed-event-predicates.rkt with 3 tests.

Tests: 3/3 pass.

### DIFF
--- a/tests/test-typed-event-predicates.rkt
+++ b/tests/test-typed-event-predicates.rkt
@@ -1,0 +1,24 @@
+#lang racket/base
+
+(require rackunit
+         "../util/typed-event-predicates.rkt"
+         "../agent/event-structs/turn-events.rkt"
+         "../agent/event-structs/hook-events.rkt")
+
+;; Test that predicates work
+(define sample-turn-start (turn-start-event "turn.started" 0 "session-1" "1" "gpt-4" "openai"))
+(define sample-hook-blocked (model-request-blocked-event "model.request.blocked" 0 "session-1" "1" "some-reason"))
+
+(test-case "turn-start-event? predicate"
+  (check-true (turn-start-event? sample-turn-start))
+  (check-false (turn-start-event? sample-hook-blocked)))
+
+(test-case "model-request-blocked-event? predicate"
+  (check-true (model-request-blocked-event? sample-hook-blocked))
+  (check-false (model-request-blocked-event? sample-turn-start)))
+
+(test-case "typed-event? base predicate"
+  (check-true (typed-event? sample-turn-start))
+  (check-true (typed-event? sample-hook-blocked)))
+
+(printf "test-typed-event-predicates.rkt: all tests passed~n")

--- a/util/typed-event-predicates.rkt
+++ b/util/typed-event-predicates.rkt
@@ -1,0 +1,26 @@
+#lang racket/base
+
+;; util/typed-event-predicates.rkt — predicates for typed event structs
+;;
+;; Provides all predicates and constructors for typed event structs
+;; defined in agent/event-structs/*.
+;; Use this module to avoid importing individual event-structs modules.
+
+(require "../agent/event-structs/base.rkt"
+         "../agent/event-structs/hook-events.rkt"
+         "../agent/event-structs/iteration-events.rkt"
+         "../agent/event-structs/message-events.rkt"
+         "../agent/event-structs/provider-events.rkt"
+         "../agent/event-structs/session-events.rkt"
+         "../agent/event-structs/tool-events.rkt"
+         "../agent/event-structs/turn-events.rkt")
+
+(provide
+ (all-from-out "../agent/event-structs/base.rkt")
+ (all-from-out "../agent/event-structs/hook-events.rkt")
+ (all-from-out "../agent/event-structs/iteration-events.rkt")
+ (all-from-out "../agent/event-structs/message-events.rkt")
+ (all-from-out "../agent/event-structs/provider-events.rkt")
+ (all-from-out "../agent/event-structs/session-events.rkt")
+ (all-from-out "../agent/event-structs/tool-events.rkt")
+ (all-from-out "../agent/event-structs/turn-events.rkt"))


### PR DESCRIPTION
Addresses #3829.

feat: v0.31.2 W0 - Create typed-event-predicates.rkt with typed event predicates (#3829)

G1: Created q/util/typed-event-predicates.rkt re-exporting all predicates from event-structs.
G2: Created tests/test-typed-event-predicates.rkt with 3 tests.

Tests: 3/3 pass.