### PR TITLE
refactor(v0.73.4 W1+W2): move iteration/ → agent/iteration/ (#6259)

### DIFF
--- a/agent/iteration/counters.rkt
+++ b/agent/iteration/counters.rkt
@@ -25,8 +25,8 @@
                   tool-call-name)
          (only-in "../../runtime/tool-coordinator.rkt" extract-tool-calls-from-messages)
          (only-in "tool-turn-bridge.rkt" update-seen-paths take-at-most)
-         (only-in "../../agent/event-emitter.rkt" emit-typed-event!)
-         (only-in "../../agent/event-structs/hook-events.rkt" turn-cancelled-event)
+         (only-in "../event-emitter.rkt" emit-typed-event!)
+         (only-in "../event-structs/hook-events.rkt" turn-cancelled-event)
          (only-in "../../util/loop-result.rkt" make-loop-result)
          (only-in "../../util/cancellation.rkt" cancellation-token? cancellation-token-cancelled?))
 

--- a/agent/iteration/loop-config.rkt
+++ b/agent/iteration/loop-config.rkt
@@ -12,7 +12,7 @@
 
 (require racket/contract
          (only-in "../../llm/provider.rkt" provider?)
-         (only-in "../../agent/event-bus.rkt" event-bus?)
+         (only-in "../event-bus.rkt" event-bus?)
          (only-in "../../runtime/layer-adapters.rkt" tool-registry? extension-registry?)
          (only-in "../../util/cancellation.rkt" cancellation-token?)
          (only-in "../../runtime/session-config.rkt" session-config? hash->session-config)

--- a/agent/iteration/loop-phases.rkt
+++ b/agent/iteration/loop-phases.rkt
@@ -11,7 +11,7 @@
 
 (require racket/contract
          racket/list
-         (only-in "../../agent/event-bus.rkt" event-bus? publish!)
+         (only-in "../event-bus.rkt" event-bus? publish!)
          (only-in "../../util/event-contracts.rkt" injection-count-payload/c)
          (only-in "tool-turn-bridge.rkt" dequeue-all-steering! drain-injected-messages!)
          (only-in "loop-config.rkt"
@@ -20,11 +20,11 @@
                   loop-config-bus
                   loop-config-session-id
                   loop-config?)
-         (only-in "../../agent/queue.rkt" queue? queue-status)
+         (only-in "../queue.rkt" queue? queue-status)
          (only-in "../../runtime/runtime-helpers.rkt" maybe-dispatch-hooks emit-session-event!)
          (only-in "../../util/hook-types.rkt" hook-result-action hook-result?)
          (only-in "../../runtime/layer-adapters.rkt" extension-registry?)
-         (only-in "internal.rkt" assert-payload))
+         (only-in "../../runtime/iteration/internal.rkt" assert-payload))
 
 ;; Re-export for consumers
 (provide (contract-out [prepare-iteration-context

--- a/agent/iteration/loop-state.rkt
+++ b/agent/iteration/loop-state.rkt
@@ -21,7 +21,7 @@
 ;; ── Opaque types for untyped struct values ────────────────────
 ;; These avoid TR's any-wrap/c failure with opaque structs.
 
-(require/typed "../../agent/event-bus.rkt" [#:opaque EventBus event-bus?])
+(require/typed "../event-bus.rkt" [#:opaque EventBus event-bus?])
 
 (require/typed "../../util/tool-registry-struct.rkt" [#:opaque ToolRegistry tool-registry?])
 

--- a/agent/iteration/main-loop.rkt
+++ b/agent/iteration/main-loop.rkt
@@ -27,10 +27,10 @@
                   loop-result-messages
                   loop-result-metadata)
          (only-in "../../util/ids.rkt" generate-id)
-         (only-in "../../agent/event-emitter.rkt" emit-typed-event!)
-         (only-in "../../agent/event-structs/hook-events.rkt" turn-cancelled-event)
-         (only-in "../../agent/event-structs/iteration-events.rkt" make-iteration-decision-event)
-         (only-in "../../agent/queue.rkt"
+         (only-in "../event-emitter.rkt" emit-typed-event!)
+         (only-in "../event-structs/hook-events.rkt" turn-cancelled-event)
+         (only-in "../event-structs/iteration-events.rkt" make-iteration-decision-event)
+         (only-in "../queue.rkt"
                   queue-status
                   queue?
                   dequeue-followup!
@@ -52,13 +52,13 @@
                   resolve-max-iterations-hard)
          (only-in "../../llm/provider.rkt" provider?)
          (only-in "../../runtime/layer-adapters.rkt" tool-registry? extension-registry?)
-         (only-in "../../agent/event-bus.rkt" event-bus?)
+         (only-in "../event-bus.rkt" event-bus?)
          (only-in "../../util/loop-result.rkt" loop-result?)
          (only-in "counters.rkt" check-cancellation)
-         (only-in "decision.rkt" iteration-ctx compute-step-result)
+         (only-in "../../runtime/iteration/decision.rkt" iteration-ctx compute-step-result)
          (only-in "step-interpreter.rkt" interpret-step)
-         (only-in "directive.rkt" directive-recurse directive-stop directive-yield)
-         (only-in "fsm-types.rkt"
+         (only-in "../../runtime/iteration/directive.rkt" directive-recurse directive-stop directive-yield)
+         (only-in "../../runtime/iteration/fsm-types.rkt"
                   state-idle
                   state-provider-turn
                   state-decision
@@ -73,7 +73,7 @@
                   next-iteration-state
                   state->symbol
                   iteration-state?)
-         (only-in "internal.rkt" assert-payload)
+         (only-in "../../runtime/iteration/internal.rkt" assert-payload)
          (only-in "loop-phases.rkt" prepare-iteration-context dispatch-turn-start-hooks)
          (only-in "loop-config.rkt"
                   loop-config?

--- a/agent/iteration/step-interpreter.rkt
+++ b/agent/iteration/step-interpreter.rkt
@@ -42,12 +42,12 @@
                   handle-tool-calls-pending
                   extract-tool-calls-from-messages)
          (only-in "../../runtime/runtime-helpers.rkt" emit-session-event! maybe-dispatch-hooks)
-         (only-in "effect-executor.rkt"
+         (only-in "../../runtime/iteration/effect-executor.rkt"
                   step-effect:append-entries
                   step-effect:emit-event
                   run-step-effects!)
          (only-in "../../util/hook-types.rkt" hook-result-action hook-result?)
-         (only-in "../../agent/event-emitter.rkt" emit-typed-event!)
+         (only-in "../event-emitter.rkt" emit-typed-event!)
          (only-in "../../util/event-contracts.rkt"
                   error-detail-payload/c
                   iteration-decision-payload/c
@@ -69,13 +69,13 @@
          (only-in "tool-turn-bridge.rkt" extract-tool-target-path)
          (only-in "../../runtime/context-policy.rkt" estimate-message-tokens)
          (only-in "../../runtime/session-compaction.rkt" compact-context-mid-turn)
-         (only-in "retry-policy.rkt"
+         (only-in "../../runtime/iteration/retry-policy.rkt"
                   estimate-mid-turn-tokens
                   maybe-compact-mid-turn
                   detect-exploration-loop)
-         (only-in "decision.rkt" step-result step-result-action step-result-new-counters)
-         (only-in "internal.rkt" assert-payload)
-         (only-in "directive.rkt" directive-recurse directive-stop))
+         (only-in "../../runtime/iteration/decision.rkt" step-result step-result-action step-result-new-counters)
+         (only-in "../../runtime/iteration/internal.rkt" assert-payload)
+         (only-in "../../runtime/iteration/directive.rkt" directive-recurse directive-stop))
 
 (provide interpret-step
          handle-stop-action

--- a/agent/iteration/tool-turn-bridge.rkt
+++ b/agent/iteration/tool-turn-bridge.rkt
@@ -21,10 +21,10 @@
                   tool-result-part-is-error?
                   event-ev
                   event-payload)
-         "../../agent/event-bus.rkt"
-         (only-in "../../agent/queue.rkt" dequeue-steering! dequeue-followup! dequeue-all-followups!)
-         "../working-set.rkt"
-         (only-in "../context-policy.rkt" estimate-message-tokens)
+         "../event-bus.rkt"
+         (only-in "../queue.rkt" dequeue-steering! dequeue-followup! dequeue-all-followups!)
+         "../../runtime/working-set.rkt"
+         (only-in "../../runtime/context-policy.rkt" estimate-message-tokens)
          (only-in "../../util/event-types.rkt" injection-event-topic)
          (only-in "../../util/shared.rkt" take-at-most))
 

--- a/runtime/iteration/decision.rkt
+++ b/runtime/iteration/decision.rkt
@@ -14,9 +14,9 @@
 
 (require racket/contract
          racket/match
-         (only-in "counters.rkt" compute-next-counters)
+         (only-in "../../agent/iteration/counters.rkt" compute-next-counters)
          (only-in "../../util/loop-result.rkt" loop-result-termination-reason loop-result-messages)
-         (only-in "loop-state.rkt"
+         (only-in "../../agent/iteration/loop-state.rkt"
                   loop-counters
                   loop-counters-iteration
                   loop-counters-consecutive-tool-count

--- a/runtime/iteration/effect-executor.rkt
+++ b/runtime/iteration/effect-executor.rkt
@@ -8,7 +8,7 @@
 
 (require racket/contract
          racket/match
-         (only-in "loop-state.rkt"
+         (only-in "../../agent/iteration/loop-state.rkt"
                   loop-infra
                   loop-infra-bus
                   loop-infra-session-id

--- a/runtime/session-lifecycle.rkt
+++ b/runtime/session-lifecycle.rkt
@@ -48,8 +48,8 @@
          (only-in "../runtime/session-context.rkt" extract-path-settings)
          "../util/ids.rkt"
          (only-in "runtime-helpers.rkt" emit-session-event! maybe-dispatch-hooks)
-         (only-in "iteration/main-loop.rkt" run-iteration-loop/v2)
-         (only-in "iteration/loop-config.rkt" make-loop-config)
+         (only-in "../agent/iteration/main-loop.rkt" run-iteration-loop/v2)
+         (only-in "../agent/iteration/loop-config.rkt" make-loop-config)
          (only-in "../agent/event-emitter.rkt" emit-typed-event!)
          (only-in "../agent/event-structs/turn-events.rkt" turn-end-event turn-start-event)
          "session-types.rkt"

--- a/tests/test-di-keyword-args.rkt
+++ b/tests/test-di-keyword-args.rkt
@@ -10,7 +10,7 @@
 
 (require rackunit
          rackunit/text-ui
-         (only-in "../runtime/iteration/main-loop.rkt" run-iteration-loop)
+         (only-in "../agent/iteration/main-loop.rkt" run-iteration-loop)
          (only-in "../runtime/iteration/retry-policy.rkt"
                   call-with-overflow-recovery
                   check-mid-turn-budget!)

--- a/tests/test-followup-queue.rkt
+++ b/tests/test-followup-queue.rkt
@@ -15,7 +15,7 @@
 (require rackunit
          "../agent/queue.rkt"
          "../agent/event-bus.rkt"
-         (only-in "../runtime/iteration/main-loop.rkt" run-iteration-loop)
+         (only-in "../agent/iteration/main-loop.rkt" run-iteration-loop)
          "../tui/state.rkt"
          "../util/protocol-types.rkt")
 

--- a/tests/test-hooks-complete.rkt
+++ b/tests/test-hooks-complete.rkt
@@ -13,7 +13,7 @@
          "../agent/state.rkt"
          "../extensions/hooks.rkt"
          "../extensions/api.rkt"
-         (only-in "../runtime/iteration/main-loop.rkt" run-iteration-loop)
+         (only-in "../agent/iteration/main-loop.rkt" run-iteration-loop)
          (only-in "../runtime/runtime-helpers.rkt" maybe-dispatch-hooks)
          "../runtime/agent-session.rkt"
          "../skills/types.rkt"

--- a/tests/test-iteration-counters-unit.rkt
+++ b/tests/test-iteration-counters-unit.rkt
@@ -9,8 +9,8 @@
 
 (require rackunit
          rackunit/text-ui
-         "../runtime/iteration/counters.rkt"
-         "../runtime/iteration/loop-state.rkt"
+         "../agent/iteration/counters.rkt"
+         "../agent/iteration/loop-state.rkt"
          (only-in "../util/message.rkt" make-message)
          (only-in "../util/content-parts.rkt" make-tool-call-part))
 

--- a/tests/test-iteration-counters.rkt
+++ b/tests/test-iteration-counters.rkt
@@ -10,8 +10,8 @@
 (require rackunit
          rackunit/text-ui
          racket/match
-         "../runtime/iteration/loop-state.rkt"
-         (only-in "../runtime/iteration/counters.rkt" compute-next-counters)
+         "../agent/iteration/loop-state.rkt"
+         (only-in "../agent/iteration/counters.rkt" compute-next-counters)
          (only-in "../util/protocol-types.rkt"
                   make-message
                   make-text-part

--- a/tests/test-iteration-decision.rkt
+++ b/tests/test-iteration-decision.rkt
@@ -6,7 +6,7 @@
 (require rackunit
          rackunit/text-ui
          "../runtime/iteration/decision.rkt"
-         "../runtime/iteration/loop-state.rkt"
+         "../agent/iteration/loop-state.rkt"
          "../util/loop-result.rkt")
 
 (define helper-suite

--- a/tests/test-iteration-edge-cases.rkt
+++ b/tests/test-iteration-edge-cases.rkt
@@ -11,7 +11,7 @@
 ;; - v0.19.10: spiral breaker event structure
 
 (require rackunit
-         (only-in "../runtime/iteration/tool-turn-bridge.rkt" update-seen-paths)
+         (only-in "../agent/iteration/tool-turn-bridge.rkt" update-seen-paths)
          (only-in "../util/json-helpers.rkt" ensure-hash-args)
          "../agent/event-bus.rkt"
          "../util/protocol-types.rkt"

--- a/tests/test-iteration-exploration.rkt
+++ b/tests/test-iteration-exploration.rkt
@@ -7,7 +7,7 @@
 ;; Verifies increased iteration budgets and exploration steering hint injection.
 
 (require rackunit
-         (only-in "../runtime/iteration/main-loop.rkt" run-iteration-loop))
+         (only-in "../agent/iteration/main-loop.rkt" run-iteration-loop))
 
 ;; ============================================================
 ;; Iteration budget defaults

--- a/tests/test-iteration-fsm.rkt
+++ b/tests/test-iteration-fsm.rkt
@@ -7,7 +7,7 @@
 (require rackunit
          rackunit/text-ui
          "../runtime/iteration/fsm-types.rkt"
-         (only-in "../runtime/iteration/main-loop.rkt" current-iteration-fsm-state))
+         (only-in "../agent/iteration/main-loop.rkt" current-iteration-fsm-state))
 
 (define fsm-suite
   (test-suite "Iteration FSM tests"

--- a/tests/test-iteration-integration.rkt
+++ b/tests/test-iteration-integration.rkt
@@ -9,17 +9,17 @@
          (only-in "../runtime/session-config.rkt" hash->session-config)
          racket/set
          racket/file
-         (only-in "../runtime/iteration/step-interpreter.rkt"
+         (only-in "../agent/iteration/step-interpreter.rkt"
                   handle-stop-action
                   interpret-step
                   execute-pending-tool-calls)
-         (only-in "../runtime/iteration/counters.rkt" compute-next-counters check-cancellation)
+         (only-in "../agent/iteration/counters.rkt" compute-next-counters check-cancellation)
          (only-in "../runtime/iteration/decision.rkt"
                   decide-next-action
                   compute-step-result
                   iteration-ctx
                   step-result)
-         (only-in "../runtime/iteration/loop-state.rkt"
+         (only-in "../agent/iteration/loop-state.rkt"
                   make-initial-counters
                   loop-infra
                   iteration-snapshot
@@ -51,11 +51,11 @@
                   cancellation-token-cancelled?)
          (only-in "../util/event.rkt" event-ev)
          (only-in "../runtime/iteration/decision.rkt" step-result)
-         (only-in "../runtime/iteration/step-interpreter.rkt"
+         (only-in "../agent/iteration/step-interpreter.rkt"
                   handle-stop-action
                   interpret-step
                   execute-pending-tool-calls)
-         (only-in "../runtime/iteration/counters.rkt" compute-next-counters check-cancellation)
+         (only-in "../agent/iteration/counters.rkt" compute-next-counters check-cancellation)
          (only-in "../runtime/iteration/decision.rkt"
                   decide-next-action
                   compute-step-result

--- a/tests/test-iteration-loop-state.rkt
+++ b/tests/test-iteration-loop-state.rkt
@@ -6,7 +6,7 @@
 
 (require rackunit
          rackunit/text-ui
-         "../runtime/iteration/loop-state.rkt"
+         "../agent/iteration/loop-state.rkt"
          "../agent/event-bus.rkt"
          racket/set)
 

--- a/tests/test-iteration-main-loop.rkt
+++ b/tests/test-iteration-main-loop.rkt
@@ -9,8 +9,8 @@
 
 (require rackunit
          rackunit/text-ui
-         "../runtime/iteration/main-loop.rkt"
-         "../runtime/iteration/loop-state.rkt"
+         "../agent/iteration/main-loop.rkt"
+         "../agent/iteration/loop-state.rkt"
          (only-in "../agent/event-bus.rkt" make-event-bus)
          (only-in "../llm/provider.rkt" make-provider)
          (only-in "../util/protocol-types.rkt" make-message make-text-part message-role)

--- a/tests/test-iteration-observability.rkt
+++ b/tests/test-iteration-observability.rkt
@@ -9,7 +9,7 @@
          racket/list
          racket/file
          "../runtime/working-set.rkt"
-         (only-in "../runtime/iteration/main-loop.rkt" run-iteration-loop)
+         (only-in "../agent/iteration/main-loop.rkt" run-iteration-loop)
          "../runtime/turn-orchestrator.rkt"
          "../runtime/agent-session.rkt"
          "../runtime/session-types.rkt"

--- a/tests/test-iteration-pure.rkt
+++ b/tests/test-iteration-pure.rkt
@@ -11,7 +11,7 @@
 (require rackunit
          rackunit/text-ui
          "../runtime/iteration/decision.rkt"
-         "../runtime/iteration/loop-state.rkt"
+         "../agent/iteration/loop-state.rkt"
          (only-in "../util/loop-result.rkt"
                   make-loop-result
                   loop-result-termination-reason

--- a/tests/test-iteration-snapshot-ws.rkt
+++ b/tests/test-iteration-snapshot-ws.rkt
@@ -9,7 +9,7 @@
 ;; without any-wrap/c contract failure.
 
 (require rackunit
-         (only-in "../runtime/iteration/loop-state.rkt"
+         (only-in "../agent/iteration/loop-state.rkt"
                   iteration-snapshot
                   iteration-snapshot?
                   iteration-snapshot-counters

--- a/tests/test-iteration-step-interpreter.rkt
+++ b/tests/test-iteration-step-interpreter.rkt
@@ -10,8 +10,8 @@
 
 (require rackunit
          rackunit/text-ui
-         "../runtime/iteration/main-loop.rkt"
-         "../runtime/iteration/loop-state.rkt"
+         "../agent/iteration/main-loop.rkt"
+         "../agent/iteration/loop-state.rkt"
          (only-in "../agent/event-bus.rkt" make-event-bus)
          (only-in "../llm/provider.rkt" make-provider)
          (only-in "../llm/model.rkt" make-model-response make-stream-chunk)

--- a/tests/test-iteration-tool-bridge.rkt
+++ b/tests/test-iteration-tool-bridge.rkt
@@ -7,7 +7,7 @@
 (require rackunit
          rackunit/text-ui
          racket/set
-         "../runtime/iteration/tool-turn-bridge.rkt"
+         "../agent/iteration/tool-turn-bridge.rkt"
          "../runtime/working-set.rkt"
          "../util/protocol-types.rkt")
 

--- a/tests/test-iteration-transitions.rkt
+++ b/tests/test-iteration-transitions.rkt
@@ -14,7 +14,7 @@
          "../util/hook-types.rkt"
          "../agent/event-bus.rkt"
          "../agent/queue.rkt"
-         (only-in "../runtime/iteration/main-loop.rkt" run-iteration-loop)
+         (only-in "../agent/iteration/main-loop.rkt" run-iteration-loop)
          "../llm/model.rkt"
          "../llm/provider.rkt"
          (only-in "../tools/tool.rkt"

--- a/tests/test-iteration-working-set.rkt
+++ b/tests/test-iteration-working-set.rkt
@@ -8,7 +8,7 @@
          rackunit/text-ui
          racket/list
          "../runtime/working-set.rkt"
-         (only-in "../runtime/iteration/main-loop.rkt" run-iteration-loop)
+         (only-in "../agent/iteration/main-loop.rkt" run-iteration-loop)
          "../util/protocol-types.rkt"
          "../agent/event-bus.rkt"
          "../util/ids.rkt"

--- a/tests/test-iteration.rkt
+++ b/tests/test-iteration.rkt
@@ -10,7 +10,7 @@
          "../agent/queue.rkt"
          "../agent/event-bus.rkt"
          "../util/ids.rkt"
-         (only-in "../runtime/iteration/main-loop.rkt" run-iteration-loop)
+         (only-in "../agent/iteration/main-loop.rkt" run-iteration-loop)
          (only-in "../util/json-helpers.rkt" ensure-hash-args)
          (only-in "../llm/provider.rkt" make-mock-provider)
          (only-in "../llm/model.rkt" make-model-response))

--- a/tests/test-loop-phases.rkt
+++ b/tests/test-loop-phases.rkt
@@ -6,7 +6,7 @@
 
 (require rackunit
          rackunit/text-ui
-         "../runtime/iteration/loop-phases.rkt"
+         "../agent/iteration/loop-phases.rkt"
          "../agent/event-bus.rkt"
          "../agent/queue.rkt")
 

--- a/tests/test-message-inject.rkt
+++ b/tests/test-message-inject.rkt
@@ -155,7 +155,7 @@
 ;; FEAT-61: Iteration loop integration
 ;; ============================================================
 
-(require (only-in "../runtime/iteration/tool-turn-bridge.rkt"
+(require (only-in "../agent/iteration/tool-turn-bridge.rkt"
                   make-injected-collector!
                   drain-injected-messages!))
 

--- a/tests/test-soft-iteration.rkt
+++ b/tests/test-soft-iteration.rkt
@@ -14,7 +14,7 @@
          "../llm/model.rkt"
          "../llm/provider.rkt"
          (only-in "../tools/tool.rkt" make-tool-registry register-tool! make-tool make-error-result)
-         (only-in "../runtime/iteration/main-loop.rkt" run-iteration-loop)
+         (only-in "../agent/iteration/main-loop.rkt" run-iteration-loop)
          (only-in "../runtime/session-config.rkt" hash->session-config))
 
 ;; ============================================================

--- a/tests/test-steering.rkt
+++ b/tests/test-steering.rkt
@@ -9,7 +9,7 @@
          rackunit/text-ui
          racket/set
          "../util/protocol-types.rkt"
-         (only-in "../runtime/iteration/tool-turn-bridge.rkt"
+         (only-in "../agent/iteration/tool-turn-bridge.rkt"
                   extract-tool-target-path
                   update-seen-paths))
 


### PR DESCRIPTION
W1+W2: Move runtime/iteration/ → agent/iteration/ for 7 files with agent/ coupling.\n\nUpdate ~80 import paths. All M1-M4 tests pass.\n\nCloses #6261. Closes #6262.