### PR TITLE
refactor: W4 batch convert 13 struct-out to explicit provides

### DIFF
--- a/runtime/context-assembly/conclusion-graph.rkt
+++ b/runtime/context-assembly/conclusion-graph.rkt
@@ -147,7 +147,12 @@
 
 ;; ── Exports ──
 
-(provide (struct-out conclusion-graph)
+(provide conclusion-graph
+         conclusion-graph?
+         struct:conclusion-graph
+         conclusion-graph-nodes
+         conclusion-graph-edges
+         conclusion-graph-reverse
          (contract-out
           [build-conclusion-graph (-> (listof task-conclusion?) conclusion-graph?)]
           [graph-conclusion-count (-> conclusion-graph? exact-nonnegative-integer?)]

--- a/runtime/context-assembly/memory-builder.rkt
+++ b/runtime/context-assembly/memory-builder.rkt
@@ -387,7 +387,15 @@
          current-memory-injection-budget
          current-memory-max-entry-chars
          ;; Telemetry
-         (struct-out memory-telemetry)
+         memory-telemetry
+         memory-telemetry?
+         struct:memory-telemetry
+         memory-telemetry-retrieved-count
+         memory-telemetry-latency-ms
+         memory-telemetry-token-estimate
+         memory-telemetry-backend-available?
+         memory-telemetry-timed-out?
+         memory-telemetry-error-message
          memory-telemetry->jsexpr
          ;; Retrieval
          observe-memory-for-context

--- a/runtime/context-assembly/selection.rkt
+++ b/runtime/context-assembly/selection.rkt
@@ -78,7 +78,17 @@
                                  catalog-proc
                                  estimate-proc))
 
-(provide (struct-out context-assembly-call-options)
+(provide context-assembly-call-options
+         context-assembly-call-options?
+         struct:context-assembly-call-options
+         context-assembly-call-options-cache
+         context-assembly-call-options-provider
+         context-assembly-call-options-model-name
+         context-assembly-call-options-trace-callback
+         context-assembly-call-options-working-set
+         context-assembly-call-options-generate-summary-proc
+         context-assembly-call-options-generate-catalog-proc
+         context-assembly-call-options-estimate-text-proc
          (contract-out
           [make-context-assembly-call-options
            (->* ()

--- a/runtime/context-assembly/task-conclusion.rkt
+++ b/runtime/context-assembly/task-conclusion.rkt
@@ -62,7 +62,17 @@
 
 ;; ── Exports ──
 
-(provide (struct-out task-conclusion)
+(provide task-conclusion
+         task-conclusion?
+         struct:task-conclusion
+         task-conclusion-id
+         task-conclusion-text
+         task-conclusion-category
+         task-conclusion-fsm-state-origin
+         task-conclusion-origin-message-ids
+         task-conclusion-timestamp
+         task-conclusion-relevance-tags
+         task-conclusion-dependencies
          task-conclusion-category?
          valid-categories
          (contract-out [conclusion->hash (-> task-conclusion? hash?)]

--- a/runtime/context-assembly/task-memory.rkt
+++ b/runtime/context-assembly/task-memory.rkt
@@ -126,7 +126,11 @@
 
 ;; ── Exports ──
 
-(provide (struct-out task-memory)
+(provide task-memory
+         task-memory?
+         struct:task-memory
+         task-memory-conclusions
+         task-memory-max-conclusions
          (contract-out
           [make-task-memory (->* () (integer?) task-memory?)]
           [add-conclusion (-> task-memory? task-conclusion? task-memory?)]

--- a/runtime/memory/policy.rkt
+++ b/runtime/memory/policy.rkt
@@ -12,7 +12,16 @@
          "types.rkt"
          (only-in "../../util/safe-mode/safe-mode-state.rkt" safe-mode?))
 
-(provide (struct-out memory-policy)
+(provide memory-policy
+         memory-policy?
+         struct:memory-policy
+         memory-policy-max-items-per-session
+         memory-policy-max-retrieve-count
+         memory-policy-max-content-length
+         memory-policy-allowed-sensitivities
+         memory-policy-blocked-content-patterns
+         memory-policy-allow-delete?
+         memory-policy-user-scope-enabled?
          memory-policy?
          default-memory-policy
          default-blocked-content-patterns

--- a/runtime/memory/protocol.rkt
+++ b/runtime/memory/protocol.rkt
@@ -7,7 +7,17 @@
 (require racket/contract
          "types.rkt")
 
-(provide (struct-out memory-backend)
+(provide memory-backend
+         memory-backend?
+         struct:memory-backend
+         memory-backend-name
+         memory-backend-store!
+         memory-backend-retrieve
+         memory-backend-update!
+         memory-backend-delete!
+         memory-backend-list
+         memory-backend-available?
+         memory-backend-manage!
          memory-backend/c
          gen:store-memory!
          gen:retrieve-memory

--- a/tui/cell-diff.rkt
+++ b/tui/cell-diff.rkt
@@ -104,7 +104,13 @@
 ;; Contracts and exports
 ;; ============================================================
 
-(provide (struct-out cell-delta)
+(provide cell-delta
+         cell-delta?
+         struct:cell-delta
+         cell-delta-col
+         cell-delta-row
+         cell-delta-old-cell
+         cell-delta-new-cell
          diff-cell-buffers
          row-hash
          delta-changed-rows

--- a/tui/vdom.rkt
+++ b/tui/vdom.rkt
@@ -131,11 +131,32 @@
 ;; Contracts and exports
 ;; ============================================================
 
-(provide (struct-out vtext)
-         (struct-out vhbox)
-         (struct-out vvbox)
-         (struct-out vfill)
-         (struct-out voverlay)
+(provide vtext
+         vtext?
+         struct:vtext
+         vtext-text
+         vtext-style
+         vhbox
+         vhbox?
+         struct:vhbox
+         vhbox-children
+         vvbox
+         vvbox?
+         struct:vvbox
+         vvbox-children
+         vfill
+         vfill?
+         struct:vfill
+         vfill-width
+         vfill-char
+         vfill-style
+         voverlay
+         voverlay?
+         struct:voverlay
+         voverlay-content
+         voverlay-anchor
+         voverlay-col
+         voverlay-row
          vnode?
          vtext*
          vfill*


### PR DESCRIPTION
Closes #7574

Convert (struct-out X) to explicit provides in 9 files (13 conversions).
struct-out count: 33→20.