### PR TITLE
v0.39.9 W2: Large monolith decomposition

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ q/
 |--------|-------|
 | Test files | 565 |
 | Source modules | 422 |
-| Source lines | 64748 |
+| Source lines | 64755 |
 | Test lines | 99373 |
 | Test assertions | 15642 |
 | Tests passing | 5835+ | `racket scripts/run-tests.rkt` results |

--- a/extensions/loader.rkt
+++ b/extensions/loader.rkt
@@ -92,61 +92,74 @@
 ;; registers it. Returns structured error info if loading fails.
 ;; When event-bus is provided, publishes extension.load.failed on error.
 ;; Returns #t if extension was loaded and registered, #f otherwise.
-(define (load-extension! registry path #:event-bus [event-bus #f])
+;; Phase 1: Validate extension state (disabled/quarantined/ok)
+(define (load-extension-validate path)
   (define ext-name (get-extension-name-from-path path))
   (define state (extension-state ext-name))
   (cond
-    [(or (eq? state 'disabled) (eq? state 'quarantined)) (void)]
-    [else
-     (define timeout-secs (current-extension-startup-timeout))
-     (define result
-       (if timeout-secs
-           ;; Run with timeout to prevent hanging on slow extensions
-           (let ([chan (make-channel)])
-             (define thd (thread (lambda () (channel-put chan (try-load-extension path)))))
-             (define maybe-result (sync/timeout timeout-secs chan))
-             (unless maybe-result
-               (kill-thread thd)) ; #447: prevent thread leak
-             (if maybe-result
-                 maybe-result
-                 (extension-load-error (if (path? path)
-                                           (path->string path)
-                                           path)
-                                       (format "extension startup timed out after ~as" timeout-secs)
-                                       'timeout)))
-           ;; No timeout — direct call
-           (try-load-extension path)))
-     (cond
-       [(extension-load-error? result)
-        (log-warning "extension load failed [~a]: ~a \u2014 ~a"
-                     (extension-load-error-category result)
-                     path
-                     (extension-load-error-message result))
-        (when event-bus
-          (publish! event-bus
-                    (make-event "extension.load.failed"
-                                (current-seconds)
-                                ""
-                                #f
-                                (hasheq 'path
-                                        (if (path? path)
-                                            (path->string path)
-                                            path)
-                                        'error
-                                        (extension-load-error-message result)
-                                        'category
-                                        (extension-load-error-category result)))))
-        (void)]
-       [(and result (extension? result))
-        ;; Tier validation: default to 'hooks (lowest) if no manifest tier declared
-        (define declared-tier 'hooks)
-        (define tier-result (extension-tier-valid? result declared-tier))
-        (when (list? tier-result)
-          (for ([msg (in-list tier-result)])
-            (log-warning "extension tier violation [~a]: ~a" (extension-name result) msg)))
-        (register-extension! registry result)
-        (void)]
-       [else (void)])]))
+    [(or (eq? state 'disabled) (eq? state 'quarantined)) state]
+    [else 'ok]))
+
+;; Phase 2: Attempt to load extension with optional timeout
+(define (load-extension-attempt path)
+  (define timeout-secs (current-extension-startup-timeout))
+  (if timeout-secs
+      ;; Run with timeout to prevent hanging on slow extensions
+      (let ([chan (make-channel)])
+        (define thd (thread (lambda () (channel-put chan (try-load-extension path)))))
+        (define maybe-result (sync/timeout timeout-secs chan))
+        (unless maybe-result
+          (kill-thread thd)) ; #447: prevent thread leak
+        (if maybe-result
+            maybe-result
+            (extension-load-error (if (path? path)
+                                      (path->string path)
+                                      path)
+                                  (format "extension startup timed out after ~as" timeout-secs)
+                                  'timeout)))
+      ;; No timeout — direct call
+      (try-load-extension path)))
+
+;; Phase 3: Register loaded extension or report error
+(define (load-extension-register! registry result path event-bus)
+  (cond
+    [(extension-load-error? result)
+     (log-warning "extension load failed [~a]: ~a — ~a"
+                  (extension-load-error-category result)
+                  path
+                  (extension-load-error-message result))
+     (when event-bus
+       (publish! event-bus
+                 (make-event "extension.load.failed"
+                             (current-seconds)
+                             ""
+                             #f
+                             (hasheq 'path
+                                     (if (path? path)
+                                         (path->string path)
+                                         path)
+                                     'error
+                                     (extension-load-error-message result)
+                                     'category
+                                     (extension-load-error-category result)))))
+     (void)]
+    [(and result (extension? result))
+     ;; Tier validation: default to 'hooks (lowest) if no manifest tier declared
+     (define declared-tier 'hooks)
+     (define tier-result (extension-tier-valid? result declared-tier))
+     (when (list? tier-result)
+       (for ([msg (in-list tier-result)])
+         (log-warning "extension tier violation [~a]: ~a" (extension-name result) msg)))
+     (register-extension! registry result)
+     (void)]
+    [else (void)]))
+
+;; Orchestrator: validate → attempt → register
+(define (load-extension! registry path #:event-bus [event-bus #f])
+  (define validation (load-extension-validate path))
+  (when (eq? validation 'ok)
+    (define result (load-extension-attempt path))
+    (load-extension-register! registry result path event-bus)))
 
 ;; Cache infrastructure removed (#448): was never called in production
 ;; code paths (discover-extensions calls try-load-extension directly).

--- a/tui/tui-render-loop.rkt
+++ b/tui/tui-render-loop.rkt
@@ -54,7 +54,8 @@
                        [draw-frame (-> any/c void?)]
                        [next-message (->* (any/c) (#:timeout any/c) (or/c any/c #f))]
                        [tui-main-loop (-> any/c void?)]
-                       [drain-events! (-> any/c void?)]))
+                       [drain-events! (-> any/c void?)]
+                       [handle-user-submit! (-> any/c string? void?)]))
 
 ;; ============================================================
 ;; Ubuf FFI/stubs
@@ -259,6 +260,78 @@
 ;; Main TUI loop
 ;; ============================================================
 
+;; Handle a user submit: enqueue if busy, debounce duplicates, or run via runner
+(define (handle-user-submit! ctx text)
+  ;; G3.1: If agent is busy, enqueue as followup instead of calling runner
+  (define cur-state (unbox (tui-ctx-ui-state-box ctx)))
+  (define busy? (ui-state-busy? cur-state))
+  (define q (unbox (tui-ctx-session-queue-box ctx)))
+  (cond
+    [(and busy? q (queue? q))
+     ;; Agent is streaming — enqueue as followup
+     (enqueue-followup! q text)
+     ;; Show system notification in transcript
+     (define queued-entry
+       (make-entry 'system
+                   "[Queued — will run after current task]"
+                   (current-inexact-milliseconds)
+                   (hasheq 'queued #t)))
+     (set-box! (tui-ctx-ui-state-box ctx) (add-transcript-entry cur-state queued-entry))
+     (mark-dirty! ctx)]
+    [else
+     ;; Not busy (or no queue) — submit to runtime (non-blocking)
+     ;; B2-D: Double-submit debounce — ignore rapid identical submits
+     (define entries (ui-state-transcript cur-state))
+     (define last-entry (and (pair? entries) (car entries)))
+     (define is-duplicate
+       (and last-entry
+            (eq? (transcript-entry-kind last-entry) 'user)
+            (string=? (transcript-entry-text last-entry) text)
+            (< (- (current-inexact-milliseconds) (transcript-entry-timestamp last-entry)) 500)))
+     (cond
+       [is-duplicate
+        (define dup-entry
+          (make-entry 'system "[Duplicate input ignored]" (current-inexact-milliseconds) (hash)))
+        (set-box! (tui-ctx-ui-state-box ctx) (add-transcript-entry cur-state dup-entry))
+        (mark-dirty! ctx)]
+       [else
+        ;; F1: Immediately set busy? so status bar shows [thinking...]
+        ;; before the LLM responds (was waiting for turn.started event)
+        (set-box! (tui-ctx-ui-state-box ctx)
+                  (clear-streaming (set-pending-tool-name (set-busy cur-state #t) #f)))
+        (mark-dirty! ctx)
+        ;; F1: Show user message in transcript immediately
+        ;; (don't wait for JSONL events — the TUI transcript is display-only)
+        (define user-entry (make-entry 'user text (current-inexact-milliseconds) (hash)))
+        (set-box! (tui-ctx-ui-state-box ctx)
+                  (add-transcript-entry (unbox (tui-ctx-ui-state-box ctx)) user-entry))
+        (mark-dirty! ctx)
+        (define runner (tui-ctx-session-runner ctx))
+        ;; Wrap runner thread with exception handler to prevent TUI hang
+        (thread
+         (lambda ()
+           (with-handlers
+               ([exn:fail? (lambda (e)
+                             (define bus (tui-ctx-event-bus ctx))
+                             (define sid (ui-state-session-id (unbox (tui-ctx-ui-state-box ctx))))
+                             ;; B3-A: Write crash log for unhandled exceptions
+                             (write-crash-log! sid (exn-message e) "run-prompt")
+                             (when (and bus sid)
+                               (publish! bus
+                                         (make-event
+                                          "runtime.error"
+                                          (current-inexact-milliseconds)
+                                          sid
+                                          #f
+                                          (hasheq 'error (exn-message e) 'errorType 'internal-error)))
+                               (publish! bus
+                                         (make-event "turn.completed"
+                                                     (current-inexact-milliseconds)
+                                                     sid
+                                                     #f
+                                                     (hasheq 'reason "error")))))])
+             (runner text))))])]))
+
 (define (tui-main-loop ctx)
   (let loop ()
     ;; Drain all pending events from the channel (non-blocking)
@@ -307,86 +380,7 @@
                  (define text (expand-inline-bash raw-text (unbox (tui-ctx-last-prompt-box ctx))))
                  ;; Store prompt for /retry (#1378)
                  (set-box! (tui-ctx-last-prompt-box ctx) text)
-                 ;; G3.1: If agent is busy, enqueue as followup instead of calling runner
-                 (define cur-state (unbox (tui-ctx-ui-state-box ctx)))
-                 (define busy? (ui-state-busy? cur-state))
-                 (define q (unbox (tui-ctx-session-queue-box ctx)))
-                 (cond
-                   [(and busy? q (queue? q))
-                    ;; Agent is streaming — enqueue as followup
-                    (enqueue-followup! q text)
-                    ;; Show system notification in transcript
-                    (define queued-entry
-                      (make-entry 'system
-                                  "[Queued \u2014 will run after current task]"
-                                  (current-inexact-milliseconds)
-                                  (hasheq 'queued #t)))
-                    (set-box! (tui-ctx-ui-state-box ctx)
-                              (add-transcript-entry cur-state queued-entry))
-                    (mark-dirty! ctx)]
-                   [else
-                    ;; Not busy (or no queue) — submit to runtime (non-blocking)
-                    ;; B2-D: Double-submit debounce — ignore rapid identical submits
-                    (define entries (ui-state-transcript cur-state))
-                    (define last-entry (and (pair? entries) (car entries)))
-                    (define is-duplicate
-                      (and last-entry
-                           (eq? (transcript-entry-kind last-entry) 'user)
-                           (string=? (transcript-entry-text last-entry) text)
-                           (< (- (current-inexact-milliseconds)
-                                 (transcript-entry-timestamp last-entry))
-                              500)))
-                    (cond
-                      [is-duplicate
-                       (define dup-entry
-                         (make-entry 'system
-                                     "[Duplicate input ignored]"
-                                     (current-inexact-milliseconds)
-                                     (hash)))
-                       (set-box! (tui-ctx-ui-state-box ctx)
-                                 (add-transcript-entry cur-state dup-entry))
-                       (mark-dirty! ctx)]
-                      [else
-                       ;; F1: Immediately set busy? so status bar shows [thinking...]
-                       ;; before the LLM responds (was waiting for turn.started event)
-                       (set-box! (tui-ctx-ui-state-box ctx)
-                                 (clear-streaming (set-pending-tool-name (set-busy cur-state #t) #f)))
-                       (mark-dirty! ctx)
-                       ;; F1: Show user message in transcript immediately
-                       ;; (don't wait for JSONL events — the TUI transcript is display-only)
-                       (define user-entry
-                         (make-entry 'user text (current-inexact-milliseconds) (hash)))
-                       (set-box! (tui-ctx-ui-state-box ctx)
-                                 (add-transcript-entry (unbox (tui-ctx-ui-state-box ctx)) user-entry))
-                       (mark-dirty! ctx)
-                       (define runner (tui-ctx-session-runner ctx))
-                       ;; Wrap runner thread with exception handler to prevent TUI hang
-                       (thread (lambda ()
-                                 (with-handlers
-                                     ([exn:fail?
-                                       (lambda (e)
-                                         (define bus (tui-ctx-event-bus ctx))
-                                         (define sid
-                                           (ui-state-session-id (unbox (tui-ctx-ui-state-box ctx))))
-                                         ;; B3-A: Write crash log for unhandled exceptions
-                                         (write-crash-log! sid (exn-message e) "run-prompt")
-                                         (when (and bus sid)
-                                           (publish! bus
-                                                     (make-event "runtime.error"
-                                                                 (current-inexact-milliseconds)
-                                                                 sid
-                                                                 #f
-                                                                 (hasheq 'error
-                                                                         (exn-message e)
-                                                                         'errorType
-                                                                         'internal-error)))
-                                           (publish! bus
-                                                     (make-event "turn.completed"
-                                                                 (current-inexact-milliseconds)
-                                                                 sid
-                                                                 #f
-                                                                 (hasheq 'reason "error")))))])
-                                   (runner text))))])])]
+                 (handle-user-submit! ctx text)]
                 [(and (list? result) (eq? (car result) 'command))
                  (define cmd (cadr result))
                  (define raw-text


### PR DESCRIPTION
Closes #4179 (sub-issue of #4176 / milestone #337)

## Changes
- **R-23**: Decompose `load-extension!` into validate→attempt→register phase helpers
  - `load-extension-validate`: check disabled/quarantined/ok state
  - `load-extension-attempt`: `try-load-extension` with optional timeout
  - `load-extension-register!`: tier validation + registry registration + error reporting
- **R-26**: Extract submit handler from `tui-render-loop`
  - `handle-user-submit!`: ~80 lines extracted into dedicated function
  - Handles busy enqueue, duplicate debounce, busy state setting, runner thread with exception handler

## Verification
- `extensions/loader.rkt` compiles cleanly
- `tui/tui-render-loop.rkt` compiles cleanly
- `test-resource-loader.rkt`: 34 tests passed
- TUI tests pass (queue-wiring, render-edge-cases, dedup)
- **18/18 lint pass**