### PR TITLE
refactor: replace struct-out with explicit exports in tool builtins and cli replay (#4661)

### DIFF
--- a/cli/replay.rkt
+++ b/cli/replay.rkt
@@ -20,19 +20,23 @@
          "../util/protocol-types.rkt"
          "../runtime/session-store.rkt")
 
-(provide
- (struct-out replay-result)
- replay-tool-calls
- replay-session-report
- replay-session-safe
- format-replay-report)
+(provide replay-result
+         replay-result?
+         replay-result-tool-name
+         replay-result-arguments
+         replay-result-original-result
+         replay-result-drifted?
+         replay-result-reason
+         replay-tool-calls
+         replay-session-report
+         replay-session-safe
+         format-replay-report)
 
 ;; ============================================================
 ;; replay-result struct
 ;; ============================================================
 
-(struct replay-result (tool-name arguments original-result drifted? reason)
-  #:transparent)
+(struct replay-result (tool-name arguments original-result drifted? reason) #:transparent)
 ;; tool-name       : string?
 ;; arguments        : string?
 ;; original-result  : string?
@@ -60,26 +64,24 @@
   ;; by tool-call-id. Report drift for unmatched entries.
 
   ;; Sort messages by timestamp for deterministic walk
-  (define sorted
-    (sort messages < #:key message-timestamp))
+  (define sorted (sort messages < #:key message-timestamp))
 
   ;; Collect all tool-call-parts and tool-result-parts
   (define call-parts
     (for*/list ([msg (in-list sorted)]
-                [cp  (in-list (message-content msg))]
+                [cp (in-list (message-content msg))]
                 #:when (tool-call-part? cp))
       cp))
 
   (define result-parts
     (for*/list ([msg (in-list sorted)]
-                [cp  (in-list (message-content msg))]
+                [cp (in-list (message-content msg))]
                 #:when (tool-result-part? cp))
       cp))
 
   ;; Index results by tool-call-id
   (define results-by-id
-    (for/fold ([acc (hash)])
-              ([rp (in-list result-parts)])
+    (for/fold ([acc (hash)]) ([rp (in-list result-parts)])
       (hash-set acc (tool-result-part-tool-call-id rp) rp)))
 
   ;; Track which result-ids have been consumed
@@ -93,32 +95,24 @@
       (cond
         [matched
          (hash-set! consumed tc-id #t)
-         (replay-result
-          (tool-call-part-name tc)
-          (tool-call-part-arguments tc)
-          (tool-result-part-content matched)
-          #f
-          #f)]
+         (replay-result (tool-call-part-name tc)
+                        (tool-call-part-arguments tc)
+                        (tool-result-part-content matched)
+                        #f
+                        #f)]
         [else
          ;; No matching result — drift
-         (replay-result
-          (tool-call-part-name tc)
-          (tool-call-part-arguments tc)
-          ""
-          #t
-          "missing result")])))
+         (replay-result (tool-call-part-name tc)
+                        (tool-call-part-arguments tc)
+                        ""
+                        #t
+                        "missing result")])))
 
   ;; Find orphan results (results with no matching call)
   (define orphan-results
     (for/list ([rp (in-list result-parts)]
-               #:when (not (hash-has-key? consumed
-                                           (tool-result-part-tool-call-id rp))))
-      (replay-result
-       ""
-       ""
-       (tool-result-part-content rp)
-       #t
-       "orphan result")))
+               #:when (not (hash-has-key? consumed (tool-result-part-tool-call-id rp))))
+      (replay-result "" "" (tool-result-part-content rp) #t "orphan result")))
 
   (append call-results orphan-results))
 
@@ -144,30 +138,33 @@
 
   ;; Collect non-deterministic tool names that appear in this session
   (define nd-in-session
-    (remove-duplicates
-     (for/list ([r (in-list results)]
-                #:when (non-deterministic-tool? (replay-result-tool-name r)))
-       (replay-result-tool-name r))))
+    (remove-duplicates (for/list ([r (in-list results)]
+                                  #:when (non-deterministic-tool? (replay-result-tool-name r)))
+                         (replay-result-tool-name r))))
 
   ;; Count non-deterministic tool calls (skipped from deterministic analysis)
   (define skipped
-    (for/sum ([r (in-list results)])
-      (if (non-deterministic-tool? (replay-result-tool-name r)) 1 0)))
+    (for/sum ([r (in-list results)]) (if (non-deterministic-tool? (replay-result-tool-name r)) 1 0)))
 
   ;; Build drift descriptions
   (define drift-descriptions
     (for/list ([r (in-list drifted)])
-      (format "~a: ~a"
-              (replay-result-tool-name r)
-              (replay-result-reason r))))
+      (format "~a: ~a" (replay-result-tool-name r) (replay-result-reason r))))
 
-  (hasheq 'total-entries (length messages)
-          'tool-call-count (length results)
-          'drift-count (length drifted)
-          'drifts drift-descriptions
-          'non-deterministic nd-in-session
-          'skipped skipped
-          'replay-results results))
+  (hasheq 'total-entries
+          (length messages)
+          'tool-call-count
+          (length results)
+          'drift-count
+          (length drifted)
+          'drifts
+          drift-descriptions
+          'non-deterministic
+          nd-in-session
+          'skipped
+          skipped
+          'replay-results
+          results))
 
 ;; ============================================================
 ;; replay-session-safe : path-string? -> hash?
@@ -179,25 +176,40 @@
 
   (cond
     [(not (file-exists? path))
-     (hasheq 'error "file not found"
-             'total-entries 0
-             'tool-call-count 0
-             'drift-count 0
-             'drifts '()
-             'non-deterministic '()
-             'skipped 0
-             'replay-results '())]
+     (hasheq 'error
+             "file not found"
+             'total-entries
+             0
+             'tool-call-count
+             0
+             'drift-count
+             0
+             'drifts
+             '()
+             'non-deterministic
+             '()
+             'skipped
+             0
+             'replay-results
+             '())]
     [else
-     (with-handlers ([exn:fail?
-                      (lambda (e)
-                        (hasheq 'error (exn-message e)
-                                'total-entries 0
-                                'tool-call-count 0
-                                'drift-count 0
-                                'drifts '()
-                                'non-deterministic '()
-                                'skipped 0
-                                'replay-results '()))])
+     (with-handlers ([exn:fail? (lambda (e)
+                                  (hasheq 'error
+                                          (exn-message e)
+                                          'total-entries
+                                          0
+                                          'tool-call-count
+                                          0
+                                          'drift-count
+                                          0
+                                          'drifts
+                                          '()
+                                          'non-deterministic
+                                          '()
+                                          'skipped
+                                          0
+                                          'replay-results
+                                          '()))])
        (replay-session-report path))]))
 
 ;; ============================================================
@@ -208,42 +220,41 @@
   ;; Formats the replay report as a human-readable CLI string.
 
   (define lines
-    (list
-     (format "Entries:        ~a" (hash-ref h 'total-entries 0))
-     (format "Tool calls:     ~a" (hash-ref h 'tool-call-count 0))
-     (format "Drift detected: ~a" (hash-ref h 'drift-count 0))
-     (format "Skipped (ND):   ~a" (hash-ref h 'skipped 0))
-     (let ([nd (hash-ref h 'non-deterministic '())])
-       (if (null? nd)
-           "Non-deterministic: (none)"
-           (format "Non-deterministic: ~a" (string-join nd ", "))))
-     (let ([drifts (hash-ref h 'drifts '())])
-       (if (null? drifts)
-           "Drifts:         (none)"
-           (format "Drifts:\n~a"
-                   (string-join
-                    (for/list ([d (in-list drifts)])
-                      (format "  - ~a" d))
-                    "\n"))))
-     (let ([results (hash-ref h 'replay-results '())])
-       (if (null? results)
-           ""
-           (format "Results:\n~a"
-                   (string-join
-                    (for/list ([r (in-list results)])
-                      (format "  [~a] ~a ~a → ~a~a"
-                              (if (replay-result-drifted? r) "DRIFT" "OK")
-                              (replay-result-tool-name r)
-                              (let ([args (replay-result-arguments r)])
-                                (if (> (string-length args) 40)
-                                    (string-append (substring args 0 40) "...")
-                                    args))
-                              (let ([res (replay-result-original-result r)])
-                                (if (> (string-length res) 40)
-                                    (string-append (substring res 0 40) "...")
-                                    res))
-                              (let ([reason (replay-result-reason r)])
-                                (if reason (format " (~a)" reason) ""))))
-                    "\n"))))))
+    (list (format "Entries:        ~a" (hash-ref h 'total-entries 0))
+          (format "Tool calls:     ~a" (hash-ref h 'tool-call-count 0))
+          (format "Drift detected: ~a" (hash-ref h 'drift-count 0))
+          (format "Skipped (ND):   ~a" (hash-ref h 'skipped 0))
+          (let ([nd (hash-ref h 'non-deterministic '())])
+            (if (null? nd)
+                "Non-deterministic: (none)"
+                (format "Non-deterministic: ~a" (string-join nd ", "))))
+          (let ([drifts (hash-ref h 'drifts '())])
+            (if (null? drifts)
+                "Drifts:         (none)"
+                (format "Drifts:\n~a"
+                        (string-join (for/list ([d (in-list drifts)])
+                                       (format "  - ~a" d))
+                                     "\n"))))
+          (let ([results (hash-ref h 'replay-results '())])
+            (if (null? results)
+                ""
+                (format "Results:\n~a"
+                        (string-join (for/list ([r (in-list results)])
+                                       (format "  [~a] ~a ~a → ~a~a"
+                                               (if (replay-result-drifted? r) "DRIFT" "OK")
+                                               (replay-result-tool-name r)
+                                               (let ([args (replay-result-arguments r)])
+                                                 (if (> (string-length args) 40)
+                                                     (string-append (substring args 0 40) "...")
+                                                     args))
+                                               (let ([res (replay-result-original-result r)])
+                                                 (if (> (string-length res) 40)
+                                                     (string-append (substring res 0 40) "...")
+                                                     res))
+                                               (let ([reason (replay-result-reason r)])
+                                                 (if reason
+                                                     (format " (~a)" reason)
+                                                     ""))))
+                                     "\n"))))))
 
   (string-join (filter (lambda (s) (> (string-length s) 0)) lines) "\n"))

--- a/tools/builtins/bash.rkt
+++ b/tools/builtins/bash.rkt
@@ -42,7 +42,12 @@
 
 (provide tool-bash
          ;; Struct-based config (v0.44.2+, sole config path since v0.46.3)
-         (struct-out bash-execution-config)
+         bash-execution-config
+         bash-execution-config?
+         bash-execution-config-policy
+         bash-execution-config-block-destructive?
+         bash-execution-config-warn-on-destructive?
+         bash-execution-config-warning-port
          make-bash-execution-config
          current-bash-execution-config
          effective-bash-config

--- a/tools/builtins/spawn-subagent.rkt
+++ b/tools/builtins/spawn-subagent.rkt
@@ -48,7 +48,13 @@
          tool-spawn-subagents
          resolve-role-prompt
          parse-subagent-config
-         (struct-out subagent-config))
+         subagent-config
+         subagent-config?
+         subagent-config-task
+         subagent-config-role
+         subagent-config-max-turns
+         subagent-config-tools
+         subagent-config-model)
 
 ;; Subagent configuration struct — replaces ad-hoc hash extraction
 (struct subagent-config (task role max-turns tools model) #:transparent)

--- a/tools/permission-gate.rkt
+++ b/tools/permission-gate.rkt
@@ -63,7 +63,11 @@
 ;; Provides
 ;; ============================================================
 
-(provide (struct-out permission-config)
+(provide permission-config
+         permission-config?
+         permission-config-auto-approved-tools
+         permission-config-needs-approval-tools
+         permission-config-approval-callback
          (contract-out [make-default-permission-config
                         (->* ()
                              (#:auto-approved (or/c (set/c string?) #f)


### PR DESCRIPTION
Addresses #4661.

refactor: replace struct-out with explicit exports in tool builtins and cli replay (#4661)