### PR TITLE
fix: W0 fix broken scheduler tests + extract nested tests (S1-S3, NF1-NF2) (#4295)

### DIFF
--- a/tests/test-scheduler-hooks.rkt
+++ b/tests/test-scheduler-hooks.rkt
@@ -243,7 +243,8 @@
       (check-not-false (regexp-match? #rx"hook error" (error-text (car results)))
                        "error message mentions hook error")
       (define metadata (scheduler-result-metadata result))
-      (check-equal? (hash-ref metadata 'errors)
+      (check-pred scheduler-batch-stats? metadata)
+      (check-equal? (scheduler-batch-stats-errors metadata)
                     1
                     "metadata counts 1 error from preflight exception"))))
 

--- a/tests/test-scheduler-safe-mode.rkt
+++ b/tests/test-scheduler-safe-mode.rkt
@@ -34,7 +34,11 @@
                   run-tool-batch
                   scheduler-result
                   scheduler-result-results
-                  scheduler-result-metadata)
+                  scheduler-result-metadata
+                  scheduler-batch-stats
+                  scheduler-batch-stats?
+                  scheduler-batch-stats-total
+                  scheduler-batch-stats-blocked)
          (only-in "../util/protocol-types.rkt"
                   tool-call
                   tool-call?
@@ -362,8 +366,9 @@
     (check-true (string-contains? (result-text (fifth results)) "blocked by safe-mode"))
     ;; Check metadata
     (define meta (scheduler-result-metadata sr))
-    (check-equal? (hash-ref meta 'total) 5)
-    (check-equal? (hash-ref meta 'blocked) 3))) ;; bash + path-blocked read + edit
+    (check-pred scheduler-batch-stats? meta)
+    (check-equal? (scheduler-batch-stats-total meta) 5)
+    (check-equal? (scheduler-batch-stats-blocked meta) 3))) ;; bash + path-blocked read + edit
 
 ;; ============================================================
 ;; 8. Predicates re-exported correctly from util/safe-mode-predicates

--- a/tests/test-scheduler.rkt
+++ b/tests/test-scheduler.rkt
@@ -508,55 +508,55 @@
   (check-equal? (length (scheduler-result-results result)) 6)
   ;; Verify all succeeded
   (for ([r (in-list (scheduler-result-results result))])
-    (check-false (tool-result-is-error? r)))
+    (check-false (tool-result-is-error? r))))
 
-  ;; ============================================================
-  ;; Scheduler Plan API (v0.44.4 — F2 test coverage)
-  ;; ============================================================
+;; ============================================================
+;; Scheduler Plan API (v0.44.5 — extracted to top level)
+;; ============================================================
 
-  (test-case "scheduler-problem struct construction"
-    (define reg (make-tool-registry))
-    (register-default-tools! reg)
-    (define prob
-      (scheduler-problem (list (make-tool-call "tc-1" "read" (hasheq 'path "/tmp/test.rkt")))
-                         reg
-                         #f ;; strategy (#f = default)
-                         #f ;; hook-dispatcher
-                         #f ;; exec-context
-                         #f)) ;; parallel?
-    (check-pred scheduler-problem? prob)
-    (check-equal? (length (scheduler-problem-calls prob)) 1))
+(test-case "scheduler-problem struct construction"
+  (define reg (make-tool-registry))
+  (register-default-tools! reg)
+  (define prob
+    (scheduler-problem (list (make-tool-call "tc-1" "read" (hasheq 'path "/tmp/test.rkt")))
+                       reg
+                       #f ;; strategy (#f = default)
+                       #f ;; hook-dispatcher
+                       #f ;; exec-context
+                       #f)) ;; parallel?
+  (check-pred scheduler-problem? prob)
+  (check-equal? (length (scheduler-problem-calls prob)) 1))
 
-  (test-case "plan-tool-batch produces a scheduler-plan"
-    (define reg (make-tool-registry))
-    (register-default-tools! reg)
-    (define prob
-      (scheduler-problem (list (make-tool-call "tc-1" "read" (hasheq 'path "/tmp/test.rkt")))
-                         reg
-                         #f
-                         #f
-                         #f
-                         #f))
-    (define plan (plan-tool-batch prob))
-    (check-pred scheduler-plan? plan)
-    (check-true (>= (length (scheduler-plan-entries plan)) 1)))
+(test-case "plan-tool-batch produces a scheduler-plan"
+  (define reg (make-tool-registry))
+  (register-default-tools! reg)
+  (define prob
+    (scheduler-problem (list (make-tool-call "tc-1" "read" (hasheq 'path "/tmp/test.rkt")))
+                       reg
+                       #f
+                       #f
+                       #f
+                       #f))
+  (define plan (plan-tool-batch prob))
+  (check-pred scheduler-plan? plan)
+  (check-true (>= (length (scheduler-plan-entries plan)) 1)))
 
-  (test-case "tool-pre-hook-payload struct"
-    (define p (tool-pre-hook-payload "bash" (hasheq 'command "ls") "tc-1"))
-    (check-pred tool-pre-hook-payload? p)
-    (check-equal? (tool-pre-hook-payload-tool-name p) "bash")
-    (check-equal? (tool-pre-hook-payload-entry-id p) "tc-1"))
+(test-case "tool-pre-hook-payload struct"
+  (define p (tool-pre-hook-payload "bash" (hasheq 'command "ls") "tc-1"))
+  (check-pred tool-pre-hook-payload? p)
+  (check-equal? (tool-pre-hook-payload-tool-name p) "bash")
+  (check-equal? (tool-pre-hook-payload-entry-id p) "tc-1"))
 
-  (test-case "tool-post-hook-payload struct"
-    (define p (tool-post-hook-payload "bash" 'success "tc-1" (hasheq 'command "ls")))
-    (check-pred tool-post-hook-payload? p)
-    (check-equal? (tool-post-hook-payload-tool-name p) "bash")
-    (check-equal? (tool-post-hook-payload-result p) 'success))
+(test-case "tool-post-hook-payload struct"
+  (define p (tool-post-hook-payload "bash" 'success "tc-1" (hasheq 'command "ls")))
+  (check-pred tool-post-hook-payload? p)
+  (check-equal? (tool-post-hook-payload-tool-name p) "bash")
+  (check-equal? (tool-post-hook-payload-result p) 'success))
 
-  (test-case "scheduler-batch-stats struct"
-    (define s (scheduler-batch-stats 10 8 1 1))
-    (check-pred scheduler-batch-stats? s)
-    (check-equal? (scheduler-batch-stats-total s) 10)
-    (check-equal? (scheduler-batch-stats-executed s) 8)
-    (check-equal? (scheduler-batch-stats-blocked s) 1)
-    (check-equal? (scheduler-batch-stats-errors s) 1)))
+(test-case "scheduler-batch-stats struct"
+  (define s (scheduler-batch-stats 10 8 1 1))
+  (check-pred scheduler-batch-stats? s)
+  (check-equal? (scheduler-batch-stats-total s) 10)
+  (check-equal? (scheduler-batch-stats-executed s) 8)
+  (check-equal? (scheduler-batch-stats-blocked s) 1)
+  (check-equal? (scheduler-batch-stats-errors s) 1))


### PR DESCRIPTION
## W0: Fix broken scheduler tests + extract nested tests (S1-S3, NF1-NF2)

- **S1/NF2**: Fixed test-scheduler-safe-mode.rkt — added struct imports, replaced hash-ref with struct accessors
- **S2/NF2**: Fixed test-scheduler-hooks.rkt — replaced hash-ref with struct accessor (whole-module import already covers it)
- **S3/NF1**: Extracted 5 nested scheduler Plan API test-cases from inside F6 to top level

Closes #4295