### PR TITLE
refactor: replace struct-out with explicit exports in scheduler, TUI, and palette (#4700)

### DIFF
--- a/tools/scheduler.rkt
+++ b/tools/scheduler.rkt
@@ -58,16 +58,50 @@
          (only-in "permission-gate.rkt" permission-config? tool-needs-approval? request-approval))
 
 ;; ── Result struct ──
-(provide (struct-out scheduler-result)
+(provide scheduler-result
+         scheduler-result?
+         scheduler-result-results
+         scheduler-result-metadata
          ;; R-15: Strategy support
-         (struct-out preflight-entry)
+         preflight-entry
+         preflight-entry?
+         preflight-entry-status
+         preflight-entry-tool-call
+         preflight-entry-tool
+         preflight-entry-error-message
          ;; v0.44.2: Planning structs
-         (struct-out scheduler-problem)
-         (struct-out scheduler-plan)
+         scheduler-problem
+         scheduler-problem?
+         scheduler-problem-calls
+         scheduler-problem-registry
+         scheduler-problem-strategy
+         scheduler-problem-hook-dispatcher
+         scheduler-problem-exec-context
+         scheduler-problem-parallel?
+         scheduler-plan
+         scheduler-plan?
+         scheduler-plan-entries
+         scheduler-plan-ordered-calls
+         scheduler-plan-execution-order
+         scheduler-plan-metadata
          ;; v0.44.2: Typed payloads
-         (struct-out tool-pre-hook-payload)
-         (struct-out tool-post-hook-payload)
-         (struct-out scheduler-batch-stats)
+         tool-pre-hook-payload
+         tool-pre-hook-payload?
+         tool-pre-hook-payload-tool-name
+         tool-pre-hook-payload-args
+         tool-pre-hook-payload-entry-id
+         tool-post-hook-payload
+         tool-post-hook-payload?
+         tool-post-hook-payload-tool-name
+         tool-post-hook-payload-result
+         tool-post-hook-payload-entry-id
+         tool-post-hook-payload-arguments
+         scheduler-batch-stats
+         scheduler-batch-stats?
+         scheduler-batch-stats-total
+         scheduler-batch-stats-executed
+         scheduler-batch-stats-blocked
+         scheduler-batch-stats-errors
          scheduler-batch-stats->hash
          plan-tool-batch
          execute-tool-plan

--- a/tui/builtins.rkt
+++ b/tui/builtins.rkt
@@ -27,7 +27,11 @@
          ;; SettingsList
          make-settings-list
          settings-entry
-         (struct-out settings-entry)
+         settings-entry?
+         settings-entry-key
+         settings-entry-label
+         settings-entry-value
+         settings-entry-type
 
          ;; Helpers
          filter-options

--- a/tui/component.rkt
+++ b/tui/component.rkt
@@ -18,31 +18,37 @@
          (only-in "render/message-layout.rkt" styled-line?))
 
 ;; Struct
-(provide (struct-out q-component)
-         (contract-out [make-q-component
-                        (->* (procedure?)
-                             (#:id symbol?
-                                   #:invalidate-fn procedure?
-                                   #:handle-input (or/c procedure? #f)
-                                   #:wants-focus? boolean?)
-                             q-component?)]
-                       [component-render (-> q-component? any/c exact-nonnegative-integer? any/c)]
-                       [component-invalidate! (-> q-component? void?)]
-                       [component-compose (-> any/c any/c any/c (listof styled-line?))]
-                       [component-cached-width (-> q-component? (or/c exact-nonnegative-integer? #f))]
-                       [component-handle-input (-> q-component? any/c any/c (values any/c any/c))]
-                       [input-consumed (-> any/c)]
-                       [input-bubble (-> any/c)]
-                       [input-action (-> any/c any/c)]
-                       [input-consumed? (-> any/c boolean?)]
-                       [input-bubble? (-> any/c boolean?)]
-                       [input-action? (-> any/c boolean?)]
-                       [input-action-data (-> any/c any/c)]
-                       [focusable-components (-> (listof q-component?) (listof q-component?))]
-                       [cycle-focus
-                        (->* ((listof q-component?) (or/c symbol? #f))
-                             (exact-integer?)
-                             (or/c symbol? #f))]))
+(provide q-component
+         q-component?
+         q-component-render-fn
+         q-component-invalidate-fn
+         q-component-cache-box
+         q-component-id
+         q-component-handle-input-fn
+         q-component-wants-focus?
+         (contract-out
+          [make-q-component
+           (->* (procedure?)
+                (#:id symbol?
+                      #:invalidate-fn procedure?
+                      #:handle-input (or/c procedure? #f)
+                      #:wants-focus? boolean?)
+                q-component?)]
+          [component-render (-> q-component? any/c exact-nonnegative-integer? any/c)]
+          [component-invalidate! (-> q-component? void?)]
+          [component-compose (-> any/c any/c any/c (listof styled-line?))]
+          [component-cached-width (-> q-component? (or/c exact-nonnegative-integer? #f))]
+          [component-handle-input (-> q-component? any/c any/c (values any/c any/c))]
+          [input-consumed (-> any/c)]
+          [input-bubble (-> any/c)]
+          [input-action (-> any/c any/c)]
+          [input-consumed? (-> any/c boolean?)]
+          [input-bubble? (-> any/c boolean?)]
+          [input-action? (-> any/c boolean?)]
+          [input-action-data (-> any/c any/c)]
+          [focusable-components (-> (listof q-component?) (listof q-component?))]
+          [cycle-focus
+           (->* ((listof q-component?) (or/c symbol? #f)) (exact-integer?) (or/c symbol? #f))]))
 
 ;; ═══════════════════════════════════════════════════════════════════
 ;; Struct

--- a/tui/input.rkt
+++ b/tui/input.rkt
@@ -21,7 +21,17 @@
 ;; input-state is used with struct-copy in many consumers (tests + sub-modules),
 ;; so we keep struct-out for it.  mouse-event is not used with struct-copy,
 ;; so we export it via contract-out.
-(provide (struct-out input-state)
+(provide input-state
+         input-state?
+         input-state-buffer
+         input-state-cursor
+         input-state-history
+         input-state-history-idx
+         input-state-saved-text
+         input-state-scroll-offset
+         input-state-undo-stack
+         input-state-redo-stack
+         input-state-kill-ring
          (contract-out
           [mouse-event? (-> any/c boolean?)]
           [mouse-event (->* (symbol? exact-integer? exact-integer? exact-integer?) () mouse-event?)]

--- a/tui/palette.rkt
+++ b/tui/palette.rkt
@@ -10,7 +10,13 @@
          "render.rkt"
          "../util/command-types.rkt")
 
-(provide (struct-out cmd-entry)
+(provide cmd-entry
+         cmd-entry?
+         cmd-entry-name
+         cmd-entry-summary
+         cmd-entry-category
+         cmd-entry-args-spec
+         cmd-entry-aliases
          make-command-registry
          register-command!
          lookup-command


### PR DESCRIPTION
Addresses #4700.

refactor: replace struct-out with explicit exports in scheduler, TUI, and palette (#4700)