### PR TITLE
fix(v0.73.8 W0): extension-registry? contract violation — C1 (#6291)

### DIFF
--- a/util/extension-types.rkt
+++ b/util/extension-types.rkt
@@ -8,10 +8,10 @@
 
 (require racket/contract)
 
-;; A-3: Standalone extension-registry? predicate.
+;; A-3: Re-export the real extension-registry? struct predicate.
 ;; Typed Racket #:opaque creates its own predicate; this is for untyped consumers.
-;; Matches the struct definition in extensions/api.rkt.
-(define extension-registry? procedure?)
+;; Must match the actual struct in extensions/api.rkt to avoid any-wrap/c violations.
+(require (only-in "../extensions/api.rkt" extension-registry?))
 
 (provide (contract-out [extension-registry? (-> any/c boolean?)])
          extension-ctx


### PR DESCRIPTION
W0: Replace fake `procedure?` predicate with real `extension-registry?` re-export from `extensions/api.rkt`. Fixes C1 CRITICAL — any-wrap/c violation in `--gui` mode. Closes #6292.