### PR TITLE
feat: v0.45.0 summary injection fix + hash-ref fix (CA-01, CA-02) (#4303)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v0.45.0 — 2026-05-15
+
+### Fixed
+- CA-01: Inject summary into result messages when messages are excluded from context
+- CA-02: Replace hash-ref on context-summary struct with context-summary-entry-count accessor
+- New test: summary-injected-into-result-messages-when-excluded
+
 ## v0.44.5 — 2026-05-14
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.44.5-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.45.0-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 
@@ -199,7 +199,7 @@ racket main.rkt --model gpt-5.4 "write a test"
 ### Verify
 
 ```bash
-racket main.rkt --version  # q version 0.44.5
+racket main.rkt --version  # q version 0.45.0
 raco test tests/           # run the full test suite
 ```
 
@@ -396,7 +396,7 @@ When q executes shell commands on behalf of an LLM, arguments are quoted via `sh
 
 
 
-**v0.44.5** — Fixed
+**v0.45.0** — Fixed
 
 **v0.44.3** — Changed
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -2,7 +2,7 @@
 
 ## Version
 
-v0.44.5
+v0.45.0
 
 ## Layer Diagram
 

--- a/docs/event-taxonomy.md
+++ b/docs/event-taxonomy.md
@@ -1,6 +1,6 @@
 # Q Event Taxonomy Reference
 
-Complete reference for all event types in Q 0.44.5.
+Complete reference for all event types in Q 0.45.0.
 ## Base Types
 
 ### `event` (protocol-level)

--- a/docs/extension-guide.md
+++ b/docs/extension-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.44.5 --># Extension Development Guide
+<!-- verified-against: 0.45.0 --># Extension Development Guide
 
 This guide walks you through creating, testing, and activating a custom
 extension for q.

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.44.5 --># Getting Started
+<!-- verified-against: 0.45.0 --># Getting Started
 
 Welcome to q, a Racket-based coding agent.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.44.5 --># Installation Guide
+<!-- verified-against: 0.45.0 --># Installation Guide
 
 <!-- This file is the canonical source. The docs/getting-started/installation.md copy is maintained for the doc site build. -->
 

--- a/docs/security-trust-model.md
+++ b/docs/security-trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.44.5 --># Security & Trust Model
+<!-- verified-against: 0.45.0 --># Security & Trust Model
 
 This document provides an honest, per-area assessment of what q enforces
 today and what is planned. It is the authoritative reference for security

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -130,6 +130,6 @@ is the primary self-hosting extension:
 (load-extension! ext-reg "path/to/extension.rkt" #:event-bus bus)
 ```
 
-## Version 0.44.5
+## Version 0.45.0
 
-This documentation reflects q 0.44.5.
+This documentation reflects q 0.45.0.

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.44.5 --># q Source Style Guide
+<!-- verified-against: 0.45.0 --># q Source Style Guide
 
 This document defines formatting and naming conventions for the q Racket codebase.
 All changes to `q/` source files (excluding `tests/`) should follow these rules.

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.44.5 --># Trust Model
+<!-- verified-against: 0.45.0 --># Trust Model
 
 ## Trust Levels
 

--- a/docs/workflow-testing.md
+++ b/docs/workflow-testing.md
@@ -121,6 +121,6 @@ Use relative paths from the test file:
 4. Use `(check-true ...)` for boolean assertions
 5. Keep tests independent — no shared mutable state between test-cases
 
-## Version 0.44.5
+## Version 0.45.0
 
-This documentation reflects q 0.44.5.
+This documentation reflects q 0.45.0.

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.44.5")
+(define version "0.45.0")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base"))

--- a/runtime/context-assembly/selection.rkt
+++ b/runtime/context-assembly/selection.rkt
@@ -29,25 +29,41 @@
                   fit-messages-pair-preserving)
          (only-in "../context-pinning.rkt" partition-messages/working-set)
          (only-in "../working-set.rkt" working-set? working-set-resolve-messages)
-         "budgeting.rkt")
+         "budgeting.rkt"
+         (only-in "../context-summary.rkt"
+                  context-summary?
+                  context-summary-text
+                  context-summary-entry-count
+                  context-summary-from-id
+                  context-summary-to-id))
 
 ;; R10: Call-options struct bundling keyword args for build-assembled-context
 (struct context-assembly-call-options
-  (cache provider model-name trace-callback working-set
-   generate-summary-proc generate-catalog-proc estimate-text-proc)
+        (cache provider
+               model-name
+               trace-callback
+               working-set
+               generate-summary-proc
+               generate-catalog-proc
+               estimate-text-proc)
   #:transparent)
 
-(define (make-context-assembly-call-options
-         #:cache [cache #f]
-         #:provider [provider #f]
-         #:model-name [model-name #f]
-         #:trace-callback [trace #f]
-         #:working-set [ws #f]
-         #:generate-summary-proc [summary-proc #f]
-         #:generate-catalog-proc [catalog-proc #f]
-         #:estimate-text-proc [estimate-proc #f])
-  (context-assembly-call-options
-   cache provider model-name trace ws summary-proc catalog-proc estimate-proc))
+(define (make-context-assembly-call-options #:cache [cache #f]
+                                            #:provider [provider #f]
+                                            #:model-name [model-name #f]
+                                            #:trace-callback [trace #f]
+                                            #:working-set [ws #f]
+                                            #:generate-summary-proc [summary-proc #f]
+                                            #:generate-catalog-proc [catalog-proc #f]
+                                            #:estimate-text-proc [estimate-proc #f])
+  (context-assembly-call-options cache
+                                 provider
+                                 model-name
+                                 trace
+                                 ws
+                                 summary-proc
+                                 catalog-proc
+                                 estimate-proc))
 
 (provide (struct-out context-assembly-call-options)
          make-context-assembly-call-options
@@ -66,13 +82,17 @@
                                  #:generate-summary-proc [generate-summary-proc #f]
                                  #:generate-catalog-proc [generate-catalog-proc #f]
                                  #:estimate-text-proc [estimate-text-proc #f])
-  (build-assembled-context/v2 idx config
-    (make-context-assembly-call-options
-     #:cache cache #:provider provider #:model-name model-name
-     #:trace-callback trace #:working-set ws
-     #:generate-summary-proc generate-summary-proc
-     #:generate-catalog-proc generate-catalog-proc
-     #:estimate-text-proc estimate-text-proc)))
+  (build-assembled-context/v2 idx
+                              config
+                              (make-context-assembly-call-options
+                               #:cache cache
+                               #:provider provider
+                               #:model-name model-name
+                               #:trace-callback trace
+                               #:working-set ws
+                               #:generate-summary-proc generate-summary-proc
+                               #:generate-catalog-proc generate-catalog-proc
+                               #:estimate-text-proc estimate-text-proc)))
 
 ;; R10: Simplified v2 API taking call-options struct
 (define (build-assembled-context/v2 idx config opts)
@@ -87,15 +107,18 @@
       (begin
         (emit-trace 'empty (hash))
         (context-result '() 0 0 0 0 #f '() #f))
-      (build-assembled-context/raw raw-messages config ws
-                                   #:memo (make-hash)
-                                   #:estimate-text-proc (context-assembly-call-options-estimate-text-proc opts)
-                                   #:generate-summary-proc (context-assembly-call-options-generate-summary-proc opts)
-                                   #:generate-catalog-proc (context-assembly-call-options-generate-catalog-proc opts)
-                                   #:provider (context-assembly-call-options-provider opts)
-                                   #:model-name (context-assembly-call-options-model-name opts)
-                                   #:cache (context-assembly-call-options-cache opts)
-                                   #:trace trace)))
+      (build-assembled-context/raw
+       raw-messages
+       config
+       ws
+       #:memo (make-hash)
+       #:estimate-text-proc (context-assembly-call-options-estimate-text-proc opts)
+       #:generate-summary-proc (context-assembly-call-options-generate-summary-proc opts)
+       #:generate-catalog-proc (context-assembly-call-options-generate-catalog-proc opts)
+       #:provider (context-assembly-call-options-provider opts)
+       #:model-name (context-assembly-call-options-model-name opts)
+       #:cache (context-assembly-call-options-cache opts)
+       #:trace trace)))
 
 ;; ============================================================
 ;; build-assembled-context/raw — pure core with explicit memo
@@ -103,7 +126,9 @@
 ;; FD-02: Extracted from build-assembled-context to enable TR migration
 ;; and stage-level testing. The public API creates memo internally.
 
-(define (build-assembled-context/raw raw-messages config ws
+(define (build-assembled-context/raw raw-messages
+                                     config
+                                     ws
                                      #:memo memo
                                      #:estimate-text-proc [estimate-text-proc #f]
                                      #:generate-summary-proc [generate-summary-proc #f]
@@ -115,8 +140,7 @@
   (define (emit-trace phase data)
     (when trace
       (trace phase data)))
-  (define memo-hit-box (or (and (hash? config) (hash-ref config 'memo-hit-counter #f))
-                           (box 0)))
+  (define memo-hit-box (or (and (hash? config) (hash-ref config 'memo-hit-counter #f)) (box 0)))
   (define base-estimate (or estimate-text-proc estimate-message-tokens))
   (define (memoized-estimate msg)
     (define id (message-id msg))
@@ -138,31 +162,24 @@
     (if ws
         (map message-id ws-messages)
         '()))
-  (define-values (pinned removable)
-    (partition-messages/working-set raw-messages ws-message-ids))
+  (define-values (pinned removable) (partition-messages/working-set raw-messages ws-message-ids))
   (define pinned-tokens (for/sum ([m (in-list pinned)]) (memoized-estimate m)))
   (define pinned-count (length pinned))
   (define removable-count (length removable))
-  (emit-trace 'phase1-pinned
-              (hash 'pinned-count
-                    pinned-count
-                    'removable-count
-                    removable-count
-                    'pinned-tokens
-                    pinned-tokens))
+  (emit-trace
+   'phase1-pinned
+   (hash 'pinned-count pinned-count 'removable-count removable-count 'pinned-tokens pinned-tokens))
 
   (define remaining-budget (- max-tokens pinned-tokens))
   (define-values (recent excluded)
     (if (<= remaining-budget 0)
         (values '() removable)
         (let ()
-          (define kept
-            (fit-messages-pair-preserving removable remaining-budget memoized-estimate))
+          (define kept (fit-messages-pair-preserving removable remaining-budget memoized-estimate))
           (define kept-ids
             (for/hash ([m (in-list kept)])
               (values (message-id m) #t)))
-          (define exc
-            (filter (lambda (m) (not (hash-has-key? kept-ids (message-id m)))) removable))
+          (define exc (filter (lambda (m) (not (hash-has-key? kept-ids (message-id m)))) removable))
           (values kept exc))))
   (define recent-count (length recent))
   (define excluded-count (length excluded))
@@ -181,9 +198,24 @@
               (hash 'has-summary?
                     (and summary-obj #t)
                     'entry-count
-                    (and summary-obj ((hash-ref summary-obj 'entry-count (lambda () 0))))))
+                    (and summary-obj (context-summary-entry-count summary-obj))))
 
-  (define summary-msg #f) ;; Summary msg construction delegated to caller
+  ;; CA-01 FIX: Convert summary to a pinned user message so it survives budget fitting
+  (define summary-msg
+    (and summary-obj
+         (let* ([summary-text (context-summary-text summary-obj)]
+                [summary-tokens (base-estimate summary-text)])
+           ;; Only inject if summary doesn't exceed 10% of budget
+           (and (<= summary-tokens (* 0.1 max-tokens))
+                (make-message (format "ctx-summary-~a-~a"
+                                      (context-summary-from-id summary-obj)
+                                      (context-summary-to-id summary-obj))
+                              #f
+                              'user
+                              'context-assembly-summary
+                              (list (make-text-part summary-text))
+                              (current-seconds)
+                              (hasheq 'pinned #t 'context-summary #t))))))
   ;; Phase 4: Generate catalog
   (define catalog
     (if generate-catalog-proc
@@ -209,7 +241,11 @@
       m))
 
   (define result-with-pin (ensure-first-user-pinned result-messages raw-messages))
-  (define total-tokens (for/sum ([m (in-list result-with-pin)]) (memoized-estimate m)))
+  (define result-with-pin-and-summary
+    (if summary-msg
+        (cons summary-msg result-with-pin)
+        result-with-pin))
+  (define total-tokens (for/sum ([m (in-list result-with-pin-and-summary)]) (memoized-estimate m)))
   (define over-budget? (> total-tokens max-tokens))
 
   (emit-trace 'done
@@ -218,7 +254,7 @@
                     'over-budget?
                     over-budget?
                     'result-count
-                    (length result-with-pin)
+                    (length result-with-pin-and-summary)
                     'pinned-count
                     pinned-count
                     'recent-count
@@ -227,7 +263,7 @@
                     excluded-count
                     'memo-hits
                     (unbox memo-hit-box)))
-  (context-result result-with-pin
+  (context-result result-with-pin-and-summary
                   total-tokens
                   pinned-count
                   recent-count

--- a/tests/test-context-assembly-raw.rkt
+++ b/tests/test-context-assembly-raw.rkt
@@ -8,10 +8,13 @@
 
 (require rackunit
          rackunit/text-ui
+         racket/string
          "../runtime/context-assembly/selection.rkt"
          "../runtime/context-assembly/budgeting.rkt"
+         "../runtime/context-summary.rkt"
          "../util/message.rkt"
-         "../util/content-parts.rkt")
+         "../util/content-parts.rkt"
+         (only-in "../util/content-parts.rkt" text-part? text-part-text))
 
 (define (make-test-msg text [id "msg-1"] [role 'user])
   (make-message id #f role 'text (list (make-text-part text)) 0 #f))
@@ -71,7 +74,43 @@
       (define msgs (list (make-test-msg "test" "msg-1")))
       (define result (build-assembled-context/raw msgs config #f #:memo memo #:trace trace-fn))
       (check-not-false result)
-      (check-true (> (length trace-events) 0) "trace should have received events"))))
+      (check-true (> (length trace-events) 0) "trace should have received events"))
+
+    ;; CA-01: Summary injection test
+    (test-case "summary-injected-into-result-messages-when-excluded"
+      ;; Build messages that exceed a tight budget, forcing exclusion + summary
+      (define messages
+        (for/list ([i (in-range 20)])
+          (make-test-msg
+           (format "Message ~a with enough text to consume tokens: ~a" i (make-string 200 #\x))
+           (format "msg-~a" i))))
+      (define budget 500) ;; tight budget → most messages excluded
+      (define cfg (make-context-assembly-config #:recent-tokens budget))
+      (define result
+        (build-assembled-context/raw
+         messages
+         cfg
+         #f
+         #:memo (make-hash)
+         #:generate-summary-proc
+         (λ (excluded provider model-name cache)
+           (context-summary "from-0"
+                            "to-19"
+                            "## Summary of excluded messages\nKey fact: important info here"
+                            (length excluded)))))
+      ;; The summary must be generated
+      (define summary-obj (context-result-summary result))
+      (check-not-false summary-obj "summary should be generated when messages excluded")
+      ;; KEY CHECK: summary text must appear in the assembled messages sent to LLM
+      (when summary-obj
+        (define result-msgs (context-result-messages result))
+        (define all-text
+          (string-join (for*/list ([m (in-list result-msgs)]
+                                   [part (in-list (message-content m))]
+                                   #:when (text-part? part))
+                         (text-part-text part))))
+        (check-true (string-contains? all-text (context-summary-text summary-obj))
+                    "summary text must be present in assembled context")))))
 
 (module+ main
   (run-tests raw-assembly-tests))

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -10,4 +10,4 @@
 (provide q-version)
 
 (: q-version String)
-(define q-version "0.44.5")
+(define q-version "0.45.0")

--- a/wiki-src/Architecture-Overview.md
+++ b/wiki-src/Architecture-Overview.md
@@ -35,7 +35,7 @@ User input → Interface (CLI/TUI/RPC)
     → Events emitted to bus
 ```
 
-## Metrics (0.44.5)
+## Metrics (0.45.0)
 > _See `racket scripts/metrics.rkt` for current numbers._
 
 - 414 source modules, 534 test files


### PR DESCRIPTION
## v0.45.0 — Summary Injection Fix (CA-01, CA-02)

- **S1**: Added test `summary-injected-into-result-messages-when-excluded` in test-context-assembly-raw.rkt
- **S2 (CA-02)**: Replaced `hash-ref` on context-summary struct with `context-summary-entry-count` accessor in selection.rkt
- **S3 (CA-01)**: Replaced `summary-msg #f` with actual injection logic — converts summary to pinned user message, capped at 10% of budget
- **S4**: Version bumped to 0.45.0, CHANGELOG entry added

Closes #4303