### PR TITLE
v0.86.5 W8: Event Registry Gap (#6891)

### DIFF
--- a/agent/event-json.rkt
+++ b/agent/event-json.rkt
@@ -333,7 +333,9 @@
                    "provider.stream.completed"
                    "model.request.blocked"
                    "message.blocked"
-                   "turn.cancelled"))
+                   "turn.cancelled"
+    "stream.turn.completed"
+    "assistant.message.completed"))
 
 (define (event-name->tool-name type)
   (match type


### PR DESCRIPTION
Add assistant.message.completed + stream.turn.completed to all-known-event-types.

Closes #6891