### PR TITLE
W7: Browser + LLM files — 13 test fixes (#8335)

### DIFF
--- a/tests/test-anthropic.rkt
+++ b/tests/test-anthropic.rkt
@@ -36,7 +36,7 @@
 ;; 2. anthropic-build-request-body — includes max_tokens
 ;; ============================================================
 
-(check-equal? (hash-ref body-basic 'max_tokens) 4096 "default max_tokens is 4096")
+(check-equal? (hash-ref body-basic 'max_tokens) 16384 "default max_tokens is 16384")
 
 ;; Custom max_tokens
 (define req-custom-max
@@ -615,10 +615,7 @@
      "assistant"
      'content
      (list (hash 'type "tool-call" 'id "call_abc123" 'name "bash" 'arguments (hash 'command "ls"))))
-    (hash 'role
-          "tool"
-          'content
-          (hash 'type "tool-result" 'toolCallId "call_abc123" 'content "file1.txt\nfile2.txt"))
+    (hash 'role "tool" 'tool_call_id "call_abc123" 'content "file1.txt\nfile2.txt")
     (hash 'role "user" 'content "Read file1.txt"))
    #f
    (hash 'model "claude-sonnet-4-20250514")))

--- a/tests/test-browser-adapter.rkt
+++ b/tests/test-browser-adapter.rkt
@@ -59,20 +59,24 @@
 
 (test-case "make-browser-adapter creates a browser-adapter"
   (reset-call-log!)
-  (define a (make-browser-adapter
-             #:open mock-open
-             #:close mock-close
-             #:navigate mock-navigate
-             #:observe mock-observe
-             #:act mock-act
-             #:screenshot mock-screenshot))
+  (define a
+    (make-browser-adapter #:open mock-open
+                          #:close mock-close
+                          #:navigate mock-navigate
+                          #:observe mock-observe
+                          #:act mock-act
+                          #:screenshot mock-screenshot))
   (check-true (browser-adapter? a)))
 
 (test-case "browser-adapter is transparent"
   (reset-call-log!)
-  (define a (make-browser-adapter
-             #:open mock-open #:close mock-close #:navigate mock-navigate
-             #:observe mock-observe #:act mock-act #:screenshot mock-screenshot))
+  (define a
+    (make-browser-adapter #:open mock-open
+                          #:close mock-close
+                          #:navigate mock-navigate
+                          #:observe mock-observe
+                          #:act mock-act
+                          #:screenshot mock-screenshot))
   (check-true (struct? a)))
 
 ;; ---------------------------------------------------------------------------
@@ -82,28 +86,40 @@
 (test-case "browser-adapter-open delegates to open-fn"
   (reset-call-log!)
   (call-log '())
-  (define a (make-browser-adapter
-             #:open mock-open #:close mock-close #:navigate mock-navigate
-             #:observe mock-observe #:act mock-act #:screenshot mock-screenshot))
+  (define a
+    (make-browser-adapter #:open mock-open
+                          #:close mock-close
+                          #:navigate mock-navigate
+                          #:observe mock-observe
+                          #:act mock-act
+                          #:screenshot mock-screenshot))
   (define result (browser-adapter-open a "s1" "https://example.com"))
   (check-equal? result 'ok)
-  (check-equal? call-log '((open . ("s1" . ("https://example.com"))))))
+  (check-equal? (call-log) '((open "s1" "https://example.com"))))
 
 (test-case "browser-adapter-close delegates to close-fn"
   (reset-call-log!)
   (call-log '())
-  (define a (make-browser-adapter
-             #:open mock-open #:close mock-close #:navigate mock-navigate
-             #:observe mock-observe #:act mock-act #:screenshot mock-screenshot))
+  (define a
+    (make-browser-adapter #:open mock-open
+                          #:close mock-close
+                          #:navigate mock-navigate
+                          #:observe mock-observe
+                          #:act mock-act
+                          #:screenshot mock-screenshot))
   (browser-adapter-close a "s1")
-  (check-equal? call-log '((close . ("s1")))))
+  (check-equal? (call-log) '((close "s1"))))
 
 (test-case "browser-adapter-navigate delegates to navigate-fn"
   (reset-call-log!)
   (call-log '())
-  (define a (make-browser-adapter
-             #:open mock-open #:close mock-close #:navigate mock-navigate
-             #:observe mock-observe #:act mock-act #:screenshot mock-screenshot))
+  (define a
+    (make-browser-adapter #:open mock-open
+                          #:close mock-close
+                          #:navigate mock-navigate
+                          #:observe mock-observe
+                          #:act mock-act
+                          #:screenshot mock-screenshot))
   (define result (browser-adapter-navigate a "s1" "https://example.com"))
   (check-true (browser-observation? result))
   (check-equal? (browser-observation-url result) "https://example.com"))
@@ -111,47 +127,67 @@
 (test-case "browser-adapter-observe delegates to observe-fn"
   (reset-call-log!)
   (call-log '())
-  (define a (make-browser-adapter
-             #:open mock-open #:close mock-close #:navigate mock-navigate
-             #:observe mock-observe #:act mock-act #:screenshot mock-screenshot))
+  (define a
+    (make-browser-adapter #:open mock-open
+                          #:close mock-close
+                          #:navigate mock-navigate
+                          #:observe mock-observe
+                          #:act mock-act
+                          #:screenshot mock-screenshot))
   (define result (browser-adapter-observe a "s1"))
   (check-true (browser-observation? result))
-  (check-equal? call-log '((observe . ("s1" . (#f))))))
+  (check-equal? (call-log) '((observe "s1" #f))))
 
 (test-case "browser-adapter-observe with selector"
   (reset-call-log!)
   (call-log '())
-  (define a (make-browser-adapter
-             #:open mock-open #:close mock-close #:navigate mock-navigate
-             #:observe mock-observe #:act mock-act #:screenshot mock-screenshot))
+  (define a
+    (make-browser-adapter #:open mock-open
+                          #:close mock-close
+                          #:navigate mock-navigate
+                          #:observe mock-observe
+                          #:act mock-act
+                          #:screenshot mock-screenshot))
   (browser-adapter-observe a "s1" #:selector "#main")
-  (check-equal? call-log '((observe . ("s1" . ("#main"))))))
+  (check-equal? (call-log) '((observe "s1" "#main"))))
 
 (test-case "browser-adapter-act delegates to act-fn"
   (reset-call-log!)
   (call-log '())
-  (define a (make-browser-adapter
-             #:open mock-open #:close mock-close #:navigate mock-navigate
-             #:observe mock-observe #:act mock-act #:screenshot mock-screenshot))
+  (define a
+    (make-browser-adapter #:open mock-open
+                          #:close mock-close
+                          #:navigate mock-navigate
+                          #:observe mock-observe
+                          #:act mock-act
+                          #:screenshot mock-screenshot))
   (define action (browser-action-click "#btn" "left"))
   (browser-adapter-act a "s1" action)
-  (check-equal? (car (car call-log)) 'act))
+  (check-equal? (car (car (call-log))) 'act))
 
 (test-case "browser-adapter-screenshot delegates to screenshot-fn"
   (reset-call-log!)
   (call-log '())
-  (define a (make-browser-adapter
-             #:open mock-open #:close mock-close #:navigate mock-navigate
-             #:observe mock-observe #:act mock-act #:screenshot mock-screenshot))
+  (define a
+    (make-browser-adapter #:open mock-open
+                          #:close mock-close
+                          #:navigate mock-navigate
+                          #:observe mock-observe
+                          #:act mock-act
+                          #:screenshot mock-screenshot))
   (define result (browser-adapter-screenshot a "s1"))
   (check-true (bytes? result))
-  (check-equal? call-log '((screenshot . ("s1" . (#f . (#f)))))))
+  (check-equal? (call-log) '((screenshot "s1" #f #f))))
 
 (test-case "browser-adapter-screenshot with options"
   (reset-call-log!)
   (call-log '())
-  (define a (make-browser-adapter
-             #:open mock-open #:close mock-close #:navigate mock-navigate
-             #:observe mock-observe #:act mock-act #:screenshot mock-screenshot))
+  (define a
+    (make-browser-adapter #:open mock-open
+                          #:close mock-close
+                          #:navigate mock-navigate
+                          #:observe mock-observe
+                          #:act mock-act
+                          #:screenshot mock-screenshot))
   (browser-adapter-screenshot a "s1" #:selector "#main" #:full-page? #t)
-  (check-equal? call-log '((screenshot . ("s1" . ("#main" . (#t)))))))
+  (check-equal? (call-log) '((screenshot "s1" "#main" #t))))

--- a/tests/test-browser-audit-w1-v0983.rkt
+++ b/tests/test-browser-audit-w1-v0983.rkt
@@ -53,7 +53,15 @@
 ;; ---------------------------------------------------------------------------
 
 (test-case "SEC-10: restart-sidecar! increments restart count even without sidecar-path"
-  (define config (hasheq 'sidecar-path #f 'restart-count 0 'pending-sema (make-semaphore 1)))
+  (define config
+    (hasheq 'sidecar-path
+            #f
+            'restart-count
+            0
+            'pending-sema
+            (make-semaphore 1)
+            'restart-sema
+            (make-semaphore 1)))
   (define state (playwright-sidecar-state #f #f #f (make-hash) #f #f config #f #f))
   (restart-sidecar! state)
   (check-equal? (hash-ref (playwright-sidecar-state-config state) 'restart-count) 1))

--- a/tests/test-browser-audit-w2.rkt
+++ b/tests/test-browser-audit-w2.rkt
@@ -36,6 +36,8 @@
             'restart-count
             0
             'pending-sema
+            (make-semaphore 1)
+            'restart-sema
             (make-semaphore 1)))
   (define state (playwright-sidecar-state #f #f #f (make-hash) #f #f config #f #f))
   (restart-sidecar! state)
@@ -43,7 +45,16 @@
 
 (test-case "H1: double restart increments count twice"
   (define config
-    (hasheq 'timeout-ms 5000 'sidecar-path #f 'restart-count 0 'pending-sema (make-semaphore 1)))
+    (hasheq 'timeout-ms
+            5000
+            'sidecar-path
+            #f
+            'restart-count
+            0
+            'pending-sema
+            (make-semaphore 1)
+            'restart-sema
+            (make-semaphore 1)))
   (define state (playwright-sidecar-state #f #f #f (make-hash) #f #f config #f #f))
   (restart-sidecar! state)
   (restart-sidecar! state)
@@ -73,7 +84,9 @@
             'node-path
             "node"
             'headless?
-            #t))
+            #t
+            'restart-sema
+            (make-semaphore 1)))
   (define state (playwright-sidecar-state #f #f #f pending #f #f config #f #f))
   (restart-sidecar! state)
   (check-equal? (hash-ref (playwright-sidecar-state-config state) 'restart-count) 1))
@@ -84,15 +97,16 @@
 
 (test-case "H2/H3: restart-sidecar! handles missing sidecar-path"
   (define state
-    (playwright-sidecar-state #f
-                              #f
-                              #f
-                              (make-hash)
-                              #f
-                              #f
-                              (hasheq 'sidecar-path #f 'restart-count 0)
-                              #f
-                              #f))
+    (playwright-sidecar-state
+     #f
+     #f
+     #f
+     (make-hash)
+     #f
+     #f
+     (hasheq 'sidecar-path #f 'restart-count 0 'restart-sema (make-semaphore 1))
+     #f
+     #f))
   (restart-sidecar! state)
   (check-equal? (hash-ref (playwright-sidecar-state-config state) 'restart-count) 1))
 

--- a/tests/test-browser-audit.rkt
+++ b/tests/test-browser-audit.rkt
@@ -14,8 +14,9 @@
          "../util/event/event.rkt")
 
 (define (make-temp-dir)
-  (define dir (build-path (find-system-path 'temp-dir)
-                          (format "q-browser-audit-test-~a" (current-milliseconds))))
+  (define dir
+    (build-path (find-system-path 'temp-dir)
+                (format "q-browser-audit-test-~a" (current-milliseconds))))
   (make-directory* dir)
   dir)
 
@@ -36,8 +37,20 @@
 
 (test-case "log-browser-action! with observation result"
   (define dir (make-temp-dir))
-  (define obs (browser-observation "https://x.com" "Title" "text" "visible"
-                                    #f #f #f #f '() '() (hash) (hash)))
+  (define obs
+    (browser-observation "https://x.com"
+                         "Title"
+                         "text"
+                         "visible"
+                         #f
+                         #f
+                         #f
+                         #f
+                         '()
+                         '()
+                         (hash)
+                         (hash)
+                         (hash)))
   (log-browser-action! "s1" 'observe obs dir)
   (define lines (file->lines (audit-log-path dir)))
   (check-equal? (length lines) 1)
@@ -66,18 +79,13 @@
 (test-case "emit-browser-event! publishes to event bus"
   (define bus (make-event-bus))
   (define received (box #f))
-  (subscribe! bus
-               (lambda (evt)
-                 (set-box! received evt)))
+  (subscribe! bus (lambda (evt) (set-box! received evt)))
   (emit-browser-event! bus 'test.event "s1" (hasheq 'key 'value))
-  (check-not-false (unbox received)
-                   "event should have been received by subscriber"))
+  (check-not-false (unbox received) "event should have been received by subscriber"))
 
 (test-case "emit-browser-event! with symbol event-type converts to string"
   (define bus (make-event-bus))
   (define received-topic (box #f))
-  (subscribe! bus
-               (lambda (evt)
-                 (set-box! received-topic (event-ev evt))))
+  (subscribe! bus (lambda (evt) (set-box! received-topic (event-ev evt))))
   (emit-browser-event! bus 'browser.action.started "s1" (hasheq))
   (check-equal? (unbox received-topic) "browser.action.started"))

--- a/tests/test-browser-mock-adapter.rkt
+++ b/tests/test-browser-mock-adapter.rkt
@@ -107,31 +107,51 @@
 
 (test-case "error-mode raises q-browser-error"
   (define a (make-mock-adapter #:error-mode 'timeout))
-  (check-exn q-browser-error?
-             (lambda ()
-               (mock-open a "https://example.com" #f))))
+  (check-exn q-browser-error? (lambda () (mock-open a "https://example.com" #f))))
 
 (test-case "error-mode affects all calls"
   (define a (make-mock-adapter #:error-mode 'connection))
-  (check-exn q-browser-error?
-             (lambda () (mock-open a "https://x.com" #f)))
-  (check-exn q-browser-error?
-             (lambda () (mock-navigate a "s1" "https://x.com/p"))))
+  (check-exn q-browser-error? (lambda () (mock-open a "https://x.com" #f)))
+  (check-exn q-browser-error? (lambda () (mock-navigate a "s1" "https://x.com/p"))))
 
 ;; ---------------------------------------------------------------------------
 ;; Configurable responses
 ;; ---------------------------------------------------------------------------
 
 (test-case "custom response for open"
-  (define custom-obs (browser-observation "https://custom.com" "Custom" "text" "visible"
-                                           #f #f #f #f '() '() (hash) (hash 'custom #t)))
+  (define custom-obs
+    (browser-observation "https://custom.com"
+                         "Custom"
+                         "text"
+                         "visible"
+                         #f
+                         #f
+                         #f
+                         #f
+                         '()
+                         '()
+                         (hash)
+                         (hash 'custom #t)
+                         (hash)))
   (define a (make-mock-adapter #:responses (hash 'open custom-obs)))
   (define obs (mock-open a "https://x.com" #f))
   (check-equal? (browser-observation-url obs) "https://custom.com"))
 
 (test-case "custom response for navigate"
-  (define custom-obs (browser-observation "https://new.com" "New Page" "text" "visible"
-                                           #f #f #f #f '() '() (hash) (hash)))
+  (define custom-obs
+    (browser-observation "https://new.com"
+                         "New Page"
+                         "text"
+                         "visible"
+                         #f
+                         #f
+                         #f
+                         #f
+                         '()
+                         '()
+                         (hash)
+                         (hash)
+                         (hash)))
   (define a (make-mock-adapter #:responses (hash 'navigate custom-obs)))
   (define obs (mock-navigate a "s1" "https://old.com"))
   (check-equal? (browser-observation-url obs) "https://new.com"))

--- a/tests/test-browser-robustness-w1.rkt
+++ b/tests/test-browser-robustness-w1.rkt
@@ -18,26 +18,27 @@
 ;; Test: screenshot-max-bytes enforcement
 ;; ---------------------------------------------------------------------------
 
-(test-case "enforce-screenshot-max-bytes truncates oversized screenshot"
+(test-case "enforce-screenshot-max-bytes nulls oversized screenshot"
   (define s (default-browser-settings))
   (define max-bytes (browser-settings-screenshot-max-bytes s))
   (check-true (exact-positive-integer? max-bytes))
-  ;; Truncate a fake oversized observation
+  ;; Oversized observation → screenshot set to #f (H4: not corrupt truncated bytes)
   (define big-bytes (make-bytes (add1 max-bytes) 65)) ; 'A' bytes
-  (define obs (browser-observation "" "" "" "" #f #f "image/png" big-bytes '() '() #f #f))
+  (define obs (browser-observation "" "" "" "" #f #f "image/png" big-bytes '() '() #f #f (hash)))
   (define truncated (enforce-screenshot-max-bytes obs max-bytes))
-  (check-true (<= (bytes-length (browser-observation-screenshot-bytes truncated)) max-bytes)))
+  (check-false (browser-observation-screenshot-bytes truncated))
+  (check-false (browser-observation-screenshot-mime truncated)))
 
 (test-case "enforce-screenshot-max-bytes passes small screenshot through"
   (define s (default-browser-settings))
   (define max-bytes (browser-settings-screenshot-max-bytes s))
   (define small-bytes (make-bytes 100 65))
-  (define obs (browser-observation "" "" "" "" #f #f "image/png" small-bytes '() '() #f #f))
+  (define obs (browser-observation "" "" "" "" #f #f "image/png" small-bytes '() '() #f #f (hash)))
   (define result (enforce-screenshot-max-bytes obs max-bytes))
   (check-equal? (browser-observation-screenshot-bytes result) small-bytes))
 
 (test-case "enforce-screenshot-max-bytes handles #f bytes"
-  (define obs (browser-observation "" "" "" "" #f #f #f #f '() '() #f #f))
+  (define obs (browser-observation "" "" "" "" #f #f #f #f '() '() #f #f (hash)))
   (define result (enforce-screenshot-max-bytes obs 524288))
   (check-false (browser-observation-screenshot-bytes result)))
 

--- a/tests/test-browser-settings.rkt
+++ b/tests/test-browser-settings.rkt
@@ -85,7 +85,10 @@
                       "/usr/local/bin/node"
                       120000
                       'persistent
-                      #f))
+                      #f
+                      #f
+                      "auto"
+                      3))
   (check-true (browser-settings-enabled? s))
   (check-equal? (browser-settings-max-sessions s) 5)
   (check-equal? (browser-settings-profile-kind s) 'persistent)
@@ -113,8 +116,22 @@
   (check-false (browser-settings-enabled? (current-browser-settings))))
 
 (test-case "current-browser-settings parameterize"
-  (parameterize
-      ([current-browser-settings
-        (browser-settings #t '("https") '() '() #t '() 1 10 5000 1024 #f 30000 'ephemeral #t)])
+  (parameterize ([current-browser-settings (browser-settings #t
+                                                             '("https")
+                                                             '()
+                                                             '()
+                                                             #t
+                                                             '()
+                                                             1
+                                                             10
+                                                             5000
+                                                             1024
+                                                             #f
+                                                             30000
+                                                             'ephemeral
+                                                             #t
+                                                             #f
+                                                             "auto"
+                                                             3)])
     (check-true (browser-settings-enabled? (current-browser-settings)))
     (check-equal? (browser-settings-max-sessions (current-browser-settings)) 1)))

--- a/tests/test-llm-model.rkt
+++ b/tests/test-llm-model.rkt
@@ -13,16 +13,16 @@
 ;; ============================================================
 
 (test-case "make-model-request creates struct"
-  (define req (make-model-request '("msg1") #f (hasheq)))
+  (define req (make-model-request (list (hasheq 'role "user" 'content "msg1")) #f (hasheq)))
   (check-pred model-request? req)
-  (check-equal? (model-request-messages req) '("msg1"))
+  (check-equal? (model-request-messages req) (list (hasheq 'role "user" 'content "msg1")))
   (check-false (model-request-tools req))
   (check-equal? (model-request-settings req) (hasheq)))
 
 (test-case "model-request->jsexpr includes tools when present"
-  (define req (make-model-request '() '(tool1) (hasheq 'temp 0.7)))
+  (define req (make-model-request '() (list (hasheq 'name "tool1")) (hasheq 'temp 0.7)))
   (define j (model-request->jsexpr req))
-  (check-equal? (hash-ref j 'tools) '(tool1))
+  (check-equal? (hash-ref j 'tools) (list (hasheq 'name "tool1")))
   (check-equal? (hash-ref j 'settings) (hasheq 'temp 0.7)))
 
 (test-case "model-request->jsexpr omits tools when #f"
@@ -31,17 +31,24 @@
   (check-false (hash-has-key? j 'tools)))
 
 (test-case "jsexpr->model-request round-trip"
-  (define req (make-model-request '("hi") '(t) (hasheq 'x 1)))
+  (define req
+    (make-model-request (list (hasheq 'role "user" 'content "hi"))
+                        (list (hasheq 'name "t"))
+                        (hasheq 'x 1)))
   (define restored (jsexpr->model-request (model-request->jsexpr req)))
-  (check-equal? (model-request-messages restored) '("hi"))
-  (check-equal? (model-request-tools restored) '(t)))
+  (check-equal? (model-request-messages restored) (list (hasheq 'role "user" 'content "hi")))
+  (check-equal? (model-request-tools restored) (list (hasheq 'name "t"))))
 
 ;; ============================================================
 ;; model-response
 ;; ============================================================
 
 (test-case "make-model-response creates struct"
-  (define resp (make-model-response '("content") (hasheq 'total-tokens 10) "gpt-4" 'stop))
+  (define resp
+    (make-model-response (list (hasheq 'type "text" 'text "content"))
+                         (hasheq 'total-tokens 10)
+                         "gpt-4"
+                         'stop))
   (check-pred model-response? resp)
   (check-equal? (model-response-model resp) "gpt-4")
   (check-eq? (model-response-stop-reason resp) 'stop))
@@ -52,7 +59,7 @@
   (check-equal? (hash-ref j 'stopReason) "length"))
 
 (test-case "jsexpr->model-response round-trip"
-  (define resp (make-model-response '("hi") (hasheq 't 5) "m" 'stop))
+  (define resp (make-model-response (list (hasheq 'type "text" 'text "hi")) (hasheq 't 5) "m" 'stop))
   (define restored (jsexpr->model-response (model-response->jsexpr resp)))
   (check-equal? (model-response-model restored) "m")
   (check-eq? (model-response-stop-reason restored) 'stop))

--- a/tests/test-mcp-config.rkt
+++ b/tests/test-mcp-config.rkt
@@ -114,8 +114,8 @@
       (define settings (make-mcp-settings (hash)))
       (check-false (broker-enabled? settings)))
 
-    (test-case "broker-enabled? returns #f even if set in config"
+    (test-case "broker-enabled? returns #t when set in config"
       (define settings (make-settings-from-paths '((mas broker enabled) #t)))
-      (check-false (broker-enabled? settings)))))
+      (check-true (broker-enabled? settings)))))
 
 (run-tests suite)

--- a/tests/test-model-command.rkt
+++ b/tests/test-model-command.rkt
@@ -74,13 +74,13 @@
 
 (test-case "test-model-command: checks block 4"
   (check-true (cmd-ctx? (make-test-cctx))
-              "cmd-ctx accepts 8 arguments including last-prompt-box and session-runner")
+              "cmd-ctx accepts arguments including last-prompt-box and session-runner")
 
   (check-false (cmd-ctx-model-registry-box (make-test-cctx))
                "cmd-ctx-model-registry-box returns #f when not provided")
 
-  (check-true (box? (cmd-ctx-model-registry-box (make-test-cctx #:model-registry 'something))))
-  "cmd-ctx-model-registry-box returns a box when registry provided")
+  (check-true (box? (cmd-ctx-model-registry-box (make-test-cctx #:model-registry 'something)))
+              "cmd-ctx-model-registry-box returns a box when registry provided"))
 
 ;; ============================================================
 ;; 2. handle-model-command — no registry (2 tests)
@@ -159,15 +159,14 @@
 
 (test-case "test-model-command: checks block 3"
   (check-equal? (parse-slash-command "/model") '(model) "parse-slash-command /model → (model)")
-
-  (check-equal? (parse-slash-command "/model gpt-4"))
-  '(model "gpt-4")
-  "parse-slash-command /model gpt-4 → (model \"gpt-4\")")
+  (check-equal? (parse-slash-command "/model gpt-4")
+                '(model "gpt-4")
+                "parse-slash-command /model gpt-4 → (model \"gpt-4\")"))
 
 (test-case "test-model-command: checks block 2"
-  (check-equal? (parse-slash-command "/model "))
-  '(model)
-  "parse-slash-command /model (trailing space) → (model)")
+  (check-equal? (parse-slash-command "/model ")
+                '(model)
+                "parse-slash-command /model (trailing space) → (model)"))
 
 (test-case "test-model-command: checks block 1"
   (check-false (parse-slash-command "/models")

--- a/tests/test-model-registry.rkt
+++ b/tests/test-model-registry.rkt
@@ -109,8 +109,7 @@
                    "registry creation from string-key config")
 
   (check-not-false (make-model-registry-from-config (make-empty-config))
-)
-                 "registry creation from empty config")
+                   "registry creation from empty config"))
 
 ;; ============================================================
 ;; Tests — available-models
@@ -182,15 +181,13 @@
 
 (test-case "test-model-registry: checks block 9"
   (check-false (resolve-model (make-model-registry-from-config (make-test-config))
-)
-                            "unknown-provider/gpt-4o")
-             "provider prefix with unknown provider returns #f")
+                              "unknown-provider/gpt-4o")
+               "provider prefix with unknown provider returns #f"))
 
 (test-case "test-model-registry: checks block 8"
   (check-false (resolve-model (make-model-registry-from-config (make-test-config))
-)
-                            "openai/nonexistent-model")
-             "provider prefix with unknown model returns #f")
+                              "openai/nonexistent-model")
+               "provider prefix with unknown model returns #f"))
 
 ;; ============================================================
 ;; Tests — resolve-model default (#f)
@@ -226,9 +223,9 @@
 ;; ============================================================
 
 (test-case "test-model-registry: checks block 7"
-  (check-false (resolve-model (make-model-registry-from-config (make-test-config)) "nonexistent-model")
-)
-             "unknown model returns #f")
+  (check-false (resolve-model (make-model-registry-from-config (make-test-config))
+                              "nonexistent-model")
+               "unknown model returns #f"))
 
 (let ([reg (make-model-registry-from-config (make-empty-config))])
   (check-false (resolve-model reg "anything") "empty registry resolve returns #f")
@@ -252,9 +249,8 @@
 
 (test-case "test-model-registry: checks block 6"
   (check-false (resolve-model-by-provider (make-model-registry-from-config (make-test-config))
-)
-                                        "nonexistent")
-             "resolve-model-by-provider returns #f for unknown provider")
+                                          "nonexistent")
+               "resolve-model-by-provider returns #f for unknown provider"))
 
 ;; ============================================================
 ;; Tests — default-model
@@ -262,26 +258,22 @@
 
 (test-case "test-model-registry: checks block 5"
   (check-equal? (default-model (make-model-registry-from-config (make-test-config)))
-)
-              "gpt-4o"
-              "default-model returns global default")
+                "gpt-4o"
+                "default-model returns global default"))
 
 (test-case "test-model-registry: checks block 4"
   (check-equal? (default-model (make-model-registry-from-config (make-single-provider-config)))
-)
-              "my-model-v2"
-              "default-model with single provider")
+                "my-model-v2"
+                "default-model with single provider"))
 
 (test-case "test-model-registry: checks block 3"
   (check-equal? (default-model (make-model-registry-from-config (make-minimal-config)))
-)
-              "llama3-70b"
-              "default-model falls back to first provider's default")
+                "llama3-70b"
+                "default-model falls back to first provider's default"))
 
 (test-case "test-model-registry: checks block 2"
   (check-false (default-model (make-model-registry-from-config (make-empty-config)))
-)
-             "default-model returns #f for empty config")
+               "default-model returns #f for empty config"))
 
 ;; ============================================================
 ;; Tests — default-model-for-mode
@@ -295,8 +287,7 @@
 
 (test-case "test-model-registry: checks block 1"
   (check-false (default-model-for-mode (make-model-registry-from-config (make-empty-config)) 'chat)
-)
-             "default-model-for-mode returns #f for empty registry")
+               "default-model-for-mode returns #f for empty registry"))
 
 ;; ============================================================
 ;; Tests — model-resolution includes provider-config

--- a/tests/test-suite-ledger.json
+++ b/tests/test-suite-ledger.json
@@ -2,78 +2,6 @@
   "entries": [
     {
       "category": "ASSERTION_FAILURE",
-      "file": "tests/test-anthropic.rkt",
-      "first_seen": "0.99.30-W5-broad-baseline",
-      "issue": "#8313",
-      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
-      "owner": "llm",
-      "release_blocking": false
-    },
-    {
-      "category": "ASSERTION_FAILURE",
-      "file": "tests/test-browser-adapter.rkt",
-      "first_seen": "0.99.30-W5-broad-baseline",
-      "issue": "#8313",
-      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
-      "owner": "browser",
-      "release_blocking": false
-    },
-    {
-      "category": "ASSERTION_FAILURE",
-      "file": "tests/test-browser-audit-w1-v0983.rkt",
-      "first_seen": "0.99.30-W5-broad-baseline",
-      "issue": "#8313",
-      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
-      "owner": "browser",
-      "release_blocking": false
-    },
-    {
-      "category": "ASSERTION_FAILURE",
-      "file": "tests/test-browser-audit-w2.rkt",
-      "first_seen": "0.99.30-W5-broad-baseline",
-      "issue": "#8313",
-      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
-      "owner": "browser",
-      "release_blocking": false
-    },
-    {
-      "category": "ASSERTION_FAILURE",
-      "file": "tests/test-browser-audit.rkt",
-      "first_seen": "0.99.30-W5-broad-baseline",
-      "issue": "#8313",
-      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
-      "owner": "browser",
-      "release_blocking": false
-    },
-    {
-      "category": "ASSERTION_FAILURE",
-      "file": "tests/test-browser-mock-adapter.rkt",
-      "first_seen": "0.99.30-W5-broad-baseline",
-      "issue": "#8313",
-      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
-      "owner": "browser",
-      "release_blocking": false
-    },
-    {
-      "category": "ASSERTION_FAILURE",
-      "file": "tests/test-browser-robustness-w1.rkt",
-      "first_seen": "0.99.30-W5-broad-baseline",
-      "issue": "#8313",
-      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
-      "owner": "browser",
-      "release_blocking": false
-    },
-    {
-      "category": "ASSERTION_FAILURE",
-      "file": "tests/test-browser-settings.rkt",
-      "first_seen": "0.99.30-W5-broad-baseline",
-      "issue": "#8313",
-      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
-      "owner": "browser",
-      "release_blocking": false
-    },
-    {
-      "category": "ASSERTION_FAILURE",
       "file": "tests/test-hook-expansion.rkt",
       "first_seen": "0.99.30-W5-broad-baseline",
       "issue": "#8313",
@@ -88,42 +16,6 @@
       "issue": "#8313",
       "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
       "owner": "extensions",
-      "release_blocking": false
-    },
-    {
-      "category": "ASSERTION_FAILURE",
-      "file": "tests/test-llm-model.rkt",
-      "first_seen": "0.99.30-W5-broad-baseline",
-      "issue": "#8313",
-      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
-      "owner": "llm",
-      "release_blocking": false
-    },
-    {
-      "category": "ASSERTION_FAILURE",
-      "file": "tests/test-mcp-config.rkt",
-      "first_seen": "0.99.30-W5-broad-baseline",
-      "issue": "#8313",
-      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
-      "owner": "llm",
-      "release_blocking": false
-    },
-    {
-      "category": "ASSERTION_FAILURE",
-      "file": "tests/test-model-command.rkt",
-      "first_seen": "0.99.30-W5-broad-baseline",
-      "issue": "#8313",
-      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
-      "owner": "llm",
-      "release_blocking": false
-    },
-    {
-      "category": "ASSERTION_FAILURE",
-      "file": "tests/test-model-registry.rkt",
-      "first_seen": "0.99.30-W5-broad-baseline",
-      "issue": "#8313",
-      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
-      "owner": "llm",
       "release_blocking": false
     },
     {
@@ -169,15 +61,6 @@
       "issue": "#8313",
       "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
       "owner": "sandbox",
-      "release_blocking": false
-    },
-    {
-      "category": "ASSERTION_FAILURE",
-      "file": "tests/test-typed-model.rkt",
-      "first_seen": "0.99.30-W5-broad-baseline",
-      "issue": "#8313",
-      "notes": "Known broad-suite debt captured by v0.99.30 W5 ledger; requires owner triage/follow-up before removal.",
-      "owner": "llm",
       "release_blocking": false
     },
     {
@@ -359,6 +242,27 @@
         ],
         "reason": "Fixed in v0.99.31 W6 (#8334)",
         "remaining_count": 24
+      }
+    },
+    {
+      "v0.99.31-W7-removals": {
+        "removed_files": [
+          "tests/test-anthropic.rkt",
+          "tests/test-browser-adapter.rkt",
+          "tests/test-browser-audit-w1-v0983.rkt",
+          "tests/test-browser-audit-w2.rkt",
+          "tests/test-browser-audit.rkt",
+          "tests/test-browser-mock-adapter.rkt",
+          "tests/test-browser-robustness-w1.rkt",
+          "tests/test-browser-settings.rkt",
+          "tests/test-llm-model.rkt",
+          "tests/test-mcp-config.rkt",
+          "tests/test-model-command.rkt",
+          "tests/test-model-registry.rkt",
+          "tests/test-typed-model.rkt"
+        ],
+        "reason": "Fixed in v0.99.31 W7 (#8335)",
+        "remaining_count": 11
       }
     }
   ]

--- a/tests/test-typed-model.rkt
+++ b/tests/test-typed-model.rkt
@@ -44,26 +44,23 @@
 
 (test-case "test-typed-model: checks block 9"
   (check-true (model-request? (make-model-request (list (hasheq 'role "user" 'content "hello"))
-)
-                                                #f
-                                                (hasheq 'model "gpt-4")))
-            "model-request: basic construction")
+                                                  #f
+                                                  (hasheq 'model "gpt-4")))
+              "model-request: basic construction"))
 
 (test-case "test-typed-model: checks block 8"
-  (check-equal?
-)
- (model-request-messages (make-model-request (list (hasheq 'role "user" 'content "hi")) #f (hasheq)))
- (list (hasheq 'role "user" 'content "hi"))
- "model-request: messages accessor")
+  (check-equal? (model-request-messages
+                 (make-model-request (list (hasheq 'role "user" 'content "hi")) #f (hasheq)))
+                (list (hasheq 'role "user" 'content "hi"))
+                "model-request: messages accessor"))
 
 (test-case "test-typed-model: checks block 7"
   (check-false (model-request-tools (make-model-request '() #f (hasheq)))
                "model-request: tools is #f when not provided")
 
   (check-equal? (model-request-settings (make-model-request '() #f (hasheq 'temperature 0.7)))
-)
-              (hasheq 'temperature 0.7)
-              "model-request: settings accessor")
+                (hasheq 'temperature 0.7)
+                "model-request: settings accessor"))
 
 ;; ============================================================
 ;; model-request serialization roundtrip
@@ -94,17 +91,15 @@
 
 (test-case "test-typed-model: checks block 6"
   (check-true (model-response? (make-model-response (list (hasheq 'type "text" 'text "Hello"))
-)
-                                                  (hasheq 'prompt-tokens 10 'completion-tokens 5)
-                                                  "gpt-4"
-                                                  'stop))
-            "model-response: basic construction")
+                                                    (hasheq 'prompt-tokens 10 'completion-tokens 5)
+                                                    "gpt-4"
+                                                    'stop))
+              "model-response: basic construction"))
 
 (test-case "test-typed-model: checks block 5"
   (check-equal? (model-response-stop-reason (make-model-response '() (hasheq) "model" 'length))
-)
-              'length
-              "model-response: stop-reason accessor")
+                'length
+                "model-response: stop-reason accessor"))
 
 ;; ============================================================
 ;; model-response serialization roundtrip
@@ -129,16 +124,14 @@
   (check-true (stream-chunk? (make-stream-chunk "hello" #f #f #f)) "stream-chunk: basic construction")
 
   (check-equal? (stream-chunk-delta-text (make-stream-chunk "hi" #f #f #f))
-)
-              "hi"
-              "stream-chunk: delta-text accessor")
+                "hi"
+                "stream-chunk: delta-text accessor"))
 
 (test-case "test-typed-model: checks block 3"
   (check-false (stream-chunk-delta-tool-call (make-stream-chunk "hi" #f #f #f))
-)
-             "stream-chunk: delta-tool-call is #f")
+               "stream-chunk: delta-tool-call is #f"))
 
-;; Optional keyword args
+;; Optional keyword arg
 (let ([chunk
        (make-stream-chunk "text" #f #f #f #:delta-thinking "thinking..." #:finish-reason 'stop)])
   (check-equal? (stream-chunk-delta-thinking chunk)
@@ -161,12 +154,10 @@
 
   ;; Empty response content
   (check-not-exn (lambda () (make-model-response '() (hasheq) "model" 'stop))
-)
-               "edge: empty response content")
+                 "edge: empty response content"))
 
 ;; model-response with tool_calls stop reason
 (test-case "test-typed-model: checks block 1"
   (check-equal? (model-response-stop-reason (make-model-response '() (hasheq) "model" 'tool-calls))
-)
-              'tool-calls
-              "edge: tool-calls stop reason")
+                'tool-calls
+                "edge: tool-calls stop reason"))


### PR DESCRIPTION
## W7: Browser + LLM files — 13 test fixes

### Changes by root cause

| Pattern | Files | Count |
|---------|-------|-------|
| Broken `check-equal?` parens (args outside call) | test-model-command, test-model-registry, test-typed-model | 3 |
| Stale make-model-request/response contracts (strings→hashes) | test-llm-model, test-typed-model | 2 |
| Stale max_tokens default (4096→16384) | test-anthropic | 1 |
| Wrong tool message format for Anthropic converter | test-anthropic | 1 |
| Stale broker-enabled? assertion (now implemented) | test-mcp-config | 1 |
| Parameter used as value: `(call-log)` not `call-log` | test-browser-adapter | 1 |
| Missing restart-sema in sidecar config | test-browser-audit-w1, w2 | 2 |
| browser-observation arity (13th field metadata added) | test-browser-audit, mock-adapter, robustness | 3 |
| browser-settings arity (3 vision fields added) | test-browser-settings | 1 |
| Stale screenshot truncation (H4: #f not corrupt bytes) | test-browser-robustness-w1 | 1 |

### Ledger Impact
- **24 → 11 entries** (13 entries removed)

### Gates
- Build: PASS
- Unit-fast: PASS (10 files, 102 tests)

Closes #8335