### PR TITLE
test+chore: W2 GC batching + W3 version bump 0.96.10 (#7523 #7524)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [0.96.10] - 2026-06-08
+
+### Test Architecture — Phase 3: Efficiency
+
+#### Changed
+- **E1**: Reduced sleep calls in 4 test files (sleep 30→3, sleep 10→2) — saves ~80s per run
+- **E2**: Converted 58 files from `(module+ test ...)` to top-level test forms for unified runner detection
+- **E3**: Changed GC from every-batch to every-5-batches in `scripts/run-tests.rkt` for reduced overhead
+
 ## [0.96.9] - 2026-06-08
 
 ### Test Architecture — Phase 2: Naming & Organization

--- a/scripts/run-tests.rkt
+++ b/scripts/run-tests.rkt
@@ -618,6 +618,8 @@
   ;; This prevents FD/thread exhaustion on large test suites.
   (define batch-size jobs)
   (define batches (split-list files batch-size))
+  (define gc-counter 0)
+  (define total-batches (length batches))
 
   (for ([batch (in-list batches)]
         [batch-idx (in-naturals)])
@@ -634,8 +636,11 @@
                   (add-result! result)))))
     ;; Wait for entire batch to complete before starting next
     (for-each thread-wait batch-threads)
-    ;; Major GC after each batch to prevent port/FD accumulation
-    (collect-garbage 'major))
+    ;; Major GC every 5 batches to prevent port/FD accumulation
+    (set! gc-counter (add1 gc-counter))
+    (when (or (= 0 (modulo gc-counter 5))
+              (= gc-counter total-batches))
+      (collect-garbage 'major)))
 
   (newline)
 

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -11,4 +11,4 @@
 
 (provide (contract-out [q-version string?]))
 
-(define q-version "0.96.9")
+(define q-version "0.96.10")


### PR DESCRIPTION
Closes #7523
Closes #7524

Change GC from every-batch to every-5-batches. Bump version 0.96.9 → 0.96.10.