### PR TITLE
release: v0.96.2 Module Sizing + Low-Priority Cleanups (#7411)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,26 @@
+## v0.96.2 — Module Sizing + Low-Priority Cleanups (2026-06-08)
+
+### Architecture
+- **F4 (memory-tools god module) — RESOLVED**: Split 928-line `memory-tools.rkt` into 5 focused modules:
+  - `memory-tools-shared.rkt` (316 LOC) — shared helpers + event emitters
+  - `memory-tools-store.rkt` (213 LOC) — store/update handlers
+  - `memory-tools-query.rkt` (89 LOC) — search/list handlers
+  - `memory-tools-manage.rkt` (314 LOC) — delete/clear/consolidate/cleanup
+  - `memory-tools.rkt` (130 LOC) — thin registration facade (-86% LOC)
+- **F6 (stream-from-provider complexity) — DEFERRED**: Single 200-line function with deeply nested state. Extraction assessed as high-risk, low-reward. Existing tests provide safety net.
+- **F7 (wire-session-event-handlers complexity) — DEFERRED**: Similar assessment.
+- **F8 (build-runtime-from-cli) — BELOW THRESHOLD**: 166 LOC, under 200-line limit. No action needed.
+- **F10 (session config accessors) — ALREADY ADEQUATE**: 24 hash-ref accessors documented and consistent.
+- **F11 (format-iso-now duplicate) — DOCUMENTED**: Thin wrapper retained for compatibility.
+- **File headers**: Added to 7 files missing them (json-mode, rpc-mode, grep, firecrawl, scrollback, tui-init, frame-diff).
+
+### Metrics
+| Metric | Before (v0.96.1) | After (v0.96.2) | Change |
+|--------|------------------|-----------------|--------|
+| memory-tools.rkt LOC | 928 | 130 | -86% |
+| Files without headers | 7 | 0 | -7 |
+| God-modules (>500 LOC) | 14 | 13 | -1 |
+
 ## v0.96.1 — Representation Hiding + Parameter Reduction (2026-06-08)
 
 ### Architecture

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.96.1")
+(define version "0.96.2")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base" "gui-easy-lib"))

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -11,4 +11,4 @@
 
 (provide (contract-out [q-version string?]))
 
-(define q-version "0.96.1")
+(define q-version "0.96.2")


### PR DESCRIPTION
Closes #7411, #7412, #7413

## v0.96.2 Release

### Summary
| Wave | PR | Issues | Description |
|------|-----|--------|-------------|
| W0 | #7414 | #7399-#7401 | Split memory-tools.rkt (928→130 LOC) |
| W1 | N/A | #7402-#7404 | Deferred (high-risk decomposition) |
| W2 | #7415 | #7405-#7407 | Header comments + cleanups |
| W3 | N/A | #7408-#7410 | F8 assessment (below threshold) |
| W4 | This PR | #7411-#7413 | Version bump + CHANGELOG |