### PR TITLE
feat(v0.55.7 W7): tighten iteration + compaction contracts (#5005)

### DIFF
--- a/runtime/compaction-hooks.rkt
+++ b/runtime/compaction-hooks.rkt
@@ -16,6 +16,7 @@
 (require racket/contract
          racket/list
          racket/match
+         (only-in "../util/event.rkt" event?)
          "../util/protocol-types.rkt"
          "../util/hook-types.rkt"
          "../agent/event-bus.rkt"
@@ -23,29 +24,52 @@
          "split-turn.rkt"
          "token-compaction.rkt")
 
-(provide (contract-out
-          ;; #697: Enriched hook
-          [build-enriched-compact-payload
-           (->* (list? any/c)
-                (#:previous-summary (or/c #f string?) #:session-id (or/c #f string?))
-                hash?)]
-          [dispatch-enriched-before-compact
-           (->* (any/c list? any/c)
-                (#:previous-summary (or/c #f string?) #:session-id (or/c #f string?))
-                (values any/c hash?))]
-          [maybe-use-custom-summary (-> any/c (or/c string? #f))]
-          ;; #698: Compaction events
-          [publish-compaction-start! (-> any/c any/c any/c any/c string? string? any/c)]
-          [publish-compaction-end!
-           (->* (any/c any/c any/c any/c any/c string? string?)
-                (#:summary-generated? boolean?)
-                any/c)]
-          [compaction-start-topic string?]
-          [compaction-end-topic string?]
-          ;; Event construction helpers
-          [make-compaction-start-event (-> any/c any/c any/c string? string? any/c)]
-          [make-compaction-end-event
-           (->* (any/c any/c any/c any/c string? string?) (#:summary-generated? boolean?) any/c)]))
+;; #697: Enriched hook
+(provide (contract-out [build-enriched-compact-payload
+                        (->* (list? compaction-strategy?)
+                             (#:previous-summary (or/c #f string?) #:session-id (or/c #f string?))
+                             hash?)]
+                       [dispatch-enriched-before-compact
+                        (->* ((or/c any/c #f) list? compaction-strategy?)
+                             (#:previous-summary (or/c #f string?) #:session-id (or/c #f string?))
+                             (values any/c hash?))]
+                       [maybe-use-custom-summary (-> (or/c any/c #f) (or/c string? #f))]
+                       ;; #698: Compaction events
+                       [publish-compaction-start!
+                        (-> (or/c event-bus? #f)
+                            (or/c symbol? #f)
+                            exact-nonnegative-integer?
+                            exact-nonnegative-integer?
+                            string?
+                            string?
+                            (or/c event? void?))]
+                       [publish-compaction-end!
+                        (->* ((or/c event-bus? #f) (or/c symbol? #f)
+                                                   exact-nonnegative-integer?
+                                                   exact-nonnegative-integer?
+                                                   exact-nonnegative-integer?
+                                                   string?
+                                                   string?)
+                             (#:summary-generated? boolean?)
+                             (or/c event? void?))]
+                       [compaction-start-topic string?]
+                       [compaction-end-topic string?]
+                       ;; Event construction helpers
+                       [make-compaction-start-event
+                        (-> (or/c symbol? #f)
+                            exact-nonnegative-integer?
+                            exact-nonnegative-integer?
+                            string?
+                            string?
+                            event?)]
+                       [make-compaction-end-event
+                        (->* ((or/c symbol? #f) exact-nonnegative-integer?
+                                                exact-nonnegative-integer?
+                                                exact-nonnegative-integer?
+                                                string?
+                                                string?)
+                             (#:summary-generated? boolean?)
+                             event?)]))
 
 ;; ============================================================
 ;; Constants

--- a/runtime/iteration/directive.rkt
+++ b/runtime/iteration/directive.rkt
@@ -16,16 +16,16 @@
          directive-stop
          directive-yield
          (contract-out [directive-recurse? (-> any/c boolean?)]
-                       [directive-recurse-new-ctx (-> directive-recurse? any/c)]
-                       [directive-recurse-new-counters (-> directive-recurse? any/c)]
-                       [directive-recurse-ws (-> directive-recurse? any/c)]
+                       [directive-recurse-new-ctx (-> directive-recurse? list?)]
+                       [directive-recurse-new-counters (-> directive-recurse? hash?)]
+                       [directive-recurse-ws (-> directive-recurse? (or/c any/c #f))]
                        [directive-stop? (-> any/c boolean?)]
                        [directive-stop-result (-> directive-stop? any/c)]
                        [directive-yield? (-> any/c boolean?)]
-                       [directive-yield-events (-> directive-yield? any/c)]
-                       [directive-yield-new-ctx (-> directive-yield? any/c)]
-                       [directive-yield-new-counters (-> directive-yield? any/c)]
-                       [directive-yield-ws (-> directive-yield? any/c)]
+                       [directive-yield-events (-> directive-yield? list?)]
+                       [directive-yield-new-ctx (-> directive-yield? list?)]
+                       [directive-yield-new-counters (-> directive-yield? hash?)]
+                       [directive-yield-ws (-> directive-yield? (or/c any/c #f))]
                        [step-directive? (-> any/c boolean?)]))
 
 (struct directive-recurse (new-ctx new-counters ws) #:transparent)

--- a/runtime/iteration/loop-config.rkt
+++ b/runtime/iteration/loop-config.rkt
@@ -106,20 +106,20 @@
          loop-config-working-set
          loop-config-session
          (contract-out [make-loop-config
-                        (->* ((listof any/c) (or/c any/c #f)
-                                             any/c
-                                             (or/c any/c #f)
-                                             (or/c any/c #f)
+                        (->* ((listof any/c) (or/c provider? #f)
+                                             event-bus?
+                                             (or/c tool-registry? #f)
+                                             (or/c extension-registry? #f)
                                              (or/c path-string? path?)
                                              string?
                                              exact-nonnegative-integer?)
-                             (#:cancellation-token (or/c any/c #f)
-                              #:config any/c
+                             (#:cancellation-token (or/c cancellation-token? #f)
+                              #:config (or/c session-config? #f)
                               #:queue (or/c any/c #f)
                               #:follow-up-delivery-mode (or/c 'all 'one-at-a-time)
                               #:injected-box (or/c box? #f)
                               #:shutdown-check (or/c procedure? #f)
                               #:force-shutdown-check (or/c procedure? #f)
-                              #:working-set (or/c any/c #f)
-                              #:session (or/c any/c #f))
+                              #:working-set (or/c working-set? #f)
+                              #:session (or/c agent-session? #f))
                              loop-config?)]))

--- a/runtime/iteration/tool-turn-bridge.rkt
+++ b/runtime/iteration/tool-turn-bridge.rkt
@@ -28,10 +28,10 @@
          (only-in "../../util/event-types.rkt" injection-event-topic)
          (only-in "../../util/shared.rkt" take-at-most))
 
-(provide (contract-out [extract-tool-target-path (-> any/c any/c)]
+(provide (contract-out [extract-tool-target-path (-> any/c (or/c path-string? #f))]
                        [take-at-most (-> list? exact-nonnegative-integer? list?)]
-                       [update-seen-paths (-> list? list? (values list? any/c))]
-                       [update-working-set-after-tools! (-> any/c list? list? any/c)]
+                       [update-seen-paths (-> list? list? (values list? boolean?))]
+                       [update-working-set-after-tools! (-> (or/c any/c #f) list? list? void?)]
                        [count-tool-errors (-> (listof any/c) exact-nonnegative-integer?)]
                        [compute-tool-counters
                         (-> list?
@@ -41,8 +41,8 @@
                        [detect-read-spiral (-> list? any/c (listof string?))]
                        [extract-last-assistant-text (-> list? any/c)]
                        [dequeue-all-steering! (-> any/c list?)]
-                       [drain-injected-messages! (-> any/c any/c any/c (listof any/c))]
-                       [make-injected-collector! (-> any/c any/c)]))
+                       [drain-injected-messages! (-> any/c any/c any/c list?)]
+                       [make-injected-collector! (-> any/c procedure?)]))
 
 ;; Extract the target file path from a tool call's arguments.
 (define (extract-tool-target-path tc)


### PR DESCRIPTION
## v0.55.7 W7 — Iteration + Compaction Contract Precision (#5005)

**directive.rkt:** 12→7, **tool-turn-bridge.rkt:** 9→8, **loop-config.rkt:** 9→2, **compaction-hooks.rkt:** 9→3

**Metric:** 1067 → 1027 any/c (−40)