### PR TITLE
feat(T2-5c): cond→match in interface/tools + version bump v0.50.4 (#4806)

sdk-core.rkt: navigate! uses match on target type.
spawn-subagent.rkt: content part dispatch uses match on type field.
10 total cond→match conversions. Version 0.50.3→0.50.4.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## v0.50.4 — 2026-05-20
+
+### Changed
+- T2-5: 10 `cond`→`match` conversions across 8 files for exhaustiveness and idiomatic Racket:
+  - `llm/provider.rkt`: stream-result->generator dispatches on type
+  - `tui/state-events.rkt`: classify-error-type uses match+regexp; handle-compaction-lifecycle uses or-patterns
+  - `extensions/loader.rkt`: classify-exception on exception type; load-extension-validate on state symbols
+  - `extensions/gsd-planning.rkt`: gsd-mode and set-gsd-mode! on symbols
+  - `runtime/settings.rkt`: deep-merge-hash inner uses match* on type pairs
+  - `interfaces/sdk-core.rkt`: navigate! dispatches on target type
+  - `tools/builtins/spawn-subagent.rkt`: content part dispatch on type field
+
+### Metrics
+- cond→match conversions: 10
+- arch-fitness tests: 33/33 ✅
+- Test failures: 0
+
+### Waves
+- W0: Agent+LLM+TUI cond→match (PR #4803)
+- W1: Runtime+Extensions cond→match (PR #4805)
+- W2: Interface+Tools cond→match + version bump (this release)
+
 ## v0.50.3 — 2026-05-20
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.50.3-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.50.4-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 
@@ -203,7 +203,7 @@ bin/q --model gpt-5.4 "write a test"
 ### Verify
 
 ```bash
-bin/q --version            # q version 0.50.3
+bin/q --version            # q version 0.50.4
 raco test tests/           # run the full test suite
 ```
 
@@ -276,7 +276,7 @@ q/
 |--------|-------|
 | Test files | 606 |
 | Source modules | 438 |
-| Source lines | 68323 |
+| Source lines | 68326 |
 | Test lines | 105383 |
 | Test assertions | 16452 |
 | Tests passing | 5835+ | `racket scripts/run-tests.rkt` results |
@@ -421,11 +421,11 @@ When q executes shell commands on behalf of an LLM, arguments are quoted via `sh
 
 
 
-**v0.50.3** — Changed
+**v0.50.4** — Changed
 
-**v0.50.3** — Fixed
+**v0.50.4** — Fixed
 
-**v0.50.3** — Changed
+**v0.50.4** — Changed
 
 **v0.49.10** — Changed
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -2,7 +2,7 @@
 
 ## Version
 
-v0.50.3
+v0.50.4
 
 ## Layer Diagram
 

--- a/docs/event-taxonomy.md
+++ b/docs/event-taxonomy.md
@@ -1,6 +1,6 @@
 # Q Event Taxonomy Reference
 
-Complete reference for all event types in Q 0.50.3.
+Complete reference for all event types in Q 0.50.4.
 ## Base Types
 
 ### `event` (protocol-level)

--- a/docs/extension-guide.md
+++ b/docs/extension-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.50.3 --># Extension Development Guide
+<!-- verified-against: 0.50.4 --># Extension Development Guide
 
 This guide walks you through creating, testing, and activating a custom
 extension for q.

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.50.3 --># Getting Started
+<!-- verified-against: 0.50.4 --># Getting Started
 
 Welcome to q, a Racket-based coding agent.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.50.3 --># Installation Guide
+<!-- verified-against: 0.50.4 --># Installation Guide
 
 <!-- This file is the canonical source. The docs/getting-started/installation.md copy is maintained for the doc site build. -->
 

--- a/docs/security-trust-model.md
+++ b/docs/security-trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.50.3 --># Security & Trust Model
+<!-- verified-against: 0.50.4 --># Security & Trust Model
 
 This document provides an honest, per-area assessment of what q enforces
 today and what is planned. It is the authoritative reference for security

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -130,6 +130,6 @@ is the primary self-hosting extension:
 (load-extension! ext-reg "path/to/extension.rkt" #:event-bus bus)
 ```
 
-## Version 0.50.3
+## Version 0.50.4
 
-This documentation reflects q 0.50.3.
+This documentation reflects q 0.50.4.

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.50.3 --># q Source Style Guide
+<!-- verified-against: 0.50.4 --># q Source Style Guide
 
 This document defines formatting and naming conventions for the q Racket codebase.
 All changes to `q/` source files (excluding `tests/`) should follow these rules.

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.50.3 --># Trust Model
+<!-- verified-against: 0.50.4 --># Trust Model
 
 ## Trust Levels
 

--- a/docs/workflow-testing.md
+++ b/docs/workflow-testing.md
@@ -121,6 +121,6 @@ Use relative paths from the test file:
 4. Use `(check-true ...)` for boolean assertions
 5. Keep tests independent — no shared mutable state between test-cases
 
-## Version 0.50.3
+## Version 0.50.4
 
-This documentation reflects q 0.50.3.
+This documentation reflects q 0.50.4.

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.50.3")
+(define version "0.50.4")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base"))

--- a/interfaces/sdk-core.rkt
+++ b/interfaces/sdk-core.rkt
@@ -11,6 +11,7 @@
 ;; thinking level, and context usage types.
 
 (require racket/contract
+         racket/match
          racket/math
          racket/list
          "../llm/provider.rkt"
@@ -393,16 +394,18 @@
 
 (define (navigate! rt target)
   (define sess (rt-sess rt))
-  (cond
-    [(not sess) 'no-active-session]
-    [else
+  (match sess
+    [#f 'no-active-session]
+    [_
      (define idx (session:agent-session-index sess))
-     (cond
-       [(not idx) 'no-active-session]
-       [(string? target) (or (navigate-to-entry! idx target) 'invalid-target)]
-       [(and (exact-integer? target) (> target 0)) (navigate-next-leaf! idx)]
-       [(and (exact-integer? target) (< target 0)) (navigate-prev-leaf! idx)]
-       [else 'invalid-target])]))
+     (match idx
+       [#f 'no-active-session]
+       [_
+        (match target
+          [(? string?) (or (navigate-to-entry! idx target) 'invalid-target)]
+          [(? exact-positive-integer?) (navigate-next-leaf! idx)]
+          [(? (lambda (x) (and (exact-integer? x) (negative? x)))) (navigate-prev-leaf! idx)]
+          [_ 'invalid-target])])]))
 
 ;; ============================================================
 ;; create-agent-session (#1152)

--- a/tools/builtins/spawn-subagent.rkt
+++ b/tools/builtins/spawn-subagent.rkt
@@ -10,6 +10,7 @@
 ;; #1203/#1204: Real provider injection — uses parent's provider
 
 (require racket/contract
+         racket/match
          racket/list
          racket/string
          "../../tools/tool.rkt"
@@ -45,9 +46,8 @@
          (only-in "../builtins/ls.rkt" tool-ls)
          (only-in "../builtins/skill-router.rkt" tool-skill-route))
 
-(provide (contract-out
-          [resolve-role-prompt (-> any/c string?)]
-          [parse-subagent-config (-> any/c subagent-config?)])
+(provide (contract-out [resolve-role-prompt (-> any/c string?)]
+                       [parse-subagent-config (-> any/c subagent-config?)])
          ;; Tool entries (direct — used by scheduler)
          tool-spawn-subagent
          tool-spawn-subagents
@@ -295,18 +295,14 @@
        ;; Build assistant message from response content parts
        (define content-parts
          (for/list ([c (in-list content)])
-           (cond
-             [(hash-ref c 'type #f)
-              =>
-              (lambda (t)
-                (cond
-                  [(equal? t "text") (hash-ref c 'text (format "~a" c))]
-                  [(equal? t "tool_call")
-                   (make-tool-call-part (hash-ref c 'id (generate-id))
-                                        (hash-ref c 'name "")
-                                        (ensure-hash-args (hash-ref c 'arguments "{}")))]
-                  [else (format "~a" c)]))]
-             [else (hash-ref c 'text (format "~a" c))])))
+           (match (hash-ref c 'type #f)
+             ["text" (hash-ref c 'text (format "~a" c))]
+             ["tool_call"
+              (make-tool-call-part (hash-ref c 'id (generate-id))
+                                   (hash-ref c 'name "")
+                                   (ensure-hash-args (hash-ref c 'arguments "{}")))]
+             [#f (hash-ref c 'text (format "~a" c))]
+             [_ (format "~a" c)])))
        (define assistant-msg
          (make-message (generate-id) #f 'assistant 'message content-parts (current-seconds) (hasheq)))
        (define new-all (append all-results (list assistant-msg)))

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -11,4 +11,4 @@
 
 (provide (contract-out [q-version string?]))
 
-(define q-version "0.50.3")
+(define q-version "0.50.4")

--- a/wiki-src/Architecture-Overview.md
+++ b/wiki-src/Architecture-Overview.md
@@ -35,7 +35,7 @@ User input → Interface (CLI/TUI/RPC)
     → Events emitted to bus
 ```
 
-## Metrics (0.50.3)
+## Metrics (0.50.4)
 > _See `racket scripts/metrics.rkt` for current numbers._
 
 - 414 source modules, 534 test files


### PR DESCRIPTION
Addresses #4806.

feat(T2-5c): cond→match in interface/tools + version bump v0.50.4 (#4806)

sdk-core.rkt: navigate! uses match on target type.
spawn-subagent.rkt: content part dispatch uses match on type field.
10 total cond→match conversions. Version 0.50.3→0.50.4.