### PR TITLE
chore(v0.33.7-W0d): version bump, CHANGELOG, docs sync, git tag v0.33.6 (#3943)

- Version bump to 0.33.7
- CHANGELOG entry for v0.33.7
- N-M03: Git tag v0.33.6 created at c1d402e
- N-D01: Docs/wiki version strings synced to 0.33.7
- README status block synced

Wave 4 of v0.33.7.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## v0.33.7 — 2026-05-08
+
+### Deep Audit Remediation
+
+**Goal:** Address 12 actionable findings from 2nd-pass deep audit of v0.33.5/v0.33.6.
+
+**Source cleanup (W0a):**
+- N-A01: Removed dead `compact-context-mid-turn` import from `retry-policy.rkt`
+- N-A02: Added `#:compact-proc` passthrough to `check-mid-turn-budget!` backward-compat wrapper
+- N-S01: Unexported `make-injection-message` (zero external callers)
+
+**Test coverage (W0b):**
+- N-T01: Test `maybe-compact-mid-turn` error path when `#:compact-proc` is `#f`
+- N-T02: Test `check-mid-turn-budget!` emit-event callback exception propagation
+- N-T03: Event-bus regression test for non-boolean truthy filter predicates
+
+**Docs sync (W0c):**
+- N-D01: Updated README metrics table (source modules 408→409, lines 63889→64055)
+
+**Planning hygiene (W0d):**
+- N-M03: Git tag v0.33.6 created at `c1d402e`
+- N-M01/N-M02/N-M04/N-M06: Planning artifacts updated
+
 ## v0.33.6 — 2026-05-07
 
 ### Hotfix — Critical Audit Findings from v0.33.5

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.33.6-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.33.7-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 
@@ -199,7 +199,7 @@ racket main.rkt --model gpt-5.4 "write a test"
 ### Verify
 
 ```bash
-racket main.rkt --version  # q version 0.33.6
+racket main.rkt --version  # q version 0.33.7
 raco test tests/           # run the full test suite
 ```
 
@@ -343,6 +343,9 @@ When q executes shell commands on behalf of an LLM, arguments are quoted via `sh
 
 
 
+
+
+**v0.33.7** — Deep Audit Remediation
 
 **v0.33.6** — Hotfix — Critical Audit Findings from v0.33.5
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -2,7 +2,7 @@
 
 ## Version
 
-v0.33.6
+v0.33.7
 
 ## Layer Diagram
 
@@ -64,7 +64,7 @@ See `docs/architecture/dependency-policy.rktd` for layering rules and known viol
 
 Two tiers:
 1. **Raw events**: `make-event` + `emit-event!` (legacy, being phased out)
-2. **Typed events**: 27 structs in `agent/event-structs/` + `emit-typed-event!` (v0.33.6+)
+2. **Typed events**: 27 structs in `agent/event-structs/` + `emit-typed-event!` (v0.33.7+)
 
 ## Testing
 

--- a/docs/event-taxonomy.md
+++ b/docs/event-taxonomy.md
@@ -1,6 +1,6 @@
 # Q Event Taxonomy Reference
 
-Complete reference for all event types in Q 0.33.6.
+Complete reference for all event types in Q 0.33.7.
 ## Base Types
 
 ### `event` (protocol-level)

--- a/docs/extension-guide.md
+++ b/docs/extension-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.33.6 --># Extension Development Guide
+<!-- verified-against: 0.33.7 --># Extension Development Guide
 
 This guide walks you through creating, testing, and activating a custom
 extension for q.

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.33.6 --># Getting Started
+<!-- verified-against: 0.33.7 --># Getting Started
 
 Welcome to q, a Racket-based coding agent.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.33.6 --># Installation Guide
+<!-- verified-against: 0.33.7 --># Installation Guide
 
 <!-- This file is the canonical source. The docs/getting-started/installation.md copy is maintained for the doc site build. -->
 

--- a/docs/security-trust-model.md
+++ b/docs/security-trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.33.6 --># Security & Trust Model
+<!-- verified-against: 0.33.7 --># Security & Trust Model
 
 This document provides an honest, per-area assessment of what q enforces
 today and what is planned. It is the authoritative reference for security

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -130,6 +130,6 @@ is the primary self-hosting extension:
 (load-extension! ext-reg "path/to/extension.rkt" #:event-bus bus)
 ```
 
-## Version 0.33.6
+## Version 0.33.7
 
-This documentation reflects q 0.33.6.
+This documentation reflects q 0.33.7.

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.33.6 --># q Source Style Guide
+<!-- verified-against: 0.33.7 --># q Source Style Guide
 
 This document defines formatting and naming conventions for the q Racket codebase.
 All changes to `q/` source files (excluding `tests/`) should follow these rules.

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.33.6 --># Trust Model
+<!-- verified-against: 0.33.7 --># Trust Model
 
 ## Trust Levels
 

--- a/docs/workflow-testing.md
+++ b/docs/workflow-testing.md
@@ -121,6 +121,6 @@ Use relative paths from the test file:
 4. Use `(check-true ...)` for boolean assertions
 5. Keep tests independent — no shared mutable state between test-cases
 
-## Version 0.33.6
+## Version 0.33.7
 
-This documentation reflects q 0.33.6.
+This documentation reflects q 0.33.7.

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.33.6")
+(define version "0.33.7")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base"))

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -10,4 +10,4 @@
 (provide q-version)
 
 (: q-version String)
-(define q-version "0.33.6")
+(define q-version "0.33.7")

--- a/wiki-src/Architecture-Overview.md
+++ b/wiki-src/Architecture-Overview.md
@@ -35,7 +35,7 @@ User input → Interface (CLI/TUI/RPC)
     → Events emitted to bus
 ```
 
-## Metrics (0.33.6)
+## Metrics (0.33.7)
 > _See `racket scripts/metrics.rkt` for current numbers._
 
 - 228 source modules, 349 test files


### PR DESCRIPTION
Addresses #3943.

chore(v0.33.7-W0d): version bump, CHANGELOG, docs sync, git tag v0.33.6 (#3943)

- Version bump to 0.33.7
- CHANGELOG entry for v0.33.7
- N-M03: Git tag v0.33.6 created at c1d402e
- N-D01: Docs/wiki version strings synced to 0.33.7
- README status block synced

Wave 4 of v0.33.7.