### PR TITLE
refactor(v0.61.3 W0): remove legacy render path — vdom+cell-diff only (#5659)

Remove dual-path rendering from tui-render-loop.rkt:
- Remove use-cell-diff? parameter (cell-diff always used)
- Remove row-level diff fallback (frame-diff, frame-vec)
- Remove vdom-bridge import (now inlined)
- render-frame-vdom! is now the sole render path
- use-vdom-render? defaults to #t (backward compat kept)
- 2 new tests verifying legacy removal

All 22 render-loop tests pass.

### DIFF
--- a/tests/test-tui-render-loop.rkt
+++ b/tests/test-tui-render-loop.rkt
@@ -16,7 +16,11 @@
          "../tui/terminal.rkt"
          "../tui/cell-buffer.rkt"
          "../tui/cell-diff.rkt"
-         "../tui/cell-diff-render.rkt")
+         "../tui/cell-diff-render.rkt"
+         "../tui/state.rkt"
+         "../tui/input.rkt"
+         "../tui/layout.rkt"
+         "../tui/vdom-bridge.rkt")
 
 (define test-tui-render-loop
   (test-suite "tui/tui-render-loop"
@@ -153,6 +157,26 @@
       (render-smart! snap prev out #:sync? #t)
       (define output (get-output-string out))
       (check-true (> (string-length output) 0) "should produce output")
-      (check-not-false (string-contains? output "B") "should contain new character"))))
+      (check-not-false (string-contains? output "B") "should contain new character"))
+
+    ;; ============================================================
+    ;; Legacy path removal tests
+    ;; ============================================================
+
+    (test-case "render-frame-vdom! is the only render path"
+      ;; Verify render-frame-vdom! works correctly as sole render path
+      (define ubuf (make-cell-buffer 80 24))
+      (define st (initial-ui-state))
+      (define inp (initial-input-state))
+      (define layout (compute-layout 24 80))
+      (define-values (cursor-col cursor-row st* frame-lines) (render-frame-vdom! ubuf st inp layout))
+      (check-true (exact-nonnegative-integer? cursor-col))
+      (check-true (exact-nonnegative-integer? cursor-row))
+      (check-true (ui-state? st*))
+      ;; frame-lines is now always empty (legacy removed)
+      (check-equal? frame-lines '()))
+
+    (test-case "use-vdom-render? defaults to #t"
+      (check-true (use-vdom-render?)))))
 
 (run-tests test-tui-render-loop)

--- a/tests/test-vdom-bridge.rkt
+++ b/tests/test-vdom-bridge.rkt
@@ -82,9 +82,9 @@
 ;; use-vdom-render? parameter
 ;; ============================================================
 
-(test-case "use-vdom-render? parameter default is #f"
-  (check-false (use-vdom-render?)))
+(test-case "use-vdom-render? parameter default is #t"
+  (check-true (use-vdom-render?)))
 
 (test-case "use-vdom-render? can be set"
-  (parameterize ([use-vdom-render? #t])
-    (check-true (use-vdom-render?))))
+  (parameterize ([use-vdom-render? #f])
+    (check-false (use-vdom-render?))))

--- a/tui/tui-render-loop.rkt
+++ b/tui/tui-render-loop.rkt
@@ -28,11 +28,9 @@
          "../tui/sgr.rkt"
          (prefix-in renderer: "../tui/renderer.rkt")
          "../tui/layout.rkt"
-         "../tui/frame-diff.rkt"
          "../tui/cell-buffer.rkt"
          "../tui/cell-diff.rkt"
          "../tui/cell-diff-render.rkt"
-         "../tui/vdom-bridge.rkt"
          "../tui/vdom-render.rkt"
          (only-in "../tui/render.rkt"
                   render-transcript
@@ -62,7 +60,6 @@
 (provide fix-sgr-bg-black
          decode-mouse-x10
          decode-mouse-tui-term
-         use-cell-diff?
          current-busy-watchdog-ms
          (contract-out [check-busy-watchdog (-> any/c number? number? (or/c any/c #f))]
                        [render-ubuf-to-terminal! (-> tui-ctx? void?)]
@@ -95,9 +92,6 @@
 ;; Coalesces rapid state changes (e.g., streaming) into single frames.
 ;; 16ms ≈ 60fps, prevents flicker during fast streaming output.
 (define MIN-RENDER-INTERVAL-MS 16)
-
-;; Render mode: #t = cell-level diffing, #f = row-level frame diffing
-(define use-cell-diff? (make-parameter #t))
 
 ;; Track last render timestamp for debouncing.
 (define last-render-ms (box 0.0))
@@ -290,19 +284,10 @@
       #:break (>= i transcript-height)
       (render-styled-line-to-buffer! line ubuf cols (+ transcript-start-row i))))
 
-  ;; 8. Build frame-lines for row-level diffing fallback
-  (define frame-vec (make-vector rows ""))
-  ;; Build simplified frame-lines (plain text) for row-diff compatibility
-  (for ([r (in-range rows)])
-    (define line-strs
-      (for/list ([c (in-range cols)])
-        (string (cell-char (cell-buffer-ref ubuf c r)))))
-    (vector-set! frame-vec r (string-join line-strs "")))
-
-  ;; 9. Return cursor position
+  ;; 8. Return cursor position
   (define-values (_visible-text _scroll-offset cursor-display-col)
     (input-visible-window input-st cols))
-  (values cursor-display-col input-y ui-state* (vector->list frame-vec)))
+  (values cursor-display-col input-y ui-state* '()))
 
 (define (render-frame! ctx)
   (define state (unbox (tui-ctx-ui-state-box ctx)))
@@ -318,46 +303,20 @@
                     #:widget-bar-h (length widget-lines)
                     #:has-widgets? (positive? (length widget-lines))))
 
-  ;; Render to ubuf — choose path based on use-vdom-render?
+  ;; Render to ubuf — always use vdom path
   (define-values (cursor-col cursor-row state* frame-lines)
-    (if (use-vdom-render?)
-        (render-frame-vdom! ubuf state inp layout)
-        (renderer:render-frame! ubuf state inp layout)))
+    (render-frame-vdom! ubuf state inp layout))
 
   ;; Write back state with updated render cache
   (set-box! (tui-ctx-ui-state-box ctx) state*)
 
-  ;; Diff-based terminal output
+  ;; Cell-level incremental diff (always)
   (tui-cursor-hide)
-  (if (use-cell-diff?)
-      ;; Cell-level incremental diff
-      (let ()
-        (define prev-ubuf (unbox (tui-ctx-prev-ubuf-box ctx)))
-        (define out (tui-output-port))
-        (render-smart! prev-ubuf ubuf out #:sync? #t)
-        ;; Store snapshot for next diff
-        (set-box! (tui-ctx-prev-ubuf-box ctx) (cell-buffer-snapshot ubuf)))
-      ;; Row-level frame diff (fallback)
-      (let ()
-        (define prev-frame (unbox (tui-ctx-previous-frame-box ctx)))
-        (define diffs (diff-frames prev-frame frame-lines))
-        (cond
-          [(null? diffs) (void)]
-          [(and (= (length diffs) 1) (eq? (diff-cmd-type (car diffs)) 'full))
-           (render-ubuf-to-terminal! ctx)]
-          [else
-           (for ([cmd (in-list diffs)])
-             (case (diff-cmd-type cmd)
-               [(write)
-                (tui-cursor 1 (+ (diff-cmd-row cmd) 1))
-                (display "\x1b[2K" (tui-output-port))
-                (display (fix-sgr-bg-black (diff-cmd-content cmd)) (tui-output-port))]
-               [(clear-from)
-                (tui-cursor 1 (+ (diff-cmd-row cmd) 1))
-                (display "\x1b[J" (tui-output-port))]
-               [else (void)]))
-           (tui-flush)])
-        (set-box! (tui-ctx-previous-frame-box ctx) frame-lines)))
+  (define prev-ubuf (unbox (tui-ctx-prev-ubuf-box ctx)))
+  (define out (tui-output-port))
+  (render-smart! prev-ubuf ubuf out #:sync? #t)
+  ;; Store snapshot for next diff
+  (set-box! (tui-ctx-prev-ubuf-box ctx) (cell-buffer-snapshot ubuf))
 
   ;; Position cursor at input location (renderer returns 0-indexed, ANSI is 1-indexed)
   (tui-cursor (+ cursor-col 1) (+ cursor-row 1))

--- a/tui/vdom-bridge.rkt
+++ b/tui/vdom-bridge.rkt
@@ -16,8 +16,9 @@
          "cell-buffer.rkt"
          "render/message-layout.rkt")
 
-;; Parameter to switch between vdom and direct rendering
-(define use-vdom-render? (make-parameter #f))
+;; Parameter to switch between vdom and direct rendering.
+;; Always #t now — legacy path removed in v0.61.3.
+(define use-vdom-render? (make-parameter #t))
 
 ;; ============================================================
 ;; Frame rendering via vdom


### PR DESCRIPTION
Addresses #5659.

refactor(v0.61.3 W0): remove legacy render path — vdom+cell-diff only (#5659)

Remove dual-path rendering from tui-render-loop.rkt:
- Remove use-cell-diff? parameter (cell-diff always used)
- Remove row-level diff fallback (frame-diff, frame-vec)
- Remove vdom-bridge import (now inlined)
- render-frame-vdom! is now the sole render path
- use-vdom-render? defaults to #t (backward compat kept)
- 2 new tests verifying legacy removal

All 22 render-loop tests pass.