### PR TITLE
fix(v0.54.9 W1): with-gsd-transaction contract — allow multi-value thunks (#4982)

### DIFF
--- a/extensions/gsd/core.rkt
+++ b/extensions/gsd/core.rkt
@@ -65,8 +65,11 @@
                        [cmd-reset (-> any/c)]
                        [cmd-done (->* (any/c) (boolean?) any/c)]
                        [cmd-wave-done (-> any/c any/c any/c)]
-                       [with-gsd-transaction (-> any/c any/c any/c any/c)]
-                       [reset-all-gsd-state! (-> any/c)]))
+                       [reset-all-gsd-state! (-> any/c)])
+         ;; with-gsd-transaction not in contract-out because it passes
+         ;; through multi-value thunk results; (-> any/c any/c any/c any/c)
+         ;; incorrectly constrains it to a single return value.
+         with-gsd-transaction)
 
 ;; ============================================================
 ;; Command registry

--- a/tests/test-gsd-transaction-contract.rkt
+++ b/tests/test-gsd-transaction-contract.rkt
@@ -7,8 +7,8 @@
 ;; Bug report: .planning/BUG_REPORT-v0.54.x-GSD-GO-TRANSACTION-CONTRACT-MISMATCH.md
 ;; Bug plan: .planning/BUG_PLAN-v0.54.x-GSD-GO-TRANSACTION-CONTRACT-MISMATCH.md
 ;;
-;; T0.1: with-gsd-transaction contract rejects multi-value thunks (the BUG)
-;; T0.2: TUI block message renders //go (double-slash formatting defect)
+;; T0.1: with-gsd-transaction now accepts multi-value thunks (W1 fixed)
+;; T0.2: TUI block message renders //go (double-slash formatting defect — W2 pending)
 
 (require rackunit
          rackunit/text-ui
@@ -72,15 +72,15 @@
     ;; The contract says (-> any/c any/c any/c any/c) — single return value.
     ;; But launch-wave-executor uses (define-values (exec waves) (with-gsd-transaction ...))
     ;; which requires the thunk to return 2 values via (values exec waves).
-    (test-case "T0.1: with-gsd-transaction rejects multi-value thunk (contract mismatch)"
-      ;; PRE-FIX: calling with-gsd-transaction with a thunk that returns
-      ;; multiple values raises a contract violation.
-      (check-exn exn:fail:contract?
-                 (lambda ()
-                   (with-gsd-transaction "test-multi-value"
-                                         (lambda () (values 'executor '(0 1 2)))
-                                         (lambda (e snap) (void))))
-                 "PRE-FIX: multi-value thunk breaks single-value contract"))
+    (test-case "T0.1: with-gsd-transaction accepts multi-value thunk (POST-FIX)"
+      ;; POST-FIX: with-gsd-transaction removed from contract-out so it
+      ;; no longer constrains thunk return arity. Multi-value thunks work.
+      (define-values (exec waves)
+        (with-gsd-transaction "test-multi-value"
+                              (lambda () (values 'executor '(0 1 2)))
+                              (lambda (e snap) (void))))
+      (check-equal? exec 'executor "first value returned")
+      (check-equal? waves '(0 1 2) "second value returned"))
 
     (test-case "T0.1b: with-gsd-transaction accepts single-value thunk"
       ;; Single-value thunks should work fine.


### PR DESCRIPTION
## v0.54.9 W1 — Fix `with-gsd-transaction` return-value contract (#4982)

**Root cause:** `with-gsd-transaction` was in `contract-out` with `(-> any/c any/c any/c any/c)`, promising a single return value. But `launch-wave-executor` calls it with `(define-values (executor wave-indices) ...)`, expecting 2 values.

**Fix:** Removed `with-gsd-transaction` from `contract-out` in `extensions/gsd/core.rkt` and added it to plain `provide`. The function passes through whatever the thunk returns (including multi-value results).

**Verification:**
- T0.1: multi-value thunks now work (was contract error)
- T0.1b/c: single-value and error paths still work
- GSD command dispatch: 18 tests pass
- Hook dispatch: 8 tests pass