### PR TITLE
feat: read-canonical-version! common-case API (#8570)

### DIFF
--- a/scripts/gen-release-manifest.rkt
+++ b/scripts/gen-release-manifest.rkt
@@ -14,7 +14,8 @@
          racket/string
          racket/system
          racket/path
-         json)
+         json
+         (only-in "version-surface.rkt" read-canonical-version!))
 
 ;; Provide W4 parse/validate/render boundary + W5 pure-core/effect-shell
 (provide (struct-out manifest)
@@ -344,15 +345,8 @@
 (define (main)
   (define args (vector->list (current-command-line-arguments)))
 
-  ;; Read version
-  (define util-path (build-path (current-directory) "util" "version.rkt"))
-  (unless (file-exists? util-path)
-    (displayln "ERROR: util/version.rkt not found")
-    (exit 1))
-  (define version (parse-q-version (file->string util-path)))
-  (unless version
-    (displayln "ERROR: could not parse version from util/version.rkt")
-    (exit 1))
+  ;; Read version (W8: migrated to read-canonical-version!)
+  (define version (read-canonical-version!))
 
   ;; Get git commit
   (define commit

--- a/scripts/gen-release-notes.rkt
+++ b/scripts/gen-release-notes.rkt
@@ -11,11 +11,11 @@
 
 (require racket/file
          racket/string
-         racket/port)
+         racket/port
+         (only-in "version-surface.rkt" read-canonical-version!))
 
-(define (parse-q-version content)
-  (define m (regexp-match #rx"\\(define q-version \"([0-9]+\\.[0-9]+\\.[0-9]+)\"" content))
-  (and m (cadr m)))
+;; W8 (#8570): parse-q-version removed; canonical version now read via
+;; read-canonical-version! from version-surface.rkt.
 
 (define (version-header? line version)
   ;; Match lines like:
@@ -54,16 +54,7 @@
   (define version
     (cond
       [(pair? args) (car args)]
-      [else
-       (define util-path (build-path (current-directory) "util" "version.rkt"))
-       (unless (file-exists? util-path)
-         (displayln "ERROR: util/version.rkt not found")
-         (exit 1))
-       (define v (parse-q-version (file->string util-path)))
-       (unless v
-         (displayln "ERROR: could not parse version")
-         (exit 1))
-       v]))
+      [else (read-canonical-version!)]))
 
   (printf "Generating release notes for v~a~n" version)
 

--- a/scripts/lint-docs.rkt
+++ b/scripts/lint-docs.rkt
@@ -16,15 +16,15 @@
          racket/list
          racket/path
          racket/string
-         racket/match)
+         racket/match
+         (only-in "version-surface.rkt" read-canonical-version!))
 
 ;; ---------------------------------------------------------------------------
 ;; Version helpers
 ;; ---------------------------------------------------------------------------
 
-(define (parse-q-version content)
-  (define m (regexp-match #rx"\\(define q-version \"([0-9]+\\.[0-9]+\\.[0-9]+)\"" content))
-  (and m (cadr m)))
+;; W8 (#8570): parse-q-version removed; canonical version now read via
+;; read-canonical-version! from version-surface.rkt.
 
 (define VERSION-PAT #rx"[0-9]+\\.[0-9]+\\.[0-9]+")
 
@@ -125,14 +125,7 @@
 ;; ---------------------------------------------------------------------------
 
 (define (main)
-  (define util-path (build-path (current-directory) "util" "version.rkt"))
-  (unless (file-exists? util-path)
-    (displayln "ERROR: util/version.rkt not found")
-    (exit 1))
-  (define canonical (parse-q-version (file->string util-path)))
-  (unless canonical
-    (displayln "ERROR: could not parse version")
-    (exit 1))
+  (define canonical (read-canonical-version!))
 
   (printf "Docs lint — canonical version: ~a~n~n" canonical)
 

--- a/scripts/version-surface.rkt
+++ b/scripts/version-surface.rkt
@@ -29,6 +29,8 @@
                        [read-canonical-version (->* () ((or/c path-string? #f)) string?)]
                        [read-canonical-version/strict
                         (->* () ((or/c path-string? #f)) (or/c string? #f))]
+                       ;; Common-case API (W8 #8570): read + error-exit
+                       [read-canonical-version! (->* () ((or/c path-string? #f)) string?)]
                        ;; Version formatting
                        [version->string (-> (listof exact-nonnegative-integer?) string?)]))
 
@@ -112,6 +114,28 @@
   (define path (version-file-path base-dir))
   (and (file-exists? path)
        (let ([content (file->string path)]) (parse-q-version-from-content content))))
+
+;; W8 (#8570): Common-case API — read canonical version with error-exit.
+;; Replaces the 6-line boilerplate repeated in 6+ scripts:
+;;   (define util-path (build-path (current-directory) "util" "version.rkt"))
+;;   (unless (file-exists? util-path) (displayln "ERROR: ...") (exit 1))
+;;   (define version (parse-q-version (file->string util-path)))
+;;   (unless version (displayln "ERROR: ...") (exit 1))
+;;
+;; DESIGN FACT (W8 §11/§12): This wrapper is deep enough because:
+;; 1. It encapsulates the read+parse+error-exit contract as a single call
+;; 2. It prevents error-message drift across 6 independently-maintained scripts
+;; 3. The rare-case API (read-canonical-version/strict) remains available
+;;    for callers that need custom error handling
+(define (read-canonical-version! [base-dir #f])
+  (define v (read-canonical-version/strict base-dir))
+  (unless v
+    (define path (version-file-path base-dir))
+    (if (file-exists? path)
+        (eprintf "ERROR: could not parse q-version from ~a\n" path)
+        (eprintf "ERROR: ~a not found\n" path))
+    (exit 1))
+  v)
 
 ;; ---------------------------------------------------------------------------
 ;; Formatting

--- a/tests/test-version-surface.rkt
+++ b/tests/test-version-surface.rkt
@@ -96,7 +96,20 @@
                      (check-exn exn:fail:contract? (λ () (parse 42))))
                    (test-case "contract: version->string rejects non-list"
                      (define v->s (vs-ref 'version->string))
-                     (check-exn exn:fail:contract? (λ () (v->s "not-a-list")))))
+                     (check-exn exn:fail:contract? (λ () (v->s "not-a-list"))))
+                   ;; ---------------------------------------------------------------------------
+                   ;; W8 (#8570): read-canonical-version! tests
+                   ;; ---------------------------------------------------------------------------
+                   (test-case "read-canonical-version!: reads actual version from project"
+                     (define rcv! (vs-ref 'read-canonical-version!))
+                     (define v (rcv! (path->string q-root)))
+                     (check-true (and (regexp-match? #rx"[0-9]+\\.[0-9]+\\.[0-9]+" v) #t)))
+                   (test-case "read-canonical-version!: returns same value as /strict"
+                     (define rcv! (vs-ref 'read-canonical-version!))
+                     (define strict-v ((vs-ref 'read-canonical-version/strict) (path->string q-root)))
+                     (check-equal? (rcv! (path->string q-root))
+                                   strict-v
+                                   "read-canonical-version! and /strict should return same value")))
 
 (module+ test
   (run-tests version-surface-tests))


### PR DESCRIPTION
## W8 — Common-case API ergonomics pilot

### Problem
6 scripts independently repeated the same 6-line boilerplate for reading the canonical version:
```racket
(define util-path (build-path (current-directory) "util" "version.rkt"))
(unless (file-exists? util-path) (displayln "ERROR: ...") (exit 1))
(define version (parse-q-version (file->string util-path)))
(unless version (displayln "ERROR: ...") (exit 1))
```

Additionally, `parse-q-version` was independently defined in 4 scripts despite `version-surface.rkt` already providing `parse-q-version-from-content`.

### Solution: `read-canonical-version!`
One common-case API that reads the canonical version and exits with error on failure. Existing `read-canonical-version/strict` remains available for callers needing custom error handling.

### Migrated scripts (proof of concept)
- `scripts/lint-docs.rkt`: removed local `parse-q-version`, 8 lines → 1 call
- `scripts/gen-release-notes.rkt`: removed local `parse-q-version`, 8 lines → 1 call  
- `scripts/gen-release-manifest.rkt`: `main` uses `read-canonical-version!`; `parse-q-version` retained for W5 API

### Manual sections applied
- §11: Make the common case easy
- §12: Avoid wrapper proliferation — one helper, documented depth

### Acceptance criteria met
- ✅ One common-case API reduces repeated caller complexity
- ✅ No wrapper proliferation (one function)
- ✅ Old behavior remains possible (via `/strict`)
- ✅ Smoke gate: 19 files, 286 tests passed
