### PR TITLE
feat: W4 execution plane default-on — Phase 3 activation (#8143)

### DIFF
--- a/runtime/settings-query.rkt
+++ b/runtime/settings-query.rkt
@@ -368,9 +368,9 @@
 ;; Execution Plane Settings (v0.99.2 MAS Schritt 2)
 ;; ============================================================
 
-;; Config key: mas.execution-plane.enabled (default #f)
+;; Config key: mas.execution-plane.enabled (default #t — Phase 3 activation)
 (define (execution-plane-enabled? settings)
-  (setting-ref* settings '(mas execution-plane enabled) #f))
+  (setting-ref* settings '(mas execution-plane enabled) #t))
 
 ;; Config key: mas.execution-plane.timeout-ms (default 120000)
 (define (execution-plane-timeout-ms settings)

--- a/sandbox/gateway-bridge.rkt
+++ b/sandbox/gateway-bridge.rkt
@@ -6,9 +6,12 @@
 ;; sends them to the worker process, and translates ipc-responses back
 ;; into the hash format expected by agent-role-handle-envelope.
 ;;
-;; Feature-gated: when current-execution-plane-enabled is #f (default),
+;; Feature-gated: when current-execution-plane-enabled is #f,
 ;; no worker is started and execute-via-worker raises an error.
 ;; The tool-gateway checks the flag before calling this module.
+;; NOTE: The settings default is now #t (Phase 3 activation, v0.99.17),
+;; but this parameter still defaults to #f — it is enabled by the
+;; wiring layer (run-modes.rkt) after proper worker setup.
 
 (require racket/contract
          racket/match

--- a/tests/test-execution-plane-deployment-gate.rkt
+++ b/tests/test-execution-plane-deployment-gate.rkt
@@ -1,0 +1,83 @@
+#lang racket/base
+
+;; tests/test-execution-plane-deployment-gate.rkt
+;; Deployment gate tests for execution plane default-on (F-EP-06 / Phase 3).
+;;
+;; Verifies that mas.execution-plane.enabled defaults to #t (Phase 3)
+;; and that the flag can still be explicitly disabled.
+
+(require rackunit
+         rackunit/text-ui
+         (only-in "../runtime/settings-core.rkt" q-settings)
+         (only-in "../runtime/settings-query.rkt"
+                  execution-plane-enabled?
+                  execution-plane-timeout-ms))
+
+;; ── Helpers ─────────────────────────────────────────────────────
+
+;; Build a q-settings with a given merged hash.
+(define (make-test-settings merged-hash)
+  (q-settings #f #f merged-hash))
+
+;; Sentinel to distinguish "not provided" from "provided as #f"
+(define UNSET (gensym 'unset))
+
+(define (make-mas-settings #:enabled [enabled UNSET] #:timeout-ms [timeout-ms UNSET])
+  (define enabled-pair
+    (if (eq? enabled UNSET)
+        '()
+        (list 'enabled enabled)))
+  (define timeout-pair
+    (if (eq? timeout-ms UNSET)
+        '()
+        (list 'timeout-ms timeout-ms)))
+  (define ep-keys (append enabled-pair timeout-pair))
+  (define mas-hash
+    (if (null? ep-keys)
+        (hasheq)
+        (hasheq 'execution-plane (apply hasheq ep-keys))))
+  (hasheq 'mas mas-hash))
+
+;; ── Test Suite ──────────────────────────────────────────────────
+
+(define suite
+  (test-suite "Execution Plane Deployment Gate (F-EP-06 / Phase 3)"
+
+    ;; ── Default value: enabled by default ──
+
+    (test-case "execution-plane-enabled? defaults to #t (Phase 3)"
+      ;; No mas key in merged settings at all
+      (define settings (make-test-settings (hasheq)))
+      (check-true (execution-plane-enabled? settings) "execution-plane-enabled? must default to #t"))
+
+    (test-case "execution-plane-enabled? returns #t when mas key exists but no execution-plane sub-key"
+      (define settings (make-test-settings (hasheq 'mas (hasheq))))
+      (check-true (execution-plane-enabled? settings)))
+
+    (test-case "execution-plane-enabled? returns #t when execution-plane key exists but no enabled sub-key"
+      (define settings (make-test-settings (make-mas-settings)))
+      (check-true (execution-plane-enabled? settings)))
+
+    ;; ── Explicit disable ──
+
+    (test-case "execution-plane-enabled? returns #f when explicitly disabled"
+      (define settings (make-test-settings (make-mas-settings #:enabled #f)))
+      (check-false (execution-plane-enabled? settings)))
+
+    (test-case "execution-plane-enabled? returns #t when explicitly enabled"
+      (define settings (make-test-settings (make-mas-settings #:enabled #t)))
+      (check-true (execution-plane-enabled? settings)))
+
+    ;; ── Timeout default (unchanged) ──
+
+    (test-case "execution-plane-timeout-ms defaults to 120000"
+      (define settings (make-test-settings (hasheq)))
+      (check-equal? (execution-plane-timeout-ms settings) 120000))
+
+    (test-case "execution-plane-timeout-ms respects explicit value"
+      (define settings (make-test-settings (make-mas-settings #:timeout-ms 30000)))
+      (check-equal? (execution-plane-timeout-ms settings) 30000))))
+
+;; ── Run ─────────────────────────────────────────────────────────
+
+(run-tests suite)

--- a/tests/test-scheduler-execution-plane.rkt
+++ b/tests/test-scheduler-execution-plane.rkt
@@ -5,6 +5,7 @@
 
 (require rackunit
          rackunit/text-ui
+         racket/runtime-path
          (only-in racket/list first)
          (only-in "../tools/tool.rkt"
                   tool?
@@ -24,7 +25,15 @@
                   tool-externalizable?
                   tool-required-capability)
          (only-in "../tools/scheduler.rkt" run-tool-batch scheduler-result-results)
-         (only-in "../sandbox/gateway-bridge.rkt" current-execution-plane-enabled shutdown-worker!))
+         (only-in "../sandbox/gateway-bridge.rkt"
+                  current-execution-plane-enabled
+                  current-worker-args
+                  shutdown-worker!))
+
+;; ── Worker path resolution ─────────────────────────────────────
+;; Resolve worker-main.rkt relative to this source file.
+(define-runtime-path worker-main-path "../sandbox/worker-main.rkt")
+(current-worker-args (list "-tm" (path->string worker-main-path)))
 
 ;; ── Test Helpers ────────────────────────────────────────────────
 

--- a/tests/test-tool-gateway-bridge.rkt
+++ b/tests/test-tool-gateway-bridge.rkt
@@ -5,6 +5,7 @@
 (require rackunit
          rackunit/text-ui
          racket/match
+         racket/runtime-path
          (only-in "../util/capability.rkt" ROLE-CAPABILITIES)
          (only-in "../util/message/mas-envelope.rkt"
                   make-mas-envelope
@@ -26,6 +27,11 @@
                   make-error-response)
          "../sandbox/gateway-bridge.rkt"
          "../agent/roles/tool-gateway.rkt")
+
+;; ── Worker path resolution ─────────────────────────────────────
+;; Resolve worker-main.rkt relative to this source file.
+(define-runtime-path worker-main-path "../sandbox/worker-main.rkt")
+(current-worker-args (list "-tm" (path->string worker-main-path)))
 
 ;; ── Test Suite ──────────────────────────────────────────────────
 


### PR DESCRIPTION
## W4: Execution Plane Default-On — F-EP-06 / Phase 3 (#8143)

### Change
Flip `mas.execution-plane.enabled` default from `#f` to `#t` in `runtime/settings-query.rkt`.

**Deliberate separation of concerns:**
- **Settings default** (`execution-plane-enabled?`): Now `#t` — production is enabled by default
- **Parameter default** (`current-execution-plane-enabled`): Stays `#f` — runtime switch only enabled by wiring layer after proper worker setup

### Files Changed
| File | Change |
|------|--------|
| `runtime/settings-query.rkt` | Default `#f` → `#t` |
| `sandbox/gateway-bridge.rkt` | Updated comment documenting Phase 3 |
| `tests/test-execution-plane-deployment-gate.rkt` | **NEW** — 7 deployment gate tests |
| `tests/test-scheduler-execution-plane.rkt` | `define-runtime-path` fix for raco test |
| `tests/test-tool-gateway-bridge.rkt` | `define-runtime-path` fix for raco test |

### Results (raco test)
| Test File | Before | After |
|-----------|--------|-------|
| test-execution-plane-deployment-gate.rkt | — | **7/7** ✅ (NEW) |
| test-scheduler-execution-plane.rkt | 8/9 | **9/9** ✅ |
| test-tool-gateway-bridge.rkt | 19/20 | **20/20** ✅ |
| All other EP tests | — | **No regression** ✅ |

**Total: 125 execution plane tests, 0 failures**