### PR TITLE
feat(v0.72.8 W2): AU-4 + AU-5 contract/predicate fixes (#6211)

### DIFF
--- a/runtime/session-mutation.rkt
+++ b/runtime/session-mutation.rkt
@@ -9,7 +9,8 @@
          "session-types.rkt"
          (submod "session-types.rkt" internal)
          (only-in "session-config.rkt" session-config?)
-         (only-in "../util/errors.rkt" raise-session-error))
+         (only-in "../util/errors.rkt" raise-session-error)
+         (only-in "session-index/schema.rkt" session-index?))
 
 (provide (contract-out [guarded-set-prompt-running! (-> agent-session? boolean? void?)]
                        [guarded-set-compacting! (-> agent-session? boolean? void?)]
@@ -18,7 +19,7 @@
                        [guarded-set-active! (-> agent-session? boolean? void?)]
                        [guarded-set-model-name! (-> agent-session? (or/c string? #f) void?)]
                        [guarded-set-config! (-> agent-session? (or/c session-config? hash? #f) void?)]
-                       [guarded-set-index! (-> agent-session? any/c void?)]
+                       [guarded-set-index! (-> agent-session? (or/c session-index? #f) void?)]
                        [guarded-set-persisted! (-> agent-session? boolean? void?)]
                        [guarded-set-pending-entries! (-> agent-session? list? void?)]
                        [guarded-set-start-time! (-> agent-session? exact-nonnegative-integer? void?)]

--- a/tests/test-component-model.rkt
+++ b/tests/test-component-model.rkt
@@ -141,11 +141,11 @@
    (define comp (make-q-component (lambda (s w) '())))
    (check-equal? (component-state-ref comp 'foo) #f)
    (check-equal? (component-state-ref comp 'foo 42) 42))
- (test-case "component-state-set! stores and retrieves values"
+ (test-case "component-state-update stores and retrieves values"
    (define comp (make-q-component (lambda (s w) '())))
-   (component-state-set! comp 'counter 0)
+   (component-state-update comp 'counter 0)
    (check-equal? (component-state-ref comp 'counter) 0)
-   (component-state-set! comp 'counter 5)
+   (component-state-update comp 'counter 5)
    (check-equal? (component-state-ref comp 'counter) 5))
  (test-case "component state persists across renders"
    (define render-count 0)
@@ -153,7 +153,7 @@
      (make-q-component (lambda (s w)
                          (set! render-count (add1 render-count))
                          (define prev (component-state-ref comp 'renders 0))
-                         (component-state-set! comp 'renders (add1 prev))
+                         (component-state-update comp 'renders (add1 prev))
                          (list (vtext (format "render #~a" (add1 prev)) '())))
                        #:vdom? #t))
    (component-render comp (initial-ui-state) 80)
@@ -164,8 +164,8 @@
  (test-case "each component has independent state"
    (define comp1 (make-q-component (lambda (s w) '())))
    (define comp2 (make-q-component (lambda (s w) '())))
-   (component-state-set! comp1 'key 'val1)
-   (component-state-set! comp2 'key 'val2)
+   (component-state-update comp1 'key 'val1)
+   (component-state-update comp2 'key 'val2)
    (check-equal? (component-state-ref comp1 'key) 'val1)
    (check-equal? (component-state-ref comp2 'key) 'val2)))
 
@@ -177,7 +177,7 @@
   (define comp
     (make-q-component (lambda (st width)
                         (define scroll (component-state-ref comp 'scroll 0))
-                        (component-state-set! comp 'scroll (+ scroll 1))
+                        (component-state-update comp 'scroll (+ scroll 1))
                         (list (vtext (format "scroll:~a" scroll) '())))
                       #:vdom? #t))
   ;; First render — scroll is 0, stored as 1

--- a/tui/state-types.rkt
+++ b/tui/state-types.rkt
@@ -163,6 +163,12 @@
 ;; Forward-declared predicates — actual structs defined in render/message-layout.rkt
 ;; and component.rkt. These are (-> any/c boolean?) predicates compatible with contracts.
 (define styled-line? (lambda (v) (and (list? v) (andmap pair? v))))
+;; AU-5 (v0.72.8): q-component? is intentionally procedure? here because the real
+;; q-component struct is in component.rkt which has a circular dependency via
+;; state.rkt → render.rkt → component.rkt → state-types.rkt.
+;; The real predicate is component.rkt's q-component?.
+;; This placeholder is safe because state-types.rkt never calls q-component? at
+;; runtime — it only appears in contract annotations checked at module boundaries.
 (define q-component? procedure?)
 
 ;; A single line in the transcript display


### PR DESCRIPTION
W2: AU-4 + AU-5 — Contract tightening + placeholder documentation.\n\n- AU-4: Tightened guarded-set-index! contract from any/c to (or/c session-index? #f)\n- AU-5: Documented q-component? placeholder — cannot re-export due to import cycle (state.rkt→render.rkt→component.rkt→state-types.rkt). Added clear comment explaining why.\n- Fixed test-component-model.rkt: updated component-state-set! → component-state-update (missed in v0.72.7)\n- All test gates pass (session-mutation, component-model 19/19)\n\nCloses #6211.