### PR TITLE
fix(v0.76.7): set-task-state + tool cleanup (#6448)

### DIFF
--- a/runtime/context-assembly/state-aware-builder.rkt
+++ b/runtime/context-assembly/state-aware-builder.rkt
@@ -145,6 +145,27 @@
         '()))
   ;; Prepend preamble + conclusion entries to tier-a
   (define new-tier-a (append preamble-entries conclusion-entries (tiered-context-tier-a base-tc)))
+  ;; v0.76.7 W6: Run rollback trigger checks (observational only)
+  (when (current-task-state-aware-assembly?)
+    (define tc-result
+      (if (and (null? preamble-entries) (null? conclusion-entries))
+          base-tc
+          (tiered-context new-tier-a
+                          (tiered-context-tier-b base-tc)
+                          (tiered-context-tier-c base-tc))))
+    (define n-conclusions (length (filter task-conclusion? conclusions)))
+    (define coverage
+      (if (> (length ws-messages) 0)
+          (/ n-conclusions (length ws-messages))
+          0.0))
+    (define warnings
+      (check-rollback-triggers #:before-tokens (length ws-messages)
+                               #:after-tokens (length effective-ws)
+                               #:conclusion-coverage coverage
+                               #:repeat-tool-count 0))
+    (when (pair? warnings)
+      (log-warning "context-assembly: rollback triggers fired: ~a" warnings))
+    tc-result)
   (if (and (null? preamble-entries) (null? conclusion-entries))
       base-tc
       (tiered-context new-tier-a (tiered-context-tier-b base-tc) (tiered-context-tier-c base-tc))))

--- a/runtime/context-assembly/state-inference.rkt
+++ b/runtime/context-assembly/state-inference.rkt
@@ -38,7 +38,7 @@
     [(member s '("read" "find" "grep" "ls")) 'read]
     [(member s '("edit" "write" "edit-normalize")) 'write]
     [(member s '("bash")) 'bash]
-    [(member s '("save-conclusion" "set-task-state")) 'meta]
+    [(member s '("save-conclusion" "set-task-state" "record_conclusion")) 'meta]
     [else 'other]))
 
 ;; ── Pattern counters ──

--- a/runtime/context-assembly/state-relevance.rkt
+++ b/runtime/context-assembly/state-relevance.rkt
@@ -106,14 +106,15 @@
                   'full
                   'plan-notes
                   'summary)
-          ;; debugging: error-focused — full working-set + tool-results
+          ;; debugging: error-focused — filtered working-set + full tool-results
+          ;; v0.76.7 W5: Changed from 'full to 'filtered per decision A7
           'debugging
           (hasheq 'system-prompt
                   'full
                   'conclusions
                   'full
                   'working-set
-                  'full
+                  'filtered
                   'recent-messages
                   'full
                   'tool-results

--- a/runtime/session-events.rkt
+++ b/runtime/session-events.rkt
@@ -161,6 +161,28 @@
                                                  'state
                                                  current-state))))
                 #:filter (lambda (evt) (equal? (event-ev evt) "tool.record_conclusion.completed")))
+
+    ;; v0.76.7 C3: Subscribe to tool.set-task-state.completed — explicit state transition
+    (subscribe! bus
+                (lambda (evt)
+                  (define payload (event-payload evt))
+                  (define target (and (hash? payload) (hash-ref payload 'target-state #f)))
+                  (when (and target (or (string? target) (symbol? target)))
+                    (define target-sym
+                      (if (string? target)
+                          (string->symbol target)
+                          target))
+                    (guarded-set-task-fsm-state! sess target-sym)
+                    ;; Persist task state change
+                    (define log-path (session-log-path-for sess))
+                    (when (file-exists? log-path)
+                      (append-task-state! log-path target-sym))
+                    (emit-session-event! bus
+                                         (agent-session-session-id sess)
+                                         "task.state.transitioned"
+                                         (hasheq 'state target-sym 'source "explicit"))))
+                #:filter (lambda (evt) (equal? (event-ev evt) "tool.set-task-state.completed")))
+
     (void)))
 
 ;; ============================================================

--- a/tests/test-state-relevance.rkt
+++ b/tests/test-state-relevance.rkt
@@ -46,8 +46,8 @@
       (check-equal? (context-level-for-state 'verification 'tool-results) 'full)
       (check-equal? (context-level-for-state 'verification 'working-set) 'filtered))
 
-    (test-case "debugging state includes full working-set"
-      (check-equal? (context-level-for-state 'debugging 'working-set) 'full)
+    (test-case "debugging state uses filtered working-set (v0.76.7 W5)"
+      (check-equal? (context-level-for-state 'debugging 'working-set) 'filtered)
       (check-equal? (context-level-for-state 'debugging 'tool-results) 'full))
 
     (test-case "fsm-state struct input works"

--- a/tools/builtins/save-conclusion.rkt
+++ b/tools/builtins/save-conclusion.rkt
@@ -21,7 +21,8 @@
                   task-memory?
                   task-memory-conclusions
                   add-conclusion
-                  make-task-memory))
+                  make-task-memory)
+         (only-in "../exec-context.rkt" exec-context-event-publisher exec-context?))
 
 ;; --------------------------------------------------
 ;; Handler function
@@ -40,6 +41,10 @@
     [(not (and (list? tags) (andmap symbol? tags)))
      (make-error-result "tags must be a list of symbols")]
     [else
+     ;; v0.76.7 W1: Emit deprecation event
+     (define ev-pub (and exec-ctx (exec-context-event-publisher exec-ctx)))
+     (when ev-pub
+       (ev-pub "tool.deprecated" (hasheq 'tool "save-conclusion" 'replacement "record_conclusion")))
      ;; Generate a unique ID and create the conclusion
      (define id (format "c~a" (current-inexact-milliseconds)))
      (define c

--- a/tools/builtins/set-task-state.rkt
+++ b/tools/builtins/set-task-state.rkt
@@ -30,7 +30,8 @@
                   task-revisit
                   task-force-transition
                   task-states-list)
-         (only-in "../../util/fsm.rkt" fsm-state-name fsm-state?))
+         (only-in "../../util/fsm.rkt" fsm-state-name fsm-state?)
+         (only-in "../exec-context.rkt" exec-context-event-publisher exec-context?))
 
 ;; State name → singleton mapping
 (define state-lookup
@@ -74,8 +75,14 @@
   (define state-name (hash-ref args 'state #f))
   (define event-name (hash-ref args 'event #f))
   ;; Convert strings to symbols for hasheq lookup (LLM sends strings)
-  (define state-sym (if (string? state-name) (string->symbol state-name) state-name))
-  (define event-sym (if (string? event-name) (string->symbol event-name) event-name))
+  (define state-sym
+    (if (string? state-name)
+        (string->symbol state-name)
+        state-name))
+  (define event-sym
+    (if (string? event-name)
+        (string->symbol event-name)
+        event-name))
   (cond
     [(not state-name) (make-error-result "Missing required argument: state")]
     [(not event-name) (make-error-result "Missing required argument: event")]
@@ -91,6 +98,11 @@
           "Unknown event: ~a. Valid: begin-explore, begin-plan, begin-implement, begin-verify, begin-debug, task-complete, revisit, force-transition"
           event-name))]
        [else
+        ;; v0.76.7 C3: Emit event for session layer to consume
+        (define ev-pub (and exec-ctx (exec-context-event-publisher exec-ctx)))
+        (when ev-pub
+          (ev-pub "tool.set-task-state.completed"
+                  (hasheq 'target-state state-name 'event-name event-name)))
         ;; The actual transition validation happens in session mutation
         ;; Here we just package the request
         (make-success-result


### PR DESCRIPTION
W1: Fix CRITICAL set-task-state + WARNING cleanup (C3+W1+W2+W5+W6)

- C3: Add `tool.set-task-state.completed` event emission + session subscriber for explicit state transitions
- W1: Deprecate `save-conclusion` (emit `tool.deprecated` event, keep registered)
- W2: Add `record_conclusion` to inference `'meta` category
- W5: Change debugging WS from `'full` to `'filtered` per decision A7
- W6: Wire `check-rollback-triggers` into assembly path with `log-warning`

135 related tests pass. Closes #6448