### PR TITLE
docs(v0.59.11 W0): freeze gate truth failures

### DIFF
--- a/docs/reports/v0.59.11-gate-truth-repro.md
+++ b/docs/reports/v0.59.11-gate-truth-repro.md
@@ -1,0 +1,81 @@
+# v0.59.11 Gate Truth Reproduction
+
+**Issue:** #5516  
+**Milestone:** v0.59.11 — Gate Truth Hotfix  
+**Baseline:** v0.59.10 `a3b53d00`  
+**Date:** 2026-05-27
+
+## Result
+
+v0.59.11 W0 reproduced current release-blocking gate failures.
+
+| Gate | Result |
+|---|---|
+| Provider schema direct test | 1 file, 0 passed, 1 failed; 21 tests, 11 passed, 10 failed |
+| Fast suite | 563 files, 562 passed, 1 failed; 8334 tests, 8324 passed, 10 failed |
+| README metrics | committed values stale: 465 source modules / 72921 source lines |
+| Finding matrix | claims provider schema fixed despite failing test |
+
+## Provider Schema Evidence
+
+```text
+Files:     1 total, 0 passed, 1 failed, 0 timeouts
+Tests:     21 total, 11 passed, 10 failed
+FAILURES:
+  ✗ tests/test-provider-registry-schema.rkt (exit=1, 11 passed, 10 failed, 1.52s)
+```
+
+Direct failure classes:
+
+- `load-providers-schema` returns empty/false.
+- Expected provider rows are absent.
+- Builtin provider registration does not register expected providers/models.
+- `openrouter` lookup fails.
+- Placeholder provider lookup returns `#f`, causing a contract error.
+- `builtin-provider-config` returns `#f`.
+
+## Fast Suite Evidence
+
+```text
+Files:     563 total, 562 passed, 1 failed, 0 timeouts
+Tests:     8334 total, 8324 passed, 10 failed
+FAILURES:
+  ✗ tests/test-provider-registry-schema.rkt (exit=1, 11 passed, 10 failed, 0.808s)
+```
+
+## Metrics Evidence
+
+Committed README values after restoring the mutation caused by metrics tooling:
+
+```text
+278:| Source modules | 465 |
+279:| Source lines | 72921 |
+```
+
+`racket scripts/metrics.rkt --lint` mutated README to the computed values before reporting success:
+
+```diff
+-| Source modules | 465 |
+-| Source lines | 72921 |
++| Source modules | 466 |
++| Source lines | 73173 |
+```
+
+This confirms W2 must repair README metrics truth and/or metrics read-only behavior.
+
+## Finding Matrix Evidence
+
+`docs/reports/v0.59.x-finding-matrix.md` still says provider schema tests pass:
+
+```text
+M-1 ... ✅ Fixed ... Provider schema tests pass; v0.59.9 guardrail recheck found no active schema regression
+```
+
+This conflicts with the reproduced provider schema failure and is assigned to W3.
+
+## Next Waves
+
+- W1 (#5519): Provider schema gate repair.
+- W2 (#5522): README metrics / lint-all restoration.
+- W3 (#5525): Finding matrix truth and contract metric disposition.
+- W4 (#5528): Full gate and review.


### PR DESCRIPTION
## Summary
- Reproduces provider schema direct failure and fast-suite failure
- Records README metrics drift and metrics tooling mutation behavior
- Records finding matrix contradiction for follow-up waves

## Verification
- `racket scripts/run-tests.rkt tests/test-provider-registry-schema.rkt --jobs 1 --timeout 60` (expected failure reproduced)
- `racket scripts/run-tests.rkt --suite fast --jobs 4 --timeout 120` (expected failure reproduced)
- `racket scripts/metrics.rkt --lint` (mutated README; restored afterward)
- `racket scripts/lint-all.rkt` (branch release-readiness failure captured)

Closes #5516