### PR TITLE
feat: v0.94.4 unified command metadata registry

### DIFF
--- a/tests/test-ui-command-registry.rkt
+++ b/tests/test-ui-command-registry.rkt
@@ -1,0 +1,115 @@
+#lang racket
+
+;; q/tests/test-ui-command-registry.rkt — Tests for unified command metadata registry
+;;
+;; W4.1 (v0.94.4): Verify canonical command list, registry operations, and parity.
+
+(require rackunit
+         rackunit/text-ui
+         "../ui-core/command-registry.rkt")
+
+(define reg (make-ui-command-registry canonical-commands))
+
+(define-test-suite
+ test-ui-command-registry
+
+ ;; ── Canonical list ───
+
+ (test-case "19 canonical commands registered"
+   (check-equal? (length (ui-registry-all reg)) 19))
+
+ (test-case "all commands have / prefix"
+   (for ([cmd (ui-registry-all reg)])
+     (check-true (string-prefix? (ui-command-name cmd) "/")
+                 (format "~a should start with /" (ui-command-name cmd)))))
+
+ (test-case "all commands have non-empty summary"
+   (for ([cmd (ui-registry-all reg)])
+     (check-true (non-empty-string? (ui-command-summary cmd))
+                 (format "~a should have summary" (ui-command-name cmd)))))
+
+ (test-case "categories are valid"
+   (for ([cmd (ui-registry-all reg)])
+     (check-not-false (member (ui-command-category cmd) '(general session model debug))
+                 (format "~a has invalid category ~a"
+                         (ui-command-name cmd) (ui-command-category cmd)))))
+
+ ;; ── Lookup ───
+
+ (test-case "lookup finds /help"
+   (check-not-false (ui-registry-lookup reg "/help")))
+
+ (test-case "lookup returns #f for unknown command"
+   (check-false (ui-registry-lookup reg "/nonexistent")))
+
+ (test-case "lookup by alias is NOT supported (by name only)"
+   ;; Aliases are for display, not registry lookup
+   (check-false (ui-registry-lookup reg "h")))
+
+ ;; ── By category ───
+
+ (test-case "general commands include /help, /quit, /clear, /status"
+   (define general (ui-registry-by-category reg 'general))
+   (define names (map ui-command-name general))
+   (for ([name '("/help" "/quit" "/clear" "/status")])
+     (check-not-false (member name names) (format "~a should be general" name))))
+
+ (test-case "session commands include /branches, /switch, /fork, /tree"
+   (define session (ui-registry-by-category reg 'session))
+   (define names (map ui-command-name session))
+   (for ([name '("/branches" "/switch" "/fork" "/tree")])
+     (check-not-false (member name names) (format "~a should be session" name))))
+
+ ;; ── Filter ───
+
+ (test-case "filter by 'help' returns /help"
+   (define results (ui-registry-filter reg "help"))
+   (check-true (>= (length results) 1))
+   (check-not-false (member "/help" (map ui-command-name results))))
+
+ (test-case "filter by 'sess' returns session-related commands"
+   (define results (ui-registry-filter reg "sess"))
+   (check-true (>= (length results) 1)))
+
+ (test-case "filter by alias 'h' returns /help"
+   (define results (ui-registry-filter reg "h"))
+   (check-not-false (member "/help" (map ui-command-name results))))
+
+ ;; ── Names ───
+
+ (test-case "ui-registry-names returns sorted list"
+   (define names (ui-registry-names reg))
+   (check-equal? names (sort names string<?)))
+
+ ;; ── Frontend availability ───
+
+ (test-case "all canonical commands available in TUI"
+   (for ([cmd (ui-registry-all reg)])
+     (check-true (ui-command-tui? cmd)
+                 (format "~a should be available in TUI" (ui-command-name cmd)))))
+
+ (test-case "all canonical commands available in GUI"
+   (for ([cmd (ui-registry-all reg)])
+     (check-true (ui-command-gui? cmd)
+                 (format "~a should be available in GUI" (ui-command-name cmd)))))
+
+ ;; ── TUI/GUI parity ───
+
+ (test-case "TUI and GUI have identical command names"
+   (define tui-names (sort (map ui-command-name (filter ui-command-tui? (ui-registry-all reg))) string<?))
+   (define gui-names (sort (map ui-command-name (filter ui-command-gui? (ui-registry-all reg))) string<?))
+   (check-equal? tui-names gui-names))
+
+ ;; ── Custom registry ───
+
+ (test-case "empty registry works"
+   (define empty-reg (make-ui-command-registry '()))
+   (check-equal? (length (ui-registry-all empty-reg)) 0))
+
+ (test-case "custom registry with one command"
+   (define cmd (ui-command "/test" "Test" 'debug '() '() #t #f))
+   (define r (make-ui-command-registry (list cmd)))
+   (check-equal? (length (ui-registry-all r)) 1)
+   (check-false (ui-command-gui? (ui-registry-lookup r "/test")))))
+
+(run-tests test-ui-command-registry)

--- a/ui-core/command-registry.rkt
+++ b/ui-core/command-registry.rkt
@@ -1,0 +1,101 @@
+#lang racket
+
+;; q/ui-core/command-registry.rkt — Unified command metadata registry
+;;
+;; Central source of truth for slash command metadata shared between TUI and GUI.
+;; Each command has: name, summary, category, args-spec, aliases, and a
+;; frontend-availability flag (tui?, gui?).
+;;
+;; W4.1 (v0.94.4): Extract from tui/palette.rkt to make command metadata
+;; available to both frontends without TUI dependency.
+
+(require racket/contract
+         (only-in "../util/command-types.rkt"
+                  cmd-entry cmd-entry? cmd-entry-name cmd-entry-summary
+                  cmd-entry-category cmd-entry-args-spec cmd-entry-aliases))
+
+(provide
+ ;; Extended command entry with frontend availability
+ ui-command
+ ui-command?
+ ui-command-name
+ ui-command-summary
+ ui-command-category
+ ui-command-args-spec
+ ui-command-aliases
+ ui-command-tui?
+ ui-command-gui?
+
+ ;; Registry
+ (contract-out
+  [make-ui-command-registry (-> (listof ui-command?) hash?)]
+  [ui-registry-lookup (-> hash? string? (or/c ui-command? #f))]
+  [ui-registry-all (-> hash? (listof ui-command?))]
+  [ui-registry-by-category (-> hash? symbol? (listof ui-command?))]
+  [ui-registry-filter (-> hash? string? (listof ui-command?))]
+  [ui-registry-names (-> hash? (listof string?))]))
+
+;; ── Extended command entry ─────────────────────────────────
+
+(struct ui-command
+  (name     ; string — e.g. "/help"
+   summary  ; string — one-line description
+   category ; symbol — 'general | 'session | 'model | 'debug
+   args-spec ; (listof string) — arg names for display
+   aliases  ; (listof string) — short forms
+   tui?     ; boolean — available in TUI
+   gui?)    ; boolean — available in GUI
+  #:transparent)
+
+;; ── Registry operations ────────────────────────────────────
+
+(define (make-ui-command-registry commands)
+  (for/hash ([cmd (in-list commands)])
+    (values (ui-command-name cmd) cmd)))
+
+(define (ui-registry-lookup registry name)
+  (hash-ref registry name #f))
+
+(define (ui-registry-all registry)
+  (sort (hash-values registry) string<? #:key ui-command-name))
+
+(define (ui-registry-by-category registry cat)
+  (filter (lambda (c) (eq? (ui-command-category c) cat))
+          (hash-values registry)))
+
+(define (ui-registry-filter registry query)
+  (define q (string-downcase query))
+  (filter (lambda (c)
+            (or (string-contains? (string-downcase (ui-command-name c)) q)
+                (string-contains? (string-downcase (ui-command-summary c)) q)
+                (member q (map string-downcase (ui-command-aliases c)))))
+          (hash-values registry)))
+
+(define (ui-registry-names registry)
+  (sort (hash-keys registry) string<?))
+
+;; ── Canonical command list ─────────────────────────────────
+
+(define canonical-commands
+  (list
+   (ui-command "/help"       "Show help"                        'general  '()               '("h" "?")    #t #t)
+   (ui-command "/quit"       "Exit session"                     'general  '()               '("q" "exit") #t #t)
+   (ui-command "/clear"      "Clear transcript"                 'general  '()               '("cls")      #t #t)
+   (ui-command "/compact"    "Trigger compaction"               'session  '()               '()           #t #t)
+   (ui-command "/interrupt"  "Interrupt current turn"           'session  '()               '("stop" "cancel") #t #t)
+   (ui-command "/branches"   "List session branches"            'session  '()               '()           #t #t)
+   (ui-command "/leaves"     "List leaf nodes"                  'session  '()               '()           #t #t)
+   (ui-command "/switch"     "Switch to branch"                 'session  '("<id>")          '()           #t #t)
+   (ui-command "/children"   "Show children of node"            'session  '("<id>")          '()           #t #t)
+   (ui-command "/model"      "Switch or show model"             'model    '("<name>")        '("m")        #t #t)
+   (ui-command "/history"    "Show session history"             'session  '()               '()           #t #t)
+   (ui-command "/fork"       "Fork session at point"            'session  '("<id>")          '()           #t #t)
+   (ui-command "/tree"       "Show session tree"                'session  '()               '("t")        #t #t)
+   (ui-command "/name"       "Set session name"                 'session  '("<title>")       '()           #t #t)
+   (ui-command "/sessions"   "List and manage sessions"         'session  '("list|info|delete") '()        #t #t)
+   (ui-command "/status"     "Show session and provider status" 'general  '()               '("st" "info") #t #t)
+   (ui-command "/activate"   "Activate extension"               'general  '("<name>")        '("a")        #t #t)
+   (ui-command "/deactivate" "Deactivate extension"             'general  '("<name>")        '()           #t #t)
+   (ui-command "/reload"     "Hot-reload all extensions"        'general  '()               '()           #t #t)))
+
+(provide canonical-commands)


### PR DESCRIPTION
Unified command metadata registry for TUI/GUI parity.

- ui-core/command-registry.rkt: 19 canonical commands
- ui-command struct with tui?/gui? flags
- Registry ops: lookup, filter, by-category, names
- 18 new tests

Closes #7015-#7020