### PR TITLE
feat: v0.44.1 FSM observability fix (R4) (#4273)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## v0.44.1 — 2026-05-14
+
+### Changed
+- **R4**: Added `turn-event-msg-hook-block` event and `stream → blocked` transition to turn FSM
+- **R4**: msg-hook blocking now sets FSM to `blocked` state (was missing)
+- **R4**: Stream cancellation now sets FSM to `complete` via `stream-cancel` transition (was missing)
+- **R4**: Context-assembly blocking in turn-orchestrator now sets FSM to `blocked`
+- Moved `current-turn-fsm-state` parameter from `loop.rkt` to `loop-fsm.rkt` (shared access)
+
+### Fixed
+- 3 broken FSM integration points where state was not updated on early-return paths
+
 ## v0.44.0 — 2026-05-14
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.44.0-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.44.1-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 
@@ -199,7 +199,7 @@ racket main.rkt --model gpt-5.4 "write a test"
 ### Verify
 
 ```bash
-racket main.rkt --version  # q version 0.44.0
+racket main.rkt --version  # q version 0.44.1
 raco test tests/           # run the full test suite
 ```
 
@@ -391,6 +391,9 @@ When q executes shell commands on behalf of an LLM, arguments are quoted via `sh
 
 
 
+
+
+**v0.44.1** — Changed
 
 **v0.44.0** — Changed
 

--- a/agent/loop-fsm.rkt
+++ b/agent/loop-fsm.rkt
@@ -29,7 +29,11 @@
          turn-event-stream-complete
          turn-event-stream-cancel
          turn-event-post-hook-done
+         turn-event-msg-hook-block
          turn-event->symbol
+
+         ;; FSM state parameter
+         current-turn-fsm-state
 
          ;; Transition table + lookup
          TURN-TRANSITIONS
@@ -64,6 +68,7 @@
 (define turn-event-stream-complete (turn-event 'stream-complete))
 (define turn-event-stream-cancel (turn-event 'stream-cancel))
 (define turn-event-post-hook-done (turn-event 'post-hook-done))
+(define turn-event-msg-hook-block (turn-event 'msg-hook-block))
 
 (define (turn-event->symbol e)
   (turn-event-name e))
@@ -80,6 +85,8 @@
                                            [(pre-hook . hook-block) . blocked]
                                            ;; stream -> post-hook (normal completion)
                                            [(stream . stream-complete) . post-hook]
+                                           ;; stream -> blocked (msg-hook blocks)
+                                           [(stream . msg-hook-block) . blocked]
                                            ;; stream -> complete (cancelled)
                                            [(stream . stream-cancel) . complete]
                                            ;; post-hook -> complete
@@ -116,3 +123,9 @@
   (define state-sym (turn-state->symbol state))
   (define event-sym (turn-event->symbol event))
   (and (find-turn-transition state-sym event-sym) #t))
+
+;; ── FSM state parameter ──
+;; Tracks current turn FSM state for observability.
+;; Moved here from loop.rkt so turn-orchestrator can import it
+;; without pulling in the full agent loop.
+(define current-turn-fsm-state (make-parameter turn-state-emit-start))

--- a/agent/loop.rkt
+++ b/agent/loop.rkt
@@ -28,8 +28,10 @@
                   turn-event-stream-complete
                   turn-event-stream-cancel
                   turn-event-post-hook-done
+                  turn-event-msg-hook-block
                   next-turn-state
-                  turn-state->symbol)
+                  turn-state->symbol
+                  current-turn-fsm-state)
          racket/string
          racket/list
          racket/date
@@ -146,8 +148,7 @@
 ;;                  #:cancellation-token (or/c cancellation-token? #f)
 ;;                  #:hook-dispatcher (or/c procedure? #f)
 ;;               -> loop-result?
-;; R-06/R-07: FSM state tracking parameter for observability
-(define current-turn-fsm-state (make-parameter turn-state-emit-start))
+;; R-06/R-07: FSM state parameter now lives in loop-fsm.rkt
 
 (define (run-agent-turn context
                         provider
@@ -244,6 +245,7 @@
      (define d-msg (decide-after-msg-hook msg-start-result))
      (match (turn-decision-tag d-msg)
        ['blocked
+        (current-turn-fsm-state (next-turn-state turn-state-stream turn-event-msg-hook-block))
         (emit-typed-event! bus
                            (make-message-blocked-event #:session-id session-id
                                                        #:turn-id turn-id
@@ -279,6 +281,7 @@
         (define d-stream (decide-after-stream sc))
         (match (turn-decision-tag d-stream)
           ['cancelled
+           (current-turn-fsm-state (next-turn-state turn-state-stream turn-event-stream-cancel))
            (handle-cancellation bus session-id turn-id st #:hook-dispatcher hook-dispatcher)]
           [_
            (build-stream-result stream-data

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -2,7 +2,7 @@
 
 ## Version
 
-v0.44.0
+v0.44.1
 
 ## Layer Diagram
 

--- a/docs/event-taxonomy.md
+++ b/docs/event-taxonomy.md
@@ -1,6 +1,6 @@
 # Q Event Taxonomy Reference
 
-Complete reference for all event types in Q 0.44.0.
+Complete reference for all event types in Q 0.44.1.
 ## Base Types
 
 ### `event` (protocol-level)

--- a/docs/extension-guide.md
+++ b/docs/extension-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.44.0 --># Extension Development Guide
+<!-- verified-against: 0.44.1 --># Extension Development Guide
 
 This guide walks you through creating, testing, and activating a custom
 extension for q.

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.44.0 --># Getting Started
+<!-- verified-against: 0.44.1 --># Getting Started
 
 Welcome to q, a Racket-based coding agent.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.44.0 --># Installation Guide
+<!-- verified-against: 0.44.1 --># Installation Guide
 
 <!-- This file is the canonical source. The docs/getting-started/installation.md copy is maintained for the doc site build. -->
 

--- a/docs/security-trust-model.md
+++ b/docs/security-trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.44.0 --># Security & Trust Model
+<!-- verified-against: 0.44.1 --># Security & Trust Model
 
 This document provides an honest, per-area assessment of what q enforces
 today and what is planned. It is the authoritative reference for security

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -130,6 +130,6 @@ is the primary self-hosting extension:
 (load-extension! ext-reg "path/to/extension.rkt" #:event-bus bus)
 ```
 
-## Version 0.44.0
+## Version 0.44.1
 
-This documentation reflects q 0.44.0.
+This documentation reflects q 0.44.1.

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.44.0 --># q Source Style Guide
+<!-- verified-against: 0.44.1 --># q Source Style Guide
 
 This document defines formatting and naming conventions for the q Racket codebase.
 All changes to `q/` source files (excluding `tests/`) should follow these rules.

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.44.0 --># Trust Model
+<!-- verified-against: 0.44.1 --># Trust Model
 
 ## Trust Levels
 

--- a/docs/workflow-testing.md
+++ b/docs/workflow-testing.md
@@ -121,6 +121,6 @@ Use relative paths from the test file:
 4. Use `(check-true ...)` for boolean assertions
 5. Keep tests independent — no shared mutable state between test-cases
 
-## Version 0.44.0
+## Version 0.44.1
 
-This documentation reflects q 0.44.0.
+This documentation reflects q 0.44.1.

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.44.0")
+(define version "0.44.1")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base"))

--- a/runtime/turn-orchestrator.rkt
+++ b/runtime/turn-orchestrator.rkt
@@ -53,6 +53,7 @@
          (only-in "../tools/registry.rkt" tool-registry?)
          (only-in "../extensions/api.rkt" extension-registry?)
          "../agent/loop.rkt"
+         (only-in "../agent/loop-fsm.rkt" current-turn-fsm-state turn-state-blocked)
          ;; ARCH-01: tool registry queries for LLM tool definitions
          (only-in "../tools/tool.rkt" list-tools-jsexpr merge-tool-lists)
          ;; Settings struct for provider settings resolution
@@ -175,6 +176,7 @@
 
   ;; Handle block action from context-assembly hook
   (when (and assembly-hook-result (eq? (hook-result-action assembly-hook-result) 'block))
+    (current-turn-fsm-state turn-state-blocked)
     (emit-session-event! bus session-id "context.assembly.blocked" (hasheq 'reason "extension-block"))
     (raise-extension-error "Context assembly blocked by extension" "unknown" "turn.started"))
 

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -10,4 +10,4 @@
 (provide q-version)
 
 (: q-version String)
-(define q-version "0.44.0")
+(define q-version "0.44.1")

--- a/wiki-src/Architecture-Overview.md
+++ b/wiki-src/Architecture-Overview.md
@@ -35,7 +35,7 @@ User input → Interface (CLI/TUI/RPC)
     → Events emitted to bus
 ```
 
-## Metrics (0.44.0)
+## Metrics (0.44.1)
 > _See `racket scripts/metrics.rkt` for current numbers._
 
 - 414 source modules, 534 test files


### PR DESCRIPTION
## v0.44.1 W0 — FSM Observability Fix (R4)

### Changes
- **S5**: Added `turn-event-msg-hook-block` event and `stream → blocked` FSM transition
- **S6**: msg-hook blocking now sets FSM to `blocked` state
- **S7**: Stream cancellation now sets FSM to `complete` via `stream-cancel` transition
- **S8**: Context-assembly blocking in turn-orchestrator sets FSM to `blocked`
- **S9**: Moved `current-turn-fsm-state` from `loop.rkt` to `loop-fsm.rkt` (shared access)

### Metrics
- 16/16 lint checks PASS
- 0 regressions
- 3 broken FSM integration points fixed

Closes #4273
Parent: #4272