### PR TITLE
fix: selection rescue + dead imports (NF12+NF13) (#4376)

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ q/
 |--------|-------|
 | Test files | 586 |
 | Source modules | 428 |
-| Source lines | 65869 |
+| Source lines | 65880 |
 | Test lines | 102968 |
 | Test assertions | 16054 |
 | Tests passing | 5835+ | `racket scripts/run-tests.rkt` results |

--- a/runtime/context-assembly/selection.rkt
+++ b/runtime/context-assembly/selection.rkt
@@ -26,7 +26,8 @@
          (only-in "../context-policy.rkt"
                   estimate-message-tokens
                   ensure-first-user-pinned
-                  fit-messages-pair-preserving)
+                  fit-messages-pair-preserving
+                  fit-messages-with-importance-rescue)
          (only-in "../context-pinning.rkt" partition-messages/working-set)
          (only-in "../working-set.rkt" working-set? working-set-resolve-messages)
          "budgeting.rkt"
@@ -179,7 +180,8 @@
     (if (<= remaining-budget 0)
         (values '() removable)
         (let ()
-          (define kept (fit-messages-pair-preserving removable remaining-budget memoized-estimate))
+          (define kept
+            (fit-messages-with-importance-rescue removable remaining-budget memoized-estimate))
           (define kept-ids
             (for/hash ([m (in-list kept)])
               (values (message-id m) #t)))

--- a/runtime/context-fit.rkt
+++ b/runtime/context-fit.rkt
@@ -12,7 +12,6 @@
          (only-in "../runtime/context-policy.rkt"
                   estimate-message-tokens
                   ensure-first-user-pinned
-                  fit-messages-pair-preserving
                   fit-messages-with-importance-rescue))
 
 (provide truncate-messages-to-budget

--- a/runtime/session-lifecycle.rkt
+++ b/runtime/session-lifecycle.rkt
@@ -44,8 +44,7 @@
          (only-in "../runtime/context-assembly.rkt"
                   build-session-context
                   build-tiered-context-with-hooks
-                  tiered-context->message-list
-                  tiered-context?)
+                  tiered-context->message-list)
          (only-in "../runtime/working-set.rkt"
                   make-working-set
                   working-set-reset!

--- a/runtime/turn-orchestrator.rkt
+++ b/runtime/turn-orchestrator.rkt
@@ -60,7 +60,7 @@
          (only-in "../runtime/settings.rkt" setting-ref setting-ref*)
          ;; Transitive dependency of tool-coordinator
          "../tools/scheduler.rkt"
-         ;; Context assembly hook dispatch (dispatch-hooks for build-assembled-context)
+         ;; Context assembly: tiered context build with hooks + importance rescue
          "../extensions/hooks.rkt"
          (only-in "../extensions/context.rkt" make-extension-ctx)
          "../runtime/session-store.rkt"


### PR DESCRIPTION
## Wave 3: Selection Rescue + Dead Imports (NF12+NF13)

- **S8**: Wired `fit-messages-with-importance-rescue` in `selection.rkt` replacing direct `fit-messages-pair-preserving` call — important messages now survive context trimming
- **S9**: Removed dead imports — `tiered-context?` from session-lifecycle.rkt, `fit-messages-pair-preserving` from context-fit.rkt, updated stale comment in turn-orchestrator.rkt

41 tests pass (36 context-assembly + 5 context-fit).

Closes #4376