### PR TITLE
feat: find-project-root sentinel path helper (#8569)

### DIFF
--- a/tests/test-config-paths.rkt
+++ b/tests/test-config-paths.rkt
@@ -64,3 +64,66 @@
 (test-case "resolve-project-dir-from-args: handles #f value gracefully"
   (define args (hash 'project_dir #f))
   (check-equal? (resolve-project-dir-from-args args) (current-directory)))
+
+;; ============================================================
+;; find-project-root  (W7 #8569)
+;; ============================================================
+
+;; The real project root is the directory containing this file's parent
+;; (tests/ → q/), which contains util/version.rkt.
+(define test-project-root
+  (simplify-path (build-path (or (current-load-relative-directory) (current-directory)) "..")))
+
+(test-case "find-project-root: finds root from within project (cwd is root)"
+  ;; Running tests from tests/ directory, cwd might be tests/ or q/
+  ;; Either way, find-project-root should find q/
+  (define root (find-project-root))
+  (check-not-false root)
+  (check-true (file-exists? (build-path root "util" "version.rkt"))
+              "root should contain util/version.rkt"))
+
+(test-case "find-project-root: finds root from a subdirectory"
+  (define root (find-project-root test-project-root))
+  (check-not-false root)
+  (check-true (file-exists? (build-path root "util" "version.rkt"))))
+
+(test-case "find-project-root: finds root from a deeper subdirectory"
+  (define deep (build-path test-project-root "scripts"))
+  (define root (find-project-root deep))
+  (check-not-false root)
+  (check-true (file-exists? (build-path root "util" "version.rkt"))))
+
+(test-case "find-project-root: returns #f for temp directory without sentinel"
+  (define root (find-project-root (find-system-path 'temp-dir)))
+  ;; Temp dir won't have util/version.rkt, but parent might on some systems
+  ;; Just check it doesn't crash
+  (check-not-exn (lambda () (find-project-root (find-system-path 'temp-dir)))))
+
+(test-case "find-project-root: accepts string path"
+  (define root (find-project-root (path->string test-project-root)))
+  (check-not-false root)
+  (check-true (file-exists? (build-path root "util" "version.rkt"))))
+
+(test-case "find-project-root: accepts #f (uses cwd)"
+  (check-not-exn (lambda () (find-project-root #f))))
+
+;; ============================================================
+;; project-root-or-cwd  (W7 #8569)
+;; ============================================================
+
+(test-case "project-root-or-cwd: returns project root when found"
+  (define root (project-root-or-cwd test-project-root))
+  (check-true (file-exists? (build-path root "util" "version.rkt"))))
+
+(test-case "project-root-or-cwd: returns cwd when sentinel not found"
+  ;; Use a path unlikely to have the sentinel
+  (define result (project-root-or-cwd "/"))
+  (check-pred path? result))
+
+(test-case "project-root-or-cwd: always returns a path"
+  (check-pred path? (project-root-or-cwd #f)))
+
+(test-case "project-root-or-cwd: backward-compatible when cwd is project root"
+  ;; When started from project root, result should equal cwd
+  (parameterize ([current-directory test-project-root])
+    (check-equal? (project-root-or-cwd) test-project-root)))

--- a/util/config-paths.rkt
+++ b/util/config-paths.rkt
@@ -15,7 +15,42 @@
 
 (provide (contract-out [project-config-dirs (-> (or/c path-string? #f) (listof path?))]
                        [global-config-dir (-> path?)]
-                       [resolve-project-dir-from-args (-> hash? path?)]))
+                       [resolve-project-dir-from-args (-> hash? path?)]
+                       [find-project-root (->* () ((or/c path-string? #f)) (or/c path? #f))]
+                       [project-root-or-cwd (->* () ((or/c path-string? #f)) path?)]))
+
+;; ---------------------------------------------------------------------------
+;; W7 (#8569): Project root detection via sentinel file
+;; ---------------------------------------------------------------------------
+;; DESIGN FACT (W7, v0.99.42): 26 script call-sites use
+;; (build-path (current-directory) "util" "version.rkt") assuming cwd
+;; is the project root. find-project-root eliminates this assumption
+;; by using util/version.rkt as a sentinel to locate the project root
+;; from any starting directory.
+
+;; Sentinel file used to identify the project root.
+;; Must exist only at the q/ project root.
+(define project-root-sentinel (build-path "util" "version.rkt"))
+
+;; find-project-root: walks up from a starting directory looking for
+;; the sentinel file. Returns the directory containing it, or #f.
+(define (find-project-root [start-dir #f])
+  (define start
+    (if start-dir
+        (path->complete-path (if (string? start-dir)
+                                 (string->path start-dir)
+                                 start-dir))
+        (current-directory)))
+  (let loop ([dir (simplify-path start)])
+    (if (file-exists? (build-path dir project-root-sentinel))
+        dir
+        (let-values ([(parent _name _dir?) (split-path dir)])
+          (and (path? parent) (loop parent))))))
+
+;; project-root-or-cwd: find-project-root with cwd fallback.
+;; Backward-compatible: if sentinel not found, returns (current-directory).
+(define (project-root-or-cwd [start-dir #f])
+  (or (find-project-root start-dir) (current-directory)))
 
 ;; Returns list of possible project config directory paths in priority order.
 ;; ".q/" first, then ".pi/" as fallback.


### PR DESCRIPTION
## W7 — External adapter path/env boundary audit and one safe fix

### Audit
Produced `.planning/ADAPTER-PATH-ENV-BOUNDARY-AUDIT-v0.99.42.md` (local-only):
- **26** `(build-path (current-directory) ...)` call-sites in 10 scripts
- **34** `current-directory` sites in runtime/extensions/tui/wiring
- **43** `getenv` sites across all non-test modules
- **0** `working-directory:` directives in `.github/workflows`

### Selected Green fix: `find-project-root` in `util/config-paths.rkt`

**Problem:** 26 script call-sites use `(build-path (current-directory) "util" "version.rkt")` assuming cwd is the project root. If cwd is wrong, paths break silently.

**Solution:** A sentinel-based project root detector:
- `find-project-root`: walks up from a starting directory looking for `util/version.rkt`. Returns the project root or `#f`.
- `project-root-or-cwd`: backward-compatible wrapper. If sentinel found, returns project root. Otherwise returns `(current-directory)` (same as current behavior).

**Scope:** Function + tests only. No call-site migration in this wave.

### Manual sections applied
- §9: No path assumptions at boundaries
- §14: Path/env parameters are explicit
- §48: Boundary assertions prevent classes of failures

### Acceptance criteria met
- ✅ Audit exists
- ✅ One Green path/env boundary fix lands
- ✅ Smoke gate: 19 files, 286 tests passed
