### PR TITLE
refactor: replace struct-out with explicit exports in manifest, loader, renderer, telemetry, and audit modules (#4685)

### DIFF
--- a/extensions/loader.rkt
+++ b/extensions/loader.rkt
@@ -28,7 +28,11 @@
          "tiers.rkt")
 
 ;; Extension loading errors
-(provide (struct-out extension-load-error)
+(provide extension-load-error
+         extension-load-error?
+         extension-load-error-path
+         extension-load-error-message
+         extension-load-error-category
          classify-exception
          (contract-out [discover-extensions (-> path-string? (listof any/c))]
                        [load-extension!

--- a/extensions/manifest.rkt
+++ b/extensions/manifest.rkt
@@ -20,7 +20,21 @@
 ;; ============================================================
 
 ;; Struct & predicate
-(provide (struct-out qpm-manifest)
+(provide qpm-manifest
+         qpm-manifest?
+         qpm-manifest-name
+         qpm-manifest-version
+         qpm-manifest-api-version
+         qpm-manifest-type
+         qpm-manifest-description
+         qpm-manifest-author
+         qpm-manifest-compat
+         qpm-manifest-compatibility
+         qpm-manifest-files
+         qpm-manifest-checksum
+         qpm-manifest-entry
+         qpm-manifest-homepage
+         qpm-manifest-license
          qpm-type?
          ;; Constructor with keyword args
          (contract-out [make-qpm-manifest

--- a/extensions/message-renderer.rkt
+++ b/extensions/message-renderer.rkt
@@ -11,16 +11,22 @@
          racket/match)
 
 ;; #726: Message renderer registry
-(provide (struct-out message-renderer)
+(provide message-renderer
+         message-renderer?
+         message-renderer-message-type
+         message-renderer-renderer-fn
+         message-renderer-ext-name
          make-message-renderer
          register-message-renderer!
          unregister-message-renderer!
          lookup-message-renderer
          list-message-renderers
          render-custom-message
-
          ;; #727: Registry struct
-         (struct-out renderer-registry)
+         renderer-registry
+         renderer-registry?
+         renderer-registry-renderers-box
+         renderer-registry-semaphore
          make-renderer-registry)
 
 ;; ============================================================

--- a/extensions/package-audit.rkt
+++ b/extensions/package-audit.rkt
@@ -33,46 +33,44 @@
 ;; Provides
 ;; ============================================================
 
-(provide
- (struct-out finding)
- (struct-out audit-result)
- (contract-out
-  [audit-package        (-> path-string? audit-result?)]
-  [scan-rkt-files       (-> path-string? (listof finding?))]
-  [classify-risk        (-> (listof finding?) (or/c 'extension 'skill 'bundle) (or/c 'low 'medium 'high))]
-  [format-audit-report  (-> audit-result? string?)]
-  [format-audit-warning (-> audit-result? string?)]))
+(provide finding
+         finding?
+         finding-severity
+         finding-message
+         audit-result
+         audit-result?
+         audit-result-risk-level
+         audit-result-findings
+         audit-result-checksum-verified?
+         (contract-out
+          [audit-package (-> path-string? audit-result?)]
+          [scan-rkt-files (-> path-string? (listof finding?))]
+          [classify-risk
+           (-> (listof finding?) (or/c 'extension 'skill 'bundle) (or/c 'low 'medium 'high))]
+          [format-audit-report (-> audit-result? string?)]
+          [format-audit-warning (-> audit-result? string?)]))
 
 ;; ============================================================
 ;; Pattern definitions
 ;; ============================================================
 
-(define network-pattern
-  #rx"require.*net/(http|url|headless)")
+(define network-pattern #rx"require.*net/(http|url|headless)")
 
-(define subprocess-pattern
-  #rx"(subprocess|system|shell-execute|process)")
+(define subprocess-pattern #rx"(subprocess|system|shell-execute|process)")
 
-(define file-write-pattern
-  #rx"(call-with-output-file|write-bytes|delete-file|delete-directory)")
+(define file-write-pattern #rx"(call-with-output-file|write-bytes|delete-file|delete-directory)")
 
-(define file-read-pattern
-  #rx"(file->string|call-with-input-file|read-bytes)")
+(define file-read-pattern #rx"(file->string|call-with-input-file|read-bytes)")
 
-(define eval-pattern
-  #px"\\beval\\b|\\bcompile\\b")
+(define eval-pattern #px"\\beval\\b|\\bcompile\\b")
 
-(define dynamic-require-pattern
-  #rx"dynamic-require")
+(define dynamic-require-pattern #rx"dynamic-require")
 
-(define ffi-pattern
-  #rx"require.*ffi/")
+(define ffi-pattern #rx"require.*ffi/")
 
-(define env-modification-pattern
-  #rx"(putenv|setenv|current-environment-variables)")
+(define env-modification-pattern #rx"(putenv|setenv|current-environment-variables)")
 
-(define unsafe-io-pattern
-  #rx"(read-byte|read-char|read\\b)")  ;; unchecked deserialization
+(define unsafe-io-pattern #rx"(read-byte|read-char|read\\b)") ;; unchecked deserialization
 
 ;; ============================================================
 ;; scan-rkt-files : path-string? -> (listof finding?)
@@ -82,12 +80,10 @@
   (define rkt-files
     (find-files (lambda (p)
                   (let ([ext (filename-extension p)])
-                    (and ext (or (bytes=? ext #"rkt")
-                                 (bytes=? ext #"zo")))))
+                    (and ext (or (bytes=? ext #"rkt") (bytes=? ext #"zo")))))
                 dir))
-  (append*
-   (for/list ([fpath (in-list rkt-files)])
-     (scan-one-file fpath dir))))
+  (append* (for/list ([fpath (in-list rkt-files)])
+             (scan-one-file fpath dir))))
 
 (define (scan-one-file fpath base-dir)
   (define rel (path->string (find-relative-path base-dir fpath)))
@@ -130,10 +126,10 @@
   (define baseline
     (case pkg-type
       [(extension) 'medium]
-      [(bundle)    'medium]
-      [(skill)     'low]))
+      [(bundle) 'medium]
+      [(skill) 'low]))
   ;; Count findings by severity
-  (define high-count   (count (lambda (f) (eq? (finding-severity f) 'high))   findings))
+  (define high-count (count (lambda (f) (eq? (finding-severity f) 'high)) findings))
   (define medium-count (count (lambda (f) (eq? (finding-severity f) 'medium)) findings))
   ;; Escalation logic
   (cond
@@ -150,19 +146,15 @@
   (define qpm-path (build-path dir "qpm.json"))
   (define manifest (read-qpm-manifest qpm-path))
   (cond
-    [(not manifest)
-     ;; No manifest found
-     (audit-result 'medium
-                   (list (finding 'medium "no manifest found"))
-                   #f)]
+    ;; No manifest found
+    [(not manifest) (audit-result 'medium (list (finding 'medium "no manifest found")) #f)]
     [else
      ;; Scan .rkt files
      (define code-findings (scan-rkt-files dir))
      ;; Check entry point
      (define entry-findings
        (if (qpm-manifest-entry manifest)
-           (list (finding 'info
-                          (format "entry point: ~a" (qpm-manifest-entry manifest))))
+           (list (finding 'info (format "entry point: ~a" (qpm-manifest-entry manifest))))
            '()))
      ;; Checksum verification
      (define expected-checksum (qpm-manifest-checksum manifest))
@@ -185,13 +177,12 @@
   (define findings (audit-result-findings result))
   (define checksum-ok (audit-result-checksum-verified? result))
   (define lines
-    (list*
-     (format "Package Audit Report")
-     (format "  Risk Level: ~a" level)
-     (format "  Checksum Verified: ~a" (if checksum-ok "yes" "no"))
-     (format "  Findings (~a):" (length findings))
-     (for/list ([f (in-list findings)])
-       (format "    [~a] ~a" (finding-severity f) (finding-message f)))))
+    (list* (format "Package Audit Report")
+           (format "  Risk Level: ~a" level)
+           (format "  Checksum Verified: ~a" (if checksum-ok "yes" "no"))
+           (format "  Findings (~a):" (length findings))
+           (for/list ([f (in-list findings)])
+             (format "    [~a] ~a" (finding-severity f) (finding-message f)))))
   (string-join lines "\n"))
 
 ;; ============================================================
@@ -201,5 +192,4 @@
 (define (format-audit-warning result)
   (define level (audit-result-risk-level result))
   (define count (length (audit-result-findings result)))
-  (format "⚠ Package risk level: ~a (~a finding~a)"
-          level count (if (= count 1) "" "s")))
+  (format "⚠ Package risk level: ~a (~a finding~a)" level count (if (= count 1) "" "s")))

--- a/extensions/telemetry.rkt
+++ b/extensions/telemetry.rkt
@@ -14,8 +14,14 @@
 
 (require racket/base)
 
-(provide ;; Telemetry event struct
-         (struct-out telemetry-event)
+;; Telemetry event struct
+(provide telemetry-event
+         telemetry-event?
+         telemetry-event-operation
+         telemetry-event-start-time
+         telemetry-event-end-time
+         telemetry-event-elapsed-ms
+         telemetry-event-metadata
          ;; Timing functions
          telemetry-start
          telemetry-end
@@ -29,12 +35,12 @@
 
 ;; A recorded telemetry event
 (struct telemetry-event
-  (operation   ; string — name of the operation
-   start-time  ; exact-positive-integer — start timestamp (ms)
-   end-time    ; exact-positive-integer — end timestamp (ms)
-   elapsed-ms  ; positive-real — elapsed time in ms
-   metadata    ; hash — optional metadata
-   )
+        (operation ; string — name of the operation
+         start-time ; exact-positive-integer — start timestamp (ms)
+         end-time ; exact-positive-integer — end timestamp (ms)
+         elapsed-ms ; positive-real — elapsed time in ms
+         metadata ; hash — optional metadata
+         )
   #:transparent)
 
 ;; ============================================================
@@ -43,9 +49,7 @@
 
 ;; Start a telemetry timer. Returns a hash with start info.
 (define (telemetry-start operation #:metadata [metadata (hasheq)])
-  (hasheq 'operation operation
-          'start-time (current-inexact-milliseconds)
-          'metadata metadata))
+  (hasheq 'operation operation 'start-time (current-inexact-milliseconds) 'metadata metadata))
 
 ;; End a telemetry timer. Takes the hash from telemetry-start.
 ;; Returns a telemetry-event.
@@ -67,8 +71,7 @@
 ;; Groups by operation name and returns per-operation stats.
 (define (telemetry-report events)
   (define groups
-    (for/fold ([acc (hasheq)])
-              ([e (in-list events)])
+    (for/fold ([acc (hasheq)]) ([e (in-list events)])
       (define op (telemetry-event-operation e))
       (define existing (hash-ref acc op '()))
       (hash-set acc op (cons e existing))))
@@ -78,11 +81,18 @@
     (define count (length elapsed-list))
     (define total (apply + elapsed-list))
     (values op
-            (hasheq 'count count
-                    'total-ms total
-                    'avg-ms (if (> count 0) (/ total count) 0)
-                    'min-ms (apply min elapsed-list)
-                    'max-ms (apply max elapsed-list)))))
+            (hasheq 'count
+                    count
+                    'total-ms
+                    total
+                    'avg-ms
+                    (if (> count 0)
+                        (/ total count)
+                        0)
+                    'min-ms
+                    (apply min elapsed-list)
+                    'max-ms
+                    (apply max elapsed-list)))))
 
 ;; Generate a one-line summary string for a telemetry event.
 (define (telemetry-summary event)


### PR DESCRIPTION
Addresses #4685.

refactor: replace struct-out with explicit exports in manifest, loader, renderer, telemetry, and audit modules (#4685)