### PR TITLE
chore: version bump 0.46.7 + CHANGELOG (#4553)

Version bump 0.46.6 → 0.46.7 with CHANGELOG entry for F1 effect
descriptor types, F1 pure loop phase functions, F2 step effect executor.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## v0.46.7 — 2026-05-18
+
+### Changed
+- **F1**: Created `agent/effect-types.rkt` with effect descriptor struct union (emit-event, update-fsm, dispatch-hook, stream-from-provider, none) and `execute-effects!` executor
+- **F1**: Created `agent/loop-phases.rkt` with pure phase functions (phase-emit-start, phase-build-context, phase-build-request, phase-pre-hook) returning `(values result (listof effect?))`
+- **F2**: Created `runtime/iteration/effect-executor.rkt` with step-effect descriptors (append-entries, emit-event, execute-tools, maybe-compact) and `run-step-effects!` executor
+
+### Added
+- `tests/test-effect-types.rkt` — 6 tests for effect descriptors
+- `tests/test-loop-phases.rkt` — 4 tests for pure phase functions
+- `tests/test-effect-executor.rkt` — 5 tests for step effect executor
+
 ## v0.46.6 — 2026-05-18
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.46.6-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.46.7-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 
@@ -203,7 +203,7 @@ bin/q --model gpt-5.4 "write a test"
 ### Verify
 
 ```bash
-bin/q --version            # q version 0.46.6
+bin/q --version            # q version 0.46.7
 raco test tests/           # run the full test suite
 ```
 
@@ -415,7 +415,7 @@ When q executes shell commands on behalf of an LLM, arguments are quoted via `sh
 
 
 
-**v0.46.6** — Changed
+**v0.46.7** — Changed
 
 **v0.45.22** — Fixed
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -2,7 +2,7 @@
 
 ## Version
 
-v0.46.6
+v0.46.7
 
 ## Layer Diagram
 

--- a/docs/event-taxonomy.md
+++ b/docs/event-taxonomy.md
@@ -1,6 +1,6 @@
 # Q Event Taxonomy Reference
 
-Complete reference for all event types in Q 0.46.6.
+Complete reference for all event types in Q 0.46.7.
 ## Base Types
 
 ### `event` (protocol-level)

--- a/docs/extension-guide.md
+++ b/docs/extension-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.46.6 --># Extension Development Guide
+<!-- verified-against: 0.46.7 --># Extension Development Guide
 
 This guide walks you through creating, testing, and activating a custom
 extension for q.

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.46.6 --># Getting Started
+<!-- verified-against: 0.46.7 --># Getting Started
 
 Welcome to q, a Racket-based coding agent.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.46.6 --># Installation Guide
+<!-- verified-against: 0.46.7 --># Installation Guide
 
 <!-- This file is the canonical source. The docs/getting-started/installation.md copy is maintained for the doc site build. -->
 

--- a/docs/security-trust-model.md
+++ b/docs/security-trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.46.6 --># Security & Trust Model
+<!-- verified-against: 0.46.7 --># Security & Trust Model
 
 This document provides an honest, per-area assessment of what q enforces
 today and what is planned. It is the authoritative reference for security

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -130,6 +130,6 @@ is the primary self-hosting extension:
 (load-extension! ext-reg "path/to/extension.rkt" #:event-bus bus)
 ```
 
-## Version 0.46.6
+## Version 0.46.7
 
-This documentation reflects q 0.46.6.
+This documentation reflects q 0.46.7.

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.46.6 --># q Source Style Guide
+<!-- verified-against: 0.46.7 --># q Source Style Guide
 
 This document defines formatting and naming conventions for the q Racket codebase.
 All changes to `q/` source files (excluding `tests/`) should follow these rules.

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.46.6 --># Trust Model
+<!-- verified-against: 0.46.7 --># Trust Model
 
 ## Trust Levels
 

--- a/docs/workflow-testing.md
+++ b/docs/workflow-testing.md
@@ -121,6 +121,6 @@ Use relative paths from the test file:
 4. Use `(check-true ...)` for boolean assertions
 5. Keep tests independent — no shared mutable state between test-cases
 
-## Version 0.46.6
+## Version 0.46.7
 
-This documentation reflects q 0.46.6.
+This documentation reflects q 0.46.7.

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.46.6")
+(define version "0.46.7")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base"))

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -10,4 +10,4 @@
 (provide q-version)
 
 (: q-version String)
-(define q-version "0.46.6")
+(define q-version "0.46.7")

--- a/wiki-src/Architecture-Overview.md
+++ b/wiki-src/Architecture-Overview.md
@@ -35,7 +35,7 @@ User input → Interface (CLI/TUI/RPC)
     → Events emitted to bus
 ```
 
-## Metrics (0.46.6)
+## Metrics (0.46.7)
 > _See `racket scripts/metrics.rkt` for current numbers._
 
 - 414 source modules, 534 test files


### PR DESCRIPTION
Addresses #4553.

chore: version bump 0.46.7 + CHANGELOG (#4553)

Version bump 0.46.6 → 0.46.7 with CHANGELOG entry for F1 effect
descriptor types, F1 pure loop phase functions, F2 step effect executor.