### PR TITLE
fix: ALL tool failures show actual error in TUI, not generic tool failed

### DIFF
--- a/agent/event-structs/tool-events.rkt
+++ b/agent/event-structs/tool-events.rkt
@@ -16,14 +16,21 @@
 ;; Tool execution lifecycle (typed-event parent)
 ;; ============================================================
 
-(define-typed-event tool-execution-start-event "tool.execution.started" (tool-name tool-call-id) #:schema-version 1)
+(define-typed-event tool-execution-start-event
+                    "tool.execution.started"
+                    (tool-name tool-call-id)
+                    #:schema-version 1)
 
-(define-typed-event tool-execution-update-event "tool.execution.updated" (tool-name progress) #:schema-version 1)
+(define-typed-event tool-execution-update-event
+                    "tool.execution.updated"
+                    (tool-name progress)
+                    #:schema-version 1)
 
 (define-typed-event tool-execution-end-event
                     "tool.execution.completed"
-                    (tool-name duration-ms result-summary)
-                    #:defaults (duration-ms 0) #:schema-version 1)
+                    (tool-name duration-ms result-summary result-error)
+                    #:defaults (duration-ms 0 result-error #f)
+                    #:schema-version 1)
 
 ;; ============================================================
 ;; Generic tool call/result (typed-event parent)
@@ -32,12 +39,14 @@
 (define-typed-event tool-call-event
                     "tool.called"
                     (tool-name arguments tool-call-id)
-                    #:defaults (arguments (hasheq)) #:schema-version 1)
+                    #:defaults (arguments (hasheq))
+                    #:schema-version 1)
 
 (define-typed-event tool-result-event
                     "tool.result"
                     (tool-call-id content is-error?)
-                    #:defaults (is-error? #f) #:schema-version 1)
+                    #:defaults (is-error? #f)
+                    #:schema-version 1)
 
 ;; ============================================================
 ;; Per-tool typed events (tool-call-event parent — manual)
@@ -239,4 +248,3 @@
 
 (define custom-tool-call-event-fields tool-call-event-fields)
 (register-event-fields! 'custom-tool-call-event custom-tool-call-event-fields)
-

--- a/browser/adapters/playwright-sidecar.rkt
+++ b/browser/adapters/playwright-sidecar.rkt
@@ -264,7 +264,8 @@
   ;; Adapter callback implementations
   (define (adapter-open session-id target)
     (define st (ensure-state))
-    (define data (send-command! st "navigate" (hasheq 'url target 'sessionId session-id)))
+    (define data
+      (send-command! st "navigate" (hasheq 'url target 'sessionId session-id) #:timeout-ms 30000))
     (data->obs data))
 
   (define (adapter-close session-id)
@@ -274,7 +275,8 @@
 
   (define (adapter-navigate session-id url)
     (define st (ensure-state))
-    (define data (send-command! st "navigate" (hasheq 'url url 'sessionId session-id)))
+    (define data
+      (send-command! st "navigate" (hasheq 'url url 'sessionId session-id) #:timeout-ms 30000))
     (data->obs data))
 
   (define (adapter-observe session-id selector)

--- a/runtime/tool-coordinator.rkt
+++ b/runtime/tool-coordinator.rkt
@@ -280,8 +280,23 @@
                                                                 (hash-ref per-tool-start-ms
                                                                           (tool-call-id tc)
                                                                           batch-start-ms))))
-                        #:result-summary (if (tool-result-is-error? tr) 'error 'completed))))
+                        #:result-summary (if (tool-result-is-error? tr) 'error 'completed)
+                        #:result-error (and (tool-result-is-error? tr) (tool-result-error-text tr)))))
   sched-result)
+
+;; Helper: extract error text from tool-result content for event propagation.
+;; Bug fix (v0.97.x): ALL tool failures showed "tool failed" because
+;; tool-execution-end-event had no error text field.
+(define (tool-result-error-text tr)
+  (define content (tool-result-content tr))
+  (cond
+    [(string? content) content]
+    [(pair? content)
+     (define first-part (car content))
+     (if (hash? first-part)
+         (or (hash-ref first-part 'text #f) (format "~a" content))
+         (format "~a" content))]
+    [else (format "~a" content)]))
 
 ;; Phase 3: Assembly (pure result construction)
 (define (assemble-tool-results-phase tool-calls

--- a/tests/test-browser-tools.rkt
+++ b/tests/test-browser-tools.rkt
@@ -82,10 +82,14 @@
               (check-equal? (hash-ref result 'status) "ok")
               (check-true (string? (hash-ref result 'session-id))))))
 
-(test-case "browser_open: blocked URL raises error"
+(test-case "browser_open: blocked URL returns error result"
   (with-svc (lambda ()
-              (check-exn q-browser-error?
-                         (lambda () (handle-browser-open (hasheq 'url "file:///etc/passwd")))))))
+              (define result (handle-browser-open (hasheq 'url "file:///etc/passwd")))
+              (check-true (tool-result-is-error? result))
+              (define content (tool-result-content result))
+              (check-true (string? (if (string? content)
+                                       content
+                                       (format "~a" content)))))))
 
 (test-case "browser_open: no service returns graceful error"
   (parameterize ([current-browser-service #f])
@@ -248,16 +252,17 @@
   (with-svc (lambda ()
               (define sid (hash-ref (open-session) 'session-id))
               (handle-browser-close (hasheq 'session-id sid))
-              (check-exn q-browser-error?
-                         (lambda () (handle-browser-observe (hasheq 'session-id sid)))))))
+              (define result (handle-browser-observe (hasheq 'session-id sid)))
+              (check-true (tool-result-is-error? result)))))
 
 (test-case "browser_open: missing URL raises error"
   (with-svc (lambda ()
               (check-exn exn:fail? (lambda () (handle-browser-open (hasheq 'session-id "s1")))))))
 
-(test-case "browser_observe: null session-id raises error"
+(test-case "browser_observe: null session-id returns error result"
   (with-svc (lambda ()
-              (check-exn exn:fail? (lambda () (handle-browser-observe (hasheq 'session-id #f)))))))
+              (define result (handle-browser-observe (hasheq 'session-id #f)))
+              (check-true (tool-result-is-error? result)))))
 
 (test-case "browser_check_local_app: returns status"
   (with-svc (lambda ()

--- a/tools/builtins/browser-tools.rkt
+++ b/tools/builtins/browser-tools.rkt
@@ -94,8 +94,9 @@
     [(not svc) (browser-not-configured-result)]
     [else
      (define url (hash-ref args 'url))
-     (define-values (sid obs) (browser-open! svc url #:options (hash-ref args 'options #f)))
-     (ok-result 'session-id sid 'observation (observation->hash obs))]))
+     (with-handlers ([q-browser-error? (lambda (e) (browser-error-result "browser_open" e))])
+       (define-values (sid obs) (browser-open! svc url #:options (hash-ref args 'options #f)))
+       (ok-result 'session-id sid 'observation (observation->hash obs)))]))
 
 (define (handle-browser-observe args [exec-ctx #f])
   (define svc (get-svc))
@@ -103,8 +104,9 @@
     [(not svc) (browser-not-configured-result)]
     [else
      (define sid (hash-ref args 'session-id))
-     (define obs (browser-observe! svc sid #:selector (hash-ref args 'selector #f)))
-     (ok-result 'observation (observation->hash obs))]))
+     (with-handlers ([q-browser-error? (lambda (e) (browser-error-result "browser_observe" e))])
+       (define obs (browser-observe! svc sid #:selector (hash-ref args 'selector #f)))
+       (ok-result 'observation (observation->hash obs)))]))
 
 (define (handle-browser-click args [exec-ctx #f])
   (define svc (get-svc))
@@ -142,8 +144,9 @@
      (define key (hash-ref args 'key))
      (define modifiers (hash-ref args 'modifiers '()))
      (define action (browser-action-press key modifiers))
-     (define obs (browser-act! svc sid action))
-     (ok-result 'observation (observation->hash obs))]))
+     (with-handlers ([q-browser-error? (lambda (e) (browser-error-result "browser_press" e))])
+       (define obs (browser-act! svc sid action))
+       (ok-result 'observation (observation->hash obs)))]))
 
 (define (handle-browser-extract args [exec-ctx #f])
   (define svc (get-svc))
@@ -153,18 +156,19 @@
      (define sid (hash-ref args 'session-id))
      (define selector (hash-ref args 'selector))
      (define extract-type (hash-ref args 'extract-type "text"))
-     (define obs (browser-observe! svc sid #:selector selector))
-     (make-success-result
-      (hasheq 'status
-              "ok"
-              'extract-type
-              extract-type
-              'data
-              (case (string->symbol extract-type)
-                [(text) (or (browser-observation-visible-text obs) "")]
-                [(html) (or (browser-observation-text-content obs) "")]
-                [(accessibility) (format "~a" (or (browser-observation-accessibility-tree obs) ""))]
-                [else (or (browser-observation-visible-text obs) "")])))]))
+     (with-handlers ([q-browser-error? (lambda (e) (browser-error-result "browser_extract" e))])
+       (define obs (browser-observe! svc sid #:selector selector))
+       (make-success-result
+        (hasheq 'status
+                "ok"
+                'extract-type
+                extract-type
+                'data
+                (case (string->symbol extract-type)
+                  [(text) (or (browser-observation-visible-text obs) "")]
+                  [(html) (or (browser-observation-text-content obs) "")]
+                  [(accessibility) (format "~a" (or (browser-observation-accessibility-tree obs) ""))]
+                  [else (or (browser-observation-visible-text obs) "")]))))]))
 
 (define (handle-browser-screenshot args [exec-ctx #f])
   (define svc (get-svc))
@@ -173,17 +177,18 @@
     [else
      (define sid (hash-ref args 'session-id))
      (define selector (hash-ref args 'selector #f))
-     (define obs (browser-screenshot! svc sid #:selector selector))
-     (define raw-bytes (browser-observation-screenshot-bytes obs))
-     ;; Base64-encode binary data for JSON-safe transport
-     (make-success-result (hasheq 'status
-                                  "ok"
-                                  'mime-type
-                                  (or (browser-observation-screenshot-mime obs) "image/png")
-                                  'data
-                                  (if (bytes? raw-bytes)
-                                      (bytes->base64-string raw-bytes)
-                                      (or raw-bytes ""))))]))
+     (with-handlers ([q-browser-error? (lambda (e) (browser-error-result "browser_screenshot" e))])
+       (define obs (browser-screenshot! svc sid #:selector selector))
+       (define raw-bytes (browser-observation-screenshot-bytes obs))
+       ;; Base64-encode binary data for JSON-safe transport
+       (make-success-result (hasheq 'status
+                                    "ok"
+                                    'mime-type
+                                    (or (browser-observation-screenshot-mime obs) "image/png")
+                                    'data
+                                    (if (bytes? raw-bytes)
+                                        (bytes->base64-string raw-bytes)
+                                        (or raw-bytes "")))))]))
 
 (define (handle-browser-scroll args [exec-ctx #f])
   (define svc (get-svc))
@@ -194,8 +199,9 @@
      (define direction (hash-ref args 'direction "down"))
      (define amount (hash-ref args 'amount 3))
      (define action (browser-action-scroll direction amount))
-     (define obs (browser-act! svc sid action))
-     (ok-result 'observation (observation->hash obs))]))
+     (with-handlers ([q-browser-error? (lambda (e) (browser-error-result "browser_scroll" e))])
+       (define obs (browser-act! svc sid action))
+       (ok-result 'observation (observation->hash obs)))]))
 
 (define (handle-browser-close args [exec-ctx #f])
   (define svc (get-svc))
@@ -203,14 +209,17 @@
     [(not svc) (browser-not-configured-result)]
     [else
      (define sid (hash-ref args 'session-id))
-     (browser-close! svc sid)
-     (ok-result 'session-id sid)]))
+     (with-handlers ([q-browser-error? (lambda (e) (browser-error-result "browser_close" e))])
+       (browser-close! svc sid)
+       (ok-result 'session-id sid))]))
 
 (define (handle-browser-check-local-app args [exec-ctx #f])
   (define svc (get-svc))
   (cond
     [(not svc) (browser-not-configured-result)]
     [else
-     ;; workflow.rkt returns a raw hash — sanitize binary, wrap in tool-result
-     (define raw-result (browser-check-local-app args))
-     (make-success-result (sanitize-binary-values raw-result))]))
+     (with-handlers ([q-browser-error? (lambda (e)
+                                         (browser-error-result "browser_check_local_app" e))])
+       ;; workflow.rkt returns a raw hash — sanitize binary, wrap in tool-result
+       (define raw-result (browser-check-local-app args))
+       (make-success-result (sanitize-binary-values raw-result)))]))

--- a/tui/state-events/core-handlers.rkt
+++ b/tui/state-events/core-handlers.rkt
@@ -124,7 +124,7 @@
   (define result-summary
     (hash-ref payload 'resultSummary (lambda () (if (hash-ref payload 'error #f) 'error 'completed))))
   (define result-raw (hash-ref payload 'result #f))
-  (define error-raw (hash-ref payload 'error #f))
+  (define error-raw (or (hash-ref payload 'resultError #f) (hash-ref payload 'error #f)))
   (define ts (event-time evt))
   (if (recent-tool-end? state name)
       (set-pending-tool-name state #f)


### PR DESCRIPTION
Fixes the universal bug where ALL tool failures (edit, browser, bash, write, etc.) showed generic "tool failed" instead of the actual error message in the TUI.

Root causes:
1. tool-execution-end-event had no error text field
2. TUI handler always fell back to "tool failed"
3. 7/9 browser handlers missing with-handlers
4. Navigate timeout mismatch (10s Racket vs 30s JS)