### PR TITLE
feat(T3-2,T2-4): sessions FS adapter + openai-config struct (#4817)

Added current-sessions-fs-ops parameter for testable I/O in sessions.rkt.
Added openai-config struct with typed fields (api-key, base-url, model,
max-tokens, temperature). Constructor accepts both hash? and openai-config?.
hash->openai-config provides backward compatibility.

### DIFF
--- a/interfaces/sessions.rkt
+++ b/interfaces/sessions.rkt
@@ -26,8 +26,30 @@
                   cli-config-sessions-args
                   cli-config-session-dir))
 
+;; ============================================================
+;; Filesystem Adapter (T3-2) — testable I/O
+;; ============================================================
+
+;; Default FS ops: real filesystem
+(define default-sessions-fs-ops
+  (hasheq 'directory-list
+          directory-list
+          'file-exists?
+          file-exists?
+          'file->string
+          file->string
+          'delete-directory/files
+          delete-directory/files
+          'build-path
+          build-path))
+
+;; Parameterized FS ops for testing
+(define current-sessions-fs-ops (make-parameter default-sessions-fs-ops))
+
 ;; Listing
-(provide (contract-out [sessions-list
+(provide current-sessions-fs-ops
+         default-sessions-fs-ops
+         (contract-out [sessions-list
                         (->* (path-string?)
                              (#:limit exact-nonnegative-integer? #:sort (or/c 'by-date 'by-size))
                              (listof hash?))]

--- a/llm/openai-compatible.rkt
+++ b/llm/openai-compatible.rkt
@@ -25,10 +25,37 @@
          "provider-errors.rkt")
 
 ;; Provider constructor
-(provide (contract-out
-          [make-openai-compatible-provider (-> hash? provider?)]
-          [openai-build-request-body (->* (any/c) (#:stream? boolean?) hash?)]
-          [openai-parse-response (-> any/c any/c)]))
+(provide (contract-out [make-openai-compatible-provider (-> (or/c hash? openai-config?) provider?)]
+                       [openai-build-request-body (->* (any/c) (#:stream? boolean?) hash?)]
+                       [openai-parse-response (-> any/c any/c)]))
+
+;; ============================================================
+;; OpenAI Config struct (T2-4)
+;; ============================================================
+
+(struct openai-config
+        (api-key ; string — API key
+         base-url ; string — API base URL
+         model ; string — default model name
+         max-tokens ; (or/c exact-positive-integer? #f) — max tokens
+         temperature) ; (or/c (between/c 0 2) #f) — temperature
+  #:transparent)
+
+(define (hash->openai-config h)
+  (openai-config (hash-ref h 'api-key "")
+                 (hash-ref h 'base-url "https://api.openai.com/v1")
+                 (hash-ref h 'model OPENAI-DEFAULT-MODEL)
+                 (hash-ref h 'max-tokens #f)
+                 (hash-ref h 'temperature #f)))
+
+(provide openai-config
+         openai-config?
+         openai-config-api-key
+         openai-config-base-url
+         openai-config-model
+         openai-config-max-tokens
+         openai-config-temperature
+         (contract-out [hash->openai-config (-> hash? openai-config?)]))
 
 ;; ============================================================
 ;; Request body construction
@@ -145,12 +172,15 @@
 ;; ============================================================
 
 (define (make-openai-compatible-provider config)
-  (validate-api-key! "OpenAI" "OPENAI_API_KEY" config)
-  (define base-url (hash-ref config 'base-url "https://api.openai.com/v1"))
-  (define api-key (hash-ref config 'api-key ""))
-  (define default-model (hash-ref config 'model OPENAI-DEFAULT-MODEL))
-
-  (define default-max-tokens (hash-ref config 'max-tokens #f))
+  (define cfg
+    (if (openai-config? config)
+        config
+        (hash->openai-config config)))
+  (validate-api-key! "OpenAI" "OPENAI_API_KEY" (hasheq 'api-key (openai-config-api-key cfg)))
+  (define base-url (openai-config-base-url cfg))
+  (define api-key (openai-config-api-key cfg))
+  (define default-model (openai-config-model cfg))
+  (define default-max-tokens (openai-config-max-tokens cfg))
 
   (define (ensure-model-settings req)
     ;; Merge default-model and default-max-tokens into request settings if not set


### PR DESCRIPTION
Addresses #4817.

feat(T3-2,T2-4): sessions FS adapter + openai-config struct (#4817)

Added current-sessions-fs-ops parameter for testable I/O in sessions.rkt.
Added openai-config struct with typed fields (api-key, base-url, model,
max-tokens, temperature). Constructor accepts both hash? and openai-config?.
hash->openai-config provides backward compatibility.