### PR TITLE
release: v0.97.13 — Architecture Audit Remediation (Critical & High) (#7727)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## [0.97.13] - 2026-06-10
+
+### Fixed
+- C1: SDK struct-out → explicit provides in sdk-core.rkt, sdk-compat.rkt
+- H4: conclusion-graph mutable → immutable (for/fold patterns)
+- H5: Embedding cache thread safety (semaphore-guarded struct)
+- H1: rollback-actions config struct for snapshot/grouped access
+- H3a: Extracted wire-runtime-parameters! from run-modes (eliminates ~60% duplication)
+- H3b: Extracted LLM callback factories (make-distill-callback, make-reflection-callback)
+- H2a: Migrated ~44 with-handlers silent-swallow sites to with-safe-fallback (logs warnings)
+
 ## [0.97.12] - 2026-06-08
 
 ### Fixed

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.97.12")
+(define version "0.97.13")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base" "gui-easy-lib"))

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -11,4 +11,4 @@
 
 (provide (contract-out [q-version string?]))
 
-(define q-version "0.97.12")
+(define q-version "0.97.13")


### PR DESCRIPTION
Fixes #7727

Version bump 0.97.12 → 0.97.13.
Closes v0.97.13 milestone.