### PR TITLE
W1b: Subagent Reliability Fixes (#8259)

### DIFF
--- a/tests/test-execution-plane-error-label.rkt
+++ b/tests/test-execution-plane-error-label.rkt
@@ -1,0 +1,79 @@
+#lang racket
+
+;; @speed fast
+;; @suite tools
+
+;; tests/test-execution-plane-error-label.rkt
+;; v0.99.26 W1b: Verify F-2 fix — error messages from tool execution
+;; show stderr and exit code instead of generic "execution plane error".
+
+(require rackunit
+         rackunit/text-ui
+         "../tools/tool.rkt"
+         "../tools/scheduler.rkt"
+         "../sandbox/ipc-protocol.rkt")
+
+(define suite
+  (test-suite "Execution Plane Error Label Fix (v0.99.26 W1b F-2)"
+
+    (test-case "status 'error with stderr shows command failed message"
+      (define resp
+        (ipc-response "req-1"
+                      'error
+                      #f
+                      (hasheq 'exit-code 2 'stderr "find: missing argument")
+                      "command exited with code 2"
+                      1))
+      (define result (ipc-response->tool-result resp))
+      (check-true (tool-result-is-error? result))
+      (define content (tool-result-content result))
+      (define msg
+        (if (list? content)
+            (hash-ref (car content) 'text "")
+            (format "~a" content)))
+      (check-true (string-contains? msg "command failed") "should say 'command failed'")
+      (check-true (string-contains? msg "exit 2") "should include exit code")
+      (check-true (string-contains? msg "find: missing argument") "should include stderr"))
+
+    (test-case "status 'error without details falls back to err-msg"
+      (define resp (ipc-response "req-2" 'error #f #f "some error message" 1))
+      (define result (ipc-response->tool-result resp))
+      (check-true (tool-result-is-error? result))
+      (define content (tool-result-content result))
+      (define msg
+        (if (list? content)
+            (hash-ref (car content) 'text "")
+            (format "~a" content)))
+      (check-true (string-contains? msg "command failed") "should say 'command failed'")
+      (check-true (string-contains? msg "some error message") "should include error message"))
+
+    (test-case "status 'ok returns success"
+      (define resp (ipc-response "req-3" 'ok "operation succeeded" #f #f 1))
+      (define result (ipc-response->tool-result resp))
+      (check-false (tool-result-is-error? result)))
+
+    (test-case "status 'timeout returns timeout message"
+      (define resp (ipc-response "req-4" 'timeout #f #f "request timed out" 1))
+      (define result (ipc-response->tool-result resp))
+      (check-true (tool-result-is-error? result))
+      (define content (tool-result-content result))
+      (define msg
+        (if (list? content)
+            (hash-ref (car content) 'text "")
+            (format "~a" content)))
+      (check-true (string-contains? msg "timed out") "should mention timeout"))
+
+    (test-case "status 'error with exit-code 1"
+      (define resp
+        (ipc-response "req-5" 'error #f (hasheq 'exit-code 1 'stderr "permission denied") "exit 1" 1))
+      (define result (ipc-response->tool-result resp))
+      (check-true (tool-result-is-error? result))
+      (define content (tool-result-content result))
+      (define msg
+        (if (list? content)
+            (hash-ref (car content) 'text "")
+            (format "~a" content)))
+      (check-true (string-contains? msg "exit 1") "should include exit code 1")
+      (check-true (string-contains? msg "permission denied") "should include stderr"))))
+
+(run-tests suite)

--- a/tests/test-mas-spawn-subagent-facade.rkt
+++ b/tests/test-mas-spawn-subagent-facade.rkt
@@ -83,9 +83,9 @@
       (define cfg (parse-subagent-config (hasheq 'task "do something")))
       (check-equal? (subagent-config-task cfg) "do something"))
 
-    (test-case "parse-subagent-config: default max-turns is 5"
+    (test-case "parse-subagent-config: default max-turns is 10"
       (define cfg (parse-subagent-config (hasheq 'task "test")))
-      (check-equal? (subagent-config-max-turns cfg) 5))
+      (check-equal? (subagent-config-max-turns cfg) 10))
 
     (test-case "parse-subagent-config: custom max-turns"
       (define cfg (parse-subagent-config (hasheq 'task "test" 'max-turns 10)))

--- a/tests/test-subagent-config.rkt
+++ b/tests/test-subagent-config.rkt
@@ -35,6 +35,6 @@
 (test-case "parse-subagent-config with defaults"
   (define cfg (parse-subagent-config (hasheq 'task "hello")))
   (check-equal? (subagent-config-task cfg) "hello")
-  (check-equal? (subagent-config-max-turns cfg) 5)
+  (check-equal? (subagent-config-max-turns cfg) 10) ; F-1b: default raised from 5 to 10
   (check-false (subagent-config-tools cfg))
   (check-false (subagent-config-model cfg)))

--- a/tests/test-subagent-retry.rkt
+++ b/tests/test-subagent-retry.rkt
@@ -1,0 +1,84 @@
+#lang racket
+
+;; @speed fast
+;; @suite tools
+
+;; tests/test-subagent-retry.rkt
+;; v0.99.26 W1b: Verify subagent auto-retry (F-1a) and max-turns default (F-1b).
+
+(require rackunit
+         rackunit/text-ui
+         "../tools/builtins/spawn-subagent.rkt"
+         "../tools/tool.rkt"
+         "../llm/provider.rkt"
+         "../llm/model.rkt"
+         "../util/ids.rkt")
+
+;; ── Mock provider that fails once then succeeds ──
+;; The first call raises a rate-limit error; subsequent calls succeed.
+;; This verifies that run-subagent-loop retries on transient errors.
+
+(define (make-retry-provider)
+  (define calls-box (box 0))
+  (define provider
+    (make-provider
+     (lambda () "retry-test-mock")
+     (lambda () (hasheq 'streaming #t))
+     (lambda (req)
+       (define n (unbox calls-box))
+       (set-box! calls-box (add1 n))
+       (if (= n 0)
+           ;; First call: simulate transient connection error (fast retry)
+           (raise (exn:fail "connection reset by peer" (current-continuation-marks)))
+           ;; Second call: success
+           (make-model-response (list (hasheq 'type "text" 'text "Task completed after retry."))
+                                (hasheq 'prompt-tokens 10 'completion-tokens 5 'total-tokens 15)
+                                "mock-model"
+                                'stop)))
+     (lambda (req) (error 'retry-test-mock "streaming not supported"))))
+  (values provider calls-box))
+
+;; ── Mock provider that always succeeds ──
+
+(define (make-always-success-provider)
+  (make-mock-provider
+   (make-model-response (list (hasheq 'type "text" 'text "Success on first try."))
+                        (hasheq 'prompt-tokens 10 'completion-tokens 5 'total-tokens 15)
+                        "mock-model"
+                        'stop)
+   #:name "mock-success"))
+
+(define (make-test-exec-ctx provider)
+  (make-exec-context #:working-directory (current-directory)
+                     #:runtime-settings (hasheq 'provider provider 'model "mock-model")))
+
+(define suite
+  (test-suite "Subagent Reliability Fixes (v0.99.26 W1b)"
+
+    ;; ---- F-1b: Default max-turns = 10 ----
+    (test-case "parse-subagent-config default max-turns is 10"
+      (define cfg (parse-subagent-config (hasheq 'task "test task")))
+      (check-equal? (subagent-config-max-turns cfg) 10))
+
+    (test-case "parse-subagent-config explicit max-turns respected"
+      (define cfg (parse-subagent-config (hasheq 'task "test task" 'max-turns 3)))
+      (check-equal? (subagent-config-max-turns cfg) 3))
+
+    ;; ---- F-1a: Subagent retries on transient provider error ----
+    ;; Uses "connection reset" which triggers fast (1s) retry backoff.
+    (test-case "subagent retries on transient provider error"
+      (define-values (provider calls-box) (make-retry-provider))
+      (define exec-ctx (make-test-exec-ctx provider))
+      (define cfg (subagent-config "Simple task" "assistant" 5 #f #f #f))
+      (define result (run-subagent-with-config cfg exec-ctx))
+      (check-false (tool-result-is-error? result) "result should not be an error after retry")
+      (check-true (> (unbox calls-box) 1) "provider-send should have been called more than once"))
+
+    (test-case "subagent succeeds without retry when no errors"
+      (define provider (make-always-success-provider))
+      (define exec-ctx (make-test-exec-ctx provider))
+      (define cfg (subagent-config "Simple task" "assistant" 5 #f #f #f))
+      (define result (run-subagent-with-config cfg exec-ctx))
+      (check-false (tool-result-is-error? result)))))
+
+(run-tests suite)

--- a/tools/builtins/spawn-subagent.rkt
+++ b/tools/builtins/spawn-subagent.rkt
@@ -18,6 +18,7 @@
          (only-in "../../runtime/runtime-helpers.rkt" emit-session-event! make-event-bus)
          (only-in "../../tui/approval-channel.rkt" current-approval-channel approval-await-result)
          (only-in "../../runtime/settings.rkt" q-settings? setting-ref)
+         (only-in "../../runtime/auto-retry.rkt" with-auto-retry)
          "../model-bridge.rkt"
          (only-in "provider-hash-bridge.rkt"
                   message->provider-hash
@@ -198,7 +199,7 @@
       [else #f]))
   (subagent-config (hash-ref args 'task #f)
                    (resolve-role-prompt (hash-ref args 'role default-role-prompt))
-                   (hash-ref args 'max-turns 5)
+                   (hash-ref args 'max-turns 10)
                    (hash-ref args 'tools #f)
                    (hash-ref args 'model #f)
                    (and caps (pair? caps) caps)))
@@ -562,7 +563,13 @@
        ;; jsexpr->bytes on the request body, which rejects Racket structs.
        (define provider-msgs (messages->provider-hashes msgs))
        (define req (make-model-request provider-msgs (list-active-tools-jsexpr registry) (hasheq)))
-       (define resp (provider-send provider req))
+       ;; F-1a (v0.99.26): Wrap provider-send in auto-retry so subagents
+       ;; survive rate-limiting and transient timeouts. Without this,
+       ;; a single 429 kills the subagent immediately while the parent
+       ;; agent retries silently.
+       (define resp
+         (with-auto-retry (lambda () (provider-send provider req))
+                          #:per-type-budgets (hash 'timeout 2 'rate-limit 4 'provider-error 2)))
        (define content (model-response-content resp))
        ;; Build assistant message from response content parts
        (define content-parts
@@ -640,7 +647,7 @@
   (define task (hash-ref job 'task #f))
   (define role-prompt (hash-ref job 'role (hash-ref job 'rolePrompt #f)))
   (define model-name (or (hash-ref job 'model #f) (resolve-model-name parent-ctx job)))
-  (define max-turns (hash-ref job 'max-turns 5))
+  (define max-turns (hash-ref job 'max-turns 10))
   ;; v0.99.22 A-2: Parse capabilities from job hash (mirrors parse-subagent-config)
   (define caps (parse-job-capabilities job))
   (define result

--- a/tools/scheduler.rkt
+++ b/tools/scheduler.rkt
@@ -119,6 +119,7 @@
          scheduler-batch-stats-errors
          scheduler-batch-stats->hash
          run-preflight
+         ipc-response->tool-result
          (contract-out [run-tool-batch
                         (->* ((listof tool-call?) tool-registry?)
                              (#:hook-dispatcher (or/c procedure? #f)
@@ -288,6 +289,13 @@
     [(ok) (make-success-result (or content "ok") details)]
     [(timeout) (make-error-result (format "tool execution timed out: ~a" (or err-msg "")))]
     [(crashed) (make-error-result (format "worker crashed: ~a" (or err-msg "")))]
+    ;; F-2 (v0.99.26): Tool ran but returned non-zero exit (e.g., bash syntax error).
+    ;; Show stderr and exit code so the agent can diagnose the failure.
+    [(error)
+     (define stderr (and details (hash? details) (hash-ref details 'stderr #f)))
+     (define exit-code (and details (hash? details) (hash-ref details 'exit-code #f)))
+     (make-error-result
+      (format "command failed (exit ~a): ~a" (or exit-code "?") (or stderr err-msg "unknown")))]
     [else (make-error-result (format "execution plane error: ~a" (or err-msg "unknown")))]))
 
 ;; ============================================================


### PR DESCRIPTION
## W1b: Subagent Reliability Fixes (F-1a/F-1b/F-2)

### F-1a (CRITICAL): Auto-retry for subagent provider calls
Wrap `provider-send` in `with-auto-retry` inside `run-subagent-loop`. Subagents now survive rate-limited and transient provider errors instead of dying immediately.

### F-1b: Default max-turns 5→10
Complex analysis tasks were exhausting 5 turns on tool calls alone. Updated defaults in `parse-subagent-config` and `run-single-job`.

### F-2: Error label fix
`ipc-response->tool-result` now handles `status='error` separately, showing `"command failed (exit N): <stderr>"` instead of generic `"execution plane error"`.

### Tests: 9 new
- `test-subagent-retry.rkt`: 4 tests (F-1a retry verification, F-1b defaults)
- `test-execution-plane-error-label.rkt`: 5 tests (F-2 error labels)
- Updated `test-subagent-config.rkt` and `test-mas-spawn-subagent-facade.rkt` for new default

Closes #8259