### PR TITLE
fix(W11): retry error classification — server vs server-error category mismatch (#5131)

Fixed bug where structured provider errors with category 'server (from
HTTP 5xx via classify-http-status) were silently NOT retried because
retryable-error? checked for 'server-error (with hyphen) instead of
'server. Changed retryable-error? to match 'server.

Added 10 fix verification tests:
- Structured 500/502/503 errors ARE now retryable (F1)
- Context-overflow (string + structured) NOT retryable (F2, F2b)
- String-based 5xx patterns retryable via fallback (F3)
- Structured rate-limit + timeout retryable (F4)
- classify-http-status maps correctly (F5)
- classify-error for structured server error (F6)
- Network errors retryable (F7)
- Auth errors NOT retryable (F8)

All tests pass. Lint: 22/23.

Wave 11 of v0.57.2.

### DIFF
--- a/runtime/auto-retry.rkt
+++ b/runtime/auto-retry.rkt
@@ -118,7 +118,7 @@
      (match (provider-error? exn)
        [#t
         (define cat (provider-error-category exn))
-        (memq cat '(rate-limit timeout server-error network))]
+        (memq cat '(rate-limit timeout server network))]
        [_
         ;; String fallback for non-structured errors
         (define msg (exn-message exn))

--- a/tests/test-retry-error-classification.rkt
+++ b/tests/test-retry-error-classification.rkt
@@ -1,18 +1,18 @@
 #lang racket
 
 ;; BOUNDARY: integration
-;; CHARACTERIZATION TEST — documents current retry/error classification for remediation
+;; FIX VERIFICATION TEST — confirms retry/error classification bug is fixed
 
 ;; tests/test-retry-error-classification.rkt
-;; Pins current retry/error classification behavior.
+;; Verifies that structured provider errors with category 'server are retryable.
 ;;
-;; Key findings:
-;; F1: Structured provider-error with category 'server (from 5xx) is NOT retryable
-;;     because retryable-error? checks for 'server-error but classify-http-status
-;;     returns 'server. This is a CATEGORY MISMATCH BUG.
-;; F2: Context-overflow string errors are correctly NOT retryable.
-;; F3: String-based 5xx patterns ("500", "503") ARE retryable via fallback.
+;; Fixed in W11 (v0.57.2): retryable-error? now checks for 'server (not 'server-error).
+;; Key behaviors:
+;; F1: Structured provider-error with category 'server (from 5xx) IS retryable (FIXED)
+;; F2: Context-overflow errors are correctly NOT retryable.
+;; F3: String-based 5xx patterns ARE retryable via fallback.
 ;; F4: Structured rate-limit and timeout errors ARE correctly retryable.
+;; F5: Auth errors are NOT retryable.
 
 (require rackunit
          rackunit/text-ui
@@ -29,78 +29,85 @@
                   provider-error-status-code
                   classify-http-status))
 
-;; ── Characterization Tests ──
+;; ── Fix Verification Tests ──
 
 (define retry-classification-suite
-  (test-suite "retry-error-classification-characterization"
+  (test-suite "retry-error-classification-fix"
 
-    ;; F1: BUG — structured 5xx (category 'server) NOT retryable
-    (test-case "CHAR: structured 500 provider-error NOT retryable (BUG: server vs server-error)"
-      ;; classify-http-status returns 'server for >= 500
-      ;; retryable-error? checks for 'server-error (with hyphen)
-      ;; These don't match → structured 5xx errors are silently NOT retried
+    ;; F1: FIXED — structured 5xx (category 'server) IS NOW retryable
+    (test-case "FIX: structured 500 provider-error IS retryable (server category)"
       (define err-500
         (provider-error "Internal Server Error" (current-continuation-marks) (hash) 'server 500))
-      (check-equal? (provider-error-category err-500)
-                    'server
-                    "classify-http-status maps 500 → 'server")
-      (check-false (retryable-error? err-500)
-                   "BUG: structured 500 not retryable — 'server ≠ 'server-error")
-      ;; Also test 502, 503
+      (check-equal? (provider-error-category err-500) 'server)
+      (check-not-false (retryable-error? err-500) "FIXED: structured 500 is retryable")
       (define err-502 (provider-error "Bad Gateway" (current-continuation-marks) (hash) 'server 502))
-      (check-false (retryable-error? err-502) "BUG: structured 502 not retryable")
+      (check-not-false (retryable-error? err-502) "FIXED: structured 502 is retryable")
       (define err-503
         (provider-error "Service Unavailable" (current-continuation-marks) (hash) 'server 503))
-      (check-false (retryable-error? err-503) "BUG: structured 503 not retryable"))
+      (check-not-false (retryable-error? err-503) "FIXED: structured 503 is retryable"))
 
-    ;; F2: Context-overflow string errors correctly NOT retryable
-    (test-case "CHAR: context-overflow string error not retryable (correct)"
+    ;; F2: Context-overflow errors correctly NOT retryable
+    (test-case "FIX: context-overflow string error not retryable"
       (define err (exn:fail "context_length exceeded" (current-continuation-marks)))
       (check-true (context-overflow-error? err) "context-overflow detected")
       (check-false (retryable-error? err) "context-overflow correctly not retryable"))
 
+    ;; F2b: Structured context-overflow is NOT retryable
+    (test-case "FIX: structured context-overflow provider-error not retryable"
+      (define err
+        (provider-error "Context length exceeded"
+                        (current-continuation-marks)
+                        (hash)
+                        'context-overflow
+                        413))
+      (check-equal? (provider-error-category err) 'context-overflow)
+      (check-false (retryable-error? err) "structured context-overflow not retryable"))
+
     ;; F3: String-based 5xx IS retryable via fallback
-    (test-case "CHAR: string-based 5xx patterns retryable via fallback"
-      (check-true (retryable-error? (exn:fail "500 Internal Server Error"
-                                              (current-continuation-marks)))
-                  "string '500' is retryable")
-      (check-true (retryable-error? (exn:fail "503 Service Unavailable" (current-continuation-marks)))
-                  "string '503' is retryable"))
+    (test-case "FIX: string-based 5xx patterns retryable via fallback"
+      (check-not-false (retryable-error? (exn:fail "500 Internal Server Error"
+                                                   (current-continuation-marks)))
+                       "string '500' is retryable")
+      (check-not-false (retryable-error? (exn:fail "503 Service Unavailable"
+                                                   (current-continuation-marks)))
+                       "string '503' is retryable"))
 
     ;; F4: Structured rate-limit and timeout ARE correctly retryable
-    (test-case "CHAR: structured rate-limit provider-error retryable"
+    (test-case "FIX: structured rate-limit provider-error retryable"
       (define err
         (provider-error "Rate limit exceeded" (current-continuation-marks) (hash) 'rate-limit 429))
       (check-equal? (provider-error-category err) 'rate-limit)
       (check-not-false (retryable-error? err) "structured rate-limit IS retryable"))
 
-    (test-case "CHAR: structured timeout provider-error retryable"
+    (test-case "FIX: structured timeout provider-error retryable"
       (define err
         (provider-error "Request timed out" (current-continuation-marks) (hash) 'timeout #f))
       (check-equal? (provider-error-category err) 'timeout)
       (check-not-false (retryable-error? err) "structured timeout IS retryable"))
 
-    ;; F5: classify-http-status mapping characterization
-    (test-case "CHAR: classify-http-status maps 5xx to 'server (not 'server-error)"
+    ;; F5: classify-http-status mapping
+    (test-case "FIX: classify-http-status maps 5xx to 'server"
       (check-equal? (classify-http-status 500) 'server)
       (check-equal? (classify-http-status 502) 'server)
       (check-equal? (classify-http-status 503) 'server)
       (check-equal? (classify-http-status 504) 'server))
 
     ;; F6: classify-error for structured server error
-    (test-case "CHAR: classify-error for structured server error"
+    (test-case "FIX: classify-error for structured server error"
       (define err (provider-error "500 error" (current-continuation-marks) (hash) 'server 500))
-      (check-equal? (classify-error err)
-                    'server
-                    "classify-error returns 'server for structured server error (from category)"))
+      (check-equal? (classify-error err) 'server))
 
-    ;; F7: Fix recommendation
-    (test-case "CHAR: document fix for server vs server-error mismatch"
-      ;; Fix: either change classify-http-status to return 'server-error
-      ;; or change retryable-error? to check for 'server instead of 'server-error.
-      ;; Recommendation: change retryable-error? to (memq cat '(... server ...))
-      ;; since 'server is the canonical name from classify-http-status.
-      ;; Also check: does ERROR-CLASSIFICATION-TABLE use 'server or 'server-error?
-      (check-true #t "fix: align category symbol names between classify and retry"))))
+    ;; F7: Network error classification
+    (test-case "FIX: structured network provider-error retryable"
+      (define err
+        (provider-error "Connection refused" (current-continuation-marks) (hash) 'network #f))
+      (check-equal? (provider-error-category err) 'network)
+      (check-not-false (retryable-error? err) "structured network error IS retryable"))
+
+    ;; F8: Auth errors are NOT retryable
+    (test-case "FIX: structured auth provider-error not retryable"
+      (define err (provider-error "Unauthorized" (current-continuation-marks) (hash) 'auth 401))
+      (check-equal? (provider-error-category err) 'auth)
+      (check-false (retryable-error? err) "structured auth error NOT retryable"))))
 
 (run-tests retry-classification-suite)


### PR DESCRIPTION
Addresses #5131.

fix(W11): retry error classification — server vs server-error category mismatch (#5131)

Fixed bug where structured provider errors with category 'server (from
HTTP 5xx via classify-http-status) were silently NOT retried because
retryable-error? checked for 'server-error (with hyphen) instead of
'server. Changed retryable-error? to match 'server.

Added 10 fix verification tests:
- Structured 500/502/503 errors ARE now retryable (F1)
- Context-overflow (string + structured) NOT retryable (F2, F2b)
- String-based 5xx patterns retryable via fallback (F3)
- Structured rate-limit + timeout retryable (F4)
- classify-http-status maps correctly (F5)
- classify-error for structured server error (F6)
- Network errors retryable (F7)
- Auth errors NOT retryable (F8)

All tests pass. Lint: 22/23.

Wave 11 of v0.57.2.