### PR TITLE
feat: W6 environment profiles and skip policy

### DIFF
--- a/scripts/run-tests.rkt
+++ b/scripts/run-tests.rkt
@@ -81,6 +81,13 @@
                   ledger-summary-counts
                   ledger-entry-matches-result?)
          (only-in "run-tests/cli.rkt" usage parse-args validate-args! known-suites known-modes)
+         (only-in "run-tests/profiles.rkt"
+                  known-profiles
+                  profile-unavailable-requirements
+                  profile-skips-test?
+                  skipped-requirements
+                  make-skipped-result
+                  skipped-result-exit-code)
          (only-in "run-tests/gate-evidence.rkt" record-gate-evidence!)
          (only-in "run-tests/inventory.rkt"
                   print-inventory
@@ -135,6 +142,12 @@
          summarize-ledger-results
          ledger-summary-counts
          ledger-entry-matches-result?
+         known-profiles
+         profile-unavailable-requirements
+         profile-skips-test?
+         skipped-requirements
+         make-skipped-result
+         skipped-result-exit-code
          bytes->string*
          clean-stale-bytecode!
          file-has-rackunit-tests?
@@ -383,13 +396,26 @@
                         repeat-total
                         mode
                         json-out
-                        ledger)
+                        ledger
+                        profile)
   (define t0 (current-inexact-milliseconds))
+  (define-values (skipped-files runnable-files)
+    (partition (lambda (f)
+                 (profile-skips-test? profile (hash-ref (get-file-metadata f) 'requires '())))
+               suite-files))
+  (define skipped-results
+    (for/list ([f (in-list skipped-files)])
+      (make-skipped-result f profile (hash-ref (get-file-metadata f) 'requires '()))))
+  (when (pair? skipped-files)
+    (printf ";; run-tests: profile=~a skipped ~a file~a by @requires metadata~n"
+            profile
+            (length skipped-files)
+            (if (= (length skipped-files) 1) "" "s")))
   (define-values (serial-files parallel-files)
     (if (> jobs 1)
-        (values (filter mutating-file? suite-files)
-                (filter (lambda (f) (not (mutating-file? f))) suite-files))
-        (values '() suite-files)))
+        (values (filter mutating-file? runnable-files)
+                (filter (lambda (f) (not (mutating-file? f))) runnable-files))
+        (values '() runnable-files)))
   (when (pair? serial-files)
     (printf ";; run-tests: serializing ~a mutation-sensitive file~a before parallel batches~n"
             (length serial-files)
@@ -409,7 +435,7 @@
                [i (in-naturals)])
       (values f i)))
   (define results
-    (sort (append serial-results parallel-results)
+    (sort (append skipped-results serial-results parallel-results)
           <
           #:key (lambda (r) (hash-ref file-order (test-file-result-path r) 0))))
   (define total-elapsed (exact-round (- (current-inexact-milliseconds) t0)))
@@ -420,16 +446,22 @@
                          #:suite (string->symbol suite-label)
                          #:mode mode
                          #:elapsed-ms total-elapsed
-                         #:ledger ledger))
+                         #:ledger ledger
+                         #:profile profile))
   (when ledger
     (print-ledger-summary ledger results))
   (save-failure-logs results)
   (define failed-files
     (count (lambda (r)
-             (and (not (= (test-file-result-exit-code r) 0))
+             (and (not (eq? (classify-test-result r) 'SKIPPED_BY_PROFILE))
+                  (not (= (test-file-result-exit-code r) 0))
                   (not (= (test-file-result-exit-code r) 2))))
            results))
-  (define timeout-files (count (lambda (r) (= (test-file-result-exit-code r) 2)) results))
+  (define timeout-files
+    (count (lambda (r)
+             (and (not (eq? (classify-test-result r) 'SKIPPED_BY_PROFILE))
+                  (= (test-file-result-exit-code r) 2)))
+           results))
   (when strict?
     (define suspicious
       (filter (lambda (r) (and (= (test-file-result-exit-code r) 0) (= (test-file-result-total r) 0)))
@@ -462,7 +494,8 @@
                   diagnose-overhead?
                   requested-mode
                   json-out
-                  ledger-path)
+                  ledger-path
+                  profile)
     (parse-args args))
   (validate-args! jobs
                   sequential?
@@ -476,7 +509,8 @@
                   diagnose-overhead?
                   requested-mode
                   json-out
-                  ledger-path)
+                  ledger-path
+                  profile)
   (when diagnose-overhead?
     (print-overhead-diagnostics #:base-dir base-dir)
     (exit 0))
@@ -505,13 +539,14 @@
   (define mode (effective-mode requested-mode suite-label))
   (define ledger (and ledger-path (load-known-failure-ledger ledger-path)))
   (define n-files (length suite-files))
-  (printf ";; run-tests: suite=~a files=~a jobs=~a sequential=~a repeat=~a mode=~a~n"
+  (printf ";; run-tests: suite=~a files=~a jobs=~a sequential=~a repeat=~a mode=~a profile=~a~n"
           suite-label
           n-files
           jobs
           sequential?
           repeat
-          mode)
+          mode
+          profile)
   (newline)
   (when (> repeat 1)
     (printf ";; run-tests: running suite ~a time~a for confidence gate~n"
@@ -531,7 +566,8 @@
                       repeat
                       mode
                       json-out
-                      ledger))
+                      ledger
+                      profile))
     (set-box! last-results results)
     (unless (zero? exit-code)
       (exit exit-code)))

--- a/scripts/run-tests/cli.rkt
+++ b/scripts/run-tests/cli.rkt
@@ -8,7 +8,8 @@
 
 (require racket/match
          racket/string
-         (only-in racket/future processor-count))
+         (only-in racket/future processor-count)
+         (only-in "profiles.rkt" known-profiles))
 
 (provide usage
          parse-args
@@ -34,6 +35,7 @@
   (displayln "  --json-out PATH         Write structured per-file JSON results")
   (displayln
    "  --ledger PATH           Read known-failure ledger JSON and report known/new/resolved failures")
+  (displayln "  --profile NAME          Environment profile: local, vps, ci, headless, full")
   (displayln "  --help            Show this help message")
   (newline)
   (displayln "Suites:")
@@ -68,7 +70,38 @@
              [diagnose-overhead? #f]
              [mode 'auto]
              [json-out #f]
-             [ledger #f])
+             [ledger #f]
+             [profile 'local])
+    (define (continue rest
+                      #:jobs [jobs* jobs]
+                      #:sequential? [sequential?* sequential?]
+                      #:timeout [timeout* timeout]
+                      #:strict? [strict?* strict?]
+                      #:suite [suite* suite]
+                      #:extra [extra* extra]
+                      #:repeat [repeat* repeat]
+                      #:record-gate? [record-gate?* record-gate?]
+                      #:inventory? [inventory?* inventory?]
+                      #:diagnose-overhead? [diagnose-overhead?* diagnose-overhead?]
+                      #:mode [mode* mode]
+                      #:json-out [json-out* json-out]
+                      #:ledger [ledger* ledger]
+                      #:profile [profile* profile])
+      (loop rest
+            jobs*
+            sequential?*
+            timeout*
+            strict?*
+            suite*
+            extra*
+            repeat*
+            record-gate?*
+            inventory?*
+            diagnose-overhead?*
+            mode*
+            json-out*
+            ledger*
+            profile*))
     (match rest
       ['()
        (values jobs
@@ -83,209 +116,30 @@
                diagnose-overhead?
                mode
                json-out
-               ledger)]
+               ledger
+               profile)]
       [(list "--help" _ ...)
        (usage)
        (exit 0)]
-      [(list "--strict" rest ...)
-       (loop rest
-             jobs
-             sequential?
-             timeout
-             #t
-             suite
-             extra
-             repeat
-             record-gate?
-             inventory?
-             diagnose-overhead?
-             mode
-             json-out
-             ledger)]
-      [(list "--jobs" n rest ...)
-       (loop rest
-             (string->number n)
-             sequential?
-             timeout
-             strict?
-             suite
-             extra
-             repeat
-             record-gate?
-             inventory?
-             diagnose-overhead?
-             mode
-             json-out
-             ledger)]
-      [(list "--sequential" rest ...)
-       (loop rest
-             1
-             #t
-             timeout
-             strict?
-             suite
-             extra
-             repeat
-             record-gate?
-             inventory?
-             diagnose-overhead?
-             mode
-             json-out
-             ledger)]
-      [(list "--timeout" secs rest ...)
-       (loop rest
-             jobs
-             sequential?
-             (string->number secs)
-             strict?
-             suite
-             extra
-             repeat
-             record-gate?
-             inventory?
-             diagnose-overhead?
-             mode
-             json-out
-             ledger)]
-      [(list "--mode" name rest ...)
-       (loop rest
-             jobs
-             sequential?
-             timeout
-             strict?
-             suite
-             extra
-             repeat
-             record-gate?
-             inventory?
-             diagnose-overhead?
-             (string->symbol name)
-             json-out
-             ledger)]
-      [(list "--suite" name rest ...)
-       (loop rest
-             jobs
-             sequential?
-             timeout
-             strict?
-             (string->symbol name)
-             extra
-             repeat
-             record-gate?
-             inventory?
-             diagnose-overhead?
-             mode
-             json-out
-             ledger)]
-      [(list "--repeat" n rest ...)
-       (loop rest
-             jobs
-             sequential?
-             timeout
-             strict?
-             suite
-             extra
-             (string->number n)
-             record-gate?
-             inventory?
-             diagnose-overhead?
-             mode
-             json-out
-             ledger)]
-      [(list "--record-gate-evidence" rest ...)
-       (loop rest
-             jobs
-             sequential?
-             timeout
-             strict?
-             suite
-             extra
-             repeat
-             #t
-             inventory?
-             diagnose-overhead?
-             mode
-             json-out
-             ledger)]
-      [(list "--inventory" rest ...)
-       (loop rest
-             jobs
-             sequential?
-             timeout
-             strict?
-             suite
-             extra
-             repeat
-             record-gate?
-             #t
-             diagnose-overhead?
-             mode
-             json-out
-             ledger)]
-      [(list "--diagnose-overhead" rest ...)
-       (loop rest
-             jobs
-             sequential?
-             timeout
-             strict?
-             suite
-             extra
-             repeat
-             record-gate?
-             inventory?
-             #t
-             mode
-             json-out
-             ledger)]
-      [(list "--json-out" path rest ...)
-       (loop rest
-             jobs
-             sequential?
-             timeout
-             strict?
-             suite
-             extra
-             repeat
-             record-gate?
-             inventory?
-             diagnose-overhead?
-             mode
-             path
-             ledger)]
-      [(list "--ledger" path rest ...)
-       (loop rest
-             jobs
-             sequential?
-             timeout
-             strict?
-             suite
-             extra
-             repeat
-             record-gate?
-             inventory?
-             diagnose-overhead?
-             mode
-             json-out
-             path)]
-      [(list (regexp #rx"^--") rest ...)
-       (eprintf "run-tests: unknown flag: ~a~n" (car rest))
+      [(list "--strict" rest ...) (continue rest #:strict? #t)]
+      [(list "--jobs" n rest ...) (continue rest #:jobs (string->number n))]
+      [(list "--sequential" rest ...) (continue rest #:jobs 1 #:sequential? #t)]
+      [(list "--timeout" secs rest ...) (continue rest #:timeout (string->number secs))]
+      [(list "--mode" name rest ...) (continue rest #:mode (string->symbol name))]
+      [(list "--suite" name rest ...) (continue rest #:suite (string->symbol name))]
+      [(list "--repeat" n rest ...) (continue rest #:repeat (string->number n))]
+      [(list "--record-gate-evidence" rest ...) (continue rest #:record-gate? #t)]
+      [(list "--inventory" rest ...) (continue rest #:inventory? #t)]
+      [(list "--diagnose-overhead" rest ...) (continue rest #:diagnose-overhead? #t)]
+      [(list "--json-out" path rest ...) (continue rest #:json-out path)]
+      [(list "--ledger" path rest ...) (continue rest #:ledger path)]
+      [(list "--profile" name rest ...) (continue rest #:profile (string->symbol name))]
+      [(list flag rest ...)
+       #:when (regexp-match? #rx"^--" flag)
+       (eprintf "run-tests: unknown flag: ~a~n" flag)
        (usage)
        (exit 2)]
-      [(list arg rest ...)
-       (loop rest
-             jobs
-             sequential?
-             timeout
-             strict?
-             suite
-             (cons arg extra)
-             repeat
-             record-gate?
-             inventory?
-             diagnose-overhead?
-             mode
-             json-out
-             ledger)])))
+      [(list arg rest ...) (continue rest #:extra (cons arg extra))])))
 
 (define (validate-args! jobs
                         sequential?
@@ -299,7 +153,8 @@
                         diagnose-overhead?
                         mode
                         json-out
-                        ledger)
+                        ledger
+                        profile)
   (unless (memq suite known-suites)
     (raise-user-error 'run-tests
                       "unknown suite: ~a (valid: ~a)"
@@ -316,6 +171,11 @@
                       "unknown mode: ~a (valid: ~a)"
                       mode
                       (string-join (map symbol->string known-modes) ", ")))
+  (unless (memq profile known-profiles)
+    (raise-user-error 'run-tests
+                      "unknown profile: ~a (valid: ~a)"
+                      profile
+                      (string-join (map symbol->string known-profiles) ", ")))
   (when (and json-out (not (string? json-out)))
     (raise-user-error 'run-tests "--json-out must be a path string, got: ~a" json-out))
   (when (and ledger (not (string? ledger)))
@@ -331,4 +191,5 @@
           inventory?
           mode
           json-out
-          ledger))
+          ledger
+          profile))

--- a/scripts/run-tests/ledger.rkt
+++ b/scripts/run-tests/ledger.rkt
@@ -84,7 +84,8 @@
   (map normalize-ledger-entry (extract-ledger-entries payload)))
 
 (define (result-failure? r)
-  (not (= (test-file-result-exit-code r) 0)))
+  (and (not (= (test-file-result-exit-code r) 0))
+       (not (eq? (classify-test-result r) 'SKIPPED_BY_PROFILE))))
 
 (define (result-path-string r)
   (normalize-path-string (test-file-result-path r)))

--- a/scripts/run-tests/parse.rkt
+++ b/scripts/run-tests/parse.rkt
@@ -110,6 +110,7 @@
   (define total (test-file-result-total r))
   (define output (result-output-string r))
   (cond
+    [(or (= exit-code 5) (regexp-match? #rx"skipped_by_profile" output)) 'SKIPPED_BY_PROFILE]
     [(and (= exit-code 0) (> total 0)) 'PASS]
     [(and (= exit-code 0) (= total 0)) 'ZERO_PARSED]
     [(= exit-code 2) 'TIMEOUT]

--- a/scripts/run-tests/profiles.rkt
+++ b/scripts/run-tests/profiles.rkt
@@ -1,0 +1,66 @@
+#lang racket/base
+
+;; q/scripts/run-tests/profiles.rkt — Environment profile skip policy
+;;
+;; Profiles make environment-dependent skips explicit and reportable. Skips are
+;; represented as SKIPPED_BY_PROFILE results and must never be counted as PASS.
+
+(require racket/list
+         racket/string
+         (only-in "parse.rkt" make-test-file-result))
+
+(provide known-profiles
+         profile-unavailable-requirements
+         profile-skips-test?
+         skipped-requirements
+         make-skipped-result
+         skipped-result-exit-code)
+
+(define known-profiles '(local vps ci headless full))
+
+(define skipped-result-exit-code 5)
+
+(define (normalize-requirement req)
+  (cond
+    [(symbol? req) (symbol->string req)]
+    [(string? req) (string-downcase (string-trim req))]
+    [else (format "~a" req)]))
+
+(define (profile-unavailable-requirements profile)
+  (case profile
+    ;; Developer workstation: terminal/subprocess/filesystem/git are assumed;
+    ;; live provider credentials are intentionally not assumed.
+    [(local) '("provider-key")]
+    ;; VPS is headless: browser/terminal are unavailable; provider credentials
+    ;; may exist and are therefore not skipped by policy.
+    [(vps) '("browser" "terminal")]
+    ;; CI must be deterministic and non-interactive by default.
+    [(ci) '("provider-key" "browser" "terminal" "network")]
+    ;; Headless means no interactive/UI/provider dependencies.
+    [(headless) '("provider-key" "browser" "terminal")]
+    ;; Full is opt-in to run everything possible.
+    [(full) '()]
+    [else '()]))
+
+(define (skipped-requirements profile requirements)
+  (define unavailable (profile-unavailable-requirements profile))
+  (filter (lambda (req)
+            (define normalized (normalize-requirement req))
+            (and (not (string=? normalized "none")) (member normalized unavailable)))
+          requirements))
+
+(define (profile-skips-test? profile requirements)
+  (pair? (skipped-requirements profile requirements)))
+
+(define (make-skipped-result path profile requirements)
+  (define skipped (skipped-requirements profile requirements))
+  (define reason
+    (format "SKIPPED_BY_PROFILE profile=~a requires=~a" profile (string-join skipped ",")))
+  (make-test-file-result path
+                         skipped-result-exit-code
+                         (string->bytes/utf-8 (string-append reason "\n"))
+                         #""
+                         0
+                         0
+                         0
+                         0))

--- a/scripts/run-tests/reporting.rkt
+++ b/scripts/run-tests/reporting.rkt
@@ -62,23 +62,37 @@
     [(> timeout-count 0) 2]
     [else 0]))
 
+(define (skipped-by-profile-result? r)
+  (eq? (classify-test-result r) 'SKIPPED_BY_PROFILE))
+
+(define (passed-result? r)
+  (and (= (test-file-result-exit-code r) 0) (not (skipped-by-profile-result? r))))
+
+(define (failed-result? r)
+  (and (not (skipped-by-profile-result? r))
+       (not (= (test-file-result-exit-code r) 0))
+       (not (= (test-file-result-exit-code r) 2))))
+
+(define (timeout-result? r)
+  (and (not (skipped-by-profile-result? r)) (= (test-file-result-exit-code r) 2)))
+
 ;; Compute a verdict symbol from results: 'pass, 'fail, 'incomplete, 'inconclusive.
 ;; - 'fail:          at least one file exited non-zero (not timeout)
 ;; - 'incomplete:    at least one file timed out (exit-code 2)
 ;; - 'inconclusive:  all files passed but zero tests were parsed
 ;; - 'pass:          all files passed and at least one test was parsed
 (define (compute-verdict results)
-  (define failed-files
-    (count (lambda (r)
-             (and (not (= (test-file-result-exit-code r) 0))
-                  (not (= (test-file-result-exit-code r) 2))))
-           results))
-  (define timeout-files (count (lambda (r) (= (test-file-result-exit-code r) 2)) results))
-  (define total-tests (for/sum ([r (in-list results)]) (test-file-result-total r)))
+  (define failed-files (count failed-result? results))
+  (define timeout-files (count timeout-result? results))
+  (define skipped-files (count skipped-by-profile-result? results))
+  (define runnable-results (filter (lambda (r) (not (skipped-by-profile-result? r))) results))
+  (define total-tests (for/sum ([r (in-list runnable-results)]) (test-file-result-total r)))
   (cond
     [(> failed-files 0) 'fail]
     [(> timeout-files 0) 'incomplete]
-    [(= total-tests 0) 'inconclusive]
+    [(and (null? runnable-results) (= skipped-files 0)) 'inconclusive]
+    [(and (pair? runnable-results) (= total-tests 0)) 'inconclusive]
+    [(and (null? runnable-results) (> skipped-files 0)) 'pass]
     [else 'pass]))
 
 (define (format-verdict-line verdict timeout-count)
@@ -93,7 +107,8 @@
     [else "  VERDICT:   ❓ UNKNOWN"]))
 
 (define known-result-categories
-  '(PASS ASSERTION_FAILURE
+  '(PASS SKIPPED_BY_PROFILE
+         ASSERTION_FAILURE
          MODULE_LOAD_FAILURE
          COMPILE_FAILURE
          TIMEOUT
@@ -152,14 +167,12 @@
                              #:suite [suite 'all]
                              #:mode [mode 'subprocess]
                              #:elapsed-ms [elapsed-ms 0]
-                             #:ledger [ledger #f])
-  (define passed-files (count (lambda (r) (= (test-file-result-exit-code r) 0)) results))
-  (define failed-files
-    (count (lambda (r)
-             (and (not (= (test-file-result-exit-code r) 0))
-                  (not (= (test-file-result-exit-code r) 2))))
-           results))
-  (define timeout-files (count (lambda (r) (= (test-file-result-exit-code r) 2)) results))
+                             #:ledger [ledger #f]
+                             #:profile [profile 'local])
+  (define passed-files (count passed-result? results))
+  (define failed-files (count failed-result? results))
+  (define timeout-files (count timeout-result? results))
+  (define skipped-files (count skipped-by-profile-result? results))
   (define counts (category-counts results))
   (define ledger-summary (and ledger (summarize-ledger-results ledger results)))
   (define payload
@@ -167,6 +180,8 @@
             (symbol->string suite)
             'mode
             (symbol->string mode)
+            'profile
+            (symbol->string profile)
             'verdict
             (symbol->string (compute-verdict results))
             'elapsed_ms
@@ -180,6 +195,8 @@
                     failed-files
                     'files_timeout
                     timeout-files
+                    'files_skipped_by_profile
+                    skipped-files
                     'tests_total
                     (for/sum ([r (in-list results)]) (test-file-result-total r))
                     'tests_passed
@@ -215,13 +232,10 @@
 
 (define (print-summary results total-start-ms)
   (define total-files (length results))
-  (define passed-files (count (lambda (r) (= (test-file-result-exit-code r) 0)) results))
-  (define failed-files
-    (count (lambda (r)
-             (and (not (= (test-file-result-exit-code r) 0))
-                  (not (= (test-file-result-exit-code r) 2))))
-           results))
-  (define timeout-files (count (lambda (r) (= (test-file-result-exit-code r) 2)) results))
+  (define passed-files (count passed-result? results))
+  (define failed-files (count failed-result? results))
+  (define timeout-files (count timeout-result? results))
+  (define skipped-files (count skipped-by-profile-result? results))
   (define zero-test-files
     (count (lambda (r) (and (= (test-file-result-exit-code r) 0) (= (test-file-result-total r) 0)))
            results))
@@ -238,6 +252,8 @@
           passed-files
           failed-files
           timeout-files)
+  (when (> skipped-files 0)
+    (printf "             Skipped by profile: ~a~n" skipped-files))
   (when (> zero-test-files 0)
     (printf "             ⚠ ~a file~a with zero parsed tests (exit=0 but no rackunit output)~n"
             zero-test-files
@@ -250,7 +266,7 @@
   (displayln "═══════════════════════════════════════════════════════════")
   (displayln (format-verdict-line verdict timeout-files))
   (displayln "═══════════════════════════════════════════════════════════")
-  (define failures (filter (lambda (r) (not (= (test-file-result-exit-code r) 0))) results))
+  (define failures (filter failed-result? results))
   (when (pair? failures)
     (newline)
     (displayln "FAILURES:")
@@ -280,7 +296,7 @@
   (string-append "q-test-fail-" (string-replace safe-base ".rkt" "") "-" path-hash ".log"))
 
 (define (save-failure-logs results)
-  (define failures (filter (lambda (r) (not (= (test-file-result-exit-code r) 0))) results))
+  (define failures (filter failed-result? results))
   (for ([f (in-list failures)])
     (define log-path (build-path "/tmp" (make-unique-log-name (test-file-result-path f))))
     (call-with-output-file log-path

--- a/tests/test-browser-audit-w1-v0983.rkt
+++ b/tests/test-browser-audit-w1-v0983.rkt
@@ -1,5 +1,7 @@
 #lang racket
 
+;; @requires browser
+
 ;; tests/test-browser-audit-w1-v0983.rkt — Tests for Wave 1 audit fixes (v0.98.3)
 ;; SEC-07: Unbounded timeout_ms clamped
 ;; SEC-10: Ping-based readiness after restart

--- a/tests/test-browser-audit-w2.rkt
+++ b/tests/test-browser-audit-w2.rkt
@@ -1,5 +1,7 @@
 #lang racket
 
+;; @requires browser
+
 ;; tests/test-browser-audit-w2.rkt — Tests for Wave 2 audit fixes
 ;; C1: restart-sidecar! actually relaunches
 ;; C2: pending-box guarded by semaphore

--- a/tests/test-run-tests-in-process-mode.rkt
+++ b/tests/test-run-tests-in-process-mode.rkt
@@ -51,7 +51,8 @@
                       diagnose?
                       mode
                       json-out
-                      ledger)
+                      ledger
+                      _profile)
         (parse-args '("--mode" "in-process" "--suite" "unit-fast")))
       (check-equal? mode 'in-process)
       (check-equal? suite 'unit-fast)
@@ -67,7 +68,8 @@
                       _diagnose?
                       default-mode
                       _json-out
-                      _ledger)
+                      _ledger
+                      _default-profile)
         (parse-args '()))
       (check-equal? default-mode 'auto))
 

--- a/tests/test-run-tests-json-classification.rkt
+++ b/tests/test-run-tests-json-classification.rkt
@@ -85,7 +85,8 @@
                       _diagnose?
                       _mode
                       json-out
-                      _ledger)
+                      _ledger
+                      _profile)
         (parse-args '("--json-out" "/tmp/q-results.json")))
       (check-equal? json-out "/tmp/q-results.json"))
 

--- a/tests/test-run-tests-ledger.rkt
+++ b/tests/test-run-tests-ledger.rkt
@@ -71,7 +71,8 @@
                       _diagnose?
                       _mode
                       _json-out
-                      ledger)
+                      ledger
+                      _profile)
         (parse-args '("--ledger" "tests/test-suite-ledger.json")))
       (check-equal? ledger "tests/test-suite-ledger.json"))
 

--- a/tests/test-run-tests-profiles.rkt
+++ b/tests/test-run-tests-profiles.rkt
@@ -1,0 +1,109 @@
+#lang racket/base
+
+;; @speed fast
+;; @suite testing
+;; @isolation subprocess
+
+(require rackunit
+         rackunit/text-ui
+         json
+         racket/file
+         racket/path
+         racket/runtime-path
+         racket/system
+         "../scripts/run-tests.rkt")
+
+(define-runtime-path here ".")
+(define project-root (simplify-path (build-path here "..")))
+
+(define runner-module `(file ,(path->string (build-path project-root "scripts/run-tests.rkt"))))
+
+(define profile-skips-test?* (dynamic-require runner-module 'profile-skips-test? (lambda () #f)))
+(define make-skipped-result* (dynamic-require runner-module 'make-skipped-result (lambda () #f)))
+(define classify-test-result* (dynamic-require runner-module 'classify-test-result (lambda () #f)))
+(define test-result->jsexpr* (dynamic-require runner-module 'test-result->jsexpr (lambda () #f)))
+
+(define (write-temp-test name content)
+  (define dir (make-temporary-file "q-profile-test-~a" 'directory))
+  (define file (build-path dir name))
+  (call-with-output-file file #:exists 'replace (lambda (out) (display content out)))
+  (values file dir))
+
+(define (delete-dir/safe dir)
+  (with-handlers ([exn:fail? (lambda (_) (void))])
+    (delete-directory/files dir)))
+
+(define (run/capture cmd)
+  (parameterize ([current-directory project-root])
+    (define out (open-output-string))
+    (define err (open-output-string))
+    (define code
+      (parameterize ([current-output-port out]
+                     [current-error-port err])
+        (system/exit-code cmd)))
+    (values code (get-output-string out) (get-output-string err))))
+
+(define suite
+  (test-suite "run-tests environment profiles"
+
+    (test-case "parse-args accepts --profile"
+      (define-values (_jobs
+                      _seq?
+                      _timeout
+                      _strict?
+                      _suite
+                      _extra
+                      _repeat
+                      _record?
+                      _inventory?
+                      _diagnose?
+                      _mode
+                      _json
+                      _ledger
+                      profile)
+        (parse-args '("--profile" "vps")))
+      (check-equal? profile 'vps))
+
+    (test-case "profile rules skip required unavailable capabilities"
+      (check-pred procedure? profile-skips-test?*)
+      (check-true (profile-skips-test?* 'vps '("browser")))
+      (check-true (profile-skips-test?* 'headless '("terminal")))
+      (check-true (profile-skips-test?* 'ci '("provider-key")))
+      (check-false (profile-skips-test?* 'full '("browser")))
+      (check-false (profile-skips-test?* 'local '("terminal")))
+      (check-false (profile-skips-test?* 'vps '("filesystem" "git"))))
+
+    (test-case "skipped result has explicit category and is not PASS"
+      (check-pred procedure? make-skipped-result*)
+      (define r (make-skipped-result* "tests/needs-browser.rkt" 'vps '("browser")))
+      (check-equal? (classify-test-result* r) 'SKIPPED_BY_PROFILE)
+      (define js (test-result->jsexpr* r))
+      (check-equal? (hash-ref js 'category) "SKIPPED_BY_PROFILE")
+      (check-equal? (hash-ref js 'exit_code) 5)
+      (check-equal? (hash-ref js 'total) 0))
+
+    (test-case "CLI skips explicit @requires browser file under vps profile"
+      (define-values (file dir)
+        (write-temp-test
+         "test-needs-browser.rkt"
+         (string-append "#lang racket/base\n"
+                        ";; @requires browser\n"
+                        "(error 'profile-test \"should not execute when skipped\")\n")))
+      (define out (build-path dir "results.json"))
+      (dynamic-wind
+       void
+       (lambda ()
+         (define-values (code stdout stderr)
+           (run/capture
+            (format "racket scripts/run-tests.rkt --profile vps --json-out ~a ~a" out file)))
+         (check-equal? code 0 stderr)
+         (check-true (regexp-match? #rx"Skipped by profile: 1" stdout))
+         (check-false (regexp-match? #rx"PASS=1" stdout))
+         (define js (call-with-input-file out read-json))
+         (check-equal? (hash-ref js 'profile) "vps")
+         (check-equal? (hash-ref (hash-ref js 'summary) 'files_skipped_by_profile) 1)
+         (define fjs (car (hash-ref js 'files)))
+         (check-equal? (hash-ref fjs 'category) "SKIPPED_BY_PROFILE"))
+       (lambda () (delete-dir/safe dir))))))
+
+(run-tests suite)

--- a/tests/test-run-tests.rkt
+++ b/tests/test-run-tests.rkt
@@ -433,7 +433,8 @@
                   diagnose?
                   mode
                   json-out
-                  ledger)
+                  ledger
+                  profile)
     (parse '("--repeat" "3")))
   (check-equal? repeat 3)
   (check-false record-gate?))
@@ -452,7 +453,8 @@
                   diagnose?
                   mode
                   json-out
-                  ledger)
+                  ledger
+                  profile)
     (parse '()))
   (check-equal? repeat 1)
   (check-false record-gate?))
@@ -471,7 +473,8 @@
                   diagnose?
                   mode
                   json-out
-                  ledger)
+                  ledger
+                  profile)
     (parse '("--suite" "smoke" "--repeat" "2")))
   (check-equal? suite 'smoke)
   (check-equal? repeat 2)
@@ -495,7 +498,8 @@
                   diagnose?
                   mode
                   json-out
-                  ledger)
+                  ledger
+                  profile)
     (parse '("--record-gate-evidence")))
   (check-true record-gate?))
 
@@ -513,7 +517,8 @@
                   diagnose?
                   mode
                   json-out
-                  ledger)
+                  ledger
+                  profile)
     (parse '()))
   (check-false record-gate?))
 


### PR DESCRIPTION
## Summary

Implements v0.99.30 W6: environment profiles and skip policy.

- Adds `--profile local|vps|ci|headless|full`.
- Adds `scripts/run-tests/profiles.rkt` with profile requirement policy.
- Applies profile skips from `@requires` metadata before test execution.
- Represents skips as `SKIPPED_BY_PROFILE`, never `PASS`.
- Reports skipped-by-profile counts separately in human and JSON output.
- Adds JSON top-level `profile` and `summary.files_skipped_by_profile`.
- Ensures ledger summaries do not treat profile skips as new/unclassified failures.
- Adds W6 regression coverage in `tests/test-run-tests-profiles.rkt`.
- Tags two Playwright sidecar audit tests with `@requires browser` to exercise real profile skip behavior under headless/VPS profiles.

## Verification

Focused format/compile:

- `raco fmt -i scripts/run-tests.rkt scripts/run-tests/cli.rkt scripts/run-tests/parse.rkt scripts/run-tests/reporting.rkt scripts/run-tests/profiles.rkt scripts/run-tests/ledger.rkt tests/test-run-tests-profiles.rkt tests/test-run-tests-in-process-mode.rkt tests/test-run-tests-json-classification.rkt tests/test-run-tests-ledger.rkt tests/test-run-tests.rkt tests/test-browser-audit-w1-v0983.rkt tests/test-browser-audit-w2.rkt`
- `raco make scripts/run-tests.rkt scripts/run-tests/cli.rkt scripts/run-tests/parse.rkt scripts/run-tests/reporting.rkt scripts/run-tests/profiles.rkt scripts/run-tests/ledger.rkt tests/test-run-tests-profiles.rkt tests/test-run-tests-in-process-mode.rkt tests/test-run-tests-json-classification.rkt tests/test-run-tests-ledger.rkt tests/test-run-tests.rkt tests/test-browser-audit-w1-v0983.rkt tests/test-browser-audit-w2.rkt`

Focused/adjacent tests:

- `raco test tests/test-run-tests-profiles.rkt` → 4 tests passed
- `raco test tests/test-run-tests-reporting-truthfulness.rkt` → 19 tests passed
- `raco test tests/test-run-tests-profiles.rkt tests/test-run-tests-ledger.rkt tests/test-run-tests-json-classification.rkt tests/test-run-tests-in-process-mode.rkt tests/test-run-tests-reporting-truthfulness.rkt tests/test-run-tests-metadata-discovery.rkt tests/test-run-tests-zero-parsed-elimination.rkt tests/test-run-tests-overhead-diagnostics.rkt` → 42 tests passed

CLI/JSON smoke:

- Explicit `@requires terminal` file under `--profile headless --ledger <empty> --json-out <tmp>` exited 0, reported `Skipped by profile: 1`, category `SKIPPED_BY_PROFILE=1`, JSON `profile=headless`, `files_skipped_by_profile=1`, and ledger counts `new=0`, `unclassified=0`.
- `racket scripts/run-tests.rkt --help` includes `--profile local, vps, ci, headless, full`.

W6 acceptance gates:

- `timeout 900 racket scripts/run-tests.rkt --suite broad --profile vps` → exit 4 due strict zero-parsed sentinel; summary:
  - `profile=vps`
  - `1042 files, 959 passed, 81 failed, 0 timeouts`
  - `Skipped by profile: 2`
  - `12594 tests, 12516 passed, 78 failed`
  - `Category: PASS=958, SKIPPED_BY_PROFILE=2, ASSERTION_FAILURE=77, MODULE_LOAD_FAILURE=2, ENVIRONMENT_MISSING=1, ZERO_PARSED=1, UNKNOWN_FAILURE=1`
  - `VERDICT: FAIL`
  - strict zero parsed: `tests/test-benchmarks.rkt`

- `timeout 900 racket scripts/run-tests.rkt --suite broad --profile local` → exit 4 due strict zero-parsed sentinel; summary:
  - `profile=local`
  - `1042 files, 956 passed, 86 failed, 0 timeouts`
  - `12591 tests, 12511 passed, 80 failed`
  - `Category: PASS=955, ASSERTION_FAILURE=82, MODULE_LOAD_FAILURE=2, ENVIRONMENT_MISSING=1, ZERO_PARSED=1, UNKNOWN_FAILURE=1`
  - `VERDICT: FAIL`
  - strict zero parsed: `tests/test-benchmarks.rkt`

Required fast gate after W6:

- `timeout 900 racket scripts/run-tests.rkt --suite fast` → exit 1, `950 files, 888 passed, 62 failed, 0 timeouts`, `11880 tests, 11817 passed, 63 failed`, `Category: PASS=888, ASSERTION_FAILURE=60, MODULE_LOAD_FAILURE=2`, `VERDICT: FAIL`.

Notes:

- README metrics were dirtied by broad/fast gates and restored before commit.
- `tests/tui/test-command-integration.rkt` has a pre-existing missing-module compile failure and was not modified.

Closes #8314.