### PR TITLE
chore: v0.45.8 version bump + changelog + docs (#4378)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## v0.45.8 — 2026-05-15
+
+### Fixed
+- **NF7**: CLI render.rkt — fixed 3 kebab→camelCase key reads (`toolName`, `resultSummary`)
+- **NF8**: Test files — fixed stale kebab keys in test-tool-dedup.rkt and test-tui-exploration-events.rkt
+- **NF9**: turn-orchestrator.rkt — fixed `summary-length` type-check (iterate over text-part content)
+- **NF10**: session-lifecycle.rkt — wired working-set message injection into tiered context build
+- **NF11**: turn-orchestrator.rkt — fixed `gsd-pinned-count` using `gsd-progress-message?` predicate
+- **NF12**: Removed dead imports from session-lifecycle.rkt, context-fit.rkt, turn-orchestrator.rkt
+- **NF13**: selection.rkt — wired `fit-messages-with-importance-rescue` for importance-aware trimming
+- **NF14**: run-tests.rkt — merged stderr+stdout for rackunit text-ui result parsing
+- **NF15**: Documented `cache-hit-p` stub with TODO comment
+
 ## v0.45.7 — 2026-05-15
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.45.7-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.45.8-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 
@@ -199,7 +199,7 @@ racket main.rkt --model gpt-5.4 "write a test"
 ### Verify
 
 ```bash
-racket main.rkt --version  # q version 0.45.7
+racket main.rkt --version  # q version 0.45.8
 raco test tests/           # run the full test suite
 ```
 
@@ -272,7 +272,7 @@ q/
 |--------|-------|
 | Test files | 586 |
 | Source modules | 428 |
-| Source lines | 65880 |
+| Source lines | 65882 |
 | Test lines | 102968 |
 | Test assertions | 16054 |
 | Tests passing | 5835+ | `racket scripts/run-tests.rkt` results |
@@ -403,9 +403,9 @@ When q executes shell commands on behalf of an LLM, arguments are quoted via `sh
 
 
 
-**v0.45.7** — Fixed
+**v0.45.8** — Fixed
 
-**v0.45.7** — Fixed
+**v0.45.8** — Fixed
 
 **v0.45.5** — Fixed
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -2,7 +2,7 @@
 
 ## Version
 
-v0.45.7
+v0.45.8
 
 ## Layer Diagram
 

--- a/docs/event-taxonomy.md
+++ b/docs/event-taxonomy.md
@@ -1,6 +1,6 @@
 # Q Event Taxonomy Reference
 
-Complete reference for all event types in Q 0.45.7.
+Complete reference for all event types in Q 0.45.8.
 ## Base Types
 
 ### `event` (protocol-level)

--- a/docs/extension-guide.md
+++ b/docs/extension-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.45.7 --># Extension Development Guide
+<!-- verified-against: 0.45.8 --># Extension Development Guide
 
 This guide walks you through creating, testing, and activating a custom
 extension for q.

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.45.7 --># Getting Started
+<!-- verified-against: 0.45.8 --># Getting Started
 
 Welcome to q, a Racket-based coding agent.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.45.7 --># Installation Guide
+<!-- verified-against: 0.45.8 --># Installation Guide
 
 <!-- This file is the canonical source. The docs/getting-started/installation.md copy is maintained for the doc site build. -->
 

--- a/docs/security-trust-model.md
+++ b/docs/security-trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.45.7 --># Security & Trust Model
+<!-- verified-against: 0.45.8 --># Security & Trust Model
 
 This document provides an honest, per-area assessment of what q enforces
 today and what is planned. It is the authoritative reference for security

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -130,6 +130,6 @@ is the primary self-hosting extension:
 (load-extension! ext-reg "path/to/extension.rkt" #:event-bus bus)
 ```
 
-## Version 0.45.7
+## Version 0.45.8
 
-This documentation reflects q 0.45.7.
+This documentation reflects q 0.45.8.

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.45.7 --># q Source Style Guide
+<!-- verified-against: 0.45.8 --># q Source Style Guide
 
 This document defines formatting and naming conventions for the q Racket codebase.
 All changes to `q/` source files (excluding `tests/`) should follow these rules.

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.45.7 --># Trust Model
+<!-- verified-against: 0.45.8 --># Trust Model
 
 ## Trust Levels
 

--- a/docs/workflow-testing.md
+++ b/docs/workflow-testing.md
@@ -121,6 +121,6 @@ Use relative paths from the test file:
 4. Use `(check-true ...)` for boolean assertions
 5. Keep tests independent — no shared mutable state between test-cases
 
-## Version 0.45.7
+## Version 0.45.8
 
-This documentation reflects q 0.45.7.
+This documentation reflects q 0.45.8.

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.45.7")
+(define version "0.45.8")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base"))

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -10,4 +10,4 @@
 (provide q-version)
 
 (: q-version String)
-(define q-version "0.45.7")
+(define q-version "0.45.8")

--- a/wiki-src/Architecture-Overview.md
+++ b/wiki-src/Architecture-Overview.md
@@ -35,7 +35,7 @@ User input → Interface (CLI/TUI/RPC)
     → Events emitted to bus
 ```
 
-## Metrics (0.45.7)
+## Metrics (0.45.8)
 > _See `racket scripts/metrics.rkt` for current numbers._
 
 - 414 source modules, 534 test files


### PR DESCRIPTION
## Wave 5: Version Bump + Full Regression

- Version bump `0.45.7` → `0.45.8` in `util/version.rkt`, `info.rkt`
- CHANGELOG entry with all 9 findings (NF7–NF15)
- Version lint clean across all docs
- README status sync
- All key tests pass: 41 context-assembly, 7 session-lifecycle, 5 tool-dedup, 12 exploration-events

Closes #4378