### PR TITLE
release: v0.34.8 — deep audit remediation (D-01–D-04, T-01–T-06)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,24 @@
 - **T-01**: Removed 11 empty stub headers from GSD integration tests (15→4)
 - **T-06**: Replaced remaining `check-true #t` in turn-compaction test
 
+### W0c — Metrics Sync + Version Bump (D-03, D-04)
+- **D-03**: Synced wiki-src/Architecture-Overview.md metrics (531→534 test files, 96796→97086 test lines, 14952→14977 assertions)
+- **D-04**: Fixed docs/architecture/overview.md LOC (63300→63297)
+
+**Verification**: lint-all 18/18, fast test suite green
+
+---
+
+## v0.34.8 — 2026-05-09
+
+**10 findings addressed** (2 Critical + 6 Warning + 2 Info):
+- D-01: Inner planning sync (was 15+ versions stale)
+- D-02: FUNCTION-QUALITY-AUDIT.md removal (confirmed absent)
+- T-01–T-06: Test quality fixes (field mapping, dead imports, stubs, assertions, tautology)
+- D-03–D-04: Metrics sync (wiki-src + overview.md)
+
+**Lint**: 18/18 | **Tests**: fast suite green | **Version**: 0.34.8
+
 
 ## [0.34.7] — 2026-05-09
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.34.7-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.34.8-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 
@@ -199,7 +199,7 @@ racket main.rkt --model gpt-5.4 "write a test"
 ### Verify
 
 ```bash
-racket main.rkt --version  # q version 0.34.7
+racket main.rkt --version  # q version 0.34.8
 raco test tests/           # run the full test suite
 ```
 
@@ -349,6 +349,9 @@ When q executes shell commands on behalf of an LLM, arguments are quoted via `sh
 
 
 
+
+
+**v0.34.8** — 2026-05-09
 
 **v0.34.7** — Architecture Decomposition (A-01, A-02)
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -2,7 +2,7 @@
 
 ## Version
 
-v0.34.7
+v0.34.8
 
 ## Layer Diagram
 
@@ -34,7 +34,7 @@ v0.34.7
 └─────────────────────────────────────────────┘
 ```
 
-## Module Counts (414 source modules, ~63,300 LOC)
+## Module Counts (414 source modules, ~63,297 LOC)
 
 | Layer | Modules | Key Files |
 |-------|---------|-----------|

--- a/docs/event-taxonomy.md
+++ b/docs/event-taxonomy.md
@@ -1,6 +1,6 @@
 # Q Event Taxonomy Reference
 
-Complete reference for all event types in Q 0.34.7.
+Complete reference for all event types in Q 0.34.8.
 ## Base Types
 
 ### `event` (protocol-level)

--- a/docs/extension-guide.md
+++ b/docs/extension-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.34.7 --># Extension Development Guide
+<!-- verified-against: 0.34.8 --># Extension Development Guide
 
 This guide walks you through creating, testing, and activating a custom
 extension for q.

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.34.7 --># Getting Started
+<!-- verified-against: 0.34.8 --># Getting Started
 
 Welcome to q, a Racket-based coding agent.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.34.7 --># Installation Guide
+<!-- verified-against: 0.34.8 --># Installation Guide
 
 <!-- This file is the canonical source. The docs/getting-started/installation.md copy is maintained for the doc site build. -->
 

--- a/docs/security-trust-model.md
+++ b/docs/security-trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.34.7 --># Security & Trust Model
+<!-- verified-against: 0.34.8 --># Security & Trust Model
 
 This document provides an honest, per-area assessment of what q enforces
 today and what is planned. It is the authoritative reference for security

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -130,6 +130,6 @@ is the primary self-hosting extension:
 (load-extension! ext-reg "path/to/extension.rkt" #:event-bus bus)
 ```
 
-## Version 0.34.7
+## Version 0.34.8
 
-This documentation reflects q 0.34.7.
+This documentation reflects q 0.34.8.

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.34.7 --># q Source Style Guide
+<!-- verified-against: 0.34.8 --># q Source Style Guide
 
 This document defines formatting and naming conventions for the q Racket codebase.
 All changes to `q/` source files (excluding `tests/`) should follow these rules.

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.34.7 --># Trust Model
+<!-- verified-against: 0.34.8 --># Trust Model
 
 ## Trust Levels
 

--- a/docs/workflow-testing.md
+++ b/docs/workflow-testing.md
@@ -121,6 +121,6 @@ Use relative paths from the test file:
 4. Use `(check-true ...)` for boolean assertions
 5. Keep tests independent — no shared mutable state between test-cases
 
-## Version 0.34.7
+## Version 0.34.8
 
-This documentation reflects q 0.34.7.
+This documentation reflects q 0.34.8.

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.34.7")
+(define version "0.34.8")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base"))

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -10,4 +10,4 @@
 (provide q-version)
 
 (: q-version String)
-(define q-version "0.34.7")
+(define q-version "0.34.8")

--- a/wiki-src/Architecture-Overview.md
+++ b/wiki-src/Architecture-Overview.md
@@ -35,12 +35,12 @@ User input → Interface (CLI/TUI/RPC)
     → Events emitted to bus
 ```
 
-## Metrics (0.34.7)
+## Metrics (0.34.8)
 > _See `racket scripts/metrics.rkt` for current numbers._
 
-- 414 source modules, 531 test files
-- 63,297 source lines, 96,796 test lines
-- 14,952 assertions (test:source ratio 1.53:1)
+- 414 source modules, 534 test files
+- 63,297 source lines, 97,086 test lines
+- 14,977 assertions (test:source ratio 1.53:1)
 - 10/10 lint checks enforced in CI
 
 For the canonical architecture description, see the [repository README](https://github.com/coinerd/q/blob/main/README.md) and [docs/adr/README.md](https://github.com/coinerd/q/blob/main/q/docs/adr/README.md).


### PR DESCRIPTION
v0.34.8 W0c — Metrics Sync + Version Bump.

- D-03: Synced wiki-src metrics (534 test files, 97086 test lines, 14977 assertions)
- D-04: Fixed overview.md LOC (63297)
- Version bump 0.34.7→0.34.8
- All docs version references updated

Verification: lint 18/18, 2092 tests pass

Closes #3990