### PR TITLE
fix: hygiene fixes — schema annotation, unexport, dead imports, parse composition, effect predicate, void stubs (W0, #4573)

W0-T1: Added #:schema-version 1 to context-assembled-event (I-2, 46/46 events now covered)
W0-T2: Removed with-registry-lock from bare provide in registry.rkt (I-3)
W0-T3: Removed directive-yield unused import from step-interpreter.rkt (M-2)
W0-T4: Rewrote parse-command-name to compose from tokenize/lookup/validate pipeline (I-4, -14 LOC)
W0-T5: Replaced effect? or/c with proper predicate function (M-1)
W0-T6: Removed void step-effect:execute-tools/maybe-compact stubs (M-5, -15 LOC)
Also fixed test-loop-phases.rkt to match W2 purity fix (2 effects, not 1)
Updated test-effect-executor.rkt to remove void stub test cases

### DIFF
--- a/agent/effect-types.rkt
+++ b/agent/effect-types.rkt
@@ -41,9 +41,10 @@
 (struct effect:none () #:transparent)
 
 ;; Predicate: is this an effect descriptor?
-(define effect?
-  (or/c effect:emit-event?
-        effect:update-fsm?
-        effect:dispatch-hook?
-        effect:stream-from-provider?
-        effect:none?))
+;; v0.46.10 (M-1): Proper predicate instead of or/c alias.
+(define (effect? v)
+  (or (effect:emit-event? v)
+      (effect:update-fsm? v)
+      (effect:dispatch-hook? v)
+      (effect:stream-from-provider? v)
+      (effect:none? v)))

--- a/agent/event-structs/session-events.rkt
+++ b/agent/event-structs/session-events.rkt
@@ -37,7 +37,8 @@
  context-assembled-event
  "context.assembled"
  (iteration total-messages assembled-messages token-count working-set-entries working-set-tokens)
- #:defaults (working-set-entries 0 working-set-tokens 0))
+ #:defaults (working-set-entries 0 working-set-tokens 0)
+ #:schema-version 1)
 
 (define-typed-event context-blocked-event "context.assembly.blocked" (reason) #:schema-version 1)
 

--- a/runtime/iteration/effect-executor.rkt
+++ b/runtime/iteration/effect-executor.rkt
@@ -18,8 +18,6 @@
 
 (provide (struct-out step-effect:append-entries)
          (struct-out step-effect:emit-event)
-         (struct-out step-effect:execute-tools)
-         (struct-out step-effect:maybe-compact)
          step-effect?
          run-step-effects!)
 
@@ -33,18 +31,9 @@
 ;; Emit a session event
 (struct step-effect:emit-event (name payload) #:transparent)
 
-;; Execute pending tool calls
-(struct step-effect:execute-tools (messages infra config ws) #:transparent)
-
-;; Maybe compact context mid-turn
-(struct step-effect:maybe-compact (context session-id config session) #:transparent)
-
 ;; Predicate
-(define step-effect?
-  (or/c step-effect:append-entries?
-        step-effect:emit-event?
-        step-effect:execute-tools?
-        step-effect:maybe-compact?))
+(define (step-effect? v)
+  (or (step-effect:append-entries? v) (step-effect:emit-event? v)))
 
 ;; ---------------------------------------------------------------------------
 ;; Executor
@@ -60,6 +49,4 @@
        (emit-session-event! (loop-infra-bus infra)
                             (loop-infra-session-id infra)
                             (step-effect:emit-event-name eff)
-                            (step-effect:emit-event-payload eff))]
-      [(step-effect:execute-tools? eff) (void)] ;; handled separately
-      [(step-effect:maybe-compact? eff) (void)]))) ;; handled separately
+                            (step-effect:emit-event-payload eff))])))

--- a/runtime/iteration/step-interpreter.rkt
+++ b/runtime/iteration/step-interpreter.rkt
@@ -74,7 +74,7 @@
                   detect-exploration-loop)
          (only-in "decision.rkt" step-result step-result-action step-result-new-counters)
          (only-in "internal.rkt" assert-payload)
-         (only-in "directive.rkt" directive-recurse directive-stop directive-yield))
+         (only-in "directive.rkt" directive-recurse directive-stop))
 
 (provide interpret-step
          handle-stop-action

--- a/tests/test-effect-executor.rkt
+++ b/tests/test-effect-executor.rkt
@@ -21,19 +21,8 @@
       (check-true (step-effect:emit-event? e))
       (check-equal? (step-effect:emit-event-name e) "test.event"))
 
-    (test-case "step-effect:execute-tools construction"
-      (define e (step-effect:execute-tools 'msgs #f #f #f))
-      (check-true (step-effect:execute-tools? e)))
-
-    (test-case "step-effect:maybe-compact construction"
-      (define e (step-effect:maybe-compact 'ctx "sess" #f #f))
-      (check-true (step-effect:maybe-compact? e)))
-
     (test-case "step-effect? predicate accepts all variants"
-      (for ([e (list (step-effect:append-entries '())
-                     (step-effect:emit-event "x" #f)
-                     (step-effect:execute-tools #f #f #f #f)
-                     (step-effect:maybe-compact #f #f #f #f))])
+      (for ([e (list (step-effect:append-entries '()) (step-effect:emit-event "x" #f))])
         (check-true (step-effect? e))))))
 
 (run-tests effect-executor-tests)

--- a/tests/test-loop-phases.rkt
+++ b/tests/test-loop-phases.rkt
@@ -34,8 +34,9 @@
                              (list (message "id1" #f 'user 'user "hello" 0 (hash)))))
       (check-true (list? raw))
       (check = (length raw) 1)
-      (check = (length effs) 1)
-      (check-true (effect:update-fsm? (car effs))))
+      (check = (length effs) 2)
+      (check-true (effect:emit-event? (car effs)))
+      (check-true (effect:update-fsm? (cadr effs))))
 
     (test-case "phase-build-request returns model request"
       (define-values (req effs) (phase-build-request '() #f #f))

--- a/tools/registry.rkt
+++ b/tools/registry.rkt
@@ -28,8 +28,6 @@
                        [set-active-tools! (-> tool-registry? (or/c (listof string?) #f) void?)]
                        [tool-active? (-> tool-registry? string? boolean?)]
                        [with-registry-snapshot (-> tool-registry? procedure? any)])
-         ;; Internal — do not use outside this module
-         with-registry-lock
          tool-registry?)
 
 ;; ============================================================

--- a/tui/command-parse.rkt
+++ b/tui/command-parse.rkt
@@ -137,35 +137,21 @@
          validate-args)
 
 (define (parse-command-name text)
-  (define trimmed (string-trim text))
+  ;; v0.46.10 (I-4): Compose from extracted pipeline stages instead of duplicating logic.
+  ;; tokenize returns (values cmd-string args-list) or #f.
+  ;; Use call-with-values to safely handle both return shapes.
+  (define tok (call-with-values (λ () (tokenize text)) vector))
   (cond
-    [(string=? trimmed "") #f]
-    [(not (char=? (string-ref trimmed 0) #\/)) #f]
-    [else
-     (define parts (string-split trimmed))
-     (define cmd (car parts))
-     (define args (cdr parts))
+    [(eq? tok #f) #f]
+    [(and (vector? tok) (= (vector-length tok) 2))
+     (define cmd (vector-ref tok 0))
+     (define args (vector-ref tok 1))
      (define table (make-command-table))
-     (define entry (hash-ref table cmd #f))
+     (define entry (lookup-command-entry cmd table))
      (cond
        [(not entry) 'unknown]
-       [(eq? (cdr entry) 'none) (parsed-command (car entry) '() 'none)]
-       [(eq? (cdr entry) 'optional)
-        (parsed-command (car entry)
-                        (if (null? args)
-                            '()
-                            (list (car args)))
-                        'optional)]
-       [(eq? (cdr entry) 'required)
-        (if (null? args)
-            (parsed-command (string->symbol (format "~a-error" (symbol->string (car entry))))
-                            (list (case (car entry)
-                                    [(switch) "Usage: /switch <branch-id>"]
-                                    [(children) "Usage: /children <node-id>"]
-                                    [else (format "Usage: /~a <id>" (symbol->string (car entry)))]))
-                            'error)
-            (parsed-command (car entry) (list (car args)) 'required))]
-       [else (parsed-command (car entry) '() 'none)])]))
+       [else (validate-args entry args)])]
+    [else #f]))
 
 ;; Resolve a command name (with alias) to canonical symbol.
 ;; Returns: symbol or #f


### PR DESCRIPTION
Addresses #4573.

fix: hygiene fixes — schema annotation, unexport, dead imports, parse composition, effect predicate, void stubs (W0, #4573)

W0-T1: Added #:schema-version 1 to context-assembled-event (I-2, 46/46 events now covered)
W0-T2: Removed with-registry-lock from bare provide in registry.rkt (I-3)
W0-T3: Removed directive-yield unused import from step-interpreter.rkt (M-2)
W0-T4: Rewrote parse-command-name to compose from tokenize/lookup/validate pipeline (I-4, -14 LOC)
W0-T5: Replaced effect? or/c with proper predicate function (M-1)
W0-T6: Removed void step-effect:execute-tools/maybe-compact stubs (M-5, -15 LOC)
Also fixed test-loop-phases.rkt to match W2 purity fix (2 effects, not 1)
Updated test-effect-executor.rkt to remove void stub test cases