### PR TITLE
refactor: replace struct-out with explicit exports in sandbox and exec-context modules (#4651)

### DIFF
--- a/sandbox/evaluator.rkt
+++ b/sandbox/evaluator.rkt
@@ -8,7 +8,12 @@
 (require racket/sandbox
          (only-in "../util/errors.rkt" with-logged-catch))
 
-(provide (struct-out eval-result)
+(provide eval-result
+         eval-result?
+         eval-result-value
+         eval-result-output
+         eval-result-error
+         eval-result-elapsed-ms
          eval-in-sandbox
          current-sandbox-memory-limit
          current-sandbox-path-limit)
@@ -17,18 +22,18 @@
 ;; Configurable limits (SEC-09)
 ;; --------------------------------------------------
 
-(define current-sandbox-memory-limit (make-parameter 256))   ;; MB
-(define current-sandbox-path-limit  (make-parameter #f))     ;; #f = no path permission changes
+(define current-sandbox-memory-limit (make-parameter 256)) ;; MB
+(define current-sandbox-path-limit (make-parameter #f)) ;; #f = no path permission changes
 
 ;; --------------------------------------------------
 ;; Result struct
 ;; --------------------------------------------------
 
 (struct eval-result
-  (value        ; any — the result value (or #f on error)
-   output       ; string — captured stdout
-   error        ; string or #f — error message
-   elapsed-ms)  ; number
+        (value ; any — the result value (or #f on error)
+         output ; string — captured stdout
+         error ; string or #f — error message
+         elapsed-ms) ; number
   #:transparent)
 
 ;; --------------------------------------------------
@@ -36,30 +41,25 @@
 ;; --------------------------------------------------
 
 (define (safe-get-output evaluator)
-  (with-logged-catch ""
-    (lambda ()
-      (let ([out (get-output evaluator)])
-        (if (string? out) out "")))))
+  (with-logged-catch "" (lambda () (let ([out (get-output evaluator)]) (if (string? out) out "")))))
 
 ;; --------------------------------------------------
 ;; Main evaluator
 ;; --------------------------------------------------
 
 (define (eval-in-sandbox code-string
-                          #:timeout [timeout 30]
-                          #:language [lang 'racket]
-                          #:allow-for-load [allow-load '()])
+                         #:timeout [timeout 30]
+                         #:language [lang 'racket]
+                         #:allow-for-load [allow-load '()])
   (define start-ms (current-inexact-milliseconds))
 
   ;; Outer handler catches creation errors
-  (with-handlers
-      ([exn:fail?
-        (lambda (e)
-          (eval-result
-           #f
-           ""
-           (exn-message e)
-           (inexact->exact (round (- (current-inexact-milliseconds) start-ms)))))])
+  (with-handlers ([exn:fail? (lambda (e)
+                               (eval-result #f
+                                            ""
+                                            (exn-message e)
+                                            (inexact->exact (round (- (current-inexact-milliseconds)
+                                                                      start-ms)))))])
     ;; Create sandbox evaluator
     (define evaluator
       (parameterize ([sandbox-output 'string]
@@ -67,17 +67,17 @@
                      [sandbox-memory-limit (current-sandbox-memory-limit)]
                      [sandbox-eval-limits (list timeout (current-sandbox-memory-limit))]
                      [sandbox-network-guard (lambda args
-                                                   (error 'evaluator "network access denied in sandbox"))]
+                                              (error 'evaluator "network access denied in sandbox"))]
                      [sandbox-path-permissions (or (current-sandbox-path-limit) '())])
         (make-evaluator lang)))
 
     ;; Try to evaluate
     (define result-val
-      (with-handlers
-          ([exn:fail?
-            (lambda (e)
-              (define elapsed (inexact->exact (round (- (current-inexact-milliseconds) start-ms))))
-              (eval-result #f (safe-get-output evaluator) (exn-message e) elapsed))])
+      (with-handlers ([exn:fail?
+                       (lambda (e)
+                         (define elapsed
+                           (inexact->exact (round (- (current-inexact-milliseconds) start-ms))))
+                         (eval-result #f (safe-get-output evaluator) (exn-message e) elapsed))])
         (define result (evaluator code-string))
         (define out (safe-get-output evaluator))
         (define elapsed (inexact->exact (round (- (current-inexact-milliseconds) start-ms))))

--- a/sandbox/limits.rkt
+++ b/sandbox/limits.rkt
@@ -5,7 +5,12 @@
 ;; Provides structured execution limits, preset configurations, merge logic,
 ;; and a predicate to check whether observed resource usage is within bounds.
 
-(provide (struct-out exec-limits)
+(provide exec-limits
+         exec-limits?
+         exec-limits-timeout-seconds
+         exec-limits-max-output-bytes
+         exec-limits-max-memory-bytes
+         exec-limits-max-processes
          default-exec-limits
          strict-exec-limits
          permissive-exec-limits

--- a/sandbox/subprocess.rkt
+++ b/sandbox/subprocess.rkt
@@ -14,7 +14,14 @@
 
 (define-logger subprocess)
 
-(provide (struct-out subprocess-result)
+(provide subprocess-result
+         subprocess-result?
+         subprocess-result-exit-code
+         subprocess-result-stdout
+         subprocess-result-stderr
+         subprocess-result-timed-out?
+         subprocess-result-elapsed-ms
+         subprocess-result-truncated?
          run-subprocess
          kill-subprocess!
          default-timeout-seconds

--- a/tools/exec-context.rkt
+++ b/tools/exec-context.rkt
@@ -8,8 +8,17 @@
          (only-in "../runtime/settings.rkt" q-settings?)
          (only-in "../tools/permission-gate.rkt" permission-config?))
 
-(provide (struct-out exec-context)
+(provide exec-context
          exec-context?
+         exec-context-working-directory
+         exec-context-cancellation-token
+         exec-context-event-publisher
+         exec-context-runtime-settings
+         exec-context-call-id
+         exec-context-session-metadata
+         exec-context-progress-callback
+         exec-context-permission-config
+         exec-context-bytes-written
          (contract-out [make-exec-context
                         (->* ()
                              ;; path-string? covers both path? and string?


### PR DESCRIPTION
Addresses #4651.

refactor: replace struct-out with explicit exports in sandbox and exec-context modules (#4651)