### PR TITLE
docs(v0.59.9 W1): verify provider schema guardrail (#5490)

### DIFF
--- a/docs/reports/provider-schema-guardrail-verification.md
+++ b/docs/reports/provider-schema-guardrail-verification.md
@@ -1,0 +1,40 @@
+# Provider Schema Guardrail Verification
+
+**Wave:** v0.59.9 W1 — Provider schema gate repair  
+**Issue:** #5490  
+**Date:** 2026-05-26  
+**Baseline version:** 0.59.8
+
+## Result
+
+The provider schema red gate captured in the original v0.59.8 audit did **not** reproduce on the current main branch after W0.
+
+## Commands Run
+
+```bash
+cd q
+find . -type d -name compiled -prune -exec rm -rf {} +
+racket scripts/run-tests.rkt tests/test-provider-registry-schema.rkt --jobs 1 --timeout 60
+```
+
+## Evidence
+
+```text
+Files: 1 total, 1 passed, 0 failed, 0 timeouts
+Tests: 13 total, 13 passed, 0 failed
+Elapsed: 5.659s
+```
+
+## Nearby Suite Note
+
+A broad smoke run was attempted as planned, but the runner did not complete within the outer command timeout and emitted repeated timeout markers. That behavior is tracked as a broader runner/TUI-suite issue and is not a provider schema regression. The targeted provider schema gate is green.
+
+## Decision
+
+No provider schema production change is made in this wave. W1 is closed as a guardrail verification wave, preserving the existing 13 passing provider schema tests as the release gate for this cluster.
+
+Follow-up work remains in:
+
+- W2: TUI interface drag-selection failure.
+- W4: historical report and finding matrix truth repair.
+- W5: final full release gate after the remaining repairs.


### PR DESCRIPTION
## Summary
- Records W1 provider schema verification evidence
- Confirms `tests/test-provider-registry-schema.rkt` is green on current main
- Leaves production provider schema code unchanged because the original red gate no longer reproduces

## Validation
- `find . -type d -name compiled -prune -exec rm -rf {} +`
- `racket scripts/run-tests.rkt tests/test-provider-registry-schema.rkt --jobs 1 --timeout 60` — 13/13 pass
- `racket scripts/lint-version.rkt`

## Note
- Broad smoke run still exhibits timeout-marker/non-completion behavior; W1 does not classify that as a provider schema regression.