### PR TITLE
test(v0.54.8 W0): characterization tests for /go unknown command bug (#4972)

### DIFF
--- a/tests/test-execute-command-hook.rkt
+++ b/tests/test-execute-command-hook.rkt
@@ -1,0 +1,140 @@
+#lang racket
+
+;; BOUNDARY: integration
+
+;; tests/test-execute-command-hook.rkt — Characterization tests for /go unknown command bug
+;;
+;; Bug report: .planning/BUG_REPORT-v0.54.x-GSD-GO-UNKNOWN-COMMAND.md
+;;
+;; T0.1: execute-command hook timeout should NOT produce generic "Unknown command"
+;; T0.2: execute-command hook is currently advisory (returns 'pass on timeout)
+;;
+;; These tests characterize the PRE-FIX behavior.
+;; After W1 fix (classify execute-command as critical):
+;; - T0.2 should be updated to expect 'block instead of 'pass
+;; - T0.1 should be updated to verify no "Unknown command" message
+
+(require rackunit
+         rackunit/text-ui
+         racket/string
+         "../extensions/hooks.rkt"
+         "../util/hook-types.rkt"
+         (only-in "../extensions/api.rkt" make-extension-registry register-extension! extension)
+         (only-in "../tui/commands.rkt"
+                  process-extension-command
+                  cmd-ctx
+                  cmd-ctx?
+                  cmd-ctx-state-box
+                  cmd-ctx-running-box
+                  cmd-ctx-needs-redraw-box
+                  cmd-ctx-input-text-box
+                  cmd-ctx-extension-registry-box)
+         (only-in "../tui/state.rkt" initial-ui-state ui-state-transcript)
+         (only-in "../tui/state-types.rkt" transcript-entry-text))
+
+;; ============================================================
+;; Helpers
+;; ============================================================
+
+(define (make-ext-reg-with-execute-command handler)
+  (define reg (make-extension-registry))
+  (define ext (extension "test-gsd" "0.1" "1.0" (hasheq 'execute-command handler)))
+  (register-extension! reg ext)
+  reg)
+
+(define (make-test-cctx #:ext-reg [ext-reg #f])
+  (cmd-ctx (box (initial-ui-state))
+           (box #t) ; running
+           #f ; event-bus
+           #f ; session-dir
+           (box #f) ; needs-redraw
+           #f ; model-registry-box
+           (box #f) ; last-prompt-box
+           #f ; session-runner
+           (box "/go") ; input-text-box
+           (box ext-reg) ; extension-registry-box
+           #f)) ; session-factory-runner
+
+(define (get-transcript-texts cctx)
+  (define state (unbox (cmd-ctx-state-box cctx)))
+  (map transcript-entry-text (ui-state-transcript state)))
+
+(define (transcript-contains? cctx substr)
+  (ormap (lambda (t) (string-contains? t substr)) (get-transcript-texts cctx)))
+
+;; ============================================================
+;; T0.2: Hook semantics — execute-command is currently advisory
+;; ============================================================
+
+(define execute-command-hook-tests
+  (test-suite "execute-command-hook characterization tests"
+    (test-case "T0.2: execute-command hook timeout returns pass (advisory default)"
+      ;; PRE-FIX characterization: execute-command is NOT in critical-hooks,
+      ;; so timeout returns 'pass (advisory default).
+      ;; After W1 fix, this test should be updated to expect 'block.
+      (parameterize ([current-hook-timeout-ms 1])
+        (define (slow-handler payload)
+          (sleep 0.1) ; way longer than 1ms
+          (hook-amend (hasheq 'text "should not reach")))
+        (define reg (make-ext-reg-with-execute-command slow-handler))
+        (define result (dispatch-hooks 'execute-command (hasheq 'command "/go" 'input "/go") reg))
+        ;; PRE-FIX: advisory returns 'pass
+        (check-equal? (hook-result-action result)
+                      'pass
+                      "PRE-FIX: execute-command timeout returns pass (advisory)")
+        (check-equal? (hook-result-payload result)
+                      (hasheq 'command "/go" 'input "/go")
+                      "original payload preserved on timeout")))
+
+    (test-case "T0.2b: execute-command hook error returns pass (advisory default)"
+      ;; PRE-FIX: errors also default to pass for advisory hooks
+      (define (failing-handler payload)
+        (error "handler crash!"))
+      (define reg (make-ext-reg-with-execute-command failing-handler))
+      (define result (dispatch-hooks 'execute-command (hasheq 'command "/go" 'input "/go") reg))
+      (check-equal? (hook-result-action result)
+                    'pass
+                    "PRE-FIX: execute-command error returns pass (advisory)"))
+
+    (test-case "T0.2c: execute-command is NOT in critical-hooks"
+      ;; PRE-FIX: verify execute-command is not currently classified as critical
+      (check-false (critical-hook? 'execute-command) "PRE-FIX: execute-command is not critical"))
+
+    ;; ============================================================
+    ;; T0.1: TUI integration — /go timeout produces unknown command
+    ;; ============================================================
+
+    (test-case "T0.1: /go with extension timeout falls to unknown command"
+      ;; PRE-FIX characterization: when extension handler times out,
+      ;; process-extension-command shows "Unknown command" because
+      ;; the timed-out advisory hook returns 'pass (not 'amend).
+      ;; After W1+W2 fixes, this should show a better message.
+      (define (slow-handler payload)
+        (sleep 0.1)
+        (hook-amend (hasheq 'text "should not reach")))
+      (define ext-reg (make-ext-reg-with-execute-command slow-handler))
+      (define cctx (make-test-cctx #:ext-reg ext-reg))
+      (define state (unbox (cmd-ctx-state-box cctx)))
+
+      (parameterize ([current-hook-timeout-ms 1])
+        (process-extension-command cctx state))
+
+      ;; PRE-FIX: we expect "Unknown command" in transcript
+      ;; (this is the BUG — should not happen for /go)
+      (check-true (transcript-contains? cctx "Unknown command")
+                  "PRE-FIX: /go timeout falls through to unknown command message"))
+
+    (test-case "T0.1b: /go with no extension registry shows unknown command"
+      ;; No extension registry → no handler → falls to unknown.
+      ;; This is EXPECTED behavior (no GSD extension loaded).
+      (define cctx (make-test-cctx #:ext-reg #f))
+      (define state (unbox (cmd-ctx-state-box cctx)))
+      (process-extension-command cctx state)
+      (check-true (transcript-contains? cctx "Unknown command")
+                  "no ext-reg: /go shows unknown (expected)"))))
+
+(module+ main
+  (run-tests execute-command-hook-tests))
+
+(module+ test
+  (run-tests execute-command-hook-tests))


### PR DESCRIPTION
## v0.54.8 W0 — Characterization Tests (#4972)

5 characterization tests confirming PRE-FIX behavior for the /go unknown command bug:

- **T0.1**: /go with extension timeout falls through to "Unknown command" (BUG)
- **T0.1b**: /go with no ext-reg shows unknown (expected, no extension loaded)
- **T0.2**: execute-command hook timeout returns `'pass` (advisory default)
- **T0.2b**: execute-command hook error returns `'pass` (advisory default)
- **T0.2c**: `execute-command` is NOT in `critical-hooks`

These tests will be updated in W1/W2 to verify the fix.