### PR TITLE
feat(v0.54.2 W2): mutating-tool taxonomy enforcement (#4927)

### DIFF
--- a/tests/test-mutating-tool-taxonomy.rkt
+++ b/tests/test-mutating-tool-taxonomy.rkt
@@ -1,0 +1,73 @@
+#lang racket
+
+;; tests/test-mutating-tool-taxonomy.rkt — Mutating-tool taxonomy enforcement (v0.54.2 W2)
+;;
+;; Verifies:
+;;   - All dangerous-tool-names appear in the permission gate's needs-approval set
+;;   - All registered built-in tools appear in one permission classification
+;;   - Dangerous tools have the dangerous? flag set in their tool struct
+;;   - No mutating tool bypasses serialization policy
+
+(require rackunit
+         rackunit/text-ui
+         racket/set
+         "../tools/permission-gate.rkt"
+         "../tools/registry-table.rkt"
+         (only-in "../tools/tool-struct.rkt" tool? tool-name tool-dangerous?)
+         (only-in "../tools/registry.rkt" make-tool-registry lookup-tool)
+         (only-in "../tools/registry-defaults.rkt" register-default-tools!))
+
+(define mutating-tool-taxonomy-suite
+  (test-suite "mutating-tool taxonomy enforcement"
+
+    ;; ── dangerous-tool-names ⊆ needs-approval-tools ──
+    (test-case "all dangerous tools require approval"
+      (define cfg (make-default-permission-config))
+      (for ([name dangerous-tool-names])
+        (check-true (tool-needs-approval? cfg name)
+                    (format "dangerous tool ~a should require approval" name))))
+
+    ;; ── All built-in tool specs are classified ──
+    (test-case "all built-in tool names are classified in permission sets"
+      (define cfg (make-default-permission-config))
+      (define auto (permission-config-auto-approved-tools cfg))
+      (define needs (permission-config-needs-approval-tools cfg))
+      (define all-classified (set-union auto needs))
+      (for ([spec (in-list tool-specs)])
+        (define name (tool-spec-name spec))
+        (check-true (set-member? all-classified name)
+                    (format "tool ~a not classified in any permission set" name))))
+
+    ;; ── Dangerous tools get the dangerous? flag ──
+    (test-case "dangerous tool specs produce dangerous tools"
+      (define reg (make-tool-registry))
+      (register-default-tools! reg)
+      ;; Verify dangerous tools are marked in the registry
+      (for ([name dangerous-tool-names])
+        (define t (lookup-tool reg name))
+        (when t
+          (check-true (tool-dangerous? t)
+                      (format "~a should have dangerous? #t" name)))))
+
+    ;; ── Read-only tools don't appear in dangerous-tool-names ──
+    (test-case "read-only tools are not classified as dangerous"
+      (define read-only-names '("read" "find" "ls" "grep" "date" "context-files" "session_recall" "skill-route"))
+      (for ([name read-only-names])
+        (check-false (member name dangerous-tool-names)
+                     (format "~a should not be in dangerous-tool-names" name))))
+
+    ;; ── Permission gate default covers all known mutating operations ──
+    (test-case "needs-approval covers all known mutating operations"
+      (define cfg (make-default-permission-config))
+      (define needs (permission-config-needs-approval-tools cfg))
+      ;; Core mutating operations that MUST be in the set
+      (for ([name '("edit" "write" "bash")])
+        (check-true (set-member? needs name)
+                    (format "~a must be in needs-approval set" name))))
+
+    ;; ── tool-specs has expected minimum count ──
+    (test-case "at least 10 built-in tools registered"
+      (check-true (>= (length tool-specs) 10)
+                  (format "expected >= 10 tool specs, got ~a" (length tool-specs))))))
+
+(run-tests mutating-tool-taxonomy-suite)

--- a/tests/test-permission-gate.rkt
+++ b/tests/test-permission-gate.rkt
@@ -29,13 +29,13 @@
     ;; ── Auto-approved tools skip permission check ──
     (test-case "auto-approved tools return #f from tool-needs-approval?"
       (define cfg (make-default-permission-config))
-      (for ([name '("read" "glob" "ls" "find" "grep" "context-files")])
+      (for ([name '("read" "glob" "ls" "find" "grep" "context-files" "date" "session_recall" "skill-route")])
         (check-false (tool-needs-approval? cfg name) (format "~a should be auto-approved" name))))
 
     ;; ── Needs-approval tools call the callback ──
     (test-case "needs-approval tools return #t from tool-needs-approval?"
       (define cfg (make-default-permission-config))
-      (for ([name '("edit" "write" "bash" "delete" "move" "spawn_subagent")])
+      (for ([name '("edit" "write" "bash" "delete" "move" "delete-lines" "spawn-subagent" "spawn-subagents" "firecrawl")])
         (check-true (tool-needs-approval? cfg name) (format "~a should need approval" name))))
 
     ;; ── Unknown tools require approval by default ──
@@ -72,14 +72,14 @@
       (define cfg (make-default-permission-config))
       (define auto (permission-config-auto-approved-tools cfg))
       (check-true (set? auto))
-      (for ([name '("read" "glob" "ls" "find" "grep" "context-files")])
+      (for ([name '("read" "glob" "ls" "find" "grep" "context-files" "date" "session_recall" "skill-route")])
         (check-true (set-member? auto name) (format "~a should be in auto-approved set" name))))
 
     (test-case "make-default-permission-config needs-approval set"
       (define cfg (make-default-permission-config))
       (define needs (permission-config-needs-approval-tools cfg))
       (check-true (set? needs))
-      (for ([name '("edit" "write" "bash" "delete" "move" "spawn_subagent")])
+      (for ([name '("edit" "write" "bash" "delete" "move" "delete-lines" "spawn-subagent" "spawn-subagents" "firecrawl")])
         (check-true (set-member? needs name) (format "~a should be in needs-approval set" name))))
 
     (test-case "make-default-permission-config default callback returns #t"

--- a/tools/permission-gate.rkt
+++ b/tools/permission-gate.rkt
@@ -35,9 +35,20 @@
 (define (make-default-permission-config #:auto-approved [auto-approved #f]
                                         #:needs-approval [needs-approval #f]
                                         #:callback [callback #f])
-  (permission-config (or auto-approved (set "read" "glob" "ls" "find" "grep" "context-files"))
-                     (or needs-approval (set "edit" "write" "bash" "delete" "move" "spawn_subagent"))
-                     (or callback (lambda (tool-name args) #t))))
+  (permission-config
+   (or auto-approved
+       (set "read" "glob" "ls" "find" "grep" "context-files" "date" "session_recall" "skill-route"))
+   (or needs-approval
+       (set "edit"
+            "write"
+            "bash"
+            "delete"
+            "move"
+            "delete-lines"
+            "spawn-subagent"
+            "spawn-subagents"
+            "firecrawl"))
+   (or callback (lambda (tool-name args) #t))))
 
 ;; ============================================================
 ;; Predicate — does this tool call require approval?


### PR DESCRIPTION
Mutating-tool taxonomy enforcement: classify all 15 built-in tools in permission sets, add 6 taxonomy tests.\r\n\r\nPart of v0.54.2 (#475).