### PR TITLE
release(v0.72.1): I14 contracts + version bump (#6175)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## v0.72.1 — 
+
+### Phase 2a: Core Contract Precision
+
+Contract tightening for core modules.
+
+| Finding | Severity | Fix |
+|---------|----------|-----|
+| C1: 28 `any/c` in loop-phases contracts | CRITICAL | Replaced with string?, event-bus?, provider?, loop-state?, procedure?, (listof tool?) |
+| W13: turn-reducer lacks contracts | WARNING | Reviewed — contracts already specific where possible |
+| I14: session-mutation uses `any/c` for typed fields | INFO | Tightened config→hash?, start-time→exact-nonnegative-integer?, last-compaction-time→(or/c exact-nonnegative-integer? #f) |
+
+**Files changed:** `loop-phases.rkt`, `session-mutation.rkt`
+
 ## v0.72.0 — 
 
 ### Phase 1: Zero-Cost Fixes

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.72.0-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.72.1-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 
@@ -202,7 +202,7 @@ bin/q --model gpt-5.4 "write a test"
 ### Verify
 
 ```bash
-bin/q --version            # q version 0.72.0
+bin/q --version            # q version 0.72.1
 raco test tests/           # run the full test suite
 ```
 
@@ -275,7 +275,7 @@ q/
 |--------|-------|
 | Test files | 720 |
 | Source modules | 518 |
-| Source lines | 79530 |
+| Source lines | 79561 |
 | Test lines | 118525 |
 | Test assertions | 18755 |
 | Tests passing | 5835+ | `racket scripts/run-tests.rkt` results |
@@ -535,6 +535,9 @@ When q executes shell commands on behalf of an LLM, arguments are quoted via `sh
 
 
 
+
+
+**v0.72.1** — Agent Evaluator + Series Audit
 
 **v0.72.0** — Agent Evaluator + Series Audit
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -2,7 +2,7 @@
 
 ## Version
 
-v0.72.0
+v0.72.1
 
 ## Native TUI Stack
 

--- a/docs/event-taxonomy.md
+++ b/docs/event-taxonomy.md
@@ -1,6 +1,6 @@
 # Q Event Taxonomy Reference
 
-Complete reference for all event types in Q 0.72.0.
+Complete reference for all event types in Q 0.72.1.
 ## Base Types
 
 ### `event` (protocol-level)

--- a/docs/extension-guide.md
+++ b/docs/extension-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.72.0 --># Extension Development Guide
+<!-- verified-against: 0.72.1 --># Extension Development Guide
 
 This guide walks you through creating, testing, and activating a custom
 extension for q.

--- a/docs/getting-started/credentials.md
+++ b/docs/getting-started/credentials.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.72.0 -->
+<!-- verified-against: 0.72.1 -->
 # Credential Management
 
 This document describes how q manages API keys and provider credentials,

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.72.0 --># Getting Started
+<!-- verified-against: 0.72.1 --># Getting Started
 
 Welcome to q, a Racket-based coding agent.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.72.0 --># Installation Guide
+<!-- verified-against: 0.72.1 --># Installation Guide
 
 <!-- This file is the canonical source. The docs/getting-started/installation.md copy is maintained for the doc site build. -->
 

--- a/docs/security-trust-model.md
+++ b/docs/security-trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.72.0 --># Security & Trust Model
+<!-- verified-against: 0.72.1 --># Security & Trust Model
 
 This document provides an honest, per-area assessment of what q enforces
 today and what is planned. It is the authoritative reference for security

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -130,6 +130,6 @@ is the primary self-hosting extension:
 (load-extension! ext-reg "path/to/extension.rkt" #:event-bus bus)
 ```
 
-## Version 0.72.0
+## Version 0.72.1
 
-This documentation reflects q 0.72.0.
+This documentation reflects q 0.72.1.

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.72.0 --># q Source Style Guide
+<!-- verified-against: 0.72.1 --># q Source Style Guide
 
 This document defines formatting and naming conventions for the q Racket codebase.
 All changes to `q/` source files (excluding `tests/`) should follow these rules.

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.72.0 -->
+<!-- verified-against: 0.72.1 -->
 # Trust Model
 
 ## Trust Levels

--- a/docs/workflow-testing.md
+++ b/docs/workflow-testing.md
@@ -121,6 +121,6 @@ Use relative paths from the test file:
 4. Use `(check-true ...)` for boolean assertions
 5. Keep tests independent — no shared mutable state between test-cases
 
-## Version 0.72.0
+## Version 0.72.1
 
-This documentation reflects q 0.72.0.
+This documentation reflects q 0.72.1.

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.72.0")
+(define version "0.72.1")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base" "gui-easy-lib"))

--- a/runtime/session-mutation.rkt
+++ b/runtime/session-mutation.rkt
@@ -16,13 +16,13 @@
                        [guarded-set-force-shutdown! (-> agent-session? boolean? void?)]
                        [guarded-set-active! (-> agent-session? boolean? void?)]
                        [guarded-set-model-name! (-> agent-session? (or/c string? #f) void?)]
-                       [guarded-set-config! (-> agent-session? any/c void?)]
+                       [guarded-set-config! (-> agent-session? hash? void?)]
                        [guarded-set-index! (-> agent-session? any/c void?)]
                        [guarded-set-persisted! (-> agent-session? boolean? void?)]
                        [guarded-set-pending-entries! (-> agent-session? list? void?)]
-                       [guarded-set-start-time! (-> agent-session? any/c void?)]
+                       [guarded-set-start-time! (-> agent-session? exact-nonnegative-integer? void?)]
                        [guarded-set-thinking-level! (-> agent-session? (or/c symbol? #f) void?)]
-                       [guarded-set-last-compaction-time! (-> agent-session? any/c void?)]
+                       [guarded-set-last-compaction-time! (-> agent-session? (or/c exact-nonnegative-integer? #f) void?)]
                        [valid-session-phase? (-> symbol? boolean?)]
                        [session-phase (-> agent-session? symbol?)]))
 

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -11,4 +11,4 @@
 
 (provide (contract-out [q-version string?]))
 
-(define q-version "0.72.0")
+(define q-version "0.72.1")

--- a/wiki-src/Architecture-Overview.md
+++ b/wiki-src/Architecture-Overview.md
@@ -35,7 +35,7 @@ User input → Interface (CLI/TUI/RPC)
     → Events emitted to bus
 ```
 
-## Metrics (0.72.0)
+## Metrics (0.72.1)
 > _See `racket scripts/metrics.rkt` for current numbers._
 
 - 414 source modules, 534 test files


### PR DESCRIPTION
W1: I14 session-mutation contracts + version bump.\n\n- Tightened session-mutation.rkt: config→hash?, start-time→exact-nonnegative-integer?, last-compaction-time→(or/c exact-nonnegative-integer? #f)\n- Version bump 0.72.0→0.72.1, CHANGELOG, README sync\n\nCloses #6175.