### PR TITLE
feat(v0.99.50 W1): canonical subagent result transport (#8716)

### DIFF
--- a/tests/test-spawn-subagent-helpers-terminal.rkt
+++ b/tests/test-spawn-subagent-helpers-terminal.rkt
@@ -1,0 +1,82 @@
+#lang racket/base
+
+;; @speed fast
+;; @suite default
+
+;; tests/test-spawn-subagent-helpers-terminal.rkt
+;; W1 (TMUX-04): Pure unit tests for typed terminal outcome helpers.
+
+(require rackunit
+         "../tools/builtins/spawn-subagent-helpers.rkt")
+
+;; ============================================================
+;; classify-terminal-status
+;; ============================================================
+
+(test-case "complete + content → completed"
+  (check-equal? (classify-terminal-status 'complete #t) 'completed))
+
+(test-case "complete + no content → approved-empty"
+  (check-equal? (classify-terminal-status 'complete #f) 'approved-empty))
+
+(test-case "max-turns-reached → timed-out"
+  (check-equal? (classify-terminal-status 'max-turns-reached #t) 'timed-out)
+  (check-equal? (classify-terminal-status 'max-turns-reached #f) 'timed-out))
+
+(test-case "cancelled → cancelled"
+  (check-equal? (classify-terminal-status 'cancelled #t) 'cancelled))
+
+(test-case "unknown status → failed"
+  (check-equal? (classify-terminal-status 'something-weird #t) 'failed)
+  (check-equal? (classify-terminal-status 'something-weird #f) 'failed))
+
+;; ============================================================
+;; result-has-content?
+;; ============================================================
+
+(test-case "result-has-content? true for non-empty"
+  (check-true (result-has-content? "hello"))
+  (check-true (result-has-content? "  x  ")))
+
+(test-case "result-has-content? false for empty/whitespace"
+  (check-false (result-has-content? ""))
+  (check-false (result-has-content? "   "))
+  (check-false (result-has-content? "\t\n")))
+
+(test-case "result-has-content? false for non-string"
+  (check-false (result-has-content? #f))
+  (check-false (result-has-content? '())))
+
+;; ============================================================
+;; make-safe-result-metadata
+;; ============================================================
+
+(test-case "make-safe-result-metadata produces all fields"
+  (define meta (make-safe-result-metadata "hello world" "sess-123" 'completed))
+  (check-equal? (hash-ref meta 'result-present?) #t)
+  (check-equal? (hash-ref meta 'content-size) 11)
+  (check-true (string? (hash-ref meta 'content-digest)))
+  (check-equal? (hash-ref meta 'session-id) "sess-123")
+  (check-equal? (hash-ref meta 'terminal-status) "completed"))
+
+(test-case "make-safe-result-metadata handles empty text"
+  (define meta (make-safe-result-metadata "" "sess-456" 'approved-empty))
+  (check-equal? (hash-ref meta 'result-present?) #f)
+  (check-equal? (hash-ref meta 'content-size) 0)
+  (check-equal? (hash-ref meta 'terminal-status) "approved-empty"))
+
+(test-case "make-safe-result-metadata handles #f text"
+  (define meta (make-safe-result-metadata #f #f 'failed))
+  (check-equal? (hash-ref meta 'result-present?) #f)
+  (check-equal? (hash-ref meta 'content-size) 0)
+  (check-equal? (hash-ref meta 'session-id) ""))
+
+(test-case "make-safe-result-metadata digest is deterministic"
+  (define meta1 (make-safe-result-metadata "same text" "s1" 'completed))
+  (define meta2 (make-safe-result-metadata "same text" "s2" 'completed))
+  (check-equal? (hash-ref meta1 'content-digest) (hash-ref meta2 'content-digest)))
+
+(test-case "make-safe-result-metadata digest differs for different text"
+  (define meta1 (make-safe-result-metadata "text A" "s1" 'completed))
+  (define meta2 (make-safe-result-metadata "text B" "s1" 'completed))
+  (check-false (equal? (hash-ref meta1 'content-digest) (hash-ref meta2 'content-digest))))

--- a/tests/test-spawn-subagent-terminal-outcomes.rkt
+++ b/tests/test-spawn-subagent-terminal-outcomes.rkt
@@ -1,0 +1,218 @@
+#lang racket
+
+;; @speed fast
+;; @suite default
+
+;; tests/test-spawn-subagent-terminal-outcomes.rkt
+;; W1 (TMUX-04): Typed terminal outcomes, provider request two, safe metadata.
+;;
+;; Verifies:
+;; 1. Provider request two contains canonical tool-call + matching tool-result.
+;; 2. Unique child sentinel reaches spawn result.
+;; 3. Typed terminal outcomes (completed, approved-empty, timed-out).
+;; 4. Safe result metadata (digest, size, session-id, terminal-status).
+;; 5. No <unsupported:...> or #hasheq garbage in result text.
+
+(require rackunit
+         rackunit/text-ui
+         json
+         racket/generator
+         "../tools/builtins/spawn-subagent.rkt"
+         "../tools/tool.rkt"
+         "../llm/provider.rkt"
+         "../llm/model.rkt"
+         "../llm/openai-compatible.rkt"
+         "../runtime/settings.rkt")
+
+;; ============================================================
+;; Request-capturing provider
+;; ============================================================
+
+;; Captures every request sent to the provider so tests can inspect request two.
+(define (make-request-capturing-provider responses)
+  (define captured-requests (box '()))
+  (define idx (box 0))
+  (define (send-handler req)
+    (set-box! captured-requests (append (unbox captured-requests) (list req)))
+    (define i (unbox idx))
+    (set-box! idx (add1 i))
+    (if (< i (length responses))
+        (list-ref responses i)
+        (make-model-response (list (hasheq 'type "text" 'text "done"))
+                             (hasheq 'prompt-tokens 5 'completion-tokens 5 'total-tokens 10)
+                             "test-model"
+                             'stop)))
+  (values (make-provider (lambda () "request-capture")
+                         (lambda () (hasheq 'streaming #f))
+                         send-handler
+                         (lambda (req)
+                           (generator () (yield (make-stream-chunk "done" #f #f #t)) (yield #f))))
+          captured-requests))
+
+;; ============================================================
+;; Tests
+;; ============================================================
+
+(define terminal-tests
+  (test-suite "spawn-subagent typed terminal outcomes (W1 TMUX-04)"
+
+    ;; ---------------------------------------------------------
+    ;; 1. Provider request two contains matching tool-call/result IDs
+    ;; ---------------------------------------------------------
+    (test-case "request two contains matching tool-call and tool-result IDs"
+      (define-values (provider captured)
+        (make-request-capturing-provider
+         (list (make-model-response (list (hasheq 'type "text" 'text "Let me check.")
+                                          (hasheq 'type
+                                                  "tool_call"
+                                                  'id
+                                                  "call_xyz789"
+                                                  'name
+                                                  "bash"
+                                                  'arguments
+                                                  (hasheq 'command "echo CHILD_SENTINEL_42")))
+                                    (hasheq 'prompt-tokens 10 'completion-tokens 10 'total-tokens 20)
+                                    "test-model"
+                                    'tool_calls)
+               (make-model-response
+                (list (hasheq 'type "text" 'text "Task done. CHILD_SENTINEL_42 found."))
+                (hasheq 'prompt-tokens 10 'completion-tokens 10 'total-tokens 20)
+                "test-model"
+                'stop))))
+      (define settings (q-settings (hash) (hash) (hasheq 'provider provider 'model "test-model")))
+      (define ctx (make-exec-context #:runtime-settings settings #:call-id "req-two-test"))
+      (define result (tool-spawn-subagent (hasheq 'task "find sentinel") ctx))
+      (check-false (tool-result-is-error? result))
+
+      (define reqs (unbox captured))
+      (check-true (>= (length reqs) 2) "should have at least 2 requests")
+      (define req-two (cadr reqs))
+      (define messages (model-request-messages req-two))
+
+      ;; Find tool_result in request two's messages
+      (define all-content
+        (apply append
+               (for/list ([m messages])
+                 (define c (hash-ref m 'content #f))
+                 (if (list? c)
+                     c
+                     '()))))
+      (define tool-results
+        (filter (lambda (c) (and (hash? c) (equal? (hash-ref c 'type #f) "tool_result")))
+                all-content))
+      (check-true (pair? tool-results) "request two must contain at least one tool_result")
+      (when (pair? tool-results)
+        (define tr (car tool-results))
+        (check-equal? (hash-ref tr 'tool_call_id #f)
+                      "call_xyz789"
+                      "tool_result must have matching tool_call_id")))
+
+    ;; ---------------------------------------------------------
+    ;; 2. Unique child sentinel reaches spawn result
+    ;; ---------------------------------------------------------
+    (test-case "child sentinel reaches spawn result"
+      (define-values (provider _c)
+        (make-request-capturing-provider
+         (list (make-model-response
+                (list (hasheq 'type "text" 'text "The answer is UNIQUE_CHILD_OUTPUT_99"))
+                (hasheq 'prompt-tokens 5 'completion-tokens 10 'total-tokens 15)
+                "test-model"
+                'stop))))
+      (define settings (q-settings (hash) (hash) (hasheq 'provider provider 'model "test-model")))
+      (define ctx (make-exec-context #:runtime-settings settings #:call-id "sentinel-test"))
+      (define result (tool-spawn-subagent (hasheq 'task "produce sentinel") ctx))
+      (check-false (tool-result-is-error? result))
+      (define result-text (hash-ref (car (tool-result-content result)) 'text ""))
+      (check-true (string-contains? result-text "UNIQUE_CHILD_OUTPUT_99")
+                  "unique child sentinel must reach result")
+      (check-false (string-contains? result-text "#hasheq"))
+      (check-false (string-contains? result-text "<unsupported:completed>")))
+
+    ;; ---------------------------------------------------------
+    ;; 3. Typed terminal outcome: completed-with-result
+    ;; ---------------------------------------------------------
+    (test-case "completed-with-result has terminal-status 'completed'"
+      (define-values (provider _c)
+        (make-request-capturing-provider
+         (list (make-model-response (list (hasheq 'type "text" 'text "Real result text."))
+                                    (hasheq 'prompt-tokens 5 'completion-tokens 5 'total-tokens 10)
+                                    "test-model"
+                                    'stop))))
+      (define settings (q-settings (hash) (hash) (hasheq 'provider provider 'model "test-model")))
+      (define ctx (make-exec-context #:runtime-settings settings #:call-id "completed-test"))
+      (define result (tool-spawn-subagent (hasheq 'task "produce result") ctx))
+      (check-false (tool-result-is-error? result))
+      (define details (tool-result-details result))
+      (check-equal? (hash-ref details 'terminal-status #f) "completed"))
+
+    ;; ---------------------------------------------------------
+    ;; 4. Typed terminal outcome: approved-empty
+    ;; ---------------------------------------------------------
+    (test-case "approved-empty is terminal typed outcome, not error"
+      (define-values (provider _c)
+        (make-request-capturing-provider
+         (list (make-model-response (list (hasheq 'type "text" 'text ""))
+                                    (hasheq 'prompt-tokens 5 'completion-tokens 0 'total-tokens 5)
+                                    "test-model"
+                                    'stop))))
+      (define settings (q-settings (hash) (hash) (hasheq 'provider provider 'model "test-model")))
+      (define ctx (make-exec-context #:runtime-settings settings #:call-id "empty-test"))
+      (define result (tool-spawn-subagent (hasheq 'task "produce nothing") ctx))
+      (check-false (tool-result-is-error? result))
+      (define details (tool-result-details result))
+      (check-equal? (hash-ref details 'terminal-status #f)
+                    "approved-empty"
+                    "empty result must be typed 'approved-empty'")
+      (check-equal? (hash-ref details 'result-present? #f) #f))
+
+    ;; ---------------------------------------------------------
+    ;; 5. Safe result metadata present
+    ;; ---------------------------------------------------------
+    (test-case "safe result metadata has digest, size, session-id"
+      (define-values (provider _c)
+        (make-request-capturing-provider
+         (list (make-model-response (list (hasheq 'type "text" 'text "Metadata test content."))
+                                    (hasheq 'prompt-tokens 5 'completion-tokens 5 'total-tokens 10)
+                                    "test-model"
+                                    'stop))))
+      (define settings (q-settings (hash) (hash) (hasheq 'provider provider 'model "test-model")))
+      (define ctx (make-exec-context #:runtime-settings settings #:call-id "meta-test"))
+      (define result (tool-spawn-subagent (hasheq 'task "metadata test") ctx))
+      (check-false (tool-result-is-error? result))
+      (define details (tool-result-details result))
+      (check-true (hash-has-key? details 'content-digest) "metadata must have content-digest")
+      (check-true (hash-has-key? details 'content-size) "metadata must have content-size")
+      (check-true (hash-has-key? details 'session-id) "metadata must have session-id")
+      (check-true (> (hash-ref details 'content-size 0) 0)
+                  "content-size must be positive for non-empty result")
+      (check-true (and (string? (hash-ref details 'content-digest #f))
+                       (> (string-length (hash-ref details 'content-digest "")) 0))
+                  "content-digest must be non-empty string"))
+
+    ;; ---------------------------------------------------------
+    ;; 6. Unknown content type produces clean label, not hash garbage
+    ;; ---------------------------------------------------------
+    (test-case "unknown content type with 'text extracts text, not #hasheq"
+      (define-values (provider _c)
+        (make-request-capturing-provider
+         (list (make-model-response (list (hasheq 'type "thinking" 'text "internal reasoning")
+                                          (hasheq 'type "text" 'text "Final answer visible."))
+                                    (hasheq 'prompt-tokens 5 'completion-tokens 5 'total-tokens 10)
+                                    "test-model"
+                                    'stop))))
+      (define settings (q-settings (hash) (hash) (hasheq 'provider provider 'model "test-model")))
+      (define ctx (make-exec-context #:runtime-settings settings #:call-id "unknown-type-test"))
+      (define result (tool-spawn-subagent (hasheq 'task "test unknown type") ctx))
+      (check-false (tool-result-is-error? result))
+      (define result-text (hash-ref (car (tool-result-content result)) 'text ""))
+      (check-false (string-contains? result-text "#hasheq")
+                   (format "must not contain #hasheq, got: ~a"
+                           (substring result-text 0 (min 200 (string-length result-text)))))
+      (check-true (string-contains? result-text "internal reasoning")
+                  "thinking content with 'text field should extract text"))))
+
+(module+ test
+  (run-tests terminal-tests))
+
+(module+ main
+  (run-tests terminal-tests))

--- a/tools/builtins/spawn-subagent-helpers.rkt
+++ b/tools/builtins/spawn-subagent-helpers.rkt
@@ -15,6 +15,7 @@
 
 (require racket/string
          racket/list
+         (only-in file/sha1 sha1)
          (only-in "../../util/capability.rkt" valid-capability?)
          (only-in "../../util/message/message.rkt" make-message message-role message-content)
          (only-in "../../util/content/content-parts.rkt"
@@ -27,7 +28,10 @@
          requires-hitl-approval?
          extract-assistant-text
          extract-text-summary
-         SUBAGENT-SUMMARY-MAX-CHARS)
+         SUBAGENT-SUMMARY-MAX-CHARS
+         classify-terminal-status
+         make-safe-result-metadata
+         result-has-content?)
 
 ;; ============================================================
 ;; Capability normalization
@@ -137,3 +141,61 @@
   (if (> (string-length full-text) max-chars)
       (string-append (substring full-text 0 (- max-chars 3)) "...")
       full-text))
+
+;; ============================================================
+;; Typed terminal outcomes (v0.99.50 W1 — TMUX-04)
+;; ============================================================
+
+;; Classify a raw loop final-status into a canonical typed terminal outcome.
+;;
+;; Raw statuses from run-subagent-loop:
+;;   'complete             → subagent finished normally
+;;   'max-turns-reached    → ran out of turns
+;;   'cancelled            → HITL-denied (transport-ineligible, W2)
+;;   (other symbols)       → unexpected loop exit
+;;
+;; Returns one of these canonical typed symbols:
+;;   'completed            — finished with non-empty result text
+;;   'approved-empty       — finished but produced empty result
+;;   'timed-out            — hit max turns without completing
+;;   'failed               — unexpected loop exit
+;;   'cancelled            — HITL-denied
+;;
+;; This function is pure — it takes the raw status symbol and a
+;; result-has-content? boolean, returning the canonical typed outcome.
+(define (classify-terminal-status raw-status has-content?)
+  (cond
+    [(eq? raw-status 'complete) (if has-content? 'completed 'approved-empty)]
+    [(eq? raw-status 'max-turns-reached) 'timed-out]
+    [(eq? raw-status 'cancelled) 'cancelled]
+    [else 'failed]))
+
+;; Check whether result text is non-empty (after trimming).
+(define (result-has-content? text)
+  (and (string? text) (> (string-length (string-trim text)) 0)))
+
+;; Build safe trace metadata for a subagent result.
+;; Logs presence, size, SHA-1 digest, IDs, and status WITHOUT logging
+;; unrestricted child content.
+;;
+;; All inputs are plain data; output is a plain hash suitable for JSON.
+;; v0.99.50 W1 (TMUX-04): Adds typed 'terminal-status while keeping
+;; legacy 'status (raw loop status) for backward compatibility.
+(define (make-safe-result-metadata result-text session-id terminal-status [raw-status #f])
+  (define trimmed (or (and (string? result-text) result-text) ""))
+  (define size (string-length trimmed))
+  (define digest (sha1 (open-input-string trimmed)))
+  (define base
+    (hasheq 'result-present?
+            (result-has-content? trimmed)
+            'content-size
+            size
+            'content-digest
+            digest
+            'session-id
+            (or session-id "")
+            'terminal-status
+            (symbol->string terminal-status)))
+  (if raw-status
+      (hash-set base 'status (symbol->string raw-status))
+      base))

--- a/tools/builtins/spawn-subagent.rkt
+++ b/tools/builtins/spawn-subagent.rkt
@@ -97,7 +97,11 @@
          ;; W2 v0.99.35: Re-export pure helpers for backward compat
          normalize-capabilities
          extract-assistant-text
-         extract-text-summary)
+         extract-text-summary
+         ;; v0.99.50 W1 (TMUX-04): Typed terminal outcomes and safe metadata
+         classify-terminal-status
+         make-safe-result-metadata
+         result-has-content?)
 
 ;; Subagent configuration struct — replaces ad-hoc hash extraction
 ;; v0.99.21 §4.2: Added capabilities field (6th, default #f for backward compat)
@@ -443,71 +447,23 @@
 
     ;; W2 v0.99.35: Extract assistant text via pure helper.
     ;; Previously inline — logic now in spawn-subagent-helpers.rkt.
+    ;; v0.99.50 W1 (TMUX-04): Use typed terminal outcomes and safe metadata.
     (define result-text (extract-assistant-text result-messages))
-    (make-success-result
-     (list (hasheq 'type "text" 'text result-text))
-     (hasheq 'turns-used max-turns 'status (symbol->string final-status) 'session-id session-id))))
+    (define has-content? (result-has-content? result-text))
+    (define terminal-status (classify-terminal-status final-status has-content?))
+    (define base-meta (make-safe-result-metadata result-text session-id terminal-status final-status))
+    (make-success-result (list (hasheq 'type "text" 'text result-text))
+                         (hash-set base-meta 'turns-used max-turns))))
 
 ;; ============================================================
 ;; Message-to-provider conversion
 ;; ============================================================
 
-;; Convert internal message struct to a provider-facing JSON hash.
-;; Providers expect simple {role, content} hashes, not q internal structs.
-;; Handles both string content (initial messages) and content-part lists
-;; (assistant messages with tool calls, tool-result messages).
-(define (message->provider-hash msg)
-  (define role-sym (message-role msg))
-  (define role-str
-    (if (symbol? role-sym)
-        (symbol->string role-sym)
-        (format "~a" role-sym)))
-  (define content (message-content msg))
-  (define content-val
-    (cond
-      [(string? content) content]
-      [(null? content) ""]
-      [(and (list? content) (andmap string? content)) (string-join content "\n")]
-      [(and (list? content) (andmap content-part? content))
-       (for/list ([cp (in-list content)])
-         (content-part->provider-hash cp))]
-      [(list? content)
-       (for/list ([c (in-list content)])
-         (cond
-           [(string? c) c]
-           [(content-part? c) (content-part->provider-hash c)]
-           [(hash? c) c]
-           [else (format "~a" c)]))]
-      [else (format "~a" content)]))
-  (hasheq 'role role-str 'content content-val))
-
-;; Convert content-part to provider-facing hash for JSON serialization.
-(define (content-part->provider-hash cp)
-  (cond
-    [(text-part? cp) (hasheq 'type "text" 'text (text-part-text cp))]
-    [(tool-call-part? cp)
-     (hasheq 'type
-             "tool_call"
-             'id
-             (or (tool-call-part-id cp) "")
-             'name
-             (or (tool-call-part-name cp) "")
-             'arguments
-             (tool-call-part-arguments cp))]
-    [(tool-result-part? cp)
-     (hasheq 'type
-             "tool_result"
-             'tool_call_id
-             (or (tool-result-part-tool-call-id cp) "")
-             'content
-             (tool-result-part-content cp)
-             'is_error
-             (tool-result-part-is-error? cp))]
-    [else (hasheq 'type "text" 'text (format "~a" cp))]))
-
-;; Convert a list of message structs to provider-facing JSON hashes.
-(define (messages->provider-hashes msgs)
-  (map message->provider-hash msgs))
+;; v0.99.50 W1 (TMUX-04): Duplicate provider conversion removed.
+;; All three functions (message->provider-hash, content-part->provider-hash,
+;; messages->provider-hashes) are imported from provider-hash-bridge.rkt.
+;; Keeping one canonical wire representation prevents divergence between
+;; the inline and extracted versions.
 
 ;; Run a simple agent loop for the subagent
 ;; v0.19.4 GAP-1 fix: actually dispatch tool_calls instead of returning 'stopped
@@ -532,16 +488,21 @@
                           #:per-type-budgets (hash 'timeout 2 'rate-limit 4 'provider-error 2)))
        (define content (model-response-content resp))
        ;; Build assistant message from response content parts
+       ;; v0.99.50 W1 (TMUX-04): Unknown content types (thinking, image, etc.)
+       ;; no longer become raw hash garbage via (format "~a" c). Instead they
+       ;; produce a clean [unsupported:type] label or extract any 'text field.
        (define content-parts
          (for/list ([c (in-list content)])
            (match (hash-ref c 'type #f)
-             ["text" (hash-ref c 'text (format "~a" c))]
+             ["text" (hash-ref c 'text "")]
              ["tool_call"
               (make-tool-call-part (hash-ref c 'id (generate-id))
                                    (hash-ref c 'name "")
                                    (ensure-hash-args (hash-ref c 'arguments "{}")))]
-             [#f (hash-ref c 'text (format "~a" c))]
-             [_ (format "~a" c)])))
+             [#f (hash-ref c 'text "")]
+             ;; Unknown but typed content: extract text if present, else clean label.
+             ;; This prevents #hasheq garbage from leaking into result text.
+             [type-str (hash-ref c 'text (format "[unsupported:~a]" type-str))])))
        (define assistant-msg
          (make-message (generate-id) #f 'assistant 'message content-parts (current-seconds) (hasheq)))
        (define new-all (append all-results (list assistant-msg)))


### PR DESCRIPTION
## W1: Canonical Subagent Result Transport (TMUX-04)

Changes:
- Remove duplicate provider conversion from spawn-subagent.rkt
- Fix unknown content type fallback (no more #hasheq garbage)
- Add typed terminal outcomes (completed, approved-empty, timed-out, etc.)
- Add safe result metadata with SHA-1 digest, content-size, session-id

19 new tests. Closes #8716
