### PR TITLE
feat(v0.76.5): Conclusion dependency tracking (#6427 #6428)

### DIFF
--- a/runtime/context-assembly/task-conclusion.rkt
+++ b/runtime/context-assembly/task-conclusion.rkt
@@ -20,7 +20,7 @@
          origin-message-ids ; (listof string) — provenance: which messages led to this
          timestamp ; integer — epoch seconds
          relevance-tags ; (listof symbol) — tags for state-relevance matching
-         )
+         dependencies)
   #:transparent)
 
 ;; ── Predicates ──
@@ -46,7 +46,9 @@
         'timestamp
         (task-conclusion-timestamp c)
         'relevance-tags
-        (task-conclusion-relevance-tags c)))
+        (task-conclusion-relevance-tags c)
+        'dependencies
+        (task-conclusion-dependencies c)))
 
 (define (hash->conclusion h)
   (task-conclusion (hash-ref h 'id)
@@ -55,7 +57,8 @@
                    (hash-ref h 'fsm-state-origin)
                    (hash-ref h 'origin-message-ids '())
                    (hash-ref h 'timestamp 0)
-                   (hash-ref h 'relevance-tags '())))
+                   (hash-ref h 'relevance-tags '())
+                   (hash-ref h 'dependencies '())))
 
 ;; ── Exports ──
 

--- a/runtime/session-events.rkt
+++ b/runtime/session-events.rkt
@@ -135,7 +135,8 @@
                                        current-state
                                        '()
                                        (current-seconds)
-                                       tag-syms))
+                                       tag-syms
+                                       '())) ; dependencies — v0.76.5
                     ;; Add to session
                     (define current-conclusions (agent-session-task-conclusions sess))
                     (guarded-set-task-conclusions! sess (append current-conclusions (list c)))

--- a/scripts/benchmark/context-efficiency.rkt
+++ b/scripts/benchmark/context-efficiency.rkt
@@ -43,7 +43,14 @@
      (for/sum ([m (tiered-context-tier-c tc)]) (msg-tokens m))))
 
 (define (make-conclusion text)
-  (task-conclusion (format "c~a" (random 100000)) text 'fact 'exploration '() (current-seconds) '()))
+  (task-conclusion (format "c~a" (random 100000))
+                   text
+                   'fact
+                   'exploration
+                   '()
+                   (current-seconds)
+                   '()
+                   '()))
 
 ;; ── Generate synthetic context for benchmark ──
 

--- a/scripts/benchmark/task-state-aware.rkt
+++ b/scripts/benchmark/task-state-aware.rkt
@@ -27,6 +27,7 @@
                    'exploration
                    '()
                    (current-seconds)
+                   '()
                    '()))
 
 (define (preamble-text task-state conclusions)

--- a/tests/test-conclusion-dependencies.rkt
+++ b/tests/test-conclusion-dependencies.rkt
@@ -1,0 +1,81 @@
+#lang racket/base
+
+;; tests/test-conclusion-dependencies.rkt — M6: Conclusion dependency tracking
+;; v0.76.5: Conclusions store file paths they depend on.
+
+(require rackunit
+         "../runtime/context-assembly/task-conclusion.rkt")
+
+;; ── Dependency field exists and defaults to empty ──
+
+(test-case "new conclusion has empty dependencies by default"
+  (define c (task-conclusion "c1" "Found a bug" 'fact 'exploration '() 1000 '() '()))
+  (check-equal? (task-conclusion-dependencies c) '()))
+
+(test-case "conclusion stores dependency paths"
+  (define c (task-conclusion "c1"
+                             "Module X depends on Y"
+                             'fact
+                             'exploration
+                             '()
+                             1000
+                             '(module)
+                             '("src/module-x.rkt" "src/module-y.rkt")))
+  (check-equal? (task-conclusion-dependencies c)
+                '("src/module-x.rkt" "src/module-y.rkt")))
+
+;; ── Serialization round-trip with dependencies ──
+
+(test-case "conclusion->hash includes dependencies"
+  (define c (task-conclusion "c1"
+                             "text"
+                             'fact
+                             'exploration
+                             '()
+                             1000
+                             '()
+                             '("file.rkt")))
+  (define h (conclusion->hash c))
+  (check-equal? (hash-ref h 'dependencies) '("file.rkt")))
+
+(test-case "hash->conclusion reads dependencies"
+  (define h (hash 'id "c1"
+                  'text "text"
+                  'category 'fact
+                  'fsm-state-origin 'exploration
+                  'origin-message-ids '()
+                  'timestamp 1000
+                  'relevance-tags '()
+                  'dependencies '("a.rkt" "b.rkt")))
+  (define c (hash->conclusion h))
+  (check-equal? (task-conclusion-dependencies c) '("a.rkt" "b.rkt")))
+
+(test-case "hash->conclusion defaults dependencies to empty when missing"
+  (define h (hash 'id "c1"
+                  'text "text"
+                  'category 'fact
+                  'fsm-state-origin 'exploration
+                  'origin-message-ids '()
+                  'timestamp 1000
+                  'relevance-tags '()))
+  (define c (hash->conclusion h))
+  (check-equal? (task-conclusion-dependencies c) '()))
+
+;; ── Multiple dependencies ──
+
+(test-case "conclusion with many dependencies"
+  (define deps (for/list ([i 10]) (format "src/file~a.rkt" i)))
+  (define c (task-conclusion "c1" "overview" 'fact 'exploration '() 1000 '() deps))
+  (check-equal? (task-conclusion-dependencies c) deps)
+  (check-equal? (length (task-conclusion-dependencies c)) 10))
+
+;; ── Cycle-free by construction ──
+
+(test-case "dependencies are just file paths, no cycle risk"
+  ;; The tagging system is acyclic by construction — dependencies are
+  ;; file path strings, not references to other conclusions.
+  (define c1 (task-conclusion "c1" "fact about A" 'fact 'exploration '() 1000 '() '("a.rkt")))
+  (define c2 (task-conclusion "c2" "fact about B" 'fact 'exploration '() 1000 '() '("b.rkt")))
+  ;; c1's dependencies don't reference c2 and vice versa
+  (check-false (member "b.rkt" (task-conclusion-dependencies c1)))
+  (check-false (member "a.rkt" (task-conclusion-dependencies c2))))

--- a/tests/test-prompt-injection.rkt
+++ b/tests/test-prompt-injection.rkt
@@ -30,6 +30,7 @@
                    'exploration
                    '()
                    (current-seconds)
+                   '()
                    '()))
 
 (define suite

--- a/tests/test-rollback-triggers.rkt
+++ b/tests/test-rollback-triggers.rkt
@@ -14,7 +14,7 @@
   (make-message "id" #f 'user 'text (list (make-text-part text)) (current-seconds) (hasheq)))
 
 (define (make-conclusion text)
-  (task-conclusion "c1" text 'fact 'exploration '() (current-seconds) '()))
+  (task-conclusion "c1" text 'fact 'exploration '() (current-seconds) '() '()))
 
 ;; ── Trigger 1: Excessive savings warning (savings > 50%) ──
 

--- a/tests/test-session-task-state.rkt
+++ b/tests/test-session-task-state.rkt
@@ -70,7 +70,7 @@
 
     (test-case "guarded-set-task-conclusions! updates conclusions"
       (define s (make-test-session))
-      (define c (task-conclusion "c1" "test" 'fact 'exploration '() 1000 '()))
+      (define c (task-conclusion "c1" "test" 'fact 'exploration '() 1000 '() '()))
       (guarded-set-task-conclusions! s (list c))
       (check-equal? (length (agent-session-task-conclusions s)) 1)
       (check-equal? (task-conclusion-text (car (agent-session-task-conclusions s))) "test"))
@@ -83,8 +83,8 @@
 
     (test-case "guarded-set-task-conclusions! can accumulate"
       (define s (make-test-session))
-      (define c1 (task-conclusion "c1" "first" 'fact 'exploration '() 1000 '()))
-      (define c2 (task-conclusion "c2" "second" 'decision 'planning '() 2000 '()))
+      (define c1 (task-conclusion "c1" "first" 'fact 'exploration '() 1000 '() '()))
+      (define c2 (task-conclusion "c2" "second" 'decision 'planning '() 2000 '() '()))
       (guarded-set-task-conclusions! s (list c1))
       (guarded-set-task-conclusions! s (append (agent-session-task-conclusions s) (list c2)))
       (check-equal? (length (agent-session-task-conclusions s)) 2))))

--- a/tests/test-state-aware-assembly.rkt
+++ b/tests/test-state-aware-assembly.rkt
@@ -58,8 +58,9 @@
 (define ws-messages (list (ws-msg "ws-entry-1") (ws-msg "ws-entry-2") (ws-msg "ws-entry-3")))
 
 (define conclusions
-  (list (task-conclusion "c1" "Files are organized by layer" 'fact 'idle '() (current-seconds) '())
-        (task-conclusion "c2" "Tests use rackunit" 'fact 'idle '() (current-seconds) '())))
+  (list
+   (task-conclusion "c1" "Files are organized by layer" 'fact 'idle '() (current-seconds) '() '())
+   (task-conclusion "c2" "Tests use rackunit" 'fact 'idle '() (current-seconds) '() '())))
 
 (define (count-ws tier-a)
   (length (filter (lambda (m) (hash-ref (message-meta-safe m) 'working-set #f)) tier-a)))
@@ -220,8 +221,8 @@
 
     (test-case "preamble includes conclusions summary"
       (define conclusions
-        (list (task-conclusion "c1" "Use struct for data" 'fact 'idle '() (current-seconds) '())
-              (task-conclusion "c2" "Tests in tests/" 'fact 'idle '() (current-seconds) '())))
+        (list (task-conclusion "c1" "Use struct for data" 'fact 'idle '() (current-seconds) '() '())
+              (task-conclusion "c2" "Tests in tests/" 'fact 'idle '() (current-seconds) '() '())))
       (define p (build-state-awareness-preamble task-exploration conclusions))
       (define text (text-part-text (car (message-content p))))
       (check-not-false (string-contains? text "Use struct for data")
@@ -236,6 +237,7 @@
                            'idle
                            '()
                            (current-seconds)
+                           '()
                            '())))
       (define p (build-state-awareness-preamble task-planning conclusions))
       (define text (text-part-text (car (message-content p))))

--- a/tests/test-state-aware-builder.rkt
+++ b/tests/test-state-aware-builder.rkt
@@ -62,7 +62,7 @@
     (test-case "state-aware with conclusions adds conclusion entries"
       (define msgs (make-test-msgs 5))
       (define conclusions
-        (list (task-conclusion "c1" "Found the bug" 'fact 'exploration '() 1000 '())))
+        (list (task-conclusion "c1" "Found the bug" 'fact 'exploration '() 1000 '() '())))
       (define tc
         (build-tiered-context/state-aware msgs
                                           #:task-state 'implementation
@@ -93,7 +93,7 @@
 
     (test-case "preamble includes conclusions text"
       (define conclusions
-        (list (task-conclusion "c1" "Bug in line 42" 'fact 'debugging '() 1000 '())))
+        (list (task-conclusion "c1" "Bug in line 42" 'fact 'debugging '() 1000 '() '())))
       (define preamble (build-state-awareness-preamble 'debugging conclusions))
       (check-not-false preamble))
 

--- a/tests/test-task-state.rkt
+++ b/tests/test-task-state.rkt
@@ -148,7 +148,14 @@
 
     (test-case "task-conclusion creation with all fields"
       (define c
-        (task-conclusion "c1" "Found the bug" 'fact 'exploration '("m1" "m2") 1000 '(bug pattern)))
+        (task-conclusion "c1"
+                         "Found the bug"
+                         'fact
+                         'exploration
+                         '("m1" "m2")
+                         1000
+                         '(bug pattern)
+                         '()))
       (check-equal? (task-conclusion-id c) "c1")
       (check-equal? (task-conclusion-text c) "Found the bug")
       (check-equal? (task-conclusion-category c) 'fact)
@@ -169,7 +176,14 @@
 
     (test-case "conclusion->hash / hash->conclusion round-trip"
       (define c
-        (task-conclusion "c2" "Decided to use FSM" 'decision 'planning '("m3") 2000 '(architecture)))
+        (task-conclusion "c2"
+                         "Decided to use FSM"
+                         'decision
+                         'planning
+                         '("m3")
+                         2000
+                         '(architecture)
+                         '()))
       (define h (conclusion->hash c))
       (define c2 (hash->conclusion h))
       (check-equal? (task-conclusion-id c2) "c2")
@@ -189,8 +203,8 @@
 
     (test-case "add-conclusion appends and returns new store"
       (define m (make-task-memory))
-      (define c1 (task-conclusion "c1" "text1" 'fact 'exploration '() 1000 '()))
-      (define c2 (task-conclusion "c2" "text2" 'decision 'planning '() 2000 '()))
+      (define c1 (task-conclusion "c1" "text1" 'fact 'exploration '() 1000 '() '()))
+      (define c2 (task-conclusion "c2" "text2" 'decision 'planning '() 2000 '() '()))
       (define m1 (add-conclusion m c1))
       (check-equal? (length (task-memory-conclusions m1)) 1)
       (define m2 (add-conclusion m1 c2))
@@ -199,9 +213,9 @@
       (check-equal? (length (task-memory-conclusions m)) 0))
 
     (test-case "conclusions-for-states filters correctly"
-      (define c1 (task-conclusion "c1" "t1" 'fact 'exploration '() 1000 '()))
-      (define c2 (task-conclusion "c2" "t2" 'decision 'planning '() 2000 '()))
-      (define c3 (task-conclusion "c3" "t3" 'pattern 'implementation '() 3000 '()))
+      (define c1 (task-conclusion "c1" "t1" 'fact 'exploration '() 1000 '() '()))
+      (define c2 (task-conclusion "c2" "t2" 'decision 'planning '() 2000 '() '()))
+      (define c3 (task-conclusion "c3" "t3" 'pattern 'implementation '() 3000 '() '()))
       (define m (add-conclusion (add-conclusion (add-conclusion (make-task-memory) c1) c2) c3))
       ;; Filter by exploration only
       (check-equal? (length (conclusions-for-states m '(exploration))) 1)
@@ -211,9 +225,9 @@
       (check-equal? (length (conclusions-for-states m '(idle))) 0))
 
     (test-case "conclusions-with-tags filters correctly"
-      (define c1 (task-conclusion "c1" "t1" 'fact 'exploration '() 1000 '(bug)))
-      (define c2 (task-conclusion "c2" "t2" 'decision 'planning '() 2000 '(architecture)))
-      (define c3 (task-conclusion "c3" "t3" 'pattern 'exploration '() 3000 '(bug pattern)))
+      (define c1 (task-conclusion "c1" "t1" 'fact 'exploration '() 1000 '(bug) '()))
+      (define c2 (task-conclusion "c2" "t2" 'decision 'planning '() 2000 '(architecture) '()))
+      (define c3 (task-conclusion "c3" "t3" 'pattern 'exploration '() 3000 '(bug pattern) '()))
       (define m (add-conclusion (add-conclusion (add-conclusion (make-task-memory) c1) c2) c3))
       (check-equal? (length (conclusions-with-tags m '(bug))) 2)
       (check-equal? (length (conclusions-with-tags m '(architecture))) 1)
@@ -230,6 +244,7 @@
                            (if (even? i) 'exploration 'planning)
                            '()
                            (* (add1 i) 1000)
+                           '()
                            '())))
       (define filled
         (for/fold ([m m]) ([c conclusions])
@@ -241,7 +256,7 @@
 
     (test-case "task-memory serialization round-trip"
       (define m (make-task-memory 10))
-      (define c (task-conclusion "c1" "test" 'fact 'exploration '("m1") 1000 '(tag)))
+      (define c (task-conclusion "c1" "test" 'fact 'exploration '("m1") 1000 '(tag) '()))
       (define m1 (add-conclusion m c))
       (define h (task-memory->hash m1))
       (define m2 (hash->task-memory h))

--- a/tests/test-v0756-audit-closure.rkt
+++ b/tests/test-v0756-audit-closure.rkt
@@ -111,7 +111,7 @@
 
     (test-case "append-conclusion! + load-conclusions round-trip"
       (define log-path (make-temp-log-path))
-      (define c1 (task-conclusion "c1" "test fact" 'fact 'exploration '() 1000 '()))
+      (define c1 (task-conclusion "c1" "test fact" 'fact 'exploration '() 1000 '() '()))
       (append-conclusion! log-path c1)
       (define loaded (load-conclusions log-path))
       (check-equal? (length loaded) 1)
@@ -121,8 +121,8 @@
 
     (test-case "append-conclusion! accumulates multiple conclusions"
       (define log-path (make-temp-log-path))
-      (define c1 (task-conclusion "c1" "first" 'fact 'exploration '() 1000 '()))
-      (define c2 (task-conclusion "c2" "second" 'decision 'planning '() 2000 '()))
+      (define c1 (task-conclusion "c1" "first" 'fact 'exploration '() 1000 '() '()))
+      (define c2 (task-conclusion "c2" "second" 'decision 'planning '() 2000 '() '()))
       (append-conclusion! log-path c1)
       (append-conclusion! log-path c2)
       (define loaded (load-conclusions log-path))
@@ -156,6 +156,7 @@
                            'exploration
                            '()
                            (* 1000 i)
+                           '()
                            '())))
       (define result (build-state-awareness-preamble 'exploration conclusions))
       (check-not-false result))
@@ -184,7 +185,7 @@
 
     (test-case "guarded-set-task-conclusions! accepts valid list"
       (define s (make-test-session))
-      (define c1 (task-conclusion "c1" "test" 'fact 'exploration '() 1000 '()))
+      (define c1 (task-conclusion "c1" "test" 'fact 'exploration '() 1000 '() '()))
       (guarded-set-task-conclusions! s (list c1))
       (check-equal? (length (agent-session-task-conclusions s)) 1))))
 

--- a/tests/test-ws-conclusion-fallback.rkt
+++ b/tests/test-ws-conclusion-fallback.rkt
@@ -16,7 +16,7 @@
   (make-message id #f 'user 'text (list (make-text-part text)) (current-seconds) (hasheq)))
 
 (define (make-conclusion text #:origin-ids [origin-ids '()])
-  (task-conclusion "c1" text 'fact 'exploration origin-ids (current-seconds) '()))
+  (task-conclusion "c1" text 'fact 'exploration origin-ids (current-seconds) '() '()))
 
 ;; ── W0: working-set-entry->conclusion-or-self ──
 

--- a/tests/test-ws-evolution.rkt
+++ b/tests/test-ws-evolution.rkt
@@ -33,8 +33,8 @@
     (working-set-add! ws p (format "msg-~a" p) 500)))
 
 (define conclusions
-  (list (task-conclusion "c1" "Use struct for data" 'fact 'idle '() (current-seconds) '())
-        (task-conclusion "c2" "Tests in tests/" 'fact 'idle '() (current-seconds) '())))
+  (list (task-conclusion "c1" "Use struct for data" 'fact 'idle '() (current-seconds) '() '())
+        (task-conclusion "c2" "Tests in tests/" 'fact 'idle '() (current-seconds) '() '())))
 
 (define suite
   (test-suite "ws-evolution"

--- a/tools/builtins/record-conclusion.rkt
+++ b/tools/builtins/record-conclusion.rkt
@@ -69,7 +69,8 @@
                               'idle ; placeholder — session layer overrides
                               '() ; origin-message-ids — set by session layer
                               (current-seconds)
-                              tags))
+                              tags
+                              '())) ; dependencies — v0.76.5
 
            ;; Emit event for session layer to persist
            (define ev-pub (and exec-ctx (exec-context-event-publisher exec-ctx)))

--- a/tools/builtins/save-conclusion.rkt
+++ b/tools/builtins/save-conclusion.rkt
@@ -49,7 +49,8 @@
                         'idle ; fsm-state-origin: will be set by session
                         '() ; origin-message-ids: set by session
                         (current-seconds)
-                        tags))
+                        tags
+                        '())) ; dependencies — v0.76.5
      (make-success-result
       (list (hasheq 'type "text" 'text (format "Conclusion saved: [~a] ~a" category content)))
       (hasheq '_conclusion c))]))


### PR DESCRIPTION
M6 W0+W1: Simplified Dependency Graph

- Add `dependencies` field (listof string?) to `task-conclusion` struct
- Updated all 26 constructor call sites across source and test files
- Serialization round-trip includes dependencies
- `hash->conclusion` defaults dependencies to `'()` when missing
- Cycle-free by construction (dependencies are file paths, not conclusion references)
- 7 new tests in `test-conclusion-dependencies.rkt`
- All 123 related tests pass

Closes #6427
Closes #6428