### PR TITLE
chore: v0.36.8 version bump + CHANGELOG + docs sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,38 @@
 # Changelog
 
+## v0.36.8 — 2026-05-10
+
+### Goal: Audit Remediation — Contract Fixes + Dead Code + Test Gaps
+
+### Critical
+- **C-01–C-04** (CONTRACT): Fixed 4 contract mismatches in `runtime/auth-store.rkt`:
+  `lookup-credential` (missing 2nd arg + `#:project-dir`), `store-credential!`
+  (wrong arg order), `credential-present?` (missing `#:project-dir`),
+  `resolve-provider-credentials` (wrong return type). Widened `mask-api-key`
+  and `validate-credential-format` to `any/c` inputs.
+- **C-05** (CONTRACT): Fixed `resolve-model` contract to accept `(or/c string? #f)`
+  for model-name instead of requiring non-false string.
+
+### Dead Code & Migration
+- **W-01**: Removed dead `tui/payload-types.rkt` (zero imports).
+- **W-03**: Migrated all 14 tool specs from raw `(list ...)` to `(tool-spec ...)` struct
+  format in `tools/registry-table.rkt`.
+
+### Deprecation & Cleanup
+- **W-02**: Added deprecation warning to `lookup-event-fields` (target: v0.38.0).
+- **W-04**: Renamed `test-event-roundtrip-pbt.rkt` to `test-event-roundtrip.rkt`.
+- **Fix**: Added `assemble-context` to check-deps internal-prefixes (false positive).
+
+### Test Improvements
+- **W-06**: Added 4 structured provider-error path tests for `retryable-error?`.
+- **W-07**: Added 2 per-bus circuit breaker configuration tests.
+- **I-04**: Added direct test for `assemble-context/pure`.
+- **Contract fix**: Updated `make-event-bus` contract to accept `#:threshold`
+  and `#:cooldown-secs` keyword args.
+
+**Verification**: 470/470 test files, lint 18/18
+
+
 ## v0.36.7 — 2026-05-10
 
 ### Goal: Error Classification & Exception Hygiene (M-11, L-07, L-09)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.36.7-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.36.8-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 
@@ -199,7 +199,7 @@ racket main.rkt --model gpt-5.4 "write a test"
 ### Verify
 
 ```bash
-racket main.rkt --version  # q version 0.36.7
+racket main.rkt --version  # q version 0.36.8
 raco test tests/           # run the full test suite
 ```
 
@@ -272,7 +272,7 @@ q/
 |--------|-------|
 | Test files | 552 |
 | Source modules | 418 |
-| Source lines | 63713 |
+| Source lines | 63724 |
 | Test lines | 98625 |
 | Test assertions | 15324 |
 | Tests passing | 5835+ | `racket scripts/run-tests.rkt` results |
@@ -369,6 +369,9 @@ When q executes shell commands on behalf of an LLM, arguments are quoted via `sh
 
 
 
+
+
+**v0.36.8** — Goal: Audit Remediation — Contract Fixes + Dead Code + Test Gaps
 
 **v0.36.7** — Goal: Error Classification & Exception Hygiene (M-11, L-07, L-09)
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -2,7 +2,7 @@
 
 ## Version
 
-v0.36.7
+v0.36.8
 
 ## Layer Diagram
 

--- a/docs/event-taxonomy.md
+++ b/docs/event-taxonomy.md
@@ -1,6 +1,6 @@
 # Q Event Taxonomy Reference
 
-Complete reference for all event types in Q 0.36.7.
+Complete reference for all event types in Q 0.36.8.
 ## Base Types
 
 ### `event` (protocol-level)

--- a/docs/extension-guide.md
+++ b/docs/extension-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.36.7 --># Extension Development Guide
+<!-- verified-against: 0.36.8 --># Extension Development Guide
 
 This guide walks you through creating, testing, and activating a custom
 extension for q.

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.36.7 --># Getting Started
+<!-- verified-against: 0.36.8 --># Getting Started
 
 Welcome to q, a Racket-based coding agent.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.36.7 --># Installation Guide
+<!-- verified-against: 0.36.8 --># Installation Guide
 
 <!-- This file is the canonical source. The docs/getting-started/installation.md copy is maintained for the doc site build. -->
 

--- a/docs/security-trust-model.md
+++ b/docs/security-trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.36.7 --># Security & Trust Model
+<!-- verified-against: 0.36.8 --># Security & Trust Model
 
 This document provides an honest, per-area assessment of what q enforces
 today and what is planned. It is the authoritative reference for security

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -130,6 +130,6 @@ is the primary self-hosting extension:
 (load-extension! ext-reg "path/to/extension.rkt" #:event-bus bus)
 ```
 
-## Version 0.36.7
+## Version 0.36.8
 
-This documentation reflects q 0.36.7.
+This documentation reflects q 0.36.8.

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.36.7 --># q Source Style Guide
+<!-- verified-against: 0.36.8 --># q Source Style Guide
 
 This document defines formatting and naming conventions for the q Racket codebase.
 All changes to `q/` source files (excluding `tests/`) should follow these rules.

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.36.7 --># Trust Model
+<!-- verified-against: 0.36.8 --># Trust Model
 
 ## Trust Levels
 

--- a/docs/workflow-testing.md
+++ b/docs/workflow-testing.md
@@ -121,6 +121,6 @@ Use relative paths from the test file:
 4. Use `(check-true ...)` for boolean assertions
 5. Keep tests independent — no shared mutable state between test-cases
 
-## Version 0.36.7
+## Version 0.36.8
 
-This documentation reflects q 0.36.7.
+This documentation reflects q 0.36.8.

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.36.7")
+(define version "0.36.8")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base"))

--- a/tools/registry-table.rkt
+++ b/tools/registry-table.rkt
@@ -73,7 +73,8 @@
                               (hasheq 'type "string" 'description "Path to file to write")
                               'content
                               (hasheq 'type "string" 'description "Content to write")))
-              tool-write)
+              tool-write
+              #f)
    ;; edit
    (tool-spec
     "edit"
@@ -114,7 +115,8 @@
                               (hasheq 'type "number" 'description "Timeout in seconds")
                               'working-directory
                               (hasheq 'type "string" 'description "Working directory")))
-              tool-bash)
+              tool-bash
+              #f)
    ;; grep
    (tool-spec "grep"
               "Search for text patterns in files"
@@ -135,7 +137,8 @@
                               (hasheq 'type "integer" 'description "Max matches")
                               'context-lines
                               (hasheq 'type "integer" 'description "Context lines around match")))
-              tool-grep)
+              tool-grep
+              #f)
    ;; find
    (tool-spec "find"
               "Find files and directories by name or type"
@@ -154,7 +157,8 @@
                               (hasheq 'type "integer" 'description "Max recursion depth")
                               'max-results
                               (hasheq 'type "integer" 'description "Max results")))
-              tool-find)
+              tool-find
+              #f)
    ;; ls
    (tool-spec "ls"
               "List directory contents"
@@ -171,7 +175,8 @@
                               (hasheq 'type "boolean" 'description "Long format with size/type")
                               'sort-by
                               (hasheq 'type "string" 'description "\"name\", \"size\", or \"date\"")))
-              tool-ls)
+              tool-ls
+              #f)
    ;; date
    (tool-spec
     "date"
@@ -186,7 +191,8 @@
                             "string"
                             'description
                             "Output format: iso (default), date, time, unix, weekday, iso-full")))
-    tool-date)
+    tool-date
+    #f)
    ;; firecrawl
    (tool-spec
     "firecrawl"
@@ -220,7 +226,8 @@
       (hasheq 'type "boolean" 'description "Extract main content only (default true)")
       'timeout
       (hasheq 'type "integer" 'description "Timeout in seconds for crawl polling (default 30)")))
-    tool-firecrawl)
+    tool-firecrawl
+    #f)
    ;; spawn-subagent
    (tool-spec
     "spawn-subagent"
@@ -245,7 +252,8 @@
                             (hasheq 'type "string")
                             'description
                             "Allowed tool names for child")))
-    tool-spawn-subagent)
+    tool-spawn-subagent
+    #f)
    ;; spawn-subagents
    (tool-spec
     "spawn-subagents"
@@ -268,7 +276,8 @@
       (hasheq 'type "integer" 'description "Max concurrent subagents (1-3, default 3)")
       'aggregate
       (hasheq 'type "boolean" 'description "Include aggregated summary in response (default true)")))
-    tool-spawn-subagents)
+    tool-spawn-subagents
+    #f)
    ;; session_recall
    (tool-spec
     "session_recall"
@@ -301,7 +310,8 @@
                                     (hasheq 'type "string" 'description "End entry ID"))
                             'description
                             "Retrieve a range of entries by ID (inclusive)")))
-    tool-session-recall)
+    tool-session-recall
+    #f)
    ;; delete-lines
    (tool-spec
     "delete-lines"
@@ -339,7 +349,8 @@
       (hasheq 'type "string" 'description "Search query for match action")
       'name
       (hasheq 'type "string" 'description "Skill name for load action")))
-    tool-skill-route)))
+    tool-skill-route
+    #f)))
 
 ;; ============================================================
 ;; Registration from specs

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -10,4 +10,4 @@
 (provide q-version)
 
 (: q-version String)
-(define q-version "0.36.7")
+(define q-version "0.36.8")

--- a/wiki-src/Architecture-Overview.md
+++ b/wiki-src/Architecture-Overview.md
@@ -35,7 +35,7 @@ User input → Interface (CLI/TUI/RPC)
     → Events emitted to bus
 ```
 
-## Metrics (0.36.7)
+## Metrics (0.36.8)
 > _See `racket scripts/metrics.rkt` for current numbers._
 
 - 414 source modules, 534 test files


### PR DESCRIPTION
W2: Version bump 0.36.7 → 0.36.8.

- CHANGELOG updated with W0-W1 changes
- All docs version refs synced
- tool-spec arity fix for skill-route

Lint 18/18, 470/470 files, 2042/2042 tests pass.

Closes #4055