### PR TITLE
feat(v0.54.1 W1): session boundary contract tightening (#4919)

### DIFF
--- a/runtime/session-lifecycle.rkt
+++ b/runtime/session-lifecycle.rkt
@@ -84,14 +84,14 @@
                (or/c string? message?)
                (or/c procedure? #f)
                (or/c procedure? #f)
-               (listof any/c))]
-          [dispatch-iteration (-> agent-session? (listof any/c) exact-nonnegative-integer? any)]
+               (listof message?))]
+          [dispatch-iteration (-> agent-session? (listof message?) exact-nonnegative-integer? any)]
           [ensure-persisted! (-> agent-session? void?)]
-          [buffer-or-append! (-> agent-session? any/c void?)]
+          [buffer-or-append! (-> agent-session? message? void?)]
           [write-crash-log! (-> (or/c string? #f) string? string? void?)]
-          [compute-parent-id (->* ((listof any/c)) ((or/c any/c #f)) (or/c any/c #f))]
-          [build-user-message (-> string? (or/c any/c #f) any/c)]
-          [inject-system-instructions (-> (listof any/c) (listof string?) (listof any/c))]))
+          [compute-parent-id (->* ((listof message?)) ((or/c session-index? #f)) (or/c string? #f))]
+          [build-user-message (-> string? (or/c string? #f) message?)]
+          [inject-system-instructions (-> (listof message?) (listof string?) (listof message?))]))
 
 ;; ============================================================
 ;; Helpers

--- a/runtime/session-manager.rkt
+++ b/runtime/session-manager.rkt
@@ -23,18 +23,19 @@
 (provide (contract-out [session-manager? (-> any/c boolean?)]
                        [persistent-session-manager? (-> any/c boolean?)]
                        [in-memory-session-manager? (-> any/c boolean?)]
-                       [make-persistent-session-manager (-> path-string? any/c)]
-                       [make-in-memory-session-manager (-> any/c)]
-                       [sm-append! (-> any/c string? any/c void?)]
-                       [sm-load (-> any/c string? (listof any/c))]
-                       [sm-list (-> any/c (listof string?))]
-                       [sm-fork! (->* (any/c string? string?) (string?) any/c)]
+                       [make-persistent-session-manager (-> path-string? session-manager?)]
+                       [make-in-memory-session-manager (-> session-manager?)]
+                       [sm-append! (-> session-manager? string? any/c void?)]
+                       [sm-load (-> session-manager? string? list?)]
+                       [sm-list (-> session-manager? (listof string?))]
+                       [sm-fork! (->* (session-manager? string? string?) (string?) any/c)]
                        ;; Re-export in-memory operations for backward compat
-                       [in-memory-append! (-> any/c string? any/c void?)]
-                       [in-memory-append-entries! (-> any/c string? (listof any/c) void?)]
-                       [in-memory-load (-> any/c string? (listof any/c))]
-                       [in-memory-list-sessions (-> any/c (listof string?))]
-                       [in-memory-fork! (->* (any/c string? string?) (string?) any/c)]))
+                       [in-memory-append! (-> in-memory-session-manager? string? any/c void?)]
+                       [in-memory-append-entries! (-> in-memory-session-manager? string? list? void?)]
+                       [in-memory-load (-> in-memory-session-manager? string? list?)]
+                       [in-memory-list-sessions (-> in-memory-session-manager? (listof string?))]
+                       [in-memory-fork!
+                        (->* (in-memory-session-manager? string? string?) (string?) string?)]))
 
 ;; ============================================================
 ;; Persistent session manager — wraps file-backed session-store


### PR DESCRIPTION
Tighten session-lifecycle and session-manager contracts — replace `any/c` with domain types.\r\n\r\nPart of v0.54.1 (#474).