### PR TITLE
refactor: add contract coverage and replace struct-out in runtime modules (#4695)

### DIFF
--- a/runtime/auto-retry.rkt
+++ b/runtime/auto-retry.rkt
@@ -5,7 +5,8 @@
 ;;; Provides retry logic for transient provider errors (429, 5xx, timeouts).
 ;;; Wraps a thunk with configurable retry attempts and exponential backoff.
 
-(require racket/match
+(require racket/contract
+         racket/match
          racket/string
          "../util/protocol-types.rkt"
          "../llm/provider-errors.rkt")
@@ -21,20 +22,52 @@
          ERROR-CLASSIFICATION-TABLE
          classify-error-from-table
          ;; Retry execution
-         with-auto-retry
+         (contract-out [with-auto-retry
+                        (->* (procedure?)
+                             (#:max-retries exact-nonnegative-integer?
+                                            #:base-delay-ms exact-nonnegative-integer?
+                                            #:rate-limit-base-delay-ms exact-nonnegative-integer?
+                                            #:max-delay-ms exact-nonnegative-integer?
+                                            #:on-retry (or/c procedure? #f)
+                                            #:per-type-budgets hash?)
+                             any/c)]
+                       [with-retry-policy
+                        (->* (any/c procedure?) (#:on-retry (or/c procedure? #f)) any/c)]
+                       [make-default-retry-policy
+                        (->* ()
+                             (#:max-retries exact-nonnegative-integer?
+                                            #:base-delay-ms exact-nonnegative-integer?
+                                            #:rate-limit-base-delay-ms exact-nonnegative-integer?
+                                            #:max-delay-ms exact-nonnegative-integer?
+                                            #:per-type-budgets hash?)
+                             any/c)])
          ;; Configuration
          default-max-retries
          default-base-delay-ms
          default-rate-limit-base-delay-ms
          default-max-delay-ms
          ;; Struct for retry stats
-         (struct-out retry-stats)
+         retry-stats
+         retry-stats?
+         retry-stats-attempts
+         retry-stats-final-delay-ms
+         retry-stats-succeeded?
          ;; Struct for retry exhaustion (A3)
-         (struct-out retry-exhausted)
+         retry-exhausted
+         retry-exhausted?
+         retry-exhausted-original-exn
+         retry-exhausted-attempts
+         retry-exhausted-last-error-type
+         retry-exhausted-total-delay-ms
+         retry-exhausted-error-history
          ;; Struct for retry policy (A21)
-         (struct-out retry-policy)
-         make-default-retry-policy
-         with-retry-policy)
+         retry-policy
+         retry-policy?
+         retry-policy-max-retries
+         retry-policy-base-delay-ms
+         retry-policy-rate-limit-base-delay-ms
+         retry-policy-max-delay-ms
+         retry-policy-per-type-budgets)
 
 ;; ============================================================
 ;; Configuration

--- a/runtime/iteration/loop-config.rkt
+++ b/runtime/iteration/loop-config.rkt
@@ -86,5 +86,40 @@
                working-set
                session))
 
-(provide (struct-out loop-config)
-         make-loop-config)
+(provide loop-config
+         loop-config?
+         loop-config-context
+         loop-config-provider
+         loop-config-bus
+         loop-config-registry
+         loop-config-ext-registry
+         loop-config-log-path
+         loop-config-session-id
+         loop-config-max-iterations
+         loop-config-cancellation-token
+         loop-config-config
+         loop-config-queue
+         loop-config-follow-up-delivery-mode
+         loop-config-injected-box
+         loop-config-shutdown-check
+         loop-config-force-shutdown-check
+         loop-config-working-set
+         loop-config-session
+         (contract-out [make-loop-config
+                        (->* ((listof any/c) (or/c any/c #f)
+                                             any/c
+                                             (or/c any/c #f)
+                                             (or/c any/c #f)
+                                             (or/c path-string? path?)
+                                             string?
+                                             exact-nonnegative-integer?)
+                             (#:cancellation-token (or/c any/c #f)
+                              #:config any/c
+                              #:queue (or/c any/c #f)
+                              #:follow-up-delivery-mode (or/c 'all 'one-at-a-time)
+                              #:injected-box (or/c box? #f)
+                              #:shutdown-check (or/c procedure? #f)
+                              #:force-shutdown-check (or/c procedure? #f)
+                              #:working-set (or/c any/c #f)
+                              #:session (or/c any/c #f))
+                             loop-config?)]))

--- a/runtime/session-types.rkt
+++ b/runtime/session-types.rkt
@@ -1,6 +1,8 @@
 #lang racket/base
 
 ;; runtime/session-types.rkt — agent-session struct definition
+
+(require racket/contract)
 ;; STABILITY: internal
 ;;
 ;; Extracted from agent-session.rkt (ARCH-05).
@@ -33,15 +35,49 @@
 ;; not sub-structs. See v0.32.6 TUI state decomposition for the
 ;; rationale (75 struct-copy callsites make nested structs worse).
 
-(provide (struct-out agent-session)
+(provide agent-session
+         agent-session?
+         agent-session-session-id
+         agent-session-session-dir
+         agent-session-provider
+         agent-session-tool-registry
+         agent-session-event-bus
+         agent-session-extension-registry
+         agent-session-model-name
+         agent-session-system-instructions
+         agent-session-index
+         agent-session-queue
+         agent-session-config
+         agent-session-active?
+         agent-session-start-time
+         agent-session-compacting?
+         agent-session-last-compaction-time
+         agent-session-persisted?
+         agent-session-pending-entries
+         agent-session-thinking-level
+         agent-session-shutdown-requested?
+         agent-session-force-shutdown?
+         agent-session-prompt-running?
+         set-agent-session-model-name!
+         set-agent-session-index!
+         set-agent-session-config!
+         set-agent-session-active?!
+         set-agent-session-start-time!
+         set-agent-session-compacting?!
+         set-agent-session-last-compaction-time!
+         set-agent-session-persisted?!
+         set-agent-session-pending-entries!
+         set-agent-session-thinking-level!
+         set-agent-session-shutdown-requested?!
+         set-agent-session-force-shutdown?!
+         set-agent-session-prompt-running?!
          session-log-path
          session-index-path
-         session-log-path-for
-         ;; Convenience accessors by group
-         session-provider
-         session-tool-registry
-         session-event-bus
-         session-extension-registry)
+         (contract-out [session-log-path-for (-> agent-session? path?)]
+                       [session-provider (-> agent-session? any/c)]
+                       [session-tool-registry (-> agent-session? any/c)]
+                       [session-event-bus (-> agent-session? any/c)]
+                       [session-extension-registry (-> agent-session? any/c)]))
 
 ;; ============================================================
 ;; agent-session struct

--- a/runtime/split-turn.rkt
+++ b/runtime/split-turn.rkt
@@ -23,7 +23,12 @@
          racket/string
          "../util/protocol-types.rkt")
 
-(provide (struct-out split-turn-result)
+(provide split-turn-result
+         split-turn-result?
+         split-turn-result-split-index
+         split-turn-result-turn-start-index
+         split-turn-result-turn-messages
+         split-turn-result-is-split?
          (contract-out
           [find-split-turn (-> (listof any/c) exact-nonnegative-integer? split-turn-result?)]
           [generate-turn-prefix (-> (listof any/c) string?)]


### PR DESCRIPTION
Addresses #4695.

refactor: add contract coverage and replace struct-out in runtime modules (#4695)