### PR TITLE
docs: record v0.99.35 remediation PR number (#8409)

### DIFF
--- a/docs/reports/AUDIT-v0.99.35-POST-IMPLEMENTATION.md
+++ b/docs/reports/AUDIT-v0.99.35-POST-IMPLEMENTATION.md
@@ -61,7 +61,7 @@ unit-fast + smoke gates.
 | W7 | #8396 | TUI core-handlers pure helper extraction | Done | #8406 |
 | W8 | #8397 | Anthropic provider narrow pure helper extraction | Done | #8407 |
 | W9 | #8398 | Final gates, docs, and in-depth audit | Done, corrected by #8409 | #8408 |
-| Hotfix | #8409 | Remediate post-closure audit blockers | Done after #8409 merge | pending |
+| Hotfix | #8409 | Remediate post-closure audit blockers | Done | #8410 |
 
 ---
 


### PR DESCRIPTION
Tiny follow-up to the v0.99.35 remediation report: replace the hotfix PR placeholder with PR #8410.

Verification:
- `racket scripts/run-tests.rkt --suite fast --profile local`: PASS, 956/956 files, 13078/13078 tests.

Refs #8409.