### PR TITLE
release(v0.99.47): version bump + CHANGELOG (#8687)

### DIFF
--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.99.46 -->
+<!-- verified-against: 0.99.47 -->
 # Architecture Overview
 
 ## Native TUI Stack

--- a/docs/distributed-execution-guide.md
+++ b/docs/distributed-execution-guide.md
@@ -1,7 +1,7 @@
-<!-- verified-against: 0.99.46 -->
+<!-- verified-against: 0.99.47 -->
 # Distributed Execution Guide
 
-This guide covers q's **opt-in** distributed execution feature (verified against v0.99.46, originally introduced for MAS Schritt 6 Phase 2). High-risk tool execution can be routed to a remote executor node over mTLS-secured TCP, isolating hostile code from the developer machine.
+This guide covers q's **opt-in** distributed execution feature (verified against v0.99.47, originally introduced for MAS Schritt 6 Phase 2). High-risk tool execution can be routed to a remote executor node over mTLS-secured TCP, isolating hostile code from the developer machine.
 
 > **Default is local-only.** No configuration changes are needed for local development. The broker is strictly opt-in behind `mas.broker.enabled = false`.
 

--- a/docs/event-taxonomy.md
+++ b/docs/event-taxonomy.md
@@ -1,7 +1,7 @@
-<!-- verified-against: 0.99.46 -->
+<!-- verified-against: 0.99.47 -->
 # Q Event Taxonomy Reference
 
-Complete reference for all event types in q 0.99.46.
+Complete reference for all event types in q 0.99.47.
 ## Base Types
 
 ### `event` (protocol-level)

--- a/docs/extension-guide.md
+++ b/docs/extension-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.99.46 --># Extension Development Guide
+<!-- verified-against: 0.99.47 --># Extension Development Guide
 
 This guide walks you through creating, testing, and activating a custom
 extension for q.

--- a/docs/getting-started/credentials.md
+++ b/docs/getting-started/credentials.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.99.46 -->
+<!-- verified-against: 0.99.47 -->
 # Credential Management
 
 This document describes how q manages API keys and provider credentials,

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.99.46 --># Getting Started
+<!-- verified-against: 0.99.47 --># Getting Started
 
 Welcome to q, a Racket-based coding agent.
 

--- a/docs/gsd-process-governance.md
+++ b/docs/gsd-process-governance.md
@@ -2,10 +2,10 @@
 
 **Status:** Active — enforced via `scripts/milestone-close-gate.rkt`  
 **Scope:** All q-agent milestones, waves, and releases  
-**Established:** v0.99.46 (2026-07-09)
+**Established:** v0.99.47 (2026-07-09)
 
 This document codifies the process rules discovered through GSD audit failures
-(v0.99.46 premature close, v0.99.46 claim inflation). Each rule exists because
+(v0.99.47 premature close, v0.99.47 claim inflation). Each rule exists because
 a prior milestone violated it and required a remediation cycle.
 
 ---
@@ -73,7 +73,7 @@ wave's STATE or PR body have corresponding GitHub issues. If a wave
 documented findings but no issues exist, the wave must NOT be closed
 until issues are filed.
 
-Example of the v0.99.46 failure: the wave documented 1 medium + 6 low
+Example of the v0.99.47 failure: the wave documented 1 medium + 6 low
 findings but filed zero issues. This should have blocked closure.
 
 ---
@@ -104,7 +104,7 @@ This is a **HARD GATE** — no exceptions, no manual overrides. The script
 exits with code 1 if any gate fails. The milestone must NOT be closed
 until the script exits 0.
 
-Example of the v0.99.46 failure: W11 was closed with CI RED and no
+Example of the v0.99.47 failure: W11 was closed with CI RED and no
 release assets. The close gate would have caught both.
 
 ---
@@ -143,8 +143,8 @@ is a process violation. The milestone-close-gate checks that the
 HANDOFF.json version matches the current canonical version before
 allowing milestone closure.
 
-Example of the v0.99.46 failure: HANDOFF.json referenced v0.99.46 while
-the project was at v0.99.46 — 47 versions stale.
+Example of the v0.99.47 failure: HANDOFF.json referenced v0.99.47 while
+the project was at v0.99.47 — 47 versions stale.
 
 ---
 
@@ -191,7 +191,7 @@ The CI gate test (`tests/test-arch-fitness.rkt`) fails when boundary
 exception dates expire. Extending dates without scheduling resolution
 work defers the problem but does not solve it.
 
-Example of the v0.99.46/46 failure: 13 boundary exceptions had
+Example of the v0.99.47/46 failure: 13 boundary exceptions had
 `revisit-by 2026-07-01` which expired, causing CI RED. The dates were
 extended to 2026-10-01, but no resolution milestone was scheduled.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.99.46 --># Installation Guide
+<!-- verified-against: 0.99.47 --># Installation Guide
 
 <!-- This file is the canonical source. The docs/getting-started/installation.md copy is maintained for the doc site build. -->
 

--- a/docs/mcp-capability-security.md
+++ b/docs/mcp-capability-security.md
@@ -1,13 +1,13 @@
-<!-- verified-against: 0.99.46 -->
+<!-- verified-against: 0.99.47 -->
 # MCP and Capability-Token Security Notes
 
 This document describes the security state for MAS Schritt 6 Phases 1 and 2.
 
-> **Phase 2 (v0.99.46) update:** Remote execution via mTLS TCP broker is now available. See [Distributed Execution Guide](distributed-execution-guide.md) and [mTLS Security Model](security-mtls.md) for details.
+> **Phase 2 (v0.99.47) update:** Remote execution via mTLS TCP broker is now available. See [Distributed Execution Guide](distributed-execution-guide.md) and [mTLS Security Model](security-mtls.md) for details.
 
 ## Scope
 
-v0.99.46 preserves the existing Phase 1 MCP/capability-token hardening. It does **not** introduce a new network broker, mTLS channel, or remote executor beyond the existing opt-in distributed execution support.
+v0.99.47 preserves the existing Phase 1 MCP/capability-token hardening. It does **not** introduce a new network broker, mTLS channel, or remote executor beyond the existing opt-in distributed execution support.
 
 Phase 1 provides:
 
@@ -24,7 +24,7 @@ Phase 1 does **not** provide:
 - ~~mTLS or cross-host authentication.~~ **→ Phase 2 provides full mTLS with mutual certificate verification.**
 - ~~Remote route execution.~~ **→ Phase 2 routes high/critical risk requests to the remote executor via mTLS.**
 
-> **v0.99.46 status:** The `remote-tagged-but-executed-local` annotation remains removed. Risk-based routing dispatches `'remote` decisions to the actual remote executor when `mas.broker.enabled = true`. When the broker is disabled (default), risk-based routing falls back to local execution with a clear warning.
+> **v0.99.47 status:** The `remote-tagged-but-executed-local` annotation remains removed. Risk-based routing dispatches `'remote` decisions to the actual remote executor when `mas.broker.enabled = true`. When the broker is disabled (default), risk-based routing falls back to local execution with a clear warning.
 
 ## Feature gates
 
@@ -67,7 +67,7 @@ The default event sink is a no-op. Integrations can parameterize `current-mcp-ev
 
 ## Capability-token API
 
-Capability tokens are HMAC-authenticated strings with strict parsing. v0.99.46 preserves the legacy API while retaining claim-aware validation.
+Capability tokens are HMAC-authenticated strings with strict parsing. v0.99.47 preserves the legacy API while retaining claim-aware validation.
 
 Primary APIs:
 

--- a/docs/security-mtls.md
+++ b/docs/security-mtls.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.99.46 -->
+<!-- verified-against: 0.99.47 -->
 # Security Model: Mutual TLS (mTLS) for Distributed Execution
 
 This document describes the security architecture of q's Phase 2 distributed execution feature (v0.99.29). It covers the trust model, threat model, defense-in-depth layers, and key rotation procedures.

--- a/docs/security-trust-model.md
+++ b/docs/security-trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.99.46 --># Security & Trust Model
+<!-- verified-against: 0.99.47 --># Security & Trust Model
 
 This document provides an honest, per-area assessment of what q enforces
 today and what is planned. It is the authoritative reference for security

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.99.46 -->
+<!-- verified-against: 0.99.47 -->
 # Self-Hosting Guide
 
 q is a self-hosting agent: it uses its own GSD (Get Stuff Done) planning workflow
@@ -131,6 +131,6 @@ is the primary self-hosting extension:
 (load-extension! ext-reg "path/to/extension.rkt" #:event-bus bus)
 ```
 
-## Version 0.99.46
+## Version 0.99.47
 
-This documentation reflects q 0.99.46.
+This documentation reflects q 0.99.47.

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.99.46 --># q Source Style Guide
+<!-- verified-against: 0.99.47 --># q Source Style Guide
 
 This document defines formatting and naming conventions for the q Racket codebase.
 All changes to `q/` source files (excluding `tests/`) should follow these rules.

--- a/docs/system-overview.md
+++ b/docs/system-overview.md
@@ -1,6 +1,6 @@
 # q Coding Agent — System Overview
 
-> **Version 0.99.46** · Racket · MIT License
+> **Version 0.99.47** · Racket · MIT License
 > The definitive reference for developers who want to understand, extend, or contribute to q.
 
 ---
@@ -485,7 +485,7 @@ bin/q init                          # Guided setup wizard
 
 | Metric | Value |
 |--------|-------|
-| Version | 0.99.46 |
+| Version | 0.99.47 |
 | Language | Racket |
 | License | MIT |
 | Source modules | 495 |

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.99.46 -->
+<!-- verified-against: 0.99.47 -->
 # Trust Model
 
 ## Trust Levels

--- a/docs/workflow-testing.md
+++ b/docs/workflow-testing.md
@@ -1,4 +1,4 @@
-<!-- verified-against: 0.99.46 -->
+<!-- verified-against: 0.99.47 -->
 # Workflow Testing Guide
 
 This guide covers q's workflow-level integration tests that verify
@@ -122,6 +122,6 @@ Use relative paths from the test file:
 4. Use `(check-true ...)` for boolean assertions
 5. Keep tests independent — no shared mutable state between test-cases
 
-## Version 0.99.46
+## Version 0.99.47
 
-This documentation reflects q 0.99.46.
+This documentation reflects q 0.99.47.

--- a/tests/test-version.rkt
+++ b/tests/test-version.rkt
@@ -15,8 +15,8 @@
     (test-case "version: q-version is a string"
       (check-true (string? q-version)))
 
-    (test-case "q-version is 0.99.46 for v0.99.46 release"
-      (check-equal? q-version "0.99.46"))
+    (test-case "q-version is 0.99.47 for v0.99.47 release"
+      (check-equal? q-version "0.99.47"))
 
     (test-case "q-version matches semver pattern"
       (check-true (regexp-match? #rx"^[0-9]+\\.[0-9]+\\.[0-9]+" q-version)))

--- a/util/version.rkt
+++ b/util/version.rkt
@@ -11,4 +11,4 @@
 
 (provide (contract-out [q-version string?]))
 
-(define q-version "0.99.46")
+(define q-version "0.99.47")

--- a/wiki-src/Architecture-Overview.md
+++ b/wiki-src/Architecture-Overview.md
@@ -35,7 +35,7 @@ User input → Interface (CLI/TUI/RPC)
     → Events emitted to bus
 ```
 
-## Metrics (0.99.46)
+## Metrics (0.99.47)
 > _See `racket scripts/metrics.rkt` for current numbers._
 
 - 414 source modules, 534 test files


### PR DESCRIPTION
## W5: Version bump + release (v0.99.47)

Final wave of v0.99.47 — GSD Process Gap Remediation.

## Changes
- Version bump 0.99.46 → 0.99.47 (38 refs synced)
- CHANGELOG.md entry for v0.99.47
- test-version.rkt updated for new version

## v0.99.47 Deliverables Summary
| Wave | Gap | Deliverable |
|------|-----|-------------|
| W0 | GAP-2,3,5 | docs/gsd-process-governance.md |
| W1 | GAP-1 | scripts/claim-verifier.rkt |
| W2 | GAP-4 | scripts/milestone-close-gate.rkt |
| W3 | GAP-6 | cleanup-tmux-env! + report fix |
| W4 | GAP-7 | Milestone #835 with 13 arch issues |
| W5 | — | Version bump + release |

## Verify
- [x] `rm -rf compiled/ && raco make main.rkt` → PASS
- [x] `racket scripts/run-tests.rkt --suite smoke --profile local` → 19/19 files, 287/287 tests PASS
- [x] `racket scripts/lint-version.rkt` → PASS (0 errors)

Closes #8687