### PR TITLE
fix: GSD /done bug + spawn-subagent layer violation (#4467)

BUG: auto-complete-inbox-waves! guard was too strict — when LLM skipped /wave-done
entirely, completed set stayed empty and auto-complete never fired. Added secondary
evidence signal: if wave executor exists AND all wave doc files are present, treat
as completed execution. New helper wave-docs-all-exist?.

F2: spawn-subagent.rkt imported agent/event-emitter.rkt directly (layer violation).
Changed to import through runtime/runtime-helpers.rkt which re-exports emit-session-event!.

Added 2 regression tests for the /done bug (positive + negative cases)."

### DIFF
--- a/extensions/gsd/archive.rkt
+++ b/extensions/gsd/archive.rkt
@@ -205,24 +205,34 @@
         (mark-wave-status! base-dir idx canonical)))))
 
 ;; Auto-complete remaining [Inbox] waves when in executing mode.
-;; Heuristic: if we're in executing mode and at least one wave was
-;; completed via /wave-done, the LLM ran the execution. Remaining
-;; [Inbox] waves were likely completed but the LLM forgot to mark them.
+;; Heuristic 1: if we're in executing mode and at least one wave was
+;; completed via /wave-done, the LLM ran the execution.
+;; Heuristic 2: if a wave executor exists AND all wave doc files are present,
+;; the execution likely ran even though the LLM never called /wave-done.
+(define (wave-docs-all-exist? base-dir entries)
+  (for/and ([e entries])
+    (wave-exists? base-dir (wave-index-entry-idx e) (wave-index-entry-slug e))))
+
 (define (auto-complete-inbox-waves! base-dir)
   (define mode (gsm-current))
   (define completed (gsm-completed-waves))
+  (define exec (gsm-wave-executor))
+  (define plan-path (build-path base-dir ".planning" "PLAN.md"))
   (cond
-    [(and (eq? mode 'executing) (not (set-empty? completed)))
-     ;; In executing mode with some completions → auto-complete remaining
-     (define plan-path (build-path base-dir ".planning" "PLAN.md"))
-     (when (file-exists? plan-path)
-       (define text (call-with-input-file plan-path port->string))
-       (define entries (parse-plan-index text))
+    [(not (file-exists? plan-path)) (void)]
+    [else
+     (define text (call-with-input-file plan-path port->string))
+     (define entries (parse-plan-index text))
+     (define should-auto-complete?
+       ;; Guard 1: In executing mode with at least one /wave-done completion
+       (or (and (eq? mode 'executing) (not (set-empty? completed)))
+           ;; Guard 2: Executor exists + all wave doc files exist
+           (and exec (wave-docs-all-exist? base-dir entries))))
+     (when should-auto-complete?
        (for ([e entries])
          (define status (string-upcase (wave-index-entry-status e)))
          (when (or (string=? status "INBOX") (string=? status "IN-PROGRESS"))
-           (mark-wave-status! base-dir (wave-index-entry-idx e) "DONE"))))]
-    [else (void)]))
+           (mark-wave-status! base-dir (wave-index-entry-idx e) "DONE"))))]))
 
 ;; Update all wave status markers in PLAN.md to [DONE] before archiving.
 ;; base-dir is the directory CONTAINING .planning/ (not .planning/ itself).

--- a/tests/test-gsd-archive.rkt
+++ b/tests/test-gsd-archive.rkt
@@ -452,6 +452,65 @@
      (reset-gsm!)
      (cleanup-tmp tmp))))
 
+;; ── v0.45.20 regression: /done fails when LLM skipped /wave-done ──
+;; BUG: auto-complete-inbox-waves! required at least one /wave-done completion.
+;; When LLM completed all waves but never called /wave-done, the guard
+;; (set-empty? completed) blocked auto-complete even though wave doc files
+;; proved execution happened. Fix: secondary guard checks wave docs exist.
+(test-case "auto-complete when LLM skipped /wave-done but wave docs exist"
+  (reset-gsm!)
+  (define tmp (make-tmp-planning-dir))
+  (dynamic-wind
+   void
+   (lambda ()
+     ;; Create plan with 3 waves, all [Inbox]
+     (write-plan!
+      tmp
+      #:status-lines
+      "- [Inbox] W0: setup \u2192 waves/W0-setup.md\n- [Inbox] W1: impl \u2192 waves/W1-impl.md\n- [Inbox] W2: test \u2192 waves/W2-test.md\n")
+     ;; Create all wave doc files (evidence of execution)
+     (write-wave! tmp 0 "setup" "Inbox" "Setup content")
+     (write-wave! tmp 1 "impl" "Inbox" "Impl content")
+     (write-wave! tmp 2 "test" "Inbox" "Test content")
+     ;; Set a wave executor (simulates /go having been called)
+     (gsm-set-wave-executor! 'fake-executor)
+     ;; Do NOT call gsm-mark-wave-complete! for any wave
+     ;; Do NOT transition to executing mode
+     ;; Sync should detect wave docs exist + executor → auto-complete
+     (sync-executor-to-plan! tmp)
+     (define plan-text (file->string (build-path tmp ".planning" "PLAN.md")))
+     (check-true (string-contains? plan-text "[DONE] W0:"))
+     (check-true (string-contains? plan-text "[DONE] W1:"))
+     (check-true (string-contains? plan-text "[DONE] W2:"))
+     (check-true (all-waves-complete? tmp)))
+   (lambda ()
+     (reset-gsm!)
+     (cleanup-tmp tmp))))
+
+(test-case "no auto-complete when no wave docs and no completions"
+  (reset-gsm!)
+  (define tmp (make-tmp-planning-dir))
+  (dynamic-wind
+   void
+   (lambda ()
+     ;; Create plan with 2 waves, all [Inbox]
+     (write-plan!
+      tmp
+      #:status-lines
+      "- [Inbox] W0: setup \u2192 waves/W0-setup.md\n- [Inbox] W1: impl \u2192 waves/W1-impl.md\n")
+     ;; Do NOT create wave doc files
+     ;; Do NOT set wave executor
+     ;; Do NOT mark any wave complete
+     (sync-executor-to-plan! tmp)
+     ;; Waves should stay [Inbox]
+     (define plan-text (file->string (build-path tmp ".planning" "PLAN.md")))
+     (check-true (string-contains? plan-text "[Inbox] W0:"))
+     (check-true (string-contains? plan-text "[Inbox] W1:"))
+     (check-false (all-waves-complete? tmp)))
+   (lambda ()
+     (reset-gsm!)
+     (cleanup-tmp tmp))))
+
 (test-case "ensure-state-md! does not overwrite existing STATE.md"
   (define tmp (make-tmp-planning-dir))
   (dynamic-wind void

--- a/tools/builtins/spawn-subagent.rkt
+++ b/tools/builtins/spawn-subagent.rkt
@@ -14,7 +14,7 @@
          racket/string
          "../../tools/tool.rkt"
          "../../agent/event-bus.rkt"
-         "../../agent/event-emitter.rkt"
+         (only-in "../../runtime/runtime-helpers.rkt" emit-session-event!)
          "../model-bridge.rkt"
          "../../util/ids.rkt"
          (only-in "../../util/protocol-types.rkt"


### PR DESCRIPTION
Addresses #4467.

fix: GSD /done bug + spawn-subagent layer violation (#4467)

BUG: auto-complete-inbox-waves! guard was too strict — when LLM skipped /wave-done
entirely, completed set stayed empty and auto-complete never fired. Added secondary
evidence signal: if wave executor exists AND all wave doc files are present, treat
as completed execution. New helper wave-docs-all-exist?.

F2: spawn-subagent.rkt imported agent/event-emitter.rkt directly (layer violation).
Changed to import through runtime/runtime-helpers.rkt which re-exports emit-session-event!.

Added 2 regression tests for the /done bug (positive + negative cases)."