### PR TITLE
feat: W2 externalize delete-lines to worker process (#8176)

### DIFF
--- a/sandbox/worker-tools.rkt
+++ b/sandbox/worker-tools.rkt
@@ -17,6 +17,7 @@
          racket/match
          racket/port
          racket/string
+         (only-in racket/list take drop)
          json
          "ipc-protocol.rkt"
          "subprocess.rkt"
@@ -256,10 +257,85 @@
                       (format "git ~a exited with code ~a" command exit-code)
                       IPC-SCHEMA-VERSION)])]))
 
+;; v0.99.20 W2 (§3.2): delete-lines — pure file-edit operation.
+;; Reads file, removes lines [start-line, end-line] (inclusive, 1-based),
+;; writes result back atomically.
+(define (execute-delete-lines args)
+  (define path (hash-ref args 'path #f))
+  (define start-line (hash-ref args 'start-line #f))
+  (define end-line (hash-ref args 'end-line #f))
+  (cond
+    [(not path) (make-error-response #f "delete-lines: missing 'path' argument")]
+    [(not start-line) (make-error-response #f "delete-lines: missing 'start-line' argument")]
+    [(not end-line) (make-error-response #f "delete-lines: missing 'end-line' argument")]
+    [(not (exact-integer? start-line))
+     (make-error-response #f (format "delete-lines: start-line must be integer, got: ~v" start-line))]
+    [(not (exact-integer? end-line))
+     (make-error-response #f (format "delete-lines: end-line must be integer, got: ~v" end-line))]
+    [(not (path-allowed? path))
+     (make-error-response #f (format "delete-lines: path not allowed: ~a" path))]
+    [else
+     (define resolved (path->complete-path (expand-user-path path) (current-directory)))
+     (cond
+       [(not (file-exists? resolved))
+        (make-error-response #f (format "delete-lines: file not found: ~a" path))]
+       [else
+        (define content (file->string resolved))
+        (define lines (string-split content "\n" #:trim? #f))
+        (define total-lines (length lines))
+        (cond
+          [(< start-line 1)
+           (make-error-response
+            #f
+            (format "delete-lines: start-line ~a is out of range (file has ~a lines)"
+                    start-line
+                    total-lines))]
+          [(> end-line total-lines)
+           (make-error-response
+            #f
+            (format "delete-lines: end-line ~a exceeds file length (file has ~a lines)"
+                    end-line
+                    total-lines))]
+          [(> start-line end-line)
+           (make-error-response
+            #f
+            (format "delete-lines: start-line (~a) must be ≤ end-line (~a)" start-line end-line))]
+          [else
+           (define before (take lines (sub1 start-line)))
+           (define after (drop lines end-line))
+           (define new-lines (append before after))
+           (define new-content (string-join new-lines "\n"))
+           (define deleted-count (- end-line start-line -1))
+           (call-with-atomic-output-file resolved (lambda (port) (display new-content port)))
+           (ipc-response #f
+                         'ok
+                         (format "Deleted lines ~a-~a from ~a (~a lines removed)"
+                                 start-line
+                                 end-line
+                                 (path->string resolved)
+                                 deleted-count)
+                         (hasheq 'path
+                                 (path->string resolved)
+                                 'lines-deleted
+                                 deleted-count
+                                 'remaining-lines
+                                 (length new-lines))
+                         #f
+                         IPC-SCHEMA-VERSION)])])]))
+
 ;; ── Tool Registry ───────────────────────────────────────────────
 
 (define worker-tool-registry
-  (hash "bash" execute-bash "write" execute-write "edit" execute-edit "git" execute-git))
+  (hash "bash"
+        execute-bash
+        "write"
+        execute-write
+        "edit"
+        execute-edit
+        "git"
+        execute-git
+        "delete-lines"
+        execute-delete-lines))
 
 (define (dispatch-tool tool-name arguments)
   (define executor (hash-ref worker-tool-registry tool-name #f))
@@ -281,6 +357,7 @@
          execute-bash
          execute-write
          execute-edit
-         execute-git)
+         execute-git
+         execute-delete-lines)
 
 ;; dispatch-tool is provided above without contract

--- a/tests/test-delete-lines-worker.rkt
+++ b/tests/test-delete-lines-worker.rkt
@@ -1,0 +1,72 @@
+#lang racket/base
+
+;; tests/test-delete-lines-worker.rkt
+;; v0.99.20 W2: Verify delete-lines tool externalization to worker process.
+;;
+;; Tests:
+;; 1. delete-lines is in externalizable-tool-names
+;; 2. Worker execute-delete-lines correctly removes a line range
+;; 3. execute-delete-lines validates path safety
+;; 4. execute-delete-lines validates line range bounds
+;; 5. dispatch-tool routes delete-lines to execute-delete-lines
+
+(require rackunit
+         rackunit/text-ui
+         racket/file
+         racket/string
+         "../tools/registry-table.rkt"
+         "../sandbox/ipc-protocol.rkt"
+         "../sandbox/worker-tools.rkt")
+
+(define temp-base (build-path (find-system-path 'temp-dir) "delete-lines-worker-test"))
+
+(when (directory-exists? temp-base)
+  (delete-directory/files temp-base))
+(make-directory* temp-base)
+
+(current-allowed-roots (list temp-base))
+
+(define (make-test-file name content)
+  (define path (build-path temp-base name))
+  (display-to-file content path #:exists 'replace)
+  path)
+
+(define suite
+  (test-suite "delete-lines Worker Externalization (v0.99.20 W2 §3.2)"
+
+    (test-case "delete-lines in externalizable-tool-names"
+      (check-not-false (member "delete-lines" externalizable-tool-names)
+                       "delete-lines should be in externalizable-tool-names"))
+
+    (test-case "execute-delete-lines removes correct line range"
+      (define f (make-test-file "dl-test-1.txt" "line1\nline2\nline3\nline4\nline5"))
+      (define resp
+        (execute-delete-lines
+         (hash 'path (path->string f) 'start-line 2 'end-line 3)))
+      (check-equal? (ipc-response-status resp) 'ok)
+      (define remaining (file->lines f))
+      (check-equal? remaining '("line1" "line4" "line5")))
+
+    (test-case "execute-delete-lines rejects paths outside allowed roots"
+      (define resp
+        (execute-delete-lines
+         (hash 'path "/etc/passwd" 'start-line 1 'end-line 2)))
+      (check-equal? (ipc-response-status resp) 'error))
+
+    (test-case "execute-delete-lines validates line range"
+      (define f (make-test-file "dl-test-2.txt" "only-line"))
+      (define resp
+        (execute-delete-lines
+         (hash 'path (path->string f) 'start-line 1 'end-line 5)))
+      (check-equal? (ipc-response-status resp) 'error)
+      (check-true (string-contains? (or (ipc-response-error-message resp) "")
+                                    "exceeds file length")))
+
+    (test-case "dispatch-tool routes delete-lines"
+      (define f (make-test-file "dl-test-3.txt" "a\nb\nc"))
+      (define resp (dispatch-tool "delete-lines"
+                                  (hash 'path (path->string f) 'start-line 1 'end-line 1)))
+      (check-equal? (ipc-response-status resp) 'ok)
+      (check-equal? (file->lines f) '("b" "c")))))
+
+(run-tests suite)

--- a/tools/registry-table.rkt
+++ b/tools/registry-table.rkt
@@ -39,10 +39,18 @@
   '("write" "edit" "bash" "delete-lines" "browser_click" "browser_type" "browser_press"))
 
 ;; M2: Tools explicitly marked as externalizable (safe to run in worker process).
-;; The worker process supports: bash, write, edit (plus git via worker-tools.rkt).
+;; The worker process supports: bash, write, edit, delete-lines (plus git via worker-tools.rkt).
 ;; All other tools default to #:externalizable? #f (run in-process even when
 ;; execution plane is enabled).
-(define externalizable-tool-names '("bash" "write" "edit"))
+;;
+;; v0.99.20 W2 (§3.2): Added delete-lines — it's a pure file-edit operation
+;; (reads file, deletes line range, writes back) fully implementable in the worker.
+;;
+;; NOTE: browser_click, browser_type, browser_press are dangerous but NOT
+;; externalizable because they require a running Chromium process that only
+;; exists in the main process. A pass-through proxy architecture is planned
+;; for M4 (v1.0.0-rc2) per the MAS Enablement Strategy §3.2.
+(define externalizable-tool-names '("bash" "write" "edit" "delete-lines"))
 
 ;; Register tools from tool-spec structs.
 (define (register-tools-from-specs! registry specs #:only [only #f])


### PR DESCRIPTION
## W2: Extension-Tool-Routing — delete-lines Externalization (§3.2)

Closes the most egregious security gap from the MAS Enablement Strategy: `delete-lines` was marked dangerous but not externalizable, meaning this file-mutating tool ran in-process even when the execution plane was active.

### Production Changes:
1. **`tools/registry-table.rkt`** — Added `"delete-lines"` to `externalizable-tool-names`. Added documentation that `browser_click/type/press` remain in-process pending proxy architecture (M4/v1.0.0-rc2).
2. **`sandbox/worker-tools.rkt`** — Added `execute-delete-lines` function:
   - Path safety validation (`path-allowed?` check)
   - Line range validation (bounds, start ≤ end)
   - Atomic file write via `call-with-atomic-output-file`
   - Added to `worker-tool-registry` hash and provides

### Test Changes:
- New: `tests/test-delete-lines-worker.rkt` (5 tests)

### Verification:
- 5/5 new delete-lines-worker tests pass ✅
- 18/18 worker-main tests pass ✅
- 4/4 worker-security tests pass ✅
- 5/5 tool-registry tests pass ✅
- `raco make main.rkt`: ✅

Closes #8176