### PR TITLE
refactor: replace struct-out with explicit exports in GSD command and state types (#4690)

### DIFF
--- a/extensions/gsd/command-parser.rkt
+++ b/extensions/gsd/command-parser.rkt
@@ -11,18 +11,39 @@
          (only-in "../../util/command-helpers.rkt" extract-cmd-args)
          (only-in "../../util/command-types.rkt" shared-command shared-command?))
 
-(provide (struct-out parsed-gsd-command)
-         (struct-out gsd-cmd-go)
-         (struct-out gsd-cmd-plan)
-         (struct-out gsd-cmd-skip)
-         (struct-out gsd-cmd-done)
-         (struct-out gsd-cmd-status)
-         (struct-out gsd-cmd-replan)
-         (struct-out gsd-cmd-reset)
-         (struct-out gsd-cmd-wave-done)
-         (struct-out gsd-cmd-artifact)
-         (struct-out gsd-command-spec)
+(provide parsed-gsd-command
          parsed-gsd-command?
+         parsed-gsd-command-canonical-name
+         parsed-gsd-command-args
+         gsd-cmd-go
+         gsd-cmd-go?
+         gsd-cmd-go-wave-arg
+         gsd-cmd-plan
+         gsd-cmd-plan?
+         gsd-cmd-plan-plan-text
+         gsd-cmd-skip
+         gsd-cmd-skip?
+         gsd-cmd-skip-skip-arg
+         gsd-cmd-done
+         gsd-cmd-done?
+         gsd-cmd-done-force?
+         gsd-cmd-status
+         gsd-cmd-status?
+         gsd-cmd-replan
+         gsd-cmd-replan?
+         gsd-cmd-reset
+         gsd-cmd-reset?
+         gsd-cmd-wave-done
+         gsd-cmd-wave-done?
+         gsd-cmd-wave-done-wave-arg
+         gsd-cmd-artifact
+         gsd-cmd-artifact?
+         gsd-cmd-artifact-artifact-name
+         gsd-command-spec
+         gsd-command-spec?
+         gsd-command-spec-canonical
+         gsd-command-spec-description
+         gsd-command-spec-aliases
          parse-gsd-command
          gsd-command-specs
          aliases-for)

--- a/extensions/gsd/command-types.rkt
+++ b/extensions/gsd/command-types.rkt
@@ -6,13 +6,14 @@
 ;; Replaces ad-hoc hasheq responses from GSD command handlers with
 ;; a proper struct. All command handlers return gsd-command-result.
 
-(provide (struct-out gsd-command-result)
-         gsd-ok
-         gsd-err
+(provide gsd-command-result
+         gsd-command-result?
          gsd-command-result-success
          gsd-command-result-mode
          gsd-command-result-message
          gsd-command-result-data
+         gsd-ok
+         gsd-err
          gsd-result?
          gsd-success?
          gsd-failed?)
@@ -20,10 +21,10 @@
 ;; Structured command result replacing ad-hoc hasheq responses.
 ;; NOTE: For new code, prefer shared command-result from util/command-types.rkt (F14).
 (struct gsd-command-result
-        (success    ; boolean
-         mode       ; symbol (current GSD state after command)
-         message    ; string (human-readable)
-         data)      ; any — optional extra (wave index, archive path, etc.)
+        (success ; boolean
+         mode ; symbol (current GSD state after command)
+         message ; string (human-readable)
+         data) ; any — optional extra (wave index, archive path, etc.)
   #:transparent)
 
 ;; Constructor for successful results
@@ -40,10 +41,8 @@
 
 ;; Was the command successful?
 (define (gsd-success? r)
-  (and (gsd-command-result? r)
-       (gsd-command-result-success r)))
+  (and (gsd-command-result? r) (gsd-command-result-success r)))
 
 ;; Did the command fail?
 (define (gsd-failed? r)
-  (and (gsd-command-result? r)
-       (not (gsd-command-result-success r))))
+  (and (gsd-command-result? r) (not (gsd-command-result-success r))))

--- a/extensions/gsd/runtime-state-types.rkt
+++ b/extensions/gsd/runtime-state-types.rkt
@@ -9,7 +9,17 @@
 
 (require racket/set)
 
-(provide (struct-out gsd-runtime-state)
+(provide gsd-runtime-state
+         gsd-runtime-state?
+         gsd-runtime-state-mode
+         gsd-runtime-state-total-waves
+         gsd-runtime-state-current-wave
+         gsd-runtime-state-completed-waves
+         gsd-runtime-state-wave-executor
+         gsd-runtime-state-plan-path
+         gsd-runtime-state-pinned-dir
+         gsd-runtime-state-edit-limit
+         gsd-runtime-state-transition-history
          make-initial-gsd-state)
 
 ;; Single canonical runtime state aggregate (F1 fix).

--- a/extensions/gsd/state-machine.rkt
+++ b/extensions/gsd/state-machine.rkt
@@ -37,7 +37,17 @@
 (provide gsm-state?
          GSD-STATES
          ;; Runtime state struct
-         (struct-out gsd-runtime-state)
+         gsd-runtime-state
+         gsd-runtime-state?
+         gsd-runtime-state-mode
+         gsd-runtime-state-total-waves
+         gsd-runtime-state-current-wave
+         gsd-runtime-state-completed-waves
+         gsd-runtime-state-wave-executor
+         gsd-runtime-state-plan-path
+         gsd-runtime-state-pinned-dir
+         gsd-runtime-state-edit-limit
+         gsd-runtime-state-transition-history
          make-initial-gsd-state
          ;; Current state query
          gsm-current


### PR DESCRIPTION
Addresses #4690.

refactor: replace struct-out with explicit exports in GSD command and state types (#4690)