### PR TITLE
refactor(v0.73.8 W2): shared timing adoption (#6291)

### DIFF
--- a/llm/anthropic.rkt
+++ b/llm/anthropic.rkt
@@ -355,8 +355,7 @@
        (define current-tool-id (box #f))
        (define current-tool-name (box #f))
        (define current-tool-index (box 0))
-       (log-info (format "[telemetry] anthropic-stream setup completed in ~a ms"
-                         (real->decimal-string (- (current-inexact-milliseconds) _stream-t0) 1)))
+       (log-stream-setup-timing "anthropic" _stream-t0)
        (generator ()
                   (let loop ([first-read? #t])
                     (define timeout-secs

--- a/llm/gemini.rkt
+++ b/llm/gemini.rkt
@@ -426,8 +426,7 @@
        (parameterize ([gemini-tool-id-counter-param 0])
          ;; Incremental SSE parsing — generator yields chunks one at a time
          (define raw-port response-port)
-         (log-info (format "[telemetry] gemini-stream setup completed in ~a ms"
-                           (real->decimal-string (- (current-inexact-milliseconds) _stream-t0) 1)))
+         (log-stream-setup-timing "gemini" _stream-t0)
          (generator ()
                     (let loop ([first-read? #t])
                       (define timeout-secs

--- a/llm/timing.rkt
+++ b/llm/timing.rkt
@@ -7,7 +7,7 @@
 (require racket/contract
          racket/format)
 
-(provide (contract-out [log-stream-setup-timing (-> string? exact-nonnegative-integer? void?)]))
+(provide (contract-out [log-stream-setup-timing (-> string? real? void?)]))
 
 ;; Log the elapsed time since stream setup started.
 ;; Usage: (define t0 (current-inexact-milliseconds)) ... (log-stream-setup-timing "provider" t0)


### PR DESCRIPTION
W2: Fix `timing.rkt` contract to accept `real?` (inexact numbers). Replace inline timing logs in `anthropic.rkt` and `gemini.rkt` with shared `log-stream-setup-timing`. Closes #6294.