### PR TITLE
fix(v0.54.7 W2): security taxonomy + bytecode scope + suite selection (#4963 #4964 #4965)

### DIFF
--- a/scripts/run-tests.rkt
+++ b/scripts/run-tests.rkt
@@ -52,7 +52,8 @@
          save-failure-logs
          format-duration
          summary-exit-code
-         bytes->string*)
+         bytes->string*
+         clean-stale-bytecode!)
 
 ;; ---------------------------------------------------------------------------
 ;; Struct: test-file-result
@@ -111,7 +112,20 @@
       (string-contains? base "permission")
       (string-contains? base "safe-mode")
       (string-contains? base "sandbox")
-      (string-contains? base "tool-bash")))
+      (string-contains? base "tool-bash")
+      ;; Tag-based: files with ";; @suite security" in first 10 lines
+      (file-has-suite-tag? f "security")))
+
+(define (file-has-suite-tag? f tag)
+  "Check if a test file has a ;; @suite <tag> comment in its first 10 lines."
+  (with-handlers ([exn:fail? (lambda (_) #f)])
+    (call-with-input-file f
+                          (lambda (port)
+                            (define target (string-append "@suite " tag))
+                            (for/or ([_ (in-range 10)]
+                                     #:break (eof-object? (peek-byte port)))
+                              (define line (read-line port))
+                              (and (string? line) (string-contains? line target)))))))
 
 (define (smoke-excluded? f)
   (or (slow-file? f)
@@ -546,7 +560,7 @@
   (define-values (jobs sequential? timeout strict? suite extra-files) (parse-args args))
 
   ;; Pre-flight: clear stale bytecode to avoid linklet mismatches
-  (define cleaned-dirs (clean-stale-bytecode! (build-path (current-directory) "..")))
+  (define cleaned-dirs (clean-stale-bytecode! (current-directory)))
   (when (> cleaned-dirs 0)
     (printf ";; run-tests: cleaned ~a stale compiled/ director~a~n"
             cleaned-dirs

--- a/tests/test-destructive-warning.rkt
+++ b/tests/test-destructive-warning.rkt
@@ -1,4 +1,5 @@
 #lang racket
+;; @suite security
 
 ;; BOUNDARY: integration
 

--- a/tests/test-mutating-tool-taxonomy.rkt
+++ b/tests/test-mutating-tool-taxonomy.rkt
@@ -1,4 +1,5 @@
 #lang racket
+;; @suite security
 
 ;; tests/test-mutating-tool-taxonomy.rkt — Mutating-tool taxonomy enforcement (v0.54.2 W2)
 ;;

--- a/tests/test-tool-internal-gate.rkt
+++ b/tests/test-tool-internal-gate.rkt
@@ -1,4 +1,5 @@
 #lang racket
+;; @suite security
 
 ;; BOUNDARY: integration
 
@@ -24,10 +25,11 @@
       (check-pred procedure? tool-execute))
 
     ;; ── dangerous tool metadata ──
-    (test-case "dangerous-tool-names includes write/edit/bash"
+    (test-case "dangerous-tool-names includes write/edit/bash/delete-lines"
       (check-not-false (member "write" dangerous-tool-names))
       (check-not-false (member "edit" dangerous-tool-names))
-      (check-not-false (member "bash" dangerous-tool-names)))
+      (check-not-false (member "bash" dangerous-tool-names))
+      (check-not-false (member "delete-lines" dangerous-tool-names)))
 
     (test-case "non-dangerous tools not in list"
       (check-false (member "read" dangerous-tool-names))

--- a/tools/registry-table.rkt
+++ b/tools/registry-table.rkt
@@ -357,7 +357,7 @@
 ;; ============================================================
 
 ;; R-03/R-22: Metadata-driven dangerous tool classification
-(define dangerous-tool-names '("write" "edit" "bash"))
+(define dangerous-tool-names '("write" "edit" "bash" "delete-lines"))
 
 ;; Register tools from tool-spec structs.
 (define (register-tools-from-specs! registry specs #:only [only #f])


### PR DESCRIPTION
## v0.54.7 Wave 2 — Security & Test Hardening

### SEC-01 (#4963): delete-lines in dangerous-tool taxonomy
- Added `delete-lines` to `dangerous-tool-names` in `registry-table.rkt`
- Updated test to verify inclusion (already in `needs-approval-tools`)

### SEC-02/TEST-01 (#4964): Bytecode cleanup scope narrowing
- Changed `clean-stale-bytecode!` from `(current-directory) ".."` to `(current-directory)`
- Scopes cleanup to repo root only, avoids touching parent directories

### TEST-02 (#4965): Security suite tag-based selection
- Added `file-has-suite-tag?` for `;; @suite security` comment detection
- Tagged 3 security-relevant tests: `test-mutating-tool-taxonomy.rkt`, `test-tool-internal-gate.rkt`, `test-destructive-warning.rkt`
- Security suite: 15 → 18 files