### PR TITLE
v0.79.0 W0: Settings + Config Wiring (GAP-1)

### DIFF
--- a/runtime/session-config.rkt
+++ b/runtime/session-config.rkt
@@ -276,7 +276,8 @@
                max-tokens
                token-budget-threshold
                session-index
-               task-state-aware?))
+               task-state-aware?
+               context-assembly-profile))
   (define base
     (if (hash? h)
         (make-immutable-hash (hash->list h))

--- a/runtime/settings.rkt
+++ b/runtime/settings.rkt
@@ -43,39 +43,40 @@
                              q-settings?)])
 
          ;; Loading — all contracted
-         (contract-out [load-global-settings (->* () (path-string?) hash?)]
-                       [load-project-settings (->* () (path-string?) hash?)]
-                       [make-minimal-settings
-                        (->* ()
-                             (#:provider (or/c string? #f) #:model (or/c string? #f) #:overrides (or/c hash? #f))
-                             q-settings?)]
-                       [merge-settings (-> hash? hash? hash?)]
-                       [deep-merge-hash (-> hash? hash? hash?)]
-                       [setting-ref (->* (q-settings? (or/c symbol? string?)) (any/c) any/c)]
-                       [setting-ref* (->* (q-settings? (listof any/c)) (any/c) any/c)]
-                       [provider-config (-> q-settings? (or/c symbol? string?) (or/c hash? #f))]
-                       [provider-names (-> q-settings? (listof symbol?))]
-                       [config-parse-error (-> path-string? (or/c string? #f))]
-                       [parallel-tools-enabled? (-> q-settings? boolean?)]
-                       [http-request-timeout (-> q-settings? number?)]
-                       [get-model-timeout (-> q-settings? string? symbol? (or/c number? #f))]
-                       [effective-request-timeout (-> q-settings? string? number?)]
-                       [warn-on-destructive? (-> q-settings? boolean?)]
-                       [security-config-from-settings (-> q-settings? hash?)]
-                       [default-session-dir (-> path-string?)]
-                       [default-project-dir (-> path?)]
-                       [session-dir-from-settings (-> q-settings? (or/c path-string? #f))]
-                       [project-dir-from-settings (-> q-settings? (or/c path-string? #f))]
-                       [trace-enabled? (-> q-settings? boolean?)]
-                       [trace-max-files (-> q-settings? exact-positive-integer?)]
-                       [steering-gentle-threshold (-> q-settings? number?)]
-                       [steering-strong-threshold (-> q-settings? number?)]
-                       [steering-hard-cap (-> q-settings? number?)]
-                       [steering-same-file-dedup? (-> q-settings? boolean?)]
-                       [credential-policy
-                        (-> q-settings?
-                            (or/c 'auto 'keychain-preferred 'keychain-required 'env-only))]
-                       [shell-risk-classifier (-> q-settings? (or/c 'regex 'structured 'both))])
+         (contract-out
+          [load-global-settings (->* () (path-string?) hash?)]
+          [load-project-settings (->* () (path-string?) hash?)]
+          [make-minimal-settings
+           (->* ()
+                (#:provider (or/c string? #f) #:model (or/c string? #f) #:overrides (or/c hash? #f))
+                q-settings?)]
+          [merge-settings (-> hash? hash? hash?)]
+          [deep-merge-hash (-> hash? hash? hash?)]
+          [setting-ref (->* (q-settings? (or/c symbol? string?)) (any/c) any/c)]
+          [setting-ref* (->* (q-settings? (listof any/c)) (any/c) any/c)]
+          [provider-config (-> q-settings? (or/c symbol? string?) (or/c hash? #f))]
+          [provider-names (-> q-settings? (listof symbol?))]
+          [config-parse-error (-> path-string? (or/c string? #f))]
+          [parallel-tools-enabled? (-> q-settings? boolean?)]
+          [http-request-timeout (-> q-settings? number?)]
+          [get-model-timeout (-> q-settings? string? symbol? (or/c number? #f))]
+          [effective-request-timeout (-> q-settings? string? number?)]
+          [warn-on-destructive? (-> q-settings? boolean?)]
+          [security-config-from-settings (-> q-settings? hash?)]
+          [default-session-dir (-> path-string?)]
+          [default-project-dir (-> path?)]
+          [session-dir-from-settings (-> q-settings? (or/c path-string? #f))]
+          [project-dir-from-settings (-> q-settings? (or/c path-string? #f))]
+          [trace-enabled? (-> q-settings? boolean?)]
+          [trace-max-files (-> q-settings? exact-positive-integer?)]
+          [steering-gentle-threshold (-> q-settings? number?)]
+          [steering-strong-threshold (-> q-settings? number?)]
+          [steering-hard-cap (-> q-settings? number?)]
+          [steering-same-file-dedup? (-> q-settings? boolean?)]
+          [credential-policy
+           (-> q-settings? (or/c 'auto 'keychain-preferred 'keychain-required 'env-only))]
+          [shell-risk-classifier (-> q-settings? (or/c 'regex 'structured 'both))]
+          [setting-context-assembly-profile (-> q-settings? symbol?)])
 
          ;; Sandbox settings (re-exported, not locally defined)
          sandbox-enabled?
@@ -401,6 +402,22 @@
 ;; Whether same-file dedup is enabled. Default: #t.
 (define (steering-same-file-dedup? settings)
   (setting-ref* settings '(steering same_file_dedup) #t))
+
+;; ============================================================
+;; Context assembly profile (v0.79.0)
+;; ============================================================
+
+;; Context assembly profile from settings.
+;; Reads (context-assembly profile) from merged settings.
+;; Returns a symbol: off, observe, bounded, self-healing, or full.
+;; Default: 'off.
+(define (setting-context-assembly-profile settings)
+  (define raw (setting-ref* settings '(context-assembly profile) "off"))
+  (define sym
+    (if (symbol? raw)
+        raw
+        (string->symbol raw)))
+  (if (memq sym '(off observe bounded self-healing full)) sym 'off))
 
 ;; ============================================================
 ;; Credential policy (v0.70.1)

--- a/tests/test-session-config.rkt
+++ b/tests/test-session-config.rkt
@@ -324,3 +324,13 @@
   (check-true (current-rollback-action-execution?))
   (check-true (current-ws-evolution-enabled?))
   (apply-context-assembly-profile! 'off))
+
+;; v0.79.0 GAP-1: Config hash round-trip for context-assembly-profile
+(test-case "config-context-assembly-profile reads from config hash"
+  (define h (hash 'context-assembly-profile 'observe))
+  (define cfg (hash->session-config h))
+  (check-eq? (config-context-assembly-profile cfg) 'observe))
+
+(test-case "config-context-assembly-profile defaults to off"
+  (define cfg (hash->session-config (hash)))
+  (check-eq? (config-context-assembly-profile cfg) 'off))

--- a/tests/test-settings.rkt
+++ b/tests/test-settings.rkt
@@ -582,3 +582,20 @@
   (define config (security-config-from-settings settings))
   (check-equal? (hash-ref config 'secret-scrub-extra-denylist) '("CUSTOM_.*"))
   (check-equal? (hash-ref config 'secret-scrub-allowlist) '("SAFE_VAR")))
+
+;; v0.79.0 GAP-1: Context assembly profile from settings
+(test-case "setting-context-assembly-profile defaults to off"
+  (define settings (q-settings (hash) (hash) (hash)))
+  (check-eq? (setting-context-assembly-profile settings) 'off))
+
+(test-case "setting-context-assembly-profile reads from config"
+  (define settings (q-settings (hash) (hash) (hash 'context-assembly (hash 'profile "observe"))))
+  (check-eq? (setting-context-assembly-profile settings) 'observe))
+
+(test-case "setting-context-assembly-profile reads symbol value"
+  (define settings (q-settings (hash) (hash) (hash 'context-assembly (hash 'profile 'bounded))))
+  (check-eq? (setting-context-assembly-profile settings) 'bounded))
+
+(test-case "setting-context-assembly-profile falls back for invalid profile"
+  (define settings (q-settings (hash) (hash) (hash 'context-assembly (hash 'profile "invalid"))))
+  (check-eq? (setting-context-assembly-profile settings) 'off))

--- a/wiring/run-modes.rkt
+++ b/wiring/run-modes.rkt
@@ -39,16 +39,16 @@
                   make-trace-logger
                   start-trace-logger!
                   project-tree->string)
-         (only-in "extension-setup.rkt" make-wired-extension-registry load-extensions-from-dir!))
+         (only-in "extension-setup.rkt" make-wired-extension-registry load-extensions-from-dir!)
+         (only-in "../runtime/session-config.rkt" apply-context-assembly-profile!))
 
 ;; Re-export mode runners from sub-modules
 (require "run-interactive.rkt"
          "run-json-rpc.rkt")
 
-(provide (contract-out
-          [build-runtime-from-cli (-> any/c any/c)]
-          [mode-for-config (-> any/c symbol?)]
-          [reload-config! (-> any/c any/c)])
+(provide (contract-out [build-runtime-from-cli (-> any/c any/c)]
+                       [mode-for-config (-> any/c symbol?)]
+                       [reload-config! (-> any/c any/c)])
          ;; Direct re-exports (no contracts needed — re-exported)
          load-extensions-from-dir!
          make-terminal-subscriber
@@ -186,7 +186,12 @@
   ;; v0.25.2 (F3): Wire security config from config.json
   (wire-security-config! settings)
 
-  (hash->session-config final-hash))
+  ;; v0.79.0 (GAP-1): Wire context assembly profile from settings
+  (define profile (setting-context-assembly-profile settings))
+  (define final-hash-with-profile (hash-set final-hash 'context-assembly-profile profile))
+  (apply-context-assembly-profile! profile)
+
+  (hash->session-config final-hash-with-profile))
 
 ;; ============================================================
 ;; mode-for-config


### PR DESCRIPTION
- Add `setting-context-assembly-profile` to settings.rkt (reads `(context-assembly profile)` from config)\n- Add `context-assembly-profile` to known-keys in session-config.rkt\n- Wire profile from settings → final-hash → `apply-context-assembly-profile!` in run-modes.rkt\n- 4 settings tests + 2 config round-trip tests\n\nCloses #6564