### PR TITLE
feat: SSE stream wall-clock deadline + consecutive-empty counter (#4402)

### DIFF
--- a/llm/stream.rkt
+++ b/llm/stream.rkt
@@ -358,10 +358,25 @@
 ;; The port is NOT closed by this function — the caller is responsible.
 (define (read-sse-chunks port
                          #:initial-timeout [initial-secs http-read-timeout-default]
-                         #:stream-timeout [stream-secs http-stream-timeout-default])
+                         #:stream-timeout [stream-secs http-stream-timeout-default]
+                         #:max-total-timeout [max-total-secs 600])
   (generator ()
              (define stream-start (current-inexact-milliseconds))
-             (let loop ([first-read? #t])
+             (define deadline (+ stream-start (* max-total-secs 1000.0)))
+             ;; v0.45.11: Consecutive empty/comment line counter.
+             ;; Prevents infinite loops when server sends keep-alives indefinitely.
+             (define max-consecutive-empty 100)
+             (let loop ([first-read? #t]
+                        [consecutive-empty 0])
+               ;; v0.45.11: Wall-clock deadline — fires regardless of keep-alives
+               (when (> (current-inexact-milliseconds) deadline)
+                 (raise (exn:fail:network:timeout
+                         (format "Stream exceeded maximum total duration (~a seconds)" max-total-secs)
+                         (current-continuation-marks))))
+               (when (>= consecutive-empty max-consecutive-empty)
+                 (raise (exn:fail:network:timeout (format "Stream exceeded ~a consecutive empty lines"
+                                                          max-consecutive-empty)
+                                                  (current-continuation-marks))))
                ;; v0.14.1: Adaptive per-chunk timeout for long generation
                (define elapsed-ms (- (current-inexact-milliseconds) stream-start))
                (define base-timeout (if first-read? initial-secs stream-secs))
@@ -383,5 +398,5 @@
                     [(eq? parsed 'done) (yield #f)]
                     [(hash? parsed)
                      (yield (normalize-openai-chunk parsed))
-                     (loop #f)]
-                    [else (loop #f)])]))))
+                     (loop #f 0)]
+                    [else (loop #f (add1 consecutive-empty))])]))))

--- a/tests/test-stream.rkt
+++ b/tests/test-stream.rkt
@@ -492,3 +492,44 @@
   (check-equal? (length (unbox warning-events)) 1)
   (check-equal? (hash-ref (event-payload (car (unbox warning-events))) 'warning)
                 "empty-assistant-response"))
+
+;; ============================================================
+;; v0.45.11 W0: Wall-clock deadline + consecutive-empty tests
+;; ============================================================
+
+(test-case "v0.45.11: wall-clock deadline fires for slow stream"
+  ;; Sleep between generator calls to let the deadline expire.
+  (define lines (string-append "data: {\"choices\":[]}\n\n"
+                               "data: {\"choices\":[]}\n\n"))
+  (define in (open-input-string lines))
+  (define gen (read-sse-chunks in #:max-total-timeout 0.05))
+  ;; First read succeeds
+  (define first (gen))
+  (check-not-false first)
+  ;; Sleep past the 50ms deadline
+  (sleep 0.1)
+  ;; Now the deadline check should fire
+  (check-exn exn:fail:network:timeout?
+             (lambda () (gen))))
+(test-case "v0.45.11: consecutive-empty abort after 100 empty lines"
+  ;; Feed 101 empty lines (no data: prefix) -- should abort after 100
+  (define empty-lines (make-string 404 #\newline)) ;; 101 newlines = 101 empty lines
+  (define in (open-input-string empty-lines))
+  (define gen (read-sse-chunks in
+                               #:initial-timeout 5
+                               #:stream-timeout 5
+                               #:max-total-timeout 600))
+  (check-exn exn:fail:network:timeout?
+             (lambda ()
+               (let loop ()
+                 (define v (gen))
+                 (when v (loop))))))
+
+(test-case "v0.45.11: normal stream with default max-total-timeout works"
+  (define in (open-input-string "data: {\"choices\":[]}\ndata: [DONE]\n"))
+  (define gen (read-sse-chunks in #:max-total-timeout 600))
+  ;; Should yield a chunk then #f -- no timeout
+  (define first (gen))
+  (check-not-false first)
+  (define second (gen))
+  (check-false second))


### PR DESCRIPTION
## Wave 0: SSE Stream Wall-Clock Deadline

- Added `#:max-total-timeout` parameter to `read-sse-chunks` (default 600s)
- Wall-clock deadline checked at top of every loop iteration — fires regardless of keep-alive lines
- Consecutive-empty counter aborts after 100 non-data lines
- 3 new tests: deadline fires with sleep, consecutive-empty abort, normal stream still works
- 78 stream tests pass

Closes #4402