### PR TITLE
W4: Event serialization boundary extraction (#8393)

### DIFF
--- a/agent/event-json-helpers.rkt
+++ b/agent/event-json-helpers.rkt
@@ -1,0 +1,303 @@
+#lang racket/base
+
+;; agent/event-json-helpers.rkt — Pure serialization boundary for typed events
+;;
+;; W4 v0.99.35: Extracted from event-json.rkt to separate pure data
+;; extraction/conversion from registry mutation side-effects.
+;;
+;; All functions in this module are pure (no I/O, no mutation, no
+;; parameters, no registry access). They can be tested in isolation.
+;;
+;; Boundary contract:
+;;   INPUTS:  typed-event structs, hashes (plain data)
+;;   OUTPUTS: hashes, strings, typed-event structs (plain data)
+;;   EFFECTS: None — safe to call from any context
+
+(require racket/match
+         (only-in "event-structs/base.rkt"
+                  typed-event
+                  typed-event-type
+                  typed-event-timestamp
+                  typed-event-session-id
+                  typed-event-turn-id)
+         (only-in "event-structs/tool-events.rkt"
+                  bash-tool-call-event
+                  bash-tool-call-event?
+                  bash-tool-call-event-command
+                  bash-tool-call-event-timeout
+                  bash-tool-call-event-cwd
+                  edit-tool-call-event
+                  edit-tool-call-event?
+                  edit-tool-call-event-path
+                  edit-tool-call-event-edits
+                  write-tool-call-event
+                  write-tool-call-event?
+                  write-tool-call-event-path
+                  write-tool-call-event-content
+                  read-tool-call-event
+                  read-tool-call-event?
+                  read-tool-call-event-path
+                  read-tool-call-event-offset
+                  read-tool-call-event-limit
+                  grep-tool-call-event
+                  grep-tool-call-event?
+                  grep-tool-call-event-pattern
+                  grep-tool-call-event-path
+                  grep-tool-call-event-glob
+                  find-tool-call-event
+                  find-tool-call-event?
+                  find-tool-call-event-pattern
+                  find-tool-call-event-path
+                  custom-tool-call-event
+                  custom-tool-call-event?
+                  tool-call-event-tool-call-id
+                  tool-call-event-tool-name
+                  tool-call-event-arguments))
+
+;; Pure mappings
+(provide event-name->tool-name
+         all-known-event-types
+         ;; Per-tool serializer cores (pure: evt -> hasheq)
+         serialize-bash-tool-call
+         serialize-edit-tool-call
+         serialize-write-tool-call
+         serialize-read-tool-call
+         serialize-grep-tool-call
+         serialize-find-tool-call
+         serialize-custom-tool-call
+         ;; Per-tool deserializer cores (pure: type ts sid tid h -> event)
+         deserialize-bash-tool-call
+         deserialize-edit-tool-call
+         deserialize-write-tool-call
+         deserialize-read-tool-call
+         deserialize-grep-tool-call
+         deserialize-find-tool-call
+         deserialize-custom-tool-call)
+
+;; ============================================================
+;; Pure mappings
+;; ============================================================
+
+(define (event-name->tool-name type)
+  (match type
+    ["tool.bash.called" "bash"]
+    ["tool.edit.called" "edit"]
+    ["tool.write.called" "write"]
+    ["tool.read.called" "read"]
+    ["tool.grep.called" "grep"]
+    ["tool.find.called" "find"]
+    [_ #f]))
+
+(define (all-known-event-types)
+  '("turn.started" "turn.completed"
+                   "message.started"
+                   "message.updated"
+                   "message.completed"
+                   "tool.execution.started"
+                   "tool.execution.updated"
+                   "tool.execution.completed"
+                   "tool.called"
+                   "tool.result"
+                   "tool.bash.called"
+                   "tool.edit.called"
+                   "tool.write.called"
+                   "tool.read.called"
+                   "tool.grep.called"
+                   "tool.find.called"
+                   "tool.custom.called"
+                   "model.request.started"
+                   "model.request.completed"
+                   "session.started"
+                   "session.shutdown"
+                   "input"
+                   "model.selected"
+                   "agent.started"
+                   "agent.completed"
+                   "context.built"
+                   "context.assembled"
+                   "context.assembly.blocked"
+                   "working-set.injected"
+                   "iteration.decision"
+                   "auto-retry.start"
+                   "model.stream.delta"
+                   "model.stream.delta.tool-call"
+                   "model.stream.thinking"
+                   "model.stream.completed"
+                   "tool.call.started"
+                   "provider.stream.delta"
+                   "provider.stream.thinking"
+                   "provider.stream.completed"
+                   "model.request.blocked"
+                   "message.blocked"
+                   "turn.cancelled"
+                   "assistant.message.completed"
+                   "browser.session.opened"
+                   "browser.session.closed"
+                   "browser.action.started"
+                   "browser.action.completed"
+                   "browser.action.failed"
+                   "browser.page.loaded"
+                   "browser.policy.blocked"
+                   "browser.sidecar.started"
+                   "browser.sidecar.stopped"
+                   "browser.screenshot.captured"))
+
+;; ============================================================
+;; Per-tool serializer cores — pure: evt -> hasheq
+;; ============================================================
+
+(define (serialize-bash-tool-call evt)
+  (hasheq 'toolName
+          "bash"
+          'toolCallId
+          (tool-call-event-tool-call-id evt)
+          'command
+          (bash-tool-call-event-command evt)
+          'timeout
+          (bash-tool-call-event-timeout evt)
+          'cwd
+          (bash-tool-call-event-cwd evt)))
+
+(define (serialize-edit-tool-call evt)
+  (hasheq 'toolName
+          "edit"
+          'toolCallId
+          (tool-call-event-tool-call-id evt)
+          'path
+          (edit-tool-call-event-path evt)
+          'edits
+          (edit-tool-call-event-edits evt)))
+
+(define (serialize-write-tool-call evt)
+  (hasheq 'toolName
+          "write"
+          'toolCallId
+          (tool-call-event-tool-call-id evt)
+          'path
+          (write-tool-call-event-path evt)
+          'content
+          (write-tool-call-event-content evt)))
+
+(define (serialize-read-tool-call evt)
+  (hasheq 'toolName
+          "read"
+          'toolCallId
+          (tool-call-event-tool-call-id evt)
+          'path
+          (read-tool-call-event-path evt)
+          'offset
+          (read-tool-call-event-offset evt)
+          'limit
+          (read-tool-call-event-limit evt)))
+
+(define (serialize-grep-tool-call evt)
+  (hasheq 'toolName
+          "grep"
+          'toolCallId
+          (tool-call-event-tool-call-id evt)
+          'pattern
+          (grep-tool-call-event-pattern evt)
+          'path
+          (grep-tool-call-event-path evt)
+          'glob
+          (grep-tool-call-event-glob evt)))
+
+(define (serialize-find-tool-call evt)
+  (hasheq 'toolName
+          "find"
+          'toolCallId
+          (tool-call-event-tool-call-id evt)
+          'pattern
+          (find-tool-call-event-pattern evt)
+          'path
+          (find-tool-call-event-path evt)))
+
+(define (serialize-custom-tool-call evt)
+  (hasheq 'toolName
+          (tool-call-event-tool-name evt)
+          'toolCallId
+          (tool-call-event-tool-call-id evt)
+          'arguments
+          (tool-call-event-arguments evt)))
+
+;; ============================================================
+;; Per-tool deserializer cores — pure: type ts sid tid h -> event
+;; ============================================================
+
+(define (deserialize-bash-tool-call type ts sid tid h)
+  (bash-tool-call-event type
+                        ts
+                        sid
+                        tid
+                        "bash"
+                        (hasheq)
+                        (hash-ref h 'toolCallId "")
+                        (hash-ref h 'command "")
+                        (hash-ref h 'timeout 30)
+                        (hash-ref h 'cwd "")))
+
+(define (deserialize-edit-tool-call type ts sid tid h)
+  (edit-tool-call-event type
+                        ts
+                        sid
+                        tid
+                        "edit"
+                        (hasheq)
+                        (hash-ref h 'toolCallId "")
+                        (hash-ref h 'path "")
+                        (hash-ref h 'edits '())))
+
+(define (deserialize-write-tool-call type ts sid tid h)
+  (write-tool-call-event type
+                         ts
+                         sid
+                         tid
+                         "write"
+                         (hasheq)
+                         (hash-ref h 'toolCallId "")
+                         (hash-ref h 'path "")
+                         (hash-ref h 'content "")))
+
+(define (deserialize-read-tool-call type ts sid tid h)
+  (read-tool-call-event type
+                        ts
+                        sid
+                        tid
+                        "read"
+                        (hasheq)
+                        (hash-ref h 'toolCallId "")
+                        (hash-ref h 'path "")
+                        (hash-ref h 'offset #f)
+                        (hash-ref h 'limit #f)))
+
+(define (deserialize-grep-tool-call type ts sid tid h)
+  (grep-tool-call-event type
+                        ts
+                        sid
+                        tid
+                        "grep"
+                        (hasheq)
+                        (hash-ref h 'toolCallId "")
+                        (hash-ref h 'pattern "")
+                        (hash-ref h 'path "")
+                        (hash-ref h 'glob "")))
+
+(define (deserialize-find-tool-call type ts sid tid h)
+  (find-tool-call-event type
+                        ts
+                        sid
+                        tid
+                        "find"
+                        (hasheq)
+                        (hash-ref h 'toolCallId "")
+                        (hash-ref h 'pattern "")
+                        (hash-ref h 'path "")))
+
+(define (deserialize-custom-tool-call type ts sid tid h)
+  (custom-tool-call-event type
+                          ts
+                          sid
+                          tid
+                          (hash-ref h 'toolName "unknown")
+                          (hash-ref h 'arguments (hasheq))
+                          (hash-ref h 'toolCallId "")))

--- a/agent/event-json.rkt
+++ b/agent/event-json.rkt
@@ -5,46 +5,24 @@
 ;; H-01: Replaced 474-line manual dual-match with registry dispatch.
 ;; Event types auto-register serializers/deserializers via define-typed-event.
 ;; Per-tool events (manual structs) register explicitly below.
+;;
+;; W4 v0.99.35: Pure serialization logic extracted to event-json-helpers.rkt.
+;; This module now focuses on registry registration + dispatch, delegating
+;; pure data extraction/conversion to the helpers module.
 
 (require racket/contract
          racket/match
          "event-structs/typed-event-predicates.rkt"
+         (only-in "event-structs/base.rkt"
+                  typed-event
+                  typed-event-type
+                  typed-event-timestamp
+                  typed-event-session-id
+                  typed-event-turn-id)
          ;; Browser event module registers browser serializers/deserializers.
          (prefix-in browser: "../browser/events.rkt")
-         ;; Per-tool event imports for manual serializer registration
-         (only-in "event-structs/tool-events.rkt"
-                  bash-tool-call-event
-                  bash-tool-call-event-command
-                  bash-tool-call-event-timeout
-                  bash-tool-call-event-cwd
-                  bash-tool-call-event?
-                  edit-tool-call-event
-                  edit-tool-call-event-path
-                  edit-tool-call-event-edits
-                  edit-tool-call-event?
-                  write-tool-call-event
-                  write-tool-call-event-path
-                  write-tool-call-event-content
-                  write-tool-call-event?
-                  read-tool-call-event
-                  read-tool-call-event-path
-                  read-tool-call-event-offset
-                  read-tool-call-event-limit
-                  read-tool-call-event?
-                  grep-tool-call-event
-                  grep-tool-call-event-pattern
-                  grep-tool-call-event-path
-                  grep-tool-call-event-glob
-                  grep-tool-call-event?
-                  find-tool-call-event
-                  find-tool-call-event-pattern
-                  find-tool-call-event-path
-                  find-tool-call-event?
-                  custom-tool-call-event
-                  custom-tool-call-event?
-                  tool-call-event-tool-call-id
-                  tool-call-event-tool-name
-                  tool-call-event-arguments)
+         ;; W4 v0.99.35: Pure serialization helpers
+         "event-json-helpers.rkt"
          ;; Registry functions
          (only-in "../util/event/event-macro.rkt"
                   lookup-event-serializer
@@ -69,181 +47,33 @@
      (hash-set (base-serializer evt) 'schemaVersion (lookup-event-schema-version event-type)))))
 
 ;; ============================================================
-;; Per-tool event serializer registration (manual structs)
+;; Per-tool event serializer/deserializer registration
+;;
+;; W4 v0.99.35: Pure serializer/deserializer logic now lives in
+;; event-json-helpers.rkt. This section registers them with the global
+;; registry at module-load time.
 ;; ============================================================
 
-;; bash-tool-call-event
-(register-tool-event-serializer! "tool.bash.called"
-                                 (lambda (evt)
-                                   (hasheq 'toolName
-                                           "bash"
-                                           'toolCallId
-                                           (tool-call-event-tool-call-id evt)
-                                           'command
-                                           (bash-tool-call-event-command evt)
-                                           'timeout
-                                           (bash-tool-call-event-timeout evt)
-                                           'cwd
-                                           (bash-tool-call-event-cwd evt))))
+(register-tool-event-serializer! "tool.bash.called" serialize-bash-tool-call)
+(register-event-deserializer! "tool.bash.called" deserialize-bash-tool-call)
 
-(register-event-deserializer! "tool.bash.called"
-                              (lambda (type ts sid tid h)
-                                (bash-tool-call-event type
-                                                      ts
-                                                      sid
-                                                      tid
-                                                      "bash"
-                                                      (hasheq)
-                                                      (hash-ref h 'toolCallId "")
-                                                      (hash-ref h 'command "")
-                                                      (hash-ref h 'timeout 30)
-                                                      (hash-ref h 'cwd ""))))
+(register-tool-event-serializer! "tool.edit.called" serialize-edit-tool-call)
+(register-event-deserializer! "tool.edit.called" deserialize-edit-tool-call)
 
-;; edit-tool-call-event
-(register-tool-event-serializer! "tool.edit.called"
-                                 (lambda (evt)
-                                   (hasheq 'toolName
-                                           "edit"
-                                           'toolCallId
-                                           (tool-call-event-tool-call-id evt)
-                                           'path
-                                           (edit-tool-call-event-path evt)
-                                           'edits
-                                           (edit-tool-call-event-edits evt))))
+(register-tool-event-serializer! "tool.write.called" serialize-write-tool-call)
+(register-event-deserializer! "tool.write.called" deserialize-write-tool-call)
 
-(register-event-deserializer! "tool.edit.called"
-                              (lambda (type ts sid tid h)
-                                (edit-tool-call-event type
-                                                      ts
-                                                      sid
-                                                      tid
-                                                      "edit"
-                                                      (hasheq)
-                                                      (hash-ref h 'toolCallId "")
-                                                      (hash-ref h 'path "")
-                                                      (hash-ref h 'edits '()))))
+(register-tool-event-serializer! "tool.read.called" serialize-read-tool-call)
+(register-event-deserializer! "tool.read.called" deserialize-read-tool-call)
 
-;; write-tool-call-event
-(register-tool-event-serializer! "tool.write.called"
-                                 (lambda (evt)
-                                   (hasheq 'toolName
-                                           "write"
-                                           'toolCallId
-                                           (tool-call-event-tool-call-id evt)
-                                           'path
-                                           (write-tool-call-event-path evt)
-                                           'content
-                                           (write-tool-call-event-content evt))))
+(register-tool-event-serializer! "tool.grep.called" serialize-grep-tool-call)
+(register-event-deserializer! "tool.grep.called" deserialize-grep-tool-call)
 
-(register-event-deserializer! "tool.write.called"
-                              (lambda (type ts sid tid h)
-                                (write-tool-call-event type
-                                                       ts
-                                                       sid
-                                                       tid
-                                                       "write"
-                                                       (hasheq)
-                                                       (hash-ref h 'toolCallId "")
-                                                       (hash-ref h 'path "")
-                                                       (hash-ref h 'content ""))))
+(register-tool-event-serializer! "tool.find.called" serialize-find-tool-call)
+(register-event-deserializer! "tool.find.called" deserialize-find-tool-call)
 
-;; read-tool-call-event
-(register-tool-event-serializer! "tool.read.called"
-                                 (lambda (evt)
-                                   (hasheq 'toolName
-                                           "read"
-                                           'toolCallId
-                                           (tool-call-event-tool-call-id evt)
-                                           'path
-                                           (read-tool-call-event-path evt)
-                                           'offset
-                                           (read-tool-call-event-offset evt)
-                                           'limit
-                                           (read-tool-call-event-limit evt))))
-
-(register-event-deserializer! "tool.read.called"
-                              (lambda (type ts sid tid h)
-                                (read-tool-call-event type
-                                                      ts
-                                                      sid
-                                                      tid
-                                                      "read"
-                                                      (hasheq)
-                                                      (hash-ref h 'toolCallId "")
-                                                      (hash-ref h 'path "")
-                                                      (hash-ref h 'offset #f)
-                                                      (hash-ref h 'limit #f))))
-
-;; grep-tool-call-event
-(register-tool-event-serializer! "tool.grep.called"
-                                 (lambda (evt)
-                                   (hasheq 'toolName
-                                           "grep"
-                                           'toolCallId
-                                           (tool-call-event-tool-call-id evt)
-                                           'pattern
-                                           (grep-tool-call-event-pattern evt)
-                                           'path
-                                           (grep-tool-call-event-path evt)
-                                           'glob
-                                           (grep-tool-call-event-glob evt))))
-
-(register-event-deserializer! "tool.grep.called"
-                              (lambda (type ts sid tid h)
-                                (grep-tool-call-event type
-                                                      ts
-                                                      sid
-                                                      tid
-                                                      "grep"
-                                                      (hasheq)
-                                                      (hash-ref h 'toolCallId "")
-                                                      (hash-ref h 'pattern "")
-                                                      (hash-ref h 'path "")
-                                                      (hash-ref h 'glob ""))))
-
-;; find-tool-call-event
-(register-tool-event-serializer! "tool.find.called"
-                                 (lambda (evt)
-                                   (hasheq 'toolName
-                                           "find"
-                                           'toolCallId
-                                           (tool-call-event-tool-call-id evt)
-                                           'pattern
-                                           (find-tool-call-event-pattern evt)
-                                           'path
-                                           (find-tool-call-event-path evt))))
-
-(register-event-deserializer! "tool.find.called"
-                              (lambda (type ts sid tid h)
-                                (find-tool-call-event type
-                                                      ts
-                                                      sid
-                                                      tid
-                                                      "find"
-                                                      (hasheq)
-                                                      (hash-ref h 'toolCallId "")
-                                                      (hash-ref h 'pattern "")
-                                                      (hash-ref h 'path ""))))
-
-;; custom-tool-call-event
-(register-tool-event-serializer! "tool.custom.called"
-                                 (lambda (evt)
-                                   (hasheq 'toolName
-                                           (tool-call-event-tool-name evt)
-                                           'toolCallId
-                                           (tool-call-event-tool-call-id evt)
-                                           'arguments
-                                           (tool-call-event-arguments evt))))
-
-(register-event-deserializer! "tool.custom.called"
-                              (lambda (type ts sid tid h)
-                                (custom-tool-call-event type
-                                                        ts
-                                                        sid
-                                                        tid
-                                                        (hash-ref h 'toolName "unknown")
-                                                        (hash-ref h 'arguments (hasheq))
-                                                        (hash-ref h 'toolCallId ""))))
+(register-tool-event-serializer! "tool.custom.called" serialize-custom-tool-call)
+(register-event-deserializer! "tool.custom.called" deserialize-custom-tool-call)
 
 ;; ============================================================
 ;; JSON Serialization (H-01: registry dispatch)
@@ -289,71 +119,3 @@
   (if deserializer
       (deserializer type ts sid tid h)
       (typed-event type ts sid tid)))
-
-;; ============================================================
-;; Registry
-;; ============================================================
-
-(define (all-known-event-types)
-  '("turn.started" "turn.completed"
-                   "message.started"
-                   "message.updated"
-                   "message.completed"
-                   "tool.execution.started"
-                   "tool.execution.updated"
-                   "tool.execution.completed"
-                   "tool.called"
-                   "tool.result"
-                   "tool.bash.called"
-                   "tool.edit.called"
-                   "tool.write.called"
-                   "tool.read.called"
-                   "tool.grep.called"
-                   "tool.find.called"
-                   "tool.custom.called"
-                   "model.request.started"
-                   "model.request.completed"
-                   "session.started"
-                   "session.shutdown"
-                   "input"
-                   "model.selected"
-                   "agent.started"
-                   "agent.completed"
-                   "context.built"
-                   "context.assembled"
-                   "context.assembly.blocked"
-                   "working-set.injected"
-                   "iteration.decision"
-                   "auto-retry.start"
-                   "model.stream.delta"
-                   "model.stream.delta.tool-call"
-                   "model.stream.thinking"
-                   "model.stream.completed"
-                   "tool.call.started"
-                   "provider.stream.delta"
-                   "provider.stream.thinking"
-                   "provider.stream.completed"
-                   "model.request.blocked"
-                   "message.blocked"
-                   "turn.cancelled"
-                   "assistant.message.completed"
-                   "browser.session.opened"
-                   "browser.session.closed"
-                   "browser.action.started"
-                   "browser.action.completed"
-                   "browser.action.failed"
-                   "browser.page.loaded"
-                   "browser.policy.blocked"
-                   "browser.sidecar.started"
-                   "browser.sidecar.stopped"
-                   "browser.screenshot.captured"))
-
-(define (event-name->tool-name type)
-  (match type
-    ["tool.bash.called" "bash"]
-    ["tool.edit.called" "edit"]
-    ["tool.write.called" "write"]
-    ["tool.read.called" "read"]
-    ["tool.grep.called" "grep"]
-    ["tool.find.called" "find"]
-    [_ #f]))

--- a/tests/test-event-json-helpers.rkt
+++ b/tests/test-event-json-helpers.rkt
@@ -1,0 +1,275 @@
+#lang racket/base
+
+;; @speed fast
+;; @suite fast
+
+;; W4 v0.99.35: Tests for event-json-helpers.rkt
+;; Pure serialization boundary functions extracted from event-json.rkt:
+;; - event-name->tool-name: pure event type to tool name mapping
+;; - all-known-event-types: pure registry list
+;; - serialize-*-tool-call: pure evt -> hasheq extraction
+;; - deserialize-*-tool-call: pure type ts sid tid h -> event construction
+
+(require rackunit
+         rackunit/text-ui
+         "../agent/event-json-helpers.rkt"
+         (only-in "../agent/event-structs/tool-events.rkt"
+                  bash-tool-call-event
+                  bash-tool-call-event?
+                  bash-tool-call-event-command
+                  bash-tool-call-event-timeout
+                  bash-tool-call-event-cwd
+                  edit-tool-call-event
+                  edit-tool-call-event?
+                  edit-tool-call-event-path
+                  edit-tool-call-event-edits
+                  write-tool-call-event
+                  write-tool-call-event?
+                  write-tool-call-event-path
+                  write-tool-call-event-content
+                  read-tool-call-event
+                  read-tool-call-event?
+                  read-tool-call-event-path
+                  read-tool-call-event-offset
+                  read-tool-call-event-limit
+                  grep-tool-call-event
+                  grep-tool-call-event?
+                  grep-tool-call-event-pattern
+                  grep-tool-call-event-path
+                  grep-tool-call-event-glob
+                  find-tool-call-event
+                  find-tool-call-event?
+                  find-tool-call-event-pattern
+                  find-tool-call-event-path
+                  custom-tool-call-event
+                  custom-tool-call-event?
+                  tool-call-event-tool-call-id
+                  tool-call-event-tool-name))
+
+(define-test-suite event-name-mapping-tests
+                   (test-case "event-name->tool-name maps known tool types"
+                     (check-equal? (event-name->tool-name "tool.bash.called") "bash")
+                     (check-equal? (event-name->tool-name "tool.edit.called") "edit")
+                     (check-equal? (event-name->tool-name "tool.write.called") "write")
+                     (check-equal? (event-name->tool-name "tool.read.called") "read")
+                     (check-equal? (event-name->tool-name "tool.grep.called") "grep")
+                     (check-equal? (event-name->tool-name "tool.find.called") "find"))
+                   (test-case "event-name->tool-name returns #f for unknown"
+                     (check-false (event-name->tool-name "tool.custom.called"))
+                     (check-false (event-name->tool-name "session.started"))
+                     (check-false (event-name->tool-name "unknown.event"))
+                     (check-false (event-name->tool-name "")))
+                   (test-case "all-known-event-types returns non-empty list"
+                     (define types (all-known-event-types))
+                     (check-true (and (pair? types) #t) "returns a non-empty list"))
+                   (test-case "all-known-event-types includes key types"
+                     (define types (all-known-event-types))
+                     (check-true (and (member "turn.started" types) #t))
+                     (check-true (and (member "tool.bash.called" types) #t))
+                     (check-true (and (member "session.started" types) #t))
+                     (check-true (and (member "browser.session.opened" types) #t)))
+                   (test-case "all-known-event-types is consistent across calls"
+                     (check-equal? (all-known-event-types) (all-known-event-types))))
+
+(define-test-suite
+ bash-serializer-tests
+ (test-case "serialize-bash-tool-call extracts all fields"
+   (define evt
+     (bash-tool-call-event "tool.bash.called"
+                           12345
+                           "s1"
+                           "t1"
+                           "bash"
+                           (hasheq)
+                           "tc-1"
+                           "ls -la"
+                           60
+                           "/tmp"))
+   (define h (serialize-bash-tool-call evt))
+   (check-equal? (hash-ref h 'toolName) "bash")
+   (check-equal? (hash-ref h 'toolCallId) "tc-1")
+   (check-equal? (hash-ref h 'command) "ls -la")
+   (check-equal? (hash-ref h 'timeout) 60)
+   (check-equal? (hash-ref h 'cwd) "/tmp"))
+ (test-case "deserialize-bash-tool-call constructs event from hash"
+   (define h (hasheq 'toolName "bash" 'toolCallId "tc-2" 'command "echo hi" 'timeout 30 'cwd "/home"))
+   (define evt (deserialize-bash-tool-call "tool.bash.called" 100 "s2" "t2" h))
+   (check-true (bash-tool-call-event? evt))
+   (check-equal? (bash-tool-call-event-command evt) "echo hi")
+   (check-equal? (bash-tool-call-event-timeout evt) 30)
+   (check-equal? (bash-tool-call-event-cwd evt) "/home"))
+ (test-case "deserialize-bash-tool-call uses defaults for missing fields"
+   (define h (hasheq))
+   (define evt (deserialize-bash-tool-call "tool.bash.called" 100 "s2" "t2" h))
+   (check-true (bash-tool-call-event? evt))
+   (check-equal? (bash-tool-call-event-command evt) "")
+   (check-equal? (bash-tool-call-event-timeout evt) 30)
+   (check-equal? (bash-tool-call-event-cwd evt) "")))
+
+(define-test-suite
+ edit-serializer-tests
+ (test-case "serialize-edit-tool-call extracts all fields"
+   (define evt
+     (edit-tool-call-event "tool.edit.called" 12345 "s1" "t1" "edit" (hasheq) "tc-1" "/foo.rkt" '()))
+   (define h (serialize-edit-tool-call evt))
+   (check-equal? (hash-ref h 'toolName) "edit")
+   (check-equal? (hash-ref h 'toolCallId) "tc-1")
+   (check-equal? (hash-ref h 'path) "/foo.rkt")
+   (check-equal? (hash-ref h 'edits) '()))
+ (test-case "deserialize-edit-tool-call constructs event"
+   (define h (hasheq 'toolName "edit" 'toolCallId "tc-2" 'path "/bar.rkt" 'edits (list "edit1")))
+   (define evt (deserialize-edit-tool-call "tool.edit.called" 100 "s2" "t2" h))
+   (check-true (edit-tool-call-event? evt))
+   (check-equal? (edit-tool-call-event-path evt) "/bar.rkt")
+   (check-equal? (edit-tool-call-event-edits evt) (list "edit1"))))
+
+(define-test-suite
+ write-serializer-tests
+ (test-case "serialize-write-tool-call extracts all fields"
+   (define evt
+     (write-tool-call-event "tool.write.called"
+                            12345
+                            "s1"
+                            "t1"
+                            "write"
+                            (hasheq)
+                            "tc-1"
+                            "/out.txt"
+                            "hello"))
+   (define h (serialize-write-tool-call evt))
+   (check-equal? (hash-ref h 'toolName) "write")
+   (check-equal? (hash-ref h 'toolCallId) "tc-1")
+   (check-equal? (hash-ref h 'path) "/out.txt")
+   (check-equal? (hash-ref h 'content) "hello"))
+ (test-case "deserialize-write-tool-call constructs event"
+   (define h (hasheq 'toolName "write" 'toolCallId "tc-2" 'path "/out2.txt" 'content "world"))
+   (define evt (deserialize-write-tool-call "tool.write.called" 100 "s2" "t2" h))
+   (check-true (write-tool-call-event? evt))
+   (check-equal? (write-tool-call-event-path evt) "/out2.txt")
+   (check-equal? (write-tool-call-event-content evt) "world")))
+
+(define-test-suite
+ read-serializer-tests
+ (test-case "serialize-read-tool-call extracts all fields"
+   (define evt
+     (read-tool-call-event "tool.read.called" 12345 "s1" "t1" "read" (hasheq) "tc-1" "/in.txt" 0 100))
+   (define h (serialize-read-tool-call evt))
+   (check-equal? (hash-ref h 'toolName) "read")
+   (check-equal? (hash-ref h 'toolCallId) "tc-1")
+   (check-equal? (hash-ref h 'path) "/in.txt")
+   (check-equal? (hash-ref h 'offset) 0)
+   (check-equal? (hash-ref h 'limit) 100))
+ (test-case "deserialize-read-tool-call constructs event"
+   (define h (hasheq 'toolName "read" 'toolCallId "tc-2" 'path "/in2.txt" 'offset 10 'limit 50))
+   (define evt (deserialize-read-tool-call "tool.read.called" 100 "s2" "t2" h))
+   (check-true (read-tool-call-event? evt))
+   (check-equal? (read-tool-call-event-path evt) "/in2.txt")
+   (check-equal? (read-tool-call-event-offset evt) 10)
+   (check-equal? (read-tool-call-event-limit evt) 50)))
+
+(define-test-suite
+ grep-serializer-tests
+ (test-case "serialize-grep-tool-call extracts all fields"
+   (define evt
+     (grep-tool-call-event "tool.grep.called"
+                           12345
+                           "s1"
+                           "t1"
+                           "grep"
+                           (hasheq)
+                           "tc-1"
+                           "pattern"
+                           "/src"
+                           "*.rkt"))
+   (define h (serialize-grep-tool-call evt))
+   (check-equal? (hash-ref h 'toolName) "grep")
+   (check-equal? (hash-ref h 'toolCallId) "tc-1")
+   (check-equal? (hash-ref h 'pattern) "pattern")
+   (check-equal? (hash-ref h 'path) "/src")
+   (check-equal? (hash-ref h 'glob) "*.rkt"))
+ (test-case "deserialize-grep-tool-call constructs event"
+   (define h (hasheq 'toolName "grep" 'toolCallId "tc-2" 'pattern "foo" 'path "/lib" 'glob "*.rkt"))
+   (define evt (deserialize-grep-tool-call "tool.grep.called" 100 "s2" "t2" h))
+   (check-true (grep-tool-call-event? evt))
+   (check-equal? (grep-tool-call-event-pattern evt) "foo")
+   (check-equal? (grep-tool-call-event-path evt) "/lib")
+   (check-equal? (grep-tool-call-event-glob evt) "*.rkt")))
+
+(define-test-suite
+ find-serializer-tests
+ (test-case "serialize-find-tool-call extracts all fields"
+   (define evt
+     (find-tool-call-event "tool.find.called" 12345 "s1" "t1" "find" (hasheq) "tc-1" "*.rkt" "/root"))
+   (define h (serialize-find-tool-call evt))
+   (check-equal? (hash-ref h 'toolName) "find")
+   (check-equal? (hash-ref h 'toolCallId) "tc-1")
+   (check-equal? (hash-ref h 'pattern) "*.rkt")
+   (check-equal? (hash-ref h 'path) "/root"))
+ (test-case "deserialize-find-tool-call constructs event"
+   (define h (hasheq 'toolName "find" 'toolCallId "tc-2" 'pattern "*.txt" 'path "/home"))
+   (define evt (deserialize-find-tool-call "tool.find.called" 100 "s2" "t2" h))
+   (check-true (find-tool-call-event? evt))
+   (check-equal? (find-tool-call-event-pattern evt) "*.txt")
+   (check-equal? (find-tool-call-event-path evt) "/home")))
+
+(define-test-suite
+ custom-serializer-tests
+ (test-case "serialize-custom-tool-call extracts all fields"
+   (define evt
+     (custom-tool-call-event "tool.custom.called"
+                             12345
+                             "s1"
+                             "t1"
+                             "mytool"
+                             (hasheq 'arg "val")
+                             "tc-1"))
+   (define h (serialize-custom-tool-call evt))
+   (check-equal? (hash-ref h 'toolName) "mytool")
+   (check-equal? (hash-ref h 'toolCallId) "tc-1")
+   (check-equal? (hash-ref h 'arguments) (hasheq 'arg "val")))
+ (test-case "deserialize-custom-tool-call constructs event"
+   (define h (hasheq 'toolName "customtool" 'toolCallId "tc-2" 'arguments (hasheq 'key "data")))
+   (define evt (deserialize-custom-tool-call "tool.custom.called" 100 "s2" "t2" h))
+   (check-true (custom-tool-call-event? evt))
+   (check-equal? (tool-call-event-tool-name evt) "customtool")
+   (check-equal? (tool-call-event-tool-call-id evt) "tc-2"))
+ (test-case "deserialize-custom-tool-call defaults for missing toolName"
+   (define h (hasheq))
+   (define evt (deserialize-custom-tool-call "tool.custom.called" 100 "s2" "t2" h))
+   (check-true (custom-tool-call-event? evt))
+   (check-equal? (tool-call-event-tool-name evt) "unknown")))
+
+(define-test-suite
+ round-trip-consistency-tests
+ (test-case "bash serialize->deserialize preserves fields"
+   (define orig
+     (bash-tool-call-event "tool.bash.called" 42 "s" "t" "bash" (hasheq) "id-1" "pwd" 45 "/var"))
+   (define h (serialize-bash-tool-call orig))
+   (define rt (deserialize-bash-tool-call "tool.bash.called" 42 "s" "t" h))
+   (check-equal? (bash-tool-call-event-command rt) (bash-tool-call-event-command orig))
+   (check-equal? (bash-tool-call-event-timeout rt) (bash-tool-call-event-timeout orig))
+   (check-equal? (bash-tool-call-event-cwd rt) (bash-tool-call-event-cwd orig)))
+ (test-case "edit serialize->deserialize preserves fields"
+   (define orig
+     (edit-tool-call-event "tool.edit.called" 42 "s" "t" "edit" (hasheq) "id-1" "/x.rkt" (list "e1")))
+   (define h (serialize-edit-tool-call orig))
+   (define rt (deserialize-edit-tool-call "tool.edit.called" 42 "s" "t" h))
+   (check-equal? (edit-tool-call-event-path rt) (edit-tool-call-event-path orig))
+   (check-equal? (edit-tool-call-event-edits rt) (edit-tool-call-event-edits orig))))
+
+(define-test-suite all-event-json-helpers-tests
+                   event-name-mapping-tests
+                   bash-serializer-tests
+                   edit-serializer-tests
+                   write-serializer-tests
+                   read-serializer-tests
+                   grep-serializer-tests
+                   find-serializer-tests
+                   custom-serializer-tests
+                   round-trip-consistency-tests)
+
+(module+ test
+  (run-tests all-event-json-helpers-tests))
+
+(module+ main
+  (run-tests all-event-json-helpers-tests))


### PR DESCRIPTION
## W4 — Event serialization and data-representation boundary

### Goal
Extract pure serialization logic from `agent/event-json.rkt` into `agent/event-json-helpers.rkt`, creating a clean boundary between pure data extraction/conversion and registry mutation side-effects.

### Changes
**New: `agent/event-json-helpers.rkt`** (303 lines)
- `event-name->tool-name` — pure event type → tool name mapping
- `all-known-event-types` — pure registry list constant
- 7 pure serializer functions (`serialize-{bash,edit,write,read,grep,find,custom}-tool-call`)
- 7 pure deserializer functions (`deserialize-*-tool-call`)

**Modified: `agent/event-json.rkt`** (359 → 121 lines, −238)
- Imports helpers, delegates registration to pure functions
- Removed 40+ lines of per-tool struct imports (no longer needed)
- Retains: registry registration, `typed-event->jsexpr`, `jsexpr->typed-event`
- Public API unchanged

**New: `tests/test-event-json-helpers.rkt`** (23 tests)
- Tests all extracted functions with edge cases and round-trip consistency

### Verification
- Build: PASS
- Unit-fast: 10/10 files, 102/102 tests PASS
- Smoke: 19/19 files, 286/286 tests PASS
- Round-trip: 38/38 PASS
- Event-types: 44/44 PASS
- Helper tests: 23/23 PASS

Closes #8393