### PR TITLE
fix: resolve all 47 test regressions (#4762)

- R01: wire-session-event-handlers! — add explicit (void) return (43 tests)
- R02: test-session-lifecycle-pure.rkt — fix require paths ../../ → ../ (1 test)
- R03: TUI command-parse test — handle parsed-command struct (1 test)
- R04: Extension hardening test — wrap hash in make-event for publish! (1 test)
- R05: Provider error recovery — fix max-retries → maxRetries key (1 test)

arch-fitness: 33/33 ✅
All modified test files now pass.

### DIFF
--- a/runtime/session-events.rkt
+++ b/runtime/session-events.rkt
@@ -68,7 +68,8 @@
                                   "session.compact.completed"
                                   (hasheq 'removedCount
                                           (compaction-result-removed-count compact-result)))))))
-     #:filter (lambda (evt) (equal? (event-ev evt) "compact.requested")))))
+     #:filter (lambda (evt) (equal? (event-ev evt) "compact.requested")))
+    (void)))
 
 ;; ============================================================
 ;; Helpers

--- a/tests/interfaces/tui.rkt
+++ b/tests/interfaces/tui.rkt
@@ -35,7 +35,8 @@
          "../../../q/tui/layout.rkt"
          "../../../q/util/protocol-types.rkt"
          "../../../q/agent/event-bus.rkt"
-         "../../../q/interfaces/tui.rkt")
+         "../../../q/interfaces/tui.rkt"
+         (only-in "../../../q/tui/command-parse.rkt" parsed-command? parsed-command-canonical-name))
 
 (test-case "make-tui-ctx returns a valid tui-ctx with default values"
   (let ([ctx (make-tui-ctx)])
@@ -153,7 +154,10 @@
     (define result (handle-key ctx #\return))
     (check-true (pair? result) "slash command returns a list")
     (check-equal? (car result) 'command "slash command result starts with 'command")
-    (check-equal? (cadr result) 'help "slash command parsed as 'help")))
+    (check-true (let ([cmd (cadr result)])
+                  (or (equal? cmd 'help)
+                      (and (parsed-command? cmd) (eq? (parsed-command-canonical-name cmd) 'help))))
+                "slash command parsed as 'help")))
 
 (test-case "handle-key: unknown slash /zz command returns 'unknown"
   (let ([ctx (make-tui-ctx)])

--- a/tests/test-session-lifecycle-pure.rkt
+++ b/tests/test-session-lifecycle-pure.rkt
@@ -5,18 +5,18 @@
 
 (require rackunit
          rackunit/text-ui
-         (only-in "../../runtime/session-lifecycle.rkt"
+         (only-in "../runtime/session-lifecycle.rkt"
                   build-user-message
                   compute-parent-id
                   inject-system-instructions)
-         (only-in "../../util/protocol-types.rkt"
+         (only-in "../util/protocol-types.rkt"
                   message?
                   message-role
                   message-kind
                   message-parent-id
                   make-message
                   make-text-part)
-         (only-in "../../util/message.rkt" message-content))
+         (only-in "../util/message.rkt" message-content))
 
 (define (make-test-message id parent-id role kind)
   (make-message id parent-id role kind (list (make-text-part "test")) 0 (hasheq)))

--- a/tests/workflows/extensions/test-extension-execution-hardening.rkt
+++ b/tests/workflows/extensions/test-extension-execution-hardening.rkt
@@ -25,7 +25,8 @@
          "../../../agent/event-bus.rkt"
          "../../../runtime/compactor.rkt"
          "../../../runtime/session-store.rkt"
-         "../../../util/jsonl.rkt")
+         "../../../util/jsonl.rkt"
+         (only-in "../../../util/event.rkt" make-event))
 
 ;; ── Helpers ──
 
@@ -199,7 +200,12 @@
       (define received (box '()))
       (subscribe! bus (lambda (evt) (set-box! received (cons evt (unbox received)))))
       ;; Fire an event
-      (publish! bus (hasheq 'tool "planning-write" 'args (hasheq 'artifact "PLAN")))
+      (publish! bus
+                (make-event "extension.tool-invoked"
+                            (current-inexact-milliseconds)
+                            #f
+                            #f
+                            (hasheq 'tool "planning-write" 'args (hasheq 'artifact "PLAN"))))
       ;; Small delay for async delivery
       (sleep 0.1)
       (check-true (>= (length (unbox received)) 1) "Should have at least one event"))))

--- a/tests/workflows/test-provider-error-recovery.rkt
+++ b/tests/workflows/test-provider-error-recovery.rkt
@@ -52,7 +52,7 @@
      (list (make-evt "model.stream.delta" '((delta . "Hello ")))
            (make-evt "runtime.error"
                      '((error . "HTTP read timeout after 120s") (errorType . timeout)))
-           (make-evt "auto-retry.start" '((attempt . 1) (max-retries . 2) (delay-ms . 1000)))
+           (make-evt "auto-retry.start" '((attempt . 1) (maxRetries . 2) (delay-ms . 1000)))
            (make-evt "model.stream.delta" '((delta . "Retried response")))
            (make-evt "model.stream.completed" '())
            (make-evt "turn.completed" '())))
@@ -72,7 +72,7 @@
    (define events
      (list (make-evt "runtime.error"
                      '((error . "HTTP 429 rate limit exceeded") (errorType . rate-limit)))
-           (make-evt "auto-retry.start" '((attempt . 1) (max-retries . 3) (delay-ms . 2000)))
+           (make-evt "auto-retry.start" '((attempt . 1) (maxRetries . 3) (delay-ms . 2000)))
            (make-evt "model.stream.delta" '((delta . "Success after rate limit")))
            (make-evt "model.stream.completed" '())
            (make-evt "turn.completed" '())))
@@ -161,7 +161,7 @@
    ;; First turn fails
    (define events-turn1
      (list (make-evt "runtime.error" '((error . "HTTP read timeout") (errorType . timeout)))
-           (make-evt "auto-retry.start" '((attempt . 1) (max-retries . 2) (delay-ms . 1000)))
+           (make-evt "auto-retry.start" '((attempt . 1) (maxRetries . 2) (delay-ms . 1000)))
            (make-evt "runtime.error" '((error . "HTTP read timeout") (errorType . timeout)))
            (make-evt "turn.completed" '())))
    (define s1 (simulate-events s0 events-turn1))
@@ -181,11 +181,11 @@
    (define s0 (initial-ui-state))
    (define events
      (list (make-evt "runtime.error" '((error . "HTTP read timeout") (errorType . timeout)))
-           (make-evt "auto-retry.start" '((attempt . 1) (max-retries . 3) (delay-ms . 1000)))
+           (make-evt "auto-retry.start" '((attempt . 1) (maxRetries . 3) (delay-ms . 1000)))
            (make-evt "runtime.error" '((error . "HTTP read timeout") (errorType . timeout)))
-           (make-evt "auto-retry.start" '((attempt . 2) (max-retries . 3) (delay-ms . 2000)))
+           (make-evt "auto-retry.start" '((attempt . 2) (maxRetries . 3) (delay-ms . 2000)))
            (make-evt "runtime.error" '((error . "HTTP read timeout") (errorType . timeout)))
-           (make-evt "auto-retry.start" '((attempt . 3) (max-retries . 3) (delay-ms . 4000)))
+           (make-evt "auto-retry.start" '((attempt . 3) (maxRetries . 3) (delay-ms . 4000)))
            (make-evt "runtime.error" '((error . "HTTP read timeout") (errorType . timeout)))
            (make-evt "turn.completed" '())))
    (define sf (simulate-events s0 events))
@@ -226,9 +226,9 @@
    (define s0 (initial-ui-state))
    (define events
      (list (make-evt "runtime.error" '((error . "HTTP read timeout") (errorType . timeout)))
-           (make-evt "auto-retry.start" '((attempt . 1) (max-retries . 2) (delay-ms . 1000)))
+           (make-evt "auto-retry.start" '((attempt . 1) (maxRetries . 2) (delay-ms . 1000)))
            (make-evt "runtime.error" '((error . "HTTP read timeout") (errorType . timeout)))
-           (make-evt "auto-retry.start" '((attempt . 2) (max-retries . 2) (delay-ms . 2000)))
+           (make-evt "auto-retry.start" '((attempt . 2) (maxRetries . 2) (delay-ms . 2000)))
            (make-evt "model.stream.delta" '((delta . "Finally succeeded")))
            (make-evt "model.stream.completed" '())
            (make-evt "turn.completed" '())))


### PR DESCRIPTION
Addresses #4762.

fix: resolve all 47 test regressions (#4762)

- R01: wire-session-event-handlers! — add explicit (void) return (43 tests)
- R02: test-session-lifecycle-pure.rkt — fix require paths ../../ → ../ (1 test)
- R03: TUI command-parse test — handle parsed-command struct (1 test)
- R04: Extension hardening test — wrap hash in make-event for publish! (1 test)
- R05: Provider error recovery — fix max-retries → maxRetries key (1 test)

arch-fitness: 33/33 ✅
All modified test files now pass.