### PR TITLE
fix(v0.74.7 W0): stale loop-state.rkt references (#6342)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v0.74.7 -- 2026-05-31
+
+### Audit Closure (W0)
+- Fixed stale `loop-state.rkt` references (moved from `runtime/` to `agent/` in v0.73.4)
+- Updated `dependency-policy.rktd`: moved exception to `agent` layer, updated sub-modules
+- Updated `test-arch-fitness.rkt`: corrected TR module path
+- Arch-fitness test failures: 2 → 0
+
+
 ## v0.74.6 -- 2026-05-30
 
 ### Architecture Controls & Release (M7)

--- a/docs/architecture/dependency-policy.rktd
+++ b/docs/architecture/dependency-policy.rktd
@@ -15,6 +15,9 @@
    (forbidden-from . (llm tools extensions))
    (rationale
     . "Runtime should not import upward into tools/extensions except via documented exceptions (includes iteration/ submodules and layer-adapters)"))
+  (agent (max-exceptions . 2)
+       (forbidden-from . (llm))
+       (rationale . "Agent layer types; minimal cross-boundary imports"))
   (tui (max-exceptions . 0)
        (forbidden-from . (llm tools))
        (allowed-from . (runtime agent extensions util)))
@@ -34,10 +37,6 @@
        (rationale . "explicit adapter facade routing tool/extension deps behind contained boundary")
        (owner . "runtime")
        (revisit-by . "2026-07-01"))
-      (iteration/loop-state.rkt
-       (rationale . "typed require from extensions/api.rkt for opaque ExtRegistry")
-       (owner . "iteration")
-       (revisit-by . "2026-08-01"))
       (agent-session.rkt (rationale . "list-extensions via adapter (re-exports extension listing)")
                          (owner . "runtime")
                          (revisit-by . "2026-07-01"))
@@ -107,11 +106,16 @@
                    (sub-modules . (binding-resolver default-map mode-map))
                    (budget . 150)
                    (convention . "Keymap resolution and default maps."))
+  (agent/iteration
+   (parent . "agent/iteration.rkt")
+   (sub-modules . (loop-state counters step-interpreter main-loop tool-turn-bridge loop-config loop-phases))
+   (budget . 400)
+   (convention . "Agent iteration loop. Migrated from runtime/ in v0.73.4. TR module in loop-state."))
   (runtime/iteration
    (parent . "runtime/iteration.rkt")
    (sub-modules
     .
-    (loop-state retry-policy tool-turn-bridge counters decision step-interpreter main-loop internal))
+    (fsm-types directive retry-policy tool-turn-bridge counters decision step-interpreter main-loop internal))
    (budget . 450)
    (convention
     . "Iteration loop decomposition. Pure logic in counters/decision, effectful in step-interpreter, orchestration in main-loop."))

--- a/tests/test-arch-fitness.rkt
+++ b/tests/test-arch-fitness.rkt
@@ -283,7 +283,7 @@
         "util/event-payloads.rkt"
         "extensions/gsd/plan-types.rkt"
         "extensions/gsd/plan-validator.rkt"
-        "runtime/iteration/loop-state.rkt"
+        "agent/iteration/loop-state.rkt"
         "runtime/iteration/retry-policy.rkt"))
 
 (define v02810-suite


### PR DESCRIPTION
W0: Fix stale loop-state.rkt references. Arch-fitness failures: 2 → 0. Closes #6343.