### PR TITLE
refactor: design hygiene fixes for tool-registry struct (#4497)

AX1-2 (LOW): Added clarifying comment that path-string? covers path? and
string? in exec-context.rkt working-directory contract.

AX1-3 (LOW): Replaced (struct-out tool-registry) with explicit provides
(tool-registry?, make-tool-registry-internal, field accessors) in
util/tool-registry-struct.rkt for auditable surface area.

AX2-1 (LOW): Renamed util/tool-registry-types.rkt → util/tool-registry-struct.rkt
for naming precision. Updated 2 import paths.

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ q/
 |--------|-------|
 | Test files | 587 |
 | Source modules | 429 |
-| Source lines | 66082 |
+| Source lines | 66087 |
 | Test lines | 103895 |
 | Test assertions | 16195 |
 | Tests passing | 5835+ | `racket scripts/run-tests.rkt` results |

--- a/runtime/iteration/loop-state.rkt
+++ b/runtime/iteration/loop-state.rkt
@@ -23,7 +23,7 @@
 
 (require/typed "../../agent/event-bus.rkt" [#:opaque EventBus event-bus?])
 
-(require/typed "../../util/tool-registry-types.rkt" [#:opaque ToolRegistry tool-registry?])
+(require/typed "../../util/tool-registry-struct.rkt" [#:opaque ToolRegistry tool-registry?])
 
 (require/typed "../../extensions/api.rkt" [#:opaque ExtRegistry extension-registry?])
 

--- a/tools/exec-context.rkt
+++ b/tools/exec-context.rkt
@@ -12,7 +12,8 @@
          exec-context?
          (contract-out [make-exec-context
                         (->* ()
-                             (#:working-directory (or/c path-string? #f)
+                             (#:working-directory (or/c path-string?
+                                                        #f) ; path-string? covers path? and string?
                                                   #:cancellation-token (or/c cancellation-token? #f)
                                                   #:event-publisher (or/c procedure? #f)
                                                   #:runtime-settings (or/c hash? q-settings? #f)

--- a/tools/registry.rkt
+++ b/tools/registry.rkt
@@ -35,7 +35,7 @@
 ;; ============================================================
 
 ;; Import struct from util/ to break runtime→tools reverse dependency (H1).
-(require "../util/tool-registry-types.rkt")
+(require "../util/tool-registry-struct.rkt")
 (provide tool-registry?)
 
 ;; Safe read-only accessor under lock

--- a/util/tool-registry-struct.rkt
+++ b/util/tool-registry-struct.rkt
@@ -1,11 +1,14 @@
 #lang racket/base
-;; util/tool-registry-types.rkt — Tool registry type definition
+;; util/tool-registry-struct.rkt — Tool registry type definition
 ;; Extracted from tools/registry.rkt to break runtime→tools reverse dependency (H1).
 ;; Both runtime/ and tools/ can import from util/ without layer violation.
 ;; STABILITY: stable
 
-(provide (struct-out tool-registry)
-         make-tool-registry-internal)
+(provide tool-registry?
+         make-tool-registry-internal
+         tool-registry-tools-box
+         tool-registry-active-set-box
+         tool-registry-sem)
 
 ;; Thread-safe tool registry struct. Fields are internal; use accessor
 ;; functions from tools/registry.rkt for safe access.


### PR DESCRIPTION
Addresses #4497.

refactor: design hygiene fixes for tool-registry struct (#4497)

AX1-2 (LOW): Added clarifying comment that path-string? covers path? and
string? in exec-context.rkt working-directory contract.

AX1-3 (LOW): Replaced (struct-out tool-registry) with explicit provides
(tool-registry?, make-tool-registry-internal, field accessors) in
util/tool-registry-struct.rkt for auditable surface area.

AX2-1 (LOW): Renamed util/tool-registry-types.rkt → util/tool-registry-struct.rkt
for naming precision. Updated 2 import paths.