### PR TITLE
fix(v0.72.1 W0): C1 loop-phases + W13 turn-reducer contracts (#6174)

### DIFF
--- a/agent/loop-phases.rkt
+++ b/agent/loop-phases.rkt
@@ -45,20 +45,51 @@
          "../util/loop-result.rkt")
 
 (provide (contract-out [phase-emit-start
-                        (-> any/c any/c any/c any/c (values any/c (listof effect?)))])
-         (contract-out [phase-build-context
-                        (-> any/c any/c any/c any/c any/c (values any/c (listof effect?)))])
-         (contract-out [phase-build-request (-> any/c any/c any/c (values any/c (listof effect?)))])
+                        (-> string? string? loop-state? any/c (values any/c (listof effect?)))])
+         (contract-out
+          [phase-build-context
+           (-> event-bus? string? string? loop-state? any/c (values any/c (listof effect?)))])
+         (contract-out [phase-build-request
+                        (-> (listof any/c) (listof tool?) any/c (values any/c (listof effect?)))])
          (contract-out [phase-pre-hook
-                        (-> any/c any/c any/c any/c any/c any/c (values any/c (listof effect?)))])
-         (contract-out
-          [phase-msg-hook
-           (-> any/c any/c any/c any/c any/c any/c any/c (values any/c (listof effect?)))])
-         (contract-out
-          [phase-stream
-           (-> any/c any/c any/c any/c any/c any/c any/c any/c (values any/c (listof effect?)))])
+                        (-> procedure?
+                            provider?
+                            (listof any/c)
+                            any/c
+                            string?
+                            string?
+                            (values any/c (listof effect?)))])
+         (contract-out [phase-msg-hook
+                        (-> procedure?
+                            provider?
+                            any/c
+                            (listof any/c)
+                            string?
+                            string?
+                            loop-state?
+                            (values any/c (listof effect?)))])
+         (contract-out [phase-stream
+                        (-> provider?
+                            any/c
+                            event-bus?
+                            string?
+                            string?
+                            loop-state?
+                            (listof any/c)
+                            (listof tool?)
+                            (values any/c (listof effect?)))])
          (contract-out [run-streaming-phase
-                        (-> any/c any/c any/c any/c any/c any/c any/c any/c any/c any/c any/c)]))
+                        (-> provider?
+                            any/c
+                            event-bus?
+                            string?
+                            string?
+                            loop-state?
+                            (listof any/c)
+                            (listof tool?)
+                            procedure?
+                            any/c
+                            any/c)]))
 
 ;; ---------------------------------------------------------------------------
 ;; Phase 1: Emit turn-started event


### PR DESCRIPTION
W0: C1 loop-phases + W13 turn-reducer contracts.\n\n- Replaced 28 `any/c` with specific types in loop-phases.rkt (string?, event-bus?, provider?, loop-state?, procedure?, (listof tool?))\n- `any/c` remains only for genuinely polymorphic positions (context list, request hash, return values)\n- turn-reducer.rkt already has specific contracts where possible\n\nCompiles clean. All loop/phase/turn-reducer tests pass.\n\nCloses #6174.