### PR TITLE
feat: GAP-6 default profile observe (#7589)

### DIFF
--- a/runtime/settings.rkt
+++ b/runtime/settings.rkt
@@ -426,7 +426,7 @@
 ;; Returns a symbol: off, observe, bounded, self-healing, or full.
 ;; Default: 'off.
 (define (setting-context-assembly-profile settings)
-  (define raw (setting-ref* settings '(context-assembly profile) "off"))
+  (define raw (setting-ref* settings '(context-assembly profile) "observe"))
   (define sym
     (if (symbol? raw)
         raw


### PR DESCRIPTION
Closes #7589

Change default context-assembly profile from off to observe.
Safest non-off profile: state-aware assembly, no mutations.