### PR TITLE
feat(W1): integrate fuzzy normalization into edit tool (#5205)

### DIFF
--- a/tests/test-tool-edit.rkt
+++ b/tests/test-tool-edit.rkt
@@ -246,3 +246,58 @@
                    "prune-old-backups should use string-suffix? instead of string-contains?")
   ;; Cleanup
   (delete-directory/files tmp-dir))
+
+;; ============================================================
+;; Fuzzy edit integration (v0.58.0 W1)
+;; ============================================================
+
+(test-case "tool-edit fuzzy replaces text with trailing whitespace drift"
+  (define tmp (make-temporary-file "q-test-edit-~a.txt"))
+  (display-to-file "alpha  \nbeta" tmp #:exists 'replace)
+  (define result (tool-edit (hasheq 'path tmp 'old-text "alpha\n" 'new-text "gamma\n" 'fuzzy? #t)))
+  (check-false (tool-result-is-error? result) (format "~a" result))
+  (check-equal? (file->string tmp) "gamma\nbeta")
+  (delete-file tmp))
+
+(test-case "tool-edit fuzzy replaces text with CRLF drift"
+  (define tmp (make-temporary-file "q-test-edit-~a.txt"))
+  (display-to-file "alpha\r\nbeta" tmp #:exists 'replace)
+  (define result
+    (tool-edit (hasheq 'path tmp 'old-text "alpha\nbeta" 'new-text "gamma\nbeta" 'fuzzy? #t)))
+  (check-false (tool-result-is-error? result) (format "~a" result))
+  (check-equal? (file->string tmp) "gamma\nbeta")
+  (delete-file tmp))
+
+(test-case "tool-edit fuzzy replaces text with tab-space drift"
+  (define tmp (make-temporary-file "q-test-edit-~a.txt"))
+  (display-to-file "\tfoo" tmp #:exists 'replace)
+  (define result (tool-edit (hasheq 'path tmp 'old-text "  foo" 'new-text "  bar" 'fuzzy? #t)))
+  (check-false (tool-result-is-error? result) (format "~a" result))
+  ;; fuzzy match replaces the normalized-equivalent span with new-text verbatim
+  (check-equal? (file->string tmp) "  bar")
+  (delete-file tmp))
+
+(test-case "tool-edit fuzzy still errors when both exact and fuzzy fail"
+  (define tmp (make-temporary-file "q-test-edit-~a.txt"))
+  (display-to-file "alpha" tmp #:exists 'replace)
+  (define result (tool-edit (hasheq 'path tmp 'old-text "beta" 'new-text "gamma" 'fuzzy? #t)))
+  (check-pred tool-result-is-error? result)
+  (check-true (string-contains? (hash-ref (car (tool-result-content result)) 'text) "not found"))
+  (delete-file tmp))
+
+(test-case "tool-edit fuzzy is off by default"
+  (define tmp (make-temporary-file "q-test-edit-~a.txt"))
+  (display-to-file "alpha  \nbeta" tmp #:exists 'replace)
+  (define result (tool-edit (hasheq 'path tmp 'old-text "alpha\n" 'new-text "gamma\n")))
+  (check-pred tool-result-is-error? result)
+  (check-true (string-contains? (hash-ref (car (tool-result-content result)) 'text) "not found"))
+  (delete-file tmp))
+
+(test-case "tool-edit fuzzy preserves line-count integrity"
+  (define tmp (make-temporary-file "q-test-edit-~a.txt"))
+  (display-to-file "line1\nline2  \nline3" tmp #:exists 'replace)
+  (define result
+    (tool-edit (hasheq 'path tmp 'old-text "line2\n" 'new-text "LINE2A\nLINE2B\n" 'fuzzy? #t)))
+  (check-false (tool-result-is-error? result) (format "~a" result))
+  (check-equal? (file->string tmp) "line1\nLINE2A\nLINE2B\nline3")
+  (delete-file tmp))

--- a/tools/builtins/edit-normalize.rkt
+++ b/tools/builtins/edit-normalize.rkt
@@ -204,11 +204,31 @@
            (values start score)
            (values best-start best-score)))]))
 
+(define (normalize-text-keep-trailing-nl s opts)
+  (define text (normalize-text s opts))
+  (define last-idx (sub1 (string-length s)))
+  (define ends-with-nl?
+    (and (>= last-idx 0)
+         (or (char=? (string-ref s last-idx) #\newline)
+             (and (>= last-idx 1)
+                  (char=? (string-ref s (sub1 last-idx)) #\return)
+                  (char=? (string-ref s last-idx) #\newline)))))
+  (define lines (string-split s "\n" #:trim? #f))
+  (define has-boundary-blanks?
+    (or (and (> (length lines) 1) (string=? (car lines) ""))
+        (and (> (length lines) 2) (string=? (list-ref lines (- (length lines) 2)) ""))))
+  (if (and ends-with-nl?
+           (not has-boundary-blanks?)
+           (or (zero? (string-length text))
+               (not (char=? (string-ref text (sub1 (string-length text))) #\newline))))
+      (string-append text "\n")
+      text))
+
 (define (fuzzy-find-match content
                           old-text
                           #:threshold (threshold 0.85)
                           #:options (opts default-normalization-options))
-  (define normalized-old/precheck (normalize-text old-text opts))
+  (define normalized-old/precheck (normalize-text-keep-trailing-nl old-text opts))
   (define exact-start
     (and (positive? (string-length normalized-old/precheck)) (substring-index content old-text)))
   (cond

--- a/tools/builtins/edit.rkt
+++ b/tools/builtins/edit.rkt
@@ -23,10 +23,14 @@
                   [set-edit-limit! set-current-max-old-text-len!])
          (only-in "../../util/path-helpers.rkt" expand-home-path)
          (only-in "../../util/error-sanitizer.rkt" sanitize-error-message)
-         (only-in "builtin-helpers.rkt" require-safe-path!))
+         (only-in "builtin-helpers.rkt" require-safe-path!)
+         "edit-normalize.rkt")
+
+(define current-fuzzy-edit-enabled? (make-parameter #f))
 
 (provide current-max-old-text-len
          set-current-max-old-text-len!
+         current-fuzzy-edit-enabled?
          (contract-out [tool-edit (->* (hash?) (any/c) any/c)]))
 
 ;; --------------------------------------------------
@@ -234,14 +238,25 @@
              (current-max-old-text-len)))]
           [_
            (define occurrences (count-occurrences content old-text))
-           (match occurrences
-             [0 (make-error-result (make-not-found-error path old-text content))]
-             [(? (lambda (n) (> n 1)))
+           (define fuzzy-allowed?
+             (or (hash-ref args 'fuzzy? (current-fuzzy-edit-enabled?)) (current-fuzzy-edit-enabled?)))
+           (define fuzzy-match
+             (and (zero? occurrences) fuzzy-allowed? (fuzzy-find-match content old-text)))
+           (cond
+             [(and (zero? occurrences) (not fuzzy-match))
+              (make-error-result (make-not-found-error path old-text content))]
+             [(> occurrences 1)
               (make-error-result
                (format "old-text appears ~a times in ~a; be more specific" occurrences path))]
-             [1
+             [else
+              ;; occurrences = 1 or fuzzy-match succeeded
               (define backup-path (save-backup path content))
-              (define new-content (string-replace content old-text new-text #:all? #f))
+              (define new-content
+                (if fuzzy-match
+                    (string-append (substring content 0 (car fuzzy-match))
+                                   new-text
+                                   (substring content (cdr fuzzy-match)))
+                    (string-replace content old-text new-text #:all? #f)))
               (define expected-delta (- (line-count new-text) (line-count old-text)))
               (define actual-delta (- (line-count new-content) (line-count content)))
               (define delta-diff (abs (- actual-delta expected-delta)))
@@ -270,15 +285,16 @@
                    (call-with-output-file path
                                           (lambda (out) (display new-content out))
                                           #:exists 'replace)
-                   (make-success-result
-                    (list (format "Edited ~a (replaced ~a occurrence)" path occurrences))
-                    (hasheq 'path
-                            path
-                            'replacements
-                            1
-                            'old-length
-                            (string-length old-text)
-                            'new-length
-                            (string-length new-text)
-                            'backup
-                            (or backup-path ""))))])])])])]))
+                   (make-success-result (list (format "Edited ~a (replaced ~a occurrence)"
+                                                      path
+                                                      (if fuzzy-match 1 occurrences)))
+                                        (hasheq 'path
+                                                path
+                                                'replacements
+                                                1
+                                                'old-length
+                                                (string-length old-text)
+                                                'new-length
+                                                (string-length new-text)
+                                                'backup
+                                                (or backup-path ""))))])])])])]))


### PR DESCRIPTION
## Summary
- Integrate fuzzy edit normalization into `tool-edit` with exact-match-first fallback
- Add `current-fuzzy-edit-enabled?` parameter and `fuzzy?` arg
- Preserve all existing safeguards (backup, line-count delta, auto-revert)
- Fix `normalize-text-keep-trailing-nl` boundary-blank heuristic

## Verification
- `racket scripts/run-tests.rkt tests/test-edit-normalize.rkt tests/test-tool-edit.rkt` → 69/69
- `raco fmt` / `raco make` pass on all 4 changed files

Closes #5205.