### PR TITLE
W8: Session/TUI/settings boundary audit + cleanup (#8421)

### DIFF
--- a/docs/reports/SESSION-TUI-SETTINGS-AUDIT-v0.99.36.md
+++ b/docs/reports/SESSION-TUI-SETTINGS-AUDIT-v0.99.36.md
@@ -1,0 +1,196 @@
+# Session/TUI/Settings Representation Boundary Audit — v0.99.36 W8
+
+**Date:** 2026-06-22
+**Wave:** W8 (#8421)
+**Risk Assessment:** GREEN (reward 11, risk 4)
+**Modules audited:** `runtime/session/session-config.rkt`, `tui/state-types.rkt`,
+  `runtime/settings-core.rkt`, `runtime/settings-query.rkt`, `tui/input/state-types.rkt`,
+  `tui/state-events/helpers.rkt`
+
+---
+
+## 1. Session-Config Representation (runtime/session/session-config.rkt)
+
+**Lines:** ~310
+**Struct:** `session-config` wrapping immutable hash via `gen:dict`
+
+### Assessment: WELL-DESIGNED
+
+The `session-config` struct implements `gen:dict` with full iteration protocol
+support (`dict-iterate-first/next/key/value`), enabling transparent `dict-ref`
+and `for/hash` access from all consumers. This is the correct boundary pattern:
+
+- **Consumers use `dict-ref`** (not `hash-ref`) for typed, default-aware access.
+- **27 smart accessors** (`config-*`) provide typed defaults without leaking the
+  hash structure.
+- **`hash->session-config` normalizes** keys (validates known keys, coerces
+  `thinking-level` strings to symbols, logs warnings for unknown keys).
+- **`session-config->hash`** enables round-trip conversion for serialization.
+
+### Findings
+
+| Finding | Severity | Notes |
+|---|---|---|
+| 27 accessors all follow same `hash-ref` pattern | LOW | Repetitive but uniform — risk of typo is low |
+| `normalize-session-config-hash` warns but preserves unknown keys | LOW | Intentional — forward compat |
+| Profile activation matrix (`apply-context-assembly-profile!`) has 5 cases × 6 flags = 30 lines | LOW | Data-driven table would be cleaner but current form is clear |
+
+### Verdict: No changes needed. The gen:dict pattern is exemplary.
+
+---
+
+## 2. TUI State Types (tui/state-types.rkt)
+
+**Lines:** ~410
+**Structs:** `ui-state` (24 fields), `streaming-state` (8 fields), `transcript-entry` (5 fields),
+  `overlay-state` (8 fields), `selection-state` (2 fields), `cache-state` (2 fields),
+  `tree-browser-state` (4 fields), `branch-info` (5 fields), `goal-display-info` (4 fields)
+
+### Assessment: WELL-STRUCTURED with one documentation defect
+
+#### Finding 2.1: ui-state field comment mismatch (BUG)
+
+**Severity:** LOW (documentation only, no runtime impact)
+
+The `ui-state` struct has 24 fields. The last 4 fields before `active-goal` are:
+
+```racket
+         context-tokens             ; (or/c #f integer?) — ... (v0.19.12 W1)
+         cost-tracker               ; ← NO COMMENT
+         context-pressure-level     ; ← NO COMMENT
+         context-pressure-percent   ; (or/c #f cost-tracker?) — mutable cost accumulator (G8.4)
+```
+
+The comment `; (or/c #f cost-tracker?) — mutable cost accumulator (G8.4)` is attached
+to `context-pressure-percent`, but it belongs on `cost-tracker`. The fields
+`context-pressure-level` and `context-pressure-percent` have no documentation.
+
+**Fix:** Move the comment to `cost-tracker`, add proper comments for the
+two pressure fields.
+
+#### Finding 2.2: Explicit struct exports (GOOD pattern)
+
+`ui-state`, `streaming-state`, `transcript-entry`, `overlay-state`, `branch-info`
+use explicit field-by-field exports instead of `struct-out`. This preserves
+`struct-copy` transparency while avoiding accidental exposing of the constructor
+pattern. The `selection-state` and `cache-state` structs use `contract-out`
+because they are NOT used with `struct-copy` externally — correct distinction.
+
+#### Finding 2.3: Render cache embedded in state (ARCHITECTURE NOTE)
+
+The architecture note at the top correctly documents WHY render cache functions
+can't be extracted: `struct-copy ui-state` requires the struct definition at
+compile time. Any extraction would create a circular dependency. This is a known
+constraint, not a defect.
+
+### Verdict: Fix Finding 2.1 (comment mismatch).
+
+---
+
+## 3. Settings Representation (runtime/settings-core.rkt + settings-query.rkt)
+
+**Lines:** settings-core.rkt ~200, settings-query.rkt ~550
+**Struct:** `q-settings` (3 fields: global, project, merged)
+
+### Assessment: WELL-STRUCTURED with one duplication issue
+
+#### Finding 3.1: Boolean coercion duplication (12 instances)
+
+**Severity:** MEDIUM (maintainability — every new boolean setting repeats the pattern)
+
+12 settings query functions repeat the exact same boolean coercion:
+
+```racket
+(define (setting-X-enabled? settings)
+  (define raw (setting-ref* settings '(path) default))
+  (cond
+    [(boolean? raw) raw]
+    [(string? raw) (and (member (string-downcase raw) '("true" "1" "yes")) #t)]
+    [else default]))
+```
+
+The functions affected:
+`setting-memory-auto-extraction-enabled?`, `setting-memory-user-scope-enabled?`,
+`setting-memory-auto-reflection-enabled?`, `setting-reflection-prompt-enabled?`,
+`blackboard-enabled?`, `hot-swap-enabled?`, `auto-reload-enabled?`, `mcp-enabled?`,
+`mcp-server-enabled?`, `broker-enabled?`, `verifier-enabled?` (variant with #t default),
+`setting-memory-auto-extraction-enabled?` (variant).
+
+**Fix:** Extract a `coerce-config-boolean` helper and replace all 12 instances.
+
+#### Finding 3.2: q-settings struct design (GOOD)
+
+The `q-settings` struct with `(global project merged)` is clean:
+- `global` and `project` are `#:INTERNAL` — access via `merged` only.
+- `merged` is the deep-merged result.
+- `deep-merge-hash` handles nested hash merging correctly.
+- Settings cache memoizes by `(project-dir, home-dir)` + mtime check.
+
+#### Finding 3.3: settings-query.rkt is large but uniform
+
+~550 lines, 40+ query functions. Each function follows a consistent pattern:
+`(setting-ref* settings path default)` + optional coercion. The uniformity
+makes it easy to navigate, and the functions are individually small (5-10 lines).
+
+---
+
+## 4. TUI Input State (tui/input/state-types.rkt)
+
+**Lines:** ~260
+**Struct:** `input-state` (9 fields)
+
+### Assessment: WELL-STRUCTURED
+
+Clean separation: pure data definitions (structs) separated from logic
+(editing-ops, history-ops). The `input-state` struct uses `#:transparent`
+and explicit field exports. Mouse event parsing, IME cursor markers, and
+horizontal scroll are well-documented with protocol references.
+
+### Verdict: No changes needed.
+
+---
+
+## 5. TUI State Event Helpers (tui/state-events/helpers.rkt)
+
+**Lines:** ~100
+**Functions:** 6 pure helpers
+
+### Assessment: WELL-STRUCTURED
+
+Extracted helpers are pure functions: `classify-error-type`, `format-error-hint`,
+`append-entry`, `recent-tool-start?`/`recent-tool-end?`. Clean separation of
+concerns.
+
+### Verdict: No changes needed.
+
+---
+
+## 6. Summary of Changes
+
+| Change | Module | Risk | Effort |
+|---|---|---|---|
+| Extract `coerce-config-boolean` helper | settings-query.rkt | LOW (identical behavior) | SMALL |
+| Fix ui-state field comment mismatch | state-types.rkt | ZERO (docs only) | TRIVIAL |
+
+Both changes are narrow, low-risk, and improve maintainability without
+altering runtime behavior.
+
+---
+
+## 7. Patterns Observed
+
+### GOOD patterns (retain)
+1. **gen:dict wrapping** (session-config): Provides transparent dict protocol
+   while hiding the hash structure.
+2. **Explicit struct exports** (tui/state-types): Field-by-field exports instead
+   of struct-out for structs used with struct-copy.
+3. **Settings query pattern** (settings-query): Each setting is a single
+   function with `setting-ref*` + default + optional coercion.
+4. **Layered settings** (settings-core): global → project → merged with
+   deep-merge and mtime-based caching.
+5. **Forward declarations** (state-types): `styled-line?` and `q-component?`
+   declared as compatible predicates to break circular dependencies.
+
+### Issues found (fixed)
+1. **Boolean coercion duplication** → extracted to `coerce-config-boolean`.
+2. **Field comment mismatch** → corrected.

--- a/runtime/settings-query.rkt
+++ b/runtime/settings-query.rkt
@@ -104,6 +104,19 @@
   (hash-keys providers-hash))
 
 ;; ============================================================
+;; Boolean coercion helper (v0.99.36 W8: extracted from 12 duplicated instances)
+;; ============================================================
+
+;; Coerce a raw config value to boolean.
+;; Accepts: #t/#f, or strings "true"/"1"/"yes" (case-insensitive).
+;; Returns the default for any other value.
+(define (coerce-config-boolean raw [default #f])
+  (cond
+    [(boolean? raw) raw]
+    [(string? raw) (and (member (string-downcase raw) '("true" "1" "yes")) #t)]
+    [else default]))
+
+;; ============================================================
 ;; Parallel execution setting
 ;; ============================================================
 
@@ -268,11 +281,7 @@
 ;; Reads (memory auto-extraction enabled) from config.
 ;; Default: #f (disabled).
 (define (setting-memory-auto-extraction-enabled? settings)
-  (define raw (setting-ref* settings '(memory auto-extraction enabled) #f))
-  (cond
-    [(boolean? raw) raw]
-    [(string? raw) (and (member (string-downcase raw) '("true" "1" "yes")) #t)]
-    [else #f]))
+  (coerce-config-boolean (setting-ref* settings '(memory auto-extraction enabled) #f)))
 
 ;; v0.95.16 W1: Auto-extraction min-confidence from settings
 ;; Reads (memory auto-extraction min-confidence) from config.
@@ -290,21 +299,13 @@
 ;; Reads (memory user-scope enabled) from config.
 ;; Default: #f (disabled).
 (define (setting-memory-user-scope-enabled? settings)
-  (define raw (setting-ref* settings '(memory user-scope enabled) #f))
-  (cond
-    [(boolean? raw) raw]
-    [(string? raw) (and (member (string-downcase raw) '("true" "1" "yes")) #t)]
-    [else #f]))
+  (coerce-config-boolean (setting-ref* settings '(memory user-scope enabled) #f)))
 
 ;; v0.95.21 W2: Auto-reflection enabled from settings
 ;; Reads (memory auto-reflection enabled) from config.
 ;; Default: #f (disabled).
 (define (setting-memory-auto-reflection-enabled? settings)
-  (define raw (setting-ref* settings '(memory auto-reflection enabled) #f))
-  (cond
-    [(boolean? raw) raw]
-    [(string? raw) (and (member (string-downcase raw) '("true" "1" "yes")) #t)]
-    [else #f]))
+  (coerce-config-boolean (setting-ref* settings '(memory auto-reflection enabled) #f)))
 
 ;; v0.95.21 W2: Auto-reflection min-items from settings
 ;; Reads (memory auto-reflection min-items) from config.
@@ -322,22 +323,16 @@
 ;; Reads (reflection-prompt-enabled) from config.
 ;; Default: #f (disabled).
 (define (setting-reflection-prompt-enabled? settings)
-  (define raw (setting-ref* settings '(reflection-prompt-enabled) #f))
-  (cond
-    [(boolean? raw) raw]
-    [(string? raw) (and (member (string-downcase raw) '("true" "1" "yes")) #t)]
-    [else #f]))
+  (coerce-config-boolean (setting-ref* settings '(reflection-prompt-enabled) #f)))
 
 ;; v0.96.14: Auto-distillation enabled from settings (overrides profile default)
 ;; Reads (auto-distillation-enabled) from config.
 ;; When not set, falls back to the context-assembly profile.
 (define (setting-auto-distillation-enabled? settings)
   (define raw (setting-ref* settings '(auto-distillation-enabled) 'unset))
-  (cond
-    [(eq? raw 'unset) 'unset] ; caller uses profile default
-    [(boolean? raw) raw]
-    [(string? raw) (and (member (string-downcase raw) '("true" "1" "yes")) #t)]
-    [else 'unset]))
+  (if (eq? raw 'unset)
+      'unset
+      (coerce-config-boolean raw 'unset)))
 
 ;; ============================================================
 ;; Credential policy (v0.70.1)
@@ -404,11 +399,7 @@
 ;; a verifier provider configured; non-GSD sessions are unaffected.
 ;; Safe fallback chain: no provider → auto-approve, error → escalate, timeout → escalate.
 (define (verifier-enabled? settings)
-  (define raw (setting-ref* settings '(mas verifier enabled) #t))
-  (cond
-    [(boolean? raw) raw]
-    [(string? raw) (and (member (string-downcase raw) '("true" "1" "yes")) #t)]
-    [else #t]))
+  (coerce-config-boolean (setting-ref* settings '(mas verifier enabled) #t) #t))
 
 ;; Config key: mas.verifier.model (default #f = use session model)
 ;; When set, verification uses a specific model instead of the session default.
@@ -455,21 +446,13 @@
 ;; context injection is enabled, and crash recovery runs from trace.jsonl.
 ;; v0.99.14: Flipped default from #f to #t (MAS Phase 1: Blackboard Default-On).
 (define (blackboard-enabled? settings)
-  (define raw (setting-ref* settings '(mas blackboard enabled) #t))
-  (cond
-    [(boolean? raw) raw]
-    [(string? raw) (and (member (string-downcase raw) '("true" "1" "yes")) #t)]
-    [else #f]))
+  (coerce-config-boolean (setting-ref* settings '(mas blackboard enabled) #t)))
 
 ;; Check whether hot-swap (registry-based dispatch) is enabled.
 ;; Config path: mas.hot-swap.enabled
 ;; Default: #t (Phase 4 activation — enabled by default since v0.99.18)
 (define (hot-swap-enabled? settings)
-  (define raw (setting-ref* settings '(mas hot-swap enabled) #t))
-  (cond
-    [(boolean? raw) raw]
-    [(string? raw) (and (member (string-downcase raw) '("true" "1" "yes")) #t)]
-    [else #t]))
+  (coerce-config-boolean (setting-ref* settings '(mas hot-swap enabled) #t) #t))
 
 ;; v0.99.20 W3 (§3.4): Check whether auto-reload (filesystem watcher) is enabled.
 ;; Config path: mas.hot-swap.auto-reload.enabled
@@ -477,11 +460,7 @@
 ;; When #t, the registry watcher monitors agent/roles/ for file changes
 ;; and automatically registers new agent versions for hot-swap.
 (define (auto-reload-enabled? settings)
-  (define raw (setting-ref* settings '(mas hot-swap auto-reload enabled) #f))
-  (cond
-    [(boolean? raw) raw]
-    [(string? raw) (and (member (string-downcase raw) '("true" "1" "yes")) #t)]
-    [else #f]))
+  (coerce-config-boolean (setting-ref* settings '(mas hot-swap auto-reload enabled) #f)))
 
 ;; ============================================================
 ;; MCP Settings (v0.99.10 MAS Schritt 6)
@@ -490,20 +469,12 @@
 ;; Config key: mas.mcp.enabled (default #f — MCP feature gate)
 ;; Master switch for all MCP functionality.
 (define (mcp-enabled? settings)
-  (define raw (setting-ref* settings '(mas mcp enabled) #f))
-  (cond
-    [(boolean? raw) raw]
-    [(string? raw) (and (member (string-downcase raw) '("true" "1" "yes")) #t)]
-    [else #f]))
+  (coerce-config-boolean (setting-ref* settings '(mas mcp enabled) #f)))
 
 ;; Config key: mas.mcp.server.enabled (default #f)
 ;; When #t, q runs as an MCP server over stdio.
 (define (mcp-server-enabled? settings)
-  (define raw (setting-ref* settings '(mas mcp server enabled) #f))
-  (cond
-    [(boolean? raw) raw]
-    [(string? raw) (and (member (string-downcase raw) '("true" "1" "yes")) #t)]
-    [else #f]))
+  (coerce-config-boolean (setting-ref* settings '(mas mcp server enabled) #f)))
 
 ;; Config key: mas.mcp.server.transport (default "stdio")
 ;; Phase 1 only supports local stdio. All other values fall back to stdio.
@@ -530,11 +501,7 @@
 ;; When #t, high-risk tool execution can be routed to remote executor nodes
 ;; via mTLS TCP broker.
 (define (broker-enabled? settings)
-  (define raw (setting-ref* settings '(mas broker enabled) #f))
-  (cond
-    [(boolean? raw) raw]
-    [(string? raw) (and (member (string-downcase raw) '("true" "1" "yes")) #t)]
-    [else #f]))
+  (coerce-config-boolean (setting-ref* settings '(mas broker enabled) #f)))
 
 ;; Config key: mas.broker.remote-host (default "localhost")
 ;; Hostname of the remote executor node.

--- a/tui/state-types.rkt
+++ b/tui/state-types.rkt
@@ -222,7 +222,8 @@
 ;;   Input:       focused-component, editor-component
 ;;   Session:     session-id, model-name, mode, mock-provider?
 ;;   Queue:       queue-counts
-;;   Budget:      context-tokens, cost-tracker
+;;   Budget:      context-tokens, cost-tracker, context-pressure-level,
+;;                context-pressure-percent
 ;;
 ;; --- Transcript group ---
 (struct ui-state
@@ -258,9 +259,9 @@
          editor-component ; (or/c #f q-component?) — custom editor for input area (#1150)
          ;; --- Budget group ---
          context-tokens ; (or/c #f integer?) — estimated token count from context events (v0.19.12 W1)
-         cost-tracker
-         context-pressure-level
-         context-pressure-percent ; (or/c #f cost-tracker?) — mutable cost accumulator (G8.4)
+         cost-tracker ; cost-tracker? — mutable cost accumulator (G8.4)
+         context-pressure-level ; (or/c #f symbol?) — context pressure level ('low 'medium 'high 'critical)
+         context-pressure-percent ; (or/c #f real?) — context pressure percentage (0–100)
          ;; --- Goal group ---
          active-goal) ; (or/c goal-display-info? #f) — active autonomous goal display info
   #:transparent)


### PR DESCRIPTION
## W8 — Session/TUI/Settings Representation Boundary Audit + Narrow Cleanup

**GREEN (reward 11, risk 4)**

### Audit
Comprehensive representation boundary audit of:
- `runtime/session/session-config.rkt` — gen:dict wrapping pattern (exemplary)
- `tui/state-types.rkt` — ui-state (24 fields), streaming-state, etc.
- `runtime/settings-core.rkt` + `settings-query.rkt` — q-settings + 40+ query functions
- `tui/input/state-types.rkt` — input-state (9 fields)
- `tui/state-events/helpers.rkt` — 6 pure helpers

### Changes (2 narrow cleanup items)

**1. Extract `coerce-config-boolean` helper (settings-query.rkt)**
Replaces 12 instances of identical boolean coercion boilerplate:
```racket
;; Before (×12):
(cond
  [(boolean? raw) raw]
  [(string? raw) (and (member (string-downcase raw) '("true" "1" "yes")) #t)]
  [else default])
;; After:
(coerce-config-boolean raw default)
```
Zero behavioral change — same logic, extracted to a single reusable function.

**2. Fix ui-state field comment mismatch (state-types.rkt)**
The comment `(or/c #f cost-tracker?) — mutable cost accumulator (G8.4)` was misattached to `context-pressure-percent` instead of `cost-tracker`. The fields `cost-tracker`, `context-pressure-level`, and `context-pressure-percent` now all have correct documentation.

### Verification
- All 171 existing tests pass (test-settings, test-state-types, test-session-config, test-settings-flow)
- Smoke gate: 220/220 tests pass
- `raco make main.rkt` passes

Closes #8421