### PR TITLE
chore: W2 NF-07/08/09/10 dead code + DRY + version bump 0.98.4 (#7860)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,27 @@
+## [0.98.4] — 2026-06-11
+
+### Critical Fixes
+
+- **NF-01 (CRITICAL)**: `adapter-screenshot` now decodes base64 string to actual bytes before storing in `screenshot-bytes`, fixing 100% crash rate of `browser_screenshot` (#7858)
+
+### Cross-Provider Vision
+
+- **NF-02 (MODERATE)**: Gemini image block keys changed from snake_case `inline_data`/`mime_type` to camelCase `inlineData`/`mimeType` matching the Gemini REST API (#7858)
+
+### Sidecar Lifecycle Hardening
+
+- **NF-03 (MODERATE)**: `start-heartbeat!` reads custodian from state inside loop instead of capturing at thread creation, preventing stale custodian after restart (#7859)
+- **NF-04 (LOW)**: `send-command!` removes orphaned async-channel from pending hash before raising on dead sidecar (#7859)
+- **NF-05 (LOW)**: `restart-sidecar!` enforces restart semaphore presence, no fallback (#7859)
+- **NF-06 (LOW)**: `make-reader-body` enforces pending semaphore, no unsafe fallbacks (#7859)
+
+### Code Quality
+
+- **NF-07 (LOW)**: Removed dead `(require json)` in `workflow.rkt` (#7860)
+- **NF-08 (LOW)**: Removed redundant duplicate `require "settings.rkt"` in `service.rkt` (#7860)
+- **NF-09 (LOW)**: Removed redundant `(only-in racket/base ...)` import in `playwright-sidecar.rkt` (#7860)
+- **NF-10 (INFO)**: Extracted duplicated `parse-data-url` to shared `llm/vision-helpers.rkt` (#7860)
+
 ## [0.98.3] — 2026-06-11
 
 ### Security & Robustness

--- a/browser/adapters/playwright-sidecar.rkt
+++ b/browser/adapters/playwright-sidecar.rkt
@@ -12,7 +12,6 @@
 
 (require racket/match
          racket/async-channel
-         (only-in racket/base make-semaphore call-with-semaphore)
          (only-in file/sha1 bytes->hex-string)
          (only-in racket/random crypto-random-bytes)
          json

--- a/browser/service.rkt
+++ b/browser/service.rkt
@@ -14,12 +14,6 @@
          "settings.rkt"
          "../util/error/errors.rkt")
 
-;; Re-export settings for enforce-screenshot-max-bytes
-(require (only-in "settings.rkt"
-                  browser-settings-screenshot-max-bytes
-                  default-browser-settings
-                  current-browser-settings))
-
 (provide secure-browser-service?
          make-secure-browser-service
          generate-session-id

--- a/browser/workflow.rkt
+++ b/browser/workflow.rkt
@@ -5,8 +5,7 @@
 ;; Higher-level browser operations that compose multiple primitives
 ;; into a single atomic workflow for common use cases.
 
-(require json
-         "types.rkt"
+(require "types.rkt"
          "service.rkt"
          "../util/error/errors.rkt")
 

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.98.3")
+(define version "0.98.4")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base" "gui-easy-lib"))

--- a/llm/anthropic.rkt
+++ b/llm/anthropic.rkt
@@ -24,7 +24,8 @@
          "provider.rkt"
          "stream.rkt"
          "http-helpers.rkt"
-         (only-in "../util/error/errors.rkt" with-logged-catch))
+         (only-in "../util/error/errors.rkt" with-logged-catch)
+         (only-in "vision-helpers.rkt" parse-data-url))
 
 ;; Provider constructor
 (provide (contract-out [make-anthropic-provider (-> hash? provider?)])
@@ -51,13 +52,6 @@
 ;; ============================================================
 ;; Image block conversion (GAP-V1: cross-provider vision)
 ;; ============================================================
-
-;; Parse a data URL "data:<mime>;base64,<data>" and return (values mime data)
-(define (parse-data-url url)
-  (define m (regexp-match #rx"^data:([^;]+);base64,(.*)$" url))
-  (if m
-      (values (cadr m) (caddr m))
-      (values "image/png" url)))
 
 ;; Convert OpenAI-format content blocks to Anthropic content blocks.
 (define (openai-block->anthropic block)

--- a/llm/gemini.rkt
+++ b/llm/gemini.rkt
@@ -25,7 +25,8 @@
          "model.rkt"
          "provider.rkt"
          "stream.rkt"
-         "http-helpers.rkt")
+         "http-helpers.rkt"
+         (only-in "vision-helpers.rkt" parse-data-url))
 
 ;; Provider constructor
 (provide (contract-out [make-gemini-provider (-> hash? provider?)])
@@ -68,13 +69,6 @@
 ;; ============================================================
 ;; Image block conversion (GAP-V1: cross-provider vision)
 ;; ============================================================
-
-;; Parse a data URL "data:<mime>;base64,<data>" and return (values mime data)
-(define (parse-data-url url)
-  (define m (regexp-match #rx"^data:([^;]+);base64,(.*)$" url))
-  (if m
-      (values (cadr m) (caddr m))
-      (values "image/png" url)))
 
 ;; Convert OpenAI-format content blocks to Gemini parts.
 (define (openai-block->gemini block)

--- a/llm/vision-helpers.rkt
+++ b/llm/vision-helpers.rkt
@@ -1,0 +1,15 @@
+#lang racket
+
+;; llm/vision-helpers.rkt — Shared helpers for vision/multimodal providers
+;;
+;; Extracted from duplicated code in anthropic.rkt and gemini.rkt (NF-10).
+
+(provide parse-data-url)
+
+;; Parse a data URL "data:<mime>;base64,<data>" and return (values mime data)
+;; Falls back to "image/png" + raw url if parsing fails.
+(define (parse-data-url url)
+  (define m (regexp-match #rx"^data:([^;]+);base64,(.*)$" url))
+  (if m
+      (values (cadr m) (caddr m))
+      (values "image/png" url)))

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -11,4 +11,4 @@
 
 (provide (contract-out [q-version string?]))
 
-(define q-version "0.98.3")
+(define q-version "0.98.4")


### PR DESCRIPTION
W2 fixes:

- **NF-07**: Removed dead `(require json)` in `workflow.rkt`
- **NF-08**: Removed redundant duplicate `require settings.rkt` in `service.rkt`
- **NF-09**: Removed redundant `(only-in racket/base ...)` in `playwright-sidecar.rkt`
- **NF-10**: Extracted duplicated `parse-data-url` to shared `llm/vision-helpers.rkt`
- Version bumped `0.98.3 → 0.98.4`
- CHANGELOG entry for v0.98.4

Tests: 8/8 pass (W0: 2, W1: 4, W4-v0983: 2)

Closes #7860, closes #7867, closes #7868, closes #7869, closes #7870