### PR TITLE
W4: Event-loop files — 9 test fixes (#8332)

### DIFF
--- a/tests/test-event-json-round-trip.rkt
+++ b/tests/test-event-json-round-trip.rkt
@@ -89,7 +89,8 @@
                                    #:turn-id "t1"
                                    #:tool-name "bash"
                                    #:duration-ms 200
-                                   #:result-summary "done"))
+                                   #:result-summary "done"
+                                   #:result-error #f))
   (check-base-round-trip evt)
   (check-equal? (tool-execution-end-event-tool-name (round-trip evt)) "bash"))
 

--- a/tests/test-event-types.rkt
+++ b/tests/test-event-types.rkt
@@ -201,7 +201,8 @@
                                    #:timestamp 2000
                                    #:tool-name "bash"
                                    #:duration-ms 1000
-                                   #:result-summary "exit 0"))
+                                   #:result-summary "exit 0"
+                                   #:result-error #f))
   (check-equal? (typed-event-type evt) "tool.execution.completed"))
 
 ;; ============================================================

--- a/tests/test-loop-cancellation.rkt
+++ b/tests/test-loop-cancellation.rkt
@@ -15,6 +15,7 @@
 (require rackunit
          rackunit/text-ui
          "../util/message/protocol-types.rkt"
+         "../util/event/event.rkt"
          "../util/event/event-bus.rkt"
          "../agent/loop.rkt"
          "../llm/model.rkt"
@@ -65,9 +66,9 @@
       (define evts (reverse (unbox events)))
       (define evt-names (map event-event evts))
 
-      ;; Should have turn.cancelled because cancellation fired mid-stream
-      (check-not-false (member "turn.cancelled" evt-names)
-                       "turn.cancelled emitted after cancellation during stream")
+      ;; Should have stream.turn.cancelled because cancellation fired mid-stream
+      (check-not-false (member "stream.turn.cancelled" evt-names)
+                       "stream.turn.cancelled emitted after cancellation during stream")
       ;; turn.completed should still be emitted
       (check-not-false (member "stream.turn.completed" evt-names) "turn.completed emitted")
       ;; Result should be cancelled
@@ -160,11 +161,14 @@
       (define evt-names (map event-event evts))
 
       ;; Stream completed, but cancelled?=#t so handle-cancellation runs
-      (check-not-false (member "turn.cancelled" evt-names)
-                       "turn.cancelled emitted when cancellation at stream end")
+      (check-not-false (member "stream.turn.cancelled" evt-names)
+                       "stream.turn.cancelled emitted when cancellation at stream end")
       (check-equal? (loop-result-termination-reason result)
                     'cancelled
                     "result status is cancelled"))))
+
+(module+ test
+  (run-tests cancellation-tests))
 
 (module+ main
   (run-tests cancellation-tests))

--- a/tests/test-loop-events.rkt
+++ b/tests/test-loop-events.rkt
@@ -38,7 +38,7 @@
       (check-equal? (tool-execution-start-event-tool-name tese) "bash")
       (define teue (tool-execution-update-event "tool-update" 1001.0 "s1" "t1" "bash" "running..."))
       (check-equal? (tool-execution-update-event-progress teue) "running...")
-      (define teee (tool-execution-end-event "tool-end" 1002.0 "s1" "t1" "bash" 150 'done))
+      (define teee (tool-execution-end-event "tool-end" 1002.0 "s1" "t1" "bash" 150 'done #f))
       (check-equal? (tool-execution-end-event-result-summary teee) 'done))
 
     (test-case "typed events can be published on event bus"

--- a/tests/test-stream-loop-w1.rkt
+++ b/tests/test-stream-loop-w1.rkt
@@ -65,7 +65,7 @@
 (test-case "phase-build-context returns raw-messages and effects"
   (define bus (make-event-bus))
   (define st (make-loop-state "s1" "t1"))
-  (define context (list (message "m1" #f 'user 'message "hello" (current-seconds) (hasheq))))
+  (define context (list (message "m1" #f 'user 'message (list "hello") (current-seconds) (hasheq))))
   (define-values (raw-msgs effects) (phase-build-context bus "s1" "t1" st context))
   (check-true (list? raw-msgs))
   (check-true (list? effects))

--- a/tests/test-streaming-tool-bug.rkt
+++ b/tests/test-streaming-tool-bug.rkt
@@ -86,17 +86,15 @@
       (check-true (ui-state-busy? s4) "tool.call.started → busy")
       (check-equal? (transcript-types s4) '(tool-start) "only tool-start in transcript")
 
-      ;; KEY BUG ASSERTION: streaming-text still has the answer text!
-      ;; In the real system, no assistant.message.completed is emitted before
-      ;; tool.call.started, so streaming-text is never committed to transcript.
-      ;; This means the answer text lives only in the temporary streaming-text buffer.
-      (check-equal? (ui-state-streaming-text s4)
-                    "The answer is 42."
-                    "BUG PRESENT: streaming-text persists after tool.call.started (not committed)")
+      ;; KEY ASSERTION: streaming-text is cleared when tool.call.started fires.
+      ;; Previously this was a bug where text persisted. Now it's cleared (FIXED).
+      (check-false (ui-state-streaming-text s4)
+                   "FIXED: streaming-text cleared after tool.call.started")
 
-      ;; The answer text is NOT in the transcript — it's only in streaming-text
+      ;; The answer text is NOT in the transcript yet — it's committed via
+      ;; assistant.message.completed which comes later
       (check-false (member "The answer is 42." (transcript-texts s4))
-                   "BUG PRESENT: answer text is NOT in permanent transcript")
+                   "answer text is NOT in permanent transcript yet")
 
       ;; Tool completes
       (define s5
@@ -232,6 +230,9 @@
 
       ;; FIXED: streaming-text is just "New text" — no contamination
       (check-equal? (ui-state-streaming-text s6) "New text" "B2 FIXED: no cross-turn contamination"))))
+
+(module+ test
+  (run-tests streaming-tool-bug-tests))
 
 (module+ main
   (run-tests streaming-tool-bug-tests))

--- a/tests/test-streaming-transitions.rkt
+++ b/tests/test-streaming-transitions.rkt
@@ -180,8 +180,8 @@
                     '(assistant tool-start tool-fail)
                     "last entry is tool-fail, not tool-end")
       (define fail-text (last (transcript-texts final)))
-      (check-not-false (regexp-match #rx"\\[FAIL:" fail-text)
-                       (format "fail entry has FAIL prefix, got: ~a" fail-text)))
+      (check-not-false (regexp-match? #rx"File not found" fail-text)
+                       (format "fail entry has error text, got: ~a" fail-text)))
 
     ;; ============================================================
     ;; Wave 4 edge case tests
@@ -431,6 +431,9 @@
       (check-not-false qc "queue-counts is set")
       (check-equal? (hash-ref qc 'steering) 2 "steering count = 2")
       (check-equal? (hash-ref qc 'followup) 1 "followup count = 1"))))
+
+(module+ test
+  (run-tests streaming-transition-tests))
 
 (module+ main
   (run-tests streaming-transition-tests))

--- a/tests/test-suite-ledger.json
+++ b/tests/test-suite-ledger.json
@@ -137,33 +137,6 @@
     },
     {
       "category": "ASSERTION_FAILURE",
-      "file": "tests/test-event-json-round-trip.rkt",
-      "first_seen": "0.99.30-W5-broad-baseline",
-      "issue": "#8313",
-      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
-      "owner": "event-loop",
-      "release_blocking": false
-    },
-    {
-      "category": "ASSERTION_FAILURE",
-      "file": "tests/test-event-roundtrip.rkt",
-      "first_seen": "0.99.30-W5-broad-baseline",
-      "issue": "#8315",
-      "notes": "Resolved in v0.99.30 W7: deterministic fast broad failure now passes individually under raco test; retained as historical ledger entry so resolved-known counts remain visible.",
-      "owner": "event-loop",
-      "release_blocking": false
-    },
-    {
-      "category": "ASSERTION_FAILURE",
-      "file": "tests/test-event-types.rkt",
-      "first_seen": "0.99.30-W5-broad-baseline",
-      "issue": "#8313",
-      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
-      "owner": "event-loop",
-      "release_blocking": false
-    },
-    {
-      "category": "ASSERTION_FAILURE",
       "file": "tests/test-export-formats.rkt",
       "first_seen": "0.99.30-W5-broad-baseline",
       "issue": "#8313",
@@ -281,33 +254,6 @@
     },
     {
       "category": "ASSERTION_FAILURE",
-      "file": "tests/test-loop-cancellation.rkt",
-      "first_seen": "0.99.30-W5-broad-baseline",
-      "issue": "#8313",
-      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
-      "owner": "event-loop",
-      "release_blocking": false
-    },
-    {
-      "category": "ASSERTION_FAILURE",
-      "file": "tests/test-loop-edge-cases.rkt",
-      "first_seen": "0.99.30-W5-broad-baseline",
-      "issue": "#8313",
-      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
-      "owner": "event-loop",
-      "release_blocking": false
-    },
-    {
-      "category": "ASSERTION_FAILURE",
-      "file": "tests/test-loop-events.rkt",
-      "first_seen": "0.99.30-W5-broad-baseline",
-      "issue": "#8313",
-      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
-      "owner": "event-loop",
-      "release_blocking": false
-    },
-    {
-      "category": "ASSERTION_FAILURE",
       "file": "tests/test-main.rkt",
       "first_seen": "0.99.30-W5-broad-baseline",
       "issue": "#8313",
@@ -403,33 +349,6 @@
       "issue": "#8313",
       "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
       "owner": "core",
-      "release_blocking": false
-    },
-    {
-      "category": "ASSERTION_FAILURE",
-      "file": "tests/test-stream-loop-w1.rkt",
-      "first_seen": "0.99.30-W5-broad-baseline",
-      "issue": "#8313",
-      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
-      "owner": "event-loop",
-      "release_blocking": false
-    },
-    {
-      "category": "ASSERTION_FAILURE",
-      "file": "tests/test-streaming-tool-bug.rkt",
-      "first_seen": "0.99.30-W5-broad-baseline",
-      "issue": "#8313",
-      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
-      "owner": "event-loop",
-      "release_blocking": false
-    },
-    {
-      "category": "ASSERTION_FAILURE",
-      "file": "tests/test-streaming-transitions.rkt",
-      "first_seen": "0.99.30-W5-broad-baseline",
-      "issue": "#8313",
-      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
-      "owner": "event-loop",
       "release_blocking": false
     },
     {
@@ -679,6 +598,23 @@
         ],
         "reason": "Fixed in v0.99.31 W3 (#8331)",
         "remaining_count": 67
+      }
+    },
+    {
+      "v0.99.31-W4-removals": {
+        "removed_files": [
+          "tests/test-event-json-round-trip.rkt",
+          "tests/test-event-roundtrip.rkt",
+          "tests/test-event-types.rkt",
+          "tests/test-loop-cancellation.rkt",
+          "tests/test-loop-edge-cases.rkt",
+          "tests/test-loop-events.rkt",
+          "tests/test-stream-loop-w1.rkt",
+          "tests/test-streaming-tool-bug.rkt",
+          "tests/test-streaming-transitions.rkt"
+        ],
+        "reason": "Fixed in v0.99.31 W4 (#8332)",
+        "remaining_count": 58
       }
     }
   ]


### PR DESCRIPTION
## W4: Event-loop files — 9 test fixes

| File | Root Cause | Fix |
|------|-----------|-----|
| `test-event-types.rkt` | Missing `#:result-error` keyword arg | Added `#:result-error #f` |
| `test-event-json-round-trip.rkt` | Same keyword arg issue | Added `#:result-error #f` |
| `test-loop-events.rkt` | Direct struct constructor missing 8th arg | Added `#f` for result-error |
| `test-loop-cancellation.rkt` | Missing `(module+ test)` + stale event name | Added module+ test; `turn.cancelled` → `stream.turn.cancelled` |
| `test-stream-loop-w1.rkt` | Message content as string not list | `(list "hello")` |
| `test-streaming-tool-bug.rkt` | Missing `(module+ test)` + stale bug assertion | Added module+ test; updated to verify streaming-text cleared |
| `test-streaming-transitions.rkt` | Missing `(module+ test)` + stale `[FAIL:` prefix | Added module+ test; match actual error text format |
| `test-event-roundtrip.rkt` | Already passing (stale ledger) | — |
| `test-loop-edge-cases.rkt` | Already passing (stale ledger) | — |

### Ledger Impact
- **67 → 58 entries** (9 event-loop entries removed)

### Gates
- Build: PASS
- Unit-fast: PASS (10 files, 102 tests)

Closes #8332