### PR TITLE
fix: dead code + orphan API fixes (NF1+NF5+NF2) (#4366)

### DIFF
--- a/runtime/context-assembly/serialization.rkt
+++ b/runtime/context-assembly/serialization.rkt
@@ -34,7 +34,7 @@
          tiered-context->message-list
          build-tiered-context-with-hooks
          compute-dynamic-tier-b-count
-         summarize-tool-result
+         summarize-tool-result ;; re-exported from session-walk.rkt via context-assembly.rkt
          context-assembly-payload
          context-assembly-payload?
          context-assembly-payload-tier-a-messages

--- a/runtime/context-assembly/session-walk.rkt
+++ b/runtime/context-assembly/session-walk.rkt
@@ -24,7 +24,6 @@
          (only-in "../session-index.rkt" active-leaf get-branch))
 
 (provide build-session-context
-         build-session-context/tokens
          assemble-context
          split-at-compaction
          entry->context-message
@@ -44,16 +43,7 @@
        [#f '()]
        [_ (assemble-context path)])]))
 
-;; Token-aware variant used by serialization.rkt
-(define (build-session-context/tokens idx #:max-tokens max-tokens)
-  (define leaf (active-leaf idx))
-  (match leaf
-    [#f '()]
-    [_
-     (define path (get-branch idx (message-id leaf)))
-     (match path
-       [#f '()]
-       [_ (assemble-context path)])]))
+;; Token-aware variant lives in serialization.rkt
 
 (define (assemble-context path)
   (define-values (pre post) (split-at-compaction path))

--- a/runtime/context-fit.rkt
+++ b/runtime/context-fit.rkt
@@ -12,14 +12,16 @@
          (only-in "../runtime/context-policy.rkt"
                   estimate-message-tokens
                   ensure-first-user-pinned
-                  fit-messages-pair-preserving))
+                  fit-messages-pair-preserving
+                  fit-messages-with-importance-rescue))
 
 (provide truncate-messages-to-budget
          fit-messages-from-recent)
 
-;; Fit messages from recent end within budget (pair-preserving).
+;; Fit messages from recent end within budget (pair-preserving + importance rescue).
+;; v0.45.7 (NF2): Now uses importance-aware rescue to preserve critical/high messages.
 (define (fit-messages-from-recent messages budget)
-  (fit-messages-pair-preserving messages budget))
+  (fit-messages-with-importance-rescue messages budget))
 
 ;; truncate-messages-to-budget: Trim messages from the front to fit within token budget.
 ;; Returns truncated message list with first-user pinning preserved.

--- a/tests/test-context-fit.rkt
+++ b/tests/test-context-fit.rkt
@@ -47,3 +47,30 @@
 
 (test-case "fit-messages-from-recent returns empty for empty input"
   (check-equal? (fit-messages-from-recent '() 1000) '()))
+
+;; v0.45.7 (NF2): Integration test — importance rescue wired through production path
+(test-case "fit-messages-from-recent rescues critical-importance messages"
+  ;; Create 20 normal messages and 1 critical message at position 0
+  (define normal-msgs
+    (for/list ([i (in-range 1 21)])
+      (make-message (format "n~a" i)
+                    #f
+                    'user
+                    'text
+                    (list (make-text-part (format "Normal message ~a with padding text" i)))
+                    i
+                    (hasheq))))
+  (define critical-msg
+    (make-message "crit-0"
+                  #f
+                  'user
+                  'text
+                  (list (make-text-part "CRITICAL DECISION"))
+                  0
+                  (hasheq 'importance 'critical)))
+  (define msgs (cons critical-msg normal-msgs))
+  ;; Small budget — critical message should be rescued by importance pass
+  (define result (fit-messages-from-recent msgs 150))
+  (define result-ids (map message-id result))
+  (check-not-false (member "crit-0" result-ids)
+                   "critical-importance message should survive importance rescue"))


### PR DESCRIPTION
## Wave 1: Dead Code + Orphan API Fixes (NF1+NF5+NF2)

- **S3**: Removed broken `build-session-context/tokens` duplicate from session-walk.rkt (NF1)
- **S4**: Documented re-export chain for `summarize-tool-result` (NF5 — already correct)
- **S5**: Wired `fit-messages-with-importance-rescue` into `fit-messages-from-recent` (NF2)
- **S6**: Added integration test verifying critical-importance messages survive rescue

Closes #4366