### PR TITLE
fix: W1 test regressions + stale descriptions (#8167)

### DIFF
--- a/tests/test-hot-swap-characterization.rkt
+++ b/tests/test-hot-swap-characterization.rkt
@@ -5,12 +5,12 @@
 ;; tests/test-hot-swap-characterization.rkt
 ;; v0.99.18 W0: Characterization Tests for Hot-Swap Subsystem
 ;;
-;; Locks in the current state of the hot-swap subsystem BEFORE
-;; Phase 4 changes (default-on flip). These tests document the
-;; pre-flip behavior so regressions are caught immediately.
+;; Documents the hot-swap subsystem behavior after Phase 4 default-on.
+;; These tests verify the runtime gate toggle semantics and agent
+;; loading paths. Updated in v0.99.19 to reflect post-flip state.
 ;;
 ;; Test Cases:
-;;   1. hot-swap-enabled? returns #f by default (pre-flip state)
+;;   1. set-hot-swap-enabled! #f disables hot-swap at runtime
 ;;   2. set-hot-swap-enabled! #t enables hot-swap
 ;;   3. make-agent-instance with hot-swap OFF uses static factory
 ;;   4. make-agent-instance with hot-swap ON uses dynamic-require
@@ -42,12 +42,12 @@
 ;; ============================================================
 
 (define characterization-suite
-  (test-suite "Hot-Swap Characterization (v0.99.18 W0 — pre-flip)"
+  (test-suite "Hot-Swap Characterization (v0.99.18 W0)"
 
     ;; ── Setup: ensure clean state before each test group ──
-    (test-case "CHAR-1: hot-swap-enabled? returns #f by default (pre-flip)"
+    (test-case "CHAR-1: set-hot-swap-enabled! #f disables hot-swap at runtime"
       (set-hot-swap-enabled! #f)
-      (check-false (hot-swap-enabled?) "Before Phase 4 flip, hot-swap should be disabled by default"))
+      (check-false (hot-swap-enabled?) "After explicit disable, hot-swap should be off"))
 
     (test-case "CHAR-2: set-hot-swap-enabled! #t enables hot-swap"
       (set-hot-swap-enabled! #t)

--- a/tests/test-registry-config-wiring.rkt
+++ b/tests/test-registry-config-wiring.rkt
@@ -92,9 +92,9 @@
 
     ;; ── hot-swap-enabled? config query ──
 
-    (test-case "hot-swap-enabled? returns #f by default"
+    (test-case "hot-swap-enabled? returns #t by default (v0.99.18 Phase 4)"
       (define settings (make-test-settings))
-      (check-false (hot-swap-enabled? settings)))
+      (check-true (hot-swap-enabled? settings)))
 
     (test-case "hot-swap-enabled? returns #t when boolean true"
       (define settings (make-mas-settings (list 'mas (make-mas-setting '(hot-swap enabled) #t))))
@@ -108,13 +108,13 @@
       (define settings (make-mas-settings (list 'mas (make-mas-setting '(hot-swap enabled) "false"))))
       (check-false (hot-swap-enabled? settings)))
 
-    (test-case "hot-swap-enabled? returns #f when key absent"
+    (test-case "hot-swap-enabled? returns #t when key absent (v0.99.18 default-on)"
       (define settings (make-test-settings))
-      (check-false (hot-swap-enabled? settings)))
+      (check-true (hot-swap-enabled? settings)))
 
-    (test-case "hot-swap-enabled? returns #f for random value"
+    (test-case "hot-swap-enabled? returns #t for random value (v0.99.18 else-branch default-on)"
       (define settings (make-mas-settings (list 'mas (make-mas-setting '(hot-swap enabled) 42))))
-      (check-false (hot-swap-enabled? settings)))
+      (check-true (hot-swap-enabled? settings)))
 
     ;; ── blackboard-enabled? still works (regression check) ──
 

--- a/tests/test-registry-deployment-gate.rkt
+++ b/tests/test-registry-deployment-gate.rkt
@@ -81,7 +81,7 @@
     ;; ── F-13: set-hot-swap-enabled! toggles feature gate ──
     (test-case "set-hot-swap-enabled! toggles feature gate (F-13)"
       (set-hot-swap-enabled! #f)
-      (check-false (hot-swap-enabled?) "default should be #f")
+      (check-false (hot-swap-enabled?) "after explicit set-hot-swap-enabled! #f")
       (set-hot-swap-enabled! #t)
       (check-true (hot-swap-enabled?) "after set to #t, should be #t")
       (set-hot-swap-enabled! #f)


### PR DESCRIPTION
## W1: Fix test regressions + stale descriptions (#8167)

### A-1: Fix 3 test regressions in `test-registry-config-wiring.rkt`
Three tests asserted the pre-Phase-4 default (`#f`) for `hot-swap-enabled?`. Updated to `#t` to match v0.99.18 default-on:
- `"returns #f by default"` → `"returns #t by default (v0.99.18 Phase 4)"`
- `"returns #f when key absent"` → `"returns #t when key absent (v0.99.18 default-on)"`
- `"returns #f for random value"` → `"returns #t for random value (v0.99.18 else-branch default-on)"`

### A-3: Stale "pre-flip" descriptions in `test-hot-swap-characterization.rkt`
- Header comment: removed pre-flip references
- Suite name: removed "pre-flip" suffix
- CHAR-1 test: renamed to reflect actual behavior

### A-4: Stale comment in `test-registry-deployment-gate.rkt`
- `"default should be #f"` → `"after explicit set-hot-swap-enabled! #f"`

### Test Results
- `test-registry-config-wiring.rkt`: **11/11** ✅ (was 8/11)
- `test-hot-swap-characterization.rkt`: **12/12** ✅
- `test-registry-deployment-gate.rkt`: **8/8** ✅
- `raco make main.rkt`: ✅
- No "pre-flip" references remain ✅

Closes #8167