### PR TITLE
chore: bump version to 0.84.0, update CHANGELOG (#6797)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v0.84.0 (2026-06-03)
+
+### Facade Purge & Version Sync
+
+- **Remove 87 deprecated facades** (49 runtime + 38 util)
+  - All runtime/*.rkt facades deleted; imports updated to canonical sub-package paths (runtime/auth/, runtime/compaction/, runtime/context/, runtime/goal/, runtime/session/, runtime/provider/, etc.)
+  - All util/*.rkt facades deleted; imports updated to canonical sub-package paths (util/content/, util/error/, util/event/, util/export/, util/json/, util/message/, util/safe-mode/, util/tool/, etc.)
+  - 620 files changed, 1048 insertions(+), 1399 deletions(-)
+  - Zero deprecated facades remain in q/
+
 ## v0.83.12 (2026-06-03)
 
 ### TUI Status Bar Visual Gap

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -11,4 +11,4 @@
 
 (provide (contract-out [q-version string?]))
 
-(define q-version "0.83.12")
+(define q-version "0.84.0")


### PR DESCRIPTION
Closes #6797.