### PR TITLE
feat(T2-2): make queue/sub-queue opaque — remove #:transparent (#4797)

Hides internal semaphore, sub-queue boxes, and event callback box.
All access already through contracted accessors (enqueue/dequeue, queue-status, etc).

### DIFF
--- a/agent/queue.rkt
+++ b/agent/queue.rkt
@@ -30,9 +30,9 @@
 ;; Enqueue conses onto tail: O(1)
 ;; Dequeue pops from head, reverses tail if head empty: amortized O(1)
 
-(struct sub-queue (head-box tail-box) #:transparent)
+(struct sub-queue (head-box tail-box))
 
-(struct queue (steering followup semaphore event-callback-box) #:transparent)
+(struct queue (steering followup semaphore event-callback-box))
 
 ;; ============================================================
 ;; Constructor


### PR DESCRIPTION
Addresses #4797.

feat(T2-2): make queue/sub-queue opaque — remove #:transparent (#4797)

Hides internal semaphore, sub-queue boxes, and event callback box.
All access already through contracted accessors (enqueue/dequeue, queue-status, etc).