### PR TITLE
release: v0.96.0 Turn Orchestrator Decomposition (#7369)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+## v0.96.0 — Turn Orchestrator Decomposition (2026-06-08)
+
+### Architecture
+- **F1 (God Module) — RESOLVED**: `turn-orchestrator.rkt` reduced from 534 LOC / 42 imports to **286 LOC / 24 imports** (47% LOC reduction, 43% import reduction).
+- **F5 (166-line Function) — RESOLVED**: `build-assembled-context` decomposed into 4 clear phases via named helpers.
+- Extracted `runtime/context-assembly/turn-context.rkt` (279 LOC): `symbol->task-state`, `assemble-context/pure`, `prepare-turn-context-state`, `emit-context-assembly-events!`, `current-last-task-fsm-state`.
+- Extracted `runtime/extension-setup.rkt` (51 LOC): `register-session-extensions!`.
+- 18 unused imports cleaned up from turn-orchestrator.rkt.
+
+### Metrics
+| Metric | Before (v0.95.21) | After (v0.96.0) | Change |
+|--------|-------------------|-----------------|--------|
+| turn-orchestrator.rkt LOC | 534 | 286 | -46% |
+| turn-orchestrator.rkt imports | 42 | 24 | -43% |
+| build-assembled-context LOC | ~169 | ~42 (coordinator) | -75% |
+| New modules | 0 | 2 | +2 |
+
 ## v0.95.21 — Memory Lifecycle Completion (2026-06-08)
 
 ### New Features

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.95.21")
+(define version "0.96.0")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base" "gui-easy-lib"))

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -11,4 +11,4 @@
 
 (provide (contract-out [q-version string?]))
 
-(define q-version "0.95.21")
+(define q-version "0.96.0")


### PR DESCRIPTION
Closes #7369, #7370, #7371, #7372

## v0.96.0 Release Gate

- Version bumped to 0.96.0
- CHANGELOG entry with metrics table
- All W0-W3 waves merged

### Summary
| Wave | PR | Issues | Description |
|------|-----|--------|-------------|
| W0 | #7373 | #7354-#7356 | Baseline characterization tests |
| W1 | #7374 | #7357-#7361 | Extract build-assembled-context helpers |
| W2 | #7375 | #7362-#7364 | Extract turn-context.rkt module |
| W3 | #7376 | #7365-#7368 | Extract extension-setup.rkt + import cleanup |
| W4 | This PR | #7369-#7372 | Version bump + CHANGELOG |