### PR TITLE
fix(v0.75.6 W1): assembly wiring + FSM validation (#6386)

### DIFF
--- a/agent/iteration/main-loop.rkt
+++ b/agent/iteration/main-loop.rkt
@@ -32,11 +32,7 @@
          (only-in "../event-emitter.rkt" emit-typed-event!)
          (only-in "../event-structs/hook-events.rkt" turn-cancelled-event)
          (only-in "../event-structs/iteration-events.rkt" make-iteration-decision-event)
-         (only-in "../queue.rkt"
-                  queue-status
-                  queue?
-                  dequeue-followup!
-                  dequeue-all-followups!)
+         (only-in "../queue.rkt" queue-status queue? dequeue-followup! dequeue-all-followups!)
          (only-in "tool-turn-bridge.rkt" dequeue-all-steering! drain-injected-messages!)
          (only-in "../../runtime/runtime-helpers.rkt" emit-session-event! maybe-dispatch-hooks)
          (only-in "../../util/hook-types.rkt" hook-result-action hook-result?)
@@ -59,7 +55,10 @@
          (only-in "counters.rkt" check-cancellation)
          (only-in "../../runtime/iteration/decision.rkt" iteration-ctx compute-step-result)
          (only-in "step-interpreter.rkt" interpret-step)
-         (only-in "../../runtime/iteration/directive.rkt" directive-recurse directive-stop directive-yield)
+         (only-in "../../runtime/iteration/directive.rkt"
+                  directive-recurse
+                  directive-stop
+                  directive-yield)
          (only-in "../../runtime/iteration/fsm-types.rkt"
                   state-idle
                   state-provider-turn
@@ -197,7 +196,8 @@
                   ;; R-06/R-07: FSM: provider-turn + hook-block -> aborted
                   (current-iteration-fsm-state (next-iteration-state state-provider-turn
                                                                      event-hook-block))
-                  (log-q-main-loop-info "turn blocked at iteration ~a" (loop-counters-iteration counters))
+                  (log-q-main-loop-info "turn blocked at iteration ~a"
+                                        (loop-counters-iteration counters))
                   (emit-session-event! bus
                                        session-id
                                        "turn.blocked"
@@ -213,7 +213,8 @@
                                              ext-reg
                                              bus
                                              session-id
-                                             (loop-counters-iteration counters)))
+                                             (loop-counters-iteration counters)
+                                             #:session sess))
                   (define result
                     (run-provider-turn ctx-final
                                        prov
@@ -229,7 +230,8 @@
                   ;; R-06/R-07: FSM: provider-turn + model-response -> decision
                   (current-iteration-fsm-state (next-iteration-state state-provider-turn
                                                                      event-model-response))
-                  (log-q-main-loop-info "model response received at iteration ~a" (loop-counters-iteration counters))
+                  (log-q-main-loop-info "model response received at iteration ~a"
+                                        (loop-counters-iteration counters))
                   (emit-typed-event! bus
                                      (make-iteration-decision-event
                                       #:session-id session-id
@@ -263,7 +265,9 @@
                      ;; R-06/R-07: FSM: decision + termination -> complete
                      (current-iteration-fsm-state (next-iteration-state state-decision
                                                                         event-termination-reason))
-                     (log-q-main-loop-info "iteration complete: ~a at iteration ~a" termination (loop-counters-iteration counters))
+                     (log-q-main-loop-info "iteration complete: ~a at iteration ~a"
+                                           termination
+                                           (loop-counters-iteration counters))
                      final-result]
                     [(directive-recurse new-ctx new-counters ws2)
                      (loop new-ctx new-counters ws2)])])]))))))

--- a/runtime/context-assembly/serialization.rkt
+++ b/runtime/context-assembly/serialization.rkt
@@ -27,7 +27,8 @@
          "budgeting.rkt"
          (only-in "state-relevance.rkt" context-level-for-state)
          (only-in "task-conclusion.rkt" task-conclusion? task-conclusion-text)
-         (only-in "../../util/fsm.rkt" fsm-state-name))
+         (only-in "../../util/fsm.rkt" fsm-state-name)
+         (only-in "../../util/ids.rkt" generate-id))
 
 (provide tiered-context
          tiered-context?
@@ -300,7 +301,7 @@
       [(eq? conclusions-level 'full)
        (for/list ([c (in-list conclusions)]
                   #:when (task-conclusion? c))
-         (make-message (format "conclusion-~a" (current-milliseconds))
+         (make-message (generate-id)
                        #f
                        'system-instruction
                        'text
@@ -311,7 +312,7 @@
        (if (<= (length conclusions) 3)
            (for/list ([c (in-list conclusions)]
                       #:when (task-conclusion? c))
-             (make-message (format "conclusion-~a" (current-milliseconds))
+             (make-message (generate-id)
                            #f
                            'system-instruction
                            'text
@@ -323,7 +324,7 @@
                  [last-c (car (reverse conclusions))])
              (for/list ([c (list first-c last-c)]
                         #:when (task-conclusion? c))
-               (make-message (format "conclusion-~a" (current-milliseconds))
+               (make-message (generate-id)
                              #f
                              'system-instruction
                              'text
@@ -341,12 +342,17 @@
                           #:working-set-messages effective-ws
                           #:trace trace-cb))
 
-  ;; Prepend conclusion entries to tier-a
-  (if (null? conclusion-entries)
+  ;; v0.75.6: Prepend state-awareness preamble to tier-a
+  (define preamble (build-state-awareness-preamble task-state conclusions))
+  (define preamble-entries
+    (if preamble
+        (list preamble)
+        '()))
+  ;; Prepend preamble + conclusion entries to tier-a
+  (define new-tier-a (append preamble-entries conclusion-entries (tiered-context-tier-a base-tc)))
+  (if (and (null? preamble-entries) (null? conclusion-entries))
       base-tc
-      (tiered-context (append conclusion-entries (tiered-context-tier-a base-tc))
-                      (tiered-context-tier-b base-tc)
-                      (tiered-context-tier-c base-tc))))
+      (tiered-context new-tier-a (tiered-context-tier-b base-tc) (tiered-context-tier-c base-tc))))
 
 ;; ── v0.75.5: System prompt state injection ──
 

--- a/runtime/session-mutation.rkt
+++ b/runtime/session-mutation.rkt
@@ -10,7 +10,8 @@
          (submod "session-types.rkt" internal)
          (only-in "session-config.rkt" session-config?)
          (only-in "../util/errors.rkt" raise-session-error)
-         (only-in "session-index/schema.rkt" session-index?))
+         (only-in "session-index/schema.rkt" session-index?)
+         (only-in "context-assembly/task-state.rkt" task-states-list))
 
 (provide (contract-out [guarded-set-prompt-running! (-> agent-session? boolean? void?)]
                        [guarded-set-compacting! (-> agent-session? boolean? void?)]
@@ -26,7 +27,7 @@
                        [guarded-set-thinking-level! (-> agent-session? (or/c symbol? #f) void?)]
                        [guarded-set-last-compaction-time!
                         (-> agent-session? (or/c exact-nonnegative-integer? #f) void?)]
-                       [guarded-set-task-fsm-state! (-> agent-session? symbol? void?)]
+                       [guarded-set-task-fsm-state! (-> agent-session? (or/c symbol? #f) void?)]
                        [guarded-set-task-conclusions! (-> agent-session? list? void?)]
                        [valid-session-phase? (-> symbol? boolean?)]
                        [session-phase (-> agent-session? symbol?)]))
@@ -111,7 +112,10 @@
   (set-agent-session-last-compaction-time! sess value))
 
 ;; Guard task-fsm-state — validates FSM transition
+;; v0.75.6: Validate that value is a known FSM state symbol.
 (define (guarded-set-task-fsm-state! sess value)
+  (when (and value (not (member value (task-states-list))))
+    (raise-session-error (format "invalid task FSM state: ~a" value) #f))
   (set-agent-session-task-fsm-state! sess value))
 
 ;; Guard task-conclusions — type-safe wrapper

--- a/runtime/turn-orchestrator.rkt
+++ b/runtime/turn-orchestrator.rkt
@@ -105,6 +105,10 @@
          "../agent/event-emitter.rkt"
          "../agent/event-structs/iteration-events.rkt"
          "../agent/event-structs/session-events.rkt"
+         (only-in "../runtime/session-types.rkt"
+                  agent-session?
+                  agent-session-task-fsm-state
+                  agent-session-task-conclusions)
          (only-in "../runtime/session-config.rkt"
                   session-config?
                   hash->session-config
@@ -130,13 +134,13 @@
                 (#:tool-list-proc (or/c procedure? #f))
                 loop-result?)]
           [build-assembled-context
-           (-> list?
-               session-config?
-               (or/c extension-registry? #f)
-               event-bus?
-               string?
-               exact-nonnegative-integer?
-               list?)]
+           (->* (list? session-config?
+                       (or/c extension-registry? #f)
+                       event-bus?
+                       string?
+                       exact-nonnegative-integer?)
+                (#:session (or/c any/c #f))
+                list?)]
           [register-session-extensions!
            (-> tool-registry? (or/c extension-registry? #f) event-bus? string? (listof hash?))]
           [assemble-context/pure
@@ -190,7 +194,13 @@
 
 ;; Build assembled context using tiered context assembly with hooks.
 ;; Returns the assembled message list.
-(define (build-assembled-context ctx-to-use config-raw ext-reg bus session-id iteration)
+(define (build-assembled-context ctx-to-use
+                                 config-raw
+                                 ext-reg
+                                 bus
+                                 session-id
+                                 iteration
+                                 #:session [session #f])
   ;; WP-37 + R2-6: Context Assembly with Tier A/B/C separation and Hook support
   (define config config-raw)
   (define ws (config-working-set config))
@@ -202,9 +212,16 @@
            (define result (dispatch-hooks hook-point payload ext-reg))
            result)))
 
+  ;; v0.75.6: Extract task state from session for state-aware assembly
+  (define task-state (and session (agent-session-task-fsm-state session)))
+  (define conclusions (and session (agent-session-task-conclusions session)))
   ;; FD-05: Delegate pure assembly to assemble-context/pure
   (define-values (ctx-assembled assembly-hook-result tc-struct)
-    (assemble-context/pure ctx-to-use config-raw #:hook-dispatcher ctx-assembly-hook-dispatcher))
+    (assemble-context/pure ctx-to-use
+                           config-raw
+                           #:hook-dispatcher ctx-assembly-hook-dispatcher
+                           #:task-state task-state
+                           #:conclusions conclusions))
 
   ;; Handle block action from context-assembly hook
   (when (and assembly-hook-result (eq? (hook-result-action assembly-hook-result) 'block))

--- a/tests/test-state-aware-assembly.rkt
+++ b/tests/test-state-aware-assembly.rkt
@@ -142,15 +142,15 @@
 
     ;; ── W1: Comparison tests ──
 
-    (test-case "exploration state behaves identically to standard"
+    (test-case "exploration state includes preamble (1 more than standard)"
       (define sa
         (build-tiered-context/state-aware base-messages
                                           #:working-set-messages ws-messages
                                           #:task-state task-exploration))
       (define std (build-tiered-context base-messages #:working-set-messages ws-messages))
-      ;; Exploration has 'full for everything → should be same
+      ;; Exploration has preamble injected → 1 more than standard
       (check-equal? (length (tiered-context->message-list sa))
-                    (length (tiered-context->message-list std))))
+                    (add1 (length (tiered-context->message-list std)))))
 
     (test-case "implementation filters working-set entries"
       (define many-ws


### PR DESCRIPTION
Wire state-aware assembly into production path. FSM validation for guarded setters. Unique conclusion IDs. Closes #6388.