### PR TITLE
feat: W3 Blackboard-Context Injection for Subagents (§4.3) (#8190)

### DIFF
--- a/tests/test-blackboard-context-injection.rkt
+++ b/tests/test-blackboard-context-injection.rkt
@@ -1,0 +1,80 @@
+#lang racket/base
+
+;; tests/test-blackboard-context-injection.rkt
+;; v0.99.21 W3 (§4.3): Tests for blackboard context injection into subagent system prompt.
+
+(require rackunit
+         rackunit/text-ui
+         racket/list
+         racket/string
+         "../agent/blackboard.rkt"
+         "../tools/builtins/spawn-subagent.rkt")
+
+(define suite
+  (test-suite "Blackboard Context Injection for Subagents (v0.99.21 §4.3)"
+
+    (test-case "build-subagent-blackboard-context returns empty when no blackboard"
+      (parameterize ([current-blackboard #f])
+        (define ctx (build-subagent-blackboard-context))
+        (check-equal? ctx "")))
+
+    (test-case "build-subagent-blackboard-context returns empty for empty blackboard"
+      (define bb (make-blackboard))
+      (parameterize ([current-blackboard bb])
+        (define ctx (build-subagent-blackboard-context))
+        (check-equal? ctx "")))
+
+    (test-case "build-subagent-blackboard-context returns content when blackboard has activity"
+      (define bb (make-blackboard))
+      (parameterize ([current-blackboard bb])
+        (update-blackboard! (lambda (state)
+                              (struct-copy blackboard-state
+                                           state
+                                           [active-plan
+                                            (hasheq 'wave-count 3 'summary "test plan")]))))
+      (parameterize ([current-blackboard bb])
+        (define ctx (build-subagent-blackboard-context))
+        (check-true (> (string-length ctx) 0) "should have content")
+        (check-true (string-contains? ctx "Parent Session Context") "should have header")
+        (check-true (string-contains? ctx "test plan") "should include plan summary")))
+
+    (test-case "build-subagent-blackboard-context includes wave status"
+      (define bb (make-blackboard))
+      (parameterize ([current-blackboard bb])
+        (update-blackboard!
+         (lambda (state)
+           (struct-copy blackboard-state state [wave-status (hasheq "w0" 'done "w1" 'in-progress)]))))
+      (parameterize ([current-blackboard bb])
+        (define ctx (build-subagent-blackboard-context))
+        (check-true (string-contains? ctx "Parent Session Context"))
+        (check-true (string-contains? ctx "w0") "should include wave status")))
+
+    (test-case "build-subagent-blackboard-context includes verifier decisions"
+      (define bb (make-blackboard))
+      (parameterize ([current-blackboard bb])
+        (update-blackboard! (lambda (state)
+                              (struct-copy blackboard-state
+                                           state
+                                           [verifier-decisions
+                                            (list (hasheq 'verdict 'approved 'risk-level 'low))]))))
+      (parameterize ([current-blackboard bb])
+        (define ctx (build-subagent-blackboard-context))
+        (check-true (> (string-length ctx) 0))
+        (check-true (string-contains? ctx "Verifier") "should include verifier info")))
+
+    (test-case "build-subagent-blackboard-context caps token budget"
+      ;; Add many activities to verify token budget guard
+      (define bb (make-blackboard))
+      (define many-waves
+        (for/hasheq ([i (in-range 100)])
+          (values (string->symbol (format "wave-~a" i)) 'done)))
+      (parameterize ([current-blackboard bb])
+        (update-blackboard! (lambda (state)
+                              (struct-copy blackboard-state state [wave-status many-waves]))))
+      (parameterize ([current-blackboard bb])
+        (define ctx (build-subagent-blackboard-context))
+        ;; MAX-BLACKBOARD-SNIPPET-LEN is 500, plus our header should keep it bounded
+        (check-true (<= (string-length ctx) 600)
+                    (format "context too long: ~a chars" (string-length ctx)))))))
+
+(run-tests suite)

--- a/tools/builtins/spawn-subagent.rkt
+++ b/tools/builtins/spawn-subagent.rkt
@@ -55,7 +55,11 @@
          (only-in "../builtins/grep.rkt" tool-grep)
          (only-in "../builtins/find.rkt" tool-find)
          (only-in "../builtins/ls.rkt" tool-ls)
-         (only-in "../builtins/skill-router.rkt" tool-skill-route))
+         (only-in "../builtins/skill-router.rkt" tool-skill-route)
+         ;; v0.99.21 §4.3: Blackboard context injection for subagents
+         (only-in "../../runtime/context-assembly/blackboard-context.rkt"
+                  build-blackboard-context-snippet)
+         (only-in "../../agent/blackboard.rkt" current-blackboard))
 
 (provide (contract-out [resolve-role-prompt (-> (or/c string? #f) string?)]
                        [parse-subagent-config (-> any/c subagent-config?)])
@@ -74,7 +78,9 @@
          subagent-config-model
          subagent-config-capabilities
          ;; v0.99.21 §4.2: Capability-aware tool filtering
-         child-safe-tools-filtered)
+         child-safe-tools-filtered
+         ;; v0.99.21 §4.3: Blackboard context injection for subagents
+         build-subagent-blackboard-context)
 
 ;; Subagent configuration struct — replaces ad-hoc hash extraction
 ;; v0.99.21 §4.2: Added capabilities field (6th, default #f for backward compat)
@@ -317,6 +323,19 @@
                (or (eq? rc 'any) (memq rc capabilities)))
              all-tools)]))
 
+;; v0.99.21 §4.3: Build blackboard context string for subagent injection.
+;; Reads the parent session's blackboard via current-blackboard parameter.
+;; Returns a formatted string with '## Parent Session Context' header when
+;; the blackboard has content, or "" when no blackboard is available.
+;; Uses the existing build-blackboard-context-snippet which handles:
+;;   - #f when no blackboard or empty
+;;   - Token budget guard (capped at 500 chars)
+(define (build-subagent-blackboard-context)
+  (define snippet (build-blackboard-context-snippet))
+  (if (and snippet (> (string-length snippet) 0))
+      (string-append "## Parent Session Context\n" snippet "\n")
+      ""))
+
 ;; Internal: run the subagent
 (define (run-subagent args role-prompt max-turns allowed-tools exec-ctx)
   (define task (hash-ref args 'task))
@@ -351,9 +370,22 @@
                          #:call-id (generate-id)
                          #:session-metadata (hasheq 'session-id session-id 'role "subagent")))
 
+    ;; v0.99.21 §4.3: Inject parent blackboard context into subagent system prompt
+    (define bb-context (build-subagent-blackboard-context))
+    (define effective-role-prompt
+      (if (> (string-length bb-context) 0)
+          (string-append bb-context "\n" role-prompt)
+          role-prompt))
+
     ;; Build messages for child
     (define system-msg
-      (make-message (generate-id) #f 'system 'message (list role-prompt) (current-seconds) (hasheq)))
+      (make-message (generate-id)
+                    #f
+                    'system
+                    'message
+                    (list effective-role-prompt)
+                    (current-seconds)
+                    (hasheq)))
     (define user-msg
       (make-message (generate-id) #f 'user 'message (list task) (current-seconds) (hasheq)))
 


### PR DESCRIPTION
## W3: Blackboard-Context Injection for Subagents (§4.3)

Injects a compact summary of the parent session's blackboard state into subagent system prompts, enabling coordinated multi-agent work.

### Key Design Decision:
Rather than creating a new `blackboard-summary` function in `agent/blackboard.rkt`, this wave **reuses the existing `build-blackboard-context-snippet`** from `runtime/context-assembly/blackboard-context.rkt`, which already:
- Returns `#f` for empty blackboards
- Formats all 6 sections (plan, waves, tests, artifacts, hypotheses, verifier)
- Has a 500-char token budget guard (v0.99.14 W3)

### Files:
- `tools/builtins/spawn-subagent.rkt`: New `build-subagent-blackboard-context` + injection into `run-subagent`
- `tests/test-blackboard-context-injection.rkt` (NEW): 6 tests

### Acceptance Gate:
- [x] `build-subagent-blackboard-context` returns `""` when no blackboard
- [x] Returns `""` for empty blackboard state
- [x] Returns formatted context when blackboard has activity
- [x] Wave status included in summary
- [x] Verifier decisions included in summary
- [x] Token budget guard respected (≤500 chars + header)
- [x] `raco make main.rkt` passes (clean bytecode)
- [x] All 6 new tests pass
- [x] No regressions in related test suites

Closes #8190