### PR TITLE
W1: Enhanced Capability Inference (#8224)

### DIFF
--- a/extensions/gsd/plan-context-builder.rkt
+++ b/extensions/gsd/plan-context-builder.rkt
@@ -7,32 +7,75 @@
 ;; Previously, command-handlers.rkt constructed plan-ctx with empty strings
 ;; and empty lists, making the verifier blind and disabling §6.1 (skip
 ;; heuristic) and §6.2 (dynamic risk threshold).
+;;
+;; v0.99.24 W1: Enhanced capability inference with:
+;;   - FILE-EXTENSION->CAPABILITY table (detects shell-exec from .sh, etc.)
+;;   - infer-capabilities-from-tasks (regex-based shell/git detection)
+;;   - get-test-summary (descriptive stub or cached file)
 
 (require racket/string
          racket/port
          racket/system
+         racket/list
          "plan-types.rkt")
 
 (provide build-enriched-plan-ctx
          infer-capabilities-from-files
-         get-diff-excerpt)
+         infer-capabilities-from-tasks
+         get-diff-excerpt
+         get-test-summary
+         FILE-EXTENSION->CAPABILITY)
 
 ;; ============================================================
 ;; Plan Context Enrichment
 ;; ============================================================
 
-;; plan-wave-ref is imported from plan-types.rkt (already provided there).
+;; v0.99.24 W1: File extension → capability mapping table.
+;; Maps known file extensions to the capability required to modify them.
+;; Conservative: only infers from structural file types, not content.
+;; Easy to extend — just add new (extension . capability) pairs.
+(define FILE-EXTENSION->CAPABILITY
+  '((".rkt" . file-write) (".rktl" . file-write)
+                          (".scrbl" . file-write)
+                          (".ss" . file-write)
+                          (".scm" . file-write)
+                          (".sh" . shell-exec)
+                          (".py" . file-write)
+                          (".md" . file-write)
+                          (".json" . file-write)
+                          (".yaml" . file-write)
+                          (".yml" . file-write)))
 
 ;; Infer capabilities from the file paths in a wave.
-;; Conservative heuristic: only infers 'file-write when .rkt files are present.
-;; Does not infer 'shell-exec or 'git-write (too unreliable from paths alone).
+;; v0.99.24 W1: Enhanced — uses FILE-EXTENSION->CAPABILITY table.
 ;; Returns a list of capability symbols (possibly empty).
+;; Uses remove-duplicates to avoid duplicate capabilities from
+;; multiple files of the same extension.
 (define (infer-capabilities-from-files files)
-  (if (and (pair? files)
-           (for/or ([f (in-list files)])
-             (string-suffix? f ".rkt")))
-      '(file-write)
-      '()))
+  (remove-duplicates (for/fold ([caps '()]) ([f (in-list files)])
+                       (for/fold ([cs caps]) ([pair (in-list FILE-EXTENSION->CAPABILITY)])
+                         (if (string-suffix? f (car pair))
+                             (cons (cdr pair) cs)
+                             cs)))))
+
+;; Infer capabilities from a wave's task descriptions.
+;; v0.99.24 W1: Uses regex heuristics on task name + action text.
+;; Detects shell-exec and git-write from natural language descriptions.
+;; Returns a list of capability symbols (possibly empty).
+(define (infer-capabilities-from-tasks wave)
+  (if (not wave)
+      '()
+      (let* ([tasks (gsd-wave-tasks wave)]
+             [task-text (string-join
+                         (for/list ([t (in-list tasks)])
+                           (string-append (or (gsd-task-name t) "") " " (or (gsd-task-action t) "")))
+                         " ")]
+             [caps '()])
+        (when (regexp-match? #rx"(?i:shell|bash|command|exec|run )" task-text)
+          (set! caps (cons 'shell-exec caps)))
+        (when (regexp-match? #rx"(?i:git|commit|push|merge)" task-text)
+          (set! caps (cons 'git-write caps)))
+        caps)))
 
 ;; Get a compact git diff excerpt for the wave's files.
 ;; v0.99.24 C-3: Fixed dead code — file paths were computed but never passed to git.
@@ -62,14 +105,28 @@
             (string-append (substring trimmed 0 2000) "...")
             trimmed))))
 
+;; Attempt to read test summary from session artifacts.
+;; v0.99.24 W1: Checks for cached test results file. Returns a descriptive
+;; message when no data is available. Never throws.
+(define (get-test-summary base-dir)
+  (define test-log (and base-dir (build-path base-dir ".planning" "test-results.txt")))
+  (cond
+    [(and test-log (file-exists? test-log))
+     (with-handlers ([exn:fail? (lambda (_) "test results unreadable")])
+       (string-trim (call-with-input-file test-log port->string)))]
+    [else "no test results available for this wave"]))
+
 ;; Build an enriched plan-context hash for the verification gate.
 ;;
 ;; This replaces the static empty-strings plan-ctx that existed before.
 ;; The verifier LLM now receives:
 ;;   - Real plan summary (wave titles)
 ;;   - Real file list from the wave's plan data
-;;   - Real (inferred) capabilities — at least 'file-write for .rkt changes
+;;   - Real (inferred) capabilities from both files and tasks
 ;;   - Diff excerpt from git (when available)
+;;   - Test summary (descriptive message or cached results)
+;;
+;; v0.99.24 W1: Now combines file-based AND task-based capability inference.
 (define (build-enriched-plan-ctx base-dir plan wave-idx)
   (define wave (and plan (plan-wave-ref plan wave-idx)))
   (define wave-files
@@ -86,8 +143,11 @@
                        (format "W~a: ~a" (gsd-wave-index w) (gsd-wave-title w)))
                      "\n")
         ""))
-  (define capabilities-used (infer-capabilities-from-files wave-files))
+  (define file-caps (infer-capabilities-from-files wave-files))
+  (define task-caps (infer-capabilities-from-tasks wave))
+  (define capabilities-used (remove-duplicates (append file-caps task-caps)))
   (define diff-excerpt (get-diff-excerpt base-dir wave-files))
+  (define test-summary (get-test-summary base-dir))
   (hasheq 'plan-summary
           plan-summary
           'wave-name
@@ -95,7 +155,7 @@
           'files-changed
           wave-files
           'test-summary
-          "tests not run"
+          test-summary
           'diff-excerpt
           diff-excerpt
           'capabilities-used

--- a/tests/test-plan-context-enrichment.rkt
+++ b/tests/test-plan-context-enrichment.rkt
@@ -5,29 +5,36 @@
 
 ;; tests/test-plan-context-enrichment.rkt
 ;; v0.99.23 B-1/B-2: Tests for plan-context enrichment.
+;; v0.99.24 W1: Enhanced capability inference tests (file-extension table + tasks).
 ;; Verifies that build-enriched-plan-ctx populates real wave data
 ;; (files-changed, capabilities-used, plan-summary, wave-name).
 
 (require rackunit
          rackunit/text-ui
          racket/string
+         racket/list
          "../extensions/gsd/plan-context-builder.rkt"
          "../extensions/gsd/plan-types.rkt")
 
 ;; ── Helpers ──
 
-(define (make-test-plan #:files [files '("a.rkt" "b.rkt")] #:title [title "Test Wave"])
-  (gsd-plan (list (gsd-wave 0 title 'pending "" files '() "" '())) #f '() '()))
+(define (make-test-plan #:files [files '("a.rkt" "b.rkt")]
+                        #:title [title "Test Wave"]
+                        #:tasks [tasks '()])
+  (gsd-plan (list (gsd-wave 0 title 'pending "" files tasks "" '())) #f '() '()))
 
 (define (make-empty-plan)
   (gsd-plan '() #f '() '()))
 
+(define (make-task name action)
+  (gsd-task name '() action "" "" 'pending))
+
 ;; ── Test Suite ──
 
 (define suite
-  (test-suite "Plan Context Enrichment (v0.99.23 B-1/B-2)"
+  (test-suite "Plan Context Enrichment (v0.99.23 + v0.99.24 W1)"
 
-    ;; ── infer-capabilities-from-files ──
+    ;; ── infer-capabilities-from-files (v0.99.23 original) ──
 
     (test-case "infer-capabilities-from-files returns file-write for .rkt files"
       (check-equal? (infer-capabilities-from-files '("a.rkt" "b.rkt")) '(file-write)))
@@ -35,11 +42,79 @@
     (test-case "infer-capabilities-from-files returns file-write for single .rkt file"
       (check-equal? (infer-capabilities-from-files '("agent/core.rkt")) '(file-write)))
 
-    (test-case "infer-capabilities-from-files returns empty for non-.rkt files"
-      (check-equal? (infer-capabilities-from-files '("README.md" "doc.txt")) '()))
+    (test-case "infer-capabilities-from-files returns empty for unknown file types"
+      ;; v0.99.24 W1: .md now maps to file-write, so use .txt/.csv (not in table)
+      (check-equal? (infer-capabilities-from-files '("data.txt" "log.csv")) '()))
 
     (test-case "infer-capabilities-from-files returns empty for no files"
       (check-equal? (infer-capabilities-from-files '()) '()))
+
+    ;; ── infer-capabilities-from-files (v0.99.24 W1 enhanced) ──
+
+    (test-case "infer-capabilities-from-files detects shell-exec from .sh files"
+      (check-equal? (infer-capabilities-from-files '("deploy.sh")) '(shell-exec)))
+
+    (test-case "infer-capabilities-from-files detects file-write from .md files"
+      (check-equal? (infer-capabilities-from-files '("README.md")) '(file-write)))
+
+    (test-case "infer-capabilities-from-files infers multiple capabilities from mixed files"
+      (define caps (infer-capabilities-from-files '("agent/core.rkt" "scripts/deploy.sh")))
+      (check-not-false (member 'file-write caps))
+      (check-not-false (member 'shell-exec caps))
+      (check-equal? (length caps) 2))
+
+    (test-case "infer-capabilities-from-files deduplicates capabilities"
+      ;; Multiple .rkt files should still produce only one 'file-write
+      (check-equal? (infer-capabilities-from-files '("a.rkt" "b.rkt" "c.rkt" "d.rkt")) '(file-write)))
+
+    ;; ── infer-capabilities-from-tasks (v0.99.24 W1 new) ──
+
+    (test-case "infer-capabilities-from-tasks detects shell-exec from task text"
+      (define wave
+        (gsd-wave 0
+                  "Test"
+                  'pending
+                  ""
+                  '()
+                  (list (make-task "Run tests" "Execute bash test runner"))
+                  ""
+                  '()))
+      (define caps (infer-capabilities-from-tasks wave))
+      (check-not-false (member 'shell-exec caps)))
+
+    (test-case "infer-capabilities-from-tasks detects git-write from task text"
+      (define wave
+        (gsd-wave 0
+                  "Test"
+                  'pending
+                  ""
+                  '()
+                  (list (make-task "Deploy" "git commit and push changes"))
+                  ""
+                  '()))
+      (define caps (infer-capabilities-from-tasks wave))
+      (check-not-false (member 'git-write caps)))
+
+    (test-case "infer-capabilities-from-tasks returns empty for read-only tasks"
+      (define wave
+        (gsd-wave 0
+                  "Test"
+                  'pending
+                  ""
+                  '()
+                  (list (make-task "Review" "Read documentation and provide feedback"))
+                  ""
+                  '()))
+      (define caps (infer-capabilities-from-tasks wave))
+      (check-equal? caps '()))
+
+    (test-case "infer-capabilities-from-tasks returns empty for wave with no tasks"
+      (define wave (gsd-wave 0 "Test" 'pending "" '() '() "" '()))
+      (define caps (infer-capabilities-from-tasks wave))
+      (check-equal? caps '()))
+
+    (test-case "infer-capabilities-from-tasks returns empty for #f wave"
+      (check-equal? (infer-capabilities-from-tasks #f) '()))
 
     ;; ── build-enriched-plan-ctx ──
 
@@ -91,6 +166,28 @@
       (define ctx (build-enriched-plan-ctx "." plan 0))
       (check-true (string? (hash-ref ctx 'test-summary))))
 
+    (test-case "build-enriched-plan-ctx test-summary is descriptive (not 'tests not run')"
+      ;; v0.99.24 W1: test-summary should now have a meaningful message
+      (define plan (make-test-plan))
+      (define ctx (build-enriched-plan-ctx "." plan 0))
+      (define ts (hash-ref ctx 'test-summary))
+      (check-true (and (string? ts) (> (string-length ts) 0)))
+      (check-false (string=? ts "tests not run")))
+
+    ;; ── v0.99.24 W1: Combined file + task inference ──
+
+    (test-case "build-enriched-plan-ctx combines file and task capabilities"
+      (define plan
+        (make-test-plan #:files '("agent/core.rkt" "scripts/deploy.sh")
+                        #:tasks (list (make-task "Deploy" "git commit and push"))))
+      (define ctx (build-enriched-plan-ctx "." plan 0))
+      (define caps (hash-ref ctx 'capabilities-used))
+      ;; Should have file-write from .rkt, shell-exec from .sh, git-write from task
+      (check-not-false (member 'file-write caps))
+      (check-not-false (member 'shell-exec caps))
+      (check-not-false (member 'git-write caps))
+      (check-equal? (length caps) 3))
+
     ;; ── Integration: enriched data makes §6.1 and §6.2 work ──
 
     (test-case "enriched ctx with .rkt files has file-write capability (enables §6.2)"
@@ -103,8 +200,6 @@
       ;; With no capabilities, should-skip-verification? returns #f (conservative)
       (define plan (make-test-plan #:files '()))
       (define ctx (build-enriched-plan-ctx "." plan 0))
-      ;; capabilities-used is '() (empty list) — should-skip-verification? returns #f
-      ;; because it requires capabilities-used to be truthy AND not contain dangerous caps
       (check-equal? (hash-ref ctx 'capabilities-used) '()))))
 
 (run-tests suite)


### PR DESCRIPTION
## W1: Enhanced Capability Inference (§6.1/§6.2 Production-Ready)

### Production Code (`extensions/gsd/plan-context-builder.rkt`)

| Feature | Description |
|---------|-------------|
| `FILE-EXTENSION->CAPABILITY` | 11-entry table: `.rkt`→file-write, `.sh`→shell-exec, `.md`→file-write, etc. |
| `infer-capabilities-from-files` (enhanced) | Rewritten to use the extension table. Now detects `shell-exec` from `.sh` files |
| `infer-capabilities-from-tasks` (NEW) | Regex heuristic scanning task names/actions for shell/bash/command/git/commit/push keywords |
| `get-test-summary` (NEW) | Reads cached `.planning/test-results.txt` or returns descriptive message (was hardcoded "tests not run") |
| `build-enriched-plan-ctx` (updated) | Now combines file-based AND task-based inference via `remove-duplicates(append(...))` |

### Tests (`tests/test-plan-context-enrichment.rkt`)
- 11 new tests (26 total, up from 15)
- Tests cover: `.sh`→shell-exec, `.md`→file-write, multi-type inference, deduplication, task-text→shell-exec, task-text→git-write, combined file+task capabilities, descriptive test-summary

### Verification
- ✅ All 26 enrichment tests pass
- ✅ All verifier tests pass (complexity-heuristic: 16/16, risk-threshold: 9/9, gate: 20/20)
- ✅ `raco make main.rkt` passes with clean bytecode

Closes #8224