### PR TITLE
fix(W4): narrow P2 any/c contracts in GSD and session modules (#5189)

A-1: command-handlers.rkt — 12 any/c removed:
  - handle-execute-command: any/c → hash?
  - handle-go-command: any/c → (or/c path-string? #f) + string?
  - handle-artifact-command: 4×any/c → string? string? (or/c path-string? #f) hash?
  - dispatch-gsd-command: 2×any/c → (or/c parsed-gsd-command? #f) + string?

A-2: context-bundle.rkt — 5 any/c removed:
  - assemble-context: 3×any/c → symbol? hash? hash?
  - explorer/executor/verifier-bundle: 2×any/c → hash? hash?
  - bundle-size-warning?: any/c → string?

A-3: session-events.rkt — 1 any/c removed:
  - wire-session-event-handlers!: 2×any/c → agent-session? procedure?

All GSD and session tests pass. Net: -18 any/c across 3 files.

Wave 4 of v0.57.7.

### DIFF
--- a/extensions/gsd/command-handlers.rkt
+++ b/extensions/gsd/command-handlers.rkt
@@ -63,12 +63,14 @@
                   set-gsd-event-bus!
                   current-gsd-ctx))
 
-(provide (contract-out [register-gsd-commands (-> any/c any/c)]
-                       [handle-execute-command (-> any/c any/c)]
-                       [handle-go-command (-> any/c any/c any/c)]
-                       [handle-gsd-status (-> any/c)]
-                       [handle-artifact-command (-> any/c any/c any/c any/c any/c)]
-                       [dispatch-gsd-command (-> any/c any/c any/c (values symbol? any/c))]))
+(provide (contract-out
+          [register-gsd-commands (-> any/c any/c)]
+          [handle-execute-command (-> hash? any/c)]
+          [handle-go-command (-> (or/c path-string? #f) string? any/c)]
+          [handle-gsd-status (-> any/c)]
+          [handle-artifact-command (-> string? string? (or/c path-string? #f) hash? any/c)]
+          [dispatch-gsd-command
+           (-> (or/c parsed-gsd-command? #f) string? (or/c path-string? #f) (values symbol? any/c))]))
 
 ;; ============================================================
 ;; Command registration

--- a/extensions/gsd/context-bundle.rkt
+++ b/extensions/gsd/context-bundle.rkt
@@ -16,11 +16,11 @@
 ;; Config (plain)
 (provide max-bundle-size
          ;; Functions (contracted)
-         (contract-out [assemble-context (-> any/c any/c any/c string?)]
-                       [explorer-bundle (-> any/c any/c string?)]
-                       [executor-bundle (-> any/c any/c string?)]
-                       [verifier-bundle (-> any/c any/c string?)]
-                       [bundle-size-warning? (-> any/c boolean?)]))
+         (contract-out [assemble-context (-> symbol? hash? hash? string?)]
+                       [explorer-bundle (-> hash? hash? string?)]
+                       [executor-bundle (-> hash? hash? string?)]
+                       [verifier-bundle (-> hash? hash? string?)]
+                       [bundle-size-warning? (-> string? boolean?)]))
 
 ;; ============================================================
 ;; Configuration

--- a/runtime/session-events.rkt
+++ b/runtime/session-events.rkt
@@ -16,7 +16,7 @@
          "session-types.rkt")
 (require "session-mutation.rkt")
 
-(provide (contract-out [wire-session-event-handlers! (-> any/c any/c void?)]))
+(provide (contract-out [wire-session-event-handlers! (-> agent-session? procedure? void?)]))
 
 ;; ============================================================
 ;; Event bus wiring


### PR DESCRIPTION
Addresses #5189.

fix(W4): narrow P2 any/c contracts in GSD and session modules (#5189)

A-1: command-handlers.rkt — 12 any/c removed:
  - handle-execute-command: any/c → hash?
  - handle-go-command: any/c → (or/c path-string? #f) + string?
  - handle-artifact-command: 4×any/c → string? string? (or/c path-string? #f) hash?
  - dispatch-gsd-command: 2×any/c → (or/c parsed-gsd-command? #f) + string?

A-2: context-bundle.rkt — 5 any/c removed:
  - assemble-context: 3×any/c → symbol? hash? hash?
  - explorer/executor/verifier-bundle: 2×any/c → hash? hash?
  - bundle-size-warning?: any/c → string?

A-3: session-events.rkt — 1 any/c removed:
  - wire-session-event-handlers!: 2×any/c → agent-session? procedure?

All GSD and session tests pass. Net: -18 any/c across 3 files.

Wave 4 of v0.57.7.