### PR TITLE
W2: TUI Approval Overlay Key Handler (#8237)

### DIFF
--- a/tests/test-tui-approval-keyhandler.rkt
+++ b/tests/test-tui-approval-keyhandler.rkt
@@ -1,0 +1,179 @@
+#lang racket
+
+;; @speed fast  ;; @suite tui
+
+;; tests/test-tui-approval-keyhandler.rkt
+;; v0.99.25 W2 §5.3: Tests for the TUI approval overlay key handler.
+;;
+;; Tests verify:
+;; - 'y' key approves and dismisses overlay
+;; - 'n' key denies and dismisses overlay
+;; - Escape cancels (denies) and dismisses overlay
+;; - Unrecognized keys pass through when approval overlay is active
+;; - Handler returns 'pass when no approval overlay is active
+;; - Handler returns 'pass for other overlay types (tree-browser)
+
+(require rackunit
+         rackunit/text-ui
+         racket/struct
+         (only-in "../tui/tui-keybindings.rkt"
+                  make-tui-ctx
+                  tui-ctx?
+                  tui-ctx-ui-state-box
+                  handle-approval-overlay-key)
+         "../tui/state-types.rkt"
+         (only-in "../tui/approval-channel.rkt"
+                  make-approval-channel
+                  set-approval-channel!
+                  clear-approval-channel!
+                  current-approval-channel
+                  approval-channel-ch
+                  approval-put!))
+
+;; ── Helpers ──
+
+(define (make-test-ctx)
+  (make-tui-ctx #:session-runner void #:event-bus #f #:session-queue #f))
+
+(define (state-with-approval-overlay)
+  (struct-copy ui-state
+               (initial-ui-state)
+               [active-overlay
+                (overlay-state 'approval-prompt
+                               '()
+                               ""
+                               'top-left
+                               #f
+                               #f
+                               0
+                               (hasheq 'capabilities '(shell-exec) 'task-preview "test"))]))
+
+(define (state-with-tree-overlay)
+  (struct-copy ui-state
+               (initial-ui-state)
+               [active-overlay (overlay-state 'tree-browser '() "" 'top-left #f #f 0 #f)]))
+
+(define (state-without-overlay)
+  (initial-ui-state))
+
+;; Set up and tear down approval channel for each test
+(define (with-approval-channel thunk)
+  (dynamic-wind (lambda () (set-approval-channel! (make-approval-channel)))
+                thunk
+                (lambda () (clear-approval-channel!))))
+
+(define (get-approval-result)
+  (define ch (current-approval-channel))
+  (and ch (sync/timeout 0.1 (approval-channel-ch ch))))
+
+;; ── Test Suite ──
+
+(define suite
+  (test-suite "TUI Approval Overlay Key Handler (v0.99.25 W2)"
+
+    ;; ── Approve ──
+
+    (test-case "y key approves spawn"
+      (with-approval-channel (lambda ()
+                               (define ctx (make-test-ctx))
+                               (set-box! (tui-ctx-ui-state-box ctx) (state-with-approval-overlay))
+                               (define result (handle-approval-overlay-key ctx #\y))
+                               (check-equal? result 'handled)
+                               (check-equal? (get-approval-result) #t)
+                               (check-false (ui-state-active-overlay
+                                             (unbox (tui-ctx-ui-state-box ctx)))))))
+
+    (test-case "Y key (uppercase) approves spawn"
+      (with-approval-channel (lambda ()
+                               (define ctx (make-test-ctx))
+                               (set-box! (tui-ctx-ui-state-box ctx) (state-with-approval-overlay))
+                               (define result (handle-approval-overlay-key ctx #\Y))
+                               (check-equal? result 'handled)
+                               (check-equal? (get-approval-result) #t))))
+
+    (test-case "y symbol approves spawn"
+      (with-approval-channel (lambda ()
+                               (define ctx (make-test-ctx))
+                               (set-box! (tui-ctx-ui-state-box ctx) (state-with-approval-overlay))
+                               (define result (handle-approval-overlay-key ctx 'y))
+                               (check-equal? result 'handled)
+                               (check-equal? (get-approval-result) #t))))
+
+    ;; ── Deny ──
+
+    (test-case "n key denies spawn"
+      (with-approval-channel (lambda ()
+                               (define ctx (make-test-ctx))
+                               (set-box! (tui-ctx-ui-state-box ctx) (state-with-approval-overlay))
+                               (define result (handle-approval-overlay-key ctx #\n))
+                               (check-equal? result 'handled)
+                               (check-equal? (get-approval-result) #f)
+                               (check-false (ui-state-active-overlay
+                                             (unbox (tui-ctx-ui-state-box ctx)))))))
+
+    (test-case "N key (uppercase) denies spawn"
+      (with-approval-channel (lambda ()
+                               (define ctx (make-test-ctx))
+                               (set-box! (tui-ctx-ui-state-box ctx) (state-with-approval-overlay))
+                               (define result (handle-approval-overlay-key ctx #\N))
+                               (check-equal? result 'handled)
+                               (check-equal? (get-approval-result) #f))))
+
+    ;; ── Cancel (Escape) ──
+
+    (test-case "Escape cancels (denies) spawn"
+      (with-approval-channel (lambda ()
+                               (define ctx (make-test-ctx))
+                               (set-box! (tui-ctx-ui-state-box ctx) (state-with-approval-overlay))
+                               (define result (handle-approval-overlay-key ctx 'escape))
+                               (check-equal? result 'handled)
+                               (check-equal? (get-approval-result) #f)
+                               (check-false (ui-state-active-overlay
+                                             (unbox (tui-ctx-ui-state-box ctx)))))))
+
+    ;; ── Pass-through ──
+
+    (test-case "unrecognized key passes through"
+      (with-approval-channel (lambda ()
+                               (define ctx (make-test-ctx))
+                               (set-box! (tui-ctx-ui-state-box ctx) (state-with-approval-overlay))
+                               (define result (handle-approval-overlay-key ctx #\a))
+                               (check-equal? result 'pass)
+                               ;; Overlay should still be active
+                               (define ov
+                                 (ui-state-active-overlay (unbox (tui-ctx-ui-state-box ctx))))
+                               (check-not-false ov)
+                               (check-equal? (overlay-state-type ov) 'approval-prompt)
+                               ;; No result on channel
+                               (check-false (get-approval-result)))))
+
+    (test-case "returns 'pass when no overlay is active"
+      (define ctx (make-test-ctx))
+      (set-box! (tui-ctx-ui-state-box ctx) (state-without-overlay))
+      (define result (handle-approval-overlay-key ctx #\y))
+      (check-equal? result 'pass))
+
+    (test-case "returns 'pass for tree-browser overlay"
+      (with-approval-channel (lambda ()
+                               (define ctx (make-test-ctx))
+                               (set-box! (tui-ctx-ui-state-box ctx) (state-with-tree-overlay))
+                               (define result (handle-approval-overlay-key ctx #\y))
+                               (check-equal? result 'pass)
+                               ;; Tree overlay should still be active
+                               (define ov
+                                 (ui-state-active-overlay (unbox (tui-ctx-ui-state-box ctx))))
+                               (check-not-false ov)
+                               (check-equal? (overlay-state-type ov) 'tree-browser))))
+
+    ;; ── Multiple keys don't double-fire ──
+
+    (test-case "after approval, overlay is gone (no double-fire)"
+      (with-approval-channel (lambda ()
+                               (define ctx (make-test-ctx))
+                               (set-box! (tui-ctx-ui-state-box ctx) (state-with-approval-overlay))
+                               (handle-approval-overlay-key ctx #\y)
+                               ;; Second keypress should pass through (overlay dismissed)
+                               (define result2 (handle-approval-overlay-key ctx #\y))
+                               (check-equal? result2 'pass))))))
+
+(run-tests suite)

--- a/tui/message-dispatch.rkt
+++ b/tui/message-dispatch.rkt
@@ -25,26 +25,31 @@
      (cond
        [(eq? tree-result 'handled) (void)]
        [else
-        (define result (handle-key ctx keycode))
+        ;; v0.99.25 §5.3: Intercept approval-prompt overlay keys
+        (define approval-result (handle-approval-overlay-key ctx keycode))
         (cond
-          [(eq? result 'quit)
-           (set-box! (tui-ctx-running-box ctx) #f)
-           'quit]
-          [(and (list? result) (eq? (car result) 'submit))
-           (define raw-text (cadr result))
-           ;; G3.3: Expand !! inline bash prefix
-           (define text (expand-inline-bash raw-text (unbox (tui-ctx-last-prompt-box ctx))))
-           ;; Store prompt for /retry (#1378)
-           (set-box! (tui-ctx-last-prompt-box ctx) text)
-           (handle-user-submit! ctx text)]
-          [(and (list? result) (eq? (car result) 'command))
-           (define cmd (cadr result))
-           (define raw-text
-             (if (>= (length result) 3)
-                 (caddr result)
-                 ""))
-           (process-slash-command ctx cmd raw-text)]
-          [else (void)])])]
+          [(eq? approval-result 'handled) (void)]
+          [else
+           (define result (handle-key ctx keycode))
+           (cond
+             [(eq? result 'quit)
+              (set-box! (tui-ctx-running-box ctx) #f)
+              'quit]
+             [(and (list? result) (eq? (car result) 'submit))
+              (define raw-text (cadr result))
+              ;; G3.3: Expand !! inline bash prefix
+              (define text (expand-inline-bash raw-text (unbox (tui-ctx-last-prompt-box ctx))))
+              ;; Store prompt for /retry (#1378)
+              (set-box! (tui-ctx-last-prompt-box ctx) text)
+              (handle-user-submit! ctx text)]
+             [(and (list? result) (eq? (car result) 'command))
+              (define cmd (cadr result))
+              (define raw-text
+                (if (>= (length result) 3)
+                    (caddr result)
+                    ""))
+              (process-slash-command ctx cmd raw-text)]
+             [else (void)])])])]
     ;; Resize event: signal caller
     [(resize) 'resize]
     ;; Redraw command: mark dirty

--- a/tui/selection.rkt
+++ b/tui/selection.rkt
@@ -17,6 +17,7 @@
          "char-width.rkt"
          "terminal.rkt"
          "tree-view.rkt"
+         "approval-channel.rkt"
          "../util/event/event-bus.rkt")
 
 ;; ============================================================
@@ -207,7 +208,46 @@
   (set-box! (tui-ctx-ui-state-box ctx) (struct-copy ui-state state [active-overlay new-ov]))
   (mark-dirty! ctx))
 
+;; ============================================================
+;; Approval overlay key handling (v0.99.25 §5.3)
+;; ============================================================
+
+;; Handle key events when approval-prompt overlay is active.
+;; Returns 'handled (consumed), 'pass (not ours / unrecognized key).
+;;
+;; Keys:
+;;   y/Y — approve subagent spawn
+;;   n/N — deny subagent spawn
+;;   Esc — cancel (deny)
+(define (handle-approval-overlay-key ctx keycode)
+  (define state (unbox (tui-ctx-ui-state-box ctx)))
+  (define ov (ui-state-active-overlay state))
+  (cond
+    ;; Not our overlay type — pass through
+    [(not (and ov (eq? (overlay-state-type ov) 'approval-prompt))) 'pass]
+    ;; Approve: y or Y
+    [(or (eq? keycode #\y) (eq? keycode #\Y) (eq? keycode 'y))
+     (approval-put! #t)
+     (set-box! (tui-ctx-ui-state-box ctx) (dismiss-overlay state))
+     (mark-dirty! ctx)
+     'handled]
+    ;; Deny: n or N
+    [(or (eq? keycode #\n) (eq? keycode #\N) (eq? keycode 'n))
+     (approval-put! #f)
+     (set-box! (tui-ctx-ui-state-box ctx) (dismiss-overlay state))
+     (mark-dirty! ctx)
+     'handled]
+    ;; Cancel (deny): Escape
+    [(eq? keycode 'escape)
+     (approval-put! #f)
+     (set-box! (tui-ctx-ui-state-box ctx) (dismiss-overlay state))
+     (mark-dirty! ctx)
+     'handled]
+    ;; Unrecognized key — pass through
+    [else 'pass]))
+
 (provide selection-text
          handle-mouse
          handle-tree-overlay-key
-         update-tree-overlay!)
+         update-tree-overlay!
+         handle-approval-overlay-key)

--- a/tui/tui-keybindings.rkt
+++ b/tui/tui-keybindings.rkt
@@ -58,7 +58,8 @@
                   selection-text
                   handle-mouse
                   handle-tree-overlay-key
-                  update-tree-overlay!)
+                  update-tree-overlay!
+                  handle-approval-overlay-key)
          ;; W20: key dispatch extracted to keybindings/key-dispatch.rkt
          (only-in "keybindings/key-dispatch.rkt" dispatch-keymap-action handle-key)
          (prefix-in commands: "../tui/commands.rkt")
@@ -116,6 +117,7 @@
          ;; W16: re-exported from selection.rkt
          handle-tree-overlay-key
          update-tree-overlay!
+         handle-approval-overlay-key
          (contract-out
           [make-tui-ctx
            (->* ()


### PR DESCRIPTION
## W2: TUI Key Handler + Display

### New Handler: `handle-approval-overlay-key` in `selection.rkt`
- Intercepts keys when `'approval-prompt` overlay is active
- `y`/`Y` → approve (`approval-put! #t`) + dismiss overlay
- `n`/`N` → deny (`approval-put! #f`) + dismiss overlay  
- `Escape` → cancel/deny (`approval-put! #f`) + dismiss overlay
- Other keys → pass through (return `'pass`)
- Non-approval overlays → pass through (return `'pass`)

### Wiring
- Re-exported through `tui-keybindings.rkt` (following tree-overlay pattern)
- Wired into `message-dispatch.rkt` as second intercept after tree overlay and before normal `handle-key` dispatch

### Tests: 10 new — ALL PASS
- `y`/`Y`/symbol-`y` approve and dismiss
- `n`/`N` deny and dismiss
- Escape cancels and dismisses
- Unrecognized keys pass through (overlay stays active)
- No overlay → pass
- Tree-browser overlay → pass
- No double-fire after approval

Closes #8237