### PR TITLE
fix(goal): extract-transcript-from-result + feature flag (#6678)

### DIFF
--- a/runtime/goal/goal-runner.rkt
+++ b/runtime/goal/goal-runner.rkt
@@ -32,7 +32,8 @@
          "goal-evidence.rkt"
          "goal-checks.rkt"
          "../../llm/provider.rkt"
-         (only-in "../../util/time.rkt" now-epoch-ms))
+         (only-in "../../util/time.rkt" now-epoch-ms)
+         (only-in "../../util/loop-result.rkt" loop-result? loop-result-messages))
 
 ;; ============================================================
 ;; Provides
@@ -43,7 +44,8 @@
          goal-loop-step
          build-continuation-prompt
          collect-evaluations
-         execute-checks-for-goal)
+         execute-checks-for-goal
+         extract-transcript-from-result)
 
 ;; Collect all evaluations from goal-state evaluations field + last-evaluation
 (define (collect-evaluations goal-st)
@@ -111,10 +113,7 @@
   (cond
     [(shutdown-check)
      (define final-st
-       (struct-copy goal-state
-                    goal-st
-                    [status 'cancelled]
-                    [updated-at (now-epoch-ms)]))
+       (struct-copy goal-state goal-st [status 'cancelled] [updated-at (now-epoch-ms)]))
      (on-event 'goal-failed
                (hasheq 'goal-text
                        (goal-state-goal-text final-st)
@@ -127,11 +126,7 @@
 
     ;; Max turns reached
     [(>= (goal-state-turns-used goal-st) (goal-state-max-turns goal-st))
-     (define final-st
-       (struct-copy goal-state
-                    goal-st
-                    [status 'failed]
-                    [updated-at (now-epoch-ms)]))
+     (define final-st (struct-copy goal-state goal-st [status 'failed] [updated-at (now-epoch-ms)]))
      (on-event 'goal-failed
                (hasheq 'goal-text
                        (goal-state-goal-text final-st)
@@ -143,11 +138,7 @@
      final-st]
 
     [(detect-no-progress (collect-evaluations goal-st))
-     (define final-st
-       (struct-copy goal-state
-                    goal-st
-                    [status 'failed]
-                    [updated-at (now-epoch-ms)]))
+     (define final-st (struct-copy goal-state goal-st [status 'failed] [updated-at (now-epoch-ms)]))
      (on-event 'goal-failed
                (hasheq 'goal-text
                        (goal-state-goal-text final-st)
@@ -194,7 +185,6 @@
       "unknown"))
 
 ;; Sum token costs from all evaluations
-
 
 ;; ============================================================
 ;; Single step
@@ -291,6 +281,7 @@
   ;; Try to extract messages from the loop result
   ;; The loop-result may have an 'assistant-response or 'messages field
   (cond
+    [(loop-result? loop-result) (loop-result-messages loop-result)]
     [(hash? loop-result)
      (define messages (hash-ref loop-result 'messages '()))
      (if (list? messages)

--- a/runtime/session/session-config.rkt
+++ b/runtime/session/session-config.rkt
@@ -53,6 +53,7 @@
 ;;   'self-healing  — bounded + auto-distill + rollback actions (behind flags)
 ;;   'full          — all features active (not recommended yet)
 (define current-context-assembly-profile (make-parameter 'off))
+(define current-goal-loop-enabled? (make-parameter #f))
 
 (define valid-profiles '(off observe bounded self-healing full))
 
@@ -105,6 +106,7 @@
 (provide session-config?
          current-task-state-aware-rollout-rate
          current-context-assembly-profile
+          current-goal-loop-enabled?
          context-assembly-profile?
          apply-context-assembly-profile!
          ;; Smart accessors with defaults

--- a/tests/test-goal-runner-extract-transcript.rkt
+++ b/tests/test-goal-runner-extract-transcript.rkt
@@ -1,0 +1,31 @@
+#lang racket/base
+
+(require rackunit
+         (only-in "../runtime/goal/goal-runner.rkt"
+                  extract-transcript-from-result)
+         (only-in "../util/loop-result.rkt"
+                  make-loop-result)
+         (only-in "../runtime/session/session-config.rkt"
+                  current-goal-loop-enabled?))
+
+(test-case "extract-transcript-from-result handles loop-result? struct"
+  (define msgs (list 'msg1 'msg2))
+  (define lr (make-loop-result msgs 'achieved (hasheq)))
+  (check-equal? (extract-transcript-from-result lr) msgs))
+
+(test-case "extract-transcript-from-result handles hash?"
+  (define h (hasheq 'messages '(a b c)))
+  (check-equal? (extract-transcript-from-result h) '(a b c)))
+
+(test-case "extract-transcript-from-result handles list?"
+  (check-equal? (extract-transcript-from-result '(x y)) '(x y)))
+
+(test-case "extract-transcript-from-result handles unknown type"
+  (check-equal? (extract-transcript-from-result 42) '()))
+
+(test-case "current-goal-loop-enabled? default is #f"
+  (check-false (current-goal-loop-enabled?)))
+
+(test-case "current-goal-loop-enabled? can be set to #t"
+  (parameterize ([current-goal-loop-enabled? #t])
+    (check-true (current-goal-loop-enabled?))))


### PR DESCRIPTION
## Summary
- Fix `extract-transcript-from-result` to handle `loop-result?` struct
- Add `current-goal-loop-enabled?` feature flag (default `#f`)
- 6 new tests

Closes #6678