### PR TITLE
fix(v0.72.0 W0): C2 raw setter breach + W4 now-epoch-ms (#6169)

### DIFF
--- a/runtime/session-compaction.rkt
+++ b/runtime/session-compaction.rkt
@@ -17,6 +17,7 @@
          "../agent/event-structs/iteration-events.rkt"
          "session-types.rkt")
 (require "session-mutation.rkt")
+(require (only-in "../util/time.rkt" now-epoch-ms))
 
 (provide (contract-out [maybe-compact-context
                         (-> agent-session? (listof any/c) integer? (listof any/c))])
@@ -50,7 +51,7 @@
     [else
      ;; #770: Stale usage guard — skip if compaction just completed
      (define last-compact (agent-session-last-compaction-time sess))
-     (define now-ms (current-inexact-milliseconds))
+     (define now-ms (now-epoch-ms))
      (cond
        [(and last-compact (< (- now-ms last-compact) 2000))
         context-with-system] ; too soon after last compaction
@@ -60,7 +61,7 @@
         (emit-typed-event! bus
                            (make-compaction-event #:session-id sid
                                                   #:turn-id #f
-                                                  #:timestamp (current-inexact-milliseconds)
+                                                  #:timestamp (now-epoch-ms)
                                                   #:reason "budget-exceeded"
                                                   #:tokens-before token-count
                                                   #:tokens-after token-count))
@@ -74,12 +75,11 @@
                                                         sid))
                       (lambda ()
                         (guarded-set-compacting! sess #f)
-                        (set-agent-session-last-compaction-time! sess (current-inexact-milliseconds))
+                        (guarded-set-last-compaction-time! sess (now-epoch-ms))
                         (emit-typed-event! bus
                                            (make-compaction-event #:session-id sid
                                                                   #:turn-id #f
-                                                                  #:timestamp
-                                                                  (current-inexact-milliseconds)
+                                                                  #:timestamp (now-epoch-ms)
                                                                   #:reason "compaction-complete"
                                                                   #:tokens-before token-count
                                                                   #:tokens-after token-count))))])]))

--- a/runtime/session-mutation.rkt
+++ b/runtime/session-mutation.rkt
@@ -7,6 +7,7 @@
 
 (require racket/contract
          "session-types.rkt"
+         (submod "session-types.rkt" internal)
          (only-in "../util/errors.rkt" raise-session-error))
 
 (provide (contract-out [guarded-set-prompt-running! (-> agent-session? boolean? void?)]

--- a/runtime/session-types.rkt
+++ b/runtime/session-types.rkt
@@ -58,21 +58,6 @@
          agent-session-shutdown-requested?
          agent-session-force-shutdown?
          agent-session-prompt-running?
-         ;; DEPRECATED (v0.54.2): Use guarded setters from session-mutation.rkt
-         ;; These will be removed in a future version.
-         set-agent-session-model-name!
-         set-agent-session-index!
-         set-agent-session-config!
-         set-agent-session-active?!
-         set-agent-session-start-time!
-         set-agent-session-compacting?!
-         set-agent-session-last-compaction-time!
-         set-agent-session-persisted?!
-         set-agent-session-pending-entries!
-         set-agent-session-thinking-level!
-         set-agent-session-shutdown-requested?!
-         set-agent-session-force-shutdown?!
-         set-agent-session-prompt-running?!
          session-log-path
          session-index-path
          (contract-out [session-log-path-for (-> agent-session? path?)]
@@ -143,3 +128,20 @@
 
 (define (session-extension-registry sess)
   (agent-session-extension-registry sess))
+
+;; Internal sub-module: provides raw setters for session-mutation.rkt only.
+;; These MUST NOT be used outside session-mutation.rkt.
+(module+ internal
+  (provide set-agent-session-model-name!
+           set-agent-session-index!
+           set-agent-session-config!
+           set-agent-session-active?!
+           set-agent-session-start-time!
+           set-agent-session-compacting?!
+           set-agent-session-last-compaction-time!
+           set-agent-session-persisted?!
+           set-agent-session-pending-entries!
+           set-agent-session-thinking-level!
+           set-agent-session-shutdown-requested?!
+           set-agent-session-force-shutdown?!
+           set-agent-session-prompt-running?!))

--- a/util/time.rkt
+++ b/util/time.rkt
@@ -1,0 +1,12 @@
+#lang racket/base
+
+;; util/time.rkt — Time utility functions
+;; Extracts the repeated (inexact->exact (round (current-inexact-milliseconds))) pattern.
+
+(require racket/contract)
+
+(provide (contract-out [now-epoch-ms (-> exact-nonnegative-integer?)]))
+
+;; Returns current time as epoch milliseconds (exact integer)
+(define (now-epoch-ms)
+  (inexact->exact (round (current-inexact-milliseconds))))


### PR DESCRIPTION
W0: C2 raw setter breach + W4 epoch-ms helper.\n\n- Created `util/time.rkt` with `now-epoch-ms` (exact integer timestamp)\n- Removed 13 deprecated raw setters from `session-types.rkt` public provide\n- Added `module+ internal` for `session-mutation.rkt` exclusive access\n- Fixed `session-compaction.rkt` to use guarded setter + `now-epoch-ms`\n\nAll compile gates pass. Closes #6169.