### PR TITLE
feat(v0.70.1 W0): credential policy model (#6005)

### DIFF
--- a/runtime/credential-backend.rkt
+++ b/runtime/credential-backend.rkt
@@ -34,6 +34,9 @@
          credential-backend-delete-fn
          credential-backend-list-fn
          credential-backend-available?-fn
+         ;; Credential policy (v0.70.1)
+         credential-policy?
+         valid-credential-policies
          (contract-out
           [make-file-credential-backend (->* () ((or/c path-string? #f)) credential-backend?)]
           [make-env-credential-backend (-> credential-backend?)]
@@ -46,7 +49,12 @@
            (->* (credential-backend? string?) (#:env-var (or/c string? #f)) (or/c hash? #f))]
           [backend-delete! (-> credential-backend? string? void?)]
           [backend-list-providers (-> credential-backend? (listof string?))]
-          [backend-available? (-> credential-backend? boolean?)]))
+          [backend-available? (-> credential-backend? boolean?)]
+          [make-policy-aware-backend
+           (->* (credential-backend?)
+                (#:policy (or/c 'auto 'keychain-preferred 'keychain-required 'env-only)
+                          #:warn-port (or/c output-port? #f))
+                credential-backend?)]))
 
 ;; ═══════════════════════════════════════════════════════════════════
 ;; Backend struct
@@ -372,3 +380,80 @@
 
 (define (shell-escape s)
   (string-replace s "'" "'\\''"))
+
+;; ═══════════════════════════════════════════════════════════════════
+;; Credential policy (v0.70.1)
+;; ═══════════════════════════════════════════════════════════════════
+
+;; Valid policy modes
+(define valid-credential-policies '(auto keychain-preferred keychain-required env-only))
+
+(define (credential-policy? v)
+  (and (symbol? v) (member v valid-credential-policies) #t))
+
+;; Policy-aware backend wrapper.
+;; Wraps an inner backend (typically chained) with policy enforcement.
+;;
+;; 'auto               — pass-through, no enforcement
+;; 'keychain-preferred — warn when falling back to file/env for store
+;; 'keychain-required  — raise on file store, warn on file load
+;; 'env-only           — raise on file store, file load returns #f
+(define (make-policy-aware-backend inner
+                                   #:policy [policy 'auto]
+                                   #:warn-port [warn-port (current-error-port)])
+  (case policy
+    [(auto) inner]
+    [else
+     (define (emit-warning msg)
+       (when warn-port
+         (fprintf warn-port "WARNING [credential-policy ~a]: ~a\n" policy msg)))
+     (define (file-fallback-violation action)
+       (raise-credential-error
+        (format "~a forbidden by credential policy '~a' — file fallback not allowed" action policy)
+        "policy"
+        (format "~a-forbidden" action)))
+     (credential-backend
+      (format "policy-aware(~a, ~a)" policy (backend-name inner))
+      ;; store!
+      (λ (be provider-name api-key)
+        (define inner-name (backend-name inner))
+        (cond
+          [(eq? policy 'keychain-required)
+           (when (member inner-name '("file" "chained"))
+             (file-fallback-violation "store"))
+           (backend-store! inner provider-name api-key)]
+          [(eq? policy 'env-only)
+           (when (member inner-name '("file" "chained" "keychain"))
+             (file-fallback-violation "store"))
+           (backend-store! inner provider-name api-key)]
+          [(eq? policy 'keychain-preferred)
+           (when (member inner-name '("file"))
+             (emit-warning
+              (format "storing credential for '~a' in file backend — consider using keychain or env" provider-name)))
+           (backend-store! inner provider-name api-key)]
+          [else (backend-store! inner provider-name api-key)]))
+      ;; load
+      (λ (be provider-name env-var)
+        (define inner-name (backend-name inner))
+        (cond
+          [(eq? policy 'env-only)
+           (if (member inner-name '("file" "keychain" "chained"))
+               (begin
+                 (emit-warning
+                  (format "loading credential for '~a' from '~a' blocked by env-only policy" provider-name inner-name))
+                 #f)
+               (backend-load inner provider-name #:env-var (or env-var #f)))]
+          [else
+           (define result (backend-load inner provider-name #:env-var (or env-var #f)))
+           (when (and result
+                      (eq? policy 'keychain-preferred)
+                      (member inner-name '("file")))
+             (emit-warning
+              (format "loaded credential for '~a' from file backend — consider using keychain" provider-name)))
+           result]))
+      ;; delete!
+      (λ (be provider-name) (backend-delete! inner provider-name))
+      ;; list
+      (λ (be) (backend-list-providers inner))
+      ;; available?
+      (λ (be) (backend-available? inner)))]))

--- a/runtime/settings.rkt
+++ b/runtime/settings.rkt
@@ -73,7 +73,10 @@
                        [steering-gentle-threshold (-> q-settings? number?)]
                        [steering-strong-threshold (-> q-settings? number?)]
                        [steering-hard-cap (-> q-settings? number?)]
-                       [steering-same-file-dedup? (-> q-settings? boolean?)])
+                       [steering-same-file-dedup? (-> q-settings? boolean?)]
+                       [credential-policy
+                        (-> q-settings?
+                            (or/c 'auto 'keychain-preferred 'keychain-required 'env-only))])
 
          ;; Sandbox settings (re-exported, not locally defined)
          sandbox-enabled?
@@ -396,3 +399,21 @@
 ;; Whether same-file dedup is enabled. Default: #t.
 (define (steering-same-file-dedup? settings)
   (setting-ref* settings '(steering same_file_dedup) #t))
+
+;; ============================================================
+;; Credential policy (v0.70.1)
+;; ============================================================
+
+;; Credential policy controls how credential backends behave when
+;; keychain is unavailable and file/env fallback would be used.
+;;
+;; Modes:
+;;   'auto               — current chain, no policy enforcement (default, backward-compatible)
+;;   'keychain-preferred — file fallback allowed with warning
+;;   'keychain-required  — file fallback forbidden for store/load
+;;   'env-only           — no local credential file writes
+;;
+;; Config key: credentials.policy
+
+(define (credential-policy settings)
+  (setting-ref* settings '(credentials policy) 'auto))

--- a/tests/test-credential-backend.rkt
+++ b/tests/test-credential-backend.rkt
@@ -17,13 +17,16 @@
                   make-keychain-credential-backend
                   make-chained-credential-backend
                   current-external-command-runner
+                  credential-policy?
+                  valid-credential-policies
                   credential-backend?
                   backend-name
                   backend-store!
                   backend-load
                   backend-delete!
                   backend-list-providers
-                  backend-available?))
+                  backend-available?
+                  make-policy-aware-backend))
 
 ;; ---------------------------------------------------------------------------
 ;; Helpers
@@ -324,3 +327,74 @@
     (define be (make-keychain-credential-backend))
     (check-true (backend-available? be))
     (check-exn exn:fail? (λ () (backend-store! be "openai" "sk-test")))))
+
+;; ---------------------------------------------------------------------------
+;; Tests: credential policy model (v0.70.1)
+;; ---------------------------------------------------------------------------
+
+(test-case "policy: auto passes through to inner"
+  (define mem (make-memory-credential-backend))
+  (define be (make-policy-aware-backend mem #:policy 'auto))
+  (backend-store! be "openai" "sk-test")
+  (define cred (backend-load be "openai"))
+  (check-not-false cred)
+  (check-equal? (hash-ref cred 'api-key) "sk-test"))
+
+(test-case "policy: keychain-preferred warns on file store"
+  (define warnings (open-output-string))
+  (define file-backend (make-file-credential-backend
+                        (build-path (find-system-path 'temp-dir) "cred-policy-test.json")))
+  (define be (make-policy-aware-backend file-backend
+                                        #:policy 'keychain-preferred
+                                        #:warn-port warnings))
+  (backend-store! be "testprov" "sk-test-warn")
+  (define warn-str (get-output-string warnings))
+  (check-true (string-contains? warn-str "consider using keychain"))
+  ;; cleanup
+  (define p (build-path (find-system-path 'temp-dir) "cred-policy-test.json"))
+  (when (file-exists? p) (delete-file p)))
+
+(test-case "policy: keychain-required raises on file store"
+  (define file-backend (make-file-credential-backend
+                        (build-path (find-system-path 'temp-dir) "cred-policy-req.json")))
+  (define be (make-policy-aware-backend file-backend #:policy 'keychain-required))
+  (check-exn exn:fail? (λ () (backend-store! be "openai" "sk-test"))))
+
+(test-case "policy: env-only raises on file store"
+  (define file-backend (make-file-credential-backend
+                        (build-path (find-system-path 'temp-dir) "cred-policy-env.json")))
+  (define be (make-policy-aware-backend file-backend #:policy 'env-only))
+  (check-exn exn:fail? (λ () (backend-store! be "openai" "sk-test"))))
+
+(test-case "policy: env-only returns #f on file load"
+  (define file-be (make-file-credential-backend
+                   (build-path (find-system-path 'temp-dir) "cred-envonly-load.json")))
+  (backend-store! file-be "openai" "sk-file")
+  (define be (make-policy-aware-backend file-be #:policy 'env-only #:warn-port #f))
+  (check-false (backend-load be "openai"))
+  ;; cleanup
+  (define p (build-path (find-system-path 'temp-dir) "cred-envonly-load.json"))
+  (when (file-exists? p) (delete-file p)))
+
+(test-case "policy: credential-policy? validates symbols"
+  (check-true (credential-policy? 'auto))
+  (check-true (credential-policy? 'keychain-required))
+  (check-false (credential-policy? 'invalid))
+  (check-false (credential-policy? "auto")))
+
+(test-case "policy: valid-credential-policies has all modes"
+  (check-equal? valid-credential-policies '(auto keychain-preferred keychain-required env-only)))
+
+(test-case "policy: keychain-required allows memory backend"
+  (define mem (make-memory-credential-backend))
+  (define be (make-policy-aware-backend mem #:policy 'keychain-required))
+  ;; memory backend is not file — should succeed
+  (backend-store! be "openai" "sk-mem-ok")
+  (define cred (backend-load be "openai"))
+  (check-not-false cred)
+  (check-equal? (hash-ref cred 'api-key) "sk-mem-ok"))
+
+(test-case "policy: backend-name reflects policy wrapper"
+  (define mem (make-memory-credential-backend))
+  (define be (make-policy-aware-backend mem #:policy 'keychain-preferred))
+  (check-true (string-contains? (backend-name be) "policy-aware")))


### PR DESCRIPTION
Credential policy model with 4 modes (auto, keychain-preferred, keychain-required, env-only). Policy-aware backend wrapper with store/load enforcement. 10 new tests. Closes #6005