### PR TITLE
W1: YAML-Subset Frontmatter Parser (#8250)

### DIFF
--- a/skills/frontmatter.rkt
+++ b/skills/frontmatter.rkt
@@ -6,9 +6,11 @@
 ;; Validates skill names and required fields per the Agent Skills standard.
 ;;
 ;; Provides:
-;;   valid-skill-name?         — check if a skill name conforms to the standard
-;;   parse-skill-frontmatter   — extract frontmatter hash from SKILL.md content
-;;   validate-frontmatter      — validate parsed frontmatter fields
+;;   valid-skill-name?                 — check if a skill name conforms to the standard
+;;   parse-skill-frontmatter           — extract flat frontmatter hash from SKILL.md content
+;;   parse-skill-frontmatter-extended  — parse YAML-subset (lists, nested maps, inline arrays)
+;;   validate-frontmatter              — validate parsed frontmatter fields
+;;   parse-fm-inline-array             — parse "[a, b, c]" → ("a" "b" "c")
 
 (require racket/string
          racket/list)
@@ -71,6 +73,199 @@
              (values k v))))]))
 
 ;; ============================================================
+;; Extended frontmatter parsing (v0.99.26 W1)
+;; ============================================================
+
+;; parse-skill-frontmatter-extended : string? -> (or/c hash? #f)
+;; Parses YAML-subset frontmatter supporting:
+;;   - Flat key: value (strings) — backward compatible
+;;   - Lists (- item syntax) with string items
+;;   - Nested maps within list items (- key: value + continuations)
+;;   - Inline arrays ([a, b, c])
+;; Returns a hash with mixed value types:
+;;   - Flat values: string?
+;;   - List values: (listof string?) or (listof hash?)
+;;   - Inline arrays: (listof string?)
+(define (parse-skill-frontmatter-extended content)
+  (define lines (string-split content "\n"))
+  (cond
+    [(< (length lines) 3) #f]
+    [(not (string=? (string-trim (car lines)) "---")) #f]
+    [else
+     (define rest (cdr lines))
+     (define end-idx
+       (for/first ([line (in-list rest)]
+                   [i (in-naturals)]
+                   #:when (string=? (string-trim line) "---"))
+         i))
+     (if (not end-idx)
+         #f
+         (let ()
+           (define fm-lines (take rest end-idx))
+           (define tokens (tokenize-fm-lines fm-lines))
+           (if (null? tokens)
+               #f
+               (let-values ([(result _remaining) (parse-fm-mapping tokens 0)])
+                 result))))]))
+
+;; --- Tokenizer ---
+
+;; tokenize-fm-lines : (listof string?) -> (listof (list/c exact-nonnegative-integer? string?))
+;; Converts raw frontmatter lines into (indent content) pairs,
+;; filtering out blank lines and comments.
+(define (tokenize-fm-lines lines)
+  (filter-map (lambda (line)
+                (define trimmed (string-trim line))
+                (cond
+                  [(string=? trimmed "") #f]
+                  [(regexp-match? #rx"^#" trimmed) #f]
+                  [else (list (fm-count-indent line) trimmed)]))
+              lines))
+
+;; fm-count-indent : string? -> exact-nonnegative-integer?
+;; Counts leading space characters (tabs not supported, per YAML spec).
+(define (fm-count-indent line)
+  (- (string-length line) (string-length (string-trim line #:left? #t #:right? #f))))
+
+;; --- Inline array parser ---
+
+;; parse-fm-inline-array : string? -> (listof string?)
+;; Parses "[a, b, c]" → ("a" "b" "c").
+;; Strips surrounding quotes from each element.
+(define (parse-fm-inline-array str)
+  (define trimmed (string-trim str))
+  (cond
+    [(and (string-prefix? trimmed "[") (string-suffix? trimmed "]"))
+     (define inner (substring trimmed 1 (- (string-length trimmed) 1)))
+     (define inner-trimmed (string-trim inner))
+     (if (string=? inner-trimmed "")
+         '()
+         (map (lambda (s) (fm-strip-quotes (string-trim s))) (string-split inner-trimmed ",")))]
+    [else (list trimmed)]))
+
+;; --- Key-value parser ---
+
+;; parse-fm-kv : string? -> (or/c (cons/c symbol? string?) #f)
+;; Parses "key: value" → (cons 'key "value").
+;; Returns #f if the string doesn't match key: value syntax.
+(define (parse-fm-kv content)
+  (define m (regexp-match #rx"^([a-zA-Z_-]+):\\s*(.*)$" content))
+  (and m (cons (string->symbol (cadr m)) (fm-strip-quotes (string-trim (caddr m))))))
+
+;; fm-strip-quotes : string? -> string?
+;; Removes surrounding single or double quotes if present.
+(define (fm-strip-quotes s)
+  (define len (string-length s))
+  (cond
+    [(and (>= len 2)
+          (or (and (string-prefix? s "\"") (string-suffix? s "\""))
+              (and (string-prefix? s "'") (string-suffix? s "'"))))
+     (substring s 1 (- len 1))]
+    [else s]))
+
+;; --- Recursive descent parser ---
+
+;; parse-fm-mapping : tokens exact-nonnegative-integer? -> (values hash? tokens)
+;; Parses key:value pairs at indent >= min-indent until dedent or list item.
+(define (parse-fm-mapping tokens min-indent)
+  (define result (make-hash))
+  (let loop ([ts tokens])
+    (cond
+      [(null? ts) (values (fm-freeze result) '())]
+      [else
+       (define tok (car ts))
+       (define indent (car tok))
+       (define content (cadr tok))
+       (cond
+         ;; Dedent → end of mapping
+         [(< indent min-indent) (values (fm-freeze result) ts)]
+         ;; List item → not part of this mapping
+         [(string-prefix? content "- ") (values (fm-freeze result) ts)]
+         ;; Key: value or key: (children)
+         [else
+          (define kv (parse-fm-kv content))
+          (cond
+            [(not kv) (loop (cdr ts))]
+            [else
+             (define key (car kv))
+             (define value (cdr kv))
+             (cond
+               ;; Inline array: key: [a, b, c]
+               [(string-prefix? value "[")
+                (hash-set! result key (parse-fm-inline-array value))
+                (loop (cdr ts))]
+               ;; Scalar: key: value
+               [(not (string=? value ""))
+                (hash-set! result key value)
+                (loop (cdr ts))]
+               ;; Children: key: (empty → indented block)
+               [else
+                (define-values (child-val remaining) (parse-fm-children (cdr ts) indent))
+                (hash-set! result key child-val)
+                (loop remaining)])])])])))
+
+;; parse-fm-children : tokens exact-nonnegative-integer? -> (values any/c tokens)
+;; Parses children of a key with empty value.
+;; Returns a list (for `- ` items) or a nested hash (for indented key:value).
+(define (parse-fm-children tokens parent-indent)
+  (cond
+    [(null? tokens) (values "" '())]
+    [else
+     (define tok (car tokens))
+     (define indent (car tok))
+     (define content (cadr tok))
+     (cond
+       [(<= indent parent-indent) (values "" tokens)]
+       [(string-prefix? content "- ") (parse-fm-list tokens parent-indent)]
+       [else
+        ;; Nested mapping
+        (define-values (child-map remaining) (parse-fm-mapping tokens (+ parent-indent 1)))
+        (values child-map remaining)])]))
+
+;; parse-fm-list : tokens exact-nonnegative-integer? -> (values list tokens)
+;; Parses a list of `- ` items until dedent.
+(define (parse-fm-list tokens parent-indent)
+  (let loop ([ts tokens]
+             [items '()])
+    (cond
+      [(null? ts) (values (reverse items) '())]
+      [else
+       (define tok (car ts))
+       (define indent (car tok))
+       (define content (cadr tok))
+       (cond
+         [(<= indent parent-indent) (values (reverse items) ts)]
+         [(not (string-prefix? content "- ")) (values (reverse items) ts)]
+         [else
+          (define-values (item remaining) (parse-fm-list-item ts))
+          (loop remaining (cons item items))])])))
+
+;; parse-fm-list-item : tokens -> (values any/c tokens)
+;; Parses one `- ...` item.
+;; A list item is either a plain string or a map (key:value on same line
+;; with continuation lines at the same column).
+(define (parse-fm-list-item tokens)
+  (define tok (car tokens))
+  (define indent (car tok))
+  (define content (cadr tok))
+  (define item-content (substring content 2))
+  (define continuation-indent (+ indent 2))
+  (define kv (parse-fm-kv item-content))
+  (cond
+    ;; Map item: synthesize token at continuation-indent and parse mapping
+    [kv
+     (define synthetic-tokens (cons (list continuation-indent item-content) (cdr tokens)))
+     (define-values (item-map remaining) (parse-fm-mapping synthetic-tokens continuation-indent))
+     (values item-map remaining)]
+    ;; Plain string item
+    [else (values item-content (cdr tokens))]))
+
+;; fm-freeze : mutable-hash? -> immutable-hash?
+(define (fm-freeze h)
+  (for/hash ([(k v) (in-hash h)])
+    (values k v)))
+
+;; ============================================================
 ;; Frontmatter validation
 ;; ============================================================
 
@@ -91,4 +286,6 @@
 
 (provide valid-skill-name?
          parse-skill-frontmatter
-         validate-frontmatter)
+         parse-skill-frontmatter-extended
+         validate-frontmatter
+         parse-fm-inline-array)

--- a/tests/test-frontmatter-extended.rkt
+++ b/tests/test-frontmatter-extended.rkt
@@ -1,0 +1,163 @@
+#lang racket
+
+;; @speed fast
+;; @suite skills
+
+;; tests/test-frontmatter-extended.rkt
+;; v0.99.26 W1: Extended frontmatter parser tests.
+;; Tests YAML-subset parsing: flat values, lists, nested maps, inline arrays.
+
+(require rackunit
+         rackunit/text-ui
+         "../skills/frontmatter.rkt")
+
+(define suite
+  (test-suite "Extended Frontmatter Parser (v0.99.26 W1)"
+
+    ;; ---- Flat key:value (backward compatible) ----
+    (test-case "flat key:value parsed as strings"
+      (define fm
+        (parse-skill-frontmatter-extended
+         "---\nname: my-skill\ndescription: A test skill\n---\nbody"))
+      (check-not-false fm)
+      (check-equal? (hash-ref fm 'name) "my-skill")
+      (check-equal? (hash-ref fm 'description) "A test skill"))
+
+    ;; ---- Quoted values ----
+    (test-case "quoted values stripped"
+      (define fm
+        (parse-skill-frontmatter-extended
+         "---\nname: \"my-skill\"\ndescription: 'A test skill'\n---\n"))
+      (check-equal? (hash-ref fm 'name) "my-skill")
+      (check-equal? (hash-ref fm 'description) "A test skill"))
+
+    ;; ---- Inline arrays ----
+    (test-case "inline array parsed as list of strings"
+      (define fm
+        (parse-skill-frontmatter-extended
+         "---\nname: test\ntags: [research, analysis, report]\n---\n"))
+      (check-equal? (hash-ref fm 'tags) '("research" "analysis" "report")))
+
+    (test-case "inline array with quoted elements"
+      (define fm
+        (parse-skill-frontmatter-extended "---\nname: test\ntags: [\"alpha\", 'beta', gamma]\n---\n"))
+      (check-equal? (hash-ref fm 'tags) '("alpha" "beta" "gamma")))
+
+    (test-case "empty inline array"
+      (define fm (parse-skill-frontmatter-extended "---\nname: test\ntags: []\n---\n"))
+      (check-equal? (hash-ref fm 'tags) '()))
+
+    ;; ---- List of strings ----
+    (test-case "list of string items"
+      (define fm
+        (parse-skill-frontmatter-extended "---\nname: test\nvariables:\n  - topic\n  - depth\n---\n"))
+      (check-equal? (hash-ref fm 'variables) '("topic" "depth")))
+
+    ;; ---- List of maps (steps) ----
+    (test-case "list of maps with role and task"
+      (define fm
+        (parse-skill-frontmatter-extended (string-append "---\n"
+                                                         "name: research-workflow\n"
+                                                         "steps:\n"
+                                                         "  - role: researcher\n"
+                                                         "    task: Find information\n"
+                                                         "  - role: writer\n"
+                                                         "    task: Write report\n"
+                                                         "---\n")))
+      (define steps (hash-ref fm 'steps))
+      (check-pred list? steps)
+      (check-equal? (length steps) 2)
+      (check-equal? (hash-ref (car steps) 'role) "researcher")
+      (check-equal? (hash-ref (car steps) 'task) "Find information")
+      (check-equal? (hash-ref (cadr steps) 'role) "writer")
+      (check-equal? (hash-ref (cadr steps) 'task) "Write report"))
+
+    ;; ---- List of maps with nested list ----
+    (test-case "list of maps with nested capabilities list"
+      (define fm
+        (parse-skill-frontmatter-extended (string-append "---\n"
+                                                         "name: complex-workflow\n"
+                                                         "steps:\n"
+                                                         "  - role: researcher\n"
+                                                         "    task: Research topic\n"
+                                                         "    capabilities:\n"
+                                                         "      - read-only\n"
+                                                         "      - network\n"
+                                                         "  - role: writer\n"
+                                                         "    task: Write report\n"
+                                                         "    capabilities:\n"
+                                                         "      - read-only\n"
+                                                         "---\n")))
+      (define steps (hash-ref fm 'steps))
+      (check-equal? (length steps) 2)
+      (define step1 (car steps))
+      (check-equal? (hash-ref step1 'role) "researcher")
+      (check-equal? (hash-ref step1 'capabilities) '("read-only" "network"))
+      (define step2 (cadr steps))
+      (check-equal? (hash-ref step2 'capabilities) '("read-only")))
+
+    ;; ---- Comments and blank lines ----
+    (test-case "comments and blank lines ignored"
+      (define fm
+        (parse-skill-frontmatter-extended (string-append "---\n"
+                                                         "# This is a comment\n"
+                                                         "name: test\n"
+                                                         "\n"
+                                                         "description: A skill\n"
+                                                         "---\n")))
+      (check-not-false fm)
+      (check-equal? (hash-ref fm 'name) "test")
+      (check-equal? (hash-ref fm 'description) "A skill"))
+
+    ;; ---- Error cases ----
+    (test-case "no frontmatter returns #f"
+      (check-false (parse-skill-frontmatter-extended "no frontmatter here")))
+
+    (test-case "missing closing --- returns #f"
+      (check-false (parse-skill-frontmatter-extended "---\nname: test\nbut no closing")))
+
+    ;; ---- Full mas-workflow frontmatter ----
+    (test-case "full mas-workflow frontmatter"
+      (define fm
+        (parse-skill-frontmatter-extended
+         (string-append "---\n"
+                        "name: research-and-write\n"
+                        "description: Research a topic then write a report\n"
+                        "type: mas-workflow\n"
+                        "steps:\n"
+                        "  - role: researcher\n"
+                        "    task: Research {{topic}} and gather key findings\n"
+                        "    capabilities:\n"
+                        "      - read-only\n"
+                        "      - network\n"
+                        "  - role: writer\n"
+                        "    task: Write a report based on {{result}}\n"
+                        "    capabilities:\n"
+                        "      - read-only\n"
+                        "variables:\n"
+                        "  - topic\n"
+                        "tags: [research, writing, mas-workflow]\n"
+                        "---\n")))
+      (check-equal? (hash-ref fm 'name) "research-and-write")
+      (check-equal? (hash-ref fm 'type) "mas-workflow")
+      (define steps (hash-ref fm 'steps))
+      (check-equal? (length steps) 2)
+      (check-equal? (hash-ref (car steps) 'role) "researcher")
+      (check-equal? (hash-ref (cadr steps) 'task) "Write a report based on {{result}}")
+      (check-equal? (hash-ref fm 'variables) '("topic"))
+      (check-equal? (hash-ref fm 'tags) '("research" "writing" "mas-workflow")))
+
+    ;; ---- 4-space indentation ----
+    (test-case "4-space indentation works"
+      (define fm
+        (parse-skill-frontmatter-extended (string-append "---\n"
+                                                         "name: test\n"
+                                                         "steps:\n"
+                                                         "    - role: planner\n"
+                                                         "      task: Make a plan\n"
+                                                         "---\n")))
+      (define steps (hash-ref fm 'steps))
+      (check-equal? (length steps) 1)
+      (check-equal? (hash-ref (car steps) 'role) "planner"))))
+
+(run-tests suite)


### PR DESCRIPTION
## W1: YAML-Subset Frontmatter Parser

### New: `parse-skill-frontmatter-extended` in `skills/frontmatter.rkt`

Supports:
- **Flat key:value** (backward compatible)
- **Lists** (`- item` syntax)
- **Nested maps** within list items (`- key: value` + continuation lines)
- **Inline arrays** (`[a, b, c]`)
- **Quoted values** (single/double quotes stripped)
- **Comments** and blank lines filtered

### Implementation
Recursive descent parser with `(indent, content)` token stream. List items with key:value on same line use a synthetic token trick: inject the first key:value at continuation-indent, then `parse-mapping` handles the rest including nested children.

### Tests: 13 new (test-frontmatter-extended.rkt)
- Flat key:value, quoted values
- Inline arrays (normal, quoted, empty)
- List of strings
- List of maps (role/task)
- List of maps with nested capabilities list
- Comments and blank lines ignored
- Error cases (no frontmatter, missing closing ---)
- Full mas-workflow frontmatter
- 4-space indentation

Closes #8250