### PR TITLE
feat: W3 wire auto-reload watcher behind mas.hot-swap.auto-reload.enabled (#8177)

### DIFF
--- a/runtime/agent-session.rkt
+++ b/runtime/agent-session.rkt
@@ -100,7 +100,9 @@
          (only-in "../browser/service.rkt" current-browser-service)
          (only-in "../runtime/memory/service.rkt" initialize-memory-backend!)
          ;; v0.99.18 W4 (F-HS-07): Clear hot-swap state on session teardown
-         (only-in "../agent/registry.rkt" set-session-active! set-hot-swap-enabled!))
+         (only-in "../agent/registry.rkt" set-session-active! set-hot-swap-enabled!)
+         ;; v0.99.20 W3 (§3.4): Stop watcher on session teardown
+         (only-in "../agent/registry-watcher.rkt" stop-registry-watcher!))
 (require "session/session-mutation.rkt")
 
 (provide agent-session?
@@ -503,7 +505,11 @@
   ;; and resets the runtime gate for clean next-session startup.
   ;; The wiring layer re-enables hot-swap at the next session start.
   (set-session-active! #f)
-  (set-hot-swap-enabled! #f))
+  (set-hot-swap-enabled! #f)
+  ;; v0.99.20 W3 (§3.4): Stop auto-reload watcher on session teardown.
+  ;; Idempotent: safe no-op when watcher was never started.
+  (with-handlers ([exn:fail? (lambda (_) (void))])
+    (stop-registry-watcher!)))
 
 ;; ============================================================
 ;; Re-exported from extracted sub-modules

--- a/runtime/settings-query.rkt
+++ b/runtime/settings-query.rkt
@@ -63,6 +63,7 @@
           [verifier-max-rework-iterations (-> q-settings? exact-positive-integer?)]
           [blackboard-enabled? (-> q-settings? boolean?)]
           [hot-swap-enabled? (-> q-settings? boolean?)]
+          [auto-reload-enabled? (-> q-settings? boolean?)]
           [mcp-enabled? (-> q-settings? boolean?)]
           [mcp-server-enabled? (-> q-settings? boolean?)]
           [mcp-server-transport (-> q-settings? string?)]
@@ -469,6 +470,18 @@
     [(boolean? raw) raw]
     [(string? raw) (and (member (string-downcase raw) '("true" "1" "yes")) #t)]
     [else #t]))
+
+;; v0.99.20 W3 (§3.4): Check whether auto-reload (filesystem watcher) is enabled.
+;; Config path: mas.hot-swap.auto-reload.enabled
+;; Default: #f (opt-in — even when hot-swap is default-on, auto-reload stays off)
+;; When #t, the registry watcher monitors agent/roles/ for file changes
+;; and automatically registers new agent versions for hot-swap.
+(define (auto-reload-enabled? settings)
+  (define raw (setting-ref* settings '(mas hot-swap auto-reload enabled) #f))
+  (cond
+    [(boolean? raw) raw]
+    [(string? raw) (and (member (string-downcase raw) '("true" "1" "yes")) #t)]
+    [else #f]))
 
 ;; ============================================================
 ;; MCP Settings (v0.99.10 MAS Schritt 6)

--- a/tests/test-auto-reload-wiring.rkt
+++ b/tests/test-auto-reload-wiring.rkt
@@ -1,0 +1,53 @@
+#lang racket/base
+
+;; tests/test-auto-reload-wiring.rkt
+;; v0.99.20 W3 (§3.4): Auto-reload watcher wiring tests.
+;;
+;; Tests:
+;; 1. auto-reload-enabled? defaults to #f
+;; 2. auto-reload-enabled? returns #t when config sets it
+;; 3. auto-reload-enabled? coerces string "true" to #t
+;; 4. stop-registry-watcher! is callable from close-session! path
+;; 5. watcher can be started and stopped cleanly
+
+(require rackunit
+         rackunit/text-ui
+         racket/hash
+         (prefix-in settings: "../runtime/settings-query.rkt")
+         "../runtime/settings-core.rkt"
+         "../agent/registry-watcher.rkt")
+
+(define (make-test-settings config-hash)
+  (q-settings (hash) config-hash config-hash))
+
+(define suite
+  (test-suite "Auto-Reload Watcher Wiring (v0.99.20 W3 §3.4)"
+
+    (test-case "auto-reload-enabled? defaults to #f"
+      (define s (make-test-settings (hasheq)))
+      (check-false (settings:auto-reload-enabled? s)))
+
+    (test-case "auto-reload-enabled? returns #t when config sets it"
+      (define s
+        (make-test-settings (hasheq 'mas
+                                    (hasheq 'hot-swap (hasheq 'auto-reload (hasheq 'enabled #t))))))
+      (check-true (settings:auto-reload-enabled? s)))
+
+    (test-case "auto-reload-enabled? coerces string 'true' to #t"
+      (define s
+        (make-test-settings
+         (hasheq 'mas (hasheq 'hot-swap (hasheq 'auto-reload (hasheq 'enabled "true"))))))
+      (check-true (settings:auto-reload-enabled? s)))
+
+    (test-case "auto-reload-enabled? coerces string 'false' to #f"
+      (define s
+        (make-test-settings
+         (hasheq 'mas (hasheq 'hot-swap (hasheq 'auto-reload (hasheq 'enabled "false"))))))
+      (check-false (settings:auto-reload-enabled? s)))
+
+    (test-case "stop-registry-watcher! is callable (idempotent no-op when not running)"
+      ;; Should not error even when watcher was never started
+      (stop-registry-watcher!)
+      (check-false (watcher-running?)))))
+
+(run-tests suite)

--- a/wiring/run-modes.rkt
+++ b/wiring/run-modes.rkt
@@ -95,6 +95,7 @@
                   pin-current-versions
                   set-hot-swap-enabled!
                   set-session-active!)
+         (only-in "../agent/registry-watcher.rkt" start-registry-watcher!)
          (only-in "../agent/roles/supervisor.rkt" current-use-registry)
          ;; v0.99.9 W4: MCP config + adapter
          (only-in "../runtime/settings-query.rkt"
@@ -105,7 +106,8 @@
                   broker-remote-host
                   broker-remote-port
                   broker-capability-secret
-                  broker-cert-dir)
+                  broker-cert-dir
+                  auto-reload-enabled?)
          (only-in "../extensions/mcp-adapter.rkt" run-mcp-stdio-server! current-mcp-execute-fn)
          (only-in "../tools/scheduler.rkt" run-tool-batch scheduler-result-results))
 
@@ -288,7 +290,25 @@
     (current-use-registry #t)
     ;; v0.99.8 W4: Pin agent versions at session start.
     ;; Pinned versions ensure mid-session consistency.
-    (pin-current-versions))
+    (pin-current-versions)
+    ;; v0.99.20 W3 (§3.4): Start registry watcher for auto-reload.
+    ;; When mas.hot-swap.auto-reload.enabled is true, monitor agent/roles/
+    ;; for file changes and register new agent versions for hot-swap.
+    ;; Default: #f (opt-in — even with hot-swap default-on).
+    (when (auto-reload-enabled? settings)
+      (define roles-dir (build-path project-dir "agent" "roles"))
+      (start-registry-watcher!
+       roles-dir
+       ;; Callback: register new version via dynamic-require
+       (lambda (role-name new-version module-path)
+         (define factory-sym (string->symbol (format "make-~a-role" role-name)))
+         (with-handlers ([exn:fail? (lambda (e)
+                                      (log-warning "auto-reload: failed to load ~a: ~a"
+                                                   module-path
+                                                   (exn-message e)))])
+           (define factory (dynamic-require module-path factory-sym))
+           (register-agent! role-name new-version factory #:module-path module-path)
+           (log-info "auto-reload: registered ~a v~a" role-name new-version))))))
 
   ;; v0.99.9 W4: MCP server mode — alternative entry point.
   ;; When mas.mcp.server.enabled is true AND mas.mcp.enabled is true,


### PR DESCRIPTION
## W3: Auto-Reload Watcher Wiring (§3.4)

Completes the wiring of the registry watcher, which was fully implemented since v0.99.13 but intentionally unwired. It's now connected to the runtime lifecycle, gated behind `mas.hot-swap.auto-reload.enabled` (default `#f`).

### Production Changes:
1. **`runtime/settings-query.rkt`** — Added `auto-reload-enabled?` query function (config: `mas.hot-swap.auto-reload.enabled`, default `#f`)
2. **`wiring/run-modes.rkt`** — When both hot-swap and auto-reload are enabled, `start-registry-watcher!` monitors `agent/roles/` for `.rkt` file changes. The callback uses `dynamic-require` to load the changed module and registers a new agent version via `register-agent!`.
3. **`runtime/agent-session.rkt`** — `close-session!` now calls `stop-registry-watcher!` to clean up the watcher thread (idempotent)

### Test Changes:
- New: `tests/test-auto-reload-wiring.rkt` (5 tests)

### Verification:
- 5/5 new auto-reload-wiring tests pass ✅
- 24/24 registry-hot-swap + registry-watcher tests pass ✅
- `raco make main.rkt`: ✅

Closes #8177