### PR TITLE
fix: resolve all contract-out return-type mismatches (P0 + P2) (#4769)

R01: cancel-token! contract changed to cancellation-token? return (matches impl + test)
R02: valid-typed-event-type? wrapped member in (and ... #t) for boolean
R03: emit-queue-event! added (void) return — hardens all enqueue/dequeue
R04: write-compaction-entry! hardened with (void) return
Hardening sweep of remaining void? contracts — no further issues found

All 11 previously-failing test files now pass (0 failures).
arch-fitness: 33/33 ✅

### DIFF
--- a/agent/event-types.rkt
+++ b/agent/event-types.rkt
@@ -23,4 +23,4 @@
 
 ;; Thin validation helper — contract-gated facade utility
 (define (valid-typed-event-type? type-str)
-  (member type-str (all-known-event-types)))
+  (and (member type-str (all-known-event-types)) #t))

--- a/agent/queue.rkt
+++ b/agent/queue.rkt
@@ -51,7 +51,8 @@
 (define (emit-queue-event! q event-type details)
   (define cb (unbox (queue-event-callback-box q)))
   (when cb
-    (cb event-type details)))
+    (cb event-type details))
+  (void))
 
 ;; ============================================================
 ;; Internal O(1) two-list queue operations

--- a/runtime/compactor.rkt
+++ b/runtime/compactor.rkt
@@ -384,5 +384,6 @@
 (define (write-compaction-entry! session-path compaction-res)
   (define summary (compaction-result-summary-message compaction-res))
   (when summary
-    (append-entry! session-path summary)))
+    (append-entry! session-path summary))
+  (void))
 ;; v0.31.x milestone placeholder

--- a/util/cancellation.rkt
+++ b/util/cancellation.rkt
@@ -20,7 +20,7 @@
                        [cancellation-token-cancelled? (-> cancellation-token? boolean?)]
                        [make-cancellation-token
                         (->* () (#:callback (or/c procedure? #f)) cancellation-token?)]
-                       [cancel-token! (-> cancellation-token? void?)]))
+                       [cancel-token! (-> cancellation-token? cancellation-token?)]))
 
 ;; ============================================================
 ;; Struct & constructor


### PR DESCRIPTION
Addresses #4769.

fix: resolve all contract-out return-type mismatches (P0 + P2) (#4769)

R01: cancel-token! contract changed to cancellation-token? return (matches impl + test)
R02: valid-typed-event-type? wrapped member in (and ... #t) for boolean
R03: emit-queue-event! added (void) return — hardens all enqueue/dequeue
R04: write-compaction-entry! hardened with (void) return
Hardening sweep of remaining void? contracts — no further issues found

All 11 previously-failing test files now pass (0 failures).
arch-fitness: 33/33 ✅