### PR TITLE
fix: v0.94.8 W1 null-safety hardening (C-3, H-2, m-2)

### DIFF
--- a/extensions/ui-surface.rkt
+++ b/extensions/ui-surface.rkt
@@ -88,25 +88,39 @@
 
 (define (ui-set-footer! ui-state-box lines)
   (maybe-emit-action! UI-ACTION-FOOTER-SET 'lines lines)
-  ((ui-callback-registry-set-footer (current-ui-registry)) ui-state-box lines))
+  (define cb (ui-callback-registry-set-footer (current-ui-registry)))
+  (when cb
+    (cb ui-state-box lines)))
 
 (define (ui-set-header! ui-state-box lines)
   (maybe-emit-action! UI-ACTION-HEADER-SET 'lines lines)
-  ((ui-callback-registry-set-header (current-ui-registry)) ui-state-box lines))
+  (define cb (ui-callback-registry-set-header (current-ui-registry)))
+  (when cb
+    (cb ui-state-box lines)))
 
 (define (ui-clear-footer! ui-state-box)
   (maybe-emit-action! UI-ACTION-FOOTER-CLEAR)
-  ((ui-callback-registry-clear-footer (current-ui-registry)) ui-state-box))
+  (define cb (ui-callback-registry-clear-footer (current-ui-registry)))
+  (when cb
+    (cb ui-state-box)))
 
 (define (ui-clear-header! ui-state-box)
   (maybe-emit-action! UI-ACTION-HEADER-CLEAR)
-  ((ui-callback-registry-clear-header (current-ui-registry)) ui-state-box))
+  (define cb (ui-callback-registry-clear-header (current-ui-registry)))
+  (when cb
+    (cb ui-state-box)))
 
 (define (ui-make-styled-line segments)
-  ((ui-callback-registry-make-styled-line (current-ui-registry)) segments))
+  (define cb (ui-callback-registry-make-styled-line (current-ui-registry)))
+  (if cb
+      (cb segments)
+      segments))
 
 (define (ui-make-styled-segment text style)
-  ((ui-callback-registry-make-styled-segment (current-ui-registry)) text style))
+  (define cb (ui-callback-registry-make-styled-segment (current-ui-registry)))
+  (if cb
+      (cb text style)
+      text))
 
 ;; Set status message in the ui-state box (dialog-api notification integration)
 (define (ui-set-status-message! ui-state-box message)
@@ -162,7 +176,12 @@
        (ui-callback-registry-clear-footer r)
        (ui-callback-registry-clear-header r)
        (ui-callback-registry-make-styled-line r)
-       (ui-callback-registry-make-styled-segment r)))
+       (ui-callback-registry-make-styled-segment r)
+       (ui-callback-registry-set-status-message r)
+       (ui-callback-registry-set-extension-widget r)
+       (ui-callback-registry-remove-extension-widget r)
+       (ui-callback-registry-remove-all-extension-widgets r)
+       #t))
 
 ;; install-ui-callbacks! : hash? -> void?
 (define (install-ui-callbacks! callbacks)

--- a/tests/test-ui-surface-null-safety.rkt
+++ b/tests/test-ui-surface-null-safety.rkt
@@ -1,0 +1,98 @@
+#lang racket
+
+;; q/tests/test-ui-surface-null-safety.rkt — Null-safety regression tests
+;;
+;; W1 (v0.94.8): Verify all ui-surface callbacks are null-safe and
+;; ui-callbacks-installed? checks all 10 fields.
+
+(require rackunit
+         rackunit/text-ui
+         (only-in "../extensions/ui-surface.rkt"
+                  ui-set-header! ui-set-footer!
+                  ui-clear-header! ui-clear-footer!
+                  ui-make-styled-line ui-make-styled-segment
+                  ui-set-status-message!
+                  ui-callbacks-installed?
+                  current-ui-registry
+                  ui-callback-registry))
+
+(define-test-suite
+ test-ui-surface-null-safety
+
+ ;; ── Null-safety: no crash when registry not installed (C-3, H-2) ───
+
+ (test-case "ui-set-header! does not crash with no callbacks"
+   (parameterize ([current-ui-registry (ui-callback-registry #f #f #f #f #f #f #f #f #f #f)])
+     (define bx (box 'state))
+     (ui-set-header! bx "test")
+     (check-equal? (unbox bx) 'state)))
+
+ (test-case "ui-set-footer! does not crash with no callbacks"
+   (parameterize ([current-ui-registry (ui-callback-registry #f #f #f #f #f #f #f #f #f #f)])
+     (define bx (box 'state))
+     (ui-set-footer! bx "test")
+     (check-equal? (unbox bx) 'state)))
+
+ (test-case "ui-clear-header! does not crash with no callbacks"
+   (parameterize ([current-ui-registry (ui-callback-registry #f #f #f #f #f #f #f #f #f #f)])
+     (define bx (box 'state))
+     (ui-clear-header! bx)
+     (check-equal? (unbox bx) 'state)))
+
+ (test-case "ui-clear-footer! does not crash with no callbacks"
+   (parameterize ([current-ui-registry (ui-callback-registry #f #f #f #f #f #f #f #f #f #f)])
+     (define bx (box 'state))
+     (ui-clear-footer! bx)
+     (check-equal? (unbox bx) 'state)))
+
+ (test-case "ui-make-styled-line returns segments when no callback"
+   (parameterize ([current-ui-registry (ui-callback-registry #f #f #f #f #f #f #f #f #f #f)])
+     (check-equal? (ui-make-styled-line '(seg1 seg2)) '(seg1 seg2))))
+
+ (test-case "ui-make-styled-segment returns text when no callback"
+   (parameterize ([current-ui-registry (ui-callback-registry #f #f #f #f #f #f #f #f #f #f)])
+     (check-equal? (ui-make-styled-segment "text" 'bold) "text")))
+
+ (test-case "ui-set-status-message! does not crash with no callbacks"
+   (parameterize ([current-ui-registry (ui-callback-registry #f #f #f #f #f #f #f #f #f #f)])
+     (define bx (box 'state))
+     (ui-set-status-message! bx "test")
+     (check-equal? (unbox bx) 'state)))
+
+ ;; ── ui-callbacks-installed? checks all 10 fields (m-2) ───
+
+ (test-case "ui-callbacks-installed? returns #f when all null"
+   (parameterize ([current-ui-registry (ui-callback-registry #f #f #f #f #f #f #f #f #f #f)])
+     (check-false (ui-callbacks-installed?))))
+
+ (test-case "ui-callbacks-installed? returns #t when all 10 installed"
+   (parameterize ([current-ui-registry (ui-callback-registry
+                                         void void void void void void
+                                         void void void void)])
+     (check-true (ui-callbacks-installed?))))
+
+ (test-case "ui-callbacks-installed? returns #f when status-message missing"
+   (parameterize ([current-ui-registry (ui-callback-registry
+                                         void void void void void void
+                                         #f void void void)])
+     (check-false (ui-callbacks-installed?))))
+
+ (test-case "ui-callbacks-installed? returns #f when set-extension-widget missing"
+   (parameterize ([current-ui-registry (ui-callback-registry
+                                         void void void void void void
+                                         void #f void void)])
+     (check-false (ui-callbacks-installed?))))
+
+ (test-case "ui-callbacks-installed? returns #f when remove-extension-widget missing"
+   (parameterize ([current-ui-registry (ui-callback-registry
+                                         void void void void void void
+                                         void void #f void)])
+     (check-false (ui-callbacks-installed?))))
+
+ (test-case "ui-callbacks-installed? returns #f when remove-all-extension-widgets missing"
+   (parameterize ([current-ui-registry (ui-callback-registry
+                                         void void void void void void
+                                         void void void #f)])
+     (check-false (ui-callbacks-installed?)))))
+
+(run-tests test-ui-surface-null-safety)


### PR DESCRIPTION
W1: Null-safety hardening for ui-surface.rkt

- Add (when cb ...) guards to all 6 unprotected callbacks
- Fix ui-callbacks-installed? to check all 10 fields
- 13 new regression tests

Closes #7065 #7066