### PR TITLE
feat: iteration loop hygiene — snapshot struct + DRY counters (FA-04, FA-02)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## v0.37.4 — 2026-05-11
+
+### Goal: Iteration Loop Hygiene (Milestone 5 of v0.37.x)
+
+### Fixed
+- **FA-04** (M): Added `iteration-snapshot` struct to `loop-state.rkt` (TR-compatible with
+  opaque types for session-config and agent-session). Replaced 6 positional parameters
+  threaded through `interpret-step` with a single snapshot, reducing parameter count
+  from 11 to 5.
+- **FA-02** (M): Extracted shared counter-increment logic into `make-next-counters` helper,
+  eliminating duplication between 'stop-soft-limit and 'continue branches.
+
+### Changed
+- `runtime/iteration/loop-state.rkt`: +`iteration-snapshot` struct (counters, ws, config,
+  sess, max-iterations, max-iterations-hard)
+- `runtime/iteration/main-loop.rkt`: construct snapshot before calling `interpret-step`
+- `runtime/iteration/step-interpreter.rkt`: accept snapshot, use `make-next-counters`
+- `tests/test-iteration-integration.rkt`: updated 4 `interpret-step` calls to use snapshot
+
+**Verification**: lint 18/18, test-iteration-pure 11/11, test-iteration-step-interpreter 3/3,
+test-iteration-integration 16/16, test-iteration-main-loop 3/3
+
+---
+
 ## v0.37.3 — 2026-05-11
 
 ### Goal: Context Assembly Purity (Milestone 4 of v0.37.x)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.37.3-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.37.4-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 
@@ -199,7 +199,7 @@ racket main.rkt --model gpt-5.4 "write a test"
 ### Verify
 
 ```bash
-racket main.rkt --version  # q version 0.37.3
+racket main.rkt --version  # q version 0.37.4
 raco test tests/           # run the full test suite
 ```
 
@@ -272,8 +272,8 @@ q/
 |--------|-------|
 | Test files | 552 |
 | Source modules | 418 |
-| Source lines | 63904 |
-| Test lines | 98720 |
+| Source lines | 63928 |
+| Test lines | 98721 |
 | Test assertions | 15348 |
 | Tests passing | 5835+ | `racket scripts/run-tests.rkt` results |
 
@@ -374,9 +374,9 @@ When q executes shell commands on behalf of an LLM, arguments are quoted via `sh
 
 
 
-**v0.37.3** — Goal: Iteration Step-Result Correctness (Milestone 3 of v0.37.x)
+**v0.37.4** — Goal: Context Assembly Purity (Milestone 4 of v0.37.x)
 
-**v0.37.3** — Goal: Audit Remediation — Comment Cleanup + Import + Test Optimization
+**v0.37.4** — Goal: Audit Remediation — Comment Cleanup + Import + Test Optimization
 
 **v0.36.9** — Goal: Audit Remediation — Test Gaps + Dead Code + Contract Tightening
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -2,7 +2,7 @@
 
 ## Version
 
-v0.37.3
+v0.37.4
 
 ## Layer Diagram
 

--- a/docs/event-taxonomy.md
+++ b/docs/event-taxonomy.md
@@ -1,6 +1,6 @@
 # Q Event Taxonomy Reference
 
-Complete reference for all event types in Q 0.37.3.
+Complete reference for all event types in Q 0.37.4.
 ## Base Types
 
 ### `event` (protocol-level)

--- a/docs/extension-guide.md
+++ b/docs/extension-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.37.3 --># Extension Development Guide
+<!-- verified-against: 0.37.4 --># Extension Development Guide
 
 This guide walks you through creating, testing, and activating a custom
 extension for q.

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.37.3 --># Getting Started
+<!-- verified-against: 0.37.4 --># Getting Started
 
 Welcome to q, a Racket-based coding agent.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.37.3 --># Installation Guide
+<!-- verified-against: 0.37.4 --># Installation Guide
 
 <!-- This file is the canonical source. The docs/getting-started/installation.md copy is maintained for the doc site build. -->
 

--- a/docs/security-trust-model.md
+++ b/docs/security-trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.37.3 --># Security & Trust Model
+<!-- verified-against: 0.37.4 --># Security & Trust Model
 
 This document provides an honest, per-area assessment of what q enforces
 today and what is planned. It is the authoritative reference for security

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -130,6 +130,6 @@ is the primary self-hosting extension:
 (load-extension! ext-reg "path/to/extension.rkt" #:event-bus bus)
 ```
 
-## Version 0.37.3
+## Version 0.37.4
 
-This documentation reflects q 0.37.3.
+This documentation reflects q 0.37.4.

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.37.3 --># q Source Style Guide
+<!-- verified-against: 0.37.4 --># q Source Style Guide
 
 This document defines formatting and naming conventions for the q Racket codebase.
 All changes to `q/` source files (excluding `tests/`) should follow these rules.

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.37.3 --># Trust Model
+<!-- verified-against: 0.37.4 --># Trust Model
 
 ## Trust Levels
 

--- a/docs/workflow-testing.md
+++ b/docs/workflow-testing.md
@@ -121,6 +121,6 @@ Use relative paths from the test file:
 4. Use `(check-true ...)` for boolean assertions
 5. Keep tests independent — no shared mutable state between test-cases
 
-## Version 0.37.3
+## Version 0.37.4
 
-This documentation reflects q 0.37.3.
+This documentation reflects q 0.37.4.

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.37.3")
+(define version "0.37.4")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base"))

--- a/runtime/iteration/loop-state.rkt
+++ b/runtime/iteration/loop-state.rkt
@@ -15,6 +15,7 @@
 
 (provide (struct-out loop-infra)
          (struct-out loop-counters)
+         (struct-out iteration-snapshot)
          make-initial-counters)
 
 ;; ── Opaque types for untyped struct values ────────────────────
@@ -27,6 +28,10 @@
 (require/typed "../../extensions/api.rkt" [#:opaque ExtRegistry extension-registry?])
 
 (require/typed "../../util/cancellation.rkt" [#:opaque CancellationToken cancellation-token?])
+
+(require/typed "../../runtime/session-config.rkt" [#:opaque SessionConfig session-config?])
+
+(require/typed "../../runtime/session-types.rkt" [#:opaque AgentSession agent-session?])
 
 ;; ── Typed imports from untyped modules ──────────────────────────
 
@@ -65,3 +70,14 @@
   :
   loop-counters
   (loop-counters 0 0 '() 0 0 '() 0 0 0))
+
+;; v0.37.4 (FA-04): Bundle loop-evolving parameters into a single struct
+;; to avoid threading 6+ positional parameters through interpret-step.
+(struct iteration-snapshot
+  ([counters : loop-counters]
+   [ws : Any]
+   [config : SessionConfig]
+   [sess : (U AgentSession #f)]
+   [max-iterations : Nonnegative-Integer]
+   [max-iterations-hard : Nonnegative-Integer])
+  #:transparent)

--- a/runtime/iteration/main-loop.rkt
+++ b/runtime/iteration/main-loop.rkt
@@ -13,6 +13,7 @@
          racket/contract
          (only-in "loop-state.rkt"
                   loop-infra
+                  iteration-snapshot
                   make-initial-counters
                   loop-counters-iteration
                   loop-counters-consecutive-tool-count
@@ -211,17 +212,14 @@
                                                       max-iterations-hard)
                                        result
                                        counters))
+                (define snapshot
+                  (iteration-snapshot counters ws config sess max-iterations max-iterations-hard))
                 (define directive
                   (interpret-step step-res
                                   result
                                   new-msgs
                                   (struct-copy loop-infra infra [ctx ctx-with-injected])
-                                  counters
-                                  ws
-                                  config
-                                  sess
-                                  max-iterations
-                                  max-iterations-hard))
+                                  snapshot))
                 (match directive
                   [(directive-stop final-result) final-result]
                   [(directive-recurse new-ctx new-counters ws2)

--- a/runtime/iteration/step-interpreter.rkt
+++ b/runtime/iteration/step-interpreter.rkt
@@ -14,6 +14,13 @@
          racket/dict
          (only-in "loop-state.rkt"
                   loop-infra
+                  iteration-snapshot
+                  iteration-snapshot-counters
+                  iteration-snapshot-ws
+                  iteration-snapshot-config
+                  iteration-snapshot-sess
+                  iteration-snapshot-max-iterations
+                  iteration-snapshot-max-iterations-hard
                   loop-infra-ctx
                   loop-infra-ext-reg
                   loop-infra-reg
@@ -147,20 +154,30 @@
         result)))
 
 ;; ============================================================
+;; Shared helpers
+;; ============================================================
+
+;; FA-02: Shared counter increment logic for recurse branches
+(define (make-next-counters base)
+  (struct-copy loop-counters
+               base
+               [iteration (add1 (loop-counters-iteration base))]
+               [consecutive-tool-count (add1 (loop-counters-consecutive-tool-count base))]
+               [stall-retry-count 0]))
+
+;; ============================================================
 ;; interpret-step
 ;; ============================================================
 
-(define (interpret-step step-res
-                        result
-                        new-msgs
-                        infra
-                        counters
-                        ws
-                        config
-                        sess
-                        max-iterations
-                        max-iterations-hard)
-  ;; v0.35.3 (W-02): Returns step-directive? instead of calling on-recurse callback
+;; v0.37.4 (FA-04): Bundle evolving parameters into iteration-snapshot
+;; to avoid threading 6+ positional parameters.
+(define (interpret-step step-res result new-msgs infra snapshot)
+  (define counters (iteration-snapshot-counters snapshot))
+  (define ws (iteration-snapshot-ws snapshot))
+  (define config (iteration-snapshot-config snapshot))
+  (define sess (iteration-snapshot-sess snapshot))
+  (define max-iterations (iteration-snapshot-max-iterations snapshot))
+  (define max-iterations-hard (iteration-snapshot-max-iterations-hard snapshot))
   (define action (step-result-action step-res))
   (match action
     ['stop
@@ -215,14 +232,7 @@
                                        budget-config
                                        #:emit-event emit-fn)
              updated-ctx)))
-     (directive-recurse ctx-after-budget
-                        (struct-copy loop-counters
-                                     counters
-                                     [iteration (add1 (loop-counters-iteration counters))]
-                                     [consecutive-tool-count
-                                      (add1 (loop-counters-consecutive-tool-count counters))]
-                                     [stall-retry-count 0])
-                        ws)]
+     (directive-recurse ctx-after-budget (make-next-counters counters) ws)]
     ['continue
      (append-entries! (loop-infra-log-path infra) new-msgs)
      (define updated-ctx (execute-pending-tool-calls new-msgs infra config ws))

--- a/tests/test-iteration-integration.rkt
+++ b/tests/test-iteration-integration.rkt
@@ -11,6 +11,7 @@
          (only-in "../runtime/iteration/loop-state.rkt"
                   make-initial-counters
                   loop-infra
+                  iteration-snapshot
                   loop-counters
                   loop-counters-iteration
                   loop-counters-consecutive-tool-count
@@ -192,7 +193,7 @@
   (define max-hard 10)
   (define step-res
     (step-result 'stop-hard-limit 'max-iterations-exceeded (make-initial-counters) (hasheq)))
-  (define out (interpret-step step-res result '() infra counters ws (hash->session-config (hash)) #f max-iter max-hard))
+  (define out (interpret-step step-res result '() infra (iteration-snapshot counters ws (hash->session-config (hash)) #f max-iter max-hard)))
   (check-true (directive-stop? out))
   (define stop-result (directive-stop-result out))
   (check-equal? (loop-result-termination-reason stop-result) 'max-iterations-exceeded)
@@ -209,7 +210,7 @@
   (define result-no-msgs (make-loop-result '() 'tool-calls-pending (hasheq)))
   (define step-res
     (step-result 'continue 'tool-calls-pending (compute-next-counters counters '()) (hasheq)))
-  (define out (interpret-step step-res result-no-msgs '() infra counters ws (hash->session-config (hash)) #f 5 10))
+  (define out (interpret-step step-res result-no-msgs '() infra (iteration-snapshot counters ws (hash->session-config (hash)) #f 5 10)))
   (check-true (directive-recurse? out) "continue returns directive-recurse")
   (define new-counters (directive-recurse-new-counters out))
   (check-equal? (loop-counters-iteration new-counters) 1 "iteration incremented on continue")
@@ -223,7 +224,7 @@
   (define ws (make-working-set))
   (define result (make-loop-result '() 'completed (hasheq)))
   (define step-res (step-result 'stop 'completed (make-initial-counters) (hasheq)))
-  (define out (interpret-step step-res result '() infra counters ws (hash->session-config (hash)) #f 5 10))
+  (define out (interpret-step step-res result '() infra (iteration-snapshot counters ws (hash->session-config (hash)) #f 5 10)))
   (check-true (directive-stop? out))
   (delete-file log-path))
 
@@ -237,7 +238,7 @@
   (define events-box (collect-events bus "iteration.soft-warning"))
   (define step-res
     (step-result 'stop-soft-limit 'tool-calls-pending (make-initial-counters) (hasheq)))
-  (define out (interpret-step step-res result '() infra counters ws (hash->session-config (hash)) #f 5 10))
+  (define out (interpret-step step-res result '() infra (iteration-snapshot counters ws (hash->session-config (hash)) #f 5 10)))
   (check-true (directive-recurse? out) "soft-limit returns directive-recurse")
   (check-true (pair? (unbox events-box)) "iteration.soft-warning event was emitted")
   (define new-counters (directive-recurse-new-counters out))

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -10,4 +10,4 @@
 (provide q-version)
 
 (: q-version String)
-(define q-version "0.37.3")
+(define q-version "0.37.4")

--- a/wiki-src/Architecture-Overview.md
+++ b/wiki-src/Architecture-Overview.md
@@ -35,7 +35,7 @@ User input → Interface (CLI/TUI/RPC)
     → Events emitted to bus
 ```
 
-## Metrics (0.37.3)
+## Metrics (0.37.4)
 > _See `racket scripts/metrics.rkt` for current numbers._
 
 - 414 source modules, 534 test files


### PR DESCRIPTION
v0.37.4 milestone.

- FA-04: iteration-snapshot struct reduces interpret-step from 11 to 5 positional params
- FA-02: make-next-counters helper DRYs soft-limit and continue branches

Lint 18/18.

Closes #4077