### PR TITLE
feat(v0.70.7 W1): scheduler injects per-tool timeout into args (#6031)

### DIFF
--- a/tests/test-tool-timeout-scheduler.rkt
+++ b/tests/test-tool-timeout-scheduler.rkt
@@ -1,0 +1,47 @@
+#lang racket/base
+
+;; tests/test-tool-timeout-scheduler.rkt — v0.70.7 W1
+
+(require rackunit
+         rackunit/text-ui
+         "../tools/tool.rkt"
+         "../tools/scheduler.rkt")
+
+(define-test-suite test-tool-timeout-scheduler
+
+  (test-case "execute-single injects per-tool timeout into args"
+    (define args-received #f)
+    (define t (make-tool "timed" "desc" (hasheq) (lambda (args ctx)
+                                                    (set! args-received args)
+                                                    (make-success-result "ok"))
+                         #:timeout-seconds 42))
+    (define registry (make-tool-registry))
+    (register-tool! registry t)
+    (define tc (tool-call "id-1" "timed" (hasheq 'command "echo hi")))
+    (define result (run-tool-batch (list tc) registry))
+    (check-equal? (hash-ref args-received 'timeout) 42))
+
+  (test-case "user-provided timeout is not overwritten by tool default"
+    (define args-received #f)
+    (define t (make-tool "timed" "desc" (hasheq) (lambda (args ctx)
+                                                    (set! args-received args)
+                                                    (make-success-result "ok"))
+                         #:timeout-seconds 30))
+    (define registry (make-tool-registry))
+    (register-tool! registry t)
+    (define tc (tool-call "id-1" "timed" (hasheq 'command "echo hi" 'timeout 99)))
+    (define result (run-tool-batch (list tc) registry))
+    (check-equal? (hash-ref args-received 'timeout) 99))
+
+  (test-case "no timeout injection when tool timeout is #f"
+    (define args-received #f)
+    (define t (make-tool "plain" "desc" (hasheq) (lambda (args ctx)
+                                                    (set! args-received args)
+                                                    (make-success-result "ok"))))
+    (define registry (make-tool-registry))
+    (register-tool! registry t)
+    (define tc (tool-call "id-1" "plain" (hasheq 'command "echo hi")))
+    (define result (run-tool-batch (list tc) registry))
+    (check-false (hash-has-key? args-received 'timeout))))
+
+(run-tests test-tool-timeout-scheduler)

--- a/tools/scheduler.rkt
+++ b/tools/scheduler.rkt
@@ -43,7 +43,7 @@
                   tool-call-id
                   tool-call-name
                   tool-call-arguments)
-         (only-in "tool-struct.rkt" tool-execute tool-dangerous?)
+         (only-in "tool-struct.rkt" tool-execute tool-dangerous? tool-timeout-seconds)
          (only-in "scheduler-strategy.rkt"
                   scheduler-strategy?
                   scheduler-strategy-preflight-filter
@@ -308,7 +308,12 @@
         (make-error-result (format "tool '~a' blocked — approval denied" tc-name))]
        [else
         ;; R-03/R-22: Use tool-dangerous? metadata instead of hardcoded list
-        (define args (tool-call-arguments tc-to-execute))
+        (define raw-args (tool-call-arguments tc-to-execute))
+        ;; v0.70.7: Inject per-tool timeout into args if the tool defines one
+        (define args
+          (if (and (tool-timeout-seconds t) (not (hash-has-key? raw-args 'timeout)))
+              (hash-set raw-args 'timeout (tool-timeout-seconds t))
+              raw-args))
         (define exec-result
           (with-handlers ([exn:fail? (lambda (e)
                                        (make-error-result


### PR DESCRIPTION
Scheduler `execute-single` injects `tool-timeout-seconds` into tool args as `'timeout` when the tool defines one and the user hasn't provided an explicit timeout. Bash tool picks this up via existing `resolve-exec-limits`. 3 tests. Closes #6031