### PR TITLE
refactor(v0.69.1 W0): format-id to generate-id (#5933)

### DIFF
--- a/runtime/cutpoint-rules.rkt
+++ b/runtime/cutpoint-rules.rkt
@@ -21,6 +21,7 @@
          racket/match
          "../util/protocol-types.rkt"
          "../util/message-helpers.rkt"
+         (only-in "../util/ids.rkt" generate-id)
          "compactor.rkt")
 
 ;; #693: Cut-point rules
@@ -180,7 +181,7 @@
         kept))
   ;; Create a fresh user message with the original prompt
   (define retry-msg
-    (make-message (format "retry-~a" (current-inexact-milliseconds))
+    (make-message (string-append "retry-" (generate-id))
                   #f
                   'user
                   'text

--- a/runtime/session-index/mutations.rkt
+++ b/runtime/session-index/mutations.rkt
@@ -24,6 +24,7 @@
                   jsexpr->message
                   message)
          (only-in "../../util/message-helpers.rkt" ensure-parent-dirs!)
+         (only-in "../../util/ids.rkt" generate-id)
          (only-in "../../util/jsonl.rkt" jsonl-read-all-valid)
          (only-in "../session-store.rkt" load-session-log)
          "schema.rkt"
@@ -238,7 +239,7 @@
     [(not entry) #f]
     [else
      (define summary-msg
-       (make-message (format "branch-summary-~a" (current-inexact-milliseconds))
+       (make-message (string-append "bs-" (generate-id))
                      entry-id
                      'system
                      'branch-summary

--- a/runtime/session-metadata.rkt
+++ b/runtime/session-metadata.rkt
@@ -10,6 +10,7 @@
 (require racket/contract
          racket/list
          racket/port
+         (only-in "../util/ids.rkt" generate-id)
          (only-in "../util/protocol-types.rkt"
                   message?
                   message-content
@@ -82,7 +83,7 @@
   (unless (label-type? label-type)
     (raise-argument-error 'set-entry-label! "label-type?" label-type))
   (define label-msg
-    (make-message (format "label-~a-~a" label-type (current-inexact-milliseconds))
+    (make-message (string-append "label-" (symbol->string label-type) "-" (generate-id))
                   target-entry-id
                   'system
                   'entry-label

--- a/runtime/session-migration.rkt
+++ b/runtime/session-migration.rkt
@@ -22,6 +22,7 @@
          json
          "../util/jsonl.rkt"
          "../util/protocol-types.rkt"
+         (only-in "../util/ids.rkt" generate-id)
          (only-in "../util/errors.rkt" with-logged-catch raise-session-error))
 
 (provide (contract-out [current-session-version exact-nonnegative-integer?]
@@ -95,7 +96,7 @@
 (define (migrate-v1->v2! path)
   (define entries (load-session-log path))
   (define header-msg
-    (make-message (format "session-version-header-~a" (current-inexact-milliseconds))
+    (make-message (string-append "svh-" (generate-id))
                   #f
                   'system
                   'session-info

--- a/runtime/session-store.rkt
+++ b/runtime/session-store.rkt
@@ -20,6 +20,7 @@
          "../util/protocol-types.rkt"
          "../util/jsonl.rkt"
          (only-in "../util/message-helpers.rkt" ensure-parent-dirs!)
+         (only-in "../util/ids.rkt" generate-id)
          (only-in "../util/errors.rkt" raise-session-error)
          ;; Extracted modules (v0.22.9 W2)
          "session-store-integrity.rkt"
@@ -170,7 +171,7 @@
     [(and (file-exists? log-path) (> (file-size log-path) 0)) (void)]
     [else
      (define header-msg
-       (make-message (format "session-version-header-~a" (current-inexact-milliseconds))
+       (make-message (string-append "svh-" (generate-id))
                      #f
                      'system
                      'session-info
@@ -219,7 +220,7 @@
   (when (< from-version to-version)
     (define entries (load-session-log log-path))
     (define header-msg
-      (make-message (format "session-version-header-~a" (current-inexact-milliseconds))
+      (make-message (string-append "svh-" (generate-id))
                     #f
                     'system
                     'session-info
@@ -262,7 +263,7 @@
   (ensure-parent-dirs! dest-path)
   (define header-msg
     (make-message
-     (format "session-version-header-~a" (current-inexact-milliseconds))
+     (string-append "svh-" (generate-id))
      #f
      'system
      'session-info
@@ -279,7 +280,7 @@
 
 (define (write-session-name! log-path name)
   (define name-msg
-    (make-message (format "session-name-~a" (current-inexact-milliseconds))
+    (make-message (string-append "sn-" (generate-id))
                   #f
                   'system
                   'session-info
@@ -305,11 +306,11 @@
                 source-path))
      (when (null? raw)
        (raise-session-error 'import-session! "No valid entries found in source" #f source-path))
-     (define new-session-id (format "imported-~a" (current-inexact-milliseconds)))
+     (define new-session-id (string-append "imported-" (generate-id)))
      (define dest-path (build-path dest-session-dir (format "~a.jsonl" new-session-id)))
      (ensure-parent-dirs! dest-path)
      (define header-msg
-       (make-message (format "session-version-header-~a" (current-inexact-milliseconds))
+       (make-message (string-append "svh-" (generate-id))
                      #f
                      'system
                      'session-info


### PR DESCRIPTION
Replace all (format "prefix-~a" (current-inexact-milliseconds)) with (string-append "prefix-" (generate-id)) across 5 runtime files. Zero format-id patterns remain outside util/ids.rkt.