### PR TITLE
refactor: v0.31.2 W1 - Refactor event-json.rkt to use typed event predicates (#3830)

G1: Changed require in event-json.rkt from event-structs.rkt to typed-event-predicates.rkt.

Changes:
- agent/event-json.rkt: now uses predicates from typed-event-predicates.rkt.

### DIFF
--- a/agent/event-json.rkt
+++ b/agent/event-json.rkt
@@ -9,7 +9,7 @@
 ;;   - all-known-event-types / event-name->tool-name (registry)
 
 (require racket/match
-         "event-structs.rkt")
+         "../util/typed-event-predicates.rkt")
 
 (provide typed-event->jsexpr
          jsexpr->typed-event


### PR DESCRIPTION
Addresses #3830.

refactor: v0.31.2 W1 - Refactor event-json.rkt to use typed event predicates (#3830)

G1: Changed require in event-json.rkt from event-structs.rkt to typed-event-predicates.rkt.

Changes:
- agent/event-json.rkt: now uses predicates from typed-event-predicates.rkt.