### PR TITLE
fix: critical regressions + KPI gate updates (#4743)

RC1: Restore session-index struct exports via all-from-out
RC3: Fix sm-fork!/in-memory-fork! contracts (void? → any/c)
H1: Update KPI gates struct-out 99→55, contract 28%→35%

### DIFF
--- a/runtime/session-index.rkt
+++ b/runtime/session-index.rkt
@@ -10,13 +10,8 @@
          "session-index/mutations.rkt"
          "session-index/query.rkt")
 
-(provide (contract-out [session-index? (-> any/c boolean?)]
-                       [bookmark? (-> any/c boolean?)]
-                       [navigate-result? (-> any/c boolean?)]
-                       [make-bookmark
-                        (-> string? string? string? exact-nonnegative-integer? bookmark?)]
-                       [make-empty-index (-> session-index?)]
-                       [build-index! (-> path-string? path-string? session-index?)]
+(provide (all-from-out "session-index/schema.rkt")
+         (contract-out [build-index! (-> path-string? path-string? session-index?)]
                        [load-index (-> path-string? session-index?)]
                        [save-index! (-> path-string? session-index? void?)]
                        [switch-leaf! (-> session-index? string? (or/c string? #f))]
@@ -48,5 +43,4 @@
                        [collect-branch-entries
                         (-> session-index? string? string? exact-nonnegative-integer? list?)]
                        [leaf-depth (-> session-index? string? (or/c exact-nonnegative-integer? #f))]
-                       [estimate-entry-tokens (-> any/c exact-nonnegative-integer?)]
-                       [session-index-entry-order (-> session-index? vector?)]))
+                       [estimate-entry-tokens (-> any/c exact-nonnegative-integer?)]))

--- a/runtime/session-manager.rkt
+++ b/runtime/session-manager.rkt
@@ -28,13 +28,13 @@
                        [sm-append! (-> any/c string? any/c void?)]
                        [sm-load (-> any/c string? (listof any/c))]
                        [sm-list (-> any/c (listof string?))]
-                       [sm-fork! (->* (any/c string? string?) (string?) void?)]
+                       [sm-fork! (->* (any/c string? string?) (string?) any/c)]
                        ;; Re-export in-memory operations for backward compat
                        [in-memory-append! (-> any/c string? any/c void?)]
                        [in-memory-append-entries! (-> any/c string? (listof any/c) void?)]
                        [in-memory-load (-> any/c string? (listof any/c))]
                        [in-memory-list-sessions (-> any/c (listof string?))]
-                       [in-memory-fork! (->* (any/c string? string?) (string?) void?)]))
+                       [in-memory-fork! (->* (any/c string? string?) (string?) any/c)]))
 
 ;; ============================================================
 ;; Persistent session manager — wraps file-backed session-store

--- a/tests/test-arch-fitness.rkt
+++ b/tests/test-arch-fitness.rkt
@@ -450,9 +450,9 @@
 ;; ════════════════════════════════════════════════════════════
 
 (define v0480-suite
-  (test-suite "v0.48.0-kpi-gates"
+  (test-suite "v0.49.10-kpi-gates"
 
-    (test-case "KPI: struct-out non-regression (v0.48.0 floor, v0.48.x target tracked)"
+    (test-case "KPI: struct-out non-regression (v0.49.10 floor, v0.50.x target tracked)"
       (define dirs-to-check
         '("runtime" "agent"
                     "llm"
@@ -470,11 +470,11 @@
       (define total-struct-out
         (for/sum ([f (in-list all-files)])
                  (length (regexp-match* #rx"\\(struct-out\\s+" (file->string f)))))
-      (check-true (<= total-struct-out 99)
-                  (format "struct-out count is ~a (v0.49.0 floor <= 99; v0.49.x target <= 60)"
+      (check-true (<= total-struct-out 55)
+                  (format "struct-out count is ~a (v0.49.10 floor <= 55; v0.50.x target <= 40)"
                           total-struct-out)))
 
-    (test-case "KPI: contract-out coverage non-regression (v0.48.0 floor, v0.48.x target tracked)"
+    (test-case "KPI: contract-out coverage non-regression (v0.49.10 floor, v0.50.x target tracked)"
       (define dirs-to-check
         '("runtime" "agent"
                     "llm"
@@ -497,9 +497,9 @@
             0
             (* 100.0 (/ files-with-contract-out (length all-files)))))
       (check-true
-       (>= coverage 28.0)
+       (>= coverage 35.0)
        (format
-        "contract-out coverage is ~a% (v0.49.0 floor >= 28.0%; v0.49.x target >= 45%) [~a/~a files]"
+        "contract-out coverage is ~a% (v0.49.10 floor >= 35.0%; v0.50.x target >= 45%) [~a/~a files]"
         (real->decimal-string coverage 2)
         files-with-contract-out
         (length all-files))))))


### PR DESCRIPTION
Addresses #4743.

fix: critical regressions + KPI gate updates (#4743)

RC1: Restore session-index struct exports via all-from-out
RC3: Fix sm-fork!/in-memory-fork! contracts (void? → any/c)
H1: Update KPI gates struct-out 99→55, contract 28%→35%