### PR TITLE
v0.80.4 W1: Protocol-Types Migration (6 consumers)

### DIFF
--- a/cli/render.rkt
+++ b/cli/render.rkt
@@ -15,7 +15,7 @@
 ;;   format-classified-error    — error formatting
 
 (require "../util/error-helpers.rkt")
-(require "../util/protocol-types.rkt"
+(require (only-in "../util/event.rkt" event-ev event-payload)
          "../util/ansi.rkt"
          "../util/markdown.rkt"
          "../util/error-classify.rkt"

--- a/extensions/events.rkt
+++ b/extensions/events.rkt
@@ -15,7 +15,6 @@
 
 (require racket/contract
          "api.rkt"
-         "../util/protocol-types.rkt"
          "../util/event.rkt")
 
 (define-logger ext-events)

--- a/interfaces/json-mode.rkt
+++ b/interfaces/json-mode.rkt
@@ -3,10 +3,9 @@
 (require racket/contract
          racket/string
          json
-         "../util/protocol-types.rkt"
          "../agent/event-bus.rkt"
-         (only-in "../util/event.rkt" event?)
-         (only-in "../util/message.rkt" message?))
+         (only-in "../util/event.rkt" event? event->jsexpr)
+         (only-in "../util/message.rkt" message? message->jsexpr))
 
 (provide intent
          intent?

--- a/interfaces/rpc-mode.rkt
+++ b/interfaces/rpc-mode.rkt
@@ -5,7 +5,7 @@
          racket/math
          json
          racket/port
-         "../util/protocol-types.rkt"
+         (only-in "../util/event.rkt" event->jsexpr event-ev)
          "../agent/event-bus.rkt")
 
 (define-logger rpc-mode)

--- a/runtime/iteration/retry-policy.rkt
+++ b/runtime/iteration/retry-policy.rkt
@@ -31,8 +31,8 @@
                 ([summary-message : (U String #f)] [removed-count : Integer]
                                                    [kept-messages : (Listof Any)])])
 
-(require/typed "../../util/protocol-types.rkt"
-               [message-content (-> Any (U String (Listof Any)))]
+(require/typed "../../util/message.rkt" [message-content (-> Any (U String (Listof Any)))])
+(require/typed "../../util/content-parts.rkt"
                [text-part? (-> Any Boolean)]
                [text-part-text (-> Any String)])
 

--- a/runtime/session-lifecycle-transitions.rkt
+++ b/runtime/session-lifecycle-transitions.rkt
@@ -6,15 +6,15 @@
 ;; These functions are pure state transitions: given data inputs,
 ;; they produce data outputs without I/O side effects.
 
-(require (only-in "../util/protocol-types.rkt"
+(require (only-in "../util/message.rkt"
                   make-message
-                  make-text-part
                   message?
                   message-id
                   message-kind
                   message-parent-id
                   message-role
                   message-content)
+         (only-in "../util/content-parts.rkt" make-text-part)
          (only-in "../util/ids.rkt" generate-id now-seconds)
          (only-in "../runtime/session-index.rkt" active-leaf)
          racket/list

--- a/util/protocol-types.rkt
+++ b/util/protocol-types.rkt
@@ -14,10 +14,12 @@
 ;;
 ;; This file re-exports everything for backward compatibility.
 ;;
-;; TRANSITIONAL (I2 v0.72.5): Remaining direct consumers:
-;;   - runtime/iteration/retry-policy.rkt
-;;   - tui/render.rkt
-;; Consider migrating these to import from specific sub-modules.
+;; TRANSITIONAL (I2 v0.72.5): New code should import from specific sub-modules.
+;; v0.80.4 migrated: cli/render.rkt, runtime/iteration/retry-policy.rkt,
+;;   runtime/session-lifecycle-transitions.rkt, interfaces/json-mode.rkt,
+;;   interfaces/rpc-mode.rkt, extensions/events.rkt
+;; Remaining consumers: ~88 files in tui/, extensions/, interfaces/.
+;; Target: remove this facade in v0.82+ after all consumers migrated.
 
 (require "content-parts.rkt"
          "message.rkt"


### PR DESCRIPTION
Migrate 6 consumers from protocol-types facade to direct imports. Updated deprecation notice.\n\nCloses #6601