### PR TITLE
docs(v0.61.4 W0): remove stale tui-term/tui-ubuf references (#5691)

### DIFF
--- a/.github/actions/setup-racket/action.yml
+++ b/.github/actions/setup-racket/action.yml
@@ -39,5 +39,4 @@ runs:
           echo "Installing local package from $PWD ..."
           raco pkg install --auto --batch "$PWD"
         fi
-        # Extra TUI deps (may already be installed as transitive deps)
-        raco pkg install --auto --batch tui-term tui-ubuf 2>/dev/null || true
+        # TUI uses native Racket implementations (no external deps needed)

--- a/README.md
+++ b/README.md
@@ -93,8 +93,7 @@ cd q
 # 3. Install dependencies
 raco pkg install --auto
 
-# 4. (Optional) Enhanced TUI rendering — works without these via built-in fallbacks
-raco pkg install tui-term tui-ubuf
+# 4. TUI uses native Racket (no external deps needed)
 ```
 
 See [docs/install.md](docs/install.md) for the one-command installer and detailed instructions.
@@ -275,8 +274,8 @@ q/
 | Metric | Value |
 |--------|-------|
 | Test files | 667 |
-| Source modules | 474 |
-| Source lines | 74302 |
+| Source modules | 473 |
+| Source lines | 74050 |
 | Test lines | 114148 |
 | Test assertions | 17830 |
 | Tests passing | 5835+ | `racket scripts/run-tests.rkt` results |

--- a/docs/compatibility-matrix.md
+++ b/docs/compatibility-matrix.md
@@ -44,11 +44,14 @@ extension API versions.
 | Local (llama.cpp server) | 0.24.9 | Stable |
 ## TUI Dependencies
 
-| Dependency | Min Version | Required For |
-|------------|-------------|--------------|
-| `tui-term` | 0.1 | Terminal abstraction |
-| `tui-ubuf` | 0.1 | Unicode buffer |
-| `charterm` | 1.0 | Direct terminal I/O (fallback) |
+All TUI functionality is implemented natively in Racket — no external packages required.
+
+| Component | Module | Description |
+|-----------|--------|-------------|
+| Terminal I/O | `tui/terminal-native.rkt` | ANSI sequences, raw mode, mouse |
+| Cell Buffer | `tui/cell-buffer.rkt` | 2D cell grid with style attributes |
+| Cell Diff | `tui/cell-diff.rkt`, `tui/cell-diff-render.rkt` | Incremental rendering |
+| Virtual DOM | `tui/vdom*.rkt` | vnode trees, layout, component system |
 
 ## Updating This Matrix
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -117,14 +117,11 @@ Also remove any PATH entries or aliases you added to your shell config.
 
 ## Optional: Full TUI Support
 
-For the enhanced TUI experience, install `tui-term` and `tui-ubuf`:
+The TUI uses native Racket implementations for all terminal I/O, cell buffering,
+and rendering. No external packages are required.
 
-```bash
-raco pkg install tui-term tui-ubuf
-```
-
-> **Note:** These packages have known compilation issues on Racket 8.10 (upstream bugs).
-> The TUI works without them using built-in fallbacks. This is not required for normal use.
+> **Note:** Previous versions required `tui-term` and `tui-ubuf` packages.
+> As of v0.60.0, these have been replaced by native implementations.
 
 ## Security Note
 


### PR DESCRIPTION
## Summary
- Removed `raco pkg install tui-term tui-ubuf` from CI action, README, and install.md
- Updated compatibility-matrix.md to list native TUI modules instead of external deps
- Historical references remain in ADR-0016 and install.md migration note (appropriate context)