### PR TITLE
chore(v0.81.1): deprecate protocol-types facade

### DIFF
--- a/tests/test-protocol-types-split.rkt
+++ b/tests/test-protocol-types-split.rkt
@@ -8,6 +8,7 @@
 ;; and that sub-modules can be imported independently (ARCH-05).
 
 (require rackunit
+         racket/file
          "../util/protocol-types.rkt"
          ;; Also test direct sub-module imports
          "../util/content-parts.rkt"
@@ -16,6 +17,13 @@
          "../util/entry-predicates.rkt"
          "../util/tree-entries.rkt"
          "../util/loop-result.rkt")
+
+(define protocol-types-source
+  (file->string (build-path (or (current-load-relative-directory) (current-directory))
+                            "../util/protocol-types.rkt")))
+
+(check-not-false (regexp-match? #rx"DEPRECATED" protocol-types-source))
+(check-not-false (regexp-match? #rx"Target removal: v0[.]82[+]" protocol-types-source))
 
 ;; ── Content parts (from facade and direct) ─────────────────
 (check-equal? (text-part-text (make-text-part "hello")) "hello")
@@ -61,10 +69,11 @@
 (check-true (tree-entry? tne))
 (check-equal? (tree-navigation-entry-target-entry-id tne) "to1")
 
-(define bse (make-branch-summary-entry "s1" #f "summary text" '(1 . 10) 500))
+(define bse (make-branch-summary-entry "s1" #f "summary text" "1..10" 500))
 (check-true (branch-summary-entry? bse))
 (check-true (tree-entry? bse))
 (check-equal? (branch-summary-entry-summary bse) "summary text")
+(check-equal? (branch-summary-entry-entry-range bse) "1..10")
 
 ;; ── Loop result ────────────────────────────────────────────
 (define lr (make-loop-result '(msg1 msg2) 'max-turns (hash)))

--- a/util/protocol-types.rkt
+++ b/util/protocol-types.rkt
@@ -1,6 +1,10 @@
 #lang racket/base
 
-;; util/protocol-types.rkt -- Backward-compat re-export facade
+;; util/protocol-types.rkt -- DEPRECATED backward-compat re-export facade
+;;
+;; DEPRECATED (v0.81.1): New source code must import the focused protocol
+;; sub-modules directly. This facade remains only for tests, external
+;; compatibility, and staged removal. Target removal: v0.82+.
 ;;
 ;; ARCH-05: Decomposed into focused sub-modules:
 ;;   - content-parts.rkt      -- text-part, tool-call-part, tool-result-part
@@ -14,12 +18,8 @@
 ;;
 ;; This file re-exports everything for backward compatibility.
 ;;
-;; TRANSITIONAL (I2 v0.72.5): New code should import from specific sub-modules.
-;; v0.80.4 migrated: cli/render.rkt, runtime/iteration/retry-policy.rkt,
-;;   runtime/session-lifecycle-transitions.rkt, interfaces/json-mode.rkt,
-;;   interfaces/rpc-mode.rkt, extensions/events.rkt
-;; Remaining consumers: ~88 files in tui/, extensions/, interfaces/.
-;; Target: remove this facade in v0.82+ after all consumers migrated.
+;; Migration status (v0.81.1): non-test source consumers have been migrated.
+;; Tests may still require the facade to verify compatibility until removal.
 
 (require "content-parts.rkt"
          "message.rkt"


### PR DESCRIPTION
## Summary
- mark `util/protocol-types.rkt` as deprecated with v0.82+ target removal
- update split/facade test to assert the deprecation header remains present
- repair stale branch-summary test fixture argument to match current contract

## Validation
- `raco make util/protocol-types.rkt main.rkt`
- `raco test tests/test-protocol-types-split.rkt`
- `raco test tests/test-protocol-types-source-migration.rkt`
- `raco test tests/test-protocol-types-package.rkt`
- `racket scripts/run-tests.rkt tests/test-protocol-types-split.rkt tests/test-protocol-types-source-migration.rkt`
- changed files compile; no non-test source references to `util/protocol-types.rkt` remain except facade itself

Note: broad `--suite fast` was attempted and timed out with existing broad-runner/failure noise.

Closes #6638