### PR TITLE
feat(v0.69.5): safe-mode contracts + version bump (#5967)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v0.69.5 — 2026-05-25
+
+### Audit Hotfix
+
+- **F2 CRITICAL**: Remove raw box accessor exports from `session-state.rkt`. Migrate 16 call sites in `state-machine.rkt` and `events.rkt` to `gsd-ctx-transaction!` / `emit-to-bus!`. Add `emit-to-bus!` with global fallback.
+- **W1**: Remove local `take-safe` from `tui/state-events.rkt` — use `take` + `min` instead.
+- **W3**: Remove duplicate `truncate-str` from `tui/builtins.rkt` — use canonical `truncate-string` from `util/string-helpers.rkt`.
+- **W4**: Add `contract-out` to 5 struct accessors and `make-safe-mode-config` in `util/safe-mode-state.rkt`. Remove double-contract from `runtime/safe-mode.rkt` re-export.
+
 ## v0.69.4 — 2026-05-25
 
 ### Abstraction Quality: Boundary Tightening

--- a/README.md
+++ b/README.md
@@ -509,6 +509,9 @@ When q executes shell commands on behalf of an LLM, arguments are quoted via `sh
 
 
 
+
+**v0.69.5** — Audit Hotfix
+
 **v0.69.4** — Abstraction Quality: Boundary Tightening
 
 **v0.69.3** — Abstraction Quality: Declarative Patterns

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -2,7 +2,7 @@
 
 ## Version
 
-v0.69.4
+v0.69.5
 
 ## Native TUI Stack
 

--- a/docs/event-taxonomy.md
+++ b/docs/event-taxonomy.md
@@ -1,6 +1,6 @@
 # Q Event Taxonomy Reference
 
-Complete reference for all event types in Q 0.69.4.
+Complete reference for all event types in Q 0.69.5.
 ## Base Types
 
 ### `event` (protocol-level)

--- a/docs/extension-guide.md
+++ b/docs/extension-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.69.4 --># Extension Development Guide
+<!-- verified-against: 0.69.5 --># Extension Development Guide
 
 This guide walks you through creating, testing, and activating a custom
 extension for q.

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.69.4 --># Getting Started
+<!-- verified-against: 0.69.5 --># Getting Started
 
 Welcome to q, a Racket-based coding agent.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.69.4 --># Installation Guide
+<!-- verified-against: 0.69.5 --># Installation Guide
 
 <!-- This file is the canonical source. The docs/getting-started/installation.md copy is maintained for the doc site build. -->
 

--- a/docs/security-trust-model.md
+++ b/docs/security-trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.69.4 --># Security & Trust Model
+<!-- verified-against: 0.69.5 --># Security & Trust Model
 
 This document provides an honest, per-area assessment of what q enforces
 today and what is planned. It is the authoritative reference for security

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -130,6 +130,6 @@ is the primary self-hosting extension:
 (load-extension! ext-reg "path/to/extension.rkt" #:event-bus bus)
 ```
 
-## Version 0.69.4
+## Version 0.69.5
 
-This documentation reflects q 0.69.4.
+This documentation reflects q 0.69.5.

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.69.4 --># q Source Style Guide
+<!-- verified-against: 0.69.5 --># q Source Style Guide
 
 This document defines formatting and naming conventions for the q Racket codebase.
 All changes to `q/` source files (excluding `tests/`) should follow these rules.

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.69.4 -->
+<!-- verified-against: 0.69.5 -->
 # Trust Model
 
 ## Trust Levels

--- a/docs/workflow-testing.md
+++ b/docs/workflow-testing.md
@@ -121,6 +121,6 @@ Use relative paths from the test file:
 4. Use `(check-true ...)` for boolean assertions
 5. Keep tests independent — no shared mutable state between test-cases
 
-## Version 0.69.4
+## Version 0.69.5
 
-This documentation reflects q 0.69.4.
+This documentation reflects q 0.69.5.

--- a/runtime/safe-mode.rkt
+++ b/runtime/safe-mode.rkt
@@ -35,14 +35,6 @@
           [current-safe-mode (parameter/c boolean?)]
           [current-safe-mode-config (parameter/c (or/c safe-mode-config? #f))]
           [project-root (parameter/c path?)]
-          [make-safe-mode-config
-           (->* ()
-                (#:active boolean?
-                 #:allowed-tools (listof string?)
-                 #:allowed-paths (listof path?)
-                 #:locked boolean?
-                 #:project-root (or/c path? #f))
-                safe-mode-config?)]
           [safe-mode? (-> boolean?)]
           [allowed-tool? (-> string? boolean?)]
           [allowed-path? (-> (or/c path? string?) boolean?)]
@@ -53,7 +45,7 @@
           [lock-safe-mode! (-> void?)]
           [safe-mode-locked? (parameter/c boolean?)]
           [safe-mode-config-info (-> hash?)])
-         ;; Struct type + accessors (plain provide for struct)
+         ;; Struct type + contracted accessors (re-exported from safe-mode-state.rkt)
          safe-mode-config
          safe-mode-config?
          safe-mode-config-active
@@ -61,6 +53,7 @@
          safe-mode-config-allowed-paths
          safe-mode-config-locked
          safe-mode-config-project-root-path
+         make-safe-mode-config
          blocked-tools)
 
 ;; ============================================================

--- a/util/safe-mode-state.rkt
+++ b/util/safe-mode-state.rkt
@@ -9,7 +9,8 @@
 ;; Both runtime/safe-mode.rkt and util/safe-mode-predicates.rkt import
 ;; from here.
 
-(require racket/string)
+(require racket/string
+         racket/contract)
 
 ;; ============================================================
 ;; Parameters
@@ -148,15 +149,24 @@
  current-safe-mode-config
  project-root
 
- ;; Struct
+ ;; Struct type + predicate
  safe-mode-config
  safe-mode-config?
- safe-mode-config-active
- safe-mode-config-allowed-tools
- safe-mode-config-allowed-paths
- safe-mode-config-locked
- safe-mode-config-project-root-path
- make-safe-mode-config
+
+ ;; Struct accessors (contracted)
+ (contract-out
+  [make-safe-mode-config (->* ()
+                               (#:active boolean?
+                                #:allowed-tools (or/c #f (listof string?))
+                                #:allowed-paths (or/c #f (listof (or/c path? string?)))
+                                #:locked boolean?
+                                #:project-root (or/c path? string?))
+                               safe-mode-config?)]
+  [safe-mode-config-active (-> safe-mode-config? boolean?)]
+  [safe-mode-config-allowed-tools (-> safe-mode-config? any/c)]
+  [safe-mode-config-allowed-paths (-> safe-mode-config? any/c)]
+  [safe-mode-config-locked (-> safe-mode-config? boolean?)]
+  [safe-mode-config-project-root-path (-> safe-mode-config? (or/c path? #f))])
 
  ;; Constants
  blocked-tools

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -11,4 +11,4 @@
 
 (provide (contract-out [q-version string?]))
 
-(define q-version "0.69.4")
+(define q-version "0.69.5")

--- a/wiki-src/Architecture-Overview.md
+++ b/wiki-src/Architecture-Overview.md
@@ -35,7 +35,7 @@ User input → Interface (CLI/TUI/RPC)
     → Events emitted to bus
 ```
 
-## Metrics (0.69.4)
+## Metrics (0.69.5)
 > _See `racket scripts/metrics.rkt` for current numbers._
 
 - 414 source modules, 534 test files


### PR DESCRIPTION
Add contract-out to 5 struct accessors + make-safe-mode-config in safe-mode-state.rkt. Remove double-contract from safe-mode.rkt. Version bump 0.69.4 to 0.69.5. CHANGELOG + docs sync.