### PR TITLE
v0.42.1 W1: turn reducer shadow mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.42.0-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.42.1-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 
@@ -199,7 +199,7 @@ racket main.rkt --model gpt-5.4 "write a test"
 ### Verify
 
 ```bash
-racket main.rkt --version  # q version 0.42.0
+racket main.rkt --version  # q version 0.42.1
 raco test tests/           # run the full test suite
 ```
 
@@ -272,7 +272,7 @@ q/
 |--------|-------|
 | Test files | 579 |
 | Source modules | 424 |
-| Source lines | 65210 |
+| Source lines | 65242 |
 | Test lines | 101742 |
 | Test assertions | 15894 |
 | Tests passing | 5835+ | `racket scripts/run-tests.rkt` results |
@@ -385,7 +385,7 @@ When q executes shell commands on behalf of an LLM, arguments are quoted via `sh
 
 
 
-**v0.42.0** — Added
+**v0.42.1** — Added
 
 **v0.41.4** — Fixed
 

--- a/agent/event-emitter.rkt
+++ b/agent/event-emitter.rkt
@@ -45,46 +45,56 @@
 ;; Subclass app fields start at vector index 5 (= 1 struct-type + 4 base fields).
 (define typed-event-base-field-count 4)
 
+;; Reflection fallback for serializing typed events without a matching serializer.
+(define (event-struct->hasheq-reflection evt)
+  (define vec (struct->vector evt))
+  (define app-start (+ 1 typed-event-base-field-count))
+  (define base
+    (hasheq 'type
+            (typed-event-type evt)
+            'timestamp
+            (typed-event-timestamp evt)
+            'session-id
+            (typed-event-session-id evt)
+            'turn-id
+            (typed-event-turn-id evt)))
+  (define name (struct-name evt))
+  (define fields (get-struct-field-names name))
+  (unless fields
+    (log-warning
+     (format "event-struct->hasheq: no field registry for ~a, dropping subclass fields" name)))
+  (for/fold ([h base])
+            ([i (in-naturals)]
+             [fname (in-list (or fields '()))])
+    (hash-set h fname (vector-ref vec (+ app-start i)))))
+
 (define (event-struct->hasheq evt)
   ;; R-13: Try auto-generated serializer first (fast path, no struct->vector)
   (define type-str (typed-event-type evt))
   (define serializer (lookup-event-serializer type-str))
   (if serializer
       ;; Fast path: merge base fields + serializer output
-      (let ([subclass-data (serializer evt)])
-        (hash-set* subclass-data
-                   'type
-                   (typed-event-type evt)
-                   'timestamp
-                   (typed-event-timestamp evt)
-                   'session-id
-                   (typed-event-session-id evt)
-                   'turn-id
-                   (typed-event-turn-id evt)))
+      (with-handlers ([exn:fail?
+                       (lambda (e)
+                         (log-warning
+                          "event-struct->hasheq: serializer for '~a' failed (~a), using reflection fallback"
+                          type-str (exn-message e))
+                         (event-struct->hasheq-reflection evt))])
+        (let ([subclass-data (serializer evt)])
+          (hash-set* subclass-data
+                     'type
+                     (typed-event-type evt)
+                     'timestamp
+                     (typed-event-timestamp evt)
+                     'session-id
+                     (typed-event-session-id evt)
+                     'turn-id
+                     (typed-event-turn-id evt))))
       ;; Legacy fallback: struct->vector reflection (R-13: prefer serializer registry)
-      (let ()
+      (begin
         (log-warning "event-struct->hasheq: no serializer for '~a', using reflection fallback"
                      (typed-event-type evt))
-        (define vec (struct->vector evt))
-        (define app-start (+ 1 typed-event-base-field-count))
-        (define base
-          (hasheq 'type
-                  (typed-event-type evt)
-                  'timestamp
-                  (typed-event-timestamp evt)
-                  'session-id
-                  (typed-event-session-id evt)
-                  'turn-id
-                  (typed-event-turn-id evt)))
-        (define name (struct-name evt))
-        (define fields (get-struct-field-names name))
-        (unless fields
-          (log-warning
-           (format "event-struct->hasheq: no field registry for ~a, dropping subclass fields" name)))
-        (for/fold ([h base])
-                  ([i (in-naturals)]
-                   [fname (in-list (or fields '()))])
-          (hash-set h fname (vector-ref vec (+ app-start i)))))))
+        (event-struct->hasheq-reflection evt))))
 
 ;; Emit a typed event on the bus.
 ;; Optional #:state for state accumulation (mirrors emit! from loop-messages).

--- a/agent/loop.rkt
+++ b/agent/loop.rkt
@@ -49,6 +49,8 @@
          "loop-messages.rkt"
          "loop-stream.rkt"
          (only-in "event-emitter.rkt" emit-typed-event!)
+         (only-in "turn-reducer.rkt" decide-after-pre-hook decide-after-msg-hook decide-after-stream)
+         (only-in "turn-model.rkt" make-stream-completion turn-decision turn-decision-tag)
          (only-in "event-structs.rkt"
                   make-turn-start-event
                   make-turn-end-event
@@ -99,6 +101,13 @@
 ;; ============================================================
 ;; Extracted helpers (I-01)
 ;; ============================================================
+
+;; Shadow-mode reducer logging -- compares reducer decision with actual behavior
+(define (shadow-log! point reducer-decision actual-action)
+  (define rtag (turn-decision-tag reducer-decision))
+  (unless (eq? rtag actual-action)
+    (log-warning "turn-reducer shadow divergence at ~a: reducer=~a actual=~a"
+                 point rtag actual-action)))
 
 ;; Phase 1: Emit turn-started event and dispatch agent-start hook
 (define (emit-turn-start! bus session-id turn-id st hook-dispatcher context)
@@ -184,6 +193,7 @@
   ;; v0.32.4: Flat match instead of nested CPS callbacks
   (match (classify-hook-result pre-hook-result)
     [(list 'block _)
+     (shadow-log! 'pre-hook (decide-after-pre-hook pre-hook-result) 'blocked)
      ;; R-06/R-07: FSM: pre-hook -> blocked
      (current-turn-fsm-state (next-turn-state turn-state-pre-hook turn-event-hook-block))
      (emit-typed-event! bus
@@ -199,6 +209,7 @@
                                              #:duration-ms 0))
      (loop-result raw-messages 'hook-blocked (hasheq 'hook 'model-request-pre))]
     [_
+     (shadow-log! 'pre-hook (decide-after-pre-hook pre-hook-result) 'check-msg-hook)
      ;; R-06/R-07: FSM: pre-hook -> stream
      (current-turn-fsm-state (next-turn-state turn-state-pre-hook turn-event-hook-pass))
      ;; DEBUG: validate raw-messages before sending
@@ -249,6 +260,7 @@
                                                 #:duration-ms 0))
         (loop-result raw-messages 'hook-blocked (hasheq 'hook 'message-start))]
        [_
+        (shadow-log! 'msg-hook (decide-after-msg-hook msg-start-result) 'begin-stream)
         ;; 5-7. Stream from provider
         (define stream-data
           (stream-from-provider provider
@@ -260,6 +272,16 @@
                                 hook-dispatcher
                                 cancellation-token))
 
+        ;; Shadow: build stream-completion struct for reducer
+        (define shadow-sc
+          (make-stream-completion
+           #:cancelled? (hash-ref stream-data 'cancelled? #f)
+           #:cancel-reason (hash-ref stream-data 'cancel-reason #f)
+           #:text (hash-ref stream-data 'text "")
+           #:tool-calls (hash-ref stream-data 'tool-calls '())))
+        (shadow-log! 'stream-complete
+                     (decide-after-stream shadow-sc)
+                     (if (hash-ref stream-data 'cancelled? #f) 'cancelled 'complete))
         (cond
           [(hash-ref stream-data 'cancelled?)
            (handle-cancellation bus session-id turn-id st #:hook-dispatcher hook-dispatcher)]

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -2,7 +2,7 @@
 
 ## Version
 
-v0.42.0
+v0.42.1
 
 ## Layer Diagram
 

--- a/docs/event-taxonomy.md
+++ b/docs/event-taxonomy.md
@@ -1,6 +1,6 @@
 # Q Event Taxonomy Reference
 
-Complete reference for all event types in Q 0.42.0.
+Complete reference for all event types in Q 0.42.1.
 ## Base Types
 
 ### `event` (protocol-level)

--- a/docs/extension-guide.md
+++ b/docs/extension-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.42.0 --># Extension Development Guide
+<!-- verified-against: 0.42.1 --># Extension Development Guide
 
 This guide walks you through creating, testing, and activating a custom
 extension for q.

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.42.0 --># Getting Started
+<!-- verified-against: 0.42.1 --># Getting Started
 
 Welcome to q, a Racket-based coding agent.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.42.0 --># Installation Guide
+<!-- verified-against: 0.42.1 --># Installation Guide
 
 <!-- This file is the canonical source. The docs/getting-started/installation.md copy is maintained for the doc site build. -->
 

--- a/docs/security-trust-model.md
+++ b/docs/security-trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.42.0 --># Security & Trust Model
+<!-- verified-against: 0.42.1 --># Security & Trust Model
 
 This document provides an honest, per-area assessment of what q enforces
 today and what is planned. It is the authoritative reference for security

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -130,6 +130,6 @@ is the primary self-hosting extension:
 (load-extension! ext-reg "path/to/extension.rkt" #:event-bus bus)
 ```
 
-## Version 0.42.0
+## Version 0.42.1
 
-This documentation reflects q 0.42.0.
+This documentation reflects q 0.42.1.

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.42.0 --># q Source Style Guide
+<!-- verified-against: 0.42.1 --># q Source Style Guide
 
 This document defines formatting and naming conventions for the q Racket codebase.
 All changes to `q/` source files (excluding `tests/`) should follow these rules.

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.42.0 --># Trust Model
+<!-- verified-against: 0.42.1 --># Trust Model
 
 ## Trust Levels
 

--- a/docs/workflow-testing.md
+++ b/docs/workflow-testing.md
@@ -121,6 +121,6 @@ Use relative paths from the test file:
 4. Use `(check-true ...)` for boolean assertions
 5. Keep tests independent — no shared mutable state between test-cases
 
-## Version 0.42.0
+## Version 0.42.1
 
-This documentation reflects q 0.42.0.
+This documentation reflects q 0.42.1.

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.42.0")
+(define version "0.42.1")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base"))

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -10,4 +10,4 @@
 (provide q-version)
 
 (: q-version String)
-(define q-version "0.42.0")
+(define q-version "0.42.1")

--- a/wiki-src/Architecture-Overview.md
+++ b/wiki-src/Architecture-Overview.md
@@ -35,7 +35,7 @@ User input → Interface (CLI/TUI/RPC)
     → Events emitted to bus
 ```
 
-## Metrics (0.42.0)
+## Metrics (0.42.1)
 > _See `racket scripts/metrics.rkt` for current numbers._
 
 - 414 source modules, 534 test files


### PR DESCRIPTION
Closes #4245 (sub-issue of #4242 / milestone #354)

## Changes
- **A2-01**: Turn reducer shadow mode in loop.rkt
  - NEW `shadow-log!` helper compares reducer decisions with actual behavior
  - Shadow calls at 3 decision points: pre-hook, msg-hook, stream-complete
  - Zero functional change -- reducer output logged but not acted upon
- **CRITICAL FIX**: `event-struct->hasheq` serializer mismatch crash
  - `#:no-serialize` stream events shared type strings with regular events
  - Added `with-handlers` fallback: serializer failure → reflection fallback
  - Fixes `test-loop.rkt` and `test-iteration-main-loop.rkt` failures

## Verification
- **497/497 test files compile**, **2170/2170 tests pass**
- **18/18 lint pass**