### PR TITLE
feat: W3 prompt-response and session artifact verification (#8591)

### DIFF
--- a/tests/helpers/tmux-q-harness.rkt
+++ b/tests/helpers/tmux-q-harness.rkt
@@ -71,6 +71,10 @@
          text-found-in?
          make-session-name
 
+         ;; Artifact discovery
+         find-session-subdirs
+         find-first-session-subdir
+
          ;; Pure functions (for unit testing)
          normalize-pane-output
          build-tmux-new-session-command
@@ -309,6 +313,28 @@
 (define (make-session-name)
   ;; tmux session names must not contain '.' or ':' — use exact integer
   (format "q-test-~a" (current-milliseconds)))
+
+;; ============================================================
+;; Artifact discovery
+;; ============================================================
+
+;; find-session-subdirs : path-string? -> (listof string?)
+;; Returns sorted list of subdirectory paths under the given session-dir.
+;; These are the session-id directories q creates (e.g. 01KVSHZK79Y5J42EJHHX38G27D).
+(define (find-session-subdirs session-dir-path)
+  (with-handlers ([exn:fail? (lambda (e) '())])
+    (if (directory-exists? session-dir-path)
+        (sort (for/list ([entry (in-list (directory-list session-dir-path))]
+                         #:when (directory-exists? (build-path session-dir-path entry)))
+                (path->string (build-path session-dir-path entry)))
+              string<?)
+        '())))
+
+;; find-first-session-subdir : path-string? -> (or/c #f string?)
+;; Returns the first session subdirectory path, or #f if none exist.
+(define (find-first-session-subdir session-dir-path)
+  (define subs (find-session-subdirs session-dir-path))
+  (and (pair? subs) (car subs)))
 
 ;; ============================================================
 ;; tmux command execution (internal)

--- a/tests/test-tmux-tui-session-artifacts.rkt
+++ b/tests/test-tmux-tui-session-artifacts.rkt
@@ -1,0 +1,179 @@
+#lang racket/base
+
+;; @speed slow
+;; @suite tui-tmux
+;; @boundary e2e
+
+;; tests/test-tmux-tui-session-artifacts.rkt — W3: prompt-response and session artifacts
+;;
+;; Real end-to-end tests that launch q --tui inside tmux, interact with it,
+;; and verify that:
+;;   T2: User input is echoed and Mock response appears
+;;   T3: Session artifacts (session.jsonl, trace.jsonl, scrollback.jsonl) are
+;;       created on disk after the session ends.
+;;
+;; Tests are SKIP by default. To run:
+;;   Q_TMUX_TUI_TESTS=1 raco test tests/test-tmux-tui-session-artifacts.rkt
+
+(require rackunit
+         racket/file
+         racket/string
+         racket/format
+         json
+         "helpers/tmux-q-harness.rkt")
+
+;; ============================================================
+;; Skip guard
+;; ============================================================
+
+(unless (should-run-tmux-tests?)
+  (printf "SKIP: tmux artifact tests require Q_TMUX_TUI_TESTS=1 and tmux~n")
+  (exit 0))
+
+(printf "Running tmux session artifact tests...~n")
+
+;; ============================================================
+;; T2: Prompt-response — input echo + Mock response visible
+;; ============================================================
+
+(define env-T2 #f)
+(define sess-T2 #f)
+
+(define (cleanup-T2)
+  (when (and sess-T2 (session-alive? sess-T2))
+    (stop-session! sess-T2)))
+
+;; T2a: User input is echoed with "> " prefix
+(check-true (dynamic-wind (lambda () (set! env-T2 (make-tmux-test-env)))
+                          (lambda ()
+                            (set! sess-T2 (start-q-tui-session! env-T2))
+                            (wait-for-text sess-T2 "q>" #:timeout-ms 20000)
+                            (send-line! sess-T2 "hello world")
+                            ;; Wait for the echo line to appear
+                            (wait-for-text sess-T2 "> hello world" #:timeout-ms 10000))
+                          (lambda () (cleanup-T2)))
+            "T2a: user input is echoed with '> ' prefix")
+
+;; T2b: Mock provider response appears
+(check-true (dynamic-wind (lambda () (set! env-T2 (make-tmux-test-env)))
+                          (lambda ()
+                            (set! sess-T2 (start-q-tui-session! env-T2))
+                            (wait-for-text sess-T2 "q>" #:timeout-ms 20000)
+                            (send-line! sess-T2 "tell me a joke")
+                            (wait-for-text sess-T2 "Mock response" #:timeout-ms 15000))
+                          (lambda () (cleanup-T2)))
+            "T2b: Mock provider response is visible")
+
+;; T2c: Multi-turn — second message response also visible
+(check-true
+ (dynamic-wind (lambda () (set! env-T2 (make-tmux-test-env)))
+               (lambda ()
+                 (set! sess-T2 (start-q-tui-session! env-T2 #:rows 50))
+                 (wait-for-text sess-T2 "q>" #:timeout-ms 20000)
+                 ;; First turn
+                 (send-line! sess-T2 "first message")
+                 (wait-for-text sess-T2 "Mock response" #:timeout-ms 15000)
+                 ;; Wait for prompt to return
+                 (sleep 1)
+                 ;; Second turn
+                 (send-line! sess-T2 "second message")
+                 ;; Capture enough lines to see both responses
+                 (wait-for-predicate sess-T2
+                                     (lambda ()
+                                       (define pane (capture-normalized sess-T2 #:lines 100))
+                                       ;; Count occurrences of "Mock response"
+                                       (define matches (regexp-match* #rx"Mock response" pane))
+                                       (>= (length matches) 2))
+                                     #:timeout-ms 15000))
+               (lambda () (cleanup-T2)))
+ "T2c: multi-turn interaction shows multiple responses")
+
+;; ============================================================
+;; T3: Session artifacts created after quit
+;; ============================================================
+
+(define env-T3 #f)
+(define sess-T3 #f)
+
+(define (cleanup-T3)
+  (when (and sess-T3 (session-alive? sess-T3))
+    (stop-session! sess-T3)))
+
+;; T3a: session.jsonl exists in session subdir after quit
+(check-true (dynamic-wind (lambda () (set! env-T3 (make-tmux-test-env)))
+                          (lambda ()
+                            (set! sess-T3 (start-q-tui-session! env-T3))
+                            (wait-for-text sess-T3 "q>" #:timeout-ms 20000)
+                            (send-line! sess-T3 "hello")
+                            (wait-for-text sess-T3 "Mock response" #:timeout-ms 15000)
+                            ;; Quit and wait for exit
+                            (send-line! sess-T3 "/quit")
+                            (wait-for-exit sess-T3 #:timeout-ms 10000)
+                            ;; Give filesystem a moment to flush
+                            (sleep 1)
+                            ;; Find the session subdir
+                            (define session-dir (tmux-q-session-session-dir sess-T3))
+                            (define subdir (find-first-session-subdir session-dir))
+                            (and subdir (file-exists? (build-path subdir "session.jsonl"))))
+                          (lambda () (cleanup-T3)))
+            "T3a: session.jsonl exists in session subdir after quit")
+
+;; T3b: trace.jsonl exists in session subdir after quit
+(check-true (dynamic-wind (lambda () (set! env-T3 (make-tmux-test-env)))
+                          (lambda ()
+                            (set! sess-T3 (start-q-tui-session! env-T3))
+                            (wait-for-text sess-T3 "q>" #:timeout-ms 20000)
+                            (send-line! sess-T3 "hello")
+                            (wait-for-text sess-T3 "Mock response" #:timeout-ms 15000)
+                            (send-line! sess-T3 "/quit")
+                            (wait-for-exit sess-T3 #:timeout-ms 10000)
+                            (sleep 1)
+                            (define session-dir (tmux-q-session-session-dir sess-T3))
+                            (define subdir (find-first-session-subdir session-dir))
+                            (and subdir (file-exists? (build-path subdir "trace.jsonl"))))
+                          (lambda () (cleanup-T3)))
+            "T3b: trace.jsonl exists in session subdir after quit")
+
+;; T3c: scrollback.jsonl exists under sessions dir after quit
+(check-true (dynamic-wind (lambda () (set! env-T3 (make-tmux-test-env)))
+                          (lambda ()
+                            (set! sess-T3 (start-q-tui-session! env-T3))
+                            (wait-for-text sess-T3 "q>" #:timeout-ms 20000)
+                            (send-line! sess-T3 "hello")
+                            (wait-for-text sess-T3 "Mock response" #:timeout-ms 15000)
+                            (send-line! sess-T3 "/quit")
+                            (wait-for-exit sess-T3 #:timeout-ms 10000)
+                            (sleep 1)
+                            (define session-dir (tmux-q-session-session-dir sess-T3))
+                            (file-exists? (build-path session-dir "scrollback.jsonl")))
+                          (lambda () (cleanup-T3)))
+            "T3c: scrollback.jsonl exists under sessions dir after quit")
+
+;; T3d: session.jsonl contains valid JSONL (first line parses as JSON)
+(check-true (dynamic-wind (lambda () (set! env-T3 (make-tmux-test-env)))
+                          (lambda ()
+                            (set! sess-T3 (start-q-tui-session! env-T3))
+                            (wait-for-text sess-T3 "q>" #:timeout-ms 20000)
+                            (send-line! sess-T3 "test message")
+                            (wait-for-text sess-T3 "Mock response" #:timeout-ms 15000)
+                            (send-line! sess-T3 "/quit")
+                            (wait-for-exit sess-T3 #:timeout-ms 10000)
+                            (sleep 1)
+                            (define session-dir (tmux-q-session-session-dir sess-T3))
+                            (define subdir (find-first-session-subdir session-dir))
+                            (and subdir
+                                 (let ([jsonl-path (build-path subdir "session.jsonl")])
+                                   (and (file-exists? jsonl-path)
+                                        ;; Parse the first non-empty line as JSON
+                                        (let* ([content (file->string jsonl-path)]
+                                               [lines (filter (lambda (l)
+                                                                (> (string-length (string-trim l)) 0))
+                                                              (string-split content "\n"))]
+                                               [first-line (string-trim (car lines))])
+                                          (with-handlers ([exn:fail? (lambda (e) #f)])
+                                            (string->jsexpr first-line)
+                                            #t))))))
+                          (lambda () (cleanup-T3)))
+            "T3d: session.jsonl first line is valid JSON")
+
+(printf "tmux session artifact tests complete.~n")


### PR DESCRIPTION
## W3 — Prompt-response and session artifact verification

### New test file
`tests/test-tmux-tui-session-artifacts.rkt` — 7 real e2e scenarios:

**T2: Prompt-response**
- T2a: User input echoed with `> ` prefix in pane
- T2b: Mock provider response (`Mock response from q.`) visible after sending message
- T2c: Multi-turn interaction — second message response also visible

**T3: Session artifacts**
- T3a: `session.jsonl` exists in session subdir after quit
- T3b: `trace.jsonl` exists in session subdir after quit
- T3c: `scrollback.jsonl` exists under sessions dir after quit
- T3d: `session.jsonl` first line is valid JSON (parseable)

### Harness additions
- `find-session-subdirs`: returns sorted list of session subdirectory paths under the sessions dir
- `find-first-session-subdir`: returns first session subdirectory path or #f

### Acceptance gates
- [x] All 7 tmux artifact tests pass with Q_TMUX_TUI_TESTS=1
- [x] All 39 harness unit tests pass
- [x] Smoke gate passes (19/19 files, 286/286 tests)
- [x] Mock provider path verified (no remote API used)
- [x] Artifacts verified under temp HOME only (no real HOME)