### PR TITLE
W0: Audit Remediation (C-1, C-2, C-3, C-4) (#8223)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ Säule B user ergonomics (HITL approval for dangerous spawns + CLI flags for MAS
 - W0: 15 new tests for plan-context enrichment
 - W1: 15 new tests for HITL spawn approval
 - W2: 9 new tests for CLI flags
-- All existing MAS tests still pass
+- All existing MAS tests pass; 4 cli-config arity regressions identified for v0.99.24 fix
 
 ### Operational / Release
 - Version bumped to 0.99.23.

--- a/extensions/gsd/plan-context-builder.rkt
+++ b/extensions/gsd/plan-context-builder.rkt
@@ -35,24 +35,32 @@
       '()))
 
 ;; Get a compact git diff excerpt for the wave's files.
+;; v0.99.24 C-3: Fixed dead code — file paths were computed but never passed to git.
+;; Uses `git show --stat HEAD -- <files>` instead of `git diff --stat` because
+;; at /wave-done time, changes are already committed.
 ;; Returns a string (possibly empty when no changes or no git).
 (define (get-diff-excerpt base-dir files)
   (if (or (null? files) (not base-dir))
       ""
       (with-handlers ([exn:fail? (lambda (_) "")])
-        (define file-args (string-join files " "))
-        (define port
+        (define output
           (parameterize ([current-directory (if (path? base-dir)
                                                 base-dir
                                                 (string->path base-dir))])
-            (open-input-string (with-output-to-string
-                                (lambda ()
-                                  (with-handlers ([exn:fail? void])
-                                    (system* (find-executable-path "git") "diff" "--stat" "--")))))))
-        (define output (string-trim (port->string port)))
-        (if (> (string-length output) 2000)
-            (string-append (substring output 0 2000) "...")
-            output))))
+            (with-output-to-string (lambda ()
+                                     (with-handlers ([exn:fail? void])
+                                       (apply system*
+                                              (find-executable-path "git")
+                                              "show"
+                                              "--stat"
+                                              "--oneline"
+                                              "HEAD"
+                                              "--"
+                                              files))))))
+        (define trimmed (string-trim output))
+        (if (> (string-length trimmed) 2000)
+            (string-append (substring trimmed 0 2000) "...")
+            trimmed))))
 
 ;; Build an enriched plan-context hash for the verification gate.
 ;;

--- a/tests/test-cli-builder.rkt
+++ b/tests/test-cli-builder.rkt
@@ -40,10 +40,10 @@
    (define cfg (parse-cli-args #("--version")))
    (check-equal? (mode-for-config cfg) 'version))
  (test-case "mode-for-config: doctor command → 'doctor"
-   (define cfg (cli-config 'doctor #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f))
+   (define cfg (cli-config 'doctor #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f #f #f #f))
    (check-equal? (mode-for-config cfg) 'doctor))
  (test-case "mode-for-config: sessions command → 'sessions"
-   (define cfg (cli-config 'sessions #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f))
+   (define cfg (cli-config 'sessions #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f #f #f #f))
    (check-equal? (mode-for-config cfg) 'sessions))
  (test-case "mode-for-config: chat command → interactive mode"
    (define cfg (parse-cli-args #()))
@@ -114,10 +114,10 @@
  ;; ============================================================
  (test-case "mode-for-config: unknown command falls back to mode from config"
    ;; Create a config with an arbitrary command and explicit mode
-   (define cfg (cli-config 'custom #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f))
+   (define cfg (cli-config 'custom #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f #f #f #f))
    (check-equal? (mode-for-config cfg) 'interactive))
  (test-case "mode-for-config: custom command with json mode"
-   (define cfg (cli-config 'custom #f #f #f 'json #f #f #f 10 #f '() #f #f '() #f #f #f))
+   (define cfg (cli-config 'custom #f #f #f 'json #f #f #f 10 #f '() #f #f '() #f #f #f #f #f #f))
    (check-equal? (mode-for-config cfg) 'json))
  ;; ============================================================
  ;; Argument parsing integration: mode-for-config with various CLI args

--- a/tests/test-cli-interactive.rkt
+++ b/tests/test-cli-interactive.rkt
@@ -17,7 +17,7 @@
 
     (test-case "basic prompt submission"
       (define prompts (box '()))
-      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f))
+      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f #f #f #f))
       (define in (open-input-string "hello\n/quit\n"))
       (define out (open-output-string))
       (run-cli-interactive cfg
@@ -28,7 +28,7 @@
 
     (test-case "multiple lines submitted as separate prompts"
       (define prompts (box '()))
-      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f))
+      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f #f #f #f))
       (define in (open-input-string "line1\nline2\n/quit\n"))
       (define out (open-output-string))
       (run-cli-interactive cfg
@@ -39,7 +39,7 @@
 
     (test-case "whitespace-only lines are skipped"
       (define prompts (box '()))
-      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f))
+      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f #f #f #f))
       (define in (open-input-string "   \nhello\n/quit\n"))
       (define out (open-output-string))
       (run-cli-interactive cfg
@@ -50,7 +50,7 @@
 
     (test-case "empty lines are skipped"
       (define prompts (box '()))
-      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f))
+      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f #f #f #f))
       (define in (open-input-string "\nhello\n/quit\n"))
       (define out (open-output-string))
       (run-cli-interactive cfg
@@ -61,7 +61,7 @@
 
     (test-case "EOF terminates with Goodbye"
       (define prompts (box '()))
-      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f))
+      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f #f #f #f))
       (define in (open-input-string "hello\n"))
       (define out (open-output-string))
       (run-cli-interactive cfg
@@ -74,21 +74,21 @@
   (test-suite "run-cli-interactive — slash commands"
 
     (test-case "/quit terminates with Goodbye"
-      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f))
+      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f #f #f #f))
       (define in (open-input-string "/quit\n"))
       (define out (open-output-string))
       (run-cli-interactive cfg #:in in #:out out)
       (check-true (string-contains? (get-output-string out) "Goodbye.")))
 
     (test-case "/exit terminates with Goodbye"
-      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f))
+      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f #f #f #f))
       (define in (open-input-string "/exit\n"))
       (define out (open-output-string))
       (run-cli-interactive cfg #:in in #:out out)
       (check-true (string-contains? (get-output-string out) "Goodbye.")))
 
     (test-case "/help displays usage"
-      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f))
+      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f #f #f #f))
       (define in (open-input-string "/help\n/quit\n"))
       (define out (open-output-string))
       (run-cli-interactive cfg #:in in #:out out)
@@ -97,14 +97,14 @@
 
     (test-case "/compact calls compact-fn"
       (define compact-called (box #f))
-      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f))
+      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f #f #f #f))
       (define in (open-input-string "/compact\n/quit\n"))
       (define out (open-output-string))
       (run-cli-interactive cfg #:compact-fn (lambda () (set-box! compact-called #t)) #:in in #:out out)
       (check-true (unbox compact-called) "compact-fn should have been called"))
 
     (test-case "/compact without compact-fn shows fallback message"
-      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f))
+      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f #f #f #f))
       (define in (open-input-string "/compact\n/quit\n"))
       (define out (open-output-string))
       (run-cli-interactive cfg #:in in #:out out)
@@ -113,7 +113,7 @@
 
     (test-case "/history calls history-fn"
       (define history-called (box #f))
-      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f))
+      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f #f #f #f))
       (define in (open-input-string "/history\n/quit\n"))
       (define out (open-output-string))
       (run-cli-interactive cfg
@@ -123,7 +123,7 @@
       (check-true (unbox history-called) "history-fn should have been called"))
 
     (test-case "/history without history-fn shows fallback message"
-      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f))
+      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f #f #f #f))
       (define in (open-input-string "/history\n/quit\n"))
       (define out (open-output-string))
       (run-cli-interactive cfg #:in in #:out out)
@@ -132,7 +132,7 @@
 
     (test-case "/model gpt-4 calls model-fn with arg"
       (define model-arg (box #f))
-      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f))
+      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f #f #f #f))
       (define in (open-input-string "/model gpt-4\n/quit\n"))
       (define out (open-output-string))
       (run-cli-interactive cfg #:model-fn (lambda (name) (set-box! model-arg name)) #:in in #:out out)
@@ -140,7 +140,7 @@
 
     (test-case "/model without arg calls model-fn with #f"
       (define model-arg (box 'not-called))
-      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f))
+      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f #f #f #f))
       (define in (open-input-string "/model\n/quit\n"))
       (define out (open-output-string))
       (run-cli-interactive cfg #:model-fn (lambda (name) (set-box! model-arg name)) #:in in #:out out)
@@ -148,7 +148,7 @@
 
     (test-case "/fork abc123 calls fork-fn with arg"
       (define fork-arg (box #f))
-      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f))
+      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f #f #f #f))
       (define in (open-input-string "/fork abc123\n/quit\n"))
       (define out (open-output-string))
       (run-cli-interactive cfg #:fork-fn (lambda (arg) (set-box! fork-arg arg)) #:in in #:out out)
@@ -156,21 +156,21 @@
 
     (test-case "/fork without arg calls fork-fn with #f"
       (define fork-arg (box 'not-called))
-      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f))
+      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f #f #f #f))
       (define in (open-input-string "/fork\n/quit\n"))
       (define out (open-output-string))
       (run-cli-interactive cfg #:fork-fn (lambda (arg) (set-box! fork-arg arg)) #:in in #:out out)
       (check-equal? (unbox fork-arg) #f))
 
     (test-case "/clear shows clear message"
-      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f))
+      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f #f #f #f))
       (define in (open-input-string "/clear\n/quit\n"))
       (define out (open-output-string))
       (run-cli-interactive cfg #:in in #:out out)
       (check-true (string-contains? (get-output-string out) "clear") "output should mention clear"))
 
     (test-case "/interrupt shows interrupt message"
-      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f))
+      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f #f #f #f))
       (define in (open-input-string "/interrupt\n/quit\n"))
       (define out (open-output-string))
       (run-cli-interactive cfg #:in in #:out out)
@@ -181,7 +181,7 @@
 
     (test-case "session-fn error is displayed and loop continues"
       (define prompts (box '()))
-      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f))
+      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f #f #f #f))
       (define in (open-input-string "bad\nok\n/quit\n"))
       (define out (open-output-string))
       (run-cli-interactive cfg
@@ -197,7 +197,7 @@
 
     (test-case "graceful degradation with string port (no readline)"
       (define prompts (box '()))
-      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f))
+      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f #f #f #f))
       (define in (open-input-string "test prompt\n/quit\n"))
       (define out (open-output-string))
       (run-cli-interactive cfg
@@ -210,7 +210,7 @@
     (test-case "mixed commands and prompts"
       (define prompts (box '()))
       (define compact-called (box #f))
-      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f))
+      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f #f #f #f))
       (define in (open-input-string "first prompt\n/compact\nsecond prompt\n/quit\n"))
       (define out (open-output-string))
       (run-cli-interactive cfg
@@ -234,7 +234,7 @@
 
     (test-case "first-run welcome appears before first prompt when config dir missing"
       (with-temp-dir (tmp-home)
-        (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f))
+        (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f #f #f #f))
         (define in (open-input-string "/quit\n"))
         (define out (open-output-string))
         (parameterize ([current-directory tmp-home])
@@ -244,7 +244,7 @@
   (test-suite "Issue #141: Mock provider warning"
 
     (test-case "mock provider name triggers warning banner"
-      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f))
+      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f #f #f #f))
       (define in (open-input-string "/quit\n"))
       (define out (open-output-string))
       (run-cli-interactive cfg #:provider-name "mock" #:in in #:out out)
@@ -252,7 +252,7 @@
       (check-true (string-contains? output "mock provider") "should warn about mock provider"))
 
     (test-case "real provider name does NOT trigger warning"
-      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f))
+      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f #f #f #f))
       (define in (open-input-string "/quit\n"))
       (define out (open-output-string))
       (run-cli-interactive cfg #:provider-name "openai" #:in in #:out out)
@@ -260,7 +260,7 @@
       (check-false (string-contains? output "mock provider") "should not warn for real provider"))
 
     (test-case "no provider-name does NOT trigger warning"
-      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f))
+      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f #f #f #f))
       (define in (open-input-string "/quit\n"))
       (define out (open-output-string))
       (run-cli-interactive cfg #:in in #:out out)
@@ -270,7 +270,7 @@
   (test-suite "Issue #145: TUI-only commands in CLI"
 
     (test-case "/clear shows TUI-only message"
-      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f))
+      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f #f #f #f))
       (define in (open-input-string "/clear\n/quit\n"))
       (define out (open-output-string))
       (run-cli-interactive cfg #:in in #:out out)
@@ -278,7 +278,7 @@
       (check-true (string-contains? output "TUI") "/clear should mention TUI"))
 
     (test-case "/interrupt shows TUI-only message"
-      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f))
+      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f #f #f #f))
       (define in (open-input-string "/interrupt\n/quit\n"))
       (define out (open-output-string))
       (run-cli-interactive cfg #:in in #:out out)
@@ -286,7 +286,7 @@
       (check-true (string-contains? output "TUI") "/interrupt should mention TUI"))
 
     (test-case "/branches shows TUI-only message"
-      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f))
+      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f #f #f #f))
       (define in (open-input-string "/branches\n/quit\n"))
       (define out (open-output-string))
       (run-cli-interactive cfg #:in in #:out out)
@@ -294,7 +294,7 @@
       (check-true (string-contains? output "TUI") "/branches should mention TUI"))
 
     (test-case "/leaves shows TUI-only message"
-      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f))
+      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f #f #f #f))
       (define in (open-input-string "/leaves\n/quit\n"))
       (define out (open-output-string))
       (run-cli-interactive cfg #:in in #:out out)
@@ -302,7 +302,7 @@
       (check-true (string-contains? output "TUI") "/leaves should mention TUI"))
 
     (test-case "/switch shows TUI-only message"
-      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f))
+      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f #f #f #f))
       (define in (open-input-string "/switch abc\n/quit\n"))
       (define out (open-output-string))
       (run-cli-interactive cfg #:in in #:out out)
@@ -310,7 +310,7 @@
       (check-true (string-contains? output "TUI") "/switch should mention TUI"))
 
     (test-case "/children shows TUI-only message"
-      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f))
+      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f #f #f #f))
       (define in (open-input-string "/children abc\n/quit\n"))
       (define out (open-output-string))
       (run-cli-interactive cfg #:in in #:out out)

--- a/tests/test-cli.rkt
+++ b/tests/test-cli.rkt
@@ -162,6 +162,8 @@
                    #f
                    #f
                    #f
+                   #f
+                   #f
                    #f))
      (define rt (cli-config->runtime-config cfg))
      (check-equal? (hash-ref rt 'model) "gpt-4")
@@ -172,7 +174,8 @@
      (check-equal? (hash-ref rt 'tools) '()))
 
    (test-case "defaults filled in"
-     (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f #f))
+     (define cfg
+       (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f #f #f #f))
      (define rt (cli-config->runtime-config cfg))
      (check-equal? (hash-ref rt 'max-iterations) 10)
      (check-false (hash-ref rt 'no-tools?))
@@ -180,7 +183,26 @@
 
    (test-case "session-id present for resume"
      (define cfg
-       (cli-config 'resume "sess-123" #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f #f))
+       (cli-config 'resume
+                   "sess-123"
+                   #f
+                   #f
+                   'interactive
+                   #f
+                   #f
+                   #f
+                   10
+                   #f
+                   '()
+                   #f
+                   #f
+                   '()
+                   #f
+                   #f
+                   #f
+                   #f
+                   #f
+                   #f))
      (define rt (cli-config->runtime-config cfg))
      (check-equal? (hash-ref rt 'session-id) "sess-123")))
  ;; ═══════════════════════════════════════════
@@ -236,7 +258,8 @@
  (test-suite "run-cli-single"
 
    (test-case "returns void regardless of session-fn return value"
-     (define cfg (cli-config 'prompt #f "test" #f 'single #f #f #f 10 #f '() #f #f '() #f #f #f #f))
+     (define cfg
+       (cli-config 'prompt #f "test" #f 'single #f #f #f 10 #f '() #f #f '() #f #f #f #f #f #f))
      (define result
        (run-cli-single cfg
                        #:session-fn (lambda (prompt) (values 'session-struct 'loop-result-struct))
@@ -424,7 +447,8 @@
 (define suite-166
   (test-suite "Issue #166: --verbose flag"
     (test-case "verbose error in interactive mode shows classified error"
-      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #t 10 #f '() #f #f '() #f #f #f #f))
+      (define cfg
+        (cli-config 'chat #f #f #f 'interactive #f #f #t 10 #f '() #f #f '() #f #f #f #f #f #f))
       (define in (open-input-string "bad\n/quit\n"))
       (define out (open-output-string))
       (run-cli-interactive cfg
@@ -438,7 +462,8 @@
       (check-true (string-contains? output "missing"))
       (check-true (string-contains? output "Stack trace:")))
     (test-case "non-verbose error in interactive mode omits stack trace"
-      (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f #f))
+      (define cfg
+        (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f #f #f #f))
       (define in (open-input-string "bad\n/quit\n"))
       (define out (open-output-string))
       (run-cli-interactive cfg
@@ -452,7 +477,8 @@
       (check-true (string-contains? output "missing"))
       (check-false (string-contains? output "Stack trace:")))
     (test-case "verbose error in single-shot mode outputs to stderr"
-      (define cfg (cli-config 'prompt #f "test" #f 'single #f #f #t 10 #f '() #f #f '() #f #f #f #f))
+      (define cfg
+        (cli-config 'prompt #f "test" #f 'single #f #f #t 10 #f '() #f #f '() #f #f #f #f #f #f))
       (define err (open-output-string))
       (parameterize ([current-error-port err])
         (run-cli-single cfg #:session-fn (lambda (prompt) (error "hash-ref: missing key"))))

--- a/tests/test-wiring-contracts.rkt
+++ b/tests/test-wiring-contracts.rkt
@@ -33,15 +33,15 @@
      (mode-for-config "not a config"))))
 
 (test-case "mode-for-config returns symbol for valid cli-config"
-  (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f))
+  (define cfg (cli-config 'chat #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f #f #f #f))
   (check-equal? (mode-for-config cfg) 'interactive))
 
 (test-case "mode-for-config returns 'help for help command"
-  (define cfg (cli-config 'help #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f))
+  (define cfg (cli-config 'help #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f #f #f #f))
   (check-equal? (mode-for-config cfg) 'help))
 
 (test-case "mode-for-config returns 'version for version command"
-  (define cfg (cli-config 'version #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f))
+  (define cfg (cli-config 'version #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f #f #f #f))
   (check-equal? (mode-for-config cfg) 'version))
 
 ;; ============================================================

--- a/tests/test-wiring-run-modes.rkt
+++ b/tests/test-wiring-run-modes.rkt
@@ -34,23 +34,23 @@
     ;; Test 1: mode-for-config — all command mappings
     ;; --------------------------------------------------
     (test-case "mode-for-config maps 'help to 'help"
-      (define cfg (cli-config 'help #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f))
+      (define cfg (cli-config 'help #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f #f #f #f))
       (check-equal? (mode-for-config cfg) 'help))
 
     (test-case "mode-for-config maps 'version to 'version"
-      (define cfg (cli-config 'version #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f))
+      (define cfg (cli-config 'version #f #f #f 'interactive #f #f #f 10 #f '() #f #f '() #f #f #f #f #f #f))
       (check-equal? (mode-for-config cfg) 'version))
 
     (test-case "mode-for-config falls through to mode for chat"
-      (define cfg (cli-config 'chat #f #f #f 'tui #f #f #f 10 #f '() #f #f '() #f #f #f))
+      (define cfg (cli-config 'chat #f #f #f 'tui #f #f #f 10 #f '() #f #f '() #f #f #f #f #f #f))
       (check-equal? (mode-for-config cfg) 'tui))
 
     (test-case "mode-for-config maps 'single mode"
-      (define cfg (cli-config 'prompt #f "hi" #f 'single #f #f #f 10 #f '() #f #f '() #f #f #f))
+      (define cfg (cli-config 'prompt #f "hi" #f 'single #f #f #f 10 #f '() #f #f '() #f #f #f #f #f #f))
       (check-equal? (mode-for-config cfg) 'single))
 
     (test-case "mode-for-config maps 'json mode"
-      (define cfg (cli-config 'chat #f #f #f 'json #f #f #f 10 #f '() #f #f '() #f #f #f))
+      (define cfg (cli-config 'chat #f #f #f 'json #f #f #f 10 #f '() #f #f '() #f #f #f #f #f #f))
       (check-equal? (mode-for-config cfg) 'json))
 
     ;; --------------------------------------------------


### PR DESCRIPTION
## W0: Audit Remediation (C-1, C-2, C-3, C-4)

### C-1/C-2: cli-config Arity Fix (50 calls across 5 files)
Fixed all `cli-config` constructor calls that were missing fields after the struct grew from 17→20 fields (`memory`, `agent-pool`, `parallel?` added in v0.99.22–v0.99.23).

| File | Calls Fixed | Result |
|------|------------|--------|
| test-cli.rkt | 7 | 0 errors (was 3 errors) |
| test-cli-interactive.rkt | 31 | 32/32 pass |
| test-wiring-run-modes.rkt | 5 | 14/14 pass |
| test-cli-builder.rkt | 4 | 22/22 pass |
| test-wiring-contracts.rkt | 3 | 7/7 pass |

### C-3: get-diff-excerpt Dead Code
Fixed `file-args` computed but never passed to git. Changed `git diff --stat --` to `git show --stat --oneline HEAD -- <files>` — at `/wave-done` time, changes are committed so `git diff` returns empty.

### C-4: CHANGELOG Correction
Updated v0.99.23 CHANGELOG to note the arity regressions.

Closes #8223