### PR TITLE
test(v0.81.1): verify protocol-types source migration

### DIFF
--- a/agent/iteration/main-loop.rkt
+++ b/agent/iteration/main-loop.rkt
@@ -23,7 +23,7 @@
          (only-in "../../util/content-parts.rkt" make-text-part)
          (only-in "../../util/loop-result.rkt" make-loop-result loop-result-messages)
          (only-in "../../util/message.rkt" message? make-message)
-         (only-in "../../util/protocol-types.rkt" loop-result-termination-reason loop-result-metadata)
+         (only-in "../../util/loop-result.rkt" loop-result-termination-reason loop-result-metadata)
          (only-in "../../util/ids.rkt" generate-id)
          (only-in "../event-emitter.rkt" emit-typed-event!)
          (only-in "../event-structs/hook-events.rkt" turn-cancelled-event)

--- a/agent/iteration/tool-turn-bridge.rkt
+++ b/agent/iteration/tool-turn-bridge.rkt
@@ -12,10 +12,8 @@
          (only-in "../../util/event.rkt" event-ev)
          (only-in "../../util/message.rkt" message-role message? message-id message-content)
          (only-in "../../util/tool-types.rkt" tool-call-name tool-call-arguments)
-         (only-in "../../util/protocol-types.rkt"
-                  text-part-text
-                  tool-result-part-is-error?
-                  event-payload)
+         (only-in "../../util/content-parts.rkt" text-part-text tool-result-part-is-error?)
+         (only-in "../../util/event.rkt" event-payload)
          "../event-bus.rkt"
          (only-in "../queue.rkt" dequeue-steering! dequeue-followup! dequeue-all-followups!)
          "../../runtime/working-set.rkt"

--- a/llm/token-budget.rkt
+++ b/llm/token-budget.rkt
@@ -10,7 +10,7 @@
          racket/string
          (only-in "../util/content-parts.rkt" text-part?)
          (only-in "../util/message.rkt" message? message-content)
-         (only-in "../util/protocol-types.rkt" text-part-text))
+         (only-in "../util/content-parts.rkt" text-part-text))
 
 (provide DEFAULT-TOKEN-BUDGET-THRESHOLD
          DEFAULT-SAFETY-MARGIN-PCT

--- a/runtime/compaction-prompts.rkt
+++ b/runtime/compaction-prompts.rkt
@@ -9,7 +9,7 @@
          racket/string
          (only-in "../util/content-parts.rkt" text-part?)
          (only-in "../util/message.rkt" message? message-role message-id message-content)
-         (only-in "../util/protocol-types.rkt" text-part-text))
+         (only-in "../util/content-parts.rkt" text-part-text))
 
 (provide (contract-out [summary-prompt (-> string? (or/c #f hash?) string?)]
                        [iterative-update-prompt (-> string? string? (or/c #f hash?) string?)]

--- a/runtime/context-assembly/selection.rkt
+++ b/runtime/context-assembly/selection.rkt
@@ -24,7 +24,7 @@
                   message-parent-id
                   message-content
                   make-message)
-         (only-in "../../util/protocol-types.rkt" compaction-summary-entry?)
+         (only-in "../../util/entry-predicates.rkt" compaction-summary-entry?)
          (only-in "../context-policy.rkt"
                   estimate-message-tokens
                   ensure-first-user-pinned

--- a/runtime/context-assembly/session-walk.rkt
+++ b/runtime/context-assembly/session-walk.rkt
@@ -19,7 +19,7 @@
                   message-content
                   message-meta
                   make-message)
-         (only-in "../../util/protocol-types.rkt" compaction-summary-entry?)
+         (only-in "../../util/entry-predicates.rkt" compaction-summary-entry?)
          (only-in "../../util/content-parts.rkt" text-part text-part? text-part-text)
          (only-in "../session-index.rkt" active-leaf get-branch))
 

--- a/runtime/context-assembly/token-metrics.rkt
+++ b/runtime/context-assembly/token-metrics.rkt
@@ -8,7 +8,7 @@
          (only-in "../../llm/token-budget.rkt" estimate-context-tokens)
          (only-in "../../util/content-parts.rkt" text-part?)
          (only-in "../../util/message.rkt" message? message-content message-role)
-         (only-in "../../util/protocol-types.rkt" text-part-text)
+         (only-in "../../util/content-parts.rkt" text-part-text)
          "context-floor.rkt"
          "state-aware-builder.rkt")
 

--- a/runtime/session-compaction.rkt
+++ b/runtime/session-compaction.rkt
@@ -11,7 +11,7 @@
          "../llm/token-budget.rkt"
          "../runtime/compactor.rkt"
          (only-in "../util/message.rkt" message-role message-content)
-         (only-in "../util/protocol-types.rkt" content-part->jsexpr)
+         (only-in "../util/content-parts.rkt" content-part->jsexpr)
          (only-in "../util/hook-types.rkt" hook-result-action)
          (only-in "runtime-helpers.rkt" emit-session-event! maybe-dispatch-hooks)
          "../agent/event-emitter.rkt"

--- a/runtime/session-events.rkt
+++ b/runtime/session-events.rkt
@@ -13,7 +13,7 @@
          "../runtime/session-index.rkt"
          (only-in "../util/event.rkt" event-ev)
          (only-in "../util/message.rkt" message-id)
-         (only-in "../util/protocol-types.rkt" event-payload)
+         (only-in "../util/event.rkt" event-payload)
          (only-in "runtime-helpers.rkt" emit-session-event!)
          "session-types.rkt"
          (only-in "context-assembly/task-conclusion.rkt" task-conclusion task-conclusion-id))

--- a/runtime/session-index/mutations.rkt
+++ b/runtime/session-index/mutations.rkt
@@ -22,7 +22,7 @@
                   make-message
                   message
                   message?)
-         (only-in "../../util/protocol-types.rkt" message->jsexpr jsexpr->message)
+         (only-in "../../util/message.rkt" message->jsexpr jsexpr->message)
          (only-in "../../util/message-helpers.rkt" ensure-parent-dirs!)
          (only-in "../../util/ids.rkt" generate-id)
          (only-in "../../util/jsonl.rkt" jsonl-read-all-valid)

--- a/runtime/session-index/query.rkt
+++ b/runtime/session-index/query.rkt
@@ -9,7 +9,7 @@
          racket/set
          (only-in "../../util/content-parts.rkt" text-part?)
          (only-in "../../util/message.rkt" message? message-id message-parent-id message-content)
-         (only-in "../../util/protocol-types.rkt" text-part-text)
+         (only-in "../../util/content-parts.rkt" text-part-text)
          "schema.rkt")
 
 (provide (contract-out

--- a/runtime/session-lifecycle.rkt
+++ b/runtime/session-lifecycle.rkt
@@ -24,7 +24,7 @@
          racket/path
          (only-in "../util/loop-result.rkt" make-loop-result)
          (only-in "../util/message.rkt" message-id message-kind message?)
-         (only-in "../util/protocol-types.rkt" loop-result-termination-reason)
+         (only-in "../util/loop-result.rkt" loop-result-termination-reason)
          (only-in "session-lifecycle-transitions.rkt"
                   build-user-message
                   compute-parent-id

--- a/runtime/session-metadata.rkt
+++ b/runtime/session-metadata.rkt
@@ -18,7 +18,7 @@
                   message-meta-safe
                   message-kind
                   make-message)
-         (only-in "../util/protocol-types.rkt" content-part->jsexpr)
+         (only-in "../util/content-parts.rkt" content-part->jsexpr)
          "../util/jsonl.rkt"
          "../runtime/session-store.rkt")
 

--- a/runtime/tool-coordinator.rkt
+++ b/runtime/tool-coordinator.rkt
@@ -40,11 +40,11 @@
                   tool-call-id
                   tool-call-name
                   tool-result-content)
-         (only-in "../util/protocol-types.rkt"
+         (only-in "../util/content-parts.rkt"
                   tool-call-part-id
                   tool-call-part-name
-                  tool-call-part-arguments
-                  tool-result-is-error?)
+                  tool-call-part-arguments)
+         (only-in "../util/tool-types.rkt" tool-result-is-error?)
          "../agent/event-bus.rkt"
          ;; ARCH-01 upward import — runtime→tools
          (only-in "layer-adapters.rkt" make-exec-context make-error-result list-tools-jsexpr)

--- a/runtime/turn-orchestrator.rkt
+++ b/runtime/turn-orchestrator.rkt
@@ -33,12 +33,9 @@
          (only-in "../util/loop-result.rkt" make-loop-result loop-result-messages)
          (only-in "../util/message.rkt" message? message-id message-role message-content make-message)
          (only-in "../util/tool-types.rkt" tool-call-name tool-call-arguments)
-         (only-in "../util/protocol-types.rkt"
-                  text-part-text
-                  loop-result-termination-reason
-                  loop-result-metadata
-                  event-payload
-                  tool-result-part-is-error?)
+         (only-in "../util/content-parts.rkt" text-part-text tool-result-part-is-error?)
+         (only-in "../util/event.rkt" event-payload)
+         (only-in "../util/loop-result.rkt" loop-result-termination-reason loop-result-metadata)
          "../agent/event-bus.rkt"
          (only-in "../util/loop-result.rkt" loop-result?)
          (only-in "../util/cancellation.rkt" cancellation-token?)

--- a/scripts/analyze-trace.rkt
+++ b/scripts/analyze-trace.rkt
@@ -33,7 +33,7 @@
                   message-kind
                   message-timestamp
                   message-meta)
-         (only-in "../util/protocol-types.rkt" text-part-text tool-call-part-name tool-call-part-id))
+         (only-in "../util/content-parts.rkt" text-part-text tool-call-part-name tool-call-part-id))
 
 (provide (contract-out [extract-metrics (-> any/c any/c)]
                        [format-report (-> any/c string?)]

--- a/scripts/benchmark/executor.rkt
+++ b/scripts/benchmark/executor.rkt
@@ -29,7 +29,7 @@
          (only-in "../../llm/provider.rkt" make-mock-provider)
          (only-in "../../llm/model.rkt" make-model-response)
          (only-in "../../util/message.rkt" message-role message-content)
-         (only-in "../../util/protocol-types.rkt" text-part-text)
+         (only-in "../../util/content-parts.rkt" text-part-text)
          (only-in "../../util/jsonl.rkt" jsonl-read-all-valid)
          (only-in "../../extensions/gsd/state-machine.rkt" [gsm-snapshot gsd-snapshot])
          "task.rkt")

--- a/tests/test-protocol-types-source-migration.rkt
+++ b/tests/test-protocol-types-source-migration.rkt
@@ -1,0 +1,51 @@
+#lang racket
+
+;; BOUNDARY: architecture
+
+;; Verifies v0.81.1 protocol-types migration guardrails:
+;; source modules should use canonical protocol sub-modules directly, while tests
+;; and the backward-compatibility facade may still exercise protocol-types.rkt.
+
+(require rackunit
+         rackunit/text-ui
+         racket/file
+         racket/list
+         racket/path
+         racket/string
+         (only-in "../util/event-classes.rkt" make-stream-text-event stream-text-event?))
+
+(define project-root
+  (simplify-path (build-path (or (current-load-relative-directory) (current-directory)) "..")))
+
+(define (path-string path)
+  (path->string (simplify-path path)))
+
+(define (source-racket-file? path)
+  (define s (path-string path))
+  (and (regexp-match? #rx"[.]rkt$" s)
+       (not (string-contains? s "/compiled/"))
+       (not (string-contains? s "/tests/"))
+       (not (regexp-match? #rx"/util/protocol-types[.]rkt$" s))))
+
+(define (source-protocol-facade-reference? path)
+  (regexp-match? #rx"\\\"[^\\\"]*protocol-types[.]rkt\\\"" (file->string path)))
+
+(define protocol-migration-tests
+  (test-suite "protocol-types source migration"
+
+    (test-case "non-test source files do not require protocol-types facade"
+      (define offenders
+        (for/list ([path (in-list (find-files source-racket-file? project-root))]
+                   #:when (source-protocol-facade-reference? path))
+          (find-relative-path project-root path)))
+      (check-equal? offenders '()))
+
+    (test-case "event-classes imports canonical modules without circular facade dependency"
+      (define evt (make-stream-text-event "turn-1" (hasheq 'text "hello")))
+      (check-true (stream-text-event? evt)))))
+
+(module+ main
+  (run-tests protocol-migration-tests))
+
+(module+ test
+  (run-tests protocol-migration-tests))

--- a/tools/builtins/session-recall.rkt
+++ b/tools/builtins/session-recall.rkt
@@ -21,7 +21,7 @@
          "../tool.rkt"
          (only-in "../../util/content-parts.rkt" text-part?)
          (only-in "../../util/message.rkt" message-id message-role message-content)
-         (only-in "../../util/protocol-types.rkt" text-part-text)
+         (only-in "../../util/content-parts.rkt" text-part-text)
          "../../util/string-helpers.rkt")
 
 (provide (contract-out [tool-session-recall (->* (hash?) ((or/c exec-context? #f)) tool-result?)]))

--- a/tools/builtins/spawn-subagent.rkt
+++ b/tools/builtins/spawn-subagent.rkt
@@ -24,11 +24,11 @@
                   make-tool-result-part)
          (only-in "../../util/message.rkt" make-message message-role message-content message-id)
          (only-in "../../util/tool-types.rkt" make-tool-call tool-call-id tool-result-content)
-         (only-in "../../util/protocol-types.rkt"
+         (only-in "../../util/content-parts.rkt"
                   tool-call-part-id
                   tool-call-part-name
-                  tool-call-part-arguments
-                  tool-result-is-error?)
+                  tool-call-part-arguments)
+         (only-in "../../util/tool-types.rkt" tool-result-is-error?)
          (only-in "../../util/json-helpers.rkt" ensure-hash-args)
          (only-in "../../util/error-sanitizer.rkt" sanitize-error-message)
          "../../tools/scheduler.rkt"

--- a/tools/tool.rkt
+++ b/tools/tool.rkt
@@ -27,7 +27,7 @@
                   tool-result?
                   tool-result-content
                   tool-result-details)
-         (only-in "../util/protocol-types.rkt" tool-result-is-error?)
+         (only-in "../util/tool-types.rkt" tool-result-is-error?)
          ;; Submodule imports
          "tool-struct.rkt"
          "exec-context.rkt"

--- a/wiring/run-interactive.rkt
+++ b/wiring/run-interactive.rkt
@@ -29,7 +29,8 @@
          (only-in "../util/content-parts.rkt" text-part?)
          (only-in "../util/event.rkt" event-ev)
          (only-in "../util/message.rkt" message-role message-content)
-         (only-in "../util/protocol-types.rkt" event-payload text-part-text)
+         (only-in "../util/content-parts.rkt" text-part-text)
+         (only-in "../util/event.rkt" event-payload)
          "../extensions/api.rkt"
          (only-in "../extensions/loader.rkt" load-extension!))
 


### PR DESCRIPTION
## Summary
- migrate remaining non-test source `only-in` imports away from `util/protocol-types.rkt`
- add source migration guardrail test that allows tests/facade compatibility but rejects source facade requires
- cover `util/event-classes.rkt` direct canonical import/circular-risk sanity

## Validation
- `git diff --name-only | grep '\.rkt$' | xargs raco make`
- `raco make main.rkt`
- `raco test tests/test-protocol-types-source-migration.rkt`
- `raco test tests/test-protocol-types-package.rkt`
- no non-test source references to `util/protocol-types.rkt` remain except the facade itself

Closes #6637