### PR TITLE
v0.80.5 W2: Session Config Regression Guards

### DIFF
--- a/tests/test-session-config-helpers.rkt
+++ b/tests/test-session-config-helpers.rkt
@@ -4,11 +4,26 @@
 ;; Part of v0.80.5 Polish Sweep
 
 (require rackunit
-         racket/contract)
+         racket/contract
+         "../runtime/session-config.rkt"
+         "../runtime/session-types.rkt")
 
-;; Placeholder — W2 will add real tests
-(test-case "placeholder: session config helpers test suite loads"
-  (check-true #t))
+(test-case "session-config: hash->session-config creates config"
+  (define cfg (hash->session-config (hasheq 'model "test-model")))
+  (check-pred session-config? cfg))
+
+(test-case "session-config: round-trip hash conversion"
+  (define h (hasheq 'model "test-model" 'provider 'openai))
+  (define cfg (hash->session-config h))
+  (define h2 (session-config->hash cfg))
+  (check-equal? (hash-ref h2 'model) "test-model"))
+
+(test-case "session-config: config-model-name accessor works"
+  (define cfg (hash->session-config (hasheq 'model-name "test-model")))
+  (check-equal? (config-model-name cfg) "test-model"))
+
+(test-case "agent-session: predicate exists and is a procedure"
+  (check-pred procedure? agent-session?))
 
 (module+ main
   (require rackunit/text-ui)


### PR DESCRIPTION
Add 4 regression tests for session-config and session-types. Deferred T3-2/3/4 refactor to v0.82+.\n\nCloses #6607