### PR TITLE
refactor(v0.69.5 W0): raw box accessor migration (#5965)

### DIFF
--- a/extensions/gsd/events.rkt
+++ b/extensions/gsd/events.rkt
@@ -12,7 +12,6 @@
          (only-in "../../agent/event-emitter.rkt" event-struct->hasheq)
          (only-in "session-state.rkt"
                   gsd-session-ctx?
-                  gsd-session-ctx-event-bus-box
                   gsd-default-ctx
                   gsd-ctx-event-bus))
 
@@ -26,7 +25,8 @@
          make-event-collector
          collector-events
          ctx-emit-gsd-event!
-         resolve-gsd-event-bus)
+         resolve-gsd-event-bus
+         emit-to-bus!)
 
 ;; ============================================================
 ;; Event taxonomy
@@ -99,7 +99,7 @@
 
 ;; Resolve event bus: prefer ctx-specific bus, fallback to global.
 (define (resolve-gsd-event-bus ctx)
-  (define ctx-bus (and ctx (unbox (gsd-session-ctx-event-bus-box ctx))))
+  (define ctx-bus (and ctx (gsd-ctx-event-bus ctx)))
   (or (and ctx-bus (procedure? ctx-bus) ctx-bus) (unbox gsd-event-bus-box)))
 
 ;; Emit to a specific session context's event bus.
@@ -129,6 +129,38 @@
                 'data
                 data)))
   (bus event-name wrapped))
+
+;; Emit to a pre-resolved bus (avoids semaphore re-acquisition inside transactions).
+(define (emit-to-bus! bus event-name data)
+  (unless (memq event-name gsd-event-names)
+    (raise-extension-error (format "Unknown event: ~a" event-name) 'gsd 'emit-event))
+  (define wrapped
+    (if (typed-event? data)
+        (hasheq 'event
+                event-name
+                'correlation-id
+                (current-gsd-correlation-id)
+                'timestamp
+                (current-inexact-milliseconds)
+                'data
+                (event-struct->hasheq data)
+                '__typed
+                #t)
+        (hasheq 'event
+                event-name
+                'correlation-id
+                (current-gsd-correlation-id)
+                'timestamp
+                (current-inexact-milliseconds)
+                'data
+                data)))
+  (when (and bus (procedure? bus))
+    (bus event-name wrapped))
+  ;; Fall back to global bus if ctx bus was #f or not a procedure
+  (unless (and bus (procedure? bus))
+    (define global-bus (unbox gsd-event-bus-box))
+    (when (procedure? global-bus)
+      (global-bus event-name wrapped))))
 
 ;; ============================================================
 ;; Event collector (for testing)

--- a/extensions/gsd/session-state.rkt
+++ b/extensions/gsd/session-state.rkt
@@ -64,6 +64,20 @@
                        (lambda ()
                          (set-box! (box-accessor ctx) (update-fn (unbox (box-accessor ctx)))))))
 
+;; Atomic state+history transaction. Runs thunk under semaphore with
+;; read-only state, history, event-bus and write callbacks for state and history.
+;; Avoids exposing raw box accessors to consumers.
+(define (gsd-ctx-transaction! ctx thunk)
+  (call-with-semaphore
+   (gsd-session-ctx-sem ctx)
+   (lambda ()
+     (define state (unbox (gsd-session-ctx-state-box ctx)))
+     (define history (unbox (gsd-session-ctx-history-box ctx)))
+     (define event-bus (unbox (gsd-session-ctx-event-bus-box ctx)))
+     (define (set-state! v) (set-box! (gsd-session-ctx-state-box ctx) v))
+     (define (set-history! v) (set-box! (gsd-session-ctx-history-box ctx) v))
+     (thunk state history event-bus set-state! set-history!))))
+
 ;; ============================================================
 ;; Per-session accessors (explicit ctx argument) — C-01 v0.35.1
 ;; ============================================================
@@ -224,16 +238,6 @@
 
 ;; Struct exports (plain)
 (provide gsd-session-ctx?
-         gsd-session-ctx-state-box
-         gsd-session-ctx-plan-box
-         gsd-session-ctx-pinned-dir-box
-         gsd-session-ctx-edit-limit-box
-         gsd-session-ctx-event-bus-box
-         gsd-session-ctx-history-box
-         gsd-session-ctx-busy-box
-         gsd-session-ctx-correlation-id-box
-         gsd-session-ctx-transaction-box
-         gsd-session-ctx-sem
          ;; Global default context (plain)
          gsd-default-ctx
          current-gsd-ctx
@@ -264,6 +268,7 @@
                        [gsd-ctx-transaction (-> gsd-session-ctx? hash?)]
                        [gsd-ctx-set-transaction! (-> gsd-session-ctx? hash? void?)]
                        [gsd-ctx-transaction-update! (-> gsd-session-ctx? procedure? void?)]
+                       [gsd-ctx-transaction! (-> gsd-session-ctx? procedure? any)]
                        [with-gsd-transaction (-> gsd-session-ctx? procedure? any)]
                        [gsd-ctx-state-snapshot (-> gsd-session-ctx? gsd-runtime-state?)]
                        [gsd-ctx-state-update! (-> gsd-session-ctx? procedure? any)]

--- a/extensions/gsd/state-machine.rkt
+++ b/extensions/gsd/state-machine.rkt
@@ -18,7 +18,7 @@
          racket/set
          "runtime-state-types.rkt"
          (only-in "policy.rkt" blocked-tools-for gsd-decide-action policy-allowed?)
-         (only-in "events.rkt" emit-gsd-event! ctx-emit-gsd-event! current-gsd-correlation-id)
+         (only-in "events.rkt" emit-gsd-event! ctx-emit-gsd-event! current-gsd-correlation-id emit-to-bus!)
          (only-in "event-structs.rkt"
                   make-gsd-transition-attempted-event
                   make-gsd-transition-succeeded-event
@@ -30,10 +30,7 @@
                   gsd-state-snapshot
                   gsd-history-snapshot
                   gsd-state-update!
-                  with-gsd-lock
                   gsd-default-ctx
-                  gsd-session-ctx-state-box
-                  gsd-session-ctx-history-box
                   gsd-session-ctx?
                   gsd-ctx-state
                   gsd-ctx-set-state!
@@ -42,7 +39,7 @@
                   gsd-ctx-history
                   gsd-ctx-set-history!
                   gsd-ctx-history-update!
-                  gsd-session-ctx-sem))
+                  gsd-ctx-transaction!))
 
 ;; States
 ;; Struct exports (plain)
@@ -209,39 +206,36 @@
       current-state)]))
 
 (define (gsm-transition! target #:event [event #f])
-  ;; R-01: Direct box access inside with-gsd-lock to avoid nested semaphore deadlock.
-  ;; gsd-state-snapshot/gsd-state-update! call with-gsd-lock internally,
-  ;; causing deadlock on the same non-reentrant semaphore.
-  (with-gsd-lock
-   (lambda ()
-     (define state (unbox (gsd-session-ctx-state-box gsd-default-ctx)))
+  (gsd-ctx-transaction!
+   gsd-default-ctx
+   (lambda (state history event-bus set-state! set-history!)
      (define current (gsd-runtime-state-mode state))
-     (ctx-emit-gsd-event!
-      (current-gsd-ctx)
+     (emit-to-bus!
+      event-bus
       'gsd.transition.attempted
       (make-gsd-transition-attempted-event #:session-id "" #:turn-id 0 #:from current #:to target))
      (define-values (result new-state) (compute-next-gsm-state state target #:event event))
      (cond
        [(ok? result)
         (define new-mode (gsd-runtime-state-mode new-state))
-        (set-box! (gsd-session-ctx-state-box gsd-default-ctx) new-state)
-        (set-gsd-history! (cons (list current new-mode (current-seconds)) (current-gsd-history)))
-        (ctx-emit-gsd-event! (current-gsd-ctx)
-                             'gsd.transition.succeeded
-                             (make-gsd-transition-succeeded-event #:session-id ""
-                                                                  #:turn-id 0
-                                                                  #:from current
-                                                                  #:to new-mode))
+        (set-state! new-state)
+        (set-history! (cons (list current new-mode (current-seconds)) history))
+        (emit-to-bus! event-bus
+                      'gsd.transition.succeeded
+                      (make-gsd-transition-succeeded-event #:session-id ""
+                                                           #:turn-id 0
+                                                           #:from current
+                                                           #:to new-mode))
         result]
        [else
-        (ctx-emit-gsd-event! (current-gsd-ctx)
-                             'gsd.transition.failed
-                             (make-gsd-transition-failed-event
-                              #:session-id ""
-                              #:turn-id 0
-                              #:from current
-                              #:to target
-                              #:reason (format "invalid: ~a -> ~a" current target)))
+        (emit-to-bus! event-bus
+                      'gsd.transition.failed
+                      (make-gsd-transition-failed-event
+                       #:session-id ""
+                       #:turn-id 0
+                       #:from current
+                       #:to target
+                       #:reason (format "invalid: ~a -> ~a" current target)))
         result]))))
 
 ;; FF-01: Auto-routing transition — finds shortest path via BFS and follows it.
@@ -258,21 +252,21 @@
          (gsm-transition! target))]))
 
 (define (gsm-reset!)
-  ;; R-01: Direct box access inside with-gsd-lock to avoid nested semaphore deadlock.
-  (with-gsd-lock (lambda ()
-                   (define state (unbox (gsd-session-ctx-state-box gsd-default-ctx)))
-                   (define old (gsd-runtime-state-mode state))
-                   (set-box! (gsd-session-ctx-state-box gsd-default-ctx)
-                             (struct-copy gsd-runtime-state state [mode 'idle] [wave-executor #f]))
-                   (set-gsd-history! (cons (list old 'idle (current-seconds)) (current-gsd-history)))
-                   (ok-result old 'idle))))
+  (gsd-ctx-transaction!
+   gsd-default-ctx
+   (lambda (state history event-bus set-state! set-history!)
+     (define old (gsd-runtime-state-mode state))
+     (set-state! (struct-copy gsd-runtime-state state [mode 'idle] [wave-executor #f]))
+     (set-history! (cons (list old 'idle (current-seconds)) history))
+     (ok-result old 'idle))))
 
 (define (reset-gsm!)
-  ;; R-01: Use set-gsd-state!/set-gsd-history! directly inside with-gsd-lock.
-  (with-gsd-lock (lambda ()
-                   (set-box! (gsd-session-ctx-state-box gsd-default-ctx) (make-initial-gsd-state))
-                   (set-gsd-history! '())
-                   (void))))
+  (gsd-ctx-transaction!
+   gsd-default-ctx
+   (lambda (state history event-bus set-state! set-history!)
+     (set-state! (make-initial-gsd-state))
+     (set-history! '())
+     (void))))
 
 (define (gsm-valid-next-states)
   (define current (gsm-current))
@@ -432,51 +426,45 @@
   (valid-targets (gsm-ctx-current ctx)))
 
 (define (gsm-ctx-transition! ctx target #:event [event #f])
-  (call-with-semaphore
-   (gsd-session-ctx-sem ctx)
-   (lambda ()
-     (define state (unbox (gsd-session-ctx-state-box ctx)))
+  (gsd-ctx-transaction!
+   ctx
+   (lambda (state history event-bus set-state! set-history!)
      (define current (gsd-runtime-state-mode state))
-     (ctx-emit-gsd-event!
-      ctx
+     (emit-to-bus!
+      event-bus
       'gsd.transition.attempted
       (make-gsd-transition-attempted-event #:session-id "" #:turn-id 0 #:from current #:to target))
      (define-values (result new-state) (compute-next-gsm-state state target #:event event))
      (cond
        [(ok? result)
         (define new-mode (gsd-runtime-state-mode new-state))
-        (set-box! (gsd-session-ctx-state-box ctx) new-state)
-        (set-box! (gsd-session-ctx-history-box ctx)
-                  (cons (list current new-mode (current-seconds))
-                        (unbox (gsd-session-ctx-history-box ctx))))
-        (ctx-emit-gsd-event! ctx
-                             'gsd.transition.succeeded
-                             (make-gsd-transition-succeeded-event #:session-id ""
-                                                                  #:turn-id 0
-                                                                  #:from current
-                                                                  #:to new-mode))
+        (set-state! new-state)
+        (set-history! (cons (list current new-mode (current-seconds)) history))
+        (emit-to-bus! event-bus
+                      'gsd.transition.succeeded
+                      (make-gsd-transition-succeeded-event #:session-id ""
+                                                           #:turn-id 0
+                                                           #:from current
+                                                           #:to new-mode))
         result]
        [else
-        (ctx-emit-gsd-event! ctx
-                             'gsd.transition.failed
-                             (make-gsd-transition-failed-event
-                              #:session-id ""
-                              #:turn-id 0
-                              #:from current
-                              #:to target
-                              #:reason (format "invalid: ~a -> ~a" current target)))
+        (emit-to-bus! event-bus
+                      'gsd.transition.failed
+                      (make-gsd-transition-failed-event
+                       #:session-id ""
+                       #:turn-id 0
+                       #:from current
+                       #:to target
+                       #:reason (format "invalid: ~a -> ~a" current target)))
         result]))))
 
 (define (gsm-ctx-reset! ctx)
-  (call-with-semaphore
-   (gsd-session-ctx-sem ctx)
-   (lambda ()
-     (define state (unbox (gsd-session-ctx-state-box ctx)))
+  (gsd-ctx-transaction!
+   ctx
+   (lambda (state history event-bus set-state! set-history!)
      (define old (gsd-runtime-state-mode state))
-     (set-box! (gsd-session-ctx-state-box ctx)
-               (struct-copy gsd-runtime-state state [mode 'idle] [wave-executor #f]))
-     (set-box! (gsd-session-ctx-history-box ctx)
-               (cons (list old 'idle (current-seconds)) (unbox (gsd-session-ctx-history-box ctx))))
+     (set-state! (struct-copy gsd-runtime-state state [mode 'idle] [wave-executor #f]))
+     (set-history! (cons (list old 'idle (current-seconds)) history))
      (ok-result old 'idle))))
 
 ;; Auto-routing multi-step transition (ctx-aware)


### PR DESCRIPTION
Remove raw box accessor exports from session-state.rkt. Migrate state-machine.rkt (15 sites) and events.rkt (1 site) to gsd-ctx-transaction!/emit-to-bus!. Add emit-to-bus! with global fallback. Net -25 LOC raw box boilerplate.