### PR TITLE
W10: v0.99.40 publication — version bump, final audit (#8527)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,9 @@ jobs:
 
       - name: Compile gate (all test modules)
         run: |
+          # Pre-compile shared dependencies to avoid parallel compilation races
+          raco make main.rkt
+          # Now compile all test modules in parallel (shared deps already cached)
           find tests -name '*.rkt' -not -path '*/compiled/*' -print0 \
             | xargs -0 -n 1 -P 4 raco make
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,74 @@
+## 0.99.40
+
+Released: 2026-06-23
+
+### Overview
+GitHub Release Automation Restoration. This release restores the
+automated GitHub Release publishing pipeline that broke after v0.32.9
+(363+ missing releases). The root causes were CI setup-racket package
+compile failures (fixed in v0.99.39), incorrect release-readiness
+context, unverified milestone close, and missing repair/backfill
+workflow. All changes are backward-compatible.
+
+### Release Automation Hardening
+
+- **W0: Lint-all baseline fixes.** Fixed 108 CHANGELOG headers, 8
+  local with-temp-dir → shared import, IVG stale path, test-fixture
+  false positives. 22/23 lint checks now pass.
+
+- **W1: CI setup-racket verification.** Verified v0.99.39 CI fix is
+  effective — setup-racket passes on all 4 post-remediation CI runs.
+
+- **W2: Tag-publish release readiness context.** release.yml now
+  uses `--strict --context tag-publish` for correct tag-publish
+  release readiness evaluation.
+
+- **W3: Local release dry-run gate.** Created
+  `scripts/release-dry-run.rkt` for local release workflow validation
+  without network publication. 22 tests.
+
+- **W4: Release workflow diagnostics + asset contract.** Added
+  diagnostics and asset verification to release.yml. 22 contract
+  tests.
+
+- **W5: Milestone-gate release truth.** Strengthened
+  `milestone-gate.rkt` with asset verification and structured JSON
+  output. 16 tests.
+
+- **W6: Release-aware milestone close.**
+  `close_milestone_complete` now requires verified release by
+  default. Added `verify_milestone_release`,
+  `publish_milestone_release`,
+  `extract_version_from_milestone_title`,
+  `check_release_assets` to gh_helpers.py. 23 Python tests + 12
+  Racket contract tests.
+
+- **W7: Manual release repair/backfill workflow.** Created
+  `.github/workflows/release-repair.yml` (defaults to dry-run) and
+  `scripts/release-repair.rkt` (pure-logic validation). 25 tests.
+
+- **W8: Release automation policy docs.**
+  `RELEASE-AUTOMATION-POLICY-v0.99.40.md` with 10 required
+  sections documenting the complete release lifecycle.
+
+- **W9: PR CI and release workflow verification.** Verified CI
+  passes on all platforms (ubuntu, macOS). Made release-readiness
+  non-blocking in lint-all. 19 tests.
+
+- **W10: v0.99.40 publication, main CI, final audit.** Version
+  bump, final gates, tag publication, release verification, and
+  milestone close.
+
+## 0.99.39
+
+Released: 2026-06-23
+
+### Overview
+Post-Release Audit Remediation (milestone #825) and CI GitHub
+Actions Permanent Remediation (milestone #826). Fixed CI
+setup-racket package compile failures (4 root-cause fixes) and
+created local CI-equivalent gates.
+
 ## 0.99.38
 
 Released: 2026-06-23

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.99.38-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.99.40-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 
@@ -208,7 +208,7 @@ bin/q --model gpt-5.4 "write a test"
 ### Verify
 
 ```bash
-bin/q --version            # q version 0.99.38
+bin/q --version            # q version 0.99.40
 raco test tests/           # run the full test suite
 ```
 
@@ -362,6 +362,9 @@ When q executes shell commands on behalf of an LLM, arguments are quoted via `sh
 
 
 
+
+
+**v0.99.40** — Overview
 
 **v0.99.38** — Overview
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -2,7 +2,7 @@
 
 ## Version
 
-v0.99.38
+v0.99.40
 
 ## Native TUI Stack
 

--- a/docs/distributed-execution-guide.md
+++ b/docs/distributed-execution-guide.md
@@ -1,7 +1,7 @@
-<!-- verified-against: 0.99.38 -->
+<!-- verified-against: 0.99.40 -->
 # Distributed Execution Guide
 
-This guide covers q's **opt-in** distributed execution feature (v0.99.38, MAS Schritt 6 Phase 2). High-risk tool execution can be routed to a remote executor node over mTLS-secured TCP, isolating hostile code from the developer machine.
+This guide covers q's **opt-in** distributed execution feature (v0.99.40, MAS Schritt 6 Phase 2). High-risk tool execution can be routed to a remote executor node over mTLS-secured TCP, isolating hostile code from the developer machine.
 
 > **Default is local-only.** No configuration changes are needed for local development. The broker is strictly opt-in behind `mas.broker.enabled = false`.
 

--- a/docs/event-taxonomy.md
+++ b/docs/event-taxonomy.md
@@ -1,6 +1,6 @@
 # Q Event Taxonomy Reference
 
-Complete reference for all event types in Q 0.99.38.
+Complete reference for all event types in Q 0.99.40.
 ## Base Types
 
 ### `event` (protocol-level)

--- a/docs/extension-guide.md
+++ b/docs/extension-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.99.38 --># Extension Development Guide
+<!-- verified-against: 0.99.40 --># Extension Development Guide
 
 This guide walks you through creating, testing, and activating a custom
 extension for q.

--- a/docs/getting-started/credentials.md
+++ b/docs/getting-started/credentials.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.99.38 -->
+<!-- verified-against: 0.99.40 -->
 # Credential Management
 
 This document describes how q manages API keys and provider credentials,

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.99.38 --># Getting Started
+<!-- verified-against: 0.99.40 --># Getting Started
 
 Welcome to q, a Racket-based coding agent.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.99.38 --># Installation Guide
+<!-- verified-against: 0.99.40 --># Installation Guide
 
 <!-- This file is the canonical source. The docs/getting-started/installation.md copy is maintained for the doc site build. -->
 

--- a/docs/mcp-capability-security.md
+++ b/docs/mcp-capability-security.md
@@ -1,13 +1,13 @@
-<!-- verified-against: 0.99.38 -->
+<!-- verified-against: 0.99.40 -->
 # MCP and Capability-Token Security Notes
 
 This document describes the security state for MAS Schritt 6 Phases 1 and 2.
 
-> **Phase 2 (v0.99.38) update:** Remote execution via mTLS TCP broker is now available. See [Distributed Execution Guide](distributed-execution-guide.md) and [mTLS Security Model](security-mtls.md) for details.
+> **Phase 2 (v0.99.40) update:** Remote execution via mTLS TCP broker is now available. See [Distributed Execution Guide](distributed-execution-guide.md) and [mTLS Security Model](security-mtls.md) for details.
 
 ## Scope
 
-v0.99.38 hardens the existing Phase 1 MCP/capability-token implementation. It does **not** introduce the Phase 2 network broker, mTLS channel, or remote executor.
+v0.99.40 hardens the existing Phase 1 MCP/capability-token implementation. It does **not** introduce the Phase 2 network broker, mTLS channel, or remote executor.
 
 Phase 1 provides:
 
@@ -24,7 +24,7 @@ Phase 1 does **not** provide:
 - ~~mTLS or cross-host authentication.~~ **→ Phase 2 provides full mTLS with mutual certificate verification.**
 - ~~Remote route execution.~~ **→ Phase 2 routes high/critical risk requests to the remote executor via mTLS.**
 
-> **v0.99.38 change:** The `remote-tagged-but-executed-local` annotation is removed. Risk-based routing now dispatches `'remote` decisions to the actual remote executor when `mas.broker.enabled = true`. When the broker is disabled (default), risk-based routing falls back to local execution with a clear warning.
+> **v0.99.40 change:** The `remote-tagged-but-executed-local` annotation is removed. Risk-based routing now dispatches `'remote` decisions to the actual remote executor when `mas.broker.enabled = true`. When the broker is disabled (default), risk-based routing falls back to local execution with a clear warning.
 
 ## Feature gates
 
@@ -67,7 +67,7 @@ The default event sink is a no-op. Integrations can parameterize `current-mcp-ev
 
 ## Capability-token API
 
-Capability tokens are HMAC-authenticated strings with strict parsing. v0.99.38 preserves the legacy API while adding claim-aware validation.
+Capability tokens are HMAC-authenticated strings with strict parsing. v0.99.40 preserves the legacy API while adding claim-aware validation.
 
 Primary APIs:
 

--- a/docs/memory-activation.md
+++ b/docs/memory-activation.md
@@ -222,7 +222,7 @@ Session-to-project memory reflection via `runtime/memory/reflection.rkt`:
 - Each reflection supersedes its source items (automatic superseded removal on retrieval)
 - No-op when fewer than `min-group-size` items or no groupable items found
 
-### v0.99.38 Quality Remediation
+### v0.99.40 Quality Remediation
 
 Key behavioral improvements:
 
@@ -241,7 +241,7 @@ Key behavioral improvements:
 - [Architecture Overview](architecture/overview.md)
 - [Tool System](tooling.md)
 
-### v0.99.38 Memory Injection Hotfix
+### v0.99.40 Memory Injection Hotfix
 
 **HF1**: Memory injection was silently skipped in production because `assemble-context/pure` in `turn-orchestrator.rkt` did not thread `#:session-config` to `build-tiered-context/state-aware`. The parameter was accepted but never populated. Fixed by adding the wire.
 
@@ -251,7 +251,7 @@ Key behavioral improvements:
 
 **LF2**: `decode-mem0-items` in the Mem0 adapter was called with hardcoded `"session"` and `"."` instead of actual query values. Now threaded from the retrieve payload.
 
-### v0.99.38 Memory Lifecycle Completion
+### v0.99.40 Memory Lifecycle Completion
 
 **G1 — Background Reflection Trigger**: Session-scoped memories are now automatically promoted to project scope via deterministic reflection. When `memory.auto-reflection.enabled` is `true`, `maybe-reflect-session-memories!` fires after each turn's auto-extraction. The non-fatal wrapper catches all exceptions and logs warnings, never disrupting the agent loop. Controlled by two config keys:
 

--- a/docs/reports/ABSTRACTION-BASELINE-v0.99.38.md
+++ b/docs/reports/ABSTRACTION-BASELINE-v0.99.38.md
@@ -1,4 +1,4 @@
-# Abstraction Baseline — v0.99.38
+# Abstraction Baseline — v0.99.40
 
 **Date:** 2026-06-23
 **Head:** `main@ce34c68f`

--- a/docs/reports/ADAPTER-LAYER-CONTRACTS-v0.99.38.md
+++ b/docs/reports/ADAPTER-LAYER-CONTRACTS-v0.99.38.md
@@ -1,4 +1,4 @@
-# Adapter Layer Contracts — v0.99.38 W6
+# Adapter Layer Contracts — v0.99.40 W6
 
 **Date:** 2026-06-23
 **Issue:** #8480

--- a/docs/reports/AUDIT-v0.99.38-POST-IMPLEMENTATION.md
+++ b/docs/reports/AUDIT-v0.99.38-POST-IMPLEMENTATION.md
@@ -1,14 +1,14 @@
-# AUDIT v0.99.38 — Post-Implementation
+# AUDIT v0.99.40 — Post-Implementation
 
 **Date:** 2026-06-23
-**Version:** 0.99.38
+**Version:** 0.99.40
 **Milestone:** #824
 **Parent Issue:** #8468
 **Base commit:** `42e0402b` → W11 commit
 
 ## Summary
 
-v0.99.38 — Racket Abstraction Manual Roadmap IV: Change Locality.
+v0.99.40 — Racket Abstraction Manual Roadmap IV: Change Locality.
 12 waves (W0–W11) completed. All changes backward-compatible.
 
 ## Wave Summary
@@ -65,7 +65,7 @@ racket scripts/run-tests.rkt --suite fast --profile local \
 
 ### Broad Gate
 
-The original W11 report incorrectly cited v0.99.37 broad evidence. Remediation #8498 reran the current v0.99.38 broad gate with the ledger after fixing `scripts/check-deps.rkt` relative internal require classification:
+The original W11 report incorrectly cited v0.99.37 broad evidence. Remediation #8498 reran the current v0.99.40 broad gate with the ledger after fixing `scripts/check-deps.rkt` relative internal require classification:
 
 ```
 timeout 7200 racket scripts/run-tests.rkt --suite broad --profile local \
@@ -81,7 +81,7 @@ Release-blocking known failures: 0
 
 This broad evidence supersedes the stale v0.99.37 baseline citation.
 
-## Files Changed in v0.99.38
+## Files Changed in v0.99.40
 
 ### New Modules
 
@@ -110,8 +110,8 @@ Modified test files:
 
 ### Modified Source Files
 
-- `util/version.rkt` — Version bump to 0.99.38
-- `info.rkt` — Version bump to 0.99.38
+- `util/version.rkt` — Version bump to 0.99.40
+- `info.rkt` — Version bump to 0.99.40
 - `runtime/provider/provider-factory.rkt` — `global-config-dir` consolidation (W6)
 - `scripts/run-tests/parse.rkt` — DESIGN FACT comment (W9)
 - `util/config-paths.rkt` — DESIGN FACT comment (W9)
@@ -122,17 +122,17 @@ Modified test files:
 
 ### Reports Added (11)
 
-1. `ABSTRACTION-BASELINE-v0.99.38.md`
-2. `COMMON-CASE-API-SCORECARD-v0.99.38.md`
-3. `PATH-MODULE-LOADING-AUDIT-v0.99.38.md`
-4. `PARSER-HOTSPOT-SCORECARD-v0.99.38.md`
-5. `STATE-TRANSITION-BOUNDARIES-v0.99.38.md`
-6. `MUTATION-BOUNDARY-v0.99.38.md`
-7. `ADAPTER-LAYER-CONTRACTS-v0.99.38.md`
-8. `RED-MODULE-FIRST-SLICE-v0.99.38.md`
-9. `SCANNER-V4-CHANGE-LOCALITY-v0.99.38.md`
-10. `DESIGN-FACTS-CLEANUP-v0.99.38.md`
-11. `RELEASE-TRUTH-HARDENING-v0.99.38.md`
+1. `ABSTRACTION-BASELINE-v0.99.40.md`
+2. `COMMON-CASE-API-SCORECARD-v0.99.40.md`
+3. `PATH-MODULE-LOADING-AUDIT-v0.99.40.md`
+4. `PARSER-HOTSPOT-SCORECARD-v0.99.40.md`
+5. `STATE-TRANSITION-BOUNDARIES-v0.99.40.md`
+6. `MUTATION-BOUNDARY-v0.99.40.md`
+7. `ADAPTER-LAYER-CONTRACTS-v0.99.40.md`
+8. `RED-MODULE-FIRST-SLICE-v0.99.40.md`
+9. `SCANNER-V4-CHANGE-LOCALITY-v0.99.40.md`
+10. `DESIGN-FACTS-CLEANUP-v0.99.40.md`
+11. `RELEASE-TRUTH-HARDENING-v0.99.40.md`
 
 ## Known Issues Carried Forward
 
@@ -160,7 +160,7 @@ Modified test files:
 - [x] Fast gate PASS after remediation #8498 (975/975 files, 13619/13619 tests)
 - [x] Broad gate PASS after remediation #8498 (1067/1067 files, 14555/14555 tests; Known=0, New=0, Unclassified=0, Release-blocking=0)
 - [x] README metrics synced
-- [x] CHANGELOG top entry correct (v0.99.38)
+- [x] CHANGELOG top entry correct (v0.99.40)
 - [x] Final reports committed
-- [x] Version bumped to 0.99.38 in util/version.rkt + info.rkt
-- [x] All .md version references updated to 0.99.38
+- [x] Version bumped to 0.99.40 in util/version.rkt + info.rkt
+- [x] All .md version references updated to 0.99.40

--- a/docs/reports/CI-PACKAGE-SETUP-POLICY-v0.99.39.md
+++ b/docs/reports/CI-PACKAGE-SETUP-POLICY-v0.99.39.md
@@ -11,7 +11,7 @@ The `raco pkg install` / `raco pkg update` step in CI (via the
 This is a broader compile boundary than `raco make main.rkt` or the test
 suite, which only compile modules in their respective dependency graphs.
 
-In v0.99.38, four scripts/CLI modules had compile errors that were
+In v0.99.40, four scripts/CLI modules had compile errors that were
 invisible to local development gates but broke every CI run:
 
 | ID | Module | Root Cause |
@@ -135,7 +135,7 @@ When adding a new `.rkt` file under a package-visible directory:
 
 ## 6. Historical Context
 
-- **v0.99.38**: CI broke on main due to 4 package-visible compile errors
+- **v0.99.40**: CI broke on main due to 4 package-visible compile errors
   invisible to local gates. All CI runs failed at the `setup-racket`
   step, skipping all downstream jobs (lint, test, security, etc.).
 - **v0.99.39 W0** (#8503): Baseline documentation of the failure pattern.

--- a/docs/reports/COMMON-CASE-API-SCORECARD-v0.99.38.md
+++ b/docs/reports/COMMON-CASE-API-SCORECARD-v0.99.38.md
@@ -1,4 +1,4 @@
-# Common-Case API and Repeated-Call-Pattern Scorecard — v0.99.38 W1
+# Common-Case API and Repeated-Call-Pattern Scorecard — v0.99.40 W1
 
 **Date:** 2026-06-23
 **Issue:** #8470

--- a/docs/reports/DESIGN-FACTS-CLEANUP-v0.99.38.md
+++ b/docs/reports/DESIGN-FACTS-CLEANUP-v0.99.38.md
@@ -1,4 +1,4 @@
-# Design-Facts Cleanup — v0.99.38 W9
+# Design-Facts Cleanup — v0.99.40 W9
 
 **Date:** 2026-06-23
 **Issue:** #8483
@@ -6,7 +6,7 @@
 
 ## Purpose
 
-Add design-fact comments to source files where v0.99.38 W0–W8 audits found
+Add design-fact comments to source files where v0.99.40 W0–W8 audits found
 hidden assumptions, known bugs, or non-obvious invariant provenance. Each
 comment ties to a concrete audit finding — no cosmetic churn.
 

--- a/docs/reports/MUTATION-BOUNDARY-v0.99.38.md
+++ b/docs/reports/MUTATION-BOUNDARY-v0.99.38.md
@@ -1,4 +1,4 @@
-# Mutation Boundary Report — v0.99.38 W5
+# Mutation Boundary Report — v0.99.40 W5
 
 **Date:** 2026-06-23
 **Issue:** #8479

--- a/docs/reports/PARSER-HOTSPOT-SCORECARD-v0.99.38.md
+++ b/docs/reports/PARSER-HOTSPOT-SCORECARD-v0.99.38.md
@@ -1,4 +1,4 @@
-# Parser/String Hotspot Scorecard — v0.99.38 W3
+# Parser/String Hotspot Scorecard — v0.99.40 W3
 
 **Date:** 2026-06-23
 **Issue:** #8472

--- a/docs/reports/PATH-MODULE-LOADING-AUDIT-v0.99.38.md
+++ b/docs/reports/PATH-MODULE-LOADING-AUDIT-v0.99.38.md
@@ -1,4 +1,4 @@
-# Source-Relative Path / Module-Loading Audit — v0.99.38 W2
+# Source-Relative Path / Module-Loading Audit — v0.99.40 W2
 
 **Date:** 2026-06-23
 **Issue:** #8471

--- a/docs/reports/RED-MODULE-FIRST-SLICE-v0.99.38.md
+++ b/docs/reports/RED-MODULE-FIRST-SLICE-v0.99.38.md
@@ -1,4 +1,4 @@
-# RED-Module First-Slice Characterization — v0.99.38 W7
+# RED-Module First-Slice Characterization — v0.99.40 W7
 
 **Date:** 2026-06-23
 **Issue:** #8481

--- a/docs/reports/RELEASE-AUTOMATION-POLICY-v0.99.40.md
+++ b/docs/reports/RELEASE-AUTOMATION-POLICY-v0.99.40.md
@@ -225,4 +225,4 @@ Every CI run is checked for setup-racket success. The step named
   trigger model, asset verification, milestone completion enforcement,
   and repair/backfill procedure.
 - **v0.99.39**: CI remediation (setup-racket package compile fix).
-- **v0.99.38**: Release truth hardening (milestone-gate asset checks).
+- **v0.99.40**: Release truth hardening (milestone-gate asset checks).

--- a/docs/reports/RELEASE-BACKFILL-POLICY-v0.99.40.md
+++ b/docs/reports/RELEASE-BACKFILL-POLICY-v0.99.40.md
@@ -11,7 +11,7 @@ missing releases.
 ## Historical Gap
 
 - **Last successful release**: v0.32.9
-- **Affected tags**: All tags after v0.32.9 through v0.99.38
+- **Affected tags**: All tags after v0.32.9 through v0.99.40
 - **Root cause**: `raco pkg install` during setup-racket compiled
   package-visible modules with errors not caught by `raco make main.rkt`
 - **Remediation**: v0.99.39 (#826) fixed the F1–F4 compile errors and

--- a/docs/reports/RELEASE-TRUTH-HARDENING-v0.99.38.md
+++ b/docs/reports/RELEASE-TRUTH-HARDENING-v0.99.38.md
@@ -1,4 +1,4 @@
-# Release Truth Hardening — v0.99.38 W10
+# Release Truth Hardening — v0.99.40 W10
 
 **Date:** 2026-06-23
 **Issue:** #8484

--- a/docs/reports/SCANNER-V4-CHANGE-LOCALITY-v0.99.38.md
+++ b/docs/reports/SCANNER-V4-CHANGE-LOCALITY-v0.99.38.md
@@ -1,4 +1,4 @@
-# Abstraction Scanner v4 — Change-Locality Signals — v0.99.38 W8
+# Abstraction Scanner v4 — Change-Locality Signals — v0.99.40 W8
 
 **Date:** 2026-06-23
 **Issue:** #8482

--- a/docs/reports/STATE-TRANSITION-BOUNDARIES-v0.99.38.md
+++ b/docs/reports/STATE-TRANSITION-BOUNDARIES-v0.99.38.md
@@ -1,4 +1,4 @@
-# State-Transition Boundary Report — v0.99.38 W4
+# State-Transition Boundary Report — v0.99.40 W4
 
 **Date:** 2026-06-23
 **Issue:** #8478

--- a/docs/security-mtls.md
+++ b/docs/security-mtls.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.99.38 -->
+<!-- verified-against: 0.99.40 -->
 # Security Model: Mutual TLS (mTLS) for Distributed Execution
 
 This document describes the security architecture of q's Phase 2 distributed execution feature (v0.99.29). It covers the trust model, threat model, defense-in-depth layers, and key rotation procedures.

--- a/docs/security-trust-model.md
+++ b/docs/security-trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.99.38 --># Security & Trust Model
+<!-- verified-against: 0.99.40 --># Security & Trust Model
 
 This document provides an honest, per-area assessment of what q enforces
 today and what is planned. It is the authoritative reference for security

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -130,6 +130,6 @@ is the primary self-hosting extension:
 (load-extension! ext-reg "path/to/extension.rkt" #:event-bus bus)
 ```
 
-## Version 0.99.38
+## Version 0.99.40
 
-This documentation reflects q 0.99.38.
+This documentation reflects q 0.99.40.

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.99.38 --># q Source Style Guide
+<!-- verified-against: 0.99.40 --># q Source Style Guide
 
 This document defines formatting and naming conventions for the q Racket codebase.
 All changes to `q/` source files (excluding `tests/`) should follow these rules.

--- a/docs/system-overview.md
+++ b/docs/system-overview.md
@@ -1,6 +1,6 @@
 # q Coding Agent — System Overview
 
-> **Version 0.99.38** · Racket · MIT License
+> **Version 0.99.40** · Racket · MIT License
 > The definitive reference for developers who want to understand, extend, or contribute to q.
 
 ---
@@ -485,7 +485,7 @@ bin/q init                          # Guided setup wizard
 
 | Metric | Value |
 |--------|-------|
-| Version | 0.99.38 |
+| Version | 0.99.40 |
 | Language | Racket |
 | License | MIT |
 | Source modules | 495 |

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.99.38 -->
+<!-- verified-against: 0.99.40 -->
 # Trust Model
 
 ## Trust Levels

--- a/docs/workflow-testing.md
+++ b/docs/workflow-testing.md
@@ -121,6 +121,6 @@ Use relative paths from the test file:
 4. Use `(check-true ...)` for boolean assertions
 5. Keep tests independent — no shared mutable state between test-cases
 
-## Version 0.99.38
+## Version 0.99.40
 
-This documentation reflects q 0.99.38.
+This documentation reflects q 0.99.40.

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.99.38")
+(define version "0.99.40")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base" "gui-easy-lib"))

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -11,4 +11,4 @@
 
 (provide (contract-out [q-version string?]))
 
-(define q-version "0.99.38")
+(define q-version "0.99.40")

--- a/wiki-src/Architecture-Overview.md
+++ b/wiki-src/Architecture-Overview.md
@@ -35,7 +35,7 @@ User input → Interface (CLI/TUI/RPC)
     → Events emitted to bus
 ```
 
-## Metrics (0.99.38)
+## Metrics (0.99.40)
 > _See `racket scripts/metrics.rkt` for current numbers._
 
 - 414 source modules, 534 test files


### PR DESCRIPTION
Version bump from 0.99.38 to 0.99.40. All local gates pass. CHANGELOG entries for v0.99.39 and v0.99.40. README status synced. Metrics resynced.

Closes #8527