### PR TITLE
fix: pure core & idiomatic patterns (M-04, L-02..L-04, L-08, L-09)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## v0.38.3 — 2026-05-11
+
+### Goal: Pure Core & Idiomatic Patterns (Milestone 4 of v0.38.x)
+
+### Fixed
+- **M-04** (MEDIUM): Refactored `extensions/gsd/plan-validator.rkt` to replace
+  all `set!` accumulators with `for/fold` in `validate-plan-strict`,
+  `validate-normalized-plan`, and `format-validation-report`.
+- **L-02** (LOW): Replaced `cond` with `match` in `util/event-payloads.rkt`
+  for `payload->hash` and `payload-session-id`.
+- **L-03** (LOW): Replaced module-level `memo-hit-box` with parameter injection
+  in `runtime/context-assembly/selection.rkt`.
+- **L-04** (LOW): Parameterized time source in `runtime/compactor.rkt`
+  `compact-history` via `#:now` keyword.
+- **L-08** (LOW): Replaced `cond` with `match` in `entry->context-message`
+  in `runtime/context-assembly/selection.rkt`.
+- **L-09** (LOW): Removed `compact-history-advisory` alias from
+  `runtime/compactor.rkt`; callers use `compact-history` directly.
+
+**Verification**: lint 18/18, targeted tests 108/108 pass
+
+---
+
 ## v0.38.2 — 2026-05-11
 
 ### Goal: Tool System Boundary Hardening (Milestone 3 of v0.38.x)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.38.2-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.38.3-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 
@@ -199,7 +199,7 @@ racket main.rkt --model gpt-5.4 "write a test"
 ### Verify
 
 ```bash
-racket main.rkt --version  # q version 0.38.2
+racket main.rkt --version  # q version 0.38.3
 raco test tests/           # run the full test suite
 ```
 
@@ -272,7 +272,7 @@ q/
 |--------|-------|
 | Test files | 552 |
 | Source modules | 418 |
-| Source lines | 63970 |
+| Source lines | 63962 |
 | Test lines | 98791 |
 | Test assertions | 15360 |
 | Tests passing | 5835+ | `racket scripts/run-tests.rkt` results |
@@ -374,9 +374,9 @@ When q executes shell commands on behalf of an LLM, arguments are quoted via `sh
 
 
 
-**v0.38.2** — Goal: Session-Config & Model-Registry Encapsulation (Milestone 2 of v0.38.x)
+**v0.38.3** — Goal: Tool System Boundary Hardening (Milestone 3 of v0.38.x)
 
-**v0.38.2** — Goal: Audit Remediation — Comment Cleanup + Import + Test Optimization
+**v0.38.3** — Goal: Audit Remediation — Comment Cleanup + Import + Test Optimization
 
 **v0.36.9** — Goal: Audit Remediation — Test Gaps + Dead Code + Contract Tightening
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -2,7 +2,7 @@
 
 ## Version
 
-v0.38.2
+v0.38.3
 
 ## Layer Diagram
 

--- a/docs/event-taxonomy.md
+++ b/docs/event-taxonomy.md
@@ -1,6 +1,6 @@
 # Q Event Taxonomy Reference
 
-Complete reference for all event types in Q 0.38.2.
+Complete reference for all event types in Q 0.38.3.
 ## Base Types
 
 ### `event` (protocol-level)

--- a/docs/extension-guide.md
+++ b/docs/extension-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.38.2 --># Extension Development Guide
+<!-- verified-against: 0.38.3 --># Extension Development Guide
 
 This guide walks you through creating, testing, and activating a custom
 extension for q.

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.38.2 --># Getting Started
+<!-- verified-against: 0.38.3 --># Getting Started
 
 Welcome to q, a Racket-based coding agent.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.38.2 --># Installation Guide
+<!-- verified-against: 0.38.3 --># Installation Guide
 
 <!-- This file is the canonical source. The docs/getting-started/installation.md copy is maintained for the doc site build. -->
 

--- a/docs/security-trust-model.md
+++ b/docs/security-trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.38.2 --># Security & Trust Model
+<!-- verified-against: 0.38.3 --># Security & Trust Model
 
 This document provides an honest, per-area assessment of what q enforces
 today and what is planned. It is the authoritative reference for security

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -130,6 +130,6 @@ is the primary self-hosting extension:
 (load-extension! ext-reg "path/to/extension.rkt" #:event-bus bus)
 ```
 
-## Version 0.38.2
+## Version 0.38.3
 
-This documentation reflects q 0.38.2.
+This documentation reflects q 0.38.3.

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.38.2 --># q Source Style Guide
+<!-- verified-against: 0.38.3 --># q Source Style Guide
 
 This document defines formatting and naming conventions for the q Racket codebase.
 All changes to `q/` source files (excluding `tests/`) should follow these rules.

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.38.2 --># Trust Model
+<!-- verified-against: 0.38.3 --># Trust Model
 
 ## Trust Levels
 

--- a/docs/workflow-testing.md
+++ b/docs/workflow-testing.md
@@ -121,6 +121,6 @@ Use relative paths from the test file:
 4. Use `(check-true ...)` for boolean assertions
 5. Keep tests independent — no shared mutable state between test-cases
 
-## Version 0.38.2
+## Version 0.38.3
 
-This documentation reflects q 0.38.2.
+This documentation reflects q 0.38.3.

--- a/extensions/gsd/plan-validator.rkt
+++ b/extensions/gsd/plan-validator.rkt
@@ -12,30 +12,40 @@
 (: validate-plan-strict : gsd-plan -> validation-result)
 (define (validate-plan-strict plan)
   (define waves (gsd-plan-waves plan))
-  (: errors : (Listof String))
-  (define errors '())
-  (: warnings : (Listof String))
-  (define warnings '())
-  (when (null? waves)
-    (set! errors (cons "Plan has no waves" errors)))
-  (for ([w waves])
-    (define widx (gsd-wave-index w))
-    (define prefix (format "Wave ~a" widx))
-    (when (string=? (gsd-wave-title w) "")
-      (set! warnings (cons (format "~a: no explicit title" prefix) warnings)))
-    (when (null? (gsd-wave-files w))
-      (set! warnings
-            (cons (format "~a: no file references — wave may not produce changes" prefix) warnings)))
-    (when (or (not (gsd-wave-verify w)) (string=? (gsd-wave-verify w) ""))
-      (set! warnings (cons (format "~a: no verify command" prefix) warnings)))
-    (when (string=? (gsd-wave-root-cause w) "")
-      (set! warnings (cons (format "~a: no root-cause/objective" prefix) warnings)))
-    (when (string=? (gsd-wave-title w) "")
-      (set! warnings
-            (cons (format "~a: cannot derive wave doc slug (empty title)" prefix) warnings))))
-  (when (and (pair? waves) (andmap (lambda ([w : gsd-wave]) (null? (gsd-wave-files w))) waves))
-    (set! errors (cons "Plan has no file references in any wave — nothing to execute" errors)))
-  (validation-result (reverse errors) (reverse warnings)))
+  (define-values (errors warnings)
+    (for/fold : (Values (Listof String) (Listof String))
+              ([errors : (Listof String) (if (null? waves) (list "Plan has no waves") '())]
+               [warnings : (Listof String) '()])
+              ([w waves])
+      (define widx (gsd-wave-index w))
+      (define prefix (format "Wave ~a" widx))
+      (define new-warnings
+        (cond
+          [(string=? (gsd-wave-title w) "")
+           (cons (format "~a: no explicit title" prefix) warnings)]
+          [else warnings]))
+      (define new-warnings2
+        (if (null? (gsd-wave-files w))
+            (cons (format "~a: no file references — wave may not produce changes" prefix) new-warnings)
+            new-warnings))
+      (define new-warnings3
+        (if (or (not (gsd-wave-verify w)) (string=? (gsd-wave-verify w) ""))
+            (cons (format "~a: no verify command" prefix) new-warnings2)
+            new-warnings2))
+      (define new-warnings4
+        (if (string=? (gsd-wave-root-cause w) "")
+            (cons (format "~a: no root-cause/objective" prefix) new-warnings3)
+            new-warnings3))
+      (define new-warnings5
+        (if (string=? (gsd-wave-title w) "")
+            (cons (format "~a: cannot derive wave doc slug (empty title)" prefix) new-warnings4)
+            new-warnings4))
+      (values errors new-warnings5)))
+  (define final-errors
+    (if (and (pair? waves) (andmap (lambda ([w : gsd-wave]) (null? (gsd-wave-files w))) waves))
+        (cons "Plan has no file references in any wave — nothing to execute" errors)
+        errors))
+  (validation-result (reverse final-errors) (reverse warnings)))
 
 ;; v0.24.2: Validate normalized plan and wrap as gsd-validated-plan.
 ;; Takes a gsd-normalized-plan (already structurally valid from normalization)
@@ -43,29 +53,35 @@
 (: validate-normalized-plan : gsd-normalized-plan -> (U gsd-validated-plan validation-result))
 (define (validate-normalized-plan norm-plan)
   (define waves (gsd-normalized-plan-waves norm-plan))
-  (: errors : (Listof String))
-  (define errors '())
-  (: warnings : (Listof String))
-  (define warnings '())
-  (when (null? waves)
-    (set! errors (cons "Plan has no waves" errors)))
-  (for ([w waves])
-    (define widx (gsd-normalized-wave-index w))
-    (define prefix (format "Wave ~a" widx))
-    (when (string=? (gsd-normalized-wave-title w) "")
-      (set! warnings (cons (format "~a: no explicit title" prefix) warnings)))
-    (when (null? (gsd-normalized-wave-files w))
-      (set! warnings
-            (cons (format "~a: no file references — wave may not produce changes" prefix) warnings)))
-    (when (string=? (gsd-normalized-wave-verify-command w) "")
-      (set! warnings (cons (format "~a: no verify command" prefix) warnings))))
-  (when (and (pair? waves)
+  (define-values (errors warnings)
+    (for/fold : (Values (Listof String) (Listof String))
+              ([errors : (Listof String) (if (null? waves) (list "Plan has no waves") '())]
+               [warnings : (Listof String) '()])
+              ([w waves])
+      (define widx (gsd-normalized-wave-index w))
+      (define prefix (format "Wave ~a" widx))
+      (define new-warnings
+        (if (string=? (gsd-normalized-wave-title w) "")
+            (cons (format "~a: no explicit title" prefix) warnings)
+            warnings))
+      (define new-warnings2
+        (if (null? (gsd-normalized-wave-files w))
+            (cons (format "~a: no file references — wave may not produce changes" prefix) new-warnings)
+            new-warnings))
+      (define new-warnings3
+        (if (string=? (gsd-normalized-wave-verify-command w) "")
+            (cons (format "~a: no verify command" prefix) new-warnings2)
+            new-warnings2))
+      (values errors new-warnings3)))
+  (define final-errors
+    (if (and (pair? waves)
              (andmap (lambda ([w : gsd-normalized-wave]) (null? (gsd-normalized-wave-files w)))
                      waves))
-    (set! errors (cons "Plan has no file references in any wave — nothing to execute" errors)))
-  (if (null? errors)
+        (cons "Plan has no file references in any wave — nothing to execute" errors)
+        errors))
+  (if (null? final-errors)
       (gsd-validated-plan norm-plan)
-      (validation-result (reverse errors) (reverse warnings))))
+      (validation-result (reverse final-errors) (reverse warnings))))
 
 (: valid-plan->go? : gsd-plan -> Boolean)
 (define (valid-plan->go? plan)
@@ -76,26 +92,26 @@
 (define (format-validation-report result)
   (define errs (validation-result-errors result))
   (define warns (validation-result-warnings result))
-  (: parts : (Listof String))
-  (define parts '())
-  (when (not (null? errs))
-    (set! parts
-          (cons (format "❌ ERRORS (block /go):\n~a"
-                        (string-join (for/list :
-                                       (Listof String)
-                                       ([e : String errs])
-                                       (format "  - ~a" e))
-                                     "\n"))
-                parts)))
-  (when (not (null? warns))
-    (set! parts
-          (cons (format "⚠️  WARNINGS:\n~a"
-                        (string-join (for/list :
-                                       (Listof String)
-                                       ([w : String warns])
-                                       (format "  - ~a" w))
-                                     "\n"))
-                parts)))
+  (define parts
+    (let ([error-part
+           (if (null? errs)
+               '()
+               (list (format "❌ ERRORS (block /go):\n~a"
+                             (string-join (for/list :
+                                            (Listof String)
+                                            ([e : String errs])
+                                            (format "  - ~a" e))
+                                          "\n"))))]
+          [warn-part
+           (if (null? warns)
+               '()
+               (list (format "⚠️  WARNINGS:\n~a"
+                             (string-join (for/list :
+                                            (Listof String)
+                                            ([w : String warns])
+                                            (format "  - ~a" w))
+                                          "\n"))))])
+      (append warn-part error-part)))
   (if (null? errs)
       (string-append "✅ Plan is valid.\n"
                      (if (null? parts)

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.38.2")
+(define version "0.38.3")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base"))

--- a/runtime/compactor.rkt
+++ b/runtime/compactor.rkt
@@ -6,7 +6,6 @@
 ;;   compaction-strategy          — struct: summary-window-size, keep-recent-count
 ;;   compaction-result            — struct: summary-message, removed-count, kept-messages
 ;;   compact-history              — summarize history and produce compaction entries (ADVISORY-ONLY)
-;;   compact-history-advisory     — explicit alias for compact-history (advisory, no filesystem)
 ;;   compact-and-persist!         — compact history AND write summary entry to session log
 ;;   build-summary-window         — determine what to summarize vs what to keep recent
 ;;   write-compaction-entry!      — write a compaction entry to session log
@@ -56,13 +55,7 @@
                                              #:hook-dispatcher (or/c procedure? #f)
                                              #:token-config any/c)
                              compaction-result?)]
-                       [compact-history-advisory
-                        (->* (list?)
-                             (#:summarize-fn procedure?
-                                             #:previous-summary (or/c string? #f)
-                                             #:hook-dispatcher (or/c procedure? #f)
-                                             #:token-config any/c)
-                             compaction-result?)]
+
                        [compact-and-persist!
                         (->* (list? (or/c path-string? #f))
                              (#:summarize-fn procedure?
@@ -261,7 +254,8 @@
                          #:summarize-fn [summarize-fn default-summarize]
                          #:previous-summary [prev-summary #f]
                          #:hook-dispatcher [hook-dispatcher #f]
-                         #:token-config [token-config (default-token-compaction-config)])
+                         #:token-config [token-config (default-token-compaction-config)]
+                         #:now [now-fn current-inexact-milliseconds])
   ;; Dispatch 'session-before-compact hook if dispatcher provided
   ;; Returns identity result if hook blocks, otherwise proceeds with compaction.
   ;; #769: Hook can provide custom summary via amend action.
@@ -321,7 +315,7 @@
               (message-id (car adjusted-recent))
               #f))
         (define summary-msg
-          (make-message (format "compaction-~a" (current-inexact-milliseconds))
+          (make-message (format "compaction-~a" (now-fn))
                         #f ; no parent — compaction summaries are root-level context
                         'system
                         'compaction-summary
@@ -346,25 +340,6 @@
   (if summary
       (cons summary kept)
       kept))
-
-;; ============================================================
-;; compact-history-advisory
-;; ============================================================
-
-;; Explicit advisory variant — returns the result but does NOT write
-;; to the session log. This is a pure function that does not touch
-;; the filesystem. Equivalent to `compact-history` but named to make
-;; the advisory contract crystal clear.
-(define (compact-history-advisory messages
-                                  #:summarize-fn [summarize-fn default-summarize]
-                                  #:previous-summary [prev-summary #f]
-                                  #:hook-dispatcher [hook-dispatcher #f]
-                                  #:token-config [token-config (default-token-compaction-config)])
-  (compact-history messages
-                   #:summarize-fn summarize-fn
-                   #:previous-summary prev-summary
-                   #:hook-dispatcher hook-dispatcher
-                   #:token-config token-config))
 
 ;; ============================================================
 ;; compact-and-persist!

--- a/runtime/context-assembly/selection.rkt
+++ b/runtime/context-assembly/selection.rkt
@@ -10,7 +10,8 @@
 ;;   pure. Then wrap with a thin impure shell that creates the memo. This would allow
 ;;   the core logic to be typed. Estimated effort: ~2 waves. Deferred to backlog.
 
-(require racket/list
+(require racket/match
+         racket/list
          racket/set
          (only-in "../../util/protocol-types.rkt"
                   message
@@ -81,7 +82,8 @@
   (define (emit-trace phase data)
     (when trace
       (trace phase data)))
-  (define memo-hit-box (box 0))
+  (define memo-hit-box (or (and (hash? config) (hash-ref config 'memo-hit-counter #f))
+                           (box 0)))
   (define base-estimate (or estimate-text-proc estimate-message-tokens))
   (define (memoized-estimate msg)
     (define id (message-id msg))
@@ -230,16 +232,15 @@
      (values pre post)]))
 
 (define (entry->context-message entry)
-  (define kind (message-kind entry))
-  (cond
-    [(memq kind '(message)) entry]
-    [(eq? kind 'compaction-summary) (transform-summary-to-user entry)]
-    [(eq? kind 'branch-summary) (transform-summary-to-user entry)]
-    [(memq kind '(session-info model-change thinking-level-change)) #f]
-    [(memq kind '(tool-result bash-execution)) entry]
-    [(eq? kind 'system-instruction) entry]
-    [(eq? kind 'custom-message) entry]
-    [else entry]))
+  (match (message-kind entry)
+    ['message entry]
+    ['compaction-summary (transform-summary-to-user entry)]
+    ['branch-summary (transform-summary-to-user entry)]
+    [(or 'session-info 'model-change 'thinking-level-change) #f]
+    [(or 'tool-result 'bash-execution) entry]
+    ['system-instruction entry]
+    ['custom-message entry]
+    [_ entry]))
 
 (define (transform-summary-to-user entry)
   (struct-copy message entry [role 'user]))

--- a/tests/test-compactor.rkt
+++ b/tests/test-compactor.rkt
@@ -360,12 +360,12 @@
    (check-equal? (length all-entries) 3)
    (delete-directory/files dir #:must-exist? #f))
  ;; ══════════════════════════════════════════════════════════════
- ;; compact-history-advisory
+ ;; compact-history-advisory removed (L-09)
  ;; ══════════════════════════════════════════════════════════════
- (test-case "compact-history-advisory is advisory-only (alias for compact-history)"
+ (test-case "compact-history produces deterministic advisory results"
    (define msgs (make-n-messages 30))
    (define r1 (compact-history msgs #:summarize-fn test-summarize #:token-config tiny-tc))
-   (define r2 (compact-history-advisory msgs #:summarize-fn test-summarize #:token-config tiny-tc))
+   (define r2 (compact-history msgs #:summarize-fn test-summarize #:token-config tiny-tc))
    ;; Both return the same removed-count and kept-count
    (check-equal? (compaction-result-removed-count r1) (compaction-result-removed-count r2))
    (check-equal? (length (compaction-result-kept-messages r1))

--- a/util/event-payloads.rkt
+++ b/util/event-payloads.rkt
@@ -75,8 +75,8 @@
 ;; Convert any known payload struct to a hasheq (for serialization/legacy consumers).
 (: payload->hash (-> Any (HashTable Symbol Any)))
 (define (payload->hash p)
-  (cond
-    [(session-start-payload? p)
+  (match p
+    [(? session-start-payload?)
      (hasheq '__type
              'session-start
              'session-id
@@ -85,21 +85,21 @@
              (session-start-payload-config p)
              'reason
              (session-start-payload-reason p))]
-    [(session-end-payload? p)
+    [(? session-end-payload?)
      (hasheq '__type
              'session-end
              'session-id
              (session-end-payload-session-id p)
              'duration
              (session-end-payload-duration p))]
-    [(session-switch-payload? p)
+    [(? session-switch-payload?)
      (hasheq '__type
              'session-switch
              'session-id
              (session-switch-payload-session-id p)
              'operation
              (session-switch-payload-operation p))]
-    [(tool-call-event-payload? p)
+    [(? tool-call-event-payload?)
      (hasheq '__type
              'tool-call
              'session-id
@@ -110,36 +110,36 @@
              (tool-call-event-payload-tool-name p)
              'tool-call-id
              (tool-call-event-payload-tool-call-id p))]
-    [(session-id-payload? p)
+    [(? session-id-payload?)
      (hasheq '__type 'session-id 'sessionId (session-id-payload-session-id p))]
-    [(error-payload? p)
+    [(? error-payload?)
      (hasheq '__type 'error 'error (error-payload-error p) 'errorType (error-payload-error-type p))]
-    [(input-payload? p)
+    [(? input-payload?)
      (hasheq '__type
              'input
              'session-id
              (input-payload-session-id p)
              'message
              (input-payload-message p))]
-    [(gsd-mode-payload? p)
+    [(? gsd-mode-payload?)
      (hasheq '__type
              'gsd-mode
              'old-mode
              (gsd-mode-payload-old-mode p)
              'new-mode
              (gsd-mode-payload-new-mode p))]
-    [(hash? p) (cast p (HashTable Symbol Any))]
-    [else (hasheq 'payload p)]))
+    [(? hash?) (cast p (HashTable Symbol Any))]
+    [_ (hasheq 'payload p)]))
 
 ;; Extract session-id from any payload that has one.
 (: payload-session-id (-> Any (Option String)))
 (define (payload-session-id p)
-  (cond
-    [(session-start-payload? p) (session-start-payload-session-id p)]
-    [(session-end-payload? p) (session-end-payload-session-id p)]
-    [(session-switch-payload? p) (session-switch-payload-session-id p)]
-    [(tool-call-event-payload? p) (tool-call-event-payload-session-id p)]
-    [(session-id-payload? p) (session-id-payload-session-id p)]
-    [(input-payload? p) (input-payload-session-id p)]
-    [(hash? p) (cast (hash-ref (cast p (HashTable Symbol Any)) 'session-id #f) (Option String))]
-    [else #f]))
+  (match p
+    [(? session-start-payload?) (session-start-payload-session-id p)]
+    [(? session-end-payload?) (session-end-payload-session-id p)]
+    [(? session-switch-payload?) (session-switch-payload-session-id p)]
+    [(? tool-call-event-payload?) (tool-call-event-payload-session-id p)]
+    [(? session-id-payload?) (session-id-payload-session-id p)]
+    [(? input-payload?) (input-payload-session-id p)]
+    [(? hash?) (cast (hash-ref (cast p (HashTable Symbol Any)) 'session-id #f) (Option String))]
+    [_ #f]))

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -10,4 +10,4 @@
 (provide q-version)
 
 (: q-version String)
-(define q-version "0.38.2")
+(define q-version "0.38.3")

--- a/wiki-src/Architecture-Overview.md
+++ b/wiki-src/Architecture-Overview.md
@@ -35,7 +35,7 @@ User input → Interface (CLI/TUI/RPC)
     → Events emitted to bus
 ```
 
-## Metrics (0.38.2)
+## Metrics (0.38.3)
 > _See `racket scripts/metrics.rkt` for current numbers._
 
 - 414 source modules, 534 test files


### PR DESCRIPTION
v0.38.3 milestone.

- M-04: Replace set! with for/fold in plan-validator.rkt
- L-02: Replace cond with match in event-payloads.rkt
- L-03: Replace module-level memo-hit-box with parameter injection
- L-04: Parameterize time source in compact-history
- L-08: Replace cond with match in entry->context-message
- L-09: Remove compact-history-advisory alias

Lint 18/18, targeted tests 108/108.

Closes #4093