### PR TITLE
feat(W15): extract TUI context facade into context.rkt (#5141)

Extracted tui-ctx struct, make-tui-ctx constructor, and mark-dirty!
from tui-keybindings.rkt into new q/tui/context.rkt module.

The new module has minimal dependencies (state, input, event-bus) and
provides the struct, all accessors, and contracted constructor.
tui-keybindings.rkt imports from context.rkt and re-exports for full
backward compatibility — no downstream import changes needed.

Verification:
- tui-keybindings.rkt compiles and re-exports correctly
- tui-render-loop.rkt, tui-init.rkt, interfaces/tui.rkt compile unchanged
- 34 TUI tests pass (keybindings: 9, init: 7, render-loop: 18)
- Lint: 22/23

Wave 15 of v0.57.3.

### DIFF
--- a/tui/context.rkt
+++ b/tui/context.rkt
@@ -1,0 +1,91 @@
+#lang racket/base
+
+;; q/tui/context.rkt — TUI context struct, constructor, and dirty flag
+;;
+;; Extracted from tui-keybindings.rkt (W15) to reduce hotspot complexity.
+;; This is a leaf module with minimal dependencies.
+
+(require racket/contract
+         racket/async-channel
+         "state.rkt"
+         "input.rkt"
+         "../agent/event-bus.rkt")
+
+;; ── tui-ctx struct ──
+;; Holds mutable references for the running TUI
+(struct tui-ctx
+        (ui-state-box ; (boxof ui-state)
+         input-state-box ; (boxof input-state)
+         event-bus ; event-bus? or #f
+         session-runner ; (string -> void) — called with user prompts
+         running-box ; (boxof boolean) — set to #f to exit
+         event-ch ; async-channel — serializes runtime events into main loop (unbounded buffer)
+         session-dir ; (or/c path-string? #f) — session directory for index loading
+         needs-redraw-box ; (boxof boolean) — #t when state changed and frame needs redraw
+         term-box ; (boxof any) — terminal instance for tui-term
+         ubuf-box ; (boxof any) — ubuf buffer for output
+         model-registry-box ; (boxof (or/c model-registry? #f)) — model registry for /model
+         previous-frame-box ; (boxof (or/c (listof string) #f)) — last rendered frame for diffing
+         last-prompt-box ; (boxof (or/c string? #f)) — last user prompt for /retry
+         extension-registry-box ; (or/c (boxof (or/c extension-registry? #f)) #f)
+         session-queue-box ; (boxof (or/c queue? #f)) — agent queue for followup during streaming (G3.1)
+         session-factory-runner) ; (or/c (string -> void) #f) — creates fresh session for /go
+  #:transparent)
+
+(define (make-tui-ctx #:event-bus [bus #f]
+                      #:session-runner [runner (lambda (prompt) (void))]
+                      #:session-dir [sess-dir #f]
+                      #:model-registry [reg #f]
+                      #:extension-registry [ext-reg #f]
+                      #:session-queue [sess-queue #f]
+                      #:session-factory-runner [factory #f])
+  (tui-ctx (box (initial-ui-state))
+           (box (initial-input-state))
+           bus
+           runner
+           (box #t)
+           (make-async-channel)
+           sess-dir
+           (box #t) ; needs-redraw: #t for first frame
+           (box #f) ; term-box - set when terminal opened
+           (box #f) ; ubuf-box - set when buffer created
+           (box reg) ; model-registry-box
+           (box #f) ; previous-frame-box - #f means no previous frame
+           (box #f) ; last-prompt-box - #f until first submit
+           (box ext-reg) ; extension-registry-box
+           (box sess-queue) ; session-queue-box
+           factory))
+
+;; Mark that the frame needs redraw.
+(define (mark-dirty! ctx)
+  (set-box! (tui-ctx-needs-redraw-box ctx) #t))
+
+(provide tui-ctx
+         tui-ctx?
+         tui-ctx-ui-state-box
+         tui-ctx-input-state-box
+         tui-ctx-event-bus
+         tui-ctx-session-runner
+         tui-ctx-running-box
+         tui-ctx-event-ch
+         tui-ctx-session-dir
+         tui-ctx-needs-redraw-box
+         tui-ctx-term-box
+         tui-ctx-ubuf-box
+         tui-ctx-model-registry-box
+         tui-ctx-previous-frame-box
+         tui-ctx-last-prompt-box
+         tui-ctx-extension-registry-box
+         tui-ctx-session-queue-box
+         tui-ctx-session-factory-runner
+         (contract-out [make-tui-ctx
+                        (->* ()
+                             (#:event-bus (or/c event-bus? #f)
+                                          #:session-runner procedure?
+                                          #:session-dir (or/c path-string? #f)
+                                          #:model-registry any/c
+                                          #:extension-registry any/c
+                                          #:session-queue any/c
+                                          #:session-factory-runner any/c)
+                             tui-ctx?)]
+                       [mark-dirty! (-> tui-ctx? void?)]))

--- a/tui/tui-keybindings.rkt
+++ b/tui/tui-keybindings.rkt
@@ -20,7 +20,6 @@
          racket/string
          racket/match
          racket/list
-         racket/async-channel
          "../tui/terminal.rkt"
          "../tui/state.rkt"
          "../tui/input.rkt"
@@ -30,6 +29,28 @@
          "../tui/char-width.rkt"
          "../util/protocol-types.rkt"
          "../agent/event-bus.rkt"
+         ;; W15: tui-ctx struct, constructor, mark-dirty! extracted to context.rkt
+         (only-in "context.rkt"
+                  tui-ctx
+                  tui-ctx?
+                  tui-ctx-ui-state-box
+                  tui-ctx-input-state-box
+                  tui-ctx-event-bus
+                  tui-ctx-session-runner
+                  tui-ctx-running-box
+                  tui-ctx-event-ch
+                  tui-ctx-session-dir
+                  tui-ctx-needs-redraw-box
+                  tui-ctx-term-box
+                  tui-ctx-ubuf-box
+                  tui-ctx-model-registry-box
+                  tui-ctx-previous-frame-box
+                  tui-ctx-last-prompt-box
+                  tui-ctx-extension-registry-box
+                  tui-ctx-session-queue-box
+                  tui-ctx-session-factory-runner
+                  make-tui-ctx
+                  mark-dirty!)
          (prefix-in commands: "../tui/commands.rkt")
          (only-in "../tui/commands.rkt" cmd-ctx?)
          (only-in "../tui/command-parse.rkt" parsed-command?)
@@ -78,83 +99,33 @@
          load-keybindings
          make-mode-keymap
          mode-overlay->keymap
-         (contract-out [make-tui-ctx
-                        (->* ()
-                             (#:event-bus (or/c event-bus? #f)
-                                          #:session-runner procedure?
-                                          #:session-dir (or/c path-string? #f)
-                                          #:model-registry any/c
-                                          #:extension-registry any/c
-                                          #:session-queue any/c
-                                          #:session-factory-runner any/c)
-                             tui-ctx?)]
-                       [mark-dirty! (-> tui-ctx? void?)]
-                       [handle-key (-> tui-ctx? any/c any/c)]
-                       [handle-mouse (-> tui-ctx? any/c any/c)]
-                       [selection-text (-> tui-ctx? ui-state? (or/c string? #f))]
-                       [process-slash-command
-                        (->* (tui-ctx? (or/c string? symbol? parsed-command?)) (string?) (or/c 'continue 'quit))]
-                       [tui-ctx->cmd-ctx (-> tui-ctx? cmd-ctx?)]
-                       [reload-keymap! (-> void?)]
-                       [current-keybindings-path
-                        (->* () ((or/c path-string? #f)) (or/c path-string? #f))]
-                       [input-expand-last-prompt (-> string? tui-ctx? string?)]))
+         (contract-out
+          [make-tui-ctx
+           (->* ()
+                (#:event-bus (or/c event-bus? #f)
+                             #:session-runner procedure?
+                             #:session-dir (or/c path-string? #f)
+                             #:model-registry any/c
+                             #:extension-registry any/c
+                             #:session-queue any/c
+                             #:session-factory-runner any/c)
+                tui-ctx?)]
+          [mark-dirty! (-> tui-ctx? void?)]
+          [handle-key (-> tui-ctx? any/c any/c)]
+          [handle-mouse (-> tui-ctx? any/c any/c)]
+          [selection-text (-> tui-ctx? ui-state? (or/c string? #f))]
+          [process-slash-command
+           (->* (tui-ctx? (or/c string? symbol? parsed-command?)) (string?) (or/c 'continue 'quit))]
+          [tui-ctx->cmd-ctx (-> tui-ctx? cmd-ctx?)]
+          [reload-keymap! (-> void?)]
+          [current-keybindings-path (->* () ((or/c path-string? #f)) (or/c path-string? #f))]
+          [input-expand-last-prompt (-> string? tui-ctx? string?)]))
 
 ;; ============================================================
-;; TUI context
+;; TUI context — extracted to context.rkt (W15)
 ;; ============================================================
-
-;; Holds mutable references for the running TUI
-(struct tui-ctx
-        (ui-state-box ; (boxof ui-state)
-         input-state-box ; (boxof input-state)
-         event-bus ; event-bus? or #f
-         session-runner ; (string -> void) — called with user prompts
-         running-box ; (boxof boolean) — set to #f to exit
-         event-ch ; async-channel — serializes runtime events into main loop (unbounded buffer)
-         session-dir ; (or/c path-string? #f) — session directory for index loading
-         needs-redraw-box ; (boxof boolean) — #t when state changed and frame needs redraw
-         term-box ; (boxof any) — terminal instance for tui-term
-         ubuf-box ; (boxof any) — ubuf buffer for output
-         model-registry-box ; (boxof (or/c model-registry? #f)) — model registry for /model
-         previous-frame-box ; (boxof (or/c (listof string) #f)) — last rendered frame for diffing
-         last-prompt-box ; (boxof (or/c string? #f)) — last user prompt for /retry
-         extension-registry-box ; (or/c (boxof (or/c extension-registry? #f)) #f)
-         session-queue-box ; (boxof (or/c queue? #f)) — agent queue for followup during streaming (G3.1)
-         session-factory-runner) ; (or/c (string -> void) #f) — creates fresh session for /go
-  )
-
-(define (make-tui-ctx #:event-bus [bus #f]
-                      #:session-runner [runner (lambda (prompt) (void))]
-                      #:session-dir [sess-dir #f]
-                      #:model-registry [reg #f]
-                      #:extension-registry [ext-reg #f]
-                      #:session-queue [sess-queue #f]
-                      #:session-factory-runner [factory #f])
-  (tui-ctx (box (initial-ui-state))
-           (box (initial-input-state))
-           bus
-           runner
-           (box #t)
-           (make-async-channel)
-           sess-dir
-           (box #t) ; needs-redraw: #t for first frame
-           (box #f) ; term-box - set when terminal opened
-           (box #f) ; ubuf-box - set when buffer created
-           (box reg) ; model-registry-box
-           (box #f) ; previous-frame-box - #f means no previous frame
-           (box #f) ; last-prompt-box - #f until first submit
-           (box ext-reg) ; extension-registry-box
-           (box sess-queue) ; session-queue-box
-           factory))
-
-;; ============================================================
-;; mark-dirty!
-;; ============================================================
-
-;; Mark that the frame needs redraw.
-(define (mark-dirty! ctx)
-  (set-box! (tui-ctx-needs-redraw-box ctx) #t))
+;; tui-ctx struct, make-tui-ctx, and mark-dirty! are now imported
+;; from q/tui/context.rkt and re-exported for backward compatibility.
 
 ;; ============================================================
 ;; Selection math


### PR DESCRIPTION
Addresses #5141.

feat(W15): extract TUI context facade into context.rkt (#5141)

Extracted tui-ctx struct, make-tui-ctx constructor, and mark-dirty!
from tui-keybindings.rkt into new q/tui/context.rkt module.

The new module has minimal dependencies (state, input, event-bus) and
provides the struct, all accessors, and contracted constructor.
tui-keybindings.rkt imports from context.rkt and re-exports for full
backward compatibility — no downstream import changes needed.

Verification:
- tui-keybindings.rkt compiles and re-exports correctly
- tui-render-loop.rkt, tui-init.rkt, interfaces/tui.rkt compile unchanged
- 34 TUI tests pass (keybindings: 9, init: 7, render-loop: 18)
- Lint: 22/23

Wave 15 of v0.57.3.