### PR TITLE
feat(v0.54.2 W1): migrate callers to guarded mutation setters (#4926)

### DIFF
--- a/runtime/agent-session.rkt
+++ b/runtime/agent-session.rkt
@@ -77,6 +77,7 @@
                   config-thinking-level
                   config-session-dir)
          (only-in "model-registry.rkt" model-registry?))
+(require "session-mutation.rkt")
 
 (provide agent-session?
          ;; v0.32.8: Convenience accessors (stable API)
@@ -436,7 +437,7 @@
       (maybe-dispatch-hooks (agent-session-extension-registry sess)
                             'session-shutdown
                             shutdown-payload))
-    (set-agent-session-active?! sess #f)))
+    (guarded-set-active! sess #f)))
 
 ;; ============================================================
 ;; Re-exported from extracted sub-modules

--- a/runtime/session-compaction.rkt
+++ b/runtime/session-compaction.rkt
@@ -16,9 +16,10 @@
          "../agent/event-emitter.rkt"
          "../agent/event-structs/iteration-events.rkt"
          "session-types.rkt")
+(require "session-mutation.rkt")
 
-(provide (contract-out
-           [maybe-compact-context (-> agent-session? (listof any/c) integer? (listof any/c))])
+(provide (contract-out [maybe-compact-context
+                        (-> agent-session? (listof any/c) integer? (listof any/c))])
          compact-context-mid-turn)
 
 ;; ============================================================
@@ -55,7 +56,7 @@
         context-with-system] ; too soon after last compaction
        [(agent-session-compacting? sess) context-with-system] ; recursive compaction guard
        [else
-        (set-agent-session-compacting?! sess #t)
+        (guarded-set-compacting! sess #t)
         (emit-typed-event! bus
                            (make-compaction-event #:session-id sid
                                                   #:turn-id #f
@@ -72,7 +73,7 @@
                                                         bus
                                                         sid))
                       (lambda ()
-                        (set-agent-session-compacting?! sess #f)
+                        (guarded-set-compacting! sess #f)
                         (set-agent-session-last-compaction-time! sess (current-inexact-milliseconds))
                         (emit-typed-event! bus
                                            (make-compaction-event #:session-id sid

--- a/runtime/session-controls.rkt
+++ b/runtime/session-controls.rkt
@@ -11,6 +11,7 @@
          racket/list
          (only-in "model-registry.rkt" available-models model-entry-name)
          "session-types.rkt")
+(require "session-mutation.rkt")
 
 (provide (contract-out [set-model! (-> agent-session? string? void?)]
                        [cycle-model! (-> agent-session? any/c (or/c string? #f))]
@@ -35,7 +36,7 @@
 (define (set-model! sess model-name)
   (unless (string? model-name)
     (raise-argument-error 'set-model! "string?" model-name))
-  (set-agent-session-model-name! sess model-name))
+  (guarded-set-model-name! sess model-name))
 
 ;; cycle-model! : agent-session? model-registry? -> (or/c string? #f)
 ;; Cycles to the next model in the registry's available models list.
@@ -54,7 +55,7 @@
                            (modulo (add1 current-idx) (length unique-names))
                            0)]
              [next-model (list-ref unique-names next-idx)])
-        (set-agent-session-model-name! sess next-model)
+        (guarded-set-model-name! sess next-model)
         next-model)))
 
 ;; ============================================================
@@ -79,17 +80,17 @@
 (define (set-thinking-level! sess level)
   (unless (thinking-level? level)
     (raise-argument-error 'set-thinking-level! "thinking level" level))
-  (set-agent-session-thinking-level! sess level))
+  (guarded-set-thinking-level! sess level))
 
 ;; ============================================================
 ;; Graceful shutdown (#1158)
 ;; ============================================================
 
 (define (request-shutdown! sess)
-  (set-agent-session-shutdown-requested?! sess #t))
+  (guarded-set-shutdown-requested! sess #t))
 
 (define (force-shutdown! sess)
-  (set-agent-session-force-shutdown?! sess #t))
+  (guarded-set-force-shutdown! sess #t))
 
 (define (shutdown-requested? sess)
   (agent-session-shutdown-requested? sess))
@@ -98,5 +99,5 @@
   (agent-session-force-shutdown? sess))
 
 (define (reset-shutdown-flags! sess)
-  (set-agent-session-shutdown-requested?! sess #f)
-  (set-agent-session-force-shutdown?! sess #f))
+  (guarded-set-shutdown-requested! sess #f)
+  (guarded-set-force-shutdown! sess #f))

--- a/runtime/session-events.rkt
+++ b/runtime/session-events.rkt
@@ -14,6 +14,7 @@
          (only-in "../util/protocol-types.rkt" event-ev event-payload message-id)
          (only-in "runtime-helpers.rkt" emit-session-event!)
          "session-types.rkt")
+(require "session-mutation.rkt")
 
 (provide (contract-out [wire-session-event-handlers! (-> any/c any/c void?)]))
 
@@ -60,9 +61,9 @@
          (when (file-exists? log-path)
            (define history (load-session-log log-path))
            (when (and (not (null? history)) (not (agent-session-compacting? sess)))
-             (set-agent-session-compacting?! sess #t)
+             (guarded-set-compacting! sess #t)
              (define compact-result (compact-history history))
-             (set-agent-session-compacting?! sess #f)
+             (guarded-set-compacting! sess #f)
              (emit-session-event! bus
                                   (agent-session-session-id sess)
                                   "session.compact.completed"

--- a/runtime/session-lifecycle.rkt
+++ b/runtime/session-lifecycle.rkt
@@ -163,7 +163,7 @@
   ;; Ensure index exists (build if first time)
   (unless (agent-session-index sess)
     (when (file-exists? log-path)
-      (set-agent-session-index! sess (build-index! log-path idx-path))))
+      (guarded-set-index! sess (build-index! log-path idx-path))))
   (define idx (agent-session-index sess))
 
   ;; Convert string to message struct if needed
@@ -223,7 +223,7 @@
   ;; Extract settings from path entries (#522)
   (define settings (extract-path-settings context-messages))
   (when (hash-ref settings 'model #f)
-    (set-agent-session-model-name! sess (hash-ref settings 'model)))
+    (guarded-set-model-name! sess (hash-ref settings 'model)))
 
   ;; Inject system instructions as an ephemeral system message prefix
   (inject-system-instructions context-messages (agent-session-system-instructions sess)))
@@ -254,7 +254,7 @@
              (hash? (hook-result-payload model-hook-res))
              (hash-has-key? (hook-result-payload model-hook-res) 'model))
     (define override-model (hash-ref (hook-result-payload model-hook-res) 'model))
-    (set-agent-session-model-name! sess override-model))
+    (guarded-set-model-name! sess override-model))
 
   ;; Run the core agent loop with tool-call iteration
   ;; v0.32.0: Start trace logger for diagnostics
@@ -335,7 +335,7 @@
   (define ws (make-working-set))
   (define base-cfg (agent-session-config sess))
   ;; v0.30.4: dict-set works on both hash? and session-config?
-  (set-agent-session-config! sess (dict-set base-cfg 'working-set ws))
+  (guarded-set-config! sess (dict-set base-cfg 'working-set ws))
 
   ;; 1. Build context: convert message, append to log, load history, inject system instructions
   (define context-with-system
@@ -354,7 +354,7 @@
                     (dispatch-iteration sess context-after-compact max-iterations)))
 
   ;; 5. Rebuild index
-  (set-agent-session-index! sess (build-index! log-path idx-path))
+  (guarded-set-index! sess (build-index! log-path idx-path))
 
   ;; 6. Emit session.updated
   (emit-session-event!
@@ -496,15 +496,15 @@
 (define (ensure-persisted! sess)
   (unless (agent-session-persisted? sess)
     (make-directory* (agent-session-session-dir sess))
-    (set-agent-session-persisted?! sess #t)
+    (guarded-set-persisted! sess #t)
     (define log-path (session-log-path-for sess))
     (write-session-version-header! log-path)
     (when (not (null? (agent-session-pending-entries sess)))
       (for ([entry (in-list (reverse (agent-session-pending-entries sess)))])
         (append-entry! log-path entry))
-      (set-agent-session-pending-entries! sess '()))))
+      (guarded-set-pending-entries! sess '()))))
 
 (define (buffer-or-append! sess entry)
   (if (agent-session-persisted? sess)
       (append-entry! (session-log-path-for sess) entry)
-      (set-agent-session-pending-entries! sess (cons entry (agent-session-pending-entries sess)))))
+      (guarded-set-pending-entries! sess (cons entry (agent-session-pending-entries sess)))))

--- a/runtime/session-mutation.rkt
+++ b/runtime/session-mutation.rkt
@@ -21,6 +21,7 @@
                        [guarded-set-pending-entries! (-> agent-session? list? any/c)]
                        [guarded-set-start-time! (-> agent-session? any/c any/c)]
                        [guarded-set-thinking-level! (-> agent-session? (or/c symbol? #f) any/c)]
+                       [guarded-set-last-compaction-time! (-> agent-session? any/c any/c)]
                        [valid-session-phase? (-> any/c boolean?)]
                        [session-phase (-> agent-session? symbol?)]))
 
@@ -98,3 +99,7 @@
 ;; Guard thinking-level — type-safe wrapper
 (define (guarded-set-thinking-level! sess value)
   (set-agent-session-thinking-level! sess value))
+
+;; Guard last-compaction-time — type-safe wrapper
+(define (guarded-set-last-compaction-time! sess value)
+  (set-agent-session-last-compaction-time! sess value))


### PR DESCRIPTION
Migrate all critical callers from raw `set-agent-session-*!` to guarded setters from `session-mutation.rkt`.\r\n\r\nPart of v0.54.2 (#475).