### PR TITLE
fix: empty-response detection (AF4/RC1) (#4386)

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ q/
 |--------|-------|
 | Test files | 586 |
 | Source modules | 428 |
-| Source lines | 65882 |
+| Source lines | 65874 |
 | Test lines | 102968 |
 | Test assertions | 16054 |
 | Tests passing | 5835+ | `racket scripts/run-tests.rkt` results |

--- a/agent/loop-stream.rkt
+++ b/agent/loop-stream.rkt
@@ -72,11 +72,16 @@
     (for/first ([c (in-list chunks)]
                 #:when (stream-chunk-finish-reason c))
       (stream-chunk-finish-reason c)))
-  (hasheq 'text (apply string-append text-parts)
-          'thinking (apply string-append thinking-parts)
-          'tool-calls tool-calls
-          'usage usage
-          'finish-reason finish-reason))
+  (hasheq 'text
+          (apply string-append text-parts)
+          'thinking
+          (apply string-append thinking-parts)
+          'tool-calls
+          tool-calls
+          'usage
+          usage
+          'finish-reason
+          finish-reason))
 
 ;; ============================================================
 ;; stream-from-provider
@@ -404,6 +409,12 @@
   (define all-chunks (reverse (hash-ref stream-data 'all-chunks)))
   (define acc (accumulate-stream-chunks all-chunks))
   (define accumulated-text (hash-ref acc 'text))
+
+  ;; AF4 (RC1): Warn on empty assistant response (thinking-only model output)
+  (when (and (string=? accumulated-text "") (null? (hash-ref acc 'tool-calls)))
+    (log-warning "q: empty assistant response — model returned no text content (session=~a turn=~a)"
+                 session-id
+                 turn-id))
 
   (define text-part (make-text-part accumulated-text))
 

--- a/tests/test-stream.rkt
+++ b/tests/test-stream.rkt
@@ -4,7 +4,8 @@
 
 (require rackunit
          "../llm/stream.rkt"
-         "../llm/model.rkt")
+         "../llm/model.rkt"
+         "../agent/loop-stream.rkt")
 
 ;; ============================================================
 ;; parse-sse-line tests
@@ -342,3 +343,22 @@
   ;; Now no more data — should timeout quickly (0.05s stream)
   (check-exn exn:fail:network:timeout? (lambda () (gen)))
   (close-output-port out))
+
+;; ============================================================
+;; v0.45.9 AF4: empty-response detection tests
+;; ============================================================
+
+(test-case "AF4: accumulate-stream-chunks returns empty text for thinking-only chunks"
+  (define thinking-chunk
+    (make-stream-chunk #f #f #f #f #:delta-thinking "Let me think..." #:finish-reason 'stop))
+  (define acc (accumulate-stream-chunks (list thinking-chunk)))
+  (check-equal? (hash-ref acc 'text) "")
+  (check-equal? (hash-ref acc 'tool-calls) '())
+  (check-not-false (hash-ref acc 'thinking)))
+
+(test-case "AF4: accumulate-stream-chunks returns text for mixed chunks"
+  (define text-chunk
+    (make-stream-chunk "Hello" #f #f #f #:finish-reason 'stop))
+  (define acc (accumulate-stream-chunks (list text-chunk)))
+  (check-equal? (hash-ref acc 'text) "Hello")
+  (check-equal? (hash-ref acc 'tool-calls) '()))


### PR DESCRIPTION
## Wave 1: Empty-Response Detection (AF4/RC1)

- **S3**: Added `log-warning` in `build-stream-result` when accumulated-text is empty and no tool-calls — detects thinking-only model outputs
- **S4**: Added 2 tests in test-stream.rkt verifying `accumulate-stream-chunks` returns empty text for thinking-only chunks

72 stream tests pass.

Closes #4386