### PR TITLE
docs(v0.61.3 W3): final cleanup — ADR-0016 update, render pipeline diagram, CHANGELOG (#5662)

- Updated ADR-0016: legacy path removed, vdom+cell-diff is sole path
- Added render pipeline diagram to docs/architecture/overview.md
- Updated CHANGELOG.md with v0.61.3 M4 series summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,26 @@
 # Changelog
+## v0.61.3 — 2026-05-27
+
+### Native TUI M4 — Remove Legacy Path + Final Cleanup
+
+**W0 — Remove legacy render path** (PR #5682)
+- Removed `use-cell-diff?` parameter — cell-diff always used
+- Removed row-level frame-diff fallback and frame-vec construction
+- `render-frame-vdom!` is now the sole render path
+- `use-vdom-render?` defaults to `#t` (kept for backward compat)
+
+**W1 — TUI smoke tests** (PR #5683)
+- New `test-tui-smoke.rkt` with 7 end-to-end tests
+- Tests full vdom render pipeline without real terminal
+
+**W2 — Component integration tests** (PR #5684)
+- New `test-vdom-component-integration.rkt` with 6 tests
+- Focus cycling, overlay wrapping, input dispatch, render roundtrip
+
+**W3 — Final cleanup** (this wave)
+- Updated ADR-0016 for final architecture
+- Added render pipeline diagram to architecture overview
+
 ## v0.61.2 — 2026-05-27
 
 ### Native TUI M3 — Cell-Diff Batch Optimization + Benchmarking

--- a/docs/adr/0016-native-tui-architecture.md
+++ b/docs/adr/0016-native-tui-architecture.md
@@ -1,7 +1,7 @@
 # ADR-0016: Native TUI Architecture
 
 ## Status
-Accepted
+Accepted — Updated for v0.61.3 (legacy path removed)
 
 ## Context
 The q TUI originally depended on two external Racket packages: `tui-term` (terminal I/O, input handling) and `tui-ubuf` (cell buffer, screen rendering). These dependencies created several problems:
@@ -49,15 +49,15 @@ Replace all external TUI dependencies with a native Racket architecture consisti
 ### Layer 6: Bridge (`tui/vdom-bridge.rkt`)
 - `render-vdom-frame!` — renders vnodes through the existing render loop
 - `styled-line->vnode` / `styled-lines->vnode` — migration helpers
-- `use-vdom-render?` parameter — toggles between vdom and direct rendering
+- `use-vdom-render?` parameter — always `#t` since v0.61.3 (legacy removed)
 
 ## Consequences
 
 ### Positive
 - **Zero external TUI dependencies**: Entire TUI stack is native Racket
-- **Better performance**: Cell-level incremental rendering (was row-level)
-- **Virtual DOM foundation**: Enables future GUI backend (M7 deferred)
-- **Cleaner code**: No `dynamic-require`, no dual code paths
+- **Better performance**: Cell-level incremental rendering with batch optimization (37% faster than per-cell)
+- **Virtual DOM is primary path**: Since v0.61.3, vdom+cell-diff is the only render path
+- **Cleaner code**: No `dynamic-require`, no dual code paths, no frame-diff fallback
 - **Easier testing**: All modules testable without external package mocking
 - **Smaller attack surface**: No dynamic loading of external packages
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -29,6 +29,31 @@ Key files: `tui/terminal-native.rkt`, `tui/cell-buffer.rkt`, `tui/cell-diff.rkt`
 `tui/cell-diff-render.rkt`, `tui/vdom.rkt`, `tui/vdom-layout.rkt`,
 `tui/vdom-render.rkt`, `tui/vdom-bridge.rkt`, `tui/vdom-components.rkt`
 
+### Render Pipeline (since v0.61.3)
+
+The TUI uses a single render path (legacy path removed in v0.61.3):
+
+```
+ui-state → render-frame-vdom!
+              ├── Header    → cell-buffer-putstring!
+              ├── Transcript → render-transcript → styled-lines → render-styled-line-to-buffer!
+              ├── Status    → render-status-bar → styled-lines → render-styled-line-to-buffer!
+              ├── Input     → render-input-line → styled-lines → render-styled-line-to-buffer!
+              └── Overlay   → overlay content → render-styled-line-to-buffer!
+         ↓
+      cell-buffer (new frame)
+         ↓
+      diff-cell-buffers (prev vs new) → deltas
+         ↓
+      render-smart! → batched ANSI output (terminal)
+```
+
+Key optimizations:
+- **Batch rendering**: Consecutive same-row/same-SGR cells → single cursor move (37% faster)
+- **SGR dedup**: Only emit SGR when attributes change
+- **Cell-diff**: XOR row hashing, smart full vs incremental threshold (50%)
+- **DECAWM**: Auto-wrap disabled during render to prevent last-column wrap glitch
+
 ## Layer Diagram
 
 ```


### PR DESCRIPTION
Addresses #5662.

docs(v0.61.3 W3): final cleanup — ADR-0016 update, render pipeline diagram, CHANGELOG (#5662)

- Updated ADR-0016: legacy path removed, vdom+cell-diff is sole path
- Added render pipeline diagram to docs/architecture/overview.md
- Updated CHANGELOG.md with v0.61.3 M4 series summary