### PR TITLE
fix: HF1 session-config wire + HF2 default scope #f

### DIFF
--- a/runtime/context-assembly/memory-builder.rkt
+++ b/runtime/context-assembly/memory-builder.rkt
@@ -111,7 +111,7 @@
                     (hasheq))]))
 
 (define (observe-memory-for-context session-config
-                                    #:scope [scope 'session]
+                                    #:scope [scope #f]
                                     #:session-id [session-id #f]
                                     #:project [project #f]
                                     #:limit [limit 20])
@@ -167,7 +167,7 @@
 ;; ---------------------------------------------------------------------------
 
 (define (observe-memory-telemetry session-config
-                                  #:scope [scope 'session]
+                                  #:scope [scope #f]
                                   #:session-id [session-id #f]
                                   #:project [project #f]
                                   #:limit [limit 20])
@@ -357,7 +357,7 @@
     item))
 
 (define (inject-memory-for-context session-config
-                                   #:scope [scope 'session]
+                                   #:scope [scope #f]
                                    #:session-id [session-id #f]
                                    #:project [project #f]
                                    #:budget-tokens [budget-tokens (current-memory-injection-budget)]

--- a/runtime/context-assembly/state-aware-builder.rkt
+++ b/runtime/context-assembly/state-aware-builder.rkt
@@ -211,7 +211,7 @@
     (define observe-memory-for-context
       (dynamic-require memory-builder-path 'observe-memory-for-context))
     (define memory-telemetry->jsexpr (dynamic-require memory-builder-path 'memory-telemetry->jsexpr))
-    (define observed (observe-memory-for-context session-config))
+    (define observed (observe-memory-for-context session-config #:scope #f))
     (when trace-cb
       (trace-cb 'memory-observe (memory-telemetry->jsexpr (cdr observed))))
     ;; v0.95.15 W3: Inject memory context when injection budget is configured
@@ -220,7 +220,7 @@
     (when (current-memory-injection-budget)
       (define inject-memory-for-context
         (dynamic-require memory-builder-path 'inject-memory-for-context))
-      (define injected (inject-memory-for-context session-config))
+      (define injected (inject-memory-for-context session-config #:scope #f))
       (define section (car injected))
       (when (and section (positive? (string-length section)))
         (set! memory-section-text section)

--- a/runtime/turn-orchestrator.rkt
+++ b/runtime/turn-orchestrator.rkt
@@ -216,7 +216,8 @@
                                            #:working-set-messages ws-messages
                                            #:task-state task-state
                                            #:conclusions conclusions
-                                           #:recent-tool-calls recent-tool-calls))
+                                           #:recent-tool-calls recent-tool-calls
+                                           #:session-config config))
        (values sa-tc #f)]
       ;; Standard assembly path
       [else


### PR DESCRIPTION
Closes #7308, #7312
Closes #7306, #7307 (HF1 sub-issues)
Closes #7309, #7310, #7311 (HF2 sub-issues)

## Fixes

- **HF1**: Thread `#:session-config config` to `build-tiered-context/state-aware` in `turn-orchestrator.rkt` — enables memory injection in production path
- **HF2**: Change default `#:scope` from `'session` to `#f` in `observe-memory-for-context`, `observe-memory-telemetry`, `inject-memory-for-context` — makes project/user-scoped items visible

## Verification
- HF1 regression test passes (documents gap + fix proof)
- HF2 regression test passes (was failing, now green)
- 22/22 state-aware-builder tests pass
- 22/22 memory-context-injection tests pass
- 18/18 memory-context-observe tests pass
- 10/10 tiered-injection tests pass