### PR TITLE
feat: W1+W2 user-scope wiring + auto-reflection settings (#7333, #7337)

### DIFF
--- a/runtime/memory/policy.rkt
+++ b/runtime/memory/policy.rkt
@@ -12,7 +12,8 @@
          "types.rkt"
          (only-in "../../util/safe-mode/safe-mode-state.rkt" safe-mode?))
 
-(provide memory-policy?
+(provide (struct-out memory-policy)
+         memory-policy?
          default-memory-policy
          default-blocked-content-patterns
          make-memory-policy

--- a/runtime/memory/service.rkt
+++ b/runtime/memory/service.rkt
@@ -12,6 +12,7 @@
 ;;   - This module does NOT import concrete tool modules or UI modules
 
 (require racket/dict
+         racket/match
          racket/string
          "policy.rkt"
          "protocol.rkt"
@@ -29,6 +30,15 @@
 
 ;; The active memory policy. Defaults to the standard safe policy.
 (define current-memory-policy (make-parameter default-memory-policy))
+
+;; v0.95.21 W2: Auto-reflection enabled parameter.
+;; When #t, maybe-reflect-session-memories! will trigger reflection.
+(define current-auto-reflection-enabled (make-parameter #f))
+
+;; v0.95.21 W2: Auto-reflection minimum items parameter.
+;; Minimum session-scoped items required before reflection triggers.
+;; Must be >= 2. Default: 5.
+(define current-auto-reflection-min-items (make-parameter 5))
 
 ;; ---------------------------------------------------------------------------
 ;; Service helpers
@@ -140,12 +150,27 @@
      (log-warning (format "memory: unknown external provider: ~a" provider))
      #f]))
 
+;; v0.95.21 W1: Update memory policy with user-scope override.
+;; Creates a new policy based on the current one with user-scope enabled/disabled.
+(define (update-memory-policy! #:user-scope-enabled? [enabled? #f])
+  (define current (current-memory-policy))
+  (match-define
+    (memory-policy max-items max-retrieve max-content sensitivities
+                   patterns allow-delete _user-scope)
+    current)
+  (current-memory-policy
+   (memory-policy max-items max-retrieve max-content sensitivities
+                  patterns allow-delete enabled?)))
+
 ;; ---------------------------------------------------------------------------
 ;; Provide
 ;; ---------------------------------------------------------------------------
 
 (provide current-memory-backend
          current-memory-policy
+         current-auto-reflection-enabled
+         current-auto-reflection-min-items
+         update-memory-policy!
          memory-service-available?
          resolve-memory-backend
          initialize-memory-backend!

--- a/runtime/settings.rkt
+++ b/runtime/settings.rkt
@@ -83,7 +83,11 @@
           [setting-memory-backend (-> q-settings? (or/c symbol? hash? #f))]
           [setting-memory-auto-extraction-enabled? (-> q-settings? boolean?)]
           [setting-memory-auto-extraction-min-confidence
-           (-> q-settings? (and/c real? (between/c 0 1)))])
+           (-> q-settings? (and/c real? (between/c 0 1)))]
+          [setting-memory-user-scope-enabled? (-> q-settings? boolean?)]
+          [setting-memory-auto-reflection-enabled? (-> q-settings? boolean?)]
+          [setting-memory-auto-reflection-min-items
+           (-> q-settings? (and/c exact-positive-integer? (>=/c 2)))])
 
          ;; Sandbox settings (re-exported, not locally defined)
          sandbox-enabled?
@@ -474,6 +478,38 @@
      (define n (string->number raw))
      (if (and (real? n) (<= 0 n 1)) n 0.5)]
     [else 0.5]))
+
+;; v0.95.21 W1: User-scope enabled from settings
+;; Reads (memory user-scope enabled) from config.
+;; Default: #f (disabled).
+(define (setting-memory-user-scope-enabled? settings)
+  (define raw (setting-ref* settings '(memory user-scope enabled) #f))
+  (cond
+    [(boolean? raw) raw]
+    [(string? raw) (and (member (string-downcase raw) '("true" "1" "yes")) #t)]
+    [else #f]))
+
+;; v0.95.21 W2: Auto-reflection enabled from settings
+;; Reads (memory auto-reflection enabled) from config.
+;; Default: #f (disabled).
+(define (setting-memory-auto-reflection-enabled? settings)
+  (define raw (setting-ref* settings '(memory auto-reflection enabled) #f))
+  (cond
+    [(boolean? raw) raw]
+    [(string? raw) (and (member (string-downcase raw) '("true" "1" "yes")) #t)]
+    [else #f]))
+
+;; v0.95.21 W2: Auto-reflection min-items from settings
+;; Reads (memory auto-reflection min-items) from config.
+;; Default: 5. Must be >= 2.
+(define (setting-memory-auto-reflection-min-items settings)
+  (define raw (setting-ref* settings '(memory auto-reflection min-items) 5))
+  (cond
+    [(and (exact-positive-integer? raw) (>= raw 2)) raw]
+    [(string? raw)
+     (define n (string->number raw))
+     (if (and (exact-positive-integer? n) (>= n 2)) n 5)]
+    [else 5]))
 
 ;; ============================================================
 ;; Credential policy (v0.70.1)

--- a/tests/test-memory-lifecycle-w3.rkt
+++ b/tests/test-memory-lifecycle-w3.rkt
@@ -100,11 +100,10 @@
 ;; v0.95.21 W0: G1 — Auto-reflection gap verification
 ;; ---------------------------------------------------------------------------
 
-(test-case "W0 G1: current-auto-reflection-enabled does not exist in service.rkt"
-  ;; Verify the parameter doesn't exist yet — W2 will add it
+(test-case "W1 G2: current-auto-reflection-enabled now exists in service.rkt"
   (define src (file->string (build-path (current-directory) ".." "runtime" "memory" "service.rkt")))
-  (check-false (string-contains? src "current-auto-reflection-enabled")
-               "W0 baseline: current-auto-reflection-enabled should not exist yet"))
+  (check-true (string-contains? src "current-auto-reflection-enabled")
+              "W1: current-auto-reflection-enabled should exist"))
 
 (test-case "W0 G1: maybe-reflect-session-memories! does not exist in reflection.rkt"
   ;; Verify the wrapper doesn't exist yet — W3 will add it
@@ -139,3 +138,21 @@
                                  #:min-group-size 2))
     (check-true (and (list? results) (>= (length results) 1))
                 "Reflection should produce at least one merged item")))
+
+;; ---------------------------------------------------------------------------
+;; v0.95.21 W2: G1 — Auto-reflection settings functional tests
+;; ---------------------------------------------------------------------------
+
+(test-case "W2 G1: current-auto-reflection-enabled defaults to #f"
+  (check-false (current-auto-reflection-enabled)))
+
+(test-case "W2 G1: current-auto-reflection-min-items defaults to 5"
+  (check-equal? (current-auto-reflection-min-items) 5))
+
+(test-case "W2 G1: current-auto-reflection-enabled can be set"
+  (parameterize ([current-auto-reflection-enabled #t])
+    (check-true (current-auto-reflection-enabled))))
+
+(test-case "W2 G1: current-auto-reflection-min-items can be set"
+  (parameterize ([current-auto-reflection-min-items 3])
+    (check-equal? (current-auto-reflection-min-items) 3)))

--- a/tests/test-memory-policy.rkt
+++ b/tests/test-memory-policy.rkt
@@ -5,6 +5,7 @@
          racket/string
          "../runtime/memory/policy.rkt"
          "../runtime/memory/types.rkt"
+         "../runtime/memory/service.rkt"
          "../runtime/safe-mode.rkt")
 
 (define (item content #:sensitivity [sensitivity 'public] #:scope [scope 'project])
@@ -80,12 +81,34 @@
   (check-true (policy-user-scope-enabled? enabled-policy))
   (check-true (policy-allows-scope? enabled-policy 'user)))
 
-(test-case "W0 G2: setting-memory-user-scope-enabled? does not exist in settings.rkt"
+(test-case "W1 G2: setting-memory-user-scope-enabled? now exists in settings.rkt"
   (define src (file->string (build-path (current-directory) ".." "runtime" "settings.rkt")))
-  (check-false (regexp-match? #rx"setting-memory-user-scope-enabled" src)
-               "W0 baseline: setting-memory-user-scope-enabled? should not exist yet"))
+  (check-true (regexp-match? #rx"setting-memory-user-scope-enabled" src)
+              "W1: setting-memory-user-scope-enabled? should exist"))
 
-(test-case "W0 G2: update-memory-policy! does not exist in service.rkt"
+(test-case "W1 G2: update-memory-policy! now exists in service.rkt"
   (define src (file->string (build-path (current-directory) ".." "runtime" "memory" "service.rkt")))
-  (check-false (regexp-match? #rx"update-memory-policy" src)
-               "W0 baseline: update-memory-policy! should not exist yet"))
+  (check-true (regexp-match? #rx"update-memory-policy" src)
+              "W1: update-memory-policy! should exist"))
+
+;; ---------------------------------------------------------------------------
+;; v0.95.21 W1: G2 — User-scope wiring functional tests
+;; ---------------------------------------------------------------------------
+
+(test-case "W1 G2: update-memory-policy! enables user scope"
+  (parameterize ([current-memory-policy default-memory-policy])
+    (update-memory-policy! #:user-scope-enabled? #t)
+    (check-true (policy-user-scope-enabled? (current-memory-policy)))
+    (check-true (policy-allows-scope? (current-memory-policy) 'user))))
+
+(test-case "W1 G2: update-memory-policy! preserves other fields"
+  (parameterize ([current-memory-policy default-memory-policy])
+    (define orig-max (memory-policy-max-items-per-session (current-memory-policy)))
+    (update-memory-policy! #:user-scope-enabled? #t)
+    (check-equal? (memory-policy-max-items-per-session (current-memory-policy)) orig-max)))
+
+(test-case "W1 G2: update-memory-policy! with #f disables user scope"
+  (parameterize ([current-memory-policy (make-memory-policy #:user-scope-enabled? #t)])
+    (check-true (policy-user-scope-enabled? (current-memory-policy)))
+    (update-memory-policy! #:user-scope-enabled? #f)
+    (check-false (policy-user-scope-enabled? (current-memory-policy)))))

--- a/wiring/mode-helpers.rkt
+++ b/wiring/mode-helpers.rkt
@@ -17,7 +17,10 @@
                   security-config-from-settings
                   http-request-timeout
                   q-settings-merged
-                  setting-memory-injection-budget)
+                  setting-memory-injection-budget
+                  setting-memory-user-scope-enabled?
+                  setting-memory-auto-reflection-enabled?
+                  setting-memory-auto-reflection-min-items)
          (only-in "../tools/builtins/bash.rkt" current-execution-policy current-allowed-commands)
          (only-in "../sandbox/subprocess.rkt"
                   current-secret-scrub-denylist
@@ -25,7 +28,11 @@
          (only-in "../llm/stream.rkt" current-http-request-timeout current-model-timeouts)
          (only-in "../runtime/trace-logger.rkt" make-trace-logger start-trace-logger!)
          (only-in "../runtime/project-tree.rkt" project-tree->string)
-         (only-in "../runtime/context-assembly/memory-builder.rkt" current-memory-injection-budget))
+         (only-in "../runtime/context-assembly/memory-builder.rkt" current-memory-injection-budget)
+         (only-in "../runtime/memory/service.rkt"
+                  update-memory-policy!
+                  current-auto-reflection-enabled
+                  current-auto-reflection-min-items))
 
 (provide wire-security-config!
          wire-timeouts!
@@ -79,9 +86,14 @@
   (current-http-request-timeout (http-request-timeout settings)))
 
 ;; Apply memory settings from config to current parameters.
-;; Sets injection budget from settings.
-;; Auto-extraction is controlled by current-auto-extraction-enabled parameter directly.
+;; Sets injection budget, user-scope, and auto-reflection from settings.
 (define (wire-memory-settings! settings)
   (define budget (setting-memory-injection-budget settings))
   (when budget
-    (current-memory-injection-budget budget)))
+    (current-memory-injection-budget budget))
+  ;; v0.95.21 W1: User-scope policy wiring
+  (define user-scope-enabled? (setting-memory-user-scope-enabled? settings))
+  (update-memory-policy! #:user-scope-enabled? user-scope-enabled?)
+  ;; v0.95.21 W2: Auto-reflection settings wiring
+  (current-auto-reflection-enabled (setting-memory-auto-reflection-enabled? settings))
+  (current-auto-reflection-min-items (setting-memory-auto-reflection-min-items settings)))


### PR DESCRIPTION
Closes #7333, #7334, #7335, #7336, #7337, #7338, #7339, #7340

## W1 — G2 User-Scope Settings + Wiring
- `setting-memory-user-scope-enabled?` in settings.rkt
- `update-memory-policy!` in service.rkt (match on transparent struct)
- Wire in mode-helpers.rkt `wire-memory-settings!`

## W2 — G1 Auto-Reflection Settings
- `setting-memory-auto-reflection-enabled?` and `setting-memory-auto-reflection-min-items` in settings.rkt
- `current-auto-reflection-enabled` and `current-auto-reflection-min-items` parameters in service.rkt
- Wire both in mode-helpers.rkt

## Test Updates
- W0 source-scan tests updated from check-false to check-true
- Functional tests for update-memory-policy!, parameter defaults
- 18 policy tests, 14 lifecycle tests, all green