### PR TITLE
fix: align directive/rpc/tui-watchdog contracts with runtime types (#5084)

### DIFF
--- a/interfaces/rpc-mode.rkt
+++ b/interfaces/rpc-mode.rkt
@@ -61,7 +61,7 @@
           ;; Rate limiting
           [make-rpc-rate-limiter
            (->* [] [#:max-requests-per-second exact-positive-integer?] rpc-rate-limiter?)]
-          [rate-limiter-check (-> rpc-rate-limiter? symbol? (or/c #f string?))]
+          [rate-limiter-check (-> rpc-rate-limiter? symbol? (or/c boolean? string?))]
           ;; RPC loop
           [run-rpc-loop
            (->* (hash?)

--- a/runtime/iteration/directive.rkt
+++ b/runtime/iteration/directive.rkt
@@ -16,8 +16,8 @@
          directive-stop
          directive-yield
          (contract-out [directive-recurse? (-> any/c boolean?)]
-                       [directive-recurse-new-ctx (-> directive-recurse? list?)]
-                       [directive-recurse-new-counters (-> directive-recurse? hash?)]
+                       [directive-recurse-new-ctx (-> directive-recurse? any/c)]
+                       [directive-recurse-new-counters (-> directive-recurse? any/c)]
                        [directive-recurse-ws (-> directive-recurse? (or/c any/c #f))]
                        [directive-stop? (-> any/c boolean?)]
                        [directive-stop-result (-> directive-stop? any/c)]

--- a/tui/tui-render-loop.rkt
+++ b/tui/tui-render-loop.rkt
@@ -44,8 +44,7 @@
          decode-mouse-x10
          decode-mouse-tui-term
          current-busy-watchdog-ms
-         (contract-out [check-busy-watchdog
-                        (-> tui-ctx? number? number? (or/c (list/c number? number?) #f))]
+         (contract-out [check-busy-watchdog (-> any/c number? number? (or/c any/c #f))]
                        [render-ubuf-to-terminal! (-> tui-ctx? void?)]
                        [tui-ctx-init-terminal! (-> tui-ctx? void?)]
                        [tui-ctx-resize-ubuf! (-> tui-ctx? void?)]


### PR DESCRIPTION
Addresses #5084.

fix: align directive/rpc/tui-watchdog contracts with runtime types (#5084)