### PR TITLE
v0.39.6 W0: Architecture Fitness Hard Gates

### DIFF
--- a/docs/architecture/dependency-policy.rktd
+++ b/docs/architecture/dependency-policy.rktd
@@ -8,105 +8,107 @@
 ;; Sections: layers, known-exceptions, module-size, complexity-budgets,
 ;;           deep-module-conventions
 
-(
- ;; Layer definitions with max boundary exceptions
- (layers
-  (runtime
-   (max-exceptions . 9)
-   (forbidden-from . (llm tools extensions))
-   (rationale . "Runtime should not import upward into tools/extensions except via turn-orchestrator.rkt"))
-  (tui
-   (max-exceptions . 0)
-   (forbidden-from . (llm tools))
-   (allowed-from . (runtime agent extensions util)))
-  (extensions
-   (max-exceptions . 2)
-   (forbidden-from . (tui))
-   (rationale . "Extensions may import from runtime/core but never TUI"))
-  (llm
-   (max-exceptions . 0)
-   (forbidden-from . (runtime tools extensions))
-   (rationale . "LLM providers are leaf modules with no upward imports")))
-
+;; Layer definitions with max boundary exceptions
+((layers (runtime
+          (max-exceptions . 9)
+          (forbidden-from . (llm tools extensions))
+          (rationale
+           .
+           "Runtime should not import upward into tools/extensions except via turn-orchestrator.rkt"))
+         (tui (max-exceptions . 0)
+              (forbidden-from . (llm tools))
+              (allowed-from . (runtime agent extensions util)))
+         (extensions (max-exceptions . 2)
+                     (forbidden-from . (tui))
+                     (rationale . "Extensions may import from runtime/core but never TUI"))
+         (llm (max-exceptions . 0)
+              (forbidden-from . (runtime tools extensions))
+              (rationale . "LLM providers are leaf modules with no upward imports")))
  ;; Known boundary exceptions (files that violate layer rules for documented reasons)
  ;; Format: ((filename . rationale) ...)
  (known-exceptions
   (runtime . ((agent-session.rkt . "extension registry + DI parameter setup")
               (iteration.rkt . "injection-event-topic value import (cannot lazy-require)")
-              (session-lifecycle.rkt . "injection-event-topic import (extracted from agent-session/iteration)")
+              (session-lifecycle.rkt
+               . "injection-event-topic import (extracted from agent-session/iteration)")
               (runtime-helpers.rkt . "hook dispatch for session events")
               (tool-coordinator.rkt . "tool execution orchestration")
               (turn-orchestrator.rkt . "context assembly + provider turn (sole boundary module)")
               (package.rkt . "package audit reads extension manifests")
               (extension-catalog.rkt . "extension loading/discovery")
-              (session-switch.rkt . "dynamic-require to extensions for lazy loading (avoids circular dependency)")))
-  (extensions . ((dialog-api.rkt . "TUI dialog interface")
-                 (ui-surface.rkt . "TUI UI surface interface")
-                 (context.rkt . "imports runtime/session-types.rkt for context assembly (bidirectional — fragile)")
-                 (ext-package-manager.rkt . "imports runtime/ for package lifecycle management (bidirectional — fragile)"))))
-
+              (session-switch.rkt
+               . "dynamic-require to extensions for lazy loading (avoids circular dependency)")))
+  (extensions
+   .
+   ((dialog-api.rkt . "TUI dialog interface")
+    (ui-surface.rkt . "TUI UI surface interface")
+    (context.rkt . "imports runtime/session-types.rkt for context assembly (bidirectional — fragile)")
+    (ext-package-manager.rkt
+     . "imports runtime/ for package lifecycle management (bidirectional — fragile)"))))
  ;; Module size configuration
- (module-size
-  (max-lines . 900)
-  (known-large . ()))
-
+ (module-size (max-lines . 900) (known-large . ()))
  ;; Complexity budgets (informational in v0.22.8, enforced in v0.23.0)
- (complexity-budgets
-  (max-lines-per-module . 900)
-  (max-function-length . 80)
-  (max-require-fan-in . 14))
-
+ (complexity-budgets (max-lines-per-module . 900)
+                     (max-function-length . 80)
+                     (max-require-fan-in . 14))
  ;; Deep module conventions (v0.27.0)
  ;; Documents the sub-module directories created by the Deep Module Refactoring.
  ;; Each convention specifies the parent module, sub-directory, and budget.
  (deep-module-conventions
-  (tui/input
-   (parent . "tui/input.rkt")
-   (sub-modules . (completion-ops editing-ops history-ops state-types))
-   (budget . 300)
-   (convention . "Stateless operation functions. Parent re-exports."))
-  (tui/keybindings
-   (parent . "tui/tui-keybindings.rkt")
-   (sub-modules . (binding-resolver default-map mode-map))
-   (budget . 150)
-   (convention . "Keymap resolution and default maps."))
+  (tui/input (parent . "tui/input.rkt")
+             (sub-modules . (completion-ops editing-ops history-ops state-types))
+             (budget . 300)
+             (convention . "Stateless operation functions. Parent re-exports."))
+  (tui/keybindings (parent . "tui/tui-keybindings.rkt")
+                   (sub-modules . (binding-resolver default-map mode-map))
+                   (budget . 150)
+                   (convention . "Keymap resolution and default maps."))
   (runtime/iteration
    (parent . "runtime/iteration.rkt")
-   (sub-modules . (loop-state retry-policy tool-turn-bridge counters decision step-interpreter main-loop internal))
+   (sub-modules
+    .
+    (loop-state retry-policy tool-turn-bridge counters decision step-interpreter main-loop internal))
    (budget . 450)
-   (convention . "Iteration loop decomposition. Pure logic in counters/decision, effectful in step-interpreter, orchestration in main-loop."))
+   (convention
+    . "Iteration loop decomposition. Pure logic in counters/decision, effectful in step-interpreter, orchestration in main-loop."))
   (runtime/session-index
    (parent . "runtime/session-index.rkt")
    (sub-modules . (schema query mutations))
    (budget . 400)
    (convention . "Session tree operations. Parent kept for consumer compatibility."))
-  (runtime/context-assembly
-   (parent . "runtime/context-assembly.rkt")
-   (sub-modules . (budgeting selection serialization))
-   (budget . 250)
-   (convention . "Context budget, message selection, serialization."))
-  (extensions/gsd-planning
-   (parent . "extensions/gsd-planning.rkt")
-   (sub-modules . (command-normalization execution-policy plan-diff))
-   (budget . 130)
-   (convention . "Pure logic extracted from GSD planning."))
-  (extensions/gsd
-   (parent . "extensions/gsd-planning.rkt")
-   (sub-modules . (command-handlers tool-handlers))
-   (budget . 350)
-   (convention . "GSD command/tool dispatch extracted from gsd-planning facade."))
-  (extensions/github/handlers
-   (parent . "extensions/github/tool-handlers.rkt")
-   (sub-modules . (issue-ops pr-ops milestone-ops))
-   (budget . 425)
-   (convention . "GitHub tool handler decomposition."))
-  (extensions/racket-tooling
-   (parent . "extensions/racket-tooling-handlers.rkt")
-   (sub-modules . (analysis formatting rewrite))
-   (budget . 420)
-   (convention . "Racket tooling: check, edit, codemod handlers."))
+  (runtime/context-assembly (parent . "runtime/context-assembly.rkt")
+                            (sub-modules . (budgeting selection serialization))
+                            (budget . 250)
+                            (convention . "Context budget, message selection, serialization."))
+  (extensions/gsd-planning (parent . "extensions/gsd-planning.rkt")
+                           (sub-modules . (command-normalization execution-policy plan-diff))
+                           (budget . 130)
+                           (convention . "Pure logic extracted from GSD planning."))
+  (extensions/gsd (parent . "extensions/gsd-planning.rkt")
+                  (sub-modules . (command-handlers tool-handlers))
+                  (budget . 350)
+                  (convention . "GSD command/tool dispatch extracted from gsd-planning facade."))
+  (extensions/github/handlers (parent . "extensions/github/tool-handlers.rkt")
+                              (sub-modules . (issue-ops pr-ops milestone-ops))
+                              (budget . 425)
+                              (convention . "GitHub tool handler decomposition."))
+  (extensions/racket-tooling (parent . "extensions/racket-tooling-handlers.rkt")
+                             (sub-modules . (analysis formatting rewrite))
+                             (budget . 420)
+                             (convention . "Racket tooling: check, edit, codemod handlers."))
   (agent/event-structs
    (parent . "agent/event-structs.rkt")
    (sub-modules . (base message-events provider-events session-events tool-events turn-events))
    (budget . 500)
-   (convention . "Event struct definitions by domain."))))
+   (convention . "Event struct definitions by domain.")))
+ ;; R-18: Pure modules — must not gain I/O imports
+ ;; Format: ((module-path . allowed-current-impurities) ...)
+ (pure-modules (decision . ("runtime/iteration/decision.rkt" . ()))
+               (event-payloads . ("util/event-payloads.rkt" . ()))
+               (event-codec . ("util/event-codec.rkt" . ())))
+ ;; R-19: Parser modules — must not require I/O modules
+ ;; Format: (module-path ...)
+ (parser-modules ("extensions/gsd/command-parser.rkt" "tui/command-parse.rkt" "cli/args.rkt"))
+ ;; R-20: Provide surface budget
+ ;; Alert when public API of a single module exceeds this count.
+ (provide-surface-budget (max-per-module . 150) (alert-threshold . 100)))

--- a/tests/test-arch-fitness.rkt
+++ b/tests/test-arch-fitness.rkt
@@ -358,3 +358,87 @@
                     (format "dict-ref config keys missing accessors: ~a" missing-accessors)))))
 
 (run-tests v0377-suite)
+
+;; ════════════════════════════════════════════════════════════
+;; v0.39.6 additions: R-18 through R-23 hard gates
+;; ════════════════════════════════════════════════════════════
+
+(define v0396-suite
+  (test-suite "v0.39.6-hard-gates"
+
+    ;; R-18: Pure modules must not gain I/O imports
+    (test-case "R-18: decision.rkt has no I/O imports"
+      (define p (build-path q-dir "runtime" "iteration" "decision.rkt"))
+      (when (file-exists? p)
+        (define reqs (extract-requires p))
+        (check-false (imports-from? reqs '("racket/port" "racket/file" "racket/tcp" "racket/os"))
+                     "decision.rkt must not import I/O modules")))
+
+    (test-case "R-18: event-payloads.rkt has no I/O imports"
+      (define p (build-path q-dir "util" "event-payloads.rkt"))
+      (when (file-exists? p)
+        (define reqs (extract-requires p))
+        (check-false (imports-from? reqs '("racket/port" "racket/file" "racket/tcp" "racket/os"))
+                     "event-payloads.rkt must not import I/O modules")))
+
+    (test-case "R-18: event-codec.rkt has no I/O imports"
+      (define p (build-path q-dir "util" "event-codec.rkt"))
+      (when (file-exists? p)
+        (define reqs (extract-requires p))
+        (check-false (imports-from? reqs '("racket/port" "racket/tcp" "racket/os"))
+                     "event-codec.rkt must not import I/O modules")))
+
+    ;; R-19: Parser modules must not require I/O modules
+    (test-case "R-19: GSD command-parser has no I/O imports"
+      (define p (build-path q-dir "extensions" "gsd" "command-parser.rkt"))
+      (when (file-exists? p)
+        (define reqs (extract-requires p))
+        (check-false (imports-from? reqs '("racket/port" "racket/file" "racket/tcp" "racket/os"))
+                     "command-parser.rkt must not import I/O modules")))
+
+    (test-case "R-19: TUI command-parse has no I/O imports"
+      (define p (build-path q-dir "tui" "command-parse.rkt"))
+      (when (file-exists? p)
+        (define reqs (extract-requires p))
+        (check-false (imports-from? reqs '("racket/port" "racket/file" "racket/tcp" "racket/os"))
+                     "command-parse.rkt must not import I/O modules")))
+
+    (test-case "R-19: CLI args has no I/O imports"
+      (define p (build-path q-dir "cli" "args.rkt"))
+      (when (file-exists? p)
+        (define reqs (extract-requires p))
+        (check-false (imports-from? reqs '("racket/port" "racket/file" "racket/tcp" "racket/os"))
+                     "cli/args.rkt must not import I/O modules")))
+
+    ;; R-20: Provide surface budget check (informational)
+    (test-case "R-20: Provide surface budget (informational)"
+      (define dirs-to-check '("runtime" "agent" "llm" "tools" "tui" "interfaces" "util" "extensions"))
+      (define all-files
+        (append* (for/list ([d (in-list dirs-to-check)])
+                   (rkt-files-in d))))
+      (define alert-threshold
+        (cdr (assoc 'alert-threshold (cdr (assoc 'provide-surface-budget policy)))))
+      (define high-provides
+        (for/list ([f (in-list all-files)]
+                   #:when (> (count-provides f) alert-threshold))
+          (cons (path->string (find-relative-path (simplify-path q-dir) (simplify-path f)))
+                (count-provides f))))
+      (when (not (null? high-provides))
+        (displayln (format "INFO: Modules with >~a provides: ~a" alert-threshold high-provides)))
+      (check-true #t "Informational -- always passes"))
+
+    ;; R-21: Fan-in hard gate (graduated from informational)
+    (test-case "R-21: Require fan-in budget (hard gate)"
+      (define dirs-to-check '("runtime" "agent" "llm" "tools" "tui" "interfaces"))
+      (define all-files
+        (append* (for/list ([d (in-list dirs-to-check)])
+                   (rkt-files-in d))))
+      (define over-limit
+        (for/list ([f (in-list all-files)]
+                   #:when (> (count-requires f) max-fan-in))
+          (cons (path->string (find-relative-path (simplify-path q-dir) (simplify-path f)))
+                (count-requires f))))
+      (check-true (<= (length over-limit) 3)
+                  (format "More than 3 files exceed fan-in limit of ~a: ~a" max-fan-in over-limit)))))
+
+(run-tests v0396-suite)

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -10,4 +10,4 @@
 (provide q-version)
 
 (: q-version String)
-(define q-version "0.39.5")
+(define q-version "0.39.6")


### PR DESCRIPTION
Closes #4167

**Milestone**: v0.39.6 (#334)
**Findings**: R-18, R-19, R-20, R-21

## Changes
- `tests/test-arch-fitness.rkt`: 8 new hard gate tests
- `docs/architecture/dependency-policy.rktd`: New sections for pure-modules, parser-modules, provide-surface-budget
- R-18: Effect-leakage checks for designated pure modules
- R-19: Parser/evaluator separation checks
- R-20: Provide surface budget (informational)
- R-21: Fan-in graduated to hard gate (<=3 exceptions allowed)