### PR TITLE
v0.39.8: Critical Bug Fix + Cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.39.8 -- 2026-05-12
+
+### Fixed
+- BUG-01: Fix sink-append-entries! infinite recursion in step-interpreter.rkt
+- R-01c: jsonl-read-all-valid-with-count delegates to jsonl-read-from-port
+
 ## v0.39.7 -- 2026-05-12
 
 ### Fixed

--- a/runtime/iteration/step-interpreter.rkt
+++ b/runtime/iteration/step-interpreter.rkt
@@ -97,7 +97,7 @@
 (define (sink-append-entries! infra new-msgs [sink #f])
   (if sink
       (send sink sink-append-entries! new-msgs)
-      (sink-append-entries! infra new-msgs)))
+      (append-entries! (loop-infra-log-path infra) new-msgs)))
 
 ;; ============================================================
 ;; execute-pending-tool-calls

--- a/util/jsonl.rkt
+++ b/util/jsonl.rkt
@@ -118,24 +118,10 @@
 (define (jsonl-read-all-valid-with-count path)
   ;; Read all valid JSONL lines, skipping partial/corrupted/empty lines.
   ;; Returns (values valid-list corrupted-count).
-  ;; corrupted-count is the number of non-empty lines that failed to parse.
+  ;; R-01c: Delegates to jsonl-read-from-port for single-source read logic.
   (if (not (file-exists? path))
       (values '() 0)
-      (call-with-input-file
-       path
-       (lambda (in)
-         (define-values (valid corrupted)
-           (for/fold ([acc '()]
-                      [bad 0])
-                     ([line (in-lines in)])
-             (define trimmed (string-trim line))
-             (cond
-               [(<= (string-length trimmed) 0) (values acc bad)]
-               ;; W10.3 (Q-07): cons + reverse instead of append (O(n²) → O(n))
-               [(jsonl-line-valid? line) (values (cons (read-json (open-input-string line)) acc) bad)]
-               [else (values acc (add1 bad))])))
-         (values (reverse valid) corrupted))
-       #:mode 'text)))
+      (call-with-input-file path jsonl-read-from-port #:mode 'text)))
 
 (define (jsonl-read-last path [max-lines 1000])
   ;; Read the last `max-lines` valid JSONL lines from file.

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -10,4 +10,4 @@
 (provide q-version)
 
 (: q-version String)
-(define q-version "0.39.7")
+(define q-version "0.39.8")


### PR DESCRIPTION
Closes #4173

**Milestone**: v0.39.8 (#336)

## Changes
- **BUG-01 (CRITICAL)**: Fix `sink-append-entries!` infinite recursion in step-interpreter.rkt — else branch now calls `append-entries!` instead of itself
- **R-01c**: `jsonl-read-all-valid-with-count` now delegates to `jsonl-read-from-port` (1 line instead of 20)
- Version bump to 0.39.8, CHANGELOG + README sync

## Verification
- `test-iteration-integration.rkt`: 16 tests passed (no hang)
- `test-jsonl.rkt`: 20 tests passed