### PR TITLE
v0.79.0 W1: CLI --context-profile Flag (GAP-1)

### DIFF
--- a/cli/args.rkt
+++ b/cli/args.rkt
@@ -37,6 +37,7 @@
          cli-config-sessions-args
          cli-config-keybindings-path
          cli-config-print-mode?
+         cli-config-context-profile
          (contract-out [parse-cli-args
                         (->* () ((or/c (vectorof string?) (listof string?) #f)) cli-config?)]
                        [cli-config->runtime-config (-> cli-config? hash?)]
@@ -66,12 +67,13 @@
          sessions-args ; list of string (subcommand args)
          keybindings-path ; path-string or #f -- custom keybindings file (#1118)
          print-mode? ; boolean -- -p/--print flag (G9.3)
+         context-profile ; symbol: off|observe|bounded|self-healing|full, or #f
          )
   #:transparent)
 
 ;; Helper: construct a "help" config (used for parse errors and --help)
 (define (make-help-config)
-  (cli-config 'help #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f))
+  (cli-config 'help #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f #f))
 
 ;; ============================================================
 ;; Flag definition table (QUAL-12)
@@ -171,7 +173,8 @@
               #f ; sessions-subcommand
               '() ; sessions-args
               (acc-ref acc 'keybindings-path)
-              (acc-ref acc 'print-mode?)))
+              (acc-ref acc 'print-mode?)
+              (acc-ref acc 'context-profile)))
 
 ;; ============================================================
 ;; Flag table -- all option definitions
@@ -309,7 +312,19 @@
                   'boolean
                   "Print mode: run once, output plain text to stdout"
                   #f
-                  (lambda (val acc) (acc-set (acc-set acc 'print-mode? #t) 'mode 'print)))))
+                  (lambda (val acc) (acc-set (acc-set acc 'print-mode? #t) 'mode 'print)))
+        ;; --context-profile <profile>
+        (flag-def "context-profile"
+                  #f
+                  "context-profile"
+                  'string
+                  "Context assembly profile: off|observe|bounded|self-healing|full"
+                  #f
+                  (lambda (val acc)
+                    (define sym (string->symbol val))
+                    (if (memq sym '(off observe bounded self-healing full))
+                        (acc-set acc 'context-profile sym)
+                        (acc-set acc 'context-profile 'off))))))
 
 ;; Build lookup tables for fast matching
 (define long-flag-table
@@ -372,7 +387,7 @@
        (cond
          [(eq? result 'help) (make-help-config)]
          [(eq? result 'version)
-          (cli-config 'version #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f)]
+          (cli-config 'version #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f)]
          [else (loop (add1 i) result)]))]
     [(or (eq? t 'string) (eq? t 'integer) (eq? t 'accumulate))
      (if (< (add1 i) n)
@@ -426,6 +441,7 @@
                              sub-sym
                              rest
                              #f
+                             #f
                              #f))
                (make-help-config)))
          (make-help-config))]
@@ -449,6 +465,7 @@
                        #f
                        'verify
                        (cons path-arg rest-args)
+                       #f
                        #f
                        #f))
          (make-help-config))]

--- a/interfaces/cli.rkt
+++ b/interfaces/cli.rkt
@@ -31,6 +31,7 @@
          cli-config-sessions-args
          cli-config-keybindings-path
          cli-config-print-mode?
+         cli-config-context-profile
          ;; from args.rkt
          parse-cli-args
          cli-config->runtime-config

--- a/tests/test-cli-interactive.rkt
+++ b/tests/test-cli-interactive.rkt
@@ -13,7 +13,7 @@
 
     (test-case "basic prompt submission"
       (define prompts (box '()))
-      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f))
+      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f))
       (define in (open-input-string "hello\n/quit\n"))
       (define out (open-output-string))
       (run-cli-interactive cfg
@@ -24,7 +24,7 @@
 
     (test-case "multiple lines submitted as separate prompts"
       (define prompts (box '()))
-      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f))
+      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f))
       (define in (open-input-string "line1\nline2\n/quit\n"))
       (define out (open-output-string))
       (run-cli-interactive cfg
@@ -35,7 +35,7 @@
 
     (test-case "whitespace-only lines are skipped"
       (define prompts (box '()))
-      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f))
+      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f))
       (define in (open-input-string "   \nhello\n/quit\n"))
       (define out (open-output-string))
       (run-cli-interactive cfg
@@ -46,7 +46,7 @@
 
     (test-case "empty lines are skipped"
       (define prompts (box '()))
-      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f))
+      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f))
       (define in (open-input-string "\nhello\n/quit\n"))
       (define out (open-output-string))
       (run-cli-interactive cfg
@@ -57,7 +57,7 @@
 
     (test-case "EOF terminates with Goodbye"
       (define prompts (box '()))
-      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f))
+      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f))
       (define in (open-input-string "hello\n"))
       (define out (open-output-string))
       (run-cli-interactive cfg
@@ -70,21 +70,21 @@
   (test-suite "run-cli-interactive — slash commands"
 
     (test-case "/quit terminates with Goodbye"
-      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f))
+      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f))
       (define in (open-input-string "/quit\n"))
       (define out (open-output-string))
       (run-cli-interactive cfg #:in in #:out out)
       (check-true (string-contains? (get-output-string out) "Goodbye.")))
 
     (test-case "/exit terminates with Goodbye"
-      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f))
+      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f))
       (define in (open-input-string "/exit\n"))
       (define out (open-output-string))
       (run-cli-interactive cfg #:in in #:out out)
       (check-true (string-contains? (get-output-string out) "Goodbye.")))
 
     (test-case "/help displays usage"
-      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f))
+      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f))
       (define in (open-input-string "/help\n/quit\n"))
       (define out (open-output-string))
       (run-cli-interactive cfg #:in in #:out out)
@@ -93,14 +93,14 @@
 
     (test-case "/compact calls compact-fn"
       (define compact-called (box #f))
-      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f))
+      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f))
       (define in (open-input-string "/compact\n/quit\n"))
       (define out (open-output-string))
       (run-cli-interactive cfg #:compact-fn (lambda () (set-box! compact-called #t)) #:in in #:out out)
       (check-true (unbox compact-called) "compact-fn should have been called"))
 
     (test-case "/compact without compact-fn shows fallback message"
-      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f))
+      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f))
       (define in (open-input-string "/compact\n/quit\n"))
       (define out (open-output-string))
       (run-cli-interactive cfg #:in in #:out out)
@@ -109,7 +109,7 @@
 
     (test-case "/history calls history-fn"
       (define history-called (box #f))
-      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f))
+      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f))
       (define in (open-input-string "/history\n/quit\n"))
       (define out (open-output-string))
       (run-cli-interactive cfg
@@ -119,7 +119,7 @@
       (check-true (unbox history-called) "history-fn should have been called"))
 
     (test-case "/history without history-fn shows fallback message"
-      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f))
+      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f))
       (define in (open-input-string "/history\n/quit\n"))
       (define out (open-output-string))
       (run-cli-interactive cfg #:in in #:out out)
@@ -128,7 +128,7 @@
 
     (test-case "/model gpt-4 calls model-fn with arg"
       (define model-arg (box #f))
-      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f))
+      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f))
       (define in (open-input-string "/model gpt-4\n/quit\n"))
       (define out (open-output-string))
       (run-cli-interactive cfg #:model-fn (lambda (name) (set-box! model-arg name)) #:in in #:out out)
@@ -136,7 +136,7 @@
 
     (test-case "/model without arg calls model-fn with #f"
       (define model-arg (box 'not-called))
-      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f))
+      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f))
       (define in (open-input-string "/model\n/quit\n"))
       (define out (open-output-string))
       (run-cli-interactive cfg #:model-fn (lambda (name) (set-box! model-arg name)) #:in in #:out out)
@@ -144,7 +144,7 @@
 
     (test-case "/fork abc123 calls fork-fn with arg"
       (define fork-arg (box #f))
-      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f))
+      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f))
       (define in (open-input-string "/fork abc123\n/quit\n"))
       (define out (open-output-string))
       (run-cli-interactive cfg #:fork-fn (lambda (arg) (set-box! fork-arg arg)) #:in in #:out out)
@@ -152,21 +152,21 @@
 
     (test-case "/fork without arg calls fork-fn with #f"
       (define fork-arg (box 'not-called))
-      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f))
+      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f))
       (define in (open-input-string "/fork\n/quit\n"))
       (define out (open-output-string))
       (run-cli-interactive cfg #:fork-fn (lambda (arg) (set-box! fork-arg arg)) #:in in #:out out)
       (check-equal? (unbox fork-arg) #f))
 
     (test-case "/clear shows clear message"
-      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f))
+      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f))
       (define in (open-input-string "/clear\n/quit\n"))
       (define out (open-output-string))
       (run-cli-interactive cfg #:in in #:out out)
       (check-true (string-contains? (get-output-string out) "clear") "output should mention clear"))
 
     (test-case "/interrupt shows interrupt message"
-      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f))
+      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f))
       (define in (open-input-string "/interrupt\n/quit\n"))
       (define out (open-output-string))
       (run-cli-interactive cfg #:in in #:out out)
@@ -177,7 +177,7 @@
 
     (test-case "session-fn error is displayed and loop continues"
       (define prompts (box '()))
-      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f))
+      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f))
       (define in (open-input-string "bad\nok\n/quit\n"))
       (define out (open-output-string))
       (run-cli-interactive cfg
@@ -193,7 +193,7 @@
 
     (test-case "graceful degradation with string port (no readline)"
       (define prompts (box '()))
-      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f))
+      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f))
       (define in (open-input-string "test prompt\n/quit\n"))
       (define out (open-output-string))
       (run-cli-interactive cfg
@@ -206,7 +206,7 @@
     (test-case "mixed commands and prompts"
       (define prompts (box '()))
       (define compact-called (box #f))
-      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f))
+      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f))
       (define in (open-input-string "first prompt\n/compact\nsecond prompt\n/quit\n"))
       (define out (open-output-string))
       (run-cli-interactive cfg
@@ -230,7 +230,7 @@
 
     (test-case "first-run welcome appears before first prompt when config dir missing"
       (define tmp-home (make-temporary-file "q-test-home-~a" 'directory))
-      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f))
+      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f))
       (define in (open-input-string "/quit\n"))
       (define out (open-output-string))
       (parameterize ([current-directory tmp-home])
@@ -240,7 +240,7 @@
   (test-suite "Issue #141: Mock provider warning"
 
     (test-case "mock provider name triggers warning banner"
-      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f))
+      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f))
       (define in (open-input-string "/quit\n"))
       (define out (open-output-string))
       (run-cli-interactive cfg #:provider-name "mock" #:in in #:out out)
@@ -248,7 +248,7 @@
       (check-true (string-contains? output "mock provider") "should warn about mock provider"))
 
     (test-case "real provider name does NOT trigger warning"
-      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f))
+      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f))
       (define in (open-input-string "/quit\n"))
       (define out (open-output-string))
       (run-cli-interactive cfg #:provider-name "openai" #:in in #:out out)
@@ -256,7 +256,7 @@
       (check-false (string-contains? output "mock provider") "should not warn for real provider"))
 
     (test-case "no provider-name does NOT trigger warning"
-      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f))
+      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f))
       (define in (open-input-string "/quit\n"))
       (define out (open-output-string))
       (run-cli-interactive cfg #:in in #:out out)
@@ -266,7 +266,7 @@
   (test-suite "Issue #145: TUI-only commands in CLI"
 
     (test-case "/clear shows TUI-only message"
-      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f))
+      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f))
       (define in (open-input-string "/clear\n/quit\n"))
       (define out (open-output-string))
       (run-cli-interactive cfg #:in in #:out out)
@@ -274,7 +274,7 @@
       (check-true (string-contains? output "TUI") "/clear should mention TUI"))
 
     (test-case "/interrupt shows TUI-only message"
-      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f))
+      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f))
       (define in (open-input-string "/interrupt\n/quit\n"))
       (define out (open-output-string))
       (run-cli-interactive cfg #:in in #:out out)
@@ -282,7 +282,7 @@
       (check-true (string-contains? output "TUI") "/interrupt should mention TUI"))
 
     (test-case "/branches shows TUI-only message"
-      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f))
+      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f))
       (define in (open-input-string "/branches\n/quit\n"))
       (define out (open-output-string))
       (run-cli-interactive cfg #:in in #:out out)
@@ -290,7 +290,7 @@
       (check-true (string-contains? output "TUI") "/branches should mention TUI"))
 
     (test-case "/leaves shows TUI-only message"
-      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f))
+      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f))
       (define in (open-input-string "/leaves\n/quit\n"))
       (define out (open-output-string))
       (run-cli-interactive cfg #:in in #:out out)
@@ -298,7 +298,7 @@
       (check-true (string-contains? output "TUI") "/leaves should mention TUI"))
 
     (test-case "/switch shows TUI-only message"
-      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f))
+      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f))
       (define in (open-input-string "/switch abc\n/quit\n"))
       (define out (open-output-string))
       (run-cli-interactive cfg #:in in #:out out)
@@ -306,7 +306,7 @@
       (check-true (string-contains? output "TUI") "/switch should mention TUI"))
 
     (test-case "/children shows TUI-only message"
-      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f))
+      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f))
       (define in (open-input-string "/children abc\n/quit\n"))
       (define out (open-output-string))
       (run-cli-interactive cfg #:in in #:out out)

--- a/wiring/run-modes.rkt
+++ b/wiring/run-modes.rkt
@@ -186,8 +186,10 @@
   ;; v0.25.2 (F3): Wire security config from config.json
   (wire-security-config! settings)
 
-  ;; v0.79.0 (GAP-1): Wire context assembly profile from settings
-  (define profile (setting-context-assembly-profile settings))
+  ;; v0.79.0 (GAP-1): Wire context assembly profile — CLI overrides settings
+  (define settings-profile (setting-context-assembly-profile settings))
+  (define cli-profile (cli-config-context-profile cfg))
+  (define profile (or cli-profile settings-profile))
   (define final-hash-with-profile (hash-set final-hash 'context-assembly-profile profile))
   (apply-context-assembly-profile! profile)
 


### PR DESCRIPTION
- Add `--context-profile` CLI flag to args.rkt with validation\n- Add `context-profile` field to `cli-config` struct\n- CLI flag overrides settings profile in run-modes.rkt\n- All constructor calls updated (16→17 args)\n- 32 CLI tests pass\n\nCloses #6565