### PR TITLE
feat(T2-3): make runtime/runtime-config opaque + version bump v0.50.3 (#4799)

Removed #:transparent from runtime, runtime-config, loop-state, queue structs.
Internal state now hidden from consumers. Version 0.50.2→0.50.3.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## v0.50.3 — 2026-05-20
+
+### Changed
+- T2-1: `agent/state.rkt` — `loop-state` struct made opaque (removed `#:transparent`).
+  Mutable boxes hidden from consumers; all access via contracted accessors.
+- T2-2: `agent/queue.rkt` — `queue` and `sub-queue` structs made opaque.
+  Semaphore and internal boxes hidden; all access via contracted API.
+- T2-3: `interfaces/sdk-core.rkt` — `runtime` and `runtime-config` structs made opaque.
+  Constructor access retained via `struct-out`; transparent printing removed.
+
+### Metrics
+- #:transparent structs reduced by 5
+- arch-fitness tests: 33/33 ✅
+- Test failures: 0
+
+### Waves
+- W0: loop-state opaque (PR #4796)
+- W1: queue opaque (PR #4798)
+- W2: SDK opaque + version bump (this release)
+
 ## v0.50.2 — 2026-05-20
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.50.2-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.50.3-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 
@@ -203,7 +203,7 @@ bin/q --model gpt-5.4 "write a test"
 ### Verify
 
 ```bash
-bin/q --version            # q version 0.50.2
+bin/q --version            # q version 0.50.3
 raco test tests/           # run the full test suite
 ```
 
@@ -276,7 +276,7 @@ q/
 |--------|-------|
 | Test files | 606 |
 | Source modules | 438 |
-| Source lines | 68326 |
+| Source lines | 68323 |
 | Test lines | 105383 |
 | Test assertions | 16452 |
 | Tests passing | 5835+ | `racket scripts/run-tests.rkt` results |
@@ -421,11 +421,11 @@ When q executes shell commands on behalf of an LLM, arguments are quoted via `sh
 
 
 
-**v0.50.2** — Changed
+**v0.50.3** — Changed
 
-**v0.50.2** — Fixed
+**v0.50.3** — Fixed
 
-**v0.50.2** — Changed
+**v0.50.3** — Changed
 
 **v0.49.10** — Changed
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -2,7 +2,7 @@
 
 ## Version
 
-v0.50.2
+v0.50.3
 
 ## Layer Diagram
 

--- a/docs/event-taxonomy.md
+++ b/docs/event-taxonomy.md
@@ -1,6 +1,6 @@
 # Q Event Taxonomy Reference
 
-Complete reference for all event types in Q 0.50.2.
+Complete reference for all event types in Q 0.50.3.
 ## Base Types
 
 ### `event` (protocol-level)

--- a/docs/extension-guide.md
+++ b/docs/extension-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.50.2 --># Extension Development Guide
+<!-- verified-against: 0.50.3 --># Extension Development Guide
 
 This guide walks you through creating, testing, and activating a custom
 extension for q.

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.50.2 --># Getting Started
+<!-- verified-against: 0.50.3 --># Getting Started
 
 Welcome to q, a Racket-based coding agent.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.50.2 --># Installation Guide
+<!-- verified-against: 0.50.3 --># Installation Guide
 
 <!-- This file is the canonical source. The docs/getting-started/installation.md copy is maintained for the doc site build. -->
 

--- a/docs/security-trust-model.md
+++ b/docs/security-trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.50.2 --># Security & Trust Model
+<!-- verified-against: 0.50.3 --># Security & Trust Model
 
 This document provides an honest, per-area assessment of what q enforces
 today and what is planned. It is the authoritative reference for security

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -130,6 +130,6 @@ is the primary self-hosting extension:
 (load-extension! ext-reg "path/to/extension.rkt" #:event-bus bus)
 ```
 
-## Version 0.50.2
+## Version 0.50.3
 
-This documentation reflects q 0.50.2.
+This documentation reflects q 0.50.3.

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.50.2 --># q Source Style Guide
+<!-- verified-against: 0.50.3 --># q Source Style Guide
 
 This document defines formatting and naming conventions for the q Racket codebase.
 All changes to `q/` source files (excluding `tests/`) should follow these rules.

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.50.2 --># Trust Model
+<!-- verified-against: 0.50.3 --># Trust Model
 
 ## Trust Levels
 

--- a/docs/workflow-testing.md
+++ b/docs/workflow-testing.md
@@ -121,6 +121,6 @@ Use relative paths from the test file:
 4. Use `(check-true ...)` for boolean assertions
 5. Keep tests independent — no shared mutable state between test-cases
 
-## Version 0.50.2
+## Version 0.50.3
 
-This documentation reflects q 0.50.2.
+This documentation reflects q 0.50.3.

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.50.2")
+(define version "0.50.3")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base"))

--- a/interfaces/sdk-core.rkt
+++ b/interfaces/sdk-core.rkt
@@ -153,12 +153,9 @@
                   system-instructions
                   token-budget-threshold
                   resource-loader
-                  session-manager)
-  #:transparent)
+                  session-manager))
 
-(struct runtime (rt-config rt-session rt-cancellation-token)
-  #:transparent
-  #:constructor-name make-runtime-internal)
+(struct runtime (rt-config rt-session rt-cancellation-token) #:constructor-name make-runtime-internal)
 
 ;; ============================================================
 ;; Internal helpers

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -11,4 +11,4 @@
 
 (provide (contract-out [q-version string?]))
 
-(define q-version "0.50.2")
+(define q-version "0.50.3")

--- a/wiki-src/Architecture-Overview.md
+++ b/wiki-src/Architecture-Overview.md
@@ -35,7 +35,7 @@ User input → Interface (CLI/TUI/RPC)
     → Events emitted to bus
 ```
 
-## Metrics (0.50.2)
+## Metrics (0.50.3)
 > _See `racket scripts/metrics.rkt` for current numbers._
 
 - 414 source modules, 534 test files


### PR DESCRIPTION
Addresses #4799.

feat(T2-3): make runtime/runtime-config opaque + version bump v0.50.3 (#4799)

Removed #:transparent from runtime, runtime-config, loop-state, queue structs.
Internal state now hidden from consumers. Version 0.50.2→0.50.3.