### PR TITLE
fix(v0.78.6): W1 test quality fixes — C3, C4, C5, W3

### DIFF
--- a/tests/test-context-assembly-integration.rkt
+++ b/tests/test-context-assembly-integration.rkt
@@ -5,6 +5,7 @@
 
 (require rackunit
          rackunit/text-ui
+         racket/string
          (only-in "../runtime/context-assembly/task-state.rkt"
                   task-exploration
                   task-planning
@@ -17,7 +18,10 @@
                   task-conclusion-id)
          (only-in "../runtime/context-assembly/serialization.rkt"
                   build-tiered-context/state-aware
-                  current-task-state-aware-assembly?)
+                  current-task-state-aware-assembly?
+                  tiered-context-tier-a
+                  tiered-context-tier-b
+                  tiered-context-tier-c)
          (only-in "../runtime/context-assembly/conclusion-graph.rkt"
                   build-conclusion-graph
                   graph-select-conclusions)
@@ -45,7 +49,11 @@
                   current-context-assembly-profile)
          (only-in "../runtime/working-set.rkt" make-working-set working-set-add! working-set-entries)
          (only-in "../runtime/agent-session.rkt" session-rollout-enabled?)
-         (only-in "../util/protocol-types.rkt" make-message make-text-part)
+         (only-in "../util/protocol-types.rkt"
+                  make-message
+                  make-text-part
+                  message-role
+                  message-content)
          (only-in "../util/message.rkt" message-id))
 
 ;; Helper: create a simple test message
@@ -156,7 +164,14 @@
                                             #:working-set-messages
                                             (list (car msgs) (cadr msgs) (caddr msgs))
                                             #:conclusions conclusions))
-        (check-not-false tc)))
+        (check-not-false tc)
+        ;; v0.78.6 W3: Verify preamble was injected (state-aware adds system-instruction)
+        (define tier-a (tiered-context-tier-a tc))
+        (check-true (> (length tier-a) 0) "tier-a should not be empty")
+        ;; Preamble should have system-instruction role
+        (check-true (for/or ([m (in-list tier-a)])
+                      (eq? (message-role m) 'system-instruction))
+                    "tier-a should contain system-instruction preamble")))
 
     ;; v0.78.0 AW1: Graph-through-builder with current-graph-conclusion-selection? #t
     (test-case "graph selection integrates with builder when flag ON"
@@ -175,7 +190,14 @@
                                             #:task-state 'implementation
                                             #:working-set-messages msgs
                                             #:conclusions conclusions))
-        (check-not-false tc)))
+        (check-not-false tc)
+        ;; v0.78.6 W3: Verify graph selection ran — context should have tier-a entries
+        ;; The key validation is that the pipeline didn't crash with graph selection ON.
+        ;; Graph selection filters conclusions by reachability from seeds, so gc3
+        ;; (unrelated exploration) is a candidate for filtering.
+        (define tier-a (tiered-context-tier-a tc))
+        (check-true (> (length tier-a) 0) "tier-a should have entries after graph selection")
+        (check-true (<= (length tier-a) 20) "graph selection should produce reasonable tier-a size")))
 
     ;; v0.78.1 G1: Profile activation matrix — each profile is strict superset
     (test-case "profile activation: full > self-healing > bounded > observe > off"
@@ -233,7 +255,14 @@
                                             #:task-state 'implementation
                                             #:working-set-messages msgs
                                             #:conclusions many-conclusions))
-        (check-not-false tc)))
+        (check-not-false tc)
+        ;; v0.78.6 W3: Verify budget was enforced — not all 20 conclusions should appear
+        (define tier-a (tiered-context-tier-a tc))
+        (define conclusion-count
+          (for/sum ([m (in-list tier-a)] #:when (message-content m))
+                   (for/sum ([p (in-list (message-content m))])
+                            (if (regexp-match? #rx"conclusion" (format "~a" p)) 1 0))))
+        (check-true (< conclusion-count 20) "budget should reduce conclusion count below raw 20")))
 
     ;; v0.78.4 G10: FSM workflow instructions in preamble
     (test-case "preamble includes FSM workflow guidance"
@@ -250,11 +279,18 @@
                                             #:working-set-messages msgs
                                             #:conclusions conclusions))
         (check-not-false tc)
-        ;; Preamble should contain tier-a entries with FSM guidance
-        (define tc-messages
-          (let-values ([(msgs _ tc-struct) (values '() #f tc)])
-            tc-struct))
-        (check-not-false tc))
+        ;; v0.78.6 C5: Verify preamble text contains FSM guidance keywords
+        (define tier-a (tiered-context-tier-a tc))
+        (define preamble-text
+          (string-join (for*/list ([m (in-list tier-a)]
+                                   #:when (message-content m)
+                                   [p (in-list (message-content m))])
+                         (format "~a" p))))
+        (check-true (> (string-length preamble-text) 0) "preamble should not be empty")
+        (check-not-false (regexp-match? #rx"record_conclusion" preamble-text)
+                         "preamble should mention record_conclusion tool")
+        (check-not-false (regexp-match? #rx"set_task_state" preamble-text)
+                         "preamble should mention set_task_state tool"))
       (apply-context-assembly-profile! 'off))
 
     ;; v0.78.4 G4: Rollout gate — profile bypass enables assembly

--- a/tests/test-session-mutation.rkt
+++ b/tests/test-session-mutation.rkt
@@ -88,16 +88,17 @@
 (test-case "guarded-set-working-set-evolved! merges conclusions, does not replace"
   ;; Create session with existing conclusions from multiple phases
   (define sess (make-test-session))
-  (guarded-set-task-conclusions! sess
-    (list (task-conclusion "existing-1" "old fact" 'fact 'exploration '() 1000 '() '())
-          (task-conclusion "existing-2" "old decision" 'decision 'implementation '() 2000 '() '())))
+  (guarded-set-task-conclusions!
+   sess
+   (list (task-conclusion "existing-1" "old fact" 'fact 'exploration '() 1000 '() '())
+         (task-conclusion "existing-2" "old decision" 'decision 'implementation '() 2000 '() '())))
   (check-equal? (length (agent-session-task-conclusions sess)) 2)
   ;; Simulate evolution result with new conclusions (the "evicted" set)
   (define evo-res
     (evolution-result
-      '() ; kept-entries
-      '() ; archived-entries
-      (list (task-conclusion "new-1" "injected fact" 'fact 'implementation '() 3000 '() '()))))
+     '() ; kept-entries
+     '() ; archived-entries
+     (list (task-conclusion "new-1" "injected fact" 'fact 'implementation '() 3000 '() '()))))
   ;; Call the function
   (guarded-set-working-set-evolved! sess evo-res)
   ;; Verify: ALL original conclusions survive + new ones added
@@ -110,10 +111,42 @@
 
 (test-case "guarded-set-working-set-evolved! with empty evolution result preserves conclusions"
   (define sess (make-test-session))
-  (guarded-set-task-conclusions! sess
-    (list (task-conclusion "keep-me" "important" 'fact 'exploration '() 1000 '() '())))
+  (guarded-set-task-conclusions!
+   sess
+   (list (task-conclusion "keep-me" "important" 'fact 'exploration '() 1000 '() '())))
   (define evo-res (evolution-result '() '() '()))
   (guarded-set-working-set-evolved! sess evo-res)
   ;; Original conclusion should survive since nothing to merge
   (check-equal? (length (agent-session-task-conclusions sess)) 1)
   (check-equal? (task-conclusion-id (car (agent-session-task-conclusions sess))) "keep-me"))
+
+;; v0.78.6 C3: G3 auto-distill persistence test
+;; Verifies that guarded-set-task-conclusions! persists conclusions correctly,
+;; simulating the auto-distill path where new conclusions are appended.
+(test-case "auto-distill persistence: new conclusions survive through guarded-set"
+  (define sess (make-test-session))
+  ;; Start with existing conclusions from exploration phase
+  (guarded-set-task-conclusions!
+   sess
+   (list (task-conclusion "exp-1" "found auth module" 'fact 'exploration '() 1000 '() '())
+         (task-conclusion "exp-2" "config in env vars" 'fact 'exploration '() 2000 '() '())))
+  (check-equal? (length (agent-session-task-conclusions sess)) 2)
+  ;; Simulate auto-distill appending a new distilled conclusion
+  (define existing (agent-session-task-conclusions sess))
+  (define distilled
+    (task-conclusion "dist-1"
+                     "auth uses OAuth2 + refresh tokens"
+                     'decision
+                     'implementation
+                     '()
+                     3000
+                     '()
+                     '()))
+  (guarded-set-task-conclusions! sess (append existing (list distilled)))
+  ;; Verify all 3 conclusions survive
+  (define final (agent-session-task-conclusions sess))
+  (check-equal? (length final) 3)
+  (define final-ids (map task-conclusion-id final))
+  (check-not-false (member "exp-1" final-ids) "existing exp-1 should survive")
+  (check-not-false (member "exp-2" final-ids) "existing exp-2 should survive")
+  (check-not-false (member "dist-1" final-ids) "new distilled conclusion should survive"))

--- a/tests/test-state-aware-builder.rkt
+++ b/tests/test-state-aware-builder.rkt
@@ -10,6 +10,7 @@
          "../runtime/context-assembly/task-conclusion.rkt"
          (only-in "../runtime/context-assembly/rollback-actions.rkt"
                   current-rollback-action-execution?)
+         (only-in "../runtime/context-assembly/state-aware-builder.rkt" check-rollback-triggers)
          (only-in "../util/protocol-types.rkt" make-message make-text-part message-role)
          (only-in "../util/fsm.rkt" fsm-state))
 
@@ -137,8 +138,18 @@
                                             #:task-state 'implementation
                                             #:working-set-messages msgs
                                             #:recent-tool-calls '(read read read read bash)))
-        ;; Should succeed — the rollback trigger should have fired but not crashed
-        (check-not-false tc)))
+        ;; v0.78.6 C4: Verify amnesia warning actually fires for repeat count > 2
+        (check-not-false tc "tiered context should be produced")
+        ;; Directly verify trigger fires: 4 repeats > 2 threshold
+        (define warnings
+          (check-rollback-triggers #:before-messages 10
+                                   #:after-messages 10
+                                   #:conclusion-coverage 0.5
+                                   #:repeat-tool-count 4))
+        (check-true (pair? warnings) "repeat count 4 should produce warnings")
+        (define amnesia-warn (assoc 'task-amnesia-detected warnings))
+        (check-not-false amnesia-warn
+                         "task-amnesia-detected warning should fire for 4 repeat tool calls")))
 
     (test-case "repeat-tool-count defaults to 0 with no recent-tool-calls"
       (parameterize ([current-task-state-aware-assembly? #t])


### PR DESCRIPTION
Fixes #6558

## Changes
- **C3**: Add G3 auto-distill persistence test in test-session-mutation.rkt
- **C4**: Fix G9 amnesia trigger assertion — verify `task-amnesia-detected` warning fires for repeat tool count > 2
- **C5**: Fix G10 FSM preamble test — replace broken `let-values` with proper preamble text extraction checking for `record_conclusion` and `set_task_state`
- **W3**: Strengthen weak integration test assertions with meaningful checks on preamble content and budget enforcement