### PR TITLE
arch: W0 break dependency cycle via config.rkt extraction (F7) (#7439)

### DIFF
--- a/runtime/context-assembly/config.rkt
+++ b/runtime/context-assembly/config.rkt
@@ -1,57 +1,23 @@
 #lang racket/base
-
-;; runtime/context-assembly/config.rkt — Consolidated context-assembly configuration
+;; runtime/context-assembly/config.rkt — context-assembly configuration parameters
+;; STABILITY: internal
 ;;
-;; Replaces 12 individual parameters with a single struct.
-;; v0.80.3: Introduced. Old parameters kept as deprecated wrappers.
+;; Thin config module to break the dependency cycle between
+;; session-config.rkt and state-aware-builder.rkt.
 
-;; Struct
-(provide (struct-out context-assembly-config)
-         ;; Constructor with defaults
-         default-context-assembly-config
-         ;; Current config parameter (eventually replaces all 12)
-         current-context-assembly-config)
+(provide current-task-state-aware-assembly?
+         current-graph-conclusion-selection?
+         current-conclusion-token-budget
+         current-ws-evolution-enabled?)
 
-;; ============================================================
-;; Config struct
-;; ============================================================
+;; Whether to enable state-aware assembly for the current task.
+(define current-task-state-aware-assembly? (make-parameter #f))
 
-;; Consolidates the 12 context-assembly parameters into a single record.
-;; Fields are grouped by subsystem.
+;; Whether to use graph-based conclusion selection.
+(define current-graph-conclusion-selection? (make-parameter #f))
 
-(struct context-assembly-config
-        ;; State-aware assembly
-        (state-aware? ; current-task-state-aware-assembly?
-         graph-selection? ; current-graph-conclusion-selection?
-         conclusion-token-budget ; current-conclusion-token-budget
-         ws-evolution? ; current-ws-evolution-enabled?
-         ;; Auto-distillation
-         auto-distill? ; current-auto-distillation-enabled?
-         auto-distill-callback ; current-llm-distill-fn
-         ;; Rollback actions
-         rollback? ; current-rollback-action-execution?
-         force-distill-callback ; current-force-distill-fn
-         expand-context-callback ; current-expand-context-fn
-         revert-state-callback ; current-revert-state-fn
-         rollback-log ; current-rollback-action-log
-         ;; State inference
-         state-inference-threshold) ; current-state-inference-threshold
-  #:transparent)
+;; Token budget for conclusion generation.
+(define current-conclusion-token-budget (make-parameter 2000))
 
-;; Default config — all features off, standard budget, threshold 0.7
-(define (default-context-assembly-config)
-  (context-assembly-config #f ; state-aware?
-                           #f ; graph-selection?
-                           2000 ; conclusion-token-budget
-                           #f ; ws-evolution?
-                           #f ; auto-distill?
-                           #f ; auto-distill-callback
-                           #f ; rollback?
-                           #f ; force-distill-callback
-                           #f ; expand-context-callback
-                           #f ; revert-state-callback
-                           '() ; rollback-log
-                           0.7)) ; state-inference-threshold
-
-;; Global config parameter — for gradual migration
-(define current-context-assembly-config (make-parameter (default-context-assembly-config)))
+;; Whether to enable working-set evolution.
+(define current-ws-evolution-enabled? (make-parameter #f))

--- a/runtime/context-assembly/state-aware-builder.rkt
+++ b/runtime/context-assembly/state-aware-builder.rkt
@@ -37,7 +37,12 @@
                   current-revert-state-fn
                   current-rollback-action-log
                   rollback-action-reason)
-         (only-in "auto-distillation.rkt" current-auto-distillation-enabled?))
+         (only-in "auto-distillation.rkt" current-auto-distillation-enabled?)
+         (only-in "config.rkt"
+                  current-task-state-aware-assembly?
+                  current-graph-conclusion-selection?
+                  current-conclusion-token-budget
+                  current-ws-evolution-enabled?))
 
 (provide current-task-state-aware-assembly?
          build-tiered-context/state-aware
@@ -50,18 +55,6 @@
          check-rollback-triggers-with-actions)
 
 (define-runtime-path memory-builder-path "memory-builder.rkt")
-
-;; Feature flag: state-aware context assembly (v0.75.3)
-(define current-task-state-aware-assembly? (make-parameter #f))
-
-;; v0.77.3 W3.3: Graph-based conclusion selection (disabled by default)
-(define current-graph-conclusion-selection? (make-parameter #f))
-
-;; v0.77.4 W4.3: Hard conclusion token budget (0 = unlimited)
-(define current-conclusion-token-budget (make-parameter 2000))
-
-;; v0.78.1 G1: WS evolution flag (moved from session-events.rkt to avoid cycle)
-(define current-ws-evolution-enabled? (make-parameter #f))
 
 ;; State-specific guidance strings (action-oriented instructions)
 (define state-guidance-table

--- a/runtime/session/session-config.rkt
+++ b/runtime/session/session-config.rkt
@@ -34,7 +34,7 @@
          (only-in "../settings.rkt" q-settings?)
          (only-in "../../util/cancellation.rkt" cancellation-token?)
          (only-in "../session-index/schema.rkt" session-index?)
-         (only-in "../context-assembly/state-aware-builder.rkt"
+         (only-in "../context-assembly/config.rkt"
                   current-task-state-aware-assembly?
                   current-conclusion-token-budget
                   current-graph-conclusion-selection?


### PR DESCRIPTION
Closes #7439, #7440, #7441, #7442

Extract 4 context-assembly parameters into new config.rkt module to break the session-config → state-aware-builder → memory-builder cycle.