### PR TITLE
refactor(W1): warning fixes, lookup-event-fields #f, loop-config default, bump v0.38.12 (#4126)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## v0.38.12 — 2026-05-12
+
+### Fixed
+- R-01: Fix 4 failing tests in `test-soft-iteration.rkt` (raw hash to tightened session-config? contract)
+- R-02: Fix 1 failing test in `test-di-keyword-args.rkt` (raw hash to tightened session-config? contract)
+- L-01: Delete dead `ui-remove-all-extension-widgets-param` from `ui-surface.rkt`
+- W-NEW-03: Align legacy `TOPIC-TOOL-START`/`TOPIC-TOOL-END` constants to match typed event naming
+- W-NEW-01: `lookup-event-fields` returns `#f` for unknown events (was `'()`, masks typos)
+- W-NEW-02: `make-loop-config` default config changed from raw `(hash)` to `(hash->session-config (hash))`
+- LINT: Fix CHANGELOG.md v0.38.11 header formatting
+
 ## v0.38.11 — 2026-05-12
 
 - W-02: Harden event-struct->hasheq with typed-event accessors (W0)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.38.11-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.38.12-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 
@@ -199,7 +199,7 @@ racket main.rkt --model gpt-5.4 "write a test"
 ### Verify
 
 ```bash
-racket main.rkt --version  # q version 0.38.11
+racket main.rkt --version  # q version 0.38.12
 raco test tests/           # run the full test suite
 ```
 
@@ -272,7 +272,7 @@ q/
 |--------|-------|
 | Test files | 555 |
 | Source modules | 419 |
-| Source lines | 64330 |
+| Source lines | 64333 |
 | Test lines | 99044 |
 | Test assertions | 15405 |
 | Tests passing | 5835+ | `racket scripts/run-tests.rkt` results |
@@ -379,7 +379,7 @@ When q executes shell commands on behalf of an LLM, arguments are quoted via `sh
 
 
 
-**v0.38.11** — 2026-05-12
+**v0.38.12** — Fixed
 
 **v0.38.9** — Fixed
 

--- a/agent/event-emitter.rkt
+++ b/agent/event-emitter.rkt
@@ -23,7 +23,7 @@
 (provide (contract-out [emit-typed-event!
                         (->* (event-bus? typed-event?) (#:state (or/c loop-state? #f)) event?)]
                        [event-struct->hasheq (-> typed-event? hash?)]
-                       [get-struct-field-names (-> symbol? (listof symbol?))])
+                       [get-struct-field-names (-> symbol? (or/c (listof symbol?) #f))])
          typed-event-base-field-count)
 
 ;; Look up the field name list for a given event struct symbol.
@@ -59,9 +59,12 @@
             (typed-event-turn-id evt)))
   (define name (struct-name evt))
   (define fields (get-struct-field-names name))
+  (unless fields
+    (log-warning (format "event-struct->hasheq: no field registry for ~a, dropping subclass fields"
+                         name)))
   (for/fold ([h base])
             ([i (in-naturals)]
-             [fname (in-list fields)])
+             [fname (in-list (or fields '()))])
     (hash-set h fname (vector-ref vec (+ app-start i)))))
 
 ;; Emit a typed event on the bus.

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -2,7 +2,7 @@
 
 ## Version
 
-v0.38.11
+v0.38.12
 
 ## Layer Diagram
 

--- a/docs/event-taxonomy.md
+++ b/docs/event-taxonomy.md
@@ -1,6 +1,6 @@
 # Q Event Taxonomy Reference
 
-Complete reference for all event types in Q 0.38.11.
+Complete reference for all event types in Q 0.38.12.
 ## Base Types
 
 ### `event` (protocol-level)

--- a/docs/extension-guide.md
+++ b/docs/extension-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.38.11 --># Extension Development Guide
+<!-- verified-against: 0.38.12 --># Extension Development Guide
 
 This guide walks you through creating, testing, and activating a custom
 extension for q.

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.38.11 --># Getting Started
+<!-- verified-against: 0.38.12 --># Getting Started
 
 Welcome to q, a Racket-based coding agent.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.38.11 --># Installation Guide
+<!-- verified-against: 0.38.12 --># Installation Guide
 
 <!-- This file is the canonical source. The docs/getting-started/installation.md copy is maintained for the doc site build. -->
 

--- a/docs/security-trust-model.md
+++ b/docs/security-trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.38.11 --># Security & Trust Model
+<!-- verified-against: 0.38.12 --># Security & Trust Model
 
 This document provides an honest, per-area assessment of what q enforces
 today and what is planned. It is the authoritative reference for security

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -130,6 +130,6 @@ is the primary self-hosting extension:
 (load-extension! ext-reg "path/to/extension.rkt" #:event-bus bus)
 ```
 
-## Version 0.38.11
+## Version 0.38.12
 
-This documentation reflects q 0.38.11.
+This documentation reflects q 0.38.12.

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.38.11 --># q Source Style Guide
+<!-- verified-against: 0.38.12 --># q Source Style Guide
 
 This document defines formatting and naming conventions for the q Racket codebase.
 All changes to `q/` source files (excluding `tests/`) should follow these rules.

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.38.11 --># Trust Model
+<!-- verified-against: 0.38.12 --># Trust Model
 
 ## Trust Levels
 

--- a/docs/workflow-testing.md
+++ b/docs/workflow-testing.md
@@ -121,6 +121,6 @@ Use relative paths from the test file:
 4. Use `(check-true ...)` for boolean assertions
 5. Keep tests independent — no shared mutable state between test-cases
 
-## Version 0.38.11
+## Version 0.38.12
 
-This documentation reflects q 0.38.11.
+This documentation reflects q 0.38.12.

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.38.11")
+(define version "0.38.12")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base"))

--- a/runtime/iteration/loop-config.rkt
+++ b/runtime/iteration/loop-config.rkt
@@ -16,7 +16,7 @@
          (only-in "../../tools/registry.rkt" tool-registry?)
          (only-in "../../extensions/api.rkt" extension-registry?)
          (only-in "../../util/cancellation.rkt" cancellation-token?)
-         (only-in "../../runtime/session-config.rkt" session-config?)
+         (only-in "../../runtime/session-config.rkt" session-config? hash->session-config)
          (only-in "../../runtime/working-set.rkt" working-set?)
          (only-in "../../runtime/session-types.rkt" agent-session?)
          (only-in "../../util/loop-result.rkt" loop-result?))
@@ -60,7 +60,7 @@
                           session-id
                           max-iterations
                           #:cancellation-token [cancellation-token #f]
-                          #:config [config (hash)]
+                          #:config [config (hash->session-config (hash))]
                           #:queue [queue #f]
                           #:follow-up-delivery-mode [follow-up-delivery-mode 'all]
                           #:injected-box [injected-box #f]

--- a/tests/test-define-event-macro.rkt
+++ b/tests/test-define-event-macro.rkt
@@ -182,7 +182,7 @@
 
 (test-case "T-05: unregistered event type returns #f"
   (define fields (lookup-event-fields 'nonexistent-event-type-xyz))
-  (check-equal? fields '()))
+  (check-false fields))
 
 (test-case "T-05: registration is idempotent"
   ;; Re-registering should not error

--- a/tests/test-event-emitter-registry.rkt
+++ b/tests/test-event-emitter-registry.rkt
@@ -139,5 +139,5 @@
     (check-true (not (null? (get-struct-field-names name)))
                 (format "~a should have field names" name))))
 
-(test-case "get-struct-field-names returns empty for unknown types"
-  (check-equal? (get-struct-field-names 'unknown-event-type) '()))
+(test-case "get-struct-field-names returns #f for unknown types"
+  (check-false (get-struct-field-names 'unknown-event-type)))

--- a/util/event-macro.rkt
+++ b/util/event-macro.rkt
@@ -40,7 +40,7 @@
   (hash-set! *event-field-registry* name fields))
 
 (define (lookup-event-fields name)
-  (hash-ref *event-field-registry* name '()))
+  (hash-ref *event-field-registry* name #f))
 
 ;; ===========================================================
 ;; Event serializer registry (H-01)

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -10,4 +10,4 @@
 (provide q-version)
 
 (: q-version String)
-(define q-version "0.38.11")
+(define q-version "0.38.12")

--- a/wiki-src/Architecture-Overview.md
+++ b/wiki-src/Architecture-Overview.md
@@ -35,7 +35,7 @@ User input → Interface (CLI/TUI/RPC)
     → Events emitted to bus
 ```
 
-## Metrics (0.38.11)
+## Metrics (0.38.12)
 > _See `racket scripts/metrics.rkt` for current numbers._
 
 - 414 source modules, 534 test files


### PR DESCRIPTION
## W1: Warning improvements + version bump to 0.38.12

- W-NEW-01: `lookup-event-fields` returns `#f` for unknown events (was `'()`) + log-warning in event-emitter
- W-NEW-02: `make-loop-config` default config changed from raw `(hash)` to `(hash->session-config (hash))`
- COSMETIC: Fix test assertion for unregistered event type (check-false instead of check-equal? '())
- VERSION: Bump to 0.38.12 + CHANGELOG + docs sync

Lint 18/18. All tests pass.

Closes #4126