### PR TITLE
docs: W1 add stability markers to 4 PUBLIC event sub-modules (AF5) (#7422)

### DIFF
--- a/agent/event-structs/base.rkt
+++ b/agent/event-structs/base.rkt
@@ -8,5 +8,6 @@
 (provide (struct-out typed-event)
          typed-event?)
 
+;; STABILITY: public — stable for extensions
 ;; Base struct: all events carry type, timestamp, session-id, turn-id
 (struct typed-event (type timestamp session-id turn-id) #:transparent)

--- a/agent/event-structs/iteration-events.rkt
+++ b/agent/event-structs/iteration-events.rkt
@@ -18,6 +18,7 @@
 
 (define-typed-event compaction-event "compaction" (reason tokens-before tokens-after) #:schema-version 1 #:no-serialize)
 
+;; STABILITY: public — stable for extensions
 (define-typed-event injection-event
                     "injection"
                     (source content-type content-length)

--- a/agent/event-structs/session-events.rkt
+++ b/agent/event-structs/session-events.rkt
@@ -31,6 +31,7 @@
 
 ;; Context events
 
+;; STABILITY: public — stable for extensions
 (define-typed-event context-event
                     "context.built"
                     (token-count window-size)

--- a/agent/event-structs/turn-events.rkt
+++ b/agent/event-structs/turn-events.rkt
@@ -5,6 +5,7 @@
 (require "base.rkt"
          "../../util/event/event-macro.rkt")
 
+;; STABILITY: public — stable for extensions
 (define-typed-event turn-start-event "turn.started" (model provider) #:schema-version 1)
 
 (define-typed-event turn-end-event "turn.completed" (reason duration-ms) #:defaults (duration-ms 0) #:schema-version 1)


### PR DESCRIPTION
Closes #7422, #7423

Add `;; STABILITY: public — stable for extensions` comments to:
- base.rkt (typed-event)
- turn-events.rkt (turn-start-event)
- session-events.rkt (context-event)
- iteration-events.rkt (injection-event)