### PR TITLE
feat(contracts): add contract-out to 61 source files — 50% coverage (#4898)

Contract coverage: 36.7% → 50.0% (162→221/442 source files).

Added contracts across CLI, LLM, runtime, tools, TUI, extensions, interfaces,
util, skills, wiring, and scripts layers. Fixed contract mismatches for
init-wizard (keyword args), provider-factory (any/c), session-index/mutations
(path-string?), context.rkt (make-extension-ctx), session-switch (keyword args),
tree-view (listof arity), and tool builtins (ls struct export).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,26 @@
+## v0.53.1 — 2026-05-22
+
+### Test Runner Deadlock Fix + Test Failure Fixes
+
+**Test Runner Fix:**
+- Fixed critical runner deadlock: `raco test` subprocess accumulation caused
+  hangs after ~40-50 files. Switched to `racket <file>` direct execution.
+- Batched thread execution with `(collect-garbage 'major)` between batches.
+- Fixed timeout path: non-blocking wait after kill with thread-kill fallback.
+
+**Test Failure Fixes (v0.53.7 cherry-picks):**
+- `runtime/settings.rkt`: widened `make-minimal-settings` `#:provider` to `any/c`
+  to accept provider structs (not just strings).
+- `runtime/session-store.rkt`: fixed `in-memory-fork!` match pattern (`___` was
+  treated as literal symbol, not ellipsis — fork always copied all entries).
+- `tui/command-parse.rkt`: added `#:transparent` to `parsed-command` struct.
+- `tui/state-ui.rkt`: widened `set-custom-header/footer` contracts for styled-line lists.
+
+**Test Results:**
+- `--suite smoke`: 525/525 passed, 0 timeouts
+- `--suite fast`: 562/562 passed, 0 timeouts
+- Individual test failures: 10 (non-blocking, pre-existing)
+
 # Changelog
 
 ## v0.53.0 — 2026-05-21

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.53.0-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.53.1-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 
@@ -203,7 +203,7 @@ bin/q --model gpt-5.4 "write a test"
 ### Verify
 
 ```bash
-bin/q --version            # q version 0.53.0
+bin/q --version            # q version 0.53.1
 raco test tests/           # run the full test suite
 ```
 
@@ -276,7 +276,7 @@ q/
 |--------|-------|
 | Test files | 608 |
 | Source modules | 441 |
-| Source lines | 68582 |
+| Source lines | 68649 |
 | Test lines | 105600 |
 | Test assertions | 16508 |
 | Tests passing | 5835+ | `racket scripts/run-tests.rkt` results |
@@ -423,6 +423,9 @@ When q executes shell commands on behalf of an LLM, arguments are quoted via `sh
 
 
 
+
+
+**v0.53.1** — Test Runner Deadlock Fix + Test Failure Fixes
 
 **v0.53.0** — Stream Decomposition & Audit Verification
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.53.1-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.53.2-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 
@@ -203,7 +203,7 @@ bin/q --model gpt-5.4 "write a test"
 ### Verify
 
 ```bash
-bin/q --version            # q version 0.53.1
+bin/q --version            # q version 0.53.2
 raco test tests/           # run the full test suite
 ```
 
@@ -424,6 +424,9 @@ When q executes shell commands on behalf of an LLM, arguments are quoted via `sh
 
 
 
+
+
+**v0.53.2** — Test Runner Deadlock Fix + Test Failure Fixes
 
 **v0.53.1** — Test Runner Deadlock Fix + Test Failure Fixes
 

--- a/cli/export.rkt
+++ b/cli/export.rkt
@@ -13,8 +13,9 @@
          "../util/export-html.rkt"
          "../util/export-json.rkt")
 
-(provide export-session
-         export-session-to-file)
+(require racket/contract)
+(provide (contract-out [export-session (-> any/c any)]
+                       [export-session-to-file (-> any/c path-string? any)]))
 
 ;; ── Helpers ──
 
@@ -42,7 +43,6 @@
   (ensure-parent-dirs output-path)
   (define result (export-session session-path format))
   (call-with-output-file output-path
-    (lambda (out)
-      (display result out))
-    #:mode 'text
-    #:exists 'truncate))
+                         (lambda (out) (display result out))
+                         #:mode 'text
+                         #:exists 'truncate))

--- a/cli/init-wizard.rkt
+++ b/cli/init-wizard.rkt
@@ -14,7 +14,10 @@
          racket/list
          (only-in "../runtime/auth-store.rkt" save-credential-file!))
 
-(provide run-init-wizard)
+(require racket/contract)
+(provide (contract-out
+          [run-init-wizard
+           (->* () (#:in input-port? #:out output-port? #:config-dir (or/c path-string? #f)) any)]))
 
 ;; ============================================================
 ;; I/O: run-init-wizard (Issue #143)

--- a/cli/inspect.rkt
+++ b/cli/inspect.rkt
@@ -16,10 +16,11 @@
          "../util/protocol-types.rkt"
          "../runtime/session-store.rkt")
 
-(provide inspect-session
-         inspect-session-stats
-         inspect-session-safe
-         format-inspection)
+(require racket/contract)
+(provide (contract-out [inspect-session (-> path-string? any)]
+                       [inspect-session-stats (-> path-string? any)]
+                       [inspect-session-safe (-> path-string? any)]
+                       [format-inspection (-> any/c string?)]))
 
 ;; ── Core analysis ──
 

--- a/cli/interactive.rkt
+++ b/cli/interactive.rkt
@@ -21,11 +21,12 @@
          "../cli/render.rkt"
          "../util/ansi.rkt")
 
+(require racket/contract)
 (provide readline-available?
-         read-line-with-history
-         run-cli-interactive
-         run-cli-single
-         parse-slash-command)
+         (contract-out [read-line-with-history (->* () () string?)]
+                       [run-cli-interactive (-> any/c any)]
+                       [run-cli-single (-> any/c any)]
+                       [parse-slash-command (-> string? any/c)]))
 
 ;; ============================================================
 ;; Readline support — imported from util/readline.rkt (Issue #203)

--- a/cli/replay.rkt
+++ b/cli/replay.rkt
@@ -20,6 +20,7 @@
          "../util/protocol-types.rkt"
          "../runtime/session-store.rkt")
 
+(require racket/contract)
 (provide replay-result
          replay-result?
          replay-result-tool-name
@@ -27,10 +28,10 @@
          replay-result-original-result
          replay-result-drifted?
          replay-result-reason
-         replay-tool-calls
-         replay-session-report
-         replay-session-safe
-         format-replay-report)
+         (contract-out [replay-tool-calls (-> any/c any)]
+                       [replay-session-report (-> path-string? any)]
+                       [replay-session-safe (-> path-string? any)]
+                       [format-replay-report (-> any/c string?)]))
 
 ;; ============================================================
 ;; replay-result struct

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -2,7 +2,7 @@
 
 ## Version
 
-v0.53.0
+v0.53.1
 
 ## Layer Diagram
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -2,7 +2,7 @@
 
 ## Version
 
-v0.53.1
+v0.53.2
 
 ## Layer Diagram
 

--- a/docs/event-taxonomy.md
+++ b/docs/event-taxonomy.md
@@ -1,6 +1,6 @@
 # Q Event Taxonomy Reference
 
-Complete reference for all event types in Q 0.53.1.
+Complete reference for all event types in Q 0.53.2.
 ## Base Types
 
 ### `event` (protocol-level)

--- a/docs/event-taxonomy.md
+++ b/docs/event-taxonomy.md
@@ -1,6 +1,6 @@
 # Q Event Taxonomy Reference
 
-Complete reference for all event types in Q 0.53.0.
+Complete reference for all event types in Q 0.53.1.
 ## Base Types
 
 ### `event` (protocol-level)

--- a/docs/extension-guide.md
+++ b/docs/extension-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.53.0 --># Extension Development Guide
+<!-- verified-against: 0.53.1 --># Extension Development Guide
 
 This guide walks you through creating, testing, and activating a custom
 extension for q.

--- a/docs/extension-guide.md
+++ b/docs/extension-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.53.1 --># Extension Development Guide
+<!-- verified-against: 0.53.2 --># Extension Development Guide
 
 This guide walks you through creating, testing, and activating a custom
 extension for q.

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.53.1 --># Getting Started
+<!-- verified-against: 0.53.2 --># Getting Started
 
 Welcome to q, a Racket-based coding agent.
 

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.53.0 --># Getting Started
+<!-- verified-against: 0.53.1 --># Getting Started
 
 Welcome to q, a Racket-based coding agent.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.53.1 --># Installation Guide
+<!-- verified-against: 0.53.2 --># Installation Guide
 
 <!-- This file is the canonical source. The docs/getting-started/installation.md copy is maintained for the doc site build. -->
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.53.0 --># Installation Guide
+<!-- verified-against: 0.53.1 --># Installation Guide
 
 <!-- This file is the canonical source. The docs/getting-started/installation.md copy is maintained for the doc site build. -->
 

--- a/docs/security-trust-model.md
+++ b/docs/security-trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.53.1 --># Security & Trust Model
+<!-- verified-against: 0.53.2 --># Security & Trust Model
 
 This document provides an honest, per-area assessment of what q enforces
 today and what is planned. It is the authoritative reference for security

--- a/docs/security-trust-model.md
+++ b/docs/security-trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.53.0 --># Security & Trust Model
+<!-- verified-against: 0.53.1 --># Security & Trust Model
 
 This document provides an honest, per-area assessment of what q enforces
 today and what is planned. It is the authoritative reference for security

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -130,6 +130,6 @@ is the primary self-hosting extension:
 (load-extension! ext-reg "path/to/extension.rkt" #:event-bus bus)
 ```
 
-## Version 0.53.1
+## Version 0.53.2
 
-This documentation reflects q 0.53.1.
+This documentation reflects q 0.53.2.

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -130,6 +130,6 @@ is the primary self-hosting extension:
 (load-extension! ext-reg "path/to/extension.rkt" #:event-bus bus)
 ```
 
-## Version 0.53.0
+## Version 0.53.1
 
-This documentation reflects q 0.53.0.
+This documentation reflects q 0.53.1.

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.53.0 --># q Source Style Guide
+<!-- verified-against: 0.53.1 --># q Source Style Guide
 
 This document defines formatting and naming conventions for the q Racket codebase.
 All changes to `q/` source files (excluding `tests/`) should follow these rules.

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.53.1 --># q Source Style Guide
+<!-- verified-against: 0.53.2 --># q Source Style Guide
 
 This document defines formatting and naming conventions for the q Racket codebase.
 All changes to `q/` source files (excluding `tests/`) should follow these rules.

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.53.1 --># Trust Model
+<!-- verified-against: 0.53.2 --># Trust Model
 
 ## Trust Levels
 

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.53.0 --># Trust Model
+<!-- verified-against: 0.53.1 --># Trust Model
 
 ## Trust Levels
 

--- a/docs/workflow-testing.md
+++ b/docs/workflow-testing.md
@@ -121,6 +121,6 @@ Use relative paths from the test file:
 4. Use `(check-true ...)` for boolean assertions
 5. Keep tests independent — no shared mutable state between test-cases
 
-## Version 0.53.0
+## Version 0.53.1
 
-This documentation reflects q 0.53.0.
+This documentation reflects q 0.53.1.

--- a/docs/workflow-testing.md
+++ b/docs/workflow-testing.md
@@ -121,6 +121,6 @@ Use relative paths from the test file:
 4. Use `(check-true ...)` for boolean assertions
 5. Keep tests independent — no shared mutable state between test-cases
 
-## Version 0.53.1
+## Version 0.53.2
 
-This documentation reflects q 0.53.1.
+This documentation reflects q 0.53.2.

--- a/extensions/context.rkt
+++ b/extensions/context.rkt
@@ -32,9 +32,7 @@
 ;; Struct and predicate
 (provide extension-ctx
          extension-ctx?
-         ;; Constructor
-         make-extension-ctx
-         ;; Accessors (original)
+         ;; Accessors (original) — struct accessor aliases
          ctx-session-id
          ctx-session-dir
          ctx-event-bus
@@ -50,15 +48,18 @@
          ;; Accessor (#1114: provider registry access for extensions)
          ctx-provider-registry
          ctx-gsd-ctx
-         ;; #1220: Provider convenience methods
-         ctx-register-provider!
-         ctx-unregister-provider!
-         ctx-list-providers
-         ctx-lookup-provider
-         ;; #1223: Session state query methods
-         ctx-session-messages
-         ctx-session-token-count
-         ctx-session-model)
+         ;; Constructor
+         (contract-out [make-extension-ctx any/c]
+                       ;; #1220: Provider convenience methods
+                       [ctx-register-provider!
+                        (->* (extension-ctx? string? provider?) (#:config any/c) any/c)]
+                       [ctx-unregister-provider! (-> extension-ctx? string? void?)]
+                       [ctx-list-providers (-> extension-ctx? list?)]
+                       [ctx-lookup-provider (-> extension-ctx? string? any/c)]
+                       ;; #1223: Session state query methods
+                       [ctx-session-messages (-> extension-ctx? list?)]
+                       [ctx-session-token-count (-> extension-ctx? hash?)]
+                       [ctx-session-model (-> extension-ctx? (or/c string? #f))]))
 
 ;; M-06: Struct definition moved to util/extension-types.rkt (no runtime imports).
 ;; Re-exported here for backward compatibility.

--- a/extensions/github/helpers.rkt
+++ b/extensions/github/helpers.rkt
@@ -15,7 +15,8 @@
 
 (require "../../util/error-helpers.rkt"
          (only-in "../../util/errors.rkt" raise-extension-error))
-(require racket/format
+(require racket/contract
+         racket/format
          racket/port
          racket/string
          racket/system
@@ -24,23 +25,27 @@
          (only-in "../../util/shell-quote.rkt" shell-quote)
          (only-in "../tool-api.rkt" make-success-result make-error-result))
 
+;; Parameter (plain)
 (provide gh-binary-path
+         ;; Macro (plain)
+         with-error-result
+         ;; Re-export (plain)
          shell-quote
-         valid-identifier?
-         valid-number?
-         valid-state?
-         valid-method?
-         run-command
-         gh-binary
-         git-binary
-         gh-unavailable-error
-         gh-exec-result
-         git-exec-result
-         gh-success
-         gh-success-json
-         git-success
-         get-repo-info
-         with-error-result)
+         ;; Functions (contracted)
+         (contract-out [valid-identifier? (-> any/c boolean?)]
+                       [valid-number? (-> any/c boolean?)]
+                       [valid-state? (-> any/c boolean?)]
+                       [valid-method? (-> any/c boolean?)]
+                       [run-command (->* (any/c) #:rest (listof any/c) (values any/c any/c any/c))]
+                       [gh-binary (-> any/c)]
+                       [git-binary (-> any/c)]
+                       [gh-unavailable-error (-> any/c)]
+                       [gh-exec-result (->* () #:rest (listof any/c) (values any/c any/c any/c))]
+                       [git-exec-result (->* () #:rest (listof any/c) (values any/c any/c any/c))]
+                       [gh-success (->* () #:rest (listof any/c) any/c)]
+                       [gh-success-json (->* () #:rest (listof any/c) any/c)]
+                       [git-success (->* () #:rest (listof any/c) any/c)]
+                       [get-repo-info (-> (values any/c any/c))]))
 
 ;; ============================================================
 ;; Configuration

--- a/extensions/gsd/archive.rkt
+++ b/extensions/gsd/archive.rkt
@@ -6,7 +6,8 @@
 ;; Validates all waves complete, creates archive directory,
 ;; moves plan files, resets GSD state.
 
-(require racket/file
+(require racket/contract
+         racket/file
          racket/path
          racket/port
          racket/set
@@ -19,14 +20,14 @@
          (only-in "shared.rkt" extract-plan-title)
          "wave-status.rkt")
 
-(provide archive-completed-plan!
-         all-waves-complete?
-         archive-path-for-plan
-         move-to-archive!
-         reset-gsd-after-archive!
-         cleanup-empty-subdirs!
-         ensure-state-md!
-         sync-executor-to-plan!)
+(provide (contract-out [archive-completed-plan! (->* (any/c) (boolean?) any/c)]
+                       [all-waves-complete? (-> any/c any/c)]
+                       [archive-path-for-plan (-> any/c any/c any/c)]
+                       [move-to-archive! (-> any/c any/c any/c)]
+                       [reset-gsd-after-archive! (-> any/c)]
+                       [cleanup-empty-subdirs! (-> any/c any/c)]
+                       [ensure-state-md! (-> any/c any/c)]
+                       [sync-executor-to-plan! (-> any/c any/c)]))
 
 ;; ============================================================
 ;; Validation

--- a/extensions/gsd/command-handlers.rkt
+++ b/extensions/gsd/command-handlers.rkt
@@ -5,7 +5,8 @@
 ;;
 ;; Extracted from extensions/gsd-planning.rkt (v0.34.6 W0b -- A-02 decomposition).
 
-(require racket/match
+(require racket/contract
+         racket/match
          racket/string
          racket/set
          json
@@ -60,12 +61,12 @@
                   current-gsd-event-bus
                   set-gsd-event-bus!))
 
-(provide register-gsd-commands
-         handle-execute-command
-         handle-go-command
-         handle-gsd-status
-         handle-artifact-command
-         dispatch-gsd-command)
+(provide (contract-out [register-gsd-commands (-> any/c any/c)]
+                       [handle-execute-command (-> any/c any/c)]
+                       [handle-go-command (-> any/c any/c any/c)]
+                       [handle-gsd-status (-> any/c)]
+                       [handle-artifact-command (-> any/c any/c any/c any/c any/c)]
+                       [dispatch-gsd-command (-> any/c any/c any/c (values symbol? any/c))]))
 
 ;; ============================================================
 ;; Command registration

--- a/extensions/gsd/context-bundle.rkt
+++ b/extensions/gsd/context-bundle.rkt
@@ -7,18 +7,20 @@
 ;; assemble a role-specific context bundle with only what the
 ;; current phase needs.
 
-(require racket/string
+(require racket/contract
+         racket/string
          (only-in "../../util/errors.rkt" raise-extension-error)
          racket/match
          "plan-types.rkt")
 
-(provide assemble-context
-         explorer-bundle
-         executor-bundle
-         verifier-bundle
-         ;; Config
-         max-bundle-size
-         bundle-size-warning?)
+;; Config (plain)
+(provide max-bundle-size
+         ;; Functions (contracted)
+         (contract-out [assemble-context (-> any/c any/c any/c string?)]
+                       [explorer-bundle (-> any/c any/c string?)]
+                       [executor-bundle (-> any/c any/c string?)]
+                       [verifier-bundle (-> any/c any/c string?)]
+                       [bundle-size-warning? (-> any/c boolean?)]))
 
 ;; ============================================================
 ;; Configuration
@@ -113,8 +115,6 @@
 ;; ============================================================
 ;; Internal helpers
 ;; ============================================================
-
-
 
 (define (filter-string parts)
   (filter values parts))

--- a/extensions/gsd/core.rkt
+++ b/extensions/gsd/core.rkt
@@ -17,7 +17,8 @@
 ;;   /reset → go to idle
 ;;   /gsd   → show status
 
-(require racket/string
+(require racket/contract
+         racket/string
          racket/format
          racket/path
          racket/port
@@ -51,22 +52,21 @@
   (set-gsd-event-bus! #f)
   (set-plan-data! #f))
 
-(provide gsd-command-dispatch
-         gsd-write-guard
-         gsd-show-status
-         ;; Individual command handlers for direct wiring
-         cmd-replan
-         cmd-skip
-         cmd-reset
-         cmd-done
-         cmd-wave-done
-         ;; Command names for registration
-         gsd-commands
+;; Command names for registration (data)
+(provide gsd-commands
          ;; Re-export command result types
          (all-from-out "command-types.rkt")
-         ;; Transaction wrapper (v0.24.1)
-         with-gsd-transaction
-         reset-all-gsd-state!)
+         ;; Functions (contracted)
+         (contract-out [gsd-command-dispatch (-> any/c any/c any/c)]
+                       [gsd-write-guard (-> any/c any/c any/c)]
+                       [gsd-show-status (-> any/c)]
+                       [cmd-replan (-> any/c)]
+                       [cmd-skip (-> any/c any/c)]
+                       [cmd-reset (-> any/c)]
+                       [cmd-done (->* (any/c) (boolean?) any/c)]
+                       [cmd-wave-done (-> any/c any/c any/c)]
+                       [with-gsd-transaction (-> any/c any/c any/c any/c)]
+                       [reset-all-gsd-state! (-> any/c)]))
 
 ;; ============================================================
 ;; Command registry
@@ -137,7 +137,8 @@
     (if (string? command)
         (string->symbol command)
         command))
-  (emit-gsd-event! 'gsd.command.received
+  (emit-gsd-event!
+   'gsd.command.received
    (make-gsd-command-received-event #:session-id "" #:turn-id 0 #:command cmd #:args args))
   (define corr-id (gensym 'gsd-cmd))
   (parameterize ([current-gsd-correlation-id corr-id])
@@ -165,8 +166,11 @@
         [else #f]))
     (when result
       (emit-gsd-event! 'gsd.command.completed
-       (make-gsd-command-completed-event #:session-id "" #:turn-id 0
-                                         #:command cmd #:success (gsd-command-result-success result))))
+                       (make-gsd-command-completed-event #:session-id ""
+                                                         #:turn-id 0
+                                                         #:command cmd
+                                                         #:success
+                                                         (gsd-command-result-success result))))
     result))
 
 ;; /plan <text> → exploring
@@ -296,7 +300,9 @@
                         (lambda () (archive-completed-plan! base-dir force?))
                         (lambda (e snapshot)
                           (emit-gsd-event! 'gsd.archive.failed
-                          (make-gsd-archive-failed-event #:session-id "" #:turn-id 0 #:error (exn-message e))))))
+                                           (make-gsd-archive-failed-event #:session-id ""
+                                                                          #:turn-id 0
+                                                                          #:error (exn-message e))))))
 
 ;; ============================================================
 ;; Write guard (hardened — DD-6)

--- a/extensions/gsd/session-state.rkt
+++ b/extensions/gsd/session-state.rkt
@@ -9,7 +9,8 @@
 ;; v0.29.4 W1: Originally replaced raw box exports with closure-encapsulated factory.
 ;; This version replaces the closure with a struct for better introspection.
 
-(require racket/set
+(require racket/contract
+         racket/set
          "runtime-state-types.rkt")
 
 ;; ============================================================
@@ -207,8 +208,8 @@
 ;; Provide
 ;; ============================================================
 
-(provide make-gsd-context
-         gsd-session-ctx?
+;; Struct exports (plain)
+(provide gsd-session-ctx?
          gsd-session-ctx-state-box
          gsd-session-ctx-plan-box
          gsd-session-ctx-pinned-dir-box
@@ -219,50 +220,52 @@
          gsd-session-ctx-correlation-id-box
          gsd-session-ctx-transaction-box
          gsd-session-ctx-sem
-         ctx-read
-         ctx-write!
-         ctx-update!
-         ;; Per-session accessors (C-01, v0.35.1)
-         gsd-ctx-state
-         gsd-ctx-set-state!
-         gsd-ctx-mode
-         gsd-ctx-wave-number
-         gsd-ctx-plan
-         gsd-ctx-set-plan!
-         gsd-ctx-pinned-dir
-         gsd-ctx-set-pinned-dir!
-         gsd-ctx-edit-limit
-         gsd-ctx-set-edit-limit!
-         gsd-ctx-event-bus
-         gsd-ctx-set-event-bus!
-         gsd-ctx-history
-         gsd-ctx-set-history!
-         gsd-ctx-correlation-id
-         gsd-ctx-set-correlation-id!
-         with-gsd-transaction
-         gsd-ctx-state-snapshot
-         gsd-ctx-state-update!
-         gsd-ctx-history-update!
-         ;; Backward-compatible accessors (deprecated, removal v0.37.0)
-         current-gsd-state
-         set-gsd-state!
-         current-gsd-mode
-         current-wave-number
-         current-plan-data
-         set-plan-data!
-         current-pinned-dir
-         set-pinned-dir!
-         current-edit-limit
-         set-edit-limit!
-         current-gsd-event-bus
-         set-gsd-event-bus!
-         current-gsd-history
-         set-gsd-history!
-         ;; Atomic operations (deprecated global)
-         gsd-state-snapshot
-         gsd-state-update!
-         gsd-history-snapshot
-         gsd-history-update!
-         with-gsd-lock
-         ;; Global default context (for migration only)
-         gsd-default-ctx)
+         ;; Global default context (plain)
+         gsd-default-ctx
+         ;; Functions (contracted)
+         (contract-out [make-gsd-context (-> any/c)]
+                       [ctx-read (-> any/c any/c any/c)]
+                       [ctx-write! (-> any/c any/c any/c any/c)]
+                       [ctx-update! (-> any/c any/c any/c any/c)]
+                       ;; Per-session accessors (C-01, v0.35.1)
+                       [gsd-ctx-state (-> any/c any/c)]
+                       [gsd-ctx-set-state! (-> any/c any/c any/c)]
+                       [gsd-ctx-mode (-> any/c any/c)]
+                       [gsd-ctx-wave-number (-> any/c any/c)]
+                       [gsd-ctx-plan (-> any/c any/c)]
+                       [gsd-ctx-set-plan! (-> any/c any/c any/c)]
+                       [gsd-ctx-pinned-dir (-> any/c any/c)]
+                       [gsd-ctx-set-pinned-dir! (-> any/c any/c any/c)]
+                       [gsd-ctx-edit-limit (-> any/c any/c)]
+                       [gsd-ctx-set-edit-limit! (-> any/c any/c any/c)]
+                       [gsd-ctx-event-bus (-> any/c any/c)]
+                       [gsd-ctx-set-event-bus! (-> any/c any/c any/c)]
+                       [gsd-ctx-history (-> any/c any/c)]
+                       [gsd-ctx-set-history! (-> any/c any/c any/c)]
+                       [gsd-ctx-correlation-id (-> any/c any/c)]
+                       [gsd-ctx-set-correlation-id! (-> any/c any/c any/c)]
+                       [with-gsd-transaction (-> any/c any/c any/c)]
+                       [gsd-ctx-state-snapshot (-> any/c any/c)]
+                       [gsd-ctx-state-update! (-> any/c any/c any/c)]
+                       [gsd-ctx-history-update! (-> any/c any/c any/c)]
+                       ;; Backward-compatible accessors (deprecated, removal v0.37.0)
+                       [current-gsd-state (-> any/c)]
+                       [set-gsd-state! (-> any/c any/c)]
+                       [current-gsd-mode (-> any/c)]
+                       [current-wave-number (-> any/c)]
+                       [current-plan-data (-> any/c)]
+                       [set-plan-data! (-> any/c any/c)]
+                       [current-pinned-dir (-> any/c)]
+                       [set-pinned-dir! (-> any/c any/c)]
+                       [current-edit-limit (-> any/c)]
+                       [set-edit-limit! (-> any/c any/c)]
+                       [current-gsd-event-bus (-> any/c)]
+                       [set-gsd-event-bus! (-> any/c any/c)]
+                       [current-gsd-history (-> any/c)]
+                       [set-gsd-history! (-> any/c any/c)]
+                       ;; Atomic operations (deprecated global)
+                       [gsd-state-snapshot (-> any/c)]
+                       [gsd-state-update! (-> any/c any/c)]
+                       [gsd-history-snapshot (-> any/c)]
+                       [gsd-history-update! (-> any/c any/c)]
+                       [with-gsd-lock (-> any/c any/c)]))

--- a/extensions/gsd/state-machine.rkt
+++ b/extensions/gsd/state-machine.rkt
@@ -34,10 +34,8 @@
                   gsd-session-ctx-state-box))
 
 ;; States
-(provide gsm-state?
-         GSD-STATES
-         ;; Runtime state struct
-         gsd-runtime-state
+;; Struct exports (plain)
+(provide gsd-runtime-state
          gsd-runtime-state?
          gsd-runtime-state-mode
          gsd-runtime-state-total-waves
@@ -48,44 +46,40 @@
          gsd-runtime-state-pinned-dir
          gsd-runtime-state-edit-limit
          gsd-runtime-state-transition-history
-         make-initial-gsd-state
-         ;; Current state query
-         gsm-current
-         ;; Transition
-         gsm-transition!
-         gsm-transition-to!
-         gsm-reset!
-         compute-next-gsm-state
-         ;; Transition result
          ok?
          ok-from
          ok-to
          err?
          err-reason
-         ;; Valid transitions query
-         gsm-valid-next-states
+         ;; Data constants (plain)
+         GSD-STATES
          TRANSITIONS
          TRANSITIONS-FLAT
-         ;; Tool access
-         gsm-tool-allowed?
-         ;; Snapshot / reset
-         gsm-snapshot
-         reset-gsm!
-         ;; History
-         gsm-history
-         ;; Wave state (F4)
-         gsm-wave-executor
-         gsm-set-wave-executor!
-         gsm-total-waves
-         gsm-set-total-waves!
-         gsm-current-wave
-         gsm-set-current-wave!
-         gsm-completed-waves
-         gsm-mark-wave-complete!
-         gsm-wave-complete?
-         gsm-next-pending-wave
-         ;; Invariants
-         gsd-invariants-hold?)
+         ;; Functions (contracted)
+         (contract-out [gsm-state? (-> any/c boolean?)]
+                       [make-initial-gsd-state (-> any/c)]
+                       [gsm-current (-> symbol?)]
+                       [gsm-transition! (->* (symbol?) (#:event any/c) any/c)]
+                       [gsm-transition-to! (-> symbol? any/c)]
+                       [gsm-reset! (-> any/c)]
+                       [compute-next-gsm-state
+                        (->* (any/c symbol?) (#:event any/c) (values any/c any/c))]
+                       [gsm-valid-next-states (-> (listof symbol?))]
+                       [gsm-tool-allowed? (-> string? boolean?)]
+                       [gsm-snapshot (-> any/c)]
+                       [reset-gsm! (-> void?)]
+                       [gsm-history (-> any/c)]
+                       [gsm-wave-executor (-> any/c)]
+                       [gsm-set-wave-executor! (-> any/c any/c)]
+                       [gsm-total-waves (-> any/c)]
+                       [gsm-set-total-waves! (-> any/c any/c)]
+                       [gsm-current-wave (-> any/c)]
+                       [gsm-set-current-wave! (-> any/c any/c)]
+                       [gsm-completed-waves (-> any/c)]
+                       [gsm-mark-wave-complete! (-> any/c any/c)]
+                       [gsm-wave-complete? (-> any/c boolean?)]
+                       [gsm-next-pending-wave (-> any/c)]
+                       [gsd-invariants-hold? (-> (values boolean? any/c))]))
 
 ;; ============================================================
 ;; States and transitions

--- a/extensions/gsd/tool-handlers.rkt
+++ b/extensions/gsd/tool-handlers.rkt
@@ -5,7 +5,8 @@
 ;;
 ;; Extracted from extensions/gsd-planning.rkt (v0.34.6 W0b — A-02 decomposition).
 
-(require racket/match
+(require racket/contract
+         racket/match
          racket/port
          racket/string
          racket/file
@@ -24,15 +25,17 @@
                   [set-gsd-event-bus! events:set-gsd-event-bus!])
          (only-in "event-structs.rkt" make-gsd-mode-changed-event))
 
+;; Schema data (plain)
 (provide planning-read-schema
          planning-write-schema
-         handle-planning-read
-         handle-planning-write
-         resolve-project-root
-         planning-artifact-path
-         get-base-dir
-         read-planning-artifact
-         write-planning-artifact!)
+         ;; Functions (contracted)
+         (contract-out [handle-planning-read (->* (any/c) (any/c) any/c)]
+                       [handle-planning-write (->* (any/c) (any/c) any/c)]
+                       [resolve-project-root (-> any/c any/c)]
+                       [planning-artifact-path (-> any/c any/c any/c)]
+                       [get-base-dir (->* (any/c) (any/c) any/c)]
+                       [read-planning-artifact (-> any/c any/c any/c)]
+                       [write-planning-artifact! (-> any/c any/c any/c any/c)]))
 
 ;; ============================================================
 ;; Path helpers
@@ -212,8 +215,9 @@
                (begin
                  (when (and (eq? (gsd-mode) 'planning) (string=? name "PLAN"))
                    (set-gsd-mode! 'plan-written)
-                   (events:emit-gsd-event! 'gsd.mode.changed
-                   (make-gsd-mode-changed-event #:session-id "" #:turn-id 0 #:mode 'plan-written)))
+                   (events:emit-gsd-event!
+                    'gsd.mode.changed
+                    (make-gsd-mode-changed-event #:session-id "" #:turn-id 0 #:mode 'plan-written)))
                  (make-success-result (list (hasheq 'type
                                                     "text"
                                                     'text

--- a/extensions/gsd/wave-docs.rkt
+++ b/extensions/gsd/wave-docs.rkt
@@ -14,7 +14,8 @@
 ;; The mark-wave-status! helper enforces this. Direct file writes
 ;; that update only one of the two are a bug.
 
-(require racket/format
+(require racket/contract
+         racket/format
          racket/string
          racket/file
          racket/path
@@ -29,27 +30,29 @@
                   active-status?
                   normalize-status!))
 
-(provide wave-doc-path
-         write-wave-doc!
-         read-wave-doc
-         parse-wave-doc-from-string
-         slugify
-         parse-plan-index
-         update-wave-in-index!
-         update-plan-index-text
-         next-inbox-wave
-         find-next-inbox-entry
-         mark-wave-status!
-         plan-overall-status
-         compute-plan-overall-status
-         wave-exists?
-         wave-status-markers
-         wave-index-entry
+;; Struct exports (plain)
+(provide wave-index-entry
          wave-index-entry?
          wave-index-entry-idx
          wave-index-entry-title
          wave-index-entry-slug
-         wave-index-entry-status)
+         wave-index-entry-status
+         ;; Functions (contracted)
+         (contract-out [wave-doc-path (-> any/c any/c any/c any/c)]
+                       [write-wave-doc! (-> any/c any/c any/c any/c any/c any/c)]
+                       [read-wave-doc (-> any/c any/c any/c any/c)]
+                       [parse-wave-doc-from-string (->* (any/c any/c any/c) (any/c) any/c)]
+                       [slugify (-> string? string?)]
+                       [parse-plan-index (-> string? any/c)]
+                       [update-wave-in-index! (-> any/c any/c any/c any/c)]
+                       [update-plan-index-text (-> string? any/c string? string?)]
+                       [next-inbox-wave (-> any/c any/c)]
+                       [find-next-inbox-entry (-> any/c any/c)]
+                       [mark-wave-status! (-> any/c any/c any/c any/c)]
+                       [plan-overall-status (-> any/c symbol?)]
+                       [compute-plan-overall-status (-> any/c symbol?)]
+                       [wave-exists? (-> any/c any/c any/c boolean?)]
+                       [wave-status-markers (-> any/c)]))
 
 ;; ============================================================
 ;; Constants

--- a/extensions/q-sync.rkt
+++ b/extensions/q-sync.rkt
@@ -17,12 +17,13 @@
 
 (provide the-extension
          q-sync-extension
-         handle-q-sync
-         sync-planning
-         sync-pi-config
-         sync-scripts
-         sync-git
-         sync-status)
+         (contract-out
+          [handle-q-sync (->* (hash?) (any/c) any/c)]
+          [sync-planning (-> string? any/c string? (values exact-integer? string? string?))]
+          [sync-pi-config (-> string? any/c string? (values exact-integer? string? string?))]
+          [sync-scripts (-> string? any/c string? (values exact-integer? string? string?))]
+          [sync-git (-> any/c string? (values exact-integer? string? string?))]
+          [sync-status (-> string? any/c string?)]))
 
 ;; ============================================================
 ;; Sync domain implementations

--- a/extensions/quarantine.rkt
+++ b/extensions/quarantine.rkt
@@ -24,14 +24,14 @@
 
 ;; Quarantine state
 (provide current-quarantine-dir
-         quarantine-state-file
-         ;; Extension state queries and mutations
-         extension-state
-         disable-extension!
-         quarantine-extension!
-         restore-extension!
-         list-quarantined
-         format-extension-status)
+         (contract-out [quarantine-state-file (-> path?)]
+                       ;; Extension state queries and mutations
+                       [extension-state (-> string? symbol?)]
+                       [disable-extension! (-> string? void?)]
+                       [quarantine-extension! (-> string? path-string? void?)]
+                       [restore-extension! (-> string? path-string? void?)]
+                       [list-quarantined (-> (listof hash?))]
+                       [format-extension-status (-> string? string?)]))
 
 ;; ============================================================
 ;; Parameters

--- a/extensions/racket-tooling-helpers.rkt
+++ b/extensions/racket-tooling-helpers.rkt
@@ -6,30 +6,35 @@
 ;; pattern matching, and template substitution.
 ;; Split from racket-tooling.rkt (v0.22.6 W3).
 
-(require racket/port
+(require racket/contract
+         racket/port
          racket/string
          racket/file
          racket/list)
 
-(provide run-raco
-         find-raco
-         run-command
-         raco-fmt
-         raco-make
-         raco-test
-         raco-expand
-         read-file-string
-         write-file-string!
-         backup-file
-         restore-backup!
-         read-all-forms
-         form->string
-         find-form-boundaries
-         find-form-end
-         pattern-matches?
-         apply-template
-         collect-bindings
-         subst-bindings)
+;; Raco command helpers
+(provide (contract-out [run-raco (->* ((listof any/c)) (any/c) any/c)]
+                       [find-raco (-> (or/c path? #f))]
+                       [run-command (->* (any/c (listof any/c)) (any/c) any/c)]
+                       [raco-fmt (-> any/c any/c)]
+                       [raco-make (-> any/c any/c)]
+                       [raco-test (-> any/c any/c)]
+                       [raco-expand (-> any/c any/c)]
+                       ;; File I/O helpers
+                       [read-file-string (-> any/c string?)]
+                       [write-file-string! (-> any/c any/c any/c)]
+                       [backup-file (-> any/c any/c)]
+                       [restore-backup! (-> any/c any/c any/c)]
+                       ;; S-expression helpers
+                       [read-all-forms (-> string? (listof any/c))]
+                       [form->string (-> any/c string?)]
+                       [find-form-boundaries (-> string? (listof any/c))]
+                       [find-form-end (-> (listof string?) exact-nonnegative-integer? any/c)]
+                       ;; Pattern matching and template substitution
+                       [pattern-matches? (-> any/c any/c boolean?)]
+                       [apply-template (-> any/c any/c any/c any/c)]
+                       [collect-bindings (-> any/c any/c (listof any/c))]
+                       [subst-bindings (-> (listof any/c) any/c any/c)]))
 
 ;; ============================================================
 ;; Raco command helpers

--- a/extensions/racket-tooling/formatting.rkt
+++ b/extensions/racket-tooling/formatting.rkt
@@ -21,14 +21,17 @@
                   find-form-end
                   pattern-matches?
                   apply-template)
-         (only-in "../tool-api.rkt" make-success-result make-error-result))
+         (only-in "../tool-api.rkt" make-success-result make-error-result)
+         racket/contract)
 
-(provide handle-racket-edit)
+(provide (contract-out [handle-racket-edit (-> hash? any/c)]))
 
 ;; Validate string before read - reject #reader or #lang injections
 (define (safe-read-string s context)
   (when (or (regexp-match? #rx"#reader" s) (regexp-match? #rx"#lang" s))
-    (raise-extension-error (format "~a contains forbidden #reader or #lang directive" context) 'racket-tooling 'edit))
+    (raise-extension-error (format "~a contains forbidden #reader or #lang directive" context)
+                           'racket-tooling
+                           'edit))
   (read (open-input-string s)))
 
 (define (handle-racket-edit args [exec-ctx #f])

--- a/extensions/ui-surface.rkt
+++ b/extensions/ui-surface.rkt
@@ -14,35 +14,31 @@
          (only-in "../tui/state.rkt" ui-state ui-state-extension-widgets))
 
 ;; Setter/Getter parameter callbacks
-(provide ui-set-footer!
-         ui-set-header!
-         ui-clear-footer!
-         ui-clear-header!
-
-         ;; Rendering callbacks
-         ui-make-styled-line
-         ui-make-styled-segment
-
-         ;; Status message callback (dialog-api)
-         ui-set-status-message!
-
-         ;; Widget callbacks (widget-api)
-         ui-set-extension-widget!
-         ui-remove-extension-widget!
-         ui-remove-all-extension-widgets!
-
-         ;; Installation (called by TUI during init)
-         install-ui-callbacks!
-
-         ;; Check if callbacks are installed
-         ui-callbacks-installed?
-
-         ;; M-08: Registry struct and accessor (for advanced use)
-         ui-callback-registry
+;; M-08: Registry struct and accessor (for advanced use)
+(provide ui-callback-registry
          ui-callback-registry?
 
          ;; R-05: Parameterized registry for test isolation
-         current-ui-registry)
+         current-ui-registry
+
+         ;; Setter/Getter callbacks
+         (contract-out [ui-set-footer! (-> any/c any/c any/c)]
+                       [ui-set-header! (-> any/c any/c any/c)]
+                       [ui-clear-footer! (-> any/c any/c)]
+                       [ui-clear-header! (-> any/c any/c)]
+                       ;; Rendering callbacks
+                       [ui-make-styled-line (-> any/c any/c)]
+                       [ui-make-styled-segment (-> any/c any/c any/c)]
+                       ;; Status message callback (dialog-api)
+                       [ui-set-status-message! (-> any/c any/c any/c)]
+                       ;; Widget callbacks (widget-api)
+                       [ui-set-extension-widget! (-> any/c any/c any/c any/c any/c)]
+                       [ui-remove-extension-widget! (-> any/c any/c any/c any/c)]
+                       [ui-remove-all-extension-widgets! (-> any/c any/c any/c)]
+                       ;; Installation (called by TUI during init)
+                       [install-ui-callbacks! (-> any/c any/c)]
+                       ;; Check if callbacks are installed
+                       [ui-callbacks-installed? (-> boolean?)]))
 
 ;; ── Callback registry struct ───────────────────────────────
 

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.53.0")
+(define version "0.53.1")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base"))

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.53.1")
+(define version "0.53.2")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base"))

--- a/interfaces/doctor.rkt
+++ b/interfaces/doctor.rkt
@@ -8,7 +8,8 @@
 ;;
 ;; Exit code: 0 if no errors, 1 if any error found.
 
-(require racket/list
+(require racket/contract
+         racket/list
          racket/string
          racket/format
          racket/match
@@ -25,23 +26,15 @@
          "../util/config-paths.rkt")
 
 ;; Struct
-(provide check-result
-         check-result?
-         check-result-name
-         check-result-status
-         check-result-message
-
-         ;; Main entry
-         run-doctor
-
-         ;; Individual checks (exported for testing)
-         check-racket-version
-         check-packages
-         check-config-dir
-         check-config-file
-         check-credentials
-         check-session-dir
-         check-tui-packages)
+(provide (struct-out check-result)
+         (contract-out [run-doctor (-> exact-nonnegative-integer?)]
+                       [check-racket-version (-> check-result?)]
+                       [check-packages (-> check-result?)]
+                       [check-config-dir (-> check-result?)]
+                       [check-config-file (-> check-result?)]
+                       [check-credentials (-> check-result?)]
+                       [check-session-dir (-> check-result?)]
+                       [check-tui-packages (-> check-result?)]))
 
 ;; ============================================================
 ;; Struct

--- a/interfaces/rpc-mode.rkt
+++ b/interfaces/rpc-mode.rkt
@@ -34,16 +34,7 @@
          rpc-notification?
          rpc-notification-method
          rpc-notification-params
-
-         ;; Parsing
-         parse-rpc-request
-
-         ;; Serialization
-         rpc-response->json
-         rpc-notification->json
-
-         ;; Error helper
-         rpc-error
+         rpc-rate-limiter?
 
          ;; Error codes
          RPC-ERROR-PARSE
@@ -54,24 +45,34 @@
          RPC-ERROR-HANDSHAKE-REQUIRED
          RPC-ERROR-RATE-LIMITED
 
-         ;; Handshake
-         generate-handshake-token
-         rpc-handshake-valid?
-
-         ;; Dispatch
-         dispatch-rpc-request
-
-         ;; Rate limiting
-         make-rpc-rate-limiter
-         rpc-rate-limiter?
-         rate-limiter-check
-
-         ;; RPC loop
-         run-rpc-loop
-
-         ;; Event forwarding
-         start-rpc-event-forwarding!
-         stop-rpc-event-forwarding!)
+         (contract-out
+          ;; Parsing
+          [parse-rpc-request (-> string? any/c)]
+          ;; Serialization
+          [rpc-response->json (-> rpc-response? string?)]
+          [rpc-notification->json (-> rpc-notification? string?)]
+          ;; Error helper
+          [rpc-error (-> any/c exact-integer? string? rpc-response?)]
+          ;; Handshake
+          [generate-handshake-token (-> string?)]
+          [rpc-handshake-valid? (-> string? string? boolean?)]
+          ;; Dispatch
+          [dispatch-rpc-request (-> rpc-request? hash? rpc-response?)]
+          ;; Rate limiting
+          [make-rpc-rate-limiter
+           (->* [] [#:max-requests-per-second exact-positive-integer?] rpc-rate-limiter?)]
+          [rate-limiter-check (-> rpc-rate-limiter? symbol? any/c)]
+          ;; RPC loop
+          [run-rpc-loop
+           (->* (hash?)
+                (#:input-port input-port?
+                              #:output-port output-port?
+                              #:handshake-token (or/c string? #f)
+                              #:rate-limiter (or/c rpc-rate-limiter? #f))
+                void?)]
+          ;; Event forwarding
+          [start-rpc-event-forwarding! (-> any/c output-port? exact-nonnegative-integer?)]
+          [stop-rpc-event-forwarding! (-> any/c exact-nonnegative-integer? void?)]))
 
 ;; ============================================================
 ;; Structs

--- a/llm/provider-errors.rkt
+++ b/llm/provider-errors.rkt
@@ -25,9 +25,9 @@
          provider-error?
          provider-error-category
          provider-error-status-code
-         raise-provider-error
-         classify-http-status
-         q-llm-error?)
+         q-llm-error?
+         (contract-out [raise-provider-error (->* (string? symbol?) ((or/c exact-integer? #f)) any)]
+                       [classify-http-status (-> exact-integer? (or/c symbol? #f))]))
 
 ;; ============================================================
 ;; Struct

--- a/pkg/registry.rkt
+++ b/pkg/registry.rkt
@@ -7,7 +7,8 @@
 ;;
 ;; Provides functions to search, resolve, and query the package index.
 
-(require "../util/json-helpers.rkt")
+(require racket/contract
+         "../util/json-helpers.rkt")
 (require json
          racket/string
          racket/list
@@ -19,29 +20,21 @@
          net/url
          net/head)
 
-;; Index operations
-(provide load-package-index
-         fetch-remote-index
-         index-packages
-
-         ;; Search
-         search-packages
-         get-package-info
-         resolve-version
-
-         ;; Install / verify
-         install-package!
-         verify-package
-         list-installed-packages
-         check-updates
-
-         ;; Index validation
-         validate-index-entry
-         validate-index
-
-         ;; Version comparison
-         version<=?
-         version<?)
+;; Functions (contracted)
+(provide (contract-out [load-package-index (->* () (any/c) any/c)]
+                       [fetch-remote-index (->* () (any/c) any/c)]
+                       [index-packages (-> any/c any/c)]
+                       [search-packages (-> any/c string? any/c)]
+                       [get-package-info (-> any/c string? any/c)]
+                       [resolve-version (->* (any/c string?) (any/c) any/c)]
+                       [install-package! (-> any/c any/c)]
+                       [verify-package (-> any/c any/c)]
+                       [list-installed-packages (-> any/c)]
+                       [check-updates (-> any/c any/c)]
+                       [validate-index-entry (-> any/c any/c)]
+                       [validate-index (-> any/c any/c)]
+                       [version<=? (-> string? string? boolean?)]
+                       [version<? (-> string? string? boolean?)]))
 
 ;; ═══════════════════════════════════════════════════════════════════
 ;; Configuration

--- a/runtime/context-assembly/selection.rkt
+++ b/runtime/context-assembly/selection.rkt
@@ -10,7 +10,8 @@
 ;;   pure. Then wrap with a thin impure shell that creates the memo. This would allow
 ;;   the core logic to be typed. Estimated effort: ~2 waves. Deferred to backlog.
 
-(require racket/match
+(require racket/contract
+         racket/match
          racket/list
          racket/set
          (only-in "../../util/protocol-types.rkt"
@@ -66,21 +67,14 @@
                                  catalog-proc
                                  estimate-proc))
 
-(provide context-assembly-call-options
-         context-assembly-call-options?
-         context-assembly-call-options-cache
-         context-assembly-call-options-provider
-         context-assembly-call-options-model-name
-         context-assembly-call-options-trace-callback
-         context-assembly-call-options-working-set
-         context-assembly-call-options-generate-summary-proc
-         context-assembly-call-options-generate-catalog-proc
-         context-assembly-call-options-estimate-text-proc
-         make-context-assembly-call-options
-         build-assembled-context
-         build-assembled-context/raw
-         build-assembled-context/v2
-         build-session-context)
+(provide (struct-out context-assembly-call-options)
+         (contract-out [make-context-assembly-call-options (-> any/c)]
+                       [build-assembled-context (-> any/c any/c any/c)]
+                       [build-assembled-context/raw (-> any/c any/c any/c #:memo any/c any/c)]
+                       [build-assembled-context/v2 (-> any/c any/c any/c any/c)]
+                       [build-session-context (-> any/c any/c)]
+                       [select-messages
+                        (-> list? list? exact-nonnegative-integer? procedure? (values list? list?))]))
 
 ;; F23: Pure selection function — testable without infrastructure.
 ;; Takes pinned messages, removable messages, a budget, and an estimation function.
@@ -98,8 +92,6 @@
         (define excluded
           (filter (lambda (m) (not (hash-has-key? kept-ids (message-id m)))) removable))
         (values (append pinned kept) excluded))))
-
-(provide select-messages)
 
 (define (build-assembled-context idx
                                  config

--- a/runtime/context-assembly/serialization.rkt
+++ b/runtime/context-assembly/serialization.rkt
@@ -1,4 +1,5 @@
 #lang racket/base
+(require racket/contract)
 
 ;; runtime/context-assembly/serialization.rkt — tiered context, entry conversion, agents discovery
 ;;
@@ -60,7 +61,7 @@
 (define (compute-tier-c-count total-messages)
   (min 12 (max 4 (quotient total-messages 50))))
 
-(provide compute-tier-c-count)
+(provide (contract-out [compute-tier-c-count (-> list? exact-nonnegative-integer?)]))
 
 ;; v0.28.21 W4: Dynamic Tier-B sizing
 ;; Scales Tier-B with total message count: min(50, max(20, total/10))

--- a/runtime/cutpoint-rules.rkt
+++ b/runtime/cutpoint-rules.rkt
@@ -34,7 +34,6 @@
          overflow-state-attempted
          overflow-state-max-attempts
          overflow-state-will-retry
-         mark-overflow-attempted!
          can-retry-overflow?
          ;; #695: Auto-retry
          make-retry-context
@@ -42,7 +41,8 @@
          retry-context-original-prompt
          retry-context-compaction-result
          retry-context-retry-messages
-         build-retry-messages)
+         (contract-out [mark-overflow-attempted! (-> overflow-state? void?)]
+                       [build-retry-messages (-> any/c string? any)]))
 
 ;; ============================================================
 ;; #693: Cut-point rules

--- a/runtime/extension-catalog.rkt
+++ b/runtime/extension-catalog.rkt
@@ -11,26 +11,27 @@
 ;; - activate-extension!: create symlink in target directory
 ;; - deactivate-extension!: remove symlink
 
-(require "../util/json-helpers.rkt")
-(require "../util/errors.rkt")
-(require racket/file
+(require racket/contract
+         "../util/json-helpers.rkt"
+         "../util/errors.rkt"
+         racket/file
          racket/path
          json
          "../extensions/api.rkt"
          (only-in "../extensions/loader.rkt" get-extension-name-from-path))
 
-(provide known-extensions-dir
-         list-known-extensions
-         list-active-extensions
-         activate-extension!
-         deactivate-extension!
-         valid-extension-name?
-         ext-info
+(provide ext-info
          ext-info?
          ext-info-name
          ext-info-source-path
          ext-info-version
-         ext-info-description)
+         ext-info-description
+         (contract-out [known-extensions-dir (-> path?)]
+                       [list-known-extensions (-> (listof ext-info?))]
+                       [list-active-extensions (-> any/c (listof ext-info?))]
+                       [activate-extension! (-> string? path-string? void?)]
+                       [deactivate-extension! (-> string? path-string? void?)]
+                       [valid-extension-name? (-> any/c boolean?)]))
 
 ;; ============================================================
 ;; Extension source directory discovery

--- a/runtime/iteration/fsm-types.rkt
+++ b/runtime/iteration/fsm-types.rkt
@@ -6,7 +6,8 @@
 ;; Defines an explicit FSM for the iteration loop using define-fsm-machine
 ;; from util/fsm.rkt. Backward-compatible exports maintained.
 
-(require (only-in "../../util/fsm.rkt"
+(require racket/contract
+         (only-in "../../util/fsm.rkt"
                   define-fsm-machine
                   fsm-state
                   fsm-state-name
@@ -19,24 +20,29 @@
 ;; ── Machine definition ──
 
 (define-fsm-machine iteration
-  #:states (idle provider-turn tool-exec decision complete retrying aborted)
-  #:events (start-loop model-response tool-result tool-calls-present
-            termination-reason hook-block error retry-requested cancel)
-  #:transitions
-  [(idle -> provider-turn) start-loop]
-  [(provider-turn -> decision) model-response]
-  [(provider-turn -> aborted) hook-block]
-  [(provider-turn -> aborted) cancel]
-  [(provider-turn -> retrying) error]
-  [(decision -> tool-exec) tool-calls-present]
-  [(decision -> complete) termination-reason]
-  [(decision -> aborted) hook-block]
-  [(tool-exec -> decision) tool-result]
-  [(tool-exec -> retrying) error]
-  [(retrying -> provider-turn) retry-requested]
-  [(retrying -> aborted) error]
-  [(complete -> complete) cancel]
-  [(aborted -> aborted) cancel])
+                    #:states (idle provider-turn tool-exec decision complete retrying aborted)
+                    #:events (start-loop model-response
+                                         tool-result
+                                         tool-calls-present
+                                         termination-reason
+                                         hook-block
+                                         error
+                                         retry-requested
+                                         cancel)
+                    #:transitions [(idle -> provider-turn) start-loop]
+                    [(provider-turn -> decision) model-response]
+                    [(provider-turn -> aborted) hook-block]
+                    [(provider-turn -> aborted) cancel]
+                    [(provider-turn -> retrying) error]
+                    [(decision -> tool-exec) tool-calls-present]
+                    [(decision -> complete) termination-reason]
+                    [(decision -> aborted) hook-block]
+                    [(tool-exec -> decision) tool-result]
+                    [(tool-exec -> retrying) error]
+                    [(retrying -> provider-turn) retry-requested]
+                    [(retrying -> aborted) error]
+                    [(complete -> complete) cancel]
+                    [(aborted -> aborted) cancel])
 
 ;; ── Backward-compatible exports ──
 
@@ -61,8 +67,10 @@
 (define event-cancel iteration-cancel)
 
 ;; Converters
-(define (state->symbol s) (fsm-state-name s))
-(define (iteration-event->symbol e) (fsm-event-name e))
+(define (state->symbol s)
+  (fsm-state-name s))
+(define (iteration-event->symbol e)
+  (fsm-event-name e))
 
 ;; Transition table (backward compat)
 (define TRANSITIONS (fsm-transitions iteration-machine))
@@ -90,7 +98,6 @@
          state-complete
          state-retrying
          state-aborted
-         state->symbol
 
          iteration-event?
          event-start-loop
@@ -102,8 +109,9 @@
          event-error
          event-retry-requested
          event-cancel
-         iteration-event->symbol
 
          TRANSITIONS
-         next-iteration-state
-         valid-transition?)
+         (contract-out [state->symbol (-> any/c symbol?)]
+                       [iteration-event->symbol (-> any/c symbol?)]
+                       [next-iteration-state (-> any/c any/c any)]
+                       [valid-transition? (-> any/c any/c boolean?)]))

--- a/runtime/iteration/tool-turn-bridge.rkt
+++ b/runtime/iteration/tool-turn-bridge.rkt
@@ -5,7 +5,8 @@
 ;; Helpers for working-set update, seen-paths tracking, exploration counting,
 ;; and tool-turn bridging.
 
-(require racket/list
+(require racket/contract
+         racket/list
          (only-in racket/string string-join)
          (only-in "../../util/protocol-types.rkt"
                   message-role
@@ -27,17 +28,21 @@
          (only-in "../../util/event-types.rkt" injection-event-topic)
          (only-in "../../util/shared.rkt" take-at-most))
 
-(provide extract-tool-target-path
-         take-at-most
-         update-seen-paths
-         update-working-set-after-tools!
-         count-tool-errors
-         compute-tool-counters
-         detect-read-spiral
-         extract-last-assistant-text
-         dequeue-all-steering!
-         drain-injected-messages!
-         make-injected-collector!)
+(provide (contract-out [extract-tool-target-path (-> any/c any/c)]
+                       [take-at-most (-> list? exact-nonnegative-integer? list?)]
+                       [update-seen-paths (-> list? list? (values list? any/c))]
+                       [update-working-set-after-tools! (-> any/c list? list? any/c)]
+                       [count-tool-errors (-> (listof any/c) exact-nonnegative-integer?)]
+                       [compute-tool-counters
+                        (-> list?
+                            exact-nonnegative-integer?
+                            exact-nonnegative-integer?
+                            (values exact-nonnegative-integer? exact-nonnegative-integer?))]
+                       [detect-read-spiral (-> list? any/c (listof string?))]
+                       [extract-last-assistant-text (-> list? any/c)]
+                       [dequeue-all-steering! (-> any/c list?)]
+                       [drain-injected-messages! (-> any/c any/c any/c (listof any/c))]
+                       [make-injected-collector! (-> any/c any/c)]))
 
 ;; Extract the target file path from a tool call's arguments.
 (define (extract-tool-target-path tc)

--- a/runtime/oauth.rkt
+++ b/runtime/oauth.rkt
@@ -8,7 +8,8 @@
 
 (require "../util/json-helpers.rkt")
 (require "../util/errors.rkt")
-(require racket/string
+(require racket/contract
+         racket/string
          racket/format
          json
          racket/file
@@ -32,28 +33,29 @@
          oauth-token-expires-at
          oauth-token-token-type
          oauth-token-scope
-         ;; Feature availability predicate
-         oauth-available?
-         ;; Predicates / validation
-         oauth-token-expired?
-         valid-oauth-config?
-         ;; URL generation
-         oauth-authorize-url
-         ;; Token exchange (stub)
-         oauth-exchange-code
-         ;; Token refresh (stub)
-         oauth-refresh-token
-         ;; Token persistence
-         store-oauth-token!
-         get-oauth-token
-         get-valid-oauth-token
-         ;; OAuth token file
-         oauth-token-file-path
-         load-oauth-tokens
-         save-oauth-token-file!
-         ;; Serialization helpers
-         oauth-token->jsexpr
-         jsexpr->oauth-token)
+         (contract-out
+          ;; Feature availability
+          [oauth-available? (-> boolean?)]
+          ;; Predicates / validation
+          [oauth-token-expired? (->* (oauth-token?) (exact-integer?) boolean?)]
+          [valid-oauth-config? (-> any/c boolean?)]
+          ;; URL generation
+          [oauth-authorize-url (-> oauth-config? string? string?)]
+          ;; Token exchange (stub)
+          [oauth-exchange-code (-> oauth-config? string? any)]
+          ;; Token refresh (stub)
+          [oauth-refresh-token (-> oauth-config? oauth-token? any)]
+          ;; Token persistence
+          [oauth-token-file-path (-> path?)]
+          [load-oauth-tokens (->* () ((or/c path-string? path?)) hash?)]
+          [save-oauth-token-file! (->* (hash?) ((or/c path-string? path?)) void?)]
+          [store-oauth-token! (->* (string? oauth-token?) (#:path (or/c path-string? path?)) void?)]
+          [get-oauth-token (->* (string?) (#:path (or/c path-string? path?)) (or/c oauth-token? #f))]
+          [get-valid-oauth-token
+           (->* (string? oauth-config?) (#:path (or/c path-string? path?)) (or/c oauth-token? #f))]
+          ;; Serialization helpers
+          [oauth-token->jsexpr (-> oauth-token? hash?)]
+          [jsexpr->oauth-token (-> any/c (or/c oauth-token? #f))]))
 
 ;; ═══════════════════════════════════════════════════════════════════
 ;; Structs

--- a/runtime/provider-factory.rkt
+++ b/runtime/provider-factory.rkt
@@ -6,7 +6,8 @@
 ;; Extracted from main.rkt. Contains build-provider, local-provider?,
 ;; and build-mock-provider.
 
-(require "settings.rkt"
+(require racket/contract
+         "settings.rkt"
          "auth-store.rkt"
          "model-registry.rkt"
          "../llm/provider.rkt"
@@ -18,12 +19,15 @@
          racket/string
          net/url)
 
-(provide build-provider
-         build-mock-provider
-         local-provider?
-         create-provider-for-name ;; for testing
-         provider-is-mock? ;; v0.14.1: for tui-init without importing llm/
-         provider-name) ;; re-export for tui-init.rkt (A1 fix)
+(provide provider-name ;; re-export for tui-init.rkt (A1 fix)
+         (contract-out [build-provider (-> hash? any/c provider?)]
+                       [build-mock-provider (-> provider?)]
+                       [local-provider? (-> any/c boolean?)]
+                       [create-provider-for-name
+                        (->* (string? (or/c string? #f) (or/c string? #f) string?)
+                             ((or/c exact-nonnegative-integer? #f))
+                             provider?)]
+                       [provider-is-mock? (-> any/c boolean?)]))
 
 ;; Build the appropriate provider based on provider name.
 (define (create-provider-for-name prov-name base-url api-key model-name [max-tokens #f])

--- a/runtime/session-index/mutations.rkt
+++ b/runtime/session-index/mutations.rkt
@@ -5,7 +5,8 @@
 ;; Mutation operations on session-index: building, persisting, branching, bookmarking.
 
 (require "../../util/error-helpers.rkt")
-(require racket/string
+(require racket/contract
+         racket/string
          racket/file
          racket/port
          racket/path
@@ -28,28 +29,28 @@
          "schema.rkt"
          "query.rkt")
 
-(provide build-index!
-         load-index
-         save-index!
-         switch-leaf!
-         mark-active-leaf!
-         navigate-to-entry!
-         navigate-to-leaf!
-         navigate-next-leaf!
-         navigate-prev-leaf!
-         branch!
-         branch-with-summary!
-         reset-leaf!
-         append-to-leaf!
-         add-bookmark!
-         remove-bookmark!
-         list-bookmarks
-         find-bookmark-by-label
-         get-bookmark
-         load-bookmarks
-         save-bookmarks!
-         load-index-with-bookmarks
-         bookmarks-path)
+(provide (contract-out [build-index! (-> path-string? path-string? any/c)]
+                       [load-index (-> string? any/c)]
+                       [save-index! (-> string? any/c any/c)]
+                       [switch-leaf! (-> any/c any/c any/c)]
+                       [mark-active-leaf! (-> any/c any/c any/c)]
+                       [navigate-to-entry! (-> any/c any/c any/c)]
+                       [navigate-to-leaf! (-> any/c any/c any/c)]
+                       [navigate-next-leaf! (-> any/c any/c)]
+                       [navigate-prev-leaf! (-> any/c any/c)]
+                       [branch! (-> any/c any/c any/c)]
+                       [branch-with-summary! (-> any/c any/c string? any/c)]
+                       [reset-leaf! (-> any/c void?)]
+                       [append-to-leaf! (-> any/c any/c any/c)]
+                       [add-bookmark! (-> any/c any/c string? any/c)]
+                       [remove-bookmark! (-> any/c any/c boolean?)]
+                       [list-bookmarks (-> any/c (listof any/c))]
+                       [find-bookmark-by-label (-> any/c string? any/c)]
+                       [get-bookmark (-> any/c any/c any/c)]
+                       [load-bookmarks (-> string? (listof any/c))]
+                       [save-bookmarks! (-> string? any/c void?)]
+                       [load-index-with-bookmarks (-> string? string? any/c)]
+                       [bookmarks-path (-> string? string?)]))
 
 ;; Counter for generating unique bookmark IDs
 (define bm-counter 0)

--- a/runtime/session-switch.rkt
+++ b/runtime/session-switch.rkt
@@ -36,12 +36,12 @@
          session-start-reason?
 
          ;; #707: Full lifecycle
-         switch-session!
          switch-result
          switch-result?
          switch-result-old-session-id
          switch-result-new-session-id
-         switch-result-reason)
+         switch-result-reason
+         (contract-out [switch-session! any/c]))
 
 ;; ============================================================
 ;; Lazy extension imports (DI defaults)

--- a/sandbox/limits.rkt
+++ b/sandbox/limits.rkt
@@ -5,26 +5,38 @@
 ;; Provides structured execution limits, preset configurations, merge logic,
 ;; and a predicate to check whether observed resource usage is within bounds.
 
+(require racket/contract)
+
 (provide exec-limits
          exec-limits?
          exec-limits-timeout-seconds
          exec-limits-max-output-bytes
          exec-limits-max-memory-bytes
          exec-limits-max-processes
-         default-exec-limits
-         strict-exec-limits
-         permissive-exec-limits
-         merge-limits
-         within-limits?
          default-timeout-seconds
          default-max-output-bytes
-         with-resource-limits
-         get-process-count
          process-count-box
-         reset-process-count!
-         track-process!
-         untrack-process!
-         current-max-processes)
+         current-max-processes
+         (contract-out
+          [default-exec-limits (-> exec-limits?)]
+          [strict-exec-limits (-> exec-limits?)]
+          [permissive-exec-limits (-> exec-limits?)]
+          [merge-limits (-> exec-limits? exec-limits? exec-limits?)]
+          [within-limits?
+           (->* [exec-limits?]
+                [#:elapsed (or/c #f number?)
+                 #:output-size (or/c #f exact-nonnegative-integer?)
+                 #:memory (or/c #f exact-nonnegative-integer?)
+                 #:processes (or/c #f exact-nonnegative-integer?)]
+                boolean?)]
+          [with-resource-limits
+           (->* [(-> any/c any)]
+                [#:timeout number? #:max-output exact-nonnegative-integer? #:custodian custodian?]
+                (values any/c boolean?))]
+          [get-process-count (-> exact-nonnegative-integer?)]
+          [track-process! (-> exact-positive-integer?)]
+          [untrack-process! (-> exact-nonnegative-integer?)]
+          [reset-process-count! (-> void?)]))
 
 ;; --------------------------------------------------
 ;; Standalone defaults (convenient constants)

--- a/scripts/analyze-trace.rkt
+++ b/scripts/analyze-trace.rkt
@@ -16,7 +16,8 @@
 ;;   racket scripts/analyze-trace.rkt --json <trace.jsonl>
 ;;   racket scripts/analyze-trace.rkt --summary <trace.jsonl>
 
-(require racket/cmdline
+(require racket/contract
+         racket/cmdline
          racket/file
          racket/format
          racket/list
@@ -37,9 +38,9 @@
                   tool-call-part-name
                   tool-call-part-id))
 
-(provide extract-metrics
-         format-report
-         metrics->json)
+(provide (contract-out [extract-metrics (-> any/c any/c)]
+                       [format-report (-> any/c string?)]
+                       [metrics->json (-> any/c string?)]))
 
 ;; ============================================================
 ;; Metrics extraction

--- a/skills/context-files.rkt
+++ b/skills/context-files.rkt
@@ -6,7 +6,8 @@
 ;; Kontext-Informationen für Agenten (Titel, Beschreibung, Instruktionen,
 ;; Beispiele, Tool-Präferenzen).
 
-(require racket/file
+(require racket/contract
+         racket/file
          racket/string
          racket/match
          racket/list
@@ -20,11 +21,11 @@
          agent-context-instructions
          agent-context-examples
          agent-context-tool-preferences
-         load-agent-context
-         parse-agent-file
-         discover-agents-files
-         merge-agent-contexts
-         find-git-root)
+         (contract-out [load-agent-context (->* () (any/c) (or/c agent-context? #f))]
+                       [parse-agent-file (-> string? agent-context?)]
+                       [discover-agents-files (->* () (any/c) (listof path?))]
+                       [merge-agent-contexts (-> (listof agent-context?) agent-context?)]
+                       [find-git-root (-> any/c (or/c path? #f))]))
 
 ;; ============================================================
 ;; Structs

--- a/skills/resource-loader.rkt
+++ b/skills/resource-loader.rkt
@@ -11,7 +11,8 @@
 ;;   Parsing (parse-skill)
 ;;   Merging (merge-skill-lists, deep-merge-hash, merge-resources)
 
-(require racket/file
+(require racket/contract
+         racket/file
          racket/port
          racket/string
          racket/hash
@@ -22,35 +23,16 @@
 
 ;; Structs
 ;; resource struct exports
-(provide resource
-         resource?
-         resource-kind
-         resource-name
-         resource-source
-         resource-content
-         ;; resource-set struct exports
-         resource-set
-         resource-set?
-         resource-set-instructions
-         resource-set-skills
-         resource-set-templates
-         resource-set-config
-         empty-resource-set
-
-         ;; Resource loading
-         load-global-resources
-         load-project-resources
-         merge-resources
-
-         ;; Progressive skill disclosure
-         skill-summary-text
-         skills-summary-section
-
-         ;; Parsing (exposed for testing)
-         parse-skill
-
-         ;; File reading
-         try-read-file)
+(provide (struct-out resource)
+         (struct-out resource-set)
+         (contract-out [empty-resource-set (-> resource-set?)]
+                       [load-global-resources (->* () (path-string?) any/c)]
+                       [load-project-resources (->* () (path-string?) any/c)]
+                       [merge-resources (-> resource-set? resource-set? resource-set?)]
+                       [skill-summary-text (-> list? string?)]
+                       [skills-summary-section (-> list? (or/c string? #f))]
+                       [parse-skill (-> string? string? hash?)]
+                       [try-read-file (-> path-string? (or/c string? #f))]))
 
 ;; ============================================================
 ;; Structs

--- a/tools/builtins/bash.rkt
+++ b/tools/builtins/bash.rkt
@@ -21,7 +21,8 @@
 ;; GC-02: Sandbox limits now read from runtime/settings when available.
 ;; Process tracking (SEC-12) is wired into every invocation.
 
-(require racket/string
+(require racket/contract
+         racket/string
          (only-in "../tool.rkt"
                   make-success-result
                   make-error-result
@@ -40,23 +41,29 @@
          (only-in "../../util/truncation.rkt" truncate-output)
          (only-in "../../util/safe-mode-predicates.rkt" safe-mode?))
 
-(provide tool-bash
-         ;; Struct-based config (v0.44.2+, sole config path since v0.46.3)
-         bash-execution-config
+;; Struct-based config (v0.44.2+, sole config path since v0.46.3)
+(provide bash-execution-config
          bash-execution-config?
          bash-execution-config-policy
          bash-execution-config-block-destructive?
          bash-execution-config-warn-on-destructive?
          bash-execution-config-warning-port
-         make-bash-execution-config
          current-bash-execution-config
-         effective-bash-config
-         destructive-command?
          destructive-patterns
          current-execution-policy
          current-allowed-commands
-         execution-policy-allows?
-         high-risk-command?)
+         (contract-out [make-bash-execution-config
+                        (->* ()
+                             (#:policy symbol?
+                                       #:block? (or/c boolean? (-> boolean?))
+                                       #:warn? boolean?
+                                       #:warning-port (or/c output-port? #f))
+                             bash-execution-config?)]
+                       [effective-bash-config (-> bash-execution-config?)]
+                       [destructive-command? (-> string? boolean?)]
+                       [execution-policy-allows? (-> string? boolean?)]
+                       [high-risk-command? (-> string? boolean?)]
+                       [tool-bash (->* (hash?) (exec-context?) any/c)]))
 
 ;; Default timeout in seconds (used when no settings available)
 (define DEFAULT-TIMEOUT-SECONDS 120)

--- a/tools/builtins/delete-lines.rkt
+++ b/tools/builtins/delete-lines.rkt
@@ -25,7 +25,8 @@
          (only-in "builtin-helpers.rkt" require-safe-path!)
          (only-in "../../util/error-sanitizer.rkt" sanitize-error-message))
 
-(provide tool-delete-lines)
+(require racket/contract)
+(provide (contract-out [tool-delete-lines (-> hash? any/c)]))
 
 ;; --------------------------------------------------
 ;; Constants

--- a/tools/builtins/edit.rkt
+++ b/tools/builtins/edit.rkt
@@ -12,7 +12,8 @@
 ;;   - post-edit line-count delta check with auto-revert on corruption
 ;;   - pre-edit backup save to ~/.q/edit-backups/
 
-(require racket/file
+(require racket/contract
+         racket/file
          racket/match
          racket/string
          (only-in racket/list last drop)
@@ -24,9 +25,9 @@
          (only-in "../../util/error-sanitizer.rkt" sanitize-error-message)
          (only-in "builtin-helpers.rkt" require-safe-path!))
 
-(provide tool-edit
-         current-max-old-text-len
-         set-current-max-old-text-len!)
+(provide current-max-old-text-len
+         set-current-max-old-text-len!
+         (contract-out [tool-edit (->* (hash?) (any/c) any/c)]))
 
 ;; --------------------------------------------------
 ;; Backup helpers

--- a/tools/builtins/grep.rkt
+++ b/tools/builtins/grep.rkt
@@ -14,7 +14,8 @@
                   expand-home-path)
          (only-in "../../util/path-filters.rkt" hidden-name? should-skip-entry? skip-dirs))
 
-(provide tool-grep)
+(require racket/contract)
+(provide (contract-out [tool-grep (-> hash? any/c)]))
 
 ;; ============================================================
 ;; Defaults

--- a/tools/builtins/ls.rkt
+++ b/tools/builtins/ls.rkt
@@ -140,13 +140,13 @@
 ;; --------------------------------------------------
 
 (define-tool ls
-  #:description "List directory contents with optional long format, hidden files, and sorting."
-  #:required ("path")
-  #:properties
-    [(path "string" "Directory to list")
-     (all? "boolean" "Show hidden files")
-     (long? "boolean" "Long format with size/type")
-     (sort-by "string" "Sort by: name, size, or date")]
-  ls-handler)
+             #:description
+             "List directory contents with optional long format, hidden files, and sorting."
+             #:required ("path")
+             #:properties [(path "string" "Directory to list")
+                           (all? "boolean" "Show hidden files")
+                           (long? "boolean" "Long format with size/type")
+                           (sort-by "string" "Sort by: name, size, or date")]
+             ls-handler)
 
 (provide ls)

--- a/tools/builtins/session-recall.rkt
+++ b/tools/builtins/session-recall.rkt
@@ -14,7 +14,8 @@
 ;; Results are ephemeral: returned as a tool result for this turn only.
 ;; Max 5 entries per call to prevent context bloat.
 
-(require racket/function
+(require racket/contract
+         racket/function
          racket/list
          racket/string
          "../tool.rkt"
@@ -25,7 +26,7 @@
                   text-part?
                   text-part-text))
 
-(provide tool-session-recall)
+(provide (contract-out [tool-session-recall (->* (hash?) (any/c) any/c)]))
 
 ;; Max entries returned per recall call
 (define MAX-RECALL-ENTRIES 5)

--- a/tui/char-width.rkt
+++ b/tui/char-width.rkt
@@ -8,19 +8,23 @@
 ;;
 ;; Reference: Unicode East Asian Width property (UAX #11)
 
-(require "../util/error-helpers.rkt")
+(require racket/contract
+         "../util/error-helpers.rkt")
 (require racket/match
          racket/string)
 
-(provide char-width
-         string-visible-width
-         visible-width
-         truncate-to-visible-width
-         display-col->string-offset
-         grapheme-span-at
-         grapheme-count
-         string-grapheme-length
-         substring-by-graphemes)
+(provide (contract-out
+          [char-width (-> char? exact-nonnegative-integer?)]
+          [string-visible-width (-> string? exact-nonnegative-integer?)]
+          [visible-width (-> string? exact-nonnegative-integer?)]
+          [truncate-to-visible-width (-> string? exact-nonnegative-integer? string?)]
+          [display-col->string-offset
+           (-> string? exact-nonnegative-integer? exact-nonnegative-integer?)]
+          [grapheme-span-at (-> string? exact-nonnegative-integer? exact-nonnegative-integer?)]
+          [grapheme-count (-> string? exact-nonnegative-integer?)]
+          [string-grapheme-length (-> string? exact-nonnegative-integer?)]
+          [substring-by-graphemes
+           (->* (string? exact-nonnegative-integer?) (exact-nonnegative-integer?) string?)]))
 
 ;; char-width : Char → {0, 1, 2}
 ;; Returns the terminal column width of a single character.
@@ -269,8 +273,9 @@
       (string-length s)
       (+ pos (grapheme-span-at-impl s pos))))
 
-(provide prev-grapheme-start
-         next-grapheme-start)
+(provide (contract-out
+          [prev-grapheme-start (-> string? exact-nonnegative-integer? exact-nonnegative-integer?)]
+          [next-grapheme-start (-> string? exact-nonnegative-integer? exact-nonnegative-integer?)]))
 
 ;; ============================================================
 ;; Display column utilities

--- a/tui/clipboard.rkt
+++ b/tui/clipboard.rkt
@@ -12,19 +12,14 @@
 ;;   'system — only use system clipboard tools
 ;;   'off    — disable clipboard entirely
 
-(require "../util/error-helpers.rkt")
+(require racket/contract
+         "../util/error-helpers.rkt")
 (require racket/port
          racket/string
          net/base64)
 
 ;; Configuration
 (provide current-clipboard-mode
-
-         ;; Public API
-         copy-text!
-         copy-selection!
-         clipboard-backend-available?
-         clipboard-paste
 
          ;; Status symbols (documented, not exported as values)
          ;; 'ok-osc52   — OSC 52 sequence emitted successfully
@@ -33,10 +28,15 @@
          ;; 'unavailable — no backend available for the selected mode
          ;; 'failed     — backend reported failure
 
-         ;; Re-exported for backward compatibility / testing
-         detect-clipboard-tool
-         clipboard-copy-via-tool
-         osc-52-copy)
+         ;; Public API
+         (contract-out [copy-text! (->* (string?) (any/c) symbol?)]
+                       [copy-selection! (-> any/c any/c any/c symbol?)]
+                       [clipboard-backend-available? (-> boolean?)]
+                       [clipboard-paste (-> (or/c string? #f))]
+                       ;; Re-exported for backward compatibility / testing
+                       [detect-clipboard-tool (-> any/c)]
+                       [clipboard-copy-via-tool (-> any/c any/c string? boolean?)]
+                       [osc-52-copy (->* (string?) (any/c) any/c)]))
 
 ;; ============================================================
 ;; Configuration

--- a/tui/commands/model.rkt
+++ b/tui/commands/model.rkt
@@ -10,8 +10,9 @@
          "../../agent/event-bus.rkt"
          "../../runtime/model-registry.rkt"
          "context.rkt")
+(require racket/contract)
 
-(provide handle-model-command)
+(provide (contract-out [handle-model-command (-> any/c any/c)]))
 
 ;; ============================================================
 ;; /model command handler

--- a/tui/input/editing-ops.rkt
+++ b/tui/input/editing-ops.rkt
@@ -5,46 +5,44 @@
 ;; All functions take an input-state and return a new input-state.
 ;; No terminal I/O. No side effects.
 
-(require racket/list
+(require racket/contract
+         racket/list
          "../char-width.rkt"
          "state-types.rkt")
 
-(provide input-insert-char
-         input-insert-newline
-         input-backspace
-         input-delete
-         input-cursor-left
-         input-cursor-right
-         input-home
-         input-end
-         input-clear
-
-         ;; Undo/Redo
-         input-undo
-         input-redo
-
-         ;; Kill ring
-         input-kill-word-backward
-         input-kill-to-beginning
-         input-kill-to-end
-         input-yank
-
-         ;; Word navigation
-         input-cursor-word-left
-         input-cursor-word-right
-
-         ;; Paste
-         input-insert-string
-
-         ;; Query
-         input-at-beginning?
-         input-at-end?
-         input-empty?
-         input-current-text
-
-         ;; Internal word helpers (shared with completion)
-         find-word-start-backward
-         find-word-end-forward)
+(provide input-state?
+         (contract-out [input-insert-char (-> any/c char? any/c)]
+                       [input-insert-newline (-> any/c any/c)]
+                       [input-backspace (-> any/c any/c)]
+                       [input-delete (-> any/c any/c)]
+                       [input-cursor-left (-> any/c any/c)]
+                       [input-cursor-right (-> any/c any/c)]
+                       [input-home (-> any/c any/c)]
+                       [input-end (-> any/c any/c)]
+                       [input-clear (-> any/c any/c)]
+                       ;; Undo/Redo
+                       [input-undo (-> any/c any/c)]
+                       [input-redo (-> any/c any/c)]
+                       ;; Kill ring
+                       [input-kill-word-backward (-> any/c any/c)]
+                       [input-kill-to-beginning (-> any/c any/c)]
+                       [input-kill-to-end (-> any/c any/c)]
+                       [input-yank (-> any/c any/c)]
+                       ;; Word navigation
+                       [input-cursor-word-left (-> any/c any/c)]
+                       [input-cursor-word-right (-> any/c any/c)]
+                       ;; Paste
+                       [input-insert-string (-> any/c string? any/c)]
+                       ;; Query
+                       [input-at-beginning? (-> any/c boolean?)]
+                       [input-at-end? (-> any/c boolean?)]
+                       [input-empty? (-> any/c boolean?)]
+                       [input-current-text (-> any/c string?)]
+                       ;; Internal word helpers (shared with completion)
+                       [find-word-start-backward
+                        (-> string? exact-nonnegative-integer? exact-nonnegative-integer?)]
+                       [find-word-end-forward
+                        (-> string? exact-nonnegative-integer? exact-nonnegative-integer?)]))
 
 ;; ============================================================
 ;; Basic editing

--- a/tui/input/state-types.rkt
+++ b/tui/input/state-types.rkt
@@ -5,7 +5,8 @@
 ;; Pure data definitions. No logic.
 
 (require "../../util/error-helpers.rkt")
-(require racket/string
+(require racket/contract
+         racket/string
          racket/list
          "../char-width.rkt"
          "../terminal.rkt")
@@ -28,34 +29,35 @@
          mouse-event-x
          mouse-event-y
 
-         ;; Constructor
-         initial-input-state
-
          ;; Constants
          MAX-UNDO-STACK
          MAX-KILL-RING
          INPUT-PROMPT-WIDTH
-
-         ;; Internal helpers (shared by editing-ops, history-ops)
-         push-undo
-         push-kill
-         strip-for-undo
-
-         ;; Mouse event support
-         parse-mouse-event
-         decode-mouse-x10
-         decode-mouse-tui-term
-         normalize-selection-range
-
-         ;; IME cursor markers
          CURSOR_MARKER
-         cursor-marker-string
-         strip-cursor-markers
-         has-cursor-markers?
-         insert-cursor-marker
 
-         ;; Horizontal scroll
-         input-visible-window)
+         (contract-out
+          ;; Constructor
+          [initial-input-state (-> any/c)]
+          ;; Internal helpers (shared by editing-ops, history-ops)
+          [push-undo (-> any/c any/c any/c)]
+          [push-kill (-> any/c string? any/c)]
+          [strip-for-undo (-> any/c any/c)]
+          ;; Mouse event support
+          [parse-mouse-event (-> any/c any/c)]
+          [decode-mouse-x10 (-> exact-integer? exact-integer? exact-integer? any/c)]
+          [decode-mouse-tui-term (-> any/c any/c)]
+          [normalize-selection-range
+           (-> any/c any/c (values exact-integer? exact-integer? exact-integer? exact-integer?))]
+          ;; IME cursor markers
+          [cursor-marker-string (-> string?)]
+          [strip-cursor-markers (-> string? string?)]
+          [has-cursor-markers? (-> string? boolean?)]
+          [insert-cursor-marker (-> string? exact-nonnegative-integer? string?)]
+          ;; Horizontal scroll
+          [input-visible-window
+           (-> any/c
+               exact-positive-integer?
+               (values string? exact-nonnegative-integer? exact-nonnegative-integer?))]))
 
 ;; Maximum undo stack depth
 (define MAX-UNDO-STACK 100)

--- a/tui/keymap.rkt
+++ b/tui/keymap.rkt
@@ -6,7 +6,8 @@
 ;; Users can override keybindings via ~/.q/keybindings.json.
 
 (require "../util/error-helpers.rkt")
-(require racket/string
+(require racket/contract
+         racket/string
          racket/port
          racket/file
          racket/match
@@ -20,29 +21,26 @@
          key-spec-ctrl
          key-spec-shift
          key-spec-alt
-         keycode->key-spec
-         key-spec->keycode
-         key-spec=?
-         parse-key-string
-
-         make-keymap
-         keymap-add!
-         keymap-remove!
-         keymap-lookup
-         keymap-list
-         keymap-find-conflicts
-         keymap-merge
-
-         default-keymap
-         load-user-keymap
-         load-keybindings
-         shortcut-specs->keymap
-
-         ;; #1189: Namespaced actions
-         namespaced-action?
-         namespace-action
-         migrate-action
-         parse-keybindings-content)
+         (contract-out [keycode->key-spec (-> any/c #:ctrl any/c #:shift any/c #:alt any/c any/c)]
+                       [key-spec->keycode (-> key-spec? symbol?)]
+                       [key-spec=? (-> key-spec? key-spec? boolean?)]
+                       [parse-key-string (-> string? key-spec?)]
+                       [make-keymap (-> any/c)]
+                       [keymap-add! (-> any/c key-spec? symbol? void?)]
+                       [keymap-remove! (-> any/c key-spec? void?)]
+                       [keymap-lookup (-> any/c key-spec? any/c)]
+                       [keymap-list (-> any/c (listof any/c))]
+                       [keymap-find-conflicts (-> any/c (listof any/c))]
+                       [keymap-merge (-> any/c any/c void?)]
+                       [default-keymap (-> any/c)]
+                       [load-user-keymap (-> any/c)]
+                       [load-keybindings (->* [] [any/c] any/c)]
+                       [shortcut-specs->keymap (-> (listof hash?) any/c)]
+                       ;; #1189: Namespaced actions
+                       [namespaced-action? (-> any/c boolean?)]
+                       [namespace-action (->* () #:rest any/c symbol?)]
+                       [migrate-action (-> symbol? symbol?)]
+                       [parse-keybindings-content (->* (string?) (any/c) any/c)]))
 
 ;; ============================================================
 ;; Key specification

--- a/tui/palette.rkt
+++ b/tui/palette.rkt
@@ -2,7 +2,8 @@
 
 ;; q/tui/palette.rkt — Slash-command registry + interactive command palette for the TUI
 
-(require racket/string
+(require racket/contract
+         racket/string
          racket/list
          racket/function
          racket/set
@@ -17,17 +18,18 @@
          cmd-entry-category
          cmd-entry-args-spec
          cmd-entry-aliases
-         make-command-registry
-         register-command!
-         lookup-command
-         resolve-command
-         all-commands
-         commands-by-category
-         filter-commands
-         render-palette-overlay
-         complete-command
-         commands-from-hashes
-         merge-extension-commands)
+         (contract-out [make-command-registry (-> hash?)]
+                       [register-command! (-> hash? cmd-entry? void?)]
+                       [lookup-command (-> hash? string? any/c)]
+                       [resolve-command (-> hash? string? (values any/c any/c))]
+                       [all-commands (-> hash? (listof cmd-entry?))]
+                       [commands-by-category (-> hash? symbol? (listof cmd-entry?))]
+                       [filter-commands (-> hash? string? (listof cmd-entry?))]
+                       [render-palette-overlay
+                        (-> string? (listof cmd-entry?) exact-nonnegative-integer? (listof any/c))]
+                       [complete-command (-> hash? string? (listof string?))]
+                       [commands-from-hashes (-> (listof hash?) (listof cmd-entry?))]
+                       [merge-extension-commands (-> hash? (listof cmd-entry?) hash?)]))
 
 ;; ---------------------------------------------------------------------------
 ;; cmd-entry struct + register-command!/lookup-command: re-exported from

--- a/tui/render/message-layout.rkt
+++ b/tui/render/message-layout.rkt
@@ -4,7 +4,8 @@
 ;;
 ;; Entry formatting, markdown rendering, styled-line construction.
 
-(require racket/match
+(require racket/contract
+         racket/match
          racket/string
          racket/list
          racket/function
@@ -23,19 +24,24 @@
          styled-segment?
          styled-segment-text
          styled-segment-style
-         plain-line
-         theme->style
-         format-entry
-         md-format-assistant
-         md-token->segment
-         styled-line->text
-         styled-line->ansi
-         styles->sgr
-         wrap-styled-line
-         wrap-text
-         wrap-single-line
-         find-break-pos
-         lookup-custom-renderer-for-tool)
+         (contract-out
+          [plain-line (-> string? styled-line?)]
+          [theme->style (->* (any/c) [(listof symbol?)] (listof symbol?))]
+          [format-entry (->* (any/c) [exact-nonnegative-integer?] (listof styled-line?))]
+          [md-format-assistant (-> string? exact-nonnegative-integer? (listof styled-line?))]
+          [md-token->segment (-> any/c styled-segment?)]
+          [styled-line->text (-> styled-line? string?)]
+          [styled-line->ansi (-> styled-line? string?)]
+          [styles->sgr (-> (listof symbol?) string?)]
+          [wrap-styled-line (-> styled-line? exact-nonnegative-integer? (listof styled-line?))]
+          [wrap-text (-> string? exact-nonnegative-integer? (listof string?))]
+          [wrap-single-line (-> string? exact-nonnegative-integer? (listof string?))]
+          [find-break-pos
+           (-> string?
+               exact-nonnegative-integer?
+               exact-nonnegative-integer?
+               exact-nonnegative-integer?)]
+          [lookup-custom-renderer-for-tool (-> string? symbol? any/c)]))
 
 ;; A styled segment (part of a line)
 (struct styled-segment

--- a/tui/terminal-input.rkt
+++ b/tui/terminal-input.rkt
@@ -11,6 +11,7 @@
 (require racket/match
          racket/port
          racket/string)
+(require racket/contract)
 
 ;; ============================================================
 ;; Decoder state encapsulation (v0.51.3 §7)
@@ -38,12 +39,12 @@
 
 ;; Raw stdin reading (used by facade for input selection)
 ;; Decoder factory and parameter (v0.51.3)
-(provide make-terminal-input-decoder
-         current-decoder
+(provide current-decoder
          decoder-state?
          decoder-state-utf8-acc
          decoder-state-paste-buf
          decoder-state-in-paste
+         (contract-out [make-terminal-input-decoder (->* () () any/c)])
          decoder-state-input-buf
          decoder-state-input-buf-data
 

--- a/tui/theme.rkt
+++ b/tui/theme.rkt
@@ -50,17 +50,17 @@
          default-dark-theme
          default-light-theme
          current-tui-theme
-         theme-ref
-         theme-color
-         theme-color->sgr
-         theme-color->sgr-bg
-         theme-style->sgr
-         register-theme!
          tui-theme-field-names
-         validate-color-value
-         load-theme-from-json
-         json-hash->theme
-         theme-field-accessor)
+         (contract-out [theme-ref (-> symbol? any/c)]
+                       [theme-color (-> symbol? (or/c string? #f))]
+                       [theme-color->sgr (-> any/c (or/c string? #f))]
+                       [theme-color->sgr-bg (-> any/c (or/c string? #f))]
+                       [theme-style->sgr (-> (listof any/c) string?)]
+                       [register-theme! (-> symbol? tui-theme? void?)]
+                       [validate-color-value (-> any/c any/c)]
+                       [load-theme-from-json (-> any/c (or/c tui-theme? #f))]
+                       [json-hash->theme (-> hash? tui-theme?)]
+                       [theme-field-accessor (-> symbol? procedure?)]))
 
 ;; ============================================================
 ;; Theme struct — all fields are ANSI color names or #f for default

--- a/tui/tree-view.rkt
+++ b/tui/tree-view.rkt
@@ -13,23 +13,32 @@
 ;;   - Keyboard navigation helpers
 ;;   - Branch abandonment detection
 
-(require racket/list
+(require racket/contract
+         racket/list
          racket/string
          racket/set
          "../util/protocol-types.rkt")
 
-(provide render-session-tree
-         render-session-tree-folded
-         tree-node?
+(provide tree-node?
          tree-node-timestamp
-         make-tree-node
-         build-tree-nodes
-         selected-node
-         tree-next-node
-         tree-prev-node
-         tree-toggle-fold
-         tree-enter-node
-         would-abandon-branch?)
+         (contract-out
+          [render-session-tree
+           (->* (any/c any/c exact-nonnegative-integer?)
+                (#:show-timestamps? any/c #:active-path-ids any/c #:bookmarks any/c)
+                (listof string?))]
+          [render-session-tree-folded
+           (->* (any/c any/c exact-nonnegative-integer? any/c)
+                (#:show-timestamps? any/c #:active-path-ids any/c #:bookmarks any/c)
+                (listof string?))]
+          [make-tree-node
+           (->* (any/c any/c any/c exact-nonnegative-integer? (listof any/c)) (any/c) any/c)]
+          [build-tree-nodes (-> (listof any/c) (listof list?))]
+          [selected-node (-> list? any/c)]
+          [tree-next-node (-> (listof any/c) exact-integer? exact-integer?)]
+          [tree-prev-node (-> (listof any/c) exact-integer? exact-integer?)]
+          [tree-toggle-fold (-> any/c any/c any/c)]
+          [tree-enter-node (-> (listof any/c) exact-integer? any/c any/c)]
+          [would-abandon-branch? (-> (listof list?) any/c any/c boolean?)]))
 
 ;; ============================================================
 ;; Tree node struct

--- a/tui/tui-init.rkt
+++ b/tui/tui-init.rkt
@@ -1,4 +1,5 @@
 #lang racket/base
+(require racket/contract)
 
 (require racket/dict)
 
@@ -30,14 +31,13 @@
          "../extensions/ui-surface.rkt"
          (only-in "../extensions/gsd/state-machine.rkt" gsm-current))
 
-(provide run-tui
-         run-tui-with-runtime
-         subscribe-runtime-events!
-         ;; Extracted phases (W-19)
-         create-tui-session
-         load-tui-scrollback
-         init-tui-terminal
-         run-tui-loop)
+(provide (contract-out [run-tui (->* () () any)]
+                       [run-tui-with-runtime (-> any/c any)]
+                       [subscribe-runtime-events! (-> any/c void?)]
+                       [create-tui-session (->* () () any)]
+                       [load-tui-scrollback (->* () () any)]
+                       [init-tui-terminal (->* () () any)]
+                       [run-tui-loop (->* () () any)]))
 
 ;; ============================================================
 ;; Runtime event subscription

--- a/util/ansi.rkt
+++ b/util/ansi.rkt
@@ -3,17 +3,13 @@
 ;; ANSI escape sequence utilities for CLI color output.
 ;; Auto-detects TTY and respects NO_COLOR convention.
 
-(require racket/string
+(require racket/contract
+         racket/string
          racket/format
-         ffi/unsafe)
+         (only-in ffi/unsafe get-ffi-obj _fun _int [-> ffi->]))
 
-(provide color-enabled?
-         ansi
-         ansi-reset
-         styled
-         styled-prompt
-         ;; Style constants for direct use
-         ANSI-RESET
+;; Style constants for direct use
+(provide ANSI-RESET
          ANSI-BOLD
          ANSI-DIM
          ANSI-ITALIC
@@ -26,35 +22,38 @@
          ANSI-MAGENTA
          ANSI-CYAN
          ANSI-WHITE
-         ANSI-GRAY)
+         ANSI-GRAY
+         (contract-out [color-enabled? (-> boolean?)]
+                       [ansi (-> string? string? string?)]
+                       [ansi-reset (-> string?)]
+                       [styled (-> string? (listof symbol?) string?)]
+                       [styled-prompt (-> string? string?)]))
 
 ;; ============================================================
 ;; ANSI escape constants
 ;; ============================================================
 
-(define ANSI-RESET    "\x1b[0m")
-(define ANSI-BOLD     "\x1b[1m")
-(define ANSI-DIM      "\x1b[2m")
-(define ANSI-ITALIC   "\x1b[3m")
+(define ANSI-RESET "\x1b[0m")
+(define ANSI-BOLD "\x1b[1m")
+(define ANSI-DIM "\x1b[2m")
+(define ANSI-ITALIC "\x1b[3m")
 (define ANSI-UNDERLINE "\x1b[4m")
-(define ANSI-INVERSE  "\x1b[7m")
-(define ANSI-RED      "\x1b[31m")
-(define ANSI-GREEN    "\x1b[32m")
-(define ANSI-YELLOW   "\x1b[33m")
-(define ANSI-BLUE     "\x1b[34m")
-(define ANSI-MAGENTA  "\x1b[35m")
-(define ANSI-CYAN     "\x1b[36m")
-(define ANSI-WHITE    "\x1b[37m")
-(define ANSI-GRAY     "\x1b[90m")
+(define ANSI-INVERSE "\x1b[7m")
+(define ANSI-RED "\x1b[31m")
+(define ANSI-GREEN "\x1b[32m")
+(define ANSI-YELLOW "\x1b[33m")
+(define ANSI-BLUE "\x1b[34m")
+(define ANSI-MAGENTA "\x1b[35m")
+(define ANSI-CYAN "\x1b[36m")
+(define ANSI-WHITE "\x1b[37m")
+(define ANSI-GRAY "\x1b[90m")
 
 ;; ============================================================
 ;; TTY detection
 ;; ============================================================
 
 ;; Cache the result — terminal state doesn't change mid-run
-(define ffi-isatty
-  (get-ffi-obj "isatty" #f (_fun _int -> _int)
-                (lambda () (lambda (fd) 0))))
+(define ffi-isatty (get-ffi-obj "isatty" #f (_fun _int ffi-> _int) (lambda () (lambda (fd) 0))))
 
 (define (tty?)
   "Check if stdout (fd 1) is connected to a terminal."
@@ -62,9 +61,7 @@
 
 (define (no-color?)
   "Check if NO_COLOR is set or TERM=dumb."
-  (or (getenv "NO_COLOR")
-      (let ([term (getenv "TERM")])
-        (and term (string=? term "dumb")))))
+  (or (getenv "NO_COLOR") (let ([term (getenv "TERM")]) (and term (string=? term "dumb")))))
 
 (define (color-enabled?)
   "True when stdout is a TTY and NO_COLOR is not set."
@@ -77,20 +74,20 @@
 (define (style->ansi sym)
   "Map a style symbol to its ANSI escape code."
   (case sym
-    [(bold)      ANSI-BOLD]
-    [(dim)       ANSI-DIM]
-    [(italic)    ANSI-ITALIC]
+    [(bold) ANSI-BOLD]
+    [(dim) ANSI-DIM]
+    [(italic) ANSI-ITALIC]
     [(underline) ANSI-UNDERLINE]
-    [(inverse)   ANSI-INVERSE]
-    [(red)       ANSI-RED]
-    [(green)     ANSI-GREEN]
-    [(yellow)    ANSI-YELLOW]
-    [(blue)      ANSI-BLUE]
-    [(magenta)   ANSI-MAGENTA]
-    [(cyan)      ANSI-CYAN]
-    [(white)     ANSI-WHITE]
-    [(gray)      ANSI-GRAY]
-    [else        ""]))
+    [(inverse) ANSI-INVERSE]
+    [(red) ANSI-RED]
+    [(green) ANSI-GREEN]
+    [(yellow) ANSI-YELLOW]
+    [(blue) ANSI-BLUE]
+    [(magenta) ANSI-MAGENTA]
+    [(cyan) ANSI-CYAN]
+    [(white) ANSI-WHITE]
+    [(gray) ANSI-GRAY]
+    [else ""]))
 
 (define (ansi codes text)
   "Wrap text with ANSI escape codes. Returns plain text if color is disabled."

--- a/util/event-contracts.rkt
+++ b/util/event-contracts.rkt
@@ -176,4 +176,4 @@
             #f))
 
 (provide event-payload-contracts
-         event-payload-contract)
+         (contract-out [event-payload-contract (-> (or/c symbol? string?) (or/c contract? #f))]))

--- a/util/event-macro.rkt
+++ b/util/event-macro.rkt
@@ -16,29 +16,31 @@
                      syntax/parse
                      racket/string
                      racket/list)
+         racket/contract
          racket/string
          (only-in "../agent/event-structs/base.rkt" typed-event))
 
 (provide define-typed-event
-         lookup-event-fields
-         register-event-fields!
-         ;; Serializer registry
-         register-event-serializer!
-         register-event-deserializer!
-         lookup-event-serializer
-         lookup-event-deserializer
-         ;; R-14: Parameterized registries for test isolation
+         with-fresh-event-registries
+         ;; Parameters (plain)
          current-event-field-registry
          current-event-serializer-registry
          current-event-deserializer-registry
-         with-fresh-event-registries
-         ;; JSON key conversion
-         field->json-key
-         ;; S8-F1: Schema versioning
          current-schema-version
          current-event-schema-registry
-         register-event-schema-version!
-         lookup-event-schema-version)
+         ;; Field registry
+         (contract-out [register-event-fields! (-> symbol? (listof symbol?) void?)]
+                       [lookup-event-fields (-> symbol? (or/c (listof symbol?) #f))]
+                       ;; Serializer registry
+                       [register-event-serializer! (-> string? procedure? void?)]
+                       [register-event-deserializer! (-> string? procedure? void?)]
+                       [lookup-event-serializer (-> string? (or/c procedure? #f))]
+                       [lookup-event-deserializer (-> string? (or/c procedure? #f))]
+                       ;; Schema versioning
+                       [register-event-schema-version! (-> string? exact-positive-integer? void?)]
+                       [lookup-event-schema-version (-> string? exact-positive-integer?)]
+                       ;; JSON key conversion
+                       [field->json-key (-> symbol? symbol?)]))
 
 ;; ===========================================================
 ;; Event field registry (I-12, I-23) -- canonical runtime mechanism for serialization

--- a/util/markdown.rkt
+++ b/util/markdown.rkt
@@ -10,7 +10,8 @@
 ;;   2. Headers (### ...)
 ;;   3. Inline: code (`...`), bold (**...**), italic (*...*), links ([text](url))
 
-(require racket/string
+(require racket/contract
+         racket/string
          racket/match
          racket/list)
 
@@ -18,9 +19,9 @@
          md-token?
          md-token-type
          md-token-content
-         parse-markdown
-         parse-line
-         parse-inline-markdown)
+         (contract-out [parse-markdown (-> string? (listof md-token?))]
+                       [parse-line (-> string? (listof md-token?))]
+                       [parse-inline-markdown (-> string? (listof md-token?))]))
 
 ;; ============================================================
 ;; Core struct — token model with selective nesting

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -11,4 +11,4 @@
 
 (provide (contract-out [q-version string?]))
 
-(define q-version "0.53.0")
+(define q-version "0.53.1")

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -11,4 +11,4 @@
 
 (provide (contract-out [q-version string?]))
 
-(define q-version "0.53.1")
+(define q-version "0.53.2")

--- a/wiki-src/Architecture-Overview.md
+++ b/wiki-src/Architecture-Overview.md
@@ -35,7 +35,7 @@ User input → Interface (CLI/TUI/RPC)
     → Events emitted to bus
 ```
 
-## Metrics (0.53.0)
+## Metrics (0.53.1)
 > _See `racket scripts/metrics.rkt` for current numbers._
 
 - 414 source modules, 534 test files

--- a/wiki-src/Architecture-Overview.md
+++ b/wiki-src/Architecture-Overview.md
@@ -35,7 +35,7 @@ User input → Interface (CLI/TUI/RPC)
     → Events emitted to bus
 ```
 
-## Metrics (0.53.1)
+## Metrics (0.53.2)
 > _See `racket scripts/metrics.rkt` for current numbers._
 
 - 414 source modules, 534 test files

--- a/wiring/extension-setup.rkt
+++ b/wiring/extension-setup.rkt
@@ -7,7 +7,8 @@
 ;; Creates extension registry, loads extensions from global + project dirs,
 ;; and queries extensions for commands and shortcuts.
 
-(require racket/file
+(require racket/contract
+         racket/file
          racket/string
          "../extensions/api.rkt"
          (only-in "../extensions/loader.rkt" load-extension!)
@@ -19,8 +20,9 @@
                   make-command-registry)
          (only-in "../tui/keymap.rkt" shortcut-specs->keymap keymap-merge))
 
-(provide make-wired-extension-registry
-         load-extensions-from-dir!)
+(provide (contract-out
+          [make-wired-extension-registry (-> any/c path-string? (values any/c any/c any/c))]
+          [load-extensions-from-dir! (->* (any/c path-string?) (#:event-bus any/c) void?)]))
 
 ;; ============================================================
 ;; make-wired-extension-registry


### PR DESCRIPTION
Addresses #4898.

feat(contracts): add contract-out to 61 source files — 50% coverage (#4898)

Contract coverage: 36.7% → 50.0% (162→221/442 source files).

Added contracts across CLI, LLM, runtime, tools, TUI, extensions, interfaces,
util, skills, wiring, and scripts layers. Fixed contract mismatches for
init-wizard (keyword args), provider-factory (any/c), session-index/mutations
(path-string?), context.rkt (make-extension-ctx), session-switch (keyword args),
tree-view (listof arity), and tool builtins (ls struct export).