### PR TITLE
fix: restore runner truthfulness and test isolation (#5174)

### DIFF
--- a/scripts/run-tests.rkt
+++ b/scripts/run-tests.rkt
@@ -163,6 +163,19 @@
       (let ([base (file-name-from-path f)])
         (and base (string-contains? (path->string base) "provider")))))
 
+(define support-test-module-names
+  '("event-simulator.rkt" "mock-tui-session.rkt" "state-assertions.rkt" "workflow-harness.rkt"))
+
+(define (support-test-module? f)
+  (define s
+    (if (path? f)
+        (path->string f)
+        f))
+  (define base (file-name-from-path s))
+  (or (string-contains? s "/helpers/")
+      (string-contains? s "/fixtures/")
+      (and base (member (path->string base) support-test-module-names) #t)))
+
 ;; Base directory for resolving test paths.
 ;; orig-dir gives CWD when invoked directly, but under `raco test --process`
 ;; it may point at the test file's directory. We detect which case we're in:
@@ -208,7 +221,8 @@
                   #:when (and (file-exists? f)
                               (let ([s (path->string f)])
                                 (and (string-suffix? s ".rkt")
-                                     (not (string-contains? s "/compiled/"))))))
+                                     (not (string-contains? s "/compiled/"))
+                                     (not (support-test-module? s))))))
          (path->string (find-relative-path base-dir f))))
      (case suite
        [(all) all-files]
@@ -251,7 +265,13 @@
   (cond
     [(pair? all-matches)
      (define passed (for/sum ([m (in-list all-matches)]) (string->number (cadr m))))
-     (define failed (for/sum ([m (in-list all-matches)]) (string->number (caddr m))))
+     (define failed
+       (for/sum ([m (in-list all-matches)])
+                (+ (string->number (caddr m))
+                   (let ([errors (list-ref m 3)])
+                     (if errors
+                         (string->number errors)
+                         0)))))
      (values passed failed (+ passed failed))]
     [else
      ;; Fall back to legacy raco test format
@@ -269,15 +289,24 @@
              (string->number (cadr m))
              n)))
 
-     (values passed failed (+ passed failed))]))
+     (cond
+       [(> (+ passed failed) 0) (values passed failed (+ passed failed))]
+       [else
+        ;; rackunit `run-test` prints result structs rather than summary counts.
+        (define result-successes (length (regexp-match* #rx"#<test-success>" output)))
+        (define result-failures
+          (+ (length (regexp-match* #rx"#<test-failure>" output))
+             (length (regexp-match* #rx"#<test-error>" output))))
+        (values result-successes result-failures (+ result-successes result-failures))])]))
 
 ;; Normalize parsed counters against process exit status.
-;; Some test files intentionally print intermediate rackunit sub-suite summaries
-;; containing non-zero failure counts while still exiting 0 overall.
+;; Parsed rackunit failures/errors are release-blocking even if a legacy test
+;; file forgot to propagate `run-tests`' non-zero result to the process exit.
 (define (normalize-counts exit-code passed failed total)
-  (if (and (= exit-code 0) (> failed 0))
-      (values passed 0 passed)
-      (values passed failed total)))
+  (values passed failed total))
+
+(define (effective-exit-code exit-code failed)
+  (if (and (= exit-code 0) (> failed 0)) 1 exit-code))
 
 ;; ---------------------------------------------------------------------------
 ;; extract-failure-lines - pull FAILURE context blocks from output
@@ -318,9 +347,12 @@
 ;; but NOT files that have (run-tests ...) — those are self-contained.
 (define (file-has-rackunit-tests? path)
   (and (file-exists? path)
-       (let ([content (file->string path)])
-         (and (or (regexp-match? #rx"\\(test-case" content) (regexp-match? #rx"\\(check-" content))
-              (not (regexp-match? #rx"\\(run-tests" content))))))
+       (let* ([content (file->string path)]
+              [has-rackunit-forms? (or (regexp-match? #rx"\\(test-case" content)
+                                       (regexp-match? #rx"\\(check-" content))]
+              [module-plus-test? (regexp-match? #px"\\(module\\+\\s+test\\b" content)]
+              [self-running? (regexp-match? #rx"\\(run-tests" content)])
+         (and has-rackunit-forms? (or module-plus-test? (not self-running?))))))
 
 ;; Common result extraction from a running process.
 ;; Handles timeout logic and stdout/stderr parsing uniformly.
@@ -351,8 +383,9 @@
         (define-values (parsed-passed parsed-failed parsed-total) (parse-raco-output merged-bytes))
         (define-values (passed failed total)
           (normalize-counts exit-code parsed-passed parsed-failed parsed-total))
+        (define effective-code (effective-exit-code exit-code failed))
         (test-file-result test-path
-                          exit-code
+                          effective-code
                           stdout-bytes
                           stderr-bytes
                           (elapsed)
@@ -368,7 +401,15 @@
      (define-values (parsed-passed parsed-failed parsed-total) (parse-raco-output merged-bytes))
      (define-values (passed failed total)
        (normalize-counts exit-code parsed-passed parsed-failed parsed-total))
-     (test-file-result test-path exit-code stdout-bytes stderr-bytes (elapsed) passed failed total)]))
+     (define effective-code (effective-exit-code exit-code failed))
+     (test-file-result test-path
+                       effective-code
+                       stdout-bytes
+                       stderr-bytes
+                       (elapsed)
+                       passed
+                       failed
+                       total)]))
 
 (define (run-single-file test-path #:timeout [timeout #f])
   (define resolved-path
@@ -619,8 +660,35 @@
 ;; Pre-flight: stale bytecode cleanup
 ;; ---------------------------------------------------------------------------
 
+(define (compiled-zo-source-candidates compiled-dir zo)
+  (define parent (path-only compiled-dir))
+  (define base-path (file-name-from-path zo))
+  (define base
+    (if base-path
+        (path->string base-path)
+        ""))
+  (define stem (regexp-replace #rx"\\.zo$" base ""))
+  (filter values
+          (list (and (regexp-match? #rx"_rkt$" stem)
+                     (build-path parent (regexp-replace #rx"_rkt$" stem ".rkt")))
+                (and (regexp-match? #rx"_rktl$" stem)
+                     (build-path parent (regexp-replace #rx"_rktl$" stem ".rktl")))
+                (and (regexp-match? #rx"_scrbl$" stem)
+                     (build-path parent (regexp-replace #rx"_scrbl$" stem ".scrbl")))
+                (path-replace-extension (path-replace-suffix zo "") #".rkt")
+                (path-replace-extension (path-replace-suffix zo "") #".rktl"))))
+
+(define (stale-compiled-zo? compiled-dir zo)
+  (and (file-exists? zo)
+       (string-suffix? (path->string zo) ".zo")
+       (let* ([candidates (compiled-zo-source-candidates compiled-dir zo)]
+              [existing-sources (filter file-exists? candidates)])
+         (or (null? existing-sources)
+             (for/or ([src (in-list existing-sources)])
+               (> (file-or-directory-modify-seconds src) (file-or-directory-modify-seconds zo)))))))
+
 (define (clean-stale-bytecode! root)
-  "Delete compiled/ directories when any .zo is older than its source .rkt.
+  "Delete compiled/ directories with stale or orphan .zo files.
   This prevents instantiate-linklet mismatches after module moves or renames."
   (define cleaned 0)
   (for ([d (in-directory root)])
@@ -628,14 +696,7 @@
       (define zo-files (directory-list d #:build? #t))
       (define stale?
         (for/or ([zo (in-list zo-files)])
-          (and (file-exists? zo)
-               (let* ([base (path-replace-suffix zo "")]
-                      [rkt (path-replace-extension base #".rkt")]
-                      [rktl (path-replace-extension base #".rktl")]
-                      [src (or (and (file-exists? rkt) rkt) (and (file-exists? rktl) rktl) #f)])
-                 (and src
-                      (> (file-or-directory-modify-seconds src)
-                         (file-or-directory-modify-seconds zo)))))))
+          (stale-compiled-zo? d zo)))
       (when stale?
         (delete-directory/files d)
         (set! cleaned (add1 cleaned)))))

--- a/tests/test-arch-01-regression.rkt
+++ b/tests/test-arch-01-regression.rkt
@@ -9,21 +9,19 @@
 (require rackunit
          rackunit/text-ui
          (only-in "../runtime/tool-coordinator.rkt" handle-tool-calls-pending)
+         (only-in "../runtime/session-config.rkt" hash->session-config)
          (only-in "../tools/tool.rkt" make-tool make-tool-registry register-tool! make-success-result)
          (only-in "../util/protocol-types.rkt" make-message make-tool-call-part)
          (only-in "../util/ids.rkt" generate-id)
          (only-in "../util/event.rkt" event-event event-payload)
-         (only-in "../tools/permission-gate.rkt" make-default-permission-config
-                  permission-config?)
+         (only-in "../tools/permission-gate.rkt" make-default-permission-config permission-config?)
          "../agent/event-bus.rkt")
 
 (define (make-echo-tool)
-  (make-tool
-   "echo"
-   "Echo tool for testing"
-   (hasheq 'type "object" 'properties (hasheq) 'required '())
-   (lambda (args _ctx)
-     (make-success-result "ok"))))
+  (make-tool "echo"
+             "Echo tool for testing"
+             (hasheq 'type "object" 'properties (hasheq) 'required '())
+             (lambda (args _ctx) (make-success-result "ok"))))
 
 (define (make-assistant-msg-with-call tool-name)
   (make-message (generate-id)
@@ -55,9 +53,16 @@
       (define new-msgs (list (make-assistant-msg-with-call "echo")))
       ;; This call would previously crash
       (define result
-        (handle-tool-calls-pending new-msgs '() #f reg bus
-                                    "test-session" "/tmp/test.log" #f (hash)
-                                    #:permission-config perm-cfg))
+        (handle-tool-calls-pending new-msgs
+                                   '()
+                                   #f
+                                   reg
+                                   bus
+                                   "test-session"
+                                   "/tmp/test.log"
+                                   #f
+                                   (hash->session-config (hash))
+                                   #:permission-config perm-cfg))
       ;; Verify the tool actually executed
       (check-pred list? result)
       ;; Give event bus a moment to deliver
@@ -75,8 +80,15 @@
       (define new-msgs (list (make-assistant-msg-with-call "echo")))
       ;; Default path — no #:permission-config supplied
       (define result
-        (handle-tool-calls-pending new-msgs '() #f reg bus
-                                    "test-session" "/tmp/test.log" #f (hash)))
+        (handle-tool-calls-pending new-msgs
+                                   '()
+                                   #f
+                                   reg
+                                   bus
+                                   "test-session"
+                                   "/tmp/test.log"
+                                   #f
+                                   (hash->session-config (hash))))
       (check-pred list? result)
       (check-true (unbox completed?) "default perm-cfg path should work"))))
 

--- a/tests/test-gsd-global-fitness.rkt
+++ b/tests/test-gsd-global-fitness.rkt
@@ -9,47 +9,50 @@
 
 (require rackunit
          rackunit/text-ui
+         racket/path
          racket/port
+         racket/runtime-path
          racket/string)
 
 ;; Allowed modules where gsd-default-ctx and gsd-event-bus-box may be referenced.
 ;; These are the compatibility/shim layer — all new code should use ctx-aware APIs.
 (define allowed-for-gsd-default-ctx
-  '("extensions/gsd/session-state.rkt"
-    "extensions/gsd/state-machine.rkt"
-    "extensions/gsd/events.rkt"))
+  '("extensions/gsd/session-state.rkt" "extensions/gsd/state-machine.rkt"
+                                       "extensions/gsd/events.rkt"))
 
-(define allowed-for-gsd-event-bus-box
-  '("extensions/gsd/events.rkt"
-    "extensions/gsd-planning.rkt"))
+(define allowed-for-gsd-event-bus-box '("extensions/gsd/events.rkt" "extensions/gsd-planning.rkt"))
 
-;; Scan all .rkt files under the source tree (excluding tests)
-;; When raco test runs, CWD is the tests/ directory. Go up one level.
-(define source-root "../")
+;; Scan all .rkt files under the source tree (excluding tests).
+;; Resolve relative to this test file so results are stable under both
+;; `racket tests/...` and `raco test tests/...`.
+(define-runtime-path source-root "../")
 
 (define (find-production-rkt-files)
-  (define output (with-output-to-string
-                   (lambda ()
-                     (system* (find-executable-path "find")
-                              source-root
-                              "-name" "*.rkt"
-                              "-not" "-path" "*/tests/*"
-                              "-not" "-path" "*/compiled/*"
-                              "-type" "f"))))
+  (define output
+    (with-output-to-string (lambda ()
+                             (system* (find-executable-path "find")
+                                      source-root
+                                      "-name"
+                                      "*.rkt"
+                                      "-not"
+                                      "-path"
+                                      "*/tests/*"
+                                      "-not"
+                                      "-path"
+                                      "*/compiled/*"
+                                      "-type"
+                                      "f"))))
   (filter (lambda (p) (string-suffix? p ".rkt"))
           (map string-trim (string-split output "\n" #:trim? #f))))
 
 (define (relative-path full-path)
-  ;; Strip ../ prefix from find output to get path relative to q/
-  (if (string-prefix? full-path "../")
-      (substring full-path 3)
-      full-path))
+  (path->string (find-relative-path source-root (simplify-path full-path))))
 
 (define (file-contains? path needle)
   (call-with-input-file path
-    (lambda (in)
-      (for/or ([line (in-lines in)])
-        (string-contains? line needle)))))
+                        (lambda (in)
+                          (for/or ([line (in-lines in)])
+                            (string-contains? line needle)))))
 
 (define gsd-global-fitness-suite
   (test-suite "gsd-global-fitness-gate"
@@ -61,7 +64,8 @@
                    #:when (file-contains? f "gsd-default-ctx")
                    #:unless (member (relative-path f) allowed-for-gsd-default-ctx))
           (relative-path f)))
-      (check-equal? violators '()
+      (check-equal? violators
+                    '()
                     (format "gsd-default-ctx found outside allowed modules: ~a"
                             (string-join violators ", "))))
 
@@ -72,22 +76,23 @@
                    #:when (file-contains? f "gsd-event-bus-box")
                    #:unless (member (relative-path f) allowed-for-gsd-event-bus-box))
           (relative-path f)))
-      (check-equal? violators '()
+      (check-equal? violators
+                    '()
                     (format "gsd-event-bus-box found outside allowed modules: ~a"
                             (string-join violators ", "))))
 
     (test-case "no new with-gsd-lock usage outside session-state.rkt"
       (define allowed-for-with-gsd-lock
-        '("extensions/gsd/session-state.rkt"
-          "extensions/gsd/state-machine.rkt"
-          "extensions/gsd/command-handlers.rkt"))
+        '("extensions/gsd/session-state.rkt" "extensions/gsd/state-machine.rkt"
+                                             "extensions/gsd/command-handlers.rkt"))
       (define files (find-production-rkt-files))
       (define violators
         (for/list ([f (in-list files)]
                    #:when (file-contains? f "with-gsd-lock")
                    #:unless (member (relative-path f) allowed-for-with-gsd-lock))
           (relative-path f)))
-      (check-equal? violators '()
+      (check-equal? violators
+                    '()
                     (format "with-gsd-lock found outside allowed modules: ~a"
                             (string-join violators ", "))))
 

--- a/tests/test-gsd-wave-executor.rkt
+++ b/tests/test-gsd-wave-executor.rkt
@@ -16,6 +16,7 @@
 ;; ============================================================
 
 (define (make-test-plan n)
+  (wave-gate-clear!)
   (gsd-plan (for/list ([i (in-range n)])
               (gsd-wave i (format "Wave ~a" i) 'pending "" '("file.rkt") '() "test" '()))
             ""

--- a/tests/test-run-tests.rkt
+++ b/tests/test-run-tests.rkt
@@ -100,6 +100,14 @@
   (check-equal? failed 0)
   (check-equal? total 0))
 
+(test-case "parse-raco-output: rackunit run-test result list"
+  (define parse (runner-ref 'parse-raco-output))
+  (define-values (passed failed total)
+    (parse #"'(#<test-success> #<test-success> #<test-success>)\n"))
+  (check-equal? passed 3)
+  (check-equal? failed 0)
+  (check-equal? total 3))
+
 (test-case "parse-raco-output: singular 'test passed' / 'test failed'"
   (define parse (runner-ref 'parse-raco-output))
   (define-values (passed failed total) (parse #"1 test passed\n1 test failed\n"))
@@ -122,13 +130,13 @@
   (check-equal? failed 0)
   (check-equal? total 13))
 
-(test-case "parse-raco-output: rackunit/text-ui with failures"
+(test-case "parse-raco-output: rackunit/text-ui counts failures and errors"
   (define parse (runner-ref 'parse-raco-output))
   (define-values (passed failed total)
     (parse #"5 success(es) 2 failure(s) 1 error(s) 8 test(s) run\n"))
   (check-equal? passed 5)
-  (check-equal? failed 2)
-  (check-equal? total 7))
+  (check-equal? failed 3)
+  (check-equal? total 8))
 
 ;; ---------------------------------------------------------------------------
 ;; 13.1: extract-failure-lines
@@ -252,7 +260,7 @@
   (define result (run "tests/nonexistent-test-file-xyz.rkt" #:timeout 10000))
   (check-not-equal? ((runner-ref 'test-file-result-exit-code) result) 0))
 
-(test-case "run-single-file: exit=0 normalizes non-zero parsed failures"
+(test-case "run-single-file: exit=0 with parsed failures is not false-green"
   (define run (runner-ref 'run-single-file))
   (define tmp (make-temporary-file "run-tests-anomaly-~a.rkt"))
   (call-with-output-file
@@ -260,13 +268,12 @@
    #:exists 'truncate/replace
    (lambda (out)
      (display "#lang racket/base\n" out)
-     (display "(displayln \"5 success(es) 1 failure(s) 0 error(s) 6 test(s) run\")\n" out)))
+     (display "(displayln \"5 success(es) 1 failure(s) 1 error(s) 7 test(s) run\")\n" out)))
   (define result (run tmp #:timeout 10000))
   (delete-file tmp)
-  (check-equal? ((runner-ref 'test-file-result-exit-code) result) 0)
-  (check-equal? ((runner-ref 'test-file-result-failed) result) 0)
-  (check-equal? ((runner-ref 'test-file-result-total) result)
-                ((runner-ref 'test-file-result-passed) result)))
+  (check-equal? ((runner-ref 'test-file-result-exit-code) result) 1)
+  (check-equal? ((runner-ref 'test-file-result-failed) result) 2)
+  (check-equal? ((runner-ref 'test-file-result-total) result) 7))
 
 ;; ---------------------------------------------------------------------------
 ;; 13.3: collect-test-files (suite filtering)
@@ -398,6 +405,47 @@
                            (displayln "(displayln \"hello\")" out)))
   (check-false (has-tests? tmp))
   (delete-file tmp))
+
+;; ---------------------------------------------------------------------------
+;; W2: Runner truthfulness/isolation regressions
+;; ---------------------------------------------------------------------------
+
+(test-case "file-has-rackunit-tests?: module+ test with run-tests needs raco discovery"
+  (define has-tests? (runner-ref 'file-has-rackunit-tests?))
+  (define tmp (make-temporary-file "module-plus-test-~a.rkt"))
+  (call-with-output-file
+   tmp
+   #:exists 'truncate/replace
+   (lambda (out)
+     (displayln "#lang racket" out)
+     (displayln "(require rackunit rackunit/text-ui)" out)
+     (displayln "(define suite (test-suite \"s\" (test-case \"ok\" (check-equal? 1 1))))" out)
+     (displayln "(module+ test (run-tests suite))" out)))
+  (check-true (has-tests? tmp))
+  (delete-file tmp))
+
+(test-case "collect-test-files: excludes helper and fixture modules"
+  (define collect (runner-ref 'collect-test-files))
+  (define fast-files (collect 'fast))
+  (for ([f (in-list fast-files)])
+    (check-false (string-contains? f "/helpers/") (format "helper should be excluded: ~a" f))
+    (check-false (string-contains? f "/fixtures/") (format "fixture should be excluded: ~a" f)))
+  (check-false (member "tests/tui/event-simulator.rkt" fast-files))
+  (check-false (member "tests/tui/mock-tui-session.rkt" fast-files))
+  (check-false (member "tests/tui/state-assertions.rkt" fast-files))
+  (check-false (member "tests/tui/workflow-harness.rkt" fast-files)))
+
+(test-case "clean-stale-bytecode!: removes orphan compiled directory"
+  (define clean! (runner-ref 'clean-stale-bytecode!))
+  (define tmp-dir (make-temporary-file "compiled-orphan-~a" 'directory))
+  (define compiled-dir (build-path tmp-dir "compiled"))
+  (make-directory compiled-dir)
+  (call-with-output-file (build-path compiled-dir "missing_rkt.zo")
+                         #:exists 'truncate/replace
+                         (lambda (out) (display "stale" out)))
+  (check-equal? (clean! tmp-dir) 1)
+  (check-false (directory-exists? compiled-dir))
+  (delete-directory/files tmp-dir #:must-exist? #f))
 
 ;; ---- 14.x: Architecture shard suite classification ----
 

--- a/tests/test-strict-runner.rkt
+++ b/tests/test-strict-runner.rkt
@@ -18,18 +18,16 @@
       (check-equal? (test-file-result-total r) 5))
 
     (test-case "normalize-counts preserves good results"
-      (define-values (passed failed total)
-        (normalize-counts 0 10 0 10))
+      (define-values (passed failed total) (normalize-counts 0 10 0 10))
       (check-equal? passed 10)
       (check-equal? failed 0)
       (check-equal? total 10))
 
-    (test-case "normalize-counts detects silent failures"
-      (define-values (passed failed total)
-        (normalize-counts 0 8 2 10))
+    (test-case "normalize-counts preserves parsed failures"
+      (define-values (passed failed total) (normalize-counts 0 8 2 10))
       (check-equal? passed 8)
-      (check-equal? failed 0)
-      (check-equal? total 8))
+      (check-equal? failed 2)
+      (check-equal? total 10))
 
     (test-case "summary-exit-code: 0 when no failures"
       (check-equal? (summary-exit-code 0 0) 0))

--- a/tests/test-tui-hotspot-characterization.rkt
+++ b/tests/test-tui-hotspot-characterization.rkt
@@ -7,14 +7,12 @@
 ;; Pins current TUI hotspot behavior to de-risk decomposition in v0.57.3.
 ;;
 ;; Key decisions documented:
-;; D1: handle-user-submit! contract says (-> tui-ctx? string? tui-ctx?) but
-;;     actually returns a thread object (from the thread spawn). The contract
-;;     throws exn:fail:contract? when called — proven by D1.
+;; D1: handle-user-submit! contract is now truthful: (-> tui-ctx? string? void?).
+;;     It mutates the TUI state box and starts runner work internally.
 ;; D2: handle-key dispatches configurable keymap first, then falls through to
 ;;     hardcoded behavior. Fallthrough is the primary path for submit.
 ;; D3: check-busy-watchdog is pure and testable.
-;; D4: handle-user-submit! is NOT safely callable due to contract lie.
-;;     v0.57.3 must fix contract to (-> tui-ctx? string? (or/c thread? void?)).
+;; D4: handle-user-submit! is safely callable and returns void.
 
 (require rackunit
          rackunit/text-ui
@@ -52,21 +50,19 @@
 (define tui-hotspot-characterization-suite
   (test-suite "tui-hotspot-characterization"
 
-    ;; D1: handle-user-submit! contract lies — produces thread, not tui-ctx?
-    (test-case "CHAR: handle-user-submit! contract violation (returns thread not tui-ctx)"
-      ;; Contract claims (-> tui-ctx? string? tui-ctx?) but the function spawns
-      ;; a thread and returns the thread object. This throws exn:fail:contract.
-      ;; v0.57.3 must fix: either return void? or (or/c thread? void?).
+    ;; D1: handle-user-submit! has a truthful void contract and mutates state.
+    (test-case "CHAR: handle-user-submit! returns void and sets busy transcript state"
       (define ctx (make-test-tui-ctx))
-      (check-exn exn:fail:contract?
-                 (lambda () (handle-user-submit! ctx "hello"))
-                 "handle-user-submit! breaks its own contract — returns thread not tui-ctx"))
+      (define result-box (box 'unset))
+      (check-not-exn (lambda () (set-box! result-box (handle-user-submit! ctx "hello"))))
+      (check-pred void? (unbox result-box))
+      (define state (unbox (tui-ctx-ui-state-box ctx)))
+      (check-true (ui-state-busy? state))
+      (check-true (for/or ([entry (in-list (ui-state-transcript state))])
+                    (and (eq? (transcript-entry-kind entry) 'user)
+                         (string=? (transcript-entry-text entry) "hello")))))
 
-    ;; D2: handle-user-submit! sets busy before throwing contract
-    ;; (Can't test this because contract check fails on return.
-    ;;  The busy state IS set inside the function before the thread returns,
-    ;;  but contract check happens on the return value.)
-    ;; Documented: the implementation sets busy at line 302 before spawning thread.
+    ;; D2: handle-user-submit! sets busy before runner completion.
 
     ;; D3: handle-key with regular character inserts into input state
     (test-case "CHAR: handle-key with char modifies input state"
@@ -109,12 +105,11 @@
 
     ;; D8: Duplicate submit documentation
     (test-case "CHAR: document duplicate submit debounce (500ms window)"
-      ;; The duplicate debounce is inside handle-user-submit! which can't be
-      ;; called due to D1 contract lie. Document behavior:
+      ;; The duplicate debounce is inside handle-user-submit!:
       ;; - If last transcript entry is 'user with same text and < 500ms old
       ;; - Adds "Duplicate input ignored" system entry
       ;; - Does NOT call runner
-      ;; v0.57.3 should extract debounce to a testable pure function.
+      ;; Future decomposition should extract debounce to a testable pure function.
       (check-true #t "documented — see comments"))
 
     ;; D9: Document call sites for v0.57.3 decomposition
@@ -125,7 +120,7 @@
       ;;   tui/commands.rkt (16031) — 391 LOC
       ;;
       ;; Decomposition plan:
-      ;;   1. Fix handle-user-submit! contract: -> void? or (or/c thread? void?)
+      ;;   1. Keep handle-user-submit! contract pinned to -> void?
       ;;   2. Extract debounce logic to pure function
       ;;   3. Extract busy-queue logic to pure function
       ;;   4. Extract keymap fallthrough to explicit dispatch table


### PR DESCRIPTION
## Summary
- Exclude support/helper/fixture modules from collected suites so strict mode targets real tests
- Count rackunit errors as failures and promote parsed failures/errors to non-zero per-file results
- Parse rackunit `run-test` result-list output to avoid zero-test false positives
- Clean orphan/stale compiled bytecode directories before broad runs
- Reset wave-gate state in wave-executor tests
- Refresh TUI characterization after submit-handler contract fix
- Stabilize arch tests under both `racket` and `raco test` execution

## Verification
- `raco test tests/test-run-tests.rkt` PASS (51)
- `raco test tests/test-strict-runner.rkt` PASS (9)
- `raco test tests/test-gsd-wave-executor.rkt` PASS (15)
- `raco test tests/test-tui-hotspot-characterization.rkt` PASS (8)
- `raco test tests/test-arch-01-regression.rkt` PASS (2)
- `raco test tests/test-gsd-global-fitness.rkt` PASS (4)
- `racket scripts/run-tests.rkt --suite arch` PASS (9 files, 96 tests)
- `racket scripts/run-tests.rkt --suite tui` TRUTHFUL RED: 4 real failing files, no strict-sentinel helper false positives
- `racket scripts/run-tests.rkt --suite fast` TRUTHFUL RED: 21 real failing files, no strict-sentinel helper false positives

Reviewer: APPROVED

Residual real failures are routed to W5/W8 broad-suite recovery; they are no longer runner false positives.

Closes #5174