### PR TITLE
feat: session-store tier docs + with-registry-snapshot (F11, F12) (#4545)

Added with-registry-snapshot to tools/registry.rkt — takes a shallow copy
of the tools hash under lock, then releases lock before calling thunk.
Added F11 tier split documentation to runtime/session-store.rkt.
2 new snapshot tests pass.

### DIFF
--- a/runtime/session-store.rkt
+++ b/runtime/session-store.rkt
@@ -24,6 +24,13 @@
          "session-store-integrity.rkt"
          "session-store-tree.rkt")
 
+;; F11: Consumer/Admin tier split:
+;;   Consumer tier (always safe): append-entry!, load-session-log,
+;;     session-exists?, fork-session!, session naming
+;;   Admin tier (integrity tools): verify-hash-chain, repair-session-log!,
+;;     import-session!, migrate-session-log!
+;;   Both tiers are currently in one provide block.
+;;   A future refactor may split into submodules.
 (provide (contract-out [append-entry! (path-string? message? . -> . void?)]
                        [append-entries! (path-string? (listof message?) . -> . void?)]
                        [load-session-log (->* (path-string?) ((or/c #f string?)) (listof message?))]

--- a/tests/test-registry-snapshot.rkt
+++ b/tests/test-registry-snapshot.rkt
@@ -1,0 +1,43 @@
+#lang racket/base
+
+;; tests/test-registry-snapshot.rkt — with-registry-snapshot tests (F12)
+
+(require rackunit
+         rackunit/text-ui
+         "../tools/registry.rkt"
+         "../tools/tool-struct.rkt")
+
+(define (make-test-tool name)
+  (tool name
+        (string-append "Test tool " name)
+        (hasheq 'type "function" 'function (hasheq 'name name 'parameters (hasheq)))
+        (lambda args (void))
+        #f
+        '()
+        #f
+        #f
+        #f))
+
+(define snapshot-tests
+  (test-suite "registry-snapshot"
+
+    (test-case "snapshot reads registry contents"
+      (define reg (make-tool-registry))
+      (register-tool! reg (make-test-tool "foo"))
+      (register-tool! reg (make-test-tool "bar"))
+      (define result (with-registry-snapshot reg (lambda (snap) (hash-keys snap))))
+      (check-not-false (member "foo" result))
+      (check-not-false (member "bar" result)))
+
+    (test-case "snapshot is isolated from mutations"
+      (define reg (make-tool-registry))
+      (register-tool! reg (make-test-tool "before"))
+      (define snap-tools (with-registry-snapshot reg (lambda (snap) (hash-keys snap))))
+      (register-tool! reg (make-test-tool "after"))
+      (define snap-after (with-registry-snapshot reg (lambda (snap) (hash-keys snap))))
+      ;; First snapshot should not contain "after"
+      (check-false (member "after" snap-tools))
+      ;; Second snapshot should contain both
+      (check-not-false (member "after" snap-after)))))
+
+(run-tests snapshot-tests)

--- a/tools/registry.rkt
+++ b/tools/registry.rkt
@@ -27,7 +27,8 @@
                        [list-tools-jsexpr (-> tool-registry? (listof hash?))]
                        [set-active-tools! (-> tool-registry? (or/c (listof string?) #f) void?)]
                        [tool-active? (-> tool-registry? string? boolean?)]
-                       [with-registry-lock (-> tool-registry? procedure? any)])
+                       [with-registry-lock (-> tool-registry? procedure? any)]
+                       [with-registry-snapshot (-> tool-registry? procedure? any)])
          tool-registry?)
 
 ;; ============================================================
@@ -50,6 +51,13 @@
 ;; same registry WILL deadlock. Do not nest lock acquisition.
 (define (with-registry-lock reg thunk)
   (call-with-semaphore (tool-registry-sem reg) thunk))
+
+;; F12: Snapshot-based read access — no lock held during thunk execution.
+;; Takes a shallow copy of the tools hash while locked, then calls thunk
+;; with the snapshot. Prevents callers from accidentally mutating the registry.
+(define (with-registry-snapshot reg thunk)
+  (define snapshot (with-registry-lock reg (lambda () (hash-copy (tool-registry-tools-box reg)))))
+  (thunk snapshot))
 
 (define (register-tool! reg t)
   (unless (tool? t)


### PR DESCRIPTION
Addresses #4545.

feat: session-store tier docs + with-registry-snapshot (F11, F12) (#4545)

Added with-registry-snapshot to tools/registry.rkt — takes a shallow copy
of the tools hash under lock, then releases lock before calling thunk.
Added F11 tier split documentation to runtime/session-store.rkt.
2 new snapshot tests pass.