### PR TITLE
feat(v0.55.10 W10): tighten tui keymap + keybindings + render-loop contracts (#5008)

### DIFF
--- a/tui/keymap.rkt
+++ b/tui/keymap.rkt
@@ -21,26 +21,29 @@
          key-spec-ctrl
          key-spec-shift
          key-spec-alt
-         (contract-out [keycode->key-spec (-> any/c #:ctrl any/c #:shift any/c #:alt any/c any/c)]
-                       [key-spec->keycode (-> key-spec? symbol?)]
-                       [key-spec=? (-> key-spec? key-spec? boolean?)]
-                       [parse-key-string (-> string? key-spec?)]
-                       [make-keymap (-> any/c)]
-                       [keymap-add! (-> any/c key-spec? symbol? void?)]
-                       [keymap-remove! (-> any/c key-spec? void?)]
-                       [keymap-lookup (-> any/c key-spec? any/c)]
-                       [keymap-list (-> any/c (listof any/c))]
-                       [keymap-find-conflicts (-> any/c (listof any/c))]
-                       [keymap-merge (-> any/c any/c void?)]
-                       [default-keymap (-> any/c)]
-                       [load-user-keymap (-> any/c)]
-                       [load-keybindings (->* [] [any/c] any/c)]
-                       [shortcut-specs->keymap (-> (listof hash?) any/c)]
-                       ;; #1189: Namespaced actions
-                       [namespaced-action? (-> any/c boolean?)]
-                       [namespace-action (->* () #:rest any/c symbol?)]
-                       [migrate-action (-> symbol? symbol?)]
-                       [parse-keybindings-content (->* (string?) (any/c) any/c)]))
+         keymap?
+         (contract-out
+          [keycode->key-spec
+           (-> (or/c string? symbol?) #:ctrl boolean? #:shift boolean? #:alt boolean? key-spec?)]
+          [key-spec->keycode (-> key-spec? symbol?)]
+          [key-spec=? (-> key-spec? key-spec? boolean?)]
+          [parse-key-string (-> string? key-spec?)]
+          [make-keymap (-> keymap?)]
+          [keymap-add! (-> keymap? key-spec? symbol? void?)]
+          [keymap-remove! (-> keymap? key-spec? void?)]
+          [keymap-lookup (-> keymap? key-spec? (or/c symbol? #f))]
+          [keymap-list (-> keymap? (listof (cons/c key-spec? symbol?)))]
+          [keymap-find-conflicts (-> keymap? (listof (list/c key-spec? (listof symbol?))))]
+          [keymap-merge (-> keymap? keymap? void?)]
+          [default-keymap (-> keymap?)]
+          [load-user-keymap (-> (or/c keymap? #f))]
+          [load-keybindings (->* [] [keymap?] (or/c keymap? #f))]
+          [shortcut-specs->keymap (-> (listof hash?) keymap?)]
+          ;; #1189: Namespaced actions
+          [namespaced-action? (-> any/c boolean?)]
+          [namespace-action (->* () #:rest any/c symbol?)]
+          [migrate-action (-> symbol? symbol?)]
+          [parse-keybindings-content (->* (string?) (any/c) any/c)]))
 
 ;; ============================================================
 ;; Key specification

--- a/tui/tui-keybindings.rkt
+++ b/tui/tui-keybindings.rkt
@@ -79,7 +79,7 @@
          mode-overlay->keymap
          (contract-out [make-tui-ctx
                         (->* ()
-                             (#:event-bus any/c
+                             (#:event-bus (or/c event-bus? #f)
                                           #:session-runner procedure?
                                           #:session-dir (or/c path-string? #f)
                                           #:model-registry any/c
@@ -88,14 +88,15 @@
                                           #:session-factory-runner any/c)
                              tui-ctx?)]
                        [mark-dirty! (-> tui-ctx? void?)]
-                       [handle-key (-> tui-ctx? any/c any/c)]
-                       [handle-mouse (-> tui-ctx? any/c any/c)]
-                       [selection-text (-> tui-ctx? any/c (or/c string? #f))]
+                       [handle-key (-> tui-ctx? any/c (values tui-ctx? any/c))]
+                       [handle-mouse (-> tui-ctx? any/c tui-ctx?)]
+                       [selection-text (-> tui-ctx? ui-state? (or/c string? #f))]
                        [process-slash-command
-                        (->* (tui-ctx? (or/c string? symbol? parsed-command?)) (string?) any/c)]
-                       [tui-ctx->cmd-ctx (-> tui-ctx? any/c)]
+                        (->* (tui-ctx? (or/c string? symbol? parsed-command?)) (string?) tui-ctx?)]
+                       [tui-ctx->cmd-ctx (-> tui-ctx? hash?)]
                        [reload-keymap! (-> void?)]
-                       [current-keybindings-path (->* () ((or/c path-string? #f)) any/c)]
+                       [current-keybindings-path
+                        (->* () ((or/c path-string? #f)) (or/c path-string? #f))]
                        [input-expand-last-prompt (-> string? tui-ctx? string?)]))
 
 ;; ============================================================

--- a/tui/tui-render-loop.rkt
+++ b/tui/tui-render-loop.rkt
@@ -44,18 +44,19 @@
          decode-mouse-x10
          decode-mouse-tui-term
          current-busy-watchdog-ms
-         (contract-out [check-busy-watchdog (-> any/c number? number? (or/c any/c #f))]
-                       [render-ubuf-to-terminal! (-> any/c void?)]
-                       [tui-ctx-init-terminal! (-> any/c void?)]
-                       [tui-ctx-resize-ubuf! (-> any/c void?)]
-                       [tui-ctx-ubuf (-> any/c any/c)]
-                       [tui-ctx-term (-> any/c any/c)]
-                       [render-frame! (-> any/c void?)]
-                       [draw-frame (-> any/c void?)]
-                       [next-message (->* (any/c) (#:timeout any/c) (or/c any/c #f))]
-                       [tui-main-loop (-> any/c void?)]
-                       [drain-events! (-> any/c void?)]
-                       [handle-user-submit! (-> any/c string? any/c)]))
+         (contract-out [check-busy-watchdog
+                        (-> tui-ctx? number? number? (or/c (list/c number? number?) #f))]
+                       [render-ubuf-to-terminal! (-> tui-ctx? void?)]
+                       [tui-ctx-init-terminal! (-> tui-ctx? void?)]
+                       [tui-ctx-resize-ubuf! (-> tui-ctx? void?)]
+                       [tui-ctx-ubuf (-> tui-ctx? any/c)]
+                       [tui-ctx-term (-> tui-ctx? any/c)]
+                       [render-frame! (-> tui-ctx? void?)]
+                       [draw-frame (-> tui-ctx? void?)]
+                       [next-message (->* (tui-ctx?) (#:timeout number?) (or/c any/c #f))]
+                       [tui-main-loop (-> tui-ctx? void?)]
+                       [drain-events! (-> tui-ctx? void?)]
+                       [handle-user-submit! (-> tui-ctx? string? tui-ctx?)]))
 
 ;; ============================================================
 ;; Ubuf FFI/stubs


### PR DESCRIPTION
## v0.55.10 W10 — TUI Keymap + Keybindings + Render-Loop Contracts (#5008)

**keymap.rkt:** 15→3, **tui-keybindings.rkt:** 11→6, **tui-render-loop.rkt:** 12→3

**Metric:** 952 → 910 any/c (−42)