### PR TITLE
fix(v0.54.7 W0): ARCH-01 arity fix + MAT-01 planning coherence (#4958 #4959)

### DIFF
--- a/runtime/tool-coordinator.rkt
+++ b/runtime/tool-coordinator.rkt
@@ -77,16 +77,17 @@
                        [make-tool-result-messages
                         (-> (listof tool-call?) (listof tool-result?) string? (listof message?))]
                        [handle-tool-calls-pending
-                        (-> (listof message?) ; new-msgs
-                            list? ; ctx-with-steering
-                            (or/c extension-registry? #f) ; ext-reg
-                            (or/c tool-registry? #f) ; reg
-                            event-bus? ; bus
-                            string? ; session-id
-                            (or/c path-string? path?) ; log-path
-                            (or/c cancellation-token? #f) ; token
-                            any/c ; config
-                            (listof message?))]))
+                        (->* ((listof message?) ; new-msgs
+                              list? ; ctx-with-steering
+                              (or/c extension-registry? #f) ; ext-reg
+                              (or/c tool-registry? #f) ; reg
+                              event-bus? ; bus
+                              string? ; session-id
+                              (or/c path-string? path?) ; log-path
+                              (or/c cancellation-token? #f) ; token
+                              any/c) ; config
+                             (#:permission-config any/c)
+                             (listof message?))]))
 ;; Pure helpers (W2 #4192)
 (provide classify-tool-results
          build-blocked-tool-results)
@@ -307,7 +308,8 @@
                                   token
                                   config
                                   per-tool-start-ms
-                                  batch-start-ms)))
+                                  batch-start-ms
+                                  perm-cfg)))
   ;; Phase 3: Assembly
   (define validated-msgs
     (assemble-tool-results-phase tool-calls

--- a/tests/test-arch-01-regression.rkt
+++ b/tests/test-arch-01-regression.rkt
@@ -1,0 +1,83 @@
+#lang racket/base
+
+;; tests/test-arch-01-regression.rkt — ARCH-01 regression test (v0.54.7 W0)
+;;
+;; Regression test for execute-tool-batch-phase arity mismatch.
+;; Verifies that perm-cfg is correctly threaded through
+;; handle-tool-calls-pending → execute-tool-batch-phase.
+
+(require rackunit
+         rackunit/text-ui
+         (only-in "../runtime/tool-coordinator.rkt" handle-tool-calls-pending)
+         (only-in "../tools/tool.rkt" make-tool make-tool-registry register-tool! make-success-result)
+         (only-in "../util/protocol-types.rkt" make-message make-tool-call-part)
+         (only-in "../util/ids.rkt" generate-id)
+         (only-in "../util/event.rkt" event-event event-payload)
+         (only-in "../tools/permission-gate.rkt" make-default-permission-config
+                  permission-config?)
+         "../agent/event-bus.rkt")
+
+(define (make-echo-tool)
+  (make-tool
+   "echo"
+   "Echo tool for testing"
+   (hasheq 'type "object" 'properties (hasheq) 'required '())
+   (lambda (args _ctx)
+     (make-success-result "ok"))))
+
+(define (make-assistant-msg-with-call tool-name)
+  (make-message (generate-id)
+                #f
+                'assistant
+                'text
+                (list (make-tool-call-part (generate-id) tool-name (hasheq)))
+                1000
+                (hasheq)))
+
+;; Regression: handle-tool-calls-pending must accept #:permission-config
+;; and pass it through to execute-tool-batch-phase without arity error
+(define arch-01-suite
+  (test-suite "ARCH-01: perm-cfg arity regression"
+
+    (test-case "handle-tool-calls-pending threads perm-cfg to execute-tool-batch-phase"
+      ;; This would have crashed before the ARCH-01 fix with
+      ;; "execute-tool-batch-phase: arity mismatch: actual: 10, expected: 11"
+      (define bus (make-event-bus))
+      (define reg (make-tool-registry))
+      (register-tool! reg (make-echo-tool))
+      (define perm-cfg (make-default-permission-config))
+      (check-pred permission-config? perm-cfg)
+      (define completed? (box #f))
+      (subscribe! bus
+                  (lambda (evt)
+                    (when (equal? (event-event evt) "tool.execution.completed")
+                      (set-box! completed? #t))))
+      (define new-msgs (list (make-assistant-msg-with-call "echo")))
+      ;; This call would previously crash
+      (define result
+        (handle-tool-calls-pending new-msgs '() #f reg bus
+                                    "test-session" "/tmp/test.log" #f (hash)
+                                    #:permission-config perm-cfg))
+      ;; Verify the tool actually executed
+      (check-pred list? result)
+      ;; Give event bus a moment to deliver
+      (check-true (unbox completed?) "tool.execution.completed event should fire"))
+
+    (test-case "handle-tool-calls-pending without perm-cfg still works (default #f)"
+      (define bus (make-event-bus))
+      (define reg (make-tool-registry))
+      (register-tool! reg (make-echo-tool))
+      (define completed? (box #f))
+      (subscribe! bus
+                  (lambda (evt)
+                    (when (equal? (event-event evt) "tool.execution.completed")
+                      (set-box! completed? #t))))
+      (define new-msgs (list (make-assistant-msg-with-call "echo")))
+      ;; Default path — no #:permission-config supplied
+      (define result
+        (handle-tool-calls-pending new-msgs '() #f reg bus
+                                    "test-session" "/tmp/test.log" #f (hash)))
+      (check-pred list? result)
+      (check-true (unbox completed?) "default perm-cfg path should work"))))
+
+(run-tests arch-01-suite)


### PR DESCRIPTION
## v0.54.7 Wave 0 — Critical Fixes

### ARCH-01: Fix execute-tool-batch-phase arity mismatch (#4958)
- **Root cause**: `execute-tool-batch-phase` takes 11 params but was called with only 10 (missing `perm-cfg`)
- **Fix**: Thread `perm-cfg` through the call site at line 301
- **Contract update**: `handle-tool-calls-pending` contract changed from `->` to `->*` to accept optional `#:permission-config` keyword
- **Regression test**: `tests/test-arch-01-regression.rkt` with 2 test cases:
  1. Explicit `#:permission-config` threading (exercises the previously-crashed path)
  2. Default path without keyword (backwards compat)

### MAT-01: Close v0.54.6 in planning artifacts (#4959)
- `.planning/STATE.md`: v0.54.6 → complete, v0.54.7 → in progress
- `.planning/SUMMARY.md`: Added v0.54.6 section
- `.planning/PLAN.md`: Added v0.54.7 wave plan

**All existing tool-coordinator tests still pass.**