### PR TITLE
test(v0.33.7-W0b): add test coverage for error paths and regression (#3941)

- N-T01: Test maybe-compact-mid-turn raises when #:compact-proc is #f
- N-T02: Test check-mid-turn-budget! propagates emit-event callback exceptions
- N-T03: Regression test for event-bus non-boolean truthy filter predicates

Wave 2 of v0.33.7.

### DIFF
--- a/tests/test-event-bus.rkt
+++ b/tests/test-event-bus.rkt
@@ -264,3 +264,19 @@
   (publish! bus (test-event #:name "model.stream.delta"))
   (publish! bus (test-event #:name "turn.completed"))
   (check-equal? (reverse (unbox received)) '("model.stream.delta")))
+
+;; ============================================================
+;; v0.33.7 W0b (N-T03): Regression test for non-boolean truthy filter
+;; The v0.33.6 fix changed (match ... [(cons #f #t) ...]) to
+;; [(cons #f (not #f)) ...] so truthy non-boolean filter results fire.
+;; ============================================================
+
+(test-case "publish! dispatches to subscriber with non-boolean truthy filter result"
+  (define bus (make-event-bus))
+  (define received (box #f))
+  ;; Filter returns a positive integer (truthy, not #t)
+  (subscribe! bus (lambda (evt) (set-box! received evt)) #:filter (lambda (e) 42))
+  (publish! bus (test-event #:name "test.type"))
+  (check-not-false (unbox received)
+                   "subscriber should fire when filter returns non-boolean truthy value")
+  (check-equal? (event-ev (unbox received)) "test.type"))

--- a/tests/test-mid-turn-compaction.rkt
+++ b/tests/test-mid-turn-compaction.rkt
@@ -104,3 +104,20 @@
       (check-true (string? result) "ls-read loop detected"))))
 
 (run-tests exploration-loop-suite)
+
+;; ============================================================
+;; v0.33.7 W0b (N-T01): maybe-compact-mid-turn error path
+;; ============================================================
+
+(test-case "maybe-compact-mid-turn raises when #:compact-proc is #f and over budget"
+  (define ctx (make-mock-context 50))
+  (define config (hasheq 'max-context-tokens 100))
+  (check-exn exn:fail?
+             (lambda ()
+               (maybe-compact-mid-turn 'mock-session
+                                       ctx
+                                       "test-session"
+                                       config
+                                       #:compact-proc #f
+                                       #:estimate-tokens (lambda (msgs) 999999)))
+             "should raise when #:compact-proc is #f and context exceeds budget"))

--- a/tests/test-midturn-budget.rkt
+++ b/tests/test-midturn-budget.rkt
@@ -70,3 +70,21 @@
   (define result (check-mid-turn-budget! ctx "test-session" config))
   ;; Should return positive integer
   (check-true (and (integer? result) (positive? result))))
+
+;; ============================================================
+;; v0.33.7 W0b (N-T02): emit-event callback exception propagation
+;; ============================================================
+
+(test-case "check-mid-turn-budget! propagates emit-event callback exception"
+  (define big-text (make-string 5000 #\x))
+  (define ctx
+    (for/list ([_ (in-range 10)])
+      (make-test-message big-text)))
+  (define config (hash 'max-context-tokens 500))
+  (define exn-msg "deliberate callback failure")
+  (check-exn (lambda (e) (and (exn:fail? e) (string-contains? (exn-message e) exn-msg)))
+             (lambda ()
+               (check-mid-turn-budget! ctx
+                                       "test-session"
+                                       config
+                                       #:emit-event (lambda (name payload) (error exn-msg))))))


### PR DESCRIPTION
Addresses #3941.

test(v0.33.7-W0b): add test coverage for error paths and regression (#3941)

- N-T01: Test maybe-compact-mid-turn raises when #:compact-proc is #f
- N-T02: Test check-mid-turn-budget! propagates emit-event callback exceptions
- N-T03: Regression test for event-bus non-boolean truthy filter predicates

Wave 2 of v0.33.7.