### PR TITLE
v0.39.5 W0: Replace struct->vector with Generated Serializers

### DIFF
--- a/agent/event-emitter.rkt
+++ b/agent/event-emitter.rkt
@@ -16,7 +16,7 @@
                   typed-event-session-id
                   typed-event-turn-id)
          ;; Auto-populated field registry from define-typed-event (I-12)
-         (only-in "../util/event-macro.rkt" lookup-event-fields))
+         (only-in "../util/event-macro.rkt" lookup-event-fields lookup-event-serializer))
 
 ;; NOTE (v0.29.14): emit-typed-event! has 2+ production callers (runtime/session-switch.rkt).
 ;; Adoption is tracked by IVG check `session-switch-typed-events`.
@@ -46,26 +46,43 @@
 (define typed-event-base-field-count 4)
 
 (define (event-struct->hasheq evt)
-  (define vec (struct->vector evt))
-  (define app-start (+ 1 typed-event-base-field-count))
-  (define base
-    (hasheq 'type
-            (typed-event-type evt)
-            'timestamp
-            (typed-event-timestamp evt)
-            'session-id
-            (typed-event-session-id evt)
-            'turn-id
-            (typed-event-turn-id evt)))
-  (define name (struct-name evt))
-  (define fields (get-struct-field-names name))
-  (unless fields
-    (log-warning (format "event-struct->hasheq: no field registry for ~a, dropping subclass fields"
-                         name)))
-  (for/fold ([h base])
-            ([i (in-naturals)]
-             [fname (in-list (or fields '()))])
-    (hash-set h fname (vector-ref vec (+ app-start i)))))
+  ;; R-13: Try auto-generated serializer first (fast path, no struct->vector)
+  (define type-str (typed-event-type evt))
+  (define serializer (lookup-event-serializer type-str))
+  (if serializer
+      ;; Fast path: merge base fields + serializer output
+      (let ([subclass-data (serializer evt)])
+        (hash-set* subclass-data
+                   'type
+                   (typed-event-type evt)
+                   'timestamp
+                   (typed-event-timestamp evt)
+                   'session-id
+                   (typed-event-session-id evt)
+                   'turn-id
+                   (typed-event-turn-id evt)))
+      ;; Legacy fallback: struct->vector reflection
+      (let ()
+        (define vec (struct->vector evt))
+        (define app-start (+ 1 typed-event-base-field-count))
+        (define base
+          (hasheq 'type
+                  (typed-event-type evt)
+                  'timestamp
+                  (typed-event-timestamp evt)
+                  'session-id
+                  (typed-event-session-id evt)
+                  'turn-id
+                  (typed-event-turn-id evt)))
+        (define name (struct-name evt))
+        (define fields (get-struct-field-names name))
+        (unless fields
+          (log-warning
+           (format "event-struct->hasheq: no field registry for ~a, dropping subclass fields" name)))
+        (for/fold ([h base])
+                  ([i (in-naturals)]
+                   [fname (in-list (or fields '()))])
+          (hash-set h fname (vector-ref vec (+ app-start i)))))))
 
 ;; Emit a typed event on the bus.
 ;; Optional #:state for state accumulation (mirrors emit! from loop-messages).

--- a/tests/test-event-serializer-fast-path.rkt
+++ b/tests/test-event-serializer-fast-path.rkt
@@ -1,0 +1,48 @@
+#lang racket
+
+;; tests/test-event-serializer-fast-path.rkt — R-13: Verify serializer registry fast path
+
+(require rackunit
+         rackunit/text-ui
+         "../agent/event-emitter.rkt"
+         "../agent/event-structs/base.rkt"
+         (only-in "../agent/event-structs/tool-events.rkt"
+                  make-tool-execution-start-event
+                  tool-execution-start-event?)
+         "../util/event-macro.rkt")
+
+(define fast-path-suite
+  (test-suite "Event serializer fast path tests (R-13)"
+
+    (test-case "event-struct->hasheq uses serializer registry for typed events"
+      (define evt
+        (make-tool-execution-start-event #:session-id "test-session"
+                                         #:turn-id "test-turn"
+                                         #:tool-name "bash"
+                                         #:tool-call-id "tc-1"))
+      (define result (event-struct->hasheq evt))
+      ;; Base fields present
+      (check-equal? (hash-ref result 'type) "tool.execution.started")
+      (check-equal? (hash-ref result 'session-id) "test-session")
+      (check-equal? (hash-ref result 'turn-id) "test-turn")
+      ;; Subclass fields present
+      (check-equal? (hash-ref result 'toolName) "bash")
+      (check-equal? (hash-ref result 'toolCallId) "tc-1"))
+
+    (test-case "serializer lookup succeeds for registered types"
+      (define ser (lookup-event-serializer "tool.execution.started"))
+      (check-not-false ser "serializer should be registered for tool.execution.started"))
+
+    (test-case "serializer lookup returns #f for unregistered types"
+      (define ser (lookup-event-serializer "nonexistent.event.type"))
+      (check-false ser))
+
+    (test-case "event-struct->hasheq fallback works for unregistered events"
+      ;; Create a minimal typed-event that has no serializer
+      (define evt (typed-event "test.unregistered" (current-inexact-milliseconds) "s1" "t1"))
+      (define result (event-struct->hasheq evt))
+      ;; Base fields still present
+      (check-equal? (hash-ref result 'type) "test.unregistered")
+      (check-equal? (hash-ref result 'session-id) "s1"))))
+
+(run-tests fast-path-suite 'verbose)

--- a/util/event-codec.rkt
+++ b/util/event-codec.rkt
@@ -54,6 +54,7 @@
        ['session-id (session-id-payload (hash-ref h 'sessionId))]
        [_ h])]
     ;; Legacy heuristic decode (backward compatible with pre-v0.28.11 data)
+    ;; R-13: Deprecated -- will be removed in v0.40.x. All events should use __type tags.
     [(and (hash-has-key? h 'error) (hash-has-key? h 'errorType))
      (error-payload (hash-ref h 'error) (hash-ref h 'errorType))]
     [(and (hash-has-key? h 'session-id) (hash-has-key? h 'message))

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -10,4 +10,4 @@
 (provide q-version)
 
 (: q-version String)
-(define q-version "0.39.4")
+(define q-version "0.39.5")


### PR DESCRIPTION
Closes #4162

**Milestone**: v0.39.5 (#333)
**Finding**: R-13

## Changes
- `agent/event-emitter.rkt`: `event-struct->hasheq` now uses auto-generated serializer registry as fast path
- Legacy `struct->vector` fallback preserved for unregistered events
- Deprecation warning on heuristic decode path in `event-codec.rkt`
- 4 tests for serializer fast path, lookup, and fallback