### PR TITLE
fix: govern MCP tool execution

### DIFF
--- a/tests/test-mcp-security-gates.rkt
+++ b/tests/test-mcp-security-gates.rkt
@@ -14,13 +14,15 @@
          racket/runtime-path
          racket/string
          "../extensions/mcp-adapter.rkt"
+         (only-in "../wiring/run-modes.rkt" make-mcp-governed-execute-fn)
          "../tools/registry.rkt"
          (only-in "../tools/tool.rkt"
                   make-tool
                   make-success-result
                   make-error-result
                   tool-result?
-                  tool-result->jsexpr)
+                  tool-result->jsexpr
+                  exec-context?)
          "../runtime/settings-query.rkt"
          (only-in "../runtime/settings.rkt" q-settings))
 
@@ -97,36 +99,30 @@
       (check-not-false (unbox calls) "execute-fn was called for known tool")
       (check-not-false (hash-ref resp 'result #f) "result returned from execute-fn"))
 
-    (test-case "F-01 CHARACTERIZE: MCP adapter invokes execute-fn without execution context"
-      ;; v0.99.11 W0: This is a repro harness for the remaining governance
-      ;; blocker. handle-mcp-request exposes only (tool-name args) to the
-      ;; execution function; there is no governed execution context argument.
-      ;; W1 should replace this characterization with a positive governed-path
-      ;; assertion.
-      (define reg (make-test-registry))
-      (define observed-arity (box #f))
-      (define observed-call (box #f))
-      (define exec-fn
-        (lambda args
-          (set-box! observed-arity (length args))
-          (set-box! observed-call args)
-          (hasheq 'content (list (hasheq 'type "text" 'text "ok")))))
-      (define req (json-roundtrip (build-mcp-tools-call 1 "echo" (hasheq 'text "hi"))))
+    (test-case "F-01 FIXED: MCP governed execute fn supplies execution context"
+      ;; v0.99.11 W1: MCP tools/call must route through the governed scheduler
+      ;; path, which supplies a real exec-context to the tool handler.
+      (define reg (make-tool-registry))
+      (define observed-ctx (box #f))
+      (register-tool! reg
+                      (make-tool "ctx-probe"
+                                 "Probe execution context"
+                                 (hasheq 'type "object" 'properties (hasheq))
+                                 (lambda (args ctx)
+                                   (set-box! observed-ctx ctx)
+                                   (make-success-result "ok"))))
+      (define exec-fn (make-mcp-governed-execute-fn reg #:working-directory (current-directory)))
+      (define req (json-roundtrip (build-mcp-tools-call 1 "ctx-probe" (hasheq))))
       (define resp (handle-mcp-request req reg exec-fn))
-      (check-equal? (unbox observed-arity)
-                    2
-                    "current MCP adapter calls execute-fn with only name and args")
-      (check-equal? (map values (unbox observed-call)) (list "echo" (hasheq 'text "hi")))
-      (check-not-false (hash-ref resp 'result #f)))
+      (check-not-false (hash-ref resp 'result #f))
+      (check-true (exec-context? (unbox observed-ctx))
+                  "governed MCP execution supplies a real exec-context, not #f"))
 
-    (test-case "F-01 CHARACTERIZE: run-modes MCP wiring still direct-executes tools with ctx #f"
-      ;; Source-level characterization for the exact independent-audit finding.
-      ;; This test intentionally records the current unsafe wiring so W1 has a
-      ;; stable red/green target: the direct `(tool-execute ... args #f)` path
-      ;; must disappear when governed MCP execution is introduced.
+    (test-case "F-01 FIXED: run-modes MCP wiring no longer direct-executes tools with ctx #f"
+      ;; Source-level regression guard for the exact independent-audit finding.
       (define run-modes-source (file->string run-modes-path))
-      (check-not-false (string-contains? run-modes-source "((tool-execute t) args #f)")
-                       "current run-modes MCP path directly invokes tool-execute with ctx #f"))
+      (check-false (string-contains? run-modes-source "((tool-execute t) args #f)")
+                   "run-modes MCP path must not directly invoke tool-execute with ctx #f"))
 
     (test-case "C2 FIXED: tool-result struct IS converted to MCP-compatible jsexpr"
       ;; W1 FIX: handle-mcp-request now checks tool-result? and converts.

--- a/wiring/run-modes.rkt
+++ b/wiring/run-modes.rkt
@@ -93,7 +93,8 @@
                   mcp-enabled?
                   mcp-server-enabled?
                   mcp-server-transport)
-         (only-in "../extensions/mcp-adapter.rkt" run-mcp-stdio-server! current-mcp-execute-fn))
+         (only-in "../extensions/mcp-adapter.rkt" run-mcp-stdio-server! current-mcp-execute-fn)
+         (only-in "../tools/scheduler.rkt" run-tool-batch scheduler-result-results))
 
 ;; Re-export mode runners from sub-modules
 (require "run-interactive.rkt"
@@ -111,7 +112,43 @@
          run-json
          run-rpc
          run-print-mode
-         wire-runtime-parameters!)
+         wire-runtime-parameters!
+         make-mcp-governed-execute-fn)
+
+;; ============================================================
+;; MCP governed tool execution
+;; ============================================================
+
+(define (make-mcp-event-publisher bus session-id)
+  (and bus
+       (lambda (event-type payload)
+         (publish! bus
+                   (make-event event-type (current-inexact-milliseconds) session-id #f payload)))))
+
+(define (make-mcp-governed-execute-fn registry
+                                      #:working-directory [working-directory #f]
+                                      #:event-publisher [event-publisher #f]
+                                      #:runtime-settings [runtime-settings #f]
+                                      #:session-metadata [session-metadata #f]
+                                      #:permission-config [permission-config #f]
+                                      #:hook-dispatcher [hook-dispatcher #f])
+  (lambda (tool-name args)
+    (define call-id (format "mcp-~a" (current-inexact-milliseconds)))
+    (define sched-result
+      (run-tool-batch (list (make-tool-call call-id tool-name args))
+                      registry
+                      #:hook-dispatcher hook-dispatcher
+                      #:exec-context (make-exec-context #:working-directory working-directory
+                                                        #:event-publisher event-publisher
+                                                        #:runtime-settings runtime-settings
+                                                        #:call-id call-id
+                                                        #:session-metadata session-metadata
+                                                        #:permission-config permission-config)
+                      #:parallel? #f))
+    (define results (scheduler-result-results sched-result))
+    (if (pair? results)
+        (car results)
+        (make-error-result (format "tool '~a' produced no result" tool-name)))))
 
 ;; ============================================================
 ;; build-runtime-from-cli
@@ -241,14 +278,14 @@
   ;; Feature-gated: zero behavioral change when disabled (default).
   (when (and (mcp-enabled? settings) (mcp-server-enabled? settings))
     (log-info "mcp: starting MCP stdio server (transport=~a)" (mcp-server-transport settings))
-    ;; Wire tool execution: route MCP tools/call to the tool registry
-    (current-mcp-execute-fn
-     (lambda (tool-name args)
-       (define t (lookup-tool reg tool-name))
-       (if t
-           ((tool-execute t) args #f)
-           (hasheq 'content
-                   (list (hasheq 'type "text" 'text (format "unknown tool: ~a" tool-name)))))))
+    ;; Wire tool execution: route MCP tools/call through the governed scheduler path.
+    (current-mcp-execute-fn (make-mcp-governed-execute-fn
+                             reg
+                             #:working-directory project-dir
+                             #:event-publisher (make-mcp-event-publisher bus (current-gsd-session-id))
+                             #:runtime-settings settings
+                             #:session-metadata
+                             (hasheq 'session-id (current-gsd-session-id) 'route 'mcp)))
     (run-mcp-stdio-server! reg)
     (exit 0))
 


### PR DESCRIPTION
## Summary
- Add `make-mcp-governed-execute-fn` to route MCP `tools/call` execution through `run-tool-batch`.
- Supply a real `exec-context` to MCP tool handlers instead of direct `tool-execute` with `ctx #f`.
- Flip W0 characterization tests to positive W1 assertions.

## Verification
- TDD red: `tests/test-mcp-security-gates.rkt` failed before production export/implementation.
- `raco make main.rkt`
- MCP focused suite passed:
  - `tests/test-mcp-adapter.rkt` 31/31
  - `tests/test-mcp-config.rkt` 17/17
  - `tests/test-mcp-events.rkt` 12/12
  - `tests/test-mcp-integration.rkt` 10/10
  - `tests/test-mcp-protocol-compliance.rkt` 7/7
  - `tests/test-mcp-security-gates.rkt` 13/13
- `timeout 1200 racket scripts/run-tests.rkt --suite fast` known red: 912 files, 834 passed, 78 failed; 11417 tests, 11296 passed, 121 failed; 5 zero-parsed sentinels

Closes #8060