### PR TITLE
feat: v0.94.1 W1.2 event-publishing dual-path in ui-surface

### DIFF
--- a/extensions/ui-surface.rkt
+++ b/extensions/ui-surface.rkt
@@ -9,9 +9,26 @@
 ;; This breaks the upward import from extensions/ → tui/ (ARCH-02).
 ;; M-08 (v0.38.4): Replaced 10 individual parameters with a single
 ;; ui-callback-registry struct.
+;; v0.94.1 (W1.2): Added event-publishing dual-path behind feature flag.
 
 (require racket/contract
-         (only-in "../tui/state.rkt" ui-state ui-state? ui-state-extension-widgets))
+         (only-in "../tui/state.rkt" ui-state ui-state? ui-state-extension-widgets)
+         (only-in "../ui-core/ui-actions.rkt"
+                  current-ui-event-actions-enabled?
+                  emit-ui-action!
+                  UI-ACTION-HEADER-SET
+                  UI-ACTION-HEADER-CLEAR
+                  UI-ACTION-FOOTER-SET
+                  UI-ACTION-FOOTER-CLEAR
+                  UI-ACTION-STATUS-SET
+                  UI-ACTION-WIDGET-REGISTER
+                  UI-ACTION-WIDGET-UNREGISTER
+                  UI-ACTION-WIDGET-UNREGISTER-ALL))
+
+;; ── Event runtime parameter ────────────────────────────────
+;; Extensions don't have direct access to the runtime hash.
+;; This parameter holds a hash with 'emit-event key (or #f).
+(define current-ui-event-runtime (make-parameter #f))
 
 ;; Setter/Getter parameter callbacks
 ;; M-08: Registry struct and accessor (for advanced use)
@@ -20,6 +37,9 @@
 
          ;; R-05: Parameterized registry for test isolation
          current-ui-registry
+
+         ;; v0.94.1: Event runtime for dual-path
+         current-ui-event-runtime
 
          ;; Setter/Getter callbacks
          (contract-out [ui-set-footer! (-> box? (or/c string? (listof any/c)) void?)]
@@ -57,18 +77,29 @@
 ;; R-05: Parameterized registry for test isolation
 (define current-ui-registry (make-parameter (ui-callback-registry #f #f #f #f #f #f #f #f #f #f)))
 
+;; ── Event emission helper ──────────────────────────────────
+
+(define (maybe-emit-action! action-name . payload-args)
+  (define runtime (current-ui-event-runtime))
+  (when (and runtime (current-ui-event-actions-enabled?))
+    (apply emit-ui-action! runtime action-name payload-args)))
+
 ;; ── Public API ─────────────────────────────────────────────
 
 (define (ui-set-footer! ui-state-box lines)
+  (maybe-emit-action! UI-ACTION-FOOTER-SET 'lines lines)
   ((ui-callback-registry-set-footer (current-ui-registry)) ui-state-box lines))
 
 (define (ui-set-header! ui-state-box lines)
+  (maybe-emit-action! UI-ACTION-HEADER-SET 'lines lines)
   ((ui-callback-registry-set-header (current-ui-registry)) ui-state-box lines))
 
 (define (ui-clear-footer! ui-state-box)
+  (maybe-emit-action! UI-ACTION-FOOTER-CLEAR)
   ((ui-callback-registry-clear-footer (current-ui-registry)) ui-state-box))
 
 (define (ui-clear-header! ui-state-box)
+  (maybe-emit-action! UI-ACTION-HEADER-CLEAR)
   ((ui-callback-registry-clear-header (current-ui-registry)) ui-state-box))
 
 (define (ui-make-styled-line segments)
@@ -78,9 +109,8 @@
   ((ui-callback-registry-make-styled-segment (current-ui-registry)) text style))
 
 ;; Set status message in the ui-state box (dialog-api notification integration)
-;; ui-state-box: box? containing ui-state
-;; message: string? — the formatted status message
 (define (ui-set-status-message! ui-state-box message)
+  (maybe-emit-action! UI-ACTION-STATUS-SET 'status message)
   (define cb (ui-callback-registry-set-status-message (current-ui-registry)))
   (when cb
     (cb ui-state-box message)))
@@ -88,6 +118,13 @@
 ;; Set a widget from an extension
 ;; Falls back to direct struct-copy when no TUI callback is installed
 (define (ui-set-extension-widget! state ext-name key lines)
+  (maybe-emit-action! UI-ACTION-WIDGET-REGISTER
+                      'ext-name
+                      ext-name
+                      'key
+                      key
+                      'descriptor
+                      (hash 'type 'text 'content lines))
   (define cb (ui-callback-registry-set-extension-widget (current-ui-registry)))
   (if cb
       (cb state ext-name key lines)
@@ -98,6 +135,7 @@
 
 ;; Remove a specific widget
 (define (ui-remove-extension-widget! state ext-name key)
+  (maybe-emit-action! UI-ACTION-WIDGET-UNREGISTER 'ext-name ext-name 'key key)
   (define cb (ui-callback-registry-remove-extension-widget (current-ui-registry)))
   (if cb
       (cb state ext-name key)
@@ -107,6 +145,7 @@
 
 ;; Remove all widgets for an extension
 (define (ui-remove-all-extension-widgets! state ext-name)
+  (maybe-emit-action! UI-ACTION-WIDGET-UNREGISTER-ALL 'ext-name ext-name)
   (define cb (ui-callback-registry-remove-all-extension-widgets (current-ui-registry)))
   (if cb
       (cb state ext-name)
@@ -126,12 +165,6 @@
        (ui-callback-registry-make-styled-segment r)))
 
 ;; install-ui-callbacks! : hash? -> void?
-;; Installs concrete UI implementations.
-;; Expected keys: set-footer, set-header, clear-footer, clear-header,
-;;                make-styled-line, make-styled-segment,
-;;                set-status-message,
-;;                set-extension-widget, remove-extension-widget,
-;;                remove-all-extension-widgets
 (define (install-ui-callbacks! callbacks)
   (current-ui-registry (ui-callback-registry (hash-ref callbacks 'set-footer #f)
                                              (hash-ref callbacks 'set-header #f)

--- a/tests/test-ui-surface-actions.rkt
+++ b/tests/test-ui-surface-actions.rkt
@@ -1,0 +1,222 @@
+#lang racket
+
+;; q/tests/test-ui-surface-actions.rkt — Tests for event-publishing dual-path
+;; in extensions/ui-surface.rkt
+;;
+;; W1.2 (v0.94.1): Verify that UI surface functions emit events when
+;; the feature flag is on, while preserving callback behavior.
+
+(require rackunit
+         rackunit/text-ui
+         "../extensions/ui-surface.rkt"
+         "../ui-core/ui-actions.rkt"
+         (only-in "../tui/state.rkt" ui-state? initial-ui-state ui-state-extension-widgets))
+
+;; Helper: collect events emitted by the mock runtime
+(define (make-event-collector)
+  (define events-box (box '()))
+  (define runtime
+    (hash 'emit-event (lambda (evt) (set-box! events-box (cons evt (unbox events-box))))))
+  (values runtime
+          (lambda () (reverse (unbox events-box)))))
+
+;; Helper: create a registry where all required callbacks are set
+(define (make-test-registry)
+  (ui-callback-registry
+   (lambda (box lines) (void))
+   (lambda (box lines) (void))
+   (lambda (box) (void))
+   (lambda (box) (void))
+   (lambda (segments) 'styled-line)
+   (lambda (text style) 'styled-segment)
+   #f #f #f #f))
+
+(define-test-suite
+ test-ui-surface-actions
+
+ ;; ─── Dual-path: event emission when flag ON ───
+
+ (test-case
+  "ui-set-footer! emits event when flag on"
+  (define-values (runtime get-events) (make-event-collector))
+  (define saved-reg (current-ui-registry))
+  (define saved-rt (current-ui-event-runtime))
+  (parameterize ([current-ui-registry (make-test-registry)]
+                 [current-ui-event-runtime runtime]
+                 [current-ui-event-actions-enabled? #t])
+    (ui-set-footer! (box #f) '("footer text")))
+  (current-ui-event-runtime saved-rt)
+  (current-ui-registry saved-reg)
+  (define events (get-events))
+  (check-equal? (length events) 1)
+  (check-equal? (hash-ref (car events) 'type) "ui.footer.set"))
+
+ (test-case
+  "ui-set-header! emits event when flag on"
+  (define-values (runtime get-events) (make-event-collector))
+  (define saved-reg (current-ui-registry))
+  (define saved-rt (current-ui-event-runtime))
+  (parameterize ([current-ui-registry (make-test-registry)]
+                 [current-ui-event-runtime runtime]
+                 [current-ui-event-actions-enabled? #t])
+    (ui-set-header! (box #f) '("header text")))
+  (current-ui-event-runtime saved-rt)
+  (current-ui-registry saved-reg)
+  (check-equal? (length (get-events)) 1)
+  (check-equal? (hash-ref (car (get-events)) 'type) "ui.header.set"))
+
+ (test-case
+  "ui-clear-footer! emits event when flag on"
+  (define-values (runtime get-events) (make-event-collector))
+  (define saved-reg (current-ui-registry))
+  (define saved-rt (current-ui-event-runtime))
+  (parameterize ([current-ui-registry (make-test-registry)]
+                 [current-ui-event-runtime runtime]
+                 [current-ui-event-actions-enabled? #t])
+    (ui-clear-footer! (box #f)))
+  (current-ui-event-runtime saved-rt)
+  (current-ui-registry saved-reg)
+  (check-equal? (length (get-events)) 1)
+  (check-equal? (hash-ref (car (get-events)) 'type) "ui.footer.clear"))
+
+ (test-case
+  "ui-clear-header! emits event when flag on"
+  (define-values (runtime get-events) (make-event-collector))
+  (define saved-reg (current-ui-registry))
+  (define saved-rt (current-ui-event-runtime))
+  (parameterize ([current-ui-registry (make-test-registry)]
+                 [current-ui-event-runtime runtime]
+                 [current-ui-event-actions-enabled? #t])
+    (ui-clear-header! (box #f)))
+  (current-ui-event-runtime saved-rt)
+  (current-ui-registry saved-reg)
+  (check-equal? (length (get-events)) 1)
+  (check-equal? (hash-ref (car (get-events)) 'type) "ui.header.clear"))
+
+ ;; ─── No events when flag OFF (default) ───
+
+ (test-case
+  "ui-set-footer! does not emit when flag off"
+  (define-values (runtime get-events) (make-event-collector))
+  (define saved-reg (current-ui-registry))
+  (define saved-rt (current-ui-event-runtime))
+  (parameterize ([current-ui-registry (make-test-registry)]
+                 [current-ui-event-runtime runtime])
+    ;; flag defaults to #f
+    (ui-set-footer! (box #f) '("test")))
+  (current-ui-event-runtime saved-rt)
+  (current-ui-registry saved-reg)
+  (check-equal? (get-events) '()))
+
+ (test-case
+  "ui-set-header! does not emit when flag off"
+  (define-values (runtime get-events) (make-event-collector))
+  (define saved-reg (current-ui-registry))
+  (define saved-rt (current-ui-event-runtime))
+  (parameterize ([current-ui-registry (make-test-registry)]
+                 [current-ui-event-runtime runtime])
+    (ui-set-header! (box #f) '("test")))
+  (current-ui-event-runtime saved-rt)
+  (current-ui-registry saved-reg)
+  (check-equal? (get-events) '()))
+
+ ;; ─── No events when runtime is #f ───
+
+ (test-case
+  "no events when runtime is #f even with flag on"
+  (define saved-reg (current-ui-registry))
+  (parameterize ([current-ui-registry (make-test-registry)]
+                 [current-ui-event-runtime #f]
+                 [current-ui-event-actions-enabled? #t])
+    ;; Should not error
+    (ui-set-footer! (box #f) '("test"))
+    (check-true #t))
+  (current-ui-registry saved-reg))
+
+ ;; ─── Widget functions emit events ───
+
+ (test-case
+  "ui-set-extension-widget! emits widget.register when flag on"
+  (define-values (runtime get-events) (make-event-collector))
+  (define saved-reg (current-ui-registry))
+  (define saved-rt (current-ui-event-runtime))
+  (parameterize ([current-ui-registry (make-test-registry)]
+                 [current-ui-event-runtime runtime]
+                 [current-ui-event-actions-enabled? #t])
+    (define state (initial-ui-state))
+    (ui-set-extension-widget! state 'my-ext 'main '("line")))
+  (current-ui-event-runtime saved-rt)
+  (current-ui-registry saved-reg)
+  (define events (get-events))
+  (check-equal? (length events) 1)
+  (check-equal? (hash-ref (car events) 'type) "ui.widget.register")
+  (check-equal? (hash-ref (car events) 'ext-name) 'my-ext))
+
+ (test-case
+  "ui-remove-extension-widget! emits widget.unregister when flag on"
+  (define-values (runtime get-events) (make-event-collector))
+  (define saved-reg (current-ui-registry))
+  (define saved-rt (current-ui-event-runtime))
+  (parameterize ([current-ui-registry (make-test-registry)]
+                 [current-ui-event-runtime runtime]
+                 [current-ui-event-actions-enabled? #t])
+    (define state (initial-ui-state))
+    (ui-remove-extension-widget! state 'my-ext 'main))
+  (current-ui-event-runtime saved-rt)
+  (current-ui-registry saved-reg)
+  (check-equal? (length (get-events)) 1)
+  (check-equal? (hash-ref (car (get-events)) 'type) "ui.widget.unregister"))
+
+ (test-case
+  "ui-remove-all-extension-widgets! emits widget.unregister-all when flag on"
+  (define-values (runtime get-events) (make-event-collector))
+  (define saved-reg (current-ui-registry))
+  (define saved-rt (current-ui-event-runtime))
+  (parameterize ([current-ui-registry (make-test-registry)]
+                 [current-ui-event-runtime runtime]
+                 [current-ui-event-actions-enabled? #t])
+    (define state (initial-ui-state))
+    (ui-remove-all-extension-widgets! state 'my-ext))
+  (current-ui-event-runtime saved-rt)
+  (current-ui-registry saved-reg)
+  (check-equal? (length (get-events)) 1)
+  (check-equal? (hash-ref (car (get-events)) 'type) "ui.widget.unregister-all"))
+
+ ;; ─── Callback still fires alongside event ───
+
+ (test-case
+  "callback still fires when event flag is on"
+  (define-values (runtime get-events) (make-event-collector))
+  (define cb-called (box #f))
+  (define saved-reg (current-ui-registry))
+  (define saved-rt (current-ui-event-runtime))
+  (define reg
+    (ui-callback-registry (lambda (box lines) (set-box! cb-called #t))
+                          #f #f #f #f #f #f #f #f #f))
+  (parameterize ([current-ui-registry reg]
+                 [current-ui-event-runtime runtime]
+                 [current-ui-event-actions-enabled? #t])
+    (ui-set-footer! (box #f) '("test")))
+  (current-ui-event-runtime saved-rt)
+  (current-ui-registry saved-reg)
+  (check-true (unbox cb-called))
+  (check-equal? (length (get-events)) 1))
+
+ ;; ─── Status message emits event ───
+
+ (test-case
+  "ui-set-status-message! emits status.set when flag on"
+  (define-values (runtime get-events) (make-event-collector))
+  (define saved-reg (current-ui-registry))
+  (define saved-rt (current-ui-event-runtime))
+  (parameterize ([current-ui-registry (make-test-registry)]
+                 [current-ui-event-runtime runtime]
+                 [current-ui-event-actions-enabled? #t])
+    (ui-set-status-message! (box #f) "status msg"))
+  (current-ui-event-runtime saved-rt)
+  (current-ui-registry saved-reg)
+  (check-equal? (length (get-events)) 1)
+  (check-equal? (hash-ref (car (get-events)) 'type) "ui.status.set"))
+ )
+
+(run-tests test-ui-surface-actions)


### PR DESCRIPTION
Adds event-publishing dual-path to extensions/ui-surface.rkt.

- 12 new tests
- All characterization tests still pass
- Callback path unchanged when flag off

Closes #6997
Closes #6998