### PR TITLE
fix: resolve examples/tooling cluster — duplicate import, multi-value contracts (#5086)

### DIFF
--- a/examples/sdk/06-sessions.rkt
+++ b/examples/sdk/06-sessions.rkt
@@ -2,8 +2,8 @@
 
 ;; examples/sdk/06-sessions.rkt — In-memory sessions, resume, list
 
-(require "../../interfaces/sdk.rkt"
-         "../../runtime/session-manager.rkt")
+(require "../../runtime/session-manager.rkt"
+         (only-in "../../interfaces/sdk-core.rkt" create-agent-session session-info))
 
 (define mgr (make-in-memory-session-manager))
 

--- a/extensions/racket-tooling-helpers.rkt
+++ b/extensions/racket-tooling-helpers.rkt
@@ -13,13 +13,13 @@
          racket/list)
 
 ;; Raco command helpers
-(provide (contract-out [run-raco (->* ((listof any/c)) (any/c) any/c)]
+(provide (contract-out [run-raco (->* ((listof any/c)) (any/c) (values any/c any/c any/c))]
                        [find-raco (-> (or/c path? #f))]
-                       [run-command (->* (any/c (listof any/c)) (any/c) any/c)]
-                       [raco-fmt (-> any/c any/c)]
-                       [raco-make (-> any/c any/c)]
-                       [raco-test (-> any/c any/c)]
-                       [raco-expand (-> any/c any/c)]
+                       [run-command (->* (any/c (listof any/c)) (any/c) (values any/c any/c any/c))]
+                       [raco-fmt (-> any/c (values any/c any/c any/c))]
+                       [raco-make (-> any/c (values any/c any/c any/c))]
+                       [raco-test (-> any/c (values any/c any/c any/c))]
+                       [raco-expand (-> any/c (values any/c any/c any/c))]
                        ;; File I/O helpers
                        [read-file-string (-> any/c string?)]
                        [write-file-string! (-> any/c any/c any/c)]
@@ -29,7 +29,8 @@
                        [read-all-forms (-> string? (listof any/c))]
                        [form->string (-> any/c string?)]
                        [find-form-boundaries (-> string? (listof any/c))]
-                       [find-form-end (-> (listof string?) exact-nonnegative-integer? any/c)]
+                       [find-form-end
+                        (-> (listof string?) exact-nonnegative-integer? (values any/c any/c))]
                        ;; Pattern matching and template substitution
                        [pattern-matches? (-> any/c any/c boolean?)]
                        [apply-template (-> any/c any/c any/c any/c)]


### PR DESCRIPTION
Addresses #5086.

fix: resolve examples/tooling cluster — duplicate import, multi-value contracts (#5086)