### PR TITLE
feat: lifecycle transition model for milestone closure (#8568)

### DIFF
--- a/scripts/milestone-gate.rkt
+++ b/scripts/milestone-gate.rkt
@@ -45,7 +45,14 @@
          GITHUB-CANCELLED
          GITHUB-SKIPPED
          GITHUB-COMPLETED
-         GITHUB-IN-PROGRESS)
+         GITHUB-IN-PROGRESS
+         ;; W6 (#8568): Lifecycle transition model
+         (struct-out milestone-lifecycle-transition-result)
+         milestone-lifecycle-states
+         milestone-lifecycle-next
+         milestone-valid-transition?
+         can-close-milestone?
+         milestone-lifecycle-transition-result)
 
 (require racket/file
          racket/list
@@ -131,7 +138,52 @@
     [else 'unknown]))
 
 ;; ---------------------------------------------------------------------------
-;; Pure logic (testable without network)
+;; W6 (#8568): Lifecycle transition model
+;; ---------------------------------------------------------------------------
+;; Explicit state machine for milestone/release closure.
+;; States: planned → in_progress → release_ready → release_published → ci_green → closed
+;;
+;; Transitions are guarded by release and CI verdicts.
+;; This makes the closure lifecycle explicit and testable
+;; without changing any GitHub issue/board behavior.
+
+;; All lifecycle states in order.
+(define milestone-lifecycle-states
+  '(planned in_progress release_ready release_published ci_green closed))
+
+;; Structured transition result.
+(struct milestone-lifecycle-transition-result (from to ok? reason) #:transparent)
+
+;; Next valid state in the lifecycle (linear progression).
+;; Returns #f if there is no next state (already closed).
+(define (milestone-lifecycle-next state)
+  (define idx (index-of milestone-lifecycle-states state))
+  (and idx
+       (< (add1 idx) (length milestone-lifecycle-states))
+       (list-ref milestone-lifecycle-states (add1 idx))))
+
+;; Check if a transition from one state to another is valid.
+;; Returns #t or #f.
+(define (milestone-valid-transition? from-state to-state)
+  (equal? (milestone-lifecycle-next from-state) to-state))
+
+;; Guard: can a milestone transition to `closed`?
+;; Requires release verdict to be success and CI verdict to be success.
+;; Returns a milestone-lifecycle-transition-result.
+(define (can-close-milestone? release-verdict ci-verdict)
+  (cond
+    [(not (release-verdict-success? release-verdict))
+     (milestone-lifecycle-transition-result 'ci_green
+                                            'closed
+                                            #f
+                                            (format "release verdict ~a blocks closing"
+                                                    release-verdict))]
+    [(not (ci-verdict-success? ci-verdict))
+     (milestone-lifecycle-transition-result 'ci_green
+                                            'closed
+                                            #f
+                                            (format "CI verdict ~a blocks closing" ci-verdict))]
+    [else (milestone-lifecycle-transition-result 'ci_green 'closed #t "all gates passed")]))
 ;; ---------------------------------------------------------------------------
 
 ;; Build a workflow verdict result hash for JSON output.

--- a/tests/test-milestone-gate.rkt
+++ b/tests/test-milestone-gate.rkt
@@ -300,3 +300,121 @@
   (define jobs (dynamic-script 'ci-required-jobs))
   (check-not-false (member "test" jobs))
   (check-not-false (member "security" jobs)))
+
+;; ============================================================
+;; W6 (#8568): Lifecycle transition model tests
+;; ============================================================
+
+(require (only-in "../scripts/milestone-gate.rkt"
+                  milestone-lifecycle-transition-result
+                  milestone-lifecycle-transition-result?
+                  milestone-lifecycle-transition-result-from
+                  milestone-lifecycle-transition-result-to
+                  milestone-lifecycle-transition-result-ok?
+                  milestone-lifecycle-transition-result-reason))
+
+;; --- milestone-lifecycle-states ---
+
+(test-case "lifecycle-states: has 6 states in order"
+  (define states (dynamic-script 'milestone-lifecycle-states))
+  (check-equal? states '(planned in_progress release_ready release_published ci_green closed)))
+
+(test-case "lifecycle-states: length is 6"
+  (check-equal? (length (dynamic-script 'milestone-lifecycle-states)) 6))
+
+;; --- milestone-lifecycle-next ---
+
+(test-case "lifecycle-next: planned → in_progress"
+  (check-equal? ((dynamic-script 'milestone-lifecycle-next) 'planned) 'in_progress))
+
+(test-case "lifecycle-next: in_progress → release_ready"
+  (check-equal? ((dynamic-script 'milestone-lifecycle-next) 'in_progress) 'release_ready))
+
+(test-case "lifecycle-next: release_ready → release_published"
+  (check-equal? ((dynamic-script 'milestone-lifecycle-next) 'release_ready) 'release_published))
+
+(test-case "lifecycle-next: release_published → ci_green"
+  (check-equal? ((dynamic-script 'milestone-lifecycle-next) 'release_published) 'ci_green))
+
+(test-case "lifecycle-next: ci_green → closed"
+  (check-equal? ((dynamic-script 'milestone-lifecycle-next) 'ci_green) 'closed))
+
+(test-case "lifecycle-next: closed → #f (no next state)"
+  (check-false ((dynamic-script 'milestone-lifecycle-next) 'closed)))
+
+(test-case "lifecycle-next: invalid state returns #f"
+  (check-false ((dynamic-script 'milestone-lifecycle-next) 'nonexistent)))
+
+;; --- milestone-valid-transition? ---
+
+(test-case "valid-transition?: planned → in_progress is valid"
+  (check-true ((dynamic-script 'milestone-valid-transition?) 'planned 'in_progress)))
+
+(test-case "valid-transition?: in_progress → release_ready is valid"
+  (check-true ((dynamic-script 'milestone-valid-transition?) 'in_progress 'release_ready)))
+
+(test-case "valid-transition?: ci_green → closed is valid"
+  (check-true ((dynamic-script 'milestone-valid-transition?) 'ci_green 'closed)))
+
+(test-case "valid-transition?: planned → closed is invalid (skipping steps)"
+  (check-false ((dynamic-script 'milestone-valid-transition?) 'planned 'closed)))
+
+(test-case "valid-transition?: in_progress → ci_green is invalid (skipping steps)"
+  (check-false ((dynamic-script 'milestone-valid-transition?) 'in_progress 'ci_green)))
+
+(test-case "valid-transition?: release_published → release_ready is invalid (backwards)"
+  (check-false ((dynamic-script 'milestone-valid-transition?) 'release_published 'release_ready)))
+
+(test-case "valid-transition?: closed → planned is invalid (backwards from terminal)"
+  (check-false ((dynamic-script 'milestone-valid-transition?) 'closed 'planned)))
+
+;; --- can-close-milestone? (guard function) ---
+
+(test-case "can-close: success+success → allowed"
+  (define r ((dynamic-script 'can-close-milestone?) 'workflow_success 'ci_success))
+  (check-true (milestone-lifecycle-transition-result-ok? r))
+  (check-equal? (milestone-lifecycle-transition-result-from r) 'ci_green)
+  (check-equal? (milestone-lifecycle-transition-result-to r) 'closed))
+
+(test-case "can-close: release blocking → blocked"
+  (define r ((dynamic-script 'can-close-milestone?) 'no_release_run 'ci_success))
+  (check-false (milestone-lifecycle-transition-result-ok? r))
+  (check-true (string-contains? (milestone-lifecycle-transition-result-reason r) "release")))
+
+(test-case "can-close: release_failed → blocked"
+  (define r ((dynamic-script 'can-close-milestone?) 'release_failed 'ci_success))
+  (check-false (milestone-lifecycle-transition-result-ok? r)))
+
+(test-case "can-close: CI blocking → blocked"
+  (define r ((dynamic-script 'can-close-milestone?) 'workflow_success 'ci_in_progress))
+  (check-false (milestone-lifecycle-transition-result-ok? r))
+  (check-true (string-contains? (milestone-lifecycle-transition-result-reason r) "CI")))
+
+(test-case "can-close: ci_failure → blocked"
+  (define r ((dynamic-script 'can-close-milestone?) 'workflow_success 'ci_failure))
+  (check-false (milestone-lifecycle-transition-result-ok? r)))
+
+(test-case "can-close: ci_cancelled → blocked"
+  (define r ((dynamic-script 'can-close-milestone?) 'workflow_success 'ci_cancelled))
+  (check-false (milestone-lifecycle-transition-result-ok? r)))
+
+(test-case "can-close: stale_run → blocked (release not confirmed)"
+  (define r ((dynamic-script 'can-close-milestone?) 'stale_run 'ci_success))
+  (check-false (milestone-lifecycle-transition-result-ok? r)))
+
+(test-case "can-close: unknown release verdict → blocked"
+  (define r ((dynamic-script 'can-close-milestone?) 'unknown 'ci_success))
+  (check-false (milestone-lifecycle-transition-result-ok? r)))
+
+(test-case "can-close: ci_required_job_unexpectedly_skipped → blocked"
+  (define r
+    ((dynamic-script 'can-close-milestone?) 'workflow_success 'ci_required_job_unexpectedly_skipped))
+  (check-false (milestone-lifecycle-transition-result-ok? r)))
+
+(test-case "can-close: success+success reason is 'all gates passed'"
+  (define r ((dynamic-script 'can-close-milestone?) 'workflow_success 'ci_success))
+  (check-equal? (milestone-lifecycle-transition-result-reason r) "all gates passed"))
+
+(test-case "can-close: result is milestone-lifecycle-transition-result?"
+  (define r ((dynamic-script 'can-close-milestone?) 'workflow_success 'ci_success))
+  (check-pred milestone-lifecycle-transition-result? r))


### PR DESCRIPTION
## W6 — Lifecycle/state-machine transition characterization

### Selected lifecycle
**Release/milestone closure lifecycle**: `planned → in_progress → release_ready → release_published → ci_green → closed`

### Changes

**scripts/milestone-gate.rkt:**
- Added `milestone-lifecycle-states` (ordered list of 6 states)
- Added `milestone-lifecycle-transition-result` struct `(from to ok? reason)`
- Added `milestone-lifecycle-next` — returns next valid state (linear progression)
- Added `milestone-valid-transition?` — checks if a transition follows the lifecycle
- Added `can-close-milestone?` — guard function that blocks closing when release verdict or CI verdict is not success; integrates with W2 verdict predicates

**tests/test-milestone-gate.rkt:**
- +24 new lifecycle tests (55 total)
- State enumeration, forward transitions, invalid transitions (skip/backwards/terminal)
- Positive and negative `can-close-milestone?` tests covering all blocking verdicts

### Manual section applied
- §40: Lifecycle transition characterization

### Acceptance criteria met
- ✅ At least one lifecycle has explicit transition fixtures/tests
- ✅ Closing while release red or CI pending remains impossible in tests
- ✅ Smoke gate: 19 files, 286 tests passed
