### PR TITLE
refactor(v0.69.0 W2): drop-right dedup + take-safe fix (#5929)

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ q/
 |--------|-------|
 | Test files | 699 |
 | Source modules | 503 |
-| Source lines | 76670 |
+| Source lines | 76674 |
 | Test lines | 116018 |
 | Test assertions | 18370 |
 | Tests passing | 5835+ | `racket scripts/run-tests.rkt` results |

--- a/gui/state-sync.rkt
+++ b/gui/state-sync.rkt
@@ -11,6 +11,7 @@
 
 (require racket/class
          racket/string
+         racket/list
          "../util/event.rkt"
          "../gui/components/rich-transcript-view.rkt"
          "../ui-core/theme-protocol.rkt")
@@ -31,9 +32,7 @@
   ;; since all GUI state updates are fast.
   gui-state-lock)
 
-;; Helper: drop-right for lists
-(define (drop-right lst n)
-  (reverse (list-tail (reverse lst) n)))
+;; drop-right — re-exported from racket/list
 
 ;; --------------------------------------------------
 ;; GUI event subscriber

--- a/tui/state-events.rkt
+++ b/tui/state-events.rkt
@@ -30,6 +30,8 @@
 ;; Event reducer registry (W-07)
 ;; ============================================================
 
+;; Event reducer registry — mutable hash for registration-time population
+;; (Immutable box pattern causes stale bytecode issues with raco make)
 (define event-reducers (make-hash))
 
 (define (register-event-reducer! type-string handler)
@@ -76,11 +78,14 @@
     (and (memq (transcript-entry-kind entry) '(tool-end tool-fail))
          (equal? (hash-ref (transcript-entry-meta entry) 'name "") name))))
 
-;; Safe take — returns up to n elements from lst (racket/list take is unsafe)
+;; Safe take — returns up to n elements from lst (iterative, no stack overflow)
 (define (take-safe lst n)
-  (if (or (<= n 0) (null? lst))
-      '()
-      (cons (car lst) (take-safe (cdr lst) (- n 1)))))
+  (let loop ([lst lst]
+             [n n]
+             [acc '()])
+    (if (or (<= n 0) (null? lst))
+        (reverse acc)
+        (loop (cdr lst) (- n 1) (cons (car lst) acc)))))
 
 ;; ============================================================
 ;; Named event handlers (extracted from case dispatch)


### PR DESCRIPTION
Replace local drop-right in gui/state-sync.rkt with racket/list (semantically identical). Fix take-safe in tui/state-events.rkt from recursive to iterative (prevents stack overflow). Event-reducers kept as mutable hash (immutable box pattern causes stale bytecode issues).