### PR TITLE
fix: address v0.99.34 audit follow-ups (#8386)

### DIFF
--- a/docs/reports/AUDIT-v0.99.34-POST-REMEDIATION.md
+++ b/docs/reports/AUDIT-v0.99.34-POST-REMEDIATION.md
@@ -24,7 +24,7 @@ v0.99.34 closed the remaining post-v0.99.33 test/release-gate debt:
 | W0 | #8378 | #8382 | `996b14e8` | Fixed edit-builtin no-match/direct flake while preserving existing `not found` wording and explicit `0 times` count. |
 | W1 | #8379 | #8383 | `d2565bc8` | Fixed subprocess pipe-buffer deadlock by draining stdout/stderr concurrently with bounded reader threads; preserved background-child inherited-pipe behavior. |
 | W2 | #8380 | #8384 | `9c1cfbc1` | Corrected stale ledger and v0.99.33 audit-report truth claims; marked ledger markdown historical and current JSON ledger empty. |
-| W3 | #8381 | pending at report creation | this report | Ran final gates and recorded exact local evidence. |
+| W3 | #8381 | #8385 | `b709f7ee` | Ran final gates and recorded exact local evidence. |
 
 ## Final gate results from W3
 

--- a/docs/reports/TEST-SUITE-LEDGER-CURRENT.md
+++ b/docs/reports/TEST-SUITE-LEDGER-CURRENT.md
@@ -1,0 +1,42 @@
+# TEST-SUITE LEDGER — Current Status
+
+**Date:** 2026-06-20  
+**Status source:** `tests/test-suite-ledger.json`  
+**Audited commit:** `main@b709f7ee`  
+**Profile:** `local`
+
+## Current status
+
+The active known-failure ledger is empty:
+
+```json
+{"entries": []}
+```
+
+Fresh v0.99.34 in-depth audit verification confirmed:
+
+```text
+Fast local:          948/948 files, 12873/12873 tests, PASS
+Broad local ledger:  1040/1040 files, 13801/13801 tests, PASS
+Known failures:      0
+New failures:        0
+Unclassified:        0
+Resolved known:      0
+Release-blocking:    0
+```
+
+## Source of truth
+
+- Current machine-readable ledger: `tests/test-suite-ledger.json`
+- Historical creation/retirement report: `docs/reports/TEST-SUITE-LEDGER.md`
+- v0.99.34 final audit: `docs/reports/AUDIT-v0.99.34-POST-REMEDIATION.md`
+- In-depth planning audit: `.planning/AUDIT-v0.99.34-IN-DEPTH.md`
+
+## Update policy
+
+If a broad-suite failure reappears:
+
+1. Do not mark the run green if failures are known or ledgered; known failures remain visible.
+2. Classify failures in `tests/test-suite-ledger.json` only after triage.
+3. Report exact command evidence, profile/environment, and ledger summary.
+4. Keep `New=0`, `Unclassified=0`, and `Release-blocking=0` as the local release-gate requirement.

--- a/docs/reports/TEST-SUITE-LEDGER.md
+++ b/docs/reports/TEST-SUITE-LEDGER.md
@@ -4,7 +4,8 @@
 >
 > This file is historical. It documents how the v0.99.30 W5 known-failure
 > ledger was created and how debt was retired in later waves. It is **not** the
-> current source of known failures.
+> current source of known failures. For the short current-status page, see
+> `docs/reports/TEST-SUITE-LEDGER-CURRENT.md`.
 >
 > The current machine-readable ledger is `tests/test-suite-ledger.json`; as of
 > `main@d2565bc8` it contains `"entries": []`. Fresh v0.99.34 W1 local gates

--- a/sandbox/subprocess.rkt
+++ b/sandbox/subprocess.rkt
@@ -138,12 +138,16 @@
                           (loop (- remaining to-record))]
                          [else (void)])]
                       [else
-                       ;; Budget exhausted.  Keep draining to EOF without storing so
-                       ;; the child is not blocked by a full pipe.
-                       (mark-truncated!)
+                       ;; Budget exhausted.  Keep draining only if there is actually
+                       ;; another byte beyond the budget.  If the next read is EOF,
+                       ;; output was exactly max-bytes and is not truncated.
                        (define n (read-bytes-avail! buf p))
-                       (unless (eof-object? n)
-                         (loop 0))])))))))
+                       (cond
+                         [(eof-object? n) (void)]
+                         [(number? n)
+                          (mark-truncated!)
+                          (loop 0)]
+                         [else (void)])])))))))
   (values reader snapshot))
 
 ;; --------------------------------------------------

--- a/tests/test-subprocess-edge-cases.rkt
+++ b/tests/test-subprocess-edge-cases.rkt
@@ -148,7 +148,21 @@
       (check-false (subprocess-result-timed-out? result) "large stderr does not deadlock")
       (check-true (subprocess-result-truncated? result) "large stderr is marked truncated")
       (check-true (<= (string-length (subprocess-result-stderr result)) 4096)
-                  "large stderr is capped at the byte budget"))))
+                  "large stderr is capped at the byte budget"))
+
+    ;; ============================================================
+    ;; SP8: exact byte-budget output is not truncation
+    ;; ============================================================
+    (test-case "SP8: exact max-output stdout is not marked truncated"
+      (define result
+        (run-subprocess "/bin/sh"
+                        #:args '("-c" "printf '%*s' 4096 '' | tr ' ' x")
+                        #:limits (fast-limits #:timeout 5 #:max-output 4096)))
+      (check-equal? (subprocess-result-exit-code result) 0 "exact-budget command succeeds")
+      (check-false (subprocess-result-timed-out? result) "exact-budget command does not time out")
+      (check-equal? (string-length (subprocess-result-stdout result)) 4096)
+      (check-false (subprocess-result-truncated? result)
+                   "exactly max-output bytes is not truncation"))))
 
 (module+ main
   (run-tests subprocess-edge-tests))

--- a/tests/test-tool-edit-builtin.rkt
+++ b/tests/test-tool-edit-builtin.rkt
@@ -90,7 +90,7 @@
          (check-pred tool-result? result)
          (check-true (tool-result-is-error? result))
          (define txt (error-text result))
-         (check-true (string-contains? txt "0"))
+         (check-true (string-contains? txt "appears 0 times"))
          (check-equal? (file->string p) "hello world\n"))
        (lambda () (cleanup-path p))))))
 


### PR DESCRIPTION
## Summary
- Strengthen edit no-match regression to require `appears 0 times`.
- Add exact max-output subprocess regression and adjust reader truncation semantics so exact-budget output is not flagged truncated unless bytes beyond the budget are observed.
- Refresh the v0.99.34 final audit W3 row with PR #8385 and `b709f7ee`.
- Add `TEST-SUITE-LEDGER-CURRENT.md` as the short current-status page and point the historical ledger report to it.

## Verification
- `raco test tests/test-tool-edit-builtin.rkt`: 7/7 PASS
- `raco test tests/test-subprocess-edge-cases.rkt`: 9/9 PASS
- `raco test tests/test-subprocess.rkt`: 22/22 PASS
- `raco test tests/test-bash-background-child.rkt`: 2/2 PASS
- fresh `raco make main.rkt`: PASS
- focused runner: 4/4 files, 40/40 tests PASS
- required fast local: 948/948 files, 12873/12873 tests PASS
- broad local ledger: 1040/1040 files, 13802/13802 tests PASS; Known=0, New=0, Unclassified=0, Release-blocking=0

Closes #8386