### PR TITLE
chore: v0.95.19 version bump, CHANGELOG, docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## v0.95.19 — Memory Injection Hotfix (2026-06-07)
+
+### Bug Fixes
+- **HF1 (HIGH)**: Thread `#:session-config config` to `build-tiered-context/state-aware` in `turn-orchestrator.rkt` — enables memory injection in production context assembly path
+- **HF2 (HIGH)**: Change default `#:scope` from `'session` to `#f` in `observe-memory-for-context`, `inject-memory-for-context`, and `observe-memory-telemetry` — project and user-scoped memories now visible during retrieval
+- **LF1 (Low)**: Check `gen:store-memory!` result in `reflect-session-memories!` — failed stores no longer produce phantom reflection items
+- **LF2 (Low)**: Thread `session-id`/`project-root` from payload into `decode-mem0-items` — Mem0 external backend uses actual query context instead of hardcoded values
+
+### Verification
+- 174+ focused memory tests passing across 10+ test files
+- 4 new regression tests (3 previously failing, now green)
+
 ## v0.95.18 — Memory Quality Remediation (2026-06-07)
 
 ### Regression Harness

--- a/docs/memory-activation.md
+++ b/docs/memory-activation.md
@@ -1,4 +1,4 @@
-# Memory Activation (v0.95.18)
+# Memory Activation (v0.95.19)
 
 ## Overview
 
@@ -240,3 +240,13 @@ Key behavioral improvements:
 
 - [Architecture Overview](architecture/overview.md)
 - [Tool System](tooling.md)
+
+### v0.95.19 Memory Injection Hotfix
+
+**HF1**: Memory injection was silently skipped in production because `assemble-context/pure` in `turn-orchestrator.rkt` did not thread `#:session-config` to `build-tiered-context/state-aware`. The parameter was accepted but never populated. Fixed by adding the wire.
+
+**HF2**: Default scope for `observe-memory-for-context` and `inject-memory-for-context` was `'session`, which excluded project-scoped and user-scoped items from retrieval. Changed to `#f` (all scopes) so tiered injection sees all available memories.
+
+**LF1**: `reflect-session-memories!` returned reflection items even when `gen:store-memory!` failed. Now filters out failed stores.
+
+**LF2**: `decode-mem0-items` in the Mem0 adapter was called with hardcoded `"session"` and `"."` instead of actual query values. Now threaded from the retrieve payload.

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.95.18")
+(define version "0.95.19")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base" "gui-easy-lib"))

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -11,4 +11,4 @@
 
 (provide (contract-out [q-version string?]))
 
-(define q-version "0.95.18")
+(define q-version "0.95.19")


### PR DESCRIPTION
Closes #7325, #7322, #7323, #7324

## Changes

- Version bumped to `0.95.19` in `util/version.rkt` and `info.rkt`
- CHANGELOG entry documenting HF1, HF2, LF1, LF2 hotfixes
- `docs/memory-activation.md` updated with v0.95.19 section

## Final Verification
- All memory tests passing (174+ across 10+ files)
- All 4 regression tests green