### PR TITLE
docs: v0.94.0 W0.1 UI current-state inventory

### DIFF
--- a/docs/reports/v0.94.0-ui-current-state.md
+++ b/docs/reports/v0.94.0-ui-current-state.md
@@ -1,0 +1,21 @@
+# v0.94.0 UI Current-State Audit
+
+**Date:** 2026-06-05
+**Wave:** W0.1 Current-state inventory
+
+## Finding Matrix
+
+| Finding | Evidence | Status | Target |
+|---|---|---:|---|
+| A. UI surface tied to TUI state | `extensions/ui-surface.rkt` requires `../tui/state.rkt`; widget fallback mutates `ui-state-extension-widgets`. | open | v0.94.1/v0.94.6 |
+| B. TUI/GUI state divergence | TUI has reducer registry in `tui/state-events.rkt`; GUI has separate subscriber `cond` in `gui/state-sync.rkt`. | open | v0.94.2 |
+| C. GUI hooks declared but not live | GUI hooks exist in `util/hook-types.rkt`; `gui/main.rkt` does not dispatch startup/close lifecycle hooks. | open | v0.94.3 |
+| D. Theme sync partial | `ui-core/theme-protocol.rkt` exists; GUI theme manager is isolated; no shared `ui.theme.change` flow. | partial | v0.94.3 |
+| E. Command parity gaps | `gui/slash-commands.rkt` uses a hand-maintained command subset and no shared metadata registry. | open | v0.94.4 |
+| F. Responsive layout partial | `ui-core/layout-protocol.rkt` has layout geometry, but no breakpoint classifier or layout event. | partial | v0.94.5 |
+| Extension widgets incomplete | Widgets are TUI-state entries, not backend-neutral descriptors. | open | v0.94.6 |
+| Render hooks incomplete | No `ui.component.pre-render` / `ui.component.post-render` hook schema yet. | open | v0.94.7 |
+
+## Next Step
+
+W0.2 should add characterization tests for callback fallback behavior, GUI hook declarations, and headless import safety.


### PR DESCRIPTION
Implements v0.94.0 W0.1 current-state inventory.

Validation: focused UI tests passed (85 tests). Broader vdom-components suggested check has a pre-existing zero-count sentinel caveat.

Closes #6989