### PR TITLE
refactor: replace struct-out with explicit exports in TUI modules (#4721)

### DIFF
--- a/tui/builtins.rkt
+++ b/tui/builtins.rkt
@@ -18,7 +18,6 @@
 ;; SelectList
 (provide make-select-list
          select-list-state
-         (struct-out select-list-state)
 
          ;; BorderedLoader
          make-bordered-loader

--- a/tui/frame-diff.rkt
+++ b/tui/frame-diff.rkt
@@ -2,7 +2,11 @@
 
 (require racket/list)
 
-(provide (struct-out diff-cmd)
+(provide diff-cmd
+         diff-cmd?
+         diff-cmd-type
+         diff-cmd-row
+         diff-cmd-content
          diff-frames
          frame->string-lines)
 
@@ -66,6 +70,5 @@
                      #:when (not (string=? p c)))
             (diff-cmd 'write i c)))
         ;; Clear rows from curr-len to prev-len-1
-        (define cleared
-          (list (diff-cmd 'clear-from curr-len #f)))
+        (define cleared (list (diff-cmd 'clear-from curr-len #f)))
         (append common-diffs cleared)])]))

--- a/tui/input/state-types.rkt
+++ b/tui/input/state-types.rkt
@@ -10,8 +10,23 @@
          "../char-width.rkt"
          "../terminal.rkt")
 
-(provide (struct-out input-state)
-         (struct-out mouse-event)
+(provide input-state
+         input-state?
+         input-state-buffer
+         input-state-cursor
+         input-state-history
+         input-state-history-idx
+         input-state-saved-text
+         input-state-scroll-offset
+         input-state-undo-stack
+         input-state-redo-stack
+         input-state-kill-ring
+         mouse-event
+         mouse-event?
+         mouse-event-type
+         mouse-event-button
+         mouse-event-x
+         mouse-event-y
 
          ;; Constructor
          initial-input-state

--- a/tui/layout.rkt
+++ b/tui/layout.rkt
@@ -10,7 +10,15 @@
          compute-layout-with-widgets
 
          ;; Layout struct
-         (struct-out tui-layout))
+         tui-layout
+         tui-layout?
+         tui-layout-cols
+         tui-layout-rows
+         tui-layout-header-row
+         tui-layout-transcript-start-row
+         tui-layout-transcript-height
+         tui-layout-status-row
+         tui-layout-input-row)
 
 ;; Screen layout: where each panel starts and how tall it is
 (struct tui-layout

--- a/tui/render.rkt
+++ b/tui/render.rkt
@@ -11,8 +11,13 @@
          "render/status-line.rkt"
          "render/diff-render.rkt")
 
-(provide (struct-out styled-line)
-         (struct-out styled-segment)
+(provide styled-line
+         styled-line?
+         styled-line-segments
+         styled-segment
+         styled-segment?
+         styled-segment-text
+         styled-segment-style
 
          ;; From message-layout
          plain-line

--- a/tui/render/message-layout.rkt
+++ b/tui/render/message-layout.rkt
@@ -16,8 +16,13 @@
          (only-in "../../util/markdown.rkt" md-token-content md-token-type)
          "../../extensions/custom-renderer-registry.rkt")
 
-(provide (struct-out styled-line)
-         (struct-out styled-segment)
+(provide styled-line
+         styled-line?
+         styled-line-segments
+         styled-segment
+         styled-segment?
+         styled-segment-text
+         styled-segment-style
          plain-line
          theme->style
          format-entry

--- a/tui/state-types.rkt
+++ b/tui/state-types.rkt
@@ -15,11 +15,61 @@
 
 ;; Structs that need struct-copy support in consumers must use struct-out.
 ;; We add contracts on functions only.
-(provide (struct-out transcript-entry)
-         (struct-out ui-state)
-         (struct-out streaming-state)
-         (struct-out overlay-state)
-         (struct-out branch-info)
+(provide transcript-entry
+         transcript-entry?
+         transcript-entry-kind
+         transcript-entry-text
+         transcript-entry-timestamp
+         transcript-entry-meta
+         transcript-entry-id
+         ui-state
+         ui-state?
+         ui-state-transcript
+         ui-state-scroll-offset
+         ui-state-session-id
+         ui-state-model-name
+         ui-state-mode
+         ui-state-streaming
+         ui-state-current-branch
+         ui-state-visible-branches
+         ui-state-selection
+         ui-state-cache
+         ui-state-next-entry-id
+         ui-state-active-overlay
+         ui-state-queue-counts
+         ui-state-extension-widgets
+         ui-state-custom-header
+         ui-state-custom-footer
+         ui-state-mock-provider?
+         ui-state-focused-component
+         ui-state-editor-component
+         ui-state-context-tokens
+         ui-state-cost-tracker
+         streaming-state
+         streaming-state?
+         streaming-state-busy?
+         streaming-state-status-message
+         streaming-state-pending-tool-name
+         streaming-state-streaming-text
+         streaming-state-streaming-thinking
+         streaming-state-busy-since
+         overlay-state
+         overlay-state?
+         overlay-state-type
+         overlay-state-content
+         overlay-state-input
+         overlay-state-anchor
+         overlay-state-width
+         overlay-state-height
+         overlay-state-margin
+         overlay-state-extra
+         branch-info
+         branch-info?
+         branch-info-id
+         branch-info-parent-id
+         branch-info-role
+         branch-info-leaf?
+         branch-info-active?
 
          ;; These structs are not used with struct-copy externally,
          ;; so we export via contract-out for stronger guarantees.

--- a/tui/state-ui.rkt
+++ b/tui/state-ui.rkt
@@ -40,8 +40,12 @@
          anchor?
 
          ;; Overlay config (#1145)
-         (struct-out overlay-config)
+         overlay-config
          overlay-config?
+         overlay-config-anchor
+         overlay-config-width-spec
+         overlay-config-height-spec
+         overlay-config-margin
          make-overlay-config
          show-overlay-with-config
          overlay-compute-bounds
@@ -124,13 +128,17 @@
   (struct-copy ui-state state [selection (selection-state (cons col row) (cons col row))]))
 
 (define (set-selection-end state col row)
-  (struct-copy ui-state state [selection (selection-state (selection-state-anchor (ui-state-selection state)) (cons col row))]))
+  (struct-copy
+   ui-state
+   state
+   [selection (selection-state (selection-state-anchor (ui-state-selection state)) (cons col row))]))
 
 (define (clear-selection state)
   (struct-copy ui-state state [selection (selection-state #f #f)]))
 
 (define (has-selection? state)
-  (and (selection-state-anchor (ui-state-selection state)) (selection-state-end (ui-state-selection state))))
+  (and (selection-state-anchor (ui-state-selection state))
+       (selection-state-end (ui-state-selection state))))
 
 ;; ============================================================
 ;; Queries

--- a/tui/state.rkt
+++ b/tui/state.rkt
@@ -37,8 +37,12 @@
          ANCHOR-CENTER
          ANCHOR-BOTTOM-RIGHT
          anchor?
-         (struct-out overlay-config)
+         overlay-config
          overlay-config?
+         overlay-config-anchor
+         overlay-config-width-spec
+         overlay-config-height-spec
+         overlay-config-margin
          make-overlay-config
          show-overlay-with-config
          overlay-compute-bounds

--- a/tui/tui-keybindings.rkt
+++ b/tui/tui-keybindings.rkt
@@ -38,7 +38,24 @@
          "keybindings/mode-map.rkt")
 
 ;; ── tui-ctx struct ──
-(provide (struct-out tui-ctx)
+(provide tui-ctx
+         tui-ctx?
+         tui-ctx-ui-state-box
+         tui-ctx-input-state-box
+         tui-ctx-event-bus
+         tui-ctx-session-runner
+         tui-ctx-running-box
+         tui-ctx-event-ch
+         tui-ctx-session-dir
+         tui-ctx-needs-redraw-box
+         tui-ctx-term-box
+         tui-ctx-ubuf-box
+         tui-ctx-model-registry-box
+         tui-ctx-previous-frame-box
+         tui-ctx-last-prompt-box
+         tui-ctx-extension-registry-box
+         tui-ctx-session-queue-box
+         tui-ctx-session-factory-runner
          ;; Re-exports (no contract needed — re-exported from other modules)
          copy-text!
          copy-selection!


### PR DESCRIPTION
Addresses #4721.

refactor: replace struct-out with explicit exports in TUI modules (#4721)