### PR TITLE
feat(v0.70.0 W1): mockable command runner seam (#6002)

### DIFF
--- a/runtime/credential-backend.rkt
+++ b/runtime/credential-backend.rkt
@@ -10,7 +10,8 @@
 ;; OS keychain (secret-tool / macOS security), and chained (fallback chain).
 
 (require "../util/json-helpers.rkt"
-         "../util/error-helpers.rkt")
+         "../util/error-helpers.rkt"
+         racket/function)
 (require "../util/errors.rkt")
 (require racket/contract
          json
@@ -21,8 +22,11 @@
          racket/list
          racket/port)
 
-;; Backend struct
-(provide credential-backend
+;; Command runner seam for keychain backends (mockable for tests)
+(provide current-external-command-runner
+
+         ;; Backend struct
+         credential-backend
          credential-backend?
          credential-backend-name
          credential-backend-store-fn
@@ -229,6 +233,26 @@
 ;; OS Keychain backend — uses secret-tool (Linux) or security (macOS)
 ;; ═══════════════════════════════════════════════════════════════════
 
+;; ═══════════════════════════════════════════════════════════════════
+;; Command runner seam — injectable for testing
+;; ═══════════════════════════════════════════════════════════════════
+
+;; Default: runs command via subprocess. Returns (values exit-code stdout-string).
+;; Override for testing: (parameterize ([current-external-command-runner mock-fn]) ...)
+(define current-external-command-runner
+  (make-parameter (λ (executable-path args #:stdin [stdin-str #f])
+                    (with-safe-fallback (values 1 "")
+                                        (define-values (sp out-port in-port err-port)
+                                          (subprocess #f #f #f executable-path args))
+                                        (when stdin-str
+                                          (display stdin-str in-port)
+                                          (close-output-port in-port))
+                                        (define out (open-output-string))
+                                        (copy-port out-port out)
+                                        (close-input-port out-port)
+                                        (close-input-port err-port)
+                                        (values (subprocess-status sp) (get-output-string out))))))
+
 ;; Key attribute for secret-tool: q-agent/provider/<name>
 (define (keychain-attrs provider-name)
   (list (cons "application" "q-agent") (cons "provider" provider-name)))
@@ -236,20 +260,10 @@
 (define (keychain-label provider-name)
   (format "q-agent: ~a" provider-name))
 
-;; Run secret-tool with argument vector (no shell interpolation).
+;; Run secret-tool via the injectable command runner.
 ;; Returns (values exit-code stdout-string).
 (define (run-secret-tool args #:stdin [stdin-str #f])
-  (with-safe-fallback (values 1 "")
-                      (define-values (sp out-port in-port err-port)
-                        (subprocess #f #f #f (find-executable-path "secret-tool") args))
-                      (when stdin-str
-                        (display stdin-str in-port)
-                        (close-output-port in-port))
-                      (define out (open-output-string))
-                      (copy-port out-port out)
-                      (close-input-port out-port)
-                      (close-input-port err-port)
-                      (values (subprocess-status sp) (get-output-string out))))
+  ((current-external-command-runner) (find-executable-path "secret-tool") args #:stdin stdin-str))
 
 (define (secret-tool-available?)
   (with-safe-fallback #f (define-values (status _) (run-secret-tool '("--version"))) (= status 0)))

--- a/tests/test-credential-backend.rkt
+++ b/tests/test-credential-backend.rkt
@@ -16,6 +16,7 @@
                   make-memory-credential-backend
                   make-keychain-credential-backend
                   make-chained-credential-backend
+                  current-external-command-runner
                   credential-backend?
                   backend-name
                   backend-store!
@@ -241,3 +242,85 @@
   (define be (make-keychain-credential-backend))
   (when (not (backend-available? be))
     (check-equal? (backend-list-providers be) '())))
+
+;; ---------------------------------------------------------------------------
+;; Tests: mockable command runner seam
+;; ---------------------------------------------------------------------------
+
+(test-case "command-runner-seam: mock overrides keychain availability"
+  ;; Mock that always reports success for --version
+  (define mock-runner (λ (exe-path args #:stdin [stdin-str #f]) (values 0 "secret-tool 0.1")))
+  (parameterize ([current-external-command-runner mock-runner])
+    (define be (make-keychain-credential-backend))
+    (check-true (backend-available? be))))
+
+(test-case "command-runner-seam: mock returns #f on unavailable"
+  ;; Mock that always fails
+  (define mock-runner (λ (exe-path args #:stdin [stdin-str #f]) (values 1 "")))
+  (parameterize ([current-external-command-runner mock-runner])
+    (define be (make-keychain-credential-backend))
+    (check-false (backend-available? be))))
+
+(test-case "command-runner-seam: mock store and load roundtrip"
+  ;; Mock that tracks stored secrets
+  (define stored-secrets (make-hash))
+  (define mock-runner
+    (λ (exe-path args #:stdin [stdin-str #f])
+      (cond
+        ;; --version check
+        [(and (pair? args) (equal? (car args) "--version")) (values 0 "secret-tool 0.1")]
+        ;; store
+        [(and (pair? args) (equal? (car args) "store"))
+         (define provider
+           (let loop ([a (cdr args)])
+             (cond
+               [(null? a) "unknown"]
+               [(equal? (car a) "--provider") (and (pair? (cdr a)) (cadr a))]
+               [else (loop (cdr a))])))
+         (when stdin-str
+           (hash-set! stored-secrets provider (string-trim stdin-str)))
+         (values 0 "")]
+        ;; lookup
+        [(and (pair? args) (equal? (car args) "lookup"))
+         (define provider
+           (let loop ([a (cdr args)])
+             (cond
+               [(null? a) "unknown"]
+               [(equal? (car a) "--provider") (and (pair? (cdr a)) (cadr a))]
+               [else (loop (cdr a))])))
+         (define val (hash-ref stored-secrets provider #f))
+         (if val
+             (values 0 val)
+             (values 1 ""))]
+        ;; clear
+        [(and (pair? args) (equal? (car args) "clear")) (values 0 "")]
+        [else (values 0 "")])))
+  (parameterize ([current-external-command-runner mock-runner])
+    (define be (make-keychain-credential-backend))
+    (check-true (backend-available? be))
+    ;; Store
+    (backend-store! be "openai" "sk-mock-key-123")
+    ;; Load
+    (define cred (backend-load be "openai"))
+    (check-not-false cred)
+    (check-equal? (hash-ref cred 'api-key) "sk-mock-key-123")
+    (check-equal? (hash-ref cred 'source) "keychain")))
+
+(test-case "command-runner-seam: mock delete succeeds"
+  (define mock-runner (λ (exe-path args #:stdin [stdin-str #f]) (values 0 "")))
+  (parameterize ([current-external-command-runner mock-runner])
+    (define be (make-keychain-credential-backend))
+    ;; delete! should not raise even with mock
+    (backend-delete! be "openai")))
+
+(test-case "command-runner-seam: mock store failure raises"
+  (define mock-runner
+    (λ (exe-path args #:stdin [stdin-str #f])
+      (cond
+        [(and (pair? args) (equal? (car args) "--version")) (values 0 "secret-tool 0.1")]
+        [(and (pair? args) (equal? (car args) "store")) (values 1 "error: store failed")]
+        [else (values 0 "")])))
+  (parameterize ([current-external-command-runner mock-runner])
+    (define be (make-keychain-credential-backend))
+    (check-true (backend-available? be))
+    (check-exn exn:fail? (λ () (backend-store! be "openai" "sk-test")))))


### PR DESCRIPTION
Adds current-external-command-runner parameter to credential-backend.rkt, enabling mock-based keychain tests. 5 new test cases for mock store/load/delete/availability. Closes #6002