### PR TITLE
release(v0.55.6): Full-Suite Recovery (#5067)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## v0.55.6 — 2026-05-23
+
+### Full-Suite Recovery
+
+**P0 (GSD planning write-guard contract violation):**
+- `extensions/gsd/tool-handlers.rkt`: `handle-planning-write` now passes `(or (current-pinned-dir) base-dir)` to `gsd-write-guard` instead of bare `(current-pinned-dir)`, which could be `#f` and violate the `path-string?` contract
+
+**P0 (bash allowlist contract strict boolean):**
+- `tools/builtins/bash.rkt`: `execution-policy-allows?` wrapped `member` result with `(and ... #t)` to return strict `boolean?` instead of list tail, fixing self-contract breakage in `allowlist` mode
+- Same fix applied to local `policy-allows?` inside `tool-bash`
+
+**P1 (runner context compatibility):**
+- `tests/test-main-entrypoint.rkt`: Replaced relative `./bin/q` with `define-runtime-path` to resolve `../bin/q` relative to the test file, fixing failures under `raco test`
+
+**Verification:**
+- `raco test tests/test-gsd-planning.rkt` → 94/94 pass
+- `raco test tests/test-tool-bash-security.rkt` → 41/41 pass
+- `raco test tests/test-main-entrypoint.rkt` → 4/4 pass
+- `racket scripts/lint-all.rkt` → 19/19 pass
+
 ## v0.55.5 — 2026-05-23
 
 ### Test Runner False-Green Fix

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.55.5-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.55.6-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 
@@ -203,7 +203,7 @@ bin/q --model gpt-5.4 "write a test"
 ### Verify
 
 ```bash
-bin/q --version            # q version 0.55.5
+bin/q --version            # q version 0.55.6
 raco test tests/           # run the full test suite
 ```
 
@@ -277,7 +277,7 @@ q/
 | Test files | 622 |
 | Source modules | 445 |
 | Source lines | 69236 |
-| Test lines | 106897 |
+| Test lines | 106898 |
 | Test assertions | 16656 |
 | Tests passing | 5835+ | `racket scripts/run-tests.rkt` results |
 
@@ -443,6 +443,9 @@ When q executes shell commands on behalf of an LLM, arguments are quoted via `sh
 
 
 
+
+
+**v0.55.6** — Full-Suite Recovery
 
 **v0.55.5** — Test Runner False-Green Fix
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -2,7 +2,7 @@
 
 ## Version
 
-v0.55.5
+v0.55.6
 
 ## Layer Diagram
 

--- a/docs/event-taxonomy.md
+++ b/docs/event-taxonomy.md
@@ -1,6 +1,6 @@
 # Q Event Taxonomy Reference
 
-Complete reference for all event types in Q 0.55.5.
+Complete reference for all event types in Q 0.55.6.
 ## Base Types
 
 ### `event` (protocol-level)

--- a/docs/extension-guide.md
+++ b/docs/extension-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.55.5 --># Extension Development Guide
+<!-- verified-against: 0.55.6 --># Extension Development Guide
 
 This guide walks you through creating, testing, and activating a custom
 extension for q.

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.55.5 --># Getting Started
+<!-- verified-against: 0.55.6 --># Getting Started
 
 Welcome to q, a Racket-based coding agent.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.55.5 --># Installation Guide
+<!-- verified-against: 0.55.6 --># Installation Guide
 
 <!-- This file is the canonical source. The docs/getting-started/installation.md copy is maintained for the doc site build. -->
 

--- a/docs/security-trust-model.md
+++ b/docs/security-trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.55.5 --># Security & Trust Model
+<!-- verified-against: 0.55.6 --># Security & Trust Model
 
 This document provides an honest, per-area assessment of what q enforces
 today and what is planned. It is the authoritative reference for security

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -130,6 +130,6 @@ is the primary self-hosting extension:
 (load-extension! ext-reg "path/to/extension.rkt" #:event-bus bus)
 ```
 
-## Version 0.55.5
+## Version 0.55.6
 
-This documentation reflects q 0.55.5.
+This documentation reflects q 0.55.6.

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.55.5 --># q Source Style Guide
+<!-- verified-against: 0.55.6 --># q Source Style Guide
 
 This document defines formatting and naming conventions for the q Racket codebase.
 All changes to `q/` source files (excluding `tests/`) should follow these rules.

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.55.5 --># Trust Model
+<!-- verified-against: 0.55.6 --># Trust Model
 
 ## Trust Levels
 

--- a/docs/workflow-testing.md
+++ b/docs/workflow-testing.md
@@ -121,6 +121,6 @@ Use relative paths from the test file:
 4. Use `(check-true ...)` for boolean assertions
 5. Keep tests independent — no shared mutable state between test-cases
 
-## Version 0.55.5
+## Version 0.55.6
 
-This documentation reflects q 0.55.5.
+This documentation reflects q 0.55.6.

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.55.5")
+(define version "0.55.6")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base"))

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -11,4 +11,4 @@
 
 (provide (contract-out [q-version string?]))
 
-(define q-version "0.55.5")
+(define q-version "0.55.6")

--- a/wiki-src/Architecture-Overview.md
+++ b/wiki-src/Architecture-Overview.md
@@ -35,7 +35,7 @@ User input → Interface (CLI/TUI/RPC)
     → Events emitted to bus
 ```
 
-## Metrics (0.55.5)
+## Metrics (0.55.6)
 > _See `racket scripts/metrics.rkt` for current numbers._
 
 - 414 source modules, 534 test files


### PR DESCRIPTION
## W4: Broad regression gate + release v0.55.6 (#5067)

Version bump 0.55.5 → 0.55.6 with CHANGELOG, README sync, and 15 doc files synced.

### Verification
- `raco test tests/test-gsd-planning.rkt` → 94/94 pass
- `raco test tests/test-tool-bash-security.rkt` → 41/41 pass
- `raco test tests/test-main-entrypoint.rkt` → 4/4 pass
- `racket scripts/lint-all.rkt` → **19/19 pass**