### PR TITLE
W2: Parallel workflow step execution (#8269)

### DIFF
--- a/skills/mas-workflow.rkt
+++ b/skills/mas-workflow.rkt
@@ -64,7 +64,7 @@
          (workflow-step (hash-ref agent 'role "assistant")
                         (hash-ref agent 'task "")
                         (parse-capabilities (hash-ref agent 'capabilities #f))
-                        (hash-ref agent 'parallel #f))))
+                        (parse-boolean (hash-ref agent 'parallel #f)))))
      ;; Validate: every step must have a non-empty task
      (define empty-tasks (filter (lambda (s) (string=? (workflow-step-task s) "")) steps))
      (cond
@@ -92,6 +92,15 @@
 ;; ============================================================
 ;; Capability parsing
 ;; ============================================================
+
+;; parse-boolean : (or/c boolean? string? #f) -> boolean?
+;; Coerce YAML boolean values. Strings "true"/"yes"/"on" (case-insensitive)
+;; become #t; everything else becomes #f.
+(define (parse-boolean v)
+  (cond
+    [(boolean? v) v]
+    [(string? v) (not (not (member (string-downcase (string-trim v)) '("true" "yes" "on" "1"))))]
+    [else #f]))
 
 ;; parse-capabilities : (or/c list? #f) -> (or/c (listof symbol?) #f)
 ;; Parse capabilities field: ("read-only" "file-write") → '(read-only file-write)

--- a/skills/workflow-executor.rkt
+++ b/skills/workflow-executor.rkt
@@ -22,11 +22,15 @@
          racket/list
          "mas-workflow.rkt"
          "template.rkt"
-         (only-in "../tools/builtins/spawn-subagent.rkt" subagent-config run-subagent-with-config)
+         (only-in "../tools/builtins/spawn-subagent.rkt"
+                  subagent-config
+                  run-subagent-with-config
+                  tool-spawn-subagents)
          (only-in "../tools/tool.rkt"
                   tool-result?
                   tool-result-is-error?
                   tool-result-content
+                  tool-result-details
                   make-error-result
                   make-success-result))
 
@@ -47,7 +51,9 @@
 ;; ============================================================
 
 ;; execute-workflow : mas-workflow? hash? (or/c exec-context? #f) -> tool-result?
-;; Execute a mas-workflow sequentially.
+;; Execute a mas-workflow.
+;; Sequential steps run one-by-one with {{result}} chaining.
+;; Consecutive steps marked parallel?: #t run together via spawn_subagents.
 ;; workflow:  mas-workflow?
 ;; variables: hash? — user-provided variable substitutions (e.g., #hash((file . "test.rkt")))
 ;; exec-ctx:  exec-context? (or #f for testing — provider resolution may fail)
@@ -55,35 +61,23 @@
 ;;           or error result if any step fails.
 (define (execute-workflow workflow variables exec-ctx)
   (define steps (mas-workflow-steps workflow))
+  (define groups (group-steps steps))
   (define step-results
-    (let loop ([remaining steps]
+    (let loop ([remaining-groups groups]
                [idx 0]
                [prev-result #f]
                [acc '()])
       (cond
-        [(null? remaining) (reverse acc)]
+        [(null? remaining-groups) (reverse acc)]
         [else
-         (define step (car remaining))
-         (define rendered-task (render-step-task step variables prev-result))
-         (define cfg
-           (subagent-config rendered-task
-                            (workflow-step-role step)
-                            10 ; max-turns (F-1b default)
-                            #f ; tools (inherit defaults)
-                            #f ; model (inherit)
-                            (workflow-step-capabilities step)))
-         (define result (run-subagent-with-config cfg exec-ctx))
-         (define result-text (extract-result-text result))
-         (define step-result
-           (workflow-step-result idx
-                                 (workflow-step-role step)
-                                 rendered-task
-                                 (not (tool-result-is-error? result))
-                                 result-text))
+         (define group (car remaining-groups))
+         (define-values (group-results next-idx group-success? next-prev-result)
+           (execute-step-group group idx variables prev-result exec-ctx))
+         (define new-acc (append group-results acc))
          (cond
            ;; On error, stop pipeline and return partial results
-           [(tool-result-is-error? result) (reverse (cons step-result acc))]
-           [else (loop (cdr remaining) (add1 idx) result-text (cons step-result acc))])])))
+           [(not group-success?) (reverse new-acc)]
+           [else (loop (cdr remaining-groups) next-idx next-prev-result new-acc)])])))
   ;; Build final result
   (define all-success? (andmap workflow-step-result-success? step-results))
   (if all-success?
@@ -96,6 +90,118 @@
 ;; ============================================================
 ;; Helpers
 ;; ============================================================
+
+;; group-steps : (listof workflow-step?) -> (listof (listof workflow-step?))
+;; Group consecutive parallel? steps together. Each sequential step is its own group.
+;; This preserves {{result}} chaining for sequential steps while allowing parallel
+;; siblings to run concurrently.
+(define (group-steps steps)
+  (let loop ([remaining steps]
+             [acc '()])
+    (cond
+      [(null? remaining) (reverse acc)]
+      [(workflow-step-parallel? (car remaining))
+       (define-values (par rest) (span workflow-step-parallel? remaining))
+       (loop rest (cons par acc))]
+      [else (loop (cdr remaining) (cons (list (car remaining)) acc))])))
+
+;; span : (X -> boolean?) (listof X) -> (values (listof X) (listof X))
+;; Split list into prefix satisfying pred and remainder.
+(define (span pred lst)
+  (let loop ([lst lst]
+             [taken '()])
+    (cond
+      [(null? lst) (values (reverse taken) '())]
+      [(pred (car lst)) (loop (cdr lst) (cons (car lst) taken))]
+      [else (values (reverse taken) lst)])))
+
+;; execute-step-group : (listof workflow-step?) exact-nonnegative-integer? hash? string? (or/c exec-context? #f)
+;;                      -> (values (listof workflow-step-result?) exact-nonnegative-integer? boolean? string?)
+;; Execute a group of steps (sequential singleton or parallel batch).
+;; Returns the step results, next index, whether the group succeeded, and the
+;; result text to pass as {{result}} to the next group (last step's result).
+(define (execute-step-group group idx variables prev-result exec-ctx)
+  (cond
+    [(= (length group) 1)
+     (define step (car group))
+     (define rendered-task (render-step-task step variables prev-result))
+     (define cfg
+       (subagent-config rendered-task
+                        (workflow-step-role step)
+                        10 ; max-turns (F-1b default)
+                        #f ; tools (inherit defaults)
+                        #f ; model (inherit)
+                        (workflow-step-capabilities step)))
+     (define result (run-subagent-with-config cfg exec-ctx))
+     (define result-text (extract-result-text result))
+     (define step-result
+       (workflow-step-result idx
+                             (workflow-step-role step)
+                             rendered-task
+                             (not (tool-result-is-error? result))
+                             result-text))
+     (values (list step-result) (add1 idx) (not (tool-result-is-error? result)) result-text)]
+    [else
+     ;; Parallel batch: run via spawn_subagents
+     (define jobs
+       (for/list ([step (in-list group)]
+                  [job-idx (in-naturals idx)])
+         (define rendered-task (render-step-task step variables prev-result))
+         (hasheq 'jobId
+                 (format "step-~a" job-idx)
+                 'task
+                 rendered-task
+                 'role
+                 (workflow-step-role step)
+                 'capabilities
+                 (or (workflow-step-capabilities step) '()))))
+     (define batch-result
+       (tool-spawn-subagents (hasheq 'jobs jobs 'maxParallel 3 'aggregate #f) exec-ctx))
+     (cond
+       [(tool-result-is-error? batch-result)
+        ;; Entire batch failed at orchestration level; mark all steps failed.
+        (define results
+          (for/list ([step (in-list group)]
+                     [step-idx (in-naturals idx)])
+            (define rendered-task (render-step-task step variables prev-result))
+            (workflow-step-result step-idx
+                                  (workflow-step-role step)
+                                  rendered-task
+                                  #f
+                                  (extract-result-text batch-result))))
+        (values results (+ idx (length group)) #f "")]
+       [else
+        (define details (or (tool-result-details batch-result) (hasheq)))
+        (define job-results (hash-ref details 'jobs '()))
+        ;; Map results by jobId because parallel completion order may differ
+        ;; from submission order.
+        (define job-result-by-id
+          (for/hash ([job-result (in-list job-results)])
+            (values (hash-ref job-result 'jobId (format "step-~a" idx)) job-result)))
+        (define results
+          (for/list ([step (in-list group)]
+                     [step-idx (in-naturals idx)])
+            (define rendered-task (render-step-task step variables prev-result))
+            (define job-id (format "step-~a" step-idx))
+            (define job-result (hash-ref job-result-by-id job-id #f))
+            (define success (and job-result (hash-ref job-result 'success #f)))
+            (define result-text
+              (if job-result
+                  (extract-text-from-content (hash-ref job-result 'content '()))
+                  ""))
+            (workflow-step-result step-idx
+                                  (workflow-step-role step)
+                                  rendered-task
+                                  success
+                                  result-text)))
+        (define group-success? (andmap workflow-step-result-success? results))
+        ;; The next sequential group sees the result of the last step in this
+        ;; group (by original step order), not the last-completed job.
+        (define next-prev-result
+          (if (null? results)
+              ""
+              (workflow-step-result-result (last results))))
+        (values results (+ idx (length group)) group-success? next-prev-result)])]))
 
 ;; render-step-task : workflow-step? hash? (or/c string? #f) -> string?
 ;; Render a step's task with template variables and previous result.
@@ -110,17 +216,21 @@
   (cond
     [(not result) ""]
     [(not (tool-result? result)) ""]
-    [else
-     (define content (tool-result-content result))
-     (cond
-       [(list? content)
-        (string-join (for/list ([c (in-list content)])
-                       (if (hash? c)
-                           (hash-ref c 'text "")
-                           (format "~a" c)))
-                     " ")]
-       [(string? content) content]
-       [else (format "~a" content)])]))
+    [else (extract-text-from-content (tool-result-content result))]))
+
+;; extract-text-from-content : (or/c list? string? any/c) -> string?
+;; Extract text from a tool result content value.
+(define (extract-text-from-content content)
+  (cond
+    [(list? content)
+     (string-join (for/list ([c (in-list content)])
+                    (cond
+                      [(hash? c) (hash-ref c 'text "")]
+                      [(string? c) c]
+                      [else (format "~a" c)]))
+                  " ")]
+    [(string? content) content]
+    [else (format "~a" content)]))
 
 ;; step-results->jsexpr : (listof workflow-step-result?) -> (listof hash?)
 (define (step-results->jsexpr results)
@@ -129,6 +239,8 @@
             (workflow-step-result-step r)
             'role
             (workflow-step-result-role r)
+            'task
+            (workflow-step-result-task r)
             'success
             (workflow-step-result-success? r)
             'result

--- a/tests/test-mas-workflow.rkt
+++ b/tests/test-mas-workflow.rkt
@@ -59,6 +59,27 @@
       (check-equal? (workflow-step-role (cadr (mas-workflow-steps wf))) "reviewer")
       (check-equal? (workflow-step-role (caddr (mas-workflow-steps wf))) "writer"))
 
+    (test-case "parse workflow with parallel steps"
+      (define fm
+        (parse-fm (skill-with-frontmatter "type: mas-workflow"
+                                          "agents:"
+                                          "  - role: researcher"
+                                          "    task: Research {{topic}}"
+                                          "    parallel: true"
+                                          "  - role: checker"
+                                          "    task: Check sources"
+                                          "    parallel: true"
+                                          "  - role: writer"
+                                          "    task: Write summary")))
+      (define-values (wf err) (parse-mas-workflow "parallel-wf" "desc" fm))
+      (check-false err)
+      (check-true (mas-workflow? wf))
+      (define steps (mas-workflow-steps wf))
+      (check-equal? (length steps) 3)
+      (check-true (workflow-step-parallel? (car steps)) "first step should be parallel")
+      (check-true (workflow-step-parallel? (cadr steps)) "second step should be parallel")
+      (check-false (workflow-step-parallel? (caddr steps)) "third step should be sequential"))
+
     (test-case "parse workflow with inline array capabilities"
       (define fm
         (parse-fm (skill-with-frontmatter "type: mas-workflow"

--- a/tests/test-workflow-executor.rkt
+++ b/tests/test-workflow-executor.rkt
@@ -42,7 +42,10 @@
 (define (make-simple-workflow steps)
   (define wf-steps
     (for/list ([s (in-list steps)])
-      (workflow-step (hash-ref s 'role "assistant") (hash-ref s 'task "") #f #f)))
+      (workflow-step (hash-ref s 'role "assistant")
+                     (hash-ref s 'task "")
+                     (hash-ref s 'capabilities #f)
+                     (hash-ref s 'parallel #f))))
   (mas-workflow "test-wf" "test desc" wf-steps '()))
 
 (define suite
@@ -146,6 +149,58 @@
       (when (hash? content)
         (define steps-hash (hash-ref content 'steps))
         (check-equal? (hash-ref (car steps-hash) 'role) "researcher")))
+
+    (test-case "execute parallel workflow steps"
+      (define provider (make-static-text-provider "Parallel done"))
+      (define exec-ctx (make-test-exec-ctx provider))
+      (define wf
+        (make-simple-workflow (list (hasheq 'role "a" 'task "Task A" 'parallel #t)
+                                    (hasheq 'role "b" 'task "Task B" 'parallel #t))))
+      (define result (execute-workflow wf (hasheq) exec-ctx))
+      (check-false (tool-result-is-error? result) "parallel workflow should succeed")
+      (define content (tool-result-content result))
+      (check-true (hash? content) "content should be a hash")
+      (check-equal? (hash-ref content 'workflow) "test-wf")
+      (define steps-hash (hash-ref content 'steps))
+      (check-equal? (length steps-hash) 2)
+      (check-true (andmap (lambda (s) (hash-ref s 'success #f)) steps-hash)
+                  "both parallel steps should succeed"))
+
+    (test-case "execute mixed sequential and parallel workflow"
+      (define provider (make-static-text-provider "Done"))
+      (define exec-ctx (make-test-exec-ctx provider))
+      (define wf
+        (make-simple-workflow (list (hasheq 'role "prep" 'task "Prepare")
+                                    (hasheq 'role "a" 'task "Parallel A" 'parallel #t)
+                                    (hasheq 'role "b" 'task "Parallel B" 'parallel #t)
+                                    (hasheq 'role "finalize" 'task "Finalize: {{result}}"))))
+      (define result (execute-workflow wf (hasheq) exec-ctx))
+      (check-false (tool-result-is-error? result) "mixed workflow should succeed")
+      (define content (tool-result-content result))
+      (define steps-hash (hash-ref content 'steps))
+      (check-equal? (length steps-hash) 4)
+      (check-true (andmap (lambda (s) (hash-ref s 'success #f)) steps-hash)
+                  "all mixed steps should succeed")
+      ;; Finalize step should see the last parallel step's result
+      (define finalize-task (hash-ref (cadddr steps-hash) 'task ""))
+      (check-true (string-contains? finalize-task "Done")
+                  "finalize should be rendered with previous result"))
+
+    (test-case "parallel step failure stops pipeline"
+      (define provider (make-failing-provider))
+      (define exec-ctx (make-test-exec-ctx provider))
+      (define wf
+        (make-simple-workflow (list (hasheq 'role "a" 'task "Task A" 'parallel #t)
+                                    (hasheq 'role "b" 'task "Task B" 'parallel #t)
+                                    (hasheq 'role "c" 'task "Task C"))))
+      (define result (execute-workflow wf (hasheq) exec-ctx))
+      (check-true (tool-result-is-error? result) "should be error")
+      (define content (tool-result-content result))
+      (define msg
+        (if (list? content)
+            (hash-ref (car content) 'text "")
+            (format "~a" content)))
+      (check-true (string-contains? msg "failed") "should mention failure"))
 
     (test-case "workflow-step-result struct"
       (define r (workflow-step-result 0 "analyst" "Do thing" #t "Done"))


### PR DESCRIPTION
## W2: Parallel workflow step execution via `spawn_subagents`

Fixes audit finding B-3.

### Changes

- `skills/mas-workflow.rkt`:
  - Added `parse-boolean` helper to coerce string boolean values from YAML frontmatter (`true`/`yes`/`on`/`1`) to `#t`.
  - Applied coercion to the `parallel` agent field.

- `skills/workflow-executor.rkt`:
  - Grouped consecutive `parallel?` steps and ran them via `tool-spawn-subagents`.
  - Kept sequential steps as singleton groups to preserve `{{result}}` chaining.
  - Mapped parallel job results by `jobId` to handle out-of-order completion.
  - Added `task` to the per-step JSON payload.
  - Refactored `extract-result-text` to reuse a new `extract-text-from-content` helper.

- `tests/test-mas-workflow.rkt`:
  - Added parser test for `parallel?` flags.

- `tests/test-workflow-executor.rkt`:
  - Extended `make-simple-workflow` to support capabilities and parallel flags.
  - Added parallel, mixed sequential/parallel, and parallel failure tests.

### Verification

- `raco make main.rkt` passes.
- `raco test tests/test-mas-workflow.rkt` passes (20/20).
- `raco test tests/test-workflow-executor.rkt` passes (16/16).
- `raco test tests/test-skill-workflow-e2e.rkt` passes (5/5).

Closes #8269