### PR TITLE
refactor: replace struct-out with explicit exports in runtime/complex + iteration (#4718)

### DIFF
--- a/runtime/compactor.rkt
+++ b/runtime/compactor.rkt
@@ -45,8 +45,15 @@
                   split-turn-result-turn-messages
                   generate-turn-prefix))
 
-(provide (struct-out compaction-strategy)
-         (struct-out compaction-result)
+(provide compaction-strategy
+         compaction-strategy?
+         compaction-strategy-summary-window-size
+         compaction-strategy-keep-recent-count
+         compaction-result
+         compaction-result?
+         compaction-result-summary-message
+         compaction-result-removed-count
+         compaction-result-kept-messages
          ;; H-02: Contract-wrapped compaction functions
          (contract-out [compact-history
                         (->* (list?)

--- a/runtime/iteration/decision.rkt
+++ b/runtime/iteration/decision.rkt
@@ -39,7 +39,13 @@
 
 (define step-action? (or/c 'continue 'stop 'stop-hard-limit 'stop-soft-limit))
 
-(provide (struct-out iteration-ctx)
+(provide iteration-ctx
+         iteration-ctx?
+         iteration-ctx-iteration
+         iteration-ctx-consecutive-tool-count
+         iteration-ctx-explore-count
+         iteration-ctx-max-iterations
+         iteration-ctx-max-iterations-hard
          (contract-out (struct step-result
                                ([action (or/c 'continue 'stop 'stop-hard-limit 'stop-soft-limit)]
                                 [termination (or/c symbol? #f)]

--- a/runtime/iteration/directive.rkt
+++ b/runtime/iteration/directive.rkt
@@ -9,9 +9,20 @@
 ;; directive-stop    : terminal, return loop-result
 ;; directive-yield   : events produced, continue (for future use)
 
-(provide (struct-out directive-recurse)
-         (struct-out directive-stop)
-         (struct-out directive-yield)
+(provide directive-recurse
+         directive-recurse?
+         directive-recurse-new-ctx
+         directive-recurse-new-counters
+         directive-recurse-ws
+         directive-stop
+         directive-stop?
+         directive-stop-result
+         directive-yield
+         directive-yield?
+         directive-yield-events
+         directive-yield-new-ctx
+         directive-yield-new-counters
+         directive-yield-ws
          step-directive?)
 
 (struct directive-recurse (new-ctx new-counters ws) #:transparent)

--- a/runtime/iteration/effect-executor.rkt
+++ b/runtime/iteration/effect-executor.rkt
@@ -16,8 +16,13 @@
          (only-in "../../runtime/runtime-helpers.rkt" emit-session-event!)
          (only-in "../../runtime/session-store.rkt" append-entries!))
 
-(provide (struct-out step-effect:append-entries)
-         (struct-out step-effect:emit-event)
+(provide step-effect:append-entries
+         step-effect:append-entries?
+         step-effect:append-entries-entries
+         step-effect:emit-event
+         step-effect:emit-event?
+         step-effect:emit-event-name
+         step-effect:emit-event-payload
          step-effect?
          run-step-effects!)
 

--- a/runtime/oauth.rkt
+++ b/runtime/oauth.rkt
@@ -16,9 +16,22 @@
          net/uri-codec)
 
 ;; OAuth config struct
-(provide (struct-out oauth-config)
+(provide oauth-config
+         oauth-config?
+         oauth-config-authorize-url
+         oauth-config-token-url
+         oauth-config-client-id
+         oauth-config-client-secret
+         oauth-config-scopes
+         oauth-config-redirect-port
          ;; OAuth token struct
-         (struct-out oauth-token)
+         oauth-token
+         oauth-token?
+         oauth-token-access-token
+         oauth-token-refresh-token
+         oauth-token-expires-at
+         oauth-token-token-type
+         oauth-token-scope
          ;; Feature availability predicate
          oauth-available?
          ;; Predicates / validation

--- a/runtime/provider-registry.rkt
+++ b/runtime/provider-registry.rkt
@@ -39,8 +39,20 @@
           [provider-summary (-> provider-registry? string? (or/c hash? #f))])
          provider-registry?
          ;; Model info struct
-         (struct-out provider-info)
-         (struct-out registered-model))
+         provider-info
+         provider-info?
+         provider-info-name
+         provider-info-provider
+         provider-info-config
+         provider-info-registered-at
+         registered-model
+         registered-model?
+         registered-model-id
+         registered-model-name
+         registered-model-provider-name
+         registered-model-context-window
+         registered-model-max-tokens
+         registered-model-capabilities)
 
 ;; ============================================================
 ;; Structs


### PR DESCRIPTION
Addresses #4718.

refactor: replace struct-out with explicit exports in runtime/complex + iteration (#4718)