### PR TITLE
fix(v0.54.8 W2): UX hardening — command-dispatch failure message (#4974)

### DIFF
--- a/tests/test-execute-command-hook.rkt
+++ b/tests/test-execute-command-hook.rkt
@@ -114,10 +114,11 @@
       (parameterize ([current-hook-timeout-ms 1])
         (process-extension-command cctx state))
 
-      ;; PRE-FIX: we expect "Unknown command" in transcript
-      ;; (this is the BUG — should not happen for /go)
-      (check-true (transcript-contains? cctx "Unknown command")
-                  "PRE-FIX: /go timeout falls through to unknown command message"))
+      ;; POST-FIX (W1+W2): hook returns 'block (critical), TUI shows specific message
+      (check-true (transcript-contains? cctx "could not be dispatched")
+                  "POST-FIX: /go timeout shows command-dispatch failure message")
+      (check-false (transcript-contains? cctx "Unknown command")
+                   "POST-FIX: /go timeout does NOT show generic unknown command"))
 
     (test-case "T0.1b: /go with no extension registry shows unknown command"
       ;; No extension registry → no handler → falls to unknown.

--- a/tui/commands.rkt
+++ b/tui/commands.rkt
@@ -172,6 +172,15 @@
     [(and ext-result (hook-result? ext-result) (eq? (hook-result-action ext-result) 'amend))
      (execute-extension-command cctx state (hook-result-payload ext-result))
      'continue]
+    [(and ext-result (hook-result? ext-result) (eq? (hook-result-action ext-result) 'block))
+     (log-debug "command blocked by extension: cmd=~a" cmd-name)
+     (define msg
+       (format
+        "Command /~a could not be dispatched. This may be caused by a large PLAN or a slow extension. Try again or use /help for available commands."
+        cmd-name))
+     (define entry (make-error-entry msg))
+     (set-box! (cmd-ctx-state-box cctx) (add-transcript-entry state entry))
+     'continue]
     [else
      (log-debug "command fell through: cmd=~a" cmd-name)
      (define entry (make-error-entry "Unknown command. Type /help for commands."))


### PR DESCRIPTION
## v0.54.8 W2 — UX hardening: command-dispatch failure message (#4974)

**Before:** When `/go` timed out, the TUI showed "Unknown command. Type /help for commands."

**After:** The TUI now distinguishes between:
- **Extension blocked** (e.g. timeout): "Command /go could not be dispatched. This may be caused by a large PLAN or a slow extension. Try again or use /help for available commands."
- **Truly unknown**: "Unknown command. Type /help for commands."

Updated T0.1 characterization test to verify the new specific message.