### PR TITLE
feat: extract with-telemetry to util/telemetry.rkt + version bump 0.46.0 (#4513)

F21: Extracted with-telemetry macro from util/error-helpers.rkt to
dedicated util/telemetry.rkt module. Backward-compatible re-export
retained in error-helpers.rkt.

Version bump 0.45.23 → 0.46.0 with CHANGELOG entry.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v0.46.0 — 2026-05-18
+
+### Changed
+- **F5**: Unified `provider-error` into `q-error` hierarchy — provider-error now inherits from q-error instead of exn:fail, enabling catch-all `q-error?` handlers
+- **F21**: Extracted `with-telemetry` from `util/error-helpers.rkt` to dedicated `util/telemetry.rkt` module
+
+### Added
+- HTTP 413 context-overflow classification in `classify-http-status`
+- Provider error hierarchy tests (q-error subtype, context field)
+
 ## v0.45.23 — 2026-05-17
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.45.23-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.46.0-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 
@@ -203,7 +203,7 @@ bin/q --model gpt-5.4 "write a test"
 ### Verify
 
 ```bash
-bin/q --version            # q version 0.45.23
+bin/q --version            # q version 0.46.0
 raco test tests/           # run the full test suite
 ```
 
@@ -275,8 +275,8 @@ q/
 | Metric | Value |
 |--------|-------|
 | Test files | 587 |
-| Source modules | 429 |
-| Source lines | 66149 |
+| Source modules | 430 |
+| Source lines | 66161 |
 | Test lines | 103912 |
 | Test assertions | 16198 |
 | Tests passing | 5835+ | `racket scripts/run-tests.rkt` results |
@@ -415,7 +415,7 @@ When q executes shell commands on behalf of an LLM, arguments are quoted via `sh
 
 
 
-**v0.45.23** — Fixed
+**v0.46.0** — Changed
 
 **v0.45.22** — Fixed
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -2,7 +2,7 @@
 
 ## Version
 
-v0.45.23
+v0.46.0
 
 ## Layer Diagram
 

--- a/docs/event-taxonomy.md
+++ b/docs/event-taxonomy.md
@@ -1,6 +1,6 @@
 # Q Event Taxonomy Reference
 
-Complete reference for all event types in Q 0.45.23.
+Complete reference for all event types in Q 0.46.0.
 ## Base Types
 
 ### `event` (protocol-level)

--- a/docs/extension-guide.md
+++ b/docs/extension-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.45.23 --># Extension Development Guide
+<!-- verified-against: 0.46.0 --># Extension Development Guide
 
 This guide walks you through creating, testing, and activating a custom
 extension for q.

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.45.23 --># Getting Started
+<!-- verified-against: 0.46.0 --># Getting Started
 
 Welcome to q, a Racket-based coding agent.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.45.23 --># Installation Guide
+<!-- verified-against: 0.46.0 --># Installation Guide
 
 <!-- This file is the canonical source. The docs/getting-started/installation.md copy is maintained for the doc site build. -->
 

--- a/docs/security-trust-model.md
+++ b/docs/security-trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.45.23 --># Security & Trust Model
+<!-- verified-against: 0.46.0 --># Security & Trust Model
 
 This document provides an honest, per-area assessment of what q enforces
 today and what is planned. It is the authoritative reference for security

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -130,6 +130,6 @@ is the primary self-hosting extension:
 (load-extension! ext-reg "path/to/extension.rkt" #:event-bus bus)
 ```
 
-## Version 0.45.23
+## Version 0.46.0
 
-This documentation reflects q 0.45.23.
+This documentation reflects q 0.46.0.

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.45.23 --># q Source Style Guide
+<!-- verified-against: 0.46.0 --># q Source Style Guide
 
 This document defines formatting and naming conventions for the q Racket codebase.
 All changes to `q/` source files (excluding `tests/`) should follow these rules.

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.45.23 --># Trust Model
+<!-- verified-against: 0.46.0 --># Trust Model
 
 ## Trust Levels
 

--- a/docs/workflow-testing.md
+++ b/docs/workflow-testing.md
@@ -121,6 +121,6 @@ Use relative paths from the test file:
 4. Use `(check-true ...)` for boolean assertions
 5. Keep tests independent — no shared mutable state between test-cases
 
-## Version 0.45.23
+## Version 0.46.0
 
-This documentation reflects q 0.45.23.
+This documentation reflects q 0.46.0.

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.45.23")
+(define version "0.46.0")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base"))

--- a/runtime/compactor.rkt
+++ b/runtime/compactor.rkt
@@ -24,7 +24,7 @@
          racket/set
          "../util/protocol-types.rkt"
          "../util/message-helpers.rkt"
-         (only-in "../util/error-helpers.rkt" with-telemetry)
+         (only-in "../util/telemetry.rkt" with-telemetry)
          "../runtime/session-store.rkt"
          (only-in "../runtime/compaction-prompts.rkt"
                   format-messages-for-summary
@@ -55,7 +55,6 @@
                                              #:hook-dispatcher (or/c procedure? #f)
                                              #:token-config any/c)
                              compaction-result?)]
-
                        [compact-and-persist!
                         (->* (list? (or/c path-string? #f))
                              (#:summarize-fn procedure?

--- a/runtime/session-lifecycle.rkt
+++ b/runtime/session-lifecycle.rkt
@@ -36,7 +36,7 @@
          (only-in "../agent/state.rkt" current-loop-state-for-error-recovery loop-state-messages)
          "../runtime/session-index.rkt"
          (only-in "../util/event-payloads.rkt" error-payload input-payload payload->hash)
-         (only-in "../util/error-helpers.rkt" with-telemetry)
+         (only-in "../util/telemetry.rkt" with-telemetry)
          (only-in "../runtime/context-assembly.rkt"
                   (build-session-context build-session-context/from-index)
                   build-tiered-context-with-hooks

--- a/util/error-helpers.rkt
+++ b/util/error-helpers.rkt
@@ -9,8 +9,7 @@
 (require racket/logging)
 (provide with-safe-fallback
          with-logged-error
-         with-telemetry
-)
+         with-telemetry)
 
 ;; with-safe-fallback — Execute body, returning DEFAULT on any exn:fail.
 ;;
@@ -31,16 +30,6 @@
                                #f)])
     body ...))
 
-;; with-telemetry — Execute body, logging operation name and elapsed time (ms).
-;; Returns the body result unchanged. Errors propagate to caller.
-;;
-;; (with-telemetry "compaction"
-;;   (expensive-operation ...))
-;; => logs "[telemetry] compaction completed in 42.3 ms"
-(define-syntax-rule (with-telemetry op-name body ...)
-  (let ([t0 (current-inexact-milliseconds)])
-    (begin0 (begin
-              body ...)
-      (log-info (format "[telemetry] ~a completed in ~a ms"
-                        op-name
-                        (real->decimal-string (- (current-inexact-milliseconds) t0) 1))))))
+;; with-telemetry — Moved to util/telemetry.rkt (F21).
+;; Re-exported here for backward compatibility.
+(require (only-in "telemetry.rkt" with-telemetry))

--- a/util/telemetry.rkt
+++ b/util/telemetry.rkt
@@ -1,0 +1,24 @@
+#lang racket/base
+
+;; util/telemetry.rkt — Timing/telemetry utilities
+;;
+;; Extracted from error-helpers.rkt to separate cross-cutting concerns:
+;; error handling vs. observability.
+
+(require racket/logging)
+
+(provide with-telemetry)
+
+;; with-telemetry — Execute body, logging operation name and elapsed time (ms).
+;; Returns the body result unchanged. Errors propagate to caller.
+;;
+;; (with-telemetry "compaction"
+;;   (expensive-operation ...))
+;; => logs "[telemetry] compaction completed in 42.3 ms"
+(define-syntax-rule (with-telemetry op-name body ...)
+  (let ([t0 (current-inexact-milliseconds)])
+    (begin0 (begin
+              body ...)
+      (log-info (format "[telemetry] ~a completed in ~a ms"
+                        op-name
+                        (real->decimal-string (- (current-inexact-milliseconds) t0) 1))))))

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -10,4 +10,4 @@
 (provide q-version)
 
 (: q-version String)
-(define q-version "0.45.23")
+(define q-version "0.46.0")

--- a/wiki-src/Architecture-Overview.md
+++ b/wiki-src/Architecture-Overview.md
@@ -35,7 +35,7 @@ User input → Interface (CLI/TUI/RPC)
     → Events emitted to bus
 ```
 
-## Metrics (0.45.23)
+## Metrics (0.46.0)
 > _See `racket scripts/metrics.rkt` for current numbers._
 
 - 414 source modules, 534 test files


### PR DESCRIPTION
Addresses #4513.

feat: extract with-telemetry to util/telemetry.rkt + version bump 0.46.0 (#4513)

F21: Extracted with-telemetry macro from util/error-helpers.rkt to
dedicated util/telemetry.rkt module. Backward-compatible re-export
retained in error-helpers.rkt.

Version bump 0.45.23 → 0.46.0 with CHANGELOG entry.