### PR TITLE
perf: W5 reduce test sleeps + pre-commit staged lint

### DIFF
--- a/scripts/pre-commit.rkt
+++ b/scripts/pre-commit.rkt
@@ -127,6 +127,32 @@
         (printf "Lint checks: FAIL~n")
         #f)))
 
+;; --- Run format + compile only on staged files ---
+
+(define (run-staged-lint staged-files)
+  (printf "~n--- Staged Lint (format + compile ~a files) ---~n" (length staged-files))
+  (define all-ok #t)
+  (for ([f (in-list staged-files)])
+    (printf "  Checking: ~a ... " f)
+    (flush-output)
+    (define fmt-code (system/exit-code (format "raco fmt -i ~a 2>&1" f)))
+    (define make-code (system/exit-code (format "raco make ~a 2>&1" f)))
+    (cond
+      [(and (= fmt-code 0) (= make-code 0)) (printf "OK~n")]
+      [(not (= fmt-code 0))
+       (printf "FORMAT FAIL~n")
+       (set! all-ok #f)]
+      [else
+       (printf "COMPILE FAIL~n")
+       (set! all-ok #f)]))
+  (if all-ok
+      (begin
+        (printf "Staged lint: PASS~n")
+        #t)
+      (begin
+        (printf "Staged lint: FAIL~n")
+        #f)))
+
 ;; --- Run test file ---
 
 (define (run-test test-path)
@@ -183,9 +209,23 @@
 
   (define all-pass #t)
 
-  ;; 1. Lint checks (delegated to lint-all.rkt)
-  (unless (run-lint-checks #:full? full-mode?)
-    (set! all-pass #f))
+  ;; 1. Lint checks — scoped to staged files in quick mode
+  (define staged (get-staged-rkt-files))
+  (printf "~n--- Staged .rkt files: ~a ---~n"
+          (if (null? staged)
+              "(none)"
+              (string-join staged ", ")))
+
+  (cond
+    [(or full-mode? all-mode?)
+     (unless (run-lint-checks #:full? full-mode?)
+       (set! all-pass #f))]
+    [(not (null? staged))
+     (unless (run-staged-lint staged)
+       (set! all-pass #f))]
+    [else
+     (unless (run-lint-checks)
+       (set! all-pass #f))])
 
   ;; 2. Tests (skipped when --no-tests to avoid infinite recursion)
   (unless no-tests?
@@ -194,12 +234,6 @@
        (unless (run-full-suite)
          (set! all-pass #f))]
       [else
-       (define staged (get-staged-rkt-files))
-       (printf "~n--- Staged .rkt files: ~a ---~n"
-               (if (null? staged)
-                   "(none)"
-                   (string-join staged ", ")))
-
        (define test-files (remove-duplicates (append-map source->test-files staged)))
 
        (if (null? test-files)

--- a/tests/test-hook-expansion.rkt
+++ b/tests/test-hook-expansion.rkt
@@ -67,7 +67,7 @@
                "1.0"
                (hasheq 'tool-call
                        (lambda (payload)
-                         (sleep 2)
+                         (sleep 0.5)
                          payload))))
   (register-extension! reg slow-ext)
   (parameterize ([current-hook-timeout-ms 50])
@@ -82,7 +82,7 @@
                "1.0"
                (hasheq 'context
                        (lambda (payload)
-                         (sleep 2)
+                         (sleep 0.5)
                          payload))))
   (register-extension! reg slow-ext)
   (parameterize ([current-hook-timeout-ms 50])

--- a/tests/test-sandbox-evaluator.rkt
+++ b/tests/test-sandbox-evaluator.rkt
@@ -41,13 +41,13 @@
 ;; ============================================================
 
 (test-case "eval-in-sandbox kills code that exceeds timeout"
-  ;; Use a very short timeout; sleeping 10s should be killed
-  (define result (eval-in-sandbox "(sleep 10)" #:timeout 1))
+  ;; Use a very short timeout; sleeping 3s should be killed
+  (define result (eval-in-sandbox "(sleep 3)" #:timeout 1))
   (check-pred eval-result? result)
   (check-false (eval-result-value result))
   (check-true (string? (eval-result-error result)))
   ;; Should have been killed well before 10 seconds (generous timeout)
-  (check-true (< (eval-result-elapsed-ms result) 15000)))
+  (check-true (< (eval-result-elapsed-ms result) 5000)))
 
 ;; ============================================================
 ;; eval-in-sandbox — forbidden operations

--- a/tests/test-sandbox-limits.rkt
+++ b/tests/test-sandbox-limits.rkt
@@ -138,7 +138,7 @@
 (test-case "with-resource-limits returns timed-out on timeout"
   (define-values (result timed-out?)
     (with-resource-limits (λ (cust)
-                            (sleep 2)
+                            (sleep 0.5)
                             'done)
                           #:timeout 0.1))
   (check-false result)

--- a/tests/test-sandbox-security.rkt
+++ b/tests/test-sandbox-security.rkt
@@ -132,7 +132,7 @@
  (test-case "with-resource-limits returns timed-out on slow thunk"
    (define-values (result timed-out?)
      (with-resource-limits (lambda (cust)
-                             (sleep 3)
+                             (sleep 1)
                              'done)
                            #:timeout 0.5))
    (check-true timed-out?))

--- a/tests/test-subprocess.rkt
+++ b/tests/test-subprocess.rkt
@@ -27,7 +27,7 @@
  (test-case "with-resource-limits: timeout triggers"
    (define-values (result timed-out?)
      (with-resource-limits (lambda (cust)
-                             (sleep 3)
+                             (sleep 1.5)
                              99)
                            #:timeout 1))
    (check-true timed-out?))

--- a/tests/test-ui-render-hooks.rkt
+++ b/tests/test-ui-render-hooks.rkt
@@ -95,7 +95,7 @@
      (make-render-hook 'slow
                        'pre-render
                        (lambda (d)
-                         (sleep 2)
+                         (sleep 0.5)
                          d) ;; 2s — will timeout
                        #:timeout-ms 50))
    (define result (apply-render-hook h "original"))
@@ -106,7 +106,7 @@
      (make-render-hook 'slow-safe
                        'pre-render
                        (lambda (d)
-                         (sleep 2)
+                         (sleep 0.5)
                          d)
                        #:timeout-ms 50))
    (define-values (result ok?) (apply-render-hook-safe h "original"))

--- a/tests/test-working-set.rkt
+++ b/tests/test-working-set.rkt
@@ -54,7 +54,7 @@
                            mock-id
                            mock-tokens)
       (define old-ts (ws-entry-timestamp (car (working-set-entries ws))))
-      (sleep 1)
+      (sleep 0.5)
       (working-set-update! ws
                            (list (make-tool "read" "/tmp/foo.rkt"))
                            (list (mock-msg "m2" "second read longer"))

--- a/tests/workflows/fixtures/test-workflow-timeout-cleanup.rkt
+++ b/tests/workflows/fixtures/test-workflow-timeout-cleanup.rkt
@@ -27,7 +27,7 @@
       (check-exn exn:fail?
                  (lambda ()
                    (with-workflow-timeout (lambda ()
-                                            (sleep 10)
+                                            (sleep 1)
                                             'done)
                                           #:timeout-ms 100))))
 
@@ -64,11 +64,11 @@
       (check-exn
        exn:fail?
        (lambda ()
-         (with-workflow-timeout (lambda () (sleep 10)) #:timeout-ms 50 #:context "test-context"))))
+         (with-workflow-timeout (lambda () (sleep 1)) #:timeout-ms 50 #:context "test-context"))))
 
     (test-case "custom on-timeout handler is called"
       (define called? (box #f))
-      (with-workflow-timeout (lambda () (sleep 10))
+      (with-workflow-timeout (lambda () (sleep 1))
                              #:timeout-ms 50
                              #:on-timeout (lambda ()
                                             (set-box! called? #t)


### PR DESCRIPTION
Closes #7575

- Reduce 12 test sleeps >0.5s to 6 (remaining are intentional timeout tests)
- Pre-commit quick mode now runs raco fmt/make on staged files only