### PR TITLE
W1: Correct v0.99.32 report drift, fix broken link, track subprocess deadlock (#8372)

### DIFF
--- a/docs/reports/AUDIT-v0.99.31-FINAL.md
+++ b/docs/reports/AUDIT-v0.99.31-FINAL.md
@@ -8,7 +8,7 @@
 > **CORRECTION (v0.99.32 W0):** An in-depth follow-up audit (2026-06-19) found
 > that while the ledger was mechanically emptied, 7 fast-gate and 6 broad-gate
 > failures remain. The claims below have been annotated with corrections.
-> See `docs/reports/AUDIT-v0.99.31-IN-DEPTH-FOLLOWUP.md` for the full audit.
+> See `.planning/AUDIT-v0.99.31-IN-DEPTH.md` for the full audit.
 
 ## Wave Summary
 

--- a/docs/reports/TECH-DEBT-subprocess-pipe-deadlock.md
+++ b/docs/reports/TECH-DEBT-subprocess-pipe-deadlock.md
@@ -1,0 +1,88 @@
+# Tech Debt: Subprocess Pipe-Buffer Deadlock
+
+**Date**: 2026-06-20  
+**Discovered**: v0.99.32 W5 (#8356, PR #8362)  
+**Severity**: Medium (production impact under large stdout)  
+**Tracking**: v0.99.33 W1 (#8372)
+
+## Problem
+
+`sandbox/subprocess.rkt` `run-subprocess` (lines 260–316) deadlocks when a
+child process writes more than the OS pipe buffer (~64KB on Linux) to stdout
+or stderr before exiting.
+
+### Root Cause
+
+The execution flow is:
+
+1. **Line 260**: `(sync/timeout effective-timeout sp)` — blocks waiting for
+   the subprocess to exit.
+2. **Lines 305–316**: Only *after* the subprocess exits, reads stdout/stderr
+   via `read-available-bounded`.
+
+When the child writes >64KB to stdout, the OS pipe buffer fills. The child
+process blocks on its next `write()` call, waiting for the parent to drain
+the pipe. But the parent is blocked on `sync/timeout` waiting for the child
+to exit. Neither can make progress → **deadlock**.
+
+### Reproduction
+
+```bash
+# Any command producing >64KB of output triggers the deadlock:
+echo "bash tool call with: ls /tmp"  # /tmp on this VPS has ~2634 entries (~81KB)
+```
+
+In v0.99.32 W5, the test `test-spawn-subagent-serialization.rkt` used a mock
+provider that returned a `bash` tool call with command `ls /tmp`. The test
+hung for 120s (runner timeout). The workaround was changing the command to
+`echo done` (9 bytes output).
+
+### Impact
+
+- Any user tool call (`bash`) that produces >64KB of stdout will hang the
+  agent until the subprocess timeout, then return partial output with a
+  timeout error code (-9).
+- This affects real-world usage (e.g., `find / -name '*.log'`, large build
+  output, `cat` on large files).
+
+## Proposed Fix
+
+Drain stdout/stderr **concurrently** with waiting for process exit, instead
+of sequentially. The pattern:
+
+```racket
+;; Spawn a reader thread for stdout and stderr BEFORE syncing on process exit
+(define stdout-ch (make-channel))
+(define stderr-ch (make-channel))
+(thread (λ () (channel-put stdout-ch (read-available-bounded stdout-in max-output))))
+(thread (λ () (channel-put stderr-ch (read-available-bounded stderr-in max-output))))
+
+;; Now wait for process exit — the reader threads can drain pipes concurrently
+(define evt-result (sync/timeout effective-timeout sp))
+
+;; Collect output from channels
+(define out-str (channel-get stdout-ch))
+(define err-str (channel-get stderr-ch))
+```
+
+Alternatively, use `sync` on multiple events (process + ports) to drain as
+data becomes available.
+
+### Considerations
+
+- `read-available-bounded` uses `port-try-peek?` (non-blocking), so a thread
+  wrapping it needs to poll or use `sync` on the port.
+- Must handle the case where the subprocess exits quickly (readers may get
+  empty reads if ports are closed by custodian shutdown).
+- Timeout path must also cancel/kill reader threads.
+
+## Workaround (Applied in v0.99.32 W5)
+
+Changed the test mock command from `ls /tmp` (81KB) to `echo done` (9 bytes).
+This avoids the deadlock for the test but does **not** fix the production bug.
+
+## Related Issues
+
+- v0.99.32 W5 (#8356, PR #8362) — discovered and worked around in test
+- v0.99.33 W1 (#8372) — this tracking report
+- `sandbox/subprocess.rkt:255-316` — the buggy code path

--- a/docs/reports/VERIFICATION-v0.99.32-FINAL.md
+++ b/docs/reports/VERIFICATION-v0.99.32-FINAL.md
@@ -1,12 +1,40 @@
 # v0.99.32 Final Verification Report
 
+> **⚠️ SUPERSEDED — v0.99.33 (#819) Corrective Note (2026-06-20):**
+>
+> This report was found to contain a material error. It claimed **"All 9 files
+> that failed at the v0.99.31 audit baseline now pass"**, specifically listing
+> `test-doctor.rkt` as passing (17/17 ✅). However, the v0.99.32 W1
+> verification that "confirmed" test-doctor.rkt passing was running with
+> stale bytecode from a previous version — when fresh bytecode was built,
+> `test-doctor.rkt` still failed with:
+> ```
+> lookup-credential: contract violation
+>   expected: string?
+>   given: 'local
+>   blaming: interfaces/doctor.rkt
+> ```
+>
+> The actual pass count for the focused 9-file set at v0.99.32 close was
+> **8/9**, not 9/9. The `test-doctor.rkt` failure was fixed in v0.99.33 W0
+> (#8371, PR #8374) by normalizing symbol provider names to strings before
+> calling `lookup-credential`.
+>
+> Additionally, the broad gate was never actually run (marked ⏩ SKIPPED),
+> meaning the claim of "no new/unclassified failures" was unverifiable.
+> The report below is preserved for historical reference only.
+
 **Date**: 2026-06-19  
 **Milestone**: #818 (v0.99.32 — v0.99.31 Audit Remediation)  
-**Branch**: `feature/wave-8356` (W5 — Final Verification)
+**Branch**: `feature/wave-8356` (W5 — Final Verification)  
+**Status**: ⚠️ SUPERSEDED by v0.99.33
 
 ## Summary
 
-All 6 waves (W0–W5) of the v0.99.32 audit remediation milestone are complete. Every previously-failing test file now passes under the test runner.
+All 6 waves (W0–W5) of the v0.99.32 audit remediation milestone are complete. ~~Every previously-failing test file now passes under the test runner.~~
+
+> **v0.99.33 correction**: 8/9 files passed. `test-doctor.rkt` was falsely
+> marked as passing due to stale bytecode. See v0.99.33 W0 (#8371) for the fix.
 
 ## Gate Results
 
@@ -24,7 +52,7 @@ All 9 files that failed at the v0.99.31 audit baseline now pass:
 
 | File | Wave | Root Cause | Fix | Tests |
 |------|------|------------|-----|-------|
-| `test-doctor.rkt` | W1 (#8352) | Stale bytecode | No code change needed — already fixed | ✅ |
+| `test-doctor.rkt` | W1 (#8352) | Stale bytecode | ⚠️ **FALSE POSITIVE** — stale bytecode masked a live contract bug. Fixed in v0.99.33 W0 (#8371). | ❌→✅ (v0.99.33) |
 | `test-tool-edit-builtin.rkt` | W1 (#8352) | Stale bytecode | No code change needed — already fixed | ✅ |
 | `test-gui-state-sync-w0.rkt` | W2 (#8353) | Relative path via CWD | `current-load-relative-directory` + `(module+ test)` | 7/7 ✅ |
 | `test-llm-error-visibility.rkt` | W2 (#8353) | Relative path via CWD | Same fix | 4/4 ✅ |


### PR DESCRIPTION
## W1: Report/Link Corrections + Subprocess Deadlock Tracking

Three documentation corrections — no code changes.

### 1. VERIFICATION-v0.99.32-FINAL.md — Supersession Correction
- Added ⚠️ SUPERSEDED banner at top
- Noted that `test-doctor.rkt` was falsely marked as passing (17/17 ✅) — stale bytecode masked a live `lookup-credential` contract bug
- Actual pass count for the focused 9-file set was **8/9**, not 9/9
- Fixed in v0.99.33 W0 (#8371, PR #8374)
- Noted broad gate was never actually run (marked ⏩ SKIPPED)

### 2. AUDIT-v0.99.31-FINAL.md — Broken Link Fix
- Line 11 referenced `docs/reports/AUDIT-v0.99.31-IN-DEPTH-FOLLOWUP.md` — file never existed
- Changed to `.planning/AUDIT-v0.99.31-IN-DEPTH.md` (matching the correct reference already at line 56)

### 3. TECH-DEBT-subprocess-pipe-deadlock.md — New Report
- Documents the `sandbox/subprocess.rkt` pipe-buffer deadlock discovered in v0.99.32 W5
- Root cause: `run-subprocess` waits for process exit (`sync/timeout`) BEFORE reading stdout — when output >64KB, OS pipe buffer fills and both processes block
- Includes reproduction, impact analysis, and proposed fix (concurrent reader threads)

Closes #8372