### PR TITLE
feat(v0.51.9 W1): deprecate bump-version.rkt in favor of sync-version.rkt (#4854)

Added deprecation notice. sync-version.rkt handles all sync surfaces.
bump-version.rkt remains for backward compat.

### DIFF
--- a/scripts/bump-version.rkt
+++ b/scripts/bump-version.rkt
@@ -1,6 +1,12 @@
 #!/usr/bin/env racket
 #lang racket/base
 
+;; scripts/bump-version.rkt — DEPRECATED: Use scripts/sync-version.rkt instead.
+;;
+;; This script is deprecated as of v0.51.9. The sync-version.rkt script
+;; now handles all version synchronization. This file remains for backward
+;; compatibility but will be removed in a future release.
+
 ;; scripts/bump-version.rkt — Single-command version sweep.
 ;;
 ;; Updates all version surfaces across the project to a new version string.


### PR DESCRIPTION
Addresses #4854.

feat(v0.51.9 W1): deprecate bump-version.rkt in favor of sync-version.rkt (#4854)

Added deprecation notice. sync-version.rkt handles all sync surfaces.
bump-version.rkt remains for backward compat.