### PR TITLE
feat(v0.76.4): Conclusion-first working-set (#6425 #6426)

### DIFF
--- a/runtime/context-assembly/state-aware-builder.rkt
+++ b/runtime/context-assembly/state-aware-builder.rkt
@@ -5,17 +5,27 @@
 
 (require racket/list
          racket/string
-         (only-in "../../util/protocol-types.rkt" message make-message make-text-part)
-         (only-in "task-conclusion.rkt" task-conclusion? task-conclusion-text)
+         (only-in "../../util/protocol-types.rkt"
+                  message
+                  message-id
+                  message-content
+                  make-message
+                  make-text-part)
+         (only-in "task-conclusion.rkt"
+                  task-conclusion?
+                  task-conclusion-text
+                  task-conclusion-origin-message-ids)
          (only-in "state-relevance.rkt" context-level-for-state)
          (only-in "../../util/ids.rkt" generate-id)
          (only-in "../../util/fsm.rkt" fsm-state? fsm-state-name)
+         (only-in "../../util/content-parts.rkt" text-part-text text-part? text-part)
          "context-floor.rkt")
 
 (provide current-task-state-aware-assembly?
          build-tiered-context/state-aware
          build-state-awareness-preamble
-         check-rollback-triggers)
+         check-rollback-triggers
+         ws-entry->conclusion-or-self)
 
 ;; Feature flag: state-aware context assembly (v0.75.3)
 (define current-task-state-aware-assembly? (make-parameter #f))
@@ -63,11 +73,20 @@
   (define conclusions-level (and state-name (context-level-for-state state-name 'conclusions)))
 
   ;; Adjust working-set based on state relevance
+  ;; v0.76.4: conclusion-first replacement when filtered/excluded
   (define effective-ws
     (cond
-      [(eq? ws-level 'excluded) '()]
-      ;; Keep only the most recent working-set entries
-      [(eq? ws-level 'filtered) (take ws-messages (min 3 (length ws-messages)))]
+      [(eq? ws-level 'excluded)
+       ;; v0.76.4: Instead of dropping all, keep entries that have matching conclusions
+       ;; (as compact replacement). Unmatched entries are still dropped (backward compat).
+       (for/list ([m (in-list ws-messages)]
+                  #:when (for/or ([c (in-list conclusions)]
+                                  #:when (task-conclusion? c))
+                           (member (message-id m) (task-conclusion-origin-message-ids c))))
+         (ws-entry->conclusion-or-self m conclusions))]
+      [(eq? ws-level 'filtered)
+       (define filtered (take ws-messages (min 3 (length ws-messages))))
+       (map (λ (m) (ws-entry->conclusion-or-self m conclusions)) filtered)]
       [else ws-messages]))
 
   ;; Add conclusions as context entries when relevant
@@ -215,3 +234,31 @@
                 warnings)))
 
   (reverse warnings))
+
+;; ════════════════════════════════════════════════════════════════
+;; v0.76.4 M5 W0: Conclusion-first working-set replacement
+;; ════════════════════════════════════════════════════════════════
+
+;; ws-entry->conclusion-or-self :
+;;   message? (listof task-conclusion?) -> message?
+;; If a conclusion references this message's ID via origin-message-ids,
+;; returns a compact replacement message with conclusion text.
+;; Otherwise returns the original message unchanged.
+(define (ws-entry->conclusion-or-self ws-msg conclusions)
+  (define msg-id-val (message-id ws-msg))
+  (define matching-conclusion
+    (for/first ([c (in-list conclusions)]
+                #:when (and (task-conclusion? c)
+                            (member msg-id-val (task-conclusion-origin-message-ids c))))
+      c))
+  (cond
+    [matching-conclusion
+     (make-message (message-id ws-msg)
+                   #f
+                   'system-instruction
+                   'text
+                   (list (make-text-part (format "[Conclusion replaces context] ~a"
+                                                 (task-conclusion-text matching-conclusion))))
+                   (current-seconds)
+                   (hasheq))]
+    [else ws-msg]))

--- a/tests/test-ws-conclusion-fallback.rkt
+++ b/tests/test-ws-conclusion-fallback.rkt
@@ -1,0 +1,118 @@
+#lang racket/base
+
+;; tests/test-ws-conclusion-fallback.rkt — M5 W0/W1: Conclusion-first working-set
+;; v0.76.4: When WS is filtered/excluded, replace with matching conclusions.
+
+(require rackunit
+         racket/string
+         "../runtime/context-assembly/state-aware-builder.rkt"
+         "../runtime/context-assembly/context-floor.rkt"
+         "../runtime/context-assembly/task-conclusion.rkt"
+         (only-in "../util/protocol-types.rkt" make-message make-text-part message-content message-id)
+         (only-in "../util/content-parts.rkt" text-part-text))
+
+;; Helpers
+(define (make-test-msg id text)
+  (make-message id #f 'user 'text (list (make-text-part text)) (current-seconds) (hasheq)))
+
+(define (make-conclusion text #:origin-ids [origin-ids '()])
+  (task-conclusion "c1" text 'fact 'exploration origin-ids (current-seconds) '()))
+
+;; ── W0: working-set-entry->conclusion-or-self ──
+
+(test-case "ws-entry replaced when matching conclusion exists"
+  (define ws-msg
+    (make-test-msg "msg-1" "This is a very long file content that takes many tokens to represent."))
+  (define conclusions (list (make-conclusion "Key insight about module X" #:origin-ids '("msg-1"))))
+  (define result (ws-entry->conclusion-or-self ws-msg conclusions))
+  ;; Result should be a message with conclusion text, not original text
+  (define result-text (text-part-text (car (message-content result))))
+  (check-true (string-contains? result-text "Key insight about module X"))
+  (check-false (string-contains? result-text "very long file content")))
+
+(test-case "ws-entry falls back when no matching conclusion"
+  (define ws-msg (make-test-msg "msg-1" "This is a very long file content that takes many tokens."))
+  (define conclusions (list (make-conclusion "Unrelated conclusion" #:origin-ids '("msg-2"))))
+  (define result (ws-entry->conclusion-or-self ws-msg conclusions))
+  ;; Should keep original message
+  (check-equal? (message-id result) "msg-1")
+  (define result-text (text-part-text (car (message-content result))))
+  (check-true (string-contains? result-text "very long file content")))
+
+(test-case "ws-entry falls back when no conclusions at all"
+  (define ws-msg (make-test-msg "msg-1" "File content here."))
+  (define result (ws-entry->conclusion-or-self ws-msg '()))
+  (check-equal? (message-id result) "msg-1"))
+
+;; ── W1: Integration with build-tiered-context/state-aware ──
+
+(test-case "filtered WS replaces entries with conclusions"
+  (define ws-msg (make-test-msg "ws-1" (make-string 500 #\x)))
+  (define conclusions (list (make-conclusion "Short summary" #:origin-ids '("ws-1"))))
+  (define tc
+    (build-tiered-context/state-aware (list (make-test-msg "m1" "hello"))
+                                      #:tier-b-count 5
+                                      #:tier-c-count 2
+                                      #:working-set-messages (list ws-msg)
+                                      #:task-state 'implementation
+                                      #:conclusions conclusions))
+  ;; The WS message in tier-a should be replaced with conclusion text
+  (define tier-a-texts
+    (for/list ([m (tiered-context-tier-a tc)])
+      (text-part-text (car (message-content m)))))
+  ;; At least one tier-a message should contain "Short summary"
+  (check-true (ormap (λ (t) (string-contains? t "Short summary")) tier-a-texts)))
+
+(test-case "mixed WS: some replaced, some fall back"
+  (define ws-1 (make-test-msg "ws-1" (make-string 500 #\x)))
+  (define ws-2 (make-test-msg "ws-2" (make-string 500 #\y)))
+  (define conclusions (list (make-conclusion "Summary of ws-1" #:origin-ids '("ws-1"))))
+  ;; verification has ws-level='filtered, so WS entries are kept and replaced where possible
+  (define tc
+    (build-tiered-context/state-aware (list (make-test-msg "m1" "hello"))
+                                      #:tier-b-count 5
+                                      #:tier-c-count 2
+                                      #:working-set-messages (list ws-1 ws-2)
+                                      #:task-state 'verification
+                                      #:conclusions conclusions))
+  (define tier-a-texts
+    (for/list ([m (tiered-context-tier-a tc)])
+      (text-part-text (car (message-content m)))))
+  ;; ws-1 should be replaced with conclusion
+  (check-true (ormap (λ (t) (string-contains? t "Summary of ws-1")) tier-a-texts))
+  ;; ws-2 should fall back (original long content) since no conclusion matches
+  (check-true (ormap (λ (t) (string-contains? t (make-string 500 #\y))) tier-a-texts)))
+
+(test-case "token count reduced when conclusions replace WS entries"
+  (define ws-msg
+    (make-test-msg "ws-1"
+                   (apply string-append
+                          (for/list ([i 100])
+                            (format "Word~a " i)))))
+  (define conclusions-no-match (list (make-conclusion "Unrelated" #:origin-ids '("other"))))
+  (define conclusions-match (list (make-conclusion "Short" #:origin-ids '("ws-1"))))
+  ;; verification has ws-level='filtered, so WS entries are kept
+  (define tc-no-replace
+    (build-tiered-context/state-aware (list (make-test-msg "m1" "hi"))
+                                      #:tier-b-count 5
+                                      #:tier-c-count 2
+                                      #:working-set-messages (list ws-msg)
+                                      #:task-state 'verification
+                                      #:conclusions conclusions-no-match))
+  (define tc-replace
+    (build-tiered-context/state-aware (list (make-test-msg "m1" "hi"))
+                                      #:tier-b-count 5
+                                      #:tier-c-count 2
+                                      #:working-set-messages (list ws-msg)
+                                      #:task-state 'verification
+                                      #:conclusions conclusions-match))
+
+  ;; With replacement, total tokens should be fewer
+  (define (tc-tokens tc)
+    (+ (for/sum ([m (tiered-context-tier-a tc)])
+                (string-length (text-part-text (car (message-content m)))))
+       (for/sum ([m (tiered-context-tier-b tc)])
+                (string-length (text-part-text (car (message-content m)))))
+       (for/sum ([m (tiered-context-tier-c tc)])
+                (string-length (text-part-text (car (message-content m)))))))
+  (check-true (< (tc-tokens tc-replace) (tc-tokens tc-no-replace))))


### PR DESCRIPTION
M5 W0+W1: Working-Set Deprecation Path

- `ws-entry->conclusion-or-self`: matches WS entries to conclusions via origin-message-ids
- When WS excluded: keeps only entries with matching conclusions (compact replacement)
- When WS filtered: applies conclusion-first to filtered subset, falls back to original
- 6 new tests in test-ws-conclusion-fallback.rkt
- All 72 related tests pass (state-aware-assembly, rollback-triggers, session-rollout, context-assembly-pure, token-metrics)

Closes #6425
Closes #6426