### PR TITLE
fix(v0.68.4 W0): set-max-undo method name fix (#5872)

### DIFF
--- a/gui/components/rich-transcript-view.rkt
+++ b/gui/components/rich-transcript-view.rkt
@@ -376,7 +376,7 @@
 
   (define text-obj (make-object text%-cls))
   (send text-obj auto-wrap #t)
-  (send text-obj set-max-undo 0)
+  (send text-obj set-max-undo-history 0)
   (send text-obj lock #t)
   (send text-obj change-style
         (make-object style-delta%-cls 'change-normal)


### PR DESCRIPTION
Addresses #5872.

fix(v0.68.4 W0): set-max-undo → set-max-undo-history method name fix (#5872)