### PR TITLE
feat(v0.51.6 W0): make tui-ctx struct opaque (#4842)

Removed #:transparent from tui-ctx struct. All callers use accessors.
9 keybinding + 106 TUI tests pass.

### DIFF
--- a/tui/tui-keybindings.rkt
+++ b/tui/tui-keybindings.rkt
@@ -120,7 +120,7 @@
          extension-registry-box ; (or/c (boxof (or/c extension-registry? #f)) #f)
          session-queue-box ; (boxof (or/c queue? #f)) — agent queue for followup during streaming (G3.1)
          session-factory-runner) ; (or/c (string -> void) #f) — creates fresh session for /go
-  #:transparent)
+  )
 
 (define (make-tui-ctx #:event-bus [bus #f]
                       #:session-runner [runner (lambda (prompt) (void))]


### PR DESCRIPTION
Addresses #4842.

feat(v0.51.6 W0): make tui-ctx struct opaque (#4842)

Removed #:transparent from tui-ctx struct. All callers use accessors.
9 keybinding + 106 TUI tests pass.