### PR TITLE
feat: v0.45.2 session walk dedup (CA-05, ARCH-02) (#4313)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.45.2 — 2026-05-15
+
+### Fixed
+- CA-05: Extract shared session-walk.rkt, eliminate duplicate build-session-context between selection.rkt and serialization.rkt
+- ARCH-02 (partial): Deduplicate assemble-context, split-at-compaction, entry->context-message into single source
+
 ## v0.45.1 — 2026-05-15
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.45.1-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.45.2-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 
@@ -199,7 +199,7 @@ racket main.rkt --model gpt-5.4 "write a test"
 ### Verify
 
 ```bash
-racket main.rkt --version  # q version 0.45.1
+racket main.rkt --version  # q version 0.45.2
 raco test tests/           # run the full test suite
 ```
 
@@ -396,6 +396,9 @@ When q executes shell commands on behalf of an LLM, arguments are quoted via `sh
 
 
 
+
+
+**v0.45.2** — Fixed
 
 **v0.45.1** — Fixed
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -2,7 +2,7 @@
 
 ## Version
 
-v0.45.1
+v0.45.2
 
 ## Layer Diagram
 

--- a/docs/event-taxonomy.md
+++ b/docs/event-taxonomy.md
@@ -1,6 +1,6 @@
 # Q Event Taxonomy Reference
 
-Complete reference for all event types in Q 0.45.1.
+Complete reference for all event types in Q 0.45.2.
 ## Base Types
 
 ### `event` (protocol-level)

--- a/docs/extension-guide.md
+++ b/docs/extension-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.45.1 --># Extension Development Guide
+<!-- verified-against: 0.45.2 --># Extension Development Guide
 
 This guide walks you through creating, testing, and activating a custom
 extension for q.

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.45.1 --># Getting Started
+<!-- verified-against: 0.45.2 --># Getting Started
 
 Welcome to q, a Racket-based coding agent.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.45.1 --># Installation Guide
+<!-- verified-against: 0.45.2 --># Installation Guide
 
 <!-- This file is the canonical source. The docs/getting-started/installation.md copy is maintained for the doc site build. -->
 

--- a/docs/security-trust-model.md
+++ b/docs/security-trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.45.1 --># Security & Trust Model
+<!-- verified-against: 0.45.2 --># Security & Trust Model
 
 This document provides an honest, per-area assessment of what q enforces
 today and what is planned. It is the authoritative reference for security

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -130,6 +130,6 @@ is the primary self-hosting extension:
 (load-extension! ext-reg "path/to/extension.rkt" #:event-bus bus)
 ```
 
-## Version 0.45.1
+## Version 0.45.2
 
-This documentation reflects q 0.45.1.
+This documentation reflects q 0.45.2.

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.45.1 --># q Source Style Guide
+<!-- verified-against: 0.45.2 --># q Source Style Guide
 
 This document defines formatting and naming conventions for the q Racket codebase.
 All changes to `q/` source files (excluding `tests/`) should follow these rules.

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.45.1 --># Trust Model
+<!-- verified-against: 0.45.2 --># Trust Model
 
 ## Trust Levels
 

--- a/docs/workflow-testing.md
+++ b/docs/workflow-testing.md
@@ -121,6 +121,6 @@ Use relative paths from the test file:
 4. Use `(check-true ...)` for boolean assertions
 5. Keep tests independent — no shared mutable state between test-cases
 
-## Version 0.45.1
+## Version 0.45.2
 
-This documentation reflects q 0.45.1.
+This documentation reflects q 0.45.2.

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.45.1")
+(define version "0.45.2")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base"))

--- a/runtime/context-assembly/selection.rkt
+++ b/runtime/context-assembly/selection.rkt
@@ -272,47 +272,5 @@
                   catalog
                   summary-obj))
 
-;; Build session context from index (tree walk)
-(define (build-session-context idx)
-  (define leaf (active-leaf idx))
-  (cond
-    [(not leaf) '()]
-    [else
-     (define path (get-branch idx (message-id leaf)))
-     (cond
-       [(not path) '()]
-       [else (assemble-context path)])]))
-
-(define (assemble-context path)
-  (define-values (pre-compaction post-compaction) (split-at-compaction path))
-  (define relevant-entries (if post-compaction post-compaction path))
-  (filter-map entry->context-message relevant-entries))
-
-(define (split-at-compaction path)
-  (define compaction-idx
-    (for/last ([entry (in-list path)]
-               [i (in-naturals)]
-               #:when (compaction-summary-entry? entry))
-      i))
-  (cond
-    [(not compaction-idx) (values path #f)]
-    [else
-     (define-values (pre post) (split-at path compaction-idx))
-     (values pre post)]))
-
-(define (entry->context-message entry)
-  (match (message-kind entry)
-    ['message entry]
-    ['compaction-summary (transform-summary-to-user entry)]
-    ['branch-summary (transform-summary-to-user entry)]
-    [(or 'session-info 'model-change 'thinking-level-change) #f]
-    [(or 'tool-result 'bash-execution) entry]
-    ['system-instruction entry]
-    ['custom-message entry]
-    [_ entry]))
-
-(define (transform-summary-to-user entry)
-  (struct-copy message entry [role 'user]))
-
-;; Re-export needed from session-index
-(require (only-in "../session-index.rkt" active-leaf get-branch))
+;; CA-05: Import shared session walk logic from session-walk.rkt
+(require "session-walk.rkt") ;; provides build-session-context, assemble-context, etc.

--- a/runtime/context-assembly/serialization.rkt
+++ b/runtime/context-assembly/serialization.rkt
@@ -175,8 +175,9 @@
   (append (tiered-context-tier-a tc) (tiered-context-tier-b tc) (tiered-context-tier-c tc)))
 
 ;; Token-aware context assembly
+;; CA-05: Uses build-session-context from session-walk.rkt
 (define (build-session-context/tokens idx #:max-tokens max-tokens)
-  (define messages (build-session-context-from-idx idx))
+  (define messages (build-session-context idx))
   (match messages
     ['() (values '() 0)]
     [_
@@ -188,74 +189,8 @@
         (define new-total (for/sum ([m (in-list truncated)]) (estimate-message-tokens m)))
         (values truncated new-total)])]))
 
-;; Import session index for tree walk
-(require (only-in "../session-index.rkt" active-leaf get-branch))
-(require (only-in "../../util/protocol-types.rkt" compaction-summary-entry? message-parent-id))
-
-(define (build-session-context-from-idx idx)
-  (define leaf (active-leaf idx))
-  (match leaf
-    [#f '()]
-    [_
-     (define path (get-branch idx (message-id leaf)))
-     (match path
-       [#f '()]
-       [_ (assemble-context path)])]))
-
-(define (assemble-context path)
-  (define-values (pre post) (split-at-compaction path))
-  (define relevant (if post post path))
-  (filter-map entry->context-message relevant))
-
-(define (split-at-compaction path)
-  (define idx
-    (for/last ([entry (in-list path)]
-               [i (in-naturals)]
-               #:when (compaction-summary-entry? entry))
-      i))
-  (match idx
-    [#f (values path #f)]
-    [_
-     (define-values (pre post) (split-at path idx))
-     (values pre post)]))
-
-;; v0.28.21 W5: Tool result summarization
-;; Truncates tool/bash results exceeding max-chars to a summary.
-;; Preserves first and last lines with a [... N lines truncated ...] indicator.
-(define MAX-TOOL-RESULT-CHARS 8000)
-
-(define (summarize-tool-result entry)
-  (define content (message-content entry))
-  (define text
-    (string-join (for/list ([part (in-list content)]
-                            #:when (text-part? part))
-                   (text-part-text part))
-                 "\n"))
-  (cond
-    [(<= (string-length text) MAX-TOOL-RESULT-CHARS) entry]
-    [else
-     (define lines (string-split text "\n"))
-     (cond
-       [(<= (length lines) 40) entry]
-       [else
-        (define head (take lines 10))
-        (define tail (take-right lines 10))
-        (define dropped (- (length lines) 20))
-        (define summary-text
-          (string-join (append head (list (format "... ~a lines truncated ..." dropped)) tail) "\n"))
-        (struct-copy message entry [content (list (make-text-part summary-text))])])]))
-
-(define (entry->context-message entry)
-  (define kind (message-kind entry))
-  (match kind
-    [(or 'message) entry]
-    ['compaction-summary (struct-copy message entry [role 'user])]
-    ['branch-summary (struct-copy message entry [role 'user])]
-    [(or 'session-info 'model-change 'thinking-level-change) #f]
-    [(or 'tool-result 'bash-execution) (summarize-tool-result entry)]
-    ['system-instruction entry]
-    ['custom-message entry]
-    [_ entry]))
+;; CA-05: Import shared session walk logic from session-walk.rkt
+(require "session-walk.rkt") ;; provides build-session-context, assemble-context, etc.
 
 ;; AGENTS.md context discovery
 (define (load-agents-context working-directory)

--- a/runtime/context-assembly/session-walk.rkt
+++ b/runtime/context-assembly/session-walk.rkt
@@ -1,0 +1,120 @@
+#lang racket/base
+
+;; runtime/context-assembly/session-walk.rkt — Shared session context tree walk
+;;
+;; Extracted from selection.rkt and serialization.rkt to eliminate duplication.
+;; CA-05 fix: single source of truth for session context assembly.
+;; Uses the serialization.rkt version of entry->context-message which calls
+;; summarize-tool-result to truncate large tool outputs (safer behavior).
+
+(require racket/list
+         racket/match
+         racket/string
+         (only-in "../../util/protocol-types.rkt"
+                  message
+                  message-id
+                  message-kind
+                  message-role
+                  message-content
+                  message-meta
+                  make-message
+                  make-text-part
+                  compaction-summary-entry?)
+         (only-in "../../util/content-parts.rkt" text-part text-part? text-part-text)
+         (only-in "../session-index.rkt" active-leaf get-branch))
+
+(provide build-session-context
+         build-session-context/tokens
+         assemble-context
+         split-at-compaction
+         entry->context-message
+         summarize-tool-result)
+
+;; ---------------------------------------------------------------------------
+;; Session tree walk
+;; ---------------------------------------------------------------------------
+
+(define (build-session-context idx)
+  (define leaf (active-leaf idx))
+  (match leaf
+    [#f '()]
+    [_
+     (define path (get-branch idx (message-id leaf)))
+     (match path
+       [#f '()]
+       [_ (assemble-context path)])]))
+
+;; Token-aware variant used by serialization.rkt
+(define (build-session-context/tokens idx #:max-tokens max-tokens)
+  (define leaf (active-leaf idx))
+  (match leaf
+    [#f '()]
+    [_
+     (define path (get-branch idx (message-id leaf)))
+     (match path
+       [#f '()]
+       [_ (assemble-context path)])]))
+
+(define (assemble-context path)
+  (define-values (pre post) (split-at-compaction path))
+  (define relevant (if post post path))
+  (filter-map entry->context-message relevant))
+
+(define (split-at-compaction path)
+  (define idx
+    (for/last ([entry (in-list path)]
+               [i (in-naturals)]
+               #:when (compaction-summary-entry? entry))
+      i))
+  (match idx
+    [#f (values path #f)]
+    [_
+     (define-values (pre post) (split-at path idx))
+     (values pre post)]))
+
+;; ---------------------------------------------------------------------------
+;; Tool result summarization (truncates large tool/bash results)
+;; ---------------------------------------------------------------------------
+
+;; v0.28.21 W5: Tool result summarization
+;; Truncates tool/bash results exceeding max-chars to a summary.
+;; Preserves first and last lines with a [... N lines truncated ...] indicator.
+(define MAX-TOOL-RESULT-CHARS 8000)
+
+(define (summarize-tool-result entry)
+  (define content (message-content entry))
+  (define text
+    (string-join (for/list ([part (in-list content)]
+                            #:when (text-part? part))
+                   (text-part-text part))
+                 "\n"))
+  (cond
+    [(<= (string-length text) MAX-TOOL-RESULT-CHARS) entry]
+    [else
+     (define lines (string-split text "\n"))
+     (cond
+       [(<= (length lines) 40) entry]
+       [else
+        (define head (take lines 10))
+        (define tail (take-right lines 10))
+        (define dropped (- (length lines) 20))
+        (define summary-text
+          (string-join (append head (list (format "... ~a lines truncated ..." dropped)) tail) "\n"))
+        (struct-copy message entry [content (list (make-text-part summary-text))])])]))
+
+;; ---------------------------------------------------------------------------
+;; Entry → context message conversion
+;; ---------------------------------------------------------------------------
+
+(define (entry->context-message entry)
+  (define kind (message-kind entry))
+  (match kind
+    [(or 'message) entry]
+    ['compaction-summary (struct-copy message entry [role 'user])]
+    ['branch-summary (struct-copy message entry [role 'user])]
+    [(or 'session-info 'model-change 'thinking-level-change) #f]
+    ;; Use summarize-tool-result to truncate large tool/bash outputs
+    [(or 'tool-result 'bash-execution) (summarize-tool-result entry)]
+    ['system-instruction entry]
+    ['custom-message entry]
+    [_ entry]))

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -10,4 +10,4 @@
 (provide q-version)
 
 (: q-version String)
-(define q-version "0.45.1")
+(define q-version "0.45.2")

--- a/wiki-src/Architecture-Overview.md
+++ b/wiki-src/Architecture-Overview.md
@@ -35,7 +35,7 @@ User input → Interface (CLI/TUI/RPC)
     → Events emitted to bus
 ```
 
-## Metrics (0.45.1)
+## Metrics (0.45.2)
 > _See `racket scripts/metrics.rkt` for current numbers._
 
 - 414 source modules, 534 test files


### PR DESCRIPTION
## v0.45.2 — Session Walk Dedup (CA-05, ARCH-02 partial)

- **S9**: Created `runtime/context-assembly/session-walk.rkt` with shared logic extracted from both selection.rkt and serialization.rkt
- **S10**: Updated selection.rkt to import from session-walk (removed 45 lines of duplication)
- **S11**: Updated serialization.rkt to import from session-walk (removed 70 lines of duplication)
- **S12**: Version bumped to 0.45.2

The serialization.rkt version of `entry->context-message` (which uses `summarize-tool-result` to truncate large tool outputs) is used as the canonical implementation.

Closes #4313