### PR TITLE
v0.78.0 W1: Fix G5 - merge conclusions in WS evolution

### DIFF
--- a/runtime/session-mutation.rkt
+++ b/runtime/session-mutation.rkt
@@ -6,6 +6,7 @@
 ;; Prevents invalid state transitions like #t→#t on prompt-running?.
 
 (require racket/contract
+         racket/set
          "session-types.rkt"
          (submod "session-types.rkt" internal)
          (only-in "session-config.rkt" session-config?)
@@ -14,7 +15,8 @@
          (only-in "context-assembly/task-state.rkt" task-states-list task-valid-direct-transition?)
          (only-in "context-assembly/ws-evolution.rkt"
                   evolution-result?
-                  evolution-result-evicted-conclusions))
+                  evolution-result-evicted-conclusions)
+         (only-in "context-assembly/task-conclusion.rkt" task-conclusion-id))
 
 (provide (contract-out [guarded-set-prompt-running! (-> agent-session? boolean? void?)]
                        [guarded-set-compacting! (-> agent-session? boolean? void?)]
@@ -33,6 +35,7 @@
                        [guarded-set-task-fsm-state! (-> agent-session? (or/c symbol? #f) void?)]
                        [guarded-set-task-conclusions! (-> agent-session? list? void?)]
                        [guarded-set-recent-tool-calls! (-> agent-session? list? void?)]
+                       [guarded-set-working-set-evolved! (-> agent-session? evolution-result? void?)]
                        [valid-session-phase? (-> symbol? boolean?)]
                        [session-phase (-> agent-session? symbol?)]))
 
@@ -139,14 +142,24 @@
   (set-agent-session-recent-tool-calls! sess value))
 
 ;; Guard task-conclusions — type-safe wrapper
-;; v0.77.1 W1.2: Guarded setter for WS evolution results.
-;; Updates conclusions from evolution result; WS is already mutated in-place.
+;; v0.78.0 W1: Fixed G5 — MERGE instead of REPLACE.
+;; The "evicted-conclusions" field name is misleading; it's actually the
+;; set of conclusions INJECTED by the evolution (to add to session).
+;; We now merge (union by ID) with existing session conclusions.
 (define (guarded-set-working-set-evolved! sess evolution-res)
   (when (and (agent-session? sess) (evolution-result? evolution-res))
-    (define evicted (evolution-result-evicted-conclusions evolution-res))
-    (when (pair? evicted)
-      ;; Replace conclusions with evicted set (already filtered by evolution)
-      (guarded-set-task-conclusions! sess evicted))))
+    (define injected (evolution-result-evicted-conclusions evolution-res))
+    (when (pair? injected)
+      (define existing (agent-session-task-conclusions sess))
+      (define existing-ids
+        (for/set ([c (in-list existing)])
+          (task-conclusion-id c)))
+      ;; Merge: keep all existing + add new ones that don't already exist
+      (define merged
+        (append existing
+                (filter (lambda (c) (not (set-member? existing-ids (task-conclusion-id c))))
+                        injected)))
+      (guarded-set-task-conclusions! sess merged))))
 
 (define (guarded-set-task-conclusions! sess value)
   (set-agent-session-task-conclusions! sess value))

--- a/tests/test-session-mutation.rkt
+++ b/tests/test-session-mutation.rkt
@@ -7,6 +7,11 @@
 (require rackunit
          "../runtime/session-types.rkt"
          "../runtime/session-mutation.rkt"
+         "../runtime/context-assembly/ws-evolution.rkt"
+         (only-in "../runtime/context-assembly/task-conclusion.rkt"
+                  task-conclusion
+                  task-conclusion?
+                  task-conclusion-id)
          "../util/ids.rkt"
          "../agent/queue.rkt")
 
@@ -31,7 +36,10 @@
                  'medium ; thinking-level
                  #f ; shutdown-requested?
                  #f ; force-shutdown?
-                 #f)) ; prompt-running?
+                 #f ; prompt-running?
+                 #f ; task-fsm-state
+                 '() ; task-conclusions
+                 '())) ; recent-tool-calls
 
 ;; W-04: prompt-running? transition guards
 
@@ -74,3 +82,38 @@
 (test-case "valid-session-phase? rejects unknown phases"
   (check-false (valid-session-phase? 'unknown))
   (check-false (valid-session-phase? 'foo)))
+
+;; ── G5 Fix: WS Evolution Conclusion Merge ──
+
+(test-case "guarded-set-working-set-evolved! merges conclusions, does not replace"
+  ;; Create session with existing conclusions from multiple phases
+  (define sess (make-test-session))
+  (guarded-set-task-conclusions! sess
+    (list (task-conclusion "existing-1" "old fact" 'fact 'exploration '() 1000 '() '())
+          (task-conclusion "existing-2" "old decision" 'decision 'implementation '() 2000 '() '())))
+  (check-equal? (length (agent-session-task-conclusions sess)) 2)
+  ;; Simulate evolution result with new conclusions (the "evicted" set)
+  (define evo-res
+    (evolution-result
+      '() ; kept-entries
+      '() ; archived-entries
+      (list (task-conclusion "new-1" "injected fact" 'fact 'implementation '() 3000 '() '()))))
+  ;; Call the function
+  (guarded-set-working-set-evolved! sess evo-res)
+  ;; Verify: ALL original conclusions survive + new ones added
+  (define final-conclusions (agent-session-task-conclusions sess))
+  (check-equal? (length final-conclusions) 3)
+  (define final-ids (map task-conclusion-id final-conclusions))
+  (check-not-false (member "existing-1" final-ids))
+  (check-not-false (member "existing-2" final-ids))
+  (check-not-false (member "new-1" final-ids)))
+
+(test-case "guarded-set-working-set-evolved! with empty evolution result preserves conclusions"
+  (define sess (make-test-session))
+  (guarded-set-task-conclusions! sess
+    (list (task-conclusion "keep-me" "important" 'fact 'exploration '() 1000 '() '())))
+  (define evo-res (evolution-result '() '() '()))
+  (guarded-set-working-set-evolved! sess evo-res)
+  ;; Original conclusion should survive since nothing to merge
+  (check-equal? (length (agent-session-task-conclusions sess)) 1)
+  (check-equal? (task-conclusion-id (car (agent-session-task-conclusions sess))) "keep-me"))


### PR DESCRIPTION
G5 fix: guarded-set-working-set-evolved! now merges (union by ID) instead of replacing.

- Added 2 new tests in test-session-mutation.rkt
- Added export of guarded-set-working-set-evolved!
- Fixed test helper (21→24 field agent-session)

Closes #6527