### PR TITLE
chore(version): bump to v0.34.6 + update planning artifacts (#3974)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## v0.34.6 — 2026-05-08
+
+### Architecture Decomposition (A-01, A-02)
+
+**Goal:** Decompose monolithic god modules into focused sub-modules.
+
+**W0a — iteration.rkt decomposition (#3972):**
+- Extracted 808-line runtime/iteration.rkt into 4 sub-modules:
+  - runtime/iteration/counters.rkt (110 lines) — compute-next-counters, check-cancellation
+  - runtime/iteration/decision.rkt (91 lines) — iteration-ctx, step-result, decide-next-action, compute-termination, compute-step-result
+  - runtime/iteration/step-interpreter.rkt (314 lines) — interpret-step, handle-stop-action, execute-pending-tool-calls
+  - runtime/iteration/main-loop.rkt (244 lines) — run-iteration-loop
+- Converted iteration.rkt into 110-line re-export facade
+- Fixed tool-coordinator.rkt to guard run-tool-batch against #f registry
+
+**W0b — gsd-planning.rkt decomposition (#3973):**
+- Extracted 670-line extensions/gsd-planning.rkt into 2 sub-modules:
+  - extensions/gsd/tool-handlers.rkt (219 lines) — handle-planning-read, handle-planning-write, artifact I/O, tool schemas
+  - extensions/gsd/command-handlers.rkt (326 lines) — slash-command registration and dispatch, /go, /gsd, /plan handlers
+- Converted gsd-planning.rkt into 184-line re-export facade
+- Moved planning-implement-prompt into gsd/prompts.rkt for centralized prompt management
+
+**Verification:** 486/486 fast test files, 2088 tests pass. Lint: 18/18 pass.
+
 ## v0.34.5 — 2026-05-08
 
 ### Docs/Lint Remediation + Contract Quick Wins + Test Hygiene

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.34.5-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.34.6-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 
@@ -199,7 +199,7 @@ racket main.rkt --model gpt-5.4 "write a test"
 ### Verify
 
 ```bash
-racket main.rkt --version  # q version 0.34.5
+racket main.rkt --version  # q version 0.34.6
 raco test tests/           # run the full test suite
 ```
 
@@ -347,6 +347,9 @@ When q executes shell commands on behalf of an LLM, arguments are quoted via `sh
 
 
 
+
+
+**v0.34.6** — Architecture Decomposition (A-01, A-02)
 
 **v0.34.5** — Docs/Lint Remediation + Contract Quick Wins + Test Hygiene
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -2,7 +2,7 @@
 
 ## Version
 
-v0.34.5
+v0.34.6
 
 ## Layer Diagram
 

--- a/docs/event-taxonomy.md
+++ b/docs/event-taxonomy.md
@@ -1,6 +1,6 @@
 # Q Event Taxonomy Reference
 
-Complete reference for all event types in Q 0.34.5.
+Complete reference for all event types in Q 0.34.6.
 ## Base Types
 
 ### `event` (protocol-level)

--- a/docs/extension-guide.md
+++ b/docs/extension-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.34.5 --># Extension Development Guide
+<!-- verified-against: 0.34.6 --># Extension Development Guide
 
 This guide walks you through creating, testing, and activating a custom
 extension for q.

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.34.5 --># Getting Started
+<!-- verified-against: 0.34.6 --># Getting Started
 
 Welcome to q, a Racket-based coding agent.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.34.5 --># Installation Guide
+<!-- verified-against: 0.34.6 --># Installation Guide
 
 <!-- This file is the canonical source. The docs/getting-started/installation.md copy is maintained for the doc site build. -->
 

--- a/docs/security-trust-model.md
+++ b/docs/security-trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.34.5 --># Security & Trust Model
+<!-- verified-against: 0.34.6 --># Security & Trust Model
 
 This document provides an honest, per-area assessment of what q enforces
 today and what is planned. It is the authoritative reference for security

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -130,6 +130,6 @@ is the primary self-hosting extension:
 (load-extension! ext-reg "path/to/extension.rkt" #:event-bus bus)
 ```
 
-## Version 0.34.5
+## Version 0.34.6
 
-This documentation reflects q 0.34.5.
+This documentation reflects q 0.34.6.

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.34.5 --># q Source Style Guide
+<!-- verified-against: 0.34.6 --># q Source Style Guide
 
 This document defines formatting and naming conventions for the q Racket codebase.
 All changes to `q/` source files (excluding `tests/`) should follow these rules.

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.34.5 --># Trust Model
+<!-- verified-against: 0.34.6 --># Trust Model
 
 ## Trust Levels
 

--- a/docs/workflow-testing.md
+++ b/docs/workflow-testing.md
@@ -121,6 +121,6 @@ Use relative paths from the test file:
 4. Use `(check-true ...)` for boolean assertions
 5. Keep tests independent — no shared mutable state between test-cases
 
-## Version 0.34.5
+## Version 0.34.6
 
-This documentation reflects q 0.34.5.
+This documentation reflects q 0.34.6.

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.34.5")
+(define version "0.34.6")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base"))

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -10,4 +10,4 @@
 (provide q-version)
 
 (: q-version String)
-(define q-version "0.34.5")
+(define q-version "0.34.6")

--- a/wiki-src/Architecture-Overview.md
+++ b/wiki-src/Architecture-Overview.md
@@ -35,7 +35,7 @@ User input → Interface (CLI/TUI/RPC)
     → Events emitted to bus
 ```
 
-## Metrics (0.34.5)
+## Metrics (0.34.6)
 > _See `racket scripts/metrics.rkt` for current numbers._
 
 - 228 source modules, 349 test files


### PR DESCRIPTION
Version bump to v0.34.6 with CHANGELOG entry, docs sync, and planning artifact updates.

Closes #3974