### PR TITLE
refactor(v0.69.2 W0): cond-to-match (#5938)

### DIFF
--- a/extensions/gsd/command-handlers.rkt
+++ b/extensions/gsd/command-handlers.rkt
@@ -78,22 +78,21 @@
 
 ;; Legacy mode wrappers (DEBT-01: migrated from gsd-planning-state.rkt)
 (define (gsd-mode)
-  (let ([s (gsm-current)])
-    (cond
-      [(eq? s 'idle) #f]
-      [(eq? s 'exploring) 'planning]
-      [else s])))
+  (match (gsm-current)
+    ['idle #f]
+    ['exploring 'planning]
+    [s s]))
 
 (define (gsd-mode? v)
   (eq? (gsd-mode) v))
 
 (define (set-gsd-mode! v)
-  (cond
-    [(not v) (gsm-reset!)]
-    [(eq? v 'planning) (gsm-transition-to! 'exploring)]
-    [(eq? v 'plan-written) (gsm-transition-to! 'plan-written)]
-    [(eq? v 'executing) (gsm-transition-to! 'executing)]
-    [else (gsm-transition! v)]))
+  (match v
+    [#f (gsm-reset!)]
+    ['planning (gsm-transition-to! 'exploring)]
+    ['plan-written (gsm-transition-to! 'plan-written)]
+    ['executing (gsm-transition-to! 'executing)]
+    [_ (gsm-transition! v)]))
 
 ;; Helper: emit a mode-changed event with standard boilerplate
 (define (emit-mode-change! mode #:reason [reason #f] #:error [err #f])

--- a/tui/state-events.rkt
+++ b/tui/state-events.rkt
@@ -408,8 +408,8 @@
 (define (handle-auto-retry-lifecycle state evt)
   (define ev (event-ev evt))
   (define payload (event-payload evt))
-  (cond
-    [(equal? ev "auto-retry.start")
+  (match ev
+    ["auto-retry.start"
      (define attempt (hash-ref payload 'attempt "?"))
      (define max-attempts (hash-ref payload 'maxRetries "?"))
      (define error-type (hash-ref payload 'errorType #f))
@@ -425,7 +425,7 @@
            (format "[retry: ~a, ~a/~a...]" type-label attempt max-attempts)
            (format "[retry: attempt ~a/~a]" attempt max-attempts)))
      (clear-streaming (append-entry state (make-entry 'system msg (event-time evt) (hash))))]
-    [(equal? ev "auto-retry.context-reduced")
+    ["auto-retry.context-reduced"
      (define original (hash-ref payload 'original-messages 0))
      (define reduced (hash-ref payload 'reduced-messages 0))
      (append-entry state
@@ -433,7 +433,7 @@
                                (format "[retry: reduced context ~a -> ~a messages]" original reduced)
                                (event-time evt)
                                (hash)))]
-    [else state]))
+    [_ state]))
 
 (define (handle-model-stream-thinking state evt)
   (define payload (event-payload evt))


### PR DESCRIPTION
Convert cond dispatches to match in gsd/command-handlers.rkt (gsd-mode, set-gsd-mode!) and tui/state-events.rkt (handle-auto-retry-lifecycle). -1 LOC.