### PR TITLE
feat(v0.76.6): Production hardening (#6429 #6430)

### DIFF
--- a/docs/adr/0019-context-assembly-activation.md
+++ b/docs/adr/0019-context-assembly-activation.md
@@ -1,0 +1,60 @@
+# ADR 0019: Context Assembly Activation
+
+## Status
+
+Accepted — v0.76.0 through v0.76.6
+
+## Context
+
+The v0.75.xx milestone series built the infrastructure for state-aware context assembly: task-state inference, state-relevance matrix, tiered context builder, task conclusions, working-set evolution, and token metrics. However, the feature was **gated off** by default (`current-task-state-aware-assembly?` = `#f`).
+
+The v0.76.xx series was needed to **activate** the feature: turn it on in production, measure results, add safety rails, and prove the 20–30% token-reduction promise.
+
+## Decision
+
+### Graduated activation (M4)
+
+- Per-session `task-state-aware?` config field (default `#f` for existing sessions)
+- Global `current-task-state-aware-assembly?` parameter as emergency kill switch
+- `session-rollout-enabled?` for A/B testing
+
+### Measurement (M4)
+
+- A/B comparison harness (`scripts/benchmark/context-efficiency.rkt`)
+- Token metrics struct with per-tier breakdowns
+- Conclusion coverage computation
+
+### Safety rails (M4)
+
+- `check-rollback-triggers`: observational trigger system (excessive-savings >50%, amnesia-risk coverage <0.20, task-amnesia repeats >2)
+- Rollback is a single parameter flip — no code changes needed
+
+### Working-set deprecation (M5)
+
+- `ws-entry->conclusion-or-self`: matches WS entries to conclusions via `origin-message-ids`
+- When WS level is `excluded`: only keeps entries with matching conclusions
+- When WS level is `filtered`: replaces matched entries with compact conclusion text
+
+### Dependency tracking (M6)
+
+- `dependencies` field on `task-conclusion` (list of file paths)
+- Simple tagging — no graph traversal. Acyclic by construction.
+- Serialization round-trip includes dependencies
+
+## Consequences
+
+### Positive
+- Token savings of 10–30% on tasks with conclusions (measured via A/B benchmark)
+- Per-session rollout allows safe A/B testing
+- Rollback is instant (single parameter)
+- Working-set entries gracefully replaced by conclusions
+
+### Negative
+- ~50-100 token preamble overhead on every assembly (acceptable for real sessions)
+- Synthetic benchmarks may show negative savings (overhead > savings on short sessions)
+- Dependency tracking is tagging-only — no transitive closure or impact analysis
+
+### Metrics (from A/B benchmark)
+- State-aware assembly adds preamble but removes redundant context in planning/implementation/debugging
+- Conclusion coverage is the key health metric (target: ≥ 30%)
+- Amnesia risk detected via repeated tool calls to same files

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -26,6 +26,7 @@ Each ADR describes a decision that was made, the context that led to it, and its
 | [0016](0016-native-tui-architecture.md) | Native TUI architecture | Accepted |
 | [0017](0017-gui-architecture.md) | GUI architecture | Accepted |
 | [0018](0018-gui-extension-integration.md) | GUI extension integration | Accepted |
+| [0019](0019-context-assembly-activation.md) | Context assembly activation | Accepted |
 
 ## Conventions
 

--- a/scripts/benchmark/context-efficiency-summary.rkt
+++ b/scripts/benchmark/context-efficiency-summary.rkt
@@ -1,0 +1,102 @@
+#lang racket/base
+
+;; scripts/benchmark/context-efficiency-summary.rkt — Aggregate context efficiency summary
+;; v0.76.6 M7 W0: Runs A/B benchmark and produces aggregate statistics.
+;;
+;; Usage: racket scripts/benchmark/context-efficiency-summary.rkt
+
+(require racket/format
+         racket/list
+         racket/match
+         "context-efficiency.rkt")
+
+;; ── Aggregate statistics ──
+
+(define (summarize-results results)
+  (define savings-list (map ab-result-savings-pct results))
+  (define n (length savings-list))
+  (define mean (/ (apply + savings-list) n))
+  (define sorted (sort savings-list <))
+  (define median
+    (if (even? n)
+        (/ (+ (list-ref sorted (sub1 (/ n 2))) (list-ref sorted (/ n 2))) 2.0)
+        (list-ref sorted (quotient n 2))))
+  (define min-s (first sorted))
+  (define max-s (last sorted))
+  ;; 95% confidence interval (simple: ±1.96 * stddev / sqrt(n))
+  (define variance (/ (for/sum ([s savings-list]) (expt (- s mean) 2)) n))
+  (define stddev (sqrt variance))
+  (define ci (* 1.96 (/ stddev (sqrt n))))
+  (hasheq 'mean mean
+          'median median
+          'min min-s
+          'max max-s
+          'ci ci
+          'n n
+          'stddev stddev
+          'pass-2of3 (>= (count (λ (r) (> (ab-result-savings-pct r) 0)) results)
+                         (ceiling (* 2/3 n)))))
+
+;; ── Main ──
+
+(module+ main
+  (printf "══════════════════════════════════════════════════════════════\n")
+  (printf "   Context Efficiency Aggregate Summary v0.76.6\n")
+  (printf "══════════════════════════════════════════════════════════════\n\n")
+
+  ;; Run all A/B scenarios
+  (define scenarios
+    (list (list 'exploration "Short exploration" 5 '())
+          (list 'exploration
+                "Exploration w/ conclusions"
+                15
+                (for/list ([i (in-range 5)])
+                  (make-conclusion (format "Found fact ~a about the module" i))))
+          (list 'planning
+                "Planning"
+                10
+                (for/list ([i (in-range 3)])
+                  (make-conclusion (format "Plan step ~a identified" i))))
+          (list 'implementation
+                "Implementation"
+                20
+                (for/list ([i (in-range 8)])
+                  (make-conclusion (format "Implementation detail ~a" i))))
+          (list 'verification
+                "Verification"
+                15
+                (for/list ([i (in-range 4)])
+                  (make-conclusion (format "Verified: check ~a passed" i))))
+          (list 'debugging
+                "Debugging"
+                25
+                (for/list ([i (in-range 6)])
+                  (make-conclusion (format "Bug clue ~a: stack trace line" i))))))
+
+  (define results
+    (for/list ([sc (in-list scenarios)])
+      (match-define (list state label msg-count conclusions) sc)
+      (define msgs (generate-context-messages msg-count))
+      (run-ab-comparison msgs state conclusions label)))
+
+  (define summary (summarize-results results))
+
+  (printf "Scenarios: ~a\n" (hash-ref summary 'n))
+  (printf "Mean savings:   ~a%\n" (~r (hash-ref summary 'mean) #:precision 1))
+  (printf "Median savings: ~a%\n" (~r (hash-ref summary 'median) #:precision 1))
+  (printf "Min savings:    ~a%\n" (~r (hash-ref summary 'min) #:precision 1))
+  (printf "Max savings:    ~a%\n" (~r (hash-ref summary 'max) #:precision 1))
+  (printf "Stddev:         ~a%\n" (~r (hash-ref summary 'stddev) #:precision 1))
+  (printf "95% CI:         ±~a%\n" (~r (hash-ref summary 'ci) #:precision 1))
+  (printf "\n2/3 tasks with savings: ~a\n"
+          (if (hash-ref summary 'pass-2of3) "PASS ✓" "FAIL ✗"))
+
+  ;; Per-scenario breakdown
+  (printf "\nPer-scenario:\n")
+  (for ([r (in-list results)])
+    (printf "  ~a: ~a% savings\n"
+            (~a (ab-result-label r) #:min-width 28)
+            (~r (ab-result-savings-pct r) #:precision 1)))
+
+  (printf "\n══════════════════════════════════════════════════════════════\n")
+  (printf "Summary complete.\n"))

--- a/scripts/benchmark/context-efficiency.rkt
+++ b/scripts/benchmark/context-efficiency.rkt
@@ -67,6 +67,19 @@
 (struct ab-result (label tokens-a tokens-b savings-pct tier-a-count tier-b-count tier-c-count)
   #:transparent)
 
+(provide ab-result
+         ab-result?
+         ab-result-label
+         ab-result-tokens-a
+         ab-result-tokens-b
+         ab-result-savings-pct
+         ab-result-tier-a-count
+         ab-result-tier-b-count
+         ab-result-tier-c-count
+         make-conclusion
+         generate-context-messages
+         run-ab-comparison)
+
 (define (run-ab-comparison messages task-state conclusions label)
   ;; A: state-aware ON
   (define tc-a


### PR DESCRIPTION
M7 W0+W1: Production Hardening

- New `context-efficiency-summary.rkt`: aggregate statistics (mean, median, CI, pass/fail)
- Added provides to `context-efficiency.rkt` for reuse as library
- ADR 0019: Context Assembly Activation decision record
- Updated ADR index
- Re-exports in serialization.rkt retained (still needed by call sites)
- All 94 related tests pass

Closes #6429
Closes #6430