### PR TITLE
feat(v0.70.6 W0): token estimate cache module (#6026)

### DIFF
--- a/tests/test-token-estimate-cache.rkt
+++ b/tests/test-token-estimate-cache.rkt
@@ -1,0 +1,63 @@
+#lang racket/base
+
+;; tests/test-token-estimate-cache.rkt — v0.70.6 W0
+
+(require rackunit
+         rackunit/text-ui
+         "../util/token-estimate-cache.rkt")
+
+;; Simple estimator for testing: tokens = string-length / 4 (rounded up)
+(define (test-estimator text)
+  (max 1 (ceiling (/ (string-length text) 4))))
+
+(define-test-suite test-token-estimate-cache
+
+  (test-case "cached-estimate: computes value on miss"
+    (clear-token-estimate-cache!)
+    (define result (cached-estimate-text-tokens test-estimator "hello world"))
+    (check-equal? result 3)
+    (define stats (token-estimate-cache-stats))
+    (check-equal? (hash-ref stats 'misses) 1)
+    (check-equal? (hash-ref stats 'hits) 0))
+
+  (test-case "cached-estimate: returns cached value on hit"
+    (clear-token-estimate-cache!)
+    (cached-estimate-text-tokens test-estimator "repeat me")
+    (define result (cached-estimate-text-tokens test-estimator "repeat me"))
+    (check-equal? result 3)
+    (define stats (token-estimate-cache-stats))
+    (check-equal? (hash-ref stats 'misses) 1)
+    (check-equal? (hash-ref stats 'hits) 1))
+
+  (test-case "cached-estimate: different texts have separate entries"
+    (clear-token-estimate-cache!)
+    (cached-estimate-text-tokens test-estimator "text one")
+    (cached-estimate-text-tokens test-estimator "text two")
+    (define stats (token-estimate-cache-stats))
+    (check-equal? (hash-ref stats 'entries) 2)
+    (check-equal? (hash-ref stats 'misses) 2))
+
+  (test-case "clear-token-estimate-cache! resets everything"
+    (clear-token-estimate-cache!)
+    (cached-estimate-text-tokens test-estimator "foo")
+    (clear-token-estimate-cache!)
+    (define stats (token-estimate-cache-stats))
+    (check-equal? (hash-ref stats 'entries) 0)
+    (check-equal? (hash-ref stats 'hits) 0)
+    (check-equal? (hash-ref stats 'misses) 0))
+
+  (test-case "make-token-estimate-cache: isolated from global cache"
+    (clear-token-estimate-cache!)
+    (define local (make-token-estimate-cache test-estimator))
+    (local "local only")
+    (check-equal? (hash-ref (token-estimate-cache-stats) 'entries) 0)
+    (check-equal? (local "local only") 3))
+
+  (test-case "make-token-estimate-cache: local cache accumulates hits"
+    (define local (make-token-estimate-cache test-estimator))
+    (local "hit me")
+    (local "hit me")
+    ;; Local caches don't expose stats, but we verify consistency
+    (check-equal? (local "hit me") 2)))
+
+(run-tests test-token-estimate-cache)

--- a/util/token-estimate-cache.rkt
+++ b/util/token-estimate-cache.rkt
@@ -1,0 +1,88 @@
+#lang racket/base
+
+;; util/token-estimate-cache.rkt — memoized token estimation cache
+;;
+;; Wraps text-based token estimation with a content-addressed cache.
+;; Reduces redundant computation when the same message content is
+;; estimated repeatedly (e.g. during context assembly iteration).
+
+(require racket/contract
+         racket/math)
+
+(provide (contract-out
+          [cached-estimate-text-tokens
+           (-> (-> string? exact-nonnegative-integer?) string? exact-nonnegative-integer?)]
+          [clear-token-estimate-cache! (-> void?)]
+          [token-estimate-cache-stats (-> (hash/c symbol? exact-nonnegative-integer?))]
+          [make-token-estimate-cache
+           (-> (-> string? exact-nonnegative-integer?) (-> string? exact-nonnegative-integer?))]))
+
+;; ============================================================
+;; Cache implementation
+;; ============================================================
+
+;; Mutable hash: content-hash -> estimated-token-count
+(define token-cache (make-hash))
+
+;; Total number of cache hits since last clear
+(define cache-hits (box 0))
+
+;; Total number of cache misses since last clear
+(define cache-misses (box 0))
+
+;; Compute a content hash for cache keying.
+;; Uses equal-hash-code for speed; collisions are acceptable for
+;; an estimation heuristic.
+(define (content-hash text)
+  (equal-hash-code text))
+
+;; cached-estimate-text-tokens : (string? -> exact-nonnegative-integer?) string? -> exact-nonnegative-integer?
+;;
+;; Looks up the token estimate for `text` in the cache. If absent,
+;; calls `estimator` to compute the value, stores it, and returns it.
+(define (cached-estimate-text-tokens estimator text)
+  (define key (content-hash text))
+  (cond
+    [(hash-has-key? token-cache key)
+     (set-box! cache-hits (add1 (unbox cache-hits)))
+     (hash-ref token-cache key)]
+    [else
+     (define result (estimator text))
+     (hash-set! token-cache key result)
+     (set-box! cache-misses (add1 (unbox cache-misses)))
+     result]))
+
+;; clear-token-estimate-cache! : -> void?
+;;
+;; Clears all cached entries and resets hit/miss counters.
+(define (clear-token-estimate-cache!)
+  (set! token-cache (make-hash))
+  (set-box! cache-hits 0)
+  (set-box! cache-misses 0))
+
+;; token-estimate-cache-stats : -> hash?
+;;
+;; Returns a hash with keys 'entries, 'hits, 'misses.
+(define (token-estimate-cache-stats)
+  (hash 'entries (hash-count token-cache) 'hits (unbox cache-hits) 'misses (unbox cache-misses)))
+
+;; make-token-estimate-cache : (string? -> exact-nonnegative-integer?) -> (string? -> exact-nonnegative-integer?)
+;;
+;; Returns a self-contained cached estimator function. Each call
+;; returns a fresh cache (isolated from the global one). Useful
+;; for testing and per-session isolation.
+(define (make-token-estimate-cache estimator)
+  (define local-cache (make-hash))
+  (define local-hits (box 0))
+  (define local-misses (box 0))
+  (lambda (text)
+    (define key (content-hash text))
+    (cond
+      [(hash-has-key? local-cache key)
+       (set-box! local-hits (add1 (unbox local-hits)))
+       (hash-ref local-cache key)]
+      [else
+       (define result (estimator text))
+       (hash-set! local-cache key result)
+       (set-box! local-misses (add1 (unbox local-misses)))
+       result])))


### PR DESCRIPTION
Adds `util/token-estimate-cache.rkt` — content-addressed memoization wrapper for text token estimation. Provides global `cached-estimate-text-tokens`, `clear-token-estimate-cache!`, `token-estimate-cache-stats`, and `make-token-estimate-cache` for isolated per-session caches. 6 tests. Closes #6026