### PR TITLE
docs(W5): add subprocess surface area risk-note to dependency policy (#5191)

P1 audit item: sandbox/subprocess.rkt is a security-sensitive boundary
module handling shell subprocess execution with resource limits, timeouts,
and output capture. Added risk-note entry to hotspot-budget section in
docs/architecture/dependency-policy.rktd.

Lint-all: 22/23 passed (release-readiness expected fail on feature branch).

Wave 5 of v0.57.7.

### DIFF
--- a/docs/architecture/dependency-policy.rktd
+++ b/docs/architecture/dependency-policy.rktd
@@ -174,4 +174,7 @@
        (owner . "runtime"))
       ("scripts/run-tests.rkt"
        (risk . "Parallel test runner with subprocess orchestration, output parsing, and suite management")
-       (owner . "tools"))))))
+       (owner . "tools"))
+      ("sandbox/subprocess.rkt"
+       (risk . "Shell subprocess execution with resource limits, timeout handling, and output capture; security-sensitive boundary")
+       (owner . "hardening"))))))


### PR DESCRIPTION
Addresses #5191.

docs(W5): add subprocess surface area risk-note to dependency policy (#5191)

P1 audit item: sandbox/subprocess.rkt is a security-sensitive boundary
module handling shell subprocess execution with resource limits, timeouts,
and output capture. Added risk-note entry to hotspot-budget section in
docs/architecture/dependency-policy.rktd.

Lint-all: 22/23 passed (release-readiness expected fail on feature branch).

Wave 5 of v0.57.7.