### PR TITLE
feat(v0.55.5 W5): tighten session-mutation + session-fsm contracts (#5003)

### DIFF
--- a/runtime/session-fsm.rkt
+++ b/runtime/session-fsm.rkt
@@ -20,7 +20,9 @@
 (require racket/contract
          (only-in "../util/fsm.rkt"
                   define-fsm-machine
+                  fsm?
                   fsm-state
+                  fsm-state?
                   fsm-state-name
                   fsm-event
                   fsm-event-name
@@ -80,16 +82,16 @@
 (define (session-can-transition? sess event-sym)
   (fsm-valid-transition? session-lifecycle-machine (session-current-state-name sess) event-sym))
 
-(provide (contract-out [session-lifecycle-machine any/c]
+(provide (contract-out [session-lifecycle-machine fsm?]
                        [session-lifecycle-state? (-> any/c boolean?)]
                        [session-lifecycle-event? (-> any/c boolean?)]
-                       [session-lifecycle-terminated any/c]
-                       [session-lifecycle-active any/c]
-                       [session-lifecycle-streaming any/c]
-                       [session-lifecycle-compacting any/c]
-                       [session-lifecycle-idle any/c]
-                       [session-lifecycle-created any/c]
-                       [session-current-state (-> any/c any/c)]
-                       [session-current-state-name (-> any/c symbol?)]
-                       [session-valid-lifecycle? (-> any/c boolean?)]
-                       [session-can-transition? (-> any/c symbol? boolean?)]))
+                       [session-lifecycle-terminated fsm-state?]
+                       [session-lifecycle-active fsm-state?]
+                       [session-lifecycle-streaming fsm-state?]
+                       [session-lifecycle-compacting fsm-state?]
+                       [session-lifecycle-idle fsm-state?]
+                       [session-lifecycle-created fsm-state?]
+                       [session-current-state (-> agent-session? fsm-state?)]
+                       [session-current-state-name (-> agent-session? symbol?)]
+                       [session-valid-lifecycle? (-> agent-session? boolean?)]
+                       [session-can-transition? (-> agent-session? symbol? boolean?)]))

--- a/runtime/session-mutation.rkt
+++ b/runtime/session-mutation.rkt
@@ -9,20 +9,20 @@
          "session-types.rkt"
          (only-in "../util/errors.rkt" raise-session-error))
 
-(provide (contract-out [guarded-set-prompt-running! (-> agent-session? boolean? any/c)]
-                       [guarded-set-compacting! (-> agent-session? boolean? any/c)]
-                       [guarded-set-shutdown-requested! (-> agent-session? boolean? any/c)]
-                       [guarded-set-force-shutdown! (-> agent-session? boolean? any/c)]
-                       [guarded-set-active! (-> agent-session? boolean? any/c)]
-                       [guarded-set-model-name! (-> agent-session? (or/c string? #f) any/c)]
-                       [guarded-set-config! (-> agent-session? any/c any/c)]
-                       [guarded-set-index! (-> agent-session? any/c any/c)]
-                       [guarded-set-persisted! (-> agent-session? boolean? any/c)]
-                       [guarded-set-pending-entries! (-> agent-session? list? any/c)]
-                       [guarded-set-start-time! (-> agent-session? any/c any/c)]
-                       [guarded-set-thinking-level! (-> agent-session? (or/c symbol? #f) any/c)]
-                       [guarded-set-last-compaction-time! (-> agent-session? any/c any/c)]
-                       [valid-session-phase? (-> any/c boolean?)]
+(provide (contract-out [guarded-set-prompt-running! (-> agent-session? boolean? void?)]
+                       [guarded-set-compacting! (-> agent-session? boolean? void?)]
+                       [guarded-set-shutdown-requested! (-> agent-session? boolean? void?)]
+                       [guarded-set-force-shutdown! (-> agent-session? boolean? void?)]
+                       [guarded-set-active! (-> agent-session? boolean? void?)]
+                       [guarded-set-model-name! (-> agent-session? (or/c string? #f) void?)]
+                       [guarded-set-config! (-> agent-session? any/c void?)]
+                       [guarded-set-index! (-> agent-session? any/c void?)]
+                       [guarded-set-persisted! (-> agent-session? boolean? void?)]
+                       [guarded-set-pending-entries! (-> agent-session? list? void?)]
+                       [guarded-set-start-time! (-> agent-session? any/c void?)]
+                       [guarded-set-thinking-level! (-> agent-session? (or/c symbol? #f) void?)]
+                       [guarded-set-last-compaction-time! (-> agent-session? any/c void?)]
+                       [valid-session-phase? (-> symbol? boolean?)]
                        [session-phase (-> agent-session? symbol?)]))
 
 ;; Valid session phases derived from boolean flags


### PR DESCRIPTION
## v0.55.5 W5 — Session-Mutation + Session-FSM Contract Precision (#5003)

**session-mutation.rkt:** 14→4 any/c (all void? returns)
**session-fsm.rkt:** 13→2 any/c (fsm?, fsm-state? types)

**Metric:** 1106 → 1080 any/c (−26)