### PR TITLE
feat: W1 wire stop-blackboard-subscriber! into session teardown (#8100)

### DIFF
--- a/runtime/agent-session.rkt
+++ b/runtime/agent-session.rkt
@@ -50,6 +50,7 @@
          "../util/ids.rkt"
          (only-in "runtime-helpers.rkt" emit-session-event! maybe-dispatch-hooks)
          (only-in "../agent/event-emitter.rkt" emit-typed-event!)
+         (only-in "../agent/blackboard-subscriber.rkt" stop-blackboard-subscriber!)
          (only-in "../agent/event-structs/session-events.rkt"
                   session-start-event
                   session-shutdown-event)
@@ -489,7 +490,12 @@
     (persist-high-value-conclusions! (agent-session-task-conclusions sess)
                                      #:backend (current-memory-backend)
                                      #:session-id (agent-session-session-id sess))
-    (guarded-set-active! sess #f)))
+    (guarded-set-active! sess #f))
+  ;; v0.99.14 W1: Stop blackboard subscriber on session teardown.
+  ;; Prevents event bus subscription leak when blackboard is default-on.
+  ;; Idempotent: safe no-op when no subscription is active.
+  (with-handlers ([exn:fail? (lambda (_) (void))])
+    (stop-blackboard-subscriber!)))
 
 ;; ============================================================
 ;; Re-exported from extracted sub-modules

--- a/tests/test-blackboard-lifecycle.rkt
+++ b/tests/test-blackboard-lifecycle.rkt
@@ -147,6 +147,31 @@
         ;; Only the wave.started event should be reflected
         (check-true (hash-has-key? waves "W2"))
         (check-false (hash-has-key? waves "W0")))
-      (delete-file trace-path))))
+      (delete-file trace-path))
+
+    ;; ── v0.99.14 W1: Session Teardown Cleanup ──
+
+    (test-case "stop-blackboard-subscriber! clears subscription after start"
+      ;; Start a subscriber on a fresh event bus
+      (define bus (make-event-bus))
+      (define bb (make-blackboard))
+      (parameterize ([current-blackboard bb])
+        (start-blackboard-subscriber! bus bb)
+        (check-true (pair? (unbox current-subscription)))
+        ;; Stop it — should clear the subscription box
+        (stop-blackboard-subscriber!)
+        (check-false (unbox current-subscription))))
+
+    (test-case "calling stop-blackboard-subscriber! twice is safe (idempotent)"
+      (set-box! current-subscription #f)
+      (check-not-exn (lambda () (stop-blackboard-subscriber!)))
+      (check-not-exn (lambda () (stop-blackboard-subscriber!)))
+      (check-false (unbox current-subscription)))
+
+    (test-case "stop-blackboard-subscriber! with no active subscription is safe no-op"
+      ;; Simulate session close when blackboard was never enabled
+      (set-box! current-subscription #f)
+      (check-not-exn (lambda () (stop-blackboard-subscriber!)))
+      (check-false (unbox current-subscription)))))
 
 (run-tests suite)


### PR DESCRIPTION
## W1: Session Lifecycle Wiring — Stop Subscriber on Teardown

Wire `stop-blackboard-subscriber!` into `close-session!` to prevent event bus subscription leaks when blackboard is default-on.

### Changes
- **`runtime/agent-session.rkt`**: Import + call `stop-blackboard-subscriber!` in `close-session!` with `with-handlers` for safety. Placed after `guarded-set-active!` so the subscription is stopped after all session state is persisted.
- **`tests/test-blackboard-lifecycle.rkt`**: 3 new tests:
  1. Subscription cleared after start+stop
  2. Double-stop is idempotent (safe)
  3. Stop with no active subscription is safe no-op

### Verification
- All 115 blackboard tests green (8 files)
- `raco make main.rkt` passes