### PR TITLE
docs(v0.61.6 W2): document legacy render-frame! usage (#5700)

### DIFF
--- a/tui/renderer.rkt
+++ b/tui/renderer.rkt
@@ -277,6 +277,9 @@
                            ov-content)])
         ov-lines)))
 
+;; Legacy frame render using frame-vec (ANSI string buffer).
+;; Used by parity tests and render integration tests.
+;; Production code uses render-frame-vdom! in tui-render-loop.rkt.
 (define (render-frame! ubuf ui-state input-st layout)
   (define header-region (layout-header layout))
   (define transcript-region (layout-transcript layout))


### PR DESCRIPTION
Addresses #5700.

docs(v0.61.6 W2): document renderer.rkt render-frame! as legacy test path (#5700)