### PR TITLE
feat(v0.54.1 W2): scheduler keyword contract conformance (#4920)

### DIFF
--- a/tools/scheduler.rkt
+++ b/tools/scheduler.rkt
@@ -110,7 +110,7 @@
          (contract-out [run-tool-batch
                         (->* ((listof tool-call?) tool-registry?)
                              (#:hook-dispatcher (or/c procedure? #f)
-                                                #:exec-context (or/c any/c #f)
+                                                #:exec-context (or/c exec-context? #f)
                                                 #:parallel? (or/c boolean? #f))
                              scheduler-result?)]
                        [max-parallel-tools (parameter/c exact-positive-integer?)]))

--- a/tools/tool-struct.rkt
+++ b/tools/tool-struct.rkt
@@ -8,7 +8,7 @@
 (provide (contract-out [tool? (-> any/c boolean?)]
                        [tool-name (-> tool? string?)]
                        [tool-description (-> tool? string?)]
-                       [tool-schema (-> tool? any/c)]
+                       [tool-schema (-> tool? hash?)]
                        [tool-execute (-> tool? procedure?)]
                        [tool-prompt-snippet (-> tool? (or/c string? #f))]
                        [tool-prompt-guidelines (-> tool? (or/c string? #f))]

--- a/tools/tool.rkt
+++ b/tools/tool.rkt
@@ -64,7 +64,7 @@
          tool-result?
          (contract-out [make-tool-result (-> any/c (or/c hash? #f) boolean? tool-result?)]
                        [make-error-result (-> string? tool-result?)]
-                       [make-success-result (->* (any/c) (any/c) tool-result?)])
+                       [make-success-result (->* (any/c) ((or/c hash? #f)) tool-result?)])
          tool-result-content
          tool-result-details
          tool-result-is-error?


### PR DESCRIPTION
Scheduler/tool contract conformance fixes: `exec-context?`, `hash?` return types, `make-success-result` details type.\r\n\r\nPart of v0.54.1 (#474).