### PR TITLE
fix: W1 NF-11 browser context overflow truncation + double-condition fix (#7878)

### DIFF
--- a/runtime/context-assembly/session-walk.rkt
+++ b/runtime/context-assembly/session-walk.rkt
@@ -126,13 +126,20 @@
     [else
      (define lines (string-split text "\n"))
      (cond
-       [(<= (length lines) 40) entry]
-       [else
+       ;; Multi-line tool result: preserve first/last 10 lines.
+       [(> (length lines) 40)
         (define head (take lines 10))
         (define tail (take-right lines 10))
         (define dropped (- (length lines) 20))
         (define summary-text
           (string-join (append head (list (format "... ~a lines truncated ..." dropped)) tail) "\n"))
+        (struct-copy message entry [content (list (make-text-part summary-text))])]
+       ;; Single (or few) very long lines: hard truncate at char limit.
+       [else
+        (define summary-text
+          (string-append (substring text 0 MAX-TOOL-RESULT-CHARS)
+                         (format "\n... ~a chars truncated ..."
+                                 (- (string-length text) MAX-TOOL-RESULT-CHARS))))
         (struct-copy message entry [content (list (make-text-part summary-text))])])]))
 
 ;; ---------------------------------------------------------------------------

--- a/tests/test-context-overflow-browser.rkt
+++ b/tests/test-context-overflow-browser.rkt
@@ -1,0 +1,87 @@
+#lang racket
+
+;; @speed fast
+;; @suite default
+
+;; tests/test-context-overflow-browser.rkt — Regression tests for NF-11
+;; context-overflow fixes in browser observations and session-walk truncation.
+
+(require rackunit
+         "../tools/builtins/browser-tools.rkt"
+         "../browser/types.rkt"
+         "../runtime/context-assembly/session-walk.rkt"
+         "../util/message/message.rkt"
+         "../util/content/content-parts.rkt")
+
+;; ---------------------------------------------------------------------------
+;; NF-11a: observation->hash truncates text fields to 4000 chars
+;; ---------------------------------------------------------------------------
+
+(define (make-big-observation text-len)
+  (browser-observation "https://example.com"
+                       "Title"
+                       (make-string text-len #\x)
+                       (make-string text-len #\y)
+                       "dom"
+                       #f
+                       #f
+                       #f
+                       '()
+                       '()
+                       #f
+                       '()
+                       #f))
+
+(test-case "observation->hash truncates text-content at 4000 chars"
+  (define obs (make-big-observation 5000))
+  (define h (observation->hash obs))
+  (define tc (hash-ref h 'text-content))
+  (check-true (string? tc))
+  (check-equal? (string-length tc) 4016) ; 4000 + "\n... [truncated]"
+  (check-true (string-suffix? tc "\n... [truncated]")))
+
+(test-case "observation->hash truncates visible-text at 4000 chars"
+  (define obs (make-big-observation 5000))
+  (define h (observation->hash obs))
+  (define vt (hash-ref h 'visible-text))
+  (check-true (string? vt))
+  (check-equal? (string-length vt) 4016)
+  (check-true (string-suffix? vt "\n... [truncated]")))
+
+(test-case "observation->hash preserves short text unchanged"
+  (define obs (make-big-observation 100))
+  (define h (observation->hash obs))
+  (check-equal? (string-length (hash-ref h 'text-content)) 100)
+  (check-equal? (string-length (hash-ref h 'visible-text)) 100))
+
+;; ---------------------------------------------------------------------------
+;; NF-11b: summarize-tool-result handles long single-line strings
+;; ---------------------------------------------------------------------------
+
+(define (make-tool-result-message text)
+  (make-message 'id-1 #f 'user 'tool-result (list (make-text-part text)) (current-seconds) (hasheq)))
+
+(test-case "summarize-tool-result truncates single-line text > 8000 chars"
+  (define big-text (make-string 9000 #\z))
+  (define entry (make-tool-result-message big-text))
+  (define result (summarize-tool-result entry))
+  (define result-text (text-part-text (first (message-content result))))
+  (check-true (< (string-length result-text) 9000))
+  (check-true (string-contains? result-text "... 1000 chars truncated ...")))
+
+(test-case "summarize-tool-result preserves text <= 8000 chars"
+  (define small-text (make-string 100 #\z))
+  (define entry (make-tool-result-message small-text))
+  (define result (summarize-tool-result entry))
+  (check-equal? result entry))
+
+(test-case "summarize-tool-result truncates multi-line text > 40 lines"
+  ;; 50 lines × 200 chars = 10000 chars, exceeds 8000 limit
+  (define many-lines
+    (string-join (for/list ([i 50])
+                   (format "line ~a ~a" i (make-string 190 #\-)))
+                 "\n"))
+  (define entry (make-tool-result-message many-lines))
+  (define result (summarize-tool-result entry))
+  (define result-text (text-part-text (first (message-content result))))
+  (check-true (string-contains? result-text "... 30 lines truncated ...")))

--- a/tools/builtins/browser-tools.rkt
+++ b/tools/builtins/browser-tools.rkt
@@ -30,7 +30,8 @@
          handle-browser-screenshot
          handle-browser-scroll
          handle-browser-close
-         handle-browser-check-local-app)
+         handle-browser-check-local-app
+         observation->hash)
 
 ;; ---------------------------------------------------------------------------
 ;; Helper: get service from exec context or parameter
@@ -70,15 +71,25 @@
 (define (browser-error-result tool-name e)
   (make-error-result (format "~a failed: ~a" tool-name (exn-message e))))
 
+;; Truncate observation text to avoid context overflow (NF-11).
+;; Pages with 50K+ chars of text-content would consume the entire
+;; context budget. 4000 chars preserves the first ~1K tokens.
+(define MAX-OBSERVATION-TEXT 4000)
+
+(define (truncate-observation-text text)
+  (if (and (string? text) (> (string-length text) MAX-OBSERVATION-TEXT))
+      (string-append (substring text 0 MAX-OBSERVATION-TEXT) "\n... [truncated]")
+      text))
+
 (define (observation->hash obs)
   (hasheq 'url
           (browser-observation-url obs)
           'title
           (browser-observation-title obs)
           'text-content
-          (browser-observation-text-content obs)
+          (truncate-observation-text (browser-observation-text-content obs))
           'visible-text
-          (browser-observation-visible-text obs)
+          (truncate-observation-text (browser-observation-visible-text obs))
           'dom-summary
           (browser-observation-dom-summary obs)
           'console-errors
@@ -182,15 +193,15 @@
      (with-handlers ([q-browser-error? (lambda (e) (browser-error-result "browser_screenshot" e))])
        (define obs (browser-screenshot! svc sid #:selector selector))
        (define raw-bytes (browser-observation-screenshot-bytes obs))
-       (define b64 (if (bytes? raw-bytes)
-                       (bytes->base64-string raw-bytes)
-                       (or raw-bytes "")))
+       (define b64
+         (if (bytes? raw-bytes)
+             (bytes->base64-string raw-bytes)
+             (or raw-bytes "")))
        (define mime (or (browser-observation-screenshot-mime obs) "image/png"))
        ;; W2: dual-path — return image-part when vision enabled
        (define settings (or (current-browser-settings) (default-browser-settings)))
        (if (browser-settings-vision-enabled? settings)
-           (make-success-result (make-image-part mime b64
-                                                  (browser-settings-vision-detail settings)))
+           (make-success-result (make-image-part mime b64 (browser-settings-vision-detail settings)))
            ;; Legacy path: hash with base64 data
            (make-success-result (hasheq 'status "ok" 'mime-type mime 'data b64))))]))
 


### PR DESCRIPTION
W1: Fix browser context overflow vectors.

- NF-11a: `observation->hash` now truncates `text-content` and `visible-text` to 4000 chars with `... [truncated]` indicator
- NF-11b: `summarize-tool-result` no longer requires >40 lines to truncate; any result >8000 chars is now truncated (character-based for few long lines, line-based for many short lines)
- NF-11c: Added `tests/test-context-overflow-browser.rkt` with 6 regression tests

Production code: `browser-tools.rkt`, `session-walk.rkt`
Tests: 65/65 pass

Closes #7878, closes #7879, closes #7880, closes #7881