### PR TITLE
feat: v0.44.2 scheduler plan + bash params (R3, R5) (#4275)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## v0.44.2 — 2026-05-14
+
+### Changed
+- **R3**: Added `scheduler-problem` and `scheduler-plan` structs for scheduler observability
+- **R3**: Split `run-tool-batch` into `plan-tool-batch` (pure) + `execute-tool-plan` (effectful)
+- **R5**: Added `tool-pre-hook-payload`, `tool-post-hook-payload`, `scheduler-batch-stats` structs
+- **R5**: Added `bash-execution-config` struct for per-request bash tool settings
+- Hook payloads in scheduler now use typed structs instead of raw hasheq
+
+### Added
+- `make-bash-execution-config` constructor (reads from deprecated parameters)
+- Backward-compatible `run-tool-batch` entry point preserved
+
 ## v0.44.1 — 2026-05-14
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.44.1-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.44.2-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 
@@ -199,7 +199,7 @@ racket main.rkt --model gpt-5.4 "write a test"
 ### Verify
 
 ```bash
-racket main.rkt --version  # q version 0.44.1
+racket main.rkt --version  # q version 0.44.2
 raco test tests/           # run the full test suite
 ```
 
@@ -392,6 +392,9 @@ When q executes shell commands on behalf of an LLM, arguments are quoted via `sh
 
 
 
+
+
+**v0.44.2** — Changed
 
 **v0.44.1** — Changed
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -2,7 +2,7 @@
 
 ## Version
 
-v0.44.1
+v0.44.2
 
 ## Layer Diagram
 

--- a/docs/event-taxonomy.md
+++ b/docs/event-taxonomy.md
@@ -1,6 +1,6 @@
 # Q Event Taxonomy Reference
 
-Complete reference for all event types in Q 0.44.1.
+Complete reference for all event types in Q 0.44.2.
 ## Base Types
 
 ### `event` (protocol-level)

--- a/docs/extension-guide.md
+++ b/docs/extension-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.44.1 --># Extension Development Guide
+<!-- verified-against: 0.44.2 --># Extension Development Guide
 
 This guide walks you through creating, testing, and activating a custom
 extension for q.

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.44.1 --># Getting Started
+<!-- verified-against: 0.44.2 --># Getting Started
 
 Welcome to q, a Racket-based coding agent.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.44.1 --># Installation Guide
+<!-- verified-against: 0.44.2 --># Installation Guide
 
 <!-- This file is the canonical source. The docs/getting-started/installation.md copy is maintained for the doc site build. -->
 

--- a/docs/security-trust-model.md
+++ b/docs/security-trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.44.1 --># Security & Trust Model
+<!-- verified-against: 0.44.2 --># Security & Trust Model
 
 This document provides an honest, per-area assessment of what q enforces
 today and what is planned. It is the authoritative reference for security

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -130,6 +130,6 @@ is the primary self-hosting extension:
 (load-extension! ext-reg "path/to/extension.rkt" #:event-bus bus)
 ```
 
-## Version 0.44.1
+## Version 0.44.2
 
-This documentation reflects q 0.44.1.
+This documentation reflects q 0.44.2.

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.44.1 --># q Source Style Guide
+<!-- verified-against: 0.44.2 --># q Source Style Guide
 
 This document defines formatting and naming conventions for the q Racket codebase.
 All changes to `q/` source files (excluding `tests/`) should follow these rules.

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.44.1 --># Trust Model
+<!-- verified-against: 0.44.2 --># Trust Model
 
 ## Trust Levels
 

--- a/docs/workflow-testing.md
+++ b/docs/workflow-testing.md
@@ -121,6 +121,6 @@ Use relative paths from the test file:
 4. Use `(check-true ...)` for boolean assertions
 5. Keep tests independent — no shared mutable state between test-cases
 
-## Version 0.44.1
+## Version 0.44.2
 
-This documentation reflects q 0.44.1.
+This documentation reflects q 0.44.2.

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.44.1")
+(define version "0.44.2")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base"))

--- a/tools/builtins/bash.rkt
+++ b/tools/builtins/bash.rkt
@@ -44,6 +44,9 @@
          current-warn-on-destructive
          current-block-destructive
          current-warning-port
+         ;; v0.44.2: Struct-based config
+         (struct-out bash-execution-config)
+         make-bash-execution-config
          current-extra-destructive-patterns
          destructive-command?
          destructive-patterns
@@ -198,6 +201,16 @@
 ;; When #t (default), emit a warning to stderr before executing.
 ;; Can be set to #f to suppress warnings.
 (define current-warn-on-destructive (make-parameter #t))
+
+;; v0.44.2 (R5): Struct-based config for per-request bash settings
+(struct bash-execution-config (policy block-destructive? warn-on-destructive? warning-port)
+  #:transparent)
+
+(define (make-bash-execution-config #:policy [policy (current-execution-policy)]
+                                    #:block? [block? (current-block-destructive)]
+                                    #:warn? [warn? (current-warn-on-destructive)]
+                                    #:warning-port [port (current-warning-port)])
+  (bash-execution-config policy block? warn? port))
 
 ;; Optional settings parameter for destructive command blocking (SEC-01).
 ;; When #t, destructive commands return an error result instead of executing.

--- a/tools/scheduler.rkt
+++ b/tools/scheduler.rkt
@@ -61,6 +61,15 @@
 (provide (struct-out scheduler-result)
          ;; R-15: Strategy support
          (struct-out preflight-entry)
+         ;; v0.44.2: Planning structs
+         (struct-out scheduler-problem)
+         (struct-out scheduler-plan)
+         ;; v0.44.2: Typed payloads
+         (struct-out tool-pre-hook-payload)
+         (struct-out tool-post-hook-payload)
+         (struct-out scheduler-batch-stats)
+         plan-tool-batch
+         execute-tool-plan
          run-preflight
          (contract-out [run-tool-batch
                         (->* ((listof tool-call?) tool-registry?)
@@ -92,6 +101,17 @@
 
 ;; v0.35.2 (W-10): Typed struct replaces ad-hoc hasheq
 (struct preflight-entry (status tool-call tool error-message) #:transparent)
+
+;; v0.44.2 (R3): Planning-phase structs for scheduler observability
+(struct scheduler-problem (calls registry strategy hook-dispatcher exec-context parallel?)
+  #:transparent)
+(struct scheduler-plan (entries ordered-calls execution-order metadata)
+  #:transparent)
+
+;; v0.44.2 (R5): Typed hook payloads and batch stats
+(struct tool-pre-hook-payload (tool-name args entry-id) #:transparent)
+(struct tool-post-hook-payload (tool-name result entry-id arguments) #:transparent)
+(struct scheduler-batch-stats (total executed blocked errors) #:transparent)
 ;; status: 'ready | 'blocked | 'error
 ;; tool: tool? (#f for blocked/error)
 ;; error-message: string? (#f for ready)
@@ -202,7 +222,7 @@
     (ev-pub "tool.execution.started"
             (hasheq 'tool-name tc-name 'tool-call-id tc-id 'start-ms tool-start-ms)))
 
-  (define pre-payload (hasheq 'tool-name tc-name 'args tc-args 'entry-id tc-id))
+  (define pre-payload (tool-pre-hook-payload tc-name tc-args tc-id))
 
   ;; Check if tool-call-pre hook blocks or amends
   (define pre-hook-result
@@ -250,7 +270,7 @@
 
         ;; Dispatch 'tool-result-post hook
         (define post-payload
-          (hasheq 'tool-name tc-name 'result exec-result 'entry-id tc-id 'arguments args))
+          (tool-post-hook-payload tc-name exec-result tc-id args))
 
         (define post-hook-result
           (if hook-dispatcher
@@ -362,43 +382,50 @@
                                                 (not (member idx blocked-indices))))
              1))
   (define executed (- total blocked errors))
-  (hasheq 'total total 'executed executed 'blocked blocked 'errors errors))
+  ;; v0.44.2: Build typed struct, then return as hasheq for backward compat
+  (define stats (scheduler-batch-stats total executed blocked errors))
+  (hasheq 'total (scheduler-batch-stats-total stats)
+          'executed (scheduler-batch-stats-executed stats)
+          'blocked (scheduler-batch-stats-blocked stats)
+          'errors (scheduler-batch-stats-errors stats)))
 
 ;; ============================================================
 ;; Main entry point
 ;; ============================================================
 
+;; v0.44.2 (R3): Pure planning phase — constructs scheduler-plan from scheduler-problem
+(define (plan-tool-batch problem)
+  (define calls (scheduler-problem-calls problem))
+  (define registry (scheduler-problem-registry problem))
+  (define hook-dispatcher (scheduler-problem-hook-dispatcher problem))
+  (define parallel? (scheduler-problem-parallel? problem))
+  (define strat (or (scheduler-problem-strategy problem) (default-scheduler-strategy)))
+  (define filtered-calls ((scheduler-strategy-preflight-filter strat) calls))
+  (define ordered-calls ((scheduler-strategy-execution-order strat) filtered-calls))
+  (define entries (run-preflight ordered-calls registry hook-dispatcher))
+  (scheduler-plan entries ordered-calls (if parallel? 'parallel 'serial) #f))
+
+;; v0.44.2 (R3): Effectful execution phase — runs a scheduler-plan
+(define (execute-tool-plan plan exec-ctx hook-dispatcher parallel? ev-pub)
+  (define entries (scheduler-plan-entries plan))
+  (when ev-pub
+    (ev-pub "tool.batch.preflight.started"
+            (hasheq 'toolCount (length (scheduler-plan-ordered-calls plan))
+                    'toolNames (map tool-call-name (scheduler-plan-ordered-calls plan)))))
+  (define results (run-execution entries exec-ctx parallel? hook-dispatcher))
+  (define metadata (compute-metadata results entries))
+  (when ev-pub
+    (ev-pub "tool.batch.completed" metadata))
+  (scheduler-result results metadata))
+
+;; Main entry point — backward compatible
 (define (run-tool-batch tool-calls
                         registry
                         #:hook-dispatcher [hook-dispatcher #f]
                         #:exec-context [exec-ctx (make-exec-context)]
                         #:parallel? [parallel? #f]
                         #:strategy [strategy #f])
-  ;; R-15: Use provided strategy or current parameter
-  (define strat (or strategy (default-scheduler-strategy)))
-  ;; Resolve event publisher from exec-context (may be #f)
+  (define problem (scheduler-problem tool-calls registry strategy hook-dispatcher exec-ctx parallel?))
+  (define plan (plan-tool-batch problem))
   (define ev-pub (and exec-ctx (exec-context-event-publisher exec-ctx)))
-
-  ;; Emit batch preflight started event
-  (when ev-pub
-    (ev-pub "tool.batch.preflight.started"
-            (hasheq 'toolCount (length tool-calls) 'toolNames (map tool-call-name tool-calls))))
-
-  ;; R-15: Apply strategy phases
-  (define filtered-calls ((scheduler-strategy-preflight-filter strat) tool-calls))
-  (define ordered-calls ((scheduler-strategy-execution-order strat) filtered-calls))
-  ;; Step 1: Preflight (serial)
-  (define preflight-entries (run-preflight ordered-calls registry hook-dispatcher))
-
-  ;; Step 2: Execution (serial or parallel)
-  (define results (run-execution preflight-entries exec-ctx parallel? hook-dispatcher))
-
-  ;; Step 3: Metadata
-  (define metadata (compute-metadata results preflight-entries))
-
-  ;; Emit batch completed event
-  (when ev-pub
-    (ev-pub "tool.batch.completed" metadata))
-
-  ;; Step 4: Return ordered result
-  (scheduler-result results metadata))
+  (execute-tool-plan plan exec-ctx hook-dispatcher parallel? ev-pub))

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -10,4 +10,4 @@
 (provide q-version)
 
 (: q-version String)
-(define q-version "0.44.1")
+(define q-version "0.44.2")

--- a/wiki-src/Architecture-Overview.md
+++ b/wiki-src/Architecture-Overview.md
@@ -35,7 +35,7 @@ User input → Interface (CLI/TUI/RPC)
     → Events emitted to bus
 ```
 
-## Metrics (0.44.1)
+## Metrics (0.44.2)
 > _See `racket scripts/metrics.rkt` for current numbers._
 
 - 414 source modules, 534 test files


### PR DESCRIPTION
## v0.44.2 W0 — Scheduler Plan + Bash Params (R3, R5)

### Changes
- **S10**: Added `scheduler-problem` and `scheduler-plan` structs
- **S10**: Split `run-tool-batch` into `plan-tool-batch` (pure) + `execute-tool-plan` (effectful)
- **S11**: Added `tool-pre-hook-payload`, `tool-post-hook-payload`, `scheduler-batch-stats` typed structs
- **S12**: Added `bash-execution-config` struct with `make-bash-execution-config` constructor
- **S13**: Version bump to 0.44.2

### Metrics
- 16/16 lint checks PASS
- 0 regressions (scheduler metadata remains hasheq-compatible)

Closes #4275
Parent: #4274