### PR TITLE
feat(v0.60.3 W2): create vdom-render.rkt (#5611)

### DIFF
--- a/tests/test-vdom-render.rkt
+++ b/tests/test-vdom-render.rkt
@@ -1,0 +1,90 @@
+#lang racket
+
+;; tests/test-vdom-render.rkt — Tests for tui/vdom-render.rkt
+
+(require rackunit
+         "../tui/vdom.rkt"
+         "../tui/vdom-layout.rkt"
+         "../tui/vdom-render.rkt"
+         "../tui/cell-buffer.rkt"
+         "../tui/render/message-layout.rkt")
+
+;; Helper: read back a row from cell buffer as string
+(define (row-string buf row)
+  (cell-buffer-row-string buf row))
+
+;; ============================================================
+;; Render vtext to buffer
+;; ============================================================
+
+(test-case "render vtext to buffer"
+  (define buf (make-cell-buffer 20 5))
+  (render-vdom-to-buffer! (vtext "Hello" '()) buf 20)
+  (check-true (string-prefix? (row-string buf 0) "Hello")))
+
+(test-case "render vtext with style"
+  (define buf (make-cell-buffer 20 5))
+  (render-vdom-to-buffer! (vtext "Bold" '(bold)) buf 20)
+  ;; Check the character is there
+  (define cell (cell-buffer-ref buf 0 0))
+  (check-equal? (cell-char cell) #\B)
+  (check-true (cell-bold? cell)))
+
+;; ============================================================
+;; Render vhbox to buffer
+;; ============================================================
+
+(test-case "render vhbox to buffer"
+  (define buf (make-cell-buffer 20 5))
+  (render-vdom-to-buffer! (vhbox (list (vtext "AB" '()) (vtext "CD" '()))) buf 20)
+  (check-true (string-prefix? (row-string buf 0) "ABCD")))
+
+;; ============================================================
+;; Render vvbox to buffer
+;; ============================================================
+
+(test-case "render vvbox to buffer"
+  (define buf (make-cell-buffer 20 5))
+  (render-vdom-to-buffer! (vvbox (list (vtext "Line1" '()) (vtext "Line2" '()))) buf 20)
+  (check-true (string-prefix? (row-string buf 0) "Line1"))
+  (check-true (string-prefix? (row-string buf 1) "Line2")))
+
+;; ============================================================
+;; Render styled-lines directly
+;; ============================================================
+
+(test-case "render-styled-lines-to-buffer!"
+  (define buf (make-cell-buffer 20 5))
+  (define lines (list (styled-line (list (styled-segment "Test" '(bold))))))
+  (render-styled-lines-to-buffer! lines buf 20)
+  (check-true (string-prefix? (row-string buf 0) "Test"))
+  (check-true (cell-bold? (cell-buffer-ref buf 0 0))))
+
+(test-case "render-styled-lines with start-row"
+  (define buf (make-cell-buffer 20 5))
+  (define lines (list (styled-line (list (styled-segment "Row2" '())))))
+  (render-styled-lines-to-buffer! lines buf 20 #:start-row 2)
+  (check-true (string-prefix? (row-string buf 2) "Row2")))
+
+;; ============================================================
+;; Truncation
+;; ============================================================
+
+(test-case "truncate long text to buffer width"
+  (define buf (make-cell-buffer 5 3))
+  (render-vdom-to-buffer! (vtext "Hello World" '()) buf 5)
+  (check-true (string-prefix? (row-string buf 0) "Hello")))
+
+;; ============================================================
+;; Complex tree
+;; ============================================================
+
+(test-case "render complex vnode tree"
+  (define tree
+    (vvbox (list (vhbox (list (vtext "Header" '(bold)) (vfill* 5) (vtext "End" '())))
+                 (vtext "Body" '()))))
+  (define buf (make-cell-buffer 30 5))
+  (render-vdom-to-buffer! tree buf 30)
+  (check-true (string-contains? (row-string buf 0) "Header"))
+  (check-true (string-contains? (row-string buf 0) "End"))
+  (check-true (string-prefix? (row-string buf 1) "Body")))

--- a/tui/vdom-render.rkt
+++ b/tui/vdom-render.rkt
@@ -1,0 +1,95 @@
+#lang racket/base
+
+;; q/tui/vdom-render.rkt — VDOM render engine
+;;
+;; Converts styled-lines (from vdom-layout) to cell-buffer writes.
+;; This replaces the direct draw-styled-line! calls in renderer.rkt
+;; when using the vdom pipeline.
+;;
+;; Pipeline: vnode → vdom-layout → styled-lines → vdom-render → cell-buffer
+
+(require racket/contract
+         racket/string
+         "vdom.rkt"
+         "vdom-layout.rkt"
+         "cell-buffer.rkt"
+         "render/message-layout.rkt"
+         "renderer.rkt"
+         "char-width.rkt")
+
+;; ============================================================
+;; Render styled-lines to cell buffer
+;; ============================================================
+
+;; Render a list of styled-lines to the cell buffer starting at row 0.
+;; Each line is one row. Lines are padded to width with spaces.
+(define (render-styled-lines-to-buffer! lines buf width #:start-row [start-row 0])
+  (for ([line (in-list lines)]
+        [row-offset (in-naturals)])
+    (render-styled-line-to-buffer! line buf width (+ start-row row-offset))))
+
+;; Render a single styled-line to the cell buffer at the given row.
+(define (render-styled-line-to-buffer! line buf width row)
+  (define cols (cell-buffer-cols buf))
+  (define effective-width (min width cols))
+  (define col 0)
+  (define remaining-width effective-width)
+  (for ([seg (in-list (styled-line-segments line))])
+    #:break (<= remaining-width 0)
+    (define text (string-replace (styled-segment-text seg) "\n" " "))
+    (define styles (styled-segment-style seg))
+    ;; Truncate text to remaining width
+    (define visible-text
+      (if (> (string-visible-width text) remaining-width)
+          (truncate-to-visible-width text remaining-width)
+          text))
+    (when (and (> (string-length visible-text) 0) (< col cols))
+      ;; Apply styles to cell-buffer via putstring with style keywords
+      (define-values (kws vals) (style->ubuf-kws styles))
+      (keyword-apply cell-buffer-putstring! kws vals (list buf col row visible-text)))
+    (set! col (+ col (string-visible-width visible-text)))
+    (set! remaining-width (- remaining-width (string-visible-width visible-text))))
+  ;; Pad remaining width with spaces (clear rest of line)
+  (when (> remaining-width 0)
+    (cell-buffer-putstring! buf col row (make-string remaining-width #\space))))
+
+;; Truncate text to fit within given visible width
+(define (truncate-to-visible-width text max-width)
+  (define len (string-length text))
+  (let loop ([i 0]
+             [width 0])
+    (cond
+      [(>= i len) text]
+      [(>= width max-width) (substring text 0 i)]
+      [else
+       (define ch (string-ref text i))
+       (define cw (char-width ch))
+       (if (> (+ width cw) max-width)
+           (substring text 0 i)
+           (loop (add1 i) (+ width cw)))])))
+
+;; ============================================================
+;; Full pipeline: vnode → cell-buffer
+;; ============================================================
+
+;; Render a vnode tree directly to a cell buffer.
+(define (render-vdom-to-buffer! v buf width #:start-row [start-row 0])
+  (define lines (vdom-layout v width))
+  (render-styled-lines-to-buffer! lines buf width #:start-row start-row))
+
+;; ============================================================
+;; Contracts and exports
+;; ============================================================
+
+(provide (contract-out
+          [render-styled-lines-to-buffer!
+           (->* ((listof styled-line?) cell-buffer? exact-nonnegative-integer?)
+                (#:start-row exact-nonnegative-integer?)
+                void?)]
+          [render-styled-line-to-buffer!
+           (-> styled-line? cell-buffer? exact-nonnegative-integer? exact-nonnegative-integer? void?)]
+          [render-vdom-to-buffer!
+           (->* (vnode? cell-buffer? exact-nonnegative-integer?)
+                (#:start-row exact-nonnegative-integer?)
+                void?)])
+         truncate-to-visible-width)


### PR DESCRIPTION
## Summary
- Created `tui/vdom-render.rkt` — converts styled-lines to cell-buffer writes
- `render-styled-lines-to-buffer!` — render line list with start-row offset
- `render-styled-line-to-buffer!` — single line with style→cell attribute mapping
- `render-vdom-to-buffer!` — full pipeline: vnode → layout → buffer
- Handles style symbol → fg/bg/bold/underline mapping via `style->ubuf-kws`
- Width-truncation with visible-width awareness (CJK support)

## Tests
- `tests/test-vdom-render.rkt` — 8 test cases covering vtext, vhbox, vvbox, styled-lines, truncation, complex tree