### PR TITLE
docs(v0.59.11 W3): correct finding matrix truth

### DIFF
--- a/docs/reports/v0.59.x-finding-matrix.md
+++ b/docs/reports/v0.59.x-finding-matrix.md
@@ -1,33 +1,60 @@
 # v0.59.x Finding Matrix
 
+## Current Series Verdict
+
+**Status:** REQUEST_CHANGES until v0.59.11/v0.59.12 closure gates pass.
+
+This matrix is a traceability artifact, not a final approval claim. It records which v0.59.x findings are fixed, which are only partially proven, and which follow-up waves still own proof gaps.
+
+Latest gate-truth updates:
+
+- v0.59.11 W1 fixed the provider registry schema gate: `tests/test-provider-registry-schema.rkt` passes 21/21 tests and smoke passes 562/562 files, 8228/8228 tests.
+- v0.59.11 W2 fixed README metric truth: `racket scripts/metrics.rkt --lint` reports all 5 static metrics match `README.md`, and clean-main `racket scripts/lint-all.rkt` reports 22 passed, 1 non-blocking warning.
+- v0.59.12 remains open for security/workflow proof gaps identified by the v0.59.10 post-remediation audit.
+
 ## Finding-to-Milestone Traceability
 
-| Finding | Description | Milestone | Status | Evidence |
+| Finding | Description | Milestone | Status | Evidence / Open Proof |
 |---|---|---|---|---|
-| C-4/C-5 | TUI layout crash/API break | v0.59.0, v0.59.6, v0.59.9 | ✅ Fixed | Layout compatibility restored; final TUI drag-selection red gate repaired |
-| M-1 | Missing `providers.rktd` | v0.59.0, v0.59.9 | ✅ Fixed | Provider schema tests pass; v0.59.9 guardrail recheck found no active schema regression |
-| M-2/M-3 | OAuth test drift/login invalid configs | v0.59.0, v0.59.1, v0.59.7 | ✅ Fixed | OAuth tests updated, `/login` fails closed, callback/browser cleanup completed |
-| M-7 | `supported-image-file?` returns list | v0.59.0 | ✅ Fixed | Image pipeline tests pass with exact boolean behavior |
-| M-9 | Historical report corruption | v0.59.6, v0.59.9 | ✅ Fixed | v0.57 report labels restored, docs/reports sync exclusion tested |
-| C-1/C-2/C-3 | OAuth PKCE/server/query security | v0.59.1, v0.59.7 | ✅ Fixed | RFC7636 S256, CSPRNG, one-shot callback, URL decode, safe browser tests |
-| C-6/C-7 | Image command injection/timeouts | v0.59.2, v0.59.7 | ✅ Fixed | No shell strings, argv operands, timeout/injection tests pass |
-| M-4/M-5/M-6/M-8 | Contracts/thread safety | v0.59.3, v0.59.7 | ✅ Fixed | Contract tests + concurrency/cache tests pass |
-| M-10/L-1 | Workflow blanket exclusion/hangs | v0.59.4, v0.59.8 | ✅ Fixed | `--suite workflows` green (24/24), timeout/cleanup wrappers, CI job added |
-| Release gate | Tags created despite red tests | v0.59.5, v0.59.8 | ✅ Fixed | `--strict` mode requires gate evidence + tag check; release CI records gate evidence |
+| C-4/C-5 | TUI layout crash/API break | v0.59.0, v0.59.6, v0.59.9 | ✅ Fixed | Layout compatibility restored; final TUI drag-selection red gate repaired; TUI gate passed in v0.59.10 audit |
+| M-1 | Missing `providers.rktd` | v0.59.0, v0.59.9, v0.59.11 | ✅ Fixed | v0.59.11 W1: provider schema focused test passes 21/21; smoke passes 562/562 files |
+| M-2/M-3 | OAuth test drift/login invalid configs | v0.59.0, v0.59.1, v0.59.7, v0.59.12 | ⚠️ Partial | OAuth/login tests improved, but v0.59.12 W0/W1 still own no-consumer callback completion and browser-launch failure surfacing proof |
+| M-7 | `supported-image-file?` returns list | v0.59.0, v0.59.12 | ⚠️ Partial | Exact boolean behavior covered; v0.59.12 W5 still owns actual resize subprocess operand proof |
+| M-9 | Historical report corruption | v0.59.6, v0.59.9 | ✅ Fixed | v0.57 report labels restored; docs/reports sync exclusion tested |
+| C-1/C-2/C-3 | OAuth PKCE/server/query security | v0.59.1, v0.59.7, v0.59.12 | ⚠️ Partial | RFC7636 S256, CSPRNG, URL decode, and one-shot callback tests exist; v0.59.12 W0 must prove callback completion is nonblocking without a waiting consumer |
+| C-6/C-7 | Image command injection/timeouts | v0.59.2, v0.59.7, v0.59.12 | ⚠️ Partial | Shell-string removal and timeout/injection tests exist; v0.59.12 W5 must prove option-like resize operands in the actual resize path |
+| M-4/M-5/M-6/M-8 | Contracts/thread safety | v0.59.3, v0.59.7, v0.59.11 | ⚠️ Tracked exception | Contract/concurrency/cache tests pass, but contract precision remains above target: `contract-metrics.rkt --summary` reports 680 `any/c` across 141 files; disposition is tracked below |
+| M-10/L-1 | Workflow blanket exclusion/hangs | v0.59.4, v0.59.8, v0.59.12 | ⚠️ Partial | `--suite workflows` was green in audit, but v0.59.12 W3 still owns multi-turn timeout/cleanup integration proof |
+| Release gate | Tags created despite red tests | v0.59.5, v0.59.8, v0.59.12 | ⚠️ Partial | Strict readiness exists; v0.59.12 W4 must split pre-tag readiness from tag-publish readiness to avoid tag-triggered self-blocking semantics |
 
 ## Disposition Summary
 
-- **Critical (C-1 through C-7)**: All 7 findings resolved with adversarial tests
-- **Major (M-1 through M-10)**: All 10 findings resolved with regression tests
-- **Low (L-1)**: Resolved via dedicated workflow suite
+- **Fixed in v0.59.11:** provider schema red gate and README/lint metrics drift.
+- **Still REQUEST_CHANGES:** OAuth callback completion proof, browser launch failure surfacing, image resize operand proof, mock provider malformed-entry validation, multi-turn workflow timeout/cleanup, release readiness context split, and final approval audit.
+- **Administrative closure is not approval:** issue/milestone closure only records workflow state; final approval requires clean gates plus independent review.
+
+## Contract Metric Disposition
+
+`racket scripts/contract-metrics.rkt --summary` is the source of truth for contract precision because it parses Racket forms and counts `any/c` only inside contract contexts.
+
+Current v0.59.11 W3 measurement:
+
+```text
+Total any/c in contract-out: 680
+Files with any/c: 141
+Total source files scanned: 372
+```
+
+Raw grep counts differ because they include/exclude comments, strings, prose, or non-contract contexts depending on the command. For release tracking, use the parser-backed `contract-metrics.rkt` total.
+
+Disposition: 680 remains above the prior v0.58.5 target of 597 and is **not claimed as reduced** in this series. It is a reviewed exception/ledger item for the next contract-precision campaign, while v0.59.11/v0.59.12 focuses on gate truth and security/workflow proof closure.
 
 ## v0.59.x Series Metrics
 
-- **Milestones**: 10 tracked milestones (v0.59.0 through v0.59.10), all closed
-- **Total waves**: 46+ across v0.59.x remediation and closure
-- **Total issues**: 170+ across v0.59.x remediation and closure
-- **any/c reduction**: 882 (v0.57.0) → 597 (v0.58.5) → 680 (v0.59.10, stricter contracts)
-- **New security tests**: 13 (image pipeline) + 20+ (OAuth) + 8 (browser/schema) + 3 (workflow cleanup)
-- **New workflow tests**: 24 (all passing)
-- **New contract tests**: 45+ (widget lifecycle, context pressure, message-meta)
-- **CI release gate**: Strict evidence-based release pipeline with 4-suite gate recording
+- **Milestones:** v0.59.0 through v0.59.10 completed administratively; v0.59.11/v0.59.12 remediation is in progress.
+- **Total waves:** 46+ across v0.59.x remediation and closure, plus v0.59.11/v0.59.12 hotfix/proof waves.
+- **Total issues:** 170+ across v0.59.x remediation and closure.
+- **any/c trend:** 882 (v0.57.0) → 597 (v0.58.5 target point) → 680 (v0.59.10/v0.59.11, stricter/parser-backed contracts; tracked exception, not a closure claim).
+- **Security tests:** image pipeline, OAuth, browser/schema, and workflow cleanup coverage exists; v0.59.12 owns the remaining path-proof gaps.
+- **Workflow tests:** workflow suite has green evidence, but multi-turn timeout/cleanup proof remains open for v0.59.12 W3.
+- **CI release gate:** strict evidence-based release pipeline exists; pre-tag/tag-publish context split remains open for v0.59.12 W4.


### PR DESCRIPTION
## Summary
- Correct the v0.59.x finding matrix so it no longer claims final approval while v0.59.12 proof gaps remain open
- Cite actual v0.59.11 W1/W2 evidence for provider schema and README/lint restoration
- Record parser-backed contract metrics as the source of truth: 680 any/c across 141 files and 372 source files scanned
- Mark OAuth/browser/image/workflow/release gaps partial with owning v0.59.12 proof waves

## Verification
- `grep -n "Provider schema tests pass\|all findings resolved\|APPROVED\|REQUEST_CHANGES\|provider schema focused\|contract-metrics" docs/reports/v0.59.x-finding-matrix.md`
- `racket scripts/contract-metrics.rkt --summary` → 680 any/c, 141 files, 372 scanned
- `racket scripts/lint-all.rkt` on feature branch → content checks pass; only release-readiness fails because it requires clean main and the branch had an intentional doc change before PR finish

Follow-up: full `lint-all` will be re-run after merge on clean main.

Closes #5525