### PR TITLE
arch(v0.73.1 W0): A-2 extract tool? to util/tool-types.rkt (#6227)

### DIFF
--- a/agent/loop-dispatch.rkt
+++ b/agent/loop-dispatch.rkt
@@ -24,7 +24,7 @@
          (only-in "turn-reducer.rkt" decide-after-msg-hook decide-after-stream)
          (only-in "turn-model.rkt" make-stream-completion turn-decision-tag)
          (only-in "event-emitter.rkt" emit-typed-event!)
-         (only-in "../tools/tool.rkt" tool?)
+         (only-in "../util/tool-types.rkt" tool?)
          (only-in "event-bus.rkt" event-bus?)
          (only-in "loop-stream.rkt" handle-cancellation build-stream-result)
          (only-in "loop-phases.rkt" phase-msg-hook phase-stream)

--- a/agent/loop-phases.rkt
+++ b/agent/loop-phases.rkt
@@ -37,7 +37,7 @@
                   make-turn-stream-complete
                   hook-stage-payload)
          (only-in "../llm/token-budget.rkt" estimate-context-tokens)
-         (only-in "../tools/tool.rkt" tool?)
+         (only-in "../util/tool-types.rkt" tool?)
          (only-in "event-bus.rkt" event-bus?)
          (only-in "loop-stream.rkt" stream-from-provider handle-cancellation build-stream-result)
          "../util/loop-result.rkt")

--- a/util/tool-types.rkt
+++ b/util/tool-types.rkt
@@ -1,13 +1,15 @@
 #lang racket/base
 
-;; util/tool-types.rkt — standalone tool-call and tool-result structs
+;; util/tool-types.rkt -- standalone tool-call and tool-result structs + tool? predicate
 ;;
-;; Canonical definitions for tool-call and tool-result data types.
-;; These are shared across the tool execution pipeline.
+;; Canonical definitions for tool data types.
+;; tool? re-exported from tools/tool-struct.rkt (A-2: avoids agent->tools layer violation).
 
-(require racket/contract)
+(require racket/contract
+         (only-in "../tools/tool-struct.rkt" tool?))
 
-(provide (contract-out [tool-call? (-> any/c boolean?)]
+(provide (contract-out [tool? (-> any/c boolean?)]
+                       [tool-call? (-> any/c boolean?)]
                        [tool-call-id (-> tool-call? (or/c string? #f))]
                        [tool-call-name (-> tool-call? (or/c string? #f))]
                        [tool-call-arguments (-> tool-call? any/c)]


### PR DESCRIPTION
W0: A-2 — Extract tool? to util/tool-types.rkt.\n\nRe-export tool? from tools/tool-struct.rkt via util/tool-types.rkt.\nUpdated loop-dispatch.rkt and loop-phases.rkt to import from util/.\n\nCloses #6227.