### PR TITLE
fix: W2 audit debt closure F-15 through F-19 + v0.99.14-F-01/F-02 (#8115)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,13 +18,13 @@ Released: 2026-06-28
 ### Testing
 - W0: 6 characterization tests (`test-blackboard-deployment-gate.rkt`) — default behavior, context snippet, subscriber idempotency.
 - W1: 3 session lifecycle cleanup tests (`test-blackboard-lifecycle.rkt`) — subscription cleared, idempotent stop, safe no-op.
-- All 115 existing blackboard tests green.
+- All 106 existing blackboard tests green.
 - Broad fast gate: zero regressions vs. v0.99.13 baseline.
 
 ### Operational / Release
 - Feature gate: `mas.blackboard.enabled` (default `#t`, was `#f`).
 - Trace logger dependency: crash recovery reads `trace.jsonl` from the session directory if it exists.
-- Token budget guard (W3, forthcoming): context injection will be capped at 500 characters.
+- Token budget guard: context injection is capped at 500 characters (implemented in W3).
 
 ## 0.99.13
 
@@ -48,11 +48,11 @@ Released: 2026-06-27
 ### Migration Notes
 - No configuration changes required. All new features are default-off.
 - To enable hot-swapping: set `mas.hot-swap.enabled = true` and `mas.hot-swap.auto-reload.enabled = true`.
-- `blackboard-follower.rkt` re-exports all symbols from `blackboard-subscriber.rkt` for backward compatibility.
+- `blackboard-subscriber.rkt` re-exports follower symbols (extracted from it) for backward compatibility.
 
 ### Testing
 - Blackboard follower: 10/10 tests green.
-- Registry hot-swap: 9/9 tests green (static path, dynamic path, version pinning, session warning, fallback).
+- Registry hot-swap: 8/9 tests green (1 dynamic-require path failure due to relative module path resolution, fixed in v0.99.15 W1).
 - Registry watcher: 9/9 tests green (file detection, modified files, start/stop lifecycle, no-leak).
 - E2E distributed execution: 6/6 tests green.
 - All existing registry tests: 31 + 11 + 7 + 10 + 2 = 61 tests green.

--- a/agent/registry-watcher.rkt
+++ b/agent/registry-watcher.rkt
@@ -9,18 +9,20 @@
 ;;   mas.hot-swap.enabled = #t AND
 ;;   mas.hot-swap.auto-reload.enabled = #t (default #f)
 ;;
-;; Uses filesystem-change-evt (available in Racket 8.x) for efficient
-;; event-based file change notification. Falls back to polling if
-;; filesystem-change-evt is not supported on the platform.
+;; Uses polling-based file change detection (checks modification times
+;; at configurable intervals). This avoids platform-specific
+;; filesystem event dependencies.
 ;;
 ;; Design:
 ;;   - start-registry-watcher!: start background thread watching agent/roles/
 ;;   - stop-registry-watcher!: terminate thread cleanly
 ;;   - path->role-name: convert file path to role symbol
-;;   - next-version: increment minor version string ("1.0.0" → "1.0.1")
+;;   - next-version: increment patch version string ("1.0.0" → "1.0.1")
 
 (require racket/match
          racket/string
+         racket/list
+         racket/contract
          "registry.rkt")
 
 ;; ============================================================
@@ -32,21 +34,15 @@
 (define (path->role-name path-str)
   (define filename
     (let* ([parts (string-split path-str "/" #:trim? #f)]
-           [last (if (null? parts)
-                     path-str
-                     (last parts))])
-      (if (string-suffix? last ".rkt")
-          (substring last 0 (- (string-length last) 4))
-          last)))
+           [fname (if (null? parts)
+                      path-str
+                      (last parts))])
+      (if (string-suffix? fname ".rkt")
+          (substring fname 0 (- (string-length fname) 4))
+          fname)))
   (string->symbol filename))
 
-;; Helper: get last element of a list.
-(define (last lst)
-  (if (null? (cdr lst))
-      (car lst)
-      (last (cdr lst))))
-
-;; Increment the minor version of a semver string.
+;; Increment the patch version of a semver string.
 ;; "1.0.0" → "1.0.1", "2.3.4" → "2.3.5"
 (define (next-version version-str)
   (define parts (string-split version-str "."))
@@ -63,10 +59,6 @@
           (lambda (n) (number->string (+ n 1)))]
          [else "1"]))
      (string-append major "." minor "." new-patch)]))
-
-;; Helper: get third element of a list.
-(define (caddr lst)
-  (car (cddr lst)))
 
 ;; ============================================================
 ;; Watcher State
@@ -154,8 +146,9 @@
 ;; Provides
 ;; ============================================================
 
-(provide path->role-name
-         next-version
-         start-registry-watcher!
-         stop-registry-watcher!
-         watcher-running?)
+(provide (contract-out [path->role-name (-> string? symbol?)]
+                       [next-version (-> string? string?)]
+                       [start-registry-watcher!
+                        (->* (path-string? procedure?) (#:poll-interval real?) thread?)]
+                       [stop-registry-watcher! (-> void?)]
+                       [watcher-running? (-> boolean?)]))

--- a/tests/test-distributed-execution-e2e.rkt
+++ b/tests/test-distributed-execution-e2e.rkt
@@ -133,22 +133,30 @@
                                 #:health-check-enabled #f))
       (sleep 0.2)
 
-      ;; Execute a tool that echoes its arguments
-      ;; bash will receive only 'command' — NOT 'capability-token' (F-10 fix)
+      ;; F-17: Strengthened assertion — verify the capability secret does
+      ;; NOT appear anywhere in the response content. The bash command
+      ;; dumps all environment variables, so if the token leaked into any
+      ;; part of the dispatch pipeline, it would appear in the output.
       (define resp
         (execute-via-remote exec
                             "bash"
-                            (hasheq 'command "echo 'token-strip-verified'")
+                            (hasheq 'command "echo 'token-strip-verified'; env")
                             'execute-tools
                             10000))
       (check-equal? (ipc-response-status resp) 'ok)
-      (check-true (string-contains? (or (ipc-response-content resp) "") "token-strip-verified"))
-
-      ;; The fact that bash succeeded means the token was stripped.
-      ;; If it hadn't been stripped, the worker would have received an extra
-      ;; 'capability-token key in arguments — which bash ignores, but the
-      ;; important part is the server validated it BEFORE stripping.
-      ;; We verify the server validated by checking it returned 'ok (not 'error).
+      (define content (or (ipc-response-content resp) ""))
+      (check-true (string-contains? content "token-strip-verified")
+                  "response should contain echo output")
+      ;; F-17: Strong negative assertion — the capability secret must not
+      ;; appear anywhere in the response. This proves the token was stripped
+      ;; before dispatch (F-10 fix). If the token leaked into stdout, stderr,
+      ;; error messages, or response details, we'd catch it here.
+      (check-false (string-contains? content TEST-SECRET)
+                   "capability secret must NOT appear in tool output (token was stripped)")
+      (check-false (string-contains? (or (ipc-response-error-message resp) "") TEST-SECRET)
+                   "capability secret must NOT appear in error message")
+      (check-false (string-contains? (format "~a" (or (ipc-response-details resp) "")) TEST-SECRET)
+                   "capability secret must NOT appear in response details")
 
       (shutdown-remote-executor! exec)
       (shutdown-executor-server! server)
@@ -266,21 +274,17 @@
       (shutdown-executor-server! server)
       (sleep 0.2))
 
-    ;; ── E2E-5: Broker disabled → local fallback ──────────────────
-    (test-case "E2E-5: broker-disabled default means local-only execution"
-      ;; When mas.broker.enabled = #f (default), the remote executor is never started.
-      ;; The tool-gateway falls back to local execution for all risk levels.
-      ;; We verify this by checking that without a remote executor configured,
-      ;; the routing decision is 'local (not 'remote).
-
-      ;; Verify the default remote tool executor is fail-closed
-      ;; (from tool-gateway.rkt: default-remote-tool-executor returns error)
-      ;; This means when broker is disabled, remote routing returns an error
-      ;; (which the caller catches and falls back to local)
-
-      ;; We simulate the broker-disabled state by NOT starting any server
-      ;; and NOT connecting any client. The test verifies that no server is
-      ;; running and the default state is local-only.
+    ;; ── E2E-5: No server running → connection fails (fail-closed) ─
+    ;; F-19: Renamed for accuracy. This test verifies the fail-closed
+    ;; behavior when no server is running — it does NOT test local
+    ;; fallback (which is handled by the wiring layer in run-modes.rkt).
+    (test-case "E2E-5: no server running → executor connection fails (fail-closed)"
+      ;; When no executor server is running, a remote executor client
+      ;; cannot connect. This is the correct fail-closed behavior:
+      ;; no server = no remote execution. In production, the wiring
+      ;; layer (run-modes.rkt) checks broker-enabled? before ever
+      ;; calling start-remote-executor!, so this situation only arises
+      ;; from misconfiguration.
 
       ;; Verify that without starting a server, a connection attempt fails gracefully
       (define test-port


### PR DESCRIPTION
## W2: Audit Debt Closure

Closes all remaining LOW/INFO audit findings from v0.99.13 and v0.99.14 in-depth audits.

### Changes

**F-15** — v0.99.13 CHANGELOG corrections:
- Hot-swap "9/9 tests green" → "8/9 tests green (1 dynamic-require path failure, fixed in v0.99.15 W1)"
- Re-export direction fixed: "blackboard-subscriber.rkt re-exports follower symbols" (was backwards)

**F-16** — `registry-watcher.rkt` comment fixes:
- Removed false `filesystem-change-evt` claim (implementation is polling-based)
- Fixed "minor version" → "patch version" in `next-version` docstring
- Removed shadowed local `last`/`caddr` definitions (now via `racket/list`)

**F-17** — Strengthened E2E-2 token-stripping assertion:
- Bash command now dumps `env` vars
- Three negative assertions verify `TEST-SECRET` does NOT appear in response content, error message, or response details

**F-18** — Added contracts to all 5 `registry-watcher.rkt` provides

**F-19** — Renamed E2E-5 from misleading "broker-disabled local-only execution" to accurate "no server running → executor connection fails (fail-closed)"

**v0.99.14-F-01** — CHANGELOG "Token budget guard (W3, forthcoming)" → past tense

**v0.99.14-F-02** — CHANGELOG "115 existing blackboard tests" → "106 existing"

### Verification
- `test-registry-watcher.rkt`: **9/9** (contracts added, no regression)
- `test-registry-hot-swap.rkt`: **9/9**
- `test-registry-deployment-gate.rkt`: **8/8**
- `test-agent-registry.rkt`: **31/31**
- `test-verifier-deployment-gate.rkt`: **7/7**
- `test-registry-config-wiring.rkt`: **11/11**
- `raco make main.rkt`: passes