### PR TITLE
feat(W18): extract process-tui-message! from render loop (#5144)

Extract the TUI message dispatch (key/resize/redraw/paste/mouse) from
tui-main-loop into q/tui/message-dispatch.rkt. The render loop now
calls process-tui-message! and only handles the 'resize signal locally
(due to tui-ctx-resize-ubuf! circular dependency).

tui-render-loop.rkt reduced from 465 → 356 lines (23%).
New module: message-dispatch.rkt (63 lines).

Verification:
- All downstream modules compile (tui-render-loop, tui-init, interfaces/tui)
- TUI tests pass (keybindings: 9, render-loop: 18, init: 7, submit: 3)
- Lint: 22/23

Wave 18 of v0.57.3.

### DIFF
--- a/tui/message-dispatch.rkt
+++ b/tui/message-dispatch.rkt
@@ -1,0 +1,63 @@
+#lang racket/base
+
+;; q/tui/message-dispatch.rkt — TUI message dispatch
+;;
+;; Extracted from tui-render-loop.rkt (W18) to make the main loop
+;; testable and reduce the render loop's responsibility.
+;;
+;; Handles: key, redraw, paste, mouse messages.
+;; Resize handling stays in render-loop (circular dep on tui-ctx-resize-ubuf!).
+
+(require "tui-keybindings.rkt"
+         "submit-handler.rkt"
+         "input.rkt")
+
+;; Process a single TUI message (from next-message adapter).
+;; Returns 'quit if quit requested, 'resize if resize needed, or void.
+;; The caller handles 'resize by calling tui-ctx-resize-ubuf! etc.
+(define (process-tui-message! ctx msg)
+  (case (car msg)
+    ;; Key press: dispatch to handler
+    [(key)
+     (define keycode (cadr msg))
+     ;; G1.1: Intercept tree-browser overlay keys before normal handling
+     (define tree-result (handle-tree-overlay-key ctx keycode))
+     (cond
+       [(eq? tree-result 'handled) (void)]
+       [else
+        (define result (handle-key ctx keycode))
+        (cond
+          [(eq? result 'quit)
+           (set-box! (tui-ctx-running-box ctx) #f)
+           'quit]
+          [(and (list? result) (eq? (car result) 'submit))
+           (define raw-text (cadr result))
+           ;; G3.3: Expand !! inline bash prefix
+           (define text (expand-inline-bash raw-text (unbox (tui-ctx-last-prompt-box ctx))))
+           ;; Store prompt for /retry (#1378)
+           (set-box! (tui-ctx-last-prompt-box ctx) text)
+           (handle-user-submit! ctx text)]
+          [(and (list? result) (eq? (car result) 'command))
+           (define cmd (cadr result))
+           (define raw-text
+             (if (>= (length result) 3)
+                 (caddr result)
+                 ""))
+           (process-slash-command ctx cmd raw-text)]
+          [else (void)])])]
+    ;; Resize event: signal caller
+    [(resize) 'resize]
+    ;; Redraw command: mark dirty
+    [(redraw) (mark-dirty! ctx)]
+    ;; Paste event: insert as single undo entry
+    [(paste)
+     (define text (cadr msg))
+     (define inp (unbox (tui-ctx-input-state-box ctx)))
+     (set-box! (tui-ctx-input-state-box ctx) (input-insert-string inp text))
+     (mark-dirty! ctx)]
+    ;; Mouse event: dispatch to handler
+    [(mouse) (handle-mouse ctx (cdr msg))]
+    ;; Unknown message type - ignore
+    [else (void)]))
+
+(provide process-tui-message!)

--- a/tui/tui-render-loop.rkt
+++ b/tui/tui-render-loop.rkt
@@ -36,7 +36,9 @@
          (only-in "../runtime/session-lifecycle.rkt" write-crash-log!)
          "../tui/tree-view.rkt"
          ;; W17: handle-user-submit! extracted to submit-handler.rkt
-         "submit-handler.rkt")
+         "submit-handler.rkt"
+         ;; W18: process-tui-message! extracted to message-dispatch.rkt
+         "message-dispatch.rkt")
 
 (define (tui-output-port)
   (or (guarded-real-output-port) (current-output-port)))
@@ -329,56 +331,11 @@
       (define msg (next-message ctx #:timeout 0.05))
 
       (when msg
-        (case (car msg)
-          ;; Key press: dispatch to handler
-          [(key)
-           (define keycode (cadr msg))
-           ;; G1.1: Intercept tree-browser overlay keys before normal handling
-           (define tree-result (handle-tree-overlay-key ctx keycode))
-           (cond
-             [(eq? tree-result 'handled) (void)]
-             [else
-              (define result (handle-key ctx keycode))
-              (cond
-                [(eq? result 'quit) (set-box! (tui-ctx-running-box ctx) #f)]
-                [(and (list? result) (eq? (car result) 'submit))
-                 (define raw-text (cadr result))
-                 ;; G3.3: Expand !! inline bash prefix
-                 (define text (expand-inline-bash raw-text (unbox (tui-ctx-last-prompt-box ctx))))
-                 ;; Store prompt for /retry (#1378)
-                 (set-box! (tui-ctx-last-prompt-box ctx) text)
-                 (handle-user-submit! ctx text)]
-                [(and (list? result) (eq? (car result) 'command))
-                 (define cmd (cadr result))
-                 (define raw-text
-                   (if (>= (length result) 3)
-                       (caddr result)
-                       ""))
-                 (process-slash-command ctx cmd raw-text)]
-                [else (void)])])]
-          ;; Resize event: resize ubuf and mark dirty
-          [(resize)
-           (define cols (cadr msg))
-           (define rows (caddr msg))
-           (tui-ctx-resize-ubuf! ctx)
-           (tui-screen-size-cache-reset!)
-           (mark-dirty! ctx)]
-
-          ;; Redraw command: mark dirty
-          [(redraw) (mark-dirty! ctx)]
-
-          ;; Paste event: insert as single undo entry
-          [(paste)
-           (define text (cadr msg))
-           (define inp (unbox (tui-ctx-input-state-box ctx)))
-           (set-box! (tui-ctx-input-state-box ctx) (input-insert-string inp text))
-           (mark-dirty! ctx)]
-
-          ;; Mouse event: dispatch to handler
-          [(mouse) (handle-mouse ctx (cdr msg))]
-
-          ;; Unknown message type - ignore
-          [else (void)]))
+        (define result (process-tui-message! ctx msg))
+        (when (eq? result 'resize)
+          (tui-ctx-resize-ubuf! ctx)
+          (tui-screen-size-cache-reset!)
+          (mark-dirty! ctx)))
 
       (when (unbox (tui-ctx-running-box ctx))
         (loop)))))


### PR DESCRIPTION
Addresses #5144.

feat(W18): extract process-tui-message! from render loop (#5144)

Extract the TUI message dispatch (key/resize/redraw/paste/mouse) from
tui-main-loop into q/tui/message-dispatch.rkt. The render loop now
calls process-tui-message! and only handles the 'resize signal locally
(due to tui-ctx-resize-ubuf! circular dependency).

tui-render-loop.rkt reduced from 465 → 356 lines (23%).
New module: message-dispatch.rkt (63 lines).

Verification:
- All downstream modules compile (tui-render-loop, tui-init, interfaces/tui)
- TUI tests pass (keybindings: 9, render-loop: 18, init: 7, submit: 3)
- Lint: 22/23

Wave 18 of v0.57.3.