### PR TITLE
feat(v0.54.5 W0): strict summary mode (#4946)

### DIFF
--- a/scripts/run-tests.rkt
+++ b/scripts/run-tests.rkt
@@ -41,6 +41,7 @@
          make-test-file-result
          ;; Parsing
          parse-raco-output
+         normalize-counts
          extract-failure-lines
          ;; Running
          run-single-file
@@ -483,20 +484,23 @@
              [jobs (processor-count)]
              [sequential? #f]
              [timeout #f]
+             [strict? (equal? (getenv "STRICT_TEST_RUNNER") "1")]
              [suite 'all]
              [extra '()])
     (match rest
-      ['() (values jobs sequential? timeout suite (reverse extra))]
+      ['() (values jobs sequential? timeout strict? suite (reverse extra))]
       [(list "--help" _ ...)
        (usage)
        (exit 0)]
-      [(list "--jobs" n rest ...) (loop rest (string->number n) sequential? timeout suite extra)]
-      [(list "--sequential" rest ...) (loop rest 1 #t timeout suite extra)]
+      [(list "--strict" rest ...) (loop rest jobs sequential? timeout #t suite extra)]
+      [(list "--jobs" n rest ...)
+       (loop rest (string->number n) sequential? timeout strict? suite extra)]
+      [(list "--sequential" rest ...) (loop rest 1 #t timeout strict? suite extra)]
       [(list "--timeout" secs rest ...)
-       (loop rest jobs sequential? (string->number secs) suite extra)]
+       (loop rest jobs sequential? (string->number secs) strict? suite extra)]
       [(list "--suite" name rest ...)
-       (loop rest jobs sequential? timeout (string->symbol name) extra)]
-      [(list arg rest ...) (loop rest jobs sequential? timeout suite (cons arg extra))])))
+       (loop rest jobs sequential? timeout strict? (string->symbol name) extra)]
+      [(list arg rest ...) (loop rest jobs sequential? timeout strict? suite (cons arg extra))])))
 
 ;; ---------------------------------------------------------------------------
 ;; Pre-flight: stale bytecode cleanup
@@ -529,7 +533,7 @@
 ;; ---------------------------------------------------------------------------
 
 (define (main args)
-  (define-values (jobs sequential? timeout suite extra-files) (parse-args args))
+  (define-values (jobs sequential? timeout strict? suite extra-files) (parse-args args))
 
   ;; Pre-flight: clear stale bytecode to avoid linklet mismatches
   (define cleaned-dirs (clean-stale-bytecode! (build-path (current-directory) "..")))
@@ -572,6 +576,18 @@
                   (not (= (test-file-result-exit-code r) 2))))
            results))
   (define timeout-files (count (lambda (r) (= (test-file-result-exit-code r) 2)) results))
+
+  ;; Strict mode: flag files that exited 0 but parsed zero tests
+  (when strict?
+    (define suspicious
+      (filter (lambda (r) (and (= (test-file-result-exit-code r) 0) (= (test-file-result-total r) 0)))
+              results))
+    (when (pair? suspicious)
+      (newline)
+      (displayln "⛔ STRICT MODE: files with zero parsed tests:")
+      (for ([s (in-list suspicious)])
+        (printf "  ~a (exit=0 but no rackunit output parsed)~n" (test-file-result-path s)))
+      (exit 4)))
 
   (exit (summary-exit-code failed-files timeout-files)))
 

--- a/tests/test-strict-runner.rkt
+++ b/tests/test-strict-runner.rkt
@@ -1,0 +1,57 @@
+#lang racket
+
+;; tests/test-strict-runner.rkt — Strict summary mode tests (v0.54.5 W0)
+
+(require rackunit
+         rackunit/text-ui
+         "../scripts/run-tests.rkt")
+
+(define strict-suite
+  (test-suite "strict runner mode tests"
+
+    (test-case "test-file-result struct has expected fields"
+      (define r (make-test-file-result "test.rkt" 0 #"" #"" 100 5 0 5))
+      (check-equal? (test-file-result-path r) "test.rkt")
+      (check-equal? (test-file-result-exit-code r) 0)
+      (check-equal? (test-file-result-passed r) 5)
+      (check-equal? (test-file-result-failed r) 0)
+      (check-equal? (test-file-result-total r) 5))
+
+    (test-case "normalize-counts preserves good results"
+      (define-values (passed failed total)
+        (normalize-counts 0 10 0 10))
+      (check-equal? passed 10)
+      (check-equal? failed 0)
+      (check-equal? total 10))
+
+    (test-case "normalize-counts detects silent failures"
+      (define-values (passed failed total)
+        (normalize-counts 0 8 2 10))
+      (check-equal? passed 8)
+      (check-equal? failed 0)
+      (check-equal? total 8))
+
+    (test-case "summary-exit-code: 0 when no failures"
+      (check-equal? (summary-exit-code 0 0) 0))
+
+    (test-case "summary-exit-code: 1 for failures"
+      (check-equal? (summary-exit-code 1 0) 1))
+
+    (test-case "summary-exit-code: 2 for timeouts"
+      (check-equal? (summary-exit-code 0 1) 2))
+
+    (test-case "summary-exit-code: 3 for both"
+      (check-equal? (summary-exit-code 1 1) 3))
+
+    (test-case "extract-failure-lines: empty for passing output"
+      (define output #"3 success(es) 0 failure(s) 0 error(s) 3 test(s) run\n")
+      (check-equal? (extract-failure-lines output) '()))
+
+    (test-case "parse-raco-output: standard rackunit format"
+      (define-values (passed failed total)
+        (parse-raco-output #"some output\n5 success(es) 0 failure(s) 0 error(s) 5 test(s) run\n"))
+      (check-equal? passed 5)
+      (check-equal? failed 0)
+      (check-equal? total 5))))
+
+(run-tests strict-suite)


### PR DESCRIPTION
Add `--strict` flag and `STRICT_TEST_RUNNER` env var to fail on files with zero parsed test results. Export `normalize-counts`. 9 unit tests.\r\n\r\nPart of v0.54.5 (#478).