### PR TITLE
feat(v0.71.4 W1): badge rendering + /goal status (#6122)

### DIFF
--- a/tests/test-goal-tui.rkt
+++ b/tests/test-goal-tui.rkt
@@ -6,7 +6,12 @@
          racket/string
          "../tui/state-types.rkt"
          "../tui/state-events.rkt"
-         "../util/protocol-types.rkt")
+         "../util/protocol-types.rkt"
+         "../tui/render/status-line.rkt"
+         (only-in "../tui/render/message-layout.rkt"
+                  styled-segment-text
+                  styled-line-segments
+                  styled-line?))
 
 ;; ============================================================
 ;; goal-display-info struct
@@ -33,10 +38,12 @@
 
 (let ()
   (define st (initial-ui-state))
-  (define evt (make-event "goal.started" 0 "s1" "t1"
-                     (hasheq 'goal-text "make all tests pass"
-                             'max-turns 8
-                             'checks '())))
+  (define evt
+    (make-event "goal.started"
+                0
+                "s1"
+                "t1"
+                (hasheq 'goal-text "make all tests pass" 'max-turns 8 'checks '())))
   (define st2 (apply-event-to-state st evt))
   (define goal (ui-state-active-goal st2))
   (check-not-false goal "active-goal set after goal.started")
@@ -52,12 +59,11 @@
 (let ()
   (define st (initial-ui-state))
   ;; First start a goal
-  (define evt1 (make-event "goal.started" 0 "s1" "t1"
-                      (hasheq 'goal-text "goal" 'max-turns 8 'checks '())))
+  (define evt1
+    (make-event "goal.started" 0 "s1" "t1" (hasheq 'goal-text "goal" 'max-turns 8 'checks '())))
   (define st1 (apply-event-to-state st evt1))
   ;; Then turn started
-  (define evt2 (make-event "goal.turn.started" 0 "s1" "t2"
-                      (hasheq 'turn-number 1 'goal-text "goal")))
+  (define evt2 (make-event "goal.turn.started" 0 "s1" "t2" (hasheq 'turn-number 1 'goal-text "goal")))
   (define st2 (apply-event-to-state st1 evt2))
   (check-equal? (goal-display-info-turns-used (ui-state-active-goal st2)) 1))
 
@@ -67,11 +73,15 @@
 
 (let ()
   (define st (initial-ui-state))
-  (define evt1 (make-event "goal.started" 0 "s1" "t1"
-                      (hasheq 'goal-text "goal" 'max-turns 8 'checks '())))
+  (define evt1
+    (make-event "goal.started" 0 "s1" "t1" (hasheq 'goal-text "goal" 'max-turns 8 'checks '())))
   (define st1 (apply-event-to-state st evt1))
-  (define evt2 (make-event "goal.achieved" 0 "s1" "t2"
-                      (hasheq 'goal-text "goal" 'turns-used 5 'total-token-cost 0)))
+  (define evt2
+    (make-event "goal.achieved"
+                0
+                "s1"
+                "t2"
+                (hasheq 'goal-text "goal" 'turns-used 5 'total-token-cost 0)))
   (define st2 (apply-event-to-state st1 evt2))
   (check-equal? (goal-display-info-status (ui-state-active-goal st2)) 'achieved)
   (check-equal? (goal-display-info-turns-used (ui-state-active-goal st2)) 5))
@@ -82,11 +92,15 @@
 
 (let ()
   (define st (initial-ui-state))
-  (define evt1 (make-event "goal.started" 0 "s1" "t1"
-                      (hasheq 'goal-text "goal" 'max-turns 8 'checks '())))
+  (define evt1
+    (make-event "goal.started" 0 "s1" "t1" (hasheq 'goal-text "goal" 'max-turns 8 'checks '())))
   (define st1 (apply-event-to-state st evt1))
-  (define evt2 (make-event "goal.failed" 0 "s1" "t2"
-                      (hasheq 'goal-text "goal" 'reason "max turns" 'turns-used 8)))
+  (define evt2
+    (make-event "goal.failed"
+                0
+                "s1"
+                "t2"
+                (hasheq 'goal-text "goal" 'reason "max turns" 'turns-used 8)))
   (define st2 (apply-event-to-state st1 evt2))
   (check-equal? (goal-display-info-status (ui-state-active-goal st2)) 'failed))
 
@@ -96,12 +110,15 @@
 
 (let ()
   (define st (initial-ui-state))
-  (define evt1 (make-event "goal.started" 0 "s1" "t1"
-                      (hasheq 'goal-text "goal" 'max-turns 8 'checks '())))
+  (define evt1
+    (make-event "goal.started" 0 "s1" "t1" (hasheq 'goal-text "goal" 'max-turns 8 'checks '())))
   (define st1 (apply-event-to-state st evt1))
-  (define evt2 (make-event "goal.check.completed" 0 "s1" "t2"
-                      (hasheq 'label "test" 'exit-code 0 'timed-out? #f
-                              'stdout "" 'stderr "")))
+  (define evt2
+    (make-event "goal.check.completed"
+                0
+                "s1"
+                "t2"
+                (hasheq 'label "test" 'exit-code 0 'timed-out? #f 'stdout "" 'stderr "")))
   (define st2 (apply-event-to-state st1 evt2))
   ;; State should be unchanged (same object)
   (check-eq? st2 st1))
@@ -112,12 +129,15 @@
 
 (let ()
   (define st (initial-ui-state))
-  (define evt1 (make-event "goal.started" 0 "s1" "t1"
-                      (hasheq 'goal-text "goal" 'max-turns 8 'checks '())))
+  (define evt1
+    (make-event "goal.started" 0 "s1" "t1" (hasheq 'goal-text "goal" 'max-turns 8 'checks '())))
   (define st1 (apply-event-to-state st evt1))
-  (define evt2 (make-event "goal.evaluated" 0 "s1" "t2"
-                      (hasheq 'achieved? #f 'reason "not yet"
-                              'turn-number 1 'token-cost 10)))
+  (define evt2
+    (make-event "goal.evaluated"
+                0
+                "s1"
+                "t2"
+                (hasheq 'achieved? #f 'reason "not yet" 'turn-number 1 'token-cost 10)))
   (define st2 (apply-event-to-state st1 evt2))
   (check-equal? (goal-display-info-status (ui-state-active-goal st2)) 'active))
 
@@ -128,9 +148,27 @@
 (let ()
   (define long-text (make-string 60 #\x))
   (define st (initial-ui-state))
-  (define evt (make-event "goal.started" 0 "s1" "t1"
-                     (hasheq 'goal-text long-text 'max-turns 8 'checks '())))
+  (define evt
+    (make-event "goal.started" 0 "s1" "t1" (hasheq 'goal-text long-text 'max-turns 8 'checks '())))
   (define st2 (apply-event-to-state st evt))
   (check-equal? (string-length (goal-display-info-goal-text (ui-state-active-goal st2))) 40))
 
 (displayln "All goal-TUI tests passed.")
+
+;; ============================================================
+;; Status bar goal badge rendering
+;; ============================================================
+
+(let ()
+  ;; No goal — no badge
+  (define st-no-goal (initial-ui-state))
+  (define line-no-goal (render-status-bar st-no-goal 80))
+  (define seg-text (styled-segment-text (car (styled-line-segments line-no-goal))))
+  (check-false (string-contains? seg-text "goal") "no goal badge when inactive")
+  ;; Active goal — badge present
+  (define st-goal
+    (struct-copy ui-state st-no-goal [active-goal (goal-display-info "tests pass" 3 8 'active)]))
+  (define line-goal (render-status-bar st-goal 80))
+  (define seg-text-goal (styled-segment-text (car (styled-line-segments line-goal))))
+  (check-true (string-contains? seg-text-goal "goal") "goal badge present when active")
+  (check-true (string-contains? seg-text-goal "3/8") "shows turn count"))

--- a/tui/commands.rkt
+++ b/tui/commands.rkt
@@ -309,13 +309,21 @@
   (cond
     ;; /goal clear — cancel active goal
     [(string=? arg-text "clear")
+     (define cleared-state (struct-copy ui-state state [active-goal #f]))
      (define entry (make-system-entry "[goal] Active goal cancelled."))
-     (set-box! (cmd-ctx-state-box cctx) (add-transcript-entry state entry))
+     (set-box! (cmd-ctx-state-box cctx) (add-transcript-entry cleared-state entry))
      'continue]
     ;; /goal status or /goal (no args) — show status
     [(or (string=? arg-text "") (string=? arg-text "status"))
+     (define goal-info (ui-state-active-goal state))
      (define entry
-       (make-system-entry "[goal] No active goal. Use /goal \"<description>\" to set one."))
+       (if goal-info
+           (make-system-entry (format "[goal] Active: ~a\nStatus: ~a | Turns: ~a/~a"
+                                      (goal-display-info-goal-text goal-info)
+                                      (goal-display-info-status goal-info)
+                                      (goal-display-info-turns-used goal-info)
+                                      (goal-display-info-max-turns goal-info)))
+           (make-system-entry "[goal] No active goal. Use /goal \"<description>\" to set one.")))
      (set-box! (cmd-ctx-state-box cctx) (add-transcript-entry state entry))
      'continue]
     ;; /goal "<description>" [--check 'cmd'] — set a goal with optional checks


### PR DESCRIPTION
W1: status bar goal badge rendering + /goal status/clear.\n\n- Status bar shows goal badge when active-goal is set\n- /goal status now shows active goal info (text, status, turns)\n- /goal clear clears active-goal from ui-state\n- 2 new rendering tests (badge present/absent)\n\nCloses #6122.