### PR TITLE
feat(v0.34.2-w0a): error fixes + structured errors (#3954)

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ q/
 |--------|-------|
 | Test files | 533 |
 | Source modules | 407 |
-| Source lines | 63208 |
+| Source lines | 63239 |
 | Test lines | 96737 |
 | Test assertions | 14931 |
 | Tests passing | 5835+ | `racket scripts/run-tests.rkt` results |

--- a/extensions/dynamic-tools.rkt
+++ b/extensions/dynamic-tools.rkt
@@ -16,6 +16,7 @@
 ;; This delegates to the tool-registry stored in the extension-ctx.
 
 (require racket/contract
+         (only-in "../util/errors.rkt" raise-extension-error)
          "context.rkt"
          "tool-api.rkt")
 
@@ -67,7 +68,7 @@
 (define (ext-unregister-tool! ctx name)
   (define reg (ctx-tool-registry ctx))
   (unless reg
-    (error 'ext-unregister-tool! "no tool-registry available in extension context"))
+    (raise-extension-error "no tool-registry available in extension context" 'dynamic-tools 'unregister))
   (unregister-tool! reg name))
 
 ;; ============================================================
@@ -89,5 +90,5 @@
 (define (ext-set-active-tools! ctx active-names)
   (define reg (ctx-tool-registry ctx))
   (unless reg
-    (error 'ext-set-active-tools! "no tool-registry available in extension context"))
+    (raise-extension-error "no tool-registry available in extension context" 'dynamic-tools 'set-active))
   (set-active-tools! reg active-names))

--- a/extensions/ext-commands.rkt
+++ b/extensions/ext-commands.rkt
@@ -7,6 +7,7 @@
 ;; Extensions register commands which appear in the TUI command palette.
 
 (require racket/contract
+         (only-in "../util/errors.rkt" raise-extension-error)
          racket/list
          "context.rkt"
          "../util/command-types.rkt")
@@ -38,7 +39,7 @@
 (define (ext-register-command! ctx name summary category args-spec aliases)
   (define reg-hash (get-reg-hash ctx))
   (unless reg-hash
-    (error 'ext-register-command!
+    (raise-extension-error "ext-register-command!" 'ext-commands 'register
            "no command-registry in extension context. Set #:command-registry."))
   (define entry (cmd-entry name summary category args-spec aliases))
   (define new-hash (register-command! reg-hash entry))
@@ -47,7 +48,7 @@
 (define (ext-unregister-command! ctx name)
   (define reg-hash (get-reg-hash ctx))
   (unless reg-hash
-    (error 'ext-unregister-command! "no command-registry in extension context"))
+    (raise-extension-error "no command-registry in extension context" 'ext-commands 'unregister))
   ;; Rebuild hash without the named command
   (define new-hash
     (for/hash ([(k v) (in-hash reg-hash)]

--- a/extensions/github/helpers.rkt
+++ b/extensions/github/helpers.rkt
@@ -13,7 +13,8 @@
 ;; Extracted from github-integration.rkt to reduce its size (Q01).
 ;; Provides shell quoting, input validation, gh/git execution, and repo info.
 
-(require "../../util/error-helpers.rkt")
+(require "../../util/error-helpers.rkt"
+         (only-in "../../util/errors.rkt" raise-extension-error))
 (require racket/format
          racket/port
          racket/string
@@ -106,7 +107,7 @@
 (define (gh-exec-result . args)
   (define bin (gh-binary))
   (unless bin
-    (error 'gh "GitHub CLI not found"))
+    (raise-extension-error "GitHub CLI not found" 'github 'cli-check))
   (apply run-command bin args))
 
 (define (git-exec-result . args)

--- a/extensions/gsd/context-bundle.rkt
+++ b/extensions/gsd/context-bundle.rkt
@@ -8,6 +8,7 @@
 ;; current phase needs.
 
 (require racket/string
+         (only-in "../../util/errors.rkt" raise-extension-error)
          racket/match
          "plan-types.rkt")
 
@@ -41,7 +42,7 @@
     [(explorer) (explorer-bundle artifacts files)]
     [(executor) (executor-bundle artifacts files)]
     [(verifier) (verifier-bundle artifacts files)]
-    [else (error 'assemble-context "unknown role: ~a" role)]))
+    [else (raise-extension-error (format "unknown role: ~a" role) 'gsd 'assemble-context)]))
 
 ;; ============================================================
 ;; Explorer bundle

--- a/extensions/gsd/events.rkt
+++ b/extensions/gsd/events.rkt
@@ -6,7 +6,8 @@
 ;; F6 fix: Stable event names + correlation IDs for GSD lifecycle.
 ;; All events follow: gsd.<category>.<action>
 
-(require racket/match)
+(require racket/match
+         (only-in "../../util/errors.rkt" raise-extension-error))
 
 (provide gsd-event-names
          emit-gsd-event!
@@ -59,7 +60,7 @@
 
 (define (emit-gsd-event! event-name data)
   (unless (memq event-name gsd-event-names)
-    (error 'emit-gsd-event! "Unknown event: ~a" event-name))
+    (raise-extension-error (format "Unknown event: ~a" event-name) 'gsd 'emit-event))
   (define bus (unbox gsd-event-bus-box))
   (bus event-name
        (hasheq 'event

--- a/extensions/image-input.rkt
+++ b/extensions/image-input.rkt
@@ -6,6 +6,7 @@
 ;; and multi-modal message construction.
 
 (require racket/string
+         (only-in "../util/errors.rkt" raise-extension-error)
          racket/file
          racket/path
          net/base64
@@ -52,9 +53,9 @@
     [(string=? action "encode")
      (define path (hash-ref args 'path ""))
      (when (string=? path "")
-       (error 'image-input "path is required for encode"))
+       (raise-extension-error "path is required for encode" 'image-input 'encode))
      (unless (file-exists? path)
-       (error 'image-input (format "File not found: ~a" path)))
+       (raise-extension-error (format "File not found: ~a" path) 'image-input 'encode))
      (define b64 (image->base64 path))
      (make-success-result (list (hasheq 'type
                                         "text"
@@ -67,7 +68,7 @@
      (define text (hash-ref args 'text ""))
      (define path (hash-ref args 'path ""))
      (when (string=? path "")
-       (error 'image-input "path is required for message"))
+       (raise-extension-error "path is required for message" 'image-input 'message))
      (define msg (make-image-message text path))
      (make-success-result
       (list (hasheq 'type "text" 'text (format "Multi-modal message created with image ~a" path))

--- a/extensions/racket-tooling/analysis.rkt
+++ b/extensions/racket-tooling/analysis.rkt
@@ -6,6 +6,7 @@
 ;; handle-racket-check: format, syntax, test, expand, and all-mode checks.
 
 (require racket/string
+         (only-in "../../util/errors.rkt" raise-extension-error)
          racket/list
          json
          (only-in "../racket-tooling-helpers.rkt"
@@ -18,9 +19,9 @@
   (define path (hash-ref args 'path ""))
   (define mode (hash-ref args 'mode "syntax"))
   (when (string=? path "")
-    (error 'racket-check "path is required"))
+    (raise-extension-error "path is required" 'racket-tooling 'check))
   (unless (file-exists? path)
-    (error 'racket-check (format "File not found: ~a" path)))
+    (raise-extension-error (format "File not found: ~a" path) 'racket-tooling 'check))
 
   (define results '())
 

--- a/extensions/racket-tooling/formatting.rkt
+++ b/extensions/racket-tooling/formatting.rkt
@@ -7,6 +7,7 @@
 ;; cond-insert-clause, match-insert-clause, rewrite-form.
 
 (require racket/string
+         (only-in "../../util/errors.rkt" raise-extension-error)
          racket/list
          (only-in "../racket-tooling-helpers.rkt"
                   raco-fmt
@@ -27,16 +28,16 @@
 ;; Validate string before read - reject #reader or #lang injections
 (define (safe-read-string s context)
   (when (or (regexp-match? #rx"#reader" s) (regexp-match? #rx"#lang" s))
-    (error 'racket-edit (format "~a contains forbidden #reader or #lang directive" context)))
+    (raise-extension-error (format "~a contains forbidden #reader or #lang directive" context) 'racket-tooling 'edit))
   (read (open-input-string s)))
 
 (define (handle-racket-edit args [exec-ctx #f])
   (define path (hash-ref args 'file (hash-ref args 'path "")))
   (define mode (hash-ref args 'mode "replace"))
   (when (string=? path "")
-    (error 'racket-edit "file is required"))
+    (raise-extension-error "file is required" 'racket-tooling 'edit))
   (unless (or (string=? mode "skeleton") (file-exists? path))
-    (error 'racket-edit (format "File not found: ~a" path)))
+    (raise-extension-error (format "File not found: ~a" path) 'racket-tooling 'edit))
   (with-handlers ([exn:fail? (lambda (e)
                                (make-error-result (format "racket-edit error: ~a" (exn-message e))))])
     (cond

--- a/extensions/racket-tooling/rewrite.rkt
+++ b/extensions/racket-tooling/rewrite.rkt
@@ -6,6 +6,7 @@
 ;; handle-racket-codemod: pattern/template-based structural rewrites.
 
 (require racket/string
+         (only-in "../../util/errors.rkt" raise-extension-error)
          racket/list
          (only-in "../racket-tooling-helpers.rkt"
                   raco-fmt
@@ -25,7 +26,7 @@
 ;; Validate string before read - reject #reader or #lang injections
 (define (safe-read-string s context)
   (when (or (regexp-match? #rx"#reader" s) (regexp-match? #rx"#lang" s))
-    (error 'racket-codemod (format "~a contains forbidden #reader or #lang directive" context)))
+    (raise-extension-error (format "~a contains forbidden #reader or #lang directive" context) 'racket-tooling 'codemod))
   (read (open-input-string s)))
 
 (define (handle-racket-codemod args [exec-ctx #f])
@@ -35,13 +36,13 @@
   (define write? (hash-ref args 'write #f))
 
   (when (string=? path "")
-    (error 'racket-codemod "file is required"))
+    (raise-extension-error "file is required" 'racket-tooling 'codemod))
   (when (string=? pattern "")
-    (error 'racket-codemod "pattern is required"))
+    (raise-extension-error "pattern is required" 'racket-tooling 'codemod))
   (when (string=? template "")
-    (error 'racket-codemod "template is required"))
+    (raise-extension-error "template is required" 'racket-tooling 'codemod))
   (unless (file-exists? path)
-    (error 'racket-codemod (format "File not found: ~a" path)))
+    (raise-extension-error (format "File not found: ~a" path) 'racket-tooling 'codemod))
 
   (define content (read-file-string path))
   (define lang-line

--- a/extensions/remote-collab/remote-collab.rkt
+++ b/extensions/remote-collab/remote-collab.rkt
@@ -6,6 +6,7 @@
 ;; via SSH + tmux. Actions: status, start, send, capture, wait, interrupt, stop.
 
 (require racket/contract
+         (only-in "../../util/errors.rkt" raise-extension-error)
          racket/string
          racket/port
          "../define-extension.rkt"
@@ -32,7 +33,7 @@
 ;; Build a remote command that wraps tmux operations via SSH
 (define (remote-tmux host session action args)
   (unless (valid-session-name? session)
-    (error 'remote-q "invalid session name: ~a" session))
+    (raise-extension-error (format "invalid session name: ~a" session) 'remote-collab 'validate))
   (case action
     [(status)
      (format "tmux has-session -t ~a 2>/dev/null && echo 'running' || echo 'stopped'" session)]
@@ -64,7 +65,7 @@
       session)]
     [(interrupt) (format "tmux send-keys -t ~a Escape" session)]
     [(stop) (format "tmux kill-session -t ~a 2>/dev/null; echo 'stopped'" session)]
-    [else (error 'remote-q "unknown action: ~a" action)]))
+    [else (raise-extension-error (format "unknown action: ~a" action) 'remote-collab 'dispatch)]))
 
 ;; ============================================================
 ;; Tool handler
@@ -78,7 +79,7 @@
   (define opts (hash-ref args 'ssh_options '()))
 
   (when (string=? host "")
-    (error 'remote-q "host is required"))
+    (raise-extension-error "host is required" 'remote-collab 'config))
 
   (define cmd (remote-tmux host session action args))
 

--- a/extensions/remote-collab/ssh-helpers.rkt
+++ b/extensions/remote-collab/ssh-helpers.rkt
@@ -6,6 +6,7 @@
 ;; Includes host validation to prevent injection via malformed host strings.
 
 (require racket/contract
+         (only-in "../../util/errors.rkt" raise-extension-error)
          racket/string
          racket/port
          racket/match)
@@ -45,7 +46,7 @@
 ;; Returns (values exit-code stdout-string stderr-string)
 (define (ssh-execute host command #:options [opts (default-ssh-options)])
   (unless (valid-ssh-host? host)
-    (error 'ssh-execute "Invalid SSH host: ~a" host))
+    (raise-extension-error (format "Invalid SSH host: ~a" host) 'remote-collab 'ssh-execute))
   (define ssh-path (find-executable-path "ssh"))
   (define all-args (append opts (list host command)))
   (define-values (sp out-in in-out err-in) (apply subprocess #f #f #f ssh-path all-args))

--- a/extensions/resource-discovery.rkt
+++ b/extensions/resource-discovery.rkt
@@ -13,6 +13,7 @@
 ;; natural layer for code that interacts with the extension API.
 
 (require racket/list
+         (only-in "../util/errors.rkt" raise-extension-error)
          "api.rkt"
          "hooks.rkt")
 
@@ -27,7 +28,7 @@
 ;; paths that extensions want scanned for skills, prompts, etc.
 (define (discover-extension-resources registry)
   (unless registry
-    (error 'discover-extension-resources "registry is required, got #f"))
+    (raise-extension-error "registry is required, got #f" 'resource-discovery 'discover))
   ;; Dispatch 'resources-discover hook on all extensions
   (define hook-result (dispatch-hooks 'resources-discover (hasheq) registry))
   ;; Extract paths from hook result payload

--- a/llm/provider.rkt
+++ b/llm/provider.rkt
@@ -17,7 +17,8 @@
          racket/generator
          racket/generic
          racket/string
-         "model.rkt")
+         "model.rkt"
+         (only-in "../util/errors.rkt" raise-credential-error))
 
 (provide provider?
          validate-api-key!
@@ -56,13 +57,12 @@
 (define (validate-api-key! provider-name env-var config)
   (define api-key (hash-ref config 'api-key ""))
   (when (or (not api-key) (not (string? api-key)) (string=? (string-trim api-key) ""))
-    (raise
-     (exn:fail
-      (format
-       "~a API key not set. Set ~a environment variable or add 'api-key' to config.json. Run 'q config' for setup."
-       provider-name
-       env-var)
-      (current-continuation-marks)))))
+    (raise-credential-error
+     (format
+      "~a API key not set. Set ~a environment variable or add 'api-key' to config.json. Run 'q config' for setup."
+      provider-name
+      env-var)
+     provider-name)))
 
 ;; ============================================================
 ;; Generic provider interface

--- a/runtime/session-store.rkt
+++ b/runtime/session-store.rkt
@@ -292,7 +292,8 @@
   (define box (in-memory-session-manager-sessions-box mgr))
   (define sessions (unbox box))
   (define existing (hash-ref sessions session-id '()))
-  (set-box! box (hash-set sessions session-id (append existing (list msg)))))
+  ;; RA-17: prepend (O(1)) instead of append (O(n)) to avoid quadratic growth
+  (set-box! box (hash-set sessions session-id (cons msg existing))))
 
 (define (in-memory-append-entries! mgr session-id msgs)
   (for ([msg (in-list msgs)])
@@ -300,7 +301,8 @@
 
 (define (in-memory-load mgr session-id)
   (define sessions (unbox (in-memory-session-manager-sessions-box mgr)))
-  (hash-ref sessions session-id '()))
+  ;; Reverse to restore chronological order (entries are stored newest-first)
+  (reverse (hash-ref sessions session-id '())))
 
 (define (in-memory-list-sessions mgr)
   (hash-keys (unbox (in-memory-session-manager-sessions-box mgr))))
@@ -318,7 +320,8 @@
         entries))
   (define box (in-memory-session-manager-sessions-box mgr))
   (define sessions (unbox box))
-  (set-box! box (hash-set sessions dest-id to-copy))
+  ;; Store in reverse-chronological order to match internal representation
+  (set-box! box (hash-set sessions dest-id (reverse to-copy)))
   dest-id)
 
 ;; ============================================================

--- a/util/json-helpers.rkt
+++ b/util/json-helpers.rkt
@@ -7,7 +7,8 @@
 
 (require racket/format
          racket/string
-         json)
+         json
+         (only-in "errors.rkt" raise-tool-error))
 
 ;; JSON argument normalization
 (provide ensure-hash-args
@@ -17,7 +18,9 @@
 
 ;; Parse tool-call arguments from string to hash if needed.
 ;; Streaming produces arguments as JSON strings; tools expect hashes.
-(define (ensure-hash-args args)
+;; RA-02: On parse failure, raises tool-error instead of returning poisoned hash.
+;; #:graceful? #t returns empty hash on failure for backward-compatible callers.
+(define (ensure-hash-args args #:graceful? [graceful? #f])
   (cond
     [(hash? args) args]
     [(string? args)
@@ -26,15 +29,28 @@
          (hash)
          (with-handlers ([exn:fail?
                           (lambda (e)
-                            (fprintf (current-error-port)
-                                     "warning: ensure-hash-args: failed to parse JSON args: ~a~n"
-                                     args)
-                            (hasheq '_parse_failed #t '_raw_args args))])
+                            (if graceful?
+                                (hash)
+                                (raise-tool-error
+                                 (format "Failed to parse tool arguments JSON: ~a" args)
+                                 "ensure-hash-args"
+                                 (hasheq 'raw args 'error (exn-message e)))))])
            (define parsed (string->jsexpr cleaned))
            (if (hash? parsed)
                parsed
-               (hasheq '_parse_failed #t '_raw_args args))))]
-    [else (hasheq '_parse_failed #t '_raw_args (format "~a" args))]))
+               (if graceful?
+                   (hash)
+                   (raise-tool-error
+                    (format "Tool arguments parsed to non-hash: ~a" args)
+                    "ensure-hash-args"
+                    (hasheq 'raw args 'parsed parsed))))))]
+    [else
+     (if graceful?
+         (hash)
+         (raise-tool-error
+          (format "Tool arguments must be hash or JSON string, got: ~a" args)
+          "ensure-hash-args"
+          (hasheq 'raw (format "~a" args))))]))
 
 ;; Read and parse a JSON file, returning the parsed value.
 (define (read-json-file path)


### PR DESCRIPTION
Closes #3954.

## Changes
- RA-02: `ensure-hash-args` raises `tool-error` on parse failure; added `#:graceful?` parameter
- RA-14: Migrated 20 highest-priority bare `(error ...)` calls in `extensions/` to `raise-extension-error`
- RA-16: `validate-api-key!` uses `raise-credential-error` instead of raw `exn:fail`
- RA-17: Fixed O(n²) `in-memory-append!` by prepending + reversing on read

## Verification
- `raco make` on all changed files → clean
- `racket scripts/run-tests.rkt --suite fast` → 488/488 files, 2077/2077 tests pass