### PR TITLE
feat: make manifest verification mandatory in release smoke (#8542)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -226,25 +226,61 @@ jobs:
           echo "$OUTPUT"
           echo "$OUTPUT" | grep -q "version ${VERSION}"
 
-      - name: Verify manifest
+      - name: Verify manifest (mandatory)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EXPECTED_VERSION: ${{ steps.download.outputs.VERSION }}
         run: |
-          VERSION="${{ steps.download.outputs.VERSION }}"
           TAG="${GITHUB_REF#refs/tags/}"
-          curl -sfL -H "Authorization: token $GH_TOKEN" -H "Accept: application/octet-stream" \
-            -o /tmp/release-manifest.json \
-            "https://api.github.com/repos/${{ github.repository }}/releases/download/${TAG}/release-manifest.json" || true
-          if [ -f /tmp/release-manifest.json ] && [ -s /tmp/release-manifest.json ]; then
-            python3 -c "
-          import json
-          m = json.load(open('/tmp/release-manifest.json'))
-          assert m['version'] == '${VERSION}', f\"manifest version {m['version']} != expected ${VERSION}\"
-          print(f'Manifest OK: version={m[\"version\"]}')
-          "
-          else
-            echo "No release-manifest.json found (optional)"
+          # Look up release by tag to find manifest asset URL
+          RELEASE_DATA=$(curl -sf -H "Authorization: token $GH_TOKEN" \
+            "https://api.github.com/repos/${{ github.repository }}/releases/tags/${TAG}")
+          if [ -z "$RELEASE_DATA" ]; then
+            echo "ERROR: Release for tag ${TAG} not found"
+            exit 1
           fi
+          # Find manifest asset URL via asset API
+          MANIFEST_URL=$(echo "$RELEASE_DATA" | jq -r '.assets[] | select(.name=="release-manifest.json") | .url')
+          if [ -z "$MANIFEST_URL" ] || [ "$MANIFEST_URL" = "null" ]; then
+            echo "ERROR: release-manifest.json asset not found in release ${TAG}"
+            exit 1
+          fi
+          # Download manifest via asset API (binary/octet-stream)
+          curl -sfL -H "Authorization: token $GH_TOKEN" -H "Accept: application/octet-stream" \
+            -o /tmp/release-manifest.json "$MANIFEST_URL"
+          if [ ! -s /tmp/release-manifest.json ]; then
+            echo "ERROR: release-manifest.json is empty or download failed"
+            exit 1
+          fi
+          # Verify manifest fields (version, tag, tarball, sha256)
+          echo "$EXPECTED_VERSION" > /tmp/expected-version.txt
+          python3 << 'PYEOF'
+          import json, hashlib, os
+          ev = open('/tmp/expected-version.txt').read().strip()
+          et = 'q-' + ev + '.tar.gz'
+          m = json.load(open('/tmp/release-manifest.json'))
+          # Version is mandatory
+          assert m['version'] == ev, 'manifest version mismatch: %s != %s' % (m['version'], ev)
+          print('Manifest version OK:', m['version'])
+          # Tag must match
+          etag = 'v' + ev
+          assert m.get('tag') == etag, 'manifest tag mismatch: %s != %s' % (m.get('tag'), etag)
+          print('Manifest tag OK:', m['tag'])
+          # Tarball asset name must match
+          assets = m.get('assets', [])
+          assert len(assets) > 0, 'manifest has no assets'
+          tarball_asset = assets[0]
+          assert tarball_asset['name'] == et, 'manifest tarball name mismatch: %s != %s' % (tarball_asset['name'], et)
+          print('Manifest tarball OK:', tarball_asset['name'])
+          # SHA256 verification if tarball is locally available
+          if 'sha256' in tarball_asset:
+              tarball_path = '/tmp/q-' + ev + '.tar.gz'
+              if os.path.exists(tarball_path):
+                  h = hashlib.sha256(open(tarball_path, 'rb').read()).hexdigest()
+                  assert h == tarball_asset['sha256'], 'sha256 mismatch: %s != %s' % (h, tarball_asset['sha256'])
+                  print('Manifest sha256 OK:', tarball_asset['sha256'])
+          print('All manifest checks passed.')
+          PYEOF
 
       - name: Run test suite
         run: |

--- a/tests/test-release-workflow-contract.rkt
+++ b/tests/test-release-workflow-contract.rkt
@@ -172,3 +172,67 @@
   (for ([line (in-list lines)]
         [i (in-naturals 1)])
     (check-false (string-contains? line "\t") (format "tab found at line ~a" i))))
+
+;; ============================================================
+;; W2: Mandatory manifest verification contract tests
+;; ============================================================
+
+(test-case "release.yml smoke job verifies manifest as mandatory"
+  (define content (read-release-yml))
+  (check-true (string-contains? content "Verify manifest (mandatory)")
+              "smoke job must have 'Verify manifest (mandatory)' step"))
+
+(test-case "release.yml does not contain optional manifest wording"
+  (define content (read-release-yml))
+  (check-false (string-contains? content "No release-manifest.json found (optional)")
+               "smoke job must NOT treat manifest as optional"))
+
+(test-case "release.yml smoke manifest verification has failing path for missing manifest"
+  (define content (read-release-yml))
+  ;; Must have explicit error + exit 1 for missing manifest
+  (check-true (string-contains? content "ERROR: release-manifest.json")
+              "must have ERROR message for missing manifest")
+  ;; Must have exit 1 for manifest failure
+  (check-true (string-contains? content "exit 1") "must have exit 1 for manifest failures"))
+
+(test-case "release.yml smoke manifest verifies version field"
+  (define content (read-release-yml))
+  (check-true (string-contains? content "manifest version mismatch")
+              "must verify manifest version field"))
+
+(test-case "release.yml smoke manifest verifies tag field"
+  (define content (read-release-yml))
+  (check-true (string-contains? content "manifest tag mismatch") "must verify manifest tag field"))
+
+(test-case "release.yml smoke manifest verifies tarball asset name"
+  (define content (read-release-yml))
+  (check-true (string-contains? content "manifest tarball name mismatch")
+              "must verify manifest tarball asset name"))
+
+(test-case "release.yml smoke manifest verifies sha256 when available"
+  (define content (read-release-yml))
+  (check-true (string-contains? content "sha256 mismatch")
+              "must verify manifest sha256 when tarball is available"))
+
+(test-case "release.yml smoke manifest uses asset API not direct download URL"
+  (define content (read-release-yml))
+  ;; Must look up release by tag to find asset URL
+  (check-true (string-contains? content "releases/tags/${TAG}")
+              "must look up release by tag for manifest asset URL")
+  ;; Must find manifest via asset filter, not direct download URL
+  (check-false (string-contains? content "releases/download/${TAG}/release-manifest.json")
+               "must NOT use unreliable direct download URL for manifest"))
+
+(test-case "release.yml smoke manifest has no '|| true' fallback"
+  (define content (read-release-yml))
+  ;; The old code had '|| true' on the manifest curl — now it's gone.
+  ;; Extract manifest step section using regexp-match-positions
+  (define start-pos (regexp-match-positions #rx"Verify manifest .mandatory" content))
+  (define end-pos (regexp-match-positions #rx"Run test suite" content))
+  (when (and start-pos end-pos)
+    (define start-idx (caar start-pos))
+    (define end-idx (caar end-pos))
+    (when (< start-idx end-idx)
+      (define manifest-section (substring content start-idx end-idx))
+      (check-false (string-contains? manifest-section "|| true")
+                   "manifest download must NOT have '|| true' masking failures"))))


### PR DESCRIPTION
W2 — Make smoke manifest verification mandatory.

- Replace optional manifest check with mandatory verification via asset API
- No more `|| true` masking, no more "(optional)" wording
- Verifies version, tag, tarball name, sha256
- 9 new contract tests (31 total)