### PR TITLE
feat: W3 add in-process/grouped test runner mode

### DIFF
--- a/scripts/run-tests.rkt
+++ b/scripts/run-tests.rkt
@@ -21,6 +21,7 @@
          racket/port
          racket/list
          racket/future
+         racket/exn
          (only-in "run-tests/classify.rkt"
                   base-dir
                   normalize-test-path
@@ -38,6 +39,7 @@
                   runtime-file?
                   extensions-file?
                   workflows-file?
+                  unit-fast-file?
                   support-test-module?
                   smoke-excluded?
                   slow-patterns
@@ -69,7 +71,7 @@
                   summary-exit-code
                   compute-verdict
                   make-unique-log-name)
-         (only-in "run-tests/cli.rkt" usage parse-args validate-args! known-suites)
+         (only-in "run-tests/cli.rkt" usage parse-args validate-args! known-suites known-modes)
          (only-in "run-tests/gate-evidence.rkt" record-gate-evidence!)
          (only-in "run-tests/inventory.rkt"
                   print-inventory
@@ -124,11 +126,13 @@
          runtime-file?
          extensions-file?
          workflows-file?
+         unit-fast-file?
          slow-file?
          tui-file?
          mutating-file?
          validate-args!
          known-suites
+         known-modes
          record-gate-evidence!
          get-file-metadata
          clear-metadata-cache!
@@ -203,16 +207,38 @@
                        failed
                        total)]))
 
-(define (run-single-file test-path #:timeout [timeout #f])
-  (define resolved-path
-    (if (absolute-path? test-path)
+(define (resolve-test-path test-path)
+  (define p
+    (if (path? test-path)
         test-path
-        (simplify-path (build-path base-dir test-path))))
-  (define file-timeout
-    (let ([meta-timeout (hash-ref (get-file-metadata test-path) 'timeout #f)])
-      (if meta-timeout
-          (* meta-timeout 1000)
-          (or timeout 120000))))
+        (string->path test-path)))
+  (if (absolute-path? p)
+      p
+      (simplify-path (build-path base-dir p))))
+
+(define (file-timeout-ms test-path timeout)
+  (let ([meta-timeout (hash-ref (get-file-metadata test-path) 'timeout #f)])
+    (if meta-timeout
+        (* meta-timeout 1000)
+        (or timeout 120000))))
+
+(define (parse-result-bytes test-path stdout-bytes stderr-bytes exit-code elapsed-ms)
+  (define merged-bytes (bytes-append stdout-bytes stderr-bytes))
+  (define-values (parsed-passed parsed-failed parsed-total) (parse-raco-output merged-bytes))
+  (define-values (passed failed total)
+    (normalize-counts exit-code parsed-passed parsed-failed parsed-total))
+  (test-file-result test-path
+                    (effective-exit-code exit-code failed)
+                    stdout-bytes
+                    stderr-bytes
+                    elapsed-ms
+                    passed
+                    failed
+                    total))
+
+(define (run-single-file/subprocess test-path #:timeout [timeout #f])
+  (define resolved-path (resolve-test-path test-path))
+  (define file-timeout (file-timeout-ms test-path timeout))
   (define t0 (current-inexact-milliseconds))
   (define elapsed (lambda () (exact-round (- (current-inexact-milliseconds) t0))))
   (define stdout-out (open-output-string))
@@ -234,12 +260,66 @@
           ctrl)))
   (build-result-from-process test-path stdout-out stderr-out ctrl file-timeout elapsed))
 
+(define (module-plus-test-file? path)
+  (and (file-exists? path) (regexp-match? #px"\\(module\\+\\s+test\\b" (file->string path))))
+
+(define (in-process-module-path resolved-path)
+  (if (module-plus-test-file? resolved-path)
+      (make-resolved-module-path (cons resolved-path '(test)))
+      (make-resolved-module-path resolved-path)))
+
+(define (in-process-eligible? resolved-path)
+  (or (module-plus-test-file? resolved-path) (not (file-has-rackunit-tests? resolved-path))))
+
+(define (run-single-file/in-process test-path #:timeout [timeout #f])
+  (define resolved-path (resolve-test-path test-path))
+  ;; Bare RackUnit files without run-tests/module+ still need raco's discovery output;
+  ;; fall back to subprocess to avoid reintroducing zero-parsed false greens.
+  (cond
+    [(not (in-process-eligible? resolved-path))
+     (run-single-file/subprocess test-path #:timeout timeout)]
+    [else
+     (define file-timeout (file-timeout-ms test-path timeout))
+     (define t0 (current-inexact-milliseconds))
+     (define elapsed (lambda () (exact-round (- (current-inexact-milliseconds) t0))))
+     (define stdout-out (open-output-string))
+     (define stderr-out (open-output-string))
+     (define exit-code (box #f))
+     (define cust (make-custodian))
+     (define worker
+       (parameterize ([current-custodian cust])
+         (thread (lambda ()
+                   (with-handlers ([exn:fail? (lambda (e)
+                                                (displayln (exn->string e) stderr-out)
+                                                (set-box! exit-code 1))])
+                     (parameterize ([current-output-port stdout-out]
+                                    [current-error-port stderr-out]
+                                    [current-directory base-dir]
+                                    [current-command-line-arguments #()]
+                                    [current-namespace (make-base-namespace)])
+                       (dynamic-require (in-process-module-path resolved-path) #f)
+                       (set-box! exit-code 0)))))))
+     (define completed? (sync/timeout (/ file-timeout 1000.0) worker))
+     (unless completed?
+       (custodian-shutdown-all cust))
+     (define stdout-bytes (string->bytes/utf-8 (get-output-string stdout-out)))
+     (define stderr-bytes (string->bytes/utf-8 (get-output-string stderr-out)))
+     (if completed?
+         (parse-result-bytes test-path stdout-bytes stderr-bytes (or (unbox exit-code) 0) (elapsed))
+         (test-file-result test-path 2 stdout-bytes stderr-bytes (elapsed) 0 0 0))]))
+
+(define (run-single-file test-path #:timeout [timeout #f] #:mode [mode 'subprocess])
+  (case mode
+    [(in-process grouped) (run-single-file/in-process test-path #:timeout timeout)]
+    [(auto subprocess) (run-single-file/subprocess test-path #:timeout timeout)]
+    [else (run-single-file/subprocess test-path #:timeout timeout)]))
+
 (define (split-list lst n)
   (cond
     [(null? lst) '()]
     [else (cons (take lst (min n (length lst))) (split-list (drop lst (min n (length lst))) n))]))
 
-(define (run-all-files files jobs timeout)
+(define (run-all-files files jobs timeout #:mode [mode 'subprocess])
   (define results (box '()))
   (define results-lock (make-semaphore 1))
   (define (add-result! r)
@@ -253,7 +333,7 @@
     (define batch-threads
       (for/list ([f (in-list batch)])
         (thread (lambda ()
-                  (define result (run-single-file f #:timeout (or timeout 120000)))
+                  (define result (run-single-file f #:timeout (or timeout 120000) #:mode mode))
                   (define exit-code (test-file-result-exit-code result))
                   (cond
                     [(= exit-code 0) (display ".")]
@@ -272,7 +352,12 @@
       (values f i)))
   (sort (unbox results) < #:key (lambda (r) (hash-ref file-order (test-file-result-path r) 0))))
 
-(define (run-suite-once suite-files jobs timeout-ms strict? suite-label repeat-num repeat-total)
+(define (effective-mode requested-mode suite-label)
+  (cond
+    [(eq? requested-mode 'auto) (if (string=? suite-label "unit-fast") 'grouped 'subprocess)]
+    [else requested-mode]))
+
+(define (run-suite-once suite-files jobs timeout-ms strict? suite-label repeat-num repeat-total mode)
   (define t0 (current-inexact-milliseconds))
   (define-values (serial-files parallel-files)
     (if (> jobs 1)
@@ -285,13 +370,13 @@
             (if (= (length serial-files) 1) "" "s")))
   (define serial-results
     (if (pair? serial-files)
-        (run-all-files serial-files 1 timeout-ms)
+        (run-all-files serial-files 1 timeout-ms #:mode mode)
         '()))
   (when (pair? serial-files)
     (restore-repo-surfaces! base-dir))
   (define parallel-results
     (if (pair? parallel-files)
-        (run-all-files parallel-files jobs timeout-ms)
+        (run-all-files parallel-files jobs timeout-ms #:mode mode)
         '()))
   (define file-order
     (for/hash ([f (in-list suite-files)]
@@ -339,7 +424,8 @@
                   repeat
                   record-gate?
                   inventory?
-                  diagnose-overhead?)
+                  diagnose-overhead?
+                  requested-mode)
     (parse-args args))
   (validate-args! jobs
                   sequential?
@@ -350,7 +436,8 @@
                   repeat
                   record-gate?
                   inventory?
-                  diagnose-overhead?)
+                  diagnose-overhead?
+                  requested-mode)
   (when diagnose-overhead?
     (print-overhead-diagnostics #:base-dir base-dir)
     (exit 0))
@@ -376,13 +463,15 @@
     (exit 1))
   (define timeout-ms (and timeout (* timeout 1000)))
   (define suite-label (symbol->string suite))
+  (define mode (effective-mode requested-mode suite-label))
   (define n-files (length suite-files))
-  (printf ";; run-tests: suite=~a files=~a jobs=~a sequential=~a repeat=~a~n"
+  (printf ";; run-tests: suite=~a files=~a jobs=~a sequential=~a repeat=~a mode=~a~n"
           suite-label
           n-files
           jobs
           sequential?
-          repeat)
+          repeat
+          mode)
   (newline)
   (when (> repeat 1)
     (printf ";; run-tests: running suite ~a time~a for confidence gate~n"
@@ -393,7 +482,7 @@
     (when (> repeat 1)
       (printf "~n;; ── Run ~a/~a ──~n" run-num repeat))
     (define-values (exit-code results)
-      (run-suite-once suite-files jobs timeout-ms strict? suite-label run-num repeat))
+      (run-suite-once suite-files jobs timeout-ms strict? suite-label run-num repeat mode))
     (set-box! last-results results)
     (unless (zero? exit-code)
       (exit exit-code)))

--- a/scripts/run-tests/classify.rkt
+++ b/scripts/run-tests/classify.rkt
@@ -26,6 +26,7 @@
          runtime-file?
          extensions-file?
          workflows-file?
+         unit-fast-file?
          smoke-excluded?
          file-has-suite-tag?
          support-test-module?
@@ -278,6 +279,13 @@
        (or (not (string-contains? f "/fixtures/"))
            (string-prefix? (path->string (file-name-from-path f)) "test-"))))
 
+(define (unit-fast-file? f)
+  (define meta (get-file-metadata f))
+  (define speed (hash-ref meta 'speed #f))
+  (define boundary (hash-ref meta 'boundary #f))
+  (and (not (mutating-file? f))
+       (or (file-has-suite-tag? f "unit-fast") (and (eq? speed 'fast) (equal? boundary "unit")))))
+
 (define (file-has-rackunit-tests? path)
   (and (file-exists? path)
        (let* ([content (file->string path)]
@@ -341,6 +349,7 @@
      (case suite
        [(all) all-files]
        [(fast) (filter (lambda (f) (not (slow-file? f))) all-files)]
+       [(unit-fast) (filter unit-fast-file? all-files)]
        [(slow) (filter slow-file? all-files)]
        [(tui) (filter tui-file? all-files)]
        [(smoke) (filter (lambda (f) (not (smoke-excluded? f))) all-files)]

--- a/scripts/run-tests/cli.rkt
+++ b/scripts/run-tests/cli.rkt
@@ -13,7 +13,8 @@
 (provide usage
          parse-args
          validate-args!
-         known-suites)
+         known-suites
+         known-modes)
 
 (define (usage)
   (displayln "Usage: racket scripts/run-tests.rkt [OPTIONS] [TEST-FILES ...]")
@@ -22,8 +23,9 @@
   (displayln "  --jobs N          Number of parallel jobs (default: processor-count)")
   (displayln "  --sequential      Run tests sequentially (jobs=1)")
   (displayln "  --timeout SECS    Per-file timeout in seconds")
+  (displayln "  --mode <name>     Execution mode: auto (default), subprocess, in-process, grouped")
   (displayln
-   "  --suite <name>    Run test suite: all (default), fast, slow, tui, smoke, security, arch, runtime, extensions, workflows")
+   "  --suite <name>    Run test suite: all (default), fast, unit-fast, slow, tui, smoke, security, arch, runtime, extensions, workflows")
   (displayln "  --strict          Enable strict zero-test detection (default: on)")
   (displayln "  --repeat N        Run suite N times (exit 1 if any run fails)")
   (displayln "  --record-gate-evidence  Write .gate-evidence/<suite>.passed on success")
@@ -34,6 +36,7 @@
   (displayln "Suites:")
   (displayln "  all     Entire tests/ directory (per-file spawn)")
   (displayln "  fast    All tests except slow patterns (per-file spawn)")
+  (displayln "  unit-fast  Fast unit tests eligible for in-process/grouped execution")
   (displayln "  slow    Only sandbox/subprocess tests")
   (displayln "  tui     Files in tests/tui/")
   (displayln "  smoke   Fast minus workflows/, interfaces/, and provider tests")
@@ -42,6 +45,9 @@
   (displayln "  runtime Runtime/session/compaction/iteration tests")
   (displayln "  extensions Extension/GSD/hook tests")
   (displayln "  workflows All tests/workflows/ including fixture self-tests (integration-level)"))
+
+(define known-suites '(all fast unit-fast slow smoke tui security arch runtime extensions workflows))
+(define known-modes '(auto subprocess in-process grouped))
 
 (define (parse-args args)
   (let loop ([rest args]
@@ -54,7 +60,8 @@
              [repeat 1]
              [record-gate? #f]
              [inventory? #f]
-             [diagnose-overhead? #f])
+             [diagnose-overhead? #f]
+             [mode 'auto])
     (match rest
       ['()
        (values jobs
@@ -66,7 +73,8 @@
                repeat
                record-gate?
                inventory?
-               diagnose-overhead?)]
+               diagnose-overhead?
+               mode)]
       [(list "--help" _ ...)
        (usage)
        (exit 0)]
@@ -81,7 +89,8 @@
              repeat
              record-gate?
              inventory?
-             diagnose-overhead?)]
+             diagnose-overhead?
+             mode)]
       [(list "--jobs" n rest ...)
        (loop rest
              (string->number n)
@@ -93,9 +102,21 @@
              repeat
              record-gate?
              inventory?
-             diagnose-overhead?)]
+             diagnose-overhead?
+             mode)]
       [(list "--sequential" rest ...)
-       (loop rest 1 #t timeout strict? suite extra repeat record-gate? inventory? diagnose-overhead?)]
+       (loop rest
+             1
+             #t
+             timeout
+             strict?
+             suite
+             extra
+             repeat
+             record-gate?
+             inventory?
+             diagnose-overhead?
+             mode)]
       [(list "--timeout" secs rest ...)
        (loop rest
              jobs
@@ -107,7 +128,21 @@
              repeat
              record-gate?
              inventory?
-             diagnose-overhead?)]
+             diagnose-overhead?
+             mode)]
+      [(list "--mode" name rest ...)
+       (loop rest
+             jobs
+             sequential?
+             timeout
+             strict?
+             suite
+             extra
+             repeat
+             record-gate?
+             inventory?
+             diagnose-overhead?
+             (string->symbol name))]
       [(list "--suite" name rest ...)
        (loop rest
              jobs
@@ -119,7 +154,8 @@
              repeat
              record-gate?
              inventory?
-             diagnose-overhead?)]
+             diagnose-overhead?
+             mode)]
       [(list "--repeat" n rest ...)
        (loop rest
              jobs
@@ -131,7 +167,8 @@
              (string->number n)
              record-gate?
              inventory?
-             diagnose-overhead?)]
+             diagnose-overhead?
+             mode)]
       [(list "--record-gate-evidence" rest ...)
        (loop rest
              jobs
@@ -143,7 +180,8 @@
              repeat
              #t
              inventory?
-             diagnose-overhead?)]
+             diagnose-overhead?
+             mode)]
       [(list "--inventory" rest ...)
        (loop rest
              jobs
@@ -155,9 +193,21 @@
              repeat
              record-gate?
              #t
-             diagnose-overhead?)]
+             diagnose-overhead?
+             mode)]
       [(list "--diagnose-overhead" rest ...)
-       (loop rest jobs sequential? timeout strict? suite extra repeat record-gate? inventory? #t)]
+       (loop rest
+             jobs
+             sequential?
+             timeout
+             strict?
+             suite
+             extra
+             repeat
+             record-gate?
+             inventory?
+             #t
+             mode)]
       [(list (regexp #rx"^--") rest ...)
        (eprintf "run-tests: unknown flag: ~a~n" (car rest))
        (usage)
@@ -173,9 +223,8 @@
              repeat
              record-gate?
              inventory?
-             diagnose-overhead?)])))
-
-(define known-suites '(all fast slow smoke tui security arch runtime extensions workflows))
+             diagnose-overhead?
+             mode)])))
 
 (define (validate-args! jobs
                         sequential?
@@ -186,7 +235,8 @@
                         repeat
                         record-gate?
                         inventory?
-                        diagnose-overhead?)
+                        diagnose-overhead?
+                        mode)
   (unless (memq suite known-suites)
     (raise-user-error 'run-tests
                       "unknown suite: ~a (valid: ~a)"
@@ -198,4 +248,9 @@
     (raise-user-error 'run-tests "--repeat must be a positive integer, got: ~a" repeat))
   (when (and timeout (or (not (number? timeout)) (<= timeout 0)))
     (raise-user-error 'run-tests "--timeout must be a positive number, got: ~a" timeout))
-  (values jobs sequential? timeout strict? suite extra repeat record-gate? inventory?))
+  (unless (memq mode known-modes)
+    (raise-user-error 'run-tests
+                      "unknown mode: ~a (valid: ~a)"
+                      mode
+                      (string-join (map symbol->string known-modes) ", ")))
+  (values jobs sequential? timeout strict? suite extra repeat record-gate? inventory? mode))

--- a/tests/test-run-tests-in-process-mode.rkt
+++ b/tests/test-run-tests-in-process-mode.rkt
@@ -1,0 +1,116 @@
+#lang racket/base
+
+;; @speed fast
+;; @suite testing
+;; @isolation subprocess
+
+(require rackunit
+         rackunit/text-ui
+         racket/file
+         racket/path
+         racket/runtime-path
+         racket/system
+         "../scripts/run-tests.rkt")
+
+(define-runtime-path here ".")
+(define project-root (simplify-path (build-path here "..")))
+
+(define (write-temp-test content)
+  (define dir (make-temporary-file "q-in-process-test-~a" 'directory))
+  (define file (build-path dir "test-pure.rkt"))
+  (call-with-output-file file #:exists 'replace (lambda (out) (display content out)))
+  (values file dir))
+
+(define (delete-dir/safe dir)
+  (with-handlers ([exn:fail? (lambda (_) (void))])
+    (delete-directory/files dir)))
+
+(define (run/capture cmd)
+  (parameterize ([current-directory project-root])
+    (define out (open-output-string))
+    (define err (open-output-string))
+    (define code
+      (parameterize ([current-output-port out]
+                     [current-error-port err])
+        (system/exit-code cmd)))
+    (values code (get-output-string out) (get-output-string err))))
+
+(define suite
+  (test-suite "run-tests in-process/grouped modes"
+
+    (test-case "parse-args accepts --mode and defaults to auto"
+      (define-values (jobs seq? timeout strict? suite extra repeat record? inventory? diagnose? mode)
+        (parse-args '("--mode" "in-process" "--suite" "unit-fast")))
+      (check-equal? mode 'in-process)
+      (check-equal? suite 'unit-fast)
+      (define-values (_jobs
+                      _seq?
+                      _timeout
+                      _strict?
+                      _suite
+                      _extra
+                      _repeat
+                      _record?
+                      _inventory?
+                      _diagnose?
+                      default-mode)
+        (parse-args '()))
+      (check-equal? default-mode 'auto))
+
+    (test-case "in-process and subprocess modes produce equivalent pure test results"
+      (define-values (file dir)
+        (write-temp-test (string-append "#lang racket/base\n"
+                                        "(require rackunit rackunit/text-ui)\n"
+                                        "(define s (test-suite \"pure\"\n"
+                                        "  (test-case \"one\" (check-equal? (+ 1 1) 2))\n"
+                                        "  (test-case \"two\" (check-true (string? \"ok\")))))\n"
+                                        "(run-tests s)\n")))
+      (dynamic-wind void
+                    (lambda ()
+                      (define path (path->string file))
+                      (define in-process (run-single-file path #:timeout 120000 #:mode 'in-process))
+                      (define subprocess (run-single-file path #:timeout 120000 #:mode 'subprocess))
+                      (check-equal? (test-file-result-exit-code in-process) 0)
+                      (check-equal? (test-file-result-exit-code subprocess) 0)
+                      (check-equal? (test-file-result-total in-process) 2)
+                      (check-equal? (test-file-result-total subprocess) 2)
+                      (check-equal? (list (test-file-result-passed in-process)
+                                          (test-file-result-failed in-process)
+                                          (test-file-result-total in-process))
+                                    (list (test-file-result-passed subprocess)
+                                          (test-file-result-failed subprocess)
+                                          (test-file-result-total subprocess))))
+                    (lambda () (delete-dir/safe dir))))
+
+    (test-case "in-process mode runs module+ test submodules"
+      (define-values (file dir)
+        (write-temp-test
+         (string-append "#lang racket/base\n"
+                        "(module+ test\n"
+                        "  (require rackunit rackunit/text-ui)\n"
+                        "  (define s (test-suite \"module+\" (test-case \"ok\" (check-true #t))))\n"
+                        "  (run-tests s))\n")))
+      (dynamic-wind void
+                    (lambda ()
+                      (define result
+                        (run-single-file (path->string file) #:timeout 120000 #:mode 'in-process))
+                      (check-equal? (test-file-result-exit-code result) 0)
+                      (check-equal? (test-file-result-total result) 1))
+                    (lambda () (delete-dir/safe dir))))
+
+    (test-case "CLI accepts grouped mode on explicit pure file"
+      (define-values (file dir)
+        (write-temp-test
+         (string-append "#lang racket/base\n"
+                        "(require rackunit rackunit/text-ui)\n"
+                        "(define s (test-suite \"cli\" (test-case \"ok\" (check-true #t))))\n"
+                        "(run-tests s)\n")))
+      (dynamic-wind void
+                    (lambda ()
+                      (define-values (code out err)
+                        (run/capture (format "racket scripts/run-tests.rkt --mode grouped ~a" file)))
+                      (check-equal? code 0 err)
+                      (check-true (regexp-match? #rx"1 total, 1 passed" out)))
+                    (lambda () (delete-dir/safe dir))))))
+
+(run-tests suite)

--- a/tests/test-run-tests.rkt
+++ b/tests/test-run-tests.rkt
@@ -421,20 +421,21 @@
 
 (test-case "parse-args: --repeat N sets repeat count"
   (define parse (runner-ref 'parse-args))
-  (define-values (jobs seq? timeout strict? suite extra repeat record-gate? inventory?)
+  (define-values (jobs seq? timeout strict? suite extra repeat record-gate? inventory? diagnose? mode)
     (parse '("--repeat" "3")))
   (check-equal? repeat 3)
   (check-false record-gate?))
 
 (test-case "parse-args: --repeat defaults to 1"
   (define parse (runner-ref 'parse-args))
-  (define-values (jobs seq? timeout strict? suite extra repeat record-gate? inventory?) (parse '()))
+  (define-values (jobs seq? timeout strict? suite extra repeat record-gate? inventory? diagnose? mode)
+    (parse '()))
   (check-equal? repeat 1)
   (check-false record-gate?))
 
 (test-case "parse-args: --repeat with --suite smoke"
   (define parse (runner-ref 'parse-args))
-  (define-values (jobs seq? timeout strict? suite extra repeat record-gate? inventory?)
+  (define-values (jobs seq? timeout strict? suite extra repeat record-gate? inventory? diagnose? mode)
     (parse '("--suite" "smoke" "--repeat" "2")))
   (check-equal? suite 'smoke)
   (check-equal? repeat 2)
@@ -446,13 +447,14 @@
 
 (test-case "parse-args: --record-gate-evidence sets flag"
   (define parse (runner-ref 'parse-args))
-  (define-values (jobs seq? timeout strict? suite extra repeat record-gate? inventory?)
+  (define-values (jobs seq? timeout strict? suite extra repeat record-gate? inventory? diagnose? mode)
     (parse '("--record-gate-evidence")))
   (check-true record-gate?))
 
 (test-case "parse-args: record-gate defaults to #f"
   (define parse (runner-ref 'parse-args))
-  (define-values (jobs seq? timeout strict? suite extra repeat record-gate? inventory?) (parse '()))
+  (define-values (jobs seq? timeout strict? suite extra repeat record-gate? inventory? diagnose? mode)
+    (parse '()))
   (check-false record-gate?))
 
 ;; ---- end of file ----


### PR DESCRIPTION
## Summary

Implements v0.99.30 W3 in-process/grouped runner support.

- Adds `--mode auto|subprocess|in-process|grouped`.
- Adds `unit-fast` suite selection for fast unit tests eligible for in-process/grouped execution.
- Preserves existing subprocess mode as fallback/default for non-eligible files.
- Runs text-ui RackUnit files in-process and supports `(module+ test ...)` via resolved submodule dynamic-require.
- Keeps bare RackUnit files without text-ui/module+ on subprocess to avoid zero-parsed false greens.
- Adds regression coverage in `tests/test-run-tests-in-process-mode.rkt`.
- Updates older parse-args tests for the new return value.

## Verification

Focused:
- `raco fmt -i scripts/run-tests.rkt scripts/run-tests/cli.rkt scripts/run-tests/classify.rkt tests/test-run-tests-in-process-mode.rkt tests/test-run-tests.rkt`
- `raco make scripts/run-tests.rkt scripts/run-tests/cli.rkt scripts/run-tests/classify.rkt tests/test-run-tests-in-process-mode.rkt tests/test-run-tests.rkt`
- `raco test tests/test-run-tests-in-process-mode.rkt tests/test-run-tests-metadata-discovery.rkt tests/test-run-tests-zero-parsed-elimination.rkt tests/test-run-tests-overhead-diagnostics.rkt` → 11 tests passed
- `racket scripts/run-tests.rkt --suite unit-fast --mode subprocess --sequential` → 10 files, 10 passed, 0 failed, 102 tests, PASS, elapsed 6.279s
- `racket scripts/run-tests.rkt --suite unit-fast --mode in-process --sequential` → 10 files, 10 passed, 0 failed, 102 tests, PASS, elapsed 6.325s
- `racket scripts/run-tests.rkt --suite unit-fast --mode grouped --sequential` → 10 files, 10 passed, 0 failed, 102 tests, PASS, elapsed 6.296s
- Tiny pure RackUnit overhead probe through `run-single-file`: in-process 50ms vs subprocess 298ms, equivalent 1-test PASS results
- `racket scripts/run-tests.rkt --help` includes `--mode` and `unit-fast`

Required fast gate:
- `timeout 900 racket scripts/run-tests.rkt --suite fast` → 947 files, 885 passed, 62 failed, 0 timeouts, 11868 tests, 11805 passed, 63 failed, VERDICT FAIL

Note: `tests/test-run-tests.rkt` compiles after arity updates but still has unrelated pre-existing assertions failing when run directly; not part of W3 acceptance.

Closes #8311.