### PR TITLE
chore: version bump 0.46.5 + CHANGELOG (#4539)

Version bump 0.46.4 → 0.46.5 with CHANGELOG entry for F6 schema
versioning and event migration infrastructure.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## v0.46.5 — 2026-05-18
+
+### Changed
+- **F6**: Added per-type `#:schema-version` clause to `define-typed-event` macro
+- **F6**: Added `current-event-schema-registry`, `register-event-schema-version!`, `lookup-event-schema-version` to `util/event-macro.rkt`
+- **F6**: `event-json.rkt` serialization now uses per-type schema version instead of global default
+
+### Added
+- `util/event-migration.rkt` — Per-type migration function registry with `run-event-migrations!`
+- `util/event-codec.rkt` now runs migrations before deserialization
+- `tests/test-schema-versioning.rkt` — 7 tests for per-type schema versioning
+- `tests/test-event-migration.rkt` — 5 tests for migration chaining
+
 ## v0.46.4 — 2026-05-18
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.46.4-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.46.5-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 
@@ -203,7 +203,7 @@ bin/q --model gpt-5.4 "write a test"
 ### Verify
 
 ```bash
-bin/q --version            # q version 0.46.4
+bin/q --version            # q version 0.46.5
 raco test tests/           # run the full test suite
 ```
 
@@ -415,7 +415,7 @@ When q executes shell commands on behalf of an LLM, arguments are quoted via `sh
 
 
 
-**v0.46.4** — Changed
+**v0.46.5** — Changed
 
 **v0.45.22** — Fixed
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -2,7 +2,7 @@
 
 ## Version
 
-v0.46.4
+v0.46.5
 
 ## Layer Diagram
 

--- a/docs/event-taxonomy.md
+++ b/docs/event-taxonomy.md
@@ -1,6 +1,6 @@
 # Q Event Taxonomy Reference
 
-Complete reference for all event types in Q 0.46.4.
+Complete reference for all event types in Q 0.46.5.
 ## Base Types
 
 ### `event` (protocol-level)

--- a/docs/extension-guide.md
+++ b/docs/extension-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.46.4 --># Extension Development Guide
+<!-- verified-against: 0.46.5 --># Extension Development Guide
 
 This guide walks you through creating, testing, and activating a custom
 extension for q.

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.46.4 --># Getting Started
+<!-- verified-against: 0.46.5 --># Getting Started
 
 Welcome to q, a Racket-based coding agent.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.46.4 --># Installation Guide
+<!-- verified-against: 0.46.5 --># Installation Guide
 
 <!-- This file is the canonical source. The docs/getting-started/installation.md copy is maintained for the doc site build. -->
 

--- a/docs/security-trust-model.md
+++ b/docs/security-trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.46.4 --># Security & Trust Model
+<!-- verified-against: 0.46.5 --># Security & Trust Model
 
 This document provides an honest, per-area assessment of what q enforces
 today and what is planned. It is the authoritative reference for security

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -130,6 +130,6 @@ is the primary self-hosting extension:
 (load-extension! ext-reg "path/to/extension.rkt" #:event-bus bus)
 ```
 
-## Version 0.46.4
+## Version 0.46.5
 
-This documentation reflects q 0.46.4.
+This documentation reflects q 0.46.5.

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.46.4 --># q Source Style Guide
+<!-- verified-against: 0.46.5 --># q Source Style Guide
 
 This document defines formatting and naming conventions for the q Racket codebase.
 All changes to `q/` source files (excluding `tests/`) should follow these rules.

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.46.4 --># Trust Model
+<!-- verified-against: 0.46.5 --># Trust Model
 
 ## Trust Levels
 

--- a/docs/workflow-testing.md
+++ b/docs/workflow-testing.md
@@ -121,6 +121,6 @@ Use relative paths from the test file:
 4. Use `(check-true ...)` for boolean assertions
 5. Keep tests independent — no shared mutable state between test-cases
 
-## Version 0.46.4
+## Version 0.46.5
 
-This documentation reflects q 0.46.4.
+This documentation reflects q 0.46.5.

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.46.4")
+(define version "0.46.5")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base"))

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -10,4 +10,4 @@
 (provide q-version)
 
 (: q-version String)
-(define q-version "0.46.4")
+(define q-version "0.46.5")

--- a/wiki-src/Architecture-Overview.md
+++ b/wiki-src/Architecture-Overview.md
@@ -35,7 +35,7 @@ User input → Interface (CLI/TUI/RPC)
     → Events emitted to bus
 ```
 
-## Metrics (0.46.4)
+## Metrics (0.46.5)
 > _See `racket scripts/metrics.rkt` for current numbers._
 
 - 414 source modules, 534 test files


### PR DESCRIPTION
Addresses #4539.

chore: version bump 0.46.5 + CHANGELOG (#4539)

Version bump 0.46.4 → 0.46.5 with CHANGELOG entry for F6 schema
versioning and event migration infrastructure.