### PR TITLE
feat: W5 broad-suite known-failure ledger

### DIFF
--- a/docs/reports/TEST-SUITE-LEDGER.md
+++ b/docs/reports/TEST-SUITE-LEDGER.md
@@ -1,0 +1,157 @@
+# TEST-SUITE LEDGER — v0.99.30 W5
+
+This report documents the initial known-failure ledger for broad-suite debt.
+
+## Source evidence
+
+- Command: `timeout 900 racket scripts/run-tests.rkt --suite broad --json-out <tmp>`
+- Result: runner wrote JSON and human summary, then exited `4` because strict zero-parsed detection flagged `tests/test-benchmarks.rkt`.
+- JSON verdict before strict zero-parsed gate: `fail`
+- Files: 1041 total, 958 passed, 83 failed, 0 timeouts
+- Tests: 12590 total, 12512 passed, 78 failed
+- Original categories: ASSERTION_FAILURE=79, ENVIRONMENT_MISSING=1, MODULE_LOAD_FAILURE=2, PASS=957, UNKNOWN_FAILURE=1, ZERO_PARSED=1
+- Addendum: `tests/test-tool-edit-builtin.rkt` passed individually (`raco test`) but failed during the broad `--ledger` rerun; it is ledgered as known broad-order/mutation-sensitive debt.
+- Ledger entries created: 84
+
+## Policy
+
+- Known failures are matched by both `file` and normalized `category`.
+- New or category-changed failures are release-blocking until triaged into the ledger or fixed.
+- Known non-release-blocking failures remain visible; they are not converted to PASS.
+- Resolved known failures are reported so stale ledger entries can be removed.
+- Strict zero-parsed files remain blocking outside the known-failure ledger.
+
+## Owner summary
+
+- architecture: 2
+- browser: 7
+- core: 20
+- event-loop: 9
+- extensions: 3
+- llm: 7
+- release-engineering: 6
+- runtime: 7
+- sandbox: 2
+- security: 2
+- tools: 1
+- tui: 14
+- workflows: 4
+
+## Category summary
+
+- ASSERTION_FAILURE: 80
+- ENVIRONMENT_MISSING: 1
+- MODULE_LOAD_FAILURE: 2
+- UNKNOWN_FAILURE: 1
+
+## Entries
+
+- `tests/test-agent-session-context.rkt` — ASSERTION_FAILURE — owner `runtime` — issue #8313 — release_blocking=false
+- `tests/test-anthropic.rkt` — ASSERTION_FAILURE — owner `llm` — issue #8313 — release_blocking=false
+- `tests/test-arch-fitness.rkt` — ASSERTION_FAILURE — owner `architecture` — issue #8313 — release_blocking=false
+- `tests/test-benchmark-scorer.rkt` — ASSERTION_FAILURE — owner `core` — issue #8313 — release_blocking=false
+- `tests/test-browser-adapter.rkt` — ASSERTION_FAILURE — owner `browser` — issue #8313 — release_blocking=false
+- `tests/test-browser-audit-w1-v0983.rkt` — ASSERTION_FAILURE — owner `browser` — issue #8313 — release_blocking=false
+- `tests/test-browser-audit-w2.rkt` — ASSERTION_FAILURE — owner `browser` — issue #8313 — release_blocking=false
+- `tests/test-browser-audit.rkt` — ASSERTION_FAILURE — owner `browser` — issue #8313 — release_blocking=false
+- `tests/test-browser-mock-adapter.rkt` — ASSERTION_FAILURE — owner `browser` — issue #8313 — release_blocking=false
+- `tests/test-browser-robustness-w1.rkt` — ASSERTION_FAILURE — owner `browser` — issue #8313 — release_blocking=false
+- `tests/test-browser-settings.rkt` — ASSERTION_FAILURE — owner `browser` — issue #8313 — release_blocking=false
+- `tests/test-bump-version.rkt` — ASSERTION_FAILURE — owner `core` — issue #8313 — release_blocking=false
+- `tests/test-cell-diff-render.rkt` — ASSERTION_FAILURE — owner `core` — issue #8313 — release_blocking=false
+- `tests/test-check-deps.rkt` — ASSERTION_FAILURE — owner `core` — issue #8313 — release_blocking=false
+- `tests/test-ci-local.rkt` — ASSERTION_FAILURE — owner `release-engineering` — issue #8313 — release_blocking=false
+- `tests/test-context-assembly-raw.rkt` — ASSERTION_FAILURE — owner `runtime` — issue #8313 — release_blocking=false
+- `tests/test-context-assembly-tree.rkt` — ASSERTION_FAILURE — owner `runtime` — issue #8313 — release_blocking=false
+- `tests/test-doctor.rkt` — ASSERTION_FAILURE — owner `core` — issue #8313 — release_blocking=false
+- `tests/test-effect-update-fsm-contract.rkt` — ASSERTION_FAILURE — owner `core` — issue #8313 — release_blocking=false
+- `tests/test-event-json-round-trip.rkt` — ASSERTION_FAILURE — owner `event-loop` — issue #8313 — release_blocking=false
+- `tests/test-event-roundtrip.rkt` — ASSERTION_FAILURE — owner `event-loop` — issue #8313 — release_blocking=false
+- `tests/test-event-types.rkt` — ASSERTION_FAILURE — owner `event-loop` — issue #8313 — release_blocking=false
+- `tests/test-export-formats.rkt` — ASSERTION_FAILURE — owner `core` — issue #8313 — release_blocking=false
+- `tests/test-facade-surface.rkt` — ASSERTION_FAILURE — owner `core` — issue #8313 — release_blocking=false
+- `tests/test-gap5-conclusion-bridge.rkt` — ASSERTION_FAILURE — owner `core` — issue #8313 — release_blocking=false
+- `tests/test-goal-evidence.rkt` — ASSERTION_FAILURE — owner `core` — issue #8313 — release_blocking=false
+- `tests/test-goal-runner.rkt` — ASSERTION_FAILURE — owner `core` — issue #8313 — release_blocking=false
+- `tests/test-gui-event-subscriber-characterization.rkt` — ASSERTION_FAILURE — owner `tui` — issue #8313 — release_blocking=false
+- `tests/test-gui-state-sync-w0.rkt` — MODULE_LOAD_FAILURE — owner `tui` — issue #8313 — release_blocking=false
+- `tests/test-hook-expansion.rkt` — ASSERTION_FAILURE — owner `extensions` — issue #8313 — release_blocking=false
+- `tests/test-hooks-complete.rkt` — ASSERTION_FAILURE — owner `extensions` — issue #8313 — release_blocking=false
+- `tests/test-hotspot-report.rkt` — ASSERTION_FAILURE — owner `architecture` — issue #8313 — release_blocking=false
+- `tests/test-integration.rkt` — ASSERTION_FAILURE — owner `core` — issue #8313 — release_blocking=false
+- `tests/test-interfaces-tui.rkt` — ASSERTION_FAILURE — owner `tui` — issue #8313 — release_blocking=false
+- `tests/test-layout-policy.rkt` — ASSERTION_FAILURE — owner `tui` — issue #8313 — release_blocking=false
+- `tests/test-lazy-context-assembly.rkt` — ASSERTION_FAILURE — owner `runtime` — issue #8313 — release_blocking=false
+- `tests/test-lint-doc-freshness.rkt` — ASSERTION_FAILURE — owner `release-engineering` — issue #8313 — release_blocking=false
+- `tests/test-lint-release-notes.rkt` — ASSERTION_FAILURE — owner `release-engineering` — issue #8313 — release_blocking=false
+- `tests/test-llm-error-visibility.rkt` — MODULE_LOAD_FAILURE — owner `llm` — issue #8313 — release_blocking=false
+- `tests/test-llm-model.rkt` — ASSERTION_FAILURE — owner `llm` — issue #8313 — release_blocking=false
+- `tests/test-loop-cancellation.rkt` — ASSERTION_FAILURE — owner `event-loop` — issue #8313 — release_blocking=false
+- `tests/test-loop-edge-cases.rkt` — ASSERTION_FAILURE — owner `event-loop` — issue #8313 — release_blocking=false
+- `tests/test-loop-events.rkt` — ASSERTION_FAILURE — owner `event-loop` — issue #8313 — release_blocking=false
+- `tests/test-main.rkt` — ASSERTION_FAILURE — owner `core` — issue #8313 — release_blocking=false
+- `tests/test-mcp-config.rkt` — ASSERTION_FAILURE — owner `llm` — issue #8313 — release_blocking=false
+- `tests/test-memory-policy.rkt` — ASSERTION_FAILURE — owner `runtime` — issue #8313 — release_blocking=false
+- `tests/test-model-command.rkt` — ASSERTION_FAILURE — owner `llm` — issue #8313 — release_blocking=false
+- `tests/test-model-registry.rkt` — ASSERTION_FAILURE — owner `llm` — issue #8313 — release_blocking=false
+- `tests/test-pre-commit.rkt` — ASSERTION_FAILURE — owner `release-engineering` — issue #8313 — release_blocking=false
+- `tests/test-prompt-injection.rkt` — ASSERTION_FAILURE — owner `security` — issue #8313 — release_blocking=false
+- `tests/test-run-tests-arg-validation.rkt` — ASSERTION_FAILURE — owner `core` — issue #8313 — release_blocking=false
+- `tests/test-run-tests.rkt` — ASSERTION_FAILURE — owner `core` — issue #8313 — release_blocking=false
+- `tests/test-safemode-enforcement.rkt` — ASSERTION_FAILURE — owner `security` — issue #8313 — release_blocking=false
+- `tests/test-self-hosting-deep.rkt` — ASSERTION_FAILURE — owner `release-engineering` — issue #8313 — release_blocking=false
+- `tests/test-self-hosting-workflow.rkt` — ASSERTION_FAILURE — owner `extensions` — issue #8313 — release_blocking=false
+- `tests/test-session-config-helpers.rkt` — ASSERTION_FAILURE — owner `runtime` — issue #8313 — release_blocking=false
+- `tests/test-settings.rkt` — ASSERTION_FAILURE — owner `core` — issue #8313 — release_blocking=false
+- `tests/test-skeleton.rkt` — ASSERTION_FAILURE — owner `core` — issue #8313 — release_blocking=false
+- `tests/test-stream-loop-w1.rkt` — ASSERTION_FAILURE — owner `event-loop` — issue #8313 — release_blocking=false
+- `tests/test-streaming-tool-bug.rkt` — ASSERTION_FAILURE — owner `event-loop` — issue #8313 — release_blocking=false
+- `tests/test-streaming-transitions.rkt` — ASSERTION_FAILURE — owner `event-loop` — issue #8313 — release_blocking=false
+- `tests/test-struct-mutability.rkt` — ASSERTION_FAILURE — owner `core` — issue #8313 — release_blocking=false
+- `tests/test-subprocess-edge-cases.rkt` — ASSERTION_FAILURE — owner `sandbox` — issue #8313 — release_blocking=false
+- `tests/test-subprocess.rkt` — ASSERTION_FAILURE — owner `sandbox` — issue #8313 — release_blocking=false
+- `tests/test-summary-integration.rkt` — ASSERTION_FAILURE — owner `core` — issue #8313 — release_blocking=false
+- `tests/test-sync-readme-status.rkt` — ASSERTION_FAILURE — owner `release-engineering` — issue #8313 — release_blocking=false
+- `tests/test-tui-event-ordering.rkt` — ASSERTION_FAILURE — owner `tui` — issue #8313 — release_blocking=false
+- `tests/test-tui-tool-cycle.rkt` — ASSERTION_FAILURE — owner `tui` — issue #8313 — release_blocking=false
+- `tests/test-tui-tool-failure-streaming.rkt` — ASSERTION_FAILURE — owner `tui` — issue #8313 — release_blocking=false
+- `tests/test-tui-tool-sequences.rkt` — ASSERTION_FAILURE — owner `tui` — issue #8313 — release_blocking=false
+- `tests/test-tui-workflow-harness.rkt` — ASSERTION_FAILURE — owner `tui` — issue #8313 — release_blocking=false
+- `tests/test-typed-model.rkt` — ASSERTION_FAILURE — owner `llm` — issue #8313 — release_blocking=false
+- `tests/test-ui-actions.rkt` — ASSERTION_FAILURE — owner `tui` — issue #8313 — release_blocking=false
+- `tests/test-util-reclassification.rkt` — ASSERTION_FAILURE — owner `core` — issue #8313 — release_blocking=false
+- `tests/test-widget-api.rkt` — ASSERTION_FAILURE — owner `tui` — issue #8313 — release_blocking=false
+- `tests/test-working-set.rkt` — ASSERTION_FAILURE — owner `runtime` — issue #8313 — release_blocking=false
+- `tests/tui/test-command-integration.rkt` — ENVIRONMENT_MISSING — owner `tui` — issue #8313 — release_blocking=false
+- `tests/tui/test-render.rkt` — ASSERTION_FAILURE — owner `tui` — issue #8313 — release_blocking=false
+- `tests/tui/test-state.rkt` — ASSERTION_FAILURE — owner `tui` — issue #8313 — release_blocking=false
+- `tests/workflows/cli/test-cli-resume.rkt` — ASSERTION_FAILURE — owner `workflows` — issue #8313 — release_blocking=false
+- `tests/workflows/cli/test-cli-single-shot.rkt` — ASSERTION_FAILURE — owner `workflows` — issue #8313 — release_blocking=false
+- `tests/workflows/parity/test-sdk-cli-parity.rkt` — ASSERTION_FAILURE — owner `workflows` — issue #8313 — release_blocking=false
+- `tests/workflows/tools/test-tool-bash-workflow.rkt` — UNKNOWN_FAILURE — owner `workflows` — issue #8313 — release_blocking=false
+- `tests/test-tool-edit-builtin.rkt` — ASSERTION_FAILURE — owner `tools` — issue #8313 — release_blocking=false
+
+## W5 acceptance verification
+
+Command:
+
+```bash
+timeout 900 racket scripts/run-tests.rkt --suite broad --ledger tests/test-suite-ledger.json
+```
+
+Observed result:
+
+```text
+broad-ledger2-exit=4
+Files: 1041 total, 959 passed, 82 failed, 0 timeouts
+Category: PASS=958, ASSERTION_FAILURE=78, MODULE_LOAD_FAILURE=2, ENVIRONMENT_MISSING=1, ZERO_PARSED=1, UNKNOWN_FAILURE=1
+VERDICT: ❌ FAIL
+Known failures: 82
+New failures: 0
+Unclassified failures: 0
+Resolved known failures: 2
+Release-blocking known failures: 0
+STRICT MODE: files with zero parsed tests: tests/test-benchmarks.rkt
+```
+
+Interpretation: W5 ledger classification is functioning; current broad failures are classified as known, no new/unclassified failures remain in this run. The command still exits `4` because strict zero-parsed detection remains correctly blocking for `tests/test-benchmarks.rkt` and is outside the known-failure ledger mechanism.

--- a/scripts/run-tests.rkt
+++ b/scripts/run-tests.rkt
@@ -73,7 +73,13 @@
                   summary-exit-code
                   compute-verdict
                   write-json-results!
+                  print-ledger-summary
                   make-unique-log-name)
+         (only-in "run-tests/ledger.rkt"
+                  load-known-failure-ledger
+                  summarize-ledger-results
+                  ledger-summary-counts
+                  ledger-entry-matches-result?)
          (only-in "run-tests/cli.rkt" usage parse-args validate-args! known-suites known-modes)
          (only-in "run-tests/gate-evidence.rkt" record-gate-evidence!)
          (only-in "run-tests/inventory.rkt"
@@ -124,6 +130,11 @@
          summary-exit-code
          compute-verdict
          write-json-results!
+         print-ledger-summary
+         load-known-failure-ledger
+         summarize-ledger-results
+         ledger-summary-counts
+         ledger-entry-matches-result?
          bytes->string*
          clean-stale-bytecode!
          file-has-rackunit-tests?
@@ -371,7 +382,8 @@
                         repeat-num
                         repeat-total
                         mode
-                        json-out)
+                        json-out
+                        ledger)
   (define t0 (current-inexact-milliseconds))
   (define-values (serial-files parallel-files)
     (if (> jobs 1)
@@ -407,7 +419,10 @@
                          results
                          #:suite (string->symbol suite-label)
                          #:mode mode
-                         #:elapsed-ms total-elapsed))
+                         #:elapsed-ms total-elapsed
+                         #:ledger ledger))
+  (when ledger
+    (print-ledger-summary ledger results))
   (save-failure-logs results)
   (define failed-files
     (count (lambda (r)
@@ -446,7 +461,8 @@
                   inventory?
                   diagnose-overhead?
                   requested-mode
-                  json-out)
+                  json-out
+                  ledger-path)
     (parse-args args))
   (validate-args! jobs
                   sequential?
@@ -459,7 +475,8 @@
                   inventory?
                   diagnose-overhead?
                   requested-mode
-                  json-out)
+                  json-out
+                  ledger-path)
   (when diagnose-overhead?
     (print-overhead-diagnostics #:base-dir base-dir)
     (exit 0))
@@ -486,6 +503,7 @@
   (define timeout-ms (and timeout (* timeout 1000)))
   (define suite-label (symbol->string suite))
   (define mode (effective-mode requested-mode suite-label))
+  (define ledger (and ledger-path (load-known-failure-ledger ledger-path)))
   (define n-files (length suite-files))
   (printf ";; run-tests: suite=~a files=~a jobs=~a sequential=~a repeat=~a mode=~a~n"
           suite-label
@@ -504,7 +522,16 @@
     (when (> repeat 1)
       (printf "~n;; ── Run ~a/~a ──~n" run-num repeat))
     (define-values (exit-code results)
-      (run-suite-once suite-files jobs timeout-ms strict? suite-label run-num repeat mode json-out))
+      (run-suite-once suite-files
+                      jobs
+                      timeout-ms
+                      strict?
+                      suite-label
+                      run-num
+                      repeat
+                      mode
+                      json-out
+                      ledger))
     (set-box! last-results results)
     (unless (zero? exit-code)
       (exit exit-code)))

--- a/scripts/run-tests/classify.rkt
+++ b/scripts/run-tests/classify.rkt
@@ -347,7 +347,7 @@
                                      (not (hash-ref (get-file-metadata rel) 'not-test? #f))))))
          (path->string (find-relative-path base-dir f))))
      (case suite
-       [(all) all-files]
+       [(all broad) all-files]
        [(fast) (filter (lambda (f) (not (slow-file? f))) all-files)]
        [(unit-fast) (filter unit-fast-file? all-files)]
        [(slow) (filter slow-file? all-files)]

--- a/scripts/run-tests/cli.rkt
+++ b/scripts/run-tests/cli.rkt
@@ -25,17 +25,20 @@
   (displayln "  --timeout SECS    Per-file timeout in seconds")
   (displayln "  --mode <name>     Execution mode: auto (default), subprocess, in-process, grouped")
   (displayln
-   "  --suite <name>    Run test suite: all (default), fast, unit-fast, slow, tui, smoke, security, arch, runtime, extensions, workflows")
+   "  --suite <name>    Run test suite: all/broad (default all), fast, unit-fast, slow, tui, smoke, security, arch, runtime, extensions, workflows")
   (displayln "  --strict          Enable strict zero-test detection (default: on)")
   (displayln "  --repeat N        Run suite N times (exit 1 if any run fails)")
   (displayln "  --record-gate-evidence  Write .gate-evidence/<suite>.passed on success")
   (displayln "  --inventory             Print inventory report (selected/excluded files) and exit")
   (displayln "  --diagnose-overhead     Measure Racket/raco per-file startup overhead and exit")
   (displayln "  --json-out PATH         Write structured per-file JSON results")
+  (displayln
+   "  --ledger PATH           Read known-failure ledger JSON and report known/new/resolved failures")
   (displayln "  --help            Show this help message")
   (newline)
   (displayln "Suites:")
   (displayln "  all     Entire tests/ directory (per-file spawn)")
+  (displayln "  broad   Alias for all discoverable tests (per-file spawn)")
   (displayln "  fast    All tests except slow patterns (per-file spawn)")
   (displayln "  unit-fast  Fast unit tests eligible for in-process/grouped execution")
   (displayln "  slow    Only sandbox/subprocess tests")
@@ -47,7 +50,8 @@
   (displayln "  extensions Extension/GSD/hook tests")
   (displayln "  workflows All tests/workflows/ including fixture self-tests (integration-level)"))
 
-(define known-suites '(all fast unit-fast slow smoke tui security arch runtime extensions workflows))
+(define known-suites
+  '(all broad fast unit-fast slow smoke tui security arch runtime extensions workflows))
 (define known-modes '(auto subprocess in-process grouped))
 
 (define (parse-args args)
@@ -63,7 +67,8 @@
              [inventory? #f]
              [diagnose-overhead? #f]
              [mode 'auto]
-             [json-out #f])
+             [json-out #f]
+             [ledger #f])
     (match rest
       ['()
        (values jobs
@@ -77,7 +82,8 @@
                inventory?
                diagnose-overhead?
                mode
-               json-out)]
+               json-out
+               ledger)]
       [(list "--help" _ ...)
        (usage)
        (exit 0)]
@@ -94,7 +100,8 @@
              inventory?
              diagnose-overhead?
              mode
-             json-out)]
+             json-out
+             ledger)]
       [(list "--jobs" n rest ...)
        (loop rest
              (string->number n)
@@ -108,7 +115,8 @@
              inventory?
              diagnose-overhead?
              mode
-             json-out)]
+             json-out
+             ledger)]
       [(list "--sequential" rest ...)
        (loop rest
              1
@@ -122,7 +130,8 @@
              inventory?
              diagnose-overhead?
              mode
-             json-out)]
+             json-out
+             ledger)]
       [(list "--timeout" secs rest ...)
        (loop rest
              jobs
@@ -136,7 +145,8 @@
              inventory?
              diagnose-overhead?
              mode
-             json-out)]
+             json-out
+             ledger)]
       [(list "--mode" name rest ...)
        (loop rest
              jobs
@@ -150,7 +160,8 @@
              inventory?
              diagnose-overhead?
              (string->symbol name)
-             json-out)]
+             json-out
+             ledger)]
       [(list "--suite" name rest ...)
        (loop rest
              jobs
@@ -164,7 +175,8 @@
              inventory?
              diagnose-overhead?
              mode
-             json-out)]
+             json-out
+             ledger)]
       [(list "--repeat" n rest ...)
        (loop rest
              jobs
@@ -178,7 +190,8 @@
              inventory?
              diagnose-overhead?
              mode
-             json-out)]
+             json-out
+             ledger)]
       [(list "--record-gate-evidence" rest ...)
        (loop rest
              jobs
@@ -192,7 +205,8 @@
              inventory?
              diagnose-overhead?
              mode
-             json-out)]
+             json-out
+             ledger)]
       [(list "--inventory" rest ...)
        (loop rest
              jobs
@@ -206,7 +220,8 @@
              #t
              diagnose-overhead?
              mode
-             json-out)]
+             json-out
+             ledger)]
       [(list "--diagnose-overhead" rest ...)
        (loop rest
              jobs
@@ -220,7 +235,8 @@
              inventory?
              #t
              mode
-             json-out)]
+             json-out
+             ledger)]
       [(list "--json-out" path rest ...)
        (loop rest
              jobs
@@ -234,6 +250,22 @@
              inventory?
              diagnose-overhead?
              mode
+             path
+             ledger)]
+      [(list "--ledger" path rest ...)
+       (loop rest
+             jobs
+             sequential?
+             timeout
+             strict?
+             suite
+             extra
+             repeat
+             record-gate?
+             inventory?
+             diagnose-overhead?
+             mode
+             json-out
              path)]
       [(list (regexp #rx"^--") rest ...)
        (eprintf "run-tests: unknown flag: ~a~n" (car rest))
@@ -252,7 +284,8 @@
              inventory?
              diagnose-overhead?
              mode
-             json-out)])))
+             json-out
+             ledger)])))
 
 (define (validate-args! jobs
                         sequential?
@@ -265,7 +298,8 @@
                         inventory?
                         diagnose-overhead?
                         mode
-                        json-out)
+                        json-out
+                        ledger)
   (unless (memq suite known-suites)
     (raise-user-error 'run-tests
                       "unknown suite: ~a (valid: ~a)"
@@ -284,4 +318,17 @@
                       (string-join (map symbol->string known-modes) ", ")))
   (when (and json-out (not (string? json-out)))
     (raise-user-error 'run-tests "--json-out must be a path string, got: ~a" json-out))
-  (values jobs sequential? timeout strict? suite extra repeat record-gate? inventory? mode json-out))
+  (when (and ledger (not (string? ledger)))
+    (raise-user-error 'run-tests "--ledger must be a path string, got: ~a" ledger))
+  (values jobs
+          sequential?
+          timeout
+          strict?
+          suite
+          extra
+          repeat
+          record-gate?
+          inventory?
+          mode
+          json-out
+          ledger))

--- a/scripts/run-tests/ledger.rkt
+++ b/scripts/run-tests/ledger.rkt
@@ -1,0 +1,173 @@
+#lang racket/base
+
+;; q/scripts/run-tests/ledger.rkt — Known broad-suite failure ledger support
+;;
+;; Ledger entries make broad-suite debt explicit and distinguish known failures
+;; from new/unclassified failures and resolved historical failures.
+;; STABILITY: internal test-runner infrastructure
+
+(require json
+         racket/list
+         racket/match
+         racket/path
+         racket/string
+         (only-in "parse.rkt" test-file-result-path test-file-result-exit-code classify-test-result))
+
+(provide load-known-failure-ledger
+         normalize-ledger-entry
+         summarize-ledger-results
+         ledger-summary-counts
+         ledger-entry-matches-result?)
+
+(define required-ledger-keys '(file category owner first_seen release_blocking issue notes))
+(define missing-sentinel (gensym 'missing))
+
+(define (hash-ref* h key [default #f])
+  (cond
+    [(hash-has-key? h key) (hash-ref h key)]
+    [(hash-has-key? h (string->symbol (symbol->string key)))
+     (hash-ref h (string->symbol (symbol->string key)))]
+    [else default]))
+
+(define (path->ledger-string p)
+  (cond
+    [(path? p) (path->string p)]
+    [(string? p) p]
+    [else (format "~a" p)]))
+
+(define (normalize-path-string p)
+  (define s (path->ledger-string p))
+  (cond
+    [(string-prefix? s "./") (substring s 2)]
+    [else s]))
+
+(define (normalize-category v)
+  (cond
+    [(symbol? v) (symbol->string v)]
+    [(string? v) v]
+    [else (format "~a" v)]))
+
+(define (normalize-ledger-entry raw)
+  (unless (hash? raw)
+    (raise-arguments-error 'normalize-ledger-entry "ledger entry must be a JSON object" "entry" raw))
+  (for ([key (in-list required-ledger-keys)])
+    (when (eq? (hash-ref* raw key missing-sentinel) missing-sentinel)
+      (raise-arguments-error 'normalize-ledger-entry
+                             "ledger entry missing required key"
+                             "key"
+                             key
+                             "entry"
+                             raw)))
+  (hasheq 'file
+          (normalize-path-string (hash-ref* raw 'file))
+          'category
+          (normalize-category (hash-ref* raw 'category))
+          'owner
+          (hash-ref* raw 'owner)
+          'first_seen
+          (hash-ref* raw 'first_seen)
+          'release_blocking
+          (and (hash-ref* raw 'release_blocking) #t)
+          'issue
+          (hash-ref* raw 'issue)
+          'notes
+          (hash-ref* raw 'notes)))
+
+(define (extract-ledger-entries payload)
+  (cond
+    [(list? payload) payload]
+    [(hash? payload) (hash-ref* payload 'entries '())]
+    [else '()]))
+
+(define (load-known-failure-ledger path)
+  (define payload (call-with-input-file path read-json))
+  (map normalize-ledger-entry (extract-ledger-entries payload)))
+
+(define (result-failure? r)
+  (not (= (test-file-result-exit-code r) 0)))
+
+(define (result-path-string r)
+  (normalize-path-string (test-file-result-path r)))
+
+(define (result-category-string r)
+  (symbol->string (classify-test-result r)))
+
+(define (same-file? entry r)
+  (string=? (hash-ref entry 'file) (result-path-string r)))
+
+(define (ledger-entry-matches-result? entry r)
+  (and (same-file? entry r) (string=? (hash-ref entry 'category) (result-category-string r))))
+
+(define (matching-entry ledger r)
+  (for/first ([entry (in-list ledger)]
+              #:when (ledger-entry-matches-result? entry r))
+    entry))
+
+(define (file-entry ledger r)
+  (for/first ([entry (in-list ledger)]
+              #:when (same-file? entry r))
+    entry))
+
+(define (result->unclassified-entry r)
+  (hasheq 'file
+          (result-path-string r)
+          'category
+          (result-category-string r)
+          'known_category
+          (let ([entry (file-entry '() r)]) (and entry (hash-ref entry 'category #f)))))
+
+(define (result->new-entry r)
+  (hasheq 'file (result-path-string r) 'category (result-category-string r)))
+
+(define (summarize-ledger-results ledger results)
+  (define failures (filter result-failure? results))
+  (define known
+    (for/list ([r (in-list failures)]
+               #:do [(define entry (matching-entry ledger r))]
+               #:when entry)
+      entry))
+  (define new
+    (for/list ([r (in-list failures)]
+               #:when (not (file-entry ledger r)))
+      (result->new-entry r)))
+  (define unclassified
+    (for/list ([r (in-list failures)]
+               #:when (not (matching-entry ledger r)))
+      (define by-file (file-entry ledger r))
+      (hasheq 'file
+              (result-path-string r)
+              'category
+              (result-category-string r)
+              'known_category
+              (and by-file (hash-ref by-file 'category #f))
+              'issue
+              (and by-file (hash-ref by-file 'issue #f)))))
+  (define resolved
+    (for/list ([entry (in-list ledger)]
+               #:unless (for/or ([r (in-list failures)])
+                          (same-file? entry r)))
+      entry))
+  (define release-blocking-known
+    (filter (lambda (entry) (hash-ref entry 'release_blocking #f)) known))
+  (hasheq 'known_failures
+          known
+          'new_failures
+          new
+          'unclassified_failures
+          unclassified
+          'resolved_known_failures
+          resolved
+          'release_blocking_known_failures
+          release-blocking-known))
+
+(define (ledger-summary-counts summary)
+  (hasheq 'known_failures
+          (length (hash-ref summary 'known_failures '()))
+          'new_failures
+          (length (hash-ref summary 'new_failures '()))
+          'unclassified_failures
+          (length (hash-ref summary 'unclassified_failures '()))
+          'resolved_known_failures
+          (length (hash-ref summary 'resolved_known_failures '()))
+          'release_blocking_known_failures
+          (length (hash-ref summary 'release_blocking_known_failures '()))))

--- a/scripts/run-tests/reporting.rkt
+++ b/scripts/run-tests/reporting.rkt
@@ -10,6 +10,10 @@
          racket/path
          racket/list
          json
+         (only-in "ledger.rkt"
+                  summarize-ledger-results
+                  ledger-summary-counts
+                  ledger-entry-matches-result?)
          (only-in "parse.rkt"
                   test-file-result-path
                   test-file-result-exit-code
@@ -33,6 +37,7 @@
          classify-test-result
          test-result->jsexpr
          write-json-results!
+         print-ledger-summary
          format-verdict-line)
 
 (define (format-duration ms)
@@ -121,11 +126,33 @@
                #:when (> (hash-ref counts category 0) 0))
     (values (string->symbol (symbol->string category)) (hash-ref counts category))))
 
+(define (ledger-match ledger r)
+  (and ledger
+       (for/first ([entry (in-list ledger)]
+                   #:when (ledger-entry-matches-result? entry r))
+         entry)))
+
+(define (test-result->ledger-jsexpr r ledger)
+  (define base (test-result->jsexpr r))
+  (define entry (ledger-match ledger r))
+  (if entry
+      (hash-set* base
+                 'known_failure
+                 #t
+                 'issue
+                 (hash-ref entry 'issue)
+                 'owner
+                 (hash-ref entry 'owner)
+                 'release_blocking
+                 (hash-ref entry 'release_blocking))
+      (hash-set base 'known_failure #f)))
+
 (define (write-json-results! path
                              results
                              #:suite [suite 'all]
                              #:mode [mode 'subprocess]
-                             #:elapsed-ms [elapsed-ms 0])
+                             #:elapsed-ms [elapsed-ms 0]
+                             #:ledger [ledger #f])
   (define passed-files (count (lambda (r) (= (test-file-result-exit-code r) 0)) results))
   (define failed-files
     (count (lambda (r)
@@ -134,6 +161,7 @@
            results))
   (define timeout-files (count (lambda (r) (= (test-file-result-exit-code r) 2)) results))
   (define counts (category-counts results))
+  (define ledger-summary (and ledger (summarize-ledger-results ledger results)))
   (define payload
     (hasheq 'suite
             (symbol->string suite)
@@ -160,9 +188,30 @@
                     (for/sum ([r (in-list results)]) (test-file-result-failed r)))
             'category_counts
             (category-counts->jsexpr counts)
+            'ledger
+            (and ledger-summary (ledger-summary-counts ledger-summary))
             'files
-            (map test-result->jsexpr results)))
+            (if ledger
+                (map (lambda (r) (test-result->ledger-jsexpr r ledger)) results)
+                (map test-result->jsexpr results))))
   (call-with-output-file path #:exists 'truncate/replace (lambda (out) (write-json payload out))))
+
+(define (print-ledger-summary ledger results)
+  (define summary (summarize-ledger-results ledger results))
+  (define counts (ledger-summary-counts summary))
+  (newline)
+  (displayln "KNOWN-FAILURE LEDGER")
+  (printf "  Known failures: ~a~n" (hash-ref counts 'known_failures))
+  (printf "  New failures: ~a~n" (hash-ref counts 'new_failures))
+  (printf "  Unclassified failures: ~a~n" (hash-ref counts 'unclassified_failures))
+  (printf "  Resolved known failures: ~a~n" (hash-ref counts 'resolved_known_failures))
+  (printf "  Release-blocking known failures: ~a~n"
+          (hash-ref counts 'release_blocking_known_failures))
+  (when (> (hash-ref counts 'unclassified_failures) 0)
+    (displayln "  ⛔ Ledger incomplete: unclassified failures remain."))
+  (when (> (hash-ref counts 'new_failures) 0)
+    (displayln "  ⛔ New failures require triage before broad gate approval."))
+  summary)
 
 (define (print-summary results total-start-ms)
   (define total-files (length results))

--- a/tests/test-run-tests-in-process-mode.rkt
+++ b/tests/test-run-tests-in-process-mode.rkt
@@ -50,7 +50,8 @@
                       inventory?
                       diagnose?
                       mode
-                      json-out)
+                      json-out
+                      ledger)
         (parse-args '("--mode" "in-process" "--suite" "unit-fast")))
       (check-equal? mode 'in-process)
       (check-equal? suite 'unit-fast)
@@ -65,7 +66,8 @@
                       _inventory?
                       _diagnose?
                       default-mode
-                      _json-out)
+                      _json-out
+                      _ledger)
         (parse-args '()))
       (check-equal? default-mode 'auto))
 

--- a/tests/test-run-tests-json-classification.rkt
+++ b/tests/test-run-tests-json-classification.rkt
@@ -84,7 +84,8 @@
                       _inventory?
                       _diagnose?
                       _mode
-                      json-out)
+                      json-out
+                      _ledger)
         (parse-args '("--json-out" "/tmp/q-results.json")))
       (check-equal? json-out "/tmp/q-results.json"))
 

--- a/tests/test-run-tests-ledger.rkt
+++ b/tests/test-run-tests-ledger.rkt
@@ -1,0 +1,178 @@
+#lang racket/base
+
+;; @speed fast
+;; @suite testing
+;; @isolation subprocess
+
+(require rackunit
+         rackunit/text-ui
+         json
+         racket/file
+         racket/path
+         racket/runtime-path
+         racket/system
+         "../scripts/run-tests.rkt")
+
+(define-runtime-path here ".")
+(define project-root (simplify-path (build-path here "..")))
+(define runner-module `(file ,(path->string (build-path project-root "scripts/run-tests.rkt"))))
+
+(define load-known-failure-ledger*
+  (dynamic-require runner-module
+                   'load-known-failure-ledger
+                   (lambda () (lambda (_) (error 'load-known-failure-ledger "missing export")))))
+
+(define summarize-ledger-results*
+  (dynamic-require runner-module
+                   'summarize-ledger-results
+                   (lambda () (lambda _ (error 'summarize-ledger-results "missing export")))))
+
+(define (result #:path path
+                #:exit [exit-code 1]
+                #:out [out "FAILURE"]
+                #:failed [failed 1]
+                #:total [total 1])
+  (test-file-result path exit-code (string->bytes/utf-8 out) #"" 10 0 failed total))
+
+(define (write-ledger entries)
+  (define path (make-temporary-file "q-known-failures-~a.json"))
+  (call-with-output-file path
+                         #:exists 'truncate/replace
+                         (lambda (out) (write-json (hasheq 'version 1 'entries entries) out)))
+  path)
+
+(define (delete-file/safe path)
+  (with-handlers ([exn:fail? (lambda (_) (void))])
+    (when (file-exists? path)
+      (delete-file path))))
+
+(define (run/capture cmd)
+  (parameterize ([current-directory project-root])
+    (define out (open-output-string))
+    (define err (open-output-string))
+    (define code
+      (parameterize ([current-output-port out]
+                     [current-error-port err])
+        (system/exit-code cmd)))
+    (values code (get-output-string out) (get-output-string err))))
+
+(define suite
+  (test-suite "run-tests known-failure ledger"
+    (test-case "parse-args accepts --ledger"
+      (define-values (_jobs
+                      _seq?
+                      _timeout
+                      _strict?
+                      _suite
+                      _extra
+                      _repeat
+                      _record?
+                      _inventory?
+                      _diagnose?
+                      _mode
+                      _json-out
+                      ledger)
+        (parse-args '("--ledger" "tests/test-suite-ledger.json")))
+      (check-equal? ledger "tests/test-suite-ledger.json"))
+
+    (test-case "known-failure ledger classifies known, new, unclassified, and resolved failures"
+      (define ledger-path
+        (write-ledger (list (hasheq 'file
+                                    "tests/known.rkt"
+                                    'category
+                                    "ASSERTION_FAILURE"
+                                    'owner
+                                    "runtime"
+                                    'first_seen
+                                    "0.99.28"
+                                    'release_blocking
+                                    #f
+                                    'issue
+                                    "#9001"
+                                    'notes
+                                    "pre-existing assertion drift")
+                            (hasheq 'file
+                                    "tests/category-changed.rkt"
+                                    'category
+                                    "MODULE_LOAD_FAILURE"
+                                    'owner
+                                    "runtime"
+                                    'first_seen
+                                    "0.99.28"
+                                    'release_blocking
+                                    #t
+                                    'issue
+                                    "#9002"
+                                    'notes
+                                    "category must match")
+                            (hasheq 'file
+                                    "tests/resolved.rkt"
+                                    'category
+                                    "ASSERTION_FAILURE"
+                                    'owner
+                                    "runtime"
+                                    'first_seen
+                                    "0.99.28"
+                                    'release_blocking
+                                    #f
+                                    'issue
+                                    "#9003"
+                                    'notes
+                                    "should be resolved"))))
+      (dynamic-wind void
+                    (lambda ()
+                      (define ledger (load-known-failure-ledger* ledger-path))
+                      (check-equal? (length ledger) 3)
+                      (define summary
+                        (summarize-ledger-results* ledger
+                                                   (list (result #:path "tests/known.rkt")
+                                                         (result #:path "tests/new.rkt")
+                                                         (result #:path "tests/category-changed.rkt"
+                                                                 #:out "FAILURE"))))
+                      (check-equal? (length (hash-ref summary 'known_failures)) 1)
+                      (check-equal? (length (hash-ref summary 'new_failures)) 1)
+                      (check-equal? (length (hash-ref summary 'unclassified_failures)) 2)
+                      (check-equal? (length (hash-ref summary 'resolved_known_failures)) 1)
+                      (check-equal? (hash-ref (car (hash-ref summary 'known_failures)) 'issue)
+                                    "#9001"))
+                    (lambda () (delete-file/safe ledger-path))))
+
+    (test-case "CLI prints known-failure ledger summary"
+      (define missing-file (make-temporary-file "test-missing-cli-known-~a.rkt"))
+      (define ledger-path
+        (write-ledger (list (hasheq 'file
+                                    (path->string missing-file)
+                                    'category
+                                    "MODULE_LOAD_FAILURE"
+                                    'owner
+                                    "testing"
+                                    'first_seen
+                                    "0.99.30"
+                                    'release_blocking
+                                    #f
+                                    'issue
+                                    "#8313"
+                                    'notes
+                                    "synthetic missing module"))))
+      (call-with-output-file missing-file
+                             #:exists 'truncate/replace
+                             (lambda (out)
+                               (displayln "#lang racket/base" out)
+                               (displayln "(require definitely/missing/module)" out)))
+      (dynamic-wind
+       void
+       (lambda ()
+         (define-values (code stdout stderr)
+           (run/capture (format "racket scripts/run-tests.rkt --sequential --ledger ~a ~a"
+                                ledger-path
+                                missing-file)))
+         (check-equal? code 1 stderr)
+         (check-true (regexp-match? #rx"Known failures:[ ]+1" stdout) stdout)
+         (check-true (regexp-match? #rx"New failures:[ ]+0" stdout) stdout)
+         (check-true (regexp-match? #rx"Unclassified failures:[ ]+0" stdout) stdout)
+         (check-true (regexp-match? #rx"Resolved known failures:[ ]+0" stdout) stdout))
+       (lambda ()
+         (delete-file/safe ledger-path)
+         (delete-file/safe missing-file))))))
+
+(run-tests suite)

--- a/tests/test-run-tests.rkt
+++ b/tests/test-run-tests.rkt
@@ -432,7 +432,8 @@
                   inventory?
                   diagnose?
                   mode
-                  json-out)
+                  json-out
+                  ledger)
     (parse '("--repeat" "3")))
   (check-equal? repeat 3)
   (check-false record-gate?))
@@ -450,7 +451,8 @@
                   inventory?
                   diagnose?
                   mode
-                  json-out)
+                  json-out
+                  ledger)
     (parse '()))
   (check-equal? repeat 1)
   (check-false record-gate?))
@@ -468,7 +470,8 @@
                   inventory?
                   diagnose?
                   mode
-                  json-out)
+                  json-out
+                  ledger)
     (parse '("--suite" "smoke" "--repeat" "2")))
   (check-equal? suite 'smoke)
   (check-equal? repeat 2)
@@ -491,7 +494,8 @@
                   inventory?
                   diagnose?
                   mode
-                  json-out)
+                  json-out
+                  ledger)
     (parse '("--record-gate-evidence")))
   (check-true record-gate?))
 
@@ -508,7 +512,8 @@
                   inventory?
                   diagnose?
                   mode
-                  json-out)
+                  json-out
+                  ledger)
     (parse '()))
   (check-false record-gate?))
 

--- a/tests/test-suite-ledger.json
+++ b/tests/test-suite-ledger.json
@@ -1,0 +1,795 @@
+{
+  "entries": [
+    {
+      "category": "ASSERTION_FAILURE",
+      "file": "tests/test-agent-session-context.rkt",
+      "first_seen": "0.99.30-W5-broad-baseline",
+      "issue": "#8313",
+      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
+      "owner": "runtime",
+      "release_blocking": false
+    },
+    {
+      "category": "ASSERTION_FAILURE",
+      "file": "tests/test-anthropic.rkt",
+      "first_seen": "0.99.30-W5-broad-baseline",
+      "issue": "#8313",
+      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
+      "owner": "llm",
+      "release_blocking": false
+    },
+    {
+      "category": "ASSERTION_FAILURE",
+      "file": "tests/test-arch-fitness.rkt",
+      "first_seen": "0.99.30-W5-broad-baseline",
+      "issue": "#8313",
+      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
+      "owner": "architecture",
+      "release_blocking": false
+    },
+    {
+      "category": "ASSERTION_FAILURE",
+      "file": "tests/test-benchmark-scorer.rkt",
+      "first_seen": "0.99.30-W5-broad-baseline",
+      "issue": "#8313",
+      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
+      "owner": "core",
+      "release_blocking": false
+    },
+    {
+      "category": "ASSERTION_FAILURE",
+      "file": "tests/test-browser-adapter.rkt",
+      "first_seen": "0.99.30-W5-broad-baseline",
+      "issue": "#8313",
+      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
+      "owner": "browser",
+      "release_blocking": false
+    },
+    {
+      "category": "ASSERTION_FAILURE",
+      "file": "tests/test-browser-audit-w1-v0983.rkt",
+      "first_seen": "0.99.30-W5-broad-baseline",
+      "issue": "#8313",
+      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
+      "owner": "browser",
+      "release_blocking": false
+    },
+    {
+      "category": "ASSERTION_FAILURE",
+      "file": "tests/test-browser-audit-w2.rkt",
+      "first_seen": "0.99.30-W5-broad-baseline",
+      "issue": "#8313",
+      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
+      "owner": "browser",
+      "release_blocking": false
+    },
+    {
+      "category": "ASSERTION_FAILURE",
+      "file": "tests/test-browser-audit.rkt",
+      "first_seen": "0.99.30-W5-broad-baseline",
+      "issue": "#8313",
+      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
+      "owner": "browser",
+      "release_blocking": false
+    },
+    {
+      "category": "ASSERTION_FAILURE",
+      "file": "tests/test-browser-mock-adapter.rkt",
+      "first_seen": "0.99.30-W5-broad-baseline",
+      "issue": "#8313",
+      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
+      "owner": "browser",
+      "release_blocking": false
+    },
+    {
+      "category": "ASSERTION_FAILURE",
+      "file": "tests/test-browser-robustness-w1.rkt",
+      "first_seen": "0.99.30-W5-broad-baseline",
+      "issue": "#8313",
+      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
+      "owner": "browser",
+      "release_blocking": false
+    },
+    {
+      "category": "ASSERTION_FAILURE",
+      "file": "tests/test-browser-settings.rkt",
+      "first_seen": "0.99.30-W5-broad-baseline",
+      "issue": "#8313",
+      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
+      "owner": "browser",
+      "release_blocking": false
+    },
+    {
+      "category": "ASSERTION_FAILURE",
+      "file": "tests/test-bump-version.rkt",
+      "first_seen": "0.99.30-W5-broad-baseline",
+      "issue": "#8313",
+      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
+      "owner": "core",
+      "release_blocking": false
+    },
+    {
+      "category": "ASSERTION_FAILURE",
+      "file": "tests/test-cell-diff-render.rkt",
+      "first_seen": "0.99.30-W5-broad-baseline",
+      "issue": "#8313",
+      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
+      "owner": "core",
+      "release_blocking": false
+    },
+    {
+      "category": "ASSERTION_FAILURE",
+      "file": "tests/test-check-deps.rkt",
+      "first_seen": "0.99.30-W5-broad-baseline",
+      "issue": "#8313",
+      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
+      "owner": "core",
+      "release_blocking": false
+    },
+    {
+      "category": "ASSERTION_FAILURE",
+      "file": "tests/test-ci-local.rkt",
+      "first_seen": "0.99.30-W5-broad-baseline",
+      "issue": "#8313",
+      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
+      "owner": "release-engineering",
+      "release_blocking": false
+    },
+    {
+      "category": "ASSERTION_FAILURE",
+      "file": "tests/test-context-assembly-raw.rkt",
+      "first_seen": "0.99.30-W5-broad-baseline",
+      "issue": "#8313",
+      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
+      "owner": "runtime",
+      "release_blocking": false
+    },
+    {
+      "category": "ASSERTION_FAILURE",
+      "file": "tests/test-context-assembly-tree.rkt",
+      "first_seen": "0.99.30-W5-broad-baseline",
+      "issue": "#8313",
+      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
+      "owner": "runtime",
+      "release_blocking": false
+    },
+    {
+      "category": "ASSERTION_FAILURE",
+      "file": "tests/test-doctor.rkt",
+      "first_seen": "0.99.30-W5-broad-baseline",
+      "issue": "#8313",
+      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
+      "owner": "core",
+      "release_blocking": false
+    },
+    {
+      "category": "ASSERTION_FAILURE",
+      "file": "tests/test-effect-update-fsm-contract.rkt",
+      "first_seen": "0.99.30-W5-broad-baseline",
+      "issue": "#8313",
+      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
+      "owner": "core",
+      "release_blocking": false
+    },
+    {
+      "category": "ASSERTION_FAILURE",
+      "file": "tests/test-event-json-round-trip.rkt",
+      "first_seen": "0.99.30-W5-broad-baseline",
+      "issue": "#8313",
+      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
+      "owner": "event-loop",
+      "release_blocking": false
+    },
+    {
+      "category": "ASSERTION_FAILURE",
+      "file": "tests/test-event-roundtrip.rkt",
+      "first_seen": "0.99.30-W5-broad-baseline",
+      "issue": "#8313",
+      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
+      "owner": "event-loop",
+      "release_blocking": false
+    },
+    {
+      "category": "ASSERTION_FAILURE",
+      "file": "tests/test-event-types.rkt",
+      "first_seen": "0.99.30-W5-broad-baseline",
+      "issue": "#8313",
+      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
+      "owner": "event-loop",
+      "release_blocking": false
+    },
+    {
+      "category": "ASSERTION_FAILURE",
+      "file": "tests/test-export-formats.rkt",
+      "first_seen": "0.99.30-W5-broad-baseline",
+      "issue": "#8313",
+      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
+      "owner": "core",
+      "release_blocking": false
+    },
+    {
+      "category": "ASSERTION_FAILURE",
+      "file": "tests/test-facade-surface.rkt",
+      "first_seen": "0.99.30-W5-broad-baseline",
+      "issue": "#8313",
+      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
+      "owner": "core",
+      "release_blocking": false
+    },
+    {
+      "category": "ASSERTION_FAILURE",
+      "file": "tests/test-gap5-conclusion-bridge.rkt",
+      "first_seen": "0.99.30-W5-broad-baseline",
+      "issue": "#8313",
+      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
+      "owner": "core",
+      "release_blocking": false
+    },
+    {
+      "category": "ASSERTION_FAILURE",
+      "file": "tests/test-goal-evidence.rkt",
+      "first_seen": "0.99.30-W5-broad-baseline",
+      "issue": "#8313",
+      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
+      "owner": "core",
+      "release_blocking": false
+    },
+    {
+      "category": "ASSERTION_FAILURE",
+      "file": "tests/test-goal-runner.rkt",
+      "first_seen": "0.99.30-W5-broad-baseline",
+      "issue": "#8313",
+      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
+      "owner": "core",
+      "release_blocking": false
+    },
+    {
+      "category": "ASSERTION_FAILURE",
+      "file": "tests/test-gui-event-subscriber-characterization.rkt",
+      "first_seen": "0.99.30-W5-broad-baseline",
+      "issue": "#8313",
+      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
+      "owner": "tui",
+      "release_blocking": false
+    },
+    {
+      "category": "MODULE_LOAD_FAILURE",
+      "file": "tests/test-gui-state-sync-w0.rkt",
+      "first_seen": "0.99.30-W5-broad-baseline",
+      "issue": "#8313",
+      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
+      "owner": "tui",
+      "release_blocking": false
+    },
+    {
+      "category": "ASSERTION_FAILURE",
+      "file": "tests/test-hook-expansion.rkt",
+      "first_seen": "0.99.30-W5-broad-baseline",
+      "issue": "#8313",
+      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
+      "owner": "extensions",
+      "release_blocking": false
+    },
+    {
+      "category": "ASSERTION_FAILURE",
+      "file": "tests/test-hooks-complete.rkt",
+      "first_seen": "0.99.30-W5-broad-baseline",
+      "issue": "#8313",
+      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
+      "owner": "extensions",
+      "release_blocking": false
+    },
+    {
+      "category": "ASSERTION_FAILURE",
+      "file": "tests/test-hotspot-report.rkt",
+      "first_seen": "0.99.30-W5-broad-baseline",
+      "issue": "#8313",
+      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
+      "owner": "architecture",
+      "release_blocking": false
+    },
+    {
+      "category": "ASSERTION_FAILURE",
+      "file": "tests/test-integration.rkt",
+      "first_seen": "0.99.30-W5-broad-baseline",
+      "issue": "#8313",
+      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
+      "owner": "core",
+      "release_blocking": false
+    },
+    {
+      "category": "ASSERTION_FAILURE",
+      "file": "tests/test-interfaces-tui.rkt",
+      "first_seen": "0.99.30-W5-broad-baseline",
+      "issue": "#8313",
+      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
+      "owner": "tui",
+      "release_blocking": false
+    },
+    {
+      "category": "ASSERTION_FAILURE",
+      "file": "tests/test-layout-policy.rkt",
+      "first_seen": "0.99.30-W5-broad-baseline",
+      "issue": "#8313",
+      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
+      "owner": "tui",
+      "release_blocking": false
+    },
+    {
+      "category": "ASSERTION_FAILURE",
+      "file": "tests/test-lazy-context-assembly.rkt",
+      "first_seen": "0.99.30-W5-broad-baseline",
+      "issue": "#8313",
+      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
+      "owner": "runtime",
+      "release_blocking": false
+    },
+    {
+      "category": "ASSERTION_FAILURE",
+      "file": "tests/test-lint-doc-freshness.rkt",
+      "first_seen": "0.99.30-W5-broad-baseline",
+      "issue": "#8313",
+      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
+      "owner": "release-engineering",
+      "release_blocking": false
+    },
+    {
+      "category": "ASSERTION_FAILURE",
+      "file": "tests/test-lint-release-notes.rkt",
+      "first_seen": "0.99.30-W5-broad-baseline",
+      "issue": "#8313",
+      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
+      "owner": "release-engineering",
+      "release_blocking": false
+    },
+    {
+      "category": "MODULE_LOAD_FAILURE",
+      "file": "tests/test-llm-error-visibility.rkt",
+      "first_seen": "0.99.30-W5-broad-baseline",
+      "issue": "#8313",
+      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
+      "owner": "llm",
+      "release_blocking": false
+    },
+    {
+      "category": "ASSERTION_FAILURE",
+      "file": "tests/test-llm-model.rkt",
+      "first_seen": "0.99.30-W5-broad-baseline",
+      "issue": "#8313",
+      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
+      "owner": "llm",
+      "release_blocking": false
+    },
+    {
+      "category": "ASSERTION_FAILURE",
+      "file": "tests/test-loop-cancellation.rkt",
+      "first_seen": "0.99.30-W5-broad-baseline",
+      "issue": "#8313",
+      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
+      "owner": "event-loop",
+      "release_blocking": false
+    },
+    {
+      "category": "ASSERTION_FAILURE",
+      "file": "tests/test-loop-edge-cases.rkt",
+      "first_seen": "0.99.30-W5-broad-baseline",
+      "issue": "#8313",
+      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
+      "owner": "event-loop",
+      "release_blocking": false
+    },
+    {
+      "category": "ASSERTION_FAILURE",
+      "file": "tests/test-loop-events.rkt",
+      "first_seen": "0.99.30-W5-broad-baseline",
+      "issue": "#8313",
+      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
+      "owner": "event-loop",
+      "release_blocking": false
+    },
+    {
+      "category": "ASSERTION_FAILURE",
+      "file": "tests/test-main.rkt",
+      "first_seen": "0.99.30-W5-broad-baseline",
+      "issue": "#8313",
+      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
+      "owner": "core",
+      "release_blocking": false
+    },
+    {
+      "category": "ASSERTION_FAILURE",
+      "file": "tests/test-mcp-config.rkt",
+      "first_seen": "0.99.30-W5-broad-baseline",
+      "issue": "#8313",
+      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
+      "owner": "llm",
+      "release_blocking": false
+    },
+    {
+      "category": "ASSERTION_FAILURE",
+      "file": "tests/test-memory-policy.rkt",
+      "first_seen": "0.99.30-W5-broad-baseline",
+      "issue": "#8313",
+      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
+      "owner": "runtime",
+      "release_blocking": false
+    },
+    {
+      "category": "ASSERTION_FAILURE",
+      "file": "tests/test-model-command.rkt",
+      "first_seen": "0.99.30-W5-broad-baseline",
+      "issue": "#8313",
+      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
+      "owner": "llm",
+      "release_blocking": false
+    },
+    {
+      "category": "ASSERTION_FAILURE",
+      "file": "tests/test-model-registry.rkt",
+      "first_seen": "0.99.30-W5-broad-baseline",
+      "issue": "#8313",
+      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
+      "owner": "llm",
+      "release_blocking": false
+    },
+    {
+      "category": "ASSERTION_FAILURE",
+      "file": "tests/test-pre-commit.rkt",
+      "first_seen": "0.99.30-W5-broad-baseline",
+      "issue": "#8313",
+      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
+      "owner": "release-engineering",
+      "release_blocking": false
+    },
+    {
+      "category": "ASSERTION_FAILURE",
+      "file": "tests/test-prompt-injection.rkt",
+      "first_seen": "0.99.30-W5-broad-baseline",
+      "issue": "#8313",
+      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
+      "owner": "security",
+      "release_blocking": false
+    },
+    {
+      "category": "ASSERTION_FAILURE",
+      "file": "tests/test-run-tests-arg-validation.rkt",
+      "first_seen": "0.99.30-W5-broad-baseline",
+      "issue": "#8313",
+      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
+      "owner": "core",
+      "release_blocking": false
+    },
+    {
+      "category": "ASSERTION_FAILURE",
+      "file": "tests/test-run-tests.rkt",
+      "first_seen": "0.99.30-W5-broad-baseline",
+      "issue": "#8313",
+      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
+      "owner": "core",
+      "release_blocking": false
+    },
+    {
+      "category": "ASSERTION_FAILURE",
+      "file": "tests/test-safemode-enforcement.rkt",
+      "first_seen": "0.99.30-W5-broad-baseline",
+      "issue": "#8313",
+      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
+      "owner": "security",
+      "release_blocking": false
+    },
+    {
+      "category": "ASSERTION_FAILURE",
+      "file": "tests/test-self-hosting-deep.rkt",
+      "first_seen": "0.99.30-W5-broad-baseline",
+      "issue": "#8313",
+      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
+      "owner": "release-engineering",
+      "release_blocking": false
+    },
+    {
+      "category": "ASSERTION_FAILURE",
+      "file": "tests/test-self-hosting-workflow.rkt",
+      "first_seen": "0.99.30-W5-broad-baseline",
+      "issue": "#8313",
+      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
+      "owner": "extensions",
+      "release_blocking": false
+    },
+    {
+      "category": "ASSERTION_FAILURE",
+      "file": "tests/test-session-config-helpers.rkt",
+      "first_seen": "0.99.30-W5-broad-baseline",
+      "issue": "#8313",
+      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
+      "owner": "runtime",
+      "release_blocking": false
+    },
+    {
+      "category": "ASSERTION_FAILURE",
+      "file": "tests/test-settings.rkt",
+      "first_seen": "0.99.30-W5-broad-baseline",
+      "issue": "#8313",
+      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
+      "owner": "core",
+      "release_blocking": false
+    },
+    {
+      "category": "ASSERTION_FAILURE",
+      "file": "tests/test-skeleton.rkt",
+      "first_seen": "0.99.30-W5-broad-baseline",
+      "issue": "#8313",
+      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
+      "owner": "core",
+      "release_blocking": false
+    },
+    {
+      "category": "ASSERTION_FAILURE",
+      "file": "tests/test-stream-loop-w1.rkt",
+      "first_seen": "0.99.30-W5-broad-baseline",
+      "issue": "#8313",
+      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
+      "owner": "event-loop",
+      "release_blocking": false
+    },
+    {
+      "category": "ASSERTION_FAILURE",
+      "file": "tests/test-streaming-tool-bug.rkt",
+      "first_seen": "0.99.30-W5-broad-baseline",
+      "issue": "#8313",
+      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
+      "owner": "event-loop",
+      "release_blocking": false
+    },
+    {
+      "category": "ASSERTION_FAILURE",
+      "file": "tests/test-streaming-transitions.rkt",
+      "first_seen": "0.99.30-W5-broad-baseline",
+      "issue": "#8313",
+      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
+      "owner": "event-loop",
+      "release_blocking": false
+    },
+    {
+      "category": "ASSERTION_FAILURE",
+      "file": "tests/test-struct-mutability.rkt",
+      "first_seen": "0.99.30-W5-broad-baseline",
+      "issue": "#8313",
+      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
+      "owner": "core",
+      "release_blocking": false
+    },
+    {
+      "category": "ASSERTION_FAILURE",
+      "file": "tests/test-subprocess-edge-cases.rkt",
+      "first_seen": "0.99.30-W5-broad-baseline",
+      "issue": "#8313",
+      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
+      "owner": "sandbox",
+      "release_blocking": false
+    },
+    {
+      "category": "ASSERTION_FAILURE",
+      "file": "tests/test-subprocess.rkt",
+      "first_seen": "0.99.30-W5-broad-baseline",
+      "issue": "#8313",
+      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
+      "owner": "sandbox",
+      "release_blocking": false
+    },
+    {
+      "category": "ASSERTION_FAILURE",
+      "file": "tests/test-summary-integration.rkt",
+      "first_seen": "0.99.30-W5-broad-baseline",
+      "issue": "#8313",
+      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
+      "owner": "core",
+      "release_blocking": false
+    },
+    {
+      "category": "ASSERTION_FAILURE",
+      "file": "tests/test-sync-readme-status.rkt",
+      "first_seen": "0.99.30-W5-broad-baseline",
+      "issue": "#8313",
+      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
+      "owner": "release-engineering",
+      "release_blocking": false
+    },
+    {
+      "category": "ASSERTION_FAILURE",
+      "file": "tests/test-tui-event-ordering.rkt",
+      "first_seen": "0.99.30-W5-broad-baseline",
+      "issue": "#8313",
+      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
+      "owner": "tui",
+      "release_blocking": false
+    },
+    {
+      "category": "ASSERTION_FAILURE",
+      "file": "tests/test-tui-tool-cycle.rkt",
+      "first_seen": "0.99.30-W5-broad-baseline",
+      "issue": "#8313",
+      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
+      "owner": "tui",
+      "release_blocking": false
+    },
+    {
+      "category": "ASSERTION_FAILURE",
+      "file": "tests/test-tui-tool-failure-streaming.rkt",
+      "first_seen": "0.99.30-W5-broad-baseline",
+      "issue": "#8313",
+      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
+      "owner": "tui",
+      "release_blocking": false
+    },
+    {
+      "category": "ASSERTION_FAILURE",
+      "file": "tests/test-tui-tool-sequences.rkt",
+      "first_seen": "0.99.30-W5-broad-baseline",
+      "issue": "#8313",
+      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
+      "owner": "tui",
+      "release_blocking": false
+    },
+    {
+      "category": "ASSERTION_FAILURE",
+      "file": "tests/test-tui-workflow-harness.rkt",
+      "first_seen": "0.99.30-W5-broad-baseline",
+      "issue": "#8313",
+      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
+      "owner": "tui",
+      "release_blocking": false
+    },
+    {
+      "category": "ASSERTION_FAILURE",
+      "file": "tests/test-typed-model.rkt",
+      "first_seen": "0.99.30-W5-broad-baseline",
+      "issue": "#8313",
+      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
+      "owner": "llm",
+      "release_blocking": false
+    },
+    {
+      "category": "ASSERTION_FAILURE",
+      "file": "tests/test-ui-actions.rkt",
+      "first_seen": "0.99.30-W5-broad-baseline",
+      "issue": "#8313",
+      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
+      "owner": "tui",
+      "release_blocking": false
+    },
+    {
+      "category": "ASSERTION_FAILURE",
+      "file": "tests/test-util-reclassification.rkt",
+      "first_seen": "0.99.30-W5-broad-baseline",
+      "issue": "#8313",
+      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
+      "owner": "core",
+      "release_blocking": false
+    },
+    {
+      "category": "ASSERTION_FAILURE",
+      "file": "tests/test-widget-api.rkt",
+      "first_seen": "0.99.30-W5-broad-baseline",
+      "issue": "#8313",
+      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
+      "owner": "tui",
+      "release_blocking": false
+    },
+    {
+      "category": "ASSERTION_FAILURE",
+      "file": "tests/test-working-set.rkt",
+      "first_seen": "0.99.30-W5-broad-baseline",
+      "issue": "#8313",
+      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
+      "owner": "runtime",
+      "release_blocking": false
+    },
+    {
+      "category": "ENVIRONMENT_MISSING",
+      "file": "tests/tui/test-command-integration.rkt",
+      "first_seen": "0.99.30-W5-broad-baseline",
+      "issue": "#8313",
+      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
+      "owner": "tui",
+      "release_blocking": false
+    },
+    {
+      "category": "ASSERTION_FAILURE",
+      "file": "tests/tui/test-render.rkt",
+      "first_seen": "0.99.30-W5-broad-baseline",
+      "issue": "#8313",
+      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
+      "owner": "tui",
+      "release_blocking": false
+    },
+    {
+      "category": "ASSERTION_FAILURE",
+      "file": "tests/tui/test-state.rkt",
+      "first_seen": "0.99.30-W5-broad-baseline",
+      "issue": "#8313",
+      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
+      "owner": "tui",
+      "release_blocking": false
+    },
+    {
+      "category": "ASSERTION_FAILURE",
+      "file": "tests/workflows/cli/test-cli-resume.rkt",
+      "first_seen": "0.99.30-W5-broad-baseline",
+      "issue": "#8313",
+      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
+      "owner": "workflows",
+      "release_blocking": false
+    },
+    {
+      "category": "ASSERTION_FAILURE",
+      "file": "tests/workflows/cli/test-cli-single-shot.rkt",
+      "first_seen": "0.99.30-W5-broad-baseline",
+      "issue": "#8313",
+      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
+      "owner": "workflows",
+      "release_blocking": false
+    },
+    {
+      "category": "ASSERTION_FAILURE",
+      "file": "tests/workflows/parity/test-sdk-cli-parity.rkt",
+      "first_seen": "0.99.30-W5-broad-baseline",
+      "issue": "#8313",
+      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
+      "owner": "workflows",
+      "release_blocking": false
+    },
+    {
+      "category": "UNKNOWN_FAILURE",
+      "file": "tests/workflows/tools/test-tool-bash-workflow.rkt",
+      "first_seen": "0.99.30-W5-broad-baseline",
+      "issue": "#8313",
+      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
+      "owner": "workflows",
+      "release_blocking": false
+    },
+    {
+      "category": "ASSERTION_FAILURE",
+      "file": "tests/test-tool-edit-builtin.rkt",
+      "first_seen": "0.99.30-W5-broad-ledger-rerun",
+      "issue": "#8313",
+      "notes": "Known broad-suite ordering/mutation-sensitive debt: passes individually but failed during W5 broad --ledger acceptance rerun.",
+      "owner": "tools",
+      "release_blocking": false
+    }
+  ],
+  "generated_by": "v0.99.30 W5 known-failure ledger",
+  "policy": {
+    "known_non_release_blocking_failures_allowed_but_visible": true,
+    "ledger_entries_must_match_file_and_category": true,
+    "new_unknown_failures_release_blocking": true,
+    "zero_parsed_strict_failures_remain_blocking": true
+  },
+  "source_category_counts": {
+    "ASSERTION_FAILURE": 79,
+    "ENVIRONMENT_MISSING": 1,
+    "MODULE_LOAD_FAILURE": 2,
+    "PASS": 957,
+    "UNKNOWN_FAILURE": 1,
+    "ZERO_PARSED": 1
+  },
+  "source_category_counts_with_ledger_rerun_addendum": {
+    "ASSERTION_FAILURE": 80,
+    "ENVIRONMENT_MISSING": 1,
+    "MODULE_LOAD_FAILURE": 2,
+    "UNKNOWN_FAILURE": 1
+  },
+  "source_command": "timeout 900 racket scripts/run-tests.rkt --suite broad --json-out <tmp>",
+  "source_summary": {
+    "files_failed": 83,
+    "files_passed": 958,
+    "files_timeout": 0,
+    "files_total": 1041,
+    "tests_failed": 78,
+    "tests_passed": 12512,
+    "tests_total": 12590
+  },
+  "source_verdict": "fail",
+  "strict_zero_parsed_note": "The source broad run exited 4 after JSON/reporting because strict mode detected tests/test-benchmarks.rkt with zero parsed tests.",
+  "version": 1,
+  "w5_addendum": "tests/test-tool-edit-builtin.rkt passed individually but failed in broad --ledger rerun; ledgered as broad-order known debt."
+}


### PR DESCRIPTION
## Summary

Implements v0.99.30 W5: broad-suite known-failure ledger.

- Adds `scripts/run-tests/ledger.rkt` for loading and summarizing known-failure ledger entries.
- Adds `--ledger PATH` runner flag.
- Adds `broad` suite alias for all discoverable tests.
- Runner reports:
  - Known failures
  - New failures
  - Unclassified failures
  - Resolved known failures
  - Release-blocking known failures
- JSON output annotates files with known-failure metadata when a ledger is provided.
- Adds initial machine-readable ledger: `tests/test-suite-ledger.json`.
- Adds human policy/report: `docs/reports/TEST-SUITE-LEDGER.md`.
- Adds W5 regression tests: `tests/test-run-tests-ledger.rkt`.

## Ledger scope

The initial ledger is based on the W5 broad-suite baseline:

- Source command: `timeout 900 racket scripts/run-tests.rkt --suite broad --json-out <tmp>`
- JSON summary before strict zero-parsed exit: 1041 files, 958 passed, 83 failed, 0 timeouts; categories `ASSERTION_FAILURE=79`, `MODULE_LOAD_FAILURE=2`, `ENVIRONMENT_MISSING=1`, `UNKNOWN_FAILURE=1`, plus `ZERO_PARSED=1`.
- Addendum: `tests/test-tool-edit-builtin.rkt` passed individually but failed in broad `--ledger` rerun, so it is ledgered as known broad-order/mutation-sensitive debt.
- Ledger entries: 84.

## Verification

Focused format/compile:

- `raco fmt -i scripts/run-tests.rkt scripts/run-tests/cli.rkt scripts/run-tests/classify.rkt scripts/run-tests/reporting.rkt scripts/run-tests/ledger.rkt tests/test-run-tests-ledger.rkt tests/test-run-tests-json-classification.rkt tests/test-run-tests-in-process-mode.rkt tests/test-run-tests.rkt`
- `raco make scripts/run-tests.rkt scripts/run-tests/cli.rkt scripts/run-tests/classify.rkt scripts/run-tests/reporting.rkt scripts/run-tests/ledger.rkt tests/test-run-tests-ledger.rkt tests/test-run-tests-json-classification.rkt tests/test-run-tests-in-process-mode.rkt tests/test-run-tests.rkt`

Focused tests:

- `raco test tests/test-run-tests-ledger.rkt` → 3 tests passed
- `raco test tests/test-run-tests-ledger.rkt tests/test-run-tests-json-classification.rkt tests/test-run-tests-in-process-mode.rkt tests/test-run-tests-metadata-discovery.rkt tests/test-run-tests-zero-parsed-elimination.rkt tests/test-run-tests-overhead-diagnostics.rkt` → 19 tests passed

CLI/JSON smoke:

- Explicit known assertion failure with `--ledger` + `--json-out`: exit 1; `Known failures: 1`; `New failures: 0`; `Unclassified failures: 0`; JSON per-file `known_failure=#t`, `issue=#8313`, ledger counts present.
- `racket scripts/run-tests.rkt --help` includes `--ledger` and `broad`.

W5 acceptance:

- `timeout 900 racket scripts/run-tests.rkt --suite broad --ledger tests/test-suite-ledger.json` → exit 4 due strict zero-parsed sentinel, while ledger classification reported:
  - Files: 1041 total, 959 passed, 82 failed, 0 timeouts
  - Category: `PASS=958`, `ASSERTION_FAILURE=78`, `MODULE_LOAD_FAILURE=2`, `ENVIRONMENT_MISSING=1`, `ZERO_PARSED=1`, `UNKNOWN_FAILURE=1`
  - `Known failures: 82`
  - `New failures: 0`
  - `Unclassified failures: 0`
  - `Resolved known failures: 2`
  - `Release-blocking known failures: 0`
  - Strict zero-parsed remains blocking for `tests/test-benchmarks.rkt`.

Required fast gate after W5:

- `timeout 900 racket scripts/run-tests.rkt --suite fast` → 949 files, 886 passed, 63 failed, 0 timeouts, 11876 tests, 11812 passed, 64 failed, `Category: PASS=886, ASSERTION_FAILURE=61, MODULE_LOAD_FAILURE=2`, VERDICT FAIL.

Notes:

- README metrics were dirtied by gate runs and restored before commit.
- `tests/test-run-tests.rkt` compiles after parse arity updates, but direct `raco test` remains affected by unrelated pre-existing assertions; not claimed as passing.

Closes #8313.