### PR TITLE
fix(v0.76.8): source code fixes — dead code, deprecated prefix, param names, event payload, error guard (#6457)

### DIFF
--- a/runtime/context-assembly/state-aware-builder.rkt
+++ b/runtime/context-assembly/state-aware-builder.rkt
@@ -147,25 +147,18 @@
   (define new-tier-a (append preamble-entries conclusion-entries (tiered-context-tier-a base-tc)))
   ;; v0.76.7 W6: Run rollback trigger checks (observational only)
   (when (current-task-state-aware-assembly?)
-    (define tc-result
-      (if (and (null? preamble-entries) (null? conclusion-entries))
-          base-tc
-          (tiered-context new-tier-a
-                          (tiered-context-tier-b base-tc)
-                          (tiered-context-tier-c base-tc))))
     (define n-conclusions (length (filter task-conclusion? conclusions)))
     (define coverage
       (if (> (length ws-messages) 0)
           (/ n-conclusions (length ws-messages))
           0.0))
     (define warnings
-      (check-rollback-triggers #:before-tokens (length ws-messages)
-                               #:after-tokens (length effective-ws)
+      (check-rollback-triggers #:before-messages (length ws-messages)
+                               #:after-messages (length effective-ws)
                                #:conclusion-coverage coverage
                                #:repeat-tool-count 0))
     (when (pair? warnings)
-      (log-warning "context-assembly: rollback triggers fired: ~a" warnings))
-    tc-result)
+      (log-warning "context-assembly: rollback triggers fired: ~a" warnings)))
   (if (and (null? preamble-entries) (null? conclusion-entries))
       base-tc
       (tiered-context new-tier-a (tiered-context-tier-b base-tc) (tiered-context-tier-c base-tc))))
@@ -219,25 +212,26 @@
 ;; ════════════════════════════════════════════════════════════════
 
 ;; check-rollback-triggers :
-;;   #:before-tokens number? #:after-tokens number?
+;;   #:before-messages number? #:after-messages number?
 ;;   #:conclusion-coverage number? #:repeat-tool-count exact-nonnegative-integer?
 ;;   -> (listof (list/c symbol? string?))
 ;;
 ;; Returns a list of warning tuples: (trigger-type message).
 ;; Triggers are observational — callers decide what to do.
-(define (check-rollback-triggers #:before-tokens before-tokens
-                                 #:after-tokens after-tokens
+(define (check-rollback-triggers #:before-messages before-messages
+                                 #:after-messages after-messages
                                  #:conclusion-coverage conclusion-coverage
                                  #:repeat-tool-count repeat-tool-count)
   (define warnings '())
 
-  ;; Trigger 1: Excessive savings (>50% tokens cut)
+  ;; Trigger 1: Excessive savings (>50% messages cut)
   ;; R2 risk: context may be too small to work effectively
-  (when (and (> before-tokens 0) (> after-tokens 0) (< after-tokens (* before-tokens 0.50)))
-    (set! warnings
-          (cons (list 'excessive-savings
-                      (format "Context reduced by >50%: ~a → ~a tokens" before-tokens after-tokens))
-                warnings)))
+  (when (and (> before-messages 0) (> after-messages 0) (< after-messages (* before-messages 0.50)))
+    (set!
+     warnings
+     (cons (list 'excessive-savings
+                 (format "Context reduced by >50%: ~a → ~a messages" before-messages after-messages))
+           warnings)))
 
   ;; Trigger 2: Low conclusion coverage (amnesia risk)
   ;; R0 risk: agent forgetting key findings

--- a/runtime/session-events.rkt
+++ b/runtime/session-events.rkt
@@ -118,9 +118,11 @@
                     (define category-raw (and (hash? payload) (hash-ref payload 'category "fact")))
                     (define tags (and (hash? payload) (hash-ref payload 'tags '())))
                     (define category-sym
-                      (if (string? category-raw)
-                          (string->symbol category-raw)
-                          category-raw))
+                      (if (symbol? category-raw)
+                          category-raw
+                          (if (string? category-raw)
+                              (string->symbol category-raw)
+                              category-raw)))
                     (define tag-syms
                       (for/list ([t (in-list (if (list? tags)
                                                  tags

--- a/tools/builtins/record-conclusion.rkt
+++ b/tools/builtins/record-conclusion.rkt
@@ -85,7 +85,7 @@
                              'text
                              text
                              'category
-                             category-raw
+                             category
                              'tags
                              tags
                              'origin-message-id

--- a/tools/builtins/save-conclusion.rkt
+++ b/tools/builtins/save-conclusion.rkt
@@ -67,7 +67,7 @@
 (define-tool
  save-conclusion
  #:description
- "Save a distilled insight or conclusion about the current task. Use after discovering important facts, making decisions, identifying patterns, finding error causes, or getting test results. Conclusions replace raw file contents in the prompt when the agent moves past exploration, enabling context optimization."
+ "[DEPRECATED - use record_conclusion instead] Save a distilled insight or conclusion about the current task. Use after discovering important facts, making decisions, identifying patterns, finding error causes, or getting test results. Conclusions replace raw file contents in the prompt when the agent moves past exploration, enabling context optimization."
  #:required ("content")
  #:properties
  [(content "string" "The conclusion text")

--- a/tools/builtins/set-task-state.rkt
+++ b/tools/builtins/set-task-state.rkt
@@ -99,11 +99,14 @@
           event-name))]
        [else
         ;; v0.76.7 C3: Emit event for session layer to consume
-        (define ev-pub (and exec-ctx (exec-context-event-publisher exec-ctx)))
-        (when ev-pub
-          (ev-pub "tool.set-task-state.completed"
-                  (hasheq 'target-state state-name 'event-name event-name)))
-        ;; The actual transition validation happens in session mutation
+        ;; v0.76.8 I2: Guard event emission against failures
+        (with-handlers ([exn:fail? (lambda (e)
+                                     (log-warning "set-task-state: event emission failed: ~a"
+                                                  (exn-message e)))])
+          (define ev-pub (and exec-ctx (exec-context-event-publisher exec-ctx)))
+          (when ev-pub
+            (ev-pub "tool.set-task-state.completed"
+                    (hasheq (quote target-state) state-name (quote event-name) event-name))))
         ;; Here we just package the request
         (make-success-result
          (list (hasheq 'type


### PR DESCRIPTION
W1: Source Code Fixes (W1 + W2 + W8 + I1 + I2)

- W1-T1: Remove dead `tc-result` binding in state-aware-builder.rkt
- W1-T2: Add `[DEPRECATED]` prefix to save-conclusion tool description
- W1-T3: Fix record-conclusion event payload category (symbol not raw string)
- W1-T4: Rename `check-rollback-triggers` params tokens→messages
- W1-T5: Add error guard around set-task-state event emission

All 5 files compile clean. Closes #6457.