### PR TITLE
chore: v0.95.21 version bump, CHANGELOG, docs (#7344)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+## v0.95.21 — Memory Lifecycle Completion (2026-06-08)
+
+### New Features
+- **G1 — Background Reflection Trigger**: Auto-reflection now fires per-turn after auto-extraction when `memory.auto-reflection.enabled` is set to `true`. Non-fatal wrapper `maybe-reflect-session-memories!` catches all exceptions. Defaults to disabled.
+- **G2 — User-Scope Config Wiring**: User-scope memory can be enabled via `memory.user-scope.enabled` config key. Policy updated at session startup from config.
+
+### Configuration Keys
+- `(memory auto-reflection enabled)` — boolean, default `false`
+- `(memory auto-reflection min-items)` — integer >= 2, default `5`
+- `(memory user-scope enabled)` — boolean, default `false`
+
+### Verification
+- 18 lifecycle tests, 18 policy tests passing
+- All new features default off — no behavioral change for existing users
+
 ## v0.95.20 — Memory Tools Event Publisher Fix (2026-06-08)
 
 ### Bug Fixes

--- a/docs/memory-activation.md
+++ b/docs/memory-activation.md
@@ -250,3 +250,35 @@ Key behavioral improvements:
 **LF1**: `reflect-session-memories!` returned reflection items even when `gen:store-memory!` failed. Now filters out failed stores.
 
 **LF2**: `decode-mem0-items` in the Mem0 adapter was called with hardcoded `"session"` and `"."` instead of actual query values. Now threaded from the retrieve payload.
+
+### v0.95.21 Memory Lifecycle Completion
+
+**G1 — Background Reflection Trigger**: Session-scoped memories are now automatically promoted to project scope via deterministic reflection. When `memory.auto-reflection.enabled` is `true`, `maybe-reflect-session-memories!` fires after each turn's auto-extraction. The non-fatal wrapper catches all exceptions and logs warnings, never disrupting the agent loop. Controlled by two config keys:
+
+```json
+{
+  "memory": {
+    "auto-reflection": {
+      "enabled": true,
+      "min-items": 5
+    }
+  }
+}
+```
+
+- `enabled` (boolean, default `false`) — gates auto-reflection
+- `min-items` (integer >= 2, default `5`) — minimum session-scoped items before reflection triggers
+
+**G2 — User-Scope Config Wiring**: User-scope memory (global, cross-project) can be enabled via config:
+
+```json
+{
+  "memory": {
+    "user-scope": {
+      "enabled": true
+    }
+  }
+}
+```
+
+When enabled, the memory policy allows storing and retrieving user-scoped items. Defaults to `false` for safety.

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.95.20")
+(define version "0.95.21")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base" "gui-easy-lib"))

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -11,4 +11,4 @@
 
 (provide (contract-out [q-version string?]))
 
-(define q-version "0.95.20")
+(define q-version "0.95.21")


### PR DESCRIPTION
Closes #7344, #7345, #7346

## W4 — Documentation + Version Bump

- Version bumped to 0.95.21 in util/version.rkt and info.rkt
- CHANGELOG.md entry with new features and config keys
- docs/memory-activation.md updated with v0.95.21 section