### PR TITLE
v0.39.1 W0: GSD Command Parse→AST Extraction

### DIFF
--- a/extensions/gsd/command-handlers.rkt
+++ b/extensions/gsd/command-handlers.rkt
@@ -14,6 +14,7 @@
          "../hooks.rkt"
          "../tool-api.rkt"
          "../gsd-planning/command-normalization.rkt"
+         "../gsd/command-parser.rkt"
          "../gsd-planning/plan-diff.rkt"
          "../gsd/state-machine.rkt"
          (only-in "../gsd/core.rkt"
@@ -108,19 +109,22 @@
 ;; Command dispatch
 ;; ============================================================
 
+;; R-04/R-16: Refactored to parse→dispatch.
+;; Pure parsing is in command-parser.rkt; this function validates and dispatches.
 (define (handle-execute-command payload)
   (define cmd (hash-ref payload 'command #f))
   (define input-text (hash-ref payload 'input ""))
   (define base-dir (or (current-pinned-dir) (current-directory)))
-  (match cmd
-    [(? (lambda (c) (member c '("/go" "/implement" "/i")))) (handle-go-command base-dir input-text)]
-    ["/gsd" (handle-gsd-status)]
-    ["/replan"
+  (define parsed (parse-gsd-command cmd input-text))
+  (cond
+    [(gsd-cmd-go? parsed) (handle-go-command base-dir input-text)]
+    [(gsd-cmd-status? parsed) (handle-gsd-status)]
+    [(gsd-cmd-replan? parsed)
      (define result (cmd-replan))
      (events:emit-gsd-event! 'gsd.mode.changed (hasheq 'mode 'exploring))
      (hook-amend (hasheq 'text (or (gsd-command-result-message result) "")))]
-    ["/skip"
-     (define args-text (extract-cmd-args input-text))
+    [(gsd-cmd-skip? parsed)
+     (define args-text (gsd-cmd-skip-skip-arg parsed))
      (define result (cmd-skip args-text))
      (when (and (gsd-success? result) base-dir)
        (define idx (and (string->number (string-trim args-text))))
@@ -130,12 +134,12 @@
          (when exec
            (wave-skip! exec idx))))
      (hook-amend (hasheq 'text (or (gsd-command-result-message result) "")))]
-    ["/reset"
+    [(gsd-cmd-reset? parsed)
      (define result (cmd-reset))
      (events:emit-gsd-event! 'gsd.mode.changed (hasheq 'mode 'idle))
      (hook-amend (hasheq 'text (or (gsd-command-result-message result) "")))]
-    [(? (lambda (c) (member c '("/wave-done" "/wd"))))
-     (define wd-args (extract-cmd-args input-text))
+    [(gsd-cmd-wave-done? parsed)
+     (define wd-args (gsd-cmd-wave-done-wave-arg parsed))
      (define result (cmd-wave-done base-dir wd-args))
      (when (gsd-success? result)
        (define data (gsd-command-result-data result))
@@ -143,9 +147,8 @@
        (when wave-idx
          (events:emit-gsd-event! 'gsd.wave.completed (hasheq 'wave wave-idx))))
      (hook-amend (hasheq 'text (or (gsd-command-result-message result) "")))]
-    ["/done"
-     (define done-args (extract-cmd-args input-text))
-     (define force? (and done-args (string-contains? done-args "--force")))
+    [(gsd-cmd-done? parsed)
+     (define force? (gsd-cmd-done-force? parsed))
      (define result (cmd-done base-dir force?))
      (when (gsd-success? result)
        (define data (gsd-command-result-data result))
@@ -155,7 +158,13 @@
                                            (hash-ref data 'archive-path "")
                                            ""))))
      (hook-amend (hasheq 'text (or (gsd-command-result-message result) "")))]
-    [_ (handle-artifact-command cmd input-text base-dir payload)]))
+    [(gsd-cmd-plan? parsed)
+     (define plan-text (gsd-cmd-plan-plan-text parsed))
+     (if plan-text
+         (handle-plan-submit plan-text base-dir input-text parsed)
+         (handle-artifact-command cmd input-text base-dir payload))]
+    [(gsd-cmd-artifact? parsed) (handle-artifact-command cmd input-text base-dir payload)]
+    [else (handle-artifact-command cmd input-text base-dir payload)]))
 
 ;; ============================================================
 ;; /go command handler
@@ -305,6 +314,30 @@ Plan:
 ;; Artifact display and /plan <text> handler
 ;; ============================================================
 
+;; R-04/R-16: Focused handler for /plan <text> submit
+(define (handle-plan-submit plan-text base-dir input-text parsed)
+  (define saved-bus (current-gsd-event-bus)) ;; Preserve event bus across reset
+  (define saved-dir (current-pinned-dir)) ;; Preserve pinned dir
+  (reset-all-gsd-state!) ;; Clean state for fresh plan (F1 fix)
+  (when saved-bus
+    (set-gsd-event-bus! saved-bus))
+  (when saved-dir
+    (set-pinned-dir! saved-dir))
+  (set-gsd-mode! 'planning)
+  (events:emit-gsd-event! 'gsd.mode.changed (hasheq 'mode 'planning))
+  (set-edit-limit! 500)
+  ;; Auto-create STATE.md if missing (#2164)
+  (ensure-state-md! base-dir)
+  (define existing-plan (read-planning-artifact base-dir "PLAN"))
+  (define stale-warning
+    (if existing-plan
+        "
+NOTE: An existing PLAN.md was found. OVERWRITE it completely with the new plan. Do NOT keep or merge old content.
+"
+        ""))
+  (define augmented-text (string-append (planning-prompt plan-text) stale-warning))
+  (hook-amend (hasheq 'submit augmented-text 'text (format "Planning: ~a" plan-text))))
+
 (define (handle-artifact-command cmd input-text base-dir payload)
   (define artifact
     (match cmd
@@ -315,44 +348,11 @@ Plan:
   (match artifact
     [#f (hook-pass payload)]
     [_
-     (define args-text
-       (let* ([trimmed (string-trim input-text)]
-              [parts (and (> (string-length trimmed) 0)
-                          (char=? (string-ref trimmed 0) #\/)
-                          (string-split trimmed))])
-         (and (pair? parts)
-              (let ([rest (string-trim (substring input-text (string-length (car parts))))])
-                (and (> (string-length rest) 0) rest)))))
-     (match (and (member cmd '("/plan" "/p")) args-text)
-       ;; /plan <text> → submit as planning prompt
-       [(? values)
-        (define saved-bus (current-gsd-event-bus)) ;; Preserve event bus across reset
-        (define saved-dir (current-pinned-dir)) ;; Preserve pinned dir
-        (reset-all-gsd-state!) ;; Clean state for fresh plan (F1 fix)
-        (when saved-bus
-          (set-gsd-event-bus! saved-bus))
-        (when saved-dir
-          (set-pinned-dir! saved-dir))
-        (set-gsd-mode! 'planning)
-        (events:emit-gsd-event! 'gsd.mode.changed (hasheq 'mode 'planning))
-        (set-edit-limit! 500)
-        ;; Auto-create STATE.md if missing (#2164)
-        (ensure-state-md! base-dir)
-        (define existing-plan (read-planning-artifact base-dir "PLAN"))
-        (define stale-warning
-          (if existing-plan
-              "
-NOTE: An existing PLAN.md was found. OVERWRITE it completely with the new plan. Do NOT keep or merge old content.
-"
-              ""))
-        (define augmented-text (string-append (planning-prompt args-text) stale-warning))
-        (hook-amend (hasheq 'submit augmented-text 'text (format "Planning: ~a" args-text)))]
-       [else
-        ;; Display artifact content
-        (define content (read-planning-artifact base-dir artifact))
-        (define text
-          (match content
-            [#f (format "No ~a found in .planning/" artifact)]
-            [(? hash?) (jsexpr->string content)]
-            [_ content]))
-        (hook-amend (hasheq 'text text))])]))
+     ;; Display artifact content
+     (define content (read-planning-artifact base-dir artifact))
+     (define text
+       (match content
+         [#f (format "No ~a found in .planning/" artifact)]
+         [(? hash?) (jsexpr->string content)]
+         [_ content]))
+     (hook-amend (hasheq 'text text))]))

--- a/extensions/gsd/command-parser.rkt
+++ b/extensions/gsd/command-parser.rkt
@@ -1,0 +1,78 @@
+#lang racket/base
+
+;; extensions/gsd/command-parser.rkt — Pure GSD command parsing (R-04/R-16)
+;; STABILITY: evolving
+;;
+;; Extracts the parse phase from handle-execute-command into a pure function.
+;; No I/O, no side effects — just string → AST transformation.
+
+(require racket/match
+         racket/string)
+
+(provide (struct-out parsed-gsd-command)
+         (struct-out gsd-cmd-go)
+         (struct-out gsd-cmd-plan)
+         (struct-out gsd-cmd-skip)
+         (struct-out gsd-cmd-done)
+         (struct-out gsd-cmd-status)
+         (struct-out gsd-cmd-replan)
+         (struct-out gsd-cmd-reset)
+         (struct-out gsd-cmd-wave-done)
+         (struct-out gsd-cmd-artifact)
+         parsed-gsd-command?
+         parse-gsd-command)
+
+;; ── Base struct ──
+
+(struct parsed-gsd-command (canonical-name args) #:transparent)
+
+;; ── Subtypes ──
+
+(struct gsd-cmd-go parsed-gsd-command (wave-arg) #:transparent)
+(struct gsd-cmd-plan parsed-gsd-command (plan-text) #:transparent)
+(struct gsd-cmd-skip parsed-gsd-command (skip-arg) #:transparent)
+(struct gsd-cmd-done parsed-gsd-command (force?) #:transparent)
+(struct gsd-cmd-status parsed-gsd-command () #:transparent)
+(struct gsd-cmd-replan parsed-gsd-command () #:transparent)
+(struct gsd-cmd-reset parsed-gsd-command () #:transparent)
+(struct gsd-cmd-wave-done parsed-gsd-command (wave-arg) #:transparent)
+(struct gsd-cmd-artifact parsed-gsd-command (artifact-name) #:transparent)
+
+;; ── Pure parser ──
+
+;; Command alias tables — pure data, no I/O.
+(define go-aliases '("/go" "/implement" "/i"))
+(define plan-aliases '("/plan" "/p"))
+(define state-aliases '("/state" "/s"))
+(define handoff-aliases '("/handoff" "/ho"))
+(define wave-done-aliases '("/wave-done" "/wd"))
+
+(define (extract-cmd-args input-text)
+  (define trimmed (string-trim input-text))
+  (if (and (> (string-length trimmed) 0) (char=? (string-ref trimmed 0) #\/))
+      (let ([parts (string-split trimmed)])
+        (if (>= (length parts) 2)
+            (string-trim (string-join (cdr parts) " "))
+            ""))
+      ""))
+
+;; Parse a slash command string into a typed AST node.
+;; Returns #f if the command is not recognized as a GSD command.
+(define (parse-gsd-command cmd input-text)
+  (define args-text (extract-cmd-args input-text))
+  (cond
+    [(member cmd go-aliases) (gsd-cmd-go cmd args-text args-text)]
+    [(member cmd plan-aliases)
+     (gsd-cmd-plan cmd args-text (if (> (string-length args-text) 0) args-text #f))]
+    [(member cmd state-aliases) (gsd-cmd-artifact cmd args-text "STATE")]
+    [(member cmd handoff-aliases) (gsd-cmd-artifact cmd args-text "HANDOFF")]
+    [(equal? cmd "/gsd") (gsd-cmd-status cmd args-text)]
+    [(equal? cmd "/replan") (gsd-cmd-replan cmd args-text)]
+    [(equal? cmd "/skip") (gsd-cmd-skip cmd args-text args-text)]
+    [(equal? cmd "/reset") (gsd-cmd-reset cmd args-text)]
+    [(member cmd wave-done-aliases) (gsd-cmd-wave-done cmd args-text args-text)]
+    [(equal? cmd "/done")
+     (gsd-cmd-done cmd args-text (and args-text (string-contains? args-text "--force")))]
+    ;; /plan without args → artifact display
+    [(member cmd plan-aliases) (gsd-cmd-artifact cmd args-text "PLAN")]
+    [else #f]))

--- a/tests/test-gsd-command-parser.rkt
+++ b/tests/test-gsd-command-parser.rkt
@@ -1,0 +1,136 @@
+#lang racket
+
+;; tests/test-gsd-command-parser.rkt — Pure parser tests (R-04/R-16)
+
+(require rackunit
+         rackunit/text-ui
+         "../extensions/gsd/command-parser.rkt")
+
+(define parser-suite
+  (test-suite "GSD command parser tests"
+
+    ;; ── Go command variants ──
+    (test-case "parse /go"
+      (define r (parse-gsd-command "/go" "/go"))
+      (check-pred gsd-cmd-go? r)
+      (check-equal? (parsed-gsd-command-canonical-name r) "/go"))
+
+    (test-case "parse /implement alias"
+      (define r (parse-gsd-command "/implement" "/implement"))
+      (check-pred gsd-cmd-go? r)
+      (check-equal? (parsed-gsd-command-canonical-name r) "/implement"))
+
+    (test-case "parse /i alias"
+      (define r (parse-gsd-command "/i" "/i"))
+      (check-pred gsd-cmd-go? r))
+
+    (test-case "parse /go with wave arg"
+      (define r (parse-gsd-command "/go" "/go 3"))
+      (check-pred gsd-cmd-go? r)
+      (check-equal? (gsd-cmd-go-wave-arg r) "3"))
+
+    ;; ── Plan command ──
+    (test-case "parse /plan with text → gsd-cmd-plan"
+      (define r (parse-gsd-command "/plan" "/plan implement feature X"))
+      (check-pred gsd-cmd-plan? r)
+      (check-equal? (gsd-cmd-plan-plan-text r) "implement feature X"))
+
+    (test-case "parse /p alias with text"
+      (define r (parse-gsd-command "/p" "/p do something"))
+      (check-pred gsd-cmd-plan? r)
+      (check-equal? (gsd-cmd-plan-plan-text r) "do something"))
+
+    (test-case "parse /plan without text → gsd-cmd-artifact"
+      ;; /plan with no text falls through to artifact display
+      (define r (parse-gsd-command "/plan" "/plan"))
+      (check-pred gsd-cmd-plan? r)
+      (check-false (gsd-cmd-plan-plan-text r)))
+
+    ;; ── Artifact display ──
+    (test-case "parse /state"
+      (define r (parse-gsd-command "/state" "/state"))
+      (check-pred gsd-cmd-artifact? r)
+      (check-equal? (gsd-cmd-artifact-artifact-name r) "STATE"))
+
+    (test-case "parse /s alias"
+      (define r (parse-gsd-command "/s" "/s"))
+      (check-pred gsd-cmd-artifact? r)
+      (check-equal? (gsd-cmd-artifact-artifact-name r) "STATE"))
+
+    (test-case "parse /handoff"
+      (define r (parse-gsd-command "/handoff" "/handoff"))
+      (check-pred gsd-cmd-artifact? r)
+      (check-equal? (gsd-cmd-artifact-artifact-name r) "HANDOFF"))
+
+    (test-case "parse /ho alias"
+      (define r (parse-gsd-command "/ho" "/ho"))
+      (check-pred gsd-cmd-artifact? r)
+      (check-equal? (gsd-cmd-artifact-artifact-name r) "HANDOFF"))
+
+    ;; ── Status ──
+    (test-case "parse /gsd"
+      (define r (parse-gsd-command "/gsd" "/gsd"))
+      (check-pred gsd-cmd-status? r))
+
+    ;; ── Replan ──
+    (test-case "parse /replan"
+      (define r (parse-gsd-command "/replan" "/replan"))
+      (check-pred gsd-cmd-replan? r))
+
+    ;; ── Skip ──
+    (test-case "parse /skip"
+      (define r (parse-gsd-command "/skip" "/skip 2"))
+      (check-pred gsd-cmd-skip? r)
+      (check-equal? (gsd-cmd-skip-skip-arg r) "2"))
+
+    ;; ── Reset ──
+    (test-case "parse /reset"
+      (define r (parse-gsd-command "/reset" "/reset"))
+      (check-pred gsd-cmd-reset? r))
+
+    ;; ── Wave-done ──
+    (test-case "parse /wave-done"
+      (define r (parse-gsd-command "/wave-done" "/wave-done 1"))
+      (check-pred gsd-cmd-wave-done? r)
+      (check-equal? (gsd-cmd-wave-done-wave-arg r) "1"))
+
+    (test-case "parse /wd alias"
+      (define r (parse-gsd-command "/wd" "/wd 5"))
+      (check-pred gsd-cmd-wave-done? r)
+      (check-equal? (gsd-cmd-wave-done-wave-arg r) "5"))
+
+    ;; ── Done ──
+    (test-case "parse /done"
+      (define r (parse-gsd-command "/done" "/done"))
+      (check-pred gsd-cmd-done? r)
+      (check-false (gsd-cmd-done-force? r)))
+
+    (test-case "parse /done --force"
+      (define r (parse-gsd-command "/done" "/done --force"))
+      (check-pred gsd-cmd-done? r)
+      (check-true (gsd-cmd-done-force? r)))
+
+    ;; ── Unknown ──
+    (test-case "unknown command returns #f"
+      (define r (parse-gsd-command "/unknown" "/unknown"))
+      (check-false r))
+
+    (test-case "empty string returns #f"
+      (define r (parse-gsd-command "" ""))
+      (check-false r))
+
+    ;; ── Base struct fields ──
+    (test-case "canonical-name preserved"
+      (define r (parse-gsd-command "/go" "/go"))
+      (check-equal? (parsed-gsd-command-canonical-name r) "/go")
+      (check-equal? (parsed-gsd-command-args r) ""))
+
+    ;; ── All parsed commands are also parsed-gsd-command? ──
+    (test-case "subtypes satisfy parsed-gsd-command?"
+      (for ([cmd
+             (in-list
+              '("/go" "/gsd" "/replan" "/skip" "/reset" "/done" "/wave-done" "/state" "/handoff"))])
+        (define r (parse-gsd-command cmd cmd))
+        (check-pred parsed-gsd-command? r (format "~a should be parsed-gsd-command?" cmd))))))
+
+(run-tests parser-suite 'verbose)


### PR DESCRIPTION
Closes #4144

**Milestone**: v0.39.1 (#329)
**Findings**: R-04, R-16

## Changes
- New `extensions/gsd/command-parser.rkt` with pure `parse-gsd-command` function
- `parsed-gsd-command` struct with 9 typed subtypes (gsd-cmd-go, gsd-cmd-plan, gsd-cmd-skip, etc.)
- Refactored `handle-execute-command` to parse→validate→dispatch pattern
- Extracted `handle-plan-submit` as focused handler
- 23 tests covering all command variants