### PR TITLE
fix: correct 6 session-config contracts (BUG-01, BUG-02)

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ q/
 |--------|-------|
 | Test files | 553 |
 | Source modules | 419 |
-| Source lines | 64312 |
+| Source lines | 64318 |
 | Test lines | 98896 |
 | Test assertions | 15383 |
 | Tests passing | 5835+ | `racket scripts/run-tests.rkt` results |

--- a/runtime/session-config.rkt
+++ b/runtime/session-config.rkt
@@ -24,7 +24,13 @@
 
 (require racket/dict
          racket/contract
-         (only-in "../runtime/working-set.rkt" working-set?))
+         (only-in "../runtime/working-set.rkt" working-set?)
+         (only-in "../llm/provider.rkt" provider?)
+         (only-in "../tools/registry.rkt" tool-registry?)
+         (only-in "../agent/event-bus.rkt" event-bus?)
+         (only-in "../extensions/api.rkt" extension-registry?)
+         (only-in "../runtime/model-registry.rkt" model-registry?)
+         (only-in "../runtime/trace-logger.rkt" trace-logger?))
 
 (provide session-config?
          session-config
@@ -34,11 +40,11 @@
          normalize-session-config-hash
          ;; Smart accessors with defaults
          (contract-out
-          [config-provider (-> session-config? (or/c #f symbol?))]
-          [config-tool-registry (-> session-config? (or/c #f hash?))]
-          [config-event-bus (-> session-config? (or/c #f hash?))]
-          [config-extension-registry (-> session-config? (or/c #f hash?))]
-          [config-model-registry (-> session-config? (or/c #f hash?))]
+          [config-provider (-> session-config? (or/c #f provider?))]
+          [config-tool-registry (-> session-config? (or/c #f tool-registry?))]
+          [config-event-bus (-> session-config? (or/c #f event-bus?))]
+          [config-extension-registry (-> session-config? (or/c #f extension-registry?))]
+          [config-model-registry (-> session-config? (or/c #f model-registry?))]
           [config-settings (-> session-config? (or/c #f hash?))]
           [config-model-name (-> session-config? (or/c #f string?))]
           [config-session-dir (-> session-config? (or/c #f path-string?))]
@@ -56,7 +62,7 @@
           [config-tier-b-count (-> session-config? exact-nonnegative-integer?)]
           [config-tier-c-count (-> session-config? exact-nonnegative-integer?)]
           [config-templates (-> session-config? (or/c #f hash?))]
-          [config-trace-logger (-> session-config? (or/c #f procedure?))]
+          [config-trace-logger (-> session-config? (or/c #f trace-logger?))]
           [config-verbose? (-> session-config? boolean?)]
           [config-max-tokens (-> session-config? exact-positive-integer?)]
           [config-token-budget-threshold (-> session-config? (or/c #f exact-nonnegative-integer?))]


### PR DESCRIPTION
## W0: Fix 6 session-config contracts (BUG-01, BUG-02)

### Changes
- **BUG-01**: `config-provider` contract `(or/c #f symbol?)` → `(or/c #f provider?)`
- **BUG-02**: Fixed 5 more wrong contracts:
  - `config-tool-registry`: `hash?` → `tool-registry?`
  - `config-event-bus`: `hash?` → `event-bus?`
  - `config-extension-registry`: `hash?` → `extension-registry?`
  - `config-model-registry`: `hash?` → `model-registry?`
  - `config-trace-logger`: `procedure?` → `trace-logger?`
- Added required `only-in` imports for all 6 struct predicates

### Acceptance Gates
- ✅ G1: Compiles (`raco make main.rkt`)
- ✅ G2: Lint 18/18
- ✅ G3: Contracts correct

Closes #4113