### PR TITLE
test: W1 runner metadata discovery schema

### DIFF
--- a/scripts/run-tests/classify.rkt
+++ b/scripts/run-tests/classify.rkt
@@ -52,6 +52,22 @@
 (define (clear-metadata-cache!)
   (hash-clear! metadata-cache))
 
+(define (metadata-tokens raw)
+  (filter (lambda (s) (not (string=? s ""))) (regexp-split #rx"[ ,\t]+" (string-trim raw))))
+
+(define (metadata-bool raw default)
+  (define normalized (string-downcase (string-trim raw)))
+  (cond
+    [(string=? normalized "") default]
+    [(member normalized '("true" "yes" "1" "on")) #t]
+    [(member normalized '("false" "no" "0" "off")) #f]
+    [else default]))
+
+(define (metadata-line-match line tag)
+  (define pattern (pregexp (format "@~a(?:[[:space:]]+([^;]*))?" (regexp-quote tag))))
+  (define m (regexp-match pattern line))
+  (and m (list line (string-trim (or (cadr m) "")))))
+
 (define (get-file-metadata f)
   (hash-ref!
    metadata-cache
@@ -61,53 +77,71 @@
        (if (absolute-path? f)
            f
            (build-path base-dir f)))
-     (if (file-exists? full-path)
-         (let ([speed #f]
-               [suite #f]
-               [mutates #f]
-               [boundary #f]
-               [isolation #f]
-               [timeout #f])
-           (with-handlers ([exn:fail? (lambda (_) (void))])
-             (call-with-input-file
-              full-path
-              (lambda (port)
-                (for ([_ (in-range 30)]
-                      #:break (eof-object? (peek-byte port)))
-                  (define line (read-line port))
-                  (when (string? line)
-                    (cond
-                      [(regexp-match? #rx";+[ \t]*@speed[ \t]+fast" line) (set! speed 'fast)]
-                      [(regexp-match? #rx";+[ \t]*@speed[ \t]+slow" line) (set! speed 'slow)]
-                      [(regexp-match? #rx";+[ \t]*@speed[ \t]+perf" line) (set! speed 'perf)]
-                      [(regexp-match #rx";+[ \t]*@suite[ \t]+(.+)$" line)
-                       =>
-                       (lambda (m) (set! suite (string-trim (cadr m))))]
-                      [(regexp-match #rx";+[ \t]*@mutates[ \t]+(.+)$" line)
-                       =>
-                       (lambda (m) (set! mutates (string-trim (cadr m))))]
-                      [(regexp-match #rx";+[ \t]*@boundary[ \t]+(.+)$" line)
-                       =>
-                       (lambda (m) (set! boundary (string-trim (cadr m))))]
-                      [(regexp-match #rx";+[ \t]*@isolation[ \t]+(.+)$" line)
-                       =>
-                       (lambda (m) (set! isolation (string-trim (cadr m))))]
-                      [(regexp-match #rx";+[ \t]*@timeout[ \t]+([0-9]+)" line)
-                       =>
-                       (lambda (m) (set! timeout (string->number (cadr m))))]))))))
-           (hash 'speed
-                 speed
-                 'suite
-                 suite
-                 'mutates
-                 mutates
-                 'boundary
-                 boundary
-                 'isolation
-                 isolation
-                 'timeout
-                 timeout))
-         (hash)))))
+     (cond
+       [(not (file-exists? full-path)) (hash)]
+       [else
+        (define speed #f)
+        (define suite #f)
+        (define suites '())
+        (define requires '())
+        (define not-test? #f)
+        (define mutates #f)
+        (define boundary #f)
+        (define isolation #f)
+        (define timeout #f)
+        (with-handlers ([exn:fail? (lambda (_) (void))])
+          (call-with-input-file full-path
+                                (lambda (port)
+                                  (for ([_ (in-range 50)]
+                                        #:break (eof-object? (peek-byte port)))
+                                    (define line (read-line port))
+                                    (when (string? line)
+                                      (define speed-match (metadata-line-match line "speed"))
+                                      (when speed-match
+                                        (define toks (metadata-tokens (cadr speed-match)))
+                                        (when (pair? toks)
+                                          (set! speed (string->symbol (car toks)))))
+                                      (define suite-match (metadata-line-match line "suite"))
+                                      (when suite-match
+                                        (set! suites (metadata-tokens (cadr suite-match)))
+                                        (set! suite (and (pair? suites) (car suites))))
+                                      (define requires-match (metadata-line-match line "requires"))
+                                      (when requires-match
+                                        (set! requires (metadata-tokens (cadr requires-match))))
+                                      (define not-test-match (metadata-line-match line "not-test"))
+                                      (when not-test-match
+                                        (set! not-test? (metadata-bool (cadr not-test-match) #t)))
+                                      (define mutates-match (metadata-line-match line "mutates"))
+                                      (when mutates-match
+                                        (set! mutates (string-trim (cadr mutates-match))))
+                                      (define boundary-match (metadata-line-match line "boundary"))
+                                      (when boundary-match
+                                        (set! boundary (string-trim (cadr boundary-match))))
+                                      (define isolation-match (metadata-line-match line "isolation"))
+                                      (when isolation-match
+                                        (set! isolation (string-trim (cadr isolation-match))))
+                                      (define timeout-match
+                                        (regexp-match #rx";+[ \\t]*@timeout[ \\t]+([0-9]+)" line))
+                                      (when timeout-match
+                                        (set! timeout (string->number (cadr timeout-match)))))))))
+        (hash 'speed
+              speed
+              'suite
+              suite
+              'suites
+              suites
+              'requires
+              requires
+              'not-test?
+              not-test?
+              'mutates
+              mutates
+              'boundary
+              boundary
+              'isolation
+              isolation
+              'timeout
+              timeout)]))))
 
 ;; ============================================================
 ;; Patterns
@@ -197,15 +231,9 @@
       (file-has-suite-tag? f "security")))
 
 (define (file-has-suite-tag? f tag)
-  (with-safe-fallback #f
-                      (call-with-input-file f
-                                            (lambda (port)
-                                              (define target (string-append "@suite " tag))
-                                              (for/or ([_ (in-range 10)]
-                                                       #:break (eof-object? (peek-byte port)))
-                                                (define line (read-line port))
-                                                (and (string? line)
-                                                     (string-contains? line target)))))))
+  (define meta (get-file-metadata f))
+  (define suites (hash-ref meta 'suites '()))
+  (or (member tag suites) #f))
 
 (define (smoke-excluded? f)
   (or (slow-file? f) (string-contains? f "/workflows/") (string-contains? f "/interfaces/")))
@@ -303,10 +331,12 @@
      (define all-files
        (for/list ([f (in-directory (build-path base-dir "tests"))]
                   #:when (and (file-exists? f)
-                              (let ([s (path->string f)])
+                              (let* ([s (path->string f)]
+                                     [rel (path->string (find-relative-path base-dir f))])
                                 (and (string-suffix? s ".rkt")
                                      (not (string-contains? s "/compiled/"))
-                                     (not (support-test-module? s))))))
+                                     (not (support-test-module? s))
+                                     (not (hash-ref (get-file-metadata rel) 'not-test? #f))))))
          (path->string (find-relative-path base-dir f))))
      (case suite
        [(all) all-files]

--- a/scripts/run-tests/inventory.rkt
+++ b/scripts/run-tests/inventory.rkt
@@ -18,7 +18,8 @@
                   runtime-file?
                   extensions-file?
                   workflows-file?
-                  support-test-module?))
+                  support-test-module?
+                  get-file-metadata))
 
 (provide print-inventory
          classify-exclusion-reason
@@ -30,6 +31,7 @@
     [(string-contains? f "/compiled/") 'compiled]
     [(not (string-suffix? f ".rkt")) 'non-rkt]
     [(support-test-module? f) 'support-module]
+    [(hash-ref (get-file-metadata f) 'not-test? #f) 'metadata-not-test]
     [else 'unknown]))
 
 (define (detect-high-risk-flags f)

--- a/tests/mock-worker.rkt
+++ b/tests/mock-worker.rkt
@@ -1,6 +1,7 @@
 #!/usr/bin/env racket
 #lang racket/base
 
+;; @not-test
 ;; Mock worker for gateway-ipc tests.
 ;; Reads newline-delimited JSON on stdin, echoes back responses.
 ;;

--- a/tests/test-run-tests-metadata-discovery.rkt
+++ b/tests/test-run-tests-metadata-discovery.rkt
@@ -1,0 +1,66 @@
+#lang racket
+
+(require rackunit
+         rackunit/text-ui
+         racket/file
+         racket/path
+         racket/runtime-path
+         "../scripts/run-tests.rkt")
+
+(define-runtime-path here ".")
+
+(define (write-lines path lines)
+  (call-with-output-file path
+                         #:exists 'replace
+                         (lambda (out)
+                           (for ([line (in-list lines)])
+                             (displayln line out)))))
+
+(define metadata-discovery-tests
+  (test-suite "run-tests metadata discovery"
+
+    (test-case "metadata parser recognizes v0.99.30 schema tags"
+      (define tmp (make-temporary-file "q-run-tests-metadata-~a.rkt"))
+      (dynamic-wind void
+                    (lambda ()
+                      (write-lines tmp
+                                   '("#lang racket" ";; @suite smoke tui"
+                                                    ";; @speed fast"
+                                                    ";; @requires network browser"
+                                                    ";; @isolation subprocess"
+                                                    ";; @not-test false"
+                                                    "(require rackunit)"
+                                                    "(check-true #t)"))
+                      (clear-metadata-cache!)
+                      (define meta (get-file-metadata tmp))
+                      (check-equal? (hash-ref meta 'speed #f) 'fast)
+                      (check-equal? (hash-ref meta 'suite #f) "smoke")
+                      (check-equal? (hash-ref meta 'suites #f) '("smoke" "tui"))
+                      (check-equal? (hash-ref meta 'requires #f) '("network" "browser"))
+                      (check-equal? (hash-ref meta 'isolation #f) "subprocess")
+                      (check-false (hash-ref meta 'not-test? #t)))
+                    (lambda ()
+                      (when (file-exists? tmp)
+                        (delete-file tmp))
+                      (clear-metadata-cache!))))
+
+    (test-case "bare @not-test metadata excludes helper files from discovery"
+      (define fixture (build-path here "test-w1-not-test-fixture.rkt"))
+      (dynamic-wind (lambda ()
+                      (write-lines fixture
+                                   '("#lang racket" ";; @not-test"
+                                                    ";; helper module intentionally named test-*"
+                                                    "(provide helper-value)"
+                                                    "(define helper-value 42)"))
+                      (clear-metadata-cache!))
+                    (lambda ()
+                      (define rel "tests/test-w1-not-test-fixture.rkt")
+                      (check-true (hash-ref (get-file-metadata rel) 'not-test? #f))
+                      (check-false (member rel (collect-test-files 'all)))
+                      (check-equal? (classify-exclusion-reason rel) 'metadata-not-test))
+                    (lambda ()
+                      (when (file-exists? fixture)
+                        (delete-file fixture))
+                      (clear-metadata-cache!))))))
+
+(run-tests metadata-discovery-tests)


### PR DESCRIPTION
## Summary

Implements v0.99.30 W1 test metadata schema + discovery cleanup.

- Parses `@suite`, `@speed`, `@requires`, `@isolation`, and `@not-test` metadata.
- Supports multiple metadata tags on one comment line, preserving existing `;; @speed ... ;; @suite ...` files.
- Excludes files marked `@not-test` from test discovery.
- Reports `metadata-not-test` in inventory exclusion reasons.
- Marks `tests/mock-worker.rkt` as an explicit helper/non-test.
- Adds focused metadata/discovery regression tests.

## Verification

- `raco fmt -i scripts/run-tests/classify.rkt scripts/run-tests/inventory.rkt tests/test-run-tests-metadata-discovery.rkt tests/mock-worker.rkt`
- `raco make scripts/run-tests.rkt scripts/run-tests/classify.rkt scripts/run-tests/inventory.rkt tests/test-run-tests-metadata-discovery.rkt tests/mock-worker.rkt`
- `raco test tests/test-run-tests-metadata-discovery.rkt tests/test-run-tests-script.rkt tests/test-run-tests-overhead-diagnostics.rkt tests/test-run-tests-reporting-truthfulness.rkt tests/test-run-tests-gate-evidence.rkt tests/test-run-tests-timeout-cleanup.rkt`
- `racket scripts/run-tests.rkt --suite all --inventory | grep 'tests/mock-worker.rkt'` → `[reason: metadata-not-test]`
- `timeout 600 racket scripts/run-tests.rkt --suite smoke` → known debt: 945 files, 883 passed, 62 failed, 0 timeouts, 5 zero-parsed, VERDICT FAIL
- `timeout 900 racket scripts/run-tests.rkt --suite fast` → known debt: 949 files, 886 passed, 63 failed, 0 timeouts, 5 zero-parsed, VERDICT FAIL

Closes #8309.