### PR TITLE
W1: Restore skill-route read-only capability contract (#8268)

### DIFF
--- a/tools/builtins/skill-router.rkt
+++ b/tools/builtins/skill-router.rkt
@@ -213,6 +213,9 @@
          [else (make-error-result (format "Skill not found: ~a" ctx-name))])]
 
       ;; workflow: execute a mas-workflow skill
+      ;; Safety: the router itself is read-only; execution is delegated to the
+      ;; workflow-executor, which runs each step through a child-safe subagent
+      ;; whose tool set is filtered by the step's declared capabilities.
       ;; Uses dynamic-require to avoid circular dependency:
       ;; skill-router → workflow-executor → spawn-subagent → skill-router
       [(string=? action "workflow")

--- a/tools/registry-table/skill-tools.rkt
+++ b/tools/registry-table/skill-tools.rkt
@@ -251,7 +251,12 @@
                      "Template variables for workflow action (e.g., {file: \"src/main.rkt\"})")))
     tool-skill-route
     #f
-    'subagent)
+    'read-only)
+   ;; NOTE: skill-route is tagged 'read-only because discovery/list/load/match
+   ;; actions are purely read-only. The optional 'workflow' action delegates
+   ;; execution to child-safe subagent tools whose own capability filtering
+   ;; governs runtime permissions; the router itself does not mutate files or
+   ;; spawn dangerous processes directly.)
    ;; delete-lines
    (make-tool-spec*
     "delete-lines"


### PR DESCRIPTION
## W1: Restore `skill-route` read-only capability contract

Fixes audit finding B-2.

### Changes

- `tools/registry-table/skill-tools.rkt`:
  - Reverted `skill-route` tool capability from `'subagent` to `'read-only`.
  - Added explanatory comment noting that discovery actions are read-only and workflow execution delegates to capability-filtered child-safe subagent tools.

- `tools/builtins/skill-router.rkt`:
  - Added safety comment clarifying that the router is read-only and workflow execution delegates to the workflow-executor's capability-filtered subagent runtime.

### Verification

- `raco make main.rkt` passes.
- `raco test tests/test-mas-tool-annotations.rkt` passes (12/12).
- `raco test tests/test-capability-aware-spawn.rkt` passes (13/13).
- `raco test tests/test-skill-workflow-e2e.rkt` passes (5/5).

Closes #8268