### PR TITLE
feat(v0.99.50 W2): correlated exactly-once HITL approvals (#8717)

### DIFF
--- a/tests/test-approval-correlation.rkt
+++ b/tests/test-approval-correlation.rkt
@@ -1,0 +1,280 @@
+#lang racket/base
+
+;; @speed fast
+;; @suite default
+
+;; tests/test-approval-correlation.rkt
+;; v0.99.50 W2 (TMUX-04): Correlated exactly-once HITL approval delivery.
+;;
+;; Verifies:
+;; 1. register → await → put-for-id delivers correct result
+;; 2. duplicate put-for-id is exactly-once (second returns #f)
+;; 3. mismatched IDs don't deliver to wrong request
+;; 4. timeout cleans up registry (no leak)
+;; 5. clear-pending-approvals cleans up all pending
+;; 6. concurrent requests get unique IDs and channels
+;; 7. request-spawn-approval emits request-id in event payload
+
+(require rackunit
+         rackunit/text-ui
+         racket/list
+         "../tui/approval-channel.rkt"
+         "../tui/state-types.rkt"
+         (only-in "../tui/tui-keybindings.rkt"
+                  make-tui-ctx
+                  tui-ctx-ui-state-box
+                  handle-approval-overlay-key)
+         "../tools/builtins/spawn-subagent.rkt"
+         "../tools/tool.rkt")
+
+(define suite
+  (test-suite "Correlated Exactly-Once Approval Delivery (v0.99.50 W2)"
+
+    ;; ── Setup: ensure clean state ──
+    (test-case "starts with empty registry"
+      (clear-pending-approvals!)
+      (check-equal? (pending-approval-count) 0))
+
+    ;; ── 1. Basic register → await → put-for-id ──
+
+    (test-case "register then put-for-id delivers result"
+      (clear-pending-approvals!)
+      (define req-id (register-approval-request!))
+      (check-equal? (pending-approval-count) 1)
+      (define result-box (box #f))
+      (define t
+        (thread (lambda ()
+                  (define-values (approved? delivered?) (approval-await-for-id req-id))
+                  (set-box! result-box (list approved? delivered?)))))
+      (sleep 0.05)
+      (check-true (approval-put-for-id! req-id #t))
+      (thread-wait t)
+      (check-equal? (unbox result-box) (list #t #t))
+      (check-equal? (pending-approval-count) 0))
+
+    (test-case "register then put-for-id delivers denial"
+      (clear-pending-approvals!)
+      (define req-id (register-approval-request!))
+      (define result-box (box #f))
+      (define t
+        (thread (lambda ()
+                  (define-values (approved? delivered?) (approval-await-for-id req-id))
+                  (set-box! result-box (list approved? delivered?)))))
+      (sleep 0.05)
+      (check-true (approval-put-for-id! req-id #f))
+      (thread-wait t)
+      (check-equal? (unbox result-box) (list #f #t)))
+
+    ;; ── 2. Exactly-once: duplicate put returns #f ──
+
+    (test-case "duplicate put-for-id is exactly-once"
+      (clear-pending-approvals!)
+      (define req-id (register-approval-request!))
+      ;; First put delivers and atomically removes from registry
+      (check-true (approval-put-for-id! req-id #t))
+      ;; Second put finds nothing — exactly-once enforcement
+      (check-false (approval-put-for-id! req-id #t))
+      (check-false (approval-put-for-id! req-id #f)))
+
+    ;; ── 3. Mismatched IDs don't cross ──
+
+    (test-case "mismatched ID does not deliver to wrong request"
+      (clear-pending-approvals!)
+      (define req-a (register-approval-request!))
+      (define req-b (register-approval-request!))
+      (check-not-equal? req-a req-b)
+      (check-equal? (pending-approval-count) 2)
+      ;; Put for B should not deliver to A
+      (check-true (approval-put-for-id! req-b #t))
+      ;; A is still pending
+      (check-equal? (pending-approval-count) 1)
+      ;; Now put for A
+      (check-true (approval-put-for-id! req-a #f))
+      (check-equal? (pending-approval-count) 0))
+
+    ;; ── 4. Timeout cleans up registry ──
+
+    (test-case "timeout removes request from registry"
+      (clear-pending-approvals!)
+      (define req-id (register-approval-request!))
+      (check-equal? (pending-approval-count) 1)
+      (define-values (approved? delivered?) (approval-await-for-id req-id 50))
+      (check-false approved?)
+      (check-false delivered?)
+      (check-equal? (pending-approval-count) 0))
+
+    ;; ── 5. clear-pending-approvals cleans up ──
+
+    (test-case "clear-pending-approvals removes all pending"
+      (clear-pending-approvals!)
+      (register-approval-request!)
+      (register-approval-request!)
+      (register-approval-request!)
+      (check-equal? (pending-approval-count) 3)
+      (clear-pending-approvals!)
+      (check-equal? (pending-approval-count) 0))
+
+    ;; ── 6. Unique IDs for concurrent requests ──
+
+    (test-case "concurrent requests get unique IDs"
+      (clear-pending-approvals!)
+      (define ids
+        (for/list ([_ (in-range 10)])
+          (register-approval-request!)))
+      (check-equal? (length ids) 10)
+      (check-equal? (length (remove-duplicates ids)) 10)
+      (check-equal? (pending-approval-count) 10)
+      (clear-pending-approvals!))
+
+    ;; ── 7. await for unknown ID returns #f #f ──
+
+    (test-case "await for unknown ID returns not-delivered"
+      (clear-pending-approvals!)
+      (define-values (approved? delivered?) (approval-await-for-id 'nonexistent-id 10))
+      (check-false approved?)
+      (check-false delivered?))
+
+    ;; ── 8. clear-approval-channel! also clears pending ──
+
+    (test-case "clear-approval-channel! also clears pending approvals"
+      (clear-pending-approvals!)
+      (register-approval-request!)
+      (register-approval-request!)
+      (check-equal? (pending-approval-count) 2)
+      (clear-approval-channel!)
+      (check-equal? (pending-approval-count) 0))
+
+    ;; ── 9. Cross-thread: full correlated lifecycle ──
+
+    (test-case "full correlated lifecycle across threads"
+      (clear-pending-approvals!)
+      (define req-id (register-approval-request!))
+      (define result-box (box #f))
+      ;; Session thread blocks on correlated await
+      (define t
+        (thread (lambda ()
+                  (define-values (approved? delivered?) (approval-await-for-id req-id))
+                  (set-box! result-box approved?))))
+      ;; Simulate TUI key handler delivering correlated response
+      (sleep 0.05)
+      (check-true (approval-put-for-id! req-id #t))
+      (thread-wait t)
+      (check-equal? (unbox result-box) #t)
+      ;; Registry is now empty
+      (check-equal? (pending-approval-count) 0))
+
+    ;; ── 10. request-spawn-approval emits request-id in event ──
+
+    (test-case "request-spawn-approval emits request-id when channel is set"
+      (clear-pending-approvals!)
+      (set-approval-channel! (make-approval-channel #:timeout-ms 100))
+      (define events-received '())
+      (define mock-publisher
+        (lambda (event-type payload)
+          (set! events-received (cons (cons event-type payload) events-received))))
+      (define mock-ctx (make-exec-context #:event-publisher mock-publisher))
+      ;; Spawn a thread to deliver the approval (will timeout otherwise)
+      (thread (lambda ()
+                (sleep 0.05)
+                ;; Find the request-id from the event and deliver
+                (when (pair? events-received)
+                  (define payload (cdar events-received))
+                  (define req-id (hash-ref payload 'request-id #f))
+                  (when req-id
+                    (approval-put-for-id! req-id #t)))))
+      (define approved (request-spawn-approval '(shell-exec) "dangerous task" mock-ctx))
+      (check-true approved "should be approved via correlated delivery")
+      (check-true (pair? events-received) "should have emitted an event")
+      (define payload (cdar events-received))
+      (check-true (hash-has-key? payload 'request-id) "event must contain request-id")
+      (clear-approval-channel!))
+
+    ;; ── 11. Stale approval cannot auto-approve new request ──
+
+    (test-case "stale approval does not leak to new request"
+      (clear-pending-approvals!)
+      (set-approval-channel! (make-approval-channel #:timeout-ms 100))
+      ;; First request registers and times out
+      (define req-1 (register-approval-request!))
+      (define-values (a1 d1) (approval-await-for-id req-1 50))
+      (check-false d1 "first request timed out")
+      (check-equal? (pending-approval-count) 0)
+      ;; Stale approval for req-1 arrives (late response)
+      (check-false (approval-put-for-id! req-1 #t) "stale approval must be rejected")
+      ;; New request gets a fresh ID
+      (define req-2 (register-approval-request!))
+      (check-not-equal? req-1 req-2)
+      ;; The stale #t is NOT sitting on req-2's channel
+      (define-values (a2 d2) (approval-await-for-id req-2 50))
+      (check-false d2 "new request must not receive stale approval")
+      (clear-approval-channel!))
+
+    ;; ── 12. Key handler delivers correlated response ──
+
+    (test-case "key handler delivers via approval-put-for-id! when request-id present"
+      (clear-pending-approvals!)
+      (set-approval-channel! (make-approval-channel #:timeout-ms 5000))
+      (define req-id (register-approval-request!))
+      ;; Build a tui-ctx with an approval overlay that has request-id in extra
+      (define ctx (make-tui-ctx #:session-runner void #:event-bus #f #:session-queue #f))
+      (set-box!
+       (tui-ctx-ui-state-box ctx)
+       (struct-copy
+        ui-state
+        (initial-ui-state)
+        [active-overlay
+         (overlay-state
+          'approval-prompt
+          '()
+          ""
+          'top-left
+          #f
+          #f
+          0
+          (hasheq 'capabilities '(shell-exec) 'task-preview "correlated test" 'request-id req-id))]))
+      ;; Session thread blocks on correlated await
+      (define result-box (box #f))
+      (define t
+        (thread (lambda ()
+                  (define-values (approved? delivered?) (approval-await-for-id req-id))
+                  (set-box! result-box approved?))))
+      (sleep 0.05)
+      ;; User presses 'y' — key handler uses correlated delivery
+      (define handler-result (handle-approval-overlay-key ctx #\y))
+      (check-equal? handler-result 'handled)
+      (thread-wait t)
+      (check-equal? (unbox result-box) #t)
+      (check-equal? (pending-approval-count) 0)
+      (clear-approval-channel!))
+
+    ;; ── 13. Key handler falls back to legacy when no request-id ──
+
+    (test-case "key handler uses legacy approval-put! when no request-id"
+      (clear-pending-approvals!)
+      (set-approval-channel! (make-approval-channel #:timeout-ms 5000))
+      ;; Build a tui-ctx with an approval overlay WITHOUT request-id in extra
+      (define ctx (make-tui-ctx #:session-runner void #:event-bus #f #:session-queue #f))
+      (set-box! (tui-ctx-ui-state-box ctx)
+                (struct-copy ui-state
+                             (initial-ui-state)
+                             [active-overlay
+                              (overlay-state
+                               'approval-prompt
+                               '()
+                               ""
+                               'top-left
+                               #f
+                               #f
+                               0
+                               (hasheq 'capabilities '(shell-exec) 'task-preview "legacy test"))]))
+      ;; Press 'n' — should go through legacy approval-put! (bare boolean)
+      (define handler-result (handle-approval-overlay-key ctx #\n))
+      (check-equal? handler-result 'handled)
+      ;; Legacy channel should have the result
+      (define ch (current-approval-channel))
+      (check-not-false ch "channel should be set")
+      (define result (sync/timeout 0.1 (approval-channel-ch ch)))
+      (check-equal? result #f "legacy denial should be on shared channel")
+      (clear-approval-channel!))))
+
+(run-tests suite)

--- a/tools/builtins/spawn-subagent.rkt
+++ b/tools/builtins/spawn-subagent.rkt
@@ -16,7 +16,11 @@
          "../../tools/tool.rkt"
          (only-in "../../util/capability.rkt" valid-capability?)
          (only-in "../../runtime/runtime-helpers.rkt" emit-session-event! make-event-bus)
-         (only-in "../../tui/approval-channel.rkt" current-approval-channel approval-await-result)
+         (only-in "../../tui/approval-channel.rkt"
+                  current-approval-channel
+                  approval-await-result
+                  register-approval-request!
+                  approval-await-for-id)
          (only-in "../../runtime/settings.rkt" q-settings? setting-ref)
          (only-in "../../runtime/auto-retry.rkt" with-auto-retry)
          "../model-bridge.rkt"
@@ -139,26 +143,39 @@
 ;; Returns #t when approved, #f when denied.
 ;; When no approval channel is available (non-interactive mode), returns #t
 ;; (permissive — the approval gate only blocks in interactive/TUI mode).
+;; v0.99.50 W2 (TMUX-04): Uses correlated request IDs for exactly-once delivery.
+;; Each request registers a unique ID in the pending registry and emits it
+;; in the event payload so the TUI can correlate the response.
 (define (request-spawn-approval capabilities task-desc exec-ctx)
   (define publisher (and exec-ctx (exec-context-event-publisher exec-ctx)))
-  ;; Emit the approval-request event for TUI display (when available)
-  (when publisher
-    (publisher "mas.spawn-approval-requested"
-               (hasheq 'capabilities
-                       capabilities
-                       'task-preview
-                       (if (and (string? task-desc) (> (string-length task-desc) 200))
-                           (substring task-desc 0 200)
-                           (or task-desc "")))))
-  ;; v0.99.25 §5.3: Check for approval channel (TUI interactive mode).
-  ;; When a channel is set, block until user responds (with timeout).
-  ;; When no channel (non-interactive mode), use the permissive parameter.
   (define ch (current-approval-channel))
-  (if ch
-      ;; Interactive: block until user responds or timeout
-      (approval-await-result)
-      ;; Non-interactive: use permissive parameter (default #t)
-      (current-spawn-approval-result)))
+  (cond
+    [ch
+     ;; Interactive mode: correlated exactly-once approval delivery.
+     (define req-id (register-approval-request!))
+     (when publisher
+       (publisher "mas.spawn-approval-requested"
+                  (hasheq 'capabilities
+                          capabilities
+                          'task-preview
+                          (if (and (string? task-desc) (> (string-length task-desc) 200))
+                              (substring task-desc 0 200)
+                              (or task-desc ""))
+                          'request-id
+                          req-id)))
+     (define-values (approved? delivered?) (approval-await-for-id req-id))
+     approved?]
+    [else
+     ;; Non-interactive: emit event for logging, use permissive parameter.
+     (when publisher
+       (publisher "mas.spawn-approval-requested"
+                  (hasheq 'capabilities
+                          capabilities
+                          'task-preview
+                          (if (and (string? task-desc) (> (string-length task-desc) 200))
+                              (substring task-desc 0 200)
+                              (or task-desc "")))))
+     (current-spawn-approval-result)]))
 
 ;; Default role prompt when no role is specified
 (define default-role-prompt

--- a/tui/approval-channel.rkt
+++ b/tui/approval-channel.rkt
@@ -33,7 +33,13 @@
                        [current-approval-channel (-> (or/c approval-channel? #f))]
                        [approval-await-result (->* () () boolean?)])
          approval-put!
-         DEFAULT-APPROVAL-TIMEOUT-MS)
+         DEFAULT-APPROVAL-TIMEOUT-MS
+         ;; v0.99.50 W2 (TMUX-04): Correlated exactly-once approval delivery
+         register-approval-request!
+         approval-await-for-id
+         approval-put-for-id!
+         clear-pending-approvals!
+         pending-approval-count)
 
 ;; ============================================================
 ;; Approval channel struct
@@ -66,8 +72,10 @@
   (void))
 
 ;; Clear the shared approval channel (called on TUI teardown).
+;; v0.99.50 W2: Also clears the pending-approvals registry.
 (define (clear-approval-channel!)
   (set-box! current-approval-channel-box #f)
+  (clear-pending-approvals!)
   (void))
 
 ;; Read the current shared approval channel.
@@ -100,3 +108,83 @@
   (when ch
     (async-channel-put (approval-channel-ch ch) result))
   (void))
+
+;; ============================================================
+;; v0.99.50 W2 (TMUX-04): Correlated exactly-once approval delivery
+;; ============================================================
+
+;; A pending approval request with a dedicated response channel.
+;; Each request gets its own async-channel, so responses can't cross.
+(struct pending-approval (id ch created-at) #:transparent)
+
+;; Registry: hash from request-id (symbol) → pending-approval
+(define pending-approvals-box (box (hash)))
+
+;; Semaphore for thread-safe registry access
+(define registry-sem (make-semaphore 1))
+
+;; Register a new approval request.
+;; Returns a unique request-id (symbol) that must be included in the
+;; response to correlate it back to this request.
+;; Each request gets its own dedicated async-channel.
+(define (register-approval-request!)
+  (define req-id (gensym 'approval))
+  (define pa (pending-approval req-id (make-async-channel) (current-inexact-milliseconds)))
+  (call-with-semaphore
+   registry-sem
+   (lambda () (set-box! pending-approvals-box (hash-set (unbox pending-approvals-box) req-id pa))))
+  req-id)
+
+;; Await an approval result for a specific request-id.
+;; Blocks until the response arrives or timeout.
+;; Returns (values approved? delivered?) where delivered? is #f on timeout
+;; or if the request was not found / already consumed.
+;; Removes the request from the registry on completion or timeout.
+(define (approval-await-for-id req-id [timeout-ms #f])
+  (define pa
+    (call-with-semaphore registry-sem (lambda () (hash-ref (unbox pending-approvals-box) req-id #f))))
+  (cond
+    [(not pa) (values #f #f)]
+    [else
+     (define ach (pending-approval-ch pa))
+     (define effective-timeout
+       (or timeout-ms
+           (let ([ch (current-approval-channel)])
+             (if ch
+                 (approval-channel-timeout-ms ch)
+                 DEFAULT-APPROVAL-TIMEOUT-MS))))
+     (define result (sync/timeout (/ effective-timeout 1000.0) ach))
+     (call-with-semaphore
+      registry-sem
+      (lambda () (set-box! pending-approvals-box (hash-remove (unbox pending-approvals-box) req-id))))
+     (if result
+         (values (car result) #t)
+         (values #f #f))]))
+
+;; Put an approval result for a specific request-id (exactly-once).
+;; Atomically removes the request from the registry before delivering,
+;; so a second put for the same ID is a no-op (returns #f).
+;; Returns #t if delivered, #f if the request-id was not found
+;; (already answered, timed out, or never registered).
+(define (approval-put-for-id! req-id approved?)
+  (define pa
+    (call-with-semaphore registry-sem
+                         (lambda ()
+                           (define h (unbox pending-approvals-box))
+                           (define found (hash-ref h req-id #f))
+                           (when found
+                             (set-box! pending-approvals-box (hash-remove h req-id)))
+                           found)))
+  (cond
+    [(not pa) #f]
+    [else
+     (async-channel-put (pending-approval-ch pa) (list approved?))
+     #t]))
+
+;; Clear all pending approval requests (called on TUI teardown).
+(define (clear-pending-approvals!)
+  (call-with-semaphore registry-sem (lambda () (set-box! pending-approvals-box (hash)))))
+
+;; Count of pending approval requests (for testing/introspection).
+(define (pending-approval-count)
+  (call-with-semaphore registry-sem (lambda () (hash-count (unbox pending-approvals-box)))))

--- a/tui/selection.rkt
+++ b/tui/selection.rkt
@@ -225,26 +225,36 @@
   (cond
     ;; Not our overlay type — pass through
     [(not (and ov (eq? (overlay-state-type ov) 'approval-prompt))) 'pass]
-    ;; Approve: y or Y
-    [(or (eq? keycode #\y) (eq? keycode #\Y) (eq? keycode 'y))
-     (approval-put! #t)
-     (set-box! (tui-ctx-ui-state-box ctx) (dismiss-overlay state))
-     (mark-dirty! ctx)
-     'handled]
-    ;; Deny: n or N
-    [(or (eq? keycode #\n) (eq? keycode #\N) (eq? keycode 'n))
-     (approval-put! #f)
-     (set-box! (tui-ctx-ui-state-box ctx) (dismiss-overlay state))
-     (mark-dirty! ctx)
-     'handled]
-    ;; Cancel (deny): Escape
-    [(eq? keycode 'escape)
-     (approval-put! #f)
-     (set-box! (tui-ctx-ui-state-box ctx) (dismiss-overlay state))
-     (mark-dirty! ctx)
-     'handled]
-    ;; Unrecognized key — pass through
-    [else 'pass]))
+    ;; v0.99.50 W2 (TMUX-04): Correlated exactly-once delivery.
+    ;; Extract request-id from overlay extra, use approval-put-for-id!
+    ;; so stale/duplicate responses are ignored.
+    [else
+     (define extra (and ov (overlay-state-extra ov)))
+     (define req-id (and (hash? extra) (hash-ref extra 'request-id #f)))
+     (define approved?
+       (cond
+         [(or (eq? keycode #\y) (eq? keycode #\Y) (eq? keycode 'y)) #t]
+         [(or (eq? keycode #\n) (eq? keycode #\N) (eq? keycode 'n)) #f]
+         [(eq? keycode 'escape) #f]
+         [else #f]))
+     (define recognized?
+       (or (eq? keycode #\y)
+           (eq? keycode #\Y)
+           (eq? keycode 'y)
+           (eq? keycode #\n)
+           (eq? keycode #\N)
+           (eq? keycode 'n)
+           (eq? keycode 'escape)))
+     (cond
+       [(not recognized?) 'pass]
+       [else
+        ;; Deliver correlated response (exactly-once via registry)
+        (if req-id
+            (approval-put-for-id! req-id approved?)
+            (approval-put! approved?)) ; backward compat for legacy events
+        (set-box! (tui-ctx-ui-state-box ctx) (dismiss-overlay state))
+        (mark-dirty! ctx)
+        'handled])]))
 
 (provide selection-text
          handle-mouse

--- a/tui/state-events/core-handlers.rkt
+++ b/tui/state-events/core-handlers.rkt
@@ -426,10 +426,13 @@
 ;; Handle spawn approval request from MAS spawn.
 ;; Sets active-overlay to 'approval-prompt so the TUI can collect
 ;; user input (y/n/Esc) and respond via approval-put!.
+;; v0.99.50 W2 (TMUX-04): Stores request-id in overlay extra for
+;; correlated exactly-once delivery.
 (define (handle-spawn-approval-requested state evt)
   (define payload (event-payload evt))
   (define capabilities (hash-ref payload 'capabilities '()))
   (define task-preview (hash-ref payload 'task-preview ""))
+  (define request-id (hash-ref payload 'request-id #f))
   (define caps-str
     (string-join (map (lambda (c)
                         (if (symbol? c)
@@ -449,18 +452,20 @@
           (plain-line (format "  Task: ~a" preview-str))
           (plain-line "")
           (plain-line "  [y] Approve   [n] Deny   [Esc] Cancel")))
-  ;; Store capabilities and task-preview in extra for key handler access.
-  (struct-copy ui-state
-               state
-               [active-overlay
-                (overlay-state 'approval-prompt
-                               content
-                               ""
-                               'top-left
-                               #f
-                               #f
-                               0
-                               (hasheq 'capabilities capabilities 'task-preview preview-str))]))
+  ;; Store capabilities, task-preview, and request-id in extra for key handler.
+  (struct-copy
+   ui-state
+   state
+   [active-overlay
+    (overlay-state
+     'approval-prompt
+     content
+     ""
+     'top-left
+     #f
+     #f
+     0
+     (hasheq 'capabilities capabilities 'task-preview preview-str 'request-id request-id))]))
 
 ;; ============================================================
 ;; Register all core handlers at module load time


### PR DESCRIPTION
## W2: Correlated Exactly-Once HITL Approvals (TMUX-04 approval path)

### Problem
The approval channel carried bare booleans with no request/response correlation. This permitted:
- Duplicate/replayed prompts
- Stale `#t` auto-approving new requests
- Cross-talk between concurrent spawn approval requests

### Fix
Added a correlated approval delivery API:
- Each request gets a unique `gensym` ID and a dedicated async-channel
- `approval-put-for-id!` atomically removes from registry before delivery (exactly-once)
- Thread-safe registry via semaphore
- Channel payload wrapped in `(list approved?)` to distinguish denial from timeout
- Legacy `approval-put!` preserved for backward compatibility

### Files Changed
- `tui/approval-channel.rkt` — New correlated API + registry
- `tools/builtins/spawn-subagent.rkt` — request-spawn-approval uses correlated path
- `tui/state-events/core-handlers.rkt` — Stores request-id in overlay extra
- `tui/selection.rkt` — Key handler uses approval-put-for-id! with fallback

### Verify
- [x] 15 new correlation tests pass
- [x] 41 existing approval tests pass (backward compat)
- [x] `rm -rf compiled/ && raco make main.rkt` PASS
- [x] `racket scripts/run-tests.rkt --suite smoke --profile local` 19/19 files, 287/287 tests PASS

Closes #8717
