### PR TITLE
W2: Add local CI-equivalent package setup gate (#8505)

### DIFF
--- a/scripts/ci-local.rkt
+++ b/scripts/ci-local.rkt
@@ -24,12 +24,16 @@
 
 (define quick? #f)
 (define fix? #f)
+(define package-setup? #f)
+(define github-setup? #f)
 
 (define (parse-flags!)
   (for ([arg (in-vector (current-command-line-arguments))])
     (cond
       [(string=? arg "--quick") (set! quick? #t)]
       [(string=? arg "--fix") (set! fix? #t)]
+      [(string=? arg "--package-setup") (set! package-setup? #t)]
+      [(string=? arg "--github-setup") (set! github-setup? #t)]
       [else (printf "Unknown flag: ~a~n" arg)])))
 
 ;; ---------------------------------------------------------------------------
@@ -125,11 +129,39 @@
     (printf "ERROR: Run from the q/ directory (main.rkt not found).~n")
     (exit 1))
 
-  (printf "~n=== CI Local Lint Suite ===~n")
+  ;; Handle package-setup mode (Option B preflight)
+  (when package-setup?
+    (printf "=== CI Package Setup Gate (preflight) ===~n")
+    (printf "This gate compiles ALL package-visible modules, mirroring~n")
+    (printf "the hidden compile boundary in GitHub Actions setup-racket.~n~n")
+    (define exit-code (system/exit-code "racket scripts/ci-package-setup.rkt --preflight"))
+    (when (not (zero? exit-code))
+      (printf "~nPackage setup gate FAILED. Run ci-local without --package-setup for lint-only.~n")
+      (exit 1))
+    (printf "~n"))
+
+  ;; Handle github-setup mode (Option A full)
+  (when github-setup?
+    (printf "=== CI Package Setup Gate (full) ===~n")
+    (printf "Running raco pkg install in isolated PLTUSERHOME.~n")
+    (printf "This is the closest local equivalent to GitHub Actions.~n~n")
+    (define exit-code (system/exit-code "racket scripts/ci-package-setup.rkt --full"))
+    (when (not (zero? exit-code))
+      (printf "~nFull package setup gate FAILED.~n")
+      (exit 1))
+    (printf "~n"))
+
+  (printf "=== CI Local Lint Suite ===~n")
   (when quick?
-    (printf "Mode: --quick (skipping slow checks)~n"))
+    (printf "Mode: --quick (skipping slow checks)~n")
+    (printf "NOTE: --quick does NOT include package setup parity.~n")
+    (printf "      Use --package-setup for CI-equivalent compile gate.~n"))
   (when fix?
     (printf "Mode: --fix (auto-fixing drift before lint)~n"))
+  (when package-setup?
+    (printf "Mode: --package-setup (preflight compile gate included)~n"))
+  (when github-setup?
+    (printf "Mode: --github-setup (full package install gate included)~n"))
   (printf "~n")
 
   ;; Phase 1: Auto-fix (if --fix)

--- a/scripts/ci-package-setup.rkt
+++ b/scripts/ci-package-setup.rkt
@@ -1,0 +1,190 @@
+#!/usr/bin/env racket
+#lang racket/base
+
+;; scripts/ci-package-setup.rkt — Local CI-equivalent package compile gate.
+;;
+;; Reproduces the hidden GitHub Actions setup-racket compile boundary
+;; that runs `raco pkg install` (or `raco pkg update`) which compiles
+;; ALL package-visible modules, not just main.rkt and its transitive deps.
+;;
+;; Two modes:
+;;   --preflight   (Option B) Compile all package-visible .rkt files via raco make.
+;;                 Fast, deterministic, no package state mutation.
+;;   --full        (Option A) Run true raco pkg install in isolated PLTUSERHOME.
+;;                 Slowest, closest to CI, may download packages.
+;;
+;; Usage:
+;;   cd q/ && racket scripts/ci-package-setup.rkt --preflight
+;;   cd q/ && racket scripts/ci-package-setup.rkt --full
+;;
+;; Default (no flag): runs --preflight.
+;; Exit 0 if all modules compile, 1 if any fail.
+
+(require racket/list
+         racket/string
+         racket/system
+         racket/match
+         racket/file)
+
+;; ---------------------------------------------------------------------------
+;; Provide pure functions for testing
+;; ---------------------------------------------------------------------------
+
+(provide build-package-setup-command
+         classify-failure
+         find-package-visible-modules
+         run-preflight-compile
+         run-full-package-setup
+         main)
+
+;; ---------------------------------------------------------------------------
+;; Pure: Build the PLTUSERHOME-isolated package setup command
+;; ---------------------------------------------------------------------------
+
+(define (build-package-setup-command project-dir #:plt-user-home [plt-user-home #f])
+  "Build the raco pkg install command with optional PLTUSERHOME isolation.
+Returns a string suitable for system/exit-code."
+  (define home (or plt-user-home "/tmp/plt-user-home-ci"))
+  (format "PLTUSERHOME=~a raco pkg install --auto --batch ~a" home project-dir))
+
+;; ---------------------------------------------------------------------------
+;; Pure: Classify failure output
+;; ---------------------------------------------------------------------------
+
+(define (classify-failure stderr-output)
+  "Classify a package setup failure into a category string.
+Returns one of:
+  'dependency-install   — raco could not resolve/install a dependency
+  'compile-failure      — a module failed to compile
+  'cache-path           — cache or path issue
+  'unknown              — unclassifiable"
+  (cond
+    [(string-contains? stderr-output "cannot find package") 'dependency-install]
+    [(string-contains? stderr-output "unbound identifier") 'compile-failure]
+    [(string-contains? stderr-output "identifier already") 'compile-failure]
+    [(string-contains? stderr-output "cannot open module file") 'compile-failure]
+    [(string-contains? stderr-output "cache") 'cache-path]
+    [(string-contains? stderr-output "no such file or directory") 'cache-path]
+    [else 'unknown]))
+
+;; ---------------------------------------------------------------------------
+;; Pure: Find package-visible .rkt modules
+;; ---------------------------------------------------------------------------
+
+(define (find-package-visible-modules project-dir)
+  "Find all .rkt files that are visible to raco pkg setup.
+Excludes tests/ (which have their own test runner), and compiled/."
+  (define all-rkt
+    (for/list ([f (in-directory project-dir)]
+               #:when (and (regexp-match? #rx"\\.rkt$" (path->string f))
+                           ;; Exclude compiled/ directories
+                           (not (string-contains? (path->string f) "/compiled/"))
+                           ;; Exclude tests/ (covered by run-tests.rkt)
+                           (not (string-contains? (path->string f) "/tests/"))
+                           ;; Exclude .planning/
+                           (not (string-contains? (path->string f) "/.planning/"))
+                           ;; Exclude tmp files
+                           (not (regexp-match? #rx"/tmp-" (path->string f)))))
+      (path->string f)))
+  (sort all-rkt string<?))
+
+;; ---------------------------------------------------------------------------
+;; Option B: Preflight compile (fast, deterministic)
+;; ---------------------------------------------------------------------------
+
+(define (run-preflight-compile project-dir)
+  "Compile all package-visible modules via raco make.
+Returns (values success? failure-details-list)."
+  (define modules (find-package-visible-modules project-dir))
+  (printf "Package-visible modules: ~a~n" (length modules))
+  (printf "Running raco make on each module...~n~n")
+  (define failures
+    (for/list ([mod (in-list modules)]
+               #:when (not (compile-single-module mod)))
+      mod))
+  (if (null? failures)
+      (begin
+        (printf "~n✅ All ~a package-visible modules compile.~n" (length modules))
+        (values #t '()))
+      (begin
+        (printf "~n❌ ~a/~a modules failed to compile.~n" (length failures) (length modules))
+        (values #f failures))))
+
+(define (compile-single-module module-path)
+  "Compile a single module via raco make. Returns #t on success, #f on failure."
+  (define cmd (format "raco make ~a 2>&1" module-path))
+  (define exit-code (system/exit-code cmd))
+  (zero? exit-code))
+
+;; ---------------------------------------------------------------------------
+;; Option A: Full package setup (slow, true CI parity)
+;; ---------------------------------------------------------------------------
+
+(define (run-full-package-setup project-dir)
+  "Run raco pkg install in an isolated PLTUSERHOME.
+Returns (values success? output-string)."
+  (define tmp-home (path->string (make-temporary-file "plt-user-home-ci-~a" 'directory)))
+  (printf "Using isolated PLTUSERHOME: ~a~n" tmp-home)
+  (define cmd (build-package-setup-command project-dir #:plt-user-home tmp-home))
+  (printf "Running: ~a~n~n" cmd)
+  (define out (open-output-string))
+  (define exit-code
+    (parameterize ([current-output-port out]
+                   [current-error-port out])
+      (system/exit-code cmd)))
+  (define output (get-output-string out))
+  ;; Cleanup
+  (with-handlers ([exn:fail? void])
+    (delete-directory/files tmp-home))
+  (values (zero? exit-code) output))
+
+;; ---------------------------------------------------------------------------
+;; Main entry point
+;; ---------------------------------------------------------------------------
+
+(define (main)
+  (define args (vector->list (current-command-line-arguments)))
+  (define mode
+    (cond
+      [(member "--full" args) 'full]
+      [(member "--preflight" args) 'preflight]
+      [else 'preflight])) ; default to preflight
+
+  ;; Ensure we're in the q/ directory
+  (unless (file-exists? "main.rkt")
+    (printf "ERROR: Run from the q/ directory (main.rkt not found).~n")
+    (exit 1))
+
+  (printf "=== CI Package Setup Gate ===~n")
+  (printf "Mode: ~a~n~n" mode)
+
+  (define project-dir (current-directory))
+
+  (case mode
+    [(preflight)
+     (define-values (success? failures) (run-preflight-compile project-dir))
+     (if success?
+         (exit 0)
+         (begin
+           (printf "~nFailed modules:~n")
+           (for ([f (in-list failures)])
+             (printf "  ✗ ~a~n" f))
+           (exit 1)))]
+    [(full)
+     (define-values (success? output) (run-full-package-setup project-dir))
+     (if success?
+         (begin
+           (printf "✅ Package setup succeeded.~n")
+           (exit 0))
+         (let* ([category (classify-failure output)]
+                [lines (string-split output "\n")]
+                [tail (take-right lines (min 20 (length lines)))])
+           (printf "❌ Package setup failed.~n")
+           (printf "Failure category: ~a~n" category)
+           (printf "~n--- Output (last 20 lines) ---~n")
+           (for ([l (in-list tail)])
+             (printf "  ~a~n" l))
+           (exit 1)))]))
+
+(module+ main
+  (main))

--- a/tests/test-ci-package-setup.rkt
+++ b/tests/test-ci-package-setup.rkt
@@ -1,0 +1,130 @@
+#lang racket
+
+;; @speed fast
+;; @suite fast
+
+;; W2 (#8505): Tests for scripts/ci-package-setup.rkt
+;; Verifies pure functions: command construction, failure classification,
+;; module discovery. Does NOT run actual raco pkg install.
+
+(require rackunit
+         racket/file
+         racket/runtime-path)
+
+;; Resolve project root relative to this test file.
+;; raco test runs from the test file's directory (tests/).
+(define project-root
+  (simplify-path
+   (build-path (or (path-only (resolved-module-path-name (variable-reference->resolved-module-path
+                                                          (#%variable-reference))))
+                   ".")
+               "..")))
+
+(require "../scripts/ci-package-setup.rkt")
+
+;; ---------------------------------------------------------------------------
+;; build-package-setup-command
+;; ---------------------------------------------------------------------------
+
+(define-test-suite
+ build-command-tests
+ (test-case "builds command with PLTUSERHOME isolation"
+   (define cmd (build-package-setup-command "/path/to/project"))
+   (check-pred (lambda (s) (string-contains? s "PLTUSERHOME")) cmd)
+   (check-pred (lambda (s) (string-contains? s "raco pkg install")) cmd)
+   (check-pred (lambda (s) (string-contains? s "--auto")) cmd)
+   (check-pred (lambda (s) (string-contains? s "--batch")) cmd)
+   (check-pred (lambda (s) (string-contains? s "/path/to/project")) cmd))
+ (test-case "uses provided PLTUSERHOME"
+   (define cmd (build-package-setup-command "/proj" #:plt-user-home "/tmp/custom-home"))
+   (check-pred (lambda (s) (string-contains? s "PLTUSERHOME=/tmp/custom-home")) cmd))
+ (test-case "uses default home when none provided"
+   (define cmd (build-package-setup-command "/proj"))
+   (check-pred (lambda (s) (string-contains? s "PLTUSERHOME=")) cmd)))
+
+;; ---------------------------------------------------------------------------
+;; classify-failure
+;; ---------------------------------------------------------------------------
+
+(define-test-suite classify-tests
+                   (test-case "classifies dependency install failure"
+                     (check-equal? (classify-failure "cannot find package foo") 'dependency-install))
+                   (test-case "classifies unbound identifier as compile failure"
+                     (check-equal? (classify-failure "foo: unbound identifier") 'compile-failure))
+                   (test-case "classifies duplicate import as compile failure"
+                     (check-equal? (classify-failure "identifier already required: foo")
+                                   'compile-failure))
+                   (test-case "classifies cannot open module as compile failure"
+                     (check-equal? (classify-failure "cannot open module file") 'compile-failure))
+                   (test-case "classifies cache failure"
+                     (check-equal? (classify-failure "cache directory corrupted") 'cache-path))
+                   (test-case "classifies path failure"
+                     (check-equal? (classify-failure "no such file or directory") 'cache-path))
+                   (test-case "classifies unknown failure"
+                     (check-equal? (classify-failure "something else happened") 'unknown)))
+
+;; ---------------------------------------------------------------------------
+;; find-package-visible-modules
+;; ---------------------------------------------------------------------------
+
+(define-test-suite
+ module-discovery-tests
+ (test-case "finds non-test .rkt files in project root"
+   (define modules (find-package-visible-modules project-root))
+   (check-pred (lambda (lst) (> (length lst) 50)) modules "expected many modules"))
+ (test-case "excludes compiled/ directories"
+   (define modules (find-package-visible-modules project-root))
+   (check-false (ormap (lambda (m) (string-contains? m "/compiled/")) modules)))
+ (test-case "excludes tests/ directory"
+   (define modules (find-package-visible-modules project-root))
+   (check-false (ormap (lambda (m) (string-contains? m "/tests/")) modules)))
+ (test-case "includes cli/generate-certificates.rkt (F1 regression target)"
+   (define modules (find-package-visible-modules project-root))
+   (check-true (ormap (lambda (m) (string-contains? m "generate-certificates")) modules)
+               "cli/generate-certificates.rkt should be package-visible"))
+ (test-case "includes scripts that previously failed compile"
+   (define modules (find-package-visible-modules project-root))
+   (check-true (ormap (lambda (m) (string-contains? m "sdk-gsd-integration-test")) modules))
+   (check-true (ormap (lambda (m) (string-contains? m "test-gsd-go-replanning")) modules))
+   (check-true (ormap (lambda (m) (string-contains? m "test-gsd-sdk-live")) modules)))
+ (test-case "returns sorted list"
+   (define modules (find-package-visible-modules project-root))
+   (check-equal? modules (sort modules string<?))))
+
+;; ---------------------------------------------------------------------------
+;; Quick mode parity warning (structural check)
+;; ---------------------------------------------------------------------------
+
+(define-test-suite quick-mode-parity-tests
+                   (test-case "ci-local.rkt warns about --quick not having package parity"
+                     (define ci-local-path (build-path project-root "scripts" "ci-local.rkt"))
+                     (define ci-local-content (file->string ci-local-path))
+                     (check-true (string-contains? ci-local-content
+                                                   "does NOT include package setup parity")
+                                 "ci-local must warn that --quick lacks package parity"))
+                   (test-case "ci-local.rkt supports --package-setup flag"
+                     (define ci-local-path (build-path project-root "scripts" "ci-local.rkt"))
+                     (define ci-local-content (file->string ci-local-path))
+                     (check-true (string-contains? ci-local-content "--package-setup")
+                                 "ci-local must support --package-setup flag"))
+                   (test-case "ci-local.rkt supports --github-setup flag"
+                     (define ci-local-path (build-path project-root "scripts" "ci-local.rkt"))
+                     (define ci-local-content (file->string ci-local-path))
+                     (check-true (string-contains? ci-local-content "--github-setup")
+                                 "ci-local must support --github-setup flag")))
+
+;; ---------------------------------------------------------------------------
+
+(module+ test
+  (require rackunit/text-ui)
+  (run-tests build-command-tests)
+  (run-tests classify-tests)
+  (run-tests module-discovery-tests)
+  (run-tests quick-mode-parity-tests))
+
+(module+ main
+  (require rackunit/text-ui)
+  (run-tests build-command-tests)
+  (run-tests classify-tests)
+  (run-tests module-discovery-tests)
+  (run-tests quick-mode-parity-tests))


### PR DESCRIPTION
Adds local CI-equivalent package compile gate.

New module `scripts/ci-package-setup.rkt` with pure functions for command construction, failure classification, and module discovery.

Updates `ci-local.rkt` with `--package-setup` and `--github-setup` flags. Quick mode now explicitly warns it lacks package setup parity.

19 new tests. All gates pass.

Closes #8505