### PR TITLE
feat: add Actions red-run classifier and audit template (#8547)

### DIFF
--- a/docs/reports/RELEASE-ACTIONS-TRUTH-POLICY-v0.99.41.md
+++ b/docs/reports/RELEASE-ACTIONS-TRUTH-POLICY-v0.99.41.md
@@ -84,11 +84,46 @@ Now includes workflow-level truth fields:
 
 - `workflow_conclusion`, `workflow_pass`, `workflow_verdict`, `workflow_jobs`
 
+## Red-Run Classification (W7)
+
+The `scripts/actions-red-run-classifier.rkt` tool classifies GitHub Actions
+runs into 7 categories, distinguishing current blocking red runs from
+historical superseded ones:
+
+| Verdict | Meaning | Blocks approval? |
+|---------|---------|------------------|
+| `current_blocking_red_release_run` | Latest release.yml run is red | Yes |
+| `current_blocking_red_main_ci` | Latest ci.yml run on main is red | Yes |
+| `historical_superseded_red` | Older red run superseded by later success | No |
+| `cancelled_superseded` | Cancelled run superseded by later success | No |
+| `in_progress_blocking` | A run is still in progress | Yes |
+| `success_current` | Latest runs are all green | No |
+| `unknown_due_api_error` | API query failed | Yes (until retried) |
+
+### Key principle
+
+Historical red runs (from iterative development) do NOT block milestone
+approval. Only the **latest** run matters. This prevents the situation
+where 37 historical failures among 80 runs obscure a current green state.
+
+The classifier queries both release workflow runs (filtered by tag) and
+main CI runs, then combines them for an overall blocking determination.
+
+### Audit template
+
+A reusable audit template is maintained at:
+`.planning/AUDIT-TEMPLATE-RELEASE-ACTIONS-TRUTH.md`
+
+This template prevents job/workflow conflation by requiring separate
+verdicts for workflow-level, job-level, asset-level, manifest-level,
+CI-level, red-run classification, and traceability sections.
+
 ## Test Coverage
 
 | Test file | Tests | Focus |
 |-----------|-------|-------|
 | `tests/test-release-audit-truth.rkt` | 24 | Release verdict + CI verdict pure functions |
 | `tests/test-milestone-gate.rkt` | 28 | Milestone gate contract + verdict classification |
+| `tests/test-actions-red-run-classifier.rkt` | 25 | Red-run classifier fixtures (7 verdicts) |
 | `tests/test-gh-helpers-release-aware.rkt` | 15 | Python contract for verify_milestone_release |
 | `scripts/test_gh_helpers_release.py` | 37 | Python verdict classification + release verification |

--- a/scripts/actions-red-run-classifier.rkt
+++ b/scripts/actions-red-run-classifier.rkt
@@ -1,0 +1,315 @@
+#!/usr/bin/env racket
+#lang racket/base
+
+;; scripts/actions-red-run-classifier.rkt — Actions red-run classifier.
+;;
+;; W7 (#8547): Classify historical vs current blocking red runs.
+;;
+;; The classifier takes structured GitHub Actions run data and produces
+;; one of 7 verdicts:
+;;
+;;   current_blocking_red_release_run  — latest release.yml run is red
+;;   current_blocking_red_main_ci      — latest ci.yml run on main is red
+;;   historical_superseded_red         — older run that a later run superseded
+;;   cancelled_superseded              — cancelled run superseded by later success
+;;   in_progress_blocking              — a run is still in progress
+;;   success_current                   — latest runs are all green
+;;   unknown_due_api_error             — API query failed; blocks until retried
+;;
+;; Usage:
+;;   cd q/ && racket scripts/actions-red-run-classifier.rkt <milestone-number> [--json]
+
+(provide classify-red-run
+         classify-red-run-set
+         make-red-run-result
+         all-blocked-verdicts
+         blocking-verdict?
+         RED_RUN_VERDICTS)
+
+(require racket/file
+         racket/list
+         racket/port
+         racket/string
+         racket/system
+         json)
+
+;; ---------------------------------------------------------------------------
+;; Pure logic (testable without network)
+;; ---------------------------------------------------------------------------
+
+;; All possible verdicts as strings.
+(define RED_RUN_VERDICTS
+  '("current_blocking_red_release_run" "current_blocking_red_main_ci"
+                                       "historical_superseded_red"
+                                       "cancelled_superseded"
+                                       "in_progress_blocking"
+                                       "success_current"
+                                       "unknown_due_api_error"))
+
+;; Verdicts that block milestone approval.
+(define all-blocked-verdicts
+  '("current_blocking_red_release_run" "current_blocking_red_main_ci"
+                                       "in_progress_blocking"
+                                       "unknown_due_api_error"))
+
+;; Check if a verdict string blocks approval.
+(define (blocking-verdict? verdict)
+  (and verdict (member verdict all-blocked-verdicts) #t))
+
+;; Build a structured red-run result hash for JSON output.
+(define (make-red-run-result verdict run-type run-id run-number conclusion detail blocking?)
+  (hasheq 'verdict
+          verdict
+          'run_type
+          run-type
+          'run_id
+          (or run-id 0)
+          'run_number
+          (or run-number 0)
+          'conclusion
+          (or conclusion "unknown")
+          'detail
+          (or detail "")
+          'blocking
+          blocking?))
+
+;; Classify a single GitHub Actions run for red-run purposes.
+;;
+;; Inputs:
+;;   run-data: hash or #f
+;;     'conclusion → "success" | "failure" | "cancelled" | #f (in-progress)
+;;     'status → "completed" | "in_progress" | "queued" | #f
+;;     'run_number → integer
+;;     'id → integer
+;;   run-type: string — "release" or "ci" or "ci-main"
+;;   is-latest?: boolean — is this the most recent run for this workflow+branch?
+;;   api-error?: boolean — did the API call fail?
+;;
+;; Returns a verdict string.
+(define (classify-red-run run-data run-type is-latest? api-error?)
+  (cond
+    ;; API error — unknown, blocks approval
+    [api-error? "unknown_due_api_error"]
+    ;; No run data at all — treat as unknown
+    [(not run-data) "unknown_due_api_error"]
+    ;; Run still in progress — blocks
+    [(let ([status (hash-ref run-data 'status #f)]) (and status (not (equal? status "completed"))))
+     "in_progress_blocking"]
+    ;; Run completed and succeeded
+    [(equal? (hash-ref run-data 'conclusion #f) "success") "success_current"]
+    ;; Run was cancelled
+    [(equal? (hash-ref run-data 'conclusion #f) "cancelled")
+     (if is-latest? "cancelled_superseded" "cancelled_superseded")]
+    ;; Run failed — determine if current/latest or historical
+    [(equal? (hash-ref run-data 'conclusion #f) "failure")
+     (if is-latest?
+         (if (equal? run-type "release")
+             "current_blocking_red_release_run"
+             "current_blocking_red_main_ci")
+         "historical_superseded_red")]
+    ;; Any other conclusion
+    [else "unknown_due_api_error"]))
+
+;; Classify a set of runs (e.g., all release runs or all CI runs on main).
+;;
+;; This function takes a list of runs (newest first) and classifies the
+;; overall red-run state. If the latest run is green, all earlier red
+;; runs are "historical_superseded_red". If the latest run is red, it's
+;; "current_blocking".
+;;
+;; Inputs:
+;;   runs: list of run-data hashes (newest first), or '() or #f
+;;   run-type: "release" or "ci" or "ci-main"
+;;   api-error?: boolean
+;;
+;; Returns a red-run result hash.
+(define (classify-red-run-set runs run-type api-error?)
+  (cond
+    [api-error?
+     (make-red-run-result "unknown_due_api_error"
+                          run-type
+                          #f
+                          #f
+                          "unknown"
+                          "API query failed — blocks until retried"
+                          #t)]
+    [(or (not runs) (null? runs))
+     (make-red-run-result "unknown_due_api_error"
+                          run-type
+                          #f
+                          #f
+                          "none"
+                          (format "No ~a runs found" run-type)
+                          #t)]
+    [else
+     (define latest (car runs))
+     (define status (hash-ref latest 'status #f))
+     (define conclusion (hash-ref latest 'conclusion #f))
+     (define run-id (hash-ref latest 'id 0))
+     (define run-number (hash-ref latest 'run_number 0))
+     (cond
+       ;; Still in progress
+       [(and status (not (equal? status "completed")))
+        (make-red-run-result "in_progress_blocking"
+                             run-type
+                             run-id
+                             run-number
+                             conclusion
+                             (format "~a run ~a is ~a — blocks approval" run-type run-number status)
+                             #t)]
+       ;; Latest succeeded
+       [(equal? conclusion "success")
+        (make-red-run-result "success_current"
+                             run-type
+                             run-id
+                             run-number
+                             conclusion
+                             (format "~a run ~a: success (latest green)" run-type run-number)
+                             #f)]
+       ;; Latest cancelled
+       [(equal? conclusion "cancelled")
+        (make-red-run-result "cancelled_superseded"
+                             run-type
+                             run-id
+                             run-number
+                             conclusion
+                             (format "~a run ~a: cancelled (latest)" run-type run-number)
+                             #t)]
+       ;; Latest failed — current blocking
+       [(equal? conclusion "failure")
+        (define verdict
+          (if (equal? run-type "release")
+              "current_blocking_red_release_run"
+              "current_blocking_red_main_ci"))
+        (make-red-run-result
+         verdict
+         run-type
+         run-id
+         run-number
+         conclusion
+         (format "~a run ~a: FAILURE (latest) — blocks approval" run-type run-number)
+         #t)]
+       [else
+        (make-red-run-result
+         "unknown_due_api_error"
+         run-type
+         run-id
+         run-number
+         conclusion
+         (format "~a run ~a: unexpected conclusion '~a'" run-type run-number conclusion)
+         #t)])]))
+
+;; ---------------------------------------------------------------------------
+;; CLI (network-dependent)
+;; ---------------------------------------------------------------------------
+
+(define (gh-api-json path)
+  (define token
+    (with-handlers ([exn:fail? (λ (_) "")])
+      (string-trim (file->string (build-path (find-system-path 'home-dir) "GH_PAT")))))
+  (define cmd
+    (format
+     "curl -s -H \"Authorization: token ~a\" -H \"Accept: application/vnd.github+json\" \"https://api.github.com/repos/coinerd/q/~a\""
+     token
+     path))
+  (define output (with-output-to-string (λ () (system cmd))))
+  (with-handlers ([exn:fail? (λ (_) #f)])
+    (string->jsexpr output)))
+
+(define (extract-version-from-milestone-title title)
+  (define m (regexp-match #rx"v?([0-9]+\\.[0-9]+\\.[0-9]+)" title))
+  (and m (cadr m)))
+
+(define args (vector->list (current-command-line-arguments)))
+(define json-output? (member "--json" args))
+
+(define milestone-number
+  (for/first ([a (in-list args)]
+              #:when (regexp-match? #rx"^[0-9]+$" a))
+    (string->number a)))
+
+(define (main)
+  (unless milestone-number
+    (printf "Usage: racket scripts/actions-red-run-classifier.rkt <milestone-number> [--json]~n")
+    (exit 0))
+
+  ;; Get milestone info
+  (define ms-data (gh-api-json (format "milestones/~a" milestone-number)))
+  (unless ms-data
+    (printf "ERROR: Could not query milestone #~a~n" milestone-number)
+    (exit 1))
+
+  (define title (hash-ref ms-data 'title ""))
+  (define version (extract-version-from-milestone-title title))
+
+  (unless version
+    (printf "ERROR: Cannot extract version from milestone title: ~a~n" title)
+    (exit 1))
+
+  (define tag (format "v~a" version))
+
+  ;; Query release workflow runs for this tag
+  (define rel-wf-data
+    (gh-api-json (format "actions/workflows/release.yml/runs?branch=~a&per_page=10" tag)))
+  (define release-runs
+    (if (and rel-wf-data (hash? rel-wf-data))
+        (hash-ref rel-wf-data 'workflow_runs '())
+        '()))
+  (define release-api-error? (not rel-wf-data))
+
+  ;; Query latest CI runs on main
+  (define ci-wf-data (gh-api-json "actions/runs?branch=main&per_page=5"))
+  (define ci-runs
+    (if (and ci-wf-data (hash? ci-wf-data))
+        (hash-ref ci-wf-data 'workflow_runs '())
+        '()))
+  (define ci-api-error? (not ci-wf-data))
+
+  ;; Classify
+  (define release-result (classify-red-run-set release-runs "release" release-api-error?))
+  (define ci-result (classify-red-run-set ci-runs "ci-main" ci-api-error?))
+
+  ;; Overall verdict — worst of the two
+  (define release-blocking? (hash-ref release-result 'blocking #t))
+  (define ci-blocking? (hash-ref ci-result 'blocking #t))
+  (define overall-blocking? (or release-blocking? ci-blocking?))
+
+  (define overall-result
+    (hasheq 'milestone
+            milestone-number
+            'version
+            version
+            'tag
+            tag
+            'release_classification
+            release-result
+            'ci_classification
+            ci-result
+            'overall_blocking
+            overall-blocking?))
+
+  (cond
+    [json-output? (printf "~a~n" (jsexpr->string overall-result))]
+    [else
+     (printf "=== Red-Run Classification for ~a (#~a) ===~n~n" tag milestone-number)
+     (printf "Release workflow:~n")
+     (printf "  Verdict:    ~a~n" (hash-ref release-result 'verdict))
+     (printf "  Run #:      ~a~n" (hash-ref release-result 'run_number))
+     (printf "  Conclusion: ~a~n" (hash-ref release-result 'conclusion))
+     (printf "  Blocking:   ~a~n" (hash-ref release-result 'blocking))
+     (printf "  Detail:     ~a~n~n" (hash-ref release-result 'detail))
+     (printf "Main CI:~n")
+     (printf "  Verdict:    ~a~n" (hash-ref ci-result 'verdict))
+     (printf "  Run #:      ~a~n" (hash-ref ci-result 'run_number))
+     (printf "  Conclusion: ~a~n" (hash-ref ci-result 'conclusion))
+     (printf "  Blocking:   ~a~n" (hash-ref ci-result 'blocking))
+     (printf "  Detail:     ~a~n~n" (hash-ref ci-result 'detail))
+     (printf "Overall blocking: ~a~n" overall-blocking?)
+     (if overall-blocking?
+         (printf "❌ RED-RUN CLASSIFICATION: BLOCKS APPROVAL~n")
+         (printf "✅ RED-RUN CLASSIFICATION: NO BLOCKING RED RUNS~n"))])
+
+  (exit (if overall-blocking? 1 0)))
+
+(module+ main
+  (main))

--- a/tests/test-actions-red-run-classifier.rkt
+++ b/tests/test-actions-red-run-classifier.rkt
@@ -1,0 +1,232 @@
+#lang racket
+
+;; @suite ci
+;; @speed fast
+;; tests/test-actions-red-run-classifier.rkt
+;;
+;; W7 (#8547): Actions red-run classifier tests.
+;; Fixture-based tests covering all 7 verdict types:
+;;   current_blocking_red_release_run  (#581 shape)
+;;   current_blocking_red_main_ci
+;;   historical_superseded_red
+;;   cancelled_superseded
+;;   in_progress_blocking
+;;   success_current
+;;   unknown_due_api_error
+
+(require rackunit
+         racket/list)
+
+(define script-path "../scripts/actions-red-run-classifier.rkt")
+
+;; --- Import classifier functions ---
+
+(define classify-red-run (dynamic-require script-path 'classify-red-run))
+
+(define classify-red-run-set (dynamic-require script-path 'classify-red-run-set))
+
+(define blocking-verdict? (dynamic-require script-path 'blocking-verdict?))
+
+(define RED_RUN_VERDICTS (dynamic-require script-path 'RED_RUN_VERDICTS))
+
+(define all-blocked-verdicts (dynamic-require script-path 'all-blocked-verdicts))
+
+;; --- Fixtures ---
+
+(define fixture-581-release-fail
+  ;; #581 shape: release.yml latest run is failure, assets published
+  (hasheq 'id
+          12345678901
+          'run_number
+          581
+          'status
+          "completed"
+          'conclusion
+          "failure"
+          'head_branch
+          "v0.99.40"))
+
+(define fixture-release-success
+  (hasheq 'id
+          12345678902
+          'run_number
+          582
+          'status
+          "completed"
+          'conclusion
+          "success"
+          'head_branch
+          "v0.99.41"))
+
+(define fixture-ci-fail-latest
+  (hasheq 'id
+          12345678903
+          'run_number
+          100
+          'status
+          "completed"
+          'conclusion
+          "failure"
+          'head_branch
+          "main"))
+
+(define fixture-ci-success
+  (hasheq 'id
+          12345678904
+          'run_number
+          101
+          'status
+          "completed"
+          'conclusion
+          "success"
+          'head_branch
+          "main"))
+
+(define fixture-ci-in-progress
+  (hasheq 'id 12345678905 'run_number 102 'status "in_progress" 'conclusion #f 'head_branch "main"))
+
+(define fixture-release-cancelled
+  (hasheq 'id
+          12345678906
+          'run_number
+          580
+          'status
+          "completed"
+          'conclusion
+          "cancelled"
+          'head_branch
+          "v0.99.40"))
+
+(define fixture-old-release-fail
+  (hasheq 'id
+          12345678907
+          'run_number
+          550
+          'status
+          "completed"
+          'conclusion
+          "failure"
+          'head_branch
+          "v0.99.39"))
+
+;; ===================================================================
+;; classify-red-run — single run tests
+;; ===================================================================
+
+(test-case "#581 shape → current_blocking_red_release_run"
+  (define verdict (classify-red-run fixture-581-release-fail "release" #t #f))
+  (check-equal? verdict "current_blocking_red_release_run"))
+
+(test-case "latest CI failure → current_blocking_red_main_ci"
+  (define verdict (classify-red-run fixture-ci-fail-latest "ci-main" #t #f))
+  (check-equal? verdict "current_blocking_red_main_ci"))
+
+(test-case "historical release failure (not latest) → historical_superseded_red"
+  (define verdict (classify-red-run fixture-old-release-fail "release" #f #f))
+  (check-equal? verdict "historical_superseded_red"))
+
+(test-case "cancelled run → cancelled_superseded"
+  (define verdict (classify-red-run fixture-release-cancelled "release" #t #f))
+  (check-equal? verdict "cancelled_superseded"))
+
+(test-case "in-progress run → in_progress_blocking"
+  (define verdict (classify-red-run fixture-ci-in-progress "ci-main" #t #f))
+  (check-equal? verdict "in_progress_blocking"))
+
+(test-case "success run → success_current"
+  (define verdict (classify-red-run fixture-release-success "release" #t #f))
+  (check-equal? verdict "success_current"))
+
+(test-case "API error → unknown_due_api_error"
+  (define verdict (classify-red-run fixture-ci-success "ci-main" #t #t))
+  (check-equal? verdict "unknown_due_api_error"))
+
+(test-case "no run data → unknown_due_api_error"
+  (define verdict (classify-red-run #f "release" #t #f))
+  (check-equal? verdict "unknown_due_api_error"))
+
+;; ===================================================================
+;; classify-red-run-set — set of runs tests
+;; ===================================================================
+
+(test-case "release set with latest failure → current_blocking_red_release_run"
+  (define result (classify-red-run-set (list fixture-581-release-fail) "release" #f))
+  (check-equal? (hash-ref result 'verdict) "current_blocking_red_release_run")
+  (check-true (hash-ref result 'blocking)))
+
+(test-case "release set with success latest → success_current"
+  (define result
+    (classify-red-run-set (list fixture-release-success fixture-581-release-fail) "release" #f))
+  (check-equal? (hash-ref result 'verdict) "success_current")
+  (check-false (hash-ref result 'blocking)))
+
+(test-case "CI set with failure latest → current_blocking_red_main_ci"
+  (define result (classify-red-run-set (list fixture-ci-fail-latest) "ci-main" #f))
+  (check-equal? (hash-ref result 'verdict) "current_blocking_red_main_ci")
+  (check-true (hash-ref result 'blocking)))
+
+(test-case "CI set with in-progress latest → in_progress_blocking"
+  (define result (classify-red-run-set (list fixture-ci-in-progress) "ci-main" #f))
+  (check-equal? (hash-ref result 'verdict) "in_progress_blocking")
+  (check-true (hash-ref result 'blocking)))
+
+(test-case "CI set with success latest → success_current"
+  (define result (classify-red-run-set (list fixture-ci-success) "ci-main" #f))
+  (check-equal? (hash-ref result 'verdict) "success_current")
+  (check-false (hash-ref result 'blocking)))
+
+(test-case "API error → unknown_due_api_error (blocks)"
+  (define result (classify-red-run-set (list fixture-ci-success) "ci-main" #t))
+  (check-equal? (hash-ref result 'verdict) "unknown_due_api_error")
+  (check-true (hash-ref result 'blocking)))
+
+(test-case "empty run set → unknown_due_api_error (blocks)"
+  (define result (classify-red-run-set '() "release" #f))
+  (check-equal? (hash-ref result 'verdict) "unknown_due_api_error")
+  (check-true (hash-ref result 'blocking)))
+
+(test-case "cancelled latest → cancelled_superseded (blocks)"
+  (define result (classify-red-run-set (list fixture-release-cancelled) "release" #f))
+  (check-equal? (hash-ref result 'verdict) "cancelled_superseded")
+  (check-true (hash-ref result 'blocking)))
+
+;; ===================================================================
+;; blocking-verdict? — blocking semantics tests
+;; ===================================================================
+
+(test-case "current_blocking_red_release_run blocks"
+  (check-true (blocking-verdict? "current_blocking_red_release_run")))
+
+(test-case "current_blocking_red_main_ci blocks"
+  (check-true (blocking-verdict? "current_blocking_red_main_ci")))
+
+(test-case "in_progress_blocking blocks"
+  (check-true (blocking-verdict? "in_progress_blocking")))
+
+(test-case "unknown_due_api_error blocks"
+  (check-true (blocking-verdict? "unknown_due_api_error")))
+
+(test-case "historical_superseded_red does NOT block"
+  (check-false (blocking-verdict? "historical_superseded_red")))
+
+(test-case "success_current does NOT block"
+  (check-false (blocking-verdict? "success_current")))
+
+(test-case "cancelled_superseded does NOT block (latest cancelled is superseded)"
+  (check-false (blocking-verdict? "cancelled_superseded")))
+
+;; ===================================================================
+;; RED_RUN_VERDICTS — completeness tests
+;; ===================================================================
+
+(test-case "RED_RUN_VERDICTS has exactly 7 verdicts"
+  (check-equal? (length RED_RUN_VERDICTS) 7))
+
+(test-case "RED_RUN_VERDICTS contains all expected verdicts"
+  (for ([v '("current_blocking_red_release_run" "current_blocking_red_main_ci"
+                                                "historical_superseded_red"
+                                                "cancelled_superseded"
+                                                "in_progress_blocking"
+                                                "success_current"
+                                                "unknown_due_api_error")])
+    (check-not-false (member v RED_RUN_VERDICTS) (format "Missing verdict: ~a" v))))


### PR DESCRIPTION
W7 — Actions red-run classifier and audit template.

**Changes:**
- `scripts/actions-red-run-classifier.rkt`: New tool classifying GitHub Actions runs into 7 verdicts (current_blocking_red_release_run, current_blocking_red_main_ci, historical_superseded_red, cancelled_superseded, in_progress_blocking, success_current, unknown_due_api_error). Pure functions `classify-red-run` and `classify-red-run-set` are testable without network.
- `tests/test-actions-red-run-classifier.rkt`: 25 fixture-based tests covering all 7 verdict types, blocking semantics, and completeness
- `docs/reports/RELEASE-ACTIONS-TRUTH-POLICY-v0.99.41.md`: Added W7 section with 7-verdict table, key principle, audit template reference

**Key behavior:**
- Historical red runs (iterative failures) do NOT block milestone approval
- Only the **latest** run matters — prevents 37/80 historical failures from obscuring current green state
- Classifier queries both release workflow runs (by tag) and main CI runs
- `unknown_due_api_error` blocks until retried

**Tests:**
- test-actions-red-run-classifier.rkt: 25 tests (all pass)
- Smoke gate: 19 files, 286 tests, all pass