### PR TITLE
fix: session-config & model-registry encapsulation (M-01, M-02)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## v0.38.1 — 2026-05-11
+
+### Goal: Session-Config & Model-Registry Encapsulation (Milestone 2 of v0.38.x)
+
+### Fixed
+- **M-01** (MEDIUM): Replaced `struct-out session-config` with selective exports
+  in `runtime/session-config.rkt`. Exported `session-config?`, `session-config`
+  constructor, `hash->session-config`, `session-config->hash`, and all `config-*`
+  accessors. Removed raw field accessor `session-config-data` from public API.
+- **M-02** (MEDIUM): Replaced `struct-out` for `model-entry`, `model-registry`,
+  and `model-resolution` in `runtime/model-registry.rkt` with selective exports.
+  Kept safe accessors (`model-entry-name`, `model-resolution-model-name`, etc.)
+  and predicates. Removed internal `model-registry-*` field accessors from public
+  API.
+
+**Verification**: lint 18/18, targeted tests 124/124 pass
+
+---
+
 ## v0.38.0 — 2026-05-11
 
 ### Goal: Quick-Win Struct Safety (Milestone 1 of v0.38.x)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.38.0-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.38.1-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 
@@ -199,7 +199,7 @@ racket main.rkt --model gpt-5.4 "write a test"
 ### Verify
 
 ```bash
-racket main.rkt --version  # q version 0.38.0
+racket main.rkt --version  # q version 0.38.1
 raco test tests/           # run the full test suite
 ```
 
@@ -272,7 +272,7 @@ q/
 |--------|-------|
 | Test files | 552 |
 | Source modules | 418 |
-| Source lines | 63956 |
+| Source lines | 63963 |
 | Test lines | 98798 |
 | Test assertions | 15360 |
 | Tests passing | 5835+ | `racket scripts/run-tests.rkt` results |
@@ -374,9 +374,9 @@ When q executes shell commands on behalf of an LLM, arguments are quoted via `sh
 
 
 
-**v0.38.0** — Goal: Audit Remediation — Accessor Migration + Dormant Symbol Cleanup
+**v0.38.1** — Goal: Quick-Win Struct Safety (Milestone 1 of v0.38.x)
 
-**v0.38.0** — Goal: Audit Remediation — Comment Cleanup + Import + Test Optimization
+**v0.38.1** — Goal: Audit Remediation — Comment Cleanup + Import + Test Optimization
 
 **v0.36.9** — Goal: Audit Remediation — Test Gaps + Dead Code + Contract Tightening
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -2,7 +2,7 @@
 
 ## Version
 
-v0.38.0
+v0.38.1
 
 ## Layer Diagram
 

--- a/docs/event-taxonomy.md
+++ b/docs/event-taxonomy.md
@@ -1,6 +1,6 @@
 # Q Event Taxonomy Reference
 
-Complete reference for all event types in Q 0.38.0.
+Complete reference for all event types in Q 0.38.1.
 ## Base Types
 
 ### `event` (protocol-level)

--- a/docs/extension-guide.md
+++ b/docs/extension-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.38.0 --># Extension Development Guide
+<!-- verified-against: 0.38.1 --># Extension Development Guide
 
 This guide walks you through creating, testing, and activating a custom
 extension for q.

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.38.0 --># Getting Started
+<!-- verified-against: 0.38.1 --># Getting Started
 
 Welcome to q, a Racket-based coding agent.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.38.0 --># Installation Guide
+<!-- verified-against: 0.38.1 --># Installation Guide
 
 <!-- This file is the canonical source. The docs/getting-started/installation.md copy is maintained for the doc site build. -->
 

--- a/docs/security-trust-model.md
+++ b/docs/security-trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.38.0 --># Security & Trust Model
+<!-- verified-against: 0.38.1 --># Security & Trust Model
 
 This document provides an honest, per-area assessment of what q enforces
 today and what is planned. It is the authoritative reference for security

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -130,6 +130,6 @@ is the primary self-hosting extension:
 (load-extension! ext-reg "path/to/extension.rkt" #:event-bus bus)
 ```
 
-## Version 0.38.0
+## Version 0.38.1
 
-This documentation reflects q 0.38.0.
+This documentation reflects q 0.38.1.

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.38.0 --># q Source Style Guide
+<!-- verified-against: 0.38.1 --># q Source Style Guide
 
 This document defines formatting and naming conventions for the q Racket codebase.
 All changes to `q/` source files (excluding `tests/`) should follow these rules.

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.38.0 --># Trust Model
+<!-- verified-against: 0.38.1 --># Trust Model
 
 ## Trust Levels
 

--- a/docs/workflow-testing.md
+++ b/docs/workflow-testing.md
@@ -121,6 +121,6 @@ Use relative paths from the test file:
 4. Use `(check-true ...)` for boolean assertions
 5. Keep tests independent — no shared mutable state between test-cases
 
-## Version 0.38.0
+## Version 0.38.1
 
-This documentation reflects q 0.38.0.
+This documentation reflects q 0.38.1.

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.38.0")
+(define version "0.38.1")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base"))

--- a/runtime/model-registry.rkt
+++ b/runtime/model-registry.rkt
@@ -38,9 +38,16 @@
       ""))
 
 ;; Structs
-(provide (struct-out model-entry)
-         (struct-out model-registry)
-         (struct-out model-resolution)
+(provide model-entry?
+         model-entry-name
+         model-entry-provider-name
+         model-entry-provider-config
+         model-registry?
+         model-resolution?
+         model-resolution-model-name
+         model-resolution-provider-name
+         model-resolution-base-url
+         model-resolution-provider-config
          ;; H-02: Contract-wrapped exports
          (contract-out
           [resolve-model (-> model-registry? (or/c string? #f) (or/c model-resolution? #f))]

--- a/runtime/session-config.rkt
+++ b/runtime/session-config.rkt
@@ -26,8 +26,8 @@
          racket/contract
          (only-in "../runtime/working-set.rkt" working-set?))
 
-(provide (struct-out session-config)
-         session-config?
+(provide session-config?
+         session-config
          hash->session-config
          session-config->hash
          resolve-max-iterations-hard

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -10,4 +10,4 @@
 (provide q-version)
 
 (: q-version String)
-(define q-version "0.38.0")
+(define q-version "0.38.1")

--- a/wiki-src/Architecture-Overview.md
+++ b/wiki-src/Architecture-Overview.md
@@ -35,7 +35,7 @@ User input → Interface (CLI/TUI/RPC)
     → Events emitted to bus
 ```
 
-## Metrics (0.38.0)
+## Metrics (0.38.1)
 > _See `racket scripts/metrics.rkt` for current numbers._
 
 - 414 source modules, 534 test files


### PR DESCRIPTION
v0.38.1 milestone.

- M-01: Replace struct-out session-config with selective exports
- M-02: Replace struct-out for model-entry/model-registry/model-resolution with selective exports

Lint 18/18, targeted tests 124/124.

Closes #4089