### PR TITLE
feat(v0.73.8 W3): contract-out step-interpreter + version bump (#6291)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v0.73.8 -- 2026-05-30
+
+### Audit Closure (A-7)
+
+- **CRITICAL:** Fix `extension-registry?` contract violation — replaced fake `procedure?` predicate with real re-export from `extensions/api.rkt` (C1)
+- **W1:** Activate dead loggers — remove dead `define-logger` from `loop-fsm.rkt`, add 4 `log-q-main-loop-info` calls at FSM transition sites in `main-loop.rkt`
+- **W2:** Complete shared timing adoption — fix `timing.rkt` contract to accept `real?`, replace inline timing logs in `anthropic.rkt` and `gemini.rkt`
+- **W3:** Add `contract-out` to `step-interpreter.rkt` for `interpret-step`, `handle-stop-action`, `execute-pending-tool-calls`, `sink-append-entries!`
+
 ## v0.73.7 -- 2026-05-30
 
 ### Extension Tests + Contract Completion (T-6/A-6b)

--- a/README.md
+++ b/README.md
@@ -552,6 +552,9 @@ When q executes shell commands on behalf of an LLM, arguments are quoted via `sh
 
 
 
+
+**v0.73.8** — Core Loop Tests: Pure Functions (T-1a)
+
 **v0.73.7** — Core Loop Tests: Pure Functions (T-1a)
 
 **v0.73.6** — Core Loop Tests: Pure Functions (T-1a)

--- a/agent/iteration/step-interpreter.rkt
+++ b/agent/iteration/step-interpreter.rkt
@@ -9,7 +9,8 @@
 ;;   handle-stop-action     — handle 'stop action from decide-next-action
 ;;   execute-pending-tool-calls — execute pending tool calls, update working set
 
-(require racket/match
+(require racket/contract
+         racket/match
          racket/class
          racket/list
          (only-in "loop-state.rkt"
@@ -77,11 +78,11 @@
          (only-in "../../runtime/iteration/internal.rkt" assert-payload)
          (only-in "../../runtime/iteration/directive.rkt" directive-recurse directive-stop))
 
-(provide interpret-step
-         handle-stop-action
-         execute-pending-tool-calls
-         ;; R-09/R-10: Optional sink for dependency injection
-         sink-append-entries!)
+(provide (contract-out
+          [interpret-step (-> any/c any/c any/c any/c any/c any/c)]
+          [handle-stop-action (-> any/c any/c any/c any/c any/c any/c any/c)]
+          [execute-pending-tool-calls (-> any/c any/c any/c any/c any/c)]
+          [sink-append-entries! (->* (any/c any/c) (any/c) void?)]))
 
 ;; ============================================================
 ;; R-09/R-10: Sink-aware append helper

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.73.7")
+(define version "0.73.8")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base" "gui-easy-lib"))

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -11,4 +11,4 @@
 
 (provide (contract-out [q-version string?]))
 
-(define q-version "0.73.7")
+(define q-version "0.73.8")


### PR DESCRIPTION
W3: Add `contract-out` to `step-interpreter.rkt`. Version bump 0.73.7 → 0.73.8. CHANGELOG + README + metrics sync. Closes #6295. Closes #6291.