### PR TITLE
refactor(v0.69.4 W0): boundary tightening for GSD context (#5947)

### DIFF
--- a/extensions/gsd/session-state.rkt
+++ b/extensions/gsd/session-state.rkt
@@ -100,6 +100,16 @@
   (ctx-read ctx gsd-session-ctx-correlation-id-box))
 (define (gsd-ctx-set-correlation-id! ctx v)
   (ctx-write! ctx gsd-session-ctx-correlation-id-box v))
+(define (gsd-ctx-busy ctx)
+  (ctx-read ctx gsd-session-ctx-busy-box))
+(define (gsd-ctx-set-busy! ctx v)
+  (ctx-write! ctx gsd-session-ctx-busy-box v))
+(define (gsd-ctx-transaction ctx)
+  (ctx-read ctx gsd-session-ctx-transaction-box))
+(define (gsd-ctx-set-transaction! ctx v)
+  (ctx-write! ctx gsd-session-ctx-transaction-box v))
+(define (gsd-ctx-transaction-update! ctx update-fn)
+  (ctx-update! ctx gsd-session-ctx-transaction-box update-fn))
 
 ;; Thread-safe transaction with explicit ctx
 (define (with-gsd-transaction ctx thunk)
@@ -249,6 +259,11 @@
                        [gsd-ctx-set-history! (-> gsd-session-ctx? list? void?)]
                        [gsd-ctx-correlation-id (-> gsd-session-ctx? (or/c string? #f))]
                        [gsd-ctx-set-correlation-id! (-> gsd-session-ctx? (or/c string? #f) void?)]
+                       [gsd-ctx-busy (-> gsd-session-ctx? any)]
+                       [gsd-ctx-set-busy! (-> gsd-session-ctx? any/c void?)]
+                       [gsd-ctx-transaction (-> gsd-session-ctx? hash?)]
+                       [gsd-ctx-set-transaction! (-> gsd-session-ctx? hash? void?)]
+                       [gsd-ctx-transaction-update! (-> gsd-session-ctx? procedure? void?)]
                        [with-gsd-transaction (-> gsd-session-ctx? procedure? any)]
                        [gsd-ctx-state-snapshot (-> gsd-session-ctx? gsd-runtime-state?)]
                        [gsd-ctx-state-update! (-> gsd-session-ctx? procedure? any)]

--- a/tests/test-gsd-context-factory.rkt
+++ b/tests/test-gsd-context-factory.rkt
@@ -6,25 +6,35 @@
 ;;
 ;; v0.29.4 W0: Original tests for closure-encapsulated context.
 ;; v0.32.5 W1: Rewritten for struct-based gsd-session-ctx.
+;; v0.69.4 W0: Updated to use gsd-ctx-* named accessors.
 
 (require rackunit
          racket/set
-         (only-in "../extensions/gsd/runtime-state-types.rkt" gsd-runtime-state?)
+         (only-in "../extensions/gsd/runtime-state-types.rkt" gsd-runtime-state gsd-runtime-state? gsd-runtime-state-mode gsd-runtime-state-current-wave)
          (only-in "../extensions/gsd/session-state.rkt"
                   make-gsd-context
                   gsd-session-ctx?
-                  gsd-session-ctx-state-box
-                  gsd-session-ctx-plan-box
-                  gsd-session-ctx-pinned-dir-box
-                  gsd-session-ctx-edit-limit-box
-                  gsd-session-ctx-event-bus-box
-                  gsd-session-ctx-history-box
-                  gsd-session-ctx-busy-box
-                  gsd-session-ctx-correlation-id-box
-                  gsd-session-ctx-transaction-box
-                  ctx-read
-                  ctx-write!
-                  ctx-update!))
+                  gsd-ctx-state
+                  gsd-ctx-set-state!
+                  gsd-ctx-plan
+                  gsd-ctx-set-plan!
+                  gsd-ctx-pinned-dir
+                  gsd-ctx-set-pinned-dir!
+                  gsd-ctx-edit-limit
+                  gsd-ctx-set-edit-limit!
+                  gsd-ctx-event-bus
+                  gsd-ctx-set-event-bus!
+                  gsd-ctx-history
+                  gsd-ctx-set-history!
+                  gsd-ctx-busy
+                  gsd-ctx-set-busy!
+                  gsd-ctx-correlation-id
+                  gsd-ctx-set-correlation-id!
+                  gsd-ctx-transaction
+                  gsd-ctx-set-transaction!
+                  gsd-ctx-transaction-update!
+                  gsd-ctx-state-update!
+                  gsd-ctx-history-update!))
 
 ;; ============================================================
 ;; 1. Factory returns a struct
@@ -40,17 +50,17 @@
 
 (test-case "state get/set roundtrip"
   (define ctx (make-gsd-context))
-  (check-pred gsd-runtime-state?
-              (ctx-read ctx gsd-session-ctx-state-box)
-              "initial state is gsd-runtime-state")
-  (ctx-write! ctx gsd-session-ctx-state-box 'idle)
-  (check-equal? (ctx-read ctx gsd-session-ctx-state-box) 'idle))
+  (define initial (gsd-ctx-state ctx))
+  (check-pred gsd-runtime-state? initial "initial state is gsd-runtime-state")
+  ;; Modify via state-update!
+  (gsd-ctx-state-update! ctx (lambda (s) (struct-copy gsd-runtime-state s [mode 'idle])))
+  (check-equal? (gsd-runtime-state-mode (gsd-ctx-state ctx)) 'idle))
 
-(test-case "state supports arbitrary values"
+(test-case "state supports arbitrary values via state-update!"
   (define ctx (make-gsd-context))
-  (define fake-state (hasheq 'mode 'executing 'wave 2))
-  (ctx-write! ctx gsd-session-ctx-state-box fake-state)
-  (check-equal? (ctx-read ctx gsd-session-ctx-state-box) fake-state))
+  (gsd-ctx-state-update! ctx (lambda (s) (struct-copy gsd-runtime-state s [mode 'executing] [current-wave 2])))
+  (check-equal? (gsd-runtime-state-mode (gsd-ctx-state ctx)) 'executing)
+  (check-equal? (gsd-runtime-state-current-wave (gsd-ctx-state ctx)) 2))
 
 ;; ============================================================
 ;; 3. Plan data get/set roundtrip
@@ -58,9 +68,9 @@
 
 (test-case "plan get/set roundtrip"
   (define ctx (make-gsd-context))
-  (check-equal? (ctx-read ctx gsd-session-ctx-plan-box) #f "initial plan is #f")
-  (ctx-write! ctx gsd-session-ctx-plan-box '((wave 1 "do stuff")))
-  (check-equal? (ctx-read ctx gsd-session-ctx-plan-box) '((wave 1 "do stuff"))))
+  (check-equal? (gsd-ctx-plan ctx) #f "initial plan is #f")
+  (gsd-ctx-set-plan! ctx '((wave 1 "do stuff")))
+  (check-equal? (gsd-ctx-plan ctx) '((wave 1 "do stuff"))))
 
 ;; ============================================================
 ;; 4. Busy flag get/set roundtrip
@@ -68,9 +78,9 @@
 
 (test-case "busy? get/set roundtrip"
   (define ctx (make-gsd-context))
-  (check-false (ctx-read ctx gsd-session-ctx-busy-box) "initial busy is #f")
-  (ctx-write! ctx gsd-session-ctx-busy-box #t)
-  (check-true (ctx-read ctx gsd-session-ctx-busy-box)))
+  (check-false (gsd-ctx-busy ctx) "initial busy is #f")
+  (gsd-ctx-set-busy! ctx #t)
+  (check-true (gsd-ctx-busy ctx)))
 
 ;; ============================================================
 ;; 5. Correlation ID get/set roundtrip
@@ -78,9 +88,9 @@
 
 (test-case "correlation-id get/set roundtrip"
   (define ctx (make-gsd-context))
-  (check-equal? (ctx-read ctx gsd-session-ctx-correlation-id-box) #f)
-  (ctx-write! ctx gsd-session-ctx-correlation-id-box "abc-123")
-  (check-equal? (ctx-read ctx gsd-session-ctx-correlation-id-box) "abc-123"))
+  (check-equal? (gsd-ctx-correlation-id ctx) #f)
+  (gsd-ctx-set-correlation-id! ctx "abc-123")
+  (check-equal? (gsd-ctx-correlation-id ctx) "abc-123"))
 
 ;; ============================================================
 ;; 6. Transaction ref/set roundtrip
@@ -89,8 +99,8 @@
 (test-case "transaction update roundtrip"
   (define ctx (make-gsd-context))
   ;; Set a value
-  (ctx-update! ctx gsd-session-ctx-transaction-box (lambda (h) (hash-set h 'edit-count 42)))
-  (check-equal? (hash-ref (ctx-read ctx gsd-session-ctx-transaction-box) 'edit-count) 42))
+  (gsd-ctx-transaction-update! ctx (lambda (h) (hash-set h 'edit-count 42)))
+  (check-equal? (hash-ref (gsd-ctx-transaction ctx) 'edit-count) 42))
 
 ;; ============================================================
 ;; 7. Two independent contexts don't interfere
@@ -99,23 +109,23 @@
 (test-case "two independent contexts are isolated"
   (define ctx-a (make-gsd-context))
   (define ctx-b (make-gsd-context))
-  (ctx-write! ctx-a gsd-session-ctx-state-box 'executing)
-  (ctx-write! ctx-b gsd-session-ctx-state-box 'idle)
-  (check-equal? (ctx-read ctx-a gsd-session-ctx-state-box) 'executing)
-  (check-equal? (ctx-read ctx-b gsd-session-ctx-state-box) 'idle)
+  (gsd-ctx-state-update! ctx-a (lambda (s) (struct-copy gsd-runtime-state s [mode 'executing])))
+  (gsd-ctx-state-update! ctx-b (lambda (s) (struct-copy gsd-runtime-state s [mode 'idle])))
+  (check-equal? (gsd-runtime-state-mode (gsd-ctx-state ctx-a)) 'executing)
+  (check-equal? (gsd-runtime-state-mode (gsd-ctx-state ctx-b)) 'idle)
   ;; Plans also isolated
-  (ctx-write! ctx-a gsd-session-ctx-plan-box '((wave 1)))
-  (ctx-write! ctx-b gsd-session-ctx-plan-box '((wave 2)))
-  (check-equal? (ctx-read ctx-a gsd-session-ctx-plan-box) '((wave 1)))
-  (check-equal? (ctx-read ctx-b gsd-session-ctx-plan-box) '((wave 2))))
+  (gsd-ctx-set-plan! ctx-a '((wave 1)))
+  (gsd-ctx-set-plan! ctx-b '((wave 2)))
+  (check-equal? (gsd-ctx-plan ctx-a) '((wave 1)))
+  (check-equal? (gsd-ctx-plan ctx-b) '((wave 2))))
 
 (test-case "transaction isolation between contexts"
   (define ctx-a (make-gsd-context))
   (define ctx-b (make-gsd-context))
-  (ctx-update! ctx-a gsd-session-ctx-transaction-box (lambda (h) (hash-set h 'key 'val-a)))
-  (ctx-update! ctx-b gsd-session-ctx-transaction-box (lambda (h) (hash-set h 'key 'val-b)))
-  (check-equal? (hash-ref (ctx-read ctx-a gsd-session-ctx-transaction-box) 'key) 'val-a)
-  (check-equal? (hash-ref (ctx-read ctx-b gsd-session-ctx-transaction-box) 'key) 'val-b))
+  (gsd-ctx-transaction-update! ctx-a (lambda (h) (hash-set h 'key 'val-a)))
+  (gsd-ctx-transaction-update! ctx-b (lambda (h) (hash-set h 'key 'val-b)))
+  (check-equal? (hash-ref (gsd-ctx-transaction ctx-a) 'key) 'val-a)
+  (check-equal? (hash-ref (gsd-ctx-transaction ctx-b) 'key) 'val-b))
 
 ;; ============================================================
 ;; 8. Thread safety (basic check)
@@ -124,13 +134,13 @@
 (test-case "concurrent mutations don't corrupt state"
   (define ctx (make-gsd-context))
   (define iterations 100)
-  ;; Spawn threads that race to set state
+  ;; Spawn threads that race to update state
   (for ([i (in-range iterations)])
-    (thread (lambda () (ctx-write! ctx gsd-session-ctx-state-box i))))
+    (thread (lambda () (gsd-ctx-state-update! ctx (lambda (s) (struct-copy gsd-runtime-state s [current-wave i]))))))
   ;; Give threads time to finish
   (sleep 0.1)
-  ;; State should be an integer (one of the racers won)
-  (check-pred integer? (ctx-read ctx gsd-session-ctx-state-box)))
+  ;; State should be a valid gsd-runtime-state with integer current-wave
+  (check-pred exact-nonnegative-integer? (gsd-runtime-state-current-wave (gsd-ctx-state ctx))))
 
 ;; ============================================================
 ;; 9. History operations
@@ -138,15 +148,15 @@
 
 (test-case "history get/set roundtrip"
   (define ctx (make-gsd-context))
-  (check-equal? (ctx-read ctx gsd-session-ctx-history-box) '() "initial history is empty")
-  (ctx-write! ctx gsd-session-ctx-history-box '(a b c))
-  (check-equal? (ctx-read ctx gsd-session-ctx-history-box) '(a b c)))
+  (check-equal? (gsd-ctx-history ctx) '() "initial history is empty")
+  (gsd-ctx-set-history! ctx '(a b c))
+  (check-equal? (gsd-ctx-history ctx) '(a b c)))
 
 (test-case "history update appends correctly"
   (define ctx (make-gsd-context))
-  (ctx-write! ctx gsd-session-ctx-history-box '(a))
-  (ctx-update! ctx gsd-session-ctx-history-box (lambda (h) (append h '(b))))
-  (check-equal? (ctx-read ctx gsd-session-ctx-history-box) '(a b)))
+  (gsd-ctx-set-history! ctx '(a))
+  (gsd-ctx-history-update! ctx (lambda (h) (append h '(b))))
+  (check-equal? (gsd-ctx-history ctx) '(a b)))
 
 ;; ============================================================
 ;; 10. Edit limit get/set roundtrip
@@ -154,9 +164,9 @@
 
 (test-case "edit-limit get/set roundtrip"
   (define ctx (make-gsd-context))
-  (check-equal? (ctx-read ctx gsd-session-ctx-edit-limit-box) 500 "default edit limit")
-  (ctx-write! ctx gsd-session-ctx-edit-limit-box 1000)
-  (check-equal? (ctx-read ctx gsd-session-ctx-edit-limit-box) 1000))
+  (check-equal? (gsd-ctx-edit-limit ctx) 500 "default edit limit")
+  (gsd-ctx-set-edit-limit! ctx 1000)
+  (check-equal? (gsd-ctx-edit-limit ctx) 1000))
 
 ;; ============================================================
 ;; 11. Pinned dir get/set roundtrip
@@ -164,9 +174,9 @@
 
 (test-case "pinned-dir get/set roundtrip"
   (define ctx (make-gsd-context))
-  (check-equal? (ctx-read ctx gsd-session-ctx-pinned-dir-box) #f)
-  (ctx-write! ctx gsd-session-ctx-pinned-dir-box "/tmp/planning")
-  (check-equal? (ctx-read ctx gsd-session-ctx-pinned-dir-box) "/tmp/planning"))
+  (check-equal? (gsd-ctx-pinned-dir ctx) #f)
+  (gsd-ctx-set-pinned-dir! ctx "/tmp/planning")
+  (check-equal? (gsd-ctx-pinned-dir ctx) "/tmp/planning"))
 
 ;; ============================================================
 ;; 12. Event bus get/set roundtrip
@@ -174,7 +184,7 @@
 
 (test-case "event-bus get/set roundtrip"
   (define ctx (make-gsd-context))
-  (check-equal? (ctx-read ctx gsd-session-ctx-event-bus-box) #f)
+  (check-equal? (gsd-ctx-event-bus ctx) #f)
   (define fake-bus (hasheq 'type 'event-bus))
-  (ctx-write! ctx gsd-session-ctx-event-bus-box fake-bus)
-  (check-equal? (ctx-read ctx gsd-session-ctx-event-bus-box) fake-bus))
+  (gsd-ctx-set-event-bus! ctx fake-bus)
+  (check-equal? (gsd-ctx-event-bus ctx) fake-bus))


### PR DESCRIPTION
Add gsd-ctx-busy/gsd-ctx-set-busy!/gsd-ctx-transaction/gsd-ctx-set-transaction!/gsd-ctx-transaction-update! named accessors. Update test-gsd-context-factory.rkt to use gsd-ctx-* named accessors instead of raw box accessor pattern. +25 lines net.