### PR TITLE
cleanup: W0 dead import removal (AF1, AF4, AF6) + comment fix (AF2) (#7417)

### DIFF
--- a/runtime/extension-setup.rkt
+++ b/runtime/extension-setup.rkt
@@ -5,14 +5,10 @@
 ;; Extracted from turn-orchestrator.rkt (v0.96.0 W3) for module sizing.
 
 (require racket/contract
-         (only-in "layer-adapters.rkt"
-                  tool-registry?
-                  extension-registry?
-                  make-extension-ctx
-                  dispatch-hooks)
+         (only-in "layer-adapters.rkt" tool-registry? extension-registry? make-extension-ctx)
          (only-in "layer-adapters.rkt" current-gsd-ctx)
          "../agent/event-bus.rkt"
-         (only-in "../util/hook-types.rkt" hook-result-action hook-result-payload hook-result?)
+         (only-in "../util/hook-types.rkt" hook-result-action hook-result-payload)
          (only-in "runtime-helpers.rkt" maybe-dispatch-hooks))
 
 (provide (contract-out

--- a/runtime/turn-orchestrator.rkt
+++ b/runtime/turn-orchestrator.rkt
@@ -23,30 +23,8 @@
 (require (only-in racket/dict in-dict)
          racket/contract
          racket/list
-         json
-         (only-in racket/string string-contains? string-join)
+         (only-in "../util/loop-result.rkt" loop-result?)
          (only-in "../util/error/errors.rkt" raise-extension-error)
-         (only-in "../util/event/event.rkt" make-event event-ev event-payload)
-         (only-in "../util/loop-result.rkt"
-                  make-loop-result
-                  loop-result-messages
-                  loop-result-termination-reason
-                  loop-result-metadata
-                  loop-result?)
-         (only-in "../util/message/message.rkt"
-                  message?
-                  message-id
-                  message-role
-                  message-content
-                  make-message)
-         (only-in "../util/tool/tool-types.rkt" tool-call-name tool-call-arguments)
-         (only-in "../util/content/content-parts.rkt"
-                  make-text-part
-                  text-part?
-                  tool-result-part?
-                  text-part-text
-                  tool-result-part-is-error?)
-         (only-in "../util/json/json-helpers.rkt" ensure-hash-args)
          "../agent/event-bus.rkt"
          (only-in "../util/cancellation.rkt" cancellation-token? cancellation-token-cancelled?)
          (only-in "../llm/provider.rkt" provider?)
@@ -60,13 +38,9 @@
          "../agent/loop.rkt"
          (only-in "../agent/loop-fsm.rkt" current-turn-fsm-state turn-state-blocked)
          (only-in "../runtime/settings.rkt" setting-ref setting-ref*)
-         "../runtime/tool-coordinator.rkt"
-         (only-in "../runtime/tool-coordinator.rkt"
-                  handle-tool-calls-pending
-                  extract-tool-calls-from-messages)
          "../util/ids.rkt"
          (only-in "../util/hook-types.rkt" hook-result-action hook-result-payload hook-result?)
-         (only-in "../runtime/auto-retry.rkt" with-auto-retry context-overflow-error?)
+         (only-in "../runtime/auto-retry.rkt" with-auto-retry)
          (only-in "provider/provider-factory.rkt" provider-is-mock?)
          (only-in "runtime-helpers.rkt" emit-session-event! maybe-dispatch-hooks)
          "../agent/event-emitter.rkt"

--- a/tools/builtins/memory-tools-shared.rkt
+++ b/tools/builtins/memory-tools-shared.rkt
@@ -54,7 +54,7 @@
           (current-seconds)
           (modulo (inexact->exact (round (* 1000 (current-inexact-milliseconds)))) 1000000)))
 
-;; F32: format-iso-now removed in v0.96.2 — use current-iso-8601 directly
+;; format-iso-now: delegates to current-iso-8601 (kept for backward compat)
 (define (format-iso-now)
   (current-iso-8601))
 

--- a/tools/builtins/memory-tools.rkt
+++ b/tools/builtins/memory-tools.rkt
@@ -13,18 +13,7 @@
                   delete-memory-handler
                   clear-memory-handler
                   consolidate-memory-handler
-                  cleanup-expired-handler)
-         (only-in "memory-tools-shared.rkt"
-                  backend-name
-                  current-memory-backend
-                  current-memory-policy
-                  pathish->string
-                  tool-project-root
-                  tool-session-id
-                  format-items-text
-                  memory-error-message
-                  make-error-result
-                  make-success-result))
+                  cleanup-expired-handler))
 
 (define-tool
  store-memory


### PR DESCRIPTION
Closes #7417, #7418, #7419, #7420, #7421

## W0: Dead Import Cleanup

- **AF1**: Remove 8 dead import entries from turn-orchestrator.rkt (33→25 imports)
- **AF4**: Remove dispatch-hooks + hook-result? from extension-setup.rkt
- **AF6**: Remove 10 unused shared imports from memory-tools facade
- **AF2**: Fix misleading format-iso-now comment

All tests pass. Zero logic changes.