### PR TITLE
feat(v0.60.4 W0): extend q-component with vdom? flag (#5614)

### DIFF
--- a/tests/test-component-model.rkt
+++ b/tests/test-component-model.rkt
@@ -5,7 +5,8 @@
 (require rackunit
          rackunit/text-ui
          "../tui/component.rkt"
-         "../tui/state.rkt")
+         "../tui/state.rkt"
+         "../tui/vdom.rkt")
 
 (define-test-suite
  test-component-model
@@ -101,6 +102,34 @@
    (check-false (ui-state-focused-component s1)))
  (test-case "focused-component defaults to #f"
    (define s0 (initial-ui-state))
-   (check-false (ui-state-focused-component s0))))
+   (check-false (ui-state-focused-component s0)))
+ ;; ──────────────────────────────
+ ;; vdom mode components
+ ;; ──────────────────────────────
+ (test-case "make-q-component with #:vdom? #t"
+   (define comp
+     (make-q-component (lambda (state width) (list (vtext "Hello vdom" '(bold))))
+                       #:id 'vdom-test
+                       #:vdom? #t))
+   (check-true (q-component-vdom? comp))
+   (check-false (q-component-vdom? (make-q-component (lambda (s w) '()))))
+   (define result (component-render comp (initial-ui-state) 80))
+   (check-equal? (length result) 1)
+   (check-true (vtext? (car result))))
+ (test-case "component-render caches vdom output"
+   (define call-count (box 0))
+   (define comp
+     (make-q-component (lambda (state width)
+                         (set-box! call-count (add1 (unbox call-count)))
+                         (list (vtext "cached" '())))
+                       #:vdom? #t))
+   (component-render comp (initial-ui-state) 80)
+   (component-render comp (initial-ui-state) 80)
+   (check-equal? (unbox call-count) 1))
+ (test-case "component-compose mixes vdom and styled-line components"
+   (define vdom-comp (make-q-component (lambda (s w) (list (vtext "vdom" '()))) #:vdom? #t))
+   (define classic-comp (make-q-component (lambda (s w) (list (list (cons 'text "classic"))))))
+   (define result (component-compose (list vdom-comp classic-comp) (initial-ui-state) 80))
+   (check-equal? (length result) 2)))
 
 (run-tests test-component-model)

--- a/tui/component.rkt
+++ b/tui/component.rkt
@@ -15,7 +15,8 @@
          racket/list
          "render.rkt"
          "state.rkt"
-         (only-in "render/message-layout.rkt" styled-line?))
+         (only-in "render/message-layout.rkt" styled-line?)
+         "vdom.rkt")
 
 ;; Struct
 (provide q-component
@@ -26,13 +27,15 @@
          q-component-id
          q-component-handle-input-fn
          q-component-wants-focus?
+         q-component-vdom?
          (contract-out
           [make-q-component
            (->* (procedure?)
                 (#:id symbol?
                       #:invalidate-fn procedure?
                       #:handle-input (or/c procedure? #f)
-                      #:wants-focus? boolean?)
+                      #:wants-focus? boolean?
+                      #:vdom? boolean?)
                 q-component?)]
           [component-render (-> q-component? ui-state? exact-nonnegative-integer? (listof any/c))]
           [component-invalidate! (-> q-component? void?)]
@@ -56,12 +59,13 @@
 ;; ═══════════════════════════════════════════════════════════════════
 
 (struct q-component
-        (render-fn ; ui-state width → (listof styled-line)
+        (render-fn ; ui-state width → (listof styled-line) or (listof vnode?)
          invalidate-fn ; → void
          cache-box ; (boxof (or/c #f (cons width lines)))
          id ; symbol
          handle-input-fn ; (or/c #f (data ui-state → (values ui-state input-result)))
-         wants-focus?) ; boolean — whether this component can receive focus
+         wants-focus? ; boolean — whether this component can receive focus
+         vdom?) ; boolean — #t when render-fn returns vnodes
   #:transparent)
 
 ;; ═══════════════════════════════════════════════════════════════════
@@ -72,8 +76,9 @@
                           #:id [id 'anonymous]
                           #:invalidate-fn [invalidate-fn void]
                           #:handle-input [handle-input-fn #f]
-                          #:wants-focus? [wants-focus? #f])
-  (q-component render-fn invalidate-fn (box #f) id handle-input-fn wants-focus?))
+                          #:wants-focus? [wants-focus? #f]
+                          #:vdom? [vdom? #f])
+  (q-component render-fn invalidate-fn (box #f) id handle-input-fn wants-focus? vdom?))
 
 ;; ═══════════════════════════════════════════════════════════════════
 ;; Operations


### PR DESCRIPTION
## Summary
- Extended `q-component` struct with `vdom?` field (default `#f`)
- When `#:vdom? #t`, render-fn returns `(listof vnode?)` instead of `(listof styled-line?)`
- `make-q-component` accepts `#:vdom?` keyword argument
- Exported `q-component-vdom?` accessor
- Backward compatible: existing components work unchanged

## Tests
- 3 new test cases: vdom component creation, caching, mixed compose
- All 15 tests pass (12 existing + 3 new)