### PR TITLE
feat: P0 tmux smoke tests + harness fixes (#8590)

### DIFF
--- a/tests/helpers/tmux-q-harness.rkt
+++ b/tests/helpers/tmux-q-harness.rkt
@@ -107,7 +107,7 @@
 
 (define (tmux-available?)
   (with-handlers ([exn:fail? (lambda (e) #f)])
-    (define-values (proc out-in err) (subprocess #f #f #f (find-executable-path "tmux") "-V"))
+    (define-values (proc out-in _stdin err) (subprocess #f #f #f (find-executable-path "tmux") "-V"))
     (subprocess-wait proc)
     (define ok? (eq? (subprocess-status proc) 0))
     (close-input-port out-in)
@@ -307,7 +307,8 @@
 ;; ============================================================
 
 (define (make-session-name)
-  (format "q-test-~a" (current-inexact-milliseconds)))
+  ;; tmux session names must not contain '.' or ':' — use exact integer
+  (format "q-test-~a" (current-milliseconds)))
 
 ;; ============================================================
 ;; tmux command execution (internal)
@@ -318,7 +319,7 @@
   (cond
     [(not tmux-path) (error 'run-tmux-command "tmux not found")]
     [capture?
-     (define-values (proc out-port err-port) (subprocess #f #f #f tmux-path (cdr args)))
+     (define-values (proc out-port _stdin err-port) (apply subprocess #f #f #f tmux-path (cdr args)))
      (subprocess-wait proc)
      (define status (subprocess-status proc))
      (define output (port->string out-port))
@@ -326,17 +327,26 @@
      (close-input-port err-port)
      (values status output)]
     [else
-     (define-values (proc out-port err-port) (subprocess #f #f #f tmux-path (cdr args)))
+     (define-values (proc out-port _stdin err-port) (apply subprocess #f #f #f tmux-path (cdr args)))
      (subprocess-wait proc)
      (define status (subprocess-status proc))
      (close-input-port out-port)
      (close-input-port err-port)
      (values status "")]))
 
+;; Compute the q source root from this module's location.
+;; The harness is at tests/helpers/tmux-q-harness.rkt, so the q root is ../..
+(define q-source-root
+  (let* ([this-file (resolved-module-path-name (variable-reference->resolved-module-path
+                                                (#%variable-reference)))]
+         [this-dir (let-values ([(base _name _dir?) (split-path this-file)])
+                     base)])
+    (path->string (simplify-path (build-path this-dir ".." "..")))))
+
 ;; Build the full shell command for q --tui
 (define (build-q-tui-command home-dir project-dir args)
   (define racket-path (find-executable-path "racket"))
-  (define main-path (path->string (build-path (current-directory) "main.rkt")))
+  (define main-path (path->string (build-path q-source-root "main.rkt")))
   (format "HOME=~a TERM=xterm-256color ~a ~a ~a"
           home-dir
           (path->string racket-path)

--- a/tests/test-tmux-q-harness.rkt
+++ b/tests/test-tmux-q-harness.rkt
@@ -155,3 +155,8 @@
             "session name is non-empty string")
 
 (check-true (string-prefix? (make-session-name) "q-test-") "session name has q-test- prefix")
+
+(check-false (string-contains? (make-session-name) ".") "session name has no dot (tmux restriction)")
+
+(check-false (string-contains? (make-session-name) ":")
+             "session name has no colon (tmux restriction)")

--- a/tests/test-tmux-tui-smoke.rkt
+++ b/tests/test-tmux-tui-smoke.rkt
@@ -1,0 +1,109 @@
+#lang racket/base
+
+;; @speed slow
+;; @suite tui-tmux
+;; @boundary e2e
+
+;; tests/test-tmux-tui-smoke.rkt — P0 tmux smoke tests for q --tui
+;;
+;; These are real end-to-end tests that launch q --tui inside a tmux
+;; pseudo-terminal, interact with it, and verify behavior.
+;;
+;; Tests are SKIP by default. To run them:
+;;   Q_TMUX_TUI_TESTS=1 raco test tests/test-tmux-tui-smoke.rkt
+;;
+;; Scenarios covered:
+;;   T0: Launch welcome — q starts, q> prompt visible, status line visible
+;;   T1: Quit command — /quit causes session to exit within timeout
+
+(require rackunit
+         racket/string
+         "helpers/tmux-q-harness.rkt")
+
+;; ============================================================
+;; Skip guard
+;; ============================================================
+
+(unless (should-run-tmux-tests?)
+  (printf "SKIP: tmux smoke tests require Q_TMUX_TUI_TESTS=1 and tmux~n")
+  (exit 0))
+
+(printf "Running tmux smoke tests...~n")
+
+;; ============================================================
+;; T0: Launch and verify prompt + status line
+;; ============================================================
+
+(define env-T0 #f)
+(define sess-T0 #f)
+
+(define (cleanup-T0)
+  (when (and sess-T0 (session-alive? sess-T0))
+    (stop-session! sess-T0)))
+
+;; T0a: Session starts and stays alive
+(check-true (dynamic-wind (lambda () (set! env-T0 (make-tmux-test-env)))
+                          (lambda ()
+                            (set! sess-T0 (start-q-tui-session! env-T0))
+                            ;; Wait for q> prompt to appear
+                            (wait-for-text sess-T0 "q>" #:timeout-ms 20000))
+                          (lambda () (cleanup-T0)))
+            "T0a: q --tui launches and shows q> prompt")
+
+;; T0b: Status line is visible (ctx: indicator)
+(check-true (dynamic-wind (lambda () (set! env-T0 (make-tmux-test-env)))
+                          (lambda ()
+                            (set! sess-T0 (start-q-tui-session! env-T0))
+                            (wait-for-text sess-T0 "q>" #:timeout-ms 20000)
+                            ;; Status line should show context indicator
+                            (wait-for-text sess-T0 "ctx:" #:timeout-ms 5000))
+                          (lambda () (cleanup-T0)))
+            "T0b: status line with ctx: indicator is visible")
+
+;; T0c: Mock provider activates (no config in temp HOME)
+(check-true (dynamic-wind (lambda () (set! env-T0 (make-tmux-test-env)))
+                          (lambda ()
+                            (set! sess-T0 (start-q-tui-session! env-T0))
+                            (wait-for-text sess-T0 "q>" #:timeout-ms 20000)
+                            ;; Send a message and wait for mock response
+                            (send-line! sess-T0 "hello")
+                            (wait-for-text sess-T0 "Mock response" #:timeout-ms 15000))
+                          (lambda () (cleanup-T0)))
+            "T0c: mock provider responds to input")
+
+;; ============================================================
+;; T1: Quit command exits cleanly
+;; ============================================================
+
+(define env-T1 #f)
+(define sess-T1 #f)
+
+(define (cleanup-T1)
+  (when (and sess-T1 (session-alive? sess-T1))
+    (stop-session! sess-T1)))
+
+;; T1a: /quit causes session to exit within timeout
+(check-true (dynamic-wind (lambda () (set! env-T1 (make-tmux-test-env)))
+                          (lambda ()
+                            (set! sess-T1 (start-q-tui-session! env-T1))
+                            (wait-for-text sess-T1 "q>" #:timeout-ms 20000)
+                            ;; Send /quit
+                            (send-line! sess-T1 "/quit")
+                            ;; Session should exit within timeout
+                            (wait-for-exit sess-T1 #:timeout-ms 10000))
+                          (lambda () (cleanup-T1)))
+            "T1a: /quit exits q within timeout")
+
+;; T1b: No orphan tmux sessions after quit
+(check-true (dynamic-wind (lambda () (set! env-T1 (make-tmux-test-env)))
+                          (lambda ()
+                            (set! sess-T1 (start-q-tui-session! env-T1))
+                            (wait-for-text sess-T1 "q>" #:timeout-ms 20000)
+                            (send-line! sess-T1 "/quit")
+                            (wait-for-exit sess-T1 #:timeout-ms 10000)
+                            ;; After quit, session should NOT be alive
+                            (not (session-alive? sess-T1)))
+                          (lambda () (cleanup-T1)))
+            "T1b: no orphan tmux session after /quit")
+
+(printf "tmux smoke tests complete.~n")


### PR DESCRIPTION
## W2 — P0 tmux smoke: startup, prompt, quit

### Harness bug fixes (critical)
- **Session name dots**: `make-session-name` used `current-inexact-milliseconds` (float with `.`). tmux silently renames dot-containing sessions, making `has-session`/`list-sessions` fail. Fixed to use `current-milliseconds` (exact integer).
- **subprocess binding**: `run-tmux-command` bound 3 values from `subprocess` (which returns 4). Fixed to use `define-values (proc out _stdin err)`.
- **subprocess apply**: `run-tmux-command` passed `(cdr args)` as a single list arg instead of spreading via `apply`. Fixed.
- **Module-relative path**: `build-q-tui-command` used `(current-directory)` to find `main.rkt`, but `raco test` runs from the test file directory. Fixed to derive q source root from harness module location via `variable-reference->resolved-module-path`.

### New test file
`tests/test-tmux-tui-smoke.rkt` — 5 real e2e scenarios:
- **T0a**: q --tui launches, `q>` prompt visible within timeout
- **T0b**: Status line with `ctx:` indicator visible
- **T0c**: Mock provider responds to user input
- **T1a**: `/quit` exits session within timeout
- **T1b**: No orphan tmux session remains after quit

### Acceptance gates
- [x] All harness unit tests pass (39/39)
- [x] All tmux smoke tests pass with Q_TMUX_TUI_TESTS=1 (5/5)
- [x] Smoke gate passes (19/19 files, 286/286 tests)
- [x] No orphan tmux sessions after tests
- [x] No real HOME or credentials used