### PR TITLE
fix(v0.78.6): W0 runtime bug fixes — C1, C2, W1, W2

### DIFF
--- a/runtime/session-events.rkt
+++ b/runtime/session-events.rkt
@@ -212,26 +212,11 @@
 
     ;; v0.77.1 W1.3: WS evolution flag exported for turn-orchestrator wiring
     ;; (subscriber deferred — working-set lives in turn scope, not session)
-
-    ;; v0.77.10 M1: WS evolution subscriber on state transitions.
-    ;; Emits context.ws-evolve-requested event for turn-orchestrator to handle.
-    ;; Turn-orchestrator has access to the working-set in turn scope.
-    (subscribe! bus
-                (lambda (evt)
-                  (when (current-ws-evolution-enabled?)
-                    (define payload (event-payload evt))
-                    (define new-state (and (hash? payload) (hash-ref payload 'state #f)))
-                    (define old-state (and (hash? payload) (hash-ref payload 'old-state #f)))
-                    ;; v0.78.2 G2: Read old-state from event payload (not session) to avoid race
-                    (when (and old-state new-state (not (eq? old-state new-state)))
-                      (log-info "session-events: WS evolution requested: ~a → ~a" old-state new-state)
-                      (emit-session-event! bus
-                                           (agent-session-session-id sess)
-                                           "context.ws-evolve-requested"
-                                           (hasheq 'old-state old-state 'new-state new-state)))))
-                #:filter (lambda (evt)
-                           (or (equal? (event-ev evt) "task.state.transitioned")
-                               (equal? (event-ev evt) "task.state.inferred"))))
+    ;;
+    ;; v0.78.6 W2: Removed orphaned context.ws-evolve-requested subscriber.
+    ;; WS evolution is handled inline in turn-orchestrator.rkt's build-assembled-context.
+    ;; The event-driven approach was abandoned because the subscriber in session-events
+    ;; doesn't have access to the working-set (which lives in session config scope).
 
     (void))
 

--- a/runtime/turn-orchestrator.rkt
+++ b/runtime/turn-orchestrator.rkt
@@ -108,12 +108,14 @@
          (only-in "../runtime/session-types.rkt"
                   agent-session?
                   agent-session-task-fsm-state
-                  agent-session-task-conclusions)
+                  agent-session-task-conclusions
+                  agent-session-recent-tool-calls)
          (only-in "../runtime/session-mutation.rkt"
                   guarded-set-working-set-evolved!
                   guarded-set-task-conclusions!)
-         (only-in "../runtime/context-assembly/ws-evolution.rkt" evolve-working-set-for-state)
-         (only-in "../runtime/context-assembly/task-state.rkt" task-idle)
+         (only-in "../runtime/context-assembly/ws-evolution.rkt"
+                  evolve-working-set-for-state/result
+                  evolution-result?)
          (only-in "../runtime/context-assembly/state-aware-builder.rkt" current-ws-evolution-enabled?)
          (only-in "../runtime/session-config.rkt"
                   session-config?
@@ -158,7 +160,9 @@
            (-> tool-registry? (or/c extension-registry? #f) event-bus? string? (listof hash?))]
           [assemble-context/pure
            (->* (list? session-config?)
-                (#:hook-dispatcher (or/c procedure? #f) #:state-aware? (or/c boolean? #f))
+                (#:hook-dispatcher (or/c procedure? #f)
+                                   #:state-aware? (or/c boolean? #f)
+                                   #:recent-tool-calls list?)
                 (values list? (or/c hook-result? #f) tiered-context?))]))
 
 ;; ============================================================
@@ -172,7 +176,8 @@
                                #:hook-dispatcher [hook-dispatcher #f]
                                #:task-state [task-state #f]
                                #:conclusions [conclusions '()]
-                               #:state-aware? [state-aware? #f])
+                               #:state-aware? [state-aware? #f]
+                               #:recent-tool-calls [recent-tool-calls '()])
   (define config config-raw)
   (define tier-b-count (config-tier-b-count config))
   (define tier-c-count (config-tier-c-count config))
@@ -194,7 +199,8 @@
                                            #:tier-c-count tier-c-count
                                            #:working-set-messages ws-messages
                                            #:task-state task-state
-                                           #:conclusions conclusions))
+                                           #:conclusions conclusions
+                                           #:recent-tool-calls recent-tool-calls))
        (values sa-tc #f)]
       ;; Standard assembly path
       [else
@@ -247,8 +253,10 @@
   ;; v0.78.2 G2: WS evolution — evolve working set on state transition
   ;; Only when WS evolution enabled and session has a working set
   (when (and (current-ws-evolution-enabled?) ws-early session task-state (not (eq? task-state 'idle)))
-    (define result (evolve-working-set-for-state ws-early task-idle task-state augmented-conclusions))
-    (when (and result session)
+    ;; v0.78.6 C1+W1: Use /result variant (returns evolution-result? struct)
+    ;; Pass #f for old-state since we don't know the previous state inline.
+    (define result (evolve-working-set-for-state/result ws-early #f task-state augmented-conclusions))
+    (when (and (evolution-result? result) session)
       (guarded-set-working-set-evolved! session result)))
   ;; FD-05: Delegate pure assembly to assemble-context/pure
   ;; v0.76.3: Pass per-session rollout flag
@@ -262,7 +270,10 @@
                            #:hook-dispatcher ctx-assembly-hook-dispatcher
                            #:task-state task-state
                            #:conclusions augmented-conclusions
-                           #:state-aware? (config-task-state-aware? config)))
+                           #:state-aware? (config-task-state-aware? config)
+                           #:recent-tool-calls (if session
+                                                   (agent-session-recent-tool-calls session)
+                                                   '())))
 
   ;; Handle block action from context-assembly hook
   (when (and assembly-hook-result (eq? (hook-result-action assembly-hook-result) 'block))


### PR DESCRIPTION
Fixes #6557

## Changes
- **C1**: Replace `evolve-working-set-for-state` with `/result` variant — returns `evolution-result?` struct that `guarded-set-working-set-evolved!` expects
- **C2**: Add `#:recent-tool-calls` keyword to `assemble-context/pure`, thread `agent-session-recent-tool-calls` from session through to `build-tiered-context/state-aware`
- **W1**: Pass `#f` for old-state instead of hardcoded `task-idle` — honest about not knowing previous state inline
- **W2**: Remove orphaned `context.ws-evolve-requested` subscriber from `session-events.rkt` — event was emitted but never consumed
- **Cleanup**: Remove dead `task-idle` import

All changes are behind feature flags (default OFF).