### PR TITLE
fix: real OBS metrics replace stubs (NF3) (#4356)

### DIFF
--- a/runtime/turn-orchestrator.rkt
+++ b/runtime/turn-orchestrator.rkt
@@ -23,7 +23,7 @@
          racket/list
          racket/promise
          json
-         (only-in racket/string string-contains?)
+         (only-in racket/string string-contains? string-join)
          (only-in "../util/errors.rkt" raise-extension-error)
          (only-in "../util/json-helpers.rkt" ensure-hash-args)
          (only-in "../util/protocol-types.rkt"
@@ -105,7 +105,9 @@
                   config-max-tokens
                   config-working-set
                   config-settings
-                  config-model-name))
+                  config-model-name)
+         (only-in "../util/protocol-types.rkt" message-kind message-content)
+         racket/set)
 
 (provide (contract-out
           [run-provider-turn
@@ -220,10 +222,30 @@
                                                0)))
 
   ;; v0.45.5 (OBS-01/02/03): Emit detailed assembly metrics
+  ;; v0.45.7 (NF3): Replaced stubs with real computed values
   (define tier-a-len (length (tiered-context-tier-a tc-struct)))
   (define tier-b-len (length (tiered-context-tier-b tc-struct)))
   (define tier-c-len (length (tiered-context-tier-c tc-struct)))
   (define assembled-total (+ tier-a-len tier-b-len tier-c-len))
+  ;; Compute excluded IDs from messages not in assembled output
+  (define assembled-ids
+    (for/set ([m (in-list ctx-assembled)])
+      (message-id m)))
+  (define excluded-id-list
+    (for/list ([m (in-list ctx-to-use)]
+               #:unless (set-member? assembled-ids (message-id m)))
+      (message-id m)))
+  (define excluded-ids-str (string-join excluded-id-list ","))
+  ;; Compute summary length from compaction-summary messages
+  (define summary-len
+    (for/sum ([m (in-list ctx-assembled)] #:when (eq? (message-kind m) 'compaction-summary))
+             (define content (message-content m))
+             (if (string? content)
+                 (string-length content)
+                 0)))
+  ;; Count GSD-pinned messages (context-assembly-summary kind)
+  (define gsd-pinned
+    (for/sum ([m (in-list ctx-assembled)] #:when (eq? (message-kind m) 'context-assembly-summary)) 1))
   (emit-typed-event! bus
                      (make-context-assembly-detail-event
                       #:session-id session-id
@@ -234,9 +256,9 @@
                       #:tier-b-count tier-b-len
                       #:tier-c-count tier-c-len
                       #:excluded-count (- (length ctx-to-use) assembled-total)
-                      #:excluded-ids ""
-                      #:summary-length 0
-                      #:gsd-pinned-count 0
+                      #:excluded-ids excluded-ids-str
+                      #:summary-length summary-len
+                      #:gsd-pinned-count gsd-pinned
                       #:ws-entry-count (if ws
                                            (working-set-entry-count ws)
                                            0)

--- a/tests/test-context-assembly.rkt
+++ b/tests/test-context-assembly.rkt
@@ -428,9 +428,25 @@
           (make-test-msg "a1" 'assistant 'message "Hi there")
           (make-test-msg "u2" 'user 'message "How are you?")))
   (define config (hash->session-config (hash 'tier-b-count 10 'tier-c-count 2 'max-tokens 4096)))
-  (define-values (result _hook-res) (ctx-assemble msgs config))
+  (define-values (result _hook-res _tc) (ctx-assemble msgs config))
   (check-pred list? result)
   (check >= (length result) 1)
   ;; Verify all results are messages
   (for ([m (in-list result)])
     (check-true (message? m))))
+
+;; v0.45.7 (NF3): OBS metrics test — verify tiered-context carries real data
+(test-case "NF3: assemble-context/pure returns tiered-context with real structure"
+  (define msgs
+    (list (make-test-msg "u1" 'user 'message "Hello")
+          (make-test-msg "a1" 'assistant 'message "Response")
+          (make-test-msg "u2" 'user 'message "Follow up")))
+  (define config (hash->session-config (hash 'tier-b-count 10 'tier-c-count 2 'max-tokens 4096)))
+  (define-values (result _hook-res tc) (ctx-assemble msgs config))
+  (check-pred tiered-context? tc)
+  ;; Total across tiers should equal assembled count
+  (define tier-total
+    (+ (length (tiered-context-tier-a tc))
+       (length (tiered-context-tier-b tc))
+       (length (tiered-context-tier-c tc))))
+  (check-equal? tier-total (length result) "tier total should match assembled count"))


### PR DESCRIPTION
## Wave 2: Observability Metrics Fix (NF3)

- **S7**: Replaced hardcoded stubs (`excluded-ids ""`, `summary-length 0`, `gsd-pinned-count 0`) with real computed values from assembled context
- **S8**: Added test verifying `assemble-context/pure` returns tiered-context with correct structure

Closes #4356