### PR TITLE
test: add regression tests for v0.45.16 shadowing + v0.45.17 contract violation (#4439)

F2: Verify build-session-context (1-arg import) distinct from build-session-context-for-prompt (4-arg local)
F3: Verify non-hash scheduler-batch-stats payloads wrapped before emit-session-event!"

### DIFF
--- a/tests/test-session-lifecycle-pure.rkt
+++ b/tests/test-session-lifecycle-pure.rkt
@@ -11,6 +11,7 @@
 (require rackunit
          rackunit/text-ui
          "../runtime/session-lifecycle.rkt"
+         "../runtime/context-assembly.rkt"
          "../util/protocol-types.rkt")
 
 ;; Build a minimal message for testing
@@ -64,6 +65,23 @@
       ;; Content should contain both instructions separated by double newline
       (define content (hash-ref (content-part->jsexpr (car (message-content sys-msg))) 'text))
       (check-true (string-contains? content "Be helpful"))
-      (check-true (string-contains? content "Be concise")))))
+      (check-true (string-contains? content "Be concise")))
+
+    ;; ── v0.45.16 regression: build-session-context shadowing ──
+    ;; The bug: local 4-arg build-session-context shadowed imported 1-arg version,
+    ;; causing arity crash on 2nd prompt when session has an index.
+    ;; Fix: renamed import → build-session-context/from-index (internal),
+    ;;       local → build-session-context-for-prompt (exported).
+    ;; This test verifies the two functions remain distinct.
+    (test-case "v0.45.16 regression: imported build-session-context distinct from for-prompt"
+      ;; build-session-context from context-assembly (1-arg, the original import)
+      (check-pred procedure? build-session-context)
+      ;; build-session-context-for-prompt from session-lifecycle (4-arg, the local)
+      (check-pred procedure? build-session-context-for-prompt)
+      ;; They must NOT be the same procedure
+      (check-false (eq? build-session-context build-session-context-for-prompt))
+      ;; Verify arities: 1-arg import vs 4-arg local
+      (check-equal? (procedure-arity build-session-context) 1)
+      (check-equal? (procedure-arity build-session-context-for-prompt) 4))))
 
 (run-tests pure-suite 'verbose)

--- a/tests/test-tool-coordinator-pure.rkt
+++ b/tests/test-tool-coordinator-pure.rkt
@@ -11,6 +11,9 @@
 (require rackunit
          rackunit/text-ui
          "../runtime/tool-coordinator.rkt"
+         "../tools/scheduler.rkt"
+         "../agent/event-bus.rkt"
+         "../agent/event-emitter.rkt"
          "../util/protocol-types.rkt")
 
 ;; Helper to extract text string from a tool-result
@@ -67,6 +70,27 @@
       (define result (build-blocked-tool-results (list tc)))
       (check-equal? (length result) 1)
       (check-true (tool-result-is-error? (first result)))
-      (check-true (string-contains? (result-text (first result)) "read")))))
+      (check-true (string-contains? (result-text (first result)) "read")))
+
+    ;; ── v0.45.17 regression: emit-session-event! with non-hash payload ──
+    ;; The bug: tool-coordinator passed raw scheduler-batch-stats struct to
+    ;; emit-session-event! (which expects hash?). Caused contract violation.
+    ;; Fix: wraps non-hash payloads in (hash 'raw payload).
+    (test-case "v0.45.17 regression: non-hash payload wrapped before emit"
+      (define bus (make-event-bus))
+      (define stats (scheduler-batch-stats 3 3 0 0))
+      ;; Verify stats is NOT a hash (the condition that triggered the bug)
+      (check-false (hash? stats))
+      ;; The wrapping logic from tool-coordinator:
+      ;;   (if (hash? payload) payload (hash 'raw payload))
+      (define wrapped
+        (if (hash? stats)
+            stats
+            (hash 'raw stats)))
+      (check-true (hash? wrapped))
+      (check-equal? (hash-ref wrapped 'raw) stats)
+      ;; emit-session-event! should not crash with the wrapped payload
+      (check-not-exn (lambda ()
+                       (emit-session-event! bus "test-session" "tool.batch.completed" wrapped))))))
 
 (run-tests pure-suite 'verbose)


### PR DESCRIPTION
Addresses #4439.

test: add regression tests for v0.45.16 shadowing + v0.45.17 contract violation (#4439)

F2: Verify build-session-context (1-arg import) distinct from build-session-context-for-prompt (4-arg local)
F3: Verify non-hash scheduler-batch-stats payloads wrapped before emit-session-event!"