### PR TITLE
W1: Commit README metrics + 0.99.29 release metadata (#8299)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,62 @@
+## 0.99.29
+
+Released: 2026-07-22
+
+### Overview
+Gate Truth Hotfix for v0.99.28. This release closes all six findings
+(B-1 through B-6) from the v0.99.28 in-depth audit before the M5/v1.0
+milestone. The hotfix focuses on gate truthfulness: ensuring that test
+results, audit narratives, and release-gate verdicts are accurate and
+verifiable.
+
+### Bug Fixes
+
+- **W0: Skill workflow E2E test hardening (B-1, BLOCKER)**.
+  `test-skill-workflow-e2e.rkt` now uses idempotent file writes
+  (`#:exists 'truncate/replace`) to prevent failures under `raco test`
+  lifecycle re-execution. Added `describe-state` diagnostic helper for
+  debugging skill discovery failures with contextual state information.
+
+### Documentation
+
+- **W1: Metrics sync and version bump (B-2, BLOCKER)**.
+  README metrics table synced with `--sync-all`. Version bumped to
+  0.99.29 in `util/version.rkt`, `info.rkt`, and README badge.
+
+- **W2: Truthful broad-suite triage (B-3, B-6)**.
+  `docs/reports/AUDIT-v0.99.29-BROAD-GATE-TRIAGE.md` reports actual
+  broad-suite results with honest verdict classification.
+
+- **W3: Corrected v0.99.28 narratives (B-4, B-5)**.
+  Errata added to v0.99.28 post-implementation audit, broad-gate triage,
+  and MAS completeness audit. Stale head commit references corrected.
+  False gate claims removed.
+
+### Breaking / Behavior Changes
+
+- None. All changes are test hardening, documentation corrections, and
+  version/metrics metadata.
+
+### Migration Notes
+
+- No API changes.
+
+### Testing
+
+- Skill workflow E2E: 5/5 PASS (verified over 10 consecutive `raco test` runs).
+- Full focused matrix (17 files): ALL PASS under `raco test`.
+- Zero regressions from v0.99.28.
+
+### Operational / Release
+
+- Broad-gate triage: `docs/reports/AUDIT-v0.99.29-BROAD-GATE-TRIAGE.md`.
+- Post-implementation audit: `docs/reports/AUDIT-v0.99.29-POST-IMPLEMENTATION.md`.
+
+### Stats
+- 1 hardened test file
+- 1 metrics sync
+- 4 audit/triage reports created or corrected
+
 ## 0.99.28
 
 Released: 2026-07-21

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.99.28-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.99.29-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 
@@ -208,7 +208,7 @@ bin/q --model gpt-5.4 "write a test"
 ### Verify
 
 ```bash
-bin/q --version            # q version 0.99.28
+bin/q --version            # q version 0.99.29
 raco test tests/           # run the full test suite
 ```
 
@@ -297,7 +297,7 @@ q/
 | Test files | 1067 |
 | Source modules | 680 |
 | Source lines | 107268 |
-| Test lines | 169783 |
+| Test lines | 169814 |
 | Test assertions | 26100 |
 | Tests passing | 5835+ | `racket scripts/run-tests.rkt` results |
 

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.99.28")
+(define version "0.99.29")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base" "gui-easy-lib"))

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -11,4 +11,4 @@
 
 (provide (contract-out [q-version string?]))
 
-(define q-version "0.99.28")
+(define q-version "0.99.29")


### PR DESCRIPTION
## W1: Commit README metrics + 0.99.29 release metadata

### Changes
- **Version bump**: 0.99.28 → 0.99.29 in `util/version.rkt`, `info.rkt`, README badge
- **Metrics sync**: Ran `--sync-all`, all 5 static metrics now match committed README
- **CHANGELOG**: Added full 0.99.29 entry with all required sections

### Gates Verified
- `metrics --lint`: All 5 static metrics match
- `lint-release-notes --version 0.99.29`: PASSED
- `test-version.rkt`: 3/3 PASS
- `raco make main.rkt`: PASS

Closes #8299