### PR TITLE
fix(v0.72.0 W1): W16 effect-base + I1 + I3 (#6170)

### DIFF
--- a/agent/effect-types.rkt
+++ b/agent/effect-types.rkt
@@ -10,33 +10,41 @@
 (require racket/contract
          (only-in "../util/fsm.rkt" fsm-state? fsm-event?))
 
-(provide (contract-out (struct effect:emit-event ([type symbol?] [payload any/c])))
+(provide (contract-out (struct effect-base ()))
+         (contract-out (struct effect:emit-event ([type symbol?] [payload any/c])))
          (contract-out (struct effect:update-fsm ([from-state fsm-state?] [event fsm-event?])))
          (contract-out (struct effect:dispatch-hook ([hook-point symbol?] [payload any/c])))
          (contract-out (struct effect:none ()))
          effect?)
 
 ;; ---------------------------------------------------------------------------
+;; Effect base type
+;; ---------------------------------------------------------------------------
+
+;; Base supertype for all effect descriptors.
+;; New effect types should inherit from this.
+(struct effect-base () #:transparent)
+
+;; ---------------------------------------------------------------------------
 ;; Effect descriptors
 ;; ---------------------------------------------------------------------------
 
 ;; Emit a typed event to the event bus
-(struct effect:emit-event (type payload) #:transparent)
+(struct effect:emit-event effect-base (type payload) #:transparent)
 
 ;; Update the turn FSM state machine
-(struct effect:update-fsm (from-state event) #:transparent)
+(struct effect:update-fsm effect-base (from-state event) #:transparent)
 
 ;; Dispatch a hook at the given hook point
-(struct effect:dispatch-hook (hook-point payload) #:transparent)
+(struct effect:dispatch-hook effect-base (hook-point payload) #:transparent)
 
 ;; No-op effect (identity)
-(struct effect:none () #:transparent)
+(struct effect:none effect-base () #:transparent)
 
 ;; ---------------------------------------------------------------------------
 ;; Predicates
 ;; ---------------------------------------------------------------------------
 
 ;; Predicate: is this an effect descriptor?
-;; v0.46.10 (M-1): Proper predicate instead of or/c alias.
-(define (effect? v)
-  (or (effect:emit-event? v) (effect:update-fsm? v) (effect:dispatch-hook? v) (effect:none? v)))
+;; Uses effect-base? supertype predicate (W16).
+(define effect? effect-base?)

--- a/runtime/goal-runner.rkt
+++ b/runtime/goal-runner.rkt
@@ -13,21 +13,20 @@
          racket/format
          racket/string
          racket/list
-         "goal-state.rkt"
+         (except-in "goal-state.rkt" NO-PROGRESS-THRESHOLD)
          (only-in "goal-state.rkt"
                   NO-PROGRESS-THRESHOLD
-                  goal-state-evaluations
-                  goal-state-checks
-                  goal-state-last-evaluation
-                  goal-state-status
-                  goal-state-goal-text
-                  goal-state-turns-used
-                  goal-state-max-turns
-                  goal-state-evaluator-mode
-                  goal-state?
-                  goal-state-id
-                  goal-state-updated-at
-                  make-goal-state)
+                  evaluation-result?
+                  evaluation-result-achieved?
+                  evaluation-result-reason
+                  evaluation-result-token-cost
+                  check-result?
+                  check-result-label
+                  check-result-exit-code
+                  check-result-timed-out?
+                  check-result-stdout
+                  check-result-stderr
+                  goal-check?)
          "goal-evaluator.rkt"
          "goal-agent-evaluator.rkt"
          "goal-evidence.rkt"

--- a/util/errors.rkt
+++ b/util/errors.rkt
@@ -81,7 +81,6 @@
           [raise-policy-error (->* (string? string? string?) (hash?) exn:fail?)]
           [raise-credential-error (->* (string? string?) (string? hash?) exn:fail?)])
          ;; Quality macros (Q06/Q07)
-         with-cleanup
          with-logged-catch)
 
 ;; Base error type for all q domain errors.
@@ -182,14 +181,6 @@
 ;; ============================================================
 ;; Quality macros (Q06/Q07)
 ;; ============================================================
-
-;; with-cleanup: Ensure cleanup runs regardless of success/failure.
-;; (with-cleanup cleanup-expr body-expr ...)
-(define-syntax-rule (with-cleanup cleanup body ...)
-  (dynamic-wind (lambda () (void))
-                (lambda ()
-                  body ...)
-                (lambda () cleanup)))
 
 ;; with-logged-catch: Like with-handlers but logs the exception before
 ;; returning the fallback value. Prevents silent failures.


### PR DESCRIPTION
W1: W16 effect-base + I1 dead code + I3 duplicate import.\n\n- Added `effect-base` supertype to effect-types.rkt, `effect?` now uses `effect-base?`\n- Deleted dead `with-cleanup` macro from `errors.rkt`\n- Replaced duplicate bare+only-in import with `except-in` in `goal-runner.rkt`\n\nCompiles clean. All goal + effect tests pass.\n\nCloses #6170.