### PR TITLE
fix: M1 stale comments + M2 duplicate require + M4 contract docs (#4455)

M1: Updated stale build-session-context references → build-session-context-for-prompt
    in session-lifecycle.rkt comments (lines 12, 135, 138).
M2: Removed duplicate racket/contract require in tool-coordinator.rkt.
M4: Added event-publisher callback contract documentation in tool.rkt."

### DIFF
--- a/runtime/session-lifecycle.rkt
+++ b/runtime/session-lifecycle.rkt
@@ -9,7 +9,7 @@
 ;;
 ;; Provides:
 ;;   run-prompt!             — main entry point for running a user prompt
-;;   build-session-context   — build context from history + system instructions
+;;   build-session-context-for-prompt — build context from history + system instructions
 ;;   dispatch-iteration      — model-select hook + iteration loop dispatch
 ;;   run-prompt-internal     — internal prompt execution (after input hook)
 
@@ -132,10 +132,10 @@
             context-messages)))
 
 ;; ============================================================
-;; build-session-context
+;; build-session-context-for-prompt
 ;; ============================================================
 
-;; build-session-context — context preparation:
+;; build-session-context-for-prompt — context preparation:
 ;;   converts user-message, appends to log, builds/updates index,
 ;;   walks tree via context-assembly, injects system instructions.
 ;;   Returns the context message list.

--- a/runtime/tool-coordinator.rkt
+++ b/runtime/tool-coordinator.rkt
@@ -18,7 +18,6 @@
 ;; header comment for full rationale.
 
 (require racket/contract
-         racket/contract
          racket/list
          racket/path
          json

--- a/tools/tool.rkt
+++ b/tools/tool.rkt
@@ -75,13 +75,16 @@
          (contract-out [make-exec-context
                         (->* ()
                              (#:working-directory (or/c path-string? path? #f)
-                                                  #:cancellation-token (or/c cancellation-token? #f)
-                                                  #:event-publisher (or/c procedure? #f symbol?)
-                                                  #:runtime-settings (or/c hash? q-settings? #f)
-                                                  #:call-id string?
-                                                  #:session-metadata (or/c hash? #f)
-                                                  #:progress-callback (or/c procedure? #f)
-                                                  #:permission-config (or/c permission-config? #f))
+                              #:cancellation-token (or/c cancellation-token? #f)
+                              ;; event-publisher : (or/c #f (-> string? hash? any))
+                              ;; Callback for scheduler lifecycle events. Receives event-type (string)
+                              ;; and payload (hash). Called by execute-tool-plan for batch events.
+                              #:event-publisher (or/c procedure? #f symbol?)
+                              #:runtime-settings (or/c hash? q-settings? #f)
+                              #:call-id string?
+                              #:session-metadata (or/c hash? #f)
+                              #:progress-callback (or/c procedure? #f)
+                              #:permission-config (or/c permission-config? #f))
                              exec-context?)])
          exec-context?
          exec-context-working-directory


### PR DESCRIPTION
Addresses #4455.

fix: M1 stale comments + M2 duplicate require + M4 contract docs (#4455)

M1: Updated stale build-session-context references → build-session-context-for-prompt
    in session-lifecycle.rkt comments (lines 12, 135, 138).
M2: Removed duplicate racket/contract require in tool-coordinator.rkt.
M4: Added event-publisher callback contract documentation in tool.rkt."