### PR TITLE
fix(tests): W0 BTF-01 fix browser-settings arity (14→17) + browser-observation (12→13) (#7874)

### DIFF
--- a/tests/test-browser-service-adapter.rkt
+++ b/tests/test-browser-service-adapter.rkt
@@ -36,7 +36,8 @@
                                                            '()
                                                            '()
                                                            #f
-                                                           (hash)))
+                                                           (hash)
+                                                           #f))
                           #:act (lambda (sid action) 'ok)
                           #:screenshot (lambda (sid sel fp) 'ok)))
   (define svc
@@ -54,7 +55,10 @@
                                                               #f
                                                               60000
                                                               'ephemeral
-                                                              #t)))
+                                                              #t
+                                                              #f
+                                                              "auto"
+                                                              5)))
   (define-values (sid result) (browser-open! svc "https://example.com"))
   (check-equal? result 'ok)
   (check-not-false opened-with)
@@ -81,14 +85,29 @@
                                                            '()
                                                            '()
                                                            #f
-                                                           (hash)))
+                                                           (hash)
+                                                           #f))
                           #:act (lambda (sid action) 'ok)
                           #:screenshot (lambda (sid sel fp) 'ok)))
   (define svc
-    (make-secure-browser-service
-     test-adapter
-     #:settings
-     (browser-settings #t '("https") '() '(3000) #t '() 3 100 30000 524288 #f 60000 'ephemeral #t)))
+    (make-secure-browser-service test-adapter
+                                 #:settings (browser-settings #t
+                                                              '("https")
+                                                              '()
+                                                              '(3000)
+                                                              #t
+                                                              '()
+                                                              3
+                                                              100
+                                                              30000
+                                                              524288
+                                                              #f
+                                                              60000
+                                                              'ephemeral
+                                                              #t
+                                                              #f
+                                                              "auto"
+                                                              5)))
   (define-values (sid _) (browser-open! svc "https://example.com"))
   (define obs (browser-observe! svc sid #:selector "h1"))
   (check-not-false observed-with)
@@ -113,16 +132,31 @@
                                                            '()
                                                            '()
                                                            #f
-                                                           (hash)))
+                                                           (hash)
+                                                           #f))
                           #:act (lambda (sid action)
                                   (set! acted-with (list sid action))
                                   'clicked)
                           #:screenshot (lambda (sid sel fp) 'ok)))
   (define svc
-    (make-secure-browser-service
-     test-adapter
-     #:settings
-     (browser-settings #t '("https") '() '(3000) #t '() 3 100 30000 524288 #f 60000 'ephemeral #t)))
+    (make-secure-browser-service test-adapter
+                                 #:settings (browser-settings #t
+                                                              '("https")
+                                                              '()
+                                                              '(3000)
+                                                              #t
+                                                              '()
+                                                              3
+                                                              100
+                                                              30000
+                                                              524288
+                                                              #f
+                                                              60000
+                                                              'ephemeral
+                                                              #t
+                                                              #f
+                                                              "auto"
+                                                              5)))
   (define-values (sid _) (browser-open! svc "https://example.com"))
   (define result (browser-act! svc sid (browser-action-click "btn" "click")))
   (check-not-false acted-with)
@@ -149,14 +183,29 @@
                                                            '()
                                                            '()
                                                            #f
-                                                           (hash)))
+                                                           (hash)
+                                                           #f))
                           #:act (lambda (sid action) 'ok)
                           #:screenshot (lambda (sid sel fp) 'ok)))
   (define svc
-    (make-secure-browser-service
-     test-adapter
-     #:settings
-     (browser-settings #t '("https") '() '(3000) #t '() 3 100 30000 524288 #f 60000 'ephemeral #t)))
+    (make-secure-browser-service test-adapter
+                                 #:settings (browser-settings #t
+                                                              '("https")
+                                                              '()
+                                                              '(3000)
+                                                              #t
+                                                              '()
+                                                              3
+                                                              100
+                                                              30000
+                                                              524288
+                                                              #f
+                                                              60000
+                                                              'ephemeral
+                                                              #t
+                                                              #f
+                                                              "auto"
+                                                              5)))
   (define-values (sid _) (browser-open! svc "https://example.com"))
   (browser-navigate! svc sid "https://example.com/page2")
   (check-equal? navigated-with "https://example.com/page2"))
@@ -164,31 +213,47 @@
 (test-case "service browser-screenshot! dispatches via adapter interface"
   (define screenshot-args #f)
   (define test-adapter
-    (make-browser-adapter #:open (lambda (sid target) 'ok)
-                          #:close (lambda (sid) 'ok)
-                          #:navigate (lambda (sid url) 'ok)
-                          #:observe (lambda (sid selector)
-                                      (browser-observation "https://example.com"
-                                                           "Test"
-                                                           "text"
-                                                           "vis"
-                                                           "dom"
-                                                           #f
-                                                           #f
-                                                           #f
-                                                           '()
-                                                           '()
-                                                           #f
-                                                           (hash)))
-                          #:act (lambda (sid action) 'ok)
-                          #:screenshot (lambda (sid sel fp)
-                                         (set! screenshot-args (list sid sel fp))
-                                         'png-bytes)))
+    (make-browser-adapter
+     #:open (lambda (sid target) 'ok)
+     #:close (lambda (sid) 'ok)
+     #:navigate (lambda (sid url) 'ok)
+     #:observe (lambda (sid selector)
+                 (browser-observation "https://example.com"
+                                      "Test"
+                                      "text"
+                                      "vis"
+                                      "dom"
+                                      #f
+                                      #f
+                                      #f
+                                      '()
+                                      '()
+                                      #f
+                                      (hash)
+                                      #f))
+     #:act (lambda (sid action) 'ok)
+     #:screenshot (lambda (sid sel fp)
+                    (set! screenshot-args (list sid sel fp))
+                    (browser-observation "" "" "" "" #f #f "image/png" #"" '() '() #f '() #f))))
   (define svc
-    (make-secure-browser-service
-     test-adapter
-     #:settings
-     (browser-settings #t '("https") '() '(3000) #t '() 3 100 30000 524288 #f 60000 'ephemeral #t)))
+    (make-secure-browser-service test-adapter
+                                 #:settings (browser-settings #t
+                                                              '("https")
+                                                              '()
+                                                              '(3000)
+                                                              #t
+                                                              '()
+                                                              3
+                                                              100
+                                                              30000
+                                                              524288
+                                                              #f
+                                                              60000
+                                                              'ephemeral
+                                                              #t
+                                                              #f
+                                                              "auto"
+                                                              5)))
   (define-values (sid _) (browser-open! svc "https://example.com"))
   (browser-screenshot! svc sid #:selector "body")
   (check-not-false screenshot-args)
@@ -215,14 +280,29 @@
                                                            '()
                                                            '()
                                                            #f
-                                                           (hash)))
+                                                           (hash)
+                                                           #f))
                           #:act (lambda (sid action) 'ok)
                           #:screenshot (lambda (sid sel fp) 'ok)))
   (define svc
-    (make-secure-browser-service
-     test-adapter
-     #:settings
-     (browser-settings #t '("https") '() '(3000) #t '() 3 100 30000 524288 #f 60000 'ephemeral #t)))
+    (make-secure-browser-service test-adapter
+                                 #:settings (browser-settings #t
+                                                              '("https")
+                                                              '()
+                                                              '(3000)
+                                                              #t
+                                                              '()
+                                                              3
+                                                              100
+                                                              30000
+                                                              524288
+                                                              #f
+                                                              60000
+                                                              'ephemeral
+                                                              #t
+                                                              #f
+                                                              "auto"
+                                                              5)))
   (define-values (sid _) (browser-open! svc "https://example.com"))
   (browser-close! svc sid)
   (check-equal? closed-sid sid))
@@ -238,10 +318,24 @@
                           #:act (lambda (sid action) (mock-act mock sid action))
                           #:screenshot (lambda (sid sel fp) (mock-screenshot mock sid sel "png"))))
   (define svc
-    (make-secure-browser-service
-     wrapped-adapter
-     #:settings
-     (browser-settings #t '("https") '() '(3000) #t '() 3 100 30000 524288 #f 60000 'ephemeral #t)))
+    (make-secure-browser-service wrapped-adapter
+                                 #:settings (browser-settings #t
+                                                              '("https")
+                                                              '()
+                                                              '(3000)
+                                                              #t
+                                                              '()
+                                                              3
+                                                              100
+                                                              30000
+                                                              524288
+                                                              #f
+                                                              60000
+                                                              'ephemeral
+                                                              #t
+                                                              #f
+                                                              "auto"
+                                                              5)))
   (define-values (sid result) (browser-open! svc "https://example.com"))
   (check-true (string? sid))
   (check-not-false result))

--- a/tests/test-browser-service.rkt
+++ b/tests/test-browser-service.rkt
@@ -50,7 +50,10 @@
                       #f
                       60000
                       'ephemeral
-                      #t))
+                      #t
+                      #f
+                      "auto"
+                      5))
   (make-secure-browser-service adapter #:settings settings #:artifact-dir dir))
 
 (define (make-temp-dir)
@@ -153,7 +156,23 @@
 (test-case "error: adapter error wrapped as q-browser-error"
   (define adapter (make-mock-adapter #:error-mode 'timeout))
   (define settings
-    (browser-settings #t '("https") '() '() #t '() 3 100 30000 524288 #f 60000 'ephemeral #t))
+    (browser-settings #t
+                      '("https")
+                      '()
+                      '()
+                      #t
+                      '()
+                      3
+                      100
+                      30000
+                      524288
+                      #f
+                      60000
+                      'ephemeral
+                      #t
+                      #f
+                      "auto"
+                      5))
   (define svc (make-secure-browser-service adapter #:settings settings))
   (check-exn q-browser-error? (lambda () (browser-open! svc "https://example.com"))))
 

--- a/tests/test-browser-tools.rkt
+++ b/tests/test-browser-tools.rkt
@@ -43,23 +43,44 @@
                       #f
                       60000
                       'ephemeral
-                      #t))
+                      #t
+                      #f
+                      "auto"
+                      5))
   (make-secure-browser-service adapter #:settings settings))
 
 (define (make-empty-observation [url "https://example.com"])
-  (browser-observation url "Example" "" "" (hasheq) #f #f #f '() '() (hasheq) (hasheq)))
+  (browser-observation url "Example" "" "" (hasheq) #f #f #f '() '() (hasheq) (hasheq) #f))
 
 (define (make-error-act-svc)
   (define adapter
-    (make-browser-adapter #:open (lambda (sid target) (make-empty-observation))
-                          #:close (lambda (sid) (void))
-                          #:navigate (lambda (sid url) (make-empty-observation url))
-                          #:observe (lambda (sid selector) (make-empty-observation))
-                          #:act (lambda (sid action)
-                                  (raise-browser-error "simulated browser action failure"
-                                                       'adapter-error))
-                          #:screenshot (lambda (sid sel fp) #"png")))
-  (make-secure-browser-service adapter))
+    (make-browser-adapter
+     #:open (lambda (sid target) (make-empty-observation))
+     #:close (lambda (sid) (void))
+     #:navigate (lambda (sid url) (make-empty-observation url))
+     #:observe (lambda (sid selector) (make-empty-observation))
+     #:act (lambda (sid action)
+             (raise-browser-error "simulated browser action failure" 'adapter-error))
+     #:screenshot (lambda (sid sel fp)
+                    (browser-observation "" "" "" "" #f #f "image/png" #"" '() '() #f '() #f))))
+  (make-secure-browser-service adapter
+                               #:settings (browser-settings #t
+                                                            '("https" "http")
+                                                            '()
+                                                            '(3000 8080)
+                                                            #t
+                                                            '()
+                                                            3
+                                                            100
+                                                            30000
+                                                            524288
+                                                            #f
+                                                            60000
+                                                            'ephemeral
+                                                            #t
+                                                            #f
+                                                            "auto"
+                                                            5)))
 
 (define (with-svc thunk)
   (parameterize ([current-browser-service (make-test-svc)])


### PR DESCRIPTION
W0: Fix 56/59 browser test failures.

- Updated all `browser-settings` constructors from 14→17 fields (added `vision-enabled?`, `vision-detail`, `vision-ephemeral-turns`)
- Updated all `browser-observation` constructors from 12→13 fields (added `metadata`)
- Fixed `make-error-act-svc` missing settings (was disabled by default)
- Fixed screenshot mock returning raw bytes instead of browser-observation

Tests: 59/59 pass (was 3/59)

Closes #7874, closes #7875, closes #7876, closes #7877