### PR TITLE
docs: correct ledger and audit truth reports (#8380)

### DIFF
--- a/docs/reports/AUDIT-v0.99.33-POST-REMEDIATION.md
+++ b/docs/reports/AUDIT-v0.99.33-POST-REMEDIATION.md
@@ -1,5 +1,23 @@
 # v0.99.33 Post-Remediation Audit Report
 
+> **Correction addendum — v0.99.34 W2 (2026-06-20)**
+>
+> This report is retained as the original v0.99.33 post-remediation report, but
+> its broad/focused conclusions were too broad for release-gate truthfulness.
+> A later independent v0.99.33 audit reran the gates from fresh bytecode and
+> found:
+>
+> - local fast PASS: `948/948 files`, `12873/12873 tests`;
+> - local broad ledger PASS: `1040/1040 files`, `13799/13799 tests`,
+>   `Known=0`, `New=0`, `Unclassified=0`, `Release-blocking=0`;
+> - focused 9-file set FAIL due intermittent
+>   `tests/test-tool-edit-builtin.rkt` (`8/9 files`, `62/63 tests`).
+>
+> Therefore the original focused 9-file PASS and universal broad PASS wording
+> below should be read as wave-local evidence only, not as final independent
+> release-gate approval. v0.99.34 W0 fixed the edit-builtin focused/direct flake
+> and v0.99.34 W1 fixed the subprocess pipe-drain production debt.
+
 **Date**: 2026-06-19  
 **Milestone**: #819 (v0.99.33 — v0.99.32 Audit Remediation)  
 **Wave**: W2 (#8373)  
@@ -171,18 +189,20 @@ The broad gate = fast suite (948 files, all PASS) + 92 slow-only files.
 
 ## Conclusion
 
-All required gates pass:
+Original wave-local conclusion, superseded in part by the v0.99.34 W2 correction addendum:
+
 - **Build**: ✅ PASS
 - **Unit-fast**: ✅ PASS (10/10 files, 102/102 tests)
 - **Smoke**: ✅ PASS (19/19 files, 286/286 tests)
-- **Focused 9-file**: ✅ PASS (9/9 files, 63/63 tests)
-- **Fast**: ✅ PASS (948/948 files, 12,866/12,866 tests)
-- **Broad**: ✅ PASS (1038/1040 files; 2 VPS-performance timeouts documented)
-- **Ledger**: Known=0, New=0, Unclassified=0, Release-blocking=0
+- **Focused 9-file**: ⚠️ Superseded — this report observed PASS, but independent v0.99.33 audit later reproduced an intermittent `tests/test-tool-edit-builtin.rkt` failure. Fixed in v0.99.34 W0.
+- **Fast**: ✅ PASS locally in later independent audit (948/948 files, 12,873/12,873 tests)
+- **Broad ledger**: ✅ PASS locally in later independent audit (1040/1040 files, 13,799/13,799 tests; Known=0, New=0, Unclassified=0, Release-blocking=0)
+- **VPS slow-only broad observations**: environment-specific and not universal broad PASS evidence.
 
-The v0.99.33 milestone successfully closes the v0.99.32 audit findings:
+The v0.99.33 milestone closed or tracked the v0.99.32 audit findings as follows:
 1. Doctor credential contract violation — **fixed** (W0)
 2. v0.99.32 final report false positive — **corrected** (W1)
-3. Subprocess pipe-buffer deadlock — **tracked as tech debt** (W1)
+3. Subprocess pipe-buffer deadlock — **tracked as tech debt in v0.99.33 W1; fixed in v0.99.34 W1**
 4. Playwright test misclassification — **fixed** (W2)
 5. README metrics drift — **fixed** (W2)
+6. Edit-builtin direct/focused flake — **discovered by later independent audit; fixed in v0.99.34 W0**

--- a/docs/reports/TECH-DEBT-subprocess-pipe-deadlock.md
+++ b/docs/reports/TECH-DEBT-subprocess-pipe-deadlock.md
@@ -3,7 +3,7 @@
 **Date**: 2026-06-20  
 **Discovered**: v0.99.32 W5 (#8356, PR #8362)  
 **Severity**: Medium (production impact under large stdout)  
-**Tracking**: v0.99.33 W1 (#8372); fixed in v0.99.34 W1 (#8379, PR pending)
+**Tracking**: v0.99.33 W1 (#8372); fixed in v0.99.34 W1 (#8379, PR #8383)
 **Status**: Fixed in v0.99.34 W1 — `run-subprocess` now starts bounded stdout/stderr drain readers before waiting for process exit.
 
 ## Problem

--- a/docs/reports/TEST-SUITE-LEDGER.md
+++ b/docs/reports/TEST-SUITE-LEDGER.md
@@ -1,5 +1,23 @@
 # TEST-SUITE LEDGER — v0.99.30 W5
 
+> **Current status addendum — v0.99.34 W2 (2026-06-20)**
+>
+> This file is historical. It documents how the v0.99.30 W5 known-failure
+> ledger was created and how debt was retired in later waves. It is **not** the
+> current source of known failures.
+>
+> The current machine-readable ledger is `tests/test-suite-ledger.json`; as of
+> `main@d2565bc8` it contains `"entries": []`. Fresh v0.99.34 W1 local gates
+> confirmed:
+>
+> - fast local: `948/948 files`, `12873/12873 tests`, PASS;
+> - broad local with ledger: `1040/1040 files`, `13801/13801 tests`, PASS;
+> - ledger summary: `Known=0`, `New=0`, `Unclassified=0`, `Release-blocking=0`.
+>
+> Historical entries below must not be read as active known failures. If broad
+> failures reappear, update `tests/test-suite-ledger.json` and add a new dated
+> report/addendum with command evidence.
+
 This report documents the initial known-failure ledger for broad-suite debt.
 
 ## Source evidence
@@ -166,7 +184,7 @@ W7 (#8315) resolved a bounded deterministic batch from the broad ledger:
 - `tests/test-gap5-conclusion-bridge.rkt`
 - `tests/test-util-reclassification.rkt`
 
-The entries remain in `tests/test-suite-ledger.json` as historical known failures with `issue: "#8315"`; when these files pass, the runner reports them under `Resolved known failures` rather than known/new/unclassified failures.
+At W7 time, the entries remained in `tests/test-suite-ledger.json` as historical known failures with `issue: "#8315"`; when these files passed, the runner reported them under `Resolved known failures` rather than known/new/unclassified failures. This is now historical: the current ledger has no active entries.
 
 W7 also fixed the strict zero-parsed sentinel for `tests/test-benchmarks.rkt` by adding an explicit RackUnit text-ui runner. Focused runner verification:
 


### PR DESCRIPTION
## Summary
- Add a v0.99.34 W2 top addendum to `TEST-SUITE-LEDGER.md` clarifying that the markdown ledger is historical and the current JSON ledger has no active entries.
- Add a correction banner and superseded conclusion wording to `AUDIT-v0.99.33-POST-REMEDIATION.md` so the focused 9-file flake and environment-specific broad evidence are reported truthfully.
- Update the subprocess pipe-deadlock report to reference merged PR #8383 instead of “PR pending”.

## Verification
- Text sanity check: no stale `PR pending`, `All required gates pass:`, or active-ledger phrasing remains in the edited report targets.
- Required W2 fast gate PASS: `racket scripts/run-tests.rkt --suite fast --profile local` — 948/948 files, 12873/12873 tests, 0 failures, 0 timeouts.

Closes #8380