### PR TITLE
W5: GSD state-machine pure transition extraction (#8394)

### DIFF
--- a/extensions/gsd/state-machine.rkt
+++ b/extensions/gsd/state-machine.rkt
@@ -12,11 +12,17 @@
 ;;                 └──────────────┘ (re-plan on failure)
 ;;
 ;; Thread safety: Uses gsd-state-sem from session-state.rkt for atomic updates.
+;;
+;; W5 v0.99.35: Pure transition logic (state predicates, transition table,
+;; compute-next-gsm-state, result types) extracted to transition-logic.rkt.
+;; This module now focuses on session-state interactions, event-bus emission,
+;; wave-gate tracking, and rework-loop protection.
 
 (require racket/contract
-         racket/match
          racket/set
          "runtime-state-types.rkt"
+         ;; W5 v0.99.35: Pure transition logic (re-exported below)
+         "transition-logic.rkt"
          (only-in "policy.rkt" blocked-tools-for gsd-decide-action policy-allowed?)
          (only-in "events.rkt"
                   emit-gsd-event!
@@ -49,7 +55,9 @@
                   gsd-session-ctx-rework-count-box
                   gsd-ctx-event-bus))
 
-;; States
+;; Re-export all pure transition logic for backward compatibility.
+(provide (all-from-out "transition-logic.rkt"))
+
 ;; Struct exports (plain)
 (provide gsd-runtime-state
          gsd-runtime-state?
@@ -62,11 +70,6 @@
          gsd-runtime-state-pinned-dir
          gsd-runtime-state-edit-limit
          gsd-runtime-state-transition-history
-         ok?
-         ok-from
-         ok-to
-         err?
-         err-reason
          ;; Wave gate
          gsd-wave-gate-counter
          gsd-wave-gate-interval
@@ -75,22 +78,13 @@
          gsd-max-rework-iterations
          gsd-rework-limit-reached?)
 
-;; Data constants (plain)
-(provide GSD-STATES
-         TRANSITIONS
-         TRANSITIONS-FLAT
-         ;; Functions (contracted)
-         (contract-out
-          [gsm-state? (-> any/c boolean?)]
+;; Functions (contracted)
+(provide (contract-out
           [make-initial-gsd-state (-> gsd-runtime-state?)]
           [gsm-current (-> symbol?)]
           [gsm-transition! (->* (symbol?) (#:event (or/c symbol? #f)) (or/c ok-result? err-result?))]
           [gsm-transition-to! (-> symbol? (or/c ok-result? err-result?))]
           [gsm-reset! (-> (or/c ok-result? err-result?))]
-          [compute-next-gsm-state
-           (->* (gsd-runtime-state? symbol?)
-                (#:event (or/c symbol? #f))
-                (values (or/c ok-result? err-result?) gsd-runtime-state?))]
           [gsm-valid-next-states (-> (listof symbol?))]
           [gsm-tool-allowed? (-> string? boolean?)]
           [gsm-snapshot (-> gsd-runtime-state?)]
@@ -132,67 +126,6 @@
           [gsm-ctx-state-restore! (-> gsd-session-ctx? gsd-runtime-state? void?)]))
 
 ;; ============================================================
-;; States and transitions
-;; ============================================================
-
-(define GSD-STATES '(idle exploring plan-written executing verifying))
-
-(define (gsm-state? v)
-  (and (symbol? v) (memq v GSD-STATES) #t))
-
-;; L-09: Transition table design note.
-;; This table is intentionally simple: plain (from . to) pairs with no guards,
-;; no actions, no conditions. This keeps the FSM easy to reason about and test.
-;; If the GSD state machine grows more complex (e.g., conditional transitions,
-;; entry/exit actions), the table should be enriched with a proper FSM library.
-;; Current design is sufficient for the 5-state GSD lifecycle.
-;;
-;; MAS Schritt 1 Integration Point:
-;; The executing→verifying transition ((executing . verify) . verifying)
-;; is where the verifier agent role (agent/roles/verifier.rkt) will be
-;; activated in Schritt 2. The verifier role has '(read-only) capability
-;; and will review wave results before transitioning to 'idle.
-;; Currently this transition is triggered by the GSD executor;
-;; in Schritt 2 it will route through the supervisor dispatch.
-(define TRANSITIONS
-  ;; Enriched transition table (F4): ((from . event) . to)
-  ;; Events name the trigger for each transition, enabling event-driven dispatch.
-  '(((idle . explore) . exploring) ((exploring . plan) . plan-written)
-                                   ((exploring . cancel) . idle)
-                                   ((plan-written . execute) . executing)
-                                   ((plan-written . cancel) . idle)
-                                   ((executing . verify) . verifying)
-                                   ((executing . cancel) . idle)
-                                   ((verifying . done) . idle)
-                                   ((verifying . rework) . executing)))
-
-;; Legacy: flat transition pairs for backward compatibility
-;; (derived from enriched table)
-(define TRANSITIONS-FLAT
-  (for/list ([t TRANSITIONS])
-    (cons (caar t) (cdr t))))
-
-;; ============================================================
-;; Transition result types
-;; ============================================================
-
-;; Successful transition
-(struct ok-result (from to) #:transparent)
-;; Failed transition
-(struct err-result (reason from attempted) #:transparent)
-
-(define (ok? r)
-  (ok-result? r))
-(define (ok-from r)
-  (ok-result-from r))
-(define (ok-to r)
-  (ok-result-to r))
-(define (err? r)
-  (err-result? r))
-(define (err-reason r)
-  (err-result-reason r))
-
-;; ============================================================
 ;; Core API — now backed by session-state parameters
 ;; ============================================================
 
@@ -202,30 +135,6 @@
 
 (define (gsm-history)
   (gsm-ctx-history gsd-default-ctx))
-
-;; Pure transition kernel (Finding 3.1.3)
-;; Compute next state without side effects.
-;; Returns (or/c ok-result? err-result?).
-(define (compute-next-gsm-state current-state target #:event [event #f])
-  (define current (gsd-runtime-state-mode current-state))
-  (cond
-    [(not (gsm-state? target))
-     (values (err-result (format "invalid state: ~a" target) current target) current-state)]
-    [(valid-transition? current target event)
-     ;; Clear executor when leaving executing mode
-     (define state*
-       (if (and (eq? current 'executing) (not (eq? target 'executing)))
-           (struct-copy gsd-runtime-state current-state [wave-executor #f])
-           current-state))
-     (define new-state (struct-copy gsd-runtime-state state* [mode target]))
-     (values (ok-result current target) new-state)]
-    [else
-     (values
-      (err-result
-       (format "invalid transition: ~a → ~a (valid: ~a)" current target (valid-targets current))
-       current
-       target)
-      current-state)]))
 
 (define (gsm-transition! target #:event [event #f])
   (gsd-ctx-transaction!
@@ -304,46 +213,6 @@
   (policy-allowed? (gsd-decide-action (hasheq 'mode current 'tool tool-name) 'tool-call)))
 
 ;; ============================================================
-;; Internal helpers
-;; ============================================================
-
-;; BFS path finder for multi-step transitions
-(define (find-transition-path from to)
-  (define visited (make-hash))
-  (define q (list (list from '())))
-  (let loop ([q q])
-    (cond
-      [(null? q) #f]
-      [else
-       (define node (caar q))
-       (define path (cdar q))
-       (cond
-         [(eq? node to) (reverse path)]
-         [(hash-has-key? visited node) (loop (cdr q))]
-         [else
-          (hash-set! visited node #t)
-          (define next-steps
-            (for/list ([t TRANSITIONS]
-                       #:when (eq? (caar t) node)
-                       #:unless (hash-has-key? visited (cdr t)))
-              (cdr t)))
-          (define new-q
-            (append (cdr q)
-                    (for/list ([s next-steps])
-                      (cons s (cons s path)))))
-          (loop new-q)])])))
-
-(define (valid-transition? from to [event #f])
-  (or (and (eq? from 'idle) (eq? to 'idle))
-      (for/or ([t TRANSITIONS])
-        (and (eq? (caar t) from) (eq? (cdr t) to) (or (not event) (eq? (cdar t) event))))))
-
-(define (valid-targets from)
-  (for/list ([t TRANSITIONS]
-             #:when (eq? (caar t) from))
-    (cdr t)))
-
-;; ============================================================
 ;; Wave state accessors — now backed by session-state parameters
 ;; ============================================================
 
@@ -378,11 +247,7 @@
   (set-member? (gsm-completed-waves) idx))
 
 (define (gsm-next-pending-wave)
-  (define tw (gsm-total-waves))
-  (define cw (gsm-completed-waves))
-  (for/first ([i (in-range tw)]
-              #:when (not (set-member? cw i)))
-    i))
+  (compute-next-pending-wave (gsm-total-waves) (gsm-completed-waves)))
 
 ;; ============================================================
 ;; Wave gate (budget enforcement)
@@ -419,28 +284,10 @@
 ;; State invariants (F3 fix: runtime invariant checks)
 ;; ============================================================
 
-;; Returns (values ok? error-message-or-#f)
-;; Checks structural invariants that should hold at all times.
+;; Returns (values ok? error-message-or-#f).
+;; W5 v0.99.35: Delegates pure invariant checking to check-state-invariants.
 (define (gsd-invariants-hold?)
-  (define state (gsd-state-snapshot))
-  (define mode (gsd-runtime-state-mode state))
-  (define tw (gsd-runtime-state-total-waves state))
-  (define cw (gsd-runtime-state-current-wave state))
-  (define completed (gsd-runtime-state-completed-waves state))
-  (define exec (gsd-runtime-state-wave-executor state))
-  (cond
-    [(not (gsm-state? mode)) (values #f (format "invalid mode: ~a" mode))]
-    [(not (exact-nonnegative-integer? tw)) (values #f (format "total-waves not non-neg-int: ~a" tw))]
-    [(not (exact-nonnegative-integer? cw)) (values #f (format "current-wave not non-neg-int: ~a" cw))]
-    [(> cw tw) (values #f (format "current-wave (~a) > total-waves (~a)" cw tw))]
-    [(not (set? completed)) (values #f (format "completed-waves not a set: ~a" completed))]
-    [(not (for/and ([idx (in-set completed)])
-            (and (exact-nonnegative-integer? idx) (< idx tw))))
-     (values #f (format "completed-waves contains invalid indices: ~a" completed))]
-    ;; If in executing/verifying, wave-executor should be set when waves exist
-    [(and (memq mode '(executing verifying)) (> tw 0) (not exec))
-     (values #f (format "in ~a with ~a waves but no wave-executor" mode tw))]
-    [else (values #t #f)]))
+  (check-state-invariants (gsd-state-snapshot)))
 
 ;; ============================================================
 ;; Context-aware API (v0.57.1 W6)
@@ -575,11 +422,7 @@
   (set-member? (gsm-ctx-completed-waves ctx) idx))
 
 (define (gsm-ctx-next-pending-wave ctx)
-  (define tw (gsm-ctx-total-waves ctx))
-  (define cw (gsm-ctx-completed-waves ctx))
-  (for/first ([i (in-range tw)]
-              #:when (not (set-member? cw i)))
-    i))
+  (compute-next-pending-wave (gsm-ctx-total-waves ctx) (gsm-ctx-completed-waves ctx)))
 
 ;; State restore (ctx-aware)
 (define (gsm-ctx-state-restore! ctx snapshot)

--- a/extensions/gsd/transition-logic.rkt
+++ b/extensions/gsd/transition-logic.rkt
@@ -1,0 +1,209 @@
+#lang racket/base
+
+;; extensions/gsd/transition-logic.rkt — Pure GSD state machine transition logic
+;;
+;; W5 v0.99.35: Extracted from state-machine.rkt to separate pure transition
+;; computation from mutable session-state interactions and event-bus side-effects.
+;;
+;; All functions in this module are pure (no I/O, no mutation of external state,
+;; no parameters, no event bus). They operate solely on the gsd-runtime-state
+;; struct and the static transition table.
+;;
+;; Boundary contract:
+;;   INPUTS:  gsd-runtime-state structs, symbols, integers, sets
+;;   OUTPUTS: ok-result/err-result structs, gsd-runtime-state structs, lists
+;;   EFFECTS: None — safe to call from any context
+
+(require racket/match
+         racket/set
+         "runtime-state-types.rkt")
+
+;; Result type structs
+(provide (struct-out ok-result)
+         (struct-out err-result)
+         ;; Result type wrapper functions
+         ok?
+         ok-from
+         ok-to
+         err?
+         err-reason
+         ;; State/transition constants
+         GSD-STATES
+         TRANSITIONS
+         TRANSITIONS-FLAT
+         ;; Pure predicates
+         gsm-state?
+         ;; Pure transition logic
+         valid-transition?
+         valid-targets
+         find-transition-path
+         compute-next-gsm-state
+         ;; Pure invariant checker
+         check-state-invariants
+         ;; Pure wave computation
+         compute-next-pending-wave)
+
+;; ============================================================
+;; States and transitions
+;; ============================================================
+
+(define GSD-STATES '(idle exploring plan-written executing verifying))
+
+(define (gsm-state? v)
+  (and (symbol? v) (memq v GSD-STATES) #t))
+
+;; L-09: Transition table design note.
+;; This table is intentionally simple: plain (from . to) pairs with no guards,
+;; no actions, no conditions. This keeps the FSM easy to reason about and test.
+;; If the GSD state machine grows more complex (e.g., conditional transitions,
+;; entry/exit actions), the table should be enriched with a proper FSM library.
+;; Current design is sufficient for the 5-state GSD lifecycle.
+;;
+;; MAS Schritt 1 Integration Point:
+;; The executing→verifying transition ((executing . verify) . verifying)
+;; is where the verifier agent role (agent/roles/verifier.rkt) will be
+;; activated in Schritt 2. The verifier role has '(read-only) capability
+;; and will review wave results before transitioning to 'idle.
+;; Currently this transition is triggered by the GSD executor;
+;; in Schritt 2 it will route through the supervisor dispatch.
+(define TRANSITIONS
+  ;; Enriched transition table (F4): ((from . event) . to)
+  ;; Events name the trigger for each transition, enabling event-driven dispatch.
+  '(((idle . explore) . exploring) ((exploring . plan) . plan-written)
+                                   ((exploring . cancel) . idle)
+                                   ((plan-written . execute) . executing)
+                                   ((plan-written . cancel) . idle)
+                                   ((executing . verify) . verifying)
+                                   ((executing . cancel) . idle)
+                                   ((verifying . done) . idle)
+                                   ((verifying . rework) . executing)))
+
+;; Legacy: flat transition pairs for backward compatibility
+;; (derived from enriched table)
+(define TRANSITIONS-FLAT
+  (for/list ([t TRANSITIONS])
+    (cons (caar t) (cdr t))))
+
+;; ============================================================
+;; Transition result types
+;; ============================================================
+
+;; Successful transition
+(struct ok-result (from to) #:transparent)
+;; Failed transition
+(struct err-result (reason from attempted) #:transparent)
+
+(define (ok? r)
+  (ok-result? r))
+(define (ok-from r)
+  (ok-result-from r))
+(define (ok-to r)
+  (ok-result-to r))
+(define (err? r)
+  (err-result? r))
+(define (err-reason r)
+  (err-result-reason r))
+
+;; ============================================================
+;; Pure transition predicates and functions
+;; ============================================================
+
+;; Check if a transition is valid given current state, target, and optional event.
+(define (valid-transition? from to [event #f])
+  (or (and (eq? from 'idle) (eq? to 'idle))
+      (for/or ([t TRANSITIONS])
+        (and (eq? (caar t) from) (eq? (cdr t) to) (or (not event) (eq? (cdar t) event))))))
+
+;; List valid target states from a given state.
+(define (valid-targets from)
+  (for/list ([t TRANSITIONS]
+             #:when (eq? (caar t) from))
+    (cdr t)))
+
+;; BFS path finder for multi-step transitions.
+;; Returns list of states to visit (excluding 'from, including 'to) or #f.
+(define (find-transition-path from to)
+  (define visited (make-hash))
+  (define q (list (cons from '())))
+  (let loop ([q q])
+    (cond
+      [(null? q) #f]
+      [else
+       (define node (caar q))
+       (define path (cdar q))
+       (cond
+         [(eq? node to) (reverse path)]
+         [(hash-has-key? visited node) (loop (cdr q))]
+         [else
+          (hash-set! visited node #t)
+          (define next-steps
+            (for/list ([t TRANSITIONS]
+                       #:when (eq? (caar t) node)
+                       #:unless (hash-has-key? visited (cdr t)))
+              (cdr t)))
+          (define new-q
+            (append (cdr q)
+                    (for/list ([s next-steps])
+                      (cons s (cons s path)))))
+          (loop new-q)])])))
+
+;; Pure transition kernel (Finding 3.1.3)
+;; Compute next state without side effects.
+;; Returns (values (or/c ok-result? err-result?) gsd-runtime-state?).
+(define (compute-next-gsm-state current-state target #:event [event #f])
+  (define current (gsd-runtime-state-mode current-state))
+  (cond
+    [(not (gsm-state? target))
+     (values (err-result (format "invalid state: ~a" target) current target) current-state)]
+    [(valid-transition? current target event)
+     ;; Clear executor when leaving executing mode
+     (define state*
+       (if (and (eq? current 'executing) (not (eq? target 'executing)))
+           (struct-copy gsd-runtime-state current-state [wave-executor #f])
+           current-state))
+     (define new-state (struct-copy gsd-runtime-state state* [mode target]))
+     (values (ok-result current target) new-state)]
+    [else
+     (values
+      (err-result
+       (format "invalid transition: ~a → ~a (valid: ~a)" current target (valid-targets current))
+       current
+       target)
+      current-state)]))
+
+;; ============================================================
+;; Pure invariant checker
+;; ============================================================
+
+;; Returns (values ok? error-message-or-#f).
+;; Checks structural invariants that should hold at all times.
+(define (check-state-invariants state)
+  (define mode (gsd-runtime-state-mode state))
+  (define tw (gsd-runtime-state-total-waves state))
+  (define cw (gsd-runtime-state-current-wave state))
+  (define completed (gsd-runtime-state-completed-waves state))
+  (define exec (gsd-runtime-state-wave-executor state))
+  (cond
+    [(not (gsm-state? mode)) (values #f (format "invalid mode: ~a" mode))]
+    [(not (exact-nonnegative-integer? tw)) (values #f (format "total-waves not non-neg-int: ~a" tw))]
+    [(not (exact-nonnegative-integer? cw)) (values #f (format "current-wave not non-neg-int: ~a" cw))]
+    [(> cw tw) (values #f (format "current-wave (~a) > total-waves (~a)" cw tw))]
+    [(not (set? completed)) (values #f (format "completed-waves not a set: ~a" completed))]
+    [(not (for/and ([idx (in-set completed)])
+            (and (exact-nonnegative-integer? idx) (< idx tw))))
+     (values #f (format "completed-waves contains invalid indices: ~a" completed))]
+    ;; If in executing/verifying, wave-executor should be set when waves exist
+    [(and (memq mode '(executing verifying)) (> tw 0) (not exec))
+     (values #f (format "in ~a with ~a waves but no wave-executor" mode tw))]
+    [else (values #t #f)]))
+
+;; ============================================================
+;; Pure wave computation
+;; ============================================================
+
+;; Compute the next pending (incomplete) wave index.
+;; Returns #f if all waves are completed.
+(define (compute-next-pending-wave total-waves completed-set)
+  (for/first ([i (in-range total-waves)]
+              #:when (not (set-member? completed-set i)))
+    i))

--- a/tests/test-transition-logic.rkt
+++ b/tests/test-transition-logic.rkt
@@ -1,0 +1,244 @@
+#lang racket/base
+
+;; @speed fast
+;; @suite fast
+
+;; W5 v0.99.35: Tests for transition-logic.rkt
+;; Pure GSD state machine transition functions extracted from state-machine.rkt.
+;; Tests cover: result types, state predicates, transition table,
+;; BFS path finding, compute-next-gsm-state, invariants, wave computation.
+
+(require rackunit
+         rackunit/text-ui
+         racket/set
+         "../extensions/gsd/transition-logic.rkt"
+         "../extensions/gsd/runtime-state-types.rkt")
+
+;; ============================================================
+;; Helpers
+;; ============================================================
+
+(define (make-state mode
+                    #:executor [exec #f]
+                    #:total-waves [tw 0]
+                    #:current-wave [cw 0]
+                    #:completed-waves [comp (set)])
+  (gsd-runtime-state mode tw cw comp exec #f #f 500 '()))
+
+;; ============================================================
+;; Result type tests
+;; ============================================================
+
+(define-test-suite result-type-tests
+                   (test-case "ok-result struct is transparent"
+                     (define r (ok-result 'idle 'exploring))
+                     (check-equal? r (ok-result 'idle 'exploring)))
+                   (test-case "ok? returns #t for ok-result"
+                     (check-true (ok? (ok-result 'idle 'exploring))))
+                   (test-case "ok? returns #f for err-result"
+                     (check-false (ok? (err-result "bad" 'idle 'executing))))
+                   (test-case "err? returns #t for err-result"
+                     (check-true (err? (err-result "bad" 'idle 'executing))))
+                   (test-case "err? returns #f for ok-result"
+                     (check-false (err? (ok-result 'idle 'exploring))))
+                   (test-case "ok-from/ok-to extractors"
+                     (define r (ok-result 'idle 'exploring))
+                     (check-equal? (ok-from r) 'idle)
+                     (check-equal? (ok-to r) 'exploring))
+                   (test-case "err-reason extractor"
+                     (define r (err-result "bad transition" 'idle 'executing))
+                     (check-equal? (err-reason r) "bad transition")))
+
+;; ============================================================
+;; State predicate tests
+;; ============================================================
+
+(define-test-suite state-predicate-tests
+                   (test-case "gsm-state? recognizes all valid states"
+                     (for ([s GSD-STATES])
+                       (check-true (gsm-state? s) (format "~a should be valid" s))))
+                   (test-case "gsm-state? rejects invalid states"
+                     (check-false (gsm-state? 'unknown))
+                     (check-false (gsm-state? 'idle2))
+                     (check-false (gsm-state? 42))
+                     (check-false (gsm-state? "idle")))
+                   (test-case "GSD-STATES has exactly 5 states"
+                     (check-equal? (length GSD-STATES) 5)))
+
+;; ============================================================
+;; Transition table tests
+;; ============================================================
+
+(define-test-suite transition-table-tests
+                   (test-case "TRANSITIONS has 9 transitions"
+                     (check-equal? (length TRANSITIONS) 9))
+                   (test-case "TRANSITIONS-FLAT derived from enriched table"
+                     (check-equal? (length TRANSITIONS-FLAT) (length TRANSITIONS))
+                     (for ([t TRANSITIONS])
+                       (define flat (cons (caar t) (cdr t)))
+                       (check-true (for/or ([f TRANSITIONS-FLAT])
+                                     (and (equal? (car f) (car flat)) (equal? (cdr f) (cdr flat))))
+                                   (format "~a in TRANSITIONS-FLAT" t)))))
+
+;; ============================================================
+;; valid-transition? tests
+;; ============================================================
+
+(define-test-suite valid-transition-tests
+                   (test-case "idle → exploring is valid"
+                     (check-true (valid-transition? 'idle 'exploring)))
+                   (test-case "exploring → plan-written is valid"
+                     (check-true (valid-transition? 'exploring 'plan-written)))
+                   (test-case "idle → executing is invalid"
+                     (check-false (valid-transition? 'idle 'executing)))
+                   (test-case "self-loop idle → idle is valid"
+                     (check-true (valid-transition? 'idle 'idle)))
+                   (test-case "self-loop exploring → exploring is invalid"
+                     (check-false (valid-transition? 'exploring 'exploring)))
+                   (test-case "valid transition with correct event"
+                     (check-true (valid-transition? 'idle 'exploring 'explore)))
+                   (test-case "valid transition with wrong event"
+                     (check-false (valid-transition? 'idle 'exploring 'cancel))))
+
+;; ============================================================
+;; valid-targets tests
+;; ============================================================
+
+(define-test-suite valid-targets-tests
+                   (test-case "valid targets from idle"
+                     (check-equal? (valid-targets 'idle) '(exploring)))
+                   (test-case "valid targets from exploring"
+                     (check-equal? (valid-targets 'exploring) '(plan-written idle)))
+                   (test-case "valid targets from plan-written"
+                     (check-equal? (valid-targets 'plan-written) '(executing idle)))
+                   (test-case "valid targets from executing"
+                     (check-equal? (valid-targets 'executing) '(verifying idle)))
+                   (test-case "valid targets from verifying"
+                     (check-equal? (valid-targets 'verifying) '(idle executing))))
+
+;; ============================================================
+;; find-transition-path tests
+;; ============================================================
+
+(define-test-suite path-finding-tests
+                   (test-case "direct path idle → exploring"
+                     (define path (find-transition-path 'idle 'exploring))
+                     (check-equal? path '(exploring)))
+                   (test-case "multi-step path idle → executing"
+                     (define path (find-transition-path 'idle 'executing))
+                     (check-true (and path (pair? path) (eq? (car (reverse path)) 'executing))))
+                   (test-case "no path exploring → plan-written (direct exists)"
+                     ;; exploring → plan-written is a direct transition
+                     (define path (find-transition-path 'exploring 'plan-written))
+                     (check-equal? path '(plan-written)))
+                   (test-case "path plan-written → exploring via idle"
+                     ;; plan-written → idle → exploring
+                     (define path (find-transition-path 'plan-written 'exploring))
+                     (check-true (and path (member 'exploring path) #t)))
+                   (test-case "path to self returns empty"
+                     ;; idle → idle is handled by valid-transition? self-loop
+                     ;; find-transition-path returns #f when from == to initially but BFS finds it
+                     (define path (find-transition-path 'verifying 'verifying))
+                     (check-true (or (null? path) (not path)))))
+
+;; ============================================================
+;; compute-next-gsm-state tests
+;; ============================================================
+
+(define-test-suite
+ compute-next-tests
+ (test-case "idle → exploring: valid transition"
+   (define-values (r s) (compute-next-gsm-state (make-state 'idle) 'exploring))
+   (check-true (ok? r))
+   (check-equal? (ok-to r) 'exploring)
+   (check-equal? (gsd-runtime-state-mode s) 'exploring))
+ (test-case "executing → idle: executor cleared"
+   (define-values (r s)
+     (compute-next-gsm-state (make-state 'executing #:executor (lambda () 'work)) 'idle))
+   (check-true (ok? r))
+   (check-equal? (gsd-runtime-state-mode s) 'idle)
+   (check-false (gsd-runtime-state-wave-executor s)))
+ (test-case "executing → verifying: executor cleared"
+   (define-values (r s)
+     (compute-next-gsm-state (make-state 'executing #:executor (lambda () 'work)) 'verifying))
+   (check-true (ok? r))
+   (check-false (gsd-runtime-state-wave-executor s)))
+ (test-case "idle → executing: invalid transition"
+   (define-values (r s) (compute-next-gsm-state (make-state 'idle) 'executing))
+   (check-true (err? r))
+   (check-equal? (gsd-runtime-state-mode s) 'idle))
+ (test-case "invalid target state returns err"
+   (define-values (r _) (compute-next-gsm-state (make-state 'idle) 'nonexistent))
+   (check-true (err? r))
+   (check-equal? (err-reason r) "invalid state: nonexistent"))
+ (test-case "transition with correct event succeeds"
+   (define-values (r _) (compute-next-gsm-state (make-state 'idle) 'exploring #:event 'explore))
+   (check-true (ok? r)))
+ (test-case "transition with wrong event fails"
+   (define-values (r _) (compute-next-gsm-state (make-state 'idle) 'exploring #:event 'cancel))
+   (check-true (err? r)))
+ (test-case "err-result preserves attempted target"
+   (define-values (r _) (compute-next-gsm-state (make-state 'idle) 'executing))
+   (check-true (err? r))
+   (check-equal? (err-result-attempted r) 'executing)))
+
+;; ============================================================
+;; check-state-invariants tests
+;; ============================================================
+
+(define-test-suite
+ invariant-tests
+ (test-case "valid state passes invariants"
+   (define-values (ok? msg) (check-state-invariants (make-state 'idle)))
+   (check-true ok?)
+   (check-false msg))
+ (test-case "invalid mode fails invariants"
+   (define-values (ok? msg)
+     (check-state-invariants (gsd-runtime-state 'bad-mode 0 0 (set) #f #f #f 500 '())))
+   (check-false ok?)
+   (check-true (and (string? msg) #t)))
+ (test-case "current-wave > total-waves fails"
+   (define-values (ok? msg)
+     (check-state-invariants (make-state 'idle #:total-waves 3 #:current-wave 5)))
+   (check-false ok?))
+ (test-case "executing without executor fails when waves exist"
+   (define-values (ok? msg)
+     (check-state-invariants (make-state 'executing #:total-waves 3 #:executor #f)))
+   (check-false ok?)))
+
+;; ============================================================
+;; compute-next-pending-wave tests
+;; ============================================================
+
+(define-test-suite pending-wave-tests
+                   (test-case "all pending when none completed"
+                     (check-equal? (compute-next-pending-wave 5 (set)) 0))
+                   (test-case "returns first non-completed index"
+                     (check-equal? (compute-next-pending-wave 5 (set 0 1 2)) 3))
+                   (test-case "returns #f when all completed"
+                     (check-false (compute-next-pending-wave 3 (set 0 1 2))))
+                   (test-case "returns #f for zero waves"
+                     (check-false (compute-next-pending-wave 0 (set))))
+                   (test-case "handles non-contiguous completed set"
+                     (check-equal? (compute-next-pending-wave 5 (set 0 2 4)) 1)))
+
+;; ============================================================
+;; All tests
+;; ============================================================
+
+(define-test-suite all-transition-logic-tests
+                   result-type-tests
+                   state-predicate-tests
+                   transition-table-tests
+                   valid-transition-tests
+                   valid-targets-tests
+                   path-finding-tests
+                   compute-next-tests
+                   invariant-tests
+                   pending-wave-tests)
+
+(module+ test
+  (run-tests all-transition-logic-tests))
+
+(module+ main
+  (run-tests all-transition-logic-tests))


### PR DESCRIPTION
## W5 — GSD state-machine pure transition extraction

### Goal
Extract pure transition logic from `extensions/gsd/state-machine.rkt` into `extensions/gsd/transition-logic.rkt`, separating pure state-machine computation from mutable session-state interactions and event-bus side-effects.

### Changes
**New: `extensions/gsd/transition-logic.rkt`** (209 lines)
- `ok-result`/`err-result` structs + wrapper functions
- `GSD-STATES`, `TRANSITIONS`, `TRANSITIONS-FLAT` constants
- `gsm-state?` — pure state predicate
- `valid-transition?` — pure transition validity check
- `valid-targets` — pure target enumeration
- `find-transition-path` — pure BFS path finder
- `compute-next-gsm-state` — pure transition kernel
- `check-state-invariants` — pure invariant checker
- `compute-next-pending-wave` — pure wave computation

**Modified: `extensions/gsd/state-machine.rkt`** (586 → 429 lines, −157)
- Imports + re-exports `transition-logic.rkt` via `(all-from-out ...)`
- `gsd-invariants-hold?` delegates to `check-state-invariants`
- `gsm-next-pending-wave` delegates to `compute-next-pending-wave`
- Public API unchanged

**Bugfix**: `find-transition-path` had `(list from '())` creating a spurious empty list in returned paths. Fixed to `(cons from '())`.

**New: `tests/test-transition-logic.rkt`** (46 tests)

### Verification
- Build: PASS
- Unit-fast: 10/10 files, 102/102 tests PASS
- Smoke: 19/19 files, 286/286 tests PASS
- Existing SM tests: 79/79 PASS
- FSM property: 22/22 PASS
- Rework limit: 5/5 PASS
- Transition logic tests: 46/46 PASS

Closes #8394