### PR TITLE
feat(v0.77.2): conclusion graph + pure task-memory selector (#6472)

### DIFF
--- a/runtime/context-assembly/conclusion-graph.rkt
+++ b/runtime/context-assembly/conclusion-graph.rkt
@@ -1,0 +1,152 @@
+#lang racket/base
+
+;; runtime/context-assembly/conclusion-graph.rkt — Pure DAG for conclusion dependencies
+;; STABILITY: evolving
+;;
+;; Builds a directed graph from task-conclusion dependencies.
+;; Supports cycle detection, topological sort, and seed-based subgraph selection.
+;; Pure functions only — no mutation, no I/O, no side effects.
+
+(require racket/contract
+         racket/list
+         "task-conclusion.rkt")
+
+;; ── Struct ──
+
+(struct conclusion-graph
+        (nodes ; (hash/c string? task-conclusion?) — id → conclusion
+         edges ; (hash/c string? (listof string?)) — id → dependency ids
+         reverse) ; (hash/c string? (listof string?)) — id → dependents
+  #:transparent)
+
+;; ── Constructor ──
+
+(define (build-conclusion-graph conclusions)
+  (define nodes
+    (for/hash ([c (in-list conclusions)])
+      (values (task-conclusion-id c) c)))
+  (define edges
+    (for/hash ([c (in-list conclusions)])
+      (values (task-conclusion-id c)
+              (filter (λ (dep-id) (hash-has-key? nodes dep-id)) (task-conclusion-dependencies c)))))
+  (define reverse
+    (let ([rev (make-hash)])
+      (for ([(id deps) (in-hash edges)])
+        (for ([dep (in-list deps)])
+          (hash-update! rev dep (λ (lst) (cons id lst)) '())))
+      (for/hash ([(k v) (in-hash rev)])
+        (values k (reverse-list v)))))
+  (conclusion-graph nodes edges reverse))
+
+(define (reverse-list lst)
+  (for/fold ([acc '()]) ([x (in-list lst)])
+    (cons x acc)))
+
+;; ── Accessors ──
+
+(define (graph-conclusion-count g)
+  (hash-count (conclusion-graph-nodes g)))
+
+(define (graph-edge-count g)
+  (for/sum ([deps (in-hash-values (conclusion-graph-edges g))]) (length deps)))
+
+;; ── Cycle Detection ──
+
+;; Returns list of cyclic node IDs (nodes involved in any cycle).
+(define (graph-detect-cycles g)
+  (define edges (conclusion-graph-edges g))
+  (define all-ids (hash-keys edges))
+  (define visited (make-hash))
+  (define rec-stack (make-hash))
+  (define cycles '())
+  (define (dfs id)
+    (hash-set! visited id #t)
+    (hash-set! rec-stack id #t)
+    (for ([dep (in-list (hash-ref edges id '()))])
+      (cond
+        [(hash-ref rec-stack dep #f) (set! cycles (cons id cycles))]
+        [(not (hash-ref visited dep #f)) (dfs dep)]))
+    (hash-set! rec-stack id #f))
+  (for ([id (in-list all-ids)])
+    (unless (hash-ref visited id #f)
+      (dfs id)))
+  (remove-duplicates cycles))
+
+;; ── Topological Sort ──
+
+;; Returns list of IDs in dependency order (dependencies first).
+;; Undefined for cyclic graphs — call graph-detect-cycles first.
+(define (graph-topological-sort g)
+  (define edges (conclusion-graph-edges g))
+  (define all-ids (hash-keys edges))
+  (define visited (make-hash))
+  (define result '())
+  (define (visit id)
+    (unless (hash-ref visited id #f)
+      (hash-set! visited id #t)
+      (for ([dep (in-list (hash-ref edges id '()))])
+        (visit dep))
+      (set! result (cons id result))))
+  (for ([id (in-list all-ids)])
+    (visit id))
+  (reverse result))
+
+;; ── Seed Selection ──
+
+;; Given seed IDs, return all reachable IDs (transitive closure via dependencies).
+;; Seeds not in the graph are silently ignored.
+(define (graph-select-by-seeds g seed-ids)
+  (define nodes (conclusion-graph-nodes g))
+  (define edges (conclusion-graph-edges g))
+  (define visited (make-hash))
+  (define (bfs queue)
+    (cond
+      [(null? queue) '()]
+      [else
+       (define id (car queue))
+       (cond
+         [(hash-ref visited id #f) (bfs (cdr queue))]
+         [else
+          (hash-set! visited id #t)
+          (define deps (hash-ref edges id '()))
+          (bfs (append (cdr queue) deps))])]))
+  ;; Only start from seeds that exist in graph
+  (define valid-seeds (filter (λ (s) (hash-has-key? nodes s)) seed-ids))
+  (bfs valid-seeds)
+  (hash-keys visited))
+
+;; ── Degraded Fallback ──
+
+;; When graph selection fails (empty seeds, no graph, cycles),
+;; fall back to bounded recency selection from a flat conclusion list.
+(define (fallback-select-conclusions conclusions max-count [states '()])
+  (define filtered
+    (if (null? states)
+        conclusions
+        (let ([state-set (for/hash ([s (in-list states)])
+                           (values s #t))])
+          (filter (λ (c) (hash-has-key? state-set (task-conclusion-fsm-state-origin c)))
+                  conclusions))))
+  ;; Sort by timestamp descending, take most recent
+  (define sorted (sort filtered > #:key task-conclusion-timestamp))
+  (take-at-most sorted max-count))
+
+(define (take-at-most lst n)
+  (if (> (length lst) n)
+      (drop lst (- (length lst) n))
+      lst))
+
+;; ── Exports ──
+
+(provide (struct-out conclusion-graph)
+         (contract-out [build-conclusion-graph (-> (listof task-conclusion?) conclusion-graph?)]
+                       [graph-conclusion-count (-> conclusion-graph? exact-nonnegative-integer?)]
+                       [graph-edge-count (-> conclusion-graph? exact-nonnegative-integer?)]
+                       [graph-detect-cycles (-> conclusion-graph? (listof string?))]
+                       [graph-topological-sort (-> conclusion-graph? (listof string?))]
+                       [graph-select-by-seeds
+                        (-> conclusion-graph? (listof string?) (listof string?))]
+                       [fallback-select-conclusions
+                        (->* ((listof task-conclusion?) exact-nonnegative-integer?)
+                             ((listof symbol?))
+                             (listof task-conclusion?))]))

--- a/runtime/context-assembly/task-memory.rkt
+++ b/runtime/context-assembly/task-memory.rkt
@@ -9,7 +9,12 @@
 (require racket/contract
          racket/list
          "task-conclusion.rkt"
-         (only-in "task-state.rkt" task-state?))
+         (only-in "task-state.rkt" task-state?)
+         (only-in "conclusion-graph.rkt"
+                  build-conclusion-graph
+                  graph-select-by-seeds
+                  graph-detect-cycles
+                  fallback-select-conclusions))
 
 ;; ── Struct ──
 
@@ -88,6 +93,37 @@
 (define (hash->task-memory h)
   (task-memory (map hash->conclusion (hash-ref h 'conclusions '())) (hash-ref h 'max-conclusions 50)))
 
+;; v0.77.2 W2.2: Graph-aware context selection combining state relevance + graph seeds.
+;; Falls back to bounded recency when graph is empty or has cycles.
+(define (conclusions-for-context mem current-states seed-ids [max-count 20])
+  (define concs (task-memory-conclusions mem))
+  (cond
+    [(null? concs) '()]
+    ;; Degraded fallback: no seeds, use state-based bounded recency
+    [(null? seed-ids) (fallback-select-conclusions concs max-count current-states)]
+    [else
+     (define g (build-conclusion-graph concs))
+     (define cycles (graph-detect-cycles g))
+     (cond
+       ;; Degraded fallback: graph has cycles, use state-based bounded recency
+       [(pair? cycles) (fallback-select-conclusions concs max-count current-states)]
+       [else
+        (define selected-ids (graph-select-by-seeds g seed-ids))
+        (define id-set
+          (for/hash ([id (in-list selected-ids)])
+            (values id #t)))
+        (define state-set
+          (for/hash ([s (in-list current-states)])
+            (values s #t)))
+        ;; Filter by state relevance, then limit by max-count
+        (define filtered
+          (filter (lambda (c)
+                    (and (hash-has-key? id-set (task-conclusion-id c))
+                         (or (null? current-states)
+                             (hash-has-key? state-set (task-conclusion-fsm-state-origin c)))))
+                  concs))
+        (take-at-most filtered max-count)])]))
+
 ;; ── Exports ──
 
 (provide (struct-out task-memory)
@@ -98,4 +134,8 @@
           [conclusions-with-tags (-> task-memory? (listof symbol?) (listof task-conclusion?))]
           [evict-stale-conclusions (->* (task-memory?) ((listof symbol?) integer?) task-memory?)]
           [task-memory->hash (-> task-memory? hash?)]
-          [hash->task-memory (-> hash? task-memory?)]))
+          [hash->task-memory (-> hash? task-memory?)]
+          [conclusions-for-context
+           (->* (task-memory? (listof symbol?) (listof string?))
+                (exact-nonnegative-integer?)
+                (listof task-conclusion?))]))

--- a/tests/test-conclusion-graph.rkt
+++ b/tests/test-conclusion-graph.rkt
@@ -1,0 +1,111 @@
+#lang racket/base
+
+(require rackunit
+         rackunit/text-ui
+         (only-in "../runtime/context-assembly/task-conclusion.rkt"
+                  task-conclusion
+                  task-conclusion-id
+                  task-conclusion-dependencies)
+         (only-in "../runtime/context-assembly/conclusion-graph.rkt"
+                  build-conclusion-graph
+                  conclusion-graph?
+                  graph-select-by-seeds
+                  graph-topological-sort
+                  graph-detect-cycles
+                  graph-conclusion-count
+                  graph-edge-count
+                  fallback-select-conclusions)
+         (only-in "../runtime/context-assembly/task-memory.rkt"
+                  make-task-memory
+                  add-conclusion
+                  conclusions-for-context))
+
+(define c1 (task-conclusion "c1" "text1" 'fact 'idle '() 100 '() '("c2")))
+(define c2 (task-conclusion "c2" "text2" 'fact 'idle '() 200 '() '()))
+(define c3 (task-conclusion "c3" "text3" 'fact 'idle '() 300 '() '("c1")))
+(define c-self (task-conclusion "cs" "self" 'fact 'idle '() 400 '() '("cs")))
+
+(define (index-of lst v)
+  (for/first ([x (in-list lst)]
+              [i (in-naturals)]
+              #:when (equal? x v))
+    i))
+
+(define suite
+  (test-suite "conclusion-graph"
+    (test-case "build empty graph"
+      (define g (build-conclusion-graph '()))
+      (check-true (conclusion-graph? g))
+      (check-equal? (graph-conclusion-count g) 0)
+      (check-equal? (graph-edge-count g) 0))
+
+    (test-case "build graph with no deps"
+      (define g (build-conclusion-graph (list c2)))
+      (check-equal? (graph-conclusion-count g) 1)
+      (check-equal? (graph-edge-count g) 0))
+
+    (test-case "build graph with deps"
+      (define g (build-conclusion-graph (list c1 c2 c3)))
+      (check-equal? (graph-conclusion-count g) 3)
+      (check-equal? (graph-edge-count g) 2))
+
+    (test-case "topological sort is valid order"
+      (define g (build-conclusion-graph (list c1 c2 c3)))
+      (define sorted (graph-topological-sort g))
+      (check-equal? (length sorted) 3)
+      (check-true (< (index-of sorted "c2") (index-of sorted "c1")))
+      (check-true (< (index-of sorted "c1") (index-of sorted "c3"))))
+
+    (test-case "detect cycle"
+      (define g (build-conclusion-graph (list c-self)))
+      (define cycles (graph-detect-cycles g))
+      (check-true (pair? cycles)))
+
+    (test-case "no cycles in acyclic graph"
+      (define g (build-conclusion-graph (list c1 c2)))
+      (check-equal? (graph-detect-cycles g) '()))
+
+    (test-case "select by seeds returns transitive closure"
+      (define g (build-conclusion-graph (list c1 c2 c3)))
+      (define selected (graph-select-by-seeds g '("c3")))
+      (check-equal? (length selected) 3)
+      (check-not-false (member "c1" selected))
+      (check-not-false (member "c2" selected))
+      (check-not-false (member "c3" selected)))
+
+    (test-case "select by unknown seed returns empty"
+      (define g (build-conclusion-graph (list c1 c2)))
+      (check-equal? (graph-select-by-seeds g '("unknown")) '()))
+
+    (test-case "fallback selects most recent by state"
+      (define concs (list c1 c2 c3))
+      (define selected (fallback-select-conclusions concs 2))
+      (check-equal? (length selected) 2))
+
+    (test-case "fallback with state filter"
+      (define concs (list c1 c2 c3))
+      (define selected (fallback-select-conclusions concs 10 '(idle)))
+      (check-equal? (length selected) 3))
+
+    (test-case "conclusions-for-context with seeds"
+      (define mem (make-task-memory))
+      (define mem2 (add-conclusion mem c1))
+      (define mem3 (add-conclusion mem2 c2))
+      (define mem4 (add-conclusion mem3 c3))
+      (define result (conclusions-for-context mem4 '(idle) '("c3")))
+      (check-true (>= (length result) 1)))
+
+    (test-case "conclusions-for-context empty seeds falls back"
+      (define mem (make-task-memory))
+      (define mem2 (add-conclusion mem c1))
+      (define mem3 (add-conclusion mem2 c2))
+      (define result (conclusions-for-context mem3 '(idle) '()))
+      (check-true (>= (length result) 1)))
+
+    (test-case "conclusions-for-context empty memory returns empty"
+      (define mem (make-task-memory))
+      (check-equal? (conclusions-for-context mem '() '()) '()))
+    (test-case "fallback with empty input"
+      (check-equal? (fallback-select-conclusions '() 5) '()))))
+
+(run-tests suite)


### PR DESCRIPTION
v0.77.2 W2 — Conclusion Graph: Pure DAG and Task-Memory Selection API

- W2.1: New conclusion-graph.rkt — build DAG from dependencies, cycle detection, topological sort, seed-based subgraph selection
- W2.2: conclusions-for-context in task-memory — graph-aware selector combining state relevance + graph seeds
- W2.3: Degraded fallback policy — empty seeds or cycles degrade to bounded recency, never failure

14 tests pass. All files compile.

Closes #6472.