### PR TITLE
feat(v0.71.2 W0): goal-evidence.rkt — evidence discipline + no-progress (#6112)

### DIFF
--- a/runtime/goal-evidence.rkt
+++ b/runtime/goal-evidence.rkt
@@ -1,0 +1,82 @@
+#lang racket/base
+
+;; q/runtime/goal-evidence.rkt — Evidence discipline + no-progress detection
+;;
+;; Two responsibilities:
+;; 1. System prompt injection: forces worker agent to produce verifiable evidence
+;; 2. No-progress detector: detects stall conditions from consecutive evaluations
+
+(require racket/contract
+         racket/match
+         racket/format
+         racket/string
+         racket/list
+         "goal-state.rkt")
+
+;; ============================================================
+;; Provides
+;; ============================================================
+
+(provide GOAL-EVIDENCE-SYSTEM-PROMPT
+         goal-system-instructions
+         detect-no-progress
+         consecutive-same-reason?
+         evidence-prompt-for-goal)
+
+;; ============================================================
+;; Evidence system prompt
+;; ============================================================
+
+(define GOAL-EVIDENCE-SYSTEM-PROMPT
+  (string-append "You are working under an active q goal. Before stopping:\n"
+                 "1. Report which goal criteria are satisfied with specific evidence\n"
+                 "2. List exact checks you ran and their outputs (commands, exit codes, file diffs)\n"
+                 "3. Describe remaining blockers precisely\n"
+                 "4. If you believe the goal is achieved, state 'GOAL ACHIEVED' with proof\n"
+                 "5. Never claim success without running at least one verification command"))
+
+;; Build the full system instructions to inject when a goal is active.
+;; Returns a list of strings to append to system-instructions.
+(define/contract (goal-system-instructions goal-st)
+  (-> goal-state? (listof string?))
+  (list GOAL-EVIDENCE-SYSTEM-PROMPT
+        (format "Active goal: ~a (turn ~a/~a)"
+                (goal-state-goal-text goal-st)
+                (goal-state-turns-used goal-st)
+                (goal-state-max-turns goal-st))))
+
+;; Build a goal-specific evidence prompt for the continuation message.
+(define/contract (evidence-prompt-for-goal goal-text evaluation)
+  (-> string? (or/c evaluation-result? #f) string?)
+  (define base (format "Continue working toward: ~a" goal-text))
+  (if evaluation
+      (format
+       "~a\n\nPrevious evaluation: ~a\n\nProvide specific evidence: run commands, check files, show outputs."
+       base
+       (evaluation-result-reason evaluation))
+      (format "~a\n\nProvide specific evidence: run commands, check files, show outputs." base)))
+
+;; ============================================================
+;; No-progress detection
+;; ============================================================
+
+;; Returns #t if the last NO-PROGRESS-THRESHOLD evaluations have the same reason
+;; AND none achieved the goal.
+(define/contract (consecutive-same-reason? evaluations)
+  (-> (listof evaluation-result?) boolean?)
+  (cond
+    [(< (length evaluations) NO-PROGRESS-THRESHOLD) #f]
+    [else
+     (define last-n (take-right evaluations NO-PROGRESS-THRESHOLD))
+     (define reasons (map evaluation-result-reason last-n))
+     (define all-failed? (andmap (lambda (e) (not (evaluation-result-achieved? e))) last-n))
+     (define all-same? (andmap (lambda (r) (equal? r (car reasons))) (cdr reasons)))
+     (and all-failed? all-same?)]))
+
+;; Detect no-progress from a list of evaluation results.
+;; Returns #t if stall is detected, #f otherwise.
+(define/contract (detect-no-progress evaluations)
+  (-> (listof evaluation-result?) boolean?)
+  (cond
+    [(< (length evaluations) NO-PROGRESS-THRESHOLD) #f]
+    [else (consecutive-same-reason? evaluations)]))

--- a/tests/test-goal-evidence.rkt
+++ b/tests/test-goal-evidence.rkt
@@ -1,0 +1,122 @@
+#lang racket/base
+
+;; tests/test-goal-evidence.rkt — Evidence prompt + no-progress detection tests
+
+(require rackunit
+         racket/string
+         (only-in "../runtime/goal-state.rkt"
+                  make-goal-state
+                  make-evaluation-result
+                  evaluation-result?
+                  evaluation-result-achieved?
+                  evaluation-result-reason
+                  goal-state-goal-text
+                  goal-state-turns-used
+                  goal-state-max-turns
+                  goal-state?)
+         "../runtime/goal-evidence.rkt")
+
+;; ============================================================
+;; GOAL-EVIDENCE-SYSTEM-PROMPT is a non-empty string
+;; ============================================================
+
+(check-true (string? GOAL-EVIDENCE-SYSTEM-PROMPT))
+(check-true (> (string-length GOAL-EVIDENCE-SYSTEM-PROMPT) 50))
+(check-not-false (string-contains? GOAL-EVIDENCE-SYSTEM-PROMPT "GOAL ACHIEVED"))
+
+;; ============================================================
+;; goal-system-instructions returns list of 2 strings
+;; ============================================================
+
+(let ()
+  (define gs (make-goal-state #:goal-text "tests pass" #:max-turns 8))
+  (define instrs (goal-system-instructions gs))
+  (check-equal? (length instrs) 2)
+  (check-true (string-contains? (cadr instrs) "tests pass"))
+  (check-true (string-contains? (cadr instrs) "turn 0/8")))
+
+;; ============================================================
+;; evidence-prompt-for-goal without evaluation
+;; ============================================================
+
+(let ()
+  (define prompt (evidence-prompt-for-goal "fix the bug" #f))
+  (check-true (string-contains? prompt "fix the bug"))
+  (check-true (string-contains? prompt "evidence")))
+
+;; ============================================================
+;; evidence-prompt-for-goal with evaluation
+;; ============================================================
+
+(let ()
+  (define eval (make-evaluation-result #:achieved? #f #:reason "still 2 test failures"))
+  (define prompt (evidence-prompt-for-goal "tests pass" eval))
+  (check-true (string-contains? prompt "tests pass"))
+  (check-true (string-contains? prompt "still 2 test failures"))
+  (check-true (string-contains? prompt "evidence")))
+
+;; ============================================================
+;; evidence-prompt-for-goal achieved includes evidence reminder
+;; ============================================================
+
+(let ()
+  (define eval (make-evaluation-result #:achieved? #t #:reason "all green"))
+  (define prompt (evidence-prompt-for-goal "tests pass" eval))
+  (check-true (string-contains? prompt "tests pass")))
+
+;; ============================================================
+;; consecutive-same-reason? — fewer than threshold → #f
+;; ============================================================
+
+(check-false (consecutive-same-reason? '()))
+(check-false (consecutive-same-reason? (list (make-evaluation-result #:achieved? #f
+                                                                     #:reason "nope"))))
+
+;; ============================================================
+;; consecutive-same-reason? — same reason 3 times → #t
+;; ============================================================
+
+(check-true (consecutive-same-reason?
+             (list (make-evaluation-result #:achieved? #f #:reason "no progress")
+                   (make-evaluation-result #:achieved? #f #:reason "no progress")
+                   (make-evaluation-result #:achieved? #f #:reason "no progress"))))
+
+;; ============================================================
+;; consecutive-same-reason? — mixed reasons → #f
+;; ============================================================
+
+(check-false (consecutive-same-reason?
+              (list (make-evaluation-result #:achieved? #f #:reason "no progress")
+                    (make-evaluation-result #:achieved? #f #:reason "different")
+                    (make-evaluation-result #:achieved? #f #:reason "no progress"))))
+
+;; ============================================================
+;; consecutive-same-reason? — one achieved → #f
+;; ============================================================
+
+(check-false (consecutive-same-reason? (list (make-evaluation-result #:achieved? #t #:reason "done")
+                                             (make-evaluation-result #:achieved? #t #:reason "done")
+                                             (make-evaluation-result #:achieved? #t
+                                                                     #:reason "done"))))
+
+;; ============================================================
+;; detect-no-progress — same as consecutive-same-reason?
+;; ============================================================
+
+(check-false (detect-no-progress '()))
+
+(check-true (detect-no-progress (list (make-evaluation-result #:achieved? #f #:reason "stuck")
+                                      (make-evaluation-result #:achieved? #f #:reason "stuck")
+                                      (make-evaluation-result #:achieved? #f #:reason "stuck"))))
+
+;; ============================================================
+;; detect-no-progress — 5 results with last 3 same → #t
+;; ============================================================
+
+(check-true (detect-no-progress (list (make-evaluation-result #:achieved? #f #:reason "first")
+                                      (make-evaluation-result #:achieved? #f #:reason "second")
+                                      (make-evaluation-result #:achieved? #f #:reason "stuck")
+                                      (make-evaluation-result #:achieved? #f #:reason "stuck")
+                                      (make-evaluation-result #:achieved? #f #:reason "stuck"))))
+
+(displayln "All goal-evidence tests passed.")


### PR DESCRIPTION
W0: goal-evidence.rkt — evidence discipline + no-progress detection.\n\n- GOAL-EVIDENCE-SYSTEM-PROMPT: forces worker to produce verifiable evidence\n- goal-system-instructions: builds system prompt injection for active goals\n- evidence-prompt-for-goal: continuation prompt with evaluation feedback\n- consecutive-same-reason?: detects 3 consecutive same-reason failures\n- detect-no-progress: stall detection from evaluation history\n- 14 tests: prompt construction, no-progress detection, edge cases\n\nCloses #6112.