### PR TITLE
refactor(v0.69.5 W1): TUI cleanup - remove take-safe + truncate-str (#5966)

### DIFF
--- a/tui/builtins.rkt
+++ b/tui/builtins.rkt
@@ -9,7 +9,8 @@
          racket/string
          "component.rkt"
          "state.rkt"
-         (only-in "../util/shared.rkt" take-at-most))
+         (only-in "../util/shared.rkt" take-at-most)
+         (only-in "../util/string-helpers.rkt" truncate-string))
 
 ;; ═══════════════════════════════════════════════════════════════════
 ;; Provides
@@ -33,8 +34,7 @@
          settings-entry-type
 
          ;; Helpers
-         filter-options
-         truncate-str)
+         filter-options)
 
 ;; ═══════════════════════════════════════════════════════════════════
 ;; Helpers
@@ -45,11 +45,6 @@
       options
       (filter (lambda (o) (string-contains? (string-downcase o) (string-downcase filter-text)))
               options)))
-
-(define (truncate-str s max-len)
-  (if (> (string-length s) max-len)
-      (string-append (substring s 0 (max 0 (- max-len 3))) "...")
-      s))
 
 (define (drop-at-most lst n)
   (drop lst (min n (length lst))))
@@ -131,7 +126,7 @@
      (define inner-width (max 10 (- width 4)))
      (define top (format "╭─~a─╮" (make-string (max 0 (- inner-width 2)) #\─)))
      (define bottom (format "╰─~a─╯" (make-string (max 0 (- inner-width 2)) #\─)))
-     (define text (format "│ ~a ~a │" spinner (truncate-str status-text (max 1 (- inner-width 4)))))
+     (define text (format "│ ~a ~a │" spinner (truncate-string status-text (max 1 (- inner-width 4)))))
      (list (list (cons 'text top)) (list (cons 'text text)) (list (cons 'text bottom))))
    #:id id
    #:handle-input (lambda (data ui-state)

--- a/tui/state-events.rkt
+++ b/tui/state-events.rkt
@@ -65,7 +65,7 @@
 ;; Dedup guard: prevent duplicate tool-start entries
 (define (recent-tool-start? st name)
   (define transcript (ui-state-transcript st))
-  (define recent (take-safe transcript dedup-window-size))
+  (define recent (take transcript (min dedup-window-size (length transcript))))
   (for/or ([entry (in-list recent)])
     (and (eq? (transcript-entry-kind entry) 'tool-start)
          (equal? (hash-ref (transcript-entry-meta entry) 'name "") name))))
@@ -73,19 +73,10 @@
 ;; Dedup guard: prevent duplicate tool-end entries
 (define (recent-tool-end? st name)
   (define transcript (ui-state-transcript st))
-  (define recent (take-safe transcript dedup-window-size))
+  (define recent (take transcript (min dedup-window-size (length transcript))))
   (for/or ([entry (in-list recent)])
     (and (memq (transcript-entry-kind entry) '(tool-end tool-fail))
          (equal? (hash-ref (transcript-entry-meta entry) 'name "") name))))
-
-;; Safe take — returns up to n elements from lst (iterative, no stack overflow)
-(define (take-safe lst n)
-  (let loop ([lst lst]
-             [n n]
-             [acc '()])
-    (if (or (<= n 0) (null? lst))
-        (reverse acc)
-        (loop (cdr lst) (- n 1) (cons (car lst) acc)))))
 
 ;; ============================================================
 ;; Named event handlers (extracted from case dispatch)


### PR DESCRIPTION
Remove take-safe (use take+min), replace truncate-str with canonical truncate-string from string-helpers.rkt. Net -14 LOC dead code.