### PR TITLE
fix: quick-win struct safety (H-01, L-05, L-14, M-06, L-01)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## v0.38.0 — 2026-05-11
+
+### Goal: Quick-Win Struct Safety (Milestone 1 of v0.38.x)
+
+### Fixed
+- **H-01** (HIGH): Removed `#:transparent` from `tool-registry` struct in
+  `tools/registry.rkt`. Zero external field access; representation now hidden.
+- **L-05** (LOW): Replaced inexact floating-point arithmetic in
+  `resolve-max-iterations-hard` with exact rational `(quotient (* max-iterations 8) 5)`.
+- **L-14** (LOW): Removed `struct-out ext-registry-data` from public API in
+  `extensions/api.rkt`. All field access is internal to the module.
+- **M-06** (MEDIUM): Added `#:port` keyword parameter to `start-trace-logger!` in
+  `runtime/trace-logger.rkt`. Supports string-port injection for testing. Added
+  guard to close existing port on re-start, preventing double-start leak.
+- **L-01** (LOW): Removed `#:transparent` from `summary-cache` struct in
+  `runtime/context-summary.rkt`. All access via helper functions; accessors
+  remain available internally.
+
+**Verification**: lint 18/18, targeted tests 54/54 pass
+
+---
+
 ## v0.37.8 — 2026-05-11
 
 ### Goal: Audit Remediation — Accessor Migration + Dormant Symbol Cleanup

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.37.8-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.38.0-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 
@@ -199,7 +199,7 @@ racket main.rkt --model gpt-5.4 "write a test"
 ### Verify
 
 ```bash
-racket main.rkt --version  # q version 0.37.8
+racket main.rkt --version  # q version 0.38.0
 raco test tests/           # run the full test suite
 ```
 
@@ -272,7 +272,7 @@ q/
 |--------|-------|
 | Test files | 552 |
 | Source modules | 418 |
-| Source lines | 63952 |
+| Source lines | 63956 |
 | Test lines | 98798 |
 | Test assertions | 15360 |
 | Tests passing | 5835+ | `racket scripts/run-tests.rkt` results |
@@ -374,9 +374,9 @@ When q executes shell commands on behalf of an LLM, arguments are quoted via `sh
 
 
 
-**v0.37.8** — Goal: Audit Remediation — Accessor Migration + Dormant Symbol Cleanup
+**v0.38.0** — Goal: Audit Remediation — Accessor Migration + Dormant Symbol Cleanup
 
-**v0.37.8** — Goal: Audit Remediation — Comment Cleanup + Import + Test Optimization
+**v0.38.0** — Goal: Audit Remediation — Comment Cleanup + Import + Test Optimization
 
 **v0.36.9** — Goal: Audit Remediation — Test Gaps + Dead Code + Contract Tightening
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -2,7 +2,7 @@
 
 ## Version
 
-v0.37.8
+v0.38.0
 
 ## Layer Diagram
 

--- a/docs/event-taxonomy.md
+++ b/docs/event-taxonomy.md
@@ -1,6 +1,6 @@
 # Q Event Taxonomy Reference
 
-Complete reference for all event types in Q 0.37.8.
+Complete reference for all event types in Q 0.38.0.
 ## Base Types
 
 ### `event` (protocol-level)

--- a/docs/extension-guide.md
+++ b/docs/extension-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.37.8 --># Extension Development Guide
+<!-- verified-against: 0.38.0 --># Extension Development Guide
 
 This guide walks you through creating, testing, and activating a custom
 extension for q.

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.37.8 --># Getting Started
+<!-- verified-against: 0.38.0 --># Getting Started
 
 Welcome to q, a Racket-based coding agent.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.37.8 --># Installation Guide
+<!-- verified-against: 0.38.0 --># Installation Guide
 
 <!-- This file is the canonical source. The docs/getting-started/installation.md copy is maintained for the doc site build. -->
 

--- a/docs/security-trust-model.md
+++ b/docs/security-trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.37.8 --># Security & Trust Model
+<!-- verified-against: 0.38.0 --># Security & Trust Model
 
 This document provides an honest, per-area assessment of what q enforces
 today and what is planned. It is the authoritative reference for security

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -130,6 +130,6 @@ is the primary self-hosting extension:
 (load-extension! ext-reg "path/to/extension.rkt" #:event-bus bus)
 ```
 
-## Version 0.37.8
+## Version 0.38.0
 
-This documentation reflects q 0.37.8.
+This documentation reflects q 0.38.0.

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.37.8 --># q Source Style Guide
+<!-- verified-against: 0.38.0 --># q Source Style Guide
 
 This document defines formatting and naming conventions for the q Racket codebase.
 All changes to `q/` source files (excluding `tests/`) should follow these rules.

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.37.8 --># Trust Model
+<!-- verified-against: 0.38.0 --># Trust Model
 
 ## Trust Levels
 

--- a/docs/workflow-testing.md
+++ b/docs/workflow-testing.md
@@ -121,6 +121,6 @@ Use relative paths from the test file:
 4. Use `(check-true ...)` for boolean assertions
 5. Keep tests independent — no shared mutable state between test-cases
 
-## Version 0.37.8
+## Version 0.38.0
 
-This documentation reflects q 0.37.8.
+This documentation reflects q 0.38.0.

--- a/extensions/api.rkt
+++ b/extensions/api.rkt
@@ -41,7 +41,6 @@
          injection-event-topic
          (struct-out extension)
          extension-registry?
-         (struct-out ext-registry-data)
          (contract-out [make-extension-registry (-> extension-registry?)]
                        [register-extension! (-> extension-registry? extension? void?)]
                        [unregister-extension! (-> extension-registry? string? void?)]

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.37.8")
+(define version "0.38.0")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base"))

--- a/runtime/context-summary.rkt
+++ b/runtime/context-summary.rkt
@@ -69,7 +69,7 @@
         ([table #:mutable] ; hash: key=(from-id . to-id) → value=text
          [order #:mutable] ; list of keys in LRU order (newest first)
          [max-entries #:mutable]) ; capacity limit
-  #:transparent)
+  )
 
 (define (make-summary-cache #:max-entries [max DEFAULT-CACHE-MAX-ENTRIES])
   (summary-cache (hash) '() max))

--- a/runtime/session-config.rkt
+++ b/runtime/session-config.rkt
@@ -156,7 +156,7 @@
 ;; ── Dynamic default resolution ─────────────────────────────────
 
 (define (resolve-max-iterations-hard config max-iterations)
-  (or (config-max-iterations-hard config) (max (inexact->exact (floor (* max-iterations 1.6))) 80)))
+  (or (config-max-iterations-hard config) (max (quotient (* max-iterations 8) 5) 80)))
 
 ;; ── Conversion helpers ───────────────────────────────────────────
 

--- a/runtime/trace-logger.rkt
+++ b/runtime/trace-logger.rkt
@@ -37,15 +37,22 @@
 ;; Start / Stop
 ;; ============================================================
 
-(define (start-trace-logger! logger)
+(define (start-trace-logger! logger #:port [out-port #f])
   (when (trace-logger-enabled? logger)
     (define bus (trace-logger-bus logger))
     (define session-dir (trace-logger-session-dir logger))
-    (define trace-path (build-path session-dir "trace.jsonl"))
-    ;; Ensure parent dir exists
-    (make-directory* session-dir)
-    ;; Open output port in append mode
-    (define out (open-output-file trace-path #:exists 'append))
+    ;; Close existing port if re-starting (prevents double-start leak)
+    (define old-out (trace-logger-out-port logger))
+    (when old-out
+      (close-output-port old-out)
+      (set-trace-logger-out-port! logger #f))
+    (define out
+      (or out-port
+          (let ([trace-path (build-path session-dir "trace.jsonl")])
+            ;; Ensure parent dir exists
+            (make-directory* session-dir)
+            ;; Open output port in append mode
+            (open-output-file trace-path #:exists 'append))))
     (set-trace-logger-out-port! logger out)
     ;; Subscribe to all events
     (define sub-id (subscribe! bus (lambda (evt) (handle-event! logger evt))))

--- a/tools/registry.rkt
+++ b/tools/registry.rkt
@@ -33,7 +33,7 @@
 ;; Tool registry
 ;; ============================================================
 
-(struct tool-registry (tools-box active-set-box sem) #:transparent)
+(struct tool-registry (tools-box active-set-box sem))
 
 ;; Safe read-only accessor under lock
 (define (tool-registry-tools reg)

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -10,4 +10,4 @@
 (provide q-version)
 
 (: q-version String)
-(define q-version "0.37.8")
+(define q-version "0.38.0")

--- a/wiki-src/Architecture-Overview.md
+++ b/wiki-src/Architecture-Overview.md
@@ -35,7 +35,7 @@ User input → Interface (CLI/TUI/RPC)
     → Events emitted to bus
 ```
 
-## Metrics (0.37.8)
+## Metrics (0.38.0)
 > _See `racket scripts/metrics.rkt` for current numbers._
 
 - 414 source modules, 534 test files


### PR DESCRIPTION
v0.38.0 milestone.

- H-01: Remove #:transparent from tool-registry
- L-05: Exact rational arithmetic in resolve-max-iterations-hard
- L-14: Remove struct-out ext-registry-data from public API
- M-06: Add #:port to start-trace-logger! + double-start guard
- L-01: Remove #:transparent from summary-cache

Lint 18/18, targeted tests 54/54.

Closes #4087