### PR TITLE
feat(T2-5b): cond→match in runtime/extensions files (#4804)

loader.rkt: classify-exception uses match on exception type predicates;
load-extension-validate uses match with or-pattern on symbols.
gsd-planning.rkt: gsd-mode and set-gsd-mode! use match on symbols.
settings.rkt: deep-merge-hash inner uses match* on (left-v, v) types.
5 cond→match conversions across 3 files.

### DIFF
--- a/extensions/gsd-planning.rkt
+++ b/extensions/gsd-planning.rkt
@@ -13,6 +13,7 @@
 
 (require racket/contract
          racket/match
+         racket/match
          racket/string
          json
          "define-extension.rkt"
@@ -69,21 +70,21 @@
 ;; Legacy mode wrappers (DEBT-01: migrated from gsd-planning-state.rkt)
 (define (gsd-mode)
   (let ([s (gsm-current)])
-    (cond
-      [(eq? s 'idle) #f]
-      [(eq? s 'exploring) 'planning]
-      [else s])))
+    (match s
+      ['idle #f]
+      ['exploring 'planning]
+      [_ s])))
 
 (define (gsd-mode? v)
   (eq? (gsd-mode) v))
 
 (define (set-gsd-mode! v)
-  (cond
-    [(not v) (gsm-reset!)]
-    [(eq? v 'planning) (gsm-transition-to! 'exploring)]
-    [(eq? v 'plan-written) (gsm-transition-to! 'plan-written)]
-    [(eq? v 'executing) (gsm-transition-to! 'executing)]
-    [else (gsm-transition! v)]))
+  (match v
+    [#f (gsm-reset!)]
+    ['planning (gsm-transition-to! 'exploring)]
+    ['plan-written (gsm-transition-to! 'plan-written)]
+    ['executing (gsm-transition-to! 'executing)]
+    [_ (gsm-transition! v)]))
 
 ;; Legacy accessor wrappers (DEBT-01)
 (define (pinned-planning-dir)
@@ -117,8 +118,8 @@
 
 ;; reset-all-gsd-state! is now in gsd/core.rkt
 
-(provide ;; State accessors (locally defined parameter wrappers)
-         (contract-out [gsd-mode (-> symbol?)]
+;; State accessors (locally defined parameter wrappers)
+(provide (contract-out [gsd-mode (-> symbol?)]
                        [gsd-mode? (-> any/c boolean?)]
                        [set-gsd-mode! (-> symbol? void?)]
                        [pinned-planning-dir (-> (or/c path? #f))]

--- a/extensions/loader.rkt
+++ b/extensions/loader.rkt
@@ -11,6 +11,7 @@
 ;;   - Provide `the-extension` bound to an extension? struct
 
 (require racket/contract
+         racket/match
          racket/file
          (only-in racket/path file-name-from-path)
          (only-in "../util/path-helpers.rkt" path-only)
@@ -101,9 +102,9 @@
 (define (load-extension-validate path)
   (define ext-name (get-extension-name-from-path path))
   (define state (extension-state ext-name))
-  (cond
-    [(or (eq? state 'disabled) (eq? state 'quarantined)) state]
-    [else 'ok]))
+  (match state
+    [(or 'disabled 'quarantined) state]
+    [_ 'ok]))
 
 ;; Phase 2: Attempt to load extension with optional timeout
 (define (load-extension-attempt path)
@@ -286,13 +287,13 @@
 
 ;; Classify an exception into a category symbol.
 (define (classify-exception e)
-  (cond
-    [(exn:fail:syntax? e) 'syntax-error]
-    [(exn:fail:read? e) 'syntax-error]
-    [(exn:fail:filesystem? e) 'filesystem-error]
-    [(exn:fail:contract? e) 'contract-error]
-    [(not-found-error? e) 'not-found]
-    [else 'unknown]))
+  (match e
+    [(? exn:fail:syntax?) 'syntax-error]
+    [(? exn:fail:read?) 'syntax-error]
+    [(? exn:fail:filesystem?) 'filesystem-error]
+    [(? exn:fail:contract?) 'contract-error]
+    [(? not-found-error?) 'not-found]
+    [_ 'unknown]))
 
 ;; Internal exception type for missing files.
 (struct not-found-error exn:fail () #:transparent)

--- a/runtime/settings.rkt
+++ b/runtime/settings.rkt
@@ -16,6 +16,7 @@
 
 (require "../util/json-helpers.rkt")
 (require racket/contract
+         racket/match
          racket/file
          racket/port
          racket/hash
@@ -153,9 +154,9 @@
     [else
      (for/fold ([acc left]) ([(k v) (in-hash right)])
        (define left-v (hash-ref acc k #f))
-       (cond
-         [(and (hash? left-v) (hash? v)) (hash-set acc k (deep-merge-hash left-v v))]
-         [else (hash-set acc k v)]))]))
+       (match* (left-v v)
+         [((? hash?) (? hash?)) (hash-set acc k (deep-merge-hash left-v v))]
+         [(_ _) (hash-set acc k v)]))]))
 
 ;; Sentinel for distinguishing "not found" from "found #f"
 (define NOT-FOUND (gensym 'not-found))


### PR DESCRIPTION
Addresses #4804.

feat(T2-5b): cond→match in runtime/extensions files (#4804)

loader.rkt: classify-exception uses match on exception type predicates;
load-extension-validate uses match with or-pattern on symbols.
gsd-planning.rkt: gsd-mode and set-gsd-mode! use match on symbols.
settings.rkt: deep-merge-hash inner uses match* on (left-v, v) types.
5 cond→match conversions across 3 files.