### PR TITLE
refactor(v0.81.1): migrate bare protocol-types imports

### DIFF
--- a/agent/loop-messages.rkt
+++ b/agent/loop-messages.rkt
@@ -12,7 +12,20 @@
          racket/list
          racket/set
          racket/match
-         "../util/protocol-types.rkt"
+         (only-in "../util/content-parts.rkt"
+                  text-part
+                  text-part-text
+                  text-part?
+                  tool-call-part
+                  tool-call-part-arguments
+                  tool-call-part-id
+                  tool-call-part-name
+                  tool-call-part?
+                  tool-result-part
+                  tool-result-part-content
+                  tool-result-part-tool-call-id
+                  tool-result-part?)
+         (only-in "../util/message.rkt" message message-content message-role message?)
          (only-in "../util/content-helpers.rkt" result-content->string)
          (only-in "../util/hook-types.rkt" hook-result? hook-result-action hook-result-payload))
 

--- a/agent/loop-phases.rkt
+++ b/agent/loop-phases.rkt
@@ -11,7 +11,7 @@
          racket/match
          racket/list
          "../util/ids.rkt"
-         "../util/protocol-types.rkt"
+         (only-in "../util/loop-result.rkt" loop-result)
          "../llm/model.rkt"
          "../llm/token-budget.rkt"
          (only-in "../llm/provider.rkt" provider-name provider?)

--- a/agent/loop-stream.rkt
+++ b/agent/loop-stream.rkt
@@ -16,7 +16,16 @@
          "../llm/model.rkt"
          "streaming-message.rkt"
          "state.rkt"
-         "../util/protocol-types.rkt"
+         (only-in "../util/content-parts.rkt"
+                  make-text-part
+                  make-tool-call-part
+                  text-part
+                  text-part-text
+                  tool-call-part-arguments
+                  tool-call-part-id
+                  tool-call-part-name)
+         (only-in "../util/loop-result.rkt" make-loop-result)
+         (only-in "../util/message.rkt" make-message message message-id)
          "../util/ids.rkt"
          (only-in "../util/cancellation.rkt" cancellation-token? cancellation-token-cancelled?)
          (only-in "../util/hook-types.rkt" hook-result? hook-result-action hook-result-payload)

--- a/agent/loop.rkt
+++ b/agent/loop.rkt
@@ -38,7 +38,8 @@
          racket/date
          racket/set
          "../util/ids.rkt"
-         "../util/protocol-types.rkt"
+         (only-in "../util/loop-result.rkt" loop-result loop-result?)
+         (only-in "../util/message.rkt" message message?)
          "event-bus.rkt"
          "state.rkt"
          "../llm/model.rkt"
@@ -81,8 +82,7 @@
                   phase-pre-hook
                   phase-msg-hook
                   phase-stream)
-         (only-in "loop-dispatch.rkt"
-                  run-streaming-phase))
+         (only-in "loop-dispatch.rkt" run-streaming-phase))
 
 (provide (contract-out [run-agent-turn
                         (->i ([ctx (listof message?)] [prov provider?] [bus event-bus?])
@@ -189,12 +189,12 @@
       [_
        ;; v0.46.10 (I-1): Streaming dispatch extracted to run-streaming-phase
        (run-streaming-phase provider
-                                 req
-                                 bus
-                                 session-id
-                                 turn-id
-                                 st
-                                 raw-messages
-                                 tools
-                                 hook-dispatcher
-                                 cancellation-token)])))
+                            req
+                            bus
+                            session-id
+                            turn-id
+                            st
+                            raw-messages
+                            tools
+                            hook-dispatcher
+                            cancellation-token)])))

--- a/agent/stream-runner.rkt
+++ b/agent/stream-runner.rkt
@@ -11,7 +11,8 @@
          "../llm/provider.rkt"
          "streaming-message.rkt"
          "state.rkt"
-         "../util/protocol-types.rkt"
+         (only-in "../util/content-parts.rkt" make-text-part)
+         (only-in "../util/message.rkt" make-message message message-id)
          "../util/ids.rkt"
          (only-in "../util/cancellation.rkt" cancellation-token? cancellation-token-cancelled?)
          (only-in "../util/hook-types.rkt" hook-result? hook-result-action hook-result-payload)

--- a/benchmarks/run.rkt
+++ b/benchmarks/run.rkt
@@ -19,10 +19,12 @@
          "metrics.rkt"
          "../llm/model.rkt"
          "../llm/provider.rkt"
-         (only-in "../tools/tool.rkt"
-                  make-tool-registry)
+         (only-in "../tools/tool.rkt" make-tool-registry)
          "../agent/event-bus.rkt"
-         "../util/protocol-types.rkt"
+         (only-in "../util/content-parts.rkt" text-part text-part-text text-part?)
+         (only-in "../util/event.rkt" event-event event-payload make-event)
+         (only-in "../util/loop-result.rkt" loop-result loop-result-messages loop-result?)
+         (only-in "../util/message.rkt" message-content message-role)
          "../interfaces/sdk.rkt")
 
 (provide run-benchmarks)
@@ -47,12 +49,10 @@
       [(session-resume)
        "Session resumed. Previous context: we discussed the event-bus module, its publish/subscribe pattern, and how subscribers can filter events by predicate."]
       [else "Acknowledged."]))
-  (make-mock-provider
-   (make-model-response
-    (list (hasheq 'type "text" 'text response-text))
-    (hasheq 'inputTokens 10 'outputTokens 20)
-    "benchmark-mock"
-    'stop)))
+  (make-mock-provider (make-model-response (list (hasheq 'type "text" 'text response-text))
+                                           (hasheq 'inputTokens 10 'outputTokens 20)
+                                           "benchmark-mock"
+                                           'stop)))
 
 ;; ============================================================
 ;; Run a single task
@@ -71,10 +71,8 @@
   (subscribe! bus
               (lambda (evt)
                 (case (event-event evt)
-                  [("turn.completed")
-                   (set-box! turn-count (add1 (unbox turn-count)))]
-                  [("tool.call.started")
-                   (set-box! tool-call-count (add1 (unbox tool-call-count)))]
+                  [("turn.completed") (set-box! turn-count (add1 (unbox turn-count)))]
+                  [("tool.call.started") (set-box! tool-call-count (add1 (unbox tool-call-count)))]
                   [("model.stream.completed")
                    (define usage (hash-ref (event-payload evt) 'usage (hasheq)))
                    (define out-tok (hash-ref usage 'outputTokens 0))
@@ -84,12 +82,8 @@
 
   (define start-ms (current-inexact-milliseconds))
   (define output
-    (with-handlers ([exn:fail?
-                     (lambda (e)
-                       (format "ERROR: ~a" (exn-message e)))])
-      (define rt (make-runtime #:provider prov
-                               #:session-dir tmp-dir
-                               #:event-bus bus))
+    (with-handlers ([exn:fail? (lambda (e) (format "ERROR: ~a" (exn-message e)))])
+      (define rt (make-runtime #:provider prov #:session-dir tmp-dir #:event-bus bus))
       (define rt-opened (open-session rt))
       (define-values (_rt-final result) (run-prompt! rt-opened (benchmark-task-prompt task)))
       ;; Extract text from result
@@ -97,16 +91,14 @@
         [(loop-result? result)
          (define msgs (loop-result-messages result))
          ;; Get last assistant message text
-         (define assistant-msgs
-           (filter (lambda (m) (eq? (message-role m) 'assistant)) msgs))
+         (define assistant-msgs (filter (lambda (m) (eq? (message-role m) 'assistant)) msgs))
          (if (null? assistant-msgs)
              "(no assistant response)"
              (let ([last-msg (last assistant-msgs)])
-               (string-join
-                (for/list ([p (in-list (message-content last-msg))]
-                           #:when (text-part? p))
-                  (text-part-text p))
-                "")))]
+               (string-join (for/list ([p (in-list (message-content last-msg))]
+                                       #:when (text-part? p))
+                              (text-part-text p))
+                            "")))]
         [(string? result) result]
         [else (format "~a" result)])))
 
@@ -117,11 +109,12 @@
     (delete-directory/files tmp-dir #:must-exist? #f))
 
   (define status (if (string-prefix? output "ERROR:") 'error 'completed))
-  (define m (make-metrics #:status status
-                          #:elapsed-ms elapsed-ms
-                          #:turns (unbox turn-count)
-                          #:tool-calls (unbox tool-call-count)
-                          #:tokens (unbox token-total)))
+  (define m
+    (make-metrics #:status status
+                  #:elapsed-ms elapsed-ms
+                  #:turns (unbox turn-count)
+                  #:tool-calls (unbox tool-call-count)
+                  #:tokens (unbox token-total)))
   (task-result task m output))
 
 ;; ============================================================
@@ -132,11 +125,11 @@
   (displayln "")
   (displayln "=== Benchmark Results ===")
   (displayln (format "~a~a~a~a~a"
-                      (pad-right "Task" 22)
-                      (pad-right "Status" 10)
-                      (pad-right "Time" 10)
-                      (pad-right "Turns" 7)
-                      (pad-right "Valid" 8)))
+                     (pad-right "Task" 22)
+                     (pad-right "Status" 10)
+                     (pad-right "Time" 10)
+                     (pad-right "Turns" 7)
+                     (pad-right "Valid" 8)))
   (displayln (make-string 57 #\-))
   (for ([r results])
     (define m (task-result-metrics r))
@@ -154,7 +147,8 @@
   (define total (length results))
   (displayln "")
   (printf "Total: ~a tasks, ~a passed, ~a failed, ~a errors\n"
-          total pass-count
+          total
+          pass-count
           (count (lambda (r) (eq? (validate-task-result r) 'fail)) results)
           (count (lambda (r) (eq? (validate-task-result r) 'error)) results))
   (printf "Total time: ~ams\n" total-ms)
@@ -188,7 +182,7 @@
   (define args (vector->list (current-command-line-arguments)))
   (define verbose? (member "--verbose" args))
   (define real-mode? (member "--real" args))
-  (define provider #f)  ;; #f = mock mode (default)
+  (define provider #f) ;; #f = mock mode (default)
 
   (when real-mode?
     (displayln "WARNING: --real mode requires a configured provider."))
@@ -203,4 +197,6 @@
 
 (define (pad-right s len)
   (define pad (- len (string-length s)))
-  (if (> pad 0) (string-append s (make-string pad #\space)) s))
+  (if (> pad 0)
+      (string-append s (make-string pad #\space))
+      s))

--- a/cli/inspect.rkt
+++ b/cli/inspect.rkt
@@ -13,7 +13,20 @@
          racket/list
          racket/string
          racket/format
-         "../util/protocol-types.rkt"
+         (only-in "../util/content-parts.rkt"
+                  tool-call-part
+                  tool-call-part-arguments
+                  tool-call-part-name
+                  tool-call-part?
+                  tool-result-part
+                  tool-result-part-is-error?
+                  tool-result-part?)
+         (only-in "../util/message.rkt"
+                  message-content
+                  message-meta-safe
+                  message-parent-id
+                  message-role
+                  message-timestamp)
          "../runtime/session-store.rkt")
 
 (require racket/contract)

--- a/cli/replay.rkt
+++ b/cli/replay.rkt
@@ -17,7 +17,17 @@
          racket/match
          racket/string
          racket/format
-         "../util/protocol-types.rkt"
+         (only-in "../util/content-parts.rkt"
+                  tool-call-part
+                  tool-call-part-arguments
+                  tool-call-part-id
+                  tool-call-part-name
+                  tool-call-part?
+                  tool-result-part
+                  tool-result-part-content
+                  tool-result-part-tool-call-id
+                  tool-result-part?)
+         (only-in "../util/message.rkt" message-content message-timestamp)
          "../runtime/session-store.rkt")
 
 (require racket/contract)

--- a/examples/extensions/typed-event-observer.rkt
+++ b/examples/extensions/typed-event-observer.rkt
@@ -9,29 +9,31 @@
 
 (require "../../agent/event-bus.rkt"
          "../../agent/event-types.rkt"
-         "../../util/protocol-types.rkt")
+         (only-in "../../util/event.rkt" event event-ev event-payload))
 
 ;; Start an observer that logs all events on the bus.
 ;; Returns subscription ID for cleanup.
 (define (start-observer! bus)
-  (subscribe!
-   bus
-   (lambda (evt)
-     (define ev-name (event-ev evt))
-     (define payload (event-payload evt))
-     (printf "[event] ~a | payload keys: ~a\n"
-             ev-name
-             (if (hash? payload) (hash-keys payload) '())))
-   #:filter (lambda (evt) #t)))
+  (subscribe! bus
+              (lambda (evt)
+                (define ev-name (event-ev evt))
+                (define payload (event-payload evt))
+                (printf "[event] ~a | payload keys: ~a\n"
+                        ev-name
+                        (if (hash? payload)
+                            (hash-keys payload)
+                            '())))
+              #:filter (lambda (evt) #t)))
 
 ;; Demonstrate publishing a typed event through the bus bridge.
 ;; The typed event is converted to a raw event internally.
 (define (demo-typed-emit! bus session-id turn-id)
   ;; Create a typed turn-start event
-  (define te (make-turn-start-event #:session-id session-id
-                                     #:turn-id turn-id
-                                     #:model "gpt-4"
-                                     #:provider "openai"))
+  (define te
+    (make-turn-start-event #:session-id session-id
+                           #:turn-id turn-id
+                           #:model "gpt-4"
+                           #:provider "openai"))
   ;; Emit via the typed bridge
   (define raw-evt (bus-emit-typed! bus te))
   ;; The raw event now has the typed event's type as event name

--- a/runtime/auto-retry.rkt
+++ b/runtime/auto-retry.rkt
@@ -8,7 +8,6 @@
 (require racket/contract
          racket/match
          racket/string
-         "../util/protocol-types.rkt"
          "../llm/provider-errors.rkt")
 
 ;; Predicates

--- a/runtime/compaction-hooks.rkt
+++ b/runtime/compaction-hooks.rkt
@@ -17,7 +17,7 @@
          racket/list
          racket/match
          (only-in "../util/event.rkt" event?)
-         "../util/protocol-types.rkt"
+         (only-in "../util/event.rkt" event event? make-event)
          "../util/hook-types.rkt"
          "../agent/event-bus.rkt"
          "compactor.rkt"

--- a/runtime/compactor.rkt
+++ b/runtime/compactor.rkt
@@ -22,7 +22,22 @@
          racket/string
          racket/list
          racket/set
-         "../util/protocol-types.rkt"
+         (only-in "../util/content-parts.rkt"
+                  make-text-part
+                  text-part
+                  text-part-text
+                  text-part?
+                  tool-call-part
+                  tool-call-part-arguments
+                  tool-call-part-name
+                  tool-call-part?)
+         (only-in "../util/message.rkt"
+                  make-message
+                  message-content
+                  message-id
+                  message-kind
+                  message-meta-safe
+                  message-role)
          (only-in "../util/time.rkt" now-epoch-ms)
          "../util/message-helpers.rkt"
          (only-in "../util/telemetry.rkt" with-telemetry)
@@ -127,7 +142,8 @@
 ;;                  'modifiedFiles -> list of paths.
 (define (extract-file-tracker messages)
   (define-values (reads writes)
-    (for*/fold ([reads (set)] [writes (set)])
+    (for*/fold ([reads (set)]
+                [writes (set)])
                ([m (in-list messages)]
                 [part (in-list (message-content m))])
       (cond
@@ -172,11 +188,13 @@
 ;; #768: Merge two file trackers, deduplicating file paths.
 (define (merge-file-trackers . trackers)
   (define-values (all-reads all-writes)
-    (for*/fold ([reads (set)] [writes (set)])
+    (for*/fold ([reads (set)]
+                [writes (set)])
                ([ft (in-list trackers)])
-      (values
-       (for/fold ([r reads]) ([path (in-list (hash-ref ft 'readFiles '()))]) (set-add r path))
-       (for/fold ([w writes]) ([path (in-list (hash-ref ft 'modifiedFiles '()))]) (set-add w path)))))
+      (values (for/fold ([r reads]) ([path (in-list (hash-ref ft 'readFiles '()))])
+                (set-add r path))
+              (for/fold ([w writes]) ([path (in-list (hash-ref ft 'modifiedFiles '()))])
+                (set-add w path)))))
   (hasheq 'readFiles (set->list all-reads) 'modifiedFiles (set->list all-writes)))
 
 ;; ============================================================

--- a/runtime/context-policy.rkt
+++ b/runtime/context-policy.rkt
@@ -13,7 +13,21 @@
          racket/list
          racket/string
          racket/set
-         "../util/protocol-types.rkt"
+         (only-in "../util/content-parts.rkt"
+                  text-part
+                  text-part-text
+                  text-part?
+                  tool-call-part
+                  tool-call-part?)
+         (only-in "../util/message.rkt"
+                  message
+                  message-content
+                  message-id
+                  message-kind
+                  message-meta-safe
+                  message-parent-id
+                  message-role
+                  message?)
          (only-in "../util/message.rkt" message-meta-safe)
          "../llm/token-budget.rkt"
          "../util/token-estimate-cache.rkt")

--- a/runtime/context-summary.rkt
+++ b/runtime/context-summary.rkt
@@ -10,7 +10,8 @@
          racket/match
          racket/string
          racket/list
-         "../util/protocol-types.rkt"
+         (only-in "../util/content-parts.rkt" text-part text-part-text text-part?)
+         (only-in "../util/message.rkt" message message-content message-id message-role message?)
          "../util/string-helpers.rkt"
          "../llm/token-budget.rkt"
          (only-in "../runtime/compaction-prompts.rkt" format-messages-for-summary)

--- a/runtime/ctx-compact.rkt
+++ b/runtime/ctx-compact.rkt
@@ -17,7 +17,8 @@
          "../agent/event-bus.rkt"
          "../runtime/compactor.rkt"
          "../runtime/compaction-hooks.rkt"
-         "../util/protocol-types.rkt")
+         (only-in "../util/content-parts.rkt" make-text-part)
+         (only-in "../util/message.rkt" make-message))
 
 ;; Compact request struct
 (provide ctx-compact-request

--- a/runtime/cutpoint-rules.rkt
+++ b/runtime/cutpoint-rules.rkt
@@ -19,7 +19,8 @@
 (require racket/contract
          racket/list
          racket/match
-         "../util/protocol-types.rkt"
+         (only-in "../util/content-parts.rkt" make-text-part)
+         (only-in "../util/message.rkt" make-message message message-role)
          "../util/message-helpers.rkt"
          (only-in "../util/ids.rkt" generate-id)
          "compactor.rkt")

--- a/runtime/session-migration.rkt
+++ b/runtime/session-migration.rkt
@@ -21,7 +21,15 @@
          racket/file
          json
          "../util/jsonl.rkt"
-         "../util/protocol-types.rkt"
+         (only-in "../util/entry-predicates.rkt" session-info-entry?)
+         (only-in "../util/message.rkt"
+                  jsexpr->message
+                  make-message
+                  message
+                  message->jsexpr
+                  message-kind
+                  message-meta-safe
+                  message?)
          (only-in "../util/ids.rkt" generate-id)
          (only-in "../util/errors.rkt" with-logged-catch raise-session-error))
 

--- a/runtime/session-store-integrity.rkt
+++ b/runtime/session-store-integrity.rkt
@@ -20,7 +20,6 @@
          racket/port
          file/sha1
          json
-         "../util/protocol-types.rkt"
          "../util/jsonl.rkt"
          (only-in "../util/message-helpers.rkt" ensure-parent-dirs!))
 

--- a/runtime/session-store-tree.rkt
+++ b/runtime/session-store-tree.rkt
@@ -12,7 +12,7 @@
 
 (require racket/contract
          racket/function
-         "../util/protocol-types.rkt")
+         (only-in "../util/message.rkt" message message-id message-kind message-parent-id message?))
 
 ;; Runtime parameters — set by session-store.rkt on load
 (define current-load-session-log (make-parameter #f))

--- a/runtime/session-store.rkt
+++ b/runtime/session-store.rkt
@@ -27,7 +27,17 @@
                   task-conclusion?
                   conclusion->hash
                   hash->conclusion)
-         "../util/protocol-types.rkt"
+         (only-in "../util/content-parts.rkt" make-text-part text-part-text)
+         (only-in "../util/message.rkt"
+                  jsexpr->message
+                  make-message
+                  message
+                  message->jsexpr
+                  message-content
+                  message-id
+                  message-kind
+                  message-parent-id
+                  message?)
          "../util/jsonl.rkt"
          (only-in "../util/message-helpers.rkt" ensure-parent-dirs!)
          (only-in "../util/ids.rkt" generate-id)

--- a/runtime/session-store/in-memory.rkt
+++ b/runtime/session-store/in-memory.rkt
@@ -4,7 +4,12 @@
 ;; Extracted from session-store.rkt (W3 v0.72.5)
 
 (require racket/match
-         "../../util/protocol-types.rkt")
+         (only-in "../../util/custom-entries.rkt"
+                  custom-entry-extension
+                  custom-entry-key
+                  custom-entry?
+                  make-custom-entry)
+         (only-in "../../util/message.rkt" message-id))
 
 (provide in-memory-session-manager?
          in-memory-session-manager

--- a/runtime/session-store/versioning.rkt
+++ b/runtime/session-store/versioning.rkt
@@ -7,7 +7,11 @@
          racket/match
          racket/file
          json
-         "../../util/protocol-types.rkt"
+         (only-in "../../util/message.rkt"
+                  jsexpr->message
+                  make-message
+                  message->jsexpr
+                  message-meta-safe)
          "../../util/jsonl.rkt"
          (only-in "../../util/message-helpers.rkt" ensure-parent-dirs!)
          (only-in "../../util/ids.rkt" generate-id)

--- a/runtime/session-switch.rkt
+++ b/runtime/session-switch.rkt
@@ -20,7 +20,6 @@
          "../agent/event-bus.rkt"
          "../agent/event-emitter.rkt"
          "../agent/event-structs/session-events.rkt"
-         "../util/protocol-types.rkt"
          (only-in "../util/errors.rkt" raise-extension-error))
 
 ;; #704: Teardown

--- a/runtime/split-turn.rkt
+++ b/runtime/split-turn.rkt
@@ -21,7 +21,8 @@
 (require racket/contract
          racket/list
          racket/string
-         "../util/protocol-types.rkt")
+         (only-in "../util/content-parts.rkt" text-part text-part-text text-part?)
+         (only-in "../util/message.rkt" message-content message-kind message-role))
 
 (provide split-turn-result
          split-turn-result?

--- a/runtime/token-compaction.rkt
+++ b/runtime/token-compaction.rkt
@@ -17,7 +17,6 @@
 
 (require racket/contract
          racket/list
-         "../util/protocol-types.rkt"
          "../llm/token-budget.rkt"
          "context-policy.rkt")
 

--- a/runtime/trace-logger.rkt
+++ b/runtime/trace-logger.rkt
@@ -12,7 +12,14 @@
          racket/file
          racket/class
          "../agent/event-bus.rkt"
-         "../util/protocol-types.rkt"
+         (only-in "../util/event.rkt"
+                  event
+                  event-ev
+                  event-payload
+                  event-session-id
+                  event-time
+                  event-turn-id
+                  event?)
          "trace-sink.rkt")
 
 (provide (contract-out

--- a/tui/commands.rkt
+++ b/tui/commands.rkt
@@ -22,7 +22,6 @@
                   parsed-command-args
                   parsed-command-arg-kind)
          "palette.rkt"
-         "../util/protocol-types.rkt"
          "../agent/event-bus.rkt"
          "../extensions/hooks.rkt"
          "../extensions/api.rkt"

--- a/tui/commands/branch.rkt
+++ b/tui/commands/branch.rkt
@@ -11,7 +11,7 @@
          "../render.rkt"
          "../terminal.rkt"
          "../tree-view.rkt"
-         "../../util/protocol-types.rkt"
+         (only-in "../../util/message.rkt" message-id message-parent-id message-role)
          "../../runtime/session-index.rkt"
          "context.rkt")
 

--- a/tui/commands/extension.rkt
+++ b/tui/commands/extension.rkt
@@ -10,7 +10,6 @@
          racket/file
          racket/path
          "../state.rkt"
-         "../../util/protocol-types.rkt"
          "../../agent/event-bus.rkt"
          "../../runtime/extension-catalog.rkt"
          "../../extensions/hooks.rkt"

--- a/tui/commands/model.rkt
+++ b/tui/commands/model.rkt
@@ -6,7 +6,7 @@
 ;; Handles /model [list|<name>] for model listing and switching.
 
 (require "../state.rkt"
-         "../../util/protocol-types.rkt"
+         (only-in "../../util/event.rkt" make-event)
          "../../agent/event-bus.rkt"
          "../../runtime/model-registry.rkt"
          "context.rkt")

--- a/tui/commands/runtime-control.rkt
+++ b/tui/commands/runtime-control.rkt
@@ -9,7 +9,7 @@
          racket/string
          racket/system
          "../state.rkt"
-         "../../util/protocol-types.rkt"
+         (only-in "../../util/event.rkt" make-event)
          "../../agent/event-bus.rkt"
          "../../runtime/oauth.rkt"
          "../../runtime/oauth-callback.rkt"

--- a/tui/commands/session.rkt
+++ b/tui/commands/session.rkt
@@ -8,7 +8,8 @@
 (require racket/string
          racket/list
          "../state.rkt"
-         "../../util/protocol-types.rkt"
+         (only-in "../../util/event.rkt" make-event)
+         (only-in "../../util/message.rkt" message-role)
          "../../agent/event-bus.rkt"
          "../../runtime/session-index.rkt"
          "../../interfaces/sessions.rkt"

--- a/tui/state-events.rkt
+++ b/tui/state-events.rkt
@@ -9,7 +9,8 @@
 (require racket/string
          racket/match
          racket/list
-         "../util/protocol-types.rkt"
+         (only-in "../util/event.rkt" event event-ev event-payload event-time event?)
+         (only-in "../util/message.rkt" message)
          "../util/cost-tracker.rkt"
          "../util/content-helpers.rkt"
          "state-types.rkt"

--- a/tui/tree-view.rkt
+++ b/tui/tree-view.rkt
@@ -17,7 +17,13 @@
          racket/list
          racket/string
          racket/set
-         "../util/protocol-types.rkt")
+         (only-in "../util/content-parts.rkt" text-part text-part-text text-part?)
+         (only-in "../util/message.rkt"
+                  message-content
+                  message-id
+                  message-parent-id
+                  message-role
+                  message-timestamp))
 
 (provide tree-node?
          tree-node-timestamp
@@ -35,7 +41,10 @@
                                     #:bookmarks (or/c hash? #f))
                 (listof string?))]
           [make-tree-node
-           (->* ((or/c string? #f) (or/c string? symbol?) string? exact-nonnegative-integer? (listof any/c))
+           (->* ((or/c string? #f) (or/c string? symbol?)
+                                   string?
+                                   exact-nonnegative-integer?
+                                   (listof any/c))
                 ((or/c number? #f))
                 tree-node?)]
           [build-tree-nodes (-> (listof any/c) (listof list?))]

--- a/tui/tui-init.rkt
+++ b/tui/tui-init.rkt
@@ -19,7 +19,7 @@
          "../tui/state.rkt"
          "../tui/scrollback.rkt"
          "../tui/render.rkt"
-         "../util/protocol-types.rkt"
+         (only-in "../util/message.rkt" message)
          "../agent/event-bus.rkt"
          "../runtime/agent-session.rkt"
          "../runtime/provider-factory.rkt"

--- a/tui/tui-keybindings.rkt
+++ b/tui/tui-keybindings.rkt
@@ -27,7 +27,6 @@
          "../tui/layout.rkt"
          "../tui/clipboard.rkt"
          "../tui/char-width.rkt"
-         "../util/protocol-types.rkt"
          "../agent/event-bus.rkt"
          ;; W15: tui-ctx struct, constructor, mark-dirty! extracted to context.rkt
          (only-in "context.rkt"

--- a/tui/tui-render-loop.rkt
+++ b/tui/tui-render-loop.rkt
@@ -46,7 +46,7 @@
                   styled-line->text
                   plain-line
                   apply-selection-highlight)
-         "../util/protocol-types.rkt"
+         (only-in "../util/event.rkt" event)
          "../agent/event-bus.rkt"
          "../tui/tui-keybindings.rkt"
          "../tui/terminal-input.rkt"
@@ -162,10 +162,10 @@
       (take-right content height)
       content))
 
-(provide (contract-out
-          [clip-visible-lines (-> list? exact-nonnegative-integer? list?)]
-          [compute-pad-count (-> list? exact-nonnegative-integer? exact-nonnegative-integer?)]
-          [clip-overlay-content (-> list? exact-nonnegative-integer? list?)]))
+(provide (contract-out [clip-visible-lines (-> list? exact-nonnegative-integer? list?)]
+                       [compute-pad-count
+                        (-> list? exact-nonnegative-integer? exact-nonnegative-integer?)]
+                       [clip-overlay-content (-> list? exact-nonnegative-integer? list?)]))
 
 ;; Render the complete frame to the terminal using ubuf.
 ;; Hides cursor during redraw to prevent flicker, shows after.

--- a/util/event-classes.rkt
+++ b/util/event-classes.rkt
@@ -7,7 +7,9 @@
 ;; Each predicate checks the event topic.
 
 (require racket/contract
-         "protocol-types.rkt")
+         (only-in "event.rkt" event event-ev event? make-event)
+         (only-in "message.rkt" message)
+         (only-in "tool-types.rkt" tool-call-id))
 
 (provide (contract-out
           ;; Predicates

--- a/util/export-html.rkt
+++ b/util/export-html.rkt
@@ -8,7 +8,19 @@
 (require racket/string
          racket/format
          racket/list
-         "../util/protocol-types.rkt")
+         (only-in "content-parts.rkt"
+                  text-part
+                  text-part-text
+                  text-part?
+                  tool-call-part
+                  tool-call-part-arguments
+                  tool-call-part-name
+                  tool-call-part?
+                  tool-result-part
+                  tool-result-part-content
+                  tool-result-part-is-error?
+                  tool-result-part?)
+         (only-in "message.rkt" message message-content message-kind message-role message-timestamp))
 
 (provide session->html)
 
@@ -25,7 +37,9 @@
 ;; ── Helpers ──
 
 (define (symbol->display-string s)
-  (if (symbol? s) (symbol->string s) s))
+  (if (symbol? s)
+      (symbol->string s)
+      s))
 
 ;; ── CSS ──
 
@@ -49,10 +63,9 @@ summary { cursor: pointer; font-weight: bold; color: #555; }
 (define (render-text-part-html tp)
   (define text (text-part-text tp))
   (define lines (string-split text "\n"))
-  (string-join
-   (for/list ([line (in-list lines)])
-     (format "<p>~a</p>" (html-escape line)))
-   "\n"))
+  (string-join (for/list ([line (in-list lines)])
+                 (format "<p>~a</p>" (html-escape line)))
+               "\n"))
 
 (define (render-tool-call-part-html tcp)
   (define name (tool-call-part-name tcp))
@@ -73,20 +86,18 @@ summary { cursor: pointer; font-weight: bold; color: #555; }
     (cond
       [(string? content) content]
       [(list? content)
-       (string-join
-        (for/list ([p (in-list content)])
-          (cond
-            [(string? p) p]
-            [(hash? p) (~a p)]
-            [else (~a p)]))
-        "\n")]
+       (string-join (for/list ([p (in-list content)])
+                      (cond
+                        [(string? p) p]
+                        [(hash? p) (~a p)]
+                        [else (~a p)]))
+                    "\n")]
       [(hash? content) (~a content)]
       [else (~a content)]))
   (if is-err?
       (format "<div class=\"error\"><strong>⚠ Error:</strong><pre><code>~a</code></pre></div>"
               (html-escape content-str))
-      (format "<pre><code>~a</code></pre>"
-              (html-escape content-str))))
+      (format "<pre><code>~a</code></pre>" (html-escape content-str))))
 
 (define (render-content-part-html cp)
   (cond
@@ -100,17 +111,19 @@ summary { cursor: pointer; font-weight: bold; color: #555; }
 (define (session->html messages)
   ;; Converts a list of message structs to a full HTML5 document.
   ;; Messages sorted by timestamp for deterministic output.
-  (define sorted
-    (sort messages < #:key message-timestamp))
+  (define sorted (sort messages < #:key message-timestamp))
   (define body-parts
     (for/list ([msg (in-list sorted)])
       (render-message-html msg)))
   (define body (string-join body-parts "\n"))
-  (string-append
-   "<!DOCTYPE html>\n<html lang=\"en\">\n<head>\n<meta charset=\"utf-8\">\n"
-   "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">\n"
-   "<title>q Session Export</title>\n<style>\n" INLINE-CSS "\n</style>\n"
-   "</head>\n<body>\n" body "\n</body>\n</html>"))
+  (string-append "<!DOCTYPE html>\n<html lang=\"en\">\n<head>\n<meta charset=\"utf-8\">\n"
+                 "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">\n"
+                 "<title>q Session Export</title>\n<style>\n"
+                 INLINE-CSS
+                 "\n</style>\n"
+                 "</head>\n<body>\n"
+                 body
+                 "\n</body>\n</html>"))
 
 (define (render-message-html msg)
   (define role (symbol->display-string (message-role msg)))
@@ -118,13 +131,13 @@ summary { cursor: pointer; font-weight: bold; color: #555; }
   (define ts (message-timestamp msg))
   (define content-parts (message-content msg))
   (define content-html
-    (string-join
-     (for/list ([cp (in-list content-parts)])
-       (render-content-part-html cp))
-     "\n"))
-  (format "<div class=\"message ~a\"><div class=\"role\">~a (~a)<span class=\"timestamp\">~a</span></div><div class=\"content\">~a</div></div>"
-          (html-escape role)
-          (html-escape role)
-          (html-escape kind)
-          ts
-          content-html))
+    (string-join (for/list ([cp (in-list content-parts)])
+                   (render-content-part-html cp))
+                 "\n"))
+  (format
+   "<div class=\"message ~a\"><div class=\"role\">~a (~a)<span class=\"timestamp\">~a</span></div><div class=\"content\">~a</div></div>"
+   (html-escape role)
+   (html-escape role)
+   (html-escape kind)
+   ts
+   content-html))

--- a/util/export-json.rkt
+++ b/util/export-json.rkt
@@ -10,7 +10,7 @@
          racket/format
          racket/list
          json
-         "../util/protocol-types.rkt")
+         (only-in "message.rkt" message->jsexpr))
 
 (provide (contract-out [session->json-string (-> list? string?)]))
 

--- a/util/export-markdown.rkt
+++ b/util/export-markdown.rkt
@@ -8,14 +8,28 @@
 (require racket/string
          racket/format
          racket/list
-         "../util/protocol-types.rkt")
+         (only-in "content-parts.rkt"
+                  text-part
+                  text-part-text
+                  text-part?
+                  tool-call-part
+                  tool-call-part-arguments
+                  tool-call-part-name
+                  tool-call-part?
+                  tool-result-part
+                  tool-result-part-content
+                  tool-result-part-is-error?
+                  tool-result-part?)
+         (only-in "message.rkt" message-content message-kind message-role message-timestamp))
 
 (provide session->markdown)
 
 ;; ── Helpers ──
 
 (define (symbol->display-string s)
-  (if (symbol? s) (symbol->string s) s))
+  (if (symbol? s)
+      (symbol->string s)
+      s))
 
 (define (message-sort-key msg)
   (message-timestamp msg))
@@ -33,11 +47,7 @@
       [(string? args) args]
       [(hash? args) (~a args)]
       [else (~a args)]))
-  (string-append
-   (format "**Tool: ~a**\n" name)
-   "```json\n"
-   args-str
-   "\n```\n"))
+  (string-append (format "**Tool: ~a**\n" name) "```json\n" args-str "\n```\n"))
 
 (define (render-tool-result-part trp)
   (define content (tool-result-part-content trp))
@@ -46,13 +56,12 @@
     (cond
       [(string? content) content]
       [(list? content)
-       (string-join
-        (for/list ([p (in-list content)])
-          (cond
-            [(string? p) p]
-            [(hash? p) (~a p)]
-            [else (~a p)]))
-        "\n")]
+       (string-join (for/list ([p (in-list content)])
+                      (cond
+                        [(string? p) p]
+                        [(hash? p) (~a p)]
+                        [else (~a p)]))
+                    "\n")]
       [(hash? content) (~a content)]
       [else (~a content)]))
   (if is-err?
@@ -71,8 +80,7 @@
 (define (session->markdown messages)
   ;; Converts a list of message structs to a Markdown string.
   ;; Messages are sorted by timestamp for deterministic output.
-  (define sorted
-    (sort messages < #:key message-sort-key))
+  (define sorted (sort messages < #:key message-sort-key))
   (define parts
     (for/list ([msg (in-list sorted)])
       (render-message msg)))
@@ -86,8 +94,7 @@
   (define heading (format "### ~a (~a)" role kind))
   (define ts-line (format "_Timestamp: ~a_" ts))
   (define body
-    (string-join
-     (for/list ([cp (in-list content-parts)])
-       (render-content-part cp))
-     "\n"))
+    (string-join (for/list ([cp (in-list content-parts)])
+                   (render-content-part cp))
+                 "\n"))
   (string-join (list heading ts-line body) "\n"))

--- a/util/message-helpers.rkt
+++ b/util/message-helpers.rkt
@@ -13,7 +13,9 @@
          racket/list
          racket/path
          racket/file
-         "../util/protocol-types.rkt")
+         (only-in "content-parts.rkt" tool-call-part tool-call-part-id tool-call-part?)
+         (only-in "message.rkt" message message-content message-kind message?)
+         (only-in "tool-types.rkt" tool-result))
 
 (provide (contract-out [has-tool-calls? (-> any/c boolean?)]
                        [tool-result-message? (-> message? boolean?)]


### PR DESCRIPTION
## Summary
- migrate/remove 42 bare `util/protocol-types.rkt` source imports
- split imports to canonical protocol sub-modules (`message`, `content-parts`, `event`, `loop-result`, `entry-predicates`, `custom-entries`, `tool-types`)
- remove unused bare facade imports in files that did not consume protocol-type identifiers

## Validation
- `git diff --name-only | grep '\.rkt$' | xargs raco make`
- `raco make main.rkt`
- no non-test source references to `util/protocol-types.rkt` remain except the facade itself
- `raco test tests/test-protocol-types-package.rkt`

Closes #6636