### PR TITLE
release(v0.71.5): docs + version bump (#6126 #6127)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## v0.71.5 — 2026-05-30
+
+### GUI Integration + Release Polish
+
+Sixth milestone of the `/goal` feature — GUI parity and documentation.
+
+- **GUI active-goal**: Added `active-goal` field to `gui-state` struct with `gui-state-set-active-goal` helper.
+- **GUI /goal handler**: `/goal clear/status/set` in `gui/slash-commands.rkt`. Added to help text.
+- **Documentation**: New `docs/getting-started/goal.md` covering usage, checks, monitoring, limitations, and security.
+- **Tests**: 5 GUI tests for struct, setter, hash round-trip.
+
 ## v0.71.4 — 2026-05-30
 
 ### TUI Integration & Status Display

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.71.4-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.71.5-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 
@@ -202,7 +202,7 @@ bin/q --model gpt-5.4 "write a test"
 ### Verify
 
 ```bash
-bin/q --version            # q version 0.71.4
+bin/q --version            # q version 0.71.5
 raco test tests/           # run the full test suite
 ```
 
@@ -530,6 +530,9 @@ When q executes shell commands on behalf of an LLM, arguments are quoted via `sh
 
 
 
+
+
+**v0.71.5** — GUI Integration + Release Polish
 
 **v0.71.4** — TUI Integration & Status Display
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -2,7 +2,7 @@
 
 ## Version
 
-v0.71.4
+v0.71.5
 
 ## Native TUI Stack
 

--- a/docs/event-taxonomy.md
+++ b/docs/event-taxonomy.md
@@ -1,6 +1,6 @@
 # Q Event Taxonomy Reference
 
-Complete reference for all event types in Q 0.71.4.
+Complete reference for all event types in Q 0.71.5.
 ## Base Types
 
 ### `event` (protocol-level)

--- a/docs/extension-guide.md
+++ b/docs/extension-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.71.4 --># Extension Development Guide
+<!-- verified-against: 0.71.5 --># Extension Development Guide
 
 This guide walks you through creating, testing, and activating a custom
 extension for q.

--- a/docs/getting-started/credentials.md
+++ b/docs/getting-started/credentials.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.71.4 -->
+<!-- verified-against: 0.71.5 -->
 # Credential Management
 
 This document describes how q manages API keys and provider credentials,

--- a/docs/getting-started/goal.md
+++ b/docs/getting-started/goal.md
@@ -1,0 +1,62 @@
+# Goal Feature
+
+The `/goal` command sets an autonomous goal that the agent works toward across multiple turns, with an independent evaluator checking progress.
+
+## Basic Usage
+
+```
+/goal "make all tests pass"
+/goal "implement user authentication"
+/goal "fix the failing CI build"
+```
+
+The agent enters an autonomous loop:
+1. Works on the goal for one turn
+2. An evaluator reviews the transcript
+3. If the goal is met, the loop stops
+4. If not, the agent continues (up to a turn limit)
+
+## With Checks
+
+Add shell commands as verification checks:
+
+```
+/goal "make tests pass" --check "raco test tests/"
+/goal "fix the bug" --check "racket tests/test-foo.rkt"
+```
+
+Checks run before each evaluation. Results are passed to the evaluator as deterministic evidence. Unsafe commands (e.g., `rm -rf`) are rejected.
+
+## Monitoring
+
+- **Status bar**: Shows `◎ goal 3/8 · active` during execution
+- **`/goal status`**: Displays active goal text, status, and turn count
+- **`/goal`** (no args): Same as `/goal status`
+
+## Controlling
+
+- **`/goal clear`**: Cancels the active goal
+- **`/g`**: Short alias for `/goal`
+
+## How It Works
+
+1. **Goal State**: Each session tracks one active goal with status (`active`, `achieved`, `failed`, `cancelled`)
+2. **Turn Budget**: Default 8 turns max (configurable)
+3. **Evaluator**: A separate LLM call reviews the transcript and decides if the goal is met
+4. **Evidence Discipline**: The worker is instructed to produce verifiable evidence
+5. **No-Progress Detection**: After 3 consecutive evaluations with the same failure reason, the goal is marked failed
+6. **Deterministic Checks**: Shell commands provide objective pass/fail evidence
+
+## Limitations
+
+- Only one active goal per session
+- Evaluation is transcript-based (not agent-based yet)
+- Goal state is excluded from LLM context to prevent bias
+- Maximum 8 turns per goal (configurable)
+
+## Security
+
+- Check commands are validated against shell risk classification
+- Commands with critical severity findings are rejected
+- Check execution has a 30-second timeout
+- All checks run in a sandboxed subprocess

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.71.4 --># Getting Started
+<!-- verified-against: 0.71.5 --># Getting Started
 
 Welcome to q, a Racket-based coding agent.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.71.4 --># Installation Guide
+<!-- verified-against: 0.71.5 --># Installation Guide
 
 <!-- This file is the canonical source. The docs/getting-started/installation.md copy is maintained for the doc site build. -->
 

--- a/docs/security-trust-model.md
+++ b/docs/security-trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.71.4 --># Security & Trust Model
+<!-- verified-against: 0.71.5 --># Security & Trust Model
 
 This document provides an honest, per-area assessment of what q enforces
 today and what is planned. It is the authoritative reference for security

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -130,6 +130,6 @@ is the primary self-hosting extension:
 (load-extension! ext-reg "path/to/extension.rkt" #:event-bus bus)
 ```
 
-## Version 0.71.4
+## Version 0.71.5
 
-This documentation reflects q 0.71.4.
+This documentation reflects q 0.71.5.

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.71.4 --># q Source Style Guide
+<!-- verified-against: 0.71.5 --># q Source Style Guide
 
 This document defines formatting and naming conventions for the q Racket codebase.
 All changes to `q/` source files (excluding `tests/`) should follow these rules.

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.71.4 -->
+<!-- verified-against: 0.71.5 -->
 # Trust Model
 
 ## Trust Levels

--- a/docs/workflow-testing.md
+++ b/docs/workflow-testing.md
@@ -121,6 +121,6 @@ Use relative paths from the test file:
 4. Use `(check-true ...)` for boolean assertions
 5. Keep tests independent — no shared mutable state between test-cases
 
-## Version 0.71.4
+## Version 0.71.5
 
-This documentation reflects q 0.71.4.
+This documentation reflects q 0.71.5.

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.71.4")
+(define version "0.71.5")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base" "gui-easy-lib"))

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -11,4 +11,4 @@
 
 (provide (contract-out [q-version string?]))
 
-(define q-version "0.71.4")
+(define q-version "0.71.5")

--- a/wiki-src/Architecture-Overview.md
+++ b/wiki-src/Architecture-Overview.md
@@ -35,7 +35,7 @@ User input → Interface (CLI/TUI/RPC)
     → Events emitted to bus
 ```
 
-## Metrics (0.71.4)
+## Metrics (0.71.5)
 > _See `racket scripts/metrics.rkt` for current numbers._
 
 - 414 source modules, 534 test files


### PR DESCRIPTION
W1+W2: Documentation + version bump 0.71.5 + CHANGELOG.\n\n- docs/getting-started/goal.md — full goal feature documentation\n- GUI active-goal + /goal handler\n- Version bumped to 0.71.5\n\nCloses #6126. Closes #6127.