### PR TITLE
chore: v0.45.20 — hygiene fixes + contract tightening + version bump (#4475)

F5: Removed unused racket/port import from spawn-subagent.rkt.
F6: Verified runtime-settings contract alignment (already fixed in W1).
F7: Tightened run-prompt! and run-prompt-internal contracts from any/c to message?.
Version bump 0.45.19 → 0.45.20 across 16 surfaces.
CHANGELOG entry covering all v0.45.20 fixes (BUG, F0–F7).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## v0.45.20 — 2026-05-14
+
+### Fixed
+- **BUG**: GSD `/done` auto-complete guard was too strict — when LLM completed all waves
+  but never called `/wave-done`, the completed set stayed empty and auto-complete never
+  fired. Added secondary evidence: if wave executor exists AND all wave doc files are
+  present on disk, auto-complete fires. (F0)
+- **F2**: `spawn-subagent.rkt` imported `agent/event-emitter.rkt` directly (layer
+  violation). Changed to import through `runtime/runtime-helpers.rkt`.
+- **F1**: Removed dead `symbol?` branch from `event-publisher` contract in `tool.rkt`.
+- **F3**: Tightened `build-session-context-for-prompt` contract from `(or/c string? list?)`
+  to `(or/c string? message?)` to match actual implementation.
+- **F5**: Removed unused `racket/port` import from `spawn-subagent.rkt`.
+- **F6**: Fixed `exec-context.rkt` `runtime-settings` contract to accept `hash?` —
+  both production code and tests pass raw hashes (fixed 10 pre-existing test failures).
+- **F7**: Tightened `run-prompt!` and `run-prompt-internal` contracts from `any/c` to
+  `message?` for better downstream guarantees.
+
+### Added
+- Regression tests for GSD `/done` bug (positive + negative cases).
+- `F4` test verifying spawn-subagent's 2-arg event-publisher calling convention.
+
 ## v0.45.19 — 2026-05-17
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.45.19-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.45.20-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 
@@ -203,7 +203,7 @@ bin/q --model gpt-5.4 "write a test"
 ### Verify
 
 ```bash
-bin/q --version            # q version 0.45.19
+bin/q --version            # q version 0.45.20
 raco test tests/           # run the full test suite
 ```
 
@@ -276,7 +276,7 @@ q/
 |--------|-------|
 | Test files | 587 |
 | Source modules | 428 |
-| Source lines | 66075 |
+| Source lines | 66074 |
 | Test lines | 103778 |
 | Test assertions | 16181 |
 | Tests passing | 5835+ | `racket scripts/run-tests.rkt` results |
@@ -413,7 +413,7 @@ When q executes shell commands on behalf of an LLM, arguments are quoted via `sh
 
 
 
-**v0.45.19** — Fixed
+**v0.45.20** — Fixed
 
 **v0.45.16** — Added
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -2,7 +2,7 @@
 
 ## Version
 
-v0.45.19
+v0.45.20
 
 ## Layer Diagram
 

--- a/docs/event-taxonomy.md
+++ b/docs/event-taxonomy.md
@@ -1,6 +1,6 @@
 # Q Event Taxonomy Reference
 
-Complete reference for all event types in Q 0.45.19.
+Complete reference for all event types in Q 0.45.20.
 ## Base Types
 
 ### `event` (protocol-level)

--- a/docs/extension-guide.md
+++ b/docs/extension-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.45.19 --># Extension Development Guide
+<!-- verified-against: 0.45.20 --># Extension Development Guide
 
 This guide walks you through creating, testing, and activating a custom
 extension for q.

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.45.19 --># Getting Started
+<!-- verified-against: 0.45.20 --># Getting Started
 
 Welcome to q, a Racket-based coding agent.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.45.19 --># Installation Guide
+<!-- verified-against: 0.45.20 --># Installation Guide
 
 <!-- This file is the canonical source. The docs/getting-started/installation.md copy is maintained for the doc site build. -->
 

--- a/docs/security-trust-model.md
+++ b/docs/security-trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.45.19 --># Security & Trust Model
+<!-- verified-against: 0.45.20 --># Security & Trust Model
 
 This document provides an honest, per-area assessment of what q enforces
 today and what is planned. It is the authoritative reference for security

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -130,6 +130,6 @@ is the primary self-hosting extension:
 (load-extension! ext-reg "path/to/extension.rkt" #:event-bus bus)
 ```
 
-## Version 0.45.19
+## Version 0.45.20
 
-This documentation reflects q 0.45.19.
+This documentation reflects q 0.45.20.

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.45.19 --># q Source Style Guide
+<!-- verified-against: 0.45.20 --># q Source Style Guide
 
 This document defines formatting and naming conventions for the q Racket codebase.
 All changes to `q/` source files (excluding `tests/`) should follow these rules.

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.45.19 --># Trust Model
+<!-- verified-against: 0.45.20 --># Trust Model
 
 ## Trust Levels
 

--- a/docs/workflow-testing.md
+++ b/docs/workflow-testing.md
@@ -121,6 +121,6 @@ Use relative paths from the test file:
 4. Use `(check-true ...)` for boolean assertions
 5. Keep tests independent — no shared mutable state between test-cases
 
-## Version 0.45.19
+## Version 0.45.20
 
-This documentation reflects q 0.45.19.
+This documentation reflects q 0.45.20.

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.45.19")
+(define version "0.45.20")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base"))

--- a/runtime/session-lifecycle.rkt
+++ b/runtime/session-lifecycle.rkt
@@ -65,14 +65,14 @@
 
 (provide (contract-out
           [run-prompt!
-           (->* (agent-session? (or/c string? any/c))
+           (->* (agent-session? (or/c string? message?))
                 (#:max-iterations (or/c exact-nonnegative-integer? #f)
                                   #:ensure-persisted! (or/c procedure? #f)
                                   #:buffer-or-append! (or/c procedure? #f))
                 any)]
           [run-prompt-internal
            (-> agent-session?
-               (or/c string? any/c)
+               (or/c string? message?)
                (or/c exact-nonnegative-integer? #f)
                (or/c exact-nonnegative-integer? #f)
                (or/c procedure? #f)

--- a/tools/builtins/spawn-subagent.rkt
+++ b/tools/builtins/spawn-subagent.rkt
@@ -10,7 +10,6 @@
 ;; #1203/#1204: Real provider injection — uses parent's provider
 
 (require racket/list
-         racket/port
          racket/string
          "../../tools/tool.rkt"
          "../../agent/event-bus.rkt"

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -10,4 +10,4 @@
 (provide q-version)
 
 (: q-version String)
-(define q-version "0.45.19")
+(define q-version "0.45.20")

--- a/wiki-src/Architecture-Overview.md
+++ b/wiki-src/Architecture-Overview.md
@@ -35,7 +35,7 @@ User input → Interface (CLI/TUI/RPC)
     → Events emitted to bus
 ```
 
-## Metrics (0.45.19)
+## Metrics (0.45.20)
 > _See `racket scripts/metrics.rkt` for current numbers._
 
 - 414 source modules, 534 test files


### PR DESCRIPTION
Addresses #4475.

chore: v0.45.20 — hygiene fixes + contract tightening + version bump (#4475)

F5: Removed unused racket/port import from spawn-subagent.rkt.
F6: Verified runtime-settings contract alignment (already fixed in W1).
F7: Tightened run-prompt! and run-prompt-internal contracts from any/c to message?.
Version bump 0.45.19 → 0.45.20 across 16 surfaces.
CHANGELOG entry covering all v0.45.20 fixes (BUG, F0–F7).