### PR TITLE
fix: W3 correct mouse-event contracts in state-types.rkt (#8142)

### DIFF
--- a/tui/input/state-types.rkt
+++ b/tui/input/state-types.rkt
@@ -42,10 +42,10 @@
                        [push-kill (-> input-state? string? input-state?)]
                        [strip-for-undo (-> input-state? input-state?)]
                        ;; Mouse event support
-                       [parse-mouse-event (-> bytes? (or/c mouse-event? #f))]
+                       [parse-mouse-event (-> any/c (or/c mouse-event? #f))]
                        [decode-mouse-x10
-                        (-> exact-integer? exact-integer? exact-integer? mouse-event?)]
-                       [decode-mouse-message (-> bytes? (or/c mouse-event? #f))]
+                        (-> exact-integer? exact-integer? exact-integer? (or/c list? #f))]
+                       [decode-mouse-message (-> any/c (or/c list? #f))]
                        [normalize-selection-range
                         (-> exact-nonnegative-integer?
                             exact-nonnegative-integer?


### PR DESCRIPTION
## W3: Fix Mouse-Event Contract Violation (F-EP-04, F-EP-05) (#8142)

### Root Cause
`decode-mouse-x10` and `decode-mouse-message` in `tui/input/state-types.rkt` return **lists** (e.g., `'(mouse click 0 16 16)`), but their contracts promised `mouse-event?` structs. This caused a contract violation error in `test-tui-render-loop.rkt`.

The `tui/input.rkt` re-export module already had the correct contracts — the source module `state-types.rkt` did not.

### Fix
Aligned contracts with actual implementations:
| Function | Old Contract | New Contract |
|----------|-------------|--------------|
| `decode-mouse-x10` | `(-> ... mouse-event?)` | `(-> ... (or/c list? #f))` |
| `decode-mouse-message` | `(-> bytes? (or/c mouse-event? #f))` | `(-> any/c (or/c list? #f))` |
| `parse-mouse-event` | `(-> bytes? ...)` | `(-> any/c ...)` |

### Results (raco test)
| Test File | Before | After |
|-----------|--------|-------|
| test-tui-render-loop.rkt | 21/22 (1 error) | **25/25** ✅ |
| test-interfaces-tui.rkt | 93/106 (13 fail) | **104/106** (2 pre-existing) ✅ |
| test-mouse-bridge.rkt | 11/11 | **11/11** ✅ |
| test-input.rkt | 97/97 | **97/97** ✅ |

The fix resolved 11 additional pre-existing test failures in interfaces-tui as a bonus.