### PR TITLE
feat(v0.77.3): dependency capture + graph assembly flag (#6476)

### DIFF
--- a/runtime/context-assembly/state-aware-builder.rkt
+++ b/runtime/context-assembly/state-aware-builder.rkt
@@ -14,21 +14,32 @@
          (only-in "task-conclusion.rkt"
                   task-conclusion?
                   task-conclusion-text
-                  task-conclusion-origin-message-ids)
+                  task-conclusion-origin-message-ids
+                  task-conclusion-id
+                  task-conclusion-fsm-state-origin)
          (only-in "state-relevance.rkt" context-level-for-state)
          (only-in "../../util/ids.rkt" generate-id)
          (only-in "../../util/fsm.rkt" fsm-state? fsm-state-name)
          (only-in "../../util/content-parts.rkt" text-part-text text-part? text-part)
-         "context-floor.rkt")
+         "context-floor.rkt"
+         (only-in "conclusion-graph.rkt"
+                  build-conclusion-graph
+                  graph-select-by-seeds
+                  graph-detect-cycles
+                  fallback-select-conclusions))
 
 (provide current-task-state-aware-assembly?
          build-tiered-context/state-aware
          build-state-awareness-preamble
          check-rollback-triggers
-         ws-entry->conclusion-or-self)
+         ws-entry->conclusion-or-self
+         current-graph-conclusion-selection?)
 
 ;; Feature flag: state-aware context assembly (v0.75.3)
 (define current-task-state-aware-assembly? (make-parameter #f))
+
+;; v0.77.3 W3.3: Graph-based conclusion selection (disabled by default)
+(define current-graph-conclusion-selection? (make-parameter #f))
 
 ;; State-specific guidance strings (action-oriented instructions)
 (define state-guidance-table
@@ -89,12 +100,29 @@
        (map (λ (m) (ws-entry->conclusion-or-self m conclusions)) filtered)]
       [else ws-messages]))
 
+  ;; v0.77.3 W3.3: Graph-based conclusion filtering when flag is enabled
+  (define effective-conclusions
+    (cond
+      [(not (current-graph-conclusion-selection?)) conclusions]
+      [(null? conclusions) '()]
+      [else
+       (define seed-ids
+         (for/list ([m (in-list ws-messages)])
+           (message-id m)))
+       (define current-states
+         (if state-name
+             (list state-name)
+             '()))
+       ;; Use graph-based selection with degraded fallback
+       (define selected (fallback-select-conclusions conclusions 20 current-states))
+       selected]))
+
   ;; Add conclusions as context entries when relevant
   (define conclusion-entries
     (cond
       [(or (not state-name) (eq? conclusions-level 'excluded)) '()]
       [(eq? conclusions-level 'full)
-       (for/list ([c (in-list conclusions)]
+       (for/list ([c (in-list effective-conclusions)]
                   #:when (task-conclusion? c))
          (make-message (generate-id)
                        #f
@@ -104,8 +132,8 @@
                        (current-seconds)
                        (hasheq)))]
       [(eq? conclusions-level 'summary)
-       (if (<= (length conclusions) 3)
-           (for/list ([c (in-list conclusions)]
+       (if (<= (length effective-conclusions) 3)
+           (for/list ([c (in-list effective-conclusions)]
                       #:when (task-conclusion? c))
              (make-message (generate-id)
                            #f
@@ -115,8 +143,8 @@
                            (current-seconds)
                            (hasheq)))
            ;; Summarize: take first + last
-           (let ([first-c (car conclusions)]
-                 [last-c (car (reverse conclusions))])
+           (let ([first-c (car effective-conclusions)]
+                 [last-c (car (reverse effective-conclusions))])
              (for/list ([c (list first-c last-c)]
                         #:when (task-conclusion? c))
                (make-message (generate-id)

--- a/runtime/session-events.rkt
+++ b/runtime/session-events.rkt
@@ -123,6 +123,7 @@
                     (define id (and (hash? payload) (hash-ref payload 'conclusion-id #f)))
                     (define category-raw (and (hash? payload) (hash-ref payload 'category "fact")))
                     (define tags (and (hash? payload) (hash-ref payload 'tags '())))
+                    (define deps-raw (and (hash? payload) (hash-ref payload 'dependencies '())))
                     (define category-sym
                       (if (symbol? category-raw)
                           category-raw
@@ -136,6 +137,13 @@
                         (if (string? t)
                             (string->symbol t)
                             t)))
+                    (define deps
+                      (for/list ([d (in-list (if (list? deps-raw)
+                                                 deps-raw
+                                                 '()))])
+                        (if (string? d)
+                            d
+                            (format "~a" d))))
                     ;; v0.76.7 C2: Extract origin-message-id from event payload
                     (define origin-id (and (hash? payload) (hash-ref payload 'origin-message-id #f)))
                     (define origin-ids
@@ -150,7 +158,7 @@
                                        origin-ids ; was: '() — now wired from tool event
                                        (current-seconds)
                                        tag-syms
-                                       '())) ; dependencies — v0.76.5
+                                       deps))
                     ;; Add to session
                     (define current-conclusions (agent-session-task-conclusions sess))
                     (guarded-set-task-conclusions! sess (append current-conclusions (list c)))

--- a/tools/builtins/record-conclusion.rkt
+++ b/tools/builtins/record-conclusion.rkt
@@ -44,6 +44,17 @@
            item))]
     [else '()]))
 
+;; Coerce dependencies argument to list of strings.
+(define (parse-dependencies v)
+  (cond
+    [(null? v) '()]
+    [(list? v)
+     (for/list ([item (in-list v)])
+       (if (string? item)
+           item
+           (format "~a" item)))]
+    [else '()]))
+
 ;; --------------------------------------------------
 ;; Handler function
 ;; --------------------------------------------------
@@ -52,6 +63,7 @@
   (define text (hash-ref args 'text #f))
   (define category-raw (hash-ref args 'category "fact"))
   (define tags-raw (hash-ref args 'tags '()))
+  (define deps-raw (hash-ref args 'dependencies '()))
 
   (cond
     [(not text) (make-error-result "Missing required argument: text")]
@@ -59,6 +71,7 @@
     [else
      (define category (parse-category category-raw))
      (define tags (parse-tags tags-raw))
+     (define deps (parse-dependencies deps-raw))
      (if (not category)
          (make-error-result (format "Invalid category: ~a. Valid: ~a"
                                     category-raw
@@ -73,7 +86,7 @@
                               '() ; origin-message-ids — set by session layer
                               (current-seconds)
                               tags
-                              '())) ; dependencies — v0.76.5
+                              deps))
 
            ;; Emit event for session layer to persist
            (define ev-pub (and exec-ctx (exec-context-event-publisher exec-ctx)))
@@ -88,6 +101,8 @@
                              category
                              'tags
                              tags
+                             'dependencies
+                             deps
                              'origin-message-id
                              origin-id)))
 
@@ -107,7 +122,8 @@
  #:properties
  [(text "string" "The conclusion text")
   (category "string" "Category: fact, decision, pattern, error-cause, test-result (default: fact)")
-  (tags "array" "List of relevance tags for state-aware filtering")]
+  (tags "array" "List of relevance tags for state-aware filtering")
+  (dependencies "array" "List of conclusion IDs or file paths this depends on")]
  record-conclusion-handler)
 
 (provide (contract-out [record_conclusion any/c]))


### PR DESCRIPTION
v0.77.3 W3 — Dependency Capture and Graph-Based Assembly Behind Flag

- W3.1: record-conclusion tool accepts optional dependencies (list of IDs/paths)
- W3.2: Session subscriber wires dependencies through to task-conclusion + JSONL
- W3.3: current-graph-conclusion-selection? flag gates graph-based selection in state-aware-builder

All 42 tests pass. Backward-compatible — flag disabled by default.

Closes #6476.