### PR TITLE
release(v0.72.8): Audit closure — version bump (#6212)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## v0.72.8 — 
+
+### Audit Closure
+
+Close 5 remaining findings from v0.72.xx post-implementation audit.
+
+| Finding | Fix |
+|---------|-----|
+| AU-2: 6 internal structs #:transparent | Removed #:transparent from directive-recurse, directive-stop, directive-yield, tool-call-actions, subscription, in-memory-session-manager |
+| AU-3: turn-reducer any/c contracts | Tightened decide-after-pre-hook and decide-after-msg-hook to (or/c hook-result? #f) |
+| AU-4: guarded-set-index! any/c | Tightened to (or/c session-index? #f) |
+| AU-5: q-component? placeholder | Documented cycle constraint; placeholder retained with explanation |
+| Fix: test-component-model.rkt | Updated component-state-set! → component-state-update (missed in v0.72.7) |
+
+**Files changed:** directive.rkt, tool-coordinator.rkt, event-bus.rkt, in-memory.rkt, turn-reducer.rkt, session-mutation.rkt, state-types.rkt, test-step-directive.rkt, test-turn-reducer.rkt, test-component-model.rkt
+
 ## v0.72.7 — 
 
 ### Phase 5: Long-Term Patterns + Sweep

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.72.7-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.72.8-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 
@@ -202,7 +202,7 @@ bin/q --model gpt-5.4 "write a test"
 ### Verify
 
 ```bash
-bin/q --version            # q version 0.72.7
+bin/q --version            # q version 0.72.8
 raco test tests/           # run the full test suite
 ```
 
@@ -275,8 +275,8 @@ q/
 |--------|-------|
 | Test files | 720 |
 | Source modules | 524 |
-| Source lines | 80004 |
-| Test lines | 118525 |
+| Source lines | 80013 |
+| Test lines | 118534 |
 | Test assertions | 18755 |
 | Tests passing | 5835+ | `racket scripts/run-tests.rkt` results |
 
@@ -542,6 +542,9 @@ When q executes shell commands on behalf of an LLM, arguments are quoted via `sh
 
 
 
+
+
+**v0.72.8** — Agent Evaluator + Series Audit
 
 **v0.72.7** — Agent Evaluator + Series Audit
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -2,7 +2,7 @@
 
 ## Version
 
-v0.72.7
+v0.72.8
 
 ## Native TUI Stack
 

--- a/docs/event-taxonomy.md
+++ b/docs/event-taxonomy.md
@@ -1,6 +1,6 @@
 # Q Event Taxonomy Reference
 
-Complete reference for all event types in Q 0.72.7.
+Complete reference for all event types in Q 0.72.8.
 ## Base Types
 
 ### `event` (protocol-level)

--- a/docs/extension-guide.md
+++ b/docs/extension-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.72.7 --># Extension Development Guide
+<!-- verified-against: 0.72.8 --># Extension Development Guide
 
 This guide walks you through creating, testing, and activating a custom
 extension for q.

--- a/docs/getting-started/credentials.md
+++ b/docs/getting-started/credentials.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.72.7 -->
+<!-- verified-against: 0.72.8 -->
 # Credential Management
 
 This document describes how q manages API keys and provider credentials,

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.72.7 --># Getting Started
+<!-- verified-against: 0.72.8 --># Getting Started
 
 Welcome to q, a Racket-based coding agent.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.72.7 --># Installation Guide
+<!-- verified-against: 0.72.8 --># Installation Guide
 
 <!-- This file is the canonical source. The docs/getting-started/installation.md copy is maintained for the doc site build. -->
 

--- a/docs/security-trust-model.md
+++ b/docs/security-trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.72.7 --># Security & Trust Model
+<!-- verified-against: 0.72.8 --># Security & Trust Model
 
 This document provides an honest, per-area assessment of what q enforces
 today and what is planned. It is the authoritative reference for security

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -130,6 +130,6 @@ is the primary self-hosting extension:
 (load-extension! ext-reg "path/to/extension.rkt" #:event-bus bus)
 ```
 
-## Version 0.72.7
+## Version 0.72.8
 
-This documentation reflects q 0.72.7.
+This documentation reflects q 0.72.8.

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.72.7 --># q Source Style Guide
+<!-- verified-against: 0.72.8 --># q Source Style Guide
 
 This document defines formatting and naming conventions for the q Racket codebase.
 All changes to `q/` source files (excluding `tests/`) should follow these rules.

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.72.7 -->
+<!-- verified-against: 0.72.8 -->
 # Trust Model
 
 ## Trust Levels

--- a/docs/workflow-testing.md
+++ b/docs/workflow-testing.md
@@ -121,6 +121,6 @@ Use relative paths from the test file:
 4. Use `(check-true ...)` for boolean assertions
 5. Keep tests independent — no shared mutable state between test-cases
 
-## Version 0.72.7
+## Version 0.72.8
 
-This documentation reflects q 0.72.7.
+This documentation reflects q 0.72.8.

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.72.7")
+(define version "0.72.8")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base" "gui-easy-lib"))

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -11,4 +11,4 @@
 
 (provide (contract-out [q-version string?]))
 
-(define q-version "0.72.7")
+(define q-version "0.72.8")

--- a/wiki-src/Architecture-Overview.md
+++ b/wiki-src/Architecture-Overview.md
@@ -35,7 +35,7 @@ User input → Interface (CLI/TUI/RPC)
     → Events emitted to bus
 ```
 
-## Metrics (0.72.7)
+## Metrics (0.72.8)
 > _See `racket scripts/metrics.rkt` for current numbers._
 
 - 414 source modules, 534 test files


### PR DESCRIPTION
W3: Version bump + CHANGELOG + verification.\n\n- Version 0.72.7 → 0.72.8\n- CHANGELOG entry with all 5 AU findings\n- README + metrics synced\n- All test gates pass\n\nCloses #6212. Closes #6208 (parent).