### PR TITLE
fix: architecture layer violations + fragile code (H1, N2, N3) (#4481)

H1: Extracted tool-registry struct to util/tool-registry-types.rkt, breaking
the runtime→tools reverse dependency. Updated loop-state.rkt to import from
util/ instead of tools/tool.rkt. tools/registry.rkt imports struct from util/.

N2: Re-exported make-event-bus from runtime/runtime-helpers.rkt. Updated
spawn-subagent.rkt to import through runtime-helpers instead of directly
from agent/event-bus.rkt (tools→agent layer violation fixed).

N3: Replaced fragile struct->vector reflection in rt-settings-ref with
proper setting-ref API from runtime/settings.rkt. No more hardcoded vector
index 3 for q-settings.merged field access.

### DIFF
--- a/runtime/iteration/loop-state.rkt
+++ b/runtime/iteration/loop-state.rkt
@@ -23,7 +23,7 @@
 
 (require/typed "../../agent/event-bus.rkt" [#:opaque EventBus event-bus?])
 
-(require/typed "../../tools/tool.rkt" [#:opaque ToolRegistry tool-registry?])
+(require/typed "../../util/tool-registry-types.rkt" [#:opaque ToolRegistry tool-registry?])
 
 (require/typed "../../extensions/api.rkt" [#:opaque ExtRegistry extension-registry?])
 

--- a/runtime/runtime-helpers.rkt
+++ b/runtime/runtime-helpers.rkt
@@ -12,10 +12,12 @@
 ;; here for backward compatibility with existing runtime callers.
 
 (require (only-in "../agent/event-emitter.rkt" emit-session-event!)
+         (only-in "../agent/event-bus.rkt" make-event-bus)
          (only-in "../extensions/hooks.rkt" dispatch-hooks)
          (only-in "../util/hook-types.rkt" hook-result-payload))
 
 (provide emit-session-event!
+         make-event-bus
          maybe-dispatch-hooks)
 
 ;; emit-session-event! is now defined in agent/event-emitter.rkt

--- a/tools/builtins/spawn-subagent.rkt
+++ b/tools/builtins/spawn-subagent.rkt
@@ -12,8 +12,8 @@
 (require racket/list
          racket/string
          "../../tools/tool.rkt"
-         "../../agent/event-bus.rkt"
-         (only-in "../../runtime/runtime-helpers.rkt" emit-session-event!)
+         (only-in "../../runtime/runtime-helpers.rkt" emit-session-event! make-event-bus)
+         (only-in "../../runtime/settings.rkt" q-settings? setting-ref)
          "../model-bridge.rkt"
          "../../util/ids.rkt"
          (only-in "../../util/protocol-types.rkt"
@@ -105,18 +105,11 @@
 ;; Resolve the provider from exec-context runtime-settings.
 ;; Returns the real provider if available, or falls back to a mock.
 ;; Extract a value from runtime-settings which may be a q-settings struct or a plain hash.
-;; #1241: After settings-contract fix, runtime-settings is a q-settings struct.
-;; Uses struct->vector for transparent struct access (no runtime import needed).
+;; v0.45.21 N3: Replaced struct->vector reflection with proper setting-ref API.
 (define (rt-settings-ref rt key [default #f])
   (cond
     [(hash? rt) (hash-ref rt key default)]
-    [(struct? rt)
-     ;; q-settings is transparent: fields are global, project, merged
-     ;; merged is at vector index 3 (0=name, 1=global, 2=project, 3=merged)
-     (define merged (vector-ref (struct->vector rt) 3))
-     (if (hash? merged)
-         (hash-ref merged key default)
-         default)]
+    [(q-settings? rt) (setting-ref rt key default)]
     [else default]))
 
 ;; #1204: Provider injection from parent session.

--- a/tools/registry.rkt
+++ b/tools/registry.rkt
@@ -14,35 +14,35 @@
                   tool-prompt-snippet
                   tool-prompt-guidelines))
 
-(provide
- (contract-out
-  [make-tool-registry (-> tool-registry?)]
-  [tool-registry-tools (-> tool-registry? (listof tool?))]
-  [register-tool! (-> tool-registry? tool? void?)]
-  [unregister-tool! (-> tool-registry? string? void?)]
-  [lookup-tool (-> tool-registry? (or/c string? #f) (or/c tool? #f))]
-  [list-tools (-> tool-registry? (listof tool?))]
-  [tool-names (-> tool-registry? (listof string?))]
-  [tool->jsexpr (-> tool? hash?)]
-  [list-active-tools (-> tool-registry? (listof tool?))]
-  [list-active-tools-jsexpr (-> tool-registry? (listof hash?))]
-  [list-tools-jsexpr (-> tool-registry? (listof hash?))]
-  [set-active-tools! (-> tool-registry? (or/c (listof string?) #f) void?)]
-  [tool-active? (-> tool-registry? string? boolean?)]
-  [with-registry-lock (-> tool-registry? procedure? any)])
- tool-registry?)
+(provide (contract-out [make-tool-registry (-> tool-registry?)]
+                       [tool-registry-tools (-> tool-registry? (listof tool?))]
+                       [register-tool! (-> tool-registry? tool? void?)]
+                       [unregister-tool! (-> tool-registry? string? void?)]
+                       [lookup-tool (-> tool-registry? (or/c string? #f) (or/c tool? #f))]
+                       [list-tools (-> tool-registry? (listof tool?))]
+                       [tool-names (-> tool-registry? (listof string?))]
+                       [tool->jsexpr (-> tool? hash?)]
+                       [list-active-tools (-> tool-registry? (listof tool?))]
+                       [list-active-tools-jsexpr (-> tool-registry? (listof hash?))]
+                       [list-tools-jsexpr (-> tool-registry? (listof hash?))]
+                       [set-active-tools! (-> tool-registry? (or/c (listof string?) #f) void?)]
+                       [tool-active? (-> tool-registry? string? boolean?)]
+                       [with-registry-lock (-> tool-registry? procedure? any)])
+         tool-registry?)
 
 ;; ============================================================
 ;; Tool registry
 ;; ============================================================
 
-(struct tool-registry (tools-box active-set-box sem))
+;; Import struct from util/ to break runtime→tools reverse dependency (H1).
+(require "../util/tool-registry-types.rkt")
+(provide tool-registry?)
 
 ;; Safe read-only accessor under lock
 (define (tool-registry-tools reg)
   (with-registry-lock reg (lambda () (hash-values (tool-registry-tools-box reg)))))
 (define (make-tool-registry)
-  (tool-registry (make-hash) (box #f) (make-semaphore 1)))
+  (make-tool-registry-internal (make-hash) (box #f) (make-semaphore 1)))
 
 ;; Thread-safe registry lock helper (Finding A2: 7 call sites)
 ;; L-10 WARNING: Racket semaphores are NOT reentrant. Calling

--- a/util/tool-registry-types.rkt
+++ b/util/tool-registry-types.rkt
@@ -1,0 +1,12 @@
+#lang racket/base
+;; util/tool-registry-types.rkt — Tool registry type definition
+;; Extracted from tools/registry.rkt to break runtime→tools reverse dependency (H1).
+;; Both runtime/ and tools/ can import from util/ without layer violation.
+;; STABILITY: stable
+
+(provide (struct-out tool-registry)
+         make-tool-registry-internal)
+
+;; Thread-safe tool registry struct. Fields are internal; use accessor
+;; functions from tools/registry.rkt for safe access.
+(struct tool-registry (tools-box active-set-box sem) #:constructor-name make-tool-registry-internal)


### PR DESCRIPTION
Addresses #4481.

fix: architecture layer violations + fragile code (H1, N2, N3) (#4481)

H1: Extracted tool-registry struct to util/tool-registry-types.rkt, breaking
the runtime→tools reverse dependency. Updated loop-state.rkt to import from
util/ instead of tools/tool.rkt. tools/registry.rkt imports struct from util/.

N2: Re-exported make-event-bus from runtime/runtime-helpers.rkt. Updated
spawn-subagent.rkt to import through runtime-helpers instead of directly
from agent/event-bus.rkt (tools→agent layer violation fixed).

N3: Replaced fragile struct->vector reflection in rt-settings-ref with
proper setting-ref API from runtime/settings.rkt. No more hardcoded vector
index 3 for q-settings.merged field access.