### PR TITLE
docs(v0.58.1): sync remaining version markers (#5228)

### DIFF
--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -2,7 +2,7 @@
 
 ## Version
 
-v0.58.0
+v0.58.1
 
 ## Layer Diagram
 

--- a/docs/event-taxonomy.md
+++ b/docs/event-taxonomy.md
@@ -1,6 +1,6 @@
 # Q Event Taxonomy Reference
 
-Complete reference for all event types in Q 0.58.0.
+Complete reference for all event types in Q 0.58.1.
 ## Base Types
 
 ### `event` (protocol-level)

--- a/docs/extension-guide.md
+++ b/docs/extension-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.58.0 --># Extension Development Guide
+<!-- verified-against: 0.58.1 --># Extension Development Guide
 
 This guide walks you through creating, testing, and activating a custom
 extension for q.

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.58.0 --># Getting Started
+<!-- verified-against: 0.58.1 --># Getting Started
 
 Welcome to q, a Racket-based coding agent.
 


### PR DESCRIPTION
## Summary
- Sync remaining documentation version markers from 0.58.0 to 0.58.1

## Verification
- Docs-only version marker sync

Closes #5228.