### PR TITLE
feat(W8): wire runtime extension context to per-session GSD ctx (#5122)

Pass current-gsd-ctx to make-extension-ctx in turn-orchestrator.rkt
so that extension contexts carry the per-session GSD context. In
gsd-planning.rkt, register-gsd-tools now sets current-gsd-ctx from
ctx-gsd-ctx when available, enabling per-session GSD state isolation
through the full runtime → extension → handler pipeline.

5 new TDD tests proving extension-ctx gsd-ctx wiring:
- extension-ctx gsd-ctx field preserves per-session context
- extension-ctx gsd-ctx defaults to #f when not provided
- per-session gsd-ctx isolates state from default
- current-gsd-ctx parameterize dispatches to session ctx
- two sessions have independent gsd-ctx

All existing tests pass. Lint: 22/23.

Wave 8 of v0.57.1.

### DIFF
--- a/extensions/gsd-planning.rkt
+++ b/extensions/gsd-planning.rkt
@@ -60,7 +60,8 @@
                   current-edit-limit
                   set-edit-limit!
                   current-gsd-event-bus
-                  set-gsd-event-bus!)
+                  set-gsd-event-bus!
+                  current-gsd-ctx)
          ;; Extracted sub-modules
          "gsd/tool-handlers.rkt"
          "gsd/command-handlers.rkt")
@@ -171,6 +172,11 @@
 
 ;; --- register-tools ---
 (define (register-gsd-tools ctx _payload)
+  ;; W8: Set current-gsd-ctx from extension context if available.
+  ;; This ensures GSD handlers use per-session ctx instead of global default.
+  (define ext-gsd-ctx (ctx-gsd-ctx ctx))
+  (when ext-gsd-ctx
+    (current-gsd-ctx ext-gsd-ctx))
   (unless (pinned-planning-dir)
     (define cwd (ctx-cwd ctx))
     (when cwd

--- a/runtime/turn-orchestrator.rkt
+++ b/runtime/turn-orchestrator.rkt
@@ -63,6 +63,7 @@
          ;; Context assembly hooks via adapter
          (only-in "layer-adapters.rkt" dispatch-hooks)
          (only-in "layer-adapters.rkt" make-extension-ctx)
+         (only-in "../extensions/gsd/session-state.rkt" current-gsd-ctx gsd-session-ctx?)
          "../runtime/session-store.rkt"
          "../runtime/tool-coordinator.rkt"
          (only-in "../runtime/context-assembly.rkt"
@@ -296,7 +297,8 @@
                            #:session-dir #f
                            #:event-bus bus
                            #:extension-registry ext-reg
-                           #:tool-registry tool-reg))
+                           #:tool-registry tool-reg
+                           #:gsd-ctx (current-gsd-ctx)))
      (define-values (_amended hook-res)
        (maybe-dispatch-hooks ext-reg 'register-tools (hasheq) #:ctx the-ext-ctx))
      (if (and hook-res (eq? (hook-result-action hook-res) 'amend))

--- a/tests/test-extension-context-hooks.rkt
+++ b/tests/test-extension-context-hooks.rkt
@@ -13,7 +13,13 @@
          "../extensions/api.rkt"
          "../extensions/context.rkt"
          (only-in "../runtime/runtime-helpers.rkt" maybe-dispatch-hooks)
-         "../util/hook-types.rkt")
+         "../util/hook-types.rkt"
+         (only-in "../extensions/gsd/session-state.rkt"
+                  make-gsd-context
+                  current-gsd-ctx
+                  gsd-default-ctx
+                  gsd-session-ctx?)
+         (only-in "../extensions/gsd/state-machine.rkt" gsm-ctx-current gsm-ctx-transition-to!))
 
 (define (make-test-ctx #:session-id sid #:model-name model [reg #f])
   (make-extension-ctx #:session-id sid
@@ -57,6 +63,65 @@
       (dispatch-hooks 'any-hook (hasheq) reg #:ctx ctx)
       (check-not-false (unbox received-ctx) "handler received context")
       (check-equal? (ctx-session-id (unbox received-ctx)) "ctx-test")
-      (check-equal? (ctx-model (unbox received-ctx)) "claude-3"))))
+      (check-equal? (ctx-model (unbox received-ctx)) "claude-3"))
+
+    ;; W8: Runtime extension context wiring for GSD ctx
+    (test-case "extension-ctx gsd-ctx field preserves per-session context"
+      (define gsd-ctx (make-gsd-context))
+      (gsm-ctx-transition-to! gsd-ctx 'executing)
+      (define ext-ctx
+        (make-extension-ctx #:session-id "sess-gsd"
+                            #:session-dir #f
+                            #:event-bus (make-event-bus)
+                            #:extension-registry (make-extension-registry)
+                            #:gsd-ctx gsd-ctx))
+      (check-eq? (ctx-gsd-ctx ext-ctx) gsd-ctx "gsd-ctx field preserved")
+      (check-eq? (gsm-ctx-current (ctx-gsd-ctx ext-ctx)) 'executing "state accessible"))
+
+    (test-case "extension-ctx gsd-ctx defaults to #f when not provided"
+      (define ext-ctx
+        (make-extension-ctx #:session-id "sess-no-gsd"
+                            #:session-dir #f
+                            #:event-bus (make-event-bus)
+                            #:extension-registry (make-extension-registry)))
+      (check-false (ctx-gsd-ctx ext-ctx) "gsd-ctx defaults to #f"))
+
+    (test-case "per-session gsd-ctx isolates state from default"
+      (define gsd-ctx (make-gsd-context))
+      (gsm-ctx-transition-to! gsd-ctx 'exploring)
+      (define ext-ctx
+        (make-extension-ctx #:session-id "sess-iso"
+                            #:session-dir #f
+                            #:event-bus (make-event-bus)
+                            #:extension-registry (make-extension-registry)
+                            #:gsd-ctx gsd-ctx))
+      (check-eq? (gsm-ctx-current (ctx-gsd-ctx ext-ctx)) 'exploring "session ctx exploring")
+      (check-eq? (gsm-ctx-current gsd-default-ctx) 'idle "default still idle"))
+
+    (test-case "current-gsd-ctx parameterize dispatches to session ctx"
+      (define gsd-ctx (make-gsd-context))
+      (gsm-ctx-transition-to! gsd-ctx 'plan-written)
+      (parameterize ([current-gsd-ctx gsd-ctx])
+        (check-eq? (gsm-ctx-current (current-gsd-ctx)) 'plan-written "parameter works")))
+
+    (test-case "two sessions have independent gsd-ctx"
+      (define gsd-a (make-gsd-context))
+      (define gsd-b (make-gsd-context))
+      (gsm-ctx-transition-to! gsd-a 'executing)
+      (gsm-ctx-transition-to! gsd-b 'verifying)
+      (define ext-a
+        (make-extension-ctx #:session-id "a"
+                            #:session-dir #f
+                            #:event-bus (make-event-bus)
+                            #:extension-registry (make-extension-registry)
+                            #:gsd-ctx gsd-a))
+      (define ext-b
+        (make-extension-ctx #:session-id "b"
+                            #:session-dir #f
+                            #:event-bus (make-event-bus)
+                            #:extension-registry (make-extension-registry)
+                            #:gsd-ctx gsd-b))
+      (check-eq? (gsm-ctx-current (ctx-gsd-ctx ext-a)) 'executing "a executing")
+      (check-eq? (gsm-ctx-current (ctx-gsd-ctx ext-b)) 'verifying "b verifying"))))
 
 (run-tests ext-ctx-hooks-suite)


### PR DESCRIPTION
Addresses #5122.

feat(W8): wire runtime extension context to per-session GSD ctx (#5122)

Pass current-gsd-ctx to make-extension-ctx in turn-orchestrator.rkt
so that extension contexts carry the per-session GSD context. In
gsd-planning.rkt, register-gsd-tools now sets current-gsd-ctx from
ctx-gsd-ctx when available, enabling per-session GSD state isolation
through the full runtime → extension → handler pipeline.

5 new TDD tests proving extension-ctx gsd-ctx wiring:
- extension-ctx gsd-ctx field preserves per-session context
- extension-ctx gsd-ctx defaults to #f when not provided
- per-session gsd-ctx isolates state from default
- current-gsd-ctx parameterize dispatches to session ctx
- two sessions have independent gsd-ctx

All existing tests pass. Lint: 22/23.

Wave 8 of v0.57.1.