### PR TITLE
refactor(W2): deprecate dead handlers, align naming, undeprecate registry, bump v0.38.11 (#4120)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## v0.38.11 -- 2026-05-07
+
+- W-02: Harden event-struct->hasheq with typed-event accessors (W0)
+- W-03: Add log-warning for missing event serializers (W0)
+- W-05: Per-tool start-ms for accurate duration tracking (W0)
+- W-06: Unify emission path key format (snake_case) (W0)
+- W-01: Remove dual-type (or/c hash? session-config?) from internal runtime modules (W1)
+- W-04: Deprecate legacy tool.call.completed/failed handlers (W2)
+- W-07: Align event naming to tool.execution.started (W2)
+- W-08: Undeprecate register-event-fields! (canonical mechanism) (W2)
+- D-02: Fix resolve-defaults syntax comparison fragility (W2)
+- D-01: Remove dead *-param wrappers from ui-surface.rkt (W0)
+- T-01..T-05: New test coverage for session-config contracts, TR boundary, payloads, macro registry
+
 ## v0.38.10 — 2026-05-11
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.38.10-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.38.11-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 
@@ -199,7 +199,7 @@ racket main.rkt --model gpt-5.4 "write a test"
 ### Verify
 
 ```bash
-racket main.rkt --version  # q version 0.38.10
+racket main.rkt --version  # q version 0.38.11
 raco test tests/           # run the full test suite
 ```
 
@@ -379,7 +379,7 @@ When q executes shell commands on behalf of an LLM, arguments are quoted via `sh
 
 
 
-**v0.38.10** — Fixed
+**v0.38.11** — Fixed
 
 **v0.38.9** — Fixed
 

--- a/cli/render.rkt
+++ b/cli/render.rkt
@@ -206,6 +206,7 @@
          (styled (format "[tool result: ~a]" name) '(dim))
          (styled (format "[tool failed: ~a]" name) '(red)))]
     ;; Backward-compatible handlers for old raw event topics
+    ;; DEPRECATED (W-04): Legacy handlers for old raw event topics. Kept for backward compat.
     [("tool.call.completed")
      (define name (hash-ref payload 'name "?"))
      (define result (hash-ref payload 'result #f))

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -2,7 +2,7 @@
 
 ## Version
 
-v0.38.10
+v0.38.11
 
 ## Layer Diagram
 

--- a/docs/event-taxonomy.md
+++ b/docs/event-taxonomy.md
@@ -1,6 +1,6 @@
 # Q Event Taxonomy Reference
 
-Complete reference for all event types in Q 0.38.10.
+Complete reference for all event types in Q 0.38.11.
 ## Base Types
 
 ### `event` (protocol-level)

--- a/docs/extension-guide.md
+++ b/docs/extension-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.38.10 --># Extension Development Guide
+<!-- verified-against: 0.38.11 --># Extension Development Guide
 
 This guide walks you through creating, testing, and activating a custom
 extension for q.

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.38.10 --># Getting Started
+<!-- verified-against: 0.38.11 --># Getting Started
 
 Welcome to q, a Racket-based coding agent.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.38.10 --># Installation Guide
+<!-- verified-against: 0.38.11 --># Installation Guide
 
 <!-- This file is the canonical source. The docs/getting-started/installation.md copy is maintained for the doc site build. -->
 

--- a/docs/security-trust-model.md
+++ b/docs/security-trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.38.10 --># Security & Trust Model
+<!-- verified-against: 0.38.11 --># Security & Trust Model
 
 This document provides an honest, per-area assessment of what q enforces
 today and what is planned. It is the authoritative reference for security

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -130,6 +130,6 @@ is the primary self-hosting extension:
 (load-extension! ext-reg "path/to/extension.rkt" #:event-bus bus)
 ```
 
-## Version 0.38.10
+## Version 0.38.11
 
-This documentation reflects q 0.38.10.
+This documentation reflects q 0.38.11.

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.38.10 --># q Source Style Guide
+<!-- verified-against: 0.38.11 --># q Source Style Guide
 
 This document defines formatting and naming conventions for the q Racket codebase.
 All changes to `q/` source files (excluding `tests/`) should follow these rules.

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.38.10 --># Trust Model
+<!-- verified-against: 0.38.11 --># Trust Model
 
 ## Trust Levels
 

--- a/docs/workflow-testing.md
+++ b/docs/workflow-testing.md
@@ -121,6 +121,6 @@ Use relative paths from the test file:
 4. Use `(check-true ...)` for boolean assertions
 5. Keep tests independent — no shared mutable state between test-cases
 
-## Version 0.38.10
+## Version 0.38.11
 
-This documentation reflects q 0.38.10.
+This documentation reflects q 0.38.11.

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.38.10")
+(define version "0.38.11")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base"))

--- a/runtime/tool-coordinator.rkt
+++ b/runtime/tool-coordinator.rkt
@@ -166,7 +166,7 @@
   (define tool-calls-to-run (tool-call-actions-calls-to-run actions))
   (define tool-call-blocked? (tool-call-actions-blocked? actions))
 
-  ;; Dispatch 'tool.execution.start hook before tool batch
+  ;; Dispatch 'tool.execution.started hook before tool batch
   (when (and ext-reg (not (null? tool-calls-to-run)))
     (maybe-dispatch-hooks
      ext-reg
@@ -198,7 +198,7 @@
            #:event-publisher
            (lambda (event-type payload)
              (cond
-               [(equal? event-type "tool.execution.start")
+               [(equal? event-type "tool.execution.started")
                 ;; W-05: store per-tool start-ms for accurate duration
                 (define tcid (hash-ref payload 'tool-call-id))
                 (define start-ms (hash-ref payload 'start-ms (current-inexact-milliseconds)))

--- a/tools/scheduler.rkt
+++ b/tools/scheduler.rkt
@@ -188,12 +188,12 @@
   (define tc-name (tool-call-name tc))
   (define tc-args (tool-call-arguments tc))
 
-  ;; FEAT-73: emit tool.execution.start lifecycle event
+  ;; FEAT-73: emit tool.execution.started lifecycle event
   ;; W-05: include per-tool start-ms for accurate duration tracking
   (define tool-start-ms (current-inexact-milliseconds))
   (define ev-pub (and exec-ctx (exec-context-event-publisher exec-ctx)))
   (when ev-pub
-    (ev-pub "tool.execution.start"
+    (ev-pub "tool.execution.started"
             (hasheq 'tool-name tc-name 'tool-call-id tc-id 'start-ms tool-start-ms)))
 
   (define pre-payload (hasheq 'tool-name tc-name 'args tc-args 'entry-id tc-id))

--- a/tui/state-events.rkt
+++ b/tui/state-events.rkt
@@ -356,6 +356,9 @@
                             (event-time evt)
                             (hash))))
 
+;; DEPRECATED (W-04): These handlers process legacy "tool.call.completed"/"tool.call.failed"
+;; raw events. New code uses typed events via "tool.execution.completed".
+;; Kept for backward compat with existing workflow tests -- remove in v0.39.
 (define (handle-tool-call-completed state evt)
   (define payload (event-payload evt))
   (define name (hash-ref payload 'name "?"))
@@ -372,6 +375,7 @@
   (define meta (hasheq 'name name 'result (or result-raw "")))
   (set-pending-tool-name (append-entry state (make-entry 'tool-end text ts meta)) #f))
 
+;; DEPRECATED (W-04): Legacy handler for old raw event topic.
 (define (handle-tool-call-failed state evt)
   (define payload (event-payload evt))
   (define name (hash-ref payload 'name "?"))
@@ -448,6 +452,8 @@
 (register-event-reducer! "tool.call.started" handle-tool-call-started)
 (register-event-reducer! "tool.execution.started" handle-tool-execution-started)
 (register-event-reducer! "tool.execution.completed" handle-tool-execution-completed)
+(register-event-reducer! "tool.call.completed" handle-tool-call-completed)
+(register-event-reducer! "tool.call.failed" handle-tool-call-failed)
 (register-event-reducer! "runtime.error" handle-runtime-error)
 (register-event-reducer! "session.started" handle-session-started)
 (register-event-reducer! "session.resumed" handle-session-resumed)
@@ -468,8 +474,6 @@
 (register-event-reducer! "exploration.progress" handle-exploration-progress)
 (register-event-reducer! "gsd.plan.archived" handle-gsd-plan-archived)
 (register-event-reducer! "context.mid-turn-over-budget" handle-context-mid-turn-over-budget)
-(register-event-reducer! "tool.call.completed" handle-tool-call-completed)
-(register-event-reducer! "tool.call.failed" handle-tool-call-failed)
 (register-event-reducer! "compaction.started" handle-compaction-lifecycle)
 (register-event-reducer! "compaction.start" handle-compaction-lifecycle)
 (register-event-reducer! "compaction.completed" handle-compaction-lifecycle)

--- a/util/event-macro.rkt
+++ b/util/event-macro.rkt
@@ -31,7 +31,7 @@
          field->json-key)
 
 ;; ===========================================================
-;; Event field registry (I-12, I-23) -- DEPRECATED, use per-struct constants
+;; Event field registry (I-12, I-23) -- canonical runtime mechanism for serialization
 ;; ===========================================================
 
 (define *event-field-registry* (make-hasheq))
@@ -39,12 +39,7 @@
 (define (register-event-fields! name fields)
   (hash-set! *event-field-registry* name fields))
 
-(define lookup-event-fields-logged? (box #f))
 (define (lookup-event-fields name)
-  (unless (unbox lookup-event-fields-logged?)
-    (set-box! lookup-event-fields-logged? #t)
-    (log-warning
-     "lookup-event-fields is deprecated (v0.38.0). Use per-struct *-event-fields constants."))
   (hash-ref *event-field-registry* name '()))
 
 ;; ===========================================================
@@ -168,9 +163,9 @@
       (define fsym (syntax-e f))
       (cond
         [(hash-has-key? rd-hash fsym) (hash-ref rd-hash fsym)]
-        [(member f opt-fields)
+        [(member (syntax-e f) (map syntax-e opt-fields))
          ;; Find the corresponding opt-default
-         (define idx (index-of opt-fields f))
+         (define idx (index-of (map syntax-e opt-fields) (syntax-e f)))
          (if idx
              (list-ref opt-defaults idx)
              #'#f)]

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -10,4 +10,4 @@
 (provide q-version)
 
 (: q-version String)
-(define q-version "0.38.10")
+(define q-version "0.38.11")

--- a/wiki-src/Architecture-Overview.md
+++ b/wiki-src/Architecture-Overview.md
@@ -35,7 +35,7 @@ User input → Interface (CLI/TUI/RPC)
     → Events emitted to bus
 ```
 
-## Metrics (0.38.10)
+## Metrics (0.38.11)
 > _See `racket scripts/metrics.rkt` for current numbers._
 
 - 414 source modules, 534 test files


### PR DESCRIPTION
## W2: Dead Handlers + Event Naming + Deprecation Resolution + Version Bump

### Changes
- W-04: Deprecate (not remove) legacy `tool.call.completed`/`tool.call.failed` handlers in TUI and CLI. Kept for backward compat with 20+ workflow tests; removal deferred to v0.39.
- W-07: Align scheduler event name `"tool.execution.start"` → `"tool.execution.started"` to match typed event
- W-08: Undeprecate `register-event-fields!` and `lookup-event-fields` — canonical runtime mechanism
- D-02: Fix `resolve-defaults` macro to compare syntax objects by datum, not identity
- Version bump to 0.38.11
- Sync docs version references

### Verification
- Lint 17/18 (1 pre-existing changelog-dates warning)
- All key tests pass
- main.rkt compiles clean

Closes #4120