### PR TITLE
feat: v0.45.3 assembly path unification + trace (ARCH-01, OBS-01) (#4321)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.45.3 — 2026-05-15
+
+### Fixed
+- ARCH-01: Added optional #:trace callback to build-tiered-context for observability (OBS-01 partial)
+- CA-05: Deprecated build-assembled-context/raw with warn-deprecated! pointing to tiered path
+
 ## v0.45.2 — 2026-05-15
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.45.2-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.45.3-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 
@@ -199,7 +199,7 @@ racket main.rkt --model gpt-5.4 "write a test"
 ### Verify
 
 ```bash
-racket main.rkt --version  # q version 0.45.2
+racket main.rkt --version  # q version 0.45.3
 raco test tests/           # run the full test suite
 ```
 
@@ -397,6 +397,9 @@ When q executes shell commands on behalf of an LLM, arguments are quoted via `sh
 
 
 
+
+
+**v0.45.3** — Fixed
 
 **v0.45.2** — Fixed
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -2,7 +2,7 @@
 
 ## Version
 
-v0.45.2
+v0.45.3
 
 ## Layer Diagram
 

--- a/docs/event-taxonomy.md
+++ b/docs/event-taxonomy.md
@@ -1,6 +1,6 @@
 # Q Event Taxonomy Reference
 
-Complete reference for all event types in Q 0.45.2.
+Complete reference for all event types in Q 0.45.3.
 ## Base Types
 
 ### `event` (protocol-level)

--- a/docs/extension-guide.md
+++ b/docs/extension-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.45.2 --># Extension Development Guide
+<!-- verified-against: 0.45.3 --># Extension Development Guide
 
 This guide walks you through creating, testing, and activating a custom
 extension for q.

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.45.2 --># Getting Started
+<!-- verified-against: 0.45.3 --># Getting Started
 
 Welcome to q, a Racket-based coding agent.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.45.2 --># Installation Guide
+<!-- verified-against: 0.45.3 --># Installation Guide
 
 <!-- This file is the canonical source. The docs/getting-started/installation.md copy is maintained for the doc site build. -->
 

--- a/docs/security-trust-model.md
+++ b/docs/security-trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.45.2 --># Security & Trust Model
+<!-- verified-against: 0.45.3 --># Security & Trust Model
 
 This document provides an honest, per-area assessment of what q enforces
 today and what is planned. It is the authoritative reference for security

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -130,6 +130,6 @@ is the primary self-hosting extension:
 (load-extension! ext-reg "path/to/extension.rkt" #:event-bus bus)
 ```
 
-## Version 0.45.2
+## Version 0.45.3
 
-This documentation reflects q 0.45.2.
+This documentation reflects q 0.45.3.

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.45.2 --># q Source Style Guide
+<!-- verified-against: 0.45.3 --># q Source Style Guide
 
 This document defines formatting and naming conventions for the q Racket codebase.
 All changes to `q/` source files (excluding `tests/`) should follow these rules.

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.45.2 --># Trust Model
+<!-- verified-against: 0.45.3 --># Trust Model
 
 ## Trust Levels
 

--- a/docs/workflow-testing.md
+++ b/docs/workflow-testing.md
@@ -121,6 +121,6 @@ Use relative paths from the test file:
 4. Use `(check-true ...)` for boolean assertions
 5. Keep tests independent — no shared mutable state between test-cases
 
-## Version 0.45.2
+## Version 0.45.3
 
-This documentation reflects q 0.45.2.
+This documentation reflects q 0.45.3.

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.45.2")
+(define version "0.45.3")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base"))

--- a/runtime/context-assembly/selection.rkt
+++ b/runtime/context-assembly/selection.rkt
@@ -35,7 +35,8 @@
                   context-summary-text
                   context-summary-entry-count
                   context-summary-from-id
-                  context-summary-to-id))
+                  context-summary-to-id)
+         (only-in "../../util/errors.rkt" warn-deprecated!))
 
 ;; R10: Call-options struct bundling keyword args for build-assembled-context
 (struct context-assembly-call-options
@@ -137,6 +138,9 @@
                                      #:model-name [model-name #f]
                                      #:cache [cache #f]
                                      #:trace [trace #f])
+  (warn-deprecated! 'build-assembled-context/raw
+                    "v0.47.0"
+                    "Use build-tiered-context from context-assembly/serialization.rkt")
   (define (emit-trace phase data)
     (when trace
       (trace phase data)))

--- a/runtime/context-assembly/serialization.rkt
+++ b/runtime/context-assembly/serialization.rkt
@@ -97,7 +97,10 @@
 (define (build-tiered-context messages
                               #:tier-b-count [tier-b-count #f]
                               #:tier-c-count [tier-c-count DEFAULT-TIER-C-COUNT]
-                              #:working-set-messages [ws-messages '()])
+                              #:working-set-messages [ws-messages '()]
+                              #:trace [trace-cb #f])
+  (when trace-cb
+    (trace-cb 'start (hasheq 'total (length messages))))
   (define-values (compaction-summaries regular-msgs)
     (partition (lambda (m) (eq? (message-kind m) 'compaction-summary)) messages))
   (define-values (gsd-pinned regular) (partition gsd-progress-message? regular-msgs))
@@ -131,9 +134,18 @@
     (if (> tier-b-size 0)
         (take-right remaining-after-c tier-b-size)
         '()))
-  (tiered-context (append sys-protected pinned-user gsd-pinned compaction-summaries ws-messages)
-                  tier-b
-                  tier-c))
+  (define tier-a (append sys-protected pinned-user gsd-pinned compaction-summaries ws-messages))
+  (when trace-cb
+    (trace-cb 'partition
+              (hasheq 'tier-a
+                      (length tier-a)
+                      'tier-b
+                      (length tier-b)
+                      'tier-c
+                      (length tier-c)
+                      'gsd-pinned
+                      (length gsd-pinned))))
+  (tiered-context tier-a tier-b tier-c))
 
 (define (build-tiered-context-with-hooks messages
                                          #:hook-dispatcher [hook-dispatcher #f]

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -10,4 +10,4 @@
 (provide q-version)
 
 (: q-version String)
-(define q-version "0.45.2")
+(define q-version "0.45.3")

--- a/wiki-src/Architecture-Overview.md
+++ b/wiki-src/Architecture-Overview.md
@@ -35,7 +35,7 @@ User input → Interface (CLI/TUI/RPC)
     → Events emitted to bus
 ```
 
-## Metrics (0.45.2)
+## Metrics (0.45.3)
 > _See `racket scripts/metrics.rkt` for current numbers._
 
 - 414 source modules, 534 test files


### PR DESCRIPTION
## v0.45.3 — Assembly Path Unification (ARCH-01, CA-05, OBS-01 partial)

- **S13**: Added optional `#:trace` callback to `build-tiered-context` for observability
- **S15**: Deprecated `build-assembled-context/raw` with `warn-deprecated!` pointing to tiered path
- **S16**: Version bumped to 0.45.3

Closes #4321