### PR TITLE
feat(W25): boundary exception blocking gate with owner/revisit-by (#5163)

Add blocking gate for undocumented upward imports:
- Enhanced dependency-policy.rktd with structured exception format:
  each exception now has rationale, owner, and revisit-by date
- New test: "All boundary exceptions have required metadata" — fails
  if any exception is missing owner or revisit-by fields
- New test: "No boundary exception has expired revisit-by date" —
  fails if any revisit-by date has passed without reassessment

All 5 boundary tests pass (3 original + 2 new gate tests).
Lint: 22/23.

Wave 25 of v0.57.5.

### DIFF
--- a/docs/architecture/dependency-policy.rktd
+++ b/docs/architecture/dependency-policy.rktd
@@ -25,29 +25,72 @@
               (forbidden-from . (runtime tools extensions))
               (rationale . "LLM providers are leaf modules with no upward imports")))
  ;; Known boundary exceptions (files that violate layer rules for documented reasons)
- ;; Format: ((filename . rationale) ...)
+ ;; Format: ((filename (rationale . "...") (owner . "...") (revisit-by . "YYYY-MM-DD")) ...)
+ ;; Owner: responsible module/component. Revisit-by: date to reassess necessity.
+ ;; Gate test: undocumented exceptions (missing owner/revisit-by) will FAIL.
  (known-exceptions
   (runtime . ((layer-adapters.rkt
-               . "explicit adapter facade routing tool/extension deps behind contained boundary")
-              (iteration/loop-state.rkt . "typed require from extensions/api.rkt for opaque ExtRegistry")
-              (agent-session.rkt . "list-extensions via adapter (re-exports extension listing)")
+               (rationale . "explicit adapter facade routing tool/extension deps behind contained boundary")
+               (owner . "runtime")
+               (revisit-by . "2026-07-01"))
+              (iteration/loop-state.rkt
+               (rationale . "typed require from extensions/api.rkt for opaque ExtRegistry")
+               (owner . "iteration")
+               (revisit-by . "2026-08-01"))
+              (agent-session.rkt
+               (rationale . "list-extensions via adapter (re-exports extension listing)")
+               (owner . "runtime")
+               (revisit-by . "2026-07-01"))
               (session-lifecycle.rkt
-               . "injection-event-topic import (extracted from agent-session/iteration)")
-              (runtime-helpers.rkt . "hook dispatch for session events (via adapter)")
-              (tool-coordinator.rkt . "tool execution orchestration (all imports via adapter)")
-              (turn-orchestrator.rkt . "context assembly + provider turn (imports via adapter)")
-              (session-config.rkt . "central typed config (imports via adapter)")
-              (package.rkt . "package audit reads extension manifests")
-              (extension-catalog.rkt . "extension loading/discovery")
+               (rationale . "injection-event-topic import (extracted from agent-session/iteration)")
+               (owner . "runtime")
+               (revisit-by . "2026-07-01"))
+              (runtime-helpers.rkt
+               (rationale . "hook dispatch for session events (via adapter)")
+               (owner . "runtime")
+               (revisit-by . "2026-07-01"))
+              (tool-coordinator.rkt
+               (rationale . "tool execution orchestration (all imports via adapter)")
+               (owner . "tools")
+               (revisit-by . "2026-07-01"))
+              (turn-orchestrator.rkt
+               (rationale . "context assembly + provider turn (imports via adapter)")
+               (owner . "runtime")
+               (revisit-by . "2026-07-01"))
+              (session-config.rkt
+               (rationale . "central typed config (imports via adapter)")
+               (owner . "runtime")
+               (revisit-by . "2026-07-01"))
+              (package.rkt
+               (rationale . "package audit reads extension manifests")
+               (owner . "extensions")
+               (revisit-by . "2026-08-01"))
+              (extension-catalog.rkt
+               (rationale . "extension loading/discovery")
+               (owner . "extensions")
+               (revisit-by . "2026-08-01"))
               (session-switch.rkt
-               . "dynamic-require to extensions for lazy loading (avoids circular dependency)")))
+               (rationale . "dynamic-require to extensions for lazy loading (avoids circular dependency)")
+               (owner . "runtime")
+               (revisit-by . "2026-07-01"))))
   (extensions
    .
-   ((dialog-api.rkt . "TUI dialog interface")
-    (ui-surface.rkt . "TUI UI surface interface")
-    (context.rkt . "imports runtime/session-types.rkt for context assembly (bidirectional — fragile)")
+   ((dialog-api.rkt
+     (rationale . "TUI dialog interface")
+     (owner . "tui")
+     (revisit-by . "2026-07-01"))
+    (ui-surface.rkt
+     (rationale . "TUI UI surface interface")
+     (owner . "tui")
+     (revisit-by . "2026-07-01"))
+    (context.rkt
+     (rationale . "imports runtime/session-types.rkt for context assembly (bidirectional — fragile)")
+     (owner . "extensions")
+     (revisit-by . "2026-07-01"))
     (ext-package-manager.rkt
-     . "imports runtime/ for package lifecycle management (bidirectional — fragile)"))))
+     (rationale . "imports runtime/ for package lifecycle management (bidirectional — fragile)")
+     (owner . "extensions")
+     (revisit-by . "2026-07-01")))))
  ;; Module size configuration
  (module-size (max-lines . 900) (known-large . ()))
  ;; Complexity budgets (informational in v0.22.8, enforced in v0.23.0)

--- a/tests/test-arch-boundaries.rkt
+++ b/tests/test-arch-boundaries.rkt
@@ -15,7 +15,8 @@
 
 (require rackunit
          rackunit/text-ui
-         "helpers/arch-utils.rkt")
+         "helpers/arch-utils.rkt"
+         racket/date)
 
 ;; Load policy from single source of truth
 (define policy-path (build-path q-dir "docs" "architecture" "dependency-policy.rktd"))
@@ -41,6 +42,7 @@
       (define runtime-files (rkt-files-in-recursive "runtime"))
       (define runtime-exc (policy-ref 'known-exceptions 'runtime))
       ;; Build set of known exception RELATIVE paths (e.g. "runtime/iteration/loop-config.rkt")
+      ;; Each entry is either (filename . "rationale") or (filename (rationale . "...") ...)
       (define known-exceptions
         (for/fold ([acc (set)]) ([entry (in-list runtime-exc)])
           (define name
@@ -81,6 +83,50 @@
       (check-equal? actual-violations
                     '()
                     (format "TUI modules importing from forbidden layers: ~a" actual-violations)))
+
+    (test-case "All boundary exceptions have required metadata (owner, revisit-by)"
+      ;; W25 blocking gate: every known exception must have owner and revisit-by fields.
+      ;; Undocumented exceptions (missing metadata) cause test failure.
+      (define layers-with-exceptions '(runtime extensions))
+      (define missing-metadata
+        (for*/list ([layer (in-list layers-with-exceptions)]
+                    [entry (in-list (policy-ref 'known-exceptions layer))])
+          (define name (car entry))
+          (define fields (cdr entry))
+          (define (has-field? f)
+            (and (pair? fields) (assoc f fields)))
+          (cond
+            [(not (has-field? 'owner)) (format "~a/~a: missing owner" layer name)]
+            [(not (has-field? 'revisit-by)) (format "~a/~a: missing revisit-by" layer name)]
+            [else #f])))
+      (define actual-missing (filter identity missing-metadata))
+      (check-equal? actual-missing
+                    '()
+                    (format "Boundary exceptions missing metadata: ~a" actual-missing)))
+
+    (test-case "No boundary exception has expired revisit-by date"
+      ;; W25 blocking gate: expired revisit-by dates must be addressed.
+      ;; Uses simple YYYY-MM-DD string comparison (ISO format sorts lexicographically).
+      (define layers-with-exceptions '(runtime extensions))
+      (define today-str
+        (parameterize ([date-display-format 'iso-8601])
+          (date->string (seconds->date (current-seconds)))))
+      (define expired
+        (for*/list ([layer (in-list layers-with-exceptions)]
+                    [entry (in-list (policy-ref 'known-exceptions layer))])
+          (define name (car entry))
+          (define fields (cdr entry))
+          (define revisit (and (pair? fields) (assoc 'revisit-by fields)))
+          (if revisit
+              (let ([date-str (cdr revisit)])
+                (if (string<? date-str today-str)
+                    (format "~a/~a: revisit-by ~a has expired" layer name date-str)
+                    #f))
+              #f)))
+      (define actual-expired (filter identity expired))
+      (check-equal? actual-expired
+                    '()
+                    (format "Expired boundary exceptions need reassessment: ~a" actual-expired)))
 
     (test-case "Recursive boundary scan includes subdirectory modules"
       ;; Prove that rkt-files-in-recursive catches files in nested directories


### PR DESCRIPTION
Addresses #5163.

feat(W25): boundary exception blocking gate with owner/revisit-by (#5163)

Add blocking gate for undocumented upward imports:
- Enhanced dependency-policy.rktd with structured exception format:
  each exception now has rationale, owner, and revisit-by date
- New test: "All boundary exceptions have required metadata" — fails
  if any exception is missing owner or revisit-by fields
- New test: "No boundary exception has expired revisit-by date" —
  fails if any revisit-by date has passed without reassessment

All 5 boundary tests pass (3 original + 2 new gate tests).
Lint: 22/23.

Wave 25 of v0.57.5.