### PR TITLE
fix(v0.75.6 W0): P0 session constructor arity (#6386)

### DIFF
--- a/runtime/agent-session.rkt
+++ b/runtime/agent-session.rkt
@@ -188,7 +188,9 @@
                              #:thinking-level [thinking-level #f]
                              #:shutdown-requested? [shutdown-requested? #f]
                              #:force-shutdown? [force-shutdown? #f]
-                             #:prompt-running? [prompt-running? #f])
+                             #:prompt-running? [prompt-running? #f]
+                             #:task-fsm-state [task-fsm-state 'idle]
+                             #:task-conclusions [task-conclusions '()])
   (agent-session id
                  dir
                  provider
@@ -209,7 +211,9 @@
                  thinking-level
                  shutdown-requested?
                  force-shutdown?
-                 prompt-running?))
+                 prompt-running?
+                 task-fsm-state
+                 task-conclusions))
 
 ;; ============================================================
 ;; make-agent-session

--- a/runtime/session-types.rkt
+++ b/runtime/session-types.rkt
@@ -99,7 +99,7 @@
          [force-shutdown? #:mutable]
          [prompt-running? #:mutable]
          [task-fsm-state #:mutable]
-         [task-conclusions #:mutable]) ; boolean — concurrent prompt execution guard
+         [task-conclusions #:mutable]) ; (listof task-conclusion?) — agent task conclusions
   #:transparent)
 
 ;; ============================================================


### PR DESCRIPTION
P0 CRITICAL FIX: Session constructor arity mismatch. Add keyword args with defaults. Fixes all session creation crashes. Closes #6387.