### PR TITLE
v0.78.1 W0: G1 - proper profile activation matrix

### DIFF
--- a/runtime/context-assembly/state-aware-builder.rkt
+++ b/runtime/context-assembly/state-aware-builder.rkt
@@ -44,6 +44,7 @@
          ws-entry->conclusion-or-self
          current-graph-conclusion-selection?
          current-conclusion-token-budget
+         current-ws-evolution-enabled?
          check-rollback-triggers-with-actions)
 
 ;; Feature flag: state-aware context assembly (v0.75.3)
@@ -54,6 +55,9 @@
 
 ;; v0.77.4 W4.3: Hard conclusion token budget (0 = unlimited)
 (define current-conclusion-token-budget (make-parameter 2000))
+
+;; v0.78.1 G1: WS evolution flag (moved from session-events.rkt to avoid cycle)
+(define current-ws-evolution-enabled? (make-parameter #f))
 
 ;; State-specific guidance strings (action-oriented instructions)
 (define state-guidance-table

--- a/runtime/session-config.rkt
+++ b/runtime/session-config.rkt
@@ -36,7 +36,11 @@
          (only-in "../runtime/session-index/schema.rkt" session-index?)
          (only-in "context-assembly/state-aware-builder.rkt"
                   current-task-state-aware-assembly?
-                  current-conclusion-token-budget))
+                  current-conclusion-token-budget
+                  current-graph-conclusion-selection?
+                  current-ws-evolution-enabled?)
+         (only-in "context-assembly/auto-distillation.rkt" current-auto-distillation-enabled?)
+         (only-in "context-assembly/rollback-actions.rkt" current-rollback-action-execution?))
 
 ;; Global rollout rate for state-aware assembly (0.0 = none, 1.0 = all)
 (define current-task-state-aware-rollout-rate (make-parameter 0.0))
@@ -56,18 +60,44 @@
   (and (symbol? v) (memq v valid-profiles) #t))
 
 ;; Apply a profile: sets individual feature flags according to the profile.
+;; v0.78.1 G1: Proper activation matrix with all feature flags.
+;; Each profile is a superset of the previous one.
 (define (apply-context-assembly-profile! profile)
   (case profile
-    [(off) (current-task-state-aware-assembly? #f)]
-    [(observe) (current-task-state-aware-assembly? #f)] ; telemetry still works
+    [(off)
+     (current-task-state-aware-assembly? #f)
+     (current-graph-conclusion-selection? #f)
+     (current-auto-distillation-enabled? #f)
+     (current-rollback-action-execution? #f)
+     (current-ws-evolution-enabled? #f)
+     (current-conclusion-token-budget 2000)]
+    [(observe)
+     (current-task-state-aware-assembly? #t)
+     (current-graph-conclusion-selection? #f)
+     (current-auto-distillation-enabled? #f)
+     (current-rollback-action-execution? #f)
+     (current-ws-evolution-enabled? #f)
+     (current-conclusion-token-budget 2000)]
     [(bounded)
      (current-task-state-aware-assembly? #t)
+     (current-graph-conclusion-selection? #t)
+     (current-auto-distillation-enabled? #f)
+     (current-rollback-action-execution? #f)
+     (current-ws-evolution-enabled? #f)
      (current-conclusion-token-budget 2000)]
     [(self-healing)
      (current-task-state-aware-assembly? #t)
+     (current-graph-conclusion-selection? #t)
+     (current-auto-distillation-enabled? #t)
+     (current-rollback-action-execution? #t)
+     (current-ws-evolution-enabled? #f)
      (current-conclusion-token-budget 2000)]
     [(full)
      (current-task-state-aware-assembly? #t)
+     (current-graph-conclusion-selection? #t)
+     (current-auto-distillation-enabled? #t)
+     (current-rollback-action-execution? #t)
+     (current-ws-evolution-enabled? #t)
      (current-conclusion-token-budget 2000)]
     [else (void)]))
 

--- a/runtime/session-events.rkt
+++ b/runtime/session-events.rkt
@@ -20,12 +20,13 @@
                   infer-task-state-from-tools
                   current-state-inference-threshold))
 (require (only-in "../util/fsm.rkt" fsm-state-name))
+(require (only-in "context-assembly/state-aware-builder.rkt"
+                  current-ws-evolution-enabled?))
 ;; v0.77.10 M1: evolve-working-set-for-state import removed — subscriber now emits
 ;; context.ws-evolve-requested event for turn-orchestrator to handle.
 ;; (require (only-in "context-assembly/ws-evolution.rkt" evolve-working-set-for-state))
 
-(provide (contract-out [wire-session-event-handlers! (-> agent-session? procedure? void?)])
-         current-ws-evolution-enabled?)
+(provide (contract-out [wire-session-event-handlers! (-> agent-session? procedure? void?)]))
 
 ;; ============================================================
 ;; Event bus wiring
@@ -34,9 +35,8 @@
 ;; Wire event-bus subscribers for fork.requested, compact.requested,
 ;; tool execution, conclusions, and state transitions.
 
-;; v0.77.1 W1.3: Feature flag for WS evolution subscriber.
-;; Disabled by default — preserves v0.76 behavior until v0.77.7 activation.
-(define current-ws-evolution-enabled? (make-parameter #f))
+;; v0.78.1 G1: current-ws-evolution-enabled? moved to state-aware-builder.rkt
+;; to avoid cycle (session-config → session-events → session-store → ...)
 ;; These events are published by TUI/CLI commands and need runtime handlers.
 (define (wire-session-event-handlers! sess fork-handler)
   (define bus (agent-session-event-bus sess))

--- a/tests/test-context-assembly-integration.rkt
+++ b/tests/test-context-assembly-integration.rkt
@@ -39,7 +39,8 @@
                   current-task-state-aware-assembly?
                   current-conclusion-token-budget
                   current-graph-conclusion-selection?)
-         (only-in "../runtime/session-events.rkt" current-ws-evolution-enabled?)
+         (only-in "../runtime/context-assembly/state-aware-builder.rkt"
+                  current-ws-evolution-enabled?)
          (only-in "../runtime/session-config.rkt"
                   apply-context-assembly-profile!
                   current-context-assembly-profile)

--- a/tests/test-session-config.rkt
+++ b/tests/test-session-config.rkt
@@ -14,7 +14,17 @@
          racket/dict
          racket/hash
          "../runtime/session-config.rkt"
-         (only-in "../runtime/session-index/schema.rkt" make-empty-index session-index?))
+         (only-in "../runtime/session-index/schema.rkt" make-empty-index session-index?)
+         (only-in "../runtime/context-assembly/state-aware-builder.rkt"
+                  current-task-state-aware-assembly?
+                  current-conclusion-token-budget
+                  current-graph-conclusion-selection?)
+         (only-in "../runtime/context-assembly/auto-distillation.rkt"
+                  current-auto-distillation-enabled?)
+         (only-in "../runtime/context-assembly/rollback-actions.rkt"
+                  current-rollback-action-execution?)
+         (only-in "../runtime/context-assembly/state-aware-builder.rkt"
+                  current-ws-evolution-enabled?))
 
 ;; ── Constructor tests ────────────────────────────────────────────
 
@@ -268,3 +278,48 @@
 
 (test-case "default profile is off"
   (check-equal? (current-context-assembly-profile) 'off))
+
+;; v0.78.1 G1: Profile activation matrix tests
+(test-case "profile 'off disables all flags"
+  (apply-context-assembly-profile! 'off)
+  (check-false (current-task-state-aware-assembly?))
+  (check-false (current-graph-conclusion-selection?))
+  (check-false (current-auto-distillation-enabled?))
+  (check-false (current-rollback-action-execution?))
+  (check-false (current-ws-evolution-enabled?)))
+
+(test-case "profile 'observe enables assembly only"
+  (apply-context-assembly-profile! 'observe)
+  (check-true (current-task-state-aware-assembly?))
+  (check-false (current-graph-conclusion-selection?))
+  (check-false (current-auto-distillation-enabled?))
+  (check-false (current-rollback-action-execution?))
+  (check-false (current-ws-evolution-enabled?))
+  (apply-context-assembly-profile! 'off))
+
+(test-case "profile 'bounded enables assembly + graph + budget"
+  (apply-context-assembly-profile! 'bounded)
+  (check-true (current-task-state-aware-assembly?))
+  (check-true (current-graph-conclusion-selection?))
+  (check-false (current-auto-distillation-enabled?))
+  (check-false (current-rollback-action-execution?))
+  (check-false (current-ws-evolution-enabled?))
+  (apply-context-assembly-profile! 'off))
+
+(test-case "profile 'self-healing enables bounded + distill + rollback"
+  (apply-context-assembly-profile! 'self-healing)
+  (check-true (current-task-state-aware-assembly?))
+  (check-true (current-graph-conclusion-selection?))
+  (check-true (current-auto-distillation-enabled?))
+  (check-true (current-rollback-action-execution?))
+  (check-false (current-ws-evolution-enabled?))
+  (apply-context-assembly-profile! 'off))
+
+(test-case "profile 'full enables everything"
+  (apply-context-assembly-profile! 'full)
+  (check-true (current-task-state-aware-assembly?))
+  (check-true (current-graph-conclusion-selection?))
+  (check-true (current-auto-distillation-enabled?))
+  (check-true (current-rollback-action-execution?))
+  (check-true (current-ws-evolution-enabled?))
+  (apply-context-assembly-profile! 'off))

--- a/tests/test-session-task-state.rkt
+++ b/tests/test-session-task-state.rkt
@@ -23,7 +23,8 @@
          (only-in "../agent/event-bus.rkt" make-event-bus publish! subscribe!)
          (only-in "../util/event.rkt" make-event event-ev event-payload)
          (only-in "../runtime/session-events.rkt"
-                  wire-session-event-handlers!
+                  wire-session-event-handlers!)
+         (only-in "../runtime/context-assembly/state-aware-builder.rkt"
                   current-ws-evolution-enabled?))
 
 (define suite


### PR DESCRIPTION
G1: Rewrite apply-context-assembly-profile! with proper activation matrix.

- 5 profiles: off, observe, bounded, self-healing, full
- Each profile is a strict superset of previous
- Moved current-ws-evolution-enabled? to state-aware-builder.rkt (cycle fix)
- 5 new profile tests (46 total)

Closes #6531