### PR TITLE
arch(v0.73.1 W1): A-3 move extension-registry? (#6228)

### DIFF
--- a/runtime/iteration/loop-state.rkt
+++ b/runtime/iteration/loop-state.rkt
@@ -25,7 +25,7 @@
 
 (require/typed "../../util/tool-registry-struct.rkt" [#:opaque ToolRegistry tool-registry?])
 
-(require/typed "../../extensions/api.rkt" [#:opaque ExtRegistry extension-registry?])
+(require/typed "../../util/extension-types.rkt" [#:opaque ExtRegistry extension-registry?])
 
 (require/typed "../../util/cancellation.rkt" [#:opaque CancellationToken cancellation-token?])
 

--- a/util/extension-types.rkt
+++ b/util/extension-types.rkt
@@ -1,11 +1,20 @@
 #lang racket/base
 
 ;; util/extension-types.rkt — Pure type definitions for extension context (M-06)
+;; A-3: Also provides extension-registry? predicate for Typed Racket boundary. — Pure type definitions for extension context (M-06)
 ;;
 ;; Contains only the struct definition with NO runtime/ or llm/ imports.
 ;; Runtime-dependent convenience methods stay in extensions/context.rkt.
 
-(provide extension-ctx
+(require racket/contract)
+
+;; A-3: Standalone extension-registry? predicate.
+;; Typed Racket #:opaque creates its own predicate; this is for untyped consumers.
+;; Matches the struct definition in extensions/api.rkt.
+(define extension-registry? procedure?)
+
+(provide (contract-out [extension-registry? (-> any/c boolean?)])
+         extension-ctx
          extension-ctx?
          extension-ctx-session-id
          extension-ctx-session-dir


### PR DESCRIPTION
W1: A-3 — Move extension-registry? to util/extension-types.rkt.\n\nStandalone predicate in util/ avoids heavy extensions/api.rkt import for Typed Racket boundary.\n\nCloses #6228.