### PR TITLE
feat: release.yml smoke uses release-smoke suite (#8543)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -282,7 +282,29 @@ jobs:
           print('All manifest checks passed.')
           PYEOF
 
-      - name: Run test suite
+      - name: Run release-smoke test suite
+        id: smoke-tests
+        continue-on-error: false
         run: |
           cd /tmp/q
-          STRICT_TEST_RUNNER=1 racket scripts/run-tests.rkt --jobs 4
+          echo "Running release-smoke suite (deterministic, artifact-focused)"
+          STRICT_TEST_RUNNER=1 racket scripts/run-tests.rkt \
+            --suite release-smoke \
+            --jobs 4 \
+            --timeout 120 \
+            2>&1 | tee smoke-output.log
+        
+      - name: Upload smoke log on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: smoke-output-log
+          path: /tmp/q/smoke-output.log
+          retention-days: 30
+        
+      - name: Smoke failure summary
+        if: failure()
+        run: |
+          echo "## Release Smoke Failures" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          grep -A 4 'FAILURE\|ERROR\|FAILED\|TIMEOUT' /tmp/q/smoke-output.log >> $GITHUB_STEP_SUMMARY || true

--- a/tests/test-release-workflow-contract.rkt
+++ b/tests/test-release-workflow-contract.rkt
@@ -236,3 +236,56 @@
       (define manifest-section (substring content start-idx end-idx))
       (check-false (string-contains? manifest-section "|| true")
                    "manifest download must NOT have '|| true' masking failures"))))
+
+;; ============================================================
+;; W3: release-smoke suite in release.yml smoke job
+;; ============================================================
+
+(test-case "release.yml smoke uses release-smoke suite"
+  (define content (read-release-yml))
+  (check-true (string-contains? content "--suite release-smoke")
+              "smoke job must use --suite release-smoke instead of default/all"))
+
+(test-case "release.yml smoke does NOT run default/all tests"
+  (define content (read-release-yml))
+  ;; The old invocation was just '--jobs 4' without --suite
+  ;; Verify the smoke step has --suite, not bare '--jobs 4'
+  (define smoke-section
+    (let* ([start-pos (regexp-match-positions #rx"Run release-smoke test suite" content)]
+           [end-pos (regexp-match-positions #rx"Upload smoke log" content)])
+      (if (and start-pos end-pos (< (caar start-pos) (caar end-pos)))
+          (substring content (caar start-pos) (caar end-pos))
+          "")))
+  (check-false (and (string-contains? smoke-section "run-tests.rkt")
+                    (not (string-contains? smoke-section "--suite")))
+               "smoke must NOT run run-tests.rkt without --suite"))
+
+(test-case "release.yml smoke step is blocking (no continue-on-error: true)"
+  (define content (read-release-yml))
+  ;; The smoke step must not have continue-on-error: true
+  (define smoke-section
+    (let* ([start-pos (regexp-match-positions #rx"Run release-smoke test suite" content)]
+           [end-pos (regexp-match-positions #rx"Upload smoke log" content)])
+      (if (and start-pos end-pos (< (caar start-pos) (caar end-pos)))
+          (substring content (caar start-pos) (caar end-pos))
+          "")))
+  (check-false (string-contains? smoke-section "continue-on-error: true")
+               "smoke step must NOT be continue-on-error: true"))
+
+(test-case "release.yml smoke uploads log on failure"
+  (define content (read-release-yml))
+  (check-true (string-contains? content "Upload smoke log on failure")
+              "must have step to upload smoke log on failure")
+  (check-true (string-contains? content "if: failure()") "log upload must trigger on failure"))
+
+(test-case "release.yml smoke logs selected suite"
+  (define content (read-release-yml))
+  (check-true (string-contains? content "Running release-smoke suite")
+              "smoke step must log which suite is being run"))
+
+(test-case "release.yml smoke has failure summary step"
+  (define content (read-release-yml))
+  (check-true (string-contains? content "Smoke failure summary")
+              "must have smoke failure summary step")
+  (check-true (string-contains? content "$GITHUB_STEP_SUMMARY")
+              "failure summary must write to GITHUB_STEP_SUMMARY"))


### PR DESCRIPTION
W3 — Update release.yml smoke to use release-smoke suite.

- Replace default/all test invocation with `--suite release-smoke`
- Smoke step is explicitly blocking (`continue-on-error: false`)
- Add smoke log upload on failure (artifact, 30-day retention)
- Add smoke failure summary step (GITHUB_STEP_SUMMARY)
- 6 new contract tests (37 total)