### PR TITLE
feat(v0.70.3 W2): shell-risk-classifier setting + release (#6016)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v0.70.3 — 2026-05-29
+
+### Structured Shell Risk Classification
+
+- **W0**: Conservative shell tokenizer + structured risk classifier (`tools/shell-risk.rkt`)
+- **W0**: Risk types: destructive, network-pipe, command-substitution, eval, exec, windows-destructive
+- **W1**: Shadow-mode integration in `bash.rkt` — logs diagnostic when regex/classifier disagree
+- **W2**: Feature flag `shell-risk-classifier` setting (`regex`, `structured`, `both`)
+- **W2**: Default `regex` for backward compatibility
+
 ## v0.70.2 — 2026-05-29
 
 ### Cross-Platform Credential Backends + Windows Install

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.70.2-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.70.3-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 
@@ -202,7 +202,7 @@ bin/q --model gpt-5.4 "write a test"
 ### Verify
 
 ```bash
-bin/q --version            # q version 0.70.2
+bin/q --version            # q version 0.70.3
 raco test tests/           # run the full test suite
 ```
 
@@ -514,6 +514,9 @@ When q executes shell commands on behalf of an LLM, arguments are quoted via `sh
 
 
 
+
+
+**v0.70.3** — Cross-Platform Credential Backends + Windows Install
 
 **v0.70.2** — Credential Policy & Plaintext Fallback Warnings
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -2,7 +2,7 @@
 
 ## Version
 
-v0.70.2
+v0.70.3
 
 ## Native TUI Stack
 

--- a/docs/event-taxonomy.md
+++ b/docs/event-taxonomy.md
@@ -1,6 +1,6 @@
 # Q Event Taxonomy Reference
 
-Complete reference for all event types in Q 0.70.2.
+Complete reference for all event types in Q 0.70.3.
 ## Base Types
 
 ### `event` (protocol-level)

--- a/docs/extension-guide.md
+++ b/docs/extension-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.70.2 --># Extension Development Guide
+<!-- verified-against: 0.70.3 --># Extension Development Guide
 
 This guide walks you through creating, testing, and activating a custom
 extension for q.

--- a/docs/getting-started/credentials.md
+++ b/docs/getting-started/credentials.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.70.2 -->
+<!-- verified-against: 0.70.3 -->
 # Credential Management
 
 This document describes how q manages API keys and provider credentials,

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.70.2 --># Getting Started
+<!-- verified-against: 0.70.3 --># Getting Started
 
 Welcome to q, a Racket-based coding agent.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.70.2 --># Installation Guide
+<!-- verified-against: 0.70.3 --># Installation Guide
 
 <!-- This file is the canonical source. The docs/getting-started/installation.md copy is maintained for the doc site build. -->
 

--- a/docs/security-trust-model.md
+++ b/docs/security-trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.70.2 --># Security & Trust Model
+<!-- verified-against: 0.70.3 --># Security & Trust Model
 
 This document provides an honest, per-area assessment of what q enforces
 today and what is planned. It is the authoritative reference for security

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -130,6 +130,6 @@ is the primary self-hosting extension:
 (load-extension! ext-reg "path/to/extension.rkt" #:event-bus bus)
 ```
 
-## Version 0.70.2
+## Version 0.70.3
 
-This documentation reflects q 0.70.2.
+This documentation reflects q 0.70.3.

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.70.2 --># q Source Style Guide
+<!-- verified-against: 0.70.3 --># q Source Style Guide
 
 This document defines formatting and naming conventions for the q Racket codebase.
 All changes to `q/` source files (excluding `tests/`) should follow these rules.

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.70.2 -->
+<!-- verified-against: 0.70.3 -->
 # Trust Model
 
 ## Trust Levels

--- a/docs/workflow-testing.md
+++ b/docs/workflow-testing.md
@@ -121,6 +121,6 @@ Use relative paths from the test file:
 4. Use `(check-true ...)` for boolean assertions
 5. Keep tests independent — no shared mutable state between test-cases
 
-## Version 0.70.2
+## Version 0.70.3
 
-This documentation reflects q 0.70.2.
+This documentation reflects q 0.70.3.

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.70.2")
+(define version "0.70.3")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base" "gui-easy-lib"))

--- a/runtime/settings.rkt
+++ b/runtime/settings.rkt
@@ -76,7 +76,10 @@
                        [steering-same-file-dedup? (-> q-settings? boolean?)]
                        [credential-policy
                         (-> q-settings?
-                            (or/c 'auto 'keychain-preferred 'keychain-required 'env-only))])
+                            (or/c 'auto 'keychain-preferred 'keychain-required 'env-only))]
+                       [shell-risk-classifier
+                        (-> q-settings?
+                            (or/c 'regex 'structured 'both))])
 
          ;; Sandbox settings (re-exported, not locally defined)
          sandbox-enabled?
@@ -417,3 +420,17 @@
 
 (define (credential-policy settings)
   (setting-ref* settings '(credentials policy) 'auto))
+
+;; ============================================================
+;; Shell risk classifier mode (v0.70.3)
+;; ============================================================
+
+;; Controls which shell risk detection method to use.
+;; Modes:
+;;   'regex     — use regex-based patterns only (default, backward-compatible)
+;;   'structured — use structured classifier only
+;;   'both       — use both; classifier wins on disagreement
+;;
+;; Config key: security.shell-risk-classifier
+(define (shell-risk-classifier settings)
+  (setting-ref* settings '(security shell-risk-classifier) 'regex))

--- a/tests/test-tool-bash-security.rkt
+++ b/tests/test-tool-bash-security.rkt
@@ -8,6 +8,9 @@
 ;; safe-mode-aware block-destructive default.
 
 (require rackunit
+         (only-in "../runtime/settings.rkt"
+                  make-minimal-settings
+                  shell-risk-classifier)
          (only-in "../tools/builtins/bash.rkt"
                   tool-bash
                   destructive-command?
@@ -254,3 +257,17 @@
   (define diag (shell-risk-classifier-diagnostic "git push origin main --force"))
   ;; Either #f (agree) or a string (disagree) is acceptable
   (check-true (or (boolean? diag) (string? diag))))
+
+;; ── v0.70.3: Shell risk classifier setting ────────────────────────
+
+(test-case "shell-risk-classifier: defaults to 'regex"
+  (define settings (make-minimal-settings))
+  (check-equal? (shell-risk-classifier settings) 'regex))
+
+(test-case "shell-risk-classifier: reads from overrides"
+  (define settings (make-minimal-settings #:overrides (hash 'security (hash 'shell-risk-classifier 'both))))
+  (check-equal? (shell-risk-classifier settings) 'both))
+
+(test-case "shell-risk-classifier: structured mode"
+  (define settings (make-minimal-settings #:overrides (hash 'security (hash 'shell-risk-classifier 'structured))))
+  (check-equal? (shell-risk-classifier settings) 'structured))

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -11,4 +11,4 @@
 
 (provide (contract-out [q-version string?]))
 
-(define q-version "0.70.2")
+(define q-version "0.70.3")

--- a/wiki-src/Architecture-Overview.md
+++ b/wiki-src/Architecture-Overview.md
@@ -35,7 +35,7 @@ User input → Interface (CLI/TUI/RPC)
     → Events emitted to bus
 ```
 
-## Metrics (0.70.2)
+## Metrics (0.70.3)
 > _See `racket scripts/metrics.rkt` for current numbers._
 
 - 414 source modules, 534 test files


### PR DESCRIPTION
Shell risk classifier setting (`shell-risk-classifier` in settings.rkt). Default `regex`. Version bump to 0.70.3. Closes #6016