### PR TITLE
v0.40.4 W0: remove raw tool constructor + fix boundary comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ q/
 |--------|-------|
 | Test files | 572 |
 | Source modules | 422 |
-| Source lines | 64816 |
+| Source lines | 64813 |
 | Test lines | 99845 |
 | Test assertions | 15722 |
 | Tests passing | 5835+ | `racket scripts/run-tests.rkt` results |

--- a/runtime/turn-orchestrator.rkt
+++ b/runtime/turn-orchestrator.rkt
@@ -6,10 +6,10 @@
 ;; Extracted from iteration.rkt for single-responsibility separation.
 ;; Handles: context assembly → provider turn → tool execution.
 ;;
-;; This module is the ONLY runtime module that imports upward into
-;; the tools/ and extensions/ layers. Other runtime modules must
-;; not import tools/tool.rkt, tools/scheduler.rkt, extensions/hooks.rkt,
-;; or extensions/context.rkt directly.
+;; This module is one of the boundary modules that imports upward into
+;; the tools/ and extensions/ layers (agent-session.rkt is another).
+;; Other runtime modules should not import tools/tool.rkt, tools/scheduler.rkt,
+;; extensions/hooks.rkt, or extensions/context.rkt directly.
 ;;
 ;; ── LAYER EXCEPTION (ARCH-01 / #341) ──────────────────────────
 ;;   tools/tool.rkt       → list-tools-jsexpr, merge-tool-lists

--- a/tests/test-tool-registry-api.rkt
+++ b/tests/test-tool-registry-api.rkt
@@ -8,7 +8,7 @@
          "../tools/tool-struct.rkt")
 
 (define (make-test-tool name desc)
-  (tool name desc (hasheq 'type "object" 'properties (hasheq)) void #f #f #f #f #f))
+  (make-tool name desc (hasheq 'type "object" 'properties (hasheq)) void))
 
 (define api-suite
   (test-suite "Tool registry API tests (R-12, R-24, R-25)"

--- a/tools/tool-struct.rkt
+++ b/tools/tool-struct.rkt
@@ -1,10 +1,9 @@
 #lang racket/base
-;; tools/tool-struct.rkt — Tool struct definition
+;; tools/tool-struct.rkt -- Tool struct definition
 ;; Extracted from tools/tool.rkt (v0.30.8 W0)
 ;; STABILITY: stable
 
 (provide tool?
-         tool
          tool-name
          tool-description
          tool-schema
@@ -16,7 +15,9 @@
          tool-prompt-guidelines
          tool-dangerous?
          tool-render-call
-         tool-render-result)
+         tool-render-result
+         ;; Keyword constructor with validation (S3-F2c)
+         make-tool)
 
 (struct tool
         (name description
@@ -28,3 +29,36 @@
               render-result
               dangerous?)
   #:transparent)
+
+;; make-tool : keyword constructor with validation
+(define (make-tool name
+                   description
+                   schema
+                   execute
+                   #:prompt-snippet [prompt-snippet #f]
+                   #:render-call [render-call #f]
+                   #:render-result [render-result #f]
+                   #:prompt-guidelines [prompt-guidelines #f]
+                   #:dangerous? [dangerous? #f])
+  (unless (string? name)
+    (raise-argument-error 'make-tool "string?" name))
+  (unless (string? description)
+    (raise-argument-error 'make-tool "string?" description))
+  (unless (hash? schema)
+    (raise-argument-error 'make-tool "hash?" schema))
+  (unless (procedure? execute)
+    (raise-argument-error 'make-tool "procedure?" execute))
+  ;; W-16: Arity check -- validate handler accepts 1 or 2 args (args [exec-ctx])
+  (unless (or (procedure-arity-includes? execute 1) (procedure-arity-includes? execute 2))
+    (raise-arguments-error 'make-tool
+                           (format "tool '~a' handler does not accept 1 or 2 args (args [exec-ctx])"
+                                   name)))
+  (tool name
+        description
+        schema
+        execute
+        prompt-snippet
+        prompt-guidelines
+        render-call
+        render-result
+        dangerous?))

--- a/tools/tool.rkt
+++ b/tools/tool.rkt
@@ -35,7 +35,6 @@
          "schema-helpers.rkt")
 
 (provide tool?
-         tool
          tool-name
          tool-description
          tool-schema
@@ -133,42 +132,6 @@
   (define cb (exec-context-progress-callback ctx))
   (when cb
     (cb percentage message)))
-
-;; ============================================================
-;; Tool constructor
-;; ============================================================
-
-(define (make-tool name
-                   description
-                   schema
-                   execute
-                   #:prompt-snippet [prompt-snippet #f]
-                   #:render-call [render-call #f]
-                   #:render-result [render-result #f]
-                   #:prompt-guidelines [prompt-guidelines #f]
-                   #:dangerous? [dangerous? #f])
-  (unless (string? name)
-    (raise-argument-error 'make-tool "string?" name))
-  (unless (string? description)
-    (raise-argument-error 'make-tool "string?" description))
-  (unless (hash? schema)
-    (raise-argument-error 'make-tool "hash?" schema))
-  (unless (procedure? execute)
-    (raise-argument-error 'make-tool "procedure?" execute))
-  ;; W-16: Arity check — validate handler accepts 1 or 2 args (args [exec-ctx])
-  (unless (or (procedure-arity-includes? execute 1) (procedure-arity-includes? execute 2))
-    (raise-arguments-error 'make-tool
-                           (format "tool '~a' handler does not accept 1 or 2 args (args [exec-ctx])"
-                                   name)))
-  (tool name
-        description
-        schema
-        execute
-        prompt-snippet
-        prompt-guidelines
-        render-call
-        render-result
-        dangerous?))
 
 ;; ============================================================
 ;; JSON-serializability validation


### PR DESCRIPTION
Closes #4212 (sub-issue of #4211 / milestone #344)

## Changes
- `tools/tool-struct.rkt`: Moved `make-tool` here, removed raw `tool` constructor from provide
- `tools/tool.rkt`: Removed local `make-tool` definition and raw `tool` re-export
- `runtime/turn-orchestrator.rkt`: Fixed misleading "sole boundary module" comment
- `tests/test-tool-registry-api.rkt`: Updated to use `make-tool`

## Verification
- `test-tool-registry-api.rkt`: 3/3 tests passed
- **18/18 lint pass**