### PR TITLE
feat: W4 structured failure classification and JSON output

### DIFF
--- a/scripts/run-tests.rkt
+++ b/scripts/run-tests.rkt
@@ -61,6 +61,8 @@
                   parse-raco-output
                   normalize-counts
                   effective-exit-code
+                  classify-test-result
+                  test-result->jsexpr
                   extract-failure-lines
                   truncate-test-output
                   DEFAULT-OUTPUT-CAP)
@@ -70,6 +72,7 @@
                   format-duration
                   summary-exit-code
                   compute-verdict
+                  write-json-results!
                   make-unique-log-name)
          (only-in "run-tests/cli.rkt" usage parse-args validate-args! known-suites known-modes)
          (only-in "run-tests/gate-evidence.rkt" record-gate-evidence!)
@@ -105,6 +108,8 @@
          make-test-file-result
          parse-raco-output
          normalize-counts
+         classify-test-result
+         test-result->jsexpr
          extract-failure-lines
          run-single-file
          run-all-files
@@ -118,6 +123,7 @@
          format-duration
          summary-exit-code
          compute-verdict
+         write-json-results!
          bytes->string*
          clean-stale-bytecode!
          file-has-rackunit-tests?
@@ -357,7 +363,15 @@
     [(eq? requested-mode 'auto) (if (string=? suite-label "unit-fast") 'grouped 'subprocess)]
     [else requested-mode]))
 
-(define (run-suite-once suite-files jobs timeout-ms strict? suite-label repeat-num repeat-total mode)
+(define (run-suite-once suite-files
+                        jobs
+                        timeout-ms
+                        strict?
+                        suite-label
+                        repeat-num
+                        repeat-total
+                        mode
+                        json-out)
   (define t0 (current-inexact-milliseconds))
   (define-values (serial-files parallel-files)
     (if (> jobs 1)
@@ -388,6 +402,12 @@
           #:key (lambda (r) (hash-ref file-order (test-file-result-path r) 0))))
   (define total-elapsed (exact-round (- (current-inexact-milliseconds) t0)))
   (print-summary results total-elapsed)
+  (when json-out
+    (write-json-results! json-out
+                         results
+                         #:suite (string->symbol suite-label)
+                         #:mode mode
+                         #:elapsed-ms total-elapsed))
   (save-failure-logs results)
   (define failed-files
     (count (lambda (r)
@@ -425,7 +445,8 @@
                   record-gate?
                   inventory?
                   diagnose-overhead?
-                  requested-mode)
+                  requested-mode
+                  json-out)
     (parse-args args))
   (validate-args! jobs
                   sequential?
@@ -437,7 +458,8 @@
                   record-gate?
                   inventory?
                   diagnose-overhead?
-                  requested-mode)
+                  requested-mode
+                  json-out)
   (when diagnose-overhead?
     (print-overhead-diagnostics #:base-dir base-dir)
     (exit 0))
@@ -482,7 +504,7 @@
     (when (> repeat 1)
       (printf "~n;; ── Run ~a/~a ──~n" run-num repeat))
     (define-values (exit-code results)
-      (run-suite-once suite-files jobs timeout-ms strict? suite-label run-num repeat mode))
+      (run-suite-once suite-files jobs timeout-ms strict? suite-label run-num repeat mode json-out))
     (set-box! last-results results)
     (unless (zero? exit-code)
       (exit exit-code)))

--- a/scripts/run-tests/cli.rkt
+++ b/scripts/run-tests/cli.rkt
@@ -31,6 +31,7 @@
   (displayln "  --record-gate-evidence  Write .gate-evidence/<suite>.passed on success")
   (displayln "  --inventory             Print inventory report (selected/excluded files) and exit")
   (displayln "  --diagnose-overhead     Measure Racket/raco per-file startup overhead and exit")
+  (displayln "  --json-out PATH         Write structured per-file JSON results")
   (displayln "  --help            Show this help message")
   (newline)
   (displayln "Suites:")
@@ -61,7 +62,8 @@
              [record-gate? #f]
              [inventory? #f]
              [diagnose-overhead? #f]
-             [mode 'auto])
+             [mode 'auto]
+             [json-out #f])
     (match rest
       ['()
        (values jobs
@@ -74,7 +76,8 @@
                record-gate?
                inventory?
                diagnose-overhead?
-               mode)]
+               mode
+               json-out)]
       [(list "--help" _ ...)
        (usage)
        (exit 0)]
@@ -90,7 +93,8 @@
              record-gate?
              inventory?
              diagnose-overhead?
-             mode)]
+             mode
+             json-out)]
       [(list "--jobs" n rest ...)
        (loop rest
              (string->number n)
@@ -103,7 +107,8 @@
              record-gate?
              inventory?
              diagnose-overhead?
-             mode)]
+             mode
+             json-out)]
       [(list "--sequential" rest ...)
        (loop rest
              1
@@ -116,7 +121,8 @@
              record-gate?
              inventory?
              diagnose-overhead?
-             mode)]
+             mode
+             json-out)]
       [(list "--timeout" secs rest ...)
        (loop rest
              jobs
@@ -129,7 +135,8 @@
              record-gate?
              inventory?
              diagnose-overhead?
-             mode)]
+             mode
+             json-out)]
       [(list "--mode" name rest ...)
        (loop rest
              jobs
@@ -142,7 +149,8 @@
              record-gate?
              inventory?
              diagnose-overhead?
-             (string->symbol name))]
+             (string->symbol name)
+             json-out)]
       [(list "--suite" name rest ...)
        (loop rest
              jobs
@@ -155,7 +163,8 @@
              record-gate?
              inventory?
              diagnose-overhead?
-             mode)]
+             mode
+             json-out)]
       [(list "--repeat" n rest ...)
        (loop rest
              jobs
@@ -168,7 +177,8 @@
              record-gate?
              inventory?
              diagnose-overhead?
-             mode)]
+             mode
+             json-out)]
       [(list "--record-gate-evidence" rest ...)
        (loop rest
              jobs
@@ -181,7 +191,8 @@
              #t
              inventory?
              diagnose-overhead?
-             mode)]
+             mode
+             json-out)]
       [(list "--inventory" rest ...)
        (loop rest
              jobs
@@ -194,7 +205,8 @@
              record-gate?
              #t
              diagnose-overhead?
-             mode)]
+             mode
+             json-out)]
       [(list "--diagnose-overhead" rest ...)
        (loop rest
              jobs
@@ -207,7 +219,22 @@
              record-gate?
              inventory?
              #t
-             mode)]
+             mode
+             json-out)]
+      [(list "--json-out" path rest ...)
+       (loop rest
+             jobs
+             sequential?
+             timeout
+             strict?
+             suite
+             extra
+             repeat
+             record-gate?
+             inventory?
+             diagnose-overhead?
+             mode
+             path)]
       [(list (regexp #rx"^--") rest ...)
        (eprintf "run-tests: unknown flag: ~a~n" (car rest))
        (usage)
@@ -224,7 +251,8 @@
              record-gate?
              inventory?
              diagnose-overhead?
-             mode)])))
+             mode
+             json-out)])))
 
 (define (validate-args! jobs
                         sequential?
@@ -236,7 +264,8 @@
                         record-gate?
                         inventory?
                         diagnose-overhead?
-                        mode)
+                        mode
+                        json-out)
   (unless (memq suite known-suites)
     (raise-user-error 'run-tests
                       "unknown suite: ~a (valid: ~a)"
@@ -253,4 +282,6 @@
                       "unknown mode: ~a (valid: ~a)"
                       mode
                       (string-join (map symbol->string known-modes) ", ")))
-  (values jobs sequential? timeout strict? suite extra repeat record-gate? inventory? mode))
+  (when (and json-out (not (string? json-out)))
+    (raise-user-error 'run-tests "--json-out must be a path string, got: ~a" json-out))
+  (values jobs sequential? timeout strict? suite extra repeat record-gate? inventory? mode json-out))

--- a/scripts/run-tests/parse.rkt
+++ b/scripts/run-tests/parse.rkt
@@ -23,6 +23,8 @@
          parse-raco-output
          normalize-counts
          effective-exit-code
+         classify-test-result
+         test-result->jsexpr
          extract-failure-lines
          truncate-test-output
          DEFAULT-OUTPUT-CAP)
@@ -92,6 +94,69 @@
 
 (define (effective-exit-code exit-code failed)
   (if (and (= exit-code 0) (> failed 0)) 1 exit-code))
+
+(define (result-output-string r)
+  (string-downcase (string-append (bytes->string* (test-file-result-stdout-bytes r))
+                                  "\n"
+                                  (bytes->string* (test-file-result-stderr-bytes r)))))
+
+(define (output-matches-any? output patterns)
+  (for/or ([pat (in-list patterns)])
+    (regexp-match? pat output)))
+
+(define (classify-test-result r)
+  (define exit-code (test-file-result-exit-code r))
+  (define failed (test-file-result-failed r))
+  (define total (test-file-result-total r))
+  (define output (result-output-string r))
+  (cond
+    [(and (= exit-code 0) (> total 0)) 'PASS]
+    [(and (= exit-code 0) (= total 0)) 'ZERO_PARSED]
+    [(= exit-code 2) 'TIMEOUT]
+    [(output-matches-any? output (list #rx"user break" #rx"break exception")) 'USER_BREAK]
+    [(output-matches-any? output
+                          (list #rx"missing environment variable"
+                                #rx"environment variable"
+                                #rx"api[_-]?key"
+                                #rx"display.*not available"
+                                #rx"x11"
+                                #rx"no such file or directory"))
+     'ENVIRONMENT_MISSING]
+    [(output-matches-any?
+      output
+      (list #rx"read-syntax" #rx"syntax error" #rx"module: identifier already defined"))
+     'COMPILE_FAILURE]
+    [(output-matches-any? output
+                          (list #rx"standard-module-name-resolver"
+                                #rx"collection not found"
+                                #rx"cannot open module file"
+                                #rx"cannot find module"
+                                #rx"cannot open input file"))
+     'MODULE_LOAD_FAILURE]
+    [(or (> failed 0)
+         (output-matches-any? output
+                              (list #rx"failure" #rx"check-[a-z0-9-]+" #rx"actual:" #rx"expected:")))
+     'ASSERTION_FAILURE]
+    [else 'UNKNOWN_FAILURE]))
+
+(define (test-result->jsexpr r)
+  (hasheq 'path
+          (let ([p (test-file-result-path r)])
+            (if (path? p)
+                (path->string p)
+                p))
+          'category
+          (symbol->string (classify-test-result r))
+          'exit_code
+          (test-file-result-exit-code r)
+          'elapsed_ms
+          (test-file-result-elapsed-ms r)
+          'passed
+          (test-file-result-passed r)
+          'failed
+          (test-file-result-failed r)
+          'total
+          (test-file-result-total r)))
 
 (define FAILURE-START #rx"^-+ FAILURE -+$")
 (define FAILURE-END #rx"^-{20,}$")

--- a/scripts/run-tests/reporting.rkt
+++ b/scripts/run-tests/reporting.rkt
@@ -9,6 +9,7 @@
 (require racket/string
          racket/path
          racket/list
+         json
          (only-in "parse.rkt"
                   test-file-result-path
                   test-file-result-exit-code
@@ -18,6 +19,8 @@
                   test-file-result-passed
                   test-file-result-failed
                   test-file-result-total
+                  classify-test-result
+                  test-result->jsexpr
                   bytes->string*
                   extract-failure-lines))
 
@@ -27,6 +30,9 @@
          summary-exit-code
          make-unique-log-name
          compute-verdict
+         classify-test-result
+         test-result->jsexpr
+         write-json-results!
          format-verdict-line)
 
 (define (format-duration ms)
@@ -81,6 +87,83 @@
     [(pass) "  VERDICT:   ✅ PASS"]
     [else "  VERDICT:   ❓ UNKNOWN"]))
 
+(define known-result-categories
+  '(PASS ASSERTION_FAILURE
+         MODULE_LOAD_FAILURE
+         COMPILE_FAILURE
+         TIMEOUT
+         ENVIRONMENT_MISSING
+         ZERO_PARSED
+         USER_BREAK
+         UNKNOWN_FAILURE))
+
+(define (category-counts results)
+  (define counts (make-hasheq))
+  (for ([category (in-list known-result-categories)])
+    (hash-set! counts category 0))
+  (for ([r (in-list results)])
+    (define category (classify-test-result r))
+    (hash-set! counts category (add1 (hash-ref counts category 0))))
+  counts)
+
+(define (print-category-summary results)
+  (define counts (category-counts results))
+  (define non-zero
+    (filter (lambda (category) (> (hash-ref counts category 0) 0)) known-result-categories))
+  (when (pair? non-zero)
+    (printf "  Category:  ~a~n"
+            (string-join (for/list ([category (in-list non-zero)])
+                           (format "~a=~a" category (hash-ref counts category)))
+                         ", "))))
+
+(define (category-counts->jsexpr counts)
+  (for/hasheq ([category (in-list known-result-categories)]
+               #:when (> (hash-ref counts category 0) 0))
+    (values (string->symbol (symbol->string category)) (hash-ref counts category))))
+
+(define (write-json-results! path
+                             results
+                             #:suite [suite 'all]
+                             #:mode [mode 'subprocess]
+                             #:elapsed-ms [elapsed-ms 0])
+  (define passed-files (count (lambda (r) (= (test-file-result-exit-code r) 0)) results))
+  (define failed-files
+    (count (lambda (r)
+             (and (not (= (test-file-result-exit-code r) 0))
+                  (not (= (test-file-result-exit-code r) 2))))
+           results))
+  (define timeout-files (count (lambda (r) (= (test-file-result-exit-code r) 2)) results))
+  (define counts (category-counts results))
+  (define payload
+    (hasheq 'suite
+            (symbol->string suite)
+            'mode
+            (symbol->string mode)
+            'verdict
+            (symbol->string (compute-verdict results))
+            'elapsed_ms
+            elapsed-ms
+            'summary
+            (hasheq 'files_total
+                    (length results)
+                    'files_passed
+                    passed-files
+                    'files_failed
+                    failed-files
+                    'files_timeout
+                    timeout-files
+                    'tests_total
+                    (for/sum ([r (in-list results)]) (test-file-result-total r))
+                    'tests_passed
+                    (for/sum ([r (in-list results)]) (test-file-result-passed r))
+                    'tests_failed
+                    (for/sum ([r (in-list results)]) (test-file-result-failed r)))
+            'category_counts
+            (category-counts->jsexpr counts)
+            'files
+            (map test-result->jsexpr results)))
+  (call-with-output-file path #:exists 'truncate/replace (lambda (out) (write-json payload out))))
+
 (define (print-summary results total-start-ms)
   (define total-files (length results))
   (define passed-files (count (lambda (r) (= (test-file-result-exit-code r) 0)) results))
@@ -111,6 +194,7 @@
             zero-test-files
             (if (= zero-test-files 1) "" "s")))
   (printf "  Tests:     ~a total, ~a passed, ~a failed~n" total-tests total-passed total-failed)
+  (print-category-summary results)
   (when (and (= total-tests 0) (= passed-files total-files))
     (displayln "  ⚠ No test results parsed — files may use non-standard output format"))
   (printf "  Elapsed:   ~a~n" (format-duration total-start-ms))
@@ -124,9 +208,10 @@
     (for ([f (in-list failures)])
       (define path (test-file-result-path f))
       (define ec (test-file-result-exit-code f))
-      (printf "  ~a ~a (exit=~a, ~a passed, ~a failed, ~a)~n"
+      (printf "  ~a ~a [~a] (exit=~a, ~a passed, ~a failed, ~a)~n"
               (if (= ec 2) "⏱" "✗")
               path
+              (classify-test-result f)
               ec
               (test-file-result-passed f)
               (test-file-result-failed f)

--- a/tests/test-run-tests-in-process-mode.rkt
+++ b/tests/test-run-tests-in-process-mode.rkt
@@ -39,7 +39,18 @@
   (test-suite "run-tests in-process/grouped modes"
 
     (test-case "parse-args accepts --mode and defaults to auto"
-      (define-values (jobs seq? timeout strict? suite extra repeat record? inventory? diagnose? mode)
+      (define-values (jobs
+                      seq?
+                      timeout
+                      strict?
+                      suite
+                      extra
+                      repeat
+                      record?
+                      inventory?
+                      diagnose?
+                      mode
+                      json-out)
         (parse-args '("--mode" "in-process" "--suite" "unit-fast")))
       (check-equal? mode 'in-process)
       (check-equal? suite 'unit-fast)
@@ -53,7 +64,8 @@
                       _record?
                       _inventory?
                       _diagnose?
-                      default-mode)
+                      default-mode
+                      _json-out)
         (parse-args '()))
       (check-equal? default-mode 'auto))
 

--- a/tests/test-run-tests-json-classification.rkt
+++ b/tests/test-run-tests-json-classification.rkt
@@ -1,0 +1,161 @@
+#lang racket/base
+
+;; @speed fast
+;; @suite testing
+;; @isolation subprocess
+
+(require rackunit
+         rackunit/text-ui
+         json
+         racket/file
+         racket/path
+         racket/runtime-path
+         racket/system
+         "../scripts/run-tests.rkt")
+
+(define-runtime-path here ".")
+(define project-root (simplify-path (build-path here "..")))
+
+(define (result #:path [path "tests/example.rkt"]
+                #:exit [exit-code 0]
+                #:out [out ""]
+                #:err [err ""]
+                #:passed [passed 0]
+                #:failed [failed 0]
+                #:total [total 0])
+  (test-file-result path
+                    exit-code
+                    (string->bytes/utf-8 out)
+                    (string->bytes/utf-8 err)
+                    17
+                    passed
+                    failed
+                    total))
+
+(define (write-temp-test content)
+  (define dir (make-temporary-file "q-json-out-test-~a" 'directory))
+  (define file (build-path dir "test-json-out.rkt"))
+  (call-with-output-file file #:exists 'replace (lambda (out) (display content out)))
+  (values file dir))
+
+(define (delete-dir/safe dir)
+  (with-handlers ([exn:fail? (lambda (_) (void))])
+    (delete-directory/files dir)))
+
+(define (run/capture cmd)
+  (parameterize ([current-directory project-root])
+    (define out (open-output-string))
+    (define err (open-output-string))
+    (define code
+      (parameterize ([current-output-port out]
+                     [current-error-port err])
+        (system/exit-code cmd)))
+    (values code (get-output-string out) (get-output-string err))))
+
+(define runner-module `(file ,(path->string (build-path project-root "scripts/run-tests.rkt"))))
+
+(define classify-test-result*
+  (dynamic-require runner-module
+                   'classify-test-result
+                   (lambda () (lambda (_) (error 'classify-test-result "missing export")))))
+
+(define test-result->jsexpr*
+  (dynamic-require runner-module
+                   'test-result->jsexpr
+                   (lambda () (lambda (_) (error 'test-result->jsexpr "missing export")))))
+
+(define write-json-results!*
+  (dynamic-require runner-module
+                   'write-json-results!
+                   (lambda () (lambda args (error 'write-json-results! "missing export")))))
+
+(define suite
+  (test-suite "run-tests structured classification + json"
+
+    (test-case "parse-args accepts --json-out"
+      (define-values (_jobs
+                      _seq?
+                      _timeout
+                      _strict?
+                      _suite
+                      _extra
+                      _repeat
+                      _record?
+                      _inventory?
+                      _diagnose?
+                      _mode
+                      json-out)
+        (parse-args '("--json-out" "/tmp/q-results.json")))
+      (check-equal? json-out "/tmp/q-results.json"))
+
+    (test-case "classify-test-result distinguishes core categories"
+      (check-equal? (classify-test-result* (result #:exit 0 #:passed 1 #:total 1)) 'PASS)
+      (check-equal? (classify-test-result* (result #:exit 0 #:total 0)) 'ZERO_PARSED)
+      (check-equal? (classify-test-result* (result #:exit 2 #:err "timeout after 1s")) 'TIMEOUT)
+      (check-equal? (classify-test-result* (result #:exit 1 #:failed 1 #:total 1 #:out "FAILURE"))
+                    'ASSERTION_FAILURE)
+      (check-equal? (classify-test-result* (result #:exit 1 #:err "read-syntax: expected a )"))
+                    'COMPILE_FAILURE)
+      (check-equal? (classify-test-result*
+                     (result #:exit 1 #:err "standard-module-name-resolver: collection not found"))
+                    'MODULE_LOAD_FAILURE)
+      (check-equal? (classify-test-result* (result #:exit 1
+                                                   #:err "missing environment variable API_KEY"))
+                    'ENVIRONMENT_MISSING)
+      (check-equal? (classify-test-result* (result #:exit 1 #:err "user break")) 'USER_BREAK))
+
+    (test-case "test-result->jsexpr includes category and counts"
+      (define js
+        (test-result->jsexpr*
+         (result #:path "tests/failing.rkt" #:exit 1 #:failed 1 #:total 1 #:out "FAILURE")))
+      (check-equal? (hash-ref js 'path) "tests/failing.rkt")
+      (check-equal? (hash-ref js 'category) "ASSERTION_FAILURE")
+      (check-equal? (hash-ref js 'exit_code) 1)
+      (check-equal? (hash-ref js 'total) 1))
+
+    (test-case "write-json-results! writes per-file categories"
+      (define out (make-temporary-file "q-results-~a.json"))
+      (dynamic-wind
+       void
+       (lambda ()
+         (write-json-results!* out
+                               (list (result #:path "tests/pass.rkt" #:passed 1 #:total 1)
+                                     (result #:path "tests/zero.rkt" #:total 0))
+                               #:suite 'unit-fast
+                               #:mode 'in-process
+                               #:elapsed-ms 25)
+         (define js (call-with-input-file out read-json))
+         (check-equal? (hash-ref js 'suite) "unit-fast")
+         (check-equal? (hash-ref js 'mode) "in-process")
+         (define files (hash-ref js 'files))
+         (check-equal? (length files) 2)
+         (check-equal? (hash-ref (car files) 'category) "PASS")
+         (check-equal? (hash-ref (cadr files) 'category) "ZERO_PARSED"))
+       (lambda ()
+         (when (file-exists? out)
+           (delete-file out)))))
+
+    (test-case "CLI writes --json-out for explicit passing file"
+      (define-values (file dir)
+        (write-temp-test
+         (string-append "#lang racket/base\n"
+                        "(require rackunit rackunit/text-ui)\n"
+                        "(define s (test-suite \"json\" (test-case \"ok\" (check-true #t))))\n"
+                        "(run-tests s)\n")))
+      (define out (build-path dir "results.json"))
+      (dynamic-wind
+       void
+       (lambda ()
+         (define-values (code stdout stderr)
+           (run/capture
+            (format "racket scripts/run-tests.rkt --mode subprocess --json-out ~a ~a" out file)))
+         (check-equal? code 0 stderr)
+         (check-true (regexp-match? #rx"Category" stdout))
+         (define js (call-with-input-file out read-json))
+         (check-equal? (hash-ref js 'verdict) "pass")
+         (define file-js (car (hash-ref js 'files)))
+         (check-equal? (hash-ref file-js 'category) "PASS")
+         (check-equal? (hash-ref file-js 'total) 1))
+       (lambda () (delete-dir/safe dir))))))
+
+(run-tests suite)

--- a/tests/test-run-tests.rkt
+++ b/tests/test-run-tests.rkt
@@ -421,21 +421,54 @@
 
 (test-case "parse-args: --repeat N sets repeat count"
   (define parse (runner-ref 'parse-args))
-  (define-values (jobs seq? timeout strict? suite extra repeat record-gate? inventory? diagnose? mode)
+  (define-values (jobs
+                  seq?
+                  timeout
+                  strict?
+                  suite
+                  extra
+                  repeat
+                  record-gate?
+                  inventory?
+                  diagnose?
+                  mode
+                  json-out)
     (parse '("--repeat" "3")))
   (check-equal? repeat 3)
   (check-false record-gate?))
 
 (test-case "parse-args: --repeat defaults to 1"
   (define parse (runner-ref 'parse-args))
-  (define-values (jobs seq? timeout strict? suite extra repeat record-gate? inventory? diagnose? mode)
+  (define-values (jobs
+                  seq?
+                  timeout
+                  strict?
+                  suite
+                  extra
+                  repeat
+                  record-gate?
+                  inventory?
+                  diagnose?
+                  mode
+                  json-out)
     (parse '()))
   (check-equal? repeat 1)
   (check-false record-gate?))
 
 (test-case "parse-args: --repeat with --suite smoke"
   (define parse (runner-ref 'parse-args))
-  (define-values (jobs seq? timeout strict? suite extra repeat record-gate? inventory? diagnose? mode)
+  (define-values (jobs
+                  seq?
+                  timeout
+                  strict?
+                  suite
+                  extra
+                  repeat
+                  record-gate?
+                  inventory?
+                  diagnose?
+                  mode
+                  json-out)
     (parse '("--suite" "smoke" "--repeat" "2")))
   (check-equal? suite 'smoke)
   (check-equal? repeat 2)
@@ -447,13 +480,35 @@
 
 (test-case "parse-args: --record-gate-evidence sets flag"
   (define parse (runner-ref 'parse-args))
-  (define-values (jobs seq? timeout strict? suite extra repeat record-gate? inventory? diagnose? mode)
+  (define-values (jobs
+                  seq?
+                  timeout
+                  strict?
+                  suite
+                  extra
+                  repeat
+                  record-gate?
+                  inventory?
+                  diagnose?
+                  mode
+                  json-out)
     (parse '("--record-gate-evidence")))
   (check-true record-gate?))
 
 (test-case "parse-args: record-gate defaults to #f"
   (define parse (runner-ref 'parse-args))
-  (define-values (jobs seq? timeout strict? suite extra repeat record-gate? inventory? diagnose? mode)
+  (define-values (jobs
+                  seq?
+                  timeout
+                  strict?
+                  suite
+                  extra
+                  repeat
+                  record-gate?
+                  inventory?
+                  diagnose?
+                  mode
+                  json-out)
     (parse '()))
   (check-false record-gate?))
 


### PR DESCRIPTION
## Summary

Implements v0.99.30 W4 structured failure classification and JSON output.

- Adds normalized per-file result categories:
  - `PASS`
  - `ASSERTION_FAILURE`
  - `MODULE_LOAD_FAILURE`
  - `COMPILE_FAILURE`
  - `TIMEOUT`
  - `ENVIRONMENT_MISSING`
  - `ZERO_PARSED`
  - `USER_BREAK`
  - `UNKNOWN_FAILURE`
- Adds `--json-out PATH` CLI flag.
- Emits per-file JSON objects with category, exit code, elapsed time, and counts.
- Adds category counts to the human summary.
- Annotates failure list entries with category.
- Adds W4 regression tests in `tests/test-run-tests-json-classification.rkt`.
- Updates parse-args tests for the new trailing `json-out` return value.

## Verification

Focused compile/format:
- `raco fmt -i scripts/run-tests.rkt scripts/run-tests/parse.rkt scripts/run-tests/reporting.rkt scripts/run-tests/cli.rkt tests/test-run-tests-json-classification.rkt tests/test-run-tests-in-process-mode.rkt tests/test-run-tests.rkt`
- `raco make scripts/run-tests.rkt scripts/run-tests/parse.rkt scripts/run-tests/reporting.rkt scripts/run-tests/cli.rkt tests/test-run-tests-json-classification.rkt tests/test-run-tests-in-process-mode.rkt tests/test-run-tests.rkt`

Focused tests:
- `raco test tests/test-run-tests-json-classification.rkt` → 5 tests passed
- `raco test tests/test-run-tests-json-classification.rkt tests/test-run-tests-in-process-mode.rkt tests/test-run-tests-metadata-discovery.rkt tests/test-run-tests-zero-parsed-elimination.rkt tests/test-run-tests-overhead-diagnostics.rkt` → 16 tests passed

CLI/JSON smoke:
- Explicit pass + assertion failure files with `--json-out`: exit 1, human summary `Category: PASS=1, ASSERTION_FAILURE=1`, JSON verdict `fail`, per-file categories `PASS` and `ASSERTION_FAILURE`.
- `racket scripts/run-tests.rkt --suite unit-fast --mode grouped --sequential --json-out <tmp>` → JSON summary `suite=unit-fast mode=grouped verdict=pass files=10 categories=#hasheq((PASS . 10))`.
- `racket scripts/run-tests.rkt --help` includes `--json-out`, `--mode`, and `unit-fast`.

Required fast gate:
- `timeout 900 racket scripts/run-tests.rkt --suite fast` → 948 files, 886 passed, 62 failed, 0 timeouts, 11873 tests, 11810 passed, 63 failed, `Category: PASS=886, ASSERTION_FAILURE=60, MODULE_LOAD_FAILURE=2`, VERDICT FAIL.

Notes:
- README metrics were dirtied by the fast gate and restored before commit.
- `tests/test-run-tests.rkt` compiles after arity updates, but direct `raco test` remains affected by unrelated pre-existing assertions; not claimed as passing.

Closes #8312.