### PR TITLE
feat: W3 token budget guard + integration tests (#8102)

### DIFF
--- a/runtime/context-assembly/blackboard-context.rkt
+++ b/runtime/context-assembly/blackboard-context.rkt
@@ -100,11 +100,30 @@
          (format "Verifier: ~a" (string-join parts ", ")))))
 
 ;; ============================================================
+;; Token Budget Guard (v0.99.14 W3)
+;; ============================================================
+
+;; Maximum length of the blackboard context snippet in characters.
+;; Prevents context-injection bloat in the system prompt.
+;; If the snippet exceeds this limit, it is truncated and suffixed with "...".
+(define MAX-BLACKBOARD-SNIPPET-LEN 500)
+
+;; Truncate a snippet to MAX-BLACKBOARD-SNIPPET-LEN chars.
+;; If already within budget, returns as-is.
+;; If over budget, returns first (MAX-BLACKBOARD-SNIPPET-LEN - 3) chars + "...".
+(define (truncate-snippet text)
+  (if (and (string? text) (> (string-length text) MAX-BLACKBOARD-SNIPPET-LEN))
+      (string-append (substring text 0 (- MAX-BLACKBOARD-SNIPPET-LEN 3)) "...")
+      text))
+
+;; ============================================================
 ;; Combined Snippet Builder
 ;; ============================================================
 
 ;; Build a compact blackboard context snippet for system prompt injection.
 ;; Returns #f if the blackboard is empty or no sections have content.
+;; The result is capped at MAX-BLACKBOARD-SNIPPET-LEN chars (500) to prevent
+;; context-injection bloat (v0.99.14 W3 token budget guard).
 ;; Optional state argument; defaults to current-blackboard.
 (define (build-blackboard-context-snippet [state #f])
   (define bb-state
@@ -122,13 +141,15 @@
                   (format-verifier-decisions bb-state))))
   (if (null? sections)
       #f
-      (string-append "[Blackboard]\n" (string-join sections "\n"))))
+      (truncate-snippet (string-append "[Blackboard]\n" (string-join sections "\n")))))
 
 ;; ============================================================
 ;; Provides
 ;; ============================================================
 
 (provide build-blackboard-context-snippet
+         MAX-BLACKBOARD-SNIPPET-LEN
+         truncate-snippet
          format-active-plan
          format-wave-status
          format-test-results

--- a/tests/test-blackboard-context.rkt
+++ b/tests/test-blackboard-context.rkt
@@ -20,6 +20,8 @@
                   update-blackboard!)
          (only-in "../runtime/context-assembly/blackboard-context.rkt"
                   build-blackboard-context-snippet
+                  MAX-BLACKBOARD-SNIPPET-LEN
+                  truncate-snippet
                   format-active-plan
                   format-wave-status
                   format-test-results
@@ -154,6 +156,49 @@
         (define preamble (build-state-awareness-preamble 'implementation '()))
         (check-not-false preamble)
         (check-true (string-contains? (preamble-text preamble) "[Blackboard]"))
-        (check-true (string-contains? (preamble-text preamble) "W0=completed"))))))
+        (check-true (string-contains? (preamble-text preamble) "W0=completed"))))
+
+    ;; ── v0.99.14 W3: Token Budget Guard ──
+
+    (test-case "MAX-BLACKBOARD-SNIPPET-LEN is 500"
+      (check-equal? MAX-BLACKBOARD-SNIPPET-LEN 500))
+
+    (test-case "snippet under 500 chars is returned as-is"
+      (define state (make-populated-state))
+      (define snippet (build-blackboard-context-snippet state))
+      (check-true (string? snippet))
+      (check-true (<= (string-length snippet) MAX-BLACKBOARD-SNIPPET-LEN)
+                  "small blackboard should not be truncated")
+      (check-false (string-suffix? snippet "...")))
+
+    (test-case "snippet over 500 chars is truncated to exactly 500"
+      (define big-wave-status
+        (for/hash ([i (in-range 60)])
+          (values (format "Wave~a" i) (if (even? i) 'completed 'in-progress))))
+      (define state (blackboard-state #f '() '() '() big-wave-status '() '() 0))
+      (define snippet (build-blackboard-context-snippet state))
+      (check-true (string? snippet))
+      (check-equal? (string-length snippet) MAX-BLACKBOARD-SNIPPET-LEN)
+      (check-true (string-suffix? snippet "...")))
+
+    (test-case "truncate-snippet is identity for short strings"
+      (check-equal? (truncate-snippet "hello") "hello"))
+
+    (test-case "truncate-snippet truncates long strings to 497+..."
+      (define long-string (make-string 1000 #\A))
+      (define result (truncate-snippet long-string))
+      (check-equal? (string-length result) 500)
+      (check-true (string-suffix? result "..."))
+      (check-equal? (substring result 0 497) (make-string 497 #\A)))
+
+    (test-case "truncate-snippet boundary: exactly 500 chars untouched"
+      (define exact-string (make-string 500 #\B))
+      (check-equal? (truncate-snippet exact-string) exact-string))
+
+    (test-case "truncate-snippet boundary: 501 chars truncated"
+      (define over-string (make-string 501 #\C))
+      (define result (truncate-snippet over-string))
+      (check-equal? (string-length result) 500)
+      (check-true (string-suffix? result "...")))))
 
 (run-tests suite)

--- a/tests/test-blackboard-deployment-gate.rkt
+++ b/tests/test-blackboard-deployment-gate.rkt
@@ -30,7 +30,8 @@
                   stop-blackboard-subscriber!
                   current-subscription)
          (only-in "../runtime/context-assembly/blackboard-context.rkt"
-                  build-blackboard-context-snippet)
+                  build-blackboard-context-snippet
+                  MAX-BLACKBOARD-SNIPPET-LEN)
          (only-in "../runtime/context-assembly/state-aware-builder.rkt"
                   current-blackboard-injection-enabled))
 
@@ -81,6 +82,37 @@
       (check-not-exn (lambda () (stop-blackboard-subscriber!)))
       ;; Calling again is still safe
       (check-not-exn (lambda () (stop-blackboard-subscriber!)))
-      (check-false (unbox current-subscription)))))
+      (check-false (unbox current-subscription)))
+
+    ;; ── v0.99.14 W3: Integration Tests ──
+
+    (test-case "default settings enable blackboard (subscriber would start)"
+      (define settings (make-settings (hash)))
+      (check-true (blackboard-enabled? settings) "blackboard should be enabled by default"))
+
+    (test-case "explicit #f disables blackboard (subscriber would not start)"
+      (define settings (make-settings (hash 'mas (hash 'blackboard (hash 'enabled #f)))))
+      (check-false (blackboard-enabled? settings)
+                   "blackboard should be disabled when explicitly set to #f"))
+
+    (test-case "injection only when blackboard is non-empty"
+      (check-false (build-blackboard-context-snippet empty-blackboard))
+      (define populated-state
+        (struct-copy blackboard-state empty-blackboard [wave-status (hash "W0" "completed")]))
+      (define snippet (build-blackboard-context-snippet populated-state))
+      (check-not-false snippet)
+      (check-true (string-contains? snippet "[Blackboard]")))
+
+    (test-case "token budget: large blackboard state truncated to 500 chars"
+      (define big-wave-status
+        (for/hash ([i (in-range 60)])
+          (values (format "Wave~a" i) (if (even? i) "completed" "in-progress"))))
+      (define state (struct-copy blackboard-state empty-blackboard [wave-status big-wave-status]))
+      (define snippet (build-blackboard-context-snippet state))
+      (check-not-false snippet)
+      (check-true (string? snippet))
+      (check-true (<= (string-length snippet) MAX-BLACKBOARD-SNIPPET-LEN)
+                  "snippet must not exceed 500 chars")
+      (check-true (string-suffix? snippet "...") "truncated snippet must end with ..."))))
 
 (run-tests deployment-gate-suite)


### PR DESCRIPTION
## W3: Integration Tests & Token Budget Guard

Adds the 500-char token budget guard to prevent context-injection bloat now that blackboard is default-on.

### Changes
- **`runtime/context-assembly/blackboard-context.rkt`**:
  - New `MAX-BLACKBOARD-SNIPPET-LEN` constant (500 chars)
  - New `truncate-snippet` helper: caps to 497 chars + `"..."`
  - `build-blackboard-context-snippet` now wraps output in `truncate-snippet`
  - Both new symbols exported

- **`tests/test-blackboard-context.rkt`**: +7 token budget tests
  - Constant value check (500)
  - Under-budget snippet returned as-is
  - Over-budget snippet truncated to exactly 500 chars
  - `truncate-snippet` identity, long-string, boundary (500/501) tests

- **`tests/test-blackboard-deployment-gate.rkt`**: +4 integration tests
  - Default settings enable blackboard (subscriber would start)
  - Explicit `#f` disables (subscriber would not start)
  - Injection only when blackboard is non-empty
  - Token budget truncation on large state

### Verification
- All 126 blackboard tests green (115 existing + 11 new)
- `raco make main.rkt` passes