### PR TITLE
feat: C8-01 unified tool-call-intent struct + provider shadow validation (#4247)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v0.42.3 — 2026-05-13
+
+### Added
+- **C8-01**: Unified tool-call-intent AST for provider tool-call data
+  - NEW `tool-call-intent` struct in `llm/model.rkt` (Typed Racket): `id`, `name`, `arguments`
+  - NEW `make-tool-call-intent` constructor, `tool-call-intent->hash`, `hash->tool-call-intent`
+  - Shadow validation in OpenAI, Anthropic, Gemini providers: round-trip check + log-warning on mismatch
+  - NEW `tests/test-tool-call-intent.rkt`: 8 tests (5 round-trip, 3 provider shadow)
+
 ## v0.42.0 — 2026-05-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.42.2-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.42.3-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 
@@ -199,7 +199,7 @@ racket main.rkt --model gpt-5.4 "write a test"
 ### Verify
 
 ```bash
-racket main.rkt --version  # q version 0.42.2
+racket main.rkt --version  # q version 0.42.3
 raco test tests/           # run the full test suite
 ```
 
@@ -384,6 +384,9 @@ When q executes shell commands on behalf of an LLM, arguments are quoted via `sh
 
 
 
+
+
+**v0.42.3** — Added
 
 **v0.42.2** — Added
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -2,7 +2,7 @@
 
 ## Version
 
-v0.42.2
+v0.42.3
 
 ## Layer Diagram
 

--- a/docs/event-taxonomy.md
+++ b/docs/event-taxonomy.md
@@ -1,6 +1,6 @@
 # Q Event Taxonomy Reference
 
-Complete reference for all event types in Q 0.42.2.
+Complete reference for all event types in Q 0.42.3.
 ## Base Types
 
 ### `event` (protocol-level)

--- a/docs/extension-guide.md
+++ b/docs/extension-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.42.2 --># Extension Development Guide
+<!-- verified-against: 0.42.3 --># Extension Development Guide
 
 This guide walks you through creating, testing, and activating a custom
 extension for q.

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.42.2 --># Getting Started
+<!-- verified-against: 0.42.3 --># Getting Started
 
 Welcome to q, a Racket-based coding agent.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.42.2 --># Installation Guide
+<!-- verified-against: 0.42.3 --># Installation Guide
 
 <!-- This file is the canonical source. The docs/getting-started/installation.md copy is maintained for the doc site build. -->
 

--- a/docs/security-trust-model.md
+++ b/docs/security-trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.42.2 --># Security & Trust Model
+<!-- verified-against: 0.42.3 --># Security & Trust Model
 
 This document provides an honest, per-area assessment of what q enforces
 today and what is planned. It is the authoritative reference for security

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -130,6 +130,6 @@ is the primary self-hosting extension:
 (load-extension! ext-reg "path/to/extension.rkt" #:event-bus bus)
 ```
 
-## Version 0.42.2
+## Version 0.42.3
 
-This documentation reflects q 0.42.2.
+This documentation reflects q 0.42.3.

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.42.2 --># q Source Style Guide
+<!-- verified-against: 0.42.3 --># q Source Style Guide
 
 This document defines formatting and naming conventions for the q Racket codebase.
 All changes to `q/` source files (excluding `tests/`) should follow these rules.

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.42.2 --># Trust Model
+<!-- verified-against: 0.42.3 --># Trust Model
 
 ## Trust Levels
 

--- a/docs/workflow-testing.md
+++ b/docs/workflow-testing.md
@@ -121,6 +121,6 @@ Use relative paths from the test file:
 4. Use `(check-true ...)` for boolean assertions
 5. Keep tests independent — no shared mutable state between test-cases
 
-## Version 0.42.2
+## Version 0.42.3
 
-This documentation reflects q 0.42.2.
+This documentation reflects q 0.42.3.

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.42.2")
+(define version "0.42.3")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base"))

--- a/llm/anthropic.rkt
+++ b/llm/anthropic.rkt
@@ -165,14 +165,22 @@
       (match type
         ["text" (hasheq 'type "text" 'text (hash-ref block 'text ""))]
         ["tool_use"
-         (hasheq 'type
-                 "tool-call"
-                 'id
-                 (hash-ref block 'id "")
-                 'name
-                 (hash-ref block 'name "")
-                 'arguments
-                 (hash-ref block 'input (hasheq)))]
+         (define tc-hash
+           (hasheq 'type
+                   "tool-call"
+                   'id
+                   (hash-ref block 'id "")
+                   'name
+                   (hash-ref block 'name "")
+                   'arguments
+                   (hash-ref block 'input (hasheq))))
+         ;; Shadow: validate round-trip through tool-call-intent
+         (define tci (hash->tool-call-intent tc-hash))
+         (define round-trip (tool-call-intent->hash tci))
+         (unless (equal? (hash-ref tc-hash 'name) (hash-ref round-trip 'name))
+           (log-warning "tool-call-intent shadow mismatch in anthropic: ~a vs ~a"
+                        (hash-ref tc-hash 'name) (hash-ref round-trip 'name)))
+         tc-hash]
         [_ block])))
 
   (make-model-response content usage model-name stop-reason))

--- a/llm/gemini.rkt
+++ b/llm/gemini.rkt
@@ -221,14 +221,22 @@
         [(hash-has-key? part 'functionCall)
          (let* ([fc (hash-ref part 'functionCall)]
                 [tool-id (gemini-gen-tool-id)])
-           (hasheq 'type
-                   "tool-call"
-                   'id
-                   tool-id
-                   'name
-                   (hash-ref fc 'name "")
-                   'arguments
-                   (hash-ref fc 'args (hasheq))))]
+           (define tc-hash
+             (hasheq 'type
+                     "tool-call"
+                     'id
+                     tool-id
+                     'name
+                     (hash-ref fc 'name "")
+                     'arguments
+                     (hash-ref fc 'args (hasheq))))
+           ;; Shadow: validate round-trip through tool-call-intent
+           (define tci (hash->tool-call-intent tc-hash))
+           (define round-trip (tool-call-intent->hash tci))
+           (unless (equal? (hash-ref tc-hash 'name) (hash-ref round-trip 'name))
+             (log-warning "tool-call-intent shadow mismatch in gemini: ~a vs ~a"
+                          (hash-ref tc-hash 'name) (hash-ref round-trip 'name)))
+           tc-hash)]
         [else part])))
 
   ;; Check for safety/recitation filtering — add warning when content is empty

--- a/llm/model.rkt
+++ b/llm/model.rkt
@@ -23,7 +23,12 @@
          jsexpr->model-response
 
          (struct-out stream-chunk)
-         make-stream-chunk)
+         make-stream-chunk
+
+         (struct-out tool-call-intent)
+         make-tool-call-intent
+         tool-call-intent->hash
+         hash->tool-call-intent)
 
 ;; ============================================================
 ;; model-request
@@ -133,3 +138,33 @@
            #:delta-thinking [delta-thinking : (Option String) #f]
            #:finish-reason [finish-reason : (Option (U String Symbol)) #f])
     (stream-chunk delta-text delta-tool-call delta-thinking usage done? finish-reason)))
+
+;; ============================================================
+;; tool-call-intent — unified AST for provider tool-call data
+;; ============================================================
+
+(struct tool-call-intent
+        ([id : String] [name : String] [arguments : (HashTable Symbol Any)])
+  #:transparent)
+
+(: make-tool-call-intent (String String (HashTable Symbol Any) -> tool-call-intent))
+(define (make-tool-call-intent id name arguments)
+  (tool-call-intent id name arguments))
+
+(: tool-call-intent->hash (tool-call-intent -> (HashTable Symbol Any)))
+(define (tool-call-intent->hash tci)
+  (hasheq 'type "tool-call"
+          'id (tool-call-intent-id tci)
+          'name (tool-call-intent-name tci)
+          'arguments (tool-call-intent-arguments tci)))
+
+(: hash->tool-call-intent ((HashTable Symbol Any) -> tool-call-intent))
+(define (hash->tool-call-intent h)
+  (define id0 (hash-ref h 'id #f))
+  (define name0 (hash-ref h 'name #f))
+  (define args0 (hash-ref h 'arguments #f))
+  (tool-call-intent (if (string? id0) id0 "")
+                    (if (string? name0) name0 "")
+                    (if (hash? args0)
+                        (cast args0 (HashTable Symbol Any))
+                        (hasheq))))

--- a/llm/openai-compatible.rkt
+++ b/llm/openai-compatible.rkt
@@ -99,14 +99,22 @@
                      (define args
                        (with-handlers ([exn:fail? (lambda (e) args-str)])
                          (string->jsexpr args-str)))
-                     (hasheq 'type
-                             "tool-call"
-                             'id
-                             (hash-ref tc 'id)
-                             'name
-                             (hash-ref fn 'name)
-                             'arguments
-                             args))
+                     (define tc-hash
+                       (hasheq 'type
+                               "tool-call"
+                               'id
+                               (hash-ref tc 'id)
+                               'name
+                               (hash-ref fn 'name)
+                               'arguments
+                               args))
+                     ;; Shadow: validate round-trip through tool-call-intent
+                     (define tci (hash->tool-call-intent tc-hash))
+                     (define round-trip (tool-call-intent->hash tci))
+                     (unless (equal? (hash-ref tc-hash 'name) (hash-ref round-trip 'name))
+                       (log-warning "tool-call-intent shadow mismatch in openai: ~a vs ~a"
+                                    (hash-ref tc-hash 'name) (hash-ref round-trip 'name)))
+                     tc-hash)
                    '()))]))
 
   (make-model-response content usage model-name finish-reason))

--- a/tests/test-tool-call-intent.rkt
+++ b/tests/test-tool-call-intent.rkt
@@ -1,0 +1,167 @@
+#lang racket/base
+
+;; BOUNDARY: integration
+
+;; tests/test-tool-call-intent.rkt — Unified tool-call-intent AST tests
+;;
+;; Covers:
+;;   (A) tool-call-intent round-trip via hash
+;;   (B) Shadow validation in provider parsers (OpenAI, Anthropic, Gemini)
+
+(require rackunit
+         rackunit/text-ui
+         racket/port
+         racket/string
+         racket/hash
+         (only-in "../llm/model.rkt"
+                  make-tool-call-intent
+                  tool-call-intent?
+                  tool-call-intent-id
+                  tool-call-intent-name
+                  tool-call-intent-arguments
+                  tool-call-intent->hash
+                  hash->tool-call-intent
+                  make-model-response
+                  model-response-content
+                  make-stream-chunk)
+         (only-in "../llm/openai-compatible.rkt"
+                  openai-parse-response)
+         (only-in "../llm/anthropic.rkt"
+                  anthropic-parse-response)
+         (only-in "../llm/gemini.rkt"
+                  gemini-parse-response
+                  gemini-reset-tool-id-counter!))
+
+;; ============================================================
+;; (A) Round-trip tests
+;; ============================================================
+
+(define roundtrip-tests
+  (test-suite "tool-call-intent round-trip"
+
+    (test-case "basic round-trip"
+      (define tci (make-tool-call-intent "call_123" "bash" (hasheq 'cmd "ls")))
+      (define h (tool-call-intent->hash tci))
+      (check-equal? (hash-ref h 'type) "tool-call")
+      (check-equal? (hash-ref h 'id) "call_123")
+      (check-equal? (hash-ref h 'name) "bash")
+      (check-equal? (hash-ref h 'arguments) (hasheq 'cmd "ls"))
+      (define tci2 (hash->tool-call-intent h))
+      (check-equal? (tool-call-intent-id tci) (tool-call-intent-id tci2))
+      (check-equal? (tool-call-intent-name tci) (tool-call-intent-name tci2))
+      (check-equal? (tool-call-intent-arguments tci) (tool-call-intent-arguments tci2)))
+
+    (test-case "empty arguments default to empty hash"
+      (define tci (make-tool-call-intent "call_0" "date" (hasheq)))
+      (define h (tool-call-intent->hash tci))
+      (define tci2 (hash->tool-call-intent h))
+      (check-equal? (tool-call-intent-arguments tci2) (hasheq)))
+
+    (test-case "hash->tool-call-intent handles missing fields"
+      (define h (hasheq 'type "tool-call" 'id "x" 'name "y"))
+      (define tci (hash->tool-call-intent h))
+      (check-equal? (tool-call-intent-id tci) "x")
+      (check-equal? (tool-call-intent-name tci) "y")
+      (check-equal? (tool-call-intent-arguments tci) (hasheq)))
+
+    (test-case "hash->tool-call-intent handles non-string id/name"
+      (define h (hasheq 'type "tool-call" 'id 42 'name 'foo 'arguments (hasheq 'a 1)))
+      (define tci (hash->tool-call-intent h))
+      (check-equal? (tool-call-intent-id tci) "")
+      (check-equal? (tool-call-intent-name tci) "")
+      (check-equal? (tool-call-intent-arguments tci) (hasheq 'a 1)))
+
+    (test-case "nested arguments survive round-trip"
+      (define args (hasheq 'file "app.rkt" 'opts (hasheq 'lines 10)))
+      (define tci (make-tool-call-intent "c1" "read" args))
+      (define h (tool-call-intent->hash tci))
+      (define tci2 (hash->tool-call-intent h))
+      (check-equal? (tool-call-intent-arguments tci2) args))))
+
+;; ============================================================
+;; (B) Provider shadow tests
+;; ============================================================
+
+(define provider-tests
+  (test-suite "Provider shadow migration"
+
+    (test-case "OpenAI parse produces tool-call-intent-compatible hash"
+      (define raw
+        (hasheq 'model "gpt-4"
+                'usage (hasheq)
+                'choices
+                (list (hasheq 'message
+                              (hasheq 'content "hello"
+                                      'tool_calls
+                                      (list (hasheq 'id "call_1"
+                                                    'function
+                                                    (hasheq 'name "bash"
+                                                            'arguments "{\"cmd\":\"ls\"}"))))
+                             'finish_reason "stop"))))
+      (define resp (openai-parse-response raw))
+      (define content (let ([c (model-response-content resp)]) c))
+      (define tc-block (for/first ([b (in-list content)]
+                                   #:when (equal? (hash-ref b 'type "") "tool-call"))
+                         b))
+      (check-true (hash? tc-block) "OpenAI response should have tool-call block")
+      (when tc-block
+        (define tci (hash->tool-call-intent tc-block))
+        (check-equal? (tool-call-intent-id tci) "call_1")
+        (check-equal? (tool-call-intent-name tci) "bash")
+        (check-equal? (tool-call-intent-arguments tci) (hasheq 'cmd "ls"))))
+
+    (test-case "Anthropic parse produces tool-call-intent-compatible hash"
+      (define raw
+        (hasheq 'model "claude-3"
+                'usage (hasheq 'input_tokens 10 'output_tokens 5)
+                'stop_reason "stop"
+                'content
+                (list (hasheq 'type "tool_use"
+                              'id "tu_1"
+                              'name "bash"
+                              'input (hasheq 'cmd "ls")))))
+      (define resp (anthropic-parse-response raw))
+      (define content (let ([c (model-response-content resp)]) c))
+      (define tc-block (for/first ([b (in-list content)]
+                                   #:when (equal? (hash-ref b 'type "") "tool-call"))
+                         b))
+      (check-true (hash? tc-block) "Anthropic response should have tool-call block")
+      (when tc-block
+        (define tci (hash->tool-call-intent tc-block))
+        (check-equal? (tool-call-intent-id tci) "tu_1")
+        (check-equal? (tool-call-intent-name tci) "bash")
+        (check-equal? (tool-call-intent-arguments tci) (hasheq 'cmd "ls"))))
+
+    (test-case "Gemini parse produces tool-call-intent-compatible hash"
+      (gemini-reset-tool-id-counter!)
+      (define raw
+        (hasheq 'modelVersion "gemini-1.5"
+                'usageMetadata (hasheq 'promptTokenCount 10
+                                       'candidatesTokenCount 5
+                                       'totalTokenCount 15)
+                'candidates
+                (list (hasheq 'content
+                              (hasheq 'parts
+                                      (list (hasheq 'functionCall
+                                                    (hasheq 'name "bash"
+                                                            'args (hasheq 'cmd "ls")))))
+                             'finishReason "STOP"))))
+      (define resp (gemini-parse-response raw))
+      (define content (let ([c (model-response-content resp)]) c))
+      (define tc-block (for/first ([b (in-list content)]
+                                   #:when (equal? (hash-ref b 'type "") "tool-call"))
+                         b))
+      (check-true (hash? tc-block) "Gemini response should have tool-call block")
+      (when tc-block
+        (define tci (hash->tool-call-intent tc-block))
+        ;; ID is generated by gemini-gen-tool-id
+        (check-true (string? (tool-call-intent-id tci)))
+        (check-equal? (tool-call-intent-name tci) "bash")
+        (check-equal? (tool-call-intent-arguments tci) (hasheq 'cmd "ls"))))))
+
+;; ============================================================
+;; Run all
+;; ============================================================
+
+(run-tests roundtrip-tests)
+(run-tests provider-tests)

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -10,4 +10,4 @@
 (provide q-version)
 
 (: q-version String)
-(define q-version "0.42.2")
+(define q-version "0.42.3")

--- a/wiki-src/Architecture-Overview.md
+++ b/wiki-src/Architecture-Overview.md
@@ -35,7 +35,7 @@ User input → Interface (CLI/TUI/RPC)
     → Events emitted to bus
 ```
 
-## Metrics (0.42.2)
+## Metrics (0.42.3)
 > _See `racket scripts/metrics.rkt` for current numbers._
 
 - 414 source modules, 534 test files


### PR DESCRIPTION
## v0.42.3 W3 — Provider Tool-Call Unification (C8-01)

### Changes
- **C8-01**: Unified `tool-call-intent` AST for provider tool-call data
  - NEW `tool-call-intent` struct in `llm/model.rkt` (Typed Racket): `id`, `name`, `arguments`
  - NEW `make-tool-call-intent`, `tool-call-intent->hash`, `hash->tool-call-intent`
  - Shadow validation in OpenAI, Anthropic, Gemini providers: round-trip check + `log-warning` on mismatch
  - NEW `tests/test-tool-call-intent.rkt`: 8 tests (5 round-trip, 3 provider shadow)
- Version bump: 0.42.2 → 0.42.3
- Doc version sync: all .md files updated

### Verification
- 16/16 lint checks PASS
- All affected provider tests PASS (Anthropic 133, Gemini 160, OpenAI)
- New test file: 8/8 PASS

Closes #4247