### PR TITLE
feat(T2-1): make loop-state opaque — remove #:transparent (#4795)

Hides mutable boxes from consumers. All access already through contracted
accessors (loop-state-messages, loop-state-events, state-add-message!,
state-add-event!). No consumers used struct constructor directly.

### DIFF
--- a/agent/state.rkt
+++ b/agent/state.rkt
@@ -31,7 +31,7 @@
 ;; Internal struct — mutable boxes for accumulation
 ;; ============================================================
 
-(struct loop-state (session-id turn-id messages-box events-box) #:transparent)
+(struct loop-state (session-id turn-id messages-box events-box))
 
 ;; ============================================================
 ;; Constructor


### PR DESCRIPTION
Addresses #4795.

feat(T2-1): make loop-state opaque — remove #:transparent (#4795)

Hides mutable boxes from consumers. All access already through contracted
accessors (loop-state-messages, loop-state-events, state-add-message!,
state-add-event!). No consumers used struct constructor directly.