### PR TITLE
fix: tool system boundary hardening (H-02)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## v0.38.2 — 2026-05-11
+
+### Goal: Tool System Boundary Hardening (Milestone 3 of v0.38.x)
+
+### Fixed
+- **H-02** (HIGH): Replaced `struct-out tool` with selective exports in
+  `tools/tool-struct.rkt`. Exported `tool?`, `tool`, constructor, and safe
+  accessors (`tool-name`, `tool-schema`, etc.). Removed `tool-execute` from
+  `tool-struct.rkt` public API.
+- **H-02** (HIGH): Updated `tools/tool.rkt` to re-export only safe accessors
+  (not `tool-execute`). `tool-execute` remains available from
+  `tools/tool-struct.rkt` for tests and internal use.
+- Updated 12 test files to import `tool-execute` from `tools/tool-struct.rkt`
+  instead of `tools/tool.rkt`, enforcing the boundary separation.
+
+**Verification**: lint 18/18, targeted tests 123/123 pass
+
+---
+
 ## v0.38.1 — 2026-05-11
 
 ### Goal: Session-Config & Model-Registry Encapsulation (Milestone 2 of v0.38.x)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.38.1-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.38.2-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 
@@ -199,7 +199,7 @@ racket main.rkt --model gpt-5.4 "write a test"
 ### Verify
 
 ```bash
-racket main.rkt --version  # q version 0.38.1
+racket main.rkt --version  # q version 0.38.2
 raco test tests/           # run the full test suite
 ```
 
@@ -272,8 +272,8 @@ q/
 |--------|-------|
 | Test files | 552 |
 | Source modules | 418 |
-| Source lines | 63963 |
-| Test lines | 98798 |
+| Source lines | 63970 |
+| Test lines | 98791 |
 | Test assertions | 15360 |
 | Tests passing | 5835+ | `racket scripts/run-tests.rkt` results |
 
@@ -374,9 +374,9 @@ When q executes shell commands on behalf of an LLM, arguments are quoted via `sh
 
 
 
-**v0.38.1** — Goal: Quick-Win Struct Safety (Milestone 1 of v0.38.x)
+**v0.38.2** — Goal: Session-Config & Model-Registry Encapsulation (Milestone 2 of v0.38.x)
 
-**v0.38.1** — Goal: Audit Remediation — Comment Cleanup + Import + Test Optimization
+**v0.38.2** — Goal: Audit Remediation — Comment Cleanup + Import + Test Optimization
 
 **v0.36.9** — Goal: Audit Remediation — Test Gaps + Dead Code + Contract Tightening
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -2,7 +2,7 @@
 
 ## Version
 
-v0.38.1
+v0.38.2
 
 ## Layer Diagram
 

--- a/docs/event-taxonomy.md
+++ b/docs/event-taxonomy.md
@@ -1,6 +1,6 @@
 # Q Event Taxonomy Reference
 
-Complete reference for all event types in Q 0.38.1.
+Complete reference for all event types in Q 0.38.2.
 ## Base Types
 
 ### `event` (protocol-level)

--- a/docs/extension-guide.md
+++ b/docs/extension-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.38.1 --># Extension Development Guide
+<!-- verified-against: 0.38.2 --># Extension Development Guide
 
 This guide walks you through creating, testing, and activating a custom
 extension for q.

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.38.1 --># Getting Started
+<!-- verified-against: 0.38.2 --># Getting Started
 
 Welcome to q, a Racket-based coding agent.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.38.1 --># Installation Guide
+<!-- verified-against: 0.38.2 --># Installation Guide
 
 <!-- This file is the canonical source. The docs/getting-started/installation.md copy is maintained for the doc site build. -->
 

--- a/docs/security-trust-model.md
+++ b/docs/security-trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.38.1 --># Security & Trust Model
+<!-- verified-against: 0.38.2 --># Security & Trust Model
 
 This document provides an honest, per-area assessment of what q enforces
 today and what is planned. It is the authoritative reference for security

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -130,6 +130,6 @@ is the primary self-hosting extension:
 (load-extension! ext-reg "path/to/extension.rkt" #:event-bus bus)
 ```
 
-## Version 0.38.1
+## Version 0.38.2
 
-This documentation reflects q 0.38.1.
+This documentation reflects q 0.38.2.

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.38.1 --># q Source Style Guide
+<!-- verified-against: 0.38.2 --># q Source Style Guide
 
 This document defines formatting and naming conventions for the q Racket codebase.
 All changes to `q/` source files (excluding `tests/`) should follow these rules.

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.38.1 --># Trust Model
+<!-- verified-against: 0.38.2 --># Trust Model
 
 ## Trust Levels
 

--- a/docs/workflow-testing.md
+++ b/docs/workflow-testing.md
@@ -121,6 +121,6 @@ Use relative paths from the test file:
 4. Use `(check-true ...)` for boolean assertions
 5. Keep tests independent — no shared mutable state between test-cases
 
-## Version 0.38.1
+## Version 0.38.2
 
-This documentation reflects q 0.38.1.
+This documentation reflects q 0.38.2.

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.38.1")
+(define version "0.38.2")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base"))

--- a/tests/test-define-tool.rkt
+++ b/tests/test-define-tool.rkt
@@ -5,7 +5,8 @@
 (require rackunit
          racket/string
          "../tools/define-tool.rkt"
-         "../tools/tool.rkt")
+         "../tools/tool.rkt"
+         "../tools/tool-struct.rkt")
 
 ;; ============================================================
 ;; Test 1: Basic tool with properties

--- a/tests/test-gsd-planning.rkt
+++ b/tests/test-gsd-planning.rkt
@@ -28,6 +28,7 @@
                   gsd-success?
                   gsd-failed?)
          "../tools/tool.rkt"
+         "../tools/tool-struct.rkt"
          "../agent/event-bus.rkt"
          "../util/event.rkt"
          (prefix-in events: "../extensions/gsd/events.rkt"))

--- a/tests/test-hooks-complete.rkt
+++ b/tests/test-hooks-complete.rkt
@@ -22,7 +22,6 @@
                   register-tool!
                   tool-name
                   tool-schema
-                  tool-execute
                   tool-call
                   tool-call?
                   make-tool-call
@@ -31,6 +30,7 @@
                   tool-call-arguments
                   make-error-result
                   make-success-result)
+         (only-in "../tools/tool-struct.rkt" tool-execute)
          "../util/ids.rkt"
          (only-in "../llm/provider.rkt" make-mock-provider)
          (only-in "../llm/model.rkt" make-model-response)

--- a/tests/test-macro-expansion.rkt
+++ b/tests/test-macro-expansion.rkt
@@ -11,6 +11,7 @@
                      syntax/parse)
          "../tools/define-tool.rkt"
          "../tools/tool.rkt"
+         "../tools/tool-struct.rkt"
          "../util/event-macro.rkt")
 
 ;; ============================================================
@@ -19,10 +20,10 @@
 
 ;; Test 1: Macro produces tool-id binding
 (define-tool macro-test-tool
-  #:description "Test tool for macro expansion"
-  #:required ("input")
-  #:properties [(input "string" "Test input")]
-  (lambda (args exec-ctx) (make-success-result "ok")))
+             #:description "Test tool for macro expansion"
+             #:required ("input")
+             #:properties [(input "string" "Test input")]
+             (lambda (args exec-ctx) (make-success-result "ok")))
 
 (test-case "define-tool: provides tool-id binding"
   (check-pred procedure? tool-macro-test-tool)
@@ -47,14 +48,13 @@
 ;; define-typed-event expansion tests
 ;; ============================================================
 
-(define-typed-event test-event "test.topic"
-  (field-a)
-  #:optional ([field-b 42]))
+(define-typed-event test-event "test.topic" (field-a) #:optional ([field-b 42]))
 
 (test-case "define-typed-event: struct is defined"
   (check-pred procedure? test-event) ;; constructor is a procedure
   (check-pred test-event? (make-test-event #:session-id "s1" #:turn-id "t1" #:field-a "x"))
-  (check-pred test-event? (make-test-event #:session-id "s1" #:turn-id "t1" #:field-a "x" #:field-b 100)))
+  (check-pred test-event?
+              (make-test-event #:session-id "s1" #:turn-id "t1" #:field-a "x" #:field-b 100)))
 
 (test-case "define-typed-event: default values work"
   (define ev (make-test-event #:session-id "s2" #:turn-id "t2" #:field-a "hello"))
@@ -74,16 +74,16 @@
 ;; ============================================================
 
 (define-tool macro-collide-a
-  #:description "First tool"
-  #:required ()
-  #:properties []
-  (lambda (args exec-ctx) (make-success-result "a")))
+             #:description "First tool"
+             #:required ()
+             #:properties []
+             (lambda (args exec-ctx) (make-success-result "a")))
 
 (define-tool macro-collide-b
-  #:description "Second tool"
-  #:required ()
-  #:properties []
-  (lambda (args exec-ctx) (make-success-result "b")))
+             #:description "Second tool"
+             #:required ()
+             #:properties []
+             (lambda (args exec-ctx) (make-success-result "b")))
 
 (test-case "define-tool: multiple uses don't collide"
   (check-equal? (tool-name macro-collide-a) "macro-collide-a")
@@ -99,26 +99,24 @@
 
 ;; Verify define-typed-event expands to struct + predicate + type
 (test-case "define-typed-event: expansion contains struct definition"
-  (define expanded (expand '(define-typed-event expansion-test-event "expansion.test"
-                             (field-x)
-                             #:optional ([field-y 0]))))
+  (define expanded
+    (expand
+     '(define-typed-event expansion-test-event "expansion.test" (field-x) #:optional ([field-y 0]))))
   (define expanded-str (format "~a" expanded))
-  (check-true (string-contains? expanded-str "struct")
-              "expansion contains 'struct'")
-  (check-true (string-contains? expanded-str "expansion-test-event?")
-              "expansion contains predicate")
+  (check-true (string-contains? expanded-str "struct") "expansion contains 'struct'")
+  (check-true (string-contains? expanded-str "expansion-test-event?") "expansion contains predicate")
   (check-true (string-contains? expanded-str "expansion-test-event-type")
               "expansion contains type constant"))
 
 ;; Verify define-tool expansion contains schema and tool binding
 (test-case "define-tool: expansion contains schema hash and tool binding"
-  (define expanded (expand '(define-tool expansion-test-tool
-                             #:description "Expansion test tool"
-                             #:required ("arg")
-                             #:properties [(arg "string" "An argument")]
-                             (lambda (args exec-ctx) (make-success-result "ok")))))
+  (define expanded
+    (expand '(define-tool expansion-test-tool
+                          #:description "Expansion test tool"
+                          #:required ("arg")
+                          #:properties [(arg "string" "An argument")]
+                          (lambda (args exec-ctx) (make-success-result "ok")))))
   (define expanded-str (format "~a" expanded))
-  (check-true (string-contains? expanded-str "tool")
-              "expansion contains 'tool' struct reference")
+  (check-true (string-contains? expanded-str "tool") "expansion contains 'tool' struct reference")
   (check-true (string-contains? expanded-str "expansion-test-tool")
               "expansion contains tool-id binding"))

--- a/tests/test-registry-defaults.rkt
+++ b/tests/test-registry-defaults.rkt
@@ -2,7 +2,8 @@
 
 (require rackunit
          "../tools/registry-defaults.rkt"
-         "../tools/tool.rkt")
+         "../tools/tool.rkt"
+         "../tools/tool-struct.rkt")
 
 ;; ============================================================
 ;; register-default-tools! — registers all tools

--- a/tests/test-scheduler-safe-mode.rkt
+++ b/tests/test-scheduler-safe-mode.rkt
@@ -13,23 +13,40 @@
 
 (require rackunit
          (only-in "../tools/tool.rkt"
-                  tool? tool-name tool-schema tool-execute
-                  make-tool make-tool-registry make-exec-context
-                  register-tool! lookup-tool
-                  tool-result? tool-result-content
-                  tool-result-details tool-result-is-error?
-                  make-error-result make-success-result)
+                  tool?
+                  tool-name
+                  tool-schema
+                  make-tool
+                  make-tool-registry
+                  make-exec-context
+                  register-tool!
+                  lookup-tool
+                  tool-result?
+                  tool-result-content
+                  tool-result-details
+                  tool-result-is-error?
+                  make-error-result
+                  make-success-result)
+         (only-in "../tools/tool-struct.rkt" tool-execute)
          (only-in "../tools/scheduler.rkt"
-                  run-tool-batch scheduler-result
-                  scheduler-result-results scheduler-result-metadata)
+                  run-tool-batch
+                  scheduler-result
+                  scheduler-result-results
+                  scheduler-result-metadata)
          (only-in "../util/protocol-types.rkt"
-                  tool-call tool-call?
-                  tool-call-id tool-call-name tool-call-arguments)
-         (only-in "../runtime/safe-mode.rkt"
-                  current-safe-mode project-root)
+                  tool-call
+                  tool-call?
+                  tool-call-id
+                  tool-call-name
+                  tool-call-arguments)
+         (only-in "../runtime/safe-mode.rkt" current-safe-mode project-root)
          (only-in "../util/safe-mode-predicates.rkt"
-                  safe-mode? allowed-tool? allowed-path?
-                  safe-mode-project-root trust-level blocked-tools))
+                  safe-mode?
+                  allowed-tool?
+                  allowed-path?
+                  safe-mode-project-root
+                  trust-level
+                  blocked-tools))
 
 ;; ============================================================
 ;; Helper: build a registry with various tool types
@@ -41,119 +58,105 @@
   ;; read tool — allowed in safe mode, takes 'path
   (register-tool!
    reg
-   (make-tool "read"
-              "Read tool"
-              (hasheq 'type "object"
-                      'properties (hasheq 'path (hasheq 'type "string"))
-                      'required '("path"))
-              (lambda (args ctx)
-                (make-success-result
-                 (list (hasheq 'type "text"
-                               'text (format "read: ~a" (hash-ref args 'path))))))))
+   (make-tool
+    "read"
+    "Read tool"
+    (hasheq 'type "object" 'properties (hasheq 'path (hasheq 'type "string")) 'required '("path"))
+    (lambda (args ctx)
+      (make-success-result
+       (list (hasheq 'type "text" 'text (format "read: ~a" (hash-ref args 'path))))))))
 
   ;; ls tool — allowed in safe mode, takes 'path
   (register-tool!
    reg
-   (make-tool "ls"
-              "List tool"
-              (hasheq 'type "object"
-                      'properties (hasheq 'path (hasheq 'type "string"))
-                      'required '("path"))
-              (lambda (args ctx)
-                (make-success-result
-                 (list (hasheq 'type "text"
-                               'text (format "ls: ~a" (hash-ref args 'path))))))))
+   (make-tool
+    "ls"
+    "List tool"
+    (hasheq 'type "object" 'properties (hasheq 'path (hasheq 'type "string")) 'required '("path"))
+    (lambda (args ctx)
+      (make-success-result
+       (list (hasheq 'type "text" 'text (format "ls: ~a" (hash-ref args 'path))))))))
 
   ;; find tool — allowed in safe mode, takes 'path
   (register-tool!
    reg
-   (make-tool "find"
-              "Find tool"
-              (hasheq 'type "object"
-                      'properties (hasheq 'path (hasheq 'type "string"))
-                      'required '("path"))
-              (lambda (args ctx)
-                (make-success-result
-                 (list (hasheq 'type "text"
-                               'text (format "find: ~a" (hash-ref args 'path))))))))
+   (make-tool
+    "find"
+    "Find tool"
+    (hasheq 'type "object" 'properties (hasheq 'path (hasheq 'type "string")) 'required '("path"))
+    (lambda (args ctx)
+      (make-success-result
+       (list (hasheq 'type "text" 'text (format "find: ~a" (hash-ref args 'path))))))))
 
   ;; grep tool — allowed in safe mode, takes 'path
   (register-tool!
    reg
-   (make-tool "grep"
-              "Grep tool"
-              (hasheq 'type "object"
-                      'properties (hasheq 'path (hasheq 'type "string"))
-                      'required '("path"))
-              (lambda (args ctx)
-                (make-success-result
-                 (list (hasheq 'type "text"
-                               'text (format "grep: ~a" (hash-ref args 'path))))))))
+   (make-tool
+    "grep"
+    "Grep tool"
+    (hasheq 'type "object" 'properties (hasheq 'path (hasheq 'type "string")) 'required '("path"))
+    (lambda (args ctx)
+      (make-success-result
+       (list (hasheq 'type "text" 'text (format "grep: ~a" (hash-ref args 'path))))))))
 
   ;; bash tool — BLOCKED in safe mode
   (register-tool!
    reg
    (make-tool "bash"
               "Bash tool"
-              (hasheq 'type "object"
-                      'properties (hasheq 'command (hasheq 'type "string"))
-                      'required '("command"))
+              (hasheq 'type
+                      "object"
+                      'properties
+                      (hasheq 'command (hasheq 'type "string"))
+                      'required
+                      '("command"))
               (lambda (args ctx)
                 (make-success-result
-                 (list (hasheq 'type "text"
-                               'text (format "bash: ~a" (hash-ref args 'command))))))))
+                 (list (hasheq 'type "text" 'text (format "bash: ~a" (hash-ref args 'command))))))))
 
   ;; edit tool — BLOCKED in safe mode, takes 'path
   (register-tool!
    reg
-   (make-tool "edit"
-              "Edit tool"
-              (hasheq 'type "object"
-                      'properties (hasheq 'path (hasheq 'type "string"))
-                      'required '("path"))
-              (lambda (args ctx)
-                (make-success-result
-                 (list (hasheq 'type "text"
-                               'text (format "edit: ~a" (hash-ref args 'path))))))))
+   (make-tool
+    "edit"
+    "Edit tool"
+    (hasheq 'type "object" 'properties (hasheq 'path (hasheq 'type "string")) 'required '("path"))
+    (lambda (args ctx)
+      (make-success-result
+       (list (hasheq 'type "text" 'text (format "edit: ~a" (hash-ref args 'path))))))))
 
   ;; write tool — BLOCKED in safe mode, takes 'path
   (register-tool!
    reg
-   (make-tool "write"
-              "Write tool"
-              (hasheq 'type "object"
-                      'properties (hasheq 'path (hasheq 'type "string"))
-                      'required '("path"))
-              (lambda (args ctx)
-                (make-success-result
-                 (list (hasheq 'type "text"
-                               'text (format "write: ~a" (hash-ref args 'path))))))))
+   (make-tool
+    "write"
+    "Write tool"
+    (hasheq 'type "object" 'properties (hasheq 'path (hasheq 'type "string")) 'required '("path"))
+    (lambda (args ctx)
+      (make-success-result
+       (list (hasheq 'type "text" 'text (format "write: ~a" (hash-ref args 'path))))))))
 
   ;; firecrawl tool — BLOCKED in safe mode
   (register-tool!
    reg
-   (make-tool "firecrawl"
-              "Firecrawl tool"
-              (hasheq 'type "object"
-                      'properties (hasheq 'url (hasheq 'type "string"))
-                      'required '("url"))
-              (lambda (args ctx)
-                (make-success-result
-                 (list (hasheq 'type "text"
-                               'text (format "firecrawl: ~a" (hash-ref args 'url))))))))
+   (make-tool
+    "firecrawl"
+    "Firecrawl tool"
+    (hasheq 'type "object" 'properties (hasheq 'url (hasheq 'type "string")) 'required '("url"))
+    (lambda (args ctx)
+      (make-success-result
+       (list (hasheq 'type "text" 'text (format "firecrawl: ~a" (hash-ref args 'url))))))))
 
   ;; extension:custom tool — BLOCKED in safe mode
   (register-tool!
    reg
-   (make-tool "extension:custom"
-              "Extension custom tool"
-              (hasheq 'type "object"
-                      'properties (hasheq 'path (hasheq 'type "string"))
-                      'required '("path"))
-              (lambda (args ctx)
-                (make-success-result
-                 (list (hasheq 'type "text"
-                               'text (format "ext: ~a" (hash-ref args 'path))))))))
+   (make-tool
+    "extension:custom"
+    "Extension custom tool"
+    (hasheq 'type "object" 'properties (hasheq 'path (hasheq 'type "string")) 'required '("path"))
+    (lambda (args ctx)
+      (make-success-result
+       (list (hasheq 'type "text" 'text (format "ext: ~a" (hash-ref args 'path))))))))
 
   reg)
 
@@ -171,229 +174,224 @@
 ;; 1. Blocked tools are blocked in safe mode
 ;; ============================================================
 
-(test-case
- "bash tool blocked in safe mode"
- (parameterize ([current-safe-mode #t]
-                [project-root test-project-root])
-   (define reg (make-test-registry))
-   (define tcs (list (tool-call "tc-1" "bash" (hasheq 'command "ls"))))
-   (define sr (run-tool-batch tcs reg))
-   (define results (scheduler-result-results sr))
-   (check-equal? (length results) 1)
-   (check-true (tool-result-is-error? (first results)))
-   (check-true (string-contains? (result-text (first results)) "blocked by safe-mode"))))
+(test-case "bash tool blocked in safe mode"
+  (parameterize ([current-safe-mode #t]
+                 [project-root test-project-root])
+    (define reg (make-test-registry))
+    (define tcs (list (tool-call "tc-1" "bash" (hasheq 'command "ls"))))
+    (define sr (run-tool-batch tcs reg))
+    (define results (scheduler-result-results sr))
+    (check-equal? (length results) 1)
+    (check-true (tool-result-is-error? (first results)))
+    (check-true (string-contains? (result-text (first results)) "blocked by safe-mode"))))
 
-(test-case
- "edit tool blocked in safe mode"
- (parameterize ([current-safe-mode #t]
-                [project-root test-project-root])
-   (define reg (make-test-registry))
-   (define tcs (list (tool-call "tc-1" "edit" (hasheq 'path "/tmp/test-scheduler-safe-mode/foo.rkt"))))
-   (define sr (run-tool-batch tcs reg))
-   (check-true (tool-result-is-error? (first (scheduler-result-results sr))))
-   (check-true (string-contains? (result-text (first (scheduler-result-results sr))) "blocked by safe-mode"))))
+(test-case "edit tool blocked in safe mode"
+  (parameterize ([current-safe-mode #t]
+                 [project-root test-project-root])
+    (define reg (make-test-registry))
+    (define tcs
+      (list (tool-call "tc-1" "edit" (hasheq 'path "/tmp/test-scheduler-safe-mode/foo.rkt"))))
+    (define sr (run-tool-batch tcs reg))
+    (check-true (tool-result-is-error? (first (scheduler-result-results sr))))
+    (check-true (string-contains? (result-text (first (scheduler-result-results sr)))
+                                  "blocked by safe-mode"))))
 
-(test-case
- "write tool blocked in safe mode"
- (parameterize ([current-safe-mode #t]
-                [project-root test-project-root])
-   (define reg (make-test-registry))
-   (define tcs (list (tool-call "tc-1" "write" (hasheq 'path "/tmp/test-scheduler-safe-mode/foo.rkt"))))
-   (define sr (run-tool-batch tcs reg))
-   (check-true (tool-result-is-error? (first (scheduler-result-results sr))))
-   (check-true (string-contains? (result-text (first (scheduler-result-results sr))) "blocked by safe-mode"))))
+(test-case "write tool blocked in safe mode"
+  (parameterize ([current-safe-mode #t]
+                 [project-root test-project-root])
+    (define reg (make-test-registry))
+    (define tcs
+      (list (tool-call "tc-1" "write" (hasheq 'path "/tmp/test-scheduler-safe-mode/foo.rkt"))))
+    (define sr (run-tool-batch tcs reg))
+    (check-true (tool-result-is-error? (first (scheduler-result-results sr))))
+    (check-true (string-contains? (result-text (first (scheduler-result-results sr)))
+                                  "blocked by safe-mode"))))
 
-(test-case
- "firecrawl tool blocked in safe mode"
- (parameterize ([current-safe-mode #t]
-                [project-root test-project-root])
-   (define reg (make-test-registry))
-   (define tcs (list (tool-call "tc-1" "firecrawl" (hasheq 'url "https://example.com"))))
-   (define sr (run-tool-batch tcs reg))
-   (check-true (tool-result-is-error? (first (scheduler-result-results sr))))
-   (check-true (string-contains? (result-text (first (scheduler-result-results sr))) "blocked by safe-mode"))))
+(test-case "firecrawl tool blocked in safe mode"
+  (parameterize ([current-safe-mode #t]
+                 [project-root test-project-root])
+    (define reg (make-test-registry))
+    (define tcs (list (tool-call "tc-1" "firecrawl" (hasheq 'url "https://example.com"))))
+    (define sr (run-tool-batch tcs reg))
+    (check-true (tool-result-is-error? (first (scheduler-result-results sr))))
+    (check-true (string-contains? (result-text (first (scheduler-result-results sr)))
+                                  "blocked by safe-mode"))))
 
 ;; ============================================================
 ;; 2. Allowed tools work in safe mode (with path inside root)
 ;; ============================================================
 
-(test-case
- "read tool allowed in safe mode with path inside root"
- (parameterize ([current-safe-mode #t]
-                [project-root test-project-root])
-   (define reg (make-test-registry))
-   (define tcs (list (tool-call "tc-1" "read" (hasheq 'path "/tmp/test-scheduler-safe-mode/src/foo.rkt"))))
-   (define sr (run-tool-batch tcs reg))
-   (check-false (tool-result-is-error? (first (scheduler-result-results sr))))
-   (check-true (string-contains? (result-text (first (scheduler-result-results sr))) "read:"))))
+(test-case "read tool allowed in safe mode with path inside root"
+  (parameterize ([current-safe-mode #t]
+                 [project-root test-project-root])
+    (define reg (make-test-registry))
+    (define tcs
+      (list (tool-call "tc-1" "read" (hasheq 'path "/tmp/test-scheduler-safe-mode/src/foo.rkt"))))
+    (define sr (run-tool-batch tcs reg))
+    (check-false (tool-result-is-error? (first (scheduler-result-results sr))))
+    (check-true (string-contains? (result-text (first (scheduler-result-results sr))) "read:"))))
 
-(test-case
- "ls tool allowed in safe mode"
- (parameterize ([current-safe-mode #t]
-                [project-root test-project-root])
-   (define reg (make-test-registry))
-   (define tcs (list (tool-call "tc-1" "ls" (hasheq 'path "/tmp/test-scheduler-safe-mode/"))))
-   (define sr (run-tool-batch tcs reg))
-   (check-false (tool-result-is-error? (first (scheduler-result-results sr))))))
+(test-case "ls tool allowed in safe mode"
+  (parameterize ([current-safe-mode #t]
+                 [project-root test-project-root])
+    (define reg (make-test-registry))
+    (define tcs (list (tool-call "tc-1" "ls" (hasheq 'path "/tmp/test-scheduler-safe-mode/"))))
+    (define sr (run-tool-batch tcs reg))
+    (check-false (tool-result-is-error? (first (scheduler-result-results sr))))))
 
-(test-case
- "find tool allowed in safe mode"
- (parameterize ([current-safe-mode #t]
-                [project-root test-project-root])
-   (define reg (make-test-registry))
-   (define tcs (list (tool-call "tc-1" "find" (hasheq 'path "/tmp/test-scheduler-safe-mode/"))))
-   (define sr (run-tool-batch tcs reg))
-   (check-false (tool-result-is-error? (first (scheduler-result-results sr))))))
+(test-case "find tool allowed in safe mode"
+  (parameterize ([current-safe-mode #t]
+                 [project-root test-project-root])
+    (define reg (make-test-registry))
+    (define tcs (list (tool-call "tc-1" "find" (hasheq 'path "/tmp/test-scheduler-safe-mode/"))))
+    (define sr (run-tool-batch tcs reg))
+    (check-false (tool-result-is-error? (first (scheduler-result-results sr))))))
 
-(test-case
- "grep tool allowed in safe mode"
- (parameterize ([current-safe-mode #t]
-                [project-root test-project-root])
-   (define reg (make-test-registry))
-   (define tcs (list (tool-call "tc-1" "grep" (hasheq 'path "/tmp/test-scheduler-safe-mode/"))))
-   (define sr (run-tool-batch tcs reg))
-   (check-false (tool-result-is-error? (first (scheduler-result-results sr))))))
+(test-case "grep tool allowed in safe mode"
+  (parameterize ([current-safe-mode #t]
+                 [project-root test-project-root])
+    (define reg (make-test-registry))
+    (define tcs (list (tool-call "tc-1" "grep" (hasheq 'path "/tmp/test-scheduler-safe-mode/"))))
+    (define sr (run-tool-batch tcs reg))
+    (check-false (tool-result-is-error? (first (scheduler-result-results sr))))))
 
 ;; ============================================================
 ;; 3. Path is blocked in safe mode (outside project root)
 ;; ============================================================
 
-(test-case
- "read tool with path outside project root blocked in safe mode"
- (parameterize ([current-safe-mode #t]
-                [project-root test-project-root])
-   (define reg (make-test-registry))
-   (define tcs (list (tool-call "tc-1" "read" (hasheq 'path "/etc/passwd"))))
-   (define sr (run-tool-batch tcs reg))
-   (check-true (tool-result-is-error? (first (scheduler-result-results sr))))
-   (check-true (string-contains? (result-text (first (scheduler-result-results sr))) "Access denied"))
-   (check-true (string-contains? (result-text (first (scheduler-result-results sr))) "outside project root"))))
+(test-case "read tool with path outside project root blocked in safe mode"
+  (parameterize ([current-safe-mode #t]
+                 [project-root test-project-root])
+    (define reg (make-test-registry))
+    (define tcs (list (tool-call "tc-1" "read" (hasheq 'path "/etc/passwd"))))
+    (define sr (run-tool-batch tcs reg))
+    (check-true (tool-result-is-error? (first (scheduler-result-results sr))))
+    (check-true (string-contains? (result-text (first (scheduler-result-results sr)))
+                                  "Access denied"))
+    (check-true (string-contains? (result-text (first (scheduler-result-results sr)))
+                                  "outside project root"))))
 
-(test-case
- "ls tool with path outside project root blocked in safe mode"
- (parameterize ([current-safe-mode #t]
-                [project-root test-project-root])
-   (define reg (make-test-registry))
-   (define tcs (list (tool-call "tc-1" "ls" (hasheq 'path "/etc"))))
-   (define sr (run-tool-batch tcs reg))
-   (check-true (tool-result-is-error? (first (scheduler-result-results sr))))
-   (check-true (string-contains? (result-text (first (scheduler-result-results sr))) "Access denied"))))
+(test-case "ls tool with path outside project root blocked in safe mode"
+  (parameterize ([current-safe-mode #t]
+                 [project-root test-project-root])
+    (define reg (make-test-registry))
+    (define tcs (list (tool-call "tc-1" "ls" (hasheq 'path "/etc"))))
+    (define sr (run-tool-batch tcs reg))
+    (check-true (tool-result-is-error? (first (scheduler-result-results sr))))
+    (check-true (string-contains? (result-text (first (scheduler-result-results sr)))
+                                  "Access denied"))))
 
 ;; ============================================================
 ;; 4. Path is allowed in safe mode (inside project root)
 ;; ============================================================
 
-(test-case
- "read tool with path inside project root allowed in safe mode"
- (parameterize ([current-safe-mode #t]
-                [project-root test-project-root])
-   (define reg (make-test-registry))
-   (define tcs (list (tool-call "tc-1" "read" (hasheq 'path "/tmp/test-scheduler-safe-mode/src/bar.rkt"))))
-   (define sr (run-tool-batch tcs reg))
-   (check-false (tool-result-is-error? (first (scheduler-result-results sr))))))
+(test-case "read tool with path inside project root allowed in safe mode"
+  (parameterize ([current-safe-mode #t]
+                 [project-root test-project-root])
+    (define reg (make-test-registry))
+    (define tcs
+      (list (tool-call "tc-1" "read" (hasheq 'path "/tmp/test-scheduler-safe-mode/src/bar.rkt"))))
+    (define sr (run-tool-batch tcs reg))
+    (check-false (tool-result-is-error? (first (scheduler-result-results sr))))))
 
 ;; ============================================================
 ;; 5. Extension tool blocked in safe mode
 ;; ============================================================
 
-(test-case
- "extension:custom tool blocked in safe mode"
- (parameterize ([current-safe-mode #t]
-                [project-root test-project-root])
-   (define reg (make-test-registry))
-   (define tcs (list (tool-call "tc-1" "extension:custom" (hasheq 'path "/tmp/test-scheduler-safe-mode/foo"))))
-   (define sr (run-tool-batch tcs reg))
-   (check-true (tool-result-is-error? (first (scheduler-result-results sr))))
-   (check-true (string-contains? (result-text (first (scheduler-result-results sr))) "blocked by safe-mode"))))
+(test-case "extension:custom tool blocked in safe mode"
+  (parameterize ([current-safe-mode #t]
+                 [project-root test-project-root])
+    (define reg (make-test-registry))
+    (define tcs
+      (list (tool-call "tc-1" "extension:custom" (hasheq 'path "/tmp/test-scheduler-safe-mode/foo"))))
+    (define sr (run-tool-batch tcs reg))
+    (check-true (tool-result-is-error? (first (scheduler-result-results sr))))
+    (check-true (string-contains? (result-text (first (scheduler-result-results sr)))
+                                  "blocked by safe-mode"))))
 
 ;; ============================================================
 ;; 6. Safe mode inactive — all tools and paths allowed
 ;; ============================================================
 
-(test-case
- "all tools allowed when safe mode inactive"
- (parameterize ([current-safe-mode #f])
-   (define reg (make-test-registry))
-   (define tcs (list (tool-call "tc-1" "bash" (hasheq 'command "ls"))
-                     (tool-call "tc-2" "read" (hasheq 'path "/etc/passwd"))
-                     (tool-call "tc-3" "edit" (hasheq 'path "/tmp/foo"))
-                     (tool-call "tc-4" "firecrawl" (hasheq 'url "https://example.com"))))
-   (define sr (run-tool-batch tcs reg))
-   (define results (scheduler-result-results sr))
-   (for ([r (in-list results)])
-     (check-false (tool-result-is-error? r) "tool should succeed when safe mode off"))))
+(test-case "all tools allowed when safe mode inactive"
+  (parameterize ([current-safe-mode #f])
+    (define reg (make-test-registry))
+    (define tcs
+      (list (tool-call "tc-1" "bash" (hasheq 'command "ls"))
+            (tool-call "tc-2" "read" (hasheq 'path "/etc/passwd"))
+            (tool-call "tc-3" "edit" (hasheq 'path "/tmp/foo"))
+            (tool-call "tc-4" "firecrawl" (hasheq 'url "https://example.com"))))
+    (define sr (run-tool-batch tcs reg))
+    (define results (scheduler-result-results sr))
+    (for ([r (in-list results)])
+      (check-false (tool-result-is-error? r) "tool should succeed when safe mode off"))))
 
 ;; ============================================================
 ;; 7. Multiple tool calls in batch — some blocked, some allowed
 ;; ============================================================
 
-(test-case
- "mixed batch in safe mode: blocked tools and paths produce errors"
- (parameterize ([current-safe-mode #t]
-                [project-root test-project-root])
-   (define reg (make-test-registry))
-   ;; bash → blocked tool, read inside root → ok, read outside root → path blocked,
-   ;; grep inside root → ok, edit → blocked tool
-   (define tcs (list (tool-call "tc-1" "bash" (hasheq 'command "ls"))
-                     (tool-call "tc-2" "read" (hasheq 'path "/tmp/test-scheduler-safe-mode/foo.rkt"))
-                     (tool-call "tc-3" "read" (hasheq 'path "/etc/passwd"))
-                     (tool-call "tc-4" "grep" (hasheq 'path "/tmp/test-scheduler-safe-mode/"))
-                     (tool-call "tc-5" "edit" (hasheq 'path "/tmp/test-scheduler-safe-mode/bar.rkt"))))
-   (define sr (run-tool-batch tcs reg))
-   (define results (scheduler-result-results sr))
-   (check-equal? (length results) 5)
-   ;; tc-1: bash → blocked tool
-   (check-true (tool-result-is-error? (first results)) "bash blocked")
-   (check-true (string-contains? (result-text (first results)) "blocked by safe-mode"))
-   ;; tc-2: read inside root → ok
-   (check-false (tool-result-is-error? (second results)) "read inside root ok")
-   ;; tc-3: read outside root → path blocked
-   (check-true (tool-result-is-error? (third results)) "read outside root blocked")
-   (check-true (string-contains? (result-text (third results)) "Access denied"))
-   ;; tc-4: grep inside root → ok
-   (check-false (tool-result-is-error? (fourth results)) "grep inside root ok")
-   ;; tc-5: edit → blocked tool
-   (check-true (tool-result-is-error? (fifth results)) "edit blocked")
-   (check-true (string-contains? (result-text (fifth results)) "blocked by safe-mode"))
-   ;; Check metadata
-   (define meta (scheduler-result-metadata sr))
-   (check-equal? (hash-ref meta 'total) 5)
-   (check-equal? (hash-ref meta 'blocked) 3)))  ;; bash + path-blocked read + edit
+(test-case "mixed batch in safe mode: blocked tools and paths produce errors"
+  (parameterize ([current-safe-mode #t]
+                 [project-root test-project-root])
+    (define reg (make-test-registry))
+    ;; bash → blocked tool, read inside root → ok, read outside root → path blocked,
+    ;; grep inside root → ok, edit → blocked tool
+    (define tcs
+      (list (tool-call "tc-1" "bash" (hasheq 'command "ls"))
+            (tool-call "tc-2" "read" (hasheq 'path "/tmp/test-scheduler-safe-mode/foo.rkt"))
+            (tool-call "tc-3" "read" (hasheq 'path "/etc/passwd"))
+            (tool-call "tc-4" "grep" (hasheq 'path "/tmp/test-scheduler-safe-mode/"))
+            (tool-call "tc-5" "edit" (hasheq 'path "/tmp/test-scheduler-safe-mode/bar.rkt"))))
+    (define sr (run-tool-batch tcs reg))
+    (define results (scheduler-result-results sr))
+    (check-equal? (length results) 5)
+    ;; tc-1: bash → blocked tool
+    (check-true (tool-result-is-error? (first results)) "bash blocked")
+    (check-true (string-contains? (result-text (first results)) "blocked by safe-mode"))
+    ;; tc-2: read inside root → ok
+    (check-false (tool-result-is-error? (second results)) "read inside root ok")
+    ;; tc-3: read outside root → path blocked
+    (check-true (tool-result-is-error? (third results)) "read outside root blocked")
+    (check-true (string-contains? (result-text (third results)) "Access denied"))
+    ;; tc-4: grep inside root → ok
+    (check-false (tool-result-is-error? (fourth results)) "grep inside root ok")
+    ;; tc-5: edit → blocked tool
+    (check-true (tool-result-is-error? (fifth results)) "edit blocked")
+    (check-true (string-contains? (result-text (fifth results)) "blocked by safe-mode"))
+    ;; Check metadata
+    (define meta (scheduler-result-metadata sr))
+    (check-equal? (hash-ref meta 'total) 5)
+    (check-equal? (hash-ref meta 'blocked) 3))) ;; bash + path-blocked read + edit
 
 ;; ============================================================
 ;; 8. Predicates re-exported correctly from util/safe-mode-predicates
 ;; ============================================================
 
-(test-case
- "safe-mode? predicate works from util import"
- (parameterize ([current-safe-mode #t])
-   (check-true (safe-mode?)))
- (parameterize ([current-safe-mode #f])
-   (check-false (safe-mode?))))
+(test-case "safe-mode? predicate works from util import"
+  (parameterize ([current-safe-mode #t])
+    (check-true (safe-mode?)))
+  (parameterize ([current-safe-mode #f])
+    (check-false (safe-mode?))))
 
-(test-case
- "allowed-tool? predicate works from util import"
- (parameterize ([current-safe-mode #t])
-   (check-false (allowed-tool? "bash"))
-   (check-true (allowed-tool? "read"))))
+(test-case "allowed-tool? predicate works from util import"
+  (parameterize ([current-safe-mode #t])
+    (check-false (allowed-tool? "bash"))
+    (check-true (allowed-tool? "read"))))
 
-(test-case
- "allowed-path? predicate works from util import"
- (parameterize ([current-safe-mode #t]
-                [project-root test-project-root])
-   (check-false (allowed-path? "/etc/passwd"))
-   (check-true (allowed-path? "/tmp/test-scheduler-safe-mode/foo.rkt"))))
+(test-case "allowed-path? predicate works from util import"
+  (parameterize ([current-safe-mode #t]
+                 [project-root test-project-root])
+    (check-false (allowed-path? "/etc/passwd"))
+    (check-true (allowed-path? "/tmp/test-scheduler-safe-mode/foo.rkt"))))
 
-(test-case
- "blocked-tools constant available"
- (check-equal? blocked-tools '("bash" "edit" "write" "firecrawl")))
+(test-case "blocked-tools constant available"
+  (check-equal? blocked-tools '("bash" "edit" "write" "firecrawl")))
 
-(test-case
- "trust-level predicate works from util import"
- (parameterize ([current-safe-mode #t])
-   (check-equal? (trust-level) 'restricted))
- (parameterize ([current-safe-mode #f])
-   (check-equal? (trust-level) 'full)))
+(test-case "trust-level predicate works from util import"
+  (parameterize ([current-safe-mode #t])
+    (check-equal? (trust-level) 'restricted))
+  (parameterize ([current-safe-mode #f])
+    (check-equal? (trust-level) 'full)))
 
 ;; ============================================================
 ;; Summary

--- a/tests/test-scheduler.rkt
+++ b/tests/test-scheduler.rkt
@@ -19,7 +19,6 @@
                   tool?
                   tool-name
                   tool-schema
-                  tool-execute
                   make-tool
                   make-tool-registry
                   make-exec-context
@@ -33,6 +32,7 @@
                   tool-result-is-error?
                   make-error-result
                   make-success-result)
+         (only-in "../tools/tool-struct.rkt" tool-execute)
          (only-in "../tools/scheduler.rkt"
                   run-tool-batch
                   scheduler-result
@@ -492,12 +492,9 @@
   (register-tool! reg
                   (make-tool "thread-recorder"
                              "Records threads for testing"
-                             (hasheq 'type 'object
-                                     'properties (hasheq)
-                                     'required '())
+                             (hasheq 'type 'object 'properties (hasheq) 'required '())
                              (lambda (args exec-ctx)
-                               (set-box! threads-seen
-                                         (cons (current-thread) (unbox threads-seen)))
+                               (set-box! threads-seen (cons (current-thread) (unbox threads-seen)))
                                (sleep 0.05) ; small delay to force contention
                                (make-success-result (list (hasheq 'text "ok")) (hasheq)))))
   ;; Run 6 parallel tool calls with max 2 — should not exceed 2 concurrent threads

--- a/tests/test-tool-properties.rkt
+++ b/tests/test-tool-properties.rkt
@@ -18,230 +18,237 @@
 
 (require rackunit
          rackunit/text-ui
-         "../tools/tool.rkt")
+         "../tools/tool.rkt"
+         "../tools/tool-struct.rkt")
 
 ;; ── Helpers ──────────────────────────────────────────────────
 
 (define (simple-schema [required '()])
-  (hasheq 'type "object"
-          'properties (hasheq 'path (hasheq 'type "string")
-                              'count (hasheq 'type "integer"))
-          'required required))
+  (hasheq 'type
+          "object"
+          'properties
+          (hasheq 'path (hasheq 'type "string") 'count (hasheq 'type "integer"))
+          'required
+          required))
 
 (define (make-dummy-tool [name "test_tool"])
   (make-tool name
              "A test tool"
              (simple-schema '("path"))
-             (lambda (args ctx)
-               (make-success-result '()))))
+             (lambda (args ctx) (make-success-result '()))))
 
 ;; ── Test Suite ───────────────────────────────────────────────
 
 (define test-tool-properties
-  (test-suite
-   "Tool Contract Property Tests"
+  (test-suite "Tool Contract Property Tests"
 
-   ;; 1 ────────────────────────────────────────────────────────
-   (test-case "tool-make-roundtrip"
-     (define schema (hasheq 'type "object"
-                            'properties (hasheq 'x (hasheq 'type "integer"))
-                            'required '("x")))
-     (define exec (lambda (args ctx) 'done))
-     (define t (make-tool "roundtrip_tool" "roundtrip desc" schema exec))
-     (check-equal? (tool-name t) "roundtrip_tool")
-     (check-equal? (tool-description t) "roundtrip desc")
-     (check-equal? (tool-schema t) schema)
-     (check-equal? (tool-execute t) exec)
-     (check-true (tool? t)))
+    ;; 1 ────────────────────────────────────────────────────────
+    (test-case "tool-make-roundtrip"
+      (define schema
+        (hasheq 'type "object" 'properties (hasheq 'x (hasheq 'type "integer")) 'required '("x")))
+      (define exec (lambda (args ctx) 'done))
+      (define t (make-tool "roundtrip_tool" "roundtrip desc" schema exec))
+      (check-equal? (tool-name t) "roundtrip_tool")
+      (check-equal? (tool-description t) "roundtrip desc")
+      (check-equal? (tool-schema t) schema)
+      (check-equal? (tool-execute t) exec)
+      (check-true (tool? t)))
 
-   ;; 2 ────────────────────────────────────────────────────────
-   (test-case "tool-registry-register-lookup"
-     (define reg (make-tool-registry))
-     (define t1 (make-dummy-tool "lookup_a"))
-     (define t2 (make-dummy-tool "lookup_b"))
-     (register-tool! reg t1)
-     (register-tool! reg t2)
-     (check-equal? (tool-name (lookup-tool reg "lookup_a")) "lookup_a")
-     (check-equal? (tool-name (lookup-tool reg "lookup_b")) "lookup_b")
-     ;; Unknown tool → #f
-     (check-false (lookup-tool reg "nonexistent")))
+    ;; 2 ────────────────────────────────────────────────────────
+    (test-case "tool-registry-register-lookup"
+      (define reg (make-tool-registry))
+      (define t1 (make-dummy-tool "lookup_a"))
+      (define t2 (make-dummy-tool "lookup_b"))
+      (register-tool! reg t1)
+      (register-tool! reg t2)
+      (check-equal? (tool-name (lookup-tool reg "lookup_a")) "lookup_a")
+      (check-equal? (tool-name (lookup-tool reg "lookup_b")) "lookup_b")
+      ;; Unknown tool → #f
+      (check-false (lookup-tool reg "nonexistent")))
 
-   ;; 3 ────────────────────────────────────────────────────────
-   (test-case "tool-registry-list"
-     (define reg (make-tool-registry))
-     (define t1 (make-dummy-tool "list_a"))
-     (define t2 (make-dummy-tool "list_b"))
-     (define t3 (make-dummy-tool "list_c"))
-     (register-tool! reg t1)
-     (register-tool! reg t2)
-     (register-tool! reg t3)
-     (define names (sort (map tool-name (list-tools reg)) string<?))
-     (check-equal? names '("list_a" "list_b" "list_c")))
+    ;; 3 ────────────────────────────────────────────────────────
+    (test-case "tool-registry-list"
+      (define reg (make-tool-registry))
+      (define t1 (make-dummy-tool "list_a"))
+      (define t2 (make-dummy-tool "list_b"))
+      (define t3 (make-dummy-tool "list_c"))
+      (register-tool! reg t1)
+      (register-tool! reg t2)
+      (register-tool! reg t3)
+      (define names (sort (map tool-name (list-tools reg)) string<?))
+      (check-equal? names '("list_a" "list_b" "list_c")))
 
-   ;; 4 ────────────────────────────────────────────────────────
-   (test-case "tool-validation-valid-args"
-     (define t (make-tool "v" "v"
-                          (hasheq 'type "object"
-                                  'properties (hasheq 'name (hasheq 'type "string")
-                                                      'age  (hasheq 'type "integer"))
-                                  'required '("name"))
-                          void))
-     ;; All correct
-     (check-true (validate-tool-args t (hasheq 'name "Alice" 'age 30)))
-     ;; Optional field omitted
-     (check-true (validate-tool-args t (hasheq 'name "Bob")))
-     ;; Extra field is fine
-     (check-true (validate-tool-args t (hasheq 'name "Eve" 'extra 'ok))))
+    ;; 4 ────────────────────────────────────────────────────────
+    (test-case "tool-validation-valid-args"
+      (define t
+        (make-tool "v"
+                   "v"
+                   (hasheq 'type
+                           "object"
+                           'properties
+                           (hasheq 'name (hasheq 'type "string") 'age (hasheq 'type "integer"))
+                           'required
+                           '("name"))
+                   void))
+      ;; All correct
+      (check-true (validate-tool-args t (hasheq 'name "Alice" 'age 30)))
+      ;; Optional field omitted
+      (check-true (validate-tool-args t (hasheq 'name "Bob")))
+      ;; Extra field is fine
+      (check-true (validate-tool-args t (hasheq 'name "Eve" 'extra 'ok))))
 
-   ;; 5 ────────────────────────────────────────────────────────
-   (test-case "tool-validation-invalid-args"
-     (define t (make-tool "iv" "iv"
-                          (hasheq 'type "object"
-                                  'properties (hasheq 'path  (hasheq 'type "string")
-                                                      'count (hasheq 'type "integer"))
-                                  'required '("path"))
-                          void))
-     ;; path expects string, got integer
-     (check-exn exn:fail?
-                (lambda () (validate-tool-args t (hasheq 'path 42 'count 1))))
-     ;; count expects integer, got string
-     (check-exn exn:fail?
-                (lambda () (validate-tool-args t (hasheq 'path "/x" 'count "five"))))
-     ;; boolean where string expected
-     (check-exn exn:fail?
-                (lambda () (validate-tool-args t (hasheq 'path #t)))))
+    ;; 5 ────────────────────────────────────────────────────────
+    (test-case "tool-validation-invalid-args"
+      (define t
+        (make-tool "iv"
+                   "iv"
+                   (hasheq 'type
+                           "object"
+                           'properties
+                           (hasheq 'path (hasheq 'type "string") 'count (hasheq 'type "integer"))
+                           'required
+                           '("path"))
+                   void))
+      ;; path expects string, got integer
+      (check-exn exn:fail? (lambda () (validate-tool-args t (hasheq 'path 42 'count 1))))
+      ;; count expects integer, got string
+      (check-exn exn:fail? (lambda () (validate-tool-args t (hasheq 'path "/x" 'count "five"))))
+      ;; boolean where string expected
+      (check-exn exn:fail? (lambda () (validate-tool-args t (hasheq 'path #t)))))
 
-   ;; 6 ────────────────────────────────────────────────────────
-   (test-case "tool-validation-missing-required"
-     (define t (make-tool "mr" "mr"
-                          (hasheq 'type "object"
-                                  'properties (hasheq 'a (hasheq 'type "string")
-                                                      'b (hasheq 'type "integer"))
-                                  'required '("a" "b"))
-                          void))
-     ;; Both missing
-     (check-exn exn:fail?
-                (lambda () (validate-tool-args t (hasheq))))
-     ;; One missing
-     (check-exn exn:fail?
-                (lambda () (validate-tool-args t (hasheq 'a "ok"))))
-     ;; Both present → passes
-     (check-true (validate-tool-args t (hasheq 'a "ok" 'b 1))))
+    ;; 6 ────────────────────────────────────────────────────────
+    (test-case "tool-validation-missing-required"
+      (define t
+        (make-tool "mr"
+                   "mr"
+                   (hasheq 'type
+                           "object"
+                           'properties
+                           (hasheq 'a (hasheq 'type "string") 'b (hasheq 'type "integer"))
+                           'required
+                           '("a" "b"))
+                   void))
+      ;; Both missing
+      (check-exn exn:fail? (lambda () (validate-tool-args t (hasheq))))
+      ;; One missing
+      (check-exn exn:fail? (lambda () (validate-tool-args t (hasheq 'a "ok"))))
+      ;; Both present → passes
+      (check-true (validate-tool-args t (hasheq 'a "ok" 'b 1))))
 
-   ;; 7 ────────────────────────────────────────────────────────
-   (test-case "tool-result-success"
-     (define content (list (hasheq 'type "text" 'text "all good")))
-     (define r (make-success-result content))
-     (check-true  (tool-result? r))
-     (check-false (tool-result-is-error? r))
-     (check-equal? (tool-result-content r) content)
-     (check-equal? (tool-result-details r) (hasheq))
-     ;; With explicit details
-     (define r2 (make-success-result content (hasheq 'bytesRead 99)))
-     (check-equal? (tool-result-details r2) (hasheq 'bytesRead 99))
-     (check-false (tool-result-is-error? r2)))
+    ;; 7 ────────────────────────────────────────────────────────
+    (test-case "tool-result-success"
+      (define content (list (hasheq 'type "text" 'text "all good")))
+      (define r (make-success-result content))
+      (check-true (tool-result? r))
+      (check-false (tool-result-is-error? r))
+      (check-equal? (tool-result-content r) content)
+      (check-equal? (tool-result-details r) (hasheq))
+      ;; With explicit details
+      (define r2 (make-success-result content (hasheq 'bytesRead 99)))
+      (check-equal? (tool-result-details r2) (hasheq 'bytesRead 99))
+      (check-false (tool-result-is-error? r2)))
 
-   ;; 8 ────────────────────────────────────────────────────────
-   (test-case "tool-result-error"
-     (define r (make-error-result "something failed"))
-     (check-true  (tool-result? r))
-     (check-true  (tool-result-is-error? r))
-     ;; Error content is a non-empty list containing the message
-     (check-true (and (list? (tool-result-content r))
-                      (positive? (length (tool-result-content r)))))
-     (define text-entry (list-ref (tool-result-content r) 0))
-     (check-equal? (hash-ref text-entry 'type) "text")
-     (check-equal? (hash-ref text-entry 'text) "something failed"))
+    ;; 8 ────────────────────────────────────────────────────────
+    (test-case "tool-result-error"
+      (define r (make-error-result "something failed"))
+      (check-true (tool-result? r))
+      (check-true (tool-result-is-error? r))
+      ;; Error content is a non-empty list containing the message
+      (check-true (and (list? (tool-result-content r)) (positive? (length (tool-result-content r)))))
+      (define text-entry (list-ref (tool-result-content r) 0))
+      (check-equal? (hash-ref text-entry 'type) "text")
+      (check-equal? (hash-ref text-entry 'text) "something failed"))
 
-   ;; 9 ────────────────────────────────────────────────────────
-   (test-case "tool-call-idempotent"
-     (define args (hasheq 'path "/tmp/x" 'line 10))
-     (define c1 (make-tool-call "id-42" "read" args))
-     (define c2 (make-tool-call "id-42" "read" args))
-     (check-equal? (tool-call-id c1)        (tool-call-id c2))
-     (check-equal? (tool-call-name c1)      (tool-call-name c2))
-     (check-equal? (tool-call-arguments c1) (tool-call-arguments c2))
-     (check-pred tool-call? c1)
-     (check-true (tool-call? c2)))
+    ;; 9 ────────────────────────────────────────────────────────
+    (test-case "tool-call-idempotent"
+      (define args (hasheq 'path "/tmp/x" 'line 10))
+      (define c1 (make-tool-call "id-42" "read" args))
+      (define c2 (make-tool-call "id-42" "read" args))
+      (check-equal? (tool-call-id c1) (tool-call-id c2))
+      (check-equal? (tool-call-name c1) (tool-call-name c2))
+      (check-equal? (tool-call-arguments c1) (tool-call-arguments c2))
+      (check-pred tool-call? c1)
+      (check-true (tool-call? c2)))
 
-   ;; 10 ───────────────────────────────────────────────────────
-   (test-case "exec-context-default"
-     (define ctx (make-exec-context))
-     (check-pred exec-context? ctx)
-     (check-true (path-string? (exec-context-working-directory ctx)))
-     (check-false (exec-context-cancellation-token ctx))
-     (check-false (exec-context-event-publisher ctx))
-     (check-false (exec-context-runtime-settings ctx))
-     (check-equal? (exec-context-call-id ctx) "")
-     (check-false (exec-context-session-metadata ctx)))
+    ;; 10 ───────────────────────────────────────────────────────
+    (test-case "exec-context-default"
+      (define ctx (make-exec-context))
+      (check-pred exec-context? ctx)
+      (check-true (path-string? (exec-context-working-directory ctx)))
+      (check-false (exec-context-cancellation-token ctx))
+      (check-false (exec-context-event-publisher ctx))
+      (check-false (exec-context-runtime-settings ctx))
+      (check-equal? (exec-context-call-id ctx) "")
+      (check-false (exec-context-session-metadata ctx)))
 
-   ;; 11 ───────────────────────────────────────────────────────
-   (test-case "registry-unregister"
-     (define reg (make-tool-registry))
-     (define t1 (make-dummy-tool "unreg_a"))
-     (define t2 (make-dummy-tool "unreg_b"))
-     (register-tool! reg t1)
-     (register-tool! reg t2)
-     (check-equal? (length (list-tools reg)) 2)
-     (unregister-tool! reg "unreg_a")
-     ;; t1 is gone
-     (check-false (lookup-tool reg "unreg_a"))
-     ;; t2 remains
-     (check-equal? (tool-name (lookup-tool reg "unreg_b")) "unreg_b")
-     ;; list-tools no longer contains unreg_a
-     (check-equal? (length (list-tools reg)) 1)
-     ;; unregister non-existent is a no-op
-     (unregister-tool! reg "no_such_tool")
-     (check-equal? (length (list-tools reg)) 1))
+    ;; 11 ───────────────────────────────────────────────────────
+    (test-case "registry-unregister"
+      (define reg (make-tool-registry))
+      (define t1 (make-dummy-tool "unreg_a"))
+      (define t2 (make-dummy-tool "unreg_b"))
+      (register-tool! reg t1)
+      (register-tool! reg t2)
+      (check-equal? (length (list-tools reg)) 2)
+      (unregister-tool! reg "unreg_a")
+      ;; t1 is gone
+      (check-false (lookup-tool reg "unreg_a"))
+      ;; t2 remains
+      (check-equal? (tool-name (lookup-tool reg "unreg_b")) "unreg_b")
+      ;; list-tools no longer contains unreg_a
+      (check-equal? (length (list-tools reg)) 1)
+      ;; unregister non-existent is a no-op
+      (unregister-tool! reg "no_such_tool")
+      (check-equal? (length (list-tools reg)) 1))
 
-   ;; 12 ───────────────────────────────────────────────────────
-   (test-case "schema-validation-complex"
-     ;; Nested object: config.nested.deep must be integer,
-     ;; config.nested.flag must be boolean, items must be array
-     (define nested-schema
-       (hasheq 'type "object"
-               'properties
-               (hasheq 'config (hasheq 'type "object"
-                                       'properties
-                                       (hasheq 'nested (hasheq 'type "object"
-                                                               'properties
-                                                               (hasheq 'deep (hasheq 'type "integer")
-                                                                       'flag (hasheq 'type "boolean")))))
-                       'items (hasheq 'type "array")
-                       'name  (hasheq 'type "string"))
-               'required '("name")))
-     (define ct (make-tool "complex" "complex tool" nested-schema void))
+    ;; 12 ───────────────────────────────────────────────────────
+    (test-case "schema-validation-complex"
+      ;; Nested object: config.nested.deep must be integer,
+      ;; config.nested.flag must be boolean, items must be array
+      (define nested-schema
+        (hasheq 'type
+                "object"
+                'properties
+                (hasheq 'config
+                        (hasheq 'type
+                                "object"
+                                'properties
+                                (hasheq 'nested
+                                        (hasheq 'type
+                                                "object"
+                                                'properties
+                                                (hasheq 'deep
+                                                        (hasheq 'type "integer")
+                                                        'flag
+                                                        (hasheq 'type "boolean")))))
+                        'items
+                        (hasheq 'type "array")
+                        'name
+                        (hasheq 'type "string"))
+                'required
+                '("name")))
+      (define ct (make-tool "complex" "complex tool" nested-schema void))
 
-     ;; Valid nested args
-     (check-true
-      (validate-tool-args ct
-                          (hasheq 'name   "test"
-                                  'config (hasheq 'nested (hasheq 'deep 42 'flag #t))
-                                  'items  (list "a" "b" "c"))))
+      ;; Valid nested args
+      (check-true (validate-tool-args ct
+                                      (hasheq 'name
+                                              "test"
+                                              'config
+                                              (hasheq 'nested (hasheq 'deep 42 'flag #t))
+                                              'items
+                                              (list "a" "b" "c"))))
 
-     ;; Missing top-level required 'name'
-     (check-exn exn:fail?
-                (lambda ()
-                  (validate-tool-args ct
-                                      (hasheq 'config (hasheq) 'items '()))))
+      ;; Missing top-level required 'name'
+      (check-exn exn:fail? (lambda () (validate-tool-args ct (hasheq 'config (hasheq) 'items '()))))
 
-     ;; Wrong type for items (should be array, got integer)
-     (check-exn exn:fail?
-                (lambda ()
-                  (validate-tool-args ct
-                                      (hasheq 'name "ok" 'items 99))))
+      ;; Wrong type for items (should be array, got integer)
+      (check-exn exn:fail? (lambda () (validate-tool-args ct (hasheq 'name "ok" 'items 99))))
 
-     ;; config is not an object (should be hash)
-     (check-exn exn:fail?
-                (lambda ()
-                  (validate-tool-args ct
-                                      (hasheq 'name "ok" 'config "not-an-object"))))
+      ;; config is not an object (should be hash)
+      (check-exn exn:fail?
+                 (lambda () (validate-tool-args ct (hasheq 'name "ok" 'config "not-an-object"))))
 
-     ;; Optional nested fields omitted → still valid
-     (check-true
-      (validate-tool-args ct (hasheq 'name "minimal"))))
-
-   )) ;; end test-suite
+      ;; Optional nested fields omitted → still valid
+      (check-true (validate-tool-args ct (hasheq 'name "minimal")))))) ;; end test-suite
 
 ;; ── Run ──────────────────────────────────────────────────────
 

--- a/tests/test-tool-registry.rkt
+++ b/tests/test-tool-registry.rkt
@@ -15,6 +15,7 @@
          rackunit/text-ui
          racket/runtime-path
          "../tools/tool.rkt"
+         "../tools/tool-struct.rkt"
          "../tools/registry-defaults.rkt")
 
 (define-runtime-path here ".")
@@ -25,383 +26,378 @@
 ;; ============================================================
 
 (define sample-schema
-  (hasheq 'type "object"
-          'properties (hasheq 'path (hasheq 'type "string")
-                              'line (hasheq 'type "integer"))
-          'required '("path")))
+  (hasheq 'type
+          "object"
+          'properties
+          (hasheq 'path (hasheq 'type "string") 'line (hasheq 'type "integer"))
+          'required
+          '("path")))
 
 (define sample-execute
-  (lambda (args ctx)
-    (make-success-result (list (hasheq 'type "text" 'text "ok")))))
+  (lambda (args ctx) (make-success-result (list (hasheq 'type "text" 'text "ok")))))
 
-(define t (make-tool "read_file"
-                     "Read a file"
-                     sample-schema
-                     sample-execute))
+(define t (make-tool "read_file" "Read a file" sample-schema sample-execute))
 
 (define tool-reg-tests
-  (test-suite
-   "Tool Registry"
+  (test-suite "Tool Registry"
 
-   ;; ============================================================
-   ;; 1. Tool struct & helpers
-   ;; ============================================================
+    ;; ============================================================
+    ;; 1. Tool struct & helpers
+    ;; ============================================================
 
-   (test-case "make-tool is a constructor procedure"
-     (check-true (procedure? make-tool)))
+    (test-case "make-tool is a constructor procedure"
+      (check-true (procedure? make-tool)))
 
-   (test-case "make-tool produces a tool with correct fields"
-     (check-pred tool? t)
-     (check-equal? (tool-name t) "read_file")
-     (check-equal? (tool-description t) "Read a file")
-     (check-equal? (tool-schema t) sample-schema)
-     (check-true (procedure? (tool-execute t))))
+    (test-case "make-tool produces a tool with correct fields"
+      (check-pred tool? t)
+      (check-equal? (tool-name t) "read_file")
+      (check-equal? (tool-description t) "Read a file")
+      (check-equal? (tool-schema t) sample-schema)
+      (check-true (procedure? (tool-execute t))))
 
-   (test-case "make-tool rejects non-string name"
-     (check-exn exn:fail?
-                (lambda () (make-tool 123 "desc" (hasheq) void))))
+    (test-case "make-tool rejects non-string name"
+      (check-exn exn:fail? (lambda () (make-tool 123 "desc" (hasheq) void))))
 
-   (test-case "make-tool rejects non-string description"
-     (check-exn exn:fail?
-                (lambda () (make-tool "x" 456 (hasheq) void))))
+    (test-case "make-tool rejects non-string description"
+      (check-exn exn:fail? (lambda () (make-tool "x" 456 (hasheq) void))))
 
-   (test-case "make-tool rejects non-hash schema"
-     (check-exn exn:fail?
-                (lambda () (make-tool "x" "d" "not-a-hash" void))))
+    (test-case "make-tool rejects non-hash schema"
+      (check-exn exn:fail? (lambda () (make-tool "x" "d" "not-a-hash" void))))
 
-   (test-case "make-tool rejects non-procedure execute"
-     (check-exn exn:fail?
-                (lambda () (make-tool "x" "d" (hasheq) "not-a-proc"))))
+    (test-case "make-tool rejects non-procedure execute"
+      (check-exn exn:fail? (lambda () (make-tool "x" "d" (hasheq) "not-a-proc"))))
 
-   ;; ============================================================
-   ;; 2. Tool result struct
-   ;; ============================================================
+    ;; ============================================================
+    ;; 2. Tool result struct
+    ;; ============================================================
 
-   (test-case "make-tool-result is a constructor procedure"
-     (check-true (procedure? make-tool-result)))
+    (test-case "make-tool-result is a constructor procedure"
+      (check-true (procedure? make-tool-result)))
 
-   (test-case "make-tool-result produces correct fields"
-     (define tr (make-tool-result
-                 (list (hasheq 'type "text" 'text "hello"))
-                 (hasheq 'bytesRead 42)
-                 #f))
-     (check-pred tool-result? tr)
-     (check-equal? (tool-result-content tr)
-                   (list (hasheq 'type "text" 'text "hello")))
-     (check-equal? (tool-result-details tr) (hasheq 'bytesRead 42))
-     (check-false (tool-result-is-error? tr)))
+    (test-case "make-tool-result produces correct fields"
+      (define tr
+        (make-tool-result (list (hasheq 'type "text" 'text "hello")) (hasheq 'bytesRead 42) #f))
+      (check-pred tool-result? tr)
+      (check-equal? (tool-result-content tr) (list (hasheq 'type "text" 'text "hello")))
+      (check-equal? (tool-result-details tr) (hasheq 'bytesRead 42))
+      (check-false (tool-result-is-error? tr)))
 
-   ;; ============================================================
-   ;; 2a. make-error-result / make-success-result helpers
-   ;; ============================================================
+    ;; ============================================================
+    ;; 2a. make-error-result / make-success-result helpers
+    ;; ============================================================
 
-   (test-case "make-error-result produces an error tool-result"
-     (define err (make-error-result "something went wrong"))
-     (check-pred tool-result? err)
-     (check-pred tool-result-is-error? err)
-     (check-true (and (list? (tool-result-content err))
-                      (positive? (length (tool-result-content err))))))
+    (test-case "make-error-result produces an error tool-result"
+      (define err (make-error-result "something went wrong"))
+      (check-pred tool-result? err)
+      (check-pred tool-result-is-error? err)
+      (check-true (and (list? (tool-result-content err))
+                       (positive? (length (tool-result-content err))))))
 
-   (test-case "make-success-result produces a non-error result with empty details"
-     (define ok (make-success-result (list (hasheq 'type "text" 'text "done"))))
-     (check-pred tool-result? ok)
-     (check-false (tool-result-is-error? ok))
-     (check-equal? (tool-result-details ok) (hasheq)))
+    (test-case "make-success-result produces a non-error result with empty details"
+      (define ok (make-success-result (list (hasheq 'type "text" 'text "done"))))
+      (check-pred tool-result? ok)
+      (check-false (tool-result-is-error? ok))
+      (check-equal? (tool-result-details ok) (hasheq)))
 
-   (test-case "make-success-result accepts custom details"
-     (define ok2 (make-success-result (list (hasheq 'type "text" 'text "done"))
-                                       (hasheq 'lines 10)))
-     (check-equal? (tool-result-details ok2) (hasheq 'lines 10)))
+    (test-case "make-success-result accepts custom details"
+      (define ok2 (make-success-result (list (hasheq 'type "text" 'text "done")) (hasheq 'lines 10)))
+      (check-equal? (tool-result-details ok2) (hasheq 'lines 10)))
 
-   ;; ============================================================
-   ;; 2b. JSON serialization for tool results
-   ;; ============================================================
+    ;; ============================================================
+    ;; 2b. JSON serialization for tool results
+    ;; ============================================================
 
-   (test-case "tool-result->jsexpr produces a hash with correct keys"
-     (define tr-for-json (make-tool-result
-                          (list (hasheq 'type "text" 'text "file contents here"))
+    (test-case "tool-result->jsexpr produces a hash with correct keys"
+      (define tr-for-json
+        (make-tool-result (list (hasheq 'type "text" 'text "file contents here"))
                           (hasheq 'path "/tmp/x.txt" 'lines 5)
                           #f))
-     (define tr-jsexpr (tool-result->jsexpr tr-for-json))
-     (check-pred hash? tr-jsexpr)
-     (check-equal? (hash-ref tr-jsexpr 'isError) #f)
-     (check-true (list? (hash-ref tr-jsexpr 'content)))
-     (check-true (hash? (hash-ref tr-jsexpr 'details))))
+      (define tr-jsexpr (tool-result->jsexpr tr-for-json))
+      (check-pred hash? tr-jsexpr)
+      (check-equal? (hash-ref tr-jsexpr 'isError) #f)
+      (check-true (list? (hash-ref tr-jsexpr 'content)))
+      (check-true (hash? (hash-ref tr-jsexpr 'details))))
 
-   (test-case "tool-result JSON round-trip preserves data"
-     (define tr-for-json (make-tool-result
-                          (list (hasheq 'type "text" 'text "file contents here"))
+    (test-case "tool-result JSON round-trip preserves data"
+      (define tr-for-json
+        (make-tool-result (list (hasheq 'type "text" 'text "file contents here"))
                           (hasheq 'path "/tmp/x.txt" 'lines 5)
                           #f))
-     (define tr-jsexpr (tool-result->jsexpr tr-for-json))
-     (define tr-round (jsexpr->tool-result tr-jsexpr))
-     (check-pred tool-result? tr-round)
-     (check-equal? (tool-result-is-error? tr-round) (tool-result-is-error? tr-for-json))
-     (check-equal? (hash-ref (list-ref (tool-result-content tr-round) 0) 'text)
-                   "file contents here")
-     (check-equal? (hash-ref (tool-result-details tr-round) 'path) "/tmp/x.txt"))
+      (define tr-jsexpr (tool-result->jsexpr tr-for-json))
+      (define tr-round (jsexpr->tool-result tr-jsexpr))
+      (check-pred tool-result? tr-round)
+      (check-equal? (tool-result-is-error? tr-round) (tool-result-is-error? tr-for-json))
+      (check-equal? (hash-ref (list-ref (tool-result-content tr-round) 0) 'text) "file contents here")
+      (check-equal? (hash-ref (tool-result-details tr-round) 'path) "/tmp/x.txt"))
 
-   (test-case "error result JSON round-trip preserves isError flag"
-     (define err-json (tool-result->jsexpr (make-error-result "oops")))
-     (check-equal? (hash-ref err-json 'isError) #t)
-     (define err-round (jsexpr->tool-result err-json))
-     (check-true (tool-result-is-error? err-round)))
+    (test-case "error result JSON round-trip preserves isError flag"
+      (define err-json (tool-result->jsexpr (make-error-result "oops")))
+      (check-equal? (hash-ref err-json 'isError) #t)
+      (define err-round (jsexpr->tool-result err-json))
+      (check-true (tool-result-is-error? err-round)))
 
-   ;; ============================================================
-   ;; 3. Execution context
-   ;; ============================================================
+    ;; ============================================================
+    ;; 3. Execution context
+    ;; ============================================================
 
-   (test-case "make-exec-context is a constructor procedure"
-     (check-true (procedure? make-exec-context)))
+    (test-case "make-exec-context is a constructor procedure"
+      (check-true (procedure? make-exec-context)))
 
-   (test-case "exec-context with required fields only"
-     (define ctx (make-exec-context
-                  #:working-directory "/tmp/project"
-                  #:call-id "call-123"))
-     (check-pred exec-context? ctx)
-     (check-equal? (exec-context-working-directory ctx) "/tmp/project")
-     (check-equal? (exec-context-call-id ctx) "call-123")
-     (check-false (exec-context-cancellation-token ctx))
-     (check-false (exec-context-event-publisher ctx))
-     (check-false (exec-context-runtime-settings ctx))
-     (check-false (exec-context-session-metadata ctx)))
+    (test-case "exec-context with required fields only"
+      (define ctx (make-exec-context #:working-directory "/tmp/project" #:call-id "call-123"))
+      (check-pred exec-context? ctx)
+      (check-equal? (exec-context-working-directory ctx) "/tmp/project")
+      (check-equal? (exec-context-call-id ctx) "call-123")
+      (check-false (exec-context-cancellation-token ctx))
+      (check-false (exec-context-event-publisher ctx))
+      (check-false (exec-context-runtime-settings ctx))
+      (check-false (exec-context-session-metadata ctx)))
 
-   (test-case "exec-context with all fields populated"
-     (define ctx2 (make-exec-context
-                   #:working-directory "/tmp/project"
-                   #:cancellation-token 'cancel-token
-                   #:event-publisher 'pub
-                   #:runtime-settings (hasheq 'timeout 30)
-                   #:call-id "call-456"
-                   #:session-metadata (hasheq 'sessionId "s1")))
-     (check-equal? (exec-context-working-directory ctx2) "/tmp/project")
-     (check-equal? (exec-context-cancellation-token ctx2) 'cancel-token)
-     (check-equal? (exec-context-event-publisher ctx2) 'pub)
-     (check-equal? (exec-context-runtime-settings ctx2) (hasheq 'timeout 30))
-     (check-equal? (exec-context-call-id ctx2) "call-456")
-     (check-equal? (exec-context-session-metadata ctx2) (hasheq 'sessionId "s1")))
+    (test-case "exec-context with all fields populated"
+      (define ctx2
+        (make-exec-context #:working-directory "/tmp/project"
+                           #:cancellation-token 'cancel-token
+                           #:event-publisher 'pub
+                           #:runtime-settings (hasheq 'timeout 30)
+                           #:call-id "call-456"
+                           #:session-metadata (hasheq 'sessionId "s1")))
+      (check-equal? (exec-context-working-directory ctx2) "/tmp/project")
+      (check-equal? (exec-context-cancellation-token ctx2) 'cancel-token)
+      (check-equal? (exec-context-event-publisher ctx2) 'pub)
+      (check-equal? (exec-context-runtime-settings ctx2) (hasheq 'timeout 30))
+      (check-equal? (exec-context-call-id ctx2) "call-456")
+      (check-equal? (exec-context-session-metadata ctx2) (hasheq 'sessionId "s1")))
 
-   ;; ============================================================
-   ;; 4. Tool registry
-   ;; ============================================================
+    ;; ============================================================
+    ;; 4. Tool registry
+    ;; ============================================================
 
-   (test-case "make-tool-registry produces a registry"
-     (define reg (make-tool-registry))
-     (check-pred tool-registry? reg)
-     (check-equal? (list-tools reg) '())
-     (check-equal? (tool-names reg) '()))
+    (test-case "make-tool-registry produces a registry"
+      (define reg (make-tool-registry))
+      (check-pred tool-registry? reg)
+      (check-equal? (list-tools reg) '())
+      (check-equal? (tool-names reg) '()))
 
-   (test-case "registry: register, lookup, and list tools"
-     (define reg (make-tool-registry))
-     (register-tool! reg t)
-     (check-equal? (length (list-tools reg)) 1)
-     (check-equal? (tool-names reg) '("read_file"))
-     (check-equal? (tool-name (lookup-tool reg "read_file")) "read_file")
-     (check-false (lookup-tool reg "nonexistent")))
+    (test-case "registry: register, lookup, and list tools"
+      (define reg (make-tool-registry))
+      (register-tool! reg t)
+      (check-equal? (length (list-tools reg)) 1)
+      (check-equal? (tool-names reg) '("read_file"))
+      (check-equal? (tool-name (lookup-tool reg "read_file")) "read_file")
+      (check-false (lookup-tool reg "nonexistent")))
 
-   (test-case "registry: duplicate registration overwrites (idempotent)"
-     (define reg (make-tool-registry))
-     (register-tool! reg t)
-     ;; Re-register same name — should succeed (last wins)
-     (register-tool! reg t)
-     (check-not-false (lookup-tool reg (tool-name t))))
+    (test-case "registry: duplicate registration overwrites (idempotent)"
+      (define reg (make-tool-registry))
+      (register-tool! reg t)
+      ;; Re-register same name — should succeed (last wins)
+      (register-tool! reg t)
+      (check-not-false (lookup-tool reg (tool-name t))))
 
-   (test-case "registry: register second tool and verify both listed"
-     (define reg (make-tool-registry))
-     (register-tool! reg t)
-     (define t2 (make-tool "write_file"
-                           "Write a file"
-                           (hasheq 'type "object"
-                                   'properties (hasheq 'path (hasheq 'type "string"))
-                                   'required '("path"))
-                           (lambda (args ctx)
-                             (make-success-result '()))))
-     (register-tool! reg t2)
-     (check-equal? (length (list-tools reg)) 2)
-     (check-equal? (sort (tool-names reg) string<?) '("read_file" "write_file")))
+    (test-case "registry: register second tool and verify both listed"
+      (define reg (make-tool-registry))
+      (register-tool! reg t)
+      (define t2
+        (make-tool "write_file"
+                   "Write a file"
+                   (hasheq 'type
+                           "object"
+                           'properties
+                           (hasheq 'path (hasheq 'type "string"))
+                           'required
+                           '("path"))
+                   (lambda (args ctx) (make-success-result '()))))
+      (register-tool! reg t2)
+      (check-equal? (length (list-tools reg)) 2)
+      (check-equal? (sort (tool-names reg) string<?) '("read_file" "write_file")))
 
-   (test-case "registry: unregister tool"
-     (define reg (make-tool-registry))
-     (register-tool! reg t)
-     (define t2 (make-tool "write_file"
-                           "Write a file"
-                           (hasheq 'type "object"
-                                   'properties (hasheq 'path (hasheq 'type "string"))
-                                   'required '("path"))
-                           (lambda (args ctx)
-                             (make-success-result '()))))
-     (register-tool! reg t2)
-     (unregister-tool! reg "read_file")
-     (check-false (lookup-tool reg "read_file"))
-     (check-equal? (tool-names reg) '("write_file")))
+    (test-case "registry: unregister tool"
+      (define reg (make-tool-registry))
+      (register-tool! reg t)
+      (define t2
+        (make-tool "write_file"
+                   "Write a file"
+                   (hasheq 'type
+                           "object"
+                           'properties
+                           (hasheq 'path (hasheq 'type "string"))
+                           'required
+                           '("path"))
+                   (lambda (args ctx) (make-success-result '()))))
+      (register-tool! reg t2)
+      (unregister-tool! reg "read_file")
+      (check-false (lookup-tool reg "read_file"))
+      (check-equal? (tool-names reg) '("write_file")))
 
-   (test-case "registry: unregister non-existent is a no-op"
-     (define reg (make-tool-registry))
-     (unregister-tool! reg "nonexistent"))
+    (test-case "registry: unregister non-existent is a no-op"
+      (define reg (make-tool-registry))
+      (unregister-tool! reg "nonexistent"))
 
-   (test-case "registry: re-register after unregister works"
-     (define reg (make-tool-registry))
-     (register-tool! reg t)
-     (unregister-tool! reg "read_file")
-     (register-tool! reg t)
-     (check-equal? (tool-name (lookup-tool reg "read_file")) "read_file"))
+    (test-case "registry: re-register after unregister works"
+      (define reg (make-tool-registry))
+      (register-tool! reg t)
+      (unregister-tool! reg "read_file")
+      (register-tool! reg t)
+      (check-equal? (tool-name (lookup-tool reg "read_file")) "read_file"))
 
-   ;; ============================================================
-   ;; 5. Argument validation against schema
-   ;; ============================================================
+    ;; ============================================================
+    ;; 5. Argument validation against schema
+    ;; ============================================================
 
-   (test-case "validate-tool-args accepts valid arguments"
-     (define validate-schema
-       (hasheq 'type "object"
-               'properties (hasheq 'path (hasheq 'type "string")
-                                   'count (hasheq 'type "integer"))
-               'required '("path")))
-     (define vt (make-tool "validated" "desc" validate-schema void))
-     (check-true (validate-tool-args vt (hasheq 'path "/tmp/x" 'count 5))))
+    (test-case "validate-tool-args accepts valid arguments"
+      (define validate-schema
+        (hasheq 'type
+                "object"
+                'properties
+                (hasheq 'path (hasheq 'type "string") 'count (hasheq 'type "integer"))
+                'required
+                '("path")))
+      (define vt (make-tool "validated" "desc" validate-schema void))
+      (check-true (validate-tool-args vt (hasheq 'path "/tmp/x" 'count 5))))
 
-   (test-case "validate-tool-args rejects missing required field"
-     (define validate-schema
-       (hasheq 'type "object"
-               'properties (hasheq 'path (hasheq 'type "string")
-                                   'count (hasheq 'type "integer"))
-               'required '("path")))
-     (define vt (make-tool "validated" "desc" validate-schema void))
-     (check-exn exn:fail?
-                (lambda () (validate-tool-args vt (hasheq 'count 5)))))
+    (test-case "validate-tool-args rejects missing required field"
+      (define validate-schema
+        (hasheq 'type
+                "object"
+                'properties
+                (hasheq 'path (hasheq 'type "string") 'count (hasheq 'type "integer"))
+                'required
+                '("path")))
+      (define vt (make-tool "validated" "desc" validate-schema void))
+      (check-exn exn:fail? (lambda () (validate-tool-args vt (hasheq 'count 5)))))
 
-   (test-case "validate-tool-args rejects wrong type for string field"
-     (define validate-schema
-       (hasheq 'type "object"
-               'properties (hasheq 'path (hasheq 'type "string")
-                                   'count (hasheq 'type "integer"))
-               'required '("path")))
-     (define vt (make-tool "validated" "desc" validate-schema void))
-     (check-exn exn:fail?
-                (lambda () (validate-tool-args vt (hasheq 'path 123)))))
+    (test-case "validate-tool-args rejects wrong type for string field"
+      (define validate-schema
+        (hasheq 'type
+                "object"
+                'properties
+                (hasheq 'path (hasheq 'type "string") 'count (hasheq 'type "integer"))
+                'required
+                '("path")))
+      (define vt (make-tool "validated" "desc" validate-schema void))
+      (check-exn exn:fail? (lambda () (validate-tool-args vt (hasheq 'path 123)))))
 
-   (test-case "validate-tool-args rejects wrong type for integer field"
-     (define validate-schema
-       (hasheq 'type "object"
-               'properties (hasheq 'path (hasheq 'type "string")
-                                   'count (hasheq 'type "integer"))
-               'required '("path")))
-     (define vt (make-tool "validated" "desc" validate-schema void))
-     (check-exn exn:fail?
-                (lambda () (validate-tool-args vt (hasheq 'path "/x" 'count "five")))))
+    (test-case "validate-tool-args rejects wrong type for integer field"
+      (define validate-schema
+        (hasheq 'type
+                "object"
+                'properties
+                (hasheq 'path (hasheq 'type "string") 'count (hasheq 'type "integer"))
+                'required
+                '("path")))
+      (define vt (make-tool "validated" "desc" validate-schema void))
+      (check-exn exn:fail? (lambda () (validate-tool-args vt (hasheq 'path "/x" 'count "five")))))
 
-   (test-case "validate-tool-args allows extra arguments"
-     (define validate-schema
-       (hasheq 'type "object"
-               'properties (hasheq 'path (hasheq 'type "string")
-                                   'count (hasheq 'type "integer"))
-               'required '("path")))
-     (define vt (make-tool "validated" "desc" validate-schema void))
-     (check-true (validate-tool-args vt (hasheq 'path "/x" 'extra "ok"))))
+    (test-case "validate-tool-args allows extra arguments"
+      (define validate-schema
+        (hasheq 'type
+                "object"
+                'properties
+                (hasheq 'path (hasheq 'type "string") 'count (hasheq 'type "integer"))
+                'required
+                '("path")))
+      (define vt (make-tool "validated" "desc" validate-schema void))
+      (check-true (validate-tool-args vt (hasheq 'path "/x" 'extra "ok"))))
 
-   (test-case "validate-tool-args passes with no required fields"
-     (define no-req-schema
-       (hasheq 'type "object"
-               'properties (hasheq 'name (hasheq 'type "string"))))
-     (define nt (make-tool "noreq" "desc" no-req-schema void))
-     (check-true (validate-tool-args nt (hasheq)))
-     (check-true (validate-tool-args nt (hasheq 'name "test"))))
+    (test-case "validate-tool-args passes with no required fields"
+      (define no-req-schema
+        (hasheq 'type "object" 'properties (hasheq 'name (hasheq 'type "string"))))
+      (define nt (make-tool "noreq" "desc" no-req-schema void))
+      (check-true (validate-tool-args nt (hasheq)))
+      (check-true (validate-tool-args nt (hasheq 'name "test"))))
 
-   (test-case "validate-tool-args passes with empty schema"
-     (define empty-schema-tool (make-tool "empty" "desc" (hasheq) void))
-     (check-true (validate-tool-args empty-schema-tool (hasheq 'anything "goes"))))
+    (test-case "validate-tool-args passes with empty schema"
+      (define empty-schema-tool (make-tool "empty" "desc" (hasheq) void))
+      (check-true (validate-tool-args empty-schema-tool (hasheq 'anything "goes"))))
 
-   (test-case "validate-tool-args rejects non-hash arguments"
-     (define validate-schema
-       (hasheq 'type "object"
-               'properties (hasheq 'path (hasheq 'type "string")
-                                   'count (hasheq 'type "integer"))
-               'required '("path")))
-     (define vt (make-tool "validated" "desc" validate-schema void))
-     (check-exn exn:fail?
-                (lambda () (validate-tool-args vt "not-a-hash"))))
+    (test-case "validate-tool-args rejects non-hash arguments"
+      (define validate-schema
+        (hasheq 'type
+                "object"
+                'properties
+                (hasheq 'path (hasheq 'type "string") 'count (hasheq 'type "integer"))
+                'required
+                '("path")))
+      (define vt (make-tool "validated" "desc" validate-schema void))
+      (check-exn exn:fail? (lambda () (validate-tool-args vt "not-a-hash"))))
 
-   ;; ============================================================
-   ;; 6. Calling execute through the tool
-   ;; ============================================================
+    ;; ============================================================
+    ;; 6. Calling execute through the tool
+    ;; ============================================================
 
-   (test-case "tool execute returns correct result"
-     (define echo-tool
-       (make-tool "echo"
-                  "Echoes args back"
-                  (hasheq 'type "object"
-                          'properties (hasheq 'msg (hasheq 'type "string"))
-                          'required '("msg"))
-                  (lambda (args ctx)
-                    (make-success-result
-                     (list (hasheq 'type "text"
-                                   'text (hash-ref args 'msg)))))))
-     (define echo-result ((tool-execute echo-tool)
-                          (hasheq 'msg "hello")
-                          (make-exec-context
-                           #:working-directory "/tmp"
-                           #:call-id "echo-1")))
-     (check-pred tool-result? echo-result)
-     (check-false (tool-result-is-error? echo-result))
-     (check-equal? (hash-ref (list-ref (tool-result-content echo-result) 0) 'text)
-                   "hello"))
+    (test-case "tool execute returns correct result"
+      (define echo-tool
+        (make-tool
+         "echo"
+         "Echoes args back"
+         (hasheq 'type "object" 'properties (hasheq 'msg (hasheq 'type "string")) 'required '("msg"))
+         (lambda (args ctx)
+           (make-success-result (list (hasheq 'type "text" 'text (hash-ref args 'msg)))))))
+      (define echo-result
+        ((tool-execute echo-tool) (hasheq 'msg "hello")
+                                  (make-exec-context #:working-directory "/tmp" #:call-id "echo-1")))
+      (check-pred tool-result? echo-result)
+      (check-false (tool-result-is-error? echo-result))
+      (check-equal? (hash-ref (list-ref (tool-result-content echo-result) 0) 'text) "hello"))
 
-   ;; ============================================================
-   ;; 6. Tool serialization (tool->jsexpr / list-tools-jsexpr)
-   ;; ============================================================
+    ;; ============================================================
+    ;; 6. Tool serialization (tool->jsexpr / list-tools-jsexpr)
+    ;; ============================================================
 
-   (test-case "tool->jsexpr produces OpenAI normalized format"
-     (define schema
-       (hasheq 'type "object"
-               'properties (hasheq 'path (hasheq 'type "string"))
-               'required '("path")))
-     (define ser-tool (make-tool "read_file" "Read a file" schema void))
-     (define jx (tool->jsexpr ser-tool))
-     (check-equal? (hash-ref jx 'type) "function")
-     (define fn (hash-ref jx 'function))
-     (check-equal? (hash-ref fn 'name) "read_file")
-     (check-equal? (hash-ref fn 'description) "Read a file")
-     (check-equal? (hash-ref fn 'parameters) schema))
+    (test-case "tool->jsexpr produces OpenAI normalized format"
+      (define schema
+        (hasheq 'type
+                "object"
+                'properties
+                (hasheq 'path (hasheq 'type "string"))
+                'required
+                '("path")))
+      (define ser-tool (make-tool "read_file" "Read a file" schema void))
+      (define jx (tool->jsexpr ser-tool))
+      (check-equal? (hash-ref jx 'type) "function")
+      (define fn (hash-ref jx 'function))
+      (check-equal? (hash-ref fn 'name) "read_file")
+      (check-equal? (hash-ref fn 'description) "Read a file")
+      (check-equal? (hash-ref fn 'parameters) schema))
 
-   (test-case "list-tools-jsexpr returns serialized tool list"
-     (define reg (make-tool-registry))
-     (register-tool! reg t)
-     (define jtools (list-tools-jsexpr reg))
-     (check-equal? (length jtools) 1)
-     (define jx (car jtools))
-     (check-equal? (hash-ref jx 'type) "function")
-     (check-equal? (hash-ref (hash-ref jx 'function) 'name) "read_file"))
+    (test-case "list-tools-jsexpr returns serialized tool list"
+      (define reg (make-tool-registry))
+      (register-tool! reg t)
+      (define jtools (list-tools-jsexpr reg))
+      (check-equal? (length jtools) 1)
+      (define jx (car jtools))
+      (check-equal? (hash-ref jx 'type) "function")
+      (check-equal? (hash-ref (hash-ref jx 'function) 'name) "read_file"))
 
-   (test-case "list-tools-jsexpr returns empty list for empty registry"
-     (define reg (make-tool-registry))
-     (check-equal? (list-tools-jsexpr reg) '()))))
+    (test-case "list-tools-jsexpr returns empty list for empty registry"
+      (define reg (make-tool-registry))
+      (check-equal? (list-tools-jsexpr reg) '()))))
 
-   (test-case "tool-registry-tools returns empty list for empty registry"
-     (define reg (make-tool-registry))
-     (check-equal? (tool-registry-tools reg) '()))
+(test-case "tool-registry-tools returns empty list for empty registry"
+  (define reg (make-tool-registry))
+  (check-equal? (tool-registry-tools reg) '()))
 
-   (test-case "tool-registry-tools returns registered tools"
-     (define reg (make-tool-registry))
-     (register-tool! reg t)
-     (check-equal? (length (tool-registry-tools reg)) 1)
-     (check-equal? (tool-name (car (tool-registry-tools reg))) "read_file"))
+(test-case "tool-registry-tools returns registered tools"
+  (define reg (make-tool-registry))
+  (register-tool! reg t)
+  (check-equal? (length (tool-registry-tools reg)) 1)
+  (check-equal? (tool-name (car (tool-registry-tools reg))) "read_file"))
 
-   (test-case "tool-active? returns #t when all tools active (no filter)"
-     (define reg (make-tool-registry))
-     (register-tool! reg t)
-     (check-true (tool-active? reg "read_file")))
+(test-case "tool-active? returns #t when all tools active (no filter)"
+  (define reg (make-tool-registry))
+  (register-tool! reg t)
+  (check-true (tool-active? reg "read_file")))
 
-   (test-case "tool-active? returns #f for inactive tool when filter set"
-     (define reg (make-tool-registry))
-     (register-tool! reg t)
-     (set-active-tools! reg '("other"))
-     (check-false (tool-active? reg "read_file")))
+(test-case "tool-active? returns #f for inactive tool when filter set"
+  (define reg (make-tool-registry))
+  (register-tool! reg t)
+  (set-active-tools! reg '("other"))
+  (check-false (tool-active? reg "read_file")))
 
-   (test-case "tool-active? returns #t for active tool when filter set"
-     (define reg (make-tool-registry))
-     (register-tool! reg t)
-     (set-active-tools! reg '("read_file"))
-     (check-true (tool-active? reg "read_file")))
-
+(test-case "tool-active? returns #t for active tool when filter set"
+  (define reg (make-tool-registry))
+  (register-tool! reg t)
+  (set-active-tools! reg '("read_file"))
+  (check-true (tool-active? reg "read_file")))
 
 (run-tests tool-reg-tests)
 
@@ -410,37 +406,32 @@
 ;; ============================================================
 
 (define registry-defaults-tests
-  (test-suite
-   "register-default-tools! #:only guard independence"
+  (test-suite "register-default-tools! #:only guard independence"
 
-   (test-case "#:only '(\"date\") registers date but not ls"
-     (define reg (make-tool-registry))
-     (register-default-tools! reg #:only '("date"))
-     (check-not-false (lookup-tool reg "date")
-                     "date should be registered")
-     (check-false (lookup-tool reg "ls")
-                  "ls should NOT be registered when not in #:only"))
+    (test-case "#:only '(\"date\") registers date but not ls"
+      (define reg (make-tool-registry))
+      (register-default-tools! reg #:only '("date"))
+      (check-not-false (lookup-tool reg "date") "date should be registered")
+      (check-false (lookup-tool reg "ls") "ls should NOT be registered when not in #:only"))
 
-   (test-case "#:only '(\"firecrawl\") registers firecrawl but not ls"
-     (define reg (make-tool-registry))
-     (register-default-tools! reg #:only '("firecrawl"))
-     (check-not-false (lookup-tool reg "firecrawl")
-                     "firecrawl should be registered")
-     (check-false (lookup-tool reg "ls")
-                  "ls should NOT be registered when not in #:only"))
+    (test-case "#:only '(\"firecrawl\") registers firecrawl but not ls"
+      (define reg (make-tool-registry))
+      (register-default-tools! reg #:only '("firecrawl"))
+      (check-not-false (lookup-tool reg "firecrawl") "firecrawl should be registered")
+      (check-false (lookup-tool reg "ls") "ls should NOT be registered when not in #:only"))
 
-   (test-case "#:only '(\"date\") — lookup-tool returns a tool"
-     (define reg (make-tool-registry))
-     (register-default-tools! reg #:only '("date"))
-     (define t (lookup-tool reg "date"))
-     (check-pred tool? t)
-     (check-equal? (tool-name t) "date"))
+    (test-case "#:only '(\"date\") — lookup-tool returns a tool"
+      (define reg (make-tool-registry))
+      (register-default-tools! reg #:only '("date"))
+      (define t (lookup-tool reg "date"))
+      (check-pred tool? t)
+      (check-equal? (tool-name t) "date"))
 
-   (test-case "#:only '(\"ls\") registers ls but not date or firecrawl"
-     (define reg (make-tool-registry))
-     (register-default-tools! reg #:only '("ls"))
-     (check-not-false (lookup-tool reg "ls"))
-     (check-false (lookup-tool reg "date"))
-     (check-false (lookup-tool reg "firecrawl")))))
+    (test-case "#:only '(\"ls\") registers ls but not date or firecrawl"
+      (define reg (make-tool-registry))
+      (register-default-tools! reg #:only '("ls"))
+      (check-not-false (lookup-tool reg "ls"))
+      (check-false (lookup-tool reg "date"))
+      (check-false (lookup-tool reg "firecrawl")))))
 
 (run-tests registry-defaults-tests)

--- a/tests/test-tool.rkt
+++ b/tests/test-tool.rkt
@@ -1,7 +1,8 @@
 #lang racket
 
 (require rackunit
-         "../tools/tool.rkt")
+         "../tools/tool.rkt"
+         "../tools/tool-struct.rkt")
 
 ;; ============================================================
 ;; Tool struct

--- a/tests/workflows/extensions/test-extension-hooks.rkt
+++ b/tests/workflows/extensions/test-extension-hooks.rkt
@@ -27,141 +27,138 @@
 ;; ============================================================
 
 (define suite
-  (test-suite
-   "Extension hooks workflow tests"
+  (test-suite "Extension hooks workflow tests"
 
-   ;; ────────────────────────────────────────────────────────
-   ;; Test 1: hook pipeline fires for tool calls
-   ;; ────────────────────────────────────────────────────────
-   (test-case "wf-ext: pre/post tool hooks fire during workflow"
-     (define prov (make-scripted-provider
-                   (list (tool-call-response "tc-1" "read"
-                                             (hash 'path "hello.txt"))
-                         (text-response "File content analyzed"))))
+    ;; ────────────────────────────────────────────────────────
+    ;; Test 1: hook pipeline fires for tool calls
+    ;; ────────────────────────────────────────────────────────
+    (test-case "wf-ext: pre/post tool hooks fire during workflow"
+      (define prov
+        (make-scripted-provider (list (tool-call-response "tc-1" "read" (hash 'path "hello.txt"))
+                                      (text-response "File content analyzed"))))
 
-     ;; Track hook invocations
-     (define hook-log (box '()))
+      ;; Track hook invocations
+      (define hook-log (box '()))
 
-     (define reg (make-tool-registry))
-     (register-tool! reg
-       (make-tool "read"
-                  "Read file"
-                  (hasheq)
-                  (lambda (args ctx)
-                    (set-box! hook-log
-                              (cons (list 'tool-execute (hash-ref args 'path "unknown"))
-                                    (unbox hook-log)))
-                    (make-success-result "file content here"))))
+      (define reg (make-tool-registry))
+      (register-tool! reg
+                      (make-tool "read"
+                                 "Read file"
+                                 (hasheq)
+                                 (lambda (args ctx)
+                                   (set-box! hook-log
+                                             (cons (list 'tool-execute
+                                                         (hash-ref args 'path "unknown"))
+                                                   (unbox hook-log)))
+                                   (make-success-result "file content here"))))
 
-     (define wr (run-workflow prov "Read hello.txt" #:tools reg
-                              #:register-default-tools? #f
-                              #:files (list (cons "hello.txt" "file content here"))))
+      (define wr
+        (run-workflow prov
+                      "Read hello.txt"
+                      #:tools reg
+                      #:register-default-tools? #f
+                      #:files (list (cons "hello.txt" "file content here"))))
 
-     ;; OUTCOME: completed
-     (define output (workflow-result-output wr))
-     (check-equal? (loop-result-termination-reason output) 'completed)
+      ;; OUTCOME: completed
+      (define output (workflow-result-output wr))
+      (check-equal? (loop-result-termination-reason output) 'completed)
 
-     ;; SIDE-EFFECTS: tool was actually executed
-     (define log (reverse (unbox hook-log)))
-     (check-true (>= (length log) 1)
-                 (format "expected at least 1 tool execution, got ~a" log))
-     (when (>= (length log) 1)
-       (check-equal? (car (car log)) 'tool-execute)
-       (check-equal? (cadr (car log)) "hello.txt"))
+      ;; SIDE-EFFECTS: tool was actually executed
+      (define log (reverse (unbox hook-log)))
+      (check-true (>= (length log) 1) (format "expected at least 1 tool execution, got ~a" log))
+      (when (>= (length log) 1)
+        (check-equal? (car (car log)) 'tool-execute)
+        (check-equal? (cadr (car log)) "hello.txt"))
 
-     ;; DURABLE STATE: session log valid
-     (check-equal? (check-session-jsonl-valid (workflow-result-session-log wr)) #t)
+      ;; DURABLE STATE: session log valid
+      (check-equal? (check-session-jsonl-valid (workflow-result-session-log wr)) #t)
 
-     ;; SIDE-EFFECTS: tool events present
-     (define recorder (workflow-result-events wr))
-     (check-true (>= (length (events-of-type recorder "tool.call.started")) 1)
-                 "expected tool.call.started")
+      ;; SIDE-EFFECTS: tool events present
+      (define recorder (workflow-result-events wr))
+      (check-true (>= (length (events-of-type recorder "tool.call.started")) 1)
+                  "expected tool.call.started")
 
-     ;; Cleanup
-     (cleanup-temp-project! (workflow-result-project-dir wr)
-                            (workflow-result-session-dir wr)))
+      ;; Cleanup
+      (cleanup-temp-project! (workflow-result-project-dir wr) (workflow-result-session-dir wr)))
 
-   ;; ────────────────────────────────────────────────────────
-   ;; Test 2: hook can block tool execution
-   ;; ────────────────────────────────────────────────────────
-   (test-case "wf-ext: blocked tool still completes workflow"
-     ;; Provider requests a tool call, but the tool returns an error.
-     ;; The loop should handle the error result and continue.
-     (define prov (make-scripted-provider
-                   (list (tool-call-response "tc-1" "dangerous"
-                                             (hash 'cmd "rm -rf /"))
-                         (text-response "I understand the command was blocked"))))
+    ;; ────────────────────────────────────────────────────────
+    ;; Test 2: hook can block tool execution
+    ;; ────────────────────────────────────────────────────────
+    (test-case "wf-ext: blocked tool still completes workflow"
+      ;; Provider requests a tool call, but the tool returns an error.
+      ;; The loop should handle the error result and continue.
+      (define prov
+        (make-scripted-provider (list (tool-call-response "tc-1" "dangerous" (hash 'cmd "rm -rf /"))
+                                      (text-response "I understand the command was blocked"))))
 
-     (define reg (make-tool-registry))
-     (register-tool! reg
-       (make-tool "dangerous"
-                  "Dangerous tool"
-                  (hasheq)
-                  (lambda (args ctx)
-                    (make-error-result "Command blocked by safety policy"))))
+      (define reg (make-tool-registry))
+      (register-tool! reg
+                      (make-tool "dangerous"
+                                 "Dangerous tool"
+                                 (hasheq)
+                                 (lambda (args ctx)
+                                   (make-error-result "Command blocked by safety policy"))))
 
-     (define wr (run-workflow prov "Run dangerous command" #:tools reg))
+      (define wr (run-workflow prov "Run dangerous command" #:tools reg))
 
-     ;; OUTCOME: completed (error fed back to model)
-     (define output (workflow-result-output wr))
-     (check-equal? (loop-result-termination-reason output) 'completed)
+      ;; OUTCOME: completed (error fed back to model)
+      (define output (workflow-result-output wr))
+      (check-equal? (loop-result-termination-reason output) 'completed)
 
-     ;; DURABLE STATE: session log valid
-     (check-equal? (check-session-jsonl-valid (workflow-result-session-log wr)) #t)
+      ;; DURABLE STATE: session log valid
+      (check-equal? (check-session-jsonl-valid (workflow-result-session-log wr)) #t)
 
-     ;; SIDE-EFFECTS: tool call was attempted
-     (define recorder (workflow-result-events wr))
-     (check-true (>= (length (events-of-type recorder "tool.call.started")) 1)
-                 "expected tool.call.started")
+      ;; SIDE-EFFECTS: tool call was attempted
+      (define recorder (workflow-result-events wr))
+      (check-true (>= (length (events-of-type recorder "tool.call.started")) 1)
+                  "expected tool.call.started")
 
-     ;; Cleanup
-     (cleanup-temp-project! (workflow-result-project-dir wr)
-                            (workflow-result-session-dir wr)))
+      ;; Cleanup
+      (cleanup-temp-project! (workflow-result-project-dir wr) (workflow-result-session-dir wr)))
 
-   ;; ────────────────────────────────────────────────────────
-   ;; Test 3: multiple tools fire events in order
-   ;; ────────────────────────────────────────────────────────
-   (test-case "wf-ext: sequential tool calls produce ordered events"
-     (define prov (make-scripted-provider
-                   (list (tool-call-response "tc-1" "step1" (hash))
-                         (tool-call-response "tc-2" "step2" (hash))
-                         (text-response "Both steps completed"))))
+    ;; ────────────────────────────────────────────────────────
+    ;; Test 3: multiple tools fire events in order
+    ;; ────────────────────────────────────────────────────────
+    (test-case "wf-ext: sequential tool calls produce ordered events"
+      (define prov
+        (make-scripted-provider (list (tool-call-response "tc-1" "step1" (hash))
+                                      (tool-call-response "tc-2" "step2" (hash))
+                                      (text-response "Both steps completed"))))
 
-     (define step-box (box '()))
+      (define step-box (box '()))
 
-     (define reg (make-tool-registry))
-     (register-tool! reg
-       (make-tool "step1" "Step 1" (hasheq)
-                  (lambda (args ctx)
-                    (set-box! step-box (cons 1 (unbox step-box)))
-                    (make-success-result "step1 done"))))
-     (register-tool! reg
-       (make-tool "step2" "Step 2" (hasheq)
-                  (lambda (args ctx)
-                    (set-box! step-box (cons 2 (unbox step-box)))
-                    (make-success-result "step2 done"))))
+      (define reg (make-tool-registry))
+      (register-tool! reg
+                      (make-tool "step1"
+                                 "Step 1"
+                                 (hasheq)
+                                 (lambda (args ctx)
+                                   (set-box! step-box (cons 1 (unbox step-box)))
+                                   (make-success-result "step1 done"))))
+      (register-tool! reg
+                      (make-tool "step2"
+                                 "Step 2"
+                                 (hasheq)
+                                 (lambda (args ctx)
+                                   (set-box! step-box (cons 2 (unbox step-box)))
+                                   (make-success-result "step2 done"))))
 
-     (define wr (run-workflow prov "Run both steps" #:tools reg))
+      (define wr (run-workflow prov "Run both steps" #:tools reg))
 
-     ;; OUTCOME: completed
-     (check-equal? (loop-result-termination-reason (workflow-result-output wr))
-                   'completed)
+      ;; OUTCOME: completed
+      (check-equal? (loop-result-termination-reason (workflow-result-output wr)) 'completed)
 
-     ;; SIDE-EFFECTS: both tools executed in order
-     (define steps (reverse (unbox step-box)))
-     (check-equal? steps '(1 2)
-                   (format "expected steps (1 2), got ~a" steps))
+      ;; SIDE-EFFECTS: both tools executed in order
+      (define steps (reverse (unbox step-box)))
+      (check-equal? steps '(1 2) (format "expected steps (1 2), got ~a" steps))
 
-     ;; DURABLE STATE: tool sequence in session log
-     (check-equal? (check-session-tool-sequence (workflow-result-session-log wr)
-                                                 '("step1" "step2"))
-                   #t)
+      ;; DURABLE STATE: tool sequence in session log
+      (check-equal? (check-session-tool-sequence (workflow-result-session-log wr) '("step1" "step2"))
+                    #t)
 
-     ;; Cleanup
-     (cleanup-temp-project! (workflow-result-project-dir wr)
-                            (workflow-result-session-dir wr)))
-
-   )) ;; end test-suite
+      ;; Cleanup
+      (cleanup-temp-project! (workflow-result-project-dir wr)
+                             (workflow-result-session-dir wr))))) ;; end test-suite
 
 ;; ============================================================
 ;; Run

--- a/tests/workflows/tools/test-tool-bash-workflow.rkt
+++ b/tests/workflows/tools/test-tool-bash-workflow.rkt
@@ -137,7 +137,8 @@
                                        (set-box! settings-validated? #t)))
                                    (make-success-result (list (hasheq 'type "text" 'text "test"))))))
 
-      (define wr (run-workflow prov "Run echo test" #:tools reg #:register-default-tools? #f #:files '()))
+      (define wr
+        (run-workflow prov "Run echo test" #:tools reg #:register-default-tools? #f #:files '()))
 
       ;; OUTCOME: loop completed
       (define output (workflow-result-output wr))

--- a/tools/tool-struct.rkt
+++ b/tools/tool-struct.rkt
@@ -3,8 +3,8 @@
 ;; Extracted from tools/tool.rkt (v0.30.8 W0)
 ;; STABILITY: stable
 
-(provide (struct-out tool)
-         tool?
+(provide tool?
+         tool
          tool-name
          tool-description
          tool-schema

--- a/tools/tool.rkt
+++ b/tools/tool.rkt
@@ -34,7 +34,14 @@
          "registry.rkt"
          "schema-helpers.rkt")
 
-(provide (all-from-out "tool-struct.rkt")
+(provide tool?
+         tool
+         tool-name
+         tool-description
+         tool-schema
+         tool-prompt-snippet
+         tool-prompt-guidelines
+         tool-dangerous?
          (contract-out [make-tool
                         (->* (string? string? hash? procedure?)
                              (#:prompt-snippet (or/c string? #f)

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -10,4 +10,4 @@
 (provide q-version)
 
 (: q-version String)
-(define q-version "0.38.1")
+(define q-version "0.38.2")

--- a/wiki-src/Architecture-Overview.md
+++ b/wiki-src/Architecture-Overview.md
@@ -35,7 +35,7 @@ User input → Interface (CLI/TUI/RPC)
     → Events emitted to bus
 ```
 
-## Metrics (0.38.1)
+## Metrics (0.38.2)
 > _See `racket scripts/metrics.rkt` for current numbers._
 
 - 414 source modules, 534 test files


### PR DESCRIPTION
v0.38.2 milestone.

- H-02: Replace struct-out tool with selective exports in tool-struct.rkt
- H-02: Update tool.rkt to re-export only safe accessors (exclude tool-execute)
- H-02: Update 12 test files to import tool-execute from tool-struct.rkt

Lint 18/18, targeted tests 123/123.

Closes #4091