### PR TITLE
chore: bump version to 0.96.8 + CHANGELOG (#7512)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [0.96.8] - 2026-06-08
+
+### Test Architecture — Phase 1: Safety & Cleanup
+
+#### Fixed
+- **D2**: Deprecated `fixtures.rkt` `with-temp-dir` (function) in favor of canonical macro in `temp-fs.rkt`
+- **C1**: Fixed temp file leaks in 15 test files — wrapped all `make-temporary-file` calls in `with-temp-dir` for guaranteed cleanup
+- **C2**: Fixed module-level mutable state in 5 test files — converted `set!` counters to `make-parameter` with per-test reset
+- **C3**: Fixed firecrawl env test to use `dynamic-wind` for guaranteed env var restore
 ## v0.96.5 — Phase 1 Quick Wins (2026-06-08)
 
 ### Architecture

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -11,4 +11,4 @@
 
 (provide (contract-out [q-version string?]))
 
-(define q-version "0.96.5")
+(define q-version "0.96.8")


### PR DESCRIPTION
Closes #7512

Version bump 0.96.5 → 0.96.8. CHANGELOG for Phase 1: Safety & Cleanup.