### PR TITLE
W3: Workflow Executor (#8252)

### DIFF
--- a/skills/workflow-executor.rkt
+++ b/skills/workflow-executor.rkt
@@ -1,0 +1,157 @@
+#lang racket/base
+
+;; skills/workflow-executor.rkt — MAS workflow execution engine
+;; STABILITY: evolving
+;;
+;; v0.99.26 §5.2: Executes a parsed mas-workflow by spawning subagents
+;; in sequence, passing each step's result as context to the next step.
+;;
+;; Reuses run-subagent-with-config from spawn-subagent.rkt.
+;; Respects HITL approval for dangerous capabilities (v0.99.25).
+;;
+;; Execution model:
+;;   step1 → result1
+;;   step2(task: "Review: {{result}}", context: result1) → result2
+;;   step3(task: "Fix: {{result}}", context: result2) → result3
+;;   return aggregated result list
+;;
+;; Error stops the pipeline: remaining steps are skipped, partial
+;; results are returned.
+
+(require racket/string
+         racket/list
+         "mas-workflow.rkt"
+         "template.rkt"
+         (only-in "../tools/builtins/spawn-subagent.rkt" subagent-config run-subagent-with-config)
+         (only-in "../tools/tool.rkt"
+                  tool-result?
+                  tool-result-is-error?
+                  tool-result-content
+                  make-error-result
+                  make-success-result))
+
+;; ============================================================
+;; Workflow execution result
+;; ============================================================
+
+;; A single step's execution result.
+;; step:     exact-nonnegative-integer? — 0-indexed step number
+;; role:     string? — agent role used
+;; task:     string? — the rendered task that was executed
+;; success?: boolean? — whether the step completed without error
+;; result:   string? — extracted text result (empty on error)
+(struct workflow-step-result (step role task success? result) #:transparent)
+
+;; ============================================================
+;; Execution
+;; ============================================================
+
+;; execute-workflow : mas-workflow? hash? (or/c exec-context? #f) -> tool-result?
+;; Execute a mas-workflow sequentially.
+;; workflow:  mas-workflow?
+;; variables: hash? — user-provided variable substitutions (e.g., #hash((file . "test.rkt")))
+;; exec-ctx:  exec-context? (or #f for testing — provider resolution may fail)
+;; Returns: tool-result? — success result with step results as content,
+;;           or error result if any step fails.
+(define (execute-workflow workflow variables exec-ctx)
+  (define steps (mas-workflow-steps workflow))
+  (define step-results
+    (let loop ([remaining steps]
+               [idx 0]
+               [prev-result #f]
+               [acc '()])
+      (cond
+        [(null? remaining) (reverse acc)]
+        [else
+         (define step (car remaining))
+         (define rendered-task (render-step-task step variables prev-result))
+         (define cfg
+           (subagent-config rendered-task
+                            (workflow-step-role step)
+                            10 ; max-turns (F-1b default)
+                            #f ; tools (inherit defaults)
+                            #f ; model (inherit)
+                            (workflow-step-capabilities step)))
+         (define result (run-subagent-with-config cfg exec-ctx))
+         (define result-text (extract-result-text result))
+         (define step-result
+           (workflow-step-result idx
+                                 (workflow-step-role step)
+                                 rendered-task
+                                 (not (tool-result-is-error? result))
+                                 result-text))
+         (cond
+           ;; On error, stop pipeline and return partial results
+           [(tool-result-is-error? result) (reverse (cons step-result acc))]
+           [else (loop (cdr remaining) (add1 idx) result-text (cons step-result acc))])])))
+  ;; Build final result
+  (define all-success? (andmap workflow-step-result-success? step-results))
+  (if all-success?
+      (make-success-result
+       (hasheq 'workflow (mas-workflow-name workflow) 'steps (step-results->jsexpr step-results)))
+      (make-error-result (format "workflow '~a' failed at step ~a"
+                                 (mas-workflow-name workflow)
+                                 (find-failed-step-index step-results)))))
+
+;; ============================================================
+;; Helpers
+;; ============================================================
+
+;; render-step-task : workflow-step? hash? (or/c string? #f) -> string?
+;; Render a step's task with template variables and previous result.
+(define (render-step-task step variables prev-result)
+  (define base-task (workflow-step-task step))
+  (define vars-with-result (hash-set variables 'result (or prev-result "")))
+  (render-template base-task vars-with-result))
+
+;; extract-result-text : (or/c tool-result? #f) -> string?
+;; Extract text from a tool-result's content.
+(define (extract-result-text result)
+  (cond
+    [(not result) ""]
+    [(not (tool-result? result)) ""]
+    [else
+     (define content (tool-result-content result))
+     (cond
+       [(list? content)
+        (string-join (for/list ([c (in-list content)])
+                       (if (hash? c)
+                           (hash-ref c 'text "")
+                           (format "~a" c)))
+                     " ")]
+       [(string? content) content]
+       [else (format "~a" content)])]))
+
+;; step-results->jsexpr : (listof workflow-step-result?) -> (listof hash?)
+(define (step-results->jsexpr results)
+  (for/list ([r (in-list results)])
+    (hasheq 'step
+            (workflow-step-result-step r)
+            'role
+            (workflow-step-result-role r)
+            'success
+            (workflow-step-result-success? r)
+            'result
+            (workflow-step-result-result r))))
+
+;; find-failed-step-index : (listof workflow-step-result?) -> exact-nonnegative-integer?
+(define (find-failed-step-index results)
+  (define failed (findf (lambda (r) (not (workflow-step-result-success? r))) results))
+  (if failed
+      (workflow-step-result-step failed)
+      0))
+
+;; ============================================================
+;; Exports
+;; ============================================================
+
+(provide workflow-step-result
+         workflow-step-result?
+         workflow-step-result-step
+         workflow-step-result-role
+         workflow-step-result-task
+         workflow-step-result-success?
+         workflow-step-result-result
+         execute-workflow
+         render-step-task
+         extract-result-text)

--- a/tests/test-workflow-executor.rkt
+++ b/tests/test-workflow-executor.rkt
@@ -1,0 +1,158 @@
+#lang racket
+
+;; @speed fast
+;; @suite skills
+
+;; tests/test-workflow-executor.rkt
+;; v0.99.26 W3: Workflow Executor tests.
+
+(require rackunit
+         rackunit/text-ui
+         json
+         racket/string
+         "../skills/workflow-executor.rkt"
+         "../skills/mas-workflow.rkt"
+         "../tools/builtins/spawn-subagent.rkt"
+         "../tools/tool.rkt"
+         "../llm/provider.rkt"
+         "../llm/model.rkt")
+
+;; ── Mock providers ──
+
+(define (make-static-text-provider text)
+  (make-mock-provider
+   (make-model-response (list (hasheq 'type "text" 'text text))
+                        (hasheq 'prompt-tokens 10 'completion-tokens 5 'total-tokens 15)
+                        "mock-model"
+                        'stop)
+   #:name "mock"))
+
+(define (make-failing-provider)
+  (make-provider (lambda () "failing-mock")
+                 (lambda () (hasheq 'streaming #t))
+                 (lambda (req) (error 'failing-provider "simulated failure"))
+                 (lambda (req) (error 'failing-provider "streaming failed"))))
+
+(define (make-test-exec-ctx provider)
+  (make-exec-context #:working-directory (current-directory)
+                     #:runtime-settings (hasheq 'provider provider 'model "mock-model")))
+
+;; ── Test helpers ──
+
+(define (make-simple-workflow steps)
+  (define wf-steps
+    (for/list ([s (in-list steps)])
+      (workflow-step (hash-ref s 'role "assistant") (hash-ref s 'task "") #f #f)))
+  (mas-workflow "test-wf" "test desc" wf-steps '()))
+
+(define suite
+  (test-suite "Workflow Executor (v0.99.26 W3)"
+
+    ;; ── render-step-task ──
+
+    (test-case "render-step-task substitutes user variables"
+      (define step (workflow-step "analyst" "Analyze {{file}}" #f #f))
+      (define rendered (render-step-task step (hasheq 'file "test.rkt") #f))
+      (check-equal? rendered "Analyze test.rkt"))
+
+    (test-case "render-step-task substitutes {{result}} from previous step"
+      (define step (workflow-step "reviewer" "Review: {{result}}" #f #f))
+      (define rendered (render-step-task step (hasheq) "Previous output"))
+      (check-equal? rendered "Review: Previous output"))
+
+    (test-case "render-step-task leaves missing variables as-is"
+      (define step (workflow-step "analyst" "Analyze {{missing}}" #f #f))
+      (define rendered (render-step-task step (hasheq) #f))
+      (check-equal? rendered "Analyze {{missing}}"))
+
+    (test-case "render-step-task handles both user var and result"
+      (define step (workflow-step "analyst" "{{action}}: {{result}}" #f #f))
+      (define rendered (render-step-task step (hasheq 'action "Summarize") "the content"))
+      (check-equal? rendered "Summarize: the content"))
+
+    ;; ── extract-result-text ──
+
+    (test-case "extract-result-text from text content list"
+      (define result (make-success-result (list (hasheq 'type "text" 'text "Hello world"))))
+      (check-equal? (extract-result-text result) "Hello world"))
+
+    (test-case "extract-result-text from error result"
+      (define result (make-error-result "Something failed"))
+      (check-true (string? (extract-result-text result))))
+
+    (test-case "extract-result-text from #f"
+      (check-equal? (extract-result-text #f) ""))
+
+    ;; ── execute-workflow: integration with mock providers ──
+
+    (test-case "execute 2-step workflow with sequential chaining"
+      (define provider (make-static-text-provider "Step done"))
+      (define exec-ctx (make-test-exec-ctx provider))
+      (define wf
+        (make-simple-workflow (list (hasheq 'role "analyst" 'task "Read the file")
+                                    (hasheq 'role "reviewer" 'task "Review: {{result}}"))))
+      (define result (execute-workflow wf (hasheq) exec-ctx))
+      (check-false (tool-result-is-error? result) "workflow should succeed")
+      (define content (tool-result-content result))
+      (check-true (hash? content) "content should be a hash")
+      (check-equal? (hash-ref content 'workflow) "test-wf")
+      (define steps-hash (hash-ref content 'steps))
+      (check-equal? (length steps-hash) 2))
+
+    (test-case "execute workflow with template variable substitution"
+      (define provider (make-static-text-provider "Analysis complete"))
+      (define exec-ctx (make-test-exec-ctx provider))
+      (define wf (make-simple-workflow (list (hasheq 'role "analyst" 'task "Analyze {{file}}"))))
+      (define result (execute-workflow wf (hasheq 'file "src/main.rkt") exec-ctx))
+      (check-false (tool-result-is-error? result)))
+
+    (test-case "error in step stops pipeline"
+      (define provider (make-failing-provider))
+      (define exec-ctx (make-test-exec-ctx provider))
+      (define wf
+        (make-simple-workflow (list (hasheq 'role "step1" 'task "First task")
+                                    (hasheq 'role "step2" 'task "Second task")
+                                    (hasheq 'role "step3" 'task "Third task"))))
+      (define result (execute-workflow wf (hasheq) exec-ctx))
+      (check-true (tool-result-is-error? result) "should be error")
+      (define content (tool-result-content result))
+      ;; Error result content is a list of text parts, not a hash
+      (define msg
+        (if (list? content)
+            (hash-ref (car content) 'text "")
+            (format "~a" content)))
+      (check-true (string-contains? msg "failed") "should mention failure"))
+
+    (test-case "workflow capabilities passed to subagent-config"
+      ;; This test verifies that capabilities from workflow-step are used
+      ;; by creating a workflow with read-only capabilities
+      (define provider (make-static-text-provider "Done"))
+      (define exec-ctx (make-test-exec-ctx provider))
+      (define wf
+        (mas-workflow "caps-test"
+                      "desc"
+                      (list (workflow-step "analyst" "Do work" '(read-only) #f))
+                      '()))
+      (define result (execute-workflow wf (hasheq) exec-ctx))
+      (check-false (tool-result-is-error? result) "read-only should not trigger HITL denial"))
+
+    (test-case "role used in workflow steps"
+      (define provider (make-static-text-provider "Role check"))
+      (define exec-ctx (make-test-exec-ctx provider))
+      (define wf (make-simple-workflow (list (hasheq 'role "researcher" 'task "Research topic"))))
+      (define result (execute-workflow wf (hasheq) exec-ctx))
+      (check-false (tool-result-is-error? result))
+      (define content (tool-result-content result))
+      (when (hash? content)
+        (define steps-hash (hash-ref content 'steps))
+        (check-equal? (hash-ref (car steps-hash) 'role) "researcher")))
+
+    (test-case "workflow-step-result struct"
+      (define r (workflow-step-result 0 "analyst" "Do thing" #t "Done"))
+      (check-equal? (workflow-step-result-step r) 0)
+      (check-equal? (workflow-step-result-role r) "analyst")
+      (check-equal? (workflow-step-result-task r) "Do thing")
+      (check-true (workflow-step-result-success? r))
+      (check-equal? (workflow-step-result-result r) "Done"))))
+
+(run-tests suite)


### PR DESCRIPTION
## W3: Workflow Executor

### New module: `skills/workflow-executor.rkt`

Executes a parsed mas-workflow by spawning subagents sequentially, chaining results.

**Core function:** `execute-workflow(workflow, variables, exec-ctx)` → `tool-result?`

**Execution model:**
- Sequential: each step receives previous step's result as `{{result}}`
- Template variables: both user-provided (`{{file}}`) and built-in (`{{result}}`)
- Error stops pipeline: first failure halts remaining steps
- Reuses `run-subagent-with-config` — no new spawning code
- HITL approval flows through existing subagent infrastructure
- Capabilities from `workflow-step` passed to `subagent-config`

**Helper functions:**
- `render-step-task`: substitutes `{{var}}` and `{{result}}` templates
- `extract-result-text`: extracts text content from `tool-result`

### Tests: 13 new (all pass)
`tests/test-workflow-executor.rkt` covers:
- Template rendering (4 tests)
- Result text extraction (3 tests)
- Full execution with mock providers (3 tests)
- Capabilities pass-through
- Role usage verification
- Struct accessors

Closes #8252