### PR TITLE
refactor: replace struct-out with explicit exports in remaining safe files (#4724)

### DIFF
--- a/interfaces/doctor.rkt
+++ b/interfaces/doctor.rkt
@@ -25,7 +25,11 @@
          "../util/config-paths.rkt")
 
 ;; Struct
-(provide (struct-out check-result)
+(provide check-result
+         check-result?
+         check-result-name
+         check-result-status
+         check-result-message
 
          ;; Main entry
          run-doctor

--- a/interfaces/json-mode.rkt
+++ b/interfaces/json-mode.rkt
@@ -6,7 +6,10 @@
          "../util/protocol-types.rkt"
          "../agent/event-bus.rkt")
 
-(provide (struct-out intent)
+(provide intent
+         intent?
+         intent-type
+         intent-payload
          (contract-out [start-json-mode!
                         (->* (any/c #:session-id string?)
                              (#:output-port (or/c output-port? #f))

--- a/interfaces/rpc-mode.rkt
+++ b/interfaces/rpc-mode.rkt
@@ -20,9 +20,20 @@
 ;; Notification: {"jsonrpc": "2.0", "method": "...", "params": {...}}
 
 ;; Structs
-(provide (struct-out rpc-request)
-         (struct-out rpc-response)
-         (struct-out rpc-notification)
+(provide rpc-request
+         rpc-request?
+         rpc-request-id
+         rpc-request-method
+         rpc-request-params
+         rpc-response
+         rpc-response?
+         rpc-response-id
+         rpc-response-result
+         rpc-response-error
+         rpc-notification
+         rpc-notification?
+         rpc-notification-method
+         rpc-notification-params
 
          ;; Parsing
          parse-rpc-request

--- a/interfaces/tui.rkt
+++ b/interfaces/tui.rkt
@@ -16,7 +16,24 @@
 
          ;; ── from tui-keybindings.rkt (struct + make) ──
          make-tui-ctx
-         (struct-out tui-ctx)
+         tui-ctx
+         tui-ctx?
+         tui-ctx-ui-state-box
+         tui-ctx-input-state-box
+         tui-ctx-event-bus
+         tui-ctx-session-runner
+         tui-ctx-running-box
+         tui-ctx-event-ch
+         tui-ctx-session-dir
+         tui-ctx-needs-redraw-box
+         tui-ctx-term-box
+         tui-ctx-ubuf-box
+         tui-ctx-model-registry-box
+         tui-ctx-previous-frame-box
+         tui-ctx-last-prompt-box
+         tui-ctx-extension-registry-box
+         tui-ctx-session-queue-box
+         tui-ctx-session-factory-runner
 
          ;; ── from tui-keybindings.rkt (key/mouse/selection/commands) ──
          handle-key

--- a/runtime/compactor.rkt
+++ b/runtime/compactor.rkt
@@ -51,6 +51,7 @@
          compaction-strategy-keep-recent-count
          compaction-result
          compaction-result?
+         struct:compaction-result
          compaction-result-summary-message
          compaction-result-removed-count
          compaction-result-kept-messages

--- a/util/extensions.rkt
+++ b/util/extensions.rkt
@@ -10,7 +10,12 @@
 ;; The extension registry (extension-registry, register-extension!, etc.)
 ;; remains in extensions/api.rkt.
 
-(provide (struct-out extension))
+(provide extension
+         extension?
+         extension-name
+         extension-version
+         extension-api-version
+         extension-hooks)
 
 ;; ============================================================
 ;; Extension struct


### PR DESCRIPTION
Addresses #4724.

refactor: replace struct-out with explicit exports in remaining safe files (#4724)