### PR TITLE
refactor: W1 extract build-assembled-context phases (#7357)

### DIFF
--- a/runtime/turn-orchestrator.rkt
+++ b/runtime/turn-orchestrator.rkt
@@ -31,7 +31,12 @@
          (only-in "../util/content/content-parts.rkt" make-text-part text-part? tool-result-part?)
          (only-in "../util/event/event.rkt" make-event event-ev)
          (only-in "../util/loop-result.rkt" make-loop-result loop-result-messages)
-         (only-in "../util/message/message.rkt" message? message-id message-role message-content make-message)
+         (only-in "../util/message/message.rkt"
+                  message?
+                  message-id
+                  message-role
+                  message-content
+                  make-message)
          (only-in "../util/tool/tool-types.rkt" tool-call-name tool-call-arguments)
          (only-in "../util/content/content-parts.rkt" text-part-text tool-result-part-is-error?)
          (only-in "../util/event/event.rkt" event-payload)
@@ -229,34 +234,15 @@
                                         #:working-set-messages ws-messages)]))
   (values (tiered-context->message-list tc) hook-result tc))
 
-;; Build assembled context using tiered context assembly with hooks.
-;; Returns the assembled message list.
-(define (build-assembled-context ctx-to-use
-                                 config-raw
-                                 ext-reg
-                                 bus
-                                 session-id
-                                 iteration
-                                 #:session [session #f])
-  ;; WP-37 + R2-6: Context Assembly with Tier A/B/C separation and Hook support
-  (define config config-raw)
-  (define ws (config-working-set config))
-
-  ;; R2-6: Create hook dispatcher function for context assembly
-  (define ctx-assembly-hook-dispatcher
-    (and ext-reg
-         (lambda (hook-point payload)
-           (define result (dispatch-hooks hook-point payload ext-reg))
-           result)))
-
-  ;; v0.75.6: Extract task state from session for state-aware assembly
+;; Prepare task state, conclusions (with auto-distill), and WS evolution
+;; for context assembly. Mutates session state when auto-distill adds conclusions
+;; or WS evolution produces a new working set.
+(define (prepare-turn-context-state ctx-to-use config-raw session)
+  (define ws-early (config-working-set config-raw))
   (define task-state-raw (and session (agent-session-task-fsm-state session)))
   (define task-state (or (symbol->task-state task-state-raw) task-state-raw))
-  ;; task-state-raw: raw symbol ('idle, 'exploration, etc.) — for auto-distill, eq? checks
-  ;; task-state: fsm-state? struct (or raw symbol if unknown) — for ws-evolution, state-aware-builder
   (define conclusions (and session (agent-session-task-conclusions session)))
   ;; v0.77.9 T2.1: Auto-distill uncovered WS entries when enabled
-  (define ws-early (config-working-set config-raw))
   (define augmented-conclusions
     (if (and (current-auto-distillation-enabled?) session conclusions task-state ws-early)
         (let ([ws-msgs (working-set-resolve-messages ws-early ctx-to-use message-id)])
@@ -270,7 +256,6 @@
                   (auto-distill (map message-id ws-msgs) conclusions task-state-raw summaries)))
         (or conclusions '())))
   ;; v0.78.2 G3: Persist auto-distilled conclusions back to session
-  ;; Only when auto-distill added new conclusions
   (when (and (current-auto-distillation-enabled?)
              session
              (pair? augmented-conclusions)
@@ -278,48 +263,29 @@
              (> (length augmented-conclusions) (length conclusions)))
     (guarded-set-task-conclusions! session augmented-conclusions))
   ;; v0.78.2 G2: WS evolution — evolve working set on state transition
-  ;; Only when WS evolution enabled and session has a working set
   (when (and (current-ws-evolution-enabled?)
              ws-early
              session
              task-state
              (not (eq? task-state-raw 'idle)))
-    ;; v0.78.6 C1+W1: Use /result variant (returns evolution-result? struct)
-    ;; v0.79.2 GAP-2: Pass tracked old-state instead of #f.
     (define old-state (current-last-task-fsm-state))
     (define result
       (evolve-working-set-for-state/result ws-early old-state task-state augmented-conclusions))
-    ;; Update tracked state for next turn
     (current-last-task-fsm-state task-state)
     (when (and (evolution-result? result) session)
       (guarded-set-working-set-evolved! session result)))
-  ;; FD-05: Delegate pure assembly to assemble-context/pure
-  ;; v0.76.3: Pass per-session rollout flag
-  ;; v0.77.9 T2.4: Apply context-assembly profile before assembly
-  (define profile (config-context-assembly-profile config-raw))
-  (unless (eq? profile 'off)
-    (apply-context-assembly-profile! profile))
-  (define-values (ctx-assembled assembly-hook-result tc-struct)
-    (assemble-context/pure ctx-to-use
-                           config-raw
-                           #:hook-dispatcher ctx-assembly-hook-dispatcher
-                           #:task-state task-state
-                           #:conclusions augmented-conclusions
-                           #:state-aware? (config-task-state-aware? config)
-                           #:recent-tool-calls (if session
-                                                   (agent-session-recent-tool-calls session)
-                                                   '())))
+  (values task-state-raw task-state augmented-conclusions))
 
-  ;; Handle block action from context-assembly hook
-  (when (and assembly-hook-result (eq? (hook-result-action assembly-hook-result) 'block))
-    (current-turn-fsm-state turn-state-blocked)
-    (emit-typed-event! bus
-                       (make-context-blocked-event #:session-id session-id
-                                                   #:turn-id ""
-                                                   #:timestamp (current-inexact-milliseconds)
-                                                   #:reason "extension-block"))
-    (raise-extension-error "Context assembly blocked by extension" "unknown" "turn.started"))
-
+;; Emit telemetry events for context assembly results.
+;; Fires: working-set.injected, context.assembled, context-assembly-detail.
+(define (emit-context-assembly-events! bus
+                                       session-id
+                                       iteration
+                                       ctx-to-use
+                                       ctx-assembled
+                                       tc-struct
+                                       ws
+                                       config-raw)
   ;; v0.26.0: Emit working-set.injected event
   (when ws
     (emit-typed-event! bus
@@ -328,9 +294,7 @@
                                                         #:timestamp (current-inexact-milliseconds)
                                                         #:entries (working-set-entry-count ws)
                                                         #:tokens (working-set-token-count ws))))
-
-  ;; Emit context.assembled event (v0.19.12 W1: added tokenCount)
-  ;; v0.29.5 W3: Defer token estimation — only computed when forced for event
+  ;; Emit context.assembled event
   (define ctx-token-count-promise
     (delay
       (estimate-context-tokens ctx-assembled)))
@@ -349,14 +313,11 @@
                       #:working-set-tokens (if ws
                                                (working-set-token-count ws)
                                                0)))
-
-  ;; v0.45.5 (OBS-01/02/03): Emit detailed assembly metrics
-  ;; v0.45.7 (NF3): Replaced stubs with real computed values
+  ;; v0.45.5: Emit detailed assembly metrics
   (define tier-a-len (length (tiered-context-tier-a tc-struct)))
   (define tier-b-len (length (tiered-context-tier-b tc-struct)))
   (define tier-c-len (length (tiered-context-tier-c tc-struct)))
   (define assembled-total (+ tier-a-len tier-b-len tier-c-len))
-  ;; Compute excluded IDs from messages not in assembled output
   (define assembled-ids
     (for/set ([m (in-list ctx-assembled)])
       (message-id m)))
@@ -365,12 +326,10 @@
                #:unless (set-member? assembled-ids (message-id m)))
       (message-id m)))
   (define excluded-ids-str (string-join excluded-id-list ","))
-  ;; Compute summary length from compaction-summary messages
   (define summary-len
     (for/sum ([m (in-list ctx-assembled)] #:when (eq? (message-kind m) 'compaction-summary))
              (for/sum ([p (in-list (message-content m))] #:when (text-part? p))
                       (string-length (text-part-text p)))))
-  ;; Count GSD-pinned messages (using gsd-progress-message? predicate)
   (define gsd-pinned (for/sum ([m (in-list ctx-assembled)] #:when (gsd-progress-message? m)) 1))
   (emit-typed-event! bus
                      (make-context-assembly-detail-event
@@ -391,12 +350,61 @@
                       #:ws-tokens (if ws
                                       (working-set-token-count ws)
                                       0)
-                      #:cache-hit-p #f) ;; TODO: future — track context cache hits from provider
-                     )
+                      #:cache-hit-p #f)))
 
-  ;; Dispatch 'context hook — extensions can amend final context
+;; Build assembled context using tiered context assembly with hooks.
+;; Returns the assembled message list.
+(define (build-assembled-context ctx-to-use
+                                 config-raw
+                                 ext-reg
+                                 bus
+                                 session-id
+                                 iteration
+                                 #:session [session #f])
+  (define config config-raw)
+  (define ws (config-working-set config))
+  (define ctx-assembly-hook-dispatcher
+    (and ext-reg
+         (lambda (hook-point payload)
+           (define result (dispatch-hooks hook-point payload ext-reg))
+           result)))
+  ;; Phase 1: Prepare task state and conclusions
+  (define-values (task-state-raw task-state augmented-conclusions)
+    (prepare-turn-context-state ctx-to-use config-raw session))
+  ;; Phase 2: Apply profile and run pure assembly
+  (define profile (config-context-assembly-profile config-raw))
+  (unless (eq? profile 'off)
+    (apply-context-assembly-profile! profile))
+  (define-values (ctx-assembled assembly-hook-result tc-struct)
+    (assemble-context/pure ctx-to-use
+                           config-raw
+                           #:hook-dispatcher ctx-assembly-hook-dispatcher
+                           #:task-state task-state
+                           #:conclusions augmented-conclusions
+                           #:state-aware? (config-task-state-aware? config)
+                           #:recent-tool-calls (if session
+                                                   (agent-session-recent-tool-calls session)
+                                                   '())))
+  ;; Handle block action from context-assembly hook
+  (when (and assembly-hook-result (eq? (hook-result-action assembly-hook-result) 'block))
+    (current-turn-fsm-state turn-state-blocked)
+    (emit-typed-event! bus
+                       (make-context-blocked-event #:session-id session-id
+                                                   #:turn-id ""
+                                                   #:timestamp (current-inexact-milliseconds)
+                                                   #:reason "extension-block"))
+    (raise-extension-error "Context assembly blocked by extension" "unknown" "turn.started"))
+  ;; Phase 3: Emit telemetry events
+  (emit-context-assembly-events! bus
+                                 session-id
+                                 iteration
+                                 ctx-to-use
+                                 ctx-assembled
+                                 tc-struct
+                                 ws
+                                 config-raw)
+  ;; Phase 4: Final context hook dispatch
   (define-values (ctx-final _ctx-hook) (maybe-dispatch-hooks ext-reg 'context ctx-assembled))
-
   ctx-final)
 
 ;; ============================================================

--- a/tests/test-turn-context-assembly.rkt
+++ b/tests/test-turn-context-assembly.rkt
@@ -8,8 +8,7 @@
          racket/file
          racket/string)
 
-(define turn-orch-path
-  (build-path (current-directory) ".." "runtime" "turn-orchestrator.rkt"))
+(define turn-orch-path (build-path (current-directory) ".." "runtime" "turn-orchestrator.rkt"))
 
 ;; ---------------------------------------------------------------------------
 ;; Source structure metrics (W0 baseline)
@@ -20,14 +19,13 @@
 
 (test-case "W0 baseline: turn-orchestrator.rkt has ~534 LOC"
   (define lines (file->lines turn-orch-path))
-  (check-true (>= (length lines) 500)
-              (format "Expected >= 500 LOC, got ~a" (length lines))))
+  (check-true (>= (length lines) 500) (format "Expected >= 500 LOC, got ~a" (length lines))))
 
 (test-case "W0 baseline: turn-orchestrator.rkt has ~42 import lines"
   (define src (file->string turn-orch-path))
-  (define import-lines (filter (lambda (l) (or (string-contains? l "only-in")
-                                                (string-contains? l "require")))
-                               (string-split src "\n")))
+  (define import-lines
+    (filter (lambda (l) (or (string-contains? l "only-in") (string-contains? l "require")))
+            (string-split src "\n")))
   (check-true (>= (length import-lines) 35)
               (format "Expected >= 35 import lines, got ~a" (length import-lines))))
 
@@ -43,8 +41,7 @@
 
 (test-case "W0 baseline: turn-orchestrator.rkt contains symbol->task-state"
   (define src (file->string turn-orch-path))
-  (check-true (string-contains? src "(define (symbol->task-state")
-              "symbol->task-state should exist"))
+  (check-true (string-contains? src "(define (symbol->task-state") "symbol->task-state should exist"))
 
 (test-case "W0 baseline: turn-orchestrator.rkt contains register-session-extensions!"
   (define src (file->string turn-orch-path))
@@ -53,8 +50,7 @@
 
 (test-case "W0 baseline: turn-orchestrator.rkt contains run-provider-turn"
   (define src (file->string turn-orch-path))
-  (check-true (string-contains? src "(define (run-provider-turn")
-              "run-provider-turn should exist"))
+  (check-true (string-contains? src "(define (run-provider-turn") "run-provider-turn should exist"))
 
 (test-case "W0 baseline: build-assembled-context is ~160-180 LOC"
   (define src (file->string turn-orch-path))
@@ -69,16 +65,18 @@
                 #:when (regexp-match? #rx"^\\(define \\(" (list-ref lines i)))
       i))
   (define fn-len (- next-define-idx start-idx))
-  (check-true (>= fn-len 150)
-              (format "Expected build-assembled-context >= 150 LOC, got ~a" fn-len)))
+  (check-true (and (>= fn-len 30) (<= fn-len 80))
+              (format "Expected build-assembled-context 30-80 LOC (post-W1), got ~a" fn-len)))
 
 (test-case "W0 baseline: turn-orchestrator provides 5 functions"
   (define src (file->string turn-orch-path))
   (check-true (string-contains? src "run-provider-turn") "provides run-provider-turn")
   (check-true (string-contains? src "build-assembled-context") "provides build-assembled-context")
-  (check-true (string-contains? src "register-session-extensions!") "provides register-session-extensions!")
+  (check-true (string-contains? src "register-session-extensions!")
+              "provides register-session-extensions!")
   (check-true (string-contains? src "assemble-context/pure") "provides assemble-context/pure")
-  (check-true (string-contains? src "current-last-task-fsm-state") "provides current-last-task-fsm-state"))
+  (check-true (string-contains? src "current-last-task-fsm-state")
+              "provides current-last-task-fsm-state"))
 
 ;; ---------------------------------------------------------------------------
 ;; turn-context.rkt does NOT exist yet (W2 will create it)
@@ -86,7 +84,28 @@
 
 (test-case "W0 baseline: context-assembly/turn-context.rkt does not exist yet"
   (define path (build-path (current-directory) ".." "runtime" "context-assembly" "turn-context.rkt"))
-  (check-false (file-exists? path)
-               "turn-context.rkt should not exist yet"))
+  (check-false (file-exists? path) "turn-context.rkt should not exist yet"))
 
-;; W1–W3 will add behavioral tests after extraction
+;; ---------------------------------------------------------------------------
+;; W1: Verify extracted helpers exist
+;; ---------------------------------------------------------------------------
+
+(test-case "W1: turn-orchestrator.rkt contains prepare-turn-context-state"
+  (define src (file->string turn-orch-path))
+  (check-true (string-contains? src "(define (prepare-turn-context-state")
+              "prepare-turn-context-state should exist after W1 extraction"))
+
+(test-case "W1: turn-orchestrator.rkt contains emit-context-assembly-events!"
+  (define src (file->string turn-orch-path))
+  (check-true (string-contains? src "(define (emit-context-assembly-events!")
+              "emit-context-assembly-events! should exist after W1 extraction"))
+
+(test-case "W1: build-assembled-context calls prepare-turn-context-state"
+  (define src (file->string turn-orch-path))
+  (check-true (string-contains? src "(prepare-turn-context-state ctx-to-use config-raw session)")
+              "build-assembled-context should delegate to prepare-turn-context-state"))
+
+(test-case "W1: build-assembled-context calls emit-context-assembly-events!"
+  (define src (file->string turn-orch-path))
+  (check-true (string-contains? src "(emit-context-assembly-events!")
+              "build-assembled-context should delegate to emit-context-assembly-events!"))


### PR DESCRIPTION
Closes #7357, #7358, #7359, #7360, #7361

## W1 — Extract build-assembled-context phases

- Extract `prepare-turn-context-state` (~40 LOC): task state, auto-distill, WS evolution
- Extract `emit-context-assembly-events!` (~55 LOC): ws.injected, context.assembled, context-assembly-detail events
- `build-assembled-context` reduced from ~169 LOC to ~42 LOC coordinator
- 15 characterization tests green, 53 context-assembly tests green