### PR TITLE
v0.39.1 W1: TUI Command Parse→AST + Version Bump

### DIFF
--- a/tests/test-parsed-command.rkt
+++ b/tests/test-parsed-command.rkt
@@ -1,0 +1,113 @@
+#lang racket
+
+;; tests/test-parsed-command.rkt — TUI command parsing tests (R-17)
+
+(require rackunit
+         rackunit/text-ui
+         "../tui/command-parse.rkt")
+
+(define parse-suite
+  (test-suite "parsed-command tests"
+
+    ;; ── Basic parsing ──
+    (test-case "non-command returns #f"
+      (check-false (parse-command-name "hello"))
+      (check-false (parse-command-name "")))
+
+    ;; ── No-arg commands ──
+    (test-case "/help returns parsed-command"
+      (define r (parse-command-name "/help"))
+      (check-pred parsed-command? r)
+      (check-equal? (parsed-command-canonical-name r) 'help)
+      (check-equal? (parsed-command-arg-kind r) 'none))
+
+    (test-case "/h alias returns help"
+      (define r (parse-command-name "/h"))
+      (check-pred parsed-command? r)
+      (check-equal? (parsed-command-canonical-name r) 'help))
+
+    (test-case "/quit returns parsed-command"
+      (define r (parse-command-name "/quit"))
+      (check-pred parsed-command? r)
+      (check-equal? (parsed-command-canonical-name r) 'quit))
+
+    (test-case "/clear returns parsed-command"
+      (define r (parse-command-name "/clear"))
+      (check-pred parsed-command? r)
+      (check-equal? (parsed-command-canonical-name r) 'clear))
+
+    ;; ── Optional-arg commands ──
+    (test-case "/model without arg"
+      (define r (parse-command-name "/model"))
+      (check-pred parsed-command? r)
+      (check-equal? (parsed-command-canonical-name r) 'model)
+      (check-equal? (parsed-command-args r) '()))
+
+    (test-case "/model with arg"
+      (define r (parse-command-name "/model gpt-4"))
+      (check-pred parsed-command? r)
+      (check-equal? (parsed-command-canonical-name r) 'model)
+      (check-equal? (parsed-command-args r) '("gpt-4")))
+
+    (test-case "/m alias with arg"
+      (define r (parse-command-name "/m claude"))
+      (check-pred parsed-command? r)
+      (check-equal? (parsed-command-canonical-name r) 'model))
+
+    ;; ── Required-arg commands ──
+    (test-case "/switch with arg"
+      (define r (parse-command-name "/switch 3"))
+      (check-pred parsed-command? r)
+      (check-equal? (parsed-command-canonical-name r) 'switch)
+      (check-equal? (parsed-command-args r) '("3")))
+
+    (test-case "/switch without arg → error"
+      (define r (parse-command-name "/switch"))
+      (check-pred parsed-command? r)
+      (check-equal? (parsed-command-arg-kind r) 'error))
+
+    (test-case "/children with arg"
+      (define r (parse-command-name "/children abc"))
+      (check-pred parsed-command? r)
+      (check-equal? (parsed-command-canonical-name r) 'children))
+
+    (test-case "/children without arg → error"
+      (define r (parse-command-name "/children"))
+      (check-pred parsed-command? r)
+      (check-equal? (parsed-command-arg-kind r) 'error))
+
+    ;; ── Unknown commands ──
+    (test-case "unknown slash command returns 'unknown"
+      (define r (parse-command-name "/xyz"))
+      (check-equal? r 'unknown))
+
+    ;; ── Other commands ──
+    (test-case "/retry returns parsed-command"
+      (define r (parse-command-name "/retry"))
+      (check-pred parsed-command? r)
+      (check-equal? (parsed-command-canonical-name r) 'retry))
+
+    (test-case "/compact returns parsed-command"
+      (define r (parse-command-name "/compact"))
+      (check-pred parsed-command? r)
+      (check-equal? (parsed-command-canonical-name r) 'compact))
+
+    (test-case "/status returns parsed-command"
+      (define r (parse-command-name "/status"))
+      (check-pred parsed-command? r)
+      (check-equal? (parsed-command-canonical-name r) 'status))
+
+    ;; ── resolve-command-name ──
+    (test-case "resolve-command-name for alias"
+      (check-equal? (resolve-command-name "/h") 'help)
+      (check-equal? (resolve-command-name "/q") 'quit)
+      (check-equal? (resolve-command-name "/m") 'model)
+      (check-false (resolve-command-name "/xyz")))
+
+    ;; ── Structured result properties ──
+    (test-case "parsed-command is transparent"
+      (define r (parse-command-name "/help"))
+      (check-true (parsed-command? r))
+      (check-false (not (parsed-command? r))))))
+
+(run-tests parse-suite 'verbose)

--- a/tui/command-parse.rkt
+++ b/tui/command-parse.rkt
@@ -10,12 +10,17 @@
 
 (provide make-command-table
          parse-command-name
-         resolve-command-name)
+         resolve-command-name
+         ;; R-17: Structured command result
+         (struct-out parsed-command))
 
 ;; Command table: maps command name strings (including aliases) to
 ;; (cons canonical-symbol arg-kind)
 ;; arg-kind: 'none = never takes args, 'optional = works with or without, 'required = needs arg
 ;; e.g. "/help" → (cons 'help 'none), "/switch" → (cons 'switch 'required)
+
+;; R-17: Structured command result replacing ad-hoc symbol/list returns.
+(struct parsed-command (canonical-name args arg-kind) #:transparent)
 
 (define (make-command-table)
   ;; General
@@ -89,6 +94,8 @@
 
 ;; Parse a slash command string into a dispatch symbol + args list.
 ;; Returns: symbol | (list symbol args...) | #f
+;; R-17: Returns parsed-command or #f for non-commands.
+;; For backward compat, also returns 'unknown for unrecognized slash commands.
 (define (parse-command-name text)
   (define trimmed (string-trim text))
   (cond
@@ -102,20 +109,23 @@
      (define entry (hash-ref table cmd #f))
      (cond
        [(not entry) 'unknown]
-       [(eq? (cdr entry) 'none) (car entry)]
+       [(eq? (cdr entry) 'none) (parsed-command (car entry) '() 'none)]
        [(eq? (cdr entry) 'optional)
-        (if (null? args)
-            (car entry)
-            `(,(car entry) ,(car args)))]
+        (parsed-command (car entry)
+                        (if (null? args)
+                            '()
+                            (list (car args)))
+                        'optional)]
        [(eq? (cdr entry) 'required)
         (if (null? args)
-            (list (string->symbol (format "~a-error" (symbol->string (car entry))))
-                  (case (car entry)
-                    [(switch) "Usage: /switch <branch-id>"]
-                    [(children) "Usage: /children <node-id>"]
-                    [else (format "Usage: /~a <id>" (symbol->string (car entry)))]))
-            `(,(car entry) ,(car args)))]
-       [else (car entry)])]))
+            (parsed-command (string->symbol (format "~a-error" (symbol->string (car entry))))
+                            (list (case (car entry)
+                                    [(switch) "Usage: /switch <branch-id>"]
+                                    [(children) "Usage: /children <node-id>"]
+                                    [else (format "Usage: /~a <id>" (symbol->string (car entry)))]))
+                            'error)
+            (parsed-command (car entry) (list (car args)) 'required))]
+       [else (parsed-command (car entry) '() 'none)])]))
 
 ;; Resolve a command name (with alias) to canonical symbol.
 ;; Returns: symbol or #f

--- a/tui/commands.rkt
+++ b/tui/commands.rkt
@@ -16,6 +16,11 @@
          racket/string
          racket/list
          "state.rkt"
+         (only-in "command-parse.rkt"
+                  parsed-command?
+                  parsed-command-canonical-name
+                  parsed-command-args
+                  parsed-command-arg-kind)
          "palette.rkt"
          "../util/protocol-types.rkt"
          "../agent/event-bus.rkt"
@@ -173,9 +178,18 @@
   ;; Mark dirty (defensive: slash commands always change state)
   (set-box! (cmd-ctx-needs-redraw-box cctx) #t)
   (define state (unbox (cmd-ctx-state-box cctx)))
-  ;; Handle structured commands (lists)
+  ;; R-17: Normalize to internal dispatch form from parsed-command struct
+  (define sym
+    (if (parsed-command? cmd)
+        (parsed-command-canonical-name cmd)
+        cmd))
+  (define args
+    (if (parsed-command? cmd)
+        (parsed-command-args cmd)
+        '()))
+  ;; Handle structured commands (lists from legacy path or parsed-command)
   (cond
-    [(list? cmd)
+    [(and (list? cmd) (not (parsed-command? cmd)))
      (match (car cmd)
        ['switch (handle-switch-command cctx (cadr cmd))]
        ['children (handle-children-command cctx (cadr cmd))]
@@ -188,8 +202,10 @@
         (set-box! (cmd-ctx-state-box cctx) (add-transcript-entry state entry))
         'continue]
        [_ 'continue])]
-    ;; Handle simple symbol commands
     [else
+     ;; R-17: Unified dispatch — sym comes from parsed-command or symbol
+     (when (parsed-command? cmd)
+       (set! cmd sym))
      (match cmd
        ['model (handle-model-command cctx)]
        ['history (handle-history-command cctx)]

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -10,4 +10,4 @@
 (provide q-version)
 
 (: q-version String)
-(define q-version "0.39.0")
+(define q-version "0.39.1")


### PR DESCRIPTION
Closes #4145

**Milestone**: v0.39.1 (#329)
**Findings**: R-17, R-11

## Changes
- `parsed-command` struct with `canonical-name`, `args`, `arg-kind` fields
- `parse-command-name` now returns `parsed-command` instead of ad-hoc symbol/list
- Updated `process-slash-command` to handle parsed-command structs
- 18 tests for all command variants
- Version bump to 0.39.1