### PR TITLE
feat(v0.60.3 W0): create vdom.rkt with vnode types (#5609)

### DIFF
--- a/tests/test-vdom.rkt
+++ b/tests/test-vdom.rkt
@@ -1,0 +1,136 @@
+#lang racket
+
+;; tests/test-vdom.rkt — Tests for tui/vdom.rkt
+
+(require rackunit
+         "../tui/vdom.rkt")
+
+;; ============================================================
+;; Constructors
+;; ============================================================
+
+(test-case "vtext constructs with text and style"
+  (define v (vtext "Hello" '(bold)))
+  (check-equal? (vtext-text v) "Hello")
+  (check-equal? (vtext-style v) '(bold)))
+
+(test-case "vtext* convenience constructor"
+  (define v (vtext* "World" 'bold 'red))
+  (check-equal? (vtext-text v) "World")
+  (check-equal? (vtext-style v) '(bold red)))
+
+(test-case "vhbox constructs with children"
+  (define v (vhbox (list (vtext "A" '()) (vtext "B" '()))))
+  (check-equal? (length (vhbox-children v)) 2))
+
+(test-case "vvbox constructs with children"
+  (define v (vvbox (list (vtext "Line1" '()) (vtext "Line2" '()))))
+  (check-equal? (length (vvbox-children v)) 2))
+
+(test-case "vfill constructs with width"
+  (define v (vfill 10 #\space '()))
+  (check-equal? (vfill-width v) 10)
+  (check-equal? (vfill-char v) #\space))
+
+(test-case "vfill* convenience constructor"
+  (define v (vfill* 5))
+  (check-equal? (vfill-width v) 5)
+  (check-equal? (vfill-char v) #\space))
+
+(test-case "voverlay constructs with content and anchor"
+  (define v (voverlay (vtext "overlay" '()) (vtext "base" '()) 2 3))
+  (check-equal? (voverlay-col v) 2)
+  (check-equal? (voverlay-row v) 3))
+
+;; ============================================================
+;; vnode? predicate
+;; ============================================================
+
+(test-case "vnode? recognizes all vnode types"
+  (check-true (vnode? (vtext "x" '())))
+  (check-true (vnode? (vhbox '())))
+  (check-true (vnode? (vvbox '())))
+  (check-true (vnode? (vfill 5 #\space '())))
+  (check-true (vnode? (voverlay (vtext "a" '()) (vtext "b" '()) 0 0))))
+
+(test-case "vnode? rejects non-vnodes"
+  (check-false (vnode? "string"))
+  (check-false (vnode? 42))
+  (check-false (vnode? '()))
+  (check-false (vnode? (hash))))
+
+;; ============================================================
+;; vnode-text-length
+;; ============================================================
+
+(test-case "vnode-text-length for vtext"
+  (check-equal? (vnode-text-length (vtext "Hello" '())) 5))
+
+(test-case "vnode-text-length for vhbox sums children"
+  (define v (vhbox (list (vtext "AB" '()) (vtext "CD" '()))))
+  (check-equal? (vnode-text-length v) 4))
+
+(test-case "vnode-text-length for vvbox takes max"
+  (define v (vvbox (list (vtext "Short" '()) (vtext "Longer" '()))))
+  (check-equal? (vnode-text-length v) 6))
+
+(test-case "vnode-text-length for vfill returns width"
+  (check-equal? (vnode-text-length (vfill 20 #\space '())) 20))
+
+(test-case "vnode-text-length for empty vhbox"
+  (check-equal? (vnode-text-length (vhbox '())) 0))
+
+;; ============================================================
+;; vnode-height
+;; ============================================================
+
+(test-case "vnode-height for vtext is 1"
+  (check-equal? (vnode-height (vtext "x" '())) 1))
+
+(test-case "vnode-height for vvbox sums children"
+  (define v (vvbox (list (vtext "A" '()) (vtext "B" '()) (vtext "C" '()))))
+  (check-equal? (vnode-height v) 3))
+
+(test-case "vnode-height for vhbox takes max"
+  (define v (vhbox (list (vtext "A" '()) (vvbox (list (vtext "B" '()) (vtext "C" '()))))))
+  (check-equal? (vnode-height v) 2))
+
+(test-case "vnode-height for vfill is 1"
+  (check-equal? (vnode-height (vfill 5 #\space '())) 1))
+
+;; ============================================================
+;; vnode-map-text
+;; ============================================================
+
+(test-case "vnode-map-text transforms text nodes"
+  (define tree (vhbox (list (vtext "hello" '()) (vtext "world" '()))))
+  (define mapped
+    (vnode-map-text (lambda (v) (vtext (string-upcase (vtext-text v)) (vtext-style v))) tree))
+  (check-equal? (vtext-text (car (vhbox-children mapped))) "HELLO")
+  (check-equal? (vtext-text (cadr (vhbox-children mapped))) "WORLD"))
+
+(test-case "vnode-map-text preserves structure"
+  (define tree (vvbox (list (vhbox (list (vtext "x" '()))))))
+  (define mapped (vnode-map-text identity tree))
+  (check-equal? tree mapped))
+
+(test-case "vnode-map-text handles voverlay"
+  (define tree (voverlay (vtext "over" '()) (vtext "base" '()) 0 0))
+  (define mapped
+    (vnode-map-text (lambda (v) (vtext (string-append "!" (vtext-text v)) (vtext-style v))) tree))
+  (check-equal? (vtext-text (voverlay-content mapped)) "!over")
+  (check-equal? (vtext-text (voverlay-anchor mapped)) "!base"))
+
+;; ============================================================
+;; Nested structures
+;; ============================================================
+
+(test-case "deeply nested vnode tree"
+  (define tree
+    (vvbox (list (vhbox (list (vtext "Header" '(bold)) (vfill* 10) (vtext "Time" '())))
+                 (vtext "Body line 1" '())
+                 (vtext "Body line 2" '())
+                 (voverlay (vtext "popup" '(inverse)) (vtext "behind" '()) 5 2))))
+  (check-true (vnode? tree))
+  (check-equal? (vnode-height tree) 4)
+  (check-true (> (vnode-text-length tree) 0)))

--- a/tui/vdom.rkt
+++ b/tui/vdom.rkt
@@ -1,0 +1,144 @@
+#lang racket/base
+
+;; q/tui/vdom.rkt — Virtual DOM data types
+;;
+;; Pure data structs representing terminal UI elements. No rendering logic.
+;; The vdom layer sits between state/components and the cell-buffer renderer.
+;;
+;; vnode types:
+;;   vtext   — styled text segment
+;;   vhbox   — horizontal concatenation of children
+;;   vvbox   — vertical stacking of children
+;;   vfill   — horizontal padding/spacing
+;;   voverlay — layered content with anchor positioning
+;;
+;; Layout engine (vdom-layout.rkt) converts vnodes → styled-line list.
+;; Render engine (vdom-render.rkt) converts styled-lines → cell-buffer writes.
+
+(require racket/contract
+         racket/list)
+
+;; ============================================================
+;; Style type — same model as styled-segment
+;; ============================================================
+
+;; Styles are (listof symbol): 'bold 'italic 'inverse 'underline 'dim
+;;   'red 'green 'yellow 'blue 'cyan 'magenta 'white
+
+;; ============================================================
+;; vnode types
+;; ============================================================
+
+;; Styled text node
+(struct vtext
+        (text ; string
+         style ; (listof symbol) — styling attributes
+         )
+  #:transparent)
+
+;; Horizontal box — children laid out left to right
+(struct vhbox
+        (children ; (listof vnode?)
+         )
+  #:transparent)
+
+;; Vertical box — children laid out top to bottom
+(struct vvbox
+        (children ; (listof vnode?)
+         )
+  #:transparent)
+
+;; Horizontal fill — padding to a given width
+(struct vfill
+        (width ; exact-nonnegative-integer?
+         char ; char (default #\space)
+         style ; (listof symbol)
+         )
+  #:transparent)
+
+;; Overlay — one child rendered on top of another at an anchor point
+(struct voverlay
+        (content ; vnode?
+         anchor ; vnode?
+         col ; exact-nonnegative-integer? — x offset
+         row ; exact-nonnegative-integer? — y offset
+         )
+  #:transparent)
+
+;; ============================================================
+;; Predicates
+;; ============================================================
+
+(define (vnode? v)
+  (or (vtext? v) (vhbox? v) (vvbox? v) (vfill? v) (voverlay? v)))
+
+;; ============================================================
+;; Convenience constructors
+;; ============================================================
+
+(define (vtext* text . styles)
+  (vtext text styles))
+
+(define (vfill* width [char #\space])
+  (vfill width char '()))
+
+;; ============================================================
+;; Tree operations
+;; ============================================================
+
+;; Count the total text length of a vnode tree
+(define (vnode-text-length v)
+  (cond
+    [(vtext? v) (string-length (vtext-text v))]
+    [(vhbox? v) (apply + (map vnode-text-length (vhbox-children v)))]
+    [(vvbox? v)
+     (define children (vvbox-children v))
+     (if (null? children)
+         0
+         (apply max (map vnode-text-length children)))]
+    [(vfill? v) (vfill-width v)]
+    [(voverlay? v) (vnode-text-length (voverlay-anchor v))]
+    [else 0]))
+
+;; Count the height (lines) of a vnode tree
+(define (vnode-height v)
+  (cond
+    [(vtext? v) 1]
+    [(vhbox? v)
+     (if (null? (vhbox-children v))
+         0
+         (apply max (map vnode-height (vhbox-children v))))]
+    [(vvbox? v) (apply + (map vnode-height (vvbox-children v)))]
+    [(vfill? v) 1]
+    [(voverlay? v) (max (vnode-height (voverlay-content v)) (vnode-height (voverlay-anchor v)))]
+    [else 0]))
+
+;; Map over all vtext nodes in tree
+(define (vnode-map-text f v)
+  (cond
+    [(vtext? v) (f v)]
+    [(vhbox? v) (vhbox (map (lambda (c) (vnode-map-text f c)) (vhbox-children v)))]
+    [(vvbox? v) (vvbox (map (lambda (c) (vnode-map-text f c)) (vvbox-children v)))]
+    [(vfill? v) v]
+    [(voverlay? v)
+     (voverlay (vnode-map-text f (voverlay-content v))
+               (vnode-map-text f (voverlay-anchor v))
+               (voverlay-col v)
+               (voverlay-row v))]
+    [else v]))
+
+;; ============================================================
+;; Contracts and exports
+;; ============================================================
+
+(provide (struct-out vtext)
+         (struct-out vhbox)
+         (struct-out vvbox)
+         (struct-out vfill)
+         (struct-out voverlay)
+         vnode?
+         vtext*
+         vfill*
+         vnode-text-length
+         vnode-height
+         vnode-map-text)


### PR DESCRIPTION
## Summary
- Created `tui/vdom.rkt` — pure data structs for Virtual DOM layer
- 5 vnode types: `vtext` (styled text), `vhbox` (horizontal), `vvbox` (vertical), `vfill` (padding), `voverlay` (layered)
- Tree operations: `vnode-text-length`, `vnode-height`, `vnode-map-text`
- Convenience constructors: `vtext*`, `vfill*`
- Predicate: `vnode?` recognizes all vnode types
- Style model matches existing `styled-segment` (listof symbol)

## Tests
- `tests/test-vdom.rkt` — 20 test cases covering constructors, predicates, tree operations, nested structures