### PR TITLE
refactor: W0 extract run-tests into sub-modules (A1) (#7526)

### DIFF
--- a/scripts/run-tests/classify.rkt
+++ b/scripts/run-tests/classify.rkt
@@ -1,0 +1,270 @@
+#lang racket/base
+
+;; Classification of test files into suites (slow, fast, tui, security, etc.)
+;; Metadata parsing from file headers (@suite, @speed, @mutates tags).
+
+(require racket/string
+         racket/path
+         racket/file)
+
+(provide get-file-metadata
+         clear-metadata-cache!
+         slow-file?
+         tui-file?
+         mutating-file?
+         mutating-patterns
+         security-file?
+         file-has-suite-tag?
+         smoke-excluded?
+         support-test-module?
+         arch-file?
+         runtime-file?
+         extensions-file?
+         workflows-file?
+         collect-test-files
+         normalize-test-path
+         resolve-base-dir
+         q-root-candidate?
+         base-dir)
+
+;; Metadata parser integration (v0.83.4)
+(define metadata-cache (make-hash))
+
+(define (clear-metadata-cache!)
+  (hash-clear! metadata-cache))
+
+(define (get-file-metadata f)
+  "Parse metadata from file header, cached per file."
+  (hash-ref!
+   metadata-cache
+   f
+   (lambda ()
+     (define full-path
+       (if (absolute-path? f)
+           f
+           (build-path base-dir f)))
+     (if (file-exists? full-path)
+         (let ([speed #f]
+               [suite #f]
+               [mutates #f]
+               [boundary #f]
+               [isolation #f]
+               [timeout #f])
+           (with-handlers ([exn:fail? (lambda (_) (void))])
+             (call-with-input-file
+              full-path
+              (lambda (port)
+                (for ([_ (in-range 30)]
+                      #:break (eof-object? (peek-byte port)))
+                  (define line (read-line port))
+                  (when (string? line)
+                    (cond
+                      [(regexp-match? #rx";+[ \t]*@speed[ \t]+fast" line) (set! speed 'fast)]
+                      [(regexp-match? #rx";+[ \t]*@speed[ \t]+slow" line) (set! speed 'slow)]
+                      [(regexp-match? #rx";+[ \t]*@speed[ \t]+perf" line) (set! speed 'perf)]
+                      [(regexp-match #rx";+[ \t]*@suite[ \t]+(.+)$" line)
+                       =>
+                       (lambda (m) (set! suite (string-trim (cadr m))))]
+                      [(regexp-match #rx";+[ \t]*@mutates[ \t]+(.+)$" line)
+                       =>
+                       (lambda (m) (set! mutates (string-trim (cadr m))))]
+                      [(regexp-match #rx";+[ \t]*@boundary[ \t]+(.+)$" line)
+                       =>
+                       (lambda (m) (set! boundary (string-trim (cadr m))))]
+                      [(regexp-match #rx";+[ \t]*@isolation[ \t]+(.+)$" line)
+                       =>
+                       (lambda (m) (set! isolation (string-trim (cadr m))))]
+                      [(regexp-match #rx";+[ \t]*@timeout[ \t]+([0-9]+)" line)
+                       =>
+                       (lambda (m) (set! timeout (string->number (cadr m))))]))))))
+           (hash 'speed
+                 speed
+                 'suite
+                 suite
+                 'mutates
+                 mutates
+                 'boundary
+                 boundary
+                 'isolation
+                 isolation
+                 'timeout
+                 timeout))
+         (hash)))))
+
+(define slow-patterns
+  '("sandbox" "subprocess"
+              "integration"
+              "benchmark"
+              "workflow-"
+              "e2e-"
+              "ci_local"
+              "metrics-readme"
+              "bump-version"
+              "examples-compile"
+              "pre-commit"
+              "racket-tooling"
+              "run-tests"
+              "audit-script"
+              "test-doctor"
+              "check-deps"
+              "self-hosting"
+              "tui-terminal"
+              "sync-readme"))
+
+(define path-slow-patterns '("/workflows/"))
+
+(define (slow-file? f)
+  (define meta (get-file-metadata f))
+  (define meta-speed (hash-ref meta 'speed #f))
+  (cond
+    [(eq? meta-speed 'fast) #f]
+    [(eq? meta-speed 'slow) #t]
+    [(eq? meta-speed 'perf) #t]
+    [else
+     (define base (file-name-from-path f))
+     (or (for/or ([p (in-list slow-patterns)])
+           (and base (string-contains? (path->string base) p)))
+         (for/or ([p (in-list path-slow-patterns)])
+           (string-contains? f p)))]))
+
+(define (tui-file? f)
+  (define meta (get-file-metadata f))
+  (define meta-suite (hash-ref meta 'suite #f))
+  (if (equal? meta-suite "tui")
+      #t
+      (let ([base (file-name-from-path f)])
+        (or (string-contains? f "/tui/")
+            (string-contains? f "/interfaces/tui.rkt")
+            (and base (string-prefix? (path->string base) "test-tui-"))))))
+
+(define mutating-patterns
+  '("ci_local" "pre-commit"
+               "check-deps"
+               "sync-version"
+               "sync-readme"
+               "bump-version"
+               "metrics-readme"
+               "self-hosting"))
+
+(define (mutating-file? f)
+  (define meta (get-file-metadata f))
+  (define meta-mutates (hash-ref meta 'mutates #f))
+  (define meta-isolation (hash-ref meta 'isolation #f))
+  (cond
+    [(equal? meta-mutates "none") #f]
+    [(equal? meta-isolation "process") #t]
+    [else
+     (let ([base (file-name-from-path f)])
+       (for/or ([p (in-list mutating-patterns)])
+         (and base (string-contains? (path->string base) p))))]))
+
+(define (security-file? f)
+  (define base (path->string (file-name-from-path f)))
+  (or (string-contains? base "security")
+      (string-contains? base "permission")
+      (string-contains? base "safe-mode")
+      (string-contains? base "sandbox")
+      (string-contains? base "tool-bash")
+      ;; Tag-based: files with ;; @suite security in first 10 lines
+      (file-has-suite-tag? f "security")))
+
+(define (file-has-suite-tag? f tag)
+  (define meta (get-file-metadata f))
+  (equal? (hash-ref meta 'suite #f) tag))
+
+(define (smoke-excluded? f)
+  (or (slow-file? f) (string-contains? f "/workflows/") (string-contains? f "/interfaces/")))
+
+(define support-test-module-names
+  '("event-simulator.rkt" "mock-tui-session.rkt" "state-assertions.rkt" "workflow-harness.rkt"))
+
+(define (support-test-module? f)
+  (define s
+    (if (path? f)
+        (path->string f)
+        f))
+  (define base (file-name-from-path s))
+  (or (string-contains? s "/helpers/")
+      (and (string-contains? s "/fixtures/")
+           (or (not base) (not (string-prefix? (path->string base) "test-"))))
+      (and base (member (path->string base) support-test-module-names) #t)))
+
+(define (q-root-candidate? p)
+  (and (directory-exists? (build-path p "tests"))
+       (file-exists? (build-path p "scripts" "run-tests.rkt"))))
+
+(define (resolve-base-dir orig)
+  (define parent (simplify-path (build-path orig "..")))
+  (define candidates
+    (list (simplify-path (build-path orig "q")) (simplify-path (build-path parent "q")) orig parent))
+  (or (for/first ([candidate (in-list candidates)]
+                  #:when (q-root-candidate? candidate))
+        candidate)
+      orig))
+
+(define base-dir (resolve-base-dir (find-system-path 'orig-dir)))
+
+(define (normalize-test-path f)
+  (define s
+    (if (path? f)
+        (path->string f)
+        f))
+  (cond
+    [(absolute-path? s) s]
+    [(string-prefix? s "q/tests/") (substring s 2)]
+    [(string-prefix? s "./q/tests/") (substring s 4)]
+    [else s]))
+
+(define (arch-file? f)
+  (or (string-contains? f "arch-")
+      (string-contains? f "boundary")
+      (string-contains? f "fitness")
+      (string-contains? f "hotspot")
+      (file-has-suite-tag? f "arch")))
+
+(define (runtime-file? f)
+  (or (string-contains? f "runtime")
+      (string-contains? f "session")
+      (string-contains? f "compaction")
+      (string-contains? f "iteration")
+      (string-contains? f "turn-")
+      (string-contains? f "tool-coord")
+      (file-has-suite-tag? f "runtime")))
+
+(define (extensions-file? f)
+  (or (string-contains? f "extensions/")
+      (string-contains? f "gsd-")
+      (string-contains? f "define-extension")
+      (string-contains? f "wave-executor")
+      (string-contains? f "hook-")
+      (file-has-suite-tag? f "extensions")))
+
+(define (workflows-file? f)
+  (and (string-contains? f "/workflows/")
+       (or (not (string-contains? f "/fixtures/"))
+           (string-prefix? (path->string (file-name-from-path f)) "test-"))))
+
+(define (collect-test-files suite #:extra-files [extra-files #f])
+  (cond
+    [(pair? extra-files) (map normalize-test-path extra-files)]
+    [else
+     (define all-files
+       (for/list ([f (in-directory (build-path base-dir "tests"))]
+                  #:when (and (file-exists? f)
+                              (let ([s (path->string f)])
+                                (and (string-suffix? s ".rkt")
+                                     (not (string-contains? s "/compiled/"))
+                                     (not (support-test-module? s))))))
+         (path->string (find-relative-path base-dir f))))
+     (case suite
+       [(all) all-files]
+       [(fast) (filter (lambda (f) (not (slow-file? f))) all-files)]
+       [(slow) (filter slow-file? all-files)]
+       [(tui) (filter tui-file? all-files)]
+       [(smoke) (filter (lambda (f) (not (smoke-excluded? f))) all-files)]
+       [(security) (filter security-file? all-files)]
+       [(arch) (filter arch-file? all-files)]
+       [(runtime) (filter runtime-file? all-files)]
+       [(extensions) (filter extensions-file? all-files)]
+       [(workflows) (filter workflows-file? all-files)]
+       [else '("tests/")])]))

--- a/scripts/run-tests/parse.rkt
+++ b/scripts/run-tests/parse.rkt
@@ -1,0 +1,91 @@
+#lang racket/base
+
+;; Parsing of test output: raco output, failure lines, count normalization.
+
+(require racket/string
+         racket/port)
+
+(provide bytes->string*
+         parse-raco-output
+         normalize-counts
+         effective-exit-code
+         extract-failure-lines)
+
+;; Safe bytes->string conversion (handles invalid UTF-8)
+(define (bytes->string* bs)
+  (with-handlers ([exn:fail? (lambda (e) (bytes->string/latin-1 bs))])
+    (bytes->string/utf-8 bs)))
+
+(define (parse-raco-output stdout-bytes)
+  (define output (bytes->string* stdout-bytes))
+  (define lines (string-split output "\n"))
+
+  (define all-matches
+    (filter
+     values
+     (for/list ([line (in-list lines)])
+       (regexp-match
+        #px"([0-9]+) success\\(es\\) ([0-9]+) failure\\(s\\)(?: ([0-9]+) error\\(s\\))? ([0-9]+) test\\(s\\) run"
+        line))))
+
+  (cond
+    [(pair? all-matches)
+     (define passed (for/sum ([m (in-list all-matches)]) (string->number (cadr m))))
+     (define failed
+       (for/sum ([m (in-list all-matches)])
+                (+ (string->number (caddr m))
+                   (let ([errors (list-ref m 3)])
+                     (if errors
+                         (string->number errors)
+                         0)))))
+     (values passed failed (+ passed failed))]
+    [else
+     (define passed
+       (for/fold ([n 0]) ([line (in-list lines)])
+         (define m (regexp-match #rx"([0-9]+) tests? passed" line))
+         (if m
+             (string->number (cadr m))
+             n)))
+
+     (define failed
+       (for/fold ([n 0]) ([line (in-list lines)])
+         (define m (regexp-match #rx"([0-9]+) tests? failed" line))
+         (if m
+             (string->number (cadr m))
+             n)))
+
+     (cond
+       [(> (+ passed failed) 0) (values passed failed (+ passed failed))]
+       [else
+        (define result-successes (length (regexp-match* #rx"#<test-success>" output)))
+        (define result-failures
+          (+ (length (regexp-match* #rx"#<test-failure>" output))
+             (length (regexp-match* #rx"#<test-error>" output))))
+        (values result-successes result-failures (+ result-successes result-failures))])]))
+
+(define (normalize-counts exit-code passed failed total)
+  (values passed failed total))
+
+(define (effective-exit-code exit-code failed)
+  (if (and (= exit-code 0) (> failed 0)) 1 exit-code))
+
+(define FAILURE-START #rx"^-+ FAILURE -+$")
+(define FAILURE-END #rx"^-{20,}$")
+
+(define (extract-failure-lines stdout-bytes)
+  (define output (bytes->string* stdout-bytes))
+  (define lines (string-split output "\n"))
+  (define in-failure? (box #f))
+  (for/list ([line (in-list lines)]
+             #:when (cond
+                      [(regexp-match? FAILURE-START line)
+                       (set-box! in-failure? #t)
+                       #t]
+                      [(and (unbox in-failure?)
+                            (regexp-match? FAILURE-END line)
+                            (not (regexp-match? FAILURE-START line)))
+                       (set-box! in-failure? #f)
+                       #t]
+                      [(unbox in-failure?) #t]
+                      [else #f]))
+    line))

--- a/scripts/run-tests/types.rkt
+++ b/scripts/run-tests/types.rkt
@@ -1,0 +1,20 @@
+#lang racket/base
+
+;; Test file result struct and constructor.
+
+(provide (struct-out test-file-result)
+         make-test-file-result)
+
+(struct test-file-result (path exit-code stdout-bytes stderr-bytes elapsed-ms passed failed total)
+  #:transparent)
+
+;; Constructor alias for cleaner test access
+(define (make-test-file-result path
+                               exit-code
+                               stdout-bytes
+                               stderr-bytes
+                               elapsed-ms
+                               passed
+                               failed
+                               total)
+  (test-file-result path exit-code stdout-bytes stderr-bytes elapsed-ms passed failed total))


### PR DESCRIPTION
Closes #7526

Extract scripts/run-tests/ into types.rkt, classify.rkt, parse.rkt sub-modules.