### PR TITLE
test: W0 characterize MCP governance bypass

### DIFF
--- a/tests/test-mcp-security-gates.rkt
+++ b/tests/test-mcp-security-gates.rkt
@@ -10,6 +10,9 @@
 (require rackunit
          rackunit/text-ui
          json
+         racket/file
+         racket/runtime-path
+         racket/string
          "../extensions/mcp-adapter.rkt"
          "../tools/registry.rkt"
          (only-in "../tools/tool.rkt"
@@ -47,6 +50,8 @@
 
 (define (json-roundtrip v)
   (string->jsexpr (jsexpr->string v)))
+
+(define-runtime-path run-modes-path "../wiring/run-modes.rkt")
 
 (define suite
   (test-suite "MCP Security Gates (W1 Remediation)"
@@ -91,6 +96,37 @@
       ;; FIX: exec-fn was called for the known tool
       (check-not-false (unbox calls) "execute-fn was called for known tool")
       (check-not-false (hash-ref resp 'result #f) "result returned from execute-fn"))
+
+    (test-case "F-01 CHARACTERIZE: MCP adapter invokes execute-fn without execution context"
+      ;; v0.99.11 W0: This is a repro harness for the remaining governance
+      ;; blocker. handle-mcp-request exposes only (tool-name args) to the
+      ;; execution function; there is no governed execution context argument.
+      ;; W1 should replace this characterization with a positive governed-path
+      ;; assertion.
+      (define reg (make-test-registry))
+      (define observed-arity (box #f))
+      (define observed-call (box #f))
+      (define exec-fn
+        (lambda args
+          (set-box! observed-arity (length args))
+          (set-box! observed-call args)
+          (hasheq 'content (list (hasheq 'type "text" 'text "ok")))))
+      (define req (json-roundtrip (build-mcp-tools-call 1 "echo" (hasheq 'text "hi"))))
+      (define resp (handle-mcp-request req reg exec-fn))
+      (check-equal? (unbox observed-arity)
+                    2
+                    "current MCP adapter calls execute-fn with only name and args")
+      (check-equal? (map values (unbox observed-call)) (list "echo" (hasheq 'text "hi")))
+      (check-not-false (hash-ref resp 'result #f)))
+
+    (test-case "F-01 CHARACTERIZE: run-modes MCP wiring still direct-executes tools with ctx #f"
+      ;; Source-level characterization for the exact independent-audit finding.
+      ;; This test intentionally records the current unsafe wiring so W1 has a
+      ;; stable red/green target: the direct `(tool-execute ... args #f)` path
+      ;; must disappear when governed MCP execution is introduced.
+      (define run-modes-source (file->string run-modes-path))
+      (check-not-false (string-contains? run-modes-source "((tool-execute t) args #f)")
+                       "current run-modes MCP path directly invokes tool-execute with ctx #f"))
 
     (test-case "C2 FIXED: tool-result struct IS converted to MCP-compatible jsexpr"
       ;; W1 FIX: handle-mcp-request now checks tool-result? and converts.


### PR DESCRIPTION
## Summary
- Add W0 characterization coverage for the remaining MCP execution-governance blocker.
- Record that MCP adapter currently invokes execute-fn with only `(tool-name args)` and no execution context.
- Record that run-modes MCP server wiring still contains direct `tool-execute` with `ctx #f`.

## Verification
- `raco make main.rkt`
- `racket tests/test-mcp-security-gates.rkt` — 13/13 pass
- `timeout 1200 racket scripts/run-tests.rkt --suite fast` — known red: 912 files, 835 passed, 77 failed; 11417 tests, 11297 passed, 120 failed; 5 zero-parsed sentinels

Closes #8058