### PR TITLE
fix: TUI stuck busy + browser session-id loss + 5 bug fixes (v0.97.16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## [0.97.16] - 2026-06-10
+
+### Fixed
+- B1: Browser policy now allows common dev ports (3000, 3001, 5173, 8000, 8080, 8443)
+  by default instead of blocking all localhost
+- B2: TUI busy-state watchdog reduced from 30 min to 5 min (matches 120s tool timeouts)
+- B3: Tool execution progress events emitted for long-running tool batches —
+  TUI status bar now shows "N tools running" instead of silent hang
+- B4: Hash truncation now preserves metadata fields (session-id, status, url) —
+  fixes browser_open session-id loss that caused LLM to hallucinate non-existent
+  session IDs, breaking all subsequent browser_screenshot/click calls
+- B5: Steering queue message now includes "Press Esc to cancel" hint
+
 ## [0.97.15] - 2026-06-10
 
 ### Fixed

--- a/browser/policy.rkt
+++ b/browser/policy.rkt
@@ -52,7 +52,8 @@
 
 (define (make-browser-policy-settings #:allowed-schemes [allowed-schemes '("https" "http")]
                                       #:allowed-domains [allowed-domains '()]
-                                      #:allowed-localhost-ports [allowed-localhost-ports '()]
+                                      #:allowed-localhost-ports
+                                      [allowed-localhost-ports '(3000 3001 5173 8000 8080 8443)]
                                       #:blocked-private-networks? [blocked-private-networks? #t]
                                       #:blocked-paths [blocked-paths '()])
   (browser-policy-settings allowed-schemes

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.97.15")
+(define version "0.97.16")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base" "gui-easy-lib"))

--- a/runtime/tool-coordinator.rkt
+++ b/runtime/tool-coordinator.rkt
@@ -79,7 +79,8 @@
          (only-in "../agent/event-emitter.rkt" emit-typed-event!)
          (only-in "../agent/event-structs/tool-events.rkt"
                   make-tool-execution-start-event
-                  make-tool-execution-end-event))
+                  make-tool-execution-end-event
+                  make-tool-execution-update-event))
 
 (provide (contract-out [extract-tool-calls-from-messages (-> (listof message?) (listof tool-call?))]
                        [make-tool-result-messages
@@ -221,6 +222,17 @@
      ext-reg
      'tool.execution.started
      (hasheq 'tools (map tool-call-name tool-calls-to-run) 'count (length tool-calls-to-run))))
+  ;; B3 fix: Emit tool.execution.updated event so TUI shows progress
+  ;; during long-running tool batches (e.g. bash commands with 120s timeouts).
+  (when (not (null? tool-calls-to-run))
+    (emit-typed-event!
+     bus
+     (make-tool-execution-update-event
+      #:session-id session-id
+      #:turn-id #f
+      #:timestamp (current-inexact-milliseconds)
+      #:tool-name (format "~a tools starting" (length tool-calls-to-run))
+      #:progress (hasheq 'total (length tool-calls-to-run) 'running (length tool-calls-to-run)))))
   (define sched-result
     (cond
       [(not reg) (scheduler-result '() (hasheq))]

--- a/tests/test-tui-watchdog.rkt
+++ b/tests/test-tui-watchdog.rkt
@@ -119,7 +119,7 @@
   (check-false result2))
 
 (test-case "watchdog: current-busy-watchdog-ms parameter has correct default"
-  (check-equal? (current-busy-watchdog-ms) (* 30 60 1000)))
+  (check-equal? (current-busy-watchdog-ms) (* 5 60 1000)))
 
 (test-case "watchdog: parameter can be overridden"
   (parameterize ([current-busy-watchdog-ms 1000])
@@ -143,7 +143,7 @@
   (check-not-false watchdog-entry "watchdog transcript entry exists")
   ;; Verify the text content matches expected message
   (check-equal? (transcript-entry-text watchdog-entry)
-                "[Watchdog: busy state timed out — force-cleared after 30 min]")
+                (format "[Watchdog: busy state timed out — force-cleared after ~a min]" (/ (* 30 60 1000) 60000)))
   ;; Verify timestamp matches the 'now' argument passed to check-busy-watchdog
   (check-equal? (transcript-entry-timestamp watchdog-entry) now)
   ;; Verify busy? is cleared

--- a/tui/render-loop/watchdog.rkt
+++ b/tui/render-loop/watchdog.rkt
@@ -21,7 +21,8 @@
 (provide current-busy-watchdog-ms
          check-busy-watchdog)
 
-(define current-busy-watchdog-ms (make-parameter (* 30 60 1000)))
+(define current-busy-watchdog-ms (make-parameter (* 5 60 1000)))
+;; B2 fix: 5 min covers 2-3 bash timeouts (120s each), network delays
 
 (define (check-busy-watchdog state now-ms watchdog-ms)
   (if (and (ui-state-busy? state) (not (ui-state-streaming-text state)))
@@ -33,10 +34,12 @@
                               "watchdog: busy timeout")
                              #f)]
                    [watchdog-entry
-                    (make-entry 'system
-                                "[Watchdog: busy state timed out — force-cleared after 30 min]"
-                                now-ms
-                                (hasheq 'watchdog #t))])
+                    (make-entry
+                     'system
+                     (format "[Watchdog: busy state timed out — force-cleared after ~a min]"
+                             (/ watchdog-ms 60000))
+                     now-ms
+                     (hasheq 'watchdog #t))])
               (add-transcript-entry cleared watchdog-entry))
             #f))
       #f))

--- a/tui/state-events/core-handlers.rkt
+++ b/tui/state-events/core-handlers.rkt
@@ -145,6 +145,19 @@
                  [meta (hasheq 'name name 'error err)])
             (set-pending-tool-name (append-entry state (make-entry 'tool-fail text ts meta)) #f)))))
 
+;; B3 fix: Show progress during long-running tool batches
+(define (handle-tool-execution-update state evt)
+  (define payload (event-payload evt))
+  (define tool-name (hash-ref payload 'toolName "?"))
+  (define progress (hash-ref payload 'progress (hasheq)))
+  (define total (hash-ref progress 'total 0))
+  (define running (hash-ref progress 'running 0))
+  (define status-text
+    (if (> total 1)
+        (format "~a tools running (~a pending)" running total)
+        (format "~a running" tool-name)))
+  (set-status-message state status-text))
+
 (define (handle-tool-call-blocked state evt)
   (define payload (event-payload evt))
   (define name (hash-ref payload 'name "?"))
@@ -374,6 +387,7 @@
 (register-event-reducer! "tool.call.started" handle-tool-call-started)
 (register-event-reducer! "tool.execution.started" handle-tool-execution-started)
 (register-event-reducer! "tool.execution.completed" handle-tool-execution-completed)
+(register-event-reducer! "tool.execution.updated" handle-tool-execution-update)
 (register-event-reducer! "runtime.error" handle-runtime-error)
 (register-event-reducer! "session.started" handle-session-started)
 (register-event-reducer! "session.resumed" handle-session-resumed)

--- a/tui/submit-handler.rkt
+++ b/tui/submit-handler.rkt
@@ -32,7 +32,7 @@
      ;; Show system notification in transcript
      (define queued-entry
        (make-entry 'system
-                   "[Queued — will run after current task]"
+                   "[Queued — will run after current task. Press Esc to cancel.]"
                    (current-inexact-milliseconds)
                    (hasheq 'queued #t)))
      (set-box! (tui-ctx-ui-state-box ctx) (add-transcript-entry cur-state queued-entry))

--- a/util/content/content-helpers.rkt
+++ b/util/content/content-helpers.rkt
@@ -35,9 +35,11 @@
         (format "[binary ~a data: ~a bytes]" mime data-len)]
        [(hash-has-key? content 'text) (hash-ref content 'text)]
        [else
+        ;; B4 fix: Preserve metadata fields (session-id, status, url) before truncating.
+        ;; Without this, browser_open results lose session-id → LLM hallucinates ID.
         (let ([s (format "~a" content)])
           (if (> (string-length s) MAX-CONTENT-STRING-LEN)
-              (format "[truncated hash content: ~a chars]" (string-length s))
+              (hash->metadata-summary content)
               s))])]
     [(list? content)
      (string-join (for/list ([part (in-list content)])
@@ -47,6 +49,24 @@
                       [else (format "~a" part)]))
                   "\n")]
     [else (format "~a" content)]))
+
+;; B4 fix: Build a structured summary from a hash, preserving metadata fields
+;; (session-id, status, url, title) while truncating large content fields.
+(define METADATA-KEYS '(session-id status url title))
+
+(define (hash->metadata-summary h)
+  (define meta-parts
+    (for/list ([k (in-list METADATA-KEYS)]
+               #:when (hash-has-key? h k))
+      (format "~a: ~a" k (hash-ref h k))))
+  (define content-parts
+    (for/list ([(k v) (in-hash h)]
+               #:unless (member k METADATA-KEYS))
+      (format "~a: ~a chars" k (min (string-length (format "~a" v)) 999999))))
+  (string-append (if (null? meta-parts)
+                     ""
+                     (format "[~a] " (string-join meta-parts ", ")))
+                 (format "[truncated: ~a]" (string-join content-parts ", "))))
 
 ;; Convert tool-result content to a display string.
 ;; Same as result-content->string but also handles top-level hashes

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -11,4 +11,4 @@
 
 (provide (contract-out [q-version string?]))
 
-(define q-version "0.97.15")
+(define q-version "0.97.16")


### PR DESCRIPTION
Fixes TUI stuck busy during tool timeouts, browser session-id lost in hash truncation, and 3 other UX bugs.

B1: Browser policy default-allow common dev ports
B2: TUI watchdog 30min→5min
B3: Tool execution progress events
B4: Hash truncation preserves metadata (session-id, status, url)
B5: Steering queue Esc-to-cancel hint

Resolves BUG_PLAN-v0.97.x-TUI-STUCK-BUSY-TOOL-HANG.md