### PR TITLE
fix(v0.70.13 W0): test path + slash notify + selection-safe insert (#6097)

### DIFF
--- a/gui/components/rich-transcript-view.rkt
+++ b/gui/components/rich-transcript-view.rkt
@@ -200,14 +200,14 @@
      (define role-delta (make-object style-delta% 'change-bold))
      (send role-delta set-delta-foreground role-color)
      (send text-obj change-style role-delta)
-     (send text-obj insert (format "~a: " label))
+     (send text-obj insert (format "~a: " label) (send text-obj last-position))
      ;; Apply normal content style with foreground color
      (define content-delta (make-object style-delta% 'change-normal))
      (send content-delta set-delta-foreground content-color)
      (send text-obj change-style content-delta)
-     (send text-obj insert (string-append text "\n\n"))]
+     (send text-obj insert (string-append text "\n\n") (send text-obj last-position))]
     ;; Headless fallback: plain text insertion
-    [else (send text-obj insert (format "~a: ~a\n\n" label text))]))
+    [else (send text-obj insert (format "~a: ~a\n\n" label text) (send text-obj last-position))]))
 
 ;; Clear a text% object and rebuild from a list of messages.
 ;; text-obj: a text% instance

--- a/gui/main.rkt
+++ b/gui/main.rkt
@@ -111,7 +111,7 @@
   (set-box! notify-callback-box notify-gui!)
 
   ;; Slash command handler (extracted to slash-commands.rkt)
-  (define handle-slash-command (make-slash-command-handler sess state-box gui-state-lock))
+  (define handle-slash-command (make-slash-command-handler sess state-box gui-state-lock notify-gui!))
 
   ;; Input callback: submit on Enter (single-line mode fires 'return on Enter)
   (define (on-input action val)

--- a/gui/slash-commands.rkt
+++ b/gui/slash-commands.rkt
@@ -22,12 +22,12 @@
 ;; --------------------------------------------------
 ;; Helper: add a system message to the transcript
 ;; --------------------------------------------------
-(define (add-system-msg! text state-box gui-state-lock)
-  (call-with-semaphore gui-state-lock
-                       (lambda ()
-                         (set-box! state-box
-                                   (gui-state-add-message (unbox state-box)
-                                                          (make-gui-message "system" text))))))
+(define (add-system-msg! text state-box gui-state-lock [notify! void])
+  (call-with-semaphore
+   gui-state-lock
+   (lambda ()
+     (set-box! state-box (gui-state-add-message (unbox state-box) (make-gui-message "system" text)))
+     (notify!))))
 
 ;; --------------------------------------------------
 ;; Extension dispatch
@@ -78,7 +78,7 @@
 ;;
 ;; Returns (-> string? boolean?) — #t if handled, #f otherwise
 ;; --------------------------------------------------
-(define (make-slash-command-handler sess state-box gui-state-lock)
+(define (make-slash-command-handler sess state-box gui-state-lock [notify! void])
   (lambda (input-text)
     (define parsed (parse-command-name input-text))
     (cond
@@ -89,7 +89,8 @@
              (add-system-msg! (format "Unknown command: ~a. Type /help for available commands."
                                       input-text)
                               state-box
-                              gui-state-lock)
+                              gui-state-lock
+                              notify!)
              #t))]
       [else
        (define cmd
@@ -105,9 +106,11 @@
           (close-session! sess)
           (exit 0)]
          [(clear)
-          (call-with-semaphore
-           gui-state-lock
-           (lambda () (set-box! state-box (struct-copy gui-state (unbox state-box) [messages '()]))))
+          (call-with-semaphore gui-state-lock
+                               (lambda ()
+                                 (set-box! state-box
+                                           (struct-copy gui-state (unbox state-box) [messages '()]))
+                                 (notify!)))
           #t]
          [(help)
           (add-system-msg! (string-append "Available commands:\n"
@@ -121,7 +124,8 @@
                                           "  /go              GSD execute command\n"
                                           "  /activate, /a    Activate extensions\n")
                            state-box
-                           gui-state-lock)
+                           gui-state-lock
+                           notify!)
           #t]
          [(status)
           (add-system-msg! (format "Session: ~a\nModel: ~a\nStatus: ~a\nMessages: ~a"
@@ -130,7 +134,8 @@
                                    (if (session-active? sess) "active" "closed")
                                    (length (gui-state-messages (unbox state-box))))
                            state-box
-                           gui-state-lock)
+                           gui-state-lock
+                           notify!)
           #t]
          [(model)
           (add-system-msg! (if (null? args)
@@ -138,15 +143,20 @@
                                (format "Model switching not yet supported in GUI. Current: ~a"
                                        (agent-session-model-name sess)))
                            state-box
-                           gui-state-lock)
+                           gui-state-lock
+                           notify!)
           #t]
          [(compact)
           (add-system-msg! "Context compaction triggered (runs on next turn)."
                            state-box
-                           gui-state-lock)
+                           gui-state-lock
+                           notify!)
           #t]
          [(interrupt)
-          (add-system-msg! "Interrupt not yet supported in GUI mode." state-box gui-state-lock)
+          (add-system-msg! "Interrupt not yet supported in GUI mode."
+                           state-box
+                           gui-state-lock
+                           notify!)
           #t]
          [else
           (or (try-extension-dispatch sess state-box gui-state-lock input-text)
@@ -154,5 +164,6 @@
                 (add-system-msg! (format "Unknown command: ~a. Type /help for available commands."
                                          input-text)
                                  state-box
-                                 gui-state-lock)
+                                 gui-state-lock
+                                 notify!)
                 #t))])])))

--- a/tests/test-credential-backend.rkt
+++ b/tests/test-credential-backend.rkt
@@ -586,7 +586,10 @@
 (test-case "macos-keychain: username resolution has fallback chain"
   ;; Verify the username resolution expression includes all 4 fallback levels
   ;; by checking the source code structure (defense against accidental removal)
-  (define src (file->string "runtime/credential-backend.rkt"))
+  (define src
+    (file->string (if (file-exists? "runtime/credential-backend.rkt")
+                      "runtime/credential-backend.rkt"
+                      "../runtime/credential-backend.rkt")))
   (check-true (string-contains? src "(getenv \"USER\")"))
   (check-true (string-contains? src "(getenv \"LOGNAME\")"))
   (check-true (string-contains? src "find-system-path 'who-am-i"))

--- a/tests/test-gui-diff-text.rkt
+++ b/tests/test-gui-diff-text.rkt
@@ -13,8 +13,11 @@
     (super-new)
     (define content "")
     (define locked #f)
+    (define insert-with-position? #f)
     ;; insert: positional insert when pos given, append otherwise
     (define/public (insert str [pos #f])
+      (when pos
+        (set! insert-with-position? #t))
       (if pos
           (set! content (string-append (substring content 0 pos) str (substring content pos)))
           (set! content (string-append content str))))
@@ -24,7 +27,8 @@
     (define/public (change-style delta [start 0] [end 0]) (void))
     (define/public (get-content) content)
     (define/public (get-text start end) (substring content start (min end (string-length content))))
-    (define/public (is-locked?) locked)))
+    (define/public (is-locked?) locked)
+    (define/public (was-insert-positional?) insert-with-position?)))
 
 (define-test-suite
  test-diff-text
@@ -91,6 +95,14 @@
    (apply-diff-to-text! text-obj old-msgs new-msgs (default-theme) last-len-box)
    (check-equal? (unbox last-len-box) 6)))
 
+(define test-positional-insert
+  (test-suite "positional insert (selection-safe)"
+    (test-case "insert-message-into-text! uses explicit position"
+      (define text-obj (make-object mock-text%))
+      (insert-message-into-text! text-obj (hash 'role "user" 'text "hello") (default-theme))
+      (check-true (send text-obj was-insert-positional?)))))
+
 (run-tests (test-suite "gui-diff-text"
              test-diff-text
-             test-incremental-append))
+             test-incremental-append
+             test-positional-insert))

--- a/tests/test-gui-slash-commands.rkt
+++ b/tests/test-gui-slash-commands.rkt
@@ -29,7 +29,15 @@
       (add-system-msg! "sys" state-box lock)
       (define msgs (gui-state-messages (unbox state-box)))
       (check-equal? (length msgs) 2)
-      (check-equal? (gui-message-role (cadr msgs)) "system"))))
+      (check-equal? (gui-message-role (cadr msgs)) "system"))
+
+    (test-case "add-system-msg! calls notify callback"
+      (define state-box (box (make-gui-state)))
+      (define lock (make-semaphore 1))
+      (define notify-called? (box #f))
+      (add-system-msg! "hello" state-box lock (lambda () (set-box! notify-called? #t)))
+      (check-true (unbox notify-called?))
+      (check-equal? (length (gui-state-messages (unbox state-box))) 1))))
 
 (define test-make-slash-command-handler
   (test-suite "make-slash-command-handler"
@@ -45,7 +53,17 @@
       (define state-box (box (make-gui-state)))
       (define lock (make-semaphore 1))
       (define handler (make-slash-command-handler #f state-box lock))
-      (check-false (handler "")))))
+      (check-false (handler "")))
+
+    (test-case "handler /help calls notify"
+      (define state-box (box (make-gui-state)))
+      (define lock (make-semaphore 1))
+      (define notify-called? (box #f))
+      (define handler
+        (make-slash-command-handler #f state-box lock (lambda () (set-box! notify-called? #t))))
+      (handler "/help")
+      (check-true (unbox notify-called?))
+      (check-equal? (length (gui-state-messages (unbox state-box))) 1))))
 
 (define test-known-commands
   (test-suite "known commands"


### PR DESCRIPTION
W0: Code fixes for v0.70.13.\n\n- F2: Fixed test relative path in test-credential-backend.rkt (dual-path pattern for raco test CWD)\n- F3: Added optional notify! callback to add-system-msg! and make-slash-command-handler, wired in gui/main.rkt\n- F4: insert-message-into-text! now uses explicit (last-position) for all inserts to preserve selection\n- New tests: notify callback, handler /help notify, positional insert verification\n\nAll compile gates pass. Closes #6097.