### PR TITLE
chore(release): bump version to v0.81.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v0.81.1 (2026-06-02)
+
+### Protocol-Types Migration
+- Migrated source imports away from `util/protocol-types.rkt` to focused canonical sub-modules.
+- Added source migration guardrail test for non-test facade references.
+- Marked `util/protocol-types.rkt` as deprecated with target removal in v0.82+.
+
 ## v0.81.0 (2026-06-02)
 
 ### SSE Dedup + Contract Tightening

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.81.0-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.81.1-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 
@@ -202,7 +202,7 @@ bin/q --model gpt-5.4 "write a test"
 ### Verify
 
 ```bash
-bin/q --version            # q version 0.81.0
+bin/q --version            # q version 0.81.1
 raco test tests/           # run the full test suite
 ```
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -2,7 +2,7 @@
 
 ## Version
 
-v0.77.0
+v0.81.1
 
 ## Native TUI Stack
 

--- a/docs/event-taxonomy.md
+++ b/docs/event-taxonomy.md
@@ -1,6 +1,6 @@
 # Q Event Taxonomy Reference
 
-Complete reference for all event types in Q 0.77.0.
+Complete reference for all event types in Q 0.81.1.
 ## Base Types
 
 ### `event` (protocol-level)

--- a/docs/extension-guide.md
+++ b/docs/extension-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.77.0 --># Extension Development Guide
+<!-- verified-against: 0.81.1 --># Extension Development Guide
 
 This guide walks you through creating, testing, and activating a custom
 extension for q.

--- a/docs/getting-started/credentials.md
+++ b/docs/getting-started/credentials.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.77.0 -->
+<!-- verified-against: 0.81.1 -->
 # Credential Management
 
 This document describes how q manages API keys and provider credentials,

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.77.0 --># Getting Started
+<!-- verified-against: 0.81.1 --># Getting Started
 
 Welcome to q, a Racket-based coding agent.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.77.0 --># Installation Guide
+<!-- verified-against: 0.81.1 --># Installation Guide
 
 <!-- This file is the canonical source. The docs/getting-started/installation.md copy is maintained for the doc site build. -->
 

--- a/docs/security-trust-model.md
+++ b/docs/security-trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.77.0 --># Security & Trust Model
+<!-- verified-against: 0.81.1 --># Security & Trust Model
 
 This document provides an honest, per-area assessment of what q enforces
 today and what is planned. It is the authoritative reference for security

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -130,6 +130,6 @@ is the primary self-hosting extension:
 (load-extension! ext-reg "path/to/extension.rkt" #:event-bus bus)
 ```
 
-## Version 0.77.0
+## Version 0.81.1
 
-This documentation reflects q 0.77.0.
+This documentation reflects q 0.81.1.

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.77.0 --># q Source Style Guide
+<!-- verified-against: 0.81.1 --># q Source Style Guide
 
 This document defines formatting and naming conventions for the q Racket codebase.
 All changes to `q/` source files (excluding `tests/`) should follow these rules.

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.77.0 -->
+<!-- verified-against: 0.81.1 -->
 # Trust Model
 
 ## Trust Levels

--- a/docs/workflow-testing.md
+++ b/docs/workflow-testing.md
@@ -121,6 +121,6 @@ Use relative paths from the test file:
 4. Use `(check-true ...)` for boolean assertions
 5. Keep tests independent — no shared mutable state between test-cases
 
-## Version 0.77.0
+## Version 0.81.1
 
-This documentation reflects q 0.77.0.
+This documentation reflects q 0.81.1.

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.81.0")
+(define version "0.81.1")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base" "gui-easy-lib"))

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -11,4 +11,4 @@
 
 (provide (contract-out [q-version string?]))
 
-(define q-version "0.81.0")
+(define q-version "0.81.1")

--- a/wiki-src/Architecture-Overview.md
+++ b/wiki-src/Architecture-Overview.md
@@ -35,7 +35,7 @@ User input → Interface (CLI/TUI/RPC)
     → Events emitted to bus
 ```
 
-## Metrics (0.77.0)
+## Metrics (0.81.1)
 > _See `racket scripts/metrics.rkt` for current numbers._
 
 - 414 source modules, 534 test files


### PR DESCRIPTION
## Summary
- bump canonical version to `0.81.1`
- sync `info.rkt`, README, docs/wiki version surfaces
- add CHANGELOG entry for protocol-types migration

## Validation
- `racket scripts/lint-version.rkt`
- `raco make main.rkt`
- `git diff --name-only | grep '\.rkt$' | xargs raco make`
- `raco test tests/test-sync-version-historical.rkt tests/test-lint-release-readiness.rkt`
- focused protocol migration tests passed in W3

Note: `scripts/lint-changelog-dates.rkt` still reports pre-existing historical changelog date-format/order noise.