### PR TITLE
refactor: replace struct-out with explicit exports in extension-types, tool-types, and loop-result (#4675)

### DIFF
--- a/util/extension-types.rkt
+++ b/util/extension-types.rkt
@@ -5,7 +5,23 @@
 ;; Contains only the struct definition with NO runtime/ or llm/ imports.
 ;; Runtime-dependent convenience methods stay in extensions/context.rkt.
 
-(provide (struct-out extension-ctx))
+(provide extension-ctx
+         extension-ctx?
+         extension-ctx-session-id
+         extension-ctx-session-dir
+         extension-ctx-event-bus
+         extension-ctx-extension-registry
+         extension-ctx-model-name
+         extension-ctx-cancellation-token
+         extension-ctx-working-directory
+         extension-ctx-session-store
+         extension-ctx-tool-registry
+         extension-ctx-command-registry
+         extension-ctx-ui-channel
+         extension-ctx-provider-registry
+         extension-ctx-session-messages
+         extension-ctx-session-token-usage
+         extension-ctx-gsd-ctx)
 
 ;; Extension context struct — bundles all session/runtime state that
 ;; extension handlers may need. All fields are read-only after construction.

--- a/util/loop-result.rkt
+++ b/util/loop-result.rkt
@@ -4,7 +4,11 @@
 ;;
 ;; Extracted from protocol-types.rkt (ARCH-05 split).
 
-(provide (struct-out loop-result)
+(provide loop-result
+         loop-result?
+         loop-result-messages
+         loop-result-termination-reason
+         loop-result-metadata
          make-loop-result)
 
 (struct loop-result (messages termination-reason metadata) #:transparent)

--- a/util/tool-types.rkt
+++ b/util/tool-types.rkt
@@ -5,8 +5,18 @@
 ;; Canonical definitions for tool-call and tool-result data types.
 ;; These are shared across the tool execution pipeline.
 
-(provide (struct-out tool-call)
-         (struct-out tool-result))
+(provide tool-call
+         tool-call?
+         tool-call-id
+         tool-call-name
+         tool-call-arguments
+         make-tool-call
+         tool-result
+         tool-result?
+         tool-result-content
+         tool-result-details
+         tool-result-is-error?
+         make-tool-result)
 
 (struct tool-call (id name arguments) #:transparent #:extra-constructor-name make-tool-call)
 


### PR DESCRIPTION
Addresses #4675.

refactor: replace struct-out with explicit exports in extension-types, tool-types, and loop-result (#4675)