### PR TITLE
refactor: replace struct-out with explicit exports in dialog-api, ui-channel, and extensions-api (#4680)

### DIFF
--- a/extensions/api.rkt
+++ b/extensions/api.rkt
@@ -12,7 +12,13 @@
 (require racket/contract
          racket/list
          ;; v0.33.0 W1: extension struct moved to foundation layer
-         "../util/extensions.rkt"
+         (only-in "../util/extensions.rkt"
+                  extension
+                  extension?
+                  extension-name
+                  extension-version
+                  extension-api-version
+                  extension-hooks)
          ;; ARCH-04 (v0.22.0): event bus re-exports for extensions
          (only-in "../agent/event-bus.rkt" publish! subscribe! unsubscribe! make-event-bus event-bus?)
          ;; Backward-compat: re-export injection-event-topic
@@ -39,7 +45,12 @@
          ;; Extension struct and registry
          json-schema?
          injection-event-topic
-         (struct-out extension)
+         extension
+         extension?
+         extension-name
+         extension-version
+         extension-api-version
+         extension-hooks
          extension-registry?
          (contract-out [make-extension-registry (-> extension-registry?)]
                        [register-extension! (-> extension-registry? extension? void?)]

--- a/extensions/dialog-api.rkt
+++ b/extensions/dialog-api.rkt
@@ -19,11 +19,29 @@
          NOTIFY-ERROR
          NOTIFY-SUCCESS
          notify-level?
-         (struct-out notification)
-         (struct-out confirm-result)
-         (struct-out select-option)
-         (struct-out select-result)
-         (struct-out notification-state)
+         notification
+         notification?
+         notification-level
+         notification-message
+         notification-timestamp
+         notification-duration
+         confirm-result
+         confirm-result?
+         confirm-result-value
+         confirm-result-timed-out?
+         select-option
+         select-option?
+         select-option-id
+         select-option-label
+         select-option-description
+         select-result
+         select-result?
+         select-result-selected-id
+         select-result-timed-out?
+         notification-state
+         notification-state?
+         notification-state-active
+         notification-state-queue
          (contract-out
           [ctx-notify
            (->* (notify-level? string?) (#:duration exact-nonnegative-integer?) notification?)]

--- a/extensions/ui-channel.rkt
+++ b/extensions/ui-channel.rkt
@@ -12,21 +12,33 @@
 (require racket/contract)
 
 ;; UI request structs
-(provide (struct-out ui-request)
-         (struct-out ui-confirm-request)
-         (struct-out ui-select-request)
-         (struct-out ui-input-request)
-         (struct-out ui-response)
-
+(provide ui-request
+         ui-request?
+         ui-request-type
+         ui-request-response-ch
+         ui-request-prompt
+         ui-confirm-request
+         ui-confirm-request?
+         ui-confirm-request-default
+         ui-select-request
+         ui-select-request?
+         ui-select-request-options
+         ui-select-request-multi?
+         ui-input-request
+         ui-input-request?
+         ui-input-request-default
+         ui-input-request-placeholder
+         ui-response
+         ui-response?
+         ui-response-value
+         ui-response-cancelled?
          ;; High-level API for extensions
          ui-confirm!
          ui-select!
          ui-input!
-
          ;; Channel creation
          make-ui-channel
          ui-channel?
-
          ;; Response waiting
          wait-for-ui-response)
 


### PR DESCRIPTION
Addresses #4680.

refactor: replace struct-out with explicit exports in dialog-api, ui-channel, and extensions-api (#4680)