### PR TITLE
fix(tui): preserve goal status bar visual state (#6784)

### DIFF
--- a/tests/test-tui-goal-status-bar.rkt
+++ b/tests/test-tui-goal-status-bar.rkt
@@ -1,0 +1,81 @@
+#lang racket/base
+
+;; BOUNDARY: unit
+;; @suite tui
+;; @speed fast
+;; @boundary unit
+;; @mutates none
+;; tests/test-tui-goal-status-bar.rkt — TUI goal status-bar reducer contracts
+
+(require rackunit
+         racket/string
+         "../util/event.rkt"
+         "../util/cost-tracker.rkt"
+         "../tui/state.rkt"
+         "../tui/state-events.rkt"
+         "../tui/render/status-line.rkt"
+         "../tui/render/message-layout.rkt")
+
+(define (evt type payload)
+  (event 1 type 1000.0 "S" #f payload))
+
+(define (status-text st)
+  (styled-segment-text (car (styled-line-segments (render-status-bar st 100)))))
+
+(test-case "goal.status appends transcript entry and sets status-message"
+  (define st (initial-ui-state #:session-id "S" #:model-name "glm-5.1"))
+  (define st1 (apply-event-to-state st (evt "goal.status" (hasheq 'message "Goal turn 1/8: working..."))))
+  (check-equal? (ui-state-status-message st1) "Goal turn 1/8: working...")
+  (check-true (string-contains? (transcript-entry-text (car (ui-state-transcript st1)))
+                                "[goal] Goal turn 1/8: working..."))
+  (check-true (string-contains? (status-text st1) "Goal turn 1/8")))
+
+(test-case "goal.turn.started sets busy marker while preserving goal badge"
+  (define st (initial-ui-state #:session-id "S" #:model-name "glm-5.1"))
+  (define st1 (apply-event-to-state st (evt "goal.started" (hasheq 'goal-text "build website" 'max-turns 8))))
+  (define st2 (apply-event-to-state st1 (evt "goal.turn.started" (hasheq 'turn-number 1))))
+  (check-true (ui-state-busy? st2))
+  (check-not-false (ui-state-active-goal st2))
+  (check-true (string-contains? (status-text st2) "*"))
+  (check-true (string-contains? (status-text st2) "goal 1/8")))
+
+(test-case "stream.turn.completed clears busy for normal chat"
+  (define st (set-busy (initial-ui-state #:session-id "S" #:model-name "glm-5.1") #t))
+  (define st1 (apply-event-to-state st (evt "stream.turn.completed" (hasheq))))
+  (check-false (ui-state-busy? st1))
+  (check-false (ui-state-active-goal st1)))
+
+(test-case "stream.turn.completed preserves active-goal visual working state"
+  (define st (initial-ui-state #:session-id "S" #:model-name "glm-5.1"))
+  (define st1 (apply-event-to-state st (evt "goal.started" (hasheq 'goal-text "build website" 'max-turns 8))))
+  (define st2 (apply-event-to-state st1 (evt "goal.turn.started" (hasheq 'turn-number 1))))
+  (define st3 (apply-event-to-state st2 (evt "stream.turn.completed" (hasheq))))
+  (check-true (ui-state-busy? st3))
+  (check-not-false (ui-state-active-goal st3))
+  (check-true (string-contains? (or (ui-state-status-message st3) "") "evaluating"))
+  (check-true (string-contains? (status-text st3) "*"))
+  (check-true (string-contains? (status-text st3) "evaluating")))
+
+(test-case "context.built accepts camelCase and kebab-case token keys"
+  (define st (initial-ui-state #:session-id "S" #:model-name "glm-5.1"))
+  (define st1 (apply-event-to-state st (evt "context.built" (hasheq 'tokenCount 5000))))
+  (check-equal? (ui-state-context-tokens st1) 5000)
+  (define st2 (apply-event-to-state st1 (evt "context.built" (hasheq 'token-count 6000))))
+  (check-equal? (ui-state-context-tokens st2) 6000))
+
+(test-case "model.stream.completed with missing or malformed usage does not throw"
+  (define st (initial-ui-state #:session-id "S" #:model-name "glm-5.1"))
+  (check-not-exn (lambda () (apply-event-to-state st (evt "model.stream.completed" (hasheq)))))
+  (check-not-exn (lambda () (apply-event-to-state st (evt "model.stream.completed" (hasheq 'usage #f))))))
+
+(test-case "model.stream.completed valid estimated usage updates cost tracker and renders cost"
+  (define trk (make-cost-tracker "glm-5.1"))
+  (define st (struct-copy ui-state
+                          (initial-ui-state #:session-id "S" #:model-name "glm-5.1")
+                          [cost-tracker trk]))
+  (define st1 (apply-event-to-state st (evt "model.stream.completed"
+                                            (hasheq 'usage (hasheq 'prompt_tokens 5000
+                                                                   'completion_tokens 250
+                                                                   'estimated? #t)))))
+  (check-true (positive? (cost-tracker-input-tokens-total (ui-state-cost-tracker st1))))
+  (check-true (string-contains? (status-text st1) "$")))

--- a/tui/state-events.rkt
+++ b/tui/state-events.rkt
@@ -291,9 +291,18 @@
 ;; v0.83.10: Handle stream.turn.completed from iteration loop.
 ;; Same cleanup as turn.completed but handles the iteration loop's completion path.
 (define (handle-stream-turn-completed state evt)
-  (set-streaming-phase (clear-streaming (set-pending-tool-name (set-busy-since (set-busy state #f) #f)
-                                                               #f))
-                       'idle))
+  (define cleared
+    (set-streaming-phase
+     (clear-streaming (set-pending-tool-name (set-busy-since (set-busy state #f) #f) #f))
+     'idle))
+  (define goal (ui-state-active-goal cleared))
+  (if (and goal (eq? (goal-display-info-status goal) 'active))
+      (set-busy (set-status-message cleared
+                                    (format "Goal turn ~a/~a: evaluating..."
+                                            (goal-display-info-turns-used goal)
+                                            (goal-display-info-max-turns goal)))
+                #t)
+      cleared))
 
 (define (handle-compaction-warning state evt)
   (define payload (event-payload evt))
@@ -344,7 +353,8 @@
 
 (define (handle-context-built state evt)
   (define payload (event-payload evt))
-  (define tok (hash-ref payload 'tokenCount #f))
+  (define tok
+    (and (hash? payload) (or (hash-ref payload 'tokenCount #f) (hash-ref payload 'token-count #f))))
   (if tok
       (struct-copy ui-state state [context-tokens tok])
       state))
@@ -463,11 +473,15 @@
 
 (define (handle-model-stream-completed state evt)
   (define payload (event-payload evt))
-  (define usage (hash-ref payload 'usage (hasheq)))
+  (define raw-usage (and (hash? payload) (hash-ref payload 'usage (hasheq))))
+  (define usage
+    (if (hash? raw-usage)
+        raw-usage
+        (hasheq)))
   (define in-tok (hash-ref usage 'prompt_tokens (hash-ref usage 'input_tokens 0)))
   (define out-tok (hash-ref usage 'completion_tokens (hash-ref usage 'output_tokens 0)))
   (define ct (ui-state-cost-tracker state))
-  (when ct
+  (when (and ct (or (positive? in-tok) (positive? out-tok)))
     (cost-tracker-update! ct in-tok out-tok (ui-model-label state)))
   (clear-streaming state))
 
@@ -526,12 +540,14 @@
   (define payload (event-payload evt))
   (define turn (hash-ref payload 'turn-number 1))
   (define current (ui-state-active-goal state))
-  (if current
-      (struct-copy ui-state
-                   state
-                   [active-goal
-                    (struct-copy goal-display-info current [turns-used turn] [status 'active])])
-      state))
+  (define updated
+    (if current
+        (struct-copy ui-state
+                     state
+                     [active-goal
+                      (struct-copy goal-display-info current [turns-used turn] [status 'active])])
+        state))
+  (set-busy-since (set-busy updated #t) (event-time evt)))
 
 (define (handle-goal-evaluated state evt)
   ;; Evaluation complete, status stays active but turns updated
@@ -570,8 +586,15 @@
 
 (define (handle-goal-status state evt)
   (define payload (event-payload evt))
-  (define msg (hash-ref payload 'message ""))
-  (append-entry state (make-entry 'system (format "[goal] ~a" msg) (event-time evt) (hash))))
+  (define msg
+    (if (hash? payload)
+        (hash-ref payload 'message "")
+        ""))
+  (define with-entry
+    (append-entry state (make-entry 'system (format "[goal] ~a" msg) (event-time evt) (hash))))
+  (if (string=? msg "")
+      with-entry
+      (set-status-message with-entry msg)))
 
 (register-event-reducer! "goal.started" handle-goal-started)
 (register-event-reducer! "goal.turn.started" handle-goal-turn-started)


### PR DESCRIPTION
Closes #6784.

Validation:
- raco make tui/state-events.rkt tui/render/status-line.rkt agent/loop-stream.rkt
- raco test tests/tui/test-render-status-line.rkt → 19 passed
- raco test tests/test-tui-goal-status-bar.rkt → 7 passed
- raco test tests/test-goal-tui.rkt → 23 passed
- raco test tests/test-tui-watchdog.rkt → 17 passed

Reviewer: APPROVED.