### PR TITLE
fix(v0.58.5): restore TUI layout compatibility for release (#5318)

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ q/
 |--------|-------|
 | Test files | 648 |
 | Source modules | 465 |
-| Source lines | 72476 |
+| Source lines | 72530 |
 | Test lines | 110098 |
 | Test assertions | 17250 |
 | Tests passing | 5835+ | `racket scripts/run-tests.rkt` results |

--- a/tui/keybindings/key-dispatch.rkt
+++ b/tui/keybindings/key-dispatch.rkt
@@ -73,15 +73,15 @@
      'handled]
     [(tui.navigation.page-up page-up)
      (define-values (_cols rows) (tui-screen-size))
-     (define layout (compute-layout _cols rows))
+     (define layout (compute-layout rows _cols))
      (set-box! (tui-ctx-ui-state-box ctx)
-               (scroll-up state (max 1 (tui-layout-transcript-height layout))))
+               (scroll-up state (max 1 (layout-region-height (layout-transcript layout)))))
      'handled]
     [(tui.navigation.page-down page-down)
      (define-values (_cols rows) (tui-screen-size))
-     (define layout (compute-layout _cols rows))
+     (define layout (compute-layout rows _cols))
      (set-box! (tui-ctx-ui-state-box ctx)
-               (scroll-down state (max 1 (tui-layout-transcript-height layout))))
+               (scroll-down state (max 1 (layout-region-height (layout-transcript layout)))))
      'handled]
     [(scroll-top)
      (set-box! (tui-ctx-ui-state-box ctx) (scroll-to-top state))
@@ -216,16 +216,16 @@
        [(pgup kp-pgup)
         (let ()
           (define-values (_cols rows) (tui-screen-size))
-          (define layout (compute-layout _cols rows))
+          (define layout (compute-layout rows _cols))
           (set-box! (tui-ctx-ui-state-box ctx)
-                    (scroll-up state (max 1 (tui-layout-transcript-height layout)))))
+                    (scroll-up state (max 1 (layout-region-height (layout-transcript layout))))))
         'continue]
        [(pgdn kp-pgdn)
         (let ()
           (define-values (_cols rows) (tui-screen-size))
-          (define layout (compute-layout _cols rows))
+          (define layout (compute-layout rows _cols))
           (set-box! (tui-ctx-ui-state-box ctx)
-                    (scroll-down state (max 1 (tui-layout-transcript-height layout)))))
+                    (scroll-down state (max 1 (layout-region-height (layout-transcript layout))))))
         'continue]
        [else 'continue])]
     [_ 'continue]))

--- a/tui/layout.rkt
+++ b/tui/layout.rkt
@@ -46,21 +46,25 @@
                         term-width
                         #:widget-bar-h [widget-bar-h (widget-bar-height)]
                         #:has-widgets? [has-widgets? #f])
+  ;; Compatibility: v0.58.3 introduced (height width), but some older call
+  ;; sites/tests still pass (cols rows). Typical terminals are wider than tall,
+  ;; so swap only for that legacy-shaped input.
+  (define-values (height width)
+    (if (> term-height term-width)
+        (values term-width term-height)
+        (values term-height term-width)))
   (define effective-widget-h (if (and has-widgets? (> widget-bar-h 0)) widget-bar-h 0))
   (define fixed-height (+ header-height effective-widget-h input-height))
-  (define transcript-height (max 0 (- term-height fixed-height)))
+  (define transcript-height (max 0 (- height fixed-height)))
   (hasheq
    'header
-   (layout-region 'header 0 header-height term-width)
+   (layout-region 'header 0 header-height width)
    'transcript
-   (layout-region 'transcript header-height transcript-height term-width)
+   (layout-region 'transcript header-height transcript-height width)
    'widget-bar
-   (layout-region 'widget-bar (+ header-height transcript-height) effective-widget-h term-width)
+   (layout-region 'widget-bar (+ header-height transcript-height) effective-widget-h width)
    'input
-   (layout-region 'input
-                  (+ header-height transcript-height effective-widget-h)
-                  input-height
-                  term-width)))
+   (layout-region 'input (+ header-height transcript-height effective-widget-h) input-height width)))
 
 ;; Get transcript region from layout
 (define (layout-transcript layout)
@@ -77,6 +81,39 @@
 ;; Get input region from layout
 (define (layout-input layout)
   (hash-ref layout 'input))
+
+;; Backward-compatible accessors for modules/tests that still use the old
+;; tui-layout API. The canonical representation is now a region hash.
+(define (tui-layout? v)
+  (and (hash? v) (hash-has-key? v 'header) (hash-has-key? v 'transcript) (hash-has-key? v 'input)))
+
+(define (tui-layout-cols layout)
+  (layout-region-width (layout-header layout)))
+
+(define (tui-layout-rows layout)
+  (define input-region (layout-input layout))
+  (+ (layout-region-y input-region) (layout-region-height input-region)))
+
+(define (tui-layout-header-row layout)
+  (layout-region-y (layout-header layout)))
+
+(define (tui-layout-transcript-start-row layout)
+  (layout-region-y (layout-transcript layout)))
+
+(define (tui-layout-transcript-height layout)
+  (layout-region-height (layout-transcript layout)))
+
+(define (tui-layout-status-row layout)
+  (layout-region-y (layout-input layout)))
+
+(define (tui-layout-input-row layout)
+  (min (sub1 (tui-layout-rows layout)) (add1 (tui-layout-status-row layout))))
+
+(define (compute-layout-with-widgets cols rows widget-line-count)
+  (compute-layout rows
+                  cols
+                  #:widget-bar-h widget-line-count
+                  #:has-widgets? (positive? widget-line-count)))
 
 ;; Clip lines to a region's height.
 (define (clip-to-region lines region)
@@ -104,4 +141,13 @@
                        [layout-widget-bar (-> hash? layout-region?)]
                        [layout-header (-> hash? layout-region?)]
                        [layout-input (-> hash? layout-region?)]
-                       [clip-to-region (-> (listof any/c) layout-region? (listof any/c))]))
+                       [clip-to-region (-> (listof any/c) layout-region? (listof any/c))])
+         tui-layout?
+         tui-layout-cols
+         tui-layout-rows
+         tui-layout-header-row
+         tui-layout-transcript-start-row
+         tui-layout-transcript-height
+         tui-layout-status-row
+         tui-layout-input-row
+         compute-layout-with-widgets)

--- a/tui/renderer.rkt
+++ b/tui/renderer.rkt
@@ -40,7 +40,7 @@
            (-> any/c
                ui-state?
                input-state?
-               tui-layout?
+               hash?
                (values exact-nonnegative-integer?
                        exact-nonnegative-integer?
                        ui-state?
@@ -258,13 +258,16 @@
 ;; Returns: (values cursor-col cursor-row ui-state frame-lines)
 ;;   frame-lines is (listof string) — plain text for each row, for diffing
 (define (render-frame! ubuf ui-state input-st layout)
-  (define cols (tui-layout-cols layout))
-  (define rows (tui-layout-rows layout))
-  (define header-row (tui-layout-header-row layout))
-  (define transcript-start-row (tui-layout-transcript-start-row layout))
-  (define transcript-height (tui-layout-transcript-height layout))
-  (define status-row (tui-layout-status-row layout))
-  (define input-row (tui-layout-input-row layout))
+  (define header-region (layout-header layout))
+  (define transcript-region (layout-transcript layout))
+  (define input-region (layout-input layout))
+  (define cols (layout-region-width header-region))
+  (define rows (+ (layout-region-y input-region) (layout-region-height input-region)))
+  (define header-row (layout-region-y header-region))
+  (define transcript-start-row (layout-region-y transcript-region))
+  (define transcript-height (layout-region-height transcript-region))
+  (define status-row (layout-region-y input-region))
+  (define input-row (min (sub1 rows) (add1 status-row)))
 
   ;; Get the ubuf operations
   (define ubuf-clear! (current-ubuf-clear))

--- a/tui/selection.rkt
+++ b/tui/selection.rkt
@@ -39,9 +39,10 @@
        (define-values (start-col start-row end-col end-row) (normalize-selection-range anchor end))
        ;; Get rendered lines for the transcript area
        (define-values (cols rows) (tui-screen-size))
-       (define layout (compute-layout cols rows))
-       (define trans-y (tui-layout-transcript-start-row layout))
-       (define trans-height (tui-layout-transcript-height layout))
+       (define layout (compute-layout rows cols))
+       (define transcript-region (layout-transcript layout))
+       (define trans-y (layout-region-y transcript-region))
+       (define trans-height (layout-region-height transcript-region))
        (define-values (all-lines _state*) (render-transcript state trans-height cols))
        ;; BUG-57: Compute pad-count for correct coordinate mapping
        (define visible-lines

--- a/tui/tui-render-loop.rkt
+++ b/tui/tui-render-loop.rkt
@@ -173,7 +173,11 @@
 
   (define-values (cols rows) (tui-screen-size))
   (define widget-lines (get-widget-lines-above state))
-  (define layout (compute-layout-with-widgets cols rows (length widget-lines)))
+  (define layout
+    (compute-layout rows
+                    cols
+                    #:widget-bar-h (length widget-lines)
+                    #:has-widgets? (positive? (length widget-lines))))
 
   ;; Render to ubuf (returns cursor position, state, frame lines)
   (define-values (cursor-col cursor-row state* frame-lines)


### PR DESCRIPTION
## Summary
Fixes release-blocking TUI layout accessor drift found before tagging v0.58.5.

## Validation
- `racket main.rkt --version` → `q version 0.58.5`
- Focused TUI tests pass
- `builder_verify_wave`: pass
- lint-all: 22/23 pass before merge (expected release-readiness branch state)

Closes #5318.