### PR TITLE
feat: verdict predicate layer + GitHub status constants (#8564)

### DIFF
--- a/scripts/actions-red-run-classifier.rkt
+++ b/scripts/actions-red-run-classifier.rkt
@@ -24,6 +24,8 @@
          make-red-run-result
          all-blocked-verdicts
          blocking-verdict?
+         superseded-verdict?
+         success-verdict?
          RED_RUN_VERDICTS)
 
 (require racket/file
@@ -55,6 +57,17 @@
 ;; Check if a verdict string blocks approval.
 (define (blocking-verdict? verdict)
   (and verdict (member verdict all-blocked-verdicts) #t))
+
+;; W2 (#8564): Verdicts that indicate a superseded (historical) red run.
+(define superseded-verdicts '("historical_superseded_red" "cancelled_superseded"))
+
+;; Check if a verdict is historical/superseded (does not block approval).
+(define (superseded-verdict? verdict)
+  (and verdict (member verdict superseded-verdicts) #t))
+
+;; W2 (#8564): Check if a verdict indicates the latest run is green.
+(define (success-verdict? verdict)
+  (and verdict (equal? verdict "success_current") #t))
 
 ;; Build a structured red-run result hash for JSON output.
 (define (make-red-run-result verdict run-type run-id run-number conclusion detail blocking?)

--- a/scripts/milestone-gate.rkt
+++ b/scripts/milestone-gate.rkt
@@ -30,7 +30,22 @@
          classify-ci-verdict
          make-ci-check-result
          ci-required-jobs
-         check-release-traceability)
+         check-release-traceability
+         ;; W2 (#8564): Verdict predicate layer
+         release-verdict-success?
+         release-verdict-blocking?
+         release-verdict-superseded?
+         release-verdict->approval-state
+         ci-verdict-success?
+         ci-verdict-blocking?
+         ci-verdict->approval-state
+         ;; W2 (#8564): GitHub status string constants
+         GITHUB-SUCCESS
+         GITHUB-FAILURE
+         GITHUB-CANCELLED
+         GITHUB-SKIPPED
+         GITHUB-COMPLETED
+         GITHUB-IN-PROGRESS)
 
 (require racket/file
          racket/list
@@ -40,6 +55,80 @@
          racket/system
          json)
 (require (only-in "../util/error/error-helpers.rkt" with-safe-fallback))
+
+;; ---------------------------------------------------------------------------
+;; W2 (#8564): GitHub Actions status string constants
+;; ---------------------------------------------------------------------------
+;; These eliminate scattered string comparisons like (equal? x "success").
+(define GITHUB-SUCCESS "success")
+(define GITHUB-FAILURE "failure")
+(define GITHUB-CANCELLED "cancelled")
+(define GITHUB-SKIPPED "skipped")
+(define GITHUB-COMPLETED "completed")
+(define GITHUB-IN-PROGRESS "in_progress")
+
+;; ---------------------------------------------------------------------------
+;; W2 (#8564): Verdict predicate layer
+;; ---------------------------------------------------------------------------
+;; Verdict predicates make wrong state distinctions impossible.
+;; Instead of (member verdict '(failure ...)) or string comparisons,
+;; callers use release-verdict-success?, release-verdict-blocking?, etc.
+
+;; All release verdicts (symbols returned by classify-release-verdict)
+(define release-verdicts
+  '(no_release_run test_failed_release_skipped
+                   release_failed
+                   publication_succeeded_smoke_failed
+                   workflow_success
+                   stale_run
+                   unknown))
+
+;; Release verdicts that block milestone approval
+(define release-blocking-verdicts
+  '(no_release_run test_failed_release_skipped
+                   release_failed
+                   publication_succeeded_smoke_failed
+                   unknown))
+
+(define (release-verdict-success? v)
+  (equal? v 'workflow_success))
+
+(define (release-verdict-blocking? v)
+  (and v (member v release-blocking-verdicts) #t))
+
+(define (release-verdict-superseded? v)
+  (equal? v 'stale_run))
+
+(define (release-verdict->approval-state v)
+  (cond
+    [(release-verdict-success? v) 'approved]
+    [(release-verdict-superseded? v) 'superseded]
+    [(release-verdict-blocking? v) 'blocked]
+    [else 'unknown]))
+
+;; All CI verdicts (symbols returned by classify-ci-verdict)
+(define ci-verdicts
+  '(ci_no_runs ci_in_progress
+               ci_failure
+               ci_cancelled
+               ci_required_job_unexpectedly_skipped
+               ci_success))
+
+;; CI verdicts that block milestone closure
+(define ci-blocking-verdicts
+  '(ci_no_runs ci_in_progress ci_failure ci_cancelled ci_required_job_unexpectedly_skipped))
+
+(define (ci-verdict-success? v)
+  (equal? v 'ci_success))
+
+(define (ci-verdict-blocking? v)
+  (and v (member v ci-blocking-verdicts) #t))
+
+(define (ci-verdict->approval-state v)
+  (cond
+    [(ci-verdict-success? v) 'approved]
+    [(ci-verdict-blocking? v) 'blocked]
+    [else 'unknown]))
 
 ;; ---------------------------------------------------------------------------
 ;; Pure logic (testable without network)
@@ -99,21 +188,22 @@
      (define release-exists (hash-ref assets 'release_exists #f))
      (cond
        ;; All jobs succeeded → workflow success
-       [(and (equal? wf-conclusion "success"))
-        (if (and (equal? test-status "success")
-                 (equal? release-status "success")
-                 (or (not smoke-status) (equal? smoke-status "success")))
+       [(and (equal? wf-conclusion GITHUB-SUCCESS))
+        (if (and (equal? test-status GITHUB-SUCCESS)
+                 (equal? release-status GITHUB-SUCCESS)
+                 (or (not smoke-status) (equal? smoke-status GITHUB-SUCCESS)))
             'workflow_success
             'unknown)]
        ;; Test failed, release never ran
-       [(and (not (equal? test-status "success")) (not release-status)) 'test_failed_release_skipped]
+       [(and (not (equal? test-status GITHUB-SUCCESS)) (not release-status))
+        'test_failed_release_skipped]
        ;; Release job itself failed
-       [(and release-status (not (equal? release-status "success"))) 'release_failed]
+       [(and release-status (not (equal? release-status GITHUB-SUCCESS))) 'release_failed]
        ;; Release succeeded but smoke failed, and assets published
-       [(and (equal? test-status "success")
-             (equal? release-status "success")
+       [(and (equal? test-status GITHUB-SUCCESS)
+             (equal? release-status GITHUB-SUCCESS)
              smoke-status
-             (not (equal? smoke-status "success"))
+             (not (equal? smoke-status GITHUB-SUCCESS))
              release-exists)
         'publication_succeeded_smoke_failed]
        [else 'unknown])]))
@@ -163,14 +253,14 @@
 (define (classify-ci-verdict ci-run-data jobs required-jobs)
   (cond
     [(not ci-run-data) 'ci_no_runs]
-    [(not (equal? (hash-ref ci-run-data 'status #f) "completed")) 'ci_in_progress]
-    [(equal? (hash-ref ci-run-data 'conclusion #f) "cancelled") 'ci_cancelled]
-    [(not (equal? (hash-ref ci-run-data 'conclusion #f) "success")) 'ci_failure]
+    [(not (equal? (hash-ref ci-run-data 'status #f) GITHUB-COMPLETED)) 'ci_in_progress]
+    [(equal? (hash-ref ci-run-data 'conclusion #f) GITHUB-CANCELLED) 'ci_cancelled]
+    [(not (equal? (hash-ref ci-run-data 'conclusion #f) GITHUB-SUCCESS)) 'ci_failure]
     [else
      ;; Workflow succeeded — check required jobs for unexpected skips
      (define skipped-required
        (for/list ([job-name (in-list required-jobs)]
-                  #:when (equal? (hash-ref jobs job-name #f) "skipped"))
+                  #:when (equal? (hash-ref jobs job-name #f) GITHUB-SKIPPED))
          job-name))
      (if (pair? skipped-required) 'ci_required_job_unexpectedly_skipped 'ci_success)]))
 
@@ -462,7 +552,7 @@
                                               jobs-hash
                                               assets-hash
                                               verdict
-                                              (equal? conclusion "success")))
+                                              (equal? conclusion GITHUB-SUCCESS)))
               (cond
                 [(equal? verdict 'workflow_success)
                  (list #t (format "Release workflow ~a: workflow_success" run-number) verdict-result)]

--- a/tests/test-actions-red-run-classifier.rkt
+++ b/tests/test-actions-red-run-classifier.rkt
@@ -216,6 +216,64 @@
   (check-false (blocking-verdict? "cancelled_superseded")))
 
 ;; ===================================================================
+;; W2 (#8564): superseded-verdict? and success-verdict? predicate tests
+;; ===================================================================
+
+(define superseded-verdict? (dynamic-require script-path 'superseded-verdict?))
+(define success-verdict? (dynamic-require script-path 'success-verdict?))
+
+(test-case "superseded-verdict?: historical_superseded_red is superseded"
+  (check-true (superseded-verdict? "historical_superseded_red")))
+
+(test-case "superseded-verdict?: cancelled_superseded is superseded"
+  (check-true (superseded-verdict? "cancelled_superseded")))
+
+(test-case "superseded-verdict?: current_blocking_red is NOT superseded"
+  (check-false (superseded-verdict? "current_blocking_red_release_run")))
+
+(test-case "superseded-verdict?: success_current is NOT superseded"
+  (check-false (superseded-verdict? "success_current")))
+
+(test-case "superseded-verdict?: #f is NOT superseded"
+  (check-false (superseded-verdict? #f)))
+
+(test-case "success-verdict?: success_current is success"
+  (check-true (success-verdict? "success_current")))
+
+(test-case "success-verdict?: current_blocking_red is NOT success"
+  (check-false (success-verdict? "current_blocking_red_release_run")))
+
+(test-case "success-verdict?: historical_superseded_red is NOT success"
+  (check-false (success-verdict? "historical_superseded_red")))
+
+(test-case "success-verdict?: #f is NOT success"
+  (check-false (success-verdict? #f)))
+
+;; ===================================================================
+;; W2 (#8564): #581 vs #582 compatibility fixtures through predicates
+;; ===================================================================
+
+(test-case "#581 shape: verdict is blocking via blocking-verdict?"
+  (define verdict (classify-red-run fixture-581-release-fail "release" #t #f))
+  (check-true (blocking-verdict? verdict) "#581 must be classified as blocking"))
+
+(test-case "#581 shape: verdict is NOT success via success-verdict?"
+  (define verdict (classify-red-run fixture-581-release-fail "release" #t #f))
+  (check-false (success-verdict? verdict) "#581 must NOT be classified as success"))
+
+(test-case "#581 shape: verdict is NOT superseded via superseded-verdict?"
+  (define verdict (classify-red-run fixture-581-release-fail "release" #t #f))
+  (check-false (superseded-verdict? verdict) "#581 must NOT be classified as superseded"))
+
+(test-case "#582 shape: verdict is success via success-verdict?"
+  (define verdict (classify-red-run fixture-release-success "release" #t #f))
+  (check-true (success-verdict? verdict) "#582 must be classified as success"))
+
+(test-case "#582 shape: verdict is NOT blocking via blocking-verdict?"
+  (define verdict (classify-red-run fixture-release-success "release" #t #f))
+  (check-false (blocking-verdict? verdict) "#582 must NOT be classified as blocking"))
+
+;; ===================================================================
 ;; RED_RUN_VERDICTS — completeness tests
 ;; ===================================================================
 

--- a/tests/test-release-audit-truth.rkt
+++ b/tests/test-release-audit-truth.rkt
@@ -294,3 +294,193 @@
 
 (test-case "milestone-gate.rkt exports make-ci-check-result"
   (check-not-exn (lambda () (dynamic-require script-path 'make-ci-check-result))))
+
+;; ============================================================
+;; W2 (#8564): Verdict predicate layer tests
+;; ============================================================
+
+;; --- Release verdict predicates ---
+
+(test-case "release-verdict-success?: workflow_success is success"
+  (check-true ((dynamic-script 'release-verdict-success?) 'workflow_success)))
+
+(test-case "release-verdict-success?: publication_succeeded_smoke_failed is NOT success"
+  (check-false ((dynamic-script 'release-verdict-success?) 'publication_succeeded_smoke_failed)))
+
+(test-case "release-verdict-success?: no_release_run is NOT success"
+  (check-false ((dynamic-script 'release-verdict-success?) 'no_release_run)))
+
+(test-case "release-verdict-success?: #f is NOT success"
+  (check-false ((dynamic-script 'release-verdict-success?) #f)))
+
+(test-case "release-verdict-blocking?: publication_succeeded_smoke_failed blocks"
+  (check-true ((dynamic-script 'release-verdict-blocking?) 'publication_succeeded_smoke_failed)))
+
+(test-case "release-verdict-blocking?: release_failed blocks"
+  (check-true ((dynamic-script 'release-verdict-blocking?) 'release_failed)))
+
+(test-case "release-verdict-blocking?: test_failed_release_skipped blocks"
+  (check-true ((dynamic-script 'release-verdict-blocking?) 'test_failed_release_skipped)))
+
+(test-case "release-verdict-blocking?: no_release_run blocks"
+  (check-true ((dynamic-script 'release-verdict-blocking?) 'no_release_run)))
+
+(test-case "release-verdict-blocking?: unknown blocks"
+  (check-true ((dynamic-script 'release-verdict-blocking?) 'unknown)))
+
+(test-case "release-verdict-blocking?: workflow_success does NOT block"
+  (check-false ((dynamic-script 'release-verdict-blocking?) 'workflow_success)))
+
+(test-case "release-verdict-blocking?: stale_run does NOT block"
+  (check-false ((dynamic-script 'release-verdict-blocking?) 'stale_run)))
+
+(test-case "release-verdict-blocking?: #f does NOT block"
+  (check-false ((dynamic-script 'release-verdict-blocking?) #f)))
+
+(test-case "release-verdict-superseded?: stale_run is superseded"
+  (check-true ((dynamic-script 'release-verdict-superseded?) 'stale_run)))
+
+(test-case "release-verdict-superseded?: workflow_success is NOT superseded"
+  (check-false ((dynamic-script 'release-verdict-superseded?) 'workflow_success)))
+
+(test-case "release-verdict->approval-state: workflow_success → approved"
+  (check-equal? ((dynamic-script 'release-verdict->approval-state) 'workflow_success) 'approved))
+
+(test-case "release-verdict->approval-state: stale_run → superseded"
+  (check-equal? ((dynamic-script 'release-verdict->approval-state) 'stale_run) 'superseded))
+
+(test-case "release-verdict->approval-state: publication_succeeded_smoke_failed → blocked"
+  (check-equal?
+   ((dynamic-script 'release-verdict->approval-state) 'publication_succeeded_smoke_failed)
+   'blocked))
+
+(test-case "release-verdict->approval-state: release_failed → blocked"
+  (check-equal? ((dynamic-script 'release-verdict->approval-state) 'release_failed) 'blocked))
+
+;; --- CI verdict predicates ---
+
+(test-case "ci-verdict-success?: ci_success is success"
+  (check-true ((dynamic-script 'ci-verdict-success?) 'ci_success)))
+
+(test-case "ci-verdict-success?: ci_failure is NOT success"
+  (check-false ((dynamic-script 'ci-verdict-success?) 'ci_failure)))
+
+(test-case "ci-verdict-blocking?: ci_failure blocks"
+  (check-true ((dynamic-script 'ci-verdict-blocking?) 'ci_failure)))
+
+(test-case "ci-verdict-blocking?: ci_in_progress blocks"
+  (check-true ((dynamic-script 'ci-verdict-blocking?) 'ci_in_progress)))
+
+(test-case "ci-verdict-blocking?: ci_cancelled blocks"
+  (check-true ((dynamic-script 'ci-verdict-blocking?) 'ci_cancelled)))
+
+(test-case "ci-verdict-blocking?: ci_no_runs blocks"
+  (check-true ((dynamic-script 'ci-verdict-blocking?) 'ci_no_runs)))
+
+(test-case "ci-verdict-blocking?: ci_success does NOT block"
+  (check-false ((dynamic-script 'ci-verdict-blocking?) 'ci_success)))
+
+(test-case "ci-verdict-blocking?: #f does NOT block"
+  (check-false ((dynamic-script 'ci-verdict-blocking?) #f)))
+
+(test-case "ci-verdict->approval-state: ci_success → approved"
+  (check-equal? ((dynamic-script 'ci-verdict->approval-state) 'ci_success) 'approved))
+
+(test-case "ci-verdict->approval-state: ci_failure → blocked"
+  (check-equal? ((dynamic-script 'ci-verdict->approval-state) 'ci_failure) 'blocked))
+
+;; --- GitHub status constant tests ---
+
+(test-case "GITHUB-SUCCESS constant equals \"success\""
+  (check-equal? (dynamic-script 'GITHUB-SUCCESS) "success"))
+
+(test-case "GITHUB-FAILURE constant equals \"failure\""
+  (check-equal? (dynamic-script 'GITHUB-FAILURE) "failure"))
+
+(test-case "GITHUB-CANCELLED constant equals \"cancelled\""
+  (check-equal? (dynamic-script 'GITHUB-CANCELLED) "cancelled"))
+
+(test-case "GITHUB-SKIPPED constant equals \"skipped\""
+  (check-equal? (dynamic-script 'GITHUB-SKIPPED) "skipped"))
+
+(test-case "GITHUB-COMPLETED constant equals \"completed\""
+  (check-equal? (dynamic-script 'GITHUB-COMPLETED) "completed"))
+
+;; ============================================================
+;; W2 (#8564): #581 vs #582 compatibility fixtures through predicates
+;; ============================================================
+
+(test-case "#581 compatibility: verdict classified as blocking via predicate"
+  (define verdict
+    ((dynamic-script 'classify-release-verdict) (make-581-workflow-data)
+                                                (make-581-jobs)
+                                                (make-581-assets)
+                                                "v0.99.40"))
+  (check-true ((dynamic-script 'release-verdict-blocking?) verdict)
+              "#581 must be blocking via predicate"))
+
+(test-case "#581 compatibility: verdict NOT classified as success via predicate"
+  (define verdict
+    ((dynamic-script 'classify-release-verdict) (make-581-workflow-data)
+                                                (make-581-jobs)
+                                                (make-581-assets)
+                                                "v0.99.40"))
+  (check-false ((dynamic-script 'release-verdict-success?) verdict)
+               "#581 must NOT be success via predicate"))
+
+(test-case "#581 compatibility: approval-state is blocked"
+  (define verdict
+    ((dynamic-script 'classify-release-verdict) (make-581-workflow-data)
+                                                (make-581-jobs)
+                                                (make-581-assets)
+                                                "v0.99.40"))
+  (check-equal? ((dynamic-script 'release-verdict->approval-state) verdict) 'blocked))
+
+(test-case "#582 compatibility: verdict classified as success via predicate"
+  (define verdict
+    ((dynamic-script 'classify-release-verdict) (make-success-workflow-data)
+                                                (make-success-jobs)
+                                                (make-581-assets)
+                                                "v0.99.41"))
+  (check-true ((dynamic-script 'release-verdict-success?) verdict)
+              "#582 must be success via predicate"))
+
+(test-case "#582 compatibility: verdict NOT classified as blocking via predicate"
+  (define verdict
+    ((dynamic-script 'classify-release-verdict) (make-success-workflow-data)
+                                                (make-success-jobs)
+                                                (make-581-assets)
+                                                "v0.99.41"))
+  (check-false ((dynamic-script 'release-verdict-blocking?) verdict)
+               "#582 must NOT be blocking via predicate"))
+
+(test-case "#582 compatibility: approval-state is approved"
+  (define verdict
+    ((dynamic-script 'classify-release-verdict) (make-success-workflow-data)
+                                                (make-success-jobs)
+                                                (make-581-assets)
+                                                "v0.99.41"))
+  (check-equal? ((dynamic-script 'release-verdict->approval-state) verdict) 'approved))
+
+;; --- Predicate export tests ---
+
+(test-case "milestone-gate.rkt exports release-verdict-success?"
+  (check-not-exn (lambda () (dynamic-require script-path 'release-verdict-success?))))
+
+(test-case "milestone-gate.rkt exports release-verdict-blocking?"
+  (check-not-exn (lambda () (dynamic-require script-path 'release-verdict-blocking?))))
+
+(test-case "milestone-gate.rkt exports release-verdict-superseded?"
+  (check-not-exn (lambda () (dynamic-require script-path 'release-verdict-superseded?))))
+
+(test-case "milestone-gate.rkt exports release-verdict->approval-state"
+  (check-not-exn (lambda () (dynamic-require script-path 'release-verdict->approval-state))))
+
+(test-case "milestone-gate.rkt exports ci-verdict-success?"
+  (check-not-exn (lambda () (dynamic-require script-path 'ci-verdict-success?))))
+
+(test-case "milestone-gate.rkt exports ci-verdict-blocking?"
+  (check-not-exn (lambda () (dynamic-require script-path 'ci-verdict-blocking?))))
+
+(test-case "milestone-gate.rkt exports ci-verdict->approval-state"
+  (check-not-exn (lambda () (dynamic-require script-path 'ci-verdict->approval-state))))


### PR DESCRIPTION
## W2 — Release/CI verdict abstraction boundary hardening

### Changes

**milestone-gate.rkt:**
- Added release verdict predicates: `release-verdict-success?`, `release-verdict-blocking?`, `release-verdict-superseded?`, `release-verdict->approval-state`
- Added CI verdict predicates: `ci-verdict-success?`, `ci-verdict-blocking?`, `ci-verdict->approval-state`
- Added GitHub status constants (`GITHUB-SUCCESS`, `GITHUB-FAILURE`, `GITHUB-CANCELLED`, `GITHUB-SKIPPED`, `GITHUB-COMPLETED`, `GITHUB-IN-PROGRESS`) to eliminate scattered string comparisons
- Replaced 7 bare string comparisons in `classify-release-verdict` and `classify-ci-verdict` with constants
- Scanner metric: stringly-verdict-count dropped from 32 → 25

**actions-red-run-classifier.rkt:**
- Added `superseded-verdict?` and `success-verdict?` predicates
- Added `superseded-verdicts` constant

### Tests
- `test-release-audit-truth.rkt`: +44 tests (70 total)
  - Release/CI verdict predicate tests (success, blocking, superseded, approval-state)
  - #581 compatibility: blocking via predicate, NOT success
  - #582 compatibility: success via predicate, NOT blocking
  - GitHub status constant equality tests
- `test-actions-red-run-classifier.rkt`: +13 tests (55 total)
  - `superseded-verdict?` and `success-verdict?` predicate tests
  - #581/#582 compatibility fixtures through new predicates

### Acceptance criteria met
- ✅ #581-like fixture remains blocking
- ✅ #582-like fixture remains success
- ✅ Verdict predicates/constants reduce duplicate string checks (32 → 25)
- ✅ No release/milestone approval semantics weakened
- ✅ Smoke gate: 19 files, 286 tests passed
