### PR TITLE
fix: CLI + test camelCase fixes (NF7+NF8) (#4373)

### DIFF
--- a/cli/render.rkt
+++ b/cli/render.rkt
@@ -180,7 +180,7 @@
          (styled (format "[tool: ~a: ~a]" name detail) '(bold yellow))
          (styled (format "[tool: ~a]" name) '(bold yellow)))]
     [("tool.execution.started")
-     (define name (hash-ref payload 'tool-name "?"))
+     (define name (hash-ref payload 'toolName "?"))
      (define args-raw (hash-ref payload 'arguments #f))
      (define args
        (cond
@@ -201,10 +201,10 @@
          (styled (format "[tool: ~a]" name) '(bold yellow)))]
     [("tool.execution.completed")
      ;; W-04: Accepts both old (name/result/error) and new (tool-name/result-summary) payloads
-     (define name (hash-ref payload 'tool-name (lambda () (hash-ref payload 'name "?"))))
+     (define name (hash-ref payload 'toolName (lambda () (hash-ref payload 'name "?"))))
      (define result-summary
        (hash-ref payload
-                 'result-summary
+                 'resultSummary
                  (lambda () (if (hash-ref payload 'error #f) 'error 'completed))))
      (cond
        [(eq? result-summary 'completed)

--- a/tests/test-tui-exploration-events.rkt
+++ b/tests/test-tui-exploration-events.rkt
@@ -20,119 +20,123 @@
 
 (define-simple-check (check-contains? str substr) (string-contains? str substr))
 
-(define-test-suite
- test-tui-exploration-events
- ;; ============================================================
- ;; iteration.soft-warning
- ;; ============================================================
- (test-case "soft-warning: adds system entry with iteration count"
-   (define s0 (initial-ui-state))
-   (define evt (make-test-event "iteration.soft-warning" (hash 'iteration 15 'remaining 5)))
-   (define s1 (apply-event-to-state s0 evt))
-   (define entries (ui-state-transcript s1))
-   (check > (length entries) 0 "adds an entry")
-   (define entry (last entries))
-   (check-equal? (transcript-entry-kind entry) 'system)
-   (check-contains? (transcript-entry-text entry) "15")
-   (check-contains? (transcript-entry-text entry) "5"))
- (test-case "soft-warning: handles missing fields gracefully"
-   (define s0 (initial-ui-state))
-   (define evt (make-test-event "iteration.soft-warning" (hash)))
-   (define s1 (apply-event-to-state s0 evt))
-   (define entries (ui-state-transcript s1))
-   (check > (length entries) 0 "adds entry even with missing fields"))
- ;; ============================================================
- ;; exploration.progress
- ;; ============================================================
- (test-case "exploration.progress: shows tool count and names"
-   (define s0 (initial-ui-state))
-   (define evt
-     (make-test-event "exploration.progress"
-                      (hash 'consecutive-tools 3 'tool-names '("read" "edit" "bash"))))
-   (define s1 (apply-event-to-state s0 evt))
-   (define entries (ui-state-transcript s1))
-   (check > (length entries) 0 "adds an entry")
-   (define entry (last entries))
-   (check-equal? (transcript-entry-kind entry) 'system)
-   (check-contains? (transcript-entry-text entry) "3")
-   (check-contains? (transcript-entry-text entry) "read")
-   (check-contains? (transcript-entry-text entry) "bash"))
- (test-case "exploration.progress: handles empty tool names"
-   (define s0 (initial-ui-state))
-   (define evt (make-test-event "exploration.progress" (hash 'consecutive-tools 0 'tool-names '())))
-   (define s1 (apply-event-to-state s0 evt))
-   (define entries (ui-state-transcript s1))
-   (check > (length entries) 0 "adds entry even with empty tools"))
- ;; ============================================================
- ;; context.mid-turn-over-budget
- ;; ============================================================
- (test-case "mid-turn-over-budget: shows token estimate and budget"
-   (define s0 (initial-ui-state))
-   (define evt
-     (make-test-event "context.mid-turn-over-budget" (hash 'estimated-tokens 95000 'budget 90000)))
-   (define s1 (apply-event-to-state s0 evt))
-   (define entries (ui-state-transcript s1))
-   (check > (length entries) 0 "adds an entry")
-   (define entry (last entries))
-   (check-equal? (transcript-entry-kind entry) 'system)
-   (check-contains? (transcript-entry-text entry) "95000")
-   (check-contains? (transcript-entry-text entry) "90000"))
- (test-case "mid-turn-over-budget: handles missing fields gracefully"
-   (define s0 (initial-ui-state))
-   (define evt (make-test-event "context.mid-turn-over-budget" (hash)))
-   (define s1 (apply-event-to-state s0 evt))
-   (define entries (ui-state-transcript s1))
-   (check > (length entries) 0 "adds entry even with missing fields"))
- ;; ============================================================
- ;; auto-retry.start with errorType
- ;; ============================================================
- (test-case "auto-retry.start: timeout error type label"
-   (define s0 (initial-ui-state))
-   (define evt
-     (make-test-event "auto-retry.start" (hash 'attempt 1 'max-retries 3 'errorType 'timeout)))
-   (define s1 (apply-event-to-state s0 evt))
-   (define entries (ui-state-transcript s1))
-   (check > (length entries) 0)
-   (define entry (last entries))
-   (check-equal? (transcript-entry-kind entry) 'system)
-   (check-contains? (transcript-entry-text entry) "LLM timeout"))
- (test-case "auto-retry.start: rate-limit error type label"
-   (define s0 (initial-ui-state))
-   (define evt
-     (make-test-event "auto-retry.start" (hash 'attempt 2 'max-retries 3 'errorType 'rate-limit)))
-   (define s1 (apply-event-to-state s0 evt))
-   (define entry (last (ui-state-transcript s1)))
-   (check-contains? (transcript-entry-text entry) "rate limited"))
- (test-case "auto-retry.start: context-overflow error type label"
-   (define s0 (initial-ui-state))
-   (define evt
-     (make-test-event "auto-retry.start"
-                      (hash 'attempt 1 'max-retries 3 'errorType 'context-overflow)))
-   (define s1 (apply-event-to-state s0 evt))
-   (define entry (last (ui-state-transcript s1)))
-   (check-contains? (transcript-entry-text entry) "context too large"))
- (test-case "auto-retry.start: provider-error error type label"
-   (define s0 (initial-ui-state))
-   (define evt
-     (make-test-event "auto-retry.start" (hash 'attempt 1 'max-retries 3 'errorType 'provider-error)))
-   (define s1 (apply-event-to-state s0 evt))
-   (define entry (last (ui-state-transcript s1)))
-   (check-contains? (transcript-entry-text entry) "server error"))
- (test-case "auto-retry.start: no errorType falls back to generic"
-   (define s0 (initial-ui-state))
-   (define evt (make-test-event "auto-retry.start" (hash 'attempt 1 'max-retries 3)))
-   (define s1 (apply-event-to-state s0 evt))
-   (define entry (last (ui-state-transcript s1)))
-   ;; Generic fallback: "[retry: attempt 1/3]" — no type-specific label like "LLM timeout"
-   (check-contains? (transcript-entry-text entry) "attempt 1/3")
-   (check-false (string-contains? (transcript-entry-text entry) "LLM timeout"))
-   (check-false (string-contains? (transcript-entry-text entry) "rate limited")))
- (test-case "auto-retry.start: clears streaming state"
-   (define s0
-     (set-streaming-thinking (set-streaming-text (initial-ui-state) "partial...") "thinking..."))
-   (define evt (make-test-event "auto-retry.start" (hash 'attempt 1 'max-retries 3)))
-   (define s1 (apply-event-to-state s0 evt))
-   (check-false (ui-state-streaming-text s1))
-   (check-false (ui-state-streaming-thinking s1))))
+(define test-tui-exploration-events
+  (test-suite "test-tui-exploration-events"
+    ;; ============================================================
+    ;; iteration.soft-warning
+    ;; ============================================================
+    (test-case "soft-warning: adds system entry with iteration count"
+      (define s0 (initial-ui-state))
+      (define evt (make-test-event "iteration.soft-warning" (hash 'iteration 15 'remaining 5)))
+      (define s1 (apply-event-to-state s0 evt))
+      (define entries (ui-state-transcript s1))
+      (check > (length entries) 0 "adds an entry")
+      (define entry (last entries))
+      (check-equal? (transcript-entry-kind entry) 'system)
+      (check-contains? (transcript-entry-text entry) "15")
+      (check-contains? (transcript-entry-text entry) "5"))
+    (test-case "soft-warning: handles missing fields gracefully"
+      (define s0 (initial-ui-state))
+      (define evt (make-test-event "iteration.soft-warning" (hash)))
+      (define s1 (apply-event-to-state s0 evt))
+      (define entries (ui-state-transcript s1))
+      (check > (length entries) 0 "adds entry even with missing fields"))
+    ;; ============================================================
+    ;; exploration.progress
+    ;; ============================================================
+    (test-case "exploration.progress: shows tool count and names"
+      (define s0 (initial-ui-state))
+      (define evt
+        (make-test-event "exploration.progress"
+                         (hash 'consecutive-tools 3 'tool-names '("read" "edit" "bash"))))
+      (define s1 (apply-event-to-state s0 evt))
+      (define entries (ui-state-transcript s1))
+      (check > (length entries) 0 "adds an entry")
+      (define entry (last entries))
+      (check-equal? (transcript-entry-kind entry) 'system)
+      (check-contains? (transcript-entry-text entry) "3")
+      (check-contains? (transcript-entry-text entry) "read")
+      (check-contains? (transcript-entry-text entry) "bash"))
+    (test-case "exploration.progress: handles empty tool names"
+      (define s0 (initial-ui-state))
+      (define evt
+        (make-test-event "exploration.progress" (hash 'consecutive-tools 0 'tool-names '())))
+      (define s1 (apply-event-to-state s0 evt))
+      (define entries (ui-state-transcript s1))
+      (check > (length entries) 0 "adds entry even with empty tools"))
+    ;; ============================================================
+    ;; context.mid-turn-over-budget
+    ;; ============================================================
+    (test-case "mid-turn-over-budget: shows token estimate and budget"
+      (define s0 (initial-ui-state))
+      (define evt
+        (make-test-event "context.mid-turn-over-budget" (hash 'estimated-tokens 95000 'budget 90000)))
+      (define s1 (apply-event-to-state s0 evt))
+      (define entries (ui-state-transcript s1))
+      (check > (length entries) 0 "adds an entry")
+      (define entry (last entries))
+      (check-equal? (transcript-entry-kind entry) 'system)
+      (check-contains? (transcript-entry-text entry) "95000")
+      (check-contains? (transcript-entry-text entry) "90000"))
+    (test-case "mid-turn-over-budget: handles missing fields gracefully"
+      (define s0 (initial-ui-state))
+      (define evt (make-test-event "context.mid-turn-over-budget" (hash)))
+      (define s1 (apply-event-to-state s0 evt))
+      (define entries (ui-state-transcript s1))
+      (check > (length entries) 0 "adds entry even with missing fields"))
+    ;; ============================================================
+    ;; auto-retry.start with errorType
+    ;; ============================================================
+    (test-case "auto-retry.start: timeout error type label"
+      (define s0 (initial-ui-state))
+      (define evt
+        (make-test-event "auto-retry.start" (hash 'attempt 1 'maxRetries 3 'errorType 'timeout)))
+      (define s1 (apply-event-to-state s0 evt))
+      (define entries (ui-state-transcript s1))
+      (check > (length entries) 0)
+      (define entry (last entries))
+      (check-equal? (transcript-entry-kind entry) 'system)
+      (check-contains? (transcript-entry-text entry) "LLM timeout"))
+    (test-case "auto-retry.start: rate-limit error type label"
+      (define s0 (initial-ui-state))
+      (define evt
+        (make-test-event "auto-retry.start" (hash 'attempt 2 'maxRetries 3 'errorType 'rate-limit)))
+      (define s1 (apply-event-to-state s0 evt))
+      (define entry (last (ui-state-transcript s1)))
+      (check-contains? (transcript-entry-text entry) "rate limited"))
+    (test-case "auto-retry.start: context-overflow error type label"
+      (define s0 (initial-ui-state))
+      (define evt
+        (make-test-event "auto-retry.start"
+                         (hash 'attempt 1 'maxRetries 3 'errorType 'context-overflow)))
+      (define s1 (apply-event-to-state s0 evt))
+      (define entry (last (ui-state-transcript s1)))
+      (check-contains? (transcript-entry-text entry) "context too large"))
+    (test-case "auto-retry.start: provider-error error type label"
+      (define s0 (initial-ui-state))
+      (define evt
+        (make-test-event "auto-retry.start"
+                         (hash 'attempt 1 'maxRetries 3 'errorType 'provider-error)))
+      (define s1 (apply-event-to-state s0 evt))
+      (define entry (last (ui-state-transcript s1)))
+      (check-contains? (transcript-entry-text entry) "server error"))
+    (test-case "auto-retry.start: no errorType falls back to generic"
+      (define s0 (initial-ui-state))
+      (define evt (make-test-event "auto-retry.start" (hash 'attempt 1 'maxRetries 3)))
+      (define s1 (apply-event-to-state s0 evt))
+      (define entry (last (ui-state-transcript s1)))
+      ;; Generic fallback: "[retry: attempt 1/3]" — no type-specific label like "LLM timeout"
+      (check-contains? (transcript-entry-text entry) "attempt 1/3")
+      (check-false (string-contains? (transcript-entry-text entry) "LLM timeout"))
+      (check-false (string-contains? (transcript-entry-text entry) "rate limited")))
+    (test-case "auto-retry.start: clears streaming state"
+      (define s0
+        (set-streaming-thinking (set-streaming-text (initial-ui-state) "partial...") "thinking..."))
+      (define evt (make-test-event "auto-retry.start" (hash 'attempt 1 'maxRetries 3)))
+      (define s1 (apply-event-to-state s0 evt))
+      (check-false (ui-state-streaming-text s1))
+      (check-false (ui-state-streaming-thinking s1)))))
 
-(run-test test-tui-exploration-events)
+(module+ main
+  (require rackunit/text-ui)
+  (exit (run-tests test-tui-exploration-events)))

--- a/tests/tui/test-tool-dedup.rkt
+++ b/tests/tui/test-tool-dedup.rkt
@@ -33,7 +33,7 @@
       (define st (initial-ui-state))
       (define evt1 (make-test-event "tool.call.started" (hasheq 'name "bash" 'arguments "ls")))
       (define evt2
-        (make-test-event "tool.execution.started" (hasheq 'tool-name "bash" 'arguments "ls")))
+        (make-test-event "tool.execution.started" (hasheq 'toolName "bash" 'arguments "ls")))
       (define result (simulate-events st (list evt1 evt2)))
       ;; Only one tool-start entry should appear
       (define tool-starts (filter (lambda (k) (eq? k 'tool-start)) (transcript-types result)))
@@ -43,7 +43,7 @@
       (define st (initial-ui-state))
       (define evt1 (make-test-event "tool.call.started" (hasheq 'name "bash" 'arguments "ls")))
       (define evt2
-        (make-test-event "tool.execution.started" (hasheq 'tool-name "read" 'arguments "foo.txt")))
+        (make-test-event "tool.execution.started" (hasheq 'toolName "read" 'arguments "foo.txt")))
       (define result (simulate-events st (list evt1 evt2)))
       (define tool-starts (filter (lambda (k) (eq? k 'tool-start)) (transcript-types result)))
       (check-equal? (length tool-starts) 2 "different tools should each produce a tool-start"))
@@ -53,9 +53,9 @@
       (define events
         (list (make-test-event "tool.call.started" (hasheq 'name "bash" 'arguments "ls"))
               (make-test-event "tool.execution.completed"
-                               (hasheq 'tool-name "bash" 'result-summary 'completed))
+                               (hasheq 'toolName "bash" 'resultSummary 'completed))
               (make-test-event "tool.execution.completed"
-                               (hasheq 'tool-name "bash" 'result-summary 'completed))))
+                               (hasheq 'toolName "bash" 'resultSummary 'completed))))
       (define result (simulate-events st events))
       (define tool-ends
         (filter (lambda (k) (memq k '(tool-end tool-fail))) (transcript-types result)))
@@ -84,4 +84,4 @@
 
 (module+ main
   (require rackunit/text-ui)
-  (run-tests tool-start-dedup-tests))
+  (exit (run-tests tool-start-dedup-tests)))


### PR DESCRIPTION
## Wave 0: CLI + Test CamelCase Fixes (NF7+NF8)

- **S1**: Fixed 3 kebab-case key reads in `cli/render.rkt` (`'tool-name`→`'toolName`, `'result-summary`→`'resultSummary`)
- **S2**: Fixed 6 stale kebab keys + exit code in `tests/tui/test-tool-dedup.rkt`
- **S3**: Fixed 6 `'max-retries`→`'maxRetries` + converted `define-test-suite`→`test-suite` + proper exit code in `tests/test-tui-exploration-events.rkt`

All 17 tests pass (5 dedup + 12 exploration).

Closes #4373