### PR TITLE
refactor: replace struct-out with explicit exports in event payloads, content parts, and event core (#4670)

### DIFF
--- a/util/content-parts.rkt
+++ b/util/content-parts.rkt
@@ -7,9 +7,19 @@
 
 (require racket/contract)
 
-(provide (struct-out text-part)
-         (struct-out tool-call-part)
-         (struct-out tool-result-part)
+(provide text-part
+         text-part?
+         text-part-text
+         tool-call-part
+         tool-call-part?
+         tool-call-part-id
+         tool-call-part-name
+         tool-call-part-arguments
+         tool-result-part
+         tool-result-part?
+         tool-result-part-tool-call-id
+         tool-result-part-content
+         tool-result-part-is-error?
          ;; Re-export parent struct accessors
          content-part?
          content-part-type

--- a/util/event-payloads.rkt
+++ b/util/event-payloads.rkt
@@ -17,14 +17,40 @@
 ;; See ADR-0013 (planned) for TR migration strategy.
 ;; ──────────────────────────────────────────────────────────────
 
-(provide (struct-out session-start-payload)
-         (struct-out session-end-payload)
-         (struct-out tool-call-event-payload)
-         (struct-out gsd-mode-payload)
-         (struct-out session-switch-payload)
-         (struct-out session-id-payload)
-         (struct-out error-payload)
-         (struct-out input-payload)
+(provide session-start-payload
+         session-start-payload?
+         session-start-payload-session-id
+         session-start-payload-config
+         session-start-payload-reason
+         session-end-payload
+         session-end-payload?
+         session-end-payload-session-id
+         session-end-payload-duration
+         tool-call-event-payload
+         tool-call-event-payload?
+         tool-call-event-payload-session-id
+         tool-call-event-payload-turn-id
+         tool-call-event-payload-tool-name
+         tool-call-event-payload-tool-call-id
+         gsd-mode-payload
+         gsd-mode-payload?
+         gsd-mode-payload-old-mode
+         gsd-mode-payload-new-mode
+         session-switch-payload
+         session-switch-payload?
+         session-switch-payload-session-id
+         session-switch-payload-operation
+         session-id-payload
+         session-id-payload?
+         session-id-payload-session-id
+         error-payload
+         error-payload?
+         error-payload-error
+         error-payload-error-type
+         input-payload
+         input-payload?
+         input-payload-session-id
+         input-payload-message
          payload->hash
          payload-session-id)
 

--- a/util/event.rkt
+++ b/util/event.rkt
@@ -11,7 +11,14 @@
 ;; auto-generated contracts from TR boundary system. Struct
 ;; constructors enforce field types at call sites in untyped modules.
 
-(provide (struct-out event)
+(provide event
+         event?
+         event-version
+         event-ev
+         event-time
+         event-session-id
+         event-turn-id
+         event-payload
          event-event
          make-event
          event->jsexpr


### PR DESCRIPTION
Addresses #4670.

refactor: replace struct-out with explicit exports in event payloads, content parts, and event core (#4670)