### PR TITLE
fix: resolve 17 contract regressions from v0.49.10 (#4755)

Fix all 17 test regressions caused by overly-narrow contracts:

- RC-A: valid-session-phase? — wrap memq in boolean
- RC-B: vcs-dir? — wrap member in boolean
- RC-C: any-tool-result-entry? — wrap memq in boolean
- RC-D: expand-home-path — accept path? and preserve type
- RC-E: generate-project-tree/project-tree->string — use ->* for optional keywords, accept string?
- RC-F: glob->regexp — use ->* for optional keyword
- RC-G: make-mock-provider — use ->* for optional keywords
- RC-H: test-tool-internal-gate — remove duplicate import
- RC-I: build-enriched-compact-payload — accept #f for session-id
- RC-D extra: require-safe-path! — accept path?

All previously-failing tests now pass:
test-session-mutation, test-path-filters, test-glob, test-project-tree,
test-tool-internal-gate, test-ctx-compact, test-tool-read/write/edit,
test-tool-delete-lines, test-ls, test-main, test-spawn-subagents-batch

arch-fitness: 33/33 ✅

### DIFF
--- a/runtime/compaction-hooks.rkt
+++ b/runtime/compaction-hooks.rkt
@@ -26,10 +26,12 @@
 (provide (contract-out
           ;; #697: Enriched hook
           [build-enriched-compact-payload
-           (->* (list? any/c) (#:previous-summary (or/c #f string?) #:session-id string?) hash?)]
+           (->* (list? any/c)
+                (#:previous-summary (or/c #f string?) #:session-id (or/c #f string?))
+                hash?)]
           [dispatch-enriched-before-compact
            (->* (any/c list? any/c)
-                (#:previous-summary (or/c #f string?) #:session-id string?)
+                (#:previous-summary (or/c #f string?) #:session-id (or/c #f string?))
                 (values any/c hash?))]
           [maybe-use-custom-summary (-> any/c (or/c string? #f))]
           ;; #698: Compaction events

--- a/runtime/project-tree.rkt
+++ b/runtime/project-tree.rkt
@@ -16,14 +16,17 @@
          racket/set
          racket/path)
 
-(provide (contract-out [generate-project-tree
-                        (-> path? #:max-depth integer? #:max-entries integer? (listof string?))]
-                       [project-tree->string
-                        (-> path? #:max-depth integer? #:max-entries integer? string?)]
-                       [DEFAULT_TREE_MAX_DEPTH integer?]
-                       [DEFAULT_TREE_MAX_ENTRIES integer?]
-                       [IGNORED-DIRS any/c]
-                       [IGNORED-EXTENSIONS any/c]))
+(provide (contract-out
+          [generate-project-tree
+           (->* ((or/c path? string?))
+                (#:max-depth integer? #:max-entries integer?)
+                (listof string?))]
+          [project-tree->string
+           (->* ((or/c path? string?)) (#:max-depth integer? #:max-entries integer?) string?)]
+          [DEFAULT_TREE_MAX_DEPTH integer?]
+          [DEFAULT_TREE_MAX_ENTRIES integer?]
+          [IGNORED-DIRS any/c]
+          [IGNORED-EXTENSIONS any/c]))
 
 ;; ============================================================
 ;; Configuration

--- a/runtime/session-mutation.rkt
+++ b/runtime/session-mutation.rkt
@@ -16,7 +16,7 @@
 
 ;; Valid session phases derived from boolean flags
 (define (valid-session-phase? phase)
-  (memq phase '(idle running compacting shutting-down)))
+  (and (memq phase '(idle running compacting shutting-down)) #t))
 
 ;; Get current phase from session flags
 (define (session-phase sess)

--- a/tests/test-tool-internal-gate.rkt
+++ b/tests/test-tool-internal-gate.rkt
@@ -6,7 +6,6 @@
 
 (require rackunit
          rackunit/text-ui
-         (only-in "../tools/tool-internal.rkt" tool-execute tool-dangerous?)
          (only-in "../tools/tool-struct.rkt" tool? tool-name tool-execute tool-dangerous?)
          (only-in "../tools/tool.rkt" make-tool)
          (only-in "../tools/registry-table.rkt"

--- a/tools/builtins/builtin-helpers.rkt
+++ b/tools/builtins/builtin-helpers.rkt
@@ -11,7 +11,7 @@
                   allowed-path?
                   safe-mode-project-root))
 
-(provide (contract-out [require-safe-path! (-> string? string? (or/c #f string?))]))
+(provide (contract-out [require-safe-path! (-> (or/c path? string?) string? (or/c #f string?))]))
 
 ;; require-safe-path! : string? string? -> (or/c #f string?)
 ;; Validates that a path is allowed under safe-mode constraints.

--- a/tools/model-bridge.rkt
+++ b/tools/model-bridge.rkt
@@ -17,4 +17,5 @@
                        [model-response-content (-> any/c any/c)]
                        [model-response-stop-reason (-> any/c any/c)]
                        [make-model-response (-> any/c any/c any/c any/c any/c)]
-                       [make-mock-provider (-> any/c #:name string? #:stream-chunks any/c any/c)]))
+                       [make-mock-provider
+                        (->* (any/c) (#:name string? #:stream-chunks any/c) any/c)]))

--- a/util/entry-predicates.rkt
+++ b/util/entry-predicates.rkt
@@ -53,4 +53,4 @@
   (and (message? msg) (eq? (message-kind msg) 'bash-execution)))
 
 (define (any-tool-result-entry? msg)
-  (and (message? msg) (memq (message-kind msg) '(tool-result bash-execution))))
+  (and (message? msg) (and (memq (message-kind msg) '(tool-result bash-execution)) #t)))

--- a/util/glob.rkt
+++ b/util/glob.rkt
@@ -5,7 +5,7 @@
 (require racket/contract
          racket/string)
 
-(provide (contract-out [glob->regexp (-> string? #:allow-slash? boolean? regexp?)]))
+(provide (contract-out [glob->regexp (->* (string?) (#:allow-slash? boolean?) regexp?)]))
 
 ;; Convert a glob pattern to a regexp.
 ;; #:allow-slash? #t means * matches / (for path-based tools like find)

--- a/util/path-filters.rkt
+++ b/util/path-filters.rkt
@@ -19,7 +19,7 @@
 
 ;; Is the name a VCS or noise directory?
 (define (vcs-dir? name)
-  (member name skip-dirs))
+  (and (member name skip-dirs) #t))
 
 ;; Does the name start with a dot?
 (define (hidden-name? name)

--- a/util/path-helpers.rkt
+++ b/util/path-helpers.rkt
@@ -12,7 +12,7 @@
 
 ;; Path utility
 (provide (contract-out [path-only (-> (or/c path? string?) (or/c path? #f))]
-                       [expand-home-path (-> string? string?)]
+                       [expand-home-path (-> (or/c path? string?) (or/c path? string?))]
                        [contains-null-bytes? (-> bytes? boolean?)]
                        [bytes->display-lines
                         (-> bytes? (values (listof string?) exact-nonnegative-integer?))]))
@@ -47,10 +47,19 @@
 ;; This is needed because Racket's file-exists?, directory-exists?, etc.
 ;; do NOT expand ~ — they treat it as a literal directory name.
 (define (expand-home-path path-str)
-  (if (and (string? path-str) (> (string-length path-str) 0) (char=? (string-ref path-str 0) #\~))
-      (let ([home (find-system-path 'home-dir)])
-        (if (and (> (string-length path-str) 1) (char=? (string-ref path-str 1) #\/))
-            (path->string (simplify-path (string->path (string-append (path->string home)
-                                                                      (substring path-str 1)))))
-            (path->string home)))
-      path-str))
+  (define was-path? (path? path-str))
+  (define s
+    (if was-path?
+        (path->string path-str)
+        path-str))
+  (define result
+    (if (and (string? s) (> (string-length s) 0) (char=? (string-ref s 0) #\~))
+        (let ([home (find-system-path 'home-dir)])
+          (if (and (> (string-length s) 1) (char=? (string-ref s 1) #\/))
+              (path->string (simplify-path (string->path (string-append (path->string home)
+                                                                        (substring s 1)))))
+              (path->string home)))
+        s))
+  (if was-path?
+      (string->path result)
+      result))


### PR DESCRIPTION
Addresses #4755.

fix: resolve 17 contract regressions from v0.49.10 (#4755)

Fix all 17 test regressions caused by overly-narrow contracts:

- RC-A: valid-session-phase? — wrap memq in boolean
- RC-B: vcs-dir? — wrap member in boolean
- RC-C: any-tool-result-entry? — wrap memq in boolean
- RC-D: expand-home-path — accept path? and preserve type
- RC-E: generate-project-tree/project-tree->string — use ->* for optional keywords, accept string?
- RC-F: glob->regexp — use ->* for optional keyword
- RC-G: make-mock-provider — use ->* for optional keywords
- RC-H: test-tool-internal-gate — remove duplicate import
- RC-I: build-enriched-compact-payload — accept #f for session-id
- RC-D extra: require-safe-path! — accept path?

All previously-failing tests now pass:
test-session-mutation, test-path-filters, test-glob, test-project-tree,
test-tool-internal-gate, test-ctx-compact, test-tool-read/write/edit,
test-tool-delete-lines, test-ls, test-main, test-spawn-subagents-batch

arch-fitness: 33/33 ✅