### PR TITLE
refactor(v0.61.4 W1): rename dead-code-era names (#5692)

### DIFF
--- a/tests/test-terminal-input.rkt
+++ b/tests/test-terminal-input.rkt
@@ -195,12 +195,12 @@
     (check-equal? (vector-ref result 0) 'tkeymsg)
     (check-equal? (vector-ref result 1) 'escape)))
 
-(test-case "stub-byte-ready? works on string port"
+(test-case "default-byte-ready? works on string port"
   (define in (open-input-string ""))
   (parameterize ([current-input-port in])
     ;; char-ready? on an empty string port returns #t (EOF is ready)
     ;; This just checks the function doesn't crash
-    (check-true (boolean? (stub-byte-ready?)))))
+    (check-true (boolean? (default-byte-ready?)))))
 
 ;; ============================================================
 ;; CSI modifier handling (#422)

--- a/tests/tui/test-mouse-bridge.rkt
+++ b/tests/tui/test-mouse-bridge.rkt
@@ -6,7 +6,7 @@
 ;;
 ;; Tests for:
 ;;   - decode-mouse-x10: X10 protocol decoding
-;;   - decode-mouse-tui-term: tui-term struct decoding (legacy) (with mock)
+;;   - decode-mouse-message: native mouse message decoding
 ;;   - SGR mouse protocol constants in terminal.rkt
 ;;   - Error guard in handle-mouse
 ;;   - Bounds validation in selection-text
@@ -17,7 +17,7 @@
 
 ;; ── Helper: create a mock tui-term tmousemsg ──
 ;; native tmousemsg is an actual struct, but we can't create one
-;; in native mode. We test decode-mouse-tui-term indirectly
+;; in native mode. We test decode-mouse-message indirectly
 ;; by testing the X10 path and the error resilience.
 
 (define mouse-bridge-tests
@@ -61,13 +61,13 @@
       (define result (decode-mouse-x10 160 33 33))
       (check-equal? result '(mouse click 0 0 0)))
 
-    ;; ── decode-mouse-tui-term with mock struct ──
+    ;; ── decode-mouse-message with mock struct ──
     ;; Since tui-term structs aren't available in test context,
-    ;; decode-mouse-tui-term should gracefully return #f for non-structs
+    ;; decode-mouse-message should gracefully return #f for non-structs
 
-    (test-case "decode-mouse-tui-term: decodes native vector input"
+    (test-case "decode-mouse-message: decodes native vector input"
       ;; Native vectors are decoded properly
-      (define result (decode-mouse-tui-term #(tmousemsg press 10 20 #t #f #f)))
+      (define result (decode-mouse-message #(tmousemsg press 10 20 #t #f #f)))
       (check-true (list? result)))
 
     ;; ── Edge cases ──

--- a/tui/input.rkt
+++ b/tui/input.rkt
@@ -86,7 +86,7 @@
           ;; Mouse events
           [parse-mouse-event (-> any/c (or/c mouse-event? #f))]
           [decode-mouse-x10 (-> exact-integer? exact-integer? exact-integer? (or/c list? #f))]
-          [decode-mouse-tui-term (-> any/c (or/c list? #f))]
+          [decode-mouse-message (-> any/c (or/c list? #f))]
           ;; Selection helpers
           [normalize-selection-range
            (-> (cons/c exact-nonnegative-integer? exact-nonnegative-integer?)

--- a/tui/input/state-types.rkt
+++ b/tui/input/state-types.rkt
@@ -45,7 +45,7 @@
           ;; Mouse event support
           [parse-mouse-event (-> any/c any/c)]
           [decode-mouse-x10 (-> exact-integer? exact-integer? exact-integer? any/c)]
-          [decode-mouse-tui-term (-> any/c any/c)]
+          [decode-mouse-message (-> any/c any/c)]
           [normalize-selection-range
            (-> any/c any/c (values exact-integer? exact-integer? exact-integer? exact-integer?))]
           ;; IME cursor markers
@@ -183,8 +183,8 @@
     [(and (<= button 2) (not motion?)) (list 'mouse 'click button x y)]
     [else #f]))
 
-;; Decode a tui-term tmousemsg struct into q's internal mouse event format.
-(define (decode-mouse-tui-term msg)
+;; Decode a native tmousemsg into q's internal mouse event format.
+(define (decode-mouse-message msg)
   (with-safe-fallback #f
                       (define kind (tmousemsg-kind msg))
                       (define x (tmousemsg-pos-x msg))

--- a/tui/terminal-input.rkt
+++ b/tui/terminal-input.rkt
@@ -50,7 +50,7 @@
 
          real-stdin-read-msg
          decode-sgr-mouse
-         stub-byte-ready?
+         default-byte-ready?
          buffered-read-byte
          input-buffer-reset!
          input-buffer-length
@@ -100,10 +100,9 @@
          utf8-accumulator-length)
 
 ;; ============================================================
-;; UTF-8 support (compatibility stubs)
+;; UTF-8 support functions
 ;; ============================================================
-;; These functions were used with charterm which required manual
-;; UTF-8 handling. Provided as stubs for backward compatibility.
+;; These functions handle UTF-8 decoding for terminal input.
 
 ;; Check if a char represents a byte > 127 (UTF-8 lead or continuation)
 (define (utf8-high-byte? ch)
@@ -663,5 +662,5 @@
      (make-tkeymsg-raw (integer->char b))]
     [_ #f]))
 
-(define (stub-byte-ready?)
+(define (default-byte-ready?)
   (char-ready? (current-input-port)))

--- a/tui/terminal.rkt
+++ b/tui/terminal.rkt
@@ -147,7 +147,7 @@
 
 (define read-msg (or read-msg-fn real-stdin-read-msg))
 
-(define byte-ready? (or byte-ready-fn stub-byte-ready?))
+(define byte-ready? (or byte-ready-fn default-byte-ready?))
 
 ;; ============================================================
 ;; Lifecycle

--- a/tui/tui-render-loop.rkt
+++ b/tui/tui-render-loop.rkt
@@ -59,7 +59,7 @@
 ;; ── Ubuf/terminal lifecycle ──
 (provide fix-sgr-bg-black
          decode-mouse-x10
-         decode-mouse-tui-term
+         decode-mouse-message
          current-busy-watchdog-ms
          (contract-out [check-busy-watchdog (-> any/c number? number? (or/c any/c #f))]
                        [render-ubuf-to-terminal! (-> tui-ctx? void?)]
@@ -356,7 +356,7 @@
     ;; Resize message
     [(tsizemsg? msg) (list 'resize (tsizemsg-cols msg) (tsizemsg-rows msg))]
     ;; Mouse message — native vector dispatch
-    [(tmousemsg? msg) (decode-mouse-tui-term msg)]
+    [(tmousemsg? msg) (decode-mouse-message msg)]
     ;; Command message (redraw, etc.)
     [(tcmdmsg? msg)
      (case (tcmdmsg-cmd msg)


### PR DESCRIPTION
Addresses #5692.

refactor(v0.61.4 W1): rename decode-mouse-tui-term and stub-byte-ready (#5692)