### PR TITLE
fix(w0): Wire agent-session-box + goal-cancel-box through TUI context pipeline (#6714)

### DIFF
--- a/gui/slash-commands.rkt
+++ b/gui/slash-commands.rkt
@@ -82,7 +82,11 @@
 ;;
 ;; Returns (-> string? boolean?) — #t if handled, #f otherwise
 ;; --------------------------------------------------
-(define (make-slash-command-handler sess state-box gui-state-lock [notify! void])
+(define (make-slash-command-handler sess
+                                    state-box
+                                    gui-state-lock
+                                    [notify! void]
+                                    #:goal-cancel-box [goal-cancel-box (box #f)])
   (lambda (input-text)
     (define parsed (parse-command-name input-text))
     (cond
@@ -243,24 +247,28 @@
                                               #:max-turns 8
                                               #:on-event on-event
                                               #:on-status (lambda (msg) (void))
-                                              #:shutdown-check (lambda () #f)))
-                                 ;; Update display with final result
-                                 (define final-info
-                                   (hash 'goal-text
-                                         clean-text
-                                         'turns-used
-                                         (goal-state-turns-used result)
-                                         'max-turns
-                                         8
-                                         'status
-                                         (goal-state-status result)))
-                                 (call-with-semaphore
-                                  gui-state-lock
-                                  (lambda ()
-                                    (set-box! state-box
-                                              (gui-state-set-active-goal (unbox state-box)
-                                                                         final-info))
-                                    (notify!)))))))
+                                              #:shutdown-check (lambda () (unbox goal-cancel-box))))
+                                 ;; Update display with final result (skip if cancelled)
+                                 (define was-cancelled (unbox goal-cancel-box))
+                                 (unless was-cancelled
+                                   (define final-info
+                                     (hash 'goal-text
+                                           clean-text
+                                           'turns-used
+                                           (goal-state-turns-used result)
+                                           'max-turns
+                                           8
+                                           'status
+                                           (goal-state-status result)))
+                                   (call-with-semaphore
+                                    gui-state-lock
+                                    (lambda ()
+                                      (set-box! state-box
+                                                (gui-state-set-active-goal (unbox state-box)
+                                                                           final-info))
+                                      (notify!))))
+                                 ;; Reset cancel box for next goal
+                                 (set-box! goal-cancel-box #f)))))
                    #t))])]
          [(interrupt)
           (add-system-msg! "Interrupt not yet supported in GUI mode."

--- a/tests/test-compaction-command.rkt
+++ b/tests/test-compaction-command.rkt
@@ -11,7 +11,7 @@
          "../util/protocol-types.rkt")
 
 (define (make-test-cctx [bus #f])
-  (cmd-ctx (box (initial-ui-state)) (box #t) bus #f (box #f) #f (box #f) #f (box "") #f #f))
+  (cmd-ctx (box (initial-ui-state)) (box #t) bus #f (box #f) #f (box #f) #f (box "") #f #f (box #f) (box #f)))
 
 (define compact-tests
   (test-suite "/compact command"

--- a/tests/test-execute-command-hook.rkt
+++ b/tests/test-execute-command-hook.rkt
@@ -52,7 +52,9 @@
            #f ; session-runner
            (box "/go") ; input-text-box
            (box ext-reg) ; extension-registry-box
-           #f)) ; session-factory-runner
+           #f ; session-factory-runner
+           (box #f) ; agent-session-box
+           (box #f))) ; goal-cancel-box
 
 (define (get-transcript-texts cctx)
   (define state (unbox (cmd-ctx-state-box cctx)))

--- a/tests/test-gsd-transaction-contract.rkt
+++ b/tests/test-gsd-transaction-contract.rkt
@@ -54,7 +54,9 @@
            #f ; session-runner
            (box "/go") ; input-text-box
            (box ext-reg) ; extension-registry-box
-           #f)) ; session-factory-runner
+           #f ; session-factory-runner
+           (box #f) ; agent-session-box
+           (box #f))) ; goal-cancel-box
 
 (define (make-ext-reg-with-execute-command handler)
   (define reg (make-extension-registry))

--- a/tests/test-login-command.rkt
+++ b/tests/test-login-command.rkt
@@ -11,7 +11,7 @@
          "../runtime/oauth-callback.rkt")
 
 (define (make-test-cctx)
-  (cmd-ctx (box (initial-ui-state)) (box #t) #f #f (box #f) #f (box #f) #f (box "") #f #f))
+  (cmd-ctx (box (initial-ui-state)) (box #t) #f #f (box #f) #f (box #f) #f (box "") #f #f (box #f) (box #f)))
 
 (define login-tests
   (test-suite "/login command"

--- a/tests/test-model-command.rkt
+++ b/tests/test-model-command.rkt
@@ -55,7 +55,9 @@
            #f ; session-runner
            (box "") ; input-text-box
            (box #f)
-           #f)) ; extension-registry-box + session-factory-runner
+           #f ; session-factory-runner
+           (box #f) ; agent-session-box
+           (box #f))) ; goal-cancel-box
 
 ;; Extract transcript text from a cmd-ctx
 (define (cctx-transcript-text cctx)

--- a/tests/test-reload-command.rkt
+++ b/tests/test-reload-command.rkt
@@ -66,7 +66,9 @@
            #f ; session-runner
            (box #f) ; input-text-box
            (box ext-reg)
-           #f)) ; session-factory-runner
+           #f ; session-factory-runner
+           (box #f) ; agent-session-box
+           (box #f))) ; goal-cancel-box
 
 ;; ============================================================
 ;; Test suite

--- a/tests/test-tui-activate-command.rkt
+++ b/tests/test-tui-activate-command.rkt
@@ -31,7 +31,9 @@
            (lambda (prompt) (void))
            (box input-text)
            (box #f)
-           #f)) ; extension-registry-box + session-factory-runner
+           #f ; session-factory-runner
+           (box #f) ; agent-session-box
+           (box #f))) ; goal-cancel-box
 
 ;; ============================================================
 ;; Tests

--- a/tests/tui/commands.rkt
+++ b/tests/tui/commands.rkt
@@ -26,7 +26,8 @@
            (box "") ;; input-text-box
            (box #f) ;; extension-registry-box
            #f ;; session-factory-runner
-           (box #f)))
+           (box #f) ;; agent-session-box
+           (box #f))) ;; goal-cancel-box
 
 (define commands-tests
   (test-suite "TUI Commands"
@@ -183,7 +184,8 @@
                  (box "")
                  (box #f)
                  factory
-                 (box #f)))
+                 (box #f) ;; agent-session-box
+                 (box #f))) ;; goal-cancel-box
       (check-true (procedure? (cmd-ctx-session-factory-runner cctx))))))
 
 (run-tests commands-tests)

--- a/tests/tui/test-command-integration.rkt
+++ b/tests/tui/test-command-integration.rkt
@@ -29,7 +29,9 @@
            #f ;; session-runner
            (box "") ;; input-text-box
            (box #f) ;; extension-registry-box
-           #f)) ;; session-factory-runner
+           #f ;; session-factory-runner
+           (box #f) ;; agent-session-box
+           (box #f))) ;; goal-cancel-box
 
 ;; Helper: get transcript text entries from cctx state
 (define (get-transcript-texts cctx)

--- a/tui/commands.rkt
+++ b/tui/commands.rkt
@@ -26,15 +26,17 @@
          "../extensions/hooks.rkt"
          "../extensions/api.rkt"
          "../runtime/goal-checks.rkt"
-         (only-in "../runtime/goal-state.rkt" goal-check-label goal-check-command
-                  goal-state-turns-used goal-state-status)
+         (only-in "../runtime/goal-state.rkt"
+                  goal-check-label
+                  goal-check-command
+                  goal-state-turns-used
+                  goal-state-status)
          (only-in "../runtime/agent-session.rkt"
                   agent-session?
                   session-provider
                   session-event-bus
                   session-id)
-         (only-in "../runtime/session/session-config.rkt"
-                  current-goal-loop-enabled?)
+         (only-in "../runtime/session/session-config.rkt" current-goal-loop-enabled?)
          ;; Sub-module imports
          (only-in "commands/context.rkt"
                   cmd-ctx
@@ -80,10 +82,8 @@
                   handle-login-command)
          ;; Goal runner + bridge
          (only-in "../runtime/goal/goal-runner.rkt" goal-run!)
-         (only-in "commands/goal-bridge.rkt"
-                  make-goal-event-bridge
-                  make-goal-run-prompt!)
-         (only-in "commands/context.rkt" cmd-ctx-agent-session-box))
+         (only-in "commands/goal-bridge.rkt" make-goal-event-bridge make-goal-run-prompt!)
+         (only-in "commands/context.rkt" cmd-ctx-agent-session-box cmd-ctx-goal-cancel-box))
 
 ;; Re-export all public APIs
 (provide cmd-ctx
@@ -104,7 +104,8 @@
          apply-slash-command
          process-extension-command
          execute-extension-command
-         cmd-ctx-session-factory-runner)
+         cmd-ctx-session-factory-runner
+         cmd-ctx-goal-cancel-box)
 
 ;; ============================================================
 ;; Extension command dispatch (extracted W-09)
@@ -332,6 +333,10 @@
   (cond
     ;; /goal clear — cancel active goal
     [(string=? arg-text "clear")
+     ;; Signal the running goal thread to stop
+     (define cancel-box (cmd-ctx-goal-cancel-box cctx))
+     (when cancel-box
+       (set-box! cancel-box #t))
      (define cleared-state (struct-copy ui-state state [active-goal #f]))
      (define entry (make-system-entry "[goal] Active goal cancelled."))
      (set-box! (cmd-ctx-state-box cctx) (add-transcript-entry cleared-state entry))
@@ -414,8 +419,7 @@
               (define sess (unbox (cmd-ctx-agent-session-box cctx)))
               (cond
                 [(not (agent-session? sess))
-                 (define entry
-                   (make-system-entry "[goal] No active session. Start a session first."))
+                 (define entry (make-system-entry "[goal] No active session. Start a session first."))
                  (set-box! (cmd-ctx-state-box cctx) (add-transcript-entry state entry))
                  'continue]
                 [else
@@ -428,39 +432,49 @@
                  (define on-event (make-goal-event-bridge bus sid))
                  (define on-status (lambda (msg) (displayln (format "goal: ~a" msg))))
                  (define shutdown-box (cmd-ctx-running-box cctx))
+                 (define cancel-box (cmd-ctx-goal-cancel-box cctx))
                  (define run-prompt! (make-goal-run-prompt! sess))
                  ;; Set initial state in UI
                  (set-box! (cmd-ctx-state-box cctx) init-state)
                  ;; Spawn autonomous loop in background thread
                  (thread
                   (lambda ()
-                    (with-handlers ([exn:fail?
-                                     (lambda (e)
-                                       (on-event 'goal-failed
-                                                 (hasheq 'goal-text clean-text
-                                                         'reason (exn-message e)
-                                                         'turns-used 0))
-                                       (displayln (format "goal loop failed: ~a" (exn-message e))))])
+                    (with-handlers
+                        ([exn:fail?
+                          (lambda (e)
+                            (on-event
+                             'goal-failed
+                             (hasheq 'goal-text clean-text 'reason (exn-message e) 'turns-used 0))
+                            (displayln (format "goal loop failed: ~a" (exn-message e))))])
                       (define result
-                        (goal-run! clean-text provider evaluator-model run-prompt!
+                        (goal-run! clean-text
+                                   provider
+                                   evaluator-model
+                                   run-prompt!
                                    #:max-turns 8
                                    #:evaluator-mode evaluator-mode
                                    #:on-event on-event
                                    #:on-status on-status
-                                   #:shutdown-check (lambda () (not (unbox shutdown-box)))))
-                      ;; Update display state with final result
-                      (define final-info
-                        (goal-display-info clean-text
-                                           (goal-state-turns-used result)
-                                           8
-                                           (goal-state-status result)))
-                      ;; Read current state, update active-goal, write back
-                      (define cur-state (unbox (cmd-ctx-state-box cctx)))
-                      (set-box! (cmd-ctx-state-box cctx)
-                                (struct-copy ui-state cur-state [active-goal final-info])))))
+                                   #:shutdown-check (lambda ()
+                                                      (or (and cancel-box (unbox cancel-box))
+                                                          (not (unbox shutdown-box))))))
+                      ;; Update display state with final result (skip if cancelled)
+                      (define was-cancelled (and cancel-box (unbox cancel-box)))
+                      (unless was-cancelled
+                        (define final-info
+                          (goal-display-info clean-text
+                                             (goal-state-turns-used result)
+                                             8
+                                             (goal-state-status result)))
+                        (define cur-state (unbox (cmd-ctx-state-box cctx)))
+                        (set-box! (cmd-ctx-state-box cctx)
+                                  (struct-copy ui-state cur-state [active-goal final-info])))
+                      (when cancel-box
+                        (set-box! cancel-box #f)))))
                  (define entry
-                   (make-system-entry
-                    (format "[goal] Autonomous loop started: ~a~a~a"
-                            clean-text check-info eval-info)))
+                   (make-system-entry (format "[goal] Autonomous loop started: ~a~a~a"
+                                              clean-text
+                                              check-info
+                                              eval-info)))
                  (set-box! (cmd-ctx-state-box cctx) (add-transcript-entry init-state entry))
                  'continue])])])])]))

--- a/tui/commands/context.rkt
+++ b/tui/commands/context.rkt
@@ -23,7 +23,8 @@
          cmd-ctx-input-text-box
          cmd-ctx-extension-registry-box
          cmd-ctx-session-factory-runner
-         cmd-ctx-agent-session-box)
+         cmd-ctx-agent-session-box
+         cmd-ctx-goal-cancel-box)
 
 ;; ============================================================
 ;; Command context — lightweight alternative to tui-ctx
@@ -43,5 +44,6 @@
          input-text-box ; (boxof string?) — raw input text for commands like /activate
          extension-registry-box
          session-factory-runner
-         agent-session-box) ; (boxof (or/c agent-session? #f)) — live session for goal-runner
+         agent-session-box ; (boxof (or/c agent-session? #f)) — live session for goal-runner
+         goal-cancel-box) ; (boxof boolean?) — #t signals goal thread to stop
   #:transparent)

--- a/tui/context.rkt
+++ b/tui/context.rkt
@@ -32,7 +32,9 @@
          session-queue-box ; (boxof (or/c queue? #f)) — agent queue for followup during streaming (G3.1)
          session-factory-runner ; (or/c (string -> void) #f) — creates fresh session for /go
          component-registry-box ; (boxof (or/c (hash/c symbol? q-component?) #f)) — persistent components
-         focused-component-id-box) ; (boxof (or/c symbol? #f)) — currently focused component
+         focused-component-id-box ; (boxof (or/c symbol? #f)) — currently focused component
+         agent-session-box ; (boxof (or/c any/c #f)) — live agent session for goal-runner
+         goal-cancel-box) ; (boxof boolean?) — #t signals goal thread to stop
   #:transparent)
 
 (define (make-tui-ctx #:event-bus [bus #f]
@@ -41,7 +43,8 @@
                       #:model-registry [reg #f]
                       #:extension-registry [ext-reg #f]
                       #:session-queue [sess-queue #f]
-                      #:session-factory-runner [factory #f])
+                      #:session-factory-runner [factory #f]
+                      #:agent-session-box [sess-box #f])
   (tui-ctx (box (initial-ui-state))
            (box (initial-input-state))
            bus
@@ -60,7 +63,9 @@
            (box sess-queue) ; session-queue-box
            factory
            (box #f) ; component-registry-box - lazy init on first render
-           (box #f))) ; focused-component-id-box - no component focused initially
+           (box #f) ; focused-component-id-box - no component focused initially
+           (or sess-box (box #f)) ; agent-session-box
+           (box #f))) ; goal-cancel-box
 
 ;; Mark that the frame needs redraw.
 (define (mark-dirty! ctx)
@@ -95,6 +100,8 @@
          tui-ctx-session-factory-runner
          tui-ctx-component-registry-box
          tui-ctx-focused-component-id-box
+         tui-ctx-agent-session-box
+         tui-ctx-goal-cancel-box
          (contract-out [make-tui-ctx
                         (->* ()
                              (#:event-bus (or/c event-bus? #f)
@@ -103,7 +110,8 @@
                                           #:model-registry any/c
                                           #:extension-registry any/c
                                           #:session-queue any/c
-                                          #:session-factory-runner any/c)
+                                          #:session-factory-runner any/c
+                                          #:agent-session-box any/c)
                              tui-ctx?)]
                        [mark-dirty! (-> tui-ctx? void?)]
                        [tui-ctx-focused-component-id (-> tui-ctx? (or/c symbol? #f))]

--- a/tui/tui-init.rkt
+++ b/tui/tui-init.rkt
@@ -100,11 +100,14 @@
                           #:new-bus bus
                           #:new-extension-registry (dict-ref rt-config 'extension-registry #f)
                           #:reason 'fork)
+         ;; Update agent-session-box with new session for goal-runner
+         (set-box! (tui-ctx-agent-session-box ctx) new-sess)
          (set-box! (tui-ctx-ui-state-box ctx)
                    (initial-ui-state #:session-id new-sid
                                      #:model-name (dict-ref rt-config 'model-name #f)))
          (set-box! (tui-ctx-needs-redraw-box ctx) #t)
-         (run-prompt! new-sess prompt)))))
+         (run-prompt! new-sess prompt)))
+     #:agent-session-box (box sess)))
 
   ;; Scrollback path
   (define scrollback-path

--- a/tui/tui-keybindings.rkt
+++ b/tui/tui-keybindings.rkt
@@ -49,6 +49,8 @@
                   tui-ctx-extension-registry-box
                   tui-ctx-session-queue-box
                   tui-ctx-session-factory-runner
+                  tui-ctx-agent-session-box
+                  tui-ctx-goal-cancel-box
                   make-tui-ctx
                   mark-dirty!)
          ;; W16: selection-text, handle-mouse, tree overlay extracted to selection.rkt
@@ -88,6 +90,8 @@
          tui-ctx-extension-registry-box
          tui-ctx-session-queue-box
          tui-ctx-session-factory-runner
+         tui-ctx-agent-session-box
+         tui-ctx-goal-cancel-box
          ;; Re-exports (no contract needed — re-exported from other modules)
          copy-text!
          copy-selection!
@@ -165,7 +169,8 @@
                     (box "")
                     (tui-ctx-extension-registry-box ctx)
                     (tui-ctx-session-factory-runner ctx)
-                    (box #f)))
+                    (tui-ctx-agent-session-box ctx)
+                    (tui-ctx-goal-cancel-box ctx)))
 
 ;; Process a slash command. Returns 'continue | 'quit
 ;; cmd can be: symbol | (list symbol args...)


### PR DESCRIPTION
Wave 0 CRITICAL hotfix for v0.82.6. F-1: wire agent-session-box through TUI context pipeline. F-2: add goal cancellation mechanism via goal-cancel-box. 10 test files updated for new cmd-ctx arity.