### PR TITLE
docs(v0.59.11 W2): restore README metrics truth

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,8 +275,8 @@ q/
 | Metric | Value |
 |--------|-------|
 | Test files | 653 |
-| Source modules | 465 |
-| Source lines | 72921 |
+| Source modules | 466 |
+| Source lines | 73173 |
 | Test lines | 111528 |
 | Test assertions | 17458 |
 | Tests passing | 5835+ | `racket scripts/run-tests.rkt` results |


### PR DESCRIPTION
## Summary
- Update README static metrics to match computed project metrics after W1 added runtime/providers.rktd
- Source modules: 465 → 466
- Source lines: 72921 → 73173

## Verification
- `racket scripts/metrics.rkt --summary` → Source modules 466, Source lines 73173
- `racket scripts/metrics.rkt --lint` → All 5 static metrics match README.md
- `racket scripts/lint-all.rkt` on feature branch → metrics-sync PASS, metrics-lint PASS; only release-readiness fails because it requires clean main and the branch had an intentional README change before PR finish

Follow-up: full `lint-all` will be re-run after merge on clean main.

Closes #5522