### PR TITLE
fix(v0.55.3 W2): /plan no-op hardening — explicit error when no runner (#5043)

### DIFF
--- a/tests/test-process-extension-command.rkt
+++ b/tests/test-process-extension-command.rkt
@@ -45,3 +45,17 @@
   (define cctx (make-test-cctx "/unknown-command arg1"))
   (define result (process-extension-command cctx (initial-ui-state)))
   (check-equal? result 'continue))
+
+;; P1 regression: submit with no runner should produce visible error
+;; Test the execute-extension-command indirectly by mocking the hook result.
+;; When runner=#f and submit payload arrives, transcript must grow.
+(test-case "execute-extension-command submit with no runner shows error"
+  (define cctx (make-test-cctx "/plan test task"))
+  (define initial-transcript (ui-state-transcript (unbox (cmd-ctx-state-box cctx))))
+  ;; Simulate what process-extension-command does on amend with submit payload
+  (execute-extension-command cctx
+                             (unbox (cmd-ctx-state-box cctx))
+                             (hasheq 'submit "plan the project" 'text "Planning: test task"))
+  (define updated-transcript (ui-state-transcript (unbox (cmd-ctx-state-box cctx))))
+  (check > (length updated-transcript) (length initial-transcript)
+         "submit with no runner should add error to transcript"))

--- a/tui/commands.rkt
+++ b/tui/commands.rkt
@@ -75,6 +75,7 @@
          ;; Main command dispatcher
          process-slash-command
          process-extension-command
+         execute-extension-command
          cmd-ctx-session-factory-runner)
 
 ;; ============================================================
@@ -124,36 +125,60 @@
              (factory new-session-text))))]
        [else
         (define runner (cmd-ctx-session-runner cctx))
-        (when runner
-          (thread
-           (lambda ()
-             (with-handlers
-                 ([exn:fail?
-                   (lambda (e)
-                     (define err-msg (format "[ERROR] Session runner failed: ~a" (exn-message e)))
-                     (define entry (make-entry 'system err-msg (current-inexact-milliseconds) (hash)))
-                     (set-box! (cmd-ctx-state-box cctx)
-                               (add-transcript-entry (unbox (cmd-ctx-state-box cctx)) entry))
-                     (set-box! (cmd-ctx-needs-redraw-box cctx) #t))])
-               (runner new-session-text)))))])]
+        (cond
+          [runner
+           (thread (lambda ()
+                     (with-handlers
+                         ([exn:fail?
+                           (lambda (e)
+                             (define err-msg
+                               (format "[ERROR] Session runner failed: ~a" (exn-message e)))
+                             (define entry
+                               (make-entry 'system err-msg (current-inexact-milliseconds) (hash)))
+                             (set-box! (cmd-ctx-state-box cctx)
+                                       (add-transcript-entry (unbox (cmd-ctx-state-box cctx)) entry))
+                             (set-box! (cmd-ctx-needs-redraw-box cctx) #t))])
+                       (runner new-session-text))))]
+          [else
+           ;; P1 hardening: no runner/factory available — show explicit error
+           (define err-entry
+             (make-entry
+              'system
+              "[ERROR] No session runner or factory available. The session may not be fully initialized."
+              (current-inexact-milliseconds)
+              (hash)))
+           (set-box! (cmd-ctx-state-box cctx)
+                     (add-transcript-entry (unbox (cmd-ctx-state-box cctx)) err-entry))
+           (set-box! (cmd-ctx-needs-redraw-box cctx) #t)])])]
     [submit-text
      (when display-text
        (define entry (make-system-entry display-text))
        (set-box! (cmd-ctx-state-box cctx)
                  (add-transcript-entry (unbox (cmd-ctx-state-box cctx)) entry)))
      (define runner (cmd-ctx-session-runner cctx))
-     (when runner
-       (thread
-        (lambda ()
-          (with-handlers ([exn:fail?
-                           (lambda (e)
-                             (define err-msg (format "[ERROR] Prompt failed: ~a" (exn-message e)))
-                             (define entry
-                               (make-entry 'system err-msg (current-inexact-milliseconds) (hash)))
-                             (set-box! (cmd-ctx-state-box cctx)
-                                       (add-transcript-entry (unbox (cmd-ctx-state-box cctx)) entry))
-                             (set-box! (cmd-ctx-needs-redraw-box cctx) #t))])
-            (runner submit-text)))))]
+     (cond
+       [runner
+        (thread
+         (lambda ()
+           (with-handlers ([exn:fail?
+                            (lambda (e)
+                              (define err-msg (format "[ERROR] Prompt failed: ~a" (exn-message e)))
+                              (define entry
+                                (make-entry 'system err-msg (current-inexact-milliseconds) (hash)))
+                              (set-box! (cmd-ctx-state-box cctx)
+                                        (add-transcript-entry (unbox (cmd-ctx-state-box cctx)) entry))
+                              (set-box! (cmd-ctx-needs-redraw-box cctx) #t))])
+             (runner submit-text))))]
+       [else
+        ;; P1 hardening: /plan no-op — when no runner available, show explicit error
+        (define err-entry
+          (make-entry 'system
+                      "[ERROR] No session runner available. The session may not be fully initialized."
+                      (current-inexact-milliseconds)
+                      (hash)))
+        (set-box! (cmd-ctx-state-box cctx)
+                  (add-transcript-entry (unbox (cmd-ctx-state-box cctx)) err-entry))
+        (set-box! (cmd-ctx-needs-redraw-box cctx) #t)])]
     [display-text
      (define entry (make-system-entry display-text))
      (set-box! (cmd-ctx-state-box cctx)


### PR DESCRIPTION
## W2: P1 fix — /plan no-op hardening (#5043)

- `submit-text` branch: explicit error when `session-runner` is `#f` (was silent no-op)
- `new-session-text` else branch: explicit error when no factory or runner
- Export `execute-extension-command` for testability
- Added regression test: 5 tests pass