### PR TITLE
feat: W3 auto-reflection trigger in lifecycle (#7341)

### DIFF
--- a/agent/loop-stream.rkt
+++ b/agent/loop-stream.rkt
@@ -57,7 +57,9 @@
                   make-stream-assistant-msg-completed-event)
          (only-in "loop-messages.rkt" usage-empty? classify-hook-result)
          ;; v0.95.16 W3: Post-turn auto-extraction
-         (only-in "../runtime/memory/auto-extraction.rkt" maybe-auto-extract-after-response!))
+         (only-in "../runtime/memory/auto-extraction.rkt" maybe-auto-extract-after-response!)
+         ;; v0.95.21 W3: Post-turn auto-reflection
+         (only-in "../runtime/memory/reflection.rkt" maybe-reflect-session-memories!))
 
 (provide classify-chunk
          chunk-has-data?
@@ -134,6 +136,8 @@
   ;; v0.95.17 W1: Post-turn auto-extraction (non-fatal, gated by parameter)
   ;; Must fire for both text-only and tool-call turns.
   (maybe-auto-extract-after-response! final-text #:session-id session-id)
+  ;; v0.95.21 W3: Post-turn auto-reflection (non-fatal, gated by parameter)
+  (maybe-reflect-session-memories! #:session-id session-id)
   (cond
     [(null? tool-call-parts)
      (emit-typed-event! bus

--- a/runtime/memory/reflection.rkt
+++ b/runtime/memory/reflection.rkt
@@ -18,7 +18,11 @@
          "types.rkt"
          "protocol.rkt"
          (only-in "search.rkt" tokenize)
-         (only-in "backends/helpers.rkt" current-iso-8601))
+         (only-in "backends/helpers.rkt" current-iso-8601)
+         (only-in "service.rkt"
+                  current-memory-backend
+                  current-auto-reflection-enabled
+                  current-auto-reflection-min-items))
 
 ;; ---------------------------------------------------------------------------
 ;; Parameters
@@ -164,11 +168,30 @@
                         (define store-result (gen:store-memory! backend refl-item))
                         (if (memory-result-ok? store-result) refl-item #f)))])])])]))
 
+;; v0.95.21 W3: Non-fatal auto-reflection trigger.
+;; Gated by current-auto-reflection-enabled and current-auto-reflection-min-items.
+;; Catches all exceptions to prevent reflection errors from disrupting the agent loop.
+(define (maybe-reflect-session-memories! #:session-id session-id
+                                         #:project-root [project-root #f])
+  (with-handlers ([exn:fail? (lambda (e)
+                               (log-warning (format "memory: auto-reflection failed: ~a"
+                                                    (exn-message e))))])
+    (cond
+      [(not (current-auto-reflection-enabled)) (void)]
+      [(not (current-memory-backend)) (void)]
+      [else
+       (define backend (current-memory-backend))
+       (reflect-session-memories! backend
+                                  #:session-id session-id
+                                  #:project-root project-root
+                                  #:min-group-size (current-auto-reflection-min-items))])))
+
 ;; ---------------------------------------------------------------------------
 ;; Provide
 ;; ---------------------------------------------------------------------------
 
 (provide reflect-session-memories!
+         maybe-reflect-session-memories!
          current-reflection-min-group-size
          current-reflection-overlap-threshold
          ;; Exports for testing

--- a/tests/test-memory-lifecycle-w3.rkt
+++ b/tests/test-memory-lifecycle-w3.rkt
@@ -105,17 +105,15 @@
   (check-true (string-contains? src "current-auto-reflection-enabled")
               "W1: current-auto-reflection-enabled should exist"))
 
-(test-case "W0 G1: maybe-reflect-session-memories! does not exist in reflection.rkt"
-  ;; Verify the wrapper doesn't exist yet — W3 will add it
+(test-case "W3 G1: maybe-reflect-session-memories! now exists in reflection.rkt"
   (define src (file->string (build-path (current-directory) ".." "runtime" "memory" "reflection.rkt")))
-  (check-false (string-contains? src "maybe-reflect-session-memories!")
-               "W0 baseline: maybe-reflect-session-memories! should not exist yet"))
+  (check-true (string-contains? src "maybe-reflect-session-memories!")
+              "W3: maybe-reflect-session-memories! should exist"))
 
-(test-case "W0 G1: auto-reflection not hooked in loop-stream.rkt"
-  ;; Verify loop-stream.rkt doesn't call reflection yet — W3 will add it
+(test-case "W3 G1: auto-reflection now hooked in loop-stream.rkt"
   (define src (file->string (build-path (current-directory) ".." "agent" "loop-stream.rkt")))
-  (check-false (string-contains? src "reflect-session")
-               "W0 baseline: auto-reflection should not be in loop-stream.rkt yet"))
+  (check-true (string-contains? src "reflect-session")
+              "W3: auto-reflection should be in loop-stream.rkt"))
 
 (test-case "W0 G1: reflect-session-memories! exists and works (existing behavior)"
   ;; Verify the underlying reflection function exists and works
@@ -156,3 +154,86 @@
 (test-case "W2 G1: current-auto-reflection-min-items can be set"
   (parameterize ([current-auto-reflection-min-items 3])
     (check-equal? (current-auto-reflection-min-items) 3)))
+
+;; ---------------------------------------------------------------------------
+;; v0.95.21 W3: G1 — maybe-reflect-session-memories! functional tests
+;; ---------------------------------------------------------------------------
+
+(test-case "W3: maybe-reflect-session-memories! no-ops when disabled"
+  (define backend (make-test-backend))
+  (parameterize ([current-auto-reflection-enabled #f]
+                 [current-memory-backend backend]
+                 [current-memory-policy default-memory-policy]
+                 [current-reflection-min-group-size 2])
+    ;; Store enough items for reflection
+    (for ([i (in-range 3)])
+      ((memory-backend-store! backend)
+       (memory-item (format "no-op-~a" i)
+                    'semantic 'session
+                    (format "shared topic ~a alpha beta gamma" i)
+                    (hasheq 'project-root "/test" 'session-id "sess-w3-noop"
+                            'tags '("shared" "topic") 'source 'test
+                            'origin-message-id (format "m~a" i))
+                    (hasheq 'sensitivity 'public 'confidence 0.9 'supersedes '())
+                    "2026-06-07T12:00:00Z"
+                    "2026-06-07T12:00:00Z")))
+    (maybe-reflect-session-memories! #:session-id "sess-w3-noop")
+    ;; No reflection items created at project scope
+    (define result ((memory-backend-retrieve backend)
+                    (memory-query "" 'project "/test" #f #f #f 100 #f)))
+    (when (memory-result-ok? result)
+      (define items (memory-result-value result))
+      (check-equal? (length items) 0
+                    "Should not reflect when disabled"))))
+
+(test-case "W3: maybe-reflect-session-memories! no-ops when no backend"
+  (parameterize ([current-auto-reflection-enabled #t]
+                 [current-memory-backend #f])
+    ;; Should not raise
+    (maybe-reflect-session-memories! #:session-id "sess-w3-nobackend")
+    (check-true #t "Should not raise when no backend")))
+
+(test-case "W3: maybe-reflect-session-memories! non-fatal on backend error"
+  (define failing-backend
+    (memory-backend "failing"
+                    (lambda (item) (error "store failed"))
+                    (lambda (q) (error "retrieve failed"))
+                    (lambda (id patch) (error "update failed"))
+                    (lambda (id scope) (error "delete failed"))
+                    (lambda () (error "list failed"))
+                    (lambda () #t)
+                    (lambda (action) (error "manage failed"))))
+  (parameterize ([current-auto-reflection-enabled #t]
+                 [current-memory-backend failing-backend]
+                 [current-auto-reflection-min-items 2])
+    ;; Should not raise despite backend errors
+    (maybe-reflect-session-memories! #:session-id "sess-w3-fail")
+    (check-true #t "Should not raise on backend failure")))
+
+(test-case "W3: maybe-reflect-session-memories! fires when enabled with backend"
+  (define backend (make-test-backend))
+  (parameterize ([current-auto-reflection-enabled #t]
+                 [current-memory-backend backend]
+                 [current-memory-policy default-memory-policy]
+                 [current-auto-reflection-min-items 2]
+                 [current-reflection-min-group-size 2])
+    ;; Store 3 groupable items in session scope
+    (for ([i (in-range 3)])
+      ((memory-backend-store! backend)
+       (memory-item (format "fire-~a" i)
+                    'semantic 'session
+                    (format "shared topic ~a alpha beta gamma" i)
+                    (hasheq 'project-root "/test" 'session-id "sess-w3-fire"
+                            'tags '("shared" "topic") 'source 'test
+                            'origin-message-id (format "m~a" i))
+                    (hasheq 'sensitivity 'public 'confidence 0.9 'supersedes '())
+                    "2026-06-07T12:00:00Z"
+                    "2026-06-07T12:00:00Z")))
+    (maybe-reflect-session-memories! #:session-id "sess-w3-fire" #:project-root "/test")
+    ;; Check that a reflection item was created at project scope
+    (define result ((memory-backend-retrieve backend)
+                    (memory-query "" 'project "/test" #f #f #f 100 #f)))
+    (when (memory-result-ok? result)
+      (define items (memory-result-value result))
+      (check-true (>= (length items) 1)
+                  "Should have created at least one reflection item"))))


### PR DESCRIPTION
Closes #7341, #7342, #7343

## W3 — G1 Auto-Reflection Trigger

- `maybe-reflect-session-memories!` in reflection.rkt — non-fatal wrapper
- Hooked in loop-stream.rkt after auto-extraction
- Gated by `current-auto-reflection-enabled` (default #f)
- Respects `current-auto-reflection-min-items` (default 5)
- Catches all exceptions, logs warning, never disrupts agent loop
- 18 lifecycle tests pass