### PR TITLE
feat: TUI state decomposition part 2 — streaming-state sub-struct (H-03 phase 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## v0.38.6 — 2026-05-12
+
+### Goal: TUI State Decomposition Part 2 (Milestone 7 of v0.38.x)
+
+### Fixed
+- **H-03 Phase 2** (HIGH): Extracted `streaming-state` sub-struct from
+  `ui-state` monolith in `tui/state-types.rkt`. Replaced 6 individual
+  fields (`busy?`, `status-message`, `pending-tool-name`,
+  `streaming-text`, `streaming-thinking`, `busy-since`) with 1
+  `streaming` sub-struct field. Added backward-compatible read
+  accessors and setter helpers (`set-busy`, `set-status-message`,
+  `set-pending-tool-name`, `set-streaming-text`,
+  `set-streaming-thinking`, `set-busy-since`, `clear-streaming`,
+  `update-streaming`). Updated all `struct-copy` call sites across
+  `tui/state-events.rkt`, `tui/tui-init.rkt`, `tui/tui-keybindings.rkt`,
+  `tui/tui-render-loop.rkt`, `extensions/dialog-api.rkt`, and 12+ test
+  files.
+- **Bugfix**: Fixed `tools/scheduler.rkt` import of `tool-execute`
+  (pre-existing regression from v0.38.2 that blocked compilation of
+  TUI modules).
+- Added backward-compatible `ui-state-rendered-cache` and
+  `ui-state-rendered-cache-width` accessors for `cache-state` sub-struct.
+
+**Verification**: lint 15/18 (3 pre-existing failures), all TUI tests pass
+
+
 ## v0.38.5 — 2026-05-12
 
 ### Goal: TUI State Decomposition Part 1 (Milestone 6 of v0.38.x)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.38.5-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.38.6-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 
@@ -199,7 +199,7 @@ racket main.rkt --model gpt-5.4 "write a test"
 ### Verify
 
 ```bash
-racket main.rkt --version  # q version 0.38.5
+racket main.rkt --version  # q version 0.38.6
 raco test tests/           # run the full test suite
 ```
 
@@ -272,8 +272,8 @@ q/
 |--------|-------|
 | Test files | 552 |
 | Source modules | 418 |
-| Source lines | 64031 |
-| Test lines | 98791 |
+| Source lines | 64103 |
+| Test lines | 98746 |
 | Test assertions | 15360 |
 | Tests passing | 5835+ | `racket scripts/run-tests.rkt` results |
 
@@ -373,6 +373,9 @@ When q executes shell commands on behalf of an LLM, arguments are quoted via `sh
 
 
 
+
+
+**v0.38.6** — Goal: TUI State Decomposition Part 2 (Milestone 7 of v0.38.x)
 
 **v0.38.5** — Goal: Extension & GSD Cleanup (Milestone 5 of v0.38.x)
 

--- a/extensions/dialog-api.rkt
+++ b/extensions/dialog-api.rkt
@@ -11,7 +11,7 @@
 (require racket/contract
          racket/list
          "ui-surface.rkt"
-         (only-in "../tui/state.rkt" ui-state ui-state-status-message))
+         (only-in "../tui/state.rkt" ui-state ui-state-status-message set-status-message))
 
 ;; Notification levels
 (provide NOTIFY-INFO
@@ -173,4 +173,4 @@
      (ui-set-status-message! state msg)
      (unbox state)]
     ;; Plain state: return a new state with the status message set
-    [else (struct-copy ui-state state [status-message msg])]))
+    [else (set-status-message state msg)]))

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.38.5")
+(define version "0.38.6")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base"))

--- a/tests/test-tui-error-recovery.rkt
+++ b/tests/test-tui-error-recovery.rkt
@@ -25,13 +25,13 @@
 (define-test-suite
  test-tui-error-recovery
  (test-case "error recovery: runtime.error clears busy?"
-   (define s0 (struct-copy ui-state (initial-ui-state #:session-id "s1") [busy? #t]))
+   (define s0 (set-busy (initial-ui-state #:session-id "s1") #t))
    (define evt
      (make-test-event "runtime.error" (hasheq 'error "test error" 'errorType 'internal-error)))
    (define s1 (apply-event-to-state s0 evt))
    (check-false (ui-state-busy? s1) "busy? cleared after runtime.error"))
  (test-case "error recovery: error message shown in transcript"
-   (define s0 (struct-copy ui-state (initial-ui-state #:session-id "s1") [busy? #t]))
+   (define s0 (set-busy (initial-ui-state #:session-id "s1") #t))
    (define evt
      (make-test-event "runtime.error"
                       (hasheq 'error "something went wrong" 'errorType 'internal-error)))
@@ -41,7 +41,7 @@
    (define entry (last entries))
    (check-equal? (transcript-entry-kind entry) 'error))
  (test-case "error recovery: turn.completed after error is idempotent"
-   (define s0 (struct-copy ui-state (initial-ui-state #:session-id "s1") [busy? #t]))
+   (define s0 (set-busy (initial-ui-state #:session-id "s1") #t))
    (define err-evt
      (make-test-event "runtime.error" (hasheq 'error "test error" 'errorType 'internal-error)))
    (define s1 (apply-event-to-state s0 err-evt))
@@ -51,7 +51,7 @@
    (define s2 (apply-event-to-state s1 done-evt))
    (check-false (ui-state-busy? s2) "busy? still false after turn.completed"))
  (test-case "error recovery: subsequent prompt works after error"
-   (define s0 (struct-copy ui-state (initial-ui-state #:session-id "s1") [busy? #t]))
+   (define s0 (set-busy (initial-ui-state #:session-id "s1") #t))
    (define err-evt
      (make-test-event "runtime.error" (hasheq 'error "test error" 'errorType 'internal-error)))
    (define s1 (apply-event-to-state s0 err-evt))
@@ -60,7 +60,7 @@
    (define s2 (apply-event-to-state s1 start-evt))
    (check-true (ui-state-busy? s2) "new turn sets busy?=#t after error recovery"))
  (test-case "error recovery: internal-error hint shown"
-   (define s0 (struct-copy ui-state (initial-ui-state #:session-id "s1") [busy? #t]))
+   (define s0 (set-busy (initial-ui-state #:session-id "s1") #t))
    (define evt
      (make-test-event "runtime.error" (hasheq 'error "internal failure" 'errorType 'internal-error)))
    (define s1 (apply-event-to-state s0 evt))
@@ -72,11 +72,9 @@
                (format "hint mentions internal: ~a" hint-text)))
  (test-case "error recovery: streaming state cleared on error"
    (define s0
-     (struct-copy ui-state
-                  (initial-ui-state #:session-id "s1")
-                  [busy? #t]
-                  [streaming-text "partial code..."]
-                  [streaming-thinking "thinking..."]))
+     (set-streaming-thinking (set-streaming-text (set-busy (initial-ui-state #:session-id "s1") #t)
+                                                 "partial code...")
+                             "thinking..."))
    (define evt (make-test-event "runtime.error" (hasheq 'error "timeout" 'errorType 'timeout)))
    (define s1 (apply-event-to-state s0 evt))
    (check-false (ui-state-streaming-text s1) "streaming-text cleared")

--- a/tests/test-tui-exploration-events.rkt
+++ b/tests/test-tui-exploration-events.rkt
@@ -127,10 +127,7 @@
    (check-false (string-contains? (transcript-entry-text entry) "rate limited")))
  (test-case "auto-retry.start: clears streaming state"
    (define s0
-     (struct-copy ui-state
-                  (initial-ui-state)
-                  [streaming-text "partial..."]
-                  [streaming-thinking "thinking..."]))
+     (set-streaming-thinking (set-streaming-text (initial-ui-state) "partial...") "thinking..."))
    (define evt (make-test-event "auto-retry.start" (hash 'attempt 1 'max-retries 3)))
    (define s1 (apply-event-to-state s0 evt))
    (check-false (ui-state-streaming-text s1))

--- a/tests/test-tui-keys.rkt
+++ b/tests/test-tui-keys.rkt
@@ -24,241 +24,230 @@
 
 ;; Helper: create input state with text and cursor position
 (define (make-input-with-text text cursor-pos)
-  (struct-copy input-state (initial-input-state)
-               [buffer text]
-               [cursor cursor-pos]))
+  (struct-copy input-state (initial-input-state) [buffer text] [cursor cursor-pos]))
 
 (define test-tui-keys
-  (test-suite
-   "TUI Arrow and Special Keys (BUG-36)"
+  (test-suite "TUI Arrow and Special Keys (BUG-36)"
 
-   ;; --------------------------------------------------
-   ;; Test 1: 'left moves cursor left
-   ;; --------------------------------------------------
-   (test-case "handle-key 'left moves cursor left"
-     (define ctx (make-test-ctx))
-     (define inp (make-input-with-text "hello" 5))
-     (set-box! (tui-ctx-input-state-box ctx) inp)
-     (define result (handle-key ctx 'left))
-     (check-equal? result 'continue)
-     (define new-inp (unbox (tui-ctx-input-state-box ctx)))
-     (check-equal? (input-state-cursor new-inp) 4))
+    ;; --------------------------------------------------
+    ;; Test 1: 'left moves cursor left
+    ;; --------------------------------------------------
+    (test-case "handle-key 'left moves cursor left"
+      (define ctx (make-test-ctx))
+      (define inp (make-input-with-text "hello" 5))
+      (set-box! (tui-ctx-input-state-box ctx) inp)
+      (define result (handle-key ctx 'left))
+      (check-equal? result 'continue)
+      (define new-inp (unbox (tui-ctx-input-state-box ctx)))
+      (check-equal? (input-state-cursor new-inp) 4))
 
-   ;; --------------------------------------------------
-   ;; Test 2: 'right moves cursor right
-   ;; --------------------------------------------------
-   (test-case "handle-key 'right moves cursor right"
-     (define ctx (make-test-ctx))
-     (define inp (make-input-with-text "hello" 2))
-     (set-box! (tui-ctx-input-state-box ctx) inp)
-     (define result (handle-key ctx 'right))
-     (check-equal? result 'continue)
-     (define new-inp (unbox (tui-ctx-input-state-box ctx)))
-     (check-equal? (input-state-cursor new-inp) 3))
+    ;; --------------------------------------------------
+    ;; Test 2: 'right moves cursor right
+    ;; --------------------------------------------------
+    (test-case "handle-key 'right moves cursor right"
+      (define ctx (make-test-ctx))
+      (define inp (make-input-with-text "hello" 2))
+      (set-box! (tui-ctx-input-state-box ctx) inp)
+      (define result (handle-key ctx 'right))
+      (check-equal? result 'continue)
+      (define new-inp (unbox (tui-ctx-input-state-box ctx)))
+      (check-equal? (input-state-cursor new-inp) 3))
 
-   ;; --------------------------------------------------
-   ;; Test 3: 'home moves cursor to beginning
-   ;; --------------------------------------------------
-   (test-case "handle-key 'home moves cursor to beginning"
-     (define ctx (make-test-ctx))
-     (define inp (make-input-with-text "hello" 5))
-     (set-box! (tui-ctx-input-state-box ctx) inp)
-     (define result (handle-key ctx 'home))
-     (check-equal? result 'continue)
-     (define new-inp (unbox (tui-ctx-input-state-box ctx)))
-     (check-equal? (input-state-cursor new-inp) 0))
+    ;; --------------------------------------------------
+    ;; Test 3: 'home moves cursor to beginning
+    ;; --------------------------------------------------
+    (test-case "handle-key 'home moves cursor to beginning"
+      (define ctx (make-test-ctx))
+      (define inp (make-input-with-text "hello" 5))
+      (set-box! (tui-ctx-input-state-box ctx) inp)
+      (define result (handle-key ctx 'home))
+      (check-equal? result 'continue)
+      (define new-inp (unbox (tui-ctx-input-state-box ctx)))
+      (check-equal? (input-state-cursor new-inp) 0))
 
-   ;; --------------------------------------------------
-   ;; Test 4: 'end moves cursor to end
-   ;; --------------------------------------------------
-   (test-case "handle-key 'end moves cursor to end"
-     (define ctx (make-test-ctx))
-     (define inp (make-input-with-text "hello" 2))
-     (set-box! (tui-ctx-input-state-box ctx) inp)
-     (define result (handle-key ctx 'end))
-     (check-equal? result 'continue)
-     (define new-inp (unbox (tui-ctx-input-state-box ctx)))
-     (check-equal? (input-state-cursor new-inp) 5))
+    ;; --------------------------------------------------
+    ;; Test 4: 'end moves cursor to end
+    ;; --------------------------------------------------
+    (test-case "handle-key 'end moves cursor to end"
+      (define ctx (make-test-ctx))
+      (define inp (make-input-with-text "hello" 2))
+      (set-box! (tui-ctx-input-state-box ctx) inp)
+      (define result (handle-key ctx 'end))
+      (check-equal? result 'continue)
+      (define new-inp (unbox (tui-ctx-input-state-box ctx)))
+      (check-equal? (input-state-cursor new-inp) 5))
 
-   ;; --------------------------------------------------
-   ;; Test 5: 'left at beginning does nothing
-   ;; --------------------------------------------------
-   (test-case "handle-key 'left at beginning does nothing"
-     (define ctx (make-test-ctx))
-     (define inp (make-input-with-text "hello" 0))
-     (set-box! (tui-ctx-input-state-box ctx) inp)
-     (define result (handle-key ctx 'left))
-     (check-equal? result 'continue)
-     (define new-inp (unbox (tui-ctx-input-state-box ctx)))
-     (check-equal? (input-state-cursor new-inp) 0))
+    ;; --------------------------------------------------
+    ;; Test 5: 'left at beginning does nothing
+    ;; --------------------------------------------------
+    (test-case "handle-key 'left at beginning does nothing"
+      (define ctx (make-test-ctx))
+      (define inp (make-input-with-text "hello" 0))
+      (set-box! (tui-ctx-input-state-box ctx) inp)
+      (define result (handle-key ctx 'left))
+      (check-equal? result 'continue)
+      (define new-inp (unbox (tui-ctx-input-state-box ctx)))
+      (check-equal? (input-state-cursor new-inp) 0))
 
-   ;; --------------------------------------------------
-   ;; Test 6: 'right at end does nothing
-   ;; --------------------------------------------------
-   (test-case "handle-key 'right at end does nothing"
-     (define ctx (make-test-ctx))
-     (define inp (make-input-with-text "hello" 5))
-     (set-box! (tui-ctx-input-state-box ctx) inp)
-     (define result (handle-key ctx 'right))
-     (check-equal? result 'continue)
-     (define new-inp (unbox (tui-ctx-input-state-box ctx)))
-     (check-equal? (input-state-cursor new-inp) 5))
+    ;; --------------------------------------------------
+    ;; Test 6: 'right at end does nothing
+    ;; --------------------------------------------------
+    (test-case "handle-key 'right at end does nothing"
+      (define ctx (make-test-ctx))
+      (define inp (make-input-with-text "hello" 5))
+      (set-box! (tui-ctx-input-state-box ctx) inp)
+      (define result (handle-key ctx 'right))
+      (check-equal? result 'continue)
+      (define new-inp (unbox (tui-ctx-input-state-box ctx)))
+      (check-equal? (input-state-cursor new-inp) 5))
 
-   ;; --------------------------------------------------
-   ;; Test 7: 'up navigates history backward
-   ;; --------------------------------------------------
-   (test-case "handle-key 'up navigates history backward"
-     (define ctx (make-test-ctx))
-     ;; First add some history
-     (define inp (input-history-push (input-history-push (initial-input-state) "first") "second"))
-     (set-box! (tui-ctx-input-state-box ctx) inp)
-     ;; Press up
-     (define result (handle-key ctx 'up))
-     (check-equal? result 'continue)
-     (define new-inp (unbox (tui-ctx-input-state-box ctx)))
-     (check-equal? (input-state-buffer new-inp) "second")
-     (check-equal? (input-state-history-idx new-inp) 1))
+    ;; --------------------------------------------------
+    ;; Test 7: 'up navigates history backward
+    ;; --------------------------------------------------
+    (test-case "handle-key 'up navigates history backward"
+      (define ctx (make-test-ctx))
+      ;; First add some history
+      (define inp (input-history-push (input-history-push (initial-input-state) "first") "second"))
+      (set-box! (tui-ctx-input-state-box ctx) inp)
+      ;; Press up
+      (define result (handle-key ctx 'up))
+      (check-equal? result 'continue)
+      (define new-inp (unbox (tui-ctx-input-state-box ctx)))
+      (check-equal? (input-state-buffer new-inp) "second")
+      (check-equal? (input-state-history-idx new-inp) 1))
 
-   ;; --------------------------------------------------
-   ;; Test 8: 'down navigates history forward
-   ;; --------------------------------------------------
-   (test-case "handle-key 'down navigates history forward"
-     (define ctx (make-test-ctx))
-     ;; Setup: push history and go up once
-     (define inp (input-history-push (input-history-push (initial-input-state) "first") "second"))
-     (set-box! (tui-ctx-input-state-box ctx) inp)
-     (handle-key ctx 'up)  ;; now at "second"
-     ;; Press down
-     (define result (handle-key ctx 'down))
-     (check-equal? result 'continue)
-     (define new-inp (unbox (tui-ctx-input-state-box ctx)))
-     ;; Should be back to browsing mode end (empty if no saved text)
-     (check-equal? (input-state-history-idx new-inp) #f))
+    ;; --------------------------------------------------
+    ;; Test 8: 'down navigates history forward
+    ;; --------------------------------------------------
+    (test-case "handle-key 'down navigates history forward"
+      (define ctx (make-test-ctx))
+      ;; Setup: push history and go up once
+      (define inp (input-history-push (input-history-push (initial-input-state) "first") "second"))
+      (set-box! (tui-ctx-input-state-box ctx) inp)
+      (handle-key ctx 'up) ;; now at "second"
+      ;; Press down
+      (define result (handle-key ctx 'down))
+      (check-equal? result 'continue)
+      (define new-inp (unbox (tui-ctx-input-state-box ctx)))
+      ;; Should be back to browsing mode end (empty if no saved text)
+      (check-equal? (input-state-history-idx new-inp) #f))
 
-   ;; --------------------------------------------------
-   ;; Test 9: 'delete removes character after cursor
-   ;; --------------------------------------------------
-   (test-case "handle-key 'delete removes character after cursor"
-     (define ctx (make-test-ctx))
-     (define inp (make-input-with-text "hello" 2))
-     (set-box! (tui-ctx-input-state-box ctx) inp)
-     (define result (handle-key ctx 'delete))
-     (check-equal? result 'continue)
-     (define new-inp (unbox (tui-ctx-input-state-box ctx)))
-     (check-equal? (input-state-buffer new-inp) "helo")
-     (check-equal? (input-state-cursor new-inp) 2))
+    ;; --------------------------------------------------
+    ;; Test 9: 'delete removes character after cursor
+    ;; --------------------------------------------------
+    (test-case "handle-key 'delete removes character after cursor"
+      (define ctx (make-test-ctx))
+      (define inp (make-input-with-text "hello" 2))
+      (set-box! (tui-ctx-input-state-box ctx) inp)
+      (define result (handle-key ctx 'delete))
+      (check-equal? result 'continue)
+      (define new-inp (unbox (tui-ctx-input-state-box ctx)))
+      (check-equal? (input-state-buffer new-inp) "helo")
+      (check-equal? (input-state-cursor new-inp) 2))
 
-   ;; --------------------------------------------------
-   ;; Test 10: 'kp-left (numpad arrow) also works
-   ;; --------------------------------------------------
-   (test-case "handle-key 'kp-left moves cursor left"
-     (define ctx (make-test-ctx))
-     (define inp (make-input-with-text "hello" 5))
-     (set-box! (tui-ctx-input-state-box ctx) inp)
-     (define result (handle-key ctx 'kp-left))
-     (check-equal? result 'continue)
-     (define new-inp (unbox (tui-ctx-input-state-box ctx)))
-     (check-equal? (input-state-cursor new-inp) 4))
+    ;; --------------------------------------------------
+    ;; Test 10: 'kp-left (numpad arrow) also works
+    ;; --------------------------------------------------
+    (test-case "handle-key 'kp-left moves cursor left"
+      (define ctx (make-test-ctx))
+      (define inp (make-input-with-text "hello" 5))
+      (set-box! (tui-ctx-input-state-box ctx) inp)
+      (define result (handle-key ctx 'kp-left))
+      (check-equal? result 'continue)
+      (define new-inp (unbox (tui-ctx-input-state-box ctx)))
+      (check-equal? (input-state-cursor new-inp) 4))
 
-   ;; --------------------------------------------------
-   ;; Test 11: 'kp-home (numpad home) also works
-   ;; --------------------------------------------------
-   (test-case "handle-key 'kp-home moves cursor to beginning"
-     (define ctx (make-test-ctx))
-     (define inp (make-input-with-text "hello" 5))
-     (set-box! (tui-ctx-input-state-box ctx) inp)
-     (define result (handle-key ctx 'kp-home))
-     (check-equal? result 'continue)
-     (define new-inp (unbox (tui-ctx-input-state-box ctx)))
-     (check-equal? (input-state-cursor new-inp) 0))
+    ;; --------------------------------------------------
+    ;; Test 11: 'kp-home (numpad home) also works
+    ;; --------------------------------------------------
+    (test-case "handle-key 'kp-home moves cursor to beginning"
+      (define ctx (make-test-ctx))
+      (define inp (make-input-with-text "hello" 5))
+      (set-box! (tui-ctx-input-state-box ctx) inp)
+      (define result (handle-key ctx 'kp-home))
+      (check-equal? result 'continue)
+      (define new-inp (unbox (tui-ctx-input-state-box ctx)))
+      (check-equal? (input-state-cursor new-inp) 0))
 
-   ;; --------------------------------------------------
-   ;; Test 12: 'kp-end (numpad end) also works
-   ;; --------------------------------------------------
-   (test-case "handle-key 'kp-end moves cursor to end"
-     (define ctx (make-test-ctx))
-     (define inp (make-input-with-text "hello" 2))
-     (set-box! (tui-ctx-input-state-box ctx) inp)
-     (define result (handle-key ctx 'kp-end))
-     (check-equal? result 'continue)
-     (define new-inp (unbox (tui-ctx-input-state-box ctx)))
-     (check-equal? (input-state-cursor new-inp) 5))
+    ;; --------------------------------------------------
+    ;; Test 12: 'kp-end (numpad end) also works
+    ;; --------------------------------------------------
+    (test-case "handle-key 'kp-end moves cursor to end"
+      (define ctx (make-test-ctx))
+      (define inp (make-input-with-text "hello" 2))
+      (set-box! (tui-ctx-input-state-box ctx) inp)
+      (define result (handle-key ctx 'kp-end))
+      (check-equal? result 'continue)
+      (define new-inp (unbox (tui-ctx-input-state-box ctx)))
+      (check-equal? (input-state-cursor new-inp) 5))
 
-   ;; ============================================================
-   ;; Issue #127: Ctrl+C interrupts agent when no selection active
-   ;; ============================================================
+    ;; ============================================================
+    ;; Issue #127: Ctrl+C interrupts agent when no selection active
+    ;; ============================================================
 
-   (test-case "handle-key 'ctrl-c with no selection interrupts agent"
-     (define bus (make-event-bus))
-     (define published-events '())
-     ;; Subscribe to capture published events
-     (subscribe! bus (lambda (evt)
-                       (set! published-events (cons evt published-events))))
-     (define ctx (make-tui-ctx #:event-bus bus))
-     ;; Set state to busy with no selection
-     (define busy-state
-       (struct-copy ui-state (initial-ui-state)
-                    [busy? #t]
-                    [streaming-text "partial..."]
-                    [pending-tool-name "bash"]))
-     (set-box! (tui-ctx-ui-state-box ctx) busy-state)
-     ;; Send ctrl-c
-     (define result (handle-key ctx 'ctrl-c))
-     (check-equal? result 'continue)
-     ;; Verify state is no longer busy
-     (define new-state (unbox (tui-ctx-ui-state-box ctx)))
-     (check-false (ui-state-busy? new-state) "ctrl-c clears busy state")
-     (check-false (ui-state-streaming-text new-state) "ctrl-c clears streaming text")
-     (check-false (ui-state-pending-tool-name new-state) "ctrl-c clears pending tool")
-     ;; Verify interrupt event was published
-     (check-equal? (length published-events) 1 "one event published")
-     (check-equal? (event-ev (car published-events))
-                   "interrupt.requested"
-                   "published interrupt.requested event"))
+    (test-case "handle-key 'ctrl-c with no selection interrupts agent"
+      (define bus (make-event-bus))
+      (define published-events '())
+      ;; Subscribe to capture published events
+      (subscribe! bus (lambda (evt) (set! published-events (cons evt published-events))))
+      (define ctx (make-tui-ctx #:event-bus bus))
+      ;; Set state to busy with no selection
+      (define busy-state
+        (set-pending-tool-name (set-streaming-text (set-busy (initial-ui-state) #t) "partial...")
+                               "bash"))
+      (set-box! (tui-ctx-ui-state-box ctx) busy-state)
+      ;; Send ctrl-c
+      (define result (handle-key ctx 'ctrl-c))
+      (check-equal? result 'continue)
+      ;; Verify state is no longer busy
+      (define new-state (unbox (tui-ctx-ui-state-box ctx)))
+      (check-false (ui-state-busy? new-state) "ctrl-c clears busy state")
+      (check-false (ui-state-streaming-text new-state) "ctrl-c clears streaming text")
+      (check-false (ui-state-pending-tool-name new-state) "ctrl-c clears pending tool")
+      ;; Verify interrupt event was published
+      (check-equal? (length published-events) 1 "one event published")
+      (check-equal? (event-ev (car published-events))
+                    "interrupt.requested"
+                    "published interrupt.requested event"))
 
-   (test-case "handle-key 'ctrl-c with selection copies instead of interrupting"
-     (define bus (make-event-bus))
-     (define published-events '())
-     (subscribe! bus (lambda (evt)
-                       (set! published-events (cons evt published-events))))
-     (define ctx (make-tui-ctx #:event-bus bus))
-     ;; Set state to busy WITH selection
-     (define busy-state
-       (set-selection-anchor
-        (struct-copy ui-state (initial-ui-state) [busy? #t])
-        0 0))
-     (set-box! (tui-ctx-ui-state-box ctx) busy-state)
-     ;; Send ctrl-c
-     (define result (handle-key ctx 'ctrl-c))
-     (check-equal? result 'continue)
-     ;; State should still be busy (copy, not interrupt)
-     (define new-state (unbox (tui-ctx-ui-state-box ctx)))
-     (check-true (ui-state-busy? new-state) "ctrl-c with selection keeps busy state")
-     ;; No interrupt event published
-     (check-equal? (length published-events) 0 "no interrupt event when selection active"))
+    (test-case "handle-key 'ctrl-c with selection copies instead of interrupting"
+      (define bus (make-event-bus))
+      (define published-events '())
+      (subscribe! bus (lambda (evt) (set! published-events (cons evt published-events))))
+      (define ctx (make-tui-ctx #:event-bus bus))
+      ;; Set state to busy WITH selection
+      (define busy-state (set-selection-anchor (set-busy (initial-ui-state) #t) 0 0))
+      (set-box! (tui-ctx-ui-state-box ctx) busy-state)
+      ;; Send ctrl-c
+      (define result (handle-key ctx 'ctrl-c))
+      (check-equal? result 'continue)
+      ;; State should still be busy (copy, not interrupt)
+      (define new-state (unbox (tui-ctx-ui-state-box ctx)))
+      (check-true (ui-state-busy? new-state) "ctrl-c with selection keeps busy state")
+      ;; No interrupt event published
+      (check-equal? (length published-events) 0 "no interrupt event when selection active"))
 
-   ;; ============================================================
-   ;; Issue #133: Ctrl+J (#\newline) inserts newline
-   ;; ============================================================
+    ;; ============================================================
+    ;; Issue #133: Ctrl+J (#\newline) inserts newline
+    ;; ============================================================
 
-   (test-case "handle-key #\\newline inserts newline (multi-line input)"
-     (define ctx (make-test-ctx))
-     (define inp (make-input-with-text "hello" 2))
-     (set-box! (tui-ctx-input-state-box ctx) inp)
-     (define result (handle-key ctx #\newline))
-     (check-equal? result 'continue)
-     (define new-inp (unbox (tui-ctx-input-state-box ctx)))
-     (check-equal? (input-state-buffer new-inp) "he\nllo")
-     (check-equal? (input-state-cursor new-inp) 3))
+    (test-case "handle-key #\\newline inserts newline (multi-line input)"
+      (define ctx (make-test-ctx))
+      (define inp (make-input-with-text "hello" 2))
+      (set-box! (tui-ctx-input-state-box ctx) inp)
+      (define result (handle-key ctx #\newline))
+      (check-equal? result 'continue)
+      (define new-inp (unbox (tui-ctx-input-state-box ctx)))
+      (check-equal? (input-state-buffer new-inp) "he\nllo")
+      (check-equal? (input-state-cursor new-inp) 3))
 
-   (test-case "handle-key #\\return still submits input"
-     (define ctx (make-test-ctx))
-     (define inp (make-input-with-text "hello" 5))
-     (set-box! (tui-ctx-input-state-box ctx) inp)
-     (define result (handle-key ctx #\return))
-     (check-equal? result '(submit "hello"))
-     (define new-inp (unbox (tui-ctx-input-state-box ctx)))
-     (check-equal? (input-state-buffer new-inp) ""))
-   ))
+    (test-case "handle-key #\\return still submits input"
+      (define ctx (make-test-ctx))
+      (define inp (make-input-with-text "hello" 5))
+      (set-box! (tui-ctx-input-state-box ctx) inp)
+      (define result (handle-key ctx #\return))
+      (check-equal? result '(submit "hello"))
+      (define new-inp (unbox (tui-ctx-input-state-box ctx)))
+      (check-equal? (input-state-buffer new-inp) ""))))
 
 (run-tests test-tui-keys)

--- a/tests/test-tui-queue-wiring.rkt
+++ b/tests/test-tui-queue-wiring.rkt
@@ -65,7 +65,7 @@
       (define ctx (make-tui-ctx #:session-runner runner #:session-queue q))
       ;; Mark state as busy (simulating streaming)
       (define state (unbox (tui-ctx-ui-state-box ctx)))
-      (define busy-state (struct-copy ui-state state [busy? #t]))
+      (define busy-state (set-busy state #t))
       (set-box! (tui-ctx-ui-state-box ctx) busy-state)
       ;; Simulate submit
       (define text "do another thing")
@@ -96,7 +96,7 @@
       (define ctx (make-tui-ctx #:session-runner runner #:session-queue q))
       ;; Mark state as busy
       (define state (unbox (tui-ctx-ui-state-box ctx)))
-      (define busy-state (struct-copy ui-state state [busy? #t]))
+      (define busy-state (set-busy state #t))
       (set-box! (tui-ctx-ui-state-box ctx) busy-state)
       ;; Simulate submit with queue wiring logic
       (define text "queued message")
@@ -128,7 +128,7 @@
       (define ctx (make-tui-ctx #:session-runner runner #:session-queue #f))
       ;; Mark busy
       (define state (unbox (tui-ctx-ui-state-box ctx)))
-      (define busy-state (struct-copy ui-state state [busy? #t]))
+      (define busy-state (set-busy state #t))
       (set-box! (tui-ctx-ui-state-box ctx) busy-state)
       ;; Simulate submit — no queue, so should fall through to runner
       (define text "fallback call")
@@ -150,7 +150,7 @@
       (define ctx (make-tui-ctx #:session-runner runner #:session-queue q))
       ;; Mark busy
       (define state (unbox (tui-ctx-ui-state-box ctx)))
-      (define busy-state (struct-copy ui-state state [busy? #t]))
+      (define busy-state (set-busy state #t))
       (set-box! (tui-ctx-ui-state-box ctx) busy-state)
       ;; Queue multiple messages
       (for ([msg '("first" "second" "third")])

--- a/tests/test-tui-renderer.rkt
+++ b/tests/test-tui-renderer.rkt
@@ -361,7 +361,7 @@
 
     (test-case "status bar shows busy indicator when busy"
       (define ubuf (make-mock-ubuf 80 24))
-      (define state (struct-copy ui-state (initial-ui-state #:session-id "s1") [busy? #t]))
+      (define state (set-busy (initial-ui-state #:session-id "s1") #t))
       (define input-st (initial-input-state))
       (define layout (compute-layout 80 24))
       (define status-row-num (tui-layout-status-row layout))
@@ -472,7 +472,7 @@
     ;; --------------------------------------------------------
     (test-case "render-frame! shows streaming text"
       (define ubuf (make-mock-ubuf 80 24))
-      (define state (struct-copy ui-state (initial-ui-state) [streaming-text "Partial response..."]))
+      (define state (set-streaming-text (initial-ui-state) "Partial response..."))
       (define input-st (initial-input-state))
       (define layout (compute-layout 80 24))
       (run-render-frame! ubuf state input-st layout)
@@ -552,8 +552,7 @@
                            (hasheq 'messageId "m1" 'content "Previous answer"))
           (make-test-event "tool.call.started" (hasheq 'id "tc-1" 'name "bash" 'arguments "ls"))))
   ;; Add streaming text to simulate mid-stream state
-  (define state
-    (struct-copy ui-state (simulate-events s0 events) [streaming-text "New answer streaming"]))
+  (define state (set-streaming-text (simulate-events s0 events) "New answer streaming"))
   (define input-st (initial-input-state))
   (define layout (compute-layout 80 24))
   ;; Should not raise — streaming text renders below committed entries
@@ -597,7 +596,7 @@
     (for/fold ([s (initial-ui-state)]) ([i (in-range 30)])
       (add-transcript-entry s (make-entry 'assistant (format "Line ~a" i) 0 (hash)))))
   ;; Add streaming text and scroll
-  (define state (struct-copy ui-state s0 [streaming-text "Streaming..."] [scroll-offset 10]))
+  (define state (struct-copy ui-state (set-streaming-text s0 "Streaming...") [scroll-offset 10]))
   ;; render-status-bar should include scroll indicator
   (define status-line (render-status-bar state 80))
   (define status-text (styled-line->text status-line))
@@ -610,11 +609,8 @@
 ;; Risk: Status message hides tool name
 (test-case "status bar with status-message + busy + pending-tool-name all set"
   (define state
-    (struct-copy ui-state
-                 (initial-ui-state)
-                 [busy? #t]
-                 [pending-tool-name "read"]
-                 [status-message "Compacting..."]))
+    (set-status-message (set-pending-tool-name (set-busy (initial-ui-state) #t) "read")
+                        "Compacting..."))
   (define line (render-status-bar state 80))
   (define text (styled-line->text line))
   ;; status-message should take priority in ui-status-text

--- a/tests/tui/render-integration.rkt
+++ b/tests/tui/render-integration.rkt
@@ -51,10 +51,16 @@
          [col (in-range (mock-ubuf-cols ubuf))])
     (mock-ubuf-set-cell! ubuf col row #\space #f #f 7 0)))
 
-(define (mock-ubuf-putstring! ubuf col row str
-                              #:fg [fg 7] #:bg [bg 0]
-                              #:bold [bold #f] #:underline [underline #f]
-                              #:italic [italic #f] #:blink [blink #f])
+(define (mock-ubuf-putstring! ubuf
+                              col
+                              row
+                              str
+                              #:fg [fg 7]
+                              #:bg [bg 0]
+                              #:bold [bold #f]
+                              #:underline [underline #f]
+                              #:italic [italic #f]
+                              #:blink [blink #f])
   (for ([i (in-range (string-length str))])
     (mock-ubuf-set-cell! ubuf (+ col i) row (string-ref str i) bold underline fg bg)))
 
@@ -73,8 +79,7 @@
   (define status-row (tui-layout-status-row layout))
   (define status-line (list-ref frame-lines status-row))
   ;; Status bar should have SGR codes (inverse video) and be non-empty
-  (and (string? status-line)
-       (> (string-length status-line) 0)))
+  (and (string? status-line) (> (string-length status-line) 0)))
 
 ;; Check that input line is at the expected row
 (define (frame-input-at-row? frame-lines layout)
@@ -95,8 +100,7 @@
 
 ;; Apply events to a ui-state
 (define (apply-events state events)
-  (for/fold ([st state])
-            ([ev (in-list events)])
+  (for/fold ([st state]) ([ev (in-list events)])
     (apply-event-to-state st ev)))
 
 ;; ============================================================
@@ -104,155 +108,152 @@
 ;; ============================================================
 
 (define w74-integration-tests
-  (test-suite
-   "W7.4: Tier 2 — Frame Integration Tests"
+  (test-suite "W7.4: Tier 2 — Frame Integration Tests"
 
-   ;; ── Test 1: Simple prompt+response frame ──
-   (test-case "frame: simple prompt+response has correct row count"
-     (define state (initial-ui-state #:session-id "test" #:model-name "gpt-4"))
-     (define ist (initial-input-state))
-     (define cols 80)
-     (define rows 24)
-     (define layout (compute-layout cols rows))
-     ;; Add a user message and assistant response
-     (define state-with-messages
-       (let* ([s (add-transcript-entry state (make-entry 'user "Hello!" 1000 (hash)))]
-              [s2 (add-transcript-entry s (make-entry 'assistant "Hi there!" 1001 (hash)))])
-         s2))
-     (define frame-lines (render-mock-frame state-with-messages ist cols rows))
-     ;; Frame should have exactly `rows` lines
-     (check-equal? (length frame-lines) rows "frame has correct row count")
-     ;; Status bar at expected row
-     (check-true (frame-status-at-row? frame-lines layout)
-                 "status bar at correct row")
-     ;; Input line at expected row
-     (check-true (frame-input-at-row? frame-lines layout)
-                 "input line at correct row"))
+    ;; ── Test 1: Simple prompt+response frame ──
+    (test-case "frame: simple prompt+response has correct row count"
+      (define state (initial-ui-state #:session-id "test" #:model-name "gpt-4"))
+      (define ist (initial-input-state))
+      (define cols 80)
+      (define rows 24)
+      (define layout (compute-layout cols rows))
+      ;; Add a user message and assistant response
+      (define state-with-messages
+        (let* ([s (add-transcript-entry state (make-entry 'user "Hello!" 1000 (hash)))]
+               [s2 (add-transcript-entry s (make-entry 'assistant "Hi there!" 1001 (hash)))])
+          s2))
+      (define frame-lines (render-mock-frame state-with-messages ist cols rows))
+      ;; Frame should have exactly `rows` lines
+      (check-equal? (length frame-lines) rows "frame has correct row count")
+      ;; Status bar at expected row
+      (check-true (frame-status-at-row? frame-lines layout) "status bar at correct row")
+      ;; Input line at expected row
+      (check-true (frame-input-at-row? frame-lines layout) "input line at correct row"))
 
-   ;; ── Test 2: Tool result with newlines doesn't corrupt layout ──
-   (test-case "frame: tool result with newlines doesn't corrupt layout"
-     (define state (initial-ui-state #:session-id "test" #:model-name "gpt-4"))
-     (define ist (initial-input-state))
-     (define cols 80)
-     (define rows 24)
-     (define layout (compute-layout cols rows))
-     ;; Simulate a tool result with embedded newlines (the bug scenario)
-     (define state-with-tool
-       (let* ([s (add-transcript-entry state (make-entry 'user "Read this file" 1000 (hash)))]
-              [s2 (add-transcript-entry s (make-entry 'tool-start "[TOOL: read] file.txt" 1001
-                                               (hasheq 'tool-name 'read)))]
-              ;; This is the text AFTER state.rkt sanitization (⏎ replaces \n)
-              [s3 (add-transcript-entry s2 (make-entry 'tool-end
-                                                "[OK: read] (1| foo ⏎ 2| bar ⏎ 3| baz)"
-                                                1002
-                                                (hasheq 'tool-name 'read)))]
-              [s4 (add-transcript-entry s3 (make-entry 'assistant "Done reading!" 1003 (hash)))])
-         s4))
-     (define frame-lines (render-mock-frame state-with-tool ist cols rows))
-     ;; No frame row should contain literal \n
-     (define newline-row (frame-row-contains-newline? frame-lines))
-     (check-false newline-row
-                  (if newline-row
-                      (format "frame row ~a contains \\n" newline-row)
-                      "no newlines in frame rows"))
-     ;; Status and input at correct positions
-     (check-true (frame-status-at-row? frame-lines layout) "status bar at correct row")
-     (check-true (frame-input-at-row? frame-lines layout) "input line at correct row")
-     ;; Frame has correct row count
-     (check-equal? (length frame-lines) rows "frame has correct row count"))
+    ;; ── Test 2: Tool result with newlines doesn't corrupt layout ──
+    (test-case "frame: tool result with newlines doesn't corrupt layout"
+      (define state (initial-ui-state #:session-id "test" #:model-name "gpt-4"))
+      (define ist (initial-input-state))
+      (define cols 80)
+      (define rows 24)
+      (define layout (compute-layout cols rows))
+      ;; Simulate a tool result with embedded newlines (the bug scenario)
+      (define state-with-tool
+        (let* ([s (add-transcript-entry state (make-entry 'user "Read this file" 1000 (hash)))]
+               [s2 (add-transcript-entry
+                    s
+                    (make-entry 'tool-start "[TOOL: read] file.txt" 1001 (hasheq 'tool-name 'read)))]
+               ;; This is the text AFTER state.rkt sanitization (⏎ replaces \n)
+               [s3 (add-transcript-entry s2
+                                         (make-entry 'tool-end
+                                                     "[OK: read] (1| foo ⏎ 2| bar ⏎ 3| baz)"
+                                                     1002
+                                                     (hasheq 'tool-name 'read)))]
+               [s4 (add-transcript-entry s3 (make-entry 'assistant "Done reading!" 1003 (hash)))])
+          s4))
+      (define frame-lines (render-mock-frame state-with-tool ist cols rows))
+      ;; No frame row should contain literal \n
+      (define newline-row (frame-row-contains-newline? frame-lines))
+      (check-false newline-row
+                   (if newline-row
+                       (format "frame row ~a contains \\n" newline-row)
+                       "no newlines in frame rows"))
+      ;; Status and input at correct positions
+      (check-true (frame-status-at-row? frame-lines layout) "status bar at correct row")
+      (check-true (frame-input-at-row? frame-lines layout) "input line at correct row")
+      ;; Frame has correct row count
+      (check-equal? (length frame-lines) rows "frame has correct row count"))
 
-   ;; ── Test 3: Streaming text maintains row positions ──
-   (test-case "frame: streaming text maintains correct row positions"
-     (define state (initial-ui-state #:session-id "test" #:model-name "gpt-4"))
-     (define ist (initial-input-state))
-     (define cols 80)
-     (define rows 24)
-     (define layout (compute-layout cols rows))
-     ;; Simulate streaming: state has streaming-text set
-     (define state-streaming
-       (struct-copy ui-state state
-                    [streaming-text "Thinking about this..."]
-                    [busy? #t]))
-     (define frame-lines (render-mock-frame state-streaming ist cols rows))
-     (check-equal? (length frame-lines) rows "streaming frame has correct row count")
-     (check-true (frame-status-at-row? frame-lines layout) "status bar correct during streaming")
-     (check-true (frame-input-at-row? frame-lines layout) "input correct during streaming"))
+    ;; ── Test 3: Streaming text maintains row positions ──
+    (test-case "frame: streaming text maintains correct row positions"
+      (define state (initial-ui-state #:session-id "test" #:model-name "gpt-4"))
+      (define ist (initial-input-state))
+      (define cols 80)
+      (define rows 24)
+      (define layout (compute-layout cols rows))
+      ;; Simulate streaming: state has streaming-text set
+      (define state-streaming (set-busy (set-streaming-text state "Thinking about this...") #t))
+      (define frame-lines (render-mock-frame state-streaming ist cols rows))
+      (check-equal? (length frame-lines) rows "streaming frame has correct row count")
+      (check-true (frame-status-at-row? frame-lines layout) "status bar correct during streaming")
+      (check-true (frame-input-at-row? frame-lines layout) "input correct during streaming"))
 
-   ;; ── Test 4: Resize preserves content integrity ──
-   (test-case "frame: resize preserves content integrity"
-     (define state (initial-ui-state #:session-id "test" #:model-name "gpt-4"))
-     (define ist (initial-input-state))
-     ;; Add some content at 80x24
-     (define state-with-content
-       (let* ([s (add-transcript-entry state (make-entry 'user "Hello" 1000 (hash)))]
-              [s2 (add-transcript-entry s (make-entry 'assistant "World!" 1001 (hash)))])
-         s2))
-     ;; Render at 120x30
-     (define frame-lines (render-mock-frame state-with-content ist 120 30))
-     (check-equal? (length frame-lines) 30 "resized frame has correct row count")
-     (define newline-row (frame-row-contains-newline? frame-lines))
-     (check-false newline-row "no newlines in resized frame"))
+    ;; ── Test 4: Resize preserves content integrity ──
+    (test-case "frame: resize preserves content integrity"
+      (define state (initial-ui-state #:session-id "test" #:model-name "gpt-4"))
+      (define ist (initial-input-state))
+      ;; Add some content at 80x24
+      (define state-with-content
+        (let* ([s (add-transcript-entry state (make-entry 'user "Hello" 1000 (hash)))]
+               [s2 (add-transcript-entry s (make-entry 'assistant "World!" 1001 (hash)))])
+          s2))
+      ;; Render at 120x30
+      (define frame-lines (render-mock-frame state-with-content ist 120 30))
+      (check-equal? (length frame-lines) 30 "resized frame has correct row count")
+      (define newline-row (frame-row-contains-newline? frame-lines))
+      (check-false newline-row "no newlines in resized frame"))
 
-   ;; ── Test 5: Scrolling doesn't duplicate status bar ──
-   (test-case "frame: many entries don't duplicate status bar"
-     (define state (initial-ui-state #:session-id "test" #:model-name "gpt-4"))
-     (define ist (initial-input-state))
-     (define cols 80)
-     (define rows 24)
-     (define layout (compute-layout cols rows))
-     ;; Add 50 transcript entries
-     (define state-with-many
-       (for/fold ([s state])
-                 ([i (in-range 50)])
-         (add-transcript-entry s (make-entry 'assistant
-                                      (format "Message ~a with some content" i)
-                                      (+ 1000 i)
-                                      (hash)))))
-     (define frame-lines (render-mock-frame state-with-many ist cols rows))
-     ;; Check status bar appears exactly once
-     (define status-row (tui-layout-status-row layout))
-     (define status-content (list-ref frame-lines status-row))
-     ;; Status bar content is there
-     (check-true (string? status-content) "status row has content")
-     (check-true (> (string-length status-content) 0) "status row is non-empty")
-     ;; Check no other row has the same content (no duplication)
-     (define status-appearances
-       (for/sum ([line (in-list frame-lines)]
-                 [i (in-naturals)])
-         (if (and (= i status-row) (equal? line status-content)) 0 0)))
-     ;; Just verify the frame row count is correct
-     (check-equal? (length frame-lines) rows "frame has correct row count with many entries"))
+    ;; ── Test 5: Scrolling doesn't duplicate status bar ──
+    (test-case "frame: many entries don't duplicate status bar"
+      (define state (initial-ui-state #:session-id "test" #:model-name "gpt-4"))
+      (define ist (initial-input-state))
+      (define cols 80)
+      (define rows 24)
+      (define layout (compute-layout cols rows))
+      ;; Add 50 transcript entries
+      (define state-with-many
+        (for/fold ([s state]) ([i (in-range 50)])
+          (add-transcript-entry
+           s
+           (make-entry 'assistant (format "Message ~a with some content" i) (+ 1000 i) (hash)))))
+      (define frame-lines (render-mock-frame state-with-many ist cols rows))
+      ;; Check status bar appears exactly once
+      (define status-row (tui-layout-status-row layout))
+      (define status-content (list-ref frame-lines status-row))
+      ;; Status bar content is there
+      (check-true (string? status-content) "status row has content")
+      (check-true (> (string-length status-content) 0) "status row is non-empty")
+      ;; Check no other row has the same content (no duplication)
+      (define status-appearances
+        (for/sum ([line (in-list frame-lines)] [i (in-naturals)])
+                 (if (and (= i status-row) (equal? line status-content)) 0 0)))
+      ;; Just verify the frame row count is correct
+      (check-equal? (length frame-lines) rows "frame has correct row count with many entries"))
 
-   ;; ── Test 6: Tool error + recovery renders correctly ──
-   (test-case "frame: tool error followed by recovery renders correctly"
-     (define state (initial-ui-state #:session-id "test" #:model-name "gpt-4"))
-     (define ist (initial-input-state))
-     (define cols 80)
-     (define rows 24)
-     (define layout (compute-layout cols rows))
-     ;; Simulate: tool call → error → retry → success
-     (define state-with-errors
-       (let* ([s (add-transcript-entry state (make-entry 'user "Fix the bug" 1000 (hash)))]
-              [s2 (add-transcript-entry s (make-entry 'tool-start "[TOOL: bash] make test" 1001
-                                               (hasheq 'tool-name 'bash)))]
-              ;; Error with newline (sanitized by state.rkt to ⏎)
-              [s3 (add-transcript-entry s2 (make-entry 'tool-fail
-                                                "[FAIL: bash] exit 1 ⏎ stderr output here"
-                                                1002
-                                                (hasheq 'tool-name 'bash)))]
-              [s4 (add-transcript-entry s3 (make-entry 'tool-start "[TOOL: bash] make test" 1003
-                                               (hasheq 'tool-name 'bash)))]
-              [s5 (add-transcript-entry s4 (make-entry 'tool-end "[OK: bash] All tests passed" 1004
-                                               (hasheq 'tool-name 'bash)))]
-              [s6 (add-transcript-entry s5 (make-entry 'assistant "Bug fixed!" 1005 (hash)))])
-         s6))
-     (define frame-lines (render-mock-frame state-with-errors ist cols rows))
-     ;; No newlines in frame
-     (check-false (frame-row-contains-newline? frame-lines)
-                  "no newlines in error/recovery frame")
-     ;; Correct layout
-     (check-true (frame-status-at-row? frame-lines layout) "status bar correct after error recovery")
-     (check-true (frame-input-at-row? frame-lines layout) "input correct after error recovery"))))
+    ;; ── Test 6: Tool error + recovery renders correctly ──
+    (test-case "frame: tool error followed by recovery renders correctly"
+      (define state (initial-ui-state #:session-id "test" #:model-name "gpt-4"))
+      (define ist (initial-input-state))
+      (define cols 80)
+      (define rows 24)
+      (define layout (compute-layout cols rows))
+      ;; Simulate: tool call → error → retry → success
+      (define state-with-errors
+        (let* ([s (add-transcript-entry state (make-entry 'user "Fix the bug" 1000 (hash)))]
+               [s2 (add-transcript-entry
+                    s
+                    (make-entry 'tool-start "[TOOL: bash] make test" 1001 (hasheq 'tool-name 'bash)))]
+               ;; Error with newline (sanitized by state.rkt to ⏎)
+               [s3 (add-transcript-entry s2
+                                         (make-entry 'tool-fail
+                                                     "[FAIL: bash] exit 1 ⏎ stderr output here"
+                                                     1002
+                                                     (hasheq 'tool-name 'bash)))]
+               [s4 (add-transcript-entry
+                    s3
+                    (make-entry 'tool-start "[TOOL: bash] make test" 1003 (hasheq 'tool-name 'bash)))]
+               [s5
+                (add-transcript-entry
+                 s4
+                 (make-entry 'tool-end "[OK: bash] All tests passed" 1004 (hasheq 'tool-name 'bash)))]
+               [s6 (add-transcript-entry s5 (make-entry 'assistant "Bug fixed!" 1005 (hash)))])
+          s6))
+      (define frame-lines (render-mock-frame state-with-errors ist cols rows))
+      ;; No newlines in frame
+      (check-false (frame-row-contains-newline? frame-lines) "no newlines in error/recovery frame")
+      ;; Correct layout
+      (check-true (frame-status-at-row? frame-lines layout) "status bar correct after error recovery")
+      (check-true (frame-input-at-row? frame-lines layout) "input correct after error recovery"))))
 
 ;; ============================================================
 ;; Run

--- a/tests/tui/render.rkt
+++ b/tests/tui/render.rkt
@@ -122,9 +122,7 @@
     ;; render-status-bar and render-input-line
     ;; --------------------------------------------------------
     (test-case "render-status-bar uses ASCII * when busy, not emoji"
-      (let ([state (struct-copy ui-state
-                                (initial-ui-state #:session-id "test-sess" #:model-name "gpt-4")
-                                [busy? #t])])
+      (let ([state (set-busy (initial-ui-state #:session-id "test-sess" #:model-name "gpt-4") #t)])
         (define line (render-status-bar state 80))
         (define text (styled-segment-text (first (styled-line-segments line))))
         (check-true (string-contains? text "*") "busy marker is ASCII *")
@@ -327,10 +325,8 @@
 
     (test-case "render-transcript: streaming text shown at bottom when scroll=0"
       (let* ([entries (list (make-entry 'system "line1" 0 (hash)))]
-             [state (struct-copy ui-state
-                                 (initial-ui-state)
-                                 [transcript entries]
-                                 [streaming-text "streaming..."])])
+             [state (set-streaming-text (struct-copy ui-state (initial-ui-state) [transcript entries])
+                                        "streaming...")])
         (define-values (lines _st) (render-transcript state 10 200))
         (check-equal? (length lines) 2 "streaming text appended")
         ;; Last line should be the streaming text (dim)
@@ -561,10 +557,8 @@
   (test-suite "Thinking indicator"
 
     (test-case "render-status-bar shows [thinking...] when busy with no streaming text"
-      (let ([state (struct-copy ui-state
-                                (initial-ui-state #:session-id "test-sess" #:model-name "gpt-4")
-                                [busy? #t]
-                                [streaming-text #f])])
+      (let ([state (clear-streaming
+                    (set-busy (initial-ui-state #:session-id "test-sess" #:model-name "gpt-4") #t))])
         (define line (render-status-bar state 80))
         (define text (styled-segment-text (first (styled-line-segments line))))
         (check-true (string-contains? text "[thinking...]")
@@ -577,10 +571,9 @@
         (check-false (string-contains? text "[thinking...]") "no [thinking...] when not busy")))
 
     (test-case "render-status-bar does NOT show [thinking...] when streaming text present"
-      (let ([state (struct-copy ui-state
-                                (initial-ui-state #:session-id "test-sess" #:model-name "gpt-4")
-                                [busy? #t]
-                                [streaming-text "Partial response..."])])
+      (let ([state (set-streaming-text
+                    (set-busy (initial-ui-state #:session-id "test-sess" #:model-name "gpt-4") #t)
+                    "Partial response...")])
         (define line (render-status-bar state 80))
         (define text (styled-segment-text (first (styled-line-segments line))))
         (check-false (string-contains? text "[thinking...]")
@@ -594,11 +587,11 @@
 
     (test-case "streaming-thinking shown when no streaming-text"
       (define state
-        (struct-copy ui-state
-                     (initial-ui-state #:session-id "test-sess" #:model-name "gpt-4")
-                     [busy? #t]
-                     [streaming-thinking "pondering deeply..."]
-                     [streaming-text #f]))
+        (set-streaming-text
+         (set-streaming-thinking
+          (set-busy (initial-ui-state #:session-id "test-sess" #:model-name "gpt-4") #t)
+          "pondering deeply...")
+         #f))
       (define-values (lines _st) (render-transcript state 10 200))
       (define all-text (string-join (map styled-line->text lines) "\n"))
       (check-true (string-contains? all-text "pondering deeply...")
@@ -606,11 +599,11 @@
 
     (test-case "streaming-thinking hidden when streaming-text present"
       (define state
-        (struct-copy ui-state
-                     (initial-ui-state #:session-id "test-sess" #:model-name "gpt-4")
-                     [busy? #t]
-                     [streaming-thinking "hidden thoughts"]
-                     [streaming-text "visible response"]))
+        (set-streaming-text
+         (set-streaming-thinking
+          (set-busy (initial-ui-state #:session-id "test-sess" #:model-name "gpt-4") #t)
+          "hidden thoughts")
+         "visible response"))
       (define-values (lines _st) (render-transcript state 10 200))
       (define all-text (string-join (map styled-line->text lines) "\n"))
       (check-false (string-contains? all-text "hidden thoughts")
@@ -621,10 +614,9 @@
       (define entry (transcript-entry 'thinking "persisted thought" 0 (hasheq) #f))
       (define state
         (struct-copy ui-state
-                     (initial-ui-state #:session-id "test-sess" #:model-name "gpt-4")
-                     [transcript (list entry)]
-                     [streaming-thinking #f]
-                     [streaming-text #f]))
+                     (clear-streaming (initial-ui-state #:session-id "test-sess"
+                                                        #:model-name "gpt-4"))
+                     [transcript (list entry)]))
       (define-values (lines _st) (render-transcript state 10 200))
       (define all-text (string-join (map styled-line->text lines) "\n"))
       (check-true (string-contains? all-text "persisted thought")
@@ -1008,8 +1000,7 @@
       (check-true (string-contains? text "ctx:0") "shows ctx:0 when no context"))
 
     (test-case "status bar shows error in status-message"
-      (define s
-        (struct-copy ui-state (initial-ui-state #:session-id "s1") [status-message "API key error"]))
+      (define s (set-status-message (initial-ui-state #:session-id "s1") "API key error"))
       (define line (render-status-bar s 80))
       (define text (styled-line->text line))
       (check-true (string-contains? text "API key error") "error shown in status bar"))))

--- a/tests/tui/state.rkt
+++ b/tests/tui/state.rkt
@@ -141,18 +141,15 @@
         (check-true (ui-state-busy? s2))))
 
     (test-case "apply-event: turn.completed"
-      (let* ([s (struct-copy ui-state (initial-ui-state) [busy? #t])]
+      (let* ([s (set-busy (initial-ui-state) #t)]
              [evt (make-test-event "turn.completed" (hash))]
              [s2 (apply-event-to-state s evt)])
         (check-false (ui-state-busy? s2))))
 
     (test-case "turn.cancelled clears busy and streaming"
       (define s0
-        (struct-copy ui-state
-                     (initial-ui-state)
-                     [busy? #t]
-                     [streaming-text "partial..."]
-                     [pending-tool-name "bash"]))
+        (set-pending-tool-name (set-streaming-text (set-busy (initial-ui-state) #t) "partial...")
+                               "bash"))
       (define evt (make-test-event "turn.cancelled" (hash)))
       (define s1 (apply-event-to-state s0 evt))
       (check-false (ui-state-busy? s1))
@@ -180,7 +177,7 @@
         (check-equal? (ui-state-status-message s2) "Compacting...")))
 
     (test-case "apply-event: compaction.completed"
-      (let* ([s (struct-copy ui-state (initial-ui-state) [status-message "Compacting..."])]
+      (let* ([s (set-status-message (initial-ui-state) "Compacting...")]
              [evt (make-test-event "compaction.completed" (hash))]
              [s2 (apply-event-to-state s evt)])
         (check-false (ui-state-status-message s2))))
@@ -265,7 +262,7 @@
 
     (test-case "ui-busy?: reflects busy state"
       (check-false (ui-busy? (initial-ui-state)))
-      (check-true (ui-busy? (struct-copy ui-state (initial-ui-state) [busy? #t]))))
+      (check-true (ui-busy? (set-busy (initial-ui-state) #t))))
 
     (test-case "ui-session-label: returns session id or default"
       (check-equal? (ui-session-label (initial-ui-state)) "no session")
@@ -277,13 +274,11 @@
 
     (test-case "ui-status-text: idle / busy / tool / status-message"
       (check-equal? (ui-status-text (initial-ui-state)) "idle")
-      (check-equal? (ui-status-text (struct-copy ui-state (initial-ui-state) [busy? #t])) "busy...")
-      (check-equal? (ui-status-text
-                     (struct-copy ui-state (initial-ui-state) [busy? #t] [pending-tool-name "bash"]))
+      (check-equal? (ui-status-text (set-busy (initial-ui-state) #t)) "busy...")
+      (check-equal? (ui-status-text (set-pending-tool-name (set-busy (initial-ui-state) #t) "bash"))
                     "busy (bash)...")
-      (check-equal?
-       (ui-status-text (struct-copy ui-state (initial-ui-state) [status-message "Compacting..."]))
-       "Compacting..."))
+      (check-equal? (ui-status-text (set-status-message (initial-ui-state) "Compacting..."))
+                    "Compacting..."))
 
     ;; ============================================================
     ;; Multiple events accumulate
@@ -556,42 +551,40 @@
     ;; ============================================================
 
     (test-case "BUG-29: runtime.error clears pending-tool-name"
-      (define s0 (struct-copy ui-state (initial-ui-state) [busy? #t] [pending-tool-name "bash"]))
+      (define s0 (set-pending-tool-name (set-busy (initial-ui-state) #t) "bash"))
       (define evt (make-test-event "runtime.error" (hash 'error "crash")))
       (define s1 (apply-event-to-state s0 evt))
       (check-false (ui-state-pending-tool-name s1) "runtime.error clears pending-tool-name")
       (check-false (ui-state-busy? s1) "runtime.error clears busy?"))
 
     (test-case "BUG-29: runtime.error clears streaming-text"
-      (define s0
-        (struct-copy ui-state (initial-ui-state) [busy? #t] [streaming-text "partial response..."]))
+      (define s0 (set-streaming-text (set-busy (initial-ui-state) #t) "partial response..."))
       (define evt (make-test-event "runtime.error" (hash 'error "crash")))
       (define s1 (apply-event-to-state s0 evt))
       (check-false (ui-state-streaming-text s1) "runtime.error clears streaming-text"))
 
     (test-case "BUG-30: turn.started clears stale pending-tool-name"
-      (define s0 (struct-copy ui-state (initial-ui-state) [pending-tool-name "old-tool"]))
+      (define s0 (set-pending-tool-name (initial-ui-state) "old-tool"))
       (define evt (make-test-event "turn.started" (hash)))
       (define s1 (apply-event-to-state s0 evt))
       (check-false (ui-state-pending-tool-name s1) "turn.started clears pending-tool-name")
       (check-true (ui-state-busy? s1) "turn.started sets busy?"))
 
     (test-case "BUG-30: turn.started clears stale streaming-text"
-      (define s0 (struct-copy ui-state (initial-ui-state) [streaming-text "stale stream text"]))
+      (define s0 (set-streaming-text (initial-ui-state) "stale stream text"))
       (define evt (make-test-event "turn.started" (hash)))
       (define s1 (apply-event-to-state s0 evt))
       (check-false (ui-state-streaming-text s1) "turn.started clears streaming-text"))
 
     (test-case "BUG-31: turn.completed clears pending-tool-name"
-      (define s0 (struct-copy ui-state (initial-ui-state) [busy? #t] [pending-tool-name "read"]))
+      (define s0 (set-pending-tool-name (set-busy (initial-ui-state) #t) "read"))
       (define evt (make-test-event "turn.completed" (hash)))
       (define s1 (apply-event-to-state s0 evt))
       (check-false (ui-state-pending-tool-name s1) "turn.completed clears pending-tool-name")
       (check-false (ui-state-busy? s1) "turn.completed clears busy?"))
 
     (test-case "BUG-31: turn.completed clears streaming-text"
-      (define s0
-        (struct-copy ui-state (initial-ui-state) [busy? #t] [streaming-text "leftover stream"]))
+      (define s0 (set-streaming-text (set-busy (initial-ui-state) #t) "leftover stream"))
       (define evt (make-test-event "turn.completed" (hash)))
       (define s1 (apply-event-to-state s0 evt))
       (check-false (ui-state-streaming-text s1) "turn.completed clears streaming-text"))
@@ -607,7 +600,7 @@
       (check-equal? (ui-state-status-message s1) "Compacting..."))
 
     (test-case "BUG-32: compaction.end clears status message"
-      (define s0 (struct-copy ui-state (initial-ui-state) [status-message "Compacting..."]))
+      (define s0 (set-status-message (initial-ui-state) "Compacting..."))
       (define evt (make-test-event "compaction.end" (hash)))
       (define s1 (apply-event-to-state s0 evt))
       (check-false (ui-state-status-message s1)))
@@ -623,7 +616,7 @@
       (check-not-false (string-contains? (transcript-entry-text last-entry) "retry")))
 
     (test-case "BUG-34: model.stream.completed clears streaming-text"
-      (define s0 (struct-copy ui-state (initial-ui-state) [busy? #t] [streaming-text "partial..."]))
+      (define s0 (set-streaming-text (set-busy (initial-ui-state) #t) "partial..."))
       (define evt (make-test-event "model.stream.completed" (hash)))
       (define s1 (apply-event-to-state s0 evt))
       (check-false (ui-state-streaming-text s1) "model.stream.completed clears streaming-text"))
@@ -634,7 +627,7 @@
 
     (test-case "BUG-38: tool.call.started guards against pending overwrite"
       ;; If a tool is already pending, don't overwrite its name
-      (define s0 (struct-copy ui-state (initial-ui-state) [busy? #t] [pending-tool-name "read"]))
+      (define s0 (set-pending-tool-name (set-busy (initial-ui-state) #t) "read"))
       (define evt
         (make-test-event "tool.call.started" (hash 'name "bash" 'arguments "{\"cmd\":\"ls\"}")))
       (define s1 (apply-event-to-state s0 evt))
@@ -658,21 +651,30 @@
 
 (let ()
   (define state (initial-ui-state))
-  (check-false (selection-state-anchor (ui-state-selection state)) "initial-ui-state: sel-anchor is #f")
+  (check-false (selection-state-anchor (ui-state-selection state))
+               "initial-ui-state: sel-anchor is #f")
   (check-false (selection-state-end (ui-state-selection state)) "initial-ui-state: sel-end is #f")
   (check-false (has-selection? state) "has-selection? returns #f initially"))
 
 (let ()
   (define state (initial-ui-state))
   (define next (set-selection-anchor state 5 10))
-  (check-equal? (selection-state-anchor (ui-state-selection next)) '(5 . 10) "set-selection-anchor sets anchor")
-  (check-equal? (selection-state-end (ui-state-selection next)) '(5 . 10) "set-selection-anchor also sets end"))
+  (check-equal? (selection-state-anchor (ui-state-selection next))
+                '(5 . 10)
+                "set-selection-anchor sets anchor")
+  (check-equal? (selection-state-end (ui-state-selection next))
+                '(5 . 10)
+                "set-selection-anchor also sets end"))
 
 (let ()
   (define state (set-selection-anchor (initial-ui-state) 5 10))
   (define next (set-selection-end state 20 30))
-  (check-equal? (selection-state-end (ui-state-selection next)) '(20 . 30) "set-selection-end updates end")
-  (check-equal? (selection-state-anchor (ui-state-selection next)) '(5 . 10) "set-selection-end preserves anchor"))
+  (check-equal? (selection-state-end (ui-state-selection next))
+                '(20 . 30)
+                "set-selection-end updates end")
+  (check-equal? (selection-state-anchor (ui-state-selection next))
+                '(5 . 10)
+                "set-selection-end preserves anchor"))
 
 (let ()
   (define state (set-selection-end (set-selection-anchor (initial-ui-state) 5 10) 20 30))
@@ -698,7 +700,8 @@
   (define s (set-selection-end (set-selection-anchor (initial-ui-state) 5 10) 20 30))
   (define scrolled (scroll-down s))
   (check-false (has-selection? scrolled) "scroll-down clears selection")
-  (check-false (selection-state-anchor (ui-state-selection scrolled)) "scroll-down clears sel-anchor"))
+  (check-false (selection-state-anchor (ui-state-selection scrolled))
+               "scroll-down clears sel-anchor"))
 
 (let ()
   ;; scroll-up preserves offset when no selection
@@ -715,13 +718,13 @@
   (check-equal? (ui-state-scroll-offset state+sel) 0 "set-selection-anchor preserves scroll-offset"))
 
 (test-case "model.request.started marks busy"
-  (define s0 (struct-copy ui-state (initial-ui-state) [busy? #f]))
+  (define s0 (set-busy (initial-ui-state) #f))
   (define evt (make-test-event "model.request.started" (hash)))
   (define s1 (apply-event-to-state s0 evt))
   (check-true (ui-state-busy? s1)))
 
 (test-case "tool.call.blocked shows in transcript"
-  (define s0 (struct-copy ui-state (initial-ui-state) [pending-tool-name "bash"]))
+  (define s0 (set-pending-tool-name (initial-ui-state) "bash"))
   (define evt (make-test-event "tool.call.blocked" (hash 'name "bash" 'reason "security policy")))
   (define s1 (apply-event-to-state s0 evt))
   (check-false (ui-state-pending-tool-name s1))
@@ -730,14 +733,14 @@
   (check-not-false (string-contains? (transcript-entry-text last-entry) "tool blocked")))
 
 (test-case "context.built stores tokenCount"
-  (define s0 (struct-copy ui-state (initial-ui-state) [busy? #t] [session-id "s1"]))
+  (define s0 (struct-copy ui-state (set-busy (initial-ui-state) #t) [session-id "s1"]))
   (define evt (make-test-event "context.built" (hash 'tokenCount 42)))
   (define s1 (apply-event-to-state s0 evt))
   (check-equal? (ui-state-context-tokens s1) 42) ; v0.19.12 W1: stores token count
   (check-not-equal? s1 s0 "context.built now returns new state with token count"))
 
 (test-case "context.built without tokenCount is passthrough"
-  (define s0 (struct-copy ui-state (initial-ui-state) [busy? #t] [session-id "s1"]))
+  (define s0 (struct-copy ui-state (set-busy (initial-ui-state) #t) [session-id "s1"]))
   (define evt (make-test-event "context.built" (hash)))
   (define s1 (apply-event-to-state s0 evt))
   (check-eq? s1 s0 "context.built without tokenCount returns state unchanged"))
@@ -747,7 +750,7 @@
 ;; ============================================================
 
 (test-case "model.stream.delta accumulates text"
-  (define s0 (struct-copy ui-state (initial-ui-state) [streaming-text "Hello"]))
+  (define s0 (set-streaming-text (initial-ui-state) "Hello"))
   (define evt (make-test-event "model.stream.delta" (hash 'delta " world")))
   (define s1 (apply-event-to-state s0 evt))
   (check-equal? (ui-state-streaming-text s1) "Hello world")

--- a/tests/tui/test-event-reducer-registry.rkt
+++ b/tests/tui/test-event-reducer-registry.rkt
@@ -65,7 +65,7 @@
   (check-false (ui-state-streaming-text st1)))
 
 (test-case "turn.cancelled clears busy and streaming"
-  (define st0 (struct-copy ui-state (initial-ui-state) [busy? #t] [streaming-text "partial text"]))
+  (define st0 (set-streaming-text (set-busy (initial-ui-state) #t) "partial text"))
   (define st1 (apply-event-to-state st0 (make-test-event "turn.cancelled" (hash))))
   (check-false (ui-state-busy? st1))
   (check-false (ui-state-streaming-text st1)))

--- a/tests/tui/test-render-status-line.rkt
+++ b/tests/tui/test-render-status-line.rkt
@@ -67,7 +67,7 @@
     ;; Busy + thinking
     ;; --------------------------------------------------------
     (test-case "busy with no streaming shows [thinking...]"
-      (define state (struct-copy ui-state (initial-ui-state) [busy? #t]))
+      (define state (set-busy (initial-ui-state) #t))
       (define result (render-status-bar state 80))
       (define text (styled-segment-text (first-segment result)))
       (check-true (string-contains? text "[thinking...]")))
@@ -76,7 +76,7 @@
     ;; Busy + tool
     ;; --------------------------------------------------------
     (test-case "busy with pending tool shows [tool-name]"
-      (define state (struct-copy ui-state (initial-ui-state) [busy? #t] [pending-tool-name "bash"]))
+      (define state (set-pending-tool-name (set-busy (initial-ui-state) #t) "bash"))
       (define result (render-status-bar state 80))
       (define text (styled-segment-text (first-segment result)))
       (check-true (string-contains? text "[bash]")))
@@ -85,7 +85,7 @@
     ;; Busy + streaming
     ;; --------------------------------------------------------
     (test-case "busy with streaming text shows [streaming...]"
-      (define state (struct-copy ui-state (initial-ui-state) [busy? #t] [streaming-text "Hello"]))
+      (define state (set-streaming-text (set-busy (initial-ui-state) #t) "Hello"))
       (define result (render-status-bar state 80))
       (define text (styled-segment-text (first-segment result)))
       (check-true (string-contains? text "[streaming...]")))
@@ -138,8 +138,7 @@
     (test-case "single segment length fits within width"
       (define state
         (struct-copy ui-state
-                     (initial-ui-state #:model-name "gpt-4o")
-                     [busy? #t]
+                     (set-busy (initial-ui-state #:model-name "gpt-4o") #t)
                      [context-tokens 12000]))
       (define width 80)
       (define result (render-status-bar state width))

--- a/tools/scheduler.rkt
+++ b/tools/scheduler.rkt
@@ -18,7 +18,6 @@
                   tool?
                   tool-name
                   tool-schema
-                  tool-execute
                   make-tool
                   make-tool-registry
                   tool-registry?
@@ -43,6 +42,7 @@
                   tool-call-id
                   tool-call-name
                   tool-call-arguments)
+         (only-in "tool-struct.rkt" tool-execute)
          (only-in "../util/hook-types.rkt" hook-result? hook-result-action hook-result-payload)
          (only-in "../util/safe-mode-predicates.rkt"
                   safe-mode?

--- a/tui/state-events.rkt
+++ b/tui/state-events.rkt
@@ -87,18 +87,15 @@
              (string=? (string-trim content) ""))
         (append-entry state (make-entry 'thinking thinking ts (hash)))
         state))
-  (struct-copy ui-state
-               (append-entry s0 (make-entry 'assistant content ts (hash)))
-               [busy? #f]
-               [pending-tool-name #f]
-               [streaming-text #f]
-               [streaming-thinking #f]))
+  (clear-streaming (set-pending-tool-name
+                    (set-busy (append-entry s0 (make-entry 'assistant content ts (hash))) #f)
+                    #f)))
 
 (define (handle-tool-call-started state evt)
   (define payload (event-payload evt))
   (define name (hash-ref payload 'name "?"))
   (if (recent-tool-start? state name)
-      (struct-copy ui-state state [busy? #t] [pending-tool-name name])
+      (set-pending-tool-name (set-busy state #t) name)
       (let* ([args-raw (hash-ref payload 'arguments #f)]
              [arg-summary (if args-raw
                               (extract-arg-summary args-raw)
@@ -108,14 +105,14 @@
              [meta (hasheq 'name name 'arguments (or args-raw ""))]
              [new-state (append-entry state (make-entry 'tool-start text ts meta))])
         (if (ui-state-pending-tool-name state)
-            (struct-copy ui-state new-state [busy? #t])
-            (struct-copy ui-state new-state [busy? #t] [pending-tool-name name])))))
+            (set-busy new-state #t)
+            (set-pending-tool-name (set-busy new-state #t) name)))))
 
 (define (handle-tool-execution-started state evt)
   (define payload (event-payload evt))
   (define name (hash-ref payload 'tool-name "?"))
   (if (recent-tool-start? state name)
-      (struct-copy ui-state state [busy? #t] [pending-tool-name name])
+      (set-pending-tool-name (set-busy state #t) name)
       (let* ([args-raw (hash-ref payload 'arguments #f)]
              [arg-summary (if args-raw
                               (extract-arg-summary args-raw)
@@ -125,8 +122,8 @@
              [meta (hasheq 'name name 'arguments (or args-raw ""))]
              [new-state (append-entry state (make-entry 'tool-start text ts meta))])
         (if (ui-state-pending-tool-name state)
-            (struct-copy ui-state new-state [busy? #t])
-            (struct-copy ui-state new-state [busy? #t] [pending-tool-name name])))))
+            (set-busy new-state #t)
+            (set-pending-tool-name (set-busy new-state #t) name)))))
 
 (define (handle-tool-execution-completed state evt)
   (define payload (event-payload evt))
@@ -134,17 +131,13 @@
   (define result-summary (hash-ref payload 'result-summary 'error))
   (define ts (event-time evt))
   (if (recent-tool-end? state name)
-      (struct-copy ui-state state [pending-tool-name #f])
+      (set-pending-tool-name state #f)
       (if (eq? result-summary 'completed)
           (let* ([meta (hasheq 'name name)])
-            (struct-copy ui-state
-                         (append-entry state (make-entry 'tool-end "" ts meta))
-                         [pending-tool-name #f]))
+            (set-pending-tool-name (append-entry state (make-entry 'tool-end "" ts meta)) #f))
           (let* ([err "tool failed"]
                  [meta (hasheq 'name name 'error err)])
-            (struct-copy ui-state
-                         (append-entry state (make-entry 'tool-fail err ts meta))
-                         [pending-tool-name #f])))))
+            (set-pending-tool-name (append-entry state (make-entry 'tool-fail err ts meta)) #f)))))
 
 ;; M-09: Extracted error classification (pure function)
 (define (classify-error-type err payload)
@@ -204,13 +197,8 @@
         (append-entry state (make-entry 'assistant streamed ts (hasheq 'partial #t)))
         state))
   (define s1
-    (struct-copy ui-state
-                 s0
-                 [busy? #f]
-                 [pending-tool-name #f]
-                 [streaming-text #f]
-                 [streaming-thinking #f]
-                 [status-message (truncate-status-msg err)]))
+    (set-status-message (clear-streaming (set-pending-tool-name (set-busy s0 #f) #f))
+                        (truncate-status-msg err)))
   (define s2 (append-entry s1 (make-entry 'error (format "Error: ~a" err) ts (hash))))
   (append-entry s2 (make-entry 'system hint ts (hash))))
 
@@ -231,17 +219,12 @@
   (define delta (hash-ref payload 'delta ""))
   (define current-streaming (ui-state-streaming-text state))
   (define new-streaming (string-append (or current-streaming "") delta))
-  (struct-copy ui-state state [streaming-text new-streaming] [busy? #t]))
+  (set-streaming-text (set-busy state #t) new-streaming))
 
 (define (handle-turn-started state evt)
-  (struct-copy ui-state
-               state
-               [busy? #t]
-               [busy-since (event-time evt)]
-               [pending-tool-name #f]
-               [streaming-text #f]
-               [streaming-thinking #f]
-               [status-message #f]))
+  (set-status-message
+   (clear-streaming (set-pending-tool-name (set-busy-since (set-busy state #t) (event-time evt)) #f))
+   #f))
 
 (define (handle-turn-completed state evt)
   (define min-busy-ms 500)
@@ -252,22 +235,11 @@
         (- ts since)
         min-busy-ms))
   (if (< elapsed min-busy-ms)
-      (struct-copy ui-state state [streaming-text #f] [streaming-thinking #f])
-      (struct-copy ui-state
-                   state
-                   [busy? #f]
-                   [busy-since #f]
-                   [streaming-text #f]
-                   [streaming-thinking #f]
-                   [pending-tool-name #f])))
+      (clear-streaming state)
+      (clear-streaming (set-pending-tool-name (set-busy-since (set-busy state #f) #f) #f))))
 
 (define (handle-turn-cancelled state evt)
-  (struct-copy ui-state
-               state
-               [busy? #f]
-               [streaming-text #f]
-               [streaming-thinking #f]
-               [pending-tool-name #f]))
+  (clear-streaming (set-pending-tool-name (set-busy state #f) #f)))
 
 (define (handle-compaction-warning state evt)
   (define payload (event-payload evt))
@@ -286,8 +258,8 @@
   (define payload (event-payload evt))
   (define reason (hash-ref payload 'reason ""))
   (if (string=? reason "compaction-complete")
-      (struct-copy ui-state state [status-message #f])
-      (struct-copy ui-state state [status-message "Compacting..."])))
+      (set-status-message state #f)
+      (set-status-message state "Compacting...")))
 
 (define (handle-auto-retry state evt)
   (define payload (event-payload evt))
@@ -305,22 +277,16 @@
     (if type-label
         (format "[retry: ~a, ~a/~a...]" type-label attempt max-attempts)
         (format "[retry: attempt ~a/~a]" attempt max-attempts)))
-  (struct-copy ui-state
-               (append-entry state (make-entry 'system msg (event-time evt) (hash)))
-               [streaming-text #f]
-               [streaming-thinking #f]))
+  (clear-streaming (append-entry state (make-entry 'system msg (event-time evt) (hash)))))
 
 (define (handle-injection state evt)
   (define payload (event-payload evt))
   (define content-type (hash-ref payload 'content-type "unknown"))
   (define msg (format "[injected ~a message]" content-type))
-  (struct-copy ui-state
-               (append-entry state (make-entry 'system msg (event-time evt) (hash)))
-               [streaming-text #f]
-               [streaming-thinking #f]))
+  (clear-streaming (append-entry state (make-entry 'system msg (event-time evt) (hash)))))
 
 (define (handle-model-request-started state evt)
-  (struct-copy ui-state state [busy? #t]))
+  (set-busy state #t))
 
 (define (handle-context-built state evt)
   (define payload (event-payload evt))
@@ -333,13 +299,12 @@
   (define payload (event-payload evt))
   (define name (hash-ref payload 'name "?"))
   (define reason (hash-ref payload 'reason "blocked by extension"))
-  (struct-copy ui-state
-               (append-entry state
-                             (make-entry 'system
-                                         (format "[tool blocked: ~a -- ~a]" name reason)
-                                         (event-time evt)
-                                         (hasheq 'name name)))
-               [pending-tool-name #f]))
+  (set-pending-tool-name (append-entry state
+                                       (make-entry 'system
+                                                   (format "[tool blocked: ~a -- ~a]" name reason)
+                                                   (event-time evt)
+                                                   (hasheq 'name name)))
+                         #f))
 
 (define (handle-queue-status-update state evt)
   (define payload (event-payload evt))
@@ -405,30 +370,27 @@
         (format "[OK: ~a] ~a" name result-summary)))
   (define ts (event-time evt))
   (define meta (hasheq 'name name 'result (or result-raw "")))
-  (struct-copy ui-state
-               (append-entry state (make-entry 'tool-end text ts meta))
-               [pending-tool-name #f]))
+  (set-pending-tool-name (append-entry state (make-entry 'tool-end text ts meta)) #f))
 
 (define (handle-tool-call-failed state evt)
   (define payload (event-payload evt))
   (define name (hash-ref payload 'name "?"))
   (define err (hash-ref payload 'error "unknown"))
   (define ts (event-time evt))
-  (struct-copy ui-state
-               (append-entry state
-                             (make-entry 'tool-fail
-                                         (string-replace (format "[FAIL: ~a] ~a" name err) "\n" " | ")
-                                         ts
-                                         (hasheq 'name name 'error err)))
-               [pending-tool-name #f]))
+  (set-pending-tool-name
+   (append-entry state
+                 (make-entry 'tool-fail
+                             (string-replace (format "[FAIL: ~a] ~a" name err) "\n" " | ")
+                             ts
+                             (hasheq 'name name 'error err)))
+   #f))
 
 (define (handle-compaction-lifecycle state evt)
   (define ev (event-ev evt))
   (cond
     [(member ev '("compaction.started" "compaction.start"))
-     (struct-copy ui-state state [status-message "Compacting..."])]
-    [(member ev '("compaction.completed" "compaction.end"))
-     (struct-copy ui-state state [status-message #f])]
+     (set-status-message state "Compacting...")]
+    [(member ev '("compaction.completed" "compaction.end")) (set-status-message state #f)]
     [else state]))
 
 (define (handle-auto-retry-lifecycle state evt)
@@ -450,10 +412,7 @@
        (if type-label
            (format "[retry: ~a, ~a/~a...]" type-label attempt max-attempts)
            (format "[retry: attempt ~a/~a]" attempt max-attempts)))
-     (struct-copy ui-state
-                  (append-entry state (make-entry 'system msg (event-time evt) (hash)))
-                  [streaming-text #f]
-                  [streaming-thinking #f])]
+     (clear-streaming (append-entry state (make-entry 'system msg (event-time evt) (hash))))]
     [(equal? ev "auto-retry.context-reduced")
      (define original (hash-ref payload 'original-messages 0))
      (define reduced (hash-ref payload 'reduced-messages 0))
@@ -469,7 +428,7 @@
   (define delta (hash-ref payload 'delta ""))
   (define current-thinking (ui-state-streaming-thinking state))
   (define new-thinking (string-append (or current-thinking "") delta))
-  (struct-copy ui-state state [streaming-thinking new-thinking] [busy? #t]))
+  (set-streaming-thinking (set-busy state #t) new-thinking))
 
 (define (handle-model-stream-completed state evt)
   (define payload (event-payload evt))
@@ -479,7 +438,7 @@
   (define ct (ui-state-cost-tracker state))
   (when ct
     (cost-tracker-update! ct in-tok out-tok (ui-model-label state)))
-  (struct-copy ui-state state [streaming-text #f] [streaming-thinking #f]))
+  (clear-streaming state))
 
 ;; ============================================================
 ;; Register all handlers at module load time

--- a/tui/state-types.rkt
+++ b/tui/state-types.rkt
@@ -15,6 +15,7 @@
          (struct-out ui-state)
          (struct-out selection-state)
          (struct-out cache-state)
+         (struct-out streaming-state)
          (struct-out branch-info)
          (struct-out overlay-state)
          (struct-out tree-browser-state)
@@ -36,6 +37,26 @@
          rendered-cache-invalidate-entry
          rendered-cache-width-valid?
          rendered-cache-set-width
+         ui-state-rendered-cache
+         ui-state-rendered-cache-width
+
+         ;; Backward-compatible streaming accessors (v0.38.6 migration)
+         ui-state-busy?
+         ui-state-status-message
+         ui-state-pending-tool-name
+         ui-state-streaming-text
+         ui-state-streaming-thinking
+         ui-state-busy-since
+
+         ;; Streaming update helpers
+         update-streaming
+         set-busy
+         set-status-message
+         set-pending-tool-name
+         set-streaming-text
+         set-streaming-thinking
+         set-busy-since
+         clear-streaming
 
          ;; String helpers
          truncate-string
@@ -52,19 +73,26 @@
   #:transparent)
 
 ;; Selection state -- cursor position and selection range
-(struct selection-state (anchor end)
-  #:transparent)
+(struct selection-state (anchor end) #:transparent)
 
 ;; Cache state -- rendered content cache
-(struct cache-state (entries width)
+(struct cache-state (entries width) #:transparent)
+
+;; Streaming state — turn activity / partial output group
+(struct streaming-state
+        (busy? ; boolean — is the agent currently processing?
+         status-message ; string or #f — temporary status
+         pending-tool-name ; string or #f — name of tool currently executing
+         streaming-text ; string or #f — partial streaming text
+         streaming-thinking ; string or #f — accumulated thinking text
+         busy-since) ; any/c — timestamp when busy started
   #:transparent)
 
-;; The complete UI state (27 fields, grouped by domain)
+;; The complete UI state (21 fields, grouped by domain)
 ;;
-;; Field groups (v0.32.6 documentation):
+;; Field groups (v0.38.6 documentation):
 ;;   Transcript:  transcript, scroll-offset, next-entry-id
-;;   Streaming:   busy?, status-message, pending-tool-name, streaming-text,
-;;                streaming-thinking, busy-since
+;;   Streaming:   streaming (streaming-state)
 ;;   Selection:   selection (selection-state)
 ;;   Branch:      current-branch, visible-branches
 ;;   Cache:       cache (cache-state)
@@ -79,17 +107,12 @@
 (struct ui-state
         (transcript ; (listof transcript-entry) — newest LAST
          scroll-offset ; integer — 0 = bottom, positive = scrolled up
-         ;; --- Streaming group ---
-         busy? ; boolean — is the agent currently processing?
          ;; --- Session group ---
          session-id ; string or #f
          model-name ; string or #f
          mode ; symbol: 'chat | 'single | etc.
-         ;; --- Streaming group (cont.) ---
-         status-message ; string or #f — temporary status
-         pending-tool-name ; string or #f — name of tool currently executing
-         streaming-text ; string or #f — partial streaming text (during model.stream.delta)
-         streaming-thinking ; string or #f — accumulated thinking text (during model.stream.thinking)
+         ;; --- Streaming group ---
+         streaming ; streaming-state — turn activity / partial output
          ;; --- Branch group ---
          current-branch ; string or #f — current branch node id
          visible-branches ; (listof branch-info) — cached branch list for display
@@ -114,9 +137,7 @@
          editor-component ; (or/c #f q-component?) — custom editor for input area (#1150)
          ;; --- Budget group ---
          context-tokens ; (or/c #f integer?) — estimated token count from context events (v0.19.12 W1)
-         cost-tracker ; (or/c #f cost-tracker?) — mutable cost accumulator (G8.4)
-         ;; --- Streaming group (cont.) ---
-         busy-since)
+         cost-tracker) ; (or/c #f cost-tracker?) — mutable cost accumulator (G8.4)
   #:transparent)
 
 ;; Overlay state for modal/popup UI elements (command palette, etc.)
@@ -192,7 +213,9 @@
                     ([k (in-list (take sorted-keys
                                        (- (hash-count new-cache) RENDER-CACHE-MAX-SIZE)))])
             (hash-remove c k)))))
-  (struct-copy ui-state state [cache (cache-state pruned-cache (cache-state-width (ui-state-cache state)))]))
+  (struct-copy ui-state
+               state
+               [cache (cache-state pruned-cache (cache-state-width (ui-state-cache state)))]))
 
 (define (rendered-cache-clear state)
   (struct-copy ui-state state [cache (cache-state (hash) #f)]))
@@ -200,14 +223,24 @@
 (define (rendered-cache-invalidate-entry state entry-id)
   (struct-copy ui-state
                state
-               [cache (cache-state (hash-remove (cache-state-entries (ui-state-cache state)) entry-id)
-                                   (cache-state-width (ui-state-cache state)))]))
+               [cache
+                (cache-state (hash-remove (cache-state-entries (ui-state-cache state)) entry-id)
+                             (cache-state-width (ui-state-cache state)))]))
 
 (define (rendered-cache-width-valid? state width)
   (equal? (cache-state-width (ui-state-cache state)) width))
 
 (define (rendered-cache-set-width state width)
-  (struct-copy ui-state state [cache (cache-state (cache-state-entries (ui-state-cache state)) width)]))
+  (struct-copy ui-state
+               state
+               [cache (cache-state (cache-state-entries (ui-state-cache state)) width)]))
+
+;; Backward-compatible cache accessors (v0.38.6: cache-state sub-struct)
+(define (ui-state-rendered-cache state)
+  (cache-state-entries (ui-state-cache state)))
+
+(define (ui-state-rendered-cache-width state)
+  (cache-state-width (ui-state-cache state)))
 
 ;; ============================================================
 ;; Constructor with defaults
@@ -218,14 +251,10 @@
                           #:mode [mode 'chat])
   (ui-state '() ; transcript
             0 ; scroll-offset
-            #f ; busy?
             session-id
             model-name
             mode
-            #f ; status-message
-            #f ; pending-tool-name
-            #f ; streaming-text
-            #f ; streaming-thinking
+            (streaming-state #f #f #f #f #f #f) ; streaming
             #f ; current-branch
             '() ; visible-branches
             (selection-state #f #f)
@@ -240,8 +269,59 @@
             #f ; focused-component
             #f ; editor-component
             #f ; context-tokens
-            (make-cost-tracker) ; cost-tracker
-            #f))
+            (make-cost-tracker)))
+
+;; ============================================================
+;; Backward-compatible streaming accessors (v0.38.6)
+;; ============================================================
+
+(define (ui-state-busy? state)
+  (streaming-state-busy? (ui-state-streaming state)))
+
+(define (ui-state-status-message state)
+  (streaming-state-status-message (ui-state-streaming state)))
+
+(define (ui-state-pending-tool-name state)
+  (streaming-state-pending-tool-name (ui-state-streaming state)))
+
+(define (ui-state-streaming-text state)
+  (streaming-state-streaming-text (ui-state-streaming state)))
+
+(define (ui-state-streaming-thinking state)
+  (streaming-state-streaming-thinking (ui-state-streaming state)))
+
+(define (ui-state-busy-since state)
+  (streaming-state-busy-since (ui-state-streaming state)))
+
+;; ============================================================
+;; Streaming update helpers
+;; ============================================================
+
+(define (update-streaming state f)
+  (struct-copy ui-state state [streaming (f (ui-state-streaming state))]))
+
+(define (set-busy state busy?)
+  (update-streaming state (lambda (s) (struct-copy streaming-state s [busy? busy?]))))
+
+(define (set-status-message state msg)
+  (update-streaming state (lambda (s) (struct-copy streaming-state s [status-message msg]))))
+
+(define (set-pending-tool-name state name)
+  (update-streaming state (lambda (s) (struct-copy streaming-state s [pending-tool-name name]))))
+
+(define (set-streaming-text state text)
+  (update-streaming state (lambda (s) (struct-copy streaming-state s [streaming-text text]))))
+
+(define (set-streaming-thinking state thinking)
+  (update-streaming state (lambda (s) (struct-copy streaming-state s [streaming-thinking thinking]))))
+
+(define (set-busy-since state since)
+  (update-streaming state (lambda (s) (struct-copy streaming-state s [busy-since since]))))
+
+(define (clear-streaming state)
+  (update-streaming state
+                    (lambda (s)
+                      (struct-copy streaming-state s [streaming-text #f] [streaming-thinking #f]))))
 
 ;; ============================================================
 ;; String helpers

--- a/tui/tui-init.rkt
+++ b/tui/tui-init.rkt
@@ -202,7 +202,7 @@
            'make-styled-segment
            styled-segment
            'set-status-message
-           (lambda (box msg) (set-box! box (struct-copy ui-state (unbox box) [status-message msg])))
+           (lambda (box msg) (set-box! box (set-status-message (unbox box) msg)))
            'set-extension-widget
            set-extension-widget
            'remove-extension-widget

--- a/tui/tui-keybindings.rkt
+++ b/tui/tui-keybindings.rkt
@@ -417,9 +417,8 @@
                                       #f
                                       (hash))))
               ;; Clear any streaming text and busy state
-              (set-box!
-               (tui-ctx-ui-state-box ctx)
-               (struct-copy ui-state state [busy? #f] [streaming-text #f] [pending-tool-name #f]))))
+              (set-box! (tui-ctx-ui-state-box ctx)
+                        (clear-streaming (set-pending-tool-name (set-busy state #f) #f)))))
         'continue]
        [else 'continue])]
 

--- a/tui/tui-render-loop.rkt
+++ b/tui/tui-render-loop.rkt
@@ -350,11 +350,7 @@
                        ;; F1: Immediately set busy? so status bar shows [thinking...]
                        ;; before the LLM responds (was waiting for turn.started event)
                        (set-box! (tui-ctx-ui-state-box ctx)
-                                 (struct-copy ui-state
-                                              cur-state
-                                              [busy? #t]
-                                              [streaming-text #f]
-                                              [pending-tool-name #f]))
+                                 (clear-streaming (set-pending-tool-name (set-busy cur-state #t) #f)))
                        (mark-dirty! ctx)
                        ;; F1: Show user message in transcript immediately
                        ;; (don't wait for JSONL events — the TUI transcript is display-only)

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -10,4 +10,4 @@
 (provide q-version)
 
 (: q-version String)
-(define q-version "0.38.5")
+(define q-version "0.38.6")


### PR DESCRIPTION
## v0.38.6 — TUI State Decomposition Part 2 (H-03 phase 2)

Extracts `streaming-state` sub-struct from `ui-state` monolith, replacing 6 individual streaming-related fields with 1 sub-struct field. Adds backward-compatible accessors and setter helpers.

### Changes
- **H-03 Phase 2**: `streaming-state` sub-struct with `busy?`, `status-message`, `pending-tool-name`, `streaming-text`, `streaming-thinking`, `busy-since`
- Backward-compatible read accessors: `ui-state-busy?`, `ui-state-status-message`, etc.
- Setter helpers: `set-busy`, `set-status-message`, `set-pending-tool-name`, `set-streaming-text`, `set-streaming-thinking`, `set-busy-since`, `clear-streaming`, `update-streaming`
- Updated all `struct-copy` call sites across source and test files
- Fixed `tools/scheduler.rkt` import of `tool-execute` (pre-existing regression from v0.38.2)
- Added `ui-state-rendered-cache` and `ui-state-rendered-cache-width` backward-compatible accessors

Closes #4099