### PR TITLE
chore: W4 version bump 0.96.11 + CHANGELOG (#7528 #7529 #7530)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [0.96.11] - 2026-06-08
+
+### Test Architecture — Phase 4: Runner Refactor
+
+#### Changed
+- **A1**: Extracted `scripts/run-tests/` into sub-modules (types, classify, parse) — modular API for external consumers
+- **A2**: Created `scripts/lint-test-tags.rkt` and auto-tagged all 905 test files with `@speed` and `@suite` metadata tags
+- **B1/B3**: God test file splitting deferred (low risk/benefit ratio for test-only changes)
+
 ## [0.96.10] - 2026-06-08
 
 ### Test Architecture — Phase 3: Efficiency

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -11,4 +11,4 @@
 
 (provide (contract-out [q-version string?]))
 
-(define q-version "0.96.10")
+(define q-version "0.96.11")


### PR DESCRIPTION
Closes #7528
Closes #7529
Closes #7530

Version bump 0.96.10 → 0.96.11. God file splitting deferred.