### PR TITLE
v0.79.2 W1: Archive Persistence Callback (GAP-4)

### DIFF
--- a/runtime/session-mutation.rkt
+++ b/runtime/session-mutation.rkt
@@ -20,6 +20,10 @@
          (only-in "context-assembly/task-conclusion.rkt" task-conclusion-id))
 
 (define-logger q-session-mutation)
+
+;; v0.79.2 GAP-4: Injectable callback for persisting archived WS entries.
+;; Signature: (-> ws-entry? void?). Runtime wires real implementation.
+(define current-archive-entry-fn (make-parameter #f))
 (provide (contract-out [guarded-set-prompt-running! (-> agent-session? boolean? void?)]
                        [guarded-set-compacting! (-> agent-session? boolean? void?)]
                        [guarded-set-shutdown-requested! (-> agent-session? boolean? void?)]
@@ -39,7 +43,8 @@
                        [guarded-set-recent-tool-calls! (-> agent-session? list? void?)]
                        [guarded-set-working-set-evolved! (-> agent-session? evolution-result? void?)]
                        [valid-session-phase? (-> symbol? boolean?)]
-                       [session-phase (-> agent-session? symbol?)]))
+                       [session-phase (-> agent-session? symbol?)])
+         current-archive-entry-fn)
 
 ;; Valid session phases derived from boolean flags
 (define (valid-session-phase? phase)
@@ -153,7 +158,12 @@
     ;; v0.79.2 GAP-4: Log archived entries (no longer silently dropped)
     (define archived (evolution-result-archived-entries evolution-res))
     (when (pair? archived)
-      (log-q-session-mutation-info (format "WS evolution archived ~a entries" (length archived))))
+      (log-q-session-mutation-info (format "WS evolution archived ~a entries" (length archived)))
+      ;; v0.79.2 GAP-4: Persist archived entries via injectable callback
+      (define archive-fn (current-archive-entry-fn))
+      (when archive-fn
+        (for ([e (in-list archived)])
+          (archive-fn e))))
     ;; Merge injected conclusions
     (define injected (evolution-result-evicted-conclusions evolution-res))
     (when (pair? injected)

--- a/tests/test-session-mutation.rkt
+++ b/tests/test-session-mutation.rkt
@@ -8,6 +8,7 @@
          "../runtime/session-types.rkt"
          "../runtime/session-mutation.rkt"
          "../runtime/context-assembly/ws-evolution.rkt"
+         (only-in "../runtime/working-set.rkt" make-working-set ws-entry ws-entry?)
          (only-in "../runtime/context-assembly/task-conclusion.rkt"
                   task-conclusion
                   task-conclusion?
@@ -150,3 +151,17 @@
   (check-not-false (member "exp-1" final-ids) "existing exp-1 should survive")
   (check-not-false (member "exp-2" final-ids) "existing exp-2 should survive")
   (check-not-false (member "dist-1" final-ids) "new distilled conclusion should survive"))
+
+;; v0.79.2 GAP-4: Archive entry callback test
+(test-case "guarded-set-working-set-evolved! calls archive callback for archived entries"
+  (define sess (make-test-session))
+  (define archived-entries (box '()))
+  ;; Create an evolution result with archived entries
+  (define ws (make-working-set #:max-entries 10 #:max-tokens 1000))
+  (define e1 (ws-entry "file1.rkt" "m1" 100 1000))
+  (define e2 (ws-entry "file2.rkt" "m2" 200 2000))
+  (define result (evolution-result '() (list e1 e2) '()))
+  (parameterize ([current-archive-entry-fn
+                  (lambda (e) (set-box! archived-entries (cons e (unbox archived-entries))))])
+    (guarded-set-working-set-evolved! sess result))
+  (check-equal? (length (unbox archived-entries)) 2))


### PR DESCRIPTION
Add `current-archive-entry-fn` injectable callback. Archived WS entries passed to callback when wired, no longer silently dropped. TDD test verifies 2 archived entries reach callback.\n\nCloses #6571