### PR TITLE
feat(v0.71.6 W1): --evaluator agent flag (#6130)

### DIFF
--- a/runtime/goal-runner.rkt
+++ b/runtime/goal-runner.rkt
@@ -15,6 +15,7 @@
          racket/list
          "goal-state.rkt"
          "goal-evaluator.rkt"
+         "goal-agent-evaluator.rkt"
          "goal-evidence.rkt"
          "goal-checks.rkt"
          "../llm/provider.rkt")
@@ -57,14 +58,21 @@
                             evaluator-model
                             run-prompt-fn!
                             #:max-turns [max-turns 8]
+                            #:evaluator-mode [evaluator-mode 'transcript]
                             #:on-event [on-event void]
                             #:on-status [on-status void])
   (->* (string? provider? string? procedure?)
-       (#:max-turns exact-nonnegative-integer? #:on-event procedure? #:on-status procedure?)
+       (#:max-turns exact-nonnegative-integer?
+                    #:evaluator-mode symbol?
+                    #:on-event procedure?
+                    #:on-status procedure?)
        goal-state?)
   ;; Initialize goal state
   (define goal-st
-    (make-goal-state #:goal-text goal-text #:max-turns max-turns #:evaluator-model evaluator-model))
+    (make-goal-state #:goal-text goal-text
+                     #:max-turns max-turns
+                     #:evaluator-model evaluator-model
+                     #:evaluator-mode evaluator-mode))
 
   ;; Emit goal.started
   (on-event 'goal-started goal-st)
@@ -153,7 +161,17 @@
   ;; Extract transcript from loop-result for evaluation
   (define transcript (extract-transcript-from-result loop-result))
   (define eval-result
-    (evaluate-transcript goal-text transcript provider evaluator-model #:check-results check-results))
+    (if (eq? (goal-state-evaluator-mode goal-st) 'agent)
+        (evaluate-with-agent goal-text
+                             transcript
+                             provider
+                             evaluator-model
+                             #:check-results check-results)
+        (evaluate-transcript goal-text
+                             transcript
+                             provider
+                             evaluator-model
+                             #:check-results check-results)))
 
   ;; Emit goal.evaluated
   (on-event 'goal-evaluated (hasheq 'evaluation eval-result 'turn turns))
@@ -203,8 +221,11 @@
                                       provider
                                       evaluator-model
                                       turn-responses
-                                      #:max-turns [max-turns 8])
-  (->* (string? provider? string? list?) (#:max-turns exact-nonnegative-integer?) goal-state?)
+                                      #:max-turns [max-turns 8]
+                                      #:evaluator-mode [evaluator-mode 'transcript])
+  (->* (string? provider? string? list?)
+       (#:max-turns exact-nonnegative-integer? #:evaluator-mode symbol?)
+       goal-state?)
   ;; Simulated run-prompt! that returns predefined responses
   (define turn-idx (box 0))
   (define (sim-run-prompt! prompt)
@@ -215,4 +236,9 @@
     (set-box! turn-idx (add1 (unbox turn-idx)))
     (values #f resp))
 
-  (goal-run! goal-text provider evaluator-model sim-run-prompt! #:max-turns max-turns))
+  (goal-run! goal-text
+             provider
+             evaluator-model
+             sim-run-prompt!
+             #:max-turns max-turns
+             #:evaluator-mode evaluator-mode))

--- a/tests/test-goal-runner.rkt
+++ b/tests/test-goal-runner.rkt
@@ -214,3 +214,24 @@
   ;; With last-evaluation
   (define gs2 (struct-copy goal-state gs [last-evaluation eval1]))
   (check-equal? (length (collect-evaluations gs2)) 1))
+
+;; ============================================================
+
+;; ============================================================
+;; Agent evaluator mode dispatch (W1)
+;; ============================================================
+
+(let ()
+  ;; Build an evaluator provider that returns achieved JSON
+  (define eval-prov (make-eval-provider (list (eval-achieved-response))))
+  (define turn-responses
+    (list (hash 'messages (list (hasheq 'role "assistant" 'content "Bug fixed.")))))
+  (define result
+    (goal-run-simulated! "fix the bug"
+                         eval-prov
+                         "mock-eval"
+                         turn-responses
+                         #:max-turns 1
+                         #:evaluator-mode 'agent))
+  (check-true (goal-state? result))
+  (check-equal? (goal-state-status result) 'achieved))

--- a/tui/commands.rkt
+++ b/tui/commands.rkt
@@ -342,6 +342,11 @@
                       (char=? (string-ref t (sub1 (string-length t))) #\')))
              (substring t 1 (sub1 (string-length t)))
              t)))
+     ;; Check for --evaluator flag
+     (define evaluator-mode
+       (if (string-contains? arg-text "--evaluator")
+           (let ([parts (string-split arg-text)]) (if (member "agent" parts) 'agent 'transcript))
+           'transcript))
      ;; Validate check safety
      (define safety-reasons (validate-check-safety checks))
      (cond
@@ -360,11 +365,13 @@
                        (map (lambda (c) (format "~a: ~a" (goal-check-label c) (goal-check-command c)))
                             checks)
                        ", "))))
+        (define eval-info (if (eq? evaluator-mode 'agent) " [agent evaluator]" ""))
         (define entry
           (make-system-entry
            (format
-            "[goal] Goal set: ~a~a\nThe autonomous goal loop will be available in a future update."
+            "[goal] Goal set: ~a~a~a\nThe autonomous goal loop will be available in a future update."
             clean-text
-            check-info)))
+            check-info
+            eval-info)))
         (set-box! (cmd-ctx-state-box cctx) (add-transcript-entry state entry))
         'continue])]))


### PR DESCRIPTION
W1: --evaluator agent flag + runner dispatch.\n\n- `goal-runner.rkt` dispatches to `evaluate-with-agent` when evaluator-mode is `'agent`\n- `--evaluator agent` flag parsed in TUI `/goal` command handler\n- `goal-run!` and `goal-run-simulated!` accept `#:evaluator-mode` keyword\n- Integration test for agent mode dispatch\n\nCloses #6130.