### PR TITLE
fix: C1 subagent event-publisher arity + H1 batch-stats→hash conversion (#4450)

C1 CRITICAL: spawn-subagent event-publisher was 1-arg lambda but scheduler calls with
2 args (event-type, payload). Now uses proper 2-arg convention with emit-session-event!.

H1 HIGH: scheduler-batch-stats struct converted to proper hash before event emission.
New scheduler-batch-stats->hash function converts struct fields to accessible hash.
Removed opaque (hash 'raw ...) wrapping from tool-coordinator.

Added test for scheduler-batch-stats->hash conversion."

### DIFF
--- a/runtime/tool-coordinator.rkt
+++ b/runtime/tool-coordinator.rkt
@@ -211,13 +211,7 @@
                                     #:timestamp (current-inexact-milliseconds)
                                     #:tool-name (hash-ref payload 'tool-name)
                                     #:tool-call-id tcid))]
-               [else
-                (emit-session-event! bus
-                                     session-id
-                                     event-type
-                                     (if (hash? payload)
-                                         payload
-                                         (hash 'raw payload)))]))
+               [else (emit-session-event! bus session-id event-type payload)]))
            #:runtime-settings (or (config-settings config)
                                   (make-minimal-settings #:provider (config-provider config)
                                                          #:model (config-model-name config)))

--- a/tests/test-tool-coordinator-pure.rkt
+++ b/tests/test-tool-coordinator-pure.rkt
@@ -73,24 +73,33 @@
       (check-true (string-contains? (result-text (first result)) "read")))
 
     ;; ── v0.45.17 regression: emit-session-event! with non-hash payload ──
-    ;; The bug: tool-coordinator passed raw scheduler-batch-stats struct to
-    ;; emit-session-event! (which expects hash?). Caused contract violation.
-    ;; Fix: wraps non-hash payloads in (hash 'raw payload).
+    ;; Superseded by v0.45.19 fix (scheduler-batch-stats->hash converts at source).
+    ;; Kept as historical regression guard: verifies wrapping fallback works.
     (test-case "v0.45.17 regression: non-hash payload wrapped before emit"
       (define bus (make-event-bus))
       (define stats (scheduler-batch-stats 3 3 0 0))
-      ;; Verify stats is NOT a hash (the condition that triggered the bug)
       (check-false (hash? stats))
-      ;; The wrapping logic from tool-coordinator:
-      ;;   (if (hash? payload) payload (hash 'raw payload))
       (define wrapped
         (if (hash? stats)
             stats
             (hash 'raw stats)))
       (check-true (hash? wrapped))
       (check-equal? (hash-ref wrapped 'raw) stats)
-      ;; emit-session-event! should not crash with the wrapped payload
       (check-not-exn (lambda ()
-                       (emit-session-event! bus "test-session" "tool.batch.completed" wrapped))))))
+                       (emit-session-event! bus "test-session" "tool.batch.completed" wrapped))))
+
+    ;; ── v0.45.19: scheduler-batch-stats→hash conversion ──
+    ;; Replaces opaque (hash 'raw ...) wrapping with proper field-level conversion.
+    ;; Downstream consumers (TUI, RPC, SDK) can now read batch stats fields.
+    (test-case "v0.45.19: scheduler-batch-stats->hash produces correct hash"
+      (define stats (scheduler-batch-stats 5 3 1 1))
+      (define h (scheduler-batch-stats->hash stats))
+      (check-true (hash? h))
+      (check-equal? (hash-ref h 'total) 5)
+      (check-equal? (hash-ref h 'executed) 3)
+      (check-equal? (hash-ref h 'blocked) 1)
+      (check-equal? (hash-ref h 'errors) 1)
+      (define bus (make-event-bus))
+      (check-not-exn (lambda () (emit-session-event! bus "test-session" "tool.batch.completed" h))))))
 
 (run-tests pure-suite 'verbose)

--- a/tools/builtins/spawn-subagent.rkt
+++ b/tools/builtins/spawn-subagent.rkt
@@ -14,6 +14,7 @@
          racket/string
          "../../tools/tool.rkt"
          "../../agent/event-bus.rkt"
+         "../../agent/event-emitter.rkt"
          "../model-bridge.rkt"
          "../../util/ids.rkt"
          (only-in "../../util/protocol-types.rkt"
@@ -247,7 +248,8 @@
       (make-exec-context #:working-directory (if exec-ctx
                                                  (exec-context-working-directory exec-ctx)
                                                  (current-directory))
-                         #:event-publisher (lambda (event) (publish! bus event))
+                         #:event-publisher (lambda (event-type payload)
+                                             (emit-session-event! bus session-id event-type payload))
                          #:runtime-settings settings
                          #:call-id (generate-id)
                          #:session-metadata (hasheq 'session-id session-id 'role "subagent")))

--- a/tools/scheduler.rkt
+++ b/tools/scheduler.rkt
@@ -68,6 +68,7 @@
          (struct-out tool-pre-hook-payload)
          (struct-out tool-post-hook-payload)
          (struct-out scheduler-batch-stats)
+         scheduler-batch-stats->hash
          plan-tool-batch
          execute-tool-plan
          run-preflight
@@ -111,6 +112,20 @@
 (struct tool-pre-hook-payload (tool-name args entry-id) #:transparent)
 (struct tool-post-hook-payload (tool-name result entry-id arguments) #:transparent)
 (struct scheduler-batch-stats (total executed blocked errors) #:transparent)
+
+;; Convert scheduler-batch-stats to a hash for event emission.
+;; Preserves struct for internal use while providing serializable hash
+;; for event bus consumers.
+(define (scheduler-batch-stats->hash s)
+  (hasheq 'total
+          (scheduler-batch-stats-total s)
+          'executed
+          (scheduler-batch-stats-executed s)
+          'blocked
+          (scheduler-batch-stats-blocked s)
+          'errors
+          (scheduler-batch-stats-errors s)))
+
 ;; status: 'ready | 'blocked | 'error
 ;; tool: tool? (#f for blocked/error)
 ;; error-message: string? (#f for ready)
@@ -411,7 +426,7 @@
   (define results (run-execution entries exec-ctx parallel? hook-dispatcher))
   (define metadata (compute-metadata results entries))
   (when ev-pub
-    (ev-pub "tool.batch.completed" metadata))
+    (ev-pub "tool.batch.completed" (scheduler-batch-stats->hash metadata)))
   (scheduler-result results metadata))
 
 ;; Main entry point — backward compatible


### PR DESCRIPTION
Addresses #4450.

fix: C1 subagent event-publisher arity + H1 batch-stats→hash conversion (#4450)

C1 CRITICAL: spawn-subagent event-publisher was 1-arg lambda but scheduler calls with
2 args (event-type, payload). Now uses proper 2-arg convention with emit-session-event!.

H1 HIGH: scheduler-batch-stats struct converted to proper hash before event emission.
New scheduler-batch-stats->hash function converts struct fields to accessible hash.
Removed opaque (hash 'raw ...) wrapping from tool-coordinator.

Added test for scheduler-batch-stats->hash conversion."