### PR TITLE
v0.78.0 W2: Fix G9 - compute repeat-tool-count from recent-tool-calls

### DIFF
--- a/runtime/context-assembly/state-aware-builder.rkt
+++ b/runtime/context-assembly/state-aware-builder.rkt
@@ -86,7 +86,8 @@
                                           #:working-set-messages [ws-messages '()]
                                           #:task-state [task-state #f]
                                           #:conclusions [conclusions '()]
-                                          #:trace [trace-cb #f])
+                                          #:trace [trace-cb #f]
+                                          #:recent-tool-calls [recent-tool-calls '()])
   ;; Accept both fsm-state structs and bare symbols
   (define state-name
     (cond
@@ -216,11 +217,21 @@
       (if (> (length ws-messages) 0)
           (/ n-conclusions (length ws-messages))
           0.0))
+    ;; v0.78.0 G9: Compute repeat-tool-count from recent tool calls
+    ;; Count the max frequency of any single tool name in recent history
+    (define repeat-count
+      (if (null? recent-tool-calls)
+          0
+          (let ()
+            (define freq (make-hash))
+            (for ([tc (in-list recent-tool-calls)])
+              (hash-set! freq tc (add1 (hash-ref freq tc 0))))
+            (apply max (hash-values freq)))))
     (define-values (warnings recommended-action)
       (check-rollback-triggers-with-actions #:before-messages (length ws-messages)
                                             #:after-messages (length effective-ws)
                                             #:conclusion-coverage coverage
-                                            #:repeat-tool-count 0))
+                                            #:repeat-tool-count repeat-count))
     (when (pair? warnings)
       (log-warning "context-assembly: rollback triggers fired: ~a" warnings))
     (when recommended-action

--- a/tests/test-state-aware-builder.rkt
+++ b/tests/test-state-aware-builder.rkt
@@ -8,6 +8,8 @@
          "../runtime/context-assembly/state-aware-builder.rkt"
          "../runtime/context-assembly/context-floor.rkt"
          "../runtime/context-assembly/task-conclusion.rkt"
+         (only-in "../runtime/context-assembly/rollback-actions.rkt"
+                  current-rollback-action-execution?)
          (only-in "../util/protocol-types.rkt" make-message make-text-part message-role)
          (only-in "../util/fsm.rkt" fsm-state))
 
@@ -122,6 +124,29 @@
 
     (test-case "preamble handles fsm-state struct input"
       (define preamble (build-state-awareness-preamble (fsm-state 'verification) '()))
-      (check-not-false preamble))))
+      (check-not-false preamble))
+
+    ;; v0.78.0 G9: repeat-tool-count computed from recent-tool-calls
+    (test-case "repeat-tool-count computed from recent-tool-calls"
+      (parameterize ([current-task-state-aware-assembly? #t]
+                     [current-rollback-action-execution? #t])
+        (define msgs (make-test-msgs 10))
+        ;; Same tool (read) repeated 4 times -> repeat-count should be 4
+        (define tc
+          (build-tiered-context/state-aware msgs
+                                            #:task-state 'implementation
+                                            #:working-set-messages msgs
+                                            #:recent-tool-calls '(read read read read bash)))
+        ;; Should succeed — the rollback trigger should have fired but not crashed
+        (check-not-false tc)))
+
+    (test-case "repeat-tool-count defaults to 0 with no recent-tool-calls"
+      (parameterize ([current-task-state-aware-assembly? #t])
+        (define msgs (make-test-msgs 10))
+        (define tc
+          (build-tiered-context/state-aware msgs
+                                            #:task-state 'implementation
+                                            #:working-set-messages msgs))
+        (check-not-false tc)))))
 
 (run-tests suite)


### PR DESCRIPTION
G9 fix: repeat-tool-count was hardcoded to 0, making amnesia rollback trigger dead code.

- Added #:recent-tool-calls parameter to build-tiered-context/state-aware
- Computes repeat count from tool call frequency
- Added 2 new tests in test-state-aware-builder.rkt

Closes #6528