### PR TITLE
fix: align context-assembly contracts with runtime message/count types (#5074)

### DIFF
--- a/runtime/context-assembly.rkt
+++ b/runtime/context-assembly.rkt
@@ -40,7 +40,8 @@
                   simple-summary-text
                   simple-summary-count
                   extract-message-text
-                  truncate-string))
+                  truncate-string)
+         (only-in "../util/message.rkt" message?))
 
 ;; Explicit re-exports from sub-modules (S1-F4)
 ;; Struct: context-assembly-config
@@ -167,7 +168,7 @@
            (-> session-index?
                #:max-tokens exact-nonnegative-integer?
                (values list? exact-nonnegative-integer?))]
-          [entry->context-message (-> (or/c hash? #f) (or/c list? #f))]
+          [entry->context-message (-> message? (or/c message? #f))]
           [load-agents-context (-> (or/c path? string?) string?)]
           [build-system-preamble (-> (or/c path? string?) string?)]
           [truncate-messages-to-budget (-> list? exact-nonnegative-integer? list?)])

--- a/runtime/context-assembly/serialization.rkt
+++ b/runtime/context-assembly/serialization.rkt
@@ -61,7 +61,8 @@
 (define (compute-tier-c-count total-messages)
   (min 12 (max 4 (quotient total-messages 50))))
 
-(provide (contract-out [compute-tier-c-count (-> list? exact-nonnegative-integer?)]))
+(provide (contract-out [compute-tier-c-count
+                        (-> exact-nonnegative-integer? exact-nonnegative-integer?)]))
 
 ;; v0.28.21 W4: Dynamic Tier-B sizing
 ;; Scales Tier-B with total message count: min(50, max(20, total/10))


### PR DESCRIPTION
Addresses #5074.

fix: align context-assembly contracts with runtime message/count types (#5074)