### PR TITLE
feat(v0.70.7 W0): per-tool timeout-seconds field in tool struct (#6030)

### DIFF
--- a/tests/test-tool-timeout.rkt
+++ b/tests/test-tool-timeout.rkt
@@ -1,0 +1,31 @@
+#lang racket/base
+
+;; tests/test-tool-timeout.rkt — v0.70.7 W0
+
+(require rackunit
+         rackunit/text-ui
+         "../tools/tool.rkt")
+
+(define-test-suite test-tool-timeout
+
+  (test-case "make-tool without timeout defaults to #f"
+    (define t (make-tool "test" "desc" (hasheq) (lambda (args) args)))
+    (check-false (tool-timeout-seconds t)))
+
+  (test-case "make-tool with timeout-seconds"
+    (define t (make-tool "test" "desc" (hasheq) (lambda (args) args)
+                         #:timeout-seconds 30))
+    (check-equal? (tool-timeout-seconds t) 30))
+
+  (test-case "tool->jsexpr includes timeoutSeconds when set"
+    (define t (make-tool "test" "desc" (hasheq) (lambda (args) args)
+                         #:timeout-seconds 60))
+    (define j (tool->jsexpr t))
+    (check-equal? (hash-ref (hash-ref j 'function) 'timeoutSeconds) 60))
+
+  (test-case "tool->jsexpr omits timeoutSeconds when #f"
+    (define t (make-tool "test" "desc" (hasheq) (lambda (args) args)))
+    (define j (tool->jsexpr t))
+    (check-false (hash-has-key? (hash-ref j 'function) 'timeoutSeconds))))
+
+(run-tests test-tool-timeout)

--- a/tools/registry.rkt
+++ b/tools/registry.rkt
@@ -12,7 +12,8 @@
                   tool-description
                   tool-schema
                   tool-prompt-snippet
-                  tool-prompt-guidelines))
+                  tool-prompt-guidelines
+                  tool-timeout-seconds))
 
 (provide (contract-out [make-tool-registry (-> tool-registry?)]
                        [tool-registry-tools (-> tool-registry? (listof tool?))]
@@ -89,7 +90,11 @@
     (if (tool-prompt-guidelines t)
         (hash-set fn-with-snippet 'promptGuidelines (tool-prompt-guidelines t))
         fn-with-snippet))
-  (hasheq 'type "function" 'function fn-with-guidelines))
+  (define fn-with-timeout
+    (if (tool-timeout-seconds t)
+        (hash-set fn-with-guidelines 'timeoutSeconds (tool-timeout-seconds t))
+        fn-with-guidelines))
+  (hasheq 'type "function" 'function fn-with-timeout))
 
 ;; ── Active tool management ──
 

--- a/tools/tool-struct.rkt
+++ b/tools/tool-struct.rkt
@@ -14,7 +14,8 @@
                        [tool-prompt-guidelines (-> tool? (or/c string? #f))]
                        [tool-dangerous? (-> tool? boolean?)]
                        [tool-render-call (-> tool? (or/c procedure? #f))]
-                       [tool-render-result (-> tool? (or/c procedure? #f))])
+                       [tool-render-result (-> tool? (or/c procedure? #f))]
+                       [tool-timeout-seconds (-> tool? (or/c exact-nonnegative-integer? #f))])
          ;; Raw struct constructor -- ONLY for use by tools/tool.rkt make-tool.
          ;; All external construction MUST use make-tool from tools/tool.rkt.
          tool)
@@ -27,5 +28,6 @@
               prompt-guidelines
               render-call
               render-result
-              dangerous?)
+              dangerous?
+              timeout-seconds)
   #:transparent)

--- a/tools/tool.rkt
+++ b/tools/tool.rkt
@@ -47,13 +47,15 @@
          tool-execute
          tool-render-call
          tool-render-result
+         tool-timeout-seconds
          (contract-out [make-tool
                         (->* (string? string? hash? procedure?)
                              (#:prompt-snippet (or/c string? #f)
                                                #:render-call (or/c procedure? #f)
                                                #:render-result (or/c procedure? #f)
                                                #:prompt-guidelines (or/c string? #f)
-                                               #:dangerous? boolean?)
+                                               #:dangerous? boolean?
+                                               #:timeout-seconds (or/c exact-nonnegative-integer? #f))
                              tool?)]
                        [validate-tool-args (-> tool? hash? boolean?)])
          merge-tool-lists
@@ -138,7 +140,8 @@
                    #:render-call [render-call #f]
                    #:render-result [render-result #f]
                    #:prompt-guidelines [prompt-guidelines #f]
-                   #:dangerous? [dangerous? #f])
+                   #:dangerous? [dangerous? #f]
+                   #:timeout-seconds [timeout-seconds #f])
   (unless (string? name)
     (raise-argument-error 'make-tool "string?" name))
   (unless (string? description)
@@ -160,7 +163,8 @@
         prompt-guidelines
         render-call
         render-result
-        dangerous?))
+        dangerous?
+        timeout-seconds))
 
 ;; ============================================================
 ;; Progress emission


### PR DESCRIPTION
Adds `timeout-seconds` field to `tool` struct (10th positional field). `make-tool` accepts `#:timeout-seconds` keyword. `tool-timeout-seconds` accessor exported. `tool->jsexpr` serializes as `timeoutSeconds` when set. 4 tests. Closes #6030