### PR TITLE
fix: W2 bash config wiring + tests + defensive grep (S6-S8, NF3) (#4297)

### DIFF
--- a/tests/test-tool-bash-security.rkt
+++ b/tests/test-tool-bash-security.rkt
@@ -9,6 +9,7 @@
 
 (require rackunit
          (only-in "../tools/builtins/bash.rkt"
+                  tool-bash
                   destructive-command?
                   destructive-patterns
                   current-block-destructive
@@ -24,10 +25,12 @@
                   bash-execution-config-warn-on-destructive?
                   current-bash-execution-config
                   effective-bash-config)
+         (only-in "../tools/tool.rkt" tool-result-is-error? tool-result-content)
          (only-in "../runtime/safe-mode.rkt"
                   safe-mode?
                   current-safe-mode-config
-                  make-safe-mode-config))
+                  make-safe-mode-config)
+         racket/string)
 
 ;; ── SEC-01: Bypass-vector pattern tests ──
 
@@ -207,4 +210,23 @@
     (parameterize ([current-bash-execution-config custom])
       (define cfg (effective-bash-config))
       (check-eq? cfg custom)
-      (check-equal? (bash-execution-config-policy cfg) 'allow))))
+      (check-equal? (bash-execution-config-policy cfg) 'allow)))
+
+  ;; ============================================================
+  ;; v0.44.5 (NF3): Integration tests — config controls tool-bash
+  ;; ============================================================
+
+  (test-case "current-bash-execution-config overrides policy in tool-bash"
+    (parameterize ([current-bash-execution-config (make-bash-execution-config #:policy 'allowlist)])
+      (define result (tool-bash (hasheq 'command "vim README.md")))
+      (check-true (tool-result-is-error? result))
+      (define txt (hash-ref (car (tool-result-content result)) 'text ""))
+      (check-true (string-contains? txt "Blocked by execution policy"))))
+
+  (test-case "current-bash-execution-config overrides block-destructive in tool-bash"
+    (parameterize ([current-bash-execution-config (make-bash-execution-config #:policy 'warn
+                                                                              #:block? #t)])
+      (define result (tool-bash (hasheq 'command "rm -rf /tmp/test")))
+      (check-true (tool-result-is-error? result))
+      (define txt (hash-ref (car (tool-result-content result)) 'text ""))
+      (check-true (string-contains? txt "Blocked destructive")))))

--- a/tools/builtins/bash.rkt
+++ b/tools/builtins/bash.rkt
@@ -273,24 +273,34 @@
     [(not command) (make-error-result "Missing required argument: command")]
     [(not (non-empty-string? command)) (make-error-result "command must be a non-empty string")]
     [else
-     ;; SEC-13 (v0.22.0): Resolve safe-mode default at call time
+     ;; v0.44.5 (NF3): Resolve effective config (parameter or deprecated fallback)
+     (define cfg (effective-bash-config))
+     (define policy (bash-execution-config-policy cfg))
      (define block-destructive?
-       (let ([v (current-block-destructive)])
+       (let ([v (bash-execution-config-block-destructive? cfg)])
          (cond
-           [(procedure? v) (v)] ;; I-13: thunk resolver
-           [(eq? v 'safe-mode-default) (safe-mode?)] ;; backward compat
+           [(procedure? v) (v)] ;; I-13: thunk resolver (safe-mode default)
            [else v])))
+     (define warn-on-destructive? (bash-execution-config-warn-on-destructive? cfg))
+     (define warning-port (or (bash-execution-config-warning-port cfg) (current-error-port)))
      ;; Execution policy gate (RA-1a, v0.24.7)
+     (define (policy-allows? cmd)
+       (case policy
+         [(warn block) #t]
+         [(allowlist)
+          (define base (extract-base-command cmd))
+          (member base (current-allowed-commands))]
+         [else #t]))
      (cond
-       [(not (execution-policy-allows? command))
+       [(not (policy-allows? command))
         (make-error-result (format "Blocked by execution policy (allowlist mode): ~a" command))]
        ;; Block takes priority
        [(and block-destructive? (destructive-command? command))
         (make-error-result (format "Blocked destructive command: ~a" command))]
        [else
         ;; Optional warning
-        (when (and (current-warn-on-destructive) (destructive-command? command))
-          (fprintf (get-warning-port) "WARNING: Destructive command detected: ~a~n" command))
+        (when (and warn-on-destructive? (destructive-command? command))
+          (fprintf warning-port "WARNING: Destructive command detected: ~a~n" command))
         (define timeout-arg (hash-ref args 'timeout #f))
         (define raw-work-dir (hash-ref args 'working-directory #f))
         (define work-dir (and raw-work-dir (expand-home-path raw-work-dir)))


### PR DESCRIPTION
## W2: Bash config wiring + tests + defensive grep (S6-S8, NF3)

- **S6/NF3**: Wired `effective-bash-config` into `tool-bash` execution path. Replaced direct reads from deprecated parameters (`current-block-destructive`, `current-warn-on-destructive`, `current-warning-port`, `current-execution-policy`) with reads from the resolved config struct. Added local `policy-allows?` helper for config-based dispatch.
- **S7**: Added 2 integration tests proving `current-bash-execution-config` controls tool-bash behavior (allowlist policy + block-destructive).
- **S8**: Defensive grep — zero remaining `hash-ref` on scheduler metadata in codebase.

Closes #4297