### PR TITLE
feat(v0.77.0): baseline context telemetry and guardrail tests (#6463)

### DIFF
--- a/runtime/context-assembly/token-metrics.rkt
+++ b/runtime/context-assembly/token-metrics.rkt
@@ -24,9 +24,20 @@
          context-metrics-savings-pct
          context-metrics-category-breakdown
          context-metrics-timestamp
+         context-token-telemetry
+         context-token-telemetry?
+         context-token-telemetry-tier-a-tokens
+         context-token-telemetry-tier-b-tokens
+         context-token-telemetry-tier-c-tokens
+         context-token-telemetry-conclusion-tokens
+         context-token-telemetry-working-set-tokens
+         context-token-telemetry-recent-tokens
+         context-token-telemetry-total-tokens
+         context-token-telemetry-timestamp
          measure-context-size
          compute-savings
          category-breakdown
+         measure-context-token-telemetry
          compute-conclusion-coverage
          measure-context-assembly)
 
@@ -39,6 +50,19 @@
                     savings-pct
                     category-breakdown
                     timestamp)
+  #:transparent)
+
+;; Observation-only tier/category token telemetry.
+;; The category fields intentionally measure caller-supplied slices rather than
+;; mutating the tiered context; later v0.77 waves reuse this as a baseline.
+(struct context-token-telemetry
+        (tier-a-tokens tier-b-tokens
+                       tier-c-tokens
+                       conclusion-tokens
+                       working-set-tokens
+                       recent-tokens
+                       total-tokens
+                       timestamp)
   #:transparent)
 
 ;; ── Token counting ──
@@ -72,6 +96,30 @@
           tier-c-tokens
           'total
           (+ tier-a-tokens tier-b-tokens tier-c-tokens)))
+
+;; measure-context-token-telemetry :
+;;   tiered-context?
+;;   #:conclusion-messages (listof message?)
+;;   #:working-set-messages (listof message?)
+;;   #:recent-messages (listof message?)
+;;   -> context-token-telemetry?
+;; Reports tier A/B/C token estimates plus category estimates without changing
+;; assembly behavior.
+(define (measure-context-token-telemetry tc
+                                         #:conclusion-messages [conclusion-messages '()]
+                                         #:working-set-messages [working-set-messages '()]
+                                         #:recent-messages [recent-messages '()])
+  (define tier-a-tokens (measure-context-size (tiered-context-tier-a tc)))
+  (define tier-b-tokens (measure-context-size (tiered-context-tier-b tc)))
+  (define tier-c-tokens (measure-context-size (tiered-context-tier-c tc)))
+  (context-token-telemetry tier-a-tokens
+                           tier-b-tokens
+                           tier-c-tokens
+                           (measure-context-size conclusion-messages)
+                           (measure-context-size working-set-messages)
+                           (measure-context-size recent-messages)
+                           (+ tier-a-tokens tier-b-tokens tier-c-tokens)
+                           (current-seconds)))
 
 ;; ── Assembly wrapper ──
 

--- a/tests/test-context-assembly-ws-budget.rkt
+++ b/tests/test-context-assembly-ws-budget.rkt
@@ -8,7 +8,17 @@
          racket/list
          "../util/protocol-types.rkt"
          "../runtime/working-set.rkt"
-         "../runtime/context-assembly.rkt")
+         "../runtime/context-assembly.rkt"
+         (only-in "../runtime/context-assembly/token-metrics.rkt"
+                  context-token-telemetry?
+                  context-token-telemetry-tier-a-tokens
+                  context-token-telemetry-tier-b-tokens
+                  context-token-telemetry-tier-c-tokens
+                  context-token-telemetry-working-set-tokens
+                  context-token-telemetry-conclusion-tokens
+                  context-token-telemetry-recent-tokens
+                  context-token-telemetry-total-tokens
+                  measure-context-token-telemetry))
 
 ;; Helper: create a test message
 (define (make-test-msg id role kind text [parent #f])
@@ -87,7 +97,47 @@
       (check-true (tiered-context? tc-without-ws))
 
       ;; Tier-a should include system + working set messages
-      (check-true (>= (length (tiered-context-tier-a tc-with-ws)) 3)))))
+      (check-true (>= (length (tiered-context-tier-a tc-with-ws)) 3)))
+
+    (test-case "T03: token telemetry reports tier/category estimates without changing assembly"
+      (define ws-msg
+        (make-message "ws-telemetry"
+                      #f
+                      'tool
+                      'tool-result
+                      (list (make-text-part "working set content"))
+                      (current-seconds)
+                      (hasheq)))
+      (define conclusion-msg
+        (make-message "c-telemetry"
+                      #f
+                      'system-instruction
+                      'text
+                      (list (make-text-part "[Conclusion] important decision"))
+                      (current-seconds)
+                      (hasheq)))
+      (define msgs
+        (list (make-test-msg "sys" 'system 'system-instruction "System")
+              (make-test-msg "recent-1" 'user 'message "recent context")))
+      (define tc (build-tiered-context msgs #:working-set-messages (list ws-msg)))
+      (define tier-a-before (tiered-context-tier-a tc))
+      (define telemetry
+        (measure-context-token-telemetry tc
+                                         #:conclusion-messages (list conclusion-msg)
+                                         #:working-set-messages (list ws-msg)
+                                         #:recent-messages msgs))
+      (check-true (context-token-telemetry? telemetry))
+      (check-equal? (tiered-context-tier-a tc) tier-a-before "telemetry must be observation-only")
+      (check-true (>= (context-token-telemetry-tier-a-tokens telemetry) 0))
+      (check-true (>= (context-token-telemetry-tier-b-tokens telemetry) 0))
+      (check-true (>= (context-token-telemetry-tier-c-tokens telemetry) 0))
+      (check-true (> (context-token-telemetry-working-set-tokens telemetry) 0))
+      (check-true (> (context-token-telemetry-conclusion-tokens telemetry) 0))
+      (check-true (> (context-token-telemetry-recent-tokens telemetry) 0))
+      (check-equal? (context-token-telemetry-total-tokens telemetry)
+                    (+ (context-token-telemetry-tier-a-tokens telemetry)
+                       (context-token-telemetry-tier-b-tokens telemetry)
+                       (context-token-telemetry-tier-c-tokens telemetry))))))
 
 (module+ main
   (run-tests budget-tests))

--- a/tests/test-rollback-triggers.rkt
+++ b/tests/test-rollback-triggers.rkt
@@ -20,8 +20,8 @@
 
 (test-case "trigger-1: excessive savings returns warning when >50% tokens cut"
   (define warnings
-    (check-rollback-triggers #:before-tokens 1000
-                             #:after-tokens 400
+    (check-rollback-triggers #:before-messages 1000
+                             #:after-messages 400
                              #:conclusion-coverage 0.5
                              #:repeat-tool-count 0))
   (define excessive (filter (λ (w) (eq? (car w) 'excessive-savings)) warnings))
@@ -29,8 +29,8 @@
 
 (test-case "trigger-1: no warning when savings < 50%"
   (define warnings
-    (check-rollback-triggers #:before-tokens 1000
-                             #:after-tokens 600
+    (check-rollback-triggers #:before-messages 1000
+                             #:after-messages 600
                              #:conclusion-coverage 0.5
                              #:repeat-tool-count 0))
   (define excessive (filter (λ (w) (eq? (car w) 'excessive-savings)) warnings))
@@ -38,8 +38,8 @@
 
 (test-case "trigger-1: no warning when after-tokens = 0 (no context at all)"
   (define warnings
-    (check-rollback-triggers #:before-tokens 1000
-                             #:after-tokens 0
+    (check-rollback-triggers #:before-messages 1000
+                             #:after-messages 0
                              #:conclusion-coverage 0.5
                              #:repeat-tool-count 0))
   (define excessive (filter (λ (w) (eq? (car w) 'excessive-savings)) warnings))
@@ -49,8 +49,8 @@
 
 (test-case "trigger-2: low coverage returns warning when < 0.20"
   (define warnings
-    (check-rollback-triggers #:before-tokens 1000
-                             #:after-tokens 800
+    (check-rollback-triggers #:before-messages 1000
+                             #:after-messages 800
                              #:conclusion-coverage 0.10
                              #:repeat-tool-count 0))
   (define amnesia (filter (λ (w) (eq? (car w) 'amnesia-risk)) warnings))
@@ -58,8 +58,8 @@
 
 (test-case "trigger-2: no warning when coverage >= 0.20"
   (define warnings
-    (check-rollback-triggers #:before-tokens 1000
-                             #:after-tokens 800
+    (check-rollback-triggers #:before-messages 1000
+                             #:after-messages 800
                              #:conclusion-coverage 0.30
                              #:repeat-tool-count 0))
   (define amnesia (filter (λ (w) (eq? (car w) 'amnesia-risk)) warnings))
@@ -69,8 +69,8 @@
 
 (test-case "trigger-3: repeated tool calls returns warning when > 2"
   (define warnings
-    (check-rollback-triggers #:before-tokens 1000
-                             #:after-tokens 800
+    (check-rollback-triggers #:before-messages 1000
+                             #:after-messages 800
                              #:conclusion-coverage 0.5
                              #:repeat-tool-count 3))
   (define repeated (filter (λ (w) (eq? (car w) 'task-amnesia-detected)) warnings))
@@ -78,8 +78,8 @@
 
 (test-case "trigger-3: no warning when repeat count <= 2"
   (define warnings
-    (check-rollback-triggers #:before-tokens 1000
-                             #:after-tokens 800
+    (check-rollback-triggers #:before-messages 1000
+                             #:after-messages 800
                              #:conclusion-coverage 0.5
                              #:repeat-tool-count 2))
   (define repeated (filter (λ (w) (eq? (car w) 'task-amnesia-detected)) warnings))
@@ -89,8 +89,8 @@
 
 (test-case "no triggers when all metrics healthy"
   (define warnings
-    (check-rollback-triggers #:before-tokens 1000
-                             #:after-tokens 800
+    (check-rollback-triggers #:before-messages 1000
+                             #:after-messages 800
                              #:conclusion-coverage 0.5
                              #:repeat-tool-count 0))
   (check-equal? warnings '()))
@@ -99,8 +99,8 @@
 
 (test-case "multiple triggers fire simultaneously"
   (define warnings
-    (check-rollback-triggers #:before-tokens 1000
-                             #:after-tokens 400
+    (check-rollback-triggers #:before-messages 1000
+                             #:after-messages 400
                              #:conclusion-coverage 0.10
                              #:repeat-tool-count 3))
   (check-equal? (length warnings) 3))

--- a/tests/test-state-aware-builder.rkt
+++ b/tests/test-state-aware-builder.rkt
@@ -70,6 +70,26 @@
       (define tier-a (tiered-context-tier-a tc))
       (check-true (>= (length tier-a) 2)))
 
+    (test-case "state-aware implementation currently injects all conclusion entries (v0.77.0 baseline)"
+      (define msgs (make-test-msgs 5))
+      (define conclusions
+        (for/list ([i (in-range 25)])
+          (task-conclusion (format "c~a" i)
+                           (format "important conclusion ~a" i)
+                           'fact
+                           'implementation
+                           '()
+                           (+ 1000 i)
+                           '()
+                           '())))
+      (define tc
+        (build-tiered-context/state-aware msgs
+                                          #:task-state 'implementation
+                                          #:conclusions conclusions))
+      ;; Baseline guard: v0.77.0 documents the pre-budget behavior. Later waves
+      ;; may replace this assertion with a hard conclusion-token budget.
+      (check-true (>= (length (tiered-context-tier-a tc)) (+ 1 (length conclusions)))))
+
     (test-case "state-aware filters working-set for implementation"
       (define msgs (make-test-msgs 5))
       (define ws (list (make-test-msg 'system "ws1")))


### PR DESCRIPTION
v0.77.0 W0 — Baseline telemetry + guardrail tests

Implements:
- W0.1 context category/tier token telemetry helper
- W0.2 regression tests for current risky behavior
- W0.3 validation scaffold evidence updated in .planning (outside repo)

Verification:
- raco test tests/test-state-aware-builder.rkt
- raco test tests/test-context-assembly-ws-budget.rkt
- raco test tests/test-rollback-triggers.rkt
- raco make runtime/context-assembly/token-metrics.rkt

Note: repository-wide preflight currently has unrelated pre-existing lint/version drift in long-line tool descriptions and docs pinned to 0.74.6; focused gates pass.

Closes #6463.