### PR TITLE
chore: v0.96.18 version bump + CHANGELOG (#7595)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.96.18] - 2026-06-08
+
+### Fixed
+- GAP-4: Graph seed resolution now maps WS message IDs to conclusion IDs via origin-message-ids
+- GAP-5: WS evolution only fires on actual state transitions (old ≠ new), eliminating redundant computation
+
+### Changed
+- GAP-8: Conclusion token budget is now dynamic — 10% of model context window, capped at 4000 tokens, minimum 500 (was hardcoded 2000)
+
 ## [0.96.17] - 2026-06-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.96.17-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.96.18-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.96.17")
+(define version "0.96.18")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base" "gui-easy-lib"))

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -11,4 +11,4 @@
 
 (provide (contract-out [q-version string?]))
 
-(define q-version "0.96.17")
+(define q-version "0.96.18")


### PR DESCRIPTION
Closes #7595

Version bump 0.96.17 → 0.96.18.