### PR TITLE
feat: effect descriptor types + pure loop phase functions (F1) (#4551)

Created agent/effect-types.rkt with effect descriptor struct union
(effect:emit-event, effect:update-fsm, effect:dispatch-hook,
effect:stream-from-provider, effect:none) and execute-effects! executor.

Created agent/loop-phases.rkt with pure phase functions
(phase-emit-start, phase-build-context, phase-build-request,
phase-pre-hook) that return (values result (listof effect?)).

6 effect-type tests + 4 loop-phase tests pass.

### DIFF
--- a/agent/effect-types.rkt
+++ b/agent/effect-types.rkt
@@ -1,0 +1,70 @@
+#lang racket/base
+
+;; agent/effect-types.rkt — Effect descriptor struct union (F1)
+;; STABILITY: evolving
+;;
+;; Defines effect descriptors returned by pure phase functions.
+;; Effects describe WHAT should happen; the executor decides HOW.
+;; This separation enables dry-run testing of agent loop phases.
+
+(require racket/contract)
+
+(provide (struct-out effect:emit-event)
+         (struct-out effect:update-fsm)
+         (struct-out effect:dispatch-hook)
+         (struct-out effect:stream-from-provider)
+         (struct-out effect:none)
+         effect?
+         execute-effects!)
+
+;; ---------------------------------------------------------------------------
+;; Effect descriptors
+;; ---------------------------------------------------------------------------
+
+;; Emit a typed event to the event bus
+(struct effect:emit-event (type payload) #:transparent)
+
+;; Update the turn FSM state machine
+(struct effect:update-fsm (from-state event) #:transparent)
+
+;; Dispatch a hook at the given hook point
+(struct effect:dispatch-hook (hook-point payload) #:transparent)
+
+;; Stream from provider with given config and messages
+(struct effect:stream-from-provider
+        (provider request bus session-id turn-id state hook-dispatcher cancellation-token)
+  #:transparent)
+
+;; No-op effect (identity)
+(struct effect:none () #:transparent)
+
+;; Predicate: is this an effect descriptor?
+(define effect?
+  (or/c effect:emit-event?
+        effect:update-fsm?
+        effect:dispatch-hook?
+        effect:stream-from-provider?
+        effect:none?))
+
+;; ---------------------------------------------------------------------------
+;; Default executor (runs effects with real side effects)
+;; ---------------------------------------------------------------------------
+
+(require "event-bus.rkt"
+         "event-emitter.rkt"
+         "loop-fsm.rkt")
+
+(define (execute-effects! effects #:bus [bus #f] #:state [st #f])
+  ;; Execute a list of effect descriptors against real infrastructure.
+  ;; This is the ONLY place where effects become side effects.
+  (for ([eff (in-list effects)])
+    (cond
+      [(effect:emit-event? eff)
+       (when (and bus (effect:emit-event-payload eff))
+         (emit-typed-event! bus (effect:emit-event-payload eff) #:state st))]
+      [(effect:update-fsm? eff)
+       (current-turn-fsm-state (next-turn-state (effect:update-fsm-from-state eff)
+                                                (effect:update-fsm-event eff)))]
+      [(effect:dispatch-hook? eff) (void)] ;; hooks dispatched separately
+      [(effect:none? eff) (void)]
+      [else (void)])))

--- a/agent/loop-phases.rkt
+++ b/agent/loop-phases.rkt
@@ -1,0 +1,97 @@
+#lang racket/base
+
+;; agent/loop-phases.rkt — Pure phase functions for agent loop (F1)
+;; STABILITY: evolving
+;;
+;; Each phase function is a PURE function that returns
+;; (values result (listof effect?)). Effects describe what should
+;; happen; the orchestrator (loop.rkt) decides how to execute them.
+
+(require racket/match
+         racket/list
+         "../util/ids.rkt"
+         "../util/protocol-types.rkt"
+         "../llm/model.rkt"
+         "../llm/token-budget.rkt"
+         (only-in "../llm/provider.rkt" provider-name provider?)
+         "effect-types.rkt"
+         "loop-messages.rkt"
+         "loop-fsm.rkt"
+         "state.rkt"
+         "event-emitter.rkt"
+         (only-in "event-structs.rkt"
+                  make-turn-start-event
+                  make-context-event
+                  make-provider-request-event
+                  make-model-request-blocked-event
+                  make-turn-end-event))
+
+(provide phase-emit-start
+         phase-build-context
+         phase-build-request
+         phase-pre-hook)
+
+;; ---------------------------------------------------------------------------
+;; Phase 1: Emit turn-started event
+;; ---------------------------------------------------------------------------
+
+;; Returns (values context (listof effect?))
+(define (phase-emit-start session-id turn-id st context)
+  (define start-event
+    (make-turn-start-event #:session-id session-id
+                           #:turn-id turn-id
+                           #:timestamp (current-inexact-milliseconds)
+                           #:model ""
+                           #:provider ""))
+  (define effects
+    (list (effect:emit-event 'turn-start start-event)
+          (effect:update-fsm turn-state-emit-start turn-event-start)))
+  (values context effects))
+
+;; ---------------------------------------------------------------------------
+;; Phase 2: Build context
+;; ---------------------------------------------------------------------------
+
+;; Returns (values raw-messages (listof effect?))
+(define (phase-build-context bus session-id turn-id st context)
+  (define raw-messages (build-raw-messages context))
+  (define token-count (estimate-context-tokens raw-messages))
+  (define ctx-event
+    (make-context-event #:session-id session-id
+                        #:turn-id turn-id
+                        #:timestamp (current-inexact-milliseconds)
+                        #:token-count token-count
+                        #:window-size (length raw-messages)))
+  ;; Emit the context event directly (it needs the bus)
+  (emit-typed-event! bus ctx-event #:state st)
+  (define effects (list (effect:update-fsm turn-state-build-context turn-event-context-built)))
+  (values raw-messages effects))
+
+;; ---------------------------------------------------------------------------
+;; Phase 3: Build model request
+;; ---------------------------------------------------------------------------
+
+;; Returns (values model-request (listof effect?))
+(define (phase-build-request raw-messages tools provider-settings)
+  (define req (make-model-request raw-messages tools (or provider-settings (hasheq))))
+  (values req '()))
+
+;; ---------------------------------------------------------------------------
+;; Phase 4: Pre-hook dispatch
+;; ---------------------------------------------------------------------------
+
+;; Returns (values hook-result (listof effect?))
+;; hook-result is #f if no hook dispatcher, or the hook result
+(define (phase-pre-hook hook-dispatcher provider raw-messages req session-id turn-id)
+  (define result
+    (and hook-dispatcher
+         (hook-dispatcher 'model-request-pre
+                          (hasheq 'model-name
+                                  (provider-name provider)
+                                  'message-count
+                                  (length raw-messages)
+                                  'messages
+                                  raw-messages
+                                  'settings
+                                  (model-request-settings req)))))
+  (values result '()))

--- a/tests/test-effect-types.rkt
+++ b/tests/test-effect-types.rkt
@@ -1,0 +1,43 @@
+#lang racket/base
+
+;; tests/test-effect-types.rkt — Effect descriptor type tests (F1)
+
+(require rackunit
+         rackunit/text-ui
+         "../agent/effect-types.rkt")
+
+(define effect-types-tests
+  (test-suite "effect-types"
+
+    (test-case "effect:none construction"
+      (define e (effect:none))
+      (check-true (effect:none? e)))
+
+    (test-case "effect:emit-event construction"
+      (define e (effect:emit-event 'turn-start (hasheq 'test #t)))
+      (check-equal? (effect:emit-event-type e) 'turn-start)
+      (check-true (hash? (effect:emit-event-payload e))))
+
+    (test-case "effect:update-fsm construction"
+      (define e (effect:update-fsm 'emit-start 'turn-start))
+      (check-equal? (effect:update-fsm-from-state e) 'emit-start)
+      (check-equal? (effect:update-fsm-event e) 'turn-start))
+
+    (test-case "effect:dispatch-hook construction"
+      (define e (effect:dispatch-hook 'agent-start (hasheq)))
+      (check-equal? (effect:dispatch-hook-hook-point e) 'agent-start))
+
+    (test-case "effect predicates"
+      (check-true (effect:none? (effect:none)))
+      (check-true (effect:emit-event? (effect:emit-event 'test #f)))
+      (check-true (effect:update-fsm? (effect:update-fsm 'a 'b)))
+      (check-true (effect:dispatch-hook? (effect:dispatch-hook 'test #f))))
+
+    (test-case "effect? contract accepts all variants"
+      (for ([e (list (effect:none)
+                     (effect:emit-event 'x #f)
+                     (effect:update-fsm 'a 'b)
+                     (effect:dispatch-hook 'c #f))])
+        (check-true (effect? e))))))
+
+(run-tests effect-types-tests)

--- a/tests/test-loop-phases.rkt
+++ b/tests/test-loop-phases.rkt
@@ -1,0 +1,49 @@
+#lang racket/base
+
+;; tests/test-loop-phases.rkt — Pure phase function tests (F1)
+
+(require rackunit
+         rackunit/text-ui
+         "../agent/effect-types.rkt"
+         "../agent/loop-phases.rkt"
+         "../agent/loop-fsm.rkt"
+         "../agent/event-bus.rkt"
+         "../agent/state.rkt"
+         "../util/message.rkt"
+         (only-in "../llm/model.rkt" model-request?))
+
+(define loop-phases-tests
+  (test-suite "loop-phases"
+
+    (test-case "phase-emit-start returns context and effects"
+      (define-values (ctx effs) (phase-emit-start "sess" "turn" #f '()))
+      (check-equal? ctx '())
+      (check = (length effs) 2)
+      (check-true (effect:emit-event? (car effs)))
+      (check-true (effect:update-fsm? (cadr effs))))
+
+    (test-case "phase-build-context returns raw messages and effects"
+      (define bus (make-event-bus))
+      (define st (make-loop-state "sess" "turn"))
+      (define-values (raw effs)
+        (phase-build-context bus
+                             "sess"
+                             "turn"
+                             st
+                             (list (message "id1" #f 'user 'user "hello" 0 (hash)))))
+      (check-true (list? raw))
+      (check = (length raw) 1)
+      (check = (length effs) 1)
+      (check-true (effect:update-fsm? (car effs))))
+
+    (test-case "phase-build-request returns model request"
+      (define-values (req effs) (phase-build-request '() #f #f))
+      (check-true (model-request? req))
+      (check-true (null? effs)))
+
+    (test-case "phase-pre-hook returns #f without dispatcher"
+      (define-values (result effs) (phase-pre-hook #f #f '() (hash) "sess" "turn"))
+      (check-false result)
+      (check-true (null? effs)))))
+
+(run-tests loop-phases-tests)


### PR DESCRIPTION
Addresses #4551.

feat: effect descriptor types + pure loop phase functions (F1) (#4551)

Created agent/effect-types.rkt with effect descriptor struct union
(effect:emit-event, effect:update-fsm, effect:dispatch-hook,
effect:stream-from-provider, effect:none) and execute-effects! executor.

Created agent/loop-phases.rkt with pure phase functions
(phase-emit-start, phase-build-context, phase-build-request,
phase-pre-hook) that return (values result (listof effect?)).

6 effect-type tests + 4 loop-phase tests pass.