### PR TITLE
test: W3 F-06 behavioral test, version bump 0.98.5, CHANGELOG (#7886)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,27 @@
+## [0.98.5] — 2026-06-11
+
+### Test Foundation
+
+- **BTF-01 (MODERATE)**: Fixed 56/59 browser test failures by updating `browser-settings` constructors to the current 17-field struct arity across `test-browser-service.rkt`, `test-browser-service-adapter.rkt`, and `test-browser-tools.rkt` (#7874)
+
+### Browser Context Overflow
+
+- **NF-11a (LOW)**: `observation->hash` now truncates `text-content` and `visible-text` to 4000 characters before returning tool results, preventing oversized browser observations from consuming context budget (#7878)
+- **NF-11b (LOW)**: Fixed double-condition truncation bug in `summarize-tool-result`: any tool result over 8000 characters is now truncated, regardless of line count (#7879)
+- **NF-11c (LOW)**: Added regression tests in `tests/test-context-overflow-browser.rkt` covering observation hash truncation and both single-line and multi-line tool-result truncation (#7880)
+
+### Code Quality
+
+- **F-05 (LOW)**: Changed Gemini image-format discriminator from `"inline_data"` to `"inlineData"` for API consistency (#7882)
+- **F-08 (INFO)**: Added defensive comment in `playwright-sidecar.rkt` documenting that `cfg` capture in `make-reader-body` is safe-by-design (old reader is killed via custodian before new state is created) (#7882)
+- **F-09 (INFO)**: Moved stray `require` after module doc-comments in `llm/anthropic.rkt` and `llm/gemini.rkt` (#7882)
+
+### Test Quality
+
+- **F-06 (LOW)**: Replaced structural `procedure?` check with behavioral test in `tests/test-browser-audit-w1-v0984.rkt`: verifies `start-heartbeat!` reads the custodian from state each iteration by mutating the state's custodian after thread creation (#7886)
+- Made `heartbeat-interval-secs` a parameter in `playwright-sidecar.rkt` to enable the behavioral NF-03 test (#7886)
+- **GAP-V2 (LOW)**: Verified clarifying comment in `extensions/image-pipeline.rkt` documenting that the resize pipeline is scaffold-only and not yet wired to browser screenshots (#7888)
+
 ## [0.98.4] — 2026-06-11
 
 ### Critical Fixes

--- a/browser/adapters/playwright-sidecar.rkt
+++ b/browser/adapters/playwright-sidecar.rkt
@@ -27,6 +27,7 @@
          send-command-with-recovery!
          restart-sidecar!
          start-heartbeat!
+         heartbeat-interval-secs
          max-sidecar-restarts
          uuid-string
          make-playwright-adapter
@@ -191,13 +192,14 @@
 ;; F11: Heartbeat thread — sends ping every 30s, kills custodian on failure
 ;; ---------------------------------------------------------------------------
 
-(define heartbeat-interval-secs 30)
+;; Parameterized for testability (NF-03 behavioral test).
+(define heartbeat-interval-secs (make-parameter 30))
 
 (define (start-heartbeat! state)
   (define ht
     (thread (lambda ()
               (let loop ()
-                (sleep heartbeat-interval-secs)
+                (sleep (heartbeat-interval-secs))
                 ;; F-04: Stop looping if sidecar is already dead
                 (unless (playwright-sidecar-state-dead? state)
                   ;; NF-03: Read custodian from state each iteration, not at thread creation

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.98.4")
+(define version "0.98.5")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base" "gui-easy-lib"))

--- a/tests/test-browser-audit-w1-v0984.rkt
+++ b/tests/test-browser-audit-w1-v0984.rkt
@@ -13,8 +13,42 @@
 ;; NF-03: Heartbeat reads custodian from state (not captured at creation)
 ;; ---------------------------------------------------------------------------
 
-(test-case "NF-03: start-heartbeat! reads custodian dynamically from state"
-  (check-true (procedure? start-heartbeat!)))
+(test-case "NF-03: heartbeat reads custodian dynamically from state"
+  (define cust1 (make-custodian))
+  (define cust2 (make-custodian))
+  (define victim1
+    (parameterize ([current-custodian cust1])
+      (thread (lambda () (sleep 1000)))))
+  (define victim2
+    (parameterize ([current-custodian cust2])
+      (thread (lambda () (sleep 1000)))))
+  (define live-reader (thread (lambda () (sleep 1000))))
+  (define dead-reader (thread (lambda () (void))))
+  (thread-wait dead-reader)
+  (define state
+    (playwright-sidecar-state #f
+                              #f
+                              #f
+                              (make-hash)
+                              live-reader
+                              cust1
+                              (hasheq 'pending-sema (make-semaphore 1) 'timeout-ms 5000)
+                              #f
+                              #f))
+  ;; Use a long enough interval that we can mutate state before the first read.
+  (parameterize ([heartbeat-interval-secs 0.5])
+    (start-heartbeat! state))
+  ;; Mutate custodian and reader while heartbeat is still in its first sleep.
+  (set-playwright-sidecar-state-custodian! state cust2)
+  (set-playwright-sidecar-state-reader-thread! state dead-reader)
+  ;; Wait for heartbeat to wake up and act on the mutated state.
+  (sleep 0.6)
+  ;; Dynamic read: current custodian (cust2) is shut down because reader is dead.
+  (check-false (thread-running? victim2))
+  ;; Stale custodian (cust1) was replaced before the read, so victim1 survives.
+  (check-true (thread-running? victim1))
+  (custodian-shutdown-all cust1)
+  (kill-thread (playwright-sidecar-state-heartbeat-thread state)))
 
 ;; ---------------------------------------------------------------------------
 ;; NF-04: Orphaned channel cleaned up on dead-sidecar fast-fail

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -11,4 +11,4 @@
 
 (provide (contract-out [q-version string?]))
 
-(define q-version "0.98.4")
+(define q-version "0.98.5")


### PR DESCRIPTION
W3: Test quality + version bump.

- F-06: Replaced structural `procedure?` check in `tests/test-browser-audit-w1-v0984.rkt` with behavioral test verifying `start-heartbeat!` reads custodian dynamically from state
- Made `heartbeat-interval-secs` a parameter in `playwright-sidecar.rkt` for testability
- GAP-V2: Verified clarifying comment in `extensions/image-pipeline.rkt` that resize pipeline is scaffold-only and not wired to browser screenshots
- Bumped version 0.98.4 → 0.98.5 in `util/version.rkt` and `info.rkt`
- Added comprehensive v0.98.5 CHANGELOG entry covering W0–W3

Production code: `playwright-sidecar.rkt`
Tests: all browser-focused tests pass (65/65 browser + context-overflow)

Closes #7886, closes #7887, closes #7888, closes #7889