### PR TITLE
test: W2 eliminate zero-parsed false greens

### DIFF
--- a/tests/test-context-assembly-config.rkt
+++ b/tests/test-context-assembly-config.rkt
@@ -1,5 +1,6 @@
 #lang racket/base
 
+;; @not-test
 ;; @skip BROKEN: Tests obsolete 12-field context-assembly-config struct.
 ;; The config was refactored to a 4-field struct (recent-tokens,
 ;; max-catalog-entries, max-catalog-tokens, summary-window) in budgeting.rkt.

--- a/tests/test-cursor-debug.rkt
+++ b/tests/test-cursor-debug.rkt
@@ -1,4 +1,5 @@
 #lang racket
+;; @not-test
 ;; @speed fast
 ;; @suite tui
 

--- a/tests/test-event-ordering.rkt
+++ b/tests/test-event-ordering.rkt
@@ -185,3 +185,5 @@
       (check-equal? (last events)
                     "stream.turn.completed"
                     "turn.completed must be the last event in the sequence"))))
+
+(run-tests event-ordering-tests)

--- a/tests/test-run-tests-zero-parsed-elimination.rkt
+++ b/tests/test-run-tests-zero-parsed-elimination.rkt
@@ -1,0 +1,29 @@
+#lang racket/base
+
+;; Regression coverage for v0.99.30 W2 zero-parsed false-green elimination.
+
+(require rackunit
+         rackunit/text-ui
+         "../scripts/run-tests.rkt")
+
+(define zero-parsed-elimination-tests
+  (test-suite "run-tests zero-parsed elimination"
+
+    (test-case "known helper/debug/obsolete files are explicitly excluded"
+      (clear-metadata-cache!)
+      (define files (collect-test-files 'all))
+      (for ([path (in-list '("tests/test-context-assembly-config.rkt"
+                             "tests/test-cursor-debug.rkt"
+                             "tests/tui/test-error-scenarios.rkt"))])
+        (check-true (hash-ref (get-file-metadata path) 'not-test? #f) path)
+        (check-false (member path files) path)
+        (check-equal? (classify-exclusion-reason path) 'metadata-not-test path)))
+
+    (test-case "fixed suites produce parsed rackunit counts"
+      (for ([path (in-list '("tests/test-event-ordering.rkt" "tests/test-vision-helpers.rkt"))]
+            [expected (in-list '(3 6))])
+        (define result (run-single-file path #:timeout 120000))
+        (check-equal? (test-file-result-exit-code result) 0 path)
+        (check-equal? (test-file-result-total result) expected path)))))
+
+(run-tests zero-parsed-elimination-tests)

--- a/tests/test-vision-helpers.rkt
+++ b/tests/test-vision-helpers.rkt
@@ -3,40 +3,44 @@
 ;; tests/test-vision-helpers.rkt — Unit tests for llm/vision-helpers.rkt (NF-10/F-07)
 
 (require rackunit
+         rackunit/text-ui
          "../llm/vision-helpers.rkt")
 
 ;; ---------------------------------------------------------------------------
 ;; parse-data-url
 ;; ---------------------------------------------------------------------------
 
-(test-suite "vision-helpers: parse-data-url"
+(define vision-helpers-tests
+  (test-suite "vision-helpers: parse-data-url"
 
-  (test-case "valid JPEG data URL"
-    (define-values (mime data) (parse-data-url "data:image/jpeg;base64,/9j/4AAQSkZJRg=="))
-    (check-equal? mime "image/jpeg")
-    (check-equal? data "/9j/4AAQSkZJRg=="))
+    (test-case "valid JPEG data URL"
+      (define-values (mime data) (parse-data-url "data:image/jpeg;base64,/9j/4AAQSkZJRg=="))
+      (check-equal? mime "image/jpeg")
+      (check-equal? data "/9j/4AAQSkZJRg=="))
 
-  (test-case "valid PNG data URL"
-    (define-values (mime data) (parse-data-url "data:image/png;base64,iVBORw0KGgo="))
-    (check-equal? mime "image/png")
-    (check-equal? data "iVBORw0KGgo="))
+    (test-case "valid PNG data URL"
+      (define-values (mime data) (parse-data-url "data:image/png;base64,iVBORw0KGgo="))
+      (check-equal? mime "image/png")
+      (check-equal? data "iVBORw0KGgo="))
 
-  (test-case "non-data URL falls back to image/png + raw URL"
-    (define-values (mime data) (parse-data-url "https://example.com/image.jpg"))
-    (check-equal? mime "image/png")
-    (check-equal? data "https://example.com/image.jpg"))
+    (test-case "non-data URL falls back to image/png + raw URL"
+      (define-values (mime data) (parse-data-url "https://example.com/image.jpg"))
+      (check-equal? mime "image/png")
+      (check-equal? data "https://example.com/image.jpg"))
 
-  (test-case "empty string falls back"
-    (define-values (mime data) (parse-data-url ""))
-    (check-equal? mime "image/png")
-    (check-equal? data ""))
+    (test-case "empty string falls back"
+      (define-values (mime data) (parse-data-url ""))
+      (check-equal? mime "image/png")
+      (check-equal? data ""))
 
-  (test-case "data URL without base64 marker falls back"
-    (define-values (mime data) (parse-data-url "data:text/html,hello"))
-    (check-equal? mime "image/png")
-    (check-equal? data "data:text/html,hello"))
+    (test-case "data URL without base64 marker falls back"
+      (define-values (mime data) (parse-data-url "data:text/html,hello"))
+      (check-equal? mime "image/png")
+      (check-equal? data "data:text/html,hello"))
 
-  (test-case "webp MIME type preserved"
-    (define-values (mime data) (parse-data-url "data:image/webp;base64,UklGRiQ="))
-    (check-equal? mime "image/webp")
-    (check-equal? data "UklGRiQ=")))
+    (test-case "webp MIME type preserved"
+      (define-values (mime data) (parse-data-url "data:image/webp;base64,UklGRiQ="))
+      (check-equal? mime "image/webp")
+      (check-equal? data "UklGRiQ="))))
+
+(run-tests vision-helpers-tests)

--- a/tests/tui/test-error-scenarios.rkt
+++ b/tests/tui/test-error-scenarios.rkt
@@ -1,5 +1,6 @@
 #lang racket
 
+;; @not-test
 ;; @speed fast  ;; @suite tui
 
 ;; BOUNDARY: io


### PR DESCRIPTION
## Summary

Implements v0.99.30 W2 zero-parsed false-green elimination.

- Explicitly excludes obsolete/helper/debug files with `@not-test`:
  - `tests/test-context-assembly-config.rkt`
  - `tests/test-cursor-debug.rkt`
  - `tests/tui/test-error-scenarios.rkt`
- Fixes real RackUnit suites to emit parsed counts:
  - `tests/test-event-ordering.rkt` now runs `event-ordering-tests`.
  - `tests/test-vision-helpers.rkt` now names/runs `vision-helpers-tests`.
- Adds `tests/test-run-tests-zero-parsed-elimination.rkt` regression coverage for exclusions and parsed counts.

## Verification

- `raco fmt -i tests/test-context-assembly-config.rkt tests/test-cursor-debug.rkt tests/test-event-ordering.rkt tests/test-vision-helpers.rkt tests/tui/test-error-scenarios.rkt tests/test-run-tests-zero-parsed-elimination.rkt`
- `raco make tests/test-context-assembly-config.rkt tests/test-cursor-debug.rkt tests/test-event-ordering.rkt tests/test-vision-helpers.rkt tests/tui/test-error-scenarios.rkt tests/test-run-tests-zero-parsed-elimination.rkt scripts/run-tests.rkt`
- `raco test tests/test-run-tests-zero-parsed-elimination.rkt tests/test-run-tests-metadata-discovery.rkt tests/test-run-tests-script.rkt tests/test-event-ordering.rkt tests/test-vision-helpers.rkt` → 19 tests passed
- Discovery query: excluded files `discovered=#f`; fixed suites `discovered=#t`
- `timeout 600 racket scripts/run-tests.rkt --suite smoke` → 942 files, 878 passed, 64 failed, 0 timeouts, no zero-parsed summary, VERDICT FAIL
- Required fast gate: `timeout 900 racket scripts/run-tests.rkt --suite fast` → 946 files, 883 passed, 63 failed, 0 timeouts, 11864 tests, 11800 passed, 64 failed, no zero-parsed summary, VERDICT FAIL

Closes #8310.