### PR TITLE
fix(tui): clean stale naming and fix version drift (#5761)

- Rename test-tui-terminal.rkt suite from "TUI Terminal Adapter
  (tui-term)" to "TUI Terminal (Native)" with updated header comment
- Remove tui-ubuf references from test-tui-renderer.rkt comments
- Fix architecture overview key dispatch version (v0.62.2 → v0.62.1)

Addresses audit findings F3 and F4 from
AUDIT-v0.61.8-v0.62.x-POST-IMPLEMENTATION.md.

### DIFF
--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -58,7 +58,7 @@ Component lifecycle (since v0.62.0):
 - `component-render` uses cache (invalidates on width/state change)
 - `component-state-ref/set!` for per-component local state
 
-Key dispatch (since v0.62.2):
+Key dispatch (since v0.62.1):
 - `focused-component-id-box` on `tui-ctx` tracks which component receives keys
 - `handle-key` checks focused component first, falls back to keymap
 - Opt-in via `wants-focus? #t` + `handle-input-fn`

--- a/tests/test-tui-renderer.rkt
+++ b/tests/test-tui-renderer.rkt
@@ -22,10 +22,10 @@
 ;; ============================================================
 
 ;; A mock cell holding character and style attributes
-;; Matches tui-ubuf: fg/bg as integers, bold, underline
+;; Matches cell-buffer: fg/bg as integers, bold, underline
 (struct mock-cell (char bold underline fg bg) #:transparent #:mutable)
 
-;; Create an empty cell (default fg=7, bg=0 like tui-ubuf)
+;; Create an empty cell (default fg=7, bg=0)
 (define (make-empty-cell)
   (mock-cell #\space #f #f 7 0))
 
@@ -64,7 +64,7 @@
     (mock-ubuf-set-cell! ubuf col row #\space #f #f 7 0)))
 
 ;; Put a string to the mock ubuf
-;; Matches real tui-ubuf signature exactly:
+;; Matches cell-buffer signature exactly:
 ;;   (ubuf x y str #:fg [7] #:bg [0] #:bold [#f] #:underline [#f] #:italic [#f] #:blink [#f])
 (define (mock-ubuf-putstring! ubuf
                               col

--- a/tests/test-tui-terminal.rkt
+++ b/tests/test-tui-terminal.rkt
@@ -2,7 +2,7 @@
 
 ;; BOUNDARY: io
 
-;; test-tui-terminal.rkt — Tests for tui-term based terminal adapter
+;; test-tui-terminal.rkt — Tests for native TUI terminal adapter
 ;;
 ;; These tests verify:
 ;;   1. Terminal lifecycle functions exist and have correct signatures
@@ -28,7 +28,7 @@
 ;; ============================================================
 
 (define terminal-tests
-  (test-suite "TUI Terminal Adapter (tui-term)"
+  (test-suite "TUI Terminal (Native)"
 
     ;; ============================================================
     ;; 1. Terminal lifecycle (open/close)


### PR DESCRIPTION
Addresses #5761.

fix(tui): clean stale naming and fix version drift (#5761)

- Rename test-tui-terminal.rkt suite from "TUI Terminal Adapter
  (tui-term)" to "TUI Terminal (Native)" with updated header comment
- Remove tui-ubuf references from test-tui-renderer.rkt comments
- Fix architecture overview key dispatch version (v0.62.2 → v0.62.1)

Addresses audit findings F3 and F4 from
AUDIT-v0.61.8-v0.62.x-POST-IMPLEMENTATION.md.