### PR TITLE
hotfix: W0 fix build break + audit findings (F-1 through F-5) (#8187)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,16 @@ Released: 2026-07-14
 This release addresses four technical debts (§3.1–§3.4) identified in the MAS (Multi-Agent System) Enablement Strategy audit, converting MAS infrastructure from passively wired to actively hardened. The work spans broad test-suite stabilization, extension tool routing, rework-loop protection, and auto-reload watcher wiring.
 
 ### Bug Fixes
-- **§3.1: Broad-suite stabilization**: Fixed 8 compilation-broken test files that masked potential MAS regressions. Root causes included SDK interface drift, arity mismatches, unbound identifiers, and syntax errors. All 8 files now compile and run.
+- **§3.1: Broad-suite stabilization**: Fixed 7 compilation-broken test files and documented 1 obsolete test file (`test-context-assembly-config.rkt` tested a completely refactored struct). Root causes included SDK interface drift, arity mismatches, unbound identifiers, and syntax errors. All 7 fixed files now compile and run.
 
 ### Features
 - **§3.2: Extension tool routing (delete-lines externalization)**: Externalized the `delete-lines` tool to the worker process sandbox. Added `"delete-lines"` to `externalizable-tool-names` in `registry-table.rkt`. Implemented `execute-delete-lines` in `worker-tools.rkt` with path safety (`path-allowed?`), line range validation, and atomic writes via `call-with-atomic-output-file`. Browser tools (`browser_click`, `browser_type`, `browser_press`) remain in-process pending a proxy architecture (M4/v1.0.0-rc2).
-- **§3.3: Rework-loop protection**: Added a rework iteration limit to the GSD state machine. New `gsd-max-rework-iterations` parameter (default 3) blocks the verifying→executing transition when the limit is reached, emitting a `transition-failed` event. The counter resets on fresh plan-written→executing transitions. Configurable via `mas.verifier.max-rework-iterations`.
+- **§3.3: Rework-loop protection**: Added a rework iteration limit to the GSD state machine. New `gsd-max-rework-iterations` parameter (default 3) blocks the verifying→executing transition when the limit is reached, emitting a `transition-failed` event. The session remains in `verifying` state until manually resolved (via `gsd done` or `gsd reset`). This is intentional — a wave that fails verification 3 times requires human review, not automatic acceptance. The counter resets on fresh plan-written→executing transitions. Configurable via `mas.verifier.max-rework-iterations`.
 - **§3.4: Auto-reload watcher wiring**: Connected the registry watcher (fully implemented since v0.99.13 but intentionally unwired) to the runtime lifecycle. When `mas.hot-swap.auto-reload.enabled` is `#t` (default `#f`), the watcher monitors `agent/roles/` for `.rkt` file changes and automatically registers new agent versions via `dynamic-require` + `register-agent!`. The watcher is stopped in `close-session!` (idempotent).
 
 ### Breaking / Behavior Changes
 - `delete-lines` now executes in the worker process sandbox when externalization is active. Path validation is enforced — only paths within the project root are accepted.
-- GSD sessions now have a rework iteration cap (default 3). Sessions exceeding this limit receive a `transition-failed` event instead of silently looping.
+- GSD sessions now have a rework iteration cap (default 3). When the limit is reached, the verifying→executing transition is **blocked** with a `transition-failed` event. The session remains in `verifying` state until manually resolved. This is intentional safety design — a wave that fails verification 3 times requires human review.
 
 ### Migration Notes
 - No action required for default configurations. All new features are opt-in or use safe defaults.
@@ -24,7 +24,7 @@ This release addresses four technical debts (§3.1–§3.4) identified in the MA
 - To adjust rework limit: set `mas.verifier.max-rework-iterations` in config.
 
 ### Testing
-- **W0**: 8 previously compilation-broken test files now compile and run.
+- **W0**: 7 previously compilation-broken test files now compile and run; 1 obsolete test documented.
 - **W1**: 5/5 new rework-limit tests pass.
 - **W2**: 5/5 new delete-lines worker tests pass.
 - **W3**: 5/5 new auto-reload wiring tests pass. 24/24 existing registry/watcher tests pass.

--- a/tests/test-rework-limit-wiring.rkt
+++ b/tests/test-rework-limit-wiring.rkt
@@ -1,0 +1,56 @@
+#lang racket/base
+
+;; tests/test-rework-limit-wiring.rkt
+;; v0.99.21 W0 (F-2): Verify that verifier-max-rework-iterations setting
+;; actually controls the gsd-max-rework-iterations parameter.
+
+(require rackunit
+         rackunit/text-ui
+         "../extensions/gsd/state-machine.rkt"
+         (prefix-in settings: "../runtime/settings-query.rkt")
+         "../runtime/settings-core.rkt")
+
+(define (make-test-settings config-hash)
+  (q-settings (hash) config-hash config-hash))
+
+(define suite
+  (test-suite "Rework-Limit Wiring (v0.99.21 W0 F-2)"
+
+    (test-case "gsd-max-rework-iterations is a parameter"
+      (check-true (procedure? gsd-max-rework-iterations))
+      ;; Verify it has a default value
+      (check-true (exact-positive-integer? (gsd-max-rework-iterations))))
+
+    (test-case "verifier-max-rework-iterations reads from settings"
+      ;; Default is 3
+      (define s1 (make-test-settings (hasheq)))
+      (check-equal? (settings:verifier-max-rework-iterations s1) 3)
+
+      ;; Custom value
+      (define s2 (make-test-settings
+                  (hasheq 'mas
+                          (hasheq 'verifier
+                                  (hasheq 'max-rework-iterations 7)))))
+      (check-equal? (settings:verifier-max-rework-iterations s2) 7))
+
+    (test-case "verifier-max-rework-iterations coerces string values"
+      (define s (make-test-settings
+                 (hasheq 'mas
+                         (hasheq 'verifier
+                                 (hasheq 'max-rework-iterations "5")))))
+      (check-equal? (settings:verifier-max-rework-iterations s) 5))
+
+    (test-case "parameter can be set from settings value"
+      ;; Simulate the wiring that run-modes.rkt does
+      (define s (make-test-settings
+                 (hasheq 'mas
+                         (hasheq 'verifier
+                                 (hasheq 'max-rework-iterations 10)))))
+      (define old-val (gsd-max-rework-iterations))
+      (gsd-max-rework-iterations (settings:verifier-max-rework-iterations s))
+      (check-equal? (gsd-max-rework-iterations) 10)
+      ;; Restore
+      (gsd-max-rework-iterations old-val))))
+
+
+(run-tests suite)

--- a/wiring/run-modes.rkt
+++ b/wiring/run-modes.rkt
@@ -94,7 +94,8 @@
          (only-in "../agent/registry.rkt"
                   pin-current-versions
                   set-hot-swap-enabled!
-                  set-session-active!)
+                  set-session-active!
+                  register-agent!)
          (only-in "../agent/registry-watcher.rkt" start-registry-watcher!)
          (only-in "../agent/roles/supervisor.rkt" current-use-registry)
          ;; v0.99.9 W4: MCP config + adapter
@@ -107,7 +108,10 @@
                   broker-remote-port
                   broker-capability-secret
                   broker-cert-dir
-                  auto-reload-enabled?)
+                  auto-reload-enabled?
+                  verifier-max-rework-iterations)
+         ;; v0.99.21 F-2: Wire rework limit parameter from settings
+         (only-in "../extensions/gsd/state-machine.rkt" gsd-max-rework-iterations)
          (only-in "../extensions/mcp-adapter.rkt" run-mcp-stdio-server! current-mcp-execute-fn)
          (only-in "../tools/scheduler.rkt" run-tool-batch scheduler-result-results))
 
@@ -309,6 +313,11 @@
            (define factory (dynamic-require module-path factory-sym))
            (register-agent! role-name new-version factory #:module-path module-path)
            (log-info "auto-reload: registered ~a v~a" role-name new-version))))))
+
+  ;; v0.99.21 F-2: Wire verifier rework limit from settings.
+  ;; The setting mas.verifier.max-rework-iterations was defined in v0.99.20
+  ;; but never connected to the gsd-max-rework-iterations parameter.
+  (gsd-max-rework-iterations (verifier-max-rework-iterations settings))
 
   ;; v0.99.9 W4: MCP server mode — alternative entry point.
   ;; When mas.mcp.server.enabled is true AND mas.mcp.enabled is true,


### PR DESCRIPTION
## W0: v0.99.20 Hotfix — Fix build break + audit findings (F-1 through F-5)

### Critical Fix (F-1):
**BUILD BREAK FIXED.** The v0.99.20 release could not compile — `register-agent!` was used in `run-modes.rkt` but not imported. `raco make main.rkt` failed. This hotfix adds the missing import.

### Other Fixes:
- **F-2:** Wired `verifier-max-rework-iterations` setting → `gsd-max-rework-iterations` parameter (was orphaned)
- **F-3:** Corrected CHANGELOG — rework limit blocks (intentional safety, not auto-done)
- **F-4:** Corrected CHANGELOG — "7 files fixed + 1 documented obsolete" (was "8 files fixed")
- **F-5:** Updated process checklist with clean-bytecode `raco make` step

### Verification:
- `raco make main.rkt` with FRESH bytecode: ✅ **PASS**
- 4/4 rework-limit-wiring tests pass
- 5/5 gsd-rework-limit tests pass (no regression)
- CHANGELOG lint: PASSED

Closes #8187