### PR TITLE
chore(W3): version bump to 0.38.14 (#4135)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v0.38.14 -- 2026-05-07
+
+### Changed
+- DEBT-02: Rename hook event symbols `'tool.execution.start` -> `'started`, `'tool.execution.end` -> `'completed` in hook-types.rkt, tool-coordinator.rkt, streaming-observer.rkt (W0)
+- FACADE-01: Delete `runtime/iteration.rkt` facade, migrate 22 test files + sdk-core.rkt to direct sub-module imports (W0)
+- DEBT-01: Delete `extensions/gsd-planning-state.rkt` shim, migrate 14 callers to direct gsd sub-module imports, add legacy wrappers in gsd-planning.rkt (W1)
+- W-04: Remove deprecated `handle-tool-call-completed`/`handle-tool-call-failed` from tui/state-events.rkt and cli/render.rkt, migrate 20 test files from `"tool.call.completed"`/`"tool.call.failed"` to `"tool.execution.completed"` with backward-compatible payload handling (W2)
+
 ## v0.38.13 — 2026-05-12
 
 ### Fixed

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.38.13")
+(define version "0.38.14")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base"))

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -10,4 +10,4 @@
 (provide q-version)
 
 (: q-version String)
-(define q-version "0.38.13")
+(define q-version "0.38.14")


### PR DESCRIPTION
## W3: Version bump to 0.38.14

- Updated `util/version.rkt` to "0.38.14"
- Updated `info.rkt` to match
- Updated `CHANGELOG.md` with W0/W1/W2 summary (DEBT-02, FACADE-01, DEBT-01, W-04)
- Lint: 11/11 IVG clean, 14/14 release-notes clean

Closes #4135