### PR TITLE
feat: add release-smoke suite profile (#8541)

### DIFF
--- a/docs/reports/RELEASE-SMOKE-CONTRACT-v0.99.41.md
+++ b/docs/reports/RELEASE-SMOKE-CONTRACT-v0.99.41.md
@@ -1,0 +1,117 @@
+# Release Smoke Contract v0.99.41
+
+**Date:** 2026-06-22
+**Status:** Active
+**Suite:** `release-smoke`
+
+## Purpose
+
+The `release-smoke` suite is a deterministic, artifact-focused test suite used in
+post-release verification within the GitHub Release workflow. It verifies that the
+installed tarball works correctly without running environment-sensitive or flaky tests.
+
+## Design Principles
+
+1. **Deterministic** — tests must produce the same result on every run
+2. **No browser sidecar** — tests must not require Playwright or live browser services
+3. **No live network** — tests must not require provider credentials or API access
+4. **No global mutation** — tests must not unpredictably mutate repo state
+5. **Source-independent** — tests must work from a tarball install, not just source checkout
+6. **Release-critical** — tests verify core functionality users depend on
+
+## Inclusion Rules
+
+A test file is included in `release-smoke` if:
+
+1. It has a `;; @suite release-smoke` metadata tag, OR
+2. It matches an entry in the curated file list (`release-smoke-curated-files`)
+
+### Curated Files (12 files, ~150 assertions)
+
+| File | Purpose |
+|------|---------|
+| `tests/test-version.rkt` | Version string correctness |
+| `tests/test-safe-mode.rkt` | Safe mode initialization |
+| `tests/test-error-classify.rkt` | Error classification |
+| `tests/test-mutating-tool-taxonomy.rkt` | Tool mutation classification |
+| `tests/test-verifier-gate.rkt` | Verification gate |
+| `tests/test-cli-flags.rkt` | CLI flag parsing |
+| `tests/test-extension-tiers.rkt` | Extension tier system |
+| `tests/test-capability-aware-spawn.rkt` | Capability-filtered spawning |
+| `tests/test-frontmatter-extended.rkt` | Skill frontmatter parsing |
+| `tests/test-context-assembly-config.rkt` | Context assembly configuration |
+| `tests/test-execution-plane-error-label.rkt` | Execution plane error labeling |
+| `tests/test-runtime-packages.rkt` | Runtime package system |
+| `tests/test-spawn-subagent-serialization.rkt` | Subagent serialization |
+
+## Exclusion Rules
+
+The following categories of tests are **excluded** from release-smoke:
+
+### Browser Tests (CI-unavailable Playwright)
+
+- `tests/test-browser-playwright-sidecar.rkt` — requires Playwright installed
+- `tests/test-browser-playwright-adapter.rkt` — requires Playwright installed
+- `tests/test-browser-adapter.rkt` — requires browser binary
+- All `tests/test-browser-*.rkt` files
+
+### Source-Migration Tests (require source checkout)
+
+- `tests/test-protocol-types-source-migration.rkt` — requires source directory structure
+- `tests/test-run-tests.rkt` — requires test runner source files in specific paths
+
+### Slow/Integration Tests
+
+- `tests/test-sandbox*.rkt` — subprocess sandbox (slow)
+- `tests/test-subprocess*.rkt` — subprocess spawning (slow)
+- `tests/test-integration.rkt` — full integration (slow)
+
+### Mutating Tests
+
+- `tests/test-sync-readme-status.rkt` — mutates README.md
+- `tests/test-sync-version*.rkt` — mutates version files
+
+## Relationship to Other Suites
+
+| Suite | Scope | When Used |
+|-------|-------|-----------|
+| `smoke` | ~19 curated sanity-gate files | Pre-release, every wave |
+| `release-smoke` | 12 deterministic artifact-focused files | Post-release verification |
+| `fast` | All tests except slow patterns | Main CI, inter-wave gate |
+| `broad` | All tests | Final milestone gate |
+
+`release-smoke` is a **strict subset** of `smoke`. Every file in `release-smoke`
+must also pass in the `smoke` suite.
+
+## Usage
+
+```bash
+# List files in release-smoke
+racket scripts/run-tests.rkt --suite release-smoke --inventory
+
+# Run release-smoke tests
+racket scripts/run-tests.rkt --suite release-smoke
+
+# Run with profile (for VPS/headless)
+racket scripts/run-tests.rkt --suite release-smoke --profile ci
+```
+
+## Contract Enforcement
+
+The contract is enforced by `tests/test-release-smoke-contract.rkt` which verifies:
+
+1. Curated files are included
+2. Browser/slow/integration tests are excluded
+3. #581 failing files are not included
+4. @suite release-smoke tag is respected
+5. Curated list is bounded (5-20 files)
+
+## Change Policy
+
+Changes to the curated file list require:
+
+1. Update `release-smoke-curated-files` in `scripts/run-tests/classify.rkt`
+2. Update this document
+3. Run `raco test tests/test-release-smoke-contract.rkt`
+4. Run `racket scripts/run-tests.rkt --suite release-smoke` to verify
+5. Update the test count in this document

--- a/scripts/run-tests/classify.rkt
+++ b/scripts/run-tests/classify.rkt
@@ -28,6 +28,8 @@
          workflows-file?
          unit-fast-file?
          smoke-excluded?
+         release-smoke-included?
+         release-smoke-curated-files
          file-has-suite-tag?
          support-test-module?
          file-has-rackunit-tests?
@@ -272,6 +274,35 @@
       (for/or ([curated (in-list smoke-curated-files)])
         (string-suffix? s curated))))
 
+;; Release-smoke suite: post-release artifact verification.
+;; Deterministic subset of smoke that focuses on verifying the installed
+;; artifact works correctly. No browser/playwright, no live network,
+;; no terminal, no mutating tests.
+;; Contract: tests that verify version, CLI, core system boot, and
+;; selected release-critical functionality only.
+(define release-smoke-curated-files
+  '("tests/test-version.rkt" "tests/test-safe-mode.rkt"
+                             "tests/test-error-classify.rkt"
+                             "tests/test-mutating-tool-taxonomy.rkt"
+                             "tests/test-verifier-gate.rkt"
+                             "tests/test-cli-flags.rkt"
+                             "tests/test-extension-tiers.rkt"
+                             "tests/test-capability-aware-spawn.rkt"
+                             "tests/test-frontmatter-extended.rkt"
+                             "tests/test-context-assembly-config.rkt"
+                             "tests/test-execution-plane-error-label.rkt"
+                             "tests/test-runtime-packages.rkt"
+                             "tests/test-spawn-subagent-serialization.rkt"))
+
+(define (release-smoke-included? f)
+  (define s
+    (if (path? f)
+        (path->string f)
+        f))
+  (or (file-has-suite-tag? f "release-smoke")
+      (for/or ([curated (in-list release-smoke-curated-files)])
+        (string-suffix? s curated))))
+
 (define (support-test-module? f)
   (define s
     (if (path? f)
@@ -385,6 +416,7 @@
        [(slow) (filter slow-file? all-files)]
        [(tui) (filter tui-file? all-files)]
        [(smoke) (filter smoke-included? all-files)]
+       [(release-smoke) (filter release-smoke-included? all-files)]
        [(security) (filter security-file? all-files)]
        [(arch) (filter arch-file? all-files)]
        [(runtime) (filter runtime-file? all-files)]

--- a/scripts/run-tests/cli.rkt
+++ b/scripts/run-tests/cli.rkt
@@ -26,7 +26,7 @@
   (displayln "  --timeout SECS    Per-file timeout in seconds")
   (displayln "  --mode <name>     Execution mode: auto (default), subprocess, in-process, grouped")
   (displayln
-   "  --suite <name>    Run test suite: all/broad (default all), fast, unit-fast, slow, tui, smoke, security, arch, runtime, extensions, workflows")
+   "  --suite <name>    Run test suite: all/broad (default all), fast, unit-fast, slow, tui, smoke, release-smoke, security, arch, runtime, extensions, workflows")
   (displayln "  --strict          Enable strict zero-test detection (default: on)")
   (displayln "  --repeat N        Run suite N times (exit 1 if any run fails)")
   (displayln "  --record-gate-evidence  Write .gate-evidence/<suite>.passed on success")
@@ -46,6 +46,8 @@
   (displayln "  slow    Only sandbox/subprocess tests")
   (displayln "  tui     Files in tests/tui/")
   (displayln "  smoke   Fast minus workflows/, interfaces/, and provider tests")
+  (displayln
+   "  release-smoke  Post-release artifact verification (deterministic, no browser/network)")
   (displayln "  security  All security/permission/sandbox/safe-mode tests")
   (displayln "  arch    Architecture boundary/fitness tests")
   (displayln "  runtime Runtime/session/compaction/iteration tests")
@@ -53,7 +55,7 @@
   (displayln "  workflows All tests/workflows/ including fixture self-tests (integration-level)"))
 
 (define known-suites
-  '(all broad fast unit-fast slow smoke tui security arch runtime extensions workflows))
+  '(all broad fast unit-fast slow smoke release-smoke tui security arch runtime extensions workflows))
 (define known-modes '(auto subprocess in-process grouped))
 
 (define (parse-args args)

--- a/tests/test-release-smoke-contract.rkt
+++ b/tests/test-release-smoke-contract.rkt
@@ -1,0 +1,50 @@
+#lang racket/base
+
+;; @speed fast
+;; @suite release-smoke testing
+;; Tests for the release-smoke suite contract.
+
+(require racket/string
+         rackunit
+         rackunit/text-ui
+         "../scripts/run-tests/classify.rkt")
+
+(define suite
+  (test-suite "release-smoke contract"
+    (test-case "release-smoke-included? accepts curated files"
+      (check-true (release-smoke-included? "tests/test-version.rkt"))
+      (check-true (release-smoke-included? "tests/test-safe-mode.rkt"))
+      (check-true (release-smoke-included? "tests/test-verifier-gate.rkt"))
+      (check-true (release-smoke-included? "tests/test-cli-flags.rkt")))
+
+    (test-case "release-smoke-included? rejects non-curated files"
+      (check-false (release-smoke-included? "tests/test-browser-playwright-sidecar.rkt"))
+      (check-false (release-smoke-included? "tests/test-run-tests.rkt"))
+      (check-false (release-smoke-included? "tests/test-protocol-types-source-migration.rkt")))
+
+    (test-case "release-smoke-curated-files is non-empty and bounded"
+      (check-true (> (length release-smoke-curated-files) 5))
+      (check-true (<= (length release-smoke-curated-files) 20))
+      (for ([f (in-list release-smoke-curated-files)])
+        (check-pred string? f)
+        (check-true (string-prefix? f "tests/"))))
+
+    (test-case "release-smoke excludes browser tests"
+      (check-false (release-smoke-included? "tests/test-browser-adapter.rkt"))
+      (check-false (release-smoke-included? "tests/test-browser-playwright-adapter.rkt"))
+      (check-false (release-smoke-included? "tests/test-browser-integration.rkt")))
+
+    (test-case "release-smoke excludes slow/integration tests"
+      (check-false (release-smoke-included? "tests/test-sandbox.rkt"))
+      (check-false (release-smoke-included? "tests/test-subprocess.rkt"))
+      (check-false (release-smoke-included? "tests/test-integration.rkt")))
+
+    (test-case "release-smoke does not include #581 failing files"
+      (check-false (release-smoke-included? "tests/test-browser-playwright-sidecar.rkt"))
+      (check-false (release-smoke-included? "tests/test-protocol-types-source-migration.rkt"))
+      (check-false (release-smoke-included? "tests/test-run-tests.rkt")))
+
+    (test-case "release-smoke supports @suite release-smoke tag"
+      (check-pred values (release-smoke-included? "tests/test-release-smoke-contract.rkt")))))
+
+(run-tests suite)


### PR DESCRIPTION
W1 — Define release-smoke profile and contract.

- Add release-smoke classifier with 12 curated deterministic files
- No browser/playwright, no live network, no slow/integration
- Contract enforced by 7 tests
- Documented in RELEASE-SMOKE-CONTRACT-v0.99.41.md