### PR TITLE
test: archive guard N1 + event-publisher depth N5 (#4485)

N1: Added negative test — wave docs exist but no executor set.
Verifies auto-complete does NOT fire when only docs exist without executor.
Guard 2 requires BOTH executor AND wave docs.

N5: Added two direct emit-session-event! tests that subscribe to bus and
verify events arrive with correct type and payload. Tests both single event
and multiple sequential events through 2-arg convention.

### DIFF
--- a/tests/test-gsd-archive.rkt
+++ b/tests/test-gsd-archive.rkt
@@ -511,6 +511,35 @@
      (reset-gsm!)
      (cleanup-tmp tmp))))
 
+;; N1: Guard 2 requires BOTH executor AND wave docs.
+;; Wave docs alone (without executor) must NOT trigger auto-complete.
+(test-case "no auto-complete when wave docs exist but no executor set (N1)"
+  (reset-gsm!)
+  (define tmp (make-tmp-planning-dir))
+  (dynamic-wind
+   void
+   (lambda ()
+     ;; Create plan with 2 waves, all [Inbox]
+     (write-plan! tmp
+                  #:status-lines
+                  "- [Inbox] W0: setup → waves/W0-setup.md
+- [Inbox] W1: impl → waves/W1-impl.md
+")
+     ;; Create wave doc files (but do NOT set executor)
+     (write-wave! tmp 0 "setup" "Inbox" "Setup content")
+     (write-wave! tmp 1 "impl" "Inbox" "Impl content")
+     ;; Do NOT set wave executor
+     ;; Do NOT mark any wave complete
+     (sync-executor-to-plan! tmp)
+     ;; Waves should stay [Inbox] — docs alone are not enough
+     (define plan-text (file->string (build-path tmp ".planning" "PLAN.md")))
+     (check-true (string-contains? plan-text "[Inbox] W0:"))
+     (check-true (string-contains? plan-text "[Inbox] W1:"))
+     (check-false (all-waves-complete? tmp)))
+   (lambda ()
+     (reset-gsm!)
+     (cleanup-tmp tmp))))
+
 (test-case "ensure-state-md! does not overwrite existing STATE.md"
   (define tmp (make-tmp-planning-dir))
   (dynamic-wind void

--- a/tests/test-spawn-subagent-integration.rkt
+++ b/tests/test-spawn-subagent-integration.rkt
@@ -19,6 +19,8 @@
          "../llm/provider.rkt"
          "../llm/model.rkt"
          "../agent/event-bus.rkt"
+         (only-in "../agent/event-emitter.rkt" emit-session-event!)
+         (only-in "../util/event.rkt" event-ev event-payload)
          "../util/ids.rkt")
 
 ;; ============================================================
@@ -223,3 +225,56 @@
   (check-false (tool-result-is-error? result)
                (format "expected success, got error: ~a" (tool-result-content result)))
   (check-true (tool-result? result)))
+
+;; ── v0.45.21 N5: Direct emit-session-event! 2-arg convention test ──
+;; Verifies that the event-publisher lambda (ev-pub event-type payload) correctly
+;; calls emit-session-event! and that events arrive on the bus with expected type.
+(test-case "N5: emit-session-event! via event-publisher publishes to bus"
+  (define bus (make-event-bus))
+  (define session-id "test-n5-session")
+  (define captured-events (box '()))
+
+  ;; Subscribe to capture events
+  (subscribe! bus
+              (lambda (evt) (set-box! captured-events (append (unbox captured-events) (list evt)))))
+
+  ;; Create the 2-arg event-publisher lambda (same shape as spawn-subagent uses internally)
+  (define ev-pub
+    (lambda (event-type payload) (emit-session-event! bus session-id event-type payload)))
+
+  ;; Emit a test event via the 2-arg convention
+  (define result-evt (ev-pub "subagent.spawn" (hasheq 'task "test")))
+
+  ;; Verify the event was published
+  (check-not-false result-evt "event-publisher should return the event")
+  (define events (unbox captured-events))
+  (check = (length events) 1 (format "expected 1 event, got ~a" (length events)))
+  (when (= (length events) 1)
+    (define evt (car events))
+    (check-equal? (event-ev evt) "subagent.spawn")
+    (check-equal? (hash-ref (event-payload evt) 'task #f) "test")))
+
+;; Also verify the 2-arg convention works with multiple sequential events
+(test-case "N5: multiple events via 2-arg convention"
+  (define bus (make-event-bus))
+  (define session-id "test-n5-multi")
+  (define captured-events (box '()))
+
+  (subscribe! bus
+              (lambda (evt) (set-box! captured-events (append (unbox captured-events) (list evt)))))
+
+  (define ev-pub
+    (lambda (event-type payload) (emit-session-event! bus session-id event-type payload)))
+
+  ;; Emit 3 events
+  (ev-pub "subagent.spawn" (hasheq 'task "first"))
+  (ev-pub "subagent.progress" (hasheq 'msg "working"))
+  (ev-pub "subagent.complete" (hasheq 'result "done"))
+
+  (define events (unbox captured-events))
+  (check = (length events) 3 (format "expected 3 events, got ~a" (length events)))
+  (when (>= (length events) 3)
+    (check-equal? (event-ev (list-ref events 0)) "subagent.spawn")
+    (check-equal? (event-ev (list-ref events 1)) "subagent.progress")
+    (check-equal? (event-ev (list-ref events 2)) "subagent.complete")
+    (check-equal? (hash-ref (event-payload (list-ref events 2)) 'result #f) "done")))


### PR DESCRIPTION
Addresses #4485.

test: archive guard N1 + event-publisher depth N5 (#4485)

N1: Added negative test — wave docs exist but no executor set.
Verifies auto-complete does NOT fire when only docs exist without executor.
Guard 2 requires BOTH executor AND wave docs.

N5: Added two direct emit-session-event! tests that subscribe to bus and
verify events arrive with correct type and payload. Tests both single event
and multiple sequential events through 2-arg convention.