### PR TITLE
chore: v0.96.19 version bump + CHANGELOG (#7601)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.96.19] - 2026-06-08
+
+### Added
+- GAP-2: Semantic memory retrieval — rank-by-relevance uses embedding cosine similarity when provider configured (NEW: runtime/memory/embeddings.rkt)
+- GAP-7: LLM-powered reflection — merge-group-items uses injectable LLM synthesis via current-reflection-lln-fn
+- GAP-10: Conclusion-to-memory bridge — high-value decisions/patterns persisted as project-scoped memory on session end (NEW: runtime/memory/conclusion-bridge.rkt)
+
+### Changed
+- GAP-9: Sensitivity classification now uses regex patterns for API keys, tokens, passwords instead of substring matching
+
 ## [0.96.18] - 2026-06-08
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.96.18-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.96.19-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.96.18")
+(define version "0.96.19")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base" "gui-easy-lib"))

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -11,4 +11,4 @@
 
 (provide (contract-out [q-version string?]))
 
-(define q-version "0.96.18")
+(define q-version "0.96.19")


### PR DESCRIPTION
Closes #7601

Version bump 0.96.18 → 0.96.19.