### PR TITLE
feat: v0.43.4 audit remediation (CF1-CF3) (#4268)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## v0.43.4 — 2026-05-14
+
+### Added
+- **CF1**: 6 new typed-event structs (gsd-plan-archived, gsd-transition-failed, 4 future-ready)
+- **CF1**: Extended gsd-plan-validated-event with optional fields (valid?, error-count, warning-count)
+- **CF1**: Extended gsd-mode-changed-event with optional fields (reason, error)
+- **CF1**: Migrated all 4 remaining hasheq emissions to typed structs (100% coverage)
+- **CF3**: Reverse-direction parity check in test-command-parity.rkt
+
+### Changed
+- `command-normalization.rkt` no longer re-exports `extract-cmd-args`
+- `test-gsd-command-normalization.rkt` imports `extract-cmd-args` from `util/command-helpers.rkt`
+- GSD typed event coverage: 12/17 (71%) → 17/17 (100%)
+
 ## v0.43.3 — 2026-05-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.43.3-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.43.4-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 
@@ -199,7 +199,7 @@ racket main.rkt --model gpt-5.4 "write a test"
 ### Verify
 
 ```bash
-racket main.rkt --version  # q version 0.43.3
+racket main.rkt --version  # q version 0.43.4
 raco test tests/           # run the full test suite
 ```
 
@@ -389,6 +389,9 @@ When q executes shell commands on behalf of an LLM, arguments are quoted via `sh
 
 
 
+
+
+**v0.43.4** — Added
 
 **v0.43.3** — Added
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -2,7 +2,7 @@
 
 ## Version
 
-v0.43.3
+v0.43.4
 
 ## Layer Diagram
 

--- a/docs/event-taxonomy.md
+++ b/docs/event-taxonomy.md
@@ -1,6 +1,6 @@
 # Q Event Taxonomy Reference
 
-Complete reference for all event types in Q 0.43.3.
+Complete reference for all event types in Q 0.43.4.
 ## Base Types
 
 ### `event` (protocol-level)

--- a/docs/extension-guide.md
+++ b/docs/extension-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.43.3 --># Extension Development Guide
+<!-- verified-against: 0.43.4 --># Extension Development Guide
 
 This guide walks you through creating, testing, and activating a custom
 extension for q.

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.43.3 --># Getting Started
+<!-- verified-against: 0.43.4 --># Getting Started
 
 Welcome to q, a Racket-based coding agent.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.43.3 --># Installation Guide
+<!-- verified-against: 0.43.4 --># Installation Guide
 
 <!-- This file is the canonical source. The docs/getting-started/installation.md copy is maintained for the doc site build. -->
 

--- a/docs/security-trust-model.md
+++ b/docs/security-trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.43.3 --># Security & Trust Model
+<!-- verified-against: 0.43.4 --># Security & Trust Model
 
 This document provides an honest, per-area assessment of what q enforces
 today and what is planned. It is the authoritative reference for security

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -130,6 +130,6 @@ is the primary self-hosting extension:
 (load-extension! ext-reg "path/to/extension.rkt" #:event-bus bus)
 ```
 
-## Version 0.43.3
+## Version 0.43.4
 
-This documentation reflects q 0.43.3.
+This documentation reflects q 0.43.4.

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.43.3 --># q Source Style Guide
+<!-- verified-against: 0.43.4 --># q Source Style Guide
 
 This document defines formatting and naming conventions for the q Racket codebase.
 All changes to `q/` source files (excluding `tests/`) should follow these rules.

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.43.3 --># Trust Model
+<!-- verified-against: 0.43.4 --># Trust Model
 
 ## Trust Levels
 

--- a/docs/workflow-testing.md
+++ b/docs/workflow-testing.md
@@ -121,6 +121,6 @@ Use relative paths from the test file:
 4. Use `(check-true ...)` for boolean assertions
 5. Keep tests independent — no shared mutable state between test-cases
 
-## Version 0.43.3
+## Version 0.43.4
 
-This documentation reflects q 0.43.3.
+This documentation reflects q 0.43.4.

--- a/extensions/gsd-planning/command-normalization.rkt
+++ b/extensions/gsd-planning/command-normalization.rkt
@@ -4,11 +4,9 @@
 ;;
 ;; Pure functions for GSD command parsing and artifact name validation.
 
-(require racket/string
-         (only-in "../../util/command-helpers.rkt" extract-cmd-args))
+(require racket/string)
 
-(provide extract-cmd-args
-         parse-wave-headers
+(provide parse-wave-headers
          valid-artifact-name?
          json-artifact?
          artifact-extensions

--- a/extensions/gsd/command-handlers.rkt
+++ b/extensions/gsd/command-handlers.rkt
@@ -49,7 +49,8 @@
                   make-gsd-wave-completed-event
                   make-gsd-plan-parsed-event
                   make-gsd-plan-validated-event
-                  make-gsd-plan-normalized-event)
+                  make-gsd-plan-normalized-event
+                  make-gsd-plan-archived-event)
          (only-in "../gsd/session-state.rkt"
                   set-gsd-state!
                   with-gsd-lock
@@ -173,10 +174,10 @@
      (when (gsd-success? cmd-result)
        (define data (gsd-command-result-data cmd-result))
        (events:emit-gsd-event! 'gsd.plan.archived
-                               (hasheq 'path
-                                       (if (hash? data)
-                                           (hash-ref data 'archive-path "")
-                                           ""))))
+     (make-gsd-plan-archived-event #:session-id "" #:turn-id 0
+       #:path (if (hash? data)
+                  (hash-ref data 'archive-path "")
+                  ""))))
      (hook-amend (hasheq 'text (or (gsd-command-result-message cmd-result) "")))]
     [(plan-submit) (handle-plan-submit result base-dir input-text parsed)]
     [(artifact) (handle-artifact-command cmd input-text base-dir payload)]
@@ -214,16 +215,15 @@
         (define validation (validate-normalized-plan norm-result))
         (define validated-plan? (gsd-validated-plan? validation))
         (events:emit-gsd-event! 'gsd.plan.validated
-                                (hasheq 'valid?
-                                        validated-plan?
-                                        'error-count
-                                        (if validated-plan?
-                                            0
-                                            (length (validation-errors validation)))
-                                        'warning-count
-                                        (if validated-plan?
-                                            0
-                                            (length (validation-warnings validation)))))
+     (make-gsd-plan-validated-event #:session-id "" #:turn-id 0
+                                    #:wave-count 0
+                                    #:valid? validated-plan?
+                                    #:error-count (if validated-plan?
+                                                      0
+                                                      (length (validation-errors validation)))
+                                    #:warning-count (if validated-plan?
+                                                        0
+                                                        (length (validation-warnings validation)))))
         (match validated-plan?
           [#f
            (list 'error
@@ -253,8 +253,11 @@
                             (values exec wis))
                           (lambda (e snap)
                             (events:emit-gsd-event!
-                             'gsd.mode.changed
-                             (hasheq 'reason "transaction-rollback" 'error (exn-message e))))))
+     'gsd.mode.changed
+     (make-gsd-mode-changed-event #:session-id "" #:turn-id 0
+                                  #:mode (gsm-current)
+                                  #:reason "transaction-rollback"
+                                  #:error (exn-message e))))))
   (match executor
     [(? gsd-command-result?) (list 'error (gsd-command-result-message executor))]
     [_ (list 'ok executor wave-indices)]))

--- a/extensions/gsd/event-structs.rkt
+++ b/extensions/gsd/event-structs.rkt
@@ -7,7 +7,9 @@
 
 (require "../../util/event-macro.rkt")
 
-(define-typed-event gsd-mode-changed-event "gsd.mode.changed" (mode))
+(define-typed-event gsd-mode-changed-event "gsd.mode.changed" (mode)
+  #:optional ([reason #f]
+              [error #f]))
 
 (define-typed-event gsd-transition-attempted-event "gsd.transition.attempted" (from to))
 
@@ -23,10 +25,26 @@
 
 (define-typed-event gsd-archive-failed-event "gsd.archive.failed" (error))
 
-(define-typed-event gsd-plan-validated-event "gsd.plan.validated" (wave-count))
+(define-typed-event gsd-plan-validated-event "gsd.plan.validated" (wave-count)
+  #:optional ([valid? #t]
+              [error-count 0]
+              [warning-count 0]))
 
 (define-typed-event gsd-plan-normalized-event "gsd.plan.normalized" (wave-count))
 
 (define-typed-event gsd-command-completed-event "gsd.command.completed" (command success))
+
+
+;; CF1-1: gsd.plan.archived
+(define-typed-event gsd-plan-archived-event "gsd.plan.archived" (path))
+
+;; CF1-4: gsd.transition.failed
+(define-typed-event gsd-transition-failed-event "gsd.transition.failed" (from to reason))
+
+;; Future-ready: no emission sites yet
+(define-typed-event gsd-wave-failed-event "gsd.wave.failed" (wave error))
+(define-typed-event gsd-wave-skipped-event "gsd.wave.skipped" (wave reason))
+(define-typed-event gsd-guard-blocked-event "gsd.guard.blocked" (tool reason))
+(define-typed-event gsd-guard-allowed-event "gsd.guard.allowed" (tool))
 
 (provide (all-defined-out))

--- a/extensions/gsd/state-machine.rkt
+++ b/extensions/gsd/state-machine.rkt
@@ -21,7 +21,8 @@
          (only-in "events.rkt" emit-gsd-event! current-gsd-correlation-id)
          (only-in "event-structs.rkt"
                   make-gsd-transition-attempted-event
-                  make-gsd-transition-succeeded-event)
+                  make-gsd-transition-succeeded-event
+                  make-gsd-transition-failed-event)
          (only-in "session-state.rkt"
                   current-gsd-history
                   set-gsd-history!
@@ -176,7 +177,9 @@
        [else
         (emit-gsd-event!
          'gsd.transition.failed
-         (hasheq 'from current 'to target 'reason (format "invalid: ~a -> ~a" current target)))
+         (make-gsd-transition-failed-event #:session-id "" #:turn-id 0
+                                           #:from current #:to target
+                                           #:reason (format "invalid: ~a -> ~a" current target)))
         result]))))
 
 ;; FF-01: Auto-routing transition — finds shortest path via BFS and follows it.

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.43.3")
+(define version "0.43.4")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base"))

--- a/tests/test-command-parity.rkt
+++ b/tests/test-command-parity.rkt
@@ -48,6 +48,10 @@
     (test-case "TUI command table has core commands"
       (for ([cmd '("/help" "/quit" "/clear" "/compact" "/switch" "/model")])
         (check hash-has-key? tui-table cmd
-          (format "Core command ~a missing from TUI table" cmd))))))
+          (format "Core command ~a missing from TUI table" cmd))))
+    (test-case "all TUI commands are in expected list -- no stale entries"
+      (for ([cmd (in-list (hash-keys tui-table))])
+        (check member cmd expected-commands
+          (format "TUI command ~a not in expected list -- stale or untested?" cmd))))))
 
 (run-tests parity-suite)

--- a/tests/test-gsd-command-normalization.rkt
+++ b/tests/test-gsd-command-normalization.rkt
@@ -6,7 +6,8 @@
 
 (require rackunit
          rackunit/text-ui
-         "../extensions/gsd-planning/command-normalization.rkt")
+         (combine-in "../extensions/gsd-planning/command-normalization.rkt"
+                 (only-in "../util/command-helpers.rkt" extract-cmd-args)))
 
 (define cmd-norm-tests
   (test-suite "GSD Command Normalization"

--- a/tests/test-gsd-event-codec-roundtrip.rkt
+++ b/tests/test-gsd-event-codec-roundtrip.rkt
@@ -25,6 +25,12 @@
       (define evt (make-gsd-mode-changed-event #:session-id "s1" #:turn-id 0 #:mode 'exploring))
       (roundtrip-event evt (hasheq 'mode 'exploring 'type "gsd.mode.changed")))
 
+    (test-case "gsd-mode-changed-event round-trip with rollback context"
+      (define evt (make-gsd-mode-changed-event #:session-id "s1" #:turn-id 0
+                                                #:mode 'idle #:reason "rollback" #:error "oops"))
+      (roundtrip-event evt (hasheq 'mode 'idle 'reason "rollback" 'error "oops"
+                                   'type "gsd.mode.changed")))
+
     (test-case "gsd-transition-attempted-event round-trip"
       (define evt (make-gsd-transition-attempted-event #:session-id "s1" #:turn-id 0 #:from 'idle #:to 'exploring))
       (roundtrip-event evt (hasheq 'from 'idle 'to 'exploring 'type "gsd.transition.attempted")))
@@ -54,8 +60,11 @@
       (roundtrip-event evt (hasheq 'error "disk full" 'type "gsd.archive.failed")))
 
     (test-case "gsd-plan-validated-event round-trip"
-      (define evt (make-gsd-plan-validated-event #:session-id "s1" #:turn-id 0 #:wave-count 3))
-      (roundtrip-event evt (hasheq 'waveCount 3 'type "gsd.plan.validated")))
+      (define evt (make-gsd-plan-validated-event #:session-id "s1" #:turn-id 0
+                                                  #:wave-count 3 #:valid? #t
+                                                  #:error-count 0 #:warning-count 0))
+      (roundtrip-event evt (hasheq 'waveCount 3 'valid #t 'errorCount 0 'warningCount 0
+                                   'type "gsd.plan.validated")))
 
     (test-case "gsd-plan-normalized-event round-trip"
       (define evt (make-gsd-plan-normalized-event #:session-id "s1" #:turn-id 0 #:wave-count 2))
@@ -63,6 +72,32 @@
 
     (test-case "gsd-command-completed-event round-trip"
       (define evt (make-gsd-command-completed-event #:session-id "s1" #:turn-id 0 #:command "wave" #:success #t))
-      (roundtrip-event evt (hasheq 'command "wave" 'success #t 'type "gsd.command.completed")))))
+      (roundtrip-event evt (hasheq 'command "wave" 'success #t 'type "gsd.command.completed")))
+    (test-case "gsd-plan-archived-event round-trip"
+      (define evt (make-gsd-plan-archived-event #:session-id "s1" #:turn-id 0 #:path "/tmp/archive"))
+      (roundtrip-event evt (hasheq 'path "/tmp/archive" 'type "gsd.plan.archived")))
+
+    (test-case "gsd-transition-failed-event round-trip"
+      (define evt (make-gsd-transition-failed-event #:session-id "s1" #:turn-id 0
+                                                     #:from 'idle #:to 'executing #:reason "invalid"))
+      (roundtrip-event evt (hasheq 'from 'idle 'to 'executing 'reason "invalid"
+                                   'type "gsd.transition.failed")))
+
+    (test-case "gsd-wave-failed-event round-trip"
+      (define evt (make-gsd-wave-failed-event #:session-id "s1" #:turn-id 0 #:wave 2 #:error "timeout"))
+      (roundtrip-event evt (hasheq 'wave 2 'error "timeout" 'type "gsd.wave.failed")))
+
+    (test-case "gsd-wave-skipped-event round-trip"
+      (define evt (make-gsd-wave-skipped-event #:session-id "s1" #:turn-id 0 #:wave 1 #:reason "empty"))
+      (roundtrip-event evt (hasheq 'wave 1 'reason "empty" 'type "gsd.wave.skipped")))
+
+    (test-case "gsd-guard-blocked-event round-trip"
+      (define evt (make-gsd-guard-blocked-event #:session-id "s1" #:turn-id 0
+                                                 #:tool "bash" #:reason "policy"))
+      (roundtrip-event evt (hasheq 'tool "bash" 'reason "policy" 'type "gsd.guard.blocked")))
+
+    (test-case "gsd-guard-allowed-event round-trip"
+      (define evt (make-gsd-guard-allowed-event #:session-id "s1" #:turn-id 0 #:tool "read"))
+      (roundtrip-event evt (hasheq 'tool "read" 'type "gsd.guard.allowed")))))
 
 (run-tests codec-suite)

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -10,4 +10,4 @@
 (provide q-version)
 
 (: q-version String)
-(define q-version "0.43.3")
+(define q-version "0.43.4")

--- a/wiki-src/Architecture-Overview.md
+++ b/wiki-src/Architecture-Overview.md
@@ -35,7 +35,7 @@ User input → Interface (CLI/TUI/RPC)
     → Events emitted to bus
 ```
 
-## Metrics (0.43.3)
+## Metrics (0.43.4)
 > _See `racket scripts/metrics.rkt` for current numbers._
 
 - 414 source modules, 534 test files


### PR DESCRIPTION
## v0.43.4 W0 — Audit Remediation (CF1-CF3)

### Changes
- **S1**: Created 6 new typed-event structs (gsd-plan-archived, gsd-transition-failed, 4 future-ready)
- **S2**: Extended gsd-plan-validated-event with optional fields (valid?, error-count, warning-count)
- **S3**: Extended gsd-mode-changed-event with optional fields (reason, error)
- **S4**: Migrated all 4 remaining hasheq emissions to typed structs
- **S5**: Updated codec round-trip tests (18/18 pass)
- **S6**: Removed stale re-export of extract-cmd-args from command-normalization
- **S7**: Added reverse-direction parity check

### Metrics
- GSD typed event coverage: 12/17 (71%) → **17/17 (100%)**
- Hasheq emission sites: 4 → **0**
- 16/16 lint checks PASS
- 18/18 codec round-trip tests PASS
- 3/3 command parity tests PASS
- 18/18 command normalization tests PASS

Closes #4268
Parent: #4267