### PR TITLE
fix(W1): source-level fixes for 3 test failures (#5192)

F-1: Guard message-meta against #f in context-policy.rkt message-importance
F-2: Enrich 401/403 error messages with response body in http-helpers.rkt
F-8: Normalize empty string to #f in extract-tool-target-path (tool-turn-bridge.rkt)
Bonus: Fix estimate-message-tokens contract violation in context-assembly/selection.rkt
where summary-text (string) was passed to message-expecting estimator.

All 3 modified source files compile and format clean.
test-context-assembly-raw.rkt: 6/6 (was 5/6 with 1 error).

Wave 1 of v0.57.7.

### DIFF
--- a/llm/http-helpers.rkt
+++ b/llm/http-helpers.rkt
@@ -133,10 +133,13 @@
               status-str))]
     ;; Authentication
     [(= status-code 401)
-     (raise-http-error! (format "~a API authentication failed (401)" provider-name) status-code)]
+     (define error-text (safe-extract-error-text response-bytes))
+     (raise-http-error! (format "~a API authentication failed (401): ~a" provider-name error-text)
+                        status-code)]
     ;; Forbidden
     [(= status-code 403)
-     (raise-http-error! (format "~a API forbidden (403)" provider-name) status-code)]
+     (define error-text (safe-extract-error-text response-bytes))
+     (raise-http-error! (format "~a API forbidden (403): ~a" provider-name error-text) status-code)]
     ;; Rate limited
     [(= status-code 429)
      (define error-text (safe-extract-error-text response-bytes))

--- a/runtime/context-assembly/selection.rkt
+++ b/runtime/context-assembly/selection.rkt
@@ -248,7 +248,7 @@
   (define summary-msg
     (and summary-obj
          (let* ([summary-text (context-summary-text summary-obj)]
-                [summary-tokens (base-estimate summary-text)])
+                [summary-tokens (quotient (string-length summary-text) 4)])
            ;; Only inject if summary doesn't exceed 10% of budget
            (and (<= summary-tokens (* 0.1 max-tokens))
                 (make-message (format "ctx-summary-~a-~a"

--- a/runtime/context-policy.rkt
+++ b/runtime/context-policy.rkt
@@ -96,7 +96,7 @@
 
 ;; Get importance from message meta (default: 'normal)
 (define (message-importance msg)
-  (hash-ref (message-meta msg) 'importance 'normal))
+  (hash-ref (or (message-meta msg) (hash)) 'importance 'normal))
 
 ;; Check if message has elevated importance
 (define (message-elevated-importance? msg)

--- a/runtime/iteration/tool-turn-bridge.rkt
+++ b/runtime/iteration/tool-turn-bridge.rkt
@@ -47,9 +47,11 @@
 ;; Extract the target file path from a tool call's arguments.
 (define (extract-tool-target-path tc)
   (define args (tool-call-arguments tc))
-  (cond
-    [(hash? args) (or (hash-ref args 'path #f) (hash-ref args 'file #f))]
-    [else #f]))
+  (define raw
+    (cond
+      [(hash? args) (or (hash-ref args 'path #f) (hash-ref args 'file #f))]
+      [else #f]))
+  (if (and (string? raw) (string=? raw "")) #f raw))
 
 ;; take-at-most: imported from util/shared.rkt (v0.32.1 Wave 1 DRY)
 


### PR DESCRIPTION
Addresses #5192.

fix(W1): source-level fixes for 3 test failures (#5192)

F-1: Guard message-meta against #f in context-policy.rkt message-importance
F-2: Enrich 401/403 error messages with response body in http-helpers.rkt
F-8: Normalize empty string to #f in extract-tool-target-path (tool-turn-bridge.rkt)
Bonus: Fix estimate-message-tokens contract violation in context-assembly/selection.rkt
where summary-text (string) was passed to message-expecting estimator.

All 3 modified source files compile and format clean.
test-context-assembly-raw.rkt: 6/6 (was 5/6 with 1 error).

Wave 1 of v0.57.7.