### PR TITLE
fix(w1): --evaluator parsing + GOAL-EVIDENCE-SYSTEM-PROMPT injection (#6715)

### DIFF
--- a/runtime/goal/goal-runner.rkt
+++ b/runtime/goal/goal-runner.rkt
@@ -199,13 +199,16 @@
   (on-event 'goal-turn-started (hasheq 'turn-number turns 'goal-text goal-text))
   (on-status (format "Goal turn ~a/~a: working..." turns (goal-state-max-turns goal-st)))
 
-  ;; Build the prompt — prepend system instructions for evidence-driven behavior
+  ;; Build the prompt — prepend evidence-driven system instructions
   (define sys-instructions
-    (format
-     "You are in an autonomous goal loop (turn ~a/~a). Goal: ~a\nProvide specific evidence: run commands, check files, show outputs."
-     turns
-     (goal-state-max-turns goal-st)
-     goal-text))
+    (string-append
+     GOAL-EVIDENCE-SYSTEM-PROMPT
+     "\n\n"
+     (format
+      "You are in an autonomous goal loop (turn ~a/~a). Goal: ~a\nProvide specific evidence: run commands, check files, show outputs."
+      turns
+      (goal-state-max-turns goal-st)
+      goal-text)))
   (define prompt
     (if (= turns 1)
         (string-append sys-instructions "\n\n" goal-text)

--- a/tui/commands.rkt
+++ b/tui/commands.rkt
@@ -378,11 +378,15 @@
                          (char=? (string-ref t (sub1 (string-length t))) #\')))
                 (substring t 1 (sub1 (string-length t)))
                 t)))
-        ;; Check for --evaluator flag
+        ;; Check for --evaluator flag (only next token after --evaluator)
         (define evaluator-mode
-          (if (string-contains? arg-text "--evaluator")
-              (let ([parts (string-split arg-text)]) (if (member "agent" parts) 'agent 'transcript))
-              'transcript))
+          (let ([parts (string-split arg-text)])
+            (define eval-idx (index-of parts "--evaluator"))
+            (if eval-idx
+                (let ([next-token (and (< (add1 eval-idx) (length parts))
+                                       (list-ref parts (add1 eval-idx)))])
+                  (if (equal? next-token "agent") 'agent 'transcript))
+                'transcript)))
         ;; Validate check safety
         (define safety-reasons (validate-check-safety checks))
         (cond


### PR DESCRIPTION
Wave 1 of v0.82.6 hotfix. F-5: fix --evaluator flag parsing to only check next token after flag. F-6: inject GOAL-EVIDENCE-SYSTEM-PROMPT into goal-loop-step.