### PR TITLE
fix: browser tool results blow up context window (4 bugs)

### DIFF
--- a/agent/loop-messages.rkt
+++ b/agent/loop-messages.rkt
@@ -210,7 +210,7 @@
                     'tool_call_id
                     (tool-result-part-tool-call-id p)
                     'content
-                    (result-content->string (tool-result-part-content p))))]
+                    (result-content->string (tool-result-part-content p) #:handle-hash? #t)))]
 
          ;; fallback -- unknown role
          [else

--- a/agent/loop-phases.rkt
+++ b/agent/loop-phases.rkt
@@ -28,6 +28,7 @@
                   make-model-request-blocked-event
                   make-message-blocked-event
                   make-turn-end-event)
+         (only-in "event-structs/context-pressure-events.rkt" make-context-pressure-event)
          (only-in "turn-reducer.rkt" decide-after-pre-hook decide-after-msg-hook decide-after-stream)
          (only-in "turn-model.rkt"
                   make-stream-completion
@@ -121,9 +122,24 @@
                         #:timestamp (current-inexact-milliseconds)
                         #:token-count token-count
                         #:window-size (length raw-messages)))
+  ;; Bug fix (v0.97.x): also emit context.pressure per iteration turn.
+  ;; Without this, TUI shows stale ctx:1% from initial prompt while context
+  ;; grows to 91K tokens from browser screenshot results.
+  (define ctx-window-size 128000) ;; conservative default; providers override
+  (define usage-pct (* 100.0 (/ token-count ctx-window-size)))
+  (define pressure-event
+    (make-context-pressure-event #:session-id session-id
+                                 #:turn-id turn-id
+                                 #:timestamp (current-inexact-milliseconds)
+                                 #:level (cond
+                                           [(>= usage-pct 80) 'red]
+                                           [(>= usage-pct 60) 'yellow]
+                                           [else 'green])
+                                 #:usage-percent usage-pct))
   ;; Return effect instead of emitting directly (purity fix W2-T1)
   (define effects
     (list (effect:emit-event 'context ctx-event)
+          (effect:emit-event 'context pressure-event)
           (effect:update-fsm turn-state-build-context turn-event-context-built)))
   (values raw-messages effects))
 

--- a/runtime/context-assembly/session-walk.rkt
+++ b/runtime/context-assembly/session-walk.rkt
@@ -21,6 +21,8 @@
                   make-message)
          (only-in "../../util/entry-predicates.rkt" compaction-summary-entry?)
          (only-in "../../util/content/content-parts.rkt" text-part text-part? text-part-text)
+         (only-in "../../util/content/content-parts.rkt" tool-result-part? tool-result-part-content)
+         (only-in "../../util/content/content-helpers.rkt" result-content->string)
          (only-in "../session-index.rkt" active-leaf get-branch))
 
 (provide build-session-context
@@ -73,10 +75,16 @@
 
 (define (summarize-tool-result entry)
   (define content (message-content entry))
+  ;; Bug fix: also extract text from tool-result-part (browser screenshot, etc.)
+  ;; Without this, large binary/hash tool results bypass truncation entirely.
   (define text
     (string-join (for/list ([part (in-list content)]
-                            #:when (text-part? part))
-                   (text-part-text part))
+                            #:when (or (text-part? part) (tool-result-part? part)))
+                   (cond
+                     [(text-part? part) (text-part-text part)]
+                     [(tool-result-part? part)
+                      (result-content->string (tool-result-part-content part) #:handle-hash? #t)]
+                     [else ""]))
                  "\n"))
   (cond
     [(<= (string-length text) MAX-TOOL-RESULT-CHARS) entry]

--- a/util/content/content-helpers.rkt
+++ b/util/content/content-helpers.rkt
@@ -16,10 +16,29 @@
 ;; Convert result content to a string for the API.
 ;; Content may be a list of content-part hashes, plain strings, or nested data.
 ;; When #:handle-hash? is #t, top-level hashes are unwrapped (used by tool-result variant).
+(define MAX-CONTENT-STRING-LEN 4000)
+
 (define (result-content->string content #:handle-hash? [handle-hash? #f])
   (cond
     [(string? content) content]
-    [(and handle-hash? (hash? content)) (hash-ref content 'text (format "~a" content))]
+    [(and handle-hash? (hash? content))
+     ;; Bug fix: guard against binary/base64 data (browser screenshots, etc.)
+     ;; Without this, a 270K base64 string gets dumped verbatim into the API context.
+     (cond
+       [(hash-has-key? content 'data)
+        (define mime (hash-ref content 'mime-type "unknown"))
+        (define data-len
+          (let ([d (hash-ref content 'data #f)])
+            (if (string? d)
+                (string-length d)
+                0)))
+        (format "[binary ~a data: ~a bytes]" mime data-len)]
+       [(hash-has-key? content 'text) (hash-ref content 'text)]
+       [else
+        (let ([s (format "~a" content)])
+          (if (> (string-length s) MAX-CONTENT-STRING-LEN)
+              (format "[truncated hash content: ~a chars]" (string-length s))
+              s))])]
     [(list? content)
      (string-join (for/list ([part (in-list content)])
                     (cond


### PR DESCRIPTION
Fixes ANALYSIS-SESSION-01KTSFCEBBV9NFT6Z7WY167P4H.

4 bugs:
1. summarize-tool-result ignores tool-result-part (truncation bypassed)
2. build-raw-messages missing #:handle-hash? #t (270K base64 dumped)
3. result-content->string no binary guard
4. context.pressure not emitted per iteration turn (stale ctx:1%)