### PR TITLE
docs(v0.59.9 W3): sync README metrics truth (#5492)

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ q/
 | Test files | 653 |
 | Source modules | 465 |
 | Source lines | 72860 |
-| Test lines | 111287 |
+| Test lines | 111292 |
 | Test assertions | 17428 |
 | Tests passing | 5835+ | `racket scripts/run-tests.rkt` results |
 


### PR DESCRIPTION
## Summary
- Synchronizes README static metrics through the approved metrics/preflight path
- Updates README Test lines from 111287 to 111292 after the W2 TUI test change
- Confirms metrics-sync and metrics-lint are truthful; remaining lint-all release-readiness failure is branch-only and expected before release/main

## Validation
- `racket scripts/metrics.rkt` — reports Test lines 111292
- `racket scripts/metrics.rkt --lint` — pass, all 5 static metrics match README.md
- `racket scripts/sync-readme-status.rkt --check` — pass
- `racket scripts/sync-version.rkt --check --all` — pass
- `racket tests/test-metrics-readme-sync.rkt` — pass
- `racket scripts/lint-all.rkt` — 21 pass / 1 expected branch-only release-readiness fail / 1 non-blocking arch warning