### PR TITLE
fix(browser,llm): W0 NF-01 screenshot bytes + NF-02 Gemini camelCase (#7858)

### DIFF
--- a/browser/adapters/playwright-sidecar.rkt
+++ b/browser/adapters/playwright-sidecar.rkt
@@ -18,7 +18,8 @@
          json
          "../adapter.rkt"
          "../types.rkt"
-         "../../util/error/errors.rkt")
+         "../../util/error/errors.rkt"
+         net/base64)
 
 (provide (struct-out playwright-sidecar-state)
          launch-sidecar!
@@ -449,6 +450,12 @@
       (send-command! st
                      "screenshot"
                      (hasheq 'sessionId session-id 'selector (or selector #f) 'fullPage full-page?)))
+    ;; NF-01: Decode base64 string to actual bytes
+    (define raw-data (hash-ref data 'data ""))
+    (define screenshot-bytes
+      (if (non-empty-string? raw-data)
+          (base64-decode (string->bytes/utf-8 raw-data))
+          #""))
     (browser-observation ""
                          ""
                          ""
@@ -456,7 +463,7 @@
                          #f
                          #f
                          (hash-ref data 'mimeType "image/png")
-                         (hash-ref data 'data "")
+                         screenshot-bytes
                          '()
                          '()
                          #f ; viewport-size

--- a/llm/gemini.rkt
+++ b/llm/gemini.rkt
@@ -85,7 +85,7 @@
      (define image-url-hash (hash-ref block 'image_url (hasheq)))
      (define url (hash-ref image-url-hash 'url ""))
      (define-values (mime data) (parse-data-url url))
-     (hasheq 'inline_data (hasheq 'mime_type mime 'data data))]
+     (hasheq 'inlineData (hasheq 'mimeType mime 'data data))]
     [else block]))
 
 ;; Convert normalized model-request to Gemini generateContent API body.

--- a/tests/test-browser-audit-w4-v0983.rkt
+++ b/tests/test-browser-audit-w4-v0983.rkt
@@ -41,7 +41,7 @@
 ;; GAP-V1: Gemini image block conversion
 ;; ---------------------------------------------------------------------------
 
-(test-case "GAP-V1: Gemini converts OpenAI image_url block to Gemini inline_data part"
+(test-case "GAP-V1: Gemini converts OpenAI image_url block to Gemini inlineData part"
   (define req
     (make-model-request
      (list (hasheq 'role
@@ -60,7 +60,7 @@
   (define parts (hash-ref (car contents) 'parts))
   (check-equal? (length parts) 2)
   (define img (cadr parts))
-  (check-true (hash-has-key? img 'inline_data))
-  (define inline (hash-ref img 'inline_data))
-  (check-equal? (hash-ref inline 'mime_type) "image/jpeg")
+  (check-true (hash-has-key? img 'inlineData))
+  (define inline (hash-ref img 'inlineData))
+  (check-equal? (hash-ref inline 'mimeType) "image/jpeg")
   (check-equal? (hash-ref inline 'data) "XYZ789"))

--- a/tests/test-browser-screenshot-type.rkt
+++ b/tests/test-browser-screenshot-type.rkt
@@ -1,0 +1,29 @@
+#lang racket
+
+;; tests/test-browser-screenshot-type.rkt — NF-01: screenshot bytes type fix
+
+(require rackunit
+         net/base64)
+
+;; ---------------------------------------------------------------------------
+;; NF-01: base64 string -> bytes conversion
+;; ---------------------------------------------------------------------------
+
+(test-case "NF-01: base64-decode converts string to bytes"
+  (define raw-data "aGVsbG8=") ;; "hello" in base64
+  (define result
+    (if (non-empty-string? raw-data)
+        (base64-decode (string->bytes/utf-8 raw-data))
+        #""))
+  (check-pred bytes? result)
+  (check-equal? result #"hello")
+  (check-equal? (bytes-length result) 5))
+
+(test-case "NF-01: empty string returns empty bytes"
+  (define raw-data "")
+  (define result
+    (if (non-empty-string? raw-data)
+        (base64-decode (string->bytes/utf-8 raw-data))
+        #""))
+  (check-pred bytes? result)
+  (check-equal? result #""))


### PR DESCRIPTION
W0 fixes:

- **NF-01 (CRITICAL)**: `adapter-screenshot` now decodes base64 string to actual bytes before storing in `screenshot-bytes` field, preventing contract violations in `enforce-screenshot-max-bytes`
- **NF-02 (MODERATE)**: Gemini image block keys changed from snake_case (`inline_data`/`mime_type`) to camelCase (`inlineData`/`mimeType`) to match the Gemini REST API

Tests:
- Updated `test-browser-audit-w4-v0983.rkt` to assert correct camelCase keys
- Added `test-browser-screenshot-type.rkt` verifying base64 decode round-trip

Closes #7858, closes #7861, closes #7862