### PR TITLE
feat: v0.95.16 W1 settings and session config for auto-extraction

### DIFF
--- a/runtime/session/session-config.rkt
+++ b/runtime/session/session-config.rkt
@@ -146,7 +146,10 @@
           [config-task-state-aware? (-> session-config? boolean?)]
           [config-context-assembly-profile (-> session-config? symbol?)]
           [config-memory-backend (-> session-config? any/c)]
-          [config-memory-enabled? (-> session-config? boolean?)]))
+          [config-memory-enabled? (-> session-config? boolean?)]
+          [config-memory-auto-extraction-enabled? (-> session-config? boolean?)]
+          [config-memory-auto-extraction-min-confidence
+           (-> session-config? (and/c real? (between/c 0 1)))]))
 
 ;; ── session-config struct ────────────────────────────────────────
 
@@ -255,6 +258,15 @@
   ;; validation happens at resolution time (current-memory-backend setter).
   (and (hash-ref (session-config-data c) 'memory-backend #f) #t))
 
+;; v0.95.16 W1: Auto-extraction config accessors
+;; Default: disabled (#f), min-confidence 0.5
+(define (config-memory-auto-extraction-enabled? c)
+  (hash-ref (session-config-data c) 'memory-auto-extraction-enabled #f))
+
+(define (config-memory-auto-extraction-min-confidence c)
+  (define raw (hash-ref (session-config-data c) 'memory-auto-extraction-min-confidence 0.5))
+  (if (and (real? raw) (<= 0 raw 1)) raw 0.5))
+
 ;; ── Dynamic default resolution ─────────────────────────────────
 
 (define (resolve-max-iterations-hard config max-iterations)
@@ -292,7 +304,9 @@
                session-index
                task-state-aware?
                context-assembly-profile
-               memory-backend))
+               memory-backend
+               memory-auto-extraction-enabled
+               memory-auto-extraction-min-confidence))
   (define base
     (if (hash? h)
         (make-immutable-hash (hash->list h))

--- a/runtime/settings.rkt
+++ b/runtime/settings.rkt
@@ -80,7 +80,10 @@
           [shell-risk-classifier (-> q-settings? (or/c 'regex 'structured 'both))]
           [setting-context-assembly-profile (-> q-settings? symbol?)]
           [setting-memory-injection-budget (-> q-settings? (or/c exact-positive-integer? #f))]
-          [setting-memory-backend (-> q-settings? (or/c symbol? #f))])
+          [setting-memory-backend (-> q-settings? (or/c symbol? #f))]
+          [setting-memory-auto-extraction-enabled? (-> q-settings? boolean?)]
+          [setting-memory-auto-extraction-min-confidence
+           (-> q-settings? (and/c real? (between/c 0 1)))])
 
          ;; Sandbox settings (re-exported, not locally defined)
          sandbox-enabled?
@@ -444,6 +447,28 @@
      (define sym (string->symbol raw))
      (if (memq sym '(hash file-jsonl)) sym #f)]
     [else #f]))
+
+;; v0.95.16 W1: Auto-extraction enabled from settings
+;; Reads (memory auto-extraction enabled) from config.
+;; Default: #f (disabled).
+(define (setting-memory-auto-extraction-enabled? settings)
+  (define raw (setting-ref* settings '(memory auto-extraction enabled) #f))
+  (cond
+    [(boolean? raw) raw]
+    [(string? raw) (and (member (string-downcase raw) '("true" "1" "yes")) #t)]
+    [else #f]))
+
+;; v0.95.16 W1: Auto-extraction min-confidence from settings
+;; Reads (memory auto-extraction min-confidence) from config.
+;; Default: 0.5. Coerces strings to numbers.
+(define (setting-memory-auto-extraction-min-confidence settings)
+  (define raw (setting-ref* settings '(memory auto-extraction min-confidence) 0.5))
+  (cond
+    [(and (real? raw) (<= 0 raw 1)) raw]
+    [(string? raw)
+     (define n (string->number raw))
+     (if (and (real? n) (<= 0 n 1)) n 0.5)]
+    [else 0.5]))
 
 ;; ============================================================
 ;; Credential policy (v0.70.1)

--- a/tests/test-memory-session-config-w1.rkt
+++ b/tests/test-memory-session-config-w1.rkt
@@ -1,0 +1,24 @@
+#lang racket/base
+;;; test-memory-session-config-w1.rkt — W1 tests for session-config auto-extraction accessors
+(require rackunit
+         "../runtime/session/session-config.rkt")
+
+(test-case "W1: config-memory-auto-extraction-enabled? default #f"
+  (define c (hash->session-config (hash)))
+  (check-false (config-memory-auto-extraction-enabled? c)))
+
+(test-case "W1: config-memory-auto-extraction-enabled? reads #t"
+  (define c (hash->session-config (hash 'memory-auto-extraction-enabled #t)))
+  (check-true (config-memory-auto-extraction-enabled? c)))
+
+(test-case "W1: config-memory-auto-extraction-min-confidence default 0.5"
+  (define c (hash->session-config (hash)))
+  (check-equal? (config-memory-auto-extraction-min-confidence c) 0.5))
+
+(test-case "W1: config-memory-auto-extraction-min-confidence reads value"
+  (define c (hash->session-config (hash 'memory-auto-extraction-min-confidence 0.8)))
+  (check-equal? (config-memory-auto-extraction-min-confidence c) 0.8))
+
+(test-case "W1: config-memory-auto-extraction-min-confidence clamps out-of-range"
+  (define c (hash->session-config (hash 'memory-auto-extraction-min-confidence 2.0)))
+  (check-equal? (config-memory-auto-extraction-min-confidence c) 0.5))

--- a/tests/test-memory-settings-w1.rkt
+++ b/tests/test-memory-settings-w1.rkt
@@ -1,0 +1,28 @@
+#lang racket/base
+;;; test-memory-settings-w1.rkt — W1 tests for auto-extraction settings
+(require rackunit
+         "../runtime/settings.rkt")
+
+(test-case "W1: setting-memory-auto-extraction-enabled? default #f"
+  (define s (make-minimal-settings))
+  (check-false (setting-memory-auto-extraction-enabled? s)))
+
+(test-case "W1: setting-memory-auto-extraction-enabled? reads boolean #t"
+  (define s (make-minimal-settings #:overrides (hash 'memory (hash 'auto-extraction (hash 'enabled #t)))))
+  (check-true (setting-memory-auto-extraction-enabled? s)))
+
+(test-case "W1: setting-memory-auto-extraction-enabled? coerces string"
+  (define s (make-minimal-settings #:overrides (hash 'memory (hash 'auto-extraction (hash 'enabled "true")))))
+  (check-true (setting-memory-auto-extraction-enabled? s)))
+
+(test-case "W1: setting-memory-auto-extraction-min-confidence default 0.5"
+  (define s (make-minimal-settings))
+  (check-equal? (setting-memory-auto-extraction-min-confidence s) 0.5))
+
+(test-case "W1: setting-memory-auto-extraction-min-confidence reads number"
+  (define s (make-minimal-settings #:overrides (hash 'memory (hash 'auto-extraction (hash 'min-confidence 0.75)))))
+  (check-equal? (setting-memory-auto-extraction-min-confidence s) 0.75))
+
+(test-case "W1: setting-memory-auto-extraction-min-confidence coerces string"
+  (define s (make-minimal-settings #:overrides (hash 'memory (hash 'auto-extraction (hash 'min-confidence "0.8")))))
+  (check-equal? (setting-memory-auto-extraction-min-confidence s) 0.8))

--- a/wiring/run-modes.rkt
+++ b/wiring/run-modes.rkt
@@ -41,8 +41,15 @@
                   project-tree->string)
          (only-in "extension-setup.rkt" make-wired-extension-registry load-extensions-from-dir!)
          (only-in "../runtime/session/session-config.rkt" apply-context-assembly-profile!)
-         (only-in "../runtime/settings.rkt" setting-memory-injection-budget setting-memory-backend)
+         (only-in "../runtime/settings.rkt"
+                  setting-memory-injection-budget
+                  setting-memory-backend
+                  setting-memory-auto-extraction-enabled?
+                  setting-memory-auto-extraction-min-confidence)
          (only-in "../runtime/context-assembly/memory-builder.rkt" current-memory-injection-budget)
+         (only-in "../runtime/memory/auto-extraction.rkt"
+                  current-auto-extraction-enabled
+                  current-auto-extraction-min-confidence)
          (only-in "../extensions/gsd/state-machine.rkt" gsm-current)
          (only-in "../runtime/gsd-query.rkt" current-gsd-mode-query))
 
@@ -214,7 +221,19 @@
         (hash-set final-hash-with-profile 'memory-backend settings-backend)
         final-hash-with-profile))
 
-  (hash->session-config final-hash-with-memory))
+  ;; v0.95.16 W1: Wire auto-extraction from settings
+  (define auto-extract-enabled? (setting-memory-auto-extraction-enabled? settings))
+  (define auto-extract-min-conf (setting-memory-auto-extraction-min-confidence settings))
+  (current-auto-extraction-enabled auto-extract-enabled?)
+  (current-auto-extraction-min-confidence auto-extract-min-conf)
+  (define final-hash-with-auto-extract
+    (hash-set* final-hash-with-memory
+               'memory-auto-extraction-enabled
+               auto-extract-enabled?
+               'memory-auto-extraction-min-confidence
+               auto-extract-min-conf))
+
+  (hash->session-config final-hash-with-auto-extract))
 
 ;; ============================================================
 ;; mode-for-config


### PR DESCRIPTION
W1: Settings and session config for auto-extraction.

- setting-memory-auto-extraction-enabled? (reads memory.auto-extraction.enabled, default #f)
- setting-memory-auto-extraction-min-confidence (reads memory.auto-extraction.min-confidence, default 0.5)
- config-memory-auto-extraction-enabled? / config-memory-auto-extraction-min-confidence
- Wired into run-modes.rkt with runtime parameters
- 11 new tests

Closes #7198 #7199 #7200