### PR TITLE
release: v0.96.16 — audit remediation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [0.96.16] - 2026-06-08
+
+### Changed
+- **AX1-1**: Decompose `terminal-input.rkt` (671→498 LOC) — extract Kitty keyboard protocol + SGR mouse decoding into `tui/input/kitty-protocol.rkt`
+- **AX1-2**: Decompose `tui-render-loop.rkt` (634→422 LOC) — extract frame-vdom + watchdog into `tui/render-loop/` submodules
+- **AX1-3**: Decompose `run-tests.rkt` (1388→370 LOC) — extract 6 sub-modules into `scripts/run-tests/`
+- **AX1-5**: Convert 13 `struct-out` to explicit provides across 9 files (33→20 remaining)
+- **AX3-3**: Reduce test sleeps >0.5s from 12 to 6 (remaining are intentional timeout tests)
+- **AX5-x**: Fix stale version references in README, info.rkt, CHANGELOG
+- **AX6-3**: Pre-commit quick mode now runs `raco fmt`/`raco make` on staged files only
+
+### Audit Source
+- `.planning/PLAN-v0.96.16-AUDIT-REMEDIATION.md`
+
+
 ## [0.96.15] - 2026-06-09
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.96.15-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.96.16-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.96.15")
+(define version "0.96.16")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base" "gui-easy-lib"))

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -11,4 +11,4 @@
 
 (provide (contract-out [q-version string?]))
 
-(define q-version "0.96.15")
+(define q-version "0.96.16")


### PR DESCRIPTION
Closes #7576

Version bump 0.96.15→0.96.16 + CHANGELOG update.

v0.96.16 deliverables:
- W0: Documentation hygiene
- W1: Decompose terminal-input.rkt (671→498 LOC)
- W2: Decompose tui-render-loop.rkt (634→422 LOC)
- W3: Decompose run-tests.rkt (1388→370 LOC)
- W4: 13 struct-out → explicit provides
- W5: Test sleep reduction (12→6) + pre-commit staged lint
- W6: Version bump + CHANGELOG