### PR TITLE
refactor: W1 blackboard follower extraction (G-2) (#8088)

### DIFF
--- a/agent/blackboard-follower.rkt
+++ b/agent/blackboard-follower.rkt
@@ -1,0 +1,107 @@
+#lang racket/base
+
+;; agent/blackboard-follower.rkt — Blackboard log follower & event relevance
+;; STABILITY: evolving
+;;
+;; Extracted from blackboard-subscriber.rkt (v0.99.13 W1, G-2).
+;; Contains the event-filtering predicate and JSONL replay logic that are
+;; independent of the event-bus subscription lifecycle.  This separation
+;; allows crash-recovery / replay to be used without pulling in the full
+;; subscriber (which depends on event-bus.rkt).
+;;
+;; Design:
+;;   - relevant-event-names: set of event symbols the blackboard reducer handles
+;;   - blackboard-relevant-event?: filter predicate (accepts event? structs and hashes)
+;;   - normalize-jsonl-entry: convert string event names to symbols (JSON round-trip)
+;;   - rebuild-blackboard-from-log!: replay JSONL events for crash recovery
+;;
+;; Part of MAS Schritt 4: Blackboard & Event Log.
+
+(require racket/contract
+         racket/match
+         (only-in "../util/event/event.rkt" event? event-ev)
+         (only-in "../util/json/jsonl.rkt" jsonl-read-all-valid strip-format-header)
+         "blackboard.rkt"
+         "blackboard-reducer.rkt")
+
+;; ============================================================
+;; Relevant Event Predicate
+;; ============================================================
+
+;; Set of event names the blackboard reducer handles.
+(define relevant-event-names
+  '(gsd.wave.started gsd.wave.completed
+                     gsd.wave.failed
+                     gsd.wave.skipped
+                     gsd.plan.parsed
+                     gsd.verification.completed
+                     gsd.verification.escalated
+                     mas.artifact.produced
+                     mas.test.result
+                     mas.hypothesis.opened
+                     mas.hypothesis.resolved
+                     mas.blackboard.sync
+                     mas.agent.version.pinned
+                     mas.agent.registered
+                     mas.agent.activated
+                     mas.mcp.connected
+                     mas.mcp.tool.called))
+
+;; Check if an event is relevant to the blackboard.
+;; Accepts both event? structs (from the bus) and hashes (from JSONL).
+(define (blackboard-relevant-event? evt)
+  (define ev-name
+    (cond
+      [(event? evt) (event-ev evt)]
+      [(hash? evt) (or (hash-ref evt 'event #f) (hash-ref evt 'ev #f))]
+      [else #f]))
+  (and ev-name
+       (let ([sym (if (string? ev-name)
+                      (string->symbol ev-name)
+                      ev-name)])
+         (and (memq sym relevant-event-names) #t))))
+
+;; ============================================================
+;; JSONL Normalisation
+;; ============================================================
+
+;; Convert string event names from JSON entries to symbols for the reducer.
+;; JSON round-trips symbols as strings; the reducer uses eq? with symbols.
+(define (normalize-jsonl-entry entry)
+  (cond
+    [(not (hash? entry)) entry]
+    [else
+     (define ev-name (or (hash-ref entry 'event #f) (hash-ref entry "event" #f)))
+     (cond
+       [(string? ev-name) (hash-set entry 'event (string->symbol ev-name))]
+       [else entry])]))
+
+;; ============================================================
+;; Crash Recovery (Log Replay)
+;; ============================================================
+
+;; Reads all valid entries, strips format header, applies relevant events.
+;; Returns the final blackboard-state.
+(define (rebuild-blackboard-from-log! log-path [bb (current-blackboard)])
+  (when bb
+    (reset-blackboard! bb))
+  (define entries (jsonl-read-all-valid log-path))
+  (define events (strip-format-header entries))
+  (define normalized (map normalize-jsonl-entry events))
+  (define relevant (filter blackboard-relevant-event? normalized))
+  (define initial (or (and bb (read-blackboard bb)) empty-blackboard))
+  (define final-state (apply-events relevant initial))
+  (when bb
+    (update-blackboard! (lambda (_) final-state) bb))
+  final-state)
+
+;; ============================================================
+;; Provides
+;; ============================================================
+
+(provide relevant-event-names)
+
+(provide (contract-out [blackboard-relevant-event? (-> any/c boolean?)]
+                       [normalize-jsonl-entry (-> any/c any/c)]
+                       [rebuild-blackboard-from-log!
+                        (->* (path-string?) (blackboard-container?) blackboard-state?)]))

--- a/agent/blackboard-subscriber.rkt
+++ b/agent/blackboard-subscriber.rkt
@@ -4,13 +4,15 @@
 ;; STABILITY: evolving
 ;;
 ;; W4 (v0.99.7): Subscribe to event bus for zero-latency blackboard updates.
-;; Also provides crash recovery by replaying events from JSONL log.
+;; v0.99.13 W1 (G-2): Extracted log-replay and event-filtering logic to
+;;   blackboard-follower.rkt.  This module retains the subscription lifecycle
+;;   and re-exports follower symbols for backward compatibility.
 ;;
 ;; Design:
 ;;   - start-blackboard-subscriber!: subscribe, reset blackboard, return sub-id
 ;;   - stop-blackboard-subscriber!: clean unsubscribe
-;;   - rebuild-blackboard-from-log!: replay JSONL events for crash recovery
-;;   - blackboard-relevant-event?: filter predicate for relevant events
+;;   - blackboard-relevant-event?: (moved to follower, re-exported)
+;;   - rebuild-blackboard-from-log!: (moved to follower, re-exported)
 ;;   - event->reducer-hash: convert event? struct to reducer hash format
 ;;
 ;; Feature-gated via mas.blackboard.enabled (default false).
@@ -22,46 +24,9 @@
          racket/match
          (only-in "../util/event/event.rkt" event? event-ev event-payload event-time)
          (only-in "../util/event/event-bus.rkt" subscribe! unsubscribe! event-bus?)
-         (only-in "../util/json/jsonl.rkt" jsonl-read-all-valid strip-format-header)
          "blackboard.rkt"
-         "blackboard-reducer.rkt")
-
-;; ============================================================
-;; Relevant Event Predicate
-;; ============================================================
-
-;; Set of event names the blackboard reducer handles.
-(define relevant-event-names
-  '(gsd.wave.started gsd.wave.completed
-                     gsd.wave.failed
-                     gsd.wave.skipped
-                     gsd.plan.parsed
-                     gsd.verification.completed
-                     gsd.verification.escalated
-                     mas.artifact.produced
-                     mas.test.result
-                     mas.hypothesis.opened
-                     mas.hypothesis.resolved
-                     mas.blackboard.sync
-                     mas.agent.version.pinned
-                     mas.agent.registered
-                     mas.agent.activated
-                     mas.mcp.connected
-                     mas.mcp.tool.called))
-
-;; Check if an event is relevant to the blackboard.
-;; Accepts both event? structs (from the bus) and hashes (from JSONL).
-(define (blackboard-relevant-event? evt)
-  (define ev-name
-    (cond
-      [(event? evt) (event-ev evt)]
-      [(hash? evt) (or (hash-ref evt 'event #f) (hash-ref evt 'ev #f))]
-      [else #f]))
-  (and ev-name
-       (let ([sym (if (string? ev-name)
-                      (string->symbol ev-name)
-                      ev-name)])
-         (and (memq sym relevant-event-names) #t))))
+         "blackboard-reducer.rkt"
+         "blackboard-follower.rkt")
 
 ;; ============================================================
 ;; Event Conversion
@@ -121,37 +86,6 @@
     (with-handlers ([exn:fail? (lambda (_) (void))])
       (unsubscribe! sub-bus sub-id))
     (set-box! current-subscription #f)))
-
-;; ============================================================
-;; Crash Recovery
-;; ============================================================
-
-;; Replay events from a JSONL log file to rebuild blackboard state.
-;; Convert string event names from JSON entries to symbols for the reducer.
-;; JSON round-trips symbols as strings; the reducer uses eq? with symbols.
-(define (normalize-jsonl-entry entry)
-  (cond
-    [(not (hash? entry)) entry]
-    [else
-     (define ev-name (or (hash-ref entry 'event #f) (hash-ref entry "event" #f)))
-     (cond
-       [(string? ev-name) (hash-set entry 'event (string->symbol ev-name))]
-       [else entry])]))
-
-;; Reads all valid entries, strips format header, applies relevant events.
-;; Returns the final blackboard-state.
-(define (rebuild-blackboard-from-log! log-path [bb (current-blackboard)])
-  (when bb
-    (reset-blackboard! bb))
-  (define entries (jsonl-read-all-valid log-path))
-  (define events (strip-format-header entries))
-  (define normalized (map normalize-jsonl-entry events))
-  (define relevant (filter blackboard-relevant-event? normalized))
-  (define initial (or (and bb (read-blackboard bb)) empty-blackboard))
-  (define final-state (apply-events relevant initial))
-  (when bb
-    (update-blackboard! (lambda (_) final-state) bb))
-  final-state)
 
 ;; ============================================================
 ;; Provides

--- a/tests/test-blackboard-follower.rkt
+++ b/tests/test-blackboard-follower.rkt
@@ -1,0 +1,106 @@
+#lang racket/base
+
+;; tests/test-blackboard-follower.rkt — Tests for blackboard-follower.rkt
+;; v0.99.13 W1 (G-2): Extraction tests for the follower module.
+;;
+;; These tests verify:
+;; 1. blackboard-relevant-event? correctly filters relevant/irrelevant events
+;; 2. normalize-jsonl-entry converts string event names to symbols
+;; 3. rebuild-blackboard-from-log! replays JSONL events correctly
+;; 4. The follower module works independently of blackboard-subscriber.rkt
+
+(require rackunit
+         rackunit/text-ui
+         racket/file
+         (only-in "../util/json/jsonl.rkt" jsonl-append!)
+         (only-in "../agent/blackboard.rkt" make-blackboard)
+         "../agent/blackboard-follower.rkt")
+
+;; ============================================================
+;; Helpers
+;; ============================================================
+
+(define (make-temp-trace-path)
+  (build-path (find-system-path 'temp-dir)
+              (format "test-follower-~a.jsonl" (current-inexact-milliseconds))))
+
+;; ============================================================
+;; Test Suite
+;; ============================================================
+
+(define follower-suite
+  (test-suite "blackboard-follower tests (v0.99.13 W1 / G-2)"
+
+    ;; ── Test 1: blackboard-relevant-event? for known events ──────
+    (test-case "blackboard-relevant-event? returns #t for relevant hash events"
+      (for ([name relevant-event-names])
+        (define evt (hasheq 'event name 'data (hasheq)))
+        (check-true (blackboard-relevant-event? evt) (format "expected ~a to be relevant" name))))
+
+    ;; ── Test 2: blackboard-relevant-event? rejects unknown events ─
+    (test-case "blackboard-relevant-event? returns #f for irrelevant events"
+      (check-false (blackboard-relevant-event? (hasheq 'event 'unknown.event)))
+      (check-false (blackboard-relevant-event? (hasheq 'event 'random.thing)))
+      (check-false (blackboard-relevant-event? "not-an-event"))
+      (check-false (blackboard-relevant-event? 42))
+      (check-false (blackboard-relevant-event? (hasheq 'no-event-key #t))))
+
+    ;; ── Test 3: blackboard-relevant-event? handles string event names ──
+    (test-case "blackboard-relevant-event? handles string event names from JSON"
+      ;; JSON round-trips symbols as strings — the follower must still match.
+      (check-true (blackboard-relevant-event? (hasheq 'event "gsd.wave.started")))
+      (check-true (blackboard-relevant-event? (hasheq 'event "mas.test.result")))
+      (check-false (blackboard-relevant-event? (hasheq 'event "unknown.event"))))
+
+    ;; ── Test 4: normalize-jsonl-entry converts string event names ──
+    (test-case "normalize-jsonl-entry converts string event names to symbols"
+      (define entry (hasheq 'event "gsd.wave.started" 'data (hasheq 'wave 1)))
+      (define normalized (normalize-jsonl-entry entry))
+      (check-equal? (hash-ref normalized 'event) 'gsd.wave.started))
+
+    (test-case "normalize-jsonl-entry leaves non-hash entries unchanged"
+      (check-equal? (normalize-jsonl-entry "string") "string")
+      (check-equal? (normalize-jsonl-entry 42) 42)
+      (check-equal? (normalize-jsonl-entry '()) '()))
+
+    (test-case "normalize-jsonl-entry leaves symbol event names unchanged"
+      (define entry (hasheq 'event 'gsd.wave.completed))
+      (define normalized (normalize-jsonl-entry entry))
+      (check-equal? (hash-ref normalized 'event) 'gsd.wave.completed))
+
+    (test-case "normalize-jsonl-entry handles string-keyed event field"
+      ;; JSON data from jsonl-read-all-valid uses equal?-based hashes.
+      ;; Use hash (not hasheq) so string keys are matched by equal?.
+      (define entry (hash "event" "mas.test.result"))
+      (define normalized (normalize-jsonl-entry entry))
+      (check-equal? (hash-ref normalized 'event #f) 'mas.test.result))
+
+    ;; ── Test 5: rebuild-blackboard-from-log! replays events ───────
+    (test-case "rebuild-blackboard-from-log! replays JSONL and applies relevant events"
+      (define trace-path (make-temp-trace-path))
+      (jsonl-append! trace-path (hash 'event "gsd.wave.started" 'data (hash 'wave "W0")))
+      (jsonl-append! trace-path (hash 'event "ui.render.requested" 'data (hash 'panel "main")))
+      (jsonl-append! trace-path (hash 'event "gsd.wave.completed" 'data (hash 'wave "W0")))
+      ;; Replay into a real blackboard container.
+      (define bb (make-blackboard))
+      (define state (rebuild-blackboard-from-log! trace-path bb))
+      (check-not-false state "rebuild returns a non-#f blackboard state")
+      (delete-file trace-path))
+
+    (test-case "rebuild-blackboard-from-log! filters out irrelevant events"
+      (define trace-path (make-temp-trace-path))
+      (jsonl-append! trace-path (hash 'event "gsd.wave.started" 'data (hash 'wave "W-filter")))
+      (jsonl-append! trace-path (hash 'event "user.typed.something" 'data (hash 'text "hi")))
+      (define bb (make-blackboard))
+      (define state (rebuild-blackboard-from-log! trace-path bb))
+      (check-not-false state "returns a valid state even with mixed events")
+      (delete-file trace-path))
+
+    ;; ── Test 6: relevant-event-names is a proper list ────────────
+    (test-case "relevant-event-names is a non-empty list of symbols"
+      (check-true (list? relevant-event-names))
+      (check-true (> (length relevant-event-names) 5))
+      (for ([name relevant-event-names])
+        (check-true (symbol? name))))))
+
+(run-tests follower-suite)


### PR DESCRIPTION
## W1 — Blackboard Follower Extraction (G-2)

Extracts log-replay and event-filtering logic from `blackboard-subscriber.rkt` into a new `blackboard-follower.rkt` module. This separates crash-recovery / JSONL replay from the event-bus subscription lifecycle.

### Moved to `blackboard-follower.rkt`:
- `relevant-event-names` (data)
- `blackboard-relevant-event?` (filter predicate)
- `normalize-jsonl-entry` (JSON string→symbol conversion)
- `rebuild-blackboard-from-log!` (JSONL log replay)

### Backward Compatibility
`blackboard-subscriber.rkt` re-exports all follower symbols. Zero behavioral change — pure code extraction. All existing consumers verified:
- `test-blackboard-subscriber.rkt`: 17/17 ✓
- `test-blackboard-lifecycle.rkt`: 12/12 ✓
- `test-blackboard-integration.rkt`: 9/9 ✓
- `test-mcp-events.rkt`: 12/12 ✓
- `test-hot-swap-events.rkt`: 7/7 ✓

### New Tests
`test-blackboard-follower.rkt`: 10/10 ✓