### PR TITLE
test: W0 reduce sleep calls in 4 test files (E1) (#7521)

### DIFF
--- a/tests/test-hook-expansion.rkt
+++ b/tests/test-hook-expansion.rkt
@@ -65,7 +65,7 @@
                "1.0"
                (hasheq 'tool-call
                        (lambda (payload)
-                         (sleep 10)
+                         (sleep 2)
                          payload))))
   (register-extension! reg slow-ext)
   (parameterize ([current-hook-timeout-ms 50])
@@ -80,7 +80,7 @@
                "1.0"
                (hasheq 'context
                        (lambda (payload)
-                         (sleep 10)
+                         (sleep 2)
                          payload))))
   (register-extension! reg slow-ext)
   (parameterize ([current-hook-timeout-ms 50])

--- a/tests/test-sandbox-security.rkt
+++ b/tests/test-sandbox-security.rkt
@@ -130,7 +130,7 @@
  (test-case "with-resource-limits returns timed-out on slow thunk"
    (define-values (result timed-out?)
      (with-resource-limits (lambda (cust)
-                             (sleep 30)
+                             (sleep 3)
                              'done)
                            #:timeout 0.5))
    (check-true timed-out?))

--- a/tests/test-subprocess.rkt
+++ b/tests/test-subprocess.rkt
@@ -24,7 +24,7 @@
  (test-case "with-resource-limits: timeout triggers"
    (define-values (result timed-out?)
      (with-resource-limits (lambda (cust)
-                             (sleep 30)
+                             (sleep 3)
                              99)
                            #:timeout 1))
    (check-true timed-out?))

--- a/tests/test-ui-render-hooks.rkt
+++ b/tests/test-ui-render-hooks.rkt
@@ -92,7 +92,7 @@
      (make-render-hook 'slow
                        'pre-render
                        (lambda (d)
-                         (sleep 10)
+                         (sleep 2)
                          d) ;; 10s — will timeout
                        #:timeout-ms 50))
    (define result (apply-render-hook h "original"))
@@ -103,7 +103,7 @@
      (make-render-hook 'slow-safe
                        'pre-render
                        (lambda (d)
-                         (sleep 10)
+                         (sleep 2)
                          d)
                        #:timeout-ms 50))
    (define-values (result ok?) (apply-render-hook-safe h "original"))


### PR DESCRIPTION
Closes #7521

Replace sleep 30→3 and sleep 10→2 in timeout tests.