### PR TITLE
W6: I/O abstraction pilot — lint-version-io.rkt (#8419)

### DIFF
--- a/docs/reports/PORT-IO-ABSTRACTION-PILOT-v0.99.36.md
+++ b/docs/reports/PORT-IO-ABSTRACTION-PILOT-v0.99.36.md
@@ -1,0 +1,96 @@
+# Port/I/O Abstraction Pilot — v0.99.36 W6
+
+**Date:** 2026-06-22
+**Wave:** W6 (#8419)
+**Risk Assessment:** GREEN (reward 15, risk 7)
+
+## 1. Pilot Summary
+
+This wave pilots the **I/O abstraction pattern** for script tooling, making
+file-reading operations injectable via parameters so that check logic can be
+tested without real file system access.
+
+**Pilot target:** `scripts/lint-version.rkt` — the version-consistency linter.
+
+## 2. Problem Statement
+
+`lint-version.rkt` had 5 check functions (`check-info-rkt`, `check-readme-badge`,
+`check-md-files`, `check-changelog-integrity`, `main`) that directly called
+`file-exists?`, `file->string`, and `in-directory`. This made the check logic:
+
+- **Untestable** without running the script as a subprocess in a real directory
+- **Untestable in isolation** — couldn't test the checking logic separately from I/O
+- **Hard to mock** — no way to inject test file content without creating real files
+
+## 3. I/O Abstraction Solution
+
+### New module: `scripts/lint-version-io.rkt`
+
+Defines 4 parameters for file I/O operations:
+
+| Parameter | Default | Purpose |
+|-----------|---------|---------|
+| `current-lint-file-exists?` | `file-exists?` | Check file existence |
+| `current-lint-file->string` | `file->string` | Read file content as string |
+| `current-lint-file->lines` | `file->lines` | Read file content as lines |
+| `current-lint-read-md-paths` | `#f` (uses directory scan) | List .md files |
+
+Plus mock file system helpers:
+
+| Helper | Purpose |
+|--------|---------|
+| `make-mock-fs` | Create hash: `path-string -> content-string` from alist |
+| `make-mock-exists` | Create mock `file-exists?` function |
+| `make-mock-read-string` | Create mock `file->string` function |
+| `make-mock-read-lines` | Create mock `file->lines` function |
+| `make-mock-md-paths` | Create mock directory listing function |
+
+### Pure functions extracted from lint-version.rkt
+
+| Function | Input | Output | I/O? |
+|----------|-------|--------|------|
+| `check-info-content` | info.rkt content, canonical version | error list | No I/O |
+| `check-readme-content` | README content, canonical version | error list | No I/O |
+| `check-changelog-content` | CHANGELOG content | error list | No I/O |
+| `find-mismatched-versions` | lines, version, filename | error list | No I/O (already existed) |
+
+### Refactored I/O wrappers
+
+All I/O wrapper functions now route through the parameters:
+- `check-info-rkt` → uses `(current-lint-file-exists?)` and `(current-lint-file->string)`
+- `check-readme-badge` → same
+- `check-md-files` → uses `(current-lint-file->string)` and optionally `(current-lint-read-md-paths)`
+- `check-changelog-integrity` → same
+- `main` → uses parameters for reading `util/version.rkt`
+
+### Guarded entry point
+
+`(main)` was wrapped in `(module+ main (main))` so the script can be `require`d
+from tests without side effects.
+
+## 4. Benefits Demonstrated
+
+1. **Pure-function testability:** Check logic tested with content strings — no file system needed
+2. **Mock I/O injection:** Full I/O wrappers tested with in-memory mock file systems
+3. **Zero behavioral change:** Script output identical when run normally (default parameters)
+4. **Pattern reusability:** The mock-fs helpers can be reused for any script that adopts this I/O abstraction
+
+## 5. Usage Pattern
+
+```racket
+;; In tests: inject mock file system
+(parameterize ([current-lint-file-exists? (make-mock-exists fs)]
+               [current-lint-file->string (make-mock-read-string fs)])
+  (check-info-rkt "1.0.0"))
+
+;; In production: default parameters use real file I/O (no change needed)
+(racket scripts/lint-version.rkt)
+```
+
+## 6. Verification
+
+- `raco make main.rkt` — PASS
+- `test-lint-version-io.rkt` — 11 tests PASS
+- `test-lint-version-pure.rkt` — 11 tests PASS (9 pure + 2 mock I/O)
+- Smoke gate: 19/19 files, 286 tests PASS
+- Script invocation: `racket scripts/lint-version.rkt` produces identical output

--- a/scripts/lint-version-io.rkt
+++ b/scripts/lint-version-io.rkt
@@ -1,0 +1,87 @@
+#lang racket/base
+
+;; scripts/lint-version-io.rkt — I/O abstraction for version linting
+;;
+;; W6 (#8419): Port/I/O abstraction pilot for report/version tooling.
+;;
+;; Makes file-reading operations injectable via parameters, enabling tests to
+;; substitute in-memory mock file systems without touching the real filesystem.
+;;
+;; Pattern:
+;;   (parameterize ([current-lint-file->string (make-mock-read-string fs)]
+;;                  [current-lint-file-exists? (make-mock-exists fs)])
+;;     ... check logic ...)
+;;
+;; Default behavior: all parameters use real file I/O (racket/file).
+;;
+;; A "mock file system" is a hash: path-string -> content-string.
+;; Use `make-mock-fs` to create one from an alist of (path . content).
+
+(require racket/file
+         racket/string)
+
+;; Parameters
+(provide current-lint-file-exists?
+         current-lint-file->string
+         current-lint-file->lines
+         current-lint-read-md-paths
+         ;; Mock file system
+         make-mock-fs
+         make-mock-exists
+         make-mock-read-string
+         make-mock-read-lines
+         make-mock-md-paths)
+
+;; ---------------------------------------------------------------------------
+;; Parameters (default: real file I/O)
+;; ---------------------------------------------------------------------------
+
+(define current-lint-file-exists? (make-parameter file-exists?))
+(define current-lint-file->string (make-parameter file->string))
+(define current-lint-file->lines (make-parameter file->lines))
+;; Returns a function: (base-path -> (listof path-string))
+(define current-lint-read-md-paths (make-parameter #f))
+
+;; ---------------------------------------------------------------------------
+;; Mock file system
+;; ---------------------------------------------------------------------------
+
+;; Create a mock file system hash from an alist: (path-string . content-string)
+(define (make-mock-fs alist)
+  (for/hash ([pair (in-list alist)])
+    (values (car pair) (cdr pair))))
+
+;; Create a mock file-exists? function from a mock fs.
+;; Accepts path or string; normalizes to string for lookup.
+(define (make-mock-exists fs)
+  (λ (path) (hash-has-key? fs (path->key path))))
+
+;; Create a mock file->string function from a mock fs.
+(define (make-mock-read-string fs)
+  (λ (path)
+    (define key (path->key path))
+    (unless (hash-has-key? fs key)
+      (error 'file->string "no such file: ~a" key))
+    (hash-ref fs key)))
+
+;; Create a mock file->lines function from a mock fs.
+(define (make-mock-read-lines fs)
+  (λ (path)
+    (define key (path->key path))
+    (unless (hash-has-key? fs key)
+      (error 'file->lines "no such file: ~a" key))
+    (string-split (hash-ref fs key) "\n")))
+
+;; Create a mock read-md-paths function that returns a fixed list.
+;; Returns a function: (base-path -> (listof path-string))
+(define (make-mock-md-paths paths)
+  (λ base-dir paths))
+
+;; ---------------------------------------------------------------------------
+;; Path normalization helper
+;; ---------------------------------------------------------------------------
+
+(define (path->key p)
+  (if (path? p)
+      (path->string p)
+      p))

--- a/scripts/lint-version.rkt
+++ b/scripts/lint-version.rkt
@@ -20,7 +20,19 @@
          racket/string
          racket/port
          "version-guard.rkt"
-         "version-surface.rkt")
+         "version-surface.rkt"
+         "lint-version-io.rkt")
+
+;; W6 (#8419): Pure check functions are exported for unit testing.
+;; I/O wrappers use lint-version-io.rkt parameters for injectable file access.
+(provide check-info-content
+         check-readme-content
+         check-changelog-content
+         find-mismatched-versions
+         check-info-rkt
+         check-readme-badge
+         check-md-files
+         check-changelog-integrity)
 
 ;; ---------------------------------------------------------------------------
 ;; Parsing helpers
@@ -116,17 +128,67 @@
                (list lineno v)))))
 
 ;; ---------------------------------------------------------------------------
-;; Checks
+;; CHANGELOG integrity threshold
+;; ---------------------------------------------------------------------------
+
+(define MIN-UNIQUE-VERSIONS 50)
+
+;; ---------------------------------------------------------------------------
+;; Pure check functions (no I/O, no side effects)
+;; W6 (#8419): Extracted from I/O wrappers for testability.
+;; Each returns a list of errors: (list path lineno found expected) or '()
+;; ---------------------------------------------------------------------------
+
+;; Pure: check info.rkt content for version match.
+(define (check-info-content content canonical)
+  (define info-v (parse-info-version content))
+  (cond
+    [(not info-v) (list (list 'info.rkt 0 "<unparseable>" canonical))]
+    [(equal? info-v canonical) '()]
+    [else (list (list 'info.rkt 0 info-v canonical))]))
+
+;; Pure: check README content for badge + verify snippet version match.
+(define (check-readme-content content canonical)
+  (define badge-m (regexp-match #rx"badge/version-([0-9]+\\.[0-9]+\\.[0-9]+)" content))
+  (define badge-v (and badge-m (cadr badge-m)))
+  (define verify-m (regexp-match #rx"q version ([0-9]+\\.[0-9]+\\.[0-9]+)" content))
+  (define verify-v (and verify-m (cadr verify-m)))
+  (append (if (and badge-v (not (equal? badge-v canonical)))
+              (list (list 'README.md 0 badge-v canonical))
+              '())
+          (if (and verify-v (not (equal? verify-v canonical)))
+              (list (list 'README.md 0 verify-v canonical))
+              '())))
+
+;; Pure: check CHANGELOG content for version header count integrity.
+(define (check-changelog-content content)
+  (define lines (string-split content "\n"))
+  (define versions
+    (for/list ([line (in-list lines)])
+      (define m (regexp-match #rx"^## v([0-9]+\\.[0-9]+\\.[0-9]+)" line))
+      (and m (cadr m))))
+  (define unique (remove-duplicates (filter (lambda (x) x) versions)))
+  (if (< (length unique) MIN-UNIQUE-VERSIONS)
+      (list (list 'CHANGELOG.md
+                  0
+                  (format "~a unique versions (< ~a)" (length unique) MIN-UNIQUE-VERSIONS)
+                  (format ">= ~a unique versions" MIN-UNIQUE-VERSIONS)))
+      '()))
+
+;; ---------------------------------------------------------------------------
+;; I/O wrappers (use parameters from lint-version-io.rkt)
 ;; ---------------------------------------------------------------------------
 
 (define (check-info-rkt canonical)
+  (define exists? (current-lint-file-exists?))
+  (define read-string (current-lint-file->string))
   (define info-path (build-path (current-directory) "info.rkt"))
   (cond
-    [(not (file-exists? info-path))
+    [(not (exists? info-path))
      (displayln "  WARN: info.rkt not found")
      '()]
     [else
-     (define info-content (file->string info-path))
+     (define info-content (read-string info-path))
      (define info-v (parse-info-version info-content))
      (cond
        [(not info-v)
@@ -140,13 +202,15 @@
         (list (list info-path 0 info-v canonical))])]))
 
 (define (check-readme-badge canonical)
+  (define exists? (current-lint-file-exists?))
+  (define read-string (current-lint-file->string))
   (define readme-path (build-path (current-directory) "README.md"))
   (cond
-    [(not (file-exists? readme-path))
+    [(not (exists? readme-path))
      (displayln "  WARN: README.md not found")
      '()]
     [else
-     (define content (file->string readme-path))
+     (define content (read-string readme-path))
      (define badge-m (regexp-match #rx"badge/version-([0-9]+\\.[0-9]+\\.[0-9]+)" content))
      (define badge-v (and badge-m (cadr badge-m)))
      (define verify-m (regexp-match #rx"q version ([0-9]+\\.[0-9]+\\.[0-9]+)" content))
@@ -169,34 +233,38 @@
                    '())))]))
 
 (define (check-md-files canonical)
-  (define md-files (collect-md-files (current-directory)))
+  (define read-string (current-lint-file->string))
+  (define custom-paths (current-lint-read-md-paths))
+  (define md-files
+    (if custom-paths
+        (custom-paths (current-directory))
+        (collect-md-files (current-directory))))
   (append* (for/list ([f (in-list md-files)])
-             (define lines (string-split (file->string f) "\n"))
+             (define lines (string-split (read-string f) "\n"))
              (define mismatches (find-mismatched-versions lines canonical f))
              (for/list ([m (in-list mismatches)])
                (printf "  ERROR: ~a:~a: \"~a\" ≠ canonical ~a~n"
-                       (path->string f)
+                       (if (path? f)
+                           (path->string f)
+                           f)
                        (first m)
                        (second m)
                        canonical)
                (list f (first m) (second m))))))
 
-;; ---------------------------------------------------------------------------
-;; CHANGELOG integrity check (AX1-NEW-1 corruption guard)
-;; ---------------------------------------------------------------------------
-
-(define MIN-UNIQUE-VERSIONS 50)
-
 (define (check-changelog-integrity)
   ;; Validate CHANGELOG.md has sufficient unique version headers.
   ;; Returns list of errors (empty = OK).
+  (define exists? (current-lint-file-exists?))
+  (define read-string (current-lint-file->string))
   (define changelog-path (build-path (current-directory) "CHANGELOG.md"))
   (cond
-    [(not (file-exists? changelog-path))
+    [(not (exists? changelog-path))
      (displayln "  WARN: CHANGELOG.md not found")
      '()]
     [else
-     (define content (file->string changelog-path))
+     (define content (read-string changelog-path))
+     (define errors (check-changelog-content content))
      (define lines (string-split content "\n"))
      (define versions
        (for/list ([line (in-list lines)])
@@ -204,19 +272,16 @@
          (and m (cadr m))))
      (define unique (remove-duplicates (filter (lambda (x) x) versions)))
      (printf "  CHANGELOG.md: ~a unique version headers~n" (length unique))
-     (cond
-       [(< (length unique) MIN-UNIQUE-VERSIONS)
-        (printf
-         "  ERROR: CHANGELOG.md appears corrupted (< ~a unique versions). ~
-                 Historical entries may have been overwritten.~n"
-         MIN-UNIQUE-VERSIONS)
-        (list (list changelog-path
-                    0
-                    (format "~a unique versions (< ~a)" (length unique) MIN-UNIQUE-VERSIONS)
-                    (format ">= ~a unique versions" MIN-UNIQUE-VERSIONS)))]
-       [else
-        (displayln "  CHANGELOG integrity: OK")
-        '()])]))
+     (if (null? errors)
+         (begin
+           (displayln "  CHANGELOG integrity: OK")
+           '())
+         (begin
+           (printf
+            "  ERROR: CHANGELOG.md appears corrupted (< ~a unique versions). ~
+                    Historical entries may have been overwritten.~n"
+            MIN-UNIQUE-VERSIONS)
+           errors))]))
 
 ;; ---------------------------------------------------------------------------
 ;; Main
@@ -224,12 +289,14 @@
 
 (define (main)
   ;; --- Read canonical version from util/version.rkt ---
+  (define exists? (current-lint-file-exists?))
+  (define read-string (current-lint-file->string))
   (define util-path (build-path (current-directory) "util" "version.rkt"))
-  (unless (file-exists? util-path)
+  (unless (exists? util-path)
     (displayln "ERROR: util/version.rkt not found in current directory")
     (exit 1))
 
-  (define util-content (file->string util-path))
+  (define util-content (read-string util-path))
   (define canonical (parse-q-version util-content))
   (unless canonical
     (displayln "ERROR: could not parse q-version from util/version.rkt")
@@ -264,4 +331,5 @@
         (displayln "Version lint FAILED")
         (exit 1))))
 
-(main)
+(module+ main
+  (main))

--- a/tests/test-lint-version-io.rkt
+++ b/tests/test-lint-version-io.rkt
@@ -1,0 +1,98 @@
+#lang racket
+
+;; @speed fast
+;; @suite default
+
+;; test-lint-version-io.rkt — Tests for I/O abstraction (W6 pilot)
+;;
+;; Tests the parameterized I/O interface for version linting.
+
+(require rackunit
+         rackunit/text-ui
+         racket/runtime-path)
+
+(define-runtime-path io-path "../scripts/lint-version-io.rkt")
+
+(define (io-ref sym)
+  (dynamic-require io-path sym))
+
+;; ---------------------------------------------------------------------------
+;; Parameter defaults
+;; ---------------------------------------------------------------------------
+
+(define-test-suite lint-version-io-tests
+                   (test-case "current-lint-file-exists? is a parameter"
+                     (define p (io-ref 'current-lint-file-exists?))
+                     (check-true (procedure? p)))
+                   (test-case "current-lint-file->string is a parameter"
+                     (define p (io-ref 'current-lint-file->string))
+                     (check-true (procedure? p)))
+                   (test-case "current-lint-file->lines is a parameter"
+                     (define p (io-ref 'current-lint-file->lines))
+                     (check-true (procedure? p)))
+                   (test-case "current-lint-read-md-paths is a parameter"
+                     (define p (io-ref 'current-lint-read-md-paths))
+                     (check-true (procedure? p)))
+                   ;; ---------------------------------------------------------------------------
+                   ;; Mock file system
+                   ;; ---------------------------------------------------------------------------
+                   (test-case "make-mock-fs creates a hash from alist"
+                     (define make-mock-fs (io-ref 'make-mock-fs))
+                     (define fs (make-mock-fs '(("info.rkt" . "(define version \"1.0.0\")"))))
+                     (check-true (hash? fs))
+                     (check-equal? (hash-ref fs "info.rkt") "(define version \"1.0.0\")"))
+                   ;; ---------------------------------------------------------------------------
+                   ;; File exists check with mock
+                   ;; ---------------------------------------------------------------------------
+                   (test-case "mock file-exists? returns true for known files"
+                     (define make-mock-fs (io-ref 'make-mock-fs))
+                     (define make-mock-exists (io-ref 'make-mock-exists))
+                     (define fs (make-mock-fs '(("info.rkt" . "content"))))
+                     (define exists? (make-mock-exists fs))
+                     (check-true (exists? "info.rkt"))
+                     (check-false (exists? "nonexistent.rkt")))
+                   ;; ---------------------------------------------------------------------------
+                   ;; File->string with mock
+                   ;; ---------------------------------------------------------------------------
+                   (test-case "mock file->string returns content for known files"
+                     (define make-mock-fs (io-ref 'make-mock-fs))
+                     (define make-mock-read (io-ref 'make-mock-read-string))
+                     (define fs (make-mock-fs '(("README.md" . "# Hello"))))
+                     (define reader (make-mock-read fs))
+                     (check-equal? (reader "README.md") "# Hello"))
+                   (test-case "mock file->string errors on unknown files"
+                     (define make-mock-fs (io-ref 'make-mock-fs))
+                     (define make-mock-read (io-ref 'make-mock-read-string))
+                     (define fs (make-mock-fs '()))
+                     (define reader (make-mock-read fs))
+                     (check-exn exn:fail? (λ () (reader "missing.md"))))
+                   ;; ---------------------------------------------------------------------------
+                   ;; Parameterize with mock I/O
+                   ;; ---------------------------------------------------------------------------
+                   (test-case "parameterize overrides default I/O"
+                     (define param (io-ref 'current-lint-file->string))
+                     (define make-mock-fs (io-ref 'make-mock-fs))
+                     (define make-mock-read (io-ref 'make-mock-read-string))
+                     (define fs (make-mock-fs '(("test.rkt" . "hello"))))
+                     (define reader (make-mock-read fs))
+                     (parameterize ([param reader])
+                       (define current-read (io-ref 'current-lint-file->string))
+                       (check-equal? ((current-read) "test.rkt") "hello")))
+                   ;; ---------------------------------------------------------------------------
+                   ;; Mock file->lines
+                   ;; ---------------------------------------------------------------------------
+                   (test-case "mock file->lines splits content by newlines"
+                     (define make-mock-fs (io-ref 'make-mock-fs))
+                     (define make-mock-read-lines (io-ref 'make-mock-read-lines))
+                     (define fs (make-mock-fs '(("test.md" . "line1\nline2\nline3"))))
+                     (define reader (make-mock-read-lines fs))
+                     (check-equal? (reader "test.md") '("line1" "line2" "line3")))
+                   ;; ---------------------------------------------------------------------------
+                   ;; Mock read-md-paths
+                   ;; ---------------------------------------------------------------------------
+                   (test-case "make-mock-md-paths returns configured list"
+                     (define make-mock-md-paths (io-ref 'make-mock-md-paths))
+                     (define paths-proc (make-mock-md-paths '("README.md" "docs/guide.md")))
+                     (check-equal? (paths-proc) '("README.md" "docs/guide.md"))))
+
+(run-tests lint-version-io-tests)

--- a/tests/test-lint-version-pure.rkt
+++ b/tests/test-lint-version-pure.rkt
@@ -1,0 +1,119 @@
+#lang racket
+
+;; @speed fast
+;; @suite default
+
+;; test-lint-version-pure.rkt — Tests for pure check functions extracted from
+;; lint-version.rkt via the I/O abstraction (W6 #8419).
+;;
+;; These tests exercise the pure check functions directly with content strings,
+;; AND test the I/O wrappers with mock file systems via lint-version-io.rkt.
+
+(require rackunit
+         rackunit/text-ui
+         racket/runtime-path)
+
+(define-runtime-path script-path "../scripts/lint-version.rkt")
+(define-runtime-path io-path "../scripts/lint-version-io.rkt")
+
+(define (lv-ref sym)
+  (dynamic-require script-path sym))
+
+(define (io-ref sym)
+  (dynamic-require io-path sym))
+
+;; ---------------------------------------------------------------------------
+;; Pure function tests (no I/O)
+;; ---------------------------------------------------------------------------
+
+(define-test-suite lint-version-pure-tests
+                   ;; --- check-info-content ---
+                   (test-case "check-info-content: matching version returns no errors"
+                     (define check (lv-ref 'check-info-content))
+                     (define content "(define version \"1.0.0\")")
+                     (check-equal? (check content "1.0.0") '()))
+                   (test-case "check-info-content: mismatched version returns error"
+                     (define check (lv-ref 'check-info-content))
+                     (define content "(define version \"0.9.0\")")
+                     (define errors (check content "1.0.0"))
+                     (check-equal? (length errors) 1))
+                   (test-case "check-info-content: unparseable content returns error"
+                     (define check (lv-ref 'check-info-content))
+                     (define content "(define something-else \"1.0.0\")")
+                     (define errors (check content "1.0.0"))
+                     (check-equal? (length errors) 1))
+                   ;; --- check-readme-content ---
+                   (test-case "check-readme-content: matching badge and verify"
+                     (define check (lv-ref 'check-readme-content))
+                     (define content "badge/version-1.0.0 and q version 1.0.0")
+                     (check-equal? (check content "1.0.0") '()))
+                   (test-case "check-readme-content: mismatched badge"
+                     (define check (lv-ref 'check-readme-content))
+                     (define content "badge/version-0.9.0 and q version 1.0.0")
+                     (define errors (check content "1.0.0"))
+                     (check-equal? (length errors) 1)
+                     (check-equal? (first (first errors)) 'README.md))
+                   (test-case "check-readme-content: mismatched verify snippet"
+                     (define check (lv-ref 'check-readme-content))
+                     (define content "badge/version-1.0.0 and q version 0.9.0")
+                     (define errors (check content "1.0.0"))
+                     (check-equal? (length errors) 1))
+                   (test-case "check-readme-content: no version strings in content"
+                     (define check (lv-ref 'check-readme-content))
+                     (define content "# Just a readme with no versions")
+                     (check-equal? (check content "1.0.0") '()))
+                   ;; --- check-changelog-content ---
+                   (test-case "check-changelog-content: sufficient versions → no errors"
+                     (define check (lv-ref 'check-changelog-content))
+                     ;; Generate 50 version headers
+                     (define content
+                       (string-join (for/list ([i (in-range 1 51)])
+                                      (format "## v0.~a.0" i))
+                                    "\n"))
+                     (check-equal? (check content) '()))
+                   (test-case "check-changelog-content: too few versions → error"
+                     (define check (lv-ref 'check-changelog-content))
+                     (define content "## v1.0.0\n## v1.0.1\n## v1.0.2")
+                     (define errors (check content))
+                     (check-equal? (length errors) 1)
+                     (check-equal? (first (first errors)) 'CHANGELOG.md)))
+
+;; ---------------------------------------------------------------------------
+;; I/O wrapper tests with mock file system
+;; ---------------------------------------------------------------------------
+
+(define-test-suite
+ lint-version-mock-io-tests
+ (test-case "check-info-rkt with mock fs: matching version"
+   (define check-info-rkt (lv-ref 'check-info-rkt))
+   (define make-mock-fs (io-ref 'make-mock-fs))
+   (define make-mock-exists (io-ref 'make-mock-exists))
+   (define make-mock-read (io-ref 'make-mock-read-string))
+   (define exists-param (io-ref 'current-lint-file-exists?))
+   (define read-param (io-ref 'current-lint-file->string))
+   (define fs
+     (make-mock-fs (list (cons (path->string (build-path (current-directory) "info.rkt"))
+                               "(define version \"1.0.0\")"))))
+   (parameterize ([exists-param (make-mock-exists fs)]
+                  [read-param (make-mock-read fs)])
+     ;; The check-info-rkt function prints and returns; check return value
+     (define result (with-output-to-string (λ () (check-info-rkt "1.0.0"))))
+     (check-true (string-contains? result "OK"))))
+ (test-case "check-info-rkt with mock fs: mismatched version"
+   (define check-info-rkt (lv-ref 'check-info-rkt))
+   (define make-mock-fs (io-ref 'make-mock-fs))
+   (define make-mock-exists (io-ref 'make-mock-exists))
+   (define make-mock-read (io-ref 'make-mock-read-string))
+   (define exists-param (io-ref 'current-lint-file-exists?))
+   (define read-param (io-ref 'current-lint-file->string))
+   (define fs
+     (make-mock-fs (list (cons (path->string (build-path (current-directory) "info.rkt"))
+                               "(define version \"0.9.0\")"))))
+   (parameterize ([exists-param (make-mock-exists fs)]
+                  [read-param (make-mock-read fs)])
+     ;; Capture output to suppress printing
+     (define result (with-output-to-string (λ () (check-info-rkt "1.0.0"))))
+     (check-true (string-contains? result "ERROR")))))
+
+(run-tests lint-version-pure-tests)
+(run-tests lint-version-mock-io-tests)


### PR DESCRIPTION
## W6 — Port/I/O Abstraction Pilot for Version Tooling

### Goal
Abstract the I/O boundary in `lint-version.rkt` so file reading is injectable, enabling tests without real file system access.

### Changes

**New: `scripts/lint-version-io.rkt`** — I/O interface module
- 4 parameters: `current-lint-file-exists?`, `current-lint-file->string`, `current-lint-file->lines`, `current-lint-read-md-paths`
- Mock file system helpers: `make-mock-fs`, `make-mock-exists`, `make-mock-read-string`, `make-mock-read-lines`, `make-mock-md-paths`

**Refactored: `scripts/lint-version.rkt`**
- Extracted 3 pure check functions: `check-info-content`, `check-readme-content`, `check-changelog-content` (no I/O, testable directly)
- All I/O wrappers route through parameters (default: real file I/O)
- Guarded `(main)` in `(module+ main ...)` so the script can be `require`d from tests

**New: 22 tests across 2 files**
- `test-lint-version-io.rkt` (11 tests): parameter defaults, mock fs, parameterize
- `test-lint-version-pure.rkt` (11 tests): pure functions + mock I/O integration

### Verification
- `raco make main.rkt` — PASS
- `test-lint-version-io.rkt` — 11 tests PASS
- `test-lint-version-pure.rkt` — 11 tests PASS
- Smoke gate: 19/19 files, 286 tests PASS
- Script invocation: identical output to before refactoring

Closes #8419