### PR TITLE
feat: add per-type #:schema-version to define-typed-event (F6) (#4537)

Added per-type schema version registry (current-event-schema-registry,
register-event-schema-version!, lookup-event-schema-version).
Extended define-typed-event macro with optional #:schema-version clause.
Updated event-json.rkt serialization to use per-type version.
7 new round-trip tests pass, all existing tests green.

### DIFF
--- a/agent/event-json.rkt
+++ b/agent/event-json.rkt
@@ -48,7 +48,8 @@
                   lookup-event-deserializer
                   register-event-serializer!
                   register-event-deserializer!
-                  current-schema-version))
+                  current-schema-version
+                  lookup-event-schema-version))
 
 (provide typed-event->jsexpr
          jsexpr->typed-event
@@ -61,7 +62,8 @@
 (define (register-tool-event-serializer! event-type base-serializer)
   (register-event-serializer!
    event-type
-   (lambda (evt) (hash-set (base-serializer evt) 'schemaVersion (current-schema-version)))))
+   (lambda (evt)
+     (hash-set (base-serializer evt) 'schemaVersion (lookup-event-schema-version event-type)))))
 
 ;; ============================================================
 ;; Per-tool event serializer registration (manual structs)
@@ -256,7 +258,7 @@
             'turnId
             (typed-event-turn-id evt)
             'schemaVersion
-            (current-schema-version)))
+            (lookup-event-schema-version (typed-event-type evt))))
   (define type-str (typed-event-type evt))
   (define serializer (lookup-event-serializer type-str))
   (when (not serializer)

--- a/tests/test-schema-versioning.rkt
+++ b/tests/test-schema-versioning.rkt
@@ -1,0 +1,70 @@
+#lang racket/base
+
+;; tests/test-schema-versioning.rkt — Per-type schema version tests (F6, S8-F1)
+
+(require rackunit
+         rackunit/text-ui
+         (only-in "../util/event-macro.rkt"
+                  define-typed-event
+                  with-fresh-event-registries
+                  current-event-schema-registry
+                  register-event-schema-version!
+                  lookup-event-schema-version
+                  current-schema-version)
+         (only-in "../agent/event-json.rkt" typed-event->jsexpr jsexpr->typed-event))
+
+;; Define test events at module level (provide must be at module level)
+(define-typed-event sv-test-event-v1 "sv-test-v1" (data) #:schema-version 1)
+(define-typed-event sv-test-event-v3 "sv-test-v3" (payload) #:schema-version 3)
+(define-typed-event sv-test-no-ver "sv-test-no-ver" (info))
+
+(define sv-tests
+  (test-suite "schema-versioning"
+
+    (test-case "per-type schema version registered"
+      (check-equal? (lookup-event-schema-version "sv-test-v1") 1)
+      (check-equal? (lookup-event-schema-version "sv-test-v3") 3)
+      (check-equal? (lookup-event-schema-version "sv-test-no-ver") 1))
+
+    (test-case "unregistered type falls back to global default"
+      (check-equal? (lookup-event-schema-version "unknown-type") 1))
+
+    (test-case "global schema version parameter works"
+      (parameterize ([current-schema-version 5])
+        (check-equal? (lookup-event-schema-version "unknown-type") 5)))
+
+    (test-case "schema-version round-trips through serialization"
+      (define evt (make-sv-test-event-v3 #:session-id "s1" #:turn-id "t1" #:payload "hello"))
+      (define json (typed-event->jsexpr evt))
+      (check-equal? (hash-ref json 'schemaVersion) 3)
+      (define back (jsexpr->typed-event json))
+      (check-equal? (sv-test-event-v3-payload back) "hello"))
+
+    (test-case "no-schema-version event uses global default"
+      (define evt (make-sv-test-no-ver #:session-id "s1" #:turn-id "t1" #:info "x"))
+      (define json (typed-event->jsexpr evt))
+      (check-equal? (hash-ref json 'schemaVersion) 1))
+
+    (test-case "deserialization tolerates future schema version"
+      (define json
+        (hasheq 'type
+                "sv-test-v1"
+                'timestamp
+                1000
+                'sessionId
+                "s1"
+                'turnId
+                "t1"
+                'schemaVersion
+                99
+                'data
+                "test"))
+      ;; Should not error, just log a warning
+      (define back (jsexpr->typed-event json))
+      (check-equal? (sv-test-event-v1-data back) "test"))
+
+    (test-case "manual schema version registration"
+      (register-event-schema-version! "manual-type" 7)
+      (check-equal? (lookup-event-schema-version "manual-type") 7))))
+
+(run-tests sv-tests)

--- a/util/event-macro.rkt
+++ b/util/event-macro.rkt
@@ -35,7 +35,10 @@
          ;; JSON key conversion
          field->json-key
          ;; S8-F1: Schema versioning
-         current-schema-version)
+         current-schema-version
+         current-event-schema-registry
+         register-event-schema-version!
+         lookup-event-schema-version)
 
 ;; ===========================================================
 ;; Event field registry (I-12, I-23) -- canonical runtime mechanism for serialization
@@ -60,6 +63,15 @@
 
 ;; S8-F1: Schema versioning for safe event evolution
 (define current-schema-version (make-parameter 1))
+
+;; Per-type schema version registry: type-string -> version (exact-positive-integer?)
+(define current-event-schema-registry (make-parameter (make-hash)))
+
+(define (register-event-schema-version! type-str version)
+  (hash-set! (current-event-schema-registry) type-str version))
+
+(define (lookup-event-schema-version type-str)
+  (hash-ref (current-event-schema-registry) type-str (current-schema-version)))
 
 (define (register-event-serializer! type-str fn)
   (hash-set! (current-event-serializer-registry) type-str fn))
@@ -196,6 +208,7 @@
                    #:defaults ([(opt-field 1) '()] [(opt-default 1) '()]))
         (~optional (~seq #:json-keys json-keys) #:defaults ([json-keys #'()]))
         (~optional (~seq #:defaults req-defaults) #:defaults ([req-defaults #'()]))
+        (~optional (~seq #:schema-version schema-ver:nat) #:defaults ([schema-ver #'#f]))
         (~optional (~and #:no-serialize ns-flag) #:defaults ([ns-flag #'#f])))
      (define opt-raw (attribute opt-field))
      (define opt-default-raw (attribute opt-default))
@@ -212,6 +225,7 @@
          [(list? opt-default-raw) opt-default-raw]
          [else '()]))
      (define skip-serialize? (eq? (syntax-e (attribute ns-flag)) '#:no-serialize))
+     (define schema-version-val (and (attribute schema-ver) (syntax-e (attribute schema-ver))))
      (define req-fields (syntax->list #'(req-field ...)))
      (define all-fields (append req-fields opt-fields))
      (define all-defaults (append (map (lambda (_) #f) req-fields) opt-defaults))
@@ -257,6 +271,10 @@
                (define fields-name '(all-field ...))
                ;; I-12: Register field names for event-struct->hasheq runtime lookup
                (register-event-fields! 'event-name fields-name)
+               ;; S8-F1: Register per-type schema version
+               (let ([sv schema-ver])
+                 (when sv
+                   (register-event-schema-version! type-str sv)))
                (define (make-name #:session-id session-id
                                   #:turn-id turn-id
                                   #:timestamp [timestamp (current-seconds)]
@@ -272,6 +290,10 @@
                (define fields-name '(all-field ...))
                ;; I-12: Register field names for event-struct->hasheq runtime lookup
                (register-event-fields! 'event-name fields-name)
+               ;; S8-F1: Register per-type schema version
+               (let ([sv schema-ver])
+                 (when sv
+                   (register-event-schema-version! type-str sv)))
                (define (make-name #:session-id session-id
                                   #:turn-id turn-id
                                   #:timestamp [timestamp (current-seconds)]
@@ -283,6 +305,10 @@
                (register-event-deserializer! type-str
                                              (lambda (type ts sid tid h)
                                                (event-name type ts sid tid deser-arg ...)))
+               ;; S8-F1: Register per-type schema version
+               (let ([sv schema-ver])
+                 (when sv
+                   (register-event-schema-version! type-str sv)))
                (provide (struct-out event-name)
                         make-name
                         type-name


### PR DESCRIPTION
Addresses #4537.

feat: add per-type #:schema-version to define-typed-event (F6) (#4537)

Added per-type schema version registry (current-event-schema-registry,
register-event-schema-version!, lookup-event-schema-version).
Extended define-typed-event macro with optional #:schema-version clause.
Updated event-json.rkt serialization to use per-type version.
7 new round-trip tests pass, all existing tests green.