### PR TITLE
feat(W23): migrate loop-result.rkt to Typed Racket (#5156)

Migrate util/loop-result.rkt from #lang racket/base with contract-out
to #lang typed/racket with raw provide. TR auto-generates contracts
at the typed/untyped boundary.

Per ADR 0014: stable, struct-heavy module with no untyped library
interaction. Migration eliminates explicit contract-out overhead and
adds compile-time type checking for the struct fields.

Contract metrics: 813 → 812 any/c (loop-result? predicate removed
from contract-out count). Files with any/c: 144 → 143.

Verification:
- main.rkt compiles (all callers work through TR boundary)
- test-protocol-types-split: 37 pass
- test-termination-reasons: 3 pass
- test-iteration-decision: 11 pass
- Lint: 22/23

Wave 23 of v0.57.4.

### DIFF
--- a/util/loop-result.rkt
+++ b/util/loop-result.rkt
@@ -1,19 +1,31 @@
-#lang racket/base
+#lang typed/racket
 
 ;; util/loop-result.rkt — Loop result struct
 ;;
 ;; Extracted from protocol-types.rkt (ARCH-05 split).
+;; Migrated to Typed Racket (W23) per ADR 0014.
+;;
+;; TR BOUNDARY:
+;; This is a #lang typed/racket module. Untyped consumers receive
+;; auto-generated contracts from the TR boundary system. Struct
+;; constructors and accessors enforce field types at call sites.
 
-(require racket/contract)
+(provide loop-result
+         loop-result?
+         loop-result-messages
+         loop-result-termination-reason
+         loop-result-metadata
+         make-loop-result)
 
-(provide (contract-out [loop-result? (-> any/c boolean?)]
-                       [loop-result-messages (-> loop-result? list?)]
-                       [loop-result-termination-reason (-> loop-result? (or/c symbol? #f))]
-                       [loop-result-metadata (-> loop-result? hash?)]
-                       [make-loop-result (-> list? (or/c symbol? #f) hash? loop-result?)])
-         loop-result)
+;; ============================================================
+;; Loop result struct
+;; ============================================================
 
-(struct loop-result (messages termination-reason metadata) #:transparent)
+(struct loop-result ([messages : (Listof Any)]
+                     [termination-reason : (U Symbol #f)]
+                     [metadata : (HashTable Symbol Any)])
+  #:transparent)
 
+(: make-loop-result (-> (Listof Any) (U Symbol #f) (HashTable Symbol Any) loop-result))
 (define (make-loop-result messages termination-reason metadata)
   (loop-result messages termination-reason metadata))


### PR DESCRIPTION
Addresses #5156.

feat(W23): migrate loop-result.rkt to Typed Racket (#5156)

Migrate util/loop-result.rkt from #lang racket/base with contract-out
to #lang typed/racket with raw provide. TR auto-generates contracts
at the typed/untyped boundary.

Per ADR 0014: stable, struct-heavy module with no untyped library
interaction. Migration eliminates explicit contract-out overhead and
adds compile-time type checking for the struct fields.

Contract metrics: 813 → 812 any/c (loop-result? predicate removed
from contract-out count). Files with any/c: 144 → 143.

Verification:
- main.rkt compiles (all callers work through TR boundary)
- test-protocol-types-split: 37 pass
- test-termination-reasons: 3 pass
- test-iteration-decision: 11 pass
- Lint: 22/23

Wave 23 of v0.57.4.