### PR TITLE
fix: correct CHANGELOG v0.49.10 metrics, write v0.49.x series retrospective (#4757)

- Fix fabricated CHANGELOG metrics: struct-out 52→31 (not 34), contract-out
  baseline 113 (not 106), coverage 32.2%→42.5%
- Write comprehensive RETROSPECTIVE-v0.49.x.md covering v0.49.0–v0.49.11
  with verified metrics trajectory, key failures, and v0.50.x recommendations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,10 @@
 - Fixed contract arity bugs: `make-model-response` (4 args), `publish-compaction-start!/end!` (return `any/c`).
 - Fixed directive.rkt match-pattern compatibility: struct constructors kept outside `contract-out`.
 
-### Metrics
-- struct-out forms: 52 → 34 (−18)
-- contract-out files: 106 → 149 (+43)
-- contract-out coverage: 30.2% → 42.5%
+### Metrics (verified from source at tag)
+- struct-out forms (arch-fitness dirs): 52 → 31 (−21)
+- contract-out files (all source): 113 → 149 (+36)
+- contract-out coverage (all source): 32.2% → 42.5% (+10.3pp)
 - arch-fitness tests: 33/33 passing
 
 ### Waves


### PR DESCRIPTION
Addresses #4757.

fix: correct CHANGELOG v0.49.10 metrics, write v0.49.x series retrospective (#4757)

- Fix fabricated CHANGELOG metrics: struct-out 52→31 (not 34), contract-out
  baseline 113 (not 106), coverage 32.2%→42.5%
- Write comprehensive RETROSPECTIVE-v0.49.x.md covering v0.49.0–v0.49.11
  with verified metrics trajectory, key failures, and v0.50.x recommendations