### PR TITLE
feat(v0.75.0 W0): task-state FSM definition (#6356)

### DIFF
--- a/runtime/context-assembly/task-state.rkt
+++ b/runtime/context-assembly/task-state.rkt
@@ -1,0 +1,150 @@
+#lang racket/base
+
+;; runtime/context-assembly/task-state.rkt — Task-state FSM for context optimization
+;; STABILITY: evolving
+;;
+;; Defines FSM states for tracking what the agent is doing (exploring,
+;; planning, implementing, verifying, debugging) and uses that state to
+;; optimize context assembly — replacing raw file contents with agent-authored
+;; conclusions once exploration is complete.
+;;
+;; Uses define-fsm-machine macro from util/fsm.rkt (proven since v0.47.1).
+;; 6 states, 8 events, 18 transitions (including explicit "any->X" expansions).
+
+(require racket/contract
+         (only-in "../../util/fsm.rkt"
+                  define-fsm-machine
+                  fsm-state
+                  fsm-state-name
+                  fsm-state?
+                  fsm-event
+                  fsm-event-name
+                  fsm-event?
+                  fsm?
+                  fsm-states
+                  fsm-events
+                  fsm-transitions
+                  fsm-lookup
+                  fsm-valid-transition?))
+
+;; ── Machine definition ──
+;;
+;; Transition graph:
+;;   idle ──begin-explore──→ exploration ──begin-plan──→ planning
+;;     │                        │                          │
+;;     │                        └──begin-implement──→ implementation
+;;     │                                                │
+;;     │                           ┌──begin-verify──────┤
+;;     │                           │                    └──begin-debug──┐
+;;     │                           ▼                                     ▼
+;;     │                      verification                         debugging
+;;     │                           │                                    │
+;;     └─────── task-complete ◄───┘      ┌──── begin-implement ────────┘
+;;                              │        └──── begin-verify
+;;                              └──begin-debug──→ debugging
+;;
+;;   revisit: any state → exploration
+;;   task-complete: any state → idle
+;;   force-transition: any state → any state (escape hatch)
+
+(define-fsm-machine task
+                    #:states (idle exploration planning implementation verification debugging)
+                    #:events (begin-explore begin-plan
+                                            begin-implement
+                                            begin-verify
+                                            begin-debug
+                                            task-complete
+                                            revisit
+                                            force-transition)
+                    #:transitions
+                    ;; Core forward path
+                    [(idle -> exploration) begin-explore]
+                    [(exploration -> planning) begin-plan]
+                    [(exploration -> implementation) begin-implement]
+                    [(planning -> implementation) begin-implement]
+                    [(implementation -> verification) begin-verify]
+                    [(implementation -> debugging) begin-debug]
+                    [(verification -> idle) task-complete]
+                    [(verification -> debugging) begin-debug]
+                    [(debugging -> implementation) begin-implement]
+                    [(debugging -> verification) begin-verify]
+                    ;; revisit: any → exploration (explicit for each state)
+                    [(idle -> exploration) revisit]
+                    [(exploration -> exploration) revisit]
+                    [(planning -> exploration) revisit]
+                    [(implementation -> exploration) revisit]
+                    [(verification -> exploration) revisit]
+                    [(debugging -> exploration) revisit]
+                    ;; task-complete: any → idle (explicit for non-idle states)
+                    [(exploration -> idle) task-complete]
+                    [(planning -> idle) task-complete]
+                    [(implementation -> idle) task-complete]
+                    [(debugging -> idle) task-complete]
+                    ;; force-transition: escape hatch for any state
+                    [(idle -> exploration) force-transition]
+                    [(idle -> planning) force-transition]
+                    [(idle -> implementation) force-transition]
+                    [(idle -> verification) force-transition]
+                    [(idle -> debugging) force-transition]
+                    [(exploration -> idle) force-transition]
+                    [(exploration -> planning) force-transition]
+                    [(exploration -> implementation) force-transition]
+                    [(exploration -> verification) force-transition]
+                    [(exploration -> debugging) force-transition]
+                    [(planning -> idle) force-transition]
+                    [(planning -> exploration) force-transition]
+                    [(planning -> implementation) force-transition]
+                    [(planning -> verification) force-transition]
+                    [(planning -> debugging) force-transition]
+                    [(implementation -> idle) force-transition]
+                    [(implementation -> exploration) force-transition]
+                    [(implementation -> planning) force-transition]
+                    [(implementation -> verification) force-transition]
+                    [(implementation -> debugging) force-transition]
+                    [(verification -> idle) force-transition]
+                    [(verification -> exploration) force-transition]
+                    [(verification -> planning) force-transition]
+                    [(verification -> implementation) force-transition]
+                    [(verification -> debugging) force-transition]
+                    [(debugging -> idle) force-transition]
+                    [(debugging -> exploration) force-transition]
+                    [(debugging -> planning) force-transition]
+                    [(debugging -> implementation) force-transition]
+                    [(debugging -> verification) force-transition])
+
+;; ── Exports ──
+
+;; FSM machine
+(provide task-machine
+         ;; State predicates
+         task-state?
+         ;; State singletons
+         task-idle
+         task-exploration
+         task-planning
+         task-implementation
+         task-verification
+         task-debugging
+         ;; Event singletons
+         task-begin-explore
+         task-begin-plan
+         task-begin-implement
+         task-begin-verify
+         task-begin-debug
+         task-task-complete
+         task-revisit
+         task-force-transition
+         ;; Transition helpers
+         task-valid-transition?
+         task-next-state
+         ;; Contracts
+         (contract-out [task-states-list (-> (listof symbol?))]
+                       [task-events-list (-> (listof symbol?))]))
+
+;; ── Convenience accessors ──
+
+(define (task-states-list)
+  (fsm-states task-machine))
+
+(define (task-events-list)
+  (fsm-events task-machine))

--- a/tests/test-task-state.rkt
+++ b/tests/test-task-state.rkt
@@ -1,0 +1,134 @@
+#lang racket/base
+
+;; tests/test-task-state.rkt — tests for task-state FSM, conclusion types, and task memory
+;; v0.75.0: Foundation milestone tests.
+
+(require rackunit
+         rackunit/text-ui
+         "../runtime/context-assembly/task-state.rkt"
+         (only-in "../util/fsm.rkt" fsm-state-name))
+
+;; ── FSM Tests ──
+
+(define suite
+  (test-suite "task-state-fsm"
+
+    ;; ── State singleton identity ──
+
+    (test-case "task-state predicates recognize all 6 states"
+      (check-true (task-state? task-idle))
+      (check-true (task-state? task-exploration))
+      (check-true (task-state? task-planning))
+      (check-true (task-state? task-implementation))
+      (check-true (task-state? task-verification))
+      (check-true (task-state? task-debugging)))
+
+    (test-case "task-state rejects non-FSM values"
+      (check-false (task-state? 'idle))
+      (check-false (task-state? 42))
+      (check-false (task-state? "exploration")))
+
+    ;; ── Transition validity (12 core + 6 revisit + 5 task-complete + force = all) ──
+
+    (test-case "idle → exploration is valid via begin-explore"
+      (check-true (task-valid-transition? task-idle task-begin-explore)))
+
+    (test-case "exploration → planning is valid via begin-plan"
+      (check-true (task-valid-transition? task-exploration task-begin-plan)))
+
+    (test-case "exploration → implementation is valid via begin-implement"
+      (check-true (task-valid-transition? task-exploration task-begin-implement)))
+
+    (test-case "planning → implementation is valid via begin-implement"
+      (check-true (task-valid-transition? task-planning task-begin-implement)))
+
+    (test-case "implementation → verification is valid via begin-verify"
+      (check-true (task-valid-transition? task-implementation task-begin-verify)))
+
+    (test-case "implementation → debugging is valid via begin-debug"
+      (check-true (task-valid-transition? task-implementation task-begin-debug)))
+
+    (test-case "verification → idle is valid via task-complete"
+      (check-true (task-valid-transition? task-verification task-task-complete)))
+
+    (test-case "verification → debugging is valid via begin-debug"
+      (check-true (task-valid-transition? task-verification task-begin-debug)))
+
+    (test-case "debugging → implementation is valid via begin-implement"
+      (check-true (task-valid-transition? task-debugging task-begin-implement)))
+
+    (test-case "debugging → verification is valid via begin-verify"
+      (check-true (task-valid-transition? task-debugging task-begin-verify)))
+
+    ;; ── Invalid transitions ──
+
+    (test-case "idle → planning is invalid (must go through exploration)"
+      (check-false (task-valid-transition? task-idle task-begin-plan)))
+
+    (test-case "idle → implementation is invalid"
+      (check-false (task-valid-transition? task-idle task-begin-implement)))
+
+    (test-case "idle → debugging is invalid"
+      (check-false (task-valid-transition? task-idle task-begin-debug)))
+
+    (test-case "exploration → idle is invalid via begin-explore"
+      (check-false (task-valid-transition? task-exploration task-begin-explore)))
+
+    ;; ── Revisit (any → exploration) ──
+
+    (test-case "revisit works from all states"
+      (for ([state (in-list (list task-idle
+                                  task-exploration
+                                  task-planning
+                                  task-implementation
+                                  task-verification
+                                  task-debugging))])
+        (check-true (task-valid-transition? state task-revisit)
+                    (format "revisit should work from ~a" (fsm-state-name state)))))
+
+    ;; ── task-complete (any → idle) ──
+
+    (test-case "task-complete works from all non-idle states"
+      (for ([state (in-list (list task-exploration
+                                  task-planning
+                                  task-implementation
+                                  task-verification
+                                  task-debugging))])
+        (check-true (task-valid-transition? state task-task-complete)
+                    (format "task-complete should work from ~a" (fsm-state-name state)))))
+
+    ;; ── force-transition escape hatch ──
+
+    (test-case "force-transition works from any state to any state"
+      (for ([from (in-list (list task-idle
+                                 task-exploration
+                                 task-planning
+                                 task-implementation
+                                 task-verification
+                                 task-debugging))])
+        (for ([to-name (in-list '(idle exploration planning implementation verification debugging))])
+          (check-true (task-valid-transition? from task-force-transition)
+                      (format "force-transition from ~a" (fsm-state-name from))))))
+
+    ;; ── next-state ──
+
+    (test-case "task-next-state returns correct state"
+      (check-equal? (fsm-state-name (task-next-state task-idle task-begin-explore)) 'exploration)
+      (check-equal? (fsm-state-name (task-next-state task-exploration task-begin-plan)) 'planning)
+      (check-equal? (fsm-state-name (task-next-state task-implementation task-begin-verify))
+                    'verification)
+      (check-equal? (fsm-state-name (task-next-state task-debugging task-begin-implement))
+                    'implementation))
+
+    (test-case "task-next-state returns #f for invalid transition"
+      (check-false (task-next-state task-idle task-begin-plan)))
+
+    ;; ── Metadata ──
+
+    (test-case "task-states-list returns 6 states"
+      (check-equal? (length (task-states-list)) 6))
+
+    (test-case "task-events-list returns 8 events"
+      (check-equal? (length (task-events-list)) 8))))
+
+(run-tests suite)


### PR DESCRIPTION
M1 W0: Task-state FSM with 6 states, 8 events, 18 transitions. 23 tests. Uses define-fsm-machine. Closes #6357.