### PR TITLE
chore: v0.96.17 version bump + CHANGELOG (#7590)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.96.17] - 2026-06-08
+
+### Added
+- GAP-1: LLM distillation wiring — channel-based sync with 5s timeout and deterministic fallback
+- GAP-3: Tool result auto-extraction for read/grep/find with content filtering
+- GAP-6: Default context-assembly profile changed from `off` to `observe`
+
+### Fixed
+- distill-with-llm now correctly receives LLM function result via channel instead of thread descriptor
+
 ## [0.96.16] - 2026-06-08
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.96.16-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.96.17-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.96.16")
+(define version "0.96.17")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base" "gui-easy-lib"))

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -11,4 +11,4 @@
 
 (provide (contract-out [q-version string?]))
 
-(define q-version "0.96.16")
+(define q-version "0.96.17")


### PR DESCRIPTION
Closes #7590

Version bump 0.96.16 → 0.96.17 with CHANGELOG entry.