### PR TITLE
W3: Version Bump 0.99.22 + CHANGELOG (#8204)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,45 @@
+## 0.99.22
+
+Released: 2026-07-16
+
+### Overview
+Three-track release: v0.99.21 audit remediation + Säule A completion (batch capabilities) +
+Säule C foundation (adaptive verification). Closes all audit findings from v0.99.21
+and introduces complexity-based verifier optimization.
+
+### Remediation (v0.99.21 Audit)
+- **A-1**: Fixed `test-subagent-config.rkt` regression — struct arity mismatch from
+  the v0.99.21 W2 capability field addition. Test now passes 4/4.
+- **A-2**: `spawn-subagents` (batch) now supports per-job `capabilities` filtering.
+  Previously only `spawn-subagent` (single) supported capabilities. The batch path
+  always gave all tools. Now jobs can specify `capabilities: ["read-only"]` etc.
+- **F-5**: Actually updated `.planning/AUDIT-PROCESS-CHECKLIST.md` with clean-bytecode
+  `raco make` verification step (was claimed in v0.99.21 but never done).
+
+### Features (Säule C: Adaptive Verification)
+- **§6.1 Complexity Heuristic**: The verification gate now skips LLM-based verification
+  for trivially simple waves (≤2 files changed, read-only tools only). These waves
+  auto-approve with a log message. Non-trivial waves go through full verification
+  as before. This reduces verifier latency for simple operations.
+- **§6.2 Dynamic Risk Threshold**: The verifier's risk threshold now adjusts dynamically
+  based on the wave's capability profile. Shell-exec and git-write waves always get
+  the strictest threshold ('low). File-write waves get 'medium. Read-only waves defer
+  to the user's configured threshold. This ensures dangerous operations are always
+  scrutinized, while simple operations are not over-verified.
+
+### Testing
+- W0: 3 new batch-capability tests (total 13 in suite); 1 regression fix
+- W1: 16 new tests for complexity heuristic
+- W2: 9 new tests for dynamic risk threshold
+- All existing MAS tests still pass
+
+### Operational / Release
+- Version bumped to 0.99.22.
+- 2 production files changed (spawn-subagent.rkt, verifier-gate.rkt).
+- 2 test files changed (1 fix, 1 extend).
+- 2 new test files.
+- 1 schema update (skill-tools.rkt).
+
 ## 0.99.21
 
 Released: 2026-07-15

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.99.21-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.99.22-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 
@@ -208,7 +208,7 @@ bin/q --model gpt-5.4 "write a test"
 ### Verify
 
 ```bash
-bin/q --version            # q version 0.99.21
+bin/q --version            # q version 0.99.22
 raco test tests/           # run the full test suite
 ```
 

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.99.21")
+(define version "0.99.22")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base" "gui-easy-lib"))

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -11,4 +11,4 @@
 
 (provide (contract-out [q-version string?]))
 
-(define q-version "0.99.21")
+(define q-version "0.99.22")


### PR DESCRIPTION
## W3: Version Bump 0.99.21 → 0.99.22 + CHANGELOG

### Changes
- `util/version.rkt`: `0.99.21` → `0.99.22`
- `info.rkt`: synced
- `README.md`: badge + example output synced
- `CHANGELOG.md`: Full v0.99.22 entry documenting all changes

### CHANGELOG Contents
- **Remediation**: A-1 (test fix), A-2 (batch capabilities), F-5 (process checklist)
- **Säule C Features**: §6.1 (complexity heuristic, 16 tests), §6.2 (dynamic risk threshold, 9 tests)
- **Testing summary**: 28 new tests across W0–W2

### Verification
- `raco make main.rkt` passes (clean bytecode)
- `test-version.rkt` 3/3 pass

Closes #8204