### PR TITLE
feat(T2-7): streaming-message FSM state replaces 3 boolean boxes (#4811)

Replaced started-box, blocked-box, cancelled-box with single state-box tracking
FSM state: not-started | streaming | done | blocked | cancelled. Backward-compatible
predicates (message-started?, cancelled?, blocked?) now check FSM state.
Added streaming-message-fsm-state accessor. 8 new FSM tests, 20 total pass.

### DIFF
--- a/agent/streaming-message.rkt
+++ b/agent/streaming-message.rkt
@@ -25,9 +25,7 @@
          tool-calls-box ; (box (listof tool-call-delta)) — accumulated tool calls
          thinking-box ; (box string) — accumulated thinking/reasoning (FEAT-72)
          chunks-box ; (box (listof stream-chunk)) — all chunks for replay
-         cancelled-box ; (box boolean)
-         blocked-box ; (box boolean)
-         started-box ; (box boolean) — whether message.start was emitted
+         state-box ; (box symbol) — FSM state: not-started | streaming | done | blocked | cancelled
          message-id ; string — unique message identifier
          )
   #:transparent) ;; Keep transparent internally for debugging
@@ -37,7 +35,7 @@
 ;; ============================================================
 
 (define (make-streaming-message message-id)
-  (streaming-message (box "") (box '()) (box "") (box '()) (box #f) (box #f) (box #f) message-id))
+  (streaming-message (box "") (box '()) (box "") (box '()) (box 'not-started) message-id))
 
 ;; ============================================================
 ;; Accumulator operations
@@ -60,13 +58,17 @@
   (set-box! b (cons chunk (unbox b))))
 
 (define (streaming-message-set-cancelled! sm)
-  (set-box! (streaming-message-cancelled-box sm) #t))
+  (set-box! (streaming-message-state-box sm) 'cancelled))
 
 (define (streaming-message-set-blocked! sm)
-  (set-box! (streaming-message-blocked-box sm) #t))
+  (set-box! (streaming-message-state-box sm) 'blocked))
 
 (define (streaming-message-set-message-started! sm)
-  (set-box! (streaming-message-started-box sm) #t))
+  (set-box! (streaming-message-state-box sm) 'streaming))
+
+;; FSM state accessor
+(define (streaming-message-fsm-state sm)
+  (unbox (streaming-message-state-box sm)))
 
 ;; ============================================================
 ;; Value accessors (unbox)
@@ -85,13 +87,13 @@
   (unbox (streaming-message-chunks-box sm)))
 
 (define (streaming-message-cancelled? sm)
-  (unbox (streaming-message-cancelled-box sm)))
+  (eq? (unbox (streaming-message-state-box sm)) 'cancelled))
 
 (define (streaming-message-blocked? sm)
-  (unbox (streaming-message-blocked-box sm)))
+  (eq? (unbox (streaming-message-state-box sm)) 'blocked))
 
 (define (streaming-message-message-started? sm)
-  (unbox (streaming-message-started-box sm)))
+  (and (memq (unbox (streaming-message-state-box sm)) '(streaming done blocked cancelled)) #t))
 
 ;; ============================================================
 ;; Finalization
@@ -152,7 +154,8 @@
                        [streaming-message-set-blocked! (-> streaming-message? void?)]
                        [streaming-message-set-message-started! (-> streaming-message? void?)])
          ;; Read accessors
-         (contract-out [streaming-message-text (-> streaming-message? string?)]
+         (contract-out [streaming-message-fsm-state (-> streaming-message? symbol?)]
+                       [streaming-message-text (-> streaming-message? string?)]
                        [streaming-message-tool-calls (-> streaming-message? (listof any/c))]
                        [streaming-message-thinking (-> streaming-message? string?)]
                        [streaming-message-chunks (-> streaming-message? (listof any/c))]

--- a/tests/test-loop-stream-pure.rkt
+++ b/tests/test-loop-stream-pure.rkt
@@ -6,7 +6,8 @@
 (require rackunit
          racket/match
          "../llm/model.rkt"
-         "../agent/loop-stream.rkt")
+         "../agent/loop-stream.rkt"
+         "../agent/streaming-message.rkt")
 
 ;; Helper: make a stream-chunk with specific fields
 (define (make-test-chunk #:delta-text [dt #f]
@@ -87,3 +88,60 @@
 
 (test-case "chunk-has-data?: #t for tool-call chunk"
   (check-true (chunk-has-data? (make-test-chunk #:delta-tool-call (hasheq)))))
+
+;; ============================================================
+;; Streaming message FSM state tests (T2-7)
+;; ============================================================
+
+(test-case "streaming-message: initial FSM state is not-started"
+  (define sm (make-streaming-message "msg-test"))
+  (check-equal? (streaming-message-fsm-state sm) 'not-started)
+  (check-false (streaming-message-message-started? sm))
+  (check-false (streaming-message-cancelled? sm))
+  (check-false (streaming-message-blocked? sm)))
+
+(test-case "streaming-message: set-message-started! transitions to streaming"
+  (define sm (make-streaming-message "msg-test"))
+  (streaming-message-set-message-started! sm)
+  (check-equal? (streaming-message-fsm-state sm) 'streaming)
+  (check-true (streaming-message-message-started? sm)))
+
+(test-case "streaming-message: set-cancelled! transitions to cancelled"
+  (define sm (make-streaming-message "msg-test"))
+  (streaming-message-set-cancelled! sm)
+  (check-equal? (streaming-message-fsm-state sm) 'cancelled)
+  (check-true (streaming-message-cancelled? sm)))
+
+(test-case "streaming-message: set-blocked! transitions to blocked"
+  (define sm (make-streaming-message "msg-test"))
+  (streaming-message-set-blocked! sm)
+  (check-equal? (streaming-message-fsm-state sm) 'blocked)
+  (check-true (streaming-message-blocked? sm)))
+
+(test-case "streaming-message: message-started? true in all non-initial states"
+  (define sm (make-streaming-message "msg-test"))
+  (streaming-message-set-message-started! sm)
+  (check-true (streaming-message-message-started? sm))
+  ;; After blocking, still "started"
+  (streaming-message-set-blocked! sm)
+  (check-true (streaming-message-message-started? sm)))
+
+(test-case "streaming-message: accumulate text"
+  (define sm (make-streaming-message "msg-test"))
+  (streaming-message-append-text! sm "hello ")
+  (streaming-message-append-text! sm "world")
+  (check-equal? (streaming-message-text sm) "hello world"))
+
+(test-case "streaming-message: accumulate tool calls"
+  (define sm (make-streaming-message "msg-test"))
+  (define tc (hasheq 'id "tc-1" 'name "read"))
+  (streaming-message-append-tool-call! sm tc)
+  (check-equal? (length (streaming-message-tool-calls sm)) 1)
+  (check-equal? (streaming-message-tool-calls sm) (list tc)))
+
+(test-case "streaming-message: ->hash includes FSM state data"
+  (define sm (make-streaming-message "msg-test"))
+  (streaming-message-set-message-started! sm)
+  (define h (streaming-message->hash sm))
+  (check-equal? (hash-ref h 'cancelled?) #f)
+  (check-equal? (hash-ref h 'stream-blocked?) #f))


### PR DESCRIPTION
Addresses #4811.

feat(T2-7): streaming-message FSM state replaces 3 boolean boxes (#4811)

Replaced started-box, blocked-box, cancelled-box with single state-box tracking
FSM state: not-started | streaming | done | blocked | cancelled. Backward-compatible
predicates (message-started?, cancelled?, blocked?) now check FSM state.
Added streaming-message-fsm-state accessor. 8 new FSM tests, 20 total pass.