### PR TITLE
fix: OBS metrics fixes (NF9+NF11+NF15) (#4374)

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ q/
 | Test files | 586 |
 | Source modules | 428 |
 | Source lines | 65869 |
-| Test lines | 102964 |
+| Test lines | 102968 |
 | Test assertions | 16054 |
 | Tests passing | 5835+ | `racket scripts/run-tests.rkt` results |
 

--- a/runtime/context-assembly/serialization.rkt
+++ b/runtime/context-assembly/serialization.rkt
@@ -48,7 +48,8 @@
          entry->context-message
          load-agents-context
          build-system-preamble
-         truncate-messages-to-budget)
+         truncate-messages-to-budget
+         gsd-progress-message?)
 
 ;; Default tier boundaries
 (define DEFAULT-TIER-B-COUNT 20)

--- a/runtime/turn-orchestrator.rkt
+++ b/runtime/turn-orchestrator.rkt
@@ -78,6 +78,7 @@
                   working-set-resolve-messages
                   working-set-entry-count
                   working-set-token-count)
+         (only-in "context-assembly/serialization.rkt" gsd-progress-message?)
          (only-in "../runtime/tool-coordinator.rkt"
                   handle-tool-calls-pending
                   extract-tool-calls-from-messages)
@@ -239,13 +240,10 @@
   ;; Compute summary length from compaction-summary messages
   (define summary-len
     (for/sum ([m (in-list ctx-assembled)] #:when (eq? (message-kind m) 'compaction-summary))
-             (define content (message-content m))
-             (if (string? content)
-                 (string-length content)
-                 0)))
-  ;; Count GSD-pinned messages (context-assembly-summary kind)
-  (define gsd-pinned
-    (for/sum ([m (in-list ctx-assembled)] #:when (eq? (message-kind m) 'context-assembly-summary)) 1))
+             (for/sum ([p (in-list (message-content m))] #:when (text-part? p))
+                      (string-length (text-part-text p)))))
+  ;; Count GSD-pinned messages (using gsd-progress-message? predicate)
+  (define gsd-pinned (for/sum ([m (in-list ctx-assembled)] #:when (gsd-progress-message? m)) 1))
   (emit-typed-event! bus
                      (make-context-assembly-detail-event
                       #:session-id session-id
@@ -265,7 +263,8 @@
                       #:ws-tokens (if ws
                                       (working-set-token-count ws)
                                       0)
-                      #:cache-hit-p #f))
+                      #:cache-hit-p #f) ;; TODO: future — track context cache hits from provider
+                     )
 
   ;; Dispatch 'context hook — extensions can amend final context
   (define-values (ctx-final _ctx-hook) (maybe-dispatch-hooks ext-reg 'context ctx-assembled))


### PR DESCRIPTION
## Wave 1: OBS Metrics Fixes (NF9+NF11+NF15)

- **S4**: Fixed `summary-length` type-check — iterate over `text-part?` content parts instead of treating `message-content` as string
- **S5**: Fixed `gsd-pinned-count` — use `gsd-progress-message?` predicate instead of wrong `context-assembly-summary` kind check. Exported `gsd-progress-message?` from serialization.rkt.
- **S6**: Documented `cache-hit-p #f` stub with TODO comment

36 context-assembly tests pass.

Closes #4374