### PR TITLE
fix(v0.71.7 W1): W3 shell injection, I1 string-truncate dedup (#6156)

### DIFF
--- a/runtime/goal-checks.rkt
+++ b/runtime/goal-checks.rkt
@@ -108,11 +108,14 @@
     (define tokens (tokenize-shell-command cmd))
     (define findings (classify-shell-risks tokens))
     (define summary (shell-risk-summary findings))
-    (define critical (hash-ref summary 'critical? #f))
-    (if critical
+    (define max-sev (hash-ref summary 'max-severity 'info))
+    (define severity-order '(info low medium high critical))
+    (define too-risky? (> (index-of severity-order max-sev) (index-of severity-order 'medium)))
+    (if too-risky?
         (append reasons
-                (list (format "Check '~a' has critical severity risks: ~a"
+                (list (format "Check '~a' has ~a severity risks: ~a"
                               (goal-check-label c)
+                              max-sev
                               (string-join (map shell-risk-finding-message findings) "; "))))
         reasons)))
 
@@ -153,10 +156,7 @@
 ;; Helpers
 ;; ============================================================
 
-(define (string-truncate s max-len)
-  (if (> (string-length s) max-len)
-      (string-append (substring s 0 (sub1 max-len)) "…")
-      s))
+;; string-truncate is provided by goal-state.rkt (consolidated in v0.71.7)
 
 ;; Summarize check results: all passed? summary string.
 (define/contract (checks-summary results)

--- a/tests/test-goal-checks.rkt
+++ b/tests/test-goal-checks.rkt
@@ -8,6 +8,7 @@
                   goal-check?
                   goal-check-command
                   goal-check-label
+                  make-goal-check
                   check-result?
                   check-result-exit-code
                   check-result-stdout
@@ -128,3 +129,19 @@
   (check-true (string-contains? summary "FAIL")))
 
 (displayln "All goal-checks tests passed.")
+
+;; ============================================================
+;; W1: Shell safety — command substitution now high severity (v0.71.7)
+;; ============================================================
+
+;; Command substitution $(...) is rejected by validate-check-safety
+(let ()
+  (define checks (list (make-goal-check #:command "echo $(whoami)" #:label "sub")))
+  (define reasons (validate-check-safety checks))
+  (check-true (pair? reasons) "command substitution rejected"))
+
+;; Pipe commands are rejected
+(let ()
+  (define checks (list (make-goal-check #:command "cat /etc/passwd | grep root" #:label "pipe")))
+  (define reasons (validate-check-safety checks))
+  (check-true (pair? reasons) "pipe rejected"))

--- a/tools/shell-risk.rkt
+++ b/tools/shell-risk.rkt
@@ -257,7 +257,7 @@
     (define pos (shell-token-start tok))
 
     (when (eq? type 'substitution)
-      (add! 'command-substitution 'medium (format "Command substitution: ~a" val) pos))
+      (add! 'command-substitution 'high (format "Command substitution: ~a" val) pos))
 
     (when (and (eq? type 'separator) (string=? (string-downcase val) "|"))
       ;; Skip whitespace to find next word


### PR DESCRIPTION
W1: Shell safety + dedup for v0.71.7.\n\n- **W3:** Raised command-substitution severity to 'high', validate-check-safety now rejects high+\n- **I1:** Consolidated string-truncate into goal-state.rkt, removed duplicate from goal-checks.rkt\n\n2 new tests. All goal + shell-risk tests pass.\n\nCloses #6156.