### PR TITLE
feat: module boundary hardening (M-06, M-07, M-14, L-02)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## v0.36.6 — 2026-05-10
+
+### Goal: Module Boundary Hardening (M-06, M-07, M-14, L-02)
+
+### Medium Impact
+- **M-06** (LAYER-02): Moved `extension-ctx` struct definition to `util/extension-types.rkt`
+  (pure types, no runtime imports). `extensions/context.rkt` re-imports and re-exports
+  for backward compatibility. Convenience methods remain in context.rkt.
+- **M-14** (PORT-01): Added `jsonl-write-to-port!` port-based variant alongside
+  path-based `jsonl-append!`. Enables batch writes with caller-managed port lifecycle.
+- **L-02** (CORE-04): Consolidated 3 separate regex patterns in `gsd-progress-message?`
+  into single combined regex with `message-meta` priority path documented.
+
+### Cleanup
+- **M-07** (MOD-01): Added deprecation notice to `runtime/iteration.rkt` facade.
+  New code should import from sub-modules directly. Removal targeted for v0.38.0.
+
+**Verification**: All modules compile, lint 18/18
+
 ## v0.36.5 — 2026-05-10
 
 ### Goal: TUI State Decomposition (H-06, M-08, M-09, L-01, L-05)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.36.5-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.36.6-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 
@@ -199,7 +199,7 @@ racket main.rkt --model gpt-5.4 "write a test"
 ### Verify
 
 ```bash
-racket main.rkt --version  # q version 0.36.5
+racket main.rkt --version  # q version 0.36.6
 raco test tests/           # run the full test suite
 ```
 
@@ -271,8 +271,8 @@ q/
 | Metric | Value |
 |--------|-------|
 | Test files | 552 |
-| Source modules | 418 |
-| Source lines | 63657 |
+| Source modules | 419 |
+| Source lines | 63687 |
 | Test lines | 98536 |
 | Test assertions | 15316 |
 | Tests passing | 5835+ | `racket scripts/run-tests.rkt` results |
@@ -367,6 +367,9 @@ When q executes shell commands on behalf of an LLM, arguments are quoted via `sh
 
 
 
+
+
+**v0.36.6** — Goal: Module Boundary Hardening (M-06, M-07, M-14, L-02)
 
 **v0.36.5** — Goal: TUI State Decomposition (H-06, M-08, M-09, L-01, L-05)
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -2,7 +2,7 @@
 
 ## Version
 
-v0.36.5
+v0.36.6
 
 ## Layer Diagram
 

--- a/docs/event-taxonomy.md
+++ b/docs/event-taxonomy.md
@@ -1,6 +1,6 @@
 # Q Event Taxonomy Reference
 
-Complete reference for all event types in Q 0.36.5.
+Complete reference for all event types in Q 0.36.6.
 ## Base Types
 
 ### `event` (protocol-level)

--- a/docs/extension-guide.md
+++ b/docs/extension-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.36.5 --># Extension Development Guide
+<!-- verified-against: 0.36.6 --># Extension Development Guide
 
 This guide walks you through creating, testing, and activating a custom
 extension for q.

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.36.5 --># Getting Started
+<!-- verified-against: 0.36.6 --># Getting Started
 
 Welcome to q, a Racket-based coding agent.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.36.5 --># Installation Guide
+<!-- verified-against: 0.36.6 --># Installation Guide
 
 <!-- This file is the canonical source. The docs/getting-started/installation.md copy is maintained for the doc site build. -->
 

--- a/docs/security-trust-model.md
+++ b/docs/security-trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.36.5 --># Security & Trust Model
+<!-- verified-against: 0.36.6 --># Security & Trust Model
 
 This document provides an honest, per-area assessment of what q enforces
 today and what is planned. It is the authoritative reference for security

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -130,6 +130,6 @@ is the primary self-hosting extension:
 (load-extension! ext-reg "path/to/extension.rkt" #:event-bus bus)
 ```
 
-## Version 0.36.5
+## Version 0.36.6
 
-This documentation reflects q 0.36.5.
+This documentation reflects q 0.36.6.

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.36.5 --># q Source Style Guide
+<!-- verified-against: 0.36.6 --># q Source Style Guide
 
 This document defines formatting and naming conventions for the q Racket codebase.
 All changes to `q/` source files (excluding `tests/`) should follow these rules.

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.36.5 --># Trust Model
+<!-- verified-against: 0.36.6 --># Trust Model
 
 ## Trust Levels
 

--- a/docs/workflow-testing.md
+++ b/docs/workflow-testing.md
@@ -121,6 +121,6 @@ Use relative paths from the test file:
 4. Use `(check-true ...)` for boolean assertions
 5. Keep tests independent — no shared mutable state between test-cases
 
-## Version 0.36.5
+## Version 0.36.6
 
-This documentation reflects q 0.36.5.
+This documentation reflects q 0.36.6.

--- a/extensions/context.rkt
+++ b/extensions/context.rkt
@@ -26,7 +26,8 @@
                   provider-info?
                   provider-info-provider)
          (only-in "../llm/provider.rkt" provider?)
-         (only-in "gsd/session-state.rkt" gsd-session-ctx?))
+         ;; M-06: Import struct from pure types module
+         "../util/extension-types.rkt")
 
 ;; Struct and predicate
 (provide extension-ctx
@@ -59,30 +60,12 @@
          ctx-session-token-count
          ctx-session-model)
 
-;; ============================================================
-;; extension-ctx struct
-;; ============================================================
-
-(struct extension-ctx
-        (session-id ; string?
-         session-dir ; (or/c path-string? #f)
-         event-bus ; event-bus?
-         extension-registry ; extension-registry?
-         model-name ; (or/c string? #f)
-         cancellation-token ; (or/c cancellation-token? #f)
-         working-directory ; (or/c path-string? #f)
-         ;; FEAT-58: rich extension context fields
-         session-store ; (or/c any/c #f) — read-only session access
-         tool-registry ; (or/c any/c #f) — dynamic tool registration
-         command-registry ; (or/c any/c #f) — slash command registration
-         ui-channel ; (or/c channel? #f) — user interaction requests
-         provider-registry ; (or/c provider-registry? #f) — LLM provider access (#1114)
-         ;; #1223: session state fields for query API
-         session-messages ; (or/c (listof hash?) #f) — read-only message history
-         session-token-usage ; (or/c hash? #f) — token usage stats
-         gsd-ctx ; (or/c gsd-session-ctx? #f) — per-session GSD state (C-01 v0.35.1)
-         )
-  #:transparent)
+;; M-06: Struct definition moved to util/extension-types.rkt (no runtime imports).
+;; Re-exported here for backward compatibility.
+;; Struct fields: session-id, session-dir, event-bus, extension-registry,
+;;   model-name, cancellation-token, working-directory, session-store,
+;;   tool-registry, command-registry, ui-channel, provider-registry,
+;;   session-messages, session-token-usage, gsd-ctx
 
 ;; ============================================================
 ;; Constructor — keyword args with optional fields defaulting to #f

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.36.5")
+(define version "0.36.6")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base"))

--- a/runtime/context-assembly/serialization.rkt
+++ b/runtime/context-assembly/serialization.rkt
@@ -86,6 +86,8 @@
     (partition (lambda (m) (eq? (message-kind m) 'compaction-summary)) messages))
   ;; v0.28.21 W7 + v0.28.22 W2: GSD progress pinning
   ;; v0.28.23 W0: tightened to tool/assistant roles only, removed broad wave-done regex
+  ;; L-02: Prefer message-meta 'gsd-pin flag over fragile regex matching.
+  ;; The regex fallback supports legacy messages created before gsd-pin was added.
   (define (gsd-progress-message? m)
     (or (hash-ref (message-meta m) 'gsd-pin #f)
         (and (memq (message-role m) '(tool assistant))
@@ -93,9 +95,9 @@
                                                 #:when (text-part? part))
                                        (text-part-text part)))])
                (and (non-empty-string? txt)
-                    (or (regexp-match? #rx"wave [0-9]+ marked complete" txt)
-                        (regexp-match? #rx"PLAN.md.*updated" txt)
-                        (regexp-match? #rx"STATE.md.*updated" txt)))))))
+                    (regexp-match?
+                     #rx"wave [0-9]+ marked complete|PLAN\\.md.*updated|STATE\\.md.*updated"
+                     txt))))))
   (define-values (gsd-pinned regular) (partition gsd-progress-message? regular-msgs))
   (define-values (sys-protected unpinned-raw)
     (partition (lambda (m) (eq? (message-kind m) 'system-instruction)) regular))

--- a/runtime/iteration.rkt
+++ b/runtime/iteration.rkt
@@ -3,6 +3,14 @@
 ;; runtime/iteration.rkt -- agent iteration loop FACADE
 ;; STABILITY: stable
 ;;
+;; M-07 DEPRECATION NOTICE: This module is a re-export facade. New code should
+;; import directly from sub-modules:
+;;   runtime/iteration/counters.rkt
+;;   runtime/iteration/decision.rkt
+;;   runtime/iteration/step-interpreter.rkt
+;;   runtime/iteration/main-loop.rkt
+;; This facade will be removed in v0.38.0.
+;;
 ;; Thin re-export facade over runtime/iteration/*. Sub-modules:
 ;;   counters.rkt          -- compute-next-counters, check-cancellation
 ;;   decision.rkt          -- iteration-ctx, step-result, decide-next-action,

--- a/util/extension-types.rkt
+++ b/util/extension-types.rkt
@@ -1,0 +1,32 @@
+#lang racket/base
+
+;; util/extension-types.rkt — Pure type definitions for extension context (M-06)
+;;
+;; Contains only the struct definition with NO runtime/ or llm/ imports.
+;; Runtime-dependent convenience methods stay in extensions/context.rkt.
+
+(provide (struct-out extension-ctx))
+
+;; Extension context struct — bundles all session/runtime state that
+;; extension handlers may need. All fields are read-only after construction.
+;; Transparent struct for testability and debugging.
+(struct extension-ctx
+        (session-id ; string?
+         session-dir ; (or/c path-string? #f)
+         event-bus ; event-bus?
+         extension-registry ; extension-registry?
+         model-name ; (or/c string? #f)
+         cancellation-token ; (or/c cancellation-token? #f)
+         working-directory ; (or/c path-string? #f)
+         ;; FEAT-58: rich extension context fields
+         session-store ; (or/c any/c #f) — read-only session access
+         tool-registry ; (or/c any/c #f) — dynamic tool registration
+         command-registry ; (or/c any/c #f) — slash command registration
+         ui-channel ; (or/c channel? #f) — user interaction requests
+         provider-registry ; (or/c any/c #f) — LLM provider access (#1114)
+         ;; #1223: session state fields for query API
+         session-messages ; (or/c (listof hash?) #f) — read-only message history
+         session-token-usage ; (or/c hash? #f) — token usage stats
+         gsd-ctx ; (or/c any/c #f) — per-session GSD state (C-01 v0.35.1)
+         )
+  #:transparent)

--- a/util/jsonl.rkt
+++ b/util/jsonl.rkt
@@ -10,6 +10,7 @@
 ;;;   jsonl-line-valid?     — check if a line is complete valid JSON
 
 (provide jsonl-append!
+         jsonl-write-to-port!
          jsonl-append-entries!
          jsonl-read-all
          jsonl-read-all-valid
@@ -36,14 +37,18 @@
 
 ;; ── Append ──
 
+;; M-14: Port-based variant — write a single entry to an output port.
+;; Caller manages port lifecycle. Useful for batch writes.
+(define (jsonl-write-to-port! out entry)
+  (write-json entry out)
+  (newline out))
+
 (define (jsonl-append! path entry)
   ;; Append a single jsexpr as one JSON line to file.
   ;; Creates the file (and parent dirs) if missing.
   (ensure-parent-dirs! path)
   (call-with-output-file path
-                         (lambda (out)
-                           (write-json entry out)
-                           (newline out))
+                         (lambda (out) (jsonl-write-to-port! out entry))
                          #:mode 'text
                          #:exists 'append))
 

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -10,4 +10,4 @@
 (provide q-version)
 
 (: q-version String)
-(define q-version "0.36.5")
+(define q-version "0.36.6")

--- a/wiki-src/Architecture-Overview.md
+++ b/wiki-src/Architecture-Overview.md
@@ -35,7 +35,7 @@ User input → Interface (CLI/TUI/RPC)
     → Events emitted to bus
 ```
 
-## Metrics (0.36.5)
+## Metrics (0.36.6)
 > _See `racket scripts/metrics.rkt` for current numbers._
 
 - 414 source modules, 534 test files


### PR DESCRIPTION
v0.36.6 — Module Boundary Hardening.

M-06: Move extension-ctx to util/extension-types.rkt.
M-07: Deprecate iteration.rkt facade.
M-14: Add jsonl-write-to-port!.
L-02: Consolidate gsd-progress-message? regex.

Lint 18/18.

Closes #4049