### PR TITLE
refactor(tools): extract safe-mode path validation helper (#3887)

Wave 2 of v0.32.1.
- Create tools/builtins/builtin-helpers.rkt with require-safe-path!
- Update read.rkt, write.rkt, edit.rkt to use require-safe-path!
- Eliminates duplicated safe-mode path check pattern across 3 files

### DIFF
--- a/tools/builtins/builtin-helpers.rkt
+++ b/tools/builtins/builtin-helpers.rkt
@@ -1,0 +1,24 @@
+#lang racket/base
+
+;; tools/builtins/builtin-helpers.rkt — shared helpers for builtin tools
+;;
+;; v0.32.1 Wave 2: Extract repeated safe-mode path validation pattern
+;; from edit.rkt, write.rkt, and read.rkt into a single helper.
+
+(require (only-in "../../util/safe-mode-predicates.rkt"
+                  safe-mode?
+                  allowed-path?
+                  safe-mode-project-root))
+
+(provide require-safe-path!)
+
+;; require-safe-path! : string? string? -> (or/c #f string?)
+;; Validates that a path is allowed under safe-mode constraints.
+;; Returns #f if path is allowed, or an error message string if blocked.
+;; Encapsulates the repeated pattern:
+;;   (and (safe-mode?) (not (allowed-path? path))) → error message
+(define (require-safe-path! path-str tool-name)
+  (cond
+    [(and (safe-mode?) (not (allowed-path? path-str)))
+     (format "~a: path '~a' outside project root (~a)" tool-name path-str (safe-mode-project-root))]
+    [else #f]))

--- a/tools/builtins/edit.rkt
+++ b/tools/builtins/edit.rkt
@@ -25,7 +25,8 @@
                   allowed-path?
                   safe-mode-project-root)
          (only-in "../../util/path-helpers.rkt" expand-home-path)
-         (only-in "../../util/error-sanitizer.rkt" sanitize-error-message))
+         (only-in "../../util/error-sanitizer.rkt" sanitize-error-message)
+         (only-in "builtin-helpers.rkt" require-safe-path!))
 
 (provide tool-edit
          current-max-old-text-len
@@ -221,9 +222,9 @@
     [(list (? string? path) (? string? old-text) (? string? new-text))
      (cond
        ;; Defense-in-depth: verify path even if scheduler already checked (SEC-09)
-       [(and (safe-mode?) (not (allowed-path? path)))
-        (make-error-result
-         (format "edit: path '~a' outside project root (~a)" path (safe-mode-project-root)))]
+       [(require-safe-path! path "edit")
+        =>
+        (lambda (err) (make-error-result err))]
        [(not (file-exists? path)) (make-error-result (format "File not found: ~a" path))]
        [else
         (define content (file->string path))

--- a/tools/builtins/read.rkt
+++ b/tools/builtins/read.rkt
@@ -21,7 +21,8 @@
                   safe-mode?
                   allowed-path?
                   safe-mode-project-root)
-         (only-in "../../util/truncation.rkt" truncate-output MAX-OUTPUT-BYTES MAX-OUTPUT-LINES))
+         (only-in "../../util/truncation.rkt" truncate-output MAX-OUTPUT-BYTES MAX-OUTPUT-LINES)
+         (only-in "builtin-helpers.rkt" require-safe-path!))
 
 (provide tool-read)
 
@@ -43,11 +44,9 @@
      (define limit (hash-ref args 'limit #f))
 
      ;; 1. Safe-mode defense-in-depth path check (SEC-01)
+     (define safe-err (require-safe-path! path-str "read"))
      (cond
-       [(and (safe-mode?) (not (allowed-path? path-str)))
-        (make-error-result (format "read: path '~a' outside project root (~a)"
-                                   path-str
-                                   (safe-mode-project-root)))]
+       [safe-err (make-error-result safe-err)]
        [(not (file-exists? path-str)) (make-error-result (format "File not found: ~a" path-str))]
 
        [else

--- a/tools/builtins/write.rkt
+++ b/tools/builtins/write.rkt
@@ -27,7 +27,8 @@
                   safe-mode-project-root)
          (only-in "../../util/error-sanitizer.rkt" sanitize-error-message)
          ;; v0.21.10: planning path resolution hardening (F7)
-         (only-in "../../extensions/gsd-planning-state.rkt" pinned-planning-dir))
+         (only-in "../../extensions/gsd-planning-state.rkt" pinned-planning-dir)
+         (only-in "builtin-helpers.rkt" require-safe-path!))
 
 (provide tool-write
          current-max-write-bytes
@@ -77,10 +78,9 @@
              (path->string (simplify-path (resolve-path p)))))))
   (cond
     [(not path-str) (make-error-result "Missing required argument: path")]
-    [(and (safe-mode?) (not (allowed-path? path-str)))
-     ;; Defense-in-depth: verify path even if scheduler already checked (SEC-09)
-     (make-error-result
-      (format "write: path '~a' outside project root (~a)" path-str (safe-mode-project-root)))]
+    [(require-safe-path! path-str "write")
+     =>
+     (lambda (err) (make-error-result err))]
     [else
      (define content-str (hash-ref args 'content ""))
      (with-handlers ([exn:fail:filesystem? (lambda (e)


### PR DESCRIPTION
Addresses #3887.

refactor(tools): extract safe-mode path validation helper (#3887)

Wave 2 of v0.32.1.
- Create tools/builtins/builtin-helpers.rkt with require-safe-path!
- Update read.rkt, write.rkt, edit.rkt to use require-safe-path!
- Eliminates duplicated safe-mode path check pattern across 3 files