### PR TITLE
feat(v0.77.1): WS evolution wiring (#6467)

### DIFF
--- a/runtime/context-assembly/ws-evolution.rkt
+++ b/runtime/context-assembly/ws-evolution.rkt
@@ -26,10 +26,17 @@
                   task-debugging)
          (only-in "task-conclusion.rkt" task-conclusion? task-conclusion-text)
          (only-in "../../util/fsm.rkt" fsm-state-name)
+         racket/set
          racket/string)
 
 (provide evolve-working-set-for-state
-         working-set-selective-keep)
+         working-set-selective-keep
+         evolution-result
+         evolution-result?
+         evolution-result-kept-entries
+         evolution-result-archived-entries
+         evolution-result-evicted-conclusions
+         evolve-working-set-for-state/result)
 
 ;; working-set-selective-keep : working-set? (-> any/c boolean?) → void?
 ;; Keep only entries matching predicate. Removes all others.
@@ -76,3 +83,32 @@
 
     ;; No evolution needed for other transitions
     [else (filter task-conclusion? conclusions)]))
+
+;; ════════════════════════════════════════════════════════════════
+;; v0.77.1 W1.1: Structured evolution result
+;; ════════════════════════════════════════════════════════════════
+
+(struct evolution-result
+        (kept-entries ; (listof ws-entry?) — entries remaining in the WS
+         archived-entries ; (listof ws-entry?) — entries removed (for append-only log)
+         evicted-conclusions) ; (listof task-conclusion?) — conclusions to inject
+  #:transparent)
+
+;; evolve-working-set-for-state/result :
+;;   working-set? task-state? task-state? (listof task-conclusion?) -> evolution-result?
+;;
+;; Like evolve-working-set-for-state but returns a structured result with
+;; archived entries for append-only persistence.
+(define (evolve-working-set-for-state/result ws old-state new-state conclusions)
+  (define entries-before (working-set-entries ws))
+  (define injected (evolve-working-set-for-state ws old-state new-state conclusions))
+  (define entries-after (working-set-entries ws))
+  ;; Compute archived: entries present before but not after
+  (define after-paths
+    (for/set ([e (in-list entries-after)])
+      (ws-entry-path e)))
+  (define archived
+    (for/list ([e (in-list entries-before)]
+               #:when (not (set-member? after-paths (ws-entry-path e))))
+      e))
+  (evolution-result entries-after archived injected))

--- a/runtime/session-events.rkt
+++ b/runtime/session-events.rkt
@@ -21,13 +21,19 @@
                   current-state-inference-threshold))
 (require (only-in "../util/fsm.rkt" fsm-state-name))
 
-(provide (contract-out [wire-session-event-handlers! (-> agent-session? procedure? void?)]))
+(provide (contract-out [wire-session-event-handlers! (-> agent-session? procedure? void?)])
+         current-ws-evolution-enabled?)
 
 ;; ============================================================
 ;; Event bus wiring
 ;; ============================================================
 
-;; Wire event-bus subscribers for fork.requested and compact.requested events.
+;; Wire event-bus subscribers for fork.requested, compact.requested,
+;; tool execution, conclusions, and state transitions.
+
+;; v0.77.1 W1.3: Feature flag for WS evolution subscriber.
+;; Disabled by default — preserves v0.76 behavior until v0.77.7 activation.
+(define current-ws-evolution-enabled? (make-parameter #f))
 ;; These events are published by TUI/CLI commands and need runtime handlers.
 (define (wire-session-event-handlers! sess fork-handler)
   (define bus (agent-session-event-bus sess))
@@ -185,9 +191,13 @@
                                          (hasheq 'state target-sym 'source "explicit"))))
                 #:filter (lambda (evt) (equal? (event-ev evt) "tool.set-task-state.completed")))
 
-    (void)))
+    ;; v0.77.1 W1.3: WS evolution flag exported for turn-orchestrator wiring
+    ;; (subscriber deferred — working-set lives in turn scope, not session)
 
-;; ============================================================
-;; Helpers
-;; ============================================================
-;; session-log-path, session-log-path-for imported from session-types.rkt (REV-05 DRY)
+    (void))
+
+  ;; ============================================================
+  ;; Helpers
+  ;; ============================================================
+  ;; session-log-path, session-log-path-for imported from session-types.rkt (REV-05 DRY)
+  )

--- a/runtime/session-mutation.rkt
+++ b/runtime/session-mutation.rkt
@@ -11,7 +11,10 @@
          (only-in "session-config.rkt" session-config?)
          (only-in "../util/errors.rkt" raise-session-error)
          (only-in "session-index/schema.rkt" session-index?)
-         (only-in "context-assembly/task-state.rkt" task-states-list task-valid-direct-transition?))
+         (only-in "context-assembly/task-state.rkt" task-states-list task-valid-direct-transition?)
+         (only-in "context-assembly/ws-evolution.rkt"
+                  evolution-result?
+                  evolution-result-evicted-conclusions))
 
 (provide (contract-out [guarded-set-prompt-running! (-> agent-session? boolean? void?)]
                        [guarded-set-compacting! (-> agent-session? boolean? void?)]
@@ -136,5 +139,14 @@
   (set-agent-session-recent-tool-calls! sess value))
 
 ;; Guard task-conclusions — type-safe wrapper
+;; v0.77.1 W1.2: Guarded setter for WS evolution results.
+;; Updates conclusions from evolution result; WS is already mutated in-place.
+(define (guarded-set-working-set-evolved! sess evolution-res)
+  (when (and (agent-session? sess) (evolution-result? evolution-res))
+    (define evicted (evolution-result-evicted-conclusions evolution-res))
+    (when (pair? evicted)
+      ;; Replace conclusions with evicted set (already filtered by evolution)
+      (guarded-set-task-conclusions! sess evicted))))
+
 (define (guarded-set-task-conclusions! sess value)
   (set-agent-session-task-conclusions! sess value))

--- a/runtime/session-store.rkt
+++ b/runtime/session-store.rkt
@@ -101,7 +101,9 @@
          append-task-state!
          load-latest-task-state
          append-conclusion!
+         append-archive-marker!
          load-conclusions
+         load-conclusions-archived
          ;; R-09/R-10: Session sink interface (v0.39.0)
          session-sink<%>
          file-session-sink%
@@ -457,6 +459,53 @@
                           v)]
                     [(and (list? v) (eq? k 'origin-message-ids))
                      v] ;; keep as strings — message IDs are strings
+                    [else v]))))
+      (hash->conclusion restored))))
+
+;; v0.77.1 W1.4: Append-only archive markers for evicted conclusions.
+;; Archived conclusions are logged but skipped by load-conclusions by default.
+;; Use load-conclusions-archived to include them.
+
+(define (append-archive-marker! path conclusion)
+  (define json-safe (conclusion-hash->json-safe (conclusion->hash conclusion)))
+  (append-entry! path
+                 (make-message (generate-id)
+                               #f
+                               'system
+                               'task-conclusion-archived
+                               (list (make-text-part (jsexpr->string json-safe)))
+                               (current-seconds)
+                               (hasheq))))
+
+(define (load-conclusions-archived path)
+  (define entries (load-session-log path))
+  (define conc-entries
+    (filter (lambda (e)
+              (and (message? e)
+                   (or (eq? (message-kind e) 'task-conclusion)
+                       (eq? (message-kind e) 'task-conclusion-archived))))
+            entries))
+  (for/list ([e (in-list conc-entries)]
+             #:when (message? e))
+    (define content (message-content e))
+    (define text
+      (if (string? content)
+          content
+          (text-part-text (car content))))
+    (with-handlers ([exn:fail? (lambda (_) #f)])
+      (define raw (string->jsexpr text))
+      (define restored
+        (for/hash ([(k v) (in-hash raw)])
+          (values k
+                  (cond
+                    [(and (string? v) (memq k '(category fsm-state-origin))) (string->symbol v)]
+                    [(and (list? v) (eq? k 'relevance-tags))
+                     (map (lambda (x)
+                            (if (string? x)
+                                (string->symbol x)
+                                x))
+                          v)]
+                    [(and (list? v) (eq? k 'origin-message-ids)) v]
                     [else v]))))
       (hash->conclusion restored))))
 

--- a/tests/test-ws-evolution.rkt
+++ b/tests/test-ws-evolution.rkt
@@ -17,7 +17,12 @@
                   ws-entry-path)
          (only-in "../runtime/context-assembly/ws-evolution.rkt"
                   evolve-working-set-for-state
-                  working-set-selective-keep)
+                  working-set-selective-keep
+                  evolve-working-set-for-state/result
+                  evolution-result?
+                  evolution-result-kept-entries
+                  evolution-result-archived-entries
+                  evolution-result-evicted-conclusions)
          (only-in "../runtime/context-assembly/task-state.rkt"
                   task-idle
                   task-exploration
@@ -119,6 +124,36 @@
       (define remaining (map ws-entry-path (working-set-entries ws)))
       (check-equal? (length remaining) 2 "only test files kept")
       (check-not-false (member "test-a.rkt" remaining))
-      (check-not-false (member "test-c.rkt" remaining)))))
+      (check-not-false (member "test-c.rkt" remaining)))
+
+    ;; v0.77.1 W1.1: evolution-result struct
+
+    (test-case "evolution-result exploration->planning archives all"
+      (define ws (make-working-set))
+      (populate-ws ws '("file1.rkt" "file2.rkt" "file3.rkt"))
+      (define result
+        (evolve-working-set-for-state/result ws task-exploration task-planning conclusions))
+      (check-true (evolution-result? result))
+      (check-equal? (length (evolution-result-kept-entries result)) 0)
+      (check-equal? (length (evolution-result-archived-entries result)) 3)
+      (check-equal? (length (evolution-result-evicted-conclusions result)) 2))
+
+    (test-case "evolution-result impl->debugging archives non-error files"
+      (define ws (make-working-set))
+      (populate-ws ws '("src/main.rkt" "tests/test-foo.rkt" "src/error-handler.rkt"))
+      (define result
+        (evolve-working-set-for-state/result ws task-implementation task-debugging conclusions))
+      (check-true (evolution-result? result))
+      (check-equal? (length (evolution-result-kept-entries result)) 2)
+      (check-equal? (length (evolution-result-archived-entries result)) 1))
+
+    (test-case "evolution-result no-change transition has empty archives"
+      (define ws (make-working-set))
+      (populate-ws ws '("plan.rkt"))
+      (define result
+        (evolve-working-set-for-state/result ws task-planning task-verification conclusions))
+      (check-true (evolution-result? result))
+      (check-equal? (length (evolution-result-kept-entries result)) 1)
+      (check-equal? (length (evolution-result-archived-entries result)) 0))))
 
 (run-tests suite)


### PR DESCRIPTION
v0.77.1 W1 — Working-Set Evolution Wiring and Active Eviction

- W1.1: evolution-result struct (kept + archived + evicted)
- W1.2: guarded-set-working-set-evolved! mutation
- W1.3: current-ws-evolution-enabled? feature flag (disabled by default)
- W1.4: append-archive-marker! + load-conclusions-archived

Tests: 12 ws-evolution, 7 session-task-state, 14 record-conclusion. All pass.

Closes #6467.