### PR TITLE
refactor: streaming phase extraction — run-agent-turn 135→62 lines (W1, #4574)

W1-T1: Added phase-msg-hook and phase-stream to loop-phases.rkt
W1-T2: Added required imports for streaming types
W1-T3: Added phase-dispatch-streaming — full post-pre-hook streaming dispatch
W1-T4: Replaced inline streaming in loop.rkt with extracted phase calls
W1-T5: All loop/iteration tests pass

KPI: run-agent-turn 135→62 lines (target ≤80, achieved 62)

### DIFF
--- a/agent/loop-phases.rkt
+++ b/agent/loop-phases.rkt
@@ -14,8 +14,10 @@
          "../llm/model.rkt"
          "../llm/token-budget.rkt"
          (only-in "../llm/provider.rkt" provider-name provider?)
+         (only-in "../llm/stream.rkt" accumulate-tool-call-deltas)
          "effect-types.rkt"
          "loop-messages.rkt"
+         "loop-stream.rkt"
          "loop-fsm.rkt"
          "state.rkt"
          (only-in "event-structs.rkt"
@@ -23,12 +25,29 @@
                   make-context-event
                   make-provider-request-event
                   make-model-request-blocked-event
-                  make-turn-end-event))
+                  make-message-blocked-event
+                  make-turn-end-event)
+         (only-in "turn-reducer.rkt" decide-after-pre-hook decide-after-msg-hook decide-after-stream)
+         (only-in "turn-model.rkt"
+                  make-stream-completion
+                  turn-decision-tag
+                  make-turn-start
+                  make-turn-hook-result
+                  make-turn-stream-complete
+                  hook-stage-payload)
+         (only-in "../llm/token-budget.rkt" estimate-context-tokens)
+         (only-in "event-emitter.rkt" emit-typed-event!)
+         (only-in "loop-stream.rkt" stream-from-provider handle-cancellation build-stream-result)
+         (only-in "state.rkt" current-loop-state-for-error-recovery)
+         "../util/loop-result.rkt")
 
 (provide phase-emit-start
          phase-build-context
          phase-build-request
-         phase-pre-hook)
+         phase-pre-hook
+         phase-msg-hook
+         phase-stream
+         phase-dispatch-streaming)
 
 ;; ---------------------------------------------------------------------------
 ;; Phase 1: Emit turn-started event
@@ -95,3 +114,120 @@
                                   'settings
                                   (model-request-settings req)))))
   (values result '()))
+
+;; ---------------------------------------------------------------------------
+;; Phase 5: Message-start hook dispatch
+;; ---------------------------------------------------------------------------
+
+;; Returns (values msg-hook-result (listof effect?))
+;; msg-hook-result: the raw hook result (for reducer)
+(define (phase-msg-hook hook-dispatcher provider req raw-messages session-id turn-id st)
+  (define msg-start-result
+    (and hook-dispatcher
+         (hook-dispatcher 'message-start
+                          (hasheq 'session-id
+                                  session-id
+                                  'turn-id
+                                  turn-id
+                                  'model-name
+                                  (provider-name provider)
+                                  'message-count
+                                  (length raw-messages)))))
+  (values msg-start-result '()))
+
+;; ---------------------------------------------------------------------------
+;; Phase 6: Stream from provider + completion dispatch
+;; ---------------------------------------------------------------------------
+
+;; Returns (values stream-result (listof effect?))
+;; stream-result is a hasheq with keys: cancelled?, cancel-reason, text, tool-calls
+(define (phase-stream provider req bus session-id turn-id st hook-dispatcher cancellation-token)
+  (define stream-data
+    (stream-from-provider provider req bus session-id turn-id st hook-dispatcher cancellation-token))
+  (values stream-data '()))
+
+;; ---------------------------------------------------------------------------
+;; Phase 7: Full post-pre-hook streaming dispatch
+;; ---------------------------------------------------------------------------
+
+;; Returns loop-result directly (this is an effectful dispatch function)
+;; Handles: msg-hook dispatch, streaming, cancellation, result building
+(define (phase-dispatch-streaming provider
+                                  req
+                                  bus
+                                  session-id
+                                  turn-id
+                                  st
+                                  raw-messages
+                                  tools
+                                  hook-dispatcher
+                                  cancellation-token)
+  (parameterize ([current-turn-fsm-state (current-turn-fsm-state)])
+    ;; FSM: pre-hook -> stream
+    (current-turn-fsm-state (next-turn-state turn-state-pre-hook turn-event-hook-pass))
+
+    ;; DEBUG: validate raw-messages before sending
+    (unless (valid-api-message-sequence? raw-messages)
+      (log-warning "INVALID message sequence detected! Dumping raw messages:")
+      (for ([rm (in-list raw-messages)]
+            [i (in-naturals)])
+        (log-warning "  msg[~a]: role=~a keys=~a" i (hash-ref rm 'role #f) (hash-keys rm)))
+      (log-warning "End of invalid sequence dump"))
+
+    (emit-typed-event! bus
+                       (make-provider-request-event
+                        #:session-id session-id
+                        #:turn-id turn-id
+                        #:timestamp (current-inexact-milliseconds)
+                        #:model (hash-ref (model-request-settings req)
+                                          'model
+                                          (lambda () (format "~a" (provider-name provider))))
+                        #:provider (format "~a" (provider-name provider)))
+                       #:state st)
+
+    ;; Phase 5: Message-start hook
+    (define-values (msg-start-result _fx5)
+      (phase-msg-hook hook-dispatcher provider req raw-messages session-id turn-id st))
+
+    (define d-msg (decide-after-msg-hook msg-start-result))
+    (match (turn-decision-tag d-msg)
+      ['blocked
+       (current-turn-fsm-state (next-turn-state turn-state-stream turn-event-msg-hook-block))
+       (emit-typed-event! bus
+                          (make-message-blocked-event #:session-id session-id
+                                                      #:turn-id turn-id
+                                                      #:timestamp (current-inexact-milliseconds)
+                                                      #:hook "message-start"
+                                                      #:reason "blocked"))
+       (emit-typed-event! bus
+                          (make-turn-end-event #:session-id session-id
+                                               #:turn-id turn-id
+                                               #:timestamp (current-inexact-milliseconds)
+                                               #:reason "hook-blocked"
+                                               #:duration-ms 0))
+       (loop-result raw-messages 'hook-blocked (hasheq 'hook 'message-start))]
+      [_
+       ;; Phase 6: Stream from provider
+       (define-values (stream-data _fx6)
+         (phase-stream provider req bus session-id turn-id st hook-dispatcher cancellation-token))
+
+       (define sc
+         (make-stream-completion #:cancelled? (hash-ref stream-data 'cancelled? #f)
+                                 #:cancel-reason (hash-ref stream-data 'cancel-reason #f)
+                                 #:text (hash-ref stream-data 'text "")
+                                 #:tool-calls (hash-ref stream-data 'tool-calls '())))
+       (define d-stream (decide-after-stream sc))
+       (match (turn-decision-tag d-stream)
+         ['cancelled
+          (current-turn-fsm-state (next-turn-state turn-state-stream turn-event-stream-cancel))
+          (handle-cancellation bus session-id turn-id st #:hook-dispatcher hook-dispatcher)]
+         [_
+          (build-stream-result stream-data
+                               raw-messages
+                               bus
+                               session-id
+                               turn-id
+                               st
+                               tools
+                               provider
+                               hook-dispatcher)])])))

--- a/agent/loop.rkt
+++ b/agent/loop.rkt
@@ -78,7 +78,10 @@
                   phase-emit-start
                   phase-build-context
                   phase-build-request
-                  phase-pre-hook))
+                  phase-pre-hook
+                  phase-msg-hook
+                  phase-stream
+                  phase-dispatch-streaming))
 
 (provide (contract-out [run-agent-turn
                         (->i ([ctx (listof message?)] [prov provider?] [bus event-bus?])
@@ -215,87 +218,14 @@
                                                #:duration-ms 0))
        (loop-result raw-messages 'hook-blocked (hasheq 'hook 'model-request-pre))]
       [_
-       ;; R-06/R-07: FSM: pre-hook -> stream
-       (current-turn-fsm-state (next-turn-state turn-state-pre-hook turn-event-hook-pass))
-       ;; DEBUG: validate raw-messages before sending
-       (unless (valid-api-message-sequence? raw-messages)
-         (log-warning "INVALID message sequence detected! Dumping raw messages:")
-         (for ([rm (in-list raw-messages)]
-               [i (in-naturals)])
-           (log-warning "  msg[~a]: role=~a keys=~a" i (hash-ref rm 'role #f) (hash-keys rm)))
-         (log-warning "End of invalid sequence dump"))
-
-       (emit-typed-event! bus
-                          (make-provider-request-event
-                           #:session-id session-id
-                           #:turn-id turn-id
-                           #:timestamp (current-inexact-milliseconds)
-                           #:model (hash-ref (model-request-settings req)
-                                             'model
-                                             (lambda () (format "~a" (provider-name provider))))
-                           #:provider (format "~a" (provider-name provider)))
-                          #:state st)
-
-       (define msg-start-result
-         (and hook-dispatcher
-              (hook-dispatcher 'message-start
-                               (hasheq 'session-id
-                                       session-id
-                                       'turn-id
-                                       turn-id
-                                       'model-name
-                                       (provider-name provider)
-                                       'message-count
-                                       (length raw-messages)))))
-
-       ;; v0.43.0: Reducer-driven msg-hook dispatch
-       (define d-msg (decide-after-msg-hook msg-start-result))
-       (match (turn-decision-tag d-msg)
-         ['blocked
-          (current-turn-fsm-state (next-turn-state turn-state-stream turn-event-msg-hook-block))
-          (emit-typed-event! bus
-                             (make-message-blocked-event #:session-id session-id
-                                                         #:turn-id turn-id
-                                                         #:timestamp (current-inexact-milliseconds)
-                                                         #:hook "message-start"
-                                                         #:reason "blocked"))
-          (emit-typed-event! bus
-                             (make-turn-end-event #:session-id session-id
-                                                  #:turn-id turn-id
-                                                  #:timestamp (current-inexact-milliseconds)
-                                                  #:reason "hook-blocked"
-                                                  #:duration-ms 0))
-          (loop-result raw-messages 'hook-blocked (hasheq 'hook 'message-start))]
-         [_
-          ;; 5-7. Stream from provider
-          (define stream-data
-            (stream-from-provider provider
-                                  req
-                                  bus
-                                  session-id
-                                  turn-id
-                                  st
-                                  hook-dispatcher
-                                  cancellation-token))
-
-          ;; v0.43.0: Reducer-driven stream-complete dispatch
-          (define sc
-            (make-stream-completion #:cancelled? (hash-ref stream-data 'cancelled? #f)
-                                    #:cancel-reason (hash-ref stream-data 'cancel-reason #f)
-                                    #:text (hash-ref stream-data 'text "")
-                                    #:tool-calls (hash-ref stream-data 'tool-calls '())))
-          (define d-stream (decide-after-stream sc))
-          (match (turn-decision-tag d-stream)
-            ['cancelled
-             (current-turn-fsm-state (next-turn-state turn-state-stream turn-event-stream-cancel))
-             (handle-cancellation bus session-id turn-id st #:hook-dispatcher hook-dispatcher)]
-            [_
-             (build-stream-result stream-data
-                                  raw-messages
-                                  bus
-                                  session-id
-                                  turn-id
-                                  st
-                                  tools
-                                  provider
-                                  hook-dispatcher)])])])))
+       ;; v0.46.10 (I-1): Streaming dispatch extracted to phase-dispatch-streaming
+       (phase-dispatch-streaming provider
+                                 req
+                                 bus
+                                 session-id
+                                 turn-id
+                                 st
+                                 raw-messages
+                                 tools
+                                 hook-dispatcher
+                                 cancellation-token)])))


### PR DESCRIPTION
Addresses #4574.

refactor: streaming phase extraction — run-agent-turn 135→62 lines (W1, #4574)

W1-T1: Added phase-msg-hook and phase-stream to loop-phases.rkt
W1-T2: Added required imports for streaming types
W1-T3: Added phase-dispatch-streaming — full post-pre-hook streaming dispatch
W1-T4: Replaced inline streaming in loop.rkt with extracted phase calls
W1-T5: All loop/iteration tests pass

KPI: run-agent-turn 135→62 lines (target ≤80, achieved 62)