### PR TITLE
docs(v0.34.7-w0b): sync planning artifacts + update architecture docs (D-01–06)

### DIFF
--- a/docs/architecture/dependency-policy.rktd
+++ b/docs/architecture/dependency-policy.rktd
@@ -72,9 +72,9 @@
    (convention . "Keymap resolution and default maps."))
   (runtime/iteration
    (parent . "runtime/iteration.rkt")
-   (sub-modules . (loop-state retry-policy tool-turn-bridge transition-logic))
-   (budget . 350)
-   (convention . "Iteration loop decomposition. Recursive core stays in parent."))
+   (sub-modules . (loop-state retry-policy tool-turn-bridge counters decision step-interpreter main-loop internal))
+   (budget . 450)
+   (convention . "Iteration loop decomposition. Pure logic in counters/decision, effectful in step-interpreter, orchestration in main-loop."))
   (runtime/session-index
    (parent . "runtime/session-index.rkt")
    (sub-modules . (schema query mutations))
@@ -90,6 +90,11 @@
    (sub-modules . (command-normalization execution-policy plan-diff))
    (budget . 130)
    (convention . "Pure logic extracted from GSD planning."))
+  (extensions/gsd
+   (parent . "extensions/gsd-planning.rkt")
+   (sub-modules . (command-handlers tool-handlers))
+   (budget . 350)
+   (convention . "GSD command/tool dispatch extracted from gsd-planning facade."))
   (extensions/github/handlers
    (parent . "extensions/github/tool-handlers.rkt")
    (sub-modules . (issue-ops pr-ops milestone-ops))

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -34,7 +34,7 @@ v0.34.6
 └─────────────────────────────────────────────┘
 ```
 
-## Module Counts (409 source modules, ~64,100 LOC)
+## Module Counts (414 source modules, ~63,300 LOC)
 
 | Layer | Modules | Key Files |
 |-------|---------|-----------|

--- a/util/errors.rkt
+++ b/util/errors.rkt
@@ -4,7 +4,7 @@
 ;;
 ;; Provides structured error types for different error domains:
 ;;   - q-error: base error with message and optional context hash
-;;   - provider-error: LLM provider failures (provider name, status-code)
+;;   - provider-error: → canonical definition in llm/provider-errors.rkt
 ;;   - tool-error: tool execution failures (tool-name)
 ;;   - session-error: session lifecycle errors (session-id)
 

--- a/wiki-src/Architecture-Overview.md
+++ b/wiki-src/Architecture-Overview.md
@@ -38,9 +38,9 @@ User input → Interface (CLI/TUI/RPC)
 ## Metrics (0.34.6)
 > _See `racket scripts/metrics.rkt` for current numbers._
 
-- 228 source modules, 349 test files
-- 43,544 source lines, 71,526 test lines
-- 11,057 assertions (test:source ratio 1.64:1)
+- 414 source modules, 531 test files
+- 63,297 source lines, 96,796 test lines
+- 14,952 assertions (test:source ratio 1.53:1)
 - 10/10 lint checks enforced in CI
 
 For the canonical architecture description, see the [repository README](https://github.com/coinerd/q/blob/main/README.md) and [docs/adr/README.md](https://github.com/coinerd/q/blob/main/q/docs/adr/README.md).


### PR DESCRIPTION
v0.34.7 Wave 0b — Documentation + Planning Sync.

- D-01: Sync inner .planning/STATE.md + PLAN.md to v0.34.6+ (gitignored, local-only)
- D-02: Update dependency-policy.rktd with iteration/gsd decomposition
- D-03: Sync module counts across README, overview, wiki-src (414 modules, 63,297 LOC)
- D-04: FUNCTION-QUALITY-AUDIT.md already absent (verified)
- D-05: Fix errors.rkt header comment for provider-error
- D-06: Verify outer STATE.md current

Verification: 486/486 fast files, 2078 tests pass; lint 18/18 pass.

Closes #3982