### PR TITLE
fix(v0.59.10 W1): OAuth callback nonblocking atomic lifecycle (#5497)

### DIFF
--- a/runtime/oauth-callback.rkt
+++ b/runtime/oauth-callback.rkt
@@ -76,19 +76,17 @@
                (kill-thread server-thread)))
            #t)))
 
-  ;; Serve in a background thread — one-shot: stop after first result
+  ;; Serve in a background thread — accept connections until the listener is
+  ;; closed by try-complete! (or the timeout thread).  The loop terminates
+  ;; because tcp-accept raises exn:fail after tcp-close, caught by the
+  ;; enclosing with-handlers.
   (set! server-thread
         (thread (lambda ()
                   (with-handlers ([exn:fail? (lambda (e) (void))])
                     (let loop ()
                       (define-values (in out) (tcp-accept listener))
                       (thread (lambda () (handle-connection in out state try-complete!)))
-                      ;; Check if already completed before accepting more
-                      (unless (zero? (semaphore-wait (make-semaphore 0))
-                                     ;; semaphore-wait on fresh 0-sema always blocks;
-                                     ;; we just check if completion-sema is drained
-                                     )
-                        (loop)))))))
+                      (loop))))))
 
   ;; Auto-shutdown after timeout
   (thread (lambda ()

--- a/tests/test-oauth-callback-security.rkt
+++ b/tests/test-oauth-callback-security.rkt
@@ -239,7 +239,65 @@ Host: localhost
              (close-output-port out)
              (close-input-port in))))
         (define code (get-code))
-        (check-equal? code "iter-code" "each iteration must get the correct code")))))
+        (check-equal? code "iter-code" "each iteration must get the correct code")))
+
+    ;; ============================================================
+    ;; W1: Cleanup independence + nonblocking completion (#5497)
+    ;; ============================================================
+
+    (test-case "cleanup is independent of consumer (#5497)"
+      ;; The listener must be closed BEFORE get-code is called,
+      ;; so resources are reclaimed even if the consumer delays.
+      (define-values (port state verifier get-code) (start-callback-server #:timeout 10))
+      (thread
+       (lambda ()
+         (sync (alarm-evt (+ (current-inexact-milliseconds) 200)))
+         (with-handlers ([exn:fail? (lambda (e) (void))])
+           (define-values (in out) (tcp-connect "127.0.0.1" port))
+           (fprintf out
+                    "GET /callback?code=cleanup-test&state=~a HTTP/1.1\r\nHost: localhost\r\n\r\n"
+                    state)
+           (flush-output out)
+           (close-output-port out)
+           (close-input-port in))))
+      ;; Wait for server to process callback and close listener
+      (sync (alarm-evt (+ (current-inexact-milliseconds) 800)))
+      ;; Listener should be closed — new connections must fail
+      (define probe
+        (with-handlers ([exn:fail? (lambda (e) 'connection-failed)])
+          (define-values (in out) (tcp-connect "127.0.0.1" port))
+          (close-input-port in)
+          (close-output-port out)
+          'connected))
+      (check-eq? probe 'connection-failed "listener must be closed before consumer calls get-code")
+      ;; Consumer can still get the code (delayed read from channel)
+      (define code (get-code))
+      (check-equal? code "cleanup-test" "delayed consumer must still receive code after cleanup"))
+
+    (test-case "nonblocking completion: get-code returns immediately after callback (#5497)"
+      ;; Once the callback has been processed, get-code should not block
+      ;; — the result is already on the channel.
+      (define-values (port state verifier get-code) (start-callback-server #:timeout 10))
+      (thread
+       (lambda ()
+         (sync (alarm-evt (+ (current-inexact-milliseconds) 200)))
+         (with-handlers ([exn:fail? (lambda (e) (void))])
+           (define-values (in out) (tcp-connect "127.0.0.1" port))
+           (fprintf out
+                    "GET /callback?code=nonblock-code&state=~a HTTP/1.1\r\nHost: localhost\r\n\r\n"
+                    state)
+           (flush-output out)
+           (close-output-port out)
+           (close-input-port in))))
+      ;; Wait for callback to be fully processed
+      (sync (alarm-evt (+ (current-inexact-milliseconds) 800)))
+      ;; get-code should return immediately (result already on channel)
+      (define before (current-inexact-milliseconds))
+      (define code (get-code))
+      (define after (current-inexact-milliseconds))
+      (check-equal? code "nonblock-code")
+      (check-true (< (- after before) 500)
+                  (format "get-code should return immediately, but took ~a ms" (- after before))))))
 
 (module+ main
   (run-tests security-tests))


### PR DESCRIPTION
## Summary
- Removes dead `semaphore-wait(make-semaphore 0)` from accept loop — the loop now terminates cleanly when `tcp-close` raises on `tcp-accept`
- Adds "cleanup is independent of consumer" test — verifies listener is closed before `get-code` is called
- Adds "nonblocking completion" test — verifies `get-code` returns immediately when result is already on the channel

## Validation
- `racket tests/test-oauth-callback-security.rkt` — 21/21 pass
- `racket tests/test-oauth-callback.rkt` — 12/12 pass
- `racket scripts/run-tests.rkt` (both files) — 33/33 pass
- `builder_verify_wave` format+compile — pass

## Abstraction gate
No new abstractions. Fixed existing loop logic and added regression tests only.