### PR TITLE
feat(v0.71.1 W0): goal-evaluator.rkt — transcript evaluation via LLM (#6107)

### DIFF
--- a/runtime/goal-evaluator.rkt
+++ b/runtime/goal-evaluator.rkt
@@ -1,0 +1,103 @@
+#lang racket/base
+
+;; q/runtime/goal-evaluator.rkt — Transcript evaluation via LLM
+;;
+;; Evaluates whether a goal has been achieved by sending the recent
+;; conversation transcript to a cheap LLM and parsing its JSON response.
+;; Returns an evaluation-result struct.
+
+(require racket/contract
+         racket/match
+         racket/format
+         racket/string
+         json
+         "../llm/model.rkt"
+         "../llm/provider.rkt"
+         "goal-state.rkt")
+
+;; ============================================================
+;; Provides
+;; ============================================================
+
+(provide EVALUATOR-SYSTEM-PROMPT
+         evaluate-transcript
+         parse-evaluator-response)
+
+(define EVALUATOR-SYSTEM-PROMPT
+  "You are a goal achievement evaluator. Given a goal condition and a conversation
+transcript, determine if the goal has been achieved. Be strict: only return true if
+there is clear evidence in the transcript that the goal condition is met. If evidence
+is ambiguous or missing, return false with a specific reason explaining what is missing.
+
+You MUST respond with valid JSON:
+{\"ok\": true/false, \"reason\": \"specific explanation\"}
+Do NOT include any text outside the JSON object.")
+
+;; ============================================================
+;; Evaluator
+;; ============================================================
+
+(define/contract (evaluate-transcript goal-text
+                                      transcript
+                                      provider
+                                      evaluator-model
+                                      #:max-tokens [max-tokens 256])
+  (->* (string? list? provider? string?) (#:max-tokens exact-nonnegative-integer?) evaluation-result?)
+  (define messages (build-evaluator-messages goal-text transcript))
+  (define req (make-model-request messages #f (hasheq 'model evaluator-model 'max_tokens max-tokens)))
+  (with-handlers ([exn:fail? (lambda (e)
+                               (make-evaluation-result #:achieved? #f
+                                                       #:reason (~a "Evaluator error: "
+                                                                    (exn-message e))
+                                                       #:model-used evaluator-model))])
+    (define resp (provider-send provider req))
+    (define content (model-response-content resp))
+    (define usage (model-response-usage resp))
+    (define token-cost (or (and usage (hash-ref usage 'total_tokens #f)) 0))
+    (define text-content (extract-text-from-content content))
+    (parse-evaluator-response text-content evaluator-model token-cost)))
+
+;; Build the message list for the evaluator LLM call
+(define (build-evaluator-messages goal-text transcript)
+  (define sys-msg (hasheq 'role "system" 'content EVALUATOR-SYSTEM-PROMPT))
+  (define goal-msg
+    (hasheq 'role "user" 'content (~a "Goal: " goal-text "\n\nEvaluate the transcript below:")))
+  (define transcript-text (format-transcript transcript))
+  (define transcript-msg (hasheq 'role "assistant" 'content transcript-text))
+  (list sys-msg goal-msg transcript-msg))
+
+;; Format messages into readable transcript string
+(define (format-transcript messages)
+  (string-join (for/list ([msg (in-list messages)])
+                 (define role (hash-ref msg 'role "unknown"))
+                 (define content (hash-ref msg 'content ""))
+                 (format "[~a]: ~a" role content))
+               "\n\n"))
+
+;; Extract text from model response content list
+(define (extract-text-from-content content)
+  (string-join (for/list ([part (in-list content)])
+                 (cond
+                   [(string? part) part]
+                   [(hash? part) (or (hash-ref part 'text #f) (hash-ref part 'content #f) (~a part))]
+                   [else (~a part)]))
+               ""))
+
+;; Parse the evaluator's JSON response
+(define/contract (parse-evaluator-response text model-used [token-cost 0])
+  (->* (string? string?) (exact-nonnegative-integer?) evaluation-result?)
+  (with-handlers ([exn:fail? (lambda (e)
+                               (make-evaluation-result #:achieved? #f
+                                                       #:reason (~a "Evaluator returned non-JSON: "
+                                                                    (exn-message e))
+                                                       #:model-used model-used
+                                                       #:token-cost token-cost))])
+    (define jx (string->jsexpr text))
+    (define ok (hash-ref jx 'ok #f))
+    (define reason (hash-ref jx 'reason "no reason provided"))
+    (make-evaluation-result #:achieved? (and ok #t)
+                            #:reason (if (string? reason)
+                                         reason
+                                         (~a reason))
+                            #:model-used model-used
+                            #:token-cost token-cost)))

--- a/tests/test-goal-evaluator.rkt
+++ b/tests/test-goal-evaluator.rkt
@@ -1,0 +1,132 @@
+#lang racket/base
+
+;; tests/test-goal-evaluator.rkt — Evaluator unit tests with mock provider
+
+(require rackunit
+         racket/format
+         racket/list
+         racket/string
+         json
+         "../llm/model.rkt"
+         "../llm/provider.rkt"
+         "../runtime/goal-evaluator.rkt"
+         "../runtime/goal-state.rkt")
+
+;; ============================================================
+;; Helper: create mock provider that returns predefined responses
+;; ============================================================
+
+(define (make-eval-mock-provider responses)
+  (define idx (box 0))
+  (make-provider (lambda () "eval-mock")
+                 (lambda () (hash 'streaming #f 'token-counting #t))
+                 (lambda (req)
+                   (define resp
+                     (if (< (unbox idx) (length responses))
+                         (list-ref responses (unbox idx))
+                         (last responses)))
+                   (set-box! idx (add1 (unbox idx)))
+                   resp)
+                 (lambda (req)
+                   (define resp
+                     (if (< (unbox idx) (length responses))
+                         (list-ref responses (unbox idx))
+                         (last responses)))
+                   (set-box! idx (add1 (unbox idx)))
+                   resp)))
+
+(define (text-response text [model "mock-eval"])
+  (make-model-response (list (hasheq 'type "text" 'text text))
+                       (hasheq 'total_tokens 50 'prompt_tokens 30 'completion_tokens 20)
+                       model
+                       'stop))
+
+;; ============================================================
+;; parse-evaluator-response tests
+;; ============================================================
+
+(let ([er (parse-evaluator-response "{\"ok\": true, \"reason\": \"all tests pass\"}" "test-model")])
+  (check-true (evaluation-result-achieved? er) "JSON ok=true → achieved")
+  (check-equal? (evaluation-result-reason er) "all tests pass")
+  (check-equal? (evaluation-result-model-used er) "test-model"))
+
+(let ([er (parse-evaluator-response "{\"ok\": false, \"reason\": \"missing evidence\"}"
+                                    "test-model")])
+  (check-false (evaluation-result-achieved? er) "JSON ok=false → not achieved")
+  (check-equal? (evaluation-result-reason er) "missing evidence"))
+
+(let ([er (parse-evaluator-response "not json at all" "test-model")])
+  (check-false (evaluation-result-achieved? er) "Non-JSON → not achieved")
+  (check-true (string-contains? (evaluation-result-reason er) "non-JSON")
+              "Non-JSON reason mentions non-JSON"))
+
+(let ([er (parse-evaluator-response "{\"ok\": true}" "test-model")])
+  (check-true (evaluation-result-achieved? er) "JSON with ok, no reason → achieved")
+  (check-equal? (evaluation-result-reason er) "no reason provided"))
+
+(let ([er (parse-evaluator-response "{\"ok\": false}" "test-model" 100)])
+  (check-false (evaluation-result-achieved? er))
+  (check-equal? (evaluation-result-token-cost er) 100 "token-cost passed through"))
+
+;; ============================================================
+;; evaluate-transcript with mock provider
+;; ============================================================
+
+(let ()
+  (define mock
+    (make-eval-mock-provider (list (text-response "{\"ok\": true, \"reason\": \"evidence found\"}"))))
+  (define er
+    (evaluate-transcript
+     "make tests pass"
+     (list (hasheq 'role "assistant" 'content "I ran the tests and they all pass."))
+     mock
+     "mock-eval"))
+  (check-true (evaluation-result-achieved? er) "Mock returns achieved")
+  (check-equal? (evaluation-result-reason er) "evidence found")
+  (check-equal? (evaluation-result-model-used er) "mock-eval")
+  (check-true (> (evaluation-result-token-cost er) 0) "Token cost tracked"))
+
+(let ()
+  (define mock
+    (make-eval-mock-provider
+     (list (text-response "{\"ok\": false, \"reason\": \"no test output\"}"))))
+  (define er
+    (evaluate-transcript "tests pass"
+                         (list (hasheq 'role "assistant" 'content "I wrote some code."))
+                         mock
+                         "mock-eval"))
+  (check-false (evaluation-result-achieved? er) "Mock returns not achieved")
+  (check-equal? (evaluation-result-reason er) "no test output"))
+
+(let ()
+  (define mock (make-eval-mock-provider (list (text-response "I think the goal is met"))))
+  (define er (evaluate-transcript "do something" '() mock "mock-eval"))
+  (check-false (evaluation-result-achieved? er) "Non-JSON response → not achieved")
+  (check-true (string-contains? (evaluation-result-reason er) "non-JSON")))
+
+;; ============================================================
+;; Empty transcript
+;; ============================================================
+
+(let ()
+  (define mock
+    (make-eval-mock-provider
+     (list (text-response "{\"ok\": false, \"reason\": \"empty transcript\"}"))))
+  (define er (evaluate-transcript "goal" '() mock "mock-eval"))
+  (check-false (evaluation-result-achieved? er) "Empty transcript → not achieved"))
+
+;; ============================================================
+;; Multiple evaluator turns
+;; ============================================================
+
+(let ()
+  (define mock
+    (make-eval-mock-provider
+     (list (text-response "{\"ok\": false, \"reason\": \"first attempt\"}")
+           (text-response "{\"ok\": true, \"reason\": \"second attempt succeeded\"}"))))
+  (define er1 (evaluate-transcript "goal" '() mock "mock-eval"))
+  (check-false (evaluation-result-achieved? er1))
+  (define er2 (evaluate-transcript "goal" '() mock "mock-eval"))
+  (check-true (evaluation-result-achieved? er2) "Second evaluation succeeds"))
+
+(displayln "All goal-evaluator tests passed.")


### PR DESCRIPTION
W0: goal-evaluator.rkt — transcript evaluation via LLM.\n\n- evaluate-transcript: sends goal + transcript to cheap LLM, parses JSON response\n- parse-evaluator-response: strict JSON parsing with graceful fallback\n- EVALUATOR-SYSTEM-PROMPT constant\n- 12 tests: JSON parsing, mock provider evaluation, non-JSON fallback, empty transcript, multi-turn evaluation\n\nCloses #6107.