### PR TITLE
feat(W6): add ctx-aware state-machine API (#5120)

Add gsm-ctx-* variants that operate on independent gsd-session-ctx
instead of the global gsd-default-ctx:

- gsm-ctx-current: read mode from specific ctx
- gsm-ctx-transition!: transition state on specific ctx
- gsm-ctx-reset!: reset state on specific ctx
- gsm-ctx-history: read transition history from specific ctx
- gsm-ctx-valid-next-states: query valid transitions for specific ctx

All functions use direct box access inside call-with-semaphore to
avoid nested semaphore deadlock (R-01 pattern).

Legacy gsm-* functions unchanged — still use gsd-default-ctx.

7 new TDD tests proving isolation:
- Independent ctx reads don't interfere
- Transitions on one ctx don't affect another
- Reset targets only the specified ctx
- History is isolated per ctx
- Valid next states computed per ctx
- Full lifecycle works on independent ctx
- Invalid transitions return err-result

All existing tests pass. Lint: 22/23 (release-readiness expected).

Wave 6 of v0.57.1.

### DIFF
--- a/extensions/gsd/state-machine.rkt
+++ b/extensions/gsd/state-machine.rkt
@@ -31,7 +31,17 @@
                   gsd-state-update!
                   with-gsd-lock
                   gsd-default-ctx
-                  gsd-session-ctx-state-box))
+                  gsd-session-ctx-state-box
+                  gsd-session-ctx-history-box
+                  gsd-session-ctx?
+                  gsd-ctx-state
+                  gsd-ctx-set-state!
+                  gsd-ctx-state-snapshot
+                  gsd-ctx-state-update!
+                  gsd-ctx-history
+                  gsd-ctx-set-history!
+                  gsd-ctx-history-update!
+                  gsd-session-ctx-sem))
 
 ;; States
 ;; Struct exports (plain)
@@ -61,35 +71,42 @@
          TRANSITIONS
          TRANSITIONS-FLAT
          ;; Functions (contracted)
-         (contract-out [gsm-state? (-> any/c boolean?)]
-                       [make-initial-gsd-state (-> gsd-runtime-state?)]
-                       [gsm-current (-> symbol?)]
-                       [gsm-transition!
-                        (->* (symbol?) (#:event (or/c symbol? #f)) (or/c ok-result? err-result?))]
-                       [gsm-transition-to! (-> symbol? (or/c ok-result? err-result?))]
-                       [gsm-reset! (-> (or/c ok-result? err-result?))]
-                       [compute-next-gsm-state
-                        (->* (gsd-runtime-state? symbol?)
-                             (#:event (or/c symbol? #f))
-                             (values (or/c ok-result? err-result?) gsd-runtime-state?))]
-                       [gsm-valid-next-states (-> (listof symbol?))]
-                       [gsm-tool-allowed? (-> string? boolean?)]
-                       [gsm-snapshot (-> gsd-runtime-state?)]
-                       [reset-gsm! (-> void?)]
-                       [gsm-history (-> list?)]
-                       [gsm-wave-executor (-> (or/c any/c #f))]
-                       [gsm-set-wave-executor! (-> (or/c any/c #f) void?)]
-                       [gsm-total-waves (-> exact-nonnegative-integer?)]
-                       [gsm-set-total-waves! (-> exact-nonnegative-integer? void?)]
-                       [gsm-current-wave (-> exact-nonnegative-integer?)]
-                       [gsm-set-current-wave! (-> exact-nonnegative-integer? void?)]
-                       [gsm-completed-waves (-> (set/c exact-nonnegative-integer?))]
-                       [gsm-mark-wave-complete! (-> exact-nonnegative-integer? void?)]
-                       [gsm-wave-complete? (-> exact-nonnegative-integer? boolean?)]
-                       [gsm-next-pending-wave (-> (or/c exact-nonnegative-integer? #f))]
-                       [gsm-clear-wave-gate! (-> void?)]
-                       [gsd-wave-gate-blocked? (-> boolean?)]
-                       [gsd-invariants-hold? (-> (values boolean? (or/c string? #f)))]))
+         (contract-out
+          [gsm-state? (-> any/c boolean?)]
+          [make-initial-gsd-state (-> gsd-runtime-state?)]
+          [gsm-current (-> symbol?)]
+          [gsm-transition! (->* (symbol?) (#:event (or/c symbol? #f)) (or/c ok-result? err-result?))]
+          [gsm-transition-to! (-> symbol? (or/c ok-result? err-result?))]
+          [gsm-reset! (-> (or/c ok-result? err-result?))]
+          [compute-next-gsm-state
+           (->* (gsd-runtime-state? symbol?)
+                (#:event (or/c symbol? #f))
+                (values (or/c ok-result? err-result?) gsd-runtime-state?))]
+          [gsm-valid-next-states (-> (listof symbol?))]
+          [gsm-tool-allowed? (-> string? boolean?)]
+          [gsm-snapshot (-> gsd-runtime-state?)]
+          [reset-gsm! (-> void?)]
+          [gsm-history (-> list?)]
+          [gsm-wave-executor (-> (or/c any/c #f))]
+          [gsm-set-wave-executor! (-> (or/c any/c #f) void?)]
+          [gsm-total-waves (-> exact-nonnegative-integer?)]
+          [gsm-set-total-waves! (-> exact-nonnegative-integer? void?)]
+          [gsm-current-wave (-> exact-nonnegative-integer?)]
+          [gsm-set-current-wave! (-> exact-nonnegative-integer? void?)]
+          [gsm-completed-waves (-> (set/c exact-nonnegative-integer?))]
+          [gsm-mark-wave-complete! (-> exact-nonnegative-integer? void?)]
+          [gsm-wave-complete? (-> exact-nonnegative-integer? boolean?)]
+          [gsm-next-pending-wave (-> (or/c exact-nonnegative-integer? #f))]
+          [gsm-clear-wave-gate! (-> void?)]
+          [gsd-wave-gate-blocked? (-> boolean?)]
+          [gsd-invariants-hold? (-> (values boolean? (or/c string? #f)))]
+          ;; Context-aware API (v0.57.1 W6)
+          [gsm-ctx-current (-> gsd-session-ctx? symbol?)]
+          [gsm-ctx-transition!
+           (->* (gsd-session-ctx? symbol?) (#:event (or/c symbol? #f)) (or/c ok-result? err-result?))]
+          [gsm-ctx-reset! (-> gsd-session-ctx? (or/c ok-result? err-result?))]
+          [gsm-ctx-history (-> gsd-session-ctx? list?)]
+          [gsm-ctx-valid-next-states (-> gsd-session-ctx? (listof symbol?))]))
 
 ;; ============================================================
 ;; States and transitions
@@ -384,3 +401,61 @@
     [(and (memq mode '(executing verifying)) (> tw 0) (not exec))
      (values #f (format "in ~a with ~a waves but no wave-executor" mode tw))]
     [else (values #t #f)]))
+
+;; ============================================================
+;; Context-aware API (v0.57.1 W6)
+;; ============================================================
+
+(define (gsm-ctx-current ctx)
+  (gsd-runtime-state-mode (gsd-ctx-state-snapshot ctx)))
+
+(define (gsm-ctx-history ctx)
+  (gsd-ctx-history ctx))
+
+(define (gsm-ctx-valid-next-states ctx)
+  (valid-targets (gsm-ctx-current ctx)))
+
+(define (gsm-ctx-transition! ctx target #:event [event #f])
+  (call-with-semaphore
+   (gsd-session-ctx-sem ctx)
+   (lambda ()
+     (define state (unbox (gsd-session-ctx-state-box ctx)))
+     (define current (gsd-runtime-state-mode state))
+     (emit-gsd-event!
+      'gsd.transition.attempted
+      (make-gsd-transition-attempted-event #:session-id "" #:turn-id 0 #:from current #:to target))
+     (define-values (result new-state) (compute-next-gsm-state state target #:event event))
+     (cond
+       [(ok? result)
+        (define new-mode (gsd-runtime-state-mode new-state))
+        (set-box! (gsd-session-ctx-state-box ctx) new-state)
+        (set-box! (gsd-session-ctx-history-box ctx)
+                  (cons (list current new-mode (current-seconds))
+                        (unbox (gsd-session-ctx-history-box ctx))))
+        (emit-gsd-event! 'gsd.transition.succeeded
+                         (make-gsd-transition-succeeded-event #:session-id ""
+                                                              #:turn-id 0
+                                                              #:from current
+                                                              #:to new-mode))
+        result]
+       [else
+        (emit-gsd-event! 'gsd.transition.failed
+                         (make-gsd-transition-failed-event
+                          #:session-id ""
+                          #:turn-id 0
+                          #:from current
+                          #:to target
+                          #:reason (format "invalid: ~a -> ~a" current target)))
+        result]))))
+
+(define (gsm-ctx-reset! ctx)
+  (call-with-semaphore
+   (gsd-session-ctx-sem ctx)
+   (lambda ()
+     (define state (unbox (gsd-session-ctx-state-box ctx)))
+     (define old (gsd-runtime-state-mode state))
+     (set-box! (gsd-session-ctx-state-box ctx)
+               (struct-copy gsd-runtime-state state [mode 'idle] [wave-executor #f]))
+     (set-box! (gsd-session-ctx-history-box ctx)
+               (cons (list old 'idle (current-seconds)) (unbox (gsd-session-ctx-history-box ctx))))
+     (ok-result old 'idle))))

--- a/tests/test-gsd-state-machine-ctx.rkt
+++ b/tests/test-gsd-state-machine-ctx.rkt
@@ -1,0 +1,97 @@
+#lang racket
+
+;; tests/test-gsd-state-machine-ctx.rkt
+;; TDD test for W6: ctx-aware state-machine API
+
+(require rackunit
+         rackunit/text-ui
+         (only-in "../extensions/gsd/session-state.rkt"
+                  make-gsd-context
+                  gsd-ctx-mode
+                  gsd-ctx-state
+                  gsd-ctx-history
+                  gsd-ctx-set-state!
+                  gsd-default-ctx)
+         "../extensions/gsd/runtime-state-types.rkt"
+         (only-in "../extensions/gsd/state-machine.rkt"
+                  gsm-current
+                  gsm-reset!
+                  gsm-ctx-current
+                  gsm-ctx-transition!
+                  gsm-ctx-reset!
+                  gsm-ctx-history
+                  gsm-ctx-valid-next-states
+                  ok?
+                  ok-to
+                  err?))
+
+(define state-machine-ctx-suite
+  (test-suite "gsd-state-machine-ctx"
+
+    (test-case "gsm-ctx-current reads from independent ctx"
+      (define ctx-a (make-gsd-context))
+      (define ctx-b (make-gsd-context))
+      ;; Both start idle
+      (check-equal? (gsm-ctx-current ctx-a) 'idle)
+      (check-equal? (gsm-ctx-current ctx-b) 'idle)
+      ;; Manually set ctx-a to exploring
+      (gsd-ctx-set-state! ctx-a
+                          (struct-copy gsd-runtime-state (gsd-ctx-state ctx-a) [mode 'exploring]))
+      (check-equal? (gsm-ctx-current ctx-a) 'exploring "ctx-a changed")
+      (check-equal? (gsm-ctx-current ctx-b) 'idle "ctx-b unchanged"))
+
+    (test-case "gsm-ctx-transition! transitions independently"
+      (define ctx-a (make-gsd-context))
+      (define ctx-b (make-gsd-context))
+      (define res (gsm-ctx-transition! ctx-a 'exploring))
+      (check-true (ok? res) "transition succeeds")
+      (check-equal? (ok-to res) 'exploring)
+      (check-equal? (gsm-ctx-current ctx-a) 'exploring "ctx-a is exploring")
+      (check-equal? (gsm-ctx-current ctx-b) 'idle "ctx-b still idle"))
+
+    (test-case "gsm-ctx-reset! resets only target ctx"
+      (define ctx-a (make-gsd-context))
+      (define ctx-b (make-gsd-context))
+      ;; Transition ctx-a to exploring
+      (gsm-ctx-transition! ctx-a 'exploring)
+      ;; Reset only ctx-a
+      (define res (gsm-ctx-reset! ctx-a))
+      (check-true (ok? res) "reset succeeds")
+      (check-equal? (gsm-ctx-current ctx-a) 'idle "ctx-a reset")
+      (check-equal? (gsm-ctx-current ctx-b) 'idle "ctx-b still idle"))
+
+    (test-case "gsm-ctx-history is isolated per ctx"
+      (define ctx-a (make-gsd-context))
+      (define ctx-b (make-gsd-context))
+      (gsm-ctx-transition! ctx-a 'exploring)
+      (define hist-a (gsm-ctx-history ctx-a))
+      (define hist-b (gsm-ctx-history ctx-b))
+      (check-not-false hist-a "ctx-a has history")
+      (check-equal? hist-b '() "ctx-b has empty history"))
+
+    (test-case "gsm-ctx-valid-next-states returns correct states"
+      (define ctx (make-gsd-context))
+      (check-equal? (gsm-ctx-valid-next-states ctx) '(exploring))
+      (gsm-ctx-transition! ctx 'exploring)
+      (check-not-false (member 'plan-written (gsm-ctx-valid-next-states ctx))))
+
+    (test-case "full lifecycle on independent ctx"
+      (define ctx (make-gsd-context))
+      (check-equal? (gsm-ctx-current ctx) 'idle)
+      (gsm-ctx-transition! ctx 'exploring)
+      (check-equal? (gsm-ctx-current ctx) 'exploring)
+      (gsm-ctx-transition! ctx 'plan-written)
+      (check-equal? (gsm-ctx-current ctx) 'plan-written)
+      (gsm-ctx-transition! ctx 'executing)
+      (check-equal? (gsm-ctx-current ctx) 'executing)
+      (gsm-ctx-transition! ctx 'verifying)
+      (check-equal? (gsm-ctx-current ctx) 'verifying)
+      (gsm-ctx-transition! ctx 'idle)
+      (check-equal? (gsm-ctx-current ctx) 'idle))
+
+    (test-case "invalid transition returns err-result"
+      (define ctx (make-gsd-context))
+      (define res (gsm-ctx-transition! ctx 'executing))
+      (check-true (err? res) "idle→executing is invalid"))))
+
+(run-tests state-machine-ctx-suite)


### PR DESCRIPTION
Addresses #5120.

feat(W6): add ctx-aware state-machine API (#5120)

Add gsm-ctx-* variants that operate on independent gsd-session-ctx
instead of the global gsd-default-ctx:

- gsm-ctx-current: read mode from specific ctx
- gsm-ctx-transition!: transition state on specific ctx
- gsm-ctx-reset!: reset state on specific ctx
- gsm-ctx-history: read transition history from specific ctx
- gsm-ctx-valid-next-states: query valid transitions for specific ctx

All functions use direct box access inside call-with-semaphore to
avoid nested semaphore deadlock (R-01 pattern).

Legacy gsm-* functions unchanged — still use gsd-default-ctx.

7 new TDD tests proving isolation:
- Independent ctx reads don't interfere
- Transitions on one ctx don't affect another
- Reset targets only the specified ctx
- History is isolated per ctx
- Valid next states computed per ctx
- Full lifecycle works on independent ctx
- Invalid transitions return err-result

All existing tests pass. Lint: 22/23 (release-readiness expected).

Wave 6 of v0.57.1.