### PR TITLE
feat(v0.72.8 W0): AU-2 — 6 structs opaque (#6209)

### DIFF
--- a/agent/event-bus.rkt
+++ b/agent/event-bus.rkt
@@ -134,7 +134,7 @@
 ;; Internal subscription record
 ;; ============================================================
 
-(struct subscription (id handler filter) #:transparent)
+(struct subscription (id handler filter))
 
 ;; ============================================================
 ;; Event bus struct

--- a/runtime/iteration/directive.rkt
+++ b/runtime/iteration/directive.rkt
@@ -28,9 +28,9 @@
                        [directive-yield-ws (-> directive-yield? (or/c any/c #f))]
                        [step-directive? (-> any/c boolean?)]))
 
-(struct directive-recurse (new-ctx new-counters ws) #:transparent)
-(struct directive-stop (result) #:transparent)
-(struct directive-yield (events new-ctx new-counters ws) #:transparent)
+(struct directive-recurse (new-ctx new-counters ws))
+(struct directive-stop (result))
+(struct directive-yield (events new-ctx new-counters ws))
 
 (define (step-directive? v)
   (or (directive-recurse? v) (directive-stop? v) (directive-yield? v)))

--- a/runtime/session-store/in-memory.rkt
+++ b/runtime/session-store/in-memory.rkt
@@ -21,7 +21,7 @@
 ;; In-memory session manager (GC-18)
 ;; ============================================================
 
-(struct in-memory-session-manager (sessions-box) #:transparent)
+(struct in-memory-session-manager (sessions-box))
 
 (define (make-in-memory-session-manager)
   (in-memory-session-manager (box (hash))))

--- a/runtime/tool-coordinator.rkt
+++ b/runtime/tool-coordinator.rkt
@@ -111,7 +111,7 @@
 ;; ============================================================
 
 ;; v0.31.5 W1: Pure function for tool-call actions
-(struct tool-call-actions (calls-to-run blocked? final-calls) #:transparent)
+(struct tool-call-actions (calls-to-run blocked? final-calls))
 
 ;; classify-tool-results : (listof tool-call?) (listof tool-result?) -> (listof hasheq?)
 ;; Pure: maps tool calls + results to status classification hashes.

--- a/tests/test-step-directive.rkt
+++ b/tests/test-step-directive.rkt
@@ -35,6 +35,6 @@
   (check-false (step-directive? #f))
   (check-false (step-directive? (hash 'status 'ready))))
 
-(test-case "directive structs are transparent"
+(test-case "directive-recurse accessor works"
   (define d (directive-recurse '(a b) '(c d) 'ws))
   (check-equal? (directive-recurse-new-ctx d) '(a b)))


### PR DESCRIPTION
W0: AU-2 — Make 6 internal structs opaque.\n\n- Removed #:transparent from directive-recurse, directive-stop, directive-yield\n- Removed #:transparent from tool-call-actions, subscription, in-memory-session-manager\n- Renamed misleading test name in test-step-directive.rkt\n- All compilation and test gates pass\n\nCloses #6209.