### PR TITLE
feat: extract shared util/fsm.rkt generic FSM library (F16) (#4530)

Created util/fsm.rkt with make-fsm, fsm-lookup, fsm-valid-transition?,
fsm-valid-targets, fsm-find-path. Refactored iteration/fsm-types.rkt
and agent/loop-fsm.rkt to use shared library instead of duplicating
BFS/lookup logic. All existing tests pass.

### DIFF
--- a/agent/loop-fsm.rkt
+++ b/agent/loop-fsm.rkt
@@ -40,7 +40,8 @@
          next-turn-state
          valid-turn-transition?)
 
-(require racket/match)
+(require racket/match
+         (only-in "../util/fsm.rkt" make-fsm fsm-lookup fsm-valid-transition?))
 
 ;; ── States ──
 
@@ -97,11 +98,20 @@
 
 ;; ── Lookup ──
 
+;; FSM machine instance for lookup
+(define turn-machine
+  (make-fsm '(emit-start build-context pre-hook stream post-hook complete blocked)
+            '(start context-built
+                    hook-pass
+                    hook-block
+                    stream-complete
+                    stream-cancel
+                    post-hook-done
+                    msg-hook-block)
+            TURN-TRANSITIONS))
+
 (define (find-turn-transition state-sym event-sym)
-  (for/or ([entry (in-list TURN-TRANSITIONS)])
-    (match entry
-      [`((,s . ,e) . ,next) (and (eq? s state-sym) (eq? e event-sym) next)]
-      [_ #f])))
+  (fsm-lookup turn-machine state-sym event-sym))
 
 (define (next-turn-state state event)
   (define state-sym (turn-state->symbol state))
@@ -120,9 +130,7 @@
     [else (error 'next-turn-state "unknown state: ~a" next-sym)]))
 
 (define (valid-turn-transition? state event)
-  (define state-sym (turn-state->symbol state))
-  (define event-sym (turn-event->symbol event))
-  (and (find-turn-transition state-sym event-sym) #t))
+  (fsm-valid-transition? turn-machine (turn-state->symbol state) (turn-event->symbol event)))
 
 ;; ── FSM state parameter ──
 ;; Tracks current turn FSM state for observability.

--- a/runtime/iteration/fsm-types.rkt
+++ b/runtime/iteration/fsm-types.rkt
@@ -7,7 +7,8 @@
 ;; enumerated as data, and the TRANSITIONS table maps (state, event) pairs
 ;; to next states. Unknown transitions raise explicit errors.
 
-(require racket/match)
+(require racket/match
+         (only-in "../../util/fsm.rkt" make-fsm fsm-lookup fsm-valid-transition?))
 
 ;; States
 (provide iteration-state?
@@ -105,11 +106,21 @@
 
 ;; ── Transition lookup ──
 
+;; fsm machine instance for lookup
+(define iteration-machine
+  (make-fsm '(idle provider-turn tool-exec decision complete retrying aborted)
+            '(start-loop model-response
+                         tool-result
+                         tool-calls-present
+                         termination-reason
+                         hook-block
+                         error
+                         retry-requested
+                         cancel)
+            TRANSITIONS))
+
 (define (find-transition state-sym event-sym)
-  (for/or ([entry (in-list TRANSITIONS)])
-    (match entry
-      [`((,s . ,e) . ,next) (and (eq? s state-sym) (eq? e event-sym) next)]
-      [_ #f])))
+  (fsm-lookup iteration-machine state-sym event-sym))
 
 (define (next-iteration-state state event)
   (define state-sym (state->symbol state))
@@ -128,6 +139,4 @@
     [else (error 'next-iteration-state "unknown state: ~a" next-sym)]))
 
 (define (valid-transition? state event)
-  (define state-sym (state->symbol state))
-  (define event-sym (iteration-event->symbol event))
-  (and (find-transition state-sym event-sym) #t))
+  (fsm-valid-transition? iteration-machine (state->symbol state) (iteration-event->symbol event)))

--- a/tests/test-fsm-generic.rkt
+++ b/tests/test-fsm-generic.rkt
@@ -1,0 +1,67 @@
+#lang racket/base
+
+;; tests/test-fsm-generic.rkt — Generic FSM library tests (F16)
+
+(require rackunit
+         rackunit/text-ui
+         (only-in "../util/fsm.rkt"
+                  make-fsm
+                  fsm?
+                  fsm-states
+                  fsm-events
+                  fsm-transitions
+                  fsm-lookup
+                  fsm-valid-transition?
+                  fsm-valid-targets
+                  fsm-find-path))
+
+(define simple-fsm
+  (make-fsm '(idle running done)
+            '(start finish reset)
+            '(((idle . start) . running) ((running . finish) . done)
+                                         ((running . reset) . idle)
+                                         ((done . reset) . idle))))
+
+(define fsm-tests
+  (test-suite "generic-fsm"
+
+    (test-case "make-fsm creates fsm struct"
+      (check-true (fsm? simple-fsm))
+      (check-equal? (fsm-states simple-fsm) '(idle running done))
+      (check-equal? (fsm-events simple-fsm) '(start finish reset))
+      (check-equal? (length (fsm-transitions simple-fsm)) 4))
+
+    (test-case "fsm-lookup finds valid transitions"
+      (check-equal? (fsm-lookup simple-fsm 'idle 'start) 'running)
+      (check-equal? (fsm-lookup simple-fsm 'running 'finish) 'done)
+      (check-equal? (fsm-lookup simple-fsm 'running 'reset) 'idle)
+      (check-equal? (fsm-lookup simple-fsm 'done 'reset) 'idle))
+
+    (test-case "fsm-lookup returns #f for invalid transitions"
+      (check-false (fsm-lookup simple-fsm 'idle 'finish))
+      (check-false (fsm-lookup simple-fsm 'done 'start))
+      (check-false (fsm-lookup simple-fsm 'idle 'reset)))
+
+    (test-case "fsm-valid-transition? returns boolean"
+      (check-true (fsm-valid-transition? simple-fsm 'idle 'start))
+      (check-false (fsm-valid-transition? simple-fsm 'idle 'finish)))
+
+    (test-case "fsm-valid-targets lists reachable states"
+      (check-equal? (fsm-valid-targets simple-fsm 'idle) '(running))
+      (check-equal? (sort (fsm-valid-targets simple-fsm 'running) symbol<?) '(done idle))
+      (check-equal? (fsm-valid-targets simple-fsm 'done) '(idle)))
+
+    (test-case "fsm-find-path finds shortest path"
+      (check-equal? (fsm-find-path simple-fsm 'idle 'running) '(start))
+      (check-equal? (fsm-find-path simple-fsm 'idle 'done) '(start finish))
+      (check-equal? (fsm-find-path simple-fsm 'running 'idle) '(reset)))
+
+    (test-case "fsm-find-path returns #f for unreachable"
+      ;; All states reachable in simple-fsm, so create one with unreachable
+      (define partial-fsm (make-fsm '(a b c) '(go) '(((a . go) . b))))
+      (check-false (fsm-find-path partial-fsm 'a 'c)))
+
+    (test-case "fsm-find-path same state returns empty path"
+      (check-equal? (fsm-find-path simple-fsm 'idle 'idle) '()))))
+
+(run-tests fsm-tests)

--- a/util/fsm.rkt
+++ b/util/fsm.rkt
@@ -1,0 +1,78 @@
+#lang racket/base
+
+;; util/fsm.rkt — Generic FSM transition library (F16)
+;; STABILITY: evolving
+;;
+;; Shared transition-table machinery used by:
+;;   runtime/iteration/fsm-types.rkt (iteration FSM)
+;;   agent/loop-fsm.rkt (turn FSM)
+;;   extensions/gsd/state-machine.rkt (GSD FSM)
+;;
+;; Each FSM is a data structure: (fsm states events transitions)
+;; where transitions is a list of ((state-sym . event-sym) . next-state-sym).
+
+(require racket/match)
+
+(provide (struct-out fsm)
+         make-fsm
+         fsm-states
+         fsm-events
+         fsm-transitions
+         fsm-lookup
+         fsm-valid-transition?
+         fsm-valid-targets
+         fsm-find-path)
+
+;; ── Struct ──
+
+(struct fsm (states events transitions) #:transparent)
+
+(define (make-fsm states events transitions)
+  ;; states: (listof symbol?)
+  ;; events: (listof symbol?)
+  ;; transitions: (listof (cons (cons symbol? symbol?) symbol?))
+  (fsm states events transitions))
+
+;; ── Lookup ──
+
+(define (fsm-lookup machine state-sym event-sym)
+  ;; Returns next-state symbol or #f
+  (for/or ([entry (in-list (fsm-transitions machine))])
+    (match entry
+      [`((,s . ,e) . ,next) (and (eq? s state-sym) (eq? e event-sym) next)]
+      [_ #f])))
+
+(define (fsm-valid-transition? machine state-sym event-sym)
+  ;; Returns #t if transition exists, #f otherwise
+  (and (fsm-lookup machine state-sym event-sym) #t))
+
+(define (fsm-valid-targets machine state-sym)
+  ;; Returns list of reachable next-state symbols from state-sym
+  (for/list ([entry (in-list (fsm-transitions machine))]
+             #:when (eq? (caar entry) state-sym))
+    (cdr entry)))
+
+;; ── BFS path finder ──
+
+(define (fsm-find-path machine from-sym to-sym)
+  ;; Returns list of event symbols to reach from → to, or #f if impossible
+  (define visited (make-hash))
+  ;; Queue entries: (cons node-sym path-events)
+  (define q (list (cons from-sym '())))
+  (let loop ([q q])
+    (cond
+      [(null? q) #f]
+      [else
+       (define node (car (car q)))
+       (define path (cdr (car q)))
+       (cond
+         [(eq? node to-sym) path]
+         [(hash-has-key? visited node) (loop (cdr q))]
+         [else
+          (hash-set! visited node #t)
+          (define next-steps
+            (for/list ([entry (in-list (fsm-transitions machine))]
+                       #:when (eq? (caar entry) node)
+                       #:unless (hash-has-key? visited (cdr entry)))
+              (cons (cdr entry) (append path (list (cdar entry))))))
+          (loop (append (cdr q) next-steps))])])))


### PR DESCRIPTION
Addresses #4530.

feat: extract shared util/fsm.rkt generic FSM library (F16) (#4530)

Created util/fsm.rkt with make-fsm, fsm-lookup, fsm-valid-transition?,
fsm-valid-targets, fsm-find-path. Refactored iteration/fsm-types.rkt
and agent/loop-fsm.rkt to use shared library instead of duplicating
BFS/lookup logic. All existing tests pass.