### PR TITLE
fix: restore session-index-entry-order to contract-out exports (#4736)

### DIFF
--- a/runtime/session-index.rkt
+++ b/runtime/session-index.rkt
@@ -48,4 +48,5 @@
                        [collect-branch-entries
                         (-> session-index? string? string? exact-nonnegative-integer? list?)]
                        [leaf-depth (-> session-index? string? (or/c exact-nonnegative-integer? #f))]
-                       [estimate-entry-tokens (-> any/c exact-nonnegative-integer?)]))
+                       [estimate-entry-tokens (-> any/c exact-nonnegative-integer?)]
+                       [session-index-entry-order (-> session-index? vector?)]))


### PR DESCRIPTION
Addresses #4736.

fix: restore session-index-entry-order to contract-out exports (#4736)