### PR TITLE
release: v0.99.42 version bump + CHANGELOG (#8573)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,80 @@
+## 0.99.42
+
+Released: 2026-06-25
+
+### Overview
+Racket Abstraction Manual Roadmap V — abstraction governance and
+high-leverage boundary hardening. This milestone applied the Racket
+Abstraction Manual (§7–§55) to harden release/CI boundary code
+without destabilizing the green release/CI pipeline. Delivered
+scanner v5 with 3 new signals, verdict predicate abstraction, 4
+structured result types, pure/effect separation for manifest
+construction, explicit lifecycle state machine, cwd-independent
+project root detection, common-case API ergonomics, and design-fact
+comments at critical invariants.
+
+### Abstraction Boundary Hardening
+
+- **W0: Baseline.** Revalidated all local gates and created the
+  abstraction fitness baseline and coverage matrix. 701 modules,
+  ~111K lines scanned.
+
+- **W1: Scanner v5.** Added 3 high-signal checks to
+  `scripts/abstraction-audit.rkt`: stringly verdict detection,
+  effectful classifier detection, optional/mandatory wording detection.
+  Scanner now has 11 signals total.
+
+- **W2: Verdict predicates.** Introduced predicate functions
+  (`release-verdict-success?`, `ci-verdict-blocking?`, etc.) and
+  status constants to replace bare string comparisons in
+  `milestone-gate.rkt` and `actions-red-run-classifier.rkt`.
+
+- **W3: Result boundary.** Introduced `dry-run-result` struct
+  replacing ad-hoc `(cons 'pass/'fail)` pairs in
+  `release-dry-run.rkt`. Follows the `status-result.rkt` pattern.
+
+- **W4: Manifest domain model.** Introduced `manifest`,
+  `manifest-asset`, and `manifest-trace` structs with pure
+  `validate-manifest` function in `gen-release-manifest.rkt`.
+  JSON parse safety with `with-handlers` wrapper.
+
+- **W5: Pure-core/effect-shell.** Separated manifest construction
+  into pure `build-manifest` and effectful `collect-release-inputs`.
+  Added `release-inputs` struct and `commits-match?` predicate.
+
+- **W6: Lifecycle state machine.** Made milestone lifecycle
+  transitions explicit with 6-state model
+  (`planned → in_progress → release_ready → release_published →
+  ci_green → closed`). Added `can-close-milestone?` guard requiring
+  release + CI success.
+
+- **W7: Path/env boundary.** Added cwd-independent
+  `find-project-root` and `project-root-or-cwd` using sentinel file.
+  Audited 26 cwd-dependent script sites (Medium risk, deferred
+  migration).
+
+- **W8: Common-case API.** Introduced `read-canonical-version!`
+  in `version-surface.rkt` replacing 6-line version-parsing
+  boilerplate repeated across 6+ scripts. Migrated 3 scripts.
+
+- **W9: Design-fact comments.** Added DESIGN FACT comments at 4
+  high-risk invariants: cancelled_superseded exclusion, validation
+  tolerance, pure/effect boundary, lifecycle linearity.
+
+- **W10: Scorecards and governance.** Created public scorecard and
+  governance report. Synced metrics.
+
+### Stats
+
+```text
+Source modules: 701 (unchanged)
+Source lines: ~112,375 (+575)
+Test assertions: ~28,152 (+270)
+Scanner signals: 11 (v5, +3)
+Structured result types: 4 (+3)
+DESIGN FACT comments: 10 (+4)
+```
+
 ## 0.99.41
 
 Released: 2026-06-24

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.99.41-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.99.42-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 
@@ -208,7 +208,7 @@ bin/q --model gpt-5.4 "write a test"
 ### Verify
 
 ```bash
-bin/q --version            # q version 0.99.41
+bin/q --version            # q version 0.99.42
 raco test tests/           # run the full test suite
 ```
 
@@ -296,7 +296,7 @@ q/
 |--------|-------|
 | Test files | 1118 |
 | Source modules | 701 |
-| Source lines | 112375 |
+| Source lines | 112378 |
 | Test lines | 180318 |
 | Test assertions | 28152 |
 | Tests passing | 5835+ | `racket scripts/run-tests.rkt` results |
@@ -364,6 +364,8 @@ When q executes shell commands on behalf of an LLM, arguments are quoted via `sh
 
 
 
+
+**v0.99.42** — Overview
 
 **v0.99.41** — Overview
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -2,7 +2,7 @@
 
 ## Version
 
-v0.99.41
+v0.99.42
 
 ## Native TUI Stack
 

--- a/docs/distributed-execution-guide.md
+++ b/docs/distributed-execution-guide.md
@@ -1,7 +1,7 @@
-<!-- verified-against: 0.99.41 -->
+<!-- verified-against: 0.99.42 -->
 # Distributed Execution Guide
 
-This guide covers q's **opt-in** distributed execution feature (v0.99.41, MAS Schritt 6 Phase 2). High-risk tool execution can be routed to a remote executor node over mTLS-secured TCP, isolating hostile code from the developer machine.
+This guide covers q's **opt-in** distributed execution feature (v0.99.42, MAS Schritt 6 Phase 2). High-risk tool execution can be routed to a remote executor node over mTLS-secured TCP, isolating hostile code from the developer machine.
 
 > **Default is local-only.** No configuration changes are needed for local development. The broker is strictly opt-in behind `mas.broker.enabled = false`.
 

--- a/docs/event-taxonomy.md
+++ b/docs/event-taxonomy.md
@@ -1,6 +1,6 @@
 # Q Event Taxonomy Reference
 
-Complete reference for all event types in Q 0.99.41.
+Complete reference for all event types in Q 0.99.42.
 ## Base Types
 
 ### `event` (protocol-level)

--- a/docs/extension-guide.md
+++ b/docs/extension-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.99.41 --># Extension Development Guide
+<!-- verified-against: 0.99.42 --># Extension Development Guide
 
 This guide walks you through creating, testing, and activating a custom
 extension for q.

--- a/docs/getting-started/credentials.md
+++ b/docs/getting-started/credentials.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.99.41 -->
+<!-- verified-against: 0.99.42 -->
 # Credential Management
 
 This document describes how q manages API keys and provider credentials,

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.99.41 --># Getting Started
+<!-- verified-against: 0.99.42 --># Getting Started
 
 Welcome to q, a Racket-based coding agent.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.99.41 --># Installation Guide
+<!-- verified-against: 0.99.42 --># Installation Guide
 
 <!-- This file is the canonical source. The docs/getting-started/installation.md copy is maintained for the doc site build. -->
 

--- a/docs/mcp-capability-security.md
+++ b/docs/mcp-capability-security.md
@@ -1,13 +1,13 @@
-<!-- verified-against: 0.99.41 -->
+<!-- verified-against: 0.99.42 -->
 # MCP and Capability-Token Security Notes
 
 This document describes the security state for MAS Schritt 6 Phases 1 and 2.
 
-> **Phase 2 (v0.99.41) update:** Remote execution via mTLS TCP broker is now available. See [Distributed Execution Guide](distributed-execution-guide.md) and [mTLS Security Model](security-mtls.md) for details.
+> **Phase 2 (v0.99.42) update:** Remote execution via mTLS TCP broker is now available. See [Distributed Execution Guide](distributed-execution-guide.md) and [mTLS Security Model](security-mtls.md) for details.
 
 ## Scope
 
-v0.99.41 hardens the existing Phase 1 MCP/capability-token implementation. It does **not** introduce the Phase 2 network broker, mTLS channel, or remote executor.
+v0.99.42 hardens the existing Phase 1 MCP/capability-token implementation. It does **not** introduce the Phase 2 network broker, mTLS channel, or remote executor.
 
 Phase 1 provides:
 
@@ -24,7 +24,7 @@ Phase 1 does **not** provide:
 - ~~mTLS or cross-host authentication.~~ **→ Phase 2 provides full mTLS with mutual certificate verification.**
 - ~~Remote route execution.~~ **→ Phase 2 routes high/critical risk requests to the remote executor via mTLS.**
 
-> **v0.99.41 change:** The `remote-tagged-but-executed-local` annotation is removed. Risk-based routing now dispatches `'remote` decisions to the actual remote executor when `mas.broker.enabled = true`. When the broker is disabled (default), risk-based routing falls back to local execution with a clear warning.
+> **v0.99.42 change:** The `remote-tagged-but-executed-local` annotation is removed. Risk-based routing now dispatches `'remote` decisions to the actual remote executor when `mas.broker.enabled = true`. When the broker is disabled (default), risk-based routing falls back to local execution with a clear warning.
 
 ## Feature gates
 
@@ -67,7 +67,7 @@ The default event sink is a no-op. Integrations can parameterize `current-mcp-ev
 
 ## Capability-token API
 
-Capability tokens are HMAC-authenticated strings with strict parsing. v0.99.41 preserves the legacy API while adding claim-aware validation.
+Capability tokens are HMAC-authenticated strings with strict parsing. v0.99.42 preserves the legacy API while adding claim-aware validation.
 
 Primary APIs:
 

--- a/docs/memory-activation.md
+++ b/docs/memory-activation.md
@@ -222,7 +222,7 @@ Session-to-project memory reflection via `runtime/memory/reflection.rkt`:
 - Each reflection supersedes its source items (automatic superseded removal on retrieval)
 - No-op when fewer than `min-group-size` items or no groupable items found
 
-### v0.99.41 Quality Remediation
+### v0.99.42 Quality Remediation
 
 Key behavioral improvements:
 
@@ -241,7 +241,7 @@ Key behavioral improvements:
 - [Architecture Overview](architecture/overview.md)
 - [Tool System](tooling.md)
 
-### v0.99.41 Memory Injection Hotfix
+### v0.99.42 Memory Injection Hotfix
 
 **HF1**: Memory injection was silently skipped in production because `assemble-context/pure` in `turn-orchestrator.rkt` did not thread `#:session-config` to `build-tiered-context/state-aware`. The parameter was accepted but never populated. Fixed by adding the wire.
 
@@ -251,7 +251,7 @@ Key behavioral improvements:
 
 **LF2**: `decode-mem0-items` in the Mem0 adapter was called with hardcoded `"session"` and `"."` instead of actual query values. Now threaded from the retrieve payload.
 
-### v0.99.41 Memory Lifecycle Completion
+### v0.99.42 Memory Lifecycle Completion
 
 **G1 — Background Reflection Trigger**: Session-scoped memories are now automatically promoted to project scope via deterministic reflection. When `memory.auto-reflection.enabled` is `true`, `maybe-reflect-session-memories!` fires after each turn's auto-extraction. The non-fatal wrapper catches all exceptions and logs warnings, never disrupting the agent loop. Controlled by two config keys:
 

--- a/docs/security-mtls.md
+++ b/docs/security-mtls.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.99.41 -->
+<!-- verified-against: 0.99.42 -->
 # Security Model: Mutual TLS (mTLS) for Distributed Execution
 
 This document describes the security architecture of q's Phase 2 distributed execution feature (v0.99.29). It covers the trust model, threat model, defense-in-depth layers, and key rotation procedures.

--- a/docs/security-trust-model.md
+++ b/docs/security-trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.99.41 --># Security & Trust Model
+<!-- verified-against: 0.99.42 --># Security & Trust Model
 
 This document provides an honest, per-area assessment of what q enforces
 today and what is planned. It is the authoritative reference for security

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -130,6 +130,6 @@ is the primary self-hosting extension:
 (load-extension! ext-reg "path/to/extension.rkt" #:event-bus bus)
 ```
 
-## Version 0.99.41
+## Version 0.99.42
 
-This documentation reflects q 0.99.41.
+This documentation reflects q 0.99.42.

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.99.41 --># q Source Style Guide
+<!-- verified-against: 0.99.42 --># q Source Style Guide
 
 This document defines formatting and naming conventions for the q Racket codebase.
 All changes to `q/` source files (excluding `tests/`) should follow these rules.

--- a/docs/system-overview.md
+++ b/docs/system-overview.md
@@ -1,6 +1,6 @@
 # q Coding Agent — System Overview
 
-> **Version 0.99.41** · Racket · MIT License
+> **Version 0.99.42** · Racket · MIT License
 > The definitive reference for developers who want to understand, extend, or contribute to q.
 
 ---
@@ -485,7 +485,7 @@ bin/q init                          # Guided setup wizard
 
 | Metric | Value |
 |--------|-------|
-| Version | 0.99.41 |
+| Version | 0.99.42 |
 | Language | Racket |
 | License | MIT |
 | Source modules | 495 |

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.99.41 -->
+<!-- verified-against: 0.99.42 -->
 # Trust Model
 
 ## Trust Levels

--- a/docs/workflow-testing.md
+++ b/docs/workflow-testing.md
@@ -121,6 +121,6 @@ Use relative paths from the test file:
 4. Use `(check-true ...)` for boolean assertions
 5. Keep tests independent — no shared mutable state between test-cases
 
-## Version 0.99.41
+## Version 0.99.42
 
-This documentation reflects q 0.99.41.
+This documentation reflects q 0.99.42.

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.99.41")
+(define version "0.99.42")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base" "gui-easy-lib"))

--- a/scripts/abstraction-audit.rkt
+++ b/scripts/abstraction-audit.rkt
@@ -234,7 +234,10 @@
 ;;   effectful-classifier-rx <- classify functions mixing I/O with classification
 ;;   optional-mandatory-rx <- #581: optional wording for mandatory assets
 (define stringly-verdict-rx
-  #px"\"(?:success|failure|failed?|pending|cancelled?|skipped?|in_progress|completed?|blocked?|red|green|pass|fail|unknown|error|warning|timeout|neutral|action_required|publication_succeeded_smoke_failed|current_blocking_red_[a-zA-Z_0-9]+)\"")
+  (pregexp (string-append "\"(?:success|failure|failed?|pending|cancelled?|skipped?|in_progress|"
+                          "completed?|blocked?|red|green|pass|fail|unknown|error|warning|"
+                          "timeout|neutral|action_required|publication_succeeded_smoke_failed|"
+                          "current_blocking_red_[a-zA-Z_0-9]+)\"")))
 (define effectful-classifier-rx
   #px"\\(define\\s+\\((?:classify|check|verify|gate|make-[a-zA-Z_0-9]*-verdict|make-[a-zA-Z_0-9]*-result)[-_a-zA-Z]*\\s")
 (define optional-before-asset-rx

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -11,4 +11,4 @@
 
 (provide (contract-out [q-version string?]))
 
-(define q-version "0.99.41")
+(define q-version "0.99.42")

--- a/wiki-src/Architecture-Overview.md
+++ b/wiki-src/Architecture-Overview.md
@@ -35,7 +35,7 @@ User input → Interface (CLI/TUI/RPC)
     → Events emitted to bus
 ```
 
-## Metrics (0.99.41)
+## Metrics (0.99.42)
 > _See `racket scripts/metrics.rkt` for current numbers._
 
 - 414 source modules, 534 test files


### PR DESCRIPTION
## W11 — v0.99.42 final version bump, release/CI gates

### Version bump
- `util/version.rkt`: 0.99.41 → 0.99.42
- `info.rkt`: 0.99.41 → 0.99.42
- `CHANGELOG.md`: Full v0.99.42 entry with wave-by-wave summary
- `README.md`: Badge, version string, status block, metrics synced
- 20 docs/*.md: Version refs synced via `sync-version.rkt --write --all`
- `scripts/abstraction-audit.rkt`: Fix long-line format lint (243 → multi-line)

### Local gates passed
- lint-version: PASS (0.99.42)
- sync-readme-status --check: PASS
- metrics --lint: PASS (5/5)
- metrics --lint-prose: PASS
- pre-release-check: 4/4 PASS
- ci-local --quick: 5/5 PASS
- release-dry-run: 5/5 PASS
- smoke: 19/19 files, 286/286 tests PASS
- release-smoke: 13/13 files, 157/157 tests PASS
