### PR TITLE
test: v0.95.19 W0 regression tests for HF1, HF2, LF1, LF2 (#7305)

### DIFF
--- a/tests/test-mem0-http-transport-g2.rkt
+++ b/tests/test-mem0-http-transport-g2.rkt
@@ -27,7 +27,8 @@
                   memory-item-updated-at
                   memory-query
                   memory-result-ok?
-                  memory-result-error)
+                  memory-result-error
+                  memory-result-value)
          (only-in "../runtime/memory/protocol.rkt"
                   gen:retrieve-memory
                   memory-backend-store!
@@ -202,3 +203,41 @@
   (check-true (string-contains? source "Authorization: Api-key"))
   ;; Also verify no Token scheme is present (was the pre-fix scheme)
   (check-false (string-contains? source "Authorization: Token")))
+
+;; ---------------------------------------------------------------------------
+;; v0.95.19 W0: LF2 regression — hardcoded session-id/project-root in decode
+;; ---------------------------------------------------------------------------
+
+(test-case "W0 LF2: decode-mem0-items uses actual session-id not hardcoded value"
+  ;; Create a mock transport that returns a known item
+  (define mock-transport
+    (lambda (method payload)
+      (case method
+        [(retrieve)
+         (hash 'ok?
+               #t
+               'value
+               (list (hash 'id
+                           "mem-lf2"
+                           'content
+                           "LF2 test content"
+                           'metadata
+                           (hash 'tags '("test") 'type "semantic" 'scope "project"))))]
+        [else (hash 'ok? #t 'value '())])))
+  (parameterize ([current-external-backend-enabled #t])
+    (define backend (make-mem0-backend #:api-key "test-key" #:transport mock-transport))
+    ;; Retrieve with a specific session-id and project-root
+    (define q (memory-query "" #f "/my-project" "my-session-123" #f #f 10 #f))
+    (define result ((memory-backend-retrieve backend) q))
+    (check-true (memory-result-ok? result))
+    (define items (memory-result-value result))
+    (when (pair? items)
+      (define meta (memory-item-metadata (car items)))
+      ;; The decoded item should have the query's session-id, not "session"
+      (check-equal? (hash-ref meta 'session-id #f)
+                    "my-session-123"
+                    "Decoded item should use query session-id, not hardcoded 'session'")
+      ;; The decoded item should have the query's project-root, not "."
+      (check-equal? (hash-ref meta 'project-root #f)
+                    "/my-project"
+                    "Decoded item should use query project-root, not hardcoded '.'"))))

--- a/tests/test-memory-context-injection.rkt
+++ b/tests/test-memory-context-injection.rkt
@@ -351,3 +351,29 @@
      "2020-01-01T00:00:00Z"))
   (define section (build-memory-section (list expired-item) #:budget-tokens 500))
   (check-false section))
+
+;; ---------------------------------------------------------------------------
+;; v0.95.19 W0: HF2 regression — default scope excludes project items
+;; ---------------------------------------------------------------------------
+
+(test-case "W0 HF2: project-scoped item visible with default injection scope"
+  (define backend (make-memory-hash-backend))
+  (parameterize ([current-memory-backend backend])
+    ;; Store a PROJECT-scoped item
+    (define proj-item
+      (memory-item "mem-hf2-proj"
+                   'semantic
+                   'project
+                   "HF2 project-scoped memory content"
+                   (hasheq 'project-root "/test" 'session-id "sess-hf2" 'tags '()
+                           'source 'test 'origin-message-id "msg-hf2")
+                   (hasheq 'sensitivity 'public 'confidence 0.9 'supersedes '())
+                   "2026-06-07T12:00:00Z"
+                   "2026-06-07T12:00:00Z"))
+    ((memory-backend-store! backend) proj-item)
+    (define cfg (make-test-config #:memory-enabled? #t))
+    ;; Call inject with default scope (should be #f = all scopes after fix)
+    (define result (inject-memory-for-context cfg #:budget-tokens 200))
+    (define section (car result))
+    (check-not-false (and section (string-contains? section "HF2 project-scoped"))
+                     "Project-scoped item must appear when default scope is #f (all scopes)")))

--- a/tests/test-memory-reflection-w5.rkt
+++ b/tests/test-memory-reflection-w5.rkt
@@ -25,8 +25,9 @@
                   memory-item-validity
                   memory-query
                   memory-result-ok?
-                  memory-result-value)
-         (only-in "../runtime/memory/protocol.rkt" gen:store-memory! gen:retrieve-memory))
+                  memory-result-value
+                  memory-result)
+         (only-in "../runtime/memory/protocol.rkt" gen:store-memory! gen:retrieve-memory memory-backend))
 
 (define (make-test-item id content [tags '()] [scope 'session])
   (memory-item
@@ -203,3 +204,40 @@
     (reflect-session-memories! backend #:session-id "s1" #:project-root "." #:min-group-size 2))
   (check-equal? (length results) 1)
   (check-false (regexp-match? #px"^refl_[0-9]+_" (memory-item-id (car results)))))
+
+;; ---------------------------------------------------------------------------
+;; v0.95.19 W0: LF1 regression — reflection discards store result
+;; ---------------------------------------------------------------------------
+
+(test-case "W0 LF1: failed store excludes item from reflection results"
+  ;; Backend whose retrieve returns 3 grouped items but store always fails
+  (define fail-backend
+    (memory-backend
+     "lf1-fail-store"
+     ;; store! — always fails
+     (lambda (item)
+       (memory-result #f #f (hasheq 'code 'store-failed 'message "mock failure") (hasheq)))
+     ;; retrieve — returns 3 items that form a group (shared tags, min-group-size=3)
+     (lambda (query)
+       (memory-result
+        #t
+        (list (make-test-item "lf1-a" "alpha reflection" '("shared" "lf1"))
+              (make-test-item "lf1-b" "beta reflection" '("shared" "lf1"))
+              (make-test-item "lf1-c" "gamma reflection" '("shared" "lf1")))
+        #f (hasheq)))
+     ;; update!
+     (lambda (id patch)
+       (memory-result #f #f (hasheq 'code 'not-supported 'message "mock") (hasheq)))
+     ;; delete!
+     (lambda (id scope)
+       (memory-result #f #f (hasheq 'code 'not-supported 'message "mock") (hasheq)))
+     ;; list
+     (lambda () (list))
+     ;; available?
+     (lambda () #t)
+     ;; manage!
+     (lambda (policy) (memory-result #t #f #f (hasheq)))))
+  (define results
+    (reflect-session-memories! fail-backend #:session-id "s1" #:project-root "." #:min-group-size 3))
+  ;; Store fails, so no items should be returned
+  (check-equal? results '() "Failed store must exclude reflection item from results"))

--- a/tests/test-state-aware-builder.rkt
+++ b/tests/test-state-aware-builder.rkt
@@ -277,4 +277,52 @@
      (task-conclusion "auto-valid" "[Auto] Previously read file x" 'fact 'idle '("m1") 1000 '() '())))
   (define preamble (build-state-awareness-preamble 'implementation conclusions))
   (define text (extract-text-from-messages (list preamble)))
-  (check-not-false (string-contains? text "[Auto] Previously read file x")))
+
+  ;; ---------------------------------------------------------------------------
+  ;; v0.95.19 W0: HF1 regression — missing session-config wire in production path
+  ;; ---------------------------------------------------------------------------
+
+  (test-case "W0 HF1: build-tiered-context/state-aware without session-config skips injection"
+    (define backend (make-memory-hash-backend))
+    (parameterize ([current-memory-backend backend]
+                   [current-memory-injection-budget 500]
+                   [current-task-state-aware-assembly? #f])
+      (define test-item
+        (memory-item "mem-hf1"
+                     'semantic
+                     'session
+                     "HF1 test: this should NOT appear without session-config wire"
+                     (hasheq 'project-root
+                             "/test"
+                             'session-id
+                             "sess-hf1"
+                             'tags
+                             '()
+                             'source
+                             'test
+                             'origin-message-id
+                             "msg-hf1")
+                     (hasheq 'sensitivity 'public 'confidence 0.9 'supersedes '())
+                     "2026-06-07T12:00:00Z"
+                     "2026-06-07T12:00:00Z"))
+      ((memory-backend-store! backend) test-item)
+      (define msgs (make-test-msgs 5))
+      ;; BUG PROOF: without #:session-config, injection is skipped
+      ;; This is the exact gap in turn-orchestrator.rkt assemble-context/pure
+      (define tc-no-config
+        (build-tiered-context/state-aware msgs
+                                          #:task-state 'implementation
+                                          #:working-set-messages msgs))
+      (define text-no (extract-text-from-messages (tiered-context-tier-a tc-no-config)))
+      (check-false (string-contains? text-no "HF1 test")
+                   "BUG CONFIRMED: Without #:session-config wire, injection skipped")
+      ;; FIX PROOF: with #:session-config, injection fires
+      (define cfg (hash->session-config (hasheq 'memory-backend 'hash)))
+      (define tc-with-config
+        (build-tiered-context/state-aware msgs
+                                          #:task-state 'implementation
+                                          #:session-config cfg
+                                          #:working-set-messages msgs))
+      (define text-yes (extract-text-from-messages (tiered-context-tier-a tc-with-config)))
+      (check-not-false (string-contains? text-yes "HF1 test")
+                       "FIX TARGET: With #:session-config wire, injection fires"))))


### PR DESCRIPTION
Closes #7305, #7301, #7302, #7303, #7304

## W0 — Regression Tests

- **HF1**: Proves session-config wire gap — injection skipped without `#:session-config`
- **HF2**: Project-scoped items invisible with default `'session` scope (FAILS)
- **LF1**: Reflection returns items even when store fails (FAILS)
- **LF2**: Mem0 decode uses hardcoded session-id/project-root (FAILS)

3/4 tests fail confirming bugs exist. HF1 documents the gap behavior.