### PR TITLE
fix: F-09 return-identity bug + F-10 capability token stripping

### DIFF
--- a/agent/distributed/remote-executor.rkt
+++ b/agent/distributed/remote-executor.rkt
@@ -300,14 +300,25 @@
      result]))
 
 ;; Execute with reconnection + retry logic.
+;; F-09 fix: Uses if/cond instead of broken `return` identity function.
+;; The original `(define (return v) v)` did NOT provide early-exit semantics.
 (define (execute-with-resilience executor tool-name arguments capability timeout-ms)
   (define conn (get-connection executor))
   ;; If connection is dead, try to reconnect first
-  (unless (and conn (remote-connection-alive? conn))
-    (log-remote-executor-info "connection dead, attempting reconnect before request")
-    (define reconnected? (reconnect-executor! executor))
-    (unless reconnected?
-      (return (make-error-response #f "connection lost and reconnection failed"))))
+  (cond
+    [(and conn (remote-connection-alive? conn))
+     ;; Connection alive — proceed to build and send request
+     (build-and-send-request executor tool-name arguments capability timeout-ms)]
+    [else
+     ;; Connection dead — attempt reconnect
+     (log-remote-executor-info "connection dead, attempting reconnect before request")
+     (define reconnected? (reconnect-executor! executor))
+     (if reconnected?
+         (build-and-send-request executor tool-name arguments capability timeout-ms)
+         (make-error-response #f "connection lost and reconnection failed"))]))
+
+;; Build the ipc-request with capability token and dispatch via with-retry.
+(define (build-and-send-request executor tool-name arguments capability timeout-ms)
   (define req-id (generate-remote-request-id))
   (define cap-token
     (sign-capability-token capability
@@ -348,20 +359,22 @@
      (define delay (* RETRY-BASE-DELAY-MS (expt 2 attempt)))
      (log-remote-executor-info "retrying in ~ams (attempt ~a)" delay (add1 attempt))
      (sleep (/ delay 1000.0))
+     ;; F-09 fix: Use proper if/cond instead of broken `return`.
      ;; Try to reconnect if connection is dead
-     (unless (remote-connection-alive? conn)
-       (log-remote-executor-info "connection dead during retry, attempting reconnect")
-       (define reconnected? (reconnect-executor! executor))
-       (unless reconnected?
-         (log-remote-executor-warning "reconnect failed during retry")
-         (return (make-error-response (ipc-request-request-id req)
-                                      "connection lost and cannot be re-established"))))
-     (with-retry executor req timeout-ms (add1 attempt))]
+     (cond
+       ;; Connection alive — retry directly
+       [(remote-connection-alive? conn) (with-retry executor req timeout-ms (add1 attempt))]
+       [else
+        ;; Connection dead — attempt reconnect
+        (log-remote-executor-info "connection dead during retry, attempting reconnect")
+        (define reconnected? (reconnect-executor! executor))
+        (if reconnected?
+            (with-retry executor req timeout-ms (add1 attempt))
+            (begin
+              (log-remote-executor-warning "reconnect failed during retry")
+              (make-error-response (ipc-request-request-id req)
+                                   "connection lost and cannot be re-established")))])]
     [else result]))
-
-;; Helper: return value without implicit begin issues
-(define (return v)
-  v)
 
 ;; ── Shutdown ────────────────────────────────────────────────────
 

--- a/docs/reports/AUDIT-v0.99.12-POST-MILESTONE-13462e25.md
+++ b/docs/reports/AUDIT-v0.99.12-POST-MILESTONE-13462e25.md
@@ -1,0 +1,166 @@
+# In-Depth Post-Milestone Audit — v0.99.12 (HEAD 13462e25)
+
+**Date**: 2026-06-27
+**Auditor**: Independent post-milestone review
+**Head**: `13462e25`
+**Base**: `0ed8dac9` (v0.99.11 post-F-07/F-08 fix)
+**Scope**: Review all v0.99.12 Phase 2 TCP broker/mTLS/remote executor work for correctness, security, spec compliance, and GSD process adherence
+
+---
+
+## Executive Summary
+
+**Verdict: ✅ APPROVED_WITH_NOTES — 4.3/5.0**
+
+v0.99.12 delivers a well-architected Phase 2 distributed execution feature with mTLS security. The defense-in-depth model is correctly implemented, all 147 focused tests pass, and the system remains completely inert when disabled. One correctness bug (F-09) was found in the reconnection failure path that produces misleading error messages but is not a security issue. Two minor findings (F-10, F-11) round out the notes.
+
+---
+
+## Changes Reviewed (33 files, +4168 lines)
+
+### New Modules (15 files)
+
+| File | Lines | Assessment |
+|------|-------|------------|
+| `util/security/tls-contexts.rkt` | 83 | ✅ Correct mTLS context creation, fail-loud |
+| `util/security/cert-generator.rkt` | 169 | ✅ RSA 4096, proper CA signing chain |
+| `cli/generate-certificates.rkt` | 53 | ✅ Simple CLI wrapper |
+| `agent/distributed/remote-ipc.rkt` | 263 | ✅ Correct async pattern, mirrors gateway-ipc |
+| `agent/distributed/remote-executor.rkt` | 452 | ⚠️ Correct overall, `return` bug (F-09) |
+| `sandbox/executor-server.rkt` | 219 | ⚠️ Missing token stripping (F-10) |
+| `sandbox/worker-dispatch.rkt` | 92 | ✅ Clean extraction, shared dispatch |
+| `tests/test-tls-contexts.rkt` | 102 | ✅ Good coverage |
+| `tests/test-cert-generator.rkt` | 107 | ✅ Good coverage |
+| `tests/test-remote-ipc.rkt` | 218 | ✅ Tests round-trip, timeout, connection drop |
+| `tests/test-remote-executor.rkt` | 200 | ✅ Tests basic execution (missing reconnect-fail) |
+| `tests/test-executor-server.rkt` | 291 | ✅ Tests mTLS, capability, size limits |
+| `tests/test-remote-ipc-resilience.rkt` | 261 | ✅ Tests circuit breaker, reconnect |
+| `tests/test-remote-executor-security.rkt` | 253 | ✅ Adversarial tests |
+| `tests/test-tool-gateway-remote-routing.rkt` | 168 | ✅ Tests routing integration |
+
+---
+
+## Findings
+
+### F-09 (MEDIUM) — `return` function does not provide early-exit semantics
+
+**Location**: `agent/distributed/remote-executor.rkt:310, 357, 363`
+
+**Issue**: The module defines `(define (return v) v)` at line 363 — a simple identity function. It is called at lines 310 and 357 inside `(unless ...)` blocks with the intent of early-returning an error response when reconnection fails:
+
+```racket
+;; Line 306-311 in execute-with-resilience:
+(unless reconnected?
+  (return (make-error-response #f "connection lost and reconnection failed")))
+;; Execution falls through! req-id, cap-token, with-retry all run on dead connection.
+```
+
+In Racket, `(return v)` evaluates `v` and discards the result. It does NOT exit the enclosing function. The function's last expression `(with-retry ...)` is what gets returned.
+
+**Impact**: When reconnection fails in `execute-with-resilience` or `with-retry`, the intended error message ("connection lost and reconnection failed") is never returned. Instead, execution continues on a dead connection, producing a different (less clear) error or timing out. This is a **correctness and UX bug**, not a security issue — no unauthorized execution path is opened.
+
+**Root Cause**: Racket does not have implicit early-return. The author intended Python/Ruby-style `return` semantics. The correct fix uses `let/ec` (escape continuation) or restructuring the control flow.
+
+**Fix**: Replace `(define (return v) v)` with proper early-exit via `let/ec` or restructure with explicit `if/cond` branches.
+
+---
+
+### F-10 (LOW) — Capability token not stripped from arguments before dispatch
+
+**Location**: `sandbox/executor-server.rkt:127-132`
+
+**Issue**: `process-secure-request` validates the capability token but then passes the original `request` (with `'capability-token` still in the `arguments` hash) to `process-ipc-request`. The token is never removed from the arguments before dispatch to the worker tool.
+
+```racket
+(if valid?
+    (process-ipc-request request)  ;; ← token still in arguments!
+    (make-error-response ...))
+```
+
+**Impact**: The executed tool receives an unexpected `'capability-token` key in its arguments. Most tools ignore unknown keys, but it is:
+1. A minor information leak — the HMAC token is passed to tool code
+2. Potential confusion for tools that validate their argument schema
+
+**Fix**: Strip the token before dispatching:
+```racket
+(define cleaned-request
+  (struct-copy ipc-request request
+    [arguments (hash-remove (ipc-request-arguments request) 'capability-token)]))
+(process-ipc-request cleaned-request)
+```
+
+---
+
+### F-11 (LOW) — Unvalidated `ssl-load-private-key!` password arguments
+
+**Location**: `util/security/tls-contexts.rkt:42, 55`
+
+**Issue**: `ssl-load-private-key!` is called with `(ssl-load-private-key! ctx key-path #f #f)`. The third argument is `asn1-formats?` and the fourth is `passphrase`. While `#f` for passphrase is correct for unencrypted keys (the cert generator uses `-nodes` to create unencrypted keys), this means encrypted private keys would fail silently with a confusing error.
+
+**Impact**: Low — the bundled cert generator always creates unencrypted keys. But if a user brings their own encrypted key, the error message would be misleading.
+
+**Recommendation**: Document that encrypted private keys are not supported in the deployment guide.
+
+---
+
+### G-01 (LOW) — No integration test for `execute-via-remote-envelope` end-to-end
+
+**Issue**: The gateway bridge test (`test-gateway-bridge-remote.rkt`) tests individual paths but does not test the full `mas-envelope → execute-via-remote → TLS → executor-server → worker-dispatch → response` round-trip with real TLS.
+
+**Impact**: The integration boundary between the gateway bridge and the remote executor is not covered by an automated test. This is understandable (requires a running executor server with mTLS certs), but should be noted as a gap.
+
+---
+
+## Positive Findings
+
+### ✅ Security Architecture Sound
+The four-layer defense-in-depth model is correctly implemented:
+- **Transport**: mTLS 1.2, RSA 4096, `ssl-set-verify! #t` on both sides
+- **Application**: HMAC-SHA256 capability tokens, constant-time MAC comparison, 5-min TTL
+- **Deployment**: Triple config gate, fail-closed defaults, fail-fast on missing secret
+- **Execution**: Registered tools only, resource limits, size limits
+
+### ✅ Default-Off Verified
+- `broker-enabled?` returns `#f` with default settings (verified at runtime)
+- No TCP listeners started when broker disabled
+- All new code paths require explicit opt-in
+
+### ✅ Worker Extraction Clean
+`sandbox/worker-dispatch.rkt` correctly extracts the dispatch logic from `worker-main.rkt`. Both the stdio worker and the TLS executor server share the same `process-ipc-request` function. No behavioral change for existing stdio workers.
+
+### ✅ Async IPC Pattern Proven
+`remote-ipc.rkt` correctly mirrors the battle-tested `gateway-ipc.rkt` pattern:
+- Module-level semaphore for request-id generation
+- Separate drain thread with exception handler
+- `async-channel` for per-request response delivery
+- `clear-all-pending!` on connection drop
+- Write-lock for serialized output
+
+### ✅ Circuit Breaker Well-Implemented
+The three-state circuit breaker (closed/open/half-open) is correctly implemented with semaphore-protected state transitions, exponential backoff reconnection, and proper failure-counting.
+
+### ✅ Documentation Excellent
+`docs/distributed-execution-guide.md` and `docs/security-mtls.md` are thorough, with clear deployment instructions, trust model, and threat model documentation.
+
+### ✅ Test Coverage Strong
+147 focused tests across 14 test files, all passing. Coverage includes:
+- mTLS context creation and cert generation
+- Async IPC round-trip, timeout, connection drop
+- Executor server mTLS, capability validation, size limits
+- Circuit breaker state transitions
+- Risk-based routing integration
+- Adversarial security (token replay, circuit storm)
+
+---
+
+## Score Breakdown
+
+| Axis | Score | Notes |
+|------|-------|-------|
+| Correctness | 4.0/5.0 | `return` bug (F-09) in error path |
+| Security | 4.5/5.0 | Token not stripped (F-10), otherwise excellent |
+| Test Quality | 4.0/5.0 | Missing reconnect-fail test, no full E2E |
+| Architecture | 5.0/5.0 | Defense-in-depth is textbook quality |
+| Process | 4.5/5.0 | Well-tracked through GSD, proper wave structure |
+| Documentation | 5.0/5.0 | Copy-paste deployable, thorough |
+| **Overall** | **4.3/5.0** | **APPROVED_WITH_NOTES** |

--- a/sandbox/executor-server.rkt
+++ b/sandbox/executor-server.rkt
@@ -127,7 +127,14 @@
       [else
        (define-values (valid? err-msg) (validate-request-capability request secret))
        (if valid?
-           (process-ipc-request request)
+           ;; F-10 fix: Strip capability token from arguments before dispatch
+           ;; so it's not passed to the worker tool.
+           (let ([cleaned-request (struct-copy ipc-request
+                                               request
+                                               [arguments
+                                                (hash-remove (ipc-request-arguments request)
+                                                             'capability-token)])])
+             (process-ipc-request cleaned-request))
            (make-error-response (ipc-request-request-id request) err-msg))])))
 
 ;; ── Accept Loop ─────────────────────────────────────────────────

--- a/tests/test-remote-ipc-resilience.rkt
+++ b/tests/test-remote-ipc-resilience.rkt
@@ -30,6 +30,7 @@
                   execute-via-remote
                   reconnect-executor!
                   remote-executor-alive?
+                  remote-executor-connection
                   remote-executor-circuit-state
                   remote-executor-circuit-failure-count
                   make-circuit-breaker
@@ -37,7 +38,8 @@
                   circuit-record-success!
                   circuit-record-failure!
                   circuit-state
-                  circuit-failure-count))
+                  circuit-failure-count)
+         (only-in "../agent/distributed/remote-ipc.rkt" remote-connection-alive-flag))
 
 ;; ── Test Fixture ──
 
@@ -255,7 +257,38 @@
         (check-true (remote-executor-alive? exec))
         (shutdown-remote-executor! exec)
         (stop-server))
-      (check-true #t "completed 10 cycles without error"))))
+      (check-true #t "completed 10 cycles without error"))
+
+    (test-case "F-09: reconnection failure returns clear error, not silent fallthrough"
+      ;; F-09 regression test: the `return` identity function did not early-exit.
+      ;; When reconnection fails, execute-with-resilience must return the
+      ;; "connection lost" error, not silently fall through to a dead connection.
+      (define-values (port stop-server) (start-mock-server))
+      (sleep 0.2)
+      (define exec
+        (start-remote-executor! #:host "localhost"
+                                #:port port
+                                #:ssl-context client-ctx
+                                #:capability-secret TEST-SECRET
+                                #:agent-id TEST-AGENT
+                                #:health-check-enabled #f))
+      (check-true (remote-executor-alive? exec))
+      ;; Kill server so reconnection will fail
+      (stop-server)
+      (sleep 0.3)
+      ;; Force the connection to be dead
+      (define conn (remote-executor-connection exec))
+      (when conn
+        (set-box! (remote-connection-alive-flag conn) #f))
+      ;; Execute should return an error mentioning connection/reconnect/circuit
+      (define resp (execute-via-remote exec "test-tool" (hasheq 'msg "dead") 'execute-tools 3000))
+      (check-equal? (ipc-response-status resp) 'error)
+      (define err-msg (or (ipc-response-error-message resp) ""))
+      (check-true (or (string-contains? err-msg "connection")
+                      (string-contains? err-msg "reconnect")
+                      (string-contains? err-msg "circuit"))
+                  (format "error should mention connection/reconnect/circuit, got: ~a" err-msg))
+      (shutdown-remote-executor! exec))))
 
 (run-tests cb-unit-suite)
 (run-tests integration-suite)


### PR DESCRIPTION
## Summary

In-depth post-milestone audit of v0.99.12 (HEAD `13462e25`) identified two issues. Both fixed.

### F-09 (MEDIUM) — `return` identity function does not provide early-exit
- `(define (return v) v)` in `remote-executor.rkt` was intended as early-return but is just an identity function
- When reconnection failed in `execute-with-resilience` and `with-retry`, the error response was silently discarded
- Execution continued on a dead connection, producing confusing errors instead of "connection lost and reconnection failed"
- **Fix**: Replaced with proper `if/cond` control flow
- **Regression test added**: F-09 test in `test-remote-ipc-resilience.rkt`

### F-10 (LOW) — Capability token not stripped before dispatch
- `executor-server.rkt` validated the capability token but passed it through to `process-ipc-request` unstripped
- The executed tool received an unexpected `'capability-token` key in its arguments
- **Fix**: Strip token via `hash-remove` before dispatching to worker

### Audit Report
- `docs/reports/AUDIT-v0.99.12-POST-MILESTONE-13462e25.md` — full in-depth audit (APPROVED_WITH_NOTES 4.3/5.0)

## Verification
- `raco make main.rkt`: PASS
- Focused gates: 148 tests, 0 failures (147 original + 1 F-09 regression)
- All existing tests pass unchanged