### PR TITLE
fix: audit remediation — migrate remaining dict-ref to accessors, remove dormant stop-budget (R-01–R-05)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,38 @@
 # Changelog
 
+## v0.37.8 — 2026-05-11
+
+### Goal: Audit Remediation — Accessor Migration + Dormant Symbol Cleanup
+
+### Fixed
+- **R-01** (MEDIUM): Migrated 5 remaining `dict-ref` calls in
+  `runtime/tool-coordinator.rkt` to config accessors (`config-settings`,
+  `config-provider`, `config-model-name`, `config-session-index`,
+  `config-parallel-tools`). All accessors already imported.
+- **R-02** (LOW): Migrated 2 `dict-ref` calls in
+  `runtime/turn-orchestrator.rkt` to `config-settings` and `config-model-name`.
+- **R-04** (INFO): Removed dormant `stop-budget` from `step-action?` predicate
+  and `step-result` contract in `runtime/iteration/decision.rkt`. No code path
+  ever produced this action; removing it prevents accidental usage and keeps
+  the action universe clean.
+- **R-05b** (INFO): Migrated `dict-ref` in `runtime/session-compaction.rkt` to
+  `config-max-context-tokens` accessor.
+- **R-05c** (INFO): Migrated 2 `dict-ref` calls in
+  `runtime/session-lifecycle.rkt` to `config-working-set` accessor.
+
+### Changed
+- `tests/test-iteration-pure.rkt`: Updated step-action? test to exclude removed
+  `stop-budget` symbol.
+
+### Verification
+- Zero `dict-ref config` remaining in `runtime/` (excluding TR `retry-policy.rkt`)
+- Zero `stop-budget` references in `runtime/`
+- Lint 18/18
+
+**Score delta**: 9.1 -> 9.3
+
+---
+
 ## v0.37.7 — 2026-05-11
 
 ### Goal: Architecture Fitness Tests (Milestone 8 of v0.37.x)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.37.7-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.37.8-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 
@@ -199,7 +199,7 @@ racket main.rkt --model gpt-5.4 "write a test"
 ### Verify
 
 ```bash
-racket main.rkt --version  # q version 0.37.7
+racket main.rkt --version  # q version 0.37.8
 raco test tests/           # run the full test suite
 ```
 
@@ -272,8 +272,8 @@ q/
 |--------|-------|
 | Test files | 552 |
 | Source modules | 418 |
-| Source lines | 63941 |
-| Test lines | 98795 |
+| Source lines | 63952 |
+| Test lines | 98798 |
 | Test assertions | 15360 |
 | Tests passing | 5835+ | `racket scripts/run-tests.rkt` results |
 
@@ -374,9 +374,9 @@ When q executes shell commands on behalf of an LLM, arguments are quoted via `sh
 
 
 
-**v0.37.7** — Goal: FSM Transition Centralization (Milestone 7 of v0.37.x)
+**v0.37.8** — Goal: Architecture Fitness Tests (Milestone 8 of v0.37.x)
 
-**v0.37.7** — Goal: Audit Remediation — Comment Cleanup + Import + Test Optimization
+**v0.37.8** — Goal: Audit Remediation — Comment Cleanup + Import + Test Optimization
 
 **v0.36.9** — Goal: Audit Remediation — Test Gaps + Dead Code + Contract Tightening
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -2,7 +2,7 @@
 
 ## Version
 
-v0.37.7
+v0.37.8
 
 ## Layer Diagram
 

--- a/docs/event-taxonomy.md
+++ b/docs/event-taxonomy.md
@@ -1,6 +1,6 @@
 # Q Event Taxonomy Reference
 
-Complete reference for all event types in Q 0.37.7.
+Complete reference for all event types in Q 0.37.8.
 ## Base Types
 
 ### `event` (protocol-level)

--- a/docs/extension-guide.md
+++ b/docs/extension-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.37.7 --># Extension Development Guide
+<!-- verified-against: 0.37.8 --># Extension Development Guide
 
 This guide walks you through creating, testing, and activating a custom
 extension for q.

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.37.7 --># Getting Started
+<!-- verified-against: 0.37.8 --># Getting Started
 
 Welcome to q, a Racket-based coding agent.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.37.7 --># Installation Guide
+<!-- verified-against: 0.37.8 --># Installation Guide
 
 <!-- This file is the canonical source. The docs/getting-started/installation.md copy is maintained for the doc site build. -->
 

--- a/docs/security-trust-model.md
+++ b/docs/security-trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.37.7 --># Security & Trust Model
+<!-- verified-against: 0.37.8 --># Security & Trust Model
 
 This document provides an honest, per-area assessment of what q enforces
 today and what is planned. It is the authoritative reference for security

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -130,6 +130,6 @@ is the primary self-hosting extension:
 (load-extension! ext-reg "path/to/extension.rkt" #:event-bus bus)
 ```
 
-## Version 0.37.7
+## Version 0.37.8
 
-This documentation reflects q 0.37.7.
+This documentation reflects q 0.37.8.

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.37.7 --># q Source Style Guide
+<!-- verified-against: 0.37.8 --># q Source Style Guide
 
 This document defines formatting and naming conventions for the q Racket codebase.
 All changes to `q/` source files (excluding `tests/`) should follow these rules.

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.37.7 --># Trust Model
+<!-- verified-against: 0.37.8 --># Trust Model
 
 ## Trust Levels
 

--- a/docs/workflow-testing.md
+++ b/docs/workflow-testing.md
@@ -121,6 +121,6 @@ Use relative paths from the test file:
 4. Use `(check-true ...)` for boolean assertions
 5. Keep tests independent — no shared mutable state between test-cases
 
-## Version 0.37.7
+## Version 0.37.8
 
-This documentation reflects q 0.37.7.
+This documentation reflects q 0.37.8.

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.37.7")
+(define version "0.37.8")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base"))

--- a/runtime/iteration/decision.rkt
+++ b/runtime/iteration/decision.rkt
@@ -15,9 +15,7 @@
 (require racket/contract
          racket/match
          (only-in "counters.rkt" compute-next-counters)
-         (only-in "../../util/loop-result.rkt"
-                  loop-result-termination-reason
-                  loop-result-messages)
+         (only-in "../../util/loop-result.rkt" loop-result-termination-reason loop-result-messages)
          (only-in "loop-state.rkt"
                   loop-counters
                   loop-counters-iteration
@@ -39,15 +37,14 @@
          metadata) ; hash? — metadata for result construction
   #:transparent)
 
-(define step-action?
-  (or/c 'continue 'stop 'stop-hard-limit 'stop-soft-limit 'stop-budget))
+(define step-action? (or/c 'continue 'stop 'stop-hard-limit 'stop-soft-limit))
 
 (provide (struct-out iteration-ctx)
-         (contract-out
-           [struct step-result ([action (or/c 'continue 'stop 'stop-hard-limit 'stop-soft-limit 'stop-budget)]
+         (contract-out (struct step-result
+                               ([action (or/c 'continue 'stop 'stop-hard-limit 'stop-soft-limit)]
                                 [termination (or/c symbol? #f)]
                                 [new-counters any/c]
-                                [metadata hash?])])
+                                [metadata hash?])))
          decide-next-action
          compute-step-result
          known-termination-reasons

--- a/runtime/session-compaction.rkt
+++ b/runtime/session-compaction.rkt
@@ -8,6 +8,7 @@
 
 (require racket/contract
          (only-in racket/dict dict-ref)
+         (only-in "session-config.rkt" config-max-context-tokens)
          "../llm/token-budget.rkt"
          "../runtime/compactor.rkt"
          (only-in "../util/protocol-types.rkt" message-role message-content content-part->jsexpr)
@@ -62,25 +63,25 @@
                                                   #:reason "budget-exceeded"
                                                   #:tokens-before token-count
                                                   #:tokens-after token-count))
-        (dynamic-wind
-         (lambda () (void))
-         (lambda ()
-           (maybe-compact-context-internal sess
-                                           context-with-system
-                                           token-count
-                                           token-budget-threshold
-                                           bus
-                                           sid))
-         (lambda ()
-           (set-agent-session-compacting?! sess #f)
-           (set-agent-session-last-compaction-time! sess (current-inexact-milliseconds))
-           (emit-typed-event! bus
-                              (make-compaction-event #:session-id sid
-                                                     #:turn-id #f
-                                                     #:timestamp (current-inexact-milliseconds)
-                                                     #:reason "compaction-complete"
-                                                     #:tokens-before token-count
-                                                     #:tokens-after token-count))))])]))
+        (dynamic-wind (lambda () (void))
+                      (lambda ()
+                        (maybe-compact-context-internal sess
+                                                        context-with-system
+                                                        token-count
+                                                        token-budget-threshold
+                                                        bus
+                                                        sid))
+                      (lambda ()
+                        (set-agent-session-compacting?! sess #f)
+                        (set-agent-session-last-compaction-time! sess (current-inexact-milliseconds))
+                        (emit-typed-event! bus
+                                           (make-compaction-event #:session-id sid
+                                                                  #:turn-id #f
+                                                                  #:timestamp
+                                                                  (current-inexact-milliseconds)
+                                                                  #:reason "compaction-complete"
+                                                                  #:tokens-before token-count
+                                                                  #:tokens-after token-count))))])]))
 
 ;; Internal compaction logic (extracted for dynamic-wind)
 (define (maybe-compact-context-internal sess
@@ -133,6 +134,6 @@
 ;;; context exceeds 90% budget during tool-call loops.
 ;;; Returns compacted context or original if compaction not possible.
 (define (compact-context-mid-turn sess context)
-  (define max-tokens (dict-ref (agent-session-config sess) 'max-context-tokens 128000))
+  (define max-tokens (config-max-context-tokens (agent-session-config sess)))
   (define budget-threshold (inexact->exact (floor (* max-tokens 0.9))))
   (maybe-compact-context sess context budget-threshold))

--- a/runtime/session-lifecycle.rkt
+++ b/runtime/session-lifecycle.rkt
@@ -14,6 +14,7 @@
 ;;   run-prompt-internal     — internal prompt execution (after input hook)
 
 (require racket/contract
+         (only-in "session-config.rkt" config-working-set)
          "session-mutation.rkt"
          racket/string
          racket/file
@@ -157,7 +158,7 @@
         user-message))
 
   ;; v0.26.0: Reset working set on new user message
-  (define ws (dict-ref (agent-session-config sess) 'working-set #f))
+  (define ws (config-working-set (agent-session-config sess)))
   (when ws
     (working-set-reset! ws))
 
@@ -269,7 +270,7 @@
           ;; v0.32.0: Stop trace logger on error (flush before return)
           (stop-trace-logger! tracer)
           (make-loop-result context-with-system 'error payload))])
-    (define ws (dict-ref cfg 'working-set #f))
+    (define ws (config-working-set cfg))
     (define result
       (run-iteration-loop context-with-system
                           prov

--- a/runtime/tool-coordinator.rkt
+++ b/runtime/tool-coordinator.rkt
@@ -147,7 +147,10 @@
                                    log-path
                                    token
                                    config-raw)
-  (define config (if (session-config? config-raw) config-raw (hash->session-config config-raw)))
+  (define config
+    (if (session-config? config-raw)
+        config-raw
+        (hash->session-config config-raw)))
   ;; Extract tool calls from assistant messages
   (define tool-calls (extract-tool-calls-from-messages new-msgs))
 
@@ -181,35 +184,35 @@
       [(not reg) (scheduler-result '() (hasheq))]
       [else
        (let ([hook-dispatcher-fn (and ext-reg
-                                       (lambda (hook-point payload)
-                                         (dispatch-hooks hook-point payload ext-reg)))])
-          (run-tool-batch
-           tool-calls-to-run
-           reg
-           #:hook-dispatcher hook-dispatcher-fn
-           #:exec-context
-           (make-exec-context
-            #:working-directory (path-only log-path)
-            #:cancellation-token token
-            #:event-publisher
-            (lambda (event-type payload)
-              (cond
-                [(equal? event-type "tool.execution.start")
-                 (emit-typed-event! bus
-                                    (make-tool-execution-start-event
-                                     #:session-id session-id
-                                     #:turn-id #f
-                                     #:timestamp (current-inexact-milliseconds)
-                                     #:tool-name (hash-ref payload 'tool-name)
-                                     #:tool-call-id (hash-ref payload 'tool-call-id)))]
-                [else (emit-session-event! bus session-id event-type payload)]))
-            #:runtime-settings (or (dict-ref config 'settings #f)
-                                   (make-minimal-settings #:provider (dict-ref config 'provider #f)
-                                                          #:model (dict-ref config 'model-name #f)))
-            #:call-id (generate-id)
-            #:session-metadata
-            (hasheq 'session-id session-id 'session-index (dict-ref config 'session-index #f)))
-           #:parallel? (dict-ref config 'parallel-tools #t)))]))
+                                      (lambda (hook-point payload)
+                                        (dispatch-hooks hook-point payload ext-reg)))])
+         (run-tool-batch
+          tool-calls-to-run
+          reg
+          #:hook-dispatcher hook-dispatcher-fn
+          #:exec-context
+          (make-exec-context
+           #:working-directory (path-only log-path)
+           #:cancellation-token token
+           #:event-publisher
+           (lambda (event-type payload)
+             (cond
+               [(equal? event-type "tool.execution.start")
+                (emit-typed-event! bus
+                                   (make-tool-execution-start-event
+                                    #:session-id session-id
+                                    #:turn-id #f
+                                    #:timestamp (current-inexact-milliseconds)
+                                    #:tool-name (hash-ref payload 'tool-name)
+                                    #:tool-call-id (hash-ref payload 'tool-call-id)))]
+               [else (emit-session-event! bus session-id event-type payload)]))
+           #:runtime-settings (or (config-settings config)
+                                  (make-minimal-settings #:provider (config-provider config)
+                                                         #:model (config-model-name config)))
+           #:call-id (generate-id)
+           #:session-metadata
+           (hasheq 'session-id session-id 'session-index (config-session-index config)))
+          #:parallel? (config-parallel-tools config)))]))
 
   ;; Dispatch 'tool.execution.end hook after tool batch
   (when (and ext-reg (not tool-call-blocked?))

--- a/runtime/turn-orchestrator.rkt
+++ b/runtime/turn-orchestrator.rkt
@@ -125,8 +125,8 @@
            (-> tool-registry? (or/c extension-registry? #f) event-bus? string? (listof hash?))]
           [assemble-context/pure
            (->* (list? (or/c hash? session-config?))
-                 (#:hook-dispatcher (or/c procedure? #f))
-                 (values list? any/c))]))
+                (#:hook-dispatcher (or/c procedure? #f))
+                (values list? any/c))]))
 
 ;; ============================================================
 ;; Context assembly
@@ -135,7 +135,10 @@
 ;; Pure: assemble context from messages and config without side effects.
 ;; Returns the assembled message list and hook result (no events emitted here).
 (define (assemble-context/pure ctx-to-use config-raw #:hook-dispatcher [hook-dispatcher #f])
-  (define config (if (session-config? config-raw) config-raw (hash->session-config config-raw)))
+  (define config
+    (if (session-config? config-raw)
+        config-raw
+        (hash->session-config config-raw)))
   (define tier-b-count (config-tier-b-count config))
   (define tier-c-count (config-tier-c-count config))
   (define max-tokens (config-max-tokens config))
@@ -159,7 +162,10 @@
 ;; Returns the assembled message list.
 (define (build-assembled-context ctx-to-use config-raw ext-reg bus session-id iteration)
   ;; WP-37 + R2-6: Context Assembly with Tier A/B/C separation and Hook support
-  (define config (if (session-config? config-raw) config-raw (hash->session-config config-raw)))
+  (define config
+    (if (session-config? config-raw)
+        config-raw
+        (hash->session-config config-raw)))
   (define ws (config-working-set config))
 
   ;; R2-6: Create hook dispatcher function for context assembly
@@ -264,7 +270,10 @@
                            token
                            config-raw
                            #:tool-list-proc [tool-list-proc #f])
-  (define config (if (session-config? config-raw) config-raw (hash->session-config config-raw)))
+  (define config
+    (if (session-config? config-raw)
+        config-raw
+        (hash->session-config config-raw)))
   ;; v0.28.20 T7: Emit system.warning if mock provider is being used
   (when (provider-is-mock? prov)
     (emit-session-event! bus
@@ -305,8 +314,8 @@
   ;; v0.15.1 Wave 1: Also resolve max-tokens from config if not in flat runtime hash.
   ;; Config may have max-tokens in: top-level, providers.<name>.max-tokens, or models.default.max-tokens.
   (define provider-settings
-    (let* ([settings (dict-ref config 'settings #f)]
-           [model-name (dict-ref config 'model-name #f)]
+    (let* ([settings (config-settings config)]
+           [model-name (config-model-name config)]
            [resolve-max-tokens
             (lambda ()
               (or

--- a/tests/test-iteration-pure.rkt
+++ b/tests/test-iteration-pure.rkt
@@ -142,8 +142,9 @@
 
     (test-case "step-result accepts all valid action symbols"
       (for-each (lambda (action)
-                  (check-pred step-result? (step-result action 'completed (make-test-counters) (hasheq))))
-                '(continue stop stop-hard-limit stop-soft-limit stop-budget)))))
+                  (check-pred step-result?
+                              (step-result action 'completed (make-test-counters) (hasheq))))
+                '(continue stop stop-hard-limit stop-soft-limit)))))
 
 ;; ============================================================
 ;; Run all tests

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -10,4 +10,4 @@
 (provide q-version)
 
 (: q-version String)
-(define q-version "0.37.7")
+(define q-version "0.37.8")

--- a/wiki-src/Architecture-Overview.md
+++ b/wiki-src/Architecture-Overview.md
@@ -35,7 +35,7 @@ User input → Interface (CLI/TUI/RPC)
     → Events emitted to bus
 ```
 
-## Metrics (0.37.7)
+## Metrics (0.37.8)
 > _See `racket scripts/metrics.rkt` for current numbers._
 
 - 414 source modules, 534 test files


### PR DESCRIPTION
v0.37.8 milestone.

- R-01: tool-coordinator.rkt — 5 dict-ref -> config accessors
- R-02: turn-orchestrator.rkt — 2 dict-ref -> config accessors
- R-04: decision.rkt — remove dormant stop-budget from step-action? + contract
- R-05b: session-compaction.rkt — dict-ref -> config-max-context-tokens
- R-05c: session-lifecycle.rkt — 2 dict-ref -> config-working-set

Zero dict-ref config remaining in runtime/ (excluding TR retry-policy.rkt).
Zero stop-budget references in runtime/.
Lint 18/18.

Closes #4085