### PR TITLE
fix: W1 tests/contracts F-07 F-06 CON-01/02/03 (#7900)

### DIFF
--- a/browser/adapters/playwright-sidecar.rkt
+++ b/browser/adapters/playwright-sidecar.rkt
@@ -12,6 +12,7 @@
 
 (require racket/match
          racket/async-channel
+         racket/contract
          (only-in file/sha1 bytes->hex-string)
          (only-in racket/random crypto-random-bytes)
          json
@@ -21,18 +22,36 @@
          net/base64)
 
 (provide (struct-out playwright-sidecar-state)
-         launch-sidecar!
-         shutdown-sidecar!
-         send-command!
-         send-command-with-recovery!
-         restart-sidecar!
-         start-heartbeat!
-         heartbeat-interval-secs
-         max-sidecar-restarts
-         uuid-string
-         make-playwright-adapter
-         make-reader-body
-         launch-sidecar-process!)
+         (contract-out
+          [launch-sidecar!
+           (->* [path-string?]
+                [#:node-path string? #:timeout-ms exact-nonnegative-integer? #:headless? boolean?]
+                playwright-sidecar-state?)]
+          [shutdown-sidecar!
+           (->* [playwright-sidecar-state?] [#:timeout-ms exact-nonnegative-integer?] void?)]
+          [send-command!
+           (->* [playwright-sidecar-state? string? hash?]
+                [#:timeout-ms (or/c #f exact-nonnegative-integer?)]
+                any/c)]
+          [send-command-with-recovery!
+           (->* [playwright-sidecar-state? string? hash?]
+                [#:timeout-ms (or/c #f exact-nonnegative-integer?)
+                 #:max-retries exact-nonnegative-integer?]
+                any/c)]
+          [restart-sidecar! (-> playwright-sidecar-state? void?)]
+          [start-heartbeat! (-> playwright-sidecar-state? void?)]
+          [heartbeat-interval-secs (parameter/c real?)]
+          [max-sidecar-restarts exact-nonnegative-integer?]
+          [uuid-string (-> string?)]
+          [make-playwright-adapter
+           (->* [path-string?]
+                [#:node-path string? #:timeout-ms exact-nonnegative-integer? #:headless? boolean?]
+                browser-adapter?)]
+          [make-reader-body (-> playwright-sidecar-state? (-> any))]
+          [launch-sidecar-process!
+           (-> playwright-sidecar-state? path-string? string? boolean? custodian?)])
+         ;; Re-export for adapter.rkt reference
+         browser-adapter?)
 
 ;; ---------------------------------------------------------------------------
 ;; Sidecar state struct

--- a/browser/service.rkt
+++ b/browser/service.rkt
@@ -12,18 +12,32 @@
          "session.rkt"
          "audit.rkt"
          "settings.rkt"
+         racket/contract
          "../util/error/errors.rkt")
 
 (provide secure-browser-service?
-         make-secure-browser-service
-         generate-session-id
-         browser-open!
-         browser-observe!
-         browser-act!
-         browser-close!
-         browser-navigate!
-         browser-screenshot!
-         enforce-screenshot-max-bytes
+         (contract-out
+          [make-secure-browser-service
+           (->*
+            [browser-adapter?]
+            [#:settings browser-settings? #:event-bus any/c #:artifact-dir (or/c #f string? path?)]
+            secure-browser-service?)]
+          [generate-session-id (-> string?)]
+          [browser-open!
+           (->* [secure-browser-service? string?]
+                [#:options any/c]
+                any)] ; returns (values string? any) — adapter determines result type
+          [browser-observe!
+           (->* [secure-browser-service? (or/c #f string?)] [#:selector (or/c #f string?)] any)]
+          [browser-act! (-> secure-browser-service? (or/c #f string?) browser-action? any)]
+          [browser-close! (-> secure-browser-service? (or/c #f string?) void?)]
+          [browser-navigate! (-> secure-browser-service? (or/c #f string?) string? any)]
+          [browser-screenshot!
+           (->* [secure-browser-service? (or/c #f string?)]
+                [#:selector (or/c #f string?) #:format string?]
+                any)]
+          [enforce-screenshot-max-bytes
+           (-> browser-observation? exact-nonnegative-integer? browser-observation?)])
          current-browser-service)
 
 ;; ---------------------------------------------------------------------------

--- a/browser/workflow.rkt
+++ b/browser/workflow.rkt
@@ -7,9 +7,10 @@
 
 (require "types.rkt"
          "service.rkt"
+         racket/contract
          "../util/error/errors.rkt")
 
-(provide browser-check-local-app)
+(provide (contract-out [browser-check-local-app (-> hash? hash?)]))
 
 ;; ---------------------------------------------------------------------------
 ;; browser-check-local-app — Quick local app health check

--- a/tests/test-browser-service.rkt
+++ b/tests/test-browser-service.rkt
@@ -154,7 +154,8 @@
 ;; ---------------------------------------------------------------------------
 
 (test-case "error: adapter error wrapped as q-browser-error"
-  (define adapter (make-mock-adapter #:error-mode 'timeout))
+  (define mock (make-mock-adapter #:error-mode 'timeout))
+  (define adapter (wrap-mock-adapter mock))
   (define settings
     (browser-settings #t
                       '("https")

--- a/tests/test-context-overflow-browser.rkt
+++ b/tests/test-context-overflow-browser.rkt
@@ -118,6 +118,34 @@
   (define h (observation->hash obs))
   (check-equal? (hash-ref h 'dom-summary) "small summary"))
 
+;; ---------------------------------------------------------------------------
+;; F-07: Boundary tests for truncation
+;; ---------------------------------------------------------------------------
+
+(test-case "observation->hash: exact boundary — 4000 chars unchanged"
+  (define obs (make-big-observation 4000))
+  (define h (observation->hash obs))
+  (check-equal? (string-length (hash-ref h 'text-content)) 4000)
+  (check-false (string-contains? (hash-ref h 'text-content) "truncated")))
+
+(test-case "observation->hash: exact boundary — 4001 chars triggers truncation"
+  (define obs (make-big-observation 4001))
+  (define h (observation->hash obs))
+  (define tc (hash-ref h 'text-content))
+  (check-true (< (string-length tc) 4020))
+  (check-true (string-contains? tc "(truncated)")))
+
+(test-case "observation->hash: empty string preserved"
+  (define obs (make-big-observation 0))
+  (define h (observation->hash obs))
+  (check-equal? (hash-ref h 'text-content) ""))
+
+(test-case "observation->hash: dom-summary #f preserved"
+  (define obs
+    (browser-observation "https://example.com" "Title" "short" "short" #f #f #f #f '() '() #f '() #f))
+  (define h (observation->hash obs))
+  (check-false (hash-ref h 'dom-summary)))
+
 (test-case "summarize-tool-result truncates multi-line text > 40 lines"
   ;; 50 lines × 200 chars = 10000 chars, exceeds 8000 limit
   (define many-lines


### PR DESCRIPTION
W1: P1 Tests & Contracts for v0.98.6 final closure.

Changes:
- F-07: Added boundary tests for truncation (exact 4000/4001 chars, empty string, dom-summary #f)
- F-06: Verified NF-03 heartbeat behavioral test already adequate (no code change needed)
- CON-01: Added contract-out to playwright-sidecar.rkt public exports (13 functions)
- CON-02: Added contract-out to browser/service.rkt public exports (10 functions)
- CON-03: Added contract-out to browser/workflow.rkt public export
- Fixed test-browser-service.rkt to wrap mock adapter before passing to make-secure-browser-service

Validation:
- raco make main.rkt clean
- test-context-overflow-browser.rkt: 12/12 pass
- test-browser-audit-w1-v0984.rkt: 4/4 pass
- test-browser-service.rkt: 26/26 pass
- test-browser-service-adapter.rkt: 8/8 pass
- test-browser-tools.rkt: 25/25 pass
- test-browser-workflow.rkt: 15/15 pass
- test-browser-sidecar-recovery.rkt: 6/6 pass
- test-image-format.rkt: 13/13 pass
- test-image-format-contracts.rkt: 12/12 pass

Closes #7900, closes #7901, closes #7902, closes #7903, closes #7904, closes #7905