### PR TITLE
fix(v0.59.6 W1): update parse-args tests for 8-value return (#5457)

### DIFF
--- a/tests/test-run-tests.rkt
+++ b/tests/test-run-tests.rkt
@@ -418,20 +418,39 @@
 
 (test-case "parse-args: --repeat N sets repeat count"
   (define parse (runner-ref 'parse-args))
-  (define-values (jobs seq? timeout strict? suite extra repeat) (parse '("--repeat" "3")))
-  (check-equal? repeat 3))
+  (define-values (jobs seq? timeout strict? suite extra repeat record-gate?)
+    (parse '("--repeat" "3")))
+  (check-equal? repeat 3)
+  (check-false record-gate?))
 
 (test-case "parse-args: --repeat defaults to 1"
   (define parse (runner-ref 'parse-args))
-  (define-values (jobs seq? timeout strict? suite extra repeat) (parse '()))
-  (check-equal? repeat 1))
+  (define-values (jobs seq? timeout strict? suite extra repeat record-gate?) (parse '()))
+  (check-equal? repeat 1)
+  (check-false record-gate?))
 
 (test-case "parse-args: --repeat with --suite smoke"
   (define parse (runner-ref 'parse-args))
-  (define-values (jobs seq? timeout strict? suite extra repeat)
+  (define-values (jobs seq? timeout strict? suite extra repeat record-gate?)
     (parse '("--suite" "smoke" "--repeat" "2")))
   (check-equal? suite 'smoke)
-  (check-equal? repeat 2))
+  (check-equal? repeat 2)
+  (check-false record-gate?))
+
+;; ---------------------------------------------------------------------------
+;; W1: --record-gate-evidence flag
+;; ---------------------------------------------------------------------------
+
+(test-case "parse-args: --record-gate-evidence sets flag"
+  (define parse (runner-ref 'parse-args))
+  (define-values (jobs seq? timeout strict? suite extra repeat record-gate?)
+    (parse '("--record-gate-evidence")))
+  (check-true record-gate?))
+
+(test-case "parse-args: record-gate defaults to #f"
+  (define parse (runner-ref 'parse-args))
+  (define-values (jobs seq? timeout strict? suite extra repeat record-gate?) (parse '()))
+  (check-false record-gate?))
 
 ;; ---- end of file ----
 


### PR DESCRIPTION
Addresses #5457.

fix(v0.59.6 W1): update parse-args tests for 8-value return (#5457)