### PR TITLE
feat(v0.75.0 W1): conclusion types + task memory store (#6356)

### DIFF
--- a/runtime/context-assembly/task-conclusion.rkt
+++ b/runtime/context-assembly/task-conclusion.rkt
@@ -1,0 +1,66 @@
+#lang racket/base
+
+;; runtime/context-assembly/task-conclusion.rkt — Conclusion type for task-state context optimization
+;; STABILITY: evolving
+;;
+;; A task-conclusion captures a distilled insight from the agent's work,
+;; tagged with the FSM state when it was recorded and relevance tags for
+;; state-aware context assembly. Replaces raw file contents in the prompt
+;; when the agent has moved past exploration.
+
+(require racket/contract)
+
+;; ── Struct ──
+
+(struct task-conclusion
+        (id ; string — unique ID
+         text ; string — the conclusion text
+         category ; symbol — 'fact | 'decision | 'pattern | 'error-cause | 'test-result
+         fsm-state-origin ; symbol — task-state when conclusion was recorded
+         origin-message-ids ; (listof string) — provenance: which messages led to this
+         timestamp ; integer — epoch seconds
+         relevance-tags ; (listof symbol) — tags for state-relevance matching
+         )
+  #:transparent)
+
+;; ── Predicates ──
+
+(define valid-categories '(fact decision pattern error-cause test-result))
+
+(define (task-conclusion-category? v)
+  (and (symbol? v) (memq v valid-categories) #t))
+
+;; ── Serialization ──
+
+(define (conclusion->hash c)
+  (hash 'id
+        (task-conclusion-id c)
+        'text
+        (task-conclusion-text c)
+        'category
+        (task-conclusion-category c)
+        'fsm-state-origin
+        (task-conclusion-fsm-state-origin c)
+        'origin-message-ids
+        (task-conclusion-origin-message-ids c)
+        'timestamp
+        (task-conclusion-timestamp c)
+        'relevance-tags
+        (task-conclusion-relevance-tags c)))
+
+(define (hash->conclusion h)
+  (task-conclusion (hash-ref h 'id)
+                   (hash-ref h 'text)
+                   (hash-ref h 'category)
+                   (hash-ref h 'fsm-state-origin)
+                   (hash-ref h 'origin-message-ids '())
+                   (hash-ref h 'timestamp 0)
+                   (hash-ref h 'relevance-tags '())))
+
+;; ── Exports ──
+
+(provide (struct-out task-conclusion)
+         task-conclusion-category?
+         valid-categories
+         (contract-out [conclusion->hash (-> task-conclusion? hash?)]
+                       [hash->conclusion (-> hash? task-conclusion?)]))

--- a/runtime/context-assembly/task-memory.rkt
+++ b/runtime/context-assembly/task-memory.rkt
@@ -1,0 +1,101 @@
+#lang racket/base
+
+;; runtime/context-assembly/task-memory.rkt — In-memory store for task conclusions
+;; STABILITY: evolving
+;;
+;; Stores conclusions ordered by timestamp. Provides state-based filtering
+;; and bounded eviction to keep memory usage under control.
+
+(require racket/contract
+         racket/list
+         "task-conclusion.rkt"
+         (only-in "task-state.rkt" task-state?))
+
+;; ── Struct ──
+
+(struct task-memory
+        (conclusions ; (listof task-conclusion?) — ordered by timestamp, newest last
+         max-conclusions ; integer — default 50
+         )
+  #:transparent)
+
+;; ── Constructor ──
+
+(define (make-task-memory [max-conclusions 50])
+  (task-memory '() max-conclusions))
+
+;; ── Mutators (functional — return new task-memory) ──
+
+(define (add-conclusion mem c)
+  (define capped
+    (take-at-most (append (task-memory-conclusions mem) (list c)) (task-memory-max-conclusions mem)))
+  (struct-copy task-memory mem [conclusions capped]))
+
+(define (take-at-most lst n)
+  (if (> (length lst) n)
+      (drop lst (- (length lst) n))
+      lst))
+
+;; ── Filtering ──
+
+;; Return conclusions whose fsm-state-origin matches one of the given states.
+(define (conclusions-for-states mem states)
+  (define state-set (list->set states))
+  (filter (λ (c) (set-member? state-set (task-conclusion-fsm-state-origin c)))
+          (task-memory-conclusions mem)))
+
+;; Return conclusions tagged with any of the given relevance tags.
+(define (conclusions-with-tags mem tags)
+  (define tag-set (list->set tags))
+  (filter (λ (c)
+            (for/or ([t (in-list (task-conclusion-relevance-tags c))])
+              (set-member? tag-set t)))
+          (task-memory-conclusions mem)))
+
+;; ── Eviction ──
+
+;; Evict oldest conclusions that don't match any of the keep-states.
+;; Keeps at least (- max-conclusions reserve) conclusions.
+(define (evict-stale-conclusions mem [keep-states '()] [reserve 10])
+  (define concs (task-memory-conclusions mem))
+  (define max-c (task-memory-max-conclusions mem))
+  (cond
+    [(<= (length concs) max-c) mem] ; under limit, no eviction needed
+    [else
+     (define keep-set (list->set keep-states))
+     (define-values (keep rest)
+       (partition (λ (c) (set-member? keep-set (task-conclusion-fsm-state-origin c))) concs))
+     (define evictable (take-at-most rest (- max-c reserve)))
+     (struct-copy task-memory mem [conclusions (append evictable keep)])]))
+
+;; ── Helpers ──
+
+(define (list->set lst)
+  (for/hash ([v (in-list lst)])
+    (values v #t)))
+
+(define (set-member? ht v)
+  (hash-has-key? ht v))
+
+;; ── Serialization ──
+
+(define (task-memory->hash mem)
+  (hash 'conclusions
+        (map conclusion->hash (task-memory-conclusions mem))
+        'max-conclusions
+        (task-memory-max-conclusions mem)))
+
+(define (hash->task-memory h)
+  (task-memory (map hash->conclusion (hash-ref h 'conclusions '())) (hash-ref h 'max-conclusions 50)))
+
+;; ── Exports ──
+
+(provide (struct-out task-memory)
+         (contract-out
+          [make-task-memory (->* () (integer?) task-memory?)]
+          [add-conclusion (-> task-memory? task-conclusion? task-memory?)]
+          [conclusions-for-states (-> task-memory? (listof symbol?) (listof task-conclusion?))]
+          [conclusions-with-tags (-> task-memory? (listof symbol?) (listof task-conclusion?))]
+          [evict-stale-conclusions (->* (task-memory?) ((listof symbol?) integer?) task-memory?)]
+          [task-memory->hash (-> task-memory? hash?)]
+          [hash->task-memory (-> hash? task-memory?)]))

--- a/tests/test-task-state.rkt
+++ b/tests/test-task-state.rkt
@@ -3,9 +3,12 @@
 ;; tests/test-task-state.rkt — tests for task-state FSM, conclusion types, and task memory
 ;; v0.75.0: Foundation milestone tests.
 
-(require rackunit
+(require racket/list
+         rackunit
          rackunit/text-ui
          "../runtime/context-assembly/task-state.rkt"
+         "../runtime/context-assembly/task-conclusion.rkt"
+         "../runtime/context-assembly/task-memory.rkt"
          (only-in "../util/fsm.rkt" fsm-state-name))
 
 ;; ── FSM Tests ──
@@ -132,3 +135,115 @@
       (check-equal? (length (task-events-list)) 8))))
 
 (run-tests suite)
+
+;; ── Conclusion + Memory Tests ──
+
+(define conclusion-suite
+  (test-suite "task-conclusion+memory"
+
+    ;; ── Conclusion creation ──
+
+    (test-case "task-conclusion creation with all fields"
+      (define c
+        (task-conclusion "c1" "Found the bug" 'fact 'exploration '("m1" "m2") 1000 '(bug pattern)))
+      (check-equal? (task-conclusion-id c) "c1")
+      (check-equal? (task-conclusion-text c) "Found the bug")
+      (check-equal? (task-conclusion-category c) 'fact)
+      (check-equal? (task-conclusion-fsm-state-origin c) 'exploration)
+      (check-equal? (task-conclusion-origin-message-ids c) '("m1" "m2"))
+      (check-equal? (task-conclusion-timestamp c) 1000)
+      (check-equal? (task-conclusion-relevance-tags c) '(bug pattern)))
+
+    (test-case "task-conclusion-category? accepts valid categories"
+      (for ([cat (in-list '(fact decision pattern error-cause test-result))])
+        (check-true (task-conclusion-category? cat) (format "~a should be valid" cat))))
+
+    (test-case "task-conclusion-category? rejects invalid categories"
+      (check-false (task-conclusion-category? 'invalid))
+      (check-false (task-conclusion-category? 42)))
+
+    ;; ── Serialization round-trip ──
+
+    (test-case "conclusion->hash / hash->conclusion round-trip"
+      (define c
+        (task-conclusion "c2" "Decided to use FSM" 'decision 'planning '("m3") 2000 '(architecture)))
+      (define h (conclusion->hash c))
+      (define c2 (hash->conclusion h))
+      (check-equal? (task-conclusion-id c2) "c2")
+      (check-equal? (task-conclusion-text c2) "Decided to use FSM")
+      (check-equal? (task-conclusion-category c2) 'decision)
+      (check-equal? (task-conclusion-fsm-state-origin c2) 'planning)
+      (check-equal? (task-conclusion-origin-message-ids c2) '("m3"))
+      (check-equal? (task-conclusion-timestamp c2) 2000)
+      (check-equal? (task-conclusion-relevance-tags c2) '(architecture)))
+
+    ;; ── Task memory ──
+
+    (test-case "make-task-memory defaults to 50 max"
+      (define m (make-task-memory))
+      (check-equal? (task-memory-max-conclusions m) 50)
+      (check-equal? (task-memory-conclusions m) '()))
+
+    (test-case "add-conclusion appends and returns new store"
+      (define m (make-task-memory))
+      (define c1 (task-conclusion "c1" "text1" 'fact 'exploration '() 1000 '()))
+      (define c2 (task-conclusion "c2" "text2" 'decision 'planning '() 2000 '()))
+      (define m1 (add-conclusion m c1))
+      (check-equal? (length (task-memory-conclusions m1)) 1)
+      (define m2 (add-conclusion m1 c2))
+      (check-equal? (length (task-memory-conclusions m2)) 2)
+      ;; Original unchanged (functional)
+      (check-equal? (length (task-memory-conclusions m)) 0))
+
+    (test-case "conclusions-for-states filters correctly"
+      (define c1 (task-conclusion "c1" "t1" 'fact 'exploration '() 1000 '()))
+      (define c2 (task-conclusion "c2" "t2" 'decision 'planning '() 2000 '()))
+      (define c3 (task-conclusion "c3" "t3" 'pattern 'implementation '() 3000 '()))
+      (define m (add-conclusion (add-conclusion (add-conclusion (make-task-memory) c1) c2) c3))
+      ;; Filter by exploration only
+      (check-equal? (length (conclusions-for-states m '(exploration))) 1)
+      ;; Filter by exploration + planning
+      (check-equal? (length (conclusions-for-states m '(exploration planning))) 2)
+      ;; Filter by idle (none match)
+      (check-equal? (length (conclusions-for-states m '(idle))) 0))
+
+    (test-case "conclusions-with-tags filters correctly"
+      (define c1 (task-conclusion "c1" "t1" 'fact 'exploration '() 1000 '(bug)))
+      (define c2 (task-conclusion "c2" "t2" 'decision 'planning '() 2000 '(architecture)))
+      (define c3 (task-conclusion "c3" "t3" 'pattern 'exploration '() 3000 '(bug pattern)))
+      (define m (add-conclusion (add-conclusion (add-conclusion (make-task-memory) c1) c2) c3))
+      (check-equal? (length (conclusions-with-tags m '(bug))) 2)
+      (check-equal? (length (conclusions-with-tags m '(architecture))) 1)
+      (check-equal? (length (conclusions-with-tags m '(nonexistent))) 0))
+
+    (test-case "evict-stale-conclusions respects max limit"
+      ;; Create store with max 3, add 5 conclusions
+      (define m (make-task-memory 3))
+      (define conclusions
+        (for/list ([i (in-range 5)])
+          (task-conclusion (format "c~a" i)
+                           (format "text~a" i)
+                           'fact
+                           (if (even? i) 'exploration 'planning)
+                           '()
+                           (* (add1 i) 1000)
+                           '())))
+      (define filled
+        (for/fold ([m m]) ([c conclusions])
+          (add-conclusion m c)))
+      ;; Should have 3 conclusions (evicted 2 oldest)
+      (check-equal? (length (task-memory-conclusions filled)) 3)
+      ;; The newest 3 should survive
+      (check-equal? (task-conclusion-id (third (task-memory-conclusions filled))) "c4"))
+
+    (test-case "task-memory serialization round-trip"
+      (define m (make-task-memory 10))
+      (define c (task-conclusion "c1" "test" 'fact 'exploration '("m1") 1000 '(tag)))
+      (define m1 (add-conclusion m c))
+      (define h (task-memory->hash m1))
+      (define m2 (hash->task-memory h))
+      (check-equal? (task-memory-max-conclusions m2) 10)
+      (check-equal? (length (task-memory-conclusions m2)) 1)
+      (check-equal? (task-conclusion-id (first (task-memory-conclusions m2))) "c1"))))
+
+(run-tests conclusion-suite)


### PR DESCRIPTION
M1 W1: task-conclusion struct + task-memory store with filtering, eviction, serialization. 10 new tests. Closes #6358.