### PR TITLE
v0.79.2 W0: State Tracking + Archive Logging (GAP-2/4)

### DIFF
--- a/runtime/session-mutation.rkt
+++ b/runtime/session-mutation.rkt
@@ -15,9 +15,11 @@
          (only-in "context-assembly/task-state.rkt" task-states-list task-valid-direct-transition?)
          (only-in "context-assembly/ws-evolution.rkt"
                   evolution-result?
-                  evolution-result-evicted-conclusions)
+                  evolution-result-evicted-conclusions
+                  evolution-result-archived-entries)
          (only-in "context-assembly/task-conclusion.rkt" task-conclusion-id))
 
+(define-logger q-session-mutation)
 (provide (contract-out [guarded-set-prompt-running! (-> agent-session? boolean? void?)]
                        [guarded-set-compacting! (-> agent-session? boolean? void?)]
                        [guarded-set-shutdown-requested! (-> agent-session? boolean? void?)]
@@ -148,6 +150,11 @@
 ;; We now merge (union by ID) with existing session conclusions.
 (define (guarded-set-working-set-evolved! sess evolution-res)
   (when (and (agent-session? sess) (evolution-result? evolution-res))
+    ;; v0.79.2 GAP-4: Log archived entries (no longer silently dropped)
+    (define archived (evolution-result-archived-entries evolution-res))
+    (when (pair? archived)
+      (log-q-session-mutation-info (format "WS evolution archived ~a entries" (length archived))))
+    ;; Merge injected conclusions
     (define injected (evolution-result-evicted-conclusions evolution-res))
     (when (pair? injected)
       (define existing (agent-session-task-conclusions sess))

--- a/runtime/turn-orchestrator.rkt
+++ b/runtime/turn-orchestrator.rkt
@@ -163,11 +163,16 @@
                 (#:hook-dispatcher (or/c procedure? #f)
                                    #:state-aware? (or/c boolean? #f)
                                    #:recent-tool-calls list?)
-                (values list? (or/c hook-result? #f) tiered-context?))]))
+                (values list? (or/c hook-result? #f) tiered-context?))])
+         current-last-task-fsm-state)
 
 ;; ============================================================
 ;; Context assembly
 ;; ============================================================
+
+;; v0.79.2 GAP-2: Track last task FSM state for WS evolution old-state.
+;; Set each turn from agent-session-task-fsm-state before it gets updated.
+(define current-last-task-fsm-state (make-parameter #f))
 
 ;; Pure: assemble context from messages and config without side effects.
 ;; Returns the assembled message list and hook result (no events emitted here).
@@ -254,8 +259,12 @@
   ;; Only when WS evolution enabled and session has a working set
   (when (and (current-ws-evolution-enabled?) ws-early session task-state (not (eq? task-state 'idle)))
     ;; v0.78.6 C1+W1: Use /result variant (returns evolution-result? struct)
-    ;; Pass #f for old-state since we don't know the previous state inline.
-    (define result (evolve-working-set-for-state/result ws-early #f task-state augmented-conclusions))
+    ;; v0.79.2 GAP-2: Pass tracked old-state instead of #f.
+    (define old-state (current-last-task-fsm-state))
+    (define result
+      (evolve-working-set-for-state/result ws-early old-state task-state augmented-conclusions))
+    ;; Update tracked state for next turn
+    (current-last-task-fsm-state task-state)
     (when (and (evolution-result? result) session)
       (guarded-set-working-set-evolved! session result)))
   ;; FD-05: Delegate pure assembly to assemble-context/pure


### PR DESCRIPTION
GAP-2: Added `current-last-task-fsm-state` parameter to track previous task state across turns. WS evolution now receives real old-state instead of always #f.\nGAP-4: `guarded-set-working-set-evolved!` now logs archived entries count instead of silently dropping them.\n\n12 WS evolution tests + session mutation tests pass.\n\nCloses #6570