### PR TITLE
docs(v0.70.0 W0): audit baseline inventory report (#6001)

### DIFF
--- a/docs/reports/v0.70.0-audit-baseline.md
+++ b/docs/reports/v0.70.0-audit-baseline.md
@@ -1,0 +1,92 @@
+# v0.70.0 Audit Baseline Report
+
+**Date:** 2026-05-29
+**Version:** 0.69.7
+**Commit:** `1716c3fc`
+**Status:** Baseline captured for v0.70.xx series
+
+---
+
+## 1. Version & Commit
+
+- `q-version`: `"0.69.7"`
+- HEAD: `1716c3fc`
+- Tag: `v0.69.7`
+
+## 2. Lint Status
+
+- **lint-all.rkt**: 21 passed, 1 failed (release-readiness — expected on non-main branch), 1 warning (arch, non-blocking)
+- **lint-doc-freshness.rkt**: PASSED (10 canonical docs verified)
+- **lint-deprecation-deadlines.rkt --ci**: PASSED (no expired version-gated TODOs)
+
+## 3. Stale Doc Markers
+
+Docs with stale `verified-against` markers (not at 0.69.7):
+
+| Doc | verified-against |
+|-----|-----------------|
+| docs/security.md | 0.30.16 |
+| docs/sdk-rpc-catalog.md | 0.24.9 |
+| docs/why-q.md | 0.24.9 |
+| docs/package-registry-spec.md | 0.24.9 |
+| docs/ecosystem/publishing-guide.md | 0.24.9 |
+| docs/ecosystem/verification-workflow.md | 0.24.9 |
+| docs/compatibility-matrix.md | 0.24.9 |
+| docs/publish-verify-workflow.md | 0.24.9 |
+| docs/api-stability.md | 0.24.9 |
+| docs/releasing.md | 0.57.1 |
+
+**Total stale markers:** 10 docs (most at 0.24.9)
+
+## 4. Top 20 Largest Test Files
+
+| Lines | File |
+|-------|------|
+| 1202 | tests/test-cli.rkt |
+| 1147 | tests/test-gemini.rkt |
+| 1123 | tests/interfaces/tui.rkt |
+| 1069 | tests/test-golden-flows.rkt |
+| 1038 | tests/test-sdk.rkt |
+| 1025 | tests/tui/state.rkt |
+| 1024 | tests/test-gsd-planning.rkt |
+| 1010 | tests/tui/render.rkt |
+| 939 | tests/test-anthropic.rkt |
+| 921 | tests/test-main.rkt |
+| 856 | tests/test-replay.rkt |
+| 771 | tests/tui/input.rkt |
+| 745 | tests/test-hooks-complete.rkt |
+| 738 | tests/test-session-store.rkt |
+| 673 | tests/test-session-index.rkt |
+| 667 | tests/test-agent-session-basic.rkt |
+| 658 | tests/test-compactor.rkt |
+| 585 | tests/test-gsd-archive.rkt |
+| 584 | tests/test-settings.rkt |
+
+**Total test lines:** 111,234
+
+## 5. TODO/FIXME Counts
+
+- **Files with TODOs:** 7 files, 27 lines total
+- **Files with FIXMEs:** 1 file, 2 lines total
+- **Combined:** 29 markers across 8 files
+
+## 6. Trace Logging Baseline
+
+- `runtime/trace-sink.rkt`: Defines `trace-sink<%>` interface with `trace-write!`, `trace-flush!`, `trace-close!`.
+- Implementations: `file-trace-sink%` (default, sync file I/O), `port-trace-sink%`, `null-trace-sink%`.
+- `runtime/trace-logger.rkt`: Subscribes to event bus, writes synchronously via configured sink.
+- **Key issue:** `file-trace-sink%` writes and flushes synchronously on each event — blocks caller thread.
+
+## 7. Credential Backend Baseline
+
+- `runtime/credential-backend.rkt`: Backend struct with store/load/delete/list/available? functions.
+- Backends: file (JSON), env, memory, keychain (`secret-tool`), chained (fallback chain).
+- **Key issue:** File fallback is silent. No policy model for warning/requiring keychain.
+- **Key issue:** Only Linux `secret-tool` keychain supported — no macOS `security` or Windows Credential Manager.
+
+## 8. Test Metrics (from README)
+
+- Source modules: 506
+- Source lines: 76,847
+- Test lines: 116,132
+- Test assertions: 18,396


### PR DESCRIPTION
Baseline inventory report for v0.70.xx series: version, lint status, stale docs, large tests, TODO/FIXME counts, trace logging and credential backend baselines. Closes #6001