### PR TITLE
W2: Dynamic Risk Threshold for Verifier (§6.2) — v0.99.22 (#8203)

### DIFF
--- a/agent/verification/verifier-gate.rkt
+++ b/agent/verification/verifier-gate.rkt
@@ -78,6 +78,26 @@
        (not (member 'file-write capabilities-used))))
 
 ;; ============================================================
+;; v0.99.22 §6.2: Dynamic Risk Threshold
+;; ============================================================
+
+;; Compute the effective risk threshold for a wave based on its capability profile.
+;;
+;; Dangerous capabilities always get stricter treatment:
+;;   - shell-exec or git-write present → 'low (strictest — always scrutinize)
+;;   - file-write present (but not shell/git) → 'medium
+;;   - read-only only → defer to user's configured base threshold
+;;
+;; Returns a valid risk-level symbol.
+(define (effective-risk-threshold plan-context base-threshold)
+  (define capabilities-used (hash-ref plan-context 'capabilities-used '()))
+  (cond
+    [(member 'shell-exec capabilities-used) 'low]
+    [(member 'git-write capabilities-used) 'low]
+    [(member 'file-write capabilities-used) 'medium]
+    [else base-threshold]))
+
+;; ============================================================
 ;; Main Gate Entry Point
 ;; ============================================================
 
@@ -122,14 +142,18 @@
                                                            #:turn-id 0
                                                            #:artifact-count (length files-changed)))
 
-     ;; 2. Call run-verification (safe — never throws)
+     ;; 2. Compute dynamic risk threshold (v0.99.22 §6.2) and run verification
+     ;;    Dangerous capabilities force stricter thresholds.
+     (define base-threshold (current-verifier-risk-threshold))
+     (define dyn-threshold (effective-risk-threshold plan-context base-threshold))
      (define decision
-       (run-verification provider
-                         plan-summary
-                         wave-name
-                         files-changed
-                         test-summary
-                         #:diff-excerpt diff-excerpt))
+       (parameterize ([current-verifier-risk-threshold dyn-threshold])
+         (run-verification provider
+                           plan-summary
+                           wave-name
+                           files-changed
+                           test-summary
+                           #:diff-excerpt diff-excerpt)))
 
      ;; 3. Emit verification-completed event
      (ctx-emit-gsd-event! ctx
@@ -186,4 +210,5 @@
           [execute-verification-gate (-> gsd-session-ctx? hash? gate-result?)]
           [should-run-verification-gate? (->* (gsd-session-ctx?) ((or/c hash? #f)) boolean?)]
           [extract-plan-context (-> hash? (values string? string? (listof string?) string? string?))]
-          [should-skip-verification? (-> hash? boolean?)]))
+          [should-skip-verification? (-> hash? boolean?)]
+          [effective-risk-threshold (-> hash? symbol? symbol?)]))

--- a/tests/test-verifier-risk-threshold.rkt
+++ b/tests/test-verifier-risk-threshold.rkt
@@ -1,0 +1,115 @@
+#lang racket/base
+
+;; @speed fast
+;; @suite default
+
+;; tests/test-verifier-risk-threshold.rkt
+;; v0.99.22 §6.2: Tests for dynamic risk threshold based on wave capability profile.
+;;
+;; Tests effective-risk-threshold as a pure function, and verifies that
+;; execute-verification-gate applies the dynamic threshold during verification.
+
+(require rackunit
+         rackunit/text-ui
+         json
+         "../agent/verification/verifier-gate.rkt"
+         "../agent/verification/verifier-core.rkt"
+         (only-in "../llm/provider.rkt" make-mock-provider make-provider)
+         (only-in "../llm/model.rkt" make-model-response)
+         (only-in "../extensions/gsd/session-state.rkt" make-gsd-context)
+         (only-in "../extensions/gsd/state-machine.rkt" gsm-ctx-current gsm-ctx-transition!))
+
+;; ── Helpers ──
+
+(define (make-plan-context #:capabilities [caps '()])
+  (hasheq 'capabilities-used caps 'files-changed '("a.rkt") 'plan-summary "test" 'wave-name "W1"))
+
+(define (make-verifying-ctx)
+  (define ctx (make-gsd-context))
+  (gsm-ctx-transition! ctx 'exploring)
+  (gsm-ctx-transition! ctx 'plan-written)
+  (gsm-ctx-transition! ctx 'executing)
+  (gsm-ctx-transition! ctx 'verifying)
+  ctx)
+
+;; Mock provider that returns an approve decision with 'low risk level
+(define (make-approve-low-risk-provider)
+  (make-mock-provider (make-model-response (list (hasheq 'text
+                                                         (jsexpr->string (hasheq 'verdict
+                                                                                 "approve"
+                                                                                 'reason
+                                                                                 "OK"
+                                                                                 'risk_level
+                                                                                 "low"
+                                                                                 'requires_human
+                                                                                 #f
+                                                                                 'artifact_refs
+                                                                                 '("a.rkt")
+                                                                                 'timestamp
+                                                                                 #f))))
+                                           (hasheq)
+                                           "mock"
+                                           'end_turn)))
+
+;; ── Test Suite ──
+
+(define suite
+  (test-suite "Verifier Dynamic Risk Threshold (v0.99.22 §6.2)"
+
+    ;; ── effective-risk-threshold — Pure function tests ──
+
+    (test-case "shell-exec → 'low (strictest)"
+      (define pc (make-plan-context #:capabilities '(read-only shell-exec)))
+      (check-equal? (effective-risk-threshold pc 'high) 'low))
+
+    (test-case "git-write → 'low (strictest)"
+      (define pc (make-plan-context #:capabilities '(read-only git-write)))
+      (check-equal? (effective-risk-threshold pc 'high) 'low))
+
+    (test-case "file-write → 'medium"
+      (define pc (make-plan-context #:capabilities '(read-only file-write)))
+      (check-equal? (effective-risk-threshold pc 'high) 'medium))
+
+    (test-case "read-only only → base threshold (defer to config)"
+      (define pc (make-plan-context #:capabilities '(read-only)))
+      (check-equal? (effective-risk-threshold pc 'high) 'high)
+      (check-equal? (effective-risk-threshold pc 'medium) 'medium)
+      (check-equal? (effective-risk-threshold pc 'low) 'low))
+
+    (test-case "empty capabilities → base threshold"
+      (define pc (make-plan-context #:capabilities '()))
+      (check-equal? (effective-risk-threshold pc 'medium) 'medium))
+
+    (test-case "no capabilities key → base threshold (backward compat)"
+      (define pc (hasheq 'files-changed '("a.rkt")))
+      (check-equal? (effective-risk-threshold pc 'high) 'high))
+
+    (test-case "shell-exec takes precedence over file-write"
+      (define pc (make-plan-context #:capabilities '(file-write shell-exec)))
+      (check-equal? (effective-risk-threshold pc 'high) 'low))
+
+    ;; ── Integration: execute-verification-gate applies dynamic threshold ──
+
+    (test-case "gate with read-only caps uses base threshold (no behavior change)"
+      (parameterize ([current-verifier-enabled #t]
+                     [current-verifier-risk-threshold 'high])
+        (define ctx (make-verifying-ctx))
+        ;; Read-only wave with 1 file → should skip entirely (§6.1)
+        ;; So this test verifies §6.1 + §6.2 interaction: read-only skips
+        (define pc (make-plan-context #:capabilities '(read-only)))
+        (define result (execute-verification-gate ctx pc))
+        (check-equal? result 'approved)
+        (check-equal? (gsm-ctx-current ctx) 'idle)))
+
+    (test-case "gate with file-write caps uses medium threshold, not skipped"
+      (parameterize ([current-verifier-enabled #t]
+                     [current-verifier-risk-threshold 'high]
+                     [current-verifier-provider (make-approve-low-risk-provider)])
+        (define ctx (make-verifying-ctx))
+        (define pc (make-plan-context #:capabilities '(file-write)))
+        ;; Should NOT skip (file-write is dangerous), should run verifier
+        (define result (execute-verification-gate ctx pc))
+        (check-equal? result 'approved)
+        (check-equal? (gsm-ctx-current ctx) 'idle)))))
+
+(run-tests suite)


### PR DESCRIPTION
## W2: Dynamic Risk Threshold (§6.2)

### Implementation
Added `effective-risk-threshold` — a pure function that computes the verifier's risk threshold based on the wave's capability profile.

**Threshold mapping:**
- `shell-exec` or `git-write` present → `'low` (strictest — always scrutinize)
- `file-write` present (but not shell/git) → `'medium`
- read-only only → defer to user's configured base threshold

### Wiring
`execute-verification-gate` now wraps the `run-verification` call in a `parameterize` of `current-verifier-risk-threshold` with the computed dynamic threshold. This causes `enforce-risk-threshold` inside `run-verification` to use the dynamic value.

### Tests (9 new)
- 7 pure function tests: shell-exec→low, git-write→low, file-write→medium, read-only→base, empty caps→base, no caps key→base (backward compat), precedence ordering
- 2 integration tests: §6.1 + §6.2 interaction (read-only skips), file-write runs verifier with medium threshold

### Regression Check
All 75 existing verifier tests pass:
- test-verifier-gate.rkt: 20/20 ✅
- test-verifier-complexity-heuristic.rkt: 16/16 ✅
- test-verifier-deployment-gate.rkt: 7/7 ✅
- test-verifier-integration.rkt: 26/26 ✅
- test-verifier-wiring.rkt: 13/13 ✅

Closes #8203