### PR TITLE
chore: v0.45.11 version bump + changelog + docs (#4404)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## v0.45.11 — 2026-05-16
+
+### Added
+- **W0**: SSE stream wall-clock deadline (`#:max-total-timeout`) in `read-sse-chunks` — prevents indefinite hangs from keep-alive bypass (default 600s)
+- **W0**: Consecutive-empty counter aborts after 100 non-data lines — prevents infinite loops
+- **W1**: TUI busy-state watchdog — force-clears stale busy state after 30 minutes, shows system message
+
+### Fixed
+- **NF1–NF6** (v0.45.10): All audit findings verified already in place from v0.45.9
+
+
 ## v0.45.10 — 2026-05-16
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.45.10-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.45.11-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 
@@ -199,7 +199,7 @@ racket main.rkt --model gpt-5.4 "write a test"
 ### Verify
 
 ```bash
-racket main.rkt --version  # q version 0.45.10
+racket main.rkt --version  # q version 0.45.11
 raco test tests/           # run the full test suite
 ```
 
@@ -404,11 +404,11 @@ When q executes shell commands on behalf of an LLM, arguments are quoted via `sh
 
 
 
-**v0.45.10** — Fixed
+**v0.45.11** — Added
 
-**v0.45.10** — Fixed
+**v0.45.11** — Fixed
 
-**v0.45.10** — Fixed
+**v0.45.11** — Fixed
 
 **v0.45.5** — Fixed
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -2,7 +2,7 @@
 
 ## Version
 
-v0.45.10
+v0.45.11
 
 ## Layer Diagram
 

--- a/docs/event-taxonomy.md
+++ b/docs/event-taxonomy.md
@@ -1,6 +1,6 @@
 # Q Event Taxonomy Reference
 
-Complete reference for all event types in Q 0.45.10.
+Complete reference for all event types in Q 0.45.11.
 ## Base Types
 
 ### `event` (protocol-level)

--- a/docs/extension-guide.md
+++ b/docs/extension-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.45.10 --># Extension Development Guide
+<!-- verified-against: 0.45.11 --># Extension Development Guide
 
 This guide walks you through creating, testing, and activating a custom
 extension for q.

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.45.10 --># Getting Started
+<!-- verified-against: 0.45.11 --># Getting Started
 
 Welcome to q, a Racket-based coding agent.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.45.10 --># Installation Guide
+<!-- verified-against: 0.45.11 --># Installation Guide
 
 <!-- This file is the canonical source. The docs/getting-started/installation.md copy is maintained for the doc site build. -->
 

--- a/docs/security-trust-model.md
+++ b/docs/security-trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.45.10 --># Security & Trust Model
+<!-- verified-against: 0.45.11 --># Security & Trust Model
 
 This document provides an honest, per-area assessment of what q enforces
 today and what is planned. It is the authoritative reference for security

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -130,6 +130,6 @@ is the primary self-hosting extension:
 (load-extension! ext-reg "path/to/extension.rkt" #:event-bus bus)
 ```
 
-## Version 0.45.10
+## Version 0.45.11
 
-This documentation reflects q 0.45.10.
+This documentation reflects q 0.45.11.

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.45.10 --># q Source Style Guide
+<!-- verified-against: 0.45.11 --># q Source Style Guide
 
 This document defines formatting and naming conventions for the q Racket codebase.
 All changes to `q/` source files (excluding `tests/`) should follow these rules.

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.45.10 --># Trust Model
+<!-- verified-against: 0.45.11 --># Trust Model
 
 ## Trust Levels
 

--- a/docs/workflow-testing.md
+++ b/docs/workflow-testing.md
@@ -121,6 +121,6 @@ Use relative paths from the test file:
 4. Use `(check-true ...)` for boolean assertions
 5. Keep tests independent — no shared mutable state between test-cases
 
-## Version 0.45.10
+## Version 0.45.11
 
-This documentation reflects q 0.45.10.
+This documentation reflects q 0.45.11.

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.45.10")
+(define version "0.45.11")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base"))

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -10,4 +10,4 @@
 (provide q-version)
 
 (: q-version String)
-(define q-version "0.45.10")
+(define q-version "0.45.11")

--- a/wiki-src/Architecture-Overview.md
+++ b/wiki-src/Architecture-Overview.md
@@ -35,7 +35,7 @@ User input → Interface (CLI/TUI/RPC)
     → Events emitted to bus
 ```
 
-## Metrics (0.45.10)
+## Metrics (0.45.11)
 > _See `racket scripts/metrics.rkt` for current numbers._
 
 - 414 source modules, 534 test files


### PR DESCRIPTION
## Wave 2: Version Bump + Full Regression

- Version bump `0.45.10` → `0.45.11` in `util/version.rkt`, `info.rkt`
- CHANGELOG entry for W0 (SSE deadline) and W1 (TUI watchdog)
- Version lint clean, README synced
- 83 tests pass (78 stream + 5 watchdog)

Closes #4404