### PR TITLE
fix(v0.73.6 W2): flaky sleep test — T-5 (#6273)

### DIFF
--- a/tests/test-sandbox-limits.rkt
+++ b/tests/test-sandbox-limits.rkt
@@ -136,7 +136,7 @@
 (test-case "with-resource-limits returns timed-out on timeout"
   (define-values (result timed-out?)
     (with-resource-limits (λ (cust)
-                            (sleep 10)
+                            (sleep 2)
                             'done)
                           #:timeout 0.1))
   (check-false result)


### PR DESCRIPTION
W2: Reduce flaky sleep 10→2 in sandbox limits test. Closes #6276.