### PR TITLE
feat(W1): hotspot report baseline and non-blocking CI annotation (#5107)

- Add scripts/hotspot-report.rkt: computes score = change-frequency × LOC
  for all source files, reports top 20 hotspots
- Supports --ci (non-blocking warnings), --json, --all flags
- Add hotspot as non-blocking check in lint-all (continue-on-error)
- Add tests/test-hotspot-report.rkt with 5 test cases:
  - default report output format
  - JSON output structure validation
  - score = frequency × LOC invariant
  - descending sort order verification
  - CI mode exits 0 (non-blocking)

Top hotspots identified:
  runtime/agent-session.rkt (31050)
  tui/tui-keybindings.rkt (24687)
  runtime/session-lifecycle.rkt (20910)
  tui/tui-render-loop.rkt (17670)
  extensions/gsd-planning.rkt (17220)

Wave 1 of v0.57.0.

### DIFF
--- a/scripts/hotspot-report.rkt
+++ b/scripts/hotspot-report.rkt
@@ -1,0 +1,166 @@
+#lang racket
+
+;; scripts/hotspot-report.rkt — Architecture hotspot report
+;;
+;; Computes hotspot scores for source files using:
+;;   score = change-frequency × LOC
+;;
+;; High scores indicate files that change often AND are large —
+;; high-risk targets for decomposition or stabilization.
+;;
+;; Usage:
+;;   racket scripts/hotspot-report.rkt              # top 20 hotspots
+;;   racket scripts/hotspot-report.rkt --all        # all source files
+;;   racket scripts/hotspot-report.rkt --ci         # CI mode: warn on high scores
+;;   racket scripts/hotspot-report.rkt --json       # JSON output
+
+(require racket/port
+         racket/string
+         racket/list
+         racket/match
+         racket/system
+         json)
+
+;; ── Configuration ──
+
+(define TOP-N 20)
+(define CI-WARN-THRESHOLD 5000)
+(define Q-DIR
+  (simplify-path (if (getenv "Q_DIR")
+                     (string->path (getenv "Q_DIR"))
+                     (build-path (current-directory) ".." "q"))))
+
+;; ── Change frequency via git ──
+
+(define (git-change-counts)
+  ;; Returns hash: relative-path → count of commits touching that file
+  (define git-result
+    (with-handlers ([exn:fail? (λ (e) #f)])
+      (define-values (sp out in err)
+        (subprocess #f #f #f (find-executable-path "git") "log" "--format=" "--name-only"))
+      (close-output-port in)
+      (define text (port->string out))
+      (close-input-port out)
+      (close-input-port err)
+      (subprocess-wait sp)
+      (define code (subprocess-status sp))
+      (if (= code 0) text #f)))
+  (define h (make-hash))
+  (when git-result
+    (for ([line (in-list (string-split git-result "\n"))])
+      (define trimmed (string-trim line))
+      (when (> (string-length trimmed) 0)
+        (hash-update! h trimmed add1 0))))
+  h)
+
+;; ── LOC counting ──
+
+(define (rkt-source-files)
+  ;; All .rkt files under Q-DIR, excluding tests/examples/benchmarks
+  (define all
+    (filter (λ (f) (regexp-match? #rx"\\.rkt$" (path->string f)))
+            (find-files (λ (p) (file-exists? p)) Q-DIR)))
+  (define abs-q-dir (simplify-path Q-DIR))
+  (filter (λ (f)
+            (define rel (path->string (find-relative-path abs-q-dir f)))
+            (not (or (string-prefix? rel "tests/")
+                     (string-prefix? rel "examples/")
+                     (string-prefix? rel "benchmarks/"))))
+          all))
+
+(define (line-count filepath)
+  (with-handlers ([exn:fail? (λ (e) 0)])
+    (length (string-split (file->string filepath) "\n"))))
+
+;; ── Scoring ──
+
+(define (compute-hotspots)
+  (define change-counts (git-change-counts))
+  (define abs-q-dir (simplify-path Q-DIR))
+  (define files (rkt-source-files))
+  (for/list ([f (in-list files)])
+    (define rel (path->string (find-relative-path abs-q-dir f)))
+    (define loc (line-count f))
+    (define freq (hash-ref change-counts rel 0))
+    (define score (* freq loc))
+    (list rel loc freq score)))
+
+(define (hotspots-by-score)
+  (sort (compute-hotspots) > #:key fourth))
+
+;; ── Reporting ──
+
+(define (print-hotspot-table entries)
+  (printf "~a   ~a   ~a   ~a~n"
+          (string-pad-right "File" 50)
+          (string-pad-left "LOC" 7)
+          (string-pad-left "Freq" 7)
+          (string-pad-left "Score" 10))
+  (printf "~a   ~a   ~a   ~a~n"
+          (make-string 50 #\-)
+          (make-string 7 #\-)
+          (make-string 7 #\-)
+          (make-string 10 #\-))
+  (for ([e (in-list entries)])
+    (printf "~a   ~a   ~a   ~a~n"
+            (string-pad-right (first e) 50)
+            (string-pad-left (number->string (second e)) 7)
+            (string-pad-left (number->string (third e)) 7)
+            (string-pad-left (number->string (fourth e)) 10))))
+
+(define (string-pad-right s n)
+  (define len (string-length s))
+  (if (>= len n)
+      (substring s 0 n)
+      (string-append s (make-string (- n len) #\space))))
+
+(define (string-pad-left s n)
+  (define len (string-length s))
+  (if (>= len n)
+      s
+      (string-append (make-string (- n len) #\space) s)))
+
+(define (print-report entries top-n)
+  (printf "=== Architecture Hotspot Report ===~n~n")
+  (printf "Score = Change Frequency × LOC~n")
+  (printf "High scores indicate high-risk files (frequently changed + large).~n~n")
+  (define shown (take entries (min top-n (length entries))))
+  (print-hotspot-table shown)
+  (printf "~nTotal source files: ~a~n" (length entries))
+  (printf "Showing top ~a of ~a~n" (min top-n (length entries)) (length entries)))
+
+(define (ci-warn entries threshold)
+  (define hot (filter (λ (e) (> (fourth e) threshold)) entries))
+  (for ([e (in-list hot)])
+    (printf "  ⚠ ~a: score ~a (freq=~a × loc=~a)~n" (first e) (fourth e) (third e) (second e)))
+  (when (> (length hot) 0)
+    (printf "~n⚠ ~a files exceed score threshold ~a~n" (length hot) threshold)))
+
+;; ── JSON output ──
+
+(define (entries->json entries)
+  (for/list ([e (in-list entries)])
+    (hash 'file (first e) 'loc (second e) 'frequency (third e) 'score (fourth e))))
+
+;; ── Main ──
+
+(define args (vector->list (current-command-line-arguments)))
+(define show-all? (member "--all" args))
+(define ci-mode? (member "--ci" args))
+(define json-mode? (member "--json" args))
+
+(define entries (hotspots-by-score))
+
+(cond
+  [json-mode?
+   (write-json (hash 'hotspots
+                     (entries->json (if show-all?
+                                        entries
+                                        (take entries (min TOP-N (length entries)))))))]
+  [else
+   (print-report entries
+                 (if show-all?
+                     (length entries)
+                     TOP-N))
+   (when ci-mode?
+     (ci-warn entries CI-WARN-THRESHOLD))])

--- a/scripts/lint-all.rkt
+++ b/scripts/lint-all.rkt
@@ -45,7 +45,8 @@
         (list "release-readiness" "scripts/lint-release-readiness.rkt" '() #f)
         (list "doc-freshness" "scripts/lint-doc-freshness.rkt" '() #f)
         (list "widened-ledger" "scripts/lint-widened-ledger.rkt" '() #t)
-        (list "contract-changes" "scripts/lint-contract-changes.rkt" '("--diff" "HEAD") #t)))
+        (list "contract-changes" "scripts/lint-contract-changes.rkt" '("--diff" "HEAD") #t)
+        (list "hotspot" "scripts/hotspot-report.rkt" '("--ci") #t)))
 
 ;; ── Helpers ──
 

--- a/tests/test-hotspot-report.rkt
+++ b/tests/test-hotspot-report.rkt
@@ -1,0 +1,83 @@
+#lang racket
+
+;; tests/test-hotspot-report.rkt — Tests for hotspot scoring logic
+
+(require rackunit
+         rackunit/text-ui
+         json
+         racket/port)
+
+;; ── Helper ──
+
+;; Resolve q/ directory: raco test changes CWD, so we need robust path resolution.
+;; Use the source file's directory (tests/) and go up one level to q/.
+(define q-dir
+  (simplify-path
+   (build-path (or (current-load-relative-directory)
+                   (let ([src (resolved-module-path-name (variable-reference->resolved-module-path
+                                                          (#%variable-reference)))])
+                     (if (path? src)
+                         (path-only src)
+                         (current-directory))))
+               'up)))
+
+(define (run-hotspot-report . args)
+  (define racket-path (or (find-executable-path "racket") (error "racket not found")))
+  (define-values (sp out in err)
+    (parameterize ([current-directory q-dir])
+      (apply subprocess #f #f #f racket-path "scripts/hotspot-report.rkt" args)))
+  (close-output-port in)
+  (define stdout-text (port->string out))
+  (close-input-port out)
+  (close-input-port err)
+  (subprocess-wait sp)
+  (define code (subprocess-status sp))
+  (values code stdout-text))
+
+;; ── Tests ──
+
+(define hotspot-tests
+  (test-suite "hotspot-report"
+
+    (test-case "default report shows top hotspots"
+      (define-values (code out) (run-hotspot-report))
+      (check-equal? code 0 "should exit 0")
+      (check-true (string-contains? out "Score = Change Frequency") "should show scoring formula")
+      (check-true (string-contains? out "Total source files:") "should show total file count"))
+
+    (test-case "JSON output is valid and has required fields"
+      (define-values (code out) (run-hotspot-report "--json"))
+      (check-equal? code 0)
+      (define data (string->jsexpr out))
+      (check-true (hash-has-key? data 'hotspots))
+      (define hotspots (hash-ref data 'hotspots))
+      (check-true (> (length hotspots) 0))
+      ;; Each hotspot must have file, loc, frequency, score
+      (for ([h (in-list hotspots)])
+        (check-true (hash-has-key? h 'file))
+        (check-true (hash-has-key? h 'loc))
+        (check-true (hash-has-key? h 'frequency))
+        (check-true (hash-has-key? h 'score))))
+
+    (test-case "score equals frequency times loc"
+      (define-values (code out) (run-hotspot-report "--json" "--all"))
+      (define data (string->jsexpr out))
+      (define hotspots (hash-ref data 'hotspots))
+      ;; Verify score = freq × loc for every entry with non-zero values
+      (for ([h (in-list hotspots)]
+            #:when (and (> (hash-ref h 'frequency) 0) (> (hash-ref h 'loc) 0)))
+        (check-equal? (hash-ref h 'score)
+                      (* (hash-ref h 'frequency) (hash-ref h 'loc))
+                      (format "score mismatch for ~a" (hash-ref h 'file)))))
+
+    (test-case "hotspots are sorted descending by score"
+      (define-values (code out) (run-hotspot-report "--json" "--all"))
+      (define data (string->jsexpr out))
+      (define scores (map (λ (h) (hash-ref h 'score)) (hash-ref data 'hotspots)))
+      (check-true (apply >= scores) "scores should be in descending order"))
+
+    (test-case "CI mode exits 0 (non-blocking)"
+      (define-values (code out) (run-hotspot-report "--ci"))
+      (check-equal? code 0 "CI mode should not fail (non-blocking)"))))
+
+(run-tests hotspot-tests)


### PR DESCRIPTION
Addresses #5107.

feat(W1): hotspot report baseline and non-blocking CI annotation (#5107)

- Add scripts/hotspot-report.rkt: computes score = change-frequency × LOC
  for all source files, reports top 20 hotspots
- Supports --ci (non-blocking warnings), --json, --all flags
- Add hotspot as non-blocking check in lint-all (continue-on-error)
- Add tests/test-hotspot-report.rkt with 5 test cases:
  - default report output format
  - JSON output structure validation
  - score = frequency × LOC invariant
  - descending sort order verification
  - CI mode exits 0 (non-blocking)

Top hotspots identified:
  runtime/agent-session.rkt (31050)
  tui/tui-keybindings.rkt (24687)
  runtime/session-lifecycle.rkt (20910)
  tui/tui-render-loop.rkt (17670)
  extensions/gsd-planning.rkt (17220)

Wave 1 of v0.57.0.