### PR TITLE
v0.81.0 W1: Azure OpenAI SSE Dedup

### DIFF
--- a/llm/azure-openai.rkt
+++ b/llm/azure-openai.rkt
@@ -19,7 +19,6 @@
          "timing.rkt"
          (only-in "model-defaults.rkt" OPENAI-DEFAULT-MODEL)
          racket/string
-         racket/generator
          racket/port
          json
          net/url
@@ -119,69 +118,37 @@
   (define body-bytes (jsexpr->bytes body))
   (define response-port-box (box #f))
   (log-stream-setup-timing "azure" _stream-t0)
-  (dynamic-wind
-   (lambda () (void))
-   (lambda ()
-     (call-with-request-timeout
-      #:cleanup (lambda ()
+  (dynamic-wind (lambda () (void))
+                (lambda ()
+                  (call-with-request-timeout
+                   #:cleanup (lambda ()
+                               (define rp (unbox response-port-box))
+                               (when rp
+                                 (with-logged-error "port cleanup" (close-input-port rp))))
+                   (lambda ()
+                     (define-values (status-line response-headers response-port)
+                       (if url-port-val
+                           (http-sendrecv host
+                                          path-str
+                                          #:port url-port-val
+                                          #:ssl? ssl?
+                                          #:method "POST"
+                                          #:headers headers
+                                          #:data body-bytes)
+                           (http-sendrecv host
+                                          path-str
+                                          #:ssl? ssl?
+                                          #:method "POST"
+                                          #:headers headers
+                                          #:data body-bytes)))
+                     (set-box! response-port-box response-port)
+                     (check-azure-status! status-line #"")
+                     ;; v0.81.0 W1: Replaced inline SSE loop with shared stream-sse-events.
+                     ;; Bonus: now handles tool_calls deltas (was missing in inline version).
+                     (stream-sse-events response-port
+                                        (lambda (parsed) (list (normalize-openai-chunk parsed)))))))
+                (lambda ()
+                  ;; W2.4: always close response port on exit
                   (define rp (unbox response-port-box))
                   (when rp
-                    (with-logged-error "port cleanup" (close-input-port rp))))
-      (lambda ()
-        (define-values (status-line response-headers response-port)
-          (if url-port-val
-              (http-sendrecv host
-                             path-str
-                             #:port url-port-val
-                             #:ssl? ssl?
-                             #:method "POST"
-                             #:headers headers
-                             #:data body-bytes)
-              (http-sendrecv host
-                             path-str
-                             #:ssl? ssl?
-                             #:method "POST"
-                             #:headers headers
-                             #:data body-bytes)))
-        (set-box! response-port-box response-port)
-        (check-azure-status! status-line #"")
-        (in-generator
-         (let loop ()
-           (define line (read-line/timeout response-port))
-           (cond
-             [(eq? line #f) (void)] ; read timeout
-             [(eof-object? line) (void)]
-             [(string-prefix? line "data: ")
-              (define data (string-trim (substring line 6)))
-              (cond
-                ;; W2.3: proper done chunk
-                [(string=? data "[DONE]") (yield (make-stream-chunk #f #f #f #t))]
-                [else
-                 (define js (with-safe-fallback #f (string->jsexpr data)))
-                 (when js
-                   (define choices (hash-ref js 'choices '()))
-                   (when (pair? choices)
-                     (define first-choice (car choices))
-                     (define delta (hash-ref first-choice 'delta (hasheq)))
-                     (define text (hash-ref delta 'content ""))
-                     ;; W2.3: extract finish-reason and usage from chunks
-                     (define finish-reason
-                       (let ([fr (hash-ref first-choice 'finish_reason #f)])
-                         (and (string? fr) (translate-stop-reason #f fr))))
-                     (define usage
-                       (let ([u (hash-ref js 'usage #f)])
-                         (and u
-                              (hasheq 'prompt-tokens
-                                      (hash-ref u 'prompt_tokens 0)
-                                      'completion-tokens
-                                      (hash-ref u 'completion_tokens 0)
-                                      'total-tokens
-                                      (hash-ref u 'total_tokens 0)))))
-                     (yield (make-stream-chunk text #f usage #f #:finish-reason finish-reason))))
-                 (loop)])]
-             [else (loop)]))))))
-   (lambda ()
-     ;; W2.4: always close response port on exit
-     (define rp (unbox response-port-box))
-     (when rp
-       (with-logged-error "port cleanup" (close-input-port rp))))))
+                    (with-logged-error "port cleanup" (close-input-port rp))))))

--- a/tests/test-sse-shared-azure.rkt
+++ b/tests/test-sse-shared-azure.rkt
@@ -3,7 +3,63 @@
 ;; test-sse-shared-azure.rkt — Tests for Azure OpenAI SSE dedup (W1)
 ;; Part of v0.81.0
 
-(require rackunit)
+(require rackunit
+         racket/port
+         racket/generator
+         "../llm/model.rkt"
+         (only-in "../llm/stream.rkt" stream-sse-events normalize-openai-chunk))
 
-(test-case "sse-shared-azure: placeholder"
-  (check-true #t "placeholder — W1 will add real tests"))
+(test-case "normalize-openai-chunk: text delta"
+  (define chunk
+    (normalize-openai-chunk
+     (hasheq 'choices (list (hasheq 'delta (hasheq 'content "hello") 'finish_reason #f)))))
+  (check-pred stream-chunk? chunk)
+  (check-equal? (stream-chunk-delta-text chunk) "hello")
+  (check-false (stream-chunk-done? chunk)))
+
+(test-case "normalize-openai-chunk: finish_reason triggers done"
+  (define chunk
+    (normalize-openai-chunk
+     (hasheq 'choices (list (hasheq 'delta (hasheq 'content "") 'finish_reason "stop")))))
+  (check-pred stream-chunk? chunk)
+  (check-equal? (stream-chunk-finish-reason chunk) "stop")
+  (check-true (stream-chunk-done? chunk)))
+
+(test-case "normalize-openai-chunk: usage extraction"
+  (define chunk
+    (normalize-openai-chunk
+     (hasheq 'choices
+             (list (hasheq 'delta (hasheq) 'finish_reason "stop"))
+             'usage
+             (hasheq 'prompt_tokens 10 'completion_tokens 20 'total_tokens 30))))
+  (check-pred stream-chunk? chunk)
+  (define usage (stream-chunk-usage chunk))
+  (check-equal? (hash-ref usage 'prompt_tokens) 10)
+  (check-equal? (hash-ref usage 'completion_tokens) 20))
+
+(test-case "normalize-openai-chunk: tool_calls delta (was missing in Azure inline)"
+  (define chunk
+    (normalize-openai-chunk
+     (hasheq
+      'choices
+      (list (hasheq
+             'delta
+             (hasheq 'tool_calls
+                     (list (hasheq 'id "call_123" 'function (hasheq 'name "read" 'arguments ""))))
+             'finish_reason
+             #f)))))
+  (check-pred stream-chunk? chunk)
+  (check-not-false (stream-chunk-delta-tool-call chunk) "tool_calls now captured"))
+
+(test-case "stream-sse-events: processes port through normalize-openai-chunk"
+  (define port
+    (open-input-string
+     (string-append
+      "data: {\"choices\":[{\"delta\":{\"content\":\"hi\"},\"finish_reason\":null}]}\n\n"
+      "data: [DONE]\n\n")))
+  (define gen (stream-sse-events port (lambda (parsed) (list (normalize-openai-chunk parsed)))))
+  (define chunks
+    (for/list ([ch (in-producer gen #f)])
+      ch))
+  (check-equal? (length chunks) 1)
+  (check-equal? (stream-chunk-delta-text (car chunks)) "hi"))


### PR DESCRIPTION
Replace Azure inline SSE loop with shared stream-sse-events. 5 new tests. Tool_calls deltas now work for Azure.\n\nCloses #6631