### PR TITLE
v0.91.3: Version Bump + CHANGELOG (#6957)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,20 @@
 
+## v0.91.3 (2026-06-03)
+
+### Playwright Sidecar + Real Adapter (Phase 5)
+
+- Add `sidecars/playwright/`: Node.js/Playwright sidecar with JSONL stdin/stdout protocol
+  - 9 command handlers: navigate, click, type, press, scroll, extract, screenshot, ping, close
+  - Page state extraction, screenshot capture with size limits, health check ping/pong
+  - Error mapping: Playwright errors → q-browser-error categories (timeout, adapter-error, sidecar-crash, policy-violation)
+  - Node.js unit tests for command validation
+- Add `browser/adapters/playwright-sidecar.rkt`: Racket adapter for sidecar process lifecycle
+  - JSONL IPC with UUID-based request/response and timeout
+  - Zombie prevention via custodian management
+  - Full browser-adapter interface implementation
+- 4 new Racket unit tests + 3 integration tests (skipped without Node.js)
+- **225 total browser tests**
+
 ## v0.90.2 (2026-06-03)
 
 ### Browser Tool Registry Integration (Phase 4)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.90.2-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.91.3-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 
@@ -202,7 +202,7 @@ bin/q --model gpt-5.4 "write a test"
 ### Verify
 
 ```bash
-bin/q --version            # q version 0.90.2
+bin/q --version            # q version 0.91.3
 raco test tests/           # run the full test suite
 ```
 

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.90.2")
+(define version "0.91.3")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base" "gui-easy-lib"))

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -11,4 +11,4 @@
 
 (provide (contract-out [q-version string?]))
 
-(define q-version "0.90.2")
+(define q-version "0.91.3")


### PR DESCRIPTION
Version bump 0.90.2 → 0.91.3. Phase 5 complete. 225 browser tests.

Closes #6957, closes #6963