### PR TITLE
v0.39.0 W0: Effect Boundary Extraction (Ports/Adapters)

### DIFF
--- a/runtime/iteration/step-interpreter.rkt
+++ b/runtime/iteration/step-interpreter.rkt
@@ -10,6 +10,7 @@
 ;;   execute-pending-tool-calls — execute pending tool calls, update working set
 
 (require racket/match
+         racket/class
          racket/list
          racket/dict
          (only-in "loop-state.rkt"
@@ -83,7 +84,20 @@
 
 (provide interpret-step
          handle-stop-action
-         execute-pending-tool-calls)
+         execute-pending-tool-calls
+         ;; R-09/R-10: Optional sink for dependency injection
+         sink-append-entries!)
+
+;; ============================================================
+;; R-09/R-10: Sink-aware append helper
+;; ============================================================
+
+;; When a sink is provided, use it instead of the path-based API.
+;; This enables test isolation and effect boundary extraction.
+(define (sink-append-entries! infra new-msgs [sink #f])
+  (if sink
+      (send sink sink-append-entries! new-msgs)
+      (append-entries! (loop-infra-log-path infra) new-msgs)))
 
 ;; ============================================================
 ;; execute-pending-tool-calls
@@ -136,8 +150,7 @@
 ;; handle-stop-action
 ;; ============================================================
 
-(define success-completion-reasons
-  '(completed))
+(define success-completion-reasons '(completed))
 
 (define (handle-stop-action result new-msgs infra counters ws config)
   (define termination (loop-result-termination-reason result))

--- a/runtime/session-store.rkt
+++ b/runtime/session-store.rkt
@@ -14,6 +14,7 @@
          racket/file
          racket/string
          racket/port
+         racket/class
          json
          "../util/protocol-types.rkt"
          "../util/jsonl.rkt"
@@ -63,7 +64,46 @@
          in-memory-fork!
          ;; Custom entry helpers (#1147)
          append-custom-entry!
-         load-custom-entries)
+         load-custom-entries
+         ;; R-09/R-10: Session sink interface (v0.39.0)
+         session-sink<%>
+         file-session-sink%
+         in-memory-session-sink%)
+
+;; ── R-09/R-10: Session sink interface (v0.39.0) ──
+;;
+;; A session-sink abstracts the storage backend for session entries.
+;; Production code uses file-session-sink%; tests can use in-memory-session-sink%.
+
+(define session-sink<%>
+  (interface ()
+    ;; Append a single message to the sink.
+    sink-append!
+    ;; Append multiple messages atomically.
+    sink-append-entries!
+    ;; Load all messages from the sink.
+    sink-load
+    ;; Fork the sink at a given entry.
+    sink-fork!))
+
+(define file-session-sink%
+  (class* object% (session-sink<%>)
+    (init-field log-path)
+    (super-new)
+    (define/public (sink-append! msg) (append-entry! log-path msg))
+    (define/public (sink-append-entries! msgs) (append-entries! log-path msgs))
+    (define/public (sink-load) (load-session-log log-path))
+    (define/public (sink-fork! entry-id dest-path) (fork-session! log-path entry-id dest-path))))
+
+(define in-memory-session-sink%
+  (class* object% (session-sink<%>)
+    (init-field manager session-id)
+    (super-new)
+    (define/public (sink-append! msg) (in-memory-append! manager session-id msg))
+    (define/public (sink-append-entries! msgs) (in-memory-append-entries! manager session-id msgs))
+    (define/public (sink-load) (in-memory-load manager session-id))
+    (define/public (sink-fork! entry-id dest-id)
+      (in-memory-fork! manager session-id dest-id entry-id))))
 
 ;; ── Append operations ──
 

--- a/tests/test-jsonl.rkt
+++ b/tests/test-jsonl.rkt
@@ -198,4 +198,31 @@
                         (check-equal? (hash-ref (car valid) 'id) "1")
                         (check-equal? (hash-ref (cadr valid) 'id) "2"))))))
 
+;; --- Port-based I/O (R-01/R-02) ---
+
+(test-case "jsonl-write-to-port! + jsonl-read-from-port roundtrip"
+  (define entries
+    (list (hasheq 'id 1 'name "alpha") (hasheq 'id 2 'name "beta") (hasheq 'id 3 'name "gamma")))
+  (define output
+    (with-output-to-string (lambda ()
+                             (for ([e (in-list entries)])
+                               (jsonl-write-to-port! (current-output-port) e)))))
+  (define-values (valid corrupted) (call-with-input-string output jsonl-read-from-port))
+  (check-equal? (length valid) 3)
+  (check-equal? corrupted 0)
+  (check-equal? (hash-ref (car valid) 'id) 1)
+  (check-equal? (hash-ref (cadr valid) 'name) "beta")
+  (check-equal? (hash-ref (caddr valid) 'id) 3))
+
+(test-case "jsonl-read-from-port skips corrupted lines"
+  (define output "{\"ok\":true}\n{BAD\n{\"also\":true}\n")
+  (define-values (valid corrupted) (call-with-input-string output jsonl-read-from-port))
+  (check-equal? (length valid) 2)
+  (check-equal? corrupted 1))
+
+(test-case "jsonl-read-from-port empty input"
+  (define-values (valid corrupted) (call-with-input-string "" jsonl-read-from-port))
+  (check-equal? valid '())
+  (check-equal? corrupted 0))
+
 (run-tests jsonl-suite 'verbose)

--- a/util/json-helpers.rkt
+++ b/util/json-helpers.rkt
@@ -14,7 +14,10 @@
 (provide ensure-hash-args
          ;; JSON file I/O
          read-json-file
-         write-json-file)
+         write-json-file
+         ;; R-01/R-02: Port-based I/O
+         read-json-from-port
+         write-json-to-port)
 
 ;; Parse tool-call arguments from string to hash if needed.
 ;; Streaming produces arguments as JSON strings; tools expect hashes.
@@ -27,36 +30,43 @@
      (define cleaned (string-trim args))
      (if (or (string=? cleaned "") (string=? cleaned "{}"))
          (hash)
-         (with-handlers ([exn:fail?
-                          (lambda (e)
-                            (if graceful?
-                                (hash)
-                                (raise-tool-error
-                                 (format "Failed to parse tool arguments JSON: ~a" args)
-                                 "ensure-hash-args"
-                                 (hasheq 'raw args 'error (exn-message e)))))])
+         (with-handlers ([exn:fail? (lambda (e)
+                                      (if graceful?
+                                          (hash)
+                                          (raise-tool-error
+                                           (format "Failed to parse tool arguments JSON: ~a" args)
+                                           "ensure-hash-args"
+                                           (hasheq 'raw args 'error (exn-message e)))))])
            (define parsed (string->jsexpr cleaned))
            (if (hash? parsed)
                parsed
                (if graceful?
                    (hash)
-                   (raise-tool-error
-                    (format "Tool arguments parsed to non-hash: ~a" args)
-                    "ensure-hash-args"
-                    (hasheq 'raw args 'parsed parsed))))))]
+                   (raise-tool-error (format "Tool arguments parsed to non-hash: ~a" args)
+                                     "ensure-hash-args"
+                                     (hasheq 'raw args 'parsed parsed))))))]
     [else
      (if graceful?
          (hash)
-         (raise-tool-error
-          (format "Tool arguments must be hash or JSON string, got: ~a" args)
-          "ensure-hash-args"
-          (hasheq 'raw (format "~a" args))))]))
+         (raise-tool-error (format "Tool arguments must be hash or JSON string, got: ~a" args)
+                           "ensure-hash-args"
+                           (hasheq 'raw (format "~a" args))))]))
 
 ;; Read and parse a JSON file, returning the parsed value.
 (define (read-json-file path)
-  (call-with-input-file path (lambda (in) (read-json in)) #:mode 'text))
+  (call-with-input-file path read-json-from-port #:mode 'text))
 
 ;; Write a value as JSON to a file.
 ;; #:exists controls the file-exists behavior (default 'truncate).
 (define (write-json-file path data #:exists [mode 'truncate])
-  (call-with-output-file path (lambda (out) (write-json data out)) #:mode 'text #:exists mode))
+  (call-with-output-file path
+                         (lambda (out) (write-json-to-port out data))
+                         #:mode 'text
+                         #:exists mode))
+
+;; R-01/R-02: Port-based I/O — callers manage port lifecycle.
+(define (read-json-from-port in)
+  (read-json in))
+
+(define (write-json-to-port out data)
+  (write-json data out))

--- a/util/jsonl.rkt
+++ b/util/jsonl.rkt
@@ -12,6 +12,7 @@
 (provide jsonl-append!
          jsonl-write-to-port!
          jsonl-append-entries!
+         jsonl-read-from-port
          jsonl-read-all
          jsonl-read-all-valid
          jsonl-read-all-valid-with-count
@@ -70,6 +71,20 @@
     (call-with-output-file path (lambda (out) (display blob out)) #:mode 'text #:exists 'append)))
 
 ;; ── Read ──
+
+;; R-01/R-02: Port-based variant — read all valid JSONL lines from an input port.
+;; Returns (values valid-list corrupted-count).
+(define (jsonl-read-from-port in)
+  (define-values (valid corrupted)
+    (for/fold ([acc '()]
+               [bad 0])
+              ([line (in-lines in)])
+      (define trimmed (string-trim line))
+      (cond
+        [(<= (string-length trimmed) 0) (values acc bad)]
+        [(jsonl-line-valid? line) (values (cons (read-json (open-input-string line)) acc) bad)]
+        [else (values acc (add1 bad))])))
+  (values (reverse valid) corrupted))
 
 (define (jsonl-read-all path)
   ;; Read all complete JSONL lines from file.

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -10,4 +10,4 @@
 (provide q-version)
 
 (: q-version String)
-(define q-version "0.38.14")
+(define q-version "0.39.0")


### PR DESCRIPTION
Closes #4141

**Milestone**: v0.39.0 (#328)
**Findings**: R-01, R-02, R-09, R-10

## Changes
- Add `jsonl-read-from-port` to `util/jsonl.rkt` — port-based variant of `jsonl-read-all-valid`
- Add `read-json-from-port` / `write-json-to-port` to `util/json-helpers.rkt` — file I/O now delegates to port variants
- Define `session-sink<%>` generic interface with `file-session-sink%` and `in-memory-session-sink%` in `runtime/session-store.rkt`
- Add `sink-append-entries!` helper in `runtime/iteration/step-interpreter.rkt` for dependency injection
- Add port-based roundtrip tests in `tests/test-jsonl.rkt`
- Version bump to 0.39.0