### PR TITLE
v0.77.10 W0: Real Rollback Action Execution (M2)

### DIFF
--- a/runtime/context-assembly/rollback-actions.rkt
+++ b/runtime/context-assembly/rollback-actions.rkt
@@ -6,6 +6,10 @@
 ;; Represents rollback actions as pure data. Actions are prioritized:
 ;; warn-only < expand-context < force-distill < revert-state.
 ;; At most one action is executed per turn to prevent recursive loops.
+;;
+;; v0.77.10 M2: Real execution via injectable callbacks.
+;; Default callbacks are no-ops. The runtime (state-aware-builder) wires
+;; real callbacks that set feature flags and budgets.
 
 (require racket/contract
          racket/list
@@ -52,7 +56,40 @@
 ;; Feature flag for action execution (disabled by default — warn-only mode)
 (define current-rollback-action-execution? (make-parameter #f))
 
+;; v0.77.10 M2: Injectable execution callbacks.
+;; Default to no-op. Runtime wires real implementations.
+;; Signature: (-> rollback-action? void?)
+(define current-force-distill-fn (make-parameter #f))
+(define current-expand-context-fn (make-parameter #f))
+
+;; v0.77.10 M2: Action execution log for observability.
+;; Each entry is a hash with 'type, 'reason, 'timestamp.
+(define current-rollback-action-log (make-parameter '()))
+
+;; v0.77.10 M2: Execute force-distill action.
+;; Calls the injectable callback if available, then logs.
+(define (execute-force-distill! action)
+  (define fn (current-force-distill-fn))
+  (when fn (fn action))
+  (log-action! action))
+
+;; v0.77.10 M2: Execute expand-context action.
+;; Calls the injectable callback if available, then logs.
+(define (execute-expand-context! action)
+  (define fn (current-expand-context-fn))
+  (when fn (fn action))
+  (log-action! action))
+
+;; Log an executed action to the rollback action log.
+(define (log-action! action)
+  (current-rollback-action-log
+   (append (current-rollback-action-log)
+           (list (hasheq 'type (rollback-action-type action)
+                         'reason (rollback-action-reason action)
+                         'timestamp (current-seconds))))))
+
 ;; Execute a rollback action if execution is enabled.
+;; v0.77.10 M2: Now dispatches to real execution functions.
 ;; Returns the action type if executed, #f otherwise.
 ;; Never executes 'revert-state unless explicitly enabled.
 (define (maybe-execute-action action)
@@ -60,6 +97,15 @@
     [(not action) #f]
     [(not (current-rollback-action-execution?)) #f]
     [(eq? (rollback-action-type action) 'revert-state) #f] ; too risky
+    [(eq? (rollback-action-type action) 'force-distill)
+     (execute-force-distill! action)
+     'force-distill]
+    [(eq? (rollback-action-type action) 'expand-context)
+     (execute-expand-context! action)
+     'expand-context]
+    [(eq? (rollback-action-type action) 'warn-only)
+     (log-action! action)
+     'warn-only]
     [else (rollback-action-type action)]))
 
 ;; ── Trigger to Action Mapping ──
@@ -79,6 +125,9 @@
 
 (provide (struct-out rollback-action)
          current-rollback-action-execution?
+         current-rollback-action-log
+         current-force-distill-fn
+         current-expand-context-fn
          rollback-action-type?
          (contract-out [make-warn-action (-> string? rollback-action?)]
                        [make-expand-context-action (-> string? hash? rollback-action?)]

--- a/runtime/context-assembly/state-aware-builder.rkt
+++ b/runtime/context-assembly/state-aware-builder.rkt
@@ -32,7 +32,11 @@
          (only-in "rollback-actions.rkt"
                   warnings->actions
                   select-highest-priority-action
-                  maybe-execute-action))
+                  maybe-execute-action
+                  current-force-distill-fn
+                  current-expand-context-fn
+                  current-rollback-action-log)
+         (only-in "auto-distillation.rkt" current-auto-distillation-enabled?))
 
 (provide current-task-state-aware-assembly?
          build-tiered-context/state-aware
@@ -224,9 +228,22 @@
     (when (pair? warnings)
       (log-warning "context-assembly: rollback triggers fired: ~a" warnings))
     (when recommended-action
-      (define executed (maybe-execute-action recommended-action))
-      (when executed
-        (log-warning "context-assembly: executed rollback action: ~a" executed))))
+      ;; v0.77.10 M2: Wire real execution callbacks
+      (parameterize ([current-force-distill-fn
+                      (lambda (a)
+                        (log-warning "context-assembly: force-distill enabling auto-distillation")
+                        (current-auto-distillation-enabled? #t))]
+                     [current-expand-context-fn
+                      (lambda (a)
+                        (define current-budget (current-conclusion-token-budget))
+                        (define expanded (* current-budget 2))
+                        (log-warning "context-assembly: expanding budget ~a \xe2\x86\x92 ~a"
+                                     current-budget
+                                     expanded)
+                        (current-conclusion-token-budget expanded))])
+        (define executed (maybe-execute-action recommended-action))
+        (when executed
+          (log-warning "context-assembly: executed rollback action: ~a" executed)))))
   (if (and (null? preamble-entries) (null? conclusion-entries))
       base-tc
       (tiered-context new-tier-a (tiered-context-tier-b base-tc) (tiered-context-tier-c base-tc))))

--- a/tests/test-rollback-actions.rkt
+++ b/tests/test-rollback-actions.rkt
@@ -1,5 +1,8 @@
 #lang racket/base
 
+;; tests/test-rollback-actions.rkt — Rollback action model tests
+;; v0.77.10 M2: Updated to verify real execution via injectable callbacks
+
 (require rackunit
          rackunit/text-ui
          (only-in "../runtime/context-assembly/rollback-actions.rkt"
@@ -14,7 +17,10 @@
                   select-highest-priority-action
                   maybe-execute-action
                   warnings->actions
-                  current-rollback-action-execution?))
+                  current-rollback-action-execution?
+                  current-rollback-action-log
+                  current-force-distill-fn
+                  current-expand-context-fn))
 
 (define suite
   (test-suite "rollback-actions"
@@ -45,12 +51,14 @@
         (check-false (maybe-execute-action (make-warn-action "test")))))
 
     (test-case "maybe-execute-action enabled executes non-revert"
-      (parameterize ([current-rollback-action-execution? #t])
+      (parameterize ([current-rollback-action-execution? #t]
+                     [current-rollback-action-log '()])
         (check-equal? (maybe-execute-action (make-force-distill-action "test" (hasheq)))
                       'force-distill)))
 
     (test-case "maybe-execute-action never executes revert-state"
-      (parameterize ([current-rollback-action-execution? #t])
+      (parameterize ([current-rollback-action-execution? #t]
+                     [current-rollback-action-log '()])
         (check-false (maybe-execute-action (make-revert-state-action "danger" (hasheq))))))
 
     (test-case "warnings->actions maps amnesia to force-distill"
@@ -64,6 +72,58 @@
       (check-equal? (rollback-action-type (car actions)) 'warn-only))
 
     (test-case "maybe-execute-action with #f input"
-      (check-false (maybe-execute-action #f)))))
+      (check-false (maybe-execute-action #f)))
+
+    ;; v0.77.10 M2: Real execution tests
+
+    (test-case "force-distill calls injectable callback"
+      (define called? #f)
+      (parameterize ([current-rollback-action-execution? #t]
+                     [current-rollback-action-log '()]
+                     [current-force-distill-fn (lambda (a) (set! called? #t))])
+        (define result (maybe-execute-action (make-force-distill-action "amnesia" (hasheq))))
+        (check-equal? result 'force-distill)
+        (check-true called? "callback was invoked")))
+
+    (test-case "expand-context calls injectable callback"
+      (define budget-before 2000)
+      (define budget-after budget-before)
+      (parameterize ([current-rollback-action-execution? #t]
+                     [current-rollback-action-log '()]
+                     [current-expand-context-fn (lambda (a) (set! budget-after (* budget-before 2)))])
+        (define result (maybe-execute-action (make-expand-context-action "excessive" (hasheq))))
+        (check-equal? result 'expand-context)
+        (check-equal? budget-after 4000 "budget was doubled")))
+
+    (test-case "action log records executed actions"
+      (parameterize ([current-rollback-action-execution? #t]
+                     [current-rollback-action-log '()])
+        (maybe-execute-action (make-force-distill-action "amnesia" (hasheq)))
+        (maybe-execute-action (make-warn-action "something"))
+        (define log (current-rollback-action-log))
+        (check-equal? (length log) 2 "two actions logged")
+        (check-equal? (hash-ref (car log) 'type) 'force-distill)
+        (check-equal? (hash-ref (cadr log) 'type) 'warn-only)))
+
+    (test-case "action log empty when execution disabled"
+      (parameterize ([current-rollback-action-execution? #f]
+                     [current-rollback-action-log '()])
+        (maybe-execute-action (make-force-distill-action "test" (hasheq)))
+        (check-equal? (length (current-rollback-action-log)) 0)))
+
+    (test-case "warn-only logs but has no callback"
+      (parameterize ([current-rollback-action-execution? #t]
+                     [current-rollback-action-log '()])
+        (define result (maybe-execute-action (make-warn-action "mild issue")))
+        (check-equal? result 'warn-only)
+        (check-equal? (length (current-rollback-action-log)) 1 "warn logged")
+        (check-equal? (hash-ref (car (current-rollback-action-log)) 'type) 'warn-only)))
+
+    (test-case "revert-state blocked and not logged"
+      (parameterize ([current-rollback-action-execution? #t]
+                     [current-rollback-action-log '()])
+        (define result (maybe-execute-action (make-revert-state-action "danger" (hasheq))))
+        (check-false result)
+        (check-equal? (length (current-rollback-action-log)) 0 "revert not logged")))))
 
 (run-tests suite)


### PR DESCRIPTION
W0 of v0.77.10: Implements real side effects for rollback actions.

- `maybe-execute-action` now dispatches to injectable callbacks
- `current-force-distill-fn` callback enables auto-distillation
- `current-expand-context-fn` callback doubles token budget
- `current-rollback-action-log` records executed actions for observability
- `state-aware-builder.rkt` wires callbacks to real flag/budget mutations
- 16 rollback-action tests pass (6 new)

Fixes finding M2 from AUDIT-v0.77.9-DEEP-POST-REMEDIATION.md.