### PR TITLE
fix(v0.55.6 W2): bash allowlist contract strict boolean (#5065)

### DIFF
--- a/tools/builtins/bash.rkt
+++ b/tools/builtins/bash.rkt
@@ -119,7 +119,7 @@
     [(warn block) #t] ; warn/block handled by destructive checks
     [(allowlist)
      (define base (extract-base-command command))
-     (member base (current-allowed-commands))]
+     (and (member base (current-allowed-commands)) #t)]
     [else #t])) ; unknown policy defaults to allow
 
 ;; Destructive command patterns (SEC-03, #449)
@@ -265,7 +265,7 @@
          [(warn block) #t]
          [(allowlist)
           (define base (extract-base-command cmd))
-          (member base (current-allowed-commands))]
+          (and (member base (current-allowed-commands)) #t)]
          [else #t]))
      (cond
        [(not (policy-allows? command))


### PR DESCRIPTION
## W2: Bash allowlist contract strict boolean (#5065)

`execution-policy-allows?` returned the list tail from `(member ...)` instead of a strict boolean, violating its `(-> string? boolean?)` contract.

Fixed by wrapping with `(and ... #t)` in both the exported function and the local `policy-allows?` inside `tool-bash`.

### Verification
- `raco test tests/test-tool-bash-security.rkt` → **41/41 pass** (was 2 failures)