### PR TITLE
feat(v0.73.7 W2): sandbox contracts — A-6b (#6282)

### DIFF
--- a/sandbox/evaluator.rkt
+++ b/sandbox/evaluator.rkt
@@ -5,18 +5,29 @@
 ;; Uses Racket's built-in racket/sandbox module to evaluate Racket code
 ;; safely with timeout and resource limits.
 
-(require racket/sandbox
+(require racket/contract
+         racket/sandbox
          (only-in "../util/errors.rkt" with-logged-catch))
 
-(provide eval-result
-         eval-result?
-         eval-result-value
-         eval-result-output
-         eval-result-error
-         eval-result-elapsed-ms
-         eval-in-sandbox
-         current-sandbox-memory-limit
-         current-sandbox-path-limit)
+(provide
+ ;; Struct (transparent, no contract needed)
+ eval-result
+ eval-result?
+ eval-result-value
+ eval-result-output
+ eval-result-error
+ eval-result-elapsed-ms
+ ;; Parameters
+ current-sandbox-memory-limit
+ current-sandbox-path-limit
+ ;; Contracted
+ (contract-out
+  [eval-in-sandbox
+   (->* (string?)
+        (#:timeout number?
+         #:language symbol?
+         #:allow-for-load (listof string?))
+        eval-result?)]))
 
 ;; --------------------------------------------------
 ;; Configurable limits (SEC-09)

--- a/sandbox/subprocess.rkt
+++ b/sandbox/subprocess.rkt
@@ -6,7 +6,8 @@
 ;; custodian-based cleanup. Every subprocess runs under its own custodian
 ;; so that timeout or kill cleans up all associated resources.
 
-(require racket/port
+(require racket/contract
+         racket/port
          racket/string
          "limits.rkt"
          ;; SEC-16 (v0.22.0): consolidated shell-quote
@@ -14,22 +15,35 @@
 
 (define-logger subprocess)
 
-(provide subprocess-result
-         subprocess-result?
-         subprocess-result-exit-code
-         subprocess-result-stdout
-         subprocess-result-stderr
-         subprocess-result-timed-out?
-         subprocess-result-elapsed-ms
-         subprocess-result-truncated?
-         run-subprocess
-         kill-subprocess!
-         default-timeout-seconds
-         default-max-output-bytes
-         sanitize-env
-         secret-env-var?
-         current-secret-scrub-denylist
-         current-secret-scrub-allowlist)
+(provide
+ ;; Struct accessors (no contract needed for transparent struct)
+ subprocess-result
+ subprocess-result?
+ subprocess-result-exit-code
+ subprocess-result-stdout
+ subprocess-result-stderr
+ subprocess-result-timed-out?
+ subprocess-result-elapsed-ms
+ subprocess-result-truncated?
+ ;; Parameters (no contract needed)
+ default-timeout-seconds
+ default-max-output-bytes
+ current-secret-scrub-denylist
+ current-secret-scrub-allowlist
+ ;; Contracted functions
+ (contract-out
+  [run-subprocess
+   (->* (string?)
+        (#:args (listof string?)
+         #:limits exec-limits?
+         #:timeout (or/c number? #f)
+         #:directory (or/c path-string? #f)
+         #:environment any/c
+         #:encoding symbol?)
+        subprocess-result?)]
+  [kill-subprocess! (-> any/c void?)]
+  [sanitize-env (->* () (any/c) any/c)]
+  [secret-env-var? (-> string? boolean?)]))
 
 ;; --------------------------------------------------
 ;; Result struct


### PR DESCRIPTION
W2: Add contract-out to sandbox/subprocess.rkt and sandbox/evaluator.rkt. Closes #6285.