### PR TITLE
feat(v0.75.2 W1): event wiring for task-state inference (#6362)

### DIFF
--- a/runtime/session-events.rkt
+++ b/runtime/session-events.rkt
@@ -15,6 +15,10 @@
          (only-in "runtime-helpers.rkt" emit-session-event!)
          "session-types.rkt")
 (require "session-mutation.rkt")
+(require (only-in "context-assembly/state-inference.rkt"
+                  infer-task-state-from-tools
+                  current-state-inference-threshold))
+(require (only-in "../util/fsm.rkt" fsm-state-name))
 
 (provide (contract-out [wire-session-event-handlers! (-> agent-session? procedure? void?)]))
 
@@ -73,6 +77,24 @@
                                                      (length (compaction-result-kept-messages
                                                               compact-result))))))))
                 #:filter (lambda (evt) (equal? (event-ev evt) "compact.requested")))
+    ;; Subscribe to tool.execution.completed — infer task state
+    (subscribe!
+     bus
+     (lambda (evt)
+       (define payload (event-payload evt))
+       (define tool-name (and (hash? payload) (hash-ref payload 'tool-name #f)))
+       (when tool-name
+         (define current-state (agent-session-task-fsm-state sess))
+         (define recent-calls (list tool-name))
+         (define-values (inferred-state confidence) (infer-task-state-from-tools recent-calls))
+         (when (and inferred-state (>= confidence (current-state-inference-threshold)))
+           (guarded-set-task-fsm-state! sess (fsm-state-name inferred-state))
+           (emit-session-event!
+            bus
+            (agent-session-session-id sess)
+            "task.state.inferred"
+            (hasheq 'state (fsm-state-name inferred-state) 'confidence confidence 'tool tool-name)))))
+     #:filter (lambda (evt) (equal? (event-ev evt) "tool.execution.completed")))
     (void)))
 
 ;; ============================================================

--- a/tests/test-task-state-inference.rkt
+++ b/tests/test-task-state-inference.rkt
@@ -1,7 +1,7 @@
 #lang racket/base
 
 ;; tests/test-task-state-inference.rkt — tests for state-inference heuristics
-;; v0.75.2 W0: Tool-call pattern → task-state inference
+;; v0.75.2: Tool-call pattern → task-state inference + event wiring
 
 (require rackunit
          rackunit/text-ui
@@ -84,7 +84,6 @@
 
     (test-case "low-confidence reads don't trigger transition"
       (define-values (state conf) (infer-task-state-from-tools '("read")))
-      ;; Only 1 read → confidence 0.5, below threshold
       (check-true (< conf (current-state-inference-threshold))))
 
     ;; ── Tool name categorization ──
@@ -112,6 +111,23 @@
 
     (test-case "infer-from-recent-turns with mixed turns"
       (define-values (state conf) (infer-from-recent-turns '(("read" "read" "read"))))
-      (check-equal? state task-exploration))))
+      (check-equal? state task-exploration))
+
+    ;; ── W1: Event wiring + confidence threshold ──
+
+    (test-case "threshold is adjustable via parameterize"
+      (check-true (procedure? current-state-inference-threshold))
+      (parameterize ([current-state-inference-threshold 0.9])
+        (check-equal? (current-state-inference-threshold) 0.9))
+      (check-equal? (current-state-inference-threshold) 0.7))
+
+    (test-case "mixed tools with edits take priority over reads"
+      (define-values (state conf)
+        (infer-task-state-from-tools '("read" "read" "read" "edit" "write")))
+      (check-equal? state task-implementation))
+
+    (test-case "explicit set_task_state overrides inference"
+      (define-values (inferred-state conf) (infer-task-state-from-tools '("set-task-state")))
+      (check-true (or (eq? inferred-state task-planning) (not inferred-state))))))
 
 (run-tests suite)


### PR DESCRIPTION
M3 W1: Event wiring + confidence threshold. tool.execution.completed subscriber. 20 tests. Closes #6364.