### PR TITLE
W8: Anthropic provider narrow pure helper extraction (#8397)

### DIFF
--- a/llm/anthropic-helpers.rkt
+++ b/llm/anthropic-helpers.rkt
@@ -1,0 +1,64 @@
+#lang racket/base
+
+;; llm/anthropic-helpers.rkt — Pure helper functions for Anthropic provider
+;;
+;; W8 v0.99.35: Narrow extraction of pure parse/format functions from
+;; llm/anthropic.rkt. These functions perform pure hash→hash transformations
+;; with no I/O, no state mutation, no side effects, and no logging.
+;;
+;; STABILITY: evolving
+
+(require racket/match
+         (only-in "vision-helpers.rkt" parse-data-url))
+
+(provide openai-block->anthropic
+         anthropic-translate-tool
+         translate-anthropic-usage)
+
+;; ============================================================
+;; Content block conversion (request side)
+;; ============================================================
+
+;; Convert OpenAI-format content blocks to Anthropic content blocks.
+;; Handles: text (passthrough), image_url → image (base64 decode via parse-data-url).
+(define (openai-block->anthropic block)
+  (define btype (hash-ref block 'type "text"))
+  (cond
+    [(equal? btype "text") block]
+    [(equal? btype "image_url")
+     (define image-url-hash (hash-ref block 'image_url (hasheq)))
+     (define url (hash-ref image-url-hash 'url ""))
+     (define-values (mime data) (parse-data-url url))
+     (hasheq 'type "image" 'source (hasheq 'type "base64" 'media_type mime 'data data))]
+    [else block]))
+
+;; ============================================================
+;; Tool definition translation (request side)
+;; ============================================================
+
+;; Translate a normalized tool definition to Anthropic format.
+;; Input: {"type":"function","function":{"name":"...","description":"...","parameters":{}}}
+;; Output: {"name":"...","description":"...","input_schema":{...}}
+(define (anthropic-translate-tool tool)
+  (define fn (hash-ref tool 'function tool))
+  (define name (hash-ref fn 'name "unknown"))
+  (define description (hash-ref fn 'description ""))
+  (define parameters (hash-ref fn 'parameters (hasheq)))
+  (hasheq 'name name 'description description 'input_schema parameters))
+
+;; ============================================================
+;; Usage normalization (response side)
+;; ============================================================
+
+;; Translate Anthropic usage hash to normalized format.
+;; input_tokens → prompt_tokens, output_tokens → completion_tokens,
+;; total_tokens = input + output.
+(define (translate-anthropic-usage usage-raw)
+  (define input-tokens (hash-ref usage-raw 'input_tokens 0))
+  (define output-tokens (hash-ref usage-raw 'output_tokens 0))
+  (hasheq 'prompt_tokens
+          input-tokens
+          'completion_tokens
+          output-tokens
+          'total_tokens
+          (+ input-tokens output-tokens)))

--- a/llm/anthropic.rkt
+++ b/llm/anthropic.rkt
@@ -25,7 +25,8 @@
          "provider.rkt"
          "stream.rkt"
          "http-helpers.rkt"
-         (only-in "vision-helpers.rkt" parse-data-url))
+         ;; W8 v0.99.35: Pure helpers extracted from this module
+         "anthropic-helpers.rkt")
 
 ;; Provider constructor
 (provide (contract-out [make-anthropic-provider (-> hash? provider?)])
@@ -59,17 +60,7 @@
 ;; Image block conversion (GAP-V1: cross-provider vision)
 ;; ============================================================
 
-;; Convert OpenAI-format content blocks to Anthropic content blocks.
-(define (openai-block->anthropic block)
-  (define btype (hash-ref block 'type "text"))
-  (cond
-    [(equal? btype "text") block]
-    [(equal? btype "image_url")
-     (define image-url-hash (hash-ref block 'image_url (hasheq)))
-     (define url (hash-ref image-url-hash 'url ""))
-     (define-values (mime data) (parse-data-url url))
-     (hasheq 'type "image" 'source (hasheq 'type "base64" 'media_type mime 'data data))]
-    [else block]))
+;; W8 v0.99.35: openai-block->anthropic extracted to anthropic-helpers.rkt
 
 ;; Convert normalized model-request to Anthropic Messages API body.
 (define (anthropic-build-request-body req #:stream? [stream? #f])
@@ -262,15 +253,7 @@
 
   with-tools)
 
-;; Translate a normalized tool definition to Anthropic format.
-;; Input: {"type":"function","function":{"name":"...","description":"...","parameters":{}}}
-;; Output: {"name":"...","description":"...","input_schema":{...}}
-(define (anthropic-translate-tool tool)
-  (define fn (hash-ref tool 'function tool))
-  (define name (hash-ref fn 'name "unknown"))
-  (define description (hash-ref fn 'description ""))
-  (define parameters (hash-ref fn 'parameters (hasheq)))
-  (hasheq 'name name 'description description 'input_schema parameters))
+;; W8 v0.99.35: anthropic-translate-tool extracted to anthropic-helpers.rkt
 
 ;; ============================================================
 ;; Response parsing
@@ -286,14 +269,8 @@
   ;; Translate stop reason
   (define stop-reason (translate-stop-reason 'anthropic stop-reason-raw))
 
-  ;; Translate usage: input_tokens → prompt_tokens, output_tokens → completion_tokens
-  (define usage
-    (hasheq 'prompt_tokens
-            (hash-ref usage-raw 'input_tokens 0)
-            'completion_tokens
-            (hash-ref usage-raw 'output_tokens 0)
-            'total_tokens
-            (+ (hash-ref usage-raw 'input_tokens 0) (hash-ref usage-raw 'output_tokens 0))))
+  ;; W8 v0.99.35: Usage translation extracted to anthropic-helpers.rkt
+  (define usage (translate-anthropic-usage usage-raw))
 
   ;; Translate content blocks
   (define content

--- a/tests/test-anthropic-helpers.rkt
+++ b/tests/test-anthropic-helpers.rkt
@@ -1,0 +1,151 @@
+#lang racket/base
+
+;; @speed fast
+;; @suite fast
+
+;; W8 v0.99.35: Tests for anthropic-helpers.rkt
+;; Pure functions extracted from llm/anthropic.rkt.
+;; Tests cover: content block conversion, tool definition translation,
+;; usage normalization — all edge cases.
+
+(require rackunit
+         rackunit/text-ui
+         "../llm/anthropic-helpers.rkt")
+
+;; ============================================================
+;; openai-block->anthropic tests
+;; ============================================================
+
+(define-test-suite
+ openai-block->anthropic-tests
+ (test-case "text block passes through unchanged"
+   (define block (hasheq 'type "text" 'text "hello"))
+   (check-equal? (openai-block->anthropic block) block))
+ (test-case "text block with default type when missing"
+   (define block (hasheq 'text "hello"))
+   (check-equal? (openai-block->anthropic block) block))
+ (test-case "image_url block converts to Anthropic image format"
+   (define block (hasheq 'type "image_url" 'image_url (hasheq 'url "data:image/png;base64,iVBOR")))
+   (define result (openai-block->anthropic block))
+   (check-equal? (hash-ref result 'type) "image")
+   (define source (hash-ref result 'source))
+   (check-equal? (hash-ref source 'type) "base64")
+   (check-equal? (hash-ref source 'media_type) "image/png")
+   (check-equal? (hash-ref source 'data) "iVBOR"))
+ (test-case "image_url with jpeg data url"
+   (define block (hasheq 'type "image_url" 'image_url (hasheq 'url "data:image/jpeg;base64,/9j/")))
+   (define result (openai-block->anthropic block))
+   (check-equal? (hash-ref result 'type) "image")
+   (check-equal? (hash-ref (hash-ref result 'source) 'media_type) "image/jpeg")
+   (check-equal? (hash-ref (hash-ref result 'source) 'data) "/9j/"))
+ (test-case "unknown block type passes through unchanged"
+   (define block (hasheq 'type "custom" 'foo "bar"))
+   (check-equal? (openai-block->anthropic block) block))
+ (test-case "image_url with missing url defaults to empty"
+   (define block (hasheq 'type "image_url"))
+   (define result (openai-block->anthropic block))
+   (check-equal? (hash-ref result 'type) "image")))
+
+;; ============================================================
+;; anthropic-translate-tool tests
+;; ============================================================
+
+(define-test-suite
+ anthropic-translate-tool-tests
+ (test-case "standard function tool"
+   (define tool
+     (hasheq
+      'type
+      "function"
+      'function
+      (hasheq 'name "get_weather" 'description "Get weather" 'parameters (hasheq 'type "object"))))
+   (define result (anthropic-translate-tool tool))
+   (check-equal? (hash-ref result 'name) "get_weather")
+   (check-equal? (hash-ref result 'description) "Get weather")
+   (check-equal? (hash-ref (hash-ref result 'input_schema) 'type) "object"))
+ (test-case "tool without type wrapper (direct function hash)"
+   (define tool (hasheq 'name "bash" 'description "Run bash" 'parameters (hasheq)))
+   (define result (anthropic-translate-tool tool))
+   (check-equal? (hash-ref result 'name) "bash")
+   (check-equal? (hash-ref result 'description) "Run bash"))
+ (test-case "missing name defaults to unknown"
+   (define tool (hasheq 'function (hasheq 'description "no name")))
+   (define result (anthropic-translate-tool tool))
+   (check-equal? (hash-ref result 'name) "unknown"))
+ (test-case "missing description defaults to empty"
+   (define tool (hasheq 'function (hasheq 'name "tool1")))
+   (define result (anthropic-translate-tool tool))
+   (check-equal? (hash-ref result 'description) ""))
+ (test-case "missing parameters defaults to empty hash"
+   (define tool (hasheq 'function (hasheq 'name "tool2" 'description "test")))
+   (define result (anthropic-translate-tool tool))
+   (check-equal? (hash-ref result 'input_schema) (hasheq)))
+ (test-case "complex nested parameters preserved"
+   (define params
+     (hasheq 'type
+             "object"
+             'properties
+             (hasheq 'location (hasheq 'type "string"))
+             'required
+             (list "location")))
+   (define tool (hasheq 'function (hasheq 'name "weather" 'parameters params)))
+   (define result (anthropic-translate-tool tool))
+   (check-equal? (hash-ref result 'input_schema) params)))
+
+;; ============================================================
+;; translate-anthropic-usage tests
+;; ============================================================
+
+(define-test-suite translate-anthropic-usage-tests
+                   (test-case "standard usage with both token types"
+                     (define usage (hasheq 'input_tokens 100 'output_tokens 50))
+                     (define result (translate-anthropic-usage usage))
+                     (check-equal? (hash-ref result 'prompt_tokens) 100)
+                     (check-equal? (hash-ref result 'completion_tokens) 50)
+                     (check-equal? (hash-ref result 'total_tokens) 150))
+                   (test-case "zero tokens"
+                     (define usage (hasheq 'input_tokens 0 'output_tokens 0))
+                     (define result (translate-anthropic-usage usage))
+                     (check-equal? (hash-ref result 'total_tokens) 0))
+                   (test-case "large token counts"
+                     (define usage (hasheq 'input_tokens 100000 'output_tokens 50000))
+                     (define result (translate-anthropic-usage usage))
+                     (check-equal? (hash-ref result 'total_tokens) 150000))
+                   (test-case "missing input_tokens defaults to 0"
+                     (define usage (hasheq 'output_tokens 30))
+                     (define result (translate-anthropic-usage usage))
+                     (check-equal? (hash-ref result 'prompt_tokens) 0)
+                     (check-equal? (hash-ref result 'completion_tokens) 30)
+                     (check-equal? (hash-ref result 'total_tokens) 30))
+                   (test-case "missing output_tokens defaults to 0"
+                     (define usage (hasheq 'input_tokens 70))
+                     (define result (translate-anthropic-usage usage))
+                     (check-equal? (hash-ref result 'prompt_tokens) 70)
+                     (check-equal? (hash-ref result 'completion_tokens) 0)
+                     (check-equal? (hash-ref result 'total_tokens) 70))
+                   (test-case "empty usage hash"
+                     (define result (translate-anthropic-usage (hasheq)))
+                     (check-equal? (hash-ref result 'prompt_tokens) 0)
+                     (check-equal? (hash-ref result 'completion_tokens) 0)
+                     (check-equal? (hash-ref result 'total_tokens) 0))
+                   (test-case "result keys are correct"
+                     (define result
+                       (translate-anthropic-usage (hasheq 'input_tokens 1 'output_tokens 1)))
+                     (check-true (hash-has-key? result 'prompt_tokens))
+                     (check-true (hash-has-key? result 'completion_tokens))
+                     (check-true (hash-has-key? result 'total_tokens))))
+
+;; ============================================================
+;; All tests
+;; ============================================================
+
+(define-test-suite all-anthropic-helpers-tests
+                   openai-block->anthropic-tests
+                   anthropic-translate-tool-tests
+                   translate-anthropic-usage-tests)
+
+(module+ test
+  (run-tests all-anthropic-helpers-tests))
+
+(module+ main
+  (run-tests all-anthropic-helpers-tests))


### PR DESCRIPTION
## W8 — Anthropic provider narrow pure helper extraction

### Goal
Narrow extraction of the safest pure functions from `llm/anthropic.rkt` into `llm/anthropic-helpers.rkt`. This is a **HIGH RISK (RED)** module — the primary LLM provider — so extraction is intentionally conservative.

### Changes
**New: `llm/anthropic-helpers.rkt`** (64 lines)
- `openai-block->anthropic` — converts OpenAI content blocks to Anthropic format (text passthrough, image_url → base64 image)
- `anthropic-translate-tool` — translates tool definitions to Anthropic input_schema format
- `translate-anthropic-usage` — normalizes Anthropic token counts to standard format

**Modified: `llm/anthropic.rkt`** (662 → 639 lines, −23)
- Removed `parse-data-url` import (now used only in helpers module)
- Added `anthropic-helpers.rkt` import
- Removed 3 function definitions
- Replaced inline usage translation with `translate-anthropic-usage` call
- **Public API unchanged** — all functions still provided via existing exports

**New: `tests/test-anthropic-helpers.rkt`** (19 tests)

### Verification
- Build: PASS
- Unit-fast: 10/10 files, 102/102 tests PASS
- Smoke: 19/19 files, 286/286 tests PASS
- Existing anthropic tests: 133 passed (no regressions)

Closes #8397