### PR TITLE
chore: version bump 0.98.0 + CHANGELOG (#7798)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,18 @@
 - F14 (event wiring table): 6 subscribers in 1 file doesn't justify table abstraction
 - F16 (defaults consolidation): Parameters well-scoped to domains
 
+## [0.98.0] — 2026-06-10
+
+### Browser Robustness
+
+- **Sidecar auto-recovery**: `send-command-with-recovery!` retries up to 2 times on sidecar crash with automatic restart (#7795)
+- **Crypto-quality session IDs**: Session IDs generated with `crypto-random-bytes` instead of `current-milliseconds` + `random` (#7797)
+- **Screenshot size enforcement**: `enforce-screenshot-max-bytes` truncates oversized screenshots per `screenshot-max-bytes` setting (#7796)
+- **Session manager thread safety**: Semaphore-wrapped mutations prevent concurrent access corruption (#7796)
+- **Workflow try/finally**: `browser-check-local-app` uses `dynamic-wind` to guarantee session cleanup on errors (#7797)
+- **UUID tests**: 6 new tests for sidecar recovery, UUID format/uniqueness/crypto-quality
+
+
 ## [0.97.18] - 2026-06-10
 
 ### Changed

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.97.19")
+(define version "0.98.0")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base" "gui-easy-lib"))

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -11,4 +11,4 @@
 
 (provide (contract-out [q-version string?]))
 
-(define q-version "0.97.19")
+(define q-version "0.98.0")


### PR DESCRIPTION
W3 of v0.98.0: Version bump.