### PR TITLE
fix: v0.95.18 W5 reflection determinism and conservative grouping (#7286)

### DIFF
--- a/runtime/memory/reflection.rkt
+++ b/runtime/memory/reflection.rkt
@@ -24,8 +24,8 @@
 ;; Parameters
 ;; ---------------------------------------------------------------------------
 
-(define current-reflection-min-group-size (make-parameter 2))
-(define current-reflection-overlap-threshold (make-parameter 0.3))
+(define current-reflection-min-group-size (make-parameter 3))
+(define current-reflection-overlap-threshold (make-parameter 0.4))
 
 ;; ---------------------------------------------------------------------------
 ;; Grouping logic
@@ -41,11 +41,12 @@
       0.0
       (/ intersection-size union-size 1.0)))
 
-;; Check if two items share at least one tag
+;; Check if two items share at least 2 tags (conservative grouping)
 (define (shared-tags? a b)
   (define tags-a (hash-ref (memory-item-metadata a) 'tags '()))
   (define tags-b (hash-ref (memory-item-metadata b) 'tags '()))
-  (and (for/or ([ta (in-list tags-a)]) (member ta tags-b)) #t))
+  (define shared-count (for/sum ([ta (in-list tags-a)]) (if (member ta tags-b) 1 0)))
+  (>= shared-count 2))
 
 ;; Check if two items are "related" (shared tags OR token overlap >= threshold)
 (define (items-related? a b threshold)
@@ -103,11 +104,8 @@
 
 ;; Build a memory-item for a reflection
 (define (make-reflection-item merged-content source-ids tags project-root session-id)
-  (define id
-    (format "refl_~a_~a"
-            (current-seconds)
-            ;; Deterministic suffix from sorted source IDs
-            (abs (equal-hash-code (sort source-ids string<?)))))
+  ;; Deterministic ID: hash of sorted source IDs, no wall-clock
+  (define id (format "refl_~a" (abs (equal-hash-code (sort source-ids string<?)))))
   (define now (current-iso-8601))
   (memory-item id
                'semantic

--- a/tests/test-memory-reflection-w5.rkt
+++ b/tests/test-memory-reflection-w5.rkt
@@ -64,8 +64,8 @@
 ;; ---------------------------------------------------------------------------
 
 (test-case "W5: shared-tags? with common tags"
-  (define a (make-test-item "a" "x" '("racket" "memory")))
-  (define b (make-test-item "b" "y" '("memory" "test")))
+  (define a (make-test-item "a" "x" '("racket" "memory" "test")))
+  (define b (make-test-item "b" "y" '("memory" "test" "other")))
   (check-true (shared-tags? a b)))
 
 (test-case "W5: shared-tags? with disjoint tags"
@@ -78,9 +78,9 @@
 ;; ---------------------------------------------------------------------------
 
 (test-case "W5: items-related? by shared tags"
-  (define a (make-test-item "a" "completely different content" '("memory")))
-  (define b (make-test-item "b" "totally unrelated text" '("memory")))
-  (check-true (items-related? a b 0.3)))
+  (define a (make-test-item "a" "completely different content" '("memory" "shared")))
+  (define b (make-test-item "b" "totally unrelated text" '("memory" "shared")))
+  (check-true (items-related? a b 0.4)))
 
 (test-case "W5: items-related? by token overlap"
   (define a (make-test-item "a" "the memory system stores facts" '()))
@@ -173,12 +173,12 @@
   (define backend1 (make-memory-hash-backend))
   (gen:store-memory! backend1 (make-test-item "m1" "alpha about memory" '("t")))
   (gen:store-memory! backend1 (make-test-item "m2" "beta about memory" '("t")))
-  (define r1 (reflect-session-memories! backend1 #:session-id "s1" #:project-root "."))
+  (define r1 (reflect-session-memories! backend1 #:session-id "s1" #:project-root "." #:min-group-size 2))
 
   (define backend2 (make-memory-hash-backend))
   (gen:store-memory! backend2 (make-test-item "m1" "alpha about memory" '("t")))
   (gen:store-memory! backend2 (make-test-item "m2" "beta about memory" '("t")))
-  (define r2 (reflect-session-memories! backend2 #:session-id "s1" #:project-root "."))
+  (define r2 (reflect-session-memories! backend2 #:session-id "s1" #:project-root "." #:min-group-size 2))
 
   (check-equal? (memory-item-content (car r1)) (memory-item-content (car r2)))
   (check-equal? (memory-item-id (car r1)) (memory-item-id (car r2))))
@@ -191,8 +191,8 @@
   (check-equal? (current-reflection-min-group-size) 3))
 
 (test-case "W0 F7: one shared tag is not sufficient for reflection relatedness"
-  (define a (make-test-item "a" "unrelated alpha" '("shared" "left")))
-  (define b (make-test-item "b" "unrelated beta" '("shared" "right")))
+  (define a (make-test-item "a" "alpha xyz foo" '("shared" "left")))
+  (define b (make-test-item "b" "beta bar baz" '("shared" "right")))
   (check-false (items-related? a b 0.3)))
 
 (test-case "W0 F7: reflection ID is deterministic and not wall-clock based"


### PR DESCRIPTION
Closes #7286, #7287, #7288, #7289

## W5 — Reflection Determinism, Conservative Grouping, and Failure Handling (F7)

### Changes
- Default min-group-size raised from 2 to 3 (conservative)
- shared-tags? requires >=2 shared tags (was >=1)
- Jaccard threshold raised from 0.3 to 0.4
- Reflection IDs fully deterministic (no wall-clock component)
- Updated pre-existing tests to match new conservative defaults

### Verification
- 19/19 reflection tests passing
- 26/26 release-gate tests passing
- Full compile clean