### PR TITLE
release: v0.34.9 — stale file cleanup + documentation accuracy (N-01–N-08)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.34.9] — 2026-05-09
+
+### Goal: Documentation integrity fixes (v0.34.8 findings)
+
+### W0 — Stale File Cleanup + Documentation Accuracy
+- **N-02**: Removed stale `FUNCTION-QUALITY-AUDIT.md` (was already absent, confirmed)
+- **N-01**: Removed stale inner `q/.planning/` directory (464 files, frozen at v0.32.11; canonical is outer `.planning/`)
+- **N-03**: Merged duplicate CHANGELOG v0.34.8 sections
+- **N-04**: Fixed README v0.34.7 description ("Architecture Decomposition" → "Deep Audit Remediation")
+- **N-05**: Added README v0.34.8 description ("Deep Audit Remediation Round 2")
+- **N-06/N-07**: Metrics already match canonical values (414 modules, 63,297 LOC)
+
+**Verification**: lint-all 18/18, smoke test suite green
+
 ## [0.34.8] — 2026-05-09
 
 ### Goal: Deep audit remediation round 2 (v0.34.7 findings)
@@ -23,17 +37,6 @@
 
 **Verification**: lint-all 18/18, fast test suite green
 
----
-
-## v0.34.8 — 2026-05-09
-
-**10 findings addressed** (2 Critical + 6 Warning + 2 Info):
-- D-01: Inner planning sync (was 15+ versions stale)
-- D-02: FUNCTION-QUALITY-AUDIT.md removal (confirmed absent)
-- T-01–T-06: Test quality fixes (field mapping, dead imports, stubs, assertions, tautology)
-- D-03–D-04: Metrics sync (wiki-src + overview.md)
-
-**Lint**: 18/18 | **Tests**: fast suite green | **Version**: 0.34.8
 
 
 ## [0.34.7] — 2026-05-09

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.34.8-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.34.9-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 
@@ -199,7 +199,7 @@ racket main.rkt --model gpt-5.4 "write a test"
 ### Verify
 
 ```bash
-racket main.rkt --version  # q version 0.34.8
+racket main.rkt --version  # q version 0.34.9
 raco test tests/           # run the full test suite
 ```
 
@@ -351,9 +351,12 @@ When q executes shell commands on behalf of an LLM, arguments are quoted via `sh
 
 
 
-**v0.34.8** — 2026-05-09
 
-**v0.34.7** — Architecture Decomposition (A-01, A-02)
+**v0.34.9** — Architecture Decomposition (A-01, A-02)
+
+**v0.34.8** — Deep Audit Remediation Round 2
+
+**v0.34.7** — Deep Audit Remediation
 
 **v0.34.6** — Architecture Decomposition (A-01, A-02)
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -2,7 +2,7 @@
 
 ## Version
 
-v0.34.8
+v0.34.9
 
 ## Layer Diagram
 

--- a/docs/event-taxonomy.md
+++ b/docs/event-taxonomy.md
@@ -1,6 +1,6 @@
 # Q Event Taxonomy Reference
 
-Complete reference for all event types in Q 0.34.8.
+Complete reference for all event types in Q 0.34.9.
 ## Base Types
 
 ### `event` (protocol-level)

--- a/docs/extension-guide.md
+++ b/docs/extension-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.34.8 --># Extension Development Guide
+<!-- verified-against: 0.34.9 --># Extension Development Guide
 
 This guide walks you through creating, testing, and activating a custom
 extension for q.

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.34.8 --># Getting Started
+<!-- verified-against: 0.34.9 --># Getting Started
 
 Welcome to q, a Racket-based coding agent.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.34.8 --># Installation Guide
+<!-- verified-against: 0.34.9 --># Installation Guide
 
 <!-- This file is the canonical source. The docs/getting-started/installation.md copy is maintained for the doc site build. -->
 

--- a/docs/security-trust-model.md
+++ b/docs/security-trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.34.8 --># Security & Trust Model
+<!-- verified-against: 0.34.9 --># Security & Trust Model
 
 This document provides an honest, per-area assessment of what q enforces
 today and what is planned. It is the authoritative reference for security

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -130,6 +130,6 @@ is the primary self-hosting extension:
 (load-extension! ext-reg "path/to/extension.rkt" #:event-bus bus)
 ```
 
-## Version 0.34.8
+## Version 0.34.9
 
-This documentation reflects q 0.34.8.
+This documentation reflects q 0.34.9.

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.34.8 --># q Source Style Guide
+<!-- verified-against: 0.34.9 --># q Source Style Guide
 
 This document defines formatting and naming conventions for the q Racket codebase.
 All changes to `q/` source files (excluding `tests/`) should follow these rules.

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.34.8 --># Trust Model
+<!-- verified-against: 0.34.9 --># Trust Model
 
 ## Trust Levels
 

--- a/docs/workflow-testing.md
+++ b/docs/workflow-testing.md
@@ -121,6 +121,6 @@ Use relative paths from the test file:
 4. Use `(check-true ...)` for boolean assertions
 5. Keep tests independent — no shared mutable state between test-cases
 
-## Version 0.34.8
+## Version 0.34.9
 
-This documentation reflects q 0.34.8.
+This documentation reflects q 0.34.9.

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.34.8")
+(define version "0.34.9")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base"))

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -10,4 +10,4 @@
 (provide q-version)
 
 (: q-version String)
-(define q-version "0.34.8")
+(define q-version "0.34.9")

--- a/wiki-src/Architecture-Overview.md
+++ b/wiki-src/Architecture-Overview.md
@@ -35,7 +35,7 @@ User input → Interface (CLI/TUI/RPC)
     → Events emitted to bus
 ```
 
-## Metrics (0.34.8)
+## Metrics (0.34.9)
 > _See `racket scripts/metrics.rkt` for current numbers._
 
 - 414 source modules, 534 test files


### PR DESCRIPTION
v0.34.9 W0 — Stale File Cleanup + Documentation Accuracy.

- N-01: Removed stale inner q/.planning/ directory (464 files, frozen at v0.32.11)
- N-02: Confirmed FUNCTION-QUALITY-AUDIT.md absent
- N-03: Merged duplicate CHANGELOG v0.34.8 sections
- N-04: Fixed README v0.34.7 description
- N-05: Added README v0.34.8 description
- N-06/N-07: Metrics verified correct (414 modules, 63,297 LOC)

Verification: lint 18/18, 2031 smoke tests pass

Closes #3995