### PR TITLE
feat(v0.72.7 W0): W6 TUI reducer + W7 event registry (#6204)

### DIFF
--- a/tui/commands.rkt
+++ b/tui/commands.rkt
@@ -88,6 +88,7 @@
 
          ;; Main command dispatcher
          process-slash-command
+         apply-slash-command
          process-extension-command
          execute-extension-command
          cmd-ctx-session-factory-runner)
@@ -236,6 +237,15 @@
 ;; ============================================================
 ;; Main command dispatcher
 ;; ============================================================
+
+;; Pure-ish state transition for slash commands.
+;; Returns (values new-state result) where result is 'continue | 'quit.
+;; W6 (v0.72.7): Return-based wrapper — callers can adopt this instead of
+;; relying on set-box! side effects. Currently delegates to process-slash-command.
+(define (apply-slash-command state cctx cmd)
+  (define result (process-slash-command cctx cmd))
+  (define new-state (unbox (cmd-ctx-state-box cctx)))
+  (values new-state result))
 
 ;; Process a slash command. Returns 'continue | 'quit
 ;; cmd can be: symbol | (list symbol args...)

--- a/tui/state-events.rkt
+++ b/tui/state-events.rkt
@@ -18,6 +18,7 @@
 (provide current-gsd-mode-query
          (contract-out [apply-event-to-state (-> ui-state? event? ui-state?)]
                        [register-event-reducer! (-> string? procedure? void?)]
+                       [call-with-test-registry (-> procedure? any)]
                        [event-reducer-registered? (-> string? boolean?)]
                        [classify-error-type (-> any/c hash? symbol?)]
                        [format-error-hint
@@ -36,12 +37,28 @@
 (define event-reducers (make-hash))
 (define event-reducers-lock (make-semaphore 1))
 
+;; W7 (v0.72.7): Parameter-based registry for test isolation.
+;; When set, tests use a fresh hash instead of the global registry.
+;; Write-once registration — re-registering an existing type is a no-op.
+(define current-event-reducers (make-parameter #f))
+
+(define (get-event-reducers)
+  (or (current-event-reducers) event-reducers))
+
+(define (call-with-test-registry thunk)
+  (parameterize ([current-event-reducers (make-hash)])
+    (thunk)))
+
 (define (register-event-reducer! type-string handler)
+  ;; Write-once: re-registering an existing type is a no-op.
   (call-with-semaphore event-reducers-lock
-                       (lambda () (hash-set! event-reducers type-string handler))))
+                       (lambda ()
+                         (unless (hash-has-key? (get-event-reducers) type-string)
+                           (hash-set! (get-event-reducers) type-string handler)))))
 
 (define (event-reducer-registered? type-string)
-  (call-with-semaphore event-reducers-lock (lambda () (hash-has-key? event-reducers type-string))))
+  (call-with-semaphore event-reducers-lock
+                       (lambda () (hash-has-key? (get-event-reducers) type-string))))
 
 ;; Local helper (avoids circular dependency with state-ui)
 (define (ui-model-label state)
@@ -556,7 +573,7 @@
 (define (apply-event-to-state state evt)
   (define ev (event-ev evt))
   (define handler
-    (call-with-semaphore event-reducers-lock (lambda () (hash-ref event-reducers ev #f))))
+    (call-with-semaphore event-reducers-lock (lambda () (hash-ref (get-event-reducers) ev #f))))
   (if handler
       (handler state evt)
       state))


### PR DESCRIPTION
W0: W6 TUI reducer + W7 event registry lifecycle.\n\n- Added apply-slash-command return-based wrapper to tui/commands.rkt\n- Added current-event-reducers parameter + call-with-test-registry for test isolation\n- Made register-event-reducer! write-once (no-op on re-register)\n- Updated apply-event-to-state dispatch to use get-event-reducers\n\nCloses #6204.