### PR TITLE
feat(v0.60.2 W0): create cell-diff.rkt for cell-level diffing (#5604)

### DIFF
--- a/tests/test-cell-diff.rkt
+++ b/tests/test-cell-diff.rkt
@@ -1,0 +1,145 @@
+#lang racket
+
+;; tests/test-cell-diff.rkt — Tests for tui/cell-diff.rkt
+
+(require rackunit
+         "../tui/cell-buffer.rkt"
+         "../tui/cell-diff.rkt")
+
+;; ============================================================
+;; Row hashing
+;; ============================================================
+
+(test-case "row-hash returns fixnum"
+  (define buf (make-cell-buffer 10 5))
+  (check-true (integer? (row-hash buf 0))))
+
+(test-case "row-hash is consistent"
+  (define buf (make-cell-buffer 10 5))
+  (check-equal? (row-hash buf 0) (row-hash buf 0)))
+
+(test-case "row-hash changes when cell changes"
+  (define buf (make-cell-buffer 10 5))
+  (define h1 (row-hash buf 0))
+  (cell-buffer-set! buf 3 0 #:char #\X)
+  (define h2 (row-hash buf 0))
+  (check-not-equal? h1 h2))
+
+(test-case "row-hash same for identical rows"
+  (define a (make-cell-buffer 10 5))
+  (define b (make-cell-buffer 10 5))
+  (check-equal? (row-hash a 0) (row-hash b 0)))
+
+;; ============================================================
+;; Diff — identical buffers
+;; ============================================================
+
+(test-case "diff identical buffers returns empty list"
+  (define a (make-cell-buffer 10 5))
+  (define b (make-cell-buffer 10 5))
+  (check-equal? (diff-cell-buffers a b) '()))
+
+;; ============================================================
+;; Diff — single cell change
+;; ============================================================
+
+(test-case "diff detects single cell change"
+  (define a (make-cell-buffer 10 5))
+  (define b (make-cell-buffer 10 5))
+  (cell-buffer-set! b 3 2 #:char #\Z)
+  (define deltas (diff-cell-buffers a b))
+  (check-equal? (length deltas) 1)
+  (define d (car deltas))
+  (check-equal? (cell-delta-col d) 3)
+  (check-equal? (cell-delta-row d) 2)
+  (check-equal? (cell-char (cell-delta-new-cell d)) #\Z))
+
+;; ============================================================
+;; Diff — row change
+;; ============================================================
+
+(test-case "diff detects multiple cells in same row"
+  (define a (make-cell-buffer 10 5))
+  (define b (make-cell-buffer 10 5))
+  (cell-buffer-set! b 0 0 #:char #\A)
+  (cell-buffer-set! b 1 0 #:char #\B)
+  (cell-buffer-set! b 2 0 #:char #\C)
+  (define deltas (diff-cell-buffers a b))
+  (check-equal? (length deltas) 3)
+  (check-equal? (delta-changed-rows deltas) 1))
+
+;; ============================================================
+;; Diff — multiple rows
+;; ============================================================
+
+(test-case "diff detects changes across multiple rows"
+  (define a (make-cell-buffer 10 5))
+  (define b (make-cell-buffer 10 5))
+  (cell-buffer-set! b 0 0 #:char #\A)
+  (cell-buffer-set! b 0 3 #:char #\B)
+  (define deltas (diff-cell-buffers a b))
+  (check-equal? (delta-changed-rows deltas) 2))
+
+;; ============================================================
+;; Diff — no previous buffer (full diff)
+;; ============================================================
+
+(test-case "diff with #f prev returns all cells"
+  (define buf (make-cell-buffer 5 3))
+  (define deltas (diff-cell-buffers #f buf))
+  (check-equal? (length deltas) (* 5 3)))
+
+;; ============================================================
+;; Diff — different dimensions
+;; ============================================================
+
+(test-case "diff with different dimensions returns full diff"
+  (define a (make-cell-buffer 5 3))
+  (define b (make-cell-buffer 5 4))
+  (define deltas (diff-cell-buffers a b))
+  ;; Should have 5*4 = 20 deltas (all cells of new buffer)
+  (check-equal? (length deltas) (* 5 4)))
+
+;; ============================================================
+;; Diff — attribute changes
+;; ============================================================
+
+(test-case "diff detects fg color change"
+  (define a (make-cell-buffer 10 5))
+  (define b (make-cell-buffer 10 5))
+  (cell-buffer-set! b 0 0 #:fg 31)
+  (define deltas (diff-cell-buffers a b))
+  (check-equal? (length deltas) 1)
+  (check-equal? (cell-fg (cell-delta-new-cell (car deltas))) 31))
+
+(test-case "diff detects bold change"
+  (define a (make-cell-buffer 10 5))
+  (define b (make-cell-buffer 10 5))
+  (cell-buffer-set! b 5 3 #:bold #t)
+  (define deltas (diff-cell-buffers a b))
+  (check-equal? (length deltas) 1)
+  (check-true (cell-bold? (cell-delta-new-cell (car deltas)))))
+
+;; ============================================================
+;; Delta statistics
+;; ============================================================
+
+(test-case "delta-count returns correct count"
+  (define a (make-cell-buffer 10 5))
+  (define b (make-cell-buffer 10 5))
+  (cell-buffer-set! b 0 0 #:char #\A)
+  (cell-buffer-set! b 1 0 #:char #\B)
+  (define deltas (diff-cell-buffers a b))
+  (check-equal? (delta-count deltas) 2))
+
+(test-case "delta-full-redraw? detects full redraw"
+  (define buf (make-cell-buffer 5 3))
+  (define deltas (diff-cell-buffers #f buf))
+  (check-true (delta-full-redraw? deltas 5 3)))
+
+(test-case "delta-full-redraw? returns #f for partial diff"
+  (define a (make-cell-buffer 10 5))
+  (define b (make-cell-buffer 10 5))
+  (cell-buffer-set! b 0 0 #:char #\A)
+  (define deltas (diff-cell-buffers a b))
+  (check-false (delta-full-redraw? deltas 10 5)))

--- a/tui/cell-diff.rkt
+++ b/tui/cell-diff.rkt
@@ -1,0 +1,108 @@
+#lang racket/base
+
+;; q/tui/cell-diff.rkt — Cell-level incremental diff between two cell buffers
+;;
+;; Computes minimal deltas between two cell buffers for efficient rendering.
+;; Uses row-hash shortcut: hash each row, only deep-diff cells in changed rows.
+;; Returns list of cell-delta structs.
+
+(require racket/contract
+         racket/list
+         "cell-buffer.rkt")
+
+;; ============================================================
+;; Cell delta struct
+;; ============================================================
+
+(struct cell-delta (col row old-cell new-cell) #:transparent)
+
+;; ============================================================
+;; Row hashing — fast change detection
+;; ============================================================
+
+;; Hash a single row by XOR-ing cell data.
+;; Not cryptographically secure — just needs to detect any change.
+(define (row-hash buf row)
+  (define cols (cell-buffer-cols buf))
+  (define h (box 0))
+  (for ([c (in-range cols)])
+    (define cell (cell-buffer-ref buf c row))
+    ;; Combine char code + fg + bg + flags into a fixnum hash
+    (define ch (char->integer (cell-char cell)))
+    (define v
+      (bitwise-xor ch
+                   (arithmetic-shift (cell-fg cell) 8)
+                   (arithmetic-shift (cell-bg cell) 16)
+                   (if (cell-bold? cell) 1 0)
+                   (if (cell-underline? cell) 2 0)
+                   (if (cell-italic? cell) 4 0)
+                   (if (cell-blink? cell) 8 0)))
+    (set-box! h (bitwise-xor (unbox h) v)))
+  (unbox h))
+
+;; ============================================================
+;; Cell diff — main algorithm
+;; ============================================================
+
+;; Compute cell-level diff between two cell buffers.
+;; Returns list of cell-delta structs for changed cells.
+;; Optimization: skip rows with matching hashes.
+(define (diff-cell-buffers prev curr)
+  (cond
+    ;; No previous buffer — full diff (all cells changed)
+    [(not prev)
+     (define cols (cell-buffer-cols curr))
+     (define rows (cell-buffer-rows curr))
+     (for*/list ([r (in-range rows)]
+                 [c (in-range cols)])
+       (cell-delta c r #f (cell-buffer-ref curr c r)))]
+    ;; Different dimensions — full diff
+    [(or (not (= (cell-buffer-cols prev) (cell-buffer-cols curr)))
+         (not (= (cell-buffer-rows prev) (cell-buffer-rows curr))))
+     (define cols (cell-buffer-cols curr))
+     (define rows (cell-buffer-rows curr))
+     (for*/list ([r (in-range rows)]
+                 [c (in-range cols)])
+       (define old-cell
+         (if (and (< c (cell-buffer-cols prev)) (< r (cell-buffer-rows prev)))
+             (cell-buffer-ref prev c r)
+             #f))
+       (cell-delta c r old-cell (cell-buffer-ref curr c r)))]
+    [else
+     ;; Same dimensions — incremental diff with row-hash shortcut
+     (define cols (cell-buffer-cols curr))
+     (define rows (cell-buffer-rows curr))
+     (apply append
+            (for/list ([r (in-range rows)]
+                       #:when (not (= (row-hash prev r) (row-hash curr r))))
+              ;; Row changed — diff individual cells
+              (for/list ([c (in-range cols)]
+                         #:unless (cell-equal? (cell-buffer-ref prev c r) (cell-buffer-ref curr c r)))
+                (cell-delta c r (cell-buffer-ref prev c r) (cell-buffer-ref curr c r)))))]))
+
+;; ============================================================
+;; Delta statistics
+;; ============================================================
+
+;; Count changed rows in a delta list
+(define (delta-changed-rows deltas)
+  (length (remove-duplicates (map cell-delta-row deltas))))
+
+;; Count total changed cells
+(define (delta-count deltas)
+  (length deltas))
+
+;; Check if delta represents a full redraw
+(define (delta-full-redraw? deltas cols rows)
+  (= (length deltas) (* cols rows)))
+
+;; ============================================================
+;; Contracts and exports
+;; ============================================================
+
+(provide (struct-out cell-delta)
+         diff-cell-buffers
+         row-hash
+         delta-changed-rows
+         delta-count
+         delta-full-redraw?)


### PR DESCRIPTION
## Summary
- Created `tui/cell-diff.rkt` — computes delta between two cell buffers
- Uses row-hash shortcut: XOR-based hash per row, only deep-diffs cells in changed rows
- Returns `cell-delta` structs (col, row, old-cell, new-cell)
- Handles: identical buffers (empty), #f prev (full), different dimensions (full), incremental
- Statistics: `delta-changed-rows`, `delta-count`, `delta-full-redraw?`

## Tests
- `tests/test-cell-diff.rkt` — 15 test cases covering row hashing, identical/single/multi-cell changes, attribute detection, statistics