### PR TITLE
feat(v0.51.6 W2): remove unnecessary #:transparent from 6 TUI structs (#4844)

Made opaque: overlay-config, render-components, key-spec, tree-node,
parsed-command, settings-entry, select-list-state.
State/layout structs kept transparent for debugging. All TUI tests pass.

### DIFF
--- a/tui/builtins.rkt
+++ b/tui/builtins.rkt
@@ -59,7 +59,7 @@
 ;; ═══════════════════════════════════════════════════════════════════
 
 ;; A scrollable, filterable selection list
-(struct select-list-state (options selected-idx filter-text scroll-offset) #:transparent)
+(struct select-list-state (options selected-idx filter-text scroll-offset))
 
 (define (make-select-list options
                           #:on-select [on-select void]
@@ -143,7 +143,7 @@
 ;; SettingsList component
 ;; ═══════════════════════════════════════════════════════════════════
 
-(struct settings-entry (key label value type) #:transparent)
+(struct settings-entry (key label value type))
 
 (define (make-settings-list entries #:on-change [on-change void] #:id [id 'settings])
   (define idx-box (box 0))

--- a/tui/command-parse.rkt
+++ b/tui/command-parse.rkt
@@ -31,7 +31,7 @@
 ;; e.g. "/help" → (cons 'help 'none), "/switch" → (cons 'switch 'required)
 
 ;; R-17: Structured command result replacing ad-hoc symbol/list returns.
-(struct parsed-command (canonical-name args arg-kind) #:transparent)
+(struct parsed-command (canonical-name args arg-kind))
 
 (define (make-command-table)
   ;; General

--- a/tui/keymap.rkt
+++ b/tui/keymap.rkt
@@ -51,7 +51,7 @@
 ;; A key-spec identifies a key combination.
 ;; name: char? or symbol? (e.g. #\a, 'up, 'return)
 ;; ctrl, shift, alt: booleans for modifier keys
-(struct key-spec (name ctrl shift alt) #:transparent)
+(struct key-spec (name ctrl shift alt))
 
 ;; Convert a terminal keycode to a key-spec.
 ;; keycode: char?, symbol?, or 'ctrl-c etc.

--- a/tui/renderer.rkt
+++ b/tui/renderer.rkt
@@ -375,7 +375,7 @@
 ;; - Per-zone cache isolation (#642)
 ;; - Foundation for overlay composition (Wave 5)
 ;; - Architecture alignment with component.rkt
-(struct render-components (trans-comp status-comp) #:transparent)
+(struct render-components (trans-comp status-comp))
 
 ;; Create component instances for transcript and status zones.
 ;; Input line is NOT wrapped as a component because it changes every keystroke

--- a/tui/state-ui.rkt
+++ b/tui/state-ui.rkt
@@ -203,7 +203,7 @@
 ;; Overlay config (#1145)
 ;; ============================================================
 
-(struct overlay-config (anchor width-spec height-spec margin) #:transparent)
+(struct overlay-config (anchor width-spec height-spec margin))
 
 (define make-overlay-config overlay-config)
 

--- a/tui/tree-view.rkt
+++ b/tui/tree-view.rkt
@@ -36,7 +36,7 @@
 ;; ============================================================
 
 ;; Tree node for rendering, with optional timestamp
-(struct tree-node (id role text depth children timestamp) #:transparent)
+(struct tree-node (id role text depth children timestamp))
 
 (define (make-tree-node id role text depth children [timestamp #f])
   (tree-node id role text depth children timestamp))


### PR DESCRIPTION
Addresses #4844.

feat(v0.51.6 W2): remove unnecessary #:transparent from 6 TUI structs (#4844)

Made opaque: overlay-config, render-components, key-spec, tree-node,
parsed-command, settings-entry, select-list-state.
State/layout structs kept transparent for debugging. All TUI tests pass.