### PR TITLE
fix: stabilize tool edit no-match tests (#8378)

### DIFF
--- a/tests/test-tool-edit-builtin.rkt
+++ b/tests/test-tool-edit-builtin.rkt
@@ -90,7 +90,12 @@
          (check-pred tool-result? result)
          (check-true (tool-result-is-error? result))
          (define txt (error-text result))
-         (check-true (string-contains? txt "0")))
+         (check-true (string-contains? txt "0"))
+         (check-equal? (file->string p) "hello world\n"))
        (lambda () (cleanup-path p))))))
 
-(run-tests edit-suite)
+(module+ test
+  (run-tests edit-suite))
+
+(module+ main
+  (run-tests edit-suite))

--- a/tools/builtins/edit.rkt
+++ b/tools/builtins/edit.rkt
@@ -190,9 +190,10 @@
       [_ ""]))
   (match line-num
     [#f
-     (string-append (format "old-text not found in ~a. Read the file first to get exact text.\n"
-                            path-str)
-                    hint)]
+     (string-append
+      (format "old-text not found in ~a (appears 0 times). Read the file first to get exact text.\n"
+              path-str)
+      hint)]
     [_
      (string-append
       (format "old-text not found in ~a.\nNearest match at line ~a:\n  \"" path-str line-num)
@@ -214,7 +215,9 @@
                       expanded
                       (path->string expanded))])
            (with-handlers ([exn:fail? (lambda (e)
-                                        (log-warning "edit: path canonicalization failed for ~a: ~a" p (exn-message e))
+                                        (log-warning "edit: path canonicalization failed for ~a: ~a"
+                                                     p
+                                                     (exn-message e))
                                         p)])
              (path->string (simplify-path (resolve-path p)))))))
   ;; Argument validation via match — flattened pyramid


### PR DESCRIPTION
## Summary
- Make edit no-match error text include both legacy `not found` wording and explicit `0 times` count.
- Convert `tests/test-tool-edit-builtin.rkt` to standard `module+ test` / `module+ main` execution.
- Add unchanged-file assertion for no-match behavior.

## Verification
- `raco test tests/test-tool-edit-builtin.rkt` PASS
- `raco test tests/test-tool-edit.rkt` PASS
- `raco test tests/test-file-tools.rkt` PASS
- `raco test tests/workflows/tools/test-tool-edit-workflow.rkt` PASS
- 20x direct `raco test tests/test-tool-edit-builtin.rkt` PASS
- 10x runner `tests/test-tool-edit-builtin.rkt` PASS
- focused 9-file target set PASS: 9/9, 63/63
- fresh `raco make main.rkt` PASS
- fast local PASS: 948/948, 12873/12873
- broad local ledger PASS: 1040/1040, Known=0 New=0 Unclassified=0 Release-blocking=0

Closes #8378