### PR TITLE
release(v0.72.2): W8 state-types + version bump (#6180)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## v0.72.2 — 
+
+### Phase 2b: Boundary Contract Precision
+
+Boundary tightening for tool-registry, settings, and state-types.
+
+| Finding | Severity | Fix |
+|---------|----------|-----|
+| W10: tool-registry internal fields publicly exported | WARNING | Moved to `module+ internal` |
+| W9: settings globals in public API | WARNING | Removed q-settings-global/project from provide |
+| W8: state-types uses `any/c` for styled-line/q-component | WARNING | Replaced with real predicates |
+| I6: tool-schema naming | INFO | Verified — no rename needed |
+
+**Files changed:** `tool-registry-struct.rkt`, `registry.rkt`, `settings.rkt`, `state-types.rkt`
+
 ## v0.72.1 — 
 
 ### Phase 2a: Core Contract Precision

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.72.1-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.72.2-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 
@@ -202,7 +202,7 @@ bin/q --model gpt-5.4 "write a test"
 ### Verify
 
 ```bash
-bin/q --version            # q version 0.72.1
+bin/q --version            # q version 0.72.2
 raco test tests/           # run the full test suite
 ```
 
@@ -275,7 +275,7 @@ q/
 |--------|-------|
 | Test files | 720 |
 | Source modules | 518 |
-| Source lines | 79561 |
+| Source lines | 79564 |
 | Test lines | 118525 |
 | Test assertions | 18755 |
 | Tests passing | 5835+ | `racket scripts/run-tests.rkt` results |
@@ -536,6 +536,9 @@ When q executes shell commands on behalf of an LLM, arguments are quoted via `sh
 
 
 
+
+
+**v0.72.2** — Agent Evaluator + Series Audit
 
 **v0.72.1** — Agent Evaluator + Series Audit
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -2,7 +2,7 @@
 
 ## Version
 
-v0.72.1
+v0.72.2
 
 ## Native TUI Stack
 

--- a/docs/event-taxonomy.md
+++ b/docs/event-taxonomy.md
@@ -1,6 +1,6 @@
 # Q Event Taxonomy Reference
 
-Complete reference for all event types in Q 0.72.1.
+Complete reference for all event types in Q 0.72.2.
 ## Base Types
 
 ### `event` (protocol-level)

--- a/docs/extension-guide.md
+++ b/docs/extension-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.72.1 --># Extension Development Guide
+<!-- verified-against: 0.72.2 --># Extension Development Guide
 
 This guide walks you through creating, testing, and activating a custom
 extension for q.

--- a/docs/getting-started/credentials.md
+++ b/docs/getting-started/credentials.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.72.1 -->
+<!-- verified-against: 0.72.2 -->
 # Credential Management
 
 This document describes how q manages API keys and provider credentials,

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.72.1 --># Getting Started
+<!-- verified-against: 0.72.2 --># Getting Started
 
 Welcome to q, a Racket-based coding agent.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.72.1 --># Installation Guide
+<!-- verified-against: 0.72.2 --># Installation Guide
 
 <!-- This file is the canonical source. The docs/getting-started/installation.md copy is maintained for the doc site build. -->
 

--- a/docs/security-trust-model.md
+++ b/docs/security-trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.72.1 --># Security & Trust Model
+<!-- verified-against: 0.72.2 --># Security & Trust Model
 
 This document provides an honest, per-area assessment of what q enforces
 today and what is planned. It is the authoritative reference for security

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -130,6 +130,6 @@ is the primary self-hosting extension:
 (load-extension! ext-reg "path/to/extension.rkt" #:event-bus bus)
 ```
 
-## Version 0.72.1
+## Version 0.72.2
 
-This documentation reflects q 0.72.1.
+This documentation reflects q 0.72.2.

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.72.1 --># q Source Style Guide
+<!-- verified-against: 0.72.2 --># q Source Style Guide
 
 This document defines formatting and naming conventions for the q Racket codebase.
 All changes to `q/` source files (excluding `tests/`) should follow these rules.

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.72.1 -->
+<!-- verified-against: 0.72.2 -->
 # Trust Model
 
 ## Trust Levels

--- a/docs/workflow-testing.md
+++ b/docs/workflow-testing.md
@@ -121,6 +121,6 @@ Use relative paths from the test file:
 4. Use `(check-true ...)` for boolean assertions
 5. Keep tests independent — no shared mutable state between test-cases
 
-## Version 0.72.1
+## Version 0.72.2
 
-This documentation reflects q 0.72.1.
+This documentation reflects q 0.72.2.

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.72.1")
+(define version "0.72.2")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base" "gui-easy-lib"))

--- a/tui/state-types.rkt
+++ b/tui/state-types.rkt
@@ -160,8 +160,10 @@
 
 ;; Forward declarations for types referenced in contracts but defined elsewhere
 ;; (These are provided by other modules and re-exported through state.rkt)
-(define styled-line? any/c) ;; placeholder — actual definition is in render/message-layout.rkt
-(define q-component? any/c) ;; placeholder — actual definition is in component.rkt
+;; Forward-declared predicates — actual structs defined in render/message-layout.rkt
+;; and component.rkt. These are (-> any/c boolean?) predicates compatible with contracts.
+(define styled-line? (lambda (v) (and (list? v) (andmap pair? v))))
+(define q-component? procedure?)
 
 ;; A single line in the transcript display
 (struct transcript-entry

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -11,4 +11,4 @@
 
 (provide (contract-out [q-version string?]))
 
-(define q-version "0.72.1")
+(define q-version "0.72.2")

--- a/wiki-src/Architecture-Overview.md
+++ b/wiki-src/Architecture-Overview.md
@@ -35,7 +35,7 @@ User input → Interface (CLI/TUI/RPC)
     → Events emitted to bus
 ```
 
-## Metrics (0.72.1)
+## Metrics (0.72.2)
 > _See `racket scripts/metrics.rkt` for current numbers._
 
 - 414 source modules, 534 test files


### PR DESCRIPTION
W1: W8 state-types + I6 + version bump.\n\n- Replaced `any/c` placeholders for styled-line? and q-component? with real predicates\n- Verified I6 tool-schema naming — no change needed\n- Version bump 0.72.1→0.72.2, CHANGELOG, README sync\n\nCloses #6180.