### PR TITLE
refactor: W2 extract context assembly to turn-context.rkt (#7362)

### DIFF
--- a/runtime/context-assembly/turn-context.rkt
+++ b/runtime/context-assembly/turn-context.rkt
@@ -1,0 +1,279 @@
+#lang racket/base
+
+;; runtime/context-assembly/turn-context.rkt — Turn-level context assembly helpers
+;; STABILITY: internal
+;;
+;; Extracted from turn-orchestrator.rkt (v0.96.0 W2) for single-responsibility.
+;; Contains: symbol->task-state, assemble-context/pure,
+;;           prepare-turn-context-state, emit-context-assembly-events!,
+;;           current-last-task-fsm-state parameter.
+
+(require racket/list
+         racket/promise
+         racket/set
+         (only-in racket/string string-join)
+         ;; Message/content types
+         (only-in "../../util/message/message.rkt"
+                  message-id message-kind message-content)
+         (only-in "../../util/content/content-parts.rkt" text-part? text-part-text)
+         ;; Event emission
+         "../../agent/event-emitter.rkt"
+         "../../agent/event-structs/iteration-events.rkt"
+         "../../agent/event-structs/session-events.rkt"
+         ;; Context assembly core
+         (only-in "../context/context-assembly.rkt"
+                  build-tiered-context-with-hooks
+                  tiered-context->message-list
+                  tiered-context?
+                  tiered-context-tier-a
+                  tiered-context-tier-b
+                  tiered-context-tier-c)
+         (only-in "../context-assembly/serialization.rkt"
+                  gsd-progress-message?
+                  build-tiered-context/state-aware
+                  current-task-state-aware-assembly?)
+         ;; Working set
+         (only-in "../working-set.rkt"
+                  working-set-resolve-messages
+                  working-set-entry-count
+                  working-set-token-count)
+         ;; Session config accessors
+         (only-in "../session/session-config.rkt"
+                  config-tier-b-count
+                  config-tier-c-count
+                  config-max-tokens
+                  config-working-set
+                  config-task-state-aware?
+                  config-context-assembly-profile
+                  apply-context-assembly-profile!)
+         ;; Session state accessors (read-only)
+         (only-in "../session/session-types.rkt"
+                  agent-session-task-fsm-state
+                  agent-session-task-conclusions
+                  agent-session-recent-tool-calls)
+         ;; Session mutation (for auto-distill persistence)
+         (only-in "../session/session-mutation.rkt"
+                  guarded-set-working-set-evolved!
+                  guarded-set-task-conclusions!)
+         ;; Hook types
+         (only-in "../../util/hook-types.rkt" hook-result? hook-result-action)
+         ;; Token estimation
+         (only-in "../../llm/token-budget.rkt" estimate-context-tokens)
+         ;; WS evolution
+         (only-in "../context-assembly/ws-evolution.rkt"
+                  evolve-working-set-for-state/result
+                  evolution-result?)
+         (only-in "../context-assembly/state-aware-builder.rkt" current-ws-evolution-enabled?)
+         ;; Auto-distillation
+         (only-in "../context-assembly/auto-distillation.rkt"
+                  auto-distill
+                  current-auto-distillation-enabled?)
+         ;; Task-state singletons
+         (only-in "../context-assembly/task-state.rkt"
+                  task-idle
+                  task-exploration
+                  task-planning
+                  task-implementation
+                  task-verification
+                  task-debugging))
+
+(provide current-last-task-fsm-state
+         symbol->task-state
+         assemble-context/pure
+         prepare-turn-context-state
+         emit-context-assembly-events!)
+
+;; ============================================================
+;; Task state conversion
+;; ============================================================
+
+;; v0.79.2 GAP-2: Track last task FSM state for WS evolution old-state.
+;; Set each turn from agent-session-task-fsm-state before it gets updated.
+(define current-last-task-fsm-state (make-parameter #f))
+
+;; Convert a raw state symbol to the canonical fsm-state? struct.
+;; The runtime stores task-fsm-state as raw symbols, but downstream consumers
+;; (ws-evolution, state-aware-builder) expect fsm-state? structs.
+(define (symbol->task-state sym)
+  (case sym
+    [(idle) task-idle]
+    [(exploration) task-exploration]
+    [(planning) task-planning]
+    [(implementation) task-implementation]
+    [(verification) task-verification]
+    [(debugging) task-debugging]
+    [else #f]))
+
+;; ============================================================
+;; Pure context assembly
+;; ============================================================
+
+;; Pure context assembly: no side effects, no session mutation.
+;; Returns (values assembled-messages hook-result tiered-context).
+(define (assemble-context/pure ctx-to-use
+                               config-raw
+                               #:hook-dispatcher [hook-dispatcher #f]
+                               #:task-state [task-state #f]
+                               #:conclusions [conclusions '()]
+                               #:state-aware? [state-aware? #f]
+                               #:recent-tool-calls [recent-tool-calls '()])
+  (define config config-raw)
+  (define tier-b-count (config-tier-b-count config))
+  (define tier-c-count (config-tier-c-count config))
+  (define max-tokens (config-max-tokens config))
+  (define ws (config-working-set config))
+  (define ws-messages-promise
+    (delay
+      (if ws
+          (working-set-resolve-messages ws ctx-to-use message-id)
+          '())))
+  (define ws-messages (force ws-messages-promise))
+  (define-values (tc hook-result)
+    (cond
+      ;; v0.76.3: State-aware assembly when enabled (global flag or per-session rollout)
+      [(and (or state-aware? (current-task-state-aware-assembly?)) task-state)
+       (define sa-tc
+         (build-tiered-context/state-aware ctx-to-use
+                                           #:tier-b-count tier-b-count
+                                           #:tier-c-count tier-c-count
+                                           #:working-set-messages ws-messages
+                                           #:task-state task-state
+                                           #:conclusions conclusions
+                                           #:recent-tool-calls recent-tool-calls
+                                           #:session-config config))
+       (values sa-tc #f)]
+      ;; Standard assembly path
+      [else
+       (build-tiered-context-with-hooks ctx-to-use
+                                        #:hook-dispatcher hook-dispatcher
+                                        #:tier-b-count tier-b-count
+                                        #:tier-c-count tier-c-count
+                                        #:max-tokens max-tokens
+                                        #:working-set-messages ws-messages)]))
+  (values (tiered-context->message-list tc) hook-result tc))
+
+;; ============================================================
+;; Turn context state preparation
+;; ============================================================
+
+;; Prepare task state, conclusions (with auto-distill), and WS evolution
+;; for context assembly. Mutates session state when auto-distill adds conclusions
+;; or WS evolution produces a new working set.
+(define (prepare-turn-context-state ctx-to-use config-raw session)
+  (define ws-early (config-working-set config-raw))
+  (define task-state-raw (and session (agent-session-task-fsm-state session)))
+  (define task-state (or (symbol->task-state task-state-raw) task-state-raw))
+  (define conclusions (and session (agent-session-task-conclusions session)))
+  ;; v0.77.9 T2.1: Auto-distill uncovered WS entries when enabled
+  (define augmented-conclusions
+    (if (and (current-auto-distillation-enabled?) session conclusions task-state ws-early)
+        (let ([ws-msgs (working-set-resolve-messages ws-early ctx-to-use message-id)])
+          ;; v0.79.2 GAP-3: Build content summaries for richer auto-distill text
+          (define summaries
+            (for/hash ([m (in-list ws-msgs)])
+              (define text-parts (filter text-part? (message-content m)))
+              (define full-text (string-join (map text-part-text text-parts) " "))
+              (values (message-id m) full-text)))
+          (append conclusions
+                  (auto-distill (map message-id ws-msgs) conclusions task-state-raw summaries)))
+        (or conclusions '())))
+  ;; v0.78.2 G3: Persist auto-distilled conclusions back to session
+  (when (and (current-auto-distillation-enabled?)
+             session
+             (pair? augmented-conclusions)
+             conclusions
+             (> (length augmented-conclusions) (length conclusions)))
+    (guarded-set-task-conclusions! session augmented-conclusions))
+  ;; v0.78.2 G2: WS evolution — evolve working set on state transition
+  (when (and (current-ws-evolution-enabled?)
+             ws-early
+             session
+             task-state
+             (not (eq? task-state-raw 'idle)))
+    (define old-state (current-last-task-fsm-state))
+    (define result
+      (evolve-working-set-for-state/result ws-early old-state task-state augmented-conclusions))
+    (current-last-task-fsm-state task-state)
+    (when (and (evolution-result? result) session)
+      (guarded-set-working-set-evolved! session result)))
+  (values task-state-raw task-state augmented-conclusions))
+
+;; ============================================================
+;; Context assembly telemetry
+;; ============================================================
+
+;; Emit telemetry events for context assembly results.
+;; Fires: working-set.injected, context.assembled, context-assembly-detail.
+(define (emit-context-assembly-events! bus
+                                       session-id
+                                       iteration
+                                       ctx-to-use
+                                       ctx-assembled
+                                       tc-struct
+                                       ws
+                                       config-raw)
+  ;; v0.26.0: Emit working-set.injected event
+  (when ws
+    (emit-typed-event! bus
+                       (make-working-set-injected-event #:session-id session-id
+                                                        #:turn-id ""
+                                                        #:timestamp (current-inexact-milliseconds)
+                                                        #:entries (working-set-entry-count ws)
+                                                        #:tokens (working-set-token-count ws))))
+  ;; Emit context.assembled event
+  (define ctx-token-count-promise
+    (delay
+      (estimate-context-tokens ctx-assembled)))
+  (emit-typed-event! bus
+                     (make-context-assembled-event
+                      #:session-id session-id
+                      #:turn-id ""
+                      #:timestamp (current-inexact-milliseconds)
+                      #:iteration iteration
+                      #:total-messages (length ctx-to-use)
+                      #:assembled-messages (length ctx-assembled)
+                      #:token-count (force ctx-token-count-promise)
+                      #:working-set-entries (if ws
+                                                (working-set-entry-count ws)
+                                                0)
+                      #:working-set-tokens (if ws
+                                               (working-set-token-count ws)
+                                               0)))
+  ;; v0.45.5: Emit detailed assembly metrics
+  (define tier-a-len (length (tiered-context-tier-a tc-struct)))
+  (define tier-b-len (length (tiered-context-tier-b tc-struct)))
+  (define tier-c-len (length (tiered-context-tier-c tc-struct)))
+  (define assembled-total (+ tier-a-len tier-b-len tier-c-len))
+  (define assembled-ids
+    (for/set ([m (in-list ctx-assembled)])
+      (message-id m)))
+  (define excluded-id-list
+    (for/list ([m (in-list ctx-to-use)]
+               #:unless (set-member? assembled-ids (message-id m)))
+      (message-id m)))
+  (define excluded-ids-str (string-join excluded-id-list ","))
+  (define summary-len
+    (for/sum ([m (in-list ctx-assembled)] #:when (eq? (message-kind m) 'compaction-summary))
+             (for/sum ([p (in-list (message-content m))] #:when (text-part? p))
+                      (string-length (text-part-text p)))))
+  (define gsd-pinned (for/sum ([m (in-list ctx-assembled)] #:when (gsd-progress-message? m)) 1))
+  (emit-typed-event! bus
+                     (make-context-assembly-detail-event
+                      #:session-id session-id
+                      #:turn-id ""
+                      #:timestamp (current-inexact-milliseconds)
+                      #:total-messages (length ctx-to-use)
+                      #:tier-a-count tier-a-len
+                      #:tier-b-count tier-b-len
+                      #:tier-c-count tier-c-len
+                      #:excluded-count (- (length ctx-to-use) assembled-total)
+                      #:excluded-ids excluded-ids-str
+                      #:summary-length summary-len
+                      #:gsd-pinned-count gsd-pinned
+                      #:ws-entry-count (if ws
+                                           (working-set-entry-count ws)
+                                           0)
+                      #:ws-tokens (if ws
+                                      (working-set-token-count ws)
+                                      0)
+                      #:cache-hit-p #f)))

--- a/runtime/turn-orchestrator.rkt
+++ b/runtime/turn-orchestrator.rkt
@@ -128,14 +128,13 @@
          (only-in "session/session-config.rkt"
                   config-context-assembly-profile
                   apply-context-assembly-profile!)
-         ;; Task-state singletons for symbol->task-state conversion
-         (only-in "../runtime/context-assembly/task-state.rkt"
-                  task-idle
-                  task-exploration
-                  task-planning
-                  task-implementation
-                  task-verification
-                  task-debugging))
+         ;; Turn-context: extracted context assembly helpers
+         (only-in "context-assembly/turn-context.rkt"
+                  current-last-task-fsm-state
+                  symbol->task-state
+                  assemble-context/pure
+                  prepare-turn-context-state
+                  emit-context-assembly-events!))
 
 (provide (contract-out
           [run-provider-turn
@@ -168,189 +167,9 @@
          current-last-task-fsm-state)
 
 ;; ============================================================
-;; Context assembly
 ;; ============================================================
-
-;; v0.79.2 GAP-2: Track last task FSM state for WS evolution old-state.
-;; Set each turn from agent-session-task-fsm-state before it gets updated.
-(define current-last-task-fsm-state (make-parameter #f))
-
-;; Convert a raw state symbol to the canonical fsm-state? struct.
-;; The runtime stores task-fsm-state as raw symbols, but downstream consumers
-;; (ws-evolution, state-aware-builder) expect fsm-state? structs.
-;; Returns #f if symbol is not a known task state.
-(define (symbol->task-state sym)
-  (and (symbol? sym)
-       (case sym
-         [(idle) task-idle]
-         [(exploration) task-exploration]
-         [(planning) task-planning]
-         [(implementation) task-implementation]
-         [(verification) task-verification]
-         [(debugging) task-debugging]
-         [else #f])))
-
-;; Pure: assemble context from messages and config without side effects.
-;; Returns the assembled message list and hook result (no events emitted here).
-(define (assemble-context/pure ctx-to-use
-                               config-raw
-                               #:hook-dispatcher [hook-dispatcher #f]
-                               #:task-state [task-state #f]
-                               #:conclusions [conclusions '()]
-                               #:state-aware? [state-aware? #f]
-                               #:recent-tool-calls [recent-tool-calls '()])
-  (define config config-raw)
-  (define tier-b-count (config-tier-b-count config))
-  (define tier-c-count (config-tier-c-count config))
-  (define max-tokens (config-max-tokens config))
-  (define ws (config-working-set config))
-  (define ws-messages-promise
-    (delay
-      (if ws
-          (working-set-resolve-messages ws ctx-to-use message-id)
-          '())))
-  (define ws-messages (force ws-messages-promise))
-  (define-values (tc hook-result)
-    (cond
-      ;; v0.76.3: State-aware assembly when enabled (global flag or per-session rollout)
-      [(and (or state-aware? (current-task-state-aware-assembly?)) task-state)
-       (define sa-tc
-         (build-tiered-context/state-aware ctx-to-use
-                                           #:tier-b-count tier-b-count
-                                           #:tier-c-count tier-c-count
-                                           #:working-set-messages ws-messages
-                                           #:task-state task-state
-                                           #:conclusions conclusions
-                                           #:recent-tool-calls recent-tool-calls
-                                           #:session-config config))
-       (values sa-tc #f)]
-      ;; Standard assembly path
-      [else
-       (build-tiered-context-with-hooks ctx-to-use
-                                        #:hook-dispatcher hook-dispatcher
-                                        #:tier-b-count tier-b-count
-                                        #:tier-c-count tier-c-count
-                                        #:max-tokens max-tokens
-                                        #:working-set-messages ws-messages)]))
-  (values (tiered-context->message-list tc) hook-result tc))
-
-;; Prepare task state, conclusions (with auto-distill), and WS evolution
-;; for context assembly. Mutates session state when auto-distill adds conclusions
-;; or WS evolution produces a new working set.
-(define (prepare-turn-context-state ctx-to-use config-raw session)
-  (define ws-early (config-working-set config-raw))
-  (define task-state-raw (and session (agent-session-task-fsm-state session)))
-  (define task-state (or (symbol->task-state task-state-raw) task-state-raw))
-  (define conclusions (and session (agent-session-task-conclusions session)))
-  ;; v0.77.9 T2.1: Auto-distill uncovered WS entries when enabled
-  (define augmented-conclusions
-    (if (and (current-auto-distillation-enabled?) session conclusions task-state ws-early)
-        (let ([ws-msgs (working-set-resolve-messages ws-early ctx-to-use message-id)])
-          ;; v0.79.2 GAP-3: Build content summaries for richer auto-distill text
-          (define summaries
-            (for/hash ([m (in-list ws-msgs)])
-              (define text-parts (filter text-part? (message-content m)))
-              (define full-text (string-join (map text-part-text text-parts) " "))
-              (values (message-id m) full-text)))
-          (append conclusions
-                  (auto-distill (map message-id ws-msgs) conclusions task-state-raw summaries)))
-        (or conclusions '())))
-  ;; v0.78.2 G3: Persist auto-distilled conclusions back to session
-  (when (and (current-auto-distillation-enabled?)
-             session
-             (pair? augmented-conclusions)
-             conclusions
-             (> (length augmented-conclusions) (length conclusions)))
-    (guarded-set-task-conclusions! session augmented-conclusions))
-  ;; v0.78.2 G2: WS evolution — evolve working set on state transition
-  (when (and (current-ws-evolution-enabled?)
-             ws-early
-             session
-             task-state
-             (not (eq? task-state-raw 'idle)))
-    (define old-state (current-last-task-fsm-state))
-    (define result
-      (evolve-working-set-for-state/result ws-early old-state task-state augmented-conclusions))
-    (current-last-task-fsm-state task-state)
-    (when (and (evolution-result? result) session)
-      (guarded-set-working-set-evolved! session result)))
-  (values task-state-raw task-state augmented-conclusions))
-
-;; Emit telemetry events for context assembly results.
-;; Fires: working-set.injected, context.assembled, context-assembly-detail.
-(define (emit-context-assembly-events! bus
-                                       session-id
-                                       iteration
-                                       ctx-to-use
-                                       ctx-assembled
-                                       tc-struct
-                                       ws
-                                       config-raw)
-  ;; v0.26.0: Emit working-set.injected event
-  (when ws
-    (emit-typed-event! bus
-                       (make-working-set-injected-event #:session-id session-id
-                                                        #:turn-id ""
-                                                        #:timestamp (current-inexact-milliseconds)
-                                                        #:entries (working-set-entry-count ws)
-                                                        #:tokens (working-set-token-count ws))))
-  ;; Emit context.assembled event
-  (define ctx-token-count-promise
-    (delay
-      (estimate-context-tokens ctx-assembled)))
-  (emit-typed-event! bus
-                     (make-context-assembled-event
-                      #:session-id session-id
-                      #:turn-id ""
-                      #:timestamp (current-inexact-milliseconds)
-                      #:iteration iteration
-                      #:total-messages (length ctx-to-use)
-                      #:assembled-messages (length ctx-assembled)
-                      #:token-count (force ctx-token-count-promise)
-                      #:working-set-entries (if ws
-                                                (working-set-entry-count ws)
-                                                0)
-                      #:working-set-tokens (if ws
-                                               (working-set-token-count ws)
-                                               0)))
-  ;; v0.45.5: Emit detailed assembly metrics
-  (define tier-a-len (length (tiered-context-tier-a tc-struct)))
-  (define tier-b-len (length (tiered-context-tier-b tc-struct)))
-  (define tier-c-len (length (tiered-context-tier-c tc-struct)))
-  (define assembled-total (+ tier-a-len tier-b-len tier-c-len))
-  (define assembled-ids
-    (for/set ([m (in-list ctx-assembled)])
-      (message-id m)))
-  (define excluded-id-list
-    (for/list ([m (in-list ctx-to-use)]
-               #:unless (set-member? assembled-ids (message-id m)))
-      (message-id m)))
-  (define excluded-ids-str (string-join excluded-id-list ","))
-  (define summary-len
-    (for/sum ([m (in-list ctx-assembled)] #:when (eq? (message-kind m) 'compaction-summary))
-             (for/sum ([p (in-list (message-content m))] #:when (text-part? p))
-                      (string-length (text-part-text p)))))
-  (define gsd-pinned (for/sum ([m (in-list ctx-assembled)] #:when (gsd-progress-message? m)) 1))
-  (emit-typed-event! bus
-                     (make-context-assembly-detail-event
-                      #:session-id session-id
-                      #:turn-id ""
-                      #:timestamp (current-inexact-milliseconds)
-                      #:total-messages (length ctx-to-use)
-                      #:tier-a-count tier-a-len
-                      #:tier-b-count tier-b-len
-                      #:tier-c-count tier-c-len
-                      #:excluded-count (- (length ctx-to-use) assembled-total)
-                      #:excluded-ids excluded-ids-str
-                      #:summary-length summary-len
-                      #:gsd-pinned-count gsd-pinned
-                      #:ws-entry-count (if ws
-                                           (working-set-entry-count ws)
-                                           0)
-                      #:ws-tokens (if ws
-                                      (working-set-token-count ws)
-                                      0)
-                      #:cache-hit-p #f)))
+;; Context assembly — helpers imported from turn-context.rkt
+;; ============================================================
 
 ;; Build assembled context using tiered context assembly with hooks.
 ;; Returns the assembled message list.

--- a/tests/test-turn-context-assembly.rkt
+++ b/tests/test-turn-context-assembly.rkt
@@ -1,58 +1,47 @@
 #lang racket/base
 ;; test-turn-context-assembly.rkt — Characterization tests for turn-orchestrator decomposition
 ;;
-;; v0.96.0 W0: Baseline characterization tests documenting current structure
-;; before extracting build-assembled-context phases into dedicated helpers.
+;; W0: Baseline metrics
+;; W1: Extract build-assembled-context phases into named helpers
+;; W2: Extract context assembly module to turn-context.rkt
 
 (require rackunit
          racket/file
          racket/string)
 
-(define turn-orch-path (build-path (current-directory) ".." "runtime" "turn-orchestrator.rkt"))
+(define turn-orch-path
+  (build-path (current-directory) ".." "runtime" "turn-orchestrator.rkt"))
+(define turn-context-path
+  (build-path (current-directory) ".." "runtime" "context-assembly" "turn-context.rkt"))
 
 ;; ---------------------------------------------------------------------------
-;; Source structure metrics (W0 baseline)
+;; turn-orchestrator.rkt structure (post-W2)
 ;; ---------------------------------------------------------------------------
 
-(test-case "W0 baseline: turn-orchestrator.rkt exists and is readable"
+(test-case "W2: turn-orchestrator.rkt exists and is readable"
   (check-true (file-exists? turn-orch-path)))
 
-(test-case "W0 baseline: turn-orchestrator.rkt has ~534 LOC"
+(test-case "W2: turn-orchestrator.rkt reduced to <=370 LOC"
   (define lines (file->lines turn-orch-path))
-  (check-true (>= (length lines) 500) (format "Expected >= 500 LOC, got ~a" (length lines))))
+  (check-true (<= (length lines) 370)
+              (format "Expected <= 370 LOC, got ~a" (length lines))))
 
-(test-case "W0 baseline: turn-orchestrator.rkt has ~42 import lines"
-  (define src (file->string turn-orch-path))
-  (define import-lines
-    (filter (lambda (l) (or (string-contains? l "only-in") (string-contains? l "require")))
-            (string-split src "\n")))
-  (check-true (>= (length import-lines) 35)
-              (format "Expected >= 35 import lines, got ~a" (length import-lines))))
-
-(test-case "W0 baseline: turn-orchestrator.rkt contains build-assembled-context"
+(test-case "W2: turn-orchestrator.rkt still contains build-assembled-context"
   (define src (file->string turn-orch-path))
   (check-true (string-contains? src "(define (build-assembled-context")
-              "build-assembled-context should exist"))
+              "build-assembled-context should still exist as coordinator"))
 
-(test-case "W0 baseline: turn-orchestrator.rkt contains assemble-context/pure"
-  (define src (file->string turn-orch-path))
-  (check-true (string-contains? src "(define (assemble-context/pure")
-              "assemble-context/pure should exist"))
-
-(test-case "W0 baseline: turn-orchestrator.rkt contains symbol->task-state"
-  (define src (file->string turn-orch-path))
-  (check-true (string-contains? src "(define (symbol->task-state") "symbol->task-state should exist"))
-
-(test-case "W0 baseline: turn-orchestrator.rkt contains register-session-extensions!"
+(test-case "W2: turn-orchestrator.rkt still contains register-session-extensions!"
   (define src (file->string turn-orch-path))
   (check-true (string-contains? src "(define (register-session-extensions!")
-              "register-session-extensions! should exist"))
+              "register-session-extensions! should still exist"))
 
-(test-case "W0 baseline: turn-orchestrator.rkt contains run-provider-turn"
+(test-case "W2: turn-orchestrator.rkt still contains run-provider-turn"
   (define src (file->string turn-orch-path))
-  (check-true (string-contains? src "(define (run-provider-turn") "run-provider-turn should exist"))
+  (check-true (string-contains? src "(define (run-provider-turn")
+              "run-provider-turn should still exist"))
 
-(test-case "W0 baseline: build-assembled-context is ~160-180 LOC"
+(test-case "W2: build-assembled-context is a slim coordinator (30-60 LOC)"
   (define src (file->string turn-orch-path))
   (define lines (string-split src "\n"))
   (define start-idx
@@ -65,47 +54,46 @@
                 #:when (regexp-match? #rx"^\\(define \\(" (list-ref lines i)))
       i))
   (define fn-len (- next-define-idx start-idx))
-  (check-true (and (>= fn-len 30) (<= fn-len 80))
-              (format "Expected build-assembled-context 30-80 LOC (post-W1), got ~a" fn-len)))
+  (check-true (and (>= fn-len 30) (<= fn-len 75))
+              (format "Expected build-assembled-context 30-75 LOC (post-W2), got ~a" fn-len)))
 
-(test-case "W0 baseline: turn-orchestrator provides 5 functions"
+(test-case "W2: turn-orchestrator.rkt imports from turn-context.rkt"
   (define src (file->string turn-orch-path))
-  (check-true (string-contains? src "run-provider-turn") "provides run-provider-turn")
-  (check-true (string-contains? src "build-assembled-context") "provides build-assembled-context")
-  (check-true (string-contains? src "register-session-extensions!")
-              "provides register-session-extensions!")
-  (check-true (string-contains? src "assemble-context/pure") "provides assemble-context/pure")
-  (check-true (string-contains? src "current-last-task-fsm-state")
-              "provides current-last-task-fsm-state"))
+  (check-true (string-contains? src "context-assembly/turn-context.rkt")
+              "should import from turn-context.rkt"))
+
+(test-case "W2: turn-orchestrator.rkt no longer defines symbol->task-state inline"
+  (define src (file->string turn-orch-path))
+  (check-false (string-contains? src "(define (symbol->task-state")
+               "symbol->task-state should be in turn-context.rkt now"))
+
+(test-case "W2: turn-orchestrator.rkt no longer defines assemble-context/pure inline"
+  (define src (file->string turn-orch-path))
+  (check-false (string-contains? src "(define (assemble-context/pure")
+               "assemble-context/pure should be in turn-context.rkt now"))
 
 ;; ---------------------------------------------------------------------------
-;; turn-context.rkt does NOT exist yet (W2 will create it)
+;; turn-context.rkt (new module, W2)
 ;; ---------------------------------------------------------------------------
 
-(test-case "W0 baseline: context-assembly/turn-context.rkt does not exist yet"
-  (define path (build-path (current-directory) ".." "runtime" "context-assembly" "turn-context.rkt"))
-  (check-false (file-exists? path) "turn-context.rkt should not exist yet"))
+(test-case "W2: context-assembly/turn-context.rkt exists"
+  (check-true (file-exists? turn-context-path)))
 
-;; ---------------------------------------------------------------------------
-;; W1: Verify extracted helpers exist
-;; ---------------------------------------------------------------------------
+(test-case "W2: turn-context.rkt provides all extracted helpers"
+  (define src (file->string turn-context-path))
+  (for ([name '("symbol->task-state"
+                "assemble-context/pure"
+                "prepare-turn-context-state"
+                "emit-context-assembly-events!"
+                "current-last-task-fsm-state")])
+    (check-true (string-contains? src name)
+                (format "turn-context.rkt should provide ~a" name))))
 
-(test-case "W1: turn-orchestrator.rkt contains prepare-turn-context-state"
-  (define src (file->string turn-orch-path))
-  (check-true (string-contains? src "(define (prepare-turn-context-state")
-              "prepare-turn-context-state should exist after W1 extraction"))
-
-(test-case "W1: turn-orchestrator.rkt contains emit-context-assembly-events!"
-  (define src (file->string turn-orch-path))
-  (check-true (string-contains? src "(define (emit-context-assembly-events!")
-              "emit-context-assembly-events! should exist after W1 extraction"))
-
-(test-case "W1: build-assembled-context calls prepare-turn-context-state"
-  (define src (file->string turn-orch-path))
-  (check-true (string-contains? src "(prepare-turn-context-state ctx-to-use config-raw session)")
-              "build-assembled-context should delegate to prepare-turn-context-state"))
-
-(test-case "W1: build-assembled-context calls emit-context-assembly-events!"
-  (define src (file->string turn-orch-path))
-  (check-true (string-contains? src "(emit-context-assembly-events!")
-              "build-assembled-context should delegate to emit-context-assembly-events!"))
+(test-case "W2: turn-context.rkt defines the extracted functions"
+  (define src (file->string turn-context-path))
+  (for ([name '("(define (symbol->task-state"
+                "(define (assemble-context/pure"
+                "(define (prepare-turn-context-state"
+                "(define (emit-context-assembly-events!")])
+    (check-true (string-contains? src name)
+                (format "turn-context.rkt should define ~a" name))))


### PR DESCRIPTION
Closes #7362, #7363, #7364

## W2 — Extract context assembly module (F1 part 1)

- New `runtime/context-assembly/turn-context.rkt` (279 LOC)
- Moved: `symbol->task-state`, `assemble-context/pure`, `prepare-turn-context-state`, `emit-context-assembly-events!`, `current-last-task-fsm-state`
- `turn-orchestrator.rkt`: 542→361 LOC (33% reduction)
- Re-exports preserved for backward compatibility
- 57 context-assembly tests green