### PR TITLE
refactor: v0.31.3 W0 - Extract pure compute-next-gsm-state from state-machine.rkt (#3835)

G1: Extracted pure function compute-next-gsm-state (Finding 3.1.3).
G2: Refactored gsm-transition! to use compute-next-gsm-state.

Tests: 7/7 pass in test-gsd-state-machine.rkt.

### DIFF
--- a/extensions/gsd/state-machine.rkt
+++ b/extensions/gsd/state-machine.rkt
@@ -41,6 +41,7 @@
          ;; Transition
          gsm-transition!
          gsm-reset!
+         compute-next-gsm-state
          ;; Transition result
          ok?
          ok-from
@@ -120,32 +121,50 @@
 (define (gsm-history)
   (gsd-history-snapshot))
 
+;; Pure transition kernel (Finding 3.1.3)
+;; Compute next state without side effects.
+;; Returns (or/c ok-result? err-result?).
+(define (compute-next-gsm-state current-state target)
+  (define current (gsd-runtime-state-mode current-state))
+  (cond
+    [(not (gsm-state? target)) (err-result (format "invalid state: ~a" target) current target)]
+    [(valid-transition? current target)
+     ;; Clear executor when leaving executing mode
+     (define state*
+       (if (and (eq? current 'executing) (not (eq? target 'executing)))
+           (struct-copy gsd-runtime-state current-state [wave-executor #f])
+           current-state))
+     (define new-state (struct-copy gsd-runtime-state state* [mode target]))
+     (ok-result current target)]
+    [else
+     (err-result
+      (format "invalid transition: ~a → ~a (valid: ~a)" current target (valid-targets current))
+      current
+      target)]))
+
 (define (gsm-transition! target)
   (with-gsd-lock
    (lambda ()
      (define state (current-gsd-state))
      (define current (gsd-runtime-state-mode state))
      (emit-gsd-event! 'gsd.transition.attempted (hasheq 'from current 'to target))
+     (define result (compute-next-gsm-state state target))
      (cond
-       [(not (gsm-state? target)) (err-result (format "invalid state: ~a" target) current target)]
-       [(valid-transition? current target)
-        ;; Clear executor when leaving executing mode
+       [(ok? result)
+        (define new-mode (ok-to result))
         (define state*
-          (if (and (eq? current 'executing) (not (eq? target 'executing)))
+          (if (and (eq? current 'executing) (not (eq? new-mode 'executing)))
               (struct-copy gsd-runtime-state state [wave-executor #f])
               state))
-        (set-gsd-state! (struct-copy gsd-runtime-state state* [mode target]))
-        (set-gsd-history! (cons (list current target (current-seconds)) (current-gsd-history)))
-        (emit-gsd-event! 'gsd.transition.succeeded (hasheq 'from current 'to target))
-        (ok-result current target)]
+        (set-gsd-state! (struct-copy gsd-runtime-state state* [mode new-mode]))
+        (set-gsd-history! (cons (list current new-mode (current-seconds)) (current-gsd-history)))
+        (emit-gsd-event! 'gsd.transition.succeeded (hasheq 'from current 'to new-mode))
+        result]
        [else
         (emit-gsd-event!
          'gsd.transition.failed
          (hasheq 'from current 'to target 'reason (format "invalid: ~a → ~a" current target)))
-        (err-result
-         (format "invalid transition: ~a → ~a (valid: ~a)" current target (valid-targets current))
-         current
-         target)]))))
+        result]))))
 
 (define (gsm-reset!)
   (with-gsd-lock

--- a/tests/extensions/test-gsd-state-machine.rkt
+++ b/tests/extensions/test-gsd-state-machine.rkt
@@ -1,0 +1,35 @@
+#lang racket/base
+
+(require rackunit
+         "../../extensions/gsd/state-machine.rkt")
+
+;; Test compute-next-gsm-state pure function
+(define (test-transition current-mode target expected-ok?)
+  (define state (make-initial-gsd-state))
+  ;; set mode to current-mode
+  (define state2 (struct-copy gsd-runtime-state state [mode current-mode]))
+  (define result (compute-next-gsm-state state2 target))
+  (check-eq? (ok? result) expected-ok?))
+
+(test-case "idle -> exploring is valid"
+  (test-transition 'idle 'exploring #t))
+
+(test-case "idle -> executing is invalid"
+  (test-transition 'idle 'executing #f))
+
+(test-case "exploring -> plan-written is valid"
+  (test-transition 'exploring 'plan-written #t))
+
+(test-case "plan-written -> executing is valid"
+  (test-transition 'plan-written 'executing #t))
+
+(test-case "executing -> verifying is valid"
+  (test-transition 'executing 'verifying #t))
+
+(test-case "verifying -> idle is valid"
+  (test-transition 'verifying 'idle #t))
+
+(test-case "verifying -> executing is valid"
+  (test-transition 'verifying 'executing #t))
+
+(printf "test-gsd-state-machine.rkt: all tests passed~n")


### PR DESCRIPTION
Addresses #3835.

refactor: v0.31.3 W0 - Extract pure compute-next-gsm-state from state-machine.rkt (#3835)

G1: Extracted pure function compute-next-gsm-state (Finding 3.1.3).
G2: Refactored gsm-transition! to use compute-next-gsm-state.

Tests: 7/7 pass in test-gsd-state-machine.rkt.