### PR TITLE
v0.79.1 W0: Idle Preamble + Revert-State Rollback (GAP-5/6)

### DIFF
--- a/runtime/context-assembly/rollback-actions.rkt
+++ b/runtime/context-assembly/rollback-actions.rkt
@@ -61,6 +61,7 @@
 ;; Signature: (-> rollback-action? void?)
 (define current-force-distill-fn (make-parameter #f))
 (define current-expand-context-fn (make-parameter #f))
+(define current-revert-state-fn (make-parameter #f))
 
 ;; v0.77.10 M2: Action execution log for observability.
 ;; Each entry is a hash with 'type, 'reason, 'timestamp.
@@ -70,23 +71,36 @@
 ;; Calls the injectable callback if available, then logs.
 (define (execute-force-distill! action)
   (define fn (current-force-distill-fn))
-  (when fn (fn action))
+  (when fn
+    (fn action))
   (log-action! action))
 
 ;; v0.77.10 M2: Execute expand-context action.
 ;; Calls the injectable callback if available, then logs.
 (define (execute-expand-context! action)
   (define fn (current-expand-context-fn))
-  (when fn (fn action))
+  (when fn
+    (fn action))
+  (log-action! action))
+
+;; v0.79.1 GAP-6: Execute revert-state action.
+;; Calls the injectable callback if available, then logs.
+;; Only executes when current-revert-state-fn is wired.
+(define (execute-revert-state! action)
+  (define fn (current-revert-state-fn))
+  (when fn
+    (fn action))
   (log-action! action))
 
 ;; Log an executed action to the rollback action log.
 (define (log-action! action)
-  (current-rollback-action-log
-   (append (current-rollback-action-log)
-           (list (hasheq 'type (rollback-action-type action)
-                         'reason (rollback-action-reason action)
-                         'timestamp (current-seconds))))))
+  (current-rollback-action-log (append (current-rollback-action-log)
+                                       (list (hasheq 'type
+                                                     (rollback-action-type action)
+                                                     'reason
+                                                     (rollback-action-reason action)
+                                                     'timestamp
+                                                     (current-seconds))))))
 
 ;; Execute a rollback action if execution is enabled.
 ;; v0.77.10 M2: Now dispatches to real execution functions.
@@ -96,7 +110,12 @@
   (cond
     [(not action) #f]
     [(not (current-rollback-action-execution?)) #f]
-    [(eq? (rollback-action-type action) 'revert-state) #f] ; too risky
+    [(eq? (rollback-action-type action) 'revert-state)
+     (if (current-revert-state-fn)
+         (begin
+           (execute-revert-state! action)
+           'revert-state)
+         #f)]
     [(eq? (rollback-action-type action) 'force-distill)
      (execute-force-distill! action)
      'force-distill]
@@ -128,6 +147,7 @@
          current-rollback-action-log
          current-force-distill-fn
          current-expand-context-fn
+         current-revert-state-fn
          rollback-action-type?
          (contract-out [make-warn-action (-> string? rollback-action?)]
                        [make-expand-context-action (-> string? hash? rollback-action?)]

--- a/runtime/context-assembly/state-aware-builder.rkt
+++ b/runtime/context-assembly/state-aware-builder.rkt
@@ -274,10 +274,10 @@
       [else #f]))
   (cond
     [(not state-name) #f]
-    [(eq? state-name 'idle) #f]
     [else
      (define label
        (case state-name
+         [(idle) "IDLE"]
          [(exploration) "EXPLORATION"]
          [(planning) "PLANNING"]
          [(implementation) "IMPLEMENTATION"]

--- a/tests/test-rollback-actions.rkt
+++ b/tests/test-rollback-actions.rkt
@@ -20,7 +20,8 @@
                   current-rollback-action-execution?
                   current-rollback-action-log
                   current-force-distill-fn
-                  current-expand-context-fn))
+                  current-expand-context-fn
+                  current-revert-state-fn))
 
 (define suite
   (test-suite "rollback-actions"
@@ -56,10 +57,19 @@
         (check-equal? (maybe-execute-action (make-force-distill-action "test" (hasheq)))
                       'force-distill)))
 
-    (test-case "maybe-execute-action never executes revert-state"
+    (test-case "maybe-execute-action skips revert-state when no fn wired (GAP-6)"
       (parameterize ([current-rollback-action-execution? #t]
-                     [current-rollback-action-log '()])
+                     [current-rollback-action-log '()]
+                     [current-revert-state-fn #f])
         (check-false (maybe-execute-action (make-revert-state-action "danger" (hasheq))))))
+
+    (test-case "maybe-execute-action executes revert-state when fn wired (GAP-6)"
+      (define executed? (box #f))
+      (parameterize ([current-rollback-action-execution? #t]
+                     [current-rollback-action-log '()]
+                     [current-revert-state-fn (lambda (_action) (set-box! executed? #t))])
+        (check-equal? (maybe-execute-action (make-revert-state-action "test" (hasheq))) 'revert-state)
+        (check-true (unbox executed?))))
 
     (test-case "warnings->actions maps amnesia to force-distill"
       (define actions (warnings->actions '("amnesia detected: 80% context lost")))

--- a/tests/test-state-aware-assembly.rkt
+++ b/tests/test-state-aware-assembly.rkt
@@ -198,9 +198,19 @@
 
     ;; ── v0.75.5: System prompt preamble tests ──
 
-    (test-case "preamble returns #f for idle state"
+    (test-case "preamble returns message for idle state (GAP-5 fix)"
       (define p (build-state-awareness-preamble task-idle '()))
-      (check-false p))
+      (check-not-false p)
+      (define text (text-part-text (car (message-content p))))
+      (check-not-false (string-contains? text "IDLE")))
+
+    (test-case "preamble returns idle with conclusions (GAP-5 fix)"
+      (define conclusions
+        (list (task-conclusion "c1" "Found X" 'fact 'idle '() (current-seconds) '() '())))
+      (define p (build-state-awareness-preamble task-idle conclusions))
+      (check-not-false p)
+      (define text (text-part-text (car (message-content p))))
+      (check-not-false (string-contains? text "Found X")))
 
     (test-case "preamble returns #f for #f state"
       (define p (build-state-awareness-preamble #f '()))


### PR DESCRIPTION
GAP-5: Idle preamble now returns proper message with guidance + conclusions instead of #f.\nGAP-6: Added current-revert-state-fn injectable callback. revert-state dispatches when wired, safe #f default.\n\n20 state-aware tests + 17 rollback tests all pass.\n\nCloses #6567