### PR TITLE
refactor: replace struct-out with explicit exports in runtime/core modules (#4715)

### DIFF
--- a/runtime/context-assembly.rkt
+++ b/runtime/context-assembly.rkt
@@ -62,7 +62,16 @@
          build-assembled-context/raw
          build-assembled-context/v2
          build-session-context
-         (struct-out context-assembly-call-options)
+         context-assembly-call-options
+         context-assembly-call-options?
+         context-assembly-call-options-cache
+         context-assembly-call-options-provider
+         context-assembly-call-options-model-name
+         context-assembly-call-options-trace-callback
+         context-assembly-call-options-working-set
+         context-assembly-call-options-generate-summary-proc
+         context-assembly-call-options-generate-catalog-proc
+         context-assembly-call-options-estimate-text-proc
          make-context-assembly-call-options
          tiered-context
          tiered-context?

--- a/runtime/context-assembly/selection.rkt
+++ b/runtime/context-assembly/selection.rkt
@@ -66,7 +66,16 @@
                                  catalog-proc
                                  estimate-proc))
 
-(provide (struct-out context-assembly-call-options)
+(provide context-assembly-call-options
+         context-assembly-call-options?
+         context-assembly-call-options-cache
+         context-assembly-call-options-provider
+         context-assembly-call-options-model-name
+         context-assembly-call-options-trace-callback
+         context-assembly-call-options-working-set
+         context-assembly-call-options-generate-summary-proc
+         context-assembly-call-options-generate-catalog-proc
+         context-assembly-call-options-estimate-text-proc
          make-context-assembly-call-options
          build-assembled-context
          build-assembled-context/raw

--- a/runtime/context-summary.rkt
+++ b/runtime/context-summary.rkt
@@ -17,8 +17,17 @@
          (only-in "../llm/provider.rkt" provider?))
 
 ;; Summary cache
-(provide (struct-out catalog-entry)
-         (struct-out context-summary)
+(provide catalog-entry
+         catalog-entry?
+         catalog-entry-id
+         catalog-entry-role
+         catalog-entry-summary
+         context-summary
+         context-summary?
+         context-summary-from-id
+         context-summary-to-id
+         context-summary-text
+         context-summary-entry-count
          summary-cache?
          summary-cache-table
          summary-cache-order

--- a/runtime/credential-backend.rkt
+++ b/runtime/credential-backend.rkt
@@ -22,7 +22,14 @@
          racket/port)
 
 ;; Backend struct
-(provide (struct-out credential-backend)
+(provide credential-backend
+         credential-backend?
+         credential-backend-name
+         credential-backend-store-fn
+         credential-backend-load-fn
+         credential-backend-delete-fn
+         credential-backend-list-fn
+         credential-backend-available?-fn
          (contract-out
           [make-file-credential-backend (->* () ((or/c path-string? #f)) credential-backend?)]
           [make-env-credential-backend (-> credential-backend?)]
@@ -348,8 +355,6 @@
 ;; ═══════════════════════════════════════════════════════════════════
 ;; Helpers
 ;; ═══════════════════════════════════════════════════════════════════
-
-
 
 (define (shell-escape s)
   (string-replace s "'" "'\\''"))

--- a/runtime/ctx-compact.rkt
+++ b/runtime/ctx-compact.rkt
@@ -20,7 +20,12 @@
          "../util/protocol-types.rkt")
 
 ;; Compact request struct
-(provide (struct-out ctx-compact-request)
+(provide ctx-compact-request
+         ctx-compact-request?
+         ctx-compact-request-instructions
+         ctx-compact-request-on-complete
+         ctx-compact-request-on-error
+         ctx-compact-request-requested-at
          ctx-compact?
 
          ;; Main API

--- a/runtime/package.rkt
+++ b/runtime/package.rkt
@@ -20,7 +20,11 @@
 ;; Provides
 ;; ============================================================
 
-(provide (struct-out qpm-package)
+(provide qpm-package
+         qpm-package?
+         qpm-package-manifest
+         qpm-package-install-dir
+         qpm-package-status
          (contract-out [current-packages-dir (parameter/c path?)]
                        [list-packages (-> (listof qpm-package?))]
                        [package-installed? (-> string? boolean?)]

--- a/runtime/settings.rkt
+++ b/runtime/settings.rkt
@@ -30,7 +30,11 @@
                   sandbox-max-processes))
 
 ;; Structs
-(provide (struct-out q-settings)
+(provide q-settings
+         q-settings?
+         q-settings-global
+         q-settings-project
+         q-settings-merged
 
          ;; Loading — contracted
          (contract-out [load-settings

--- a/runtime/token-compaction.rkt
+++ b/runtime/token-compaction.rkt
@@ -21,7 +21,11 @@
          "../llm/token-budget.rkt"
          "context-policy.rkt")
 
-(provide (struct-out token-compaction-config)
+(provide token-compaction-config
+         token-compaction-config?
+         token-compaction-config-keep-recent-tokens
+         token-compaction-config-reserve-tokens
+         token-compaction-config-max-context-tokens
          (contract-out
           [build-token-summary-window
            (-> (listof any/c) token-compaction-config? (values (listof any/c) (listof any/c)))]

--- a/runtime/tool-coordinator.rkt
+++ b/runtime/tool-coordinator.rkt
@@ -91,7 +91,11 @@
          build-blocked-tool-results)
 
 ;; v0.31.5 W1: export struct
-(provide (struct-out tool-call-actions))
+(provide tool-call-actions
+         tool-call-actions?
+         tool-call-actions-calls-to-run
+         tool-call-actions-blocked?
+         tool-call-actions-final-calls)
 
 ;; ============================================================
 ;; Helpers (QUAL-01: emit-session-event! and maybe-dispatch-hooks


### PR DESCRIPTION
Addresses #4715.

refactor: replace struct-out with explicit exports in runtime/core modules (#4715)