### PR TITLE
fix: v0.95.18 W2 Blank [Auto] preamble fix (#7274)

### DIFF
--- a/runtime/context-assembly/auto-distillation.rkt
+++ b/runtime/context-assembly/auto-distillation.rkt
@@ -19,7 +19,8 @@
                   task-conclusion-fsm-state-origin
                   task-conclusion-timestamp
                   task-conclusion-relevance-tags
-                  task-conclusion-dependencies))
+                  task-conclusion-dependencies)
+         racket/string)
 
 ;; ── Uncovered Entry Detection ──
 
@@ -38,18 +39,19 @@
 
 ;; Generate a deterministic fallback conclusion for an uncovered entry.
 ;; v0.79.2 GAP-3: Accept optional content summary for richer fallback text.
+;; v0.95.18 F9: Blank/whitespace content treated as absent — use provenance fallback.
 (define (make-deterministic-fallback msg-id current-state [content-summary #f])
-  (task-conclusion
-   (format "auto-~a" msg-id)
-   (if content-summary
-       (format "[Auto] ~a" (substring content-summary 0 (min (string-length content-summary) 200)))
-       (format "[Auto] Previously read file (origin: ~a)" msg-id))
-   'fact
-   (or current-state 'idle)
-   (list msg-id)
-   (current-seconds)
-   '(auto-distilled)
-   '()))
+  (define trimmed (and content-summary (string-trim content-summary)))
+  (task-conclusion (format "auto-~a" msg-id)
+                   (if (and trimmed (non-empty-string? trimmed))
+                       (format "[Auto] ~a" (substring trimmed 0 (min (string-length trimmed) 200)))
+                       (format "[Auto] Previously read file (origin: ~a)" msg-id))
+                   'fact
+                   (or current-state 'idle)
+                   (list msg-id)
+                   (current-seconds)
+                   '(auto-distilled)
+                   '()))
 
 ;; Generate fallback conclusions for all uncovered entries.
 ;; v0.79.2 GAP-3: Accept optional content-summary hash (msg-id -> string).

--- a/runtime/context-assembly/state-aware-builder.rkt
+++ b/runtime/context-assembly/state-aware-builder.rkt
@@ -329,10 +329,16 @@
          [(debugging) "DEBUGGING"]
          [else "UNKNOWN"]))
      (define guidance (hash-ref state-guidance-table state-name "Focus on the current task."))
-     (define conclusion-count (length (filter task-conclusion? conclusions)))
+     ;; v0.95.18 F9: Filter bare [Auto] conclusions before count/render
+     (define visible-conclusions
+       (filter (lambda (c)
+                 (and (task-conclusion? c)
+                      (not (equal? (string-trim (task-conclusion-text c)) "[Auto]"))))
+               conclusions))
+     (define conclusion-count (length visible-conclusions))
      (define conclusion-section
        (if (> conclusion-count 0)
-           (let* ([top (take conclusions (min 10 (length conclusions)))]
+           (let* ([top (take visible-conclusions (min 10 (length visible-conclusions)))]
                   [texts (for/list ([c (in-list top)])
                            (format "  - ~a" (task-conclusion-text c)))])
              (format "\n\nKey conclusions (~a in memory):\n~a"


### PR DESCRIPTION
Closes #7274, #7275, #7276, #7277

## W2 — Blank [Auto] Auto-Distillation and State Preamble Fix (F9)

### Changes
- Fix auto-distillation to treat blank/whitespace content as absent (use provenance fallback)
- Fix state preamble to filter bare `[Auto]` conclusions before count/render
- Preserve valid `[Auto] Previously read file x` rendering

### Verification
```bash
cd q
raco make runtime/context-assembly/auto-distillation.rkt runtime/context-assembly/state-aware-builder.rkt main.rkt
racket scripts/run-tests.rkt tests/test-auto-distillation.rkt tests/test-state-aware-builder.rkt
```