### PR TITLE
W0: Fix skill-route workflow execution + happy-path E2E (#8267)

### DIFF
--- a/tests/test-skill-workflow-e2e.rkt
+++ b/tests/test-skill-workflow-e2e.rkt
@@ -12,7 +12,9 @@
          racket/string
          json
          "../tools/builtins/skill-router.rkt"
-         "../tools/tool.rkt")
+         "../tools/tool.rkt"
+         "../llm/provider.rkt"
+         "../llm/model.rkt")
 
 ;; ── Test skill content ──
 
@@ -102,6 +104,40 @@
         (check-true (tool-result-is-error? result))
         (define content (tool-result-content result))
         (define text (hash-ref (car content) 'text ""))
-        (check-true (or (string-contains? text "requires") (string-contains? text "name")))))))
+        (check-true (or (string-contains? text "requires") (string-contains? text "name")))))
+
+    (test-case "workflow action executes mas-workflow from non-repo current directory"
+      ;; Regression test for B-1: dynamic-require used runtime-relative paths,
+      ;; so calling skill-route from a project directory failed. This test
+      ;; parameterizes current-directory to a temp project dir and provides a
+      ;; mock provider via exec-context.
+      (parameterize ([current-directory temp-dir])
+        (define mock-response
+          (make-model-response (list (hasheq 'type "text" 'text "mocked step output"))
+                               (hasheq 'prompt-tokens 0 'completion-tokens 0 'total-tokens 0)
+                               "mock-model"
+                               'stop))
+        (define mock-provider (make-mock-provider mock-response #:name "workflow-test-mock"))
+        (define exec-ctx
+          (make-exec-context #:runtime-settings (hasheq 'provider mock-provider 'model "mock-model")))
+        (define result
+          (tool-skill-route
+           (hasheq 'action "workflow" 'name "test-workflow" 'variables (hasheq 'file "src/main.rkt"))
+           exec-ctx))
+        (check-false (tool-result-is-error? result) "happy-path workflow should succeed")
+        (define content (tool-result-content result))
+        (check-true (list? content) "result content should be a list")
+        (define text (hash-ref (car content) 'text ""))
+        (check-true (string-contains? text "Workflow 'test-workflow' completed successfully")
+                    "result should report successful completion")
+        (check-true (string-contains? text "mocked step output")
+                    "result should include mocked subagent output")
+        ;; Verify the workflow executed 2 steps
+        (define payload-match (regexp-match #rx"\n(.*)$" text))
+        (check-true (pair? payload-match) "text should contain newline-delimited JSON payload")
+        (define parsed (string->jsexpr (cadr payload-match)))
+        (check-true (hash? parsed) "parsed payload should be a hash")
+        (check-equal? (hash-ref parsed 'workflow #f) "test-workflow")
+        (check-equal? (length (hash-ref parsed 'steps '())) 2)))))
 
 (run-tests suite)

--- a/tools/builtins/skill-router.rkt
+++ b/tools/builtins/skill-router.rkt
@@ -13,7 +13,8 @@
 ;; Scans .q/skills/ and .pi/skills/ directories from the working directory.
 ;; This is a read-only discovery tool — no modification.
 
-(require "../../util/error/error-helpers.rkt")
+(require "../../util/error/error-helpers.rkt"
+         racket/runtime-path)
 (require racket/contract
          racket/file
          racket/string
@@ -26,6 +27,12 @@
          "../../tools/tool.rkt")
 
 (provide (contract-out [tool-skill-route (->* (hash?) (any/c) any/c)]))
+
+;; Stable module-path indexes for workflow support modules.
+;; These resolve relative to this source module at runtime, not relative to
+;; the process current-directory, fixing B-1 (broken skill-route workflow).
+(define-runtime-module-path-index mas-workflow-module "../../skills/mas-workflow.rkt")
+(define-runtime-module-path-index workflow-executor-module "../../skills/workflow-executor.rkt")
 
 ;; ============================================================
 ;; Skill discovery helpers
@@ -224,11 +231,11 @@
             [(not (and fm (equal? wf-type "mas-workflow")))
              (make-error-result (format "Skill '~a' is not a mas-workflow skill" wf-name))]
             [else
-             ;; Lazily load workflow modules to break dependency cycle
-             (define parse-mas-workflow-fn
-               (dynamic-require "../../skills/mas-workflow.rkt" 'parse-mas-workflow))
-             (define execute-workflow-fn
-               (dynamic-require "../../skills/workflow-executor.rkt" 'execute-workflow))
+             ;; Lazily load workflow modules to break dependency cycle.
+             ;; Module-path indexes are defined at the top level so resolution
+             ;; is stable relative to this source module.
+             (define parse-mas-workflow-fn (dynamic-require mas-workflow-module 'parse-mas-workflow))
+             (define execute-workflow-fn (dynamic-require workflow-executor-module 'execute-workflow))
              (define variables (hash-ref args 'variables (hasheq)))
              (define-values (wf wf-err)
                (parse-mas-workflow-fn wf-name (hash-ref wf-found 'description "") fm))


### PR DESCRIPTION
## W0: Fix `skill-route workflow` execution + happy-path E2E

Fixes audit finding B-1 (BLOCKER): `skill-route workflow` failed because `dynamic-require` used runtime-relative string module paths.

### Changes

- `tools/builtins/skill-router.rkt`:
  - Added `racket/runtime-path` require.
  - Moved `define-runtime-module-path-index` for `skills/mas-workflow.rkt` and `skills/workflow-executor.rkt` to the top level.
  - Replaced string `dynamic-require` paths with stable module-path-index values.
  - Kept circular dependency broken.

- `tests/test-skill-workflow-e2e.rkt`:
  - Added happy-path workflow execution test with mock provider and exec-context, parameterized to a temp project directory (non-repo root).
  - Asserts success message, 2 executed steps, and mocked subagent output.

### Verification

- `raco make main.rkt` passes.
- `raco test tests/test-skill-workflow-e2e.rkt` passes (5/5).

Closes #8267