### PR TITLE
feat(v0.72.8 W1): AU-3 — Turn-reducer contracts (#6210)

### DIFF
--- a/agent/turn-reducer.rkt
+++ b/agent/turn-reducer.rkt
@@ -13,6 +13,7 @@
          racket/match
          "turn-model.rkt"
          (only-in "loop-messages.rkt" classify-hook-result)
+         (only-in "../util/hook-types.rkt" hook-result?)
          (only-in "loop-fsm.rkt"
                   turn-state-emit-start
                   turn-state-build-context
@@ -81,7 +82,7 @@
 (provide classify-hook-result
          (contract-out [decide-after-start (-> any/c turn-decision?)]
                        [decide-after-context (-> any/c turn-decision?)]
-                       [decide-after-pre-hook (-> any/c turn-decision?)]
-                       [decide-after-msg-hook (-> any/c turn-decision?)]
+                       [decide-after-pre-hook (-> (or/c hook-result? #f) turn-decision?)]
+                       [decide-after-msg-hook (-> (or/c hook-result? #f) turn-decision?)]
                        [decide-after-stream (-> stream-completion? turn-decision?)]
                        [decide-turn-step (-> turn-command? turn-decision?)]))

--- a/tests/test-turn-reducer.rkt
+++ b/tests/test-turn-reducer.rkt
@@ -30,7 +30,7 @@
       (check-true (decision-blocked? d)))
 
     (test-case "pre-hook pass -> check-msg-hook decision"
-      (define d (decide-after-pre-hook 'pass))
+      (define d (decide-after-pre-hook #f))
       (check-true (decision-check-msg-hook? d)))
 
     (test-case "msg-hook block -> blocked decision"
@@ -39,7 +39,7 @@
       (check-true (decision-blocked? d)))
 
     (test-case "msg-hook pass -> begin-stream decision"
-      (define d (decide-after-msg-hook 'pass))
+      (define d (decide-after-msg-hook #f))
       (check-true (decision-begin-stream? d)))
 
     (test-case "stream cancelled -> cancelled decision"


### PR DESCRIPTION
W1: AU-3 — Tighten turn-reducer contracts.\n\n- Tightened decide-after-pre-hook: any/c → (or/c hook-result? #f)\n- Tightened decide-after-msg-hook: any/c → (or/c hook-result? #f)\n- Fixed test shortcuts: replaced 'pass with #f in 2 tests\n- Left decide-after-start and decide-after-context as any/c (opaque payload)\n- All test gates pass (17/17 turn-reducer, 11/11 turn-model, 8/8 integration)\n\nCloses #6210.