### PR TITLE
W0: Remediation (A-1 + A-2 + F-5) — v0.99.22 (#8201)

### DIFF
--- a/tests/test-capability-aware-spawn.rkt
+++ b/tests/test-capability-aware-spawn.rkt
@@ -66,17 +66,41 @@
       (check-equal? (subagent-config-capabilities cfg) '(read-only)))
 
     (test-case "parse-subagent-config handles multiple capabilities"
-      (define cfg (parse-subagent-config (hasheq 'task "test" 'capabilities '("read-only" "file-write"))))
+      (define cfg
+        (parse-subagent-config (hasheq 'task "test" 'capabilities '("read-only" "file-write"))))
       (check-equal? (subagent-config-capabilities cfg) '(read-only file-write)))
 
     (test-case "parse-subagent-config filters invalid capabilities"
-      (define cfg (parse-subagent-config (hasheq 'task "test" 'capabilities '("read-only" "bogus-cap"))))
+      (define cfg
+        (parse-subagent-config (hasheq 'task "test" 'capabilities '("read-only" "bogus-cap"))))
       ;; Only valid capability is kept
       (check-equal? (subagent-config-capabilities cfg) '(read-only)))
 
     (test-case "parse-subagent-config handles empty capabilities list"
       (define cfg (parse-subagent-config (hasheq 'task "test" 'capabilities '())))
       ;; Empty list after filtering becomes #f (treat as "all tools")
-      (check-false (subagent-config-capabilities cfg)))))
+      (check-false (subagent-config-capabilities cfg)))
+
+    ;; v0.99.22 A-2: Batch capabilities support
+    (test-case "parse-job-capabilities returns #f when no capabilities key"
+      (define caps (parse-job-capabilities (hasheq 'task "hello")))
+      (check-false caps))
+
+    (test-case "parse-job-capabilities parses valid capabilities"
+      (define caps
+        (parse-job-capabilities (hasheq 'task "hello" 'capabilities '("read-only" "file-write"))))
+      (check-equal? caps '(read-only file-write)))
+
+    (test-case "parse-job-capabilities filters invalid and returns #f for empty"
+      ;; Mix of valid and invalid
+      (define caps1
+        (parse-job-capabilities (hasheq 'task "hello" 'capabilities '("read-only" "bogus"))))
+      (check-equal? caps1 '(read-only))
+      ;; All invalid → #f
+      (define caps2 (parse-job-capabilities (hasheq 'task "hello" 'capabilities '("bogus"))))
+      (check-false caps2)
+      ;; Empty list → #f
+      (define caps3 (parse-job-capabilities (hasheq 'task "hello" 'capabilities '())))
+      (check-false caps3))))
 
 (run-tests suite)

--- a/tests/test-subagent-config.rkt
+++ b/tests/test-subagent-config.rkt
@@ -10,7 +10,7 @@
 
 ;; subagent-config struct
 (test-case "subagent-config construction"
-  (define cfg (subagent-config "do stuff" "assistant" 5 #f #f))
+  (define cfg (subagent-config "do stuff" "assistant" 5 #f #f #f))
   (check-equal? (subagent-config-task cfg) "do stuff")
   (check-equal? (subagent-config-role cfg) "assistant")
   (check-equal? (subagent-config-max-turns cfg) 5)
@@ -18,7 +18,7 @@
   (check-false (subagent-config-model cfg)))
 
 (test-case "subagent-config transparent"
-  (define cfg (subagent-config "task" "role" 3 '("read") "gpt-4"))
+  (define cfg (subagent-config "task" "role" 3 '("read") "gpt-4" #f))
   (check-equal? (subagent-config-tools cfg) '("read"))
   (check-equal? (subagent-config-model cfg) "gpt-4"))
 

--- a/tools/builtins/spawn-subagent.rkt
+++ b/tools/builtins/spawn-subagent.rkt
@@ -80,7 +80,9 @@
          ;; v0.99.21 §4.2: Capability-aware tool filtering
          child-safe-tools-filtered
          ;; v0.99.21 §4.3: Blackboard context injection for subagents
-         build-subagent-blackboard-context)
+         build-subagent-blackboard-context
+         ;; v0.99.22 A-2: Batch capabilities parsing
+         parse-job-capabilities)
 
 ;; Subagent configuration struct — replaces ad-hoc hash extraction
 ;; v0.99.21 §4.2: Added capabilities field (6th, default #f for backward compat)
@@ -559,6 +561,24 @@
 ;; spawn-subagents: Batch parallel execution
 ;; ============================================================
 
+;; v0.99.22 A-2: Parse capabilities from a job hash (for batch spawn path).
+;; Mirrors the capability parsing in parse-subagent-config.
+;; Returns #f when no valid capabilities, or a list of symbols.
+(define (parse-job-capabilities job)
+  (define caps-raw (hash-ref job 'capabilities #f))
+  (cond
+    [(not caps-raw) #f]
+    [(list? caps-raw)
+     (define filtered
+       (filter valid-capability?
+               (map (lambda (c)
+                      (if (string? c)
+                          (string->symbol c)
+                          c))
+                    caps-raw)))
+     (if (null? filtered) #f filtered)]
+    [else #f]))
+
 ;; Run a single job and return (cons job-id result) or (cons job-id error)
 (define (run-single-job job provider parent-ctx)
   (define job-id (hash-ref job 'jobId #f))
@@ -566,6 +586,8 @@
   (define role-prompt (hash-ref job 'role (hash-ref job 'rolePrompt #f)))
   (define model-name (or (hash-ref job 'model #f) (resolve-model-name parent-ctx job)))
   (define max-turns (hash-ref job 'max-turns 5))
+  ;; v0.99.22 A-2: Parse capabilities from job hash (mirrors parse-subagent-config)
+  (define caps (parse-job-capabilities job))
   (define result
     (if (not task)
         (make-error-result "task is required for each job")
@@ -576,7 +598,9 @@
                               'model
                               model-name
                               'max-turns
-                              max-turns)
+                              max-turns
+                              'capabilities
+                              caps)
                       (or role-prompt default-role-prompt)
                       max-turns
                       #f ;; allowed-tools

--- a/tools/registry-table/skill-tools.rkt
+++ b/tools/registry-table/skill-tools.rkt
@@ -155,12 +155,32 @@
      'properties
      (hasheq
       'jobs
-      (hasheq 'type
-              "array"
-              'description
-              "Array of job objects, each with task (required), role, model, max-turns, jobId"
-              'items
-              (hasheq 'type "object"))
+      (hasheq
+       'type
+       "array"
+       'description
+       "Array of job objects, each with task (required), role, model, max-turns, jobId, capabilities"
+       'items
+       (hasheq
+        'type
+        "object"
+        'properties
+        (hasheq
+         'task
+         (hasheq 'type "string")
+         'role
+         (hasheq 'type "string")
+         'capabilities
+         (hasheq
+          'type
+          "array"
+          'items
+          (hasheq 'type
+                  "string"
+                  'enum
+                  '("read-only" "file-write" "shell-exec" "git-write" "network" "browser" "any"))
+          'description
+          "Capability filter for this job's child agent"))))
       'maxParallel
       (hasheq 'type "integer" 'description "Max concurrent subagents (1-3, default 3)")
       'aggregate


### PR DESCRIPTION
## W0: Remediation (A-1 + A-2 + F-5)

### A-1: Fix test-subagent-config.rkt Regression (P0)
Two test cases constructed `subagent-config` with 5 args but struct now has 6 fields (added in v0.99.21 W2). Fixed by adding `#f` as 6th arg (capabilities).

### A-2: Batch Spawn Capabilities Support (P1)
`run-single-job` (batch path) did not pass `capabilities` to `run-subagent`. Now:
- Extracted `parse-job-capabilities` as standalone testable function
- `run-single-job` reads capabilities from job hash and passes through
- Updated `spawn-subagents` schema with capabilities property + enum
- Added 3 new batch-capability tests (total 13 capability tests)

### F-5: Process Checklist (P2)
`.planning/AUDIT-PROCESS-CHECKLIST.md` already updated (local-only file).

### Test Results
- `test-subagent-config.rkt`: 4/4 PASS ✅
- `test-capability-aware-spawn.rkt`: 13/13 PASS ✅ (10 original + 3 new)
- `raco make main.rkt`: Clean ✅

Closes #8201