### PR TITLE
feat(v0.71.4 W0): ui-state + event reducers + goal badge (#6121)

### DIFF
--- a/tests/test-goal-tui.rkt
+++ b/tests/test-goal-tui.rkt
@@ -1,0 +1,136 @@
+#lang racket/base
+
+;; tests/test-goal-tui.rkt — TUI goal event reducer + display tests
+
+(require rackunit
+         racket/string
+         "../tui/state-types.rkt"
+         "../tui/state-events.rkt"
+         "../util/protocol-types.rkt")
+
+;; ============================================================
+;; goal-display-info struct
+;; ============================================================
+
+(let ()
+  (define gdi (goal-display-info "tests pass" 3 8 'active))
+  (check-equal? (goal-display-info-goal-text gdi) "tests pass")
+  (check-equal? (goal-display-info-turns-used gdi) 3)
+  (check-equal? (goal-display-info-max-turns gdi) 8)
+  (check-equal? (goal-display-info-status gdi) 'active))
+
+;; ============================================================
+;; initial-ui-state has no active goal
+;; ============================================================
+
+(let ()
+  (define st (initial-ui-state))
+  (check-false (ui-state-active-goal st)))
+
+;; ============================================================
+;; goal.started sets active-goal
+;; ============================================================
+
+(let ()
+  (define st (initial-ui-state))
+  (define evt (make-event "goal.started" 0 "s1" "t1"
+                     (hasheq 'goal-text "make all tests pass"
+                             'max-turns 8
+                             'checks '())))
+  (define st2 (apply-event-to-state st evt))
+  (define goal (ui-state-active-goal st2))
+  (check-not-false goal "active-goal set after goal.started")
+  (check-equal? (goal-display-info-goal-text goal) "make all tests pass")
+  (check-equal? (goal-display-info-turns-used goal) 0)
+  (check-equal? (goal-display-info-max-turns goal) 8)
+  (check-equal? (goal-display-info-status goal) 'active))
+
+;; ============================================================
+;; goal.turn.started increments turns
+;; ============================================================
+
+(let ()
+  (define st (initial-ui-state))
+  ;; First start a goal
+  (define evt1 (make-event "goal.started" 0 "s1" "t1"
+                      (hasheq 'goal-text "goal" 'max-turns 8 'checks '())))
+  (define st1 (apply-event-to-state st evt1))
+  ;; Then turn started
+  (define evt2 (make-event "goal.turn.started" 0 "s1" "t2"
+                      (hasheq 'turn-number 1 'goal-text "goal")))
+  (define st2 (apply-event-to-state st1 evt2))
+  (check-equal? (goal-display-info-turns-used (ui-state-active-goal st2)) 1))
+
+;; ============================================================
+;; goal.achieved sets status
+;; ============================================================
+
+(let ()
+  (define st (initial-ui-state))
+  (define evt1 (make-event "goal.started" 0 "s1" "t1"
+                      (hasheq 'goal-text "goal" 'max-turns 8 'checks '())))
+  (define st1 (apply-event-to-state st evt1))
+  (define evt2 (make-event "goal.achieved" 0 "s1" "t2"
+                      (hasheq 'goal-text "goal" 'turns-used 5 'total-token-cost 0)))
+  (define st2 (apply-event-to-state st1 evt2))
+  (check-equal? (goal-display-info-status (ui-state-active-goal st2)) 'achieved)
+  (check-equal? (goal-display-info-turns-used (ui-state-active-goal st2)) 5))
+
+;; ============================================================
+;; goal.failed sets status
+;; ============================================================
+
+(let ()
+  (define st (initial-ui-state))
+  (define evt1 (make-event "goal.started" 0 "s1" "t1"
+                      (hasheq 'goal-text "goal" 'max-turns 8 'checks '())))
+  (define st1 (apply-event-to-state st evt1))
+  (define evt2 (make-event "goal.failed" 0 "s1" "t2"
+                      (hasheq 'goal-text "goal" 'reason "max turns" 'turns-used 8)))
+  (define st2 (apply-event-to-state st1 evt2))
+  (check-equal? (goal-display-info-status (ui-state-active-goal st2)) 'failed))
+
+;; ============================================================
+;; goal.check.completed is no-op
+;; ============================================================
+
+(let ()
+  (define st (initial-ui-state))
+  (define evt1 (make-event "goal.started" 0 "s1" "t1"
+                      (hasheq 'goal-text "goal" 'max-turns 8 'checks '())))
+  (define st1 (apply-event-to-state st evt1))
+  (define evt2 (make-event "goal.check.completed" 0 "s1" "t2"
+                      (hasheq 'label "test" 'exit-code 0 'timed-out? #f
+                              'stdout "" 'stderr "")))
+  (define st2 (apply-event-to-state st1 evt2))
+  ;; State should be unchanged (same object)
+  (check-eq? st2 st1))
+
+;; ============================================================
+;; goal.evaluated keeps active status
+;; ============================================================
+
+(let ()
+  (define st (initial-ui-state))
+  (define evt1 (make-event "goal.started" 0 "s1" "t1"
+                      (hasheq 'goal-text "goal" 'max-turns 8 'checks '())))
+  (define st1 (apply-event-to-state st evt1))
+  (define evt2 (make-event "goal.evaluated" 0 "s1" "t2"
+                      (hasheq 'achieved? #f 'reason "not yet"
+                              'turn-number 1 'token-cost 10)))
+  (define st2 (apply-event-to-state st1 evt2))
+  (check-equal? (goal-display-info-status (ui-state-active-goal st2)) 'active))
+
+;; ============================================================
+;; Goal text truncated to 40 chars
+;; ============================================================
+
+(let ()
+  (define long-text (make-string 60 #\x))
+  (define st (initial-ui-state))
+  (define evt (make-event "goal.started" 0 "s1" "t1"
+                     (hasheq 'goal-text long-text 'max-turns 8 'checks '())))
+  (define st2 (apply-event-to-state st evt))
+  (check-equal? (string-length (goal-display-info-goal-text (ui-state-active-goal st2))) 40))
+
+(displayln "All goal-TUI tests passed.")

--- a/tui/render/status-line.rkt
+++ b/tui/render/status-line.rkt
@@ -78,9 +78,27 @@
           (format " [~a]" joined))
         ""))
 
+  ;; Goal badge
+  (define goal-info (ui-state-active-goal state))
+  (define goal-badge
+    (if goal-info
+        (let* ([t (goal-display-info-turns-used goal-info)]
+               [m (goal-display-info-max-turns goal-info)]
+               [s (goal-display-info-status goal-info)]
+               [status-text (case s
+                              [(active) "active"]
+                              [(achieved) "\u2713"]
+                              [(failed) "\u2717"]
+                              [(cancelled) "\u2717"]
+                              [else "?"])]
+               [text (format "\u25ce goal ~a/~a \u00b7 ~a" t m status-text)])
+          (format " ~a" text))
+        ""))
+
   ;; Inverse segment (prefix + session + model + state)
   (define busy-marker (if busy " *" "  "))
-  (define inv-text (string-append " q" busy-marker " " session-label state-indicator queue-text))
+  (define inv-text
+    (string-append " q" busy-marker " " session-label state-indicator queue-text goal-badge))
 
   ;; Normal-style segments (context + cost + scroll)
   ;; Show context pressure percentage when available, else token count

--- a/tui/state-events.rkt
+++ b/tui/state-events.rkt
@@ -485,6 +485,71 @@
 (register-event-reducer! "context.pressure" handle-context-pressure)
 
 ;; ============================================================
+;; Goal event reducers (v0.71.4)
+;; ============================================================
+
+(define (handle-goal-started state evt)
+  (define payload (event-payload evt))
+  (define goal-text (hash-ref payload 'goal-text ""))
+  (define max-turns (hash-ref payload 'max-turns 8))
+  (struct-copy ui-state
+               state
+               [active-goal (goal-display-info (truncate-string goal-text 40) 0 max-turns 'active)]))
+
+(define (handle-goal-turn-started state evt)
+  (define payload (event-payload evt))
+  (define turn (hash-ref payload 'turn-number 1))
+  (define current (ui-state-active-goal state))
+  (if current
+      (struct-copy ui-state
+                   state
+                   [active-goal
+                    (struct-copy goal-display-info current [turns-used turn] [status 'active])])
+      state))
+
+(define (handle-goal-evaluated state evt)
+  ;; Evaluation complete, status stays active but turns updated
+  (define current (ui-state-active-goal state))
+  (if current
+      (struct-copy ui-state
+                   state
+                   [active-goal (struct-copy goal-display-info current [status 'active])])
+      state))
+
+(define (handle-goal-check-completed state evt)
+  ;; Informational only — no state change
+  state)
+
+(define (handle-goal-achieved state evt)
+  (define payload (event-payload evt))
+  (define turns (hash-ref payload 'turns-used 0))
+  (define current (ui-state-active-goal state))
+  (if current
+      (struct-copy ui-state
+                   state
+                   [active-goal
+                    (struct-copy goal-display-info current [turns-used turns] [status 'achieved])])
+      state))
+
+(define (handle-goal-failed state evt)
+  (define payload (event-payload evt))
+  (define turns (hash-ref payload 'turns-used 0))
+  (define current (ui-state-active-goal state))
+  (if current
+      (struct-copy ui-state
+                   state
+                   [active-goal
+                    (struct-copy goal-display-info current [turns-used turns] [status 'failed])])
+      state))
+
+(register-event-reducer! "goal.started" handle-goal-started)
+(register-event-reducer! "goal.turn.started" handle-goal-turn-started)
+(register-event-reducer! "goal.evaluated" handle-goal-evaluated)
+(register-event-reducer! "goal.check.completed" handle-goal-check-completed)
+(register-event-reducer! "goal.achieved" handle-goal-achieved)
+(register-event-reducer! "goal.failed" handle-goal-failed)
+
+;; ============================================================
 ;; Event reduction dispatch
 ;; ============================================================
 

--- a/tui/state-types.rkt
+++ b/tui/state-types.rkt
@@ -149,7 +149,14 @@
           [truncate-string (-> string? exact-nonnegative-integer? string?)]
           [extract-arg-summary (-> (or/c string? hash?) string?)])
          ui-state-context-pressure-level
-         ui-state-context-pressure-percent)
+         ui-state-context-pressure-percent
+         ui-state-active-goal
+         goal-display-info
+         goal-display-info?
+         goal-display-info-goal-text
+         goal-display-info-turns-used
+         goal-display-info-max-turns
+         goal-display-info-status)
 
 ;; Forward declarations for types referenced in contracts but defined elsewhere
 ;; (These are provided by other modules and re-exported through state.rkt)
@@ -234,7 +241,17 @@
          context-tokens ; (or/c #f integer?) — estimated token count from context events (v0.19.12 W1)
          cost-tracker
          context-pressure-level
-         context-pressure-percent) ; (or/c #f cost-tracker?) — mutable cost accumulator (G8.4)
+         context-pressure-percent ; (or/c #f cost-tracker?) — mutable cost accumulator (G8.4)
+         ;; --- Goal group ---
+         active-goal) ; (or/c goal-display-info? #f) — active autonomous goal display info
+  #:transparent)
+
+;; Goal display info for TUI status bar
+(struct goal-display-info
+        (goal-text ; string (truncated to 40 chars)
+         turns-used ; exact-nonnegative-integer?
+         max-turns ; exact-nonnegative-integer?
+         status) ; symbol: 'active 'achieved 'failed 'cancelled
   #:transparent)
 
 ;; Overlay state for modal/popup UI elements (command palette, etc.)
@@ -367,6 +384,7 @@
             #f ; editor-component
             #f ; context-tokens
             (make-cost-tracker)
+            #f
             #f
             #f))
 


### PR DESCRIPTION
W0: ui-state extension + goal event reducers + status bar badge.\n\n- Added `goal-display-info` struct to state-types.rkt\n- Added `active-goal` field to `ui-state` struct\n- Registered 6 goal event reducers in state-events.rkt (started, turn-started, evaluated, check-completed, achieved, failed)\n- Goal badge in status bar: `◎ goal 3/8 · active`\n- 9 tests for event reducers + display info\n\nCloses #6121.