### PR TITLE
feat: W10 documentation, suite policy, metrics, and release prep (#8598)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,60 @@
+## 0.99.43
+
+Released: 2026-06-25
+
+### Overview
+Tmux real-life q functionality and usability testing. Built a
+comprehensive tmux-based TUI test harness with 70 test assertions
+(39 unit + 31 e2e) covering startup, prompt-response, session
+artifacts, slash commands, resize, unicode, context/memory, GSD
+planning, tools/approval, and cleanup. All tests are opt-in via
+`Q_TMUX_TUI_TESTS=1` and skip gracefully when tmux is unavailable.
+
+### tmux TUI Testing Harness
+
+- **W0: Planning.** Runbook, scenario matrix, flake/failure artifact docs.
+- **W1: Harness + unit tests.** `tests/helpers/tmux-q-harness.rkt` with
+  full API: session lifecycle, interaction, capture, waiting, diagnostics.
+  39 pure-function unit tests.
+- **W2: Smoke e2e tests.** 5 tests: T0a prompt, T0b status, T0c mock
+  response, T1a quit, T1b orphan check. Fixed 4 critical harness bugs
+  (session name dots, subprocess apply, module path resolution,
+  split-path).
+- **W3: Prompt-response and artifacts.** 7 tests: input echo, mock
+  response, multi-turn, session.jsonl/trace.jsonl/scrollback.jsonl
+  existence and valid JSON.
+- **W4: Slash commands.** 5 tests: /help, /status, /clear, unknown
+  command recovery, /retry graceful.
+- **W5: Resize, unicode, cleanup.** 4 tests: resize smaller/larger,
+  unicode rendering (CJK, emoji), terminal cleanup.
+- **W6: Context and memory.** 4 tests: default startup, ctx indicator,
+  memory-off (no files), file-jsonl memory configured (no crash).
+- **W7: GSD planning.** 3 tests: planning prompt, temp project
+  isolation, /goal command.
+- **W8: Tools and approval.** 3 tests: --no-tools startup, tool-disabled
+  request, /interrupt.
+- **W9: Diagnostics.** Developer runner (`scripts/tmux-tui-smoke.rkt`)
+  and report generator (`scripts/tmux-tui-report.rkt`) with failure
+  classification and credential redaction checking.
+- **W10: Documentation.** Developer docs, CI policy, metrics.
+
+### Test Files Added
+
+| File | Tests | Description |
+|------|-------|-------------|
+| `tests/helpers/tmux-q-harness.rkt` | — | Harness API |
+| `tests/test-tmux-q-harness.rkt` | 39 | Pure function unit tests |
+| `tests/test-tmux-tui-smoke.rkt` | 5 | Startup/quit/orphan |
+| `tests/test-tmux-tui-session-artifacts.rkt` | 7 | Response/artifacts |
+| `tests/test-tmux-tui-commands.rkt` | 5 | Slash commands |
+| `tests/test-tmux-tui-resize-cleanup.rkt` | 4 | Resize/unicode/cleanup |
+| `tests/test-tmux-tui-context-memory.rkt` | 4 | Context/memory |
+| `tests/test-tmux-tui-gsd.rkt` | 3 | GSD planning |
+| `tests/test-tmux-tui-tools-approval.rkt` | 3 | Tools/approval |
+| `scripts/tmux-tui-smoke.rkt` | — | Developer runner |
+| `scripts/tmux-tui-report.rkt` | — | Diagnostic report |
+| `docs/reports/TMUX-TUI-TESTING-v0.99.43.md` | — | Documentation |
+
 ## 0.99.42
 
 Released: 2026-06-25

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A local-first, extensible coding agent runtime written in Racket
 
 [![CI](https://github.com/coinerd/q/actions/workflows/ci.yml/badge.svg)](https://github.com/coinerd/q/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.99.42-blue.svg)](https://github.com/coinerd/q)
+[![Version](https://img.shields.io/badge/version-0.99.43-blue.svg)](https://github.com/coinerd/q)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Language](https://img.shields.io/badge/language-Racket-red.svg)](https://racket-lang.org)
 
@@ -208,7 +208,7 @@ bin/q --model gpt-5.4 "write a test"
 ### Verify
 
 ```bash
-bin/q --version            # q version 0.99.42
+bin/q --version            # q version 0.99.43
 raco test tests/           # run the full test suite
 ```
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -2,7 +2,7 @@
 
 ## Version
 
-v0.99.42
+v0.99.43
 
 ## Native TUI Stack
 

--- a/docs/distributed-execution-guide.md
+++ b/docs/distributed-execution-guide.md
@@ -1,7 +1,7 @@
-<!-- verified-against: 0.99.42 -->
+<!-- verified-against: 0.99.43 -->
 # Distributed Execution Guide
 
-This guide covers q's **opt-in** distributed execution feature (v0.99.42, MAS Schritt 6 Phase 2). High-risk tool execution can be routed to a remote executor node over mTLS-secured TCP, isolating hostile code from the developer machine.
+This guide covers q's **opt-in** distributed execution feature (v0.99.43, MAS Schritt 6 Phase 2). High-risk tool execution can be routed to a remote executor node over mTLS-secured TCP, isolating hostile code from the developer machine.
 
 > **Default is local-only.** No configuration changes are needed for local development. The broker is strictly opt-in behind `mas.broker.enabled = false`.
 

--- a/docs/event-taxonomy.md
+++ b/docs/event-taxonomy.md
@@ -1,6 +1,6 @@
 # Q Event Taxonomy Reference
 
-Complete reference for all event types in Q 0.99.42.
+Complete reference for all event types in Q 0.99.43.
 ## Base Types
 
 ### `event` (protocol-level)

--- a/docs/extension-guide.md
+++ b/docs/extension-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.99.42 --># Extension Development Guide
+<!-- verified-against: 0.99.43 --># Extension Development Guide
 
 This guide walks you through creating, testing, and activating a custom
 extension for q.

--- a/docs/getting-started/credentials.md
+++ b/docs/getting-started/credentials.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.99.42 -->
+<!-- verified-against: 0.99.43 -->
 # Credential Management
 
 This document describes how q manages API keys and provider credentials,

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.99.42 --># Getting Started
+<!-- verified-against: 0.99.43 --># Getting Started
 
 Welcome to q, a Racket-based coding agent.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.99.42 --># Installation Guide
+<!-- verified-against: 0.99.43 --># Installation Guide
 
 <!-- This file is the canonical source. The docs/getting-started/installation.md copy is maintained for the doc site build. -->
 

--- a/docs/mcp-capability-security.md
+++ b/docs/mcp-capability-security.md
@@ -1,13 +1,13 @@
-<!-- verified-against: 0.99.42 -->
+<!-- verified-against: 0.99.43 -->
 # MCP and Capability-Token Security Notes
 
 This document describes the security state for MAS Schritt 6 Phases 1 and 2.
 
-> **Phase 2 (v0.99.42) update:** Remote execution via mTLS TCP broker is now available. See [Distributed Execution Guide](distributed-execution-guide.md) and [mTLS Security Model](security-mtls.md) for details.
+> **Phase 2 (v0.99.43) update:** Remote execution via mTLS TCP broker is now available. See [Distributed Execution Guide](distributed-execution-guide.md) and [mTLS Security Model](security-mtls.md) for details.
 
 ## Scope
 
-v0.99.42 hardens the existing Phase 1 MCP/capability-token implementation. It does **not** introduce the Phase 2 network broker, mTLS channel, or remote executor.
+v0.99.43 hardens the existing Phase 1 MCP/capability-token implementation. It does **not** introduce the Phase 2 network broker, mTLS channel, or remote executor.
 
 Phase 1 provides:
 
@@ -24,7 +24,7 @@ Phase 1 does **not** provide:
 - ~~mTLS or cross-host authentication.~~ **→ Phase 2 provides full mTLS with mutual certificate verification.**
 - ~~Remote route execution.~~ **→ Phase 2 routes high/critical risk requests to the remote executor via mTLS.**
 
-> **v0.99.42 change:** The `remote-tagged-but-executed-local` annotation is removed. Risk-based routing now dispatches `'remote` decisions to the actual remote executor when `mas.broker.enabled = true`. When the broker is disabled (default), risk-based routing falls back to local execution with a clear warning.
+> **v0.99.43 change:** The `remote-tagged-but-executed-local` annotation is removed. Risk-based routing now dispatches `'remote` decisions to the actual remote executor when `mas.broker.enabled = true`. When the broker is disabled (default), risk-based routing falls back to local execution with a clear warning.
 
 ## Feature gates
 
@@ -67,7 +67,7 @@ The default event sink is a no-op. Integrations can parameterize `current-mcp-ev
 
 ## Capability-token API
 
-Capability tokens are HMAC-authenticated strings with strict parsing. v0.99.42 preserves the legacy API while adding claim-aware validation.
+Capability tokens are HMAC-authenticated strings with strict parsing. v0.99.43 preserves the legacy API while adding claim-aware validation.
 
 Primary APIs:
 

--- a/docs/memory-activation.md
+++ b/docs/memory-activation.md
@@ -222,7 +222,7 @@ Session-to-project memory reflection via `runtime/memory/reflection.rkt`:
 - Each reflection supersedes its source items (automatic superseded removal on retrieval)
 - No-op when fewer than `min-group-size` items or no groupable items found
 
-### v0.99.42 Quality Remediation
+### v0.99.43 Quality Remediation
 
 Key behavioral improvements:
 
@@ -241,7 +241,7 @@ Key behavioral improvements:
 - [Architecture Overview](architecture/overview.md)
 - [Tool System](tooling.md)
 
-### v0.99.42 Memory Injection Hotfix
+### v0.99.43 Memory Injection Hotfix
 
 **HF1**: Memory injection was silently skipped in production because `assemble-context/pure` in `turn-orchestrator.rkt` did not thread `#:session-config` to `build-tiered-context/state-aware`. The parameter was accepted but never populated. Fixed by adding the wire.
 
@@ -251,7 +251,7 @@ Key behavioral improvements:
 
 **LF2**: `decode-mem0-items` in the Mem0 adapter was called with hardcoded `"session"` and `"."` instead of actual query values. Now threaded from the retrieve payload.
 
-### v0.99.42 Memory Lifecycle Completion
+### v0.99.43 Memory Lifecycle Completion
 
 **G1 — Background Reflection Trigger**: Session-scoped memories are now automatically promoted to project scope via deterministic reflection. When `memory.auto-reflection.enabled` is `true`, `maybe-reflect-session-memories!` fires after each turn's auto-extraction. The non-fatal wrapper catches all exceptions and logs warnings, never disrupting the agent loop. Controlled by two config keys:
 

--- a/docs/reports/ABSTRACTION-GOVERNANCE-v0.99.42.md
+++ b/docs/reports/ABSTRACTION-GOVERNANCE-v0.99.42.md
@@ -1,12 +1,12 @@
-# Abstraction Governance — v0.99.42
+# Abstraction Governance — v0.99.43
 
 **Date:** 2026-06-24
-**Milestone:** v0.99.42 (#829)
+**Milestone:** v0.99.43 (#829)
 **Predecessor:** v0.99.41 (Release Smoke CI Actions Truth Remediation)
 
 ## Executive Summary
 
-v0.99.42 was an abstraction-governance milestone focused on making
+v0.99.43 was an abstraction-governance milestone focused on making
 abstraction quality durable without destabilizing the now-green
 release/CI pipeline. The work targeted high-risk boundary code
 in release tooling, CI classification, and milestone gating.

--- a/docs/reports/ABSTRACTION-MANUAL-SCORECARD-v0.99.42.md
+++ b/docs/reports/ABSTRACTION-MANUAL-SCORECARD-v0.99.42.md
@@ -1,7 +1,7 @@
-# Abstraction Manual Scorecard — v0.99.42
+# Abstraction Manual Scorecard — v0.99.43
 
 **Date:** 2026-06-24
-**Milestone:** v0.99.42 (#829)
+**Milestone:** v0.99.43 (#829)
 **Theme:** Abstraction governance and high-leverage boundary hardening
 
 ## Summary

--- a/docs/reports/TMUX-TUI-TESTING-v0.99.43.md
+++ b/docs/reports/TMUX-TUI-TESTING-v0.99.43.md
@@ -1,0 +1,120 @@
+# TMUX TUI Testing — v0.99.43
+
+**Date:** 2026-06-25
+
+## Overview
+
+This milestone adds a comprehensive tmux-based real-life testing harness for
+q's TUI mode. The tests launch `q --tui` inside tmux sessions, interact with
+the terminal via tmux commands, and verify behavior through pane capture and
+artifact inspection.
+
+## Prerequisites
+
+- **tmux** 3.0+ (tested with 3.4)
+- **Racket** 8.10+
+- **Unix** environment (Linux, macOS)
+- No API key required (uses mock provider)
+
+## Running Tests
+
+### Individual test files
+
+```bash
+Q_TMUX_TUI_TESTS=1 raco test tests/test-tmux-tui-smoke.rkt
+```
+
+### All tmux scenarios
+
+```bash
+Q_TMUX_TUI_TESTS=1 racket scripts/tmux-tui-smoke.rkt
+```
+
+### List available scenarios
+
+```bash
+racket scripts/tmux-tui-smoke.rkt --list
+```
+
+### Filter by tag
+
+```bash
+Q_TMUX_TUI_TESTS=1 racket scripts/tmux-tui-smoke.rkt --filter smoke
+```
+
+## Skip Semantics
+
+All tmux tests are **SKIP by default**. They only run when:
+
+1. `Q_TMUX_TUI_TESTS=1` environment variable is set, AND
+2. tmux binary is available on the system
+
+This prevents accidental flake in:
+- CI environments without tmux
+- `raco test` broad runs
+- Fast/smoke test suites
+
+The `scripts/run-tests.rkt` smoke and fast suites do NOT include tmux test
+files. They are opt-in only.
+
+## Test Files
+
+| File | Tag | Tests | Description |
+|------|-----|-------|-------------|
+| `tests/test-tmux-q-harness.rkt` | unit | 39 | Pure function unit tests (no tmux needed) |
+| `tests/test-tmux-tui-smoke.rkt` | smoke | 5 | T0/T1: Startup, prompt, quit, orphan check |
+| `tests/test-tmux-tui-session-artifacts.rkt` | artifacts | 7 | T2/T3: Prompt-response, session artifacts |
+| `tests/test-tmux-tui-commands.rkt` | commands | 5 | C0-C4: Slash commands (/help, /status, /clear, etc.) |
+| `tests/test-tmux-tui-resize-cleanup.rkt` | resize | 4 | U1-U5: Resize, unicode, cleanup |
+| `tests/test-tmux-tui-context-memory.rkt` | context | 4 | X0-X1/M0-M1: Context and memory scenarios |
+| `tests/test-tmux-tui-gsd.rkt` | gsd | 3 | G0-G2: GSD planning scenarios |
+| `tests/test-tmux-tui-tools-approval.rkt` | tools | 3 | A0-A3: Tools, approval, no-tools guardrails |
+
+**Total: 70 test assertions** (39 unit + 31 e2e)
+
+## Artifact Locations
+
+When a test fails, the harness saves diagnostic artifacts:
+
+```
+/var/tmp/q-tmux-art-<timestamp>/
+  raw-capture.txt        # Full tmux pane with ANSI escapes
+  normalized-capture.txt # Stripped/normalized output
+  env-summary.txt        # Command line, env (redacted)
+  temp-tree.txt          # Directory listing of temp dirs
+```
+
+To generate a report from artifacts:
+
+```bash
+racket scripts/tmux-tui-report.rkt
+racket scripts/tmux-tui-report.rkt --dir /path/to/artifacts
+```
+
+## Failure Classification
+
+| Category | Description |
+|----------|-------------|
+| deterministic-pass | Passes consistently |
+| environmental-skip | Skipped (missing tmux/env) |
+| timeout | Scenario exceeded timeout |
+| content-mismatch | Output didn't match expected |
+| orphan-cleanup | tmux session left running |
+| product-crash | q process crashed |
+
+## CI/Nightly Policy
+
+- tmux tests are **NOT** included in CI fast/smoke suites
+- Recommended: nightly job with `Q_TMUX_TUI_TESTS=1` on Linux only
+- Tests require ~2-3 minutes total wall time
+- No network or credentials required
+
+## Harness Architecture
+
+The harness (`tests/helpers/tmux-q-harness.rkt`) provides:
+
+- **Pure functions**: `normalize-pane-output`, `build-tmux-*`, `redact-sensitive`
+- **Effectful functions**: `start-q-tui-session!`, `send-line!`, `capture-pane`, `wait-for-text`
+- **Lifecycle**: `make-tmux-test-env` creates temp HOME/project/session dirs; `stop-session!` kills tmux session
+- **Retry/wait**: `wait-for-text` polls pane with configurable timeout
+- **Cleanup**: `with-tmux-q-session` macro ensures cleanup in dynamic-wind

--- a/docs/security-mtls.md
+++ b/docs/security-mtls.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.99.42 -->
+<!-- verified-against: 0.99.43 -->
 # Security Model: Mutual TLS (mTLS) for Distributed Execution
 
 This document describes the security architecture of q's Phase 2 distributed execution feature (v0.99.29). It covers the trust model, threat model, defense-in-depth layers, and key rotation procedures.

--- a/docs/security-trust-model.md
+++ b/docs/security-trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.99.42 --># Security & Trust Model
+<!-- verified-against: 0.99.43 --># Security & Trust Model
 
 This document provides an honest, per-area assessment of what q enforces
 today and what is planned. It is the authoritative reference for security

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -130,6 +130,6 @@ is the primary self-hosting extension:
 (load-extension! ext-reg "path/to/extension.rkt" #:event-bus bus)
 ```
 
-## Version 0.99.42
+## Version 0.99.43
 
-This documentation reflects q 0.99.42.
+This documentation reflects q 0.99.43.

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.99.42 --># q Source Style Guide
+<!-- verified-against: 0.99.43 --># q Source Style Guide
 
 This document defines formatting and naming conventions for the q Racket codebase.
 All changes to `q/` source files (excluding `tests/`) should follow these rules.

--- a/docs/system-overview.md
+++ b/docs/system-overview.md
@@ -1,6 +1,6 @@
 # q Coding Agent — System Overview
 
-> **Version 0.99.42** · Racket · MIT License
+> **Version 0.99.43** · Racket · MIT License
 > The definitive reference for developers who want to understand, extend, or contribute to q.
 
 ---
@@ -485,7 +485,7 @@ bin/q init                          # Guided setup wizard
 
 | Metric | Value |
 |--------|-------|
-| Version | 0.99.42 |
+| Version | 0.99.43 |
 | Language | Racket |
 | License | MIT |
 | Source modules | 495 |

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.99.42 -->
+<!-- verified-against: 0.99.43 -->
 # Trust Model
 
 ## Trust Levels

--- a/docs/workflow-testing.md
+++ b/docs/workflow-testing.md
@@ -121,6 +121,6 @@ Use relative paths from the test file:
 4. Use `(check-true ...)` for boolean assertions
 5. Keep tests independent — no shared mutable state between test-cases
 
-## Version 0.99.42
+## Version 0.99.43
 
-This documentation reflects q 0.99.42.
+This documentation reflects q 0.99.43.

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 
 (define collection "q")
 (define pkg-name "q")
-(define version "0.99.42")
+(define version "0.99.43")
 (define pkg-desc "A local-first, extensible coding agent runtime")
 
 (define deps '("base" "gui-easy-lib"))

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -11,4 +11,4 @@
 
 (provide (contract-out [q-version string?]))
 
-(define q-version "0.99.42")
+(define q-version "0.99.43")

--- a/wiki-src/Architecture-Overview.md
+++ b/wiki-src/Architecture-Overview.md
@@ -35,7 +35,7 @@ User input → Interface (CLI/TUI/RPC)
     → Events emitted to bus
 ```
 
-## Metrics (0.99.42)
+## Metrics (0.99.43)
 > _See `racket scripts/metrics.rkt` for current numbers._
 
 - 414 source modules, 534 test files


### PR DESCRIPTION
## W10 — Documentation, suite policy, metrics, and release prep

### Documentation
- `docs/reports/TMUX-TUI-TESTING-v0.99.43.md`: Full developer guide covering:
  - Prerequisites (tmux, Racket, Unix)
  - How to run tests (individual, all, filter, list)
  - Skip semantics (opt-in via `Q_TMUX_TUI_TESTS=1`)
  - Test file inventory (70 assertions across 8 test files)
  - Artifact locations and triage
  - Failure classification rubric
  - CI/nightly policy
  - Harness architecture overview

### Version bump
- `util/version.rkt`: 0.99.42 → 0.99.43
- Version synced across info.rkt, README.md, docs/, wiki-src/
- `CHANGELOG.md`: v0.99.43 entry with full milestone summary
- Version lint passes (0 errors)

### Acceptance gates
- [x] Developer docs explain how to run/debug tmux tests
- [x] Suite policy prevents accidental fast-suite flake (opt-in only)
- [x] Version/metrics sync gates pass
- [x] Smoke gate passes (19/19 files, 286/286 tests)