### PR TITLE
release(v0.54.8): version bump + doc sync (#4975)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v0.54.8 — 2026-05-22
+
+### Entrypoint Hardening — /go Unknown Command Fix
+
+- **W0**: 5 characterization tests confirming /go unknown-command bug behavior
+- **W1**: Classified `execute-command` as critical hook — timeout/error now returns `hook-block` instead of `hook-pass` (extensions/hooks.rkt)
+- **W2**: UX hardening in TUI — command-dispatch failure now shows specific guidance message instead of generic "Unknown command" (tui/commands.rkt)
+
 ## v0.54.7 — 2026-05-22
 
 ### Project Review Remediation

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.54.7-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.54.8-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 
@@ -203,7 +203,7 @@ bin/q --model gpt-5.4 "write a test"
 ### Verify
 
 ```bash
-bin/q --version            # q version 0.54.7
+bin/q --version            # q version 0.54.8
 raco test tests/           # run the full test suite
 ```
 
@@ -434,6 +434,9 @@ When q executes shell commands on behalf of an LLM, arguments are quoted via `sh
 
 
 
+
+
+**v0.54.8** — Entrypoint Hardening — /go Unknown Command Fix
 
 **v0.54.7** — Project Review Remediation
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -2,7 +2,7 @@
 
 ## Version
 
-v0.54.7
+v0.54.8
 
 ## Layer Diagram
 

--- a/docs/event-taxonomy.md
+++ b/docs/event-taxonomy.md
@@ -1,6 +1,6 @@
 # Q Event Taxonomy Reference
 
-Complete reference for all event types in Q 0.54.7.
+Complete reference for all event types in Q 0.54.8.
 ## Base Types
 
 ### `event` (protocol-level)

--- a/docs/extension-guide.md
+++ b/docs/extension-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.54.7 --># Extension Development Guide
+<!-- verified-against: 0.54.8 --># Extension Development Guide
 
 This guide walks you through creating, testing, and activating a custom
 extension for q.

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.54.7 --># Getting Started
+<!-- verified-against: 0.54.8 --># Getting Started
 
 Welcome to q, a Racket-based coding agent.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.54.7 --># Installation Guide
+<!-- verified-against: 0.54.8 --># Installation Guide
 
 <!-- This file is the canonical source. The docs/getting-started/installation.md copy is maintained for the doc site build. -->
 

--- a/docs/security-trust-model.md
+++ b/docs/security-trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.54.7 --># Security & Trust Model
+<!-- verified-against: 0.54.8 --># Security & Trust Model
 
 This document provides an honest, per-area assessment of what q enforces
 today and what is planned. It is the authoritative reference for security

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -130,6 +130,6 @@ is the primary self-hosting extension:
 (load-extension! ext-reg "path/to/extension.rkt" #:event-bus bus)
 ```
 
-## Version 0.54.7
+## Version 0.54.8
 
-This documentation reflects q 0.54.7.
+This documentation reflects q 0.54.8.

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.54.7 --># q Source Style Guide
+<!-- verified-against: 0.54.8 --># q Source Style Guide
 
 This document defines formatting and naming conventions for the q Racket codebase.
 All changes to `q/` source files (excluding `tests/`) should follow these rules.

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.54.7 --># Trust Model
+<!-- verified-against: 0.54.8 --># Trust Model
 
 ## Trust Levels
 

--- a/docs/workflow-testing.md
+++ b/docs/workflow-testing.md
@@ -121,6 +121,6 @@ Use relative paths from the test file:
 4. Use `(check-true ...)` for boolean assertions
 5. Keep tests independent — no shared mutable state between test-cases
 
-## Version 0.54.7
+## Version 0.54.8
 
-This documentation reflects q 0.54.7.
+This documentation reflects q 0.54.8.

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.54.7")
+(define version "0.54.8")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base"))

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -11,4 +11,4 @@
 
 (provide (contract-out [q-version string?]))
 
-(define q-version "0.54.7")
+(define q-version "0.54.8")

--- a/wiki-src/Architecture-Overview.md
+++ b/wiki-src/Architecture-Overview.md
@@ -35,7 +35,7 @@ User input → Interface (CLI/TUI/RPC)
     → Events emitted to bus
 ```
 
-## Metrics (0.54.7)
+## Metrics (0.54.8)
 > _See `racket scripts/metrics.rkt` for current numbers._
 
 - 414 source modules, 534 test files


### PR DESCRIPTION
## v0.54.8 Release (#4975)

Version bump 0.54.7 → 0.54.8 + doc sync (15 files).

### Changes in this release:
- **W0**: 5 characterization tests for /go unknown-command bug
- **W1**: `execute-command` classified as critical hook — timeout/error returns `hook-block`
- **W2**: TUI shows specific command-dispatch failure message instead of generic "Unknown command"