### PR TITLE
bump: v0.99.20 — MAS Technical Debt Repayment (#8178)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,39 @@
+## 0.99.20
+
+Released: 2026-07-14
+
+### Overview
+
+This release addresses four technical debts (§3.1–§3.4) identified in the MAS (Multi-Agent System) Enablement Strategy audit, converting MAS infrastructure from passively wired to actively hardened. The work spans broad test-suite stabilization, extension tool routing, rework-loop protection, and auto-reload watcher wiring.
+
+### Bug Fixes
+- **§3.1: Broad-suite stabilization**: Fixed 8 compilation-broken test files that masked potential MAS regressions. Root causes included SDK interface drift, arity mismatches, unbound identifiers, and syntax errors. All 8 files now compile and run.
+
+### Features
+- **§3.2: Extension tool routing (delete-lines externalization)**: Externalized the `delete-lines` tool to the worker process sandbox. Added `"delete-lines"` to `externalizable-tool-names` in `registry-table.rkt`. Implemented `execute-delete-lines` in `worker-tools.rkt` with path safety (`path-allowed?`), line range validation, and atomic writes via `call-with-atomic-output-file`. Browser tools (`browser_click`, `browser_type`, `browser_press`) remain in-process pending a proxy architecture (M4/v1.0.0-rc2).
+- **§3.3: Rework-loop protection**: Added a rework iteration limit to the GSD state machine. New `gsd-max-rework-iterations` parameter (default 3) blocks the verifying→executing transition when the limit is reached, emitting a `transition-failed` event. The counter resets on fresh plan-written→executing transitions. Configurable via `mas.verifier.max-rework-iterations`.
+- **§3.4: Auto-reload watcher wiring**: Connected the registry watcher (fully implemented since v0.99.13 but intentionally unwired) to the runtime lifecycle. When `mas.hot-swap.auto-reload.enabled` is `#t` (default `#f`), the watcher monitors `agent/roles/` for `.rkt` file changes and automatically registers new agent versions via `dynamic-require` + `register-agent!`. The watcher is stopped in `close-session!` (idempotent).
+
+### Breaking / Behavior Changes
+- `delete-lines` now executes in the worker process sandbox when externalization is active. Path validation is enforced — only paths within the project root are accepted.
+- GSD sessions now have a rework iteration cap (default 3). Sessions exceeding this limit receive a `transition-failed` event instead of silently looping.
+
+### Migration Notes
+- No action required for default configurations. All new features are opt-in or use safe defaults.
+- To enable auto-reload: set `mas.hot-swap.auto-reload.enabled: true` in config.
+- To adjust rework limit: set `mas.verifier.max-rework-iterations` in config.
+
+### Testing
+- **W0**: 8 previously compilation-broken test files now compile and run.
+- **W1**: 5/5 new rework-limit tests pass.
+- **W2**: 5/5 new delete-lines worker tests pass.
+- **W3**: 5/5 new auto-reload wiring tests pass. 24/24 existing registry/watcher tests pass.
+- `raco make main.rkt`: PASS.
+
+### Operational / Release
+- Version bumped to 0.99.20. `info.rkt` and `README.md` synced.
+- 4 production files changed across W1–W3, 0 in W0 (test-only).
+
 ## 0.99.19
 
 Released: 2026-07-13

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.99.19-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.99.20-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 
@@ -208,7 +208,7 @@ bin/q --model gpt-5.4 "write a test"
 ### Verify
 
 ```bash
-bin/q --version            # q version 0.99.19
+bin/q --version            # q version 0.99.20
 raco test tests/           # run the full test suite
 ```
 

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.99.19")
+(define version "0.99.20")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base" "gui-easy-lib"))

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -11,4 +11,4 @@
 
 (provide (contract-out [q-version string?]))
 
-(define q-version "0.99.19")
+(define q-version "0.99.20")


### PR DESCRIPTION
## W4: Version Bump 0.99.19 → 0.99.20 + CHANGELOG

Version bump and CHANGELOG entry for the v0.99.20 — MAS Technical Debt Repayment release.

### Changes:
- `util/version.rkt`: `0.99.19` → `0.99.20`
- `info.rkt`: `0.99.19` → `0.99.20`
- `README.md`: Badge + example output updated
- `CHANGELOG.md`: New `## 0.99.20` entry documenting all 4 debts addressed (§3.1–§3.4)

### Verification:
- `racket scripts/sync-version.rkt`: All targets in sync ✅
- `racket scripts/lint-release-notes.rkt --version 0.99.20`: PASSED ✅
- `raco test tests/test-version.rkt`: 3/3 pass ✅

Closes #8178