### PR TITLE
refactor: replace struct-out with explicit exports in scheduler-strategy, cli, and auth-store (#4656)

### DIFF
--- a/cli/args.rkt
+++ b/cli/args.rkt
@@ -17,7 +17,24 @@
          racket/format
          "../util/version.rkt")
 
-(provide (struct-out cli-config)
+(provide cli-config
+         cli-config?
+         cli-config-command
+         cli-config-session-id
+         cli-config-prompt
+         cli-config-model
+         cli-config-mode
+         cli-config-project-dir
+         cli-config-config-path
+         cli-config-verbose?
+         cli-config-max-turns
+         cli-config-no-tools?
+         cli-config-tools
+         cli-config-session-dir
+         cli-config-sessions-subcommand
+         cli-config-sessions-args
+         cli-config-keybindings-path
+         cli-config-print-mode?
          parse-cli-args
          cli-config->runtime-config
          print-usage

--- a/runtime/auth-store.rkt
+++ b/runtime/auth-store.rkt
@@ -15,8 +15,16 @@
          racket/path)
 
 ;; Structs
-(provide (struct-out credential)
-         (struct-out redacted-credential)
+(provide credential
+         credential?
+         credential-provider-name
+         credential-api-key
+         credential-source
+         redacted-credential
+         redacted-credential?
+         redacted-credential-provider-name
+         redacted-credential-masked-api-key
+         redacted-credential-source
          ;; H-02: Contract-wrapped exports
          (contract-out
           [lookup-credential

--- a/tools/scheduler-strategy.rkt
+++ b/tools/scheduler-strategy.rkt
@@ -8,14 +8,29 @@
 
 (require "tool-struct.rkt")
 
-(provide (struct-out scheduler-strategy)
-         (struct-out tool-invocation-result)
-         (struct-out tool-success)
-         (struct-out tool-structured-failure)
-         (struct-out tool-retryable-failure)
-         (struct-out tool-policy-denied)
-         default-scheduler-strategy
+(provide scheduler-strategy
+         scheduler-strategy?
+         scheduler-strategy-preflight-filter
+         scheduler-strategy-execution-order
+         tool-invocation-result
          tool-invocation-result?
+         tool-invocation-result-tool-name
+         tool-success
+         tool-success?
+         tool-success-content
+         tool-success-details
+         tool-structured-failure
+         tool-structured-failure?
+         tool-structured-failure-message
+         tool-structured-failure-details
+         tool-retryable-failure
+         tool-retryable-failure?
+         tool-retryable-failure-message
+         tool-retryable-failure-error
+         tool-policy-denied
+         tool-policy-denied?
+         tool-policy-denied-reason
+         default-scheduler-strategy
          tool-result->invocation-result)
 
 ;; ── Tool invocation result tagged union ──


### PR DESCRIPTION
Addresses #4656.

refactor: replace struct-out with explicit exports in scheduler-strategy, cli, and auth-store (#4656)