### PR TITLE
release: v0.99.18 — MAS Phase 4 hot-swap default-on (#8159)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,36 @@
+## 0.99.18
+
+Released: 2026-07-13
+
+### Features
+- **Hot-swap default-on (MAS Phase 4)**: Agent hot-swap now defaults to enabled (`mas.hot-swap.enabled` defaults to `#t` in `settings-query.rkt`). The dynamic agent loading path in `load-agent-dynamically` is now the primary code path. The runtime registry box (`hot-swap-enabled-box` in `agent/registry.rkt`) still defaults to `#f` — it is bridged at runtime by the wiring layer (`run-modes.rkt`) which reads the settings value. Explicit `mas.hot-swap.enabled: false` in config still disables it.
+
+### Bug Fixes
+- **F-HS-01: `mas-envelope` shared module**: Added `'q/util/message/mas-envelope` to `SHARED-MODULES` in `agent/registry.rkt`, allowing dynamically loaded agent modules to require the MAS envelope type.
+- **F-HS-03: Agent identity verification**: `load-agent-dynamically` now performs an `agent-role?` check on dynamically loaded factories. If the loaded module does not produce a valid agent role, it falls back to the static factory. This prevents malformed dynamic loads from crashing the agent pipeline.
+- **F-HS-05: Dead `decode-mouse-x10` provides**: Removed stale `decode-mouse-x10` re-exports from `tui/tui-render-loop.rkt` and `interfaces/tui.rkt`. The function is defined in `tui/input/state-types.rkt` and remains available via `tui/input.rkt`.
+- **F-HS-07: Session teardown clears hot-swap state**: `close-session!` in `runtime/agent-session.rkt` now calls `set-session-active! #f` and `set-hot-swap-enabled! #f`, preventing stale session-active flags from blocking version switches and ensuring clean next-session startup.
+
+### Documentation
+- **F-HS-06: Registry watcher documentation**: Added prominent `⚠️ INTENTIONALLY UNWIRED` notice to `agent/registry-watcher.rkt`, clarifying that the module is fully implemented and tested but not connected to runtime startup. The watcher is gated behind `mas.hot-swap.auto-reload.enabled` (default `#f`).
+
+### Breaking / Behavior Changes
+- **Hot-swap default-on**: `mas.hot-swap.enabled` now defaults to `#t`. Users who relied on the default-off behavior must explicitly set `mas.hot-swap.enabled: false` in their config to disable it.
+
+### Migration Notes
+- To disable hot-swap, add to config: `{"mas": {"hot-swap": {"enabled": false}}}`
+- The auto-reload watcher (`registry-watcher.rkt`) remains opt-in behind `mas.hot-swap.auto-reload.enabled: true`.
+
+### Testing
+- W0: 12 characterization tests documenting pre-Phase-4 hot-swap behavior (`test-hot-swap-characterization.rkt`).
+- W1: Added `mas-envelope` to `SHARED-MODULES`; added 6 identity verification tests (`test-registry-hot-swap.rkt`, 15 total).
+- W2: 16 deployment gate tests covering settings parsing, registry gate toggles, supervisor resolution, watcher default-off, session tracking, and E2E integration (`test-hot-swap-deployment-gate.rkt`).
+- W3: Flipped `hot-swap-enabled?` default from `#f` to `#t` in `settings-query.rkt`; updated DG-1a test.
+- W4: Dead import removal, watcher documentation, session teardown. Added DG-5c test (17 total deployment gate tests).
+
+### Operational / Release
+- Version bumped to 0.99.18. `info.rkt` and `README.md` synced.
+
 ## 0.99.17
 
 Released: 2026-07-06

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.99.17-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.99.18-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 
@@ -208,7 +208,7 @@ bin/q --model gpt-5.4 "write a test"
 ### Verify
 
 ```bash
-bin/q --version            # q version 0.99.17
+bin/q --version            # q version 0.99.18
 raco test tests/           # run the full test suite
 ```
 

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.99.17")
+(define version "0.99.18")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base" "gui-easy-lib"))

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -11,4 +11,4 @@
 
 (provide (contract-out [q-version string?]))
 
-(define q-version "0.99.17")
+(define q-version "0.99.18")


### PR DESCRIPTION
## W5: Version Bump + CHANGELOG (#8159)

### Changes
- **`util/version.rkt`**: `q-version` bumped `0.99.17` → `0.99.18`
- **`info.rkt`**: `version` bumped `0.99.17` → `0.99.18`
- **`README.md`**: Version badge + `--version` output updated
- **`CHANGELOG.md`**: Full 0.99.18 entry documenting all Phase 4 changes

### CHANGELOG Contents
Documents all 5 implementation waves:
- **W1**: `mas-envelope` in `SHARED-MODULES`, `agent-role?` identity verification
- **W2**: 16 deployment gate tests
- **W3**: Hot-swap default flip `#f` → `#t` in `settings-query.rkt`
- **W4**: Dead `decode-mouse-x10` removal, watcher documentation, session teardown

### Verification
- `raco make main.rkt` passes
- `q-version` returns `"0.99.18"` at runtime
- Version strings consistent across all 4 files

Closes #8159