### PR TITLE
feat: pure-core/effect-shell I/O boundary for gen-release-manifest (#8567)

### DIFF
--- a/scripts/gen-release-manifest.rkt
+++ b/scripts/gen-release-manifest.rkt
@@ -16,7 +16,7 @@
          racket/path
          json)
 
-;; Provide W4 parse/validate/render boundary
+;; Provide W4 parse/validate/render boundary + W5 pure-core/effect-shell
 (provide (struct-out manifest)
          (struct-out manifest-asset)
          (struct-out manifest-trace)
@@ -28,7 +28,12 @@
          jsexpr->manifest
          validate-manifest
          parse-manifest-json
-         manifest->json-string)
+         manifest->json-string
+         ;; W5 (#8567): pure-core/effect-shell I/O boundary
+         (struct-out release-inputs)
+         build-manifest
+         commits-match?
+         parse-q-version)
 
 ;; ---------------------------------------------------------------------------
 ;; W4 (#8566): Manifest domain model — parse/validate/render boundary
@@ -212,7 +217,50 @@
   (manifest-validation (null? errors) (reverse errors)))
 
 ;; ---------------------------------------------------------------------------
-;; Version parsing
+;; W5 (#8567): Pure-core / effect-shell I/O boundary
+;; ---------------------------------------------------------------------------
+;; Separates manifest construction (pure) from data collection (effects).
+;; The pure core takes a release-inputs struct and produces a manifest.
+;; The effect shell collects raw data from files, git, and the environment.
+
+;; Raw inputs gathered from the environment (no processing, just collection).
+(struct release-inputs
+        (version commit date tarball-name tarball-size tarball-sha256 tag-commit-sha tag-object-sha)
+  #:transparent)
+
+;; Pure: determine if two commit SHAs match (exact, prefix, or both unknown).
+(define (commits-match? commit tag-commit-sha)
+  (and commit
+       tag-commit-sha
+       (not (equal? commit "unknown"))
+       (not (equal? tag-commit-sha "unknown"))
+       (or (string=? commit tag-commit-sha)
+           (string-prefix? tag-commit-sha commit)
+           (string-prefix? commit tag-commit-sha))))
+
+;; Pure: build a manifest from raw release inputs.
+;; No I/O — takes a release-inputs struct, produces a manifest struct.
+(define (build-manifest ri)
+  (define version (release-inputs-version ri))
+  (define commit (release-inputs-commit ri))
+  (define tag-name (format "v~a" version))
+  (define tag-commit-sha (release-inputs-tag-commit-sha ri))
+  (define commit* (or commit "unknown"))
+  (define commit-matches? (commits-match? commit* tag-commit-sha))
+  (make-manifest #:version version
+                 #:commit commit*
+                 #:date (release-inputs-date ri)
+                 #:assets (list (manifest-asset (release-inputs-tarball-name ri)
+                                                (release-inputs-tarball-size ri)
+                                                (release-inputs-tarball-sha256 ri)))
+                 #:traceability (manifest-trace tag-name
+                                                tag-commit-sha
+                                                (release-inputs-tag-object-sha ri)
+                                                commit*
+                                                commit-matches?)))
+
+;; ---------------------------------------------------------------------------
+;; Version parsing (pure — takes file content string)
 ;; ---------------------------------------------------------------------------
 
 (define (parse-q-version content)
@@ -260,6 +308,18 @@
   (if (or (string=? trimmed "") (regexp-match? #rx"unknown revision" trimmed)) #f trimmed))
 
 (define (emit-manifest version commit date tarball-path)
+  ;; Effect shell: collect raw inputs from filesystem and git
+  (define ri (collect-release-inputs version commit date tarball-path))
+  ;; Pure core: build manifest from inputs
+  (define m (build-manifest ri))
+  ;; Render: serialize and print
+  (displayln (manifest->json-string m)))
+
+;; ---------------------------------------------------------------------------
+;; Effect shell: collect raw inputs from the environment
+;; ---------------------------------------------------------------------------
+
+(define (collect-release-inputs version commit date tarball-path)
   (define size
     (if tarball-path
         (file-size-bytes tarball-path)
@@ -272,28 +332,10 @@
     (if tarball-path
         (path->string (file-name-from-path tarball-path))
         (format "q-~a.tar.gz" version)))
-  ;; Traceability: tag SHA and tag object SHA
   (define tag-name (format "v~a" version))
   (define tag-commit-sha (git-tag-sha tag-name))
   (define tag-obj-sha (git-tag-object-sha tag-name))
-  (define commit* (or commit "unknown"))
-  (define commit-matches?
-    (and commit
-         (not (equal? commit "unknown"))
-         (not (equal? tag-commit-sha "unknown"))
-         (or (string=? commit tag-commit-sha)
-             (string-prefix? tag-commit-sha commit)
-             (string-prefix? commit tag-commit-sha))))
-  ;; Build manifest struct (W4: parse/validate/render boundary)
-  (define m
-    (make-manifest #:version version
-                   #:commit commit*
-                   #:date date
-                   #:assets (list (manifest-asset tarball-name size sha))
-                   #:traceability
-                   (manifest-trace tag-name tag-commit-sha tag-obj-sha commit* commit-matches?)))
-  ;; Serialize to JSON
-  (displayln (manifest->json-string m)))
+  (release-inputs version commit date tarball-name size sha tag-commit-sha tag-obj-sha))
 
 ;; ---------------------------------------------------------------------------
 ;; Main

--- a/tests/test-release-manifest-traceability.rkt
+++ b/tests/test-release-manifest-traceability.rkt
@@ -343,3 +343,172 @@
 
 (test-case "gen-release-manifest.rkt exports manifest-valid?"
   (check-not-exn (lambda () (dynamic-require manifest-script-path 'manifest-valid?))))
+
+;; ============================================================
+;; W5 (#8567): Pure-core/effect-shell I/O boundary tests
+;; ============================================================
+
+(require (only-in "../scripts/gen-release-manifest.rkt"
+                  release-inputs
+                  release-inputs?
+                  release-inputs-version
+                  release-inputs-commit
+                  release-inputs-date
+                  release-inputs-tarball-name
+                  release-inputs-tarball-size
+                  release-inputs-tarball-sha256
+                  release-inputs-tag-commit-sha
+                  release-inputs-tag-object-sha
+                  build-manifest
+                  commits-match?
+                  parse-q-version))
+
+;; --- commits-match? predicate ---
+
+(test-case "commits-match?: exact match"
+  (check-true (commits-match? "abc1234" "abc1234")))
+
+(test-case "commits-match?: prefix match (tag longer)"
+  (check-true (commits-match? "abc1234" "abc123456789")))
+
+(test-case "commits-match?: prefix match (commit longer)"
+  (check-true (commits-match? "abc123456789" "abc1234")))
+
+(test-case "commits-match?: different commits"
+  (check-false (commits-match? "abc1234" "def5678")))
+
+(test-case "commits-match?: unknown commit"
+  (check-false (commits-match? "unknown" "abc1234")))
+
+(test-case "commits-match?: unknown tag sha"
+  (check-false (commits-match? "abc1234" "unknown")))
+
+(test-case "commits-match?: #f commit"
+  (check-false (commits-match? #f "abc1234")))
+
+(test-case "commits-match?: #f tag sha"
+  (check-false (commits-match? "abc1234" #f)))
+
+;; --- parse-q-version (pure) ---
+
+(test-case "parse-q-version: valid version line"
+  (check-equal? (parse-q-version "(define q-version \"0.99.42\")") "0.99.42"))
+
+(test-case "parse-q-version: returns #f for no match"
+  (check-false (parse-q-version "no version here")))
+
+(test-case "parse-q-version: handles multiline content"
+  (check-equal? (parse-q-version "#lang racket/base\n(define q-version \"1.2.3\")\n") "1.2.3"))
+
+;; --- release-inputs struct ---
+
+(test-case "release-inputs struct: all fields accessible"
+  (define ri
+    (release-inputs "1.0.0"
+                    "abc123"
+                    "2026-06-22"
+                    "q-1.0.0.tar.gz"
+                    999
+                    "deadbeef"
+                    "abc123"
+                    "tag-obj-sha"))
+  (check-equal? (release-inputs-version ri) "1.0.0")
+  (check-equal? (release-inputs-commit ri) "abc123")
+  (check-equal? (release-inputs-date ri) "2026-06-22")
+  (check-equal? (release-inputs-tarball-name ri) "q-1.0.0.tar.gz")
+  (check-equal? (release-inputs-tarball-size ri) 999)
+  (check-equal? (release-inputs-tarball-sha256 ri) "deadbeef")
+  (check-equal? (release-inputs-tag-commit-sha ri) "abc123")
+  (check-equal? (release-inputs-tag-object-sha ri) "tag-obj-sha"))
+
+(test-case "release-inputs struct: transparent equality"
+  (define ri1 (release-inputs "1.0.0" "c" "d" "n" 0 "s" "t" #f))
+  (define ri2 (release-inputs "1.0.0" "c" "d" "n" 0 "s" "t" #f))
+  (check-equal? ri1 ri2))
+
+;; --- build-manifest (pure core) ---
+
+(test-case "build-manifest: produces manifest from release-inputs"
+  (define ri
+    (release-inputs "0.99.42" "abc1234" "2026-06-22" "q-0.99.42.tar.gz" 12345 "n/a" "abc1234" #f))
+  (define m (build-manifest ri))
+  (check-pred manifest? m)
+  (check-equal? (manifest-version m) "0.99.42")
+  (check-equal? (manifest-tag m) "v0.99.42")
+  (check-equal? (manifest-commit m) "abc1234"))
+
+(test-case "build-manifest: tag auto-generated from version"
+  (define ri (release-inputs "1.2.3" "c" "d" "n" 0 "s" "unknown" #f))
+  (define m (build-manifest ri))
+  (check-equal? (manifest-tag m) "v1.2.3"))
+
+(test-case "build-manifest: commit defaults to unknown when #f"
+  (define ri (release-inputs "1.0.0" #f "d" "n" 0 "s" "unknown" #f))
+  (define m (build-manifest ri))
+  (check-equal? (manifest-commit m) "unknown"))
+
+(test-case "build-manifest: commit-matches-tag? true when SHAs match"
+  (define ri (release-inputs "1.0.0" "abc123" "d" "n" 0 "s" "abc123" #f))
+  (define m (build-manifest ri))
+  (define tr (manifest-traceability m))
+  (check-true (manifest-trace-commit-matches-tag? tr)))
+
+(test-case "build-manifest: commit-matches-tag? false when SHAs differ"
+  (define ri (release-inputs "1.0.0" "abc123" "d" "n" 0 "s" "def456" #f))
+  (define m (build-manifest ri))
+  (define tr (manifest-traceability m))
+  (check-false (manifest-trace-commit-matches-tag? tr)))
+
+(test-case "build-manifest: commit-matches-tag? false when tag SHA unknown"
+  (define ri (release-inputs "1.0.0" "abc123" "d" "n" 0 "s" "unknown" #f))
+  (define m (build-manifest ri))
+  (define tr (manifest-traceability m))
+  (check-false (manifest-trace-commit-matches-tag? tr)))
+
+(test-case "build-manifest: assets preserved from inputs"
+  (define ri (release-inputs "1.0.0" "c" "d" "q-1.0.0.tar.gz" 555 "some-sha" "unknown" #f))
+  (define m (build-manifest ri))
+  (define a (car (manifest-assets m)))
+  (check-equal? (manifest-asset-name a) "q-1.0.0.tar.gz")
+  (check-equal? (manifest-asset-size a) 555)
+  (check-equal? (manifest-asset-sha256 a) "some-sha"))
+
+(test-case "build-manifest: traceability captures all inputs"
+  (define ri (release-inputs "2.0.0" "c1" "d" "n" 0 "s" "c2" "obj-sha"))
+  (define m (build-manifest ri))
+  (define tr (manifest-traceability m))
+  (check-equal? (manifest-trace-tag-name tr) "v2.0.0")
+  (check-equal? (manifest-trace-tag-commit-sha tr) "c2")
+  (check-equal? (manifest-trace-tag-object-sha tr) "obj-sha")
+  (check-equal? (manifest-trace-manifest-commit-sha tr) "c1"))
+
+(test-case "build-manifest: result passes validation"
+  (define ri
+    (release-inputs "0.99.42" "abc1234" "2026-06-22" "q-0.99.42.tar.gz" 12345 "n/a" "abc1234" #f))
+  (define m (build-manifest ri))
+  (define mv (validate-manifest m))
+  (check-true (manifest-valid? mv)))
+
+;; --- build-manifest → manifest->json-string round-trip ---
+
+(test-case "build-manifest + json-string: produces valid JSON"
+  (define ri (release-inputs "0.99.42" "abc1234" "2026-06-22" "q.tar.gz" 100 "n/a" "abc1234" #f))
+  (define json-str (manifest->json-string (build-manifest ri)))
+  (define m2 (parse-manifest-json json-str))
+  (check-pred manifest? m2)
+  (check-equal? (manifest-version m2) "0.99.42")
+  (check-equal? (manifest-commit m2) "abc1234"))
+
+;; --- Export existence for W5 ---
+
+(test-case "gen-release-manifest.rkt exports release-inputs struct"
+  (check-not-exn (lambda () (dynamic-require manifest-script-path 'release-inputs))))
+
+(test-case "gen-release-manifest.rkt exports build-manifest"
+  (check-not-exn (lambda () (dynamic-require manifest-script-path 'build-manifest))))
+
+(test-case "gen-release-manifest.rkt exports commits-match?"
+  (check-not-exn (lambda () (dynamic-require manifest-script-path 'commits-match?))))
+
+(test-case "gen-release-manifest.rkt exports parse-q-version"
+  (check-not-exn (lambda () (dynamic-require manifest-script-path 'parse-q-version))))


### PR DESCRIPTION
## W5 — Pure-core/effect-shell I/O boundary pilot

### Selected surface
`scripts/gen-release-manifest.rkt` — separated manifest construction (pure) from data collection (effects).

### Changes

**scripts/gen-release-manifest.rkt:**
- Added `release-inputs` struct holding raw environment data (version, commit, date, tarball info, tag SHAs)
- Added `build-manifest` pure function: `release-inputs → manifest` (no I/O)
- Added `commits-match?` pure predicate: extracted SHA comparison logic into testable function
- Exported `parse-q-version` (already pure — takes content string)
- Refactored `emit-manifest` into: `collect-release-inputs` (effect shell) → `build-manifest` (pure core) → `manifest->json-string` (render)
- All filesystem/git/system I/O now isolated in effect shell functions

**tests/test-release-manifest-traceability.rkt:**
- +27 new tests (70 total): commits-match?, parse-q-version, release-inputs struct, build-manifest pure core, round-trip, export existence

### Manual sections applied
- §16: Pure core / effect shell separation (ports/path parameters)
- §27: No I/O in computation functions

### Acceptance criteria met
- ✅ One effectful shell is thinner
- ✅ Pure core (`build-manifest`) has direct fixture tests
- ✅ CLI/output behavior preserved (identical JSON output)
- ✅ Smoke gate: 19 files, 286 tests passed
