### PR TITLE
release(v0.59.9 W5): final truth gate hotfix (#5494)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## v0.59.9 — 2026-05-26
+
+### Final Truth Gate Hotfix
+
+Restore final gate truth before security/workflow enforcement continues.
+
+**W0 — Red Gate Reproduction**
+- Published final truth gate reproduction report
+- Verified provider schema red gate no longer reproduces
+- Reproduced TUI drag-selection red gate and lint/report drift
+
+**W1 — Provider Schema Guardrail Verification**
+- Re-ran provider schema targeted checks
+- Published guardrail evidence showing no active provider schema regression
+
+**W2 — TUI Interface Red-Gate Repair**
+- Fixed stale hard-coded TUI drag-selection test geometry
+- Verified TUI interface file and full TUI suite are green
+
+**W3 — README Metrics and Lint Truth**
+- Re-synchronized README static metrics through the approved metrics path
+- Confirmed metrics-sync and metrics-lint pass truthfully
+
+**W4 — Historical Report and Finding Matrix Truth**
+- Restored v0.57.6 historical report version values
+- Corrected v0.59.x finding matrix milestone traceability
+- Added regression coverage proving docs/reports are excluded from global version sync
+
 ## v0.59.8 — 2026-05-26
 
 ### Workflow Fixture Integrity + Release Enforcement

--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ q/
 | Test files | 653 |
 | Source modules | 465 |
 | Source lines | 72860 |
-| Test lines | 111336 |
+| Test lines | 111348 |
 | Test assertions | 17431 |
 | Tests passing | 5835+ | `racket scripts/run-tests.rkt` results |
 

--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ q/
 | Test files | 653 |
 | Source modules | 465 |
 | Source lines | 72860 |
-| Test lines | 111333 |
+| Test lines | 111336 |
 | Test assertions | 17431 |
 | Tests passing | 5835+ | `racket scripts/run-tests.rkt` results |
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.59.8-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.59.9-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 
@@ -203,7 +203,7 @@ bin/q --model gpt-5.4 "write a test"
 ### Verify
 
 ```bash
-bin/q --version            # q version 0.59.8
+bin/q --version            # q version 0.59.9
 raco test tests/           # run the full test suite
 ```
 
@@ -467,6 +467,9 @@ When q executes shell commands on behalf of an LLM, arguments are quoted via `sh
 
 
 
+
+
+**v0.59.9** — Final Truth Gate Hotfix
 
 **v0.59.8** — Workflow Fixture Integrity + Release Enforcement
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -2,7 +2,7 @@
 
 ## Version
 
-v0.59.8
+v0.59.9
 
 ## Layer Diagram
 

--- a/docs/event-taxonomy.md
+++ b/docs/event-taxonomy.md
@@ -1,6 +1,6 @@
 # Q Event Taxonomy Reference
 
-Complete reference for all event types in Q 0.59.8.
+Complete reference for all event types in Q 0.59.9.
 ## Base Types
 
 ### `event` (protocol-level)

--- a/docs/extension-guide.md
+++ b/docs/extension-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.59.8 --># Extension Development Guide
+<!-- verified-against: 0.59.9 --># Extension Development Guide
 
 This guide walks you through creating, testing, and activating a custom
 extension for q.

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.59.8 --># Getting Started
+<!-- verified-against: 0.59.9 --># Getting Started
 
 Welcome to q, a Racket-based coding agent.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.59.8 --># Installation Guide
+<!-- verified-against: 0.59.9 --># Installation Guide
 
 <!-- This file is the canonical source. The docs/getting-started/installation.md copy is maintained for the doc site build. -->
 

--- a/docs/reports/final-truth-gate-release-evidence.md
+++ b/docs/reports/final-truth-gate-release-evidence.md
@@ -1,0 +1,60 @@
+# Final Truth Gate Release Evidence
+
+**Release:** v0.59.9  
+**Wave:** v0.59.9 W5 — Release gate and reviewer approval  
+**Issue:** #5494  
+**Branch:** `release/v0.59.9-final-gate`
+
+## Summary
+
+v0.59.9 restores truthful final-gate evidence after the v0.59.9 closure waves.
+The release branch is expected to fail the release-readiness `main`-branch check before merge;
+all version, changelog, metrics, and gate-evidence checks pass.
+
+## Gate Evidence
+
+| Gate | Command | Result |
+|---|---|---|
+| arch | `racket scripts/run-tests.rkt --suite arch --record-gate-evidence` | PASS — 9/9 files, 96/96 tests |
+| workflows | `racket scripts/run-tests.rkt --suite workflows --jobs 4 --timeout 90 --record-gate-evidence` | PASS — 24/24 files, 117/117 tests |
+| tui | `racket scripts/run-tests.rkt --suite tui --jobs 4 --timeout 60 --record-gate-evidence` | PASS — 70/70 files, 1253/1253 tests |
+| fast | Chunked `racket scripts/run-tests.rkt` over all 563 fast files | PASS — 563/563 files passed |
+
+## Fast Suite Note
+
+A single monolithic `--suite fast` invocation did not complete in the local harness within the
+outer shell timeout, but the same 563-file fast set was enumerated with `collect-test-files 'fast`
+and executed in chunks. All chunks passed:
+
+- chunk aa: 75/75 files, 1265 tests
+- chunk ab: 75/75 files, 992 tests
+- chunk ac: 75/75 files, 1291 tests
+- chunk ad: 75/75 files, 900 tests
+- chunk ae: 75/75 files, 979 tests
+- chunk af: 75/75 files, 1137 tests (executed as smaller subchunks after local harness timeout)
+- chunk ag: 75/75 files, 924 tests
+- chunk ah: 38/38 files, 828 tests
+
+During fast gate execution two test-harness truth issues were corrected:
+
+1. `tests/test-sync-version-historical.rkt` now resolves `scripts/sync-version.rkt` via
+   `define-runtime-path` so it passes under the project runner as well as direct `racket`.
+2. `tests/test-tool-read.rkt` now tests traversal blocking under explicit safe-mode configuration
+   with a temporary outside file, avoiding dependence on whether a parent `etc/passwd` fixture exists.
+
+## Release Readiness
+
+`racket scripts/lint-release-readiness.rkt --strict` result on the release branch:
+
+- PASS version sync: 0.59.9
+- PASS CHANGELOG entry exists
+- PASS clean working tree
+- PASS tag v0.59.9 does not exist yet
+- PASS gate evidence for fast/tui/arch/workflows
+- FAIL branch check only: expected on `release/v0.59.9-final-gate`; this check must pass after merge to `main`
+
+`racket scripts/lint-all.rkt` result on the release branch:
+
+- 21 pass
+- 1 expected release-readiness branch-only failure
+- 1 non-blocking architecture warning

--- a/docs/security-trust-model.md
+++ b/docs/security-trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.59.8 --># Security & Trust Model
+<!-- verified-against: 0.59.9 --># Security & Trust Model
 
 This document provides an honest, per-area assessment of what q enforces
 today and what is planned. It is the authoritative reference for security

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -130,6 +130,6 @@ is the primary self-hosting extension:
 (load-extension! ext-reg "path/to/extension.rkt" #:event-bus bus)
 ```
 
-## Version 0.59.8
+## Version 0.59.9
 
-This documentation reflects q 0.59.8.
+This documentation reflects q 0.59.9.

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.59.8 --># q Source Style Guide
+<!-- verified-against: 0.59.9 --># q Source Style Guide
 
 This document defines formatting and naming conventions for the q Racket codebase.
 All changes to `q/` source files (excluding `tests/`) should follow these rules.

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.59.8 --># Trust Model
+<!-- verified-against: 0.59.9 --># Trust Model
 
 ## Trust Levels
 

--- a/docs/workflow-testing.md
+++ b/docs/workflow-testing.md
@@ -121,6 +121,6 @@ Use relative paths from the test file:
 4. Use `(check-true ...)` for boolean assertions
 5. Keep tests independent — no shared mutable state between test-cases
 
-## Version 0.59.8
+## Version 0.59.9
 
-This documentation reflects q 0.59.8.
+This documentation reflects q 0.59.9.

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.59.8")
+(define version "0.59.9")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base"))

--- a/tests/test-sync-version-historical.rkt
+++ b/tests/test-sync-version-historical.rkt
@@ -10,7 +10,10 @@
 (require rackunit
          racket/file
          racket/port
+         racket/runtime-path
          (only-in "../scripts/version-guard.rkt" historical-line?))
+
+(define-runtime-path q-root "..")
 
 ;; ---------------------------------------------------------------------------
 ;; 7 positive pattern tests
@@ -57,7 +60,7 @@
 
 (test-case "sync-version --all skips docs/reports historical reports"
   (define root (make-temporary-file "sync-version-reports-~a" 'directory))
-  (define script-path (build-path (current-directory) "scripts" "sync-version.rkt"))
+  (define script-path (build-path q-root "scripts" "sync-version.rkt"))
   (dynamic-wind
    void
    (lambda ()

--- a/tests/test-tool-read.rkt
+++ b/tests/test-tool-read.rkt
@@ -5,6 +5,7 @@
 (require rackunit
          "../tools/builtins/read.rkt"
          "../tools/tool.rkt"
+         "../util/safe-mode-state.rkt"
          racket/file)
 
 ;; ============================================================
@@ -69,9 +70,20 @@
 ;; TEST-02: Additional coverage — path traversal, symlink, large file
 ;; ============================================================
 
-(test-case "tool-read: path traversal returns error"
-  (define result (tool-read (hasheq 'path "../../etc/passwd")))
-  (check-pred tool-result-is-error? result))
+(test-case "tool-read: path traversal returns error in safe mode"
+  (define project-root-dir (make-temporary-file "q-read-root-~a" 'directory))
+  (define outside-file (make-temporary-file "q-read-outside-~a.txt"))
+  (display-to-file "outside" outside-file #:exists 'replace)
+  (dynamic-wind void
+                (lambda ()
+                  (parameterize ([current-safe-mode-config (make-safe-mode-config #:active #t
+                                                                                  #:project-root
+                                                                                  project-root-dir)])
+                    (define result (tool-read (hasheq 'path outside-file)))
+                    (check-pred tool-result-is-error? result)))
+                (lambda ()
+                  (delete-file outside-file)
+                  (delete-directory/files project-root-dir))))
 
 (test-case "tool-read: symlink resolves correctly"
   (define tmp (make-temporary-file "q-test-symlink-~a.txt"))

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -11,4 +11,4 @@
 
 (provide (contract-out [q-version string?]))
 
-(define q-version "0.59.8")
+(define q-version "0.59.9")

--- a/wiki-src/Architecture-Overview.md
+++ b/wiki-src/Architecture-Overview.md
@@ -35,7 +35,7 @@ User input → Interface (CLI/TUI/RPC)
     → Events emitted to bus
 ```
 
-## Metrics (0.59.8)
+## Metrics (0.59.9)
 > _See `racket scripts/metrics.rkt` for current numbers._
 
 - 414 source modules, 534 test files


### PR DESCRIPTION
## Summary
- Bumps q to v0.59.9 and synchronizes info.rkt, README, docs, and status surfaces
- Adds CHANGELOG entry for Final Truth Gate Hotfix
- Stabilizes two gate-truth tests found during final fast-gate execution
  - `test-sync-version-historical.rkt` now resolves sync-version via runtime path under the project runner
  - `test-tool-read.rkt` now makes traversal blocking deterministic under explicit safe mode
- Records release gate evidence in `docs/reports/final-truth-gate-release-evidence.md`

## Validation
- `racket scripts/run-tests.rkt --suite arch --record-gate-evidence` — 9/9 files, 96/96 tests pass
- `racket scripts/run-tests.rkt --suite workflows --jobs 4 --timeout 90 --record-gate-evidence` — 24/24 files, 117/117 tests pass
- `racket scripts/run-tests.rkt --suite tui --jobs 4 --timeout 60 --record-gate-evidence` — 70/70 files, 1253/1253 tests pass
- Fast suite chunked over all 563 fast files — 563/563 pass; see report for chunk evidence
- `racket scripts/lint-release-readiness.rkt --strict` — all checks pass except expected branch-only main check
- `racket scripts/lint-all.rkt` — 21 pass / 1 expected branch-only release-readiness fail / 1 non-blocking arch warning
- `racket scripts/lint-version.rkt` — pass
- `racket scripts/metrics.rkt --lint` — pass

## Release note
After squash merge to `main`, run strict release readiness on main, tag `v0.59.9`, push the tag, and close milestone #518/parent #5488.