### PR TITLE
fix(v0.59.6 W3): restore historical reports and fix hash-keys lint (#5459)

### DIFF
--- a/docs/reports/v0.57.0-metric-baseline.md
+++ b/docs/reports/v0.57.0-metric-baseline.md
@@ -1,7 +1,7 @@
-# v0.59.5 Metric Baseline — Measurement + Characterization Truth
+# v0.57.0 Metric Baseline
 
-**Date**: 2026-05-24
-**Milestone**: v0.59.5 (#495)
+**Date**: 2026-05-20
+**Milestone**: v0.57.0 (#455)
 **Status**: Complete
 
 ## Baseline Metrics
@@ -42,29 +42,29 @@
 
 ## Key Findings (documented for remediation)
 
-### v0.59.5 — GSD Session Isolation
+### v0.57.0 — GSD Session Isolation
 - `gsd-default-ctx` is module-level global singleton in `session-state.rkt`
 - `state-machine.rkt` directly accesses `gsd-default-ctx` at 6 call sites
 - `current-gsd-*` / `set-gsd-*` API all operate on shared global
 - Independent `make-gsd-context` instances ARE properly isolated (API supports it)
 - Production code doesn't use the per-session API
 
-### v0.59.5 — Runtime Boundaries + Resilience
+### v0.57.0 — Runtime Boundaries + Resilience
 - **BUG**: Structured 5xx provider-errors (category `'server`) are NOT retryable
   - `retryable-error?` checks for `'server-error` but `classify-http-status` returns `'server`
   - String-based 5xx IS retryable via fallback — inconsistent behavior
   - Fix: change `'server-error` → `'server` in memq list
 
-### v0.59.5 — TUI Hotspot Decomposition
+### v0.57.0 — TUI Hotspot Decomposition
 - **BUG**: `handle-user-submit!` contract lies — claims `(-> tui-ctx? string? tui-ctx?)` but returns thread
   - Contract throws `exn:fail:contract?` on every call
   - Prevents testing the function
   - Fix: change to `(-> tui-ctx? string? void?)` or `(-> tui-ctx? string? thread?)`
 - Top TUI hotspots: keybindings (24687), render-loop (17670), commands (16031)
 
-### v0.59.5 — Contract Precision
+### v0.57.0 — Contract Precision
 - 882 `any/c` across 148 files
-- v0.59.5 will target top-5 offenders for typed boundary pilot
+- v0.57.0 will target top-5 offenders for typed boundary pilot
 
 ## Waves Completed
 - W0 (#5106): Recursive arch boundary baseline — PR #5112

--- a/docs/reports/v0.57.6-audit-remediation-baseline.md
+++ b/docs/reports/v0.57.6-audit-remediation-baseline.md
@@ -1,11 +1,11 @@
-# Corrective Audit Remediation Baseline
+# v0.57.6 Audit Remediation Baseline
 
 **Date:** 2026-05-25  
 **Wave:** W0 — Reproduce, classify, and freeze baseline  
 **Issue:** #5172  
 **Branch:** `feature/v0576-w0-baseline`  
 **Baseline commit:** `c0963c42`  
-**Baseline version:** `q version 0.59.5`
+**Baseline version:** `q version 0.57.6`
 
 ## Purpose
 
@@ -82,8 +82,8 @@ This maps to W2.
 
 `racket scripts/lint-all.rkt` failed release-readiness:
 
-- tag `v0.59.5` does not exist yet — PASS in current pre-release semantics
-- `CHANGELOG missing entry for 0.59.5` — false negative because changelog uses `## v0.59.5`
+- tag `v0.57.6` does not exist yet — PASS in current pre-release semantics
+- `CHANGELOG missing entry for 0.57.6` — false negative because changelog uses `## v0.57.6`
 - `git has 1 uncommitted change(s)` — caused by lint/metrics mutating `README.md`
 - branch check failed because W0 ran on feature branch, expected during wave work
 

--- a/tests/test-registry-snapshot.rkt
+++ b/tests/test-registry-snapshot.rkt
@@ -26,16 +26,18 @@
       (define reg (make-tool-registry))
       (register-tool! reg (make-test-tool "foo"))
       (register-tool! reg (make-test-tool "bar"))
-      (define result (with-registry-snapshot reg (lambda (snap) (hash-keys snap))))
+      (define result (sort (with-registry-snapshot reg (lambda (snap) (hash-keys snap))) string<?))
       (check-not-false (member "foo" result))
       (check-not-false (member "bar" result)))
 
     (test-case "snapshot is isolated from mutations"
       (define reg (make-tool-registry))
       (register-tool! reg (make-test-tool "before"))
-      (define snap-tools (with-registry-snapshot reg (lambda (snap) (hash-keys snap))))
+      (define snap-tools
+        (sort (with-registry-snapshot reg (lambda (snap) (hash-keys snap))) string<?))
       (register-tool! reg (make-test-tool "after"))
-      (define snap-after (with-registry-snapshot reg (lambda (snap) (hash-keys snap))))
+      (define snap-after
+        (sort (with-registry-snapshot reg (lambda (snap) (hash-keys snap))) string<?))
       ;; First snapshot should not contain "after"
       (check-false (member "after" snap-tools))
       ;; Second snapshot should contain both


### PR DESCRIPTION
Addresses #5459.

fix(v0.59.6 W3): restore historical reports and fix hash-keys lint (#5459)