### PR TITLE
feat: prompt injection framework for state-aware assembly (M2 W0)

### DIFF
--- a/runtime/context-assembly/state-aware-builder.rkt
+++ b/runtime/context-assembly/state-aware-builder.rkt
@@ -19,21 +19,26 @@
 ;; Feature flag: state-aware context assembly (v0.75.3)
 (define current-task-state-aware-assembly? (make-parameter #f))
 
-;; State-specific guidance strings
+;; State-specific guidance strings (action-oriented instructions)
 (define state-guidance-table
-  (hasheq
-   'idle
-   "Awaiting instructions."
-   'exploration
-   "Focus on reading and understanding the codebase. Use save_conclusion to record key findings."
-   'planning
-   "Break down the task into steps. Use save_conclusion to record the plan."
-   'implementation
-   "Focus on editing files. Use save_conclusion to record key decisions."
-   'verification
-   "Run tests and verify correctness. Use save_conclusion to record test results."
-   'debugging
-   "Focus on error-related files. Use save_conclusion to record debugging insights."))
+  (hasheq 'idle
+          "Awaiting instructions."
+          'exploration
+          (string-append "Focus on reading and understanding the codebase. "
+                         "Record key findings with record_conclusion before moving on.")
+          'planning
+          (string-append "Break down the task into steps. "
+                         "Save your plan as conclusions with record_conclusion.")
+          'implementation
+          (string-append "Focus on editing files. "
+                         "Record key decisions with record_conclusion. "
+                         "Prefer existing conclusions over re-reading files.")
+          'verification
+          (string-append "Run tests and verify correctness. "
+                         "Record test results as conclusions with record_conclusion.")
+          'debugging
+          (string-append "Focus on error-related files. "
+                         "Save error analysis as conclusions with record_conclusion.")))
 
 ;; build-tiered-context/state-aware :
 ;;   Same signature as build-tiered-context, plus optional task-state and conclusions.
@@ -148,13 +153,16 @@
          [(debugging) "DEBUGGING"]
          [else "UNKNOWN"]))
      (define guidance (hash-ref state-guidance-table state-name "Focus on the current task."))
+     (define conclusion-count (length (filter task-conclusion? conclusions)))
      (define conclusion-section
-       (if (and (pair? conclusions) (task-conclusion? (car conclusions)))
+       (if (> conclusion-count 0)
            (let* ([top (take conclusions (min 10 (length conclusions)))]
                   [texts (for/list ([c (in-list top)])
                            (format "  - ~a" (task-conclusion-text c)))])
-             (format "\n\nKey conclusions:\n~a" (string-join texts "\n")))
-           ""))
+             (format "\n\nKey conclusions (~a in memory):\n~a"
+                     conclusion-count
+                     (string-join texts "\n")))
+           "\n\nNo conclusions in memory yet. Use record_conclusion to save findings."))
      (define preamble-text
        (format "You are currently in the ~a phase.~a~a" label guidance conclusion-section))
      (make-message "state-awareness-preamble"

--- a/tests/test-prompt-injection.rkt
+++ b/tests/test-prompt-injection.rkt
@@ -1,0 +1,176 @@
+#lang racket/base
+
+;; tests/test-prompt-injection.rkt — Prompt injection effectiveness tests
+;; v0.76.1 W0: Verify state-aware system prompt instructions are injected correctly.
+
+(require rackunit
+         rackunit/text-ui
+         racket/list
+         racket/string
+         "../runtime/context-assembly/state-aware-builder.rkt"
+         "../runtime/context-assembly/task-conclusion.rkt"
+         "../runtime/context-assembly/context-floor.rkt"
+         (only-in "../util/protocol-types.rkt"
+                  message-content
+                  message-role
+                  make-message
+                  make-text-part)
+         (only-in "../util/content-parts.rkt" text-part-text)
+         (only-in "../util/fsm.rkt" fsm-state))
+
+;; Helper: extract text from a preamble message
+(define (preamble-text p)
+  (text-part-text (car (message-content p))))
+
+;; Helper: make a test conclusion
+(define (make-test-conclusion text [category 'fact])
+  (task-conclusion (format "c~a" (current-inexact-milliseconds))
+                   text
+                   category
+                   'exploration
+                   '()
+                   (current-seconds)
+                   '()))
+
+(define suite
+  (test-suite "prompt-injection"
+
+    ;; ── Presence / Absence ──
+    (test-case "preamble absent when feature flag is off"
+      (parameterize ([current-task-state-aware-assembly? #f])
+        (define msgs
+          (list (make-message "id"
+                              #f
+                              'user
+                              'text
+                              (list (make-text-part "hello"))
+                              (current-seconds)
+                              (hasheq))))
+        (define tc (build-tiered-context/state-aware msgs #:task-state 'exploration))
+        ;; When flag is off but task-state is passed, preamble still appears
+        ;; (the flag controls integration, not the builder itself)
+        (check-true (>= (length (tiered-context-tier-a tc)) 1))))
+
+    (test-case "preamble present for exploration state"
+      (define p (build-state-awareness-preamble 'exploration '()))
+      (check-not-false p)
+      (check-equal? (message-role p) 'system-instruction))
+
+    (test-case "preamble absent for idle state"
+      (check-false (build-state-awareness-preamble 'idle '())))
+
+    (test-case "preamble absent for #f state"
+      (check-false (build-state-awareness-preamble #f '())))
+
+    ;; ── State labels ──
+    (test-case "preamble contains correct state label for exploration"
+      (define text (preamble-text (build-state-awareness-preamble 'exploration '())))
+      (check-not-false (string-contains? text "EXPLORATION")))
+
+    (test-case "preamble contains correct state label for implementation"
+      (define text (preamble-text (build-state-awareness-preamble 'implementation '())))
+      (check-not-false (string-contains? text "IMPLEMENTATION")))
+
+    (test-case "preamble contains correct state label for verification"
+      (define text (preamble-text (build-state-awareness-preamble 'verification '())))
+      (check-not-false (string-contains? text "VERIFICATION")))
+
+    (test-case "preamble works with fsm-state struct"
+      (define text (preamble-text (build-state-awareness-preamble (fsm-state 'debugging) '())))
+      (check-not-false (string-contains? text "DEBUGGING")))
+
+    ;; ── Action-oriented instructions ──
+    (test-case "exploration instructions reference record_conclusion"
+      (define text (preamble-text (build-state-awareness-preamble 'exploration '())))
+      (check-not-false (string-contains? text "record_conclusion")
+                       (format "Missing record_conclusion in: ~a" text)))
+
+    (test-case "planning instructions reference record_conclusion"
+      (define text (preamble-text (build-state-awareness-preamble 'planning '())))
+      (check-not-false (string-contains? text "record_conclusion")
+                       (format "Missing record_conclusion in: ~a" text)))
+
+    (test-case "implementation instructions reference record_conclusion"
+      (define text (preamble-text (build-state-awareness-preamble 'implementation '())))
+      (check-not-false (string-contains? text "record_conclusion")
+                       (format "Missing record_conclusion in: ~a" text)))
+
+    (test-case "implementation instructions tell agent to prefer conclusions"
+      (define text (preamble-text (build-state-awareness-preamble 'implementation '())))
+      (check-not-false (string-contains? text "Prefer existing conclusions")
+                       (format "Missing preference instruction in: ~a" text)))
+
+    (test-case "verification instructions reference record_conclusion"
+      (define text (preamble-text (build-state-awareness-preamble 'verification '())))
+      (check-not-false (string-contains? text "record_conclusion")
+                       (format "Missing record_conclusion in: ~a" text)))
+
+    (test-case "debugging instructions reference record_conclusion"
+      (define text (preamble-text (build-state-awareness-preamble 'debugging '())))
+      (check-not-false (string-contains? text "record_conclusion")
+                       (format "Missing record_conclusion in: ~a" text)))
+
+    ;; ── Dynamic conclusion count ──
+    (test-case "preamble shows 0 conclusions with encouragement"
+      (define text (preamble-text (build-state-awareness-preamble 'exploration '())))
+      (check-not-false (string-contains? text "No conclusions in memory yet"))
+      (check-not-false (string-contains? text "record_conclusion")))
+
+    (test-case "preamble shows exact conclusion count for 1 conclusion"
+      (define conclusions (list (make-test-conclusion "Found the bug")))
+      (define text (preamble-text (build-state-awareness-preamble 'implementation conclusions)))
+      (check-not-false (string-contains? text "1 in memory") (format "Missing count in: ~a" text)))
+
+    (test-case "preamble shows exact conclusion count for 3 conclusions"
+      (define conclusions
+        (list (make-test-conclusion "A") (make-test-conclusion "B") (make-test-conclusion "C")))
+      (define text (preamble-text (build-state-awareness-preamble 'planning conclusions)))
+      (check-not-false (string-contains? text "3 in memory") (format "Missing count in: ~a" text)))
+
+    (test-case "preamble lists conclusion texts when conclusions exist"
+      (define conclusions (list (make-test-conclusion "Use structs for data")))
+      (define text (preamble-text (build-state-awareness-preamble 'exploration conclusions)))
+      (check-not-false (string-contains? text "Use structs for data")))
+
+    ;; ── No duplicate injection ──
+    (test-case "single preamble in tier-a for state-aware assembly"
+      (define msgs
+        (list (make-message "id"
+                            #f
+                            'user
+                            'text
+                            (list (make-text-part "hello"))
+                            (current-seconds)
+                            (hasheq))))
+      (define tc (build-tiered-context/state-aware msgs #:task-state 'planning))
+      (define tier-a (tiered-context-tier-a tc))
+      (define preamble-count (count (lambda (m) (eq? (message-role m) 'system-instruction)) tier-a))
+      (check-true (>= preamble-count 1) "Should have at least the preamble")
+      (check-true (<= preamble-count 2)
+                  (format "Too many system-instruction messages: ~a" preamble-count)))
+
+    ;; ── Conclusion cap ──
+    (test-case "preamble limits displayed conclusions to top 10"
+      (define conclusions
+        (for/list ([i (in-range 15)])
+          (make-test-conclusion (format "Finding ~a" i))))
+      (define text (preamble-text (build-state-awareness-preamble 'debugging conclusions)))
+      (check-not-false (string-contains? text "Finding 9"))
+      (check-false (string-contains? text "Finding 14")))
+
+    ;; ── Integration: full assembly includes preamble ──
+    (test-case "state-aware assembly includes instructions in message list"
+      (define msgs
+        (list (make-message "id"
+                            #f
+                            'user
+                            'text
+                            (list (make-text-part "hello"))
+                            (current-seconds)
+                            (hasheq))))
+      (define tc (build-tiered-context/state-aware msgs #:task-state 'verification))
+      (define tier-a (tiered-context-tier-a tc))
+      (check-true (>= (length tier-a) 1))
+      (check-equal? (message-role (car tier-a)) 'system-instruction))))
+
+(run-tests suite)


### PR DESCRIPTION
## M2 W0: Prompt Injection Framework (#6417)

Updates the state-awareness preamble to be action-oriented, referencing the correct `record_conclusion` tool and including dynamic conclusion counts.

### Changes
- `runtime/context-assembly/state-aware-builder.rkt`:
  - `state-guidance-table` now uses `record_conclusion` and action-oriented instructions
  - `build-state-awareness-preamble` includes conclusion count and encouragement when empty
- `tests/test-prompt-injection.rkt`: 21 tests covering presence/absence, state labels, action instructions, record_conclusion references, conclusion count accuracy, no duplicate injection

### Verification
- 128 tests pass across 6 state-aware test files
- No regressions in existing tests

### Pre-existing lint
This PR does not introduce new lint. 4 format-lint and 14 version-lint failures are pre-existing from prior milestones.