### PR TITLE
feat(W13): exact contract metric — reader-based any/c counting (#5133)

Replaced regex-based any/c counting with reader-based parsing that only
counts any/c inside actual contract forms (contract-out, define/contract,
->, ->*, etc.), excluding comments and strings.

Key changes:
- strip-lang-lines: strips #lang before reader parsing
- read-all-forms: reader-based form extraction
- count-anyc-in-contract-out-entries: walks contract-out entries correctly
  (skips identifier, counts only in contract expressions)
- count-anyc-in-form: handles provide, define/contract, and raw contract forms

New baseline: 846 any/c (was 878 — 32 were false positives in comments).
15 TDD tests cover: no contract-out, single/multiple any/c, comments,
strings, define/contract, ->*, multi-line, malformed input.

All tests pass. Lint: 22/23.

Wave 13 of v0.57.2.

### DIFF
--- a/scripts/contract-metrics.rkt
+++ b/scripts/contract-metrics.rkt
@@ -1,69 +1,154 @@
 #lang racket
 
-;; q/scripts/contract-metrics.rkt — Count any/c in contract-out across source tree
+;; q/scripts/contract-metrics.rkt — Count any/c in contract forms across source tree
 ;;
 ;; Usage: racket q/scripts/contract-metrics.rkt [--json] [--summary]
 ;;
-;; Scans all .rkt files under src-dirs (excluding tests/, scripts/)
-;; and counts occurrences of `any/c` in files that contain `contract-out`.
+;; Uses the Racket reader to parse files into S-expressions, then walks
+;; the syntax tree to count `any/c` ONLY inside actual contract forms
+;; (contract-out, define/contract, ->, ->*, etc.), not in comments or strings.
 
 (require racket/string
-         racket/file)
+         racket/file
+         racket/port)
 
 ;; ── File discovery ──────────────────────────────────────────
 
-(define src-dirs '("extensions" "agent" "runtime" "tui" "tools" "util"
-                   "interfaces" "cli" "llm" "sandbox" "skills" "wiring"))
+(define src-dirs
+  '("extensions" "agent"
+                 "runtime"
+                 "tui"
+                 "tools"
+                 "util"
+                 "interfaces"
+                 "cli"
+                 "llm"
+                 "sandbox"
+                 "skills"
+                 "wiring"))
 
 (define (under-src-dir? p)
   (define str (path->string p))
-  ;; Strip leading ./ if present
-  (define clean (if (string-prefix? str "./") (substring str 2) str))
+  (define clean
+    (if (string-prefix? str "./")
+        (substring str 2)
+        str))
   (ormap (lambda (d) (string-prefix? clean (string-append d "/"))) src-dirs))
 
 (define (find-src-files [root "."])
   (for/list ([f (in-directory root)]
-             #:when (and (path-has-extension? f #".rkt")
-                         (under-src-dir? f)))
+             #:when (and (path-has-extension? f #".rkt") (under-src-dir? f)))
     (path->string f)))
 
-;; ── Counting ────────────────────────────────────────────────
+;; ── Reader-based parsing ────────────────────────────────────
 
+;; Strip #lang line(s) from content before reading, since the reader
+;; cannot handle #lang directives.
+(define (strip-lang-lines content)
+  (define lines (string-split content "\n" #:trim? #f))
+  (string-join (for/list ([line (in-list lines)]
+                          #:unless (regexp-match? #rx"^#lang" line))
+                 line)
+               "\n"))
+
+;; Read all top-level forms from a string, returning list of datums.
+(define (read-all-forms content)
+  (with-handlers ([exn:fail:read? (lambda (_) '())])
+    (define in (open-input-string (strip-lang-lines content)))
+    (port-count-lines! in)
+    (let loop ([acc '()])
+      (define form (read in))
+      (if (eof-object? form)
+          (reverse acc)
+          (loop (cons form acc))))))
+
+;; ── Contract form detection ─────────────────────────────────
+
+;; Symbols that introduce contract forms where any/c should be counted.
+(define contract-heads '(contract-out define/contract define/contract* -> ->* ->i ->d case-> proc->))
+
+(define (contract-head? d)
+  (and (symbol? d) (memq d contract-heads) #t))
+
+;; ── Counting any/c in contract forms ────────────────────────
+
+;; Count any/c symbols in a datum tree when already inside a contract context.
+(define (count-anyc-raw tree)
+  (cond
+    [(eq? tree 'any/c) 1]
+    [(and (pair? tree) (list? tree)) (for/sum ([sub (in-list tree)]) (count-anyc-raw sub))]
+    [else 0]))
+
+;; Process a contract-out body: each child is (id contract-expr ...)
+;; where the contract expressions (everything after id) contain any/c.
+(define (count-anyc-in-contract-out-entries entries)
+  (for/sum ([entry (in-list entries)])
+           (cond
+             [(and (list? entry) (>= (length entry) 2))
+              ;; Skip the first element (identifier), count any/c in rest
+              (for/sum ([sub (in-list (cdr entry))]) (count-anyc-raw sub))]
+             ;; Single element — probably a rename or struct-out, skip
+             [(and (list? entry) (= (length entry) 1)) 0]
+             [else 0])))
+
+;; Walk a top-level form, counting any/c inside contract contexts.
+(define (count-anyc-in-form form)
+  (cond
+    [(not (list? form)) 0]
+    [(null? form) 0]
+    ;; (provide (contract-out ...)) or (provide/contract-out ...)
+    [(eq? (car form) 'provide)
+     (for/sum ([sub (in-list (cdr form))])
+              (cond
+                [(and (list? sub) (not (null? sub)) (eq? (car sub) 'contract-out))
+                 (count-anyc-in-contract-out-entries (cdr sub))]
+                [else 0]))]
+    ;; (define/contract (name args) contract body ...)
+    ;; The third element (index 2) is the contract expression
+    [(and (eq? (car form) 'define/contract) (>= (length form) 3)) (count-anyc-raw (list-ref form 2))]
+    ;; Other top-level forms with contract heads
+    [(contract-head? (car form)) (count-anyc-raw form)]
+    [else 0]))
+
+;; ── Public API ──────────────────────────────────────────────
+
+;; Count any/c in contract forms within file content string.
 (define (count-anyc-in-file content)
-  ;; Count any/c occurrences in lines that are inside a contract-out form.
-  ;; Simplified: if file contains contract-out, count all any/c.
-  ;; This slightly overcounts (any/c in comments/docs) but is good enough
-  ;; for tracking reduction progress.
-  (if (regexp-match? #rx"contract-out" content)
-      (length (regexp-match-positions* #rx"any/c" content))
-      0))
+  (define forms (read-all-forms content))
+  (for/sum ([form (in-list forms)]) (count-anyc-in-form form)))
+
+;; Helper: count any/c in a contract-form string.
+(define (anyc-in-contract-form? str)
+  (with-handlers ([exn:fail? (lambda (_) 0)])
+    (define form (read (open-input-string str)))
+    (if (and (pair? form) (contract-head? (car form)))
+        (count-anyc-raw form)
+        0)))
 
 ;; ── Main ────────────────────────────────────────────────────
 
 (define (run-metrics #:root [root "."] #:json? [json? #f] #:summary? [summary? #f])
   (define files (find-src-files root))
   (define results
-    (sort
-     (for/list ([f (in-list files)])
-       (define content
-         (with-handlers ([exn:fail? (lambda (_) "")])
-           (file->string f)))
-       (define n (count-anyc-in-file content))
-       (cons f n))
-     > #:key cdr))
+    (sort (for/list ([f (in-list files)])
+            (define content
+              (with-handlers ([exn:fail? (lambda (_) "")])
+                (file->string f)))
+            (define n (count-anyc-in-file content))
+            (cons f n))
+          >
+          #:key cdr))
   (define total (apply + (map cdr results)))
   (define files-with-anyc (filter (lambda (p) (> (cdr p) 0)) results))
 
   (cond
-    [json?
-     (displayln (format "{ \"total\": ~a, \"files\": ~a }"
-                        total (length files-with-anyc)))]
+    [json? (displayln (format "{ \"total\": ~a, \"files\": ~a }" total (length files-with-anyc)))]
     [summary?
      (printf "Total any/c in contract-out: ~a~n" total)
      (printf "Files with any/c: ~a~n" (length files-with-anyc))
      (printf "Total source files scanned: ~a~n" (length files))]
     [else
-     (printf "~n── Contract Metrics: any/c in contract-out ──~n~n")
+     (printf "~n── Contract Metrics: any/c in contract forms ──~n~n")
      (printf "Total: ~a any/c across ~a files~n~n" total (length files-with-anyc))
      (for ([p (in-list files-with-anyc)])
        (printf "  ~a  ~a~n" (cdr p) (car p)))
@@ -73,13 +158,18 @@
 
 ;; ── CLI ─────────────────────────────────────────────────────
 
-(define json-mode #f)
-(define summary-mode #f)
+(module+ main
+  (define json-mode #f)
+  (define summary-mode #f)
 
-(command-line
- #:program "contract-metrics"
- #:once-each
- [("--json") "Output JSON" (set! json-mode #t)]
- [("--summary") "Summary only" (set! summary-mode #t)]
- #:args ()
- (run-metrics #:root "." #:json? json-mode #:summary? summary-mode))
+  (command-line #:program "contract-metrics"
+                #:once-each [("--json") "Output JSON" (set! json-mode #t)]
+                [("--summary") "Summary only" (set! summary-mode #t)]
+                #:args ()
+                (run-metrics #:root "." #:json? json-mode #:summary? summary-mode)))
+
+;; ── Testable exports ────────────────────────────────────────
+
+(provide count-anyc-in-file
+         anyc-in-contract-form?
+         run-metrics)

--- a/tests/test-contract-metrics.rkt
+++ b/tests/test-contract-metrics.rkt
@@ -1,0 +1,92 @@
+#lang racket
+
+;; tests/test-contract-metrics.rkt
+;; TDD tests for contract-metrics exact counting (only any/c inside contract forms)
+
+(require rackunit
+         rackunit/text-ui
+         (only-in "../scripts/contract-metrics.rkt"
+                  count-anyc-in-file
+                  anyc-in-contract-form?))
+
+(define contract-metrics-suite
+  (test-suite "contract-metrics-exact"
+
+    ;; ── count-anyc-in-file: basic cases ──
+
+    (test-case "file with no contract-out has zero any/c"
+      (define content "#lang racket\n(define x 42)\n")
+      (check-equal? (count-anyc-in-file content) 0))
+
+    (test-case "file with contract-out but no any/c has zero"
+      (define content "#lang racket\n(provide (contract-out [foo -> string?]))\n")
+      (check-equal? (count-anyc-in-file content) 0))
+
+    (test-case "single any/c in contract-out counts as 1"
+      (define content "#lang racket\n(provide (contract-out [foo -> any/c]))\n")
+      (check-equal? (count-anyc-in-file content) 1))
+
+    (test-case "any/c in comment is NOT counted"
+      (define content "#lang racket\n;; any/c should not be counted\n(provide (contract-out [foo -> string?]))\n")
+      (check-equal? (count-anyc-in-file content) 0))
+
+    (test-case "any/c in string is NOT counted"
+      (define content "#lang racket\n(define doc \"any/c is a contract\")\n(provide (contract-out [foo -> string?]))\n")
+      (check-equal? (count-anyc-in-file content) 0))
+
+    (test-case "multiple any/c in contract-out all counted"
+      (define content "#lang racket\n(provide (contract-out\n  [foo (-> any/c any/c string?)]\n  [bar (-> any/c)]))\n")
+      (check-equal? (count-anyc-in-file content) 3))
+
+    (test-case "any/c outside contract-out NOT counted"
+      (define content "#lang racket\n(define (f x) x) ;; x is any/c\n(provide (contract-out [foo -> string?]))\n")
+      (check-equal? (count-anyc-in-file content) 0))
+
+    (test-case "any/c in define/contract IS counted"
+      (define content "#lang racket\n(define/contract (foo x)\n  (-> any/c string?)\n  (format \"~a\" x))\n")
+      (check-equal? (count-anyc-in-file content) 1))
+
+    (test-case "any/c in ->* contract counted"
+      (define content "#lang racket\n(provide (contract-out\n  [foo (->* (any/c) (#:bar any/c) any/c)]))\n")
+      (check-equal? (count-anyc-in-file content) 3))
+
+    ;; ── anyc-in-contract-form? helper ──
+
+    (test-case "anyc-in-contract-form? returns 0 for non-contract form"
+      (check-equal? (anyc-in-contract-form? "(define x 42)") 0))
+
+    (test-case "anyc-in-contract-form? returns count for contract form"
+      (check-equal? (anyc-in-contract-form? "(-> any/c string?)") 1))
+
+    (test-case "anyc-in-contract-form? handles nested forms"
+      (check-equal? (anyc-in-contract-form? "(->* (any/c) (#:opt any/c) string?)") 2))
+
+    ;; ── Edge cases ──
+
+    (test-case "malformed sexpr returns 0 (graceful)"
+      (check-equal? (count-anyc-in-file "((broken") 0))
+
+    (test-case "file with both contract-out and comments only counts contract"
+      (define content "#lang racket
+;; any/c in comment
+;; Another any/c reference
+(provide (contract-out
+  [foo (-> any/c string?)]  ;; one any/c in contract
+  [bar (-> string? any/c)]))  ;; another any/c in contract
+;; any/c after contract
+")
+      (check-equal? (count-anyc-in-file content) 2))
+
+    (test-case "multi-line contract forms counted correctly"
+      (define content "#lang racket
+(provide
+ (contract-out
+  [make-thing (->* (string?
+                    exact-nonnegative-integer?)
+                   (#:opt any/c
+                    #:other any/c)
+                   any/c)]))
+")
+      (check-equal? (count-anyc-in-file content) 3))))
+
+(run-tests contract-metrics-suite)


### PR DESCRIPTION
Addresses #5133.

feat(W13): exact contract metric — reader-based any/c counting (#5133)

Replaced regex-based any/c counting with reader-based parsing that only
counts any/c inside actual contract forms (contract-out, define/contract,
->, ->*, etc.), excluding comments and strings.

Key changes:
- strip-lang-lines: strips #lang before reader parsing
- read-all-forms: reader-based form extraction
- count-anyc-in-contract-out-entries: walks contract-out entries correctly
  (skips identifier, counts only in contract expressions)
- count-anyc-in-form: handles provide, define/contract, and raw contract forms

New baseline: 846 any/c (was 878 — 32 were false positives in comments).
15 TDD tests cover: no contract-out, single/multiple any/c, comments,
strings, define/contract, ->*, multi-line, malformed input.

All tests pass. Lint: 22/23.

Wave 13 of v0.57.2.