### PR TITLE
refactor(v0.60.5 W0): remove dead tui-term code (#5618)

### DIFF
--- a/tests/test-terminal-native.rkt
+++ b/tests/test-terminal-native.rkt
@@ -11,11 +11,6 @@
          "../tui/terminal-native.rkt")
 
 ;; ============================================================
-;; tui-term-available? is always #f (native-only)
-;; ============================================================
-
-(test-case "tui-term-available? is #f (native-only)"
-  (check-false tui-term-available?))
 
 ;; ============================================================
 ;; make-tty-term returns a value
@@ -115,9 +110,6 @@
 ;; ============================================================
 ;; Mouse message accessors
 ;; ============================================================
-
-(test-case "tmousemsg-tui-term? is always #f"
-  (check-false (tmousemsg-tui-term? (vector 'tmousemsg 'press 10 20 #t #f #f))))
 
 (test-case "tmousemsg-kind extracts kind from vector"
   (define msg (vector 'tmousemsg 'press 10 20 #t #f #f))

--- a/tests/tui/test-mouse-bridge.rkt
+++ b/tests/tui/test-mouse-bridge.rkt
@@ -6,7 +6,7 @@
 ;;
 ;; Tests for:
 ;;   - decode-mouse-x10: X10 protocol decoding
-;;   - decode-mouse-tui-term: tui-term struct decoding (with mock)
+;;   - decode-mouse-tui-term: tui-term struct decoding (legacy) (with mock)
 ;;   - SGR mouse protocol constants in terminal.rkt
 ;;   - Error guard in handle-mouse
 ;;   - Bounds validation in selection-text
@@ -16,8 +16,8 @@
          "../../tui/input.rkt")
 
 ;; ── Helper: create a mock tui-term tmousemsg ──
-;; tui-term's tmousemsg is an actual struct, but we can't create one
-;; without tui-term loaded. We test decode-mouse-tui-term indirectly
+;; native tmousemsg is an actual struct, but we can't create one
+;; in native mode. We test decode-mouse-tui-term indirectly
 ;; by testing the X10 path and the error resilience.
 
 (define mouse-bridge-tests
@@ -65,10 +65,10 @@
     ;; Since tui-term structs aren't available in test context,
     ;; decode-mouse-tui-term should gracefully return #f for non-structs
 
-    (test-case "decode-mouse-tui-term: returns #f for non-tui-term input"
-      ;; A plain vector should not match tui-term struct predicate
-      (define result (decode-mouse-tui-term #(tmousemsg press (1 2) #t #f #f)))
-      (check-false result))
+    (test-case "decode-mouse-tui-term: decodes native vector input"
+      ;; Native vectors are decoded properly
+      (define result (decode-mouse-tui-term #(tmousemsg press 10 20 #t #f #f)))
+      (check-true (list? result)))
 
     ;; ── Edge cases ──
 

--- a/tui/renderer.rkt
+++ b/tui/renderer.rkt
@@ -3,7 +3,7 @@
 ;; tui/renderer.rkt — Terminal UI rendering engine
 ;;
 ;; Layer: TUI (interface layer)
-;; Purpose: Renders styled-lines to a tui-ubuf buffer for terminal display.
+;; Purpose: Renders styled-lines to a native cell buffer for terminal display.
 ;; Manages message layout, status line, diff rendering, and theme application.
 ;; Consumes runtime events via state-events.rkt and renders to virtual buffer.
 

--- a/tui/terminal-input.rkt
+++ b/tui/terminal-input.rkt
@@ -4,7 +4,7 @@
 ;;
 ;; Handles raw stdin input reading, ANSI escape sequence parsing,
 ;; key/mouse event generation, and UTF-8 accumulator state.
-;; These are the "real stdin" fallbacks used when tui-term is unavailable.
+;; Native terminal input handling (raw mode, ANSI decoding).
 ;;
 ;; Extracted from terminal.rkt for separation of concerns.
 

--- a/tui/terminal-native.rkt
+++ b/tui/terminal-native.rkt
@@ -42,7 +42,6 @@
          tcmdmsg-cmd
 
          ;; Mouse message accessors
-         tmousemsg-tui-term?
          tmousemsg-kind
          tmousemsg-pos-x
          tmousemsg-pos-y
@@ -50,19 +49,13 @@
          tmousemsg-middle?
          tmousemsg-right?
 
-         ;; Legacy compat (always #f — no tui-term)
-         tui-term-available?
          read-msg-fn
          byte-ready-fn)
 
 ;; ============================================================
-;; Compatibility constants (always native, no tui-term)
+;; Compatibility (native-only, no external packages)
 ;; ============================================================
 
-;; Always #f — tui-term is never used
-(define tui-term-available? #f)
-
-;; No tui-term message functions available
 (define read-msg-fn #f)
 (define byte-ready-fn #f)
 
@@ -160,11 +153,6 @@
 ;; Mouse message accessors (native)
 ;; ============================================================
 ;; Native mouse messages are vectors: #(tmousemsg kind x y left? middle? right?)
-;; tui-term struct-based mouse messages are no longer supported.
-
-(define (tmousemsg-tui-term? msg)
-  ;; Always #f — no tui-term structs in native mode
-  #f)
 
 (define (tmousemsg-kind msg)
   (if (and (vector? msg) (> (vector-length msg) 1) (eq? (vector-ref msg 0) 'tmousemsg))

--- a/tui/terminal.rkt
+++ b/tui/terminal.rkt
@@ -105,7 +105,6 @@
          tmousemsg-cx
          tmousemsg-cy
          ;; Mouse events — native vector accessors
-         tmousemsg-tui-term?
          tmousemsg-kind
          tmousemsg-pos-x
          tmousemsg-pos-y

--- a/tui/tui-render-loop.rkt
+++ b/tui/tui-render-loop.rkt
@@ -67,7 +67,7 @@
          (all-from-out "submit-handler.rkt"))
 
 ;; ============================================================
-;; Cell buffer (native — replaces tui-ubuf)
+;; Cell buffer (native)
 ;; ============================================================
 
 ;; Minimum render interval in milliseconds.


### PR DESCRIPTION
## Summary
- Removed dead `tmousemsg-tui-term?` (always returned #f) from terminal-native.rkt and terminal.rkt
- Removed `tui-term-available?` constant (always #f) from terminal-native.rkt
- Cleaned up legacy tui-term/tui-ubuf comments across 5 source files
- Updated test expectations to match native-only behavior
- Fixed mouse bridge test that expected #f for native vectors

## Dead code removed
- `tmousemsg-tui-term?` function (always #f)
- `tui-term-available?` constant (always #f)
- Two test cases for removed functions