### PR TITLE
refactor(M9): parameter naming + MAX-STREAM-CHUNKS → define (#7733+7734)

### DIFF
--- a/agent/stream-reducer.rkt
+++ b/agent/stream-reducer.rkt
@@ -15,7 +15,7 @@
 ;; Configurable chunk limit (v0.12.3 Wave 0.1)
 ;; ============================================================
 
-(define MAX-STREAM-CHUNKS (make-parameter 10000))
+(define MAX-STREAM-CHUNKS 10000)
 
 (provide classify-chunk
          chunk-has-data?

--- a/agent/stream-runner.rkt
+++ b/agent/stream-runner.rkt
@@ -67,7 +67,7 @@
 
   (define stream-gen (provider-stream provider req))
   (define chunk-count (box 0))
-  (define limit (MAX-STREAM-CHUNKS))
+  (define limit MAX-STREAM-CHUNKS)
   (define received-done? (box #f))
 
   ;; Error boundary — emit cleanup events on provider crash.

--- a/llm/gemini.rkt
+++ b/llm/gemini.rkt
@@ -49,17 +49,17 @@
 ;; Per-request tool call ID counter (Issue #200)
 ;; Parameter justified: thread-local isolation via `parameterize` in stream/send calls;
 ;; concurrent requests must not share or collide on IDs.
-(define gemini-tool-id-counter-param (make-parameter 0))
+(define current-gemini-tool-id-counter (make-parameter 0))
 
 ;; Generate a unique tool call ID within the current request.
 (define (gemini-gen-tool-id)
-  (define next (add1 (gemini-tool-id-counter-param)))
-  (gemini-tool-id-counter-param next)
+  (define next (add1 (current-gemini-tool-id-counter)))
+  (current-gemini-tool-id-counter next)
   (format "gemini_~a" next))
 
 ;; Reset the parameter for a fresh request.
 (define (gemini-reset-tool-id-counter!)
-  (gemini-tool-id-counter-param 0))
+  (current-gemini-tool-id-counter 0))
 
 ;; ============================================================
 ;; Request body construction
@@ -297,7 +297,7 @@
         #f))
 
   ;; Emit text/tool deltas from parts
-  ;; Tool calls use a running index from gemini-tool-id-counter-param
+  ;; Tool calls use a running index from current-gemini-tool-id-counter
   ;; so that multiple functionCalls across SSE chunks get distinct indices.
   ;; The counter starts at 0 and is incremented by gemini-gen-tool-id.
   (for ([part (in-list parts)])
@@ -309,7 +309,7 @@
       [(hash-has-key? part 'functionCall)
        (let* ([fc (hash-ref part 'functionCall)]
               [tc-id (gemini-gen-tool-id)]
-              [tc-index (sub1 (gemini-tool-id-counter-param))]
+              [tc-index (sub1 (current-gemini-tool-id-counter))]
               [tc-delta
                (hasheq
                 'index
@@ -373,7 +373,7 @@
     (define body (gemini-build-request-body merged-req))
     (define model-name (hash-ref (model-request-settings merged-req) 'model default-model))
     ;; Bind per-request counter (Issue #200)
-    (parameterize ([gemini-tool-id-counter-param 0])
+    (parameterize ([current-gemini-tool-id-counter 0])
       (define raw (gemini-do-http-request base-url api-key model-name body))
       (gemini-parse-response raw)))
 
@@ -439,7 +439,7 @@
          (define resp-body (read-response-body/timeout response-port))
          (check-provider-status! "Gemini" status-line resp-body))
        ;; Bind per-request counter (Issue #200)
-       (parameterize ([gemini-tool-id-counter-param 0])
+       (parameterize ([current-gemini-tool-id-counter 0])
          ;; Incremental SSE parsing — generator yields chunks one at a time
          (define raw-port response-port)
          (log-stream-setup-timing "gemini" _stream-t0)

--- a/runtime/safe-mode.rkt
+++ b/runtime/safe-mode.rkt
@@ -31,20 +31,19 @@
 ;; Re-export everything from safe-mode-state
 ;; ============================================================
 
-(provide (contract-out
-          [current-safe-mode (parameter/c boolean?)]
-          [current-safe-mode-config (parameter/c (or/c safe-mode-config? #f))]
-          [project-root (parameter/c path?)]
-          [safe-mode? (-> boolean?)]
-          [allowed-tool? (-> string? boolean?)]
-          [allowed-path? (-> (or/c path? string?) boolean?)]
-          [safe-mode-project-root (-> path?)]
-          [trust-level (-> (or/c 'full 'restricted))]
-          [safe-mode-active! (-> void?)]
-          [safe-mode-deactivate! (-> void?)]
-          [lock-safe-mode! (-> void?)]
-          [safe-mode-locked? (parameter/c boolean?)]
-          [safe-mode-config-info (-> hash?)])
+(provide (contract-out [current-safe-mode (parameter/c boolean?)]
+                       [current-safe-mode-config (parameter/c (or/c safe-mode-config? #f))]
+                       [project-root (parameter/c path?)]
+                       [safe-mode? (-> boolean?)]
+                       [allowed-tool? (-> string? boolean?)]
+                       [allowed-path? (-> (or/c path? string?) boolean?)]
+                       [safe-mode-project-root (-> path?)]
+                       [trust-level (-> (or/c 'full 'restricted))]
+                       [safe-mode-active! (-> void?)]
+                       [safe-mode-deactivate! (-> void?)]
+                       [lock-safe-mode! (-> void?)]
+                       [current-safe-mode-locked? (parameter/c boolean?)]
+                       [safe-mode-config-info (-> hash?)])
          ;; Struct type + contracted accessors (re-exported from safe-mode-state.rkt)
          safe-mode-config
          safe-mode-config?
@@ -63,13 +62,13 @@
 (define safe-mode-lock-one-shot (box #f))
 ;; Parameter justified: tests use `parameterize` for isolation;
 ;; production sets #t once on lock activation.
-(define safe-mode-locked? (make-parameter #f))
+(define current-safe-mode-locked? (make-parameter #f))
 
 (define (locked?)
   (define cfg (current-safe-mode-config))
   (cond
     [(safe-mode-config? cfg) (safe-mode-config-locked cfg)]
-    [else (or (unbox safe-mode-lock-one-shot) (safe-mode-locked?))]))
+    [else (or (unbox safe-mode-lock-one-shot) (current-safe-mode-locked?))]))
 
 ;; ============================================================
 ;; Actions
@@ -97,7 +96,7 @@
 
 (define (lock-safe-mode!)
   (set-box! safe-mode-lock-one-shot #t)
-  (safe-mode-locked? #t))
+  (current-safe-mode-locked? #t))
 
 ;; ============================================================
 ;; Introspection

--- a/tui/tui-render-loop.rkt
+++ b/tui/tui-render-loop.rkt
@@ -59,7 +59,7 @@
          (only-in "render-loop/watchdog.rkt" current-busy-watchdog-ms check-busy-watchdog))
 
 (define (tui-output-port)
-  (or (guarded-real-output-port) (current-output-port)))
+  (or (current-guarded-real-output-port) (current-output-port)))
 
 ;; ── Ubuf/terminal lifecycle ──
 (provide fix-sgr-bg-black

--- a/util/error/output-guard.rkt
+++ b/util/error/output-guard.rkt
@@ -13,7 +13,7 @@
 (require racket/contract)
 
 ;; Parameter
-(provide guarded-real-output-port
+(provide current-guarded-real-output-port
          ;; Macro
          with-output-guard
          ;; Guarded functions
@@ -27,7 +27,7 @@
 
 ;; Holds the real terminal output port while the guard is active.
 ;; #f when guard is not active.
-(define guarded-real-output-port (make-parameter #f))
+(define current-guarded-real-output-port (make-parameter #f))
 
 ;; ============================================================
 ;; Output guard
@@ -38,12 +38,12 @@
   (open-output-nowhere))
 
 ;; Call `thunk` with current-output-port redirected to a null sink.
-;; The real terminal port is available via (guarded-real-output-port).
+;; The real terminal port is available via (current-guarded-real-output-port).
 (define (call-with-output-guard thunk #:redirect-to [redirect-port #f])
   (define real-port (current-output-port))
   (define sink (or redirect-port (make-null-sink)))
   (parameterize ([current-output-port sink]
-                 [guarded-real-output-port real-port])
+                 [current-guarded-real-output-port real-port])
     (thunk)))
 
 ;; Macro form
@@ -59,7 +59,7 @@
 ;; Call `thunk` with the real terminal output port restored.
 ;; Use this for intentional TUI rendering writes.
 (define (call-with-raw-output thunk)
-  (define real-port (guarded-real-output-port))
+  (define real-port (current-guarded-real-output-port))
   (if real-port
       (parameterize ([current-output-port real-port])
         (thunk))


### PR DESCRIPTION
v0.97.14 W4+W5 — Rename production parameters to current- prefix. Convert MAX-STREAM-CHUNKS to define constant. Skipped M8 (Racket phase limitation).