### PR TITLE
release(v0.58.1): bump version, CHANGELOG, tag (#5225)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## v0.58.1 — 2026-05-25
+
+### Context Pressure Signaling & `/compact` Command
+
+Milestone giving users visibility and control over context compaction.
+
+**W0 — Context Pressure Event System**
+- Created `agent/event-structs/context-pressure-events.rkt`: `context-pressure-event` typed event
+- Created `runtime/context-pressure.rkt`: `check-context-pressure` computes green/yellow/red level
+  from token count vs budget (thresholds: <60% green, 60-80% yellow, >80% red)
+- Wired `check-context-pressure` into `run-prompt-internal` after `maybe-compact-context`
+- 6 tests covering thresholds, event emission, percentage accuracy
+
+**W1 — TUI Status Bar Integration**
+- Added `context-pressure-level` and `context-pressure-percent` to `ui-state` struct
+- `render-status-bar` shows `[ctx: 45%]` when pressure data available
+- Warning markers: `!` for yellow, `!!` for red
+- `current-show-context-pressure?` parameter (default `#t`)
+- Falls back to raw token count when disabled or unavailable
+- 7 tests covering rendering at all levels and fallback modes
+
+**W2 — `/compact` Command**
+- `/compact` now accepts `--dry-run` argument (shows transcript entry count preview)
+- Blocked during active tool loop (`ui-state-busy?`)
+- `session.compact.completed` event now includes `keptCount` alongside `removedCount`
+- 3 tests for event emission, dry-run, and busy blocking
+
 ## v0.58.0 — 2026-05-25
 
 ### Fuzzy-Match Edit Tool + Tool Robustness

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.58.0-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.58.1-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 
@@ -203,7 +203,7 @@ bin/q --model gpt-5.4 "write a test"
 ### Verify
 
 ```bash
-bin/q --version            # q version 0.58.0
+bin/q --version            # q version 0.58.1
 raco test tests/           # run the full test suite
 ```
 
@@ -453,6 +453,9 @@ When q executes shell commands on behalf of an LLM, arguments are quoted via `sh
 
 
 
+
+
+**v0.58.1** — Context Pressure Signaling & `/compact` Command
 
 **v0.58.0** — Fuzzy-Match Edit Tool + Tool Robustness
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.58.0 --># Installation Guide
+<!-- verified-against: 0.58.1 --># Installation Guide
 
 <!-- This file is the canonical source. The docs/getting-started/installation.md copy is maintained for the doc site build. -->
 

--- a/docs/reports/v0.57.0-metric-baseline.md
+++ b/docs/reports/v0.57.0-metric-baseline.md
@@ -1,7 +1,7 @@
-# v0.58.0 Metric Baseline — Measurement + Characterization Truth
+# v0.58.1 Metric Baseline — Measurement + Characterization Truth
 
 **Date**: 2026-05-24
-**Milestone**: v0.58.0 (#495)
+**Milestone**: v0.58.1 (#495)
 **Status**: Complete
 
 ## Baseline Metrics
@@ -42,29 +42,29 @@
 
 ## Key Findings (documented for remediation)
 
-### v0.58.0 — GSD Session Isolation
+### v0.58.1 — GSD Session Isolation
 - `gsd-default-ctx` is module-level global singleton in `session-state.rkt`
 - `state-machine.rkt` directly accesses `gsd-default-ctx` at 6 call sites
 - `current-gsd-*` / `set-gsd-*` API all operate on shared global
 - Independent `make-gsd-context` instances ARE properly isolated (API supports it)
 - Production code doesn't use the per-session API
 
-### v0.58.0 — Runtime Boundaries + Resilience
+### v0.58.1 — Runtime Boundaries + Resilience
 - **BUG**: Structured 5xx provider-errors (category `'server`) are NOT retryable
   - `retryable-error?` checks for `'server-error` but `classify-http-status` returns `'server`
   - String-based 5xx IS retryable via fallback — inconsistent behavior
   - Fix: change `'server-error` → `'server` in memq list
 
-### v0.58.0 — TUI Hotspot Decomposition
+### v0.58.1 — TUI Hotspot Decomposition
 - **BUG**: `handle-user-submit!` contract lies — claims `(-> tui-ctx? string? tui-ctx?)` but returns thread
   - Contract throws `exn:fail:contract?` on every call
   - Prevents testing the function
   - Fix: change to `(-> tui-ctx? string? void?)` or `(-> tui-ctx? string? thread?)`
 - Top TUI hotspots: keybindings (24687), render-loop (17670), commands (16031)
 
-### v0.58.0 — Contract Precision
+### v0.58.1 — Contract Precision
 - 882 `any/c` across 148 files
-- v0.58.0 will target top-5 offenders for typed boundary pilot
+- v0.58.1 will target top-5 offenders for typed boundary pilot
 
 ## Waves Completed
 - W0 (#5106): Recursive arch boundary baseline — PR #5112

--- a/docs/reports/v0.57.6-audit-remediation-baseline.md
+++ b/docs/reports/v0.57.6-audit-remediation-baseline.md
@@ -5,7 +5,7 @@
 **Issue:** #5172  
 **Branch:** `feature/v0576-w0-baseline`  
 **Baseline commit:** `c0963c42`  
-**Baseline version:** `q version 0.58.0`
+**Baseline version:** `q version 0.58.1`
 
 ## Purpose
 
@@ -29,7 +29,7 @@ racket scripts/lint-all.rkt
 
 | Metric | Value |
 |---|---:|
-| Version | 0.58.0 |
+| Version | 0.58.1 |
 | Exact `any/c` in contract-out | 812 |
 | Files with `any/c` | 143 |
 | Source files scanned by contract metrics | 363 |
@@ -39,7 +39,7 @@ racket scripts/lint-all.rkt
 | Gate | Exit | Result |
 |---|---:|---|
 | `raco make main.rkt` | 0 | PASS |
-| `racket main.rkt --version` | 0 | `q version 0.58.0` |
+| `racket main.rkt --version` | 0 | `q version 0.58.1` |
 | `racket scripts/run-tests.rkt --suite fast` | 4 | FAIL: 12 failing files + strict sentinel false positives |
 | `racket scripts/run-tests.rkt --suite tui` | 4 | FAIL: actual tests pass, strict sentinel flags helpers |
 | `racket scripts/run-tests.rkt --suite arch` | 4 | FAIL: actual tests pass, strict sentinel flags helpers/workflow file |
@@ -82,8 +82,8 @@ This maps to W2.
 
 `racket scripts/lint-all.rkt` failed release-readiness:
 
-- tag `v0.58.0` does not exist yet — PASS in current pre-release semantics
-- `CHANGELOG missing entry for 0.58.0` — false negative because changelog uses `## v0.58.0`
+- tag `v0.58.1` does not exist yet — PASS in current pre-release semantics
+- `CHANGELOG missing entry for 0.58.1` — false negative because changelog uses `## v0.58.1`
 - `git has 1 uncommitted change(s)` — caused by lint/metrics mutating `README.md`
 - branch check failed because W0 ran on feature branch, expected during wave work
 

--- a/docs/security-trust-model.md
+++ b/docs/security-trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.58.0 --># Security & Trust Model
+<!-- verified-against: 0.58.1 --># Security & Trust Model
 
 This document provides an honest, per-area assessment of what q enforces
 today and what is planned. It is the authoritative reference for security

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -130,6 +130,6 @@ is the primary self-hosting extension:
 (load-extension! ext-reg "path/to/extension.rkt" #:event-bus bus)
 ```
 
-## Version 0.58.0
+## Version 0.58.1
 
-This documentation reflects q 0.58.0.
+This documentation reflects q 0.58.1.

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.58.0 --># q Source Style Guide
+<!-- verified-against: 0.58.1 --># q Source Style Guide
 
 This document defines formatting and naming conventions for the q Racket codebase.
 All changes to `q/` source files (excluding `tests/`) should follow these rules.

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.58.0 --># Trust Model
+<!-- verified-against: 0.58.1 --># Trust Model
 
 ## Trust Levels
 

--- a/docs/workflow-testing.md
+++ b/docs/workflow-testing.md
@@ -121,6 +121,6 @@ Use relative paths from the test file:
 4. Use `(check-true ...)` for boolean assertions
 5. Keep tests independent — no shared mutable state between test-cases
 
-## Version 0.58.0
+## Version 0.58.1
 
-This documentation reflects q 0.58.0.
+This documentation reflects q 0.58.1.

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.58.0")
+(define version "0.58.1")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base"))

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -11,4 +11,4 @@
 
 (provide (contract-out [q-version string?]))
 
-(define q-version "0.58.0")
+(define q-version "0.58.1")

--- a/wiki-src/Architecture-Overview.md
+++ b/wiki-src/Architecture-Overview.md
@@ -35,7 +35,7 @@ User input → Interface (CLI/TUI/RPC)
     → Events emitted to bus
 ```
 
-## Metrics (0.58.0)
+## Metrics (0.58.1)
 > _See `racket scripts/metrics.rkt` for current numbers._
 
 - 414 source modules, 534 test files


### PR DESCRIPTION
## Summary
- Version bump 0.58.0 → 0.58.1
- CHANGELOG entry for v0.58.1 milestone
- All version surfaces synced

## Verification
- `racket scripts/lint-all.rkt` → 22/23 (release-readiness branch/tag check expected fail)
- Targeted regression tests → 49/49 pass
- Tag `v0.58.1` pushed

Closes #5225 (W3 release gate), #5226 (version bump), #5227 (CHANGELOG), #5228 (tag).