### PR TITLE
fix: dead import cleanup (AF1+AF2+AF3) (#4385)

### DIFF
--- a/runtime/context-assembly/selection.rkt
+++ b/runtime/context-assembly/selection.rkt
@@ -26,7 +26,6 @@
          (only-in "../context-policy.rkt"
                   estimate-message-tokens
                   ensure-first-user-pinned
-                  fit-messages-pair-preserving
                   fit-messages-with-importance-rescue)
          (only-in "../context-pinning.rkt" partition-messages/working-set)
          (only-in "../working-set.rkt" working-set? working-set-resolve-messages)

--- a/runtime/session-lifecycle.rkt
+++ b/runtime/session-lifecycle.rkt
@@ -23,14 +23,9 @@
          racket/path
          (only-in "../util/protocol-types.rkt"
                   message-id
-                  message-role
-                  message-content
                   message-kind
-                  message-meta
-                  message-parent-id
                   make-message
                   make-text-part
-                  content-part->jsexpr
                   loop-result-termination-reason
                   make-loop-result)
          "../agent/event-bus.rkt"
@@ -38,7 +33,6 @@
          (only-in "../util/errors.rkt" raise-session-error)
          "../runtime/session-store.rkt"
          "../runtime/session-index.rkt"
-         (only-in "../util/event-types.rkt" injection-event-topic)
          (only-in "../util/event-payloads.rkt" error-payload input-payload payload->hash)
          (only-in "../util/error-helpers.rkt" with-telemetry)
          (only-in "../runtime/context-assembly.rkt"
@@ -48,7 +42,6 @@
          (only-in "../runtime/working-set.rkt"
                   make-working-set
                   working-set-reset!
-                  working-set-entries
                   working-set-resolve-messages)
          (only-in "../runtime/session-context.rkt" extract-path-settings)
          "../util/ids.rkt"


### PR DESCRIPTION
## Wave 0: Dead Import Cleanup (AF1+AF2+AF3)

- **S1**: Removed 7 dead imports from session-lifecycle.rkt: `message-role`, `message-content`, `message-meta`, `message-parent-id`, `content-part->jsexpr`, `injection-event-topic`, `working-set-entries`
- **S2**: Removed dead `fit-messages-pair-preserving` from selection.rkt

36 context-assembly + 7 session-lifecycle tests pass.

Closes #4385