### PR TITLE
fix: stale test string + version bump to 0.38.13 (#4129)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.38.13 — 2026-05-12
+
+### Fixed
+- L-NEW-01: Fix stale `"tool.execution.start"` in `test-rpc-methods.rkt` subscribe filter test
+
 ## v0.38.12 — 2026-05-12
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.38.12-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.38.13-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 
@@ -199,7 +199,7 @@ racket main.rkt --model gpt-5.4 "write a test"
 ### Verify
 
 ```bash
-racket main.rkt --version  # q version 0.38.12
+racket main.rkt --version  # q version 0.38.13
 raco test tests/           # run the full test suite
 ```
 
@@ -379,7 +379,7 @@ When q executes shell commands on behalf of an LLM, arguments are quoted via `sh
 
 
 
-**v0.38.12** — Fixed
+**v0.38.13** — Fixed
 
 **v0.38.9** — Fixed
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -2,7 +2,7 @@
 
 ## Version
 
-v0.38.12
+v0.38.13
 
 ## Layer Diagram
 

--- a/docs/event-taxonomy.md
+++ b/docs/event-taxonomy.md
@@ -1,6 +1,6 @@
 # Q Event Taxonomy Reference
 
-Complete reference for all event types in Q 0.38.12.
+Complete reference for all event types in Q 0.38.13.
 ## Base Types
 
 ### `event` (protocol-level)

--- a/docs/extension-guide.md
+++ b/docs/extension-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.38.12 --># Extension Development Guide
+<!-- verified-against: 0.38.13 --># Extension Development Guide
 
 This guide walks you through creating, testing, and activating a custom
 extension for q.

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.38.12 --># Getting Started
+<!-- verified-against: 0.38.13 --># Getting Started
 
 Welcome to q, a Racket-based coding agent.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.38.12 --># Installation Guide
+<!-- verified-against: 0.38.13 --># Installation Guide
 
 <!-- This file is the canonical source. The docs/getting-started/installation.md copy is maintained for the doc site build. -->
 

--- a/docs/security-trust-model.md
+++ b/docs/security-trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.38.12 --># Security & Trust Model
+<!-- verified-against: 0.38.13 --># Security & Trust Model
 
 This document provides an honest, per-area assessment of what q enforces
 today and what is planned. It is the authoritative reference for security

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -130,6 +130,6 @@ is the primary self-hosting extension:
 (load-extension! ext-reg "path/to/extension.rkt" #:event-bus bus)
 ```
 
-## Version 0.38.12
+## Version 0.38.13
 
-This documentation reflects q 0.38.12.
+This documentation reflects q 0.38.13.

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.38.12 --># q Source Style Guide
+<!-- verified-against: 0.38.13 --># q Source Style Guide
 
 This document defines formatting and naming conventions for the q Racket codebase.
 All changes to `q/` source files (excluding `tests/`) should follow these rules.

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.38.12 --># Trust Model
+<!-- verified-against: 0.38.13 --># Trust Model
 
 ## Trust Levels
 

--- a/docs/workflow-testing.md
+++ b/docs/workflow-testing.md
@@ -121,6 +121,6 @@ Use relative paths from the test file:
 4. Use `(check-true ...)` for boolean assertions
 5. Keep tests independent — no shared mutable state between test-cases
 
-## Version 0.38.12
+## Version 0.38.13
 
-This documentation reflects q 0.38.12.
+This documentation reflects q 0.38.13.

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.38.12")
+(define version "0.38.13")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base"))

--- a/tests/test-rpc-methods.rkt
+++ b/tests/test-rpc-methods.rkt
@@ -109,7 +109,7 @@
                                           (set-box! received-filter filter)
                                           99))))
       (define handler (hash-ref handlers 'subscribe))
-      (define result (handler (hasheq 'filter '("model.stream.text" "tool.execution.start"))))
+      (define result (handler (hasheq 'filter '("model.stream.text" "tool.execution.started"))))
       (check-equal? (hash-ref result 'subscriptionId) 99)
       (check-not-false (unbox received-filter)))
 

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -10,4 +10,4 @@
 (provide q-version)
 
 (: q-version String)
-(define q-version "0.38.12")
+(define q-version "0.38.13")

--- a/wiki-src/Architecture-Overview.md
+++ b/wiki-src/Architecture-Overview.md
@@ -35,7 +35,7 @@ User input → Interface (CLI/TUI/RPC)
     → Events emitted to bus
 ```
 
-## Metrics (0.38.12)
+## Metrics (0.38.13)
 > _See `racket scripts/metrics.rkt` for current numbers._
 
 - 414 source modules, 534 test files


### PR DESCRIPTION
## Fix stale test string + version bump to 0.38.13

- L-NEW-01: Fix stale `"tool.execution.start"` → `"tool.execution.started"` in `test-rpc-methods.rkt` subscribe filter test
- VERSION: Bump to 0.38.13 + CHANGELOG + docs sync

Lint 18/18. 27/27 tests pass.

Closes #4129