### PR TITLE
ci(v0.54.0 W2): entrypoint regression gate in CI (#4913)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,5 +211,11 @@ jobs:
           echo "$output"
           echo "$output" | grep -qE '^q version [0-9]+\.[0-9]+\.[0-9]+$'
 
+      - name: Help smoke check
+        run: |
+          output=$(racket main.rkt --help)
+          echo "$output"
+          echo "$output" | grep -qE '^Usage:'
+
       - name: Provider compilation smoke tests
         run: raco test tests/test-provider-smoke.rkt

--- a/cli/args.rkt
+++ b/cli/args.rkt
@@ -37,7 +37,8 @@
          cli-config-sessions-args
          cli-config-keybindings-path
          cli-config-print-mode?
-         (contract-out [parse-cli-args (->* () ((or/c (vectorof string?) #f)) cli-config?)]
+         (contract-out [parse-cli-args
+                        (->* () ((or/c (vectorof string?) (listof string?) #f)) cli-config?)]
                        [cli-config->runtime-config (-> cli-config? hash?)]
                        [print-usage (->* () ((or/c output-port? #f)) void?)]
                        [print-version (->* () (output-port?) void?)])


### PR DESCRIPTION
- Add `--help` smoke check to CI smoke gate\r\n- Widen `parse-cli-args` contract to accept `(listof string?)` in addition to `(vectorof string?)`\r\n\r\nPart of v0.54.0 milestone (#473).