### PR TITLE
W3: Broad-suite harness/report truthfulness (#8283)

### DIFF
--- a/scripts/run-tests.rkt
+++ b/scripts/run-tests.rkt
@@ -67,6 +67,7 @@
                   save-failure-logs
                   format-duration
                   summary-exit-code
+                  compute-verdict
                   make-unique-log-name)
          (only-in "run-tests/cli.rkt" usage parse-args validate-args! known-suites)
          (only-in "run-tests/gate-evidence.rkt" record-gate-evidence!)
@@ -101,6 +102,7 @@
          save-failure-logs
          format-duration
          summary-exit-code
+         compute-verdict
          bytes->string*
          clean-stale-bytecode!
          file-has-rackunit-tests?

--- a/scripts/run-tests/reporting.rkt
+++ b/scripts/run-tests/reporting.rkt
@@ -25,7 +25,9 @@
          save-failure-logs
          format-duration
          summary-exit-code
-         make-unique-log-name)
+         make-unique-log-name
+         compute-verdict
+         format-verdict-line)
 
 (define (format-duration ms)
   (define total-secs (/ ms 1000.0))
@@ -49,6 +51,36 @@
     [(> timeout-count 0) 2]
     [else 0]))
 
+;; Compute a verdict symbol from results: 'pass, 'fail, 'incomplete, 'inconclusive.
+;; - 'fail:          at least one file exited non-zero (not timeout)
+;; - 'incomplete:    at least one file timed out (exit-code 2)
+;; - 'inconclusive:  all files passed but zero tests were parsed
+;; - 'pass:          all files passed and at least one test was parsed
+(define (compute-verdict results)
+  (define failed-files
+    (count (lambda (r)
+             (and (not (= (test-file-result-exit-code r) 0))
+                  (not (= (test-file-result-exit-code r) 2))))
+           results))
+  (define timeout-files (count (lambda (r) (= (test-file-result-exit-code r) 2)) results))
+  (define total-tests (for/sum ([r (in-list results)]) (test-file-result-total r)))
+  (cond
+    [(> failed-files 0) 'fail]
+    [(> timeout-files 0) 'incomplete]
+    [(= total-tests 0) 'inconclusive]
+    [else 'pass]))
+
+(define (format-verdict-line verdict timeout-count)
+  (case verdict
+    [(fail) "  VERDICT:   ❌ FAIL"]
+    [(incomplete)
+     (format "  VERDICT:   ⏱ INCOMPLETE (~a timeout~a)"
+             timeout-count
+             (if (= timeout-count 1) "" "s"))]
+    [(inconclusive) "  VERDICT:   ⚠ INCONCLUSIVE (0 tests parsed)"]
+    [(pass) "  VERDICT:   ✅ PASS"]
+    [else "  VERDICT:   ❓ UNKNOWN"]))
+
 (define (print-summary results total-start-ms)
   (define total-files (length results))
   (define passed-files (count (lambda (r) (= (test-file-result-exit-code r) 0)) results))
@@ -58,9 +90,13 @@
                   (not (= (test-file-result-exit-code r) 2))))
            results))
   (define timeout-files (count (lambda (r) (= (test-file-result-exit-code r) 2)) results))
-  (define total-passed (apply + (map test-file-result-passed results)))
-  (define total-failed (apply + (map test-file-result-failed results)))
-  (define total-tests (apply + (map test-file-result-total results)))
+  (define zero-test-files
+    (count (lambda (r) (and (= (test-file-result-exit-code r) 0) (= (test-file-result-total r) 0)))
+           results))
+  (define total-passed (for/sum ([r (in-list results)]) (test-file-result-passed r)))
+  (define total-failed (for/sum ([r (in-list results)]) (test-file-result-failed r)))
+  (define total-tests (for/sum ([r (in-list results)]) (test-file-result-total r)))
+  (define verdict (compute-verdict results))
   (newline)
   (displayln "═══════════════════════════════════════════════════════════")
   (displayln "                    TEST SUMMARY")
@@ -70,10 +106,16 @@
           passed-files
           failed-files
           timeout-files)
+  (when (> zero-test-files 0)
+    (printf "             ⚠ ~a file~a with zero parsed tests (exit=0 but no rackunit output)~n"
+            zero-test-files
+            (if (= zero-test-files 1) "" "s")))
   (printf "  Tests:     ~a total, ~a passed, ~a failed~n" total-tests total-passed total-failed)
   (when (and (= total-tests 0) (= passed-files total-files))
     (displayln "  ⚠ No test results parsed — files may use non-standard output format"))
   (printf "  Elapsed:   ~a~n" (format-duration total-start-ms))
+  (displayln "═══════════════════════════════════════════════════════════")
+  (displayln (format-verdict-line verdict timeout-files))
   (displayln "═══════════════════════════════════════════════════════════")
   (define failures (filter (lambda (r) (not (= (test-file-result-exit-code r) 0))) results))
   (when (pair? failures)

--- a/tests/test-run-tests-reporting-truthfulness.rkt
+++ b/tests/test-run-tests-reporting-truthfulness.rkt
@@ -1,0 +1,121 @@
+#lang racket
+
+;; @speed fast
+;; @suite default
+
+;; BOUNDARY: unit
+
+;; tests/test-run-tests-reporting-truthfulness.rkt
+;;
+;; Tests for the test-runner reporting truthfulness fixes (W3, #8283).
+;; Verifies that compute-verdict and print-summary honestly report
+;; PASS/FAIL/INCOMPLETE/INCONCLUSIVE instead of silently masking timeouts
+;; and zero-test files.
+
+(require rackunit
+         rackunit/text-ui
+         racket/port
+         (only-in "../scripts/run-tests/parse.rkt" make-test-file-result)
+         (only-in "../scripts/run-tests/reporting.rkt"
+                  compute-verdict
+                  summary-exit-code
+                  print-summary
+                  format-verdict-line))
+
+;; Helpers for constructing results
+(define (make-passed path n)
+  (make-test-file-result path 0 #"" #"" 100 n 0 n))
+
+(define (make-failed path n)
+  (make-test-file-result path 1 #"" #"" 100 (- n 1) 1 n))
+
+(define (make-timeout path)
+  (make-test-file-result path 2 #"" #"" 5000 0 0 0))
+
+(define (make-zero-test path)
+  (make-test-file-result path 0 #"" #"" 50 0 0 0))
+
+(define-test-suite
+ compute-verdict-tests
+ (test-case "all-passing results with tests → 'pass"
+   (define results (list (make-passed "test-a.rkt" 10) (make-passed "test-b.rkt" 5)))
+   (check-equal? (compute-verdict results) 'pass))
+ (test-case "any failure → 'fail"
+   (define results (list (make-passed "test-a.rkt" 10) (make-failed "test-b.rkt" 5)))
+   (check-equal? (compute-verdict results) 'fail))
+ (test-case "timeout without failures → 'incomplete"
+   (define results (list (make-passed "test-a.rkt" 10) (make-timeout "test-slow.rkt")))
+   (check-equal? (compute-verdict results) 'incomplete))
+ (test-case "both failure and timeout → 'fail (fail takes priority)"
+   (define results (list (make-failed "test-a.rkt" 5) (make-timeout "test-b.rkt")))
+   (check-equal? (compute-verdict results) 'fail))
+ (test-case "zero tests across all files → 'inconclusive"
+   (define results (list (make-zero-test "test-a.rkt") (make-zero-test "test-b.rkt")))
+   (check-equal? (compute-verdict results) 'inconclusive))
+ (test-case "mixed zero-test and passing → 'pass (at least some tests ran)"
+   (define results (list (make-zero-test "test-a.rkt") (make-passed "test-b.rkt" 3)))
+   (check-equal? (compute-verdict results) 'pass))
+ (test-case "empty results → 'inconclusive"
+   (check-equal? (compute-verdict '()) 'inconclusive)))
+
+(define-test-suite summary-exit-code-tests
+                   (test-case "no failures, no timeouts → 0 (pass)"
+                     (check-equal? (summary-exit-code 0 0) 0))
+                   (test-case "failures only → 1"
+                     (check-equal? (summary-exit-code 3 0) 1))
+                   (test-case "timeouts only → 2"
+                     (check-equal? (summary-exit-code 0 2) 2))
+                   (test-case "both failures and timeouts → 3"
+                     (check-equal? (summary-exit-code 2 1) 3)))
+
+(define-test-suite format-verdict-line-tests
+                   (test-case "pass verdict"
+                     (check-true (string-contains? (format-verdict-line 'pass 0) "PASS")))
+                   (test-case "fail verdict"
+                     (check-true (string-contains? (format-verdict-line 'fail 0) "FAIL")))
+                   (test-case "incomplete verdict includes timeout count"
+                     (define line (format-verdict-line 'incomplete 3))
+                     (check-true (string-contains? line "INCOMPLETE"))
+                     (check-true (string-contains? line "3")))
+                   (test-case "inconclusive verdict"
+                     (check-true (string-contains? (format-verdict-line 'inconclusive 0)
+                                                   "INCONCLUSIVE"))))
+
+(define-test-suite
+ print-summary-verdict-tests
+ (test-case "summary includes VERDICT line for passing results"
+   (define out (open-output-string))
+   (parameterize ([current-output-port out])
+     (print-summary (list (make-passed "test-a.rkt" 5)) 100))
+   (define output (get-output-string out))
+   (check-true (string-contains? output "VERDICT"))
+   (check-true (string-contains? output "PASS")))
+ (test-case "summary includes FAIL verdict for failing results"
+   (define out (open-output-string))
+   (parameterize ([current-output-port out])
+     (print-summary (list (make-failed "test-a.rkt" 5)) 100))
+   (define output (get-output-string out))
+   (check-true (string-contains? output "VERDICT"))
+   (check-true (string-contains? output "FAIL")))
+ (test-case "summary includes INCOMPLETE verdict for timeout results"
+   (define out (open-output-string))
+   (parameterize ([current-output-port out])
+     (print-summary (list (make-passed "test-a.rkt" 5) (make-timeout "test-slow.rkt")) 100))
+   (define output (get-output-string out))
+   (check-true (string-contains? output "VERDICT"))
+   (check-true (string-contains? output "INCOMPLETE"))
+   (check-true (string-contains? output "timeout")))
+ (test-case "summary warns about zero-test files"
+   (define out (open-output-string))
+   (parameterize ([current-output-port out])
+     (print-summary (list (make-passed "test-a.rkt" 5) (make-zero-test "test-empty.rkt")) 100))
+   (define output (get-output-string out))
+   (check-true (string-contains? output "zero parsed tests"))
+   ;; Should still pass since some tests ran
+   (check-true (string-contains? output "PASS"))))
+
+(run-tests (make-test-suite "run-tests reporting truthfulness"
+                            (list compute-verdict-tests
+                                  summary-exit-code-tests
+                                  format-verdict-line-tests
+                                  print-summary-verdict-tests)))


### PR DESCRIPTION
## W3: Broad-suite harness/report truthfulness

Fixes the test runner so it never silently reports PASS when results are actually incomplete or inconclusive.

### Problem

The `print-summary` function showed raw stats (files passed/failed/timeouts, tests passed/failed) but **no explicit verdict line**. Timeout-heavy runs (common in the broad suite) could look like PASS at a glance because:
1. No "VERDICT: ..." line was printed
2. Zero-test files (exit=0 but no rackunit output parsed) were silently counted as "passed"
3. No programmatic way to ask "did this actually pass?"

### Changes

1. **`scripts/run-tests/reporting.rkt`**:
   - **`compute-verdict`**: New function returning `'pass`, `'fail`, `'incomplete`, or `'inconclusive` based on result analysis. `'fail` takes priority over `'incomplete`.
   - **`format-verdict-line`**: Renders verdict as a clear status line with emoji.
   - **`print-summary`** now:
     - Counts zero-test files and warns about them even in non-strict mode
     - Prints a prominent **VERDICT** line at the bottom: `✅ PASS` / `❌ FAIL` / `⏱ INCOMPLETE (N timeouts)` / `⚠ INCONCLUSIVE (0 tests parsed)`

2. **`scripts/run-tests.rkt`**: Re-exports `compute-verdict`.

3. **`tests/test-run-tests-reporting-truthfulness.rkt`** (NEW, 19 tests):
   - `compute-verdict`: all-pass, any-fail, timeout-only, fail+timeout priority, zero-test, mixed, empty
   - `summary-exit-code`: all 4 exit code combinations
   - `format-verdict-line`: all 4 verdict types
   - `print-summary`: verdict line appears for pass/fail/incomplete, zero-test warning

### Verification

- `test-run-tests-reporting-truthfulness.rkt`: 19/19 PASS
- `test-run-tests-script.rkt`: 6/6 PASS
- `test-run-tests-gate-evidence.rkt`: PASS
- `test-run-tests-timeout-cleanup.rkt`: 8/8 PASS
- `raco make main.rkt`: PASS

Closes #8283