### PR TITLE
v0.79.3 W0: Auto-Distillation Content Summaries (GAP-3)

### DIFF
--- a/runtime/context-assembly/auto-distillation.rkt
+++ b/runtime/context-assembly/auto-distillation.rkt
@@ -37,21 +37,25 @@
 ;; ── Deterministic Fallback ──
 
 ;; Generate a deterministic fallback conclusion for an uncovered entry.
-;; Uses the message ID and a generic template.
-(define (make-deterministic-fallback msg-id current-state)
-  (task-conclusion (format "auto-~a" msg-id)
-                   (format "[Auto] Previously read file (origin: ~a)" msg-id)
-                   'fact
-                   (or current-state 'idle)
-                   (list msg-id)
-                   (current-seconds)
-                   '(auto-distilled)
-                   '()))
+;; v0.79.2 GAP-3: Accept optional content summary for richer fallback text.
+(define (make-deterministic-fallback msg-id current-state [content-summary #f])
+  (task-conclusion
+   (format "auto-~a" msg-id)
+   (if content-summary
+       (format "[Auto] ~a" (substring content-summary 0 (min (string-length content-summary) 200)))
+       (format "[Auto] Previously read file (origin: ~a)" msg-id))
+   'fact
+   (or current-state 'idle)
+   (list msg-id)
+   (current-seconds)
+   '(auto-distilled)
+   '()))
 
 ;; Generate fallback conclusions for all uncovered entries.
-(define (generate-fallback-conclusions uncovered-ids current-state)
+;; v0.79.2 GAP-3: Accept optional content-summary hash (msg-id -> string).
+(define (generate-fallback-conclusions uncovered-ids current-state [content-summaries (hash)])
   (for/list ([id (in-list uncovered-ids)])
-    (make-deterministic-fallback id current-state)))
+    (make-deterministic-fallback id current-state (hash-ref content-summaries id #f))))
 
 ;; ── Optional LLM Distillation Interface ──
 
@@ -79,13 +83,14 @@
 
 ;; Generate auto-conclusions for uncovered WS entries.
 ;; Returns (listof task-conclusion?) — either LLM-distilled or deterministic fallbacks.
-(define (auto-distill ws-message-ids conclusions current-state)
+;; v0.79.2 GAP-3: Accept optional content-summary hash for richer fallback text.
+(define (auto-distill ws-message-ids conclusions current-state [content-summaries (hash)])
   (define uncovered (find-uncovered-entries ws-message-ids conclusions))
   (cond
     [(null? uncovered) '()]
     [(not (current-auto-distillation-enabled?)) '()]
     [(current-llm-distill-fn) (distill-with-llm uncovered current-state (current-llm-distill-fn) 5)]
-    [else (generate-fallback-conclusions uncovered current-state)]))
+    [else (generate-fallback-conclusions uncovered current-state content-summaries)]))
 
 ;; ── Exports ──
 
@@ -94,9 +99,8 @@
          (contract-out [find-uncovered-entries
                         (-> (listof string?) (listof task-conclusion?) (listof string?))]
                        [generate-fallback-conclusions
-                        (-> (listof string?) (or/c symbol? #f) (listof task-conclusion?))]
+                        (->* ((listof string?) (or/c symbol? #f)) (hash?) (listof task-conclusion?))]
                        [auto-distill
-                        (-> (listof string?)
-                            (listof task-conclusion?)
-                            (or/c symbol? #f)
-                            (listof task-conclusion?))]))
+                        (->* ((listof string?) (listof task-conclusion?) (or/c symbol? #f))
+                             (hash?)
+                             (listof task-conclusion?))]))

--- a/runtime/turn-orchestrator.rkt
+++ b/runtime/turn-orchestrator.rkt
@@ -245,7 +245,14 @@
   (define augmented-conclusions
     (if (and (current-auto-distillation-enabled?) session conclusions task-state ws-early)
         (let ([ws-msgs (working-set-resolve-messages ws-early ctx-to-use message-id)])
-          (append conclusions (auto-distill (map message-id ws-msgs) conclusions task-state)))
+          ;; v0.79.2 GAP-3: Build content summaries for richer auto-distill text
+          (define summaries
+            (for/hash ([m (in-list ws-msgs)])
+              (define text-parts (filter text-part? (message-content m)))
+              (define full-text (string-join (map text-part-text text-parts) " "))
+              (values (message-id m) full-text)))
+          (append conclusions
+                  (auto-distill (map message-id ws-msgs) conclusions task-state summaries)))
         (or conclusions '())))
   ;; v0.78.2 G3: Persist auto-distilled conclusions back to session
   ;; Only when auto-distill added new conclusions

--- a/tests/test-auto-distillation.rkt
+++ b/tests/test-auto-distillation.rkt
@@ -1,6 +1,7 @@
 #lang racket/base
 
 (require rackunit
+         racket/string
          rackunit/text-ui
          (only-in "../runtime/context-assembly/task-conclusion.rkt"
                   task-conclusion
@@ -8,7 +9,8 @@
                   task-conclusion-origin-message-ids
                   task-conclusion-relevance-tags
                   task-conclusion-category
-                  task-conclusion-id)
+                  task-conclusion-id
+                  task-conclusion-text)
          (only-in "../runtime/context-assembly/auto-distillation.rkt"
                   find-uncovered-entries
                   generate-fallback-conclusions
@@ -62,3 +64,33 @@
         (check-equal? result '())))))
 
 (run-tests suite)
+
+;; v0.79.2 GAP-3: Content summary produces richer fallback text
+(test-case "auto-distill with content summary produces richer text"
+  (parameterize ([current-auto-distillation-enabled? #t])
+    (define summaries (hash "m1" "This file implements the authentication module using OAuth2"))
+    (define result (auto-distill '("m1") '() 'exploration summaries))
+    (check-equal? (length result) 1)
+    (define c (car result))
+    (check-not-false (string-contains? (task-conclusion-text c) "OAuth2"))
+    (check-false (string-contains? (task-conclusion-text c) "Previously read file"))))
+
+(test-case "auto-distill without content summary uses placeholder"
+  (parameterize ([current-auto-distillation-enabled? #t])
+    (define result (auto-distill '("m1") '() 'idle))
+    (check-equal? (length result) 1)
+    (check-not-false (string-contains? (task-conclusion-text (car result)) "Previously read file"))))
+
+(test-case "auto-distill passes content summaries to fallback"
+  (parameterize ([current-auto-distillation-enabled? #t])
+    (define summaries (hash "m1" "Authentication uses JWT tokens with refresh"))
+    (define result (auto-distill '("m1") '() 'exploration summaries))
+    (check-equal? (length result) 1)
+    (check-not-false (string-contains? (task-conclusion-text (car result)) "JWT"))))
+
+(test-case "content summary truncates at 200 chars"
+  (parameterize ([current-auto-distillation-enabled? #t])
+    (define long-text (make-string 300 #\x))
+    (define summaries (hash "m1" long-text))
+    (define result (auto-distill '("m1") '() 'idle summaries))
+    (check-true (<= (string-length (task-conclusion-text (car result))) 210))))


### PR DESCRIPTION
GAP-3: Auto-distillation now uses actual message content instead of placeholder text.\n- `auto-distill` accepts optional content-summary hash\n- Fallback conclusions show first 200 chars of file content\n- Turn-orchestrator builds summaries from WS messages\n- 4 new tests, all 12 tests pass\n\nCloses #6573