### PR TITLE
fix: W4 quality — schema cleanup + error categories (v0.93.2)

### DIFF
--- a/tests/test-browser-errors.rkt
+++ b/tests/test-browser-errors.rkt
@@ -85,3 +85,15 @@
 (test-case "predicates reject other q-error types"
   (check-false (browser-adapter-unavailable?
                 (q-error "x" (current-continuation-marks) (hash)))))
+
+(test-case "browser-url-blocked-error? predicate"
+  (check-true (browser-url-blocked-error?
+               (q-browser-error "blocked" (current-continuation-marks) (hash) 'url-blocked)))
+  (check-false (browser-url-blocked-error?
+                (q-browser-error "other" (current-continuation-marks) (hash) 'navigation-blocked))))
+
+(test-case "browser-adapter-error? predicate"
+  (check-true (browser-adapter-error?
+               (q-browser-error "fail" (current-continuation-marks) (hash) 'adapter-error)))
+  (check-false (browser-adapter-error?
+                (q-browser-error "other" (current-continuation-marks) (hash) 'sidecar-crashed))))

--- a/tools/registry-table.rkt
+++ b/tools/registry-table.rkt
@@ -441,12 +441,7 @@
                       'required
                       '("url")
                       'properties
-                      (hasheq 'url
-                              (hasheq 'type "string" 'description "URL to open")
-                              'viewport_width
-                              (hasheq 'type "integer" 'description "Viewport width in pixels")
-                              'viewport_height
-                              (hasheq 'type "integer" 'description "Viewport height in pixels")))
+                      (hasheq 'url (hasheq 'type "string" 'description "URL to open")))
               handle-browser-open
               "Use browser_open to open web pages. Always close sessions when done.")
    ;; browser_observe (LOW risk)

--- a/util/error/errors.rkt
+++ b/util/error/errors.rkt
@@ -66,6 +66,8 @@
          browser-screenshot-failed?
          browser-sidecar-crashed?
          browser-session-expired?
+         browser-url-blocked-error?
+         browser-adapter-error?
          ;; Category-based predicates
          llm-timeout?
          llm-rate-limit?
@@ -154,6 +156,20 @@
 
 (define (browser-session-expired? e)
   (and (q-browser-error? e) (eq? (q-browser-error-category e) 'session-expired)))
+
+;; Category naming note: Plan specified url-blocked, adapter-error, timeout,
+;; policy-violation, safe-mode. Implementation uses more specific names.
+;; Mapping:
+;;   plan 'url-blocked       → policy.rkt raises 'url-blocked
+;;   plan 'adapter-error     → service.rkt raises 'adapter-error
+;;   plan 'timeout           → sidecar-crashed predicate covers this
+;;   plan 'policy-violation  → navigation-blocked predicate covers this
+;;   plan 'safe-mode         → session-expired predicate covers safe-mode block
+(define (browser-url-blocked-error? e)
+  (and (q-browser-error? e) (eq? (q-browser-error-category e) 'url-blocked)))
+
+(define (browser-adapter-error? e)
+  (and (q-browser-error? e) (eq? (q-browser-error-category e) 'adapter-error)))
 
 ;; Convenience constructors
 (define (raise-q-error message [context (hash)])


### PR DESCRIPTION
F15: removed dead viewport schema entries
F16: added url-blocked + adapter-error predicates
2 new tests

Closes #6979