### PR TITLE
chore: version bump 0.46.4 + deprecate iteration wrapper (#4532)

Version bump 0.46.3 → 0.46.4 with CHANGELOG entry.
Migrated session-lifecycle to run-iteration-loop/v2.
Added deprecation comment to backward-compat wrapper.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## v0.46.4 — 2026-05-18
+
+### Changed
+- **F16**: Extracted shared `util/fsm.rkt` generic FSM library — `make-fsm`, `fsm-lookup`, `fsm-valid-transition?`, `fsm-find-path`
+- **F16**: Refactored `runtime/iteration/fsm-types.rkt` and `agent/loop-fsm.rkt` to use shared FSM library
+- **F3**: Added FSM transition validation guards to `agent/turn-reducer.rkt`
+- **F15**: Migrated `runtime/session-lifecycle.rkt` to use `run-iteration-loop/v2` with config struct
+
+### Added
+- `tests/test-fsm-generic.rkt` — 8 tests for generic FSM library
+- `turn-machine` export from `loop-fsm.rkt`
+- 2 new turn-reducer validation tests (19 total)
+
 ## v0.46.3 — 2026-05-18
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.46.3-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.46.4-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 
@@ -203,7 +203,7 @@ bin/q --model gpt-5.4 "write a test"
 ### Verify
 
 ```bash
-bin/q --version            # q version 0.46.3
+bin/q --version            # q version 0.46.4
 raco test tests/           # run the full test suite
 ```
 
@@ -276,7 +276,7 @@ q/
 |--------|-------|
 | Test files | 590 |
 | Source modules | 431 |
-| Source lines | 66284 |
+| Source lines | 66287 |
 | Test lines | 104147 |
 | Test assertions | 16245 |
 | Tests passing | 5835+ | `racket scripts/run-tests.rkt` results |
@@ -415,7 +415,7 @@ When q executes shell commands on behalf of an LLM, arguments are quoted via `sh
 
 
 
-**v0.46.3** — Changed
+**v0.46.4** — Changed
 
 **v0.45.22** — Fixed
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -2,7 +2,7 @@
 
 ## Version
 
-v0.46.3
+v0.46.4
 
 ## Layer Diagram
 

--- a/docs/event-taxonomy.md
+++ b/docs/event-taxonomy.md
@@ -1,6 +1,6 @@
 # Q Event Taxonomy Reference
 
-Complete reference for all event types in Q 0.46.3.
+Complete reference for all event types in Q 0.46.4.
 ## Base Types
 
 ### `event` (protocol-level)

--- a/docs/extension-guide.md
+++ b/docs/extension-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.46.3 --># Extension Development Guide
+<!-- verified-against: 0.46.4 --># Extension Development Guide
 
 This guide walks you through creating, testing, and activating a custom
 extension for q.

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.46.3 --># Getting Started
+<!-- verified-against: 0.46.4 --># Getting Started
 
 Welcome to q, a Racket-based coding agent.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.46.3 --># Installation Guide
+<!-- verified-against: 0.46.4 --># Installation Guide
 
 <!-- This file is the canonical source. The docs/getting-started/installation.md copy is maintained for the doc site build. -->
 

--- a/docs/security-trust-model.md
+++ b/docs/security-trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.46.3 --># Security & Trust Model
+<!-- verified-against: 0.46.4 --># Security & Trust Model
 
 This document provides an honest, per-area assessment of what q enforces
 today and what is planned. It is the authoritative reference for security

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -130,6 +130,6 @@ is the primary self-hosting extension:
 (load-extension! ext-reg "path/to/extension.rkt" #:event-bus bus)
 ```
 
-## Version 0.46.3
+## Version 0.46.4
 
-This documentation reflects q 0.46.3.
+This documentation reflects q 0.46.4.

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.46.3 --># q Source Style Guide
+<!-- verified-against: 0.46.4 --># q Source Style Guide
 
 This document defines formatting and naming conventions for the q Racket codebase.
 All changes to `q/` source files (excluding `tests/`) should follow these rules.

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.46.3 --># Trust Model
+<!-- verified-against: 0.46.4 --># Trust Model
 
 ## Trust Levels
 

--- a/docs/workflow-testing.md
+++ b/docs/workflow-testing.md
@@ -121,6 +121,6 @@ Use relative paths from the test file:
 4. Use `(check-true ...)` for boolean assertions
 5. Keep tests independent — no shared mutable state between test-cases
 
-## Version 0.46.3
+## Version 0.46.4
 
-This documentation reflects q 0.46.3.
+This documentation reflects q 0.46.4.

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.46.3")
+(define version "0.46.4")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base"))

--- a/runtime/iteration/main-loop.rkt
+++ b/runtime/iteration/main-loop.rkt
@@ -287,7 +287,8 @@
                      (loop new-ctx new-counters ws2)])])]))))))
 
 ;; ============================================================
-;; run-iteration-loop (backward-compatible wrapper)
+;; run-iteration-loop (DEPRECATED: use run-iteration-loop/v2 with loop-config struct)
+;; Kept for backward compatibility with existing tests.
 ;; ============================================================
 
 (define (run-iteration-loop context

--- a/runtime/session-lifecycle.rkt
+++ b/runtime/session-lifecycle.rkt
@@ -48,7 +48,8 @@
          (only-in "../runtime/session-context.rkt" extract-path-settings)
          "../util/ids.rkt"
          (only-in "runtime-helpers.rkt" emit-session-event! maybe-dispatch-hooks)
-         (only-in "iteration/main-loop.rkt" run-iteration-loop)
+         (only-in "iteration/main-loop.rkt" run-iteration-loop/v2)
+         (only-in "iteration/loop-config.rkt" make-loop-config)
          (only-in "../agent/event-emitter.rkt" emit-typed-event!)
          (only-in "../agent/event-structs/turn-events.rkt" turn-end-event turn-start-event)
          "session-types.rkt"
@@ -289,20 +290,21 @@
           (make-loop-result context-with-system 'error payload))])
     (define ws (config-working-set cfg))
     (define result
-      (run-iteration-loop context-with-system
-                          prov
-                          bus
-                          reg
-                          (agent-session-extension-registry sess)
-                          log-path
-                          sid
-                          max-iterations
-                          #:cancellation-token cancellation-tok
-                          #:config cfg
-                          #:working-set ws
-                          #:shutdown-check (lambda () (agent-session-shutdown-requested? sess))
-                          #:force-shutdown-check (lambda () (agent-session-force-shutdown? sess))
-                          #:session sess))
+      (run-iteration-loop/v2
+       (make-loop-config context-with-system
+                         prov
+                         bus
+                         reg
+                         (agent-session-extension-registry sess)
+                         log-path
+                         sid
+                         max-iterations
+                         #:cancellation-token cancellation-tok
+                         #:config cfg
+                         #:working-set ws
+                         #:shutdown-check (lambda () (agent-session-shutdown-requested? sess))
+                         #:force-shutdown-check (lambda () (agent-session-force-shutdown? sess))
+                         #:session sess)))
     ;; v0.32.0: Stop trace logger on normal completion
     (stop-trace-logger! tracer)
     result))

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -10,4 +10,4 @@
 (provide q-version)
 
 (: q-version String)
-(define q-version "0.46.3")
+(define q-version "0.46.4")

--- a/wiki-src/Architecture-Overview.md
+++ b/wiki-src/Architecture-Overview.md
@@ -35,7 +35,7 @@ User input → Interface (CLI/TUI/RPC)
     → Events emitted to bus
 ```
 
-## Metrics (0.46.3)
+## Metrics (0.46.4)
 > _See `racket scripts/metrics.rkt` for current numbers._
 
 - 414 source modules, 534 test files


### PR DESCRIPTION
Addresses #4532.

chore: version bump 0.46.4 + deprecate iteration wrapper (#4532)

Version bump 0.46.3 → 0.46.4 with CHANGELOG entry.
Migrated session-lifecycle to run-iteration-loop/v2.
Added deprecation comment to backward-compat wrapper.