### PR TITLE
feat(W12): runtime contract precision — reduce focused any/c by 5 (#5132)

Tightened contracts in 3 runtime modules:
- auto-retry.rkt: make-retry-policy returns retry-policy? (was any/c),
  with-retry-policy accepts retry-policy? (was any/c),
  make-default-retry-policy returns retry-policy? (was any/c)
- turn-orchestrator.rkt: assemble-context/pure returns (or/c hook-result? #f)
  instead of any/c
- tool-coordinator.rkt: handle-tool-calls-pending accepts session-config?
  (was any/c) and (or/c permission-config? #f) (was any/c)

Net reduction: 6 → 1 any/c in these modules (5 eliminated, target was 3).

All tests pass. Lint: 22/23.

Wave 12 of v0.57.2.

### DIFF
--- a/runtime/auto-retry.rkt
+++ b/runtime/auto-retry.rkt
@@ -30,9 +30,9 @@
                                             #:max-delay-ms exact-nonnegative-integer?
                                             #:on-retry (or/c procedure? #f)
                                             #:per-type-budgets hash?)
-                             any/c)]
+                             retry-policy?)]
                        [with-retry-policy
-                        (->* (any/c procedure?) (#:on-retry (or/c procedure? #f)) any/c)]
+                        (->* (retry-policy? procedure?) (#:on-retry (or/c procedure? #f)) any/c)]
                        [make-default-retry-policy
                         (->* ()
                              (#:max-retries exact-nonnegative-integer?
@@ -40,7 +40,7 @@
                                             #:rate-limit-base-delay-ms exact-nonnegative-integer?
                                             #:max-delay-ms exact-nonnegative-integer?
                                             #:per-type-budgets hash?)
-                             any/c)])
+                             retry-policy?)])
          ;; Configuration
          default-max-retries
          default-base-delay-ms

--- a/runtime/tool-coordinator.rkt
+++ b/runtime/tool-coordinator.rkt
@@ -85,8 +85,8 @@
                               string? ; session-id
                               (or/c path-string? path?) ; log-path
                               (or/c cancellation-token? #f) ; token
-                              any/c) ; config
-                             (#:permission-config any/c)
+                              session-config?) ; config
+                             (#:permission-config (or/c permission-config? #f))
                              (listof message?))]))
 ;; Pure helpers (W2 #4192)
 (provide classify-tool-results

--- a/runtime/turn-orchestrator.rkt
+++ b/runtime/turn-orchestrator.rkt
@@ -137,7 +137,7 @@
           [assemble-context/pure
            (->* (list? session-config?)
                 (#:hook-dispatcher (or/c procedure? #f))
-                (values list? any/c tiered-context?))]))
+                (values list? (or/c hook-result? #f) tiered-context?))]))
 
 ;; ============================================================
 ;; Context assembly


### PR DESCRIPTION
Addresses #5132.

feat(W12): runtime contract precision — reduce focused any/c by 5 (#5132)

Tightened contracts in 3 runtime modules:
- auto-retry.rkt: make-retry-policy returns retry-policy? (was any/c),
  with-retry-policy accepts retry-policy? (was any/c),
  make-default-retry-policy returns retry-policy? (was any/c)
- turn-orchestrator.rkt: assemble-context/pure returns (or/c hook-result? #f)
  instead of any/c
- tool-coordinator.rkt: handle-tool-calls-pending accepts session-config?
  (was any/c) and (or/c permission-config? #f) (was any/c)

Net reduction: 6 → 1 any/c in these modules (5 eliminated, target was 3).

All tests pass. Lint: 22/23.

Wave 12 of v0.57.2.