### PR TITLE
feat: v0.43.2 context-assembly call-options + cmd dedup (R10, R6) (#4261)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## v0.43.2 — 2026-05-14
+
+### Added
+- **R10**: `context-assembly-call-options` struct bundling 8 keyword args for `build-assembled-context`
+- `build-assembled-context/v2` API accepting call-options struct
+- `util/command-helpers.rkt` with shared `extract-cmd-args` (deduplicated from 2 sites)
+
+### Changed
+- `build-assembled-context` now delegates to v2 via call-options struct (backward-compatible)
+- `extract-cmd-args` deduplicated from `gsd/command-parser.rkt` and `gsd-planning/command-normalization.rkt`
+
 ## v0.43.1 — 2026-05-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.43.1-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.43.2-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 
@@ -199,7 +199,7 @@ racket main.rkt --model gpt-5.4 "write a test"
 ### Verify
 
 ```bash
-racket main.rkt --version  # q version 0.43.1
+racket main.rkt --version  # q version 0.43.2
 raco test tests/           # run the full test suite
 ```
 
@@ -271,8 +271,8 @@ q/
 | Metric | Value |
 |--------|-------|
 | Test files | 582 |
-| Source modules | 425 |
-| Source lines | 65385 |
+| Source modules | 426 |
+| Source lines | 65423 |
 | Test lines | 102113 |
 | Test assertions | 15946 |
 | Tests passing | 5835+ | `racket scripts/run-tests.rkt` results |
@@ -389,7 +389,7 @@ When q executes shell commands on behalf of an LLM, arguments are quoted via `sh
 
 
 
-**v0.43.1** — Added
+**v0.43.2** — Added
 
 **v0.43.0** — Changed
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -2,7 +2,7 @@
 
 ## Version
 
-v0.43.1
+v0.43.2
 
 ## Layer Diagram
 

--- a/docs/event-taxonomy.md
+++ b/docs/event-taxonomy.md
@@ -1,6 +1,6 @@
 # Q Event Taxonomy Reference
 
-Complete reference for all event types in Q 0.43.1.
+Complete reference for all event types in Q 0.43.2.
 ## Base Types
 
 ### `event` (protocol-level)

--- a/docs/extension-guide.md
+++ b/docs/extension-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.43.1 --># Extension Development Guide
+<!-- verified-against: 0.43.2 --># Extension Development Guide
 
 This guide walks you through creating, testing, and activating a custom
 extension for q.

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.43.1 --># Getting Started
+<!-- verified-against: 0.43.2 --># Getting Started
 
 Welcome to q, a Racket-based coding agent.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.43.1 --># Installation Guide
+<!-- verified-against: 0.43.2 --># Installation Guide
 
 <!-- This file is the canonical source. The docs/getting-started/installation.md copy is maintained for the doc site build. -->
 

--- a/docs/security-trust-model.md
+++ b/docs/security-trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.43.1 --># Security & Trust Model
+<!-- verified-against: 0.43.2 --># Security & Trust Model
 
 This document provides an honest, per-area assessment of what q enforces
 today and what is planned. It is the authoritative reference for security

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -130,6 +130,6 @@ is the primary self-hosting extension:
 (load-extension! ext-reg "path/to/extension.rkt" #:event-bus bus)
 ```
 
-## Version 0.43.1
+## Version 0.43.2
 
-This documentation reflects q 0.43.1.
+This documentation reflects q 0.43.2.

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.43.1 --># q Source Style Guide
+<!-- verified-against: 0.43.2 --># q Source Style Guide
 
 This document defines formatting and naming conventions for the q Racket codebase.
 All changes to `q/` source files (excluding `tests/`) should follow these rules.

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.43.1 --># Trust Model
+<!-- verified-against: 0.43.2 --># Trust Model
 
 ## Trust Levels
 

--- a/docs/workflow-testing.md
+++ b/docs/workflow-testing.md
@@ -121,6 +121,6 @@ Use relative paths from the test file:
 4. Use `(check-true ...)` for boolean assertions
 5. Keep tests independent — no shared mutable state between test-cases
 
-## Version 0.43.1
+## Version 0.43.2
 
-This documentation reflects q 0.43.1.
+This documentation reflects q 0.43.2.

--- a/extensions/gsd-planning/command-normalization.rkt
+++ b/extensions/gsd-planning/command-normalization.rkt
@@ -4,7 +4,8 @@
 ;;
 ;; Pure functions for GSD command parsing and artifact name validation.
 
-(require racket/string)
+(require racket/string
+         (only-in "../../util/command-helpers.rkt" extract-cmd-args))
 
 (provide extract-cmd-args
          parse-wave-headers
@@ -26,16 +27,6 @@
                      ("SUMMARY" . ".md")
                      ("REVIEW" . ".md")
                      ("ANALYSIS" . ".md")))
-
-(define (extract-cmd-args input-text)
-  (define trimmed (string-trim input-text))
-  (define parts
-    (and (> (string-length trimmed) 0)
-         (char=? (string-ref trimmed 0) #\/)
-         (string-split trimmed)))
-  (if (and (pair? parts) (> (length parts) 1))
-      (string-trim (string-join (cdr parts) " "))
-      ""))
 
 (define (parse-wave-headers plan-text)
   (define matches (regexp-match* #rx"## [Ww]ave +([0-9]+)" plan-text))

--- a/extensions/gsd/command-parser.rkt
+++ b/extensions/gsd/command-parser.rkt
@@ -7,7 +7,8 @@
 ;; No I/O, no side effects -- just string -> AST transformation.
 
 (require racket/match
-         racket/string)
+         racket/string
+         (only-in "../../util/command-helpers.rkt" extract-cmd-args))
 
 (provide (struct-out parsed-gsd-command)
          (struct-out gsd-cmd-go)
@@ -65,15 +66,6 @@
       (list canonical)))
 
 ;; -- Pure parser --
-
-(define (extract-cmd-args input-text)
-  (define trimmed (string-trim input-text))
-  (if (and (> (string-length trimmed) 0) (char=? (string-ref trimmed 0) #\/))
-      (let ([parts (string-split trimmed)])
-        (if (>= (length parts) 2)
-            (string-trim (string-join (cdr parts) " "))
-            ""))
-      ""))
 
 ;; Parse a slash command string into a typed AST node.
 ;; Returns #f if the command is not recognized as a GSD command.

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.43.1")
+(define version "0.43.2")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base"))

--- a/runtime/context-assembly.rkt
+++ b/runtime/context-assembly.rkt
@@ -60,7 +60,10 @@
          context-result-summary
          build-assembled-context
          build-assembled-context/raw
+         build-assembled-context/v2
          build-session-context
+         (struct-out context-assembly-call-options)
+         make-context-assembly-call-options
          tiered-context
          tiered-context?
          tiered-context-tier-a

--- a/runtime/context-assembly/selection.rkt
+++ b/runtime/context-assembly/selection.rkt
@@ -31,8 +31,29 @@
          (only-in "../working-set.rkt" working-set? working-set-resolve-messages)
          "budgeting.rkt")
 
-(provide build-assembled-context
+;; R10: Call-options struct bundling keyword args for build-assembled-context
+(struct context-assembly-call-options
+  (cache provider model-name trace-callback working-set
+   generate-summary-proc generate-catalog-proc estimate-text-proc)
+  #:transparent)
+
+(define (make-context-assembly-call-options
+         #:cache [cache #f]
+         #:provider [provider #f]
+         #:model-name [model-name #f]
+         #:trace-callback [trace #f]
+         #:working-set [ws #f]
+         #:generate-summary-proc [summary-proc #f]
+         #:generate-catalog-proc [catalog-proc #f]
+         #:estimate-text-proc [estimate-proc #f])
+  (context-assembly-call-options
+   cache provider model-name trace ws summary-proc catalog-proc estimate-proc))
+
+(provide (struct-out context-assembly-call-options)
+         make-context-assembly-call-options
+         build-assembled-context
          build-assembled-context/raw
+         build-assembled-context/v2
          build-session-context)
 
 (define (build-assembled-context idx
@@ -45,9 +66,21 @@
                                  #:generate-summary-proc [generate-summary-proc #f]
                                  #:generate-catalog-proc [generate-catalog-proc #f]
                                  #:estimate-text-proc [estimate-text-proc #f])
+  (build-assembled-context/v2 idx config
+    (make-context-assembly-call-options
+     #:cache cache #:provider provider #:model-name model-name
+     #:trace-callback trace #:working-set ws
+     #:generate-summary-proc generate-summary-proc
+     #:generate-catalog-proc generate-catalog-proc
+     #:estimate-text-proc estimate-text-proc)))
+
+;; R10: Simplified v2 API taking call-options struct
+(define (build-assembled-context/v2 idx config opts)
+  (define trace (context-assembly-call-options-trace-callback opts))
   (define (emit-trace phase data)
     (when trace
       (trace phase data)))
+  (define ws (context-assembly-call-options-working-set opts))
   (define raw-messages (build-session-context idx))
   (emit-trace 'start (hash 'raw-count (length raw-messages)))
   (if (null? raw-messages)
@@ -56,12 +89,12 @@
         (context-result '() 0 0 0 0 #f '() #f))
       (build-assembled-context/raw raw-messages config ws
                                    #:memo (make-hash)
-                                   #:estimate-text-proc estimate-text-proc
-                                   #:generate-summary-proc generate-summary-proc
-                                   #:generate-catalog-proc generate-catalog-proc
-                                   #:provider provider
-                                   #:model-name model-name
-                                   #:cache cache
+                                   #:estimate-text-proc (context-assembly-call-options-estimate-text-proc opts)
+                                   #:generate-summary-proc (context-assembly-call-options-generate-summary-proc opts)
+                                   #:generate-catalog-proc (context-assembly-call-options-generate-catalog-proc opts)
+                                   #:provider (context-assembly-call-options-provider opts)
+                                   #:model-name (context-assembly-call-options-model-name opts)
+                                   #:cache (context-assembly-call-options-cache opts)
                                    #:trace trace)))
 
 ;; ============================================================

--- a/util/command-helpers.rkt
+++ b/util/command-helpers.rkt
@@ -1,0 +1,19 @@
+#lang racket/base
+
+;; util/command-helpers.rkt -- shared command argument extraction
+;;
+;; R6: Deduplicated extract-cmd-args from gsd/command-parser.rkt
+;; and gsd-planning/command-normalization.rkt into a single source.
+
+(require racket/string)
+
+(define (extract-cmd-args input-text)
+  (define trimmed (string-trim input-text))
+  (if (and (> (string-length trimmed) 0) (char=? (string-ref trimmed 0) #\/))
+      (let ([parts (string-split trimmed)])
+        (if (>= (length parts) 2)
+            (string-trim (string-join (cdr parts) " "))
+            ""))
+      ""))
+
+(provide extract-cmd-args)

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -10,4 +10,4 @@
 (provide q-version)
 
 (: q-version String)
-(define q-version "0.43.1")
+(define q-version "0.43.2")

--- a/wiki-src/Architecture-Overview.md
+++ b/wiki-src/Architecture-Overview.md
@@ -35,7 +35,7 @@ User input → Interface (CLI/TUI/RPC)
     → Events emitted to bus
 ```
 
-## Metrics (0.43.1)
+## Metrics (0.43.2)
 > _See `racket scripts/metrics.rkt` for current numbers._
 
 - 414 source modules, 534 test files


### PR DESCRIPTION
## v0.43.2 W0 -- Context-Assembly Config + Command Dedup (R10, R6)

### Changes
- **R10**: `context-assembly-call-options` struct bundles 8 keyword args for `build-assembled-context`
- `build-assembled-context/v2` API accepts call-options struct
- `build-assembled-context` delegates to v2 (backward-compatible)
- **R6**: `extract-cmd-args` deduplicated from 2 sites into `util/command-helpers.rkt`

### Verification
- 16/16 lint checks PASS
- 34/34 context-assembly tests PASS
- 41/41 command tests PASS
- 0 regressions

Closes #4261