### PR TITLE
docs(v0.59.6 W0): reproduce and freeze red-gate failures (#5456)

### DIFF
--- a/docs/reports/v0.59.6-w0-baseline-reproduction.md
+++ b/docs/reports/v0.59.6-w0-baseline-reproduction.md
@@ -1,0 +1,22 @@
+# v0.59.6 W0 — Baseline Reproduction Report
+
+**Date**: 2026-05-26
+**Issue**: #5456
+**Baseline**: v0.59.5
+
+## Failing Tests (6 files)
+
+| File | Tests | Status |
+|---|---|---|
+| test-run-tests.rkt | 3 failures | parse-args arity drift (7→8 values) |
+| test-arch-fitness.rkt | 1 failure | widget-lifecycle imports from tui/ |
+| tui/input.rkt | 1 failure | pre-existing /q parse |
+| test-widget-api.rkt | 3 failures | layout clamping returns 0 not 1 |
+| interfaces/tui.rkt | hang | pre-existing compilation hang |
+| test-provider-registry-schema.rkt | passes | no current failure |
+
+## Lint-all: 20/23 pass (tests lint, release-readiness on branch)
+
+## any/c: 680 (target ≤597)
+
+## Historical reports: v0.57.0 header says "v0.59.5"


### PR DESCRIPTION
Addresses #5456.

docs(v0.59.6 W0): reproduce and freeze red-gate failures (#5456)