### PR TITLE
v0.80.4 W3: Protocol-Types Migration (8 more consumers)

### DIFF
--- a/agent/event-bus.rkt
+++ b/agent/event-bus.rkt
@@ -13,7 +13,6 @@
 
 (require racket/contract
          racket/match
-         "../util/protocol-types.rkt"
          "../util/event.rkt"
          "event-types.rkt")
 

--- a/agent/wait-idle.rkt
+++ b/agent/wait-idle.rkt
@@ -7,7 +7,7 @@
 ;; Lives in agent/ because it depends on agent/event-bus.
 
 (require racket/contract
-         "../util/protocol-types.rkt"
+         (only-in "../util/event.rkt" event-ev event-session-id)
          "event-bus.rkt")
 
 (provide (contract-out [wait-for-idle! (->* (event-bus? string?) ((or/c #f number?)) any)]))

--- a/extensions/loader.rkt
+++ b/extensions/loader.rkt
@@ -19,7 +19,7 @@
          racket/port
          racket/string
          json
-         "../util/protocol-types.rkt"
+         (only-in "../util/event.rkt" make-event)
          "../agent/event-bus.rkt"
          "api.rkt"
          "../util/checksum.rkt"

--- a/extensions/message-inject.rkt
+++ b/extensions/message-inject.rkt
@@ -19,7 +19,9 @@
 (require racket/contract
          "event-api.rkt"
          "api.rkt"
-         "../util/protocol-types.rkt"
+         (only-in "../util/event.rkt" make-event)
+         (only-in "../util/message.rkt" make-message message?)
+         (only-in "../util/content-parts.rkt" make-text-part)
          "../util/ids.rkt"
          "../util/event.rkt")
 

--- a/extensions/widget-api.rkt
+++ b/extensions/widget-api.rkt
@@ -11,7 +11,7 @@
 (require racket/contract
          racket/match
          "api.rkt"
-         "../util/protocol-types.rkt"
+         (only-in "../util/event.rkt" event-payload)
          "ui-surface.rkt")
 
 ;; Widget API — uses ui-state box for state updates

--- a/interfaces/sdk-compat.rkt
+++ b/interfaces/sdk-compat.rkt
@@ -16,7 +16,8 @@
          racket/file
          racket/math
          racket/list
-         "../util/protocol-types.rkt"
+         (only-in "../util/tree-entries.rkt" make-branch-entry make-tree-navigation-entry)
+         (only-in "../util/message.rkt" message-id)
          (prefix-in session: "../runtime/agent-session.rkt")
          (only-in "../runtime/compactor.rkt"
                   compact-history

--- a/interfaces/sdk-core.rkt
+++ b/interfaces/sdk-core.rkt
@@ -18,7 +18,9 @@
          (only-in "../tools/tool.rkt" make-tool-registry tool-registry?)
          (only-in "../tools/registry-defaults.rkt" register-default-tools!)
          "../agent/event-bus.rkt"
-         "../util/protocol-types.rkt"
+         (only-in "../util/loop-result.rkt" loop-result)
+         (only-in "../util/event.rkt" make-event)
+         (only-in "../util/message.rkt" message?)
          (prefix-in session: "../runtime/agent-session.rkt")
          (only-in "../runtime/turn-orchestrator.rkt" register-session-extensions!)
          (only-in "../runtime/compactor.rkt"

--- a/interfaces/sdk-public.rkt
+++ b/interfaces/sdk-public.rkt
@@ -96,7 +96,7 @@
          (only-in "../runtime/provider-factory.rkt" build-provider)
          (only-in "../agent/event-bus.rkt" make-event-bus event-bus? subscribe! publish!)
          (only-in "../util/event.rkt" event?)
-         (only-in "../util/protocol-types.rkt" message?)
+         (only-in "../util/message.rkt" message?)
          (only-in "../extensions/api.rkt"
                   make-extension-registry
                   register-extension!


### PR DESCRIPTION
Migrate 8 more consumers from protocol-types facade to direct imports. Total: 14 migrated, ~80 remaining.\n\nCloses #6603