### PR TITLE
feat(W0): add fuzzy edit normalization library (#5201)

Adds tools/builtins/edit-normalize.rkt with:
- configurable normalization pipeline for CRLF, trailing whitespace,
  blank-line collapse, tabs-to-spaces, and boundary blank trimming
- LCS-based similarity-score
- fuzzy-find-match that maps normalized matches back to original coordinates
- threshold-driven candidate matching and empty-normalized safety guards

Adds tests/test-edit-normalize.rkt with 42 tests covering exact, CRLF,
trailing whitespace, blank lines, tabs, boundary blanks, thresholds, and
coordinate mapping.

Review: APPROVED.

### DIFF
--- a/tests/test-edit-normalize.rkt
+++ b/tests/test-edit-normalize.rkt
@@ -1,0 +1,185 @@
+#lang racket
+
+(require rackunit
+         "../tools/builtins/edit-normalize.rkt")
+
+(define (slice s span)
+  (and span (substring s (car span) (cdr span))))
+
+(module+ test
+  (test-case "normalize-text preserves ordinary text"
+    (check-equal? (normalize-text "alpha\nbeta") "alpha\nbeta"))
+
+  (test-case "normalize-text normalizes CRLF and CR newlines"
+    (check-equal? (normalize-text "a\r\nb\rc") "a\nb\nc"))
+
+  (test-case "normalize-text strips trailing spaces and tabs per line"
+    (check-equal? (normalize-text "a  \n b\t\n") "a\n b"))
+
+  (test-case "normalize-text collapses repeated blank lines"
+    (check-equal? (normalize-text "a\n\n\n\nb") "a\n\nb"))
+
+  (test-case "normalize-text expands tabs to spaces"
+    (check-equal? (normalize-text "\ta\n\t\tb") "  a\n    b"))
+
+  (test-case "normalize-text trims leading and trailing blank lines"
+    (check-equal? (normalize-text "\n\nalpha\n\n") "alpha"))
+
+  (test-case "normalize-text can preserve trailing whitespace when configured"
+    (define opts (normalize-options #f #t #t #t 2 #t))
+    (check-equal? (normalize-text "a  \n" opts) "a  "))
+
+  (test-case "normalize-text can preserve repeated blank lines when configured"
+    (define opts (normalize-options #t #t #f #t 2 #t))
+    (check-equal? (normalize-text "a\n\n\nb" opts) "a\n\n\nb"))
+
+  (test-case "normalize-crlf can be disabled independently"
+    (define opts (normalize-options #t #f #t #t 2 #t))
+    (check-equal? (normalize-text "a\r\nb" opts) "a\r\nb")
+    (check-equal? (normalize-text "a  \r\nb" opts) "a\r\nb"))
+
+  (test-case "normalize-text can preserve boundary blank lines when configured"
+    (define opts (normalize-options #t #t #t #t 2 #f))
+    (check-equal? (normalize-text "\nalpha\n") "alpha")
+    (check-equal? (normalize-text "\nalpha\n" opts) "\nalpha\n"))
+
+  (test-case "similarity-score exact and empty cases"
+    (check-= (similarity-score "abc" "abc") 1.0 0.0)
+    (check-= (similarity-score "" "") 1.0 0.0)
+    (check-equal? (similarity-score "abc" "") 0.0)
+    (check-equal? (similarity-score "" "abc") 0.0))
+
+  (test-case "similarity-score partial overlap"
+    (check > (similarity-score "abcdef" "abcXYZ") 0.4)
+    (check < (similarity-score "abcdef" "XYZ") 0.4))
+
+  (test-case "fuzzy-find-match finds exact match coordinates"
+    (define s "one\ntwo\nthree")
+    (define span (fuzzy-find-match s "two"))
+    (check-equal? span (cons 4 7))
+    (check-equal? (slice s span) "two"))
+
+  (test-case "fuzzy-find-match tolerates trailing whitespace drift"
+    (define s "alpha   \nbeta\ngamma")
+    (define span (fuzzy-find-match s "alpha\nbeta"))
+    (check-equal? (slice s span) "alpha   \nbeta"))
+
+  (test-case "fuzzy-find-match tolerates old-text trailing whitespace drift"
+    (define s "alpha\nbeta\ngamma")
+    (define span (fuzzy-find-match s "alpha   \nbeta   "))
+    (check-equal? (slice s span) "alpha\nbeta"))
+
+  (test-case "fuzzy-find-match tolerates CRLF drift"
+    (define s "alpha\r\nbeta\r\ngamma")
+    (define span (fuzzy-find-match s "alpha\nbeta"))
+    (check-equal? (slice s span) "alpha\r\nbeta"))
+
+  (test-case "fuzzy-find-match tolerates tab indentation drift"
+    (define s "(define (f)\n\t(+ 1 2))")
+    (define span (fuzzy-find-match s "(define (f)\n  (+ 1 2))"))
+    (check-equal? (slice s span) "(define (f)\n\t(+ 1 2))"))
+
+  (test-case "fuzzy-find-match tolerates extra blank line drift"
+    (define s "alpha\n\n\nbeta\ngamma")
+    (define span (fuzzy-find-match s "alpha\n\nbeta"))
+    (check-equal? (slice s span) "alpha\n\n\nbeta"))
+
+  (test-case "fuzzy-find-match trims boundary blank lines in old-text"
+    (define s "alpha\nbeta\ngamma")
+    (define span (fuzzy-find-match s "\n\nalpha\nbeta\n"))
+    (check-equal? (slice s span) "alpha\nbeta"))
+
+  (test-case "fuzzy-find-match rejects absent text"
+    (check-false (fuzzy-find-match "alpha\nbeta" "delta")))
+
+  (test-case "fuzzy-find-match rejects low threshold mismatch"
+    (check-false (fuzzy-find-match "alpha beta gamma" "alpha zeta gamma" #:threshold 0.99))
+    (check-not-false (fuzzy-find-match "alpha beta gamma" "alpha zeta gamma" #:threshold 0.70)))
+
+  (test-case "fuzzy-find-match accepts threshold-compatible normalized match"
+    (check-not-false (fuzzy-find-match "alpha   \nbeta" "alpha\nbeta" #:threshold 0.85)))
+
+  (test-case "fuzzy-find-match returns original coordinates for middle match"
+    (define s "prefix\nalpha   \nbeta\nsuffix")
+    (define span (fuzzy-find-match s "alpha\nbeta"))
+    (check-equal? (slice s span) "alpha   \nbeta"))
+
+  (test-case "fuzzy-find-match handles multiple whitespace normalizations together"
+    (define s "before\r\n\talpha   \r\n\r\n\r\n\tbeta\r\nafter")
+    (define span (fuzzy-find-match s "  alpha\n\n  beta"))
+    (check-equal? (slice s span) "\talpha   \r\n\r\n\r\n\tbeta"))
+
+  (test-case "normalization suite covers many whitespace variants"
+    (define variants
+      (list "a\nb"
+            "a  \nb"
+            "a\r\nb"
+            "\na\nb\n"
+            "a\n\n\nb"
+            "a\t\nb"
+            "\t(a)\n\t(b)"
+            "x\r\ny\r\nz"
+            "x   \n\n\ny   "
+            "\n\n\tcall\t\n\n"))
+    (for ([v (in-list variants)])
+      (check-true (string? (normalize-text v)))
+      (check-not-false (regexp-match? #rx"^[^\r]*$" (normalize-text v)))))
+
+  (test-case "coordinate mapping never returns out-of-range spans"
+    (for ([old (in-list (list "a\nb" "a  \nb" "\na\nb\n" "a\r\nb"))])
+      (define s (string-append "prefix\n" old "\nsuffix"))
+      (define span (fuzzy-find-match s "a\nb"))
+      (check-not-false span)
+      (check-true (<= 0 (car span) (cdr span) (string-length s)))))
+
+  (test-case "additional normalization examples"
+    (check-equal? (normalize-text "x\r\ny") "x\ny")
+    (check-equal? (normalize-text "x\ry") "x\ny")
+    (check-equal? (normalize-text "x  ") "x")
+    (check-equal? (normalize-text "x\t") "x")
+    (check-equal? (normalize-text "\t") "")
+    (check-equal? (normalize-text "\tfoo") "  foo")
+    (check-equal? (normalize-text "foo\n\n") "foo")
+    (check-equal? (normalize-text "\n\nfoo") "foo")
+    (check-equal? (normalize-text "foo\n\nbar") "foo\n\nbar")
+    (check-equal? (normalize-text "foo\n\n\nbar") "foo\n\nbar")
+    (check-not-false (fuzzy-find-match "x\nfoo  \nbar\ny" "foo\nbar"))
+    (check-not-false (fuzzy-find-match "x\r\nfoo\r\nbar" "foo\nbar"))
+    (check-not-false (fuzzy-find-match "x\n\tfoo" "  foo"))
+    (check-false (fuzzy-find-match "foo" "bar")))
+
+  (test-case "crlf fuzzy case 1"
+    (check-not-false (fuzzy-find-match "a\r\nb" "a\nb")))
+  (test-case "trailing-space fuzzy case 2"
+    (check-not-false (fuzzy-find-match "a  \nb" "a\nb")))
+  (test-case "old-text trailing-space fuzzy case 3"
+    (check-not-false (fuzzy-find-match "a\nb" "a  \nb")))
+  (test-case "boundary blank fuzzy case 4"
+    (check-not-false (fuzzy-find-match "a\nb" "\na\nb\n")))
+  (test-case "tab fuzzy case 5"
+    (check-not-false (fuzzy-find-match "\ta" "  a")))
+  (test-case "blank collapse normalize case 6"
+    (check-equal? (normalize-text "a\n\n\n\nb") "a\n\nb"))
+  (test-case "empty normalize case 7"
+    (check-equal? (normalize-text "") ""))
+  (test-case "spaces-only normalize case 8"
+    (check-equal? (normalize-text "   ") ""))
+  (test-case "tabs-only normalize case 9"
+    (check-equal? (normalize-text "\t\t") ""))
+  (test-case "similarity high case 10"
+    (check > (similarity-score "abcdef" "abcxef") 0.8))
+  (test-case "similarity low case 11"
+    (check < (similarity-score "abcdef" "uvwxyz") 0.2))
+  (test-case "reject missing fuzzy case 12"
+    (check-false (fuzzy-find-match "abcdef" "ghijk")))
+  (test-case "empty normalized fuzzy does not crash case 12b"
+    (check-false (fuzzy-find-match "   " "\t"))
+    (check-false (fuzzy-find-match "abc" ""))
+    (check-false (fuzzy-find-match "   " "   ")))
+  (test-case "middle span fuzzy case 13"
+    (define s "111\nabc  \ndef\n222")
+    (check-equal? (slice s (fuzzy-find-match s "abc\ndef")) "abc  \ndef"))
+
+  (test-case "default-normalization-options is a normalize-options value"
+    (check-true (normalize-options? default-normalization-options))
+    (check-equal? (normalize-options-tab-width default-normalization-options) 2)))

--- a/tools/builtins/edit-normalize.rkt
+++ b/tools/builtins/edit-normalize.rkt
@@ -1,0 +1,229 @@
+#lang racket/base
+
+;; tools/builtins/edit-normalize.rkt — whitespace-tolerant edit matching
+
+(require racket/contract
+         racket/list
+         racket/string)
+
+(struct normalize-options
+        (strip-trailing? normalize-crlf?
+                         collapse-blank-lines?
+                         tabs-to-spaces?
+                         tab-width
+                         trim-boundary-blank-lines?)
+  #:transparent)
+
+(struct nline (pairs newline-idx) #:transparent)
+
+(provide (contract-out
+          (struct normalize-options
+                  ([strip-trailing? boolean?] [normalize-crlf? boolean?]
+                                              [collapse-blank-lines? boolean?]
+                                              [tabs-to-spaces? boolean?]
+                                              [tab-width exact-positive-integer?]
+                                              [trim-boundary-blank-lines? boolean?]))
+          [default-normalization-options normalize-options?]
+          [normalize-text (->* (string?) (normalize-options?) string?)]
+          [similarity-score (-> string? string? real?)]
+          [fuzzy-find-match
+           (->* (string? string?) (#:threshold real? #:options normalize-options?) (or/c pair? #f))]))
+
+(define default-normalization-options (normalize-options #t #t #t #t 2 #t))
+
+(define (emit-pair ch idx pairs)
+  (cons (cons ch idx) pairs))
+
+(define (normalize-newlines s opts)
+  (define len (string-length s))
+  (let loop ([i 0]
+             [out '()])
+    (cond
+      [(>= i len) (reverse out)]
+      [else
+       (define ch (string-ref s i))
+       (cond
+         [(and (normalize-options-normalize-crlf? opts) (char=? ch #\return))
+          (if (and (< (add1 i) len) (char=? (string-ref s (add1 i)) #\newline))
+              (loop (+ i 2) (emit-pair #\newline i out))
+              (loop (add1 i) (emit-pair #\newline i out)))]
+         [else (loop (add1 i) (emit-pair ch i out))])])))
+
+(define (split-lines pairs)
+  (let loop ([remaining pairs]
+             [line-pairs '()]
+             [lines '()])
+    (cond
+      [(null? remaining) (reverse (cons (nline (reverse line-pairs) #f) lines))]
+      [else
+       (define p (car remaining))
+       (if (char=? (car p) #\newline)
+           (loop (cdr remaining) '() (cons (nline (reverse line-pairs) (cdr p)) lines))
+           (loop (cdr remaining) (cons p line-pairs) lines))])))
+
+(define (expand-tabs pairs width)
+  (let loop ([remaining pairs]
+             [out '()])
+    (cond
+      [(null? remaining) (reverse out)]
+      [else
+       (define p (car remaining))
+       (if (char=? (car p) #\tab)
+           (loop (cdr remaining) (append (make-list (max 1 width) (cons #\space (cdr p))) out))
+           (loop (cdr remaining) (cons p out)))])))
+
+(define (trailing-strip-char? ch opts)
+  (and (char-whitespace? ch)
+       (or (normalize-options-normalize-crlf? opts) (not (char=? ch #\return)))))
+
+(define (strip-trailing-pairs pairs opts)
+  (cond
+    [(null? pairs) '()]
+    [(and (not (normalize-options-normalize-crlf? opts)) (char=? (car (last pairs)) #\return))
+     (append (strip-trailing-pairs (drop-right pairs 1) opts) (list (last pairs)))]
+    [else
+     (let loop ([remaining (reverse pairs)])
+       (cond
+         [(null? remaining) '()]
+         [(trailing-strip-char? (caar remaining) opts) (loop (cdr remaining))]
+         [else (reverse remaining)]))]))
+
+(define (pairs->string pairs)
+  (list->string (map car pairs)))
+
+(define (blank-line? line)
+  (string=? (string-trim (pairs->string (nline-pairs line))) ""))
+
+(define (normalize-line line opts)
+  (define tabbed
+    (if (normalize-options-tabs-to-spaces? opts)
+        (expand-tabs (nline-pairs line) (normalize-options-tab-width opts))
+        (nline-pairs line)))
+  (define stripped
+    (if (normalize-options-strip-trailing? opts)
+        (strip-trailing-pairs tabbed opts)
+        tabbed))
+  (nline stripped (nline-newline-idx line)))
+
+(define (trim-boundary-blank-lines lines opts)
+  (if (normalize-options-trim-boundary-blank-lines? opts)
+      (dropf-right (dropf lines blank-line?) blank-line?)
+      lines))
+
+(define (collapse-blank-lines lines opts)
+  (if (normalize-options-collapse-blank-lines? opts)
+      (let loop ([remaining lines]
+                 [previous-blank? #f]
+                 [out '()])
+        (cond
+          [(null? remaining) (reverse out)]
+          [else
+           (define line (car remaining))
+           (define blank? (blank-line? line))
+           (if (and blank? previous-blank?)
+               (loop (cdr remaining) #t out)
+               (loop (cdr remaining) blank? (cons line out)))]))
+      lines))
+
+(define (line-newline-map line)
+  (or (nline-newline-idx line)
+      (and (pair? (nline-pairs line)) (cdar (reverse (nline-pairs line))))
+      0))
+
+(define (join-lines lines)
+  (let loop ([remaining lines]
+             [out '()])
+    (cond
+      [(null? remaining) (reverse out)]
+      [else
+       (define line (car remaining))
+       (define with-line (append (reverse (nline-pairs line)) out))
+       (if (pair? (cdr remaining))
+           (loop (cdr remaining) (emit-pair #\newline (line-newline-map line) with-line))
+           (loop (cdr remaining) with-line))])))
+
+(define (normalize-pairs s opts)
+  (join-lines (collapse-blank-lines
+               (trim-boundary-blank-lines (map (lambda (line) (normalize-line line opts))
+                                               (split-lines (normalize-newlines s opts)))
+                                          opts)
+               opts)))
+
+(define (normalize-with-map s opts)
+  (define pairs (normalize-pairs s opts))
+  (values (pairs->string pairs) (map cdr pairs)))
+
+(define (normalize-text s (opts default-normalization-options))
+  (define-values (normalized maps) (normalize-with-map s opts))
+  normalized)
+
+(define (substring-index haystack needle)
+  (define m (regexp-match-positions (regexp-quote needle) haystack))
+  (and m (caar m)))
+
+(define (lcs-length a b)
+  (define la (string-length a))
+  (define lb (string-length b))
+  (define prev (make-vector (add1 lb) 0))
+  (for ([i (in-range la)])
+    (define curr (make-vector (add1 lb) 0))
+    (for ([j (in-range lb)])
+      (vector-set! curr
+                   (add1 j)
+                   (if (char=? (string-ref a i) (string-ref b j))
+                       (add1 (vector-ref prev j))
+                       (max (vector-ref prev (add1 j)) (vector-ref curr j)))))
+    (set! prev curr))
+  (vector-ref prev lb))
+
+(define (similarity-score a b)
+  (cond
+    [(and (zero? (string-length a)) (zero? (string-length b))) 1.0]
+    [(or (zero? (string-length a)) (zero? (string-length b))) 0.0]
+    [else (/ (lcs-length a b) (max (string-length a) (string-length b)))]))
+
+(define (normalized-end->original-end maps norm-end original-len)
+  (cond
+    [(zero? norm-end) 0]
+    [(>= norm-end (length maps)) original-len]
+    [else (add1 (list-ref maps (sub1 norm-end)))]))
+
+(define (best-window-start normalized-content normalized-old threshold)
+  (define content-len (string-length normalized-content))
+  (define old-len (string-length normalized-old))
+  (cond
+    [(or (zero? old-len) (< content-len old-len)) #f]
+    [else
+     (for/fold ([best-start #f]
+                [best-score 0.0]
+                #:result (and best-start (>= best-score threshold) best-start))
+               ([start (in-range 0 (add1 (- content-len old-len)))])
+       (define score
+         (similarity-score (substring normalized-content start (+ start old-len)) normalized-old))
+       (if (> score best-score)
+           (values start score)
+           (values best-start best-score)))]))
+
+(define (fuzzy-find-match content
+                          old-text
+                          #:threshold (threshold 0.85)
+                          #:options (opts default-normalization-options))
+  (define normalized-old/precheck (normalize-text old-text opts))
+  (define exact-start
+    (and (positive? (string-length normalized-old/precheck)) (substring-index content old-text)))
+  (cond
+    [exact-start (cons exact-start (+ exact-start (string-length old-text)))]
+    [else
+     (define-values (normalized-content content-map) (normalize-with-map content opts))
+     (define normalized-old normalized-old/precheck)
+     (define start
+       (or (substring-index normalized-content normalized-old)
+           (best-window-start normalized-content normalized-old threshold)))
+     (cond
+       [(or (not start) (zero? (string-length normalized-old)) (null? content-map)) #f]
+       [else
+        (define norm-end (+ start (string-length normalized-old)))
+        (define original-start (list-ref content-map start))
+        (define original-end
+          (normalized-end->original-end content-map norm-end (string-length content)))
+        (cons original-start original-end)])]))


### PR DESCRIPTION
## Summary
- Add standalone fuzzy edit normalization/matching library
- Preserve exact coordinate mapping back to original file content
- Cover 42 normalization/fuzzy-match cases

## Verification
- `raco fmt -i tools/builtins/edit-normalize.rkt tests/test-edit-normalize.rkt`
- `raco make tools/builtins/edit-normalize.rkt tests/test-edit-normalize.rkt`
- `racket scripts/run-tests.rkt tests/test-edit-normalize.rkt` → 42/42
- Read-only reviewer: APPROVED

Closes #5201.