### PR TITLE
W2: Spawn-subagent adapter boundary pilot (#8391)

### DIFF
--- a/tests/test-spawn-subagent-helpers.rkt
+++ b/tests/test-spawn-subagent-helpers.rkt
@@ -1,0 +1,121 @@
+#lang racket
+
+;; @speed fast
+;; @suite fast
+
+;; W2 v0.99.35: Tests for spawn-subagent-helpers.rkt
+;; Verifies pure functions extracted from spawn-subagent.rkt:
+;; - normalize-capabilities (deduplicated capability parsing)
+;; - requires-hitl-approval? (pure capability check)
+;; - extract-assistant-text (pure message-to-text extraction)
+;; - extract-text-summary (pure text truncation)
+
+(require rackunit
+         rackunit/text-ui
+         racket/string
+         racket/list
+         racket/runtime-path)
+
+(require (only-in "../tools/builtins/spawn-subagent-helpers.rkt"
+                  normalize-capabilities
+                  requires-hitl-approval?
+                  extract-assistant-text
+                  extract-text-summary
+                  SUBAGENT-SUMMARY-MAX-CHARS))
+
+(require (only-in "../util/message/message.rkt" make-message message-role message-content)
+         (only-in "../util/content/content-parts.rkt"
+                  make-tool-call-part
+                  make-tool-result-part
+                  text-part?))
+
+(define-test-suite
+ normalize-capabilities-tests
+ (test-case "normalize-capabilities: #f input → #f"
+   (check-false (normalize-capabilities #f)))
+ (test-case "normalize-capabilities: empty list → #f"
+   (check-false (normalize-capabilities '())))
+ (test-case "normalize-capabilities: string → list of one symbol"
+   (check-equal? (normalize-capabilities "read-only") '(read-only)))
+ (test-case "normalize-capabilities: list of strings → list of symbols"
+   (check-equal? (normalize-capabilities '("read-only" "file-write")) '(read-only file-write)))
+ (test-case "normalize-capabilities: list of symbols → filtered list"
+   (check-equal? (normalize-capabilities '(read-only file-write)) '(read-only file-write)))
+ (test-case "normalize-capabilities: filters invalid capabilities"
+   (check-equal? (normalize-capabilities '("read-only" "bogus")) '(read-only)))
+ (test-case "normalize-capabilities: all-invalid → #f"
+   (check-false (normalize-capabilities '("bogus" "also-bogus"))))
+ (test-case "normalize-capabilities: mixed strings and symbols"
+   (check-equal? (normalize-capabilities '("read-only" shell-exec)) '(read-only shell-exec))))
+
+(define-test-suite requires-hitl-approval-tests
+                   (test-case "#t for shell-exec"
+                     (check-true (and (requires-hitl-approval? '(shell-exec)) #t)))
+                   (test-case "#t for git-write"
+                     (check-true (and (requires-hitl-approval? '(git-write)) #t)))
+                   (test-case "#t for mixed with shell-exec"
+                     (check-true (and (requires-hitl-approval? '(read-only shell-exec)) #t)))
+                   (test-case "#f for read-only only"
+                     (check-false (requires-hitl-approval? '(read-only))))
+                   (test-case "#f for file-write only"
+                     (check-false (requires-hitl-approval? '(file-write))))
+                   (test-case "#f for #f"
+                     (check-false (requires-hitl-approval? #f)))
+                   (test-case "#f for empty list"
+                     (check-false (requires-hitl-approval? '()))))
+
+(define-test-suite
+ extract-assistant-text-tests
+ (test-case "empty message list → empty string"
+   (check-equal? (extract-assistant-text '()) ""))
+ (test-case "extracts text from assistant message with string content"
+   (define msg (make-message 'id1 #f 'assistant 'message '("Hello world") 0 (hasheq)))
+   (check-equal? (extract-assistant-text (list msg)) "Hello world"))
+ (test-case "ignores non-assistant messages"
+   (define sys (make-message 'id0 #f 'system 'message '("system prompt") 0 (hasheq)))
+   (define asst (make-message 'id1 #f 'assistant 'message '("result text") 0 (hasheq)))
+   (check-equal? (extract-assistant-text (list sys asst)) "result text"))
+ (test-case "joins multiple assistant messages with newline"
+   (define m1 (make-message 'id1 #f 'assistant 'message '("first") 0 (hasheq)))
+   (define m2 (make-message 'id2 #f 'assistant 'message '("second") 0 (hasheq)))
+   (check-equal? (extract-assistant-text (list m1 m2)) "first\nsecond"))
+ (test-case "summarizes tool-call-only messages"
+   (define m1
+     (make-message 'id1
+                   #f
+                   'assistant
+                   'message
+                   (list (make-tool-call-part "tc1" "read" "{}"))
+                   0
+                   (hasheq)))
+   (check-true (string-contains? (extract-assistant-text (list m1)) "read"))))
+
+(define-test-suite
+ extract-text-summary-tests
+ (test-case "constant is 4000"
+   (check-equal? SUBAGENT-SUMMARY-MAX-CHARS 4000))
+ (test-case "short content passes through"
+   (check-equal? (extract-text-summary (list (hasheq 'type "text" 'text "hello"))) "hello"))
+ (test-case "long content is truncated with ellipsis"
+   (define long-text (make-string 5000 #\X))
+   (define result (extract-text-summary (list (hasheq 'type "text" 'text long-text))))
+   (check-true (>= (string-length result) 3997) "truncated content is substantial")
+   (check-true (string-suffix? result "...") "ends with ellipsis"))
+ (test-case "empty content → empty string"
+   (check-equal? (extract-text-summary '()) "")))
+
+;; ============================================================
+;; Run all tests
+;; ============================================================
+
+(define-test-suite all-spawn-subagent-helpers-tests
+                   normalize-capabilities-tests
+                   requires-hitl-approval-tests
+                   extract-assistant-text-tests
+                   extract-text-summary-tests)
+
+(module+ test
+  (run-tests all-spawn-subagent-helpers-tests))
+
+(module+ main
+  (run-tests all-spawn-subagent-helpers-tests))

--- a/tools/builtins/spawn-subagent-helpers.rkt
+++ b/tools/builtins/spawn-subagent-helpers.rkt
@@ -1,0 +1,139 @@
+#lang racket/base
+
+;; tools/builtins/spawn-subagent-helpers.rkt — Pure functions for spawn-subagent
+;;
+;; W2 v0.99.35: Extracted from spawn-subagent.rkt to create a clean boundary
+;; between pure request/result normalization and effectful process orchestration.
+;;
+;; All functions in this module are pure (no I/O, no mutation, no parameters).
+;; They can be tested in isolation without mocking providers or event buses.
+;;
+;; Boundary contract:
+;;   INPUTS:  Plain data (hashes, lists, strings, symbols, message structs)
+;;   OUTPUTS: Plain data (strings, lists of symbols, normalized hashes)
+;;   EFFECTS: None — safe to call from any context
+
+(require racket/string
+         racket/list
+         (only-in "../../util/capability.rkt" valid-capability?)
+         (only-in "../../util/message/message.rkt" make-message message-role message-content)
+         (only-in "../../util/content/content-parts.rkt"
+                  text-part?
+                  text-part-text
+                  tool-call-part?
+                  tool-call-part-name))
+
+(provide normalize-capabilities
+         requires-hitl-approval?
+         extract-assistant-text
+         extract-text-summary
+         SUBAGENT-SUMMARY-MAX-CHARS)
+
+;; ============================================================
+;; Capability normalization
+;; ============================================================
+
+;; Normalize raw capability input to a validated list of symbols, or #f.
+;;
+;; Accepts: #f, '(), a single string/symbol, or a list of strings/symbols.
+;; Returns: #f when no valid capabilities remain, or a list of symbols.
+;;
+;; This deduplicates the logic previously inlined in both:
+;;   - parse-subagent-config (spawn-subagent.rkt)
+;;   - parse-job-capabilities (spawn-subagent.rkt)
+(define (normalize-capabilities caps-raw)
+  (cond
+    [(not caps-raw) #f]
+    [(null? caps-raw) #f]
+    [(string? caps-raw)
+     (define sym (string->symbol caps-raw))
+     (if (valid-capability? sym)
+         (list sym)
+         #f)]
+    [(list? caps-raw)
+     (define filtered
+       (filter valid-capability?
+               (map (lambda (c)
+                      (if (string? c)
+                          (string->symbol c)
+                          c))
+                    caps-raw)))
+     (if (null? filtered) #f filtered)]
+    [else #f]))
+
+;; ============================================================
+;; HITL approval check
+;; ============================================================
+
+;; Check if subagent capabilities require HITL approval.
+;; Returns #t when capabilities include shell-exec or git-write.
+;; Returns #f for #f, '(), or read-only/file-write-only capabilities.
+(define (requires-hitl-approval? capabilities)
+  (and (list? capabilities)
+       (pair? capabilities)
+       (or (memq 'shell-exec capabilities) (memq 'git-write capabilities))))
+
+;; ============================================================
+;; Result text extraction
+;; ============================================================
+
+;; Extract text content from assistant messages in a message list.
+;;
+;; For each assistant message:
+;;   - String content → the string
+;;   - List content → extract strings and text-parts, join with \n
+;;   - Tool-call-only messages → summarize tool names as [called: tool1, tool2]
+;;
+;; Non-assistant messages (system, user, tool) are skipped.
+;; Multiple assistant messages are joined with \n.
+(define (extract-assistant-text messages)
+  (string-join (for/list ([m (in-list messages)]
+                          #:when (eq? (message-role m) 'assistant))
+                 (define content (message-content m))
+                 (cond
+                   [(string? content) content]
+                   [(list? content)
+                    (define strings-only
+                      (for/list ([c (in-list content)]
+                                 #:when (string? c))
+                        c))
+                    (define text-parts
+                      (for/list ([c (in-list content)]
+                                 #:when (text-part? c))
+                        (text-part-text c)))
+                    (define tool-parts
+                      (for/list ([c (in-list content)]
+                                 #:when (tool-call-part? c))
+                        (tool-call-part-name c)))
+                    (define all-text (append strings-only text-parts))
+                    (cond
+                      [(pair? all-text) (string-join all-text "\n")]
+                      [(pair? tool-parts) (format "[called: ~a]" (string-join tool-parts ", "))]
+                      [else ""])]
+                   [else (format "~a" content)]))
+               "\n"))
+
+;; ============================================================
+;; Text summary truncation
+;; ============================================================
+
+;; Maximum characters in subagent result summaries.
+;; Bug fix: Raised from 200→4000 chars — the old 200-char limit destroyed
+;; nearly all useful content from subagent tasks.
+(define SUBAGENT-SUMMARY-MAX-CHARS 4000)
+
+;; Extract a text summary from tool result content.
+;; Truncates to max-chars characters with ellipsis.
+(define (extract-text-summary content [max-chars SUBAGENT-SUMMARY-MAX-CHARS])
+  (define full-text
+    (string-join (for/list ([c (in-list (if (list? content)
+                                            content
+                                            '()))])
+                   (cond
+                     [(and (hash? c) (hash-ref c 'text #f)) (hash-ref c 'text "")]
+                     [(string? c) c]
+                     [else ""]))
+                 "\n"))
+  (if (> (string-length full-text) max-chars)
+      (string-append (substring full-text 0 (- max-chars 3)) "...")
+      full-text))

--- a/tools/builtins/spawn-subagent.rkt
+++ b/tools/builtins/spawn-subagent.rkt
@@ -61,7 +61,9 @@
          ;; v0.99.21 §4.3: Blackboard context injection for subagents
          (only-in "../../runtime/context-assembly/blackboard-context.rkt"
                   build-blackboard-context-snippet)
-         (only-in "../../agent/blackboard.rkt" current-blackboard))
+         (only-in "../../agent/blackboard.rkt" current-blackboard)
+         ;; W2 v0.99.35: Pure helpers extracted for testability
+         "spawn-subagent-helpers.rkt")
 
 (provide (contract-out [resolve-role-prompt (-> (or/c string? #f) string?)]
                        [parse-subagent-config (-> any/c subagent-config?)])
@@ -91,7 +93,11 @@
          current-spawn-approval-result
          run-subagent-with-config
          ;; v0.99.23 §5.1: Session-wide agent pool limit
-         current-agent-pool-limit)
+         current-agent-pool-limit
+         ;; W2 v0.99.35: Re-export pure helpers for backward compat
+         normalize-capabilities
+         extract-assistant-text
+         extract-text-summary)
 
 ;; Subagent configuration struct — replaces ad-hoc hash extraction
 ;; v0.99.21 §4.2: Added capabilities field (6th, default #f for backward compat)
@@ -122,13 +128,8 @@
 ;; Tests can parameterize this to #f to simulate denial.
 (define current-spawn-approval-result (make-parameter #t))
 
-;; v0.99.23 §5.3: Check if subagent spawn requires HITL approval.
-;; Returns #t when capabilities include shell-exec or git-write.
-;; Returns #f for #f, '(), or read-only capabilities.
-(define (requires-hitl-approval? capabilities)
-  (and (list? capabilities)
-       (pair? capabilities)
-       (or (memq 'shell-exec capabilities) (memq 'git-write capabilities))))
+;; W2 v0.99.35: requires-hitl-approval? moved to spawn-subagent-helpers.rkt
+;; (pure function — no I/O, no mutation)
 
 ;; v0.99.23 §5.3: Request HITL approval via exec-ctx event system.
 ;; Returns #t when approved, #f when denied.
@@ -183,26 +184,15 @@
 
 ;; Parse subagent-config from tool call args hash.
 ;; v0.99.21 §4.2: Added capabilities parsing.
+;; W2 v0.99.35: Uses normalize-capabilities from helpers for deduplicated parsing.
 (define (parse-subagent-config args)
-  (define caps-raw (hash-ref args 'capabilities #f))
-  (define caps
-    (cond
-      [(not caps-raw) #f]
-      [(list? caps-raw)
-       (filter valid-capability?
-               (map (lambda (c)
-                      (if (string? c)
-                          (string->symbol c)
-                          c))
-                    caps-raw))]
-      [(string? caps-raw) (list (string->symbol caps-raw))]
-      [else #f]))
+  (define caps (normalize-capabilities (hash-ref args 'capabilities #f)))
   (subagent-config (hash-ref args 'task #f)
                    (resolve-role-prompt (hash-ref args 'role default-role-prompt))
                    (hash-ref args 'max-turns 10)
                    (hash-ref args 'tools #f)
                    (hash-ref args 'model #f)
-                   (and caps (pair? caps) caps)))
+                   caps))
 
 ;; Execute subagent using typed config struct.
 ;; v0.99.23 §5.3: HITL approval gate for dangerous capabilities.
@@ -451,39 +441,9 @@
     (define-values (result-messages final-status)
       (run-subagent-loop provider registry (list system-msg user-msg) child-ctx max-turns))
 
-    ;; Extract final text from result — ONLY text content, not tool-call-parts.
-    ;; Bug fix: (format "~a" content) on mixed lists containing tool-call-part
-    ;; structs produces #hasheq() / #(struct:...) garbage that the parent LLM
-    ;; cannot parse. Extract string items + text-parts from content.
-    ;; When no text is present (tool-call-only message), summarize tool names.
-    (define result-text
-      (string-join (for/list ([m (in-list result-messages)]
-                              #:when (eq? (message-role m) 'assistant))
-                     (define content (message-content m))
-                     (cond
-                       [(string? content) content]
-                       [(list? content)
-                        (define strings-only
-                          (for/list ([c (in-list content)]
-                                     #:when (string? c))
-                            c))
-                        (define text-parts
-                          (for/list ([c (in-list content)]
-                                     #:when (text-part? c))
-                            (text-part-text c)))
-                        (define tool-parts
-                          (for/list ([c (in-list content)]
-                                     #:when (tool-call-part? c))
-                            (tool-call-part-name c)))
-                        (define all-text (append strings-only text-parts))
-                        (cond
-                          [(pair? all-text) (string-join all-text "\n")]
-                          ;; No text — summarize what tools were called
-                          [(pair? tool-parts) (format "[called: ~a]" (string-join tool-parts ", "))]
-                          [else ""])]
-                       [else (format "~a" content)]))
-                   "\n"))
-
+    ;; W2 v0.99.35: Extract assistant text via pure helper.
+    ;; Previously inline — logic now in spawn-subagent-helpers.rkt.
+    (define result-text (extract-assistant-text result-messages))
     (make-success-result
      (list (hasheq 'type "text" 'text result-text))
      (hasheq 'turns-used max-turns 'status (symbol->string final-status) 'session-id session-id))))
@@ -624,22 +584,10 @@
 ;; ============================================================
 
 ;; v0.99.22 A-2: Parse capabilities from a job hash (for batch spawn path).
-;; Mirrors the capability parsing in parse-subagent-config.
+;; W2 v0.99.35: Now delegates to normalize-capabilities from helpers.
 ;; Returns #f when no valid capabilities, or a list of symbols.
 (define (parse-job-capabilities job)
-  (define caps-raw (hash-ref job 'capabilities #f))
-  (cond
-    [(not caps-raw) #f]
-    [(list? caps-raw)
-     (define filtered
-       (filter valid-capability?
-               (map (lambda (c)
-                      (if (string? c)
-                          (string->symbol c)
-                          c))
-                    caps-raw)))
-     (if (null? filtered) #f filtered)]
-    [else #f]))
+  (normalize-capabilities (hash-ref job 'capabilities #f)))
 
 ;; Run a single job and return (cons job-id result) or (cons job-id error)
 (define (run-single-job job provider parent-ctx)
@@ -741,24 +689,8 @@
                                     'jobs
                                     job-results)))]))
 
-;; Extract a text summary from tool result content.
-;; Bug fix: Raised from 200→4000 chars — the old 200-char limit destroyed
-;; nearly all useful content from subagent tasks.
-(define SUBAGENT-SUMMARY-MAX-CHARS 4000)
-
-(define (extract-text-summary content [max-chars SUBAGENT-SUMMARY-MAX-CHARS])
-  (define full-text
-    (string-join (for/list ([c (in-list (if (list? content)
-                                            content
-                                            '()))])
-                   (cond
-                     [(and (hash? c) (hash-ref c 'text #f)) (hash-ref c 'text "")]
-                     [(string? c) c]
-                     [else ""]))
-                 "\n"))
-  (if (> (string-length full-text) max-chars)
-      (string-append (substring full-text 0 (- max-chars 3)) "...")
-      full-text))
+;; W2 v0.99.35: extract-text-summary and SUBAGENT-SUMMARY-MAX-CHARS
+;; moved to spawn-subagent-helpers.rkt (pure functions).
 
 ;; Run jobs in parallel with bounded concurrency using threads + channel
 (define (run-jobs-parallel jobs provider exec-ctx max-parallel)


### PR DESCRIPTION
## W2 — Spawn-subagent Adapter Boundary Pilot

### Goal
Extract pure functions from spawn-subagent.rkt to create a clean boundary between pure request/result normalization and effectful process orchestration.

### Changes
**New: `tools/builtins/spawn-subagent-helpers.rkt`** (139 lines)
- `normalize-capabilities` — deduplicated capability parsing (was inlined in 2 places)
- `requires-hitl-approval?` — pure capability check
- `extract-assistant-text` — pure message-to-text extraction (was 30+ lines inline)
- `extract-text-summary` — pure text truncation
- `SUBAGENT-SUMMARY-MAX-CHARS` — constant

**Modified: `tools/builtins/spawn-subagent.rkt`** (809 → 741 lines, -68)
- Imports helpers, re-exports for backward compatibility
- `parse-subagent-config`: 20 → 8 lines (uses `normalize-capabilities`)
- `parse-job-capabilities`: 13 → 3 lines (uses `normalize-capabilities`)
- `run-subagent`: 33 lines inline extraction → 1 line call

**New: `tests/test-spawn-subagent-helpers.rkt`** (24 tests)
- Tests all 4 extracted functions with edge cases

### Boundary Contract
All helpers are pure: no I/O, no mutation, no parameters. Safe to call from any context.

### Verification
- Build: PASS
- Unit-fast: 10/10 files, 102/102 tests PASS
- Smoke: 19/19 files, 286/286 tests PASS
- Related: 57 spawn-related tests PASS (approval, capability, serialization, helpers, config, integration, results)

Closes #8391