### PR TITLE
chore: v0.45.10 version bump + changelog + docs (#4401)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 ## v0.45.10 — 2026-05-16
 
 ### Fixed
+- **NF1**: Partial messages from stream errors now persist to session.jsonl via loop-state flush
+- **NF2**: Added test coverage for partial message persistence (2 tests)
+- **NF3**: Replaced log-warning with event bus emission for empty-response detection (observable by TUI/extensions)
+- **NF4**: Fixed whitespace-only response false-negative (uses string-trim)
+- **NF5**: Added thinking-length and model context to empty-response warning
+- **NF6**: Retry context pollution prevention verified — error path returns original context, not loop-state
+
+
+## v0.45.10 — 2026-05-16
+
+### Fixed
 - **NF1**: Partial messages from stream errors now flushed to session.jsonl via
   `current-loop-state-for-error-recovery` parameter (was in-memory only)
 - **NF3**: Empty-response warning now uses event bus (`runtime.warning`) instead

--- a/README.md
+++ b/README.md
@@ -271,8 +271,8 @@ q/
 | Metric | Value |
 |--------|-------|
 | Test files | 586 |
-| Source modules | 429 |
-| Source lines | 66188 |
+| Source modules | 428 |
+| Source lines | 65944 |
 | Test lines | 103173 |
 | Test assertions | 16075 |
 | Tests passing | 5835+ | `racket scripts/run-tests.rkt` results |
@@ -406,9 +406,9 @@ When q executes shell commands on behalf of an LLM, arguments are quoted via `sh
 
 **v0.45.10** — Fixed
 
-**v0.45.9** — Fixed
+**v0.45.10** — Fixed
 
-**v0.45.9** — Fixed
+**v0.45.10** — Fixed
 
 **v0.45.5** — Fixed
 


### PR DESCRIPTION
## Wave 3: Version Bump + Full Regression

- Version bump `0.45.9` → `0.45.10` in `util/version.rkt`, `info.rkt`
- CHANGELOG entry with NF1–NF6 findings (all verified already in place)
- Version lint clean, README synced
- 122 context-assembly + 75 stream + 11 stream-error tests pass

Closes #4401