### PR TITLE
fix: FSM transition validation + inference accumulation (#6414)

### DIFF
--- a/runtime/context-assembly/task-state.rkt
+++ b/runtime/context-assembly/task-state.rkt
@@ -137,6 +137,7 @@
          ;; Transition helpers
          task-valid-transition?
          task-next-state
+         task-valid-direct-transition?
          ;; Contracts
          (contract-out [task-states-list (-> (listof symbol?))]
                        [task-events-list (-> (listof symbol?))]))
@@ -148,3 +149,9 @@
 
 (define (task-events-list)
   (fsm-events task-machine))
+
+;; Check if a direct state→state transition is valid (any event).
+;; Used by session-mutation.rkt for transition validation.
+(define (task-valid-direct-transition? from-sym to-sym)
+  (for/or ([event-sym (in-list (fsm-events task-machine))])
+    (eq? (fsm-lookup task-machine from-sym event-sym) to-sym)))

--- a/runtime/session-events.rkt
+++ b/runtime/session-events.rkt
@@ -16,7 +16,6 @@
          "session-types.rkt"
          (only-in "context-assembly/task-conclusion.rkt" task-conclusion task-conclusion-id))
 (require "session-mutation.rkt")
-(require (submod "session-types.rkt" internal))
 (require (only-in "context-assembly/state-inference.rkt"
                   infer-task-state-from-tools
                   current-state-inference-threshold))
@@ -90,11 +89,10 @@
          (define current-recent (agent-session-recent-tool-calls sess))
          (define updated-recent (append current-recent (list tool-name)))
          ;; Keep last 10 tool calls
-         (set-agent-session-recent-tool-calls! sess
-                                               (if (> (length updated-recent) 10)
-                                                   (list-tail updated-recent
-                                                              (- (length updated-recent) 10))
-                                                   updated-recent))
+         (guarded-set-recent-tool-calls! sess
+                                         (if (> (length updated-recent) 10)
+                                             (list-tail updated-recent (- (length updated-recent) 10))
+                                             updated-recent))
          (define-values (inferred-state confidence)
            (infer-task-state-from-tools (agent-session-recent-tool-calls sess)))
          (when (and inferred-state (>= confidence (current-state-inference-threshold)))

--- a/runtime/session-mutation.rkt
+++ b/runtime/session-mutation.rkt
@@ -11,7 +11,7 @@
          (only-in "session-config.rkt" session-config?)
          (only-in "../util/errors.rkt" raise-session-error)
          (only-in "session-index/schema.rkt" session-index?)
-         (only-in "context-assembly/task-state.rkt" task-states-list))
+         (only-in "context-assembly/task-state.rkt" task-states-list task-valid-direct-transition?))
 
 (provide (contract-out [guarded-set-prompt-running! (-> agent-session? boolean? void?)]
                        [guarded-set-compacting! (-> agent-session? boolean? void?)]
@@ -29,6 +29,7 @@
                         (-> agent-session? (or/c exact-nonnegative-integer? #f) void?)]
                        [guarded-set-task-fsm-state! (-> agent-session? (or/c symbol? #f) void?)]
                        [guarded-set-task-conclusions! (-> agent-session? list? void?)]
+                       [guarded-set-recent-tool-calls! (-> agent-session? list? void?)]
                        [valid-session-phase? (-> symbol? boolean?)]
                        [session-phase (-> agent-session? symbol?)]))
 
@@ -113,10 +114,26 @@
 
 ;; Guard task-fsm-state — validates FSM transition
 ;; v0.75.6: Validate that value is a known FSM state symbol.
+;; v0.76.0 W1: Validate that the transition from current state is valid.
 (define (guarded-set-task-fsm-state! sess value)
+  ;; First, validate that value is a known state
   (when (and value (not (member value (task-states-list))))
     (raise-session-error (format "invalid task FSM state: ~a" value) #f))
+  ;; Second, validate that the transition is allowed
+  (define current (agent-session-task-fsm-state sess))
+  (when (and value
+             current
+             (not (eq? current 'idle))
+             (not (eq? value 'idle))
+             (not (task-valid-direct-transition? current value)))
+    (raise-session-error (format "invalid task FSM transition: ~a → ~a" current value) #f))
   (set-agent-session-task-fsm-state! sess value))
+
+;; Guard recent-tool-calls — keeps last 10, validates list of symbols/strings
+(define (guarded-set-recent-tool-calls! sess value)
+  (unless (and (list? value) (andmap (lambda (v) (or (symbol? v) (string? v))) value))
+    (raise-session-error "recent-tool-calls must be a list of symbols or strings" #f))
+  (set-agent-session-recent-tool-calls! sess value))
 
 ;; Guard task-conclusions — type-safe wrapper
 (define (guarded-set-task-conclusions! sess value)

--- a/tests/test-task-state-inference.rkt
+++ b/tests/test-task-state-inference.rkt
@@ -3,7 +3,8 @@
 ;; tests/test-task-state-inference.rkt — tests for state-inference heuristics
 ;; v0.75.2: Tool-call pattern → task-state inference + event wiring
 
-(require rackunit
+(require racket/list
+         rackunit
          rackunit/text-ui
          "../runtime/context-assembly/state-inference.rkt"
          (only-in "../runtime/context-assembly/task-state.rkt"
@@ -128,6 +129,27 @@
 
     (test-case "explicit set_task_state overrides inference"
       (define-values (inferred-state conf) (infer-task-state-from-tools '("set-task-state")))
-      (check-true (or (eq? inferred-state task-planning) (not inferred-state))))))
+      (check-true (or (eq? inferred-state task-planning) (not inferred-state))))
+
+    ;; ── W1: Accumulated tool calls + mixed types ──
+
+    (test-case "inference handles symbol tool names"
+      (define-values (state conf) (infer-task-state-from-tools '(read read edit)))
+      (check-equal? state task-implementation))
+
+    (test-case "inference handles mixed string/symbol tool names"
+      (define-values (state conf) (infer-task-state-from-tools '("read" read "edit" write)))
+      (check-equal? state task-implementation))
+
+    (test-case "batch inference caps at 10 calls"
+      (define many-reads (make-list 15 "read"))
+      (define-values (state conf) (infer-from-recent-turns (list many-reads)))
+      (check-equal? state task-exploration)
+      ;; Should not error despite >10 calls
+      (check-true (>= conf 0.5)))
+
+    (test-case "batch inference with multiple turn windows"
+      (define-values (state conf) (infer-from-recent-turns '(("read") ("edit" "write"))))
+      (check-equal? state task-implementation))))
 
 (run-tests suite)

--- a/tests/test-task-state.rkt
+++ b/tests/test-task-state.rkt
@@ -9,6 +9,9 @@
          "../runtime/context-assembly/task-state.rkt"
          "../runtime/context-assembly/task-conclusion.rkt"
          "../runtime/context-assembly/task-memory.rkt"
+         "../runtime/session-mutation.rkt"
+         "../runtime/session-types.rkt"
+         "../tests/helpers/session-fixture.rkt"
          (only-in "../util/fsm.rkt" fsm-state-name))
 
 ;; ── FSM Tests ──
@@ -247,3 +250,48 @@
       (check-equal? (task-conclusion-id (first (task-memory-conclusions m2))) "c1"))))
 
 (run-tests conclusion-suite)
+
+;; ── Session Mutation Tests ──
+
+(define mutation-suite
+  (test-suite "session-mutation"
+
+    (test-case "guarded-set-task-fsm-state! allows initialization from idle"
+      (define sess (make-test-session))
+      (guarded-set-task-fsm-state! sess 'exploration)
+      (check-equal? (agent-session-task-fsm-state sess) 'exploration))
+
+    (test-case "guarded-set-task-fsm-state! allows valid forward transition"
+      (define sess (make-test-session))
+      (guarded-set-task-fsm-state! sess 'exploration)
+      (guarded-set-task-fsm-state! sess 'planning)
+      (check-equal? (agent-session-task-fsm-state sess) 'planning))
+
+    (test-case "guarded-set-task-fsm-state! allows transition to idle (reset)"
+      (define sess (make-test-session))
+      (guarded-set-task-fsm-state! sess 'implementation)
+      (guarded-set-task-fsm-state! sess 'idle)
+      (check-equal? (agent-session-task-fsm-state sess) 'idle))
+
+    (test-case "guarded-set-task-fsm-state! rejects invalid transition"
+      (define sess (make-test-session))
+      (guarded-set-task-fsm-state! sess 'exploration)
+      (check-exn exn:fail? (lambda () (guarded-set-task-fsm-state! sess 'verification))))
+
+    (test-case "guarded-set-task-fsm-state! rejects unknown state"
+      (define sess (make-test-session))
+      (check-exn exn:fail? (lambda () (guarded-set-task-fsm-state! sess 'unknown-state))))
+
+    (test-case "guarded-set-task-fsm-state! allows any state from #f (uninitialized)"
+      (define sess (make-test-session))
+      ;; task-fsm-state defaults to #f for new sessions
+      (guarded-set-task-fsm-state! sess 'debugging)
+      (check-equal? (agent-session-task-fsm-state sess) 'debugging))
+
+    (test-case "guarded-set-recent-tool-calls! validates input"
+      (define sess (make-test-session))
+      (guarded-set-recent-tool-calls! sess '("read" "edit" "bash"))
+      (check-equal? (length (agent-session-recent-tool-calls sess)) 3)
+      (check-exn exn:fail? (lambda () (guarded-set-recent-tool-calls! sess '(read 42)))))))
+
+(run-tests mutation-suite)


### PR DESCRIPTION
Fixes FSM transition validation and inference accumulation (M1 W1 #6414).

**G2 — Transition validation:**
- `guarded-set-task-fsm-state!` now rejects invalid state→state transitions
- New `task-valid-direct-transition?` helper in task-state.rkt
- Allows initialization from idle/#f and reset to idle
- Rejects e.g. exploration → verification (must go through implementation)

**G3 — Inference accumulation:**
- `guarded-set-recent-tool-calls!` added to session-mutation.rkt
- session-events.rkt now uses the guarded setter instead of raw setter

**Tests:** +11 new tests across test-task-state.rkt (+7) and test-task-state-inference.rkt (+4)

Closes #6414.