### PR TITLE
W2: MAS technical debt — registry defaults, CLI verbose, tool taxonomy (#8282)

### DIFF
--- a/tests/test-cli.rkt
+++ b/tests/test-cli.rkt
@@ -363,7 +363,9 @@
       (define e (exn:fail "hash-ref: contract violation" (current-continuation-marks)))
       (define result (classify-error e))
       (check-not-false result)
-      (check-true (string-contains? (cadr result) "contract")))
+      ;; hash-ref errors are classified as session (missing key), not contract
+      (check-equal? (car result) 'session)
+      (check-true (string-contains? (cadr result) "missing")))
     (test-case "read-json"
       (define e (exn:fail "read-json: expected" (current-continuation-marks)))
       (define result (classify-error e))

--- a/tests/test-registry-defaults.rkt
+++ b/tests/test-registry-defaults.rkt
@@ -14,28 +14,45 @@
 ;; register-default-tools! — registers all tools
 ;; ============================================================
 
-(test-case "register-default-tools! registers all 17 built-in tools"
+(test-case "register-default-tools! registers all 35 built-in tools"
   (define reg (make-tool-registry))
   (register-default-tools! reg)
   (define names (sort (tool-names reg) string<?))
   (check equal?
          names
-         (sort '("bash"
+         (sort '("bash" "browser_check_local_app"
+                        "browser_click"
+                        "browser_close"
+                        "browser_extract"
+                        "browser_observe"
+                        "browser_open"
+                        "browser_press"
+                        "browser_screenshot"
+                        "browser_scroll"
+                        "browser_type"
+                        "cleanup-expired-memory"
+                        "clear-memory"
+                        "consolidate-memory"
                         "date"
                         "delete-lines"
+                        "delete-memory"
                         "edit"
                         "find"
                         "firecrawl"
                         "grep"
+                        "list-memory"
                         "ls"
                         "read"
                         "record_conclusion"
                         "save-conclusion"
+                        "search-memory"
                         "session_recall"
                         "set-task-state"
                         "skill-route"
                         "spawn-subagent"
                         "spawn-subagents"
+                        "store-memory"
+                        "update-memory"
                         "write")
                string<?)))
 

--- a/tools/permission-gate.rkt
+++ b/tools/permission-gate.rkt
@@ -59,7 +59,14 @@
                               "browser_extract"
                               "browser_screenshot"
                               "browser_scroll"
-                              "browser_close"))
+                              "browser_close"
+                              ;; Memory tools (read-only / safe state mutation)
+                              "list-memory"
+                              "search-memory"
+                              "store-memory"
+                              "update-memory"
+                              "consolidate-memory"
+                              "cleanup-expired-memory"))
                      (or needs-approval
                          (set "edit"
                               "write"
@@ -74,7 +81,10 @@
                               "browser_click"
                               "browser_type"
                               "browser_press"
-                              "browser_check_local_app"))
+                              "browser_check_local_app"
+                              ;; Destructive memory tools
+                              "delete-memory"
+                              "clear-memory"))
                      (or callback (lambda (tool-name args) #t))
                      (if (memq mode '(strict permissive)) mode 'strict)))
 

--- a/util/error/error-classify.rkt
+++ b/util/error/error-classify.rkt
@@ -32,6 +32,17 @@
 (define (classify-error e)
   (define msg (exn-message e))
   (cond
+    ;; ── Session domain (checked before contract because hash-ref errors
+    ;; often contain 'contract' in the message, but are really missing-key errors) ──
+    [(or (regexp-match? #rx"hash-ref:" msg) (regexp-match? #rx"session" msg))
+     (list 'session
+           (cond
+             [(regexp-match? #rx"hash-ref:" msg) "A required value was missing from the data."]
+             [else "A session error occurred."])
+           '("Check your configuration file for missing fields."
+             "Run 'q doctor' to diagnose configuration issues."
+             "Try creating a new session."))]
+
     ;; ── Contract domain ────────────────────────────────────
     [(or (regexp-match? #rx"contract" msg)
          (regexp-match? #rx"blaming:" msg)
@@ -97,16 +108,6 @@
              "Run 'q init' to set up your configuration."
              "Check file permissions."
              "Run 'q doctor' to diagnose configuration issues."))]
-
-    ;; ── Session domain ─────────────────────────────────────
-    [(or (regexp-match? #rx"hash-ref:" msg) (regexp-match? #rx"session" msg))
-     (list 'session
-           (cond
-             [(regexp-match? #rx"hash-ref:" msg) "A required value was missing from the data."]
-             [else "A session error occurred."])
-           '("Check your configuration file for missing fields."
-             "Run 'q doctor' to diagnose configuration issues."
-             "Try creating a new session."))]
 
     ;; ── Tool domain ────────────────────────────────────────
     [(or (regexp-match? #rx"tool.*timeout|timed? ?out" msg)


### PR DESCRIPTION
## W2: MAS technical debt fixes

Fixes MAS-TD-1/2/3.

### Changes

1. **`util/error/error-classify.rkt`** (MAS-TD-2 / Issues #149, #166): Reordered `classify-error` — `hash-ref:` session pattern now checked BEFORE the `contract` pattern. Previously `'hash-ref: contract violation'` was incorrectly classified as `'contract` instead of `'session`, hiding the user-friendly "missing key" message.

2. **`tools/permission-gate.rkt`** (MAS-TD-3): Added 8 memory tools to permission classification. Read/safe-mutation tools auto-approved; destructive tools (`delete-memory`, `clear-memory`) require approval.

3. **`tests/test-registry-defaults.rkt`** (MAS-TD-1): Updated hardcoded tool count from 17 to 35 (stale since v0.86.2).

4. **`tests/test-cli.rkt`**: Updated Issue #165 hash-ref test to expect correct `'session` classification.

### Verification

- `test-registry-defaults.rkt`: 7/7 PASS
- `test-mutating-tool-taxonomy.rkt`: 6/6 PASS
- `test-error-classify.rkt`: 23/23 PASS
- `test-cli.rkt`: 69/69 PASS (all 6 submodules)
- `raco make main.rkt`: PASS

Closes #8282