### PR TITLE
chore: bump version to 0.49.10 + process hygiene (#4751)

Version bump: 0.49.9 → 0.49.10 across all version surfaces.
CHANGELOG.md: Add v0.49.10 entry with full metrics and wave index.
Docs: Sync version references in 11 doc files.

Final v0.49.10 metrics:
- struct-out: 34 (KPI gate ≤55 ✅)
- contract-out: 149/351 = 42.4% (KPI gate ≥35% ✅)
- arch-fitness: 33/33 passing ✅

Closes v0.49.x audit remediation series.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## v0.49.10 — 2026-05-20
+
+### Changed
+- Closed v0.49.x audit remediation series.
+- Fixed critical session-index export regression (RC1): restored `session-index` constructor and accessors via `all-from-out`.
+- Fixed `sm-fork!`/`in-memory-fork!` contracts (RC3): changed return from `void?` to `any/c`.
+- Updated KPI gates: struct-out floor ≤55, contract-out coverage floor ≥35%.
+- Migrated 3 struct-out files to explicit exports: `llm/provider-errors.rkt`, `skills/resource-loader.rkt`, `skills/context-files.rkt`.
+- Added `contract-out` to 46 files across runtime/, tools/, util/, agent/.
+- Fixed contract arity bugs: `make-model-response` (4 args), `publish-compaction-start!/end!` (return `any/c`).
+- Fixed directive.rkt match-pattern compatibility: struct constructors kept outside `contract-out`.
+
+### Metrics
+- struct-out forms: 52 → 34 (−18)
+- contract-out files: 106 → 149 (+43)
+- contract-out coverage: 30.2% → 42.5%
+- arch-fitness tests: 33/33 passing
+
+### Waves
+- W0: Critical regression fixes + KPI gates (PR #4744)
+- W1: Remaining struct-out migration (PR #4746)
+- W2: Contract-out wave 1 — runtime/ (PR #4748)
+- W3: Contract-out wave 2 — tools/util/agent (PR #4750)
+- W4: Process hygiene + version bump (this release)
+
 ## v0.48.0 — 2026-05-19
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.49.9-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.49.10-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 
@@ -203,7 +203,7 @@ bin/q --model gpt-5.4 "write a test"
 ### Verify
 
 ```bash
-bin/q --version            # q version 0.49.9
+bin/q --version            # q version 0.49.10
 raco test tests/           # run the full test suite
 ```
 
@@ -276,7 +276,7 @@ q/
 |--------|-------|
 | Test files | 606 |
 | Source modules | 438 |
-| Source lines | 68086 |
+| Source lines | 68197 |
 | Test lines | 105374 |
 | Test assertions | 16452 |
 | Tests passing | 5835+ | `racket scripts/run-tests.rkt` results |
@@ -416,6 +416,9 @@ When q executes shell commands on behalf of an LLM, arguments are quoted via `sh
 
 
 
+
+
+**v0.49.10** — Changed
 
 **v0.49.9** — Changed
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -2,7 +2,7 @@
 
 ## Version
 
-v0.49.9
+v0.49.10
 
 ## Layer Diagram
 

--- a/docs/event-taxonomy.md
+++ b/docs/event-taxonomy.md
@@ -1,6 +1,6 @@
 # Q Event Taxonomy Reference
 
-Complete reference for all event types in Q 0.49.9.
+Complete reference for all event types in Q 0.49.10.
 ## Base Types
 
 ### `event` (protocol-level)

--- a/docs/extension-guide.md
+++ b/docs/extension-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.49.9 --># Extension Development Guide
+<!-- verified-against: 0.49.10 --># Extension Development Guide
 
 This guide walks you through creating, testing, and activating a custom
 extension for q.

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.49.9 --># Getting Started
+<!-- verified-against: 0.49.10 --># Getting Started
 
 Welcome to q, a Racket-based coding agent.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.49.9 --># Installation Guide
+<!-- verified-against: 0.49.10 --># Installation Guide
 
 <!-- This file is the canonical source. The docs/getting-started/installation.md copy is maintained for the doc site build. -->
 

--- a/docs/security-trust-model.md
+++ b/docs/security-trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.49.9 --># Security & Trust Model
+<!-- verified-against: 0.49.10 --># Security & Trust Model
 
 This document provides an honest, per-area assessment of what q enforces
 today and what is planned. It is the authoritative reference for security

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -130,6 +130,6 @@ is the primary self-hosting extension:
 (load-extension! ext-reg "path/to/extension.rkt" #:event-bus bus)
 ```
 
-## Version 0.49.9
+## Version 0.49.10
 
-This documentation reflects q 0.49.9.
+This documentation reflects q 0.49.10.

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.49.9 --># q Source Style Guide
+<!-- verified-against: 0.49.10 --># q Source Style Guide
 
 This document defines formatting and naming conventions for the q Racket codebase.
 All changes to `q/` source files (excluding `tests/`) should follow these rules.

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.49.9 --># Trust Model
+<!-- verified-against: 0.49.10 --># Trust Model
 
 ## Trust Levels
 

--- a/docs/workflow-testing.md
+++ b/docs/workflow-testing.md
@@ -121,6 +121,6 @@ Use relative paths from the test file:
 4. Use `(check-true ...)` for boolean assertions
 5. Keep tests independent — no shared mutable state between test-cases
 
-## Version 0.49.9
+## Version 0.49.10
 
-This documentation reflects q 0.49.9.
+This documentation reflects q 0.49.10.

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.49.9")
+(define version "0.49.10")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base"))

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -10,4 +10,4 @@
 (provide q-version)
 
 (: q-version String)
-(define q-version "0.49.9")
+(define q-version "0.49.10")

--- a/wiki-src/Architecture-Overview.md
+++ b/wiki-src/Architecture-Overview.md
@@ -35,7 +35,7 @@ User input → Interface (CLI/TUI/RPC)
     → Events emitted to bus
 ```
 
-## Metrics (0.49.9)
+## Metrics (0.49.10)
 > _See `racket scripts/metrics.rkt` for current numbers._
 
 - 414 source modules, 534 test files


### PR DESCRIPTION
Addresses #4751.

chore: bump version to 0.49.10 + process hygiene (#4751)

Version bump: 0.49.9 → 0.49.10 across all version surfaces.
CHANGELOG.md: Add v0.49.10 entry with full metrics and wave index.
Docs: Sync version references in 11 doc files.

Final v0.49.10 metrics:
- struct-out: 34 (KPI gate ≤55 ✅)
- contract-out: 149/351 = 42.4% (KPI gate ≥35% ✅)
- arch-fitness: 33/33 passing ✅

Closes v0.49.x audit remediation series.