### PR TITLE
feat(v0.77.5): auto-distillation + optional LLM path (#6485)

### DIFF
--- a/runtime/context-assembly/auto-distillation.rkt
+++ b/runtime/context-assembly/auto-distillation.rkt
@@ -1,0 +1,102 @@
+#lang racket/base
+
+;; runtime/context-assembly/auto-distillation.rkt — Automatic fallback conclusions
+;; STABILITY: evolving
+;;
+;; Identifies uncovered working-set entries (no matching conclusion origin-message-ids)
+;; and produces deterministic fallback conclusions. Optional LLM distillation is injectable
+;; but disabled by default. Timeout/failure returns deterministic fallback.
+
+(require racket/contract
+         racket/list
+         (only-in "task-conclusion.rkt"
+                  task-conclusion
+                  task-conclusion?
+                  task-conclusion-id
+                  task-conclusion-origin-message-ids
+                  task-conclusion-text
+                  task-conclusion-category
+                  task-conclusion-fsm-state-origin
+                  task-conclusion-timestamp
+                  task-conclusion-relevance-tags
+                  task-conclusion-dependencies))
+
+;; ── Uncovered Entry Detection ──
+
+;; Find WS entries (represented as message IDs) that have no covering conclusion.
+;; A message ID is "covered" if any conclusion's origin-message-ids contains it.
+(define (find-uncovered-entries ws-message-ids conclusions)
+  (define covered-ids
+    (for/fold ([s (hash)])
+              ([c (in-list conclusions)]
+               #:when (task-conclusion? c))
+      (for/fold ([acc s]) ([mid (in-list (task-conclusion-origin-message-ids c))])
+        (hash-set acc mid #t))))
+  (filter (lambda (id) (not (hash-has-key? covered-ids id))) ws-message-ids))
+
+;; ── Deterministic Fallback ──
+
+;; Generate a deterministic fallback conclusion for an uncovered entry.
+;; Uses the message ID and a generic template.
+(define (make-deterministic-fallback msg-id current-state)
+  (task-conclusion (format "auto-~a" msg-id)
+                   (format "[Auto] Previously read file (origin: ~a)" msg-id)
+                   'fact
+                   (or current-state 'idle)
+                   (list msg-id)
+                   (current-seconds)
+                   '(auto-distilled)
+                   '()))
+
+;; Generate fallback conclusions for all uncovered entries.
+(define (generate-fallback-conclusions uncovered-ids current-state)
+  (for/list ([id (in-list uncovered-ids)])
+    (make-deterministic-fallback id current-state)))
+
+;; ── Optional LLM Distillation Interface ──
+
+;; LLM distillation function type: (listof string?) symbol? -> (listof task-conclusion?)
+;; When provided, called instead of deterministic fallback.
+;; On timeout/error, falls back to deterministic.
+
+(define (distill-with-llm uncovered-ids current-state llm-distill-fn timeout-secs)
+  (with-handlers ([exn:fail? (lambda (e)
+                               (generate-fallback-conclusions uncovered-ids current-state))])
+    (define result
+      (sync/timeout timeout-secs (thread (lambda () (llm-distill-fn uncovered-ids current-state)))))
+    (cond
+      [(not result) (generate-fallback-conclusions uncovered-ids current-state)]
+      [(and (list? result) (andmap task-conclusion? result)) result]
+      [else (generate-fallback-conclusions uncovered-ids current-state)])))
+
+;; ── Main Entry Point ──
+
+;; Feature flag for auto-distillation
+(define current-auto-distillation-enabled? (make-parameter #f))
+
+;; Optional LLM distillation function (parameter)
+(define current-llm-distill-fn (make-parameter #f))
+
+;; Generate auto-conclusions for uncovered WS entries.
+;; Returns (listof task-conclusion?) — either LLM-distilled or deterministic fallbacks.
+(define (auto-distill ws-message-ids conclusions current-state)
+  (define uncovered (find-uncovered-entries ws-message-ids conclusions))
+  (cond
+    [(null? uncovered) '()]
+    [(not (current-auto-distillation-enabled?)) '()]
+    [(current-llm-distill-fn) (distill-with-llm uncovered current-state (current-llm-distill-fn) 5)]
+    [else (generate-fallback-conclusions uncovered current-state)]))
+
+;; ── Exports ──
+
+(provide current-auto-distillation-enabled?
+         current-llm-distill-fn
+         (contract-out [find-uncovered-entries
+                        (-> (listof string?) (listof task-conclusion?) (listof string?))]
+                       [generate-fallback-conclusions
+                        (-> (listof string?) (or/c symbol? #f) (listof task-conclusion?))]
+                       [auto-distill
+                        (-> (listof string?)
+                            (listof task-conclusion?)
+                            (or/c symbol? #f)
+                            (listof task-conclusion?))]))

--- a/tests/test-auto-distillation.rkt
+++ b/tests/test-auto-distillation.rkt
@@ -1,0 +1,64 @@
+#lang racket/base
+
+(require rackunit
+         rackunit/text-ui
+         (only-in "../runtime/context-assembly/task-conclusion.rkt"
+                  task-conclusion
+                  task-conclusion?
+                  task-conclusion-origin-message-ids
+                  task-conclusion-relevance-tags
+                  task-conclusion-category
+                  task-conclusion-id)
+         (only-in "../runtime/context-assembly/auto-distillation.rkt"
+                  find-uncovered-entries
+                  generate-fallback-conclusions
+                  auto-distill
+                  current-auto-distillation-enabled?))
+
+(define c-with-coverage
+  (task-conclusion "c1" "Found pattern" 'fact 'idle '("msg-1" "msg-2") 100 '() '()))
+
+(define suite
+  (test-suite "auto-distillation"
+    (test-case "find-uncovered-entries with full coverage"
+      (define uncovered (find-uncovered-entries '("msg-1" "msg-2") (list c-with-coverage)))
+      (check-equal? uncovered '()))
+
+    (test-case "find-uncovered-entries with partial coverage"
+      (define uncovered (find-uncovered-entries '("msg-1" "msg-2" "msg-3") (list c-with-coverage)))
+      (check-equal? (length uncovered) 1)
+      (check-equal? (car uncovered) "msg-3"))
+
+    (test-case "find-uncovered-entries with no conclusions"
+      (define uncovered (find-uncovered-entries '("msg-1" "msg-2") '()))
+      (check-equal? (length uncovered) 2))
+
+    (test-case "find-uncovered-entries with empty WS"
+      (check-equal? (find-uncovered-entries '() (list c-with-coverage)) '()))
+
+    (test-case "generate-fallback-conclusions creates valid conclusions"
+      (define fallbacks (generate-fallback-conclusions '("m1" "m2") 'implementation))
+      (check-equal? (length fallbacks) 2)
+      (for ([c (in-list fallbacks)])
+        (check-true (task-conclusion? c))
+        (check-equal? (task-conclusion-category c) 'fact)
+        (check-not-false (member 'auto-distilled (task-conclusion-relevance-tags c)))))
+
+    (test-case "auto-distill disabled returns empty"
+      (parameterize ([current-auto-distillation-enabled? #f])
+        (define result (auto-distill '("m1") '() 'idle))
+        (check-equal? result '())))
+
+    (test-case "auto-distill enabled with uncovered entries"
+      (parameterize ([current-auto-distillation-enabled? #t])
+        (define result (auto-distill '("m1" "m2") '() 'exploration))
+        (check-equal? (length result) 2)
+        (for ([c (in-list result)])
+          (check-true (task-conclusion? c)))))
+
+    (test-case "auto-distill enabled with all covered returns empty"
+      (parameterize ([current-auto-distillation-enabled? #t])
+        (define result (auto-distill '("msg-1") (list c-with-coverage) 'idle))
+        (check-equal? result '())))))
+
+(run-tests suite)


### PR DESCRIPTION
v0.77.5 W5 — Automatic Distillation: Deterministic First, LLM Optional

- W5.1: New auto-distillation.rkt — finds uncovered WS entries, generates deterministic fallbacks
- W5.2: Optional LLM distillation via current-llm-distill-fn with timeout/failure fallback
- W5.3/W5.4: Feature flag current-auto-distillation-enabled? (off by default), auto-distilled tag + provenance

8 tests pass.

Closes #6485.