### PR TITLE
feat(v0.55.3 W3): tighten gsd wave-docs + archive + tool-handlers contracts (#5001)

### DIFF
--- a/extensions/gsd/archive.rkt
+++ b/extensions/gsd/archive.rkt
@@ -20,14 +20,15 @@
          (only-in "shared.rkt" extract-plan-title)
          "wave-status.rkt")
 
-(provide (contract-out [archive-completed-plan! (->* (any/c) (boolean?) any/c)]
-                       [all-waves-complete? (-> any/c any/c)]
-                       [archive-path-for-plan (-> any/c any/c any/c)]
-                       [move-to-archive! (-> any/c any/c any/c)]
-                       [reset-gsd-after-archive! (-> any/c)]
-                       [cleanup-empty-subdirs! (-> any/c any/c)]
-                       [ensure-state-md! (-> any/c any/c)]
-                       [sync-executor-to-plan! (-> any/c any/c)]))
+(provide (contract-out [archive-completed-plan!
+                        (->* ((or/c path-string? #f)) (boolean?) gsd-command-result?)]
+                       [all-waves-complete? (-> path-string? boolean?)]
+                       [archive-path-for-plan (-> path-string? string? path?)]
+                       [move-to-archive! (-> path-string? path? path?)]
+                       [reset-gsd-after-archive! (-> void?)]
+                       [cleanup-empty-subdirs! (-> path-string? void?)]
+                       [ensure-state-md! (-> path-string? void?)]
+                       [sync-executor-to-plan! (-> path-string? void?)]))
 
 ;; ============================================================
 ;; Validation

--- a/extensions/gsd/tool-handlers.rkt
+++ b/extensions/gsd/tool-handlers.rkt
@@ -29,13 +29,14 @@
 (provide planning-read-schema
          planning-write-schema
          ;; Functions (contracted)
-         (contract-out [handle-planning-read (->* (any/c) (any/c) any/c)]
-                       [handle-planning-write (->* (any/c) (any/c) any/c)]
-                       [resolve-project-root (-> any/c any/c)]
-                       [planning-artifact-path (-> any/c any/c any/c)]
-                       [get-base-dir (->* (any/c) (any/c) any/c)]
-                       [read-planning-artifact (-> any/c any/c any/c)]
-                       [write-planning-artifact! (-> any/c any/c any/c any/c)]))
+         (contract-out [handle-planning-read (->* (hash?) (any/c) any/c)]
+                       [handle-planning-write (->* (hash?) (any/c) any/c)]
+                       [resolve-project-root (-> path-string? path?)]
+                       [planning-artifact-path (-> path-string? string? (or/c path? #f))]
+                       [get-base-dir (->* (hash?) (any/c) path?)]
+                       [read-planning-artifact (-> path-string? string? (or/c hash? string? #f))]
+                       [write-planning-artifact!
+                        (-> path-string? string? (or/c hash? string?) (or/c path? #f))]))
 
 ;; ============================================================
 ;; Path helpers

--- a/extensions/gsd/wave-docs.rkt
+++ b/extensions/gsd/wave-docs.rkt
@@ -38,21 +38,22 @@
          wave-index-entry-slug
          wave-index-entry-status
          ;; Functions (contracted)
-         (contract-out [wave-doc-path (-> any/c any/c any/c any/c)]
-                       [write-wave-doc! (-> any/c any/c any/c any/c any/c any/c)]
-                       [read-wave-doc (-> any/c any/c any/c any/c)]
-                       [parse-wave-doc-from-string (->* (any/c any/c any/c) (any/c) any/c)]
-                       [slugify (-> string? string?)]
-                       [parse-plan-index (-> string? any/c)]
-                       [update-wave-in-index! (-> any/c any/c any/c any/c)]
-                       [update-plan-index-text (-> string? any/c string? string?)]
-                       [next-inbox-wave (-> any/c any/c)]
-                       [find-next-inbox-entry (-> any/c any/c)]
-                       [mark-wave-status! (-> any/c any/c any/c any/c)]
-                       [plan-overall-status (-> any/c symbol?)]
-                       [compute-plan-overall-status (-> any/c symbol?)]
-                       [wave-exists? (-> any/c any/c any/c boolean?)]
-                       [wave-status-markers (-> any/c)]))
+         (contract-out
+          [wave-doc-path (-> path-string? exact-nonnegative-integer? string? path?)]
+          [write-wave-doc! (-> path-string? exact-nonnegative-integer? string? string? string? path?)]
+          [read-wave-doc (-> path-string? exact-nonnegative-integer? string? (or/c hash? #f))]
+          [parse-wave-doc-from-string (->* (any/c any/c any/c) (any/c) hash?)]
+          [slugify (-> string? string?)]
+          [parse-plan-index (-> string? (listof wave-index-entry?))]
+          [update-wave-in-index! (-> path-string? exact-nonnegative-integer? string? boolean?)]
+          [update-plan-index-text (-> string? exact-nonnegative-integer? string? string?)]
+          [next-inbox-wave (-> path-string? (or/c wave-index-entry? #f))]
+          [find-next-inbox-entry (-> (listof wave-index-entry?) (or/c wave-index-entry? #f))]
+          [mark-wave-status! (-> path-string? exact-nonnegative-integer? string? boolean?)]
+          [plan-overall-status (-> path-string? symbol?)]
+          [compute-plan-overall-status (-> (listof wave-index-entry?) symbol?)]
+          [wave-exists? (-> path-string? exact-nonnegative-integer? string? boolean?)]
+          [wave-status-markers (-> (listof pair?))]))
 
 ;; ============================================================
 ;; Constants


### PR DESCRIPTION
## v0.55.3 W3 — GSD Wave-Docs + Archive + Tool-Handlers Contract Precision (#5001)

**wave-docs.rkt:** 14→1 any/c
**archive.rkt:** 8→0 any/c  
**tool-handlers.rkt:** 7→3 any/c

**Metric:** 1215 → 1147 any/c (−68)

All GSD tests pass (archive, command-dispatch, planning-integration, state-machine).