### PR TITLE
W3: Fix non-standard run-tests 'symbol form (#8354)

### DIFF
--- a/docs/reports/TEST-SUITE-REMEDIATION-v0.99.32.md
+++ b/docs/reports/TEST-SUITE-REMEDIATION-v0.99.32.md
@@ -57,8 +57,9 @@ Both target tests pass under fresh-bytecode direct `raco test` and `scripts/run-
 |------|-------|--------|-----|
 | W0 | #8351 | ✅ Done | #8357 |
 | W1 | #8352 | ✅ Done (verified, no code change needed) | #8358 |
-| W2 | #8353 | ✅ Done | — |
-| W3 | #8354 | Todo | — |
+| W2 | #8353 | ✅ Done | #8359 |
+| W3 | #8354 | ✅ Done | — |
+| W4 | #8355 | Todo | — |
 | W4 | #8355 | Todo | — |
 | W5 | #8356 | Todo | — |
 
@@ -85,3 +86,24 @@ test-loop-edge-cases.rkt:       6/6 PASS under runner subprocess
 unit-fast:                      10/10 PASS (102 tests)
 build:                          PASS
 ```
+
+## W3 Verification: Non-standard Test Runner Forms (2026-06-19)
+
+### Root Cause Fixed
+
+Both `test-session-config-helpers.rkt` and `test-struct-mutability.rkt` used `(run-tests 'symbol)` in their `module+ main` — this is a **contract violation** because `run-tests` from `rackunit/text-ui` expects a `test-case?` or `test-suite?`, not a symbol. The runner's subprocess mode executes the `main` submodule, which triggered this violation, producing zero parsed tests.
+
+Fix: Wrapped all module-level `test-case` forms into a `test-suite`, added `rackunit/text-ui` to the require list, and replaced `(run-tests 'symbol)` with `(run-tests suite-name)` in both `(module+ test ...)` and `(module+ main ...)`.
+
+### Verification Results
+
+```
+test-session-config-helpers.rkt:  4/4 PASS under runner subprocess
+test-struct-mutability.rkt:       8/8 PASS under runner subprocess
+unit-fast:                        10/10 PASS (102 tests)
+build:                            PASS
+```
+
+### Sweep
+
+Confirmed only 2 files in the entire test suite used the invalid `(run-tests 'symbol)` form. No other files affected.

--- a/tests/test-session-config-helpers.rkt
+++ b/tests/test-session-config-helpers.rkt
@@ -1,32 +1,39 @@
 #lang racket/base
 
-;; @speed fast  ;; @suite runtime
+;; @speed fast
+;; @suite runtime
 
 ;; test-session-config-helpers.rkt — Tests for session config helpers (T3-2/3/4)
 ;; Part of v0.80.5 Polish Sweep
 
 (require rackunit
+         rackunit/text-ui
          racket/contract
          "../runtime/session/session-config.rkt"
          "../runtime/session/session-types.rkt")
 
-(test-case "session-config: hash->session-config creates config"
-  (define cfg (hash->session-config (hasheq 'model "test-model")))
-  (check-pred session-config? cfg))
+(define session-config-tests
+  (test-suite "session-config-helpers"
 
-(test-case "session-config: round-trip hash conversion"
-  (define h (hasheq 'model "test-model" 'provider 'openai))
-  (define cfg (hash->session-config h))
-  (define h2 (session-config->hash cfg))
-  (check-equal? (hash-ref h2 'model) "test-model"))
+    (test-case "session-config: hash->session-config creates config"
+      (define cfg (hash->session-config (hasheq 'model "test-model")))
+      (check-pred session-config? cfg))
 
-(test-case "session-config: config-model-name accessor works"
-  (define cfg (hash->session-config (hasheq 'model-name "test-model")))
-  (check-equal? (config-model-name cfg) "test-model"))
+    (test-case "session-config: round-trip hash conversion"
+      (define h (hasheq 'model "test-model" 'provider 'openai))
+      (define cfg (hash->session-config h))
+      (define h2 (session-config->hash cfg))
+      (check-equal? (hash-ref h2 'model) "test-model"))
 
-(test-case "agent-session: predicate exists and is a procedure"
-  (check-pred procedure? agent-session?))
+    (test-case "session-config: config-model-name accessor works"
+      (define cfg (hash->session-config (hasheq 'model-name "test-model")))
+      (check-equal? (config-model-name cfg) "test-model"))
+
+    (test-case "agent-session: predicate exists and is a procedure"
+      (check-pred procedure? agent-session?))))
+
+(module+ test
+  (run-tests session-config-tests))
 
 (module+ main
-  (require rackunit/text-ui)
-  (run-tests 'test-session-config-helpers))
+  (run-tests session-config-tests))

--- a/tests/test-struct-mutability.rkt
+++ b/tests/test-struct-mutability.rkt
@@ -7,6 +7,7 @@
 ;; Part of v0.80.5 Polish Sweep
 
 (require rackunit
+         rackunit/text-ui
          racket/contract
          "../agent/streaming-message.rkt")
 
@@ -14,70 +15,75 @@
 ;; T3-1: streaming-message uses #:mutable fields instead of boxes
 ;; ============================================================
 
-(test-case "streaming-message: make-streaming-message returns opaque struct"
-  (define sm (make-streaming-message "test-id-1"))
-  (check-pred streaming-message? sm)
-  (check-equal? (streaming-message-message-id sm) "test-id-1"))
+(define struct-mutability-tests
+  (test-suite "struct-mutability"
 
-(test-case "streaming-message: text accumulation works without boxes"
-  (define sm (make-streaming-message "test-id-2"))
-  (check-equal? (streaming-message-text sm) "")
-  (streaming-message-append-text! sm "hello ")
-  (streaming-message-append-text! sm "world")
-  (check-equal? (streaming-message-text sm) "hello world"))
+    (test-case "streaming-message: make-streaming-message returns opaque struct"
+      (define sm (make-streaming-message "test-id-1"))
+      (check-pred streaming-message? sm)
+      (check-equal? (streaming-message-message-id sm) "test-id-1"))
 
-(test-case "streaming-message: tool-call accumulation works"
-  (define sm (make-streaming-message "test-id-3"))
-  (check-equal? (streaming-message-get-tool-calls sm) '())
-  (streaming-message-append-tool-call! sm (hasheq 'name "read" 'arguments '{}))
-  (streaming-message-append-tool-call! sm (hasheq 'name "write" 'arguments '{}))
-  (define tcs (streaming-message-get-tool-calls sm))
-  (check-equal? (length tcs) 2)
-  ;; Should be in insertion order (reversed internally)
-  (check-equal? (hash-ref (car tcs) 'name) "read")
-  (check-equal? (hash-ref (cadr tcs) 'name) "write"))
+    (test-case "streaming-message: text accumulation works without boxes"
+      (define sm (make-streaming-message "test-id-2"))
+      (check-equal? (streaming-message-text sm) "")
+      (streaming-message-append-text! sm "hello ")
+      (streaming-message-append-text! sm "world")
+      (check-equal? (streaming-message-text sm) "hello world"))
 
-(test-case "streaming-message: thinking accumulation works"
-  (define sm (make-streaming-message "test-id-4"))
-  (check-equal? (streaming-message-thinking sm) "")
-  (streaming-message-append-thinking! sm "hmm")
-  (streaming-message-append-thinking! sm " more")
-  (check-equal? (streaming-message-thinking sm) "hmm more"))
+    (test-case "streaming-message: tool-call accumulation works"
+      (define sm (make-streaming-message "test-id-3"))
+      (check-equal? (streaming-message-get-tool-calls sm) '())
+      (streaming-message-append-tool-call! sm (hasheq 'name "read" 'arguments '{}))
+      (streaming-message-append-tool-call! sm (hasheq 'name "write" 'arguments '{}))
+      (define tcs (streaming-message-get-tool-calls sm))
+      (check-equal? (length tcs) 2)
+      ;; Should be in insertion order (reversed internally)
+      (check-equal? (hash-ref (car tcs) 'name) "read")
+      (check-equal? (hash-ref (cadr tcs) 'name) "write"))
 
-(test-case "streaming-message: FSM state transitions work"
-  (define sm (make-streaming-message "test-id-5"))
-  (check-equal? (streaming-message-fsm-state sm) 'not-started)
-  (streaming-message-set-message-started! sm)
-  (check-equal? (streaming-message-fsm-state sm) 'streaming)
-  (check-true (streaming-message-message-started? sm))
-  (streaming-message-set-blocked! sm)
-  (check-true (streaming-message-blocked? sm))
-  (check-false (streaming-message-cancelled? sm)))
+    (test-case "streaming-message: thinking accumulation works"
+      (define sm (make-streaming-message "test-id-4"))
+      (check-equal? (streaming-message-thinking sm) "")
+      (streaming-message-append-thinking! sm "hmm")
+      (streaming-message-append-thinking! sm " more")
+      (check-equal? (streaming-message-thinking sm) "hmm more"))
 
-(test-case "streaming-message: cancel state works"
-  (define sm (make-streaming-message "test-id-6"))
-  (streaming-message-set-cancelled! sm)
-  (check-true (streaming-message-cancelled? sm))
-  (check-false (streaming-message-blocked? sm)))
+    (test-case "streaming-message: FSM state transitions work"
+      (define sm (make-streaming-message "test-id-5"))
+      (check-equal? (streaming-message-fsm-state sm) 'not-started)
+      (streaming-message-set-message-started! sm)
+      (check-equal? (streaming-message-fsm-state sm) 'streaming)
+      (check-true (streaming-message-message-started? sm))
+      (streaming-message-set-blocked! sm)
+      (check-true (streaming-message-blocked? sm))
+      (check-false (streaming-message-cancelled? sm)))
 
-(test-case "streaming-message: finalize produces message with correct content"
-  (define sm (make-streaming-message "test-id-7"))
-  (streaming-message-append-text! sm "response text")
-  (streaming-message-set-message-started! sm)
-  (define msg (streaming-message-finalize sm))
-  ;; Should return a message struct (opaque, check via message? if available)
-  (check-not-false msg))
+    (test-case "streaming-message: cancel state works"
+      (define sm (make-streaming-message "test-id-6"))
+      (streaming-message-set-cancelled! sm)
+      (check-true (streaming-message-cancelled? sm))
+      (check-false (streaming-message-blocked? sm)))
 
-(test-case "streaming-message: ->hash produces correct snapshot"
-  (define sm (make-streaming-message "test-id-8"))
-  (streaming-message-append-text! sm "hello")
-  (streaming-message-append-tool-call! sm (hasheq 'id "tc1" 'name "read"))
-  (define h (streaming-message->hash sm))
-  (check-equal? (hash-ref h 'text) "hello")
-  (check-equal? (length (hash-ref h 'tool-calls)) 1)
-  (check-false (hash-ref h 'cancelled?))
-  (check-false (hash-ref h 'stream-blocked?)))
+    (test-case "streaming-message: finalize produces message with correct content"
+      (define sm (make-streaming-message "test-id-7"))
+      (streaming-message-append-text! sm "response text")
+      (streaming-message-set-message-started! sm)
+      (define msg (streaming-message-finalize sm))
+      ;; Should return a message struct (opaque, check via message? if available)
+      (check-not-false msg))
+
+    (test-case "streaming-message: ->hash produces correct snapshot"
+      (define sm (make-streaming-message "test-id-8"))
+      (streaming-message-append-text! sm "hello")
+      (streaming-message-append-tool-call! sm (hasheq 'id "tc1" 'name "read"))
+      (define h (streaming-message->hash sm))
+      (check-equal? (hash-ref h 'text) "hello")
+      (check-equal? (length (hash-ref h 'tool-calls)) 1)
+      (check-false (hash-ref h 'cancelled?))
+      (check-false (hash-ref h 'stream-blocked?)))))
+
+(module+ test
+  (run-tests struct-mutability-tests))
 
 (module+ main
-  (require rackunit/text-ui)
-  (run-tests 'test-struct-mutability))
+  (run-tests struct-mutability-tests))


### PR DESCRIPTION
## W3: Non-standard test runner forms fix

### Root Cause
Both `test-session-config-helpers.rkt` and `test-struct-mutability.rkt` used `(run-tests 'symbol)` in `module+ main` — a **contract violation** because `run-tests` from `rackunit/text-ui` expects a `test-case?` or `test-suite?`, not a symbol. The runner's subprocess mode executes the `main` submodule, triggering this violation with zero parsed tests.

### Fix
- Wrapped module-level `test-case` forms into `test-suite`
- Added `rackunit/text-ui` to requires
- Replaced `(run-tests 'symbol)` with `(run-tests suite-name)` in both `(module+ test)` and `(module+ main)`

### Sweep
Confirmed only 2 files in the entire test suite used this invalid form.

### Verification
```
test-session-config-helpers.rkt:  4/4 PASS under runner subprocess
test-struct-mutability.rkt:       8/8 PASS under runner subprocess
unit-fast:                        10/10 PASS (102 tests)
build:                            PASS
```

Closes #8354