### PR TITLE
fix: W0 correctness/dedup F-03 F-04 F-08 NF-11d (#7895)

### DIFF
--- a/extensions/image-format.rkt
+++ b/extensions/image-format.rkt
@@ -32,7 +32,9 @@
 ;; Format an image for Gemini's generateContent API.
 ;; Returns an inlineData block with mimeType.
 (define (format-image-gemini base64-data media-type)
-  (hasheq 'type "inlineData" 'inlineData (hasheq 'mimeType media-type 'data base64-data)))
+  ;; F-04: Canonical Gemini shape is {inlineData: {mimeType, data}}.
+  ;; The 'type discriminator is internal and inconsistent with openai-block->gemini.
+  (hasheq 'inlineData (hasheq 'mimeType media-type 'data base64-data)))
 
 ;; ═══════════════════════════════════════════════════════════════════
 ;; Dispatch

--- a/tests/test-context-overflow-browser.rkt
+++ b/tests/test-context-overflow-browser.rkt
@@ -37,16 +37,16 @@
   (define h (observation->hash obs))
   (define tc (hash-ref h 'text-content))
   (check-true (string? tc))
-  (check-equal? (string-length tc) 4016) ; 4000 + "\n... [truncated]"
-  (check-true (string-suffix? tc "\n... [truncated]")))
+  (check-equal? (string-length tc) 4015) ; 4000 + "\n...(truncated)"
+  (check-true (string-suffix? tc "\n...(truncated)")))
 
 (test-case "observation->hash truncates visible-text at 4000 chars"
   (define obs (make-big-observation 5000))
   (define h (observation->hash obs))
   (define vt (hash-ref h 'visible-text))
   (check-true (string? vt))
-  (check-equal? (string-length vt) 4016)
-  (check-true (string-suffix? vt "\n... [truncated]")))
+  (check-equal? (string-length vt) 4015)
+  (check-true (string-suffix? vt "\n...(truncated)")))
 
 (test-case "observation->hash preserves short text unchanged"
   (define obs (make-big-observation 100))
@@ -74,6 +74,49 @@
   (define entry (make-tool-result-message small-text))
   (define result (summarize-tool-result entry))
   (check-equal? result entry))
+
+;; ---------------------------------------------------------------------------
+;; NF-11d: dom-summary is also truncated (F-08)
+;; ---------------------------------------------------------------------------
+
+(test-case "observation->hash truncates dom-summary at 4000 chars"
+  (define obs
+    (browser-observation "https://example.com"
+                         "Title"
+                         "short"
+                         "short"
+                         (make-string 5000 #\d)
+                         #f
+                         #f
+                         #f
+                         '()
+                         '()
+                         #f
+                         '()
+                         #f))
+  (define h (observation->hash obs))
+  (define ds (hash-ref h 'dom-summary))
+  (check-true (string? ds))
+  (check-equal? (string-length ds) 4015)
+  (check-true (string-suffix? ds "\n...(truncated)")))
+
+(test-case "observation->hash preserves short dom-summary unchanged"
+  (define obs
+    (browser-observation "https://example.com"
+                         "Title"
+                         "short"
+                         "short"
+                         "small summary"
+                         #f
+                         #f
+                         #f
+                         '()
+                         '()
+                         #f
+                         '()
+                         #f))
+  (define h (observation->hash obs))
+  (check-equal? (hash-ref h 'dom-summary) "small summary"))
 
 (test-case "summarize-tool-result truncates multi-line text > 40 lines"
   ;; 50 lines × 200 chars = 10000 chars, exceeds 8000 limit

--- a/tests/test-image-format-contracts.rkt
+++ b/tests/test-image-format-contracts.rkt
@@ -31,7 +31,9 @@
     (test-case "format-image-gemini with valid inputs returns hash"
       (define result (format-image-gemini "dGVzdA==" "image/webp"))
       (check-true (hash? result))
-      (check-equal? (hash-ref result 'type) "inlineData"))
+      ;; F-04: Canonical Gemini shape has no 'type key.
+      (check-false (hash-has-key? result 'type))
+      (check-true (hash-has-key? result 'inlineData)))
 
     (test-case "format-image-for-provider dispatches correctly"
       (define openai-result (format-image-for-provider 'openai "dGVzdA==" "image/png"))

--- a/tests/test-image-format.rkt
+++ b/tests/test-image-format.rkt
@@ -50,13 +50,15 @@
 
     (test-case "format-image-gemini produces inlineData block"
       (define result (format-image-gemini "abc123" "image/png"))
-      (check-equal? (hash-ref result 'type) "inlineData")
+      ;; F-04: Canonical Gemini shape is {inlineData: {...}} with no 'type key.
+      (check-false (hash-has-key? result 'type))
       (define inline-data (hash-ref result 'inlineData))
       (check-equal? (hash-ref inline-data 'mimeType) "image/png")
       (check-equal? (hash-ref inline-data 'data) "abc123"))
 
     (test-case "format-image-gemini handles webp"
       (define result (format-image-gemini "xyz" "image/webp"))
+      (check-false (hash-has-key? result 'type))
       (check-equal? (hash-ref (hash-ref result 'inlineData) 'mimeType) "image/webp"))
 
     ;; ============================================================
@@ -77,11 +79,13 @@
 
     (test-case "format-image-for-provider gemini"
       (define result (format-image-for-provider 'gemini "abc" "image/png"))
-      (check-equal? (hash-ref result 'type) "inlineData"))
+      (check-false (hash-has-key? result 'type))
+      (check-true (hash-has-key? result 'inlineData)))
 
     (test-case "format-image-for-provider google alias"
       (define result (format-image-for-provider 'google "abc" "image/png"))
-      (check-equal? (hash-ref result 'type) "inlineData"))
+      (check-false (hash-has-key? result 'type))
+      (check-true (hash-has-key? result 'inlineData)))
 
     (test-case "format-image-for-provider azure uses openai format"
       (define result (format-image-for-provider 'azure "abc" "image/png"))

--- a/tools/builtins/browser-tools.rkt
+++ b/tools/builtins/browser-tools.rkt
@@ -19,6 +19,7 @@
          "../../util/error/errors.rkt"
          "../../browser/settings.rkt"
          "../../util/content/content-parts.rkt"
+         "../../util/truncation.rkt"
          "../tool.rkt")
 
 (provide handle-browser-open
@@ -76,9 +77,10 @@
 ;; context budget. 4000 chars preserves the first ~1K tokens.
 (define MAX-OBSERVATION-TEXT 4000)
 
+;; F-03: Delegate to the canonical truncation utility instead of duplicating logic.
 (define (truncate-observation-text text)
-  (if (and (string? text) (> (string-length text) MAX-OBSERVATION-TEXT))
-      (string-append (substring text 0 MAX-OBSERVATION-TEXT) "\n... [truncated]")
+  (if (string? text)
+      (truncate-to-n-chars text MAX-OBSERVATION-TEXT)
       text))
 
 (define (observation->hash obs)
@@ -91,7 +93,7 @@
           'visible-text
           (truncate-observation-text (browser-observation-visible-text obs))
           'dom-summary
-          (browser-observation-dom-summary obs)
+          (truncate-observation-text (browser-observation-dom-summary obs))
           'console-errors
           (browser-observation-console-errors obs)
           'viewport-size


### PR DESCRIPTION
W0: P0 Correctness & Dedup for v0.98.6 final closure.

Changes:
- F-03: Deduplicated `truncate-observation-text` by delegating to `truncate-to-n-chars` from `util/truncation.rkt`
- F-04: Harmonized Gemini image block shape — removed redundant 'type key so canonical shape is `{inlineData: {...}}`
- F-08: Applied `truncate-observation-text` to `dom-summary` in `observation->hash`
- NF-11d: Added dom-summary truncation verification tests
- Updated expected truncation suffix/length in `test-context-overflow-browser.rkt`
- Updated `test-image-format.rkt` and `test-image-format-contracts.rkt` for new Gemini shape

Validation:
- `raco make main.rkt` clean
- `test-context-overflow-browser.rkt`: 8/8 pass
- `test-image-format.rkt`: 13/13 pass
- `test-image-format-contracts.rkt`: 12/12 pass

Closes #7895, closes #7896, closes #7897, closes #7898, closes #7899