### PR TITLE
release: v0.96.4 Audit Hotfix (#7435)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## v0.96.4 — Audit Hotfix (2026-06-08)
+
+### Architecture
+- **BF1 (dead imports) — RESOLVED**: Removed 4 remaining dead imports from `turn-orchestrator.rkt`: `racket/list`, `cancellation-token-cancelled?`, `tool-result?`, `hook-result-payload`.
+- **BF2 (stale comment) — RESOLVED**: Fixed layer-exception comment to reference `layer-adapters.rkt` instead of stale `extensions/hooks.rkt`.
+
+### Metrics
+| Metric | Before (v0.96.3) | After (v0.96.4) | Change |
+|--------|------------------|-----------------|--------|
+| turn-orchestrator dead imports | 4 | 0 | -100% |
+| turn-orchestrator import count | 25 | 21 | -16% |
+
 ## v0.96.3 — Architecture Audit Hotfix (2026-06-08)
 
 ### Architecture

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.96.3")
+(define version "0.96.4")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base" "gui-easy-lib"))

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -11,4 +11,4 @@
 
 (provide (contract-out [q-version string?]))
 
-(define q-version "0.96.3")
+(define q-version "0.96.4")


### PR DESCRIPTION
Closes #7435, #7436

Version bump to 0.96.4. CHANGELOG updated with BF1-BF2 resolution.