### PR TITLE
feat: v0.43.0 turn-reducer as primary decision driver (#4259)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## v0.43.0 — 2026-05-14
+
+### Changed
+- **R2**: Turn-reducer is now the primary decision driver in `agent/loop.rkt`
+  (replaces manual `classify-hook-result` + `match` blocks with reducer-driven dispatch)
+- Removed `shadow-log!` function and all shadow-mode logging (reducer IS the decision-maker)
+- FSM state tracking retained for observability (follows reducer decisions)
+
+### Added
+- New integration test: `tests/test-turn-reducer-integration.rkt` (8 tests)
+  covering full turn lifecycle via `decide-turn-step`
+
 ## v0.42.4 — 2026-05-13
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.42.4-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.43.0-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 
@@ -199,7 +199,7 @@ racket main.rkt --model gpt-5.4 "write a test"
 ### Verify
 
 ```bash
-racket main.rkt --version  # q version 0.42.4
+racket main.rkt --version  # q version 0.43.0
 raco test tests/           # run the full test suite
 ```
 
@@ -386,6 +386,9 @@ When q executes shell commands on behalf of an LLM, arguments are quoted via `sh
 
 
 
+
+
+**v0.43.0** — Changed
 
 **v0.42.4** — Fixed
 

--- a/agent/loop.rkt
+++ b/agent/loop.rkt
@@ -49,8 +49,13 @@
          "loop-messages.rkt"
          "loop-stream.rkt"
          (only-in "event-emitter.rkt" emit-typed-event!)
-         (only-in "turn-reducer.rkt" decide-after-pre-hook decide-after-msg-hook decide-after-stream)
-         (only-in "turn-model.rkt" make-stream-completion turn-decision turn-decision-tag)
+         (only-in "turn-reducer.rkt"
+                  decide-after-pre-hook decide-after-msg-hook decide-after-stream
+                  decide-after-start decide-after-context decide-turn-step)
+         (only-in "turn-model.rkt"
+                  make-stream-completion turn-decision-tag
+                  make-turn-start make-turn-hook-result make-turn-stream-complete
+                  hook-stage-payload)
          (only-in "event-structs.rkt"
                   make-turn-start-event
                   make-turn-end-event
@@ -101,13 +106,6 @@
 ;; ============================================================
 ;; Extracted helpers (I-01)
 ;; ============================================================
-
-;; Shadow-mode reducer logging -- compares reducer decision with actual behavior
-(define (shadow-log! point reducer-decision actual-action)
-  (define rtag (turn-decision-tag reducer-decision))
-  (unless (eq? rtag actual-action)
-    (log-warning "turn-reducer shadow divergence at ~a: reducer=~a actual=~a"
-                 point rtag actual-action)))
 
 ;; Phase 1: Emit turn-started event and dispatch agent-start hook
 (define (emit-turn-start! bus session-id turn-id st hook-dispatcher context)
@@ -190,10 +188,10 @@
                                   'settings
                                   (model-request-settings req)))))
 
-  ;; v0.32.4: Flat match instead of nested CPS callbacks
-  (match (classify-hook-result pre-hook-result)
-    [(list 'block _)
-     (shadow-log! 'pre-hook (decide-after-pre-hook pre-hook-result) 'blocked)
+  ;; v0.43.0: Reducer-driven dispatch
+  (define d-pre (decide-after-pre-hook pre-hook-result))
+  (match (turn-decision-tag d-pre)
+    ['blocked
      ;; R-06/R-07: FSM: pre-hook -> blocked
      (current-turn-fsm-state (next-turn-state turn-state-pre-hook turn-event-hook-block))
      (emit-typed-event! bus
@@ -209,7 +207,6 @@
                                              #:duration-ms 0))
      (loop-result raw-messages 'hook-blocked (hasheq 'hook 'model-request-pre))]
     [_
-     (shadow-log! 'pre-hook (decide-after-pre-hook pre-hook-result) 'check-msg-hook)
      ;; R-06/R-07: FSM: pre-hook -> stream
      (current-turn-fsm-state (next-turn-state turn-state-pre-hook turn-event-hook-pass))
      ;; DEBUG: validate raw-messages before sending
@@ -243,10 +240,10 @@
                                      'message-count
                                      (length raw-messages)))))
 
-     ;; v0.32.4: Second hook — flat match, no nesting
-     (match (classify-hook-result msg-start-result)
-       [(list 'block _)
-        (shadow-log! 'msg-hook (decide-after-msg-hook msg-start-result) 'blocked)
+     ;; v0.43.0: Reducer-driven msg-hook dispatch
+     (define d-msg (decide-after-msg-hook msg-start-result))
+     (match (turn-decision-tag d-msg)
+       ['blocked
         (emit-typed-event! bus
                            (make-message-blocked-event #:session-id session-id
                                                        #:turn-id turn-id
@@ -261,7 +258,6 @@
                                                 #:duration-ms 0))
         (loop-result raw-messages 'hook-blocked (hasheq 'hook 'message-start))]
        [_
-        (shadow-log! 'msg-hook (decide-after-msg-hook msg-start-result) 'begin-stream)
         ;; 5-7. Stream from provider
         (define stream-data
           (stream-from-provider provider
@@ -273,20 +269,18 @@
                                 hook-dispatcher
                                 cancellation-token))
 
-        ;; Shadow: build stream-completion struct for reducer
-        (define shadow-sc
+        ;; v0.43.0: Reducer-driven stream-complete dispatch
+        (define sc
           (make-stream-completion
            #:cancelled? (hash-ref stream-data 'cancelled? #f)
            #:cancel-reason (hash-ref stream-data 'cancel-reason #f)
            #:text (hash-ref stream-data 'text "")
            #:tool-calls (hash-ref stream-data 'tool-calls '())))
-        (shadow-log! 'stream-complete
-                     (decide-after-stream shadow-sc)
-                     (if (hash-ref stream-data 'cancelled? #f) 'cancelled 'complete))
-        (cond
-          [(hash-ref stream-data 'cancelled?)
+        (define d-stream (decide-after-stream sc))
+        (match (turn-decision-tag d-stream)
+          ['cancelled
            (handle-cancellation bus session-id turn-id st #:hook-dispatcher hook-dispatcher)]
-          [else
+          [_
            (build-stream-result stream-data
                                 raw-messages
                                 bus

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -2,7 +2,7 @@
 
 ## Version
 
-v0.42.4
+v0.43.0
 
 ## Layer Diagram
 

--- a/docs/event-taxonomy.md
+++ b/docs/event-taxonomy.md
@@ -1,6 +1,6 @@
 # Q Event Taxonomy Reference
 
-Complete reference for all event types in Q 0.42.4.
+Complete reference for all event types in Q 0.43.0.
 ## Base Types
 
 ### `event` (protocol-level)

--- a/docs/extension-guide.md
+++ b/docs/extension-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.42.4 --># Extension Development Guide
+<!-- verified-against: 0.43.0 --># Extension Development Guide
 
 This guide walks you through creating, testing, and activating a custom
 extension for q.

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.42.4 --># Getting Started
+<!-- verified-against: 0.43.0 --># Getting Started
 
 Welcome to q, a Racket-based coding agent.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.42.4 --># Installation Guide
+<!-- verified-against: 0.43.0 --># Installation Guide
 
 <!-- This file is the canonical source. The docs/getting-started/installation.md copy is maintained for the doc site build. -->
 

--- a/docs/security-trust-model.md
+++ b/docs/security-trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.42.4 --># Security & Trust Model
+<!-- verified-against: 0.43.0 --># Security & Trust Model
 
 This document provides an honest, per-area assessment of what q enforces
 today and what is planned. It is the authoritative reference for security

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -130,6 +130,6 @@ is the primary self-hosting extension:
 (load-extension! ext-reg "path/to/extension.rkt" #:event-bus bus)
 ```
 
-## Version 0.42.4
+## Version 0.43.0
 
-This documentation reflects q 0.42.4.
+This documentation reflects q 0.43.0.

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.42.4 --># q Source Style Guide
+<!-- verified-against: 0.43.0 --># q Source Style Guide
 
 This document defines formatting and naming conventions for the q Racket codebase.
 All changes to `q/` source files (excluding `tests/`) should follow these rules.

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.42.4 --># Trust Model
+<!-- verified-against: 0.43.0 --># Trust Model
 
 ## Trust Levels
 

--- a/docs/workflow-testing.md
+++ b/docs/workflow-testing.md
@@ -121,6 +121,6 @@ Use relative paths from the test file:
 4. Use `(check-true ...)` for boolean assertions
 5. Keep tests independent — no shared mutable state between test-cases
 
-## Version 0.42.4
+## Version 0.43.0
 
-This documentation reflects q 0.42.4.
+This documentation reflects q 0.43.0.

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.42.4")
+(define version "0.43.0")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base"))

--- a/tests/test-turn-reducer-integration.rkt
+++ b/tests/test-turn-reducer-integration.rkt
@@ -1,0 +1,100 @@
+#lang racket
+
+;; BOUNDARY: integration
+
+;; tests/test-turn-reducer-integration.rkt -- Turn-reducer integration tests (v0.43.0)
+;;
+;; Verifies that the reducer-driven dispatch in loop.rkt produces correct
+;; decisions at all 6 branch points of the turn lifecycle.
+
+(require rackunit
+         rackunit/text-ui
+         "../agent/turn-reducer.rkt"
+         "../agent/turn-model.rkt"
+         (only-in "../util/hook-types.rkt" hook-result? hook-block hook-pass))
+
+(define integration-suite
+  (test-suite "turn-reducer integration with loop"
+
+    ;; S1: Validate reducer alignment with hook results
+
+    (test-case "reducer blocks on hook-block result"
+      (define block-result (hook-block "test-reason"))
+      (define d-pre (decide-after-pre-hook block-result))
+      (check-equal? (turn-decision-tag d-pre) 'blocked)
+      (define d-msg (decide-after-msg-hook block-result))
+      (check-equal? (turn-decision-tag d-msg) 'blocked))
+
+    (test-case "reducer passes on hook-pass result"
+      (define pass-result (hook-pass 'some-data))
+      (define d-pre (decide-after-pre-hook pass-result))
+      (check-equal? (turn-decision-tag d-pre) 'check-msg-hook)
+      (define d-msg (decide-after-msg-hook pass-result))
+      (check-equal? (turn-decision-tag d-msg) 'begin-stream))
+
+    (test-case "reducer passes on #f (no hook)"
+      (define d-pre (decide-after-pre-hook #f))
+      (check-equal? (turn-decision-tag d-pre) 'check-msg-hook)
+      (define d-msg (decide-after-msg-hook #f))
+      (check-equal? (turn-decision-tag d-msg) 'begin-stream))
+
+    ;; Full lifecycle via decide-turn-step
+    (test-case "full turn lifecycle via decide-turn-step: happy path"
+      (define ctx (turn-context "s1" 0 '() '() (hasheq) (hasheq) #f))
+      ;; Phase 1: start
+      (define d1 (decide-turn-step (make-turn-start ctx)))
+      (check-equal? (turn-decision-tag d1) 'build-context)
+      ;; Phase 2: context (always continues)
+      (define d2 (decide-after-context ctx))
+      (check-equal? (turn-decision-tag d2) 'check-pre-hook)
+      ;; Phase 3: pre-hook pass
+      (define d3 (decide-turn-step (make-turn-hook-result
+                                     (hook-stage-payload 'pre (hook-pass)))))
+      (check-equal? (turn-decision-tag d3) 'check-msg-hook)
+      ;; Phase 4: msg-hook pass
+      (define d4 (decide-turn-step (make-turn-hook-result
+                                     (hook-stage-payload 'msg (hook-pass)))))
+      (check-equal? (turn-decision-tag d4) 'begin-stream)
+      ;; Phase 5: stream complete
+      (define sc (make-stream-completion
+                  #:cancelled? #f
+                  #:text "hello"
+                  #:tool-calls '()))
+      (define d5 (decide-turn-step (make-turn-stream-complete sc)))
+      (check-equal? (turn-decision-tag d5) 'complete))
+
+    (test-case "full turn lifecycle: pre-hook blocked"
+      (define ctx (turn-context "s1" 0 '() '() (hasheq) (hasheq) #f))
+      (define d1 (decide-turn-step (make-turn-start ctx)))
+      (check-equal? (turn-decision-tag d1) 'build-context)
+      ;; Pre-hook blocks
+      (define d3 (decide-turn-step (make-turn-hook-result
+                                     (hook-stage-payload 'pre (hook-block "denied")))))
+      (check-equal? (turn-decision-tag d3) 'blocked))
+
+    (test-case "full turn lifecycle: msg-hook blocked"
+      ;; Pre-hook passes
+      (define d3 (decide-turn-step
+                  (make-turn-hook-result
+                   (hook-stage-payload 'pre (hook-pass)))))
+      (check-equal? (turn-decision-tag d3) 'check-msg-hook)
+      ;; Msg-hook blocks
+      (define d4 (decide-turn-step
+                  (make-turn-hook-result
+                   (hook-stage-payload 'msg (hook-block "nope")))))
+      (check-equal? (turn-decision-tag d4) 'blocked))
+
+    (test-case "full turn lifecycle: stream cancelled"
+      (define sc (make-stream-completion
+                  #:cancelled? #t
+                  #:cancel-reason "user"
+                  #:text ""
+                  #:tool-calls '()))
+      (define d5 (decide-turn-step (make-turn-stream-complete sc)))
+      (check-equal? (turn-decision-tag d5) 'cancelled))
+
+    (test-case "decide-turn-step handles cancel command"
+      (define d (decide-turn-step (make-turn-cancel "timeout")))
+      (check-equal? (turn-decision-tag d) 'cancelled))))
+
+(run-tests integration-suite)

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -10,4 +10,4 @@
 (provide q-version)
 
 (: q-version String)
-(define q-version "0.42.4")
+(define q-version "0.43.0")

--- a/wiki-src/Architecture-Overview.md
+++ b/wiki-src/Architecture-Overview.md
@@ -35,7 +35,7 @@ User input → Interface (CLI/TUI/RPC)
     → Events emitted to bus
 ```
 
-## Metrics (0.42.4)
+## Metrics (0.43.0)
 > _See `racket scripts/metrics.rkt` for current numbers._
 
 - 414 source modules, 534 test files


### PR DESCRIPTION
## v0.43.0 W0 — Turn-Reducer Integration (R2)

### Core Change
- Turn-reducer is now the **primary decision driver** in `agent/loop.rkt`
- Replaced manual `classify-hook-result` + `match` blocks with reducer-driven dispatch
- FSM state tracking retained for observability (follows reducer decisions)

### What Changed
- `agent/loop.rkt`: Uses `decide-after-pre-hook`, `decide-after-msg-hook`, `decide-after-stream` as primary decision-makers
- Removed `shadow-log!` function and all 5 shadow-mode logging calls
- New imports: `decide-after-start`, `decide-after-context`, `decide-turn-step`, `hook-stage-payload`, etc.

### New Tests
- `tests/test-turn-reducer-integration.rkt` — 8 tests covering full turn lifecycle via `decide-turn-step`

### Verification
- 16/16 lint checks PASS
- 60 tests PASS (loop, FSM, reducer, integration)
- 0 regressions

Closes #4259