### PR TITLE
feat(v0.61.1 W1): production StatusBarComponent using render-status-bar (#5650)

Upgrade make-status-bar-vdom-component to use render-status-bar from
status-line.rkt. Full status info: model name, session label, busy state,
context pressure, cost, scroll indicator. 3 new tests. All 22 pass.

### DIFF
--- a/tests/test-vdom-components.rkt
+++ b/tests/test-vdom-components.rkt
@@ -27,6 +27,30 @@
   (check-true (q-component-vdom? comp))
   (check-equal? (q-component-id comp) 'status-bar-vdom))
 
+(test-case "production status bar renders model name"
+  (define st (initial-ui-state #:model-name "gpt-4o"))
+  (define comp (make-status-bar-vdom-component))
+  (define result (component-render comp st 80))
+  (check-true (andmap vnode? result))
+  (check-equal? (length result) 1))
+
+(test-case "production status bar renders session label"
+  (define st (initial-ui-state #:session-id "test-sess" #:model-name "gpt-4o"))
+  (define comp (make-status-bar-vdom-component))
+  (define result (component-render comp st 80))
+  (check-true (andmap vnode? result))
+  (define v (car result))
+  (check-true (vhbox? v)))
+
+(test-case "production status bar renders to cell buffer"
+  (define st (initial-ui-state #:model-name "gpt-4o"))
+  (define comp (make-status-bar-vdom-component))
+  (define vnodes (component-render comp st 80))
+  (define buf (make-cell-buffer 80 1))
+  (render-vdom-to-buffer! (vvbox vnodes) buf 80)
+  (define row0 (cell-buffer-row-string buf 0))
+  (check-true (> (string-length (string-trim row0)) 0)))
+
 (test-case "input box component is vdom"
   (define comp (make-input-box-vdom-component))
   (check-true (q-component-vdom? comp))

--- a/tui/vdom-components.rkt
+++ b/tui/vdom-components.rkt
@@ -16,6 +16,7 @@
          "state.rkt"
          "render/message-layout.rkt"
          "render/diff-render.rkt"
+         "render/status-line.rkt"
          "palette.rkt")
 
 ;; ============================================================
@@ -54,15 +55,12 @@
 ;; ============================================================
 
 (define (make-status-bar-vdom-component)
-  (make-q-component
-   (lambda (st width)
-     (define model-name (or (ui-state-model-name st) "no-model"))
-     (define mode (ui-state-mode st))
-     (define status-text (format " ~a | ~a " model-name mode))
-     (define fill-w (max 0 (- width (string-length status-text) 1)))
-     (list (vhbox (list (vtext status-text '(bold)) (vfill* fill-w) (vtext " " '())))))
-   #:id 'status-bar-vdom
-   #:vdom? #t))
+  (make-q-component (lambda (st width)
+                      ;; Production: use render-status-bar from status-line.rkt
+                      (define styled-line-result (render-status-bar st width))
+                      (list (styled-line->vnode styled-line-result)))
+                    #:id 'status-bar-vdom
+                    #:vdom? #t))
 
 ;; ============================================================
 ;; Input box component — renders the input area


### PR DESCRIPTION
Addresses #5650.

feat(v0.61.1 W1): production StatusBarComponent using render-status-bar (#5650)

Upgrade make-status-bar-vdom-component to use render-status-bar from
status-line.rkt. Full status info: model name, session label, busy state,
context pressure, cost, scroll indicator. 3 new tests. All 22 pass.