### PR TITLE
feat(v0.76.3): Rollback triggers (#6424)

### DIFF
--- a/runtime/context-assembly/state-aware-builder.rkt
+++ b/runtime/context-assembly/state-aware-builder.rkt
@@ -14,7 +14,8 @@
 
 (provide current-task-state-aware-assembly?
          build-tiered-context/state-aware
-         build-state-awareness-preamble)
+         build-state-awareness-preamble
+         check-rollback-triggers)
 
 ;; Feature flag: state-aware context assembly (v0.75.3)
 (define current-task-state-aware-assembly? (make-parameter #f))
@@ -172,3 +173,45 @@
                    (list (make-text-part preamble-text))
                    (current-seconds)
                    (hasheq))]))
+
+;; ════════════════════════════════════════════════════════════════
+;; v0.76.3 W2: Rollback trigger checks (observational only)
+;; ════════════════════════════════════════════════════════════════
+
+;; check-rollback-triggers :
+;;   #:before-tokens number? #:after-tokens number?
+;;   #:conclusion-coverage number? #:repeat-tool-count exact-nonnegative-integer?
+;;   -> (listof (list/c symbol? string?))
+;;
+;; Returns a list of warning tuples: (trigger-type message).
+;; Triggers are observational — callers decide what to do.
+(define (check-rollback-triggers #:before-tokens before-tokens
+                                 #:after-tokens after-tokens
+                                 #:conclusion-coverage conclusion-coverage
+                                 #:repeat-tool-count repeat-tool-count)
+  (define warnings '())
+
+  ;; Trigger 1: Excessive savings (>50% tokens cut)
+  ;; R2 risk: context may be too small to work effectively
+  (when (and (> before-tokens 0) (> after-tokens 0) (< after-tokens (* before-tokens 0.50)))
+    (set! warnings
+          (cons (list 'excessive-savings
+                      (format "Context reduced by >50%: ~a → ~a tokens" before-tokens after-tokens))
+                warnings)))
+
+  ;; Trigger 2: Low conclusion coverage (amnesia risk)
+  ;; R0 risk: agent forgetting key findings
+  (when (< conclusion-coverage 0.20)
+    (set! warnings
+          (cons (list 'amnesia-risk (format "Conclusion coverage too low: ~a" conclusion-coverage))
+                warnings)))
+
+  ;; Trigger 3: Repeated tool calls (same file re-read > 2x)
+  ;; Indicates agent is re-reading files it should have conclusions for
+  (when (> repeat-tool-count 2)
+    (set! warnings
+          (cons (list 'task-amnesia-detected
+                      (format "Repeated tool calls detected: ~a re-reads" repeat-tool-count))
+                warnings)))
+
+  (reverse warnings))

--- a/tests/test-rollback-triggers.rkt
+++ b/tests/test-rollback-triggers.rkt
@@ -1,0 +1,106 @@
+#lang racket/base
+
+;; tests/test-rollback-triggers.rkt — Tests for M4 W2 rollback triggers
+;; v0.76.3 W2: Observational triggers that emit warnings when context is too aggressive.
+
+(require rackunit
+         "../runtime/context-assembly/state-aware-builder.rkt"
+         "../runtime/context-assembly/context-floor.rkt"
+         "../runtime/context-assembly/task-conclusion.rkt"
+         (only-in "../util/protocol-types.rkt" make-message make-text-part message-content))
+
+;; Helpers
+(define (make-test-msg text)
+  (make-message "id" #f 'user 'text (list (make-text-part text)) (current-seconds) (hasheq)))
+
+(define (make-conclusion text)
+  (task-conclusion "c1" text 'fact 'exploration '() (current-seconds) '()))
+
+;; ── Trigger 1: Excessive savings warning (savings > 50%) ──
+
+(test-case "trigger-1: excessive savings returns warning when >50% tokens cut"
+  (define warnings
+    (check-rollback-triggers #:before-tokens 1000
+                             #:after-tokens 400
+                             #:conclusion-coverage 0.5
+                             #:repeat-tool-count 0))
+  (define excessive (filter (λ (w) (eq? (car w) 'excessive-savings)) warnings))
+  (check-true (pair? excessive)))
+
+(test-case "trigger-1: no warning when savings < 50%"
+  (define warnings
+    (check-rollback-triggers #:before-tokens 1000
+                             #:after-tokens 600
+                             #:conclusion-coverage 0.5
+                             #:repeat-tool-count 0))
+  (define excessive (filter (λ (w) (eq? (car w) 'excessive-savings)) warnings))
+  (check-false (pair? excessive)))
+
+(test-case "trigger-1: no warning when after-tokens = 0 (no context at all)"
+  (define warnings
+    (check-rollback-triggers #:before-tokens 1000
+                             #:after-tokens 0
+                             #:conclusion-coverage 0.5
+                             #:repeat-tool-count 0))
+  (define excessive (filter (λ (w) (eq? (car w) 'excessive-savings)) warnings))
+  (check-false (pair? excessive)))
+
+;; ── Trigger 2: Low conclusion coverage (amnesia risk) ──
+
+(test-case "trigger-2: low coverage returns warning when < 0.20"
+  (define warnings
+    (check-rollback-triggers #:before-tokens 1000
+                             #:after-tokens 800
+                             #:conclusion-coverage 0.10
+                             #:repeat-tool-count 0))
+  (define amnesia (filter (λ (w) (eq? (car w) 'amnesia-risk)) warnings))
+  (check-true (pair? amnesia)))
+
+(test-case "trigger-2: no warning when coverage >= 0.20"
+  (define warnings
+    (check-rollback-triggers #:before-tokens 1000
+                             #:after-tokens 800
+                             #:conclusion-coverage 0.30
+                             #:repeat-tool-count 0))
+  (define amnesia (filter (λ (w) (eq? (car w) 'amnesia-risk)) warnings))
+  (check-false (pair? amnesia)))
+
+;; ── Trigger 3: Repeated tool calls (same file re-read) ──
+
+(test-case "trigger-3: repeated tool calls returns warning when > 2"
+  (define warnings
+    (check-rollback-triggers #:before-tokens 1000
+                             #:after-tokens 800
+                             #:conclusion-coverage 0.5
+                             #:repeat-tool-count 3))
+  (define repeated (filter (λ (w) (eq? (car w) 'task-amnesia-detected)) warnings))
+  (check-true (pair? repeated)))
+
+(test-case "trigger-3: no warning when repeat count <= 2"
+  (define warnings
+    (check-rollback-triggers #:before-tokens 1000
+                             #:after-tokens 800
+                             #:conclusion-coverage 0.5
+                             #:repeat-tool-count 2))
+  (define repeated (filter (λ (w) (eq? (car w) 'task-amnesia-detected)) warnings))
+  (check-false (pair? repeated)))
+
+;; ── No triggers case ──
+
+(test-case "no triggers when all metrics healthy"
+  (define warnings
+    (check-rollback-triggers #:before-tokens 1000
+                             #:after-tokens 800
+                             #:conclusion-coverage 0.5
+                             #:repeat-tool-count 0))
+  (check-equal? warnings '()))
+
+;; ── Multiple triggers fire simultaneously ──
+
+(test-case "multiple triggers fire simultaneously"
+  (define warnings
+    (check-rollback-triggers #:before-tokens 1000
+                             #:after-tokens 400
+                             #:conclusion-coverage 0.10
+                             #:repeat-tool-count 3))
+  (check-equal? (length warnings) 3))


### PR DESCRIPTION
M4 W2: Automatic Rollback Triggers

- `check-rollback-triggers` in state-aware-builder.rkt
- Trigger 1: excessive-savings (>50% token cut, R2 risk)
- Trigger 2: amnesia-risk (conclusion coverage < 0.20, R0 risk)
- Trigger 3: task-amnesia-detected (repeat tool calls > 2)
- Observational only — returns warning tuples, no side effects
- 9 new tests in test-rollback-triggers.rkt

Closes #6424