### PR TITLE
fix(v0.53.7): add #:transparent to parsed-command for equal? comparison (#4892)

- tui/command-parse.rkt: add #:transparent to parsed-command struct
- Fixes test-tui-enter.rkt and tui/branch.rkt assertion failures where
  two parsed-command instances with identical fields failed equal?

### DIFF
--- a/tui/command-parse.rkt
+++ b/tui/command-parse.rkt
@@ -31,7 +31,7 @@
 ;; e.g. "/help" → (cons 'help 'none), "/switch" → (cons 'switch 'required)
 
 ;; R-17: Structured command result replacing ad-hoc symbol/list returns.
-(struct parsed-command (canonical-name args arg-kind))
+(struct parsed-command (canonical-name args arg-kind) #:transparent)
 
 (define (make-command-table)
   ;; General


### PR DESCRIPTION
Addresses #4892.

fix(v0.53.7): add #:transparent to parsed-command for equal? comparison (#4892)

- tui/command-parse.rkt: add #:transparent to parsed-command struct
- Fixes test-tui-enter.rkt and tui/branch.rkt assertion failures where
  two parsed-command instances with identical fields failed equal?