### PR TITLE
refactor(v0.69.3 W2): ui-event struct (#5944)

### DIFF
--- a/ui-core/dispatch.rkt
+++ b/ui-core/dispatch.rkt
@@ -9,7 +9,8 @@
 ;; Architecture:
 ;;   User action → dispatch-*! → event bus → state reducer → UI update
 
-(require racket/contract)
+(require racket/contract
+         "event-types.rkt")
 
 (provide (contract-out [dispatch-submit! (-> any/c string? void?)]
                        [dispatch-cancel! (-> any/c void?)]
@@ -21,68 +22,56 @@
                        [dispatch-input-append! (-> any/c string? void?)]
                        [dispatch-input-clear! (-> any/c void?)]))
 
+;; Helper: emit a ui-event via the runtime's event mechanism.
+(define (emit-ui-event! runtime type . payload-args)
+  (define emit-fn (hash-ref runtime 'emit-event #f))
+  (when emit-fn
+    (emit-fn (ui-event->hash (apply make-ui-event type payload-args)))))
+
 ;; ──────────────────────────────
 ;; Submit user input
 ;; ──────────────────────────────
 (define (dispatch-submit! runtime text)
-  ;; In full wiring, this calls the submit handler on the agent session.
-  ;; For now, emit a user-input event via the runtime's event mechanism.
-  (define emit-fn (hash-ref runtime 'emit-event #f))
-  (when emit-fn
-    (emit-fn (hash 'type "user.input" 'text text))))
+  (emit-ui-event! runtime "user.input" 'text text))
 
 ;; ──────────────────────────────
 ;; Cancel current operation
 ;; ──────────────────────────────
 (define (dispatch-cancel! runtime)
-  (define emit-fn (hash-ref runtime 'emit-event #f))
-  (when emit-fn
-    (emit-fn (hash 'type "user.cancel"))))
+  (emit-ui-event! runtime "user.cancel"))
 
 ;; ──────────────────────────────
 ;; Scroll transcript
 ;; ──────────────────────────────
 (define (dispatch-scroll! runtime direction)
-  (define emit-fn (hash-ref runtime 'emit-event #f))
-  (when emit-fn
-    (emit-fn (hash 'type "ui.scroll" 'direction direction))))
+  (emit-ui-event! runtime "ui.scroll" 'direction direction))
 
 ;; ──────────────────────────────
 ;; Execute a slash command
 ;; ──────────────────────────────
 (define (dispatch-command! runtime command-name args)
-  (define emit-fn (hash-ref runtime 'emit-event #f))
-  (when emit-fn
-    (emit-fn (hash 'type "user.command" 'command command-name 'args args))))
+  (emit-ui-event! runtime "user.command" 'command command-name 'args args))
 
 ;; ──────────────────────────────
 ;; Resize event
 ;; ──────────────────────────────
 (define (dispatch-resize! runtime cols rows)
-  (define emit-fn (hash-ref runtime 'emit-event #f))
-  (when emit-fn
-    (emit-fn (hash 'type "ui.resize" 'cols cols 'rows rows))))
+  (emit-ui-event! runtime "ui.resize" 'cols cols 'rows rows))
 
 ;; ──────────────────────────────
 ;; Focus a specific component
 ;; ──────────────────────────────
 (define (dispatch-focus! runtime component-id)
-  (define emit-fn (hash-ref runtime 'emit-event #f))
-  (when emit-fn
-    (emit-fn (hash 'type "ui.focus" 'component component-id))))
+  (emit-ui-event! runtime "ui.focus" 'component component-id))
 
 ;; ──────────────────────────────
 ;; Append text to input
 ;; ──────────────────────────────
 (define (dispatch-input-append! runtime text)
-  (define emit-fn (hash-ref runtime 'emit-event #f))
-  (when emit-fn
-    (emit-fn (hash 'type "ui.input.append" 'text text))))
+  (emit-ui-event! runtime "ui.input.append" 'text text))
 
 ;; ──────────────────────────────
 ;; Clear input field
 ;; ──────────────────────────────
 (define (dispatch-input-clear! runtime)
-  (define emit-fn (hash-ref runtime 'emit-event #f))
-  (when emit-fn
-    (emit-fn (hash 'type "ui.input.clear"))))
+  (emit-ui-event! runtime "ui.input.clear"))

--- a/ui-core/event-types.rkt
+++ b/ui-core/event-types.rkt
@@ -1,0 +1,33 @@
+#lang racket/base
+
+;; ui-core/event-types.rkt — Struct types for UI events
+;;
+;; Replaces raw hash constructions in ui-core/dispatch.rkt with
+;; typed structs to prevent key-typo bugs.
+
+(require racket/contract)
+
+(provide (struct-out ui-event)
+         (contract-out
+          [make-ui-event (->* (string?) () #:rest any/c ui-event?)]
+          [ui-event->hash (-> ui-event? hash?)]))
+
+;; A UI event with a type string and optional payload fields.
+;; Payload is stored as a hash for flexibility since UI events
+;; have varying payloads.
+(struct ui-event (type payload) #:transparent)
+
+;; Constructor that builds payload from keyword-style rest args
+(define (make-ui-event type . payload-args)
+  (define payload
+    (let loop ([args payload-args] [h (hasheq)])
+      (if (null? args)
+          h
+          (if (null? (cdr args))
+              h
+              (loop (cddr args) (hash-set h (car args) (cadr args)))))))
+  (ui-event type payload))
+
+;; Convert to hash for backward compatibility with event bus
+(define (ui-event->hash evt)
+  (hash-set (ui-event-payload evt) 'type (ui-event-type evt)))


### PR DESCRIPTION
Define ui-event struct in ui-core/event-types.rkt. Migrate ui-core/dispatch.rkt from raw hash constructions to struct-based events with hash conversion for backward compatibility. Extracted emit-ui-event! helper reducing 8 duplicate patterns to 1.