### PR TITLE
feat(W7): add ctx-aware handler infrastructure and wave operations (#5121)

Extended state-machine.rkt with ctx-aware variants for all operations
needed by command/tool handlers:

- gsm-ctx-transition-to! (auto-routing multi-step)
- gsm-ctx-snapshot
- gsm-ctx-wave-executor/set-wave-executor!
- gsm-ctx-total-waves/set-total-waves!
- gsm-ctx-current-wave/set-current-wave!
- gsm-ctx-completed-waves
- gsm-ctx-mark-wave-complete!
- gsm-ctx-state-restore!

Added current-gsd-ctx parameter to session-state.rkt — defaults to
gsd-default-ctx, enabling parameterize-based ctx isolation in handlers.

5 new TDD tests proving command flow isolation:
- /plan equivalent isolates via ctx parameter
- /reset equivalent isolates via ctx parameter
- /wave-done equivalent isolates via ctx parameter
- Full lifecycle isolates via ctx parameter
- Default ctx unaffected by parameterize

All existing tests pass. Lint: 22/23 (release-readiness expected).

Wave 7 of v0.57.1.

### DIFF
--- a/extensions/gsd/session-state.rkt
+++ b/extensions/gsd/session-state.rkt
@@ -132,6 +132,10 @@
 
 (define gsd-default-ctx (make-gsd-context))
 
+;; v0.57.1 W7: Active context parameter for ctx-aware handler dispatch.
+;; Defaults to gsd-default-ctx. Tests can parameterize to isolated contexts.
+(define current-gsd-ctx (make-parameter gsd-default-ctx))
+
 ;; H-05: gsd-state-sem removed — collapsed into per-ctx semaphore.
 
 ;; ============================================================
@@ -222,6 +226,7 @@
          gsd-session-ctx-sem
          ;; Global default context (plain)
          gsd-default-ctx
+         current-gsd-ctx
          ;; Functions (contracted)
          (contract-out [make-gsd-context (-> gsd-session-ctx?)]
                        [ctx-read (-> gsd-session-ctx? procedure? any)]

--- a/extensions/gsd/state-machine.rkt
+++ b/extensions/gsd/state-machine.rkt
@@ -106,7 +106,19 @@
            (->* (gsd-session-ctx? symbol?) (#:event (or/c symbol? #f)) (or/c ok-result? err-result?))]
           [gsm-ctx-reset! (-> gsd-session-ctx? (or/c ok-result? err-result?))]
           [gsm-ctx-history (-> gsd-session-ctx? list?)]
-          [gsm-ctx-valid-next-states (-> gsd-session-ctx? (listof symbol?))]))
+          [gsm-ctx-valid-next-states (-> gsd-session-ctx? (listof symbol?))]
+          ;; Context-aware API extended (v0.57.1 W7)
+          [gsm-ctx-transition-to! (-> gsd-session-ctx? symbol? (or/c ok-result? err-result?))]
+          [gsm-ctx-snapshot (-> gsd-session-ctx? gsd-runtime-state?)]
+          [gsm-ctx-wave-executor (-> gsd-session-ctx? any/c)]
+          [gsm-ctx-set-wave-executor! (-> gsd-session-ctx? any/c void?)]
+          [gsm-ctx-total-waves (-> gsd-session-ctx? exact-nonnegative-integer?)]
+          [gsm-ctx-set-total-waves! (-> gsd-session-ctx? exact-nonnegative-integer? void?)]
+          [gsm-ctx-current-wave (-> gsd-session-ctx? exact-nonnegative-integer?)]
+          [gsm-ctx-set-current-wave! (-> gsd-session-ctx? exact-nonnegative-integer? void?)]
+          [gsm-ctx-completed-waves (-> gsd-session-ctx? set?)]
+          [gsm-ctx-mark-wave-complete! (-> gsd-session-ctx? exact-nonnegative-integer? void?)]
+          [gsm-ctx-state-restore! (-> gsd-session-ctx? gsd-runtime-state? void?)]))
 
 ;; ============================================================
 ;; States and transitions
@@ -459,3 +471,54 @@
      (set-box! (gsd-session-ctx-history-box ctx)
                (cons (list old 'idle (current-seconds)) (unbox (gsd-session-ctx-history-box ctx))))
      (ok-result old 'idle))))
+
+;; Auto-routing multi-step transition (ctx-aware)
+(define (gsm-ctx-transition-to! ctx target)
+  (define current (gsm-ctx-current ctx))
+  (cond
+    [(eq? current target) (ok-result current target)]
+    [else
+     (define path (find-transition-path current target))
+     (if path
+         (for/fold ([result (ok-result current current)]) ([step path])
+           (gsm-ctx-transition! ctx step))
+         (gsm-ctx-transition! ctx target))]))
+
+;; Snapshot (ctx-aware)
+(define (gsm-ctx-snapshot ctx)
+  (gsd-ctx-state-snapshot ctx))
+
+;; Wave operations (ctx-aware)
+(define (gsm-ctx-wave-executor ctx)
+  (gsd-runtime-state-wave-executor (gsd-ctx-state-snapshot ctx)))
+
+(define (gsm-ctx-set-wave-executor! ctx exec)
+  (gsd-ctx-state-update! ctx
+                         (lambda (state) (struct-copy gsd-runtime-state state [wave-executor exec]))))
+
+(define (gsm-ctx-total-waves ctx)
+  (gsd-runtime-state-total-waves (gsd-ctx-state-snapshot ctx)))
+
+(define (gsm-ctx-set-total-waves! ctx n)
+  (gsd-ctx-state-update! ctx (lambda (state) (struct-copy gsd-runtime-state state [total-waves n]))))
+
+(define (gsm-ctx-current-wave ctx)
+  (gsd-runtime-state-current-wave (gsd-ctx-state-snapshot ctx)))
+
+(define (gsm-ctx-set-current-wave! ctx n)
+  (gsd-ctx-state-update! ctx (lambda (state) (struct-copy gsd-runtime-state state [current-wave n]))))
+
+(define (gsm-ctx-completed-waves ctx)
+  (gsd-runtime-state-completed-waves (gsd-ctx-state-snapshot ctx)))
+
+(define (gsm-ctx-mark-wave-complete! ctx idx)
+  (gsd-ctx-state-update! ctx
+                         (lambda (state)
+                           (struct-copy gsd-runtime-state
+                                        state
+                                        [completed-waves
+                                         (set-add (gsd-runtime-state-completed-waves state) idx)]))))
+
+;; State restore (ctx-aware)
+(define (gsm-ctx-state-restore! ctx snapshot)
+  (gsd-ctx-set-state! ctx snapshot))

--- a/tests/test-gsd-command-ctx-isolation.rkt
+++ b/tests/test-gsd-command-ctx-isolation.rkt
@@ -1,0 +1,96 @@
+#lang racket
+
+;; tests/test-gsd-command-ctx-isolation.rkt
+;; TDD for W7: command handlers isolate per ctx via current-gsd-ctx parameter
+
+(require rackunit
+         rackunit/text-ui
+         "../extensions/gsd/runtime-state-types.rkt"
+         (only-in "../extensions/gsd/session-state.rkt"
+                  make-gsd-context
+                  current-gsd-ctx
+                  gsd-default-ctx
+                  gsd-ctx-state
+                  gsd-ctx-mode)
+         (only-in "../extensions/gsd/state-machine.rkt"
+                  gsm-ctx-current
+                  gsm-ctx-transition!
+                  gsm-ctx-transition-to!
+                  gsm-ctx-reset!
+                  gsm-ctx-history
+                  gsm-ctx-mark-wave-complete!
+                  gsm-ctx-total-waves
+                  gsm-ctx-set-total-waves!
+                  gsm-ctx-completed-waves
+                  ok?
+                  ok-to
+                  err?))
+
+(define command-ctx-isolation-suite
+  (test-suite "gsd-command-ctx-isolation"
+
+    (test-case "/plan equivalent isolates via ctx"
+      (define ctx-a (make-gsd-context))
+      (define ctx-b (make-gsd-context))
+      ;; Transition ctx-a to exploring (simulates /plan)
+      (parameterize ([current-gsd-ctx ctx-a])
+        (define res (gsm-ctx-transition-to! (current-gsd-ctx) 'exploring))
+        (check-true (ok? res) "plan transition succeeds"))
+      (check-equal? (gsm-ctx-current ctx-a) 'exploring "ctx-a is exploring")
+      (check-equal? (gsm-ctx-current ctx-b) 'idle "ctx-b unaffected"))
+
+    (test-case "/reset equivalent isolates via ctx"
+      (define ctx-a (make-gsd-context))
+      (define ctx-b (make-gsd-context))
+      ;; Set ctx-a to executing
+      (gsm-ctx-transition! ctx-a 'exploring)
+      (gsm-ctx-transition! ctx-a 'plan-written)
+      (gsm-ctx-transition! ctx-a 'executing)
+      ;; Reset only ctx-a
+      (parameterize ([current-gsd-ctx ctx-a])
+        (define res (gsm-ctx-reset! (current-gsd-ctx)))
+        (check-true (ok? res) "reset succeeds"))
+      (check-equal? (gsm-ctx-current ctx-a) 'idle "ctx-a reset")
+      (check-equal? (gsm-ctx-current ctx-b) 'idle "ctx-b still idle"))
+
+    (test-case "/wave-done equivalent isolates via ctx"
+      (define ctx-a (make-gsd-context))
+      (define ctx-b (make-gsd-context))
+      ;; Setup ctx-a in executing state with 3 waves
+      (gsm-ctx-transition! ctx-a 'exploring)
+      (gsm-ctx-transition! ctx-a 'plan-written)
+      (gsm-ctx-transition! ctx-a 'executing)
+      (gsm-ctx-set-total-waves! ctx-a 3)
+      ;; Mark wave 0 complete on ctx-a
+      (parameterize ([current-gsd-ctx ctx-a])
+        (gsm-ctx-mark-wave-complete! (current-gsd-ctx) 0))
+      (check-equal? (set-count (gsm-ctx-completed-waves ctx-a)) 1 "ctx-a has 1 completed")
+      (check-equal? (set-count (gsm-ctx-completed-waves ctx-b)) 0 "ctx-b has 0 completed"))
+
+    (test-case "full lifecycle isolates via ctx"
+      (define ctx (make-gsd-context))
+      (parameterize ([current-gsd-ctx ctx])
+        (check-equal? (gsm-ctx-current (current-gsd-ctx)) 'idle)
+        (gsm-ctx-transition-to! (current-gsd-ctx) 'exploring)
+        (check-equal? (gsm-ctx-current (current-gsd-ctx)) 'exploring)
+        (gsm-ctx-transition-to! (current-gsd-ctx) 'plan-written)
+        (check-equal? (gsm-ctx-current (current-gsd-ctx)) 'plan-written)
+        (gsm-ctx-transition-to! (current-gsd-ctx) 'executing)
+        (check-equal? (gsm-ctx-current (current-gsd-ctx)) 'executing)
+        (gsm-ctx-transition-to! (current-gsd-ctx) 'verifying)
+        (check-equal? (gsm-ctx-current (current-gsd-ctx)) 'verifying)
+        (gsm-ctx-transition-to! (current-gsd-ctx) 'idle)
+        (check-equal? (gsm-ctx-current (current-gsd-ctx)) 'idle)))
+
+    (test-case "default ctx unaffected by parameterize"
+      (define ctx (make-gsd-context))
+      ;; Remember default state
+      (define default-before (gsm-ctx-current gsd-default-ctx))
+      ;; Operate on isolated ctx
+      (parameterize ([current-gsd-ctx ctx])
+        (gsm-ctx-transition-to! (current-gsd-ctx) 'exploring)
+        (gsm-ctx-transition-to! (current-gsd-ctx) 'executing))
+      ;; Default should be unchanged
+      (check-equal? (gsm-ctx-current gsd-default-ctx) default-before "default unchanged"))))
+
+(run-tests command-ctx-isolation-suite)


### PR DESCRIPTION
Addresses #5121.

feat(W7): add ctx-aware handler infrastructure and wave operations (#5121)

Extended state-machine.rkt with ctx-aware variants for all operations
needed by command/tool handlers:

- gsm-ctx-transition-to! (auto-routing multi-step)
- gsm-ctx-snapshot
- gsm-ctx-wave-executor/set-wave-executor!
- gsm-ctx-total-waves/set-total-waves!
- gsm-ctx-current-wave/set-current-wave!
- gsm-ctx-completed-waves
- gsm-ctx-mark-wave-complete!
- gsm-ctx-state-restore!

Added current-gsd-ctx parameter to session-state.rkt — defaults to
gsd-default-ctx, enabling parameterize-based ctx isolation in handlers.

5 new TDD tests proving command flow isolation:
- /plan equivalent isolates via ctx parameter
- /reset equivalent isolates via ctx parameter
- /wave-done equivalent isolates via ctx parameter
- Full lifecycle isolates via ctx parameter
- Default ctx unaffected by parameterize

All existing tests pass. Lint: 22/23 (release-readiness expected).

Wave 7 of v0.57.1.