### PR TITLE
fix(W2): tighten agent-session.rkt contract (any/c → or/c) (#4830)

Changed resume-agent-session contract from any/c to (or/c session-config? hash?)
to match actual function signature that accepts both types.

### DIFF
--- a/runtime/agent-session.rkt
+++ b/runtime/agent-session.rkt
@@ -98,7 +98,7 @@
          buffer-or-append!
          (contract-out ;; NOTE (W-01): This is the ONLY entry point that accepts raw hashes for backward compat.
           [make-agent-session (-> (or/c hash? session-config?) agent-session?)]
-          [resume-agent-session (-> string? any/c agent-session?)]
+          [resume-agent-session (-> string? (or/c session-config? hash?) agent-session?)]
           [fork-session (->* (agent-session?) ((or/c string? #f)) agent-session?)]
           [run-prompt!
            (->* (agent-session? (or/c string? message?))


### PR DESCRIPTION
Addresses #4830.

fix(W2): tighten agent-session.rkt contract (any/c → or/c) (#4830)

Changed resume-agent-session contract from any/c to (or/c session-config? hash?)
to match actual function signature that accepts both types.