### PR TITLE
chore: bump version to 0.94.8

### DIFF
--- a/util/version.rkt
+++ b/util/version.rkt
@@ -11,4 +11,4 @@
 
 (provide (contract-out [q-version string?]))
 
-(define q-version "0.93.3")
+(define q-version "0.94.8")


### PR DESCRIPTION
W8: Version bump to 0.94.8

Closes #7079 #7080