### PR TITLE
W0: Approval Channel Infrastructure (#8235)

### DIFF
--- a/tests/test-approval-channel.rkt
+++ b/tests/test-approval-channel.rkt
@@ -1,0 +1,91 @@
+#lang racket/base
+
+;; @speed fast
+;; @suite default
+
+;; tests/test-approval-channel.rkt
+;; v0.99.25 W0 §5.3: Tests for the HITL approval channel infrastructure.
+
+(require rackunit
+         rackunit/text-ui
+         racket/async-channel
+         "../tui/approval-channel.rkt")
+
+(define suite
+  (test-suite "HITL Approval Channel Infrastructure (v0.99.25 W0)"
+
+    ;; ── make-approval-channel ──
+
+    (test-case "make-approval-channel returns approval-channel?"
+      (define ch (make-approval-channel))
+      (check-true (approval-channel? ch)))
+
+    (test-case "make-approval-channel with custom timeout"
+      (define ch (make-approval-channel #:timeout-ms 5000))
+      (check-equal? (approval-channel-timeout-ms ch) 5000))
+
+    (test-case "make-approval-channel default timeout is 120000"
+      (define ch (make-approval-channel))
+      (check-equal? (approval-channel-timeout-ms ch) 120000))
+
+    (test-case "approval-channel-ch returns an async-channel"
+      (define ch (make-approval-channel))
+      (check-true (async-channel? (approval-channel-ch ch))))
+
+    ;; ── current-approval-channel (box) ──
+
+    (test-case "current-approval-channel is #f by default (non-interactive)"
+      (clear-approval-channel!)
+      (check-false (current-approval-channel)))
+
+    (test-case "set-approval-channel! then current-approval-channel returns it"
+      (clear-approval-channel!)
+      (define ch (make-approval-channel))
+      (set-approval-channel! ch)
+      (check-eq? (current-approval-channel) ch)
+      (clear-approval-channel!))
+
+    (test-case "clear-approval-channel! resets to #f"
+      (define ch (make-approval-channel))
+      (set-approval-channel! ch)
+      (clear-approval-channel!)
+      (check-false (current-approval-channel)))
+
+    ;; ── approval-await-result ──
+
+    (test-case "approval-await-result returns #t with no channel (non-interactive)"
+      (clear-approval-channel!)
+      (check-true (approval-await-result)))
+
+    (test-case "approval-await-result returns #f on timeout (no channel-put)"
+      (clear-approval-channel!)
+      (define ch (make-approval-channel #:timeout-ms 50))
+      (set-approval-channel! ch)
+      (check-false (approval-await-result))
+      (clear-approval-channel!))
+
+    ;; ── approval-put! + approval-await-result (cross-thread) ──
+
+    (test-case "approval-put! puts #t then await returns #t"
+      (clear-approval-channel!)
+      (define ch (make-approval-channel #:timeout-ms 5000))
+      (set-approval-channel! ch)
+      (approval-put! #t)
+      (check-true (approval-await-result))
+      (clear-approval-channel!))
+
+    (test-case "approval-put! puts #f then await returns #f"
+      (clear-approval-channel!)
+      (define ch (make-approval-channel #:timeout-ms 5000))
+      (set-approval-channel! ch)
+      (approval-put! #f)
+      (check-false (approval-await-result))
+      (clear-approval-channel!))
+
+    (test-case "approval-put! is no-op when no channel set"
+      (clear-approval-channel!)
+      (approval-put! #t)
+      (approval-put! #f)
+      (check-true #t))))
+
+(run-tests suite)

--- a/tools/builtins/spawn-subagent.rkt
+++ b/tools/builtins/spawn-subagent.rkt
@@ -16,6 +16,7 @@
          "../../tools/tool.rkt"
          (only-in "../../util/capability.rkt" valid-capability?)
          (only-in "../../runtime/runtime-helpers.rkt" emit-session-event! make-event-bus)
+         (only-in "../../tui/approval-channel.rkt" current-approval-channel approval-await-result)
          (only-in "../../runtime/settings.rkt" q-settings? setting-ref)
          "../model-bridge.rkt"
          (only-in "provider-hash-bridge.rkt"
@@ -143,9 +144,15 @@
                        (if (and (string? task-desc) (> (string-length task-desc) 200))
                            (substring task-desc 0 200)
                            (or task-desc "")))))
-  ;; Consult the approval result parameter.
-  ;; Default #t (permissive). TUI mode would set this based on user response.
-  (current-spawn-approval-result))
+  ;; v0.99.25 §5.3: Check for approval channel (TUI interactive mode).
+  ;; When a channel is set, block until user responds (with timeout).
+  ;; When no channel (non-interactive mode), use the permissive parameter.
+  (define ch (current-approval-channel))
+  (if ch
+      ;; Interactive: block until user responds or timeout
+      (approval-await-result)
+      ;; Non-interactive: use permissive parameter (default #t)
+      (current-spawn-approval-result)))
 
 ;; Default role prompt when no role is specified
 (define default-role-prompt

--- a/tui/approval-channel.rkt
+++ b/tui/approval-channel.rkt
@@ -1,0 +1,102 @@
+#lang racket/base
+
+;; tui/approval-channel.rkt — HITL approval synchronization
+;; STABILITY: evolving
+;;
+;; v0.99.25 §5.3: Channel-based blocking mechanism for HITL approval.
+;; The tool execution thread (session) blocks on channel-get while
+;; the TUI main thread collects user input and puts the result.
+;;
+;; Uses async-channel: put is non-blocking, get blocks with timeout.
+;;
+;; Thread-safety:
+;;   - Uses a module-level box, NOT a parameter. Racket parameters are
+;;     NOT inherited by child threads. The session thread spawned by
+;;     handle-user-submit! wouldn't see a parameterized value.
+;;   - Boxes ARE shared across threads (heap-allocated mutable cells).
+;;
+;; Deadlock safety:
+;;   - Session thread runs in (thread ...) spawned by submit-handler.rkt
+;;   - TUI main loop uses sync/timeout 0 — never blocks
+;;   - async-channel-get has a timeout (default 120s) to prevent permanent hang
+
+(require racket/contract
+         racket/async-channel)
+
+(provide (contract-out [approval-channel? (-> any/c boolean?)]
+                       [make-approval-channel
+                        (->* () (#:timeout-ms exact-nonnegative-integer?) approval-channel?)]
+                       [approval-channel-ch (-> approval-channel? async-channel?)]
+                       [approval-channel-timeout-ms (-> approval-channel? exact-nonnegative-integer?)]
+                       [set-approval-channel! (-> (or/c approval-channel? #f) void?)]
+                       [clear-approval-channel! (-> void?)]
+                       [current-approval-channel (-> (or/c approval-channel? #f))]
+                       [approval-await-result (->* () () boolean?)])
+         approval-put!
+         DEFAULT-APPROVAL-TIMEOUT-MS)
+
+;; ============================================================
+;; Approval channel struct
+;; ============================================================
+
+;; The async-channel carries boolean? values: #t = approved, #f = denied.
+(struct approval-channel (ch timeout-ms) #:transparent)
+
+;; ============================================================
+;; Module-level box (thread-safe shared state)
+;; ============================================================
+
+;; The box is set once during TUI init and read by spawn-subagent.
+;; When #f (non-interactive mode: CLI, JSON, RPC), approval is permissive.
+(define current-approval-channel-box (box #f))
+
+;; Default timeout: 120 seconds (2 minutes).
+(define DEFAULT-APPROVAL-TIMEOUT-MS 120000)
+
+;; ============================================================
+;; Public API
+;; ============================================================
+
+(define (make-approval-channel #:timeout-ms [timeout-ms DEFAULT-APPROVAL-TIMEOUT-MS])
+  (approval-channel (make-async-channel) timeout-ms))
+
+;; Set the shared approval channel (called by TUI init).
+(define (set-approval-channel! ch)
+  (set-box! current-approval-channel-box ch)
+  (void))
+
+;; Clear the shared approval channel (called on TUI teardown).
+(define (clear-approval-channel!)
+  (set-box! current-approval-channel-box #f)
+  (void))
+
+;; Read the current shared approval channel.
+;; Returns #f in non-interactive mode.
+(define (current-approval-channel)
+  (unbox current-approval-channel-box))
+
+;; Await approval result from the TUI.
+;; Blocks the calling thread (session) until the TUI puts a result.
+;; Returns #t (approved) or #f (denied/timeout).
+;; When no channel is set (non-interactive mode), returns #t (permissive).
+(define (approval-await-result)
+  (define ch (current-approval-channel))
+  (cond
+    [(not ch) #t] ; Non-interactive: permissive
+    [else
+     (define timeout-secs (/ (approval-channel-timeout-ms ch) 1000.0))
+     (define ach (approval-channel-ch ch))
+     (define result (sync/timeout timeout-secs ach))
+     ;; sync/timeout returns #f on timeout, or the channel value.
+     ;; Channel values are #t (approved) or #f (denied).
+     ;; On timeout, return #f (deny). On denial, also #f. Both safe.
+     (if result result #f)]))
+
+;; Put an approval result onto the channel (called by TUI key handler).
+;; Non-blocking: async-channel-put never blocks.
+;; Returns void. If no channel is set, this is a no-op.
+(define (approval-put! result)
+  (define ch (current-approval-channel))
+  (when ch
+    (async-channel-put (approval-channel-ch ch) result))
+  (void))


### PR DESCRIPTION
## W0: Approval Channel Infrastructure

### New Module: `tui/approval-channel.rkt`
- **async-channel** based (non-blocking put, blocking get with timeout)
- **Module-level box** for thread-safe shared state (parameters are NOT inherited by child threads)
- `approval-await-result` blocks session thread with 120s timeout → deny
- `approval-put!` non-blocking put from TUI key handler
- `set/clear-approval-channel!` for TUI init/teardown

### Updated: `tools/builtins/spawn-subagent.rkt`
- `request-spawn-approval` now checks `current-approval-channel`
- Interactive: blocks on `approval-await-result`
- Non-interactive: falls through to permissive parameter (unchanged)

### Tests: 12 unit tests — ALL PASS
### Existing: 15 spawn-approval tests — ALL PASS (no regressions)

Closes #8235