### PR TITLE
feat(v0.61.1 W4): extract render-header-line and render-overlay-lines (#5653)

Extract inline header and overlay rendering from renderer.rkt into
standalone functions returning styled-lines:
- render-header-line(cols) → inverse styled-line
- render-overlay-lines(overlay, height) → (listof styled-line?)

4 new tests. Both old and new render paths can now call the same
section functions.

### DIFF
--- a/tests/test-tui-renderer.rkt
+++ b/tests/test-tui-renderer.rkt
@@ -715,7 +715,40 @@
             (make-test-event "model.stream.thinking" (hasheq 'delta "thinking"))
             (make-test-event "model.stream.completed" (hasheq))))
     (define state (simulate-events s0 events))
-    (check-false (ui-state-streaming-thinking state))))
+    (check-false (ui-state-streaming-thinking state)))
+
+  ;; ============================================================
+  ;; Extracted section functions
+  ;; ============================================================
+
+  (test-case "render-header-line returns inverse styled-line"
+    (define line (render-header-line 80))
+    (check-true (styled-line? line))
+    (define segs (styled-line-segments line))
+    (check-true (not (null? segs)))
+    ;; Should have inverse style
+    (define styles (styled-segment-style (car segs)))
+    (check-not-false (member 'inverse styles))
+    ;; Text should contain "q"
+    (check-not-false (string-contains? (styled-segment-text (car segs)) "q")))
+
+  (test-case "render-header-line width matches cols"
+    (define line (render-header-line 40))
+    (define text (styled-line->text line))
+    (check-equal? (string-length text) 40))
+
+  (test-case "render-overlay-lines returns empty for #f"
+    (check-equal? (render-overlay-lines #f 10) '()))
+
+  (test-case "render-overlay-lines clips to transcript height"
+    (define ov (overlay-state 'test
+                              (list (plain-line "Line 1")
+                                    (plain-line "Line 2")
+                                    (plain-line "Line 3")
+                                    (plain-line "Line 4"))
+                              #f #f #f #f #f #f))
+    (define lines (render-overlay-lines ov 2))
+    (check-equal? (length lines) 2)))
 
 ;; ============================================================
 ;; Run tests

--- a/tui/renderer.rkt
+++ b/tui/renderer.rkt
@@ -36,6 +36,9 @@
 
 ;; Main rendering function
 (provide (contract-out
+          [render-header-line (-> exact-nonnegative-integer? styled-line?)]
+          [render-overlay-lines
+           (-> (or/c #f overlay-state?) exact-nonnegative-integer? (listof styled-line?))]
           [render-frame!
            (-> any/c
                ui-state?
@@ -257,6 +260,23 @@
 ;; Side effect: Modifies ubuf contents.
 ;; Returns: (values cursor-col cursor-row ui-state frame-lines)
 ;;   frame-lines is (listof string) — plain text for each row, for diffing
+;; Render header line as a styled-line.
+;; Returns a single styled-line with inverse style.
+(define (render-header-line cols)
+  (define header-text (format " q ~a" (make-string (max 0 (- cols 3)) #\space)))
+  (styled-line (list (styled-segment header-text '(inverse)))))
+
+;; Render overlay lines from overlay-state, clipped to transcript height.
+;; Returns (listof styled-line?) ready for drawing.
+(define (render-overlay-lines overlay transcript-height)
+  (if (not overlay)
+      '()
+      (let* ([ov-content (overlay-state-content overlay)]
+             [ov-lines (if (> (length ov-content) transcript-height)
+                           (take-right ov-content transcript-height)
+                           ov-content)])
+        ov-lines)))
+
 (define (render-frame! ubuf ui-state input-st layout)
   (define header-region (layout-header layout))
   (define transcript-region (layout-transcript layout))


### PR DESCRIPTION
Addresses #5653.

feat(v0.61.1 W4): extract render-header-line and render-overlay-lines (#5653)

Extract inline header and overlay rendering from renderer.rkt into
standalone functions returning styled-lines:
- render-header-line(cols) → inverse styled-line
- render-overlay-lines(overlay, height) → (listof styled-line?)

4 new tests. Both old and new render paths can now call the same
section functions.