### PR TITLE
v0.90.2: Version Bump + CHANGELOG (#6948)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,14 @@
 
+## v0.90.2 (2026-06-03)
+
+### Browser Tool Registry Integration (Phase 4)
+
+- Add `tools/builtins/browser-tools.rkt`: 9 tool handlers (browser_open, browser_observe, browser_click, browser_type, browser_press, browser_extract, browser_screenshot, browser_scroll, browser_close)
+- Register all 9 browser tools in `tools/registry-table.rkt` with JSON schemas and prompt guidelines
+- Risk classification: click/type/press = HIGH risk (requires approval), open = MEDIUM, observe/extract/screenshot/scroll/close = LOW
+- 16 new tool handler tests
+- **217 total browser tests**
+
 ## v0.89.3 (2026-06-03)
 
 ### Browser Secure Service + Audit + Mock Adapter (Phase 3)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.89.3-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.90.2-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 
@@ -202,7 +202,7 @@ bin/q --model gpt-5.4 "write a test"
 ### Verify
 
 ```bash
-bin/q --version            # q version 0.89.3
+bin/q --version            # q version 0.90.2
 raco test tests/           # run the full test suite
 ```
 

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.89.3")
+(define version "0.90.2")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base" "gui-easy-lib"))

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -11,4 +11,4 @@
 
 (provide (contract-out [q-version string?]))
 
-(define q-version "0.89.3")
+(define q-version "0.90.2")


### PR DESCRIPTION
Version bump 0.89.3 → 0.90.2. Phase 4 complete. 217 browser tests.

Closes #6948, closes #6951