### PR TITLE
feat(v0.71.0 W1): typed events + persistence + context filtering (#6104)

### DIFF
--- a/agent/event-structs/session-events.rkt
+++ b/agent/event-structs/session-events.rkt
@@ -23,14 +23,19 @@
 
 (define-typed-event agent-start-event "agent.started" (model) #:schema-version 1)
 
-(define-typed-event agent-end-event "agent.completed" (reason duration-ms) #:defaults (duration-ms 0) #:schema-version 1)
+(define-typed-event agent-end-event
+                    "agent.completed"
+                    (reason duration-ms)
+                    #:defaults (duration-ms 0)
+                    #:schema-version 1)
 
 ;; Context events
 
 (define-typed-event context-event
                     "context.built"
                     (token-count window-size)
-                    #:defaults (token-count 0 window-size 0) #:schema-version 1)
+                    #:defaults (token-count 0 window-size 0)
+                    #:schema-version 1)
 
 ;; v0.44.3 (R2): Context assembly lifecycle events — replaces raw hasheq payloads
 (define-typed-event
@@ -42,7 +47,10 @@
 
 (define-typed-event context-blocked-event "context.assembly.blocked" (reason) #:schema-version 1)
 
-(define-typed-event working-set-injected-event "working-set.injected" (entries tokens) #:schema-version 1)
+(define-typed-event working-set-injected-event
+                    "working-set.injected"
+                    (entries tokens)
+                    #:schema-version 1)
 
 ;; v0.45.5 (OBS-01/02/03): Detailed assembly metrics for observability
 (define-typed-event context-assembly-detail-event
@@ -75,5 +83,35 @@
                                              ws-tokens
                                              0
                                              cache-hit-p
-                                             #f) #:schema-version 1)
+                                             #f)
+                    #:schema-version 1)
 
+;; v0.71.0: Goal autonomous loop events
+;; Emitted by goal-runner.rkt during /goal execution
+
+(define-typed-event goal-start-event "goal.started" (goal-text max-turns checks) #:schema-version 1)
+
+(define-typed-event goal-turn-start-event
+                    "goal.turn.started"
+                    (turn-number goal-text)
+                    #:schema-version 1)
+
+(define-typed-event goal-evaluated-event
+                    "goal.evaluated"
+                    (achieved? reason turn-number token-cost)
+                    #:defaults (token-cost 0)
+                    #:schema-version 1)
+
+(define-typed-event goal-check-event
+                    "goal.check.completed"
+                    (label exit-code timed-out? stdout stderr)
+                    #:defaults (timed-out? #f stdout "" stderr "")
+                    #:schema-version 1)
+
+(define-typed-event goal-achieved-event
+                    "goal.achieved"
+                    (goal-text turns-used total-token-cost)
+                    #:defaults (total-token-cost 0)
+                    #:schema-version 1)
+
+(define-typed-event goal-failed-event "goal.failed" (goal-text reason turns-used) #:schema-version 1)

--- a/runtime/context-assembly/session-walk.rkt
+++ b/runtime/context-assembly/session-walk.rkt
@@ -107,4 +107,5 @@
     [(or 'tool-result 'bash-execution) (summarize-tool-result entry)]
     ['system-instruction entry]
     ['custom-message entry]
+    [(or 'goal-state) #f]
     [_ entry]))

--- a/runtime/goal-state.rkt
+++ b/runtime/goal-state.rkt
@@ -254,7 +254,7 @@
           'goal-text
           (goal-state-goal-text gs)
           'status
-          (goal-state-status gs)
+          (symbol->string (goal-state-status gs))
           'turns-used
           (goal-state-turns-used gs)
           'max-turns
@@ -262,7 +262,7 @@
           'evaluator-model
           (goal-state-evaluator-model gs)
           'evaluator-mode
-          (goal-state-evaluator-mode gs)
+          (symbol->string (goal-state-evaluator-mode gs))
           'checks
           (map goal-check->hash (goal-state-checks gs))
           'last-evaluation
@@ -278,11 +278,17 @@
   (-> hash? goal-state?)
   (goal-state (hash-ref h 'id "")
               (hash-ref h 'goal-text "")
-              (hash-ref h 'status 'active)
+              (let ([s (hash-ref h 'status "active")])
+                (if (symbol? s)
+                    s
+                    (string->symbol s)))
               (hash-ref h 'turns-used 0)
               (hash-ref h 'max-turns DEFAULT-GOAL-MAX-TURNS)
               (hash-ref h 'evaluator-model "auto")
-              (hash-ref h 'evaluator-mode DEFAULT-EVALUATOR-MODE)
+              (let ([m (hash-ref h 'evaluator-mode "transcript")])
+                (if (symbol? m)
+                    m
+                    (string->symbol m)))
               (map hash->goal-check (hash-ref h 'checks '()))
               (let ([le (hash-ref h 'last-evaluation #f)]) (and le (hash->evaluation-result le)))
               (hash-ref h 'started-at 0)

--- a/runtime/session-store.rkt
+++ b/runtime/session-store.rkt
@@ -17,6 +17,7 @@
          racket/port
          racket/class
          json
+         "../runtime/goal-state.rkt"
          "../util/protocol-types.rkt"
          "../util/jsonl.rkt"
          (only-in "../util/message-helpers.rkt" ensure-parent-dirs!)
@@ -73,6 +74,9 @@
          ;; Custom entry helpers (#1147)
          append-custom-entry!
          load-custom-entries
+         ;; Goal state persistence (v0.71.0)
+         append-goal-state!
+         load-latest-goal-state
          ;; R-09/R-10: Session sink interface (v0.39.0)
          session-sink<%>
          file-session-sink%
@@ -448,6 +452,36 @@
                  (equal? (custom-entry-extension e) extension-name)
                  (or (not key) (equal? (custom-entry-key e) key))))
           entries))
+
+;; ============================================================
+;; Goal state persistence (v0.71.0)
+;; ============================================================
+
+(define (append-goal-state! path gs)
+  ;; Store goal-state as a JSON string in a system message
+  ;; so it survives message->jsexpr serialization
+  (define gs-json-str (jsexpr->string (goal-state->hash gs)))
+  (append-entry! path
+                 (make-message (goal-state-id gs)
+                               #f
+                               'system
+                               'goal-state
+                               (list (make-text-part gs-json-str))
+                               (goal-state-updated-at gs)
+                               #f)))
+
+(define (load-latest-goal-state path)
+  (define entries (load-session-log path))
+  (define goal-entries
+    (filter (lambda (e) (and (message? e) (eq? (message-kind e) 'goal-state))) entries))
+  (if (null? goal-entries)
+      #f
+      (let* ([last-entry (car (reverse goal-entries))]
+             [content (message-content last-entry)]
+             [json-str (if (string? content)
+                           content
+                           (text-part-text (car content)))])
+        (hash->goal-state (string->jsexpr json-str)))))
 
 ;; ── Session-info helper ──
 

--- a/tests/test-goal-state.rkt
+++ b/tests/test-goal-state.rkt
@@ -191,3 +191,126 @@
   (check-equal? (hash-ref h 'goal-text) "test"))
 
 (displayln "All goal-state tests passed.")
+
+;; ============================================================
+;; W1: Typed events
+;; ============================================================
+
+(require "../agent/event-structs/base.rkt"
+         "../agent/event-structs/session-events.rkt")
+
+;; goal-start-event (positional: type ts sid tid goal-text max-turns checks)
+(let ([e (goal-start-event "goal.started" 0 "s1" "t1" "tests pass" 8 '())])
+  (check-equal? (goal-start-event-goal-text e) "tests pass")
+  (check-equal? (goal-start-event-max-turns e) 8)
+  (check-true (string? (typed-event-type e)) "goal-start-event has string type"))
+
+;; goal-turn-start-event
+(let ([e (goal-turn-start-event "goal.turn.started" 0 "s1" "t1" 1 "tests pass")])
+  (check-equal? (goal-turn-start-event-turn-number e) 1)
+  (check-equal? (goal-turn-start-event-goal-text e) "tests pass"))
+
+;; goal-evaluated-event (positional: ... achieved? reason turn-number token-cost)
+(let ([e (goal-evaluated-event "goal.evaluated" 0 "s1" "t1" #f "still failing" 2 50)])
+  (check-false (goal-evaluated-event-achieved? e))
+  (check-equal? (goal-evaluated-event-reason e) "still failing")
+  (check-equal? (goal-evaluated-event-token-cost e) 50))
+
+;; goal-evaluated-event without token-cost
+(let ([e (goal-evaluated-event "goal.evaluated" 0 "s1" "t1" #t "done" 3 0)])
+  (check-equal? (goal-evaluated-event-token-cost e) 0 "token-cost explicit 0"))
+
+;; goal-check-event (label exit-code [timed-out? #f] [stdout ""] [stderr ""])
+(let ([e (goal-check-event "goal.check.completed" 0 "s1" "t1" "tests" 0 #f "" "")])
+  (check-equal? (goal-check-event-label e) "tests")
+  (check-equal? (goal-check-event-exit-code e) 0)
+  (check-false (goal-check-event-timed-out? e)))
+
+;; goal-achieved-event (goal-text turns-used [total-token-cost 0])
+(let ([e (goal-achieved-event "goal.achieved" 0 "s1" "t1" "tests pass" 5 300)])
+  (check-equal? (goal-achieved-event-goal-text e) "tests pass")
+  (check-equal? (goal-achieved-event-turns-used e) 5))
+
+;; goal-failed-event
+(let ([e (goal-failed-event "goal.failed" 0 "s1" "t1" "tests pass" "max-turns" 8)])
+  (check-equal? (goal-failed-event-reason e) "max-turns")
+  (check-equal? (goal-failed-event-turns-used e) 8))
+
+;; Event type is a string
+(let ([e (goal-start-event "goal.started" 0 "s1" "t1" "test" 4 '())])
+  (check-true (string? (typed-event-type e)) "goal-start-event has string type"))
+
+;; ============================================================
+;; W1: Persistence
+;; ============================================================
+
+(require racket/file
+         "../runtime/session-store.rkt")
+
+(define test-goal-dir (make-temporary-file "goal-test-~a" 'directory))
+
+(let ()
+  (define log-path (build-path test-goal-dir "session.jsonl"))
+  ;; Write session version header
+  (write-session-version-header! log-path)
+  ;; Append goal state
+  (define gs (make-goal-state #:goal-text "tests pass" #:max-turns 4))
+  (append-goal-state! log-path gs)
+  ;; Load latest
+  (define loaded (load-latest-goal-state log-path))
+  (check-true (goal-state? loaded) "load-latest-goal-state returns struct")
+  (check-equal? (goal-state-goal-text loaded) "tests pass")
+  (check-equal? (goal-state-max-turns loaded) 4)
+  (check-equal? (goal-state-status loaded) 'active))
+
+;; Load returns #f when no goals
+(let ()
+  (define log-path (build-path test-goal-dir "empty-session.jsonl"))
+  (write-session-version-header! log-path)
+  (check-false (load-latest-goal-state log-path) "load-latest returns #f when empty"))
+
+;; Multiple goals → latest wins
+(let ()
+  (define log-path (build-path test-goal-dir "multi-session.jsonl"))
+  (write-session-version-header! log-path)
+  (append-goal-state! log-path (make-goal-state #:goal-text "first" #:max-turns 2))
+  (append-goal-state! log-path
+                      (make-goal-state #:goal-text "second" #:max-turns 4 #:status 'achieved))
+  (define loaded (load-latest-goal-state log-path))
+  (check-equal? (goal-state-goal-text loaded) "second")
+  (check-equal? (goal-state-status loaded) 'achieved))
+
+;; Cleanup
+(delete-directory/files test-goal-dir)
+
+;; ============================================================
+;; W1: Context filtering — goal-state excluded from context
+;; ============================================================
+
+(require "../runtime/context-assembly/session-walk.rkt"
+         "../util/message.rkt")
+
+(let ()
+  (define gs-msg
+    (make-message "g1"
+                  #f
+                  'system
+                  'goal-state
+                  (list (hasheq 'goal-text "test"))
+                  (inexact->exact (round (current-inexact-milliseconds)))
+                  #f))
+  (check-false (entry->context-message gs-msg) "goal-state kind excluded from context"))
+
+(let ()
+  (define user-msg
+    (make-message "m1"
+                  #f
+                  'user
+                  'message
+                  (list "hello")
+                  (inexact->exact (round (current-inexact-milliseconds)))
+                  #f))
+  (check-true (message? (entry->context-message user-msg))
+              "regular message still included in context"))
+
+(displayln "All W1 tests passed.")


### PR DESCRIPTION
W1: typed events + persistence + context filtering.\n\n- 6 goal typed events: goal-start, goal-turn-start, goal-evaluated, goal-check, goal-achieved, goal-failed\n- append-goal-state! / load-latest-goal-state persistence helpers in session-store.rkt\n- goal-state kind excluded from context assembly via session-walk.rkt\n- goal-state->hash now JSON-safe (symbols→strings)\n- 18 new tests: event construction, persistence round-trip, context filtering\n\nAll compile and pass. Closes #6104.