### PR TITLE
feat(v0.34.1-w0a): tool + message constructor contracts (#3952)

### DIFF
--- a/runtime/iteration.rkt
+++ b/runtime/iteration.rkt
@@ -112,7 +112,7 @@
          (only-in "context-policy.rkt" estimate-message-tokens))
 
 (provide (contract-out [run-iteration-loop
-                        (->* (list? (or/c provider? #f)
+                        (->* ((listof message?) (or/c provider? #f)
                                     event-bus?
                                     (or/c tool-registry? #f)
                                     (or/c extension-registry? #f)

--- a/tools/tool.rkt
+++ b/tools/tool.rkt
@@ -49,7 +49,7 @@
 
          ;; ── Tool result (re-exported from agent/types.rkt) ──
          tool-result?
-         (contract-out [make-tool-result (-> any/c any/c any/c tool-result?)]
+         (contract-out [make-tool-result (-> any/c (or/c hash? #f) boolean? tool-result?)]
                        [make-error-result (-> string? tool-result?)]
                        [make-success-result (->* (any/c) (any/c) tool-result?)])
          tool-result-content

--- a/util/message.rkt
+++ b/util/message.rkt
@@ -8,8 +8,17 @@
 (require racket/contract
          "content-parts.rkt")
 
-(provide (struct-out message)
-         make-message
+(provide message
+         message?
+         message-id
+         message-parent-id
+         message-role
+         message-kind
+         message-content
+         message-timestamp
+         message-meta
+         (contract-out [make-message
+                        (-> any/c (or/c string? symbol? #f) symbol? symbol? (listof any/c) any/c any/c message?)])
          message->jsexpr
          jsexpr->message)
 


### PR DESCRIPTION
Closes #3952.

## Changes
- RA-01: Tighten `make-tool-result` contract from `any/c any/c any/c` to `any/c (or/c hash? #f) boolean?`
- RA-06: Add `make-message` contract-out in `util/message.rkt` (keep raw `message` constructor for backward compat)
- RA-13: Tighten `run-iteration-loop` first arg from `list?` to `(listof message?)`

## Verification
- `raco make` on all changed files → clean
- `racket scripts/run-tests.rkt --suite fast` → 488/488 files, 2077/2077 tests pass