### PR TITLE
feat(v0.68.4 W4): streaming-cursor blink during LLM streaming (#5876)

### DIFF
--- a/gui/components/streaming-cursor.rkt
+++ b/gui/components/streaming-cursor.rkt
@@ -1,0 +1,76 @@
+#lang racket/base
+
+;; q/gui/components/streaming-cursor.rkt — Streaming cursor blink state
+;;
+;; Provides a timer-based cursor that blinks at the end of the last
+;; assistant message while streaming is active. All timer logic is
+;; testable in headless mode via a background thread.
+
+(require racket/contract
+         racket/format)
+
+(provide (contract-out [make-streaming-cursor-state (-> hash?)]
+                       [streaming-cursor-active? (-> hash? boolean?)]
+                       [streaming-cursor-string (-> hash? string?)]
+                       [streaming-cursor-start! (-> hash? (-> void?) void?)]
+                       [streaming-cursor-stop! (-> hash? void?)]
+                       [streaming-cursor-toggle-phase! (-> hash? void?)]))
+
+;; ──────────────────────────────
+;; Pure helpers
+;; ──────────────────────────────
+
+;; Create initial cursor state.
+;; Returns a hash with:
+;;   active?  — boolean, whether cursor is currently blinking
+;;   phase    — exact-nonnegative-integer (0 = visible "|", 1 = hidden " ")
+;;   thread   — #f or the background thread handle
+(define (make-streaming-cursor-state)
+  (make-hash (list (cons 'active? #f) (cons 'phase 0) (cons 'thread #f))))
+
+(define (streaming-cursor-active? state)
+  (hash-ref state 'active? #f))
+
+;; Return the current cursor glyph based on phase.
+;; When inactive, returns empty string.
+(define (streaming-cursor-string state)
+  (cond
+    [(not (streaming-cursor-active? state)) ""]
+    [(= 0 (hash-ref state 'phase 0)) "|"]
+    [else " "]))
+
+;; ──────────────────────────────
+;; Timer / thread helpers (impure)
+;; ──────────────────────────────
+
+;; Toggle the blink phase between 0 (visible) and 1 (hidden).
+(define (streaming-cursor-toggle-phase! state)
+  (define current (hash-ref state 'phase 0))
+  (hash-set! state 'phase (if (= current 0) 1 0)))
+
+;; Start the cursor blink loop.
+;; state: cursor state hash (mutable)
+;; notify: thunk called after each phase toggle so GUI can refresh
+(define (streaming-cursor-start! state notify)
+  (hash-set! state 'active? #t)
+  (hash-set! state 'phase 0)
+  (define t
+    (thread (lambda ()
+              (let loop ()
+                (when (streaming-cursor-active? state)
+                  (sleep 0.5)
+                  (when (streaming-cursor-active? state)
+                    (streaming-cursor-toggle-phase! state)
+                    (with-handlers ([exn:fail? (lambda (e) (void))])
+                      (notify))
+                    (loop)))))))
+  (hash-set! state 'thread t))
+
+;; Stop the cursor blink loop.
+(define (streaming-cursor-stop! state)
+  (hash-set! state 'active? #f)
+  (hash-set! state 'phase 0)
+  (define t (hash-ref state 'thread #f))
+  (when (thread? t)
+    (break-thread t)
+    (hash-set! state 'thread #f)))

--- a/gui/main.rkt
+++ b/gui/main.rkt
@@ -33,7 +33,8 @@
          "../util/version.rkt"
          "../extensions/hooks.rkt"
          "../tui/command-parse.rkt"
-         "../gui/components/rich-transcript-view.rkt")
+         "../gui/components/rich-transcript-view.rkt"
+         "../gui/components/streaming-cursor.rkt")
 
 (provide (contract-out [run-gui-with-runtime (-> any/c any/c void?)]
                        [run-gui (-> void?)]
@@ -249,7 +250,18 @@
                           (send transcript-text delete 0 (send transcript-text last-position))
                           (for ([msg (in-list msgs)])
                             (insert-message-into-text! transcript-text msg theme))
-                          (send transcript-text lock #t))))))
+                          ;; Append streaming cursor when processing
+                          (when (eq? st 'processing)
+                            (send transcript-text insert (streaming-cursor-string cursor-state)))
+                          (send transcript-text lock #t))
+                        ;; Manage streaming cursor based on status
+                        (cond
+                          [(eq? st 'processing)
+                           (unless (streaming-cursor-active? cursor-state)
+                             (streaming-cursor-start! cursor-state notify-gui!))]
+                          [else
+                           (when (streaming-cursor-active? cursor-state)
+                             (streaming-cursor-stop! cursor-state))]))))))
 
   ;; Store notify callback in box so subscriber can use it
   (set-box! notify-callback-box notify-gui!)
@@ -419,6 +431,9 @@
                                    style-delta%
                                    theme
                                    queue-callback))
+
+  ;; Streaming cursor state (blinks during LLM response)
+  (define cursor-state (make-streaming-cursor-state))
 
   ;; Track last rendered messages for diff-based updates
 

--- a/tests/test-gui-streaming-cursor.rkt
+++ b/tests/test-gui-streaming-cursor.rkt
@@ -1,0 +1,63 @@
+#lang racket/base
+
+;; q/tests/test-gui-streaming-cursor.rkt — Tests for streaming-cursor.rkt
+
+(require rackunit
+         rackunit/text-ui
+         "../gui/components/streaming-cursor.rkt")
+
+(define-test-suite streaming-cursor-tests
+                   (test-case "initial state is inactive"
+                     (define s (make-streaming-cursor-state))
+                     (check-false (streaming-cursor-active? s))
+                     (check-equal? (streaming-cursor-string s) ""))
+                   (test-case "cursor string visible when active phase 0"
+                     (define s (make-streaming-cursor-state))
+                     (hash-set! s 'active? #t)
+                     (hash-set! s 'phase 0)
+                     (check-equal? (streaming-cursor-string s) "|"))
+                   (test-case "cursor string hidden when active phase 1"
+                     (define s (make-streaming-cursor-state))
+                     (hash-set! s 'active? #t)
+                     (hash-set! s 'phase 1)
+                     (check-equal? (streaming-cursor-string s) " "))
+                   (test-case "toggle phase flips between 0 and 1"
+                     (define s (make-streaming-cursor-state))
+                     (hash-set! s 'active? #t)
+                     (hash-set! s 'phase 0)
+                     (streaming-cursor-toggle-phase! s)
+                     (check-equal? (hash-ref s 'phase) 1)
+                     (streaming-cursor-toggle-phase! s)
+                     (check-equal? (hash-ref s 'phase) 0))
+                   (test-case "start! sets active and phase 0"
+                     (define s (make-streaming-cursor-state))
+                     (define notify-count 0)
+                     (define (notify!)
+                       (set! notify-count (+ notify-count 1)))
+                     (streaming-cursor-start! s notify!)
+                     (check-true (streaming-cursor-active? s))
+                     (check-equal? (hash-ref s 'phase) 0)
+                     (check-equal? (streaming-cursor-string s) "|")
+                     (streaming-cursor-stop! s))
+                   (test-case "stop! sets inactive and empty string"
+                     (define s (make-streaming-cursor-state))
+                     (hash-set! s 'active? #t)
+                     (hash-set! s 'phase 1)
+                     (streaming-cursor-stop! s)
+                     (check-false (streaming-cursor-active? s))
+                     (check-equal? (streaming-cursor-string s) ""))
+                   (test-case "multiple start/stop cycles"
+                     (define s (make-streaming-cursor-state))
+                     (define (noop)
+                       (void))
+                     (streaming-cursor-start! s noop)
+                     (check-true (streaming-cursor-active? s))
+                     (streaming-cursor-stop! s)
+                     (check-false (streaming-cursor-active? s))
+                     (streaming-cursor-start! s noop)
+                     (check-true (streaming-cursor-active? s))
+                     (streaming-cursor-stop! s)
+                     (check-false (streaming-cursor-active? s))))
+
+(module+ main
+  (run-tests streaming-cursor-tests))


### PR DESCRIPTION
Addresses #5876.

feat(v0.68.4 W4): implement streaming-cursor.rkt with timer-based blink (#5876)