### PR TITLE
v0.39.3 W1: Scheduler Strategy Interface + Version Bump

### DIFF
--- a/tests/test-scheduler-strategy.rkt
+++ b/tests/test-scheduler-strategy.rkt
@@ -1,0 +1,80 @@
+#lang racket
+
+;; tests/test-scheduler-strategy.rkt — R-15: scheduler strategy tests
+
+(require rackunit
+         rackunit/text-ui
+         "../tools/scheduler-strategy.rkt")
+
+(define strategy-suite
+  (test-suite "Scheduler strategy tests"
+
+    ;; ── Strategy struct ──
+    (test-case "default-scheduler-strategy is a scheduler-strategy"
+      (define s (default-scheduler-strategy))
+      (check-pred scheduler-strategy? s))
+
+    (test-case "default preflight-filter passes all tools"
+      (define s (default-scheduler-strategy))
+      (define calls '(a b c))
+      (check-equal? ((scheduler-strategy-preflight-filter s) calls) calls))
+
+    (test-case "default execution-order preserves order"
+      (define s (default-scheduler-strategy))
+      (define calls '(a b c))
+      (check-equal? ((scheduler-strategy-execution-order s) calls) calls))
+
+    (test-case "default parallelism-degree is 1 (serial)"
+      (define s (default-scheduler-strategy))
+      (check-equal? ((scheduler-strategy-parallelism-degree s)) 1))
+
+    ;; ── Custom strategy ──
+    (test-case "custom strategy can filter tools"
+      (define s
+        (scheduler-strategy (lambda (calls) (filter (lambda (c) (not (equal? c 'skip-me))) calls))
+                            (lambda (calls) calls)
+                            (lambda () 2)))
+      (check-equal? ((scheduler-strategy-preflight-filter s) '(a skip-me b)) '(a b)))
+
+    (test-case "custom strategy can reorder"
+      (define s (scheduler-strategy values (lambda (calls) (reverse calls)) (lambda () 1)))
+      (check-equal? ((scheduler-strategy-execution-order s) '(a b c)) '(c b a)))
+
+    ;; ── Tool invocation result algebra ──
+    (test-case "tool-success"
+      (define r (tool-success "read" "content" #f))
+      (check-pred tool-success? r)
+      (check-pred tool-invocation-result? r)
+      (check-equal? (tool-invocation-result-tool-name r) "read")
+      (check-equal? (tool-success-content r) "content"))
+
+    (test-case "tool-structured-failure"
+      (define r (tool-structured-failure "edit" "bad match" #f))
+      (check-pred tool-structured-failure? r)
+      (check-pred tool-invocation-result? r)
+      (check-equal? (tool-structured-failure-message r) "bad match"))
+
+    (test-case "tool-retryable-failure"
+      (define r (tool-retryable-failure "bash" "timeout" #f))
+      (check-pred tool-retryable-failure? r)
+      (check-pred tool-invocation-result? r))
+
+    (test-case "tool-policy-denied"
+      (define r (tool-policy-denied "write" "safe mode"))
+      (check-pred tool-policy-denied? r)
+      (check-pred tool-invocation-result? r)
+      (check-equal? (tool-policy-denied-reason r) "safe mode"))
+
+    ;; ── Result type discrimination ──
+    (test-case "each result type is distinct"
+      (define results
+        (list (tool-success "a" "ok" #f)
+              (tool-structured-failure "b" "err" #f)
+              (tool-retryable-failure "c" "retry" #f)
+              (tool-policy-denied "d" "denied")))
+      (check-true (tool-success? (car results)))
+      (check-true (tool-structured-failure? (cadr results)))
+      (check-true (tool-retryable-failure? (caddr results)))
+      (check-true (tool-policy-denied? (cadddr results))))))
+
+(run-tests strategy-suite 'verbose)

--- a/tools/scheduler-strategy.rkt
+++ b/tools/scheduler-strategy.rkt
@@ -1,0 +1,56 @@
+#lang racket/base
+
+;; tools/scheduler-strategy.rkt — Pluggable scheduler strategy (R-15)
+;; STABILITY: evolving
+;;
+;; Defines scheduler-strategy struct with function fields for customizing
+;; tool batch execution behavior. Default strategy preserves current behavior.
+
+(require "tool-struct.rkt")
+
+(provide (struct-out scheduler-strategy)
+         (struct-out tool-invocation-result)
+         (struct-out tool-success)
+         (struct-out tool-structured-failure)
+         (struct-out tool-retryable-failure)
+         (struct-out tool-policy-denied)
+         default-scheduler-strategy
+         tool-invocation-result?
+         tool-result->invocation-result)
+
+;; ── Tool invocation result tagged union ──
+
+(struct tool-invocation-result (tool-name) #:transparent)
+(struct tool-success tool-invocation-result (content details) #:transparent)
+(struct tool-structured-failure tool-invocation-result (message details) #:transparent)
+(struct tool-retryable-failure tool-invocation-result (message error) #:transparent)
+(struct tool-policy-denied tool-invocation-result (reason) #:transparent)
+
+;; ── Scheduler strategy ──
+
+(struct scheduler-strategy
+        (preflight-filter ; (listof tool-call) -> (listof tool-call)
+         execution-order ; (listof tool-call) -> (listof tool-call)
+         parallelism-degree) ; -> exact-nonnegative-integer?
+  #:transparent)
+
+;; Default strategy: all tools pass preflight, maintain original order, serial execution
+(define (default-scheduler-strategy)
+  (scheduler-strategy (lambda (calls) calls) ; preflight-filter: pass all
+                      (lambda (calls) calls) ; execution-order: keep order
+                      (lambda () 1))) ; parallelism: serial
+
+;; Convert tool-result to tool-invocation-result
+(define (tool-result->invocation-result tool-name result)
+  (if (tool-result-is-error? result)
+      (tool-structured-failure tool-name
+                               (format "~a" (tool-result-content result))
+                               (tool-result-details result))
+      (tool-success tool-name (tool-result-content result) (tool-result-details result))))
+
+;; Need these from tool.rkt (re-import to avoid circular dependency)
+(require (only-in "tool.rkt"
+                  tool-result?
+                  tool-result-content
+                  tool-result-details
+                  tool-result-is-error?))

--- a/tools/scheduler.rkt
+++ b/tools/scheduler.rkt
@@ -43,6 +43,11 @@
                   tool-call-name
                   tool-call-arguments)
          (only-in "tool-struct.rkt" tool-execute tool-dangerous?)
+         (only-in "scheduler-strategy.rkt"
+                  scheduler-strategy?
+                  scheduler-strategy-preflight-filter
+                  scheduler-strategy-execution-order
+                  default-scheduler-strategy)
          (only-in "../util/hook-types.rkt" hook-result? hook-result-action hook-result-payload)
          (only-in "../util/safe-mode-predicates.rkt"
                   safe-mode?
@@ -54,6 +59,8 @@
 
 ;; ── Result struct ──
 (provide (struct-out scheduler-result)
+         ;; R-15: Strategy support
+         current-scheduler-strategy
          (struct-out preflight-entry)
          run-preflight
          (contract-out [run-tool-batch
@@ -67,6 +74,9 @@
 ;; ============================================================
 ;; Scheduler result struct
 ;; ============================================================
+
+;; R-15: Pluggable strategy parameter
+(define current-scheduler-strategy (make-parameter (default-scheduler-strategy)))
 
 (struct scheduler-result (results metadata) #:transparent)
 
@@ -366,7 +376,10 @@
                         registry
                         #:hook-dispatcher [hook-dispatcher #f]
                         #:exec-context [exec-ctx (make-exec-context)]
-                        #:parallel? [parallel? #f])
+                        #:parallel? [parallel? #f]
+                        #:strategy [strategy #f])
+  ;; R-15: Use provided strategy or current parameter
+  (define strat (or strategy (current-scheduler-strategy)))
   ;; Resolve event publisher from exec-context (may be #f)
   (define ev-pub (and exec-ctx (exec-context-event-publisher exec-ctx)))
 
@@ -375,8 +388,11 @@
     (ev-pub "tool.batch.preflight.started"
             (hasheq 'toolCount (length tool-calls) 'toolNames (map tool-call-name tool-calls))))
 
+  ;; R-15: Apply strategy phases
+  (define filtered-calls ((scheduler-strategy-preflight-filter strat) tool-calls))
+  (define ordered-calls ((scheduler-strategy-execution-order strat) filtered-calls))
   ;; Step 1: Preflight (serial)
-  (define preflight-entries (run-preflight tool-calls registry hook-dispatcher))
+  (define preflight-entries (run-preflight ordered-calls registry hook-dispatcher))
 
   ;; Step 2: Execution (serial or parallel)
   (define results (run-execution preflight-entries exec-ctx parallel? hook-dispatcher))

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -10,4 +10,4 @@
 (provide q-version)
 
 (: q-version String)
-(define q-version "0.39.2")
+(define q-version "0.39.3")


### PR DESCRIPTION
Closes #4154. Closes #4151.

**Milestone**: v0.39.3 (#331)
**Findings**: R-15, R-03, R-08, R-22

## Changes
- `tools/scheduler-strategy.rkt`: Strategy struct with pluggable filter/order/parallelism
- `tool-invocation-result` tagged union: tool-success, tool-structured-failure, tool-retryable-failure, tool-policy-denied
- `run-tool-batch` accepts `#:strategy` parameter
- `current-scheduler-strategy` parameter for global override
- 11 tests for strategy and result algebra
- Version bump to 0.39.3