### PR TITLE
release: v0.75.7 (#6395)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## v0.75.7 (2026-05-30)
+
+### GUI/GSD Workflow Usability Fixes
+
+#### Bug Fixes
+- **GUI**: Tool messages now show arguments and results in transcript (was: `Tool: [xxx]`, now: `Tool: [bash] command: ls`)
+- **GUI**: Tool execution results now appear in transcript via `tool.execution.completed` handler
+- **GUI**: `gui-message` struct extended with `meta` field for structured tool data
+- **GSD**: `/plan` now cleans old wave files and emphasizes wave-first ordering in prompt
+- **GSD**: `/go` now validates wave doc existence before state transition
+- **GSD**: `/go` resilient to relaxed wave index format (`- W0: Title` without `[Status]` brackets)
+- **GSD**: `/go` now includes persistent task summary to prevent focus loss during execution
+- **Context**: `gsd-progress-message?` extended to pin execution-instruction messages
+
+#### Tests Added
+- 13 tests in test-gui-types.rkt (5 new: meta field)
+- 25 tests in test-gui-state-sync.rkt (5 new: tool args/results, 20 fixed: struct migration)
+- 5 tests in test-gsd-wave-gen-validation.rkt (wave doc validation)
+- 5 tests in test-gsd-relaxed-index.rkt (relaxed parser)
+- 3 tests in test-gsd-task-focus.rkt (task summary)
+- 6 tests in serialization.rkt module+test (execution instruction pinning)
+
+
 ## v0.75.6 (2026-05-30)
 
 ### Audit Closure (v0.75.6)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.75.6-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.75.7-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 
@@ -202,7 +202,7 @@ bin/q --model gpt-5.4 "write a test"
 ### Verify
 
 ```bash
-bin/q --version            # q version 0.75.6
+bin/q --version            # q version 0.75.7
 raco test tests/           # run the full test suite
 ```
 
@@ -347,6 +347,9 @@ When q executes shell commands on behalf of an LLM, arguments are quoted via `sh
 
 
 
+
+
+**v0.75.7** — Core Loop Tests: Pure Functions (T-1a)
 
 **v0.74.8** — Core Loop Tests: Pure Functions (T-1a)
 

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.75.6")
+(define version "0.75.7")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base" "gui-easy-lib"))

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -11,4 +11,4 @@
 
 (provide (contract-out [q-version string?]))
 
-(define q-version "0.75.6")
+(define q-version "0.75.7")


### PR DESCRIPTION
Version bump to 0.75.7 + CHANGELOG + README sync. Release wave. Closes #6400.