### PR TITLE
refactor(arch): contain package and catalog extension dependencies (#8701 #8702)

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,8 +296,8 @@ q/
 |--------|-------|
 | Test files | 1145 |
 | Source modules | 707 |
-| Source lines | 113598 |
-| Test lines | 191582 |
+| Source lines | 113620 |
+| Test lines | 191584 |
 | Test assertions | 30278 |
 | Tests passing | 5835+ | `racket scripts/run-tests.rkt` results |
 

--- a/docs/architecture/dependency-policy.rktd
+++ b/docs/architecture/dependency-policy.rktd
@@ -50,12 +50,6 @@
      (permanent-waiver . #t)
      (waiver-justification
       . "The adapter is the intentional composition boundary that contains all runtime-to-tool and runtime-to-extension wiring; removing it would spread forbidden imports across runtime consumers."))
-    (package.rkt (rationale . "package audit reads extension manifests")
-                 (owner . "extensions")
-                 (revisit-by . "2026-08-01"))
-    (extension-catalog.rkt (rationale . "extension loading/discovery")
-                           (owner . "extensions")
-                           (revisit-by . "2026-08-01"))
     (session/session-switch.rkt
      (rationale . "dynamic-require to extensions for lazy loading (avoids circular dependency)")
      (owner . "runtime")

--- a/runtime/extension-catalog.rkt
+++ b/runtime/extension-catalog.rkt
@@ -17,8 +17,7 @@
          racket/file
          racket/path
          json
-         "../extensions/api.rkt"
-         (only-in "../extensions/loader.rkt" get-extension-name-from-path))
+         "layer-adapters.rkt")
 (require (only-in "../util/error/error-helpers.rkt" with-safe-fallback))
 (require "../util/config-paths.rkt")
 

--- a/runtime/layer-adapters.rkt
+++ b/runtime/layer-adapters.rkt
@@ -21,6 +21,8 @@
 ;; Re-exported from extensions/:
 ;;   - dispatch-hooks (context assembly hook dispatch)
 ;;   - make-extension-ctx (extension context factory)
+;;   - manifest operations (package management adapter)
+;;   - catalog metadata operations (extension discovery adapter)
 
 (require racket/contract
          (only-in "../tools/tool.rkt"
@@ -34,7 +36,19 @@
          (only-in "../tools/scheduler.rkt" run-tool-batch scheduler-result scheduler-result-results)
          (only-in "../extensions/hooks.rkt" dispatch-hooks)
          (only-in "../extensions/context.rkt" make-extension-ctx)
-         (only-in "../extensions/api.rkt" extension-registry? list-extensions)
+         (only-in "../extensions/api.rkt"
+                  extension-registry?
+                  list-extensions
+                  extension-name
+                  extension-version)
+         (only-in "../extensions/loader.rkt" get-extension-name-from-path)
+         (only-in "../extensions/manifest.rkt"
+                  read-qpm-manifest
+                  validate-manifest
+                  compute-manifest-checksum
+                  qpm-manifest-name
+                  qpm-manifest-checksum
+                  qpm-manifest-files)
          (only-in "../extensions/gsd/session-state.rkt" current-gsd-ctx gsd-session-ctx?))
 
 ;; Tool schema assembly
@@ -62,4 +76,13 @@
          make-default-permission-config
          ;; GSD session context
          current-gsd-ctx
-         gsd-session-ctx?)
+         gsd-session-ctx?
+         extension-name
+         extension-version
+         get-extension-name-from-path
+         read-qpm-manifest
+         validate-manifest
+         compute-manifest-checksum
+         qpm-manifest-name
+         qpm-manifest-checksum
+         qpm-manifest-files)

--- a/runtime/package.rkt
+++ b/runtime/package.rkt
@@ -14,7 +14,7 @@
          racket/port
          racket/string
          racket/path
-         "../extensions/manifest.rkt")
+         "layer-adapters.rkt")
 (require (only-in "../util/error/error-helpers.rkt" with-safe-fallback))
 (require "../util/config-paths.rkt")
 

--- a/tests/test-arch-boundaries.rkt
+++ b/tests/test-arch-boundaries.rkt
@@ -126,6 +126,8 @@
           (runtime "turn-orchestrator.rkt" ("../tools/" "../extensions/"))
           (runtime "session/session-config.rkt" ("../../tools/" "../../extensions/"))
           (runtime "goal/goal-checks.rkt" ("../../tools/" "../../extensions/"))
+          (runtime "package.rkt" ("../tools/" "../extensions/"))
+          (runtime "extension-catalog.rkt" ("../tools/" "../extensions/"))
           (agent "iteration/loop-state.rkt" ("../../llm/"))))
       (for ([item (in-list retired)])
         (define layer (car item))

--- a/tests/test-arch-fitness.rkt
+++ b/tests/test-arch-fitness.rkt
@@ -112,11 +112,11 @@
         "Runtime boundary exceptions (~a) exceed policy maximum (~a). Update dependency-policy.rktd or refactor."
         (length runtime-exceptions)
         max-runtime-exc))
-      ;; At least 3 of the known exceptions should still be importing
-      (check-true
-       (>= (length still-importing) 3)
-       (format "Too few known exceptions still importing from tools/extensions: ~a (expected >= 3)"
-               still-importing))
+      ;; Only the intentional adapter facade may retain static upward imports.
+      ;; Other exceptions (for example, lazy dynamic loading) must not expand this list.
+      (check-equal? still-importing
+                    '("layer-adapters.rkt")
+                    (format "Unexpected runtime static upward imports: ~a" still-importing))
       (check-true (<= (length still-importing) max-runtime-exc)
                   (format "More than ~a runtime files importing from tools/extensions: ~a"
                           max-runtime-exc


### PR DESCRIPTION
## Summary
- route package manifest operations through the intentional `runtime/layer-adapters.rkt` composition boundary
- route extension catalog metadata/name operations through the same contained adapter
- remove direct boundary exceptions for `runtime/package.rkt` and `runtime/extension-catalog.rkt`
- pin both retired modules and assert that only `layer-adapters.rkt` retains static upward runtime imports

## Verification
- red-first architecture test failed while both exceptions/direct imports remained
- package/catalog/layer-adapter tests: 44 PASS
- architecture boundaries: 6 PASS
- architecture fitness: 57 PASS
- dependency completeness: PASS
- lint: 22 PASS, 1 non-blocking release-readiness warning
- fast suite: 1010/1010 files, 15013/15013 tests PASS
- reviewer: APPROVED

Closes #8701
Closes #8702