### PR TITLE
feat(W26): hotspot budget policy with risk notes (#5164)

Add hotspot budget section to dependency-policy.rktd:
- warn-threshold: 5000 (advisory)
- block-threshold: 20000 (must have risk note)
- Risk notes for top 2 hotspots: agent-session.rkt, session-lifecycle.rkt

New test: "Hotspot budget: files exceeding block-threshold have risk notes"
validates that files scoring > 20000 have documented risk notes in the policy.

All 6 hotspot tests pass (5 original + 1 new budget gate).
Lint: 22/23.

Wave 26 of v0.57.5.

### DIFF
--- a/docs/architecture/dependency-policy.rktd
+++ b/docs/architecture/dependency-policy.rktd
@@ -157,4 +157,18 @@
  (parser-modules ("extensions/gsd/command-parser.rkt" "tui/command-parse.rkt" "cli/args.rkt"))
  ;; R-20: Provide surface budget
  ;; Alert when public API of a single module exceeds this count.
- (provide-surface-budget (max-per-module . 150) (alert-threshold . 100)))
+ (provide-surface-budget (max-per-module . 150) (alert-threshold . 100))
+ ;; R-21: Hotspot budget policy
+ ;; Files with hotspot score > warn-threshold should have a risk-note entry.
+ ;; Files with score > block-threshold without a risk-note will fail CI.
+ ;; Format of risk-notes: ((file-path (risk . "description") (owner . "team")) ...)
+ (hotspot-budget
+  (warn-threshold . 5000)
+  (block-threshold . 20000)
+  (risk-notes
+   . (("runtime/agent-session.rkt"
+       (risk . "Central session orchestration; high fan-in, hard to decompose further")
+       (owner . "runtime"))
+      ("runtime/session-lifecycle.rkt"
+       (risk . "Session lifecycle FSM; high state complexity")
+       (owner . "runtime"))))))

--- a/tests/test-hotspot-report.rkt
+++ b/tests/test-hotspot-report.rkt
@@ -78,6 +78,33 @@
 
     (test-case "CI mode exits 0 (non-blocking)"
       (define-values (code out) (run-hotspot-report "--ci"))
-      (check-equal? code 0 "CI mode should not fail (non-blocking)"))))
+      (check-equal? code 0 "CI mode should not fail (non-blocking)"))
+
+    (test-case "Hotspot budget: files exceeding block-threshold have risk notes"
+      ;; W26 blocking gate: files with score > 20000 must have a risk-note entry
+      ;; in the dependency policy's hotspot-budget section.
+      (define policy-path (build-path q-dir "docs" "architecture" "dependency-policy.rktd"))
+      (define policy (call-with-input-file policy-path read))
+      (define hotspot-section (let ([hb (assoc 'hotspot-budget policy)]) (and hb (cdr hb))))
+      (define block-threshold (cdr (assoc 'block-threshold hotspot-section)))
+      (define risk-notes-raw (cdr (assoc 'risk-notes hotspot-section)))
+      (define risk-note-files
+        (for/set ([entry (in-list risk-notes-raw)])
+          (car entry)))
+      ;; Get current hotspot scores
+      (define-values (code out) (run-hotspot-report "--json" "--all"))
+      (define data (string->jsexpr out))
+      (define hotspots (hash-ref data 'hotspots))
+      (define blocking-violations
+        (for/list ([h (in-list hotspots)]
+                   #:when (> (hash-ref h 'score) block-threshold))
+          (define f (hash-ref h 'file))
+          (if (set-member? risk-note-files f)
+              #f
+              (format "~a: score ~a > ~a but no risk note" f (hash-ref h 'score) block-threshold))))
+      (define actual-violations (filter identity blocking-violations))
+      (check-equal? actual-violations
+                    '()
+                    (format "Hotspot budget violations: ~a" actual-violations)))))
 
 (run-tests hotspot-tests)


### PR DESCRIPTION
Addresses #5164.

feat(W26): hotspot budget policy with risk notes (#5164)

Add hotspot budget section to dependency-policy.rktd:
- warn-threshold: 5000 (advisory)
- block-threshold: 20000 (must have risk note)
- Risk notes for top 2 hotspots: agent-session.rkt, session-lifecycle.rkt

New test: "Hotspot budget: files exceeding block-threshold have risk notes"
validates that files scoring > 20000 have documented risk notes in the policy.

All 6 hotspot tests pass (5 original + 1 new budget gate).
Lint: 22/23.

Wave 26 of v0.57.5.