### PR TITLE
feat(v0.70.4 W1): async trace logger integration (#6019)

### DIFF
--- a/runtime/trace-logger.rkt
+++ b/runtime/trace-logger.rkt
@@ -17,7 +17,9 @@
 
 (provide (contract-out [make-trace-logger
                         (->* (event-bus? path-string?)
-                             (#:enabled? boolean? #:sink (or/c (is-a?/c trace-sink<%>) #f))
+                             (#:enabled? boolean?
+                              #:sink (or/c (is-a?/c trace-sink<%>) #f)
+                              #:async? boolean?)
                              trace-logger?)]
                        [trace-logger? (-> any/c boolean?)]
                        [start-trace-logger!
@@ -35,15 +37,16 @@
              [seq #:mutable]
              [sub-id #:mutable]
              [out-port #:mutable]
-             [sink #:mutable])
+             [sink #:mutable]
+             [async? #:mutable])
   #:transparent)
 
 ;; ============================================================
 ;; Constructor
 ;; ============================================================
 
-(define (make-trace-logger bus session-dir #:enabled? [enabled? #t] #:sink [sink #f])
-  (trace-logger bus session-dir enabled? 0 #f #f sink))
+(define (make-trace-logger bus session-dir #:enabled? [enabled? #t] #:sink [sink #f] #:async? [async? #f])
+  (trace-logger bus session-dir enabled? 0 #f #f sink async?))
 
 ;; ============================================================
 ;; Start / Stop
@@ -66,6 +69,11 @@
             ;; Open output port in append mode
             (open-output-file trace-path #:exists 'append))))
     (set-trace-logger-out-port! logger out)
+    ;; v0.70.4: wrap sink in async-trace-sink% when async? is enabled
+    (when (and (trace-logger-async? logger) (not (trace-logger-sink logger)))
+      (define trace-path (build-path (trace-logger-session-dir logger) "trace.jsonl"))
+      (define file-sink (new json-file-trace-sink% [path trace-path]))
+      (set-trace-logger-sink! logger (new async-trace-sink% [inner-sink file-sink])))
     ;; Subscribe to all events
     (define sub-id (subscribe! bus (lambda (evt) (handle-event! logger evt))))
     (set-trace-logger-sub-id! logger sub-id)))

--- a/runtime/trace-sink.rkt
+++ b/runtime/trace-sink.rkt
@@ -7,10 +7,12 @@
 ;; Allows swapping file/port/null sinks without changing trace-logger.
 
 (require racket/class
-         racket/contract)
+         racket/contract
+         json)
 
 (provide (contract-out [trace-sink<%> any/c]
                        [file-trace-sink% any/c]
+                       [json-file-trace-sink% any/c]
                        [port-trace-sink% any/c]
                        [null-trace-sink% any/c]
                        [async-trace-sink% any/c]))
@@ -33,6 +35,28 @@
       (unless out
         (set! out (open-output-file path #:exists exists-mode)))
       (write entry out)
+      (newline out))
+
+    (define/public (trace-flush!)
+      (when out
+        (flush-output out)))
+
+    (define/public (trace-close!)
+      (when out
+        (close-output-port out)
+        (set! out #f)))))
+
+;; JSON file trace sink (v0.70.4) — writes jsexpr via write-json
+(define json-file-trace-sink%
+  (class* object% (trace-sink<%>)
+    (init-field path [exists-mode 'append])
+    (super-new)
+    (define out #f)
+
+    (define/public (trace-write! entry)
+      (unless out
+        (set! out (open-output-file path #:exists exists-mode)))
+      (write-json entry out)
       (newline out))
 
     (define/public (trace-flush!)

--- a/tests/test-trace-logger.rkt
+++ b/tests/test-trace-logger.rkt
@@ -210,3 +210,35 @@
   (define output (get-output-string out))
   (check-true (string-contains? output "test.port") "trace event should appear in string port output")
   (delete-directory/files dir))
+
+;; ============================================================
+;; v0.70.4: Async trace logger integration
+;; ============================================================
+
+(test-case "async trace logger writes events via async sink"
+  (define dir (make-temp-dir))
+  (define bus (make-event-bus))
+  (define logger (make-trace-logger bus dir #:enabled? #t #:async? #t))
+  (start-trace-logger! logger)
+  (publish! bus (make-event "async.evt" (current-seconds) "s1" #f (hasheq 'key "async-val")))
+  (flush-trace-logger! logger)
+  (stop-trace-logger! logger)
+  (define entries (read-trace-jsonl dir))
+  (check >= (length entries) 1)
+  (check-equal? (hash-ref (car entries) 'phase #f) "async.evt")
+  (delete-directory/files dir))
+
+(test-case "async trace logger preserves sequence order"
+  (define dir (make-temp-dir))
+  (define bus (make-event-bus))
+  (define logger (make-trace-logger bus dir #:enabled? #t #:async? #t))
+  (start-trace-logger! logger)
+  (for ([i (in-range 10)])
+    (publish! bus (make-event (format "seq.~a" i) (current-seconds) "s1" #f (hasheq 'n i))))
+  (flush-trace-logger! logger)
+  (stop-trace-logger! logger)
+  (define entries (read-trace-jsonl dir))
+  (check-equal? (length entries) 10)
+  (define seqs (map (lambda (e) (hash-ref e 'seq #f)) entries))
+  (check-equal? seqs '(1 2 3 4 5 6 7 8 9 10))
+  (delete-directory/files dir))


### PR DESCRIPTION
Adds `#:async?` flag to `make-trace-logger`. When true, wraps a `json-file-trace-sink%` in `async-trace-sink%` for nonblocking trace writes. Default remains sync. 2 new integration tests. Closes #6019