### PR TITLE
v0.92.2: Validation + Version Bump (#6968)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,17 @@
 
+## v0.92.2 (2026-06-03)
+
+### Workflow Tool + Documentation (Phase 6)
+
+- Add `browser/workflow.rkt`: `browser_check_local_app` composite tool
+  - Open URL → observe → screenshot → close → return composite result
+  - Returns: url, title, text, console_errors, loaded_successfully, load_time_ms, screenshot
+- Register `browser_check_local_app` as MEDIUM risk in tool registry
+- Add `docs/browser-guide.md`: feature overview, architecture, tool reference, security model
+- Add `docs/adr/0020-browser-feature-architecture.md`: sidecar rationale, JSONL protocol, adapter contract
+- 15 workflow + integration tests
+- **240 total browser tests**
+
 ## v0.91.3 (2026-06-03)
 
 ### Playwright Sidecar + Real Adapter (Phase 5)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.91.3-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.92.2-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 
@@ -202,7 +202,7 @@ bin/q --model gpt-5.4 "write a test"
 ### Verify
 
 ```bash
-bin/q --version            # q version 0.91.3
+bin/q --version            # q version 0.92.2
 raco test tests/           # run the full test suite
 ```
 

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.91.3")
+(define version "0.92.2")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base" "gui-easy-lib"))

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -11,4 +11,4 @@
 
 (provide (contract-out [q-version string?]))
 
-(define q-version "0.91.3")
+(define q-version "0.92.2")


### PR DESCRIPTION
Version bump 0.91.3 → 0.92.2. Phase 6 complete. 240 browser tests.

Closes #6968