### PR TITLE
fix(v0.74.8 W0): build-tiered-context-with-hooks contract (#6349)

### DIFF
--- a/runtime/context-assembly.rkt
+++ b/runtime/context-assembly.rkt
@@ -50,7 +50,8 @@
                   simple-summary-count
                   extract-message-text
                   truncate-string)
-         (only-in "../util/message.rkt" message?))
+         (only-in "../util/message.rkt" message?)
+         (only-in "../util/hook-types.rkt" hook-result?))
 
 ;; Explicit re-exports from sub-modules (S1-F4)
 ;; Struct: context-assembly-config
@@ -159,7 +160,7 @@
                                 #:hook-dispatcher (or/c procedure? #f)
                                 #:max-tokens exact-nonnegative-integer?
                                 #:working-set-messages (or/c (listof message?) #f))
-                (values tiered-context? (or/c hash? #f)))]
+                (values tiered-context? (or/c hook-result? #f)))]
           [compute-dynamic-tier-b-count (-> exact-nonnegative-integer? exact-nonnegative-integer?)]
           [summarize-tool-result (-> message? message?)]
           ;; Struct: context-assembly-payload

--- a/tests/test-compactor.rkt
+++ b/tests/test-compactor.rkt
@@ -438,6 +438,16 @@
    ;; Tiers should be unchanged
    (check-equal? (length (tiered-context-tier-c tc)) 3)
    (check-equal? (length (tiered-context-tier-b tc)) 5))
+ (test-case "build-tiered-context-with-hooks contract accepts hook-result (regression v0.74.8)"
+   (define msgs (make-n-messages 10))
+   (define pass-hook (λ (hook-point data) (hook-pass data)))
+   (define-values (tc hr)
+     (build-tiered-context-with-hooks msgs
+                                      #:hook-dispatcher pass-hook
+                                      #:tier-b-count 3
+                                      #:tier-c-count 2))
+   (check-pred hook-result? hr)
+   (check-equal? (hook-result-action hr) 'pass))
  (test-case "build-tiered-context-with-hooks: hook returns 'amend"
    ;; Hook that modifies tier composition via amend
    (define msgs (make-n-messages 20))


### PR DESCRIPTION
W0: P0 contract bugfix. (or/c hash? #f) → (or/c hook-result? #f). Regression test added. Closes #6350.