### PR TITLE
feat(v0.47.10): contract coverage wave 3 — context-fit + trace-logger (#4626)

Add contract-out to context-fit and trace-logger modules.
Extension API already fully contracted.
All 2175 tests pass across 560 files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ q/
 |--------|-------|
 | Test files | 606 |
 | Source modules | 438 |
-| Source lines | 67228 |
+| Source lines | 67235 |
 | Test lines | 105282 |
 | Test assertions | 16435 |
 | Tests passing | 5835+ | `racket scripts/run-tests.rkt` results |

--- a/runtime/context-fit.rkt
+++ b/runtime/context-fit.rkt
@@ -6,7 +6,8 @@
 ;; Functions for fitting messages within token budgets while preserving
 ;; system instructions and first-user pinning.
 
-(require racket/list
+(require racket/contract
+         racket/list
          racket/set
          (only-in "../util/protocol-types.rkt" message-role message-kind message-id)
          (only-in "../runtime/context-policy.rkt"
@@ -15,8 +16,9 @@
                   ensure-first-user-pinned
                   fit-messages-with-importance-rescue))
 
-(provide truncate-messages-to-budget
-         fit-messages-from-recent)
+(provide (contract-out
+          [truncate-messages-to-budget (-> (listof any/c) exact-nonnegative-integer? (listof any/c))]
+          [fit-messages-from-recent (-> (listof any/c) exact-nonnegative-integer? (listof any/c))]))
 
 ;; Fit messages from recent end within budget (pair-preserving + importance rescue).
 ;; v0.45.7 (NF2): Now uses importance-aware rescue to preserve critical/high messages.

--- a/runtime/trace-logger.rkt
+++ b/runtime/trace-logger.rkt
@@ -6,7 +6,8 @@
 ;; Subscribes to the event bus and writes trace.jsonl entries
 ;; with sequence numbers, ISO timestamps, and event data.
 
-(require racket/date
+(require racket/contract
+         racket/date
          json
          racket/file
          racket/class
@@ -14,11 +15,15 @@
          "../util/protocol-types.rkt"
          "trace-sink.rkt")
 
-(provide make-trace-logger
-         trace-logger?
-         start-trace-logger!
-         stop-trace-logger!
-         flush-trace-logger!)
+(provide (contract-out [make-trace-logger
+                        (->* (event-bus? path-string?)
+                             (#:enabled? boolean? #:sink (or/c (is-a?/c trace-sink<%>) #f))
+                             trace-logger?)]
+                       [trace-logger? (-> any/c boolean?)]
+                       [start-trace-logger!
+                        (->* (trace-logger?) (#:port (or/c output-port? #f)) void?)]
+                       [stop-trace-logger! (-> trace-logger? void?)]
+                       [flush-trace-logger! (-> trace-logger? void?)]))
 
 ;; ============================================================
 ;; Trace logger struct


### PR DESCRIPTION
Addresses #4627.

feat(v0.47.10): contract coverage wave 3 — context-fit + trace-logger (#4626)

Add contract-out to context-fit and trace-logger modules.
Extension API already fully contracted.
All 2175 tests pass across 560 files.