### PR TITLE
feat(W2): grep/find robustness & exact-match coverage (#5209)

### DIFF
--- a/tests/test-find.rkt
+++ b/tests/test-find.rkt
@@ -236,4 +236,37 @@
 ;; Run
 ;; ============================================================
 
+;; Robustness: negative max-depth clamps to 0
+(test-case "negative max-depth clamps to 0"
+  (with-temp-dir (λ (dir)
+                   (create-file dir "l0.txt")
+                   (create-file dir "sub/l1.txt")
+                   (define r (tool-find (hasheq 'path (path->string dir) 'max-depth -1)))
+                   (check-false (result-is-error? r))
+                   (define c (result-content r))
+                   (check-not-false (member "l0.txt" c))
+                   (check-not-false (member "sub" c))
+                   (check-false (member "sub/l1.txt" c)))))
+
+;; Robustness: negative max-results clamps to 1
+(test-case "negative max-results clamps to 1"
+  (with-temp-dir (λ (dir)
+                   (create-file dir "a.txt")
+                   (create-file dir "b.txt")
+                   (define r (tool-find (hasheq 'path (path->string dir) 'max-results -5)))
+                   (check-false (result-is-error? r))
+                   (check-equal? (length (result-content r)) 1)
+                   (check-equal? (hash-ref (result-details r) 'total-found) 2)
+                   (check-true (hash-ref (result-details r) 'truncated?)))))
+
+;; Edge case: empty name pattern matches all
+(test-case "empty name pattern matches all"
+  (with-temp-dir (λ (dir)
+                   (create-file dir "a.txt")
+                   (create-file dir "b.rkt")
+                   (define r (tool-find (hasheq 'path (path->string dir) 'name "")))
+                   (check-false (result-is-error? r))
+                   (define c (result-content r))
+                   (check-equal? (length c) 2))))
+
 (run-tests find-tests)

--- a/tests/test-grep.rkt
+++ b/tests/test-grep.rkt
@@ -263,4 +263,46 @@
 ;; Run
 ;; ============================================================
 
+;; Robustness: invalid regex pattern returns error, not crash
+(test-case "invalid regex pattern returns error"
+  (with-temp-dir (λ (dir)
+                   (define f (build-path dir "regex.txt"))
+                   (write-string-to-file f "alpha\n")
+                   (define r (tool-grep (hasheq 'pattern "[" 'path (path->string f))))
+                   (check-true (result-is-error? r))
+                   (define c (string-join (result-content r) ""))
+                   (check-true (regexp-match? #rx"[Ii]nvalid|[Pp]attern" c)))))
+
+;; Exact-match coverage: literal metacharacters treated as literals
+(test-case "exact match treats metacharacters as literals"
+  (with-temp-dir (λ (dir)
+                   (define f (build-path dir "exact.txt"))
+                   (write-string-to-file f "alpha[1]\nbeta\n[1] gamma\n")
+                   (define r (tool-grep (hasheq 'pattern "[1]" 'path (path->string f) 'exact? #t)))
+                   (check-false (result-is-error? r))
+                   (define d (result-details r))
+                   (check-equal? (hash-ref d 'total-matches) 2))))
+
+;; Exact-match coverage: case-insensitive exact match
+(test-case "exact match case-insensitive"
+  (with-temp-dir
+   (λ (dir)
+     (define f (build-path dir "exactci.txt"))
+     (write-string-to-file f "Hello\nhello\nHELLO\n")
+     (define r
+       (tool-grep (hasheq 'pattern "hello" 'path (path->string f) 'exact? #t 'case-insensitive? #t)))
+     (check-false (result-is-error? r))
+     (define d (result-details r))
+     (check-equal? (hash-ref d 'total-matches) 3))))
+
+;; Edge case: empty pattern matches every line
+(test-case "empty pattern matches every line"
+  (with-temp-dir (λ (dir)
+                   (define f (build-path dir "empty-pattern.txt"))
+                   (write-string-to-file f "alpha\nbeta\ngamma\n")
+                   (define r (tool-grep (hasheq 'pattern "" 'path (path->string f) 'context-lines 0)))
+                   (check-false (result-is-error? r))
+                   (define d (result-details r))
+                   (check-equal? (hash-ref d 'total-matches) 3))))
+
 (run-tests grep-tests)

--- a/tools/builtins/find.rkt
+++ b/tools/builtins/find.rkt
@@ -96,12 +96,12 @@
         ;; 4. Parse optional arguments
         (define name-pattern (hash-ref args 'name #f))
         (define type-filter (hash-ref args 'type "any"))
-        (define max-depth (hash-ref args 'max-depth 10))
-        (define max-results (hash-ref args 'max-results 100))
+        (define max-depth (max 0 (hash-ref args 'max-depth 10)))
+        (define max-results (max 1 (hash-ref args 'max-results 100)))
 
-        ;; Compile glob pattern if provided
+        ;; Compile glob pattern if provided (empty string → match all)
         (define name-re
-          (if name-pattern
+          (if (and name-pattern (positive? (string-length name-pattern)))
               (glob->regexp name-pattern #:allow-slash? #t)
               #f))
 
@@ -123,15 +123,16 @@
 ;; Tool definition via define-tool macro
 ;; --------------------------------------------------
 
-(define-tool find
-  #:description "Recursively list files and directories matching a name pattern. Supports glob patterns and type filtering."
-  #:required ("path")
-  #:properties
-    [(path "string" "Root directory to search")
-     (name "string" "Name pattern (glob, optional)")
-     (type "string" "Type filter: 'file', 'dir', or 'any' (default)")
-     (max-depth "integer" "Maximum directory depth to search (default 10)")
-     (max-results "integer" "Maximum results to return (default 100)")]
-  find-handler)
+(define-tool
+ find
+ #:description
+ "Recursively list files and directories matching a name pattern. Supports glob patterns and type filtering."
+ #:required ("path")
+ #:properties [(path "string" "Root directory to search")
+               (name "string" "Name pattern (glob, optional)")
+               (type "string" "Type filter: 'file', 'dir', or 'any' (default)")
+               (max-depth "integer" "Maximum directory depth to search (default 10)")
+               (max-results "integer" "Maximum results to return (default 100)")]
+ find-handler)
 
 (provide find)

--- a/tools/builtins/grep.rkt
+++ b/tools/builtins/grep.rkt
@@ -25,6 +25,7 @@
 (define DEFAULT-CASE-INSENSITIVE #f)
 (define DEFAULT-MAX-RESULTS 50)
 (define DEFAULT-CONTEXT-LINES 2)
+(define DEFAULT-EXACT #f)
 
 ;; ============================================================
 ;; Internal helpers
@@ -37,11 +38,16 @@
     (define s (path->string part))
     (or (hidden-name? s) (member s skip-dirs))))
 
-;; Compile the regex pattern
-(define (compile-pattern pattern case-insensitive?)
-  (if case-insensitive?
-      (regexp (string-append "(?i:" pattern ")"))
-      (regexp pattern)))
+;; Compile the regex pattern. Returns #f on invalid regex.
+(define (compile-pattern pattern case-insensitive? exact?)
+  (with-handlers ([exn:fail? (lambda (e) #f)])
+    (define effective-pattern
+      (if exact?
+          (regexp-quote pattern)
+          pattern))
+    (if case-insensitive?
+        (regexp (string-append "(?i:" effective-pattern ")"))
+        (regexp effective-pattern))))
 
 ;; ============================================================
 ;; Core search in a single file
@@ -148,23 +154,26 @@
      (define case-insensitive? (hash-ref args 'case-insensitive? DEFAULT-CASE-INSENSITIVE))
      (define max-results (hash-ref args 'max-results DEFAULT-MAX-RESULTS))
      (define context-lines (hash-ref args 'context-lines DEFAULT-CONTEXT-LINES))
+     (define exact? (hash-ref args 'exact? DEFAULT-EXACT))
 
      ;; 2. Compile pattern
-     (define pattern-rx (compile-pattern pattern case-insensitive?))
-
-     ;; 3. Resolve path
-     (define the-path (string->path path-str))
-
+     (define pattern-rx (compile-pattern pattern case-insensitive? exact?))
      (cond
-       [(not (or (file-exists? the-path) (directory-exists? the-path)))
-        (make-error-result (format "Path not found: ~a" path-str))]
-       [(file-exists? the-path)
-        ;; Single file search
-        (search-single-file the-path path-str pattern-rx context-lines max-results 1)]
-       [(directory-exists? the-path)
-        ;; Directory search
-        (search-directory the-path path-str pattern-rx glob-pattern context-lines max-results)]
-       [else (make-error-result (format "Path not found: ~a" path-str))])]))
+       [(not pattern-rx) (make-error-result (format "Invalid pattern: ~a" pattern))]
+       [else
+        ;; 3. Resolve path
+        (define the-path (string->path path-str))
+
+        (cond
+          [(not (or (file-exists? the-path) (directory-exists? the-path)))
+           (make-error-result (format "Path not found: ~a" path-str))]
+          [(file-exists? the-path)
+           ;; Single file search
+           (search-single-file the-path path-str pattern-rx context-lines max-results 1)]
+          [(directory-exists? the-path)
+           ;; Directory search
+           (search-directory the-path path-str pattern-rx glob-pattern context-lines max-results)]
+          [else (make-error-result (format "Path not found: ~a" path-str))])])]))
 
 ;; ============================================================
 ;; Single file search


### PR DESCRIPTION
## Summary
- Grep tool: add `exact?` literal-match mode, catch invalid regex patterns
- Find tool: clamp negative `max-depth`/`max-results`, treat empty `name` as match-all
- 7 new tests covering edge cases and robustness

## Verification
- `racket scripts/run-tests.rkt tests/test-grep.rkt tests/test-find.rkt` → 38/38
- `raco fmt` / `raco make` pass on all changed files

Closes #5209.