### PR TITLE
W8: Scanner v4 change-locality signals (#8482)

### DIFF
--- a/docs/reports/SCANNER-V4-CHANGE-LOCALITY-v0.99.38.md
+++ b/docs/reports/SCANNER-V4-CHANGE-LOCALITY-v0.99.38.md
@@ -1,0 +1,111 @@
+# Abstraction Scanner v4 — Change-Locality Signals — v0.99.38 W8
+
+**Date:** 2026-06-23
+**Issue:** #8482
+**Base:** `main@34c57b2d`
+
+## Purpose
+
+Extend the v0.99.37 abstraction fitness scanner with 4 new change-locality
+signal categories that catch concrete failure classes identified in W0–W7.
+
+## What Was Done
+
+### New Scanner Signals
+
+Extended `scripts/abstraction-audit.rkt` with 4 new pure counting functions:
+
+| Signal | Regex | What it catches | Source |
+|--------|-------|-----------------|--------|
+| `count-cwd-sensitive-paths` | `dynamic-require\|"[^/]\|file->string\|"[^/]` | CWD-dependent file loading with relative-path string literals | W2 audit |
+| `count-mutation-sites` | `call-with-output-file\|write-to-file\|display-to-file\|...` | File-writing mutation operations | W5 mutation boundary |
+| `count-hash-ref-chains` | `hash-ref\s+\(hash-ref` | Nested hash-ref chains (API pain point P5) | W1 scorecard |
+| `count-inline-config-paths` | `build-path\s+\(find-system-path\s+'home-dir` | Inline config dir instead of shared helper | W6 adapter audit |
+
+All signals are **advisory only** — they appear in the report but do not
+fail the build unless `--strict` mode adds thresholds for them (not done
+in this wave).
+
+### Scanner Architecture Changes
+
+1. **4 new exported functions** added to `provide` block
+2. **4 new regex patterns** (`cwd-sensitive-rx`, `mutation-site-rx`, `hash-ref-chain-rx`, `inline-config-path-rx`)
+3. **`audit-content`** extended with 4 new hash keys per module finding
+4. **`compute-summary`** extended with 4 new aggregate category lists
+5. **`format-report`** extended with 4 new report sections
+
+### New Tests
+
+**22 new tests** in `tests/test-abstraction-audit.rkt`:
+
+**`v4-change-locality-signal-tests` (16 unit tests):**
+- CWD-sensitive paths: 5 tests (relative dynamic-require, relative file->string, absolute NOT flagged, build-path NOT flagged, clean text)
+- Mutation sites: 4 tests (call-with-output-file, write-to-file, read-only returns 0, clean text)
+- Hash-ref chains: 4 tests (single nested chain, multiple chains, single hash-ref returns 0, clean text)
+- Inline config paths: 3 tests (build-path find-system-path, global-config-dir NOT flagged, clean text)
+
+**`v4-audit-content-integration-tests` (6 integration tests):**
+- All 4 new keys present in audit-content output
+- CWD-sensitive detection via audit-content
+- Mutation site detection via audit-content
+- Hash-ref chain detection via audit-content
+- Inline config path detection via audit-content
+- Clean text has all 0 signals
+
+**Total scanner tests: 61** (39 existing + 22 new)
+
+## How to Interpret New Signals
+
+### CWD-Sensitive Path Patterns
+
+**What it means:** The module uses `dynamic-require` or `file->string` (or
+similar) with a string literal that does NOT start with `/`. These patterns
+break when the process working directory changes.
+
+**Action:** Audit flagged modules against the W2 path-module-loading audit.
+If safe (using `build-path`, `define-runtime-path`, or
+`variable-reference->resolved-module-path`), no action needed. Otherwise,
+migrate to source-relative resolution.
+
+**Note:** This signal is conservative — it only catches string-literal
+relative paths, not computed paths. Modules using `build-path` or variables
+are NOT flagged (correctly).
+
+### File Mutation Sites
+
+**What it means:** The module contains file-writing operations
+(`call-with-output-file`, `write-to-file`, `display-to-file`, etc.).
+
+**Action:** Cross-reference with the W5 mutation boundary report. Check
+whether the module follows the pure-helpers + thin-shell pattern
+(compute function extracted, I/O centralized in a `write-or-check` wrapper).
+
+### Hash-Ref Chains
+
+**What it means:** The module contains `(hash-ref (hash-ref ...))` patterns
+— nested hash lookups that are fragile to key changes and hard to test.
+
+**Action:** Review against the W1 common-case API scorecard (pain point P5).
+Consider extracting an accessor function or using a struct with named fields.
+
+**Limitation:** The regex only catches `hash-ref` immediately nested inside
+another `hash-ref` (non-overlapping matches). Triple nesting counts as 1,
+not 2.
+
+### Inline Config Paths
+
+**What it means:** The module contains the pattern
+`(build-path (find-system-path 'home-dir) ...)` instead of using the shared
+`global-config-dir` helper from `util/config-paths.rkt`.
+
+**Action:** Migrate to `global-config-dir` (or `project-config-dirs`) from
+`util/config-paths.rkt`. The W6 adapter audit identified ~19 remaining sites.
+
+## Risk Assessment
+
+- **All signals are advisory** — no CI failure unless `--strict` mode is
+  explicitly invoked with thresholds.
+- **No existing behavior changed** — the 39 prior tests all pass unchanged.
+- **Pure functions only** — all 4 new counters are pure regex-match operations.
+- **No scanner framework complexity** — regex-based detection only, as per
+  the scope controls ("Do not turn scanner into a parser framework").

--- a/scripts/abstraction-audit.rkt
+++ b/scripts/abstraction-audit.rkt
@@ -56,6 +56,10 @@
          count-bench-timing
          count-ad-hoc-parsing
          count-event-handlers
+         count-cwd-sensitive-paths
+         count-mutation-sites
+         count-hash-ref-chains
+         count-inline-config-paths
          audit-content
          current-audit-file->lines)
 
@@ -149,7 +153,15 @@
           'ad-hoc-parse-count
           (count-ad-hoc-parsing text)
           'event-handler-count
-          (count-event-handlers text))))
+          (count-event-handlers text)
+          'cwd-sensitive-path-count
+          (count-cwd-sensitive-paths text)
+          'mutation-site-count
+          (count-mutation-sites text)
+          'hash-ref-chain-count
+          (count-hash-ref-chains text)
+          'inline-config-path-count
+          (count-inline-config-paths text))))
 
 ;; Count exported identifiers in (provide ...) forms.
 ;; Handles: provide id, provide (contract-out ...), provide (struct-out ...)
@@ -186,6 +198,18 @@
 ;; Handler/model risk: defines functions AND dispatches on event/state types
 (define event-handler-rx #px"define.*handler|handle-event|handle-key|dispatch")
 
+;; v0.99.38 W8: Change-locality signals
+;; CWD-sensitive: dynamic-require with relative-path string, file->* without build-path
+(define cwd-sensitive-rx
+  #px"dynamic-require\\s+\"[^/]|file->string\\s+\"[^/]|file->lines\\s+\"[^/]|file->bytes\\s+\"[^/]|file->list\\s+\"[^/]")
+;; Mutation sites: file-writing calls that modify the filesystem
+(define mutation-site-rx
+  #px"call-with-output-file|with-output-to-file|display-to-file|write-to-file|open-output-file")
+;; Hash-ref chains: nested hash-ref calls (common-case API pain point P5)
+(define hash-ref-chain-rx #px"hash-ref\\s+\\(hash-ref")
+;; Inline config paths: (build-path (find-system-path 'home-dir) ...) pattern
+(define inline-config-path-rx #px"build-path\\s+\\(find-system-path\\s+'home-dir")
+
 (define (count-matches text rx)
   (length (regexp-match* rx text)))
 
@@ -208,6 +232,25 @@
 (define (count-event-handlers text)
   "Count event handler definitions in text."
   (count-matches text event-handler-rx))
+
+;; v0.99.38 W8: Change-locality signal counters
+(define (count-cwd-sensitive-paths text)
+  "Count CWD-sensitive dynamic-require / file->* patterns in text.
+   These are relative-path string arguments that break if CWD changes."
+  (count-matches text cwd-sensitive-rx))
+
+(define (count-mutation-sites text)
+  "Count file-writing mutation sites (call-with-output-file, etc.) in text."
+  (count-matches text mutation-site-rx))
+
+(define (count-hash-ref-chains text)
+  "Count nested hash-ref chains in text (common-case API pain point P5)."
+  (count-matches text hash-ref-chain-rx))
+
+(define (count-inline-config-paths text)
+  "Count inline (build-path (find-system-path 'home-dir) ...) patterns in text.
+   These should use the shared global-config-dir helper instead."
+  (count-matches text inline-config-path-rx))
 
 (define (count-io-effects text)
   "Count I/O effect occurrences in text."
@@ -319,52 +362,75 @@
   (define all-ad-hoc-parse (filter (lambda (f) (> (hash-ref f 'ad-hoc-parse-count 0) 0)) findings))
   (define all-event-handlers (filter (lambda (f) (> (hash-ref f 'event-handler-count 0) 0)) findings))
 
-  (hash 'total-modules
-        (length findings)
-        'largest-modules
-        (map (lambda (f)
-               (hash 'path
-                     (hash-ref f 'path)
-                     'lines
-                     (hash-ref f 'line-count)
-                     'exports
-                     (hash-ref f 'export-count)))
-             largest)
-        'parameter-usage
-        (map (lambda (f) (hash 'path (hash-ref f 'path) 'count (hash-ref f 'parameter-count)))
-             (sort all-params > #:key (lambda (f) (hash-ref f 'parameter-count 0))))
-        'macro-usage
-        (map (lambda (f) (hash 'path (hash-ref f 'path) 'count (hash-ref f 'macro-count)))
-             (sort all-macros > #:key (lambda (f) (hash-ref f 'macro-count 0))))
-        'struct-out-exports
-        (map (lambda (f) (hash 'path (hash-ref f 'path) 'count (hash-ref f 'struct-out-count 0)))
-             (sort all-struct-out > #:key (lambda (f) (hash-ref f 'struct-out-count 0))))
-        'io-mixed-with-logic
-        (map (lambda (f) (hash 'path (hash-ref f 'path) 'count (hash-ref f 'io-count 0)))
-             (sort all-io-mixed > #:key (lambda (f) (hash-ref f 'io-count 0))))
-        'serialization-hotspots
-        (map (lambda (f) (hash 'path (hash-ref f 'path) 'count (hash-ref f 'serialization-count)))
-             (sort all-serialization > #:key (lambda (f) (hash-ref f 'serialization-count 0))))
-        'error-density
-        (map (lambda (f) (hash 'path (hash-ref f 'path) 'count (hash-ref f 'error-count 0)))
-             (sort all-errors > #:key (lambda (f) (hash-ref f 'error-count 0))))
-        'handler-density
-        (map (lambda (f) (hash 'path (hash-ref f 'path) 'count (hash-ref f 'handler-count 0)))
-             (sort all-handlers > #:key (lambda (f) (hash-ref f 'handler-count 0))))
-        'all-defined-out-modules
-        (map (lambda (f) (hash-ref f 'path)) all-all-defined-out)
-        'mutable-cache-modules
-        (map (lambda (f) (hash 'path (hash-ref f 'path) 'count (hash-ref f 'mutable-cache-count 0)))
-             (sort all-mutable-cache > #:key (lambda (f) (hash-ref f 'mutable-cache-count 0))))
-        'bench-timing-modules
-        (map (lambda (f) (hash 'path (hash-ref f 'path) 'count (hash-ref f 'bench-timing-count 0)))
-             (sort all-bench-timing > #:key (lambda (f) (hash-ref f 'bench-timing-count 0))))
-        'ad-hoc-parse-modules
-        (map (lambda (f) (hash 'path (hash-ref f 'path) 'count (hash-ref f 'ad-hoc-parse-count 0)))
-             (sort all-ad-hoc-parse > #:key (lambda (f) (hash-ref f 'ad-hoc-parse-count 0))))
-        'event-handler-modules
-        (map (lambda (f) (hash 'path (hash-ref f 'path) 'count (hash-ref f 'event-handler-count 0)))
-             (sort all-event-handlers > #:key (lambda (f) (hash-ref f 'event-handler-count 0))))))
+  ;; v0.99.38 W8: Change-locality signals
+  (define all-cwd-sensitive
+    (filter (lambda (f) (> (hash-ref f 'cwd-sensitive-path-count 0) 0)) findings))
+  (define all-mutation-sites (filter (lambda (f) (> (hash-ref f 'mutation-site-count 0) 0)) findings))
+  (define all-hash-ref-chains
+    (filter (lambda (f) (> (hash-ref f 'hash-ref-chain-count 0) 0)) findings))
+  (define all-inline-config-paths
+    (filter (lambda (f) (> (hash-ref f 'inline-config-path-count 0) 0)) findings))
+
+  (hash
+   'total-modules
+   (length findings)
+   'largest-modules
+   (map (lambda (f)
+          (hash 'path
+                (hash-ref f 'path)
+                'lines
+                (hash-ref f 'line-count)
+                'exports
+                (hash-ref f 'export-count)))
+        largest)
+   'parameter-usage
+   (map (lambda (f) (hash 'path (hash-ref f 'path) 'count (hash-ref f 'parameter-count)))
+        (sort all-params > #:key (lambda (f) (hash-ref f 'parameter-count 0))))
+   'macro-usage
+   (map (lambda (f) (hash 'path (hash-ref f 'path) 'count (hash-ref f 'macro-count)))
+        (sort all-macros > #:key (lambda (f) (hash-ref f 'macro-count 0))))
+   'struct-out-exports
+   (map (lambda (f) (hash 'path (hash-ref f 'path) 'count (hash-ref f 'struct-out-count 0)))
+        (sort all-struct-out > #:key (lambda (f) (hash-ref f 'struct-out-count 0))))
+   'io-mixed-with-logic
+   (map (lambda (f) (hash 'path (hash-ref f 'path) 'count (hash-ref f 'io-count 0)))
+        (sort all-io-mixed > #:key (lambda (f) (hash-ref f 'io-count 0))))
+   'serialization-hotspots
+   (map (lambda (f) (hash 'path (hash-ref f 'path) 'count (hash-ref f 'serialization-count)))
+        (sort all-serialization > #:key (lambda (f) (hash-ref f 'serialization-count 0))))
+   'error-density
+   (map (lambda (f) (hash 'path (hash-ref f 'path) 'count (hash-ref f 'error-count 0)))
+        (sort all-errors > #:key (lambda (f) (hash-ref f 'error-count 0))))
+   'handler-density
+   (map (lambda (f) (hash 'path (hash-ref f 'path) 'count (hash-ref f 'handler-count 0)))
+        (sort all-handlers > #:key (lambda (f) (hash-ref f 'handler-count 0))))
+   'all-defined-out-modules
+   (map (lambda (f) (hash-ref f 'path)) all-all-defined-out)
+   'mutable-cache-modules
+   (map (lambda (f) (hash 'path (hash-ref f 'path) 'count (hash-ref f 'mutable-cache-count 0)))
+        (sort all-mutable-cache > #:key (lambda (f) (hash-ref f 'mutable-cache-count 0))))
+   'bench-timing-modules
+   (map (lambda (f) (hash 'path (hash-ref f 'path) 'count (hash-ref f 'bench-timing-count 0)))
+        (sort all-bench-timing > #:key (lambda (f) (hash-ref f 'bench-timing-count 0))))
+   'ad-hoc-parse-modules
+   (map (lambda (f) (hash 'path (hash-ref f 'path) 'count (hash-ref f 'ad-hoc-parse-count 0)))
+        (sort all-ad-hoc-parse > #:key (lambda (f) (hash-ref f 'ad-hoc-parse-count 0))))
+   'event-handler-modules
+   (map (lambda (f) (hash 'path (hash-ref f 'path) 'count (hash-ref f 'event-handler-count 0)))
+        (sort all-event-handlers > #:key (lambda (f) (hash-ref f 'event-handler-count 0))))
+   'cwd-sensitive-path-modules
+   (map (lambda (f) (hash 'path (hash-ref f 'path) 'count (hash-ref f 'cwd-sensitive-path-count 0)))
+        (sort all-cwd-sensitive > #:key (lambda (f) (hash-ref f 'cwd-sensitive-path-count 0))))
+   'mutation-site-modules
+   (map (lambda (f) (hash 'path (hash-ref f 'path) 'count (hash-ref f 'mutation-site-count 0)))
+        (sort all-mutation-sites > #:key (lambda (f) (hash-ref f 'mutation-site-count 0))))
+   'hash-ref-chain-modules
+   (map (lambda (f) (hash 'path (hash-ref f 'path) 'count (hash-ref f 'hash-ref-chain-count 0)))
+        (sort all-hash-ref-chains > #:key (lambda (f) (hash-ref f 'hash-ref-chain-count 0))))
+   'inline-config-path-modules
+   (map
+    (lambda (f) (hash 'path (hash-ref f 'path) 'count (hash-ref f 'inline-config-path-count 0)))
+    (sort all-inline-config-paths > #:key (lambda (f) (hash-ref f 'inline-config-path-count 0))))))
 
 (define (take-at-most lst n)
   (if (> (length lst) n)
@@ -521,6 +587,51 @@
         (fprintf out "| Count | Path |\n")
         (fprintf out "|-------|------|\n")
         (for ([p eh])
+          (fprintf out "| ~a | ~a |\n" (hash-ref p 'count) (hash-ref p 'path)))
+        (fprintf out "\n")))
+
+  ;; v0.99.38 W8: Change-locality signals
+  (fprintf out "## CWD-Sensitive Path Patterns (dynamic-require / file->* with relative paths)\n\n")
+  (define csp (hash-ref summary 'cwd-sensitive-path-modules '()))
+  (if (null? csp)
+      (fprintf out "None found.\n\n")
+      (begin
+        (fprintf out "| Count | Path |\n")
+        (fprintf out "|-------|------|\n")
+        (for ([p csp])
+          (fprintf out "| ~a | ~a |\n" (hash-ref p 'count) (hash-ref p 'path)))
+        (fprintf out "\n")))
+
+  (fprintf out "## File Mutation Sites (call-with-output-file / write-to-file / display-to-file)\n\n")
+  (define ms (hash-ref summary 'mutation-site-modules '()))
+  (if (null? ms)
+      (fprintf out "None found.\n\n")
+      (begin
+        (fprintf out "| Count | Path |\n")
+        (fprintf out "|-------|------|\n")
+        (for ([p (take-at-most ms 20)])
+          (fprintf out "| ~a | ~a |\n" (hash-ref p 'count) (hash-ref p 'path)))
+        (fprintf out "\n")))
+
+  (fprintf out "## Hash-Ref Chains (nested hash-ref — common-case API pain point)\n\n")
+  (define hrc (hash-ref summary 'hash-ref-chain-modules '()))
+  (if (null? hrc)
+      (fprintf out "None found.\n\n")
+      (begin
+        (fprintf out "| Count | Path |\n")
+        (fprintf out "|-------|------|\n")
+        (for ([p (take-at-most hrc 20)])
+          (fprintf out "| ~a | ~a |\n" (hash-ref p 'count) (hash-ref p 'path)))
+        (fprintf out "\n")))
+
+  (fprintf out "## Inline Config Paths ((build-path (find-system-path 'home-dir) ...))\n\n")
+  (define icp (hash-ref summary 'inline-config-path-modules '()))
+  (if (null? icp)
+      (fprintf out "None found.\n\n")
+      (begin
+        (fprintf out "| Count | Path |\n")
+        (fprintf out "|-------|------|\n")
+        (for ([p icp])
           (fprintf out "| ~a | ~a |\n" (hash-ref p 'count) (hash-ref p 'path)))
         (fprintf out "\n")))
 

--- a/tests/test-abstraction-audit.rkt
+++ b/tests/test-abstraction-audit.rkt
@@ -464,6 +464,98 @@ EOF
      (check-true (> (hash-ref finding 'line-count) 0) "mocked module has positive lines"))))
 
 ;; ============================================================
+;; v0.99.38 W8: Change-locality signal tests
+;; ============================================================
+
+(define-test-suite
+ v4-change-locality-signal-tests
+ (test-case "count-cwd-sensitive-paths detects dynamic-require with relative path"
+   (define text "(dynamic-require \"foo/bar.rkt\" 'x)")
+   (check-equal? ((audit-ref 'count-cwd-sensitive-paths) text) 1 "detects relative dynamic-require"))
+ (test-case "count-cwd-sensitive-paths detects file->string with relative path"
+   (define text "(file->string \"config.json\")")
+   (check-equal? ((audit-ref 'count-cwd-sensitive-paths) text) 1 "detects relative file->string"))
+ (test-case "count-cwd-sensitive-paths does NOT flag absolute paths"
+   (define text "(file->string \"/etc/config.json\")")
+   (check-equal? ((audit-ref 'count-cwd-sensitive-paths) text) 0 "absolute path not flagged"))
+ (test-case "count-cwd-sensitive-paths does NOT flag build-path"
+   (define text "(file->string (build-path dir \"config.json\"))")
+   (check-equal? ((audit-ref 'count-cwd-sensitive-paths) text) 0 "build-path not flagged"))
+ (test-case "count-cwd-sensitive-paths returns 0 for clean text"
+   (define text "(define (f x) x)")
+   (check-equal? ((audit-ref 'count-cwd-sensitive-paths) text) 0 "clean text returns 0"))
+ (test-case "count-mutation-sites detects call-with-output-file"
+   (define text "(call-with-output-file \"a.txt\" f #:exists 'truncate)")
+   (check-pred positive? ((audit-ref 'count-mutation-sites) text) "detects call-with-output-file"))
+ (test-case "count-mutation-sites detects write-to-file"
+   (define text "(write-to-file \"out.txt\" data)")
+   (check-pred positive? ((audit-ref 'count-mutation-sites) text) "detects write-to-file"))
+ (test-case "count-mutation-sites returns 0 for read-only text"
+   (define text "(file->string \"input.txt\")")
+   (check-equal? ((audit-ref 'count-mutation-sites) text) 0 "read-only returns 0"))
+ (test-case "count-mutation-sites returns 0 for clean text"
+   (define text "(define (f x) x)")
+   (check-equal? ((audit-ref 'count-mutation-sites) text) 0 "clean text returns 0"))
+ (test-case "count-hash-ref-chains detects nested hash-ref"
+   (define text "(hash-ref (hash-ref h 'a) 'b)")
+   (check-equal? ((audit-ref 'count-hash-ref-chains) text) 1 "detects 1 nested hash-ref chain"))
+ (test-case "count-hash-ref-chains detects multiple nested hash-ref"
+   (define text "(hash-ref (hash-ref (hash-ref h 'a) 'b) 'c) (hash-ref (hash-ref h 'x) 'y)")
+   (check-true (>= ((audit-ref 'count-hash-ref-chains) text) 2)
+               "detects >= 2 nested hash-ref chains"))
+ (test-case "count-hash-ref-chains returns 0 for single hash-ref"
+   (define text "(hash-ref h 'a)")
+   (check-equal? ((audit-ref 'count-hash-ref-chains) text) 0 "single hash-ref returns 0"))
+ (test-case "count-hash-ref-chains returns 0 for clean text"
+   (define text "(define (f x) x)")
+   (check-equal? ((audit-ref 'count-hash-ref-chains) text) 0 "clean text returns 0"))
+ (test-case "count-inline-config-paths detects build-path find-system-path home-dir"
+   (define text "(build-path (find-system-path 'home-dir) \".q\")")
+   (check-equal? ((audit-ref 'count-inline-config-paths) text) 1 "detects inline config path"))
+ (test-case "count-inline-config-paths returns 0 for global-config-dir usage"
+   (define text "(global-config-dir)")
+   (check-equal? ((audit-ref 'count-inline-config-paths) text) 0 "global-config-dir not flagged"))
+ (test-case "count-inline-config-paths returns 0 for clean text"
+   (define text "(define (f x) x)")
+   (check-equal? ((audit-ref 'count-inline-config-paths) text) 0 "clean text returns 0")))
+
+(define-test-suite
+ v4-audit-content-integration-tests
+ (test-case "audit-content includes all 4 new signal keys"
+   (define text "#lang racket/base\n(define (f x) x)")
+   (define finding ((audit-ref 'audit-content) "test.rkt" text))
+   (check-true (hash-has-key? finding 'cwd-sensitive-path-count) "has cwd-sensitive-path-count")
+   (check-true (hash-has-key? finding 'mutation-site-count) "has mutation-site-count")
+   (check-true (hash-has-key? finding 'hash-ref-chain-count) "has hash-ref-chain-count")
+   (check-true (hash-has-key? finding 'inline-config-path-count) "has inline-config-path-count"))
+ (test-case "audit-content detects cwd-sensitive in fixture"
+   (define text "#lang racket/base\n(define (load-config)\n  (file->string \"config.json\"))")
+   (define finding ((audit-ref 'audit-content) "cwd.rkt" text))
+   (check-pred positive? (hash-ref finding 'cwd-sensitive-path-count) "cwd-sensitive > 0"))
+ (test-case "audit-content detects mutation site in fixture"
+   (define text
+     "#lang racket/base\n(define (save! data)\n  (call-with-output-file \"out.txt\" (lambda (o) (write data o)) #:exists 'truncate))")
+   (define finding ((audit-ref 'audit-content) "mut.rkt" text))
+   (check-pred positive? (hash-ref finding 'mutation-site-count) "mutation-site > 0"))
+ (test-case "audit-content detects hash-ref chain in fixture"
+   (define text
+     "#lang racket/base\n(define (get-name config)\n  (hash-ref (hash-ref config 'user) 'name))")
+   (define finding ((audit-ref 'audit-content) "chain.rkt" text))
+   (check-pred positive? (hash-ref finding 'hash-ref-chain-count) "hash-ref-chain > 0"))
+ (test-case "audit-content detects inline config path in fixture"
+   (define text
+     "#lang racket/base\n(define (config-dir)\n  (build-path (find-system-path 'home-dir) \".q\"))")
+   (define finding ((audit-ref 'audit-content) "icp.rkt" text))
+   (check-pred positive? (hash-ref finding 'inline-config-path-count) "inline-config-path > 0"))
+ (test-case "audit-content on clean text has all 0 signals"
+   (define text "#lang racket/base\n(define (f x) x)")
+   (define finding ((audit-ref 'audit-content) "clean.rkt" text))
+   (check-equal? (hash-ref finding 'cwd-sensitive-path-count) 0 "clean: 0 cwd-sensitive")
+   (check-equal? (hash-ref finding 'mutation-site-count) 0 "clean: 0 mutation-sites")
+   (check-equal? (hash-ref finding 'hash-ref-chain-count) 0 "clean: 0 hash-ref-chains")
+   (check-equal? (hash-ref finding 'inline-config-path-count) 0 "clean: 0 inline-config-paths")))
+
+;; ============================================================
 ;; Run all tests
 ;; ============================================================
 
@@ -476,7 +568,9 @@ EOF
                    count-exports-tests
                    red-flag-signal-tests
                    v3-signal-tests
-                   pure-audit-content-tests)
+                   pure-audit-content-tests
+                   v4-change-locality-signal-tests
+                   v4-audit-content-integration-tests)
 
 (module+ test
   (run-tests all-abstraction-audit-tests))


### PR DESCRIPTION
4 new advisory signal categories in abstraction-audit.rkt. 22 new tests (61 total). All advisory only.

Closes #8482