### PR TITLE
v0.86.5 W1: Event Name Migration + Steering Fix (#6884)

### DIFF
--- a/tests/test-agent-session-basic.rkt
+++ b/tests/test-agent-session-basic.rkt
@@ -498,7 +498,7 @@
    (check-equal? (last names) "session.updated")
    ;; Core loop events in between
    (check-not-false (member "turn.started" names))
-   (check-not-false (member "turn.completed" names))
+   (check-not-false (member "stream.turn.completed" names))
    (check-not-false (member "context.built" names))
    (check-not-false (member "assistant.message.completed" names))
 

--- a/tests/test-event-ordering.rkt
+++ b/tests/test-event-ordering.rkt
@@ -180,7 +180,7 @@
 
       (define events (unbox captured))
       (check-equal? (last events)
-                    "turn.completed"
+                    "stream.turn.completed"
                     "turn.completed must be the last event in the sequence"))))
 
 (module+ test

--- a/tests/test-loop-cancellation.rkt
+++ b/tests/test-loop-cancellation.rkt
@@ -66,7 +66,7 @@
       (check-not-false (member "turn.cancelled" evt-names)
                        "turn.cancelled emitted after cancellation during stream")
       ;; turn.completed should still be emitted
-      (check-not-false (member "turn.completed" evt-names) "turn.completed emitted")
+      (check-not-false (member "stream.turn.completed" evt-names) "turn.completed emitted")
       ;; Result should be cancelled
       (check-equal? (loop-result-termination-reason result) 'cancelled "result status is cancelled"))
 

--- a/tests/test-loop-edge-cases.rkt
+++ b/tests/test-loop-edge-cases.rkt
@@ -61,7 +61,7 @@
       (define evt-names (map event-event evts))
 
       ;; Should complete normally
-      (check-not-false (member "turn.completed" evt-names) "turn.completed emitted")
+      (check-not-false (member "stream.turn.completed" evt-names) "turn.completed emitted")
 
       ;; No text delta was emitted (no message.start because no text)
       (check-false (member "message.start" evt-names) "no message.start for tool-only stream")
@@ -97,7 +97,7 @@
       (define evt-names (map event-event evts))
 
       ;; Should complete normally
-      (check-not-false (member "turn.completed" evt-names) "turn.completed emitted on empty stream")
+      (check-not-false (member "stream.turn.completed" evt-names) "turn.completed emitted on empty stream")
       (check-equal? (loop-result-termination-reason result) 'completed "result status is completed")
       ;; No message events (no text content)
       (check-false (member "message.start" evt-names) "no message.start for empty stream"))
@@ -191,7 +191,7 @@
       ;; message.end must be emitted as cleanup
       (check-not-false (member "message.end" evt-names) "message.end emitted as cleanup after crash")
       ;; turn.completed must be emitted as cleanup
-      (check-not-false (member "turn.completed" evt-names)
+      (check-not-false (member "stream.turn.completed" evt-names)
                        "turn.completed emitted as cleanup after crash"))
 
     ;; ============================================================
@@ -231,7 +231,7 @@
         ;; Should have message.start, message.end, turn.completed
         (check-not-false (member "message.start" evt-names))
         (check-not-false (member "message.end" evt-names))
-        (check-not-false (member "turn.completed" evt-names))
+        (check-not-false (member "stream.turn.completed" evt-names))
         ;; Chunk count should be limited
         (check-true (<= (unbox call-count) 105)
                     (format "chunk count ~a is within limit" (unbox call-count)))))
@@ -264,7 +264,7 @@
       ;; No message.start was emitted
       (check-false (member "message.start" evt-names) "no message.start when crash before text")
       ;; But turn.completed should still be emitted as cleanup
-      (check-not-false (member "turn.completed" evt-names) "turn.completed emitted as cleanup"))))
+      (check-not-false (member "stream.turn.completed" evt-names) "turn.completed emitted as cleanup"))))
 
 (module+ main
   (run-tests edge-case-tests)

--- a/tests/test-loop.rkt
+++ b/tests/test-loop.rkt
@@ -68,9 +68,9 @@
   (define q (make-queue))
   (check-pred queue-empty? q)
   (define msg-1 (make-message "m-1" #f 'user 'message (list (make-text-part "hi")) 1000 '#hash()))
-  (enqueue-steering! q msg-1)
+  (enqueue-steering! q "steer-text")
   (check-false (queue-empty? q))
-  (check-equal? (dequeue-steering! q) msg-1)
+  (check-equal? (dequeue-steering! q) "steer-text")
   (check-true (queue-empty? q)))
 
 ;; ============================================================

--- a/tests/test-streaming-tool-events.rkt
+++ b/tests/test-streaming-tool-events.rkt
@@ -75,7 +75,7 @@
       (check-not-false (member "model.stream.delta" events))
       (check-not-false (member "assistant.message.completed" events))
       (check-not-false (member "tool.call.started" events))
-      (check-not-false (member "turn.completed" events))
+      (check-not-false (member "stream.turn.completed" events))
 
       ;; Specifically verify B1: assistant.message.completed comes before tool.call.started
       (define amc-idx (index-of events "assistant.message.completed"))


### PR DESCRIPTION
Fix "turn.completed" → "stream.turn.completed" in 5 test files + fix enqueue-steering! in test-loop.rkt.

Closes #6884