### PR TITLE
fix(v0.54.9 W2): remove double slash from block message + include reason (#4983)

### DIFF
--- a/tests/test-gsd-transaction-contract.rkt
+++ b/tests/test-gsd-transaction-contract.rkt
@@ -8,7 +8,7 @@
 ;; Bug plan: .planning/BUG_PLAN-v0.54.x-GSD-GO-TRANSACTION-CONTRACT-MISMATCH.md
 ;;
 ;; T0.1: with-gsd-transaction now accepts multi-value thunks (W1 fixed)
-;; T0.2: TUI block message renders //go (double-slash formatting defect — W2 pending)
+;; T0.2: TUI block message renders /go correctly (W2 fixed)
 
 (require rackunit
          rackunit/text-ui
@@ -96,12 +96,10 @@
       (check-true (string-contains? (gsd-command-result-message result) "boom")
                   "error message propagated"))
 
-    ;; T0.2: TUI block message renders //go (double-slash)
+    ;; T0.2: TUI block message renders /go (no double-slash)
     ;; parse-extension-command returns "/go" (with slash).
-    ;; The format string "Command /~a ..." then produces "Command //go".
-    (test-case "T0.2: TUI block message has double slash (//go)"
-      ;; PRE-FIX: the blocked-command message template uses "/~a" but
-      ;; cmd-name already contains the leading slash.
+    ;; POST-FIX: format string uses "Command ~a ..." (no extra slash).
+    (test-case "T0.2: TUI block message shows /go (no double slash)"
       ;; Create a handler that triggers 'block by timing out.
       (define (slow-handler payload)
         (sleep 0.1)
@@ -113,8 +111,10 @@
       (parameterize ([current-hook-timeout-ms 1])
         (process-extension-command cctx state))
 
-      ;; PRE-FIX: message contains "//go" (double slash)
-      (check-true (transcript-contains? cctx "//go") "PRE-FIX: block message has double slash //go"))
+      ;; POST-FIX: message contains "/go" (single slash)
+      (check-true (transcript-contains? cctx "/go") "POST-FIX: block message shows /go")
+      ;; And must NOT contain double-slash
+      (check-false (transcript-contains? cctx "//go") "POST-FIX: block message has no double slash"))
 
     (test-case "T0.2b: TUI block message includes useful guidance"
       ;; Even with the formatting bug, the message should contain guidance.

--- a/tui/commands.rkt
+++ b/tui/commands.rkt
@@ -174,10 +174,16 @@
      'continue]
     [(and ext-result (hook-result? ext-result) (eq? (hook-result-action ext-result) 'block))
      (log-debug "command blocked by extension: cmd=~a" cmd-name)
+     (define block-reason (hook-result-payload ext-result))
      (define msg
-       (format
-        "Command /~a could not be dispatched. This may be caused by a large PLAN or a slow extension. Try again or use /help for available commands."
-        cmd-name))
+       (if (and block-reason (not (equal? block-reason (hasheq))))
+           (format
+            "Command ~a could not be dispatched: ~a. Try again or use /help for available commands."
+            cmd-name
+            block-reason)
+           (format
+            "Command ~a could not be dispatched. This may be caused by a large PLAN or a slow extension. Try again or use /help for available commands."
+            cmd-name)))
      (define entry (make-error-entry msg))
      (set-box! (cmd-ctx-state-box cctx) (add-transcript-entry state entry))
      'continue]


### PR DESCRIPTION
## v0.54.9 W2 — UX fix: double-slash rendering + error detail (#4983)

**Bug 1:** TUI showed `//go` (double-slash) because `cmd-name` already contains `/` and the format string added another.

**Fix:** Changed format string from `"Command /~a ..."` to `"Command ~a ..."`.

**Bug 2:** Block reason payload from `hook-result-payload` was silently ignored.

**Fix:** When payload is present and non-empty, include it in the error message.

**Verification:**
- T0.2: message shows `/go` (no double-slash)
- T0.2b: message includes dispatch-failure guidance
- execute-command-hook: 5 tests pass