### PR TITLE
W6: State-aware builder pure helper extraction (#8395)

### DIFF
--- a/runtime/context-assembly/state-aware-builder.rkt
+++ b/runtime/context-assembly/state-aware-builder.rkt
@@ -5,6 +5,12 @@
 ;;
 ;; v0.95.14: Observe-only memory telemetry is wired behind session-config gates;
 ;; prompt injection remains explicit in memory-builder.rkt.
+;;
+;; W6 v0.99.35: Pure helper functions (state coercion, text extraction,
+;; rollback trigger computation, conclusion-first replacement, state guidance)
+;; extracted to state-aware-helpers.rkt. This module focuses on the stateful
+;; orchestrator: memory observation/injection, trace callbacks, rollback action
+;; execution, and preamble generation with parameter side-effects.
 
 (require racket/list
          racket/runtime-path
@@ -26,8 +32,13 @@
                   task-conclusion-fsm-state-origin)
          (only-in "state-relevance.rkt" context-level-for-state)
          (only-in "../../util/ids.rkt" generate-id)
-         (only-in "../../util/fsm/fsm.rkt" fsm-state? fsm-state-name)
-         (only-in "../../util/content/content-parts.rkt" text-part-text text-part? text-part)
+         (only-in "state-aware-helpers.rkt"
+                  coerce-task-state
+                  extract-recent-text
+                  check-rollback-triggers
+                  check-rollback-triggers-with-actions
+                  ws-entry->conclusion-or-self
+                  state-guidance-table)
          "context-floor.rkt"
          (only-in "conclusion-graph.rkt"
                   build-conclusion-graph
@@ -35,8 +46,6 @@
                   graph-detect-cycles)
          (only-in "conclusion-ranker.rkt" rank-and-budget)
          (only-in "rollback-actions.rkt"
-                  warnings->actions
-                  select-highest-priority-action
                   maybe-execute-action
                   current-force-distill-fn
                   current-expand-context-fn
@@ -75,59 +84,6 @@
 
 ;; v0.99.7 W5: Blackboard context injection into system prompt preamble
 (define current-blackboard-injection-enabled (make-parameter #f))
-
-;; v0.96.13 WP-1: Extract recent assistant message text for memory query context.
-;; Takes a list of messages and count N, returns concatenated text of the last N
-;; assistant/user messages truncated to 200 chars. Returns #f if no text found.
-(define (extract-recent-text messages n)
-  (define assistant-msgs
-    (for/list ([m (in-list messages)]
-               #:when (and (message? m) (memq (message-role m) '(assistant user))))
-      (define content-parts (message-content m))
-      (define text
-        (for/fold ([acc ""])
-                  ([part (in-list (if (list? content-parts)
-                                      content-parts
-                                      '()))])
-          (if (text-part? part)
-              (string-append acc (if (string=? acc "") "" " ") (text-part-text part))
-              acc)))
-      text))
-  (define recent (take (reverse assistant-msgs) (min n (length assistant-msgs))))
-  (define joined (string-join (filter (lambda (s) (> (string-length s) 0)) recent) ". "))
-  (if (> (string-length joined) 0)
-      (substring joined 0 (min (string-length joined) 200))
-      #f))
-
-;; State-specific guidance strings (action-oriented instructions)
-(define state-guidance-table
-  (hasheq 'idle
-          "Awaiting instructions."
-          'exploration
-          (string-append "Focus on reading and understanding the codebase. "
-                         "Record key findings with record_conclusion before moving on.")
-          'planning
-          (string-append "Break down the task into steps. "
-                         "Save your plan as conclusions with record_conclusion.")
-          'implementation
-          (string-append "Focus on editing files. "
-                         "Record key decisions with record_conclusion. "
-                         "Prefer existing conclusions over re-reading files.")
-          'verification
-          (string-append "Run tests and verify correctness. "
-                         "Record test results as conclusions with record_conclusion.")
-          'debugging
-          (string-append "Focus on error-related files. "
-                         "Save error analysis as conclusions with record_conclusion.")))
-
-;; GAP-I v0.97.11: Extracted state coercion helper (was duplicated ×4).
-;; Converts task-state (symbol, fsm-state struct, or #f) to a bare symbol or #f.
-(define (coerce-task-state ts)
-  (cond
-    [(not ts) #f]
-    [(symbol? ts) ts]
-    [(fsm-state? ts) (fsm-state-name ts)]
-    [else #f]))
 
 ;; build-tiered-context/state-aware :
 ;;   Same signature as build-tiered-context, plus optional task-state and conclusions.
@@ -405,7 +361,7 @@
             (lambda (a)
               (define current-budget (current-conclusion-token-budget))
               (define expanded (* current-budget 2))
-              (log-warning "context-assembly: expanding budget ~a â ~a" current-budget expanded)
+              (log-warning "context-assembly: expanding budget ~a → ~a" current-budget expanded)
               (current-conclusion-token-budget expanded))]
            [current-revert-state-fn
             (lambda (a)
@@ -483,102 +439,3 @@
                    (list (make-text-part preamble-text))
                    (current-seconds)
                    (hasheq))]))
-
-;; ════════════════════════════════════════════════════════════════
-;; v0.76.3 W2: Rollback trigger checks (observational only)
-;; ════════════════════════════════════════════════════════════════
-
-;; check-rollback-triggers :
-;;   #:before-messages number? #:after-messages number?
-;;   #:conclusion-coverage number? #:repeat-tool-count exact-nonnegative-integer?
-;;   -> (listof (list/c symbol? string?))
-;;
-;; Returns a list of warning tuples: (trigger-type message).
-;; Triggers are observational — callers decide what to do.
-(define (check-rollback-triggers #:before-messages before-messages
-                                 #:after-messages after-messages
-                                 #:conclusion-coverage conclusion-coverage
-                                 #:repeat-tool-count repeat-tool-count)
-  ;; M6 (v0.97.15): Converted from imperative set! accumulation to
-  ;; pure for/fold. Each trigger conditionally appends a warning tuple.
-  (define warnings
-    (reverse
-     (for/fold ([acc '()])
-               ([trigger
-                 (in-list
-                  ;; Trigger 1: Excessive savings (>50% messages cut)
-                  (list (and (and (> before-messages 0)
-                                  (> after-messages 0)
-                                  (< after-messages (* before-messages 0.50)))
-                             (list 'excessive-savings
-                                   (format "Context reduced by >50%: ~a → ~a messages"
-                                           before-messages
-                                           after-messages)))
-                        ;; Trigger 2: Low conclusion coverage (amnesia risk)
-                        (and (< conclusion-coverage 0.20)
-                             (list 'amnesia-risk
-                                   (format "Conclusion coverage too low: ~a" conclusion-coverage)))
-                        ;; Trigger 3: Repeated tool calls (same file re-read > 2x)
-                        (and (> repeat-tool-count 2)
-                             (list 'task-amnesia-detected
-                                   (format "Repeated tool calls detected: ~a re-reads"
-                                           repeat-tool-count)))
-                        ;; Trigger 4 — Stuck detection (>=6 tool calls, 0 conclusions)
-                        ;; NOTE: this AND Trigger 3 both fire when repeat>=6 and coverage=0.
-                        (and (>= repeat-tool-count 6)
-                             (= conclusion-coverage 0)
-                             (list 'stuck-detected
-                                   (format "stuck: ~a tool calls without recording conclusions"
-                                           repeat-tool-count)))))])
-       (if trigger
-           (cons trigger acc)
-           acc))))
-  warnings)
-
-;; v0.77.6 W6.2: Extended trigger output with recommended actions.
-;; Returns (values warnings recommended-action) where recommended-action
-;; is the highest-priority rollback-action or #f.
-(define (check-rollback-triggers-with-actions #:before-messages before-messages
-                                              #:after-messages after-messages
-                                              #:conclusion-coverage conclusion-coverage
-                                              #:repeat-tool-count repeat-tool-count)
-  (define warnings
-    (check-rollback-triggers #:before-messages before-messages
-                             #:after-messages after-messages
-                             #:conclusion-coverage conclusion-coverage
-                             #:repeat-tool-count repeat-tool-count))
-  ;; Pass full (symbol . string) pairs to warnings->actions for symbol-based matching.
-  (define actions (warnings->actions warnings))
-  (define recommended (select-highest-priority-action actions))
-  (values warnings recommended))
-
-;; ════════════════════════════════════════════════════════════════
-;; v0.76.4 M5 W0: Conclusion-first working-set replacement
-;; ════════════════════════════════════════════════════════════════
-
-;; ws-entry->conclusion-or-self :
-;;   message? (listof task-conclusion?) -> message?
-;; If a conclusion references this message's ID via origin-message-ids,
-;; returns a compact replacement message with conclusion text.
-;; Otherwise returns the original message unchanged.
-(define (ws-entry->conclusion-or-self ws-msg conclusions)
-  (define msg-id-val (message-id ws-msg))
-  ;; v0.76.7 C1+C2: Use ormap+equal? for robust matching across types
-  (define (origin-matches? c)
-    (define oids (task-conclusion-origin-message-ids c))
-    (and (pair? oids) (ormap (lambda (oid) (equal? msg-id-val oid)) oids)))
-  (define matching-conclusion
-    (for/first ([c (in-list conclusions)]
-                #:when (and (task-conclusion? c) (origin-matches? c)))
-      c))
-  (cond
-    [matching-conclusion
-     (make-message (message-id ws-msg)
-                   #f
-                   'system
-                   'system-instruction
-                   (list (make-text-part (format "[Conclusion replaces context] ~a"
-                                                 (task-conclusion-text matching-conclusion))))
-                   (current-seconds)
-                   (hasheq))]
-    [else ws-msg]))

--- a/runtime/context-assembly/state-aware-helpers.rkt
+++ b/runtime/context-assembly/state-aware-helpers.rkt
@@ -1,0 +1,182 @@
+#lang racket/base
+
+;; runtime/context-assembly/state-aware-helpers.rkt
+;; W6 v0.99.35: Pure helpers extracted from state-aware-builder.rkt
+;;
+;; These functions perform pure computation — no I/O, no parameter mutation,
+;; no event emission, no logging. They can be tested without runtime setup.
+;;
+;; STABILITY: evolving
+
+(require racket/list
+         racket/string
+         (only-in "../../util/content/content-parts.rkt" make-text-part text-part? text-part-text)
+         (only-in "../../util/message/message.rkt"
+                  message?
+                  message-id
+                  message-content
+                  message-role
+                  make-message)
+         (only-in "task-conclusion.rkt"
+                  task-conclusion?
+                  task-conclusion-text
+                  task-conclusion-origin-message-ids)
+         (only-in "../../util/fsm/fsm.rkt" fsm-state? fsm-state-name)
+         (only-in "rollback-actions.rkt" warnings->actions select-highest-priority-action))
+
+(provide coerce-task-state
+         extract-recent-text
+         check-rollback-triggers
+         check-rollback-triggers-with-actions
+         ws-entry->conclusion-or-self
+         state-guidance-table)
+
+;; ============================================================
+;; State coercion (pure)
+;; ============================================================
+
+;; Converts task-state (symbol, fsm-state struct, or #f) to a bare symbol or #f.
+(define (coerce-task-state ts)
+  (cond
+    [(not ts) #f]
+    [(symbol? ts) ts]
+    [(fsm-state? ts) (fsm-state-name ts)]
+    [else #f]))
+
+;; ============================================================
+;; Recent text extraction (pure)
+;; ============================================================
+
+;; Takes a list of messages and count N, returns concatenated text of the last N
+;; assistant/user messages truncated to 200 chars. Returns #f if no text found.
+(define (extract-recent-text messages n)
+  (define assistant-msgs
+    (for/list ([m (in-list messages)]
+               #:when (and (message? m) (memq (message-role m) '(assistant user))))
+      (define content-parts (message-content m))
+      (define text
+        (for/fold ([acc ""])
+                  ([part (in-list (if (list? content-parts)
+                                      content-parts
+                                      '()))])
+          (if (text-part? part)
+              (string-append acc (if (string=? acc "") "" " ") (text-part-text part))
+              acc)))
+      text))
+  (define recent (take (reverse assistant-msgs) (min n (length assistant-msgs))))
+  (define joined (string-join (filter (lambda (s) (> (string-length s) 0)) recent) ". "))
+  (if (> (string-length joined) 0)
+      (substring joined 0 (min (string-length joined) 200))
+      #f))
+
+;; ============================================================
+;; State guidance table (pure constant)
+;; ============================================================
+
+;; State-specific guidance strings (action-oriented instructions)
+(define state-guidance-table
+  (hasheq 'idle
+          "Awaiting instructions."
+          'exploration
+          (string-append "Focus on reading and understanding the codebase. "
+                         "Record key findings with record_conclusion before moving on.")
+          'planning
+          (string-append "Break down the task into steps. "
+                         "Save your plan as conclusions with record_conclusion.")
+          'implementation
+          (string-append "Focus on editing files. "
+                         "Record key decisions with record_conclusion. "
+                         "Prefer existing conclusions over re-reading files.")
+          'verification
+          (string-append "Run tests and verify correctness. "
+                         "Record test results as conclusions with record_conclusion.")
+          'debugging
+          (string-append "Focus on error-related files. "
+                         "Save error analysis as conclusions with record_conclusion.")))
+
+;; ============================================================
+;; Rollback trigger checks (pure)
+;; ============================================================
+
+;; Returns a list of warning tuples: (trigger-type message).
+;; Triggers are observational — callers decide what to do.
+(define (check-rollback-triggers #:before-messages before-messages
+                                 #:after-messages after-messages
+                                 #:conclusion-coverage conclusion-coverage
+                                 #:repeat-tool-count repeat-tool-count)
+  (define warnings
+    (reverse
+     (for/fold ([acc '()])
+               ([trigger
+                 (in-list
+                  ;; Trigger 1: Excessive savings (>50% messages cut)
+                  (list (and (and (> before-messages 0)
+                                  (> after-messages 0)
+                                  (< after-messages (* before-messages 0.50)))
+                             (list 'excessive-savings
+                                   (format "Context reduced by >50%: ~a → ~a messages"
+                                           before-messages
+                                           after-messages)))
+                        ;; Trigger 2: Low conclusion coverage (amnesia risk)
+                        (and (< conclusion-coverage 0.20)
+                             (list 'amnesia-risk
+                                   (format "Conclusion coverage too low: ~a" conclusion-coverage)))
+                        ;; Trigger 3: Repeated tool calls (same file re-read > 2x)
+                        (and (> repeat-tool-count 2)
+                             (list 'task-amnesia-detected
+                                   (format "Repeated tool calls detected: ~a re-reads"
+                                           repeat-tool-count)))
+                        ;; Trigger 4 — Stuck detection (>=6 tool calls, 0 conclusions)
+                        (and (>= repeat-tool-count 6)
+                             (= conclusion-coverage 0)
+                             (list 'stuck-detected
+                                   (format "stuck: ~a tool calls without recording conclusions"
+                                           repeat-tool-count)))))])
+       (if trigger
+           (cons trigger acc)
+           acc))))
+  warnings)
+
+;; Returns (values warnings recommended-action) where recommended-action
+;; is the highest-priority rollback-action or #f.
+(define (check-rollback-triggers-with-actions #:before-messages before-messages
+                                              #:after-messages after-messages
+                                              #:conclusion-coverage conclusion-coverage
+                                              #:repeat-tool-count repeat-tool-count)
+  (define warnings
+    (check-rollback-triggers #:before-messages before-messages
+                             #:after-messages after-messages
+                             #:conclusion-coverage conclusion-coverage
+                             #:repeat-tool-count repeat-tool-count))
+  ;; Pass full (symbol . string) pairs to warnings->actions for symbol-based matching.
+  (define actions (warnings->actions warnings))
+  (define recommended (select-highest-priority-action actions))
+  (values warnings recommended))
+
+;; ============================================================
+;; Conclusion-first working-set replacement (pure)
+;; ============================================================
+
+;; If a conclusion references this message's ID via origin-message-ids,
+;; returns a compact replacement message with conclusion text.
+;; Otherwise returns the original message unchanged.
+(define (ws-entry->conclusion-or-self ws-msg conclusions)
+  (define msg-id-val (message-id ws-msg))
+  (define (origin-matches? c)
+    (define oids (task-conclusion-origin-message-ids c))
+    (and (pair? oids) (ormap (lambda (oid) (equal? msg-id-val oid)) oids)))
+  (define matching-conclusion
+    (for/first ([c (in-list conclusions)]
+                #:when (and (task-conclusion? c) (origin-matches? c)))
+      c))
+  (cond
+    [matching-conclusion
+     (make-message (message-id ws-msg)
+                   #f
+                   'system
+                   'system-instruction
+                   (list (make-text-part (format "[Conclusion replaces context] ~a"
+                                                 (task-conclusion-text matching-conclusion))))
+                   (current-seconds)
+                   (hasheq))]
+    [else ws-msg]))

--- a/tests/test-state-aware-helpers.rkt
+++ b/tests/test-state-aware-helpers.rkt
@@ -1,0 +1,263 @@
+#lang racket/base
+
+;; @speed fast
+;; @suite fast
+
+;; W6 v0.99.35: Tests for state-aware-helpers.rkt
+;; Pure functions extracted from state-aware-builder.rkt.
+;; Tests cover: state coercion, text extraction, rollback trigger computation,
+;; conclusion-first replacement, state guidance table.
+
+(require rackunit
+         rackunit/text-ui
+         racket/string
+         (only-in "../util/content/content-parts.rkt" make-text-part text-part)
+         (only-in "../util/message/message.rkt" make-message message-id message-role message-content)
+         (only-in "../runtime/context-assembly/task-conclusion.rkt"
+                  task-conclusion
+                  task-conclusion?
+                  task-conclusion-text
+                  task-conclusion-origin-message-ids)
+         (only-in "../util/fsm/fsm.rkt" fsm-state fsm-state?)
+         "../runtime/context-assembly/state-aware-helpers.rkt")
+
+;; ============================================================
+;; Helpers
+;; ============================================================
+
+(define (make-text-message role text)
+  (make-message "msg-id" #f role 'text (list (make-text-part text)) (current-seconds) (hasheq)))
+
+;; ============================================================
+;; coerce-task-state tests
+;; ============================================================
+
+(define-test-suite coerce-task-state-tests
+                   (test-case "coerces symbol to itself"
+                     (check-equal? (coerce-task-state 'idle) 'idle)
+                     (check-equal? (coerce-task-state 'exploring) 'exploring))
+                   (test-case "coerces #f to #f"
+                     (check-false (coerce-task-state #f)))
+                   (test-case "coerces fsm-state to its name"
+                     (check-equal? (coerce-task-state (fsm-state 'planning)) 'planning))
+                   (test-case "coerces invalid input to #f"
+                     (check-false (coerce-task-state 42))
+                     (check-false (coerce-task-state "idle"))
+                     (check-false (coerce-task-state '()))))
+
+;; ============================================================
+;; extract-recent-text tests
+;; ============================================================
+
+(define-test-suite
+ extract-recent-text-tests
+ (test-case "extracts text from assistant messages"
+   (define msgs (list (make-text-message 'user "Hello") (make-text-message 'assistant "World")))
+   (define result (extract-recent-text msgs 3))
+   (check-true (string? result))
+   (check-true (string-contains? result "Hello"))
+   (check-true (string-contains? result "World")))
+ (test-case "returns #f for empty message list"
+   (check-false (extract-recent-text '() 3)))
+ (test-case "returns #f for no assistant/user messages"
+   (define msgs (list (make-text-message 'system "sys")))
+   (check-false (extract-recent-text msgs 3)))
+ (test-case "limits to N most recent messages"
+   (define msgs
+     (list (make-text-message 'user "first")
+           (make-text-message 'assistant "second")
+           (make-text-message 'user "third")
+           (make-text-message 'assistant "fourth")))
+   (define result (extract-recent-text msgs 2))
+   ;; With n=2, we get the last 2: "fourth" and "third"
+   (check-true (string-contains? result "fourth"))
+   (check-true (string-contains? result "third")))
+ (test-case "truncates to 200 characters"
+   (define long-text (make-string 300 #\x))
+   (define msgs (list (make-text-message 'assistant long-text)))
+   (define result (extract-recent-text msgs 1))
+   (check-true (string? result))
+   (check-true (<= (string-length result) 200)))
+ (test-case "handles N larger than message count"
+   (define msgs (list (make-text-message 'assistant "only one")))
+   (define result (extract-recent-text msgs 10))
+   (check-true (string-contains? result "only one"))))
+
+;; ============================================================
+;; state-guidance-table tests
+;; ============================================================
+
+(define-test-suite state-guidance-table-tests
+                   (test-case "has entry for idle"
+                     (check-true (string? (hash-ref state-guidance-table 'idle #f))))
+                   (test-case "has entry for exploration"
+                     (check-true (string? (hash-ref state-guidance-table 'exploration #f))))
+                   (test-case "has entry for planning"
+                     (check-true (string? (hash-ref state-guidance-table 'planning #f))))
+                   (test-case "has entry for implementation"
+                     (check-true (string? (hash-ref state-guidance-table 'implementation #f))))
+                   (test-case "has entry for verification"
+                     (check-true (string? (hash-ref state-guidance-table 'verification #f))))
+                   (test-case "has entry for debugging"
+                     (check-true (string? (hash-ref state-guidance-table 'debugging #f))))
+                   (test-case "returns #f for unknown state"
+                     (check-false (hash-ref state-guidance-table 'nonexistent #f))))
+
+;; ============================================================
+;; check-rollback-triggers tests
+;; ============================================================
+
+(define-test-suite check-rollback-triggers-tests
+                   (test-case "no triggers when healthy"
+                     (define warnings
+                       (check-rollback-triggers #:before-messages 10
+                                                #:after-messages 10
+                                                #:conclusion-coverage 0.5
+                                                #:repeat-tool-count 1))
+                     (check-true (null? warnings)))
+                   (test-case "excessive-savings when >50% messages cut"
+                     (define warnings
+                       (check-rollback-triggers #:before-messages 100
+                                                #:after-messages 40
+                                                #:conclusion-coverage 0.5
+                                                #:repeat-tool-count 1))
+                     (check-true (and (pair? warnings)
+                                      (eq? (car (car warnings)) 'excessive-savings))))
+                   (test-case "no excessive-savings when after-messages is 0"
+                     (define warnings
+                       (check-rollback-triggers #:before-messages 100
+                                                #:after-messages 0
+                                                #:conclusion-coverage 0.5
+                                                #:repeat-tool-count 1))
+                     (check-false (for/or ([w warnings])
+                                    (eq? (car w) 'excessive-savings))))
+                   (test-case "amnesia-risk when coverage < 0.20"
+                     (define warnings
+                       (check-rollback-triggers #:before-messages 10
+                                                #:after-messages 10
+                                                #:conclusion-coverage 0.10
+                                                #:repeat-tool-count 0))
+                     (check-true (and (pair? warnings)
+                                      (for/or ([w warnings])
+                                        (eq? (car w) 'amnesia-risk)))))
+                   (test-case "no amnesia-risk when coverage >= 0.20"
+                     (define warnings
+                       (check-rollback-triggers #:before-messages 10
+                                                #:after-messages 10
+                                                #:conclusion-coverage 0.20
+                                                #:repeat-tool-count 0))
+                     (check-false (for/or ([w warnings])
+                                    (eq? (car w) 'amnesia-risk))))
+                   (test-case "task-amnesia when repeat-tool-count > 2"
+                     (define warnings
+                       (check-rollback-triggers #:before-messages 10
+                                                #:after-messages 10
+                                                #:conclusion-coverage 0.5
+                                                #:repeat-tool-count 3))
+                     (check-true (and (pair? warnings)
+                                      (for/or ([w warnings])
+                                        (eq? (car w) 'task-amnesia-detected)))))
+                   (test-case "stuck-detected when repeat >= 6 and coverage = 0"
+                     (define warnings
+                       (check-rollback-triggers #:before-messages 10
+                                                #:after-messages 10
+                                                #:conclusion-coverage 0
+                                                #:repeat-tool-count 6))
+                     (check-true (and (pair? warnings)
+                                      (for/or ([w warnings])
+                                        (eq? (car w) 'stuck-detected)))))
+                   (test-case "no stuck when repeat >= 6 but coverage > 0"
+                     (define warnings
+                       (check-rollback-triggers #:before-messages 10
+                                                #:after-messages 10
+                                                #:conclusion-coverage 0.1
+                                                #:repeat-tool-count 6))
+                     (check-false (for/or ([w warnings])
+                                    (eq? (car w) 'stuck-detected))))
+                   (test-case "multiple triggers fire simultaneously"
+                     (define warnings
+                       (check-rollback-triggers #:before-messages 100
+                                                #:after-messages 10
+                                                #:conclusion-coverage 0.0
+                                                #:repeat-tool-count 6))
+                     ;; Should have excessive-savings, amnesia-risk, task-amnesia, stuck-detected
+                     (check-true (>= (length warnings) 3))))
+
+;; ============================================================
+;; check-rollback-triggers-with-actions tests
+;; ============================================================
+
+(define-test-suite triggers-with-actions-tests
+                   (test-case "returns warnings and recommended-action"
+                     (define-values (warnings action)
+                       (check-rollback-triggers-with-actions #:before-messages 100
+                                                             #:after-messages 10
+                                                             #:conclusion-coverage 0.0
+                                                             #:repeat-tool-count 6))
+                     (check-true (pair? warnings)))
+                   (test-case "no triggers yields empty warnings and #f action"
+                     (define-values (warnings action)
+                       (check-rollback-triggers-with-actions #:before-messages 10
+                                                             #:after-messages 10
+                                                             #:conclusion-coverage 0.5
+                                                             #:repeat-tool-count 0))
+                     (check-true (null? warnings))))
+
+;; ============================================================
+;; ws-entry->conclusion-or-self tests
+;; ============================================================
+
+(define-test-suite ws-entry->conclusion-or-self-tests
+                   (test-case "returns conclusion when origin-message-ids matches"
+                     (define ws-msg (make-text-message 'assistant "original content"))
+                     (define msg-id-val (message-id ws-msg))
+                     (define conclusion
+                       (task-conclusion "concl-id"
+                                        "This is the conclusion text"
+                                        'fact
+                                        'implementation
+                                        (list msg-id-val)
+                                        (current-seconds)
+                                        '()
+                                        '()))
+                     (define result (ws-entry->conclusion-or-self ws-msg (list conclusion)))
+                     ;; The result should be a replacement message (system role)
+                     (check-equal? (message-role result) 'system)
+                     (check-true (and (pair? (message-content result))
+                                      (string-contains? (format "~a" (message-content result))
+                                                        "Conclusion replaces context"))))
+                   (test-case "returns original when no matching conclusion"
+                     (define ws-msg (make-text-message 'assistant "original content"))
+                     (define result (ws-entry->conclusion-or-self ws-msg '()))
+                     (check-equal? (message-role result) 'assistant))
+                   (test-case "returns original when conclusion does not match"
+                     (define ws-msg (make-text-message 'assistant "original content"))
+                     (define conclusion
+                       (task-conclusion "concl-id"
+                                        "Conclusion text"
+                                        'fact
+                                        'implementation
+                                        (list "different-id")
+                                        (current-seconds)
+                                        '()
+                                        '()))
+                     (define result (ws-entry->conclusion-or-self ws-msg (list conclusion)))
+                     (check-equal? (message-role result) 'assistant)))
+
+;; ============================================================
+;; All tests
+;; ============================================================
+
+(define-test-suite all-state-aware-helpers-tests
+                   coerce-task-state-tests
+                   extract-recent-text-tests
+                   state-guidance-table-tests
+                   check-rollback-triggers-tests
+                   triggers-with-actions-tests
+                   ws-entry->conclusion-or-self-tests)
+
+(module+ test
+  (run-tests all-state-aware-helpers-tests))
+
+(module+ main
+  (run-tests all-state-aware-helpers-tests))


### PR DESCRIPTION
## W6 — State-aware builder pure helper extraction

### Goal
Extract pure helper functions from `runtime/context-assembly/state-aware-builder.rkt` into `runtime/context-assembly/state-aware-helpers.rkt`, separating pure assembly computation from stateful orchestration.

### Changes
**New: `runtime/context-assembly/state-aware-helpers.rkt`** (182 lines)
- `coerce-task-state` — converts symbol/fsm-state/#f to bare symbol or #f
- `extract-recent-text` — concatenates last N assistant/user messages
- `state-guidance-table` — state-specific guidance string constant
- `check-rollback-triggers` — pure rollback trigger computation (4 triggers)
- `check-rollback-triggers-with-actions` — trigger computation + action mapping
- `ws-entry->conclusion-or-self` — pure conclusion-first working-set replacement

**Modified: `runtime/context-assembly/state-aware-builder.rkt`** (584 → 441 lines, −143)
- Imports all 6 functions from helpers module via `(only-in ...)`
- Removed extracted definitions and now-unused imports
- Public API unchanged

**New: `tests/test-state-aware-helpers.rkt`** (31 tests)

### Verification
- Build: PASS
- Unit-fast: 10/10 files, 102/102 tests PASS
- Smoke: 19/19 files, 286/286 tests PASS
- Rollback triggers: 9/9 PASS
- WS conclusion fallback: 3/3 PASS
- State-aware assembly: 20/20 PASS
- Context assembly pure: 4/4 PASS
- Pre-existing failure (W0 HF1 injection): unchanged

Closes #8395