### PR TITLE
fix(v0.72.2 W0): W10 tool-registry + W9 settings boundary (#6179)

### DIFF
--- a/runtime/settings.rkt
+++ b/runtime/settings.rkt
@@ -33,8 +33,6 @@
 ;; Structs
 (provide q-settings
          q-settings?
-         q-settings-global
-         q-settings-project
          q-settings-merged
 
          ;; Loading — contracted
@@ -77,9 +75,7 @@
                        [credential-policy
                         (-> q-settings?
                             (or/c 'auto 'keychain-preferred 'keychain-required 'env-only))]
-                       [shell-risk-classifier
-                        (-> q-settings?
-                            (or/c 'regex 'structured 'both))])
+                       [shell-risk-classifier (-> q-settings? (or/c 'regex 'structured 'both))])
 
          ;; Sandbox settings (re-exported, not locally defined)
          sandbox-enabled?

--- a/tools/registry.rkt
+++ b/tools/registry.rkt
@@ -36,7 +36,8 @@
 ;; ============================================================
 
 ;; Import struct from util/ to break runtime→tools reverse dependency (H1).
-(require "../util/tool-registry-struct.rkt")
+(require "../util/tool-registry-struct.rkt"
+         (submod "../util/tool-registry-struct.rkt" internal))
 (provide tool-registry?)
 
 ;; Safe read-only accessor under lock

--- a/util/tool-registry-struct.rkt
+++ b/util/tool-registry-struct.rkt
@@ -6,12 +6,16 @@
 
 (require racket/contract)
 
-(provide (contract-out [tool-registry? (-> any/c boolean?)]
-                       [make-tool-registry-internal (-> any/c any/c any/c tool-registry?)]
-                       [tool-registry-tools-box (-> tool-registry? any/c)]
-                       [tool-registry-active-set-box (-> tool-registry? any/c)]
-                       [tool-registry-sem (-> tool-registry? any/c)])
+;; Public: predicate and struct type (for struct-copy)
+(provide (contract-out [tool-registry? (-> any/c boolean?)])
          tool-registry)
+
+;; Internal: only for tools/registry.rkt
+(module+ internal
+  (provide make-tool-registry-internal
+           tool-registry-tools-box
+           tool-registry-active-set-box
+           tool-registry-sem))
 
 ;; Thread-safe tool registry struct. Fields are internal; use accessor
 ;; functions from tools/registry.rkt for safe access.


### PR DESCRIPTION
W0: W10 tool-registry + W9 settings boundary.\n\n- Moved tool-registry internal accessors (tools-box, active-set-box, sem) to `module+ internal`\n- Registry imports from internal sub-module for exclusive access\n- Removed q-settings-global and q-settings-project from public provide\n\nCompiles clean.\n\nCloses #6179.