### PR TITLE
v0.80.1 W2: Event Macro Registry Fixes (A3)

### DIFF
--- a/tests/test-event-macro-isolation.rkt
+++ b/tests/test-event-macro-isolation.rkt
@@ -4,21 +4,41 @@
 ;; STABILITY: evolving
 
 (require rackunit
-         rackunit/text-ui)
+         rackunit/text-ui
+         "../util/event-macro.rkt")
 
 ;; ── Test Suite ──
 
 (define suite
-  (test-suite
-   "Event Macro Isolation (A3)"
+  (test-suite "Event Macro Isolation (A3)"
 
-   ;; Test 1: Event macro module loads successfully
-   (test-case "event-macro module loads"
-     ;; Just verify the require succeeds
-     (check-true #t))
+    ;; Test 1: with-fresh-event-registries resets ALL 4 registries
+    (test-case "with-fresh-event-registries resets all registries"
+      ;; Populate registries
+      (hash-set! (current-event-field-registry) 'test-event '(field1 field2))
+      (hash-set! (current-event-serializer-registry) "test.event" (lambda (e) 'serialized))
+      (hash-set! (current-event-deserializer-registry) "test.event" (lambda (d) 'deserialized))
+      (hash-set! (current-event-schema-registry) "test.event" 99)
 
-   ;; Test 2: W2 will verify with-fresh-event-registries resets all registries
-   (test-case "W2 will verify registry isolation"
-     (check-true #t))))
+      ;; Verify populated
+      (check-not-false (hash-ref (current-event-field-registry) 'test-event #f))
+      (check-not-false (hash-ref (current-event-serializer-registry) "test.event" #f))
+      (check-not-false (hash-ref (current-event-deserializer-registry) "test.event" #f))
+      (check-not-false (hash-ref (current-event-schema-registry) "test.event" #f))
+
+      ;; Verify fresh scope is clean
+      (with-fresh-event-registries
+       (check-false (hash-ref (current-event-field-registry) 'test-event #f))
+       (check-false (hash-ref (current-event-serializer-registry) "test.event" #f))
+       (check-false (hash-ref (current-event-deserializer-registry) "test.event" #f))
+       (check-false (hash-ref (current-event-schema-registry) "test.event" #f))))
+
+    ;; Test 2: Registries are independent
+    (test-case "registries don't leak across isolation boundaries"
+      (with-fresh-event-registries
+       (hash-set! (current-event-field-registry) 'isolated '(x))
+       (check-equal? (hash-ref (current-event-field-registry) 'isolated #f) '(x)))
+      ;; After scope, original registry restored
+      (check-false (hash-ref (current-event-field-registry) 'isolated #f)))))
 
 (run-tests suite)

--- a/util/event-macro.rkt
+++ b/util/event-macro.rkt
@@ -91,7 +91,8 @@
 (define-syntax-rule (with-fresh-event-registries body ...)
   (parameterize ([current-event-field-registry (make-hasheq)]
                  [current-event-serializer-registry (make-hash)]
-                 [current-event-deserializer-registry (make-hash)])
+                 [current-event-deserializer-registry (make-hash)]
+                 [current-event-schema-registry (make-hash)])
     body ...))
 
 ;; ===========================================================


### PR DESCRIPTION
A3: Fix with-fresh-event-registries to reset all 4 registries. Add 2 isolation tests.\n\nCloses #6589