### PR TITLE
quality(v0.73.1 W3): Q-2 stream-timing extraction (#6230)

### DIFF
--- a/llm/anthropic.rkt
+++ b/llm/anthropic.rkt
@@ -10,6 +10,7 @@
 ;; SSE parsing delegates to llm/stream.rkt.
 
 (require racket/contract
+         "timing.rkt"
          racket/match
          racket/string
          (only-in "model-defaults.rkt" ANTHROPIC-DEFAULT-MODEL ANTHROPIC-DEFAULT-BASE-URL)

--- a/llm/azure-openai.rkt
+++ b/llm/azure-openai.rkt
@@ -16,6 +16,7 @@
 (require "../util/errors.rkt")
 (require "provider-errors.rkt")
 (require racket/contract
+         "timing.rkt"
          (only-in "model-defaults.rkt" OPENAI-DEFAULT-MODEL)
          racket/string
          racket/generator
@@ -117,8 +118,7 @@
   (define headers (list (format "api-key: ~a" api-key) "Content-Type: application/json"))
   (define body-bytes (jsexpr->bytes body))
   (define response-port-box (box #f))
-  (log-info (format "[telemetry] azure-stream setup completed in ~a ms"
-                    (real->decimal-string (- (current-inexact-milliseconds) _stream-t0) 1)))
+  (log-stream-setup-timing "azure" _stream-t0)
   (dynamic-wind
    (lambda () (void))
    (lambda ()

--- a/llm/gemini.rkt
+++ b/llm/gemini.rkt
@@ -11,6 +11,7 @@
 ;; SSE parsing delegates to llm/stream.rkt.
 
 (require racket/contract
+         "timing.rkt"
          racket/match
          racket/string
          (only-in "model-defaults.rkt" GEMINI-DEFAULT-MODEL GEMINI-DEFAULT-BASE-URL)

--- a/llm/openai-compatible.rkt
+++ b/llm/openai-compatible.rkt
@@ -10,6 +10,7 @@
 ;; SSE parsing delegates to llm/stream.rkt.
 
 (require racket/contract
+         "timing.rkt"
          (only-in "model-defaults.rkt" OPENAI-DEFAULT-MODEL)
          racket/match
          racket/string
@@ -301,8 +302,7 @@
     ;; Simple wrapper: yield chunks until done, then close port.
     ;; No dynamic-wind — it fires before/after on every yield which
     ;; causes the port to be closed between yields.
-    (log-info (format "[telemetry] openai-stream setup completed in ~a ms"
-                      (real->decimal-string (- (current-inexact-milliseconds) _stream-t0) 1)))
+    (log-stream-setup-timing "openai" _stream-t0)
     (generator ()
                (let loop ()
                  (define chunk (gen))

--- a/llm/timing.rkt
+++ b/llm/timing.rkt
@@ -1,0 +1,17 @@
+#lang racket/base
+
+;; llm/timing.rkt -- Shared timing utility for LLM streaming providers (Q-2)
+;;
+;; Extracts the repeated _stream-t0 + log-info telemetry pattern.
+
+(require racket/contract
+         racket/format)
+
+(provide (contract-out [log-stream-setup-timing (-> string? exact-nonnegative-integer? void?)]))
+
+;; Log the elapsed time since stream setup started.
+;; Usage: (define t0 (current-inexact-milliseconds)) ... (log-stream-setup-timing "provider" t0)
+(define (log-stream-setup-timing provider-name start-ms)
+  (log-info (format "[telemetry] ~a-stream setup completed in ~a ms"
+                    provider-name
+                    (real->decimal-string (- (current-inexact-milliseconds) start-ms) 1))))


### PR DESCRIPTION
W3: Q-2 -- Extract with-stream-timing for LLM providers.\n\nCreated llm/timing.rkt with log-stream-setup-timing helper.\nReplaced inline _stream-t0 + log pattern in 4 providers.\n\nCloses #6230.