### PR TITLE
fix: GSD deadlock + stream event arity crash + dead code cleanup (R-01, R-02, N-08, N-11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## v0.35.9 — 2026-05-10
+
+### Goal: Hotfix — Deadlock + Arity Crash + Dead Code Cleanup
+
+### 🔴 Critical Fixes
+- **R-01**: Fix GSD state machine deadlock — `gsm-transition!`/`gsm-reset!`/`reset-gsm!` nested
+  `with-gsd-lock` on same non-reentrant semaphore via `gsd-state-snapshot`/`gsd-state-update!`,
+  causing all GSD workflow tests to hang (14 test timeouts restored to passing)
+- **R-02**: Fix `stream-completed-event` JSON round-trip arity crash — deserialization was missing
+  the `truncated?` optional field (7-arg constructor called with 6 args)
+
+### 🟢 Cleanup
+- **N-08**: Remove `circuit-breaker-state` from `event-bus.rkt` provide (was dead export)
+- **N-11**: Remove dead `tui.editor.cut`/`tui.editor.select-all` keymap bindings from `keymap.rkt`
+
+**Verification**: lint 18/18, 0 GSD timeouts, all event round-trips pass
+
 ## v0.35.8 — 2026-05-10
 
 ### Goal: Deep Audit Remediation (N-01–N-13, I-07)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.35.8-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.35.9-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 
@@ -199,7 +199,7 @@ racket main.rkt --model gpt-5.4 "write a test"
 ### Verify
 
 ```bash
-racket main.rkt --version  # q version 0.35.8
+racket main.rkt --version  # q version 0.35.9
 raco test tests/           # run the full test suite
 ```
 
@@ -272,7 +272,7 @@ q/
 |--------|-------|
 | Test files | 550 |
 | Source modules | 416 |
-| Source lines | 63575 |
+| Source lines | 63569 |
 | Test lines | 98368 |
 | Test assertions | 15279 |
 | Tests passing | 5835+ | `racket scripts/run-tests.rkt` results |
@@ -360,6 +360,9 @@ When q executes shell commands on behalf of an LLM, arguments are quoted via `sh
 
 
 
+
+
+**v0.35.9** — Goal: Hotfix — Deadlock + Arity Crash + Dead Code Cleanup
 
 **v0.35.8** — Goal: Deep Audit Remediation (N-01–N-13, I-07)
 

--- a/agent/event-bus.rkt
+++ b/agent/event-bus.rkt
@@ -34,8 +34,6 @@
          ;; Circuit breaker configuration
          current-circuit-breaker-threshold
          current-circuit-breaker-cooldown-secs
-         ;; Deprecated: use explicit breaker-state argument instead
-         circuit-breaker-state
          ;; New per-bus isolated circuit breaker functions
          circuit-broken?
          record-failure!

--- a/agent/event-json.rkt
+++ b/agent/event-json.rkt
@@ -20,6 +20,7 @@
                   stream-completed-event
                   stream-completed-event-usage
                   stream-completed-event-finish_reason
+                  stream-completed-event-truncated?
                   stream-tool-call-started-event
                   stream-tool-call-started-event-id
                   stream-tool-call-started-event-name
@@ -180,7 +181,9 @@
      (hasheq 'usage
              (stream-completed-event-usage evt)
              'finish_reason
-             (stream-completed-event-finish_reason evt))]
+             (stream-completed-event-finish_reason evt)
+             'truncated?
+             (stream-completed-event-truncated? evt))]
     [(? stream-tool-call-started-event?)
      (hasheq 'id
              (stream-tool-call-started-event-id evt)
@@ -397,7 +400,8 @@
                              sid
                              tid
                              (hash-ref h 'usage (hasheq))
-                             (hash-ref h 'finish_reason ""))]
+                             (hash-ref h 'finish_reason "")
+                             (hash-ref h 'truncated? #f))]
     ["tool.call.started"
      (stream-tool-call-started-event type
                                      ts

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -2,7 +2,7 @@
 
 ## Version
 
-v0.35.8
+v0.35.9
 
 ## Layer Diagram
 

--- a/docs/event-taxonomy.md
+++ b/docs/event-taxonomy.md
@@ -1,6 +1,6 @@
 # Q Event Taxonomy Reference
 
-Complete reference for all event types in Q 0.35.8.
+Complete reference for all event types in Q 0.35.9.
 ## Base Types
 
 ### `event` (protocol-level)

--- a/docs/extension-guide.md
+++ b/docs/extension-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.35.8 --># Extension Development Guide
+<!-- verified-against: 0.35.9 --># Extension Development Guide
 
 This guide walks you through creating, testing, and activating a custom
 extension for q.

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.35.8 --># Getting Started
+<!-- verified-against: 0.35.9 --># Getting Started
 
 Welcome to q, a Racket-based coding agent.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.35.8 --># Installation Guide
+<!-- verified-against: 0.35.9 --># Installation Guide
 
 <!-- This file is the canonical source. The docs/getting-started/installation.md copy is maintained for the doc site build. -->
 

--- a/docs/security-trust-model.md
+++ b/docs/security-trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.35.8 --># Security & Trust Model
+<!-- verified-against: 0.35.9 --># Security & Trust Model
 
 This document provides an honest, per-area assessment of what q enforces
 today and what is planned. It is the authoritative reference for security

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -130,6 +130,6 @@ is the primary self-hosting extension:
 (load-extension! ext-reg "path/to/extension.rkt" #:event-bus bus)
 ```
 
-## Version 0.35.8
+## Version 0.35.9
 
-This documentation reflects q 0.35.8.
+This documentation reflects q 0.35.9.

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.35.8 --># q Source Style Guide
+<!-- verified-against: 0.35.9 --># q Source Style Guide
 
 This document defines formatting and naming conventions for the q Racket codebase.
 All changes to `q/` source files (excluding `tests/`) should follow these rules.

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.35.8 --># Trust Model
+<!-- verified-against: 0.35.9 --># Trust Model
 
 ## Trust Levels
 

--- a/docs/workflow-testing.md
+++ b/docs/workflow-testing.md
@@ -121,6 +121,6 @@ Use relative paths from the test file:
 4. Use `(check-true ...)` for boolean assertions
 5. Keep tests independent — no shared mutable state between test-cases
 
-## Version 0.35.8
+## Version 0.35.9
 
-This documentation reflects q 0.35.8.
+This documentation reflects q 0.35.9.

--- a/extensions/gsd/state-machine.rkt
+++ b/extensions/gsd/state-machine.rkt
@@ -20,15 +20,14 @@
          (only-in "policy.rkt" blocked-tools-for gsd-decide-action policy-allowed?)
          (only-in "events.rkt" emit-gsd-event! current-gsd-correlation-id)
          (only-in "session-state.rkt"
-                  current-gsd-state ; N-03: kept for with-gsd-lock compatibility
-                  set-gsd-state! ; N-03: kept for with-gsd-lock compatibility
+                  current-gsd-state
+                  set-gsd-state!
                   current-gsd-history
                   set-gsd-history!
-                  gsd-state-snapshot
-                  gsd-state-update!
                   gsd-state-sem
-                  gsd-history-update!
+                  gsd-state-snapshot
                   gsd-history-snapshot
+                  gsd-state-update!
                   with-gsd-lock))
 
 ;; States
@@ -148,18 +147,20 @@
       current-state)]))
 
 (define (gsm-transition! target)
-  ;; N-03: Uses gsd-state-snapshot/gsd-state-update! instead of deprecated globals
+  ;; R-01: Use current-gsd-state/set-gsd-state! directly inside with-gsd-lock.
+  ;; gsd-state-snapshot/gsd-state-update! call with-gsd-lock internally,
+  ;; causing deadlock on the same non-reentrant semaphore.
   (with-gsd-lock
    (lambda ()
-     (define state (gsd-state-snapshot))
+     (define state (current-gsd-state))
      (define current (gsd-runtime-state-mode state))
      (emit-gsd-event! 'gsd.transition.attempted (hasheq 'from current 'to target))
      (define-values (result new-state) (compute-next-gsm-state state target))
      (cond
        [(ok? result)
         (define new-mode (gsd-runtime-state-mode new-state))
-        (gsd-state-update! (lambda (_) new-state))
-        (gsd-history-update! (lambda (h) (cons (list current new-mode (current-seconds)) h)))
+        (set-gsd-state! new-state)
+        (set-gsd-history! (cons (list current new-mode (current-seconds)) (current-gsd-history)))
         (emit-gsd-event! 'gsd.transition.succeeded (hasheq 'from current 'to new-mode))
         result]
        [else
@@ -169,21 +170,20 @@
         result]))))
 
 (define (gsm-reset!)
-  ;; N-03: Uses gsd-state-snapshot/gsd-state-update!
+  ;; R-01: Use current-gsd-state/set-gsd-state! directly inside with-gsd-lock.
   (with-gsd-lock
    (lambda ()
-     (define state (gsd-state-snapshot))
+     (define state (current-gsd-state))
      (define old (gsd-runtime-state-mode state))
-     (gsd-state-update! (lambda (_)
-                          (struct-copy gsd-runtime-state state [mode 'idle] [wave-executor #f])))
-     (gsd-history-update! (lambda (h) (cons (list old 'idle (current-seconds)) h)))
+     (set-gsd-state! (struct-copy gsd-runtime-state state [mode 'idle] [wave-executor #f]))
+     (set-gsd-history! (cons (list old 'idle (current-seconds)) (current-gsd-history)))
      (ok-result old 'idle))))
 
 (define (reset-gsm!)
-  ;; N-03: Uses gsd-state-update!/gsd-history-update!
+  ;; R-01: Use set-gsd-state!/set-gsd-history! directly inside with-gsd-lock.
   (with-gsd-lock (lambda ()
-                   (gsd-state-update! (lambda (_) (make-initial-gsd-state)))
-                   (gsd-history-update! (lambda (_) '()))
+                   (set-gsd-state! (make-initial-gsd-state))
+                   (set-gsd-history! '())
                    (void))))
 
 (define (gsm-valid-next-states)

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.35.8")
+(define version "0.35.9")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base"))

--- a/tui/keymap.rkt
+++ b/tui/keymap.rkt
@@ -127,12 +127,8 @@
           'tui.editor.word-right
           'copy
           'tui.editor.copy
-          'cut
-          'tui.editor.cut
           'paste
           'tui.editor.paste
-          'select-all
-          'tui.editor.select-all
           'clear-input
           'tui.editor.clear-input
           'clear-screen
@@ -220,12 +216,8 @@
   (keymap-add! km (key-spec 'right #f #t #f) 'tui.navigation.end)
   ;; Ctrl-C for copy
   (keymap-add! km (key-spec #\c #t #f #f) 'tui.editor.copy)
-  ;; Ctrl-X for cut
-  (keymap-add! km (key-spec #\x #t #f #f) 'tui.editor.cut)
   ;; Ctrl-V for paste
   (keymap-add! km (key-spec #\v #t #f #f) 'tui.editor.paste)
-  ;; Ctrl-A for select-all
-  (keymap-add! km (key-spec #\a #t #f #f) 'tui.editor.select-all)
   ;; Ctrl-U for clear input
   (keymap-add! km (key-spec #\u #t #f #f) 'tui.editor.clear-input)
   ;; Ctrl-L for clear screen

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -10,4 +10,4 @@
 (provide q-version)
 
 (: q-version String)
-(define q-version "0.35.8")
+(define q-version "0.35.9")

--- a/wiki-src/Architecture-Overview.md
+++ b/wiki-src/Architecture-Overview.md
@@ -35,7 +35,7 @@ User input → Interface (CLI/TUI/RPC)
     → Events emitted to bus
 ```
 
-## Metrics (0.35.8)
+## Metrics (0.35.9)
 > _See `racket scripts/metrics.rkt` for current numbers._
 
 - 414 source modules, 534 test files


### PR DESCRIPTION
v0.35.9 W0 — Hotfix: Deadlock + Arity Crash + Dead Code Cleanup.

**CRITICAL**: R-01 — Fix GSD state machine deadlock (nested `with-gsd-lock` on non-reentrant semaphore)
**HIGH**: R-02 — Fix `stream-completed-event` JSON round-trip arity crash
**LOW**: N-08 — Remove dead `circuit-breaker-state` export, N-11 — Remove dead keymap bindings

Lint 18/18, 0 GSD timeouts, all event round-trips pass.

Closes #4035