### PR TITLE
feat(v0.67.0 W1): error boundary views (#5795)

### DIFF
--- a/gui/views/error-boundary.rkt
+++ b/gui/views/error-boundary.rkt
@@ -1,0 +1,35 @@
+#lang racket/base
+
+;; q/gui/views/error-boundary.rkt — Error boundary views for GUI
+;;
+;; Provides error boundary wrappers that catch rendering errors
+;; and display fallback views instead of crashing.
+
+(require racket/contract
+         "../../ui-core/theme-protocol.rkt")
+
+(provide (contract-out [render-error-fallback (->* (ui-theme?) [(or/c string? #f)] hash?)]
+                       [with-error-boundary (-> procedure? procedure? any)]))
+
+;; ──────────────────────────────
+;; Error fallback view
+;; ──────────────────────────────
+(define (render-error-fallback theme [message #f])
+  (hash 'view
+        'error-fallback
+        'type
+        'error
+        'message
+        (or message "An error occurred while rendering this view")
+        'bg
+        (theme-ref theme 'background)
+        'fg
+        (theme-ref theme 'error)))
+
+;; ──────────────────────────────
+;; Error boundary wrapper
+;; ──────────────────────────────
+(define (with-error-boundary render-fn fallback-fn)
+  (lambda args
+    (with-handlers ([exn:fail? (lambda (e) (apply fallback-fn args))])
+      (apply render-fn args))))

--- a/tests/test-gui-error-boundary.rkt
+++ b/tests/test-gui-error-boundary.rkt
@@ -1,0 +1,39 @@
+#lang racket
+
+;; q/tests/test-gui-error-boundary.rkt — Tests for gui/views/error-boundary.rkt
+
+(require rackunit
+         rackunit/text-ui
+         "../ui-core/theme-protocol.rkt"
+         "../gui/views/error-boundary.rkt")
+
+(define-test-suite
+ test-gui-error-boundary
+ (test-case "render-error-fallback produces error view"
+   (define result (render-error-fallback (default-theme)))
+   (check-equal? (hash-ref result 'view) 'error-fallback)
+   (check-not-false (hash-ref result 'message)))
+ (test-case "render-error-fallback with custom message"
+   (define result (render-error-fallback (default-theme) "Custom error"))
+   (check-equal? (hash-ref result 'message) "Custom error"))
+ (test-case "with-error-boundary returns wrapped function"
+   (define wrapped
+     (with-error-boundary (lambda () (error "boom")) (lambda () (hash 'view 'fallback))))
+   (check-true (procedure? wrapped)))
+ (test-case "with-error-boundary catches errors"
+   (define wrapped
+     (with-error-boundary (lambda () (error "boom")) (lambda () (hash 'view 'fallback))))
+   (define result (wrapped))
+   (check-equal? (hash-ref result 'view) 'fallback))
+ (test-case "with-error-boundary passes through on success"
+   (define wrapped
+     (with-error-boundary (lambda () (hash 'view 'success)) (lambda () (hash 'view 'fallback))))
+   (define result (wrapped))
+   (check-equal? (hash-ref result 'view) 'success))
+ (test-case "with-error-boundary passes arguments"
+   (define wrapped
+     (with-error-boundary (lambda (x) (hash 'value (+ x 1))) (lambda (x) (hash 'value 0))))
+   (define result (wrapped 5))
+   (check-equal? (hash-ref result 'value) 6)))
+
+(run-tests test-gui-error-boundary)


### PR DESCRIPTION
Addresses #5795.

feat(v0.67.0 W1): gui/views/error-boundary.rkt with fallback rendering + 6 tests (#5795)