### PR TITLE
fix: LF1 reflection store check + LF2 mem0 decode threading

### DIFF
--- a/runtime/memory/backends/mem0-api.rkt
+++ b/runtime/memory/backends/mem0-api.rkt
@@ -243,7 +243,9 @@
             (case method
               [(retrieve)
                (define items (hash-ref raw 'value '()))
-               (hash 'ok? #t 'value (decode-mem0-items items "session" "."))]
+               (hash 'ok? #t 'value (decode-mem0-items items
+                                                           (hash-ref payload 'session-id "unknown")
+                                                           (hash-ref payload 'project-root ".")))]
               [else raw])])))
      (make-external-backend (format "mem0(~a)" base-url) mem0-transport #:timeout-ms timeout-ms)]))
 

--- a/runtime/memory/reflection.rkt
+++ b/runtime/memory/reflection.rkt
@@ -156,12 +156,13 @@
            (cond
              [(null? valid-groups) '()]
              [else
-              (for/list ([group (in-list valid-groups)])
-                (define-values (merged-text source-ids tags) (merge-group-items group))
-                (define refl-item
-                  (make-reflection-item merged-text source-ids tags project-root session-id))
-                (gen:store-memory! backend refl-item)
-                refl-item)])])])]))
+              (filter memory-item?
+                      (for/list ([group (in-list valid-groups)])
+                        (define-values (merged-text source-ids tags) (merge-group-items group))
+                        (define refl-item
+                          (make-reflection-item merged-text source-ids tags project-root session-id))
+                        (define store-result (gen:store-memory! backend refl-item))
+                        (if (memory-result-ok? store-result) refl-item #f)))])])])]))
 
 ;; ---------------------------------------------------------------------------
 ;; Provide


### PR DESCRIPTION
Closes #7315, #7318
Closes #7313, #7314 (LF1 sub-issues)
Closes #7316, #7317 (LF2 sub-issues)

## Fixes

- **LF1**: Check `gen:store-memory!` result in `reflect-session-memories!` — filter out `#f` entries from failed stores
- **LF2**: Thread `session-id`/`project-root` from payload into `decode-mem0-items` instead of hardcoded values

## Verification
- 20/20 reflection tests pass
- 11/11 mem0 transport tests pass