### PR TITLE
fix: dead helper deprecation + expansion macro test (W2, #4575)

W2-T1: Rewrote test-define-extension-expand.rkt to test define-q-extension
       macro (7 test cases: name, version, api-version, hooks, defaults, multi-hook)
W2-T2: Marked emit-turn-start!/build-turn-context as deprecated in loop.rkt
W2-T3: Removed from provide, migrated test-stream-loop-w1.rkt to phase functions

KPI: test-define-extension-expand.rkt invokes define-q-extension macro ✓
KPI: Zero dead exports from loop.rkt ✓

### DIFF
--- a/agent/loop.rkt
+++ b/agent/loop.rkt
@@ -119,13 +119,12 @@
          MAX-STREAM-CHUNKS
          usage-empty?
          parts->text-string
-         classify-hook-result
-         emit-turn-start!
-         build-turn-context)
+         classify-hook-result)
 ;; ============================================================
 ;; Extracted helpers (I-01)
 ;; ============================================================
 
+;; DEPRECATED v0.46.10: Use phase-emit-start from loop-phases.rkt instead
 ;; Phase 1: Emit turn-started event and dispatch agent-start hook
 (define (emit-turn-start! bus session-id turn-id st hook-dispatcher context)
   (emit-typed-event! bus
@@ -140,6 +139,7 @@
      'agent-start
      (hasheq 'session-id session-id 'turn-id turn-id 'message-count (length context)))))
 
+;; DEPRECATED v0.46.10: Use phase-build-context from loop-phases.rkt instead
 ;; Phase 2: Build normalized context and emit context.built event
 (define (build-turn-context bus session-id turn-id st context)
   (define raw-messages (build-raw-messages context))

--- a/tests/test-define-extension-expand.rkt
+++ b/tests/test-define-extension-expand.rkt
@@ -1,28 +1,64 @@
-#lang racket
+#lang racket/base
 
-;; tests/test-define-extension-expand.rkt — Extension struct tests (F17)
+;; tests/test-define-extension-expand.rkt — define-q-extension macro tests (M-4)
 ;; BOUNDARY: pure
+;;
+;; Tests the define-q-extension MACRO, not just the underlying struct.
+;; Verifies macro expansion produces correct extension values with
+;; hooks, defaults, and hook-point validation.
 
-(require rackunit
-         rackunit/text-ui
+(require racket/function
+         rackunit
+         "../extensions/define-extension.rkt"
          "../util/extensions.rkt")
 
-(define expansion-tests
-  (test-suite "define-extension-expand"
+;; ============================================================
+;; W2-T1 (M-4): Test the macro, not just the struct
+;; ============================================================
 
-    (test-case "extension struct predicate"
-      (check-true (procedure? extension?)))
+;; Basic invocation with all fields
+(define-q-extension test-ext-basic
+                    #:version "2.0.0"
+                    #:api-version "2"
+                    #:on message-start
+                    (lambda (payload) 'hook-result-1))
 
-    (test-case "extension struct accessors"
-      (check-true (procedure? extension-name))
-      (check-true (procedure? extension-version))
-      (check-true (procedure? extension-hooks)))
+(test-case "define-q-extension creates extension with correct name"
+  (check-equal? (extension-name test-ext-basic) "test-ext-basic"))
 
-    (test-case "extension construction"
-      (define ext (extension "test" "1.0" "1" (hash)))
-      (check-equal? (extension-name ext) "test")
-      (check-equal? (extension-version ext) "1.0")
-      (check-equal? (extension-api-version ext) "1")
-      (check-equal? (extension-hooks ext) (hash)))))
+(test-case "define-q-extension sets version from #:version"
+  (check-equal? (extension-version test-ext-basic) "2.0.0"))
 
-(run-tests expansion-tests)
+(test-case "define-q-extension sets api-version from #:api-version"
+  (check-equal? (extension-api-version test-ext-basic) "2"))
+
+(test-case "define-q-extension registers hook handler"
+  (define hooks (extension-hooks test-ext-basic))
+  (check-not-false (hash-has-key? hooks 'message-start))
+  (check-equal? ((hash-ref hooks 'message-start) 'ignored) 'hook-result-1))
+
+;; Extension with defaults (no #:version, no #:api-version)
+(define-q-extension test-ext-defaults #:on turn-start (lambda (payload) 'turn-hook-result))
+
+(test-case "define-q-extension defaults version to 0.1.0"
+  (check-equal? (extension-version test-ext-defaults) "0.1.0"))
+
+(test-case "define-q-extension defaults api-version to 1"
+  (check-equal? (extension-api-version test-ext-defaults) "1"))
+
+;; Extension with multiple hooks
+(define-q-extension test-ext-multi
+                    #:version "1.5.0"
+                    #:on model-request-pre
+                    (lambda (p) 'pre)
+                    #:on tool-call
+                    (lambda (p) 'tool)
+                    #:on turn-end
+                    (lambda (p) 'end))
+
+(test-case "define-q-extension with multiple hooks"
+  (define hooks (extension-hooks test-ext-multi))
+  (check-equal? (hash-count hooks) 3)
+  (check-not-false (hash-has-key? hooks 'model-request-pre))
+  (check-not-false (hash-has-key? hooks 'tool-call))
+  (check-not-false (hash-has-key? hooks 'turn-end)))

--- a/tests/test-stream-loop-w1.rkt
+++ b/tests/test-stream-loop-w1.rkt
@@ -3,22 +3,19 @@
 ;; BOUNDARY: integration
 
 ;; tests/test-stream-loop-w1.rkt — Streaming decomposition & loop cleanup tests (W-06, I-01)
+;; Updated v0.46.10: emit-turn-start!/build-turn-context deprecated, now test phase functions
 
 (require rackunit
          "../agent/loop.rkt"
+         "../agent/loop-phases.rkt"
+         "../agent/loop-fsm.rkt"
          "../agent/event-bus.rkt"
          "../agent/state.rkt"
          "../util/message.rkt")
 
 ;; ============================================================
-;; I-01: Extracted helper functions exist
+;; I-01: Main entry point exists
 ;; ============================================================
-
-(test-case "emit-turn-start! is exported from loop.rkt"
-  (check-true (procedure? emit-turn-start!)))
-
-(test-case "build-turn-context is exported from loop.rkt"
-  (check-true (procedure? build-turn-context)))
 
 (test-case "run-agent-turn is exported"
   (check-true (procedure? run-agent-turn)))
@@ -31,39 +28,42 @@
   (check-true (procedure? stream-from-provider)))
 
 ;; ============================================================
-;; I-01: emit-turn-start! works correctly
+;; Phase functions exist (replaces deprecated helpers)
 ;; ============================================================
 
-(test-case "emit-turn-start! emits turn.started event"
-  (define bus (make-event-bus))
-  (define events '())
-  (subscribe! bus (lambda (e) (set! events (cons e events))))
+(test-case "phase-emit-start is exported from loop-phases"
+  (check-true (procedure? phase-emit-start)))
+
+(test-case "phase-build-context is exported from loop-phases"
+  (check-true (procedure? phase-build-context)))
+
+(test-case "phase-build-request is exported from loop-phases"
+  (check-true (procedure? phase-build-request)))
+
+(test-case "phase-pre-hook is exported from loop-phases"
+  (check-true (procedure? phase-pre-hook)))
+
+;; ============================================================
+;; Phase 1: phase-emit-start returns values + effects
+;; ============================================================
+
+(test-case "phase-emit-start returns context and effects"
   (define st (make-loop-state "s1" "t1"))
-  (emit-turn-start! bus "s1" "t1" st #f '())
-  (check-not-false events))
-
-(test-case "emit-turn-start! dispatches agent-start hook"
-  (define bus (make-event-bus))
-  (define st (make-loop-state "s1" "t1"))
-  (define hook-called? (box #f))
-  (define (mock-hook-dispatcher action payload)
-    (when (eq? action 'agent-start)
-      (set-box! hook-called? #t)))
-  (emit-turn-start! bus
-                    "s1"
-                    "t1"
-                    st
-                    mock-hook-dispatcher
-                    (list (message "m1" #f 'user 'message "hello" (current-seconds) (hasheq))))
-  (check-true (unbox hook-called?)))
+  (define context '())
+  (define-values (ctx effects) (phase-emit-start "s1" "t1" st context))
+  (check-equal? ctx context)
+  (check-true (list? effects))
+  (check-true (>= (length effects) 1)))
 
 ;; ============================================================
-;; I-01: build-turn-context produces raw-messages
+;; Phase 2: phase-build-context returns raw-messages + effects
 ;; ============================================================
 
-(test-case "build-turn-context returns raw-messages"
+(test-case "phase-build-context returns raw-messages and effects"
   (define bus (make-event-bus))
   (define st (make-loop-state "s1" "t1"))
   (define context (list (message "m1" #f 'user 'message "hello" (current-seconds) (hasheq))))
-  (define result (build-turn-context bus "s1" "t1" st context))
-  (check-true (list? result)))
+  (define-values (raw-msgs effects) (phase-build-context bus "s1" "t1" st context))
+  (check-true (list? raw-msgs))
+  (check-true (list? effects))
+  (check-true (>= (length effects) 1)))


### PR DESCRIPTION
Addresses #4575.

fix: dead helper deprecation + expansion macro test (W2, #4575)

W2-T1: Rewrote test-define-extension-expand.rkt to test define-q-extension
       macro (7 test cases: name, version, api-version, hooks, defaults, multi-hook)
W2-T2: Marked emit-turn-start!/build-turn-context as deprecated in loop.rkt
W2-T3: Removed from provide, migrated test-stream-loop-w1.rkt to phase functions

KPI: test-define-extension-expand.rkt invokes define-q-extension macro ✓
KPI: Zero dead exports from loop.rkt ✓