### PR TITLE
release(v0.72.4): struct opacity + compactor + version bump (#6190)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## v0.72.4 — 
+
+### Phase 3b: Opaque Representations
+
+Struct opacity + goal-state split + mutable-set elimination.
+
+| Finding | Severity | Fix |
+|---------|----------|-----|
+| W2: goal-state monolith | WARNING | Split into goal-types.rkt + goal-codec.rkt, facade re-exports |
+| W1: turn-model #:transparent structs | WARNING | Removed #:transparent from 5 structs |
+| I7: append-entries! uses set-box! | INFO | Already pure — no change needed |
+| I8: compactor mutable-set | INFO | Replaced with immutable set + for/fold |
+
+**Files changed:** `goal-types.rkt` (new), `goal-codec.rkt` (new), `goal-state.rkt` (facade), `turn-model.rkt`, `compactor.rkt`
+
 ## v0.72.3 — 
 
 ### Phase 3a: Purity Enforcement

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.72.3-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.72.4-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 
@@ -202,7 +202,7 @@ bin/q --model gpt-5.4 "write a test"
 ### Verify
 
 ```bash
-bin/q --version            # q version 0.72.3
+bin/q --version            # q version 0.72.4
 raco test tests/           # run the full test suite
 ```
 
@@ -274,8 +274,8 @@ q/
 | Metric | Value |
 |--------|-------|
 | Test files | 720 |
-| Source modules | 519 |
-| Source lines | 79596 |
+| Source modules | 521 |
+| Source lines | 79652 |
 | Test lines | 118525 |
 | Test assertions | 18755 |
 | Tests passing | 5835+ | `racket scripts/run-tests.rkt` results |
@@ -538,6 +538,9 @@ When q executes shell commands on behalf of an LLM, arguments are quoted via `sh
 
 
 
+
+
+**v0.72.4** — Agent Evaluator + Series Audit
 
 **v0.72.3** — Agent Evaluator + Series Audit
 

--- a/agent/turn-model.rkt
+++ b/agent/turn-model.rkt
@@ -15,13 +15,13 @@
 
 (struct turn-context
         (session-id iteration messages active-tools model-config budget-ctx extension-registry)
-  #:transparent)
+ )
 
 ;; ============================================================
 ;; Turn command -- discriminated union (4 tags)
 ;; ============================================================
 
-(struct turn-command (tag payload) #:transparent)
+(struct turn-command (tag payload))
 
 (define (make-turn-start payload)
   (turn-command 'start payload))
@@ -48,7 +48,7 @@
 ;; Turn decision -- discriminated union (8 tags)
 ;; ============================================================
 
-(struct turn-decision (tag payload metadata) #:transparent)
+(struct turn-decision (tag payload metadata))
 
 (define (make-decision-emit-start payload)
   (turn-decision 'emit-start payload (hasheq)))
@@ -100,7 +100,7 @@
 ;; ============================================================
 
 (struct stream-completion (cancelled? cancel-reason text tool-calls usage model all-chunks)
-  #:transparent)
+ )
 
 (define (make-stream-completion #:cancelled? [cancelled? #f]
                                 #:cancel-reason [cancel-reason #f]
@@ -115,7 +115,7 @@
 ;; Hook stage payload -- replaces raw hash for decide-turn-step
 ;; ============================================================
 
-(struct hook-stage-payload (stage result) #:transparent)
+(struct hook-stage-payload (stage result))
 
 ;; ============================================================
 ;; Provide

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -2,7 +2,7 @@
 
 ## Version
 
-v0.72.3
+v0.72.4
 
 ## Native TUI Stack
 

--- a/docs/event-taxonomy.md
+++ b/docs/event-taxonomy.md
@@ -1,6 +1,6 @@
 # Q Event Taxonomy Reference
 
-Complete reference for all event types in Q 0.72.3.
+Complete reference for all event types in Q 0.72.4.
 ## Base Types
 
 ### `event` (protocol-level)

--- a/docs/extension-guide.md
+++ b/docs/extension-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.72.3 --># Extension Development Guide
+<!-- verified-against: 0.72.4 --># Extension Development Guide
 
 This guide walks you through creating, testing, and activating a custom
 extension for q.

--- a/docs/getting-started/credentials.md
+++ b/docs/getting-started/credentials.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.72.3 -->
+<!-- verified-against: 0.72.4 -->
 # Credential Management
 
 This document describes how q manages API keys and provider credentials,

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.72.3 --># Getting Started
+<!-- verified-against: 0.72.4 --># Getting Started
 
 Welcome to q, a Racket-based coding agent.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.72.3 --># Installation Guide
+<!-- verified-against: 0.72.4 --># Installation Guide
 
 <!-- This file is the canonical source. The docs/getting-started/installation.md copy is maintained for the doc site build. -->
 

--- a/docs/security-trust-model.md
+++ b/docs/security-trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.72.3 --># Security & Trust Model
+<!-- verified-against: 0.72.4 --># Security & Trust Model
 
 This document provides an honest, per-area assessment of what q enforces
 today and what is planned. It is the authoritative reference for security

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -130,6 +130,6 @@ is the primary self-hosting extension:
 (load-extension! ext-reg "path/to/extension.rkt" #:event-bus bus)
 ```
 
-## Version 0.72.3
+## Version 0.72.4
 
-This documentation reflects q 0.72.3.
+This documentation reflects q 0.72.4.

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.72.3 --># q Source Style Guide
+<!-- verified-against: 0.72.4 --># q Source Style Guide
 
 This document defines formatting and naming conventions for the q Racket codebase.
 All changes to `q/` source files (excluding `tests/`) should follow these rules.

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.72.3 -->
+<!-- verified-against: 0.72.4 -->
 # Trust Model
 
 ## Trust Levels

--- a/docs/workflow-testing.md
+++ b/docs/workflow-testing.md
@@ -121,6 +121,6 @@ Use relative paths from the test file:
 4. Use `(check-true ...)` for boolean assertions
 5. Keep tests independent — no shared mutable state between test-cases
 
-## Version 0.72.3
+## Version 0.72.4
 
-This documentation reflects q 0.72.3.
+This documentation reflects q 0.72.4.

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.72.3")
+(define version "0.72.4")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base" "gui-easy-lib"))

--- a/runtime/compactor.rkt
+++ b/runtime/compactor.rkt
@@ -125,30 +125,28 @@
 ;; Returns a hash: 'readFiles -> list of paths,
 ;;                  'modifiedFiles -> list of paths.
 (define (extract-file-tracker messages)
-  (define reads (mutable-set))
-  (define writes (mutable-set))
-  (for ([m (in-list messages)])
-    (define content (message-content m))
-    (for ([part (in-list content)])
+  (define-values (reads writes)
+    (for*/fold ([reads (set)] [writes (set)])
+               ([m (in-list messages)]
+                [part (in-list (message-content m))])
       (cond
-        [(tool-call-part? part)
+        [(not (tool-call-part? part)) (values reads writes)]
+        [else
          (define tool-name (tool-call-part-name part))
          (define args (tool-call-part-arguments part))
          (define path
            (cond
              [(hash? args) (hash-ref args 'path #f)]
              [(string? args)
-              ;; Try to extract path from JSON string
               (and (string-contains? args "path")
                    (let ([m (regexp-match #rx"\"path\"[[:space:]]*:[[:space:]]*\"([^\"]+)\"" args)])
                      (and m (cadr m))))]
              [else #f]))
-         (when path
-           (cond
-             [(member tool-name '("read" "find" "grep" "ls")) (set-add! reads path)]
-             [(member tool-name '("edit" "write")) (set-add! writes path)]))]
-        ;; Tool results may contain file paths in content
-        [(tool-result-part? part) (void)])))
+         (cond
+           [(not path) (values reads writes)]
+           [(member tool-name '("read" "find" "grep" "ls")) (values (set-add reads path) writes)]
+           [(member tool-name '("edit" "write")) (values reads (set-add writes path))]
+           [else (values reads writes)])])))
   (hasheq 'readFiles (set->list reads) 'modifiedFiles (set->list writes)))
 
 ;; Find the most recent compaction-summary message in the list.
@@ -172,13 +170,12 @@
 
 ;; #768: Merge two file trackers, deduplicating file paths.
 (define (merge-file-trackers . trackers)
-  (define all-reads (mutable-set))
-  (define all-writes (mutable-set))
-  (for ([ft (in-list trackers)])
-    (for ([path (in-list (hash-ref ft 'readFiles '()))])
-      (set-add! all-reads path))
-    (for ([path (in-list (hash-ref ft 'modifiedFiles '()))])
-      (set-add! all-writes path)))
+  (define-values (all-reads all-writes)
+    (for*/fold ([reads (set)] [writes (set)])
+               ([ft (in-list trackers)])
+      (values
+       (for/fold ([r reads]) ([path (in-list (hash-ref ft 'readFiles '()))]) (set-add r path))
+       (for/fold ([w writes]) ([path (in-list (hash-ref ft 'modifiedFiles '()))]) (set-add w path)))))
   (hasheq 'readFiles (set->list all-reads) 'modifiedFiles (set->list all-writes)))
 
 ;; ============================================================

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -11,4 +11,4 @@
 
 (provide (contract-out [q-version string?]))
 
-(define q-version "0.72.3")
+(define q-version "0.72.4")

--- a/wiki-src/Architecture-Overview.md
+++ b/wiki-src/Architecture-Overview.md
@@ -35,7 +35,7 @@ User input → Interface (CLI/TUI/RPC)
     → Events emitted to bus
 ```
 
-## Metrics (0.72.3)
+## Metrics (0.72.4)
 > _See `racket scripts/metrics.rkt` for current numbers._
 
 - 414 source modules, 534 test files


### PR DESCRIPTION
W1: W1 struct opacity + I7/I8 + version bump.\n\n- Removed #:transparent from 5 turn-model structs\n- Replaced mutable-set with immutable set + for/fold in compactor.rkt\n- Version bump 0.72.3→0.72.4, CHANGELOG, README sync\n\nCloses #6190.