### PR TITLE
feat(v0.51.7 W2): convert cond→match in cli/args.rkt and doctor.rkt (#4847)

5 cond→match conversions: acc-ref list traversal, command dispatch,
mode dispatch (cli/args.rkt), version>=? comparison (doctor.rkt).
All tests pass.

### DIFF
--- a/cli/args.rkt
+++ b/cli/args.rkt
@@ -14,6 +14,7 @@
 ;;   q-version           -- version constant
 
 (require racket/contract
+         racket/match
          racket/string
          racket/format
          "../util/version.rkt")
@@ -98,10 +99,10 @@
 ;;    but an alist is purely functional and easy to test).
 
 (define (acc-ref acc key [default #f])
-  (cond
-    [(null? acc) default]
-    [(eq? (caar acc) key) (cdar acc)]
-    [else (acc-ref (cdr acc) key default)]))
+  (match acc
+    ['() default]
+    [(cons (cons (== key) val) _) val]
+    [(cons _ rest) (acc-ref rest key default)]))
 
 (define (acc-set acc key val)
   (cons (cons key val) (filter (lambda (p) (not (eq? (car p) key))) acc)))
@@ -132,23 +133,27 @@
     (let ([cmd (acc-ref acc 'command)]
           [sid (acc-ref acc 'session-id)]
           [prompt (acc-ref acc 'prompt)])
-      (cond
-        [(eq? cmd 'help) 'help]
-        [(eq? cmd 'version) 'version]
-        [(eq? cmd 'init) 'init]
-        [(eq? cmd 'sessions) 'sessions]
-        [(and sid (eq? cmd 'chat)) 'resume]
-        [prompt 'prompt]
-        [else cmd])))
+      (match (cons cmd sid)
+        [(cons 'help _) 'help]
+        [(cons 'version _) 'version]
+        [(cons 'init _) 'init]
+        [(cons 'sessions _) 'sessions]
+        [(cons 'chat (not #f)) 'resume]
+        [_
+         (match prompt
+           [#f cmd]
+           [_ 'prompt])])))
   (define final-mode
     (let ([m (acc-ref acc 'mode)])
-      (cond
-        [(eq? m 'json) 'json]
-        [(eq? m 'rpc) 'rpc]
-        [(eq? m 'tui) 'tui]
-        [(eq? m 'print) 'print]
-        [(eq? final-command 'prompt) 'single]
-        [else 'interactive])))
+      (match m
+        ['json 'json]
+        ['rpc 'rpc]
+        ['tui 'tui]
+        ['print 'print]
+        [_
+         (match final-command
+           ['prompt 'single]
+           [_ 'interactive])])))
   (cli-config final-command
               (acc-ref acc 'session-id)
               (acc-ref acc 'prompt)

--- a/interfaces/doctor.rkt
+++ b/interfaces/doctor.rkt
@@ -90,13 +90,11 @@
 ;; Compare two version lists lexicographically.
 ;; Returns #t if actual >= required.
 (define (version>=? actual required)
-  (cond
-    [(and (null? actual) (null? required)) #t]
-    [(null? required) #t]
-    [(null? actual) #f]
-    [else
-     (define a (car actual))
-     (define r (car required))
+  (match (cons actual required)
+    [(cons '() '()) #t]
+    [(cons _ '()) #t]
+    [(cons '() _) #f]
+    [(cons (list a ___) (list r ___))
      (cond
        [(> a r) #t]
        [(< a r) #f]


### PR DESCRIPTION
Addresses #4847.

feat(v0.51.7 W2): convert cond→match in cli/args.rkt and doctor.rkt (#4847)

5 cond→match conversions: acc-ref list traversal, command dispatch,
mode dispatch (cli/args.rkt), version>=? comparison (doctor.rkt).
All tests pass.