### PR TITLE
fix(v0.55.4 W2): align effect:update-fsm contract with FSM struct usage (#5050)

### DIFF
--- a/agent/effect-types.rkt
+++ b/agent/effect-types.rkt
@@ -10,10 +10,11 @@
 ;; Also defines streaming-plan — pure computation result for the
 ;; streaming phase (v0.47.2).
 
-(require racket/contract)
+(require racket/contract
+         (only-in "../util/fsm.rkt" fsm-state? fsm-event?))
 
 (provide (contract-out (struct effect:emit-event ([type symbol?] [payload any/c])))
-         (contract-out (struct effect:update-fsm ([from-state symbol?] [event symbol?])))
+         (contract-out (struct effect:update-fsm ([from-state fsm-state?] [event fsm-event?])))
          (contract-out (struct effect:dispatch-hook ([hook-point symbol?] [payload any/c])))
          (contract-out (struct effect:none ()))
          (contract-out (struct streaming-plan

--- a/tests/test-effect-types.rkt
+++ b/tests/test-effect-types.rkt
@@ -5,7 +5,9 @@
 
 (require rackunit
          rackunit/text-ui
-         "../agent/effect-types.rkt")
+         "../agent/effect-types.rkt"
+         "../agent/loop-fsm.rkt"
+         (only-in "../util/fsm.rkt" fsm-state-name fsm-event-name))
 
 (define effect-types-tests
   (test-suite "effect-types"
@@ -19,10 +21,11 @@
       (check-equal? (effect:emit-event-type e) 'turn-start)
       (check-true (hash? (effect:emit-event-payload e))))
 
-    (test-case "effect:update-fsm construction"
-      (define e (effect:update-fsm 'emit-start 'turn-start))
-      (check-equal? (effect:update-fsm-from-state e) 'emit-start)
-      (check-equal? (effect:update-fsm-event e) 'turn-start))
+    (test-case "effect:update-fsm construction with FSM structs"
+      (define e (effect:update-fsm turn-state-emit-start turn-event-start))
+      (check-true (effect:update-fsm? e))
+      (check-equal? (fsm-state-name (effect:update-fsm-from-state e)) 'emit-start)
+      (check-equal? (fsm-event-name (effect:update-fsm-event e)) 'start))
 
     (test-case "effect:dispatch-hook construction"
       (define e (effect:dispatch-hook 'agent-start (hasheq)))
@@ -31,13 +34,13 @@
     (test-case "effect predicates"
       (check-true (effect:none? (effect:none)))
       (check-true (effect:emit-event? (effect:emit-event 'test #f)))
-      (check-true (effect:update-fsm? (effect:update-fsm 'a 'b)))
+      (check-true (effect:update-fsm? (effect:update-fsm turn-state-emit-start turn-event-start)))
       (check-true (effect:dispatch-hook? (effect:dispatch-hook 'test #f))))
 
     (test-case "effect? contract accepts all variants"
       (for ([e (list (effect:none)
                      (effect:emit-event 'x #f)
-                     (effect:update-fsm 'a 'b)
+                     (effect:update-fsm turn-state-emit-start turn-event-start)
                      (effect:dispatch-hook 'c #f))])
         (check-true (effect? e))))))
 


### PR DESCRIPTION
## W2: Fix effect:update-fsm contract to accept fsm-state?/fsm-event? (#5050)

Updates `effect:update-fsm` contract in `agent/effect-types.rkt` to match actual call-site usage in `agent/loop-phases.rkt`:
- `from-state`: `symbol?` → `fsm-state?`
- `event`: `symbol?` → `fsm-event?`

Imports `fsm-state?` and `fsm-event?` from `../util/fsm.rkt`.

Also updates `tests/test-effect-types.rkt` to construct `effect:update-fsm` with FSM structs instead of raw symbols.

**Verification:**
- Regression tests: 3/3 pass (`test-effect-update-fsm-contract.rkt`)
- Effect types tests: 6/6 pass (`test-effect-types.rkt`)
- Original reproduction now succeeds