### PR TITLE
v0.78.4 W0: G4+G10 — rollout gate + FSM workflow instructions

### DIFF
--- a/runtime/agent-session.rkt
+++ b/runtime/agent-session.rkt
@@ -70,6 +70,7 @@
                   session-config?
                   hash->session-config
                   current-task-state-aware-rollout-rate
+                  current-context-assembly-profile
                   config-provider
                   config-tool-registry
                   config-event-bus
@@ -224,7 +225,11 @@
 ;; Deterministic A/B assignment using session-id hash modulo 100.
 (define (session-rollout-enabled? sid)
   (define rate (current-task-state-aware-rollout-rate))
-  (and (> rate 0.0) (< (modulo (equal-hash-code sid) 100) (inexact->exact (round (* rate 100))))))
+  (define profile (current-context-assembly-profile))
+  ;; v0.78.4 G4: If an explicit profile is set (not 'off), always allow
+  (or (not (eq? profile 'off))
+      (and (> rate 0.0)
+           (< (modulo (equal-hash-code sid) 100) (inexact->exact (round (* rate 100)))))))
 
 ;; ============================================================
 ;; make-agent-session

--- a/runtime/context-assembly/state-aware-builder.rkt
+++ b/runtime/context-assembly/state-aware-builder.rkt
@@ -296,7 +296,11 @@
                      (string-join texts "\n")))
            "\n\nNo conclusions in memory yet. Use record_conclusion to save findings."))
      (define preamble-text
-       (format "You are currently in the ~a phase.~a~a" label guidance conclusion-section))
+       (format
+        "You are currently in the ~a phase.~a~a\n\nWorkflow: Use record_conclusion to persist findings. Use set_task_state to transition: exploration→planning→implementation→verification→debugging."
+        label
+        guidance
+        conclusion-section))
      (make-message "state-awareness-preamble"
                    #f
                    'system-instruction


### PR DESCRIPTION
G4: session-rollout-enabled? now bypasses rate check when profile ≠ 'off.
G10: Added FSM workflow instructions to preamble (record_conclusion, set_task_state).

Closes #6534