### PR TITLE
fix: W1 raco test subprocess compatibility via runtime-path (#8140)

### DIFF
--- a/tests/test-execution-plane-characterization.rkt
+++ b/tests/test-execution-plane-characterization.rkt
@@ -18,12 +18,14 @@
          rackunit/text-ui
          racket/port
          racket/string
+         racket/runtime-path
          json
          "../sandbox/ipc-protocol.rkt"
          "../sandbox/gateway-ipc.rkt")
 
-;; Path to the mock worker script
-(define mock-worker-path (build-path (current-directory) "tests" "mock-worker.rkt"))
+;; Path to the mock worker script — resolved relative to this source file
+;; so it works under both `racket` and `raco test`.
+(define-runtime-path mock-worker-path "mock-worker.rkt")
 (define racket-bin (find-executable-path "racket"))
 
 (define (start-mock-worker [mode "echo"])

--- a/tests/test-gateway-ipc-concurrent.rkt
+++ b/tests/test-gateway-ipc-concurrent.rkt
@@ -6,11 +6,15 @@
 (require rackunit
          rackunit/text-ui
          racket/async-channel
+         racket/runtime-path
          (only-in racket/list remove-duplicates)
          "../sandbox/ipc-protocol.rkt"
          "../sandbox/gateway-ipc.rkt")
 
-(define mock-path (path->string (path->complete-path "tests/mock-worker.rkt")))
+;; Mock worker path — resolved relative to this source file
+;; so it works under both `racket` and `raco test`.
+(define-runtime-path mock-worker-src "mock-worker.rkt")
+(define mock-path (path->string mock-worker-src))
 
 (define (start-mock [mode "echo"])
   (start-worker! "racket" (list "-tm" mock-path mode) #f))

--- a/tests/test-gateway-ipc.rkt
+++ b/tests/test-gateway-ipc.rkt
@@ -6,11 +6,14 @@
          rackunit/text-ui
          racket/port
          racket/string
+         racket/runtime-path
          "../sandbox/ipc-protocol.rkt"
          "../sandbox/gateway-ipc.rkt")
 
-;; Path to the mock worker script
-(define mock-worker-path (build-path (current-directory) "tests" "mock-worker.rkt"))
+;; Path to the mock worker script — resolved relative to this source file
+;; so it works under both `racket` and `raco test` (which sets
+;; current-directory to the test file's directory).
+(define-runtime-path mock-worker-path "mock-worker.rkt")
 
 (define racket-bin (find-executable-path "racket"))
 


### PR DESCRIPTION
## W1: Fix raco test Subprocess Compatibility (F-EP-01) (#8140)

### Root Cause
Under `raco test`, `current-directory` is set to the test file's directory (`q/tests/`). Tests that built mock-worker paths via `(build-path (current-directory) "tests/mock-worker.rkt")` produced wrong paths like `q/tests/tests/mock-worker.rkt`, causing worker subprocesses to fail silently (process starts but immediately exits with module-not-found).

### Fix
Replaced `(build-path (current-directory) ...)` with `define-runtime-path` from `racket/runtime-path`, which resolves paths relative to the source file — working identically under both `racket` and `raco test`.

### Results
| Test File | Before (`raco test`) | After (`raco test`) |
|-----------|---------------------|---------------------|
| test-gateway-ipc.rkt | 11/19 (8 fail) | **19/19** ✅ |
| test-gateway-ipc-concurrent.rkt | 8/12 (3 fail + 1 error) | **12/12** ✅ |
| test-execution-plane-characterization.rkt | 0/9 (9 fail) | **9/9** ✅ |

All tests also pass under `racket` direct execution (no regression).