### PR TITLE
fix: status normalization (Option A) + remove dead status-eqv? + exec-context formatting (#4507)

AX1-NEW-2 (MEDIUM): Applied Option A — normalize status at parse time
in wave-docs.rkt parse-plan-index using normalize-status!. All downstream
string=? comparisons now work because entries are already canonical.

AX3-3 (LOW): Fixed exec-context.rkt contract formatting — moved comment
above the parameter and put (or/c path-string? #f) on one line.

AX3-5 (LOW): Removed dead status-eqv? from wave-status.rkt (defined +
provided but never called outside tests). Removed corresponding test case.

Fixed normalize-plan-status-markers! in archive.rkt to use raw regex
parsing instead of parse-plan-index (which now normalizes, hiding the
raw status needed for comparison).

Wave 1 of v0.45.23.

### DIFF
--- a/extensions/gsd/archive.rkt
+++ b/extensions/gsd/archive.rkt
@@ -196,13 +196,17 @@
   (define plan-path (build-path base-dir ".planning" "PLAN.md"))
   (when (file-exists? plan-path)
     (define text (call-with-input-file plan-path port->string))
-    (define entries (parse-plan-index text))
-    (for ([e entries])
-      (define status (wave-index-entry-status e))
-      (define idx (wave-index-entry-idx e))
-      (define canonical (normalize-status! status))
-      (when (and canonical (not (string=? status canonical)))
-        (mark-wave-status! base-dir idx canonical)))))
+    ;; Parse raw: regex-match directly to get RAW status strings
+    ;; (parse-plan-index normalizes, so we can't compare raw vs canonical)
+    (define index-line-rx #rx"^[-*] +\\[([A-Za-z-]+)\\] +W([0-9]+):")
+    (for ([line (in-list (string-split text "\n"))])
+      (define m (regexp-match index-line-rx line))
+      (when m
+        (define raw-status (cadr m))
+        (define idx (string->number (caddr m)))
+        (define canonical (normalize-status! raw-status))
+        (when (and canonical (not (string=? raw-status canonical)))
+          (mark-wave-status! base-dir idx canonical))))))
 
 ;; Auto-complete remaining [Inbox] waves when in executing mode.
 ;; Heuristic 1: if we're in executing mode and at least one wave was

--- a/extensions/gsd/wave-docs.rkt
+++ b/extensions/gsd/wave-docs.rkt
@@ -26,7 +26,8 @@
                   STATUS-DEFERRED
                   STATUS-FAILED
                   done-or-deferred?
-                  active-status?))
+                  active-status?
+                  normalize-status!))
 
 (provide wave-doc-path
          write-wave-doc!
@@ -106,8 +107,18 @@
 (define (parse-wave-doc-from-string text idx slug [path #f])
   (define status (extract-status text))
   (define content (strip-status-header text))
-  (hasheq 'index idx 'slug slug 'status status 'content content
-          'path (if path (path->string path) #f)))
+  (hasheq 'index
+          idx
+          'slug
+          slug
+          'status
+          status
+          'content
+          content
+          'path
+          (if path
+              (path->string path)
+              #f)))
 
 (define (read-wave-doc base-dir idx slug)
   (define path (wave-doc-path base-dir idx slug))
@@ -140,7 +151,8 @@
   (for/fold ([entries '()]) ([line lines])
     (define m (regexp-match index-line-rx line))
     (if m
-        (let* ([status (cadr m)]
+        (let* ([raw-status (cadr m)]
+               [status (or (normalize-status! raw-status) raw-status)]
                [idx (string->number (caddr m))]
                [title (string-trim (cadddr m))]
                [target (and (list? m) (> (length m) 4) (list-ref m 4))]

--- a/extensions/gsd/wave-status.rkt
+++ b/extensions/gsd/wave-status.rkt
@@ -49,10 +49,6 @@
   "Is s a non-terminal status?"
   (not (terminal-status? s)))
 
-(define (status-eqv? a b)
-  "Case-insensitive status comparison."
-  (string=? (string-upcase a) (string-upcase b)))
-
 (define (normalize-status! s)
   "Normalize a case-variant status string to canonical form.
    Returns the canonical string or #f if not recognized."
@@ -79,5 +75,4 @@
          terminal-status?
          done-or-deferred?
          active-status?
-         status-eqv?
          normalize-status!)

--- a/tests/test-gsd-wave-status.rkt
+++ b/tests/test-gsd-wave-status.rkt
@@ -45,12 +45,6 @@
   (check-false (active-status? STATUS-DONE))
   (check-false (active-status? STATUS-DEFERRED)))
 
-(test-case "status-eqv? is case-insensitive"
-  (check-true (status-eqv? "DONE" "done"))
-  (check-true (status-eqv? "Done" "DONE"))
-  (check-true (status-eqv? "deferred" "DEFERRED"))
-  (check-false (status-eqv? "DONE" "DEFERRED")))
-
 (test-case "normalize-status! returns canonical form"
   (check-equal? (normalize-status! "DONE") STATUS-DONE)
   (check-equal? (normalize-status! "Done") STATUS-DONE)

--- a/tools/exec-context.rkt
+++ b/tools/exec-context.rkt
@@ -12,8 +12,8 @@
          exec-context?
          (contract-out [make-exec-context
                         (->* ()
-                             (#:working-directory (or/c path-string?
-                                                        #f) ; path-string? covers path? and string?
+                             ;; path-string? covers both path? and string?
+                             (#:working-directory (or/c path-string? #f)
                                                   #:cancellation-token (or/c cancellation-token? #f)
                                                   #:event-publisher (or/c procedure? #f)
                                                   #:runtime-settings (or/c hash? q-settings? #f)


### PR DESCRIPTION
Addresses #4507.

fix: status normalization (Option A) + remove dead status-eqv? + exec-context formatting (#4507)

AX1-NEW-2 (MEDIUM): Applied Option A — normalize status at parse time
in wave-docs.rkt parse-plan-index using normalize-status!. All downstream
string=? comparisons now work because entries are already canonical.

AX3-3 (LOW): Fixed exec-context.rkt contract formatting — moved comment
above the parameter and put (or/c path-string? #f) on one line.

AX3-5 (LOW): Removed dead status-eqv? from wave-status.rkt (defined +
provided but never called outside tests). Removed corresponding test case.

Fixed normalize-plan-status-markers! in archive.rkt to use raw regex
parsing instead of parse-plan-index (which now normalizes, hiding the
raw status needed for comparison).

Wave 1 of v0.45.23.