### PR TITLE
test+fix: test coverage + lint + version bump to 0.38.8 (W1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,23 @@
 # Changelog
 
-## v0.38.7 — 2026-05-12
+## v0.38.8 -- 2026-05-07
+
+### Fixed
+- R-01--R-05: Re-exported `tool-execute` from `tools/tool.rkt` facade (5 test files fixed)
+- R-06: Re-exported `tool-render-call`/`tool-render-result` from facade
+- R-07: Exported `model-entry`/`model-resolution` constructors for test fixtures
+- R-08: Fixed `test-tui-selection-state.rkt` selection accessor names
+- P-01: Replaced `struct-out summary-cache` with selective exports
+- P-02: Removed `#:transparent` from `model-registry` struct
+- P-03: Added deprecation note to `tool-execute` in `tool-struct.rkt`
+- CHANGELOG dates corrected for v0.38.5/6/7
+
+### Added
+- Test for `build-assembled-context/raw` (T-01 memo injection)
+- Test for `start-trace-logger!` `#:port` parameter (T-02)
+- Test for `parse-wave-doc-from-string` (T-03 pure extraction)
+
+## v0.38.7 — 2026-05-07
 
 ### Goal: Runtime Loop Config Struct & Event DSL Polish (Milestone 8 of v0.38.x)
 
@@ -25,7 +42,7 @@
 **Verification**: targeted tests all pass (iteration, events, context-assembly)
 
 
-## v0.38.6 — 2026-05-12
+## v0.38.6 — 2026-05-07
 
 ### Goal: TUI State Decomposition Part 2 (Milestone 7 of v0.38.x)
 
@@ -51,7 +68,7 @@
 **Verification**: lint 15/18 (3 pre-existing failures), all TUI tests pass
 
 
-## v0.38.5 — 2026-05-12
+## v0.38.5 — 2026-05-07
 
 ### Goal: TUI State Decomposition Part 1 (Milestone 6 of v0.38.x)
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.38.7-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.38.8-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 
@@ -199,7 +199,7 @@ racket main.rkt --model gpt-5.4 "write a test"
 ### Verify
 
 ```bash
-racket main.rkt --version  # q version 0.38.7
+racket main.rkt --version  # q version 0.38.8
 raco test tests/           # run the full test suite
 ```
 
@@ -375,6 +375,9 @@ When q executes shell commands on behalf of an LLM, arguments are quoted via `sh
 
 
 
+
+
+**v0.38.8** — Goal: Runtime Loop Config Struct & Event DSL Polish (Milestone 8 of v0.38.x)
 
 **v0.38.7** — Goal: Runtime Loop Config Struct & Event DSL Polish (Milestone 8 of v0.38.x)
 

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.38.7")
+(define version "0.38.8")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base"))

--- a/tests/test-context-assembly-raw.rkt
+++ b/tests/test-context-assembly-raw.rkt
@@ -1,0 +1,75 @@
+#lang racket
+
+;; tests/test-context-assembly-raw.rkt -- Tests for build-assembled-context/raw
+;;
+;; T-01: Verify the pure context-assembly core with memo and trace support.
+
+(require rackunit
+         rackunit/text-ui
+         "../runtime/context-assembly/selection.rkt"
+         "../runtime/context-assembly/budgeting.rkt"
+         "../util/message.rkt"
+         "../util/content-parts.rkt")
+
+(define (make-test-msg text [id "msg-1"] [role 'user])
+  (make-message id #f role 'text (list (make-text-part text)) 0 #f))
+
+(define raw-assembly-tests
+  (test-suite "build-assembled-context/raw"
+
+    (test-case "empty messages returns minimal context"
+      (define config (make-context-assembly-config #:recent-tokens 4096))
+      (define memo (make-hash))
+      (define result (build-assembled-context/raw '() config #f #:memo memo))
+      (check-not-false result)
+      (check-equal? (length (context-result-messages result)) 0)
+      (check-equal? (context-result-total-tokens result) 0))
+
+    (test-case "single user message is included in result"
+      (define config (make-context-assembly-config #:recent-tokens 4096))
+      (define memo (make-hash))
+      (define msgs (list (make-test-msg "hello world" "msg-1")))
+      (define result (build-assembled-context/raw msgs config #f #:memo memo))
+      (check-not-false result)
+      (check-equal? (length (context-result-messages result)) 1))
+
+    (test-case "memoization reuses cache on second call"
+      (define config (make-context-assembly-config #:recent-tokens 4096))
+      (define memo (make-hash))
+      (define msgs (list (make-test-msg "hello" "msg-1")))
+      ;; First call
+      (define r1 (build-assembled-context/raw msgs config #f #:memo memo))
+      (check-not-false r1)
+      ;; Memo should now have an entry
+      (check-true (> (hash-count memo) 0) "memo should have entries after first call")
+      ;; Second call with same memo should work
+      (define r2 (build-assembled-context/raw msgs config #f #:memo memo))
+      (check-not-false r2)
+      ;; Both should return same number of messages
+      (check-equal? (length (context-result-messages r1)) (length (context-result-messages r2))))
+
+    (test-case "over-budget message is excluded"
+      (define config (make-context-assembly-config #:recent-tokens 1))
+      (define memo (make-hash))
+      ;; Multiple messages to guarantee some are excluded
+      (define msgs
+        (for/list ([i (in-range 10)])
+          (make-test-msg (format "message number ~a with enough text" i) (format "msg-~a" i))))
+      (define result (build-assembled-context/raw msgs config #f #:memo memo))
+      ;; With budget of 1, most should be excluded
+      (check-true (> (context-result-excluded-count result) 0)
+                  "at least some messages should be excluded with tiny budget"))
+
+    (test-case "trace callback receives events"
+      (define trace-events '())
+      (define (trace-fn phase data)
+        (set! trace-events (cons (cons phase data) trace-events)))
+      (define config (make-context-assembly-config #:recent-tokens 4096))
+      (define memo (make-hash))
+      (define msgs (list (make-test-msg "test" "msg-1")))
+      (define result (build-assembled-context/raw msgs config #f #:memo memo #:trace trace-fn))
+      (check-not-false result)
+      (check-true (> (length trace-events) 0) "trace should have received events"))))
+
+(module+ main
+  (run-tests raw-assembly-tests))

--- a/tests/test-gsd-wave-docs.rkt
+++ b/tests/test-gsd-wave-docs.rkt
@@ -335,3 +335,32 @@
   (update-wave-in-index! test-dir 1 "FAILED")
   (check-equal? (plan-overall-status test-dir) 'partly-done)
   (teardown))
+
+;; ============================================================
+;; T-03: parse-wave-doc-from-string pure extraction
+;; ============================================================
+
+(test-case "parse-wave-doc-from-string parses valid DONE wave"
+  (define text "# Wave 0
+Status: DONE
+Some content here.")
+  (define result (parse-wave-doc-from-string text 0 "W0" (string->path "/tmp/W0.md")))
+  (check-not-false result)
+  (check-equal? (hash-ref result 'status) "DONE")
+  (check-equal? (hash-ref result 'slug) "W0")
+  (check-equal? (hash-ref result 'index) 0)
+  (check-equal? (hash-ref result 'path) "/tmp/W0.md"))
+
+(test-case "parse-wave-doc-from-string parses wave without status"
+  (define text "# Wave 1
+Some description without status header.")
+  (define result (parse-wave-doc-from-string text 1 "W1"))
+  (check-not-false result)
+  (check-equal? (hash-ref result 'status) "Inbox")
+  (check-equal? (hash-ref result 'slug) "W1"))
+
+(test-case "parse-wave-doc-from-string returns hash for empty input"
+  (define result (parse-wave-doc-from-string "" 0 "W0"))
+  (check-not-false result)
+  ;; Empty input -> status defaults to Inbox
+  (check-equal? (hash-ref result 'status) "Inbox"))

--- a/tests/test-trace-logger.rkt
+++ b/tests/test-trace-logger.rkt
@@ -189,3 +189,22 @@
   (define entries (read-trace-jsonl dir))
   (check-equal? (length entries) 20 "all 20 events with nested structs should be logged")
   (delete-directory/files dir))
+
+;; ============================================================
+;; T-02: #:port parameter for testability
+;; ============================================================
+
+(test-case "start-trace-logger! accepts #:port string port"
+  (define dir (make-temp-dir))
+  (define bus (make-event-bus))
+  (define logger (make-trace-logger bus dir #:enabled? #t))
+  (define out (open-output-string))
+  (start-trace-logger! logger #:port out)
+  ;; Publish a trace event
+  (publish! bus (make-event "test.port" (current-seconds) "s" #f (hasheq 'key "value")))
+  (flush-trace-logger! logger)
+  (stop-trace-logger! logger)
+  ;; Check output was written to string port
+  (define output (get-output-string out))
+  (check-true (string-contains? output "test.port") "trace event should appear in string port output")
+  (delete-directory/files dir))

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -10,4 +10,4 @@
 (provide q-version)
 
 (: q-version String)
-(define q-version "0.38.7")
+(define q-version "0.38.8")


### PR DESCRIPTION
## W1: Test Coverage + Lint + Version Bump

### Changes
- **T-01**: New test file `tests/test-context-assembly-raw.rkt` (5 tests for `build-assembled-context/raw`)
- **T-02**: Appended `#:port` test to `tests/test-trace-logger.rkt`
- **T-03**: Appended `parse-wave-doc-from-string` tests to `tests/test-gsd-wave-docs.rkt` (3 cases)
- **L-01**: Fixed CHANGELOG future dates for v0.38.5/6/7
- **V-01**: Version bump to 0.38.8 in info.rkt, version.rkt, README.md, CHANGELOG.md

Closes #4106