### PR TITLE
fix: GAP-5 WS evolution guard + GAP-8 dynamic budget (#7594)

### DIFF
--- a/runtime/context-assembly/config.rkt
+++ b/runtime/context-assembly/config.rkt
@@ -8,7 +8,8 @@
 (provide current-task-state-aware-assembly?
          current-graph-conclusion-selection?
          current-conclusion-token-budget
-         current-ws-evolution-enabled?)
+         current-ws-evolution-enabled?
+         compute-conclusion-budget)
 
 ;; Whether to enable state-aware assembly for the current task.
 (define current-task-state-aware-assembly? (make-parameter #f))
@@ -18,6 +19,17 @@
 
 ;; Token budget for conclusion generation.
 (define current-conclusion-token-budget (make-parameter 2000))
+
+;; GAP-8: Dynamic conclusion budget (ADR-0023)
+;; 10% of context window, capped at 4000 tokens, minimum 500.
+(define CONCLUSION-BUDGET-MAX 4000)
+(define CONCLUSION-BUDGET-MIN 500)
+(define CONCLUSION-BUDGET-FRACTION 0.10)
+
+(define (compute-conclusion-budget max-context-tokens)
+  (min CONCLUSION-BUDGET-MAX
+       (max CONCLUSION-BUDGET-MIN
+            (inexact->exact (floor (* max-context-tokens CONCLUSION-BUDGET-FRACTION))))))
 
 ;; Whether to enable working-set evolution.
 (define current-ws-evolution-enabled? (make-parameter #f))

--- a/runtime/context-assembly/ws-evolution.rkt
+++ b/runtime/context-assembly/ws-evolution.rkt
@@ -111,15 +111,21 @@
 ;; Like evolve-working-set-for-state but returns a structured result with
 ;; archived entries for append-only persistence.
 (define (evolve-working-set-for-state/result ws old-state new-state conclusions)
-  (define entries-before (working-set-entries ws))
-  (define injected (evolve-working-set-for-state ws old-state new-state conclusions))
-  (define entries-after (working-set-entries ws))
-  ;; Compute archived: entries present before but not after
-  (define after-paths
-    (for/set ([e (in-list entries-after)])
-      (ws-entry-path e)))
-  (define archived
-    (for/list ([e (in-list entries-before)]
-               #:when (not (set-member? after-paths (ws-entry-path e))))
-      e))
-  (evolution-result entries-after archived injected))
+  ;; GAP-5: Skip evolution when old-state equals new-state
+  (define old-name (state->name old-state))
+  (define new-name (state->name new-state))
+  (if (equal? old-name new-name)
+      #f ;; No evolution needed — same state
+      (let ()
+        (define entries-before (working-set-entries ws))
+        (define injected (evolve-working-set-for-state ws old-state new-state conclusions))
+        (define entries-after (working-set-entries ws))
+        ;; Compute archived: entries present before but not after
+        (define after-paths
+          (for/set ([e (in-list entries-after)])
+            (ws-entry-path e)))
+        (define archived
+          (for/list ([e (in-list entries-before)]
+                     #:when (not (set-member? after-paths (ws-entry-path e))))
+            e))
+        (evolution-result entries-after archived injected))))

--- a/runtime/session/session-config.rkt
+++ b/runtime/session/session-config.rkt
@@ -39,7 +39,8 @@
                   current-task-state-aware-assembly?
                   current-conclusion-token-budget
                   current-graph-conclusion-selection?
-                  current-ws-evolution-enabled?)
+                  current-ws-evolution-enabled?
+                  compute-conclusion-budget)
          (only-in "../context-assembly/auto-distillation.rkt" current-auto-distillation-enabled?)
          (only-in "../context-assembly/rollback-actions.rkt" current-rollback-action-execution?))
 
@@ -73,35 +74,35 @@
      (current-auto-distillation-enabled? #f)
      (current-rollback-action-execution? #f)
      (current-ws-evolution-enabled? #f)
-     (current-conclusion-token-budget 2000)]
+     (current-conclusion-token-budget (compute-conclusion-budget 8000))]
     [(observe)
      (current-task-state-aware-assembly? #t)
      (current-graph-conclusion-selection? #f)
      (current-auto-distillation-enabled? #f)
      (current-rollback-action-execution? #f)
      (current-ws-evolution-enabled? #f)
-     (current-conclusion-token-budget 2000)]
+     (current-conclusion-token-budget (compute-conclusion-budget 8000))]
     [(bounded)
      (current-task-state-aware-assembly? #t)
      (current-graph-conclusion-selection? #t)
      (current-auto-distillation-enabled? #f)
      (current-rollback-action-execution? #f)
      (current-ws-evolution-enabled? #f)
-     (current-conclusion-token-budget 2000)]
+     (current-conclusion-token-budget (compute-conclusion-budget 8000))]
     [(self-healing)
      (current-task-state-aware-assembly? #t)
      (current-graph-conclusion-selection? #t)
      (current-auto-distillation-enabled? #t)
      (current-rollback-action-execution? #t)
      (current-ws-evolution-enabled? #f)
-     (current-conclusion-token-budget 2000)]
+     (current-conclusion-token-budget (compute-conclusion-budget 8000))]
     [(full)
      (current-task-state-aware-assembly? #t)
      (current-graph-conclusion-selection? #t)
      (current-auto-distillation-enabled? #t)
      (current-rollback-action-execution? #t)
      (current-ws-evolution-enabled? #t)
-     (current-conclusion-token-budget 2000)]
+     (current-conclusion-token-budget (compute-conclusion-budget 8000))]
     [else (void)]))
 
 (provide session-config?


### PR DESCRIPTION
Closes #7594

GAP-5: Skip WS evolution when old-state = new-state
GAP-8: Dynamic budget = 10% context window, cap 4000, min 500