### PR TITLE
feat: abstraction scanner v5 with manual red-flag signals (#8563)

### DIFF
--- a/scripts/abstraction-audit.rkt
+++ b/scripts/abstraction-audit.rkt
@@ -60,6 +60,9 @@
          count-mutation-sites
          count-hash-ref-chains
          count-inline-config-paths
+         count-stringly-verdicts
+         count-effectful-classifiers
+         count-optional-mandatory-wording
          audit-content
          current-audit-file->lines)
 
@@ -161,7 +164,13 @@
           'hash-ref-chain-count
           (count-hash-ref-chains text)
           'inline-config-path-count
-          (count-inline-config-paths text))))
+          (count-inline-config-paths text)
+          'stringly-verdict-count
+          (count-stringly-verdicts text)
+          'effectful-classifier-count
+          (count-effectful-classifiers text)
+          'optional-mandatory-count
+          (count-optional-mandatory-wording text))))
 
 ;; Count exported identifiers in (provide ...) forms.
 ;; Handles: provide id, provide (contract-out ...), provide (struct-out ...)
@@ -218,6 +227,32 @@
 
 (define (count-matches text rx)
   (length (regexp-match* rx text)))
+
+;; v0.99.42 W1: Manual red-flag signals
+;; DESIGN FACT: Each signal encodes a concrete v0.99.40/v0.99.41 incident:
+;;   stringly-verdict-rx <- #581: verdict strings scattered across modules
+;;   effectful-classifier-rx <- classify functions mixing I/O with classification
+;;   optional-mandatory-rx <- #581: optional wording for mandatory assets
+(define stringly-verdict-rx
+  #px"\"(?:success|failure|failed?|pending|cancelled?|skipped?|in_progress|completed?|blocked?|red|green|pass|fail|unknown|error|warning|timeout|neutral|action_required|publication_succeeded_smoke_failed|current_blocking_red_[a-zA-Z_0-9]+)\"")
+(define effectful-classifier-rx
+  #px"\\(define\\s+\\((?:classify|check|verify|gate|make-[a-zA-Z_0-9]*-verdict|make-[a-zA-Z_0-9]*-result)[-_a-zA-Z]*\\s")
+(define optional-before-asset-rx
+  #px"(?:optional|may[ ]+(?:be[ ]+)?(?:missing|absent|skipped))[^\n]{0,80}(?:manifest|asset|tarball)")
+(define asset-before-optional-rx
+  #px"(?:manifest|asset|tarball)[^\n]{0,80}(?:optional|may[ ]+(?:be[ ]+)?(?:missing|absent|skipped))")
+
+(define (count-stringly-verdicts text)
+  "Count string literals used as status/verdict values (failure-design smell)."
+  (count-matches text stringly-verdict-rx))
+
+(define (count-effectful-classifiers text)
+  "Count classify/verdict/check/verify function definitions that may mix effects."
+  (count-matches text effectful-classifier-rx))
+
+(define (count-optional-mandatory-wording text)
+  "Count optional language near mandatory release assets (manifest/tarball/asset)."
+  (+ (count-matches text optional-before-asset-rx) (count-matches text asset-before-optional-rx)))
 
 (define (count-struct-outs text)
   "Count the number of struct-out forms in the text."
@@ -377,6 +412,14 @@
   (define all-inline-config-paths
     (filter (lambda (f) (> (hash-ref f 'inline-config-path-count 0) 0)) findings))
 
+  ;; v0.99.42 W1: Manual red-flag signals
+  (define all-stringly-verdicts
+    (filter (lambda (f) (> (hash-ref f 'stringly-verdict-count 0) 0)) findings))
+  (define all-effectful-classifiers
+    (filter (lambda (f) (> (hash-ref f 'effectful-classifier-count 0) 0)) findings))
+  (define all-optional-mandatory
+    (filter (lambda (f) (> (hash-ref f 'optional-mandatory-count 0) 0)) findings))
+
   (hash
    'total-modules
    (length findings)
@@ -434,9 +477,18 @@
    (map (lambda (f) (hash 'path (hash-ref f 'path) 'count (hash-ref f 'hash-ref-chain-count 0)))
         (sort all-hash-ref-chains > #:key (lambda (f) (hash-ref f 'hash-ref-chain-count 0))))
    'inline-config-path-modules
+   (map (lambda (f) (hash 'path (hash-ref f 'path) 'count (hash-ref f 'inline-config-path-count 0)))
+        (sort all-inline-config-paths > #:key (lambda (f) (hash-ref f 'inline-config-path-count 0))))
+   'stringly-verdict-modules
+   (map (lambda (f) (hash 'path (hash-ref f 'path) 'count (hash-ref f 'stringly-verdict-count 0)))
+        (sort all-stringly-verdicts > #:key (lambda (f) (hash-ref f 'stringly-verdict-count 0))))
+   'effectful-classifier-modules
    (map
-    (lambda (f) (hash 'path (hash-ref f 'path) 'count (hash-ref f 'inline-config-path-count 0)))
-    (sort all-inline-config-paths > #:key (lambda (f) (hash-ref f 'inline-config-path-count 0))))))
+    (lambda (f) (hash 'path (hash-ref f 'path) 'count (hash-ref f 'effectful-classifier-count 0)))
+    (sort all-effectful-classifiers > #:key (lambda (f) (hash-ref f 'effectful-classifier-count 0))))
+   'optional-mandatory-modules
+   (map (lambda (f) (hash 'path (hash-ref f 'path) 'count (hash-ref f 'optional-mandatory-count 0)))
+        (sort all-optional-mandatory > #:key (lambda (f) (hash-ref f 'optional-mandatory-count 0))))))
 
 (define (take-at-most lst n)
   (if (> (length lst) n)
@@ -638,6 +690,40 @@
         (fprintf out "| Count | Path |\n")
         (fprintf out "|-------|------|\n")
         (for ([p icp])
+          (fprintf out "| ~a | ~a |\n" (hash-ref p 'count) (hash-ref p 'path)))
+        (fprintf out "\n")))
+
+  ;; v0.99.42 W1: Manual red-flag signals
+  (fprintf out "## Stringly Verdict Constants (string status/verdict returns)\n\n")
+  (define sv (hash-ref summary 'stringly-verdict-modules '()))
+  (if (null? sv)
+      (fprintf out "None found.\n\n")
+      (begin
+        (fprintf out "| Count | Path |\n")
+        (fprintf out "|-------|------|\n")
+        (for ([p (take-at-most sv 20)])
+          (fprintf out "| ~a | ~a |\n" (hash-ref p 'count) (hash-ref p 'path)))
+        (fprintf out "\n")))
+
+  (fprintf out "## Effectful Classifier Functions (classify/verify/gate with potential I/O)\n\n")
+  (define ec (hash-ref summary 'effectful-classifier-modules '()))
+  (if (null? ec)
+      (fprintf out "None found.\n\n")
+      (begin
+        (fprintf out "| Count | Path |\n")
+        (fprintf out "|-------|------|\n")
+        (for ([p (take-at-most ec 20)])
+          (fprintf out "| ~a | ~a |\n" (hash-ref p 'count) (hash-ref p 'path)))
+        (fprintf out "\n")))
+
+  (fprintf out "## Optional-Mandatory Asset Wording (optional near manifest/asset/tarball)\n\n")
+  (define om (hash-ref summary 'optional-mandatory-modules '()))
+  (if (null? om)
+      (fprintf out "None found.\n\n")
+      (begin
+        (fprintf out "| Count | Path |\n")
+        (fprintf out "|-------|------|\n")
+        (for ([p om])
           (fprintf out "| ~a | ~a |\n" (hash-ref p 'count) (hash-ref p 'path)))
         (fprintf out "\n")))
 

--- a/tests/test-abstraction-audit.rkt
+++ b/tests/test-abstraction-audit.rkt
@@ -570,7 +570,96 @@ EOF
                    v3-signal-tests
                    pure-audit-content-tests
                    v4-change-locality-signal-tests
-                   v4-audit-content-integration-tests)
+                   v4-audit-content-integration-tests
+                   v5-manual-red-flag-signal-tests
+                   v5-audit-content-integration-tests)
+
+;; ============================================================
+;; v0.99.42 W1: Manual red-flag signal tests
+;; ============================================================
+
+(define-test-suite
+ v5-manual-red-flag-signal-tests
+ (test-case "count-stringly-verdicts detects status string constants"
+   (define text "\"success\" \"failure\" \"pending\" \"cancelled\"")
+   (check-equal? ((audit-ref 'count-stringly-verdicts) text) 4 "counts 4 verdict strings"))
+ (test-case "count-stringly-verdicts detects publication_succeeded_smoke_failed"
+   (define text "\"publication_succeeded_smoke_failed\"")
+   (check-equal? ((audit-ref 'count-stringly-verdicts) text) 1 "detects compound verdict string"))
+ (test-case "count-stringly-verdicts detects current_blocking_red variant"
+   (define text "\"current_blocking_red_release_run\"")
+   (check-equal? ((audit-ref 'count-stringly-verdicts) text) 1 "detects blocking verdict string"))
+ (test-case "count-stringly-verdicts returns 0 for clean text"
+   (define text "(define (f x) x)")
+   (check-equal? ((audit-ref 'count-stringly-verdicts) text) 0 "clean text returns 0"))
+ (test-case "count-effectful-classifiers detects classify function"
+   (define text "(define (classify-run data) ...)")
+   (check-pred positive? ((audit-ref 'count-effectful-classifiers) text) "detects classify function"))
+ (test-case "count-effectful-classifiers detects check-* function"
+   (define text "(define (check-release-status release) ...)")
+   (check-pred positive? ((audit-ref 'count-effectful-classifiers) text) "detects check function"))
+ (test-case "count-effectful-classifiers detects verify function"
+   (define text "(define (verify-manifest data) ...)")
+   (check-pred positive? ((audit-ref 'count-effectful-classifiers) text) "detects verify function"))
+ (test-case "count-effectful-classifiers detects gate function"
+   (define text "(define (gate-release info) ...)")
+   (check-pred positive? ((audit-ref 'count-effectful-classifiers) text) "detects gate function"))
+ (test-case "count-effectful-classifiers detects make-*-verdict function"
+   (define text "(define (make-ci-verdict data) ...)")
+   (check-pred positive?
+               ((audit-ref 'count-effectful-classifiers) text)
+               "detects make-verdict function"))
+ (test-case "count-effectful-classifiers returns 0 for non-classifier"
+   (define text "(define (process-data x) x)")
+   (check-equal? ((audit-ref 'count-effectful-classifiers) text) 0 "non-classifier returns 0"))
+ (test-case "count-optional-mandatory-wording detects optional manifest"
+   (define text "The manifest is optional and may be missing")
+   (check-pred positive?
+               ((audit-ref 'count-optional-mandatory-wording) text)
+               "detects optional manifest"))
+ (test-case "count-optional-mandatory-wording detects may be absent asset"
+   (define text "If the asset may be absent, skip validation")
+   (check-pred positive?
+               ((audit-ref 'count-optional-mandatory-wording) text)
+               "detects may be absent asset"))
+ (test-case "count-optional-mandatory-wording returns 0 for mandatory wording"
+   (define text "The manifest is required")
+   (check-equal? ((audit-ref 'count-optional-mandatory-wording) text)
+                 0
+                 "mandatory wording returns 0"))
+ (test-case "count-optional-mandatory-wording returns 0 for unrelated optional"
+   (define text "The flag is optional for backwards compatibility")
+   (check-equal? ((audit-ref 'count-optional-mandatory-wording) text)
+                 0
+                 "unrelated optional returns 0")))
+
+(define-test-suite
+ v5-audit-content-integration-tests
+ (test-case "audit-content includes 3 new v0.99.42 signal keys"
+   (define text "#lang racket/base\n(define (f x) x)")
+   (define finding ((audit-ref 'audit-content) "test.rkt" text))
+   (check-true (hash-has-key? finding 'stringly-verdict-count) "has stringly-verdict-count")
+   (check-true (hash-has-key? finding 'effectful-classifier-count) "has effectful-classifier-count")
+   (check-true (hash-has-key? finding 'optional-mandatory-count) "has optional-mandatory-count"))
+ (test-case "audit-content detects stringly verdict in fixture"
+   (define text "#lang racket/base\n(define (get-status)\n  \"success\")")
+   (define finding ((audit-ref 'audit-content) "verdict.rkt" text))
+   (check-pred positive? (hash-ref finding 'stringly-verdict-count) "stringly-verdict > 0"))
+ (test-case "audit-content detects effectful classifier in fixture"
+   (define text
+     "#lang racket/base\n(define (classify-run run-data)\n  (if (hash-ref run-data 'status)\n      \"success\"\n      \"failure\"))")
+   (define finding ((audit-ref 'audit-content) "classify.rkt" text))
+   (check-pred positive? (hash-ref finding 'effectful-classifier-count) "effectful-classifier > 0"))
+ (test-case "audit-content detects optional-mandatory wording in fixture"
+   (define text "#lang racket/base\n;; The release manifest is optional in this workflow.")
+   (define finding ((audit-ref 'audit-content) "optional.rkt" text))
+   (check-pred positive? (hash-ref finding 'optional-mandatory-count) "optional-mandatory > 0"))
+ (test-case "audit-content on clean text has all 0 v5 signals"
+   (define text "#lang racket/base\n(define (f x) x)")
+   (define finding ((audit-ref 'audit-content) "clean.rkt" text))
+   (check-equal? (hash-ref finding 'stringly-verdict-count) 0 "clean: 0 stringly-verdicts")
+   (check-equal? (hash-ref finding 'effectful-classifier-count) 0 "clean: 0 effectful-classifiers")
+   (check-equal? (hash-ref finding 'optional-mandatory-count) 0 "clean: 0 optional-mandatory")))
 
 (module+ test
   (run-tests all-abstraction-audit-tests))


### PR DESCRIPTION
## W1 — Abstraction scanner/checklist v5 for manual red flags

### Changes
- Added 3 new high-signal checks to `scripts/abstraction-audit.rkt`:
  - `count-stringly-verdicts`: detects string status/verdict constants (§25 failure design)
  - `count-effectful-classifiers`: detects classify/verify/gate functions (§16 pure-core/effect-shell)
  - `count-optional-mandatory-wording`: detects optional language near mandatory assets (#581 incident)
- Added 23 new tests in `tests/test-abstraction-audit.rkt` (80 total, was 57)
- Scanner output now includes 3 new report sections

### Evidence
- Stringly verdicts: milestone-gate.rkt (32), actions-red-run-classifier.rkt (23) — directly from v0.99.41 incidents
- Effectful classifiers: lint-tests.rkt (7), lint-version.rkt (6) — real boundary violations
- Optional-mandatory: detected in scanner self-reference (expected)

### Gates
- `raco make scripts/abstraction-audit.rkt` ✅
- `raco test tests/test-abstraction-audit.rkt` — 80/80 pass ✅
- Smoke gate: 19 files, 286 tests ✅
