### PR TITLE
refactor(v0.69.7 W2): rename hex->color-object to hex->color-components (#5992)

### DIFF
--- a/gui/components/rich-transcript-view.rkt
+++ b/gui/components/rich-transcript-view.rkt
@@ -19,7 +19,7 @@
 
 (provide role->label
          role->color
-         hex->color-object
+         hex->color-components
          (contract-out
           [make-role-label-delta (-> string? (or/c string? #f) hash?)]
           [make-content-delta (-> (or/c string? #f) hash?)]
@@ -58,7 +58,7 @@
     [(tool) (theme-ref theme 'warning)]
     [else (theme-ref theme 'muted)]))
 
-(define (hex->color-object hex-str)
+(define (hex->color-components hex-str)
   (define cleaned (string-trim (or hex-str "#000000") "#" #:left? #t))
   (define r (string->number (substring cleaned 0 2) 16))
   (define g (string->number (substring cleaned 2 4) 16))

--- a/tests/test-gui-rich-transcript.rkt
+++ b/tests/test-gui-rich-transcript.rkt
@@ -25,19 +25,19 @@
                      (check-equal? (role->color "assistant" t) (theme-ref t 'foreground))
                      (check-equal? (role->color "system" t) (theme-ref t 'muted))
                      (check-equal? (role->color "tool" t) (theme-ref t 'warning)))
-                   ;; ── hex->color-object ──
-                   (test-case "hex->color-object parses hex with #"
-                     (define c (hex->color-object "#1e1e2e"))
+                   ;; ── hex->color-components ──
+                   (test-case "hex->color-components parses hex with #"
+                     (define c (hex->color-components "#1e1e2e"))
                      (check-equal? (hash-ref c 'r) 30)
                      (check-equal? (hash-ref c 'g) 30)
                      (check-equal? (hash-ref c 'b) 46))
-                   (test-case "hex->color-object handles no hash prefix"
-                     (define c (hex->color-object "ff0000"))
+                   (test-case "hex->color-components handles no hash prefix"
+                     (define c (hex->color-components "ff0000"))
                      (check-equal? (hash-ref c 'r) 255)
                      (check-equal? (hash-ref c 'g) 0)
                      (check-equal? (hash-ref c 'b) 0))
-                   (test-case "hex->color-object handles #f"
-                     (define c (hex->color-object #f))
+                   (test-case "hex->color-components handles #f"
+                     (define c (hex->color-components #f))
                      (check-equal? (hash-ref c 'r) 0))
                    ;; ── delta factories ──
                    (test-case "make-role-label-delta produces descriptor"


### PR DESCRIPTION
Renames hex->color-object to hex->color-components in rich-transcript-view.rkt and test file. Closes #5992