### PR TITLE
W2: MAS Workflow Types + Parser (#8251)

### DIFF
--- a/skills/mas-workflow.rkt
+++ b/skills/mas-workflow.rkt
@@ -1,0 +1,135 @@
+#lang racket/base
+
+;; skills/mas-workflow.rkt — MAS workflow skill type
+;; STABILITY: evolving
+;;
+;; v0.99.26 §5.2: Defines the data structures and parser for
+;; mas-workflow skills. A mas-workflow skill packages a multi-agent
+;; pipeline as a declarative spec in SKILL.md frontmatter.
+;;
+;; The frontmatter format is:
+;;
+;;   ---
+;;   type: mas-workflow
+;;   agents:
+;;     - role: analyst
+;;       task: "Read and summarize {{file}}"
+;;       capabilities: [read-only]
+;;     - role: reviewer
+;;       task: "Review the summary: {{result}}"
+;;       capabilities: [read-only]
+;;   ---
+;;
+;; This module handles parsing + validation only. Execution is in
+;; skills/workflow-executor.rkt (W3).
+
+(require racket/string
+         racket/list)
+
+;; ============================================================
+;; Structs
+;; ============================================================
+
+;; A single step in a multi-agent workflow pipeline.
+;; role:         string? — agent role (used as system prompt or skill name)
+;; task:         string? — task description (supports {{var}} templates)
+;; capabilities: (or/c (listof symbol?) #f) — capability filter for child tools
+;; parallel?:    boolean? — if #t, run this step in parallel with siblings
+(struct workflow-step (role task capabilities parallel?) #:transparent)
+
+;; A complete parsed mas-workflow.
+;; name:        string?
+;; description: string?
+;; steps:       (listof workflow-step?)
+;; variables:   (listof string?) — template vars detected in tasks (e.g., "file")
+(struct mas-workflow (name description steps variables) #:transparent)
+
+;; ============================================================
+;; Parser
+;; ============================================================
+
+;; parse-mas-workflow : string? string? hash? -> (values (or/c mas-workflow? #f) (or/c string? #f))
+;; Parse frontmatter hash into a mas-workflow.
+;; Returns (values workflow error) where error is #f on success,
+;; or an error message string on failure.
+(define (parse-mas-workflow name description frontmatter)
+  (define agents-raw (hash-ref frontmatter 'agents #f))
+  (cond
+    [(not agents-raw) (values #f "mas-workflow requires 'agents' field")]
+    [(not (list? agents-raw)) (values #f "'agents' must be a list")]
+    [(null? agents-raw) (values #f "'agents' list must not be empty")]
+    [else
+     (define steps
+       (for/list ([agent (in-list agents-raw)])
+         (workflow-step (hash-ref agent 'role "assistant")
+                        (hash-ref agent 'task "")
+                        (parse-capabilities (hash-ref agent 'capabilities #f))
+                        (hash-ref agent 'parallel #f))))
+     ;; Validate: every step must have a non-empty task
+     (define empty-tasks (filter (lambda (s) (string=? (workflow-step-task s) "")) steps))
+     (cond
+       [(not (null? empty-tasks)) (values #f "every workflow step must have a 'task'")]
+       [else
+        (define vars (extract-template-variables steps))
+        (values (mas-workflow name description steps vars) #f)])]))
+
+;; ============================================================
+;; Template variable extraction
+;; ============================================================
+
+;; extract-template-variables : (listof workflow-step?) -> (listof string?)
+;; Extract {{var}} references from all step tasks.
+;; Returns a deduplicated list of variable names (without braces).
+;; Note: {{result}} is a built-in variable, but it IS included in the
+;; list so the executor can track all referenced variables.
+(define (extract-template-variables steps)
+  (remove-duplicates (for*/list ([step (in-list steps)]
+                                 [m (in-list (regexp-match* #rx"\\{\\{([^}]+)\\}\\}"
+                                                            (workflow-step-task step)
+                                                            #:match-select cadr))])
+                       (string-trim m))))
+
+;; ============================================================
+;; Capability parsing
+;; ============================================================
+
+;; parse-capabilities : (or/c list? #f) -> (or/c (listof symbol?) #f)
+;; Parse capabilities field: ("read-only" "file-write") → '(read-only file-write)
+;; Returns #f when input is #f, empty, or contains no valid strings.
+(define (parse-capabilities caps-raw)
+  (cond
+    [(not caps-raw) #f]
+    [(list? caps-raw)
+     (define parsed (filter-map (lambda (c) (and (string? c) (string->symbol c))) caps-raw))
+     (if (null? parsed) #f parsed)]
+    [else #f]))
+
+;; ============================================================
+;; Utility predicates
+;; ============================================================
+
+;; workflow-has-result-chaining? : mas-workflow? -> boolean?
+;; Returns #t if any step references {{result}} (indicating sequential chaining).
+(define (workflow-has-result-chaining? wf)
+  (ormap (lambda (v) (string=? v "result")) (mas-workflow-variables wf)))
+
+;; ============================================================
+;; Exports
+;; ============================================================
+
+(provide workflow-step
+         workflow-step?
+         workflow-step-role
+         workflow-step-task
+         workflow-step-capabilities
+         workflow-step-parallel?
+         mas-workflow
+         mas-workflow?
+         mas-workflow-name
+         mas-workflow-description
+         mas-workflow-steps
+         mas-workflow-variables
+         parse-mas-workflow
+         extract-template-variables
+         parse-capabilities
+         workflow-has-result-chaining?)

--- a/tests/test-mas-workflow.rkt
+++ b/tests/test-mas-workflow.rkt
@@ -1,0 +1,190 @@
+#lang racket
+
+;; @speed fast
+;; @suite skills
+
+;; tests/test-mas-workflow.rkt
+;; v0.99.26 W2: MAS Workflow Types + Parser tests.
+
+(require rackunit
+         rackunit/text-ui
+         "../skills/mas-workflow.rkt"
+         "../skills/frontmatter.rkt")
+
+;; Helper: parse a SKILL.md frontmatter string and return the extended hash.
+(define (parse-fm content)
+  (parse-skill-frontmatter-extended content))
+
+;; Helper: build a complete SKILL.md string with frontmatter.
+(define (skill-with-frontmatter . fm-lines)
+  (string-append "---\n" (string-join fm-lines "\n") "\n---\n"))
+
+(define suite
+  (test-suite "MAS Workflow Types + Parser (v0.99.26 W2)"
+
+    ;; ── Struct construction ──
+
+    (test-case "workflow-step struct construction"
+      (define step (workflow-step "analyst" "Analyze {{file}}" '(read-only) #f))
+      (check-equal? (workflow-step-role step) "analyst")
+      (check-equal? (workflow-step-task step) "Analyze {{file}}")
+      (check-equal? (workflow-step-capabilities step) '(read-only))
+      (check-false (workflow-step-parallel? step)))
+
+    (test-case "mas-workflow struct construction"
+      (define wf (mas-workflow "test-wf" "A test workflow" '() '()))
+      (check-equal? (mas-workflow-name wf) "test-wf")
+      (check-equal? (mas-workflow-description wf) "A test workflow")
+      (check-equal? (mas-workflow-steps wf) '())
+      (check-equal? (mas-workflow-variables wf) '()))
+
+    ;; ── parse-mas-workflow: valid workflows ──
+
+    (test-case "parse valid workflow with 3 steps"
+      (define fm
+        (parse-fm (skill-with-frontmatter "type: mas-workflow"
+                                          "agents:"
+                                          "  - role: analyst"
+                                          "    task: Read and summarize {{file}}"
+                                          "  - role: reviewer"
+                                          "    task: Review the summary for {{result}}"
+                                          "  - role: writer"
+                                          "    task: Write up the final report")))
+      (define-values (wf err) (parse-mas-workflow "my-wf" "description" fm))
+      (check-false err)
+      (check-true (mas-workflow? wf))
+      (check-equal? (mas-workflow-name wf) "my-wf")
+      (check-equal? (length (mas-workflow-steps wf)) 3)
+      (check-equal? (workflow-step-role (car (mas-workflow-steps wf))) "analyst")
+      (check-equal? (workflow-step-role (cadr (mas-workflow-steps wf))) "reviewer")
+      (check-equal? (workflow-step-role (caddr (mas-workflow-steps wf))) "writer"))
+
+    (test-case "parse workflow with inline array capabilities"
+      (define fm
+        (parse-fm (skill-with-frontmatter "type: mas-workflow"
+                                          "agents:"
+                                          "  - role: researcher"
+                                          "    task: Research {{topic}}"
+                                          "    capabilities: [read-only, network]")))
+      (define-values (wf err) (parse-mas-workflow "research" "desc" fm))
+      (check-false err)
+      (define step (car (mas-workflow-steps wf)))
+      (check-equal? (workflow-step-capabilities step) '(read-only network)))
+
+    (test-case "parse workflow with list-form capabilities"
+      (define fm
+        (parse-fm (skill-with-frontmatter "type: mas-workflow"
+                                          "agents:"
+                                          "  - role: coder"
+                                          "    task: Fix the bug"
+                                          "    capabilities:"
+                                          "      - read-only"
+                                          "      - file-write")))
+      (define-values (wf err) (parse-mas-workflow "fixer" "desc" fm))
+      (check-false err)
+      (define step (car (mas-workflow-steps wf)))
+      (check-equal? (workflow-step-capabilities step) '(read-only file-write)))
+
+    (test-case "default role when not specified"
+      (define fm
+        (parse-fm (skill-with-frontmatter "type: mas-workflow" "agents:" "  - task: Do something")))
+      (define-values (wf err) (parse-mas-workflow "test" "desc" fm))
+      (check-false err)
+      (define step (car (mas-workflow-steps wf)))
+      (check-equal? (workflow-step-role step) "assistant"))
+
+    ;; ── parse-mas-workflow: validation failures ──
+
+    (test-case "reject workflow without agents field"
+      (define fm (hasheq 'type "mas-workflow"))
+      (define-values (wf err) (parse-mas-workflow "test" "desc" fm))
+      (check-false wf)
+      (check-true (string-contains? err "agents")))
+
+    (test-case "reject step without task"
+      (define fm
+        (parse-fm (skill-with-frontmatter "type: mas-workflow" "agents:" "  - role: analyst")))
+      (define-values (wf err) (parse-mas-workflow "test" "desc" fm))
+      (check-false wf)
+      (check-true (string-contains? err "task")))
+
+    (test-case "reject empty agents list"
+      (define fm (hasheq 'agents '()))
+      (define-values (wf err) (parse-mas-workflow "test" "desc" fm))
+      (check-false wf)
+      (check-true (string-contains? err "empty")))
+
+    ;; ── extract-template-variables ──
+
+    (test-case "extract template variables from tasks"
+      (define steps
+        (list (workflow-step "a" "Read {{file}}" #f #f)
+              (workflow-step "b" "Review {{result}} for {{issue}}" #f #f)))
+      (define vars (extract-template-variables steps))
+      (check-equal? (sort vars string<?) '("file" "issue" "result")))
+
+    (test-case "deduplicate repeated variables"
+      (define steps
+        (list (workflow-step "a" "Read {{file}}" #f #f) (workflow-step "b" "Process {{file}}" #f #f)))
+      (define vars (extract-template-variables steps))
+      (check-equal? vars '("file")))
+
+    (test-case "no variables in task"
+      (define steps (list (workflow-step "a" "Just a static task" #f #f)))
+      (define vars (extract-template-variables steps))
+      (check-equal? vars '()))
+
+    ;; ── parse-capabilities ──
+
+    (test-case "parse-capabilities from strings"
+      (check-equal? (parse-capabilities '("read-only" "network")) '(read-only network)))
+
+    (test-case "parse-capabilities #f returns #f"
+      (check-false (parse-capabilities #f)))
+
+    (test-case "parse-capabilities empty list returns #f"
+      (check-false (parse-capabilities '())))
+
+    (test-case "parse-capabilities filters non-strings"
+      (check-equal? (parse-capabilities '("read-only" 42 #f "file-write")) '(read-only file-write)))
+
+    ;; ── workflow-has-result-chaining? ──
+
+    (test-case "workflow-has-result-chaining? true"
+      (define steps
+        (list (workflow-step "a" "Step 1" #f #f) (workflow-step "b" "Review {{result}}" #f #f)))
+      (define wf (mas-workflow "test" "desc" steps '("result")))
+      (check-true (workflow-has-result-chaining? wf)))
+
+    (test-case "workflow-has-result-chaining? false"
+      (define steps (list (workflow-step "a" "Step 1" #f #f) (workflow-step "b" "Step 2" #f #f)))
+      (define wf (mas-workflow "test" "desc" steps '()))
+      (check-false (workflow-has-result-chaining? wf)))
+
+    ;; ── Full end-to-end parse from SKILL.md content ──
+
+    (test-case "full SKILL.md → mas-workflow parse"
+      (define skill-content
+        (string-append "---\n"
+                       "type: mas-workflow\n"
+                       "agents:\n"
+                       "  - role: researcher\n"
+                       "    task: Research {{topic}} and find sources\n"
+                       "    capabilities: [read-only, network]\n"
+                       "  - role: writer\n"
+                       "    task: Write a summary based on {{result}}\n"
+                       "    capabilities:\n"
+                       "      - read-only\n"
+                       "---\n"
+                       "# Research and Write\n\n"
+                       "This workflow does research then writes it up."))
+      (define fm (parse-fm skill-content))
+      (check-true (hash? fm))
+      (define-values (wf err) (parse-mas-workflow "research-and-write" "desc" fm))
+      (check-false err)
+      (check-true (mas-workflow? wf))
+      (check-equal? (length (mas-workflow-steps wf)) 2)
+      (check-true (and (member "topic" (mas-workflow-variables wf)) #t) "should have topic var")
+      (check-true (and (member "result" (mas-workflow-variables wf)) #t) "should have result var"))))
+
+(run-tests suite)


### PR DESCRIPTION
## W2: MAS Workflow Types + Parser

### New module: `skills/mas-workflow.rkt`

**Structs:**
- `workflow-step` (role, task, capabilities, parallel?)
- `mas-workflow` (name, description, steps, variables)

**Parser:**
- `parse-mas-workflow`: frontmatter hash → `(values mas-workflow? string?)`
  - Uses `parse-skill-frontmatter-extended` (from W1) for agents list parsing
  - Validates: agents present, non-empty, each step has task
  - Extracts template variables (`{{var}}`) from all step tasks
  - Parses capabilities: inline arrays `[a, b]` and list-form `- item`

**Helpers:**
- `extract-template-variables`: regex-based `{{var}}` extraction with dedup
- `parse-capabilities`: string list → symbol list (filters non-strings)
- `workflow-has-result-chaining?`: detects `{{result}}` usage

### Tests: 19 new (all pass)
`tests/test-mas-workflow.rkt` covers:
- Struct construction (workflow-step, mas-workflow)
- Valid workflow parsing (3 steps, capabilities, default role)
- Validation failures (missing agents, empty agents, missing task)
- Template variable extraction (dedup, multiple vars, no vars)
- Capability parsing (strings, #f, empty, non-string filtering)
- Result chaining detection
- Full SKILL.md → mas-workflow end-to-end parse

Closes #8251