### PR TITLE
W2: Centralize version-surface registry (#8415)

### DIFF
--- a/scripts/audit-project.rkt
+++ b/scripts/audit-project.rkt
@@ -20,7 +20,8 @@
          racket/match
          racket/date
          racket/path
-         json)
+         json
+         "version-surface.rkt")
 
 ;; ── Configuration ──
 
@@ -270,12 +271,10 @@
 ;; ── JSON output ──
 
 (define (read-version-string)
-  (with-handlers ([exn:fail? (lambda (e) "unknown")])
-    (define content (file->string (build-path Q-DIR "util" "version.rkt")))
-    (define m (regexp-match #rx"q-version \"([0-9]+\\.[0-9]+\\.[0-9]+)\"" content))
-    (if m
-        (cadr m)
-        "unknown")))
+  ;; Centralized via version-surface.rkt (W2 #8415).
+  ;; Uses Q-DIR as base, returns "unknown" on failure for backward compat.
+  (define v (read-canonical-version (path->string Q-DIR)))
+  (if (equal? v "0.0.0") "unknown" v))
 
 (define (generate-json-report report-text critical-count findings inv)
   (define risky (filter (lambda (f) (equal? (finding-category f) "risky-api")) findings))

--- a/scripts/lint-version.rkt
+++ b/scripts/lint-version.rkt
@@ -19,35 +19,19 @@
          racket/path
          racket/string
          racket/port
-         "version-guard.rkt")
+         "version-guard.rkt"
+         "version-surface.rkt")
 
 ;; ---------------------------------------------------------------------------
 ;; Parsing helpers
 ;; ---------------------------------------------------------------------------
 
+;; Version parsing centralized in version-surface.rkt (W2 #8415).
+;; Locally re-exported under original names for backward compatibility.
+(define parse-q-version parse-q-version-from-content)
+(define parse-info-version parse-info-version-from-content)
+
 (define VERSION-PAT #rx"[0-9]+\\.[0-9]+\\.[0-9]+")
-
-;; Parse `(define q-version "X.Y.Z")` from util/version.rkt content.
-(define (parse-q-version content)
-  ;; Handles both #lang racket and #lang typed/racket (multi-line) formats.
-  (define start (regexp-match-positions #rx"\\(define q-version" content))
-  (cond
-    [(not start) #f]
-    [else
-     (define after (substring content (cdar start)))
-     (define m (regexp-match #rx"([0-9]+\\.[0-9]+\\.[0-9]+)" after))
-     (and m (cadr m))]))
-
-;; Parse `(define version "X.Y.Z")` from info.rkt content.
-(define (parse-info-version content)
-  (define lines (string-split content "\n"))
-  (for/or ([line (in-list lines)])
-    (define trimmed (string-trim line))
-    (cond
-      [(and (string-prefix? trimmed "(define version") (string-suffix? trimmed ")"))
-       (define m (regexp-match #rx"\"([0-9]+\\.[0-9]+\\.[0-9]+)\"" trimmed))
-       (and m (cadr m))]
-      [else #f])))
 
 ;; ---------------------------------------------------------------------------
 ;; File scanning

--- a/scripts/lint-widened-ledger.rkt
+++ b/scripts/lint-widened-ledger.rkt
@@ -18,39 +18,20 @@
          racket/string
          racket/list
          racket/path
-         racket/match)
+         racket/match
+         "version-surface.rkt")
 
 ;; ---------------------------------------------------------------------------
-;; Version comparison
+;; Version comparison — centralized in version-surface.rkt (W2 #8415).
+;; version<=? and parse-version-components are imported and re-exported.
 ;; ---------------------------------------------------------------------------
-
-(define (parse-version s)
-  (map string->number (string-split s ".")))
-
-(define (version<=? a b)
-  (let loop ([as (parse-version a)]
-             [bs (parse-version b)])
-    (cond
-      [(and (null? as) (null? bs)) #t]
-      [(null? as) #t] ; shorter version is "earlier"
-      [(null? bs) #f]
-      [(< (car as) (car bs)) #t]
-      [(> (car as) (car bs)) #f]
-      [else (loop (cdr as) (cdr bs))])))
 
 ;; ---------------------------------------------------------------------------
 ;; Read current project version
 ;; ---------------------------------------------------------------------------
 
 (define (get-current-version)
-  (define path "util/version.rkt")
-  (if (file-exists? path)
-      (let* ([content (file->string path)]
-             [m (regexp-match #rx"define q-version \"([^\"]+)\"" content)])
-        (if m
-            (cadr m)
-            "0.0.0"))
-      "0.0.0"))
+  (read-canonical-version))
 
 ;; ---------------------------------------------------------------------------
 ;; Parse ledger table

--- a/scripts/sync-version.rkt
+++ b/scripts/sync-version.rkt
@@ -31,7 +31,8 @@
          racket/port
          racket/string
          racket/path
-         "version-guard.rkt")
+         "version-guard.rkt"
+         "version-surface.rkt")
 
 ;; ---------------------------------------------------------------------------
 ;; Parsing
@@ -43,23 +44,9 @@
 (define STATUS-GUARD
   "<!-- DO NOT EDIT: Status section is historical. Use sync-version.rkt for version bumps. -->")
 
-;; Extract q-version from util/version.rkt content.
-;; Handles both `#lang racket` and `#lang typed/racket` formats.
-;; Typed Racket may split `(define q-version : String "X.Y.Z")` across lines.
-(define (parse-q-version content)
-  ;; Find the version string after `(define q-version` — handles multi-line Typed Racket format
-  (define start (regexp-match-positions #rx"\\(define q-version" content))
-  (cond
-    [(not start) #f]
-    [else
-     (define after (substring content (cdar start)))
-     (define m (regexp-match #rx"([0-9]+\\.[0-9]+\\.[0-9]+)" after))
-     (and m (cadr m))]))
-
-;; Extract version from info.rkt content.
-(define (parse-info-version content)
-  (define m (regexp-match #rx"\\(define version \"([0-9]+\\.[0-9]+\\.[0-9]+)\"" content))
-  (and m (cadr m)))
+;; Version parsing centralized in version-surface.rkt (W2 #8415).
+(define parse-q-version parse-q-version-from-content)
+(define parse-info-version parse-info-version-from-content)
 
 ;; ---------------------------------------------------------------------------
 ;; Sync info.rkt

--- a/scripts/version-surface.rkt
+++ b/scripts/version-surface.rkt
@@ -1,0 +1,120 @@
+#lang racket/base
+
+;; scripts/version-surface.rkt — Centralized version surface registry
+;;
+;; Consolidates the version-parsing logic that was independently duplicated
+;; across lint-version.rkt, sync-version.rkt, lint-widened-ledger.rkt, and
+;; audit-project.rkt. Each of those scripts had its own regex, error fallback,
+;; and path-construction logic for reading the canonical version from
+;; util/version.rkt.
+;;
+;; W2 (#8415): Created during v0.99.36 to establish a single source of truth
+;; for version-surface parsing.
+
+(require racket/file
+         racket/match
+         racket/path
+         racket/string)
+
+;; Content-level parsing (no I/O)
+(provide parse-q-version-from-content
+         parse-info-version-from-content
+         parse-version-components
+         ;; Comparison
+         version<=?
+         version<?
+         version=?
+         ;; File-level reading (with I/O)
+         read-canonical-version
+         read-canonical-version/strict
+         ;; Version formatting
+         version->string)
+
+;; ---------------------------------------------------------------------------
+;; Constants
+;; ---------------------------------------------------------------------------
+
+(define VERSION-FILE-NAME "version.rkt")
+(define VERSION-FILE-REL-PATH '("util" "version.rkt"))
+(define FALLBACK-VERSION "0.0.0")
+(define STRICT-FAIL-SENTINEL #f)
+
+;; ---------------------------------------------------------------------------
+;; Content-level parsing (pure functions, no I/O)
+;; ---------------------------------------------------------------------------
+
+;; Parse `(define q-version "X.Y.Z")` from content string.
+;; Handles both #lang racket and #lang typed/racket (multi-line) formats.
+(define (parse-q-version-from-content content)
+  (define start (regexp-match-positions #rx"\\(define q-version" content))
+  (cond
+    [(not start) #f]
+    [else
+     (define after (substring content (cdar start)))
+     (define m (regexp-match #rx"([0-9]+\\.[0-9]+\\.[0-9]+)" after))
+     (and m (cadr m))]))
+
+;; Parse `(define version "X.Y.Z")` from info.rkt content string.
+(define (parse-info-version-from-content content)
+  (define m (regexp-match #rx"\\(define version \"([0-9]+\\.[0-9]+\\.[0-9]+)\"" content))
+  (and m (cadr m)))
+
+;; Split "X.Y.Z" into list of numbers: (1 2 3)
+(define (parse-version-components s)
+  (map string->number (string-split s ".")))
+
+;; ---------------------------------------------------------------------------
+;; Comparison (pure)
+;; ---------------------------------------------------------------------------
+
+(define (version<=? a b)
+  (let loop ([as (parse-version-components a)]
+             [bs (parse-version-components b)])
+    (cond
+      [(and (null? as) (null? bs)) #t]
+      [(null? as) #t] ; shorter version is "earlier"
+      [(null? bs) #f]
+      [(< (car as) (car bs)) #t]
+      [(> (car as) (car bs)) #f]
+      [else (loop (cdr as) (cdr bs))])))
+
+(define (version<? a b)
+  (and (version<=? a b) (not (version=? a b))))
+
+(define (version=? a b)
+  (equal? a b))
+
+;; ---------------------------------------------------------------------------
+;; File-level reading (with I/O)
+;; ---------------------------------------------------------------------------
+
+;; Build the path to util/version.rkt relative to an optional base directory.
+;; If base-dir is #f, uses current-directory.
+(define (version-file-path base-dir)
+  (if base-dir
+      (apply build-path base-dir VERSION-FILE-REL-PATH)
+      (apply build-path (current-directory) VERSION-FILE-REL-PATH)))
+
+;; Read canonical version from util/version.rkt.
+;; Returns the version string, or FALLBACK-VERSION on error.
+(define (read-canonical-version [base-dir #f])
+  (define path (version-file-path base-dir))
+  (if (file-exists? path)
+      (let* ([content (file->string path)]
+             [v (parse-q-version-from-content content)])
+        (or v FALLBACK-VERSION))
+      FALLBACK-VERSION))
+
+;; Strict variant: returns #f on any failure (file not found, parse error).
+(define (read-canonical-version/strict [base-dir #f])
+  (define path (version-file-path base-dir))
+  (and (file-exists? path)
+       (let ([content (file->string path)]) (parse-q-version-from-content content))))
+
+;; ---------------------------------------------------------------------------
+;; Formatting
+;; ---------------------------------------------------------------------------
+
+;; Format version components back to string: (1 2 3) -> "1.2.3"
+(define (version->string components)
+  (string-join (map number->string components) "."))

--- a/tests/test-version-surface.rkt
+++ b/tests/test-version-surface.rkt
@@ -1,0 +1,98 @@
+#lang racket
+
+;; @speed fast
+;; @suite default
+
+;; test-version-surface.rkt — Tests for centralized version surface registry
+;; W2 (#8415): Consolidates version-parsing logic from 4 scripts.
+
+(require rackunit
+         rackunit/text-ui
+         racket/file
+         racket/runtime-path)
+
+(define-runtime-path script-path "../scripts/version-surface.rkt")
+(define-runtime-path q-root "..")
+
+(define (vs-ref sym)
+  (dynamic-require script-path sym))
+
+;; ---------------------------------------------------------------------------
+;; Content-level parsing tests
+;; ---------------------------------------------------------------------------
+
+(define-test-suite version-surface-tests
+                   (test-case "parse-q-version-from-content: basic"
+                     (define parse (vs-ref 'parse-q-version-from-content))
+                     (check-equal? (parse "(define q-version \"1.2.3\")") "1.2.3"))
+                   (test-case "parse-q-version-from-content: typed racket multiline"
+                     (define parse (vs-ref 'parse-q-version-from-content))
+                     (define content "#lang typed/racket\n(define q-version : String\n  \"0.99.36\")")
+                     (check-equal? (parse content) "0.99.36"))
+                   (test-case "parse-q-version-from-content: returns #f when not found"
+                     (define parse (vs-ref 'parse-q-version-from-content))
+                     (check-false (parse "(define other-thing \"1.0\")")))
+                   (test-case "parse-info-version-from-content: basic"
+                     (define parse (vs-ref 'parse-info-version-from-content))
+                     (check-equal? (parse "(define version \"2.3.4\")") "2.3.4"))
+                   (test-case "parse-info-version-from-content: returns #f when not found"
+                     (define parse (vs-ref 'parse-info-version-from-content))
+                     (check-false (parse "(define q-version \"2.3.4\")")))
+                   ;; ---------------------------------------------------------------------------
+                   ;; Version comparison tests
+                   ;; ---------------------------------------------------------------------------
+                   (test-case "version<=?: basic comparisons"
+                     (define v<=? (vs-ref 'version<=?))
+                     (check-true (v<=? "0.55.0" "0.56.0"))
+                     (check-true (v<=? "0.55.0" "0.55.0"))
+                     (check-false (v<=? "0.56.0" "0.55.0"))
+                     (check-true (v<=? "0.58.0" "1.0.0"))
+                     (check-true (v<=? "0.1.0" "0.2.0")))
+                   (test-case "version<?: strict ordering"
+                     (define v<? (vs-ref 'version<?))
+                     (check-true (v<? "0.55.0" "0.56.0"))
+                     (check-false (v<? "0.55.0" "0.55.0"))
+                     (check-false (v<? "0.56.0" "0.55.0")))
+                   (test-case "version=?: equality"
+                     (define v=? (vs-ref 'version=?))
+                     (check-true (v=? "1.2.3" "1.2.3"))
+                     (check-false (v=? "1.2.3" "1.2.4")))
+                   ;; ---------------------------------------------------------------------------
+                   ;; Component parsing tests
+                   ;; ---------------------------------------------------------------------------
+                   (test-case "parse-version-components: basic"
+                     (define pvc (vs-ref 'parse-version-components))
+                     (check-equal? (pvc "1.2.3") '(1 2 3))
+                     (check-equal? (pvc "0.0.0") '(0 0 0)))
+                   ;; ---------------------------------------------------------------------------
+                   ;; Version formatting tests
+                   ;; ---------------------------------------------------------------------------
+                   (test-case "version->string: round-trip"
+                     (define v->s (vs-ref 'version->string))
+                     (check-equal? (v->s '(1 2 3)) "1.2.3"))
+                   ;; ---------------------------------------------------------------------------
+                   ;; File-level I/O tests
+                   ;; ---------------------------------------------------------------------------
+                   (test-case "read-canonical-version: reads from actual version.rkt"
+                     (define rcv (vs-ref 'read-canonical-version))
+                     (define v (rcv (path->string q-root)))
+                     (check-true (and (regexp-match? #rx"[0-9]+\\.[0-9]+\\.[0-9]+" v) #t)))
+                   (test-case "read-canonical-version/strict: returns string for valid file"
+                     (define rcvs (vs-ref 'read-canonical-version/strict))
+                     (define v (rcvs (path->string q-root)))
+                     (check-true (string? v))
+                     (check-true (and (regexp-match? #rx"[0-9]+\\.[0-9]+\\.[0-9]+" v) #t)))
+                   (test-case "read-canonical-version: returns fallback for nonexistent dir"
+                     (define rcv (vs-ref 'read-canonical-version))
+                     (define v (rcv "/nonexistent/path"))
+                     (check-equal? v "0.0.0"))
+                   (test-case "read-canonical-version/strict: returns #f for nonexistent dir"
+                     (define rcvs (vs-ref 'read-canonical-version/strict))
+                     (define v (rcvs "/nonexistent/path"))
+                     (check-false v)))
+
+(module+ test
+  (run-tests version-surface-tests))
+
+(module+ main
+  (run-tests version-surface-tests))


### PR DESCRIPTION
## W2 — Centralize Version-Surface Registry

### Changes
- **scripts/version-surface.rkt** (NEW): Single source of truth for version parsing. Provides `parse-q-version-from-content`, `parse-info-version-from-content`, `parse-version-components`, `version<=?`, `version<?`, `version=?`, `read-canonical-version`, `read-canonical-version/strict`, `version->string`.
- **scripts/lint-version.rkt**: Replaced local `parse-q-version` and `parse-info-version` with imports from version-surface.rkt.
- **scripts/sync-version.rkt**: Same — replaced local `parse-q-version` and `parse-info-version`.
- **scripts/lint-widened-ledger.rkt**: Replaced local `get-current-version`, `parse-version`, `version<=?` with centralized module.
- **scripts/audit-project.rkt**: Replaced local `read-version-string` with centralized `read-canonical-version`.
- **tests/test-version-surface.rkt** (NEW): 14 tests covering content parsing, comparison, I/O, formatting.

### Eliminated Duplication
4 independent version-parsing implementations (each with different regex patterns, fallback values, and error handling) consolidated into 1 module.

### Verification
- `raco make main.rkt` — PASS
- All 4 scripts run end-to-end correctly (lint-version, sync-version, lint-widened-ledger, audit-project)
- 14 new + 27 existing tests pass
- Smoke gate — 19/19 files, 286 tests PASS

Closes #8415