### PR TITLE
feat: W3 flip hot-swap default to #t (#8156)

### DIFF
--- a/runtime/settings-query.rkt
+++ b/runtime/settings-query.rkt
@@ -447,13 +447,13 @@
 
 ;; Check whether hot-swap (registry-based dispatch) is enabled.
 ;; Config path: mas.hot-swap.enabled
-;; Default: #f (direct construction path)
+;; Default: #t (Phase 4 activation — enabled by default since v0.99.18)
 (define (hot-swap-enabled? settings)
-  (define raw (setting-ref* settings '(mas hot-swap enabled) #f))
+  (define raw (setting-ref* settings '(mas hot-swap enabled) #t))
   (cond
     [(boolean? raw) raw]
     [(string? raw) (and (member (string-downcase raw) '("true" "1" "yes")) #t)]
-    [else #f]))
+    [else #t]))
 
 ;; ============================================================
 ;; MCP Settings (v0.99.10 MAS Schritt 6)

--- a/tests/test-hot-swap-deployment-gate.rkt
+++ b/tests/test-hot-swap-deployment-gate.rkt
@@ -64,11 +64,10 @@
     ;; DG-1: Settings layer — hot-swap-enabled? config parsing
     ;; ============================================================
 
-    (test-case "DG-1a: hot-swap-enabled? returns #f for empty settings (pre-flip default)"
-      ;; Pre-flip: default is #f. Post-flip (W3): default will be #t.
-      ;; This test will be updated in W3 to check #t.
-      (check-false (settings:hot-swap-enabled? empty-settings)
-                   "pre-flip: empty settings should default to #f"))
+    (test-case "DG-1a: hot-swap-enabled? returns #t for empty settings (post-flip default)"
+      ;; Post-flip (W3): default is #t. Phase 4 activation.
+      (check-true (settings:hot-swap-enabled? empty-settings)
+                  "post-flip: empty settings should default to #t"))
 
     (test-case "DG-1b: hot-swap-enabled? returns #t when config explicitly enables"
       (check-true (settings:hot-swap-enabled? hot-swap-true-settings)


### PR DESCRIPTION
## W3: Hot-Swap Default-On Flip (F-HS-04)

**This is the core Phase 4 change.** Flips `mas.hot-swap.enabled` default from `#f` to `#t`.

### Changes
- **`runtime/settings-query.rkt`**: `setting-ref*` default `#f` → `#t`, `else` clause `#f` → `#t`
- **`tests/test-hot-swap-deployment-gate.rkt`**: DG-1a updated to expect `#t` for empty settings

### Why It's Safe
1. **Two-layer fallback chain**: `load-agent-dynamically` → static factory; `resolve-sub-role` → direct construction
2. **Runtime registry box stays `#f`**: The wiring layer (`run-modes.rkt`) bridges settings → registry at startup
3. **Auto-reload watcher stays opt-in**: Only registry dispatch path is enabled, not the file watcher
4. **Registry always populated**: `register-default-agents!` runs before the hot-swap check

### Test Results
- **51/51** hot-swap tests pass (16 deployment gate, 15 hot-swap, 12 characterization, 8 registry gate)
- `raco make main.rkt` passes

Closes #8156