### PR TITLE
v0.78.3 W0: G6+G7+G8 — inference confidence, preamble, summary

### DIFF
--- a/runtime/context-assembly/state-aware-builder.rkt
+++ b/runtime/context-assembly/state-aware-builder.rkt
@@ -183,10 +183,11 @@
                            (list (make-text-part (format "[Conclusion] ~a" (task-conclusion-text c))))
                            (current-seconds)
                            (hasheq)))
-           ;; Summarize: take first + last
-           (let ([first-c (car budgeted-conclusions)]
-                 [last-c (car (reverse budgeted-conclusions))])
-             (for/list ([c (list first-c last-c)]
+           ;; v0.78.3 G8: Use rank-and-budget for summary (not first+last)
+           (let ([ranked (rank-and-budget budgeted-conclusions
+                                          #:current-state state-name
+                                          #:max-conclusion-tokens 500)])
+             (for/list ([c (in-list ranked)]
                         #:when (task-conclusion? c))
                (make-message (generate-id)
                              #f
@@ -207,7 +208,8 @@
                           #:trace trace-cb))
 
   ;; v0.75.6: Prepend state-awareness preamble to tier-a
-  (define preamble (build-state-awareness-preamble task-state conclusions))
+  ;; v0.78.3 G7: Use budgeted conclusions (not raw) for preamble
+  (define preamble (build-state-awareness-preamble task-state budgeted-conclusions))
   (define preamble-entries
     (if preamble
         (list preamble)

--- a/runtime/context-assembly/state-inference.rkt
+++ b/runtime/context-assembly/state-inference.rkt
@@ -104,7 +104,7 @@
        [(and (>= n-read 3) (= n-write 0)) (values task-exploration 0.85)]
 
        ;; planning: meta tools (save-conclusion) + reads (gathering info)
-       [(and (>= (count-category recent-calls 'meta) 1) (= n-write 0)) (values task-planning 0.6)]
+       [(and (>= (count-category recent-calls 'meta) 1) (= n-write 0)) (values task-planning 0.75)]
 
        ;; Light exploration: some reads, no writes
        [(and (>= n-read 1) (= n-write 0)) (values task-exploration 0.5)]


### PR DESCRIPTION
G6: Planning inference confidence 0.6→0.75 (above 0.7 threshold).
G7: Preamble now uses budgeted conclusions instead of raw.
G8: Summary mode uses rank-and-budget instead of first+last.

Closes #6533