### PR TITLE
release(v0.72.6): W11 explicit provides + version bump (#6200)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## v0.72.6 — 
+
+### Phase 4b: Module Decomposition II
+
+Event-structs explicit provides + event-bus documentation.
+
+| Finding | Severity | Fix |
+|---------|----------|-----|
+| W12: event-bus layer violation | WARNING | Documented as foundational utility in extensions/api.rkt |
+| W11: event-structs all-from-out | WARNING | Replaced with 239 explicit identifier provides |
+| I13: context-assembly facade | INFO | Documented sub-module origins for future migration |
+
+**Files changed:** event-structs.rkt, extensions/api.rkt, context-assembly.rkt
+
 ## v0.72.5 — 
 
 ### Phase 4a: Module Decomposition I

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.72.5-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.72.6-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 
@@ -202,7 +202,7 @@ bin/q --model gpt-5.4 "write a test"
 ### Verify
 
 ```bash
-bin/q --version            # q version 0.72.5
+bin/q --version            # q version 0.72.6
 raco test tests/           # run the full test suite
 ```
 
@@ -275,7 +275,7 @@ q/
 |--------|-------|
 | Test files | 720 |
 | Source modules | 524 |
-| Source lines | 79708 |
+| Source lines | 79952 |
 | Test lines | 118525 |
 | Test assertions | 18755 |
 | Tests passing | 5835+ | `racket scripts/run-tests.rkt` results |
@@ -540,6 +540,9 @@ When q executes shell commands on behalf of an LLM, arguments are quoted via `sh
 
 
 
+
+
+**v0.72.6** — Agent Evaluator + Series Audit
 
 **v0.72.5** — Agent Evaluator + Series Audit
 

--- a/agent/event-structs.rkt
+++ b/agent/event-structs.rkt
@@ -10,19 +10,14 @@
 ;;   - event-structs/provider-events.rkt -- provider/LLM events
 ;;   - event-structs/session-events.rkt  -- session/input/model/agent/context events
 ;;   - event-structs/iteration-events.rkt -- auto-retry/compaction/injection events
+;;   - event-structs/hook-events.rkt     -- hook interception events
+;;   - event-structs/stream-events.rkt   -- streaming events
 ;;
 ;; This file re-exports everything for backward compatibility.
-;; New code should import the focused sub-modules directly.
+;; W11 (v0.72.6): Replaced wildcard re-exports with explicit identifier lists
+;; to prevent accidental export leakage from sub-module changes.
 ;;
-;; v0.30.6 status: 30 typed event structs across 8 sub-modules.
-;;   - runtime/ files: 15 emit-typed-event! sites (fully migrated)
-;;   - agent/loop*.rkt: 28 raw emit! sites (use dotted event names)
-;;   - These two systems coexist: typed events use hyphenated names
-;;     ("turn.started"), raw emit! uses dotted names ("turn.started").
-;;   - New hook-events.rkt sub-module adds: model-request-blocked,
-;;     message-blocked, turn-cancelled, assistant-message-completed
-;;   - New provider streaming events: model-stream-delta,
-;;     model-stream-thinking, model-stream-completed
+;; v0.30.6 status: 30+ typed event structs across 9 sub-modules.
 
 (require "event-structs/base.rkt"
          "event-structs/turn-events.rkt"
@@ -34,13 +29,252 @@
          "event-structs/hook-events.rkt"
          "event-structs/stream-events.rkt")
 
-;; WARNING: all-from-out leaks submodule additions -- keep submodules stable
-(provide (all-from-out "event-structs/base.rkt")
-         (all-from-out "event-structs/turn-events.rkt")
-         (all-from-out "event-structs/message-events.rkt")
-         (all-from-out "event-structs/tool-events.rkt")
-         (all-from-out "event-structs/provider-events.rkt")
-         (all-from-out "event-structs/session-events.rkt")
-         (all-from-out "event-structs/iteration-events.rkt")
-         (all-from-out "event-structs/hook-events.rkt")
-         (all-from-out "event-structs/stream-events.rkt"))
+(provide
+;; From event-structs/base.rkt
+         (struct-out typed-event)
+         typed-event?
+         ;; From event-structs/turn-events.rkt
+         (struct-out turn-start-event)
+         make-turn-start-event
+         turn-start-event-type
+         turn-start-event-fields
+         (struct-out turn-end-event)
+         make-turn-end-event
+         turn-end-event-type
+         turn-end-event-fields
+         ;; From event-structs/message-events.rkt
+         (struct-out message-start-event)
+         make-message-start-event
+         message-start-event-type
+         message-start-event-fields
+         (struct-out message-update-event)
+         make-message-update-event
+         message-update-event-type
+         message-update-event-fields
+         (struct-out message-end-event)
+         make-message-end-event
+         message-end-event-type
+         message-end-event-fields
+         ;; From event-structs/tool-events.rkt
+         (struct-out tool-execution-start-event)
+         make-tool-execution-start-event
+         tool-execution-start-event-type
+         tool-execution-start-event-fields
+         (struct-out tool-execution-update-event)
+         make-tool-execution-update-event
+         tool-execution-update-event-type
+         tool-execution-update-event-fields
+         (struct-out tool-execution-end-event)
+         make-tool-execution-end-event
+         tool-execution-end-event-type
+         tool-execution-end-event-fields
+         (struct-out tool-call-event)
+         make-tool-call-event
+         tool-call-event-type
+         tool-call-event-fields
+         (struct-out tool-result-event)
+         make-tool-result-event
+         tool-result-event-type
+         tool-result-event-fields
+         (struct-out bash-tool-call-event)
+         (struct-out edit-tool-call-event)
+         (struct-out write-tool-call-event)
+         (struct-out read-tool-call-event)
+         (struct-out grep-tool-call-event)
+         (struct-out find-tool-call-event)
+         (struct-out custom-tool-call-event)
+         make-bash-tool-call-event
+         bash-tool-call-event?
+         bash-tool-call-event-fields
+         make-edit-tool-call-event
+         edit-tool-call-event?
+         edit-tool-call-event-fields
+         make-write-tool-call-event
+         write-tool-call-event?
+         write-tool-call-event-fields
+         make-read-tool-call-event
+         read-tool-call-event?
+         read-tool-call-event-fields
+         make-grep-tool-call-event
+         grep-tool-call-event?
+         grep-tool-call-event-fields
+         make-find-tool-call-event
+         find-tool-call-event?
+         find-tool-call-event-fields
+         make-custom-tool-call-event
+         custom-tool-call-event?
+         custom-tool-call-event-fields
+         ;; From event-structs/provider-events.rkt
+         (struct-out provider-request-event)
+         make-provider-request-event
+         provider-request-event-type
+         provider-request-event-fields
+         (struct-out provider-response-event)
+         make-provider-response-event
+         provider-response-event-type
+         provider-response-event-fields
+         (struct-out model-stream-delta-event)
+         make-model-stream-delta-event
+         model-stream-delta-event-type
+         model-stream-delta-event-fields
+         (struct-out model-stream-thinking-event)
+         make-model-stream-thinking-event
+         model-stream-thinking-event-type
+         model-stream-thinking-event-fields
+         (struct-out model-stream-completed-event)
+         make-model-stream-completed-event
+         model-stream-completed-event-type
+         model-stream-completed-event-fields
+         ;; From event-structs/session-events.rkt
+         (struct-out session-start-event)
+         make-session-start-event
+         session-start-event-type
+         session-start-event-fields
+         (struct-out session-shutdown-event)
+         make-session-shutdown-event
+         session-shutdown-event-type
+         session-shutdown-event-fields
+         (struct-out input-event)
+         make-input-event
+         input-event-type
+         input-event-fields
+         (struct-out model-select-event)
+         make-model-select-event
+         model-select-event-type
+         model-select-event-fields
+         (struct-out agent-start-event)
+         make-agent-start-event
+         agent-start-event-type
+         agent-start-event-fields
+         (struct-out agent-end-event)
+         make-agent-end-event
+         agent-end-event-type
+         agent-end-event-fields
+         (struct-out context-event)
+         make-context-event
+         context-event-type
+         context-event-fields
+         (struct-out context-assembled-event)
+         make-context-assembled-event
+         context-assembled-event-type
+         context-assembled-event-fields
+         (struct-out context-blocked-event)
+         make-context-blocked-event
+         context-blocked-event-type
+         context-blocked-event-fields
+         (struct-out working-set-injected-event)
+         make-working-set-injected-event
+         working-set-injected-event-type
+         working-set-injected-event-fields
+         (struct-out context-assembly-detail-event)
+         make-context-assembly-detail-event
+         context-assembly-detail-event-type
+         context-assembly-detail-event-fields
+         (struct-out goal-start-event)
+         make-goal-start-event
+         goal-start-event-type
+         goal-start-event-fields
+         (struct-out goal-turn-start-event)
+         make-goal-turn-start-event
+         goal-turn-start-event-type
+         goal-turn-start-event-fields
+         (struct-out goal-evaluated-event)
+         make-goal-evaluated-event
+         goal-evaluated-event-type
+         goal-evaluated-event-fields
+         (struct-out goal-check-event)
+         make-goal-check-event
+         goal-check-event-type
+         goal-check-event-fields
+         (struct-out goal-achieved-event)
+         make-goal-achieved-event
+         goal-achieved-event-type
+         goal-achieved-event-fields
+         (struct-out goal-failed-event)
+         make-goal-failed-event
+         goal-failed-event-type
+         goal-failed-event-fields
+         ;; From event-structs/iteration-events.rkt
+         (struct-out auto-retry-event)
+         make-auto-retry-event
+         auto-retry-event-type
+         auto-retry-event-fields
+         (struct-out auto-retry-start-event)
+         make-auto-retry-start-event
+         auto-retry-start-event-type
+         auto-retry-start-event-fields
+         (struct-out compaction-event)
+         make-compaction-event
+         compaction-event-type
+         compaction-event-fields
+         (struct-out injection-event)
+         make-injection-event
+         injection-event-type
+         injection-event-fields
+         (struct-out iteration-decision-event)
+         make-iteration-decision-event
+         iteration-decision-event-type
+         iteration-decision-event-fields
+         ;; From event-structs/hook-events.rkt
+         (struct-out model-request-blocked-event)
+         make-model-request-blocked-event
+         model-request-blocked-event-type
+         model-request-blocked-event-fields
+         (struct-out message-blocked-event)
+         make-message-blocked-event
+         message-blocked-event-type
+         message-blocked-event-fields
+         (struct-out turn-cancelled-event)
+         make-turn-cancelled-event
+         turn-cancelled-event-type
+         turn-cancelled-event-fields
+         (struct-out assistant-message-completed-event)
+         make-assistant-message-completed-event
+         assistant-message-completed-event-type
+         assistant-message-completed-event-fields
+         ;; From event-structs/stream-events.rkt
+         (struct-out stream-completed-event)
+         make-stream-completed-event
+         stream-completed-event-type
+         stream-completed-event-fields
+         (struct-out stream-delta-event)
+         make-stream-delta-event
+         stream-delta-event-type
+         stream-delta-event-fields
+         (struct-out stream-tool-call-delta-event)
+         make-stream-tool-call-delta-event
+         stream-tool-call-delta-event-type
+         stream-tool-call-delta-event-fields
+         (struct-out stream-thinking-event)
+         make-stream-thinking-event
+         stream-thinking-event-type
+         stream-thinking-event-fields
+         (struct-out stream-message-start-event)
+         make-stream-message-start-event
+         stream-message-start-event-type
+         stream-message-start-event-fields
+         (struct-out stream-message-delta-event)
+         make-stream-message-delta-event
+         stream-message-delta-event-type
+         stream-message-delta-event-fields
+         (struct-out stream-message-end-event)
+         make-stream-message-end-event
+         stream-message-end-event-type
+         stream-message-end-event-fields
+         (struct-out stream-turn-completed-event)
+         make-stream-turn-completed-event
+         stream-turn-completed-event-type
+         stream-turn-completed-event-fields
+         (struct-out stream-turn-cancelled-event)
+         make-stream-turn-cancelled-event
+         stream-turn-cancelled-event-type
+         stream-turn-cancelled-event-fields
+         (struct-out stream-tool-call-started-event)
+         make-stream-tool-call-started-event
+         stream-tool-call-started-event-type
+         stream-tool-call-started-event-fields
+         (struct-out stream-assistant-msg-completed-event)
+         make-stream-assistant-msg-completed-event
+         stream-assistant-msg-completed-event-type
+         stream-assistant-msg-completed-event-fields
+)

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -2,7 +2,7 @@
 
 ## Version
 
-v0.72.5
+v0.72.6
 
 ## Native TUI Stack
 

--- a/docs/event-taxonomy.md
+++ b/docs/event-taxonomy.md
@@ -1,6 +1,6 @@
 # Q Event Taxonomy Reference
 
-Complete reference for all event types in Q 0.72.5.
+Complete reference for all event types in Q 0.72.6.
 ## Base Types
 
 ### `event` (protocol-level)

--- a/docs/extension-guide.md
+++ b/docs/extension-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.72.5 --># Extension Development Guide
+<!-- verified-against: 0.72.6 --># Extension Development Guide
 
 This guide walks you through creating, testing, and activating a custom
 extension for q.

--- a/docs/getting-started/credentials.md
+++ b/docs/getting-started/credentials.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.72.5 -->
+<!-- verified-against: 0.72.6 -->
 # Credential Management
 
 This document describes how q manages API keys and provider credentials,

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.72.5 --># Getting Started
+<!-- verified-against: 0.72.6 --># Getting Started
 
 Welcome to q, a Racket-based coding agent.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.72.5 --># Installation Guide
+<!-- verified-against: 0.72.6 --># Installation Guide
 
 <!-- This file is the canonical source. The docs/getting-started/installation.md copy is maintained for the doc site build. -->
 

--- a/docs/security-trust-model.md
+++ b/docs/security-trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.72.5 --># Security & Trust Model
+<!-- verified-against: 0.72.6 --># Security & Trust Model
 
 This document provides an honest, per-area assessment of what q enforces
 today and what is planned. It is the authoritative reference for security

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -130,6 +130,6 @@ is the primary self-hosting extension:
 (load-extension! ext-reg "path/to/extension.rkt" #:event-bus bus)
 ```
 
-## Version 0.72.5
+## Version 0.72.6
 
-This documentation reflects q 0.72.5.
+This documentation reflects q 0.72.6.

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.72.5 --># q Source Style Guide
+<!-- verified-against: 0.72.6 --># q Source Style Guide
 
 This document defines formatting and naming conventions for the q Racket codebase.
 All changes to `q/` source files (excluding `tests/`) should follow these rules.

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.72.5 -->
+<!-- verified-against: 0.72.6 -->
 # Trust Model
 
 ## Trust Levels

--- a/docs/workflow-testing.md
+++ b/docs/workflow-testing.md
@@ -121,6 +121,6 @@ Use relative paths from the test file:
 4. Use `(check-true ...)` for boolean assertions
 5. Keep tests independent — no shared mutable state between test-cases
 
-## Version 0.72.5
+## Version 0.72.6
 
-This documentation reflects q 0.72.5.
+This documentation reflects q 0.72.6.

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.72.5")
+(define version "0.72.6")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base" "gui-easy-lib"))

--- a/runtime/context-assembly.rkt
+++ b/runtime/context-assembly.rkt
@@ -6,6 +6,13 @@
 ;; Thin facade: re-exports from context-assembly/budgeting, selection, serialization.
 ;; Also re-exports from context-summary.rkt (sibling module).
 ;; All struct definitions live in sub-modules (single source of truth).
+;;
+;; I13 (v0.72.6): Documented as transitional facade. Each symbol originates
+;; from a specific sub-module. New code should import directly from:
+;;   - context-assembly/budgeting.rkt  — token budget calculations
+;;   - context-assembly/selection.rkt  — message selection strategies
+;;   - context-assembly/serialization.rkt — serialization helpers
+;;   - context-summary.rkt            — summary entities
 
 (require racket/contract
          "context-assembly/budgeting.rkt"

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -11,4 +11,4 @@
 
 (provide (contract-out [q-version string?]))
 
-(define q-version "0.72.5")
+(define q-version "0.72.6")

--- a/wiki-src/Architecture-Overview.md
+++ b/wiki-src/Architecture-Overview.md
@@ -35,7 +35,7 @@ User input → Interface (CLI/TUI/RPC)
     → Events emitted to bus
 ```
 
-## Metrics (0.72.5)
+## Metrics (0.72.6)
 > _See `racket scripts/metrics.rkt` for current numbers._
 
 - 414 source modules, 534 test files


### PR DESCRIPTION
W1: W11 event-structs explicit provides + I13 context-assembly docs + version bump.\n\n- Replaced all-from-out with 239 explicit identifier provides in event-structs.rkt\n- Documented event-bus as foundational utility in extensions/api.rkt\n- Added sub-module origin docs to context-assembly.rkt\n- Version bump 0.72.5→0.72.6, CHANGELOG, README sync\n\nCloses #6200.