### PR TITLE
feat: v0.45.4 summary quality gates (SAL-04, CA-04, TEST-02) (#4326)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v0.45.4 — 2026-05-15
+
+### Fixed
+- SAL-04: Added entity extraction utility (summary-entities.rkt) and quality gate in llm-summarize
+- CA-04: Expanded simple-summary-text from 20×100 to 30×200 with file path extraction
+- TEST-02: Added 9 tests for summary quality gates (test-summary-quality.rkt)
+
 ## v0.45.3 — 2026-05-15
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.45.3-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.45.4-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 
@@ -199,7 +199,7 @@ racket main.rkt --model gpt-5.4 "write a test"
 ### Verify
 
 ```bash
-racket main.rkt --version  # q version 0.45.3
+racket main.rkt --version  # q version 0.45.4
 raco test tests/           # run the full test suite
 ```
 
@@ -398,6 +398,9 @@ When q executes shell commands on behalf of an LLM, arguments are quoted via `sh
 
 
 
+
+
+**v0.45.4** — Fixed
 
 **v0.45.3** — Fixed
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -2,7 +2,7 @@
 
 ## Version
 
-v0.45.3
+v0.45.4
 
 ## Layer Diagram
 

--- a/docs/event-taxonomy.md
+++ b/docs/event-taxonomy.md
@@ -1,6 +1,6 @@
 # Q Event Taxonomy Reference
 
-Complete reference for all event types in Q 0.45.3.
+Complete reference for all event types in Q 0.45.4.
 ## Base Types
 
 ### `event` (protocol-level)

--- a/docs/extension-guide.md
+++ b/docs/extension-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.45.3 --># Extension Development Guide
+<!-- verified-against: 0.45.4 --># Extension Development Guide
 
 This guide walks you through creating, testing, and activating a custom
 extension for q.

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.45.3 --># Getting Started
+<!-- verified-against: 0.45.4 --># Getting Started
 
 Welcome to q, a Racket-based coding agent.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.45.3 --># Installation Guide
+<!-- verified-against: 0.45.4 --># Installation Guide
 
 <!-- This file is the canonical source. The docs/getting-started/installation.md copy is maintained for the doc site build. -->
 

--- a/docs/security-trust-model.md
+++ b/docs/security-trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.45.3 --># Security & Trust Model
+<!-- verified-against: 0.45.4 --># Security & Trust Model
 
 This document provides an honest, per-area assessment of what q enforces
 today and what is planned. It is the authoritative reference for security

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -130,6 +130,6 @@ is the primary self-hosting extension:
 (load-extension! ext-reg "path/to/extension.rkt" #:event-bus bus)
 ```
 
-## Version 0.45.3
+## Version 0.45.4
 
-This documentation reflects q 0.45.3.
+This documentation reflects q 0.45.4.

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.45.3 --># q Source Style Guide
+<!-- verified-against: 0.45.4 --># q Source Style Guide
 
 This document defines formatting and naming conventions for the q Racket codebase.
 All changes to `q/` source files (excluding `tests/`) should follow these rules.

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.45.3 --># Trust Model
+<!-- verified-against: 0.45.4 --># Trust Model
 
 ## Trust Levels
 

--- a/docs/workflow-testing.md
+++ b/docs/workflow-testing.md
@@ -121,6 +121,6 @@ Use relative paths from the test file:
 4. Use `(check-true ...)` for boolean assertions
 5. Keep tests independent — no shared mutable state between test-cases
 
-## Version 0.45.3
+## Version 0.45.4
 
-This documentation reflects q 0.45.3.
+This documentation reflects q 0.45.4.

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.45.3")
+(define version "0.45.4")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base"))

--- a/runtime/compactor-llm-bridge.rkt
+++ b/runtime/compactor-llm-bridge.rkt
@@ -13,7 +13,11 @@
          (only-in "compaction-prompts.rkt"
                   summary-prompt
                   iterative-update-prompt
-                  format-messages-for-summary))
+                  format-messages-for-summary)
+         (only-in "context-assembly/summary-entities.rkt"
+                  extract-key-entities
+                  check-entity-preservation
+                  entity-preservation-appendix))
 
 (provide (contract-out [llm-summarize
                         (->* (list? any/c any/c)
@@ -42,12 +46,25 @@
   (define resp (provider-send provider req))
   ;; Extract text from response content
   (define content (model-response-content resp))
-  (string-join (for/list ([part (in-list content)])
-                 (cond
-                   [(hash? part) (hash-ref part 'text "")]
-                   [(string? part) part]
-                   [else (format "~a" part)]))
-               ""))
+  (define raw-summary
+    (string-join (for/list ([part (in-list content)])
+                   (cond
+                     [(hash? part) (hash-ref part 'text "")]
+                     [(string? part) part]
+                     [else (format "~a" part)]))
+                 ""))
+  ;; SAL-04 quality gate: check entity preservation
+  (define entities (extract-key-entities messages))
+  (define missing (check-entity-preservation entities raw-summary))
+  (define final-summary
+    (if (null? missing)
+        raw-summary
+        (string-append raw-summary (entity-preservation-appendix missing))))
+  ;; Reject empty or too-short summaries
+  (when (< (string-length final-summary) 50)
+    (log-warning (format "context-summary: LLM summary too short (~a chars)"
+                         (string-length final-summary))))
+  final-summary)
 
 ;; Create a summarize function suitable for use with compact-history.
 ;; The returned function has signature: (listof message?) -> string

--- a/runtime/context-assembly/summary-entities.rkt
+++ b/runtime/context-assembly/summary-entities.rkt
@@ -1,0 +1,52 @@
+#lang racket/base
+
+;; runtime/context-assembly/summary-entities.rkt — Entity extraction for summary validation
+;;
+;; SAL-04 fix: Extracts key entities (file paths, function/module names) from
+;; messages so summaries can be checked for entity preservation.
+
+(require racket/string
+         racket/list
+         (only-in "../../util/message.rkt" message-content)
+         (only-in "../../util/content-parts.rkt" text-part? text-part-text))
+
+(provide extract-key-entities
+         check-entity-preservation
+         entity-preservation-appendix)
+
+;; File path patterns: /path/to/file.rkt, ./relative/path.rkt, src/file.rkt
+(define FILE-PATH-RE
+  (regexp (string-append "[/\\.]?" "[a-zA-Z0-9_./-]+" "\\.(rkt|rktl|scrbl|md|json|py)")))
+
+;; Function/module name patterns: define-xxx, struct xxx
+(define DEFINITION-RE (regexp (string-append "(define|defstruct|struct)" " [-a-zA-Z0-9_(]+")))
+
+;; Extract top entities from a list of messages
+(define (extract-key-entities messages [max-entities 20])
+  (define all-text
+    (string-join (for*/list ([m (in-list messages)]
+                             [part (in-list (message-content m))]
+                             #:when (text-part? part))
+                   (text-part-text part))))
+  (define file-paths (remove-duplicates (regexp-match* FILE-PATH-RE all-text) string=?))
+  (define definitions (remove-duplicates (regexp-match* DEFINITION-RE all-text) string=?))
+  (append (take-at-most file-paths (quotient max-entities 2))
+          (take-at-most definitions (quotient max-entities 2))))
+
+(define (take-at-most lst n)
+  (take lst (min n (length lst))))
+
+;; Check which entities are preserved in summary text
+(define (check-entity-preservation entities summary-text)
+  (for/list ([e (in-list entities)]
+             #:when (not (string-contains? summary-text e)))
+    e))
+
+;; Generate appendix text for missing entities
+(define (entity-preservation-appendix missing-entities)
+  (if (null? missing-entities)
+      ""
+      (string-append "\n\n## Key Entities Referenced (auto-appended)\n"
+                     (string-join (for/list ([e (in-list missing-entities)])
+                                    (format "- ~a" e))
+                                  "\n"))))

--- a/runtime/context-summary.rkt
+++ b/runtime/context-summary.rkt
@@ -238,20 +238,33 @@
         (context-summary from-id to-id summary-text actual-count)]
        [_ (context-summary from-id to-id cached (length entries))])]))
 
+;; CA-04 fix: expanded from 20×100 to 30×200 with file path extraction
+(define FILE-IN-TEXT-RE
+  (regexp (string-append "[a-zA-Z0-9_./-]+" "\\.[a-zA-Z][a-zA-Z][a-zA-Z]?[a-zA-Z]?")))
+
 (define (simple-summary-text entries)
-  (string-append "## Progress\n### Done\n"
+  (string-append "## Progress Summary (fallback — LLM summarization unavailable)\n\n"
+                 "### Done\n"
                  (string-join (for/list ([m (in-list entries)]
                                          [i (in-naturals)]
-                                         #:break (>= i 20))
-                                (format "- [~a] ~a: ~a"
+                                         #:break (>= i 30))
+                                (define text (extract-message-text m))
+                                (define files (regexp-match* FILE-IN-TEXT-RE text))
+                                (define truncated (truncate-string text 200))
+                                (format "- [~a] ~a: ~a~a"
                                         (message-id m)
                                         (symbol->string (message-role m))
-                                        (truncate-string (extract-message-text m) 100)))
+                                        truncated
+                                        (if (pair? files)
+                                            (format " [files: ~a]"
+                                                    (string-join (take files (min 5 (length files)))
+                                                                 ", "))
+                                            "")))
                               "\n")))
 
 ;; Count of entries actually represented in simple-summary-text
 (define (simple-summary-count entries)
-  (min (length entries) 20))
+  (min (length entries) 30))
 
 ;; ============================================================
 ;; Helpers

--- a/tests/test-summary-quality.rkt
+++ b/tests/test-summary-quality.rkt
@@ -1,0 +1,92 @@
+#lang racket/base
+
+;; tests/test-summary-quality.rkt — Tests for summary quality gates (SAL-04, CA-04)
+;;
+;; Tests for:
+;;   - extract-key-entities (summary-entities.rkt)
+;;   - check-entity-preservation (summary-entities.rkt)
+;;   - entity-preservation-appendix (summary-entities.rkt)
+;;   - simple-summary-text file path extraction (context-summary.rkt)
+
+(require rackunit
+         (only-in "../util/protocol-types.rkt" make-message make-text-part)
+         (only-in "../runtime/context-assembly/summary-entities.rkt"
+                  extract-key-entities
+                  check-entity-preservation
+                  entity-preservation-appendix)
+         (only-in "../runtime/context-summary.rkt" simple-summary-text)
+         racket/string)
+
+;; Helper: create a simple message
+(define (make-simple-message role text [id (gensym 'msg)])
+  (make-message id #f role 'text (list (make-text-part text)) 0 #f))
+
+;; ---------------------------------------------------------------------------
+;; extract-key-entities
+;; ---------------------------------------------------------------------------
+
+(test-case "extract-key-entities finds file paths"
+  (define msgs (list (make-simple-message 'user "Edit runtime/context-assembly.rkt and fix the bug")))
+  (define entities (extract-key-entities msgs))
+  (check-not-false (member "runtime/context-assembly.rkt" entities)
+                   (format "Expected runtime/context-assembly.rkt in ~a" entities)))
+
+(test-case "extract-key-entities finds definitions"
+  (define msgs (list (make-simple-message 'assistant "(define (foo-bar x) (+ x 1))")))
+  (define entities (extract-key-entities msgs))
+  (check-not-false (ormap (lambda (e) (string-contains? e "define")) entities)
+                   (format "Expected definition match in ~a" entities)))
+
+(test-case "extract-key-entities respects max-entities limit"
+  (define msgs
+    (for/list ([i (in-range 50)])
+      (make-simple-message 'assistant (format "Edit file~a.rkt and file~a.py" i i))))
+  (define entities (extract-key-entities msgs 10))
+  (check-true (<= (length entities) 10)))
+
+;; ---------------------------------------------------------------------------
+;; check-entity-preservation
+;; ---------------------------------------------------------------------------
+
+(test-case "check-entity-preservation detects missing entities"
+  (define entities '("foo.rkt" "bar.rkt" "baz.rkt"))
+  (define missing (check-entity-preservation entities "summary mentions foo.rkt"))
+  (check-equal? missing '("bar.rkt" "baz.rkt")))
+
+(test-case "check-entity-preservation returns empty when all preserved"
+  (define entities '("foo.rkt" "bar.rkt"))
+  (define missing (check-entity-preservation entities "summary has foo.rkt and bar.rkt"))
+  (check-equal? missing '()))
+
+;; ---------------------------------------------------------------------------
+;; entity-preservation-appendix
+;; ---------------------------------------------------------------------------
+
+(test-case "entity-preservation-appendix generates appendix for missing"
+  (define result (entity-preservation-appendix '("lost.rkt" "gone.rkt")))
+  (check-true (string-contains? result "lost.rkt"))
+  (check-true (string-contains? result "gone.rkt"))
+  (check-true (string-contains? result "Key Entities")))
+
+(test-case "entity-preservation-appendix returns empty for no missing"
+  (check-equal? (entity-preservation-appendix '()) ""))
+
+;; ---------------------------------------------------------------------------
+;; simple-summary-text file extraction (CA-04)
+;; ---------------------------------------------------------------------------
+
+(test-case "simple-summary-text extracts file paths"
+  (define msgs
+    (for/list ([i (in-range 5)])
+      (make-simple-message 'assistant (format "Edited ~a.rkt file" i))))
+  (define text (simple-summary-text msgs))
+  (check-true (string-contains? text "files:"))
+  (check-true (string-contains? text "fallback")))
+
+(test-case "simple-summary-text caps at 30 entries"
+  (define msgs
+    (for/list ([i (in-range 40)])
+      (make-simple-message 'assistant (format "Entry ~a" i))))
+  (define text (simple-summary-text msgs))
+  ;; Entry 30 should NOT be present (0-indexed, capped at 30)
+  (check-false (string-contains? text "Entry 30")))

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -10,4 +10,4 @@
 (provide q-version)
 
 (: q-version String)
-(define q-version "0.45.3")
+(define q-version "0.45.4")

--- a/wiki-src/Architecture-Overview.md
+++ b/wiki-src/Architecture-Overview.md
@@ -35,7 +35,7 @@ User input → Interface (CLI/TUI/RPC)
     → Events emitted to bus
 ```
 
-## Metrics (0.45.3)
+## Metrics (0.45.4)
 > _See `racket scripts/metrics.rkt` for current numbers._
 
 - 414 source modules, 534 test files


### PR DESCRIPTION
## v0.45.4 — Summary Quality Gates (SAL-04, CA-04, TEST-02)

- **S17**: Created `runtime/context-assembly/summary-entities.rkt` — entity extraction (file paths, definitions) for summary validation
- **S18**: Added quality gate to `llm-summarize` — checks entity preservation, appends missing entities, warns on too-short summaries
- **S19**: Improved `simple-summary-text` — 30 entries × 200 chars with file path extraction (was 20×100)
- **S20**: Added `tests/test-summary-quality.rkt` with 9 test cases; version bumped to 0.45.4

Closes #4326