### PR TITLE
fix: drain subprocess output concurrently (#8379)

### DIFF
--- a/docs/reports/TECH-DEBT-subprocess-pipe-deadlock.md
+++ b/docs/reports/TECH-DEBT-subprocess-pipe-deadlock.md
@@ -3,7 +3,8 @@
 **Date**: 2026-06-20  
 **Discovered**: v0.99.32 W5 (#8356, PR #8362)  
 **Severity**: Medium (production impact under large stdout)  
-**Tracking**: v0.99.33 W1 (#8372)
+**Tracking**: v0.99.33 W1 (#8372); fixed in v0.99.34 W1 (#8379, PR pending)
+**Status**: Fixed in v0.99.34 W1 — `run-subprocess` now starts bounded stdout/stderr drain readers before waiting for process exit.
 
 ## Problem
 
@@ -45,7 +46,17 @@ hung for 120s (runner timeout). The workaround was changing the command to
 - This affects real-world usage (e.g., `find / -name '*.log'`, large build
   output, `cat` on large files).
 
-## Proposed Fix
+## Fix Implemented in v0.99.34 W1
+
+`run-subprocess` now starts bounded stdout/stderr reader threads immediately after subprocess launch and before `(sync/timeout effective-timeout sp)`. The readers store at most the configured byte budget while continuing to drain excess output so child processes do not block on full OS pipes. On timeout, the subprocess is killed and the latest reader snapshots are returned with the timeout error.
+
+Regression coverage was added in `tests/test-subprocess-edge-cases.rkt`:
+
+- large stdout (`yes x | head -c 200000`) completes without timeout and is marked truncated;
+- large stderr (`yes e | head -c 200000 >&2`) completes without timeout and is marked truncated;
+- existing timeout partial-output behavior remains covered.
+
+## Original Proposed Fix
 
 Drain stdout/stderr **concurrently** with waiting for process exit, instead
 of sequentially. The pattern:
@@ -78,11 +89,14 @@ data becomes available.
 
 ## Workaround (Applied in v0.99.32 W5)
 
+**Superseded by v0.99.34 W1 fix.** The workaround below is retained as historical context.
+
 Changed the test mock command from `ls /tmp` (81KB) to `echo done` (9 bytes).
 This avoids the deadlock for the test but does **not** fix the production bug.
 
 ## Related Issues
 
 - v0.99.32 W5 (#8356, PR #8362) — discovered and worked around in test
-- v0.99.33 W1 (#8372) — this tracking report
-- `sandbox/subprocess.rkt:255-316` — the buggy code path
+- v0.99.33 W1 (#8372) — tracking report introduced
+- v0.99.34 W1 (#8379) — production fix and regression coverage
+- `sandbox/subprocess.rkt` — fixed code path starts drain readers before waiting for process exit

--- a/sandbox/subprocess.rkt
+++ b/sandbox/subprocess.rkt
@@ -93,28 +93,58 @@
         (get-output-string acc))))
 
 (define (read-port-bounded p max-bytes)
-  (if (or (not p) (port-closed? p))
-      ""
-      (let loop ([acc (open-output-bytes)]
-                 [remaining max-bytes])
-        (define buf-size (min 4096 remaining))
-        (if (<= remaining 0)
-            ;; Output hit the byte budget — drain rest and mark truncated
-            ;; Discard remainder past byte budget; port may already be
-            ;; closed by custodian, so silently swallow errors.
-            (begin
+  (define-values (reader get-result) (start-bounded-reader p max-bytes "read-port-bounded"))
+  (sync reader)
+  (define-values (text truncated?) (get-result))
+  (if truncated?
+      (string-append text (format "\n[output truncated at ~a bytes]" max-bytes))
+      text))
+
+;; Start a reader thread immediately after subprocess launch.  This prevents a
+;; child that writes more than the OS pipe buffer from blocking forever while
+;; the parent is still waiting for process exit.  The reader stores at most
+;; max-bytes and drains the remainder so the child can finish; callers can ask
+;; for the latest captured value even if timeout cleanup interrupts the thread.
+(define (start-bounded-reader p max-bytes label)
+  (define acc (open-output-bytes))
+  (define lock (make-semaphore 1))
+  (define truncated? #f)
+  (define (record-bytes! bs [start 0] [end (bytes-length bs)])
+    (call-with-semaphore lock (lambda () (write-bytes bs acc start end))))
+  (define (mark-truncated!)
+    (call-with-semaphore lock (lambda () (set! truncated? #t))))
+  (define (snapshot)
+    (call-with-semaphore lock
+                         (lambda ()
+                           (values (bytes->string/utf-8 (get-output-bytes acc) #\uFFFD) truncated?))))
+  (define reader
+    (thread (lambda ()
               (with-handlers ([exn:fail? (lambda (e)
-                                           (log-subprocess-warning "read-port-bounded discard: ~a"
-                                                                   (exn-message e)))])
-                (copy-port p (open-output-bytes))) ; discard remainder
-              (string-append (get-output-string acc)
-                             (format "\n[output truncated at ~a bytes]" max-bytes)))
-            (let ([bs (read-bytes buf-size p)])
-              (cond
-                [(eof-object? bs) (get-output-string acc)]
-                [else
-                 (write-bytes bs acc)
-                 (loop acc (- remaining (bytes-length bs)))]))))))
+                                           (log-subprocess-warning "~a: ~a" label (exn-message e)))])
+                (unless (or (not p) (port-closed? p))
+                  (define buf (make-bytes 4096))
+                  (let loop ([remaining max-bytes])
+                    (sync p)
+                    (cond
+                      [(> remaining 0)
+                       (define n (read-bytes-avail! buf p))
+                       (cond
+                         [(eof-object? n) (void)]
+                         [(number? n)
+                          (define to-record (min n remaining))
+                          (record-bytes! buf 0 to-record)
+                          (when (> n remaining)
+                            (mark-truncated!))
+                          (loop (- remaining to-record))]
+                         [else (void)])]
+                      [else
+                       ;; Budget exhausted.  Keep draining to EOF without storing so
+                       ;; the child is not blocked by a full pipe.
+                       (mark-truncated!)
+                       (define n (read-bytes-avail! buf p))
+                       (unless (eof-object? n)
+                         (loop 0))])))))))
+  (values reader snapshot))
 
 ;; --------------------------------------------------
 ;; Kill helper
@@ -256,8 +286,27 @@
             ;; (previously used /bin/sh -c which was vulnerable to injection)
             (apply subprocess #f #f #f cmd-path args))))
 
-    ;; Close stdin immediately
+    ;; Close stdin immediately and start output drainers before waiting for the
+    ;; child.  Waiting first can deadlock when child output fills the OS pipe.
     (close-output-port stdin-out)
+    (define-values (stdout-reader get-stdout) (start-bounded-reader stdout-in max-output "stdout"))
+    (define-values (stderr-reader get-stderr) (start-bounded-reader stderr-in max-output "stderr"))
+
+    (define (reader-results)
+      (define-values (out-str out-truncated?) (get-stdout))
+      (define-values (err-str err-truncated?) (get-stderr))
+      (values out-str err-str (or out-truncated? err-truncated?)))
+
+    (define (finish-reader! reader port label)
+      (unless (sync/timeout 1 reader)
+        ;; A backgrounded grandchild can inherit stdout/stderr after the direct
+        ;; subprocess exits.  Close our read end instead of waiting forever for
+        ;; an EOF that may not arrive until the grandchild exits.
+        (with-handlers ([exn:fail?
+                         (lambda (e)
+                           (log-subprocess-warning "close inherited ~a: ~a" label (exn-message e)))])
+          (close-input-port port))
+        (sync/timeout 0.25 reader)))
 
     ;; Wait with timeout
     (define evt-result (sync/timeout effective-timeout sp))
@@ -265,24 +314,17 @@
     (cond
       ;; Timeout
       [(not evt-result)
-       ;; Collect partial output BEFORE killing — ports are still readable
-       ;; Collect partial output before killing; ports may be closed
-       ;; by the OS if the process already exited.
-       (define partial-out
-         (with-handlers ([exn:fail? (lambda (e)
-                                      (log-subprocess-warning "partial stdout: ~a" (exn-message e))
-                                      "")])
-           (read-available-bounded stdout-in max-output)))
-       (define partial-err
-         (with-handlers ([exn:fail? (lambda (e)
-                                      (log-subprocess-warning "partial stderr: ~a" (exn-message e))
-                                      "")])
-           (read-available-bounded stderr-in max-output)))
        ;; Kill the subprocess explicitly before shutting custodian.
        ;; May fail if process already dead.
        (with-handlers ([exn:fail? (lambda (e)
                                     (log-subprocess-warning "subprocess-kill: ~a" (exn-message e)))])
          (subprocess-kill sp))
+       ;; Give reader threads a bounded chance to observe EOF and flush their
+       ;; latest snapshots.  If they do not finish, snapshot still returns the
+       ;; latest captured bytes.
+       (sync/timeout 1 stdout-reader)
+       (sync/timeout 1 stderr-reader)
+       (define-values (partial-out partial-err partial-truncated?) (reader-results))
        (define end-ms (current-inexact-milliseconds))
        (custodian-shutdown-all cust)
        (subprocess-result
@@ -294,29 +336,18 @@
                  effective-timeout))
         #t
         (inexact->exact (round (- end-ms start-ms)))
-        #f)] ; truncated? — partial read, not byte-budget truncation
+        partial-truncated?)]
 
       ;; Completed
-      ;; BUGFIX: Use read-available-bounded (non-blocking) instead of
-      ;; read-port-bounded (blocking) because a backgrounded child process
-      ;; may have inherited the pipe — blocking read-bytes would hang forever
-      ;; waiting for EOF that never comes. Since the subprocess already exited,
-      ;; all its output is available in the pipe buffer.
       [else
-       (define out-str
-         (with-handlers ([exn:fail? (lambda (e)
-                                      (log-subprocess-warning "completed stdout: ~a" (exn-message e))
-                                      "")])
-           (read-available-bounded stdout-in max-output)))
-       (define err-str
-         (with-handlers ([exn:fail? (lambda (e)
-                                      (log-subprocess-warning "completed stderr: ~a" (exn-message e))
-                                      "")])
-           (read-available-bounded stderr-in max-output)))
+       ;; Process exited; readers should finish after draining stdout/stderr.
+       ;; Bound the join to preserve the background-child inherited-pipe fix.
+       (finish-reader! stdout-reader stdout-in "stdout")
+       (finish-reader! stderr-reader stderr-in "stderr")
+       (define-values (out-str err-str output-truncated?) (reader-results))
        (define exit-code (subprocess-status sp))
-       (define out-truncated? (string-contains? out-str "[output truncated at"))
 
-       ;; Close ports; may already be closed by custodian shutdown.
+       ;; Close ports; may already be closed by EOF/custodian shutdown.
        (with-handlers ([exn:fail? (lambda (e)
                                     (log-subprocess-warning "close stdout: ~a" (exn-message e)))])
          (close-input-port stdout-in))
@@ -331,4 +362,4 @@
                           err-str
                           #f
                           (inexact->exact (round (- end-ms start-ms)))
-                          out-truncated?)])))
+                          output-truncated?)])))

--- a/tests/test-subprocess-edge-cases.rkt
+++ b/tests/test-subprocess-edge-cases.rkt
@@ -123,7 +123,32 @@
       (check-not-false (regexp-match? #rx"stdout-msg" (subprocess-result-stdout result))
                        "stdout contains stdout-msg")
       (check-not-false (regexp-match? #rx"stderr-msg" (subprocess-result-stderr result))
-                       "stderr contains stderr-msg"))))
+                       "stderr contains stderr-msg"))
+
+    ;; ============================================================
+    ;; SP7: child output larger than pipe buffer must not deadlock
+    ;; ============================================================
+    (test-case "SP7: large stdout larger than pipe buffer completes without timeout"
+      (define result
+        (run-subprocess "/bin/sh"
+                        #:args '("-c" "yes x | head -c 200000")
+                        #:limits (fast-limits #:timeout 5 #:max-output 4096)))
+      (check-equal? (subprocess-result-exit-code result) 0 "large stdout command succeeds")
+      (check-false (subprocess-result-timed-out? result) "large stdout does not deadlock")
+      (check-true (subprocess-result-truncated? result) "large stdout is marked truncated")
+      (check-true (<= (string-length (subprocess-result-stdout result)) 4096)
+                  "large stdout is capped at the byte budget"))
+
+    (test-case "SP7: large stderr larger than pipe buffer completes without timeout"
+      (define result
+        (run-subprocess "/bin/sh"
+                        #:args '("-c" "yes e | head -c 200000 >&2")
+                        #:limits (fast-limits #:timeout 5 #:max-output 4096)))
+      (check-equal? (subprocess-result-exit-code result) 0 "large stderr command succeeds")
+      (check-false (subprocess-result-timed-out? result) "large stderr does not deadlock")
+      (check-true (subprocess-result-truncated? result) "large stderr is marked truncated")
+      (check-true (<= (string-length (subprocess-result-stderr result)) 4096)
+                  "large stderr is capped at the byte budget"))))
 
 (module+ main
   (run-tests subprocess-edge-tests))


### PR DESCRIPTION
## Summary
- Start bounded stdout/stderr reader threads before waiting for subprocess exit to avoid pipe-buffer deadlock.
- Preserve background-child inherited-pipe behavior with bounded reader joins after direct process exit.
- Add large stdout and large stderr regression coverage in `tests/test-subprocess-edge-cases.rkt`.
- Update subprocess pipe-buffer tech-debt report to mark the debt fixed in v0.99.34 W1.

## Verification
- `raco test tests/test-bash-background-child.rkt` PASS: 2/2
- `raco test tests/test-subprocess-edge-cases.rkt` PASS: 8/8
- `raco test tests/test-subprocess.rkt` PASS: 22/22
- runner focused subprocess/background set PASS: 3/3 files, 32/32 tests
- fresh `raco make main.rkt` PASS
- fast local PASS: 948/948 files, 12873/12873 tests
- broad local ledger PASS: 1040/1040 files, 13801/13801 tests, Known=0 New=0 Unclassified=0 Release-blocking=0

Closes #8379