### PR TITLE
W2: Runner diagnostics + module-load fixes (#8353)

### DIFF
--- a/agent/stream-reducer.rkt
+++ b/agent/stream-reducer.rkt
@@ -15,7 +15,7 @@
 ;; Configurable chunk limit (v0.12.3 Wave 0.1)
 ;; ============================================================
 
-(define MAX-STREAM-CHUNKS 10000)
+(define MAX-STREAM-CHUNKS (make-parameter 10000))
 
 (provide classify-chunk
          chunk-has-data?

--- a/agent/stream-runner.rkt
+++ b/agent/stream-runner.rkt
@@ -67,7 +67,7 @@
 
   (define stream-gen (provider-stream provider req))
   (define chunk-count (box 0))
-  (define limit MAX-STREAM-CHUNKS)
+  (define limit (MAX-STREAM-CHUNKS))
   (define received-done? (box #f))
 
   ;; Error boundary — emit cleanup events on provider crash.

--- a/docs/reports/TEST-SUITE-REMEDIATION-v0.99.32.md
+++ b/docs/reports/TEST-SUITE-REMEDIATION-v0.99.32.md
@@ -56,8 +56,32 @@ Both target tests pass under fresh-bytecode direct `raco test` and `scripts/run-
 | Wave | Issue | Status | PR |
 |------|-------|--------|-----|
 | W0 | #8351 | ✅ Done | #8357 |
-| W1 | #8352 | ✅ Done (verified, no code change needed) | — |
-| W2 | #8353 | Todo | — |
+| W1 | #8352 | ✅ Done (verified, no code change needed) | #8358 |
+| W2 | #8353 | ✅ Done | — |
 | W3 | #8354 | Todo | — |
 | W4 | #8355 | Todo | — |
 | W5 | #8356 | Todo | — |
+
+## W2 Verification: Runner Diagnostics + Module-load Fixes (2026-06-19)
+
+### Root Causes Fixed
+
+1. **test-gui-state-sync-w0.rkt** (MODULE_LOAD_FAILURE): File used relative paths `"../gui/main.rkt"` via `with-input-from-file`, which resolve relative to CWD. Runner runs from `q/`, so the path resolved incorrectly. Fix: Added `this-dir` via `current-load-relative-directory` and `build-path` for path resolution. Also added `(module+ test ...)` so runner detects it as rackunit test file.
+
+2. **test-llm-error-visibility.rkt** (MODULE_LOAD_FAILURE): Same relative path issue with `with-input-from-file "../util/error/error-helpers.rkt"`. Same fix applied.
+
+3. **test-loop-edge-cases.rkt** (ASSERTION_FAILURE): `(parameterize ([MAX-STREAM-CHUNKS 100]) ...)` failed because `MAX-STREAM-CHUNKS` was a plain `define`, not a parameter. Production fix: Changed to `(make-parameter 10000)` in `agent/stream-reducer.rkt`, updated call site in `agent/stream-runner.rkt` to `(MAX-STREAM-CHUNKS)`. Also removed duplicate module-level `(run-tests ...)` and added `(module+ test ...)`.
+
+### Runner Diagnostic Enhancement
+
+- Added `output` field to JSON test results in `scripts/run-tests/parse.rkt` — captures truncated stdout/stderr for each test file, enabling better failure diagnosis.
+
+### Verification Results
+
+```
+test-gui-state-sync-w0.rkt:     7/7 PASS under runner subprocess
+test-llm-error-visibility.rkt:  4/4 PASS under runner subprocess
+test-loop-edge-cases.rkt:       6/6 PASS under runner subprocess
+unit-fast:                      10/10 PASS (102 tests)
+build:                          PASS
+```

--- a/scripts/run-tests/parse.rkt
+++ b/scripts/run-tests/parse.rkt
@@ -157,7 +157,9 @@
           'failed
           (test-file-result-failed r)
           'total
-          (test-file-result-total r)))
+          (test-file-result-total r)
+          'output
+          (truncate-test-output (result-output-string r) DEFAULT-OUTPUT-CAP)))
 
 (define FAILURE-START #rx"^-+ FAILURE -+$")
 (define FAILURE-END #rx"^-{20,}$")

--- a/tests/test-gui-state-sync-w0.rkt
+++ b/tests/test-gui-state-sync-w0.rkt
@@ -9,45 +9,54 @@
          "../gui/main.rkt"
          "../gui/state-sync.rkt")
 
+;; Resolve paths relative to this source file, not CWD.
+;; This makes the test work under both `raco test` and `scripts/run-tests.rkt`.
+(define this-dir (or (current-load-relative-directory) (current-directory)))
+
 (define (file-source path)
-  (with-input-from-file path
-    (lambda () (port->string (current-input-port)))))
+  (with-input-from-file (build-path this-dir path) (lambda () (port->string (current-input-port)))))
 
 (define main-src (file-source "../gui/main.rkt"))
 (define sync-src (file-source "../gui/state-sync.rkt"))
 
 (define test-double-event-fix
-  (test-suite
-   "double-event-fix"
-   (test-case "model.stream.completed appears exactly once in state-sync.rkt cond clauses"
-     (define count 0)
-     (let loop ([pos 0])
-       (define found (regexp-match-positions #rx"model[.]stream[.]completed" sync-src pos))
-       (when found
-         (set! count (+ count 1))
-         (loop (cdar found))))
-     ;; Should be exactly 1: the dedicated cond clause
-     (check-equal? count 1))
+  (test-suite "double-event-fix"
+    (test-case "model.stream.completed appears exactly once in state-sync.rkt cond clauses"
+      (define count 0)
+      (let loop ([pos 0])
+        (define found (regexp-match-positions #rx"model[.]stream[.]completed" sync-src pos))
+        (when found
+          (set! count (+ count 1))
+          (loop (cdar found))))
+      ;; Should be exactly 1: the dedicated cond clause
+      (check-equal? count 1))
 
-   (test-case "turn.completed clause does NOT contain model.stream.completed"
-     (check-false (regexp-match? #rx"turn[.]completed.*model[.]stream[.]completed" sync-src)))
+    (test-case "turn.completed clause does NOT contain model.stream.completed"
+      (check-false (regexp-match? #rx"turn[.]completed.*model[.]stream[.]completed" sync-src)))
 
-   (test-case "make-gui-event-subscriber moved out of main.rkt"
-     (check-false (regexp-match? #rx"[(]define [(]make-gui-event-subscriber" main-src)))
+    (test-case "make-gui-event-subscriber moved out of main.rkt"
+      (check-false (regexp-match? #rx"[(]define [(]make-gui-event-subscriber" main-src)))
 
-   (test-case "make-gui-event-subscriber exists in state-sync.rkt"
-     (check-true (regexp-match? #rx"[(]define [(]make-gui-event-subscriber" sync-src)))))
+    (test-case "make-gui-event-subscriber exists in state-sync.rkt"
+      (check-true (regexp-match? #rx"[(]define [(]make-gui-event-subscriber" sync-src)))))
 
 (define test-flatten-extraction
-  (test-suite
-   "flatten-extraction"
-   (test-case "make-notify-gui-callback exists in state-sync.rkt"
-     (check-true (regexp-match? #rx"[(]define [(]make-notify-gui-callback" sync-src)))
+  (test-suite "flatten-extraction"
+    (test-case "make-notify-gui-callback exists in state-sync.rkt"
+      (check-true (regexp-match? #rx"[(]define [(]make-notify-gui-callback" sync-src)))
 
-   (test-case "gui-state-lock exists in state-sync.rkt"
-     (check-true (regexp-match? #rx"[(]define gui-state-lock" sync-src)))
+    (test-case "gui-state-lock exists in state-sync.rkt"
+      (check-true (regexp-match? #rx"[(]define gui-state-lock" sync-src)))
 
-   (test-case "gui/main.rkt requires state-sync.rkt"
-     (check-true (regexp-match? #rx"state-sync[.]rkt\"" main-src)))))
+    (test-case "gui/main.rkt requires state-sync.rkt"
+      (check-true (regexp-match? #rx"state-sync[.]rkt\"" main-src)))))
 
-(run-tests (test-suite "gui-state-sync-w0" test-double-event-fix test-flatten-extraction))
+(module+ test
+  (run-tests (test-suite "gui-state-sync-w0"
+               test-double-event-fix
+               test-flatten-extraction)))
+
+(module+ main
+  (run-tests (test-suite "gui-state-sync-w0"
+               test-double-event-fix
+               test-flatten-extraction)))

--- a/tests/test-llm-error-visibility.rkt
+++ b/tests/test-llm-error-visibility.rkt
@@ -11,6 +11,9 @@
          racket/string
          (only-in "../llm/provider-errors.rkt" provider-error? provider-error-category))
 
+;; Resolve paths relative to this source file, not CWD.
+(define this-dir (or (current-load-relative-directory) (current-directory)))
+
 ;; ── Test Suite ──
 
 (define suite
@@ -44,8 +47,14 @@
 
     ;; Test 4: with-safe-fallback now logs warnings (v0.81.0 W3)
     (test-case "with-safe-fallback logs warnings instead of silent swallow"
-      (define src (with-input-from-file "../util/error/error-helpers.rkt" (lambda () (read-string 10000))))
+      (define src
+        (with-input-from-file (build-path this-dir "../util/error/error-helpers.rkt")
+                              (lambda () (read-string 10000))))
       (check-not-false (string-contains? src "log-warning \"with-safe-fallback caught")
                        "with-safe-fallback should log warnings"))))
 
-(run-tests suite)
+(module+ test
+  (run-tests suite))
+
+(module+ main
+  (run-tests suite))

--- a/tests/test-loop-edge-cases.rkt
+++ b/tests/test-loop-edge-cases.rkt
@@ -100,7 +100,8 @@
       (define evt-names (map event-event evts))
 
       ;; Should complete normally
-      (check-not-false (member "stream.turn.completed" evt-names) "turn.completed emitted on empty stream")
+      (check-not-false (member "stream.turn.completed" evt-names)
+                       "turn.completed emitted on empty stream")
       (check-equal? (loop-result-termination-reason result) 'completed "result status is completed")
       ;; No message events (no text content)
       (check-false (member "message.start" evt-names) "no message.start for empty stream"))
@@ -267,10 +268,13 @@
       ;; No message.start was emitted
       (check-false (member "message.start" evt-names) "no message.start when crash before text")
       ;; But turn.completed should still be emitted as cleanup
-      (check-not-false (member "stream.turn.completed" evt-names) "turn.completed emitted as cleanup"))))
+      (check-not-false (member "stream.turn.completed" evt-names)
+                       "turn.completed emitted as cleanup"))))
+
+(module+ test
+  (run-tests edge-case-tests)
+  (run-tests stream-safety-tests))
 
 (module+ main
   (run-tests edge-case-tests)
   (run-tests stream-safety-tests))
-
-(run-tests edge-case-tests)


### PR DESCRIPTION
## W2: Runner Diagnostics + Module-load Fixes

### Root Causes Fixed

1. **test-gui-state-sync-w0.rkt** (MODULE_LOAD_FAILURE): Relative paths via `with-input-from-file` resolved against CWD instead of source file. Fix: Use `current-load-relative-directory` + add `(module+ test)`.

2. **test-llm-error-visibility.rkt** (MODULE_LOAD_FAILURE): Same relative path issue. Same fix applied.

3. **test-loop-edge-cases.rkt** (ASSERTION_FAILURE): `parameterize` on `MAX-STREAM-CHUNKS` failed — was a plain `define`, not a parameter. Production fix: make it a `make-parameter` in `stream-reducer.rkt`, update call site in `stream-runner.rkt`.

### Runner Diagnostic Enhancement
- Added `output` field to JSON results for stdout/stderr capture

### Verification
```
test-gui-state-sync-w0.rkt:     7/7 PASS
test-llm-error-visibility.rkt:  4/4 PASS
test-loop-edge-cases.rkt:       6/6 PASS
unit-fast:                      10/10 PASS (102 tests)
build:                          PASS
```

Closes #8353