### PR TITLE
release(v0.33.5): version bump + CHANGELOG (#3935)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## v0.33.5 — 2026-05-07
+
+### Audit Remediation (v0.33.5)
+
+**Goal:** Fix all 9 findings from the v0.33.0–v0.33.4 audit series.
+
+**W0a — Fix TR boundary regression:**
+- Replaced direct `event-bus?`/`session-config?` passing across Typed Racket boundary with callback pattern
+- `retry-policy.rkt`: all functions now accept `#:emit-event (-> String Any Any)` callback instead of raw bus
+- `maybe-compact-mid-turn`: accepts `#:compact-proc` to avoid passing opaque session struct across TR boundary
+- Removed `emit-session-event!` import from TR module (was source of `any-wrap/c` failure)
+- Updated 8 test files to use new callback-based API
+- Fixes 2 test failures in `test-di-keyword-args.rkt`
+
+**W0b — Remove dead keyword args:**
+- Removed `#:compact-proc`, `#:estimate-tokens`, `#:inject-topic` from `run-iteration-loop`
+- These DI parameters were accepted but the bound variables were never used
+- Removed dead imports: `compact-history`, `injection-event-topic`
+
+**W0c — Cleanup imports + dedup:**
+- Removed duplicate `injection-event-topic` definition from `message-inject.rkt`
+- Removed circular dependency in `util/contracts.rkt` (was importing from `extensions/api.rkt`)
+- `loop-state.rkt` now imports `extension-registry?` directly from `extensions/api.rkt`
+
+**Verification:** 488/488 test files, 2077 tests, 0 failures
+
+---
+
 ## v0.32.11 — 2026-05-07
 
 ### Test Regression Fix (v0.32.11-W0)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.32.11-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.33.5-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 
@@ -199,7 +199,7 @@ racket main.rkt --model gpt-5.4 "write a test"
 ### Verify
 
 ```bash
-racket main.rkt --version  # q version 0.32.11
+racket main.rkt --version  # q version 0.33.5
 raco test tests/           # run the full test suite
 ```
 
@@ -272,7 +272,7 @@ q/
 |--------|-------|
 | Test files | 533 |
 | Source modules | 409 |
-| Source lines | 63913 |
+| Source lines | 63896 |
 | Test lines | 96683 |
 | Test assertions | 14924 |
 | Tests passing | 5835+ | `racket scripts/run-tests.rkt` results |
@@ -341,6 +341,9 @@ When q executes shell commands on behalf of an LLM, arguments are quoted via `sh
 
 
 
+
+
+**v0.33.5** — Audit Remediation (v0.33.5)
 
 **v0.32.11** — Test Regression Fix (v0.32.11-W0)
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -2,7 +2,7 @@
 
 ## Version
 
-v0.32.11
+v0.33.5
 
 ## Layer Diagram
 
@@ -64,7 +64,7 @@ See `docs/architecture/dependency-policy.rktd` for layering rules and known viol
 
 Two tiers:
 1. **Raw events**: `make-event` + `emit-event!` (legacy, being phased out)
-2. **Typed events**: 27 structs in `agent/event-structs/` + `emit-typed-event!` (v0.32.11+)
+2. **Typed events**: 27 structs in `agent/event-structs/` + `emit-typed-event!` (v0.33.5+)
 
 ## Testing
 

--- a/docs/event-taxonomy.md
+++ b/docs/event-taxonomy.md
@@ -1,6 +1,6 @@
 # Q Event Taxonomy Reference
 
-Complete reference for all event types in Q 0.32.11.
+Complete reference for all event types in Q 0.33.5.
 ## Base Types
 
 ### `event` (protocol-level)

--- a/docs/extension-guide.md
+++ b/docs/extension-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.32.11 --># Extension Development Guide
+<!-- verified-against: 0.33.5 --># Extension Development Guide
 
 This guide walks you through creating, testing, and activating a custom
 extension for q.

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.32.11 --># Getting Started
+<!-- verified-against: 0.33.5 --># Getting Started
 
 Welcome to q, a Racket-based coding agent.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.32.11 --># Installation Guide
+<!-- verified-against: 0.33.5 --># Installation Guide
 
 <!-- This file is the canonical source. The docs/getting-started/installation.md copy is maintained for the doc site build. -->
 

--- a/docs/security-trust-model.md
+++ b/docs/security-trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.32.11 --># Security & Trust Model
+<!-- verified-against: 0.33.5 --># Security & Trust Model
 
 This document provides an honest, per-area assessment of what q enforces
 today and what is planned. It is the authoritative reference for security

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -130,6 +130,6 @@ is the primary self-hosting extension:
 (load-extension! ext-reg "path/to/extension.rkt" #:event-bus bus)
 ```
 
-## Version 0.32.11
+## Version 0.33.5
 
-This documentation reflects q 0.32.11.
+This documentation reflects q 0.33.5.

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.32.11 --># q Source Style Guide
+<!-- verified-against: 0.33.5 --># q Source Style Guide
 
 This document defines formatting and naming conventions for the q Racket codebase.
 All changes to `q/` source files (excluding `tests/`) should follow these rules.

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.32.11 --># Trust Model
+<!-- verified-against: 0.33.5 --># Trust Model
 
 ## Trust Levels
 

--- a/docs/workflow-testing.md
+++ b/docs/workflow-testing.md
@@ -121,6 +121,6 @@ Use relative paths from the test file:
 4. Use `(check-true ...)` for boolean assertions
 5. Keep tests independent — no shared mutable state between test-cases
 
-## Version 0.32.11
+## Version 0.33.5
 
-This documentation reflects q 0.32.11.
+This documentation reflects q 0.33.5.

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.32.11")
+(define version "0.33.5")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base"))

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -10,4 +10,4 @@
 (provide q-version)
 
 (: q-version String)
-(define q-version "0.32.11")
+(define q-version "0.33.5")

--- a/wiki-src/Architecture-Overview.md
+++ b/wiki-src/Architecture-Overview.md
@@ -35,7 +35,7 @@ User input → Interface (CLI/TUI/RPC)
     → Events emitted to bus
 ```
 
-## Metrics (0.32.11)
+## Metrics (0.33.5)
 > _See `racket scripts/metrics.rkt` for current numbers._
 
 - 228 source modules, 349 test files


### PR DESCRIPTION
Version bump to 0.33.5 + CHANGELOG entries for v0.33.5 audit remediation.\n\nSynced version refs in 11 docs/wiki files.\n\nAll 16/16 CI lints pass.\n\nCloses #3935