### PR TITLE
feat(v0.70.9 W2): release v0.70.9 + pilot results (#6040)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.70.8-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.70.9-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 
@@ -202,7 +202,7 @@ bin/q --model gpt-5.4 "write a test"
 ### Verify
 
 ```bash
-bin/q --version            # q version 0.70.8
+bin/q --version            # q version 0.70.9
 raco test tests/           # run the full test suite
 ```
 
@@ -520,6 +520,9 @@ When q executes shell commands on behalf of an LLM, arguments are quoted via `sh
 
 
 
+
+
+**v0.70.9** — Structured Shell Risk Classification
 
 **v0.70.8** — Structured Shell Risk Classification
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -2,7 +2,7 @@
 
 ## Version
 
-v0.70.8
+v0.70.9
 
 ## Native TUI Stack
 

--- a/docs/event-taxonomy.md
+++ b/docs/event-taxonomy.md
@@ -1,6 +1,6 @@
 # Q Event Taxonomy Reference
 
-Complete reference for all event types in Q 0.70.8.
+Complete reference for all event types in Q 0.70.9.
 ## Base Types
 
 ### `event` (protocol-level)

--- a/docs/extension-guide.md
+++ b/docs/extension-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.70.8 --># Extension Development Guide
+<!-- verified-against: 0.70.9 --># Extension Development Guide
 
 This guide walks you through creating, testing, and activating a custom
 extension for q.

--- a/docs/getting-started/credentials.md
+++ b/docs/getting-started/credentials.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.70.8 -->
+<!-- verified-against: 0.70.9 -->
 # Credential Management
 
 This document describes how q manages API keys and provider credentials,

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.70.8 --># Getting Started
+<!-- verified-against: 0.70.9 --># Getting Started
 
 Welcome to q, a Racket-based coding agent.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.70.8 --># Installation Guide
+<!-- verified-against: 0.70.9 --># Installation Guide
 
 <!-- This file is the canonical source. The docs/getting-started/installation.md copy is maintained for the doc site build. -->
 

--- a/docs/reports/TYPED-RACKET-TARGETS-v0.70.9.md
+++ b/docs/reports/TYPED-RACKET-TARGETS-v0.70.9.md
@@ -39,7 +39,18 @@ Identify 2–3 leaf modules with stable structs and low macro complexity for Typ
 - `util/event-payloads.rkt` — payload structs in typed/racket
 - `runtime/iteration/loop-state.rkt` — state struct in typed/racket
 
-## Next Steps
-1. Convert `util/event-access.rkt` to `#lang typed/racket`.
-2. Run `test-event-access.rkt` to verify boundary contracts still enforce.
-3. If green, decide W2 target or stop.
+## W1 Results
+
+- **Converted**: `util/event-access.rkt` → `#lang typed/racket`
+- **Compile**: ✅ `raco make` passes
+- **Tests**: ✅ `test-event-access.rkt` passes (6/6)
+- **Downstream consumers**: ✅ `agent/event-types.rkt` compiles; `tests/test-stream-error-wrapping.rkt` passes (16/16)
+- **Contract churn**: None — removed manual `contract-out`; TR boundary auto-generates contracts for untyped consumers.
+- **Compile-time impact**: Negligible.
+
+## W2 Decision: STOP
+
+Per the v0.70.9 plan risk decision, the second target (`util/event-types.rkt`) is a 13-line constants module with negligible typing value. The next viable candidate (`util/tool-types.rkt`) is re-exported by facade `util/protocol-types.rkt`, which violates the "no facade typing" rule.
+
+**Conclusion**: Pilot succeeded with one clean conversion. No blockers. Series stops here for v0.70.9 to maintain conservative risk posture. Future milestones may revisit additional leaf targets.
+

--- a/docs/security-trust-model.md
+++ b/docs/security-trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.70.8 --># Security & Trust Model
+<!-- verified-against: 0.70.9 --># Security & Trust Model
 
 This document provides an honest, per-area assessment of what q enforces
 today and what is planned. It is the authoritative reference for security

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -130,6 +130,6 @@ is the primary self-hosting extension:
 (load-extension! ext-reg "path/to/extension.rkt" #:event-bus bus)
 ```
 
-## Version 0.70.8
+## Version 0.70.9
 
-This documentation reflects q 0.70.8.
+This documentation reflects q 0.70.9.

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.70.8 --># q Source Style Guide
+<!-- verified-against: 0.70.9 --># q Source Style Guide
 
 This document defines formatting and naming conventions for the q Racket codebase.
 All changes to `q/` source files (excluding `tests/`) should follow these rules.

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.70.8 -->
+<!-- verified-against: 0.70.9 -->
 # Trust Model
 
 ## Trust Levels

--- a/docs/workflow-testing.md
+++ b/docs/workflow-testing.md
@@ -121,6 +121,6 @@ Use relative paths from the test file:
 4. Use `(check-true ...)` for boolean assertions
 5. Keep tests independent — no shared mutable state between test-cases
 
-## Version 0.70.8
+## Version 0.70.9
 
-This documentation reflects q 0.70.8.
+This documentation reflects q 0.70.9.

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.70.8")
+(define version "0.70.9")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base" "gui-easy-lib"))

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -11,4 +11,4 @@
 
 (provide (contract-out [q-version string?]))
 
-(define q-version "0.70.8")
+(define q-version "0.70.9")

--- a/wiki-src/Architecture-Overview.md
+++ b/wiki-src/Architecture-Overview.md
@@ -35,7 +35,7 @@ User input → Interface (CLI/TUI/RPC)
     → Events emitted to bus
 ```
 
-## Metrics (0.70.8)
+## Metrics (0.70.9)
 > _See `racket scripts/metrics.rkt` for current numbers._
 
 - 414 source modules, 534 test files


### PR DESCRIPTION
Version bump to 0.70.9. Updated typed racket pilot report with W1 results and W2 stop decision. Second candidate too small; facade-adjacent candidate excluded per risk decision. Closes #6040.