### PR TITLE
fix(v0.76.7): test quality — W7+W8+W9 (#6449)

### DIFF
--- a/tests/test-record-conclusion.rkt
+++ b/tests/test-record-conclusion.rkt
@@ -11,13 +11,17 @@
          (only-in "../util/event.rkt" make-event)
          "../runtime/session-events.rkt"
          "../runtime/session-types.rkt"
+         (only-in "../runtime/session-mutation.rkt" guarded-set-task-fsm-state!)
          (only-in "../runtime/context-assembly/task-conclusion.rkt"
                   task-conclusion?
                   task-conclusion-text
                   task-conclusion-category
                   task-conclusion-fsm-state-origin
-                  task-conclusion-relevance-tags)
-         (submod "../runtime/session-types.rkt" internal))
+                  task-conclusion-relevance-tags
+                  task-conclusion-origin-message-ids)
+         (submod "../runtime/session-types.rkt" internal)
+         ;; v0.76.7 W9: Shared session fixture
+         (only-in "helpers/session-fixture.rkt" make-test-session))
 
 ;; Helper: call tool handler directly
 (define (call-tool t args)
@@ -104,38 +108,14 @@
 
     (test-case "session handler persists conclusion from event"
       (define bus (make-event-bus))
-      (define sess
-        (agent-session "test-sess"
-                       "/tmp/q-test-record"
-                       #f
-                       #f
-                       bus
-                       #f
-                       #f
-                       '()
-                       #f
-                       #f
-                       #f
-                       #f
-                       #t
-                       0
-                       #f
-                       #f
-                       #f
-                       #f
-                       #f
-                       #f
-                       #f
-                       'idle
-                       '()
-                       '()))
+      (define sess (make-test-session #:event-bus bus))
       (wire-session-event-handlers! sess (lambda (s e) s))
       ;; Publish a record_conclusion event
       (publish! bus
                 (make-event
                  "tool.record_conclusion.completed"
                  (current-seconds)
-                 "test-sess"
+                 (agent-session-session-id sess)
                  #f
                  (hasheq 'text "handler test" 'conclusion-id "c123" 'category "fact" 'tags '())))
       ;; Allow event processing (synchronous bus)
@@ -149,36 +129,14 @@
 
     (test-case "session handler sets fsm-state-origin to current state"
       (define bus (make-event-bus))
-      (define sess
-        (agent-session "test-sess"
-                       "/tmp/q-test-record"
-                       #f
-                       #f
-                       bus
-                       #f
-                       #f
-                       '()
-                       #f
-                       #f
-                       #f
-                       #f
-                       #t
-                       0
-                       #f
-                       #f
-                       #f
-                       #f
-                       #f
-                       #f
-                       #f
-                       'implementation
-                       '()
-                       '()))
+      (define sess (make-test-session #:event-bus bus))
+      ;; Set state to implementation before wiring handlers
+      (guarded-set-task-fsm-state! sess 'implementation)
       (wire-session-event-handlers! sess (lambda (s e) s))
       (publish! bus
                 (make-event "tool.record_conclusion.completed"
                             (current-seconds)
-                            "test-sess"
+                            (agent-session-session-id sess)
                             #f
                             (hasheq 'text "state test" 'category "decision" 'tags '())))
       (define conclusions (agent-session-task-conclusions sess))

--- a/tests/test-session-task-state.rkt
+++ b/tests/test-session-task-state.rkt
@@ -2,6 +2,7 @@
 
 ;; tests/test-session-task-state.rkt — tests for task-state session fields + persistence
 ;; v0.75.1 W1: Session fields + guarded setters
+;; v0.76.7 W9: Refactored to use shared session fixture
 
 (require rackunit
          rackunit/text-ui
@@ -17,36 +18,8 @@
          (only-in "../runtime/context-assembly/task-conclusion.rkt"
                   task-conclusion
                   task-conclusion?
-                  task-conclusion-text))
-
-;; Helper: create a minimal agent-session with default fields
-(define (make-test-session)
-  (apply agent-session
-         (list "test-session"
-               "/tmp/test-session"
-               #f ; provider
-               #f ; tool-registry
-               #f ; event-bus
-               #f ; extension-registry
-               #f ; model-name
-               '() ; system-instructions
-               #f ; index
-               #f ; queue
-               (hasheq) ; config
-               #f ; active?
-               0 ; start-time
-               #f ; compacting?
-               #f ; last-compaction-time
-               #f ; persisted?
-               '() ; pending-entries
-               #f ; thinking-level
-               #f ; shutdown-requested?
-               #f ; force-shutdown?
-               #f ; prompt-running?
-               'idle ; task-fsm-state
-               '() ; task-conclusions
-               '() ; recent-tool-calls
-               )))
+                  task-conclusion-text)
+         (only-in "helpers/session-fixture.rkt" make-test-session))
 
 (define suite
   (test-suite "session-task-state"

--- a/tests/test-token-metrics.rkt
+++ b/tests/test-token-metrics.rkt
@@ -20,7 +20,7 @@
                   category-breakdown
                   compute-conclusion-coverage
                   measure-context-assembly)
-         (only-in "../util/protocol-types.rkt" make-message make-text-part)
+         (only-in "../util/protocol-types.rkt" make-message make-text-part message-kind message-role)
          (only-in "../runtime/context-assembly/context-floor.rkt"
                   tiered-context?
                   tiered-context-tier-a
@@ -156,10 +156,16 @@
       (define-values (tc metrics) (measure-context-assembly (msgs 3 "test")))
       (check-equal? (context-metrics-task-state metrics) 'none))
 
-    (test-case "state-aware assembly with preamble adds some overhead"
+    (test-case "state-aware assembly with preamble adds preamble overhead"
       (define-values (tc metrics)
         (measure-context-assembly (msgs 10 "test message content") #:task-state 'implementation))
-      ;; Preamble adds tokens, so after may be > before when no filtering happens
-      (check-true (context-metrics? metrics)))))
+      ;; v0.76.7 W7: Non-tautological — verify preamble exists in tier-a
+      ;; for non-idle states (implementation state injects state-awareness preamble)
+      (check-true (context-metrics? metrics))
+      (define preamble-msg
+        (for/first ([m (tiered-context-tier-a tc)]
+                    #:when (equal? (message-role m) 'system-instruction))
+          m))
+      (check-not-false preamble-msg "preamble message should be present for implementation state"))))
 
 (run-tests suite)

--- a/tests/test-v0756-audit-closure.rkt
+++ b/tests/test-v0756-audit-closure.rkt
@@ -31,7 +31,9 @@
          (only-in "../runtime/context-assembly/serialization.rkt" build-state-awareness-preamble)
          ;; Message content access
          (only-in "../util/content-parts.rkt" text-part-text)
-         (only-in "../util/protocol-types.rkt" message-content message-kind))
+         (only-in "../util/protocol-types.rkt" message-content message-kind)
+         ;; v0.76.7 W9: Shared session fixture
+         (only-in "helpers/session-fixture.rkt" make-test-session))
 
 ;; ============================================================
 ;; Helpers
@@ -49,34 +51,8 @@
     (with-handlers ([exn:fail? void])
       (delete-directory/files parent))))
 
-;; Create a minimal agent-session for FSM validation tests
-(define (make-test-session)
-  (apply agent-session
-         (list "test-session"
-               "/tmp/test-session"
-               #f
-               #f
-               #f
-               #f
-               #f
-               '()
-               #f
-               #f
-               (hasheq)
-               #f
-               0
-               #f
-               #f
-               #f
-               '()
-               #f
-               #f
-               #f
-               #f
-               'idle
-               '()
-               '())))
-
+;; ============================================================
+;; Tests
 ;; ============================================================
 ;; Test Suite
 ;; ============================================================

--- a/tests/test-ws-conclusion-fallback.rkt
+++ b/tests/test-ws-conclusion-fallback.rkt
@@ -116,3 +116,34 @@
        (for/sum ([m (tiered-context-tier-c tc)])
                 (string-length (text-part-text (car (message-content m)))))))
   (check-true (< (tc-tokens tc-replace) (tc-tokens tc-no-replace))))
+
+;; ── W2-T2 (v0.76.7 W8): excluded WS path test ──
+
+(test-case "excluded WS: matched entries replaced, unmatched dropped"
+  ;; implementation state has ws-level='excluded
+  ;; Matched WS entries become compact conclusions; unmatched entries are dropped entirely
+  (define ws-1 (make-test-msg "ws-1" (make-string 500 #\x)))
+  (define ws-2 (make-test-msg "ws-2" (make-string 500 #\y)))
+  (define conclusions (list (make-conclusion "Summary of ws-1" #:origin-ids '("ws-1"))))
+  (define tc
+    (build-tiered-context/state-aware (list (make-test-msg "m1" "hello"))
+                                      #:tier-b-count 5
+                                      #:tier-c-count 2
+                                      #:working-set-messages (list ws-1 ws-2)
+                                      #:task-state 'implementation
+                                      #:conclusions conclusions))
+  (define tier-a-texts
+    (for/list ([m (tiered-context-tier-a tc)])
+      (text-part-text (car (message-content m)))))
+  ;; ws-1 should be replaced with conclusion (present in tier-a)
+  (check-true (ormap (λ (t) (string-contains? t "Summary of ws-1")) tier-a-texts)
+              "matched WS entry should be replaced with conclusion")
+  ;; ws-2 should be completely dropped (not in any tier)
+  (define all-texts
+    (append tier-a-texts
+            (for/list ([m (tiered-context-tier-b tc)])
+              (text-part-text (car (message-content m))))
+            (for/list ([m (tiered-context-tier-c tc)])
+              (text-part-text (car (message-content m))))))
+  (check-false (ormap (λ (t) (string-contains? t (make-string 500 #\y))) all-texts)
+               "unmatched WS entry should be dropped entirely in excluded state"))


### PR DESCRIPTION
W2: Fix WARNING test quality issues (W7+W8+W9)

- W7: Fix tautological assertion in `test-token-metrics.rkt` — now verifies preamble message in tier-a via `message-role` check
- W8: Add `'excluded` WS path test — matched entries replaced, unmatched dropped in implementation state
- W9: Refactor brittle manual constructors in 3 test files to use shared `make-test-session` fixture

139 related tests pass. Closes #6449