### PR TITLE
W1: Abstraction-audit red-flag tooling + review checklist (#8414)

### DIFF
--- a/docs/reports/ABSTRACTION-RED-FLAGS-v0.99.36.md
+++ b/docs/reports/ABSTRACTION-RED-FLAGS-v0.99.36.md
@@ -1,0 +1,591 @@
+# Abstraction Fitness Report
+
+**Total modules scanned:** 691
+
+## Largest Modules (top 20)
+
+| Lines | Exports | Path |
+|-------|---------|------|
+| 741 | 3 | ./tools/builtins/spawn-subagent.rkt |
+| 639 | 2 | ./llm/anthropic.rkt |
+| 634 | 2 | ./cli/args.rkt |
+| 621 | 2 | ./wiring/run-modes.rkt |
+| 592 | 1 | ./scripts/run-tests.rkt |
+| 562 | 1 | ./agent/event-structs.rkt |
+| 558 | 2 | ./runtime/settings-query.rkt |
+| 549 | 1 | ./tui/terminal.rkt |
+| 548 | 6 | ./runtime/session/session-store.rkt |
+| 548 | 3 | ./tui/state-types.rkt |
+| 534 | 2 | ./tools/scheduler.rkt |
+| 528 | 24 | ./scripts/abstraction-audit.rkt |
+| 522 | 3 | ./runtime/agent-session.rkt |
+| 520 | 3 | ./browser/adapters/playwright-sidecar.rkt |
+| 511 | 1 | ./tui/state-events/core-handlers.rkt |
+| 498 | 2 | ./tui/terminal-input.rkt |
+| 487 | 4 | ./tui/tui-render-loop.rkt |
+| 486 | 2 | ./interfaces/sessions.rkt |
+| 477 | 1 | ./tui/commands.rkt |
+| 476 | 2 | ./llm/gemini.rkt |
+
+## Parameter Usage
+
+| Count | Path |
+|-------|------|
+| 12 | ./scripts/run-benchmark.rkt |
+| 8 | ./scripts/abstraction-audit.rkt |
+| 7 | ./runtime/context-assembly/rollback-actions.rkt |
+| 7 | ./util/event/event-macro.rkt |
+| 5 | ./agent/verification/verifier-core.rkt |
+| 5 | ./runtime/memory/embeddings.rkt |
+| 5 | ./sandbox/gateway-bridge.rkt |
+| 4 | ./llm/gemini.rkt |
+| 4 | ./runtime/context-assembly/config.rkt |
+| 4 | ./runtime/memory/service.rkt |
+| 4 | ./sandbox/gateway-ipc.rkt |
+| 4 | ./sandbox/limits.rkt |
+| 4 | ./tools/builtins/spawn-subagent.rkt |
+| 3 | ./agent/roles/tool-gateway.rkt |
+| 3 | ./agent/verification/verifier-prompt.rkt |
+| 3 | ./extensions/gsd/session-state.rkt |
+| 3 | ./extensions/gsd/state-machine.rkt |
+| 3 | ./pkg/registry.rkt |
+| 3 | ./runtime/context-assembly/auto-distillation.rkt |
+| 3 | ./runtime/context-assembly/memory-builder.rkt |
+| 3 | ./runtime/context-assembly/state-aware-builder.rkt |
+| 3 | ./runtime/memory/reflection.rkt |
+| 3 | ./runtime/session/session-config.rkt |
+| 3 | ./sandbox/evaluator.rkt |
+| 3 | ./sandbox/subprocess.rkt |
+| 3 | ./scripts/audit-project.rkt |
+| 3 | ./scripts/capture-regression.rkt |
+| 3 | ./scripts/lint-release-notes.rkt |
+| 3 | ./scripts/run-dogfood-session.rkt |
+| 3 | ./tools/builtins/bash.rkt |
+| 3 | ./util/error/output-guard.rkt |
+| 3 | ./util/event/event-bus.rkt |
+| 3 | ./util/lockfile.rkt |
+| 3 | ./util/safe-mode/safe-mode-state.rkt |
+| 2 | ./agent/distributed/remote-ipc.rkt |
+| 2 | ./agent/loop-dispatch.rkt |
+| 2 | ./browser/adapters/playwright-sidecar.rkt |
+| 2 | ./cli/generate-certificates.rkt |
+| 2 | ./extensions/mcp-adapter.rkt |
+| 2 | ./extensions/ui-surface.rkt |
+| 2 | ./gui/lifecycle-hooks.rkt |
+| 2 | ./launch.rkt |
+| 2 | ./llm/stream.rkt |
+| 2 | ./runtime/compaction/ctx-compact.rkt |
+| 2 | ./runtime/credentials/protocol.rkt |
+| 2 | ./runtime/memory/auto-extraction.rkt |
+| 2 | ./runtime/memory/backends/external-protocol.rkt |
+| 2 | ./runtime/safe-mode.rkt |
+| 2 | ./runtime/session/session-events.rkt |
+| 2 | ./runtime/session/session-store-tree.rkt |
+| 2 | ./sandbox/worker-dispatch.rkt |
+| 2 | ./scripts/ci-local.rkt |
+| 2 | ./scripts/run-tests.rkt |
+| 2 | ./tools/builtins/write.rkt |
+| 2 | ./tui/render-loop/watchdog.rkt |
+| 2 | ./tui/renderer.rkt |
+| 2 | ./tui/state-events/registry.rkt |
+| 2 | ./tui/terminal.rkt |
+| 2 | ./util/truncation.rkt |
+| 1 | ./agent/blackboard.rkt |
+| 1 | ./agent/distributed/remote-executor.rkt |
+| 1 | ./agent/event-struct-coverage.rkt |
+| 1 | ./agent/iteration/main-loop.rkt |
+| 1 | ./agent/iteration/step-interpreter.rkt |
+| 1 | ./agent/loop-fsm.rkt |
+| 1 | ./agent/loop.rkt |
+| 1 | ./agent/registry-watcher.rkt |
+| 1 | ./agent/registry.rkt |
+| 1 | ./agent/roles/supervisor.rkt |
+| 1 | ./agent/state.rkt |
+| 1 | ./agent/stream-reducer.rkt |
+| 1 | ./agent/verification/verifier-gate.rkt |
+| 1 | ./browser/service.rkt |
+| 1 | ./browser/settings.rkt |
+| 1 | ./extensions/combinators.rkt |
+| 1 | ./extensions/github/helpers.rkt |
+| 1 | ./extensions/gsd/core.rkt |
+| 1 | ./extensions/gsd/events.rkt |
+| 1 | ./extensions/gsd/plan-context-builder.rkt |
+| 1 | ./extensions/hooks.rkt |
+| 1 | ./extensions/loader.rkt |
+| 1 | ./extensions/manifest-audit.rkt |
+| 1 | ./extensions/quarantine.rkt |
+| 1 | ./extensions/racket-tooling-helpers.rkt |
+| 1 | ./extensions/remote-collab/ssh-helpers.rkt |
+| 1 | ./extensions/widget-lifecycle.rkt |
+| 1 | ./gui/main.rkt |
+| 1 | ./interfaces/doctor.rkt |
+| 1 | ./interfaces/sessions.rkt |
+| 1 | ./runtime/auth/oauth.rkt |
+| 1 | ./runtime/context-assembly/state-inference.rkt |
+| 1 | ./runtime/context-assembly/turn-context.rkt |
+| 1 | ./runtime/gsd-query.rkt |
+| 1 | ./runtime/memory/conclusion-bridge.rkt |
+| 1 | ./runtime/package.rkt |
+| 1 | ./runtime/session/session-mutation.rkt |
+| 1 | ./runtime/session/session-persistence.rkt |
+| 1 | ./sandbox/executor-server.rkt |
+| 1 | ./sandbox/worker-tools.rkt |
+| 1 | ./scripts/benchmark/executor.rkt |
+| 1 | ./scripts/benchmark/scorer.rkt |
+| 1 | ./scripts/lint-ivg.rkt |
+| 1 | ./scripts/lint-security.rkt |
+| 1 | ./scripts/metrics.rkt |
+| 1 | ./scripts/run-tests/overhead.rkt |
+| 1 | ./tools/builtins/edit.rkt |
+| 1 | ./tools/scheduler.rkt |
+| 1 | ./tui/approval-channel.rkt |
+| 1 | ./tui/clipboard.rkt |
+| 1 | ./tui/commands/runtime-control.rkt |
+| 1 | ./tui/component.rkt |
+| 1 | ./tui/keybindings/binding-resolver.rkt |
+| 1 | ./tui/render/status-line.rkt |
+| 1 | ./tui/state-ui.rkt |
+| 1 | ./tui/terminal-input.rkt |
+| 1 | ./tui/theme.rkt |
+| 1 | ./tui/tui-render-loop.rkt |
+| 1 | ./tui/vdom-bridge.rkt |
+| 1 | ./ui-core/ui-actions.rkt |
+| 1 | ./util/audit-log.rkt |
+| 1 | ./util/capability.rkt |
+| 1 | ./util/event/event-migration.rkt |
+| 1 | ./util/security/cert-generator.rkt |
+| 1 | ./wiring/rpc-ui-adapter.rkt |
+
+## Macro Usage
+
+| Count | Path |
+|-------|------|
+| 8 | ./scripts/abstraction-audit.rkt |
+| 3 | ./extensions/define-extension.rkt |
+| 3 | ./util/event/event-macro.rkt |
+| 3 | ./util/fsm/fsm.rkt |
+| 2 | ./extensions/test-harness.rkt |
+| 2 | ./tools/define-tool.rkt |
+| 2 | ./util/error/error-helpers.rkt |
+| 1 | ./browser/service.rkt |
+| 1 | ./browser/session.rkt |
+| 1 | ./extensions/github/helpers.rkt |
+| 1 | ./runtime/auth/auth-store.rkt |
+| 1 | ./tui/terminal.rkt |
+| 1 | ./util/error/output-guard.rkt |
+| 1 | ./util/telemetry.rkt |
+
+## struct-out Exports
+
+| Count | Path |
+|-------|------|
+| 10 | ./scripts/abstraction-audit.rkt |
+| 7 | ./agent/event-structs/memory-events.rkt |
+| 7 | ./agent/event-structs/tool-events.rkt |
+| 4 | ./scripts/benchmark/task.rkt |
+| 3 | ./runtime/context-assembly/budgeting.rkt |
+| 2 | ./benchmarks/metrics.rkt |
+| 2 | ./extensions/gsd/transition-logic.rkt |
+| 2 | ./gui/gui-types.rkt |
+| 2 | ./runtime/context-assembly/rollback-actions.rkt |
+| 2 | ./scripts/benchmark/report.rkt |
+| 2 | ./scripts/check-imports.rkt |
+| 2 | ./skills/resource-loader.rkt |
+| 1 | ./agent/streaming-message.rkt |
+| 1 | ./benchmarks/tasks.rkt |
+| 1 | ./browser/adapter.rkt |
+| 1 | ./browser/adapters/mock.rkt |
+| 1 | ./browser/adapters/playwright-sidecar.rkt |
+| 1 | ./browser/settings.rkt |
+| 1 | ./browser/types.rkt |
+| 1 | ./extensions/gsd/plan-types.rkt |
+| 1 | ./interfaces/cli.rkt |
+| 1 | ./interfaces/doctor.rkt |
+| 1 | ./interfaces/sdk-compat.rkt |
+| 1 | ./interfaces/sdk-core.rkt |
+| 1 | ./runtime/goal/goal-types.rkt |
+| 1 | ./runtime/memory/types.rkt |
+| 1 | ./runtime/session/lifecycle-state.rkt |
+| 1 | ./scripts/benchmark/executor.rkt |
+| 1 | ./scripts/benchmark/scorer.rkt |
+| 1 | ./scripts/run-dogfood-session.rkt |
+| 1 | ./scripts/run-tests/overhead.rkt |
+| 1 | ./tui/cell-buffer.rkt |
+| 1 | ./tui/input.rkt |
+| 1 | ./ui-core/event-types.rkt |
+| 1 | ./ui-core/ui-delta.rkt |
+| 1 | ./ui-core/ui-reducer.rkt |
+| 1 | ./util/security/capability-tokens.rkt |
+
+## I/O Mixed With Pure Logic
+
+| Count | Path |
+|-------|------|
+| 53 | ./sandbox/subprocess.rkt |
+| 28 | ./sandbox/worker-tools.rkt |
+| 25 | ./sandbox/subprocess-helpers.rkt |
+| 25 | ./tui/clipboard.rkt |
+| 21 | ./sandbox/gateway-ipc.rkt |
+| 20 | ./scripts/run-tests.rkt |
+| 18 | ./scripts/abstraction-audit.rkt |
+| 18 | ./scripts/audit-project.rkt |
+| 16 | ./tools/builtins/bash.rkt |
+| 15 | ./browser/adapters/playwright-sidecar.rkt |
+| 13 | ./tui/commands/extension.rkt |
+| 11 | ./scripts/metrics.rkt |
+| 11 | ./scripts/sync-version.rkt |
+| 10 | ./runtime/goal/goal-checks.rkt |
+| 10 | ./tui/commands/session.rkt |
+| 9 | ./extensions/package-audit.rkt |
+| 9 | ./runtime/session/session-lifecycle.rkt |
+| 9 | ./tui/state-events/core-handlers.rkt |
+| 8 | ./extensions/gsd/archive.rkt |
+| 8 | ./extensions/gsd/wave-docs.rkt |
+| 7 | ./interfaces/sessions.rkt |
+| 7 | ./scripts/bump-version.rkt |
+| 7 | ./scripts/lint-ivg.rkt |
+| 7 | ./tools/builtins/find.rkt |
+| 7 | ./tui/commands/runtime-control.rkt |
+| 7 | ./util/json/jsonl.rkt |
+| 6 | ./extensions/racket-tooling-helpers.rkt |
+| 6 | ./runtime/credentials/protocol.rkt |
+| 6 | ./scripts/lint-all.rkt |
+| 6 | ./scripts/lint-release-readiness.rkt |
+| 6 | ./scripts/run-tests/cli.rkt |
+| 5 | ./extensions/remote-collab/ssh-helpers.rkt |
+| 5 | ./extensions/remote-collab/tmux-helpers.rkt |
+| 5 | ./pkg/registry.rkt |
+| 5 | ./scripts/hotspot-report.rkt |
+| 5 | ./scripts/lint-version.rkt |
+| 5 | ./scripts/run-tests/classify.rkt |
+| 5 | ./scripts/run-tests/gate-evidence.rkt |
+| 5 | ./scripts/sync-readme-status.rkt |
+| 5 | ./skills/resource-loader.rkt |
+| 5 | ./util/lockfile.rkt |
+| 4 | ./extensions/github/helpers.rkt |
+| 4 | ./extensions/gsd/core.rkt |
+| 4 | ./extensions/gsd/tool-handlers.rkt |
+| 4 | ./extensions/q-sync.rkt |
+| 4 | ./runtime/memory/backends/file-jsonl-ops.rkt |
+| 4 | ./runtime/session/session-store-integrity.rkt |
+| 4 | ./scripts/check-protocols.rkt |
+| 4 | ./scripts/gen-release-manifest.rkt |
+| 4 | ./scripts/lint-doc-freshness.rkt |
+| 4 | ./scripts/lint-tests.rkt |
+| 4 | ./scripts/run-tests/inventory.rkt |
+| 4 | ./tools/builtins/delete-lines.rkt |
+| 4 | ./tools/builtins/edit.rkt |
+| 4 | ./tools/builtins/grep.rkt |
+| 4 | ./tui/commands/branch.rkt |
+| 4 | ./tui/terminal-native.rkt |
+| 4 | ./wiring/run-modes.rkt |
+| 3 | ./agent/mas-guidance.rkt |
+| 3 | ./examples/extensions/keyboard-shortcut.rkt |
+| 3 | ./extensions/loader.rkt |
+| 3 | ./extensions/manifest.rkt |
+| 3 | ./extensions/message-inject.rkt |
+| 3 | ./interfaces/doctor.rkt |
+| 3 | ./runtime/context-assembly/blackboard-context.rkt |
+| 3 | ./runtime/context-assembly/serialization.rkt |
+| 3 | ./scripts/arch-report.rkt |
+| 3 | ./scripts/check-lint-alignment.rkt |
+| 3 | ./scripts/lint-contract-changes.rkt |
+| 3 | ./scripts/lint-credential-policy.rkt |
+| 3 | ./scripts/lint-docs.rkt |
+| 3 | ./scripts/lint-test-tags.rkt |
+| 3 | ./scripts/milestone-gate.rkt |
+| 3 | ./scripts/pre-commit.rkt |
+| 3 | ./scripts/run-dogfood-session.rkt |
+| 3 | ./scripts/run-tests/reporting.rkt |
+| 3 | ./scripts/sdk-gsd-integration-test.rkt |
+| 3 | ./tools/registry-table.rkt |
+| 3 | ./tui/commands.rkt |
+| 3 | ./tui/state-types.rkt |
+| 3 | ./tui/theme.rkt |
+| 2 | ./agent/loop-messages.rkt |
+| 2 | ./agent/registry-watcher.rkt |
+| 2 | ./agent/roles/base.rkt |
+| 2 | ./agent/verification/verifier-prompt.rkt |
+| 2 | ./extensions/quarantine.rkt |
+| 2 | ./extensions/session-export.rkt |
+| 2 | ./llm/anthropic.rkt |
+| 2 | ./runtime/compaction/compactor.rkt |
+| 2 | ./runtime/context/context-pinning.rkt |
+| 2 | ./runtime/context-assembly/state-aware-builder.rkt |
+| 2 | ./runtime/goal/goal-evidence.rkt |
+| 2 | ./runtime/project-tree.rkt |
+| 2 | ./runtime/session/session-lifecycle-transitions.rkt |
+| 2 | ./runtime/session-index/mutations.rkt |
+| 2 | ./runtime/session-store/versioning.rkt |
+| 2 | ./runtime/settings-core.rkt |
+| 2 | ./runtime/trace-sink.rkt |
+| 2 | ./sandbox/limits.rkt |
+| 2 | ./scripts/benchmark/baseline.rkt |
+| 2 | ./scripts/benchmark/fixtures/legacy.rkt |
+| 2 | ./scripts/benchmark/scorer.rkt |
+| 2 | ./scripts/benchmark/task.rkt |
+| 2 | ./scripts/capture-regression.rkt |
+| 2 | ./scripts/check-deps.rkt |
+| 2 | ./scripts/check-imports.rkt |
+| 2 | ./scripts/gen-release-notes.rkt |
+| 2 | ./scripts/gen-sdk-catalog.rkt |
+| 2 | ./scripts/lint-ci-readiness.rkt |
+| 2 | ./scripts/lint-deprecation-deadlines.rkt |
+| 2 | ./scripts/lint-security.rkt |
+| 2 | ./scripts/lint-widened-ledger.rkt |
+| 2 | ./scripts/metrics-report.rkt |
+| 2 | ./scripts/run-tests/overhead.rkt |
+| 2 | ./scripts/test-gsd-sdk-live.rkt |
+| 2 | ./tools/builtins/spawn-subagent.rkt |
+| 2 | ./tools/builtins/write.rkt |
+| 2 | ./tui/commands/general.rkt |
+| 2 | ./tui/keymap.rkt |
+| 2 | ./tui/submit-handler.rkt |
+| 2 | ./util/audit-log.rkt |
+| 2 | ./util/error/error-classify.rkt |
+| 2 | ./util/json/checksum.rkt |
+| 2 | ./util/json/json-helpers.rkt |
+| 2 | ./wiring/mode-helpers.rkt |
+| 1 | ./agent/event-struct-coverage.rkt |
+| 1 | ./browser/audit.rkt |
+| 1 | ./cli/export.rkt |
+| 1 | ./cli/init-wizard.rkt |
+| 1 | ./cli/replay.rkt |
+| 1 | ./examples/extensions/context-enricher.rkt |
+| 1 | ./examples/extensions/error-handler.rkt |
+| 1 | ./examples/extensions/tool-guard.rkt |
+| 1 | ./examples/sdk/03-custom-prompt.rkt |
+| 1 | ./extensions/compact-context.rkt |
+| 1 | ./extensions/gsd/plan-context-builder.rkt |
+| 1 | ./extensions/gsd/prompts.rkt |
+| 1 | ./extensions/gsd/wave-executor.rkt |
+| 1 | ./extensions/image-input.rkt |
+| 1 | ./gui/gui-types.rkt |
+| 1 | ./gui/slash-commands.rkt |
+| 1 | ./interfaces/gui.rkt |
+| 1 | ./llm/gemini.rkt |
+| 1 | ./llm/stream.rkt |
+| 1 | ./runtime/auth/oauth-callback.rkt |
+| 1 | ./runtime/compaction/session-compaction.rkt |
+| 1 | ./runtime/compaction/token-compaction.rkt |
+| 1 | ./runtime/context/context-fit.rkt |
+| 1 | ./runtime/context-assembly/context-floor.rkt |
+| 1 | ./runtime/context-assembly/memory-builder.rkt |
+| 1 | ./runtime/goal/goal-agent-evaluator.rkt |
+| 1 | ./runtime/goal/goal-runner.rkt |
+| 1 | ./runtime/memory/auto-extraction.rkt |
+| 1 | ./runtime/memory/backends/memory-hash.rkt |
+| 1 | ./runtime/memory/search.rkt |
+| 1 | ./runtime/provider/provider-schema.rkt |
+| 1 | ./runtime/session/session-migration.rkt |
+| 1 | ./runtime/session/session-persistence.rkt |
+| 1 | ./runtime/session/session-store.rkt |
+| 1 | ./runtime/settings-query.rkt |
+| 1 | ./runtime/trace-logger.rkt |
+| 1 | ./sandbox/gateway-bridge.rkt |
+| 1 | ./scripts/archive-planning.rkt |
+| 1 | ./scripts/co-change-report.rkt |
+| 1 | ./scripts/contract-metrics.rkt |
+| 1 | ./scripts/lint-changelog-dates.rkt |
+| 1 | ./scripts/lint-format.rkt |
+| 1 | ./scripts/lint-pkg-metadata.rkt |
+| 1 | ./scripts/lint-release-notes.rkt |
+| 1 | ./scripts/run-tests/ledger.rkt |
+| 1 | ./scripts/run-tests/profiles.rkt |
+| 1 | ./scripts/test-gsd-go-replanning.rkt |
+| 1 | ./scripts/test-metadata.rkt |
+| 1 | ./scripts/wrap-lines.rkt |
+| 1 | ./skills/context-files.rkt |
+| 1 | ./skills/mas-workflow.rkt |
+| 1 | ./tools/builtins/read.rkt |
+| 1 | ./tools/builtins/skill-router.rkt |
+| 1 | ./tools/builtins/spawn-subagent-helpers.rkt |
+| 1 | ./tools/scheduler.rkt |
+| 1 | ./tools/shell-risk.rkt |
+| 1 | ./tui/commands/model.rkt |
+| 1 | ./tui/scrollback.rkt |
+| 1 | ./tui/state-events/goal-handlers.rkt |
+| 1 | ./tui/tui-init.rkt |
+| 1 | ./tui/tui-render-loop.rkt |
+| 1 | ./ui-core/observable-bridge.rkt |
+| 1 | ./util/command-types.rkt |
+| 1 | ./util/error/error-sanitizer.rkt |
+| 1 | ./util/error/errors.rkt |
+| 1 | ./util/export/export-html.rkt |
+| 1 | ./util/markdown.rkt |
+| 1 | ./util/message/message-helpers.rkt |
+| 1 | ./util/shell-quote.rkt |
+| 1 | ./util/truncation.rkt |
+
+## Serialization Hotspots
+
+| Count | Path |
+|-------|------|
+| 26 | ./runtime/session/session-store.rkt |
+| 24 | ./runtime/goal/goal-codec.rkt |
+| 18 | ./browser/types.rkt |
+| 17 | ./llm/model.rkt |
+| 15 | ./runtime/memory/types.rkt |
+| 15 | ./scripts/abstraction-audit.rkt |
+| 12 | ./tui/scrollback.rkt |
+| 10 | ./gui/gui-types.rkt |
+| 10 | ./runtime/memory/backends/file-jsonl-ops.rkt |
+| 10 | ./sandbox/ipc-protocol.rkt |
+| 9 | ./agent/event-emitter.rkt |
+| 9 | ./scripts/benchmark/report.rkt |
+| 8 | ./llm/anthropic.rkt |
+| 8 | ./llm/openai-compatible.rkt |
+| 8 | ./runtime/auth/oauth.rkt |
+| 8 | ./runtime/goal/goal-state.rkt |
+| 8 | ./runtime/session/session-config.rkt |
+| 8 | ./runtime/session-index/mutations.rkt |
+| 8 | ./sandbox/worker-dispatch.rkt |
+| 8 | ./tools/builtins/browser-tools.rkt |
+| 8 | ./tools/tool.rkt |
+| 7 | ./interfaces/json-mode.rkt |
+| 7 | ./runtime/context-assembly/task-conclusion.rkt |
+| 7 | ./runtime/session-store/versioning.rkt |
+| 7 | ./util/event/event.rkt |
+| 6 | ./agent/event-json.rkt |
+| 6 | ./extensions/manifest.rkt |
+| 6 | ./runtime/context-assembly/task-memory.rkt |
+| 6 | ./runtime/session/session-store-integrity.rkt |
+| 6 | ./scripts/audit-project.rkt |
+| 6 | ./scripts/run-tests/reporting.rkt |
+| 6 | ./util/content/content-parts.rkt |
+| 6 | ./util/message/message.rkt |
+| 6 | ./wiring/run-modes.rkt |
+| 5 | ./extensions/github/handlers/milestone-ops.rkt |
+| 5 | ./runtime/session/session-migration.rkt |
+| 5 | ./tools/registry.rkt |
+| 4 | ./extensions/gsd/events.rkt |
+| 4 | ./extensions/session-export.rkt |
+| 4 | ./llm/gemini.rkt |
+| 4 | ./runtime/memory/backends/mem0-api.rkt |
+| 4 | ./sandbox/executor-server.rkt |
+| 4 | ./skills/workflow-executor.rkt |
+| 4 | ./tools/builtins/skill-router.rkt |
+| 4 | ./util/message/mas-envelope.rkt |
+| 4 | ./wiring/run-json-rpc.rkt |
+| 3 | ./agent/distributed/remote-ipc.rkt |
+| 3 | ./extensions/mcp-adapter.rkt |
+| 3 | ./extensions/tool-api.rkt |
+| 3 | ./llm/http-helpers.rkt |
+| 3 | ./llm/openrouter.rkt |
+| 3 | ./runtime/agent-session.rkt |
+| 3 | ./runtime/context-assembly/state-aware-builder.rkt |
+| 3 | ./runtime/session/session-lifecycle.rkt |
+| 3 | ./sandbox/gateway-ipc.rkt |
+| 3 | ./tools/scheduler.rkt |
+| 3 | ./tui/theme.rkt |
+| 3 | ./util/event/event-codec.rkt |
+| 3 | ./util/event/event-payloads.rkt |
+| 3 | ./util/export/export-json.rkt |
+| 2 | ./agent/iteration/loop-config.rkt |
+| 2 | ./agent/iteration/main-loop.rkt |
+| 2 | ./agent/streaming-message.rkt |
+| 2 | ./browser/adapters/playwright-sidecar.rkt |
+| 2 | ./extensions/github/helpers.rkt |
+| 2 | ./extensions/gsd/tool-handlers.rkt |
+| 2 | ./gui/state-sync.rkt |
+| 2 | ./interfaces/rpc-mode.rkt |
+| 2 | ./llm/azure-openai.rkt |
+| 2 | ./llm/stream.rkt |
+| 2 | ./runtime/compaction/session-compaction.rkt |
+| 2 | ./runtime/context-assembly/memory-builder.rkt |
+| 2 | ./runtime/tool-coordinator.rkt |
+| 2 | ./scripts/run-tests/parse.rkt |
+| 2 | ./scripts/run-tests.rkt |
+| 2 | ./tools/builtins/firecrawl.rkt |
+| 2 | ./ui-core/event-types.rkt |
+| 2 | ./util/content/content-helpers.rkt |
+| 2 | ./util/event/event-macro.rkt |
+| 1 | ./agent/stream-runner.rkt |
+| 1 | ./agent/verification/verifier-core.rkt |
+| 1 | ./browser/audit.rkt |
+| 1 | ./examples/extensions/typed-event-observer.rkt |
+| 1 | ./extensions/github/handlers/issue-ops.rkt |
+| 1 | ./extensions/github/tool-handlers.rkt |
+| 1 | ./extensions/gsd/command-handlers.rkt |
+| 1 | ./extensions/racket-tooling/analysis.rkt |
+| 1 | ./gui/components/keybindings.rkt |
+| 1 | ./interfaces/sessions.rkt |
+| 1 | ./pkg/registry.rkt |
+| 1 | ./runtime/goal/goal-agent-evaluator.rkt |
+| 1 | ./runtime/goal/goal-evaluator.rkt |
+| 1 | ./runtime/memory/embeddings.rkt |
+| 1 | ./runtime/session/session-metadata.rkt |
+| 1 | ./scripts/capture-regression.rkt |
+| 1 | ./scripts/metrics-report.rkt |
+| 1 | ./scripts/milestone-gate.rkt |
+| 1 | ./scripts/run-benchmark.rkt |
+| 1 | ./tools/builtins/spawn-subagent.rkt |
+| 1 | ./tui/keymap.rkt |
+| 1 | ./tui/tui-init.rkt |
+| 1 | ./ui-core/dispatch.rkt |
+| 1 | ./ui-core/ui-actions.rkt |
+| 1 | ./util/event/event-bus.rkt |
+| 1 | ./util/json/json-helpers.rkt |
+| 1 | ./util/tool/tool-display.rkt |
+
+## Error/Raise Density (top 20)
+
+| Count | Path |
+|-------|------|
+| 17 | ./extensions/racket-tooling/formatting.rkt |
+| 16 | ./util/error/errors.rkt |
+| 13 | ./browser/adapters/playwright-sidecar.rkt |
+| 12 | ./llm/stream.rkt |
+| 12 | ./tools/builtins/firecrawl.rkt |
+| 10 | ./llm/http-helpers.rkt |
+| 8 | ./scripts/run-tests/cli.rkt |
+| 7 | ./tools/tool.rkt |
+| 6 | ./agent/registry.rkt |
+| 6 | ./runtime/session/session-mutation.rkt |
+| 6 | ./scripts/benchmark/task.rkt |
+| 5 | ./browser/service.rkt |
+| 5 | ./browser/session.rkt |
+| 5 | ./extensions/racket-tooling/rewrite.rkt |
+| 5 | ./llm/model.rkt |
+| 5 | ./tools/builtins/skill-router.rkt |
+| 4 | ./agent/distributed/remote-ipc.rkt |
+| 4 | ./extensions/manifest.rkt |
+| 4 | ./llm/openai-compatible.rkt |
+| 4 | ./runtime/extension-catalog.rkt |
+
+## Handler Density (with-handlers, top 20)
+
+| Count | Path |
+|-------|------|
+| 10 | ./tools/builtins/browser-tools.rkt |
+| 9 | ./browser/adapters/playwright-sidecar.rkt |
+| 9 | ./tui/tui-init.rkt |
+| 7 | ./sandbox/subprocess.rkt |
+| 6 | ./sandbox/executor-server.rkt |
+| 6 | ./tools/scheduler.rkt |
+| 5 | ./agent/distributed/remote-executor.rkt |
+| 5 | ./interfaces/doctor.rkt |
+| 5 | ./runtime/auth/auth-store.rkt |
+| 5 | ./runtime/auth/oauth-callback.rkt |
+| 5 | ./sandbox/gateway-bridge.rkt |
+| 5 | ./tools/builtins/edit.rkt |
+| 5 | ./tools/builtins/firecrawl.rkt |
+| 5 | ./tools/builtins/grep.rkt |
+| 5 | ./tui/clipboard.rkt |
+| 5 | ./tui/commands/extension.rkt |
+| 4 | ./agent/distributed/remote-ipc.rkt |
+| 4 | ./examples/extensions/error-handler.rkt |
+| 4 | ./extensions/loader.rkt |
+| 4 | ./gui/main.rkt |
+
+## all-defined-out Usage
+
+- ./browser/events.rkt
+- ./extensions/gsd/event-structs.rkt
+- ./scripts/abstraction-audit.rkt
+- ./scripts/check-imports.rkt
+
+## Advisory
+
+This report is advisory. Use with the Abstraction Instruction Manual
+to identify candidates for boundary clarification.

--- a/docs/reports/ABSTRACTION-REVIEW-CHECKLIST-v0.99.36.md
+++ b/docs/reports/ABSTRACTION-REVIEW-CHECKLIST-v0.99.36.md
@@ -1,0 +1,123 @@
+# Abstraction Review Checklist — v0.99.36
+
+**Companion to:** `scripts/abstraction-audit.rkt`  
+**Manual reference:** Racket Abstraction Instruction Manual
+
+## Purpose
+
+This checklist translates the red-flag signals from the abstraction audit
+into actionable manual review questions. The audit tool provides objective
+evidence; this checklist guides the human judgment.
+
+## How to Use
+
+1. Run `racket scripts/abstraction-audit.rkt --root .` to generate the report
+2. For each module in the report, review the relevant checklist questions below
+3. Document findings in the wave report or audit document
+
+## Signal-to-Question Mapping
+
+### struct-out Exports
+
+**Signal:** Module uses `(struct-out ...)` in provide form.
+
+**Review questions:**
+- Does every consumer need `struct-copy` or field mutation? If not, consider explicit provides.
+- Are mutable fields exposed that should be hidden behind accessor functions?
+- Is the struct used as a public protocol type (justifies struct-out) or an internal implementation detail?
+- Could a constructor + accessors provide the same utility without exposing the representation?
+
+**Manual references:** §7 (Deep Modules), §9 (Information Hiding), §17 (Interfaces)
+
+### all-defined-out Usage
+
+**Signal:** Module uses `(all-defined-out)`.
+
+**Review questions:**
+- Is every definition in this module truly part of the public API?
+- Could future internal definitions accidentally become public API?
+- Would explicit provides document the intended API surface?
+
+**Manual references:** §9 (Information Hiding), §13 (Comments)
+
+### Parameter Usage (make-parameter / parameterize)
+
+**Signal:** Module defines parameters or uses parameterize.
+
+**Review questions:**
+- Is the parameter used for legitimate dynamic extent (testing, configuration)?
+- Or is it hiding ordinary data flow that would be clearer as function arguments?
+- Does the parameter have a clear owner (the module that defines and documents it)?
+- Is the default value tested?
+
+**Manual references:** §29 (Different Layer, Different Abstraction)
+
+### Error/Raise Density
+
+**Signal:** Module has high `error`/`raise` call count.
+
+**Review questions:**
+- Are errors raised at the right boundary (close to the cause)?
+- Do error messages include enough context for diagnosis?
+- Is there a result-based alternative (return structured failure instead of raising)?
+- Are expected failures (file-not-found, parse-error) handled with results rather than exceptions?
+
+**Manual references:** §25 (Errors as Data), §26 (Partial Success)
+
+### Handler Density (with-handlers)
+
+**Signal:** Module has high `with-handlers` count.
+
+**Review questions:**
+- Are handlers recovering gracefully or just suppressing errors?
+- Do handlers log or report the original error before recovery?
+- Is the handler at the right level (not too broad)?
+- Could result-based error handling replace some handler patterns?
+
+**Manual references:** §25 (Errors as Data), §31 (Exceptions)
+
+### I/O Mixed With Logic
+
+**Signal:** Module mixes file/process I/O with pure function definitions.
+
+**Review questions:**
+- Can the formatting/validation logic be separated from the I/O?
+- Would string-port testing reduce reliance on filesystem fixtures?
+- Is the I/O at the module boundary (justified) or interleaved with logic?
+
+**Manual references:** §16 (Shallow Module), §27 (Ports)
+
+### Macro Usage (define-syntax / syntax-parse)
+
+**Signal:** Module defines macros.
+
+**Review questions:**
+- Is a macro truly necessary, or would a higher-order function suffice?
+- Are there expansion tests for complex macros (syntax-parse)?
+- Are hygiene and introduced identifiers documented?
+- What happens when the macro is used incorrectly — is the error message helpful?
+
+**Manual references:** §31 (DSLs), §34 (Macro Hygiene), §36 (S-expression Liberation)
+
+### Serialization Hotspots (->jsexpr / jsexpr->)
+
+**Signal:** Module has serialization/deserialization code.
+
+**Review questions:**
+- Is serialization at the module boundary?
+- Are round-trip properties tested?
+- Could serialization be delegated to a shared helper?
+
+**Manual references:** §19 (Consistency)
+
+## Strict Mode Thresholds
+
+| Threshold | Limit | Rationale |
+|-----------|-------|-----------|
+| max-lines | 800 | Modules over 800 lines likely mix concerns |
+| max-exports | 40 | High export count suggests a shallow interface |
+| max-require-count | 30 | High fan-out suggests too many dependencies |
+| max-handler-count | 12 | High handler density may indicate error-as-control-flow |
+| max-error-count | 20 | High error density may indicate missing result types |
+
+**Note:** These thresholds are intentionally generous. The audit is advisory.

--- a/scripts/abstraction-audit.rkt
+++ b/scripts/abstraction-audit.rkt
@@ -21,6 +21,8 @@
 ;;   - I/O effects mixed with pure logic definitions
 ;;   - Serialization hotspots (->jsexpr / jsexpr-> / hash-> / ->hash)
 ;;   - Exception handler density (with-handlers)
+;;   - Error/raise density (error, raise)
+;;   - Provide form shapes (all-defined-out, struct-out, contract-out, explicit)
 ;;   - Dependency fan-out (require forms)
 ;;
 ;; Output:
@@ -46,7 +48,10 @@
          count-exports
          count-requires
          count-matches
-         has-io-effects?)
+         has-io-effects?
+         count-io-effects
+         detect-provide-shapes
+         count-struct-outs)
 
 ;; ============================================================
 ;; Core data structures
@@ -54,8 +59,9 @@
 
 ;; A module-finding is a hash with keys:
 ;;   path, line-count, export-count, parameter-count, macro-count,
-;;   has-struct-out?, io-mixed-with-logic?, serialization-count,
-;;   handler-count, require-count
+;;   struct-out-count, has-struct-out?, io-count, io-mixed-with-logic?,
+;;   serialization-count, handler-count, error-count, provide-shapes,
+;;   require-count
 
 ;; An audit-report is a hash with keys:
 ;;   modules   — list of module-finding hashes
@@ -78,10 +84,14 @@
              [export-count (count-exports text)]
              [parameter-count (count-matches text parameter-rx)]
              [macro-count (count-matches text macro-rx)]
-             [has-struct-out? (regexp-match? struct-out-rx text)]
-             [io? (has-io-effects? text)]
+             [struct-out-count (count-struct-outs text)]
+             [has-struct-out? (> struct-out-count 0)]
+             [io-count (count-io-effects text)]
+             [io? (> io-count 0)]
              [serialization-count (count-matches text serialization-rx)]
              [handler-count (count-matches text handler-rx)]
+             [error-count (count-matches text error-rx)]
+             [provide-shapes (detect-provide-shapes text)]
              [require-count (count-requires text)])
         (hash 'path
               (if (path? path)
@@ -95,14 +105,22 @@
               parameter-count
               'macro-count
               macro-count
+              'struct-out-count
+              struct-out-count
               'has-struct-out?
               has-struct-out?
+              'io-count
+              io-count
               'io-mixed-with-logic?
               io?
               'serialization-count
               serialization-count
               'handler-count
               handler-count
+              'error-count
+              error-count
+              'provide-shapes
+              provide-shapes
               'require-count
               require-count))))
 
@@ -130,9 +148,41 @@
 (define struct-out-rx #px"struct-out\\s")
 (define serialization-rx #px"->jsexpr|jsexpr->|->hash|hash->")
 (define handler-rx #rx"with-handlers")
+(define error-rx #px"\\(error\\b|\\(raise\\b")
+(define all-defined-out-rx #px"all-defined-out")
+(define contract-out-rx #px"contract-out")
 
 (define (count-matches text rx)
   (length (regexp-match* rx text)))
+
+(define (count-struct-outs text)
+  "Count the number of struct-out forms in the text."
+  (length (regexp-match* struct-out-rx text)))
+
+(define (count-io-effects text)
+  "Count I/O effect occurrences in text."
+  (apply +
+         (map (lambda (pat) (length (regexp-match* (regexp (regexp-quote pat)) text))) io-patterns)))
+
+(define (detect-provide-shapes text)
+  "Detect which provide form shapes are present. Returns a list of symbols."
+  (define shapes '())
+  (when (regexp-match? all-defined-out-rx text)
+    (set! shapes (cons 'all-defined-out shapes)))
+  (when (regexp-match? struct-out-rx text)
+    (set! shapes (cons 'struct-out shapes)))
+  (when (regexp-match? contract-out-rx text)
+    (set! shapes (cons 'contract-out shapes)))
+  ;; Explicit IDs: detect bare identifiers in provide forms.
+  ;; Flatten newlines so multi-line provides can be checked.
+  ;; Pattern 1: (provide bare-id ...) — first token is a bare identifier.
+  ;; Pattern 2: (provide (sub-form) bare-id ...) — bare ID after a sub-form.
+  (define flat (regexp-replace* #rx"\n" text " "))
+  (when (or (regexp-match? #px"\\(provide\\s+[a-zA-Z!_@%-]" flat)
+            (regexp-match? #px"\\(provide\\s.*?\\)\\s+[a-zA-Z!_@%-]" flat))
+    (set! shapes (cons 'explicit shapes)))
+  (reverse shapes) ; preserve discovery order
+  )
 
 (define io-patterns
   '("call-with-output-file" "call-with-input-file"
@@ -207,6 +257,13 @@
   (define all-struct-out (filter (lambda (f) (hash-ref f 'has-struct-out? #f)) findings))
   (define all-io-mixed (filter (lambda (f) (hash-ref f 'io-mixed-with-logic? #f)) findings))
   (define all-serialization (filter (lambda (f) (> (hash-ref f 'serialization-count 0) 0)) findings))
+  (define all-errors (filter (lambda (f) (> (hash-ref f 'error-count 0) 0)) findings))
+  (define all-handlers (filter (lambda (f) (> (hash-ref f 'handler-count 0) 0)) findings))
+  (define all-all-defined-out
+    (filter (lambda (f)
+              (and (list? (hash-ref f 'provide-shapes '()))
+                   (member 'all-defined-out (hash-ref f 'provide-shapes '()))))
+            findings))
 
   (hash 'total-modules
         (length findings)
@@ -226,12 +283,22 @@
         (map (lambda (f) (hash 'path (hash-ref f 'path) 'count (hash-ref f 'macro-count)))
              (sort all-macros > #:key (lambda (f) (hash-ref f 'macro-count 0))))
         'struct-out-exports
-        (map (lambda (f) (hash-ref f 'path)) all-struct-out)
+        (map (lambda (f) (hash 'path (hash-ref f 'path) 'count (hash-ref f 'struct-out-count 0)))
+             (sort all-struct-out > #:key (lambda (f) (hash-ref f 'struct-out-count 0))))
         'io-mixed-with-logic
-        (map (lambda (f) (hash-ref f 'path)) all-io-mixed)
+        (map (lambda (f) (hash 'path (hash-ref f 'path) 'count (hash-ref f 'io-count 0)))
+             (sort all-io-mixed > #:key (lambda (f) (hash-ref f 'io-count 0))))
         'serialization-hotspots
         (map (lambda (f) (hash 'path (hash-ref f 'path) 'count (hash-ref f 'serialization-count)))
-             (sort all-serialization > #:key (lambda (f) (hash-ref f 'serialization-count 0))))))
+             (sort all-serialization > #:key (lambda (f) (hash-ref f 'serialization-count 0))))
+        'error-density
+        (map (lambda (f) (hash 'path (hash-ref f 'path) 'count (hash-ref f 'error-count 0)))
+             (sort all-errors > #:key (lambda (f) (hash-ref f 'error-count 0))))
+        'handler-density
+        (map (lambda (f) (hash 'path (hash-ref f 'path) 'count (hash-ref f 'handler-count 0)))
+             (sort all-handlers > #:key (lambda (f) (hash-ref f 'handler-count 0))))
+        'all-defined-out-modules
+        (map (lambda (f) (hash-ref f 'path)) all-all-defined-out)))
 
 (define (take-at-most lst n)
   (if (> (length lst) n)
@@ -243,8 +310,15 @@
 ;; ============================================================
 
 (define (report->jsexpr report)
-  "Convert audit-report to a JSON-serializable jsexpr."
-  report) ; Already hash-based jsexpr-compatible
+  "Convert audit-report to a JSON-serializable jsexpr.
+   Converts symbol values in provide-shapes to strings for JSON compatibility."
+  (define modules (hash-ref report 'modules))
+  (define json-modules
+    (map (lambda (m)
+           (define shapes (hash-ref m 'provide-shapes '()))
+           (hash-set m 'provide-shapes (map (lambda (s) (symbol->string s)) shapes)))
+         modules))
+  (hash 'modules json-modules 'summary (hash-ref report 'summary)))
 
 (define (jsexpr->json-string js)
   "Convert jsexpr to a JSON string."
@@ -288,14 +362,18 @@
 
   ;; struct-out exports
   (fprintf out "## struct-out Exports\n\n")
+  (fprintf out "| Count | Path |\n")
+  (fprintf out "|-------|------|\n")
   (for ([s (hash-ref summary 'struct-out-exports)])
-    (fprintf out "- ~a\n" s))
+    (fprintf out "| ~a | ~a |\n" (hash-ref s 'count) (hash-ref s 'path)))
   (fprintf out "\n")
 
   ;; I/O mixed with logic
   (fprintf out "## I/O Mixed With Pure Logic\n\n")
+  (fprintf out "| Count | Path |\n")
+  (fprintf out "|-------|------|\n")
   (for ([p (hash-ref summary 'io-mixed-with-logic)])
-    (fprintf out "- ~a\n" p))
+    (fprintf out "| ~a | ~a |\n" (hash-ref p 'count) (hash-ref p 'path)))
   (fprintf out "\n")
 
   ;; Serialization hotspots
@@ -306,6 +384,32 @@
     (fprintf out "| ~a | ~a |\n" (hash-ref s 'count) (hash-ref s 'path)))
   (fprintf out "\n")
 
+  ;; Error/raise density
+  (fprintf out "## Error/Raise Density (top 20)\n\n")
+  (fprintf out "| Count | Path |\n")
+  (fprintf out "|-------|------|\n")
+  (for ([e (take-at-most (hash-ref summary 'error-density) 20)])
+    (fprintf out "| ~a | ~a |\n" (hash-ref e 'count) (hash-ref e 'path)))
+  (fprintf out "\n")
+
+  ;; Handler density
+  (fprintf out "## Handler Density (with-handlers, top 20)\n\n")
+  (fprintf out "| Count | Path |\n")
+  (fprintf out "|-------|------|\n")
+  (for ([h (take-at-most (hash-ref summary 'handler-density) 20)])
+    (fprintf out "| ~a | ~a |\n" (hash-ref h 'count) (hash-ref h 'path)))
+  (fprintf out "\n")
+
+  ;; all-defined-out modules
+  (fprintf out "## all-defined-out Usage\n\n")
+  (define ado (hash-ref summary 'all-defined-out-modules '()))
+  (if (null? ado)
+      (fprintf out "None found.\n\n")
+      (begin
+        (for ([p ado])
+          (fprintf out "- ~a\n" p))
+        (fprintf out "\n")))
+
   ;; Advisory
   (fprintf out "## Advisory\n\n")
   (fprintf out "This report is advisory. Use with the Abstraction Instruction Manual\n")
@@ -315,7 +419,17 @@
 ;; Strict mode thresholds
 ;; ============================================================
 
-(define strict-thresholds (hash 'max-lines 800 'max-exports 40 'max-require-count 30))
+(define strict-thresholds
+  (hash 'max-lines
+        800
+        'max-exports
+        40
+        'max-require-count
+        30
+        'max-handler-count
+        12
+        'max-error-count
+        20))
 
 (define (strict-violations report)
   "Return list of strict-mode violations. Empty list = pass."
@@ -325,6 +439,8 @@
              (define lines (hash-ref m 'line-count))
              (define exports (hash-ref m 'export-count))
              (define reqs (hash-ref m 'require-count))
+             (define handlers (hash-ref m 'handler-count 0))
+             (define errors (hash-ref m 'error-count 0))
              (append (if (> lines (hash-ref strict-thresholds 'max-lines))
                          (list (format "~a: ~a lines exceeds max ~a"
                                        path
@@ -342,6 +458,18 @@
                                        path
                                        reqs
                                        (hash-ref strict-thresholds 'max-require-count)))
+                         '())
+                     (if (> handlers (hash-ref strict-thresholds 'max-handler-count))
+                         (list (format "~a: ~a handlers exceeds max ~a"
+                                       path
+                                       handlers
+                                       (hash-ref strict-thresholds 'max-handler-count)))
+                         '())
+                     (if (> errors (hash-ref strict-thresholds 'max-error-count))
+                         (list (format "~a: ~a error/raise calls exceeds max ~a"
+                                       path
+                                       errors
+                                       (hash-ref strict-thresholds 'max-error-count)))
                          '())))))
 
 ;; ============================================================

--- a/tests/test-abstraction-audit.rkt
+++ b/tests/test-abstraction-audit.rkt
@@ -44,7 +44,8 @@
 EOF
               )
 
-  ;; Big module with parameters, macros, struct-out, I/O mixed with logic
+  ;; Big module with parameters, macros, struct-out, I/O mixed with logic,
+  ;; error/raise, and provide shapes
   (write-file (build-path base-dir "subdir" "big-module.rkt")
               #<<EOF
 #lang racket/base
@@ -94,6 +95,15 @@ EOF
 #lang racket/base
 (define skipped-compiled #t)
 EOF
+              )
+  ;; Module with all-defined-out
+  (write-file (build-path base-dir "subdir" "ado-module.rkt")
+              #<<EOF
+#lang racket/base
+(provide (all-defined-out))
+(define (helper x) x)
+(define (other y) y)
+EOF
               ))
 
 (define (cleanup-fixture-tree base-dir)
@@ -112,7 +122,10 @@ EOF
    (check-true (procedure? (audit-ref 'jsexpr->json-string)) "jsexpr->json-string is a procedure")
    (check-true (procedure? (audit-ref 'find-rkt-files)) "find-rkt-files is a procedure")
    (check-true (procedure? (audit-ref 'count-exports)) "count-exports is a procedure")
-   (check-true (procedure? (audit-ref 'has-io-effects?)) "has-io-effects? is a procedure")))
+   (check-true (procedure? (audit-ref 'has-io-effects?)) "has-io-effects? is a procedure")
+   (check-true (procedure? (audit-ref 'count-io-effects)) "count-io-effects is a procedure")
+   (check-true (procedure? (audit-ref 'detect-provide-shapes)) "detect-provide-shapes is a procedure")
+   (check-true (procedure? (audit-ref 'count-struct-outs)) "count-struct-outs is a procedure")))
 
 (define-test-suite
  audit-module-tests
@@ -130,6 +143,11 @@ EOF
    (check-true (hash-has-key? finding 'macro-count) "finding has macro-count")
    (check-true (hash-has-key? finding 'has-struct-out?) "finding has has-struct-out?")
    (check-true (hash-has-key? finding 'io-mixed-with-logic?) "finding has io-mixed-with-logic?")
+   (check-true (hash-has-key? finding 'struct-out-count) "finding has struct-out-count")
+   (check-true (hash-has-key? finding 'io-count) "finding has io-count")
+   (check-true (hash-has-key? finding 'error-count) "finding has error-count")
+   (check-true (hash-has-key? finding 'provide-shapes) "finding has provide-shapes")
+   (check-true (hash-has-key? finding 'handler-count) "finding has handler-count")
 
    ;; Verify the big fixture module has expected properties
    (check-pred positive? (hash-ref finding 'line-count) "big-module has positive line count")
@@ -138,6 +156,17 @@ EOF
    (check-pred positive? (hash-ref finding 'macro-count) "big-module has macro usage")
    (check-true (hash-ref finding 'has-struct-out?) "big-module has struct-out")
    (check-true (hash-ref finding 'io-mixed-with-logic?) "big-module mixes I/O with logic")
+   (check-pred positive?
+               (hash-ref finding 'struct-out-count)
+               "big-module has positive struct-out-count")
+   (check-pred positive? (hash-ref finding 'io-count) "big-module has positive io-count")
+   (check-pred positive? (hash-ref finding 'error-count) "big-module has positive error-count")
+   (check-true (and (member 'struct-out (hash-ref finding 'provide-shapes)) #t)
+               "big-module provide-shapes includes struct-out")
+   (check-true (and (member 'explicit (hash-ref finding 'provide-shapes)) #t)
+               "big-module provide-shapes includes explicit")
+   (check-false (and (member 'all-defined-out (hash-ref finding 'provide-shapes)) #t)
+                "big-module does NOT use all-defined-out")
 
    (cleanup-fixture-tree tmpdir))
  (test-case "audit-module returns #f for nonexistent file"
@@ -180,13 +209,22 @@ EOF
    (check-true (hash-has-key? summary 'io-mixed-with-logic) "summary has io-mixed-with-logic")
    (check-true (hash-has-key? summary 'serialization-hotspots) "summary has serialization-hotspots")
    (check-true (hash-has-key? summary 'total-modules) "summary has total-modules")
+   (check-true (hash-has-key? summary 'error-density) "summary has error-density")
+   (check-true (hash-has-key? summary 'handler-density) "summary has handler-density")
+   (check-true (hash-has-key? summary 'all-defined-out-modules) "summary has all-defined-out-modules")
 
-   ;; Should find exactly 2 production/source modules in fixture. The tests/
-   ;; and compiled/ files are intentional sentinels and must be skipped.
-   (check-equal? (hash-ref summary 'total-modules) 2 "fixture has 2 production modules")
+   ;; Should find exactly 3 production/source modules in fixture (clean, big-module, ado-module).
+   (check-equal? (hash-ref summary 'total-modules) 3 "fixture has 3 production modules")
 
    ;; Should find struct-out in fixture
    (check-true (and (hash-ref summary 'struct-out-exports) #t) "struct-out-exports is non-empty")
+
+   ;; Should find all-defined-out in ado-module
+   (check-true (and (hash-ref summary 'all-defined-out-modules) #t)
+               "all-defined-out-modules is non-empty")
+
+   ;; Should find error density in big-module
+   (check-true (and (hash-ref summary 'error-density) #t) "error-density is non-empty")
 
    (cleanup-fixture-tree tmpdir))
  (test-case "find-rkt-files excludes tests and compiled directories by default"
@@ -194,7 +232,7 @@ EOF
    (setup-fixture-tree tmpdir)
 
    (define files (map path->string ((audit-ref 'find-rkt-files) (path->string tmpdir))))
-   (check-equal? (length files) 2 "fixture scan excludes skipped directories")
+   (check-equal? (length files) 3 "fixture scan excludes skipped directories")
    (check-false (ormap (lambda (p) (string-contains? p "/tests/")) files)
                 "default scan excludes tests/")
    (check-false (ormap (lambda (p) (string-contains? p "/compiled/")) files)
@@ -243,6 +281,63 @@ EOF
                      (check-true (>= ((audit-ref 'count-exports) text) 2)
                                  "struct-out counts as at least 2")))
 
+(define-test-suite
+ red-flag-signal-tests
+ (test-case "count-struct-outs counts struct-out forms"
+   (define text "(provide (struct-out a) (struct-out b))")
+   (check-equal? ((audit-ref 'count-struct-outs) text) 2 "counts 2 struct-out forms"))
+ (test-case "count-struct-outs returns 0 for no struct-out"
+   (define text "(provide greet)")
+   (check-equal? ((audit-ref 'count-struct-outs) text) 0 "no struct-out returns 0"))
+ (test-case "count-io-effects counts I/O pattern occurrences"
+   (define text "(call-with-output-file \"a\" f)\n(file->string \"b\")")
+   (check-true (>= ((audit-ref 'count-io-effects) text) 2) "counts >= 2 I/O occurrences"))
+ (test-case "count-io-effects returns 0 for clean text"
+   (define text "(define (f x) x)")
+   (check-equal? ((audit-ref 'count-io-effects) text) 0 "no I/O returns 0"))
+ (test-case "detect-provide-shapes detects all-defined-out"
+   (define text "(provide (all-defined-out))")
+   (define shapes ((audit-ref 'detect-provide-shapes) text))
+   (check-true (and (member 'all-defined-out shapes) #t) "detects all-defined-out"))
+ (test-case "detect-provide-shapes detects struct-out"
+   (define text "(provide (struct-out widget))")
+   (define shapes ((audit-ref 'detect-provide-shapes) text))
+   (check-true (and (member 'struct-out shapes) #t) "detects struct-out"))
+ (test-case "detect-provide-shapes detects contract-out"
+   (define text "(provide (contract-out [f (-> number? number?)]))")
+   (define shapes ((audit-ref 'detect-provide-shapes) text))
+   (check-true (and (member 'contract-out shapes) #t) "detects contract-out"))
+ (test-case "detect-provide-shapes detects explicit IDs"
+   (define text "(provide greet farewell)")
+   (define shapes ((audit-ref 'detect-provide-shapes) text))
+   (check-true (and (member 'explicit shapes) #t) "detects explicit"))
+ (test-case "detect-provide-shapes on empty returns empty list"
+   (define text "(define x 1)")
+   (check-equal? ((audit-ref 'detect-provide-shapes) text) '() "no provide returns empty list"))
+ (test-case "audit-module detects error-count in big fixture"
+   (define tmpdir (make-temporary-file "abstraction-audit-~a" 'directory))
+   (setup-fixture-tree tmpdir)
+   (define big-path (build-path tmpdir "subdir" "big-module.rkt"))
+   (define finding ((audit-ref 'audit-module) (path->string big-path)))
+   (check-pred positive? (hash-ref finding 'error-count) "big-module has error calls")
+   (cleanup-fixture-tree tmpdir))
+ (test-case "audit-module detects all-defined-out in ado fixture"
+   (define tmpdir (make-temporary-file "abstraction-audit-~a" 'directory))
+   (setup-fixture-tree tmpdir)
+   (define ado-path (build-path tmpdir "subdir" "ado-module.rkt"))
+   (define finding ((audit-ref 'audit-module) (path->string ado-path)))
+   (define shapes (hash-ref finding 'provide-shapes))
+   (check-true (and (member 'all-defined-out shapes) #t) "ado-module has all-defined-out"))
+ (test-case "audit-module on clean file has zero error count"
+   (define tmpdir (make-temporary-file "abstraction-audit-~a" 'directory))
+   (setup-fixture-tree tmpdir)
+   (define clean-path (build-path tmpdir "clean.rkt"))
+   (define finding ((audit-ref 'audit-module) (path->string clean-path)))
+   (check-equal? (hash-ref finding 'error-count) 0 "clean module has 0 error calls")
+   (check-equal? (hash-ref finding 'io-count) 0 "clean module has 0 io-count")
+   (check-equal? (hash-ref finding 'struct-out-count) 0 "clean module has 0 struct-out-count")
+   (cleanup-fixture-tree tmpdir)))
+
 ;; ============================================================
 ;; Run all tests
 ;; ============================================================
@@ -253,7 +348,8 @@ EOF
                    audit-directory-tests
                    json-serialization-tests
                    no-mutation-tests
-                   count-exports-tests)
+                   count-exports-tests
+                   red-flag-signal-tests)
 
 (module+ test
   (run-tests all-abstraction-audit-tests))


### PR DESCRIPTION
## W1 — Abstraction-Audit Red-Flag Tooling + Review Checklist

### Changes
- **scripts/abstraction-audit.rkt**: Added 5 new objective signals (struct-out-count, error/raise-count, io-count, provide-shapes, handler threshold). New exports: `count-io-effects`, `detect-provide-shapes`, `count-struct-outs`.
- **tests/test-abstraction-audit.rkt**: Added 10 new test cases in `red-flag-signal-tests` suite (22 total, all passing).
- **docs/reports/ABSTRACTION-RED-FLAGS-v0.99.36.md**: Generated red-flag report.
- **docs/reports/ABSTRACTION-REVIEW-CHECKLIST-v0.99.36.md**: Signal-to-question mapping for manual review.

### Verification
- `raco make main.rkt` — PASS
- `raco test tests/test-abstraction-audit.rkt` — 22/22 PASS
- Smoke gate — 19/19 files, 286 tests PASS

Closes #8414