### PR TITLE
feat: launch wrapper with stale bytecode protection (#4427)

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,28 +178,32 @@ Start your local server (e.g. `llama-server`), then run q.
 ### Run
 
 ```bash
-# Terminal UI (interactive)
+# Terminal UI (interactive) — using stale-bytecode-safe wrapper
+bin/q-tui
+# ...or directly:
 racket main.rkt --tui
 
 # Single-shot prompt
-racket main.rkt "explain what this codebase does"
+bin/q "explain what this codebase does"
 
 # Resume a session
-racket main.rkt --session <session-id>
+bin/q --session <session-id>
 
 # JSON mode (machine-readable output)
-racket main.rkt --json
+bin/q --json
 
 # Override model for this run
-racket main.rkt --model gpt-5.4 "write a test"
+bin/q --model gpt-5.4 "write a test"
 ```
 
-> **Tip:** Create a shell alias for convenience: `alias q='racket /path/to/q/main.rkt'`
+> **Tip:** The `bin/q` and `bin/q-tui` wrappers use `racket --make` for automatic
+> stale-bytecode recompilation after `git pull`. Use them instead of bare
+> `racket main.rkt` to avoid running outdated `.zo` files.
 
 ### Verify
 
 ```bash
-racket main.rkt --version  # q version 0.45.14
+bin/q --version            # q version 0.45.14
 raco test tests/           # run the full test suite
 ```
 

--- a/bin/q
+++ b/bin/q
@@ -1,0 +1,6 @@
+#!/bin/bash
+# bin/q — Launch q with stale bytecode protection
+# The --make flag enables automatic recompilation when source is newer than .zo files.
+# After `git pull`, this ensures the running process picks up source changes immediately.
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+exec racket --make "$SCRIPT_DIR/../main.rkt" "$@"

--- a/bin/q-tui
+++ b/bin/q-tui
@@ -1,0 +1,4 @@
+#!/bin/bash
+# bin/q-tui — Launch q in TUI mode with stale bytecode protection
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+exec racket --make "$SCRIPT_DIR/../main.rkt" --tui "$@"


### PR DESCRIPTION
## W0: Launch wrapper with `racket --make` for stale bytecode protection

**Problem**: After `git pull`, `racket main.rkt` uses stale `.zo` bytecode files instead of updated source.

**Solution**: 
- `bin/q` — wrapper using `racket --make` for automatic recompilation
- `bin/q-tui` — convenience wrapper for TUI mode  
- README updated to document wrapper usage

**Verified**: `bin/q --version` returns correct version; touching source files + re-running auto-recompiles correctly.

Closes #4427