### PR TITLE
feat(v0.61.1 W3): production Header + Overlay components (#5652)

Header: upgraded to match renderer.rkt exactly — " q " with inverse style.
Overlay: production comment updates, same solid voverlay implementation.
2 new header tests. All 26 component tests pass.

### DIFF
--- a/tests/test-vdom-components.rkt
+++ b/tests/test-vdom-components.rkt
@@ -76,6 +76,24 @@
   (check-true (q-component-vdom? comp))
   (check-equal? (q-component-id comp) 'header-vdom))
 
+(test-case "production header renders inverse-style header"
+  (define comp (make-header-vdom-component))
+  (define result (component-render comp (initial-ui-state) 80))
+  (check-true (andmap vnode? result))
+  (check-true (vhbox? (car result)))
+  ;; The header should have inverse style
+  (define children (vhbox-children (car result)))
+  (check-not-false (member 'inverse (vtext-style (car children)))))
+
+(test-case "production header renders to cell buffer"
+  (define comp (make-header-vdom-component))
+  (define vnodes (component-render comp (initial-ui-state) 80))
+  (define buf (make-cell-buffer 80 1))
+  (render-vdom-to-buffer! (vvbox vnodes) buf 80)
+  (define row0 (cell-buffer-row-string buf 0))
+  ;; Should contain "q" in the header
+  (check-not-false (string-contains? row0 "q")))
+
 ;; ============================================================
 ;; Component rendering returns vnodes
 ;; ============================================================

--- a/tui/vdom-components.rkt
+++ b/tui/vdom-components.rkt
@@ -83,15 +83,13 @@
 ;; ============================================================
 
 (define (make-header-vdom-component)
-  (make-q-component
-   (lambda (st width)
-     (define version-text " q ")
-     (define right-text (format " ~a " (or (ui-state-model-name st) "")))
-     (define fill-w (max 0 (- width (string-length version-text) (string-length right-text))))
-     (list (vhbox
-            (list (vtext version-text '(bold cyan)) (vfill* fill-w) (vtext right-text '(dim))))))
-   #:id 'header-vdom
-   #:vdom? #t))
+  (make-q-component (lambda (st width)
+                      ;; Production: matches renderer.rkt header row — " q " padded to full width
+                      ;; with inverse video (fg=0 bg=7)
+                      (define header-text (format " q ~a" (make-string (max 0 (- width 3)) #\space)))
+                      (list (vhbox (list (vtext header-text '(inverse))))))
+                    #:id 'header-vdom
+                    #:vdom? #t))
 
 ;; ============================================================
 ;; Overlay component — renders a popup/dialog overlay
@@ -99,6 +97,9 @@
 
 (define (make-overlay-vdom-component content-comp #:anchor anchor-comp #:col [col 0] #:row [row 0])
   (make-q-component (lambda (st width)
+                      ;; Production: renders overlay from ui-state if active.
+                      ;; content-comp renders the overlay content,
+                      ;; anchor-comp renders the background (typically transcript).
                       (define content-vnodes ((q-component-render-fn content-comp) st width))
                       (define anchor-vnodes ((q-component-render-fn anchor-comp) st width))
                       (define content-node


### PR DESCRIPTION
Addresses #5652.

feat(v0.61.1 W3): production Header + Overlay components (#5652)

Header: upgraded to match renderer.rkt exactly — " q " with inverse style.
Overlay: production comment updates, same solid voverlay implementation.
2 new header tests. All 26 component tests pass.