### PR TITLE
fix(runtime): normalize steering strings and suppress benign bash warnings (#6785)

### DIFF
--- a/agent/iteration/loop-phases.rkt
+++ b/agent/iteration/loop-phases.rkt
@@ -24,7 +24,10 @@
          (only-in "../../runtime/runtime-helpers.rkt" maybe-dispatch-hooks emit-session-event!)
          (only-in "../../util/hook-types.rkt" hook-result-action hook-result?)
          (only-in "../../runtime/layer-adapters.rkt" extension-registry?)
-         (only-in "../../runtime/iteration/internal.rkt" assert-payload))
+         (only-in "../../runtime/iteration/internal.rkt" assert-payload)
+         (only-in "../../util/ids.rkt" generate-id)
+         (only-in "../../util/message.rkt" make-message message?)
+         (only-in "../../util/content-parts.rkt" make-text-part))
 
 ;; Re-export for consumers
 (provide (contract-out [prepare-iteration-context
@@ -42,6 +45,21 @@
 ;; Pure-ish: Context preparation
 ;; ============================================================
 
+;; Convert steering queue items to context messages.
+;; TUI steering can arrive as raw strings while iteration context consumers expect message?.
+(define (steering-item->message item)
+  (cond
+    [(message? item) item]
+    [(string? item)
+     (make-message (generate-id)
+                   #f
+                   'user
+                   'message
+                   (list (make-text-part item))
+                   (current-seconds)
+                   (hasheq 'source 'steering))]
+    [else #f]))
+
 ;; Prepare iteration context by dequeuing steering and injected messages.
 ;; Returns the augmented context list.
 (define (prepare-iteration-context ctx steering-queue injected-box bus ext-reg session-id)
@@ -52,9 +70,10 @@
           (let ([qs (queue-status steering-queue)])
             (when (or (> (hash-ref qs 'steering 0) 0) (> (hash-ref qs 'followup 0) 0))
               (emit-session-event! bus session-id "queue.status-update" qs)))
-          (if (null? steering-msgs)
+          (define steering-msgs* (filter values (map steering-item->message steering-msgs)))
+          (if (null? steering-msgs*)
               ctx
-              (append ctx steering-msgs)))
+              (append ctx steering-msgs*)))
         ctx))
   ;; Injected messages
   (if injected-box

--- a/tests/test-destructive-warning.rkt
+++ b/tests/test-destructive-warning.rkt
@@ -60,6 +60,32 @@
                "ls should NOT produce a destructive-command warning on stderr"))
 
 ;; --------------------------------------------------
+;; Test 4b: Benign command substitution does NOT leak warning/diagnostic
+;; --------------------------------------------------
+(let ([captured-stderr (open-output-string)])
+  (define benign-command
+    "for f in /tmp/example.rkt; do name=$(basename \"$f\"); echo \"$name\"; done")
+  (parameterize ([current-error-port captured-stderr]
+                 [current-bash-execution-config (make-bash-execution-config #:warn? #t #:block? #f)])
+    (tool-bash (hasheq 'command benign-command)))
+  (define stderr-str (get-output-string captured-stderr))
+  (check-false (string-contains? stderr-str "Destructive command detected")
+               "benign command substitution should not produce destructive warning")
+  (check-false (string-contains? stderr-str "[CLASSIFIER-DIAG]")
+               "classifier disagreement diagnostics should not print by default"))
+
+;; --------------------------------------------------
+;; Test 4c: Risky regex-only commands still warn
+;; --------------------------------------------------
+(let ([captured-stderr (open-output-string)])
+  (parameterize ([current-error-port captured-stderr]
+                 [current-bash-execution-config (make-bash-execution-config #:warn? #t #:block? #f)])
+    (tool-bash (hasheq 'command "source /tmp/untrusted-q-test-script")))
+  (define stderr-str (get-output-string captured-stderr))
+  (check-not-false (string-contains? stderr-str "Destructive command detected")
+                   "risky regex-only commands should still warn in warn mode"))
+
+;; --------------------------------------------------
 ;; Test 5: Setting warn? #f suppresses warnings on destructive commands
 ;; --------------------------------------------------
 (let ([captured-stderr (open-output-string)])

--- a/tests/test-iteration-steering.rkt
+++ b/tests/test-iteration-steering.rkt
@@ -1,0 +1,50 @@
+#lang racket/base
+
+;; BOUNDARY: unit
+;; @suite runtime
+;; @speed fast
+;; @boundary unit
+;; @mutates none
+;; tests/test-iteration-steering.rkt — steering queue normalization contracts
+
+(require rackunit
+         "../agent/event-bus.rkt"
+         "../agent/queue.rkt"
+         "../agent/iteration/loop-phases.rkt"
+         "../util/message.rkt"
+         "../util/content-parts.rkt")
+
+(define (message-text msg)
+  (define part (car (message-content msg)))
+  (and (text-part? part) (text-part-text part)))
+
+(test-case "prepare-iteration-context converts raw steering strings to user messages"
+  (define bus (make-event-bus))
+  (define q (make-queue))
+  (enqueue-steering! q "No, use /home/user/src/q-agent/q/website")
+  (define result (prepare-iteration-context '() q #f bus #f "s1"))
+  (check-equal? (length result) 1)
+  (define msg (car result))
+  (check-true (message? msg))
+  (check-equal? (message-role msg) 'user)
+  (check-equal? (message-kind msg) 'message)
+  (check-equal? (message-text msg) "No, use /home/user/src/q-agent/q/website")
+  (check-equal? (hash-ref (message-meta msg) 'source #f) 'steering))
+
+(test-case "prepare-iteration-context preserves existing message steering items"
+  (define bus (make-event-bus))
+  (define q (make-queue))
+  (define original
+    (make-message "mid" #f 'user 'message (list (make-text-part "already a message")) 0 (hasheq)))
+  (enqueue-steering! q original)
+  (define result (prepare-iteration-context '() q #f bus #f "s1"))
+  (check-equal? result (list original)))
+
+(test-case "prepared context with raw steering can be consumed by message-id"
+  (define bus (make-event-bus))
+  (define q (make-queue))
+  (define base
+    (make-message "base" #f 'user 'message (list (make-text-part "base")) 0 (hasheq)))
+  (enqueue-steering! q "steer text")
+  (define result (prepare-iteration-context (list base) q #f bus #f "s1"))
+  (check-not-exn (lambda () (map message-id result))))

--- a/tools/builtins/bash.rkt
+++ b/tools/builtins/bash.rkt
@@ -207,6 +207,14 @@
   (for/or ([pattern (in-list high-risk-patterns)])
     (regexp-match? pattern lower)))
 
+;; Structured classifier source-of-truth helper for user-visible warnings.
+(define (structured-destructive-command? command)
+  (define findings (classify-shell-risks (tokenize-shell-command command)))
+  (for/or ([f (in-list findings)])
+    (member
+     (shell-risk-finding-type f)
+     '(destructive high-risk windows-destructive network-pipe command-substitution eval exec))))
+
 ;; ── Structured risk classifier shadow mode (v0.70.3) ──
 ;; Compares regex-based detection with structured classifier.
 ;; Returns diagnostic string when they disagree, #f when they agree.
@@ -316,13 +324,24 @@
        [(and block-destructive? (destructive-command? command))
         (make-error-result (format "Blocked destructive command: ~a" command))]
        [else
-        ;; Optional warning
-        (when (and warn-on-destructive? (destructive-command? command))
+        ;; Optional warning. Prefer structured classifier for user-visible warning-only UX:
+        ;; benign command substitutions such as name=$(basename "$f") should not alarm users
+        ;; when the structured classifier finds no risk.
+        (define regex-destructive? (destructive-command? command))
+        (define structured-destructive? (structured-destructive-command? command))
+        (define lower-command (string-downcase command))
+        (define benign-substitution-disagreement?
+          (and regex-destructive?
+               (not structured-destructive?)
+               (or (regexp-match? #rx"\\$\\(" lower-command)
+                   (regexp-match? #rx"`[^`]+`" lower-command))))
+        (define should-warn?
+          (or structured-destructive?
+              (and regex-destructive? (not benign-substitution-disagreement?))))
+        (when (and warn-on-destructive? should-warn?)
           (fprintf warning-port "WARNING: Destructive command detected: ~a~n" command))
-        ;; v0.70.3: Structured classifier shadow mode — log disagreements
-        (define classifier-diag (shell-risk-classifier-diagnostic command))
-        (when classifier-diag
-          (fprintf warning-port "~a" classifier-diag))
+        ;; v0.70.3: Shadow diagnostics remain available through
+        ;; shell-risk-classifier-diagnostic, but are not printed to stderr/TUI by default.
         (define timeout-arg (hash-ref args 'timeout #f))
         (define raw-work-dir (hash-ref args 'working-directory #f))
         (define work-dir (and raw-work-dir (expand-home-path raw-work-dir)))


### PR DESCRIPTION
Closes #6785.

Validation:
- raco make agent/iteration/loop-phases.rkt tools/builtins/bash.rkt
- raco test tests/test-iteration-steering.rkt → 3 passed
- raco test tests/test-steering.rkt → 28 passed
- raco test tests/test-destructive-warning.rkt → 16 passed
- raco test tests/test-tool-bash-security.rkt → 50 passed
- raco test tests/test-loop-phases.rkt → 6 passed

Reviewer: APPROVED.