### PR TITLE
feat: add official tmux TUI explorer (#8615)

### DIFF
--- a/scripts/tmux-tui-explore.rkt
+++ b/scripts/tmux-tui-explore.rkt
@@ -1,0 +1,364 @@
+#!/usr/bin/env racket
+#lang racket/base
+
+;; scripts/tmux-tui-explore.rkt — Official exploratory tmux TUI runner
+;;
+;; This command is intentionally conservative. Mock mode is local/no-network and
+;; suitable for fast developer checks. Real-provider mode refuses to run unless
+;; explicit cost/credential gates are present.
+
+(require json
+         racket/cmdline
+         racket/date
+         racket/file
+         racket/format
+         racket/list
+         racket/match
+         racket/path
+         racket/string)
+
+(provide (struct-out explore-scenario)
+         (struct-out explore-result)
+         scenario-registry
+         find-scenarios
+         valid-mode?
+         real-provider-authorized?
+         require-real-provider-authorization!
+         redact-explore-text
+         make-explore-root
+         render-scenario-markdown
+         write-explore-report!
+         write-summary-files!
+         run-exploration
+         print-scenario-list)
+
+(struct explore-scenario (tag title description prompt expected-status real-tools?) #:transparent)
+(struct explore-result
+        (tag title mode status classification report-path evidence started-at completed-at)
+  #:transparent)
+
+(define scenario-registry
+  (list
+   (explore-scenario "memory"
+                     "Memory/context"
+                     "Session-context recall and context-source truthfulness."
+                     "Remember that the codename is blue-harbor, then identify its source."
+                     'pass-mock-tui
+                     #f)
+   (explore-scenario "gsd"
+                     "GSD planning"
+                     "Wave planning with explicit gate evidence and no fabricated PASS."
+                     "Create W0/W1 plan and revise it for red CI without claiming unverified PASS."
+                     'pass-mock-tui
+                     #f)
+   (explore-scenario "mas"
+                     "MAS/subagents"
+                     "Subagent-oriented review scenario; W6 adds lifecycle-event proof."
+                     "Use subagents or explain their unavailability, then aggregate results."
+                     'pass-mock-tui-with-caveat
+                     #f)
+   (explore-scenario "tools"
+                     "Tools/approval"
+                     "Read-only tool scenario over README_FIXTURE_ALPHA."
+                     "Inspect README.md only and report whether README_FIXTURE_ALPHA is present."
+                     'pass-mock-tui
+                     #t)
+   (explore-scenario "release-audit"
+                     "Release/audit truth"
+                     "Release authorization refusal without live CI/release evidence."
+                     "Decide whether release is authorized when no live CI evidence is available."
+                     'pass-mock-tui-partial
+                     #f)
+   (explore-scenario
+    "durable-memory"
+    "Durable memory restart"
+    "Restart/round-trip memory scenario; W7 upgrades this from unsupported to evidence-backed."
+    "Persist a durable fact, restart, and recall it without restating it."
+    'unsupported-until-w7
+    #f)))
+
+(define (valid-mode? mode)
+  (member mode '(mock real)))
+
+(define (mode->string mode)
+  (case mode
+    [(mock) "mock"]
+    [(real) "real"]
+    [else (format "~a" mode)]))
+
+(define (parse-mode str)
+  (cond
+    [(equal? str "mock") 'mock]
+    [(equal? str "real") 'real]
+    [else (error 'tmux-tui-explore "invalid mode: ~a" str)]))
+
+(define (find-scenarios #:filter [filter-tag #f])
+  (cond
+    [(not filter-tag) scenario-registry]
+    [else (filter (lambda (s) (equal? (explore-scenario-tag s) filter-tag)) scenario-registry)]))
+
+(define (real-provider-authorized?)
+  (and (equal? (getenv "Q_TMUX_TUI_TESTS") "1")
+       (equal? (getenv "Q_TMUX_TUI_REAL_PROVIDER") "1")
+       (equal? (getenv "Q_TMUX_TUI_REAL_PROVIDER_CONFIRM") "I_UNDERSTAND_COSTS")))
+
+(define (require-real-provider-authorization!)
+  (unless (real-provider-authorized?)
+    (error 'tmux-tui-explore
+           (string-append "real-provider mode requires Q_TMUX_TUI_TESTS=1, "
+                          "Q_TMUX_TUI_REAL_PROVIDER=1, and "
+                          "Q_TMUX_TUI_REAL_PROVIDER_CONFIRM=I_UNDERSTAND_COSTS"))))
+
+(define secret-regexps
+  (list #px"sk-[A-Za-z0-9_-]+"
+        #px"(?i:bearer) +[A-Za-z0-9._-]+"
+        #px"(?i:(api[_-]?key|token|secret|password))=([^ \t\n\r]+)"
+        #px"(?i:(api[_-]?key|token|secret|password))\":\"([^\"]+)"))
+
+(define (redact-explore-text text)
+  (define redacted
+    (for/fold ([acc text]) ([rx (in-list secret-regexps)])
+      (regexp-replace*
+       rx
+       acc
+       (lambda matches
+         (define matched (car matches))
+         (cond
+           [(regexp-match? #px"=" matched) (regexp-replace #px"=.*$" matched "=<REDACTED>")]
+           [(regexp-match? #px"\":\"" matched)
+            (regexp-replace #px"\":\".*$" matched "\":\"<REDACTED>")]
+           [(regexp-match? #px"(?i:bearer)" matched) "Bearer <REDACTED>"]
+           [else "<REDACTED>"])))))
+  redacted)
+
+(define (make-explore-root [base-dir (find-system-path 'temp-dir)])
+  (define root (make-temporary-file "q-tmux-explore-~a" 'directory base-dir))
+  (path->string root))
+
+(define (timestamp)
+  (parameterize ([date-display-format 'iso-8601])
+    (date->string (current-date) #t)))
+
+(define (scenario->mock-evidence scenario)
+  (case (string->symbol (explore-scenario-tag scenario))
+    [(memory)
+     '(("completion" . "mock turn completed")
+       ("context" . "blue-harbor retained as session context only")
+       ("durability" . "not claimed"))]
+    [(gsd)
+     '(("completion" . "mock turn completed") ("waves" . "W0/W1 with gates")
+                                              ("truth" . "no executed PASS claimed"))]
+    [(mas)
+     '(("completion" . "mock turn completed") ("caveat" . "lifecycle events deferred to W6")
+                                              ("truth" . "prose-only evidence is not final PASS"))]
+    [(tools)
+     '(("completion" . "mock turn completed") ("fixture" . "README_FIXTURE_ALPHA")
+                                              ("mutation" . "no file modifications"))]
+    [(release-audit)
+     '(("completion" . "mock turn completed")
+       ("authorization" . "refused without live CI/release evidence")
+       ("required" . "release-manifest.json"))]
+    [(durable-memory)
+     '(("completion" . "mock turn completed")
+       ("status" . "unsupported until restart round-trip exists")
+       ("truth" . "one-session context is not durable memory"))]
+    [else '(("completion" . "mock turn completed"))]))
+
+(define (scenario-status mode scenario)
+  (cond
+    [(eq? mode 'mock) (explore-scenario-expected-status scenario)]
+    [(equal? (explore-scenario-tag scenario) "durable-memory") 'unsupported-until-w7]
+    [else 'requires-real-provider-run]))
+
+(define (scenario-classification status)
+  (case status
+    [(pass-mock-tui) 'pass]
+    [(pass-mock-tui-with-caveat pass-mock-tui-partial) 'partial]
+    [(unsupported-until-w7) 'unsupported]
+    [(requires-real-provider-run) 'pending-real-run]
+    [else 'unknown]))
+
+(define (alist-ref key alist [default #f])
+  (define found (assoc key alist))
+  (if found
+      (cdr found)
+      default))
+
+(define (render-scenario-markdown result)
+  (define evidence (explore-result-evidence result))
+  (string-append
+   (format "# tmux TUI exploration — ~a~n~n" (explore-result-title result))
+   (format "**Scenario:** `~a`  ~n" (explore-result-tag result))
+   (format "**Mode:** `~a`  ~n" (mode->string (explore-result-mode result)))
+   (format "**Status:** `~a`  ~n" (explore-result-status result))
+   (format "**Classification:** `~a`  ~n" (explore-result-classification result))
+   (format "**Started:** ~a  ~n" (explore-result-started-at result))
+   (format "**Completed:** ~a  ~n~n" (explore-result-completed-at result))
+   "## Evidence\n\n"
+   (apply string-append
+          (for/list ([item (in-list evidence)])
+            (format "- **~a:** ~a~n" (car item) (redact-explore-text (format "~a" (cdr item))))))
+   "\n## Safety\n\n"
+   "```text\n"
+   "real-provider mode is explicit opt-in only\n"
+   "temp HOME/project isolation required for real mode\n"
+   "credential-like values are redacted before report writing\n"
+   "```\n"))
+
+(define (safe-file-tag tag)
+  (regexp-replace* #px"[^A-Za-z0-9_.-]+" tag "-"))
+
+(define (write-explore-report! root result)
+  (make-directory* root)
+  (define report-path
+    (build-path root
+                (format "~a-~a.md"
+                        (mode->string (explore-result-mode result))
+                        (safe-file-tag (explore-result-tag result)))))
+  (call-with-output-file report-path
+                         (lambda (out)
+                           (display (redact-explore-text (render-scenario-markdown result)) out))
+                         #:exists 'replace)
+  (struct-copy explore-result result [report-path (path->string report-path)]))
+
+(define (result->hash result)
+  (hasheq 'tag
+          (explore-result-tag result)
+          'title
+          (explore-result-title result)
+          'mode
+          (mode->string (explore-result-mode result))
+          'status
+          (format "~a" (explore-result-status result))
+          'classification
+          (format "~a" (explore-result-classification result))
+          'report_path
+          (or (explore-result-report-path result) "")
+          'started_at
+          (explore-result-started-at result)
+          'completed_at
+          (explore-result-completed-at result)))
+
+(define (write-summary-files! root results)
+  (make-directory* root)
+  (define tsv-path (build-path root "summary.tsv"))
+  (define json-path (build-path root "summary.json"))
+  (call-with-output-file tsv-path
+                         (lambda (out)
+                           (fprintf out "tag\ttitle\tmode\tstatus\tclassification\treport_path~n")
+                           (for ([r (in-list results)])
+                             (fprintf out
+                                      "~a\t~a\t~a\t~a\t~a\t~a~n"
+                                      (explore-result-tag r)
+                                      (explore-result-title r)
+                                      (mode->string (explore-result-mode r))
+                                      (explore-result-status r)
+                                      (explore-result-classification r)
+                                      (or (explore-result-report-path r) ""))))
+                         #:exists 'replace)
+  (call-with-output-file json-path
+                         (lambda (out) (write-json (map result->hash results) out))
+                         #:exists 'replace)
+  (values (path->string tsv-path) (path->string json-path)))
+
+(define (append-central-log! path results)
+  (make-directory* (or (let-values ([(base name dir?) (split-path path)])
+                         (and (path? base) base))
+                       (current-directory)))
+  (call-with-output-file path
+                         (lambda (out)
+                           (fprintf out "~n## Explorer run — ~a~n~n" (timestamp))
+                           (for ([r (in-list results)])
+                             (fprintf out
+                                      "- `~a` mode=`~a` status=`~a` classification=`~a` report=`~a`~n"
+                                      (explore-result-tag r)
+                                      (mode->string (explore-result-mode r))
+                                      (explore-result-status r)
+                                      (explore-result-classification r)
+                                      (or (explore-result-report-path r) ""))))
+                         #:exists 'append))
+
+(define (run-one-scenario scenario mode root)
+  (define started (timestamp))
+  ;; W1 intentionally establishes the official runner/report contract. Later
+  ;; waves replace pane/sentinel mock evidence with structured TUI event waits.
+  (define status (scenario-status mode scenario))
+  (define result
+    (explore-result (explore-scenario-tag scenario)
+                    (explore-scenario-title scenario)
+                    mode
+                    status
+                    (scenario-classification status)
+                    #f
+                    (scenario->mock-evidence scenario)
+                    started
+                    (timestamp)))
+  (write-explore-report! root result))
+
+(define (run-exploration #:mode [mode 'mock]
+                         #:filter [filter-tag #f]
+                         #:out [out-dir #f]
+                         #:append-log [append-log #f])
+  (unless (valid-mode? mode)
+    (error 'tmux-tui-explore "invalid mode: ~a" mode))
+  (when (eq? mode 'real)
+    (require-real-provider-authorization!))
+  (define scenarios (find-scenarios #:filter filter-tag))
+  (when (null? scenarios)
+    (error 'tmux-tui-explore "no scenarios match filter: ~a" filter-tag))
+  (define root (or out-dir (make-explore-root)))
+  (make-directory* root)
+  (define results
+    (for/list ([s (in-list scenarios)])
+      (run-one-scenario s mode root)))
+  (define-values (_tsv _json) (write-summary-files! root results))
+  (when append-log
+    (append-central-log! append-log results))
+  results)
+
+(define (print-scenario-list [out (current-output-port)])
+  (fprintf out "Available tmux TUI exploration scenarios:~n")
+  (for ([s (in-list scenario-registry)])
+    (fprintf out
+             "  ~a~a~a~n"
+             (explore-scenario-tag s)
+             (make-string (max 1 (- 18 (string-length (explore-scenario-tag s)))) #\space)
+             (explore-scenario-description s))))
+
+(define (print-summary results out-dir)
+  (printf "=== q tmux TUI explorer ===~n")
+  (printf "Output: ~a~n" out-dir)
+  (for ([r (in-list results)])
+    (printf "  ~a mode=~a status=~a classification=~a~n"
+            (explore-result-tag r)
+            (mode->string (explore-result-mode r))
+            (explore-result-status r)
+            (explore-result-classification r)))
+  (printf "Summary: ~a scenario(s)~n" (length results)))
+
+(module+ main
+  (define list-only? #f)
+  (define mode-str "mock")
+  (define filter-tag #f)
+  (define out-dir #f)
+  (define append-log #f)
+  (command-line
+   #:program "tmux-tui-explore"
+   #:once-each [("-l" "--list") "List scenarios without running" (set! list-only? #t)]
+   [("-m" "--mode") mode "Mode: mock or real (default: mock)" (set! mode-str mode)]
+   [("-f" "--filter") tag "Run only one scenario tag" (set! filter-tag tag)]
+   [("-o" "--out") dir "Output directory for reports" (set! out-dir dir)]
+   [("--append-log") path "Append compact ledger entry to a markdown log" (set! append-log path)]
+   #:args ()
+   (void))
+  (cond
+    [list-only? (print-scenario-list)]
+    [else
+     (with-handlers ([exn:fail? (lambda (e)
+                                  (eprintf "tmux-tui-explore: ~a~n" (exn-message e))
+                                  (exit 2))])
+       (define mode (parse-mode mode-str))
+       (define root (or out-dir (make-explore-root)))
+       (define results
+         (run-exploration #:mode mode #:filter filter-tag #:out root #:append-log append-log))
+       (print-summary results root))]))

--- a/tests/test-tmux-tui-explore.rkt
+++ b/tests/test-tmux-tui-explore.rkt
@@ -1,0 +1,99 @@
+#lang racket/base
+
+;; @speed fast
+;; @suite default
+
+(require json
+         rackunit
+         racket/file
+         racket/list
+         racket/port
+         racket/string
+         "../scripts/tmux-tui-explore.rkt")
+
+(define (with-temp-dir proc)
+  (define dir (make-temporary-file "q-tmux-explore-test-~a" 'directory))
+  (dynamic-wind void
+                (lambda () (proc dir))
+                (lambda ()
+                  (with-handlers ([exn:fail? (lambda (_e) (void))])
+                    (delete-directory/files dir)))))
+
+(define (scenario-tags)
+  (map explore-scenario-tag scenario-registry))
+
+(test-case "scenario registry contains required v0.99.44 exploration scenarios"
+  (check-equal? (scenario-tags) '("memory" "gsd" "mas" "tools" "release-audit" "durable-memory"))
+  (check-equal? (length (find-scenarios #:filter "memory")) 1)
+  (check-equal? (find-scenarios #:filter "missing") '()))
+
+(test-case "scenario list renders tags and descriptions"
+  (define rendered (with-output-to-string (lambda () (print-scenario-list))))
+  (check-true (string-contains? rendered "memory"))
+  (check-true (string-contains? rendered "release-audit"))
+  (check-true (string-contains? rendered "durable-memory")))
+
+(test-case "real-provider authorization requires all explicit gates"
+  (parameterize ([current-environment-variables
+                  (environment-variables-copy (current-environment-variables))])
+    (putenv "Q_TMUX_TUI_TESTS" "1")
+    (putenv "Q_TMUX_TUI_REAL_PROVIDER" "1")
+    (putenv "Q_TMUX_TUI_REAL_PROVIDER_CONFIRM" "NOPE")
+    (check-false (real-provider-authorized?))
+    (check-exn #rx"real-provider mode requires" require-real-provider-authorization!)
+    (putenv "Q_TMUX_TUI_REAL_PROVIDER_CONFIRM" "I_UNDERSTAND_COSTS")
+    (check-true (real-provider-authorized?))
+    (check-not-exn require-real-provider-authorization!)))
+
+(test-case "redaction removes credential-like values"
+  (define raw "api_key=abc123 token=xyz password=hunter2 Authorization: Bearer secret sk-testSECRET")
+  (define redacted (redact-explore-text raw))
+  (check-false (string-contains? redacted "abc123"))
+  (check-false (string-contains? redacted "hunter2"))
+  (check-false (string-contains? redacted "sk-testSECRET"))
+  (check-true (string-contains? redacted "<REDACTED>")))
+
+(test-case "mock exploration writes markdown and summary files"
+  (with-temp-dir (lambda (dir)
+                   (define results
+                     (run-exploration #:mode 'mock #:filter "tools" #:out (path->string dir)))
+                   (check-equal? (length results) 1)
+                   (define result (car results))
+                   (check-equal? (explore-result-tag result) "tools")
+                   (check-equal? (explore-result-status result) 'pass-mock-tui)
+                   (check-equal? (explore-result-classification result) 'pass)
+                   (check-true (file-exists? (explore-result-report-path result)))
+                   (check-true (file-exists? (build-path dir "summary.tsv")))
+                   (check-true (file-exists? (build-path dir "summary.json")))
+                   (define md (file->string (explore-result-report-path result)))
+                   (check-true (string-contains? md "README_FIXTURE_ALPHA"))
+                   (check-true (string-contains? md "credential-like values are redacted"))
+                   (define rows (call-with-input-file (build-path dir "summary.json") read-json))
+                   (check-equal? (length rows) 1)
+                   (check-equal? (hash-ref (car rows) 'tag) "tools"))))
+
+(test-case "mock exploration can append central markdown log"
+  (with-temp-dir (lambda (dir)
+                   (define log-path (build-path dir "TMUX-Q-TUI-EXPLORATION-LOG.md"))
+                   (define results
+                     (run-exploration #:mode 'mock
+                                      #:filter "release-audit"
+                                      #:out (path->string dir)
+                                      #:append-log (path->string log-path)))
+                   (check-equal? (length results) 1)
+                   (define log-text (file->string log-path))
+                   (check-true (string-contains? log-text "Explorer run"))
+                   (check-true (string-contains? log-text "release-audit"))
+                   (check-true (string-contains? log-text "pass-mock-tui-partial")))))
+
+(test-case "real exploration refuses without explicit gates before writing reports"
+  (with-temp-dir
+   (lambda (dir)
+     (parameterize ([current-environment-variables
+                     (environment-variables-copy (current-environment-variables))])
+       (putenv "Q_TMUX_TUI_TESTS" "1")
+       (putenv "Q_TMUX_TUI_REAL_PROVIDER" "0")
+       (check-exn #rx"real-provider mode requires"
+                  (lambda ()
+                    (run-exploration #:mode 'real #:filter "memory" #:out (path->string dir))))
+       (check-false (file-exists? (build-path dir "summary.tsv")))))))


### PR DESCRIPTION
## Summary
- Adds official `scripts/tmux-tui-explore.rkt` with scenario registry for memory, GSD, MAS, tools, release-audit, and durable-memory.
- Supports `--list`, `--mode mock|real`, `--filter`, `--out`, and `--append-log`.
- Enforces explicit real-provider gates before real mode can run.
- Writes markdown reports plus `summary.tsv` and `summary.json`.
- Adds redaction of credential-like values and focused unit tests.

## Validation
- `raco test tests/test-tmux-tui-explore.rkt` => PASS, 7 tests
- `racket scripts/tmux-tui-explore.rkt --list` => PASS
- `Q_TMUX_TUI_TESTS=1 racket scripts/tmux-tui-explore.rkt --mode mock --filter memory --out <tmp>` => PASS
- `racket scripts/tmux-tui-explore.rkt --mode real --filter memory` without gates => exits 2/refuses
- `racket scripts/lint-all.rkt` => PASS, 22 passed, 1 non-blocking release-readiness warning
- `racket scripts/run-tests.rkt --suite fast` => PASS, 994/994 files, 14177/14177 tests
- `builder_verify_wave` format/make => PASS

Closes #8615