### PR TITLE
v0.77.10 W1: WS Evolution Event Emission (M1)

### DIFF
--- a/runtime/session-events.rkt
+++ b/runtime/session-events.rkt
@@ -20,7 +20,9 @@
                   infer-task-state-from-tools
                   current-state-inference-threshold))
 (require (only-in "../util/fsm.rkt" fsm-state-name))
-(require (only-in "context-assembly/ws-evolution.rkt" evolve-working-set-for-state))
+;; v0.77.10 M1: evolve-working-set-for-state import removed — subscriber now emits
+;; context.ws-evolve-requested event for turn-orchestrator to handle.
+;; (require (only-in "context-assembly/ws-evolution.rkt" evolve-working-set-for-state))
 
 (provide (contract-out [wire-session-event-handlers! (-> agent-session? procedure? void?)])
          current-ws-evolution-enabled?)
@@ -203,23 +205,26 @@
     ;; v0.77.1 W1.3: WS evolution flag exported for turn-orchestrator wiring
     ;; (subscriber deferred — working-set lives in turn scope, not session)
 
-    ;; v0.77.9 T2.3: WS evolution subscriber on state transitions
-    ;; When WS evolution is enabled, logs evolution opportunity for each state change.
-    ;; Full WS mutation requires config update — logged here for observability.
-    (subscribe! bus
-                (lambda (evt)
-                  (when (current-ws-evolution-enabled?)
-                    (define payload (event-payload evt))
-                    (define new-state (and (hash? payload) (hash-ref payload 'state #f)))
-                    (when new-state
-                      (define current-state (agent-session-task-fsm-state sess))
-                      (when (and current-state (not (eq? current-state new-state)))
-                        (log-info "session-events: WS evolution opportunity: ~a → ~a"
-                                  current-state
-                                  new-state)))))
-                #:filter (lambda (evt)
-                           (or (equal? (event-ev evt) "task.state.transitioned")
-                               (equal? (event-ev evt) "task.state.inferred"))))
+    ;; v0.77.10 M1: WS evolution subscriber on state transitions.
+    ;; Emits context.ws-evolve-requested event for turn-orchestrator to handle.
+    ;; Turn-orchestrator has access to the working-set in turn scope.
+    (subscribe!
+     bus
+     (lambda (evt)
+       (when (current-ws-evolution-enabled?)
+         (define payload (event-payload evt))
+         (define new-state (and (hash? payload) (hash-ref payload 'state #f)))
+         (when new-state
+           (define current-state (agent-session-task-fsm-state sess))
+           (when (and current-state (not (eq? current-state new-state)))
+             (log-info "session-events: WS evolution requested: ~a → ~a" current-state new-state)
+             (emit-session-event! bus
+                                  (agent-session-session-id sess)
+                                  "context.ws-evolve-requested"
+                                  (hasheq 'old-state current-state 'new-state new-state))))))
+     #:filter (lambda (evt)
+                (or (equal? (event-ev evt) "task.state.transitioned")
+                    (equal? (event-ev evt) "task.state.inferred"))))
 
     (void))
 

--- a/tests/test-session-task-state.rkt
+++ b/tests/test-session-task-state.rkt
@@ -20,9 +20,11 @@
                   task-conclusion?
                   task-conclusion-text)
          (only-in "helpers/session-fixture.rkt" make-test-session)
-         (only-in "../agent/event-bus.rkt" make-event-bus publish!)
-         (only-in "../util/event.rkt" make-event)
-         (only-in "../runtime/session-events.rkt" wire-session-event-handlers!))
+         (only-in "../agent/event-bus.rkt" make-event-bus publish! subscribe!)
+         (only-in "../util/event.rkt" make-event event-ev event-payload)
+         (only-in "../runtime/session-events.rkt"
+                  wire-session-event-handlers!
+                  current-ws-evolution-enabled?))
 
 (define suite
   (test-suite "session-task-state"
@@ -78,6 +80,34 @@
                             #f
                             (hasheq 'target-state "implementation" 'event-name "begin-implement")))
       ;; Verify state transitioned
-      (check-equal? (agent-session-task-fsm-state sess) 'implementation))))
+      (check-equal? (agent-session-task-fsm-state sess) 'implementation))
+
+    (test-case "WS evolution subscriber emits context.ws-evolve-requested event (M1)"
+      (define bus (make-event-bus))
+      (define sess (make-test-session #:event-bus bus))
+      (define received-events '())
+      ;; Subscribe to capture emitted events
+      (subscribe! bus
+                  (lambda (evt) (set! received-events (cons evt received-events)))
+                  #:filter (lambda (evt) (equal? (event-ev evt) "context.ws-evolve-requested")))
+      (wire-session-event-handlers! sess (lambda (s e) s))
+      ;; Set initial state
+      (guarded-set-task-fsm-state! sess 'exploration)
+      ;; Enable WS evolution
+      (parameterize ([current-ws-evolution-enabled? #t])
+        ;; Publish state transition event
+        (publish! bus
+                  (make-event "task.state.transitioned"
+                              (current-seconds)
+                              (agent-session-session-id sess)
+                              #f
+                              (hasheq 'state 'planning))))
+      ;; Verify event was emitted
+      (check-true (>= (length received-events) 1))
+      (define evt (car received-events))
+      (define payload (event-payload evt))
+      (check-equal? (hash-ref payload 'old-state) 'exploration)
+      (check-equal? (hash-ref payload 'new-state) 'planning))))
+
 
 (run-tests suite)


### PR DESCRIPTION
W1 of v0.77.10: Wires WS evolution subscriber to emit events.

- Session-events subscriber now emits `context.ws-evolve-requested` event with old/new state
- Removed unused `evolve-working-set-for-state` import from session-events.rkt
- Added test verifying event emission on state transition when flag enabled
- 8 session-task-state tests pass (1 new)

Fixes finding M1 from AUDIT-v0.77.9-DEEP-POST-REMEDIATION.md.