### PR TITLE
fix(v0.55.6 W1): GSD planning write-guard path contract (#5064)

### DIFF
--- a/extensions/gsd/tool-handlers.rkt
+++ b/extensions/gsd/tool-handlers.rkt
@@ -196,7 +196,7 @@
      (define guard-arg (and art-path (path->string art-path)))
      (define guard-result
        (if guard-arg
-           (gsd-write-guard guard-arg (current-pinned-dir))
+           (gsd-write-guard guard-arg (or (current-pinned-dir) base-dir))
            (policy-decision #t #f '())))
      (match (policy-blocked? guard-result)
        [#t (make-error-result (format "Blocked: ~a" (policy-reason guard-result)))]


### PR DESCRIPTION
## W1: GSD planning path contract fix (#5064)

Fix `gsd-write-guard` contract violation when `current-pinned-dir` is `#f`.

In `handle-planning-write`, pass `(or (current-pinned-dir) base-dir)` instead of bare `(current-pinned-dir)`, since `base-dir` is always a valid path computed by `get-base-dir`.

### Verification
- `raco test tests/test-gsd-planning.rkt` → **94/94 pass** (was 4 failures)