### PR TITLE
feat(v0.60.1 W0): create native cell-buffer.rkt (#5599)

### DIFF
--- a/tests/test-cell-buffer.rkt
+++ b/tests/test-cell-buffer.rkt
@@ -1,0 +1,203 @@
+#lang racket
+
+;; tests/test-cell-buffer.rkt — Tests for tui/cell-buffer.rkt
+
+(require rackunit
+         "../tui/cell-buffer.rkt")
+
+;; ============================================================
+;; Creation
+;; ============================================================
+
+(test-case "make-cell-buffer creates buffer with correct dimensions"
+  (define buf (make-cell-buffer 80 24))
+  (check-equal? (cell-buffer-cols buf) 80)
+  (check-equal? (cell-buffer-rows buf) 24))
+
+(test-case "make-cell-buffer fills with default cells"
+  (define buf (make-cell-buffer 10 5))
+  (for* ([r (in-range 5)]
+         [c (in-range 10)])
+    (define cell (cell-buffer-ref buf c r))
+    (check-equal? (cell-char cell) #\space)
+    (check-equal? (cell-fg cell) 7)
+    (check-equal? (cell-bg cell) 0)
+    (check-false (cell-bold? cell))
+    (check-false (cell-underline? cell))))
+
+(test-case "new buffer is dirty"
+  (define buf (make-cell-buffer 10 5))
+  (check-true (cell-buffer-dirty? buf)))
+
+;; ============================================================
+;; Cell access and mutation
+;; ============================================================
+
+(test-case "cell-buffer-set! writes a cell"
+  (define buf (make-cell-buffer 10 5))
+  (cell-buffer-set! buf 3 2 #:char #\X #:fg 31 #:bold #t)
+  (define cell (cell-buffer-ref buf 3 2))
+  (check-equal? (cell-char cell) #\X)
+  (check-equal? (cell-fg cell) 31)
+  (check-true (cell-bold? cell)))
+
+(test-case "cell-buffer-set! preserves defaults for unspecified attrs"
+  (define buf (make-cell-buffer 10 5))
+  (cell-buffer-set! buf 0 0 #:char #\A)
+  (define cell (cell-buffer-ref buf 0 0))
+  (check-equal? (cell-char cell) #\A)
+  (check-equal? (cell-fg cell) 7)
+  (check-false (cell-bold? cell)))
+
+(test-case "cell-buffer-set! marks buffer dirty"
+  (define buf (make-cell-buffer 10 5))
+  (set-cell-buffer-dirty?! buf #f)
+  (cell-buffer-set! buf 0 0 #:char #\Z)
+  (check-true (cell-buffer-dirty? buf)))
+
+;; ============================================================
+;; Clear
+;; ============================================================
+
+(test-case "cell-buffer-clear! resets all cells to defaults"
+  (define buf (make-cell-buffer 10 5))
+  (cell-buffer-set! buf 5 3 #:char #\Q #:fg 31 #:bold #t)
+  (cell-buffer-clear! buf)
+  (define cell (cell-buffer-ref buf 5 3))
+  (check-equal? (cell-char cell) #\space)
+  (check-equal? (cell-fg cell) 7)
+  (check-false (cell-bold? cell)))
+
+(test-case "cell-buffer-clear! marks buffer dirty"
+  (define buf (make-cell-buffer 10 5))
+  (set-cell-buffer-dirty?! buf #f)
+  (cell-buffer-clear! buf)
+  (check-true (cell-buffer-dirty? buf)))
+
+;; ============================================================
+;; Resize
+;; ============================================================
+
+(test-case "cell-buffer-resize! changes dimensions"
+  (define buf (make-cell-buffer 80 24))
+  (cell-buffer-resize! buf 120 40)
+  (check-equal? (cell-buffer-cols buf) 120)
+  (check-equal? (cell-buffer-rows buf) 40))
+
+(test-case "cell-buffer-resize! preserves existing content"
+  (define buf (make-cell-buffer 80 24))
+  (cell-buffer-set! buf 10 5 #:char #\K #:fg 32)
+  (cell-buffer-resize! buf 120 40)
+  (define cell (cell-buffer-ref buf 10 5))
+  (check-equal? (cell-char cell) #\K)
+  (check-equal? (cell-fg cell) 32))
+
+(test-case "cell-buffer-resize! fills new area with defaults"
+  (define buf (make-cell-buffer 10 5))
+  (cell-buffer-resize! buf 20 10)
+  (define cell (cell-buffer-ref buf 15 8))
+  (check-equal? (cell-char cell) #\space)
+  (check-equal? (cell-fg cell) 7))
+
+(test-case "cell-buffer-resize! shrinks buffer"
+  (define buf (make-cell-buffer 80 24))
+  (cell-buffer-set! buf 5 5 #:char #\A)
+  (cell-buffer-resize! buf 40 12)
+  (check-equal? (cell-buffer-cols buf) 40)
+  (check-equal? (cell-buffer-rows buf) 12)
+  ;; Cell (5,5) is within new bounds, should be preserved
+  (check-equal? (cell-char (cell-buffer-ref buf 5 5)) #\A))
+
+(test-case "cell-buffer-resize! marks buffer dirty"
+  (define buf (make-cell-buffer 10 5))
+  (set-cell-buffer-dirty?! buf #f)
+  (cell-buffer-resize! buf 20 10)
+  (check-true (cell-buffer-dirty? buf)))
+
+;; ============================================================
+;; putstring!
+;; ============================================================
+
+(test-case "cell-buffer-putstring! writes string to buffer"
+  (define buf (make-cell-buffer 80 24))
+  (cell-buffer-putstring! buf 5 3 "Hello")
+  (check-equal? (cell-char (cell-buffer-ref buf 5 3)) #\H)
+  (check-equal? (cell-char (cell-buffer-ref buf 6 3)) #\e)
+  (check-equal? (cell-char (cell-buffer-ref buf 7 3)) #\l)
+  (check-equal? (cell-char (cell-buffer-ref buf 8 3)) #\l)
+  (check-equal? (cell-char (cell-buffer-ref buf 9 3)) #\o))
+
+(test-case "cell-buffer-putstring! applies attributes to all chars"
+  (define buf (make-cell-buffer 80 24))
+  (cell-buffer-putstring! buf 0 0 "XY" #:fg 31 #:bg 4 #:bold #t)
+  (check-equal? (cell-fg (cell-buffer-ref buf 0 0)) 31)
+  (check-equal? (cell-bg (cell-buffer-ref buf 0 0)) 4)
+  (check-true (cell-bold? (cell-buffer-ref buf 0 0)))
+  (check-equal? (cell-fg (cell-buffer-ref buf 1 0)) 31))
+
+(test-case "cell-buffer-putstring! truncates at buffer boundary"
+  (define buf (make-cell-buffer 10 5))
+  ;; Write starting at col 8 — only "AB" fits (cols 8, 9)
+  (cell-buffer-putstring! buf 8 0 "ABCDE")
+  (check-equal? (cell-char (cell-buffer-ref buf 8 0)) #\A)
+  (check-equal? (cell-char (cell-buffer-ref buf 9 0)) #\B)
+  ;; Col 10+ doesn't exist, so only 2 chars written
+  ;; Verify the cell after the write boundary is still default
+  ;; (not applicable since buffer is only 10 cols, index 10 would be OOB)
+  )
+
+(test-case "cell-buffer-putstring! handles empty string"
+  (define buf (make-cell-buffer 10 5))
+  (cell-buffer-set! buf 0 0 #:char #\X)
+  (cell-buffer-putstring! buf 0 0 "")
+  (check-equal? (cell-char (cell-buffer-ref buf 0 0)) #\X))
+
+;; ============================================================
+;; Cell comparison
+;; ============================================================
+
+(test-case "cell-equal? returns #t for identical cells"
+  (define a (vector #\A 31 4 #t #f #f #f))
+  (define b (vector #\A 31 4 #t #f #f #f))
+  (check-true (cell-equal? a b)))
+
+(test-case "cell-equal? returns #f for different chars"
+  (define a (vector #\A 7 0 #f #f #f #f))
+  (define b (vector #\B 7 0 #f #f #f #f))
+  (check-false (cell-equal? a b)))
+
+(test-case "cell-equal? returns #f for different fg"
+  (define a (vector #\A 7 0 #f #f #f #f))
+  (define b (vector #\A 31 0 #f #f #f #f))
+  (check-false (cell-equal? a b)))
+
+(test-case "cell-equal? returns #f for different bold"
+  (define a (vector #\A 7 0 #t #f #f #f))
+  (define b (vector #\A 7 0 #f #f #f #f))
+  (check-false (cell-equal? a b)))
+
+;; ============================================================
+;; Row helpers
+;; ============================================================
+
+(test-case "cell-buffer-row-string extracts row as string"
+  (define buf (make-cell-buffer 10 5))
+  (cell-buffer-putstring! buf 0 2 "Hello")
+  (check-equal? (cell-buffer-row-string buf 2) "Hello     "))
+
+(test-case "cell-buffer-row-string for empty row"
+  (define buf (make-cell-buffer 5 3))
+  (check-equal? (cell-buffer-row-string buf 0) "     "))
+
+;; ============================================================
+;; Performance (smoke test)
+;; ============================================================
+
+(test-case "1000x80 buffer fill completes in reasonable time"
+  (define buf (make-cell-buffer 80 1000))
+  (define start (current-inexact-milliseconds))
+  (for ([row (in-range 1000)])
+    (cell-buffer-putstring! buf 0 row (make-string 80 #\X) #:fg 31))
+  (define elapsed (- (current-inexact-milliseconds) start))
+  ;; Should complete in well under 100ms
+  (check-true (< elapsed 100.0) (format "Buffer fill took ~ams (expected < 100ms)" elapsed)))

--- a/tui/cell-buffer.rkt
+++ b/tui/cell-buffer.rkt
@@ -1,0 +1,205 @@
+#lang racket/base
+
+;; q/tui/cell-buffer.rkt — Native 2D cell buffer (replaces tui-ubuf)
+;;
+;; A cell buffer is a 2D array of cells, each storing:
+;;   character (char?), fg (0-255), bg (0-255), bold, underline, italic, blink
+;;
+;; Uses flat vectors for performance: cell at (col, row) is at index (+ (* row cols) col).
+;; Thread-safe for single-writer (render loop) usage.
+
+(require racket/contract)
+
+;; ============================================================
+;; Cell representation
+;; ============================================================
+
+;; A cell is a vector: #(char fg bg bold? underline? italic? blink?)
+;; Index constants for clarity
+(define CELL-CHAR-IDX 0)
+(define CELL-FG-IDX 1)
+(define CELL-BG-IDX 2)
+(define CELL-BOLD-IDX 3)
+(define CELL-UNDERLINE-IDX 4)
+(define CELL-ITALIC-IDX 5)
+(define CELL-BLINK-IDX 6)
+(define CELL-SIZE 7)
+
+;; Default cell: space, fg=7 (white), bg=0 (black), no attributes
+(define (make-default-cell)
+  (vector #\space 7 0 #f #f #f #f))
+
+;; ============================================================
+;; Cell buffer struct
+;; ============================================================
+
+(struct cell-buffer (cols rows cells dirty?) #:mutable)
+
+;; Create a new cell buffer filled with default cells
+(define (make-cell-buffer cols rows)
+  (define cells (make-vector (* cols rows)))
+  (for ([i (in-range (vector-length cells))])
+    (vector-set! cells i (make-default-cell)))
+  (cell-buffer cols rows cells #t))
+
+;; ============================================================
+;; Cell access and mutation
+;; ============================================================
+
+(define (cell-buffer-ref buf col row)
+  (define idx (+ (* row (cell-buffer-cols buf)) col))
+  (vector-ref (cell-buffer-cells buf) idx))
+
+(define (cell-buffer-set! buf
+                          col
+                          row
+                          #:char [ch #\space]
+                          #:fg [fg 7]
+                          #:bg [bg 0]
+                          #:bold [bold #f]
+                          #:underline [underline #f]
+                          #:italic [italic #f]
+                          #:blink [blink #f])
+  (define idx (+ (* row (cell-buffer-cols buf)) col))
+  (vector-set! (cell-buffer-cells buf) idx (vector ch fg bg bold underline italic blink))
+  (set-cell-buffer-dirty?! buf #t))
+
+;; Clear entire buffer to default cells
+(define (cell-buffer-clear! buf)
+  (for ([i (in-range (vector-length (cell-buffer-cells buf)))])
+    (vector-set! (cell-buffer-cells buf) i (make-default-cell)))
+  (set-cell-buffer-dirty?! buf #t))
+
+;; Resize buffer (creates new buffer, copies existing cells that fit)
+(define (cell-buffer-resize! buf new-cols new-rows)
+  (define old-cols (cell-buffer-cols buf))
+  (define old-rows (cell-buffer-rows buf))
+  (define old-cells (cell-buffer-cells buf))
+  (define new-cells (make-vector (* new-cols new-rows)))
+  ;; Fill with defaults
+  (for ([i (in-range (vector-length new-cells))])
+    (vector-set! new-cells i (make-default-cell)))
+  ;; Copy cells that fit
+  (define copy-rows (min old-rows new-rows))
+  (define copy-cols (min old-cols new-cols))
+  (for* ([r (in-range copy-rows)]
+         [c (in-range copy-cols)])
+    (define old-idx (+ (* r old-cols) c))
+    (define new-idx (+ (* r new-cols) c))
+    (vector-set! new-cells new-idx (vector-ref old-cells old-idx)))
+  (set-cell-buffer-cols! buf new-cols)
+  (set-cell-buffer-rows! buf new-rows)
+  (set-cell-buffer-cells! buf new-cells)
+  (set-cell-buffer-dirty?! buf #t))
+
+;; ============================================================
+;; Cell attribute accessors
+;; ============================================================
+
+(define (cell-char cell)
+  (vector-ref cell CELL-CHAR-IDX))
+(define (cell-fg cell)
+  (vector-ref cell CELL-FG-IDX))
+(define (cell-bg cell)
+  (vector-ref cell CELL-BG-IDX))
+(define (cell-bold? cell)
+  (vector-ref cell CELL-BOLD-IDX))
+(define (cell-underline? cell)
+  (vector-ref cell CELL-UNDERLINE-IDX))
+(define (cell-italic? cell)
+  (vector-ref cell CELL-ITALIC-IDX))
+(define (cell-blink? cell)
+  (vector-ref cell CELL-BLINK-IDX))
+
+;; ============================================================
+;; Cell comparison (for diffing)
+;; ============================================================
+
+(define (cell-equal? a b)
+  (and (eq? (cell-char a) (cell-char b))
+       (= (cell-fg a) (cell-fg b))
+       (= (cell-bg a) (cell-bg b))
+       (eq? (cell-bold? a) (cell-bold? b))
+       (eq? (cell-underline? a) (cell-underline? b))
+       (eq? (cell-italic? a) (cell-italic? b))
+       (eq? (cell-blink? a) (cell-blink? b))))
+
+;; ============================================================
+;; Row helpers
+;; ============================================================
+
+;; Extract row as a string of characters
+(define (cell-buffer-row-string buf row)
+  (define cols (cell-buffer-cols buf))
+  (define chars (make-string cols))
+  (for ([c (in-range cols)])
+    (string-set! chars c (cell-char (cell-buffer-ref buf c row))))
+  chars)
+
+;; ============================================================
+;; putstring! — write a string with attributes to the buffer
+;; ============================================================
+
+;; Compatible with tui-ubuf signature:
+;;   (ubuf-putstring! ubuf x y str #:fg #:bg #:bold #:underline #:italic #:blink)
+(define (cell-buffer-putstring! buf
+                                col
+                                row
+                                str
+                                #:fg [fg 7]
+                                #:bg [bg 0]
+                                #:bold [bold #f]
+                                #:underline [underline #f]
+                                #:italic [italic #f]
+                                #:blink [blink #f])
+  (define cols (cell-buffer-cols buf))
+  (define rows (cell-buffer-rows buf))
+  (define len (string-length str))
+  (for ([i (in-range len)])
+    (define c (+ col i))
+    (when (and (< c cols) (< row rows) (>= c 0) (>= row 0))
+      (cell-buffer-set! buf
+                        c
+                        row
+                        #:char (string-ref str i)
+                        #:fg fg
+                        #:bg bg
+                        #:bold bold
+                        #:underline underline
+                        #:italic italic
+                        #:blink blink))))
+
+;; ============================================================
+;; Contracts and exports
+;; ============================================================
+
+;; Struct and constructor
+(provide (struct-out cell-buffer)
+         make-cell-buffer
+
+         ;; Cell access
+         cell-buffer-ref
+         cell-buffer-set!
+         cell-buffer-clear!
+         cell-buffer-resize!
+
+         ;; Cell attribute accessors
+         cell-char
+         cell-fg
+         cell-bg
+         cell-bold?
+         cell-underline?
+         cell-italic?
+         cell-blink?
+
+         ;; Cell comparison
+         cell-equal?
+
+         ;; Row helpers
+         cell-buffer-row-string
+
+         ;; putstring (tui-ubuf compatible)
+         cell-buffer-putstring!
+
+         ;; Constants
+         CELL-SIZE)


### PR DESCRIPTION
## Summary
- Created `tui/cell-buffer.rkt` — native 2D cell buffer replacing external tui-ubuf
- Cell struct: `(vector char fg bg bold? underline? italic? blink?)` — flat vector for performance
- API: `make-cell-buffer`, `cell-buffer-ref`, `cell-buffer-set!`, `cell-buffer-clear!`, `cell-buffer-resize!`, `cell-buffer-putstring!`
- `cell-buffer-putstring!` signature matches tui-ubuf for compatibility
- `cell-buffer-resize!` preserves existing content that fits
- Row helper: `cell-buffer-row-string`
- Cell comparison: `cell-equal?` for diffing support
- Performance: 1000×80 buffer fill < 100ms

## Tests
- `tests/test-cell-buffer.rkt` — 20 test cases covering creation, mutation, clear, resize, putstring, truncation, comparison, performance