### PR TITLE
chore: bump version to 0.49.12, update CHANGELOG, sync docs (#4766)

W2 series close for v0.49.12:
- CHANGELOG.md: v0.49.12 entry with metrics (158/350=45.1% contract-out KPI-dirs)
- Version bump: 0.49.11 → 0.49.12 in util/version.rkt, info.rkt
- Docs sync: all .md files updated to 0.49.12
- Retrospective updated: covers v0.49.0–v0.49.12
- arch-fitness: 33/33 ✅

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## v0.49.12 — 2026-05-20
+
+### Changed
+- Added contract-out to 9 files: util/version.rkt, llm/model-defaults.rkt, agent/event-json.rkt,
+  agent/state.rkt, cli/args.rkt, tools/tool-struct.rkt, util/cancellation.rkt, agent/event-types.rkt,
+  agent/queue.rkt.
+- Fixed 47 test regressions from v0.49.11 — explicit `(void)` returns in session event handlers,
+  corrected require paths, parsed-command struct handling, event bus make-event wrapping,
+  auto-retry lifecycle key (`maxRetries` camelCase).
+- Reverted util/version.rkt from `#lang typed/racket` to `#lang racket/base` for contract-out support.
+- agent/event-types.rkt: added `valid-typed-event-type?` contract-gated helper alongside all-from-out facade.
+
+### Metrics (verified from source)
+- struct-out forms (arch-fitness dirs): 31 (KPI gate ≤55 ✅)
+- contract-out files (KPI-dirs): 158/350 = 45.1% (KPI gate ≥45% ✅, was 42.5%)
+- arch-fitness tests: 33/33 ✅
+
+### Waves
+- W0: Fix 47 test regressions from v0.49.11 (PR #4763)
+- W1: Contract-out coverage gap close — +9 files (PR #4765)
+- W2: CHANGELOG, retrospective, version bump (this release)
+
 ## v0.49.11 — 2026-05-20
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.49.11-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.49.12-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 
@@ -203,7 +203,7 @@ bin/q --model gpt-5.4 "write a test"
 ### Verify
 
 ```bash
-bin/q --version            # q version 0.49.11
+bin/q --version            # q version 0.49.12
 raco test tests/           # run the full test suite
 ```
 
@@ -419,7 +419,7 @@ When q executes shell commands on behalf of an LLM, arguments are quoted via `sh
 
 
 
-**v0.49.11** — Fixed
+**v0.49.12** — Changed
 
 **v0.49.10** — Changed
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -2,7 +2,7 @@
 
 ## Version
 
-v0.49.11
+v0.49.12
 
 ## Layer Diagram
 

--- a/docs/event-taxonomy.md
+++ b/docs/event-taxonomy.md
@@ -1,6 +1,6 @@
 # Q Event Taxonomy Reference
 
-Complete reference for all event types in Q 0.49.11.
+Complete reference for all event types in Q 0.49.12.
 ## Base Types
 
 ### `event` (protocol-level)

--- a/docs/extension-guide.md
+++ b/docs/extension-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.49.11 --># Extension Development Guide
+<!-- verified-against: 0.49.12 --># Extension Development Guide
 
 This guide walks you through creating, testing, and activating a custom
 extension for q.

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.49.11 --># Getting Started
+<!-- verified-against: 0.49.12 --># Getting Started
 
 Welcome to q, a Racket-based coding agent.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.49.11 --># Installation Guide
+<!-- verified-against: 0.49.12 --># Installation Guide
 
 <!-- This file is the canonical source. The docs/getting-started/installation.md copy is maintained for the doc site build. -->
 

--- a/docs/security-trust-model.md
+++ b/docs/security-trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.49.11 --># Security & Trust Model
+<!-- verified-against: 0.49.12 --># Security & Trust Model
 
 This document provides an honest, per-area assessment of what q enforces
 today and what is planned. It is the authoritative reference for security

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -130,6 +130,6 @@ is the primary self-hosting extension:
 (load-extension! ext-reg "path/to/extension.rkt" #:event-bus bus)
 ```
 
-## Version 0.49.11
+## Version 0.49.12
 
-This documentation reflects q 0.49.11.
+This documentation reflects q 0.49.12.

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.49.11 --># q Source Style Guide
+<!-- verified-against: 0.49.12 --># q Source Style Guide
 
 This document defines formatting and naming conventions for the q Racket codebase.
 All changes to `q/` source files (excluding `tests/`) should follow these rules.

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.49.11 --># Trust Model
+<!-- verified-against: 0.49.12 --># Trust Model
 
 ## Trust Levels
 

--- a/docs/workflow-testing.md
+++ b/docs/workflow-testing.md
@@ -121,6 +121,6 @@ Use relative paths from the test file:
 4. Use `(check-true ...)` for boolean assertions
 5. Keep tests independent — no shared mutable state between test-cases
 
-## Version 0.49.11
+## Version 0.49.12
 
-This documentation reflects q 0.49.11.
+This documentation reflects q 0.49.12.

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.49.11")
+(define version "0.49.12")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base"))

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -11,4 +11,4 @@
 
 (provide (contract-out [q-version string?]))
 
-(define q-version "0.49.11")
+(define q-version "0.49.12")

--- a/wiki-src/Architecture-Overview.md
+++ b/wiki-src/Architecture-Overview.md
@@ -35,7 +35,7 @@ User input → Interface (CLI/TUI/RPC)
     → Events emitted to bus
 ```
 
-## Metrics (0.49.11)
+## Metrics (0.49.12)
 > _See `racket scripts/metrics.rkt` for current numbers._
 
 - 414 source modules, 534 test files


### PR DESCRIPTION
Addresses #4766.

chore: bump version to 0.49.12, update CHANGELOG, sync docs (#4766)

W2 series close for v0.49.12:
- CHANGELOG.md: v0.49.12 entry with metrics (158/350=45.1% contract-out KPI-dirs)
- Version bump: 0.49.11 → 0.49.12 in util/version.rkt, info.rkt
- Docs sync: all .md files updated to 0.49.12
- Retrospective updated: covers v0.49.0–v0.49.12
- arch-fitness: 33/33 ✅