### PR TITLE
fix: W2 raco test compatibility for E2E + worker-main tests (#8141)

### DIFF
--- a/tests/test-execution-plane-e2e.rkt
+++ b/tests/test-execution-plane-e2e.rkt
@@ -10,6 +10,7 @@
 
 (require rackunit
          rackunit/text-ui
+         racket/runtime-path
          (only-in racket/string string-contains?)
          (only-in "../util/capability.rkt" ROLE-CAPABILITIES)
          (only-in "../util/message/mas-envelope.rkt" make-mas-envelope mas-envelope-trace-id)
@@ -39,6 +40,13 @@
          (only-in "../tools/scheduler.rkt" run-tool-batch scheduler-result-results))
 
 ;; ── Test Helpers ────────────────────────────────────────────────
+
+;; ── Worker path resolution ─────────────────────────────────────
+;; Under raco test, current-directory is set to the test file's
+;; directory. Use runtime-path to locate worker-main.rkt relative
+;; to this source file so it works under both racket and raco test.
+(define-runtime-path worker-main-path "../sandbox/worker-main.rkt")
+(current-worker-args (list "-tm" (path->string worker-main-path)))
 
 (define call-counter (box 0))
 

--- a/tests/test-worker-main.rkt
+++ b/tests/test-worker-main.rkt
@@ -8,9 +8,14 @@
          racket/port
          racket/file
          racket/string
+         racket/runtime-path
          "../sandbox/ipc-protocol.rkt"
          "../sandbox/worker-tools.rkt"
          "../sandbox/worker-main.rkt")
+
+;; Worker main path — resolved relative to this source file
+;; so it works under both racket and raco test.
+(define-runtime-path worker-main-src "../sandbox/worker-main.rkt")
 
 ;; ── Helpers ─────────────────────────────────────────────────────
 
@@ -163,7 +168,7 @@
     (test-case "full round-trip: subprocess worker bash"
       (define racket-bin (find-executable-path "racket"))
       (define-values (proc out-in in-out err-in)
-        (subprocess #f #f #f racket-bin "sandbox/worker-main.rkt"))
+        (subprocess #f #f #f racket-bin (path->string worker-main-src)))
       (define req
         (ipc-request "integ-1" "bash" (hasheq 'command "echo integration") 5000 #f 'shell-exec 1))
       (display (jsexpr->string (ipc-request->jsexpr req)) in-out)


### PR DESCRIPTION
## W2: Fix Execution Plane E2E + Worker Tests (F-EP-02, F-EP-03) (#8141)

### Root Cause
Same pattern as W1 — under `raco test`, `current-directory` is the test file's directory (`q/tests/`). Both test files used relative paths to locate `worker-main.rkt`:
- **test-execution-plane-e2e.rkt**: Relied on `gateway-bridge.rkt` default `current-worker-args='("-tm" "sandbox/worker-main.rkt")'` which resolved to `q/tests/sandbox/worker-main.rkt` (nonexistent)
- **test-worker-main.rkt**: Spawned subprocess with hardcoded relative path `"sandbox/worker-main.rkt"`

### Fix
Added `define-runtime-path` to resolve `worker-main.rkt` relative to the source file:
- E2E: Override `current-worker-args` at module level with absolute runtime path
- Worker-main: Use runtime path in `subprocess` spawn call

### Results (raco test)
| Test File | Before | After |
|-----------|--------|-------|
| test-execution-plane-e2e.rkt | 7/16 (9 fail) | **16/16** ✅ |
| test-worker-main.rkt | 17/18 (1 EOF) | **18/18** ✅ |

No regression under `racket` direct execution.