### PR TITLE
chore: version bump v0.50.7 + CHANGELOG (#4824)

Version 0.50.6→0.50.7. Fixes 38 contract-related test errors across
3 test files. 8 contract bugs + 1 duplicate require resolved.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## v0.50.7 — 2026-05-21
+
+### Fixed
+- A1: `build-system-preamble` contract corrected `list?` → `string?` (returns joined string).
+- A2: `build-session-context/tokens` contract corrected to `(values list? exact-nonnegative-integer?)` (returns 2 values).
+- A3: `context-summary-prompt` contract corrected to `(->* (list?) (#:previous-summary ...) string?)`.
+- B1: `set-gsd-mode!` contract corrected — accepts `(or/c symbol? #f)`, returns `(or/c ok? err?)`.
+- B2: `gsd-session-cleanup` contract corrected `void?` → `hook-result?`.
+- B3: `completed-waves` contract corrected `(listof ...)` → `(set/c ...)`.
+- B4: `gsd-mode` contract corrected `symbol?` → `(or/c symbol? #f)` (returns #f for idle).
+- C1: Removed duplicate `racket/match` require in `extensions/gsd-planning.rkt`.
+
+### Metrics
+- Failing test errors fixed: 38 → 0 (test-gsd-planning-boundary 27, test-gsd-planning 9, test-context-summary 2)
+- Arch-fitness: 33/33 ✅
+- GSD tests: 177/177 ✅
+
+### Waves
+- W0: Contract fixes (PR #4825)
+- W1: CHANGELOG + version bump (this release)
+
 ## v0.50.6 — 2026-05-20
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.50.6-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.50.7-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 
@@ -203,7 +203,7 @@ bin/q --model gpt-5.4 "write a test"
 ### Verify
 
 ```bash
-bin/q --version            # q version 0.50.6
+bin/q --version            # q version 0.50.7
 raco test tests/           # run the full test suite
 ```
 
@@ -276,7 +276,7 @@ q/
 |--------|-------|
 | Test files | 608 |
 | Source modules | 439 |
-| Source lines | 68474 |
+| Source lines | 68478 |
 | Test lines | 105586 |
 | Test assertions | 16506 |
 | Tests passing | 5835+ | `racket scripts/run-tests.rkt` results |
@@ -421,11 +421,11 @@ When q executes shell commands on behalf of an LLM, arguments are quoted via `sh
 
 
 
-**v0.50.6** — Changed
+**v0.50.7** — Fixed
 
-**v0.50.6** — Fixed
+**v0.50.7** — Fixed
 
-**v0.50.6** — Changed
+**v0.50.7** — Changed
 
 **v0.49.10** — Changed
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -2,7 +2,7 @@
 
 ## Version
 
-v0.50.6
+v0.50.7
 
 ## Layer Diagram
 

--- a/docs/event-taxonomy.md
+++ b/docs/event-taxonomy.md
@@ -1,6 +1,6 @@
 # Q Event Taxonomy Reference
 
-Complete reference for all event types in Q 0.50.6.
+Complete reference for all event types in Q 0.50.7.
 ## Base Types
 
 ### `event` (protocol-level)

--- a/docs/extension-guide.md
+++ b/docs/extension-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.50.6 --># Extension Development Guide
+<!-- verified-against: 0.50.7 --># Extension Development Guide
 
 This guide walks you through creating, testing, and activating a custom
 extension for q.

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.50.6 --># Getting Started
+<!-- verified-against: 0.50.7 --># Getting Started
 
 Welcome to q, a Racket-based coding agent.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.50.6 --># Installation Guide
+<!-- verified-against: 0.50.7 --># Installation Guide
 
 <!-- This file is the canonical source. The docs/getting-started/installation.md copy is maintained for the doc site build. -->
 

--- a/docs/security-trust-model.md
+++ b/docs/security-trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.50.6 --># Security & Trust Model
+<!-- verified-against: 0.50.7 --># Security & Trust Model
 
 This document provides an honest, per-area assessment of what q enforces
 today and what is planned. It is the authoritative reference for security

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -130,6 +130,6 @@ is the primary self-hosting extension:
 (load-extension! ext-reg "path/to/extension.rkt" #:event-bus bus)
 ```
 
-## Version 0.50.6
+## Version 0.50.7
 
-This documentation reflects q 0.50.6.
+This documentation reflects q 0.50.7.

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.50.6 --># q Source Style Guide
+<!-- verified-against: 0.50.7 --># q Source Style Guide
 
 This document defines formatting and naming conventions for the q Racket codebase.
 All changes to `q/` source files (excluding `tests/`) should follow these rules.

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.50.6 --># Trust Model
+<!-- verified-against: 0.50.7 --># Trust Model
 
 ## Trust Levels
 

--- a/docs/workflow-testing.md
+++ b/docs/workflow-testing.md
@@ -121,6 +121,6 @@ Use relative paths from the test file:
 4. Use `(check-true ...)` for boolean assertions
 5. Keep tests independent — no shared mutable state between test-cases
 
-## Version 0.50.6
+## Version 0.50.7
 
-This documentation reflects q 0.50.6.
+This documentation reflects q 0.50.7.

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.50.6")
+(define version "0.50.7")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base"))

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -11,4 +11,4 @@
 
 (provide (contract-out [q-version string?]))
 
-(define q-version "0.50.6")
+(define q-version "0.50.7")

--- a/wiki-src/Architecture-Overview.md
+++ b/wiki-src/Architecture-Overview.md
@@ -35,7 +35,7 @@ User input → Interface (CLI/TUI/RPC)
     → Events emitted to bus
 ```
 
-## Metrics (0.50.6)
+## Metrics (0.50.7)
 > _See `racket scripts/metrics.rkt` for current numbers._
 
 - 414 source modules, 534 test files


### PR DESCRIPTION
Addresses #4824.

chore: version bump v0.50.7 + CHANGELOG (#4824)

Version 0.50.6→0.50.7. Fixes 38 contract-related test errors across
3 test files. 8 contract bugs + 1 duplicate require resolved.