### PR TITLE
ci: update cache action pins for Node 24 runtime (#8585)

### DIFF
--- a/.github/actions/setup-racket/action.yml
+++ b/.github/actions/setup-racket/action.yml
@@ -13,7 +13,7 @@ runs:
       run: find . -name '*.zo' -delete -o -name 'compiled' -type d -exec rm -rf {} + 2>/dev/null; true
 
     - name: Cache Racket packages
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: |
           ~/.racket

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Cache Racket packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.local/share/racket
           key: racket-pkgs-lint-${{ hashFiles('**/info.rkt') }}
@@ -69,7 +69,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Cache Racket packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.local/share/racket
           key: racket-pkgs-lint-${{ hashFiles('**/info.rkt') }}
@@ -99,7 +99,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Cache Racket packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.local/share/racket
@@ -151,7 +151,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Cache Racket packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.local/share/racket
           key: racket-pkgs-security-${{ hashFiles('**/info.rkt') }}
@@ -183,7 +183,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Cache Racket packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.local/share/racket
           key: racket-pkgs-release-${{ hashFiles('**/info.rkt') }}
@@ -226,7 +226,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Cache Racket packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.local/share/racket


### PR DESCRIPTION
## Summary
- update all GitHub Actions `actions/cache` pins from v4 to v5
- remove Node.js 20 cache action runtime deprecation warning under Node 24 enforcement
- preserve existing cache keys, paths, workflow structure, and setup-racket package compile gate

## Verification
- workflow/action YAML parse: PASS
- `raco test tests/test-release-workflow-contract.rkt tests/test-w9-ci-workflow-verification.rkt tests/test-ci-workflow-diagnostics.rkt tests/test-lint-release-readiness.rkt`: PASS, 89 tests
- `racket scripts/lint-all.rkt`: PASS, 22 passed, 1 non-blocking release-readiness warning
- `racket scripts/run-tests.rkt --suite fast`: PASS, 991/991 files, 14128/14128 tests

Audit remediation for v0.99.42 in-depth audit Node.js 20 deprecation finding.