### PR TITLE
W3: HITL approval gate for dangerous workflow steps (#8270)

### DIFF
--- a/skills/workflow-executor.rkt
+++ b/skills/workflow-executor.rkt
@@ -25,7 +25,9 @@
          (only-in "../tools/builtins/spawn-subagent.rkt"
                   subagent-config
                   run-subagent-with-config
-                  tool-spawn-subagents)
+                  tool-spawn-subagents
+                  requires-hitl-approval?
+                  request-spawn-approval)
          (only-in "../tools/tool.rkt"
                   tool-result?
                   tool-result-is-error?
@@ -115,13 +117,47 @@
       [(pred (car lst)) (loop (cdr lst) (cons (car lst) taken))]
       [else (values (reverse taken) lst)])))
 
+;; step-group-capabilities : (listof workflow-step?) -> (listof symbol?)
+;; Aggregate all capabilities requested by steps in a group.
+(define (step-group-capabilities group)
+  (remove-duplicates (append* (for/list ([step (in-list group)])
+                                (or (workflow-step-capabilities step) '())))))
+
+;; step-group-task-preview : (listof workflow-step?) hash? (or/c string? #f) -> string?
+;; Build a short task preview for approval requests.
+(define (step-group-task-preview group variables prev-result)
+  (string-join
+   (for/list ([step (in-list group)])
+     (format "[~a] ~a" (workflow-step-role step) (render-step-task step variables prev-result)))
+   "\n"))
+
 ;; execute-step-group : (listof workflow-step?) exact-nonnegative-integer? hash? string? (or/c exec-context? #f)
 ;;                      -> (values (listof workflow-step-result?) exact-nonnegative-integer? boolean? string?)
 ;; Execute a group of steps (sequential singleton or parallel batch).
 ;; Returns the step results, next index, whether the group succeeded, and the
 ;; result text to pass as {{result}} to the next group (last step's result).
 (define (execute-step-group group idx variables prev-result exec-ctx)
+  ;; v0.99.27 W3: HITL approval gate for dangerous capabilities.
+  ;; Covers both sequential steps (run-subagent-with-config also checks) and
+  ;; parallel batches (which previously bypassed the gate via run-subagent).
+  (define group-caps (step-group-capabilities group))
+  (define approval-denied?
+    (and (requires-hitl-approval? group-caps)
+         (not (request-spawn-approval group-caps
+                                      (step-group-task-preview group variables prev-result)
+                                      exec-ctx))))
   (cond
+    [approval-denied?
+     (define denied-msg "subagent spawn blocked — HITL approval denied")
+     (define denied-results
+       (for/list ([step (in-list group)]
+                  [step-idx (in-naturals idx)])
+         (workflow-step-result step-idx
+                               (workflow-step-role step)
+                               (render-step-task step variables prev-result)
+                               #f
+                               denied-msg)))
+     (values denied-results (+ idx (length group)) #f "")]
     [(= (length group) 1)
      (define step (car group))
      (define rendered-task (render-step-task step variables prev-result))

--- a/tests/test-workflow-executor.rkt
+++ b/tests/test-workflow-executor.rkt
@@ -12,7 +12,7 @@
          racket/string
          "../skills/workflow-executor.rkt"
          "../skills/mas-workflow.rkt"
-         "../tools/builtins/spawn-subagent.rkt"
+         (only-in "../tools/builtins/spawn-subagent.rkt" current-spawn-approval-result)
          "../tools/tool.rkt"
          "../llm/provider.rkt"
          "../llm/model.rkt")
@@ -138,6 +138,68 @@
                       '()))
       (define result (execute-workflow wf (hasheq) exec-ctx))
       (check-false (tool-result-is-error? result) "read-only should not trigger HITL denial"))
+
+    (test-case "dangerous sequential capability requires approval — denied"
+      (parameterize ([current-spawn-approval-result #f])
+        (define provider (make-static-text-provider "Done"))
+        (define exec-ctx (make-test-exec-ctx provider))
+        (define wf
+          (mas-workflow "dangerous-seq"
+                        "desc"
+                        (list (workflow-step "runner" "rm -rf /" '(shell-exec) #f))
+                        '()))
+        (define result (execute-workflow wf (hasheq) exec-ctx))
+        (check-true (tool-result-is-error? result) "denied workflow should error")
+        (define content (tool-result-content result))
+        (define msg
+          (if (list? content)
+              (hash-ref (car content) 'text "")
+              (format "~a" content)))
+        (check-true (string-contains? msg "failed") "should mention failure")))
+
+    (test-case "dangerous sequential capability approved by default in non-interactive mode"
+      (define provider (make-static-text-provider "Done"))
+      (define exec-ctx (make-test-exec-ctx provider))
+      (define wf
+        (mas-workflow "dangerous-seq-approved"
+                      "desc"
+                      (list (workflow-step "runner" "echo ok" '(shell-exec) #f))
+                      '()))
+      (define result (execute-workflow wf (hasheq) exec-ctx))
+      (check-false (tool-result-is-error? result) "default permissive mode should allow"))
+
+    (test-case "dangerous parallel capability requires approval — denied"
+      (parameterize ([current-spawn-approval-result #f])
+        (define provider (make-static-text-provider "Done"))
+        (define exec-ctx (make-test-exec-ctx provider))
+        (define wf
+          (mas-workflow "dangerous-par"
+                        "desc"
+                        (list (workflow-step "a" "Run A" '(shell-exec) #t)
+                              (workflow-step "b" "Run B" '(shell-exec) #t)
+                              (workflow-step "c" "Clean up" '(git-write) #f))
+                        '()))
+        (define result (execute-workflow wf (hasheq) exec-ctx))
+        (check-true (tool-result-is-error? result) "denied parallel workflow should error")
+        (define content (tool-result-content result))
+        (define msg
+          (if (list? content)
+              (hash-ref (car content) 'text "")
+              (format "~a" content)))
+        (check-true (string-contains? msg "failed") "should mention failure")
+        (check-true (string-contains? msg "step 1") "should indicate failed step")))
+
+    (test-case "dangerous parallel capability approved by default in non-interactive mode"
+      (define provider (make-static-text-provider "Done"))
+      (define exec-ctx (make-test-exec-ctx provider))
+      (define wf
+        (mas-workflow "dangerous-par-approved"
+                      "desc"
+                      (list (workflow-step "a" "Run A" '(shell-exec) #t)
+                            (workflow-step "b" "Run B" '(shell-exec) #t))
+                      '()))
+      (define result (execute-workflow wf (hasheq) exec-ctx))
+      (check-false (tool-result-is-error? result) "default permissive mode should allow parallel"))
 
     (test-case "role used in workflow steps"
       (define provider (make-static-text-provider "Role check"))


### PR DESCRIPTION
## W3: HITL approval gate for dangerous workflow steps

Fixes audit finding B-3.

### Changes

- `skills/workflow-executor.rkt`:
  - Added `step-group-capabilities` and `step-group-task-preview` helpers.
  - `execute-step-group` now checks `requires-hitl-approval?` for the union of capabilities in the group and calls `request-spawn-approval` before executing either sequential singletons or parallel batches.
  - Parallel batches previously bypassed approval by calling `run-subagent` directly inside `tool-spawn-subagents`; this is now covered.
  - On denial the entire group is marked failed and the pipeline stops.

- `tests/test-workflow-executor.rkt`:
  - Imported `current-spawn-approval-result` from `spawn-subagent.rkt`.
  - Added tests for denied/approved `shell-exec` sequential steps and denied/approved `shell-exec` parallel steps, plus non-interactive default permissive behavior.

### Verification

- `raco make main.rkt` passes.
- `raco test tests/test-workflow-executor.rkt` passes (20/20).
- `raco test tests/test-mas-workflow.rkt` passes (20/20).
- `raco test tests/test-skill-workflow-e2e.rkt` passes (5/5).

Closes #8270