### PR TITLE
test(v0.59.9 W2): align TUI drag selection test with layout (#5491)

### DIFF
--- a/tests/interfaces/tui.rkt
+++ b/tests/interfaces/tui.rkt
@@ -1011,8 +1011,13 @@
     (define state2
       (add-transcript-entry state (make-entry 'assistant "Alpha Beta Gamma Delta" 0 (hash))))
     (set-box! (tui-ctx-ui-state-box ctx) state2)
-    ;; Content is bottom-aligned: pad-count=20, content at row 21
-    (define content-row (+ 1 (- 21 1))) ; trans-y + (trans-height - content-count)
+    ;; Content is bottom-aligned in the actual computed transcript region.
+    ;; Keep this tied to `compute-layout` instead of stale hard-coded dimensions.
+    (define-values (cols rows) (tui-screen-size))
+    (define layout (compute-layout rows cols))
+    (define transcript-region (layout-transcript layout))
+    (define content-row
+      (+ (layout-region-y transcript-region) (sub1 (layout-region-height transcript-region))))
     ;; Select first 5 chars ("Alpha") — drag to col 4 (0..4 = 5 chars)
     (handle-mouse ctx `(click 0 0 ,content-row))
     (handle-mouse ctx `(drag 4 ,content-row))


### PR DESCRIPTION
## Summary
- Fixes the red `tests/interfaces/tui.rkt` gate by removing stale hard-coded transcript geometry from the drag-selection release regression
- Derives the content row from `compute-layout`, preserving the intended assertion: release must not extend selection past the last drag endpoint

## Validation
- `racket_check format q/tests/interfaces/tui.rkt` — pass
- `racket_check syntax q/tests/interfaces/tui.rkt` — pass
- `racket scripts/run-tests.rkt tests/interfaces/tui.rkt --jobs 1 --timeout 120` — 106/106 pass
- `racket scripts/run-tests.rkt --suite tui --jobs 4 --timeout 60` — 70/70 files, 1253/1253 tests pass in 4m55s

## Note
- `builder_verify_wave` format/compile passed but its TUI test subprocess timed out; manual project runner evidence above completed successfully.