### PR TITLE
v0.78.2 W0: G2+G3 — WS evolution wiring + auto-distill persistence

### DIFF
--- a/runtime/session-events.rkt
+++ b/runtime/session-events.rkt
@@ -20,8 +20,7 @@
                   infer-task-state-from-tools
                   current-state-inference-threshold))
 (require (only-in "../util/fsm.rkt" fsm-state-name))
-(require (only-in "context-assembly/state-aware-builder.rkt"
-                  current-ws-evolution-enabled?))
+(require (only-in "context-assembly/state-aware-builder.rkt" current-ws-evolution-enabled?))
 ;; v0.77.10 M1: evolve-working-set-for-state import removed — subscriber now emits
 ;; context.ws-evolve-requested event for turn-orchestrator to handle.
 ;; (require (only-in "context-assembly/ws-evolution.rkt" evolve-working-set-for-state))
@@ -88,34 +87,41 @@
                                                               compact-result))))))))
                 #:filter (lambda (evt) (equal? (event-ev evt) "compact.requested")))
     ;; Subscribe to tool.execution.completed — infer task state
-    (subscribe!
-     bus
-     (lambda (evt)
-       (define payload (event-payload evt))
-       (define tool-name (and (hash? payload) (hash-ref payload 'tool-name #f)))
-       (when tool-name
-         ;; v0.75.6: Accumulate tool calls for better inference
-         (define current-recent (agent-session-recent-tool-calls sess))
-         (define updated-recent (append current-recent (list tool-name)))
-         ;; Keep last 10 tool calls
-         (guarded-set-recent-tool-calls! sess
-                                         (if (> (length updated-recent) 10)
-                                             (list-tail updated-recent (- (length updated-recent) 10))
-                                             updated-recent))
-         (define-values (inferred-state confidence)
-           (infer-task-state-from-tools (agent-session-recent-tool-calls sess)))
-         (when (and inferred-state (>= confidence (current-state-inference-threshold)))
-           (guarded-set-task-fsm-state! sess (fsm-state-name inferred-state))
-           ;; v0.75.6: Persist task state change
-           (define log-path (session-log-path (agent-session-session-dir sess)))
-           (when (file-exists? log-path)
-             (append-task-state! log-path (fsm-state-name inferred-state)))
-           (emit-session-event!
-            bus
-            (agent-session-session-id sess)
-            "task.state.inferred"
-            (hasheq 'state (fsm-state-name inferred-state) 'confidence confidence 'tool tool-name)))))
-     #:filter (lambda (evt) (equal? (event-ev evt) "tool.execution.completed")))
+    (subscribe! bus
+                (lambda (evt)
+                  (define payload (event-payload evt))
+                  (define tool-name (and (hash? payload) (hash-ref payload 'tool-name #f)))
+                  (when tool-name
+                    ;; v0.75.6: Accumulate tool calls for better inference
+                    (define current-recent (agent-session-recent-tool-calls sess))
+                    (define updated-recent (append current-recent (list tool-name)))
+                    ;; Keep last 10 tool calls
+                    (guarded-set-recent-tool-calls! sess
+                                                    (if (> (length updated-recent) 10)
+                                                        (list-tail updated-recent
+                                                                   (- (length updated-recent) 10))
+                                                        updated-recent))
+                    (define-values (inferred-state confidence)
+                      (infer-task-state-from-tools (agent-session-recent-tool-calls sess)))
+                    (when (and inferred-state (>= confidence (current-state-inference-threshold)))
+                      (define old-state (agent-session-task-fsm-state sess))
+                      (guarded-set-task-fsm-state! sess (fsm-state-name inferred-state))
+                      ;; v0.75.6: Persist task state change
+                      (define log-path (session-log-path (agent-session-session-dir sess)))
+                      (when (file-exists? log-path)
+                        (append-task-state! log-path (fsm-state-name inferred-state)))
+                      (emit-session-event! bus
+                                           (agent-session-session-id sess)
+                                           "task.state.inferred"
+                                           (hasheq 'state
+                                                   (fsm-state-name inferred-state)
+                                                   'old-state
+                                                   old-state
+                                                   'confidence
+                                                   confidence
+                                                   'tool
+                                                   tool-name)))))
+                #:filter (lambda (evt) (equal? (event-ev evt) "tool.execution.completed")))
     ;; Subscribe to tool.record_conclusion.completed — persist conclusion
     (subscribe! bus
                 (lambda (evt)
@@ -182,25 +188,27 @@
                 #:filter (lambda (evt) (equal? (event-ev evt) "tool.record_conclusion.completed")))
 
     ;; v0.76.7 C3: Subscribe to tool.set-task-state.completed — explicit state transition
-    (subscribe! bus
-                (lambda (evt)
-                  (define payload (event-payload evt))
-                  (define target (and (hash? payload) (hash-ref payload 'target-state #f)))
-                  (when (and target (or (string? target) (symbol? target)))
-                    (define target-sym
-                      (if (string? target)
-                          (string->symbol target)
-                          target))
-                    (guarded-set-task-fsm-state! sess target-sym)
-                    ;; Persist task state change
-                    (define log-path (session-log-path-for sess))
-                    (when (file-exists? log-path)
-                      (append-task-state! log-path target-sym))
-                    (emit-session-event! bus
-                                         (agent-session-session-id sess)
-                                         "task.state.transitioned"
-                                         (hasheq 'state target-sym 'source "explicit"))))
-                #:filter (lambda (evt) (equal? (event-ev evt) "tool.set-task-state.completed")))
+    (subscribe!
+     bus
+     (lambda (evt)
+       (define payload (event-payload evt))
+       (define target (and (hash? payload) (hash-ref payload 'target-state #f)))
+       (when (and target (or (string? target) (symbol? target)))
+         (define target-sym
+           (if (string? target)
+               (string->symbol target)
+               target))
+         (define old-state (agent-session-task-fsm-state sess))
+         (guarded-set-task-fsm-state! sess target-sym)
+         ;; Persist task state change
+         (define log-path (session-log-path-for sess))
+         (when (file-exists? log-path)
+           (append-task-state! log-path target-sym))
+         (emit-session-event! bus
+                              (agent-session-session-id sess)
+                              "task.state.transitioned"
+                              (hasheq 'state target-sym 'old-state old-state 'source "explicit"))))
+     #:filter (lambda (evt) (equal? (event-ev evt) "tool.set-task-state.completed")))
 
     ;; v0.77.1 W1.3: WS evolution flag exported for turn-orchestrator wiring
     ;; (subscriber deferred — working-set lives in turn scope, not session)
@@ -208,23 +216,22 @@
     ;; v0.77.10 M1: WS evolution subscriber on state transitions.
     ;; Emits context.ws-evolve-requested event for turn-orchestrator to handle.
     ;; Turn-orchestrator has access to the working-set in turn scope.
-    (subscribe!
-     bus
-     (lambda (evt)
-       (when (current-ws-evolution-enabled?)
-         (define payload (event-payload evt))
-         (define new-state (and (hash? payload) (hash-ref payload 'state #f)))
-         (when new-state
-           (define current-state (agent-session-task-fsm-state sess))
-           (when (and current-state (not (eq? current-state new-state)))
-             (log-info "session-events: WS evolution requested: ~a → ~a" current-state new-state)
-             (emit-session-event! bus
-                                  (agent-session-session-id sess)
-                                  "context.ws-evolve-requested"
-                                  (hasheq 'old-state current-state 'new-state new-state))))))
-     #:filter (lambda (evt)
-                (or (equal? (event-ev evt) "task.state.transitioned")
-                    (equal? (event-ev evt) "task.state.inferred"))))
+    (subscribe! bus
+                (lambda (evt)
+                  (when (current-ws-evolution-enabled?)
+                    (define payload (event-payload evt))
+                    (define new-state (and (hash? payload) (hash-ref payload 'state #f)))
+                    (define old-state (and (hash? payload) (hash-ref payload 'old-state #f)))
+                    ;; v0.78.2 G2: Read old-state from event payload (not session) to avoid race
+                    (when (and old-state new-state (not (eq? old-state new-state)))
+                      (log-info "session-events: WS evolution requested: ~a → ~a" old-state new-state)
+                      (emit-session-event! bus
+                                           (agent-session-session-id sess)
+                                           "context.ws-evolve-requested"
+                                           (hasheq 'old-state old-state 'new-state new-state)))))
+                #:filter (lambda (evt)
+                           (or (equal? (event-ev evt) "task.state.transitioned")
+                               (equal? (event-ev evt) "task.state.inferred"))))
 
     (void))
 

--- a/runtime/turn-orchestrator.rkt
+++ b/runtime/turn-orchestrator.rkt
@@ -109,6 +109,12 @@
                   agent-session?
                   agent-session-task-fsm-state
                   agent-session-task-conclusions)
+         (only-in "../runtime/session-mutation.rkt"
+                  guarded-set-working-set-evolved!
+                  guarded-set-task-conclusions!)
+         (only-in "../runtime/context-assembly/ws-evolution.rkt" evolve-working-set-for-state)
+         (only-in "../runtime/context-assembly/task-state.rkt" task-idle)
+         (only-in "../runtime/context-assembly/state-aware-builder.rkt" current-ws-evolution-enabled?)
          (only-in "../runtime/session-config.rkt"
                   session-config?
                   hash->session-config
@@ -230,6 +236,20 @@
         (let ([ws-msgs (working-set-resolve-messages ws-early ctx-to-use message-id)])
           (append conclusions (auto-distill (map message-id ws-msgs) conclusions task-state)))
         (or conclusions '())))
+  ;; v0.78.2 G3: Persist auto-distilled conclusions back to session
+  ;; Only when auto-distill added new conclusions
+  (when (and (current-auto-distillation-enabled?)
+             session
+             (pair? augmented-conclusions)
+             conclusions
+             (> (length augmented-conclusions) (length conclusions)))
+    (guarded-set-task-conclusions! session augmented-conclusions))
+  ;; v0.78.2 G2: WS evolution — evolve working set on state transition
+  ;; Only when WS evolution enabled and session has a working set
+  (when (and (current-ws-evolution-enabled?) ws-early session task-state (not (eq? task-state 'idle)))
+    (define result (evolve-working-set-for-state ws-early task-idle task-state augmented-conclusions))
+    (when (and result session)
+      (guarded-set-working-set-evolved! session result)))
   ;; FD-05: Delegate pure assembly to assemble-context/pure
   ;; v0.76.3: Pass per-session rollout flag
   ;; v0.77.9 T2.4: Apply context-assembly profile before assembly

--- a/tests/test-session-task-state.rkt
+++ b/tests/test-session-task-state.rkt
@@ -102,7 +102,7 @@
                               (current-seconds)
                               (agent-session-session-id sess)
                               #f
-                              (hasheq 'state 'planning))))
+                              (hasheq 'state 'planning 'old-state 'exploration))))
       ;; Verify event was emitted
       (check-true (>= (length received-events) 1))
       (define evt (car received-events))


### PR DESCRIPTION
G2: Fixed WS evolution subscriber race (reads old-state from payload). Wired WS evolution into turn-orchestrator context assembly.

G3: Auto-distilled conclusions now persist back to session.

- Added old-state to task.state.inferred and task.state.transitioned events
- Fixed subscriber to read old-state from payload (not session)
- Added WS evolution call in build-assembled-context
- Added auto-distill conclusion persistence

Closes #6532