### PR TITLE
feat(W0): recursive architecture boundary baseline (#5106)

- Add rkt-files-in-recursive helper to arch-utils for subdirectory scanning
- Update boundary test to scan runtime/ recursively (catches iteration/* submodules)
- Document 5 previously-invisible upward imports in dependency-policy.rktd:
  - runtime/iteration/loop-config.rkt (tool-registry, extension-registry)
  - runtime/iteration/loop-phases.rkt (extension-registry)
  - runtime/iteration/main-loop.rkt (tool-registry, extension-registry)
  - runtime/iteration/step-interpreter.rkt (permission-gate)
  - runtime/layer-adapters.rkt (adapter facade)
- Bump runtime max-exceptions from 10 to 16 to accommodate discovered exceptions
- Add test proving recursive scan is strict superset of flat scan

Wave 0 of v0.57.0.

### DIFF
--- a/docs/architecture/dependency-policy.rktd
+++ b/docs/architecture/dependency-policy.rktd
@@ -10,11 +10,11 @@
 
 ;; Layer definitions with max boundary exceptions
 ((layers (runtime
-          (max-exceptions . 10)
+          (max-exceptions . 16)
           (forbidden-from . (llm tools extensions))
           (rationale
            .
-           "Runtime should not import upward into tools/extensions except via turn-orchestrator.rkt"))
+           "Runtime should not import upward into tools/extensions except via documented exceptions (includes iteration/ submodules and layer-adapters)"))
          (tui (max-exceptions . 0)
               (forbidden-from . (llm tools))
               (allowed-from . (runtime agent extensions util)))
@@ -29,6 +29,16 @@
  (known-exceptions
   (runtime . ((agent-session.rkt . "extension registry + DI parameter setup")
               (iteration/loop-state.rkt . "typed require from extensions/api.rkt for opaque ExtRegistry")
+              (iteration/loop-config.rkt
+               . "typed require of tool-registry? and extension-registry? for loop config")
+              (iteration/loop-phases.rkt
+               . "typed require of extension-registry? for phase dispatch")
+              (iteration/main-loop.rkt
+               . "typed require of tool-registry? and extension-registry? for main loop")
+              (iteration/step-interpreter.rkt
+               . "typed require of permission-config? for step-level permission checks")
+              (layer-adapters.rkt
+               . "explicit adapter facade routing tool/extension deps behind contained boundary")
               (session-lifecycle.rkt
                . "injection-event-topic import (extracted from agent-session/iteration)")
               (runtime-helpers.rkt . "hook dispatch for session events")

--- a/tests/helpers/arch-utils.rkt
+++ b/tests/helpers/arch-utils.rkt
@@ -21,7 +21,8 @@
          line-count
          char-count
          count-provides
-         q-dir)
+         q-dir
+         rkt-files-in-recursive)
 
 ;; ============================================================
 ;; Read-based S-expression require parser
@@ -91,6 +92,18 @@
   (if (directory-exists? (build-path q-dir dir))
       (filter (λ (f) (regexp-match? #rx"\\.rkt$" (path->string f)))
               (directory-list (build-path q-dir dir) #:build? #t))
+      '()))
+
+;; Recursive variant — includes files in subdirectories.
+(define (rkt-files-in-recursive dir)
+  (define base (build-path q-dir dir))
+  (if (directory-exists? base)
+      (let loop ([path base])
+        (append* (for/list ([f (in-list (directory-list path #:build? #t))])
+                   (cond
+                     [(directory-exists? f) (loop f)]
+                     [(regexp-match? #rx"\\.rkt$" (path->string f)) (list f)]
+                     [else '()]))))
       '()))
 
 (define (line-count filepath)

--- a/tests/test-arch-boundaries.rkt
+++ b/tests/test-arch-boundaries.rkt
@@ -37,20 +37,32 @@
   (test-suite "architecture-boundaries"
 
     (test-case "Only known exceptions in runtime/ import from tools/ or extensions/"
-      (define runtime-files (rkt-files-in "runtime"))
+      ;; Use recursive scan to include subdirectory modules (runtime/iteration/*, etc.)
+      (define runtime-files (rkt-files-in-recursive "runtime"))
       (define runtime-exc (policy-ref 'known-exceptions 'runtime))
+      ;; Build set of known exception RELATIVE paths (e.g. "runtime/iteration/loop-config.rkt")
       (define known-exceptions
-        (map (λ (s)
-               (if (symbol? s)
-                   (symbol->string s)
-                   s))
-             (map car runtime-exc)))
+        (for/fold ([acc (set)]) ([entry (in-list runtime-exc)])
+          (define name
+            (if (symbol? (car entry))
+                (symbol->string (car entry))
+                (car entry)))
+          ;; Accept both bare filename and runtime/ prefixed path
+          (set-add (set-add acc name) (string-append "runtime/" name))))
+      ;; Also match filenames for backward compat
+      (define (known-exception? f)
+        (define rel (path->string (find-relative-path (build-path q-dir "runtime") f)))
+        (define bare (path->string (file-name-from-path f)))
+        (or (set-member? known-exceptions rel)
+            (set-member? known-exceptions bare)
+            (set-member? known-exceptions (string-append "runtime/" rel))
+            (set-member? known-exceptions (string-append "runtime/" bare))))
       (define violations
         (for/list ([f (in-list runtime-files)]
-                   #:when (not (member (path->string (file-name-from-path f)) known-exceptions)))
+                   #:when (not (known-exception? f)))
           (define reqs (extract-requires f))
           (if (imports-from? reqs '("../tools/" "../../tools/" "../extensions/" "../../extensions/"))
-              (format "~a: upward imports detected" (file-name-from-path f))
+              (format "~a: upward imports detected" (find-relative-path q-dir f))
               #f)))
       (define actual-violations (filter identity violations))
       (check-equal? actual-violations
@@ -68,6 +80,28 @@
       (define actual-violations (filter identity violations))
       (check-equal? actual-violations
                     '()
-                    (format "TUI modules importing from forbidden layers: ~a" actual-violations)))))
+                    (format "TUI modules importing from forbidden layers: ~a" actual-violations)))
+
+    (test-case "Recursive boundary scan includes subdirectory modules"
+      ;; Prove that rkt-files-in-recursive catches files in nested directories
+      ;; that rkt-files-in would miss. This is the core fix from W0.
+      (define flat-files (rkt-files-in "runtime"))
+      (define recursive-files (rkt-files-in-recursive "runtime"))
+      ;; Recursive must be a strict superset
+      (check-true (> (length recursive-files) (length flat-files))
+                  (format "Recursive scan (~a files) must find more than flat scan (~a files)"
+                          (length recursive-files)
+                          (length flat-files)))
+      ;; Specifically, runtime/iteration/ subdirectory files must be included
+      (define iteration-files
+        (filter (λ (f) (string-contains? (path->string f) "iteration/")) recursive-files))
+      (check-true (>= (length iteration-files) 10)
+                  (format "runtime/iteration/ should have 10+ files, found ~a"
+                          (length iteration-files)))
+      ;; runtime/iteration/loop-state.rkt must be in the recursive list
+      (define loop-state-file
+        (findf (λ (f) (string-suffix? (path->string f) "loop-state.rkt")) recursive-files))
+      (check-not-false loop-state-file
+                       "runtime/iteration/loop-state.rkt must be found by recursive scan"))))
 
 (run-tests boundary-tests)


### PR DESCRIPTION
Addresses #5106.

feat(W0): recursive architecture boundary baseline (#5106)

- Add rkt-files-in-recursive helper to arch-utils for subdirectory scanning
- Update boundary test to scan runtime/ recursively (catches iteration/* submodules)
- Document 5 previously-invisible upward imports in dependency-policy.rktd:
  - runtime/iteration/loop-config.rkt (tool-registry, extension-registry)
  - runtime/iteration/loop-phases.rkt (extension-registry)
  - runtime/iteration/main-loop.rkt (tool-registry, extension-registry)
  - runtime/iteration/step-interpreter.rkt (permission-gate)
  - runtime/layer-adapters.rkt (adapter facade)
- Bump runtime max-exceptions from 10 to 16 to accommodate discovered exceptions
- Add test proving recursive scan is strict superset of flat scan

Wave 0 of v0.57.0.