### PR TITLE
feat: record_conclusion tool implementation (#6413)

### DIFF
--- a/runtime/session-events.rkt
+++ b/runtime/session-events.rkt
@@ -13,7 +13,8 @@
          "../runtime/session-index.rkt"
          (only-in "../util/protocol-types.rkt" event-ev event-payload message-id)
          (only-in "runtime-helpers.rkt" emit-session-event!)
-         "session-types.rkt")
+         "session-types.rkt"
+         (only-in "context-assembly/task-conclusion.rkt" task-conclusion task-conclusion-id))
 (require "session-mutation.rkt")
 (require (submod "session-types.rkt" internal))
 (require (only-in "context-assembly/state-inference.rkt"
@@ -108,6 +109,53 @@
             "task.state.inferred"
             (hasheq 'state (fsm-state-name inferred-state) 'confidence confidence 'tool tool-name)))))
      #:filter (lambda (evt) (equal? (event-ev evt) "tool.execution.completed")))
+    ;; Subscribe to tool.record_conclusion.completed — persist conclusion
+    (subscribe! bus
+                (lambda (evt)
+                  (define payload (event-payload evt))
+                  (define text (and (hash? payload) (hash-ref payload 'text #f)))
+                  (when text
+                    (define current-state (or (agent-session-task-fsm-state sess) 'idle))
+                    (define id (and (hash? payload) (hash-ref payload 'conclusion-id #f)))
+                    (define category-raw (and (hash? payload) (hash-ref payload 'category "fact")))
+                    (define tags (and (hash? payload) (hash-ref payload 'tags '())))
+                    (define category-sym
+                      (if (string? category-raw)
+                          (string->symbol category-raw)
+                          category-raw))
+                    (define tag-syms
+                      (for/list ([t (in-list (if (list? tags)
+                                                 tags
+                                                 '()))])
+                        (if (string? t)
+                            (string->symbol t)
+                            t)))
+                    (define c
+                      (task-conclusion (or id (format "c~a" (current-inexact-milliseconds)))
+                                       text
+                                       category-sym
+                                       current-state
+                                       '()
+                                       (current-seconds)
+                                       tag-syms))
+                    ;; Add to session
+                    (define current-conclusions (agent-session-task-conclusions sess))
+                    (guarded-set-task-conclusions! sess (append current-conclusions (list c)))
+                    ;; Persist to log
+                    (define log-path (session-log-path-for sess))
+                    (when (file-exists? log-path)
+                      (append-conclusion! log-path c))
+                    ;; Emit confirmation
+                    (emit-session-event! bus
+                                         (agent-session-session-id sess)
+                                         "task.conclusion.recorded"
+                                         (hasheq 'conclusion-id
+                                                 (task-conclusion-id c)
+                                                 'category
+                                                 category-sym
+                                                 'state
+                                                 current-state))))
+                #:filter (lambda (evt) (equal? (event-ev evt) "tool.record_conclusion.completed")))
     (void)))
 
 ;; ============================================================

--- a/tests/test-record-conclusion.rkt
+++ b/tests/test-record-conclusion.rkt
@@ -1,0 +1,188 @@
+#lang racket/base
+
+;; tests/test-record-conclusion.rkt — tests for record_conclusion tool
+;; v0.76.0 W0: Tool implementation + persistence wiring
+
+(require rackunit
+         rackunit/text-ui
+         "../tools/builtins/record-conclusion.rkt"
+         "../tools/tool.rkt"
+         (only-in "../agent/event-bus.rkt" make-event-bus publish!)
+         (only-in "../util/event.rkt" make-event)
+         "../runtime/session-events.rkt"
+         "../runtime/session-types.rkt"
+         (only-in "../runtime/context-assembly/task-conclusion.rkt"
+                  task-conclusion?
+                  task-conclusion-text
+                  task-conclusion-category
+                  task-conclusion-fsm-state-origin
+                  task-conclusion-relevance-tags)
+         (submod "../runtime/session-types.rkt" internal))
+
+;; Helper: call tool handler directly
+(define (call-tool t args)
+  ((tool-execute t) args #f))
+
+;; Helper: call tool with exec-ctx that captures events
+(define (call-tool-with-ctx t args)
+  (define captured-events '())
+  (define mock-ctx
+    ((dynamic-require "../tools/exec-context.rkt" 'make-exec-context)
+     #:event-publisher (lambda (event-type payload)
+                         (set! captured-events (cons (cons event-type payload) captured-events)))))
+  (define result ((tool-execute t) args mock-ctx))
+  (values result captured-events))
+
+(define suite
+  (test-suite "record-conclusion"
+
+    ;; ── Tool metadata ──
+
+    (test-case "record_conclusion is a valid tool"
+      (check-true (tool? record_conclusion))
+      (check-equal? (tool-name record_conclusion) "record_conclusion"))
+
+    ;; ── Handler validation ──
+
+    (test-case "record_conclusion creates conclusion with text"
+      (define result (call-tool record_conclusion (hasheq 'text "Found the bug")))
+      (check-false (tool-result-is-error? result)))
+
+    (test-case "record_conclusion rejects missing text"
+      (define result (call-tool record_conclusion (hasheq)))
+      (check-true (tool-result-is-error? result)))
+
+    (test-case "record_conclusion rejects non-string text"
+      (define result (call-tool record_conclusion (hasheq 'text 42)))
+      (check-true (tool-result-is-error? result)))
+
+    (test-case "record_conclusion rejects invalid category"
+      (define result (call-tool record_conclusion (hasheq 'text "test" 'category "invalid-category")))
+      (check-true (tool-result-is-error? result)))
+
+    (test-case "record_conclusion accepts all valid categories"
+      (for ([cat (in-list '("fact" "decision" "pattern" "error-cause" "test-result"))])
+        (define result (call-tool record_conclusion (hasheq 'text "test" 'category cat)))
+        (check-false (tool-result-is-error? result) (format "category ~a should be accepted" cat))))
+
+    (test-case "record_conclusion defaults category to fact"
+      (define result (call-tool record_conclusion (hasheq 'text "default test")))
+      (check-false (tool-result-is-error? result)))
+
+    (test-case "record_conclusion with tags"
+      (define result (call-tool record_conclusion (hasheq 'text "test" 'tags '("bug" "pattern"))))
+      (check-false (tool-result-is-error? result)))
+
+    (test-case "record_conclusion returns success with conclusion_id"
+      (define result (call-tool record_conclusion (hasheq 'text "test conclusion")))
+      (check-false (tool-result-is-error? result))
+      (define content (tool-result-content result))
+      (check-true (list? content))
+      (check-true (> (length content) 1)))
+
+    ;; ── Event emission ──
+
+    (test-case "record_conclusion emits tool.record_conclusion.completed event"
+      (define-values (result events)
+        (call-tool-with-ctx record_conclusion (hasheq 'text "event test" 'category "fact")))
+      (check-false (tool-result-is-error? result))
+      (check-true (> (length events) 0))
+      (define ev (assoc "tool.record_conclusion.completed" events))
+      (check-not-false ev)
+      (check-equal? (hash-ref (cdr ev) 'text #f) "event test")
+      (check-equal? (hash-ref (cdr ev) 'category #f) "fact"))
+
+    (test-case "record_conclusion event includes tags"
+      (define-values (result events)
+        (call-tool-with-ctx record_conclusion (hasheq 'text "tagged" 'tags '("a" "b"))))
+      (define ev (assoc "tool.record_conclusion.completed" events))
+      (check-not-false ev)
+      (define tags (hash-ref (cdr ev) 'tags #f))
+      (check-equal? tags '(a b)))
+
+    ;; ── Session event handler integration ──
+
+    (test-case "session handler persists conclusion from event"
+      (define bus (make-event-bus))
+      (define sess
+        (agent-session "test-sess"
+                       "/tmp/q-test-record"
+                       #f
+                       #f
+                       bus
+                       #f
+                       #f
+                       '()
+                       #f
+                       #f
+                       #f
+                       #f
+                       #t
+                       0
+                       #f
+                       #f
+                       #f
+                       #f
+                       #f
+                       #f
+                       #f
+                       'idle
+                       '()
+                       '()))
+      (wire-session-event-handlers! sess (lambda (s e) s))
+      ;; Publish a record_conclusion event
+      (publish! bus
+                (make-event
+                 "tool.record_conclusion.completed"
+                 (current-seconds)
+                 "test-sess"
+                 #f
+                 (hasheq 'text "handler test" 'conclusion-id "c123" 'category "fact" 'tags '())))
+      ;; Allow event processing (synchronous bus)
+      (define conclusions (agent-session-task-conclusions sess))
+      (check-true (> (length conclusions) 0))
+      (define c (car conclusions))
+      (check-true (task-conclusion? c))
+      (check-equal? (task-conclusion-text c) "handler test")
+      (check-equal? (task-conclusion-category c) 'fact)
+      (check-equal? (task-conclusion-fsm-state-origin c) 'idle))
+
+    (test-case "session handler sets fsm-state-origin to current state"
+      (define bus (make-event-bus))
+      (define sess
+        (agent-session "test-sess"
+                       "/tmp/q-test-record"
+                       #f
+                       #f
+                       bus
+                       #f
+                       #f
+                       '()
+                       #f
+                       #f
+                       #f
+                       #f
+                       #t
+                       0
+                       #f
+                       #f
+                       #f
+                       #f
+                       #f
+                       #f
+                       #f
+                       'implementation
+                       '()
+                       '()))
+      (wire-session-event-handlers! sess (lambda (s e) s))
+      (publish! bus
+                (make-event "tool.record_conclusion.completed"
+                            (current-seconds)
+                            "test-sess"
+                            #f
+                            (hasheq 'text "state test" 'category "decision" 'tags '())))
+      (define conclusions (agent-session-task-conclusions sess))
+      (check-true (> (length conclusions) 0))
+      (check-equal? (task-conclusion-fsm-state-origin (car conclusions)) 'implementation))))
+
+(run-tests suite)

--- a/tools/builtins/record-conclusion.rkt
+++ b/tools/builtins/record-conclusion.rkt
@@ -1,0 +1,99 @@
+#lang racket/base
+
+;; tools/builtins/record-conclusion.rkt — Record conclusion tool
+;;
+;; Layer: tools (built-in)
+;; Purpose: Allows the agent to record distilled insights (conclusions) during
+;; a task. Emits a tool.record_conclusion.completed event that the session
+;; layer subscribes to for persistence.
+
+(require racket/contract
+         racket/string
+         "../tool.rkt"
+         "../define-tool.rkt"
+         (only-in "../../runtime/context-assembly/task-conclusion.rkt"
+                  task-conclusion
+                  task-conclusion?
+                  task-conclusion-category?
+                  valid-categories)
+         (only-in "../../tools/exec-context.rkt" exec-context-event-publisher exec-context?))
+
+;; --------------------------------------------------
+;; Helpers
+;; --------------------------------------------------
+
+;; Coerce argument to symbol category, validating against known categories.
+(define (parse-category v)
+  (define sym
+    (if (string? v)
+        (string->symbol v)
+        v))
+  (and (task-conclusion-category? sym) sym))
+
+;; Coerce tags argument to list of symbols.
+(define (parse-tags v)
+  (cond
+    [(null? v) '()]
+    [(list? v)
+     (for/list ([item (in-list v)])
+       (if (string? item)
+           (string->symbol item)
+           item))]
+    [else '()]))
+
+;; --------------------------------------------------
+;; Handler function
+;; --------------------------------------------------
+
+(define (record-conclusion-handler args [exec-ctx #f])
+  (define text (hash-ref args 'text #f))
+  (define category-raw (hash-ref args 'category "fact"))
+  (define tags-raw (hash-ref args 'tags '()))
+
+  (cond
+    [(not text) (make-error-result "Missing required argument: text")]
+    [(not (string? text)) (make-error-result "text must be a string")]
+    [else
+     (define category (parse-category category-raw))
+     (define tags (parse-tags tags-raw))
+     (if (not category)
+         (make-error-result (format "Invalid category: ~a. Valid: ~a"
+                                    category-raw
+                                    (string-join (map symbol->string valid-categories) ", ")))
+         (let ([id (format "c~a" (current-inexact-milliseconds))])
+           ;; Create conclusion (fsm-state-origin is 'idle placeholder — session layer fills in)
+           (define c
+             (task-conclusion id
+                              text
+                              category
+                              'idle ; placeholder — session layer overrides
+                              '() ; origin-message-ids — set by session layer
+                              (current-seconds)
+                              tags))
+
+           ;; Emit event for session layer to persist
+           (define ev-pub (and exec-ctx (exec-context-event-publisher exec-ctx)))
+           (when ev-pub
+             (ev-pub "tool.record_conclusion.completed"
+                     (hasheq 'conclusion-id id 'text text 'category category-raw 'tags tags)))
+
+           (make-success-result
+            (list (hasheq 'type "text" 'text (format "Conclusion recorded: [~a] ~a" category text))
+                  (hasheq 'type "json" 'json (hasheq 'success #t 'conclusion_id id))))))]))
+
+;; --------------------------------------------------
+;; Tool definition via define-tool macro
+;; --------------------------------------------------
+
+(define-tool
+ record_conclusion
+ #:description
+ "Record a distilled insight or conclusion about the current task. Use after discovering important facts, making decisions, identifying patterns, finding error causes, or getting test results. Conclusions replace raw file contents in the prompt when the agent moves past exploration, enabling context optimization."
+ #:required ("text")
+ #:properties
+ [(text "string" "The conclusion text")
+  (category "string" "Category: fact, decision, pattern, error-cause, test-result (default: fact)")
+  (tags "array" "List of relevance tags for state-aware filtering")]
+ record-conclusion-handler)
+
+(provide (contract-out [record_conclusion any/c]))

--- a/tools/registry-table.rkt
+++ b/tools/registry-table.rkt
@@ -21,7 +21,8 @@
          "builtins/session-recall.rkt"
          "builtins/skill-router.rkt"
          "builtins/save-conclusion.rkt"
-         "builtins/set-task-state.rkt")
+         "builtins/set-task-state.rkt"
+         "builtins/record-conclusion.rkt")
 
 ;; M-03: Named struct replacing raw list access.
 ;; Each spec was a list: (name description schema handler [prompt-guidelines])
@@ -253,6 +254,32 @@
                      'description
                      "List of relevance tags (symbols) for state-aware filtering")))
     tool-save-conclusion
+    #f)
+   ;; set-task-state
+   (tool-spec
+    "record_conclusion"
+    (string-append
+     "Record a distilled insight or conclusion about the current task. "
+     "Use after discovering important facts, making decisions, identifying patterns, "
+     "finding error causes, or getting test results. "
+     "Conclusions replace raw file contents in the prompt when the agent moves past exploration, "
+     "enabling context optimization.")
+    (hasheq
+     'type
+     "object"
+     'required
+     '("text")
+     'properties
+     (hasheq 'text
+             (hasheq 'type "string" 'description "The conclusion text")
+             'category
+             (hasheq 'type
+                     "string"
+                     'description
+                     "Category: fact, decision, pattern, error-cause, test-result (default: fact)")
+             'tags
+             (hasheq 'type "array" 'description "List of relevance tags for state-aware filtering")))
+    tool-record_conclusion
     #f)
    ;; set-task-state
    (tool-spec


### PR DESCRIPTION
Implements the `record_conclusion` tool (M1 W0 #6413).

- New tool `tools/builtins/record-conclusion.rkt` with schema: text (required), category, tags
- Emits `tool.record_conclusion.completed` event via exec-context event publisher
- Session event handler persists conclusion to session + appends to JSONL log
- 13 tests covering tool validation, event emission, and session integration

Closes #6413.