### PR TITLE
feat(v0.53.2): extract stream modules — pure reducer + effectful runner (#4876)

- Extract classify-chunk, chunk-has-data?, accumulate-stream-chunks to agent/stream-reducer.rkt (96 LOC)
- Extract stream-from-provider to agent/stream-runner.rkt (251 LOC)
- Slim loop-stream.rkt from 587 → 297 LOC (effectful result building only)
- MAX-STREAM-CHUNKS parameter moved to stream-reducer.rkt (shared by runner)
- All 95 stream tests pass, arch-fitness 33/33

### DIFF
--- a/agent/loop-stream.rkt
+++ b/agent/loop-stream.rkt
@@ -20,7 +20,14 @@
          "../util/ids.rkt"
          (only-in "../util/cancellation.rkt" cancellation-token? cancellation-token-cancelled?)
          (only-in "../util/hook-types.rkt" hook-result? hook-result-action hook-result-payload)
-         (only-in "../llm/stream.rkt" accumulate-tool-call-deltas)
+         ;; Re-exported from stream-reducer.rkt (v0.53.2)
+         (only-in "stream-reducer.rkt"
+                  classify-chunk
+                  chunk-has-data?
+                  accumulate-stream-chunks
+                  MAX-STREAM-CHUNKS)
+         ;; Re-exported from stream-runner.rkt (v0.53.2)
+         (only-in "stream-runner.rkt" stream-from-provider)
          (only-in "../llm/token-budget.rkt" estimate-turn-tokens)
          (only-in "event-emitter.rkt" emit-typed-event!)
          ;; v0.45.12 M2: emit-session-event! moved to agent layer (was runtime/runtime-helpers.rkt)
@@ -41,315 +48,18 @@
                   make-stream-assistant-msg-completed-event)
          (only-in "loop-messages.rkt" usage-empty? classify-hook-result))
 
-;; ============================================================
-;; Configurable chunk limit (v0.12.3 Wave 0.1)
-;; ============================================================
-
-(define MAX-STREAM-CHUNKS (make-parameter 10000))
-
 (provide classify-chunk
          chunk-has-data?
          MAX-STREAM-CHUNKS
-         (contract-out [accumulate-stream-chunks (-> list? hash?)]
-                       [stream-from-provider
-                        (-> any/c ; provider
-                            any/c ; req
-                            (or/c any/c #f) ; bus
-                            string? ; session-id
-                            string? ; turn-id
-                            any/c ; state
-                            (or/c procedure? #f) ; hook-dispatcher
-                            (or/c any/c #f) ; cancellation-token
-                            hash?)]
-                       [handle-cancellation
+         accumulate-stream-chunks
+         stream-from-provider
+         (contract-out [handle-cancellation
                         (->* ((or/c any/c #f) string? string? any/c)
                              (#:hook-dispatcher (or/c procedure? #f))
                              any/c)]
                        [build-stream-result
                         (-> any/c any/c any/c string? string? any/c any/c any/c any/c any/c)]))
 
-;; ============================================================
-;; accumulate-stream-chunks : pure helper (S11-F1)
-;; ============================================================
-
-;; Given a list of stream-chunks, return accumulated:
-;;   'text, 'tool-calls, 'thinking, 'usage, 'finish-reason
-(define (accumulate-stream-chunks chunks)
-  (define text-parts
-    (for/list ([c (in-list chunks)]
-               #:when (stream-chunk-delta-text c))
-      (stream-chunk-delta-text c)))
-  (define thinking-parts
-    (for/list ([c (in-list chunks)]
-               #:when (stream-chunk-delta-thinking c))
-      (stream-chunk-delta-thinking c)))
-  (define tool-calls (accumulate-tool-call-deltas chunks))
-  (define usage
-    (for/first ([c (in-list chunks)]
-                #:when (stream-chunk-usage c))
-      (stream-chunk-usage c)))
-  (define finish-reason
-    (for/first ([c (in-list chunks)]
-                #:when (stream-chunk-finish-reason c))
-      (stream-chunk-finish-reason c)))
-  (hasheq 'text
-          (apply string-append text-parts)
-          'thinking
-          (apply string-append thinking-parts)
-          'tool-calls
-          tool-calls
-          'usage
-          usage
-          'finish-reason
-          finish-reason))
-
-;; ============================================================
-;; Pure chunk classification (T2-6)
-;; ============================================================
-
-;; classify-chunk : stream-chunk -> (listof (list symbol any))
-;; Pure: returns a list of (type, data) pairs describing what the chunk contains.
-;; Each pair is (cons type-symbol data) where:
-;;   ('text-delta . string)          — text content to accumulate
-;;   ('thinking-delta . string)      — thinking/reasoning content
-;;   ('tool-call-delta . hash)       — tool call delta
-;;   ('done . (hash 'usage _ 'finish-reason _)) — stream completion
-;; Returns '() if chunk has no useful data.
-(define (classify-chunk chunk)
-  (append (let ([dt (stream-chunk-delta-text chunk)])
-            (if dt
-                (list (cons 'text-delta dt))
-                '()))
-          (let ([th (stream-chunk-delta-thinking chunk)])
-            (if th
-                (list (cons 'thinking-delta th))
-                '()))
-          (let ([tc (stream-chunk-delta-tool-call chunk)])
-            (if tc
-                (list (cons 'tool-call-delta tc))
-                '()))
-          (if (stream-chunk-done? chunk)
-              (list (cons 'done
-                          (hasheq 'usage
-                                  (or (stream-chunk-usage chunk) (hasheq))
-                                  'finish-reason
-                                  (or (stream-chunk-finish-reason chunk) "unknown"))))
-              '())))
-
-;; chunk-has-data? : stream-chunk -> boolean
-;; Pure: returns #t if chunk carries any useful payload.
-(define (chunk-has-data? chunk)
-  (pair? (classify-chunk chunk)))
-
-;; ============================================================
-;; stream-from-provider
-;; ============================================================
-
-;; Wraps the streaming loop. Returns a hash with keys:
-;;   'text            — accumulated text string
-;;   'tool-calls      — list of accumulated tool-call deltas
-;;   'all-chunks      — list of all stream chunks
-;;   'cancelled?      — boolean
-;;   'stream-blocked? — boolean (from message-update hook block)
-(define (stream-from-provider provider
-                              req
-                              bus
-                              session-id
-                              turn-id
-                              state
-                              hook-dispatcher
-                              cancellation-token)
-  (define sm (make-streaming-message (format "msg-~a-~a" turn-id (current-inexact-milliseconds))))
-  (define message-id (streaming-message-message-id sm))
-
-  (define stream-gen (provider-stream provider req))
-  (define chunk-count (box 0))
-  (define limit (MAX-STREAM-CHUNKS))
-  (define received-done? (box #f))
-
-  ;; Error boundary — emit cleanup events on provider crash.
-  (with-handlers ([exn:fail?
-                   (lambda (e)
-                     ;; AF5 (RC2): Persist partial assistant message before re-raising.
-                     ;; Prevents data loss when stream times out after receiving content.
-                     (define partial-text (streaming-message-text sm))
-                     (when (and partial-text (> (string-length partial-text) 0))
-                       (define partial-msg
-                         (make-message (generate-id)
-                                       #f
-                                       'assistant
-                                       'message
-                                       (list (make-text-part partial-text))
-                                       (now-seconds)
-                                       (hasheq 'turnId turn-id 'partial #t)))
-                       (state-add-message! state partial-msg))
-                     (when (streaming-message-message-started? sm)
-                       (emit-typed-event! bus
-                                          (make-stream-message-end-event #:session-id session-id
-                                                                         #:turn-id turn-id
-                                                                         #:message-id message-id
-                                                                         #:usage (hasheq))
-                                          #:state state))
-                     (emit-typed-event! bus
-                                        (make-stream-turn-completed-event #:session-id session-id
-                                                                          #:turn-id turn-id
-                                                                          #:termination 'error
-                                                                          #:turn-id-str turn-id
-                                                                          #:reason
-                                                                          "provider-stream-error")
-                                        #:state state)
-                     (raise e))])
-    (let stream-loop ()
-      (define chunk (stream-gen))
-      (when (and chunk (not (eq? chunk #f)))
-        (set-box! chunk-count (+ 1 (unbox chunk-count)))
-        (when (> (unbox chunk-count) limit)
-          (log-warning
-           (format "stream-from-provider: exceeded ~a chunks, truncating session=~a turn=~a"
-                   limit
-                   session-id
-                   turn-id))
-          (emit-typed-event! bus
-                             (make-stream-completed-event #:session-id session-id
-                                                          #:turn-id turn-id
-                                                          #:usage (hasheq)
-                                                          #:finish_reason "unknown"
-                                                          #:truncated? #t)
-                             #:state state)
-          (when (streaming-message-message-started? sm)
-            (emit-typed-event! bus
-                               (make-stream-message-end-event #:session-id session-id
-                                                              #:turn-id turn-id
-                                                              #:message-id message-id
-                                                              #:usage (hasheq))
-                               #:state state)))
-        (unless (> (unbox chunk-count) limit)
-          (streaming-message-append-chunk! sm chunk)
-          (when (stream-chunk-delta-text chunk)
-            ;; Emit message.start on first text delta
-            (unless (streaming-message-message-started? sm)
-              (streaming-message-set-message-started! sm)
-              (emit-typed-event! bus
-                                 (make-stream-message-start-event #:session-id session-id
-                                                                  #:turn-id turn-id
-                                                                  #:message-id message-id)
-                                 #:state state))
-            ;; Text delta
-            (streaming-message-append-text! sm (stream-chunk-delta-text chunk))
-            (emit-typed-event! bus
-                               (make-stream-delta-event #:session-id session-id
-                                                        #:turn-id turn-id
-                                                        #:delta (stream-chunk-delta-text chunk))
-                               #:state state)
-            ;; Emit message.delta with message-id for extension consumption
-            (emit-typed-event! bus
-                               (make-stream-message-delta-event #:session-id session-id
-                                                                #:turn-id turn-id
-                                                                #:text (stream-chunk-delta-text chunk)
-                                                                #:message-id message-id)
-                               #:state state)
-            ;; Dispatch message-update hook for text delta
-            (when hook-dispatcher
-              (define update-result
-                (hook-dispatcher 'message-update
-                                 (hasheq 'session-id
-                                         session-id
-                                         'turn-id
-                                         turn-id
-                                         'delta-text
-                                         (stream-chunk-delta-text chunk)
-                                         'delta-tool-call
-                                         #f)))
-              (match (classify-hook-result update-result)
-                [(list 'block _) (streaming-message-set-blocked! sm)]
-                [_ (void)])))
-          ;; FEAT-72: Thinking/reasoning delta
-          (when (stream-chunk-delta-thinking chunk)
-            (streaming-message-append-thinking! sm (stream-chunk-delta-thinking chunk))
-            (emit-typed-event! bus
-                               (make-stream-thinking-event #:session-id session-id
-                                                           #:turn-id turn-id
-                                                           #:delta
-                                                           (stream-chunk-delta-thinking chunk))
-                               #:state state))
-          (when (stream-chunk-delta-tool-call chunk)
-            (define tc-delta (stream-chunk-delta-tool-call chunk))
-            (streaming-message-append-tool-call! sm tc-delta)
-            (emit-typed-event! bus
-                               (make-stream-tool-call-delta-event #:session-id session-id
-                                                                  #:turn-id turn-id
-                                                                  #:delta-tool-call tc-delta)
-                               #:state state)
-            ;; Dispatch message-update hook for tool-call delta
-            (when hook-dispatcher
-              (define update-result
-                (hook-dispatcher 'message-update
-                                 (hasheq 'session-id
-                                         session-id
-                                         'turn-id
-                                         turn-id
-                                         'delta-text
-                                         #f
-                                         'delta-tool-call
-                                         tc-delta)))
-              (match (classify-hook-result update-result)
-                [(list 'block _) (streaming-message-set-blocked! sm)]
-                [_ (void)])))
-          (when (stream-chunk-done? chunk)
-            (set-box! received-done? #t)
-            (emit-typed-event! bus
-                               (make-stream-completed-event
-                                #:session-id session-id
-                                #:turn-id turn-id
-                                #:usage (or (stream-chunk-usage chunk) (hasheq))
-                                #:finish_reason (or (stream-chunk-finish-reason chunk) "unknown"))
-                               #:state state)
-            (when (streaming-message-message-started? sm)
-              (emit-typed-event! bus
-                                 (make-stream-message-end-event #:session-id session-id
-                                                                #:turn-id turn-id
-                                                                #:message-id message-id
-                                                                #:usage (or (stream-chunk-usage chunk)
-                                                                            (hasheq)))
-                                 #:state state)))
-          ;; Check cancellation after processing chunk
-          (cond
-            [(and cancellation-token (cancellation-token-cancelled? cancellation-token))
-             (streaming-message-set-cancelled! sm)
-             (emit-typed-event! bus
-                                (make-stream-turn-cancelled-event #:session-id session-id
-                                                                  #:turn-id turn-id
-                                                                  #:reason "cancellation-token")
-                                #:state state)]
-            [(streaming-message-blocked? sm)
-             (emit-typed-event! bus
-                                (make-stream-completed-event #:session-id session-id
-                                                             #:turn-id turn-id
-                                                             #:usage (hasheq)
-                                                             #:finish_reason "unknown")
-                                #:state state)]
-            [else (stream-loop)])))))
-
-  ;; BUG-SILENT-STREAM-EOF: synthetic completion for streams without done chunk
-  (unless (unbox received-done?)
-    (when (streaming-message-message-started? sm)
-      (emit-typed-event! bus
-                         (make-stream-completed-event #:session-id session-id
-                                                      #:turn-id turn-id
-                                                      #:usage (hasheq)
-                                                      #:finish_reason "eof"
-                                                      #:truncated? #t)
-                         #:state state)
-      (emit-typed-event! bus
-                         (make-stream-message-end-event #:session-id session-id
-                                                        #:turn-id turn-id
-                                                        #:message-id message-id
-                                                        #:usage (hasheq))
-                         #:state state)))
-
-  (streaming-message->hash sm))
-
-;; ============================================================
 ;; handle-cancellation
 ;; ============================================================
 

--- a/agent/stream-reducer.rkt
+++ b/agent/stream-reducer.rkt
@@ -1,0 +1,96 @@
+#lang racket/base
+
+;; agent/stream-reducer.rkt — Pure stream chunk classification and accumulation
+;;
+;; Extracted from loop-stream.rkt (v0.53.2 decomposition).
+;; Contains only pure functions with no I/O, event emission, or state mutation.
+;; These can be tested without mocks or providers.
+
+(require racket/contract
+         racket/match
+         "../llm/model.rkt"
+         (only-in "../llm/stream.rkt" accumulate-tool-call-deltas))
+
+;; ============================================================
+;; Configurable chunk limit (v0.12.3 Wave 0.1)
+;; ============================================================
+
+(define MAX-STREAM-CHUNKS (make-parameter 10000))
+
+(provide classify-chunk
+         chunk-has-data?
+         MAX-STREAM-CHUNKS
+         (contract-out [accumulate-stream-chunks (-> list? hash?)]))
+
+;; ============================================================
+;; accumulate-stream-chunks : pure helper (S11-F1)
+;; ============================================================
+
+;; Given a list of stream-chunks, return accumulated:
+;;   'text, 'tool-calls, 'thinking, 'usage, 'finish-reason
+(define (accumulate-stream-chunks chunks)
+  (define text-parts
+    (for/list ([c (in-list chunks)]
+               #:when (stream-chunk-delta-text c))
+      (stream-chunk-delta-text c)))
+  (define thinking-parts
+    (for/list ([c (in-list chunks)]
+               #:when (stream-chunk-delta-thinking c))
+      (stream-chunk-delta-thinking c)))
+  (define tool-calls (accumulate-tool-call-deltas chunks))
+  (define usage
+    (for/first ([c (in-list chunks)]
+                #:when (stream-chunk-usage c))
+      (stream-chunk-usage c)))
+  (define finish-reason
+    (for/first ([c (in-list chunks)]
+                #:when (stream-chunk-finish-reason c))
+      (stream-chunk-finish-reason c)))
+  (hasheq 'text
+          (apply string-append text-parts)
+          'thinking
+          (apply string-append thinking-parts)
+          'tool-calls
+          tool-calls
+          'usage
+          usage
+          'finish-reason
+          finish-reason))
+
+;; ============================================================
+;; Pure chunk classification (T2-6)
+;; ============================================================
+
+;; classify-chunk : stream-chunk -> (listof (cons symbol any))
+;; Pure: returns a list of (type . data) pairs describing what the chunk contains.
+;; Each pair is (cons type-symbol data) where:
+;;   ('text-delta . string)          — text content to accumulate
+;;   ('thinking-delta . string)      — thinking/reasoning content
+;;   ('tool-call-delta . hash)       — tool call delta
+;;   ('done . (hash 'usage _ 'finish-reason _)) — stream completion
+;; Returns '() if chunk has no useful data.
+(define (classify-chunk chunk)
+  (append (let ([dt (stream-chunk-delta-text chunk)])
+            (if dt
+                (list (cons 'text-delta dt))
+                '()))
+          (let ([th (stream-chunk-delta-thinking chunk)])
+            (if th
+                (list (cons 'thinking-delta th))
+                '()))
+          (let ([tc (stream-chunk-delta-tool-call chunk)])
+            (if tc
+                (list (cons 'tool-call-delta tc))
+                '()))
+          (if (stream-chunk-done? chunk)
+              (list (cons 'done
+                          (hasheq 'usage
+                                  (or (stream-chunk-usage chunk) (hasheq))
+                                  'finish-reason
+                                  (or (stream-chunk-finish-reason chunk) "unknown"))))
+              '())))
+
+;; chunk-has-data? : stream-chunk -> boolean
+;; Pure: returns #t if chunk carries any useful payload.
+(define (chunk-has-data? chunk)
+  (pair? (classify-chunk chunk)))

--- a/agent/stream-runner.rkt
+++ b/agent/stream-runner.rkt
@@ -1,0 +1,251 @@
+#lang racket/base
+
+;; agent/stream-runner.rkt — Effectful streaming loop
+;;
+;; Extracted from loop-stream.rkt (v0.53.2 decomposition).
+;; Contains the provider streaming loop with event emission and state mutation.
+
+(require racket/contract
+         racket/match
+         "../llm/model.rkt"
+         "../llm/provider.rkt"
+         "streaming-message.rkt"
+         "state.rkt"
+         "../util/protocol-types.rkt"
+         "../util/ids.rkt"
+         (only-in "../util/cancellation.rkt" cancellation-token? cancellation-token-cancelled?)
+         (only-in "../util/hook-types.rkt" hook-result? hook-result-action hook-result-payload)
+         (only-in "event-emitter.rkt" emit-typed-event!)
+         (only-in "event-bus.rkt" event-bus?)
+         ;; Stream event types
+         (only-in "event-structs/stream-events.rkt"
+                  make-stream-completed-event
+                  make-stream-delta-event
+                  make-stream-tool-call-delta-event
+                  make-stream-thinking-event
+                  make-stream-message-start-event
+                  make-stream-message-delta-event
+                  make-stream-message-end-event
+                  make-stream-turn-completed-event
+                  make-stream-turn-cancelled-event)
+         (only-in "loop-messages.rkt" classify-hook-result)
+         ;; Chunk limit parameter from stream-reducer module
+         (only-in "stream-reducer.rkt" MAX-STREAM-CHUNKS))
+
+(provide (contract-out [stream-from-provider
+                        (-> any/c ; provider
+                            any/c ; req
+                            (or/c any/c #f) ; bus
+                            string? ; session-id
+                            string? ; turn-id
+                            any/c ; state
+                            (or/c procedure? #f) ; hook-dispatcher
+                            (or/c any/c #f) ; cancellation-token
+                            hash?)]))
+
+;; ============================================================
+;; stream-from-provider
+;; ============================================================
+
+;; Wraps the streaming loop. Returns a hash with keys:
+;;   'text            — accumulated text string
+;;   'tool-calls      — list of accumulated tool-call deltas
+;;   'all-chunks      — list of all stream chunks
+;;   'cancelled?      — boolean
+;;   'stream-blocked? — boolean (from message-update hook block)
+(define (stream-from-provider provider
+                              req
+                              bus
+                              session-id
+                              turn-id
+                              state
+                              hook-dispatcher
+                              cancellation-token)
+  (define sm (make-streaming-message (format "msg-~a-~a" turn-id (current-inexact-milliseconds))))
+  (define message-id (streaming-message-message-id sm))
+
+  (define stream-gen (provider-stream provider req))
+  (define chunk-count (box 0))
+  (define limit (MAX-STREAM-CHUNKS))
+  (define received-done? (box #f))
+
+  ;; Error boundary — emit cleanup events on provider crash.
+  (with-handlers ([exn:fail?
+                   (lambda (e)
+                     ;; AF5 (RC2): Persist partial assistant message before re-raising.
+                     (define partial-text (streaming-message-text sm))
+                     (when (and partial-text (> (string-length partial-text) 0))
+                       (define partial-msg
+                         (make-message (generate-id)
+                                       #f
+                                       'assistant
+                                       'message
+                                       (list (make-text-part partial-text))
+                                       (now-seconds)
+                                       (hasheq 'turnId turn-id 'partial #t)))
+                       (state-add-message! state partial-msg))
+                     (when (streaming-message-message-started? sm)
+                       (emit-typed-event! bus
+                                          (make-stream-message-end-event #:session-id session-id
+                                                                         #:turn-id turn-id
+                                                                         #:message-id message-id
+                                                                         #:usage (hasheq))
+                                          #:state state))
+                     (emit-typed-event! bus
+                                        (make-stream-turn-completed-event #:session-id session-id
+                                                                          #:turn-id turn-id
+                                                                          #:termination 'error
+                                                                          #:turn-id-str turn-id
+                                                                          #:reason
+                                                                          "provider-stream-error")
+                                        #:state state)
+                     (raise e))])
+    (let stream-loop ()
+      (define chunk (stream-gen))
+      (when (and chunk (not (eq? chunk #f)))
+        (set-box! chunk-count (+ 1 (unbox chunk-count)))
+        (when (> (unbox chunk-count) limit)
+          (log-warning
+           (format "stream-from-provider: exceeded ~a chunks, truncating session=~a turn=~a"
+                   limit
+                   session-id
+                   turn-id))
+          (emit-typed-event! bus
+                             (make-stream-completed-event #:session-id session-id
+                                                          #:turn-id turn-id
+                                                          #:usage (hasheq)
+                                                          #:finish_reason "unknown"
+                                                          #:truncated? #t)
+                             #:state state)
+          (when (streaming-message-message-started? sm)
+            (emit-typed-event! bus
+                               (make-stream-message-end-event #:session-id session-id
+                                                              #:turn-id turn-id
+                                                              #:message-id message-id
+                                                              #:usage (hasheq))
+                               #:state state)))
+        (unless (> (unbox chunk-count) limit)
+          (streaming-message-append-chunk! sm chunk)
+          (when (stream-chunk-delta-text chunk)
+            ;; Emit message.start on first text delta
+            (unless (streaming-message-message-started? sm)
+              (streaming-message-set-message-started! sm)
+              (emit-typed-event! bus
+                                 (make-stream-message-start-event #:session-id session-id
+                                                                  #:turn-id turn-id
+                                                                  #:message-id message-id)
+                                 #:state state))
+            ;; Text delta
+            (streaming-message-append-text! sm (stream-chunk-delta-text chunk))
+            (emit-typed-event! bus
+                               (make-stream-delta-event #:session-id session-id
+                                                        #:turn-id turn-id
+                                                        #:delta (stream-chunk-delta-text chunk))
+                               #:state state)
+            ;; Emit message.delta with message-id for extension consumption
+            (emit-typed-event! bus
+                               (make-stream-message-delta-event #:session-id session-id
+                                                                #:turn-id turn-id
+                                                                #:text (stream-chunk-delta-text chunk)
+                                                                #:message-id message-id)
+                               #:state state)
+            ;; Dispatch message-update hook for text delta
+            (when hook-dispatcher
+              (define update-result
+                (hook-dispatcher 'message-update
+                                 (hasheq 'session-id
+                                         session-id
+                                         'turn-id
+                                         turn-id
+                                         'delta-text
+                                         (stream-chunk-delta-text chunk)
+                                         'delta-tool-call
+                                         #f)))
+              (match (classify-hook-result update-result)
+                [(list 'block _) (streaming-message-set-blocked! sm)]
+                [_ (void)])))
+          ;; FEAT-72: Thinking/reasoning delta
+          (when (stream-chunk-delta-thinking chunk)
+            (streaming-message-append-thinking! sm (stream-chunk-delta-thinking chunk))
+            (emit-typed-event! bus
+                               (make-stream-thinking-event #:session-id session-id
+                                                           #:turn-id turn-id
+                                                           #:delta
+                                                           (stream-chunk-delta-thinking chunk))
+                               #:state state))
+          (when (stream-chunk-delta-tool-call chunk)
+            (define tc-delta (stream-chunk-delta-tool-call chunk))
+            (streaming-message-append-tool-call! sm tc-delta)
+            (emit-typed-event! bus
+                               (make-stream-tool-call-delta-event #:session-id session-id
+                                                                  #:turn-id turn-id
+                                                                  #:delta-tool-call tc-delta)
+                               #:state state)
+            ;; Dispatch message-update hook for tool-call delta
+            (when hook-dispatcher
+              (define update-result
+                (hook-dispatcher 'message-update
+                                 (hasheq 'session-id
+                                         session-id
+                                         'turn-id
+                                         turn-id
+                                         'delta-text
+                                         #f
+                                         'delta-tool-call
+                                         tc-delta)))
+              (match (classify-hook-result update-result)
+                [(list 'block _) (streaming-message-set-blocked! sm)]
+                [_ (void)])))
+          (when (stream-chunk-done? chunk)
+            (set-box! received-done? #t)
+            (emit-typed-event! bus
+                               (make-stream-completed-event
+                                #:session-id session-id
+                                #:turn-id turn-id
+                                #:usage (or (stream-chunk-usage chunk) (hasheq))
+                                #:finish_reason (or (stream-chunk-finish-reason chunk) "unknown"))
+                               #:state state)
+            (when (streaming-message-message-started? sm)
+              (emit-typed-event! bus
+                                 (make-stream-message-end-event #:session-id session-id
+                                                                #:turn-id turn-id
+                                                                #:message-id message-id
+                                                                #:usage (or (stream-chunk-usage chunk)
+                                                                            (hasheq)))
+                                 #:state state)))
+          ;; Check cancellation after processing chunk
+          (cond
+            [(and cancellation-token (cancellation-token-cancelled? cancellation-token))
+             (streaming-message-set-cancelled! sm)
+             (emit-typed-event! bus
+                                (make-stream-turn-cancelled-event #:session-id session-id
+                                                                  #:turn-id turn-id
+                                                                  #:reason "cancellation-token")
+                                #:state state)]
+            [(streaming-message-blocked? sm)
+             (emit-typed-event! bus
+                                (make-stream-completed-event #:session-id session-id
+                                                             #:turn-id turn-id
+                                                             #:usage (hasheq)
+                                                             #:finish_reason "unknown")
+                                #:state state)]
+            [else (stream-loop)])))))
+
+  ;; BUG-SILENT-STREAM-EOF: synthetic completion for streams without done chunk
+  (unless (unbox received-done?)
+    (when (streaming-message-message-started? sm)
+      (emit-typed-event! bus
+                         (make-stream-completed-event #:session-id session-id
+                                                      #:turn-id turn-id
+                                                      #:usage (hasheq)
+                                                      #:finish_reason "eof"
+                                                      #:truncated? #t)
+                         #:state state)
+      (emit-typed-event! bus
+                         (make-stream-message-end-event #:session-id session-id
+                                                        #:turn-id turn-id
+                                                        #:message-id message-id
+                                                        #:usage (hasheq))
+                         #:state state)))
+
+  (streaming-message->hash sm))


### PR DESCRIPTION
Addresses #4876.

feat(v0.53.2): extract stream modules — pure reducer + effectful runner (#4876)

- Extract classify-chunk, chunk-has-data?, accumulate-stream-chunks to agent/stream-reducer.rkt (96 LOC)
- Extract stream-from-provider to agent/stream-runner.rkt (251 LOC)
- Slim loop-stream.rkt from 587 → 297 LOC (effectful result building only)
- MAX-STREAM-CHUNKS parameter moved to stream-reducer.rkt (shared by runner)
- All 95 stream tests pass, arch-fitness 33/33