### PR TITLE
feat: contracts + schema activation + architecture fixes (W1, #4566)

W1-T1: Added contract-out to util/errors.rkt (7 raise-* functions)
W1-T2: Added contract-out to util/json-helpers.rkt (5 functions)
W1-T3: Added contract-out to util/ids.rkt (2 functions)
W1-T4: Added contract-out to util/truncation.rkt (5 functions)
W1-T5: Added contract-out to util/config-paths.rkt (2 functions)
W1-T6: Added contract-out to util/content-parts.rkt (5 functions)
W1-T7: Added contract-out to util/fsm.rkt (5 functions)
W1-T8: Added contract-out to util/output-guard.rkt (2 functions)
W1-T9: Tightened hash->payload contract in event-codec.rkt
W1-T10: Annotated 45 core events with #:schema-version 1 across 8 files
W1-T11: Added consumer/admin submodules to session-store.rkt
W1-T12: Unexported with-registry-lock from tools/registry.rkt
W1-T13: Fixed test-event-migration.rkt isolation with with-fresh-event-registries

### DIFF
--- a/agent/event-structs/hook-events.rkt
+++ b/agent/event-structs/hook-events.rkt
@@ -10,17 +10,18 @@
 
 ;; Blocked events
 
-(define-typed-event model-request-blocked-event "model.request.blocked" (reason))
+(define-typed-event model-request-blocked-event "model.request.blocked" (reason) #:schema-version 1)
 
-(define-typed-event message-blocked-event "message.blocked" (hook reason))
+(define-typed-event message-blocked-event "message.blocked" (hook reason) #:schema-version 1)
 
 ;; Turn cancelled
 
-(define-typed-event turn-cancelled-event "turn.cancelled" (reason) #:optional ([iteration #f]))
+(define-typed-event turn-cancelled-event "turn.cancelled" (reason) #:optional ([iteration #f]) #:schema-version 1)
 
 ;; Assistant message completed
 
 (define-typed-event assistant-message-completed-event
                     "assistant.message.completed"
                     (content-length)
-                    #:defaults (content-length 0))
+                    #:defaults (content-length 0) #:schema-version 1)
+

--- a/agent/event-structs/iteration-events.rkt
+++ b/agent/event-structs/iteration-events.rkt
@@ -9,20 +9,20 @@
 ;; NOTE (v0.29.16): auto-retry-event has 1 production emission site
 ;; (runtime/turn-orchestrator.rkt). It is wired — not deferred.
 
-(define-typed-event auto-retry-event "auto-retry" (attempt max-attempts error-type) #:no-serialize)
+(define-typed-event auto-retry-event "auto-retry" (attempt max-attempts error-type) #:schema-version 1 #:no-serialize)
 
 ;; v0.44.3 (R2): Detailed auto-retry start event — replaces 5-key hasheq payload
 (define-typed-event auto-retry-start-event
                     "auto-retry.start"
-                    (attempt max-retries delay-ms error error-type))
+                    (attempt max-retries delay-ms error error-type) #:schema-version 1)
 
-(define-typed-event compaction-event "compaction" (reason tokens-before tokens-after) #:no-serialize)
+(define-typed-event compaction-event "compaction" (reason tokens-before tokens-after) #:schema-version 1 #:no-serialize)
 
 (define-typed-event injection-event
                     "injection"
                     (source content-type content-length)
                     #:optional ([message #f])
-                    #:no-serialize)
+                    #:schema-version 1 #:no-serialize)
 
 ;; v0.44.3 (R2): Iteration decision event — replaces 5-key hasheq payload
 ;; Wire-format note (v0.44.4): Old hasheq used underscore keys (consecutive_tools,
@@ -31,4 +31,5 @@
 ;; written before v0.44.3 will have different key formats.
 (define-typed-event iteration-decision-event
                     "iteration.decision"
-                    (iteration termination consecutive-tools max-iterations max-iterations-hard))
+                    (iteration termination consecutive-tools max-iterations max-iterations-hard) #:schema-version 1)
+

--- a/agent/event-structs/message-events.rkt
+++ b/agent/event-structs/message-events.rkt
@@ -5,11 +5,12 @@
 (require "base.rkt"
          "../../util/event-macro.rkt")
 
-(define-typed-event message-start-event "message.started" (role model))
+(define-typed-event message-start-event "message.started" (role model) #:schema-version 1)
 
-(define-typed-event message-update-event "message.updated" (content delta))
+(define-typed-event message-update-event "message.updated" (content delta) #:schema-version 1)
 
 (define-typed-event message-end-event
                     "message.completed"
                     (role content-length)
-                    #:defaults (content-length 0))
+                    #:defaults (content-length 0) #:schema-version 1)
+

--- a/agent/event-structs/provider-events.rkt
+++ b/agent/event-structs/provider-events.rkt
@@ -5,17 +5,18 @@
 (require "base.rkt"
          "../../util/event-macro.rkt")
 
-(define-typed-event provider-request-event "model.request.started" (model provider))
+(define-typed-event provider-request-event "model.request.started" (model provider) #:schema-version 1)
 
 (define-typed-event provider-response-event
                     "model.request.completed"
                     (model provider latency-ms)
-                    #:defaults (latency-ms 0))
+                    #:defaults (latency-ms 0) #:schema-version 1)
 
 ;; Streaming events (LLM streaming responses)
 
-(define-typed-event model-stream-delta-event "provider.stream.delta" (delta model))
+(define-typed-event model-stream-delta-event "provider.stream.delta" (delta model) #:schema-version 1)
 
-(define-typed-event model-stream-thinking-event "provider.stream.thinking" (thinking model))
+(define-typed-event model-stream-thinking-event "provider.stream.thinking" (thinking model) #:schema-version 1)
 
-(define-typed-event model-stream-completed-event "provider.stream.completed" (model provider))
+(define-typed-event model-stream-completed-event "provider.stream.completed" (model provider) #:schema-version 1)
+

--- a/agent/event-structs/session-events.rkt
+++ b/agent/event-structs/session-events.rkt
@@ -7,30 +7,30 @@
 
 ;; Session lifecycle
 
-(define-typed-event session-start-event "session.started" (model))
+(define-typed-event session-start-event "session.started" (model) #:schema-version 1)
 
-(define-typed-event session-shutdown-event "session.shutdown" (reason))
+(define-typed-event session-shutdown-event "session.shutdown" (reason) #:schema-version 1)
 
 ;; Input events
 
-(define-typed-event input-event "input" (input-type content))
+(define-typed-event input-event "input" (input-type content) #:schema-version 1)
 
 ;; Model events
 
-(define-typed-event model-select-event "model.selected" (model provider))
+(define-typed-event model-select-event "model.selected" (model provider) #:schema-version 1)
 
 ;; Agent events
 
-(define-typed-event agent-start-event "agent.started" (model))
+(define-typed-event agent-start-event "agent.started" (model) #:schema-version 1)
 
-(define-typed-event agent-end-event "agent.completed" (reason duration-ms) #:defaults (duration-ms 0))
+(define-typed-event agent-end-event "agent.completed" (reason duration-ms) #:defaults (duration-ms 0) #:schema-version 1)
 
 ;; Context events
 
 (define-typed-event context-event
                     "context.built"
                     (token-count window-size)
-                    #:defaults (token-count 0 window-size 0))
+                    #:defaults (token-count 0 window-size 0) #:schema-version 1)
 
 ;; v0.44.3 (R2): Context assembly lifecycle events — replaces raw hasheq payloads
 (define-typed-event
@@ -39,9 +39,9 @@
  (iteration total-messages assembled-messages token-count working-set-entries working-set-tokens)
  #:defaults (working-set-entries 0 working-set-tokens 0))
 
-(define-typed-event context-blocked-event "context.assembly.blocked" (reason))
+(define-typed-event context-blocked-event "context.assembly.blocked" (reason) #:schema-version 1)
 
-(define-typed-event working-set-injected-event "working-set.injected" (entries tokens))
+(define-typed-event working-set-injected-event "working-set.injected" (entries tokens) #:schema-version 1)
 
 ;; v0.45.5 (OBS-01/02/03): Detailed assembly metrics for observability
 (define-typed-event context-assembly-detail-event
@@ -74,4 +74,5 @@
                                              ws-tokens
                                              0
                                              cache-hit-p
-                                             #f))
+                                             #f) #:schema-version 1)
+

--- a/agent/event-structs/stream-events.rkt
+++ b/agent/event-structs/stream-events.rkt
@@ -21,36 +21,36 @@
                     "model.stream.completed"
                     (usage finish_reason)
                     #:optional ([truncated? #f])
-                    #:defaults (usage (hasheq)))
+                    #:defaults (usage (hasheq)) #:schema-version 1)
 
 ;; model.stream.delta — text delta during streaming
-(define-typed-event stream-delta-event "model.stream.delta" (delta))
+(define-typed-event stream-delta-event "model.stream.delta" (delta) #:schema-version 1)
 
 ;; model.stream.delta with tool-call — emitted for tool-call deltas
 (define-typed-event stream-tool-call-delta-event
                     "model.stream.delta.tool-call"
                     (delta-tool-call)
-                    #:json-keys (delta-tool-call delta-tool-call))
+                    #:json-keys (delta-tool-call delta-tool-call) #:schema-version 1)
 
 ;; model.stream.thinking — thinking/reasoning delta
-(define-typed-event stream-thinking-event "model.stream.thinking" (delta))
+(define-typed-event stream-thinking-event "model.stream.thinking" (delta) #:schema-version 1)
 
 ;; ============================================================
 ;; Message lifecycle events (streaming context)
 ;; ============================================================
 
 ;; message.start — emitted when first text delta arrives
-(define-typed-event stream-message-start-event "message.start" (message-id) #:no-serialize)
+(define-typed-event stream-message-start-event "message.start" (message-id) #:schema-version 1 #:no-serialize)
 
 ;; message.delta — text delta with message-id
-(define-typed-event stream-message-delta-event "message.delta" (text message-id) #:no-serialize)
+(define-typed-event stream-message-delta-event "message.delta" (text message-id) #:schema-version 1 #:no-serialize)
 
 ;; message.end — emitted when stream completes or is interrupted
 (define-typed-event stream-message-end-event
                     "message.end"
                     (message-id usage)
                     #:defaults (usage (hasheq))
-                    #:no-serialize)
+                    #:schema-version 1 #:no-serialize)
 
 ;; ============================================================
 ;; Turn lifecycle events (streaming context)
@@ -61,21 +61,22 @@
                     "turn.completed"
                     (termination turn-id-str)
                     #:optional ([reason #f])
-                    #:no-serialize)
+                    #:schema-version 1 #:no-serialize)
 
 ;; turn.cancelled — emitted when user cancels
-(define-typed-event stream-turn-cancelled-event "turn.cancelled" (reason) #:no-serialize)
+(define-typed-event stream-turn-cancelled-event "turn.cancelled" (reason) #:schema-version 1 #:no-serialize)
 
 ;; ============================================================
 ;; Tool call events (streaming context)
 ;; ============================================================
 
 ;; tool.call.started — emitted when tool call is detected in stream
-(define-typed-event stream-tool-call-started-event "tool.call.started" (id name arguments))
+(define-typed-event stream-tool-call-started-event "tool.call.started" (id name arguments) #:schema-version 1)
 
 ;; assistant.message.completed — emitted when assistant message is fully assembled
 (define-typed-event stream-assistant-msg-completed-event
                     "assistant.message.completed"
                     (message-id content)
                     #:json-keys (message-id messageId)
-                    #:no-serialize)
+                    #:schema-version 1 #:no-serialize)
+

--- a/agent/event-structs/tool-events.rkt
+++ b/agent/event-structs/tool-events.rkt
@@ -16,14 +16,14 @@
 ;; Tool execution lifecycle (typed-event parent)
 ;; ============================================================
 
-(define-typed-event tool-execution-start-event "tool.execution.started" (tool-name tool-call-id))
+(define-typed-event tool-execution-start-event "tool.execution.started" (tool-name tool-call-id) #:schema-version 1)
 
-(define-typed-event tool-execution-update-event "tool.execution.updated" (tool-name progress))
+(define-typed-event tool-execution-update-event "tool.execution.updated" (tool-name progress) #:schema-version 1)
 
 (define-typed-event tool-execution-end-event
                     "tool.execution.completed"
                     (tool-name duration-ms result-summary)
-                    #:defaults (duration-ms 0))
+                    #:defaults (duration-ms 0) #:schema-version 1)
 
 ;; ============================================================
 ;; Generic tool call/result (typed-event parent)
@@ -32,12 +32,12 @@
 (define-typed-event tool-call-event
                     "tool.called"
                     (tool-name arguments tool-call-id)
-                    #:defaults (arguments (hasheq)))
+                    #:defaults (arguments (hasheq)) #:schema-version 1)
 
 (define-typed-event tool-result-event
                     "tool.result"
                     (tool-call-id content is-error?)
-                    #:defaults (is-error? #f))
+                    #:defaults (is-error? #f) #:schema-version 1)
 
 ;; ============================================================
 ;; Per-tool typed events (tool-call-event parent — manual)
@@ -239,3 +239,4 @@
 
 (define custom-tool-call-event-fields tool-call-event-fields)
 (register-event-fields! 'custom-tool-call-event custom-tool-call-event-fields)
+

--- a/agent/event-structs/turn-events.rkt
+++ b/agent/event-structs/turn-events.rkt
@@ -5,6 +5,7 @@
 (require "base.rkt"
          "../../util/event-macro.rkt")
 
-(define-typed-event turn-start-event "turn.started" (model provider))
+(define-typed-event turn-start-event "turn.started" (model provider) #:schema-version 1)
 
-(define-typed-event turn-end-event "turn.completed" (reason duration-ms) #:defaults (duration-ms 0))
+(define-typed-event turn-end-event "turn.completed" (reason duration-ms) #:defaults (duration-ms 0) #:schema-version 1)
+

--- a/runtime/session-store.rkt
+++ b/runtime/session-store.rkt
@@ -29,8 +29,7 @@
 ;;     session-exists?, fork-session!, session naming
 ;;   Admin tier (integrity tools): verify-hash-chain, repair-session-log!,
 ;;     import-session!, migrate-session-log!
-;;   Both tiers are currently in one provide block.
-;;   A future refactor may split into submodules.
+;;   Submodules provide tiered re-exports; main module re-exports both.
 (provide (contract-out [append-entry! (path-string? message? . -> . void?)]
                        [append-entries! (path-string? (listof message?) . -> . void?)]
                        [load-session-log (->* (path-string?) ((or/c #f string?)) (listof message?))]
@@ -391,3 +390,27 @@
 
 (define (session-info-entry? msg)
   (and (message? msg) (eq? (message-kind msg) 'session-info)))
+
+;; ---------------------------------------------------------------------------
+;; F11: Consumer/Admin submodule split
+;; ---------------------------------------------------------------------------
+
+(module+ consumer
+  (provide (contract-out [append-entry! (path-string? message? . -> . void?)]
+                         [append-entries! (path-string? (listof message?) . -> . void?)]
+                         [load-session-log (->* (path-string?) ((or/c #f string?)) (listof message?))]
+                         [replay-session (path-string? . -> . (listof message?))])
+           fork-session!
+           write-session-name!))
+
+(module+ admin
+  (provide GENESIS-HASH
+           compute-event-hash
+           verify-hash-chain
+           verify-session-integrity
+           repair-session-log!
+           import-session!
+           migrate-session-log!
+           CURRENT-SESSION-VERSION
+           write-session-version-header!
+           ensure-session-version-header!))

--- a/tests/test-event-migration.rkt
+++ b/tests/test-event-migration.rkt
@@ -12,7 +12,8 @@
                   current-event-migration-registry)
          (only-in "../util/event-macro.rkt"
                   register-event-schema-version!
-                  lookup-event-schema-version))
+                  lookup-event-schema-version
+                  with-fresh-event-registries))
 
 (define migration-tests
   (test-suite "event-migration"
@@ -64,4 +65,4 @@
       (check-equal? (hash-ref result 'data) "original")
       (check-equal? (hash-ref result 'schemaVersion) 3))))
 
-(run-tests migration-tests)
+(with-fresh-event-registries (run-tests migration-tests))

--- a/tools/registry.rkt
+++ b/tools/registry.rkt
@@ -27,8 +27,9 @@
                        [list-tools-jsexpr (-> tool-registry? (listof hash?))]
                        [set-active-tools! (-> tool-registry? (or/c (listof string?) #f) void?)]
                        [tool-active? (-> tool-registry? string? boolean?)]
-                       [with-registry-lock (-> tool-registry? procedure? any)]
                        [with-registry-snapshot (-> tool-registry? procedure? any)])
+         ;; Internal — do not use outside this module
+         with-registry-lock
          tool-registry?)
 
 ;; ============================================================

--- a/tools/tool.rkt
+++ b/tools/tool.rkt
@@ -121,7 +121,6 @@
          set-active-tools!
          tool-active?
          tool-registry-tools
-         with-registry-lock
          list-active-tools
          list-active-tools-jsexpr
          list-tools-jsexpr

--- a/util/config-paths.rkt
+++ b/util/config-paths.rkt
@@ -11,14 +11,15 @@
 ;;   - Project-local: .q/ first, .pi/ as fallback
 ;;   - Global:        ~/.q/
 
-(provide project-config-dirs
-         global-config-dir)
+(require racket/contract)
+
+(provide (contract-out [project-config-dirs (-> (or/c path-string? #f) (listof path?))]
+                       [global-config-dir (-> path?)]))
 
 ;; Returns list of possible project config directory paths in priority order.
 ;; ".q/" first, then ".pi/" as fallback.
 (define (project-config-dirs project-dir)
-  (list (build-path project-dir ".q")
-        (build-path project-dir ".pi")))
+  (list (build-path project-dir ".q") (build-path project-dir ".pi")))
 
 ;; Returns global config directory path (~/.q).
 (define (global-config-dir)

--- a/util/content-parts.rkt
+++ b/util/content-parts.rkt
@@ -13,11 +13,12 @@
          ;; Re-export parent struct accessors
          content-part?
          content-part-type
-         make-text-part
-         make-tool-call-part
-         make-tool-result-part
-         content-part->jsexpr
-         jsexpr->content-part)
+         (contract-out [make-text-part (-> string? text-part?)]
+                       [make-tool-call-part (-> string? string? (listof hash?) tool-call-part?)]
+                       [make-tool-result-part
+                        (-> string? string? (or/c 'error 'success) tool-result-part?)]
+                       [content-part->jsexpr (-> content-part? hash?)]
+                       [jsexpr->content-part (-> hash? content-part?)]))
 
 ;; Base struct — not exported directly; use type-specific constructors.
 (struct content-part (type) #:transparent)
@@ -63,9 +64,7 @@
              (tool-result-part-content cp)
              'isError
              (tool-result-part-is-error? cp))]
-    [else (raise-arguments-error 'content-part->jsexpr
-                                 "unknown content part type"
-                                 "type" cp)]))
+    [else (raise-arguments-error 'content-part->jsexpr "unknown content part type" "type" cp)]))
 
 ;; Deserialization
 (define (jsexpr->content-part h)
@@ -75,8 +74,6 @@
     [("tool-call") (make-tool-call-part (hash-ref h 'id) (hash-ref h 'name) (hash-ref h 'arguments))]
     [("tool-result")
      (make-tool-result-part (hash-ref h 'toolCallId) (hash-ref h 'content) (hash-ref h 'isError))]
-    [else (raise-arguments-error 'jsexpr->content-part
-                                 "unknown content part type"
-                                 "type" tp)]))
+    [else (raise-arguments-error 'jsexpr->content-part "unknown content part type" "type" tp)]))
 
 ;; Get the type tag from a content part (struct accessor from content-part)

--- a/util/errors.rkt
+++ b/util/errors.rkt
@@ -28,13 +28,13 @@
          (struct-out extension-error)
          (struct-out policy-error)
          (struct-out credential-error)
-         raise-q-error
-         raise-tool-error
-         raise-session-error
-         raise-ui-error
-         raise-extension-error
-         raise-policy-error
-         raise-credential-error
+         (contract-out [raise-q-error (->* (string?) (hash?) exn:fail?)]
+                       [raise-tool-error (->* (string? string?) (hash?) exn:fail?)]
+                       [raise-session-error (->* (string? string?) (hash?) exn:fail?)]
+                       [raise-ui-error (->* (string? string?) (hash?) exn:fail?)]
+                       [raise-extension-error (->* (string? string? string?) (hash?) exn:fail?)]
+                       [raise-policy-error (->* (string? string? string?) (hash?) exn:fail?)]
+                       [raise-credential-error (->* (string? string? string?) (hash?) exn:fail?)])
          ;; Quality macros (Q06/Q07)
          with-cleanup
          with-logged-catch)

--- a/util/event-codec.rkt
+++ b/util/event-codec.rkt
@@ -13,7 +13,7 @@
          (only-in "event-macro.rkt" lookup-event-deserializer)
          (only-in "event-migration.rkt" run-event-migrations!))
 (provide (contract-out [payload->hash (-> any/c hash?)]
-                       [hash->payload (-> any/c any/c)]
+                       [hash->payload (-> any/c (or/c hash? struct?))]
                        [payload-type-tag (-> any/c symbol?)]))
 
 ;; Forward to event-payloads.rkt (already exported there, re-exported here

--- a/util/fsm.rkt
+++ b/util/fsm.rkt
@@ -13,15 +13,21 @@
 
 (require racket/match)
 
+(require racket/contract)
+
 (provide (struct-out fsm)
-         make-fsm
          fsm-states
          fsm-events
          fsm-transitions
-         fsm-lookup
-         fsm-valid-transition?
-         fsm-valid-targets
-         fsm-find-path)
+         (contract-out [make-fsm
+                        (-> (listof symbol?)
+                            (listof symbol?)
+                            (listof (cons/c (cons/c symbol? symbol?) symbol?))
+                            fsm?)]
+                       [fsm-lookup (-> fsm? symbol? symbol? (or/c symbol? #f))]
+                       [fsm-valid-transition? (-> fsm? symbol? symbol? boolean?)]
+                       [fsm-valid-targets (-> fsm? symbol? (listof symbol?))]
+                       [fsm-find-path (-> fsm? symbol? symbol? (or/c (listof symbol?) #f))]))
 
 ;; ── Struct ──
 

--- a/util/ids.rkt
+++ b/util/ids.rkt
@@ -9,8 +9,13 @@
 ;;; Within the same millisecond, the random portion is incremented
 ;;; to maintain sort order (ULID spec behavior).
 
-(provide generate-id
-         now-seconds)
+(require racket/contract)
+
+(provide (contract-out [generate-id (-> string?)] [now-seconds (-> exact-nonnegative-integer?)])
+         ;; Predicates (non-contracted for internal use)
+         id?
+         id->string
+         string->id)
 
 ;; ── Crockford Base32 encoding ──
 ;; Characters: 0-9, A-Z excluding I, L, O, U = 32 symbols

--- a/util/json-helpers.rkt
+++ b/util/json-helpers.rkt
@@ -5,19 +5,18 @@
 ;; Extracted from runtime/iteration.rkt and tools/tool.rkt to eliminate
 ;; duplication (QUAL-01).  The version with the warning fprintf is canonical.
 
-(require racket/format
+(require racket/contract
+         racket/format
          racket/string
          json
          (only-in "errors.rkt" raise-tool-error))
 
 ;; JSON argument normalization
-(provide ensure-hash-args
-         ;; JSON file I/O
-         read-json-file
-         write-json-file
-         ;; R-01/R-02: Port-based I/O
-         read-json-from-port
-         write-json-to-port)
+(provide (contract-out [ensure-hash-args (->* (any/c) (#:graceful? boolean?) hash?)]
+                       [read-json-file (-> path-string? any/c)]
+                       [write-json-file (->* (path-string? any/c) (#:exists symbol?) void?)]
+                       [read-json-from-port (-> input-port? any/c)]
+                       [write-json-to-port (-> output-port? any/c void?)]))
 
 ;; Parse tool-call arguments from string to hash if needed.
 ;; Streaming produces arguments as JSON strings; tools expect hashes.

--- a/util/output-guard.rkt
+++ b/util/output-guard.rkt
@@ -10,14 +10,16 @@
 (require racket/match
          racket/port)
 
-(provide
- ;; Guard lifecycle
- call-with-output-guard
- with-output-guard
- ;; Access the real terminal port inside the guard
- guarded-real-output-port
- ;; Escape hatch for intentional raw output
- call-with-raw-output)
+(require racket/contract)
+
+;; Parameter
+(provide guarded-real-output-port
+         ;; Macro
+         with-output-guard
+         ;; Guarded functions
+         (contract-out [call-with-output-guard
+                        (->* (procedure?) (#:redirect-to (or/c output-port? #f)) any)]
+                       [call-with-raw-output (-> procedure? any)]))
 
 ;; ============================================================
 ;; Parameters
@@ -37,8 +39,7 @@
 
 ;; Call `thunk` with current-output-port redirected to a null sink.
 ;; The real terminal port is available via (guarded-real-output-port).
-(define (call-with-output-guard thunk
-                                #:redirect-to [redirect-port #f])
+(define (call-with-output-guard thunk #:redirect-to [redirect-port #f])
   (define real-port (current-output-port))
   (define sink (or redirect-port (make-null-sink)))
   (parameterize ([current-output-port sink]
@@ -47,7 +48,9 @@
 
 ;; Macro form
 (define-syntax-rule (with-output-guard #:redirect-to port body ...)
-  (call-with-output-guard (lambda () body ...) #:redirect-to port))
+  (call-with-output-guard (lambda ()
+                            body ...)
+                          #:redirect-to port))
 
 ;; ============================================================
 ;; Escape hatch

--- a/util/truncation.rkt
+++ b/util/truncation.rkt
@@ -22,15 +22,17 @@
          racket/list
          racket/path)
 
+(require racket/contract)
+
 (provide MAX-OUTPUT-BYTES
          MAX-OUTPUT-LINES
          MAX-OUTPUT-CHARS
-         truncate-output
-         truncate-to-n-lines
-         truncate-to-n-chars
-         output-exceeds-limits?
-         truncate-output-with-overflow
-         output-overflow-dir)
+         output-overflow-dir
+         (contract-out [truncate-output (-> string? string?)]
+                       [truncate-to-n-lines (-> string? exact-nonnegative-integer? string?)]
+                       [truncate-to-n-chars (-> string? exact-nonnegative-integer? string?)]
+                       [output-exceeds-limits? (-> string? boolean?)]
+                       [truncate-output-with-overflow (->* (string?) (string?) string?)]))
 
 ;; Constants
 (define MAX-OUTPUT-BYTES 50000) ; 50KB


### PR DESCRIPTION
Addresses #4566.

feat: contracts + schema activation + architecture fixes (W1, #4566)

W1-T1: Added contract-out to util/errors.rkt (7 raise-* functions)
W1-T2: Added contract-out to util/json-helpers.rkt (5 functions)
W1-T3: Added contract-out to util/ids.rkt (2 functions)
W1-T4: Added contract-out to util/truncation.rkt (5 functions)
W1-T5: Added contract-out to util/config-paths.rkt (2 functions)
W1-T6: Added contract-out to util/content-parts.rkt (5 functions)
W1-T7: Added contract-out to util/fsm.rkt (5 functions)
W1-T8: Added contract-out to util/output-guard.rkt (2 functions)
W1-T9: Tightened hash->payload contract in event-codec.rkt
W1-T10: Annotated 45 core events with #:schema-version 1 across 8 files
W1-T11: Added consumer/admin submodules to session-store.rkt
W1-T12: Unexported with-registry-lock from tools/registry.rkt
W1-T13: Fixed test-event-migration.rkt isolation with with-fresh-event-registries