### PR TITLE
release: v0.96.5 Phase 1 Quick Wins (#7486)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## v0.96.5 — Phase 1 Quick Wins (2026-06-08)
+
+### Architecture
+- **F7 (dependency cycle) — RESOLVED**: Extracted 4 context-assembly parameters into new `runtime/context-assembly/config.rkt`, breaking the `session-config` → `state-aware-builder` → `memory-builder` cycle.
+- **F5/F10 (stability markers) — RESOLVED**: Added `;; STABILITY: public` to 27 hub modules (>15 fan-in).
+- **F2 (composition roots) — RESOLVED**: Documented 5 composition root modules with `COMPOSITION ROOT` comments.
+
+### Metrics
+| Metric | Before (v0.96.4) | After (v0.96.5) | Change |
+|--------|------------------|-----------------|--------|
+| Dependency cycles | 1 | 0 | -1 |
+| Stability markers | 89 | 116+ | +27 |
+
 ## v0.96.4 — Audit Hotfix (2026-06-08)
 
 ### Architecture

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.96.4")
+(define version "0.96.5")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base" "gui-easy-lib"))

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -11,4 +11,4 @@
 
 (provide (contract-out [q-version string?]))
 
-(define q-version "0.96.4")
+(define q-version "0.96.5")


### PR DESCRIPTION
Closes #7486

Version bump to 0.96.5 for Phase 1 Quick Wins milestone.