### PR TITLE
feat: W3 verifier default-on + risk threshold flip (#8116)

### DIFF
--- a/runtime/settings-query.rkt
+++ b/runtime/settings-query.rkt
@@ -388,14 +388,18 @@
 ;; Verifier Agent Settings (v0.99.5 MAS Schritt 3)
 ;; ============================================================
 
-;; Config key: mas.verifier.enabled (default #f — inert by default)
+;; Config key: mas.verifier.enabled (default #t — enabled by default since v0.99.15)
 ;; When #t, verification gate runs between executing and idle/done.
+;; v0.99.15: Flipped default from #f to #t (MAS Phase 2: Verifier Default-On).
+;; The verifier only activates for GSD wave-done commands in sessions with
+;; a verifier provider configured; non-GSD sessions are unaffected.
+;; Safe fallback chain: no provider → auto-approve, error → escalate, timeout → escalate.
 (define (verifier-enabled? settings)
-  (define raw (setting-ref* settings '(mas verifier enabled) #f))
+  (define raw (setting-ref* settings '(mas verifier enabled) #t))
   (cond
     [(boolean? raw) raw]
     [(string? raw) (and (member (string-downcase raw) '("true" "1" "yes")) #t)]
-    [else #f]))
+    [else #t]))
 
 ;; Config key: mas.verifier.model (default #f = use session model)
 ;; When set, verification uses a specific model instead of the session default.
@@ -406,16 +410,18 @@
     [(symbol? raw) (symbol->string raw)]
     [else #f]))
 
-;; Config key: mas.verifier.risk-threshold (default 'medium)
+;; Config key: mas.verifier.risk-threshold (default 'high — conservative since v0.99.15)
 ;; Valid values: 'low, 'medium, 'high.
 ;; Decisions with risk-level >= threshold are forced to require human review.
+;; v0.99.15: Changed default from 'medium to 'high so the verifier gate
+;; only escalates genuinely high-risk decisions by default.
 (define (verifier-risk-threshold settings)
-  (define raw (setting-ref* settings '(mas verifier risk-threshold) "medium"))
+  (define raw (setting-ref* settings '(mas verifier risk-threshold) "high"))
   (define sym
     (if (symbol? raw)
         raw
         (string->symbol raw)))
-  (if (memq sym '(low medium high)) sym 'medium))
+  (if (memq sym '(low medium high)) sym 'high))
 
 ;; ============================================================
 ;; Blackboard Settings (v0.99.7 MAS Schritt 4)

--- a/tests/test-verifier-deployment-gate.rkt
+++ b/tests/test-verifier-deployment-gate.rkt
@@ -5,15 +5,16 @@
 ;; tests/test-verifier-deployment-gate.rkt
 ;; v0.99.15 W0: Verifier Characterization & Pre-Implementation Safety Net
 ;;
-;; These tests lock in the CURRENT default-off behavior of the verifier
-;; before the default flip in W3. After W3, tests #1 and #4 will be updated.
+;; Updated in W3: Tests #1 and #4 now reflect the flipped defaults:
+;;   verifier-enabled? default is now #t (was #f)
+;;   verifier-risk-threshold default is now 'high (was 'medium)
 ;;
 ;; Test Cases:
-;;   1. verifier-enabled? returns #f for default settings (characterize current)
+;;   1. verifier-enabled? returns #t for default settings (post-W3 flip)
 ;;   2. verifier-enabled? returns #t when explicitly enabled
 ;;   3. verifier-enabled? returns #f when explicitly disabled
-;;   4. verifier-risk-threshold returns 'medium for default settings
-;;   5. verifier-risk-threshold returns 'high when explicitly set
+;;   4. verifier-risk-threshold returns 'high for default settings (post-W3)
+;;   5. verifier-risk-threshold returns 'medium when explicitly set
 ;;   6. Gate with flag OFF returns 'approved (no LLM call)
 ;;   7. Gate with flag ON + no provider returns 'approved (safe fallback)
 
@@ -44,10 +45,10 @@
 (define deployment-gate-suite
   (test-suite "Verifier Deployment Gate (v0.99.15 W0)"
 
-    ;; ── Test 1: Default is #f (characterize current default-off) ──
-    (test-case "verifier-enabled? returns #f for default settings"
+    ;; ── Test 1: Default is #t (post-W3 default-on) ──
+    (test-case "verifier-enabled? returns #t for default settings"
       (define settings (make-settings (hash)))
-      (check-false (verifier-enabled? settings) "default should be #f before W3 flip"))
+      (check-true (verifier-enabled? settings) "default should be #t after W3 flip"))
 
     ;; ── Test 2: Explicit #t ──
     (test-case "verifier-enabled? returns #t when mas.verifier.enabled = #t"
@@ -59,15 +60,15 @@
       (define settings (make-settings (hash 'mas (hash 'verifier (hash 'enabled #f)))))
       (check-false (verifier-enabled? settings)))
 
-    ;; ── Test 4: Risk threshold default is 'medium ──
-    (test-case "verifier-risk-threshold returns 'medium for default settings"
+    ;; ── Test 4: Risk threshold default is 'high (post-W3) ──
+    (test-case "verifier-risk-threshold returns 'high for default settings"
       (define settings (make-settings (hash)))
-      (check-equal? (verifier-risk-threshold settings) 'medium))
-
-    ;; ── Test 5: Risk threshold explicit 'high ──
-    (test-case "verifier-risk-threshold returns 'high when explicitly set"
-      (define settings (make-settings (hash 'mas (hash 'verifier (hash 'risk-threshold "high")))))
       (check-equal? (verifier-risk-threshold settings) 'high))
+
+    ;; ── Test 5: Risk threshold explicit 'medium ──
+    (test-case "verifier-risk-threshold returns 'medium when explicitly set"
+      (define settings (make-settings (hash 'mas (hash 'verifier (hash 'risk-threshold "medium")))))
+      (check-equal? (verifier-risk-threshold settings) 'medium))
 
     ;; ── Test 6: Gate with flag OFF returns 'approved ──
     (test-case "execute-verification-gate returns 'approved when verifier disabled"

--- a/tests/test-verifier-integration.rkt
+++ b/tests/test-verifier-integration.rkt
@@ -120,9 +120,9 @@
 
     ;; ── Config Accessor Tests ──
 
-    (test-case "verifier-enabled? returns #f when not set"
+    (test-case "verifier-enabled? returns #t by default (v0.99.15 default-on)"
       (define s (make-minimal-settings))
-      (check-false (verifier-enabled? s)))
+      (check-true (verifier-enabled? s)))
 
     (test-case "verifier-enabled? returns #t when mas.verifier.enabled is true"
       (define s
@@ -160,9 +160,9 @@
         (make-minimal-settings #:overrides (hasheq 'mas (hasheq 'verifier (hasheq 'model 'glm-5.1)))))
       (check-equal? (verifier-model s) "glm-5.1"))
 
-    (test-case "verifier-risk-threshold returns 'medium by default"
+    (test-case "verifier-risk-threshold returns 'high by default (v0.99.15)"
       (define s (make-minimal-settings))
-      (check-equal? (verifier-risk-threshold s) 'medium))
+      (check-equal? (verifier-risk-threshold s) 'high))
 
     (test-case "verifier-risk-threshold parses string \"high\""
       (define s
@@ -176,11 +176,11 @@
                                (hasheq 'mas (hasheq 'verifier (hasheq 'risk-threshold "low")))))
       (check-equal? (verifier-risk-threshold s) 'low))
 
-    (test-case "verifier-risk-threshold coerces invalid to 'medium"
+    (test-case "verifier-risk-threshold coerces invalid to 'high (v0.99.15 default)"
       (define s
         (make-minimal-settings #:overrides
                                (hasheq 'mas (hasheq 'verifier (hasheq 'risk-threshold "extreme")))))
-      (check-equal? (verifier-risk-threshold s) 'medium))
+      (check-equal? (verifier-risk-threshold s) 'high))
 
     (test-case "verifier-risk-threshold accepts symbol directly"
       (define s
@@ -210,14 +210,16 @@
 
     (test-case "config-disabled→parameter wiring (manual simulation)"
       (save-params!)
-      (define s (make-minimal-settings))
+      ;; Explicitly disable to test the disabled path (default is now #t)
+      (define s
+        (make-minimal-settings #:overrides (hasheq 'mas (hasheq 'verifier (hasheq 'enabled #f)))))
       (current-verifier-enabled (verifier-enabled? s))
       (current-verifier-model (verifier-model s))
       (current-verifier-risk-threshold (verifier-risk-threshold s))
 
       (check-false (current-verifier-enabled))
       (check-false (current-verifier-model))
-      (check-equal? (current-verifier-risk-threshold) 'medium)
+      (check-equal? (current-verifier-risk-threshold) 'high)
 
       (restore-params!))
 


### PR DESCRIPTION
## W3: Verifier Default Flip + Risk Threshold

MAS Phase 2: Flip verifier defaults for safe-by-default verification.

### Default Changes

| Setting | Old Default | New Default | Rationale |
|---------|------------|------------|-----------|
| `mas.verifier.enabled` | `#f` (inert) | `#t` (active) | Verifier on by default — verification is a safety feature |
| `mas.verifier.risk-threshold` | `"medium"` | `"high"` | Only escalate genuinely high-risk decisions by default |

### Safety Analysis

The verifier default-on is safe because:
1. **Scope-limited**: The verifier only activates for GSD `wave-done` commands
2. **Non-GSD sessions**: Completely unaffected — no code path reaches the gate
3. **Safe fallback chain**: No provider → auto-approve, error → escalate, timeout → escalate
4. **Parameter default unchanged**: `current-verifier-enabled` parameter defaults to `#f` (runtime safety: uninitialized modules skip verification; settings value is wired in during session start)

### Files Changed
- `runtime/settings-query.rkt`: Flip both defaults + update docstrings
- `tests/test-verifier-deployment-gate.rkt`: Tests 1 & 4 updated for new defaults
- `tests/test-verifier-integration.rkt`: 4 tests updated for new defaults

### Verification
- `test-verifier-deployment-gate.rkt`: **7/7**
- `test-verifier-integration.rkt`: **26/26**
- `test-verifier-gate.rkt`: **20/20**
- `test-verifier-core.rkt`: **30/30**
- `test-verifier-hardening.rkt`: **25/25**
- `test-verifier-prompt.rkt`: **17/17**
- `test-verifier-types.rkt`: **30/30**
- `test-verifier-wiring.rkt`: **7/7**
- `test-registry-config-wiring.rkt`: **11/11**
- `raco make main.rkt`: passes