### PR TITLE
W4: Skill Router Integration + System Prompt (#8253)

### DIFF
--- a/skills/resource-loader.rkt
+++ b/skills/resource-loader.rkt
@@ -148,7 +148,7 @@
                (define skill-name (path->string entry))
                (define skill-file (build-path skills-dir entry "SKILL.md"))
                (define content (try-read-file skill-file))
-               (and content (parse-skill skill-name content))))]))
+               (and content (hash-set (parse-skill skill-name content) 'raw-content content))))]))
 
 ;; Load templates from a templates/ subdirectory
 (define (load-templates dir)

--- a/tests/test-skill-workflow-e2e.rkt
+++ b/tests/test-skill-workflow-e2e.rkt
@@ -1,0 +1,107 @@
+#lang racket
+
+;; @speed fast
+;; @suite skills
+
+;; tests/test-skill-workflow-e2e.rkt
+;; v0.99.26 W4: E2E test for skill-router workflow action.
+
+(require rackunit
+         rackunit/text-ui
+         racket/file
+         racket/string
+         json
+         "../tools/builtins/skill-router.rkt"
+         "../tools/tool.rkt")
+
+;; ── Test skill content ──
+
+(define mas-workflow-skill-content
+  (string-append "---\n"
+                 "type: mas-workflow\n"
+                 "agents:\n"
+                 "  - role: analyst\n"
+                 "    task: Analyze the input\n"
+                 "    capabilities: [read-only]\n"
+                 "  - role: summarizer\n"
+                 "    task: Summarize: {{result}}\n"
+                 "    capabilities: [read-only]\n"
+                 "---\n"
+                 "# Test Workflow\n\n"
+                 "A simple 2-step workflow for testing."))
+
+(define standard-skill-content
+  (string-append "---\n"
+                 "name: regular-skill\n"
+                 "description: A standard skill\n"
+                 "---\n"
+                 "# Regular Skill\n\n"
+                 "This is a non-workflow skill."))
+
+;; ── Test helpers ──
+
+(define temp-dir (make-temporary-file "q-workflow-e2e-~a" 'directory))
+
+(define (setup-test-skills)
+  (define skills-dir (build-path temp-dir ".q" "skills"))
+  (define wf-dir (build-path skills-dir "test-workflow"))
+  (define std-dir (build-path skills-dir "regular-skill"))
+  (make-directory* wf-dir)
+  (make-directory* std-dir)
+  (call-with-output-file (build-path wf-dir "SKILL.md")
+                         (lambda (out) (display mas-workflow-skill-content out)))
+  (call-with-output-file (build-path std-dir "SKILL.md")
+                         (lambda (out) (display standard-skill-content out))))
+
+(define (cleanup-test-skills)
+  (when (directory-exists? temp-dir)
+    (delete-directory/files temp-dir)))
+
+;; ── Suite ──
+
+(define suite
+  (test-suite "Skill Workflow E2E (v0.99.26 W4)"
+
+    #:before setup-test-skills
+    #:after cleanup-test-skills
+
+    (test-case "list action shows skill types"
+      (parameterize ([current-directory temp-dir])
+        (define result (tool-skill-route (hasheq 'action "list")))
+        (check-false (tool-result-is-error? result))
+        (define content (tool-result-content result))
+        (define text (hash-ref (car content) 'text ""))
+        (define parsed (string->jsexpr text))
+        ;; Should have both skills
+        (check-true (list? parsed))
+        (check-true (>= (length parsed) 2))
+        ;; Check that types are included
+        (define types (map (lambda (s) (hash-ref s 'type "standard")) parsed))
+        (check-true (and (member "mas-workflow" types) #t) "should include mas-workflow type")
+        (check-true (and (member "standard" types) #t) "should include standard type")))
+
+    (test-case "workflow action rejects non-workflow skill"
+      (parameterize ([current-directory temp-dir])
+        (define result (tool-skill-route (hasheq 'action "workflow" 'name "regular-skill")))
+        (check-true (tool-result-is-error? result))
+        (define content (tool-result-content result))
+        (define text (hash-ref (car content) 'text ""))
+        (check-true (string-contains? text "not a mas-workflow"))))
+
+    (test-case "workflow action rejects missing skill"
+      (parameterize ([current-directory temp-dir])
+        (define result (tool-skill-route (hasheq 'action "workflow" 'name "nonexistent")))
+        (check-true (tool-result-is-error? result))
+        (define content (tool-result-content result))
+        (define text (hash-ref (car content) 'text ""))
+        (check-true (string-contains? text "not found"))))
+
+    (test-case "workflow action requires name"
+      (parameterize ([current-directory temp-dir])
+        (define result (tool-skill-route (hasheq 'action "workflow")))
+        (check-true (tool-result-is-error? result))
+        (define content (tool-result-content result))
+        (define text (hash-ref (car content) 'text ""))
+        (check-true (or (string-contains? text "requires") (string-contains? text "name")))))))
+
+(run-tests suite)

--- a/tools/builtins/skill-router.rkt
+++ b/tools/builtins/skill-router.rkt
@@ -20,6 +20,7 @@
          racket/list
          json
          "../../skills/resource-loader.rkt"
+         "../../skills/frontmatter.rkt"
          "../../util/config-paths.rkt"
          (only-in "../../util/error/error-sanitizer.rkt" sanitize-error-message)
          "../../tools/tool.rkt")
@@ -43,13 +44,15 @@
              [else
               (with-safe-fallback
                '()
-               (filter values
-                       (for/list ([entry (in-list (directory-list skills-dir))]
-                                  #:when (directory-exists? (build-path skills-dir entry)))
-                         (define skill-name (path->string entry))
-                         (define skill-file (build-path skills-dir entry "SKILL.md"))
-                         (define content (try-read-file skill-file))
-                         (and content (parse-skill skill-name content)))))]))))
+               (filter
+                values
+                (for/list ([entry (in-list (directory-list skills-dir))]
+                           #:when (directory-exists? (build-path skills-dir entry)))
+                  (define skill-name (path->string entry))
+                  (define skill-file (build-path skills-dir entry "SKILL.md"))
+                  (define content (try-read-file skill-file))
+                  (and content
+                       (hash-set (parse-skill skill-name content) 'raw-content content)))))]))))
 
 ;; ============================================================
 ;; Tool handler
@@ -62,12 +65,20 @@
                                                    (format "skill-route error: ~a"
                                                            (exn-message e)))))])
     (cond
-      ;; list: return all skills with name + description
+      ;; list: return all skills with name + description + type
       [(string=? action "list")
        (define skills (discover-skills))
        (define summaries
          (for/list ([s (in-list skills)])
-           (hasheq 'name (hash-ref s 'name "?") 'description (hash-ref s 'description ""))))
+           (define raw-content (hash-ref s 'raw-content (hash-ref s 'content "")))
+           (define fm (parse-skill-frontmatter-extended raw-content))
+           (define skill-type (and fm (hash-ref fm 'type #f)))
+           (hasheq 'name
+                   (hash-ref s 'name "?")
+                   'description
+                   (hash-ref s 'description "")
+                   'type
+                   (or skill-type "standard"))))
        (make-success-result (list (hasheq 'type "text" 'text (jsexpr->string summaries))))]
 
       ;; match: search skills by query text
@@ -194,6 +205,52 @@
           (make-success-result (list (hasheq 'type "text" 'text full-content)))]
          [else (make-error-result (format "Skill not found: ~a" ctx-name))])]
 
+      ;; workflow: execute a mas-workflow skill
+      ;; Uses dynamic-require to avoid circular dependency:
+      ;; skill-router → workflow-executor → spawn-subagent → skill-router
+      [(string=? action "workflow")
+       (define wf-name (hash-ref args 'name ""))
+       (when (string=? wf-name "")
+         (raise (exn:fail "workflow requires 'name'" (current-continuation-marks))))
+       (define wf-skills (discover-skills))
+       (define wf-found (findf (lambda (s) (string=? (hash-ref s 'name "") wf-name)) wf-skills))
+       (cond
+         [(not wf-found) (make-error-result (format "Skill not found: ~a" wf-name))]
+         [else
+          (define raw-content (hash-ref wf-found 'raw-content (hash-ref wf-found 'content "")))
+          (define fm (parse-skill-frontmatter-extended raw-content))
+          (define wf-type (and fm (hash-ref fm 'type #f)))
+          (cond
+            [(not (and fm (equal? wf-type "mas-workflow")))
+             (make-error-result (format "Skill '~a' is not a mas-workflow skill" wf-name))]
+            [else
+             ;; Lazily load workflow modules to break dependency cycle
+             (define parse-mas-workflow-fn
+               (dynamic-require "../../skills/mas-workflow.rkt" 'parse-mas-workflow))
+             (define execute-workflow-fn
+               (dynamic-require "../../skills/workflow-executor.rkt" 'execute-workflow))
+             (define variables (hash-ref args 'variables (hasheq)))
+             (define-values (wf wf-err)
+               (parse-mas-workflow-fn wf-name (hash-ref wf-found 'description "") fm))
+             (cond
+               [wf-err (make-error-result wf-err)]
+               [else
+                (define wf-result (execute-workflow-fn wf variables exec-ctx))
+                (define wf-content (tool-result-content wf-result))
+                (define wf-is-error (tool-result-is-error? wf-result))
+                (define wf-msg
+                  (if wf-is-error
+                      (if (list? wf-content)
+                          (hash-ref (car wf-content) 'text "")
+                          (format "~a" wf-content))
+                      (format "Workflow '~a' completed successfully.\n~a"
+                              wf-name
+                              (jsexpr->string wf-content))))
+                (if wf-is-error
+                    (make-error-result wf-msg)
+                    (make-success-result (list (hasheq 'type "text" 'text wf-msg))))])])])]
+
       [else
-       (make-error-result (format "Unknown action: ~a. Valid: list, match, load, recommend, context"
-                                  action))])))
+       (make-error-result
+        (format "Unknown action: ~a. Valid: list, match, load, recommend, context, workflow"
+                action))])))

--- a/tools/registry-table/skill-tools.rkt
+++ b/tools/registry-table/skill-tools.rkt
@@ -226,26 +226,32 @@
    ;; skill-route
    (make-tool-spec*
     "skill-route"
-    "Discover, search, and load skill instructions by name or description."
+    (string-append
+     "Discover, search, load skills, or execute mas-workflow skills. "
+     "Actions: list (all skills), match (search), load (full content), workflow (execute pipeline).")
     (hasheq
      'type
      "object"
      'required
      '()
      'properties
-     (hasheq
-      'action
-      (hasheq 'type
-              "string"
-              'description
-              "Action: list (all skills), match (search by query), load (full content by name)")
-      'query
-      (hasheq 'type "string" 'description "Search query for match action")
-      'name
-      (hasheq 'type "string" 'description "Skill name for load action")))
+     (hasheq 'action
+             (hasheq 'type
+                     "string"
+                     'description
+                     "Action: list, match, load, or workflow (execute mas-workflow)")
+             'query
+             (hasheq 'type "string" 'description "Search query for match action")
+             'name
+             (hasheq 'type "string" 'description "Skill name for load or workflow action")
+             'variables
+             (hasheq 'type
+                     "object"
+                     'description
+                     "Template variables for workflow action (e.g., {file: \"src/main.rkt\"})")))
     tool-skill-route
     #f
-    'read-only)
+    'subagent)
    ;; delete-lines
    (make-tool-spec*
     "delete-lines"

--- a/wiring/run-modes.rkt
+++ b/wiring/run-modes.rkt
@@ -25,6 +25,7 @@
          "../runtime/settings.rkt"
          "../skills/types.rkt"
          (only-in "../skills/resource-loader.rkt" skills-summary-section)
+         (only-in "../skills/frontmatter.rkt" parse-skill-frontmatter-extended)
          "../runtime/provider/model-registry.rkt"
          (only-in "../runtime/provider/provider-factory.rkt" build-provider)
          "../tools/tool.rkt"
@@ -184,6 +185,15 @@
 ;; v0.35.2 (W-03): Returns session-config? instead of mutable hash.
 ;; Consumers should use dict-ref (not hash-ref) for access.
 
+;; v0.99.26 §5.2: Filter skills that have type: mas-workflow in their frontmatter.
+;; Returns a list of skill hashes (same format as resource-set-skills).
+(define (filter-workflow-skills skills)
+  (filter (lambda (s)
+            (define raw-content (hash-ref s 'raw-content (hash-ref s 'content "")))
+            (define fm (parse-skill-frontmatter-extended raw-content))
+            (and fm (equal? (hash-ref fm 'type #f) "mas-workflow")))
+          skills))
+
 (define (build-runtime-from-cli cfg)
   (define base-config (cli-config->runtime-config cfg))
   (define bus (make-event-bus))
@@ -207,6 +217,20 @@
   ;; Progressive skill disclosure: inject skill summaries into system prompt
   ;; Full SKILL.md content is available on-demand via the `read` tool
   (define skill-section (skills-summary-section (resource-set-skills all-resources)))
+
+  ;; v0.99.26 §5.2: Detect mas-workflow skills and inject workflow guidance.
+  ;; When workflow skills are present, tell the agent how to execute them.
+  (define workflow-section
+    (let ([wf-skills (filter-workflow-skills (resource-set-skills all-resources))])
+      (if (null? wf-skills)
+          #f
+          (string-append
+           "\n\n## Available Workflows\n\n"
+           "Multi-agent workflows that can be triggered with `skill-route`:\n"
+           (string-join (for/list ([s (in-list wf-skills)])
+                          (format "- **~a**: ~a" (hash-ref s 'name "?") (hash-ref s 'description "")))
+                        "\n")
+           "\n\nExecute with: skill-route {action: \"workflow\", name: \"<skill-name>\", variables: {...}}"))))
 
   ;; v0.19.3 Wave 3: Inject project file tree into system prompt
   ;; This saves 1-2 exploration iterations per session.
@@ -237,6 +261,9 @@
     (append system-instrs
             (if skill-section
                 (list skill-section)
+                (list))
+            (if workflow-section
+                (list workflow-section)
                 (list))
             (if project-tree-section
                 (list project-tree-section)


### PR DESCRIPTION
## W4: Skill Router Integration + System Prompt

### Changes

**skill-router.rkt:**
- New `"workflow"` action: discovers skill, parses frontmatter, validates `type=mas-workflow`, executes pipeline
- Uses `dynamic-require` to load workflow modules lazily (breaks circular dependency: `skill-router → workflow-executor → spawn-subagent → skill-router`)
- `"list"` action now includes skill type (`standard`/`mas-workflow`)
- `discover-skills` preserves `raw-content` for frontmatter detection

**skill-tools.rkt:**
- Updated `skill-route` tool description to mention workflow action
- Added `variables` property to tool schema for workflow execution

**run-modes.rkt:**
- `filter-workflow-skills`: detects mas-workflow skills from frontmatter
- "Available Workflows" section injected into system prompt when workflow skills present
- Tells agent how to execute workflows via `skill-route`

**resource-loader.rkt:**
- `load-skills` preserves `raw-content` alongside parsed fields

### Tests: 4 new (all pass)
`tests/test-skill-workflow-e2e.rkt`:
- list action shows skill types
- workflow action rejects non-workflow skill  
- workflow action rejects missing skill
- workflow action requires name

Closes #8253