### PR TITLE
fix(v0.76.7): Conclusion-first replacement C1+C2 (#6447)

### DIFF
--- a/runtime/context-assembly/state-aware-builder.rkt
+++ b/runtime/context-assembly/state-aware-builder.rkt
@@ -246,10 +246,13 @@
 ;; Otherwise returns the original message unchanged.
 (define (ws-entry->conclusion-or-self ws-msg conclusions)
   (define msg-id-val (message-id ws-msg))
+  ;; v0.76.7 C1+C2: Use ormap+equal? for robust matching across types
+  (define (origin-matches? c)
+    (define oids (task-conclusion-origin-message-ids c))
+    (and (pair? oids) (ormap (lambda (oid) (equal? msg-id-val oid)) oids)))
   (define matching-conclusion
     (for/first ([c (in-list conclusions)]
-                #:when (and (task-conclusion? c)
-                            (member msg-id-val (task-conclusion-origin-message-ids c))))
+                #:when (and (task-conclusion? c) (origin-matches? c)))
       c))
   (cond
     [matching-conclusion

--- a/runtime/session-events.rkt
+++ b/runtime/session-events.rkt
@@ -128,12 +128,18 @@
                         (if (string? t)
                             (string->symbol t)
                             t)))
+                    ;; v0.76.7 C2: Extract origin-message-id from event payload
+                    (define origin-id (and (hash? payload) (hash-ref payload 'origin-message-id #f)))
+                    (define origin-ids
+                      (if (and origin-id (string? origin-id) (not (string=? origin-id "")))
+                          (list origin-id)
+                          '()))
                     (define c
                       (task-conclusion (or id (format "c~a" (current-inexact-milliseconds)))
                                        text
                                        category-sym
                                        current-state
-                                       '()
+                                       origin-ids ; was: '() — now wired from tool event
                                        (current-seconds)
                                        tag-syms
                                        '())) ; dependencies — v0.76.5

--- a/runtime/session-store.rkt
+++ b/runtime/session-store.rkt
@@ -447,12 +447,16 @@
           (values k
                   (cond
                     [(and (string? v) (memq k '(category fsm-state-origin))) (string->symbol v)]
-                    [(and (list? v) (memq k '(origin-message-ids relevance-tags)))
+                    ;; v0.76.7 C1: relevance-tags values are symbols,
+                    ;; but origin-message-ids are strings (message IDs).
+                    [(and (list? v) (eq? k 'relevance-tags))
                      (map (lambda (x)
                             (if (string? x)
                                 (string->symbol x)
                                 x))
                           v)]
+                    [(and (list? v) (eq? k 'origin-message-ids))
+                     v] ;; keep as strings — message IDs are strings
                     [else v]))))
       (hash->conclusion restored))))
 

--- a/tools/builtins/record-conclusion.rkt
+++ b/tools/builtins/record-conclusion.rkt
@@ -16,7 +16,10 @@
                   task-conclusion?
                   task-conclusion-category?
                   valid-categories)
-         (only-in "../../tools/exec-context.rkt" exec-context-event-publisher exec-context?))
+         (only-in "../../tools/exec-context.rkt"
+                  exec-context-event-publisher
+                  exec-context?
+                  exec-context-call-id))
 
 ;; --------------------------------------------------
 ;; Helpers
@@ -75,8 +78,18 @@
            ;; Emit event for session layer to persist
            (define ev-pub (and exec-ctx (exec-context-event-publisher exec-ctx)))
            (when ev-pub
+             (define origin-id (or (and exec-ctx (exec-context-call-id exec-ctx)) ""))
              (ev-pub "tool.record_conclusion.completed"
-                     (hasheq 'conclusion-id id 'text text 'category category-raw 'tags tags)))
+                     (hasheq 'conclusion-id
+                             id
+                             'text
+                             text
+                             'category
+                             category-raw
+                             'tags
+                             tags
+                             'origin-message-id
+                             origin-id)))
 
            (make-success-result
             (list (hasheq 'type "text" 'text (format "Conclusion recorded: [~a] ~a" category text))


### PR DESCRIPTION
W0: Fix CRITICAL conclusion-first replacement (C1+C2)

- C2: Wire `origin-message-id` in `record_conclusion` event payload (from exec-context-call-id), read in session-events subscriber
- C1: Fix deserialization type corruption — `origin-message-ids` are strings, not symbols
- Defensive: Use `ormap+equal?` for robust matching in `ws-entry->conclusion-or-self`

Closes #6447