### PR TITLE
release: W3 process checklist + version bump 0.99.19 (#8169)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,36 @@
+## 0.99.19
+
+Released: 2026-07-13
+
+### Overview
+
+This is a test and documentation only remediation release. It addresses the five findings (A-1 through A-5) from the v0.99.18 post-implementation in-depth audit. Zero production code changes.
+
+### Bug Fixes
+- **A-1: Test regressions in config-wiring suite**: Fixed 3 failing assertions in `test-registry-config-wiring.rkt`. The `hot-swap-enabled?` default flipped from `#f` to `#t` in v0.99.18, but 3 tests still asserted `#f`. Updated all 3 to `check-true` with post-flip descriptions. Tests: 8/11 → **11/11**.
+
+### Documentation
+- **A-2: Missing W6 audit report**: Created `docs/reports/AUDIT-v0.99.18-POST-IMPLEMENTATION.md` — the persistent audit artifact that was missing from the v0.99.18 milestone. Covers all 7 F-HS findings, CHANGELOG accuracy audit (13/13 verified), architecture assessment. Score: 4.2/5.0 APPROVED.
+- **A-3: Stale "pre-flip" descriptions**: Updated header comment, suite name, and CHAR-1 test name in `test-hot-swap-characterization.rkt` to reflect post-Phase-4 state.
+- **A-4: Stale comment in deployment gate test**: Updated comment in `test-registry-deployment-gate.rkt` from "default should be #f" to "after explicit set-hot-swap-enabled! #f".
+- **A-5: Process checklist improvement**: Added "Before Declaring a Wave Complete" section to `.planning/AUDIT-PROCESS-CHECKLIST.md`, requiring grep for all tests of changed functions before wave completion.
+
+### Breaking / Behavior Changes
+- None. This is a test and documentation only release.
+
+### Migration Notes
+- None required. No production code changed.
+
+### Testing
+- All 11 registry/hot-swap test suites pass: **135/135** (was 132/135).
+- W1: Fixed 3 test regressions. Config-wiring: 11/11, characterization: 12/12, deployment gate: 8/8.
+- W2: Created missing audit report artifact.
+- W3: Process checklist update + version bump.
+
+### Operational / Release
+- Version bumped to 0.99.19. `info.rkt` and `README.md` synced.
+- Zero production code changes — test and documentation only.
+
 ## 0.99.18
 
 Released: 2026-07-13

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.99.18-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.99.19-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 
@@ -208,7 +208,7 @@ bin/q --model gpt-5.4 "write a test"
 ### Verify
 
 ```bash
-bin/q --version            # q version 0.99.18
+bin/q --version            # q version 0.99.19
 raco test tests/           # run the full test suite
 ```
 

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.99.18")
+(define version "0.99.19")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base" "gui-easy-lib"))

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -11,4 +11,4 @@
 
 (provide (contract-out [q-version string?]))
 
-(define q-version "0.99.18")
+(define q-version "0.99.19")


### PR DESCRIPTION
## W3: Process checklist update + version bump (#8169)

### A-5: Process Checklist Improvement
Added "Before Declaring a Wave Complete" section to `.planning/AUDIT-PROCESS-CHECKLIST.md` requiring:
- Grep for ALL tests of every changed function
- Run all test suites that import changed modules
- Verify no assertions reference old default values
- Run `raco test` on adjacent suites

### Version Bump 0.99.18 → 0.99.19
- `util/version.rkt`
- `info.rkt`
- `README.md`
- `CHANGELOG.md` (new v0.99.19 section documenting all remediation: A-1 through A-5)

### Verification
- `lint-release-notes.rkt --version 0.99.19`: ✅ PASSED
- `sync-version.rkt`: ✅ All targets in sync
- `raco make main.rkt`: ✅
- 11 registry/hot-swap suites: ✅ **135/135** pass

Closes #8169