### PR TITLE
test: W0 runner overhead diagnostics

### DIFF
--- a/docs/reports/TEST-SUITE-BASELINE-v0.99.30.md
+++ b/docs/reports/TEST-SUITE-BASELINE-v0.99.30.md
@@ -1,0 +1,88 @@
+# Test Suite Baseline: v0.99.30 W0 — Overhead Diagnostics
+
+**Wave:** W0 (#8308)  
+**Branch:** `feature/v09930-w0-overhead-diagnostics`  
+**Purpose:** Establish measured test-runner startup/harness overhead before deeper runner architecture changes.
+
+---
+
+## 1. Diagnostic Command
+
+v0.99.30 W0 adds:
+
+```bash
+racket scripts/run-tests.rkt --diagnose-overhead
+```
+
+The command measures representative fixed-cost operations:
+
+- raw `racket -e '(void)'` process startup,
+- direct `racket` execution of an empty module,
+- `raco test` execution of an empty module,
+- `raco test` execution of a tiny rackunit module,
+- `raco test` execution of one normal project test (`tests/test-version.rkt`) when available.
+
+---
+
+## 2. Local Baseline
+
+Environment path:
+
+```text
+Base dir: /home/user/src/q-agent/q
+Racket:   /usr/bin/racket
+raco:     /usr/bin/raco
+```
+
+Observed output:
+
+```text
+racket-noop:              382ms exit=0
+racket-empty:             188ms exit=0
+raco-empty:               395ms exit=0
+raco-rackunit-empty:      474ms exit=0
+raco-representative-test: 479ms exit=0
+```
+
+## 3. Initial Interpretation
+
+On this local environment, per-file subprocess/raco overhead is sub-second (~0.4–0.5s for empty/rackunit files). This is consistent with the v0.99.28 local broad-gate observation that the suite can complete in minutes and return `VERDICT: FAIL` with 0 timeouts.
+
+This does **not** invalidate the remote VPS observation. Instead, it establishes that broad-suite behavior is environment-dependent and must be measured per profile:
+
+- local/dev may be able to complete the current subprocess-based broad runner,
+- VPS may be dominated by per-file subprocess overhead and return `INCOMPLETE`,
+- CI may differ again depending on bytecode cache, filesystem, and CPU scheduling.
+
+---
+
+## 4. Required Follow-up Measurements
+
+Run the same command on each execution profile:
+
+```bash
+racket scripts/run-tests.rkt --diagnose-overhead
+```
+
+Record:
+
+| Profile | racket-noop | racket-empty | raco-empty | raco-rackunit-empty | representative | Notes |
+|---------|-------------|--------------|------------|---------------------|----------------|-------|
+| local | 382ms | 188ms | 395ms | 474ms | 479ms | W0 local baseline |
+| vps | TBD | TBD | TBD | TBD | TBD | Needed to validate remote overhead finding |
+| ci | TBD | TBD | TBD | TBD | TBD | Needed before CI gate policy |
+
+---
+
+## 5. W0 Result
+
+W0 provides the measurement tool and first local baseline. Later waves should use this data to justify:
+
+- in-process or grouped execution for pure tests,
+- environment profiles,
+- truthful `FAIL` vs `INCOMPLETE` broad-suite reports,
+- release gate policy.
+
+---
+
+*Generated as part of v0.99.30 W0.*

--- a/scripts/run-tests.rkt
+++ b/scripts/run-tests.rkt
@@ -75,7 +75,20 @@
                   print-inventory
                   classify-exclusion-reason
                   detect-high-risk-flags
-                  compute-inventory-hash))
+                  compute-inventory-hash)
+         (only-in "run-tests/overhead.rkt"
+                  print-overhead-diagnostics
+                  collect-overhead-diagnostics
+                  format-overhead-result
+                  run-overhead-command
+                  make-overhead-result
+                  overhead-result?
+                  overhead-result-label
+                  overhead-result-command
+                  overhead-result-exit-code
+                  overhead-result-elapsed-ms
+                  overhead-result-stdout
+                  overhead-result-stderr))
 
 (provide test-file-result
          test-file-result?
@@ -124,7 +137,19 @@
          print-inventory
          classify-exclusion-reason
          detect-high-risk-flags
-         compute-inventory-hash)
+         compute-inventory-hash
+         print-overhead-diagnostics
+         collect-overhead-diagnostics
+         format-overhead-result
+         run-overhead-command
+         make-overhead-result
+         overhead-result?
+         overhead-result-label
+         overhead-result-command
+         overhead-result-exit-code
+         overhead-result-elapsed-ms
+         overhead-result-stdout
+         overhead-result-stderr)
 
 (define (build-result-from-process test-path stdout-out stderr-out ctrl timeout elapsed)
   (cond
@@ -305,9 +330,30 @@
   (values exit-code results))
 
 (define (main args)
-  (define-values (jobs sequential? timeout strict? suite extra-files repeat record-gate? inventory?)
+  (define-values (jobs
+                  sequential?
+                  timeout
+                  strict?
+                  suite
+                  extra-files
+                  repeat
+                  record-gate?
+                  inventory?
+                  diagnose-overhead?)
     (parse-args args))
-  (validate-args! jobs sequential? timeout strict? suite extra-files repeat record-gate? inventory?)
+  (validate-args! jobs
+                  sequential?
+                  timeout
+                  strict?
+                  suite
+                  extra-files
+                  repeat
+                  record-gate?
+                  inventory?
+                  diagnose-overhead?)
+  (when diagnose-overhead?
+    (print-overhead-diagnostics #:base-dir base-dir)
+    (exit 0))
   (define cleaned-dirs (clean-stale-bytecode! (current-directory)))
   (when (> cleaned-dirs 0)
     (printf ";; run-tests: cleaned ~a stale compiled/ director~a~n"

--- a/scripts/run-tests/cli.rkt
+++ b/scripts/run-tests/cli.rkt
@@ -28,6 +28,7 @@
   (displayln "  --repeat N        Run suite N times (exit 1 if any run fails)")
   (displayln "  --record-gate-evidence  Write .gate-evidence/<suite>.passed on success")
   (displayln "  --inventory             Print inventory report (selected/excluded files) and exit")
+  (displayln "  --diagnose-overhead     Measure Racket/raco per-file startup overhead and exit")
   (displayln "  --help            Show this help message")
   (newline)
   (displayln "Suites:")
@@ -52,15 +53,35 @@
              [extra '()]
              [repeat 1]
              [record-gate? #f]
-             [inventory? #f])
+             [inventory? #f]
+             [diagnose-overhead? #f])
     (match rest
       ['()
-       (values jobs sequential? timeout strict? suite (reverse extra) repeat record-gate? inventory?)]
+       (values jobs
+               sequential?
+               timeout
+               strict?
+               suite
+               (reverse extra)
+               repeat
+               record-gate?
+               inventory?
+               diagnose-overhead?)]
       [(list "--help" _ ...)
        (usage)
        (exit 0)]
       [(list "--strict" rest ...)
-       (loop rest jobs sequential? timeout #t suite extra repeat record-gate? inventory?)]
+       (loop rest
+             jobs
+             sequential?
+             timeout
+             #t
+             suite
+             extra
+             repeat
+             record-gate?
+             inventory?
+             diagnose-overhead?)]
       [(list "--jobs" n rest ...)
        (loop rest
              (string->number n)
@@ -71,9 +92,10 @@
              extra
              repeat
              record-gate?
-             inventory?)]
+             inventory?
+             diagnose-overhead?)]
       [(list "--sequential" rest ...)
-       (loop rest 1 #t timeout strict? suite extra repeat record-gate? inventory?)]
+       (loop rest 1 #t timeout strict? suite extra repeat record-gate? inventory? diagnose-overhead?)]
       [(list "--timeout" secs rest ...)
        (loop rest
              jobs
@@ -84,7 +106,8 @@
              extra
              repeat
              record-gate?
-             inventory?)]
+             inventory?
+             diagnose-overhead?)]
       [(list "--suite" name rest ...)
        (loop rest
              jobs
@@ -95,7 +118,8 @@
              extra
              repeat
              record-gate?
-             inventory?)]
+             inventory?
+             diagnose-overhead?)]
       [(list "--repeat" n rest ...)
        (loop rest
              jobs
@@ -106,11 +130,34 @@
              extra
              (string->number n)
              record-gate?
-             inventory?)]
+             inventory?
+             diagnose-overhead?)]
       [(list "--record-gate-evidence" rest ...)
-       (loop rest jobs sequential? timeout strict? suite extra repeat #t inventory?)]
+       (loop rest
+             jobs
+             sequential?
+             timeout
+             strict?
+             suite
+             extra
+             repeat
+             #t
+             inventory?
+             diagnose-overhead?)]
       [(list "--inventory" rest ...)
-       (loop rest jobs sequential? timeout strict? suite extra repeat record-gate? #t)]
+       (loop rest
+             jobs
+             sequential?
+             timeout
+             strict?
+             suite
+             extra
+             repeat
+             record-gate?
+             #t
+             diagnose-overhead?)]
+      [(list "--diagnose-overhead" rest ...)
+       (loop rest jobs sequential? timeout strict? suite extra repeat record-gate? inventory? #t)]
       [(list (regexp #rx"^--") rest ...)
        (eprintf "run-tests: unknown flag: ~a~n" (car rest))
        (usage)
@@ -125,11 +172,21 @@
              (cons arg extra)
              repeat
              record-gate?
-             inventory?)])))
+             inventory?
+             diagnose-overhead?)])))
 
 (define known-suites '(all fast slow smoke tui security arch runtime extensions workflows))
 
-(define (validate-args! jobs sequential? timeout strict? suite extra repeat record-gate? inventory?)
+(define (validate-args! jobs
+                        sequential?
+                        timeout
+                        strict?
+                        suite
+                        extra
+                        repeat
+                        record-gate?
+                        inventory?
+                        diagnose-overhead?)
   (unless (memq suite known-suites)
     (raise-user-error 'run-tests
                       "unknown suite: ~a (valid: ~a)"

--- a/scripts/run-tests/overhead.rkt
+++ b/scripts/run-tests/overhead.rkt
@@ -1,0 +1,116 @@
+#lang racket/base
+
+;; q/scripts/run-tests/overhead.rkt — test-runner overhead diagnostics
+;;
+;; W0 of v0.99.30: measure fixed-cost process/test startup overhead so
+;; local/VPS/CI broad-suite behavior can be reported with evidence instead
+;; of conjecture.
+
+(require racket/file
+         racket/format
+         racket/list
+         racket/match
+         racket/math
+         racket/path
+         racket/port
+         racket/string
+         racket/system)
+
+(provide (struct-out overhead-result)
+         make-overhead-result
+         run-overhead-command
+         collect-overhead-diagnostics
+         format-overhead-result
+         print-overhead-diagnostics)
+
+(struct overhead-result (label command exit-code elapsed-ms stdout stderr) #:transparent)
+
+(define (make-overhead-result label command exit-code elapsed-ms stdout stderr)
+  (overhead-result label command exit-code elapsed-ms stdout stderr))
+
+(define (now-ms)
+  (current-inexact-milliseconds))
+
+(define (elapsed-since t0)
+  (exact-round (- (now-ms) t0)))
+
+(define (run-overhead-command label executable args #:cwd [cwd (current-directory)])
+  (define exe-path (find-executable-path executable))
+  (unless exe-path
+    (error 'run-overhead-command "executable not found: ~a" executable))
+  (define stdout-out (open-output-string))
+  (define stderr-out (open-output-string))
+  (define command-text (string-join (cons executable args) " "))
+  (define t0 (now-ms))
+  (define-values (_proc stdin _pid _stderr ctrl)
+    (parameterize ([current-directory cwd])
+      (apply values (apply process*/ports stdout-out #f stderr-out exe-path args))))
+  (when stdin
+    (close-output-port stdin))
+  (ctrl 'wait)
+  (define exit-code (ctrl 'exit-code))
+  (make-overhead-result label
+                        command-text
+                        exit-code
+                        (elapsed-since t0)
+                        (get-output-string stdout-out)
+                        (get-output-string stderr-out)))
+
+(define (write-file path content)
+  (call-with-output-file path #:exists 'replace (lambda (out) (display content out))))
+
+(define (collect-overhead-diagnostics #:base-dir [base-dir (current-directory)])
+  (define temp-dir (make-temporary-file "q-run-tests-overhead-~a" 'directory))
+  (define empty-file (build-path temp-dir "empty.rkt"))
+  (define rackunit-file (build-path temp-dir "rackunit-empty.rkt"))
+  (write-file empty-file "#lang racket/base\n(void)\n")
+  (write-file rackunit-file
+              (string-append
+               "#lang racket\n"
+               "(require rackunit rackunit/text-ui)\n"
+               "(run-tests (test-suite \"empty\" (test-case \"ok\" (check-true #t))))\n"))
+  (define representative (build-path base-dir "tests" "test-version.rkt"))
+  (define commands
+    (append
+     (list (list "racket-noop" "racket" (list "-e" "(void)"))
+           (list "racket-empty" "racket" (list (path->string empty-file)))
+           (list "raco-empty" "raco" (list "test" (path->string empty-file)))
+           (list "raco-rackunit-empty" "raco" (list "test" (path->string rackunit-file))))
+     (if (file-exists? representative)
+         (list (list "raco-representative-test" "raco" (list "test" (path->string representative))))
+         '())))
+  (dynamic-wind void
+                (lambda ()
+                  (for/list ([cmd (in-list commands)])
+                    (match cmd
+                      [(list label exe args) (run-overhead-command label exe args #:cwd base-dir)])))
+                (lambda ()
+                  (when (directory-exists? temp-dir)
+                    (delete-directory/files temp-dir)))))
+
+(define (format-overhead-result r)
+  (format "  ~a: ~ams exit=~a cmd=~a"
+          (overhead-result-label r)
+          (overhead-result-elapsed-ms r)
+          (overhead-result-exit-code r)
+          (overhead-result-command r)))
+
+(define (print-overhead-diagnostics #:base-dir [base-dir (current-directory)])
+  (displayln "═══════════════════════════════════════════════════════════")
+  (displayln "              TEST RUNNER OVERHEAD DIAGNOSTIC")
+  (displayln "═══════════════════════════════════════════════════════════")
+  (printf "  Base dir:   ~a~n" (path->string (simplify-path base-dir)))
+  (printf "  Racket:     ~a~n" (or (find-executable-path "racket") "not found"))
+  (printf "  raco:       ~a~n" (or (find-executable-path "raco") "not found"))
+  (newline)
+  (define results (collect-overhead-diagnostics #:base-dir base-dir))
+  (for ([r (in-list results)])
+    (displayln (format-overhead-result r)))
+  (newline)
+  (displayln "Interpretation:")
+  (displayln "  - racket-noop approximates raw Racket process startup cost.")
+  (displayln "  - raco-empty approximates per-file raco test harness overhead.")
+  (displayln "  - raco-rackunit-empty approximates parser-visible rackunit overhead.")
+  (displayln "  - raco-representative-test samples one normal project test when available.")
+  (displayln "═══════════════════════════════════════════════════════════")
+  results)

--- a/tests/test-run-tests-overhead-diagnostics.rkt
+++ b/tests/test-run-tests-overhead-diagnostics.rkt
@@ -1,0 +1,53 @@
+#lang racket
+
+;; @speed fast
+;; @suite testing
+;; @isolation subprocess
+
+;; tests/test-run-tests-overhead-diagnostics.rkt
+;; W0: verifies the run-tests overhead diagnostics entry points.
+
+(require rackunit
+         rackunit/text-ui
+         racket/runtime-path
+         racket/system
+         racket/string
+         "../scripts/run-tests/overhead.rkt")
+
+(define-runtime-path here ".")
+(define project-root (simplify-path (build-path here "..")))
+
+(define (run/capture cmd)
+  (parameterize ([current-directory project-root])
+    (define out (open-output-string))
+    (define err (open-output-string))
+    (define code
+      (parameterize ([current-output-port out]
+                     [current-error-port err])
+        (system/exit-code cmd)))
+    (values code (get-output-string out) (get-output-string err))))
+
+(define suite
+  (test-suite "run-tests overhead diagnostics"
+
+    (test-case "make-overhead-result records label command exit and elapsed"
+      (define r (make-overhead-result "noop" "racket -e '(void)'" 0 12 "" ""))
+      (check-equal? (overhead-result-label r) "noop")
+      (check-equal? (overhead-result-command r) "racket -e '(void)'")
+      (check-equal? (overhead-result-exit-code r) 0)
+      (check-equal? (overhead-result-elapsed-ms r) 12))
+
+    (test-case "format-overhead-result includes useful fields"
+      (define line (format-overhead-result (make-overhead-result "simple" "cmd" 0 25 "" "")))
+      (check-true (string-contains? line "simple"))
+      (check-true (string-contains? line "25ms"))
+      (check-true (string-contains? line "exit=0")))
+
+    (test-case "diagnose command exits successfully and prints report header"
+      (define-values (code out err) (run/capture "racket scripts/run-tests.rkt --diagnose-overhead"))
+      (check-equal? code 0 err)
+      (check-true (string-contains? out "TEST RUNNER OVERHEAD DIAGNOSTIC"))
+      (check-true (string-contains? out "racket-noop"))
+      (check-true (string-contains? out "raco-empty")))))
+
+(run-tests suite)


### PR DESCRIPTION
## Summary

Implements v0.99.30 W0 baseline measurement + overhead diagnostics.

- Adds `scripts/run-tests/overhead.rkt`
- Adds `--diagnose-overhead` CLI early-exit mode
- Adds unit/CLI coverage for diagnostics
- Adds `docs/reports/TEST-SUITE-BASELINE-v0.99.30.md`

## Verification

- `raco make scripts/run-tests.rkt scripts/run-tests/cli.rkt scripts/run-tests/overhead.rkt`
- `raco test tests/test-run-tests-overhead-diagnostics.rkt tests/test-run-tests-script.rkt tests/test-run-tests-reporting-truthfulness.rkt tests/test-run-tests-gate-evidence.rkt tests/test-run-tests-timeout-cleanup.rkt`
- `racket scripts/run-tests.rkt --diagnose-overhead`
- `timeout 900 racket scripts/run-tests.rkt --suite fast` → known broad debt: 951 files, 887 passed, 64 failed, 0 timeouts, 6 zero-parsed, VERDICT FAIL

Closes #8308.