### PR TITLE
W3: Subprocess result-boundary consolidation (#8392)

### DIFF
--- a/sandbox/subprocess-helpers.rkt
+++ b/sandbox/subprocess-helpers.rkt
@@ -1,0 +1,152 @@
+#lang racket/base
+
+;; sandbox/subprocess-helpers.rkt — Pure result-boundary helpers
+;;
+;; W3 v0.99.35: Extracted from subprocess.rkt to create a clean boundary
+;; between pure result construction/classification and effectful subprocess
+;; management (process spawning, port reading, custodian cleanup).
+;;
+;; All functions in this module are pure (no I/O, no mutation, no parameters).
+;; They can be tested in isolation without spawning real subprocesses.
+;;
+;; Boundary contract:
+;;   INPUTS:  Plain data (strings, integers, booleans, regex patterns)
+;;   OUTPUTS: Plain data (subprocess-result struct, strings, booleans)
+;;   EFFECTS: None — safe to call from any context
+
+(require racket/format
+         racket/string)
+
+;; Struct (re-exported by subprocess.rkt for backward compat)
+(provide subprocess-result
+         subprocess-result?
+         subprocess-result-exit-code
+         subprocess-result-stdout
+         subprocess-result-stderr
+         subprocess-result-timed-out?
+         subprocess-result-elapsed-ms
+         subprocess-result-truncated?
+         ;; Exit code constants
+         EXIT-CODE-TIMEOUT
+         EXIT-CODE-ERROR
+         ;; Pure result constructors
+         make-error-result
+         make-timeout-result
+         make-success-result
+         ;; Pure result classifiers
+         exit-success?
+         exit-timeout?
+         exit-error?
+         ;; Pure message formatters
+         format-timeout-message
+         format-truncation-message
+         ;; Secret detection (pure — takes explicit args, no parameters)
+         secret-patterns
+         SECRET-IMPLICIT-ALLOWLIST
+         check-secret-var?)
+
+;; ============================================================
+;; Result struct
+;; ============================================================
+
+(struct subprocess-result
+        (exit-code ; integer
+         stdout ; string
+         stderr ; string
+         timed-out? ; boolean
+         elapsed-ms ; number
+         truncated?) ; boolean — output was cut at byte budget
+  #:transparent)
+
+;; ============================================================
+;; Exit code constants
+;; ============================================================
+
+;; Exit code used when a subprocess is killed due to timeout.
+(define EXIT-CODE-TIMEOUT -9)
+
+;; Exit code used when subprocess execution failed (e.g., command not found).
+(define EXIT-CODE-ERROR -1)
+
+;; ============================================================
+;; Pure result constructors
+;; ============================================================
+
+;; Construct an execution-error result (e.g., command not found, exec failure).
+(define (make-error-result message elapsed-ms)
+  (subprocess-result EXIT-CODE-ERROR "" message #f elapsed-ms #f))
+
+;; Construct a timeout result with partial output captured before the kill.
+;; Appends the timeout system message to partial stderr.
+(define (make-timeout-result stdout stderr timeout-secs elapsed-ms truncated?)
+  (subprocess-result EXIT-CODE-TIMEOUT
+                     stdout
+                     (string-append stderr (format-timeout-message timeout-secs))
+                     #t
+                     elapsed-ms
+                     truncated?))
+
+;; Construct a normal completion result.
+(define (make-success-result exit-code stdout stderr elapsed-ms truncated?)
+  (subprocess-result exit-code stdout stderr #f elapsed-ms truncated?))
+
+;; ============================================================
+;; Pure result classifiers
+;; ============================================================
+
+(define (exit-success? exit-code)
+  (eqv? exit-code 0))
+(define (exit-timeout? exit-code)
+  (eqv? exit-code EXIT-CODE-TIMEOUT))
+(define (exit-error? exit-code)
+  (eqv? exit-code EXIT-CODE-ERROR))
+
+;; ============================================================
+;; Pure message formatters
+;; ============================================================
+
+(define (format-timeout-message timeout-secs)
+  (format "\n[SYS] Command timed out after ~a seconds. Partial output shown above." timeout-secs))
+
+(define (format-truncation-message max-bytes)
+  (format "\n[output truncated at ~a bytes]" max-bytes))
+
+;; ============================================================
+;; Secret environment variable detection (pure — no parameters)
+;; ============================================================
+
+;; Patterns that indicate sensitive env vars.
+(define secret-patterns
+  (list #rx"(?i:API.?KEY)"
+        #rx"(?i:SECRET)"
+        #rx"(?i:TOKEN)"
+        #rx"(?i:PASSWORD)"
+        #rx"(?i:CREDENTIAL)"
+        #rx"(?i:^AUTH$|^AUTH_|_AUTH_)"
+        #rx"(?i:GH_PAT)"
+        #rx"(?i:_PAT$)"))
+
+;; Built-in implicit allowlist: well-known non-secret env vars that should
+;; never be scrubbed even if they partially match a secret pattern.
+(define SECRET-IMPLICIT-ALLOWLIST '("XAUTHORITY" "GPG_AUTH_INFO" "AUTHOR" "GPG_TTY" "SSH_AUTH_SOCK"))
+
+;; Pure secret detection — given a variable name, extra denylist patterns,
+;; and an allowlist, determine if the variable should be scrubbed.
+;;
+;; Priority: implicit-allowlist > user-allowlist > (default-patterns + extra-denylist)
+;;
+;; This is the pure core of secret-env-var? in subprocess.rkt. That function
+;; wraps this with parameter reads for current-secret-scrub-denylist and
+;; current-secret-scrub-allowlist.
+(define (check-secret-var? name extra-denylist extra-allowlist)
+  (cond
+    ;; 1. Implicit allowlist — always safe
+    [(member name SECRET-IMPLICIT-ALLOWLIST) #f]
+    ;; 2. User allowlist — explicitly allowed
+    [(for/or ([pat (in-list extra-allowlist)])
+       (regexp-match? pat name))
+     #f]
+    ;; 3. Default patterns + extra denylist
+    [else
+     (for/or ([pat (in-list (append secret-patterns extra-denylist))])
+       (regexp-match? pat name))]))

--- a/sandbox/subprocess.rkt
+++ b/sandbox/subprocess.rkt
@@ -11,11 +11,13 @@
          racket/string
          "limits.rkt"
          ;; SEC-16 (v0.22.0): consolidated shell-quote
-         (only-in "../util/shell-quote.rkt" shell-quote))
+         (only-in "../util/shell-quote.rkt" shell-quote)
+         ;; W3 v0.99.35: Pure result-boundary helpers
+         "subprocess-helpers.rkt")
 
 (define-logger subprocess)
 
-;; Struct accessors (no contract needed for transparent struct)
+;; Struct accessors (re-exported from subprocess-helpers.rkt)
 (provide subprocess-result
          subprocess-result?
          subprocess-result-exit-code
@@ -24,6 +26,14 @@
          subprocess-result-timed-out?
          subprocess-result-elapsed-ms
          subprocess-result-truncated?
+         ;; W3 v0.99.35: Pure result-boundary helpers (re-exported)
+         ;; Note: make-error-result/make-success-result NOT re-exported here
+         ;; to avoid conflict with tool.rkt's exports of the same names.
+         exit-success?
+         exit-timeout?
+         exit-error?
+         EXIT-CODE-TIMEOUT
+         EXIT-CODE-ERROR
          ;; Parameters (no contract needed)
          default-timeout-seconds
          default-max-output-bytes
@@ -43,18 +53,8 @@
                        [sanitize-env (->* () (any/c) any/c)]
                        [secret-env-var? (-> string? boolean?)]))
 
-;; --------------------------------------------------
-;; Result struct
-;; --------------------------------------------------
-
-(struct subprocess-result
-        (exit-code ; integer
-         stdout ; string
-         stderr ; string
-         timed-out? ; boolean
-         elapsed-ms ; number
-         truncated?) ; boolean — output was cut at byte budget
-  #:transparent)
+;; W3 v0.99.35: subprocess-result struct moved to subprocess-helpers.rkt.
+;; All struct exports above are re-exported from there.
 
 ;; --------------------------------------------------
 ;; Bounded port reader — reads incrementally with a byte budget
@@ -178,20 +178,8 @@
 ;; Environment sanitization — strip sensitive env vars
 ;; --------------------------------------------------
 
-;; Patterns that indicate sensitive env vars
-(define secret-patterns
-  (list #rx"(?i:API.?KEY)"
-        #rx"(?i:SECRET)"
-        #rx"(?i:TOKEN)"
-        #rx"(?i:PASSWORD)"
-        #rx"(?i:CREDENTIAL)"
-        #rx"(?i:^AUTH$|^AUTH_|_AUTH_)"
-        #rx"(?i:GH_PAT)"
-        #rx"(?i:_PAT$)"))
-
-;; Built-in implicit allowlist: well-known non-secret env vars that should
-;; never be scrubbed even if they partially match a secret pattern.
-(define SECRET-IMPLICIT-ALLOWLIST '("XAUTHORITY" "GPG_AUTH_INFO" "AUTHOR" "GPG_TTY" "SSH_AUTH_SOCK"))
+;; W3 v0.99.35: secret-patterns and SECRET-IMPLICIT-ALLOWLIST moved to
+;; subprocess-helpers.rkt. secret-env-var? delegates to check-secret-var?.
 
 ;; ── RA-2 (v0.24.7): Configurable secret scrubbing ──
 ;; Extra denylist: additional regex patterns to scrub (extends secret-patterns).
@@ -205,21 +193,7 @@
     (if (bytes? name)
         (bytes->string/utf-8 name)
         name))
-  ;; Check implicit allowlist first — well-known non-secret vars
-  (cond
-    [(member name-str SECRET-IMPLICIT-ALLOWLIST) #f]
-    [else
-     ;; Check user allowlist — if matched, never scrub
-     (define allowed?
-       (for/or ([pat (in-list (current-secret-scrub-allowlist))])
-         (regexp-match? pat name-str)))
-     (cond
-       [allowed? #f]
-       [else
-        ;; Check default patterns + extra denylist
-        (define all-patterns (append secret-patterns (current-secret-scrub-denylist)))
-        (for/or ([pat (in-list all-patterns)])
-          (regexp-match? pat name-str))])]))
+  (check-secret-var? name-str (current-secret-scrub-denylist) (current-secret-scrub-allowlist)))
 
 (define (sanitize-env [env (current-environment-variables)])
   (define clean (make-environment-variables))
@@ -261,13 +235,10 @@
 
   (with-handlers ([exn:fail? (lambda (e)
                                (custodian-shutdown-all cust)
-                               (subprocess-result
-                                -1
-                                ""
+                               (make-error-result
                                 (format "Failed to execute: ~a" (exn-message e))
-                                #f
-                                (inexact->exact (round (- (current-inexact-milliseconds) start-ms)))
-                                #f))])
+                                (inexact->exact (round (- (current-inexact-milliseconds)
+                                                          start-ms)))))])
 
     (define cmd-path (resolve-command command))
     (unless cmd-path
@@ -331,16 +302,11 @@
        (define-values (partial-out partial-err partial-truncated?) (reader-results))
        (define end-ms (current-inexact-milliseconds))
        (custodian-shutdown-all cust)
-       (subprocess-result
-        -9
-        partial-out
-        (string-append
-         partial-err
-         (format "\n[SYS] Command timed out after ~a seconds. Partial output shown above."
-                 effective-timeout))
-        #t
-        (inexact->exact (round (- end-ms start-ms)))
-        partial-truncated?)]
+       (make-timeout-result partial-out
+                            partial-err
+                            effective-timeout
+                            (inexact->exact (round (- end-ms start-ms)))
+                            partial-truncated?)]
 
       ;; Completed
       [else
@@ -361,9 +327,8 @@
        (custodian-shutdown-all cust)
 
        (define end-ms (current-inexact-milliseconds))
-       (subprocess-result exit-code
-                          out-str
-                          err-str
-                          #f
-                          (inexact->exact (round (- end-ms start-ms)))
-                          output-truncated?)])))
+       (make-success-result exit-code
+                            out-str
+                            err-str
+                            (inexact->exact (round (- end-ms start-ms)))
+                            output-truncated?)])))

--- a/tests/test-subprocess-helpers.rkt
+++ b/tests/test-subprocess-helpers.rkt
@@ -1,0 +1,148 @@
+#lang racket
+
+;; @speed fast
+;; @suite fast
+
+;; W3 v0.99.35: Tests for subprocess-helpers.rkt
+;; Pure result-boundary functions extracted from subprocess.rkt:
+;; - Result struct + constructors (make-error-result, make-timeout-result, make-success-result)
+;; - Exit code classifiers (exit-success?, exit-timeout?, exit-error?)
+;; - Message formatters (format-timeout-message, format-truncation-message)
+;; - Secret detection (check-secret-var?, secret-patterns, SECRET-IMPLICIT-ALLOWLIST)
+
+(require rackunit
+         rackunit/text-ui)
+
+(require (only-in "../sandbox/subprocess-helpers.rkt"
+                  subprocess-result
+                  subprocess-result?
+                  subprocess-result-exit-code
+                  subprocess-result-stdout
+                  subprocess-result-stderr
+                  subprocess-result-timed-out?
+                  subprocess-result-elapsed-ms
+                  subprocess-result-truncated?
+                  EXIT-CODE-TIMEOUT
+                  EXIT-CODE-ERROR
+                  make-error-result
+                  make-timeout-result
+                  make-success-result
+                  exit-success?
+                  exit-timeout?
+                  exit-error?
+                  format-timeout-message
+                  format-truncation-message
+                  secret-patterns
+                  SECRET-IMPLICIT-ALLOWLIST
+                  check-secret-var?))
+
+(define-test-suite result-constructor-tests
+                   (test-case "make-error-result constructs error result"
+                     (define r (make-error-result "Failed to execute: boom" 500))
+                     (check-equal? (subprocess-result-exit-code r) EXIT-CODE-ERROR)
+                     (check-equal? (subprocess-result-stdout r) "")
+                     (check-equal? (subprocess-result-stderr r) "Failed to execute: boom")
+                     (check-false (subprocess-result-timed-out? r))
+                     (check-equal? (subprocess-result-elapsed-ms r) 500)
+                     (check-false (subprocess-result-truncated? r)))
+                   (test-case "make-timeout-result constructs timeout result"
+                     (define r (make-timeout-result "partial-out" "partial-err" 30 5000 #t))
+                     (check-equal? (subprocess-result-exit-code r) EXIT-CODE-TIMEOUT)
+                     (check-equal? (subprocess-result-stdout r) "partial-out")
+                     (check-true (string-contains? (subprocess-result-stderr r) "timed out"))
+                     (check-true (string-contains? (subprocess-result-stderr r) "partial-err"))
+                     (check-true (subprocess-result-timed-out? r))
+                     (check-equal? (subprocess-result-elapsed-ms r) 5000)
+                     (check-true (subprocess-result-truncated? r)))
+                   (test-case "make-success-result constructs success result"
+                     (define r (make-success-result 0 "hello\n" "" 100 #f))
+                     (check-equal? (subprocess-result-exit-code r) 0)
+                     (check-equal? (subprocess-result-stdout r) "hello\n")
+                     (check-equal? (subprocess-result-stderr r) "")
+                     (check-false (subprocess-result-timed-out? r))
+                     (check-equal? (subprocess-result-elapsed-ms r) 100)
+                     (check-false (subprocess-result-truncated? r)))
+                   (test-case "make-success-result with non-zero exit"
+                     (define r (make-success-result 1 "out" "err" 50 #f))
+                     (check-equal? (subprocess-result-exit-code r) 1)
+                     (check-false (subprocess-result-timed-out? r))))
+
+(define-test-suite exit-classifier-tests
+                   (test-case "exit-success? for 0"
+                     (check-true (exit-success? 0)))
+                   (test-case "exit-success? false for 1"
+                     (check-false (exit-success? 1)))
+                   (test-case "exit-success? false for -1"
+                     (check-false (exit-success? EXIT-CODE-ERROR)))
+                   (test-case "exit-success? false for -9"
+                     (check-false (exit-success? EXIT-CODE-TIMEOUT)))
+                   (test-case "exit-timeout? for -9"
+                     (check-true (exit-timeout? EXIT-CODE-TIMEOUT)))
+                   (test-case "exit-timeout? false for 0"
+                     (check-false (exit-timeout? 0)))
+                   (test-case "exit-error? for -1"
+                     (check-true (exit-error? EXIT-CODE-ERROR)))
+                   (test-case "exit-error? false for 0"
+                     (check-false (exit-error? 0)))
+                   (test-case "exit-error? false for -9"
+                     (check-false (exit-error? EXIT-CODE-TIMEOUT))))
+
+(define-test-suite message-formatter-tests
+                   (test-case "format-timeout-message contains timeout seconds"
+                     (define msg (format-timeout-message 30))
+                     (check-true (string-contains? msg "30") "contains timeout value")
+                     (check-true (string-contains? msg "timed out") "mentions timeout")
+                     (check-true (string-contains? msg "Partial output") "mentions partial output"))
+                   (test-case "format-truncation-message contains byte count"
+                     (define msg (format-truncation-message 4096))
+                     (check-true (string-contains? msg "4096") "contains byte value")
+                     (check-true (string-contains? msg "truncated") "mentions truncation")))
+
+(define-test-suite
+ secret-detection-tests
+ (test-case "check-secret-var? detects API_KEY"
+   (check-true (check-secret-var? "API_KEY" '() '())))
+ (test-case "check-secret-var? detects SECRET"
+   (check-true (check-secret-var? "MY_SECRET" '() '())))
+ (test-case "check-secret-var? detects TOKEN"
+   (check-true (check-secret-var? "GITHUB_TOKEN" '() '())))
+ (test-case "check-secret-var? detects PASSWORD"
+   (check-true (check-secret-var? "DB_PASSWORD" '() '())))
+ (test-case "check-secret-var? allows PATH"
+   (check-false (check-secret-var? "PATH" '() '())))
+ (test-case "check-secret-var? allows HOME"
+   (check-false (check-secret-var? "HOME" '() '())))
+ (test-case "check-secret-var? allows TERM"
+   (check-false (check-secret-var? "TERM" '() '())))
+ (test-case "check-secret-var? implicit allowlist: AUTHOR"
+   (check-false (check-secret-var? "AUTHOR" '() '())))
+ (test-case "check-secret-var? implicit allowlist: XAUTHORITY"
+   (check-false (check-secret-var? "XAUTHORITY" '() '())))
+ (test-case "check-secret-var? implicit allowlist: SSH_AUTH_SOCK"
+   (check-false (check-secret-var? "SSH_AUTH_SOCK" '() '())))
+ (test-case "check-secret-var? detects bare AUTH"
+   (check-true (check-secret-var? "AUTH" '() '())))
+ (test-case "check-secret-var? detects AUTH_TOKEN"
+   (check-true (check-secret-var? "MY_AUTH_TOKEN" '() '())))
+ (test-case "extra denylist adds patterns"
+   (check-true (check-secret-var? "MY_CUSTOM_VAR" (list #rx"(?i:CUSTOM)") '())))
+ (test-case "extra allowlist overrides pattern"
+   (check-false (check-secret-var? "MY_TOKEN_COUNT" '() (list #rx"(?i:TOKEN_COUNT)"))))
+ (test-case "allowlist takes priority over denylist"
+   (check-false (check-secret-var? "CUSTOM_FLAG" (list #rx"(?i:CUSTOM)") (list #rx"(?i:FLAG)"))))
+ (test-case "secret-patterns is a non-empty list"
+   (check-true (and (pair? secret-patterns) #t)))
+ (test-case "SECRET-IMPLICIT-ALLOWLIST includes known vars"
+   (check-true (and (member "SSH_AUTH_SOCK" SECRET-IMPLICIT-ALLOWLIST) #t) "contains SSH_AUTH_SOCK")))
+
+(define-test-suite all-subprocess-helpers-tests
+                   result-constructor-tests
+                   exit-classifier-tests
+                   message-formatter-tests
+                   secret-detection-tests)
+
+(module+ test
+  (run-tests all-subprocess-helpers-tests))
+
+(module+ main
+  (run-tests all-subprocess-helpers-tests))


### PR DESCRIPTION
## W3 — Subprocess/tool I/O and result-boundary consolidation

### Goal
Extract pure result-boundary functions from `sandbox/subprocess.rkt` into `sandbox/subprocess-helpers.rkt`, creating a clean boundary between pure result construction/classification and effectful subprocess management.

### Changes
**New: `sandbox/subprocess-helpers.rkt`** (152 lines)
- `subprocess-result` struct (moved here, re-exported by subprocess.rkt)
- `make-error-result` / `make-timeout-result` / `make-success-result` — pure result constructors
- `exit-success?` / `exit-timeout?` / `exit-error?` — exit code classifiers
- `EXIT-CODE-TIMEOUT` / `EXIT-CODE-ERROR` — named constants
- `format-timeout-message` / `format-truncation-message` — pure formatters
- `secret-patterns` / `SECRET-IMPLICIT-ALLOWLIST` — data definitions
- `check-secret-var?` — pure secret detection (no parameters)

**Modified: `sandbox/subprocess.rkt`** (~370 → 334 lines)
- Imports helpers, re-exports struct + classifiers + constants
- `secret-env-var?` now delegates to `check-secret-var?` (14 → 6 lines)
- `run-subprocess` uses helper constructors instead of inline struct construction
- Note: `make-error-result`/`make-success-result` NOT re-exported from subprocess.rkt to avoid naming conflict with `tool.rkt`'s same-named exports

**New: `tests/test-subprocess-helpers.rkt`** (32 tests)
- Tests all extracted functions with edge cases

### Verification
- Build: PASS
- Unit-fast: 10/10 files, 102/102 tests PASS
- Smoke: 19/19 files, 286/286 tests PASS
- Helper tests: 32/32 PASS

Closes #8392