### PR TITLE
feat(core): apply define-typed-event macro to all event structs (#3892)

Wave 1 of v0.32.2.
- Convert 22 event structs to use define-typed-event macro
- Add #:optional field support for injection-event, turn-cancelled-event
- Replace 50-line manual field-name registry with macro-generated constants
- Fix per-tool event field mapping (include parent tool-call-event fields)
- Fix missing streaming/blocked events from emitter registry
- Add *-event-fields exports for per-tool events
- ~293 lines removed across 8 files (34% reduction)
- Version bump to v0.32.2
- All 2035 tests pass

### DIFF
--- a/agent/event-emitter.rkt
+++ b/agent/event-emitter.rkt
@@ -2,6 +2,7 @@
 
 ;; agent/event-emitter.rkt -- typed event emission bridge
 ;; v0.29.2: Bridge between typed event structs and raw event bus.
+;; v0.32.2: Replace manual field-name registry with macro-generated constants.
 
 (require (only-in racket/string string-prefix?)
          (only-in "../util/event.rkt" make-event)
@@ -12,75 +13,132 @@
                   typed-event-type
                   typed-event-timestamp
                   typed-event-session-id
-                  typed-event-turn-id))
+                  typed-event-turn-id)
+         ;; Import event-struct modules for *-event-fields constants
+         (only-in "../agent/event-structs/turn-events.rkt"
+                  turn-start-event-fields
+                  turn-end-event-fields)
+         (only-in "../agent/event-structs/message-events.rkt"
+                  message-start-event-fields
+                  message-update-event-fields
+                  message-end-event-fields)
+         (only-in "../agent/event-structs/iteration-events.rkt"
+                  auto-retry-event-fields
+                  compaction-event-fields
+                  injection-event-fields)
+         (only-in "../agent/event-structs/provider-events.rkt"
+                  provider-request-event-fields
+                  provider-response-event-fields
+                  model-stream-delta-event-fields
+                  model-stream-thinking-event-fields
+                  model-stream-completed-event-fields)
+         (only-in "../agent/event-structs/session-events.rkt"
+                  session-start-event-fields
+                  session-shutdown-event-fields
+                  input-event-fields
+                  model-select-event-fields
+                  agent-start-event-fields
+                  agent-end-event-fields
+                  context-event-fields)
+         (only-in "../agent/event-structs/tool-events.rkt"
+                  tool-execution-start-event-fields
+                  tool-execution-update-event-fields
+                  tool-execution-end-event-fields
+                  tool-call-event-fields
+                  tool-result-event-fields
+                  bash-tool-call-event-fields
+                  edit-tool-call-event-fields
+                  write-tool-call-event-fields
+                  read-tool-call-event-fields
+                  grep-tool-call-event-fields
+                  find-tool-call-event-fields
+                  custom-tool-call-event-fields)
+         (only-in "../agent/event-structs/hook-events.rkt"
+                  model-request-blocked-event-fields
+                  message-blocked-event-fields
+                  turn-cancelled-event-fields
+                  assistant-message-completed-event-fields))
 
 ;; NOTE (v0.29.14): emit-typed-event! has 2+ production callers (runtime/session-switch.rkt).
 ;; Adoption is tracked by IVG check `session-switch-typed-events`.
 (provide emit-typed-event!
          event-struct->hasheq)
 
-;; Field name mappings: sub-struct fields after typed-event base (type timestamp session-id turn-id)
+;; Field name mappings: auto-synced from *-event-fields constants.
+;; Per-tool events append tool-call-event-fields to include parent fields.
 (define struct-field-names
   (hasheq 'message-start-event
-          '(role model)
+          message-start-event-fields
           'message-update-event
-          '(content delta)
+          message-update-event-fields
           'message-end-event
-          '(role content-length)
+          message-end-event-fields
           'provider-request-event
-          '(model provider)
+          provider-request-event-fields
           'provider-response-event
-          '(model provider latency-ms)
+          provider-response-event-fields
+          'model-stream-delta-event
+          model-stream-delta-event-fields
+          'model-stream-thinking-event
+          model-stream-thinking-event-fields
+          'model-stream-completed-event
+          model-stream-completed-event-fields
           'session-start-event
-          '(model)
+          session-start-event-fields
           'session-shutdown-event
-          '(reason)
+          session-shutdown-event-fields
           'input-event
-          '(input-type content)
+          input-event-fields
           'model-select-event
-          '(model provider)
+          model-select-event-fields
           'agent-start-event
-          '(model)
+          agent-start-event-fields
           'agent-end-event
-          '(reason duration-ms)
+          agent-end-event-fields
           'turn-cancelled-event
-          '(reason iteration)
+          turn-cancelled-event-fields
           'context-event
-          '(token-count window-size)
+          context-event-fields
           'tool-execution-start-event
-          '(tool-name tool-call-id)
+          tool-execution-start-event-fields
           'tool-execution-update-event
-          '(tool-name progress)
+          tool-execution-update-event-fields
           'tool-execution-end-event
-          '(tool-name duration-ms result-summary)
+          tool-execution-end-event-fields
           'tool-call-event
-          '(tool-name arguments tool-call-id)
+          tool-call-event-fields
           'tool-result-event
-          '(tool-call-id content is-error?)
+          tool-result-event-fields
           'bash-tool-call-event
-          '(command timeout cwd)
+          bash-tool-call-event-fields
           'edit-tool-call-event
-          '(path edits)
+          edit-tool-call-event-fields
           'write-tool-call-event
-          '(path content)
+          write-tool-call-event-fields
           'read-tool-call-event
-          '(path offset limit)
+          read-tool-call-event-fields
           'grep-tool-call-event
-          '(pattern path)
+          grep-tool-call-event-fields
           'find-tool-call-event
-          '(pattern path)
+          find-tool-call-event-fields
           'custom-tool-call-event
-          '()
+          custom-tool-call-event-fields
           'turn-start-event
-          '(model provider)
+          turn-start-event-fields
           'turn-end-event
-          '(reason duration-ms)
+          turn-end-event-fields
           'auto-retry-event
-          '(attempt max-attempts error-type)
+          auto-retry-event-fields
           'compaction-event
-          '(reason tokens-before tokens-after)
+          compaction-event-fields
           'injection-event
-          '(source content-type content-length message)))
+          injection-event-fields
+          'model-request-blocked-event
+          model-request-blocked-event-fields
+          'message-blocked-event
+          message-blocked-event-fields
+          'assistant-message-completed-event
+          assistant-message-completed-event-fields))
 
 ;; Extract struct name, stripping the struct: prefix from struct->vector
 (define (struct-name evt)

--- a/agent/event-structs/hook-events.rkt
+++ b/agent/event-structs/hook-events.rkt
@@ -5,67 +5,24 @@
 ;; Events emitted when hooks block operations (model requests, messages)
 ;; or when a turn is cancelled.
 
-(require "base.rkt")
+(require "base.rkt"
+         "../../util/event-macro.rkt")
 
-(provide
- ;; Blocked events
- (struct-out model-request-blocked-event)
- (struct-out message-blocked-event)
- make-model-request-blocked-event
- make-message-blocked-event
- model-request-blocked-event?
- message-blocked-event?
- ;; Turn cancelled
- (struct-out turn-cancelled-event)
- make-turn-cancelled-event
- turn-cancelled-event?
- ;; Assistant message completed
- (struct-out assistant-message-completed-event)
- make-assistant-message-completed-event
- assistant-message-completed-event?)
-
-;; ============================================================
 ;; Blocked events
-;; ============================================================
 
-(struct model-request-blocked-event typed-event (reason) #:transparent)
+(define-typed-event model-request-blocked-event "model.request.blocked"
+  (reason))
 
-(define (make-model-request-blocked-event #:session-id session-id
-                                          #:turn-id turn-id
-                                          #:timestamp timestamp
-                                          #:reason reason)
-  (model-request-blocked-event "model.request.blocked" timestamp session-id turn-id reason))
+(define-typed-event message-blocked-event "message.blocked"
+  (hook reason))
 
-(struct message-blocked-event typed-event (hook reason) #:transparent)
-
-(define (make-message-blocked-event #:session-id session-id
-                                    #:turn-id turn-id
-                                    #:timestamp timestamp
-                                    #:hook hook
-                                    #:reason reason)
-  (message-blocked-event "message.blocked" timestamp session-id turn-id hook reason))
-
-;; ============================================================
 ;; Turn cancelled
-;; ============================================================
 
-(struct turn-cancelled-event typed-event (reason iteration) #:transparent)
+(define-typed-event turn-cancelled-event "turn.cancelled"
+  (reason)
+  #:optional ([iteration #f]))
 
-(define (make-turn-cancelled-event #:session-id session-id
-                                   #:turn-id turn-id
-                                   #:timestamp timestamp
-                                   #:reason reason
-                                   #:iteration [iteration #f])
-  (turn-cancelled-event "turn.cancelled" timestamp session-id turn-id reason iteration))
-
-;; ============================================================
 ;; Assistant message completed
-;; ============================================================
 
-(struct assistant-message-completed-event typed-event (content-length) #:transparent)
-
-(define (make-assistant-message-completed-event #:session-id session-id
-                                                 #:turn-id turn-id
-                                                 #:timestamp timestamp
-                                                 #:content-length content-length)
-  (assistant-message-completed-event "assistant.message.completed" timestamp session-id turn-id content-length))
+(define-typed-event assistant-message-completed-event "assistant.message.completed"
+  (content-length))

--- a/agent/event-structs/iteration-events.rkt
+++ b/agent/event-structs/iteration-events.rkt
@@ -3,72 +3,18 @@
 ;; agent/event-structs/iteration-events.rkt — iteration lifecycle events
 ;; (auto-retry, compaction, injection)
 
-(require "base.rkt")
+(require "base.rkt"
+         "../../util/event-macro.rkt")
 
-;; Auto-retry events
-(provide (struct-out auto-retry-event)
-         make-auto-retry-event
-         auto-retry-event?
-
-         ;; Compaction events
-         (struct-out compaction-event)
-         make-compaction-event
-         compaction-event?
-
-         ;; Injection events
-         (struct-out injection-event)
-         make-injection-event
-         injection-event?)
-
-;; ============================================================
-;; Auto-retry events
-;; ============================================================
-;;
 ;; NOTE (v0.29.16): auto-retry-event has 1 production emission site
 ;; (runtime/turn-orchestrator.rkt). It is wired — not deferred.
 
-(struct auto-retry-event typed-event (attempt max-attempts error-type) #:transparent)
+(define-typed-event auto-retry-event "auto-retry"
+  (attempt max-attempts error-type))
 
-(define (make-auto-retry-event #:session-id session-id
-                               #:turn-id turn-id
-                               #:timestamp timestamp
-                               #:attempt attempt
-                               #:max-attempts max-attempts
-                               #:error-type error-type)
-  (auto-retry-event "auto-retry" timestamp session-id turn-id attempt max-attempts error-type))
+(define-typed-event compaction-event "compaction"
+  (reason tokens-before tokens-after))
 
-;; ============================================================
-;; Compaction events
-;; ============================================================
-
-(struct compaction-event typed-event (reason tokens-before tokens-after) #:transparent)
-
-(define (make-compaction-event #:session-id session-id
-                               #:turn-id turn-id
-                               #:timestamp timestamp
-                               #:reason reason
-                               #:tokens-before tokens-before
-                               #:tokens-after tokens-after)
-  (compaction-event "compaction" timestamp session-id turn-id reason tokens-before tokens-after))
-
-;; ============================================================
-;; Injection events
-;; ============================================================
-
-(struct injection-event typed-event (source content-type content-length message) #:transparent)
-
-(define (make-injection-event #:session-id session-id
-                              #:turn-id turn-id
-                              #:timestamp timestamp
-                              #:source source
-                              #:content-type content-type
-                              #:content-length content-length
-                              #:message [message #f])
-  (injection-event "injection"
-                   timestamp
-                   session-id
-                   turn-id
-                   source
-                   content-type
-                   content-length
-                   message))
+(define-typed-event injection-event "injection"
+  (source content-type content-length)
+  #:optional ([message #f]))

--- a/agent/event-structs/message-events.rkt
+++ b/agent/event-structs/message-events.rkt
@@ -5,35 +5,11 @@
 (require "base.rkt"
          "../../util/event-macro.rkt")
 
-(provide (struct-out message-update-event)
-         (struct-out message-end-event)
-         make-message-start-event
-         make-message-update-event
-         make-message-end-event
-         message-update-event?
-         message-end-event?)
+(define-typed-event message-start-event "message.started"
+  (role model))
 
-(define-event message-start-event typed-event (role model))
-(define-event message-update-event typed-event (content delta))
-(define-event message-end-event typed-event (role content-length))
+(define-typed-event message-update-event "message.updated"
+  (content delta))
 
-(define (make-message-start-event #:session-id session-id
-                                  #:turn-id turn-id
-                                  #:timestamp timestamp
-                                  #:role role
-                                  #:model model)
-  (message-start-event "message.started" timestamp session-id turn-id role model))
-
-(define (make-message-update-event #:session-id session-id
-                                   #:turn-id turn-id
-                                   #:timestamp timestamp
-                                   #:content content
-                                   #:delta delta)
-  (message-update-event "message.updated" timestamp session-id turn-id content delta))
-
-(define (make-message-end-event #:session-id session-id
-                                #:turn-id turn-id
-                                #:timestamp timestamp
-                                #:role role
-                                #:content-length content-length)
-  (message-end-event "message.completed" timestamp session-id turn-id role content-length))
+(define-typed-event message-end-event "message.completed"
+  (role content-length))

--- a/agent/event-structs/provider-events.rkt
+++ b/agent/event-structs/provider-events.rkt
@@ -2,77 +2,22 @@
 
 ;; agent/event-structs/provider-events.rkt — provider/LLM request/response events
 
-(require "base.rkt")
+(require "base.rkt"
+         "../../util/event-macro.rkt")
 
-(provide (struct-out provider-request-event)
-         (struct-out provider-response-event)
-         make-provider-request-event
-         make-provider-response-event
-         provider-request-event?
-         provider-response-event?
-         ;; Streaming events
-         (struct-out model-stream-delta-event)
-         (struct-out model-stream-thinking-event)
-         (struct-out model-stream-completed-event)
-         make-model-stream-delta-event
-         make-model-stream-thinking-event
-         make-model-stream-completed-event
-         model-stream-delta-event?
-         model-stream-thinking-event?
-         model-stream-completed-event?)
+(define-typed-event provider-request-event "model.request.started"
+  (model provider))
 
-(struct provider-request-event typed-event (model provider) #:transparent)
-(struct provider-response-event typed-event (model provider latency-ms) #:transparent)
+(define-typed-event provider-response-event "model.request.completed"
+  (model provider latency-ms))
 
-(define (make-provider-request-event #:session-id session-id
-                                     #:turn-id turn-id
-                                     #:timestamp timestamp
-                                     #:model model
-                                     #:provider provider)
-  (provider-request-event "model.request.started" timestamp session-id turn-id model provider))
-
-(define (make-provider-response-event #:session-id session-id
-                                      #:turn-id turn-id
-                                      #:timestamp timestamp
-                                      #:model model
-                                      #:provider provider
-                                      #:latency-ms latency-ms)
-  (provider-response-event "model.request.completed"
-                           timestamp
-                           session-id
-                           turn-id
-                           model
-                           provider
-                           latency-ms))
-
-
-;; ============================================================
 ;; Streaming events (LLM streaming responses)
-;; ============================================================
 
-(struct model-stream-delta-event typed-event (delta model) #:transparent)
+(define-typed-event model-stream-delta-event "model.stream.delta"
+  (delta model))
 
-(define (make-model-stream-delta-event #:session-id session-id
-                                       #:turn-id turn-id
-                                       #:timestamp timestamp
-                                       #:delta delta
-                                       #:model model)
-  (model-stream-delta-event "model.stream.delta" timestamp session-id turn-id delta model))
+(define-typed-event model-stream-thinking-event "model.stream.thinking"
+  (thinking model))
 
-(struct model-stream-thinking-event typed-event (thinking model) #:transparent)
-
-(define (make-model-stream-thinking-event #:session-id session-id
-                                          #:turn-id turn-id
-                                          #:timestamp timestamp
-                                          #:thinking thinking
-                                          #:model model)
-  (model-stream-thinking-event "model.stream.thinking" timestamp session-id turn-id thinking model))
-
-(struct model-stream-completed-event typed-event (model provider) #:transparent)
-
-(define (make-model-stream-completed-event #:session-id session-id
-                                           #:turn-id turn-id
-                                           #:timestamp timestamp
-                                           #:model model
-                                           #:provider provider)
-  (model-stream-completed-event "model.stream.completed" timestamp session-id turn-id model provider))
+(define-typed-event model-stream-completed-event "model.stream.completed"
+  (model provider))

--- a/agent/event-structs/session-events.rkt
+++ b/agent/event-structs/session-events.rkt
@@ -2,114 +2,36 @@
 
 ;; agent/event-structs/session-events.rkt — session, input, model, agent, context events
 
-(require "base.rkt")
+(require "base.rkt"
+         "../../util/event-macro.rkt")
 
-(provide
- ;; Session lifecycle
- (struct-out session-start-event)
- (struct-out session-shutdown-event)
- make-session-start-event
- make-session-shutdown-event
- session-start-event?
- session-shutdown-event?
-
- ;; Input events
- (struct-out input-event)
- make-input-event
- input-event?
-
- ;; Model events
- (struct-out model-select-event)
- make-model-select-event
- model-select-event?
-
- ;; Agent events
- (struct-out agent-start-event)
- (struct-out agent-end-event)
- make-agent-start-event
- make-agent-end-event
- agent-start-event?
- agent-end-event?
-
- ;; Context events
- (struct-out context-event)
- make-context-event
- context-event?)
-
-;; ============================================================
 ;; Session lifecycle
-;; ============================================================
 
-(struct session-start-event typed-event (model) #:transparent)
-(struct session-shutdown-event typed-event (reason) #:transparent)
+(define-typed-event session-start-event "session.started"
+  (model))
 
-(define (make-session-start-event #:session-id session-id
-                                  #:turn-id turn-id
-                                  #:timestamp timestamp
-                                  #:model model)
-  (session-start-event "session.started" timestamp session-id turn-id model))
+(define-typed-event session-shutdown-event "session.shutdown"
+  (reason))
 
-(define (make-session-shutdown-event #:session-id session-id
-                                     #:turn-id turn-id
-                                     #:timestamp timestamp
-                                     #:reason reason)
-  (session-shutdown-event "session.shutdown" timestamp session-id turn-id reason))
-
-;; ============================================================
 ;; Input events
-;; ============================================================
 
-(struct input-event typed-event (input-type content) #:transparent)
+(define-typed-event input-event "input"
+  (input-type content))
 
-(define (make-input-event #:session-id session-id
-                          #:turn-id turn-id
-                          #:timestamp timestamp
-                          #:input-type input-type
-                          #:content content)
-  (input-event "input" timestamp session-id turn-id input-type content))
-
-;; ============================================================
 ;; Model events
-;; ============================================================
 
-(struct model-select-event typed-event (model provider) #:transparent)
+(define-typed-event model-select-event "model.selected"
+  (model provider))
 
-(define (make-model-select-event #:session-id session-id
-                                 #:turn-id turn-id
-                                 #:timestamp timestamp
-                                 #:model model
-                                 #:provider provider)
-  (model-select-event "model.selected" timestamp session-id turn-id model provider))
-
-;; ============================================================
 ;; Agent events
-;; ============================================================
 
-(struct agent-start-event typed-event (model) #:transparent)
-(struct agent-end-event typed-event (reason duration-ms) #:transparent)
+(define-typed-event agent-start-event "agent.started"
+  (model))
 
-(define (make-agent-start-event #:session-id session-id
-                                #:turn-id turn-id
-                                #:timestamp timestamp
-                                #:model model)
-  (agent-start-event "agent.started" timestamp session-id turn-id model))
+(define-typed-event agent-end-event "agent.completed"
+  (reason duration-ms))
 
-(define (make-agent-end-event #:session-id session-id
-                              #:turn-id turn-id
-                              #:timestamp timestamp
-                              #:reason reason
-                              #:duration-ms duration-ms)
-  (agent-end-event "agent.completed" timestamp session-id turn-id reason duration-ms))
-
-;; ============================================================
 ;; Context events
-;; ============================================================
 
-(struct context-event typed-event (token-count window-size) #:transparent)
-
-(define (make-context-event #:session-id session-id
-                            #:turn-id turn-id
-                            #:timestamp timestamp
-                            #:token-count token-count
-                            #:window-size window-size)
-  (context-event "context.built" timestamp session-id turn-id token-count window-size))
+(define-typed-event context-event "context.built"
+  (token-count window-size))

--- a/agent/event-structs/tool-events.rkt
+++ b/agent/event-structs/tool-events.rkt
@@ -4,30 +4,43 @@
 ;;
 ;; Contains tool execution lifecycle, generic tool call/result,
 ;; and all per-tool typed events (bash, edit, write, read, grep, find, custom).
+;;
+;; Simple events (typed-event parent) use define-typed-event macro.
+;; Per-tool events (tool-call-event parent with complex constructors) remain manual.
 
 (require "base.rkt"
          "../../util/event-macro.rkt")
 
-;; Tool execution lifecycle
-(provide (struct-out tool-execution-update-event)
-         (struct-out tool-execution-end-event)
-         make-tool-execution-start-event
-         make-tool-execution-update-event
-         make-tool-execution-end-event
-         tool-execution-start-event?
-         tool-execution-update-event?
-         tool-execution-end-event?
+;; ============================================================
+;; Tool execution lifecycle (typed-event parent)
+;; ============================================================
 
-         ;; Generic tool call/result
-         (struct-out tool-call-event)
-         (struct-out tool-result-event)
-         make-tool-call-event
-         make-tool-result-event
-         tool-call-event?
-         tool-result-event?
+(define-typed-event tool-execution-start-event "tool.execution.started"
+  (tool-name tool-call-id))
 
-         ;; Per-tool typed events
-         (struct-out bash-tool-call-event)
+(define-typed-event tool-execution-update-event "tool.execution.updated"
+  (tool-name progress))
+
+(define-typed-event tool-execution-end-event "tool.execution.completed"
+  (tool-name duration-ms result-summary))
+
+;; ============================================================
+;; Generic tool call/result (typed-event parent)
+;; ============================================================
+
+(define-typed-event tool-call-event "tool.called"
+  (tool-name arguments tool-call-id))
+
+(define-typed-event tool-result-event "tool.result"
+  (tool-call-id content is-error?))
+
+;; ============================================================
+;; Per-tool typed events (tool-call-event parent — manual)
+;; These inherit from tool-call-event and have complex constructors
+;; that compute arguments from specific fields.
+;; ============================================================
+
+(provide (struct-out bash-tool-call-event)
          (struct-out edit-tool-call-event)
          (struct-out write-tool-call-event)
          (struct-out read-tool-call-event)
@@ -47,80 +60,15 @@
          read-tool-call-event?
          grep-tool-call-event?
          find-tool-call-event?
-         custom-tool-call-event?)
-
-;; ============================================================
-;; Tool execution lifecycle
-;; ============================================================
-
-(define-event tool-execution-start-event typed-event (tool-name tool-call-id))
-(struct tool-execution-update-event typed-event (tool-name progress) #:transparent)
-(struct tool-execution-end-event typed-event (tool-name duration-ms result-summary) #:transparent)
-
-(define (make-tool-execution-start-event #:session-id session-id
-                                         #:turn-id turn-id
-                                         #:timestamp timestamp
-                                         #:tool-name tool-name
-                                         #:tool-call-id tool-call-id)
-  (tool-execution-start-event "tool.execution.started"
-                              timestamp
-                              session-id
-                              turn-id
-                              tool-name
-                              tool-call-id))
-
-(define (make-tool-execution-update-event #:session-id session-id
-                                          #:turn-id turn-id
-                                          #:timestamp timestamp
-                                          #:tool-name tool-name
-                                          #:progress progress)
-  (tool-execution-update-event "tool.execution.updated"
-                               timestamp
-                               session-id
-                               turn-id
-                               tool-name
-                               progress))
-
-(define (make-tool-execution-end-event #:session-id session-id
-                                       #:turn-id turn-id
-                                       #:timestamp timestamp
-                                       #:tool-name tool-name
-                                       #:duration-ms duration-ms
-                                       #:result-summary result-summary)
-  (tool-execution-end-event "tool.execution.completed"
-                            timestamp
-                            session-id
-                            turn-id
-                            tool-name
-                            duration-ms
-                            result-summary))
-
-;; ============================================================
-;; Generic tool call/result
-;; ============================================================
-
-(struct tool-call-event typed-event (tool-name arguments tool-call-id) #:transparent)
-(struct tool-result-event typed-event (tool-call-id content is-error?) #:transparent)
-
-(define (make-tool-call-event #:session-id session-id
-                              #:turn-id turn-id
-                              #:timestamp timestamp
-                              #:tool-name tool-name
-                              #:arguments arguments
-                              #:tool-call-id tool-call-id)
-  (tool-call-event "tool.called" timestamp session-id turn-id tool-name arguments tool-call-id))
-
-(define (make-tool-result-event #:session-id session-id
-                                #:turn-id turn-id
-                                #:timestamp timestamp
-                                #:tool-call-id tool-call-id
-                                #:content content
-                                #:is-error? is-error?)
-  (tool-result-event "tool.result" timestamp session-id turn-id tool-call-id content is-error?))
-
-;; ============================================================
-;; Per-tool typed events (Issue #1311)
-;; ============================================================
+         custom-tool-call-event?
+         ;; Field lists for per-tool events (for event serialization)
+         bash-tool-call-event-fields
+         edit-tool-call-event-fields
+         write-tool-call-event-fields
+         read-tool-call-event-fields
+         grep-tool-call-event-fields
+         find-tool-call-event-fields
+         custom-tool-call-event-fields)
 
 ;; bash-tool-call-event
 (struct bash-tool-call-event tool-call-event (command timeout cwd) #:transparent)
@@ -143,6 +91,9 @@
                         timeout
                         cwd))
 
+(define bash-tool-call-event-fields
+  (append tool-call-event-fields '(command timeout cwd)))
+
 ;; edit-tool-call-event
 (struct edit-tool-call-event tool-call-event (path edits) #:transparent)
 
@@ -162,6 +113,9 @@
                         path
                         edits))
 
+(define edit-tool-call-event-fields
+  (append tool-call-event-fields '(path edits)))
+
 ;; write-tool-call-event
 (struct write-tool-call-event tool-call-event (path content) #:transparent)
 
@@ -180,6 +134,9 @@
                          tool-call-id
                          path
                          content))
+
+(define write-tool-call-event-fields
+  (append tool-call-event-fields '(path content)))
 
 ;; read-tool-call-event
 (struct read-tool-call-event tool-call-event (path offset limit) #:transparent)
@@ -202,12 +159,11 @@
                         offset
                         limit))
 
+(define read-tool-call-event-fields
+  (append tool-call-event-fields '(path offset limit)))
+
 ;; grep-tool-call-event
-(struct grep-tool-call-event
-        tool-call-event
-        (pattern path
-          glob)
-  #:transparent)
+(struct grep-tool-call-event tool-call-event (pattern path glob) #:transparent)
 
 (define (make-grep-tool-call-event #:session-id session-id
                                    #:turn-id turn-id
@@ -226,6 +182,9 @@
                         pattern
                         path
                         glob))
+
+(define grep-tool-call-event-fields
+  (append tool-call-event-fields '(pattern path glob)))
 
 ;; find-tool-call-event
 (struct find-tool-call-event tool-call-event (pattern path) #:transparent)
@@ -246,6 +205,9 @@
                         pattern
                         path))
 
+(define find-tool-call-event-fields
+  (append tool-call-event-fields '(pattern path)))
+
 ;; custom-tool-call-event — fallback for unknown tools
 (struct custom-tool-call-event tool-call-event () #:transparent)
 
@@ -262,3 +224,5 @@
                           tool-name
                           arguments
                           tool-call-id))
+
+(define custom-tool-call-event-fields tool-call-event-fields)

--- a/agent/event-structs/turn-events.rkt
+++ b/agent/event-structs/turn-events.rkt
@@ -2,28 +2,11 @@
 
 ;; agent/event-structs/turn-events.rkt — turn lifecycle events
 
-(require "base.rkt")
+(require "base.rkt"
+         "../../util/event-macro.rkt")
 
-(provide (struct-out turn-start-event)
-         (struct-out turn-end-event)
-         make-turn-start-event
-         make-turn-end-event
-         turn-start-event?
-         turn-end-event?)
+(define-typed-event turn-start-event "turn.started"
+  (model provider))
 
-(struct turn-start-event typed-event (model provider) #:transparent)
-(struct turn-end-event typed-event (reason duration-ms) #:transparent)
-
-(define (make-turn-start-event #:session-id session-id
-                               #:turn-id turn-id
-                               #:timestamp timestamp
-                               #:model model
-                               #:provider provider)
-  (turn-start-event "turn.started" timestamp session-id turn-id model provider))
-
-(define (make-turn-end-event #:session-id session-id
-                             #:turn-id turn-id
-                             #:timestamp timestamp
-                             #:reason reason
-                             #:duration-ms duration-ms)
-  (turn-end-event "turn.completed" timestamp session-id turn-id reason duration-ms))
+(define-typed-event turn-end-event "turn.completed"
+  (reason duration-ms))

--- a/tests/test-define-event-macro.rkt
+++ b/tests/test-define-event-macro.rkt
@@ -2,7 +2,7 @@
 
 ;; tests/test-define-event-macro.rkt — tests for define-typed-event macro
 ;;
-;; v0.32.2 Wave 0: Comprehensive expansion tests.
+;; v0.32.2 Wave 0+1: Comprehensive expansion and integration tests.
 
 (require rackunit
          racket/base
@@ -106,6 +106,41 @@
   (check-equal? (vector-ref vec 6) "openai"))
 
 ;; ============================================================
+;; Test: optional field with default
+;; ============================================================
+(define-typed-event test-optional-event "test.optional" (required-field) #:optional ([opt-field #f]))
+
+(test-case "define-typed-event: optional field defaults"
+  (define evt (make-test-optional-event #:session-id "s1" #:turn-id "t1" #:required-field "hello"))
+  (check-true (test-optional-event? evt))
+  (check-equal? (test-optional-event-required-field evt) "hello")
+  (check-equal? (test-optional-event-opt-field evt) #f)
+  (check-equal? test-optional-event-fields '(required-field opt-field)))
+
+(test-case "define-typed-event: optional field with explicit value"
+  (define evt
+    (make-test-optional-event #:session-id "s1"
+                              #:turn-id "t1"
+                              #:required-field "hello"
+                              #:opt-field "world"))
+  (check-equal? (test-optional-event-opt-field evt) "world"))
+
+(test-case "define-typed-event: optional fields included in field list"
+  (check-equal? test-optional-event-fields '(required-field opt-field)))
+
+;; ============================================================
+;; Test: multiple optional fields
+;; ============================================================
+(define-typed-event test-multi-opt-event "test.multi-opt" (x) #:optional ([y 0] [z 'none]))
+
+(test-case "define-typed-event: multiple optional fields"
+  (define evt (make-test-multi-opt-event #:session-id "s1" #:turn-id "t1" #:x 5))
+  (check-equal? (test-multi-opt-event-x evt) 5)
+  (check-equal? (test-multi-opt-event-y evt) 0)
+  (check-equal? (test-multi-opt-event-z evt) 'none)
+  (check-equal? test-multi-opt-event-fields '(x y z)))
+
+;; ============================================================
 ;; Test: deprecated define-event still works
 ;; ============================================================
 (define-event test-legacy-event (x y))
@@ -115,3 +150,34 @@
   (check-true (test-legacy-event? evt))
   (check-equal? (test-legacy-event-x evt) 1)
   (check-equal? (test-legacy-event-y evt) 2))
+
+;; ============================================================
+;; Integration: verify real event-struct modules
+;; ============================================================
+(require "../agent/event-structs/turn-events.rkt"
+         "../agent/event-structs/iteration-events.rkt"
+         "../agent/event-structs/hook-events.rkt")
+
+(test-case "integration: turn-start-event uses macro"
+  (define evt
+    (make-turn-start-event #:session-id "s1" #:turn-id "t1" #:model "gpt-4" #:provider "openai"))
+  (check-true (turn-start-event? evt))
+  (check-equal? turn-start-event-type "turn.started")
+  (check-equal? turn-start-event-fields '(model provider)))
+
+(test-case "integration: injection-event with optional message"
+  (define evt
+    (make-injection-event #:session-id "s1"
+                          #:turn-id "t1"
+                          #:source "test"
+                          #:content-type "text"
+                          #:content-length 42))
+  (check-true (injection-event? evt))
+  (check-equal? (injection-event-message evt) #f)
+  (check-equal? injection-event-fields '(source content-type content-length message)))
+
+(test-case "integration: turn-cancelled-event with optional iteration"
+  (define evt (make-turn-cancelled-event #:session-id "s1" #:turn-id "t1" #:reason "timeout"))
+  (check-true (turn-cancelled-event? evt))
+  (check-equal? (turn-cancelled-event-iteration evt) #f)
+  (check-equal? turn-cancelled-event-fields '(reason iteration)))

--- a/util/event-macro.rkt
+++ b/util/event-macro.rkt
@@ -6,8 +6,14 @@
 ;;   define-event        — basic struct+provide (DEPRECATED, kept for compat)
 ;;   define-typed-event  — full code generation: struct, constructor, type, fields, provide
 ;;
-;; v0.32.2 Wave 0: define-typed-event macro using syntax-parse.
-;; Generates struct + keyword-arg constructor + type string + field list + provide.
+;; Usage:
+;;   (define-typed-event turn-start-event "turn.started"
+;;     (model provider))
+;;   (define-typed-event injection-event "injection"
+;;     (source content-type content-length)
+;;     #:optional ([message #f]))
+;;
+;; Generates: struct, make-*-event constructor, *-event-type, *-event-fields, provide
 
 (require (for-syntax racket/base
                      racket/syntax
@@ -35,39 +41,73 @@
 ;; ===========================================================
 ;; define-typed-event macro
 ;; ===========================================================
-;;
-;; Usage:
-;;   (define-typed-event turn-start-event "turn.started"
-;;     (model provider))
 
 (begin-for-syntax
-  (define (make-kw-arg-list fields)
-    ;; Build alternating keyword-identifier list: (#:model model #:provider provider ...)
+  (define (make-kw-arg-list fields defaults)
+    ;; fields: list of identifier syntax
+    ;; defaults: list of #f or default-expression syntax
+    ;; Returns flat list: (#:f1 f1 #:f2 [f2 default2] ...)
     (apply append
-           (for/list ([f fields])
+           (for/list ([f fields]
+                      [d defaults])
              (define kw (datum->syntax f (string->keyword (symbol->string (syntax-e f)))))
-             (list kw f)))))
+             (if d
+                 (list kw #`[#,f #,d])
+                 (list kw f))))))
 
 (define-syntax (define-typed-event stx)
   (syntax-parse stx
-    [(_ event-name:id type-str:str (user-field:id ...))
+    ;; With optional fields
+    [(_ event-name:id
+        type-str:str
+        (req-field:id ...)
+        (~seq #:optional ([opt-field:id opt-default:expr] ...)))
+     (define all-fields (append (syntax->list #'(req-field ...)) (syntax->list #'(opt-field ...))))
+     (define all-defaults
+       (append (map (λ (_) #f) (syntax->list #'(req-field ...))) (syntax->list #'(opt-default ...))))
      (define make-name (format-id #'event-name "make-~a" #'event-name))
      (define type-name (format-id #'event-name "~a-type" #'event-name))
      (define fields-name (format-id #'event-name "~a-fields" #'event-name))
-     (define kw-args (make-kw-arg-list (syntax->list #'(user-field ...))))
+     (define kw-args (make-kw-arg-list all-fields all-defaults))
      (with-syntax ([make-name make-name]
                    [type-name type-name]
                    [fields-name fields-name]
+                   [(all-field ...) all-fields]
                    [(kw-arg ...) kw-args])
        #'(begin
-           (struct event-name typed-event (user-field ...) #:transparent)
+           (struct event-name typed-event (all-field ...) #:transparent)
            (define type-name type-str)
-           (define fields-name '(user-field ...))
+           (define fields-name '(all-field ...))
            (define (make-name #:session-id session-id
                               #:turn-id turn-id
                               #:timestamp [timestamp (current-seconds)]
                               kw-arg ...)
-             (event-name type-str timestamp session-id turn-id user-field ...))
+             (event-name type-str timestamp session-id turn-id all-field ...))
+           (provide (struct-out event-name)
+                    make-name
+                    type-name
+                    fields-name)))]
+    ;; Without optional fields
+    [(_ event-name:id type-str:str (req-field:id ...))
+     (define all-fields (syntax->list #'(req-field ...)))
+     (define make-name (format-id #'event-name "make-~a" #'event-name))
+     (define type-name (format-id #'event-name "~a-type" #'event-name))
+     (define fields-name (format-id #'event-name "~a-fields" #'event-name))
+     (define kw-args (make-kw-arg-list all-fields (map (λ (_) #f) all-fields)))
+     (with-syntax ([make-name make-name]
+                   [type-name type-name]
+                   [fields-name fields-name]
+                   [(all-field ...) all-fields]
+                   [(kw-arg ...) kw-args])
+       #'(begin
+           (struct event-name typed-event (all-field ...) #:transparent)
+           (define type-name type-str)
+           (define fields-name '(all-field ...))
+           (define (make-name #:session-id session-id
+                              #:turn-id turn-id
+                              #:timestamp [timestamp (current-seconds)]
+                              kw-arg ...)
+             (event-name type-str timestamp session-id turn-id all-field ...))
            (provide (struct-out event-name)
                     make-name
                     type-name

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -10,4 +10,4 @@
 (provide q-version)
 
 (: q-version String)
-(define q-version "0.32.0")
+(define q-version "0.32.2")


### PR DESCRIPTION
Addresses #3892.

feat(core): apply define-typed-event macro to all event structs (#3892)

Wave 1 of v0.32.2.
- Convert 22 event structs to use define-typed-event macro
- Add #:optional field support for injection-event, turn-cancelled-event
- Replace 50-line manual field-name registry with macro-generated constants
- Fix per-tool event field mapping (include parent tool-call-event fields)
- Fix missing streaming/blocked events from emitter registry
- Add *-event-fields exports for per-tool events
- ~293 lines removed across 8 files (34% reduction)
- Version bump to v0.32.2
- All 2035 tests pass