### PR TITLE
release: v0.67.1 — GUI audit hotfix (#5824)

Version bump 0.67.0 → 0.67.1. CHANGELOG entry. All docs synced.
- Fixed broken event filter (F1)
- Fixed status always idle (F2)  
- Fixed test-gui-init.rkt broken path (F10)
- 13 stale v0.62.3 doc versions synced to v0.67.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## v0.67.1 — 2026-05-28
+
+### GUI Audit Hotfix
+
+Post-implementation audit remediation for the v0.63.0–v0.67.0 GUI milestone series:
+- **F1**: Fixed broken event filter in `wire-bridge!` — was checking `(hash? evt)` on `event` structs, silently dropping all events from the agent. Now uses `(event-ev evt)`.
+- **F2**: Fixed `render-app` status always returning `'idle` — both branches of the conditional were identical. Now maps status text to `'processing`, `'error`, or `'idle` based on content.
+- **F10**: Fixed `test-gui-init.rkt` broken relative path — now uses `runtime-path` for `info.rkt` lookup.
+- **+4 new tests**: 1 for event filter (F1), 3 for status mapping (F2).
+- **13 docs synced**: Stale v0.62.3 version references updated to v0.67.0.
+
 ## v0.67.0 — 2026-05-25
 
 ### Stabilization, Polish, Documentation

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.67.0-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.67.1-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 
@@ -202,7 +202,7 @@ bin/q --model gpt-5.4 "write a test"
 ### Verify
 
 ```bash
-bin/q --version            # q version 0.67.0
+bin/q --version            # q version 0.67.1
 raco test tests/           # run the full test suite
 ```
 
@@ -493,6 +493,9 @@ When q executes shell commands on behalf of an LLM, arguments are quoted via `sh
 
 
 
+
+
+**v0.67.1** — GUI Audit Hotfix
 
 **v0.67.0** — Stabilization, Polish, Documentation
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -2,7 +2,7 @@
 
 ## Version
 
-v0.67.0
+v0.67.1
 
 ## Native TUI Stack
 

--- a/docs/event-taxonomy.md
+++ b/docs/event-taxonomy.md
@@ -1,6 +1,6 @@
 # Q Event Taxonomy Reference
 
-Complete reference for all event types in Q 0.67.0.
+Complete reference for all event types in Q 0.67.1.
 ## Base Types
 
 ### `event` (protocol-level)

--- a/docs/extension-guide.md
+++ b/docs/extension-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.67.0 --># Extension Development Guide
+<!-- verified-against: 0.67.1 --># Extension Development Guide
 
 This guide walks you through creating, testing, and activating a custom
 extension for q.

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.67.0 --># Getting Started
+<!-- verified-against: 0.67.1 --># Getting Started
 
 Welcome to q, a Racket-based coding agent.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.67.0 --># Installation Guide
+<!-- verified-against: 0.67.1 --># Installation Guide
 
 <!-- This file is the canonical source. The docs/getting-started/installation.md copy is maintained for the doc site build. -->
 

--- a/docs/security-trust-model.md
+++ b/docs/security-trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.67.0 --># Security & Trust Model
+<!-- verified-against: 0.67.1 --># Security & Trust Model
 
 This document provides an honest, per-area assessment of what q enforces
 today and what is planned. It is the authoritative reference for security

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -130,6 +130,6 @@ is the primary self-hosting extension:
 (load-extension! ext-reg "path/to/extension.rkt" #:event-bus bus)
 ```
 
-## Version 0.67.0
+## Version 0.67.1
 
-This documentation reflects q 0.67.0.
+This documentation reflects q 0.67.1.

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.67.0 --># q Source Style Guide
+<!-- verified-against: 0.67.1 --># q Source Style Guide
 
 This document defines formatting and naming conventions for the q Racket codebase.
 All changes to `q/` source files (excluding `tests/`) should follow these rules.

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.67.0 -->
+<!-- verified-against: 0.67.1 -->
 # Trust Model
 
 ## Trust Levels

--- a/docs/workflow-testing.md
+++ b/docs/workflow-testing.md
@@ -121,6 +121,6 @@ Use relative paths from the test file:
 4. Use `(check-true ...)` for boolean assertions
 5. Keep tests independent — no shared mutable state between test-cases
 
-## Version 0.67.0
+## Version 0.67.1
 
-This documentation reflects q 0.67.0.
+This documentation reflects q 0.67.1.

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.67.0")
+(define version "0.67.1")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base" "gui-easy-lib"))

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -11,4 +11,4 @@
 
 (provide (contract-out [q-version string?]))
 
-(define q-version "0.67.0")
+(define q-version "0.67.1")

--- a/wiki-src/Architecture-Overview.md
+++ b/wiki-src/Architecture-Overview.md
@@ -35,7 +35,7 @@ User input → Interface (CLI/TUI/RPC)
     → Events emitted to bus
 ```
 
-## Metrics (0.67.0)
+## Metrics (0.67.1)
 > _See `racket scripts/metrics.rkt` for current numbers._
 
 - 414 source modules, 534 test files


### PR DESCRIPTION
Addresses #5824.

release: v0.67.1 — GUI audit hotfix (#5824)

Version bump 0.67.0 → 0.67.1. CHANGELOG entry. All docs synced.
- Fixed broken event filter (F1)
- Fixed status always idle (F2)  
- Fixed test-gui-init.rkt broken path (F10)
- 13 stale v0.62.3 doc versions synced to v0.67.1