### PR TITLE
chore: v0.36.9 version bump + CHANGELOG + docs sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## v0.36.9 — 2026-05-10
+
+### Goal: Audit Remediation — Test Gaps + Dead Code + Contract Tightening
+
+### Fixed
+- **N-01** (TEST): Added `#:cooldown-secs` circuit breaker tests (W-07c, W-07d)
+- **N-02** (COMMENT): Fixed stale filename in `test-event-roundtrip.rkt` header
+- **N-03** (DEAD CODE): Removed legacy `list?` branch from `register-tools-from-specs!` — all specs now use `tool-spec` structs
+- **N-04** (IMPORT): Narrowed `cli/init-wizard.rkt` import to `(only-in ...)`
+- **N-06** (CONTRACT): Tightened `resolve-provider-credentials` to `hash/c` for static validation
+- **N-07** (THREAD): Made deprecation flag atomic (`box`/`set-box!`) instead of plain `set!`
+- **N-08** (TEST): Added `'network` category test for `retryable-error?`
+- **W-05** (DOCS): Documented single-threaded invariant in `wave-executor.rkt`
+
+### Changed
+- `tests/test-auto-retry.rkt` +4, `tests/test-event-bus.rkt` +17
+- `tools/registry-table.rkt` -11 lines (dead branch removed)
+- `util/event-macro.rkt`: `set!` → `set-box!`
+- `runtime/auth-store.rkt`: contract tightened
+- `cli/init-wizard.rkt`: `(only-in ...)`
+- `extensions/gsd/wave-executor.rkt`: TOCTOU docs
+
+---
+
 ## v0.36.8 — 2026-05-10
 
 ### Goal: Audit Remediation — Contract Fixes + Dead Code + Test Gaps

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.36.8-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.36.9-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 
@@ -199,7 +199,7 @@ racket main.rkt --model gpt-5.4 "write a test"
 ### Verify
 
 ```bash
-racket main.rkt --version  # q version 0.36.8
+racket main.rkt --version  # q version 0.36.9
 raco test tests/           # run the full test suite
 ```
 
@@ -370,6 +370,9 @@ When q executes shell commands on behalf of an LLM, arguments are quoted via `sh
 
 
 
+
+
+**v0.36.9** — Goal: Audit Remediation — Test Gaps + Dead Code + Contract Tightening
 
 **v0.36.8** — Goal: Audit Remediation — Contract Fixes + Dead Code + Test Gaps
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -2,7 +2,7 @@
 
 ## Version
 
-v0.36.8
+v0.36.9
 
 ## Layer Diagram
 

--- a/docs/event-taxonomy.md
+++ b/docs/event-taxonomy.md
@@ -1,6 +1,6 @@
 # Q Event Taxonomy Reference
 
-Complete reference for all event types in Q 0.36.8.
+Complete reference for all event types in Q 0.36.9.
 ## Base Types
 
 ### `event` (protocol-level)

--- a/docs/extension-guide.md
+++ b/docs/extension-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.36.8 --># Extension Development Guide
+<!-- verified-against: 0.36.9 --># Extension Development Guide
 
 This guide walks you through creating, testing, and activating a custom
 extension for q.

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.36.8 --># Getting Started
+<!-- verified-against: 0.36.9 --># Getting Started
 
 Welcome to q, a Racket-based coding agent.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.36.8 --># Installation Guide
+<!-- verified-against: 0.36.9 --># Installation Guide
 
 <!-- This file is the canonical source. The docs/getting-started/installation.md copy is maintained for the doc site build. -->
 

--- a/docs/security-trust-model.md
+++ b/docs/security-trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.36.8 --># Security & Trust Model
+<!-- verified-against: 0.36.9 --># Security & Trust Model
 
 This document provides an honest, per-area assessment of what q enforces
 today and what is planned. It is the authoritative reference for security

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -130,6 +130,6 @@ is the primary self-hosting extension:
 (load-extension! ext-reg "path/to/extension.rkt" #:event-bus bus)
 ```
 
-## Version 0.36.8
+## Version 0.36.9
 
-This documentation reflects q 0.36.8.
+This documentation reflects q 0.36.9.

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.36.8 --># q Source Style Guide
+<!-- verified-against: 0.36.9 --># q Source Style Guide
 
 This document defines formatting and naming conventions for the q Racket codebase.
 All changes to `q/` source files (excluding `tests/`) should follow these rules.

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.36.8 --># Trust Model
+<!-- verified-against: 0.36.9 --># Trust Model
 
 ## Trust Levels
 

--- a/docs/workflow-testing.md
+++ b/docs/workflow-testing.md
@@ -121,6 +121,6 @@ Use relative paths from the test file:
 4. Use `(check-true ...)` for boolean assertions
 5. Keep tests independent — no shared mutable state between test-cases
 
-## Version 0.36.8
+## Version 0.36.9
 
-This documentation reflects q 0.36.8.
+This documentation reflects q 0.36.9.

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.36.8")
+(define version "0.36.9")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base"))

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -10,4 +10,4 @@
 (provide q-version)
 
 (: q-version String)
-(define q-version "0.36.8")
+(define q-version "0.36.9")

--- a/wiki-src/Architecture-Overview.md
+++ b/wiki-src/Architecture-Overview.md
@@ -35,7 +35,7 @@ User input → Interface (CLI/TUI/RPC)
     → Events emitted to bus
 ```
 
-## Metrics (0.36.8)
+## Metrics (0.36.9)
 > _See `racket scripts/metrics.rkt` for current numbers._
 
 - 414 source modules, 534 test files


### PR DESCRIPTION
W1: Version bump 0.36.8 → 0.36.9 + CHANGELOG + docs version sync.

Lint 18/18.

Closes #4060