### PR TITLE
feat: W0 certificate infrastructure and mTLS primitives (#8070)

### DIFF
--- a/cli/generate-certificates.rkt
+++ b/cli/generate-certificates.rkt
@@ -1,0 +1,53 @@
+#lang racket/base
+
+;; q/cli/generate-certificates.rkt — q generate-certificates command
+;;
+;; W0 (v0.99.12): Generates a complete mTLS certificate set (CA + server +
+;; client) for use with distributed execution.
+;;
+;; Usage:
+;;   q generate-certificates --output-dir ~/.q/certs
+;;   q generate-certificates --output-dir ~/.q/certs --force
+
+(require racket/contract
+         racket/cmdline
+         racket/file
+         racket/port
+         "../util/security/cert-generator.rkt")
+
+;; ── Main ──
+
+(define (run-generate-certificates args)
+  (define output-dir (make-parameter "~/.q/certs"))
+  (define force? (make-parameter #f))
+  (command-line #:program "q generate-certificates"
+                #:argv args
+                #:once-each
+                [("--output-dir" "-o") dir "Output directory for certificates" (output-dir dir)]
+                [("--force" "-f") "Overwrite existing certificates" (force? #t)]
+                #:args ()
+                (void))
+  (define dir (output-dir))
+  (define resolved-dir
+    (if (string-prefix? dir "~/")
+        (build-path (find-system-path 'home-dir) (substring dir 2))
+        dir))
+  ;; Check for existing certs
+  (define ca-path (build-path resolved-dir "ca.pem"))
+  (when (and (file-exists? ca-path) (not (force?)))
+    (displayln (format "Error: ca.pem already exists in ~a. Use --force to overwrite." resolved-dir))
+    (exit 1))
+  (printf "Generating mTLS certificate set in ~a...~n" resolved-dir)
+  (define paths (generate-cert-set! resolved-dir))
+  (printf "✓ CA certificate: ~a~n" (hash-ref paths 'ca-cert))
+  (printf "✓ Server certificate: ~a~n" (hash-ref paths 'server-cert))
+  (printf "✓ Client certificate: ~a~n" (hash-ref paths 'client-cert))
+  (displayln "")
+  (displayln "Deployment instructions:")
+  (displayln "  1. Copy ca.pem, server.pem, server-key.pem to the executor node")
+  (displayln "  2. Copy ca.pem, client.pem, client-key.pem to the orchestrator node")
+  (displayln "  3. Configure mas.broker.cert-dir to point to the cert directory")
+  (displayln "  4. Set mas.broker.capability-secret to a shared secret")
+  (displayln "  5. Enable mas.broker.enabled = true"))
+
+(provide run-generate-certificates)

--- a/tests/test-cert-generator.rkt
+++ b/tests/test-cert-generator.rkt
@@ -1,0 +1,107 @@
+#lang racket
+
+;; @speed slow  ;; @suite security
+
+;; tests/test-cert-generator.rkt — W0 (v0.99.12) Certificate Generation Tests
+;;
+;; Tests that certificate generation produces valid PEM files that:
+;;   - Can be generated from scratch
+;;   - Are valid PEM format (openssl verifies them)
+;;   - Work with TLS context creation (round-trip)
+
+(require rackunit
+         rackunit/text-ui
+         racket/file
+         racket/system
+         racket/port
+         (only-in "../util/security/cert-generator.rkt"
+                  generate-ca!
+                  generate-server-cert!
+                  generate-client-cert!
+                  generate-cert-set!)
+         (only-in "../util/security/tls-contexts.rkt"
+                  make-server-ssl-context
+                  make-client-ssl-context))
+
+;; ── Helpers ──
+
+(define (file-contains-pem? path)
+  (and (file-exists? path)
+       (regexp-match? #rx"BEGIN (CERTIFICATE|PRIVATE KEY)" (file->string path #:mode 'text))))
+
+(define (openssl-verifies-cert? cert-path ca-path)
+  (define result
+    (parameterize ([current-output-port (open-output-nowhere)]
+                   [current-error-port (open-output-nowhere)])
+      (system/exit-code
+       (format "openssl verify -CAfile ~a ~a" (path->string ca-path) (path->string cert-path)))))
+  (= result 0))
+
+;; ── Shared fixture: generate cert set once ──
+
+(define test-dir (make-temporary-file "certgen-test-~a" 'directory))
+(define cert-paths (generate-cert-set! test-dir))
+
+(define suite
+  (test-suite "Certificate Generation (W0)"
+
+    ;; ════════════════════════════════════════════════════════════
+    ;; CA Generation
+    ;; ════════════════════════════════════════════════════════════
+
+    (test-case "generate-ca! produced valid PEM files"
+      (check-true (file-contains-pem? (hash-ref cert-paths 'ca-cert)) "ca.pem is a valid PEM cert")
+      (check-true (file-contains-pem? (hash-ref cert-paths 'ca-key)) "ca-key.pem is a valid PEM key")
+      (check-true (openssl-verifies-cert? (hash-ref cert-paths 'ca-cert)
+                                          (hash-ref cert-paths 'ca-cert))
+                  "CA cert verifies against itself"))
+
+    ;; ════════════════════════════════════════════════════════════
+    ;; Server Certificate Generation
+    ;; ════════════════════════════════════════════════════════════
+
+    (test-case "generate-server-cert! produced cert signed by CA"
+      (check-true (file-contains-pem? (hash-ref cert-paths 'server-cert))
+                  "server.pem is a valid PEM cert")
+      (check-true (file-contains-pem? (hash-ref cert-paths 'server-key))
+                  "server-key.pem is a valid PEM key")
+      (check-true (openssl-verifies-cert? (hash-ref cert-paths 'server-cert)
+                                          (hash-ref cert-paths 'ca-cert))
+                  "server cert verifies against CA"))
+
+    ;; ════════════════════════════════════════════════════════════
+    ;; Client Certificate Generation
+    ;; ════════════════════════════════════════════════════════════
+
+    (test-case "generate-client-cert! produced cert signed by CA"
+      (check-true (file-contains-pem? (hash-ref cert-paths 'client-cert))
+                  "client.pem is a valid PEM cert")
+      (check-true (file-contains-pem? (hash-ref cert-paths 'client-key))
+                  "client-key.pem is a valid PEM key")
+      (check-true (openssl-verifies-cert? (hash-ref cert-paths 'client-cert)
+                                          (hash-ref cert-paths 'ca-cert))
+                  "client cert verifies against CA"))
+
+    ;; ════════════════════════════════════════════════════════════
+    ;; Full Certificate Set
+    ;; ════════════════════════════════════════════════════════════
+
+    (test-case "generate-cert-set! produced all 6 files"
+      (for ([key '(ca-cert ca-key server-cert server-key client-cert client-key)])
+        (check-true (file-exists? (hash-ref cert-paths key)) (format "~a file exists" key))))
+
+    ;; ════════════════════════════════════════════════════════════
+    ;; Round-trip: generated certs work with TLS contexts
+    ;; ════════════════════════════════════════════════════════════
+
+    (test-case "generated certs create valid TLS contexts"
+      ;; Server context
+      (check-not-false (make-server-ssl-context #:cert-path (hash-ref cert-paths 'server-cert)
+                                                #:key-path (hash-ref cert-paths 'server-key)
+                                                #:ca-path (hash-ref cert-paths 'ca-cert)))
+      ;; Client context
+      (check-not-false (make-client-ssl-context #:cert-path (hash-ref cert-paths 'client-cert)
+                                                #:key-path (hash-ref cert-paths 'client-key)
+                                                #:ca-path (hash-ref cert-paths 'ca-cert))))))
+
+(run-tests suite 'verbose)

--- a/tests/test-tls-contexts.rkt
+++ b/tests/test-tls-contexts.rkt
@@ -1,0 +1,102 @@
+#lang racket
+
+;; @speed slow  ;; @suite security
+
+;; tests/test-tls-contexts.rkt — W0 (v0.99.12) mTLS Context Tests
+;;
+;; Tests that mTLS context creation:
+;;   - Succeeds with valid cert paths
+;;   - Fails clearly with missing cert/key/CA files
+;;   - Produces contexts with mandatory verification enabled
+
+(require rackunit
+         rackunit/text-ui
+         racket/file
+         racket/system
+         racket/port
+         (only-in "../util/security/cert-generator.rkt"
+                  generate-ca!
+                  generate-server-cert!
+                  generate-client-cert!)
+         "../util/security/tls-contexts.rkt")
+
+;; ── Shared test fixture: generate real certs once ──
+
+(define test-certs-dir (make-temporary-file "tls-test-~a" 'directory))
+
+(define-values (ca-cert-path ca-key-path) (generate-ca! test-certs-dir))
+(define-values (server-cert-path server-key-path)
+  (generate-server-cert! test-certs-dir ca-cert-path ca-key-path))
+(define-values (client-cert-path client-key-path)
+  (generate-client-cert! test-certs-dir ca-cert-path ca-key-path))
+
+(define suite
+  (test-suite "mTLS Context Creation (W0)"
+
+    ;; ════════════════════════════════════════════════════════════
+    ;; Server SSL Context
+    ;; ════════════════════════════════════════════════════════════
+
+    (test-case "make-server-ssl-context succeeds with valid certs"
+      (check-not-false (make-server-ssl-context #:cert-path server-cert-path
+                                                #:key-path server-key-path
+                                                #:ca-path ca-cert-path)))
+
+    (test-case "make-server-ssl-context fails with missing cert file"
+      (check-exn exn:fail?
+                 (lambda ()
+                   (make-server-ssl-context #:cert-path "/nonexistent/cert.pem"
+                                            #:key-path server-key-path
+                                            #:ca-path ca-cert-path))))
+
+    (test-case "make-server-ssl-context fails with missing key file"
+      (check-exn exn:fail?
+                 (lambda ()
+                   (make-server-ssl-context #:cert-path server-cert-path
+                                            #:key-path "/nonexistent/key.pem"
+                                            #:ca-path ca-cert-path))))
+
+    (test-case "make-server-ssl-context fails with missing CA file"
+      (check-exn exn:fail?
+                 (lambda ()
+                   (make-server-ssl-context #:cert-path server-cert-path
+                                            #:key-path server-key-path
+                                            #:ca-path "/nonexistent/ca.pem"))))
+
+    ;; ════════════════════════════════════════════════════════════
+    ;; Client SSL Context
+    ;; ════════════════════════════════════════════════════════════
+
+    (test-case "make-client-ssl-context succeeds with valid certs"
+      (check-not-false (make-client-ssl-context #:cert-path client-cert-path
+                                                #:key-path client-key-path
+                                                #:ca-path ca-cert-path)))
+
+    (test-case "make-client-ssl-context fails with missing cert file"
+      (check-exn exn:fail?
+                 (lambda ()
+                   (make-client-ssl-context #:cert-path "/nonexistent/cert.pem"
+                                            #:key-path client-key-path
+                                            #:ca-path ca-cert-path))))
+
+    (test-case "make-client-ssl-context fails with missing key file"
+      (check-exn exn:fail?
+                 (lambda ()
+                   (make-client-ssl-context #:cert-path client-cert-path
+                                            #:key-path "/nonexistent/key.pem"
+                                            #:ca-path ca-cert-path))))
+
+    ;; ════════════════════════════════════════════════════════════
+    ;; Error message quality
+    ;; ════════════════════════════════════════════════════════════
+
+    (test-case "error message mentions which file is missing"
+      (define err-msg
+        (with-handlers ([exn:fail? exn-message])
+          (make-server-ssl-context #:cert-path "/nonexistent/cert.pem"
+                                   #:key-path server-key-path
+                                   #:ca-path ca-cert-path)))
+      (check-true (string-contains? err-msg "server certificate chain")
+                  "error message identifies the missing file type"))))
+
+(run-tests suite 'verbose)

--- a/util/security/cert-generator.rkt
+++ b/util/security/cert-generator.rkt
@@ -1,0 +1,169 @@
+#lang racket/base
+
+;; util/security/cert-generator.rkt — CA + client/server certificate generation
+;; STABILITY: evolving
+;;
+;; W0 (v0.99.12): Generates self-signed CA and CA-signed client/server
+;; certificate pairs using the `openssl` CLI. These certs are used for
+;; mutual-TLS (mTLS) between the orchestrator and executor nodes.
+;;
+;; All certs use RSA 4096-bit keys with 365-day validity.
+;; Output files follow the naming convention:
+;;   ca.pem / ca-key.pem
+;;   server.pem / server-key.pem
+;;   client.pem / client-key.pem
+
+(require racket/contract
+         racket/file
+         racket/string
+         racket/system
+         racket/port)
+
+;; ============================================================
+;; Helpers
+;; ============================================================
+
+(define (run-openssl! args output-dir)
+  (define result
+    (parameterize ([current-directory output-dir]
+                   [current-output-port (open-output-nowhere)]
+                   [current-error-port (open-output-nowhere)])
+      (system/exit-code (format "openssl ~a" (string-join args " ")))))
+  (unless (= result 0)
+    (raise (exn:fail (format "cert-generator: openssl failed with exit code ~a (args: ~a)"
+                             result
+                             (string-join args " "))
+                     (current-continuation-marks))))
+  result)
+
+(define (ensure-output-dir! output-dir)
+  (make-directory* output-dir)
+  output-dir)
+
+;; ============================================================
+;; CA Generation
+;; ============================================================
+
+;; Generate a self-signed CA certificate and private key.
+;; Produces: ca.pem (cert) and ca-key.pem (private key) in output-dir.
+(define (generate-ca! output-dir)
+  (ensure-output-dir! output-dir)
+  (run-openssl! '("req" "-x509"
+                        "-newkey"
+                        "rsa:4096"
+                        "-days"
+                        "365"
+                        "-nodes"
+                        "-keyout"
+                        "ca-key.pem"
+                        "-out"
+                        "ca.pem"
+                        "-subj"
+                        "/CN=q-mtls-ca/O=q-agent")
+                output-dir)
+  (values (build-path output-dir "ca.pem") (build-path output-dir "ca-key.pem")))
+
+;; ============================================================
+;; Server Certificate Generation
+;; ============================================================
+
+;; Generate a server certificate signed by the CA.
+;; Produces: server.pem (cert) and server-key.pem (private key) in output-dir.
+(define (generate-server-cert! output-dir ca-cert-path ca-key-path)
+  (ensure-output-dir! output-dir)
+  ;; Step 1: Generate private key and CSR
+  (run-openssl! '("req" "-newkey"
+                        "rsa:4096"
+                        "-nodes"
+                        "-keyout"
+                        "server-key.pem"
+                        "-out"
+                        "server.csr"
+                        "-subj"
+                        "/CN=q-executor-server/O=q-agent")
+                output-dir)
+  ;; Step 2: Sign CSR with CA
+  (run-openssl! (list "x509"
+                      "-req"
+                      "-in"
+                      "server.csr"
+                      "-CA"
+                      (path->string ca-cert-path)
+                      "-CAkey"
+                      (path->string ca-key-path)
+                      "-CAcreateserial"
+                      "-out"
+                      "server.pem"
+                      "-days"
+                      "365")
+                output-dir)
+  (values (build-path output-dir "server.pem") (build-path output-dir "server-key.pem")))
+
+;; ============================================================
+;; Client Certificate Generation
+;; ============================================================
+
+;; Generate a client certificate signed by the CA.
+;; Produces: client.pem (cert) and client-key.pem (private key) in output-dir.
+(define (generate-client-cert! output-dir ca-cert-path ca-key-path)
+  (ensure-output-dir! output-dir)
+  ;; Step 1: Generate private key and CSR
+  (run-openssl! '("req" "-newkey"
+                        "rsa:4096"
+                        "-nodes"
+                        "-keyout"
+                        "client-key.pem"
+                        "-out"
+                        "client.csr"
+                        "-subj"
+                        "/CN=q-orchestrator-client/O=q-agent")
+                output-dir)
+  ;; Step 2: Sign CSR with CA
+  (run-openssl! (list "x509"
+                      "-req"
+                      "-in"
+                      "client.csr"
+                      "-CA"
+                      (path->string ca-cert-path)
+                      "-CAkey"
+                      (path->string ca-key-path)
+                      "-CAcreateserial"
+                      "-out"
+                      "client.pem"
+                      "-days"
+                      "365")
+                output-dir)
+  (values (build-path output-dir "client.pem") (build-path output-dir "client-key.pem")))
+
+;; ============================================================
+;; Full Certificate Set Generation
+;; ============================================================
+
+;; Generate a complete CA + server + client certificate set.
+;; Returns a hash with all paths.
+(define (generate-cert-set! output-dir)
+  (ensure-output-dir! output-dir)
+  (define-values (ca-cert ca-key) (generate-ca! output-dir))
+  (define-values (server-cert server-key) (generate-server-cert! output-dir ca-cert ca-key))
+  (define-values (client-cert client-key) (generate-client-cert! output-dir ca-cert ca-key))
+  (hasheq 'ca-cert
+          ca-cert
+          'ca-key
+          ca-key
+          'server-cert
+          server-cert
+          'server-key
+          server-key
+          'client-cert
+          client-cert
+          'client-key
+          client-key))
+
+;; ============================================================
+;; Provides
+;; ============================================================
+
+(provide (contract-out [generate-ca! (-> path-string? (values path? path?))]
+                       [generate-server-cert! (-> path-string? path? path? (values path? path?))]
+                       [generate-client-cert! (-> path-string? path? path? (values path? path?))]
+                       [generate-cert-set! (-> path-string? hash?)]))

--- a/util/security/tls-contexts.rkt
+++ b/util/security/tls-contexts.rkt
@@ -1,0 +1,83 @@
+#lang racket/base
+
+;; util/security/tls-contexts.rkt — mTLS context creation wrappers
+;; STABILITY: evolving
+;;
+;; W0 (v0.99.12): Provides safe, fail-loud wrappers around Racket's openssl
+;; module for creating mutual-TLS (mTLS) server and client contexts.
+;;
+;; Both server and client contexts require:
+;;   - A certificate chain PEM file (cert-path)
+;;   - A private key PEM file (key-path)
+;;   - A CA certificate PEM file (ca-path)
+;;
+;; Both contexts enable mandatory certificate verification (ssl-set-verify! #t),
+;; which means:
+;;   - Server context: client must present a valid cert signed by the CA
+;;   - Client context: server must present a valid cert signed by the CA
+;;
+;; All paths are validated at context-creation time. Missing files raise
+;; exn:fail with a clear, actionable error message.
+
+(require racket/contract
+         racket/file
+         openssl)
+
+;; ============================================================
+;; Validation Helpers
+;; ============================================================
+
+(define (file-exists-or-fail! path description)
+  (unless (file-exists? path)
+    (raise (exn:fail (format "mTLS context error: ~a not found at '~a'" description path)
+                     (current-continuation-marks))))
+  path)
+
+;; ============================================================
+;; Server SSL Context
+;; ============================================================
+
+;; Create an mTLS server context with mandatory client-cert verification.
+;; All three paths must point to valid PEM files.
+(define (make-server-ssl-context #:cert-path cert-path #:key-path key-path #:ca-path ca-path)
+  (file-exists-or-fail! cert-path "server certificate chain")
+  (file-exists-or-fail! key-path "server private key")
+  (file-exists-or-fail! ca-path "CA certificate")
+  (define ctx (ssl-make-server-context 'tls))
+  (ssl-load-certificate-chain! ctx cert-path)
+  (ssl-load-private-key! ctx key-path #f #f)
+  (ssl-load-verify-root-certificates! ctx ca-path)
+  (ssl-set-verify! ctx #t)
+  ctx)
+
+;; ============================================================
+;; Client SSL Context
+;; ============================================================
+
+;; Create an mTLS client context with mandatory server-cert verification.
+;; All three paths must point to valid PEM files.
+(define (make-client-ssl-context #:cert-path cert-path #:key-path key-path #:ca-path ca-path)
+  (file-exists-or-fail! cert-path "client certificate chain")
+  (file-exists-or-fail! key-path "client private key")
+  (file-exists-or-fail! ca-path "CA certificate")
+  (define ctx (ssl-make-client-context 'tls))
+  (ssl-load-certificate-chain! ctx cert-path)
+  (ssl-load-private-key! ctx key-path #f #f)
+  (ssl-load-verify-root-certificates! ctx ca-path)
+  (ssl-set-verify! ctx #t)
+  ctx)
+
+;; ============================================================
+;; Provides
+;; ============================================================
+
+(provide (contract-out [make-server-ssl-context
+                        (-> #:cert-path path-string?
+                            #:key-path path-string?
+                            #:ca-path path-string?
+                            ssl-server-context?)]
+                       [make-client-ssl-context
+                        (-> #:cert-path path-string?
+                            #:key-path path-string?
+                            #:ca-path path-string?
+                            ssl-client-context?)]))


### PR DESCRIPTION
## W0 — Certificate Infrastructure & mTLS Primitives

Implements the cryptographic foundation for v0.99.12 Phase 2 TCP broker with mTLS.

### New Files
- `util/security/tls-contexts.rkt` — mTLS context creation wrappers with mandatory cert verification
- `util/security/cert-generator.rkt` — CA + client/server cert generation via openssl CLI
- `cli/generate-certificates.rkt` — `q generate-certificates` CLI command
- `tests/test-tls-contexts.rkt` — 8 tests for context creation and error handling
- `tests/test-cert-generator.rkt` — 5 tests including round-trip TLS verification

### Test Results
- `test-tls-contexts.rkt`: 8/8 PASS
- `test-cert-generator.rkt`: 5/5 PASS
- `raco make main.rkt`: PASS
- Existing MCP/capability tests: unaffected

### Acceptance
- ✅ mTLS context creation succeeds with valid certs, fails with missing files
- ✅ Certificate generation produces valid PEM files
- ✅ Generated certs work with TLS context creation (round-trip)
- ✅ Zero behavioral change (all new code is isolated infrastructure)