### PR TITLE
feat: v0.95.16 W3 lifecycle hook for post-turn auto-extraction

### DIFF
--- a/agent/loop-stream.rkt
+++ b/agent/loop-stream.rkt
@@ -55,7 +55,9 @@
                   make-stream-turn-cancelled-event
                   make-stream-tool-call-started-event
                   make-stream-assistant-msg-completed-event)
-         (only-in "loop-messages.rkt" usage-empty? classify-hook-result))
+         (only-in "loop-messages.rkt" usage-empty? classify-hook-result)
+         ;; v0.95.16 W3: Post-turn auto-extraction
+         (only-in "../runtime/memory/auto-extraction.rkt" maybe-auto-extract-after-response!))
 
 (provide classify-chunk
          chunk-has-data?
@@ -148,6 +150,8 @@
      (when hook-dispatcher
        (hook-dispatcher 'agent-end
                         (hasheq 'session-id session-id 'turn-id turn-id 'termination 'completed)))
+     ;; v0.95.16 W3: Post-turn auto-extraction (non-fatal, gated by parameter)
+     (maybe-auto-extract-after-response! final-text #:session-id session-id)
      (make-loop-result
       (loop-state-messages state)
       'completed

--- a/runtime/memory/auto-extraction.rkt
+++ b/runtime/memory/auto-extraction.rkt
@@ -21,6 +21,7 @@
                   effective-memory-scope
                   memory-persistent-write-allowed?)
          (only-in "backends/helpers.rkt" current-iso-8601) ; F32
+         (only-in "service.rkt" current-memory-backend current-memory-policy)
          (only-in "../../agent/event-structs/memory-events.rkt"
                   make-mem-item-stored-event
                   make-mem-policy-blocked-event
@@ -284,6 +285,31 @@
 ;; Provide
 ;; ---------------------------------------------------------------------------
 
+;; ---------------------------------------------------------------------------
+;; Lifecycle helper for post-turn hook
+;; ---------------------------------------------------------------------------
+
+;; Non-fatal post-turn auto-extraction. Called from the agent loop after
+;; a completed assistant text turn. Catches all exceptions silently.
+;; Returns void — extraction results are observable via events only.
+(define (maybe-auto-extract-after-response! response-text
+                                            #:session-id session-id
+                                            #:project-root [project-root #f]
+                                            #:on-event [on-event void]
+                                            #:on-typed-event [on-typed-event void])
+  (with-handlers ([exn:fail? (lambda (e)
+                               (log-warning (format "auto-extraction error: ~a" (exn-message e))))])
+    (define backend (current-memory-backend))
+    (define policy (current-memory-policy))
+    (when (and (current-auto-extraction-enabled) backend)
+      (try-auto-extract response-text
+                        #:backend backend
+                        #:policy policy
+                        #:session-id session-id
+                        #:project-root (or project-root ".")
+                        #:on-event on-event
+                        #:on-typed-event on-typed-event))))
+
 (provide current-auto-extraction-enabled
          current-auto-extraction-min-confidence
          classify-sensitivity
@@ -294,6 +320,7 @@
          extraction-result-action
          extraction-result-item
          extraction-result-reason
+         maybe-auto-extract-after-response!
          ;; Low-level checks for testing
          contains-secret?
          looks-like-raw-output?

--- a/tests/test-memory-lifecycle-w3.rkt
+++ b/tests/test-memory-lifecycle-w3.rkt
@@ -1,0 +1,95 @@
+#lang racket/base
+;;; test-memory-lifecycle-w3.rkt — W3 tests for post-turn auto-extraction lifecycle hook
+(require rackunit
+         racket/string
+         "../runtime/memory/auto-extraction.rkt"
+         "../runtime/memory/types.rkt"
+         "../runtime/memory/protocol.rkt"
+         "../runtime/memory/backends/memory-hash.rkt"
+         "../runtime/memory/policy.rkt"
+         "../runtime/memory/service.rkt")
+
+;; Helper: create a hash backend for testing
+(define (make-test-backend)
+  (make-memory-hash-backend))
+
+(test-case "W3: maybe-auto-extract-after-response! does nothing when disabled"
+  (parameterize ([current-auto-extraction-enabled #f]
+                 [current-memory-backend (make-test-backend)]
+                 [current-memory-policy default-memory-policy])
+    (define events '())
+    (maybe-auto-extract-after-response! "This is a factual statement about the project."
+                                        #:session-id "test-session"
+                                        #:on-typed-event (lambda (e) (set! events (cons e events))))
+    (check-equal? events '())))
+
+(test-case "W3: maybe-auto-extract-after-response! extracts when enabled"
+  (parameterize ([current-auto-extraction-enabled #t]
+                 [current-auto-extraction-min-confidence 0.3]
+                 [current-memory-backend (make-test-backend)]
+                 [current-memory-policy default-memory-policy])
+    (define events '())
+    (maybe-auto-extract-after-response!
+     "The project uses Racket for the agent core. Config files are in the project root."
+     #:session-id "test-session"
+     #:project-root "/tmp/test"
+     #:on-typed-event (lambda (e) (set! events (cons e events))))
+    ;; Should produce at least one event (store-requested, possibly stored)
+    (check-true (> (length events) 0) "Should produce events when enabled")))
+
+(test-case "W3: maybe-auto-extract-after-response! blocks secrets"
+  (parameterize ([current-auto-extraction-enabled #t]
+                 [current-auto-extraction-min-confidence 0.1]
+                 [current-memory-backend (make-test-backend)]
+                 [current-memory-policy default-memory-policy])
+    (define blocked '())
+    (maybe-auto-extract-after-response!
+     "The API key is sk-1234567890abcdef1234567890abcdef for the service."
+     #:session-id "test-session"
+     #:on-event (lambda (action item reason)
+                  (when (eq? action 'blocked)
+                    (set! blocked (cons reason blocked))))
+     #:on-typed-event void)
+    (check-true (> (length blocked) 0) "Secret content should be blocked")))
+
+(test-case "W3: maybe-auto-extract-after-response! does not fail on backend error"
+  (define failing-backend
+    (memory-backend "failing"
+                    (lambda (item) (error "Backend unavailable"))
+                    (lambda (query) (memory-result #t '() #f #f))
+                    (lambda (id item) (error "Update failed"))
+                    (lambda (id scope) (memory-result #t #f #f #f))
+                    (lambda (query) (memory-result #t '() #f #f))
+                    (lambda () #t)
+                    (lambda (query) (memory-result #t '() #f #f))))
+  (parameterize ([current-auto-extraction-enabled #t]
+                 [current-auto-extraction-min-confidence 0.1]
+                 [current-memory-backend failing-backend]
+                 [current-memory-policy default-memory-policy])
+    ;; Should NOT raise an exception
+    (maybe-auto-extract-after-response! "The project uses Racket for the agent core module."
+                                        #:session-id "test-session")
+    (check-true #t "Should not raise on backend failure")))
+
+(test-case "W3: maybe-auto-extract-after-response! skips short response"
+  (parameterize ([current-auto-extraction-enabled #t]
+                 [current-memory-backend (make-test-backend)]
+                 [current-memory-policy default-memory-policy])
+    (define events '())
+    (maybe-auto-extract-after-response! "OK"
+                                        #:session-id "test-session"
+                                        #:on-typed-event (lambda (e) (set! events (cons e events))))
+    ;; Short response should produce skipped result, no stored events
+    (check-equal?
+     (length (filter (lambda (e) (and (hash? e) (eq? (hash-ref e 'type #f) 'memory.stored))) events))
+     0)))
+
+(test-case "W3: maybe-auto-extract-after-response! skips empty response"
+  (parameterize ([current-auto-extraction-enabled #t]
+                 [current-memory-backend (make-test-backend)]
+                 [current-memory-policy default-memory-policy])
+    (define events '())
+    (maybe-auto-extract-after-response! ""
+                                        #:session-id "test-session"
+                                        #:on-typed-event (lambda (e) (set! events (cons e events))))
+    (check-equal? events '())))


### PR DESCRIPTION
W3: Lifecycle Hook for Post-Turn Auto-Extraction.

- maybe-auto-extract-after-response! helper
- Wired into build-final-stream-result (text-only turns)
- Non-fatal, gated by parameter
- 6 new tests

Closes #7204 #7205 #7206