### PR TITLE
fix(v0.70.11 W2): contracts + lint + code quality (#6085)

### DIFF
--- a/runtime/session-store.rkt
+++ b/runtime/session-store.rkt
@@ -160,9 +160,11 @@
              (thread-send worker item)
              (void))]
         [(drop-old)
-         (if (semaphore-try-wait? space-sema)
-             (thread-send worker item)
-             (void))]
+         ;; drop-old not fully implemented — falls back to drop-new with warning
+         (unless (semaphore-try-wait? space-sema)
+           (log-warning "async-session-sink: drop-old not fully implemented, dropping new entry"))
+         (when (semaphore-try-wait? space-sema)
+           (thread-send worker item))]
         [else
          (semaphore-wait space-sema)
          (thread-send worker item)]))

--- a/scripts/lint-credential-policy.rkt
+++ b/scripts/lint-credential-policy.rkt
@@ -23,11 +23,12 @@
 (define cred-doc "docs/getting-started/credentials.md")
 (if (file-exists? cred-doc)
     (let ([content (file->string cred-doc)])
-      (unless (or (string-contains? content "credential policy") (string-contains? content "Credential Policy"))
+      (unless (or (string-contains? content "credential policy")
+                  (string-contains? content "Credential Policy"))
         (warn "credentials.md missing 'credential policy' section"))
-      (unless (or (string-contains? content "keychain-preferred") (string-contains? content ""))
+      (unless (string-contains? content "keychain-preferred")
         (warn "credentials.md missing keychain-preferred policy mention"))
-      (unless (or (string-contains? content "env-only") (string-contains? content ""))
+      (unless (string-contains? content "env-only")
         (warn "credentials.md missing env-only policy mention")))
     (warn (format "~a not found" cred-doc)))
 
@@ -61,5 +62,6 @@
    (displayln (format "  FAIL: ~a credential policy warning(s)" n) (current-error-port))
    (exit 1)]
   [else
-   (displayln (format "  WARN: ~a credential policy warning(s) (non-blocking)" n) (current-error-port))
+   (displayln (format "  WARN: ~a credential policy warning(s) (non-blocking)" n)
+              (current-error-port))
    (exit 0)])

--- a/tools/shell-risk.rkt
+++ b/tools/shell-risk.rkt
@@ -20,13 +20,12 @@
          shell-risk-finding-severity
          shell-risk-finding-message
          shell-risk-finding-position
-         tokenize-shell-command
-         classify-shell-risks
-         shell-risk-summary
-         (contract-out
-          [risk-severity? (-> symbol? boolean?)]
-          [token-type? (-> symbol? boolean?)]
-          [risk-type? (-> symbol? boolean?)]))
+         (contract-out [tokenize-shell-command (-> string? (listof shell-token?))]
+                       [classify-shell-risks (-> (listof shell-token?) (listof shell-risk-finding?))]
+                       [shell-risk-summary (-> (listof shell-risk-finding?) (hash/c symbol? any/c))]
+                       [risk-severity? (-> symbol? boolean?)]
+                       [token-type? (-> symbol? boolean?)]
+                       [risk-type? (-> symbol? boolean?)]))
 
 ;; ── Data structures ───────────────────────────────────────────────
 
@@ -40,9 +39,15 @@
   (member v '(word separator redirect substitution quote whitespace unknown)))
 
 (define (risk-type? v)
-  (member v '(destructive high-risk network-pipe substitution
-                         redirect-sensitive command-substitution
-                         eval exec windows-destructive)))
+  (member v
+          '(destructive high-risk
+                        network-pipe
+                        substitution
+                        redirect-sensitive
+                        command-substitution
+                        eval
+                        exec
+                        windows-destructive)))
 
 ;; ── Tokenizer helpers ─────────────────────────────────────────────
 
@@ -61,20 +66,22 @@
       [else (loop (add1 j))])))
 
 (define (find-matching-paren chars i close-char)
-  (let loop ([j i] [depth 1])
+  (let loop ([j i]
+             [depth 1])
     (cond
       [(>= j (length chars)) #f]
       [(char=? (list-ref chars j) #\() (loop (add1 j) (add1 depth))]
       [(char=? (list-ref chars j) close-char)
-       (if (= depth 1) j (loop (add1 j) (sub1 depth)))]
+       (if (= depth 1)
+           j
+           (loop (add1 j) (sub1 depth)))]
       [else (loop (add1 j) depth)])))
 
 (define (skip-redirect chars i)
   (let loop ([j i])
     (cond
       [(>= j (length chars)) j]
-      [(member (list-ref chars j)
-               '(#\> #\< #\& #\0 #\1 #\2 #\3 #\4 #\5 #\6 #\7 #\8 #\9))
+      [(member (list-ref chars j) '(#\> #\< #\& #\0 #\1 #\2 #\3 #\4 #\5 #\6 #\7 #\8 #\9))
        (loop (add1 j))]
       [else j])))
 
@@ -97,52 +104,92 @@
          ;; Single-quoted string
          [(char=? c #\')
           (define j (find-char chars (add1 i) #\'))
-          (loop (if j (add1 j) len)
-                (cons (shell-token 'quote (substring command i (if j (add1 j) len))
-                                   i (if j (add1 j) len))
+          (loop (if j
+                    (add1 j)
+                    len)
+                (cons (shell-token 'quote
+                                   (substring command
+                                              i
+                                              (if j
+                                                  (add1 j)
+                                                  len))
+                                   i
+                                   (if j
+                                       (add1 j)
+                                       len))
                       tokens))]
          ;; Double-quoted string
          [(char=? c #\")
           (define j (find-char chars (add1 i) #\"))
-          (loop (if j (add1 j) len)
-                (cons (shell-token 'quote (substring command i (if j (add1 j) len))
-                                   i (if j (add1 j) len))
+          (loop (if j
+                    (add1 j)
+                    len)
+                (cons (shell-token 'quote
+                                   (substring command
+                                              i
+                                              (if j
+                                                  (add1 j)
+                                                  len))
+                                   i
+                                   (if j
+                                       (add1 j)
+                                       len))
                       tokens))]
          ;; Command substitution $(...)
          [(and (char=? c #\$) (< (add1 i) len) (char=? (list-ref chars (add1 i)) #\())
           (define j (find-matching-paren chars (+ i 2) #\)))
-          (loop (if j (add1 j) len)
-                (cons (shell-token 'substitution (substring command i (if j (add1 j) len))
-                                   i (if j (add1 j) len))
+          (loop (if j
+                    (add1 j)
+                    len)
+                (cons (shell-token 'substitution
+                                   (substring command
+                                              i
+                                              (if j
+                                                  (add1 j)
+                                                  len))
+                                   i
+                                   (if j
+                                       (add1 j)
+                                       len))
                       tokens))]
          ;; Backtick substitution
          [(char=? c #\`)
           (define j (find-char chars (add1 i) #\`))
-          (loop (if j (add1 j) len)
-                (cons (shell-token 'substitution (substring command i (if j (add1 j) len))
-                                   i (if j (add1 j) len))
+          (loop (if j
+                    (add1 j)
+                    len)
+                (cons (shell-token 'substitution
+                                   (substring command
+                                              i
+                                              (if j
+                                                  (add1 j)
+                                                  len))
+                                   i
+                                   (if j
+                                       (add1 j)
+                                       len))
                       tokens))]
          ;; Separators
-         [(char=? c #\;)
-          (loop (add1 i) (cons (shell-token 'separator ";" i (add1 i)) tokens))]
+         [(char=? c #\;) (loop (add1 i) (cons (shell-token 'separator ";" i (add1 i)) tokens))]
          [(and (char=? c #\&) (< (add1 i) len) (char=? (list-ref chars (add1 i)) #\&))
           (loop (+ i 2) (cons (shell-token 'separator "&&" i (+ i 2)) tokens))]
          [(and (char=? c #\|) (< (add1 i) len) (char=? (list-ref chars (add1 i)) #\|))
           (loop (+ i 2) (cons (shell-token 'separator "||" i (+ i 2)) tokens))]
-         [(char=? c #\|)
-          (loop (add1 i) (cons (shell-token 'separator "|" i (add1 i)) tokens))]
+         [(char=? c #\|) (loop (add1 i) (cons (shell-token 'separator "|" i (add1 i)) tokens))]
          ;; Redirects
-         [(or (char=? c #\>) (char=? c #\<)
-              (and (char-numeric? c) (< (add1 i) len)
-                   (char=? (list-ref chars (add1 i)) #\>)))
+         [(or (char=? c #\>)
+              (char=? c #\<)
+              (and (char-numeric? c) (< (add1 i) len) (char=? (list-ref chars (add1 i)) #\>)))
           (define j (skip-redirect chars i))
           (loop j (cons (shell-token 'redirect (substring command i j) i j) tokens))]
          ;; Word
          [else
-          (define j (skip-while chars i
-                     (lambda (ch)
-                       (not (or (char-whitespace? ch)
-                                (member ch '(#\; #\| #\& #\> #\< #\( #\) #\` #\' #\")))))))
+          (define j
+            (skip-while chars
+                        i
+                        (lambda (ch)
+                          (not (or (char-whitespace? ch)
+                                   (member ch '(#\; #\| #\& #\> #\< #\( #\) #\` #\' #\")))))))
           (loop j (cons (shell-token 'word (substring command i j) i j) tokens))])]))
 
   (loop 0 '()))
@@ -156,7 +203,9 @@
 
   ;; Build combined strings from word tokens, breaking only on separators
   (define word-runs '())
-  (let loop ([toks tokens] [current '()] [start #f])
+  (let loop ([toks tokens]
+             [current '()]
+             [start #f])
     (cond
       [(null? toks)
        (when (pair? current)
@@ -169,8 +218,7 @@
        (when (pair? current)
          (set! word-runs (cons (cons start (string-join (reverse current) " ")) word-runs)))
        (loop (cdr toks) '() #f)]
-      [else
-       (loop (cdr toks) current start)]))
+      [else (loop (cdr toks) current start)]))
   (set! word-runs (reverse word-runs))
 
   (for ([run (in-list word-runs)])
@@ -178,8 +226,7 @@
     (define val (string-downcase (cdr run)))
 
     (cond
-      [(and (string-prefix? val "rm")
-            (or (string-contains? val "-rf") (string-contains? val "-fr")))
+      [(and (string-prefix? val "rm") (or (string-contains? val "-rf") (string-contains? val "-fr")))
        (add! 'destructive 'critical (format "Recursive force delete: ~a" val) pos)]
       [(string-prefix? val "rmdir")
        (add! 'destructive 'high (format "Directory removal: ~a" val) pos)]
@@ -189,22 +236,18 @@
        (add! 'destructive 'critical (format "Direct device write: ~a" val) pos)]
       [(string-prefix? val "shutdown")
        (add! 'destructive 'high (format "System shutdown: ~a" val) pos)]
-      [(string-prefix? val "reboot")
-       (add! 'destructive 'high (format "System reboot: ~a" val) pos)]
+      [(string-prefix? val "reboot") (add! 'destructive 'high (format "System reboot: ~a" val) pos)]
       [(string-prefix? val "format")
        (add! 'windows-destructive 'high (format "Windows format: ~a" val) pos)]
       [(string-prefix? val "del")
        (add! 'windows-destructive 'medium (format "Windows delete: ~a" val) pos)]
       [(and (string-prefix? val "chmod") (string-contains? val "777") (string-contains? val "/"))
        (add! 'destructive 'high (format "Dangerous chmod: ~a" val) pos)]
-      [(string-prefix? val "eval")
-       (add! 'eval 'medium (format "Eval indirection: ~a" val) pos)]
-      [(string-prefix? val "exec")
-       (add! 'exec 'medium (format "Process replacement: ~a" val) pos)]
+      [(string-prefix? val "eval") (add! 'eval 'medium (format "Eval indirection: ~a" val) pos)]
+      [(string-prefix? val "exec") (add! 'exec 'medium (format "Process replacement: ~a" val) pos)]
       [(and (string-prefix? val "git") (string-contains? val "--force"))
        (add! 'destructive 'high (format "Force push: ~a" val) pos)]
-      [(string-prefix? val "mv ")
-       (add! 'destructive 'medium (format "Move operation: ~a" val) pos)]))
+      [(string-prefix? val "mv ") (add! 'destructive 'medium (format "Move operation: ~a" val) pos)]))
 
   ;; Substitution and pipe detection on individual tokens
   (for ([tok (in-list tokens)]
@@ -214,9 +257,7 @@
     (define pos (shell-token-start tok))
 
     (when (eq? type 'substitution)
-      (add! 'command-substitution 'medium
-            (format "Command substitution: ~a" val)
-            pos))
+      (add! 'command-substitution 'medium (format "Command substitution: ~a" val) pos))
 
     (when (and (eq? type 'separator) (string=? (string-downcase val) "|"))
       ;; Skip whitespace to find next word
@@ -231,7 +272,8 @@
         (when (eq? (shell-token-type next-tok) 'word)
           (define next-val (string-downcase (shell-token-value next-tok)))
           (when (member next-val '("sh" "bash" "cmd" "powershell"))
-            (add! 'network-pipe 'high
+            (add! 'network-pipe
+                  'high
                   (format "Pipe to shell: | ~a" next-val)
                   (shell-token-start next-tok)))))))
 
@@ -243,16 +285,20 @@
   (define severities (map shell-risk-finding-severity findings))
   (define severity-order '(info low medium high critical))
   (define (index-of lst item)
-    (let loop ([i 0] [l lst])
-      (cond [(null? l) -1]
-            [(equal? (car l) item) i]
-            [else (loop (add1 i) (cdr l))])))
+    (let loop ([i 0]
+               [l lst])
+      (cond
+        [(null? l) -1]
+        [(equal? (car l) item) i]
+        [else (loop (add1 i) (cdr l))])))
   (define max-sev
     (for/fold ([best 'info]) ([s (in-list severities)])
-      (if (> (index-of severity-order s) (index-of severity-order best))
-          s
-          best)))
-  (hasheq 'count (length findings)
-          'severities severities
-          'max-severity max-sev
-          'critical? (member 'critical severities)))
+      (if (> (index-of severity-order s) (index-of severity-order best)) s best)))
+  (hasheq 'count
+          (length findings)
+          'severities
+          severities
+          'max-severity
+          max-sev
+          'critical?
+          (and (member 'critical severities) #t)))


### PR DESCRIPTION
W2: Contracts, Lint Fix, Minor Code Quality.\n\n- A1-4: Added contracts to shell-risk main API (tokenize-shell-command, classify-shell-risks, shell-risk-summary)\n- C1-8: Fixed tautological string checks in lint-credential-policy.rkt\n- C1-11: shell-risk-summary critical? now returns boolean instead of list\n- C1-13: drop-old policy now logs warning instead of silently falling back\n\nAll targeted tests pass. Closes #6085.