### PR TITLE
fix: busy-state stuck during rapid iterations — remove min-busy-ms guard (#4423)

### DIFF
--- a/runtime/session-lifecycle.rkt
+++ b/runtime/session-lifecycle.rkt
@@ -431,9 +431,18 @@
               user-message))
         (run-prompt-internal sess effective-input max-iterations token-budget-threshold ep! ba!)]))
    ;; Cleanup: always reset prompt-running? even on error
+   ;; v0.45.14: Safety-net turn.completed ensures TUI busy? is always cleared,
+   ;; even if a regression prevents normal event flow.
    ;; B3-A: Emergency persist — defense-in-depth if session not yet persisted
    (lambda ()
      (guarded-set-prompt-running! sess #f)
+     ;; v0.45.14 W0a: Safety-net turn.completed for TUI busy-state recovery
+     (with-handlers ([exn:fail? void])
+       (define sid (agent-session-session-id sess))
+       (define bus (agent-session-event-bus sess))
+       (emit-typed-event!
+        bus
+        (turn-end-event "turn.completed" (current-inexact-milliseconds) sid #f "cleanup" 0)))
      (unless (agent-session-persisted? sess)
        (with-handlers ([exn:fail? void])
          (ensure-persisted! sess))))))

--- a/tests/test-tui-watchdog.rkt
+++ b/tests/test-tui-watchdog.rkt
@@ -10,7 +10,9 @@
          "../tui/state-events.rkt"
          "../tui/state-ui.rkt"
          ;; v0.45.12 L4: Import the actual watchdog function
-         (only-in "../tui/tui-render-loop.rkt" check-busy-watchdog current-busy-watchdog-ms))
+         (only-in "../tui/tui-render-loop.rkt" check-busy-watchdog current-busy-watchdog-ms)
+         ;; v0.45.14: event constructor for apply-event-to-state tests
+         (only-in "tui/event-simulator.rkt" make-test-event))
 
 ;; Helper: create a minimal ui-state for testing
 (define (make-test-state #:busy? [busy? #f] #:busy-since [since #f])
@@ -150,3 +152,61 @@
   (check-true (hash-ref (transcript-entry-meta (first entries)) 'watchdog #f))
   ;; Pre-existing entry is second
   (check-equal? (transcript-entry-text (second entries)) "existing message"))
+
+;; ============================================================
+;; v0.45.14 W0: Rapid-iteration busy-state stuck fix
+;; ============================================================
+
+(test-case "v0.45.14: turn-completed always clears busy? regardless of elapsed time"
+  ;; Even with busy-since very recent (< 500ms), handle-turn-completed must clear busy?
+  (define now (current-inexact-milliseconds))
+  (define st
+    (set-busy (set-busy-since (initial-ui-state #:session-id "test" #:model-name "m") #t) now))
+  ;; Create a turn.completed event
+  (define evt (make-test-event "turn.completed" (hasheq) #:time (+ now 100)))
+  (define result (apply-event-to-state st evt))
+  ;; busy? MUST be #f even though only 100ms elapsed
+  (check-false (ui-state-busy? result))
+  (check-false (ui-state-busy-since result))
+  (check-false (ui-state-pending-tool-name result)))
+
+(test-case "v0.45.14: rapid iteration pattern does not stick busy"
+  ;; Simulate 10 rapid turn.started/turn.completed pairs with short elapsed times
+  (define base (initial-ui-state #:session-id "test" #:model-name "m"))
+  (define (turn-pair st idx)
+    (define start-time (+ (* idx 200) 1000000))
+    (define end-time (+ start-time 150)) ;; 150ms — well under old 500ms threshold
+    (define start-evt (make-test-event "turn.started" (hasheq) #:time start-time))
+    (define after-start (apply-event-to-state st start-evt))
+    ;; Simulate tool activity
+    (define tool-evt
+      (make-test-event "tool.call.started" (hasheq 'name "read") #:time (+ start-time 10)))
+    (define after-tool (apply-event-to-state after-start tool-evt))
+    ;; Complete the turn
+    (define end-evt (make-test-event "turn.completed" (hasheq) #:time end-time))
+    (apply-event-to-state after-tool end-evt))
+  (define final-st
+    (for/fold ([st base]) ([i (in-range 10)])
+      (turn-pair st i)))
+  ;; After 10 rapid iterations, busy? MUST be #f
+  (check-false (ui-state-busy? final-st))
+  (check-false (ui-state-busy-since final-st)))
+
+(test-case "v0.45.14: watchdog does not fire during active streaming"
+  ;; Even with expired busy-since, watchdog returns #f if streaming text is present
+  (define now (+ (current-inexact-milliseconds) (* 31 60 1000)))
+  (define base (set-busy (set-busy-since (initial-ui-state) #t) (- now (* 31 60 1000))))
+  ;; Set streaming text — agent is clearly alive and streaming
+  (define st (set-streaming-text base "partial response text..."))
+  (define result (check-busy-watchdog st now (* 30 60 1000)))
+  ;; Watchdog must NOT fire
+  (check-false result))
+
+(test-case "v0.45.14: turn-cancelled clears busy-since"
+  (define now (current-inexact-milliseconds))
+  (define st
+    (set-busy (set-busy-since (initial-ui-state #:session-id "test" #:model-name "m") #t) now))
+  (define evt (make-test-event "turn.cancelled" (hasheq) #:time (+ now 100)))
+  (define result (apply-event-to-state st evt))
+  (check-false (ui-state-busy? result))
+  (check-false (ui-state-busy-since result)))

--- a/tui/state-events.rkt
+++ b/tui/state-events.rkt
@@ -249,20 +249,15 @@
    (clear-streaming (set-pending-tool-name (set-busy-since (set-busy state #t) (event-time evt)) #f))
    #f))
 
+;; v0.45.14: Removed min-busy-ms anti-flicker guard. Always clear busy? on turn.completed.
+;; The old guard caused busy? to stay #t during rapid iterations (< 500ms each),
+;; leading to false watchdog fires after 30 minutes.
 (define (handle-turn-completed state evt)
-  (define min-busy-ms 500)
-  (define since (ui-state-busy-since state))
-  (define ts (event-time evt))
-  (define elapsed
-    (if since
-        (- ts since)
-        min-busy-ms))
-  (if (< elapsed min-busy-ms)
-      (clear-streaming state)
-      (clear-streaming (set-pending-tool-name (set-busy-since (set-busy state #f) #f) #f))))
+  (clear-streaming (set-pending-tool-name (set-busy-since (set-busy state #f) #f) #f)))
 
+;; v0.45.14: Also clear busy-since for consistency with handle-turn-completed.
 (define (handle-turn-cancelled state evt)
-  (clear-streaming (set-pending-tool-name (set-busy state #f) #f)))
+  (clear-streaming (set-pending-tool-name (set-busy-since (set-busy state #f) #f) #f)))
 
 (define (handle-compaction-warning state evt)
   (define payload (event-payload evt))

--- a/tui/tui-render-loop.rkt
+++ b/tui/tui-render-loop.rkt
@@ -338,9 +338,11 @@
 (define current-busy-watchdog-ms (make-parameter (* 30 60 1000)))
 
 ;; v0.45.12 L4: Extracted watchdog check to a testable pure function.
+;; v0.45.14: Added streaming guard — don't fire if agent is actively streaming.
 ;; Returns #f if no action needed, or the updated state if watchdog fires.
 (define (check-busy-watchdog state now-ms watchdog-ms)
-  (if (ui-state-busy? state)
+  (if (and (ui-state-busy? state)
+           (not (ui-state-streaming-text state))) ;; agent is actively streaming — don't fire
       (let ([since (ui-state-busy-since state)])
         (if (and since (> (- now-ms since) watchdog-ms))
             (let* ([cleared (set-status-message


### PR DESCRIPTION
## W0: Fix busy-state stuck during rapid GSD iterations (HIGH severity)

**Root cause**: `handle-turn-completed` had a `min-busy-ms` (500ms) anti-flicker guard that did NOT clear `busy?` when turns completed quickly. During GSD planning with 10-30+ rapid tool-call iterations (< 500ms each), `busy?` stayed `#t` permanently, causing false watchdog fires after 30 minutes.

**Changes**:
1. **Primary fix**: Remove `min-busy-ms` conditional — always clear `busy?` on `turn.completed`
2. **Consistency**: Clear `busy-since` in `handle-turn-cancelled` too
3. **Defense-in-depth**: Safety-net `turn.completed` with reason `"cleanup"` in `run-prompt!` cleanup thunk
4. **Watchdog streaming guard**: Don't fire watchdog if streaming text is present (agent is clearly alive)

**Tests**: 4 new test cases (16/16 pass)
- `turn-completed always clears busy? regardless of elapsed time`
- `rapid iteration pattern does not stick busy` (10 rapid turn pairs)
- `watchdog does not fire during active streaming`
- `turn-cancelled clears busy-since`

Closes #4423