### PR TITLE
arch: W2 convert struct-out to explicit provides in 4 hub modules (F3) (#7459)

### DIFF
--- a/agent/event-structs/base.rkt
+++ b/agent/event-structs/base.rkt
@@ -6,8 +6,12 @@
 ;; All event structs inherit from typed-event.
 ;; Category-specific sub-modules require this module.
 
-(provide (struct-out typed-event)
-         typed-event?)
+(provide typed-event
+         typed-event?
+         typed-event-type
+         typed-event-timestamp
+         typed-event-session-id
+         typed-event-turn-id)
 
 ;; STABILITY: public — stable for extensions
 ;; Base struct: all events carry type, timestamp, session-id, turn-id

--- a/agent/iteration/loop-state.rkt
+++ b/agent/iteration/loop-state.rkt
@@ -13,9 +13,37 @@
 ;; Opaque types (EventBus, ToolRegistry, ExtRegistry, CancellationToken)
 ;; are defined via #:opaque to avoid any-wrap/c issues with TR boundaries.
 
-(provide (struct-out loop-infra)
-         (struct-out loop-counters)
-         (struct-out iteration-snapshot)
+(provide ;; loop-infra
+         loop-infra
+         loop-infra?
+         loop-infra-ctx
+         loop-infra-ext-reg
+         loop-infra-reg
+         loop-infra-bus
+         loop-infra-session-id
+         loop-infra-log-path
+         loop-infra-token
+         ;; loop-counters
+         loop-counters
+         loop-counters?
+         loop-counters-iteration
+         loop-counters-consecutive-tool-count
+         loop-counters-seen-paths
+         loop-counters-intent-retry-count
+         loop-counters-consecutive-error-count
+         loop-counters-recent-tool-names
+         loop-counters-explore-count
+         loop-counters-implement-count
+         loop-counters-stall-retry-count
+         ;; iteration-snapshot
+         iteration-snapshot
+         iteration-snapshot?
+         iteration-snapshot-counters
+         iteration-snapshot-ws
+         iteration-snapshot-config
+         iteration-snapshot-sess
+         iteration-snapshot-max-iterations
+         iteration-snapshot-max-iterations-hard
          make-initial-counters)
 
 ;; ── Opaque types for untyped struct values ────────────────────

--- a/llm/model.rkt
+++ b/llm/model.rkt
@@ -148,10 +148,34 @@
 ;; ============================================================
 
 ;; Struct types (predicates + accessors)
-(provide (struct-out model-request)
-         (struct-out model-response)
-         (struct-out stream-chunk)
-         (struct-out tool-call-intent)
+(provide ;; Struct type model-request (predicate + accessors)
+         model-request
+         model-request?
+         model-request-messages
+         model-request-tools
+         model-request-settings
+         ;; Struct type model-response (predicate + accessors)
+         model-response
+         model-response?
+         model-response-content
+         model-response-usage
+         model-response-model
+         model-response-stop-reason
+         ;; Struct type stream-chunk (predicate + accessors)
+         stream-chunk
+         stream-chunk?
+         stream-chunk-delta-text
+         stream-chunk-delta-tool-call
+         stream-chunk-delta-thinking
+         stream-chunk-usage
+         stream-chunk-done?
+         stream-chunk-finish-reason
+         ;; Struct type tool-call-intent (predicate + accessors)
+         tool-call-intent
+         tool-call-intent?
+         tool-call-intent-id
+         tool-call-intent-name
+         tool-call-intent-arguments
 
          ;; Constructors with contracts
          (contract-out [make-model-request (-> message-list/c tool-list/c settings/c model-request?)]

--- a/util/event/event-macro.rkt
+++ b/util/event/event-macro.rkt
@@ -264,13 +264,24 @@
          (define json-key (cdr fk))
          #`(hash-ref h '#,json-key #,default)))
 
+     ;; F3: Generate explicit accessor identifiers (replaces struct-out)
+     ;; Parent fields (type, timestamp, session-id, turn-id) use typed-event-* accessors.
+     ;; Only the sub-struct's own fields get event-name-* accessors.
+     (define base-ids
+       (list (format-id #'event-name "~a" #'event-name) (format-id #'event-name "~a?" #'event-name)))
+     (define field-accessors
+       (for/list ([f all-fields])
+         (format-id #'event-name "~a-~a" #'event-name f)))
+     (define all-provided-ids (append base-ids field-accessors))
+
      (with-syntax ([make-name make-name]
                    [type-name type-name]
                    [fields-name fields-name]
                    [(all-field ...) all-fields]
                    [(kw-arg ...) kw-args]
                    [(serializer-pair ...) serializer-body]
-                   [(deser-arg ...) deser-args])
+                   [(deser-arg ...) deser-args]
+                   [(provided-id ...) all-provided-ids])
        (if skip-serialize?
            #'(begin
                (struct event-name typed-event (all-field ...) #:transparent)
@@ -287,7 +298,7 @@
                                   #:timestamp [timestamp (current-seconds)]
                                   kw-arg ...)
                  (event-name type-str timestamp session-id turn-id all-field ...))
-               (provide (struct-out event-name)
+               (provide provided-id ...
                         make-name
                         type-name
                         fields-name))
@@ -312,7 +323,7 @@
                (register-event-deserializer! type-str
                                              (lambda (type ts sid tid h)
                                                (event-name type ts sid tid deser-arg ...)))
-               (provide (struct-out event-name)
+               (provide provided-id ...
                         make-name
                         type-name
                         fields-name))))]))


### PR DESCRIPTION
Closes #7459, #7460, #7461

Replaced struct-out with explicit identifier provides in llm/model.rkt, agent/event-structs/base.rkt, agent/iteration/loop-state.rkt, and util/event/event-macro.rkt.

G13 validation: 0 struct-out in hub modules.