### PR TITLE
W2: Benchmark gate policy - decouple timing from correctness (#8442)

### DIFF
--- a/docs/reports/BENCHMARK-GATE-POLICY-v0.99.37.md
+++ b/docs/reports/BENCHMARK-GATE-POLICY-v0.99.37.md
@@ -1,0 +1,87 @@
+# Benchmark Gate Policy — v0.99.37
+
+**Date:** 2026-06-22
+**Wave:** W2 (#8442) — P0 Priority
+
+---
+
+## Problem
+
+Three strict wall-clock timing assertions in `tests/test-bench-streaming-render.rkt`
+caused false release blockers under scheduler noise (the #8435 pattern):
+
+| Line | Assertion | Risk |
+|------|-----------|------|
+| 101 | `(check-true (<= batch-time (+ (* 2 percell-time) 100)))` | Fails when per-cell rendering is faster than batched under CPU contention |
+| 127 | `(check-true (< per-frame 5.0))` | Fails on slow CI machines (4 vCPU) when scheduling delays push render time past 5ms |
+| 146 | `(check-true (< diff-time 100.0))` | Fails on slow machines when 10K cell diff takes >100ms under load |
+
+These assertions conflate **performance characteristics** with **correctness**, 
+making the broad test gate fragile and non-deterministic.
+
+---
+
+## Policy
+
+### Principle: Correctness gates test OUTPUT, not TIME
+
+Benchmark tests running inside the broad correctness suite must:
+1. **Assert output correctness** — the operation produces valid, non-empty results.
+2. **Report timing as advisory** — wall-clock measurements are printed for 
+   human inspection but never cause test failure.
+3. **Separate strict performance gates** — micro-benchmark thresholds belong in
+   a dedicated benchmark runner (`benchmarks/`), not the correctness suite.
+
+### Applied Pattern
+
+```racket
+;; BEFORE (fragile — fails under scheduler noise):
+(define elapsed (measure ...))
+(check-true (< elapsed 100.0) "should be fast")
+
+;; AFTER (robust — tests correctness, reports timing):
+(define elapsed (measure ...))
+(printf "Advisory: elapsed=~a ms~n" (real->decimal-string elapsed 2))
+(define result (compute ...))
+(check-true (valid? result) "should produce valid output")
+```
+
+---
+
+## Changes Applied
+
+### tests/test-bench-streaming-render.rkt
+
+**Benchmark 1** (batch vs per-cell rendering):
+- Removed: `(check-true (<= batch-time (+ (* 2 percell-time) 100)))`
+- Added: Advisory `printf` with ratio. Existing output-correctness checks retained.
+
+**Benchmark 2** (VDOM pipeline overhead):
+- Removed: `(check-true (< per-frame 5.0))`
+- Added: Advisory `printf` with per-frame timing. Buffer-population check added.
+
+**Benchmark 3** (cell-diff throughput):
+- Removed: `(check-true (< diff-time 100.0))`
+- Added: Advisory `printf` with diff timing. Delta-production check added.
+
+### tests/test-benchmarks.rkt
+
+No timing assertions found — already compliant.
+
+---
+
+## Verification
+
+```
+$ raco test tests/test-bench-streaming-render.rkt
+Batched: 1634.82 ms, Per-cell: 2421.02 ms
+Speedup: 32.5%
+Advisory: batch=1634.82 ms, per-cell=2421.02 ms, ratio=0.68
+VDOM pipeline: 95.42 ms total, 1.91 ms/frame
+Advisory: per-frame=1.91 ms
+Cell-diff 10K cells: 4.74 ms
+Advisory: diff-time=4.74 ms for 10K cells
+3 tests passed
+```
+
+All tests pass deterministically. Timing data is still visible for human inspection.

--- a/tests/test-bench-streaming-render.rkt
+++ b/tests/test-bench-streaming-render.rkt
@@ -96,10 +96,13 @@
   (when (> percell-time 0)
     (define speedup (* 100.0 (/ (- percell-time batch-time) percell-time)))
     (printf "Speedup: ~a%~n" (real->decimal-string speedup 1))
-    ;; Guard only against catastrophic regression; strict performance claims
-    ;; belong in a dedicated benchmark runner, not the broad correctness gate.
-    (check-true (<= batch-time (+ (* 2 percell-time) 100))
-                "batched renderer should not be catastrophically slower")))
+    ;; Advisory timing only — wall-clock comparisons are not correctness gates.
+    ;; Both render paths must produce output (checked above); performance
+    ;; regressions belong in a dedicated benchmark runner.
+    (printf "Advisory: batch=~a ms, per-cell=~a ms, ratio=~a~n"
+            (real->decimal-string batch-time 2)
+            (real->decimal-string percell-time 2)
+            (real->decimal-string (/ batch-time percell-time) 2))))
 
 ;; ============================================================
 ;; Benchmark 2: VDOM pipeline overhead
@@ -123,8 +126,11 @@
 
   (define per-frame (/ vdom-time 50.0))
   (printf "VDOM pipeline: ~a ms total, ~a ms/frame~n" vdom-time (real->decimal-string per-frame 2))
-  ;; Should be < 5ms per frame
-  (check-true (< per-frame 5.0) "vdom overhead should be < 5ms/frame"))
+  ;; Correctness gate: VDOM pipeline must produce a populated buffer.
+  ;; Timing is advisory only — wall-clock thresholds are not correctness gates
+  ;; and cause false failures under scheduler noise (#8435 pattern).
+  (printf "Advisory: per-frame=~a ms~n" (real->decimal-string per-frame 2))
+  (check-true (> (cell-buffer-rows buf) 0) "vdom pipeline should produce a buffer"))
 
 ;; ============================================================
 ;; Benchmark 3: Cell-diff throughput
@@ -143,4 +149,8 @@
       (- (current-inexact-milliseconds) start)))
 
   (printf "Cell-diff 10K cells: ~a ms~n" diff-time)
-  (check-true (< diff-time 100.0) "10K cell diff should complete in < 100ms"))
+  ;; Correctness gate: diff must produce deltas for all changed cells.
+  ;; Timing is advisory only — wall-clock thresholds are not correctness gates.
+  (printf "Advisory: diff-time=~a ms for 10K cells~n" (real->decimal-string diff-time 2))
+  (define deltas (diff-cell-buffers a b))
+  (check-true (> (length deltas) 0) "10K cell diff should produce deltas"))


### PR DESCRIPTION
## W2 - Benchmark/Performance Semantics Boundary Hardening (P0)

Converts 3 strict wall-clock timing assertions to correctness checks.

Closes #8442