### PR TITLE
quality(v0.73.1 W2): Q-1 now-epoch-ms/secs (#6229)

### DIFF
--- a/interfaces/sdk-core.rkt
+++ b/interfaces/sdk-core.rkt
@@ -59,7 +59,8 @@
                   in-memory-list-sessions
                   in-memory-fork!)
          (only-in "../util/loop-result.rkt" loop-result?)
-         "../util/cancellation.rkt")
+         "../util/cancellation.rkt"
+         (only-in "../util/time.rkt" now-epoch-secs))
 
 (provide (struct-out runtime-config)
          (struct-out runtime)
@@ -283,7 +284,7 @@
   (when sess
     (publish! bus
               (make-event "interrupt.requested"
-                          (exact-truncate (/ (current-inexact-milliseconds) 1000))
+                          (now-epoch-secs)
                           (session:session-id sess)
                           #f
                           (hasheq 'sessionId (session:session-id sess)))))
@@ -314,7 +315,7 @@
      (define sid (session:session-id sess))
      (publish! bus
                (make-event "compaction.started"
-                           (exact-truncate (/ (current-inexact-milliseconds) 1000))
+                           (now-epoch-secs)
                            sid
                            #f
                            (hasheq 'sessionId sid 'persist? persist?)))
@@ -329,7 +330,7 @@
            (compact-history history)))
      (publish! bus
                (make-event "compaction.completed"
-                           (exact-truncate (/ (current-inexact-milliseconds) 1000))
+                           (now-epoch-secs)
                            sid
                            #f
                            (hasheq 'sessionId

--- a/runtime/goal-checks.rkt
+++ b/runtime/goal-checks.rkt
@@ -12,7 +12,8 @@
          racket/list
          "goal-state.rkt"
          "../sandbox/subprocess.rkt"
-         "../tools/shell-risk.rkt")
+         "../tools/shell-risk.rkt"
+         (only-in "../util/time.rkt" now-epoch-ms))
 
 ;; ============================================================
 ;; Provides
@@ -130,13 +131,13 @@
        check-result?)
   (define cmd (goal-check-command check))
   (define label (goal-check-label check))
-  (define start-ms (inexact->exact (round (current-inexact-milliseconds))))
+  (define start-ms (now-epoch-ms))
   (define result
     (run-subprocess "/bin/sh"
                     #:args (list "-c" cmd)
                     #:timeout timeout
                     #:directory (or directory (current-directory))))
-  (define elapsed (- (inexact->exact (round (current-inexact-milliseconds))) start-ms))
+  (define elapsed (- (now-epoch-ms) start-ms))
   (check-result label
                 (or (subprocess-result-exit-code result) -1)
                 (string-truncate (or (subprocess-result-stdout result) "") 500)

--- a/runtime/goal-runner.rkt
+++ b/runtime/goal-runner.rkt
@@ -31,7 +31,8 @@
          "goal-agent-evaluator.rkt"
          "goal-evidence.rkt"
          "goal-checks.rkt"
-         "../llm/provider.rkt")
+         "../llm/provider.rkt"
+         (only-in "../util/time.rkt" now-epoch-ms))
 
 ;; ============================================================
 ;; Provides
@@ -113,7 +114,7 @@
        (struct-copy goal-state
                     goal-st
                     [status 'cancelled]
-                    [updated-at (inexact->exact (round (current-inexact-milliseconds)))]))
+                    [updated-at (now-epoch-ms)]))
      (on-event 'goal-failed
                (hasheq 'goal-text
                        (goal-state-goal-text final-st)
@@ -130,7 +131,7 @@
        (struct-copy goal-state
                     goal-st
                     [status 'failed]
-                    [updated-at (inexact->exact (round (current-inexact-milliseconds)))]))
+                    [updated-at (now-epoch-ms)]))
      (on-event 'goal-failed
                (hasheq 'goal-text
                        (goal-state-goal-text final-st)
@@ -146,7 +147,7 @@
        (struct-copy goal-state
                     goal-st
                     [status 'failed]
-                    [updated-at (inexact->exact (round (current-inexact-milliseconds)))]))
+                    [updated-at (now-epoch-ms)]))
      (on-event 'goal-failed
                (hasheq 'goal-text
                        (goal-state-goal-text final-st)
@@ -262,7 +263,7 @@
                     (evaluation-result-token-cost eval-result)))
 
   ;; Update goal state
-  (define now (inexact->exact (round (current-inexact-milliseconds))))
+  (define now (now-epoch-ms))
   (define new-status (if (evaluation-result-achieved? eval-result) 'achieved 'active))
 
   (struct-copy goal-state

--- a/runtime/goal-types.rkt
+++ b/runtime/goal-types.rkt
@@ -7,7 +7,8 @@
 
 (require racket/contract
          racket/format
-         "../util/ids.rkt")
+         "../util/ids.rkt"
+         (only-in "../util/time.rkt" now-epoch-ms))
 
 ;; Structs (no struct-out — use contracted constructors)
 (provide goal-state
@@ -213,8 +214,8 @@
               checks
               evaluations
               last-evaluation
-              (or started-at (inexact->exact (round (current-inexact-milliseconds))))
-              (or updated-at (inexact->exact (round (current-inexact-milliseconds))))
+              (or started-at (now-epoch-ms))
+              (or updated-at (now-epoch-ms))
               meta))
 
 ;; I4 (v0.72.7): Moved from goal-runner.rkt to be alongside goal-state struct

--- a/util/time.rkt
+++ b/util/time.rkt
@@ -1,12 +1,17 @@
 #lang racket/base
 
-;; util/time.rkt — Time utility functions
+;; util/time.rkt -- Time utility functions
 ;; Extracts the repeated (inexact->exact (round (current-inexact-milliseconds))) pattern.
 
 (require racket/contract)
 
-(provide (contract-out [now-epoch-ms (-> exact-nonnegative-integer?)]))
+(provide (contract-out [now-epoch-ms (-> exact-nonnegative-integer?)]
+                       [now-epoch-secs (-> exact-nonnegative-integer?)]))
 
 ;; Returns current time as epoch milliseconds (exact integer)
 (define (now-epoch-ms)
   (inexact->exact (round (current-inexact-milliseconds))))
+
+;; Returns current time as epoch seconds (exact integer)
+(define (now-epoch-secs)
+  (inexact->exact (round (/ (current-inexact-milliseconds) 1000))))


### PR DESCRIPTION
W2: Q-1 -- Adopt now-epoch-ms + add now-epoch-secs.\n\n- Added now-epoch-secs to util/time.rkt\n- Replaced 8 inline timestamp patterns across 4 files\n- Left sandbox/evaluator.rkt alone (uses inexact arithmetic for elapsed)\n\nCloses #6229.