### PR TITLE
docs(W27): sync architecture overview with current state (#5165)

Update docs/architecture/overview.md:
- Module count: 417 → 428 source modules
- LOC: ~63,754 → ~65,000
- Interfaces count: ~35 → ~45 (TUI decomposition modules)
- Lint suite: 18 → 22 checks
- Add contract metrics and hotspot report to testing section
- Add Typed Racket modules section (per ADR 0014)
- Add Contract Metrics section with baseline/current data

Lint: 22/23.

Wave 27 of v0.57.5.

### DIFF
--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -34,7 +34,7 @@ v0.57.0
 └─────────────────────────────────────────────┘
 ```
 
-## Module Counts (417 source modules, ~63,754 LOC)
+## Module Counts (428 source modules, ~65,000 LOC)
 
 | Layer | Modules | Key Files |
 |-------|---------|-----------|
@@ -44,7 +44,7 @@ v0.57.0
 | Tools (tools/) | ~15 | `tool.rkt`, `registry-defaults.rkt`, `builtins/` |
 | Runtime (runtime/) | ~45 | `iteration.rkt`, `agent-session.rkt`, `session-lifecycle.rkt` |
 | Extensions (extensions/) | ~30 | `gsd/`, `github/`, `racket-tooling/` |
-| Interfaces (interfaces/, cli/, tui/) | ~35 | `sdk-core.rkt`, `args.rkt`, `renderer.rkt` |
+| Interfaces (interfaces/, cli/, tui/) | ~45 | `sdk-core.rkt`, `args.rkt`, `renderer.rkt`, `tui/keybindings/` |
 | Wiring (wiring/) | ~3 | `run-modes.rkt`, `mode-helpers.rkt` |
 | Sandbox (sandbox/) | ~3 | `subprocess.rkt` |
 | Scripts (scripts/) | ~25 | `lint-all.rkt`, `sync-version.rkt`, `run-tests.rkt` |
@@ -66,9 +66,22 @@ Two tiers:
 1. **Raw events**: `make-event` + `emit-event!` (legacy, stable for interop)
 2. **Typed events**: 27 structs in `agent/event-structs/` + `emit-typed-event!` (introduced v0.33.7, stable)
 
-## Testing
+## Typed Racket Modules
+
+Per ADR 0014, stable struct-heavy modules are migrated to Typed Racket:
+- `util/event.rkt`, `util/event-payloads.rkt`, `util/hook-types.rkt`
+- `util/version.rkt`, `util/loop-result.rkt`
+- `extensions/gsd/plan-types.rkt`, `extensions/gsd/plan-validator.rkt`
+
+## Contract Metrics
+
+- Baseline: 882 any/c (148 files)
+- Current: 812 any/c (143 files) — 7.9% reduction
+- See `docs/reports/f2-contract-precision-trend.md` for trend analysis
 
 - 500+ test files in `tests/`
 - Parallel runner: `racket scripts/run-tests.rkt`
-- 18-check lint suite: `racket scripts/lint-all.rkt`
+- 22-check lint suite: `racket scripts/lint-all.rkt`
+- Contract metrics: `racket scripts/contract-metrics.rkt`
+- Hotspot report: `racket scripts/hotspot-report.rkt`
 - IVG invariants: 8 checks in `scripts/lint-ivg.rkt`


### PR DESCRIPTION
Addresses #5165.

docs(W27): sync architecture overview with current state (#5165)

Update docs/architecture/overview.md:
- Module count: 417 → 428 source modules
- LOC: ~63,754 → ~65,000
- Interfaces count: ~35 → ~45 (TUI decomposition modules)
- Lint suite: 18 → 22 checks
- Add contract metrics and hotspot report to testing section
- Add Typed Racket modules section (per ADR 0014)
- Add Contract Metrics section with baseline/current data

Lint: 22/23.

Wave 27 of v0.57.5.