### PR TITLE
fix(v0.34.0-w0a): dead code removal + trivial contracts (#3950)

### DIFF
--- a/runtime/iteration.rkt
+++ b/runtime/iteration.rkt
@@ -357,10 +357,10 @@
      (make-loop-result ctx 'completed (hasheq 'reason "graceful-shutdown" 'iteration iteration))]
     [else #f]))
 
-;; process-tool-results: Execute pending tool calls, update working set,
+;; execute-pending-tool-calls: Execute pending tool calls, update working set,
 ;; and compute new iteration counters. Shared by 'continue and 'stop-soft-limit.
 ;; Returns updated-ctx (with tool results appended).
-(define (process-tool-results new-msgs infra config ws)
+(define (execute-pending-tool-calls new-msgs infra config ws)
   (define updated-ctx
     (handle-tool-calls-pending new-msgs
                                (loop-infra-ctx infra)
@@ -567,7 +567,7 @@
                                   max-iterations-hard
                                   'remaining
                                   (- max-iterations-hard (add1 (loop-counters-iteration counters)))))
-     (define updated-ctx (process-tool-results new-msgs infra config ws))
+     (define updated-ctx (execute-pending-tool-calls new-msgs infra config ws))
      (define budget-config (hasheq 'max-context-tokens (dict-ref config 'max-context-tokens 128000)))
      (define emit-fn
        (lambda (name payload)
@@ -596,7 +596,7 @@
                  ws)]
     ['continue
      (append-entries! (loop-infra-log-path infra) new-msgs)
-     (define updated-ctx (process-tool-results new-msgs infra config ws))
+     (define updated-ctx (execute-pending-tool-calls new-msgs infra config ws))
      (define new-counters (step-result-new-counters step-res))
      ;; v0.28.22 W1: exploration loop detection
      (define loop-warning
@@ -639,8 +639,8 @@
                               steering-queue
                               follow-up-mode
                               on-recurse)
-  (define (call-process-tool-results)
-    (process-tool-results new-msgs infra config ws))
+  (define (call-execute-pending-tool-calls)
+    (execute-pending-tool-calls new-msgs infra config ws))
   (match action
     ['stop
      (handle-stop-action result
@@ -681,7 +681,7 @@
                                   max-iterations-hard
                                   'remaining
                                   (- max-iterations-hard (add1 (loop-counters-iteration counters)))))
-     (define updated-ctx (call-process-tool-results))
+     (define updated-ctx (call-execute-pending-tool-calls))
      (define budget-config (hasheq 'max-context-tokens (dict-ref config 'max-context-tokens 128000)))
      (define emit-fn
        (lambda (name payload)
@@ -710,7 +710,7 @@
                  ws)]
     ['continue
      (append-entries! (loop-infra-log-path infra) new-msgs)
-     (define updated-ctx (call-process-tool-results))
+     (define updated-ctx (call-execute-pending-tool-calls))
      (define new-counters (compute-next-counters counters new-msgs))
      ;; v0.28.22 W1: exploration loop detection
      (define loop-warning
@@ -906,7 +906,7 @@
            handle-stop-action
            interpret-step
            compute-next-counters
-           process-tool-results ;; NOTE: requires tool-coordinator mock for isolated testing
+           execute-pending-tool-calls ;; NOTE: requires tool-coordinator mock for isolated testing
            decide-next-action
            check-cancellation
            compute-step-result

--- a/tests/test-iteration-integration.rkt
+++ b/tests/test-iteration-integration.rkt
@@ -212,7 +212,7 @@
   (define ws (make-working-set))
   (define msgs (list (make-msg-with-tool-call "read" (hasheq 'path "/tmp/test.rkt"))))
   (define result (make-loop-result msgs 'tool-calls-pending (hasheq)))
-  ;; process-tool-results needs tool-coordinator; use empty msg list
+  ;; execute-pending-tool-calls needs tool-coordinator; use empty msg list
   ;; to avoid calling handle-tool-calls-pending with real tools
   (define result-no-msgs (make-loop-result '() 'tool-calls-pending (hasheq)))
   (define recurse-args-box (box #f))

--- a/tools/tool.rkt
+++ b/tools/tool.rkt
@@ -42,7 +42,7 @@
                                                #:render-result (or/c procedure? #f)
                                                #:prompt-guidelines (or/c string? #f))
                              tool?)]
-                       [validate-tool-args (-> tool? hash? any/c)])
+                       [validate-tool-args (-> tool? hash? boolean?)])
          merge-tool-lists
          validate-tool-schema
          format-tool-schema-hint
@@ -90,7 +90,7 @@
          make-tool-call
 
          ;; ── Tool-call argument validation ──
-         (all-from-out "../util/json-helpers.rkt")
+         ensure-hash-args
          json-serializable?
          validate-tool-result
 
@@ -115,7 +115,6 @@
 
 (define (emit-progress! ctx percentage message)
   (define cb (exec-context-progress-callback ctx))
-  exec-context-permission-config
   (when cb
     (cb percentage message)))
 


### PR DESCRIPTION
Closes #3950.

## Changes
- RA-03: Remove dead `exec-context-permission-config` expression from `emit-progress!`
- RA-07: Tighten `validate-tool-args` return contract `any/c` → `boolean?`
- RA-10: Replace `all-from-out` json-helpers with explicit `only-in` for `ensure-hash-args`
- RA-33: Tighten `run-tool-batch` registry contract `any/c` → `tool-registry?`
- RA-37: Tighten `require/typed` in `retry-policy.rkt`
  - `dict-ref`: `Any` → `(HashTable Symbol Any)` for config arg
  - `message-content`: return `Any` → `(U String (Listof Any))`
- RA-39: Rename `process-tool-results` → `execute-pending-tool-calls`
  - Updated all 5 internal call sites + `for-testing` export + test comment

## Verification
- `raco make` on all changed files → clean
- `racket scripts/run-tests.rkt --suite fast` → 488/488 files, 2086/2086 tests pass