### PR TITLE
fix: MCP params validation, error redaction, capability symbol polish

### DIFF
--- a/extensions/mcp-adapter.rkt
+++ b/extensions/mcp-adapter.rkt
@@ -94,6 +94,7 @@
 ;; Extracted from handle-mcp-request to keep match clauses readable.
 (define (handle-tools-call req id registry execute-fn)
   ;; H3: Validate params presence — return -32602 if missing.
+  ;; F-02 (v0.99.11 W2): Validate params type and structure.
   (cond
     [(not (hash-has-key? req 'params))
      (hasheq 'jsonrpc
@@ -104,9 +105,37 @@
              (hasheq 'code -32602 'message "Invalid params: missing 'params'"))]
     [else
      (define params (hash-ref req 'params))
-     (define tool-name-str (hash-ref params 'name ""))
-     (define tool-args (hash-ref params 'arguments (hasheq)))
-     (handle-tools-call-exec id tool-name-str tool-args registry execute-fn)]))
+     (cond
+       ;; F-02: params must be a hash/object.
+       [(not (hash? params))
+        (hasheq 'jsonrpc
+                "2.0"
+                'id
+                id
+                'error
+                (hasheq 'code -32602 'message "Invalid params: params must be an object"))]
+       [else
+        (define tool-name-str (hash-ref params 'name ""))
+        (define tool-args (hash-ref params 'arguments (hasheq)))
+        (cond
+          ;; F-02: name must be a non-empty string.
+          [(not (and (string? tool-name-str) (positive? (string-length tool-name-str))))
+           (hasheq
+            'jsonrpc
+            "2.0"
+            'id
+            id
+            'error
+            (hasheq 'code -32602 'message "Invalid params: 'name' must be a non-empty string"))]
+          ;; F-02: arguments must be a hash/object if present.
+          [(not (hash? tool-args))
+           (hasheq 'jsonrpc
+                   "2.0"
+                   'id
+                   id
+                   'error
+                   (hasheq 'code -32602 'message "Invalid params: 'arguments' must be an object"))]
+          [else (handle-tools-call-exec id tool-name-str tool-args registry execute-fn)])])]))
 
 ;; Inner handler for tools/call once params are validated.
 ;; C1: check tool existence. H3: wrap exceptions. C2: convert tool-result.
@@ -146,17 +175,9 @@
                             #f
                             #:route (raw-result-route raw-result)
                             #:error-code -32603)
-     (hasheq 'jsonrpc
-             "2.0"
-             'id
-             id
-             'error
-             (hasheq 'code
-                     -32603
-                     'message
-                     "Internal error"
-                     'data
-                     (hasheq 'detail (hash-ref raw-result '__internal-error))))]
+     ;; F-03 (v0.99.11 W2): Do NOT expose internal exception details to clients.
+     ;; The error message is logged server-side only.
+     (hasheq 'jsonrpc "2.0" 'id id 'error (hasheq 'code -32603 'message "Internal error"))]
     [else
      ;; C2 (v0.99.10 W1): Convert tool-result structs to MCP-compatible jsexpr.
      (define result

--- a/tests/test-capability-token-hardening.rkt
+++ b/tests/test-capability-token-hardening.rkt
@@ -120,6 +120,22 @@
 
     (test-case "future token rejected"
       (define token (sign-capability-token 'file-write "agent-X" SECRET #:timestamp 10000))
-      (check-false (validate-capability-token token SECRET #:now 100)))))
+      (check-false (validate-capability-token token SECRET #:now 100)))
+
+    ;; ════════════════════════════════════════════════════════════
+    ;; F-06 LOW: Symbol capabilities must be validated as strictly as strings
+    ;; ════════════════════════════════════════════════════════════
+
+    (test-case "F-06 FIXED: symbol with colons is rejected at signing"
+      ;; A symbol like '|invalid:symbol| would produce a capability string
+      ;; containing colons, which would break token parsing on validation.
+      ;; After the fix, sign-capability-token should reject such symbols
+      ;; via the capability-input? contract.
+      (check-exn exn:fail:contract?
+                 (lambda () (sign-capability-token '|invalid:symbol| "agent-A" SECRET))))
+
+    (test-case "F-06 FIXED: normal symbol still works after tightening"
+      (define token (sign-capability-token 'read-only "agent-A" SECRET #:timestamp 1000))
+      (check-equal? (validate-capability-token token SECRET #:now 1100) 'read-only))))
 
 (run-tests suite)

--- a/tests/test-mcp-security-gates.rkt
+++ b/tests/test-mcp-security-gates.rkt
@@ -200,6 +200,92 @@
 
     (test-case "transport works correctly for symbols"
       (define settings (make-settings-from-paths (list '(mas mcp server transport) 'stdio)))
-      (check-equal? (mcp-server-transport settings) "stdio"))))
+      (check-equal? (mcp-server-transport settings) "stdio"))
+
+    ;; ════════════════════════════════════════════════════════════
+    ;; F-02 HIGH: Malformed tools/call params must return -32602, not crash
+    ;; ════════════════════════════════════════════════════════════
+
+    (test-case "F-02 FIXED: params not a hash returns -32602 without exception"
+      (define reg (make-test-registry))
+      (define exec-fn (lambda (name args) (hasheq 'content '())))
+      (define req
+        (json-roundtrip (hasheq 'jsonrpc "2.0" 'id 1 'method "tools/call" 'params "not-a-hash")))
+      (define resp (handle-mcp-request req reg exec-fn))
+      (check-true (mcp-error-response? resp))
+      (check-equal? (mcp-error-code resp) -32602))
+
+    (test-case "F-02 FIXED: name as number returns -32602 without exception"
+      (define reg (make-test-registry))
+      (define exec-fn (lambda (name args) (hasheq 'content '())))
+      (define req
+        (json-roundtrip (hasheq 'jsonrpc
+                                "2.0"
+                                'id
+                                1
+                                'method
+                                "tools/call"
+                                'params
+                                (hasheq 'name 42 'arguments (hasheq)))))
+      (define resp (handle-mcp-request req reg exec-fn))
+      (check-true (mcp-error-response? resp))
+      (check-equal? (mcp-error-code resp) -32602))
+
+    (test-case "F-02 FIXED: arguments as string returns -32602 without exception"
+      (define reg (make-test-registry))
+      (define exec-fn (lambda (name args) (hasheq 'content '())))
+      (define req
+        (json-roundtrip (hasheq 'jsonrpc
+                                "2.0"
+                                'id
+                                1
+                                'method
+                                "tools/call"
+                                'params
+                                (hasheq 'name "echo" 'arguments "not-a-hash"))))
+      (define resp (handle-mcp-request req reg exec-fn))
+      (check-true (mcp-error-response? resp))
+      (check-equal? (mcp-error-code resp) -32602))
+
+    (test-case "F-02 FIXED: empty name returns -32602 without exception"
+      (define reg (make-test-registry))
+      (define exec-fn (lambda (name args) (hasheq 'content '())))
+      (define req
+        (json-roundtrip (hasheq 'jsonrpc
+                                "2.0"
+                                'id
+                                1
+                                'method
+                                "tools/call"
+                                'params
+                                (hasheq 'name "" 'arguments (hasheq)))))
+      (define resp (handle-mcp-request req reg exec-fn))
+      (check-true (mcp-error-response? resp))
+      (check-equal? (mcp-error-code resp) -32602))
+
+    ;; ════════════════════════════════════════════════════════════
+    ;; F-03 MEDIUM: Internal exception details must not leak to clients
+    ;; ════════════════════════════════════════════════════════════
+
+    (test-case "F-03 FIXED: internal exception details are redacted from client response"
+      (define reg (make-test-registry))
+      (define exec-fn (lambda (name args) (error "secret API key: ABC123XYZ")))
+      (define req (json-roundtrip (build-mcp-tools-call 1 "echo" (hasheq 'text "hi"))))
+      (define resp (handle-mcp-request req reg exec-fn))
+      (check-true (mcp-error-response? resp))
+      (check-equal? (mcp-error-code resp) -32603)
+      ;; The sensitive detail must NOT appear anywhere in the response
+      (define resp-str (jsexpr->string resp))
+      (check-false (regexp-match? #rx"ABC123XYZ" resp-str)
+                   "internal exception detail must not leak to client"))
+
+    (test-case "F-03 FIXED: exception detail not in data field"
+      (define reg (make-test-registry))
+      (define exec-fn (lambda (name args) (error "INTERNAL_PATH=/secret/data")))
+      (define req (json-roundtrip (build-mcp-tools-call 1 "echo" (hasheq 'text "hi"))))
+      (define resp (handle-mcp-request req reg exec-fn))
+      (define err (hash-ref resp 'error #f))
+      (check-false (hash-has-key? (or err (hasheq)) 'data)
+                   "error response must not include data/detail field"))))
 
 (run-tests suite)

--- a/util/security/capability-tokens.rkt
+++ b/util/security/capability-tokens.rkt
@@ -56,7 +56,12 @@
   (and (non-empty-string? v) (not (regexp-match? #rx":" v))))
 
 (define (capability-input? v)
-  (or (symbol? v) (token-field-string? v)))
+  ;; F-06 (v0.99.11 W2): Both symbol and string inputs must pass the same
+  ;; field validation after symbol->string conversion.
+  (and (or (symbol? v) (string? v))
+       (token-field-string? (if (symbol? v)
+                                (symbol->string v)
+                                v))))
 
 (define (secret-key? v)
   (non-empty-string? v))


### PR DESCRIPTION
## Summary
- F-02 HIGH: `handle-tools-call` now validates `params` is a hash, `name` is a non-empty string, and `arguments` is a hash. Malformed inputs return JSON-RPC `-32602 Invalid params` instead of crashing.
- F-03 MEDIUM: `handle-tools-call-result` no longer includes internal exception details in `data.detail`. Internal errors return generic `-32603 Internal error` without leaking implementation details.
- F-06 LOW: `capability-input?` contract tightened so symbols containing colons are rejected at signing time, matching the same validation applied to string inputs.

## TDD
Tests written first, verified red against unfixed code, then fixed:
- 4 new F-02 param validation tests in `test-mcp-security-gates.rkt`
- 2 new F-03 error redaction tests in `test-mcp-security-gates.rkt`
- 2 new F-06 symbol validation tests in `test-capability-token-hardening.rkt`

## Verification
- `raco make main.rkt`: PASS
- MCP focused suite: adapter 31/31, config 17/17, events 12/12, integration 10/10, protocol compliance 7/7, security gates 19/19
- Capability-token suite: tokens 22/22, hardening 18/18
- Broad fast suite: 912 files, 835 passed, 77 failed; 11425 tests, 11305 passed, 120 failed; 5 zero-parsed sentinels; exit 4 (known unrelated red)

Closes #8062