### PR TITLE
fix: critical regressions + struct safety (W0 — R-01–R-08, P-01–P-03)

### DIFF
--- a/runtime/context-assembly.rkt
+++ b/runtime/context-assembly.rkt
@@ -13,7 +13,6 @@
          (only-in "context-summary.rkt"
                   DEFAULT-CACHE-MAX-ENTRIES
                   make-summary-cache
-                  summary-cache
                   summary-cache?
                   summary-cache-lookup
                   summary-cache-store!
@@ -50,7 +49,6 @@
 ;; Re-export from context-summary.rkt
 (provide DEFAULT-CACHE-MAX-ENTRIES
          make-summary-cache
-         summary-cache
          summary-cache?
          summary-cache-lookup
          summary-cache-store!

--- a/runtime/context-summary.rkt
+++ b/runtime/context-summary.rkt
@@ -19,7 +19,10 @@
 ;; Summary cache
 (provide (struct-out catalog-entry)
          (struct-out context-summary)
-         (struct-out summary-cache)
+         summary-cache?
+         summary-cache-table
+         summary-cache-order
+         summary-cache-max-entries
          DEFAULT-CACHE-MAX-ENTRIES
          (contract-out [make-summary-cache
                         (->* () (#:max-entries exact-nonnegative-integer?) summary-cache?)]

--- a/runtime/model-registry.rkt
+++ b/runtime/model-registry.rkt
@@ -39,11 +39,14 @@
 
 ;; Structs
 (provide model-entry?
+         model-entry
          model-entry-name
          model-entry-provider-name
          model-entry-provider-config
          model-registry?
+         model-registry
          model-resolution?
+         model-resolution
          model-resolution-model-name
          model-resolution-provider-name
          model-resolution-base-url
@@ -80,12 +83,11 @@
 
 ;; Internal registry struct (not exported)
 (struct model-registry
-        (index ; hash: model-name → (listof model-entry) — may have duplicates across providers
-         providers ; hash: provider-name-string → provider-config-hash
+        (index ; hash: model-name -> (listof model-entry) -- may have duplicates across providers
+         providers ; hash: provider-name-string -> provider-config-hash
          default-provider ; string or #f
          default-model ; string or #f
-         )
-  #:transparent)
+         ))
 
 ;; ============================================================
 ;; Config key normalization

--- a/tests/test-tui-selection-state.rkt
+++ b/tests/test-tui-selection-state.rkt
@@ -12,56 +12,54 @@
          "../util/protocol-types.rkt")
 
 (define selection-state-tests
-  (test-suite
-   "TUI Selection + Transcript Mutation"
+  (test-suite "TUI Selection + Transcript Mutation"
 
-   ;; T8: Selection + transcript mutation via event
-   ;; When a new event adds to the transcript while selection is active,
-   ;; the selection coordinates become stale (wrong row offset).
-   (test-case
-    "selection becomes stale when transcript mutates"
-    (define s0 (initial-ui-state))
-    ;; Build up some transcript
-    (define s1
-      (simulate-events s0
-        (list (make-test-event "turn.started" (hasheq))
-              (make-test-event "model.stream.delta" (hasheq 'delta "Line 1"))
-              (make-test-event "assistant.message.completed"
-                               (hasheq 'messageId "m1" 'content "Line 1"))
-              (make-test-event "turn.completed"
-                               (hasheq 'termination 'completed 'turnId "t1")))))
-    ;; Now set a selection
-    (define s2 (set-selection-anchor s1 0 0))
-    (define s3 (set-selection-end s2 5 0))
-    (check-true (has-selection? s3) "selection is active")
+    ;; T8: Selection + transcript mutation via event
+    ;; When a new event adds to the transcript while selection is active,
+    ;; the selection coordinates become stale (wrong row offset).
+    (test-case "selection becomes stale when transcript mutates"
+      (define s0 (initial-ui-state))
+      ;; Build up some transcript
+      (define s1
+        (simulate-events s0
+                         (list (make-test-event "turn.started" (hasheq))
+                               (make-test-event "model.stream.delta" (hasheq 'delta "Line 1"))
+                               (make-test-event "assistant.message.completed"
+                                                (hasheq 'messageId "m1" 'content "Line 1"))
+                               (make-test-event "turn.completed"
+                                                (hasheq 'termination 'completed 'turnId "t1")))))
+      ;; Now set a selection
+      (define s2 (set-selection-anchor s1 0 0))
+      (define s3 (set-selection-end s2 5 0))
+      (check-true (has-selection? s3) "selection is active")
 
-    ;; Now a new turn adds transcript entries — selection coords are now stale
-    (define s4
-      (simulate-events s3
-        (list (make-test-event "turn.started" (hasheq))
-              (make-test-event "model.stream.delta" (hasheq 'delta "Line 2"))
-              (make-test-event "assistant.message.completed"
-                               (hasheq 'messageId "m2" 'content "Line 2"))
-              (make-test-event "turn.completed"
-                               (hasheq 'termination 'completed 'turnId "t2")))))
-    ;; Selection is still technically active (coords unchanged)
-    (check-true (has-selection? s4)
-                "selection still active after transcript growth (documents behavior)")
-    ;; But the transcript is longer now
-    (check-equal? (transcript-length s4) 3
-                  "3 entries after 2 turns + session-start? or 2 entries from turns"))
+      ;; Now a new turn adds transcript entries — selection coords are now stale
+      (define s4
+        (simulate-events s3
+                         (list (make-test-event "turn.started" (hasheq))
+                               (make-test-event "model.stream.delta" (hasheq 'delta "Line 2"))
+                               (make-test-event "assistant.message.completed"
+                                                (hasheq 'messageId "m2" 'content "Line 2"))
+                               (make-test-event "turn.completed"
+                                                (hasheq 'termination 'completed 'turnId "t2")))))
+      ;; Selection is still technically active (coords unchanged)
+      (check-true (has-selection? s4)
+                  "selection still active after transcript growth (documents behavior)")
+      ;; But the transcript is longer now
+      (check-equal? (transcript-length s4)
+                    3
+                    "3 entries after 2 turns + session-start? or 2 entries from turns"))
 
-   ;; Selection cleared when scroll changes
-   (test-case
-    "clear-selection resets anchor and end"
-    (define s0 (initial-ui-state))
-    (define s1 (set-selection-anchor s0 0 0))
-    (define s2 (set-selection-end s1 10 5))
-    (check-true (has-selection? s2) "selection active before clear")
-    (define s3 (clear-selection s2))
-    (check-false (has-selection? s3) "selection cleared")
-    (check-false (ui-state-sel-anchor s3) "anchor is #f")
-    (check-false (ui-state-sel-end s3) "end is #f"))))
+    ;; Selection cleared when scroll changes
+    (test-case "clear-selection resets anchor and end"
+      (define s0 (initial-ui-state))
+      (define s1 (set-selection-anchor s0 0 0))
+      (define s2 (set-selection-end s1 10 5))
+      (check-true (has-selection? s2) "selection active before clear")
+      (define s3 (clear-selection s2))
+      (check-false (has-selection? s3) "selection cleared")
+      (check-false (selection-state-anchor (ui-state-selection s3)) "anchor is #f")
+      (check-false (selection-state-end (ui-state-selection s3)) "end is #f"))))
 
 (module+ main
   (run-tests selection-state-tests))

--- a/tools/tool-struct.rkt
+++ b/tools/tool-struct.rkt
@@ -8,10 +8,15 @@
          tool-name
          tool-description
          tool-schema
+         ;; NOTE: tool-execute is exported for test/internal use only.
+         ;;       Production code should use tools/scheduler.rkt for invocation.
+         ;;       A future breaking change may gate this behind a test-only module.
          tool-execute
          tool-prompt-snippet
          tool-prompt-guidelines
-         tool-dangerous?)
+         tool-dangerous?
+         tool-render-call
+         tool-render-result)
 
 (struct tool
         (name description

--- a/tools/tool.rkt
+++ b/tools/tool.rkt
@@ -42,6 +42,12 @@
          tool-prompt-snippet
          tool-prompt-guidelines
          tool-dangerous?
+         ;; Tool execution accessor (re-exported from tool-struct.rkt)
+         ;; NOTE: tool-execute is for test/internal use only.
+         ;;       Production code should use tools/scheduler.rkt for invocation.
+         tool-execute
+         tool-render-call
+         tool-render-result
          (contract-out [make-tool
                         (->* (string? string? hash? procedure?)
                              (#:prompt-snippet (or/c string? #f)


### PR DESCRIPTION
## W0: Critical Regressions + Struct Safety

### Changes
- **R-01–R-06**: Re-exported `tool-execute`, `tool-render-call`, `tool-render-result` from `tools/tool.rkt` facade and `tools/tool-struct.rkt`
- **R-07**: Exported `model-entry`, `model-resolution`, `model-registry` constructors
- **R-08**: Fixed `test-tui-selection-state.rkt` to use `selection-state-anchor/end` accessors
- **P-01**: Replaced `struct-out summary-cache` with selective exports (removes mutator leakage)
- **P-02**: Removed `#:transparent` from `model-registry` struct
- **P-03**: Added deprecation note to `tool-execute` export

Closes #4105