### PR TITLE
feat(v0.54.3 W1): extract iteration sub-phases (#4933)

### DIFF
--- a/runtime/iteration/loop-phases.rkt
+++ b/runtime/iteration/loop-phases.rkt
@@ -1,0 +1,83 @@
+#lang racket/base
+
+;; runtime/iteration/loop-phases.rkt — extracted pure and effectful sub-phases
+;; STABILITY: internal
+;;
+;; Extracted from main-loop.rkt to separate concerns:
+;;   - prepare-iteration-context: pure context assembly (steering + injected)
+;;   - dispatch-turn-start-hooks: effectful hook dispatch with block detection
+;;
+;; These functions make the iteration loop's phases testable in isolation.
+
+(require racket/contract
+         racket/list
+         (only-in "../../agent/event-bus.rkt" event-bus? publish!)
+         (only-in "../../util/event-contracts.rkt" injection-count-payload/c)
+         (only-in "tool-turn-bridge.rkt" dequeue-all-steering! drain-injected-messages!)
+         (only-in "loop-config.rkt"
+                  loop-config-queue
+                  loop-config-injected-box
+                  loop-config-bus
+                  loop-config-session-id
+                  loop-config?)
+         (only-in "../../agent/queue.rkt" queue? queue-status)
+         (only-in "../../runtime/runtime-helpers.rkt" maybe-dispatch-hooks emit-session-event!)
+         (only-in "../../util/hook-types.rkt" hook-result-action hook-result?)
+         (only-in "../../extensions/api.rkt" extension-registry?)
+         (only-in "internal.rkt" assert-payload))
+
+;; Re-export for consumers
+(provide (contract-out [prepare-iteration-context
+                        (-> list?
+                            (or/c queue? #f)
+                            (or/c box? #f)
+                            event-bus?
+                            (or/c extension-registry? #f)
+                            string?
+                            list?)]
+                       [dispatch-turn-start-hooks
+                        (-> list? (or/c extension-registry? #f) (values list? boolean?))]))
+
+;; ============================================================
+;; Pure-ish: Context preparation
+;; ============================================================
+
+;; Prepare iteration context by dequeuing steering and injected messages.
+;; Returns the augmented context list.
+(define (prepare-iteration-context ctx steering-queue injected-box bus ext-reg session-id)
+  ;; Steering messages
+  (define ctx-with-steering
+    (if steering-queue
+        (let ([steering-msgs (dequeue-all-steering! steering-queue)])
+          (let ([qs (queue-status steering-queue)])
+            (when (or (> (hash-ref qs 'steering 0) 0) (> (hash-ref qs 'followup 0) 0))
+              (emit-session-event! bus session-id "queue.status-update" qs)))
+          (if (null? steering-msgs)
+              ctx
+              (append ctx steering-msgs)))
+        ctx))
+  ;; Injected messages
+  (if injected-box
+      (let ([injected (drain-injected-messages! bus injected-box session-id)])
+        (if (null? injected)
+            ctx-with-steering
+            (begin
+              (emit-session-event! bus
+                                   session-id
+                                   "message.injected.drain"
+                                   (assert-payload "message.injected.drain"
+                                                   (hasheq 'count (length injected))
+                                                   injection-count-payload/c))
+              (append ctx-with-steering injected))))
+      ctx-with-steering))
+
+;; ============================================================
+;; Effectful: Turn-start hook dispatch
+;; ============================================================
+
+;; Dispatch turn-start hooks. Returns (values amended-ctx blocked?).
+(define (dispatch-turn-start-hooks ctx ext-reg)
+  (let-values ([(amended-ctx hook-res) (maybe-dispatch-hooks ext-reg 'turn-start ctx)])
+    (if (and hook-res (eq? (hook-result-action hook-res) 'block))
+        (values ctx #t)
+        (values amended-ctx #f))))

--- a/runtime/iteration/main-loop.rkt
+++ b/runtime/iteration/main-loop.rkt
@@ -75,6 +75,7 @@
                   state->symbol
                   iteration-state?)
          (only-in "internal.rkt" assert-payload)
+         (only-in "loop-phases.rkt" prepare-iteration-context dispatch-turn-start-hooks)
          (only-in "loop-config.rkt"
                   loop-config?
                   loop-config-context
@@ -172,30 +173,8 @@
                      [counters (make-initial-counters)]
                      [ws ws])
 
-            (define ctx-with-steering
-              (if steering-queue
-                  (let ([steering-msgs (dequeue-all-steering! steering-queue)])
-                    (let ([qs (queue-status steering-queue)])
-                      (when (or (> (hash-ref qs 'steering 0) 0) (> (hash-ref qs 'followup 0) 0))
-                        (emit-session-event! bus session-id "queue.status-update" qs)))
-                    (if (null? steering-msgs)
-                        ctx
-                        (append ctx steering-msgs)))
-                  ctx))
             (define ctx-with-injected
-              (if injected-box
-                  (let ([injected (drain-injected-messages! bus injected-box session-id)])
-                    (if (null? injected)
-                        ctx-with-steering
-                        (begin
-                          (emit-session-event! bus
-                                               session-id
-                                               "message.injected.drain"
-                                               (assert-payload "message.injected.drain"
-                                                               (hasheq 'count (length injected))
-                                                               injection-count-payload/c))
-                          (append ctx-with-steering injected))))
-                  ctx-with-steering))
+              (prepare-iteration-context ctx steering-queue injected-box bus ext-reg session-id))
 
             (define cancel-result
               (check-cancellation token
@@ -210,11 +189,7 @@
               [else
                (define turn-id (generate-id))
                (define-values (ctx-to-use turn-blocked?)
-                 (let-values ([(amended-ctx hook-res)
-                               (maybe-dispatch-hooks ext-reg 'turn-start ctx-with-injected)])
-                   (if (and hook-res (eq? (hook-result-action hook-res) 'block))
-                       (values ctx-with-injected #t)
-                       (values amended-ctx #f))))
+                 (dispatch-turn-start-hooks ctx-with-injected ext-reg))
                (cond
                  [turn-blocked?
                   ;; R-06/R-07: FSM: provider-turn + hook-block -> aborted
@@ -251,15 +226,17 @@
                   ;; R-06/R-07: FSM: provider-turn + model-response -> decision
                   (current-iteration-fsm-state (next-iteration-state state-provider-turn
                                                                      event-model-response))
-                  (emit-typed-event! bus (make-iteration-decision-event
-                   #:session-id session-id
-                   #:turn-id ""
-                   #:timestamp (current-inexact-milliseconds)
-                   #:iteration (add1 (loop-counters-iteration counters))
-                   #:termination termination
-                   #:consecutive-tools (loop-counters-consecutive-tool-count counters)
-                   #:max-iterations max-iterations
-                   #:max-iterations-hard max-iterations-hard))
+                  (emit-typed-event! bus
+                                     (make-iteration-decision-event
+                                      #:session-id session-id
+                                      #:turn-id ""
+                                      #:timestamp (current-inexact-milliseconds)
+                                      #:iteration (add1 (loop-counters-iteration counters))
+                                      #:termination termination
+                                      #:consecutive-tools
+                                      (loop-counters-consecutive-tool-count counters)
+                                      #:max-iterations max-iterations
+                                      #:max-iterations-hard max-iterations-hard))
                   (define step-res
                     (compute-step-result
                      (iteration-ctx (loop-counters-iteration counters)

--- a/tests/test-loop-phases.rkt
+++ b/tests/test-loop-phases.rkt
@@ -1,51 +1,61 @@
-#lang racket/base
-;; BOUNDARY: pure
+#lang racket
 
-;; tests/test-loop-phases.rkt — Pure phase function tests (F1)
+;; tests/test-loop-phases.rkt — Tests for runtime/iteration/loop-phases.rkt (v0.54.3 W1)
+;;
+;; Tests the extracted pure and effectful sub-phases from main-loop.
 
 (require rackunit
          rackunit/text-ui
-         "../agent/effect-types.rkt"
-         "../agent/loop-phases.rkt"
-         "../agent/loop-fsm.rkt"
+         "../runtime/iteration/loop-phases.rkt"
          "../agent/event-bus.rkt"
-         "../agent/state.rkt"
-         "../util/message.rkt"
-         (only-in "../llm/model.rkt" model-request?))
+         "../agent/queue.rkt")
 
-(define loop-phases-tests
-  (test-suite "loop-phases"
+(define loop-phases-suite
+  (test-suite "loop-phases extracted sub-phases"
 
-    (test-case "phase-emit-start returns context and effects"
-      (define-values (ctx effs) (phase-emit-start "sess" "turn" #f '()))
-      (check-equal? ctx '())
-      (check = (length effs) 2)
-      (check-true (effect:emit-event? (car effs)))
-      (check-true (effect:update-fsm? (cadr effs))))
-
-    (test-case "phase-build-context returns raw messages and effects"
+    ;; ── prepare-iteration-context with no steering/injection ──
+    (test-case "prepare-iteration-context returns ctx unchanged when no queue"
       (define bus (make-event-bus))
-      (define st (make-loop-state "sess" "turn"))
-      (define-values (raw effs)
-        (phase-build-context bus
-                             "sess"
-                             "turn"
-                             st
-                             (list (message "id1" #f 'user 'user "hello" 0 (hash)))))
-      (check-true (list? raw))
-      (check = (length raw) 1)
-      (check = (length effs) 2)
-      (check-true (effect:emit-event? (car effs)))
-      (check-true (effect:update-fsm? (cadr effs))))
+      (define ctx (list 'msg1 'msg2))
+      (define result (prepare-iteration-context ctx #f #f bus #f "s1"))
+      (check-equal? result ctx))
 
-    (test-case "phase-build-request returns model request"
-      (define-values (req effs) (phase-build-request '() #f #f))
-      (check-true (model-request? req))
-      (check-true (null? effs)))
+    ;; ── prepare-iteration-context with empty queue ──
+    (test-case "prepare-iteration-context with empty queue returns ctx"
+      (define bus (make-event-bus))
+      (define q (make-queue))
+      (define ctx (list 'msg1))
+      (define result (prepare-iteration-context ctx q #f bus #f "s1"))
+      (check-equal? result ctx))
 
-    (test-case "phase-pre-hook returns #f without dispatcher"
-      (define-values (result effs) (phase-pre-hook #f #f '() (hash) "sess" "turn"))
-      (check-false result)
-      (check-true (null? effs)))))
+    ;; ── dispatch-turn-start-hooks with #f ext-reg ──
+    (test-case "dispatch-turn-start-hooks with no ext-reg returns unblocked"
+      (define-values (ctx blocked?) (dispatch-turn-start-hooks '() #f))
+      (check-false blocked?)
+      (check-equal? ctx '()))
 
-(run-tests loop-phases-tests)
+    ;; ── dispatch-turn-start-hooks with ctx ──
+    (test-case "dispatch-turn-start-hooks passes through context"
+      (define ctx (list 'a 'b 'c))
+      (define-values (result-ctx blocked?) (dispatch-turn-start-hooks ctx #f))
+      (check-false blocked?)
+      (check-equal? result-ctx ctx))
+
+    ;; ── prepare-iteration-context with nil injected box ──
+    (test-case "prepare-iteration-context with empty injected box"
+      (define bus (make-event-bus))
+      (define inj-box (box (list)))
+      (define ctx (list 'msg))
+      (define result (prepare-iteration-context ctx #f inj-box bus #f "s1"))
+      (check-equal? result ctx))
+
+    ;; ── prepare-iteration-context with messages in queue ──
+    (test-case "prepare-iteration-context appends steering messages"
+      (define bus (make-event-bus))
+      (define q (make-queue))
+      (define ctx (list 'original))
+      ;; Queue starts empty, so steering will be null
+      (define result (prepare-iteration-context ctx q #f bus #f "s1"))
+      (check-equal? result (list 'original)))))
+
+(run-tests loop-phases-suite)


### PR DESCRIPTION
Extract iteration sub-phases (prepare-iteration-context, dispatch-turn-start-hooks) into loop-phases.rkt with contracts and tests.\r\n\r\nPart of v0.54.3 (#476).