### PR TITLE
docs: W0 audit remediation baseline (#5172)

### DIFF
--- a/docs/reports/v0.57.6-audit-remediation-baseline.md
+++ b/docs/reports/v0.57.6-audit-remediation-baseline.md
@@ -1,0 +1,116 @@
+# Corrective Audit Remediation Baseline
+
+**Date:** 2026-05-25  
+**Wave:** W0 — Reproduce, classify, and freeze baseline  
+**Issue:** #5172  
+**Branch:** `feature/v0576-w0-baseline`  
+**Baseline commit:** `c0963c42`  
+**Baseline version:** `q version 0.57.1`
+
+## Purpose
+
+This report freezes the failing release state described by `.planning/PROJECT_REVIEW-v0.57.x-GSD-AUDIT.md` before implementing the corrective remediation waves.
+
+## Commands Run
+
+```bash
+cd q
+find . -type d -name compiled -prune -exec rm -rf {} +
+raco make main.rkt
+racket main.rkt --version
+racket scripts/contract-metrics.rkt --summary
+racket scripts/run-tests.rkt --suite fast
+racket scripts/run-tests.rkt --suite tui
+racket scripts/run-tests.rkt --suite arch
+racket scripts/lint-all.rkt
+```
+
+## Baseline Metrics
+
+| Metric | Value |
+|---|---:|
+| Version | 0.57.1 |
+| Exact `any/c` in contract-out | 812 |
+| Files with `any/c` | 143 |
+| Source files scanned by contract metrics | 363 |
+
+## Gate Results
+
+| Gate | Exit | Result |
+|---|---:|---|
+| `raco make main.rkt` | 0 | PASS |
+| `racket main.rkt --version` | 0 | `q version 0.57.1` |
+| `racket scripts/run-tests.rkt --suite fast` | 4 | FAIL: 12 failing files + strict sentinel false positives |
+| `racket scripts/run-tests.rkt --suite tui` | 4 | FAIL: actual tests pass, strict sentinel flags helpers |
+| `racket scripts/run-tests.rkt --suite arch` | 4 | FAIL: actual tests pass, strict sentinel flags helpers/workflow file |
+| `racket scripts/lint-all.rkt` | 1 | FAIL: release-readiness; lint mutated README metrics |
+
+## Fast Suite Failures
+
+After clearing `compiled/` dirs first, the fast suite failed with 12 files:
+
+1. `tests/test-auto-retry.rkt`
+2. `tests/test-failure-injection.rkt`
+3. `tests/test-golden-flows.rkt`
+4. `tests/test-gsd-wave-executor.rkt`
+5. `tests/test-model-command.rkt`
+6. `tests/test-pipeline-smoke.rkt`
+7. `tests/test-sdk.rkt`
+8. `tests/test-spawn-subagent-tool-dispatch.rkt`
+9. `tests/test-spawn-subagents-batch.rkt`
+10. `tests/test-tool-coordinator-duration.rkt`
+11. `tests/test-wave1-compaction.rkt`
+12. `tests/test-wave5-capability-gaps.rkt`
+
+These map to W1 contract fixes, W2 test isolation/runner fixes, and W5 downstream workflow verification.
+
+## Strict Sentinel False Positives
+
+The strict sentinel flags helper/fixture modules that are not intended standalone test files, including:
+
+- `tests/helpers/*.rkt`
+- `tests/tui/event-simulator.rkt`
+- `tests/tui/mock-tui-session.rkt`
+- `tests/tui/state-assertions.rkt`
+- `tests/tui/workflow-harness.rkt`
+- `tests/workflows/fixtures/*.rkt`
+- selected workflow/helper modules that execute cleanly but report zero parsed tests
+
+This maps to W2.
+
+## Lint Failure and Side Effect
+
+`racket scripts/lint-all.rkt` failed release-readiness:
+
+- tag `v0.57.1` does not exist yet — PASS in current pre-release semantics
+- `CHANGELOG missing entry for 0.57.1` — false negative because changelog uses `## v0.57.1`
+- `git has 1 uncommitted change(s)` — caused by lint/metrics mutating `README.md`
+- branch check failed because W0 ran on feature branch, expected during wave work
+
+The README mutation changed metric values during lint:
+
+```diff
+- Source modules | 456 |
+- Source lines | 70655 |
++ Source modules | 457 |
++ Source lines | 70907 |
+```
+
+This maps to W3.
+
+## Wave Mapping
+
+| Finding cluster | Wave |
+|---|---|
+| auto-retry/model-bridge/model command/tool-coordinator contracts | W1 |
+| strict sentinel, stale bytecode, wave-gate reset, TUI characterization consistency | W2 |
+| lint-all read-only and release-readiness changelog regex | W3 |
+| GSD ctx-aware event/command paths | W4 |
+| security/workflow recovery | W5 |
+| docs/release history/hotspot debt | W6 |
+| `.planning/` state | W7 |
+| version/tag/triple-gate/closure | W8 |
+
+## Conclusion
+
+The W0 baseline reproduces the audit findings. Proceed to W1 contract and caller fixes.


### PR DESCRIPTION
## Summary
- Reproduces and freezes audit remediation baseline
- Records fast/tui/arch/lint failures and maps findings to W1-W8

## Verification
- `raco make main.rkt` PASS
- `racket main.rkt --version` => q version 0.57.1
- `racket scripts/contract-metrics.rkt --summary` => 812 any/c
- `racket scripts/run-tests.rkt --suite fast` FAIL as expected for W0 baseline
- `racket scripts/run-tests.rkt --suite tui` FAIL as expected due strict sentinel
- `racket scripts/run-tests.rkt --suite arch` FAIL as expected due strict sentinel
- `racket scripts/lint-all.rkt` FAIL as expected due release-readiness/readme mutation

Closes #5172