### PR TITLE
feat(v0.61.1 W0): production TranscriptComponent using render-transcript (#5649)

Upgrade make-transcript-vdom-component from placeholder to production:
- Uses render-transcript to get styled-lines, converts to vnode trees
- Adds styled-lines->vnodes and styled-line->vnode helper functions
- 7 new tests: entry rendering, empty state, segment conversion, cell buffer output
- All 19 component tests pass.

### DIFF
--- a/tests/test-vdom-components.rkt
+++ b/tests/test-vdom-components.rkt
@@ -9,7 +9,9 @@
          "../tui/vdom-components.rkt"
          "../tui/component.rkt"
          "../tui/cell-buffer.rkt"
-         "../tui/state.rkt")
+         "../tui/state.rkt"
+         "../tui/state-types.rkt"
+         "../tui/render/message-layout.rkt")
 
 ;; ============================================================
 ;; Component construction
@@ -111,5 +113,66 @@
   (define buf (make-cell-buffer 80 10))
   (render-vdom-to-buffer! (vvbox vnodes) buf 80)
   ;; Should have content in at least row 0
+  (define row0 (cell-buffer-row-string buf 0))
+  (check-true (> (string-length (string-trim row0)) 0)))
+
+;; ============================================================
+;; Production TranscriptComponent tests
+;; ============================================================
+
+(test-case "production transcript renders entries as vnodes"
+  (define st0 (initial-ui-state))
+  (define st1 (add-transcript-entry st0 (transcript-entry 'user "Hello" 0 (hash) #f)))
+  (define st2 (add-transcript-entry st1 (transcript-entry 'assistant "Hi there!" 0 (hash) #f)))
+  (define comp (make-transcript-vdom-component))
+  (define result (component-render comp st2 80))
+  (check-true (andmap vnode? result))
+  ;; Should have multiple rows (user + assistant entries)
+  (check-true (> (length result) 0)))
+
+(test-case "production transcript with empty state returns vnodes"
+  (define comp (make-transcript-vdom-component))
+  (define result (component-render comp (initial-ui-state) 80))
+  (check-true (andmap vnode? result)))
+
+(test-case "styled-line->vnode converts single segment"
+  (define sl (styled-line (list (styled-segment "Hello" '(bold)))))
+  (define v (styled-line->vnode sl))
+  (check-true (vhbox? v))
+  (define children (vhbox-children v))
+  (check-equal? (length children) 1)
+  (check-equal? (vtext-text (car children)) "Hello")
+  (check-equal? (vtext-style (car children)) '(bold)))
+
+(test-case "styled-line->vnode converts multi-segment line"
+  (define sl (styled-line (list (styled-segment "Hello " '()) (styled-segment "World" '(bold)))))
+  (define v (styled-line->vnode sl))
+  (check-true (vhbox? v))
+  (define children (vhbox-children v))
+  (check-equal? (length children) 2)
+  (check-equal? (vtext-text (car children)) "Hello ")
+  (check-equal? (vtext-style (cadr children)) '(bold)))
+
+(test-case "styled-line->vnode handles empty segments"
+  (define sl (styled-line '()))
+  (define v (styled-line->vnode sl))
+  (check-true (vhbox? v)))
+
+(test-case "styled-lines->vnodes converts list"
+  (define lines
+    (list (styled-line (list (styled-segment "Line 1" '())))
+          (styled-line (list (styled-segment "Line 2" '(bold))))))
+  (define vnodes (styled-lines->vnodes lines))
+  (check-equal? (length vnodes) 2)
+  (check-true (andmap vhbox? vnodes)))
+
+(test-case "production transcript renders to cell buffer"
+  (define st0 (initial-ui-state))
+  (define st1 (add-transcript-entry st0 (transcript-entry 'user "Test message" 0 (hash) #f)))
+  (define comp (make-transcript-vdom-component))
+  (define vnodes (component-render comp st1 80))
+  (define buf (make-cell-buffer 80 10))
+  (render-vdom-to-buffer! (vvbox vnodes) buf 80)
+  ;; Should have content in at least one row
   (define row0 (cell-buffer-row-string buf 0))
   (check-true (> (string-length (string-trim row0)) 0)))

--- a/tui/vdom-components.rkt
+++ b/tui/vdom-components.rkt
@@ -9,11 +9,13 @@
 
 (require racket/contract
          racket/string
+         racket/list
          "vdom.rkt"
          "vdom-layout.rkt"
          "component.rkt"
          "state.rkt"
          "render/message-layout.rkt"
+         "render/diff-render.rkt"
          "palette.rkt")
 
 ;; ============================================================
@@ -22,11 +24,30 @@
 
 (define (make-transcript-vdom-component)
   (make-q-component (lambda (st width)
-                      ;; For now, return a placeholder vvbox.
-                      ;; Full implementation will iterate messages and build vnodes.
-                      (list (vtext "Transcript" '(dim))))
+                      ;; Production: use render-transcript to get styled-lines, convert to vnodes.
+                      ;; transcript-height is a large value; the caller clips to visible area.
+                      (define-values (styled-lines _st) (render-transcript st 1000 width))
+                      (define vnodes (styled-lines->vnodes styled-lines))
+                      vnodes)
                     #:id 'transcript-vdom
                     #:vdom? #t))
+
+;; Convert styled-lines to a list of vnode rows (one vhbox per line).
+(define (styled-lines->vnodes lines)
+  (for/list ([line (in-list lines)])
+    (styled-line->vnode line)))
+
+;; Convert a single styled-line to a vhbox of vtext segments.
+(define (styled-line->vnode line)
+  (define segs (styled-line-segments line))
+  (cond
+    [(null? segs) (vhbox (list (vtext "" '())))]
+    [(= (length segs) 1)
+     (define seg (car segs))
+     (vhbox (list (vtext (styled-segment-text seg) (styled-segment-style seg))))]
+    [else
+     (vhbox (for/list ([seg (in-list segs)])
+              (vtext (styled-segment-text seg) (styled-segment-style seg))))]))
 
 ;; ============================================================
 ;; Status bar component — renders model info, status line
@@ -122,6 +143,8 @@
 ;; ============================================================
 
 (provide (contract-out [make-transcript-vdom-component (-> q-component?)]
+                       [styled-lines->vnodes (-> (listof styled-line?) (listof vnode?))]
+                       [styled-line->vnode (-> styled-line? vnode?)]
                        [make-status-bar-vdom-component (-> q-component?)]
                        [make-input-box-vdom-component (-> q-component?)]
                        [make-header-vdom-component (-> q-component?)]


### PR DESCRIPTION
Addresses #5649.

feat(v0.61.1 W0): production TranscriptComponent using render-transcript (#5649)

Upgrade make-transcript-vdom-component from placeholder to production:
- Uses render-transcript to get styled-lines, converts to vnode trees
- Adds styled-lines->vnodes and styled-line->vnode helper functions
- 7 new tests: entry rendering, empty state, segment conversion, cell buffer output
- All 19 component tests pass.