### PR TITLE
feat: W2 flip blackboard default-on + version bump to 0.99.14 (#8101)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,31 @@
+## 0.99.14
+
+Released: 2026-06-28
+
+### Features
+- **Blackboard default-on (MAS Phase 1)**: The blackboard subsystem now defaults to enabled (`mas.blackboard.enabled` defaults to `#t`). This enables zero-latency event-bus-driven blackboard updates, context injection of wave/task status into the system prompt, and crash recovery from `trace.jsonl` — all by default, with no configuration required.
+- **Session lifecycle cleanup**: `close-session!` now calls `stop-blackboard-subscriber!` to prevent event bus subscription leaks when sessions end. The call is idempotent and safe when no subscriber is active.
+
+### Breaking / Behavior Changes
+- `mas.blackboard.enabled` default changed from `#f` to `#t`. Sessions will now start the blackboard subscriber and inject context by default.
+- To disable: set `mas.blackboard.enabled = false` explicitly in config.
+
+### Migration Notes
+- No action required for most users — blackboard is passive and low-overhead.
+- To opt out: set `mas.blackboard.enabled = false` in your config file.
+- The blackboard subscriber is stopped automatically on session close (W1 wiring).
+
+### Testing
+- W0: 6 characterization tests (`test-blackboard-deployment-gate.rkt`) — default behavior, context snippet, subscriber idempotency.
+- W1: 3 session lifecycle cleanup tests (`test-blackboard-lifecycle.rkt`) — subscription cleared, idempotent stop, safe no-op.
+- All 115 existing blackboard tests green.
+- Broad fast gate: zero regressions vs. v0.99.13 baseline.
+
+### Operational / Release
+- Feature gate: `mas.blackboard.enabled` (default `#t`, was `#f`).
+- Trace logger dependency: crash recovery reads `trace.jsonl` from the session directory if it exists.
+- Token budget guard (W3, forthcoming): context injection will be capped at 500 characters.
+
 ## 0.99.13
 
 Released: 2026-06-27

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.99.13-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.99.14-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 
@@ -208,7 +208,7 @@ bin/q --model gpt-5.4 "write a test"
 ### Verify
 
 ```bash
-bin/q --version            # q version 0.99.13
+bin/q --version            # q version 0.99.14
 raco test tests/           # run the full test suite
 ```
 

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.99.13")
+(define version "0.99.14")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base" "gui-easy-lib"))

--- a/runtime/settings-query.rkt
+++ b/runtime/settings-query.rkt
@@ -421,11 +421,12 @@
 ;; Blackboard Settings (v0.99.7 MAS Schritt 4)
 ;; ============================================================
 
-;; Config key: mas.blackboard.enabled (default #f — inert by default)
+;; Config key: mas.blackboard.enabled (default #t — enabled by default since v0.99.14)
 ;; When #t, blackboard subscriber starts on session startup,
 ;; context injection is enabled, and crash recovery runs from trace.jsonl.
+;; v0.99.14: Flipped default from #f to #t (MAS Phase 1: Blackboard Default-On).
 (define (blackboard-enabled? settings)
-  (define raw (setting-ref* settings '(mas blackboard enabled) #f))
+  (define raw (setting-ref* settings '(mas blackboard enabled) #t))
   (cond
     [(boolean? raw) raw]
     [(string? raw) (and (member (string-downcase raw) '("true" "1" "yes")) #t)]

--- a/tests/test-blackboard-deployment-gate.rkt
+++ b/tests/test-blackboard-deployment-gate.rkt
@@ -41,10 +41,10 @@
 (define deployment-gate-suite
   (test-suite "Blackboard Deployment Gate (v0.99.14 W0)"
 
-    ;; ── Test 1: Current default is #f ──
-    (test-case "blackboard-enabled? returns #f for default settings"
+    ;; ── Test 1: Default is now #t (v0.99.14 W2 flip) ──
+    (test-case "blackboard-enabled? returns #t for default settings"
       (define settings (make-settings (hash)))
-      (check-false (blackboard-enabled? settings) "default should be #f before W2 flip"))
+      (check-true (blackboard-enabled? settings) "default should be #t after W2 flip"))
 
     ;; ── Test 2: Explicit #t ──
     (test-case "blackboard-enabled? returns #t when mas.blackboard.enabled = #t"

--- a/tests/test-blackboard-lifecycle.rkt
+++ b/tests/test-blackboard-lifecycle.rkt
@@ -48,9 +48,9 @@
 
     ;; ── W6-T2: Config Schema ──
 
-    (test-case "blackboard-enabled? defaults to #f"
+    (test-case "blackboard-enabled? defaults to #t (v0.99.14)"
       (define settings (make-settings (hash)))
-      (check-false (blackboard-enabled? settings)))
+      (check-true (blackboard-enabled? settings)))
 
     (test-case "blackboard-enabled? returns #t when mas.blackboard.enabled is true"
       (define settings (make-settings (hash 'mas (hash 'blackboard (hash 'enabled #t)))))
@@ -64,9 +64,9 @@
       (define settings (make-settings (hash 'mas (hash 'blackboard (hash 'enabled "false")))))
       (check-false (blackboard-enabled? settings)))
 
-    (test-case "blackboard-enabled? handles missing mas key"
+    (test-case "blackboard-enabled? handles missing mas key (defaults to #t)"
       (define settings (make-settings (hash 'other-key 'val)))
-      (check-false (blackboard-enabled? settings)))
+      (check-true (blackboard-enabled? settings)))
 
     ;; ── W6-T1: Subscriber Lifecycle ──
 

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -11,4 +11,4 @@
 
 (provide (contract-out [q-version string?]))
 
-(define q-version "0.99.13")
+(define q-version "0.99.14")


### PR DESCRIPTION
## W2: Config Default Flip + Version Bump + CHANGELOG

Flips `mas.blackboard.enabled` default from `#f` to `#t` — the core change of MAS Phase 1: Blackboard Default-On.

### Changes
- **`runtime/settings-query.rkt`**: Default flipped from `#f` → `#t`
- **`tests/test-blackboard-deployment-gate.rkt`**: Test #1 updated (default is now `#t`)
- **`tests/test-blackboard-lifecycle.rkt`**: Default test + missing-key test updated to `#t`
- **`util/version.rkt`**: `0.99.13` → `0.99.14`
- **`info.rkt`, `README.md`**: Version synced
- **`CHANGELOG.md`**: v0.99.14 section added, passes `lint-release-notes.rkt`

### Verification
- All 115 blackboard tests green
- `raco make main.rkt` passes
- `sync-version.rkt` verified (0 drift)
- `lint-release-notes.rkt --version 0.99.14` PASSES