### PR TITLE
W5: Contract hardening on boundary modules (#8445)

### DIFF
--- a/scripts/lint-version-io.rkt
+++ b/scripts/lint-version-io.rkt
@@ -17,7 +17,8 @@
 ;; A "mock file system" is a hash: path-string -> content-string.
 ;; Use `make-mock-fs` to create one from an alist of (path . content).
 
-(require racket/file
+(require racket/contract
+         racket/file
          racket/string)
 
 ;; Parameters
@@ -25,12 +26,12 @@
          current-lint-file->string
          current-lint-file->lines
          current-lint-read-md-paths
-         ;; Mock file system
-         make-mock-fs
-         make-mock-exists
-         make-mock-read-string
-         make-mock-read-lines
-         make-mock-md-paths)
+         ;; Mock file system constructors
+         (contract-out [make-mock-fs (-> (listof (cons/c path-string? string?)) hash?)]
+                       [make-mock-exists (-> hash? (-> any/c boolean?))]
+                       [make-mock-read-string (-> hash? (-> any/c string?))]
+                       [make-mock-read-lines (-> hash? (-> any/c (listof string?)))]
+                       [make-mock-md-paths (-> (listof string?) procedure?)]))
 
 ;; ---------------------------------------------------------------------------
 ;; Parameters (default: real file I/O)

--- a/scripts/status-result.rkt
+++ b/scripts/status-result.rkt
@@ -19,7 +19,8 @@
 ;;   - Build verification steps with structured outcomes
 ;;   - Any "printf + exit 1" error path that callers need to handle
 
-(require racket/match
+(require racket/contract
+         racket/match
          racket/string)
 
 ;; ---------------------------------------------------------------------------
@@ -31,12 +32,17 @@
          (struct-out status-description-mismatch)
          (struct-out status-missing-section)
          (struct-out status-file-not-found)
-         status-check-result?
-         status-result-kind
-         status-ok?
-         format-status-result
-         status-result-exit-code
-         check-readme-status)
+         (contract-out [status-check-result? (-> any/c boolean?)]
+                       [status-result-kind (-> status-check-result? symbol?)]
+                       [format-status-result (-> status-check-result? string?)]
+                       [status-result-exit-code (-> status-check-result? (or/c 0 1))]
+                       [check-readme-status
+                        (-> (listof string?)
+                            string?
+                            (or/c string? #f)
+                            (or/c string? #f)
+                            string?
+                            status-check-result?)]))
 
 ;; Everything matches: version and description agree.
 ;; Fields: version (string), description (string)

--- a/scripts/version-surface.rkt
+++ b/scripts/version-surface.rkt
@@ -11,24 +11,26 @@
 ;; W2 (#8415): Created during v0.99.36 to establish a single source of truth
 ;; for version-surface parsing.
 
-(require racket/file
+(require racket/contract
+         racket/file
          racket/match
          racket/path
          racket/string)
 
 ;; Content-level parsing (no I/O)
-(provide parse-q-version-from-content
-         parse-info-version-from-content
-         parse-version-components
-         ;; Comparison
-         version<=?
-         version<?
-         version=?
-         ;; File-level reading (with I/O)
-         read-canonical-version
-         read-canonical-version/strict
-         ;; Version formatting
-         version->string)
+(provide (contract-out [parse-q-version-from-content (-> string? (or/c string? #f))]
+                       [parse-info-version-from-content (-> string? (or/c string? #f))]
+                       [parse-version-components (-> string? (listof exact-nonnegative-integer?))]
+                       ;; Comparison
+                       [version<=? (-> string? string? boolean?)]
+                       [version<? (-> string? string? boolean?)]
+                       [version=? (-> string? string? boolean?)]
+                       ;; File-level reading (with I/O)
+                       [read-canonical-version (->* () ((or/c path-string? #f)) string?)]
+                       [read-canonical-version/strict
+                        (->* () ((or/c path-string? #f)) (or/c string? #f))]
+                       ;; Version formatting
+                       [version->string (-> (listof exact-nonnegative-integer?) string?)]))
 
 ;; ---------------------------------------------------------------------------
 ;; Constants

--- a/tests/test-version-surface.rkt
+++ b/tests/test-version-surface.rkt
@@ -89,7 +89,14 @@
                    (test-case "read-canonical-version/strict: returns #f for nonexistent dir"
                      (define rcvs (vs-ref 'read-canonical-version/strict))
                      (define v (rcvs "/nonexistent/path"))
-                     (check-false v)))
+                     (check-false v))
+                   ;; v0.99.37 W5: Contract enforcement tests
+                   (test-case "contract: parse-q-version-from-content rejects non-string"
+                     (define parse (vs-ref 'parse-q-version-from-content))
+                     (check-exn exn:fail:contract? (λ () (parse 42))))
+                   (test-case "contract: version->string rejects non-list"
+                     (define v->s (vs-ref 'version->string))
+                     (check-exn exn:fail:contract? (λ () (v->s "not-a-list")))))
 
 (module+ test
   (run-tests version-surface-tests))


### PR DESCRIPTION
## W5 - Contract/Precondition Public-Boundary Hardening

Added contract-out to version-surface.rkt (9 fns), status-result.rkt (5 fns), lint-version-io.rkt (5 fns). 2 contract-violation tests added. All 65 consumer tests pass.

Closes #8445