### PR TITLE
feat(v0.76.3): Per-session config + rollout gate (#6422)

### DIFF
--- a/runtime/agent-session.rkt
+++ b/runtime/agent-session.rkt
@@ -25,6 +25,7 @@
          racket/file
          racket/list
          racket/path
+         racket/dict
          (only-in "../util/errors.rkt" raise-session-error)
          (only-in "../util/protocol-types.rkt" message-id message-kind make-loop-result message?)
          "../agent/queue.rkt"
@@ -68,6 +69,7 @@
          (only-in "session-config.rkt"
                   session-config?
                   hash->session-config
+                  current-task-state-aware-rollout-rate
                   config-provider
                   config-tool-registry
                   config-event-bus
@@ -133,7 +135,8 @@
          agent-session-thinking-level
          ;; Graceful shutdown (#1158)
          agent-session-shutdown-requested?
-         agent-session-force-shutdown?)
+         agent-session-force-shutdown?
+         session-rollout-enabled?)
 
 ;; ============================================================
 ;; ARCH-05: struct definition moved to session-types.rkt
@@ -217,6 +220,12 @@
                  task-conclusions
                  recent-tool-calls))
 
+;; session-rollout-enabled? : string? -> boolean?
+;; Deterministic A/B assignment using session-id hash modulo 100.
+(define (session-rollout-enabled? sid)
+  (define rate (current-task-state-aware-rollout-rate))
+  (and (> rate 0.0) (< (modulo (equal-hash-code sid) 100) (inexact->exact (round (* rate 100))))))
+
 ;; ============================================================
 ;; make-agent-session
 ;; ============================================================
@@ -231,21 +240,25 @@
   (define base-dir (config-session-dir cfg))
   (define dir (build-path base-dir sid))
 
+  ;; M4 W0: Rollout gate — deterministically assign task-state-aware? based on session-id hash
+  (define task-state-aware? (session-rollout-enabled? sid))
+  (define cfg-with-rollout (dict-set cfg 'task-state-aware? task-state-aware?))
+
   (define session-created-at (now-seconds))
 
   (define sess
     (make-session-struct #:id sid
                          #:dir dir
-                         #:provider (config-provider cfg)
-                         #:tool-registry (config-tool-registry cfg)
-                         #:event-bus (config-event-bus cfg)
-                         #:extension-registry (config-extension-registry cfg)
-                         #:model-name (config-model-name cfg)
-                         #:system-instructions (config-system-instructions cfg)
+                         #:provider (config-provider cfg-with-rollout)
+                         #:tool-registry (config-tool-registry cfg-with-rollout)
+                         #:event-bus (config-event-bus cfg-with-rollout)
+                         #:extension-registry (config-extension-registry cfg-with-rollout)
+                         #:model-name (config-model-name cfg-with-rollout)
+                         #:system-instructions (config-system-instructions cfg-with-rollout)
                          #:queue (make-queue)
-                         #:config cfg
+                         #:config cfg-with-rollout
                          #:start-time session-created-at
-                         #:thinking-level (config-thinking-level cfg)))
+                         #:thinking-level (config-thinking-level cfg-with-rollout)))
 
   ;; Emit session.started
   (emit-typed-event! (agent-session-event-bus sess)

--- a/runtime/session-config.rkt
+++ b/runtime/session-config.rkt
@@ -35,7 +35,11 @@
          (only-in "../util/cancellation.rkt" cancellation-token?)
          (only-in "../runtime/session-index/schema.rkt" session-index?))
 
+;; Global rollout rate for state-aware assembly (0.0 = none, 1.0 = all)
+(define current-task-state-aware-rollout-rate (make-parameter 0.0))
+
 (provide session-config?
+         current-task-state-aware-rollout-rate
          ;; Smart accessors with defaults
          (contract-out
           [hash->session-config (-> hash? session-config?)]
@@ -69,7 +73,8 @@
           [config-verbose? (-> session-config? boolean?)]
           [config-max-tokens (-> session-config? exact-positive-integer?)]
           [config-token-budget-threshold (-> session-config? (or/c #f exact-nonnegative-integer?))]
-          [config-session-index (-> session-config? (or/c #f session-index?))]))
+          [config-session-index (-> session-config? (or/c #f session-index?))]
+          [config-task-state-aware? (-> session-config? boolean?)]))
 
 ;; ── session-config struct ────────────────────────────────────────
 
@@ -161,6 +166,8 @@
   (hash-ref (session-config-data c) 'token-budget-threshold #f))
 (define (config-session-index c)
   (hash-ref (session-config-data c) 'session-index #f))
+(define (config-task-state-aware? c)
+  (hash-ref (session-config-data c) 'task-state-aware? #f))
 
 ;; ── Dynamic default resolution ─────────────────────────────────
 
@@ -196,7 +203,8 @@
                verbose?
                max-tokens
                token-budget-threshold
-               session-index))
+               session-index
+               task-state-aware?))
   (define base
     (if (hash? h)
         (make-immutable-hash (hash->list h))

--- a/runtime/turn-orchestrator.rkt
+++ b/runtime/turn-orchestrator.rkt
@@ -117,7 +117,8 @@
                   config-max-tokens
                   config-working-set
                   config-settings
-                  config-model-name)
+                  config-model-name
+                  config-task-state-aware?)
          (only-in "../util/protocol-types.rkt" message-kind message-content)
          racket/set)
 
@@ -145,7 +146,7 @@
            (-> tool-registry? (or/c extension-registry? #f) event-bus? string? (listof hash?))]
           [assemble-context/pure
            (->* (list? session-config?)
-                (#:hook-dispatcher (or/c procedure? #f))
+                (#:hook-dispatcher (or/c procedure? #f) #:state-aware? (or/c boolean? #f))
                 (values list? (or/c hook-result? #f) tiered-context?))]))
 
 ;; ============================================================
@@ -158,7 +159,8 @@
                                config-raw
                                #:hook-dispatcher [hook-dispatcher #f]
                                #:task-state [task-state #f]
-                               #:conclusions [conclusions '()])
+                               #:conclusions [conclusions '()]
+                               #:state-aware? [state-aware? #f])
   (define config config-raw)
   (define tier-b-count (config-tier-b-count config))
   (define tier-c-count (config-tier-c-count config))
@@ -172,8 +174,8 @@
   (define ws-messages (force ws-messages-promise))
   (define-values (tc hook-result)
     (cond
-      ;; v0.75.3: State-aware assembly when feature flag is on
-      [(and (current-task-state-aware-assembly?) task-state)
+      ;; v0.76.3: State-aware assembly when enabled (global flag or per-session rollout)
+      [(and (or state-aware? (current-task-state-aware-assembly?)) task-state)
        (define sa-tc
          (build-tiered-context/state-aware ctx-to-use
                                            #:tier-b-count tier-b-count
@@ -216,12 +218,14 @@
   (define task-state (and session (agent-session-task-fsm-state session)))
   (define conclusions (and session (agent-session-task-conclusions session)))
   ;; FD-05: Delegate pure assembly to assemble-context/pure
+  ;; v0.76.3: Pass per-session rollout flag
   (define-values (ctx-assembled assembly-hook-result tc-struct)
     (assemble-context/pure ctx-to-use
                            config-raw
                            #:hook-dispatcher ctx-assembly-hook-dispatcher
                            #:task-state task-state
-                           #:conclusions conclusions))
+                           #:conclusions conclusions
+                           #:state-aware? (config-task-state-aware? config)))
 
   ;; Handle block action from context-assembly hook
   (when (and assembly-hook-result (eq? (hook-result-action assembly-hook-result) 'block))

--- a/tests/test-session-rollout.rkt
+++ b/tests/test-session-rollout.rkt
@@ -1,0 +1,85 @@
+#lang racket/base
+
+;; tests/test-session-rollout.rkt -- Per-session config + rollout gate tests
+;; v0.76.3 W0: Feature-flag activation with deterministic A/B assignment.
+
+(require rackunit
+         rackunit/text-ui
+         racket/dict
+         (only-in "../runtime/session-config.rkt"
+                  session-config?
+                  hash->session-config
+                  current-task-state-aware-rollout-rate
+                  config-task-state-aware?)
+         (only-in "../runtime/agent-session.rkt" make-agent-session session-rollout-enabled?)
+         (only-in "../agent/event-bus.rkt" make-event-bus)
+         (only-in "../tools/tool.rkt" make-tool-registry)
+         (only-in "../runtime/session-types.rkt" agent-session-config))
+
+(define (make-test-cfg)
+  (hash 'session-dir
+        "/tmp/q-test-sessions"
+        'event-bus
+        (make-event-bus)
+        'tool-registry
+        (make-tool-registry)))
+
+(define suite
+  (test-suite "session-rollout"
+
+    (test-case "default is #f when key missing"
+      (define cfg (hash->session-config (hash)))
+      (check-equal? (config-task-state-aware? cfg) #f))
+
+    (test-case "returns #t when set"
+      (define cfg (hash->session-config (hash 'task-state-aware? #t)))
+      (check-equal? (config-task-state-aware? cfg) #t))
+
+    (test-case "returns #f when explicitly set to #f"
+      (define cfg (hash->session-config (hash 'task-state-aware? #f)))
+      (check-equal? (config-task-state-aware? cfg) #f))
+
+    (test-case "rollout-enabled? returns #f when rate is 0.0"
+      (parameterize ([current-task-state-aware-rollout-rate 0.0])
+        (check-false (session-rollout-enabled? "test-id-123"))
+        (check-false (session-rollout-enabled? "any-id"))))
+
+    (test-case "rollout-enabled? returns #t when rate is 1.0"
+      (parameterize ([current-task-state-aware-rollout-rate 1.0])
+        (check-true (session-rollout-enabled? "test-id-123"))
+        (check-true (session-rollout-enabled? "any-id"))))
+
+    (test-case "rollout-enabled? is deterministic for same ID"
+      (parameterize ([current-task-state-aware-rollout-rate 0.5])
+        (define r1 (session-rollout-enabled? "abc"))
+        (define r2 (session-rollout-enabled? "abc"))
+        (check-equal? r1 r2)))
+
+    (test-case "rollout-enabled? at 0.5 gives mixed results across IDs"
+      (parameterize ([current-task-state-aware-rollout-rate 0.5])
+        (define results
+          (for/list ([i (in-range 100)])
+            (session-rollout-enabled? (format "session-~a" i))))
+        (define enabled (length (filter values results)))
+        (check-true (> enabled 10) (format "Expected some enabled, got ~a" enabled))
+        (check-true (< enabled 90) (format "Expected some disabled, got ~a" enabled))))
+
+    (test-case "rate 0.0 means no sessions get the flag"
+      (parameterize ([current-task-state-aware-rollout-rate 0.0])
+        (for ([i (in-range 10)])
+          (define sess (make-agent-session (make-test-cfg)))
+          (define cfg (agent-session-config sess))
+          (check-equal? (config-task-state-aware? cfg) #f))))
+
+    (test-case "rate 1.0 means all sessions get the flag"
+      (parameterize ([current-task-state-aware-rollout-rate 1.0])
+        (for ([i (in-range 10)])
+          (define sess (make-agent-session (make-test-cfg)))
+          (define cfg (agent-session-config sess))
+          (check-equal? (config-task-state-aware? cfg) #t))))
+
+    (test-case "task-state-aware? is accessible via dict-ref"
+      (define cfg (hash->session-config (hash 'task-state-aware? #t)))
+      (check-equal? (dict-ref cfg 'task-state-aware?) #t))))
+
+(run-tests suite)


### PR DESCRIPTION
M4 W0: Graduated Feature Activation

- `config-task-state-aware?` accessor in session-config.rkt
- `current-task-state-aware-rollout-rate` parameter (default 0.0)
- `session-rollout-enabled?` deterministic hash-based A/B assignment
- `make-agent-session` sets `task-state-aware?` via rollout gate
- `assemble-context/pure` accepts `#:state-aware?` per-session flag
- `build-assembled-context` passes per-session flag from config
- 10 new tests in `test-session-rollout.rkt`

Closes #6422