### PR TITLE
feat(v0.99.50 W0): sessions CLI, semantic resume, useful history (#8715)

### DIFF
--- a/interfaces/sessions.rkt
+++ b/interfaces/sessions.rkt
@@ -73,7 +73,7 @@
                         (->* (path-string? string?)
                              (#:confirm? boolean? #:in input-port? #:out output-port?)
                              (or/c 'ok 'not-found 'cancelled))]
-                       [run-sessions-command (-> hash? void?)]
+                       [run-sessions-command (-> cli-config? void?)]
                        [scan-session-dirs (-> path-string? (listof list?))]
                        [read-session-metadata (-> string? (or/c path-string? #f) (or/c hash? #f))]
                        [read-trace-entries (-> path-string? (listof any/c))]

--- a/tests/test-tui-history-command.rkt
+++ b/tests/test-tui-history-command.rkt
@@ -1,0 +1,79 @@
+#lang racket/base
+
+;; @speed fast
+;; @suite default
+
+;; tests/test-tui-history-command.rkt
+;; W0 (#8715): Tests for /history command improvements (V9949-TMUX-05).
+
+(require rackunit
+         racket/string
+         (only-in "../util/message/message.rkt"
+                  message
+                  message-id
+                  message-role
+                  message-content
+                  message-timestamp
+                  message-meta)
+         (only-in "../util/content/content-parts.rkt" text-part)
+         "../tui/commands/session.rkt")
+
+;; ---------------------------------------------------------------------------
+;; pad2
+;; ---------------------------------------------------------------------------
+
+(test-case "pad2 zero-pads single digit"
+  (check-equal? (pad2 5) "05"))
+
+(test-case "pad2 does not pad double digit"
+  (check-equal? (pad2 12) "12"))
+
+(test-case "pad2 handles zero"
+  (check-equal? (pad2 0) "00"))
+
+;; ---------------------------------------------------------------------------
+;; format-ts
+;; ---------------------------------------------------------------------------
+
+(test-case "format-ts formats valid timestamp"
+  (define result (format-ts 1689300000))
+  (check-true (regexp-match? #rx"^[0-9][0-9]:[0-9][0-9]:[0-9][0-9]$" result)
+              (format "result: ~a" result)))
+
+(test-case "format-ts returns placeholder for zero"
+  (check-equal? (format-ts 0) "--:--:--"))
+
+(test-case "format-ts returns placeholder for #f"
+  (check-equal? (format-ts #f) "--:--:--"))
+
+;; ---------------------------------------------------------------------------
+;; message-excerpt
+;; ---------------------------------------------------------------------------
+
+(test-case "message-excerpt extracts text from message"
+  (define msg (message "m1" #f 'user 'text (list (text-part "text" "Hello world")) 0 (hash)))
+  (define excerpt (message-excerpt msg))
+  (check-true (string-contains? excerpt "Hello world")))
+
+(test-case "message-excerpt truncates long text"
+  (define long-text (make-string 100 #\x))
+  (define msg (message "m2" #f 'user 'text (list (text-part "text" long-text)) 0 (hash)))
+  (define excerpt (message-excerpt msg))
+  (check-true (< (string-length excerpt) 70))
+  (check-true (string-suffix? excerpt "...")))
+
+(test-case "message-excerpt handles empty content"
+  (define msg (message "m3" #f 'user 'text '() 0 (hash)))
+  (define excerpt (message-excerpt msg))
+  (check-equal? excerpt "(non-text)"))
+
+(test-case "message-excerpt collapses whitespace"
+  (define msg (message "m4" #f 'user 'text (list (text-part "text" "  hello   world  ")) 0 (hash)))
+  (define excerpt (message-excerpt msg))
+  (check-false (string-contains? excerpt "  "))
+  (check-true (string-contains? excerpt "hello world")))
+
+(test-case "message-excerpt respects custom max-len"
+  (define msg (message "m5" #f 'user 'text (list (text-part "text" "abcdefghij")) 0 (hash)))
+  (define excerpt (message-excerpt msg 5))
+  (check-true (string-suffix? excerpt "...")))

--- a/tui/commands/session.rkt
+++ b/tui/commands/session.rkt
@@ -9,7 +9,13 @@
          racket/list
          "../state.rkt"
          (only-in "../../util/event/event.rkt" make-event)
-         (only-in "../../util/message/message.rkt" message-role)
+         (only-in "../../util/message/message.rkt"
+                  message-role
+                  message-id
+                  message-content
+                  message-timestamp
+                  message-meta)
+         (only-in "../../util/content/content-parts.rkt" text-part? text-part-text)
          "../../util/event/event-bus.rkt"
          "../../runtime/session-index.rkt"
          "../../interfaces/sessions.rkt"
@@ -19,11 +25,47 @@
 (provide handle-history-command
          handle-fork-command
          handle-name-command
-         handle-sessions-tui-command)
+         handle-sessions-tui-command
+         message-excerpt
+         format-ts
+         pad2)
 
 ;; ============================================================
 ;; /history command handler
 ;; ============================================================
+
+;; Extract a bounded excerpt from message content parts.
+(define (message-excerpt msg [max-len 60])
+  (define parts (message-content msg))
+  (define text
+    (string-join (for/list ([p (in-list parts)]
+                            #:when (text-part? p))
+                   (text-part-text p))
+                 " "))
+  (define cleaned (string-normalize-spaces (string-trim text)))
+  (if (> (string-length cleaned) max-len)
+      (string-append (substring cleaned 0 max-len) "...")
+      (if (string=? cleaned "") "(non-text)" cleaned)))
+
+;; Format a timestamp (epoch seconds) to HH:MM:SS.
+(define (pad2 n)
+  (define s
+    (if (number? n)
+        (number->string n)
+        (format "~a" n)))
+  (if (< (string-length s) 2)
+      (string-append "0" s)
+      s))
+
+(define (format-ts ts)
+  (if (and (number? ts) (> ts 0))
+      (let* ([secs (inexact->exact (truncate ts))]
+             [date (seconds->date secs #f)])
+        (format "~a:~a:~a"
+                (pad2 (date-hour date))
+                (pad2 (date-minute date))
+                (pad2 (date-second date))))
+      "--:--:--"))
 
 (define (handle-history-command cctx)
   (define state (unbox (cmd-ctx-state-box cctx)))
@@ -42,8 +84,22 @@
          (let ()
            (define header (make-entry 'system "Session history:" 0 (hash)))
            (define entries-out
-             (for/list ([msg (in-vector entries)])
-               (make-entry 'system (format "  [~a]" (message-role msg)) 0 (hash))))
+             (for/list ([msg (in-vector entries)]
+                        [i (in-naturals)])
+               (define role (message-role msg))
+               (define mid (or (message-id msg) "—"))
+               (define ts (message-timestamp msg))
+               (define meta (message-meta msg))
+               (define tool-name (and (hash? meta) (hash-ref meta 'tool-name #f)))
+               (define label
+                 (if tool-name
+                     (format "~a/~a" role tool-name)
+                     (symbol->string role)))
+               (make-entry
+                'system
+                (format "  [~a] ~a ~a [~a] ~a" i (format-ts ts) mid label (message-excerpt msg))
+                0
+                (hash))))
            (define all-entries (cons header entries-out))
            (define new-state
              (for/fold ([s state]) ([e (in-list all-entries)])

--- a/tui/tui-init.rkt
+++ b/tui/tui-init.rkt
@@ -124,9 +124,14 @@
 
 (define (create-tui-session rt-config cli-cfg)
   ;; Create agent session and TUI context from runtime config.
+  ;; If rt-config has a 'session-id, resume that session instead of creating new.
   ;; Returns (values ctx sess scrollback-path)
   (define bus (dict-ref rt-config 'event-bus #f))
-  (define sess (make-agent-session rt-config))
+  (define maybe-sid (dict-ref rt-config 'session-id #f))
+  (define sess
+    (if maybe-sid
+        (resume-agent-session maybe-sid rt-config)
+        (make-agent-session rt-config)))
 
   ;; Wire custom keybindings path if specified
   (define kb-path (and (cli-config? cli-cfg) (cli-config-keybindings-path cli-cfg)))


### PR DESCRIPTION
## W0: Session commands, semantic resume, and useful history

Addresses V9949-TMUX-01, V9949-TMUX-02, V9949-TMUX-05.

## Changes
- **sessions CLI contract**: Fixed `run-sessions-command` contract from `hash?` to `cli-config?`
- **TUI resume**: `create-tui-session` now calls `resume-agent-session` when a session-id is present instead of always creating a fresh session
- **/history**: Now shows `[row-index] HH:MM:SS message-id [role/tool-name] excerpt` instead of just `[role]`

## Verify
- [x] `raco test tests/test-tui-history-command.rkt` → 11 pass
- [x] `rm -rf compiled/ && raco make main.rkt` → PASS
- [x] `racket scripts/run-tests.rkt --suite smoke --profile local` → 19/19 files, 287/287 tests PASS

Closes #8715