### PR TITLE
fix: W2 F-TUI-03 delta render row-end clear (#8128)

### DIFF
--- a/tests/test-tui-snapshot-drift.rkt
+++ b/tests/test-tui-snapshot-drift.rkt
@@ -107,23 +107,21 @@
       ;; Should contain the actual text
       (check-true (string-contains? output "ABC") "should contain the changed text"))
 
-    ;; ── Test 7: render-deltas-to-port! does NOT emit ESC[K ──
-    ;; This documents the F-TUI-03 condition: delta render lacks ESC[K.
-    (test-case "F-TUI-03: render-deltas-to-port! does NOT emit ESC[K (bug characterization)"
+    ;; ── Test 7: render-deltas-to-port! emits ESC[K for shortened rows (FIXED) ──
+    ;; After W2 fix, delta render emits ESC[K after rows whose last delta is a default cell.
+    (test-case "F-TUI-03: render-deltas-to-port! emits ESC[K for shortened rows (fixed)"
       (define prev (make-cell-buffer 10 3))
       (cell-buffer-putstring! prev 0 0 "XXXXXXXXX" #:fg 2)
       (define curr (make-cell-buffer 10 3))
       (cell-buffer-putstring! curr 0 0 "ABC" #:fg 2)
-      ;; Only first 3 cells differ (A replaces X, B replaces X, C replaces X)
-      ;; Cells 3-8 still have X in prev but space in curr — they're in deltas
+      ;; Cols 0-2 change to ABC, cols 3-8 change from X to default (space)
       (define deltas (diff-cell-buffers prev curr))
       (define out (open-output-string))
       (render-deltas-to-port! deltas curr out #:sync? #f)
       (define output (get-output-string out))
-      ;; Before W2 fix: no ESC[K in delta render
-      ;; After W2 fix: ESC[K emitted at row boundaries
-      (check-false (string-contains? output "\x1b[K")
-                   "delta render does NOT emit ESC[K (F-TUI-03 bug condition)"))
+      ;; After W2 fix: ESC[K IS emitted because last delta in row has default new-cell
+      (check-true (string-contains? output "\x1b[K")
+                  "delta render SHOULD emit ESC[K for rows ending in default cells (F-TUI-03 fixed)"))
 
     ;; ── Test 8: cell-buffer-snapshot produces independent copy ──
     (test-case "cell-buffer-snapshot produces independent copy"
@@ -202,6 +200,64 @@
       ;; Verify BOTH are cleared
       (check-false (unbox (tui-ctx-prev-ubuf-box ctx)) "prev-ubuf-box must be #f after resize")
       (check-false (unbox (tui-ctx-previous-frame-box ctx))
-                   "previous-frame-box must be #f after resize"))))
+                   "previous-frame-box must be #f after resize"))
+
+    ;; ============================================================
+    ;; W2 Tests: F-TUI-03 Delta Render Row-End Clear
+    ;; ============================================================
+
+    ;; ── Test 14: F-TUI-03 — multiple rows shortened → ESC[K at each boundary ──
+    (test-case "F-TUI-03: multiple shortened rows each get ESC[K"
+      (define prev (make-cell-buffer 10 3))
+      (cell-buffer-putstring! prev 0 0 "XXXXX" #:fg 2)
+      (cell-buffer-putstring! prev 0 1 "YYYYY" #:fg 3)
+      (define curr (make-cell-buffer 10 3))
+      (cell-buffer-putstring! curr 0 0 "AB" #:fg 2)
+      (cell-buffer-putstring! curr 0 1 "CD" #:fg 3)
+      (define deltas (diff-cell-buffers prev curr))
+      (define out (open-output-string))
+      (render-deltas-to-port! deltas curr out #:sync? #f)
+      (define output (get-output-string out))
+      ;; Count ESC[K occurrences — should be 2 (one per shortened row)
+      (define esc-k-count (length (regexp-match-positions* #rx"\x1b\\[K" output)))
+      (check-equal? esc-k-count 2 "should emit ESC[K once per shortened row"))
+
+    ;; ── Test 15: F-TUI-03 — no deltas → no ESC[K ──
+    (test-case "F-TUI-03: no deltas produces no ESC[K"
+      (define buf (make-cell-buffer 10 3))
+      (define out (open-output-string))
+      (render-deltas-to-port! '() buf out #:sync? #f)
+      (define output (get-output-string out))
+      (check-false (string-contains? output "\x1b[K") "no deltas should produce no ESC[K"))
+
+    ;; ── Test 16: F-TUI-03 — row NOT shortened (last delta non-default) → no ESC[K ──
+    (test-case "F-TUI-03: row ending with non-default cell does NOT get ESC[K"
+      (define prev (make-cell-buffer 10 3))
+      (cell-buffer-putstring! prev 0 0 "Hello" #:fg 2)
+      (define curr (make-cell-buffer 10 3))
+      (cell-buffer-putstring! curr 0 0 "Hexlo" #:fg 2)
+      ;; Only col 1 changes: e→x. Last delta new-cell is 'x' (non-default)
+      (define deltas (diff-cell-buffers prev curr))
+      (define out (open-output-string))
+      (render-deltas-to-port! deltas curr out #:sync? #f)
+      (define output (get-output-string out))
+      (check-false (string-contains? output "\x1b[K")
+                   "row ending with non-default cell should NOT emit ESC[K"))
+
+    ;; ── Test 17: F-TUI-03 — multiple batches same row → single ESC[K at row end ──
+    (test-case "F-TUI-03: multiple batches in same row produce single ESC[K"
+      (define prev (make-cell-buffer 10 3))
+      (cell-buffer-putstring! prev 0 0 "XXXXX" #:fg 2)
+      (define curr (make-cell-buffer 10 3))
+      ;; Put ABC with fg=2 at cols 0-2, then spaces (default fg=7) at cols 3-4
+      (cell-buffer-putstring! curr 0 0 "ABC" #:fg 2)
+      ;; Deltas will have two batches: ABC (fg2) and spaces (fg7) — same row
+      (define deltas (diff-cell-buffers prev curr))
+      (define out (open-output-string))
+      (render-deltas-to-port! deltas curr out #:sync? #f)
+      (define output (get-output-string out))
+      ;; Multiple batches in same row, but only ONE ESC[K at the row end
+      (define esc-k-count (length (regexp-match-positions* #rx"\x1b\\[K" output)))
+      (check-equal? esc-k-count 1 "single ESC[K for multi-batch row ending in default"))))
 
 (run-tests snapshot-drift-suite)

--- a/tui/cell-diff-render.rkt
+++ b/tui/cell-diff-render.rkt
@@ -8,6 +8,7 @@
 ;; Uses DEC 2026 (Synchronized Output) when available.
 
 (require racket/contract
+         racket/list
          racket/string
          "cell-buffer.rkt"
          "cell-diff.rkt"
@@ -55,63 +56,78 @@
 ;; Render deltas to output port
 ;; ============================================================
 
+;; F-TUI-03 (v0.99.16 W2): Check if a cell is a default/blank cell.
+;; Used to determine whether to emit ESC[K after a row's deltas.
+(define (default-cell? cell)
+  (and (char=? (cell-char cell) #\space)
+       (= (cell-fg cell) 7)
+       (= (cell-bg cell) 0)
+       (not (cell-bold? cell))
+       (not (cell-underline? cell))
+       (not (cell-italic? cell))
+       (not (cell-blink? cell))))
+
 ;; Render cell deltas to an output port as minimal ANSI sequences.
 ;; Deltas should be sorted by position (row-major order) for optimal grouping.
+;; F-TUI-03 (v0.99.16 W2): After each row's last delta, if the last cell
+;; is a default/blank cell, emit ESC[K to clear residual content to the
+;; right. This prevents display corruption when row content is shortened
+;; and the terminal's actual state has drifted from the snapshot.
 (define (render-deltas-to-port! deltas buf out #:sync? [sync? #t])
   (call-with-terminal-render-guards
    out
    sync?
    (lambda ()
-     (define prev-sgr #f)
+     (define prev-sgr (box #f))
      ;; Filter out continuation cells — they are rendered as part of their base char
      (define real-deltas
        (filter (lambda (d) (not (continuation-cell? (cell-delta-new-cell d)))) deltas))
-     ;; Batch consecutive deltas in same row with same SGR into one cursor move + string
-     (let loop ([remaining real-deltas])
-       (cond
-         [(null? remaining) (void)]
-         [else
-          (define d (car remaining))
-          (define col (cell-delta-col d))
-          (define row (cell-delta-row d))
-          (define new-cell (cell-delta-new-cell d))
-          (define sgr (cell->sgr new-cell))
-          ;; Position cursor: CSI row+1 ; col+1 H
-          (display (format "\x1b[~a;~aH" (add1 row) (add1 col)) out)
-          ;; Apply SGR only if changed
-          (unless (equal? sgr prev-sgr)
-            (display sgr out)
-            (set! prev-sgr sgr))
-          ;; Collect consecutive cells in same row with same SGR
-          (define chars (list (cell-char new-cell)))
-          (let gather ([rest (cdr remaining)]
-                       [acc chars]
-                       [next-col (add1 col)])
-            (cond
-              [(null? rest)
-               ;; Emit batch — last batch in entire delta list
-               (display (list->string (reverse acc)) out)
-               ;; NOTE: No ESC[K here. The delta list includes all changed
-               ;; cells (including trailing spaces), so unchanged content to
-               ;; the right of the last delta must NOT be erased. ESC[K would
-               ;; destroy on-screen content that hasn't changed.
-               (loop rest)]
-              [else
-               (define nd (car rest))
-               (define nd-col (cell-delta-col nd))
-               (define nd-row (cell-delta-row nd))
-               (define nd-cell (cell-delta-new-cell nd))
-               (define nd-sgr (cell->sgr nd-cell))
-               (cond
-                 [(and (= nd-row row) (= nd-col next-col) (equal? nd-sgr sgr))
-                  ;; Same row, consecutive column, same style — batch continues
-                  (gather (cdr rest) (cons (cell-char nd-cell) acc) (add1 next-col))]
-                 [else
-                  ;; Batch ends — emit accumulated chars
-                  (display (list->string (reverse acc)) out)
-                  ;; NOTE: No ESC[K between batches. The delta list includes
-                  ;; all changed cells; unchanged content must not be erased.
-                  (loop rest)])]))])))))
+     ;; F-TUI-03 (v0.99.16 W2): Group deltas by row for row-end ESC[K emission.
+     ;; Deltas from diff-cell-buffers are already sorted by row then column.
+     (define row-groups (group-by cell-delta-row real-deltas))
+     (for ([row-group (in-list row-groups)])
+       ;; Render all batches in this row group
+       (let loop ([remaining row-group])
+         (cond
+           [(null? remaining) (void)]
+           [else
+            (define d (car remaining))
+            (define col (cell-delta-col d))
+            (define row (cell-delta-row d))
+            (define new-cell (cell-delta-new-cell d))
+            (define sgr (cell->sgr new-cell))
+            ;; Position cursor: CSI row+1 ; col+1 H
+            (display (format "\x1b[~a;~aH" (add1 row) (add1 col)) out)
+            ;; Apply SGR only if changed
+            (unless (equal? sgr (unbox prev-sgr))
+              (display sgr out)
+              (set-box! prev-sgr sgr))
+            ;; Collect consecutive cells with same SGR
+            (define chars (list (cell-char new-cell)))
+            (let gather ([rest (cdr remaining)]
+                         [acc chars]
+                         [next-col (add1 col)])
+              (cond
+                ;; Emit batch — last batch in this row group
+                [(null? rest) (display (list->string (reverse acc)) out)]
+                [else
+                 (define nd (car rest))
+                 (define nd-col (cell-delta-col nd))
+                 (define nd-cell (cell-delta-new-cell nd))
+                 (define nd-sgr (cell->sgr nd-cell))
+                 (cond
+                   [(and (= nd-col next-col) (equal? nd-sgr sgr))
+                    ;; Consecutive column, same style — batch continues
+                    (gather (cdr rest) (cons (cell-char nd-cell) acc) (add1 next-col))]
+                   [else
+                    ;; Batch ends — emit accumulated chars
+                    (display (list->string (reverse acc)) out)
+                    (loop rest)])]))]))
+       ;; F-TUI-03 (v0.99.16 W2): After the last delta in this row, if the
+       ;; last cell is a default/blank cell, emit ESC[K to clear any residual
+       ;; content to the right (defensive against snapshot drift).
+       (when (default-cell? (cell-delta-new-cell (last row-group)))
+         (display "\x1b[K" out))))))
 
 ;; ============================================================
 ;; Full buffer render (for first frame or resize)


### PR DESCRIPTION
## W2: Delta Render Row-End Clear (F-TUI-03)

### F-TUI-03: ESC[K at Row Boundaries
**File:** `tui/cell-diff-render.rkt`

Refactored `render-deltas-to-port!` to group cell deltas by row using `group-by`. After rendering each row's batches, if the last delta's new-cell is a default/blank cell (space, fg=7, bg=0, no attributes), emit `ESC[K` (Erase to End of Line) to clear residual content to the right.

This prevents display corruption when row text is shortened and the terminal's actual state has drifted from the tracked snapshot. The `ESC[K` is only emitted when the row was shortened (last delta changed TO a default cell), NOT when the row ends with non-default content — preventing unintended erasure of unchanged trailing content.

Added `default-cell?` helper predicate. SGR state preserved across rows via box.

### Test Results
- Updated W0 test #7: `check-false` → `check-true` (ESC[K now emitted for shortened rows)
- Added 4 new tests (14-17)
- All 17 tests pass
- No regressions in existing TUI tests