### PR TITLE
fix(v0.55.6 W3): runner context compatibility for entrypoint tests (#5066)

### DIFF
--- a/tests/test-main-entrypoint.rkt
+++ b/tests/test-main-entrypoint.rkt
@@ -10,9 +10,10 @@
          racket/system
          racket/port
          racket/string
+         racket/runtime-path
          (only-in "../interfaces/cli.rkt" parse-cli-args))
 
-(define q-bin "./bin/q")
+(define-runtime-path q-bin "../bin/q")
 
 (define (run-main . args)
   "Run q via bin/q wrapper as subprocess, return (values exit-code stdout stderr)"


### PR DESCRIPTION
## W3: Runner context compatibility for entrypoint tests (#5066)

`test-main-entrypoint.rkt` used relative path `./bin/q` which fails under `raco test` because the working directory differs from the source file location.

Fixed by using `racket/runtime-path` `define-runtime-path` to resolve `../bin/q` relative to the test file location.

### Verification
- `raco test tests/test-main-entrypoint.rkt` → **4/4 pass** (was 3 failures)