### PR TITLE
chore: version bump to v0.83.10 + metadata tag docs (#6777)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## v0.83.10 (2026-06-03)
+
+### Audit Closure — Runtime Fixes, Workflow Contracts, Metadata Tags
+
+**W0 (#6775):**
+- F1: Unique failure log names via `equal-hash-code` on full test path
+- F2: `@boundary`, `@isolation`, `@timeout` metadata tags recognized by runner
+- F3: `scenario-eof` factory for empty-stream provider testing
+- F4: `make-goal-provider-per-turn-cap` for goal loop turn-limit testing
+
+**W1 (#6776):**
+- T5: `test-goal-workflow-contract.rkt` — 8 goal lifecycle workflow tests
+- T7: Emit `context.built` event so TUI status bar shows token count
+- T9: `stream.turn.completed` handler clears busy state in TUI
+- T10: `stream_options.include_usage` in OpenAI-compatible streaming requests
+- T12: Preserve `session-index` in config when setting working-set
+- T13: Use `project-dir` for tool working-directory instead of log path
+- T14: Wire session queue into `make-loop-config` + use `enqueue-steering!` in submit-handler
+- T15: Clamp `maxParallel` instead of rejecting in `spawn-subagent`
+
+**W2 (#6777):**
+- T6: Document 6 metadata tags in `TEST_CONVENTIONS.md` with reference table
+- T16: Version bump to v0.83.10
+
 ## v0.83.9 (2026-06-03)
 
 ### Series Closure, Metrics, and Release Readiness

--- a/docs/TEST_CONVENTIONS.md
+++ b/docs/TEST_CONVENTIONS.md
@@ -21,9 +21,22 @@ Add these to the first 30 lines of test files:
 ;; @speed fast           ; fast | slow
 ;; @boundary unit        ; unit | integration
 ;; @mutates none         ; none | env | cwd | env,cwd
+;; @isolation none       ; none | mutating | process (v0.83.10+)
+;; @timeout 30           ; per-file timeout in seconds (v0.83.10+)
 ```
 
 The runner reads these tags for classification. Files without tags use heuristic fallbacks.
+
+### Tag Reference
+
+| Tag | Values | Effect |
+|-----|--------|--------|
+| `@suite` | `runtime`, `tui`, `cli`, `llm`, `tools`, `extensions` | Suite classification for parallel grouping |
+| `@speed` | `fast`, `slow` | Slow tests skipped in `--suite fast` |
+| `@boundary` | `unit`, `integration` | Integration tests may need sandbox isolation |
+| `@mutates` | `none`, `env`, `cwd`, `env,cwd` | Declares what the test mutates; affects sandbox setup |
+| `@isolation` | `none`, `mutating`, `process` | `mutating`/`process` forces sandbox setup; overrides heuristic |
+| `@timeout` | integer (seconds) | Per-file timeout override; replaces default timeout |
 
 ## Test Sandbox
 

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -11,4 +11,4 @@
 
 (provide (contract-out [q-version string?]))
 
-(define q-version "0.83.9")
+(define q-version "0.83.10")


### PR DESCRIPTION
Closes #6777. Closes #6774. Final wave of v0.83.10 audit closure milestone.