### PR TITLE
W6: Port/effect-shell II for audit writer path (#8446)

### DIFF
--- a/docs/reports/PORT-EFFECT-SHELL-v0.99.37.md
+++ b/docs/reports/PORT-EFFECT-SHELL-v0.99.37.md
@@ -1,0 +1,48 @@
+# Port/Effect-Shell II for Audit Writer Path — v0.99.37
+
+## W6 (#8446): Port abstraction for abstraction-audit.rkt
+
+### Problem
+
+`scripts/abstraction-audit.rkt` mixes I/O with analysis. The `audit-module`
+function calls `file->lines` directly, making it impossible to test analysis
+logic without creating temporary files on disk. The existing tests in
+`test-abstraction-audit.rkt` create real fixture directories for every test
+case — slow and fragile.
+
+### Pattern Applied
+
+Following the `lint-version-io.rkt` pattern (v0.99.36 W6), we apply the
+port/effect-shell pattern to the audit scanner:
+
+1. **Pure core extraction**: `audit-content` takes `(path text)` and returns
+   a finding hash. No I/O, no side effects. All existing analysis functions
+   (count-exports, count-io-effects, etc.) are already pure — they operate
+   on text strings.
+
+2. **I/O parameter injection**: A `current-audit-file->lines` parameter
+   wraps `file->lines`. Default is real file I/O; tests substitute mock
+   readers.
+
+3. **Thin shell**: `audit-module` becomes a thin I/O wrapper that reads
+   the file via the parameter and delegates to `audit-content`.
+
+### Benefits
+
+- **Testability**: Analysis logic tested without filesystem I/O
+- **Speed**: Pure tests are instant vs. temp-directory setup/teardown
+- **Isolation**: I/O failures don't cascade into analysis logic
+- **Consistency**: Same pattern as lint-version-io.rkt (v0.99.36)
+
+### API Surface
+
+```racket
+;; Pure: analyze text content (no I/O)
+(audit-content path text) → (or/c module-finding? #f)
+
+;; Parameterized I/O (default: file->lines)
+(current-audit-file->lines) → parameter
+
+;; Thin shell: read file via parameter, delegate to pure core
+(audit-module path) → (or/c module-finding? #f)
+```

--- a/scripts/abstraction-audit.rkt
+++ b/scripts/abstraction-audit.rkt
@@ -55,7 +55,15 @@
          count-mutable-caches
          count-bench-timing
          count-ad-hoc-parsing
-         count-event-handlers)
+         count-event-handlers
+         audit-content
+         current-audit-file->lines)
+
+;; ============================================================
+;; I/O parameter (W6 v0.99.37)
+;; ============================================================
+
+(define current-audit-file->lines (make-parameter file->lines))
 
 ;; ============================================================
 ;; Core data structures
@@ -77,64 +85,71 @@
 
 (define (audit-module path)
   "Analyze a single .rkt file and return a module-finding hash.
-   Returns #f if the file cannot be read."
+   Returns #f if the file cannot be read.
+   Uses current-audit-file->lines parameter for I/O (W6 v0.99.37)."
+  (define reader (current-audit-file->lines))
   (define lines
     (with-handlers ([exn:fail:filesystem? (lambda (_) #f)])
-      (file->lines path)))
+      (reader path)))
   (if (not lines)
       #f
-      (let* ([text (string-join lines "\n")]
-             [line-count (length lines)]
-             [export-count (count-exports text)]
-             [parameter-count (count-matches text parameter-rx)]
-             [macro-count (count-matches text macro-rx)]
-             [struct-out-count (count-struct-outs text)]
-             [has-struct-out? (> struct-out-count 0)]
-             [io-count (count-io-effects text)]
-             [io? (> io-count 0)]
-             [serialization-count (count-matches text serialization-rx)]
-             [handler-count (count-matches text handler-rx)]
-             [error-count (count-matches text error-rx)]
-             [provide-shapes (detect-provide-shapes text)]
-             [require-count (count-requires text)])
-        (hash 'path
-              (if (path? path)
-                  (path->string path)
-                  path)
-              'line-count
-              line-count
-              'export-count
-              export-count
-              'parameter-count
-              parameter-count
-              'macro-count
-              macro-count
-              'struct-out-count
-              struct-out-count
-              'has-struct-out?
-              has-struct-out?
-              'io-count
-              io-count
-              'io-mixed-with-logic?
-              io?
-              'serialization-count
-              serialization-count
-              'handler-count
-              handler-count
-              'error-count
-              error-count
-              'provide-shapes
-              provide-shapes
-              'require-count
-              require-count
-              'mutable-cache-count
-              (count-mutable-caches text)
-              'bench-timing-count
-              (count-bench-timing text)
-              'ad-hoc-parse-count
-              (count-ad-hoc-parsing text)
-              'event-handler-count
-              (count-event-handlers text)))))
+      (audit-content path (string-join lines "\n"))))
+
+(define (audit-content path text)
+  "Analyze module text content and return a module-finding hash.
+   Pure function: no I/O. W6 v0.99.37."
+  (let* ([lines (string-split text "\n")]
+         [line-count (length lines)]
+         [export-count (count-exports text)]
+         [parameter-count (count-matches text parameter-rx)]
+         [macro-count (count-matches text macro-rx)]
+         [struct-out-count (count-struct-outs text)]
+         [has-struct-out? (> struct-out-count 0)]
+         [io-count (count-io-effects text)]
+         [io? (> io-count 0)]
+         [serialization-count (count-matches text serialization-rx)]
+         [handler-count (count-matches text handler-rx)]
+         [error-count (count-matches text error-rx)]
+         [provide-shapes (detect-provide-shapes text)]
+         [require-count (count-requires text)])
+    (hash 'path
+          (if (path? path)
+              (path->string path)
+              path)
+          'line-count
+          line-count
+          'export-count
+          export-count
+          'parameter-count
+          parameter-count
+          'macro-count
+          macro-count
+          'struct-out-count
+          struct-out-count
+          'has-struct-out?
+          has-struct-out?
+          'io-count
+          io-count
+          'io-mixed-with-logic?
+          io?
+          'serialization-count
+          serialization-count
+          'handler-count
+          handler-count
+          'error-count
+          error-count
+          'provide-shapes
+          provide-shapes
+          'require-count
+          require-count
+          'mutable-cache-count
+          (count-mutable-caches text)
+          'bench-timing-count
+          (count-bench-timing text)
+          'ad-hoc-parse-count
+          (count-ad-hoc-parsing text)
+          'event-handler-count
+          (count-event-handlers text))))
 
 ;; Count exported identifiers in (provide ...) forms.
 ;; Handles: provide id, provide (contract-out ...), provide (struct-out ...)

--- a/tests/test-abstraction-audit.rkt
+++ b/tests/test-abstraction-audit.rkt
@@ -417,6 +417,53 @@ EOF
    (cleanup-fixture-tree tmpdir)))
 
 ;; ============================================================
+;; W6 v0.99.37: Pure audit-content tests (no filesystem I/O)
+;; ============================================================
+
+(define-test-suite
+ pure-audit-content-tests
+ (test-case "audit-content analyzes text without I/O"
+   (define text
+     "#lang racket/base\n(provide greet)\n(define (greet name)\n  (string-append \"Hello, \" name \"!\"))")
+   (define finding ((audit-ref 'audit-content) "test.rkt" text))
+   (check-true (hash? finding) "returns a hash")
+   (check-equal? (hash-ref finding 'path) "test.rkt" "path preserved")
+   (check-true (> (hash-ref finding 'line-count) 0) "positive line count"))
+ (test-case "audit-content detects struct-out without I/O"
+   (define text "#lang racket/base\n(provide (struct-out widget))\n(struct widget (name))")
+   (define finding ((audit-ref 'audit-content) "w.rkt" text))
+   (check-true (hash-ref finding 'has-struct-out?) "detects struct-out")
+   (check-pred positive? (hash-ref finding 'struct-out-count) "struct-out count > 0"))
+ (test-case "audit-content detects I/O mixed with logic"
+   (define text
+     "#lang racket/base\n(define (f x)\n  (call-with-output-file \"a\" (lambda (o) (display x o))))")
+   (define finding ((audit-ref 'audit-content) "io.rkt" text))
+   (check-true (hash-ref finding 'io-mixed-with-logic?) "detects I/O mixed with logic")
+   (check-pred positive? (hash-ref finding 'io-count) "io count > 0"))
+ (test-case "audit-content detects mutable-cache without I/O"
+   (define text
+     "#lang racket/base\n(define cache (make-hash))\n(define (handle-event e)\n  (hash-set! cache 'last e))")
+   (define finding ((audit-ref 'audit-content) "cache.rkt" text))
+   (check-pred positive? (hash-ref finding 'mutable-cache-count) "mutable cache count > 0")
+   (check-pred positive? (hash-ref finding 'event-handler-count) "event handler count > 0"))
+ (test-case "audit-content on empty text returns hash with 0 lines"
+   (define finding ((audit-ref 'audit-content) "empty.rkt" ""))
+   (check-true (hash? finding) "returns hash for empty text")
+   (check-equal? (hash-ref finding 'line-count) 0 "empty string splits to 0 lines"))
+ (test-case "audit-content: path string preserved as-is"
+   (define finding ((audit-ref 'audit-content) "foo/bar.rkt" "(define x 1)"))
+   (check-equal? (hash-ref finding 'path) "foo/bar.rkt"))
+ (test-case "audit-module with mocked I/O parameter"
+   (define mock-text "#lang racket/base\n(provide f)\n(define (f x) x)")
+   (define mock-reader (lambda (path) (string-split mock-text "\n")))
+   ;; Use eval to parameterize since audit-ref uses dynamic-require
+   (define orig-param (audit-ref 'current-audit-file->lines))
+   (parameterize ([orig-param mock-reader])
+     (define finding ((audit-ref 'audit-module) "mock.rkt"))
+     (check-true (hash? finding) "mocked audit-module returns hash")
+     (check-true (> (hash-ref finding 'line-count) 0) "mocked module has positive lines"))))
+
+;; ============================================================
 ;; Run all tests
 ;; ============================================================
 
@@ -428,7 +475,8 @@ EOF
                    no-mutation-tests
                    count-exports-tests
                    red-flag-signal-tests
-                   v3-signal-tests)
+                   v3-signal-tests
+                   pure-audit-content-tests)
 
 (module+ test
   (run-tests all-abstraction-audit-tests))


### PR DESCRIPTION
## W6 - Port/Effect-Shell II for Audit Writer Path

Applied port abstraction to abstraction-audit.rkt: extracted pure `audit-content` function, added `current-audit-file->lines` parameter, refactored `audit-module` as thin shell. 7 new pure-function tests. All 39 tests pass.

Closes #8446