### PR TITLE
release: v0.58.3 (#5261)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## v0.58.3 — 2026-05-25
+
+### Rich TUI Extension Widgets
+
+Milestone enabling extensions to inject rich, interactive UI components
+into the TUI with thread-safe registries, widget lifecycle, and layout regions.
+
+**W0 — Thread-safe Registries + Below-transcript Slot**
+- `extensions/custom-renderer-registry.rkt`: Added semaphore for thread-safe mutations
+  (register/unregister/lookup wrapped in `call-with-semaphore`)
+- `tui/state-ui.rkt`: `get-widget-lines-below` returns actual widget lines (was stub returning `'()`)
+- `widget-bar-height` parameter (default 3) for configurable below-transcript slot
+- 5 new tests: 2 thread-safety, 3 below-transcript rendering
+
+**W1 — Widget Lifecycle Protocol**
+- `extensions/widget-lifecycle.rkt`: Full lifecycle protocol with mount/render/input/unmount
+- `widget-lifecycle` struct with idempotent mount/unmount callbacks
+- Thread-safe registry: register/unregister/lookup/list lifecycle widgets
+- Focus management: `focusable-lifecycle-widgets`, `cycle-lifecycle-focus`
+- Input routing: `route-lifecycle-input` delivers key events to focused widget
+- `widget->component` conversion for integration with q-component system
+- 18 tests covering lifecycle, registry, focus, and input routing
+
+**W2 — Layout Regions Integration**
+- `tui/layout.rkt`: 5-region layout computation (header, transcript, widget-bar, input, overlay)
+- Height allocation: fixed header (1), fixed input (3), configurable widget-bar, flexible transcript
+- `clip-to-region` for truncating/padding lines to region height
+- 13 tests covering layout computation, edge cases, and stacking
+
 ## v0.58.2 — 2026-05-25
 
 ### OAuth2 Login, OpenRouter Provider & Provider Registry

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.58.2-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.58.3-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 
@@ -203,7 +203,7 @@ bin/q --model gpt-5.4 "write a test"
 ### Verify
 
 ```bash
-bin/q --version            # q version 0.58.2
+bin/q --version            # q version 0.58.3
 raco test tests/           # run the full test suite
 ```
 
@@ -455,6 +455,9 @@ When q executes shell commands on behalf of an LLM, arguments are quoted via `sh
 
 
 
+
+
+**v0.58.3** — Rich TUI Extension Widgets
 
 **v0.58.2** — OAuth2 Login, OpenRouter Provider & Provider Registry
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -2,7 +2,7 @@
 
 ## Version
 
-v0.58.2
+v0.58.3
 
 ## Layer Diagram
 

--- a/docs/event-taxonomy.md
+++ b/docs/event-taxonomy.md
@@ -1,6 +1,6 @@
 # Q Event Taxonomy Reference
 
-Complete reference for all event types in Q 0.58.2.
+Complete reference for all event types in Q 0.58.3.
 ## Base Types
 
 ### `event` (protocol-level)

--- a/docs/extension-guide.md
+++ b/docs/extension-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.58.2 --># Extension Development Guide
+<!-- verified-against: 0.58.3 --># Extension Development Guide
 
 This guide walks you through creating, testing, and activating a custom
 extension for q.

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.58.2 --># Getting Started
+<!-- verified-against: 0.58.3 --># Getting Started
 
 Welcome to q, a Racket-based coding agent.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.58.2 --># Installation Guide
+<!-- verified-against: 0.58.3 --># Installation Guide
 
 <!-- This file is the canonical source. The docs/getting-started/installation.md copy is maintained for the doc site build. -->
 

--- a/docs/reports/v0.57.0-metric-baseline.md
+++ b/docs/reports/v0.57.0-metric-baseline.md
@@ -1,7 +1,7 @@
-# v0.58.2 Metric Baseline — Measurement + Characterization Truth
+# v0.58.3 Metric Baseline — Measurement + Characterization Truth
 
 **Date**: 2026-05-24
-**Milestone**: v0.58.2 (#495)
+**Milestone**: v0.58.3 (#495)
 **Status**: Complete
 
 ## Baseline Metrics
@@ -42,29 +42,29 @@
 
 ## Key Findings (documented for remediation)
 
-### v0.58.2 — GSD Session Isolation
+### v0.58.3 — GSD Session Isolation
 - `gsd-default-ctx` is module-level global singleton in `session-state.rkt`
 - `state-machine.rkt` directly accesses `gsd-default-ctx` at 6 call sites
 - `current-gsd-*` / `set-gsd-*` API all operate on shared global
 - Independent `make-gsd-context` instances ARE properly isolated (API supports it)
 - Production code doesn't use the per-session API
 
-### v0.58.2 — Runtime Boundaries + Resilience
+### v0.58.3 — Runtime Boundaries + Resilience
 - **BUG**: Structured 5xx provider-errors (category `'server`) are NOT retryable
   - `retryable-error?` checks for `'server-error` but `classify-http-status` returns `'server`
   - String-based 5xx IS retryable via fallback — inconsistent behavior
   - Fix: change `'server-error` → `'server` in memq list
 
-### v0.58.2 — TUI Hotspot Decomposition
+### v0.58.3 — TUI Hotspot Decomposition
 - **BUG**: `handle-user-submit!` contract lies — claims `(-> tui-ctx? string? tui-ctx?)` but returns thread
   - Contract throws `exn:fail:contract?` on every call
   - Prevents testing the function
   - Fix: change to `(-> tui-ctx? string? void?)` or `(-> tui-ctx? string? thread?)`
 - Top TUI hotspots: keybindings (24687), render-loop (17670), commands (16031)
 
-### v0.58.2 — Contract Precision
+### v0.58.3 — Contract Precision
 - 882 `any/c` across 148 files
-- v0.58.2 will target top-5 offenders for typed boundary pilot
+- v0.58.3 will target top-5 offenders for typed boundary pilot
 
 ## Waves Completed
 - W0 (#5106): Recursive arch boundary baseline — PR #5112

--- a/docs/reports/v0.57.6-audit-remediation-baseline.md
+++ b/docs/reports/v0.57.6-audit-remediation-baseline.md
@@ -5,7 +5,7 @@
 **Issue:** #5172  
 **Branch:** `feature/v0576-w0-baseline`  
 **Baseline commit:** `c0963c42`  
-**Baseline version:** `q version 0.58.2`
+**Baseline version:** `q version 0.58.3`
 
 ## Purpose
 
@@ -29,7 +29,7 @@ racket scripts/lint-all.rkt
 
 | Metric | Value |
 |---|---:|
-| Version | 0.58.2 |
+| Version | 0.58.3 |
 | Exact `any/c` in contract-out | 812 |
 | Files with `any/c` | 143 |
 | Source files scanned by contract metrics | 363 |
@@ -39,7 +39,7 @@ racket scripts/lint-all.rkt
 | Gate | Exit | Result |
 |---|---:|---|
 | `raco make main.rkt` | 0 | PASS |
-| `racket main.rkt --version` | 0 | `q version 0.58.2` |
+| `racket main.rkt --version` | 0 | `q version 0.58.3` |
 | `racket scripts/run-tests.rkt --suite fast` | 4 | FAIL: 12 failing files + strict sentinel false positives |
 | `racket scripts/run-tests.rkt --suite tui` | 4 | FAIL: actual tests pass, strict sentinel flags helpers |
 | `racket scripts/run-tests.rkt --suite arch` | 4 | FAIL: actual tests pass, strict sentinel flags helpers/workflow file |
@@ -82,8 +82,8 @@ This maps to W2.
 
 `racket scripts/lint-all.rkt` failed release-readiness:
 
-- tag `v0.58.2` does not exist yet — PASS in current pre-release semantics
-- `CHANGELOG missing entry for 0.58.2` — false negative because changelog uses `## v0.58.2`
+- tag `v0.58.3` does not exist yet — PASS in current pre-release semantics
+- `CHANGELOG missing entry for 0.58.3` — false negative because changelog uses `## v0.58.3`
 - `git has 1 uncommitted change(s)` — caused by lint/metrics mutating `README.md`
 - branch check failed because W0 ran on feature branch, expected during wave work
 

--- a/docs/security-trust-model.md
+++ b/docs/security-trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.58.2 --># Security & Trust Model
+<!-- verified-against: 0.58.3 --># Security & Trust Model
 
 This document provides an honest, per-area assessment of what q enforces
 today and what is planned. It is the authoritative reference for security

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -130,6 +130,6 @@ is the primary self-hosting extension:
 (load-extension! ext-reg "path/to/extension.rkt" #:event-bus bus)
 ```
 
-## Version 0.58.2
+## Version 0.58.3
 
-This documentation reflects q 0.58.2.
+This documentation reflects q 0.58.3.

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.58.2 --># q Source Style Guide
+<!-- verified-against: 0.58.3 --># q Source Style Guide
 
 This document defines formatting and naming conventions for the q Racket codebase.
 All changes to `q/` source files (excluding `tests/`) should follow these rules.

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.58.2 --># Trust Model
+<!-- verified-against: 0.58.3 --># Trust Model
 
 ## Trust Levels
 

--- a/docs/workflow-testing.md
+++ b/docs/workflow-testing.md
@@ -121,6 +121,6 @@ Use relative paths from the test file:
 4. Use `(check-true ...)` for boolean assertions
 5. Keep tests independent — no shared mutable state between test-cases
 
-## Version 0.58.2
+## Version 0.58.3
 
-This documentation reflects q 0.58.2.
+This documentation reflects q 0.58.3.

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.58.2")
+(define version "0.58.3")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base"))

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -11,4 +11,4 @@
 
 (provide (contract-out [q-version string?]))
 
-(define q-version "0.58.2")
+(define q-version "0.58.3")

--- a/wiki-src/Architecture-Overview.md
+++ b/wiki-src/Architecture-Overview.md
@@ -35,7 +35,7 @@ User input → Interface (CLI/TUI/RPC)
     → Events emitted to bus
 ```
 
-## Metrics (0.58.2)
+## Metrics (0.58.3)
 > _See `racket scripts/metrics.rkt` for current numbers._
 
 - 414 source modules, 534 test files


### PR DESCRIPTION
## Summary
Version bump 0.58.2 → 0.58.3 with CHANGELOG and docs sync.

## v0.58.3 Changes
- W0: Thread-safe renderer registry + below-transcript widget rendering
- W1: Widget lifecycle protocol with mount/unmount/focus management
- W2: 5-region TUI layout computation

Closes #5261, #5262, #5263, #5264.