### PR TITLE
fix(v0.59.6 W4): fix lint/metrics and protect historical reports (#5460)

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,8 +276,8 @@ q/
 |--------|-------|
 | Test files | 650 |
 | Source modules | 465 |
-| Source lines | 72825 |
-| Test lines | 110832 |
+| Source lines | 72830 |
+| Test lines | 110834 |
 | Test assertions | 17367 |
 | Tests passing | 5835+ | `racket scripts/run-tests.rkt` results |
 

--- a/docs/reports/v0.59.6-w0-baseline-reproduction.md
+++ b/docs/reports/v0.59.6-w0-baseline-reproduction.md
@@ -19,4 +19,4 @@
 
 ## any/c: 680 (target ≤597)
 
-## Historical reports: v0.57.0 header says "v0.59.5"
+## Historical reports: v0.59.5 header says "v0.59.5"

--- a/scripts/lint-tests.rkt
+++ b/scripts/lint-tests.rkt
@@ -51,7 +51,11 @@
   (or (string-contains? str " ")
       (string-contains-char? str #\\)
       ;; Unicode right arrow (→)
-      (regexp-match? #rx"\u2192" str)))
+      (regexp-match? #rx"\u2192" str)
+      ;; URL paths (query strings, percent-encoded) — not filesystem
+      (regexp-match? #rx"^/[a-z]+\\?" str)
+      ;; Fixture paths used in test suites
+      (string=? str "/fixtures/")))
 
 (define (test-fixture-path? str)
   ;; Test fixtures for nonexistent or fake paths — not real dependencies

--- a/scripts/sync-version.rkt
+++ b/scripts/sync-version.rkt
@@ -115,7 +115,8 @@
       (string-contains? s "/docs/ecosystem/")
       (string-contains? s "/docs/demos/")
       (string-contains? s "/docs/adr/")
-      (string-contains? s "/docs/security.md")))
+      (string-contains? s "/docs/security.md")
+      (string-contains? s "/docs/reports/")))
 
 ;; historical-line? is now provided by version-guard.rkt
 

--- a/tests/test-command-parity.rkt
+++ b/tests/test-command-parity.rkt
@@ -12,7 +12,7 @@
          (only-in "../tui/command-parse.rkt" make-command-table))
 
 (define tui-table (make-command-table))
-(define tui-names (hash-keys tui-table))
+(define tui-names (sort (hash-keys tui-table) string<?))
 
 ;; TUI commands that should exist in the command table
 (define expected-commands
@@ -64,7 +64,7 @@
       (for ([cmd '("/help" "/quit" "/clear" "/compact" "/switch" "/model")])
         (check hash-has-key? tui-table cmd (format "Core command ~a missing from TUI table" cmd))))
     (test-case "all TUI commands are in expected list -- no stale entries"
-      (for ([cmd (in-list (hash-keys tui-table))])
+      (for ([cmd (in-list (sort (hash-keys tui-table) string<?))])
         (check member
                cmd
                expected-commands

--- a/tests/test-message-helpers.rkt
+++ b/tests/test-message-helpers.rkt
@@ -91,7 +91,7 @@
       (define msg (make-message "m2" #f 'user 'message (list (make-text-part "hi")) 1000 #f))
       (define result (message-meta-safe msg))
       (check-true (hash? result))
-      (check-equal? (hash-keys result) '()))
+      (check-equal? (sort (hash-keys result) symbol<?) '()))
 
     (test-case "message-meta-safe with hash-ref default returns value"
       (define msg (make-message "m3" #f 'user 'message (list (make-text-part "hi")) 1000 #f))


### PR DESCRIPTION
Addresses #5460.

fix(v0.59.6 W4): fix lint/metrics and protect historical reports (#5460)