### PR TITLE
fix(v0.59.10 W3): strict provider schema validation (#5499)

### DIFF
--- a/runtime/provider-schema.rkt
+++ b/runtime/provider-schema.rkt
@@ -22,15 +22,44 @@
            (->* (provider-registry?) ((or/c path-string? path?)) exact-nonnegative-integer?)]
           [list-builtin-provider-names (-> (listof string?))]
           [provider-is-placeholder? (-> provider-info? boolean?)]
-          [builtin-provider-config (-> provider-registry? string? (or/c hash? #f))]))
+          [builtin-provider-config (-> provider-registry? string? (or/c hash? #f))])
+         validate-provider-entry)
 
 ;; Runtime path to the schema file
 (define-runtime-path providers-schema-file "providers.rktd")
 
+;; Validate a single provider schema entry.
+;; Returns #t if valid, or a string error message.
+;; Required: car is a symbol, (base-url . string?) and (default-model . string?).
+(define (validate-provider-entry entry)
+  (cond
+    [(not (pair? entry)) "entry must be a pair"]
+    [(not (symbol? (car entry))) (format "provider name must be a symbol, got: ~a" (car entry))]
+    [else
+     (define def (cdr entry))
+     (define base-url (pfield def 'base-url #f))
+     (define default-model (pfield def 'default-model #f))
+     (define models (pfield def 'models '()))
+     (cond
+       [(not (string? base-url)) (format "provider ~a: base-url must be a string" (car entry))]
+       [(not (string? default-model))
+        (format "provider ~a: default-model must be a string" (car entry))]
+       [(not (list? models)) (format "provider ~a: models must be a list" (car entry))]
+       [else #t])]))
+
 ;; Load the raw provider schema as an alist.
+;; Validates entries — malformed entries are skipped with a warning.
 (define (load-providers-schema [path providers-schema-file])
   (with-handlers ([exn:fail? (lambda (e) '())])
-    (call-with-input-file path read)))
+    (define raw (call-with-input-file path read))
+    (for/list ([entry (in-list (if (list? raw)
+                                   raw
+                                   '()))]
+               #:when (let ([v (validate-provider-entry entry)])
+                        (when (string? v)
+                          (log-warning "provider-schema: skipping malformed entry: ~a" v))
+                        (eq? v #t)))
+      entry)))
 
 ;; Extract a field from a provider definition alist
 (define (pfield def field [default #f])

--- a/tests/test-provider-registry-schema.rkt
+++ b/tests/test-provider-registry-schema.rkt
@@ -118,7 +118,55 @@
     (test-case "builtin-provider-config returns #f for unknown provider"
       (define reg (make-provider-registry))
       (load-builtin-providers! reg)
-      (check-false (builtin-provider-config reg "nonexistent")))))
+      (check-false (builtin-provider-config reg "nonexistent")))
+
+    ;; ============================================================
+    ;; Schema validation (#5499)
+    ;; ============================================================
+
+    (test-case "validate-provider-entry accepts valid entry (#5499)"
+      (define entry '(test-provider (base-url . "https://api.test.com") (default-model . "test-1")))
+      (check-eq? (validate-provider-entry entry) #t))
+
+    (test-case "validate-provider-entry rejects non-pair (#5499)"
+      (check-true (string? (validate-provider-entry "not-a-pair"))))
+
+    (test-case "validate-provider-entry rejects non-symbol name (#5499)"
+      (define entry '("not-a-symbol" (base-url . "https://test.com") (default-model . "m1")))
+      (check-true (string? (validate-provider-entry entry))))
+
+    (test-case "validate-provider-entry rejects missing base-url (#5499)"
+      (define entry '(bad (default-model . "m1")))
+      (check-true (string? (validate-provider-entry entry))))
+
+    (test-case "validate-provider-entry rejects non-string base-url (#5499)"
+      (define entry '(bad (base-url . 123) (default-model . "m1")))
+      (check-true (string? (validate-provider-entry entry))))
+
+    (test-case "validate-provider-entry rejects missing default-model (#5499)"
+      (define entry '(bad (base-url . "https://test.com")))
+      (check-true (string? (validate-provider-entry entry))))
+
+    (test-case "validate-provider-entry rejects non-list models (#5499)"
+      (define entry
+        '(bad (base-url . "https://test.com") (default-model . "m1") (models . "not-list")))
+      (check-true (string? (validate-provider-entry entry))))
+
+    (test-case "load-providers-schema filters malformed entries (#5499)"
+      (define tmp (make-temporary-file "qtest-schema-~a.rktd"))
+      (call-with-output-file
+       tmp
+       (lambda (out)
+         (write '((good (base-url . "https://good.com") (default-model . "g1") (models . ()))
+                  ("bad-name" (base-url . "https://bad.com") (default-model . "b1"))
+                  (no-url (default-model . "x"))
+                  (also-good (base-url . "https://also.com") (default-model . "a1") (models . ())))
+                out))
+       #:exists 'replace)
+      (define schema (load-providers-schema tmp))
+      (check-equal? (length schema) 2)
+      (check-equal? (map car schema) '(good also-good))
+      (delete-file tmp))))
 
 (module+ main
   (run-tests provider-registry-schema-tests))

--- a/tests/workflows/extensions/test-extension-round-trip.rkt
+++ b/tests/workflows/extensions/test-extension-round-trip.rkt
@@ -56,7 +56,7 @@
                              "function"
                              'function
                              (hash 'name "planning-read" 'arguments "{\"artifact\": \"PLAN.md\"}"))))
-           (hash 'role 'assistant 'content "Plan reviewed." 'tool_calls (list))))
+           (text-response "Plan reviewed.")))
          "Check the plan"
          #:extension-registry ext-reg
          #:files (list (cons ".planning/PLAN.md" "# Plan\nWave 1: Do stuff"))
@@ -75,11 +75,10 @@
       (load-extension! ext-reg gsd-planning-path)
 
       (define result
-        (run-workflow
-         (make-scripted-provider (list (hash 'role 'assistant 'content "Done." 'tool_calls (list))))
-         "Hello"
-         #:extension-registry ext-reg
-         #:max-iterations 3))
+        (run-workflow (make-scripted-provider (list (text-response "Done.")))
+                      "Hello"
+                      #:extension-registry ext-reg
+                      #:max-iterations 3))
 
       ;; Session log should exist and be valid
       (check-true (file-exists? (workflow-result-session-log result)) "Session log should exist")
@@ -96,8 +95,7 @@
                              (lambda (out) (display "You are a test skill assistant.\n" out)))
 
       (define result
-        (run-workflow (make-scripted-provider
-                       (list (hash 'role 'assistant 'content "Using test skill." 'tool_calls (list))))
+        (run-workflow (make-scripted-provider (list (text-response "Using test skill.")))
                       "Hello"
                       #:skills-dir tmp-dir
                       #:max-iterations 3))
@@ -113,12 +111,11 @@
         (fail "gsd-planning extension not found"))
 
       (define result
-        (run-workflow-multi-turn
-         (make-scripted-provider (list (hash 'role 'assistant 'content "Turn 1" 'tool_calls (list))
-                                       (hash 'role 'assistant 'content "Turn 2" 'tool_calls (list))))
-         '("First" "Second")
-         #:extensions (list gsd-planning-path)
-         #:max-iterations 3))
+        (run-workflow-multi-turn (make-scripted-provider (list (text-response "Turn 1")
+                                                               (text-response "Turn 2")))
+                                 '("First" "Second")
+                                 #:extensions (list gsd-planning-path)
+                                 #:max-iterations 3))
 
       (check-false (workflow-result-output result))
       (check-true (file-exists? (workflow-result-session-log result))))))

--- a/tests/workflows/extensions/test-sdk-extension-loading.rkt
+++ b/tests/workflows/extensions/test-sdk-extension-loading.rkt
@@ -35,9 +35,7 @@
         (load-extension! ext-reg gsd-path #:event-bus bus))
 
       ;; Run workflow with the extension registry
-      (define prov
-        (make-scripted-provider
-         (list (hash 'role 'assistant 'content "I'll check the planning state." 'tool_calls (list)))))
+      (define prov (make-scripted-provider (list (text-response "I'll check the planning state."))))
       (define result
         (run-workflow prov "Check planning state" #:extension-registry ext-reg #:max-iterations 3))
 
@@ -50,9 +48,7 @@
       (unless (file-exists? gsd-path)
         (error 'test "Extension not found: ~a" gsd-path))
 
-      (define prov
-        (make-scripted-provider
-         (list (hash 'role 'assistant 'content "Planning check done." 'tool_calls (list)))))
+      (define prov (make-scripted-provider (list (text-response "Planning check done."))))
       (define result
         (run-workflow prov "Check planning" #:extensions (list gsd-path) #:max-iterations 3))
 
@@ -60,17 +56,14 @@
 
     (test-case "no extensions: backward compatible"
       ;; Should work without any extensions (default behavior)
-      (define prov
-        (make-scripted-provider (list (hash 'role 'assistant 'content "Hello!" 'tool_calls (list)))))
+      (define prov (make-scripted-provider (list (text-response "Hello!"))))
       (define result (run-workflow prov "Hello" #:max-iterations 3))
 
       (check-not-false (workflow-result-output result)))
 
     (test-case "multi-turn accepts #:extensions"
       (define gsd-path (extension-path "gsd-planning"))
-      (define prov
-        (make-scripted-provider (list (hash 'role 'assistant 'content "Step 1" 'tool_calls (list))
-                                      (hash 'role 'assistant 'content "Step 2" 'tool_calls (list)))))
+      (define prov (make-scripted-provider (list (text-response "Step 1") (text-response "Step 2"))))
 
       (define result
         (run-workflow-multi-turn prov


### PR DESCRIPTION
## Summary
- Adds `validate-provider-entry` to `provider-schema.rkt` — rejects malformed entries (non-symbol names, missing/invalid base-url or default-model, non-list models)
- `load-providers-schema` now filters out malformed entries with a warning log
- Migrates raw hash script entries in workflow tests to use `text-response` constructor
- Adds 8 new schema validation tests

## Validation
- `racket tests/test-provider-registry-schema.rkt` — 21/21 pass
- `racket tests/workflows/extensions/test-sdk-extension-loading.rkt` — 4/4 pass
- `racket tests/workflows/extensions/test-extension-round-trip.rkt` — 4/4 pass
- `builder_verify_wave` format+compile — pass

## Abstraction gate
`validate-provider-entry` names a real schema validation domain concept. Returns #t or error string, avoiding exception-based control flow.