### PR TITLE
fix(v0.55.1 W2): P1 type mismatches — gsd-write-guard + tree-view contracts (#5031)

### DIFF
--- a/extensions/gsd/core.rkt
+++ b/extensions/gsd/core.rkt
@@ -37,7 +37,12 @@
                   make-gsd-command-received-event
                   make-gsd-command-completed-event
                   make-gsd-archive-failed-event)
-         (only-in "policy.rkt" gsd-decide-action policy-allowed? policy-blocked? policy-reason)
+         (only-in "policy.rkt"
+                  gsd-decide-action
+                  policy-allowed?
+                  policy-blocked?
+                  policy-reason
+                  policy-decision?)
          (only-in "session-state.rkt"
                   current-pinned-dir
                   set-pinned-dir!
@@ -59,7 +64,7 @@
          ;; Functions (contracted)
          (contract-out [gsd-command-dispatch
                         (-> (or/c symbol? string?) any/c (or/c gsd-command-result? #f))]
-                       [gsd-write-guard (-> path-string? path-string? gsd-command-result?)]
+                       [gsd-write-guard (-> path-string? path-string? policy-decision?)]
                        [gsd-show-status (-> gsd-command-result?)]
                        [cmd-replan (-> gsd-command-result?)]
                        [cmd-skip (-> any/c gsd-command-result?)]

--- a/tui/tree-view.rkt
+++ b/tui/tree-view.rkt
@@ -35,7 +35,7 @@
                                     #:bookmarks (or/c hash? #f))
                 (listof string?))]
           [make-tree-node
-           (->* ((or/c string? #f) string? string? exact-nonnegative-integer? (listof any/c))
+           (->* ((or/c string? #f) (or/c string? symbol?) string? exact-nonnegative-integer? (listof any/c))
                 ((or/c number? #f))
                 tree-node?)]
           [build-tree-nodes (-> (listof any/c) (listof list?))]
@@ -43,8 +43,8 @@
           [tree-next-node (-> (listof any/c) exact-integer? exact-integer?)]
           [tree-prev-node (-> (listof any/c) exact-integer? exact-integer?)]
           [tree-toggle-fold (-> (set/c string?) (or/c string? #f) (set/c string?))]
-          [tree-enter-node (-> (listof any/c) exact-integer? (or/c string? #f) any/c)]
-          [would-abandon-branch? (-> (listof list?) (set/c string?) (or/c string? #f) boolean?)]))
+          [tree-enter-node (-> (listof any/c) exact-integer? (set/c string?) (set/c string?))]
+          [would-abandon-branch? (-> (listof list?) (or/c string? #f) (or/c string? #f) boolean?)]))
 
 ;; ============================================================
 ;; Tree node struct


### PR DESCRIPTION
## W2: Fix P1 type mismatches (#5031)

- `gsd-write-guard`: return type `policy-decision?` (was `gsd-command-result?`)
- `tree-enter-node`: 3rd arg `(set/c string?)`, return `(set/c string?)`
- `make-tree-node`: role accepts `(or/c string? symbol?)`
- `would-abandon-branch?`: 2nd arg `(or/c string? #f)` (was `(set/c string?)`)