### PR TITLE
feat: turn orchestrator decomposition — pure assembly + effectful dispatch (FD-05)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## v0.37.5 — 2026-05-11
+
+### Goal: Turn Orchestrator Decomposition (Milestone 6 of v0.37.x)
+
+### Fixed
+- **FD-05** (M): Separated pure assembly from effectful dispatch in
+  `build-assembled-context`. `assemble-context/pure` now accepts optional
+  `#:hook-dispatcher` and returns `(values list? any/c)`. `build-assembled-context`
+  delegates pure assembly to it, then handles block results, emits events, and
+  dispatches the 'context hook. Eliminates ~25 lines of duplicated config
+  extraction and tiered-context building.
+
+### Changed
+- `runtime/turn-orchestrator.rkt`: `assemble-context/pure` signature extended;
+  `build-assembled-context` refactored to delegate
+- `tests/test-context-assembly.rkt`: updated for values return
+
+**Verification**: lint 18/18, test-context-assembly 34/34
+
+---
+
 ## v0.37.4 — 2026-05-11
 
 ### Goal: Iteration Loop Hygiene (Milestone 5 of v0.37.x)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.37.4-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.37.5-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 
@@ -199,7 +199,7 @@ racket main.rkt --model gpt-5.4 "write a test"
 ### Verify
 
 ```bash
-racket main.rkt --version  # q version 0.37.4
+racket main.rkt --version  # q version 0.37.5
 raco test tests/           # run the full test suite
 ```
 
@@ -272,7 +272,7 @@ q/
 |--------|-------|
 | Test files | 552 |
 | Source modules | 418 |
-| Source lines | 63928 |
+| Source lines | 63913 |
 | Test lines | 98721 |
 | Test assertions | 15348 |
 | Tests passing | 5835+ | `racket scripts/run-tests.rkt` results |
@@ -374,9 +374,9 @@ When q executes shell commands on behalf of an LLM, arguments are quoted via `sh
 
 
 
-**v0.37.4** — Goal: Context Assembly Purity (Milestone 4 of v0.37.x)
+**v0.37.5** — Goal: Iteration Loop Hygiene (Milestone 5 of v0.37.x)
 
-**v0.37.4** — Goal: Audit Remediation — Comment Cleanup + Import + Test Optimization
+**v0.37.5** — Goal: Audit Remediation — Comment Cleanup + Import + Test Optimization
 
 **v0.36.9** — Goal: Audit Remediation — Test Gaps + Dead Code + Contract Tightening
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -2,7 +2,7 @@
 
 ## Version
 
-v0.37.4
+v0.37.5
 
 ## Layer Diagram
 

--- a/docs/event-taxonomy.md
+++ b/docs/event-taxonomy.md
@@ -1,6 +1,6 @@
 # Q Event Taxonomy Reference
 
-Complete reference for all event types in Q 0.37.4.
+Complete reference for all event types in Q 0.37.5.
 ## Base Types
 
 ### `event` (protocol-level)

--- a/docs/extension-guide.md
+++ b/docs/extension-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.37.4 --># Extension Development Guide
+<!-- verified-against: 0.37.5 --># Extension Development Guide
 
 This guide walks you through creating, testing, and activating a custom
 extension for q.

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.37.4 --># Getting Started
+<!-- verified-against: 0.37.5 --># Getting Started
 
 Welcome to q, a Racket-based coding agent.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.37.4 --># Installation Guide
+<!-- verified-against: 0.37.5 --># Installation Guide
 
 <!-- This file is the canonical source. The docs/getting-started/installation.md copy is maintained for the doc site build. -->
 

--- a/docs/security-trust-model.md
+++ b/docs/security-trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.37.4 --># Security & Trust Model
+<!-- verified-against: 0.37.5 --># Security & Trust Model
 
 This document provides an honest, per-area assessment of what q enforces
 today and what is planned. It is the authoritative reference for security

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -130,6 +130,6 @@ is the primary self-hosting extension:
 (load-extension! ext-reg "path/to/extension.rkt" #:event-bus bus)
 ```
 
-## Version 0.37.4
+## Version 0.37.5
 
-This documentation reflects q 0.37.4.
+This documentation reflects q 0.37.5.

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.37.4 --># q Source Style Guide
+<!-- verified-against: 0.37.5 --># q Source Style Guide
 
 This document defines formatting and naming conventions for the q Racket codebase.
 All changes to `q/` source files (excluding `tests/`) should follow these rules.

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.37.4 --># Trust Model
+<!-- verified-against: 0.37.5 --># Trust Model
 
 ## Trust Levels
 

--- a/docs/workflow-testing.md
+++ b/docs/workflow-testing.md
@@ -121,6 +121,6 @@ Use relative paths from the test file:
 4. Use `(check-true ...)` for boolean assertions
 5. Keep tests independent — no shared mutable state between test-cases
 
-## Version 0.37.4
+## Version 0.37.5
 
-This documentation reflects q 0.37.4.
+This documentation reflects q 0.37.5.

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.37.4")
+(define version "0.37.5")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base"))

--- a/runtime/turn-orchestrator.rkt
+++ b/runtime/turn-orchestrator.rkt
@@ -123,15 +123,18 @@
                list?)]
           [register-session-extensions!
            (-> tool-registry? (or/c extension-registry? #f) event-bus? string? (listof hash?))]
-          [assemble-context/pure (-> list? (or/c hash? session-config?) list?)]))
+          [assemble-context/pure
+           (->* (list? (or/c hash? session-config?))
+                 (#:hook-dispatcher (or/c procedure? #f))
+                 (values list? any/c))]))
 
 ;; ============================================================
 ;; Context assembly
 ;; ============================================================
 
 ;; Pure: assemble context from messages and config without side effects.
-;; Returns the assembled message list (no events, no hooks).
-(define (assemble-context/pure ctx-to-use config-raw)
+;; Returns the assembled message list and hook result (no events emitted here).
+(define (assemble-context/pure ctx-to-use config-raw #:hook-dispatcher [hook-dispatcher #f])
   (define config (if (session-config? config-raw) config-raw (hash->session-config config-raw)))
   (define tier-b-count (config-tier-b-count config))
   (define tier-c-count (config-tier-c-count config))
@@ -143,32 +146,21 @@
           (working-set-resolve-messages ws ctx-to-use message-id)
           '())))
   (define ws-messages (force ws-messages-promise))
-  (define-values (tc _hook-result)
+  (define-values (tc hook-result)
     (build-tiered-context-with-hooks ctx-to-use
+                                     #:hook-dispatcher hook-dispatcher
                                      #:tier-b-count tier-b-count
                                      #:tier-c-count tier-c-count
                                      #:max-tokens max-tokens
                                      #:working-set-messages ws-messages))
-  (tiered-context->message-list tc))
+  (values (tiered-context->message-list tc) hook-result))
 
 ;; Build assembled context using tiered context assembly with hooks.
 ;; Returns the assembled message list.
 (define (build-assembled-context ctx-to-use config-raw ext-reg bus session-id iteration)
   ;; WP-37 + R2-6: Context Assembly with Tier A/B/C separation and Hook support
   (define config (if (session-config? config-raw) config-raw (hash->session-config config-raw)))
-  (define tier-b-count (config-tier-b-count config))
-  (define tier-c-count (config-tier-c-count config))
-  (define max-tokens (config-max-tokens config))
-  ;; v0.26.0: Extract working set from config
-  ;; v0.29.5 W3: Defer ws-message resolution
   (define ws (config-working-set config))
-  (define ws-messages-promise
-    (delay
-      (if ws
-          (working-set-resolve-messages ws ctx-to-use message-id)
-          '())))
-  (define ws-messages (force ws-messages-promise))
-  (define ws-message-ids (map message-id ws-messages))
 
   ;; R2-6: Create hook dispatcher function for context assembly
   (define ctx-assembly-hook-dispatcher
@@ -177,21 +169,14 @@
            (define result (dispatch-hooks hook-point payload ext-reg))
            result)))
 
-  ;; Build tiered context with hook support
-  (define-values (tc assembly-hook-result)
-    (build-tiered-context-with-hooks ctx-to-use
-                                     #:hook-dispatcher ctx-assembly-hook-dispatcher
-                                     #:tier-b-count tier-b-count
-                                     #:tier-c-count tier-c-count
-                                     #:max-tokens max-tokens
-                                     #:working-set-messages ws-messages))
+  ;; FD-05: Delegate pure assembly to assemble-context/pure
+  (define-values (ctx-assembled assembly-hook-result)
+    (assemble-context/pure ctx-to-use config-raw #:hook-dispatcher ctx-assembly-hook-dispatcher))
 
   ;; Handle block action from context-assembly hook
   (when (and assembly-hook-result (eq? (hook-result-action assembly-hook-result) 'block))
     (emit-session-event! bus session-id "context.assembly.blocked" (hasheq 'reason "extension-block"))
     (raise-extension-error "Context assembly blocked by extension" "unknown" "turn.started"))
-
-  (define ctx-assembled (tiered-context->message-list tc))
 
   ;; v0.26.0: Emit working-set.injected event
   (when ws

--- a/tests/test-context-assembly.rkt
+++ b/tests/test-context-assembly.rkt
@@ -425,7 +425,7 @@
           (make-test-msg "a1" 'assistant 'message "Hi there")
           (make-test-msg "u2" 'user 'message "How are you?")))
   (define config (hash 'tier-b-count 10 'tier-c-count 2 'max-tokens 4096))
-  (define result (ctx-assemble msgs config))
+  (define-values (result _hook-res) (ctx-assemble msgs config))
   (check-pred list? result)
   (check >= (length result) 1)
   ;; Verify all results are messages

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -10,4 +10,4 @@
 (provide q-version)
 
 (: q-version String)
-(define q-version "0.37.4")
+(define q-version "0.37.5")

--- a/wiki-src/Architecture-Overview.md
+++ b/wiki-src/Architecture-Overview.md
@@ -35,7 +35,7 @@ User input → Interface (CLI/TUI/RPC)
     → Events emitted to bus
 ```
 
-## Metrics (0.37.4)
+## Metrics (0.37.5)
 > _See `racket scripts/metrics.rkt` for current numbers._
 
 - 414 source modules, 534 test files


### PR DESCRIPTION
v0.37.5 milestone.

- FD-05: assemble-context/pure takes optional #:hook-dispatcher; build-assembled-context delegates pure assembly
- Eliminates duplicated config extraction and tiered-context building

Lint 18/18.

Closes #4079