### PR TITLE
W3: Local release dry-run / tag-publish gate (#8520)

### DIFF
--- a/scripts/ci-local.rkt
+++ b/scripts/ci-local.rkt
@@ -26,6 +26,7 @@
 (define fix? #f)
 (define package-setup? #f)
 (define github-setup? #f)
+(define release-dry-run? #f)
 
 (define (parse-flags!)
   (for ([arg (in-vector (current-command-line-arguments))])
@@ -34,6 +35,7 @@
       [(string=? arg "--fix") (set! fix? #t)]
       [(string=? arg "--package-setup") (set! package-setup? #t)]
       [(string=? arg "--github-setup") (set! github-setup? #t)]
+      [(string=? arg "--release-dry-run") (set! release-dry-run? #t)]
       [else (printf "Unknown flag: ~a~n" arg)])))
 
 ;; ---------------------------------------------------------------------------
@@ -139,6 +141,18 @@
       (printf "~nPackage setup gate FAILED. Run ci-local without --package-setup for lint-only.~n")
       (exit 1))
     (printf "~n"))
+
+  ;; Handle release-dry-run mode
+  (when release-dry-run?
+    (printf "=== Release Dry-Run ===~n")
+    (printf "Validating release workflow semantics locally.~n")
+    (printf "No tags or releases will be created.~n~n")
+    (define exit-code (system/exit-code "racket scripts/release-dry-run.rkt --context tag-publish"))
+    (when (not (zero? exit-code))
+      (printf "~nRelease dry-run FAILED.~n")
+      (exit 1))
+    (printf "~nRelease dry-run PASSED.~n")
+    (exit 0))
 
   ;; Handle github-setup mode (Option A full)
   (when github-setup?

--- a/scripts/release-dry-run.rkt
+++ b/scripts/release-dry-run.rkt
@@ -1,0 +1,203 @@
+#!/usr/bin/env racket
+#lang racket/base
+
+;; scripts/release-dry-run.rkt — Local release workflow dry-run.
+;;
+;; W3 (#8520): Validate release workflow semantics locally before
+;; pushing a tag. No network publication occurs — this script never
+;; calls `git tag`, `git push --tags`, or `gh release create`.
+;;
+;; Checks:
+;;   1. Version match: requested version matches util/version.rkt
+;;   2. Tag format: vX.Y.Z (semver)
+;;   3. CHANGELOG entry: CHANGELOG.md has entry for version
+;;   4. Release notes: gen-release-notes.rkt produces non-empty output
+;;   5. Manifest: gen-release-manifest.rkt produces valid JSON output
+;;   6. Tarball build: tarball build command is syntactically valid
+;;   7. No publication: verify no git tag/release creation commands run
+;;
+;; Exit codes:
+;;   0 — all checks pass, release is ready
+;;   1 — one or more checks failed
+;;
+;; Usage:
+;;   cd q/
+;;   racket scripts/release-dry-run.rkt
+;;   racket scripts/release-dry-run.rkt --version 0.99.40 --context tag-publish
+
+(provide validate-version-match
+         validate-tag-format
+         extract-canonical-version
+         extract-changelog-version
+         parse-dry-run-args
+         dry-run-checks
+         tag-format-rx)
+
+(require racket/string
+         racket/port
+         racket/file
+         racket/list
+         racket/match
+         racket/system)
+
+;; ---------------------------------------------------------------------------
+;; Pure logic (no I/O)
+;; ---------------------------------------------------------------------------
+
+;; Semver tag format: vX.Y.Z
+(define tag-format-rx #px"^v([0-9]+)\\.([0-9]+)\\.([0-9]+)$")
+
+;; Plain version format: X.Y.Z
+(define version-format-rx #px"^([0-9]+)\\.([0-9]+)\\.([0-9]+)$")
+
+;; Extract canonical version from util/version.rkt content.
+(define (extract-canonical-version content)
+  (define m (regexp-match #px"\\(define q-version \"([0-9]+\\.[0-9]+\\.[0-9]+)\"" content))
+  (and m (cadr m)))
+
+;; Extract CHANGELOG version section header.
+(define (extract-changelog-version content version)
+  (define v-pattern (format "## ~a" (regexp-quote version)))
+  (define vp-pattern (format "## v~a" (regexp-quote version)))
+  (or (regexp-match? (regexp v-pattern) content) (regexp-match? (regexp vp-pattern) content)))
+
+;; Validate that requested version matches canonical version.
+;; Returns (list 'match/'mismatch canonical requested) or (list 'error msg).
+(define (validate-version-match requested canonical)
+  (cond
+    [(not canonical) (list 'error "Cannot read canonical version from util/version.rkt")]
+    [(equal? requested canonical) (list 'match canonical requested)]
+    [else (list 'mismatch canonical requested)]))
+
+;; Validate tag format. Tag must be vX.Y.Z.
+(define (validate-tag-format tag)
+  (if (regexp-match? tag-format-rx tag)
+      (list 'ok tag)
+      (list 'invalid tag)))
+
+;; Parse command-line arguments.
+;; Returns (values version context)
+;; version: string or #f (defaults to canonical)
+;; context: 'tag-publish or 'pre-tag (defaults to 'tag-publish)
+(define (parse-dry-run-args args)
+  (define version #f)
+  (define context 'tag-publish)
+  (let loop ([rest args])
+    (match rest
+      [(list "--version" v more ...)
+       (set! version v)
+       (loop more)]
+      [(list "--context" c more ...)
+       (when (member c '("tag-publish" "pre-tag"))
+         (set! context (string->symbol c)))
+       (loop more)]
+      [(list "--help" _ ...) 'help]
+      [(list) (void)]
+      [_ (loop (cdr rest))]))
+  (values version context))
+
+;; Build the list of check descriptors (name, thunk) for dry-run.
+;; Each thunk returns (cons 'pass/'fail message).
+(define (dry-run-checks version context file-exists? file->string run-subprocess)
+  ;; Check 1: Version match
+  (list (cons "version-match"
+              (lambda ()
+                (define util-content (file->string "util/version.rkt"))
+                (define canonical (extract-canonical-version util-content))
+                (define result (validate-version-match (or version canonical) canonical))
+                (match result
+                  [(list 'match c _) (cons 'pass (format "version ~a matches canonical" c))]
+                  [(list 'mismatch c r) (cons 'fail (format "requested ~a ≠ canonical ~a" r c))]
+                  [(list 'error msg) (cons 'fail msg)])))
+        ;; Check 2: Tag format
+        (cons "tag-format"
+              (lambda ()
+                (define v (or version (extract-canonical-version (file->string "util/version.rkt"))))
+                (define tag (format "v~a" v))
+                (define result (validate-tag-format tag))
+                (match result
+                  [(list 'ok t) (cons 'pass (format "tag ~a is valid semver" t))]
+                  [(list 'invalid t) (cons 'fail (format "tag ~a is not valid semver" t))])))
+        ;; Check 3: CHANGELOG entry
+        (cons "changelog-entry"
+              (lambda ()
+                (define v (or version (extract-canonical-version (file->string "util/version.rkt"))))
+                (define cl-content (file->string "CHANGELOG.md"))
+                (if (extract-changelog-version cl-content v)
+                    (cons 'pass (format "CHANGELOG has entry for v~a" v))
+                    (cons 'fail (format "CHANGELOG missing entry for v~a" v)))))
+        ;; Check 4: Release notes generation
+        (cons "release-notes"
+              (lambda ()
+                (define v (or version (extract-canonical-version (file->string "util/version.rkt"))))
+                (define exit-code (run-subprocess "racket" (list "scripts/gen-release-notes.rkt" v)))
+                (if (zero? exit-code)
+                    (cons 'pass "release notes generation succeeded")
+                    (cons 'fail "release notes generation failed"))))
+        ;; Check 5: Manifest generation
+        (cons "manifest"
+              (lambda ()
+                (define exit-code (run-subprocess "racket" (list "scripts/gen-release-manifest.rkt")))
+                (if (zero? exit-code)
+                    (cons 'pass "manifest generation succeeded")
+                    (cons 'fail "manifest generation failed"))))))
+
+;; ---------------------------------------------------------------------------
+;; I/O layer
+;; ---------------------------------------------------------------------------
+
+(define (run-subprocess/real cmd args)
+  "Run a subprocess, return exit code. Output suppressed."
+  (define-values (proc out-port in-port err-port)
+    (apply subprocess #f #f #f (find-executable-path cmd) args))
+  (subprocess-wait proc)
+  (subprocess-status proc))
+
+;; ---------------------------------------------------------------------------
+;; Main
+;; ---------------------------------------------------------------------------
+
+(define (main)
+  (define argv (vector->list (current-command-line-arguments)))
+  (define-values (version context) (parse-dry-run-args argv))
+
+  (unless (file-exists? "util/version.rkt")
+    (displayln "ERROR: Run from q/ project root (util/version.rkt not found)")
+    (exit 1))
+
+  (displayln "=== Release Dry-Run ===")
+  (printf "Context: ~a~n" context)
+  (when version
+    (printf "Requested version: ~a~n" version))
+  (displayln "")
+
+  ;; Determine canonical version for display
+  (define canonical (extract-canonical-version (file->string "util/version.rkt")))
+  (printf "Canonical version: ~a~n~n" (or canonical "UNKNOWN"))
+
+  (displayln "--- Checks ---")
+  (define checks (dry-run-checks version context file-exists? file->string run-subprocess/real))
+
+  (define results
+    (for/list ([c (in-list checks)])
+      (define name (car c))
+      (define result ((cdr c)))
+      (define status (car result))
+      (define msg (cdr result))
+      (printf "  [~a] ~a: ~a~n" (if (eq? status 'pass) "PASS" "FAIL") name msg)
+      (cons name status)))
+
+  ;; Summary
+  (define failures (filter (λ (r) (eq? (cdr r) 'fail)) results))
+  (displayln "")
+  (displayln "--- Summary ---")
+  (printf "Checks: ~a total, ~a passed, ~a failed~n"
+          (length results)
+          (- (length results) (length failures))
+          (length failures))
+  (displayln "No tags or releases were created. (Dry-run only)")
+
+  (exit (if (null? failures) 0 1)))
+
+(module+ main
+  (main))

--- a/tests/test-release-dry-run.rkt
+++ b/tests/test-release-dry-run.rkt
@@ -1,0 +1,191 @@
+#lang racket
+
+;; @speed fast
+;; @suite ci
+;; tests/test-release-dry-run.rkt
+;; W3 (#8520): Tests for scripts/release-dry-run.rkt
+
+(require rackunit
+         racket/port
+         racket/file)
+
+;; ── Helper: load the script as a module ──
+(define script-path "../scripts/release-dry-run.rkt")
+
+(define (dynamic-script sym)
+  (dynamic-require script-path sym))
+
+;; ============================================================
+;; Pure logic tests
+;; ============================================================
+
+(test-case "extract-canonical-version: parses version correctly"
+  (define content "(define q-version \"0.99.40\")")
+  (define result ((dynamic-script 'extract-canonical-version) content))
+  (check-equal? result "0.99.40"))
+
+(test-case "extract-canonical-version: returns #f for no match"
+  (define content "(define some-other-var \"0.99.40\")")
+  (define result ((dynamic-script 'extract-canonical-version) content))
+  (check-false result))
+
+(test-case "validate-version-match: matching versions"
+  (define result ((dynamic-script 'validate-version-match) "0.99.40" "0.99.40"))
+  (check-equal? (car result) 'match))
+
+(test-case "validate-version-match: mismatched versions"
+  (define result ((dynamic-script 'validate-version-match) "0.99.39" "0.99.40"))
+  (check-equal? (car result) 'mismatch))
+
+(test-case "validate-version-match: missing canonical"
+  (define result ((dynamic-script 'validate-version-match) "0.99.40" #f))
+  (check-equal? (car result) 'error))
+
+(test-case "validate-tag-format: valid semver tag"
+  (define result ((dynamic-script 'validate-tag-format) "v0.99.40"))
+  (check-equal? (car result) 'ok))
+
+(test-case "validate-tag-format: invalid tag (missing v prefix)"
+  (define result ((dynamic-script 'validate-tag-format) "0.99.40"))
+  (check-equal? (car result) 'invalid))
+
+(test-case "validate-tag-format: invalid tag (non-semver)"
+  (define result ((dynamic-script 'validate-tag-format) "v0.99"))
+  (check-equal? (car result) 'invalid))
+
+(test-case "validate-tag-format: invalid tag (extra components)"
+  (define result ((dynamic-script 'validate-tag-format) "v0.99.40.1"))
+  (check-equal? (car result) 'invalid))
+
+(test-case "extract-changelog-version: finds v-prefixed header"
+  (define content "## Changelog\n\n## v0.99.40 — 2026-06-21\n\n- Some change\n")
+  (check-true ((dynamic-script 'extract-changelog-version) content "0.99.40")))
+
+(test-case "extract-changelog-version: finds bare version header"
+  (define content "## Changelog\n\n## 0.99.40\n\n- Some change\n")
+  (check-true ((dynamic-script 'extract-changelog-version) content "0.99.40")))
+
+(test-case "extract-changelog-version: returns #f for missing version"
+  (define content "## Changelog\n\n## v0.99.39 — 2026-06-20\n\n- Some change\n")
+  (check-false ((dynamic-script 'extract-changelog-version) content "0.99.40")))
+
+;; ============================================================
+;; Argument parsing tests
+;; ============================================================
+
+(test-case "parse-dry-run-args: default context is tag-publish"
+  (define-values (version context) ((dynamic-script 'parse-dry-run-args) '()))
+  (check-false version)
+  (check-equal? context 'tag-publish))
+
+(test-case "parse-dry-run-args: extracts version"
+  (define-values (version context) ((dynamic-script 'parse-dry-run-args) '("--version" "0.99.40")))
+  (check-equal? version "0.99.40")
+  (check-equal? context 'tag-publish))
+
+(test-case "parse-dry-run-args: extracts context pre-tag"
+  (define-values (version context) ((dynamic-script 'parse-dry-run-args) '("--context" "pre-tag")))
+  (check-equal? context 'pre-tag))
+
+(test-case "parse-dry-run-args: extracts version and context together"
+  (define-values (version context)
+    ((dynamic-script 'parse-dry-run-args) '("--version" "1.0.0" "--context" "tag-publish")))
+  (check-equal? version "1.0.0")
+  (check-equal? context 'tag-publish))
+
+;; ============================================================
+;; Integration: dry-run checks
+;; ============================================================
+
+(test-case "dry-run-checks: all pass with valid project state"
+  ;; Provide mock implementations for file-exists?, file->string, run-subprocess
+  (define mock-file-exists?
+    (lambda (path)
+      (member path '("util/version.rkt" "CHANGELOG.md"))
+      #t))
+  (define mock-file->string
+    (lambda (path)
+      (cond
+        [(equal? path "util/version.rkt") "(define q-version \"0.99.40\")"]
+        [(equal? path "CHANGELOG.md") "## v0.99.40 — 2026-06-21\n\n- Changes\n"]
+        [else ""])))
+  (define mock-run-subprocess (lambda (cmd args) 0)) ; always succeeds
+  (define checks
+    ((dynamic-script 'dry-run-checks) "0.99.40"
+                                      'tag-publish
+                                      mock-file-exists?
+                                      mock-file->string
+                                      mock-run-subprocess))
+  (for ([c (in-list checks)])
+    (define result ((cdr c)))
+    (check-equal? (car result) 'pass (format "check ~a should pass" (car c)))))
+
+(test-case "dry-run-checks: fails on version mismatch"
+  (define mock-file-exists? (lambda (path) #t))
+  (define mock-file->string
+    (lambda (path)
+      (cond
+        [(equal? path "util/version.rkt") "(define q-version \"0.99.38\")"]
+        [else "## v0.99.38\n- Changes\n"])))
+  (define mock-run-subprocess (lambda (cmd args) 0))
+  (define checks
+    ((dynamic-script 'dry-run-checks) "0.99.40" ; requested version differs from canonical
+                                      'tag-publish
+                                      mock-file-exists?
+                                      mock-file->string
+                                      mock-run-subprocess))
+  ;; Find the version-match check
+  (define version-check (cdr (assoc "version-match" checks)))
+  (define result (version-check))
+  (check-equal? (car result) 'fail))
+
+(test-case "dry-run-checks: fails on missing CHANGELOG entry"
+  (define mock-file-exists? (lambda (path) #t))
+  (define mock-file->string
+    (lambda (path)
+      (cond
+        [(equal? path "util/version.rkt") "(define q-version \"0.99.40\")"]
+        [(equal? path "CHANGELOG.md") "## v0.99.39\n- Old changes\n"]
+        [else ""])))
+  (define mock-run-subprocess (lambda (cmd args) 0))
+  (define checks
+    ((dynamic-script 'dry-run-checks) "0.99.40"
+                                      'tag-publish
+                                      mock-file-exists?
+                                      mock-file->string
+                                      mock-run-subprocess))
+  ;; Find the changelog-entry check
+  (define changelog-check (cdr (assoc "changelog-entry" checks)))
+  (define result (changelog-check))
+  (check-equal? (car result) 'fail))
+
+(test-case "dry-run-checks: fails when release notes generation fails"
+  (define mock-file-exists? (lambda (path) #t))
+  (define mock-file->string
+    (lambda (path)
+      (cond
+        [(equal? path "util/version.rkt") "(define q-version \"0.99.40\")"]
+        [else "## v0.99.40\n- Changes\n"])))
+  (define mock-run-subprocess (lambda (cmd args) 1)) ; always fails
+  (define checks
+    ((dynamic-script 'dry-run-checks) "0.99.40"
+                                      'tag-publish
+                                      mock-file-exists?
+                                      mock-file->string
+                                      mock-run-subprocess))
+  (define notes-check (cdr (assoc "release-notes" checks)))
+  (define result (notes-check))
+  (check-equal? (car result) 'fail))
+
+;; ============================================================
+;; Script existence
+;; ============================================================
+
+(test-case "release-dry-run.rkt exists and compiles"
+  (check-true (file-exists? "../scripts/release-dry-run.rkt"))
+  (check-not-exn (lambda () (dynamic-require "../scripts/release-dry-run.rkt" #f))))
+
+(test-case "ci-local.rkt has --release-dry-run flag"
+  (check-true (file-exists? "../scripts/ci-local.rkt"))
+  (define content (file->string "../scripts/ci-local.rkt"))
+  (check-true (string-contains? content "--release-dry-run")))


### PR DESCRIPTION
Create `scripts/release-dry-run.rkt` for local release workflow validation. Validates version match, tag format, CHANGELOG entry, release notes generation, and manifest generation without creating tags or releases.

Add `--release-dry-run` flag to `ci-local.rkt`.

22 new tests covering pure logic, argument parsing, and mocked dry-run checks.

Closes #8520