### PR TITLE
feat(v0.58.1-W1): TUI status bar context pressure indicator (#5217)

### DIFF
--- a/tests/tui/test-event-reducer-registry.rkt
+++ b/tests/tui/test-event-reducer-registry.rkt
@@ -94,3 +94,15 @@
   (check-equal? (ui-state-status-message st1) "Compacting...")
   (define st2 (apply-event-to-state st1 (make-test-event "compaction.completed" (hash))))
   (check-false (ui-state-status-message st2)))
+
+(test-case "context.pressure sets pressure level and percent"
+  (define st0 (initial-ui-state))
+  (define st1
+    (apply-event-to-state st0
+                          (make-test-event "context.pressure"
+                                           (hasheq 'level 'yellow 'usage-percent 72.5))))
+  (check-equal? (ui-state-context-pressure-level st1) 'yellow)
+  (check-= (ui-state-context-pressure-percent st1) 72.5 0.01))
+
+(test-case "context.pressure registered"
+  (check-true (event-reducer-registered? "context.pressure")))

--- a/tests/tui/test-render-status-line.rkt
+++ b/tests/tui/test-render-status-line.rkt
@@ -135,6 +135,59 @@
       (check-false (string-contains? text "\u2191")))
 
     ;; --------------------------------------------------------
+    ;; Context pressure indicator (v0.58.1 W1)
+    ;; --------------------------------------------------------
+    (test-case "context pressure shows percentage when available"
+      (define state
+        (struct-copy ui-state
+                     (initial-ui-state)
+                     [context-pressure-level 'green]
+                     [context-pressure-percent 45.0]))
+      (define result (render-status-bar state 80))
+      (define text (styled-segment-text (first-segment result)))
+      (check-true (string-contains? text "ctx:45%")))
+
+    (test-case "context pressure yellow shows ! marker"
+      (define state
+        (struct-copy ui-state
+                     (initial-ui-state)
+                     [context-pressure-level 'yellow]
+                     [context-pressure-percent 70.0]))
+      (define result (render-status-bar state 80))
+      (define text (styled-segment-text (first-segment result)))
+      (check-true (string-contains? text "ctx:70!%")))
+
+    (test-case "context pressure red shows !! marker"
+      (define state
+        (struct-copy ui-state
+                     (initial-ui-state)
+                     [context-pressure-level 'red]
+                     [context-pressure-percent 90.0]))
+      (define result (render-status-bar state 80))
+      (define text (styled-segment-text (first-segment result)))
+      (check-true (string-contains? text "ctx:90!!%")))
+
+    (test-case "context pressure disabled falls back to token count"
+      (parameterize ([current-show-context-pressure? #f])
+        (define state
+          (struct-copy ui-state
+                       (initial-ui-state)
+                       [context-pressure-level 'green]
+                       [context-pressure-percent 45.0]
+                       [context-tokens 12000]))
+        (define result (render-status-bar state 80))
+        (define text (styled-segment-text (first-segment result)))
+        (check-true (string-contains? text "ctx:1.2K"))
+        (check-false (string-contains? text "%"))))
+
+    (test-case "no pressure data falls back to token count"
+      (define state (struct-copy ui-state (initial-ui-state) [context-tokens 500]))
+      (define result (render-status-bar state 80))
+      (define text (styled-segment-text (first-segment result)))
+      (check-true (string-contains? text "ctx:500"))
+      (check-false (string-contains? text "%")))
+
+    ;; --------------------------------------------------------
     ;; Width fitting (v0.28.17: single segment fills width)
     ;; --------------------------------------------------------
     (test-case "single segment length fits within width"

--- a/tui/render/status-line.rkt
+++ b/tui/render/status-line.rkt
@@ -14,7 +14,12 @@
          "message-layout.rkt")
 
 (provide render-status-bar
-         render-input-line)
+         render-input-line
+         current-show-context-pressure?)
+
+;; ── Parameter ──
+
+(define current-show-context-pressure? (make-parameter #t))
 
 ;; ── Token formatting helper ──
 
@@ -45,6 +50,8 @@
   (define scroll-off (ui-state-scroll-offset state))
   (define ctx-tokens (ui-state-context-tokens state))
   (define cost-trk (ui-state-cost-tracker state))
+  (define ctx-pressure-level (ui-state-context-pressure-level state))
+  (define ctx-pressure-pct (ui-state-context-pressure-percent state))
 
   ;; Build state indicator based on busy state
   (define state-indicator
@@ -76,8 +83,17 @@
   (define inv-text (string-append " q" busy-marker " " session-label state-indicator queue-text))
 
   ;; Normal-style segments (context + cost + scroll)
-  ;; Always show context tokens — default to 0 when not yet built
-  (define ctx-part (format " ctx:~a" (format-tokens (or ctx-tokens 0))))
+  ;; Show context pressure percentage when available, else token count
+  (define ctx-part
+    (cond
+      [(and (current-show-context-pressure?) ctx-pressure-pct (real? ctx-pressure-pct))
+       (define level-marker
+         (case ctx-pressure-level
+           [(yellow) "!"]
+           [(red) "!!"]
+           [else ""]))
+       (format " ctx:~a~a%" (inexact->exact (round ctx-pressure-pct)) level-marker)]
+      [else (format " ctx:~a" (format-tokens (or ctx-tokens 0)))]))
   (define cost-part
     (if (and cost-trk (positive? (cost-tracker-input-tokens-total cost-trk)))
         (format " ~a" (format-cost (cost-tracker-total cost-trk)))

--- a/tui/state-events.rkt
+++ b/tui/state-events.rkt
@@ -376,6 +376,13 @@
   (define path (hash-ref payload 'path "?"))
   (append-entry state (make-entry 'system (format "[archived] ~a" path) (event-time evt) (hash))))
 
+(define (handle-context-pressure state evt)
+  (define payload (event-payload evt))
+  (struct-copy ui-state
+               state
+               [context-pressure-level (hash-ref payload 'level #f)]
+               [context-pressure-percent (hash-ref payload 'usage-percent #f)]))
+
 (define (handle-context-mid-turn-over-budget state evt)
   (define payload (event-payload evt))
   (define estimated (hash-ref payload 'estimated-tokens "?"))
@@ -476,6 +483,7 @@
 (register-event-reducer! "auto-retry.context-reduced" handle-auto-retry-lifecycle)
 (register-event-reducer! "model.stream.thinking" handle-model-stream-thinking)
 (register-event-reducer! "model.stream.completed" handle-model-stream-completed)
+(register-event-reducer! "context.pressure" handle-context-pressure)
 
 ;; ============================================================
 ;; Event reduction dispatch

--- a/tui/state-types.rkt
+++ b/tui/state-types.rkt
@@ -146,7 +146,9 @@
           [clear-streaming (-> ui-state? ui-state?)]
           ;; String helpers
           [truncate-string (-> string? exact-nonnegative-integer? string?)]
-          [extract-arg-summary (-> (or/c string? hash?) string?)]))
+          [extract-arg-summary (-> (or/c string? hash?) string?)])
+         ui-state-context-pressure-level
+         ui-state-context-pressure-percent)
 
 ;; Forward declarations for types referenced in contracts but defined elsewhere
 ;; (These are provided by other modules and re-exported through state.rkt)
@@ -229,7 +231,9 @@
          editor-component ; (or/c #f q-component?) — custom editor for input area (#1150)
          ;; --- Budget group ---
          context-tokens ; (or/c #f integer?) — estimated token count from context events (v0.19.12 W1)
-         cost-tracker) ; (or/c #f cost-tracker?) — mutable cost accumulator (G8.4)
+         cost-tracker
+         context-pressure-level
+         context-pressure-percent) ; (or/c #f cost-tracker?) — mutable cost accumulator (G8.4)
   #:transparent)
 
 ;; Overlay state for modal/popup UI elements (command palette, etc.)
@@ -361,7 +365,9 @@
             #f ; focused-component
             #f ; editor-component
             #f ; context-tokens
-            (make-cost-tracker)))
+            (make-cost-tracker)
+            #f
+            #f))
 
 ;; ============================================================
 ;; Backward-compatible streaming accessors (v0.38.6)


### PR DESCRIPTION
## Summary
TUI status bar integration for v0.58.1 W1.

## Changes
- `tui/state-types.rkt`: new `context-pressure-level` and `context-pressure-percent` fields on `ui-state`
- `tui/state-events.rkt`: handle `"context.pressure"` events
- `tui/render/status-line.rkt`: show pressure percentage with warning markers
- Tests: 7 new tests across status-line and event-reducer test files

## Verification
- `racket scripts/run-tests.rkt tests/tui/test-render-status-line.rkt` → 19/19 pass
- `racket scripts/run-tests.rkt tests/tui/test-event-reducer-registry.rkt` → 13/13 pass
- Targeted regression suite → 47/47 pass
- `racket scripts/lint-all.rkt` → 20/23 (release-readiness expected fail)

Closes #5217 (W1), #5218 (W1.1), #5219 (W1.2), #5220 (W1.3).