### PR TITLE
feat(v0.55.0 W0): contract metrics + blame helpers (#4998)

### DIFF
--- a/scripts/contract-metrics.rkt
+++ b/scripts/contract-metrics.rkt
@@ -1,0 +1,85 @@
+#lang racket
+
+;; q/scripts/contract-metrics.rkt — Count any/c in contract-out across source tree
+;;
+;; Usage: racket q/scripts/contract-metrics.rkt [--json] [--summary]
+;;
+;; Scans all .rkt files under src-dirs (excluding tests/, scripts/)
+;; and counts occurrences of `any/c` in files that contain `contract-out`.
+
+(require racket/string
+         racket/file)
+
+;; ── File discovery ──────────────────────────────────────────
+
+(define src-dirs '("extensions" "agent" "runtime" "tui" "tools" "util"
+                   "interfaces" "cli" "llm" "sandbox" "skills" "wiring"))
+
+(define (under-src-dir? p)
+  (define str (path->string p))
+  ;; Strip leading ./ if present
+  (define clean (if (string-prefix? str "./") (substring str 2) str))
+  (ormap (lambda (d) (string-prefix? clean (string-append d "/"))) src-dirs))
+
+(define (find-src-files [root "."])
+  (for/list ([f (in-directory root)]
+             #:when (and (path-has-extension? f #".rkt")
+                         (under-src-dir? f)))
+    (path->string f)))
+
+;; ── Counting ────────────────────────────────────────────────
+
+(define (count-anyc-in-file content)
+  ;; Count any/c occurrences in lines that are inside a contract-out form.
+  ;; Simplified: if file contains contract-out, count all any/c.
+  ;; This slightly overcounts (any/c in comments/docs) but is good enough
+  ;; for tracking reduction progress.
+  (if (regexp-match? #rx"contract-out" content)
+      (length (regexp-match-positions* #rx"any/c" content))
+      0))
+
+;; ── Main ────────────────────────────────────────────────────
+
+(define (run-metrics #:root [root "."] #:json? [json? #f] #:summary? [summary? #f])
+  (define files (find-src-files root))
+  (define results
+    (sort
+     (for/list ([f (in-list files)])
+       (define content
+         (with-handlers ([exn:fail? (lambda (_) "")])
+           (file->string f)))
+       (define n (count-anyc-in-file content))
+       (cons f n))
+     > #:key cdr))
+  (define total (apply + (map cdr results)))
+  (define files-with-anyc (filter (lambda (p) (> (cdr p) 0)) results))
+
+  (cond
+    [json?
+     (displayln (format "{ \"total\": ~a, \"files\": ~a }"
+                        total (length files-with-anyc)))]
+    [summary?
+     (printf "Total any/c in contract-out: ~a~n" total)
+     (printf "Files with any/c: ~a~n" (length files-with-anyc))
+     (printf "Total source files scanned: ~a~n" (length files))]
+    [else
+     (printf "~n── Contract Metrics: any/c in contract-out ──~n~n")
+     (printf "Total: ~a any/c across ~a files~n~n" total (length files-with-anyc))
+     (for ([p (in-list files-with-anyc)])
+       (printf "  ~a  ~a~n" (cdr p) (car p)))
+     (printf "~n── Total: ~a any/c ──~n" total)])
+
+  total)
+
+;; ── CLI ─────────────────────────────────────────────────────
+
+(define json-mode #f)
+(define summary-mode #f)
+
+(command-line
+ #:program "contract-metrics"
+ #:once-each
+ [("--json") "Output JSON" (set! json-mode #t)]
+ [("--summary") "Summary only" (set! summary-mode #t)]
+ #:args ()
+ (run-metrics #:root "." #:json? json-mode #:summary? summary-mode))

--- a/tests/helpers/contract-blame.rkt
+++ b/tests/helpers/contract-blame.rkt
@@ -1,0 +1,39 @@
+#lang racket/base
+
+;; q/tests/helpers/contract-blame.rkt — Contract blame assertion helpers
+;;
+;; Provides:
+;;   check-contract-blame  — asserts expression triggers contract violation
+;;   check-contract-accepts — asserts value passes a contract
+
+(require rackunit
+         racket/contract)
+
+(provide check-contract-blame
+         check-contract-accepts)
+
+;; check-contract-blame : (->* (string? (-> any)) (#:message (or/c string? #f)) void?)
+;; Asserts that calling thunk triggers a contract violation.
+;; Optionally checks that the error message contains #:message.
+(define (check-contract-blame label thunk #:message [msg #f])
+  (with-check-info
+   (['label label])
+   (define raised? #f)
+   (define caught-msg #f)
+   (with-handlers ([exn:fail:contract? (lambda (e)
+                                         (set! raised? #t)
+                                         (set! caught-msg (exn-message e)))])
+     (thunk))
+   (with-check-info
+    (['contract-violation-raised? raised?] ['error-message caught-msg])
+    (check-true raised? (format "~a: expected contract violation but none raised" label))
+    (when (and msg raised?)
+      (check-not-false (and caught-msg (regexp-match? (regexp-quote msg) caught-msg))
+                       (format "~a: expected message containing ~a, got ~a" label msg caught-msg))))))
+
+;; check-contract-accepts : (-> string? contract? any/c void?)
+;; Asserts that value satisfies the given contract.
+(define (check-contract-accepts label ct val)
+  (with-check-info (['label label] ['contract ct] ['value val])
+                   (check-not-exn (lambda () (contract ct val 'positive 'negative))
+                                  (format "~a: value should satisfy contract" label))))


### PR DESCRIPTION
## v0.55.0 W0 — Baseline Metrics + Contract-Blame Infrastructure (#4998)

- `q/scripts/contract-metrics.rkt` — counts `any/c` in `contract-out` per file. **Baseline: 1338 any/c across 151 files**.
- `q/tests/helpers/contract-blame.rkt` — `check-contract-blame` and `check-contract-accepts` test helpers for TDD contract tightening.