### PR TITLE
v0.80.3 W1: Structured Error Classification (T1-4)

### DIFF
--- a/runtime/auto-retry.rkt
+++ b/runtime/auto-retry.rkt
@@ -155,9 +155,13 @@
                      "exceeds the maximum"))
 
 (define (context-overflow-error? exn)
-  (define msg (exn-message exn))
-  (for/or ([pattern (in-list CONTEXT_OVERFLOW_PATTERNS)])
-    (string-contains? (string-downcase msg) pattern)))
+  ;; Fast path: structured provider-error
+  (or (and (provider-error? exn) (eq? (provider-error-category exn) 'context-overflow))
+      ;; Fallback: string matching for non-structured errors
+      (let ()
+        (define msg (exn-message exn))
+        (for/or ([pattern (in-list CONTEXT_OVERFLOW_PATTERNS)])
+          (string-contains? (string-downcase msg) pattern)))))
 
 ;; ============================================================
 ;; Permanent tool error predicate (v0.19.3 Wave 2)
@@ -186,16 +190,24 @@
 (define TIMEOUT_PATTERNS '("timeout" "timed out" "connection reset" "broken pipe" "read error" "eof"))
 
 (define (timeout-error? exn)
-  (define msg (exn-message exn))
-  (for/or ([pattern (in-list TIMEOUT_PATTERNS)])
-    (string-contains? (string-downcase msg) pattern)))
+  ;; Fast path: structured provider-error
+  (or (and (provider-error? exn) (eq? (provider-error-category exn) 'timeout))
+      ;; Fallback: string matching for non-structured errors
+      (let ()
+        (define msg (exn-message exn))
+        (for/or ([pattern (in-list TIMEOUT_PATTERNS)])
+          (string-contains? (string-downcase msg) pattern)))))
 
 (define RATE_LIMIT_PATTERNS '("429" "rate" "overloaded" "quota" "too many requests"))
 
 (define (rate-limit-error? exn)
-  (define msg (exn-message exn))
-  (for/or ([pattern (in-list RATE_LIMIT_PATTERNS)])
-    (string-contains? (string-downcase msg) pattern)))
+  ;; Fast path: structured provider-error
+  (or (and (provider-error? exn) (eq? (provider-error-category exn) 'rate-limit))
+      ;; Fallback: string matching for non-structured errors
+      (let ()
+        (define msg (exn-message exn))
+        (for/or ([pattern (in-list RATE_LIMIT_PATTERNS)])
+          (string-contains? (string-downcase msg) pattern)))))
 
 ;; Classify an error into a symbolic type for recovery hint rendering.
 ;; Returns one of: 'timeout, 'rate-limit, 'auth, 'context-overflow,

--- a/tests/test-error-classify-structured.rkt
+++ b/tests/test-error-classify-structured.rkt
@@ -20,13 +20,13 @@
       (check-true (procedure? provider-error-status-code)))
 
     ;; Test 2: classify-http-status maps common codes
-    (test-case "classify-http-status maps 429 → rate-limit"
+    (test-case "classify-http-status maps codes to categories"
       (check-equal? (classify-http-status 429) 'rate-limit)
       (check-equal? (classify-http-status 401) 'auth)
       (check-equal? (classify-http-status 500) 'server)
       (check-equal? (classify-http-status 200) #f))
 
-    ;; Test 3: auto-retry uses provider-error-category fast path
+    ;; Test 3: retryable-error? uses structured category fast path
     (test-case "retryable-error? recognizes structured provider-error"
       (define err (provider-error "test" (current-continuation-marks) (hash) 'rate-limit 429))
       (check-true (retryable-error? err)))
@@ -34,6 +34,31 @@
     ;; Test 4: non-provider-error falls back to string matching
     (test-case "retryable-error? falls back to string matching"
       (define err (exn:fail "429 Too Many Requests" (current-continuation-marks)))
-      (check-true (retryable-error? err)))))
+      (check-true (retryable-error? err)))
+
+    ;; Test 5: timeout-error? uses structured category fast path
+    (test-case "timeout-error? recognizes structured provider-error"
+      (define err (provider-error "test" (current-continuation-marks) (hash) 'timeout #f))
+      (check-true (timeout-error? err)))
+
+    ;; Test 6: rate-limit-error? uses structured category fast path
+    (test-case "rate-limit-error? recognizes structured provider-error"
+      (define err (provider-error "test" (current-continuation-marks) (hash) 'rate-limit 429))
+      (check-true (rate-limit-error? err)))
+
+    ;; Test 7: context-overflow-error? uses structured category fast path
+    (test-case "context-overflow-error? recognizes structured provider-error"
+      (define err (provider-error "test" (current-continuation-marks) (hash) 'context-overflow 413))
+      (check-true (context-overflow-error? err)))
+
+    ;; Test 8: string fallback still works for timeout
+    (test-case "timeout-error? falls back to string matching"
+      (define err (exn:fail "connection timed out" (current-continuation-marks)))
+      (check-true (timeout-error? err)))
+
+    ;; Test 9: string fallback still works for rate limit
+    (test-case "rate-limit-error? falls back to string matching"
+      (define err (exn:fail "rate limit exceeded" (current-continuation-marks)))
+      (check-true (rate-limit-error? err)))))
 
 (run-tests suite)


### PR DESCRIPTION
T1-4: Add structured provider-error fast paths to context-overflow-error?, timeout-error?, rate-limit-error?. 9 tests.\n\nCloses #6596