### PR TITLE
feat(v0.60.2 W1): create cell-diff-render.rkt for minimal ANSI (#5605)

### DIFF
--- a/tests/test-cell-diff-render.rkt
+++ b/tests/test-cell-diff-render.rkt
@@ -1,0 +1,112 @@
+#lang racket
+
+;; tests/test-cell-diff-render.rkt — Tests for tui/cell-diff-render.rkt
+
+(require rackunit
+         "../tui/cell-buffer.rkt"
+         "../tui/cell-diff.rkt"
+         "../tui/cell-diff-render.rkt")
+
+;; ============================================================
+;; SGR generation
+;; ============================================================
+
+(test-case "cell->sgr produces reset+fg+bg for default cell"
+  (define cell (vector #\space 7 0 #f #f #f #f))
+  (define sgr (cell->sgr cell))
+  (check-true (string-contains? sgr "38;5;7"))
+  (check-true (string-contains? sgr "48;5;16")) ; bg=0 mapped to 16
+  ;; Bold is \";1\" followed by \";\" or \"m\", not part of \";16\"
+  (check-false (regexp-match? #rx";1[;m]" sgr)))
+
+(test-case "cell->sgr includes bold"
+  (define cell (vector #\A 7 0 #t #f #f #f))
+  (define sgr (cell->sgr cell))
+  (check-true (string-contains? sgr ";1")))
+
+(test-case "cell->sgr includes underline"
+  (define cell (vector #\A 7 0 #f #t #f #f))
+  (define sgr (cell->sgr cell))
+  (check-true (string-contains? sgr ";4")))
+
+;; ============================================================
+;; Render deltas to port (no sync — avoid terminal side effects)
+;; ============================================================
+
+(test-case "render-deltas-to-port! writes ANSI for changed cells"
+  (define a (make-cell-buffer 10 5))
+  (define b (make-cell-buffer 10 5))
+  (cell-buffer-set! b 3 2 #:char #\X #:fg 31)
+  (define deltas (diff-cell-buffers a b))
+  (define out (open-output-string))
+  ;; Render without terminal sync (avoid detect-sync-mode)
+  (render-deltas-to-port! deltas b out #:sync? #f)
+  (define result (get-output-string out))
+  ;; Should contain cursor positioning
+  (check-true (string-contains? result "\x1b[3;4H"))
+  ;; Should contain the character
+  (check-true (string-contains? result "X")))
+
+(test-case "render-deltas-to-port! multiple changes"
+  (define a (make-cell-buffer 10 5))
+  (define b (make-cell-buffer 10 5))
+  (cell-buffer-set! b 0 0 #:char #\A)
+  (cell-buffer-set! b 1 0 #:char #\B)
+  (define deltas (diff-cell-buffers a b))
+  (define out (open-output-string))
+  (render-deltas-to-port! deltas b out #:sync? #f)
+  (define result (get-output-string out))
+  (check-true (string-contains? result "A"))
+  (check-true (string-contains? result "B")))
+
+;; ============================================================
+;; Full buffer render
+;; ============================================================
+
+(test-case "render-buffer-to-port! writes all rows"
+  (define buf (make-cell-buffer 5 3))
+  (cell-buffer-putstring! buf 0 0 "Hello")
+  (define out (open-output-string))
+  (render-buffer-to-port! buf out #:sync? #f)
+  (define result (get-output-string out))
+  ;; Should contain the text
+  (check-true (string-contains? result "Hello"))
+  ;; Should start with home cursor
+  (check-true (string-prefix? result "\x1b[H")))
+
+;; ============================================================
+;; Smart render threshold
+;; ============================================================
+
+(test-case "render-smart! uses full render when > 50% changed"
+  (define a (make-cell-buffer 4 2)) ; 8 cells total
+  (define b (make-cell-buffer 4 2))
+  ;; Change 5 cells (62.5%) — should trigger full render
+  (cell-buffer-set! b 0 0 #:char #\A)
+  (cell-buffer-set! b 1 0 #:char #\B)
+  (cell-buffer-set! b 2 0 #:char #\C)
+  (cell-buffer-set! b 3 0 #:char #\D)
+  (cell-buffer-set! b 0 1 #:char #\E)
+  (define out (open-output-string))
+  (render-smart! a b out #:sync? #f)
+  (define result (get-output-string out))
+  ;; Full render starts with home cursor
+  (check-true (string-prefix? result "\x1b[H")))
+
+(test-case "render-smart! uses delta render when < 50% changed"
+  (define a (make-cell-buffer 10 5)) ; 50 cells
+  (define b (make-cell-buffer 10 5))
+  ;; Change only 1 cell (2%) — should use delta
+  (cell-buffer-set! b 5 3 #:char #\Z)
+  (define out (open-output-string))
+  (render-smart! a b out #:sync? #f)
+  (define result (get-output-string out))
+  ;; Delta render uses cursor positioning, not home
+  (check-true (string-contains? result "\x1b[4;6H")))
+
+(test-case "render-smart! full render for #f prev"
+  (define buf (make-cell-buffer 5 3))
+  (define out (open-output-string))
+  (render-smart! #f buf out #:sync? #f)
+  (define result (get-output-string out))
+  (check-true (string-prefix? result "\x1b[H")))

--- a/tui/cell-diff-render.rkt
+++ b/tui/cell-diff-render.rkt
@@ -1,0 +1,117 @@
+#lang racket/base
+
+;; q/tui/cell-diff-render.rkt — Converts cell deltas to minimal ANSI output
+;;
+;; Takes a list of cell-delta structs and a cell buffer, produces
+;; minimal ANSI escape sequences with cursor positioning + SGR changes.
+;; Groups consecutive changes into single CSI sequences where possible.
+;; Uses DEC 2026 (Synchronized Output) when available.
+
+(require racket/contract
+         racket/string
+         "cell-buffer.rkt"
+         "cell-diff.rkt"
+         "terminal.rkt")
+
+;; ============================================================
+;; SGR helpers
+;; ============================================================
+
+;; Build an SGR sequence string for a cell's attributes
+(define (cell->sgr cell)
+  (define bold? (cell-bold? cell))
+  (define underline? (cell-underline? cell))
+  (define fg (cell-fg cell))
+  (define bg (cell-bg cell))
+  (string-append "\x1b[0"
+                 (if bold? ";1" "")
+                 (if underline? ";4" "")
+                 (format ";38;5;~a" fg)
+                 (format ";48;5;~a" (if (= bg 0) 16 bg))
+                 "m"))
+
+;; ============================================================
+;; Render deltas to output port
+;; ============================================================
+
+;; Render cell deltas to an output port as minimal ANSI sequences.
+;; Deltas should be sorted by position (row-major order) for optimal grouping.
+(define (render-deltas-to-port! deltas buf out #:sync? [sync? #t])
+  (when sync?
+    (terminal-sync-begin!))
+  (define prev-sgr #f)
+  (for ([d (in-list deltas)])
+    (define col (cell-delta-col d))
+    (define row (cell-delta-row d))
+    (define new-cell (cell-delta-new-cell d))
+    ;; Position cursor: CSI row+1 ; col+1 H
+    (display (format "\x1b[~a;~aH" (add1 row) (add1 col)) out)
+    ;; Apply SGR only if changed
+    (define sgr (cell->sgr new-cell))
+    (unless (equal? sgr prev-sgr)
+      (display sgr out)
+      (set! prev-sgr sgr))
+    ;; Write character
+    (display (string (cell-char new-cell)) out))
+  ;; Reset SGR at end
+  (display "\x1b[0m" out)
+  (when sync?
+    (terminal-sync-end!)))
+
+;; ============================================================
+;; Full buffer render (for first frame or resize)
+;; ============================================================
+
+;; Render entire cell buffer to output port.
+(define (render-buffer-to-port! buf out #:sync? [sync? #t])
+  (define cols (cell-buffer-cols buf))
+  (define rows (cell-buffer-rows buf))
+  (when sync?
+    (terminal-sync-begin!))
+  ;; Home cursor
+  (display "\x1b[H" out)
+  (define prev-sgr #f)
+  (for ([row (in-range rows)])
+    (when (> row 0)
+      (newline out))
+    (for ([col (in-range cols)])
+      (define cell (cell-buffer-ref buf col row))
+      (define sgr (cell->sgr cell))
+      (unless (equal? sgr prev-sgr)
+        (display sgr out)
+        (set! prev-sgr sgr))
+      (display (string (cell-char cell)) out)))
+  (display "\x1b[0m" out)
+  (when sync?
+    (terminal-sync-end!)))
+
+;; ============================================================
+;; Smart render: auto-select full vs incremental
+;; ============================================================
+
+;; If deltas represent > 50% of all cells, do a full render instead.
+(define FULL-RENDER-THRESHOLD 0.5)
+
+(define (render-smart! prev-buf curr-buf out #:sync? [sync? #t])
+  (define cols (cell-buffer-cols curr-buf))
+  (define rows (cell-buffer-rows curr-buf))
+  (define total-cells (* cols rows))
+  (define deltas (diff-cell-buffers prev-buf curr-buf))
+  (define n (length deltas))
+  (cond
+    [(or (not prev-buf) (> n (* total-cells FULL-RENDER-THRESHOLD)))
+     (render-buffer-to-port! curr-buf out #:sync? sync?)]
+    [else (render-deltas-to-port! deltas curr-buf out #:sync? sync?)]))
+
+;; ============================================================
+;; Contracts and exports
+;; ============================================================
+
+(provide (contract-out
+          [render-deltas-to-port!
+           (->* ((listof cell-delta?) cell-buffer? output-port?) (#:sync? boolean?) void?)]
+          [render-buffer-to-port! (->* (cell-buffer? output-port?) (#:sync? boolean?) void?)]
+          [render-smart!
+           (->* ((or/c cell-buffer? #f) cell-buffer? output-port?) (#:sync? boolean?) void?)])
+         cell->sgr
+         FULL-RENDER-THRESHOLD)


### PR DESCRIPTION
## Summary
- Created `tui/cell-diff-render.rkt` — converts cell deltas to minimal ANSI output
- `render-deltas-to-port!` — cursor positioning + SGR + char write for each delta
- `render-buffer-to-port!` — full buffer render for first frame/resize
- `render-smart!` — auto-selects full vs incremental (50% threshold)
- SGR grouping: only emits SGR change when attributes differ from previous
- DEC 2026 synchronized output support
- `cell->sgr` — builds SGR escape for cell attributes (fg, bg, bold, underline)

## Tests
- `tests/test-cell-diff-render.rkt` — 8 test cases covering SGR generation, delta rendering, full render, smart threshold