### PR TITLE
feat(v0.34.4): session boundary encapsulation (RA-05) (#3967)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.34.3-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.34.4-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 
@@ -199,7 +199,7 @@ racket main.rkt --model gpt-5.4 "write a test"
 ### Verify
 
 ```bash
-racket main.rkt --version  # q version 0.34.3
+racket main.rkt --version  # q version 0.34.4
 raco test tests/           # run the full test suite
 ```
 
@@ -272,8 +272,8 @@ q/
 |--------|-------|
 | Test files | 533 |
 | Source modules | 407 |
-| Source lines | 63131 |
-| Test lines | 96877 |
+| Source lines | 63125 |
+| Test lines | 96880 |
 | Test assertions | 14972 |
 | Tests passing | 5835+ | `racket scripts/run-tests.rkt` results |
 

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.34.3")
+(define version "0.34.4")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base"))

--- a/runtime/agent-session.rkt
+++ b/runtime/agent-session.rkt
@@ -94,16 +94,10 @@
          cycle-model!
          agent-session-system-instructions
          agent-session-compacting?
-         set-agent-session-compacting?!
          agent-session-last-compaction-time
-         set-agent-session-last-compaction-time!
          agent-session-persisted?
-         set-agent-session-persisted?!
          agent-session-pending-entries
-         set-agent-session-pending-entries!
          agent-session-prompt-running?
-         set-agent-session-prompt-running?!
-         set-agent-session-config!
          ensure-persisted!
          buffer-or-append!
          (contract-out [make-agent-session (-> any/c agent-session?)]

--- a/tests/test-agent-session.rkt
+++ b/tests/test-agent-session.rkt
@@ -9,6 +9,7 @@
 (require rackunit
          racket/file
          "../runtime/agent-session.rkt"
+         "../runtime/session-types.rkt"
          "../agent/event-bus.rkt"
          "../tools/tool.rkt")
 

--- a/tests/test-compaction-guard.rkt
+++ b/tests/test-compaction-guard.rkt
@@ -13,6 +13,7 @@
          "../util/protocol-types.rkt"
          "../agent/event-bus.rkt"
          "../runtime/agent-session.rkt"
+         "../runtime/session-types.rkt"
          "../runtime/session-store.rkt"
          "../runtime/compactor.rkt")
 

--- a/tests/test-stale-usage-guard.rkt
+++ b/tests/test-stale-usage-guard.rkt
@@ -9,7 +9,8 @@
          rackunit/text-ui
          "../util/protocol-types.rkt"
          "../agent/event-bus.rkt"
-         "../runtime/agent-session.rkt")
+         "../runtime/agent-session.rkt"
+         "../runtime/session-types.rkt")
 
 (define (make-temp-dir)
   (make-temporary-file "q-stale-test-~a" 'directory))

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -10,4 +10,4 @@
 (provide q-version)
 
 (: q-version String)
-(define q-version "0.34.3")
+(define q-version "0.34.4")


### PR DESCRIPTION
Closes #3967.

## Changes
- Removed 6 raw `set-agent-session-*!` mutators from `runtime/agent-session.rkt` public API:
  - `set-agent-session-compacting?!`
  - `set-agent-session-last-compaction-time!`
  - `set-agent-session-persisted?!`
  - `set-agent-session-pending-entries!`
  - `set-agent-session-prompt-running?!`
  - `set-agent-session-config!`
- Internal modules already access these via `session-types.rkt` `struct-out`
- Test files updated to import `session-types.rkt` directly for internal mutator access

## Verification
- `racket scripts/run-tests.rkt --suite fast` → 488/488 files, 2088/2088 tests pass
- Version bumped to 0.34.4