### PR TITLE
chore: v0.97.14 version bump + CHANGELOG + deprecation (#7735)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,28 @@
+## [0.97.14] - 2026-06-10
+
+### Fixed
+- Bug fix: ALL tool failures now show actual error in TUI instead of generic "tool failed"
+  - Added result-error field to tool-execution-end-event (event layer)
+  - Extract error text from tool-result in tool-coordinator (runtime layer)
+  - TUI reads result-error from event payload (presentation layer)
+  - Added with-handlers to all 8 browser tool handlers (error wrapping)
+  - Increased navigate timeout from 10s to 30s (timeout mismatch)
+- Bug fix: browser_screenshot blows up context window (4 root causes)
+  - summarize-tool-result ignores tool-result-part (truncation bypassed)
+  - build-raw-messages missing #:handle-hash? (270K base64 dumped verbatim)
+  - result-content->string has no binary/base64 guard
+  - context.pressure only emitted once per prompt (stale ctx:1% in TUI)
+- M1: Tighten step-interpreter any/c contracts (9 replacements)
+- M2: browser/types.rkt struct-out → explicit provides (11 structs)
+- M3: gsd/plan-types.rkt struct-out → explicit provides (7 structs)
+- M4: all-from-out → explicit provides in 5 facade modules (~12 replacements)
+- M9: Parameter naming convention (3 renames to current- prefix)
+- M9: MAX-STREAM-CHUNKS converted from make-parameter to define constant
+- H6: Deprecated legacy global GSD state-machine API (4 functions)
+
+### Skipped
+- M8: field->json-key duplication — Racket phase system requires separate runtime/compile-time implementations
+
 ## [0.97.13] - 2026-06-10
 
 ### Fixed

--- a/extensions/gsd/state-machine.rkt
+++ b/extensions/gsd/state-machine.rkt
@@ -179,6 +179,7 @@
 ;; Core API — now backed by session-state parameters
 ;; ============================================================
 
+#| DEPRECATED — use gsm-ctx-* with explicit context instead. Will be removed in v1.0.0. |#
 (define (gsm-current)
   (gsm-ctx-current gsd-default-ctx))
 
@@ -329,6 +330,7 @@
 ;; Wave state accessors — now backed by session-state parameters
 ;; ============================================================
 
+#| DEPRECATED — use gsm-ctx-* with explicit context instead. Will be removed in v1.0.0. |#
 (define (gsm-wave-executor)
   (gsm-ctx-wave-executor gsd-default-ctx))
 
@@ -341,6 +343,7 @@
 (define (gsm-set-total-waves! n)
   (gsm-ctx-set-total-waves! gsd-default-ctx n))
 
+#| DEPRECATED — use gsm-ctx-* with explicit context instead. Will be removed in v1.0.0. |#
 (define (gsm-current-wave)
   (gsm-ctx-current-wave gsd-default-ctx))
 
@@ -353,6 +356,7 @@
 (define (gsm-mark-wave-complete! idx)
   (gsm-ctx-mark-wave-complete! gsd-default-ctx idx))
 
+#| DEPRECATED — use gsm-ctx-* with explicit context instead. Will be removed in v1.0.0. |#
 (define (gsm-wave-complete? idx)
   (set-member? (gsm-completed-waves) idx))
 

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.97.13")
+(define version "0.97.14")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base" "gui-easy-lib"))

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -11,4 +11,4 @@
 
 (provide (contract-out [q-version string?]))
 
-(define q-version "0.97.13")
+(define q-version "0.97.14")


### PR DESCRIPTION
v0.97.14 W6 — Version bump 0.97.13 → 0.97.14. Deprecation comments on legacy GSD functions. Full CHANGELOG entry.