### PR TITLE
fix: code hygiene + test additions (v0.45.13 W0 L1+L2+L3) (#4417)

### DIFF
--- a/tui/tui-render-loop.rkt
+++ b/tui/tui-render-loop.rkt
@@ -361,7 +361,7 @@
     ;; Drain all pending events from the channel (non-blocking)
     (drain-events! ctx)
 
-    ;; v0.45.11 W1 / v0.45.12 L3+L4: Busy-state watchdog — force-clear stale busy state
+    ;; Busy-state watchdog — force-clear stale busy state (v0.45.12 L3+L4)
     (define cur-state (unbox (tui-ctx-ui-state-box ctx)))
     (define watchdog-result
       (check-busy-watchdog cur-state (current-inexact-milliseconds) (current-busy-watchdog-ms)))


### PR DESCRIPTION
## W0: Code hygiene + test additions (L1+L2+L3)

- **L1**: Updated stale v0.45.11 comment in `tui/tui-render-loop.rkt` → `v0.45.12 L3+L4`
- **L2**: Deadline first-read test already in `test-stream.rkt` — verified passing
- **L3**: Thinking-only partial message test already in `test-stream-error-wrapping.rkt` — verified passing

97 tests pass (84 stream + 13 stream-error-wrapping).

Closes #4417