### PR TITLE
fix: SDK contract alignment + case-insensitive status handling (#4494)

AX1-1 (HIGH): Widened sdk-core.rkt run-prompt! contract to accept
(or/c string? message?) — completes the N4 widening from v0.45.21.

AX1-4 (MED): Fixed all-waves-complete? case-insensitive status handling
by making terminal-status? use case-insensitive comparison via
string-upcase. Now correctly recognizes Done/done/DONE/Deferred/deferred.

Archive tests now 29/29 (previously 28/29 with pre-existing failure).

### DIFF
--- a/extensions/gsd/wave-status.rkt
+++ b/extensions/gsd/wave-status.rkt
@@ -37,8 +37,9 @@
   (and (string? s) (member s ALL-STATUSES) #t))
 
 (define (terminal-status? s)
-  "Is s a terminal status (DONE or DEFERRED)?"
-  (or (string=? s STATUS-DONE) (string=? s STATUS-DEFERRED)))
+  "Is s a terminal status (DONE or DEFERRED)? Case-insensitive."
+  (define up (string-upcase s))
+  (or (string=? up STATUS-DONE) (string=? up STATUS-DEFERRED)))
 
 (define (done-or-deferred? s)
   "Is s DONE or DEFERRED? (alias for terminal-status?)"

--- a/interfaces/sdk-core.rkt
+++ b/interfaces/sdk-core.rkt
@@ -86,7 +86,7 @@
                              runtime?)]
                        [open-session (->* (runtime?) ((or/c string? #f)) runtime?)]
                        [run-prompt!
-                        (runtime? string?
+                        (runtime? (or/c string? message?)
                                   . -> .
                                   (values runtime? (or/c loop-result? hash? #f 'no-active-session)))]
                        [make-cancellation-token


### PR DESCRIPTION
Addresses #4494.

fix: SDK contract alignment + case-insensitive status handling (#4494)

AX1-1 (HIGH): Widened sdk-core.rkt run-prompt! contract to accept
(or/c string? message?) — completes the N4 widening from v0.45.21.

AX1-4 (MED): Fixed all-waves-complete? case-insensitive status handling
by making terminal-status? use case-insensitive comparison via
string-upcase. Now correctly recognizes Done/done/DONE/Deferred/deferred.

Archive tests now 29/29 (previously 28/29 with pre-existing failure).