### PR TITLE
refactor: replace struct-out with explicit exports in core type modules (#4646)

### DIFF
--- a/llm/stream.rkt
+++ b/llm/stream.rkt
@@ -26,7 +26,11 @@
          ;; — OpenAI chunk normalization —
          normalize-openai-chunks
          normalize-openai-chunk
-         (struct-out tool-call-accum)
+         tool-call-accum
+         tool-call-accum?
+         tool-call-accum-id
+         tool-call-accum-name
+         tool-call-accum-arguments
          accumulate-tool-call-deltas
          ;; — Incremental SSE reading —
          read-sse-chunks

--- a/llm/token-budget.rkt
+++ b/llm/token-budget.rkt
@@ -12,13 +12,18 @@
 
 (provide DEFAULT-TOKEN-BUDGET-THRESHOLD
          DEFAULT-SAFETY-MARGIN-PCT
-         (struct-out context-usage)
+         context-usage
+         context-usage?
+         context-usage-total-tokens
+         context-usage-max-tokens
+         context-usage-usage-percent
+         context-usage-compaction-threshold
          (contract-out
           [estimate-context-tokens (-> (listof (or/c message? hash?)) exact-nonnegative-integer?)]
-          [estimate-turn-tokens (-> (listof (or/c message? hash?)) string? exact-nonnegative-integer?)]
+          [estimate-turn-tokens
+           (-> (listof (or/c message? hash?)) string? exact-nonnegative-integer?)]
           [should-compact? (-> exact-nonnegative-integer? exact-nonnegative-integer? boolean?)]
-          [remaining-budget
-           (-> exact-nonnegative-integer? exact-nonnegative-integer? exact-integer?)]
+          [remaining-budget (-> exact-nonnegative-integer? exact-nonnegative-integer? exact-integer?)]
           [estimate-text-tokens (-> string? exact-nonnegative-integer?)]
           [get-context-usage
            (-> exact-nonnegative-integer? exact-nonnegative-integer? context-usage?)]

--- a/util/command-types.rkt
+++ b/util/command-types.rkt
@@ -10,11 +10,22 @@
 ;; NOTE: shared-command is GSD-specific (used by extensions/gsd/ subsystems).
 ;; The TUI layer uses cmd-entry and its own local parsed-command struct.
 
-(provide (struct-out cmd-entry)
+(provide cmd-entry
+         cmd-entry?
+         cmd-entry-name
+         cmd-entry-summary
+         cmd-entry-category
+         cmd-entry-args-spec
+         cmd-entry-aliases
          register-command!
          lookup-command
          ;; F14: Shared command AST types
-         (struct-out shared-command))
+         shared-command
+         shared-command?
+         shared-command-name
+         shared-command-args
+         shared-command-kind
+         shared-command-source)
 ;; ---------------------------------------------------------------------------
 ;; TUI command registry types (ARCH-02)
 ;; ---------------------------------------------------------------------------

--- a/util/hook-types.rkt
+++ b/util/hook-types.rkt
@@ -8,7 +8,10 @@
 ;; This is a #lang typed/racket module. Untyped consumers receive
 ;; auto-generated contracts from TR boundary system.
 
-(provide (struct-out hook-result)
+(provide hook-result
+         hook-result?
+         hook-result-action
+         hook-result-payload
          hook-pass
          hook-amend
          hook-block


### PR DESCRIPTION
Addresses #4646.

refactor: replace struct-out with explicit exports in core type modules (#4646)