### PR TITLE
feat(v0.70.9 W1): convert util/event-access.rkt to typed/racket (#6039)

### DIFF
--- a/util/event-access.rkt
+++ b/util/event-access.rkt
@@ -1,35 +1,43 @@
-#lang racket/base
+#lang typed/racket
 
 ;; util/event-access.rkt — selector functions for event structs
+;;
+;; Migrated to #lang typed/racket in v0.70.9 W1.
+;; Previously used racket/contract; now relies on TR boundary contracts
+;; for untyped consumers.
+;;
 ;; Provides an abstraction layer over direct struct field access.
 ;; Use these selectors instead of calling event-ev, event-time, etc. directly.
 
-(require racket/contract
-         "event.rkt")
+(require "event.rkt")
 
-;; Selectors (contract-out)
-(provide (contract-out [event-type-ref (-> event? any/c)]
-                       [event-timestamp-ref (-> event? any/c)]
-                       [event-session-id-ref (-> event? (or/c string? #f))]
-                       [event-turn-id-ref (-> event? (or/c string? #f))]
-                       [event-payload-ref (-> event? any/c)])
-         ;; Re-export predicates and constructors for convenience (from typed/racket module)
+(provide event-type-ref
+         event-timestamp-ref
+         event-session-id-ref
+         event-turn-id-ref
+         event-payload-ref
          event?
          make-event)
 
 ;; Selector functions
 ;; The struct field for event type is 'ev' (aliased as event-event).
+
+(: event-type-ref : (-> event Any))
 (define (event-type-ref evt)
   (event-ev evt))
 
+(: event-timestamp-ref : (-> event Real))
 (define (event-timestamp-ref evt)
   (event-time evt))
 
+(: event-session-id-ref : (-> event (Option String)))
 (define (event-session-id-ref evt)
   (event-session-id evt))
 
+(: event-turn-id-ref : (-> event (Option String)))
 (define (event-turn-id-ref evt)
   (event-turn-id evt))
 
+(: event-payload-ref : (-> event Any))
 (define (event-payload-ref evt)
   (event-payload evt))


### PR DESCRIPTION
Converted `util/event-access.rkt` from `#lang racket/base` to `#lang typed/racket`. Removed manual `racket/contract` boilerplate; TR boundary generates contracts for untyped consumers automatically. All downstream consumers (`agent/event-types.rkt`, `tests/test-stream-error-wrapping.rkt`) compile and pass. Closes #6039.