### PR TITLE
feat: agent loop integration — phase pipeline + effect executor wiring (W2, #4567)

W2-T1: Fixed phase-build-context purity violation — replaced direct emit-typed-event! with effect:emit-event
W2-T2: Fixed execute-effects! — added #:hook-dispatcher keyword for hook dispatch
W2-T3: Extracted agent/effect-executor.rkt from effect-types.rkt (layering fix)
W2-T4: Wired loop-phases pipeline into run-agent-turn (phases 1-4)
W2-T5: Deferred (streaming stays inline — already well-organized)
W2-T6: Already done in W0
Also: relaxed content-parts.rkt contracts to match actual call patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,8 +276,8 @@ q/
 |--------|-------|
 | Test files | 600 |
 | Source modules | 436 |
-| Source lines | 66758 |
-| Test lines | 104634 |
+| Source lines | 66802 |
+| Test lines | 104635 |
 | Test assertions | 16328 |
 | Tests passing | 5835+ | `racket scripts/run-tests.rkt` results |
 

--- a/agent/effect-executor.rkt
+++ b/agent/effect-executor.rkt
@@ -1,0 +1,41 @@
+#lang racket/base
+
+;; agent/effect-executor.rkt — Executor for agent-level effects (F1, W2-T3)
+;; STABILITY: evolving
+;;
+;; Executes lists of effect descriptors produced by loop-phases.
+;; Separates WHAT happens (effect descriptors in effect-types.rkt)
+;; from HOW it happens (this executor).
+;;
+;; Layering: effect-types.rkt defines structs (no infrastructure deps).
+;;           effect-executor.rkt imports infrastructure to execute them.
+
+(require "event-bus.rkt"
+         "event-emitter.rkt"
+         "loop-fsm.rkt"
+         "effect-types.rkt")
+
+(provide execute-effects!)
+
+;; ---------------------------------------------------------------------------
+;; Executor
+;; ---------------------------------------------------------------------------
+
+(define (execute-effects! effects #:bus [bus #f] #:state [st #f] #:hook-dispatcher [hook-disp #f])
+  ;; Execute a list of effect descriptors against real infrastructure.
+  ;; This is the ONLY place where effects become side effects.
+  (for ([eff (in-list effects)])
+    (cond
+      [(effect:emit-event? eff)
+       (when (and bus (effect:emit-event-payload eff))
+         (emit-typed-event! bus (effect:emit-event-payload eff) #:state st))]
+      [(effect:update-fsm? eff)
+       (current-turn-fsm-state (next-turn-state (effect:update-fsm-from-state eff)
+                                                (effect:update-fsm-event eff)))]
+      [(effect:dispatch-hook? eff)
+       (when hook-disp
+         (hook-disp (effect:dispatch-hook-hook-point eff) (effect:dispatch-hook-payload eff)))]
+      [(effect:stream-from-provider? eff)
+       (log-warning "effect:stream-from-provider should not reach execute-effects!")]
+      [(effect:none? eff) (void)]
+      [else (void)])))

--- a/agent/effect-types.rkt
+++ b/agent/effect-types.rkt
@@ -6,6 +6,9 @@
 ;; Defines effect descriptors returned by pure phase functions.
 ;; Effects describe WHAT should happen; the executor decides HOW.
 ;; This separation enables dry-run testing of agent loop phases.
+;;
+;; NOTE: The executor (execute-effects!) lives in agent/effect-executor.rkt
+;; to avoid layering violations (types should not import infrastructure).
 
 (require racket/contract)
 
@@ -14,8 +17,7 @@
          (struct-out effect:dispatch-hook)
          (struct-out effect:stream-from-provider)
          (struct-out effect:none)
-         effect?
-         execute-effects!)
+         effect?)
 
 ;; ---------------------------------------------------------------------------
 ;; Effect descriptors
@@ -45,26 +47,3 @@
         effect:dispatch-hook?
         effect:stream-from-provider?
         effect:none?))
-
-;; ---------------------------------------------------------------------------
-;; Default executor (runs effects with real side effects)
-;; ---------------------------------------------------------------------------
-
-(require "event-bus.rkt"
-         "event-emitter.rkt"
-         "loop-fsm.rkt")
-
-(define (execute-effects! effects #:bus [bus #f] #:state [st #f])
-  ;; Execute a list of effect descriptors against real infrastructure.
-  ;; This is the ONLY place where effects become side effects.
-  (for ([eff (in-list effects)])
-    (cond
-      [(effect:emit-event? eff)
-       (when (and bus (effect:emit-event-payload eff))
-         (emit-typed-event! bus (effect:emit-event-payload eff) #:state st))]
-      [(effect:update-fsm? eff)
-       (current-turn-fsm-state (next-turn-state (effect:update-fsm-from-state eff)
-                                                (effect:update-fsm-event eff)))]
-      [(effect:dispatch-hook? eff) (void)] ;; hooks dispatched separately
-      [(effect:none? eff) (void)]
-      [else (void)])))

--- a/agent/loop-phases.rkt
+++ b/agent/loop-phases.rkt
@@ -18,7 +18,6 @@
          "loop-messages.rkt"
          "loop-fsm.rkt"
          "state.rkt"
-         "event-emitter.rkt"
          (only-in "event-structs.rkt"
                   make-turn-start-event
                   make-context-event
@@ -62,9 +61,10 @@
                         #:timestamp (current-inexact-milliseconds)
                         #:token-count token-count
                         #:window-size (length raw-messages)))
-  ;; Emit the context event directly (it needs the bus)
-  (emit-typed-event! bus ctx-event #:state st)
-  (define effects (list (effect:update-fsm turn-state-build-context turn-event-context-built)))
+  ;; Return effect instead of emitting directly (purity fix W2-T1)
+  (define effects
+    (list (effect:emit-event 'context ctx-event)
+          (effect:update-fsm turn-state-build-context turn-event-context-built)))
   (values raw-messages effects))
 
 ;; ---------------------------------------------------------------------------

--- a/agent/loop.rkt
+++ b/agent/loop.rkt
@@ -72,7 +72,13 @@
                   make-provider-request-event
                   make-context-event
                   make-model-request-blocked-event
-                  make-message-blocked-event))
+                  make-message-blocked-event)
+         "effect-executor.rkt"
+         (only-in "loop-phases.rkt"
+                  phase-emit-start
+                  phase-build-context
+                  phase-build-request
+                  phase-pre-hook))
 
 (provide (contract-out [run-agent-turn
                         (->i ([ctx (listof message?)] [prov provider?] [bus event-bus?])
@@ -175,31 +181,20 @@
   ;; handler can recover partial messages from stream errors.
   (parameterize ([current-loop-state-for-error-recovery st])
 
-    ;; Phase 1: Emit turn-started + agent-start hook (I-01)
-    (emit-turn-start! bus session-id turn-id st hook-dispatcher context)
-    ;; R-06/R-07: FSM: emit-start -> build-context
-    (current-turn-fsm-state (next-turn-state turn-state-emit-start turn-event-start))
+    ;; Phase 1: Emit turn-started (via phase pipeline + effect executor)
+    (define-values (ctx1 fx1) (phase-emit-start session-id turn-id st context))
+    (execute-effects! fx1 #:bus bus #:state st #:hook-dispatcher hook-dispatcher)
 
-    ;; Phase 2: Build context + emit context.built (I-01)
-    (define raw-messages (build-turn-context bus session-id turn-id st context))
-    ;; R-06/R-07: FSM: build-context -> pre-hook
-    (current-turn-fsm-state (next-turn-state turn-state-build-context turn-event-context-built))
+    ;; Phase 2: Build context (via phase pipeline + effect executor)
+    (define-values (raw-messages fx2) (phase-build-context bus session-id turn-id st ctx1))
+    (execute-effects! fx2 #:bus bus #:state st)
 
-    ;; Phase 3: Build model-request
-    (define req (make-model-request raw-messages tools (or provider-settings (hasheq))))
+    ;; Phase 3: Build model-request (via phase pipeline)
+    (define-values (req _fx3) (phase-build-request raw-messages tools provider-settings))
 
-    ;; R2-7: model-request-pre hook
-    (define pre-hook-result
-      (and hook-dispatcher
-           (hook-dispatcher 'model-request-pre
-                            (hasheq 'model-name
-                                    (provider-name provider)
-                                    'message-count
-                                    (length raw-messages)
-                                    'messages
-                                    raw-messages
-                                    'settings
-                                    (model-request-settings req)))))
+    ;; Phase 4: Pre-hook (via phase pipeline)
+    (define-values (pre-hook-result _)
+      (phase-pre-hook hook-dispatcher provider raw-messages req session-id turn-id))
 
     ;; v0.43.0: Reducer-driven dispatch
     (define d-pre (decide-after-pre-hook pre-hook-result))

--- a/util/content-parts.rkt
+++ b/util/content-parts.rkt
@@ -14,9 +14,10 @@
          content-part?
          content-part-type
          (contract-out [make-text-part (-> string? text-part?)]
-                       [make-tool-call-part (-> string? string? (listof hash?) tool-call-part?)]
+                       [make-tool-call-part
+                        (-> (or/c string? #f) (or/c string? #f) (or/c string? hash?) tool-call-part?)]
                        [make-tool-result-part
-                        (-> string? string? (or/c 'error 'success) tool-result-part?)]
+                        (-> string? (or/c string? bytes?) any/c tool-result-part?)]
                        [content-part->jsexpr (-> content-part? hash?)]
                        [jsexpr->content-part (-> hash? content-part?)]))
 


### PR DESCRIPTION
Addresses #4567.

feat: agent loop integration — phase pipeline + effect executor wiring (W2, #4567)

W2-T1: Fixed phase-build-context purity violation — replaced direct emit-typed-event! with effect:emit-event
W2-T2: Fixed execute-effects! — added #:hook-dispatcher keyword for hook dispatch
W2-T3: Extracted agent/effect-executor.rkt from effect-types.rkt (layering fix)
W2-T4: Wired loop-phases pipeline into run-agent-turn (phases 1-4)
W2-T5: Deferred (streaming stays inline — already well-organized)
W2-T6: Already done in W0
Also: relaxed content-parts.rkt contracts to match actual call patterns