### PR TITLE
perf(v0.61.2 W0): batch consecutive cell writes in cell-diff-render (#5655)

Optimize render-deltas-to-port! to batch consecutive changed cells in
the same row with the same SGR into a single cursor move + string write.
A 200-char streaming line now uses 1 cursor move instead of 200.

5 new batch tests verifying: consecutive batching, gap splitting,
SGR-boundary splitting, row-boundary splitting, 200-char single batch.
All 14 cell-diff-render tests pass.

### DIFF
--- a/tests/test-cell-diff-render.rkt
+++ b/tests/test-cell-diff-render.rkt
@@ -110,3 +110,94 @@
   (render-smart! #f buf out #:sync? #f)
   (define result (get-output-string out))
   (check-true (string-contains? result "\x1b[H")))
+
+;; ============================================================
+;; Batch optimization tests
+;; ============================================================
+
+(test-case "batch: consecutive cells emit single cursor move"
+  (define a (make-cell-buffer 10 1))
+  (define b (make-cell-buffer 10 1))
+  ;; Write 5 consecutive chars starting at col 0
+  (cell-buffer-set! b 0 0 #:char #\H #:fg 7)
+  (cell-buffer-set! b 1 0 #:char #\e #:fg 7)
+  (cell-buffer-set! b 2 0 #:char #\l #:fg 7)
+  (cell-buffer-set! b 3 0 #:char #\l #:fg 7)
+  (cell-buffer-set! b 4 0 #:char #\o #:fg 7)
+  (define deltas (diff-cell-buffers a b))
+  (check-equal? (length deltas) 5)
+  (define out (open-output-string))
+  (render-deltas-to-port! deltas b out #:sync? #f)
+  (define result (get-output-string out))
+  ;; Should contain "Hello" as a single string (batched)
+  (check-true (string-contains? result "Hello"))
+  ;; Should have exactly 1 cursor move, not 5
+  (define cursor-re (format "~a\\[[0-9]+;[0-9]+H" (integer->char 27)))
+  (define cursor-moves (regexp-match* (regexp cursor-re) result))
+  (check-equal? (length cursor-moves) 1))
+
+(test-case "batch: non-consecutive cells use separate cursor moves"
+  (define a (make-cell-buffer 10 1))
+  (define b (make-cell-buffer 10 1))
+  ;; Write chars at col 0 and col 5 (gap at cols 1-4)
+  (cell-buffer-set! b 0 0 #:char #\A #:fg 7)
+  (cell-buffer-set! b 5 0 #:char #\B #:fg 7)
+  (define deltas (diff-cell-buffers a b))
+  (define out (open-output-string))
+  (render-deltas-to-port! deltas b out #:sync? #f)
+  (define result (get-output-string out))
+  ;; Should have 2 cursor moves (not batched across gap)
+  (define cursor-re (format "~a\\[[0-9]+;[0-9]+H" (integer->char 27)))
+  (define cursor-moves (regexp-match* (regexp cursor-re) result))
+  (check-equal? (length cursor-moves) 2))
+
+(test-case "batch: different SGR breaks batch"
+  (define a (make-cell-buffer 10 1))
+  (define b (make-cell-buffer 10 1))
+  ;; Same row, consecutive cols, but different fg color
+  (cell-buffer-set! b 0 0 #:char #\A #:fg 7)
+  (cell-buffer-set! b 1 0 #:char #\B #:fg 31) ; different fg
+  (cell-buffer-set! b 2 0 #:char #\C #:fg 7)
+  (define deltas (diff-cell-buffers a b))
+  (define out (open-output-string))
+  (render-deltas-to-port! deltas b out #:sync? #f)
+  (define result (get-output-string out))
+  ;; Should have 3 cursor moves: A alone (col 0), B alone (col 1, diff SGR), C (col 2, new batch)
+  (define cursor-re (format "~a\\[[0-9]+;[0-9]+H" (integer->char 27)))
+  (define cursor-moves (regexp-match* (regexp cursor-re) result))
+  (check-equal? (length cursor-moves) 3))
+
+(test-case "batch: different rows use separate cursor moves"
+  (define a (make-cell-buffer 5 3))
+  (define b (make-cell-buffer 5 3))
+  ;; Write consecutive chars across rows
+  (cell-buffer-set! b 0 0 #:char #\A #:fg 7)
+  (cell-buffer-set! b 1 0 #:char #\B #:fg 7)
+  (cell-buffer-set! b 0 1 #:char #\C #:fg 7) ; different row
+  (cell-buffer-set! b 1 1 #:char #\D #:fg 7)
+  (define deltas (diff-cell-buffers a b))
+  (define out (open-output-string))
+  (render-deltas-to-port! deltas b out #:sync? #f)
+  (define result (get-output-string out))
+  ;; Should have 2 cursor moves: one for row 0 (AB), one for row 1 (CD)
+  (define cursor-re (format "~a\\[[0-9]+;[0-9]+H" (integer->char 27)))
+  (define cursor-moves (regexp-match* (regexp cursor-re) result))
+  (check-equal? (length cursor-moves) 2)
+  ;; Should contain both batched strings
+  (check-true (string-contains? result "AB"))
+  (check-true (string-contains? result "CD")))
+
+(test-case "batch: 200-char line uses single cursor move"
+  (define a (make-cell-buffer 200 1))
+  (define b (make-cell-buffer 200 1))
+  (for ([i (in-range 200)])
+    (cell-buffer-set! b i 0 #:char (integer->char (+ 65 (modulo i 26))) #:fg 7))
+  (define deltas (diff-cell-buffers a b))
+  (check-equal? (length deltas) 200)
+  (define out (open-output-string))
+  (render-deltas-to-port! deltas b out #:sync? #f)
+  (define result (get-output-string out))
+  ;; Should have exactly 1 cursor move for all 200 cells
+  (define cursor-re (format "~a\\[[0-9]+;[0-9]+H" (integer->char 27)))
+  (define cursor-moves (regexp-match* (regexp cursor-re) result))
+  (check-equal? (length cursor-moves) 1))

--- a/tui/cell-diff-render.rkt
+++ b/tui/cell-diff-render.rkt
@@ -40,19 +40,46 @@
   (when sync?
     (terminal-sync-begin!))
   (define prev-sgr #f)
-  (for ([d (in-list deltas)])
-    (define col (cell-delta-col d))
-    (define row (cell-delta-row d))
-    (define new-cell (cell-delta-new-cell d))
-    ;; Position cursor: CSI row+1 ; col+1 H
-    (display (format "\x1b[~a;~aH" (add1 row) (add1 col)) out)
-    ;; Apply SGR only if changed
-    (define sgr (cell->sgr new-cell))
-    (unless (equal? sgr prev-sgr)
-      (display sgr out)
-      (set! prev-sgr sgr))
-    ;; Write character
-    (display (string (cell-char new-cell)) out))
+  ;; Batch consecutive deltas in same row with same SGR into one cursor move + string
+  (let loop ([remaining deltas])
+    (cond
+      [(null? remaining) (void)]
+      [else
+       (define d (car remaining))
+       (define col (cell-delta-col d))
+       (define row (cell-delta-row d))
+       (define new-cell (cell-delta-new-cell d))
+       (define sgr (cell->sgr new-cell))
+       ;; Position cursor: CSI row+1 ; col+1 H
+       (display (format "\x1b[~a;~aH" (add1 row) (add1 col)) out)
+       ;; Apply SGR only if changed
+       (unless (equal? sgr prev-sgr)
+         (display sgr out)
+         (set! prev-sgr sgr))
+       ;; Collect consecutive cells in same row with same SGR
+       (define chars (list (cell-char new-cell)))
+       (let gather ([rest (cdr remaining)]
+                    [acc chars]
+                    [next-col (add1 col)])
+         (cond
+           [(null? rest)
+            ;; Emit batch
+            (display (list->string (reverse acc)) out)
+            (loop rest)]
+           [else
+            (define nd (car rest))
+            (define nd-col (cell-delta-col nd))
+            (define nd-row (cell-delta-row nd))
+            (define nd-cell (cell-delta-new-cell nd))
+            (define nd-sgr (cell->sgr nd-cell))
+            (cond
+              [(and (= nd-row row) (= nd-col next-col) (equal? nd-sgr sgr))
+               ;; Same row, consecutive column, same style — batch
+               (gather (cdr rest) (cons (cell-char nd-cell) acc) (add1 next-col))]
+              [else
+               ;; Batch ends — emit accumulated chars
+               (display (list->string (reverse acc)) out)
+               (loop rest)])]))]))
   ;; Reset SGR at end
   (display "\x1b[0m" out)
   (when sync?


### PR DESCRIPTION
Addresses #5655.

perf(v0.61.2 W0): batch consecutive cell writes in cell-diff-render (#5655)

Optimize render-deltas-to-port! to batch consecutive changed cells in
the same row with the same SGR into a single cursor move + string write.
A 200-char streaming line now uses 1 cursor move instead of 200.

5 new batch tests verifying: consecutive batching, gap splitting,
SGR-boundary splitting, row-boundary splitting, 200-char single batch.
All 14 cell-diff-render tests pass.