### PR TITLE
docs: W8 release-gate policy and final reliability audit

### DIFF
--- a/docs/reports/AUDIT-v0.99.30-TEST-SUITE-RELIABILITY.md
+++ b/docs/reports/AUDIT-v0.99.30-TEST-SUITE-RELIABILITY.md
@@ -1,0 +1,255 @@
+# Audit: v0.99.30 Test Suite Reliability & Harness Modernization
+
+**Milestone:** v0.99.30 — Test Suite Reliability & Harness Modernization  
+**Wave:** W8 (#8316)  
+**Commit audited:** `7aaa0a35` plus W8 documentation branch changes  
+**Audit type:** final reliability audit and release-gate policy codification
+
+## Verdict
+
+**APPROVED AS TEST-HARNESS RELIABILITY MILESTONE, WITH KNOWN BROAD-SUITE DEBT REMAINING.**
+
+v0.99.30 did not make the entire historical suite green. It did resolve the core reliability failure: broad-suite status is now profile-specific, classified, ledger-aware, JSON-emittable, and strict about zero-parsed false greens.
+
+## What changed across W0–W7
+
+| Wave | Result |
+|------|--------|
+| W0 | Added overhead diagnostic and local baseline report. |
+| W1 | Added metadata parsing/discovery cleanup and `@not-test` handling. |
+| W2 | Added strict zero-parsed detection and inventory/reporting support. |
+| W3 | Added explicit runner modes: `auto`, `subprocess`, `in-process`, `grouped`; added `unit-fast`. |
+| W4 | Added normalized categories and JSON output. |
+| W5 | Added broad-suite known-failure ledger and known/new/unclassified/resolved reporting. |
+| W6 | Added environment profiles and explicit `SKIPPED_BY_PROFILE` semantics. |
+| W7 | Fixed a bounded deterministic failure batch and removed the `tests/test-benchmarks.rkt` zero-parsed sentinel. |
+| W8 | Codifies release-gate policy and records final local/VPS reliability evidence. |
+
+## Baseline vs final state
+
+### W0 local overhead baseline
+
+From `docs/reports/TEST-SUITE-BASELINE-v0.99.30.md`:
+
+```text
+racket-noop:              382ms exit=0
+racket-empty:             188ms exit=0
+raco-empty:               395ms exit=0
+raco-rackunit-empty:      474ms exit=0
+raco-representative-test: 479ms exit=0
+```
+
+Interpretation: local per-file subprocess overhead was sub-second, so local broad could complete and truthfully return `FAIL` rather than `INCOMPLETE`.
+
+### W8 VPS overhead diagnostic
+
+Command run on synced VPS main at `7aaa0a35`:
+
+```bash
+ssh user@vps2402959.fastwebserver.de \
+  'cd ~/src/q-agent/q && git fetch origin main && git reset --hard origin/main && racket scripts/run-tests.rkt --diagnose-overhead'
+```
+
+Observed:
+
+```text
+Base dir:   /home/user/src/q-agent/q
+Racket:     /home/user/.racket/bin/racket
+raco:       /home/user/.racket/bin/raco
+racket-noop: 1330ms exit=0
+racket-empty: 204ms exit=0
+raco-empty: 14844ms exit=0
+raco-rackunit-empty: 15114ms exit=0
+raco-representative-test: 15472ms exit=0
+```
+
+Interpretation: VPS broad infeasibility is dominated by per-file `raco test`/bytecode/harness overhead, not by a single universal hanging test. This validates the profile-specific reporting requirement.
+
+## Final local gate evidence
+
+Working directory: `/home/user/src/q-agent/q`  
+Base commit before W8 docs: `7aaa0a35`  
+Artifacts: `tmp/v09930-w8-gates/*.json`, `*.out`, `*.err` (local workspace artifacts; not committed)
+
+### Local smoke
+
+```bash
+racket scripts/run-tests.rkt --suite smoke --profile local --json-out tmp/v09930-w8-gates/smoke-local.json
+```
+
+Result:
+
+```text
+exit=1
+suite=smoke mode=subprocess profile=local
+Files: 946 total, 887 passed, 59 failed, 0 timeouts
+Tests: 11851 total, 11793 passed, 58 failed
+Category: PASS=887, ASSERTION_FAILURE=57, MODULE_LOAD_FAILURE=2
+VERDICT: FAIL
+```
+
+Interpretation: smoke remains red because the current smoke selection is still broad-like. This is not claimed green.
+
+### Local unit-fast in-process
+
+```bash
+racket scripts/run-tests.rkt --suite unit-fast --mode in-process --profile local --json-out tmp/v09930-w8-gates/unit-fast-inprocess-local.json
+```
+
+Result:
+
+```text
+exit=0
+suite=unit-fast mode=in-process profile=local
+Files: 10 total, 10 passed, 0 failed, 0 timeouts
+Tests: 102 total, 102 passed, 0 failed
+Category: PASS=10
+VERDICT: PASS
+```
+
+### Local unit-fast subprocess
+
+```bash
+racket scripts/run-tests.rkt --suite unit-fast --mode subprocess --profile local --json-out tmp/v09930-w8-gates/unit-fast-subprocess-local.json
+```
+
+Result:
+
+```text
+exit=0
+suite=unit-fast mode=subprocess profile=local
+Files: 10 total, 10 passed, 0 failed, 0 timeouts
+Tests: 102 total, 102 passed, 0 failed
+Category: PASS=10
+VERDICT: PASS
+```
+
+### Local broad with ledger
+
+```bash
+timeout 900 racket scripts/run-tests.rkt --suite broad --profile local --ledger tests/test-suite-ledger.json --json-out tmp/v09930-w8-gates/broad-ledger-local.json
+```
+
+Result:
+
+```text
+exit=1
+suite=broad mode=subprocess profile=local
+Files: 1042 total, 964 passed, 78 failed, 0 timeouts
+Tests: 12617 total, 12546 passed, 71 failed
+Category: PASS=964, ASSERTION_FAILURE=74, MODULE_LOAD_FAILURE=2, ENVIRONMENT_MISSING=1, UNKNOWN_FAILURE=1
+VERDICT: FAIL
+Known failures: 78
+New failures: 0
+Unclassified failures: 0
+Resolved known failures: 6
+Release-blocking known failures: 0
+```
+
+Interpretation: local broad is red but actionable: no new failures, no unclassified failures, no release-blocking known failures, and no strict zero-parsed sentinel was reported.
+
+## Final VPS gate evidence
+
+Working directory: remote `~/src/q-agent/q` synced to `origin/main` at `7aaa0a35`.  
+Artifacts: remote `tmp/v09930-w8-gates/*.json`, `*.out`, `*.err` where produced.
+
+### VPS unit-fast in-process
+
+```bash
+racket scripts/run-tests.rkt --suite unit-fast --mode in-process --profile vps --json-out tmp/v09930-w8-gates/unit-fast-inprocess-vps.json
+```
+
+Result:
+
+```text
+exit=0
+suite=unit-fast files=10 jobs=4 mode=in-process profile=vps
+Files: 10 total, 10 passed, 0 failed, 0 timeouts
+Tests: 102 total, 102 passed, 0 failed
+Category: PASS=10
+VERDICT: PASS
+```
+
+### VPS unit-fast subprocess
+
+```bash
+racket scripts/run-tests.rkt --suite unit-fast --mode subprocess --profile vps --json-out tmp/v09930-w8-gates/unit-fast-subprocess-vps.json
+```
+
+Result:
+
+```text
+exit=0
+suite=unit-fast files=10 jobs=4 mode=subprocess profile=vps
+Files: 10 total, 10 passed, 0 failed, 0 timeouts
+Tests: 102 total, 102 passed, 0 failed
+Category: PASS=10
+VERDICT: PASS
+```
+
+### VPS broad with ledger
+
+```bash
+timeout 900 racket scripts/run-tests.rkt --suite broad --profile vps --ledger tests/test-suite-ledger.json --json-out tmp/v09930-w8-gates/broad-ledger-vps.json
+```
+
+Result:
+
+```text
+exit=124
+suite=broad files=1042 jobs=4 mode=subprocess profile=vps
+profile=vps skipped 2 files by @requires metadata
+stderr: user break at timeout
+stdout ended after serial mutation-sensitive files and partial progress; no final summary was produced.
+```
+
+Interpretation: VPS broad remains **INCOMPLETE** under a 900s subprocess broad run. The audit does not infer final pass/fail/known/new counts for VPS broad. This is distinct from local broad, which completed and returned known-debt `FAIL`.
+
+## Acceptance questions
+
+### Did per-file overhead decrease for pure tests?
+
+Partially. The milestone added `unit-fast` and in-process/grouped modes so pure tests can avoid per-file `raco test` subprocess overhead. The measured `unit-fast` suite passes on local and VPS in both in-process and subprocess modes. The historical broad suite still defaults to subprocess isolation because many files are integration/mutation-sensitive.
+
+### Are zero-parsed false greens eliminated?
+
+The runner now has strict zero-parsed detection. W7 fixed the known strict sentinel `tests/test-benchmarks.rkt` by adding an explicit RackUnit text-ui runner. The final local broad ledger run did not report a strict zero-parsed blocker.
+
+### Are broad failures classified?
+
+Yes for completed profiles. Local broad reports normalized categories and ledger split:
+
+```text
+PASS=964, ASSERTION_FAILURE=74, MODULE_LOAD_FAILURE=2, ENVIRONMENT_MISSING=1, UNKNOWN_FAILURE=1
+Known=78, New=0, Unclassified=0, Release-blocking known=0
+```
+
+### Are local/VPS/CI statuses separated?
+
+Yes for local and VPS evidence in W8. CI remains not measured in this wave and must not be inferred. Local broad is completed known-debt `FAIL`; VPS broad is 900s `INCOMPLETE` with high measured `raco test` overhead.
+
+### Is there a ledger for known failures?
+
+Yes: `tests/test-suite-ledger.json`, documented by `docs/reports/TEST-SUITE-LEDGER.md`. Known failures remain visible and are not counted as passes.
+
+### What gates are release-blocking now?
+
+For post-v0.99.30 release audits:
+
+- focused changed/adjacent `raco test` suites must pass,
+- fresh-bytecode `raco make main.rkt` must pass for release approval,
+- `unit-fast` must pass for the profile(s) used as release evidence,
+- broad with ledger must have `New failures: 0`, `Unclassified failures: 0`, `Release-blocking known failures: 0`, and no strict zero-parsed blockers if it is used as a known-debt truth gate,
+- profile-specific incomplete broad results must be reported as incomplete and cannot be upgraded to pass.
+
+## Remaining open debt
+
+- Local smoke remains red because its current selection is still broad-like; future work should narrow or redefine smoke if it is intended as a hard green gate.
+- Local broad still has 78 known non-release-blocking failures in this W8 run.
+- VPS broad remains infeasible within 900s under subprocess mode; more tests need metadata/in-process eligibility or a dedicated VPS/CI execution plan.
+- CI profile evidence is not available in this audit.
+
+## Final conclusion
+
+v0.99.30 succeeds at its core objective: it turns ambiguous broad-suite narratives into explicit, profile-aware, classified, reproducible gate evidence. It does not certify that the whole historical suite is green.
+

--- a/docs/reports/TEST-GATE-POLICY-v0.99.30.md
+++ b/docs/reports/TEST-GATE-POLICY-v0.99.30.md
@@ -1,0 +1,73 @@
+# Test Gate Policy — v0.99.30
+
+**Milestone:** v0.99.30 — Test Suite Reliability & Harness Modernization  
+**Wave:** W8 (#8316)  
+**Status:** Active policy for post-v0.99.30 release audits
+
+## Purpose
+
+This policy prevents broad-suite ambiguity from becoming release narrative drift. A release audit must report the exact suite, profile, runner mode, JSON/log artifact, and known/new failure split for every gate it cites.
+
+## Gate tiers
+
+| Gate | Command shape | Release meaning |
+|------|---------------|-----------------|
+| Focused wave tests | `raco test <changed/adjacent tests>` | Required for every implementation wave. Must pass except explicitly documented unrelated pre-existing failures. |
+| Fresh build | `find . -name compiled -type d -exec rm -rf {} + && raco make main.rkt` | Required for audit/release approval. Prevents stale-bytecode false confidence. |
+| Unit-fast | `racket scripts/run-tests.rkt --suite unit-fast --mode in-process --profile <profile>` and subprocess parity when relevant | Required green for releases that rely on the modernized runner. |
+| Smoke / fast | `racket scripts/run-tests.rkt --suite smoke|fast --profile <profile>` | Required to be reported exactly. Green is required only if the milestone declares it as a release-blocking gate; otherwise red must be classified. |
+| Broad with ledger | `racket scripts/run-tests.rkt --suite broad --profile <profile> --ledger tests/test-suite-ledger.json --json-out <path>` | Truth gate. Broad may remain red only when all failures are known/non-release-blocking or profile-skipped, with zero new/unclassified/release-blocking known failures. |
+| VPS / CI broad | same as broad, `--profile vps|ci` | Must be reported separately from local. Timeout/incomplete is not interchangeable with local fail/pass. |
+
+## Required report fields
+
+Every gate citation must include:
+
+- exact command,
+- working directory / commit,
+- profile (`local`, `vps`, `ci`, `headless`, or `full`),
+- suite,
+- mode (`auto`, `subprocess`, `in-process`, or `grouped`),
+- exit code,
+- JSON/log artifact path when produced,
+- file summary,
+- test summary,
+- normalized category summary,
+- ledger summary when `--ledger` is used,
+- skipped-by-profile count,
+- timeout/incomplete/user-break status.
+
+## Broad-suite approval rules
+
+A broad-suite result can support release approval only when all of the following are true for the cited profile:
+
+1. `New failures: 0`.
+2. `Unclassified failures: 0`.
+3. `Release-blocking known failures: 0`.
+4. Strict zero-parsed detection reports no blocking files.
+5. Skips are explicit `SKIPPED_BY_PROFILE`, not silent passes.
+6. The audit does not claim PASS unless the runner verdict and process exit indicate PASS.
+
+If the broad command times out or is interrupted, the audit must state `INCOMPLETE` for that profile and must not infer the final known/new split unless JSON/log evidence exists.
+
+## Known-failure ledger rules
+
+- Known failures are not passes.
+- Ledger entries must include file, category, owner, issue, note, and `release_blocking` status.
+- Category changes are treated as new/unclassified until triaged.
+- Resolved known failures should be reported and removed or updated in a later cleanup wave.
+- The ledger must not be used to hide strict zero-parsed files; zero-parsed files must be fixed, marked `@not-test`, or explicitly classified by runner policy.
+
+## Environment profile rules
+
+Local, VPS, CI, headless, and full profile results are independent facts. A release audit may say, for example, "local broad completed with known debt" and "VPS broad timed out/incomplete due high per-file `raco test` overhead". It must not collapse those into a universal broad-suite status.
+
+## v0.99.30 policy baseline
+
+As of W8:
+
+- `unit-fast` is green on local and VPS in both in-process/subprocess modes where measured.
+- local broad with ledger completes with no new/unclassified failures but still has known non-release-blocking debt.
+- VPS broad remains infeasible under the current per-file subprocess broad runner within 900s; this is reported as profile-specific incomplete evidence, not a universal suite result.
+- strict zero-parsed false green for `tests/test-benchmarks.rkt` was fixed in W7.
+


### PR DESCRIPTION
## Summary

Implements v0.99.30 W8 (#8316): release-gate policy docs and final reliability audit.

Added:

- `docs/reports/TEST-GATE-POLICY-v0.99.30.md`
- `docs/reports/AUDIT-v0.99.30-TEST-SUITE-RELIABILITY.md`

Also updated external planning process files locally (outside this repo commit):

- `.planning/TEST-GATE-POLICY.md`
- `.planning/AUDIT-PROCESS-CHECKLIST.md`

## Final gate evidence

Local W8 gates on main `7aaa0a35` before docs commit:

- `racket scripts/run-tests.rkt --suite smoke --profile local --json-out tmp/v09930-w8-gates/smoke-local.json` → exit 1, `946 files, 887 passed, 59 failed, 0 timeouts`, `11851 tests, 11793 passed, 58 failed`, `Category PASS=887 ASSERTION_FAILURE=57 MODULE_LOAD_FAILURE=2`, `VERDICT FAIL`.
- `racket scripts/run-tests.rkt --suite unit-fast --mode in-process --profile local --json-out tmp/v09930-w8-gates/unit-fast-inprocess-local.json` → exit 0, `10 files passed`, `102 tests passed`, `VERDICT PASS`.
- `racket scripts/run-tests.rkt --suite unit-fast --mode subprocess --profile local --json-out tmp/v09930-w8-gates/unit-fast-subprocess-local.json` → exit 0, `10 files passed`, `102 tests passed`, `VERDICT PASS`.
- `timeout 900 racket scripts/run-tests.rkt --suite broad --profile local --ledger tests/test-suite-ledger.json --json-out tmp/v09930-w8-gates/broad-ledger-local.json` → exit 1, `1042 files, 964 passed, 78 failed, 0 timeouts`, `12617 tests, 12546 passed, 71 failed`, `Category PASS=964 ASSERTION_FAILURE=74 MODULE_LOAD_FAILURE=2 ENVIRONMENT_MISSING=1 UNKNOWN_FAILURE=1`, `Known failures 78`, `New failures 0`, `Unclassified failures 0`, `Resolved known failures 6`, `Release-blocking known failures 0`.

VPS W8 evidence after syncing remote to `7aaa0a35`:

- `racket scripts/run-tests.rkt --diagnose-overhead` → `raco-empty 14844ms`, `raco-rackunit-empty 15114ms`, representative `raco test` `15472ms`.
- `racket scripts/run-tests.rkt --suite unit-fast --mode in-process --profile vps --json-out tmp/v09930-w8-gates/unit-fast-inprocess-vps.json` → exit 0, `10 files passed`, `102 tests passed`, `VERDICT PASS`.
- `racket scripts/run-tests.rkt --suite unit-fast --mode subprocess --profile vps --json-out tmp/v09930-w8-gates/unit-fast-subprocess-vps.json` → exit 0, `10 files passed`, `102 tests passed`, `VERDICT PASS`.
- `timeout 900 racket scripts/run-tests.rkt --suite broad --profile vps --ledger tests/test-suite-ledger.json --json-out tmp/v09930-w8-gates/broad-ledger-vps.json` → exit 124; partial output only (`1042 files`, `profile=vps skipped 2`, serial mutation-sensitive phase started); stderr user break at timeout; no final summary, so classified as VPS broad INCOMPLETE, not pass/fail.

Required fast gate after W8 docs:

- `timeout 900 racket scripts/run-tests.rkt --suite fast` → exit 1, `950 files, 893 passed, 57 failed, 0 timeouts`, `11880 tests, 11824 passed, 56 failed`, `Category PASS=893 ASSERTION_FAILURE=55 MODULE_LOAD_FAILURE=2`, `VERDICT FAIL`.

Notes:

- README metrics were dirtied by local gate runs and restored before commit.
- Temp gate artifacts were not committed.

Closes #8316.