### PR TITLE
feat(v0.61.8 W3): clean stale naming and shelfware (#5732)

### DIFF
--- a/tests/tui/test-component.rkt
+++ b/tests/tui/test-component.rkt
@@ -8,7 +8,6 @@
          rackunit/text-ui
          "../../../q/tui/component.rkt"
          "../../../q/tui/render.rkt"
-         "../../../q/tui/renderer.rkt"
          "../../../q/tui/state.rkt")
 
 (define-test-suite
@@ -158,43 +157,6 @@
    (define result (component-render status-comp state 80))
    (check-equal? (length result) 1)
    (define text (styled-line->text (car result)))
-   (check-true (string-contains? text "gpt-4")))
- ;; ──────────────────────────────
- ;; Render-components wiring (#641)
- ;; ──────────────────────────────
- (test-case "make-render-components creates transcript + status components"
-   (define comps (make-render-components))
-   ;; Test via public render functions — they should work without error
-   (define state (initial-ui-state #:model-name "test"))
-   (define status-result (render-components-status comps state 80))
-   (check-equal? (length status-result) 1)
-   (check-true (string-contains? (styled-line->text (car status-result)) "test")))
- (test-case "render-components-status returns styled lines via component"
-   (define comps (make-render-components))
-   (define state (initial-ui-state #:model-name "claude-3"))
-   (define result (render-components-status comps state 80))
-   (check-equal? (length result) 1)
-   (check-true (string-contains? (styled-line->text (car result)) "claude-3")))
- (test-case "render-components-status caches by width"
-   (define comps (make-render-components))
-   (define state (initial-ui-state #:model-name "gpt-4"))
-   ;; First call — cache miss
-   (define r1 (render-components-status comps state 80))
-   ;; Second call — cache hit (same width)
-   (define r2 (render-components-status comps state 80))
-   (check-equal? r1 r2)
-   ;; Width change — cache miss
-   (define r3 (render-components-status comps state 120))
-   (check-not-equal? (length (styled-line-segments (car r3))) 0))
- (test-case "render-components-invalidate! clears status cache"
-   (define comps (make-render-components))
-   (define state (initial-ui-state #:model-name "test"))
-   ;; Render to populate cache
-   (render-components-status comps state 80)
-   ;; Invalidate
-   (render-components-invalidate! comps)
-   ;; Re-render should work (cache cleared)
-   (define result (render-components-status comps state 80))
-   (check-equal? (length result) 1)))
+   (check-true (string-contains? text "gpt-4"))))
 
 (run-tests test-component)

--- a/tui/frame-diff.rkt
+++ b/tui/frame-diff.rkt
@@ -18,7 +18,7 @@
          )
   #:transparent)
 
-;; Convert a ubuf-style rendered frame into a list of strings (one per row)
+;; Convert a cell-buffer rendered frame into a list of strings (one per row)
 ;; This is a helper for testing. frame is a list of strings.
 (define (frame->string-lines frame)
   frame)

--- a/tui/renderer.rkt
+++ b/tui/renderer.rkt
@@ -41,16 +41,6 @@
           [render-overlay-lines
            (-> (or/c #f overlay-state?) exact-nonnegative-integer? (listof styled-line?))]
           ;; Component-based rendering
-          [make-render-components (-> render-components?)]
-          [render-components-transcript
-           (-> render-components?
-               ui-state?
-               exact-nonnegative-integer?
-               exact-nonnegative-integer?
-               (values (listof styled-line?) ui-state?))]
-          [render-components-status
-           (-> render-components? ui-state? exact-nonnegative-integer? (listof styled-line?))]
-          [render-components-invalidate! (-> render-components? void?)]
           ;; Style mapping (for testing)
           [style->ubuf-kws (-> (listof symbol?) (values (listof keyword?) list?))]
           ;; Ubuf operations (settable for testing)


### PR DESCRIPTION
Addresses #5732.

feat(v0.61.8 W3): remove shelfware render-components, clean stale naming (#5732)