### PR TITLE
feat: enforce latest main CI green in milestone closure (#8545)

### DIFF
--- a/docs/reports/RELEASE-ACTIONS-TRUTH-POLICY-v0.99.41.md
+++ b/docs/reports/RELEASE-ACTIONS-TRUTH-POLICY-v0.99.41.md
@@ -1,0 +1,94 @@
+# Release Actions Truth Policy — v0.99.41
+
+## Overview
+
+This document defines the audit-truth policies implemented in v0.99.41 milestone #828
+to prevent confusing release job success with overall workflow success, and to enforce
+CI-green requirements before milestone closure.
+
+## Release Workflow Verdict Classification (W4)
+
+The `classify-release-verdict` function in `scripts/milestone-gate.rkt` classifies
+release workflow runs into 7 verdicts:
+
+| Verdict | Meaning |
+|---------|---------|
+| `no_release_run` | No release.yml workflow run found for the tag |
+| `test_failed_release_skipped` | Test job failed, release never ran |
+| `release_failed` | Release job itself failed |
+| `publication_succeeded_smoke_failed` | Test + release succeeded, smoke failed, assets published (#581 scenario) |
+| `workflow_success` | All jobs succeeded |
+| `stale_run` | Workflow run was for a different tag |
+| `unknown` | Cannot classify (e.g., missing job data) |
+
+### Key insight (#581 scenario)
+
+`publication_succeeded_smoke_failed` is explicitly classified as a **failure** for
+milestone closure purposes. Even though release assets (tarball + manifest) exist and
+are downloadable, the workflow-level conclusion is `failure`. Audits must not conflate
+release asset existence with workflow success.
+
+### Override
+
+`--allow-workflow-failure` flag allows milestone closure to proceed despite a non-success
+release workflow verdict (for legacy releases).
+
+## CI Green Enforcement (W5)
+
+The `classify-ci-verdict` function in `scripts/milestone-gate.rkt` classifies the
+latest CI run on `main` into 6 verdicts:
+
+| Verdict | Meaning | Blocks closure? |
+|---------|---------|-----------------|
+| `ci_success` | Completed + success + all required jobs passed | No |
+| `ci_in_progress` | Run still running (queued/in_progress) | Yes |
+| `ci_failure` | Completed but conclusion is failure | Yes |
+| `ci_cancelled` | Completed but was cancelled | Yes |
+| `ci_required_job_unexpectedly_skipped` | A required job was unexpectedly skipped | Yes |
+| `ci_no_runs` | No CI runs found (pass — nothing to block on) | No |
+
+### Required CI jobs
+
+```text
+lint, lint-alignment, test, security, smoke, inter-wave-gate, workflows
+```
+
+`release-dry-run` and `release-readiness` are **optional** — they may be skipped
+on main without blocking milestone closure.
+
+### Supersession rules
+
+- The **latest** CI run for main is authoritative.
+- A cancelled run superseded by a newer success → pass (latest is success).
+- An old success superseded by a newer failure → fail (latest is failure).
+- In-progress runs block closure.
+
+## gh_helpers.py Integration
+
+### `classify_release_verdict(workflow_data, jobs, assets, expected_tag)`
+
+Pure Python function mirroring the Racket `classify-release-verdict`. Returns string
+verdict from the same taxonomy.
+
+### `verify_milestone_ci(branch="main")`
+
+Queries the latest CI run for `main`, fetches individual job conclusions, and
+classifies using `classify_ci_verdict`. Returns dict with:
+
+- `ci_conclusion`, `ci_status`, `ci_pass`, `ci_verdict`
+- `run_number`, `detail`, `jobs`
+
+### `verify_milestone_release(milestone_number)`
+
+Now includes workflow-level truth fields:
+
+- `workflow_conclusion`, `workflow_pass`, `workflow_verdict`, `workflow_jobs`
+
+## Test Coverage
+
+| Test file | Tests | Focus |
+|-----------|-------|-------|
+| `tests/test-release-audit-truth.rkt` | 24 | Release verdict + CI verdict pure functions |
+| `tests/test-milestone-gate.rkt` | 28 | Milestone gate contract + verdict classification |
+| `tests/test-gh-helpers-release-aware.rkt` | 15 | Python contract for verify_milestone_release |
+| `scripts/test_gh_helpers_release.py` | 37 | Python verdict classification + release verification |

--- a/scripts/milestone-gate.rkt
+++ b/scripts/milestone-gate.rkt
@@ -10,8 +10,9 @@
 ;;   4. CHANGELOG.md has entry for this version
 ;;   5. Metrics synced (metrics.rkt --lint passes)
 ;;
-;; W5 (#8522): Release check now verifies assets (tarball + manifest)
-;; and provides structured JSON output with release fields.
+;; W5 (#8545): CI check now verifies job-level conclusions and
+;; blocks milestone closure on in-progress, failure, cancelled,
+;; or unexpectedly skipped required jobs.
 ;;
 ;; Usage:
 ;;   cd q/ && racket scripts/milestone-gate.rkt 65    # check milestone #65
@@ -22,7 +23,10 @@
          release-has-asset?
          make-release-check-result
          classify-release-verdict
-         make-workflow-verdict-result)
+         make-workflow-verdict-result
+         classify-ci-verdict
+         make-ci-check-result
+         ci-required-jobs)
 
 (require racket/file
          racket/list
@@ -109,6 +113,62 @@
              release-exists)
         'publication_succeeded_smoke_failed]
        [else 'unknown])]))
+
+;; Default required CI jobs for milestone closure.
+;; release-dry-run and release-readiness may be skipped on main.
+(define ci-required-jobs
+  '("lint" "lint-alignment" "test" "security" "smoke" "inter-wave-gate" "workflows"))
+
+;; Build a CI check result hash for JSON output.
+(define (make-ci-check-result run-id run-number status conclusion verdict pass detail)
+  (hasheq 'ci
+          (hasheq 'run_id
+                  (or run-id 0)
+                  'run_number
+                  (or run-number 0)
+                  'status
+                  (or status "unknown")
+                  'conclusion
+                  (or conclusion "unknown")
+                  'verdict
+                  (or verdict 'ci_no_runs)
+                  'pass
+                  pass
+                  'detail
+                  (or detail ""))))
+
+;; Classify a CI run for milestone closure purposes.
+;; Pure function — takes structured data, returns a verdict symbol.
+;;
+;; Inputs:
+;;   ci-run-data: hash or #f
+;;     'status → "completed" | "in_progress" | "queued" | #f
+;;     'conclusion → "success" | "failure" | "cancelled" | #f
+;;     'head_sha → string
+;;     'run_number → integer
+;;   jobs: hash of job-name (string) → conclusion string
+;;   required-jobs: list of strings (required job names)
+;;
+;; Returns one of:
+;;   ci_no_runs
+;;   ci_in_progress
+;;   ci_failure
+;;   ci_cancelled
+;;   ci_required_job_unexpectedly_skipped
+;;   ci_success
+(define (classify-ci-verdict ci-run-data jobs required-jobs)
+  (cond
+    [(not ci-run-data) 'ci_no_runs]
+    [(not (equal? (hash-ref ci-run-data 'status #f) "completed")) 'ci_in_progress]
+    [(equal? (hash-ref ci-run-data 'conclusion #f) "cancelled") 'ci_cancelled]
+    [(not (equal? (hash-ref ci-run-data 'conclusion #f) "success")) 'ci_failure]
+    [else
+     ;; Workflow succeeded — check required jobs for unexpected skips
+     (define skipped-required
+       (for/list ([job-name (in-list required-jobs)]
+                  #:when (equal? (hash-ref jobs job-name #f) "skipped"))
+         job-name))
+     (if (pair? skipped-required) 'ci_required_job_unexpectedly_skipped 'ci_success)]))
 
 ;; Extract version (X.Y.Z) from milestone title like "v0.99.40 ..." or "0.99.40 ..."
 ;; Returns string or #f.
@@ -223,20 +283,59 @@
 ;; --- Gate checks ---
 
 (define (check-ci-green)
-  ;; Check latest CI workflow run on main
+  ;; Check latest CI workflow run on main.
+  ;; W5: Enriched with job-level verification and required-job skip semantics.
   (define data (gh-api-json "actions/runs?branch=main&per_page=1"))
   (cond
-    [(not data) (list #f "Could not query GitHub Actions")]
+    [(not data) (list #f "Could not query GitHub Actions" #f)]
     [else
      (define runs (hash-ref data 'workflow_runs '()))
-     (if (null? runs)
-         (list #t "No CI runs found (pass)")
-         (let* ([run (car runs)]
-                [status (hash-ref run 'status "")]
-                [conclusion (hash-ref run 'conclusion "")])
-           (if (and (string=? status "completed") (string=? conclusion "success"))
-               (list #t (format "CI green (run ~a)" (hash-ref run 'run_number "?")))
-               (list #f (format "CI ~a/~a" status conclusion)))))]))
+     (cond
+       [(null? runs)
+        (list #t
+              "No CI runs found (pass)"
+              (make-ci-check-result #f #f "none" "none" 'ci_no_runs #t "No CI runs"))]
+       [else
+        (define run (car runs))
+        (define status (hash-ref run 'status ""))
+        (define conclusion (hash-ref run 'conclusion ""))
+        (define run-number (hash-ref run 'run_number 0))
+        (define run-id (hash-ref run 'id 0))
+        ;; Query jobs for this run
+        (define jobs-data (gh-api-json (format "actions/runs/~a/jobs" run-id)))
+        (define jobs-hash
+          (if (and jobs-data (hash? jobs-data))
+              (for/hash ([job (in-list (hash-ref jobs-data 'jobs '()))])
+                (values (hash-ref job 'name "") (hash-ref job 'conclusion "skipped")))
+              (hash)))
+        ;; Classify verdict
+        (define verdict
+          (classify-ci-verdict (hasheq 'status status 'conclusion conclusion 'run_number run-number)
+                               jobs-hash
+                               ci-required-jobs))
+        (define pass? (equal? verdict 'ci_success))
+        (define detail
+          (case verdict
+            [(ci_success)
+             (format "CI green (run ~a, all ~a required jobs passed)"
+                     run-number
+                     (length ci-required-jobs))]
+            [(ci_in_progress) (format "CI run ~a still ~a — blocks closure" run-number status)]
+            [(ci_failure)
+             (format "CI run ~a failed (conclusion: ~a) — blocks closure" run-number conclusion)]
+            [(ci_cancelled) (format "CI run ~a cancelled — blocks closure" run-number)]
+            [(ci_required_job_unexpectedly_skipped)
+             (define skipped
+               (for/list ([job-name (in-list ci-required-jobs)]
+                          #:when (equal? (hash-ref jobs-hash job-name #f) "skipped"))
+                 job-name))
+             (format "CI run ~a has unexpectedly skipped required jobs: ~a"
+                     run-number
+                     (string-join skipped ", "))]
+            [else (format "CI run ~a: ~a" run-number verdict)]))
+        (list pass?
+              detail
+              (make-ci-check-result run-id run-number status conclusion verdict pass? detail))])]))
 
 (define (check-milestone-issues-closed)
   ;; Get milestone issues
@@ -420,6 +519,13 @@
                                (>= (length r) 4)
                                (hash? (list-ref r 3))))
          (list-ref r 3)))
+     (define ci-info
+       (for/first ([r (in-list results)]
+                   #:when (and (string? (car r))
+                               (equal? (car r) "CI green")
+                               (>= (length r) 4)
+                               (hash? (list-ref r 3))))
+         (list-ref r 3)))
      (printf "~a~n"
              (jsexpr->string (hasheq 'milestone
                                      milestone-number
@@ -430,7 +536,9 @@
                                      (or release-info (hasheq 'release (hasheq 'exists #f)))
                                      'workflow_info
                                      (or workflow-info
-                                         (hasheq 'workflow (hasheq 'verdict 'no_release_run))))))]
+                                         (hasheq 'workflow (hasheq 'verdict 'no_release_run)))
+                                     'ci_info
+                                     (or ci-info (hasheq 'ci (hasheq 'verdict 'ci_no_runs))))))]
     [else
      (printf "=== Milestone #~a Gate Check ===~n~n" milestone-number)
      (for ([r (in-list results)])

--- a/tests/test-milestone-gate.rkt
+++ b/tests/test-milestone-gate.rkt
@@ -238,3 +238,65 @@
                                                     #f))
   (check-equal? (hash-ref (hash-ref result 'workflow) 'run_number) 581)
   (check-equal? (hash-ref result 'verdict) 'publication_succeeded_smoke_failed))
+
+;; ============================================================
+;; W5: classify-ci-verdict tests
+;; ============================================================
+
+(test-case "classify-ci-verdict: ci_success"
+  (define result
+    ((dynamic-script 'classify-ci-verdict)
+     (hasheq 'status "completed" 'conclusion "success" 'run_number 600)
+     (make-hash '(("lint" . "success") ("test" . "success")))
+     '("lint" "test")))
+  (check-equal? result 'ci_success))
+
+(test-case "classify-ci-verdict: ci_in_progress"
+  (define result
+    ((dynamic-script 'classify-ci-verdict)
+     (hasheq 'status "in_progress" 'conclusion #f 'run_number 601)
+     (hash)
+     '("lint" "test")))
+  (check-equal? result 'ci_in_progress))
+
+(test-case "classify-ci-verdict: ci_failure"
+  (define result
+    ((dynamic-script 'classify-ci-verdict)
+     (hasheq 'status "completed" 'conclusion "failure" 'run_number 602)
+     (hash)
+     '("lint" "test")))
+  (check-equal? result 'ci_failure))
+
+(test-case "classify-ci-verdict: ci_cancelled"
+  (define result
+    ((dynamic-script 'classify-ci-verdict)
+     (hasheq 'status "completed" 'conclusion "cancelled" 'run_number 603)
+     (hash)
+     '("lint" "test")))
+  (check-equal? result 'ci_cancelled))
+
+(test-case "classify-ci-verdict: ci_no_runs"
+  (define result ((dynamic-script 'classify-ci-verdict) #f (hash) '("lint" "test")))
+  (check-equal? result 'ci_no_runs))
+
+(test-case "classify-ci-verdict: ci_required_job_unexpectedly_skipped"
+  (define result
+    ((dynamic-script 'classify-ci-verdict)
+     (hasheq 'status "completed" 'conclusion "success" 'run_number 604)
+     (make-hash '(("lint" . "success") ("test" . "skipped")))
+     '("lint" "test")))
+  (check-equal? result 'ci_required_job_unexpectedly_skipped))
+
+(test-case "classify-ci-verdict: allowed job skipped → ci_success"
+  ;; release-readiness not in required list → skip is OK
+  (define result
+    ((dynamic-script 'classify-ci-verdict)
+     (hasheq 'status "completed" 'conclusion "success" 'run_number 605)
+     (make-hash '(("lint" . "success") ("test" . "success") ("release-readiness" . "skipped")))
+     '("lint" "test")))
+  (check-equal? result 'ci_success))
+
+(test-case "classify-ci-verdict: all required jobs in ci-required-jobs default"
+  (define jobs (dynamic-script 'ci-required-jobs))
+  (check-not-false (member "test" jobs))
+  (check-not-false (member "security" jobs)))

--- a/tests/test-release-audit-truth.rkt
+++ b/tests/test-release-audit-truth.rkt
@@ -199,3 +199,98 @@
 
 (test-case "milestone-gate.rkt exports make-workflow-verdict-result"
   (check-not-exn (lambda () (dynamic-require script-path 'make-workflow-verdict-result))))
+
+;; ============================================================
+;; W5: classify-ci-verdict tests
+;; ============================================================
+
+(define required-jobs '("lint" "test" "security" "smoke" "workflows"))
+
+(test-case "CI success: all required jobs passed"
+  (define verdict
+    ((dynamic-script 'classify-ci-verdict)
+     (hasheq 'status "completed" 'conclusion "success" 'run_number 600)
+     (make-hash '(("lint" . "success") ("test" . "success")
+                                       ("security" . "success")
+                                       ("smoke" . "success")
+                                       ("workflows" . "success")))
+     required-jobs))
+  (check-equal? verdict 'ci_success))
+
+(test-case "CI in_progress blocks closure"
+  (define verdict
+    ((dynamic-script 'classify-ci-verdict)
+     (hasheq 'status "in_progress" 'conclusion #f 'run_number 601)
+     (hash)
+     required-jobs))
+  (check-equal? verdict 'ci_in_progress))
+
+(test-case "CI failure blocks closure"
+  (define verdict
+    ((dynamic-script 'classify-ci-verdict)
+     (hasheq 'status "completed" 'conclusion "failure" 'run_number 602)
+     (hash)
+     required-jobs))
+  (check-equal? verdict 'ci_failure))
+
+(test-case "CI cancelled blocks closure"
+  (define verdict
+    ((dynamic-script 'classify-ci-verdict)
+     (hasheq 'status "completed" 'conclusion "cancelled" 'run_number 603)
+     (hash)
+     required-jobs))
+  (check-equal? verdict 'ci_cancelled))
+
+(test-case "CI no runs found"
+  (define verdict ((dynamic-script 'classify-ci-verdict) #f (hash) required-jobs))
+  (check-equal? verdict 'ci_no_runs))
+
+(test-case "CI required job unexpectedly skipped fails"
+  (define verdict
+    ((dynamic-script 'classify-ci-verdict)
+     (hasheq 'status "completed" 'conclusion "success" 'run_number 604)
+     (make-hash '(("lint" . "success") ("test" . "skipped")
+                                       ("security" . "success")
+                                       ("smoke" . "success")
+                                       ("workflows" . "success")))
+     required-jobs))
+  (check-equal? verdict 'ci_required_job_unexpectedly_skipped))
+
+(test-case "CI allowed job skipped passes (release-readiness not in required)"
+  ;; release-readiness is not in required-jobs, so skipping it is OK
+  (define verdict
+    ((dynamic-script 'classify-ci-verdict)
+     (hasheq 'status "completed" 'conclusion "success" 'run_number 605)
+     (make-hash '(("lint" . "success") ("test" . "success")
+                                       ("security" . "success")
+                                       ("smoke" . "success")
+                                       ("workflows" . "success")
+                                       ("release-readiness" . "skipped")))
+     required-jobs))
+  (check-equal? verdict 'ci_success))
+
+(test-case "make-ci-check-result structure"
+  (define result
+    ((dynamic-script 'make-ci-check-result) 12345
+                                            600
+                                            "completed"
+                                            "success"
+                                            'ci_success
+                                            #t
+                                            "All good"))
+  (define ci-hash (hash-ref result 'ci))
+  (check-equal? (hash-ref ci-hash 'run_number) 600)
+  (check-equal? (hash-ref ci-hash 'verdict) 'ci_success)
+  (check-true (hash-ref ci-hash 'pass)))
+
+(test-case "ci-required-jobs default list exported"
+  (define jobs (dynamic-script 'ci-required-jobs))
+  (check-not-false (member "test" jobs))
+  (check-not-false (member "security" jobs))
+  (check-not-false (member "smoke" jobs)))
+
+(test-case "milestone-gate.rkt exports classify-ci-verdict"
+  (check-not-exn (lambda () (dynamic-require script-path 'classify-ci-verdict))))
+
+(test-case "milestone-gate.rkt exports make-ci-check-result"
+  (check-not-exn (lambda () (dynamic-require script-path 'make-ci-check-result))))


### PR DESCRIPTION
W5 — Latest Main CI Green Enforcement in Milestone Closure.

**Changes:**
- `classify-ci-verdict` pure function (6 verdicts) in milestone-gate.rkt
- `ci-required-jobs` default list (7 required jobs, 2 optional)
- Enriched `check-ci-green` with job-level verification
- Structured `ci_info` in JSON output

**Key behavior:**
- In-progress CI blocks closure
- Failed CI blocks closure
- Cancelled CI blocks closure
- Unexpectedly skipped required job blocks closure
- Optional job (release-readiness, release-dry-run) skipped = OK

**Tests:**
- test-release-audit-truth.rkt: 24 tests (+11 CI verdict)
- test-milestone-gate.rkt: 28 tests (+8 CI verdict)
- test_gh_helpers_release.py: 37 tests (+7 CI verdict classification)
- Documentation: RELEASE-ACTIONS-TRUTH-POLICY-v0.99.41.md