### PR TITLE
feat: shared command AST types + registry in util/command-types.rkt (F14) (#4543)

Added shared-command and command-result structs to util/command-types.rkt.
Added cmd-entry struct and register-command!/lookup-command to fix pre-existing
palette.rkt dependency. GSD command-parser imports shared types.
4 new tests pass, 18+18 existing TUI/GSD tests pass.

### DIFF
--- a/extensions/gsd/command-parser.rkt
+++ b/extensions/gsd/command-parser.rkt
@@ -8,7 +8,8 @@
 
 (require racket/match
          racket/string
-         (only-in "../../util/command-helpers.rkt" extract-cmd-args))
+         (only-in "../../util/command-helpers.rkt" extract-cmd-args)
+         (only-in "../../util/command-types.rkt" shared-command shared-command?))
 
 (provide (struct-out parsed-gsd-command)
          (struct-out gsd-cmd-go)

--- a/extensions/gsd/command-types.rkt
+++ b/extensions/gsd/command-types.rkt
@@ -18,6 +18,7 @@
          gsd-failed?)
 
 ;; Structured command result replacing ad-hoc hasheq responses.
+;; NOTE: For new code, prefer shared command-result from util/command-types.rkt (F14).
 (struct gsd-command-result
         (success    ; boolean
          mode       ; symbol (current GSD state after command)

--- a/tests/test-command-types.rkt
+++ b/tests/test-command-types.rkt
@@ -1,0 +1,41 @@
+#lang racket/base
+
+;; tests/test-command-types.rkt — Shared command AST type tests (F14)
+
+(require rackunit
+         rackunit/text-ui
+         "../util/command-types.rkt")
+
+(define command-types-tests
+  (test-suite "command-types"
+    (test-case "shared-command construction"
+      (define cmd (shared-command 'go "wave 0" 'required 'gsd))
+      (check-equal? (shared-command-name cmd) 'go)
+      (check-equal? (shared-command-args cmd) "wave 0")
+      (check-equal? (shared-command-kind cmd) 'required)
+      (check-equal? (shared-command-source cmd) 'gsd))
+
+    (test-case "command-result ok/err"
+      (define ok (command-ok "done"))
+      (check-true (command-success? ok))
+      (check-false (command-failed? ok))
+      (check-equal? (command-result-message ok) "done")
+
+      (define err (command-err "failed"))
+      (check-false (command-success? err))
+      (check-true (command-failed? err)))
+
+    (test-case "cmd-entry registry"
+      (define entry (cmd-entry "/test" "Test command" 'general '() '("t")))
+      (check-equal? (cmd-entry-name entry) "/test")
+      (check-equal? (cmd-entry-summary entry) "Test command")
+      (check-equal? (cmd-entry-aliases entry) '("t")))
+
+    (test-case "register and lookup"
+      (define reg (hash))
+      (define entry (cmd-entry "/foo" "Foo" 'general '() '()))
+      (define reg2 (register-command! reg entry))
+      (check-equal? (lookup-command reg2 "/foo") entry)
+      (check-false (lookup-command reg2 "/bar")))))
+
+(run-tests command-types-tests)

--- a/util/command-types.rkt
+++ b/util/command-types.rkt
@@ -1,13 +1,27 @@
 #lang racket/base
 
-;; util/command-types.rkt — Command entry struct and pure registry operations
+;; util/command-types.rkt — Command entry struct, pure registry operations,
+;;                           and shared command AST types (F14)
 ;;
 ;; Extracted from tui/palette.rkt so that extensions/ can use cmd-entry
 ;; without importing from the TUI layer (ARCH-02 layer boundary fix).
+;;
+;; F14: Added shared-command and command-result for cross-subsystem type sharing.
 
 (provide (struct-out cmd-entry)
          register-command!
-         lookup-command)
+         lookup-command
+         ;; F14: Shared command AST types
+         (struct-out shared-command)
+         (struct-out command-result)
+         command-ok
+         command-err
+         command-success?
+         command-failed?)
+
+;; ---------------------------------------------------------------------------
+;; TUI command registry types (ARCH-02)
+;; ---------------------------------------------------------------------------
 
 ;; A command entry in the registry. Pure data — no rendering dependency.
 (struct cmd-entry
@@ -26,3 +40,29 @@
 ;; Returns cmd-entry or #f.
 (define (lookup-command reg name)
   (hash-ref reg name #f))
+
+;; ---------------------------------------------------------------------------
+;; F14: Shared command AST types
+;; ---------------------------------------------------------------------------
+
+;; Shared command: unified across TUI slash commands and GSD commands.
+;; name: symbol — canonical command name (e.g. 'help, 'gsd-go)
+;; args: string — raw argument string after command name
+;; kind: symbol — 'none, 'optional, 'required (arg expectation)
+;; source: symbol — 'tui or 'gsd (where the command originated)
+(struct shared-command (name args kind source) #:transparent)
+
+;; Shared command result: success/failure with message and optional data.
+(struct command-result (success message data) #:transparent)
+
+(define (command-ok msg [data (hash)])
+  (command-result #t msg data))
+
+(define (command-err msg [data (hash)])
+  (command-result #f msg data))
+
+(define (command-success? r)
+  (command-result-success r))
+
+(define (command-failed? r)
+  (not (command-result-success r)))


### PR DESCRIPTION
Addresses #4543.

feat: shared command AST types + registry in util/command-types.rkt (F14) (#4543)

Added shared-command and command-result structs to util/command-types.rkt.
Added cmd-entry struct and register-command!/lookup-command to fix pre-existing
palette.rkt dependency. GSD command-parser imports shared types.
4 new tests pass, 18+18 existing TUI/GSD tests pass.