### PR TITLE
v0.39.3 W0: Gate tool-execute Behind Scheduler

### DIFF
--- a/extensions/tool-api.rkt
+++ b/extensions/tool-api.rkt
@@ -10,63 +10,62 @@
 ;; and execution context helpers.
 
 (require "../tools/tool.rkt"
-         (only-in "../tools/tool-struct.rkt" tool-execute))
+         (only-in "../tools/tool-internal.rkt" tool-execute))
 
-(provide
- ;; Tool result constructors (most common need)
- make-success-result
- make-error-result
- make-tool-result
- tool-result?
- tool-result-content
- tool-result-details
- tool-result-is-error?
- tool-result->jsexpr
- jsexpr->tool-result
+;; Tool result constructors (most common need)
+(provide make-success-result
+         make-error-result
+         make-tool-result
+         tool-result?
+         tool-result-content
+         tool-result-details
+         tool-result-is-error?
+         tool-result->jsexpr
+         jsexpr->tool-result
 
- ;; Tool struct (dynamic-tools needs this)
- make-tool
- tool?
- tool-name
- tool-description
- tool-schema
- tool-execute
- tool-prompt-snippet
- tool-prompt-guidelines
- tool-dangerous?
- tool->jsexpr
- merge-tool-lists
- validate-tool-schema
- format-tool-schema-hint
+         ;; Tool struct (dynamic-tools needs this)
+         make-tool
+         tool?
+         tool-name
+         tool-description
+         tool-schema
+         ;; R-15: tool-execute removed from extension API; use tools/tool-internal.rkt
+         tool-prompt-snippet
+         tool-prompt-guidelines
+         tool-dangerous?
+         tool->jsexpr
+         merge-tool-lists
+         validate-tool-schema
+         format-tool-schema-hint
 
- ;; Tool registry
- make-tool-registry
- tool-registry?
- register-tool!
- unregister-tool!
- set-active-tools!
- tool-active?
- list-active-tools
- list-active-tools-jsexpr
- lookup-tool
- list-tools
- list-tools-jsexpr
- tool-names
+         ;; Tool registry
+         make-tool-registry
+         tool-registry?
+         register-tool!
+         unregister-tool!
+         set-active-tools!
+         tool-active?
+         list-active-tools
+         list-active-tools-jsexpr
+         lookup-tool
+         list-tools
+         list-tools-jsexpr
+         tool-names
 
- ;; Execution context
- make-exec-context
- exec-context?
- exec-context-working-directory
- exec-context-cancellation-token
- exec-context-event-publisher
- exec-context-runtime-settings
- exec-context-call-id
- exec-context-session-metadata
- exec-context-progress-callback
- exec-context-permission-config
- emit-progress!
+         ;; Execution context
+         make-exec-context
+         exec-context?
+         exec-context-working-directory
+         exec-context-cancellation-token
+         exec-context-event-publisher
+         exec-context-runtime-settings
+         exec-context-call-id
+         exec-context-session-metadata
+         exec-context-progress-callback
+         exec-context-permission-config
+         emit-progress!
 
- ;; Tool call struct
- tool-call
- tool-call?
- tool-call-id)
+         ;; Tool call struct
+         tool-call
+         tool-call?
+         tool-call-id)

--- a/tests/test-tool-internal-gate.rkt
+++ b/tests/test-tool-internal-gate.rkt
@@ -1,0 +1,71 @@
+#lang racket
+
+;; tests/test-tool-internal-gate.rkt — R-15: verify tool-execute gating
+
+(require rackunit
+         rackunit/text-ui
+         (only-in "../tools/tool-internal.rkt" tool-execute tool-dangerous?)
+         (only-in "../tools/tool-struct.rkt" tool? tool-name tool-execute tool-dangerous?)
+         (only-in "../tools/tool.rkt" make-tool)
+         (only-in "../tools/registry-table.rkt"
+                  register-tools-from-specs!
+                  tool-specs
+                  tool-spec-name
+                  tool-spec?
+                  dangerous-tool-names)
+         (only-in "../tools/registry.rkt" make-tool-registry lookup-tool))
+
+(define gate-suite
+  (test-suite "Tool execute gate tests"
+
+    ;; ── tool-internal.rkt provides tool-execute ──
+    (test-case "tool-internal provides tool-execute"
+      (check-pred procedure? tool-execute))
+
+    ;; ── dangerous tool metadata ──
+    (test-case "dangerous-tool-names includes write/edit/bash"
+      (check-not-false (member "write" dangerous-tool-names))
+      (check-not-false (member "edit" dangerous-tool-names))
+      (check-not-false (member "bash" dangerous-tool-names)))
+
+    (test-case "non-dangerous tools not in list"
+      (check-false (member "read" dangerous-tool-names))
+      (check-false (member "grep" dangerous-tool-names))
+      (check-false (member "ls" dangerous-tool-names)))
+
+    ;; ── registration marks dangerous tools ──
+    (test-case "registered write tool is dangerous"
+      (define reg (make-tool-registry))
+      (register-tools-from-specs! reg tool-specs #:only '("write"))
+      (define t (lookup-tool reg "write"))
+      (check-true (tool-dangerous? t)))
+
+    (test-case "registered edit tool is dangerous"
+      (define reg (make-tool-registry))
+      (register-tools-from-specs! reg tool-specs #:only '("edit"))
+      (define t (lookup-tool reg "edit"))
+      (check-true (tool-dangerous? t)))
+
+    (test-case "registered bash tool is dangerous"
+      (define reg (make-tool-registry))
+      (register-tools-from-specs! reg tool-specs #:only '("bash"))
+      (define t (lookup-tool reg "bash"))
+      (check-true (tool-dangerous? t)))
+
+    (test-case "registered read tool is not dangerous"
+      (define reg (make-tool-registry))
+      (register-tools-from-specs! reg tool-specs #:only '("read"))
+      (define t (lookup-tool reg "read"))
+      (check-false (tool-dangerous? t)))
+
+    ;; ── make-tool with #:dangerous? ──
+    (test-case "make-tool accepts #:dangerous? flag"
+      (define t
+        (make-tool "test" "test tool" (hasheq 'type "object") (lambda (args) "ok") #:dangerous? #t))
+      (check-true (tool-dangerous? t)))
+
+    (test-case "make-tool defaults to not dangerous"
+      (define t (make-tool "safe" "safe tool" (hasheq 'type "object") (lambda (args) "ok")))
+      (check-false (tool-dangerous? t)))))
+
+(run-tests gate-suite 'verbose)

--- a/tools/registry-table.rkt
+++ b/tools/registry-table.rkt
@@ -27,6 +27,7 @@
 (struct tool-spec (name description schema handler prompt-guidelines) #:transparent)
 
 (provide register-tools-from-specs!
+         dangerous-tool-names
          tool-specs
          tool-spec
          tool-spec?
@@ -355,6 +356,9 @@
 ;; Registration from specs
 ;; ============================================================
 
+;; R-03/R-22: Metadata-driven dangerous tool classification
+(define dangerous-tool-names '("write" "edit" "bash"))
+
 ;; Register tools from tool-spec structs.
 (define (register-tools-from-specs! registry specs #:only [only #f])
   (for ([spec (in-list specs)])
@@ -363,16 +367,19 @@
        (define name (tool-spec-name spec))
        (when (or (not only) (member name only))
          (define pg (tool-spec-prompt-guidelines spec))
+         (define dangerous? (and (member name dangerous-tool-names) #t))
          (if pg
              (register-tool! registry
                              (make-tool name
                                         (tool-spec-description spec)
                                         (tool-spec-schema spec)
                                         (tool-spec-handler spec)
-                                        #:prompt-guidelines pg))
+                                        #:prompt-guidelines pg
+                                        #:dangerous? dangerous?))
              (register-tool! registry
                              (make-tool name
                                         (tool-spec-description spec)
                                         (tool-spec-schema spec)
-                                        (tool-spec-handler spec)))))]))
+                                        (tool-spec-handler spec)
+                                        #:dangerous? dangerous?))))]))
   (void))

--- a/tools/scheduler.rkt
+++ b/tools/scheduler.rkt
@@ -42,7 +42,7 @@
                   tool-call-id
                   tool-call-name
                   tool-call-arguments)
-         (only-in "tool-struct.rkt" tool-execute)
+         (only-in "tool-struct.rkt" tool-execute tool-dangerous?)
          (only-in "../util/hook-types.rkt" hook-result? hook-result-action hook-result-payload)
          (only-in "../util/safe-mode-predicates.rkt"
                   safe-mode?
@@ -233,15 +233,13 @@
              (not (request-approval perm-cfg tc-name (tool-call-arguments tc-to-execute))))
         (make-error-result (format "tool '~a' blocked — approval denied" tc-name))]
        [else
-        ;; Execute the tool (with file mutation queue for write tools)
-        (define file-mutating-tools '("write" "edit"))
+        ;; R-03/R-22: Use tool-dangerous? metadata instead of hardcoded list
         (define args (tool-call-arguments tc-to-execute))
         (define exec-result
           (with-handlers ([exn:fail? (lambda (e)
                                        (make-error-result
                                         (format "tool '~a' raised: ~a" tc-name (exn-message e))))])
-            (define path-arg
-              (and (member tc-name file-mutating-tools) (hash? args) (hash-ref args 'path #f)))
+            (define path-arg (and (tool-dangerous? t) (hash? args) (hash-ref args 'path #f)))
             (with-file-mutation-queue path-arg (lambda () ((tool-execute t) args exec-ctx)))))
 
         ;; Dispatch 'tool-result-post hook

--- a/tools/tool-internal.rkt
+++ b/tools/tool-internal.rkt
@@ -1,0 +1,16 @@
+#lang racket/base
+
+;; tools/tool-internal.rkt — Internal tool execution access (R-15)
+;; STABILITY: evolving
+;;
+;; Provides tool-execute for production internal callers (scheduler,
+;; dynamic-tools, tests). NOT exported to extensions via tool-api.rkt.
+;; Extensions must go through the scheduler for tool invocation.
+
+(require "../tools/tool-struct.rkt")
+
+(provide tool-execute
+         tool-dangerous?)
+
+;; Re-export from tool-struct for internal use
+;; tool-execute and tool-dangerous? are already bound by the require

--- a/tools/tool.rkt
+++ b/tools/tool.rkt
@@ -53,7 +53,8 @@
                              (#:prompt-snippet (or/c string? #f)
                                                #:render-call (or/c procedure? #f)
                                                #:render-result (or/c procedure? #f)
-                                               #:prompt-guidelines (or/c string? #f))
+                                               #:prompt-guidelines (or/c string? #f)
+                                               #:dangerous? boolean?)
                              tool?)]
                        [validate-tool-args (-> tool? hash? boolean?)])
          merge-tool-lists


### PR DESCRIPTION
Closes #4152

**Milestone**: v0.39.3 (#331)
**Findings**: R-15, R-03, R-08, R-22

## Changes
- `tools/tool-internal.rkt`: New internal module providing `tool-execute` for production callers
- `extensions/tool-api.rkt`: Removed `tool-execute` from extension API
- `tools/scheduler.rkt`: Replaced hardcoded `file-mutating-tools` with `tool-dangerous?` metadata check
- `tools/registry-table.rkt`: Added `dangerous-tool-names`, marks write/edit/bash as dangerous
- `tools/tool.rkt`: Added `#:dangerous?` to `make-tool` contract
- 9 tests for tool execute gate and dangerous metadata