### PR TITLE
release(v0.72.5): W14 errors split + version bump (#6195)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## v0.72.5 — 
+
+### Phase 4a: Module Decomposition I
+
+Session-store split + errors split + protocol-types documentation.
+
+| Finding | Severity | Fix |
+|---------|----------|-----|
+| W3: session-store monolith | WARNING | Split into versioning.rkt + in-memory.rkt sub-modules |
+| W14: warn-deprecated! in errors.rkt | WARNING | Extracted to util/deprecation.rkt, re-exported |
+| I2: protocol-types transitional | INFO | Documented remaining consumers for future migration |
+
+**Files changed:** session-store/versioning.rkt (new), session-store/in-memory.rkt (new), session-store.rkt (facade), deprecation.rkt (new), errors.rkt, protocol-types.rkt
+
 ## v0.72.4 — 
 
 ### Phase 3b: Opaque Representations

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.72.4-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.72.5-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 
@@ -202,7 +202,7 @@ bin/q --model gpt-5.4 "write a test"
 ### Verify
 
 ```bash
-bin/q --version            # q version 0.72.4
+bin/q --version            # q version 0.72.5
 raco test tests/           # run the full test suite
 ```
 
@@ -274,8 +274,8 @@ q/
 | Metric | Value |
 |--------|-------|
 | Test files | 720 |
-| Source modules | 521 |
-| Source lines | 79652 |
+| Source modules | 524 |
+| Source lines | 79708 |
 | Test lines | 118525 |
 | Test assertions | 18755 |
 | Tests passing | 5835+ | `racket scripts/run-tests.rkt` results |
@@ -539,6 +539,9 @@ When q executes shell commands on behalf of an LLM, arguments are quoted via `sh
 
 
 
+
+
+**v0.72.5** — Agent Evaluator + Series Audit
 
 **v0.72.4** — Agent Evaluator + Series Audit
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -2,7 +2,7 @@
 
 ## Version
 
-v0.72.4
+v0.72.5
 
 ## Native TUI Stack
 

--- a/docs/event-taxonomy.md
+++ b/docs/event-taxonomy.md
@@ -1,6 +1,6 @@
 # Q Event Taxonomy Reference
 
-Complete reference for all event types in Q 0.72.4.
+Complete reference for all event types in Q 0.72.5.
 ## Base Types
 
 ### `event` (protocol-level)

--- a/docs/extension-guide.md
+++ b/docs/extension-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.72.4 --># Extension Development Guide
+<!-- verified-against: 0.72.5 --># Extension Development Guide
 
 This guide walks you through creating, testing, and activating a custom
 extension for q.

--- a/docs/getting-started/credentials.md
+++ b/docs/getting-started/credentials.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.72.4 -->
+<!-- verified-against: 0.72.5 -->
 # Credential Management
 
 This document describes how q manages API keys and provider credentials,

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.72.4 --># Getting Started
+<!-- verified-against: 0.72.5 --># Getting Started
 
 Welcome to q, a Racket-based coding agent.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.72.4 --># Installation Guide
+<!-- verified-against: 0.72.5 --># Installation Guide
 
 <!-- This file is the canonical source. The docs/getting-started/installation.md copy is maintained for the doc site build. -->
 

--- a/docs/security-trust-model.md
+++ b/docs/security-trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.72.4 --># Security & Trust Model
+<!-- verified-against: 0.72.5 --># Security & Trust Model
 
 This document provides an honest, per-area assessment of what q enforces
 today and what is planned. It is the authoritative reference for security

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -130,6 +130,6 @@ is the primary self-hosting extension:
 (load-extension! ext-reg "path/to/extension.rkt" #:event-bus bus)
 ```
 
-## Version 0.72.4
+## Version 0.72.5
 
-This documentation reflects q 0.72.4.
+This documentation reflects q 0.72.5.

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.72.4 --># q Source Style Guide
+<!-- verified-against: 0.72.5 --># q Source Style Guide
 
 This document defines formatting and naming conventions for the q Racket codebase.
 All changes to `q/` source files (excluding `tests/`) should follow these rules.

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.72.4 -->
+<!-- verified-against: 0.72.5 -->
 # Trust Model
 
 ## Trust Levels

--- a/docs/workflow-testing.md
+++ b/docs/workflow-testing.md
@@ -121,6 +121,6 @@ Use relative paths from the test file:
 4. Use `(check-true ...)` for boolean assertions
 5. Keep tests independent — no shared mutable state between test-cases
 
-## Version 0.72.4
+## Version 0.72.5
 
-This documentation reflects q 0.72.4.
+This documentation reflects q 0.72.5.

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.72.4")
+(define version "0.72.5")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base" "gui-easy-lib"))

--- a/util/deprecation.rkt
+++ b/util/deprecation.rkt
@@ -1,0 +1,15 @@
+#lang racket/base
+
+;; util/deprecation.rkt — Deprecation warning utilities
+;; Extracted from errors.rkt (W14 v0.72.5)
+
+(provide warn-deprecated!)
+
+;; Deprecation warning
+(define (warn-deprecated! symbol-name removal-version [extra-notes #f])
+  (log-warning (format "DEPRECATED: ~a (will be removed in ~a).~a"
+                       symbol-name
+                       removal-version
+                       (if extra-notes
+                           (format " ~a" extra-notes)
+                           ""))))

--- a/util/errors.rkt
+++ b/util/errors.rkt
@@ -8,16 +8,8 @@
 ;;   - tool-error: tool execution failures (tool-name)
 ;;   - session-error: session lifecycle errors (session-id)
 
-(require racket/contract)
-
-;; Deprecation warning
-(define (warn-deprecated! symbol-name removal-version [extra-notes #f])
-  (log-warning (format "DEPRECATED: ~a (will be removed in ~a).~a"
-                       symbol-name
-                       removal-version
-                       (if extra-notes
-                           (format " ~a" extra-notes)
-                           ""))))
+(require racket/contract
+         (only-in "deprecation.rkt" warn-deprecated!))
 
 ;; Error structs and constructors
 (provide warn-deprecated!

--- a/util/protocol-types.rkt
+++ b/util/protocol-types.rkt
@@ -13,6 +13,11 @@
 ;;   - tool-types.rkt         -- tool-call, tool-result structs
 ;;
 ;; This file re-exports everything for backward compatibility.
+;;
+;; TRANSITIONAL (I2 v0.72.5): Remaining direct consumers:
+;;   - runtime/iteration/retry-policy.rkt
+;;   - tui/render.rkt
+;; Consider migrating these to import from specific sub-modules.
 
 (require "content-parts.rkt"
          "message.rkt"

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -11,4 +11,4 @@
 
 (provide (contract-out [q-version string?]))
 
-(define q-version "0.72.4")
+(define q-version "0.72.5")

--- a/wiki-src/Architecture-Overview.md
+++ b/wiki-src/Architecture-Overview.md
@@ -35,7 +35,7 @@ User input → Interface (CLI/TUI/RPC)
     → Events emitted to bus
 ```
 
-## Metrics (0.72.4)
+## Metrics (0.72.5)
 > _See `racket scripts/metrics.rkt` for current numbers._
 
 - 414 source modules, 534 test files


### PR DESCRIPTION
W1: W14 errors split + I2 protocol-types + version bump.\n\n- Extracted warn-deprecated! to util/deprecation.rkt, re-exported from errors.rkt\n- Documented protocol-types.rkt remaining consumers\n- Version bump 0.72.4→0.72.5, CHANGELOG, README sync\n\nCloses #6195.