### PR TITLE
feat(W10): runtime adapter containment — route upward imports through layer-adapters (#5130)

Extended layer-adapters.rkt to re-export extension-registry?,
list-extensions, permission-config?, make-default-permission-config,
current-gsd-ctx, and gsd-session-ctx?. Updated 8 runtime files
(turn-orchestrator, tool-coordinator, session-config, runtime-helpers,
agent-session, and 4 iteration/ modules) to import through the adapter
instead of directly from tools/ and extensions/.

Reduced direct runtime upward imports from 9 to 4 files:
- layer-adapters.rkt (explicit adapter facade)
- package.rkt (manifest reading)
- extension-catalog.rkt (extension loading)
- session-switch.rkt (dynamic-require lazy loading)
- iteration/loop-state.rkt (Typed Racket opaque require)

Updated dependency-policy.rktd: max-exceptions 16→12, removed 5
iteration/ entries that now import via adapter. Updated arch-fitness
threshold accordingly.

All tests pass. Lint: 22/23.

Wave 10 of v0.57.2.

### DIFF
--- a/docs/architecture/dependency-policy.rktd
+++ b/docs/architecture/dependency-policy.rktd
@@ -10,7 +10,7 @@
 
 ;; Layer definitions with max boundary exceptions
 ((layers (runtime
-          (max-exceptions . 16)
+          (max-exceptions . 12)
           (forbidden-from . (llm tools extensions))
           (rationale
            .
@@ -27,29 +27,20 @@
  ;; Known boundary exceptions (files that violate layer rules for documented reasons)
  ;; Format: ((filename . rationale) ...)
  (known-exceptions
-  (runtime . ((agent-session.rkt . "extension registry + DI parameter setup")
-              (iteration/loop-state.rkt . "typed require from extensions/api.rkt for opaque ExtRegistry")
-              (iteration/loop-config.rkt
-               . "typed require of tool-registry? and extension-registry? for loop config")
-              (iteration/loop-phases.rkt
-               . "typed require of extension-registry? for phase dispatch")
-              (iteration/main-loop.rkt
-               . "typed require of tool-registry? and extension-registry? for main loop")
-              (iteration/step-interpreter.rkt
-               . "typed require of permission-config? for step-level permission checks")
-              (layer-adapters.rkt
+  (runtime . ((layer-adapters.rkt
                . "explicit adapter facade routing tool/extension deps behind contained boundary")
+              (iteration/loop-state.rkt . "typed require from extensions/api.rkt for opaque ExtRegistry")
+              (agent-session.rkt . "list-extensions via adapter (re-exports extension listing)")
               (session-lifecycle.rkt
                . "injection-event-topic import (extracted from agent-session/iteration)")
-              (runtime-helpers.rkt . "hook dispatch for session events")
-              (tool-coordinator.rkt . "tool execution orchestration")
-              (turn-orchestrator.rkt . "context assembly + provider turn (sole boundary module)")
+              (runtime-helpers.rkt . "hook dispatch for session events (via adapter)")
+              (tool-coordinator.rkt . "tool execution orchestration (all imports via adapter)")
+              (turn-orchestrator.rkt . "context assembly + provider turn (imports via adapter)")
+              (session-config.rkt . "central typed config (imports via adapter)")
               (package.rkt . "package audit reads extension manifests")
               (extension-catalog.rkt . "extension loading/discovery")
               (session-switch.rkt
-               . "dynamic-require to extensions for lazy loading (avoids circular dependency)")
-              (session-config.rkt
-               . "central typed config referencing cross-layer type predicates")))
+               . "dynamic-require to extensions for lazy loading (avoids circular dependency)")))
   (extensions
    .
    ((dialog-api.rkt . "TUI dialog interface")

--- a/runtime/agent-session.rkt
+++ b/runtime/agent-session.rkt
@@ -35,7 +35,7 @@
          (only-in "../util/event-types.rkt" injection-event-topic)
          "../runtime/compactor.rkt"
          (only-in "../util/extensions.rkt" extension-name)
-         (only-in "../extensions/api.rkt" list-extensions)
+         (only-in "layer-adapters.rkt" list-extensions)
          ;; TR BOUNDARY: event-payloads.rkt is #lang typed/racket.
          (only-in "../util/event-payloads.rkt"
                   session-start-payload

--- a/runtime/iteration/loop-config.rkt
+++ b/runtime/iteration/loop-config.rkt
@@ -13,8 +13,7 @@
 (require racket/contract
          (only-in "../../llm/provider.rkt" provider?)
          (only-in "../../agent/event-bus.rkt" event-bus?)
-         (only-in "../../tools/registry.rkt" tool-registry?)
-         (only-in "../../extensions/api.rkt" extension-registry?)
+         (only-in "../../runtime/layer-adapters.rkt" tool-registry? extension-registry?)
          (only-in "../../util/cancellation.rkt" cancellation-token?)
          (only-in "../../runtime/session-config.rkt" session-config? hash->session-config)
          (only-in "../../runtime/working-set.rkt" working-set?)

--- a/runtime/iteration/loop-phases.rkt
+++ b/runtime/iteration/loop-phases.rkt
@@ -23,7 +23,7 @@
          (only-in "../../agent/queue.rkt" queue? queue-status)
          (only-in "../../runtime/runtime-helpers.rkt" maybe-dispatch-hooks emit-session-event!)
          (only-in "../../util/hook-types.rkt" hook-result-action hook-result?)
-         (only-in "../../extensions/api.rkt" extension-registry?)
+         (only-in "../../runtime/layer-adapters.rkt" extension-registry?)
          (only-in "internal.rkt" assert-payload))
 
 ;; Re-export for consumers

--- a/runtime/iteration/main-loop.rkt
+++ b/runtime/iteration/main-loop.rkt
@@ -51,8 +51,7 @@
                   hash->session-config
                   resolve-max-iterations-hard)
          (only-in "../../llm/provider.rkt" provider?)
-         (only-in "../../tools/registry.rkt" tool-registry?)
-         (only-in "../../extensions/api.rkt" extension-registry?)
+         (only-in "../../runtime/layer-adapters.rkt" tool-registry? extension-registry?)
          (only-in "../../agent/event-bus.rkt" event-bus?)
          (only-in "../../util/loop-result.rkt" loop-result?)
          (only-in "counters.rkt" check-cancellation)

--- a/runtime/iteration/step-interpreter.rkt
+++ b/runtime/iteration/step-interpreter.rkt
@@ -37,7 +37,7 @@
                   message-id
                   tool-call-name
                   tool-call-arguments)
-         (only-in "../../tools/permission-gate.rkt" permission-config?)
+         (only-in "../../runtime/layer-adapters.rkt" permission-config?)
          (only-in "../../runtime/tool-coordinator.rkt"
                   handle-tool-calls-pending
                   extract-tool-calls-from-messages)

--- a/runtime/layer-adapters.rkt
+++ b/runtime/layer-adapters.rkt
@@ -29,9 +29,12 @@
                   tool-registry?
                   make-exec-context
                   make-error-result)
+         (only-in "../tools/permission-gate.rkt" permission-config? make-default-permission-config)
          (only-in "../tools/scheduler.rkt" run-tool-batch scheduler-result scheduler-result-results)
          (only-in "../extensions/hooks.rkt" dispatch-hooks)
-         (only-in "../extensions/context.rkt" make-extension-ctx))
+         (only-in "../extensions/context.rkt" make-extension-ctx)
+         (only-in "../extensions/api.rkt" extension-registry? list-extensions)
+         (only-in "../extensions/gsd/session-state.rkt" current-gsd-ctx gsd-session-ctx?))
 
 ;; Tool schema assembly
 (provide list-tools-jsexpr
@@ -49,4 +52,13 @@
          ;; Extension hooks
          dispatch-hooks
          ;; Extension context factory
-         make-extension-ctx)
+         make-extension-ctx
+         ;; Extension registry + listing
+         extension-registry?
+         list-extensions
+         ;; Permission gate
+         permission-config?
+         make-default-permission-config
+         ;; GSD session context
+         current-gsd-ctx
+         gsd-session-ctx?)

--- a/runtime/runtime-helpers.rkt
+++ b/runtime/runtime-helpers.rkt
@@ -14,7 +14,7 @@
 (require racket/contract
          (only-in "../agent/event-emitter.rkt" emit-session-event!)
          (only-in "../agent/event-bus.rkt" make-event-bus)
-         (only-in "../extensions/hooks.rkt" dispatch-hooks)
+         (only-in "layer-adapters.rkt" dispatch-hooks)
          (only-in "../util/hook-types.rkt" hook-result-payload))
 
 (provide emit-session-event!

--- a/runtime/session-config.rkt
+++ b/runtime/session-config.rkt
@@ -26,9 +26,9 @@
          racket/contract
          (only-in "../runtime/working-set.rkt" working-set?)
          (only-in "../llm/provider.rkt" provider?)
-         (only-in "../tools/registry.rkt" tool-registry?)
+         (only-in "layer-adapters.rkt" tool-registry?)
          (only-in "../agent/event-bus.rkt" event-bus?)
-         (only-in "../extensions/api.rkt" extension-registry?)
+         (only-in "layer-adapters.rkt" extension-registry?)
          (only-in "../runtime/model-registry.rkt" model-registry?)
          (only-in "../runtime/trace-logger.rkt" trace-logger?)
          (only-in "../runtime/settings.rkt" q-settings?)

--- a/runtime/tool-coordinator.rkt
+++ b/runtime/tool-coordinator.rkt
@@ -52,12 +52,12 @@
          "../agent/event-bus.rkt"
          ;; ARCH-01 upward import — runtime→tools
          (only-in "layer-adapters.rkt" make-exec-context make-error-result list-tools-jsexpr)
-         (only-in "../tools/permission-gate.rkt" permission-config? make-default-permission-config)
+         ;; Permission gate via adapter
+         (only-in "layer-adapters.rkt" permission-config? make-default-permission-config)
          ;; ARCH-01 upward import via adapter
          (only-in "layer-adapters.rkt" run-tool-batch scheduler-result scheduler-result-results)
-         ;; ARCH-01 upward import — runtime→extensions: hooks
-         (only-in "../extensions/hooks.rkt" dispatch-hooks)
-         (only-in "../extensions/api.rkt" extension-registry?)
+         ;; Hooks + extension registry via adapter
+         (only-in "layer-adapters.rkt" dispatch-hooks extension-registry?)
          (only-in "../agent/event-bus.rkt" event-bus?)
          (only-in "../runtime/session-store.rkt" append-entries!)
          (only-in "../runtime/settings.rkt" make-minimal-settings setting-ref setting-ref*)

--- a/runtime/turn-orchestrator.rkt
+++ b/runtime/turn-orchestrator.rkt
@@ -50,8 +50,8 @@
          (only-in "../util/loop-result.rkt" loop-result?)
          (only-in "../util/cancellation.rkt" cancellation-token?)
          (only-in "../llm/provider.rkt" provider?)
-         (only-in "../tools/registry.rkt" tool-registry?)
-         (only-in "../extensions/api.rkt" extension-registry?)
+         ;; ARCH-01: tool registry + extension registry via adapter
+         (only-in "layer-adapters.rkt" tool-registry? extension-registry?)
          "../agent/loop.rkt"
          (only-in "../agent/loop-fsm.rkt" current-turn-fsm-state turn-state-blocked)
          ;; ARCH-01: tool registry queries via adapter
@@ -63,7 +63,8 @@
          ;; Context assembly hooks via adapter
          (only-in "layer-adapters.rkt" dispatch-hooks)
          (only-in "layer-adapters.rkt" make-extension-ctx)
-         (only-in "../extensions/gsd/session-state.rkt" current-gsd-ctx gsd-session-ctx?)
+         ;; GSD session context via adapter
+         (only-in "layer-adapters.rkt" current-gsd-ctx gsd-session-ctx?)
          "../runtime/session-store.rkt"
          "../runtime/tool-coordinator.rkt"
          (only-in "../runtime/context-assembly.rkt"

--- a/tests/test-arch-fitness.rkt
+++ b/tests/test-arch-fitness.rkt
@@ -110,10 +110,10 @@
         "Runtime boundary exceptions (~a) exceed policy maximum (~a). Update dependency-policy.rktd or refactor."
         (length runtime-exceptions)
         max-runtime-exc))
-      ;; At least 5 of the known exceptions should still be importing
+      ;; At least 3 of the known exceptions should still be importing
       (check-true
-       (>= (length still-importing) 5)
-       (format "Too few known exceptions still importing from tools/extensions: ~a (expected >= 5)"
+       (>= (length still-importing) 3)
+       (format "Too few known exceptions still importing from tools/extensions: ~a (expected >= 3)"
                still-importing))
       (check-true (<= (length still-importing) max-runtime-exc)
                   (format "More than ~a runtime files importing from tools/extensions: ~a"


### PR DESCRIPTION
Addresses #5130.

feat(W10): runtime adapter containment — route upward imports through layer-adapters (#5130)

Extended layer-adapters.rkt to re-export extension-registry?,
list-extensions, permission-config?, make-default-permission-config,
current-gsd-ctx, and gsd-session-ctx?. Updated 8 runtime files
(turn-orchestrator, tool-coordinator, session-config, runtime-helpers,
agent-session, and 4 iteration/ modules) to import through the adapter
instead of directly from tools/ and extensions/.

Reduced direct runtime upward imports from 9 to 4 files:
- layer-adapters.rkt (explicit adapter facade)
- package.rkt (manifest reading)
- extension-catalog.rkt (extension loading)
- session-switch.rkt (dynamic-require lazy loading)
- iteration/loop-state.rkt (Typed Racket opaque require)

Updated dependency-policy.rktd: max-exceptions 16→12, removed 5
iteration/ entries that now import via adapter. Updated arch-fitness
threshold accordingly.

All tests pass. Lint: 22/23.

Wave 10 of v0.57.2.