### PR TITLE
v0.39.2 W0: Parameterize Global Mutable Registries

### DIFF
--- a/extensions/ui-surface.rkt
+++ b/extensions/ui-surface.rkt
@@ -39,7 +39,10 @@
 
          ;; M-08: Registry struct and accessor (for advanced use)
          ui-callback-registry
-         ui-callback-registry?)
+         ui-callback-registry?
+
+         ;; R-05: Parameterized registry for test isolation
+         current-ui-registry)
 
 ;; ── Callback registry struct ───────────────────────────────
 
@@ -55,41 +58,41 @@
                     remove-all-extension-widgets)
   #:transparent)
 
-;; Global mutable registry (replaces 10 individual parameters).
-(define *ui-registry* (box (ui-callback-registry #f #f #f #f #f #f #f #f #f #f)))
+;; R-05: Parameterized registry for test isolation
+(define current-ui-registry (make-parameter (ui-callback-registry #f #f #f #f #f #f #f #f #f #f)))
 
 ;; ── Public API ─────────────────────────────────────────────
 
 (define (ui-set-footer! ui-state-box lines)
-  ((ui-callback-registry-set-footer (unbox *ui-registry*)) ui-state-box lines))
+  ((ui-callback-registry-set-footer (current-ui-registry)) ui-state-box lines))
 
 (define (ui-set-header! ui-state-box lines)
-  ((ui-callback-registry-set-header (unbox *ui-registry*)) ui-state-box lines))
+  ((ui-callback-registry-set-header (current-ui-registry)) ui-state-box lines))
 
 (define (ui-clear-footer! ui-state-box)
-  ((ui-callback-registry-clear-footer (unbox *ui-registry*)) ui-state-box))
+  ((ui-callback-registry-clear-footer (current-ui-registry)) ui-state-box))
 
 (define (ui-clear-header! ui-state-box)
-  ((ui-callback-registry-clear-header (unbox *ui-registry*)) ui-state-box))
+  ((ui-callback-registry-clear-header (current-ui-registry)) ui-state-box))
 
 (define (ui-make-styled-line segments)
-  ((ui-callback-registry-make-styled-line (unbox *ui-registry*)) segments))
+  ((ui-callback-registry-make-styled-line (current-ui-registry)) segments))
 
 (define (ui-make-styled-segment text style)
-  ((ui-callback-registry-make-styled-segment (unbox *ui-registry*)) text style))
+  ((ui-callback-registry-make-styled-segment (current-ui-registry)) text style))
 
 ;; Set status message in the ui-state box (dialog-api notification integration)
 ;; ui-state-box: box? containing ui-state
 ;; message: string? — the formatted status message
 (define (ui-set-status-message! ui-state-box message)
-  (define cb (ui-callback-registry-set-status-message (unbox *ui-registry*)))
+  (define cb (ui-callback-registry-set-status-message (current-ui-registry)))
   (when cb
     (cb ui-state-box message)))
 
 ;; Set a widget from an extension
 ;; Falls back to direct struct-copy when no TUI callback is installed
 (define (ui-set-extension-widget! state ext-name key lines)
-  (define cb (ui-callback-registry-set-extension-widget (unbox *ui-registry*)))
+  (define cb (ui-callback-registry-set-extension-widget (current-ui-registry)))
   (if cb
       (cb state ext-name key lines)
       ;; Fallback: directly update the extension-widgets hash
@@ -99,7 +102,7 @@
 
 ;; Remove a specific widget
 (define (ui-remove-extension-widget! state ext-name key)
-  (define cb (ui-callback-registry-remove-extension-widget (unbox *ui-registry*)))
+  (define cb (ui-callback-registry-remove-extension-widget (current-ui-registry)))
   (if cb
       (cb state ext-name key)
       (let* ([widgets (ui-state-extension-widgets state)]
@@ -108,7 +111,7 @@
 
 ;; Remove all widgets for an extension
 (define (ui-remove-all-extension-widgets! state ext-name)
-  (define cb (ui-callback-registry-remove-all-extension-widgets (unbox *ui-registry*)))
+  (define cb (ui-callback-registry-remove-all-extension-widgets (current-ui-registry)))
   (if cb
       (cb state ext-name)
       (let* ([widgets (ui-state-extension-widgets state)]
@@ -118,7 +121,7 @@
         (struct-copy ui-state state [extension-widgets new-widgets]))))
 
 (define (ui-callbacks-installed?)
-  (define r (unbox *ui-registry*))
+  (define r (current-ui-registry))
   (and (ui-callback-registry-set-footer r)
        (ui-callback-registry-set-header r)
        (ui-callback-registry-clear-footer r)
@@ -134,14 +137,13 @@
 ;;                set-extension-widget, remove-extension-widget,
 ;;                remove-all-extension-widgets
 (define (install-ui-callbacks! callbacks)
-  (set-box! *ui-registry*
-            (ui-callback-registry (hash-ref callbacks 'set-footer #f)
-                                  (hash-ref callbacks 'set-header #f)
-                                  (hash-ref callbacks 'clear-footer #f)
-                                  (hash-ref callbacks 'clear-header #f)
-                                  (hash-ref callbacks 'make-styled-line #f)
-                                  (hash-ref callbacks 'make-styled-segment #f)
-                                  (hash-ref callbacks 'set-status-message #f)
-                                  (hash-ref callbacks 'set-extension-widget #f)
-                                  (hash-ref callbacks 'remove-extension-widget #f)
-                                  (hash-ref callbacks 'remove-all-extension-widgets #f))))
+  (current-ui-registry (ui-callback-registry (hash-ref callbacks 'set-footer #f)
+                                             (hash-ref callbacks 'set-header #f)
+                                             (hash-ref callbacks 'clear-footer #f)
+                                             (hash-ref callbacks 'clear-header #f)
+                                             (hash-ref callbacks 'make-styled-line #f)
+                                             (hash-ref callbacks 'make-styled-segment #f)
+                                             (hash-ref callbacks 'set-status-message #f)
+                                             (hash-ref callbacks 'set-extension-widget #f)
+                                             (hash-ref callbacks 'remove-extension-widget #f)
+                                             (hash-ref callbacks 'remove-all-extension-widgets #f))))

--- a/tests/test-parameterized-registries.rkt
+++ b/tests/test-parameterized-registries.rkt
@@ -1,0 +1,81 @@
+#lang racket
+
+;; tests/test-parameterized-registries.rkt — R-05/R-14 registry isolation tests
+
+(require rackunit
+         rackunit/text-ui
+         "../util/event-macro.rkt"
+         "../extensions/ui-surface.rkt")
+
+(define registry-suite
+  (test-suite "Parameterized registry isolation tests"
+
+    ;; ── Event field registry ──
+    (test-case "event field registry: parameterize isolation"
+      ;; Register in outer scope
+      (register-event-fields! 'test-outer '(a b c))
+      (check-equal? (lookup-event-fields 'test-outer) '(a b c))
+      ;; Inner scope with fresh registry
+      (with-fresh-event-registries (check-false (lookup-event-fields 'test-outer))
+                                   (register-event-fields! 'test-inner '(x y))
+                                   (check-equal? (lookup-event-fields 'test-inner) '(x y)))
+      ;; Outer scope unchanged
+      (check-equal? (lookup-event-fields 'test-outer) '(a b c))
+      (check-false (lookup-event-fields 'test-inner)))
+
+    (test-case "event field registry: direct parameterize"
+      (parameterize ([current-event-field-registry (make-hasheq)])
+        (register-event-fields! 'isolated '(foo))
+        (check-equal? (lookup-event-fields 'isolated) '(foo)))
+      ;; Global should not have 'isolated (unless another test registered it)
+      ;; We just verify the parameterize worked
+      (check-true #t))
+
+    ;; ── Serializer registry ──
+    (test-case "serializer registry: parameterize isolation"
+      (with-fresh-event-registries (register-event-serializer! "test-type" (lambda (e) (hasheq)))
+                                   (check-pred procedure? (lookup-event-serializer "test-type")))
+      ;; After scope, should be gone
+      (check-false (lookup-event-serializer "test-type")))
+
+    ;; ── Deserializer registry ──
+    (test-case "deserializer registry: parameterize isolation"
+      (with-fresh-event-registries (register-event-deserializer! "test-type"
+                                                                 (lambda (t ts sid tid h) #f))
+                                   (check-pred procedure? (lookup-event-deserializer "test-type")))
+      (check-false (lookup-event-deserializer "test-type")))
+
+    ;; ── All three registries at once ──
+    (test-case "with-fresh-event-registries isolates all three"
+      (with-fresh-event-registries (register-event-fields! 'combo '(a))
+                                   (register-event-serializer! "combo" values)
+                                   (register-event-deserializer! "combo" values)
+                                   (check-equal? (lookup-event-fields 'combo) '(a))
+                                   (check-pred procedure? (lookup-event-serializer "combo"))
+                                   (check-pred procedure? (lookup-event-deserializer "combo")))
+      ;; After scope
+      (check-false (lookup-event-fields 'combo))
+      (check-false (lookup-event-serializer "combo"))
+      (check-false (lookup-event-deserializer "combo")))
+
+    ;; ── UI registry ──
+    (test-case "UI registry: parameterize isolation"
+      ;; Override in scope
+      (define test-registry (ui-callback-registry (lambda (s l) (void)) #f #f #f #f #f #f #f #f #f))
+      (parameterize ([current-ui-registry test-registry])
+        (check-equal? (current-ui-registry) test-registry))
+      ;; After scope, back to default
+      (check-not-eq? (current-ui-registry) test-registry))
+
+    ;; ── Nested parameterize ──
+    (test-case "nested parameterize preserves outer scope"
+      (with-fresh-event-registries (register-event-fields! 'outer '(x))
+                                   (parameterize ([current-event-field-registry (make-hasheq)])
+                                     (register-event-fields! 'inner '(y))
+                                     (check-equal? (lookup-event-fields 'inner) '(y))
+                                     (check-false (lookup-event-fields 'outer)))
+                                   ;; Back to with-fresh-event-registries scope
+                                   (check-equal? (lookup-event-fields 'outer) '(x))
+                                   (check-false (lookup-event-fields 'inner))))))
+
+(run-tests registry-suite 'verbose)

--- a/util/event-macro.rkt
+++ b/util/event-macro.rkt
@@ -27,6 +27,11 @@
          register-event-deserializer!
          lookup-event-serializer
          lookup-event-deserializer
+         ;; R-14: Parameterized registries for test isolation
+         current-event-field-registry
+         current-event-serializer-registry
+         current-event-deserializer-registry
+         with-fresh-event-registries
          ;; JSON key conversion
          field->json-key)
 
@@ -34,35 +39,41 @@
 ;; Event field registry (I-12, I-23) -- canonical runtime mechanism for serialization
 ;; ===========================================================
 
-(define *event-field-registry* (make-hasheq))
+;; R-14: Parameterized registries for test isolation
+(define current-event-field-registry (make-parameter (make-hasheq)))
 
 (define (register-event-fields! name fields)
-  (hash-set! *event-field-registry* name fields))
+  (hash-set! (current-event-field-registry) name fields))
 
 (define (lookup-event-fields name)
-  (hash-ref *event-field-registry* name #f))
+  (hash-ref (current-event-field-registry) name #f))
 
 ;; ===========================================================
 ;; Event serializer registry (H-01)
 ;; ===========================================================
 
-;; type-string -> (lambda (evt) hasheq?)
-(define *event-serializer-registry* (make-hash))
-
-;; type-string -> (lambda (type ts sid tid h) typed-event?)
-(define *event-deserializer-registry* (make-hash))
+;; R-14: Parameterized registries for test isolation
+(define current-event-serializer-registry (make-parameter (make-hash)))
+(define current-event-deserializer-registry (make-parameter (make-hash)))
 
 (define (register-event-serializer! type-str fn)
-  (hash-set! *event-serializer-registry* type-str fn))
+  (hash-set! (current-event-serializer-registry) type-str fn))
 
 (define (register-event-deserializer! type-str fn)
-  (hash-set! *event-deserializer-registry* type-str fn))
+  (hash-set! (current-event-deserializer-registry) type-str fn))
 
 (define (lookup-event-serializer type-str)
-  (hash-ref *event-serializer-registry* type-str #f))
+  (hash-ref (current-event-serializer-registry) type-str #f))
 
 (define (lookup-event-deserializer type-str)
-  (hash-ref *event-deserializer-registry* type-str #f))
+  (hash-ref (current-event-deserializer-registry) type-str #f))
+
+;; R-14: Test isolation helper -- fresh registries in parameterize scope
+(define-syntax-rule (with-fresh-event-registries body ...)
+  (parameterize ([current-event-field-registry (make-hasheq)]
+                 [current-event-serializer-registry (make-hash)]
+                 [current-event-deserializer-registry (make-hash)])
+    body ...))
 
 ;; ===========================================================
 ;; JSON key conversion (H-01)

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -10,4 +10,4 @@
 (provide q-version)
 
 (: q-version String)
-(define q-version "0.39.1")
+(define q-version "0.39.2")


### PR DESCRIPTION
Closes #4149. Closes #4148.

**Milestone**: v0.39.2 (#330)
**Findings**: R-05, R-14

## Changes
- `event-macro.rkt`: Convert `*event-field-registry*`, `*event-serializer-registry*`, `*event-deserializer-registry*` to parameters
- `ui-surface.rkt`: Convert `*ui-registry*` box to `current-ui-registry` parameter
- Add `with-fresh-event-registries` macro for test isolation
- 7 tests for parameterize isolation
- Version bump to 0.39.2