### PR TITLE
fix: 8 contract bugs + 1 duplicate require (A1-A3, B1-B4, C1) (#4823)

A1: build-system-preamble list?→string?
A2: build-session-context/tokens single→multi-value (values)
A3: context-summary-prompt wrong arg type + missing #:previous-summary keyword
B1: set-gsd-mode! accepts (or/c symbol? #f), returns (or/c ok? err?)
B2: gsd-session-cleanup void?→hook-result?
B3: completed-waves (listof ...)→(set/c ...)
B4: gsd-mode symbol?→(or/c symbol? #f)
C1: Removed duplicate racket/match require

Fixes 38 test-case errors across 3 test files (27+9+2=38→0).

### DIFF
--- a/extensions/gsd-planning.rkt
+++ b/extensions/gsd-planning.rkt
@@ -12,7 +12,7 @@
 ;; backward compatibility.
 
 (require racket/contract
-         racket/match
+         racket/set
          racket/match
          racket/string
          json
@@ -119,14 +119,14 @@
 ;; reset-all-gsd-state! is now in gsd/core.rkt
 
 ;; State accessors (locally defined parameter wrappers)
-(provide (contract-out [gsd-mode (-> symbol?)]
+(provide (contract-out [gsd-mode (-> (or/c symbol? #f))]
                        [gsd-mode? (-> any/c boolean?)]
-                       [set-gsd-mode! (-> symbol? void?)]
+                       [set-gsd-mode! (-> (or/c symbol? #f) (or/c ok? err?))]
                        [pinned-planning-dir (-> (or/c path? #f))]
                        [set-pinned-planning-dir! (-> (or/c path? #f) void?)]
                        [current-max-old-text-len (-> (or/c exact-positive-integer? #f))]
                        [set-current-max-old-text-len! (-> (or/c exact-positive-integer? #f) void?)]
-                       [completed-waves (-> (listof exact-nonnegative-integer?))]
+                       [completed-waves (-> (set/c exact-nonnegative-integer?))]
                        [total-waves (-> (or/c exact-nonnegative-integer? #f))]
                        [set-total-waves! (-> (or/c exact-nonnegative-integer? #f) void?)]
                        [mark-wave-complete! (-> exact-nonnegative-integer? void?)]
@@ -137,7 +137,7 @@
                        [emit-gsd-event! (-> symbol? any/c void?)]
                        [gsd-event-bus (-> (or/c any/c #f))]
                        [set-gsd-event-bus! (-> (or/c any/c #f) void?)]
-                       [gsd-session-cleanup (-> any/c void?)])
+                       [gsd-session-cleanup (-> any/c hook-result?)])
          ;; Re-exports from sub-modules (kept as direct provides)
          the-extension
          gsd-planning-extension

--- a/runtime/context-assembly.rkt
+++ b/runtime/context-assembly.rkt
@@ -157,10 +157,13 @@
           [payload->tiered-context (-> context-assembly-payload? tiered-context?)]
           [tiered-context->payload
            (->* (tiered-context? exact-nonnegative-integer?) (hash?) context-assembly-payload?)]
-          [build-session-context/tokens (-> any/c #:max-tokens exact-nonnegative-integer? any/c)]
+          [build-session-context/tokens
+           (-> any/c
+               #:max-tokens exact-nonnegative-integer?
+               (values list? exact-nonnegative-integer?))]
           [entry->context-message (-> any/c any/c)]
           [load-agents-context (-> (or/c path? string?) list?)]
-          [build-system-preamble (-> (or/c path? string?) list?)]
+          [build-system-preamble (-> (or/c path? string?) string?)]
           [truncate-messages-to-budget (-> list? exact-nonnegative-integer? list?)])
          ;; Struct constructors (direct for match compatibility)
          context-assembly-config
@@ -195,7 +198,8 @@
                        [context-summary-to-id (-> context-summary? string?)]
                        [context-summary-text (-> context-summary? string?)]
                        [context-summary-entry-count (-> context-summary? exact-nonnegative-integer?)]
-                       [context-summary-prompt (-> context-summary? string?)]
+                       [context-summary-prompt
+                        (->* (list?) (#:previous-summary (or/c string? #f)) string?)]
                        [generate-context-summary
                         (->* (list? (or/c any/c #f) (or/c string? #f))
                              (#:cache (or/c summary-cache? #f))


### PR DESCRIPTION
Addresses #4823.

fix: 8 contract bugs + 1 duplicate require (A1-A3, B1-B4, C1) (#4823)

A1: build-system-preamble list?→string?
A2: build-session-context/tokens single→multi-value (values)
A3: context-summary-prompt wrong arg type + missing #:previous-summary keyword
B1: set-gsd-mode! accepts (or/c symbol? #f), returns (or/c ok? err?)
B2: gsd-session-cleanup void?→hook-result?
B3: completed-waves (listof ...)→(set/c ...)
B4: gsd-mode symbol?→(or/c symbol? #f)
C1: Removed duplicate racket/match require

Fixes 38 test-case errors across 3 test files (27+9+2=38→0).