### PR TITLE
W0: Audit Remediation (#8249)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,13 +75,14 @@ replaces the previous always-permissive behavior with a user-controlled gate.
 - W3: 10 new tests (integration tests)
 - 42 new tests total across 4 waves
 - All 57 approval-related tests pass (42 new + 15 pre-existing)
-- 45 TUI smoke tests pass (no regressions)
+- 44 TUI smoke tests pass (no regressions)
 
 ### Operational / Release
 - Version bumped to 0.99.25.
 - 1 new production module (`tui/approval-channel.rkt`).
-- 7 production files changed (approval-channel, spawn-subagent, core-handlers,
-  message-layout, selection, tui-keybindings, message-dispatch, tui-init).
+- 8 production files changed (1 new + 7 modified):
+  approval-channel (NEW), spawn-subagent, core-handlers,
+  message-layout, selection, tui-keybindings, message-dispatch, tui-init.
 - 4 new test files.
 - `raco make main.rkt` passes with clean bytecode.
 

--- a/tests/test-approval-channel-teardown.rkt
+++ b/tests/test-approval-channel-teardown.rkt
@@ -1,0 +1,79 @@
+#lang racket
+
+;; @speed fast
+;; @suite tui
+
+;; tests/test-approval-channel-teardown.rkt
+;; v0.99.26 W0 E-2: Verify exception-safe channel cleanup.
+;;
+;; The fix wraps run-tui-loop in dynamic-wind so that
+;; clear-approval-channel! runs even when an exception propagates.
+;; This test verifies the channel-clearing behavior at the
+;; approval-channel module level (dynamic-wind integration is
+;; tested via build verification + existing TUI test suites).
+
+(require rackunit
+         rackunit/text-ui
+         (only-in "../tui/approval-channel.rkt"
+                  make-approval-channel
+                  set-approval-channel!
+                  clear-approval-channel!
+                  current-approval-channel
+                  approval-put!
+                  approval-await-result))
+
+(define suite
+  (test-suite "Approval Channel Teardown (v0.99.26 W0 E-2)"
+
+    (test-case "channel is cleared after explicit clear call"
+      ;; Simulate TUI init
+      (set-approval-channel! (make-approval-channel))
+      (check-not-false (current-approval-channel))
+      ;; Simulate TUI teardown
+      (clear-approval-channel!)
+      (check-false (current-approval-channel)))
+
+    (test-case "channel is cleared even after simulated exception"
+      ;; Simulate TUI init
+      (set-approval-channel! (make-approval-channel))
+      (check-not-false (current-approval-channel))
+      ;; Simulate exception path with dynamic-wind cleanup
+      (with-handlers ([exn:fail? (lambda (_) (void))])
+        (dynamic-wind void
+                      (lambda () (raise (exn:fail "simulated crash" (current-continuation-marks))))
+                      (lambda () (clear-approval-channel!))))
+      ;; Channel should be cleared despite exception
+      (check-false (current-approval-channel)))
+
+    (test-case "channel works correctly after re-init following exception"
+      ;; First session crashes
+      (set-approval-channel! (make-approval-channel))
+      (with-handlers ([exn:fail? (lambda (_) (void))])
+        (dynamic-wind void
+                      (lambda () (raise (exn:fail "crash" (current-continuation-marks))))
+                      (lambda () (clear-approval-channel!))))
+      (check-false (current-approval-channel))
+      ;; Second session starts fresh
+      (set-approval-channel! (make-approval-channel))
+      (check-not-false (current-approval-channel))
+      ;; Approval works in new session
+      (define result-box (box #f))
+      (define t (thread (lambda () (set-box! result-box (approval-await-result)))))
+      (sleep 0.05)
+      (approval-put! #t)
+      (thread-wait t)
+      (check-equal? (unbox result-box) #t)
+      (clear-approval-channel!))
+
+    (test-case "stale channel from crashed session does not block"
+      ;; Simulate: session 1 crashes, channel cleared, session 2 non-interactive
+      (set-approval-channel! (make-approval-channel))
+      (with-handlers ([exn:fail? (lambda (_) (void))])
+        (dynamic-wind void
+                      (lambda () (raise (exn:fail "crash" (current-continuation-marks))))
+                      (lambda () (clear-approval-channel!))))
+      ;; Non-interactive: no channel → permissive
+      (check-false (current-approval-channel))
+      (check-equal? (approval-await-result) #t))))
+
+(run-tests suite)

--- a/tui/tui-init.rkt
+++ b/tui/tui-init.rkt
@@ -348,10 +348,13 @@
   (define-values (ctx sess scrollback-path) (create-tui-session rt-config cli-cfg))
   (load-tui-scrollback ctx sess rt-config scrollback-path)
   (init-tui-terminal ctx)
-  (run-tui-loop ctx scrollback-path)
-  ;; v0.99.25 §5.3: Clear approval channel on TUI teardown.
-  ;; Prevents stale channel from leaking to non-TUI modes after exit.
-  (clear-approval-channel!)
+  ;; v0.99.26 E-2: Wrap run-tui-loop in dynamic-wind to guarantee
+  ;; clear-approval-channel! runs on both normal exit AND exception paths.
+  ;; Without this, an unhandled exception in the TUI loop would leave
+  ;; the approval channel set, causing subsequent code to block.
+  (dynamic-wind void
+                (lambda () (run-tui-loop ctx scrollback-path))
+                (lambda () (clear-approval-channel!)))
   (displayln "Goodbye."))
 
 ;; Simple TUI run (for testing without full runtime)


### PR DESCRIPTION
## W0: Audit Remediation

### E-2 Fix: Exception-safe channel cleanup
Wrapped `run-tui-loop` in `dynamic-wind` so `clear-approval-channel!` runs on both normal exit AND exception paths.

### E-3 Fix: CHANGELOG test count
"45 TUI smoke tests" → "44 TUI smoke tests"

### E-4 Fix: CHANGELOG file count
"7 production files changed" → "8 production files changed (1 new + 7 modified)"

### Tests: 4 new (test-approval-channel-teardown.rkt)
- Channel cleared after explicit clear call
- Channel cleared even after simulated exception (dynamic-wind)
- Channel works after re-init following exception
- Stale channel from crashed session does not block

Closes #8249