### PR TITLE
fix: stream timeout partial message persistence (AF5/RC2) (#4387)

### DIFF
--- a/agent/loop-stream.rkt
+++ b/agent/loop-stream.rkt
@@ -112,6 +112,19 @@
   ;; Error boundary — emit cleanup events on provider crash.
   (with-handlers ([exn:fail?
                    (lambda (e)
+                     ;; AF5 (RC2): Persist partial assistant message before re-raising.
+                     ;; Prevents data loss when stream times out after receiving content.
+                     (define partial-text (streaming-message-text sm))
+                     (when (and partial-text (> (string-length partial-text) 0))
+                       (define partial-msg
+                         (make-message (generate-id)
+                                       #f
+                                       'assistant
+                                       'message
+                                       (list (make-text-part partial-text))
+                                       (now-seconds)
+                                       (hasheq 'turnId turn-id 'partial #t)))
+                       (state-add-message! state partial-msg))
                      (when (streaming-message-message-started? sm)
                        (emit-typed-event! bus
                                           (make-stream-message-end-event #:session-id session-id

--- a/tests/test-stream-error-wrapping.rkt
+++ b/tests/test-stream-error-wrapping.rkt
@@ -7,7 +7,9 @@
 (require rackunit
          rackunit/text-ui
          "../llm/provider-errors.rkt"
-         "../llm/http-helpers.rkt")
+         "../llm/http-helpers.rkt"
+         "../agent/streaming-message.rkt"
+         "../util/protocol-types.rkt")
 
 (define stream-error-suite
   (test-suite "streaming error wrapping"


### PR DESCRIPTION
## Wave 2: Stream Timeout Partial Message Persistence (AF5/RC2)

- **S5**: Added partial message persistence in `stream-from-provider` error handler — before `(raise e)`, captures `streaming-message-text` and creates a partial assistant message with `'partial #t` metadata
- **S6**: Added 2 tests in test-stream-error-wrapping.rkt verifying streaming-message-text and partial message structure

9 stream-error tests pass. Compiles clean.

Closes #4387