### PR TITLE
release: v0.96.1 Representation Hiding + Parameter Reduction (#7393)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## v0.96.1 — Representation Hiding + Parameter Reduction (2026-06-08)
+
+### Architecture
+- **F2 (Event struct-out over-exposure) — DOCUMENTED**: Classified 60 event types as PUBLIC (4) vs INTERNAL (56). PUBLIC events marked with stability commitment. Assessment: `struct-out` for `#:transparent` immutable structs is idiomatic Racket; explicit provides would be more verbose with no security benefit.
+- **F3 (Parameter proliferation) — RESOLVED**: Audited all 129 production parameters. Dead `circuit-breaker-state` removed. Already at ≤130 target. Classification: 42 function-arg candidates, 27 groupable, 36 keep-as-is.
+
+### Metrics
+| Metric | Before (v0.96.0) | After (v0.96.1) | Change |
+|--------|------------------|-----------------|--------|
+| Production parameters | 130 | 129 | -1 |
+| Event types classified | 0 | 60 | +60 |
+| Dead parameters | 1 | 0 | -1 |
+
 ## v0.96.0 — Turn Orchestrator Decomposition (2026-06-08)
 
 ### Architecture

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.96.0")
+(define version "0.96.1")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base" "gui-easy-lib"))

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -11,4 +11,4 @@
 
 (provide (contract-out [q-version string?]))
 
-(define q-version "0.96.0")
+(define q-version "0.96.1")


### PR DESCRIPTION
Closes #7393, #7394, #7395

## v0.96.1 Release

- Version bumped to 0.96.1
- CHANGELOG with metrics

### Summary
| Wave | PR | Issues | Description |
|------|-----|--------|-------------|
| W0 | N/A | #7378-#7380 | Event + parameter audit (read-only) |
| W1-W2 | #7396 | #7381-#7386 | Event API classification + documentation |
| W3-W4 | #7397 | #7387-#7392 | Parameter audit + dead code removal |
| W5 | This PR | #7393-#7395 | Version bump + CHANGELOG |