### PR TITLE
chore: v0.45.13 version bump + docs sync (#4419)

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,8 +271,8 @@ q/
 | Metric | Value |
 |--------|-------|
 | Test files | 587 |
-| Source modules | 429 |
-| Source lines | 66257 |
+| Source modules | 428 |
+| Source lines | 66013 |
 | Test lines | 103553 |
 | Test assertions | 16142 |
 | Tests passing | 5835+ | `racket scripts/run-tests.rkt` results |


### PR DESCRIPTION
## W2: Version Bump + Full Regression (L4)

- Version `0.45.12` → `0.45.13` in `util/version.rkt`, `info.rkt`
- CHANGELOG entry for all W0/W1 findings
- README status block synced
- Version lint clean
- 109 tests pass (84 stream + 18 stream-error-wrapping + 7 watchdog — note: raco counts differ from individual runs)

Closes #4419