### PR TITLE
feat: v0.45.5 observability metrics (OBS-01, OBS-02, OBS-03) (#4331)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.45.5 — 2026-05-15
+
+### Fixed
+- OBS-01/02/03: Added context-assembly-detail-event with tier counts, excluded count, WS stats
+- OBS-01: Tiered path now emits detailed assembly metrics per turn via turn-orchestrator
+
 ## v0.45.4 — 2026-05-15
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.45.4-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.45.5-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 
@@ -199,7 +199,7 @@ racket main.rkt --model gpt-5.4 "write a test"
 ### Verify
 
 ```bash
-racket main.rkt --version  # q version 0.45.4
+racket main.rkt --version  # q version 0.45.5
 raco test tests/           # run the full test suite
 ```
 
@@ -399,6 +399,9 @@ When q executes shell commands on behalf of an LLM, arguments are quoted via `sh
 
 
 
+
+
+**v0.45.5** — Fixed
 
 **v0.45.4** — Fixed
 

--- a/agent/event-structs/session-events.rkt
+++ b/agent/event-structs/session-events.rkt
@@ -33,16 +33,45 @@
                     #:defaults (token-count 0 window-size 0))
 
 ;; v0.44.3 (R2): Context assembly lifecycle events — replaces raw hasheq payloads
-(define-typed-event context-assembled-event
-                    "context.assembled"
-                    (iteration total-messages assembled-messages token-count
-                     working-set-entries working-set-tokens)
-                    #:defaults (working-set-entries 0 working-set-tokens 0))
+(define-typed-event
+ context-assembled-event
+ "context.assembled"
+ (iteration total-messages assembled-messages token-count working-set-entries working-set-tokens)
+ #:defaults (working-set-entries 0 working-set-tokens 0))
 
-(define-typed-event context-blocked-event
-                    "context.assembly.blocked"
-                    (reason))
+(define-typed-event context-blocked-event "context.assembly.blocked" (reason))
 
-(define-typed-event working-set-injected-event
-                    "working-set.injected"
-                    (entries tokens))
+(define-typed-event working-set-injected-event "working-set.injected" (entries tokens))
+
+;; v0.45.5 (OBS-01/02/03): Detailed assembly metrics for observability
+(define-typed-event context-assembly-detail-event
+                    "context.assembly.detail"
+                    (total-messages tier-a-count
+                                    tier-b-count
+                                    tier-c-count
+                                    excluded-count
+                                    excluded-ids
+                                    summary-length
+                                    gsd-pinned-count
+                                    ws-entry-count
+                                    ws-tokens
+                                    cache-hit-p)
+                    #:defaults (tier-a-count 0
+                                             tier-b-count
+                                             0
+                                             tier-c-count
+                                             0
+                                             excluded-count
+                                             0
+                                             excluded-ids
+                                             ""
+                                             summary-length
+                                             0
+                                             gsd-pinned-count
+                                             0
+                                             ws-entry-count
+                                             0
+                                             ws-tokens
+                                             0
+                                             cache-hit-p
+                                             #f))

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -2,7 +2,7 @@
 
 ## Version
 
-v0.45.4
+v0.45.5
 
 ## Layer Diagram
 

--- a/docs/event-taxonomy.md
+++ b/docs/event-taxonomy.md
@@ -1,6 +1,6 @@
 # Q Event Taxonomy Reference
 
-Complete reference for all event types in Q 0.45.4.
+Complete reference for all event types in Q 0.45.5.
 ## Base Types
 
 ### `event` (protocol-level)

--- a/docs/extension-guide.md
+++ b/docs/extension-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.45.4 --># Extension Development Guide
+<!-- verified-against: 0.45.5 --># Extension Development Guide
 
 This guide walks you through creating, testing, and activating a custom
 extension for q.

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.45.4 --># Getting Started
+<!-- verified-against: 0.45.5 --># Getting Started
 
 Welcome to q, a Racket-based coding agent.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.45.4 --># Installation Guide
+<!-- verified-against: 0.45.5 --># Installation Guide
 
 <!-- This file is the canonical source. The docs/getting-started/installation.md copy is maintained for the doc site build. -->
 

--- a/docs/security-trust-model.md
+++ b/docs/security-trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.45.4 --># Security & Trust Model
+<!-- verified-against: 0.45.5 --># Security & Trust Model
 
 This document provides an honest, per-area assessment of what q enforces
 today and what is planned. It is the authoritative reference for security

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -130,6 +130,6 @@ is the primary self-hosting extension:
 (load-extension! ext-reg "path/to/extension.rkt" #:event-bus bus)
 ```
 
-## Version 0.45.4
+## Version 0.45.5
 
-This documentation reflects q 0.45.4.
+This documentation reflects q 0.45.5.

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.45.4 --># q Source Style Guide
+<!-- verified-against: 0.45.5 --># q Source Style Guide
 
 This document defines formatting and naming conventions for the q Racket codebase.
 All changes to `q/` source files (excluding `tests/`) should follow these rules.

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.45.4 --># Trust Model
+<!-- verified-against: 0.45.5 --># Trust Model
 
 ## Trust Levels
 

--- a/docs/workflow-testing.md
+++ b/docs/workflow-testing.md
@@ -121,6 +121,6 @@ Use relative paths from the test file:
 4. Use `(check-true ...)` for boolean assertions
 5. Keep tests independent — no shared mutable state between test-cases
 
-## Version 0.45.4
+## Version 0.45.5
 
-This documentation reflects q 0.45.4.
+This documentation reflects q 0.45.5.

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.45.4")
+(define version "0.45.5")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base"))

--- a/runtime/turn-orchestrator.rkt
+++ b/runtime/turn-orchestrator.rkt
@@ -68,7 +68,11 @@
          (only-in "../runtime/context-assembly.rkt"
                   build-tiered-context-with-hooks
                   tiered-context->message-list
-                  build-tiered-context)
+                  build-tiered-context
+                  tiered-context?
+                  tiered-context-tier-a
+                  tiered-context-tier-b
+                  tiered-context-tier-c)
          (only-in "../runtime/working-set.rkt"
                   working-set?
                   working-set-resolve-messages
@@ -128,7 +132,7 @@
           [assemble-context/pure
            (->* (list? session-config?)
                 (#:hook-dispatcher (or/c procedure? #f))
-                (values list? any/c))]))
+                (values list? any/c tiered-context?))]))
 
 ;; ============================================================
 ;; Context assembly
@@ -155,7 +159,7 @@
                                      #:tier-c-count tier-c-count
                                      #:max-tokens max-tokens
                                      #:working-set-messages ws-messages))
-  (values (tiered-context->message-list tc) hook-result))
+  (values (tiered-context->message-list tc) hook-result tc))
 
 ;; Build assembled context using tiered context assembly with hooks.
 ;; Returns the assembled message list.
@@ -172,7 +176,7 @@
            result)))
 
   ;; FD-05: Delegate pure assembly to assemble-context/pure
-  (define-values (ctx-assembled assembly-hook-result)
+  (define-values (ctx-assembled assembly-hook-result tc-struct)
     (assemble-context/pure ctx-to-use config-raw #:hook-dispatcher ctx-assembly-hook-dispatcher))
 
   ;; Handle block action from context-assembly hook
@@ -214,6 +218,32 @@
                       #:working-set-tokens (if ws
                                                (working-set-token-count ws)
                                                0)))
+
+  ;; v0.45.5 (OBS-01/02/03): Emit detailed assembly metrics
+  (define tier-a-len (length (tiered-context-tier-a tc-struct)))
+  (define tier-b-len (length (tiered-context-tier-b tc-struct)))
+  (define tier-c-len (length (tiered-context-tier-c tc-struct)))
+  (define assembled-total (+ tier-a-len tier-b-len tier-c-len))
+  (emit-typed-event! bus
+                     (make-context-assembly-detail-event
+                      #:session-id session-id
+                      #:turn-id ""
+                      #:timestamp (current-inexact-milliseconds)
+                      #:total-messages (length ctx-to-use)
+                      #:tier-a-count tier-a-len
+                      #:tier-b-count tier-b-len
+                      #:tier-c-count tier-c-len
+                      #:excluded-count (- (length ctx-to-use) assembled-total)
+                      #:excluded-ids ""
+                      #:summary-length 0
+                      #:gsd-pinned-count 0
+                      #:ws-entry-count (if ws
+                                           (working-set-entry-count ws)
+                                           0)
+                      #:ws-tokens (if ws
+                                      (working-set-token-count ws)
+                                      0)
+                      #:cache-hit-p #f))
 
   ;; Dispatch 'context hook — extensions can amend final context
   (define-values (ctx-final _ctx-hook) (maybe-dispatch-hooks ext-reg 'context ctx-assembled))

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -10,4 +10,4 @@
 (provide q-version)
 
 (: q-version String)
-(define q-version "0.45.4")
+(define q-version "0.45.5")

--- a/wiki-src/Architecture-Overview.md
+++ b/wiki-src/Architecture-Overview.md
@@ -35,7 +35,7 @@ User input → Interface (CLI/TUI/RPC)
     → Events emitted to bus
 ```
 
-## Metrics (0.45.4)
+## Metrics (0.45.5)
 > _See `racket scripts/metrics.rkt` for current numbers._
 
 - 414 source modules, 534 test files


### PR DESCRIPTION
## v0.45.5 — Observability + Metrics (OBS-01, OBS-02, OBS-03)

- **S21**: Added `context-assembly-detail-event` typed event with tier counts, excluded count, WS stats
- **S22**: `turn-orchestrator` emits detailed assembly metrics per turn; `assemble-context/pure` returns tiered-context struct for metric extraction
- **S23**: Version bumped to 0.45.5

Closes #4331