### PR TITLE
refactor(W1): tighten internal contracts to session-config? only (#4119)

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,8 +272,8 @@ q/
 |--------|-------|
 | Test files | 555 |
 | Source modules | 419 |
-| Source lines | 64348 |
-| Test lines | 99041 |
+| Source lines | 64337 |
+| Test lines | 99042 |
 | Test assertions | 15405 |
 | Tests passing | 5835+ | `racket scripts/run-tests.rkt` results |
 

--- a/runtime/agent-session.rkt
+++ b/runtime/agent-session.rkt
@@ -100,19 +100,20 @@
          agent-session-prompt-running?
          ensure-persisted!
          buffer-or-append!
-         (contract-out [make-agent-session (-> (or/c hash? session-config?) agent-session?)]
-                       [resume-agent-session (-> string? any/c agent-session?)]
-                       [fork-session (->* (agent-session?) ((or/c string? #f)) agent-session?)]
-                       [run-prompt!
-                        (->* (agent-session? (or/c string? message?))
-                             (#:max-iterations (or/c exact-nonnegative-integer? #f)
-                                               #:ensure-persisted! (or/c procedure? #f)
-                                               #:buffer-or-append! (or/c procedure? #f))
-                             any)]
-                       [session-id (-> agent-session? string?)]
-                       [session-history (-> agent-session? list?)]
-                       [session-active? (-> agent-session? boolean?)]
-                       [close-session! (-> agent-session? void?)])
+         (contract-out ;; NOTE (W-01): This is the ONLY entry point that accepts raw hashes for backward compat.
+          [make-agent-session (-> (or/c hash? session-config?) agent-session?)]
+          [resume-agent-session (-> string? any/c agent-session?)]
+          [fork-session (->* (agent-session?) ((or/c string? #f)) agent-session?)]
+          [run-prompt!
+           (->* (agent-session? (or/c string? message?))
+                (#:max-iterations (or/c exact-nonnegative-integer? #f)
+                                  #:ensure-persisted! (or/c procedure? #f)
+                                  #:buffer-or-append! (or/c procedure? #f))
+                any)]
+          [session-id (-> agent-session? string?)]
+          [session-history (-> agent-session? list?)]
+          [session-active? (-> agent-session? boolean?)]
+          [close-session! (-> agent-session? void?)])
          maybe-compact-context
          ;; Thinking level control (#1153)
          thinking-levels

--- a/runtime/iteration.rkt
+++ b/runtime/iteration.rkt
@@ -93,7 +93,7 @@
                                                 string?
                                                 exact-nonnegative-integer?)
                              (#:cancellation-token (or/c cancellation-token? #f)
-                              #:config (or/c hash? session-config?)
+                              #:config session-config?
                               #:queue (or/c queue? #f)
                               #:follow-up-delivery-mode (or/c 'all 'one-at-a-time)
                               #:injected-box (or/c box? #f)

--- a/runtime/iteration/loop-config.rkt
+++ b/runtime/iteration/loop-config.rkt
@@ -39,7 +39,7 @@
          max-iterations ; exact-nonnegative-integer? — iteration limit
          ;; Optional fields (keyword, default #f)
          cancellation-token ; (or/c cancellation-token? #f)
-         config ; (or/c hash? session-config?)
+         config ; session-config?
          queue ; (or/c queue? #f) — steering message queue
          follow-up-delivery-mode ; (or/c 'all 'one-at-a-time)
          injected-box ; (or/c box? #f) — injected message box

--- a/runtime/iteration/main-loop.rkt
+++ b/runtime/iteration/main-loop.rkt
@@ -89,7 +89,7 @@
                                                 string?
                                                 exact-nonnegative-integer?)
                              (#:cancellation-token (or/c cancellation-token? #f)
-                              #:config (or/c hash? session-config?)
+                              #:config session-config?
                               #:queue (or/c queue? #f)
                               #:follow-up-delivery-mode (or/c 'all 'one-at-a-time)
                               #:injected-box (or/c box? #f)
@@ -122,10 +122,7 @@
         [force-shutdown-check (loop-config-force-shutdown-check cfg)]
         [initial-ws (loop-config-working-set cfg)]
         [sess (loop-config-session cfg)])
-    (define config
-      (if (session-config? config-raw)
-          config-raw
-          (hash->session-config config-raw)))
+    (define config config-raw)
     (define max-iterations-hard (resolve-max-iterations-hard config max-iterations))
     (define ws (or initial-ws (make-working-set)))
     (define agent-start-payload
@@ -276,7 +273,7 @@
                             session-id
                             max-iterations
                             #:cancellation-token [token #f]
-                            #:config [config-raw (hash)]
+                            #:config [config-raw (hash->session-config (hash))]
                             #:queue [steering-queue #f]
                             #:follow-up-delivery-mode [follow-up-mode 'all]
                             #:injected-box [injected-box #f]

--- a/runtime/turn-orchestrator.rkt
+++ b/runtime/turn-orchestrator.rkt
@@ -110,12 +110,12 @@
                        string?
                        string?
                        (or/c cancellation-token? #f)
-                       (or/c hash? session-config?))
+                       session-config?)
                 (#:tool-list-proc (or/c procedure? #f))
                 loop-result?)]
           [build-assembled-context
            (-> list?
-               (or/c hash? session-config?)
+               session-config?
                (or/c extension-registry? #f)
                event-bus?
                string?
@@ -124,7 +124,7 @@
           [register-session-extensions!
            (-> tool-registry? (or/c extension-registry? #f) event-bus? string? (listof hash?))]
           [assemble-context/pure
-           (->* (list? (or/c hash? session-config?))
+           (->* (list? session-config?)
                 (#:hook-dispatcher (or/c procedure? #f))
                 (values list? any/c))]))
 
@@ -135,10 +135,7 @@
 ;; Pure: assemble context from messages and config without side effects.
 ;; Returns the assembled message list and hook result (no events emitted here).
 (define (assemble-context/pure ctx-to-use config-raw #:hook-dispatcher [hook-dispatcher #f])
-  (define config
-    (if (session-config? config-raw)
-        config-raw
-        (hash->session-config config-raw)))
+  (define config config-raw)
   (define tier-b-count (config-tier-b-count config))
   (define tier-c-count (config-tier-c-count config))
   (define max-tokens (config-max-tokens config))
@@ -162,10 +159,7 @@
 ;; Returns the assembled message list.
 (define (build-assembled-context ctx-to-use config-raw ext-reg bus session-id iteration)
   ;; WP-37 + R2-6: Context Assembly with Tier A/B/C separation and Hook support
-  (define config
-    (if (session-config? config-raw)
-        config-raw
-        (hash->session-config config-raw)))
+  (define config config-raw)
   (define ws (config-working-set config))
 
   ;; R2-6: Create hook dispatcher function for context assembly
@@ -270,10 +264,7 @@
                            token
                            config-raw
                            #:tool-list-proc [tool-list-proc #f])
-  (define config
-    (if (session-config? config-raw)
-        config-raw
-        (hash->session-config config-raw)))
+  (define config config-raw)
   ;; v0.28.20 T7: Emit system.warning if mock provider is being used
   (when (provider-is-mock? prov)
     (emit-session-event! bus

--- a/tests/test-context-assembly.rkt
+++ b/tests/test-context-assembly.rkt
@@ -415,7 +415,8 @@
 ;; I-04: Direct test for assemble-context/pure
 ;; ============================================================
 
-(require (only-in "../runtime/turn-orchestrator.rkt" (assemble-context/pure ctx-assemble-pure)))
+(require (only-in "../runtime/turn-orchestrator.rkt" (assemble-context/pure ctx-assemble-pure))
+         (only-in "../runtime/session-config.rkt" hash->session-config))
 
 (define ctx-assemble ctx-assemble-pure)
 
@@ -424,7 +425,7 @@
     (list (make-test-msg "u1" 'user 'message "Hello")
           (make-test-msg "a1" 'assistant 'message "Hi there")
           (make-test-msg "u2" 'user 'message "How are you?")))
-  (define config (hash 'tier-b-count 10 'tier-c-count 2 'max-tokens 4096))
+  (define config (hash->session-config (hash 'tier-b-count 10 'tier-c-count 2 'max-tokens 4096)))
   (define-values (result _hook-res) (ctx-assemble msgs config))
   (check-pred list? result)
   (check >= (length result) 1)


### PR DESCRIPTION
## W1: Contract Tightening — Remove Dual-Type

### Changes
- Remove `(or/c hash? session-config?)` from 4 internal runtime modules
- Keep dual-type only in `make-agent-session` (the single correct entry point)
- Fix default config in `run-iteration-loop` to use `(hash->session-config (hash))`
- Fix `test-context-assembly.rkt` caller

### Verification
- No remaining dual-type in internal modules (only `agent-session.rkt`)
- Lint 18/18
- All relevant tests pass (iteration, context-assembly, agent-session)

Closes #4119