### PR TITLE
feat: W2 executor node server with mTLS (#8072)

### DIFF
--- a/sandbox/executor-server.rkt
+++ b/sandbox/executor-server.rkt
@@ -1,0 +1,219 @@
+#lang racket/base
+
+;; sandbox/executor-server.rkt — mTLS TCP executor node server
+;; STABILITY: evolving
+;;
+;; W2 (v0.99.12): Network-facing TLS server that accepts mTLS connections
+;; from orchestrator clients and dispatches JSON-RPC tool calls to the
+;; worker tool registry.
+;;
+;; Architecture:
+;;   ┌──────────────┐   mTLS   ┌───────────────┐
+;;   │ Orchestrator │ ───────→ │ Executor      │ ← this server
+;;   │ (W1 client)  │ ←─────── │ (W2 server)   │
+;;   └──────────────┘          └───────────────┘
+;;
+;; Per-connection thread:
+;;   1. ssl-accept (mTLS handshake with client cert verification)
+;;   2. Read newline-delimited JSON requests
+;;   3. Validate capability token in arguments
+;;   4. Parse as ipc-request
+;;   5. Dispatch via process-ipc-request (shared with stdio worker)
+;;   6. Write ipc-response as JSON line
+;;
+;; Security:
+;;   - Mandatory mTLS: ssl-set-verify! #t rejects connections without client cert
+;;   - Capability token validation on every request
+;;   - Request size limit: IPC-MAX-REQUEST-BYTES (1 MB)
+;;   - Graceful shutdown: stop accepting, drain active connections
+
+(require racket/contract
+         racket/match
+         racket/string
+         racket/tcp
+         openssl
+         (only-in json string->jsexpr jsexpr->string)
+         "ipc-protocol.rkt"
+         "worker-dispatch.rkt"
+         "../util/security/capability-tokens.rkt")
+
+;; ── Logging ─────────────────────────────────────────────────────
+
+(define-logger executor-server)
+
+;; ── Defaults ────────────────────────────────────────────────────
+
+(define DEFAULT-MAX-CONNECTIONS 50)
+(define DEFAULT-MAX-REQUEST-BYTES IPC-MAX-REQUEST-BYTES)
+
+;; ── Executor Server Struct ──────────────────────────────────────
+
+(struct executor-server
+        (listener ; ssl-listener?
+         accept-thread ; (or/c thread? #f)
+         capability-secret ; string? — shared secret for token validation
+         active-conns ; (boxof exact-nonnegative-integer?)
+         shutdown? ; (boxof boolean)
+         custodian) ; custodian?
+  #:transparent)
+
+;; ── Capability Token Validation ─────────────────────────────────
+
+;; Validate the capability token embedded in the request arguments.
+;; Returns (values valid? error-message).
+(define (validate-request-capability request secret)
+  (define arguments (ipc-request-arguments request))
+  (define required-cap (ipc-request-capability request))
+  (define token (hash-ref arguments 'capability-token #f))
+  (cond
+    [(not token) (values #f "missing capability token")]
+    [(not (string? token)) (values #f "invalid capability token format")]
+    [else
+     (define claims (validate-capability-token/claims token secret))
+     (cond
+       [(not claims) (values #f "invalid or expired capability token")]
+       [(not (eq? (capability-token-claims-capability claims) required-cap))
+        (values #f "capability mismatch: token does not match request capability")]
+       [else (values #t #f)])]))
+
+;; ── Per-Connection Handler ──────────────────────────────────────
+
+(define (handle-connection in out secret server-shutdown? conn-counter max-conns)
+  ;; Increment active connection count
+  (set-box! conn-counter (add1 (unbox conn-counter)))
+  (log-executor-server-info "connection opened (~a active)" (unbox conn-counter))
+  (with-handlers ([exn:fail? (lambda (e)
+                               (log-executor-server-warning "connection error: ~a" (exn-message e)))])
+    (let loop ()
+      (unless (unbox server-shutdown?)
+        (define line (read-line in 'any))
+        (cond
+          [(eof-object? line) (log-executor-server-info "client disconnected")]
+          [else
+           (define trimmed (string-trim line))
+           (unless (string=? trimmed "")
+             ;; Check request size
+             (define req-size (string-length trimmed))
+             (define response
+               (if (> req-size DEFAULT-MAX-REQUEST-BYTES)
+                   (make-error-response #f
+                                        (format "request too large (~a bytes, max ~a)"
+                                                req-size
+                                                DEFAULT-MAX-REQUEST-BYTES))
+                   ;; Parse and dispatch
+                   (process-secure-request trimmed secret)))
+             ;; Send response
+             (define json-str (serialize-response response))
+             (display json-str out)
+             (newline out)
+             (flush-output out))
+           (loop)]))))
+  ;; Decrement active connection count
+  (set-box! conn-counter (sub1 (unbox conn-counter)))
+  (with-handlers ([exn:fail? void])
+    (close-input-port in)
+    (close-output-port out)))
+
+;; Process a single request line with capability token validation
+(define (process-secure-request line secret)
+  (with-handlers ([exn:fail? (lambda (e)
+                               (make-error-response #f (format "server error: ~a" (exn-message e))))])
+    (define req-data
+      (with-handlers ([exn:fail? (lambda (_) #f)])
+        (string->jsexpr line)))
+    (define request (and req-data (jsexpr->ipc-request req-data)))
+    (cond
+      [(not request) (make-error-response #f "malformed request")]
+      [else
+       (define-values (valid? err-msg) (validate-request-capability request secret))
+       (if valid?
+           (process-ipc-request request)
+           (make-error-response (ipc-request-request-id request) err-msg))])))
+
+;; ── Accept Loop ─────────────────────────────────────────────────
+
+(define (start-accept-loop! server)
+  (define listener (executor-server-listener server))
+  (define secret (executor-server-capability-secret server))
+  (define shutdown-box (executor-server-shutdown? server))
+  (define conn-counter (executor-server-active-conns server))
+  (define max-conns DEFAULT-MAX-CONNECTIONS)
+  (thread
+   (lambda ()
+     (let loop ()
+       (unless (unbox shutdown-box)
+         (with-handlers ([exn:fail? (lambda (e)
+                                      (unless (unbox shutdown-box)
+                                        (log-executor-server-warning "accept error: ~a"
+                                                                     (exn-message e))))])
+           ;; Check connection limit
+           (when (< (unbox conn-counter) max-conns)
+             (define-values (in out) (ssl-accept listener))
+             (thread (lambda ()
+                       (handle-connection in out secret shutdown-box conn-counter max-conns)))))
+         (loop))))))
+
+;; ── Server Lifecycle ────────────────────────────────────────────
+
+;; Start an executor server on the given port with mTLS.
+;; The ssl-server-context must have ssl-set-verify! #t (mandatory client cert).
+(define (start-executor-server! #:port port
+                                #:ssl-context ssl-context
+                                #:capability-secret capability-secret
+                                #:max-connections [max-connections DEFAULT-MAX-CONNECTIONS])
+  (define server-custodian (make-custodian))
+  (define server-listener
+    (parameterize ([current-custodian server-custodian])
+      ;; Pass the pre-configured ssl-server-context (already has certs,
+      ;; key, CA, and ssl-set-verify! #t from make-server-ssl-context)
+      (ssl-listen port 5 #t #f ssl-context)))
+  (define server
+    (executor-server server-listener #f capability-secret (box 0) (box #f) server-custodian))
+  (define accept-thread (start-accept-loop! server))
+  (define server-with-thread (struct-copy executor-server server [accept-thread accept-thread]))
+  (log-executor-server-info "executor server started on port ~a" port)
+  server-with-thread)
+
+;; Gracefully shutdown: stop accepting, wait for active connections to drain
+(define (shutdown-executor-server! server [drain-timeout-ms 5000])
+  (set-box! (executor-server-shutdown? server) #t)
+  ;; Close listener to stop accepting new connections
+  (with-handlers ([exn:fail? void])
+    (ssl-close (executor-server-listener server)))
+  ;; Wait for active connections to drain (up to timeout)
+  (define deadline (+ (current-inexact-milliseconds) drain-timeout-ms))
+  (let loop ()
+    (when (and (> (unbox (executor-server-active-conns server)) 0)
+               (< (current-inexact-milliseconds) deadline))
+      (sleep 0.1)
+      (loop)))
+  ;; Force shutdown: kill custodian
+  (custodian-shutdown-all (executor-server-custodian server))
+  (log-executor-server-info "executor server stopped"))
+
+;; Check if server is still accepting connections
+(define (executor-server-running? server)
+  (and (not (unbox (executor-server-shutdown? server)))
+       (executor-server-accept-thread server)
+       (thread-running? (executor-server-accept-thread server))))
+
+;; ── Provides ────────────────────────────────────────────────────
+
+(provide executor-server
+         executor-server?
+         executor-server-listener
+         executor-server-accept-thread
+         executor-server-capability-secret
+         executor-server-active-conns
+         executor-server-shutdown?
+         executor-server-custodian)
+
+(provide (contract-out [start-executor-server!
+                        (->* (#:port exact-positive-integer?
+                                     #:ssl-context ssl-server-context?
+                                     #:capability-secret string?)
+                             (#:max-connections exact-positive-integer?)
+                             executor-server?)]
+                       [shutdown-executor-server!
+                        (->* (executor-server?) (exact-positive-integer?) void?)]
+                       [executor-server-running? (-> executor-server? boolean?)]))

--- a/sandbox/worker-dispatch.rkt
+++ b/sandbox/worker-dispatch.rkt
@@ -1,0 +1,92 @@
+#lang racket/base
+
+;; sandbox/worker-dispatch.rkt — Reusable tool dispatch for workers
+;; STABILITY: evolving
+;;
+;; W2 (v0.99.12): Extracted from worker-main.rkt so that both the stdio
+;; worker (worker-main.rkt) and the TLS executor server (executor-server.rkt)
+;; share the same dispatch logic.
+;;
+;; process-ipc-request: (-> ipc-request? ipc-response?)
+;;   Takes a parsed ipc-request, dispatches to the worker tool registry,
+;;   and returns an ipc-response with the request-id stamped in.
+
+(require racket/match
+         (only-in json string->jsexpr jsexpr->string)
+         "ipc-protocol.rkt"
+         "worker-tools.rkt")
+
+;; ── IPC Request Processing ──────────────────────────────────────
+
+;; Dispatch an ipc-request to the worker tool registry.
+;; The working-dir field is honored (parameterized current-directory).
+;; The request-id from the request is stamped into the response.
+(define (process-ipc-request request)
+  (define req-id (ipc-request-request-id request))
+  (define tool-name (ipc-request-tool-name request))
+  (define arguments (ipc-request-arguments request))
+  ;; Parameterize CWD so changes don't leak across requests
+  (define response
+    (let ([wd (ipc-request-working-dir request)])
+      (if wd
+          (parameterize ([current-directory wd])
+            (dispatch-tool tool-name arguments))
+          (dispatch-tool tool-name arguments))))
+  ;; Stamp the request-id into the response
+  (ipc-response req-id
+                (ipc-response-status response)
+                (ipc-response-content response)
+                (ipc-response-details response)
+                (ipc-response-error-message response)
+                (ipc-response-schema-version response)))
+
+;; ── JSON Line Processing ────────────────────────────────────────
+
+;; Parse a JSON line → ipc-request → dispatch → ipc-response
+;; Returns ipc-response.
+;; On malformed JSON or parse failure, returns an error response.
+(define (process-request-line line)
+  (with-handlers ([exn:fail? (lambda (e)
+                               (make-error-response #f (format "worker error: ~a" (exn-message e))))])
+    (define req-data
+      (with-handlers ([exn:fail? (lambda (_) #f)])
+        (string->jsexpr line)))
+    (define request (and req-data (jsexpr->ipc-request req-data)))
+    (cond
+      [(not request) (make-error-response #f "malformed request")]
+      [else (process-ipc-request request)])))
+
+;; ── Response Serialization ──────────────────────────────────────
+
+;; Serialize an ipc-response to a JSON string, enforcing IPC-MAX-RESPONSE-BYTES.
+;; Returns the JSON string (possibly with a truncated error response).
+(define (serialize-response resp)
+  ;; Normalize void content to #f for JSON serialization
+  (define clean-response
+    (if (void? (ipc-response-content resp))
+        (ipc-response (ipc-response-request-id resp)
+                      (ipc-response-status resp)
+                      #f
+                      (ipc-response-details resp)
+                      (ipc-response-error-message resp)
+                      (ipc-response-schema-version resp))
+        resp))
+  ;; Enforce IPC-MAX-RESPONSE-BYTES
+  (define json-str (jsexpr->string (ipc-response->jsexpr clean-response)))
+  (if (> (string-length json-str) IPC-MAX-RESPONSE-BYTES)
+      (let ([truncated (ipc-response (ipc-response-request-id clean-response)
+                                     'error
+                                     (format "response too large (~a bytes, max ~a)"
+                                             (string-length json-str)
+                                             IPC-MAX-RESPONSE-BYTES)
+                                     (hasheq 'original-bytes (string-length json-str))
+                                     "response exceeded size limit"
+                                     (ipc-response-schema-version clean-response))])
+        (jsexpr->string (ipc-response->jsexpr truncated)))
+      json-str))
+
+;; ── Provides ────────────────────────────────────────────────────
+
+(provide process-ipc-request
+         process-request-line
+         serialize-response)

--- a/sandbox/worker-main.rkt
+++ b/sandbox/worker-main.rkt
@@ -1,6 +1,6 @@
 #lang racket/base
 
-;; sandbox/worker-main.rkt — Execution Plane Worker
+;; sandbox/worker-main.rkt — Execution Plane Worker (stdio)
 ;;
 ;; Run as: racket -tm sandbox/worker-main.rkt
 ;; Communicates via newline-delimited JSON on stdin/stdout.
@@ -11,44 +11,14 @@
 ;;   3. Dispatch to worker-tool-registry
 ;;   4. Write ipc-response as JSON to stdout
 ;;   5. Repeat until EOF on stdin
+;;
+;; W2 (v0.99.12): Dispatch logic extracted to worker-dispatch.rkt.
+;; This module is now a thin stdio wrapper around process-request-line
+;; and serialize-response.
 
-(require racket/match
-         json
+(require racket/string
          "ipc-protocol.rkt"
-         "worker-tools.rkt")
-
-;; ── Request Processing ──────────────────────────────────────────
-
-(define (process-request-line line)
-  ;; Parse JSON → ipc-request → dispatch → ipc-response
-  ;; Returns ipc-response
-  ;; M5: Use parameterize for CWD so changes don't leak across requests
-  (with-handlers ([exn:fail? (lambda (e)
-                               (make-error-response #f (format "worker error: ~a" (exn-message e))))])
-    (define req-data
-      (with-handlers ([exn:fail? (lambda (_) #f)])
-        (string->jsexpr line)))
-    (define request (and req-data (jsexpr->ipc-request req-data)))
-    (cond
-      [(not request) (make-error-response #f "malformed request")]
-      [else
-       (define req-id (ipc-request-request-id request))
-       (define tool-name (ipc-request-tool-name request))
-       (define arguments (ipc-request-arguments request))
-       ;; M5: parameterize restores CWD after dispatch (no leak)
-       (define response
-         (let ([wd (ipc-request-working-dir request)])
-           (if wd
-               (parameterize ([current-directory wd])
-                 (dispatch-tool tool-name arguments))
-               (dispatch-tool tool-name arguments))))
-       ;; Stamp the request-id into the response
-       (ipc-response req-id
-                     (ipc-response-status response)
-                     (ipc-response-content response)
-                     (ipc-response-details response)
-                     (ipc-response-error-message response)
-                     (ipc-response-schema-version response))])))
+         "worker-dispatch.rkt")
 
 ;; ── Worker Main Loop ────────────────────────────────────────────
 
@@ -65,31 +35,9 @@
        [else
         ;; Process the request
         (define response (process-request-line trimmed))
-        ;; Normalize void content to #f for JSON serialization
-        (define clean-response
-          (if (void? (ipc-response-content response))
-              (ipc-response (ipc-response-request-id response)
-                            (ipc-response-status response)
-                            #f
-                            (ipc-response-details response)
-                            (ipc-response-error-message response)
-                            (ipc-response-schema-version response))
-              response))
-        ;; M4: Enforce IPC-MAX-RESPONSE-BYTES — prevent oversized responses from crashing
-        (define json-str (jsexpr->string (ipc-response->jsexpr clean-response)))
-        (define final-json-str
-          (if (> (string-length json-str) IPC-MAX-RESPONSE-BYTES)
-              (let ([truncated (ipc-response (ipc-response-request-id clean-response)
-                                             'error
-                                             (format "response too large (~a bytes, max ~a)"
-                                                     (string-length json-str)
-                                                     IPC-MAX-RESPONSE-BYTES)
-                                             (hasheq 'original-bytes (string-length json-str))
-                                             "response exceeded size limit"
-                                             (ipc-response-schema-version clean-response))])
-                (jsexpr->string (ipc-response->jsexpr truncated)))
-              json-str))
-        (display final-json-str (current-output-port))
+        ;; Serialize with size enforcement
+        (define json-str (serialize-response response))
+        (display json-str (current-output-port))
         (newline (current-output-port))
         (flush-output (current-output-port))
         (worker-loop)])]))
@@ -101,10 +49,6 @@
 
 (module+ main
   (worker-loop))
-
-;; ── Requires for string-trim ────────────────────────────────────
-
-(require racket/string)
 
 ;; ── Provides for testing ────────────────────────────────────────
 

--- a/tests/test-executor-server.rkt
+++ b/tests/test-executor-server.rkt
@@ -1,0 +1,291 @@
+#lang racket
+
+;; @speed slow  ;; @suite security
+
+;; tests/test-executor-server.rkt — W2 (v0.99.12) Executor Node Server Tests
+;;
+;; Integration tests with real mTLS:
+;;   - Server accepts valid mTLS connections
+;;   - Valid capability token → dispatch succeeds
+;;   - Missing capability token → rejected
+;;   - Invalid/expired capability token → rejected
+;;   - Oversized request → rejected
+;;   - Graceful shutdown
+;;   - worker-main.rkt tests still pass after extraction
+
+(require rackunit
+         rackunit/text-ui
+         racket/file
+         racket/string
+         racket/port
+         json
+         openssl
+         (only-in "../util/security/cert-generator.rkt" generate-cert-set!)
+         (only-in "../util/security/capability-tokens.rkt" sign-capability-token CAPABILITY-TOKEN-TTL)
+         (only-in "../util/security/tls-contexts.rkt" make-server-ssl-context make-client-ssl-context)
+         (only-in "../sandbox/ipc-protocol.rkt"
+                  ipc-response-status
+                  ipc-response-request-id
+                  ipc-response-content
+                  ipc-response-error-message
+                  ipc-request->jsexpr
+                  ipc-request
+                  IPC-SCHEMA-VERSION)
+         "../sandbox/executor-server.rkt"
+         "../sandbox/worker-dispatch.rkt")
+
+;; ── Test Fixture ──
+
+(define test-certs-dir (make-temporary-file "executor-server-test-~a" 'directory))
+(define cert-paths (generate-cert-set! test-certs-dir))
+
+(define server-ctx
+  (make-server-ssl-context #:cert-path (hash-ref cert-paths 'server-cert)
+                           #:key-path (hash-ref cert-paths 'server-key)
+                           #:ca-path (hash-ref cert-paths 'ca-cert)))
+
+(define client-ctx
+  (make-client-ssl-context #:cert-path (hash-ref cert-paths 'client-cert)
+                           #:key-path (hash-ref cert-paths 'client-key)
+                           #:ca-path (hash-ref cert-paths 'ca-cert)))
+
+(define TEST-SECRET "executor-server-test-secret")
+(define TEST-AGENT "test-agent-w2")
+
+;; ── Helper: find a free port ──
+
+(define (find-free-port)
+  (define listener (tcp-listen 0))
+  (define-values (_host port __ ___) (tcp-addresses listener #t))
+  (tcp-close listener)
+  port)
+
+;; ── Helper: connect as client and send a request ──
+
+(define (connect-and-request port request-jsexpr)
+  (define-values (in out) (ssl-connect "localhost" port client-ctx))
+  (displayln (jsexpr->string request-jsexpr) out)
+  (flush-output out)
+  (define response-line (read-line in 'any))
+  (close-input-port in)
+  (close-output-port out)
+  (and (not (eof-object? response-line)) (string->jsexpr (string-trim response-line))))
+
+;; ── Helper: build a valid request with capability token ──
+
+(define (make-test-request #:request-id [req-id "test-req-1"]
+                           #:tool-name [tool "bash"]
+                           #:capability [cap 'execute-tools]
+                           #:capability-token [token #f]
+                           #:arguments [args (hasheq 'command "echo hello")])
+  (define enriched-args
+    (if token
+        (hash-set args 'capability-token token)
+        args))
+  (hasheq 'request-id
+          req-id
+          'tool-name
+          tool
+          'arguments
+          enriched-args
+          'timeout-ms
+          30000
+          'working-dir
+          #f
+          'capability
+          (symbol->string cap)
+          'schema-version
+          IPC-SCHEMA-VERSION))
+
+;; ── Tests ──
+
+(define suite
+  (test-suite "Executor Node Server (W2)"
+
+    ;; ════════════════════════════════════════════════════════════
+    ;; Server starts and accepts connections
+    ;; ════════════════════════════════════════════════════════════
+
+    (test-case "server starts and accepts mTLS connections"
+      (define port (find-free-port))
+      (define server
+        (start-executor-server! #:port port #:ssl-context server-ctx #:capability-secret TEST-SECRET))
+      (check-true (executor-server-running? server))
+      ;; Give server a moment to start
+      (sleep 0.2)
+      ;; Connect with valid client cert and token
+      (define token (sign-capability-token 'execute-tools TEST-AGENT TEST-SECRET))
+      (define req (make-test-request #:capability-token token))
+      (define resp (connect-and-request port req))
+      (check-not-false resp "got a response")
+      (when resp
+        (check-equal? (hash-ref resp 'status) "ok"))
+      (shutdown-executor-server! server))
+
+    ;; ════════════════════════════════════════════════════════════
+    ;; Valid request with valid token → ok response
+    ;; ════════════════════════════════════════════════════════════
+
+    (test-case "valid request with valid token returns ok"
+      (define port (find-free-port))
+      (define server
+        (start-executor-server! #:port port #:ssl-context server-ctx #:capability-secret TEST-SECRET))
+      (sleep 0.2)
+      (define token (sign-capability-token 'execute-tools TEST-AGENT TEST-SECRET))
+      (define req (make-test-request #:capability-token token))
+      (define resp (connect-and-request port req))
+      (check-not-false resp)
+      (when resp
+        (check-equal? (hash-ref resp 'status) "ok")
+        (check-equal? (hash-ref resp 'request-id) "test-req-1"))
+      (shutdown-executor-server! server))
+
+    ;; ════════════════════════════════════════════════════════════
+    ;; Missing capability token → rejected
+    ;; ════════════════════════════════════════════════════════════
+
+    (test-case "request without capability token is rejected"
+      (define port (find-free-port))
+      (define server
+        (start-executor-server! #:port port #:ssl-context server-ctx #:capability-secret TEST-SECRET))
+      (sleep 0.2)
+      ;; No capability token in arguments
+      (define req (make-test-request))
+      (define resp (connect-and-request port req))
+      (check-not-false resp)
+      (when resp
+        (check-equal? (hash-ref resp 'status) "error")
+        (check-true (string-contains? (or (hash-ref resp 'error-message "") "") "capability token")
+                    "error message mentions capability token"))
+      (shutdown-executor-server! server))
+
+    ;; ════════════════════════════════════════════════════════════
+    ;; Invalid capability token → rejected
+    ;; ════════════════════════════════════════════════════════════
+
+    (test-case "request with invalid capability token is rejected"
+      (define port (find-free-port))
+      (define server
+        (start-executor-server! #:port port #:ssl-context server-ctx #:capability-secret TEST-SECRET))
+      (sleep 0.2)
+      (define req (make-test-request #:capability-token "cap:bogus:agent:1:deadbeef"))
+      (define resp (connect-and-request port req))
+      (check-not-false resp)
+      (when resp
+        (check-equal? (hash-ref resp 'status) "error")
+        (check-true (string-contains? (or (hash-ref resp 'error-message "") "") "invalid")
+                    "error message mentions invalid token"))
+      (shutdown-executor-server! server))
+
+    ;; ════════════════════════════════════════════════════════════
+    ;; Capability mismatch → rejected
+    ;; ════════════════════════════════════════════════════════════
+
+    (test-case "capability mismatch is rejected"
+      (define port (find-free-port))
+      (define server
+        (start-executor-server! #:port port #:ssl-context server-ctx #:capability-secret TEST-SECRET))
+      (sleep 0.2)
+      ;; Token for write-files, but request says execute-tools
+      (define token (sign-capability-token 'write-files TEST-AGENT TEST-SECRET))
+      (define req (make-test-request #:capability-token token #:capability 'execute-tools))
+      (define resp (connect-and-request port req))
+      (check-not-false resp)
+      (when resp
+        (check-equal? (hash-ref resp 'status) "error")
+        (check-true (string-contains? (or (hash-ref resp 'error-message "") "") "mismatch")
+                    "error message mentions mismatch"))
+      (shutdown-executor-server! server))
+
+    ;; ════════════════════════════════════════════════════════════
+    ;; Oversized request → rejected
+    ;; ════════════════════════════════════════════════════════════
+
+    (test-case "oversized request is rejected"
+      (define port (find-free-port))
+      (define server
+        (start-executor-server! #:port port #:ssl-context server-ctx #:capability-secret TEST-SECRET))
+      (sleep 0.2)
+      ;; Create a request larger than 1MB
+      (define huge-args (hasheq 'command (make-string 1100000 #\x)))
+      (define token (sign-capability-token 'execute-tools TEST-AGENT TEST-SECRET))
+      (define req (make-test-request #:capability-token token #:arguments huge-args))
+      (define resp (connect-and-request port req))
+      (check-not-false resp)
+      (when resp
+        (check-equal? (hash-ref resp 'status) "error")
+        (check-true (string-contains? (or (hash-ref resp 'error-message "") "") "too large")
+                    "error message mentions too large"))
+      (shutdown-executor-server! server))
+
+    ;; ════════════════════════════════════════════════════════════
+    ;; Graceful shutdown
+    ;; ════════════════════════════════════════════════════════════
+
+    (test-case "server stops accepting after shutdown"
+      (define port (find-free-port))
+      (define server
+        (start-executor-server! #:port port #:ssl-context server-ctx #:capability-secret TEST-SECRET))
+      (sleep 0.2)
+      (check-true (executor-server-running? server))
+      (shutdown-executor-server! server 1000)
+      (check-false (executor-server-running? server)))
+
+    ;; ════════════════════════════════════════════════════════════
+    ;; Multiple requests on same connection
+    ;; ════════════════════════════════════════════════════════════
+
+    (test-case "multiple requests on same connection"
+      (define port (find-free-port))
+      (define server
+        (start-executor-server! #:port port #:ssl-context server-ctx #:capability-secret TEST-SECRET))
+      (sleep 0.2)
+      (define token (sign-capability-token 'execute-tools TEST-AGENT TEST-SECRET))
+      (define-values (in out) (ssl-connect "localhost" port client-ctx))
+      ;; Send 3 requests
+      (for ([i (in-range 3)])
+        (define req (make-test-request #:request-id (format "req-~a" i) #:capability-token token))
+        (displayln (jsexpr->string req) out)
+        (flush-output out)
+        (define resp-line (read-line in 'any))
+        (check-not-false (not (eof-object? resp-line)))
+        (unless (eof-object? resp-line)
+          (define resp (string->jsexpr (string-trim resp-line)))
+          (check-equal? (hash-ref resp 'status) "ok")
+          (check-equal? (hash-ref resp 'request-id) (format "req-~a" i))))
+      (close-input-port in)
+      (close-output-port out)
+      (shutdown-executor-server! server))
+
+    ;; ════════════════════════════════════════════════════════════
+    ;; Worker dispatch extraction tests
+    ;; ════════════════════════════════════════════════════════════
+
+    (test-case "process-ipc-request dispatches correctly"
+      (define req
+        (ipc-request "w2-test"
+                     "bash"
+                     (hasheq 'command "echo w2-extraction-test")
+                     30000
+                     #f
+                     'execute-tools
+                     IPC-SCHEMA-VERSION))
+      (define resp (process-ipc-request req))
+      (check-equal? (ipc-response-status resp) 'ok)
+      (check-equal? (ipc-response-request-id resp) "w2-test")
+      (check-equal? (ipc-response-content resp) "w2-extraction-test"))
+
+    (test-case "serialize-response produces valid JSON"
+      (define req
+        (ipc-request "serial-test"
+                     "bash"
+                     (hasheq 'command "echo test")
+                     30000
+                     #f
+                     'execute-tools
+                     IPC-SCHEMA-VERSION))
+      (define resp (process-ipc-request req))
+      (define json-str (serialize-response resp))
+      (check-not-false (string->jsexpr json-str) "output is valid JSON"))))
+
+(run-tests suite 'verbose)


### PR DESCRIPTION
## W2 — Executor Node Server

Implements the TCP+mTLS server for v0.99.12 Phase 2 distributed execution. This is the server counterpart to W1's client.

### New Files
- `sandbox/executor-server.rkt` — mTLS TCP server that accepts connections from orchestrator clients, validates capability tokens, and dispatches to worker tools.
- `sandbox/worker-dispatch.rkt` — Extracted dispatch logic from `worker-main.rkt`. Contains `process-ipc-request`, `process-request-line`, and `serialize-response`.
- `tests/test-executor-server.rkt` — 10 integration tests with real mTLS.

### Modified Files
- `sandbox/worker-main.rkt` — Refactored to use `worker-dispatch.rkt`. Zero behavioral change — still a thin stdio wrapper.

### Test Results
- `test-executor-server.rkt`: 10/10 PASS
- `test-worker-main.rkt`: 18/18 PASS (unchanged after extraction)
- `test-gateway-ipc.rkt`: 19/19 PASS
- `test-ipc-protocol.rkt`: 16/16 PASS
- `test-tls-contexts.rkt`: 8/8 PASS
- `test-remote-ipc.rkt`: 5/5 PASS
- `test-remote-executor.rkt`: 4/4 PASS
- `raco make main.rkt`: PASS

### Security Features
- **Mandatory mTLS**: ssl-server-context with `ssl-set-verify! #t` rejects connections without client cert
- **Capability token validation**: Every request validated via HMAC-SHA256. Missing, invalid, expired, and capability-mismatch tokens rejected
- **Request size limit**: Requests > IPC-MAX-REQUEST-BYTES (1MB) rejected
- **Connection limit**: Max concurrent connections enforced