### PR TITLE
fix(v0.70.11 W1): async sink + trace-logger + token cache (#6084)

### DIFF
--- a/runtime/session-store.rkt
+++ b/runtime/session-store.rkt
@@ -125,29 +125,30 @@
     (define flush-ch (make-channel))
 
     (define worker
-      (thread
-       (lambda ()
-         (let loop ()
-           (define msg (thread-receive))
-           (cond
-             [(eq? msg 'flush)
-              (channel-put flush-ch 'ok)
-              (loop)]
-             [(eq? msg 'stop)
-              (void)]
-             [(pair? msg)
-              ;; msg is a pair: (cons 'entries list) or (cons 'single message)
-              (case (car msg)
-                [(entries)
-                 (send inner-sink sink-append-entries! (cdr msg))
-                 (semaphore-post space-sema)]
-                [(single)
-                 (send inner-sink sink-append! (cdr msg))
-                 (semaphore-post space-sema)])
-              (loop)]
-             [else
-              (semaphore-post space-sema)
-              (loop)])))))
+      (thread (lambda ()
+                (let loop ()
+                  (define msg (thread-receive))
+                  (cond
+                    [(eq? msg 'flush)
+                     ;; Flush inner sink if it supports flush (e.g. nested async)
+                     (when (object-method-arity-includes? inner-sink 'sink-flush! 0)
+                       (send inner-sink sink-flush!))
+                     (channel-put flush-ch 'ok)
+                     (loop)]
+                    [(eq? msg 'stop) (void)]
+                    [(pair? msg)
+                     ;; msg is a pair: (cons 'entries list) or (cons 'single message)
+                     (case (car msg)
+                       [(entries)
+                        (send inner-sink sink-append-entries! (cdr msg))
+                        (semaphore-post space-sema)]
+                       [(single)
+                        (send inner-sink sink-append! (cdr msg))
+                        (semaphore-post space-sema)])
+                     (loop)]
+                    [else
+                     (semaphore-post space-sema)
+                     (loop)])))))
 
     (define (try-send! item)
       (case policy
@@ -174,11 +175,9 @@
       (unless (unbox closed-box)
         (try-send! (cons 'entries msgs))))
 
-    (define/public (sink-load)
-      (send inner-sink sink-load))
+    (define/public (sink-load) (send inner-sink sink-load))
 
-    (define/public (sink-fork! entry-id dest-id)
-      (send inner-sink sink-fork! entry-id dest-id))
+    (define/public (sink-fork! entry-id dest-id) (send inner-sink sink-fork! entry-id dest-id))
 
     ;; Non-interface methods for flush/close contract
     (define/public (sink-get-worker) worker)
@@ -337,7 +336,8 @@
            new-acc)]))
   (define path-entries (walk-up source-entry-id '()))
   (ensure-parent-dirs! dest-path)
-  (define header-msg (make-version-header-message #:extra (hasheq 'parentSession (path->string source-path))))
+  (define header-msg
+    (make-version-header-message #:extra (hasheq 'parentSession (path->string source-path))))
   (define all-entries (cons header-msg path-entries))
   (jsonl-append-entries! dest-path (map message->jsexpr all-entries))
   (length path-entries))
@@ -377,7 +377,9 @@
      (define new-session-id (string-append "imported-" (generate-id)))
      (define dest-path (build-path dest-session-dir (format "~a.jsonl" new-session-id)))
      (ensure-parent-dirs! dest-path)
-     (define header-msg (make-version-header-message #:extra (hasheq 'imported-from (path->string source-path) 'imported-at (current-seconds))))
+     (define header-msg
+       (make-version-header-message
+        #:extra (hasheq 'imported-from (path->string source-path) 'imported-at (current-seconds))))
      (define messages (map jsexpr->message raw))
      (define all-entries (cons header-msg messages))
      (jsonl-append-entries! dest-path (map message->jsexpr all-entries))

--- a/runtime/trace-logger.rkt
+++ b/runtime/trace-logger.rkt
@@ -15,17 +15,15 @@
          "../util/protocol-types.rkt"
          "trace-sink.rkt")
 
-(provide (contract-out [make-trace-logger
-                        (->* (event-bus? path-string?)
-                             (#:enabled? boolean?
-                              #:sink (or/c (is-a?/c trace-sink<%>) #f)
-                              #:async? boolean?)
-                             trace-logger?)]
-                       [trace-logger? (-> any/c boolean?)]
-                       [start-trace-logger!
-                        (->* (trace-logger?) (#:port (or/c output-port? #f)) void?)]
-                       [stop-trace-logger! (-> trace-logger? void?)]
-                       [flush-trace-logger! (-> trace-logger? void?)]))
+(provide (contract-out
+          [make-trace-logger
+           (->* (event-bus? path-string?)
+                (#:enabled? boolean? #:sink (or/c (is-a?/c trace-sink<%>) #f) #:async? boolean?)
+                trace-logger?)]
+          [trace-logger? (-> any/c boolean?)]
+          [start-trace-logger! (->* (trace-logger?) (#:port (or/c output-port? #f)) void?)]
+          [stop-trace-logger! (-> trace-logger? void?)]
+          [flush-trace-logger! (-> trace-logger? void?)]))
 
 ;; ============================================================
 ;; Trace logger struct
@@ -45,7 +43,11 @@
 ;; Constructor
 ;; ============================================================
 
-(define (make-trace-logger bus session-dir #:enabled? [enabled? #t] #:sink [sink #f] #:async? [async? #f])
+(define (make-trace-logger bus
+                           session-dir
+                           #:enabled? [enabled? #t]
+                           #:sink [sink #f]
+                           #:async? [async? #f])
   (trace-logger bus session-dir enabled? 0 #f #f sink async?))
 
 ;; ============================================================
@@ -71,6 +73,9 @@
     (set-trace-logger-out-port! logger out)
     ;; v0.70.4: wrap sink in async-trace-sink% when async? is enabled
     (when (and (trace-logger-async? logger) (not (trace-logger-sink logger)))
+      ;; Close the port we just opened — async sink manages its own file handle
+      (close-output-port out)
+      (set-trace-logger-out-port! logger #f)
       (define trace-path (build-path (trace-logger-session-dir logger) "trace.jsonl"))
       (define file-sink (new json-file-trace-sink% [path trace-path]))
       (set-trace-logger-sink! logger (new async-trace-sink% [inner-sink file-sink])))
@@ -105,7 +110,8 @@
 
 (define (handle-event! logger evt)
   (define out (trace-logger-out-port logger))
-  (when out
+  (define sink (trace-logger-sink logger))
+  (when (or out (and sink (object? sink)))
     (define seq (add1 (trace-logger-seq logger)))
     (set-trace-logger-seq! logger seq)
     (define entry
@@ -123,7 +129,6 @@
               (sanitize-for-json (event-payload evt))))
     ;; v0.15.1: Wrap write-json in error handler to prevent
     ;; partial writes from corrupting the JSONL file.
-    (define sink (trace-logger-sink logger))
     (cond
       [(and sink (object? sink))
        (with-handlers ([exn:fail? (lambda (e)

--- a/util/token-estimate-cache.rkt
+++ b/util/token-estimate-cache.rkt
@@ -6,8 +6,7 @@
 ;; Reduces redundant computation when the same message content is
 ;; estimated repeatedly (e.g. during context assembly iteration).
 
-(require racket/contract
-         racket/math)
+(require racket/contract)
 
 (provide (contract-out
           [cached-estimate-text-tokens
@@ -31,10 +30,10 @@
 (define cache-misses (box 0))
 
 ;; Compute a content hash for cache keying.
-;; Uses equal-hash-code for speed; collisions are acceptable for
-;; an estimation heuristic.
+;; Uses the string itself as key with equal?-based hash table.
+;; This avoids equal-hash-code collision risk.
 (define (content-hash text)
-  (equal-hash-code text))
+  text)
 
 ;; cached-estimate-text-tokens : (string? -> exact-nonnegative-integer?) string? -> exact-nonnegative-integer?
 ;;


### PR DESCRIPTION
W1: Async Sink Fixes + Token Cache Safety.\n\n- S1-2: async-session-sink flush now flushes inner sink if supported\n- S1-4: trace-logger closes file handle when async? is true, events routed through sink\n- C1-5: token-estimate-cache uses string identity as key instead of equal-hash-code\n- C1-6: Removed unused racket/math import\n\nAll targeted tests pass. Closes #6084.