### PR TITLE
feat(llm): W4 cross-provider vision — GAP-V1, GAP-V2 (#7830)

### DIFF
--- a/extensions/image-pipeline.rkt
+++ b/extensions/image-pipeline.rkt
@@ -5,6 +5,9 @@
 ;; Subprocess-based image resizing for multimodal LLM input.
 ;; SECURITY: All subprocess calls use argv lists (never shell strings).
 ;; Tool paths resolved via find-executable-path. No shell injection possible.
+;;
+;; GAP-V2 (v0.99.x): This resize pipeline is not yet wired to browser screenshots.
+;; Future work: decode base64 → bytes → resize → re-encode → inject into context.
 
 (require racket/file
          racket/path
@@ -44,7 +47,7 @@
 
 (define (delete-file* p)
   (with-handlers ([exn:fail? (lambda (e)
-                              (log-debug "image-pipeline: delete-file failed: ~a" (exn-message e)))])
+                               (log-debug "image-pipeline: delete-file failed: ~a" (exn-message e)))])
     (when (file-exists? p)
       (delete-file p))))
 
@@ -97,11 +100,13 @@
   (close-output-port stdin-out)
   (define timeout-thread
     (and timeout-secs
-         (thread (lambda ()
-                   (sleep timeout-secs)
-                   (with-handlers ([exn:fail? (lambda (e)
-                                               (log-debug "image-pipeline: subprocess-kill failed: ~a" (exn-message e)))])
-                     (subprocess-kill sp #t))))))
+         (thread
+          (lambda ()
+            (sleep timeout-secs)
+            (with-handlers ([exn:fail? (lambda (e)
+                                         (log-debug "image-pipeline: subprocess-kill failed: ~a"
+                                                    (exn-message e)))])
+              (subprocess-kill sp #t))))))
   (subprocess-wait sp)
   (when timeout-thread
     (kill-thread timeout-thread))
@@ -213,7 +218,8 @@
        (thread (lambda ()
                  (sleep (image-metadata-timeout))
                  (with-handlers ([exn:fail? (lambda (e)
-                                             (log-debug "image-pipeline: ffmpeg kill failed: ~a" (exn-message e)))])
+                                              (log-debug "image-pipeline: ffmpeg kill failed: ~a"
+                                                         (exn-message e)))])
                    (subprocess-kill sp #t)))))
      (subprocess-wait sp)
      (kill-thread timeout-thread)

--- a/llm/anthropic.rkt
+++ b/llm/anthropic.rkt
@@ -48,6 +48,29 @@
 ;; Request body construction
 ;; ============================================================
 
+;; ============================================================
+;; Image block conversion (GAP-V1: cross-provider vision)
+;; ============================================================
+
+;; Parse a data URL "data:<mime>;base64,<data>" and return (values mime data)
+(define (parse-data-url url)
+  (define m (regexp-match #rx"^data:([^;]+);base64,(.*)$" url))
+  (if m
+      (values (cadr m) (caddr m))
+      (values "image/png" url)))
+
+;; Convert OpenAI-format content blocks to Anthropic content blocks.
+(define (openai-block->anthropic block)
+  (define btype (hash-ref block 'type "text"))
+  (cond
+    [(equal? btype "text") block]
+    [(equal? btype "image_url")
+     (define image-url-hash (hash-ref block 'image_url (hasheq)))
+     (define url (hash-ref image-url-hash 'url ""))
+     (define-values (mime data) (parse-data-url url))
+     (hasheq 'type "image" 'source (hasheq 'type "base64" 'media_type mime 'data data))]
+    [else block]))
+
 ;; Convert normalized model-request to Anthropic Messages API body.
 (define (anthropic-build-request-body req #:stream? [stream? #f])
   (define settings (model-request-settings req))
@@ -78,6 +101,13 @@
           "user"
           'content
           (list (hasheq 'type "tool_result" 'tool_use_id tool-call-id 'content tool-result-content)))]
+        ;; User with list content (text + images) (GAP-V1)
+        [(and (equal? role "user") (list? content))
+         (hasheq 'role
+                 role
+                 'content
+                 (for/list ([block (in-list content)])
+                   (openai-block->anthropic block)))]
         ;; Assistant with list content (tool calls)
         [(and (equal? role "assistant") (list? content))
          (hasheq 'role

--- a/llm/gemini.rkt
+++ b/llm/gemini.rkt
@@ -65,6 +65,29 @@
 ;; Request body construction
 ;; ============================================================
 
+;; ============================================================
+;; Image block conversion (GAP-V1: cross-provider vision)
+;; ============================================================
+
+;; Parse a data URL "data:<mime>;base64,<data>" and return (values mime data)
+(define (parse-data-url url)
+  (define m (regexp-match #rx"^data:([^;]+);base64,(.*)$" url))
+  (if m
+      (values (cadr m) (caddr m))
+      (values "image/png" url)))
+
+;; Convert OpenAI-format content blocks to Gemini parts.
+(define (openai-block->gemini block)
+  (define btype (hash-ref block 'type "text"))
+  (cond
+    [(equal? btype "text") (hasheq 'text (hash-ref block 'text ""))]
+    [(equal? btype "image_url")
+     (define image-url-hash (hash-ref block 'image_url (hasheq)))
+     (define url (hash-ref image-url-hash 'url ""))
+     (define-values (mime data) (parse-data-url url))
+     (hasheq 'inline_data (hasheq 'mime_type mime 'data data))]
+    [else block]))
+
 ;; Convert normalized model-request to Gemini generateContent API body.
 (define (gemini-build-request-body req #:stream? [stream? #f])
   (define settings (model-request-settings req))
@@ -115,6 +138,10 @@
            (define tool-name (hash-ref call-id->name tool-call-id ""))
            (list (hasheq 'functionResponse
                          (hasheq 'name tool-name 'response (hasheq 'content tool-result-content))))]
+          ;; User with list content (text + images) (GAP-V1)
+          [(and (equal? role "user") (list? content))
+           (for/list ([block (in-list content)])
+             (openai-block->gemini block))]
           ;; Assistant with list content (tool calls + text)
           [(and (equal? role "assistant") (list? content))
            (for/list ([block (in-list content)])

--- a/tests/test-browser-audit-w4-v0983.rkt
+++ b/tests/test-browser-audit-w4-v0983.rkt
@@ -1,0 +1,66 @@
+#lang racket
+
+;; tests/test-browser-audit-w4-v0983.rkt — Tests for Wave 4 audit fixes (v0.98.3)
+;; GAP-V1: Cross-provider vision image serialization
+
+(require rackunit
+         "../llm/anthropic.rkt"
+         "../llm/gemini.rkt"
+         "../llm/model.rkt")
+
+;; ---------------------------------------------------------------------------
+;; GAP-V1: Anthropic image block conversion
+;; ---------------------------------------------------------------------------
+
+(test-case "GAP-V1: Anthropic converts OpenAI image_url block to Anthropic image block"
+  (define req
+    (make-model-request
+     (list (hasheq 'role
+                   "user"
+                   'content
+                   (list (hasheq 'type "text" 'text "Hello")
+                         (hasheq 'type
+                                 "image_url"
+                                 'image_url
+                                 (hasheq 'url "data:image/png;base64,ABC123" 'detail "auto")))))
+     #f
+     (hasheq 'model "claude-3" 'max-tokens 1024)))
+  (define body (anthropic-build-request-body req))
+  (define messages (hash-ref body 'messages))
+  (check-equal? (length messages) 1)
+  (define content (hash-ref (car messages) 'content))
+  (check-equal? (length content) 2)
+  (define img (cadr content))
+  (check-equal? (hash-ref img 'type) "image")
+  (define src (hash-ref img 'source))
+  (check-equal? (hash-ref src 'type) "base64")
+  (check-equal? (hash-ref src 'media_type) "image/png")
+  (check-equal? (hash-ref src 'data) "ABC123"))
+
+;; ---------------------------------------------------------------------------
+;; GAP-V1: Gemini image block conversion
+;; ---------------------------------------------------------------------------
+
+(test-case "GAP-V1: Gemini converts OpenAI image_url block to Gemini inline_data part"
+  (define req
+    (make-model-request
+     (list (hasheq 'role
+                   "user"
+                   'content
+                   (list (hasheq 'type "text" 'text "Hello")
+                         (hasheq 'type
+                                 "image_url"
+                                 'image_url
+                                 (hasheq 'url "data:image/jpeg;base64,XYZ789" 'detail "auto")))))
+     #f
+     (hasheq 'model "gemini-1.5" 'max-tokens 1024)))
+  (define body (gemini-build-request-body req))
+  (define contents (hash-ref body 'contents))
+  (check-equal? (length contents) 1)
+  (define parts (hash-ref (car contents) 'parts))
+  (check-equal? (length parts) 2)
+  (define img (cadr parts))
+  (check-true (hash-has-key? img 'inline_data))
+  (define inline (hash-ref img 'inline_data))
+  (check-equal? (hash-ref inline 'mime_type) "image/jpeg")
+  (check-equal? (hash-ref inline 'data) "XYZ789"))


### PR DESCRIPTION
Implements W4 findings from v0.98.3 Browser Audit Hotfix:

- **GAP-V1**: Anthropic and Gemini adapters now convert OpenAI-format `image_url` content blocks to their native image formats
  - Anthropic: `{type: "image", source: {type: "base64", media_type: "image/png", data: "..."}}`
  - Gemini: `{inline_data: {mime_type: "image/png", data: "..."}}`
- **GAP-V2**: Added TODO documenting that `extensions/image-pipeline.rkt` resize pipeline is not yet wired to browser screenshots (deferred to v0.99.x)

2 new tests verify Anthropic and Gemini image block conversion. All prior audit tests pass.

Closes #7830, closes #7850, closes #7851