### PR TITLE
v0.40.3 W1: merge stream-chunk construction paths + version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v0.40.3 — 2026-05-12
+
+### Changed
+- **S11-F1**: Extract shared `accumulate-stream-chunks` pure helper in loop-stream.rkt
+- **S11-F2**: Merge duplicate `normalize-openai-chunks` / `normalize-openai-chunk` paths
+  in llm/stream.rkt; chunks now delegates to singular normalize-openai-chunk
+
 ## v0.40.2 — 2026-05-12
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.40.2-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.40.3-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 
@@ -199,7 +199,7 @@ racket main.rkt --model gpt-5.4 "write a test"
 ### Verify
 
 ```bash
-racket main.rkt --version  # q version 0.40.2
+racket main.rkt --version  # q version 0.40.3
 raco test tests/           # run the full test suite
 ```
 
@@ -272,7 +272,7 @@ q/
 |--------|-------|
 | Test files | 572 |
 | Source modules | 422 |
-| Source lines | 64858 |
+| Source lines | 64816 |
 | Test lines | 99845 |
 | Test assertions | 15722 |
 | Tests passing | 5835+ | `racket scripts/run-tests.rkt` results |
@@ -383,7 +383,7 @@ When q executes shell commands on behalf of an LLM, arguments are quoted via `sh
 
 
 
-**v0.40.2** — Changed
+**v0.40.3** — Changed
 
 **v0.39.10** — Added
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -2,7 +2,7 @@
 
 ## Version
 
-v0.40.2
+v0.40.3
 
 ## Layer Diagram
 

--- a/docs/event-taxonomy.md
+++ b/docs/event-taxonomy.md
@@ -1,6 +1,6 @@
 # Q Event Taxonomy Reference
 
-Complete reference for all event types in Q 0.40.2.
+Complete reference for all event types in Q 0.40.3.
 ## Base Types
 
 ### `event` (protocol-level)

--- a/docs/extension-guide.md
+++ b/docs/extension-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.40.2 --># Extension Development Guide
+<!-- verified-against: 0.40.3 --># Extension Development Guide
 
 This guide walks you through creating, testing, and activating a custom
 extension for q.

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.40.2 --># Getting Started
+<!-- verified-against: 0.40.3 --># Getting Started
 
 Welcome to q, a Racket-based coding agent.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.40.2 --># Installation Guide
+<!-- verified-against: 0.40.3 --># Installation Guide
 
 <!-- This file is the canonical source. The docs/getting-started/installation.md copy is maintained for the doc site build. -->
 

--- a/docs/security-trust-model.md
+++ b/docs/security-trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.40.2 --># Security & Trust Model
+<!-- verified-against: 0.40.3 --># Security & Trust Model
 
 This document provides an honest, per-area assessment of what q enforces
 today and what is planned. It is the authoritative reference for security

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -130,6 +130,6 @@ is the primary self-hosting extension:
 (load-extension! ext-reg "path/to/extension.rkt" #:event-bus bus)
 ```
 
-## Version 0.40.2
+## Version 0.40.3
 
-This documentation reflects q 0.40.2.
+This documentation reflects q 0.40.3.

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.40.2 --># q Source Style Guide
+<!-- verified-against: 0.40.3 --># q Source Style Guide
 
 This document defines formatting and naming conventions for the q Racket codebase.
 All changes to `q/` source files (excluding `tests/`) should follow these rules.

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.40.2 --># Trust Model
+<!-- verified-against: 0.40.3 --># Trust Model
 
 ## Trust Levels
 

--- a/docs/workflow-testing.md
+++ b/docs/workflow-testing.md
@@ -121,6 +121,6 @@ Use relative paths from the test file:
 4. Use `(check-true ...)` for boolean assertions
 5. Keep tests independent — no shared mutable state between test-cases
 
-## Version 0.40.2
+## Version 0.40.3
 
-This documentation reflects q 0.40.2.
+This documentation reflects q 0.40.3.

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.40.2")
+(define version "0.40.3")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base"))

--- a/llm/stream.rkt
+++ b/llm/stream.rkt
@@ -203,52 +203,10 @@
 
 ;; Convert a list of OpenAI-format streaming response objects
 ;; into canonical stream-chunk structs.
+;; Thin wrapper: delegates to normalize-openai-chunk per element.
 (define (normalize-openai-chunks raw-chunks)
   (for/list ([chunk (in-list raw-chunks)])
-    (define choices (hash-ref chunk 'choices '()))
-    (define usage (hash-ref chunk 'usage #f))
-    (define choice
-      (if (null? choices)
-          #f
-          (car choices)))
-    (define delta
-      (if choice
-          (hash-ref choice 'delta #f)
-          #f))
-    (define finish-reason
-      (if choice
-          (hash-ref choice 'finish_reason #f)
-          #f))
-
-    ;; Extract text delta
-    (define delta-content
-      (if delta
-          (hash-ref delta 'content #f)
-          #f))
-    ;; JSON null is represented as 'null symbol in Racket - filter it out
-    (define delta-text (if (string? delta-content) delta-content #f))
-
-    ;; v0.28.19: Extract reasoning_content for thinking models (glm-5.1, DeepSeek-R1)
-    (define delta-thinking
-      (if delta
-          (hash-ref delta 'reasoning_content #f)
-          #f))
-
-    ;; Extract tool-call delta
-    (define delta-tool-call
-      (if delta
-          (let ([tcs (hash-ref delta 'tool_calls #f)])
-            (if (and tcs (pair? tcs))
-                (car tcs) ; first tool call delta
-                #f))
-          #f))
-
-    (make-stream-chunk delta-text
-                       delta-tool-call
-                       usage
-                       (and (string? finish-reason) #t)
-                       #:delta-thinking delta-thinking
-                       #:finish-reason finish-reason)))
+    (normalize-openai-chunk chunk)))
 
 ;; ============================================================
 ;; accumulate-tool-call-deltas

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -10,4 +10,4 @@
 (provide q-version)
 
 (: q-version String)
-(define q-version "0.40.2")
+(define q-version "0.40.3")

--- a/wiki-src/Architecture-Overview.md
+++ b/wiki-src/Architecture-Overview.md
@@ -35,7 +35,7 @@ User input → Interface (CLI/TUI/RPC)
     → Events emitted to bus
 ```
 
-## Metrics (0.40.2)
+## Metrics (0.40.3)
 > _See `racket scripts/metrics.rkt` for current numbers._
 
 - 414 source modules, 534 test files


### PR DESCRIPTION
Closes #4208 (sub-issue of #4206 / milestone #343)

## Changes
- `llm/stream.rkt`: `normalize-openai-chunks` now delegates to `normalize-openai-chunk` per element
- Version bump to **0.40.3**, CHANGELOG + README + docs synced

## Verification
- **18/18 lint pass**