### PR TITLE
style: W2 F-05/F-08/F-09 code quality fixes (#7882)

### DIFF
--- a/browser/adapters/playwright-sidecar.rkt
+++ b/browser/adapters/playwright-sidecar.rkt
@@ -74,6 +74,9 @@
 (define (make-reader-body state)
   (define pending (playwright-sidecar-state-pending-box state))
   (define cfg (playwright-sidecar-state-config state))
+  ;; F-08: cfg is captured at thread creation. During restart, the old reader
+  ;; is killed via custodian-shutdown-all before launch-sidecar-process! creates
+  ;; a new state, so this closure always refers to the live config.
   (lambda ()
     (define in (playwright-sidecar-state-stdout-port state))
     (let loop ()

--- a/extensions/image-format.rkt
+++ b/extensions/image-format.rkt
@@ -32,7 +32,7 @@
 ;; Format an image for Gemini's generateContent API.
 ;; Returns an inlineData block with mimeType.
 (define (format-image-gemini base64-data media-type)
-  (hasheq 'type "inline_data" 'inlineData (hasheq 'mimeType media-type 'data base64-data)))
+  (hasheq 'type "inlineData" 'inlineData (hasheq 'mimeType media-type 'data base64-data)))
 
 ;; ═══════════════════════════════════════════════════════════════════
 ;; Dispatch

--- a/llm/anthropic.rkt
+++ b/llm/anthropic.rkt
@@ -1,6 +1,5 @@
 #lang racket/base
 
-(require "../util/error/error-helpers.rkt")
 ;; llm/anthropic.rkt — Anthropic provider adapter
 ;;
 ;; Translates normalized model-request structs into Anthropic Messages
@@ -10,6 +9,7 @@
 ;; HTTP calls use net/http-client from Racket stdlib.
 ;; SSE parsing delegates to llm/stream.rkt.
 
+(require "../util/error/error-helpers.rkt")
 (require racket/contract
          "timing.rkt"
          racket/match

--- a/llm/gemini.rkt
+++ b/llm/gemini.rkt
@@ -1,6 +1,5 @@
 #lang racket/base
 
-(require "../util/error/error-helpers.rkt")
 ;; llm/gemini.rkt — Google Gemini provider adapter
 ;;
 ;; Translates normalized model-request structs into Gemini
@@ -11,6 +10,7 @@
 ;; HTTP calls use net/http-client from Racket stdlib.
 ;; SSE parsing delegates to llm/stream.rkt.
 
+(require "../util/error/error-helpers.rkt")
 (require racket/contract
          "timing.rkt"
          racket/match


### PR DESCRIPTION
W2: Code quality fixes.

- F-05: `image-format.rkt` discriminator changed from `"inline_data"` to `"inlineData"` for Gemini API consistency
- F-08: Added defensive comment in `playwright-sidecar.rkt` documenting that `cfg` capture in `make-reader-body` is safe-by-design (old reader killed via custodian before new one starts)
- F-09: Moved stray `require` after doc-comments in `anthropic.rkt` and `gemini.rkt`

Production code: `image-format.rkt`, `playwright-sidecar.rkt`, `anthropic.rkt`, `gemini.rkt`
Tests: 65/65 pass

Closes #7882, closes #7883, closes #7884, closes #7885