### PR TITLE
feat(v0.71.3 W1): check integration in evaluator + runner (#6117)

### DIFF
--- a/runtime/goal-evaluator.rkt
+++ b/runtime/goal-evaluator.rkt
@@ -13,7 +13,8 @@
          json
          "../llm/model.rkt"
          "../llm/provider.rkt"
-         "goal-state.rkt")
+         "goal-state.rkt"
+         "goal-checks.rkt")
 
 ;; ============================================================
 ;; Provides
@@ -41,9 +42,12 @@ Do NOT include any text outside the JSON object.")
                                       transcript
                                       provider
                                       evaluator-model
-                                      #:max-tokens [max-tokens 256])
-  (->* (string? list? provider? string?) (#:max-tokens exact-nonnegative-integer?) evaluation-result?)
-  (define messages (build-evaluator-messages goal-text transcript))
+                                      #:max-tokens [max-tokens 256]
+                                      #:check-results [check-results '()])
+  (->* (string? list? provider? string?)
+       (#:max-tokens exact-nonnegative-integer? #:check-results (listof check-result?))
+       evaluation-result?)
+  (define messages (build-evaluator-messages goal-text transcript check-results))
   (define req (make-model-request messages #f (hasheq 'model evaluator-model 'max_tokens max-tokens)))
   (with-handlers ([exn:fail? (lambda (e)
                                (make-evaluation-result #:achieved? #f
@@ -58,10 +62,24 @@ Do NOT include any text outside the JSON object.")
     (parse-evaluator-response text-content evaluator-model token-cost)))
 
 ;; Build the message list for the evaluator LLM call
-(define (build-evaluator-messages goal-text transcript)
+(define (build-evaluator-messages goal-text transcript [check-results '()])
   (define sys-msg (hasheq 'role "system" 'content EVALUATOR-SYSTEM-PROMPT))
+  (define check-text
+    (if (null? check-results)
+        ""
+        (format "\n\nDeterministic check results:\n~a"
+                (string-join (for/list ([cr (in-list check-results)])
+                               (format "- ~a: ~a (exit ~a)~a"
+                                       (check-result-label cr)
+                                       (if (= (check-result-exit-code cr) 0) "PASS" "FAIL")
+                                       (check-result-exit-code cr)
+                                       (if (check-result-timed-out? cr) " [TIMED OUT]" "")))
+                             "\n"))))
   (define goal-msg
-    (hasheq 'role "user" 'content (~a "Goal: " goal-text "\n\nEvaluate the transcript below:")))
+    (hasheq 'role
+            "user"
+            'content
+            (~a "Goal: " goal-text check-text "\n\nEvaluate the transcript below:")))
   (define transcript-text (format-transcript transcript))
   (define transcript-msg (hasheq 'role "assistant" 'content transcript-text))
   (list sys-msg goal-msg transcript-msg))

--- a/runtime/goal-runner.rkt
+++ b/runtime/goal-runner.rkt
@@ -16,6 +16,7 @@
          "goal-state.rkt"
          "goal-evaluator.rkt"
          "goal-evidence.rkt"
+         "goal-checks.rkt"
          "../llm/provider.rkt")
 
 ;; ============================================================
@@ -26,7 +27,8 @@
          goal-run-simulated!
          goal-loop-step
          build-continuation-prompt
-         collect-evaluations)
+         collect-evaluations
+         execute-checks-for-goal)
 
 (define NO-PROGRESS-THRESHOLD 3)
 
@@ -37,6 +39,14 @@
   (if last-eval
       (append from-checks (list last-eval))
       from-checks))
+
+;; Execute all deterministic checks from goal-state and return results.
+;; If no checks defined, returns empty list.
+(define (execute-checks-for-goal goal-st)
+  (define checks (goal-state-checks goal-st))
+  (if (and (pair? checks) (goal-check? (car checks)))
+      (execute-all-checks checks #:timeout 30)
+      '()))
 
 ;; ============================================================
 ;; Main entry point
@@ -136,10 +146,14 @@
   ;; Run the prompt through the agent
   (define-values (updated-sess loop-result) (run-prompt-fn! prompt))
 
+  ;; Execute deterministic checks if any
+  (define check-results (execute-checks-for-goal goal-st))
+
   ;; Evaluate the result
   ;; Extract transcript from loop-result for evaluation
   (define transcript (extract-transcript-from-result loop-result))
-  (define eval-result (evaluate-transcript goal-text transcript provider evaluator-model))
+  (define eval-result
+    (evaluate-transcript goal-text transcript provider evaluator-model #:check-results check-results))
 
   ;; Emit goal.evaluated
   (on-event 'goal-evaluated (hasheq 'evaluation eval-result 'turn turns))

--- a/tests/test-goal-command.rkt
+++ b/tests/test-goal-command.rkt
@@ -44,3 +44,5 @@
   (check-equal? (parsed-command-canonical-name result) 'goal))
 
 (displayln "All goal-command tests passed.")
+
+(displayln "All goal-command tests passed.")

--- a/tests/test-goal-evaluator.rkt
+++ b/tests/test-goal-evaluator.rkt
@@ -10,7 +10,8 @@
          "../llm/model.rkt"
          "../llm/provider.rkt"
          "../runtime/goal-evaluator.rkt"
-         "../runtime/goal-state.rkt")
+         "../runtime/goal-state.rkt"
+         (only-in "../runtime/goal-state.rkt" check-result))
 
 ;; ============================================================
 ;; Helper: create mock provider that returns predefined responses
@@ -130,3 +131,49 @@
   (check-true (evaluation-result-achieved? er2) "Second evaluation succeeds"))
 
 (displayln "All goal-evaluator tests passed.")
+
+;; ============================================================
+;; evaluate-transcript with check-results
+;; ============================================================
+
+;; ============================================================
+;; evaluate-transcript with check-results
+;; ============================================================
+
+(let ()
+  (define (text-response text)
+    (make-model-response (list (hasheq 'type "text" 'text text))
+                         (hasheq 'total_tokens 20)
+                         "mock"
+                         'stop))
+  (define (make-check-mock responses)
+    (define idx (box 0))
+    (make-provider (lambda () "test-eval")
+                   (lambda () (hash 'streaming #f 'token-counting #t))
+                   (lambda (req)
+                     (define resp
+                       (if (< (unbox idx) (length responses))
+                           (list-ref responses (unbox idx))
+                           (last responses)))
+                     (set-box! idx (add1 (unbox idx)))
+                     resp)
+                   (lambda (req)
+                     (define resp
+                       (if (< (unbox idx) (length responses))
+                           (list-ref responses (unbox idx))
+                           (last responses)))
+                     (set-box! idx (add1 (unbox idx)))
+                     resp)))
+  (define cr-pass (check-result "test-1" 0 "all good" "" #f 10))
+  (define cr-fail (check-result "test-2" 1 "" "error" #f 5))
+  ;; Provider returns "achieved"
+  (define mock-ok
+    (make-check-mock (list (text-response "{\"ok\": true, \"reason\": \"checks pass\"}"))))
+  (define er-pass (evaluate-transcript "goal" '() mock-ok "mock-eval" #:check-results (list cr-pass)))
+  (check-true (evaluation-result-achieved? er-pass) "achieved with passing check")
+  ;; Provider returns "not yet" for failed check context
+  (define mock-fail
+    (make-check-mock (list (text-response "{\"ok\": false, \"reason\": \"check failed\"}"))))
+  (define er-fail
+    (evaluate-transcript "goal" '() mock-fail "mock-eval" #:check-results (list cr-fail)))
+  (check-false (evaluation-result-achieved? er-fail) "failed check → not achieved"))

--- a/tui/commands.rkt
+++ b/tui/commands.rkt
@@ -26,6 +26,8 @@
          "../agent/event-bus.rkt"
          "../extensions/hooks.rkt"
          "../extensions/api.rkt"
+         "../runtime/goal-checks.rkt"
+         (only-in "../runtime/goal-state.rkt" goal-check-label goal-check-command)
          ;; Sub-module imports
          (only-in "commands/context.rkt"
                   cmd-ctx
@@ -316,19 +318,45 @@
        (make-system-entry "[goal] No active goal. Use /goal \"<description>\" to set one."))
      (set-box! (cmd-ctx-state-box cctx) (add-transcript-entry state entry))
      'continue]
-    ;; /goal "<description>" — set a goal
+    ;; /goal "<description>" [--check 'cmd'] — set a goal with optional checks
     [else
-     ;; Strip surrounding quotes if present
+     ;; Check for --check arguments
+     (define-values (goal-text checks)
+       (if (string-contains? arg-text "--check")
+           (parse-goal-checks arg-text)
+           (values arg-text '())))
+     ;; Strip surrounding quotes from goal text if present
      (define clean-text
-       (let ([t arg-text])
+       (let ([t goal-text])
          (if (and (> (string-length t) 1)
-                  (char=? (string-ref t 0) #\")
-                  (char=? (string-ref t (sub1 (string-length t))) #\"))
+                  (or (char=? (string-ref t 0) #\") (char=? (string-ref t 0) #\'))
+                  (or (char=? (string-ref t (sub1 (string-length t))) #\")
+                      (char=? (string-ref t (sub1 (string-length t))) #\')))
              (substring t 1 (sub1 (string-length t)))
              t)))
-     (define entry
-       (make-system-entry
-        (format "[goal] Goal set: ~a\nThe autonomous goal loop will be available in a future update."
-                clean-text)))
-     (set-box! (cmd-ctx-state-box cctx) (add-transcript-entry state entry))
-     'continue]))
+     ;; Validate check safety
+     (define safety-reasons (validate-check-safety checks))
+     (cond
+       [(pair? safety-reasons)
+        (define entry
+          (make-system-entry (format "[goal] REJECTED — unsafe check commands:\n~a"
+                                     (string-join safety-reasons "\n"))))
+        (set-box! (cmd-ctx-state-box cctx) (add-transcript-entry state entry))
+        'continue]
+       [else
+        (define check-info
+          (if (null? checks)
+              ""
+              (format "\nChecks: ~a"
+                      (string-join
+                       (map (lambda (c) (format "~a: ~a" (goal-check-label c) (goal-check-command c)))
+                            checks)
+                       ", "))))
+        (define entry
+          (make-system-entry
+           (format
+            "[goal] Goal set: ~a~a\nThe autonomous goal loop will be available in a future update."
+            clean-text
+            check-info)))
+        (set-box! (cmd-ctx-state-box cctx) (add-transcript-entry state entry))
+        'continue])]))


### PR DESCRIPTION
W1: integrate checks into evaluator, runner, and /goal command.\n\n- evaluate-transcript gains #:check-results parameter\n- Check results appended to evaluator prompt as deterministic evidence\n- Runner executes checks before LLM evaluation\n- /goal command parses --check arguments, validates safety\n- Tests: evaluator with check results (2 new), command handler\n\nCloses #6117.