### PR TITLE
fix: TUI camelCase key fixes (NF6+NF6b+NF6c) (#4365)

### DIFF
--- a/tests/tui/state.rkt
+++ b/tests/tui/state.rkt
@@ -991,3 +991,35 @@
   (define s0 (initial-ui-state))
   (define s1 (struct-copy ui-state s0 [mock-provider? #t]))
   (check-true (ui-state-mock-provider? s1) "mock-provider? set to #t"))
+
+;; ============================================================
+;; v0.45.7 Wave 0 (NF6): TUI camelCase key fix tests
+;; ============================================================
+
+(test-case "NF6: tool.execution.started reads camelCase toolName"
+  (define s0 (initial-ui-state))
+  (define evt (make-test-event "tool.execution.started" (hash 'toolName "read" 'toolCallId "tc-1")))
+  (define s1 (apply-event-to-state s0 evt))
+  (define entries (ui-state-transcript s1))
+  (check > (length entries) 0 "should have at least one transcript entry")
+  (define entry (car entries))
+  (check-equal? (hash-ref (transcript-entry-meta entry) 'name #f) "read"))
+
+(test-case "NF6: tool.execution.completed reads camelCase toolName"
+  (define s0 (initial-ui-state))
+  ;; Start the tool first
+  (define start-evt
+    (make-test-event "tool.execution.started" (hash 'toolName "bash" 'toolCallId "tc-2")))
+  (define s1 (apply-event-to-state s0 start-evt))
+  ;; Then complete it
+  (define end-evt
+    (make-test-event "tool.execution.completed" (hash 'toolName "bash" 'resultSummary 'completed)))
+  (define s2 (apply-event-to-state s1 end-evt))
+  ;; Should have tool-end entries — verify name is "bash", not "?"
+  (define entries (ui-state-transcript s2))
+  (define tool-end-entries (filter (lambda (e) (eq? (transcript-entry-kind e) 'tool-end)) entries))
+  (check > (length tool-end-entries) 0 "should have a tool-end entry")
+  (define end-entry (car tool-end-entries))
+  (check-equal? (hash-ref (transcript-entry-meta end-entry) 'name #f)
+                "bash"
+                "tool name should be 'bash', not '?'"))

--- a/tui/state-events.rkt
+++ b/tui/state-events.rkt
@@ -119,7 +119,7 @@
 
 (define (handle-tool-execution-started state evt)
   (define payload (event-payload evt))
-  (define name (hash-ref payload 'tool-name "?"))
+  (define name (hash-ref payload 'toolName "?"))
   (if (recent-tool-start? state name)
       (set-pending-tool-name (set-busy state #t) name)
       (let* ([args-raw (hash-ref payload 'arguments #f)]
@@ -135,13 +135,11 @@
             (set-pending-tool-name (set-busy new-state #t) name)))))
 
 (define (handle-tool-execution-completed state evt)
-  ;; W-04: Accepts both old (name/result/error) and new (tool-name/result-summary) payloads
+  ;; W-04: Accepts both old (name/result/error) and new (toolName/resultSummary) payloads
   (define payload (event-payload evt))
-  (define name (hash-ref payload 'tool-name (lambda () (hash-ref payload 'name "?"))))
+  (define name (hash-ref payload 'toolName (lambda () (hash-ref payload 'name "?"))))
   (define result-summary
-    (hash-ref payload
-              'result-summary
-              (lambda () (if (hash-ref payload 'error #f) 'error 'completed))))
+    (hash-ref payload 'resultSummary (lambda () (if (hash-ref payload 'error #f) 'error 'completed))))
   (define result-raw (hash-ref payload 'result #f))
   (define error-raw (hash-ref payload 'error #f))
   (define ts (event-time evt))
@@ -395,7 +393,7 @@
   (cond
     [(equal? ev "auto-retry.start")
      (define attempt (hash-ref payload 'attempt "?"))
-     (define max-attempts (hash-ref payload 'max-retries "?"))
+     (define max-attempts (hash-ref payload 'maxRetries "?"))
      (define error-type (hash-ref payload 'errorType #f))
      (define type-label
        (case error-type


### PR DESCRIPTION
## Wave 0: TUI CamelCase Key Fixes (NF6+NF6b+NF6c)

- **S1**: Fixed 4 hash-ref keys: `tool-name`→`toolName`, `result-summary`→`resultSummary`, `max-retries`→`maxRetries`
- **S2**: Added 2 tests verifying camelCase key reads in tool event handlers

Closes #4365