### PR TITLE
v0.39.5 W1: Tool Registry API Cleanup

### DIFF
--- a/tests/test-tool-registry-api.rkt
+++ b/tests/test-tool-registry-api.rkt
@@ -1,0 +1,40 @@
+#lang racket
+
+;; tests/test-tool-registry-api.rkt — R-12/R-24/R-25: Tool registry API cleanup
+
+(require rackunit
+         rackunit/text-ui
+         "../tools/registry.rkt"
+         "../tools/tool-struct.rkt")
+
+(define (make-test-tool name desc)
+  (tool name desc (hasheq 'type "object" 'properties (hasheq)) void #f #f #f #f #f))
+
+(define api-suite
+  (test-suite "Tool registry API tests (R-12, R-24, R-25)"
+
+    (test-case "list-active-tools-jsexpr returns empty for fresh registry"
+      (define reg (make-tool-registry))
+      (define result (list-active-tools-jsexpr reg))
+      (check-equal? result '()))
+
+    (test-case "list-active-tools-jsexpr returns JSON for registered tools"
+      (define reg (make-tool-registry))
+      (define t (make-test-tool "test-tool" "A test tool"))
+      (register-tool! reg t)
+      (define result (list-active-tools-jsexpr reg))
+      (check = (length result) 1)
+      ;; tool->jsexpr wraps in function schema format
+      (define entry (car result))
+      (check-equal? (hash-ref entry 'type) "function")
+      (define fn-data (hash-ref entry 'function))
+      (check-equal? (hash-ref fn-data 'name) "test-tool")
+      (check-equal? (hash-ref fn-data 'description) "A test tool"))
+
+    (test-case "list-tools-jsexpr returns same as list-active-tools-jsexpr"
+      (define reg (make-tool-registry))
+      (register-tool! reg (make-test-tool "t1" "desc 1"))
+      (register-tool! reg (make-test-tool "t2" "desc 2"))
+      (check-equal? (list-tools-jsexpr reg) (list-active-tools-jsexpr reg)))))
+
+(run-tests api-suite 'verbose)

--- a/tools/registry.rkt
+++ b/tools/registry.rkt
@@ -65,6 +65,8 @@
       (with-registry-lock reg (lambda () (hash-ref (tool-registry-tools-box reg) name #f)))))
 
 ;; tool->jsexpr : tool? -> hash?
+;; Returns a JSON-serializable hash representation of a tool.
+;; Safe for external consumers (SDK, JSON mode, extensions).
 ;; Serialize a tool struct to the OpenAI normalized format.
 (define (tool->jsexpr t)
   (define base-fn
@@ -89,19 +91,22 @@
 
 (define (tool-active? reg name)
   (with-registry-lock reg
-    (lambda ()
-      (define active-set (unbox (tool-registry-active-set-box reg)))
-      (or (not active-set) (set-member? active-set name)))))
+                      (lambda ()
+                        (define active-set (unbox (tool-registry-active-set-box reg)))
+                        (or (not active-set) (set-member? active-set name)))))
 
 (define (list-active-tools reg)
   (with-registry-lock reg
                       (lambda ()
                         (define active-set (unbox (tool-registry-active-set-box reg)))
                         (filter (lambda (t)
-                                  (or (not active-set)
-                                      (set-member? active-set (tool-name t))))
+                                  (or (not active-set) (set-member? active-set (tool-name t))))
                                 (hash-values (tool-registry-tools-box reg))))))
 
+;; R-12/R-24: list-active-tools-jsexpr — primary external API
+;; Returns JSON-serializable list of active tools. Use this for
+;; SDK consumers, JSON mode, and extension API surfaces.
+;; tool-registry-tools returns internal tool? values for tool-layer use only.
 (define (list-active-tools-jsexpr reg)
   (map tool->jsexpr (list-active-tools reg)))
 


### PR DESCRIPTION
Closes #4164. Closes #4161.

**Milestone**: v0.39.5 (#333)
**Findings**: R-12, R-24, R-25

## Changes
- `tools/registry.rkt`: Documentation for `list-active-tools-jsexpr` as primary external API
- `tool-registry-tools` documented as returning internal `tool?` values only
- 3 tests for registry JSON API surface