### PR TITLE
refactor: add contract-out to 18 runtime/ files (#4747)

Add contract-out to runtime/ files: session-context, iteration/directive,
runtime-helpers, context-pinning, session-mutation, summary-entities,
trace-sink, session-events, session-fsm, project-tree, session-index/query,
iteration/counters, compaction-prompts, context-assembly (facade),
session-metadata, session-migration, session-store-tree, compaction-hooks.

Key fixes:
- directive.rkt: Keep struct constructors outside contract-out (needed for match)
- compaction-hooks.rkt: Fix return contracts (void? → any/c)
- runtime-helpers.rkt: Keep re-exports outside contract-out

contract-out coverage: 106→124 files (30.2%→35.3%)
struct-out: 34 (unchanged)
arch-fitness: 33/33 passing

### DIFF
--- a/runtime/compaction-hooks.rkt
+++ b/runtime/compaction-hooks.rkt
@@ -23,19 +23,27 @@
          "split-turn.rkt"
          "token-compaction.rkt")
 
-(provide
- ;; #697: Enriched hook
- build-enriched-compact-payload
- dispatch-enriched-before-compact
- maybe-use-custom-summary
- ;; #698: Compaction events
- publish-compaction-start!
- publish-compaction-end!
- compaction-start-topic
- compaction-end-topic
- ;; Event construction helpers
- make-compaction-start-event
- make-compaction-end-event)
+(provide (contract-out
+          ;; #697: Enriched hook
+          [build-enriched-compact-payload
+           (->* (list? any/c) (#:previous-summary (or/c #f string?) #:session-id string?) hash?)]
+          [dispatch-enriched-before-compact
+           (->* (any/c list? any/c)
+                (#:previous-summary (or/c #f string?) #:session-id string?)
+                (values any/c hash?))]
+          [maybe-use-custom-summary (-> any/c (or/c string? #f))]
+          ;; #698: Compaction events
+          [publish-compaction-start! (-> any/c any/c any/c any/c string? string? any/c)]
+          [publish-compaction-end!
+           (->* (any/c any/c any/c any/c any/c string? string?)
+                (#:summary-generated? boolean?)
+                any/c)]
+          [compaction-start-topic string?]
+          [compaction-end-topic string?]
+          ;; Event construction helpers
+          [make-compaction-start-event (-> any/c any/c any/c string? string? any/c)]
+          [make-compaction-end-event
+           (->* (any/c any/c any/c any/c string? string?) (#:summary-generated? boolean?) any/c)]))
 
 ;; ============================================================
 ;; Constants
@@ -50,7 +58,8 @@
 
 ;; Build the enriched payload for session-before-compact.
 ;; This gives extensions full context about what's about to be compacted.
-(define (build-enriched-compact-payload messages strategy
+(define (build-enriched-compact-payload messages
+                                        strategy
                                         #:previous-summary [prev-summary #f]
                                         #:session-id [session-id "unknown"])
   (define total (length messages))
@@ -65,29 +74,41 @@
   ;; Estimate tokens
   (define tokens-before (estimate-messages-tokens messages))
   ;; Build payload hash
-  (hasheq 'message-count total
-          'messages-to-summarize (length old)
-          'messages-to-keep (length recent)
-          'turn-prefix turn-prefix-text
-          'previous-summary (or prev-summary "")
-          'tokens-before tokens-before
-          'split-index split-idx
-          'is-split-turn (split-turn-result-is-split? split-info)
-          'session-id session-id
-          'strategy strategy))
+  (hasheq 'message-count
+          total
+          'messages-to-summarize
+          (length old)
+          'messages-to-keep
+          (length recent)
+          'turn-prefix
+          turn-prefix-text
+          'previous-summary
+          (or prev-summary "")
+          'tokens-before
+          tokens-before
+          'split-index
+          split-idx
+          'is-split-turn
+          (split-turn-result-is-split? split-info)
+          'session-id
+          session-id
+          'strategy
+          strategy))
 
 ;; Dispatch the enriched before-compact hook.
 ;; Returns (values hook-result-or-#f enriched-payload)
 ;; The hook-result may contain a custom summary in its payload.
-(define (dispatch-enriched-before-compact hook-dispatcher messages strategy
+(define (dispatch-enriched-before-compact hook-dispatcher
+                                          messages
+                                          strategy
                                           #:previous-summary [prev-summary #f]
                                           #:session-id [session-id "unknown"])
-  (define payload (build-enriched-compact-payload messages strategy
-                                                   #:previous-summary prev-summary
-                                                   #:session-id session-id))
-  (define hook-res
-    (and hook-dispatcher
-         (hook-dispatcher 'session-before-compact payload)))
+  (define payload
+    (build-enriched-compact-payload messages
+                                    strategy
+                                    #:previous-summary prev-summary
+                                    #:session-id session-id))
+  (define hook-res (and hook-dispatcher (hook-dispatcher 'session-before-compact payload)))
   (values hook-res payload))
 
 ;; If the hook returned a custom summary, extract it.
@@ -102,44 +123,58 @@
 ;; ============================================================
 
 ;; Create a compaction-start event.
-(define (make-compaction-start-event reason message-count tokens-before
-                                     session-id turn-id)
+(define (make-compaction-start-event reason message-count tokens-before session-id turn-id)
   (make-event compaction-start-topic
               (current-inexact-milliseconds)
               session-id
               turn-id
-              (hasheq 'reason reason
-                      'message-count message-count
-                      'tokens-before tokens-before)))
+              (hasheq 'reason reason 'message-count message-count 'tokens-before tokens-before)))
 
 ;; Create a compaction-end event.
-(define (make-compaction-end-event reason removed-count tokens-before tokens-after
-                                   session-id turn-id
+(define (make-compaction-end-event reason
+                                   removed-count
+                                   tokens-before
+                                   tokens-after
+                                   session-id
+                                   turn-id
                                    #:summary-generated? [summary-gen? #t])
   (make-event compaction-end-topic
               (current-inexact-milliseconds)
               session-id
               turn-id
-              (hasheq 'reason reason
-                      'removed-count removed-count
-                      'tokens-before tokens-before
-                      'tokens-after tokens-after
-                      'summary-generated? summary-gen?)))
+              (hasheq 'reason
+                      reason
+                      'removed-count
+                      removed-count
+                      'tokens-before
+                      tokens-before
+                      'tokens-after
+                      tokens-after
+                      'summary-generated?
+                      summary-gen?)))
 
 ;; Publish a compaction-start event to the event bus.
-(define (publish-compaction-start! bus reason message-count tokens-before
-                                   session-id turn-id)
+(define (publish-compaction-start! bus reason message-count tokens-before session-id turn-id)
   (when bus
-    (define evt (make-compaction-start-event reason message-count tokens-before
-                                             session-id turn-id))
+    (define evt (make-compaction-start-event reason message-count tokens-before session-id turn-id))
     (publish! bus evt)))
 
 ;; Publish a compaction-end event to the event bus.
-(define (publish-compaction-end! bus reason removed-count tokens-before tokens-after
-                                 session-id turn-id
+(define (publish-compaction-end! bus
+                                 reason
+                                 removed-count
+                                 tokens-before
+                                 tokens-after
+                                 session-id
+                                 turn-id
                                  #:summary-generated? [summary-gen? #t])
   (when bus
-    (define evt (make-compaction-end-event reason removed-count tokens-before tokens-after
-                                           session-id turn-id
-                                           #:summary-generated? summary-gen?))
+    (define evt
+      (make-compaction-end-event reason
+                                 removed-count
+                                 tokens-before
+                                 tokens-after
+                                 session-id
+                                 turn-id
+                                 #:summary-generated? summary-gen?))
     (publish! bus evt)))

--- a/runtime/compaction-prompts.rkt
+++ b/runtime/compaction-prompts.rkt
@@ -5,7 +5,8 @@
 ;; Provides structured summary prompt and iterative update prompt
 ;; for the compaction system.
 
-(require racket/string
+(require racket/contract
+         racket/string
          (only-in "../util/protocol-types.rkt"
                   message?
                   message-role
@@ -14,11 +15,11 @@
                   text-part?
                   text-part-text))
 
-(provide summary-prompt
-         iterative-update-prompt
-         format-messages-for-summary
-         MAX-TOOL-RESULT-CHARS
-         MAX-SUMMARY-WORDS)
+(provide (contract-out [summary-prompt (-> string? (or/c #f hash?) string?)]
+                       [iterative-update-prompt (-> string? string? (or/c #f hash?) string?)]
+                       [format-messages-for-summary (-> list? string?)]
+                       [MAX-TOOL-RESULT-CHARS exact-positive-integer?]
+                       [MAX-SUMMARY-WORDS exact-positive-integer?]))
 
 (define MAX-TOOL-RESULT-CHARS 2000)
 (define MAX-SUMMARY-WORDS 500)

--- a/runtime/context-assembly.rkt
+++ b/runtime/context-assembly.rkt
@@ -7,7 +7,8 @@
 ;; Also re-exports from context-summary.rkt (sibling module).
 ;; All struct definitions live in sub-modules (single source of truth).
 
-(require "context-assembly/budgeting.rkt"
+(require racket/contract
+         "context-assembly/budgeting.rkt"
          "context-assembly/selection.rkt"
          "context-assembly/serialization.rkt"
          (only-in "context-summary.rkt"
@@ -41,82 +42,93 @@
                   truncate-string))
 
 ;; Explicit re-exports from sub-modules (S1-F4)
-(provide context-assembly-config
-         context-assembly-config?
-         context-assembly-config-recent-tokens
-         context-assembly-config-max-catalog-entries
-         context-assembly-config-max-catalog-tokens
-         context-assembly-config-summary-window
-         make-context-assembly-config
-         context-result
-         context-result?
-         context-result-messages
-         context-result-total-tokens
-         context-result-pinned-count
-         context-result-recent-count
-         context-result-excluded-count
-         context-result-over-budget?
-         context-result-catalog
-         context-result-summary
-         build-assembled-context
-         build-assembled-context/raw
-         build-assembled-context/v2
-         build-session-context
-         context-assembly-call-options
-         context-assembly-call-options?
-         context-assembly-call-options-cache
-         context-assembly-call-options-provider
-         context-assembly-call-options-model-name
-         context-assembly-call-options-trace-callback
-         context-assembly-call-options-working-set
-         context-assembly-call-options-generate-summary-proc
-         context-assembly-call-options-generate-catalog-proc
-         context-assembly-call-options-estimate-text-proc
-         make-context-assembly-call-options
-         tiered-context
-         tiered-context?
-         tiered-context-tier-a
-         tiered-context-tier-b
-         tiered-context-tier-c
-         build-tiered-context
-         tiered-context->message-list
-         build-tiered-context-with-hooks
-         compute-dynamic-tier-b-count
-         summarize-tool-result
-         context-assembly-payload
-         context-assembly-payload?
-         context-assembly-payload-tier-a-messages
-         context-assembly-payload-tier-b-messages
-         context-assembly-payload-tier-c-messages
-         context-assembly-payload-max-tokens
-         context-assembly-payload-metadata
-         payload->tiered-context
-         tiered-context->payload
-         build-session-context/tokens
-         entry->context-message
-         load-agents-context
-         build-system-preamble
-         truncate-messages-to-budget)
+;; Struct: context-assembly-config
+(provide (contract-out [context-assembly-config any/c]
+                       [context-assembly-config? (-> any/c boolean?)]
+                       [context-assembly-config-recent-tokens any/c]
+                       [context-assembly-config-max-catalog-entries any/c]
+                       [context-assembly-config-max-catalog-tokens any/c]
+                       [context-assembly-config-summary-window any/c]
+                       [make-context-assembly-config any/c]
+                       ;; Struct: context-result
+                       [context-result any/c]
+                       [context-result? (-> any/c boolean?)]
+                       [context-result-messages any/c]
+                       [context-result-total-tokens any/c]
+                       [context-result-pinned-count any/c]
+                       [context-result-recent-count any/c]
+                       [context-result-excluded-count any/c]
+                       [context-result-over-budget? (-> any/c boolean?)]
+                       [context-result-catalog any/c]
+                       [context-result-summary any/c]
+                       ;; Context builders
+                       [build-assembled-context any/c]
+                       [build-assembled-context/raw any/c]
+                       [build-assembled-context/v2 any/c]
+                       [build-session-context any/c]
+                       ;; Struct: context-assembly-call-options
+                       [context-assembly-call-options any/c]
+                       [context-assembly-call-options? (-> any/c boolean?)]
+                       [context-assembly-call-options-cache any/c]
+                       [context-assembly-call-options-provider any/c]
+                       [context-assembly-call-options-model-name any/c]
+                       [context-assembly-call-options-trace-callback any/c]
+                       [context-assembly-call-options-working-set any/c]
+                       [context-assembly-call-options-generate-summary-proc any/c]
+                       [context-assembly-call-options-generate-catalog-proc any/c]
+                       [context-assembly-call-options-estimate-text-proc any/c]
+                       [make-context-assembly-call-options any/c]
+                       ;; Struct: tiered-context
+                       [tiered-context any/c]
+                       [tiered-context? (-> any/c boolean?)]
+                       [tiered-context-tier-a any/c]
+                       [tiered-context-tier-b any/c]
+                       [tiered-context-tier-c any/c]
+                       [build-tiered-context any/c]
+                       [tiered-context->message-list any/c]
+                       [build-tiered-context-with-hooks any/c]
+                       [compute-dynamic-tier-b-count any/c]
+                       [summarize-tool-result any/c]
+                       ;; Struct: context-assembly-payload
+                       [context-assembly-payload any/c]
+                       [context-assembly-payload? (-> any/c boolean?)]
+                       [context-assembly-payload-tier-a-messages any/c]
+                       [context-assembly-payload-tier-b-messages any/c]
+                       [context-assembly-payload-tier-c-messages any/c]
+                       [context-assembly-payload-max-tokens any/c]
+                       [context-assembly-payload-metadata any/c]
+                       ;; Payload / context helpers
+                       [payload->tiered-context any/c]
+                       [tiered-context->payload any/c]
+                       [build-session-context/tokens any/c]
+                       [entry->context-message any/c]
+                       [load-agents-context any/c]
+                       [build-system-preamble any/c]
+                       [truncate-messages-to-budget any/c]))
 
 ;; Re-export from context-summary.rkt
-(provide DEFAULT-CACHE-MAX-ENTRIES
-         make-summary-cache
-         summary-cache?
-         summary-cache-lookup
-         summary-cache-store!
-         summary-cache-count
-         summary-cache-max-entries
-         catalog-entry
-         catalog-entry?
-         catalog-entry-id
-         catalog-entry-role
-         catalog-entry-summary
-         generate-catalog
-         context-summary
-         context-summary?
-         context-summary-from-id
-         context-summary-to-id
-         context-summary-text
-         context-summary-entry-count
-         context-summary-prompt
-         generate-context-summary)
+;; Constants
+(provide (contract-out [DEFAULT-CACHE-MAX-ENTRIES exact-positive-integer?]
+                       ;; Summary cache
+                       [make-summary-cache any/c]
+                       [summary-cache? (-> any/c boolean?)]
+                       [summary-cache-lookup any/c]
+                       [summary-cache-store! any/c]
+                       [summary-cache-count any/c]
+                       [summary-cache-max-entries any/c]
+                       ;; Struct: catalog-entry
+                       [catalog-entry any/c]
+                       [catalog-entry? (-> any/c boolean?)]
+                       [catalog-entry-id any/c]
+                       [catalog-entry-role any/c]
+                       [catalog-entry-summary any/c]
+                       [generate-catalog any/c]
+                       ;; Struct: context-summary
+                       [context-summary any/c]
+                       [context-summary? (-> any/c boolean?)]
+                       [context-summary-from-id any/c]
+                       [context-summary-to-id any/c]
+                       [context-summary-text any/c]
+                       [context-summary-entry-count any/c]
+                       [context-summary-prompt any/c]
+                       [generate-context-summary any/c]))

--- a/runtime/context-assembly/summary-entities.rkt
+++ b/runtime/context-assembly/summary-entities.rkt
@@ -5,14 +5,15 @@
 ;; SAL-04 fix: Extracts key entities (file paths, function/module names) from
 ;; messages so summaries can be checked for entity preservation.
 
-(require racket/string
+(require racket/contract
+         racket/string
          racket/list
          (only-in "../../util/message.rkt" message-content)
          (only-in "../../util/content-parts.rkt" text-part? text-part-text))
 
-(provide extract-key-entities
-         check-entity-preservation
-         entity-preservation-appendix)
+(provide (contract-out [extract-key-entities (->* (list?) (exact-positive-integer?) any/c)]
+                       [check-entity-preservation (-> list? string? list?)]
+                       [entity-preservation-appendix (-> list? string?)]))
 
 ;; File path patterns: /path/to/file.rkt, ./relative/path.rkt, src/file.rkt
 (define FILE-PATH-RE

--- a/runtime/context-pinning.rkt
+++ b/runtime/context-pinning.rkt
@@ -7,12 +7,13 @@
 ;; (system prompt, first user message, compaction summaries) and
 ;; partitions them from removable messages.
 
-(require racket/list
+(require racket/contract
+         racket/list
          racket/set
          (only-in "../util/protocol-types.rkt" message-role message-kind message-id))
 
-(provide partition-messages
-         partition-messages/working-set)
+(provide (contract-out [partition-messages (-> list? (values list? list?))]
+                       [partition-messages/working-set (-> list? list? (values list? list?))]))
 
 ;; ============================================================
 ;; Phase 1: Pin system prompt + first user + compaction summaries

--- a/runtime/iteration/counters.rkt
+++ b/runtime/iteration/counters.rkt
@@ -23,19 +23,15 @@
                   tool-result-part?
                   tool-result-part-is-error?
                   tool-call-name)
-         (only-in "../../runtime/tool-coordinator.rkt"
-                  extract-tool-calls-from-messages)
-         (only-in "tool-turn-bridge.rkt"
-                  update-seen-paths
-                  take-at-most)
+         (only-in "../../runtime/tool-coordinator.rkt" extract-tool-calls-from-messages)
+         (only-in "tool-turn-bridge.rkt" update-seen-paths take-at-most)
          (only-in "../../agent/event-emitter.rkt" emit-typed-event!)
          (only-in "../../agent/event-structs/hook-events.rkt" turn-cancelled-event)
          (only-in "../../util/loop-result.rkt" make-loop-result)
-         (only-in "../../util/cancellation.rkt"
-                  cancellation-token?
-                  cancellation-token-cancelled?))
+         (only-in "../../util/cancellation.rkt" cancellation-token? cancellation-token-cancelled?))
 
-(provide compute-next-counters check-cancellation)
+(provide (contract-out [compute-next-counters (-> any/c (listof any/c) any/c)]
+                       [check-cancellation (-> any/c any/c any/c any/c any/c any/c any/c any/c)]))
 
 ;; ============================================================
 ;; compute-next-counters

--- a/runtime/iteration/directive.rkt
+++ b/runtime/iteration/directive.rkt
@@ -9,21 +9,24 @@
 ;; directive-stop    : terminal, return loop-result
 ;; directive-yield   : events produced, continue (for future use)
 
+(require racket/contract)
+
+;; Struct constructors needed as match patterns — must NOT be in contract-out
 (provide directive-recurse
-         directive-recurse?
-         directive-recurse-new-ctx
-         directive-recurse-new-counters
-         directive-recurse-ws
          directive-stop
-         directive-stop?
-         directive-stop-result
          directive-yield
-         directive-yield?
-         directive-yield-events
-         directive-yield-new-ctx
-         directive-yield-new-counters
-         directive-yield-ws
-         step-directive?)
+         (contract-out [directive-recurse? (-> any/c boolean?)]
+                       [directive-recurse-new-ctx (-> directive-recurse? any/c)]
+                       [directive-recurse-new-counters (-> directive-recurse? any/c)]
+                       [directive-recurse-ws (-> directive-recurse? any/c)]
+                       [directive-stop? (-> any/c boolean?)]
+                       [directive-stop-result (-> directive-stop? any/c)]
+                       [directive-yield? (-> any/c boolean?)]
+                       [directive-yield-events (-> directive-yield? any/c)]
+                       [directive-yield-new-ctx (-> directive-yield? any/c)]
+                       [directive-yield-new-counters (-> directive-yield? any/c)]
+                       [directive-yield-ws (-> directive-yield? any/c)]
+                       [step-directive? (-> any/c boolean?)]))
 
 (struct directive-recurse (new-ctx new-counters ws) #:transparent)
 (struct directive-stop (result) #:transparent)

--- a/runtime/project-tree.rkt
+++ b/runtime/project-tree.rkt
@@ -9,18 +9,21 @@
 ;; v0.19.3 Wave 3: Context Seeding with Project File Tree (C4)
 
 (require "../util/error-helpers.rkt")
-(require racket/list
+(require racket/contract
+         racket/list
          racket/match
          racket/string
          racket/set
          racket/path)
 
-(provide generate-project-tree
-         project-tree->string
-         DEFAULT_TREE_MAX_DEPTH
-         DEFAULT_TREE_MAX_ENTRIES
-         IGNORED-DIRS
-         IGNORED-EXTENSIONS)
+(provide (contract-out [generate-project-tree
+                        (-> path? #:max-depth integer? #:max-entries integer? (listof string?))]
+                       [project-tree->string
+                        (-> path? #:max-depth integer? #:max-entries integer? string?)]
+                       [DEFAULT_TREE_MAX_DEPTH integer?]
+                       [DEFAULT_TREE_MAX_ENTRIES integer?]
+                       [IGNORED-DIRS any/c]
+                       [IGNORED-EXTENSIONS any/c]))
 
 ;; ============================================================
 ;; Configuration

--- a/runtime/runtime-helpers.rkt
+++ b/runtime/runtime-helpers.rkt
@@ -11,14 +11,16 @@
 ;; layer violation (agent core should not import from runtime). Re-exported
 ;; here for backward compatibility with existing runtime callers.
 
-(require (only-in "../agent/event-emitter.rkt" emit-session-event!)
+(require racket/contract
+         (only-in "../agent/event-emitter.rkt" emit-session-event!)
          (only-in "../agent/event-bus.rkt" make-event-bus)
          (only-in "../extensions/hooks.rkt" dispatch-hooks)
          (only-in "../util/hook-types.rkt" hook-result-payload))
 
 (provide emit-session-event!
          make-event-bus
-         maybe-dispatch-hooks)
+         (contract-out [maybe-dispatch-hooks
+                        (->* (any/c any/c any/c) (#:ctx any/c) (values any/c any/c))]))
 
 ;; emit-session-event! is now defined in agent/event-emitter.rkt
 ;; and re-exported here for backward compatibility.

--- a/runtime/session-context.rkt
+++ b/runtime/session-context.rkt
@@ -5,9 +5,8 @@
 ;; ARCH-05 partial (v0.22.0): Extracted from agent-session.rkt.
 ;; Pure functions for context message analysis.
 
-(require (only-in "../util/protocol-types.rkt"
-                  message-kind
-                  message-meta))
+(require racket/contract
+         (only-in "../util/protocol-types.rkt" message-kind message-meta))
 
 ;; extract-path-settings — walk context messages to find latest
 ;;   model-change and thinking-level-change entries.
@@ -22,4 +21,4 @@
        (hash-set settings 'thinking-level (hash-ref (message-meta msg) 'level #f))]
       [else settings])))
 
-(provide extract-path-settings)
+(provide (contract-out [extract-path-settings (-> list? any/c)]))

--- a/runtime/session-events.rkt
+++ b/runtime/session-events.rkt
@@ -6,7 +6,8 @@
 ;; Extracted from agent-session.rkt (ARCH-05b).
 ;; Handles fork.requested and compact.requested events from TUI/CLI.
 
-(require "../agent/event-bus.rkt"
+(require racket/contract
+         "../agent/event-bus.rkt"
          "../runtime/session-store.rkt"
          "../runtime/compactor.rkt"
          "../runtime/session-index.rkt"
@@ -14,7 +15,7 @@
          (only-in "runtime-helpers.rkt" emit-session-event!)
          "session-types.rkt")
 
-(provide wire-session-event-handlers!)
+(provide (contract-out [wire-session-event-handlers! (-> any/c any/c void?)]))
 
 ;; ============================================================
 ;; Event bus wiring

--- a/runtime/session-fsm.rkt
+++ b/runtime/session-fsm.rkt
@@ -17,7 +17,8 @@
 ;;   (session-current-state sess) → fsm-state
 ;;   (session-valid-lifecycle? sess) → boolean
 
-(require (only-in "../util/fsm.rkt"
+(require racket/contract
+         (only-in "../util/fsm.rkt"
                   define-fsm-machine
                   fsm-state
                   fsm-state-name
@@ -34,22 +35,25 @@
 ;; ── Session FSM ──
 
 (define-fsm-machine session-lifecycle
-  #:states (created active streaming compacting idle terminated)
-  #:events (session-started stream-requested stream-complete
-            compaction-needed compaction-complete
-            turn-complete new-turn session-ended)
-  #:transitions
-  [(created -> active) session-started]
-  [(active -> streaming) stream-requested]
-  [(active -> compacting) compaction-needed]
-  [(active -> idle) turn-complete]
-  [(streaming -> active) stream-complete]
-  [(compacting -> active) compaction-complete]
-  [(idle -> active) new-turn]
-  [(active -> terminated) session-ended]
-  [(streaming -> terminated) session-ended]
-  [(compacting -> terminated) session-ended]
-  [(idle -> terminated) session-ended])
+                    #:states (created active streaming compacting idle terminated)
+                    #:events (session-started stream-requested
+                                              stream-complete
+                                              compaction-needed
+                                              compaction-complete
+                                              turn-complete
+                                              new-turn
+                                              session-ended)
+                    #:transitions [(created -> active) session-started]
+                    [(active -> streaming) stream-requested]
+                    [(active -> compacting) compaction-needed]
+                    [(active -> idle) turn-complete]
+                    [(streaming -> active) stream-complete]
+                    [(compacting -> active) compaction-complete]
+                    [(idle -> active) new-turn]
+                    [(active -> terminated) session-ended]
+                    [(streaming -> terminated) session-ended]
+                    [(compacting -> terminated) session-ended]
+                    [(idle -> terminated) session-ended])
 
 ;; ── Derived state computation ──
 
@@ -57,14 +61,10 @@
 ;; Computes the FSM state from the session's boolean flags.
 (define (session-current-state sess)
   (cond
-    [(not (agent-session-active? sess))
-     session-lifecycle-terminated]
-    [(agent-session-compacting? sess)
-     session-lifecycle-compacting]
-    [(agent-session-prompt-running? sess)
-     session-lifecycle-streaming]
-    [else
-     session-lifecycle-active]))
+    [(not (agent-session-active? sess)) session-lifecycle-terminated]
+    [(agent-session-compacting? sess) session-lifecycle-compacting]
+    [(agent-session-prompt-running? sess) session-lifecycle-streaming]
+    [else session-lifecycle-active]))
 
 ;; session-current-state-name : agent-session? -> symbol
 (define (session-current-state-name sess)
@@ -78,20 +78,18 @@
 ;; session-can-transition? : agent-session? symbol -> boolean
 ;; Whether the session can accept the given event from its current state.
 (define (session-can-transition? sess event-sym)
-  (fsm-valid-transition? session-lifecycle-machine
-                         (session-current-state-name sess)
-                         event-sym))
+  (fsm-valid-transition? session-lifecycle-machine (session-current-state-name sess) event-sym))
 
-(provide session-lifecycle-machine
-         session-lifecycle-state?
-         session-lifecycle-event?
-         session-lifecycle-terminated
-         session-lifecycle-active
-         session-lifecycle-streaming
-         session-lifecycle-compacting
-         session-lifecycle-idle
-         session-lifecycle-created
-         session-current-state
-         session-current-state-name
-         session-valid-lifecycle?
-         session-can-transition?)
+(provide (contract-out [session-lifecycle-machine any/c]
+                       [session-lifecycle-state? (-> any/c boolean?)]
+                       [session-lifecycle-event? (-> any/c boolean?)]
+                       [session-lifecycle-terminated any/c]
+                       [session-lifecycle-active any/c]
+                       [session-lifecycle-streaming any/c]
+                       [session-lifecycle-compacting any/c]
+                       [session-lifecycle-idle any/c]
+                       [session-lifecycle-created any/c]
+                       [session-current-state (-> any/c any/c)]
+                       [session-current-state-name (-> any/c symbol?)]
+                       [session-valid-lifecycle? (-> any/c boolean?)]
+                       [session-can-transition? (-> any/c symbol? boolean?)]))

--- a/runtime/session-index/query.rkt
+++ b/runtime/session-index/query.rkt
@@ -4,7 +4,8 @@
 ;;
 ;; Read-only query operations on session-index.
 
-(require racket/list
+(require racket/contract
+         racket/list
          racket/set
          (only-in "../../util/protocol-types.rkt"
                   message-id
@@ -14,16 +15,16 @@
                   text-part-text)
          "schema.rkt")
 
-(provide lookup-entry
-         children-of
-         leaf-nodes
-         resolve-active-leaf
-         active-leaf
-         get-branch
-         find-common-ancestor
-         collect-branch-entries
-         leaf-depth
-         estimate-entry-tokens)
+(provide (contract-out [lookup-entry (-> any/c any/c any/c)]
+                       [children-of (-> any/c any/c (listof any/c))]
+                       [leaf-nodes (-> any/c (listof any/c))]
+                       [resolve-active-leaf (-> any/c any/c)]
+                       [active-leaf (-> any/c any/c)]
+                       [get-branch (-> any/c any/c (or/c list? #f))]
+                       [find-common-ancestor (-> any/c any/c any/c any/c)]
+                       [collect-branch-entries (-> any/c any/c any/c integer? (listof any/c))]
+                       [estimate-entry-tokens (-> any/c integer?)]
+                       [leaf-depth (-> any/c any/c (or/c integer? #f))]))
 
 (define (lookup-entry idx id)
   (hash-ref (session-index-by-id idx) id #f))
@@ -39,7 +40,9 @@
 
 (define (resolve-active-leaf idx)
   (define leaves (leaf-nodes idx))
-  (if (null? leaves) #f (last leaves)))
+  (if (null? leaves)
+      #f
+      (last leaves)))
 
 (define (active-leaf idx)
   (define marked-id (unbox (session-index-active-leaf-id idx)))
@@ -59,7 +62,9 @@
       [else
        (define new-acc (cons entry acc))
        (define pid (message-parent-id entry))
-       (if pid (walk-up pid new-acc) new-acc)]))
+       (if pid
+           (walk-up pid new-acc)
+           new-acc)]))
   (walk-up entry-id '()))
 
 (define (find-common-ancestor idx id-a id-b)
@@ -73,7 +78,8 @@
        (loop (and msg (message-parent-id msg)))])))
 
 (define (ancestor-set idx id)
-  (let loop ([current id] [acc (set)])
+  (let loop ([current id]
+             [acc (set)])
     (cond
       [(not current) acc]
       [(set-member? acc current) acc]
@@ -82,7 +88,9 @@
        (loop (and msg (message-parent-id msg)) (set-add acc current))])))
 
 (define (collect-branch-entries idx old-leaf-id ancestor-id token-budget)
-  (let loop ([current old-leaf-id] [acc '()] [tokens-used 0])
+  (let loop ([current old-leaf-id]
+             [acc '()]
+             [tokens-used 0])
     (cond
       [(not current) acc]
       [(equal? current ancestor-id) acc]
@@ -98,10 +106,12 @@
 (define (estimate-entry-tokens msg)
   (define content (message-content msg))
   (for/sum ([part (in-list content)])
-    (cond
-      [(text-part? part) (quotient (string-length (text-part-text part)) 4)]
-      [else 10])))
+           (cond
+             [(text-part? part) (quotient (string-length (text-part-text part)) 4)]
+             [else 10])))
 
 (define (leaf-depth idx entry-id)
   (define path (get-branch idx entry-id))
-  (if path (sub1 (length path)) #f))
+  (if path
+      (sub1 (length path))
+      #f))

--- a/runtime/session-metadata.rkt
+++ b/runtime/session-metadata.rkt
@@ -11,27 +11,32 @@
          racket/list
          racket/port
          (only-in "../util/protocol-types.rkt"
-                  message? message-content message-meta message-kind
-                  make-message make-text-part content-part->jsexpr)
+                  message?
+                  message-content
+                  message-meta
+                  message-kind
+                  make-message
+                  make-text-part
+                  content-part->jsexpr)
          "../util/jsonl.rkt"
          "../runtime/session-store.rkt")
 
-(provide
- ;; #710: Session naming
- set-session-name!
- get-session-name
- session-name-entry?
-
- ;; #711: Entry labeling
- set-entry-label!
- get-entry-label
- entry-label?
- label-type?
- list-labeled-entries
- ;; Label types
- LABEL-CHECKPOINT
- LABEL-MILESTONE
- LABEL-BRANCH-POINT)
+(provide (contract-out
+          ;; #710: Session naming
+          [set-session-name! (-> path-string? string? void?)]
+          [get-session-name (-> path-string? (or/c string? #f))]
+          [session-name-entry? (-> any/c boolean?)]
+          ;; #711: Entry labeling
+          [set-entry-label!
+           (->* (path-string? string? label-type?) (#:description (or/c string? #f)) void?)]
+          [get-entry-label (-> list? string? (or/c symbol? #f))]
+          [entry-label? (-> any/c boolean?)]
+          [label-type? (-> any/c boolean?)]
+          [list-labeled-entries (-> list? list?)]
+          ;; Label types
+          [LABEL-CHECKPOINT symbol?]
+          [LABEL-MILESTONE symbol?]
+          [LABEL-BRANCH-POINT symbol?]))
 
 ;; ============================================================
 ;; Constants
@@ -42,10 +47,7 @@
 (define LABEL-BRANCH-POINT 'branch-point)
 
 (define (label-type? v)
-  (and (symbol? v)
-       (or (eq? v LABEL-CHECKPOINT)
-           (eq? v LABEL-MILESTONE)
-           (eq? v LABEL-BRANCH-POINT))))
+  (and (symbol? v) (or (eq? v LABEL-CHECKPOINT) (eq? v LABEL-MILESTONE) (eq? v LABEL-BRANCH-POINT))))
 
 ;; ============================================================
 ;; #710: Session naming
@@ -59,8 +61,7 @@
 ;; Returns the last set name, or #f if no name is set.
 (define (get-session-name log-path)
   (define entries (load-session-log log-path))
-  (define name-entries
-    (filter session-name-entry? entries))
+  (define name-entries (filter session-name-entry? entries))
   (if (null? name-entries)
       #f
       (hash-ref (message-meta (car (reverse name-entries))) 'name #f)))
@@ -77,8 +78,7 @@
 
 ;; Set a label on a specific entry in the session log.
 ;; Appends a label entry that references the target entry.
-(define (set-entry-label! log-path target-entry-id label-type
-                           #:description [description #f])
+(define (set-entry-label! log-path target-entry-id label-type #:description [description #f])
   (unless (label-type? label-type)
     (raise-argument-error 'set-entry-label! "label-type?" label-type))
   (define label-msg
@@ -87,38 +87,43 @@
                   'system
                   'entry-label
                   (list (make-text-part (or description
-                                           (format "~a label for ~a" label-type target-entry-id))))
+                                            (format "~a label for ~a" label-type target-entry-id))))
                   (current-seconds)
-                  (hasheq 'label-type (symbol->string label-type)
-                          'target-id target-entry-id
-                          'description description)))
+                  (hasheq 'label-type
+                          (symbol->string label-type)
+                          'target-id
+                          target-entry-id
+                          'description
+                          description)))
   (append-entry! log-path label-msg))
 
 ;; Get the label for a specific entry, if any.
 ;; Returns the label-type symbol or #f.
 (define (get-entry-label entries target-entry-id)
   (define label-entries
-    (filter (lambda (e) (and (eq? (message-kind e) 'entry-label)
-                              (equal? (hash-ref (message-meta e) 'target-id #f)
-                                      target-entry-id)))
+    (filter (lambda (e)
+              (and (eq? (message-kind e) 'entry-label)
+                   (equal? (hash-ref (message-meta e) 'target-id #f) target-entry-id)))
             entries))
   (if (null? label-entries)
       #f
       (let ([raw (hash-ref (message-meta (car (reverse label-entries))) 'label-type #f)])
-        (if (string? raw) (string->symbol raw) raw))))
+        (if (string? raw)
+            (string->symbol raw)
+            raw))))
 
 ;; Check if an entry is a label entry.
 (define (entry-label? entry)
-  (and (message? entry)
-       (eq? (message-kind entry) 'entry-label)))
+  (and (message? entry) (eq? (message-kind entry) 'entry-label)))
 
 ;; List all labeled entries from a session log.
 ;; Returns list of (cons target-id label-type).
 (define (list-labeled-entries entries)
-  (filter-map
-   (lambda (e)
-     (and (entry-label? e)
-          (let ([raw (hash-ref (message-meta e) 'label-type #f)])
-            (cons (hash-ref (message-meta e) 'target-id #f)
-                  (if (string? raw) (string->symbol raw) raw)))))
-   entries))
+  (filter-map (lambda (e)
+                (and (entry-label? e)
+                     (let ([raw (hash-ref (message-meta e) 'label-type #f)])
+                       (cons (hash-ref (message-meta e) 'target-id #f)
+                             (if (string? raw)
+                                 (string->symbol raw)
+                                 raw)))))
+              entries))

--- a/runtime/session-migration.rkt
+++ b/runtime/session-migration.rkt
@@ -17,18 +17,19 @@
 ;;;
 ;;; #773
 
-(require racket/file
+(require racket/contract
+         racket/file
          json
          "../util/jsonl.rkt"
          "../util/protocol-types.rkt"
          (only-in "../util/errors.rkt" with-logged-catch raise-session-error))
 
-(provide current-session-version
-         read-session-version
-         migrate-session-log!
-         ensure-session-version!
-         register-migration!
-         run-migrations!)
+(provide (contract-out [current-session-version exact-nonnegative-integer?]
+                       [read-session-version (-> path-string? exact-nonnegative-integer?)]
+                       [migrate-session-log! (-> path-string? void?)]
+                       [ensure-session-version! (-> path-string? void?)]
+                       [register-migration! (-> exact-nonnegative-integer? procedure? void?)]
+                       [run-migrations! (-> path-string? void?)]))
 
 ;; Current format version (synced with session-store.rkt)
 (define current-session-version 2)

--- a/runtime/session-mutation.rkt
+++ b/runtime/session-mutation.rkt
@@ -5,13 +5,14 @@
 ;; Wraps all set-agent-session-...! calls with transition checks.
 ;; Prevents invalid state transitions like #t→#t on prompt-running?.
 
-(require "session-types.rkt"
+(require racket/contract
+         "session-types.rkt"
          (only-in "../util/errors.rkt" raise-session-error))
 
-(provide guarded-set-prompt-running!
-         guarded-set-compacting!
-         guarded-set-shutdown-requested!
-         valid-session-phase?)
+(provide (contract-out [guarded-set-prompt-running! (-> agent-session? boolean? any/c)]
+                       [guarded-set-compacting! (-> agent-session? boolean? any/c)]
+                       [guarded-set-shutdown-requested! (-> agent-session? boolean? any/c)]
+                       [valid-session-phase? (-> any/c boolean?)]))
 
 ;; Valid session phases derived from boolean flags
 (define (valid-session-phase? phase)

--- a/runtime/session-store-tree.rkt
+++ b/runtime/session-store-tree.rkt
@@ -13,12 +13,15 @@
          racket/lazy-require
          "../util/protocol-types.rkt")
 
-(provide append-tree-entry!
-         load-tree
-         get-tree-branch
-         get-children
-         resolve-active-branch
-         tree-info)
+(provide (contract-out [append-tree-entry!
+                        (->* (path-string? message?)
+                             (#:before-hook (or/c #f procedure?) #:after-hook (or/c #f procedure?))
+                             void?)]
+                       [load-tree (-> path-string? hash?)]
+                       [get-tree-branch (-> hash? string? list?)]
+                       [get-children (-> hash? string? list?)]
+                       [resolve-active-branch (-> hash? list?)]
+                       [tree-info (-> hash? hash?)]))
 
 ;; Lazy-require to break circular dependency with session-store.rkt
 (lazy-require ["session-store.rkt" (load-session-log append-entry!)])

--- a/runtime/trace-sink.rkt
+++ b/runtime/trace-sink.rkt
@@ -6,12 +6,13 @@
 ;; Defines a trace-sink<%> interface that abstracts trace output.
 ;; Allows swapping file/port/null sinks without changing trace-logger.
 
-(require racket/class)
+(require racket/class
+         racket/contract)
 
-(provide trace-sink<%>
-         file-trace-sink%
-         port-trace-sink%
-         null-trace-sink%)
+(provide (contract-out [trace-sink<%> any/c]
+                       [file-trace-sink% any/c]
+                       [port-trace-sink% any/c]
+                       [null-trace-sink% any/c]))
 
 ;; Interface: trace-sink<%>
 (define trace-sink<%>


### PR DESCRIPTION
Addresses #4747.

refactor: add contract-out to 18 runtime/ files (#4747)

Add contract-out to runtime/ files: session-context, iteration/directive,
runtime-helpers, context-pinning, session-mutation, summary-entities,
trace-sink, session-events, session-fsm, project-tree, session-index/query,
iteration/counters, compaction-prompts, context-assembly (facade),
session-metadata, session-migration, session-store-tree, compaction-hooks.

Key fixes:
- directive.rkt: Keep struct constructors outside contract-out (needed for match)
- compaction-hooks.rkt: Fix return contracts (void? → any/c)
- runtime-helpers.rkt: Keep re-exports outside contract-out

contract-out coverage: 106→124 files (30.2%→35.3%)
struct-out: 34 (unchanged)
arch-fitness: 33/33 passing