### PR TITLE
test: W3 env guard firecrawl API key test with dynamic-wind (C3) (#7511)

### DIFF
--- a/tests/test-firecrawl.rkt
+++ b/tests/test-firecrawl.rkt
@@ -79,15 +79,18 @@
     ;; ---- API key detection ----
 
     (test-case "firecrawl-api-key returns #f when no env/config"
-      ;; Temporarily clear env var
+      ;; Temporarily clear env var with proper cleanup
       (define old-env (getenv "FIRECRAWL_API_KEY"))
-      (putenv "FIRECRAWL_API_KEY" "")
-      (define key (firecrawl-api-key))
-      ;; Restore
-      (when old-env
-        (putenv "FIRECRAWL_API_KEY" old-env))
-      ;; key may be #f or the config value — just check it doesn't crash
-      (check-true (or (not key) (string? key))))
+      (dynamic-wind
+        (lambda () (putenv "FIRECRAWL_API_KEY" ""))
+        (lambda ()
+          (define key (firecrawl-api-key))
+          ;; key may be #f or the config value — just check it doesn't crash
+          (check-true (or (not key) (string? key))))
+        (lambda ()
+          (if old-env
+              (putenv "FIRECRAWL_API_KEY" old-env)
+              (putenv "FIRECRAWL_API_KEY" "")))))
 
     ;; ---- Format helpers ----
 

--- a/tests/test-main.rkt
+++ b/tests/test-main.rkt
@@ -42,7 +42,8 @@
          ;; Session config
          "../runtime/session/session-config.rkt"
          ;; Extensions
-         (only-in "../extensions/api.rkt" extension-registry? list-extensions))
+         (only-in "../extensions/api.rkt" extension-registry? list-extensions)
+         (only-in "helpers/temp-fs.rkt" with-temp-dir))
 
 (define (capture-output thunk)
   (with-output-to-string thunk))


### PR DESCRIPTION
Closes #7511

Fix firecrawl env test cleanup with dynamic-wind. Clipboard already guarded. test-main.rkt manages own env vars.