### PR TITLE
refactor(v0.69.3 W0): gui struct types (#5942)

### DIFF
--- a/gui/gui-types.rkt
+++ b/gui/gui-types.rkt
@@ -1,0 +1,76 @@
+#lang racket/base
+
+;; gui/gui-types.rkt — Struct types for GUI state
+;;
+;; Replaces raw hash constructions in gui/state-sync.rkt with
+;; typed structs to prevent key-typo bugs (§8, §12).
+
+(require racket/contract
+         racket/list)
+
+(provide (struct-out gui-message)
+         (struct-out gui-state)
+         (contract-out
+          [make-gui-message (->* (string? string?) () gui-message?)]
+          [make-gui-state (->* () () #:rest list? gui-state?)]
+          [gui-state-add-message (-> gui-state? gui-message? gui-state?)]
+          [gui-state-update-last-message (-> gui-state? (-> gui-message? gui-message?) gui-state?)]
+          [gui-state-set-status (-> gui-state? symbol? gui-state?)]
+          [gui-state->hash (-> gui-state? hash?)]
+          [hash->gui-state (-> hash? gui-state?)]
+          [gui-message->hash (-> gui-message? hash?)]
+          [hash->gui-message (-> hash? gui-message?)]))
+
+;; A single chat message in the GUI transcript.
+(struct gui-message (role text) #:transparent)
+
+;; The full GUI state: messages, status, model name.
+(struct gui-state (messages status model) #:transparent)
+
+;; --- Constructors with defaults ---
+
+(define (make-gui-message role text)
+  (gui-message role text))
+
+(define (make-gui-state . args)
+  (gui-state '() 'idle #f))
+
+;; --- Immutable update helpers ---
+
+(define (gui-state-add-message gs msg)
+  (struct-copy gui-state gs
+               [messages (append (gui-state-messages gs) (list msg))]))
+
+(define (gui-state-update-last-message gs updater)
+  (define msgs (gui-state-messages gs))
+  (if (null? msgs)
+      gs
+      (let* ([all-but-last (drop-right msgs 1)]
+             [last-msg (last msgs)]
+             [updated (updater last-msg)])
+        (struct-copy gui-state gs
+                     [messages (append all-but-last (list updated))]))))
+
+(define (gui-state-set-status gs status)
+  (struct-copy gui-state gs [status status]))
+
+;; --- Hash conversion (backward compatibility) ---
+
+(define (gui-message->hash msg)
+  (hash 'role (gui-message-role msg)
+        'text (gui-message-text msg)))
+
+(define (hash->gui-message h)
+  (gui-message (hash-ref h 'role "")
+               (hash-ref h 'text "")))
+
+(define (gui-state->hash gs)
+  (hash 'messages (map gui-message->hash (gui-state-messages gs))
+        'status (gui-state-status gs)
+        'model (gui-state-model gs)))
+
+(define (hash->gui-state h)
+  (gui-state (map hash->gui-message (hash-ref h 'messages '()))
+             (hash-ref h 'status 'idle)
+             (hash-ref h 'model #f)))
+

--- a/tests/test-gui-types.rkt
+++ b/tests/test-gui-types.rkt
@@ -1,0 +1,58 @@
+#lang racket/base
+
+(require rackunit
+         rackunit/text-ui
+         "../gui/gui-types.rkt")
+
+(define-test-suite test-gui-types
+  (test-case "gui-message struct"
+    (define msg (make-gui-message "user" "hello"))
+    (check-equal? (gui-message-role msg) "user")
+    (check-equal? (gui-message-text msg) "hello"))
+
+  (test-case "gui-state defaults"
+    (define gs (make-gui-state))
+    (check-equal? (gui-state-messages gs) '())
+    (check-equal? (gui-state-status gs) 'idle)
+    (check-false (gui-state-model gs)))
+
+  (test-case "gui-state-add-message"
+    (define gs (make-gui-state))
+    (define gs2 (gui-state-add-message gs (make-gui-message "user" "hi")))
+    (check-equal? (length (gui-state-messages gs2)) 1)
+    (check-equal? (gui-state-messages gs) '())) ; immutable original
+
+  (test-case "gui-state-update-last-message"
+    (define gs (make-gui-state))
+    (define gs2 (gui-state-add-message gs (make-gui-message "assistant" "hello")))
+    (define gs3 (gui-state-update-last-message gs2
+                  (lambda (m) (gui-message "assistant" (string-append (gui-message-text m) " world")))))
+    (check-equal? (gui-message-text (car (gui-state-messages gs3))) "hello world"))
+
+  (test-case "gui-state-set-status"
+    (define gs (gui-state-set-status (make-gui-state) 'processing))
+    (check-equal? (gui-state-status gs) 'processing))
+
+  (test-case "gui-message->hash round-trip"
+    (define msg (make-gui-message "tool" "[bash: ls]"))
+    (define h (gui-message->hash msg))
+    (check-equal? (hash-ref h 'role) "tool")
+    (define msg2 (hash->gui-message h))
+    (check-equal? (gui-message-role msg2) "tool")
+    (check-equal? (gui-message-text msg2) "[bash: ls]"))
+
+  (test-case "gui-state->hash round-trip"
+    (define gs (gui-state-add-message (make-gui-state) (make-gui-message "user" "test")))
+    (define h (gui-state->hash gs))
+    (check-equal? (length (hash-ref h 'messages)) 1)
+    (define gs2 (hash->gui-state h))
+    (check-equal? (length (gui-state-messages gs2)) 1)
+    (check-equal? (gui-message-role (car (gui-state-messages gs2))) "user"))
+
+  (test-case "gui-state-update-last-message on empty"
+    (define gs (make-gui-state))
+    (define gs2 (gui-state-update-last-message gs (lambda (m) m)))
+    (check-equal? (gui-state-messages gs2) '()))
+  )
+
+(run-tests test-gui-types)


### PR DESCRIPTION
Define gui-message and gui-state structs with immutable update helpers and hash conversion for backward compatibility. New test file with 8 test cases.