### PR TITLE
feat: W2 Capability-Aware Subagent Spawning (§4.2) (#8189)

### DIFF
--- a/tests/test-capability-aware-spawn.rkt
+++ b/tests/test-capability-aware-spawn.rkt
@@ -1,0 +1,82 @@
+#lang racket/base
+
+;; tests/test-capability-aware-spawn.rkt
+;; v0.99.21 W2 (§4.2): Tests for capability-aware subagent spawning.
+
+(require rackunit
+         rackunit/text-ui
+         racket/list
+         "../tools/builtins/spawn-subagent.rkt"
+         "../tools/tool.rkt")
+
+(define suite
+  (test-suite "Capability-Aware Subagent Spawn (v0.99.21 §4.2)"
+
+    (test-case "child-safe-tools-filtered returns all tools when #f"
+      (define all (child-safe-tools))
+      (define filtered (child-safe-tools-filtered #f))
+      (check-equal? (length filtered) (length all)))
+
+    (test-case "child-safe-tools-filtered returns all tools when empty list"
+      (define all (child-safe-tools))
+      (define filtered (child-safe-tools-filtered '()))
+      (check-equal? (length filtered) (length all)))
+
+    (test-case "read-only filter returns only read-only tools"
+      (define filtered (child-safe-tools-filtered '(read-only)))
+      (define names (map tool-name filtered))
+      ;; Should include read-only tools: read, grep, find, ls
+      (check-not-false (member "read" names) "read tool should be included")
+      (check-not-false (member "grep" names) "grep tool should be included")
+      (check-not-false (member "find" names) "find tool should be included")
+      (check-not-false (member "ls" names) "ls tool should be included")
+      ;; Should NOT include write, edit, bash
+      (check-false (member "write" names) "write tool should NOT be included")
+      (check-false (member "edit" names) "edit tool should NOT be included")
+      (check-false (member "bash" names) "bash tool should NOT be included"))
+
+    (test-case "file-write filter returns file-write tools"
+      (define filtered (child-safe-tools-filtered '(file-write)))
+      (define names (map tool-name filtered))
+      ;; Should include write, edit
+      (check-not-false (member "write" names) "write tool should be included")
+      (check-not-false (member "edit" names) "edit tool should be included")
+      ;; Should NOT include bash
+      (check-false (member "bash" names) "bash tool should NOT be included"))
+
+    (test-case "multiple capabilities include all matching tools"
+      (define filtered (child-safe-tools-filtered '(read-only shell-exec)))
+      (define names (map tool-name filtered))
+      ;; read-only: read, grep, find, ls
+      (check-not-false (member "read" names) "read tool should be included")
+      (check-not-false (member "ls" names) "ls tool should be included")
+      ;; shell-exec: bash
+      (check-not-false (member "bash" names) "bash tool should be included")
+      ;; file-write should NOT be included
+      (check-false (member "write" names) "write tool should NOT be included")
+      (check-false (member "edit" names) "edit tool should NOT be included"))
+
+    (test-case "subagent-config has capabilities field"
+      (define cfg (parse-subagent-config (hasheq 'task "test")))
+      (check-true (subagent-config? cfg))
+      (check-false (subagent-config-capabilities cfg)))
+
+    (test-case "parse-subagent-config reads capabilities arg"
+      (define cfg (parse-subagent-config (hasheq 'task "test" 'capabilities '("read-only"))))
+      (check-equal? (subagent-config-capabilities cfg) '(read-only)))
+
+    (test-case "parse-subagent-config handles multiple capabilities"
+      (define cfg (parse-subagent-config (hasheq 'task "test" 'capabilities '("read-only" "file-write"))))
+      (check-equal? (subagent-config-capabilities cfg) '(read-only file-write)))
+
+    (test-case "parse-subagent-config filters invalid capabilities"
+      (define cfg (parse-subagent-config (hasheq 'task "test" 'capabilities '("read-only" "bogus-cap"))))
+      ;; Only valid capability is kept
+      (check-equal? (subagent-config-capabilities cfg) '(read-only)))
+
+    (test-case "parse-subagent-config handles empty capabilities list"
+      (define cfg (parse-subagent-config (hasheq 'task "test" 'capabilities '())))
+      ;; Empty list after filtering becomes #f (treat as "all tools")
+      (check-false (subagent-config-capabilities cfg)))))
+
+(run-tests suite)

--- a/tools/builtins/spawn-subagent.rkt
+++ b/tools/builtins/spawn-subagent.rkt
@@ -71,10 +71,14 @@
          subagent-config-role
          subagent-config-max-turns
          subagent-config-tools
-         subagent-config-model)
+         subagent-config-model
+         subagent-config-capabilities
+         ;; v0.99.21 §4.2: Capability-aware tool filtering
+         child-safe-tools-filtered)
 
 ;; Subagent configuration struct — replaces ad-hoc hash extraction
-(struct subagent-config (task role max-turns tools model) #:transparent)
+;; v0.99.21 §4.2: Added capabilities field (6th, default #f for backward compat)
+(struct subagent-config (task role max-turns tools model capabilities) #:transparent)
 
 ;; Spawn rate limiter: parameter holding list of spawn timestamps (milliseconds)
 (define current-spawn-timestamps (make-parameter (box '())))
@@ -119,12 +123,27 @@
             (run-subagent-with-config cfg exec-ctx)))))
 
 ;; Parse subagent-config from tool call args hash.
+;; v0.99.21 §4.2: Added capabilities parsing.
 (define (parse-subagent-config args)
+  (define caps-raw (hash-ref args 'capabilities #f))
+  (define caps
+    (cond
+      [(not caps-raw) #f]
+      [(list? caps-raw)
+       (filter valid-capability?
+               (map (lambda (c)
+                      (if (string? c)
+                          (string->symbol c)
+                          c))
+                    caps-raw))]
+      [(string? caps-raw) (list (string->symbol caps-raw))]
+      [else #f]))
   (subagent-config (hash-ref args 'task #f)
                    (resolve-role-prompt (hash-ref args 'role default-role-prompt))
                    (hash-ref args 'max-turns 5)
                    (hash-ref args 'tools #f)
-                   (hash-ref args 'model #f)))
+                   (hash-ref args 'model #f)
+                   (and caps (pair? caps) caps)))
 
 ;; Execute subagent using typed config struct.
 (define (run-subagent-with-config cfg exec-ctx)
@@ -137,7 +156,9 @@
                         'tools
                         (subagent-config-tools cfg)
                         'model
-                        (subagent-config-model cfg))
+                        (subagent-config-model cfg)
+                        'capabilities
+                        (subagent-config-capabilities cfg))
                 (subagent-config-role cfg)
                 (subagent-config-max-turns cfg)
                 (subagent-config-tools cfg)
@@ -281,6 +302,21 @@
            (tool-name t)
            (tool-required-capability t))))
 
+;; v0.99.21 §4.2: Capability-aware tool filtering for subagent children.
+;; Returns child-safe tools filtered by the given capabilities list.
+;; - When capabilities is #f or empty, returns ALL child-safe tools (backward compat).
+;; - When capabilities is a list of symbols, returns only tools whose
+;;   required-capability is 'any or is in the capabilities list.
+(define (child-safe-tools-filtered capabilities)
+  (define all-tools (child-safe-tools))
+  (cond
+    [(or (not capabilities) (null? capabilities)) all-tools]
+    [else
+     (filter (lambda (t)
+               (define rc (tool-required-capability t))
+               (or (eq? rc 'any) (memq rc capabilities)))
+             all-tools)]))
+
 ;; Internal: run the subagent
 (define (run-subagent args role-prompt max-turns allowed-tools exec-ctx)
   (define task (hash-ref args 'task))
@@ -292,9 +328,11 @@
     (define model-name (resolve-model-name exec-ctx args))
 
     ;; Create scoped tool registry with child-safe tools
+    ;; v0.99.21 §4.2: Filter tools by capabilities when specified
+    (define capabilities (hash-ref args 'capabilities #f))
     (define registry (make-tool-registry))
     ;; Register tools directly to avoid circular dependency with registry-defaults
-    (for ([t (child-safe-tools)])
+    (for ([t (child-safe-tools-filtered capabilities)])
       (register-tool! registry t))
 
     ;; Build child session

--- a/tools/registry-table/skill-tools.rkt
+++ b/tools/registry-table/skill-tools.rkt
@@ -99,26 +99,47 @@
    (make-tool-spec*
     "spawn-subagent"
     "Spawn an isolated child agent to execute a delegated task"
-    (hasheq 'type
-            "object"
-            'required
-            '("task")
-            'properties
-            (hasheq 'task
-                    (hasheq 'type "string" 'description "Task description for the child agent")
-                    'role
-                    (hasheq 'type "string" 'description "Role prompt to load")
-                    'model
-                    (hasheq 'type "string" 'description "Model override for child")
-                    'max-turns
-                    (hasheq 'type "integer" 'description "Max turns (default 5)")
-                    'tools
-                    (hasheq 'type
-                            "array"
-                            'items
-                            (hasheq 'type "string")
-                            'description
-                            "Allowed tool names for child")))
+    (hasheq
+     'type
+     "object"
+     'required
+     '("task")
+     'properties
+     (hasheq
+      'task
+      (hasheq 'type "string" 'description "Task description for the child agent")
+      'role
+      (hasheq 'type "string" 'description "Role prompt to load")
+      'model
+      (hasheq 'type "string" 'description "Model override for child")
+      'max-turns
+      (hasheq 'type "integer" 'description "Max turns (default 5)")
+      'tools
+      (hasheq 'type
+              "array"
+              'items
+              (hasheq 'type "string")
+              'description
+              "Allowed tool names for child")
+      'capabilities
+      (hasheq
+       'type
+       "array"
+       'items
+       (hasheq 'type
+               "string"
+               'enum
+               '("read-only" "file-write"
+                             "shell-exec"
+                             "plan-write"
+                             "git-write"
+                             "network"
+                             "memory-write"
+                             "browser"
+                             "subagent"
+                             "any"))
+       'description
+       "Capability filter: child only gets tools matching these capabilities. Default: all child-safe tools.")))
     tool-spawn-subagent
     #f
     'subagent)


### PR DESCRIPTION
## W2: Capability-Aware Subagent Spawning (§4.2)

Adds capability filtering to `spawn-subagent`, allowing the primary agent to restrict which tools a child agent can access based on capability annotations.

### Files:
- `tools/builtins/spawn-subagent.rkt`: Extended struct + `child-safe-tools-filtered` + parsing
- `tools/registry-table/skill-tools.rkt`: Added `capabilities` parameter to tool schema with enum
- `tests/test-capability-aware-spawn.rkt` (NEW): 10 tests

### Acceptance Gate:
- [x] `subagent-config` struct extended with `capabilities` field (backward compatible)
- [x] `child-safe-tools-filtered` function filters tools by capability
- [x] `parse-subagent-config` reads capabilities arg (handles strings, lists, invalid values)
- [x] Tool schema updated with `capabilities` enum parameter
- [x] `raco make main.rkt` passes (clean bytecode)
- [x] All 10 new tests pass
- [x] No regressions in related test suites

Closes #8189