### PR TITLE
release: v0.58.2 (#5245)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,41 @@
 # Changelog
 
+## v0.58.2 — 2026-05-25
+
+### OAuth2 Login, OpenRouter Provider & Provider Registry
+
+Milestone adding OAuth2 browser-based login flow, OpenRouter as a first-class provider,
+and a declarative provider registry schema.
+
+**W0 — OAuth2 HTTP Callback Server**
+- `runtime/oauth-callback.rkt`: HTTP callback server with PKCE + CSRF state, ephemeral port
+- `runtime/oauth.rkt`: Real `oauth-exchange-code` and `oauth-refresh-token` using `net/http-client`
+- Base64/base64url encoding helpers for PKCE
+- 12 tests covering callback server, PKCE, token persistence, expiry
+
+**W1 — `/login` Command & Provider Selection**
+- `tui/commands/runtime-control.rkt`: `handle-login-command` with provider selection
+- Cross-platform browser launch (macOS/Linux/Windows) via `process`
+- Background thread: callback server → browser → code exchange → token storage
+- Known provider configs: openai, anthropic, google, openrouter
+- `tests/test-login-command.rkt`: 4 tests + 3 additional OAuth tests
+
+**W2 — OpenRouter Provider**
+- `llm/openrouter.rkt`: Provider wrapper delegating to OpenAI-compatible adapter
+- Static model catalog for offline selection (gpt-4o-mini, claude-3.5-sonnet, gemini-2.0-flash)
+- Provider factory dispatch for `openrouter` provider name
+- 6 tests covering construction, config, request body shape, factory dispatch
+
+**W3 — Provider Registry Schema**
+- `runtime/providers.rktd`: Machine-readable schema for 5 built-in providers
+  (openai, anthropic, gemini, azure, openrouter) with base-url, default-model,
+  auth-type, factory, and model catalogs
+- `runtime/provider-schema.rkt`: `load-builtin-providers!` populates registry from schema
+  with placeholder providers and full model metadata
+- `provider-is-placeholder?` detects unconfigured providers
+- `builtin-provider-config` retrieves provider metadata by name
+- 14 tests covering schema loading, registry population, model registration, placeholder upgrade
+
 ## v0.58.1 — 2026-05-25
 
 ### Context Pressure Signaling & `/compact` Command

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.58.1-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.58.2-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 
@@ -203,7 +203,7 @@ bin/q --model gpt-5.4 "write a test"
 ### Verify
 
 ```bash
-bin/q --version            # q version 0.58.1
+bin/q --version            # q version 0.58.2
 raco test tests/           # run the full test suite
 ```
 
@@ -454,6 +454,9 @@ When q executes shell commands on behalf of an LLM, arguments are quoted via `sh
 
 
 
+
+
+**v0.58.2** — OAuth2 Login, OpenRouter Provider & Provider Registry
 
 **v0.58.1** — Context Pressure Signaling & `/compact` Command
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -2,7 +2,7 @@
 
 ## Version
 
-v0.58.1
+v0.58.2
 
 ## Layer Diagram
 

--- a/docs/event-taxonomy.md
+++ b/docs/event-taxonomy.md
@@ -1,6 +1,6 @@
 # Q Event Taxonomy Reference
 
-Complete reference for all event types in Q 0.58.1.
+Complete reference for all event types in Q 0.58.2.
 ## Base Types
 
 ### `event` (protocol-level)

--- a/docs/extension-guide.md
+++ b/docs/extension-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.58.1 --># Extension Development Guide
+<!-- verified-against: 0.58.2 --># Extension Development Guide
 
 This guide walks you through creating, testing, and activating a custom
 extension for q.

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.58.1 --># Getting Started
+<!-- verified-against: 0.58.2 --># Getting Started
 
 Welcome to q, a Racket-based coding agent.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.58.1 --># Installation Guide
+<!-- verified-against: 0.58.2 --># Installation Guide
 
 <!-- This file is the canonical source. The docs/getting-started/installation.md copy is maintained for the doc site build. -->
 

--- a/docs/reports/v0.57.0-metric-baseline.md
+++ b/docs/reports/v0.57.0-metric-baseline.md
@@ -1,7 +1,7 @@
-# v0.58.1 Metric Baseline — Measurement + Characterization Truth
+# v0.58.2 Metric Baseline — Measurement + Characterization Truth
 
 **Date**: 2026-05-24
-**Milestone**: v0.58.1 (#495)
+**Milestone**: v0.58.2 (#495)
 **Status**: Complete
 
 ## Baseline Metrics
@@ -42,29 +42,29 @@
 
 ## Key Findings (documented for remediation)
 
-### v0.58.1 — GSD Session Isolation
+### v0.58.2 — GSD Session Isolation
 - `gsd-default-ctx` is module-level global singleton in `session-state.rkt`
 - `state-machine.rkt` directly accesses `gsd-default-ctx` at 6 call sites
 - `current-gsd-*` / `set-gsd-*` API all operate on shared global
 - Independent `make-gsd-context` instances ARE properly isolated (API supports it)
 - Production code doesn't use the per-session API
 
-### v0.58.1 — Runtime Boundaries + Resilience
+### v0.58.2 — Runtime Boundaries + Resilience
 - **BUG**: Structured 5xx provider-errors (category `'server`) are NOT retryable
   - `retryable-error?` checks for `'server-error` but `classify-http-status` returns `'server`
   - String-based 5xx IS retryable via fallback — inconsistent behavior
   - Fix: change `'server-error` → `'server` in memq list
 
-### v0.58.1 — TUI Hotspot Decomposition
+### v0.58.2 — TUI Hotspot Decomposition
 - **BUG**: `handle-user-submit!` contract lies — claims `(-> tui-ctx? string? tui-ctx?)` but returns thread
   - Contract throws `exn:fail:contract?` on every call
   - Prevents testing the function
   - Fix: change to `(-> tui-ctx? string? void?)` or `(-> tui-ctx? string? thread?)`
 - Top TUI hotspots: keybindings (24687), render-loop (17670), commands (16031)
 
-### v0.58.1 — Contract Precision
+### v0.58.2 — Contract Precision
 - 882 `any/c` across 148 files
-- v0.58.1 will target top-5 offenders for typed boundary pilot
+- v0.58.2 will target top-5 offenders for typed boundary pilot
 
 ## Waves Completed
 - W0 (#5106): Recursive arch boundary baseline — PR #5112

--- a/docs/reports/v0.57.6-audit-remediation-baseline.md
+++ b/docs/reports/v0.57.6-audit-remediation-baseline.md
@@ -5,7 +5,7 @@
 **Issue:** #5172  
 **Branch:** `feature/v0576-w0-baseline`  
 **Baseline commit:** `c0963c42`  
-**Baseline version:** `q version 0.58.1`
+**Baseline version:** `q version 0.58.2`
 
 ## Purpose
 
@@ -29,7 +29,7 @@ racket scripts/lint-all.rkt
 
 | Metric | Value |
 |---|---:|
-| Version | 0.58.1 |
+| Version | 0.58.2 |
 | Exact `any/c` in contract-out | 812 |
 | Files with `any/c` | 143 |
 | Source files scanned by contract metrics | 363 |
@@ -39,7 +39,7 @@ racket scripts/lint-all.rkt
 | Gate | Exit | Result |
 |---|---:|---|
 | `raco make main.rkt` | 0 | PASS |
-| `racket main.rkt --version` | 0 | `q version 0.58.1` |
+| `racket main.rkt --version` | 0 | `q version 0.58.2` |
 | `racket scripts/run-tests.rkt --suite fast` | 4 | FAIL: 12 failing files + strict sentinel false positives |
 | `racket scripts/run-tests.rkt --suite tui` | 4 | FAIL: actual tests pass, strict sentinel flags helpers |
 | `racket scripts/run-tests.rkt --suite arch` | 4 | FAIL: actual tests pass, strict sentinel flags helpers/workflow file |
@@ -82,8 +82,8 @@ This maps to W2.
 
 `racket scripts/lint-all.rkt` failed release-readiness:
 
-- tag `v0.58.1` does not exist yet — PASS in current pre-release semantics
-- `CHANGELOG missing entry for 0.58.1` — false negative because changelog uses `## v0.58.1`
+- tag `v0.58.2` does not exist yet — PASS in current pre-release semantics
+- `CHANGELOG missing entry for 0.58.2` — false negative because changelog uses `## v0.58.2`
 - `git has 1 uncommitted change(s)` — caused by lint/metrics mutating `README.md`
 - branch check failed because W0 ran on feature branch, expected during wave work
 

--- a/docs/security-trust-model.md
+++ b/docs/security-trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.58.1 --># Security & Trust Model
+<!-- verified-against: 0.58.2 --># Security & Trust Model
 
 This document provides an honest, per-area assessment of what q enforces
 today and what is planned. It is the authoritative reference for security

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -130,6 +130,6 @@ is the primary self-hosting extension:
 (load-extension! ext-reg "path/to/extension.rkt" #:event-bus bus)
 ```
 
-## Version 0.58.1
+## Version 0.58.2
 
-This documentation reflects q 0.58.1.
+This documentation reflects q 0.58.2.

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.58.1 --># q Source Style Guide
+<!-- verified-against: 0.58.2 --># q Source Style Guide
 
 This document defines formatting and naming conventions for the q Racket codebase.
 All changes to `q/` source files (excluding `tests/`) should follow these rules.

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.58.1 --># Trust Model
+<!-- verified-against: 0.58.2 --># Trust Model
 
 ## Trust Levels
 

--- a/docs/workflow-testing.md
+++ b/docs/workflow-testing.md
@@ -121,6 +121,6 @@ Use relative paths from the test file:
 4. Use `(check-true ...)` for boolean assertions
 5. Keep tests independent — no shared mutable state between test-cases
 
-## Version 0.58.1
+## Version 0.58.2
 
-This documentation reflects q 0.58.1.
+This documentation reflects q 0.58.2.

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.58.1")
+(define version "0.58.2")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base"))

--- a/runtime/oauth-callback.rkt
+++ b/runtime/oauth-callback.rkt
@@ -86,10 +86,9 @@
      (define code (extract-callback-code line expected-state))
      (cond
        [code
-        (fprintf out
-                 "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\n"
-                 "<html><body><h2>Authorization successful!</h2>"
-                 "<p>You can close this tab.</p></body></html>")
+        (display "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\n" out)
+        (display "<html><body><h2>Authorization successful!</h2>" out)
+        (display "<p>You can close this tab.</p></body></html>" out)
         (channel-put result-chan code)]
        [else
         (fprintf out "HTTP/1.1 400 Bad Request\r\nContent-Type: text/plain\r\n\r\nOAuth error")

--- a/runtime/provider-registry.rkt
+++ b/runtime/provider-registry.rkt
@@ -14,6 +14,7 @@
          racket/match
          racket/list
          racket/string
+         racket/runtime-path
          "../llm/provider.rkt"
          "../llm/model.rkt")
 

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -11,4 +11,4 @@
 
 (provide (contract-out [q-version string?]))
 
-(define q-version "0.58.1")
+(define q-version "0.58.2")

--- a/wiki-src/Architecture-Overview.md
+++ b/wiki-src/Architecture-Overview.md
@@ -35,7 +35,7 @@ User input → Interface (CLI/TUI/RPC)
     → Events emitted to bus
 ```
 
-## Metrics (0.58.1)
+## Metrics (0.58.2)
 > _See `racket scripts/metrics.rkt` for current numbers._
 
 - 414 source modules, 534 test files


### PR DESCRIPTION
## Summary
Version bump 0.58.1 → 0.58.2 with CHANGELOG and docs sync.

## v0.58.2 Changes
- W0: OAuth2 HTTP callback server with PKCE + token exchange
- W1: `/login` command with provider selection and auth persistence
- W2: OpenRouter provider wrapping OpenAI-compatible adapter
- W3: Provider registry schema and dynamic loading (providers.rktd)

Closes #5245, #5246, #5247, #5248.