### PR TITLE
feat(v0.55.2 W2): tighten gsd state-machine + core contracts (#5000)

### DIFF
--- a/extensions/gsd/core.rkt
+++ b/extensions/gsd/core.rkt
@@ -57,15 +57,16 @@
          ;; Re-export command result types
          (all-from-out "command-types.rkt")
          ;; Functions (contracted)
-         (contract-out [gsd-command-dispatch (-> any/c any/c any/c)]
-                       [gsd-write-guard (-> any/c any/c any/c)]
-                       [gsd-show-status (-> any/c)]
-                       [cmd-replan (-> any/c)]
-                       [cmd-skip (-> any/c any/c)]
-                       [cmd-reset (-> any/c)]
-                       [cmd-done (->* (any/c) (boolean?) any/c)]
-                       [cmd-wave-done (-> any/c any/c any/c)]
-                       [reset-all-gsd-state! (-> any/c)])
+         (contract-out [gsd-command-dispatch
+                        (-> (or/c symbol? string?) any/c (or/c gsd-command-result? #f))]
+                       [gsd-write-guard (-> path-string? path-string? gsd-command-result?)]
+                       [gsd-show-status (-> gsd-command-result?)]
+                       [cmd-replan (-> gsd-command-result?)]
+                       [cmd-skip (-> any/c gsd-command-result?)]
+                       [cmd-reset (-> gsd-command-result?)]
+                       [cmd-done (->* ((or/c path-string? #f)) (boolean?) gsd-command-result?)]
+                       [cmd-wave-done (-> (or/c path-string? #f) any/c gsd-command-result?)]
+                       [reset-all-gsd-state! (-> void?)])
          ;; with-gsd-transaction not in contract-out because it passes
          ;; through multi-value thunk results; (-> any/c any/c any/c any/c)
          ;; incorrectly constrains it to a single return value.

--- a/extensions/gsd/state-machine.rkt
+++ b/extensions/gsd/state-machine.rkt
@@ -57,29 +57,32 @@
          TRANSITIONS-FLAT
          ;; Functions (contracted)
          (contract-out [gsm-state? (-> any/c boolean?)]
-                       [make-initial-gsd-state (-> any/c)]
+                       [make-initial-gsd-state (-> gsd-runtime-state?)]
                        [gsm-current (-> symbol?)]
-                       [gsm-transition! (->* (symbol?) (#:event any/c) any/c)]
-                       [gsm-transition-to! (-> symbol? any/c)]
-                       [gsm-reset! (-> any/c)]
+                       [gsm-transition!
+                        (->* (symbol?) (#:event (or/c symbol? #f)) (or/c ok-result? err-result?))]
+                       [gsm-transition-to! (-> symbol? (or/c ok-result? err-result?))]
+                       [gsm-reset! (-> (or/c ok-result? err-result?))]
                        [compute-next-gsm-state
-                        (->* (any/c symbol?) (#:event any/c) (values any/c any/c))]
+                        (->* (gsd-runtime-state? symbol?)
+                             (#:event (or/c symbol? #f))
+                             (values (or/c ok-result? err-result?) gsd-runtime-state?))]
                        [gsm-valid-next-states (-> (listof symbol?))]
                        [gsm-tool-allowed? (-> string? boolean?)]
-                       [gsm-snapshot (-> any/c)]
+                       [gsm-snapshot (-> gsd-runtime-state?)]
                        [reset-gsm! (-> void?)]
-                       [gsm-history (-> any/c)]
-                       [gsm-wave-executor (-> any/c)]
-                       [gsm-set-wave-executor! (-> any/c any/c)]
-                       [gsm-total-waves (-> any/c)]
-                       [gsm-set-total-waves! (-> any/c any/c)]
-                       [gsm-current-wave (-> any/c)]
-                       [gsm-set-current-wave! (-> any/c any/c)]
-                       [gsm-completed-waves (-> any/c)]
-                       [gsm-mark-wave-complete! (-> any/c any/c)]
-                       [gsm-wave-complete? (-> any/c boolean?)]
-                       [gsm-next-pending-wave (-> any/c)]
-                       [gsd-invariants-hold? (-> (values boolean? any/c))]))
+                       [gsm-history (-> list?)]
+                       [gsm-wave-executor (-> (or/c any/c #f))]
+                       [gsm-set-wave-executor! (-> (or/c any/c #f) void?)]
+                       [gsm-total-waves (-> exact-nonnegative-integer?)]
+                       [gsm-set-total-waves! (-> exact-nonnegative-integer? void?)]
+                       [gsm-current-wave (-> exact-nonnegative-integer?)]
+                       [gsm-set-current-wave! (-> exact-nonnegative-integer? void?)]
+                       [gsm-completed-waves (-> (set/c exact-nonnegative-integer?))]
+                       [gsm-mark-wave-complete! (-> exact-nonnegative-integer? void?)]
+                       [gsm-wave-complete? (-> exact-nonnegative-integer? boolean?)]
+                       [gsm-next-pending-wave (-> (or/c exact-nonnegative-integer? #f))]
+                       [gsd-invariants-hold? (-> (values boolean? (or/c string? #f)))]))
 
 ;; ============================================================
 ;; States and transitions


### PR DESCRIPTION
## v0.55.2 W2 — GSD State-Machine + Core Contract Precision (#5000)

**state-machine.rkt:** 27→3 any/c
- `make-initial-gsd-state`: → `gsd-runtime-state?`
- `gsm-transition!`: → `(or/c ok-result? err-result?)`
- `compute-next-gsm-state`: typed input + values output
- All wave accessors: `exact-nonnegative-integer?` / `void?` / `set/c`

**core.rkt:** 10→4 any/c
- `gsd-command-dispatch`: `(or/c symbol? string?)` → `(or/c gsd-command-result? #f)`
- `gsd-write-guard`: `path-string?` → `gsd-command-result?`
- `reset-all-gsd-state!`: → `void?`

**Metric:** 1253 → 1215 any/c (−38)