### PR TITLE
feat(v0.99.50 W3): truthful tmux explorer and semantic evidence (#8718)

### DIFF
--- a/docs/reports/AUDIT-v0.99.44-FINAL.md
+++ b/docs/reports/AUDIT-v0.99.44-FINAL.md
@@ -5,6 +5,20 @@
 **Parent Issue:** #8613
 **Status:** ✅ COMPLETE
 
+> ## v0.99.50 Erratum (2026-07-13)
+>
+> The completion status above is a historical v0.99.44 milestone statement,
+> not current proof that real-provider exploration executed. The v0.99.44
+> explorer's `--mode real` path produced gated but synthetic/pending evidence;
+> it did not launch tmux, q, or a provider. The executable authorization
+> contract is `Q_TMUX_TUI_TESTS=1`, `Q_TMUX_TUI_REAL_PROVIDER=1`, and
+> `Q_TMUX_TUI_REAL_PROVIDER_CONFIRM=I_UNDERSTAND_COSTS`, plus an explicit
+> `Q_TMUX_TUI_REAL_PROVIDER_HOME` for the v0.99.50 executor. Historical claims
+> about universally redacted raw captures and selectable `tui-tmux` suites were
+> also inaccurate. See the corrected safety runbook and v0.99.50 semantic
+> executor/verifier tests. This erratum preserves rather than silently rewrites
+> the original audit evidence.
+
 ---
 
 ## 1. Executive Summary

--- a/docs/reports/TMUX-TUI-EXPLORATION-SAFETY-RUNBOOK-v0.99.44.md
+++ b/docs/reports/TMUX-TUI-EXPLORATION-SAFETY-RUNBOOK-v0.99.44.md
@@ -1,376 +1,217 @@
-# tmux TUI Exploration Safety Runbook — v0.99.44
+# tmux TUI Exploration Safety Runbook — v0.99.44 (v0.99.50 correction)
 
-**Date:** 2026-07-04
+**Original date:** 2026-07-04
+
+**Operational contract corrected:** 2026-07-13
 
 ## Overview
 
-This runbook documents the safety policies, test suite configuration, and
-operational procedures for running real-LLM tmux TUI exploration in the
-q-agent project. It covers the exploratory testing infrastructure delivered
-in v0.99.44 waves W0–W9.
+This runbook defines the executable safety contract for mock and explicit
+real-provider tmux TUI exploration. The v0.99.50 correction supersedes obsolete
+environment-variable, suite, redaction, and helper-field claims from the
+original v0.99.44 text.
 
----
+The governing rule is: **protocol evidence over plausible prose**. Prompt
+echoes, generic model text, stale events, and mock-provider output cannot make a
+real scenario PASS.
 
-## 1. Safety Policies
+## 1. Authorization and prerequisites
 
-### 1.1 Temp HOME Isolation
+Real mode requires all three acknowledgement gates with these exact values:
 
-All real-provider tmux TUI sessions MUST use a temporary HOME directory:
-
-```
-q-tmux-home-<timestamp>/
-  .q/
-    config.json       # copied from real config (bytes, never printed)
-    credentials.json  # copied from real credentials (bytes, never printed)
-  .config/...
+```text
+Q_TMUX_TUI_TESTS=1
+Q_TMUX_TUI_REAL_PROVIDER=1
+Q_TMUX_TUI_REAL_PROVIDER_CONFIRM=I_UNDERSTAND_COSTS
 ```
 
-**Violation:** Running `q --tui` with real `$HOME` while using real credentials.
+It also requires:
 
-**Enforcement:** `make-real-provider-tmux-env` in
-`tests/helpers/tmux-q-harness.rkt` creates the isolated environment and
-returns `tmux-env` with `temp-home` set. The `copy-q-config-to-temp-home!`
-helper copies config/credentials by bytes without printing contents.
+- `tmux` and `racket` on `PATH`;
+- an explicit source HOME in `Q_TMUX_TUI_REAL_PROVIDER_HOME`;
+- at least one recognized q file under that HOME's `.q/` directory:
+  `config.json`, `credentials.json`, or `config.rkt`.
 
-### 1.2 Credential Redaction
+The three acknowledgement variables authorize cost-bearing execution. They do
+**not** validate credentials or provider availability. The executor validates
+the source HOME and recognized q files before starting tmux.
 
-All captured text, trace summaries, and environment reports are redacted
-before being written to disk:
+No API key value belongs in a command argument, report, pane summary, or shell
+history. Legacy non-TUI opt-in/key variable names are not part of the
+executable contract.
 
-- Bearer tokens: `Authorization: Bearer sk-...` → `Authorization: Bearer <REDACTED>`
-- API keys: `sk-...` → `<REDACTED>`
-- Config file paths: real `$HOME` path replaced with `<HOME>`
-- Any `key=value` pairs with `key`, `token`, `secret`, `password` in key name
+## 2. Isolation and credential handling
 
-**Enforcement:** `redact-sensitive` handles bearer tokens, `sk-` API keys,
-`HOME` path substitution, and key-value patterns. `redact-explore-text`
-wraps all explorer report output.
+Every real execution creates a fresh workspace containing:
 
-### 1.3 Real-Provider Opt-In Gate
-
-Real-provider mode refuses to start unless ALL THREE conditions are met:
-
-1. `Q_TMUX_REAL_PROVIDER=1` — explicit opt-in
-2. `Q_TMUX_REAL_PROVIDER_KEY` — non-empty API key
-3. `Q_TMUX_REAL_PROVIDER_HOME` — HOME containing valid `.q/credentials.json`
-
-**Enforcement:** `real-provider-authorized?` checks all three env vars.
-`require-real-provider-authorization!` raises `exn:fail` if any are missing.
-
-### 1.4 No `tmux kill-server`
-
-Broad tmux cleanup (e.g., `tmux kill-server`) is FORBIDDEN. It would
-destroy unrelated user sessions. Only narrowly-named test sessions may be
-killed:
-
-```
-q-test-<scenario>     # OK to kill
-q-tmux-test-<tag>     # OK to kill
+```text
+q-tmux-real-<unique>/
+  home/                 # temporary HOME
+    .q/                 # recognized config copied without displaying contents
+  project/              # isolated fixture project
+  launch.sh             # contains paths and command only, never credential contents
 ```
 
-**Enforcement:** `stop-session!` kills only the named session via
-`tmux kill-session -t <name>`.
+The production executor in `scripts/tmux-explore/executor.rkt`:
 
-### 1.5 Mock/No-Network by Default
+1. creates the destination HOME and project;
+2. copies only recognized files from the explicit source HOME;
+3. starts one uniquely named `q-explore-*` tmux session;
+4. sends the registered scenario prompt;
+5. waits for structured `turn.completed` or `stream.turn.completed` evidence;
+6. writes only redacted capture/trace artifacts to the requested output root;
+7. uses `dynamic-wind` to stop the named session and delete the
+   copied-credential HOME on success, timeout, exception, and interruption.
 
-The default exploration mode is `mock` — no network access, no API
-credentials, no cost. Mock mode uses the mock worker provider.
+The older test helper `make-real-provider-tmux-env` returns a `tmux-env`; its
+actual HOME field accessor is `tmux-env-home`. Its companion
+`copy-q-config-to-temp-home!` is an explicit second step and may copy
+`config.json`, `credentials.json`, and `config.rkt`.
 
-**Enforcement:** `scripts/tmux-tui-explore.rkt` defaults to `--mode mock`.
-Real-provider mode requires explicit `--mode real`.
+## 3. Narrow tmux cleanup
 
----
+`tmux kill-server` is forbidden. Cleanup uses only:
 
-## 2. Test Suite Policy
-
-### 2.1 Suite Classification
-
-| Suite | Environment | tmux Tests | Real Provider | CI Default |
-|-------|-------------|------------|---------------|------------|
-| fast | Any | Excluded | Excluded | Yes |
-| smoke | Any | Excluded | Excluded | Yes |
-| full | Any | Excluded | Excluded | No |
-| tui-tmux | `Q_TMUX_TUI_TESTS=1` | Included | Excluded | No |
-| tui-tmux-real | `Q_TMUX_REAL_PROVIDER=1` | Included | Included | No |
-
-### 2.2 Annotations
-
-tmux test files carry these annotations:
-
-```racket
-;; @speed slow
-;; @suite tui-tmux
-;; @boundary e2e
+```text
+tmux kill-session -t <generated-q-explore-session>
 ```
 
-The `scripts/run-tests.rkt` test classifier recognizes these annotations
-and routes files to the correct suite. tmux test files are never included
-in fast, smoke, or full suites.
+The executor never enumerates and kills unrelated sessions. The generated
+session name is retained as non-secret metadata so cleanup and artifact review
+can be correlated.
 
-### 2.3 Test File Inventory
+## 4. Redaction and retained artifacts
 
-| File | Purpose | Tests |
-|------|---------|-------|
-| `tests/test-tmux-q-harness.rkt` | Pure unit tests for harness helpers | 149 |
-| `tests/test-tmux-tui-smoke.rkt` | T0/T1: Startup, prompt, quit | 5 |
-| `tests/test-tmux-tui-session-artifacts.rkt` | T2/T3: Session artifacts | 7 |
-| `tests/test-tmux-tui-commands.rkt` | C0-C4: Slash commands | 5 |
-| `tests/test-tmux-tui-resize-cleanup.rkt` | U1-U5: Resize, unicode, cleanup | 4 |
-| `tests/test-tmux-tui-context-memory.rkt` | X0/M0: Context and memory | 4 |
-| `tests/test-tmux-tui-gsd.rkt` | G0-G2: GSD planning | 3 |
-| `tests/test-tmux-tui-tools-approval.rkt` | A0-A3: Tools, approval | 3 |
-| `tests/test-tmux-tui-explore.rkt` | Explorer scenarios | 7 |
-| `tests/test-tmux-tui-report.rkt` | Report generator | 3 |
+`util/credential-redaction.rkt` is the canonical policy used by the explorer,
+harness, and report scanner. It avoids known false positives while retaining
+leak detection:
 
-### 2.4 Real-Provider Test Policy
+- `set-task-state` and `risk-score` are clean;
+- `Bearer authentication` is clean;
+- existing `<REDACTED>` placeholders are clean and idempotent;
+- realistic long `sk-` API keys, Bearer/JWT tokens, and key assignments are
+  redacted and detected;
+- a mixture of placeholders and a real secret still fails leak scanning.
 
-Real-provider tests are:
+Real executor artifacts are written outside the credential workspace:
 
-1. **Never default CI blockers** — they require explicit opt-in
-2. **Cost-bearing** — each run consumes API tokens
-3. **Credential-bearing** — real API keys are involved
-4. **Environment-specific** — results may vary by model/provider
-
-Real-provider test results should be classified as:
-
-| Classification | Meaning |
-|----------------|---------|
-| `pass` | Scenario completed with expected evidence |
-| `partial` | Some evidence found but incomplete |
-| `flake` | Intermittent pass/fail — needs investigation |
-| `fail` | Scenario failed deterministically |
-| `incomplete` | Not yet run with real provider |
-| `skip` | Intentionally skipped (unsupported) |
-
----
-
-## 3. Exploratory Testing Infrastructure
-
-### 3.1 Components
-
-```
-scripts/tmux-tui-explore.rkt       Official exploratory runner (mock/real)
-scripts/tmux-tui-smoke.rkt          Scenario smoke runner
-scripts/tmux-tui-report.rkt         Artifact report generator
-tests/helpers/tmux-q-harness.rkt    Reusable test harness (149 tests)
-tests/test-tmux-q-harness.rkt       Harness unit tests
-tests/test-tmux-tui-explore.rkt     Explorer unit tests
+```text
+<tag>-capture.txt       # redacted bounded pane capture
+<tag>-trace.jsonl       # redacted structured events
+<tag>-execution.txt     # session name, terminal status, event count
+<tag>-execution-error.txt  # redacted error text, when startup/execution fails
 ```
 
-### 3.2 Harness API Surface (W0–W9)
+The copied-credential HOME is deleted after artifacts are emitted. Historical
+`write-failure-artifacts!` output from the test harness is a different API: its
+raw capture is diagnostic and must not be assumed universally redacted. Never
+publish a retained artifact without running the report scanner.
 
-#### W2: Structured Turn Completion
-- `find-trace-jsonl-paths` — locate trace.jsonl files in session dirs
-- `read-trace-events` — parse JSONL entries
-- `turn-completion-trace-entry?` — predicate for completion events
-- `latest-turn-completion-event` — find latest completion event
-- `wait-for-turn-completion-event` — poll for completion with timeout
+## 5. Registered scenarios and semantic requirements
 
-#### W3: Real-Provider Safe Helpers
-- `real-provider-authorized?` — three-env-var gate check
-- `make-real-provider-tmux-env` — create isolated temp env
-- `copy-q-config-to-temp-home!` — copy config by bytes (no printing)
-- `send-prompt-and-wait!` — send prompt + wait for trace completion
-- `write-exploration-artifacts!` — write normalized capture + env summary
+The exact registered tags are:
 
-#### W4: Approval-Prompt Automation
-- `detect-approval-prompt` / `parse-approval-prompt` — detect and extract
-- `classify-approval-safety` — safe/dangerous/caution classification
-- `handle-approval-if-present!` — auto-approve safe, auto-deny dangerous
-- `approve-approval!` / `deny-approval!` — send y/n keys
+| Tag | Required structured evidence |
+|---|---|
+| `memory` | correlated retrieval event with result presence and terminal completion |
+| `gsd` | ordered attempted/succeeded transition with matching transition ID |
+| `mas` | matching approval, tool-call, child, result, turn, and terminal completion |
+| `tools` | ordered started/completed tool events with matching tool/call IDs and result |
+| `release-audit` | structured authorization-refused event and terminal completion |
+| `durable-memory` | ordered matching store, resume, retrieval, and completion lifecycle |
+| `resume` | matching resumed session/previous-session IDs and completion |
+| `compact` | terminal persisted compaction event with truthful before/after counts |
 
-#### W5: Tool-Execution Trace Verification
-- `tool-execution-phases` — 6 known tool event phases
-- `find-tool-execution-events` — scan traces for tool events
-- `parse-tool-events` — convert to tool-info structs
-- `compute-file-fingerprint` — len+sum fingerprint
-- `verify-file-unchanged!` — compare before/after fingerprints
-- `detect-sensitive-leak` / `verify-artifact-redacted!` — leak detection
+Every scenario verifier rejects missing traces, timeout, crash, mock-provider
+fallback, unrelated IDs, missing results, and absent terminal completion.
 
-#### W6: MAS/Subagent Lifecycle Evidence
-- `mas-lifecycle-phases` — 11 known MAS event phases
-- `find-mas-events` — scan traces for MAS events
-- `parse-spawn-approval-event` — extract spawn approval data
-- `parse-mas-lifecycle` — full lifecycle parse
-- `verify-subagent-spawn-lifecycle` — verify spawn→tool→complete chain
+Mock mode is deterministic and no-network. Its evidence is explicitly labeled
+mock and is never eligible for a real PASS.
 
-#### W7: Durable Memory Restart Round-Trip
-- `memory-event-phases` / `session-lifecycle-phases` — known phases
-- `find-memory-events` / `find-session-lifecycle-events` — scan traces
-- `parse-memory-store-event` / `parse-memory-retrieval-event` — extract data
-- `parse-session-start-event` — extract reason/prev-id/session-dir
-- `parse-durable-memory-roundtrip` — full lifecycle: store→restart→retrieve
-- `verify-durable-memory-roundtrip` — verify complete round-trip present
+## 6. Running the explorer
 
-#### W8: GSD Lifecycle and Release/Audit Truthfulness
-- `gsd-event-phases` — 16 known GSD event phases
-- `find-gsd-events` — scan traces for GSD events
-- `parse-gsd-transition-event` / `parse-gsd-wave-event` / `parse-gsd-plan-event`
-- `parse-gsd-lifecycle` — full lifecycle parse
-- `verify-gsd-transition-succeeded` — verify transition from→to
-- `release-refusal-patterns` — 7 known refusal phrases
-- `detect-release-authorization-refusal` — scan for refusal patterns
-- `find-release-manifest` / `verify-release-manifest-present!`
-- `verify-release-authorization-refused!` — assert refusal present
-
-#### W9: Flake Classification and Centralized Reporting
-- `flake-classifications` — 8 standard outcome categories
-- `flake-record` struct — per-scenario classification
-- `classify-result-status` — map status to classification
-- `flake-indicator-patterns` / `detect-flake-indicators` — flake text detection
-- `flaky-run?` — check if any record is flake-classified
-- `classify-exploration-run` — produce records from results
-- `central-log-entry` struct — structured log entry with counts
-- `make-central-log-entry` — aggregate records
-- `write-central-log-entry!` — append JSONL to log
-- `parse-central-log` — read JSONL entries
-- `exploration-bundle` struct — aggregated summary
-- `make-exploration-bundle` — create bundle with pass-rate
-- `render-bundle-index-markdown` — markdown summary table
-
-### 3.3 Explorer Scenarios
-
-| Tag | Title | Mock Status | Real Status |
-|-----|-------|-------------|-------------|
-| memory | Memory and Context Retention | pass | pending-real-run |
-| gsd | GSD Planning Lifecycle | pass | pending-real-run |
-| mas | MAS/Subagent Coordination | pass (caveat) | pending-real-run |
-| tools | Tool Execution and Approval | pass | pending-real-run |
-| release-audit | Release Authorization Audit | pass | pending-real-run |
-| durable-memory | Durable Memory Restart Round-Trip | partial | pending-real-run |
-
-### 3.4 Running the Explorer
+### Mock mode
 
 ```bash
-# Mock mode (default, no network, no cost)
-racket scripts/tmux-tui-explore.rkt
-
-# Real-provider mode (requires explicit opt-in)
-Q_TMUX_REAL_PROVIDER=1 \
-Q_TMUX_REAL_PROVIDER_KEY=$ANTHROPIC_API_KEY \
-Q_TMUX_REAL_PROVIDER_HOME=$HOME \
-racket scripts/tmux-tui-explore.rkt --mode real
-
-# List scenarios
+racket scripts/tmux-tui-explore.rkt --mode mock
+racket scripts/tmux-tui-explore.rkt --mode mock --filter tools
 racket scripts/tmux-tui-explore.rkt --list
-
-# Run specific scenario
-racket scripts/tmux-tui-explore.rkt --filter memory
 ```
 
-### 3.5 Centralized Log Protocol
+### Real mode: one cost-bounded scenario
 
-Exploration runs append structured JSONL entries to a central log:
-
-```json
-{"timestamp":"2026-07-04T12:00:00","run_id":"run-001","total":6,"pass":4,"partial":1,"fail":0,"flake":0,"skip":0,"incomplete":1,"mode":"mock"}
+```bash
+Q_TMUX_TUI_TESTS=1 \
+Q_TMUX_TUI_REAL_PROVIDER=1 \
+Q_TMUX_TUI_REAL_PROVIDER_CONFIRM=I_UNDERSTAND_COSTS \
+Q_TMUX_TUI_REAL_PROVIDER_HOME="$HOME" \
+racket scripts/tmux-tui-explore.rkt --mode real --filter tools
 ```
 
-The log enables:
-- Historical trend tracking across runs
-- Pass-rate evolution over time
-- Flake detection and classification
-- Bundle-level summary generation
+If any selected real scenario is not PASS, the command exits nonzero. For a
+manual diagnostic run that should retain reports without acting as a gate, add
+the explicit `--non-gating` option:
 
----
-
-## 4. Known Limitations
-
-### 4.1 Model Turn Completion Signal
-
-The visible `q>` prompt is NOT a reliable model-turn completion signal.
-The TUI may show `q>` while the model is still thinking or streaming.
-
-**Mitigation:** Use `trace.jsonl` `turn.completed` or
-`stream.turn.completed` events instead. The harness provides
-`wait-for-turn-completion-event` for this purpose.
-
-### 4.2 Queued Prompts
-
-If automation sends prompts too early (before the model finishes), the
-TUI queues them. This produces `[Queued — will run after current task]`.
-
-**Mitigation:** Always wait for turn completion events before sending the
-next prompt. Use `assert-no-queued-prompts!` to verify.
-
-### 4.3 Sentinel Echo and Wrapping
-
-Sentinel text may appear in echoed prompts. Pane capture may truncate or
-wrap markers. This causes false-positive and false-negative matches.
-
-**Mitigation:** Use structured trace evidence (trace.jsonl events) rather
-than visible text matching. Redact and normalize captures before comparison.
-
-### 4.4 Pane Capture Truncation
-
-tmux pane capture may truncate long outputs, losing evidence at the
-bottom of the scrollback.
-
-**Mitigation:** Use `capture-pane -p -S -` (full scrollback) and
-normalize before matching. For critical evidence, rely on trace.jsonl
-events rather than pane text.
-
----
-
-## 5. Failure Artifact Handling
-
-When a scenario fails, the harness saves diagnostic artifacts:
-
-```
-/var/tmp/q-tmux-art-<timestamp>/
-  raw-capture.txt            # Full pane with ANSI escapes
-  normalized-capture.txt     # Stripped/normalized output
-  env-summary.txt            # Command line, env (redacted)
-  temp-tree.txt              # Directory listing of temp dirs
-  trace-summary.txt          # Trace event summary (W3+)
-  reason.txt                 # Failure reason (if present)
+```bash
+racket scripts/tmux-tui-explore.rkt --mode real --filter tools --non-gating
 ```
 
-**Retained success dirs:** Empty `q-tmux-art-*` directories without
-`reason.txt` are classified as `retained-success-dir`, not failures.
+Authorization variables are still required with `--non-gating`.
 
-Generate a report from artifacts:
+## 7. Test suite policy
+
+There is no selectable `tui-tmux` or `tui-tmux-real` suite in
+`scripts/run-tests.rkt`. Relevant executable suite commands are:
+
+```bash
+racket scripts/run-tests.rkt --suite fast
+racket scripts/run-tests.rkt --suite smoke --profile local
+racket scripts/run-tests.rkt --suite tui
+```
+
+`Q_TMUX_TUI_TESTS=1` controls whether opt-in tmux scenarios execute; it is not a
+suite selector. Slow/e2e metadata controls normal test inventory selection.
+Real-provider exploration remains manual and is not a default CI blocker.
+
+Focused W3 gates:
+
+```bash
+raco test tests/test-secret-redaction.rkt
+raco test tests/test-tmux-tui-explore.rkt tests/test-tmux-explore-verifiers.rkt
+raco test tests/test-tmux-explore-executor.rkt tests/test-tmux-q-harness.rkt
+raco test tests/test-tmux-tui-report.rkt tests/test-tmux-real-provider-docs.rkt
+Q_TMUX_TUI_TESTS=1 racket scripts/tmux-tui-smoke.rkt
+```
+
+## 8. Evidence and failure interpretation
+
+The visible `q>` prompt is readiness evidence, not turn-completion evidence.
+The executor waits for structured completion in `trace.jsonl`. Pane text is
+retained only as supporting, redacted evidence.
+
+A real result is non-PASS when any of the following occurs:
+
+- startup or provider failure;
+- timeout or session crash;
+- missing/malformed trace;
+- mock-provider fallback;
+- no correlated scenario lifecycle;
+- mismatched turn, sequence, approval, tool-call, child, session, or result ID;
+- no terminal completion.
+
+Use the report scanner for retained harness bundles:
 
 ```bash
 racket scripts/tmux-tui-report.rkt
 racket scripts/tmux-tui-report.rkt --dir /path/to/artifacts
 ```
 
----
+Explorer `--append-log` appends a Markdown ledger. Harness centralized logging
+is a separate JSONL protocol; the two formats must not be conflated.
 
-## 6. CI Integration Recommendations
+## 9. CI policy
 
-### 6.1 Current State
-
-tmux tests are NOT included in CI fast/smoke/full suites. They are opt-in
-only via `Q_TMUX_TUI_TESTS=1`.
-
-### 6.2 Recommended Nightly Job
-
-```yaml
-# .github/workflows/tmux-tui-nightly.yml (future)
-name: tmux TUI Nightly
-on:
-  schedule:
-    - cron: '0 4 * * *'  # 4 AM UTC daily
-jobs:
-  tmux-tui:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/setup-racket
-      - run: sudo apt-get install -y tmux
-      - run: Q_TMUX_TUI_TESTS=1 racket scripts/tmux-tui-smoke.rkt
-      - run: racket scripts/tmux-tui-explore.rkt --mode mock
-      - run: racket scripts/tmux-tui-report.rkt
-```
-
-### 6.3 Real-Provider CI
-
-Real-provider tests should NOT run in CI due to:
-- API cost per run
-- Credential exposure risk
-- Model/provider variability
-
-Real-provider exploration should be run manually with the safety
-procedures in this runbook.
+Mock/focused tests may run in CI. Real-provider exploration should remain an
+explicit manual operation because it is cost-bearing, credential-bearing, and
+provider-variable. Never store copied credentials, raw credential-bearing pane
+captures, or a temporary real-provider HOME as CI artifacts.

--- a/runtime/tool-coordinator.rkt
+++ b/runtime/tool-coordinator.rkt
@@ -280,21 +280,38 @@
                                                          (scheduler-result-results sched-result))
                                   'count
                                   (length tool-calls-to-run))))
-  ;; G13: Emit typed tool-execution-end events
+  ;; G13: Emit typed tool-execution-end events.
+  ;; v0.99.50 W3: Also emit a correlated protocol record because the v1 typed
+  ;; end-event schema predates tool-call identity and cannot be changed without
+  ;; breaking its public/red-module contract.
   (for ([tc (in-list tool-calls-to-run)]
         [tr (in-list (scheduler-result-results sched-result))])
+    (define duration-ms
+      (inexact->exact (floor (- (current-inexact-milliseconds)
+                                (hash-ref per-tool-start-ms (tool-call-id tc) batch-start-ms)))))
+    (define result-summary (if (tool-result-is-error? tr) 'error 'completed))
     (emit-typed-event! bus
                        (make-tool-execution-end-event
                         #:session-id session-id
                         #:turn-id #f
                         #:timestamp (current-inexact-milliseconds)
                         #:tool-name (tool-call-name tc)
-                        #:duration-ms (inexact->exact (floor (- (current-inexact-milliseconds)
-                                                                (hash-ref per-tool-start-ms
-                                                                          (tool-call-id tc)
-                                                                          batch-start-ms))))
-                        #:result-summary (if (tool-result-is-error? tr) 'error 'completed)
-                        #:result-error (and (tool-result-is-error? tr) (tool-result-error-text tr)))))
+                        #:duration-ms duration-ms
+                        #:result-summary result-summary
+                        #:result-error (and (tool-result-is-error? tr) (tool-result-error-text tr))))
+    (emit-session-event! bus
+                         session-id
+                         "tool.execution.correlated-completed"
+                         (hasheq 'tool-name
+                                 (tool-call-name tc)
+                                 'tool-call-id
+                                 (tool-call-id tc)
+                                 'duration-ms
+                                 duration-ms
+                                 'result-present?
+                                 #t
+                                 'result-summary
+                                 result-summary)))
   sched-result)
 
 ;; Helper: extract error text from tool-result content for event propagation.

--- a/scripts/tmux-explore/executor.rkt
+++ b/scripts/tmux-explore/executor.rkt
@@ -1,0 +1,343 @@
+#lang racket/base
+
+;; scripts/tmux-explore/executor.rkt — Truthful isolated real tmux executor
+;;
+;; v0.99.50 W3 (TMUX-03): Real mode must launch an actual q TUI in a uniquely
+;; named tmux session, observe structured trace completion, retain only
+;; redacted artifacts, and delete the copied-credential workspace on every
+;; exit path. This module deliberately does not import test helpers.
+
+(require json
+         racket/file
+         racket/list
+         racket/path
+         racket/port
+         racket/runtime-path
+         racket/string
+         racket/system
+         "../../util/credential-redaction.rkt")
+
+(provide call-with-executor-cleanup
+         run-real-scenario)
+
+(define-runtime-path q-root "../..")
+
+(define config-file-names '("config.json" "credentials.json" "config.rkt"))
+(define completion-phases '("turn.completed" "stream.turn.completed"))
+
+(define (call-with-executor-cleanup workspace
+                                    session-name
+                                    thunk
+                                    #:stop-session [stop-session (lambda (_name) (void))])
+  (dynamic-wind void
+                thunk
+                (lambda ()
+                  ;; Capture stop failure, still remove credential files, then fail loudly.
+                  (define stop-error #f)
+                  (when session-name
+                    (with-handlers ([exn:fail? (lambda (error) (set! stop-error error))])
+                      (stop-session session-name)))
+                  (when (directory-exists? workspace)
+                    (delete-directory/files workspace))
+                  (when stop-error
+                    (raise stop-error)))))
+
+(define (command-output executable . args)
+  (define-values (process stdout stdin stderr) (apply subprocess #f #f #f executable args))
+  (close-output-port stdin)
+  ;; Drain both pipes concurrently so a verbose child cannot deadlock while
+  ;; one pipe waits for EOF and the other fills its OS buffer.
+  (define output-box (box ""))
+  (define error-box (box ""))
+  (define output-reader (thread (lambda () (set-box! output-box (port->string stdout)))))
+  (define error-reader (thread (lambda () (set-box! error-box (port->string stderr)))))
+  (subprocess-wait process)
+  (thread-wait output-reader)
+  (thread-wait error-reader)
+  (values (subprocess-status process) (unbox output-box) (unbox error-box)))
+
+(define (command-success? executable . args)
+  (define-values (status _output _error) (apply command-output executable args))
+  (zero? status))
+
+(define (shell-quote value)
+  (string-append "'" (string-replace (format "~a" value) "'" "'\"'\"'") "'"))
+
+(define (environment-timeout-ms)
+  (define raw (getenv "Q_TMUX_TUI_EXPLORER_TIMEOUT_MS"))
+  (define parsed (and raw (string->number raw)))
+  (if (and (exact-integer? parsed) (positive? parsed)) parsed 120000))
+
+(define (source-home-path)
+  (define raw (getenv "Q_TMUX_TUI_REAL_PROVIDER_HOME"))
+  (unless (and raw (not (string=? (string-trim raw) "")))
+    (error 'tmux-tui-explore
+           "real mode requires Q_TMUX_TUI_REAL_PROVIDER_HOME naming an explicit source HOME"))
+  (define path (path->complete-path raw))
+  (unless (directory-exists? path)
+    (error 'tmux-tui-explore "real-provider source HOME does not exist: ~a" path))
+  path)
+
+(define (copy-recognized-config! source-home destination-home)
+  (define source-q (build-path source-home ".q"))
+  (define destination-q (build-path destination-home ".q"))
+  (make-directory* destination-q)
+  (define copied
+    (for/list ([name (in-list config-file-names)]
+               #:when (file-exists? (build-path source-q name)))
+      (copy-file (build-path source-q name) (build-path destination-q name) #t)
+      name))
+  (when (null? copied)
+    (error
+     'tmux-tui-explore
+     "source HOME has none of the recognized q config files: config.json, credentials.json, config.rkt"))
+  copied)
+
+(define (delete-copied-config! destination-home copied)
+  (for ([name (in-list copied)])
+    (define path (build-path destination-home ".q" name))
+    (when (file-exists? path)
+      (delete-file path))))
+
+(define (safe-tag tag)
+  (regexp-replace* #px"[^A-Za-z0-9_.-]+" tag "-"))
+
+(define (write-launcher! path home project tools?)
+  (call-with-output-file
+   path
+   (lambda (out)
+     (define racket-path
+       (path->string (or (find-executable-path "racket")
+                         (error 'tmux-tui-explore "racket executable not found"))))
+     (define safe-path (or (getenv "PATH") "/usr/bin:/bin"))
+     (fprintf out "#!/bin/sh~n")
+     (fprintf out "cd ~a~n" (shell-quote (path->string project)))
+     ;; env -i prevents inherited provider keys and unrelated secrets from
+     ;; entering q or tool subprocesses. Provider auth comes from temp HOME.
+     (fprintf out
+              "exec env -i HOME=~a TERM=xterm-256color PATH=~a LANG=C.UTF-8 ~a ~a --tui~a~n"
+              (shell-quote (path->string home))
+              (shell-quote safe-path)
+              (shell-quote racket-path)
+              (shell-quote (path->string (build-path q-root "main.rkt")))
+              (if tools? "" " --no-tools")))
+   #:exists 'replace)
+  path)
+
+(define (tmux-session-alive? tmux server-name session-name)
+  (command-success? tmux "-L" server-name "has-session" "-t" session-name))
+
+(define (stop-tmux-session! tmux server-name session-name)
+  ;; A private -L server plus exact -t target prevents collision with user tmux.
+  (when (tmux-session-alive? tmux server-name session-name)
+    (unless (command-success? tmux "-L" server-name "kill-session" "-t" session-name)
+      (error 'tmux-tui-explore "failed to stop owned tmux session"))
+    (when (tmux-session-alive? tmux server-name session-name)
+      (error 'tmux-tui-explore "owned tmux session remained alive after cleanup")))
+  (void))
+
+(define (capture-pane tmux server-name session-name)
+  (define-values (status output _error)
+    (command-output tmux "-L" server-name "capture-pane" "-p" "-t" session-name "-S" "-200"))
+  (if (zero? status) output ""))
+
+(define (send-line! tmux server-name session-name text)
+  (unless (command-success? tmux "-L" server-name "send-keys" "-t" session-name "-l" text)
+    (error 'tmux-tui-explore "failed to send scenario prompt"))
+  (unless (command-success? tmux "-L" server-name "send-keys" "-t" session-name "Enter")
+    (error 'tmux-tui-explore "failed to submit scenario prompt")))
+
+(define (wait-until predicate timeout-ms [poll-ms 250])
+  (define deadline (+ (current-inexact-milliseconds) timeout-ms))
+  (let loop ()
+    (cond
+      [(predicate) #t]
+      [(>= (current-inexact-milliseconds) deadline) #f]
+      [else
+       (sleep (/ poll-ms 1000.0))
+       (loop)])))
+
+(define (trace-paths sessions-root)
+  (if (directory-exists? sessions-root)
+      (for/list ([path (in-directory sessions-root)]
+                 #:when (and (file-exists? path)
+                             (equal? (path->string (file-name-from-path path)) "trace.jsonl")))
+        path)
+      '()))
+
+(define (read-json-line line)
+  (with-handlers ([exn:fail? (lambda (_error) #f)])
+    (string->jsexpr line)))
+
+(define (read-trace-events sessions-root)
+  (append* (for/list ([path (in-list (sort (trace-paths sessions-root) path<?))])
+             (with-handlers ([exn:fail? (lambda (_error) '())])
+               (filter hash?
+                       (for/list ([line (in-list (file->lines path))]
+                                  #:unless (string=? (string-trim line) ""))
+                         (read-json-line line)))))))
+
+(define (event-phase event)
+  (define raw
+    (or (hash-ref event 'phase #f)
+        (hash-ref event "phase" #f)
+        (hash-ref event 'event #f)
+        (hash-ref event "event" "")))
+  (string-downcase (format "~a" raw)))
+
+(define (completion-event? event)
+  (member (event-phase event) completion-phases))
+
+(define (trace-text events)
+  (with-output-to-string (lambda ()
+                           (for ([event (in-list events)])
+                             (write-json event)
+                             (newline)))))
+
+(define (mock-provider-observed? capture events)
+  (regexp-match? #px"(?i:mock response|mock-provider|mock_provider)"
+                 (string-append capture "\n" (trace-text events))))
+
+(define (write-redacted-artifacts! output-root tag session-name status capture events)
+  (make-directory* output-root)
+  (define prefix (safe-tag tag))
+  (define capture-path (build-path output-root (format "~a-capture.txt" prefix)))
+  (define trace-path (build-path output-root (format "~a-trace.jsonl" prefix)))
+  (define metadata-path (build-path output-root (format "~a-execution.txt" prefix)))
+  (call-with-output-file capture-path
+                         (lambda (out) (display (redact-secrets capture) out))
+                         #:exists 'replace)
+  (call-with-output-file trace-path
+                         (lambda (out) (display (redact-secrets (trace-text events)) out))
+                         #:exists 'replace)
+  (call-with-output-file
+   metadata-path
+   (lambda (out)
+     (fprintf out "session=~a~nstatus=~a~ntrace-events=~a~n" session-name status (length events)))
+   #:exists 'replace)
+  (path->string metadata-path))
+
+(define (failed-observation output-root tag session-name message)
+  (make-directory* output-root)
+  (define path (build-path output-root (format "~a-execution-error.txt" (safe-tag tag))))
+  (call-with-output-file path (lambda (out) (display (redact-secrets message) out)) #:exists 'replace)
+  (hash 'status
+        'failed
+        'trace-events
+        '()
+        'capture
+        ""
+        'mock-provider?
+        #f
+        'timed-out?
+        #f
+        'crashed?
+        #t
+        'artifact-path
+        (path->string path)
+        'session-name
+        session-name))
+
+;; Launch one real scenario. The returned observation is intentionally raw
+;; protocol evidence; scripts/tmux-explore/verifiers.rkt owns PASS/FAIL.
+(define (run-real-scenario tag prompt output-root #:tools? [tools? #f])
+  (define tmux
+    (or (find-executable-path "tmux")
+        (error 'tmux-tui-explore "tmux executable is required for real mode")))
+  (define source-home (source-home-path))
+  (define workspace (make-temporary-file "q-tmux-real-~a" 'directory))
+  (define destination-home (build-path workspace "home"))
+  (define project (build-path workspace "project"))
+  (define sessions-root (build-path destination-home ".q" "sessions"))
+  (define launcher (build-path workspace "launch.sh"))
+  (define unique-suffix
+    (format "~a-~a" (inexact->exact (floor (current-inexact-milliseconds))) (random 1000000)))
+  (define server-name (format "q-explore-server-~a" unique-suffix))
+  (define session-name (format "q-explore-~a" unique-suffix))
+  (with-handlers ([exn:fail?
+                   (lambda (error)
+                     (failed-observation output-root tag session-name (exn-message error)))])
+    (call-with-executor-cleanup
+     workspace
+     session-name
+     (lambda ()
+       (make-directory* destination-home)
+       (make-directory* project)
+       (define copied (copy-recognized-config! source-home destination-home))
+       (call-with-output-file (build-path project "README.md")
+                              (lambda (out)
+                                (display "# Explorer Fixture\n\nREADME_FIXTURE_ALPHA\n" out))
+                              #:exists 'replace)
+       (write-launcher! launcher destination-home project tools?)
+       (unless (command-success? tmux
+                                 "-L"
+                                 server-name
+                                 "-f"
+                                 "/dev/null"
+                                 "new-session"
+                                 "-d"
+                                 "-s"
+                                 session-name
+                                 "-x"
+                                 "100"
+                                 "-y"
+                                 "30"
+                                 "-c"
+                                 (path->string project)
+                                 (format "/bin/sh ~a" (shell-quote (path->string launcher))))
+         (error 'tmux-tui-explore "failed to start named tmux q session"))
+       (define ready?
+         (wait-until (lambda ()
+                       (and (tmux-session-alive? tmux server-name session-name)
+                            (string-contains? (capture-pane tmux server-name session-name) "q>")))
+                     30000))
+       (unless ready?
+         (error 'tmux-tui-explore "q TUI did not become ready in the named tmux session"))
+       ;; Read-only tools are auto-approved. Remove every copied config or
+       ;; credential file before a tool-capable prompt. If provider setup was
+       ;; lazy and this makes the turn fail, the result truthfully remains FAIL.
+       (when tools?
+         (delete-copied-config! destination-home copied))
+       (define baseline-count (length (read-trace-events sessions-root)))
+       (send-line! tmux server-name session-name prompt)
+       (define timeout-ms (environment-timeout-ms))
+       (define completed?
+         (wait-until (lambda ()
+                       (define all-events (read-trace-events sessions-root))
+                       (and (> (length all-events) baseline-count)
+                            (findf completion-event? (drop all-events baseline-count))))
+                     timeout-ms))
+       (define all-events (read-trace-events sessions-root))
+       (define events
+         (if (>= (length all-events) baseline-count)
+             (drop all-events baseline-count)
+             '()))
+       (define alive? (tmux-session-alive? tmux server-name session-name))
+       (define capture (capture-pane tmux server-name session-name))
+       (define status
+         (cond
+           [completed? 'completed]
+           [alive? 'timed-out]
+           [else 'failed]))
+       (define mock? (mock-provider-observed? capture events))
+       (define artifact-path
+         (write-redacted-artifacts! output-root tag session-name status capture events))
+       (hash 'status
+             status
+             'trace-events
+             events
+             'capture
+             capture
+             'provider-confirmed?
+             (and completed? (not mock?))
+             'mock-provider?
+             mock?
+             'timed-out?
+             (eq? status 'timed-out)
+             'crashed?
+             (and (not alive?) (not completed?))
+             'artifact-path
+             artifact-path
+             'session-name
+             session-name))
+     #:stop-session (lambda (name) (stop-tmux-session! tmux server-name name)))))

--- a/scripts/tmux-explore/verifiers.rkt
+++ b/scripts/tmux-explore/verifiers.rkt
@@ -1,0 +1,282 @@
+#lang racket/base
+
+;; scripts/tmux-explore/verifiers.rkt — Scenario-specific semantic evidence
+;;
+;; v0.99.50 W3 (TMUX-09): A real explorer result is PASS only when structured
+;; lifecycle evidence is correlated. Pane prose, prompt echoes, generic mock
+;; responses, stale events, and unrelated IDs are insufficient.
+
+(require racket/list
+         racket/string)
+
+(provide required-scenario-tags
+         (struct-out verification-result)
+         verify-scenario-evidence)
+
+(define required-scenario-tags
+  '("memory" "gsd" "mas" "tools" "release-audit" "durable-memory" "resume" "compact"))
+
+(struct verification-result (passed? status reasons evidence) #:transparent)
+
+(define absent (gensym 'absent))
+
+(define (key-candidates key)
+  (define s
+    (if (symbol? key)
+        (symbol->string key)
+        key))
+  (remove-duplicates (list key
+                           s
+                           (string->symbol s)
+                           (string->symbol (string-replace s "-" "_"))
+                           (string-replace s "-" "_")
+                           (string->symbol (string-replace s "_" "-"))
+                           (string-replace s "_" "-"))))
+
+(define (hash-ref-any h keys [default #f])
+  (if (not (hash? h))
+      default
+      (let loop ([remaining keys])
+        (cond
+          [(null? remaining) default]
+          [else
+           (define found
+             (for/or ([candidate (in-list (key-candidates (car remaining)))])
+               (define value (hash-ref h candidate absent))
+               (and (not (eq? value absent)) (cons #t value))))
+           (if found
+               (cdr found)
+               (loop (cdr remaining)))]))))
+
+(define (event-data event)
+  (hash-ref-any event '(data payload details) (hash)))
+
+(define (event-field event keys [default #f])
+  (define top (hash-ref-any event keys absent))
+  (if (eq? top absent)
+      (hash-ref-any (event-data event) keys default)
+      top))
+
+(define (event-phase event)
+  (define phase (event-field event '(phase event type) ""))
+  (string-downcase (format "~a" phase)))
+
+(define (event-turn event)
+  (event-field event '(turn-id turnId turn sequence-id sequenceId) #f))
+
+(define (event-session event)
+  (event-field event '(session-id sessionId) #f))
+
+(define completion-phases '("turn.completed" "stream.turn.completed"))
+
+(define (completion-event? event)
+  (and (member (event-phase event) completion-phases)
+       (not (member (string-downcase (format "~a" (event-field event '(reason status) "completed")))
+                    '("error" "failed" "cancelled" "canceled")))))
+
+(define (phase=? event phase)
+  (string=? (event-phase event) phase))
+
+(define (events-with-phase events phase)
+  (filter (lambda (event) (phase=? event phase)) events))
+
+(define (same-value? a b)
+  (and a b (equal? (format "~a" a) (format "~a" b))))
+
+(define (truthy? value)
+  (and (or (eq? value #t)
+           (member (string-downcase (format "~a" value)) '("true" "yes" "present" "approved")))
+       #t))
+
+(define (correlated-to-completion? event completion)
+  (define event-turn-id (event-turn event))
+  (and (same-value? (event-session event) (event-session completion))
+       (or (not event-turn-id) (same-value? event-turn-id (event-turn completion)))))
+
+(define (index-of-event events target)
+  (for/first ([event (in-list events)]
+              [index (in-naturals)]
+              #:when (eq? event target))
+    index))
+
+(define (ordered? events . targets)
+  (define indexes (map (lambda (target) (index-of-event events target)) targets))
+  (and (andmap exact-nonnegative-integer? indexes)
+       (for/and ([a (in-list indexes)]
+                 [b (in-list (cdr indexes))])
+         (< a b))))
+
+(define (verify-memory events completion)
+  (for/or ([event (in-list (events-with-phase events "memory.retrieval.performed"))])
+    (define count (event-field event '(result-count resultCount) 0))
+    (and (correlated-to-completion? event completion)
+         (or (and (exact-nonnegative-integer? count) (positive? count))
+             (truthy? (event-field event '(result-present? result-present found?) #f)))
+         (ordered? events event completion))))
+
+(define (verify-gsd events completion)
+  (for*/or ([attempt (in-list (events-with-phase events "gsd.transition.attempted"))]
+            [success (in-list (events-with-phase events "gsd.transition.succeeded"))])
+    (define attempt-id (event-field attempt '(transition-id transitionId plan-id)))
+    (define success-id (event-field success '(transition-id transitionId plan-id)))
+    (define matching-transition?
+      (if (and attempt-id success-id)
+          (same-value? attempt-id success-id)
+          (and (same-value? (event-field attempt '(from)) (event-field success '(from)))
+               (same-value? (event-field attempt '(to)) (event-field success '(to))))))
+    (and (correlated-to-completion? attempt completion)
+         (correlated-to-completion? success completion)
+         matching-transition?
+         (ordered? events attempt success completion))))
+
+(define (verify-tools events completion [required-tool #f])
+  (for*/or ([started (in-list (events-with-phase events "tool.execution.started"))]
+            [completed (in-list (events-with-phase events "tool.execution.correlated-completed"))])
+    (define started-name (event-field started '(tool-name toolName name)))
+    (define completed-name (event-field completed '(tool-name toolName name)))
+    (and (correlated-to-completion? started completion)
+         (correlated-to-completion? completed completion)
+         (same-value? (event-field started '(tool-call-id toolCallId call-id))
+                      (event-field completed '(tool-call-id toolCallId call-id)))
+         (same-value? started-name completed-name)
+         (or (not required-tool)
+             (string=? (string-downcase (format "~a" started-name)) required-tool))
+         (truthy? (event-field completed '(result-present? result-present has-result?) #f))
+         (string=? (string-downcase (format "~a" (event-field completed '(result-summary status))))
+                   "completed")
+         (ordered? events started completed completion))))
+
+(define (verify-mas events completion-event)
+  (for*/or ([request (in-list (events-with-phase events "mas.spawn-approval-requested"))]
+            [decision (in-list (events-with-phase events "mas.spawn-approval-decided"))]
+            [completed (in-list (events-with-phase events "tool.execution.correlated-completed"))])
+    (define approval-id (event-field request '(approval-id request-id approvalId)))
+    (define call-id (event-field request '(tool-call-id toolCallId call-id)))
+    (and (correlated-to-completion? request completion-event)
+         (correlated-to-completion? decision completion-event)
+         (correlated-to-completion? completed completion-event)
+         (event-field request '(child-id childId))
+         (same-value? approval-id (event-field decision '(approval-id request-id approvalId)))
+         (same-value? call-id (event-field decision '(tool-call-id toolCallId call-id)))
+         (same-value? call-id (event-field completed '(tool-call-id toolCallId call-id)))
+         (string=? (string-downcase (format "~a" (event-field decision '(decision status))))
+                   "approved")
+         (truthy? (event-field completed '(result-present? result-present has-result?) #f))
+         (ordered? events request decision completed completion-event))))
+
+(define (verify-release-audit events completion)
+  (for/or ([event (in-list (events-with-phase events "release.authorization.refused"))])
+    (and (correlated-to-completion? event completion)
+         (eq? (event-field event '(authorized? authorized) #t) #f)
+         (event-field event '(reason code))
+         (ordered? events event completion))))
+
+(define (resume-start? event)
+  (and (phase=? event "session.started")
+       (string=? (string-downcase (format "~a" (event-field event '(reason mode)))) "resume")
+       (event-field event '(session-id sessionId))
+       (event-field event '(previous-session-id previousSessionId))))
+
+(define (verify-durable-memory events completion)
+  (for*/or ([stored (in-list (events-with-phase events "memory.item.stored"))]
+            [started (in-list (filter resume-start? events))]
+            [retrieved (in-list (events-with-phase events "memory.retrieval.performed"))])
+    (and (correlated-to-completion? retrieved completion)
+         (same-value? (event-field stored '(memory-id item-id id))
+                      (event-field retrieved '(memory-id item-id id)))
+         (same-value? (event-field started '(session-id sessionId))
+                      (event-field retrieved '(session-id sessionId)))
+         (truthy? (event-field retrieved '(result-present? result-present found?) #f))
+         (ordered? events stored started retrieved completion))))
+
+(define (verify-resume events completion)
+  (for*/or ([started (in-list (filter resume-start? events))]
+            [resumed (in-list (events-with-phase events "session.resumed"))])
+    (and (correlated-to-completion? resumed completion)
+         (same-value? (event-field started '(session-id sessionId))
+                      (event-field resumed '(session-id sessionId)))
+         (same-value? (event-field started '(previous-session-id previousSessionId))
+                      (event-field resumed '(previous-session-id previousSessionId)))
+         (ordered? events started resumed completion))))
+
+(define (verify-compact events completion)
+  (for/or ([event (in-list (events-with-phase events "session.compact.completed"))])
+    (define removed (event-field event '(removed-count removedCount) #f))
+    (define kept (event-field event '(kept-count keptCount) #f))
+    (define before
+      (or
+       (event-field event '(before-count beforeCount original-count) #f)
+       (and (exact-nonnegative-integer? removed) (exact-nonnegative-integer? kept) (+ removed kept))))
+    (define after (or (event-field event '(after-count afterCount compacted-count) #f) kept))
+    (and (correlated-to-completion? event completion)
+         (exact-nonnegative-integer? before)
+         (exact-nonnegative-integer? after)
+         (<= after before)
+         (truthy? (event-field event '(persisted? durable?) #f))
+         (ordered? events event completion))))
+
+(define (scenario-semantic-pass? tag events completion)
+  (case (string->symbol tag)
+    [(memory) (verify-memory events completion)]
+    [(gsd) (verify-gsd events completion)]
+    [(mas) (verify-mas events completion)]
+    [(tools) (verify-tools events completion)]
+    [(release-audit) (verify-release-audit events completion)]
+    [(durable-memory) (verify-durable-memory events completion)]
+    [(resume) (verify-resume events completion)]
+    [(compact) (verify-compact events completion)]
+    [else #f]))
+
+(define (verify-scenario-evidence tag observation)
+  (cond
+    [(not (member tag required-scenario-tags))
+     (verification-result #f 'unsupported (list "unregistered scenario tag") '())]
+    [(not (hash? observation))
+     (verification-result #f 'fail (list "executor returned no observation") '())]
+    [else
+     (define status (hash-ref-any observation '(status) 'failed))
+     (define events (hash-ref-any observation '(trace-events traceEvents) '()))
+     (define blockers
+       (filter values
+               (list (and (not (eq? status 'completed)) (format "terminal status is ~a" status))
+                     (and (truthy? (hash-ref-any observation '(timed-out?) #f)) "execution timed out")
+                     (and (truthy? (hash-ref-any observation '(crashed?) #f)) "session crashed")
+                     (and (truthy? (hash-ref-any observation '(mock-provider?) #f))
+                          "mock-provider fallback observed")
+                     (and (not (truthy? (hash-ref-any observation '(provider-confirmed?) #f)))
+                          "non-mock provider execution is not positively confirmed")
+                     (and (not (and (list? events) (pair? events))) "structured trace is missing"))))
+     (define completion (and (list? events) (findf completion-event? (reverse events))))
+     (define turn-id (and completion (event-turn completion)))
+     (define reasons
+       (append blockers
+               (if completion
+                   '()
+                   (list "terminal completion event is missing"))
+               (if (and completion turn-id)
+                   '()
+                   (list "completion turn ID is missing"))
+               (if (and completion (event-session completion))
+                   '()
+                   (list "completion session ID is missing"))))
+     (cond
+       [(pair? reasons)
+        (verification-result #f
+                             'fail
+                             reasons
+                             (list (cons 'trace-event-count
+                                         (if (list? events)
+                                             (length events)
+                                             0))))]
+       [(scenario-semantic-pass? tag events completion)
+        (verification-result #t
+                             'pass
+                             '()
+                             (list (cons 'turn-id turn-id)
+                                   (cons 'trace-event-count (length events))))]
+       [else
+        (verification-result #f
+                             'fail
+                             (list "scenario-specific correlated lifecycle evidence is absent")
+                             (list (cons 'turn-id turn-id)
+                                   (cons 'trace-event-count (length events))))])]))

--- a/scripts/tmux-tui-explore.rkt
+++ b/scripts/tmux-tui-explore.rkt
@@ -15,7 +15,10 @@
          racket/list
          racket/match
          racket/path
-         racket/string)
+         racket/string
+         "../util/credential-redaction.rkt"
+         "tmux-explore/executor.rkt"
+         "tmux-explore/verifiers.rkt")
 
 (provide (struct-out explore-scenario)
          (struct-out explore-result)
@@ -30,6 +33,8 @@
          write-explore-report!
          write-summary-files!
          run-exploration
+         real-results-gating-pass?
+         exploration-exit-code
          print-scenario-list)
 
 (struct explore-scenario (tag title description prompt expected-status real-tools?) #:transparent)
@@ -72,10 +77,22 @@
    (explore-scenario
     "durable-memory"
     "Durable memory restart"
-    "Restart/round-trip memory scenario; W7 upgrades this from unsupported to evidence-backed."
-    "Persist a durable fact, restart, and recall it without restating it."
-    'unsupported-until-w7
-    #f)))
+    "Store, resume, and retrieve one correlated durable-memory item."
+    "Persist the codename amber-quay, restart the session, and retrieve it without restating it."
+    'pass-mock-tui-with-caveat
+    #f)
+   (explore-scenario "resume"
+                     "Session resume"
+                     "Resume the exact persisted session with structured continuity evidence."
+                     "Resume this session and report the prior session identifier."
+                     'pass-mock-tui-with-caveat
+                     #f)
+   (explore-scenario "compact"
+                     "Durable compaction"
+                     "Run compaction and require a terminal persisted lifecycle event."
+                     "/compact"
+                     'pass-mock-tui-with-caveat
+                     #f)))
 
 (define (valid-mode? mode)
   (member mode '(mock real)))
@@ -109,27 +126,7 @@
                           "Q_TMUX_TUI_REAL_PROVIDER=1, and "
                           "Q_TMUX_TUI_REAL_PROVIDER_CONFIRM=I_UNDERSTAND_COSTS"))))
 
-(define secret-regexps
-  (list #px"sk-[A-Za-z0-9_-]+"
-        #px"(?i:bearer) +[A-Za-z0-9._-]+"
-        #px"(?i:(api[_-]?key|token|secret|password))=([^ \t\n\r]+)"
-        #px"(?i:(api[_-]?key|token|secret|password))\":\"([^\"]+)"))
-
-(define (redact-explore-text text)
-  (define redacted
-    (for/fold ([acc text]) ([rx (in-list secret-regexps)])
-      (regexp-replace*
-       rx
-       acc
-       (lambda matches
-         (define matched (car matches))
-         (cond
-           [(regexp-match? #px"=" matched) (regexp-replace #px"=.*$" matched "=<REDACTED>")]
-           [(regexp-match? #px"\":\"" matched)
-            (regexp-replace #px"\":\".*$" matched "\":\"<REDACTED>")]
-           [(regexp-match? #px"(?i:bearer)" matched) "Bearer <REDACTED>"]
-           [else "<REDACTED>"])))))
-  redacted)
+(define redact-explore-text redact-secrets)
 
 (define (make-explore-root [base-dir (find-system-path 'temp-dir)])
   (define root (make-temporary-file "q-tmux-explore-~a" 'directory base-dir))
@@ -299,27 +296,79 @@
                                       (or (explore-result-report-path r) ""))))
                          #:exists 'append))
 
-(define (run-one-scenario scenario mode root)
+(define (default-real-executor scenario root)
+  (run-real-scenario (explore-scenario-tag scenario)
+                     (explore-scenario-prompt scenario)
+                     root
+                     #:tools? (explore-scenario-real-tools? scenario)))
+
+(define (failed-executor-observation error)
+  (hash 'status
+        'failed
+        'trace-events
+        '()
+        'capture
+        ""
+        'mock-provider?
+        #f
+        'timed-out?
+        #f
+        'crashed?
+        #t
+        'error
+        (exn-message error)))
+
+(define (real-result-evidence observation verification)
+  (list (cons "evidence-source" "observed isolated tmux/q execution")
+        (cons "execution-status" (hash-ref observation 'status 'failed))
+        (cons "trace-event-count" (length (hash-ref observation 'trace-events '())))
+        (cons "verifier"
+              (if (verification-result-passed? verification)
+                  "correlated semantic lifecycle evidence matched"
+                  (string-join (verification-result-reasons verification) "; ")))
+        (cons "artifact" (hash-ref observation 'artifact-path "no retained artifact"))))
+
+(define (run-one-scenario scenario mode root executor)
   (define started (timestamp))
-  ;; W1 intentionally establishes the official runner/report contract. Later
-  ;; waves replace pane/sentinel mock evidence with structured TUI event waits.
-  (define status (scenario-status mode scenario))
   (define result
-    (explore-result (explore-scenario-tag scenario)
-                    (explore-scenario-title scenario)
-                    mode
-                    status
-                    (scenario-classification status)
-                    #f
-                    (scenario->mock-evidence scenario)
-                    started
-                    (timestamp)))
+    (cond
+      [(eq? mode 'mock)
+       (define status (scenario-status mode scenario))
+       (explore-result (explore-scenario-tag scenario)
+                       (explore-scenario-title scenario)
+                       mode
+                       status
+                       (scenario-classification status)
+                       #f
+                       (cons '("evidence-source" . "deterministic mock; never valid for real PASS")
+                             (scenario->mock-evidence scenario))
+                       started
+                       (timestamp))]
+      [else
+       (define observation
+         (with-handlers ([exn:fail? failed-executor-observation])
+           (executor scenario root)))
+       (define verification (verify-scenario-evidence (explore-scenario-tag scenario) observation))
+       (define passed? (verification-result-passed? verification))
+       (define execution-status (hash-ref observation 'status 'failed))
+       (explore-result (explore-scenario-tag scenario)
+                       (explore-scenario-title scenario)
+                       mode
+                       (if passed?
+                           'pass
+                           (if (eq? execution-status 'completed) 'failed-verifier execution-status))
+                       (if passed? 'pass 'fail)
+                       #f
+                       (real-result-evidence observation verification)
+                       started
+                       (timestamp))]))
   (write-explore-report! root result))
 
 (define (run-exploration #:mode [mode 'mock]
                          #:filter [filter-tag #f]
                          #:out [out-dir #f]
-                         #:append-log [append-log #f])
+                         #:append-log [append-log #f]
+                         #:executor [executor default-real-executor])
   (unless (valid-mode? mode)
     (error 'tmux-tui-explore "invalid mode: ~a" mode))
   (when (eq? mode 'real)
@@ -330,12 +379,27 @@
   (define root (or out-dir (make-explore-root)))
   (make-directory* root)
   (define results
-    (for/list ([s (in-list scenarios)])
-      (run-one-scenario s mode root)))
+    (for/list ([scenario (in-list scenarios)])
+      (run-one-scenario scenario mode root executor)))
   (define-values (_tsv _json) (write-summary-files! root results))
   (when append-log
     (append-central-log! append-log results))
   results)
+
+(define (real-results-gating-pass? results)
+  (and (pair? results)
+       (andmap (lambda (result)
+                 (and (eq? (explore-result-mode result) 'real)
+                      (eq? (explore-result-status result) 'pass)
+                      (eq? (explore-result-classification result) 'pass)))
+               results)))
+
+(define (exploration-exit-code mode results non-gating?)
+  (cond
+    [(not (eq? mode 'real)) 0]
+    [non-gating? 0]
+    [(real-results-gating-pass? results) 0]
+    [else 1]))
 
 (define (print-scenario-list [out (current-output-port)])
   (fprintf out "Available tmux TUI exploration scenarios:~n")
@@ -363,6 +427,7 @@
   (define filter-tag #f)
   (define out-dir #f)
   (define append-log #f)
+  (define non-gating? #f)
   (command-line
    #:program "tmux-tui-explore"
    #:once-each [("-l" "--list") "List scenarios without running" (set! list-only? #t)]
@@ -370,6 +435,7 @@
    [("-f" "--filter") tag "Run only one scenario tag" (set! filter-tag tag)]
    [("-o" "--out") dir "Output directory for reports" (set! out-dir dir)]
    [("--append-log") path "Append compact ledger entry to a markdown log" (set! append-log path)]
+   [("--non-gating") "Report real non-PASS outcomes without a nonzero exit" (set! non-gating? #t)]
    #:args ()
    (void))
   (cond
@@ -382,4 +448,8 @@
        (define root (or out-dir (make-explore-root)))
        (define results
          (run-exploration #:mode mode #:filter filter-tag #:out root #:append-log append-log))
-       (print-summary results root))]))
+       (print-summary results root)
+       (define code (exploration-exit-code mode results non-gating?))
+       (unless (zero? code)
+         (eprintf "tmux-tui-explore: one or more real scenarios did not PASS~n")
+         (exit code)))]))

--- a/scripts/tmux-tui-report.rkt
+++ b/scripts/tmux-tui-report.rkt
@@ -17,7 +17,8 @@
          racket/string
          racket/date
          racket/format
-         racket/file)
+         racket/file
+         "../util/credential-redaction.rkt")
 
 (provide path-basename
          classify-failure
@@ -67,23 +68,14 @@
 ;; Check for credential leakage in artifact files. Redacted key names such as
 ;; API_KEY=<REDACTED> are allowed; raw bearer/API key values are not.
 (define (check-redaction dir)
-  (define leak-patterns '("sk-ant-" "Bearer "))
-  (define assignment-patterns
-    '(#rx"(?i:api[_-]?key)=([^<\\s][^\\s]*)" #rx"(?i:token)=([^<\\s][^\\s]*)"
-                                             #rx"(?i:secret)=([^<\\s][^\\s]*)"
-                                             #rx"(?i:password)=([^<\\s][^\\s]*)"))
-  (define leaked '())
-  (for ([f (in-list expected-artifact-files)])
-    (define path (build-path dir f))
-    (when (file-exists? path)
-      (define content (file->string path))
-      (for ([pat (in-list leak-patterns)])
-        (when (string-contains? content pat)
-          (set! leaked (cons (format "~a in ~a" pat f) leaked))))
-      (for ([pat (in-list assignment-patterns)])
-        (when (regexp-match? pat content)
-          (set! leaked (cons (format "secret assignment in ~a" f) leaked))))))
-  leaked)
+  ;; v0.99.50 W3 (TMUX-07): Use the same precision-tuned policy as the
+  ;; explorer and harness, avoiding benign Bearer/sk- false positives.
+  (for*/fold ([leaked '()])
+             ([f (in-list expected-artifact-files)]
+              [path (in-value (build-path dir f))]
+              #:when (file-exists? path)
+              [leak (in-list (find-secret-leaks (file->string path)))])
+    (cons (format "~a in ~a" leak f) leaked)))
 
 ;; Scan directory for artifact subdirs.
 (define (scan-artifact-dir base-dir)

--- a/tests/helpers/tmux-q-harness.rkt
+++ b/tests/helpers/tmux-q-harness.rkt
@@ -31,7 +31,8 @@
          racket/list
          racket/date
          racket/system
-         (only-in racket/port port->string with-input-from-string))
+         (only-in racket/port port->string with-input-from-string)
+         "../../util/credential-redaction.rkt")
 
 ;; Struct
 (provide (struct-out tmux-q-session)
@@ -448,11 +449,9 @@
              line)]
         [else line])))
   (define step1 (string-join step1-lines "\n"))
-  ;; Step 2: redact bearer tokens
-  (define step2 (regexp-replace* #px"(?i:bearer) +[A-Za-z0-9._-]+" step1 "Bearer <REDACTED>"))
-  ;; Step 3: redact API key patterns (sk-...)
-  (define step3 (regexp-replace* #px"sk-[A-Za-z0-9_-]+" step2 "<REDACTED>"))
-  ;; Step 4: redact HOME path if provided
+  ;; Step 2: apply the centralized credential policy (TMUX-07).
+  (define step3 (redact-secrets step1))
+  ;; Step 3: redact HOME path if provided
   (define step4
     (if (and home-path (> (string-length home-path) 0))
         (string-replace step3 home-path "<HOME>")
@@ -941,14 +940,8 @@
 ;; Pure: checks if text contains un-redacted sensitive patterns.
 ;; Returns #t if a sensitive pattern is found that is NOT already redacted.
 (define (detect-sensitive-leak text)
-  (and (string? text)
-       (let* ([has-bearer (regexp-match? #px"[Bb]earer +[A-Za-z0-9._-]{8,}" text)]
-              [has-api-key (regexp-match? #px"sk-[A-Za-z0-9]{10,}" text)]
-              [has-redacted (string-contains? text "<REDACTED>")])
-         (and (or has-bearer has-api-key)
-              ;; If the only match IS <REDACTED>, it's fine
-              (not (and has-redacted (not has-bearer) (not has-api-key)))))
-       #t))
+  ;; v0.99.50 W3 (TMUX-07): One policy across explorer, harness, and report.
+  (contains-secret-leak? text))
 
 ;; verify-artifact-redacted! : path-string? -> void?
 ;; Reads an artifact file and fails if un-redacted sensitive content is found.

--- a/tests/test-secret-redaction.rkt
+++ b/tests/test-secret-redaction.rkt
@@ -1,0 +1,136 @@
+#lang racket/base
+
+;; @speed fast
+;; @suite default
+
+;; tests/test-secret-redaction.rkt
+;; v0.99.50 W3 (TMUX-07): Centralized credential redaction and leak detection.
+;;
+;; Verifies the three-way redaction policy is consistent and free of the
+;; false positives identified in V9949-TMUX-07:
+;; - benign `sk-` substrings inside words (risk-score, set-task-state)
+;; - `Bearer authentication` (dictionary word, not a token)
+;; - already-redacted `<REDACTED>` placeholders
+;; While still catching real secrets.
+
+(require json
+         rackunit
+         rackunit/text-ui
+         racket/string
+         "../util/credential-redaction.rkt")
+
+(define suite
+  (test-suite "Centralized Secret Redaction (v0.99.50 W3 / TMUX-07)"
+
+    ;; ── Benign strings: must NOT be flagged as leaks ──
+
+    (test-case "risk-score is not flagged as a leak"
+      (check-false (contains-secret-leak? "risk-score is above threshold"))
+      (check-false (contains-secret-leak? "the risk-score value")))
+
+    (test-case "set-task-state is not flagged as a leak"
+      (check-false (contains-secret-leak? "set-task-state completed")))
+
+    (test-case "Bearer authentication is not flagged as a leak"
+      (check-false (contains-secret-leak? "Bearer authentication failed"))
+      (check-false (contains-secret-leak? "uses Bearer authentication headers")))
+
+    (test-case "REDACTED placeholders are not flagged"
+      (check-false (contains-secret-leak? "API_KEY=<REDACTED>"))
+      (check-false (contains-secret-leak? "token=<REDACTED>"))
+      (check-false (contains-secret-leak? "Bearer <REDACTED>")))
+
+    (test-case "common tool names and phrases are clean"
+      (check-false (contains-secret-leak? "task-state was set"))
+      (check-false (contains-secret-leak? "the password field is optional"))
+      (check-false (contains-secret-leak? "password=<REDACTED>")))
+
+    ;; ── Real secrets: MUST be flagged ──
+
+    (test-case "real sk- API key is flagged"
+      (check-true (contains-secret-leak? "key=sk-ant-api03-abcdefghijklmnopqrstuvwxyz1234567890"))
+      (check-true (contains-secret-leak?
+                   "sk-proj-abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOP")))
+
+    (test-case "real Bearer token is flagged"
+      (check-true
+       (contains-secret-leak?
+        "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.SflKxwRS"))
+      (check-true (contains-secret-leak? "Bearer dGhpc19pc19hX3JlYWxfczNjcmV0X3QwazNu")))
+
+    (test-case "real key=value assignments are flagged"
+      (check-true (contains-secret-leak? "api_key=abcdef1234567890abcdef"))
+      (check-true (contains-secret-leak? "token=ghp_abcdefghijklmnopqrstuvwxyz"))
+      (check-true (contains-secret-leak? "secret=mysecretvalue123456"))
+      (check-true (contains-secret-leak? "password=hunter2special")))
+
+    (test-case "real JSON and header assignments are flagged"
+      (check-true (contains-secret-leak? "{\"api_key\":\"realkey1234567890abcdef\"}"))
+      (check-true (contains-secret-leak? "{\"token\" : \"ghp_realtoken1234567890\"}"))
+      (check-true (contains-secret-leak? "x-api-key: realkey1234567890abcdef")))
+
+    ;; ── Mixed redacted and real: MUST be flagged ──
+
+    (test-case "mixed redacted and real values are flagged"
+      (check-true (contains-secret-leak? "token=<REDACTED> api_key=realkey1234567890abcdef"))
+      (check-true (contains-secret-leak?
+                   "Bearer <REDACTED> and sk-real-key-abcdefghijklmnopqrstuvwxyz")))
+
+    ;; ── Redaction: benign text is unchanged ──
+
+    (test-case "redact-secrets preserves benign text"
+      (check-equal? (redact-secrets "risk-score is 42") "risk-score is 42")
+      (check-equal? (redact-secrets "set-task-state done") "set-task-state done")
+      (check-equal? (redact-secrets "Bearer authentication") "Bearer authentication"))
+
+    (test-case "redact-secrets preserves already-redacted placeholders"
+      (check-equal? (redact-secrets "API_KEY=<REDACTED>") "API_KEY=<REDACTED>")
+      (check-equal? (redact-secrets "token=<REDACTED>") "token=<REDACTED>"))
+
+    ;; ── Redaction: real secrets are replaced ──
+
+    (test-case "redact-secrets removes sk- API keys"
+      (define r (redact-secrets "key=sk-ant-api03-abcdefghijklmnopqrstuvwxyz1234567890"))
+      (check-false (string-contains? r "sk-ant-api03-"))
+      (check-true (string-contains? r "<REDACTED>")))
+
+    (test-case "redact-secrets removes Bearer tokens"
+      (define r
+        (redact-secrets
+         "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxIn0.SflK"))
+      (check-false (string-contains? r "eyJhbGci"))
+      (check-true (string-contains? r "Bearer <REDACTED>")))
+
+    (test-case "redact-secrets removes key=value assignments"
+      (define r (redact-secrets "api_key=abcdef1234567890abcdef"))
+      (check-false (string-contains? r "abcdef1234567890abcdef"))
+      (check-true (string-contains? r "api_key=<REDACTED>")))
+
+    (test-case "redact-secrets preserves valid JSON while replacing values"
+      (define r (redact-secrets "{\"token\" : \"ghp_realtoken1234567890\",\"ok\":true}"))
+      (check-false (string-contains? r "ghp_realtoken"))
+      (check-equal? (hash-ref (string->jsexpr r) 'token) "<REDACTED>")
+      (check-true (hash-ref (string->jsexpr r) 'ok)))
+
+    (test-case "redact-secrets preserves credential header names"
+      (define r (redact-secrets "x-api-key: realkey1234567890abcdef"))
+      (check-equal? r "x-api-key: <REDACTED>"))
+
+    (test-case "redact-secrets is idempotent"
+      (define text "api_key=abcdef1234567890abcdef")
+      (define once (redact-secrets text))
+      (define twice (redact-secrets once))
+      (check-equal? once twice "redacting already-redacted text should be a no-op"))
+
+    ;; ── find-secret-leaks: returns descriptions ──
+
+    (test-case "find-secret-leaks returns empty for clean text"
+      (check-equal? (find-secret-leaks "risk-score is fine") '()))
+
+    (test-case "find-secret-leaks returns descriptions for dirty text"
+      (define leaks (find-secret-leaks "api_key=realsecret1234567890abcdef"))
+      (check-true (pair? leaks) "should find at least one leak")
+      (for ([l (in-list leaks)])
+        (check-true (string? l) "each leak should be a description string")))))
+
+(run-tests suite)

--- a/tests/test-tmux-explore-executor.rkt
+++ b/tests/test-tmux-explore-executor.rkt
@@ -1,0 +1,80 @@
+#lang racket/base
+
+;; @speed fast
+;; @suite default
+
+(require rackunit
+         rackunit/text-ui
+         racket/file
+         "../scripts/tmux-explore/executor.rkt")
+
+(define (make-workspace)
+  (define dir (make-temporary-file "q-executor-cleanup-~a" 'directory))
+  (call-with-output-file (build-path dir "copied-credentials.json")
+                         (lambda (out) (display "secret fixture" out)))
+  dir)
+
+(define suite
+  (test-suite "real explorer executor cleanup"
+
+    (test-case "success deletes credential workspace and stops only named session"
+      (define dir (make-workspace))
+      (define stopped '())
+      (define result
+        (call-with-executor-cleanup dir
+                                    "q-explore-owned"
+                                    (lambda () 'completed)
+                                    #:stop-session
+                                    (lambda (name) (set! stopped (cons name stopped)))))
+      (check-equal? result 'completed)
+      (check-false (directory-exists? dir))
+      (check-equal? stopped '("q-explore-owned")))
+
+    (test-case "timeout result still deletes workspace and stops named session"
+      (define dir (make-workspace))
+      (define stopped '())
+      (define result
+        (call-with-executor-cleanup dir
+                                    "q-explore-timeout"
+                                    (lambda () (hash 'status 'timed-out))
+                                    #:stop-session
+                                    (lambda (name) (set! stopped (cons name stopped)))))
+      (check-equal? (hash-ref result 'status) 'timed-out)
+      (check-false (directory-exists? dir))
+      (check-equal? stopped '("q-explore-timeout")))
+
+    (test-case "exception deletes workspace and never targets unrelated sessions"
+      (define dir (make-workspace))
+      (define stopped '())
+      (check-exn #rx"executor exploded"
+                 (lambda ()
+                   (call-with-executor-cleanup dir
+                                               "q-explore-failed"
+                                               (lambda () (error 'fixture "executor exploded"))
+                                               #:stop-session
+                                               (lambda (name) (set! stopped (cons name stopped))))))
+      (check-false (directory-exists? dir))
+      (check-equal? stopped '("q-explore-failed")))
+
+    (test-case "stop failure is visible after credential workspace deletion"
+      (define dir (make-workspace))
+      (check-exn #rx"stop failed"
+                 (lambda ()
+                   (call-with-executor-cleanup dir
+                                               "q-explore-stop-failure"
+                                               void
+                                               #:stop-session
+                                               (lambda (_name) (error 'fixture "stop failed")))))
+      (check-false (directory-exists? dir)))
+
+    (test-case "no session name means no tmux cleanup call"
+      (define dir (make-workspace))
+      (define stopped '())
+      (call-with-executor-cleanup dir
+                                  #f
+                                  void
+                                  #:stop-session (lambda (name) (set! stopped (cons name stopped))))
+      (check-false (directory-exists? dir))
+      (check-equal? stopped '()))))
+
+(run-tests suite)

--- a/tests/test-tmux-explore-verifiers.rkt
+++ b/tests/test-tmux-explore-verifiers.rkt
@@ -1,0 +1,187 @@
+#lang racket/base
+
+;; @speed fast
+;; @suite default
+
+;; v0.99.50 W3 (TMUX-09): semantic verifier fixtures for every exact
+;; registered explorer tag. Positive fixtures carry correlated structured
+;; lifecycle evidence; deceptive negatives contain plausible prose or
+;; unrelated/mismatched events and must fail.
+
+(require rackunit
+         rackunit/text-ui
+         racket/list
+         "../scripts/tmux-explore/verifiers.rkt")
+
+(define turn "turn-1")
+(define call "call-1")
+(define approval "approval-1")
+(define session "session-1")
+(define memory "memory-1")
+
+(define (evt phase #:turn [turn-id turn] #:data [data (hash)])
+  (hash 'phase phase 'session-id session 'turn-id turn-id 'data data))
+
+(define completion (evt "turn.completed"))
+
+(define positive-fixtures
+  (hash
+   "memory"
+   (list (evt "memory.retrieval.performed"
+              #:data (hash 'scope "session" 'query-snippet "blue-harbor" 'result-count 1))
+         completion)
+   "gsd"
+   (list (evt "gsd.transition.attempted" #:data (hash 'from "planned" 'to "executing"))
+         (evt "gsd.transition.succeeded" #:data (hash 'from "planned" 'to "executing"))
+         completion)
+   "mas"
+   (list (evt "mas.spawn-approval-requested"
+              #:data (hash 'approval-id approval 'tool-call-id call 'child-id "child-1"))
+         (evt "mas.spawn-approval-decided"
+              #:data (hash 'approval-id approval 'tool-call-id call 'decision "approved"))
+         (evt "tool.execution.correlated-completed"
+              #:data (hash 'tool-call-id
+                           call
+                           'tool-name
+                           "spawn_subagent"
+                           'result-present?
+                           #t
+                           'result-summary
+                           "completed"))
+         completion)
+   "tools"
+   (list
+    (evt "tool.execution.started" #:data (hash 'tool-call-id call 'tool-name "read"))
+    (evt "tool.execution.correlated-completed"
+         #:data
+         (hash 'tool-call-id call 'tool-name "read" 'result-present? #t 'result-summary "completed"))
+    completion)
+   "release-audit"
+   (list (evt "release.authorization.refused" #:data (hash 'reason "missing-live-ci" 'authorized? #f))
+         completion)
+   "durable-memory"
+   (list (evt "memory.item.stored"
+              #:turn "turn-store"
+              #:data (hash 'memory-id memory 'session-id "session-0"))
+         (evt "session.started"
+              #:turn #f
+              #:data (hash 'reason "resume" 'session-id session 'previous-session-id "session-0"))
+         (evt "memory.retrieval.performed"
+              #:data (hash 'memory-id memory 'session-id session 'result-present? #t))
+         completion)
+   "resume"
+   (list (evt "session.started"
+              #:turn #f
+              #:data (hash 'reason "resume" 'session-id session 'previous-session-id "session-0"))
+         (evt "session.resumed" #:data (hash 'session-id session 'previous-session-id "session-0"))
+         completion)
+   "compact"
+   (list (evt "session.compact.completed"
+              #:data (hash 'session-id session 'before-count 42 'after-count 12 'persisted? #t))
+         completion)))
+
+(define negative-fixtures
+  (hash
+   ;; Plausible answer and completion, but no retrieval event.
+   "memory"
+   (list completion)
+   ;; Attempt and success are unrelated transition IDs.
+   "gsd"
+   (list (evt "gsd.transition.attempted" #:data (hash 'from "planned" 'to "executing"))
+         (evt "gsd.transition.succeeded" #:data (hash 'from "planned" 'to "done"))
+         completion)
+   ;; Approval decision and result target another tool call.
+   "mas"
+   (list (evt "mas.spawn-approval-requested"
+              #:data (hash 'approval-id approval 'tool-call-id call 'child-id "child-1"))
+         (evt "mas.spawn-approval-decided"
+              #:data (hash 'approval-id approval 'tool-call-id "other" 'decision "approved"))
+         (evt "tool.execution.correlated-completed"
+              #:data (hash 'tool-call-id
+                           "other"
+                           'tool-name
+                           "spawn_subagent"
+                           'result-present?
+                           #t
+                           'result-summary
+                           "completed"))
+         completion)
+   ;; Tool names and call IDs do not match.
+   "tools"
+   (list
+    (evt "tool.execution.started" #:data (hash 'tool-call-id call 'tool-name "read"))
+    (evt
+     "tool.execution.correlated-completed"
+     #:data
+     (hash 'tool-call-id "other" 'tool-name "bash" 'result-present? #t 'result-summary "completed"))
+    completion)
+   ;; Refusal prose alone must not count as protocol evidence.
+   "release-audit"
+   (list completion)
+   ;; Store/retrieve IDs differ and no resume edge.
+   "durable-memory"
+   (list (evt "memory.item.stored"
+              #:turn "turn-store"
+              #:data (hash 'memory-id memory 'session-id "session-0"))
+         (evt "memory.retrieval.performed"
+              #:data (hash 'memory-id "other" 'session-id session 'result-present? #t))
+         completion)
+   ;; Fresh session is not resume.
+   "resume"
+   (list (evt "session.started" #:turn #f #:data (hash 'reason "new" 'session-id session)) completion)
+   ;; Accepted/prose without terminal compact completion is not PASS.
+   "compact"
+   (list (evt "session.compact.requested" #:data (hash 'session-id session)) completion)))
+
+(define (observation events
+                     #:capture [capture "plausible assistant prose says everything passed"]
+                     #:status [status 'completed]
+                     #:mock? [mock? #f]
+                     #:timed-out? [timed-out? #f]
+                     #:crashed? [crashed? #f])
+  (hash 'status
+        status
+        'trace-events
+        events
+        'capture
+        capture
+        'provider-confirmed?
+        (not mock?)
+        'mock-provider?
+        mock?
+        'timed-out?
+        timed-out?
+        'crashed?
+        crashed?))
+
+(define suite
+  (test-suite "tmux explorer semantic verifiers"
+
+    (test-case "all exact registered tags accept correlated positive fixtures"
+      (for ([tag (in-list required-scenario-tags)])
+        (define result (verify-scenario-evidence tag (observation (hash-ref positive-fixtures tag))))
+        (check-true
+         (verification-result-passed? result)
+         (format "positive fixture should pass: ~a / ~a" tag (verification-result-reasons result)))))
+
+    (test-case "all exact registered tags reject deceptive negative fixtures"
+      (for ([tag (in-list required-scenario-tags)])
+        (define result (verify-scenario-evidence tag (observation (hash-ref negative-fixtures tag))))
+        (check-false (verification-result-passed? result)
+                     (format "deceptive fixture must fail: ~a" tag))))
+
+    (test-case "timeout missing trace mock fallback and crash can never pass"
+      (define valid-tools (hash-ref positive-fixtures "tools"))
+      (for ([obs (in-list (list (observation valid-tools #:timed-out? #t)
+                                (observation '())
+                                (observation valid-tools #:mock? #t)
+                                (observation valid-tools #:crashed? #t)
+                                (observation valid-tools #:status 'failed)))])
+        (check-false (verification-result-passed? (verify-scenario-evidence "tools" obs)))))
+
+    (test-case "unknown scenario tag fails closed"
+      (define result (verify-scenario-evidence "not-registered" (observation (list completion))))
+      (check-false (verification-result-passed? result))
+      (check-equal? (verification-result-status result) 'unsupported))))
+
+(run-tests suite)

--- a/tests/test-tmux-q-harness.rkt
+++ b/tests/test-tmux-q-harness.rkt
@@ -278,9 +278,14 @@
   (check-false (detect-queued-prompts "")))
 
 (test-case "redact-sensitive redacts bearer tokens"
-  (define result (redact-sensitive "Authorization: Bearer abc123secret"))
-  (check-false (string-contains? result "abc123secret"))
+  (define token "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.real-token")
+  (define result (redact-sensitive (string-append "Authorization: Bearer " token)))
+  (check-false (string-contains? result token))
   (check-true (string-contains? result "<REDACTED>")))
+
+(test-case "redact-sensitive preserves benign credential lookalikes"
+  (define benign "set-task-state risk-score Bearer authentication token=<REDACTED>")
+  (check-equal? (redact-sensitive benign) benign))
 
 (test-case "redact-sensitive redacts API key patterns"
   (define result (redact-sensitive "api_key=sk-proj123abc456"))
@@ -490,10 +495,15 @@
                    (check-exn #rx"file was modified" (lambda () (verify-file-unchanged! f fp))))))
 
 (test-case "detect-sensitive-leak detects bearer tokens"
-  (check-true (detect-sensitive-leak "Authorization: Bearer abc123secretkey")))
+  (check-true (detect-sensitive-leak
+               "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.real-token")))
 
 (test-case "detect-sensitive-leak detects API keys"
-  (check-true (detect-sensitive-leak "key=sk-proj123abc456def789")))
+  (check-true (detect-sensitive-leak "key=sk-proj-abcdefghijklmnopqrstuvwxyz1234567890")))
+
+(test-case "detect-sensitive-leak ignores benign credential lookalikes"
+  (check-false (detect-sensitive-leak
+                "set-task-state risk-score Bearer authentication token=<REDACTED>")))
 
 (test-case "detect-sensitive-leak ignores already-redacted content"
   (check-false (detect-sensitive-leak "Authorization: Bearer <REDACTED>")))
@@ -515,9 +525,11 @@
   (with-temp-dir
    (lambda (dir)
      (define f (build-path dir "artifact.txt"))
-     (call-with-output-file f
-                            (lambda (out) (display "Authorization: Bearer secretkey123" out))
-                            #:exists 'replace)
+     (call-with-output-file
+      f
+      (lambda (out)
+        (display "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.real-token" out))
+      #:exists 'replace)
      (check-exn #rx"un-redacted sensitive content" (lambda () (verify-artifact-redacted! f))))))
 
 ;; ============================================================

--- a/tests/test-tmux-real-provider-docs.rkt
+++ b/tests/test-tmux-real-provider-docs.rkt
@@ -1,0 +1,51 @@
+#lang racket/base
+
+;; @speed fast
+;; @suite default
+
+(require rackunit
+         racket/file
+         racket/runtime-path
+         racket/string)
+
+(define-runtime-path runbook "../docs/reports/TMUX-TUI-EXPLORATION-SAFETY-RUNBOOK-v0.99.44.md")
+(define-runtime-path audit "../docs/reports/AUDIT-v0.99.44-FINAL.md")
+
+(define text (file->string runbook))
+(define audit-text (file->string audit))
+
+(test-case "runbook contains the executable authorization contract"
+  (for ([required (in-list '("Q_TMUX_TUI_TESTS=1"
+                             "Q_TMUX_TUI_REAL_PROVIDER=1"
+                             "Q_TMUX_TUI_REAL_PROVIDER_CONFIRM=I_UNDERSTAND_COSTS"
+                             "Q_TMUX_TUI_REAL_PROVIDER_HOME"))])
+    (check-true (string-contains? text required) required))
+  (check-false (string-contains? text "Q_TMUX_REAL_PROVIDER_KEY"))
+  (check-false (string-contains? text "Q_TMUX_REAL_PROVIDER=1")))
+
+(test-case "runbook lists exact registered scenario tags and real command"
+  (for ([tag (in-list
+              '("memory" "gsd" "mas" "tools" "release-audit" "durable-memory" "resume" "compact"))])
+    (check-true (string-contains? text (format "`~a`" tag)) tag))
+  (check-true (string-contains? text
+                                "racket scripts/tmux-tui-explore.rkt --mode real --filter tools"))
+  (check-true (string-contains? text "--non-gating")))
+
+(test-case "runbook documents actual helper and cleanup contracts"
+  (check-true (string-contains? text "tmux-env-home"))
+  (check-false (string-contains? text "`temp-home`"))
+  (check-true (string-contains? text "config.rkt"))
+  (check-true (string-contains? text "dynamic-wind"))
+  (check-true (string-contains? text "kill-session"))
+  (check-true (string-contains? text "kill-server"))
+  (check-true (string-contains? text "copied-credential HOME")))
+
+(test-case "runbook does not advertise nonexistent selectable suites"
+  (check-false (string-contains? text "| tui-tmux |"))
+  (check-false (string-contains? text "| tui-tmux-real |"))
+  (check-true (string-contains? text "--suite tui")))
+
+(test-case "historical audit includes explicit v0.99.50 erratum"
+  (check-true (string-contains? audit-text "v0.99.50 Erratum"))
+  (check-true (string-contains? audit-text "synthetic"))
+  (check-true (string-contains? audit-text "Q_TMUX_TUI_REAL_PROVIDER_CONFIRM")))

--- a/tests/test-tmux-tui-explore.rkt
+++ b/tests/test-tmux-tui-explore.rkt
@@ -8,8 +8,12 @@
          racket/file
          racket/list
          racket/port
+         racket/runtime-path
          racket/string
+         racket/system
          "../scripts/tmux-tui-explore.rkt")
+
+(define-runtime-path explorer-script "../scripts/tmux-tui-explore.rkt")
 
 (define (with-temp-dir proc)
   (define dir (make-temporary-file "q-tmux-explore-test-~a" 'directory))
@@ -22,8 +26,9 @@
 (define (scenario-tags)
   (map explore-scenario-tag scenario-registry))
 
-(test-case "scenario registry contains required v0.99.44 exploration scenarios"
-  (check-equal? (scenario-tags) '("memory" "gsd" "mas" "tools" "release-audit" "durable-memory"))
+(test-case "scenario registry contains exact v0.99.50 semantic scenarios"
+  (check-equal? (scenario-tags)
+                '("memory" "gsd" "mas" "tools" "release-audit" "durable-memory" "resume" "compact"))
   (check-equal? (length (find-scenarios #:filter "memory")) 1)
   (check-equal? (find-scenarios #:filter "missing") '()))
 
@@ -45,13 +50,24 @@
     (check-true (real-provider-authorized?))
     (check-not-exn require-real-provider-authorization!)))
 
-(test-case "redaction removes credential-like values"
-  (define raw "api_key=abc123 token=xyz password=hunter2 Authorization: Bearer secret sk-testSECRET")
+(test-case "redaction removes realistic credential-like values"
+  (define raw
+    (string-append "api_key=abc123 token=xyz password=hunter2 "
+                   "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.real-token "
+                   "sk-ant-api03-abcdefghijklmnopqrstuvwxyz1234567890"))
   (define redacted (redact-explore-text raw))
   (check-false (string-contains? redacted "abc123"))
   (check-false (string-contains? redacted "hunter2"))
-  (check-false (string-contains? redacted "sk-testSECRET"))
+  (check-false (string-contains? redacted "sk-ant-api03-"))
   (check-true (string-contains? redacted "<REDACTED>")))
+
+(test-case "explorer redaction preserves benign lookalikes and detects mixed leaks"
+  (define benign "set-task-state risk-score Bearer authentication token=<REDACTED>")
+  (check-equal? (redact-explore-text benign) benign)
+  (define mixed "token=<REDACTED> sk-proj-abcdefghijklmnopqrstuvwxyz1234567890")
+  (define redacted (redact-explore-text mixed))
+  (check-false (string-contains? redacted "sk-proj-"))
+  (check-true (string-contains? redacted "token=<REDACTED>")))
 
 (test-case "mock exploration writes markdown and summary files"
   (with-temp-dir (lambda (dir)
@@ -98,3 +114,125 @@
                   (lambda ()
                     (run-exploration #:mode 'real #:filter "memory" #:out (path->string dir))))
        (check-false (file-exists? (build-path dir "summary.tsv")))))))
+
+(define (positive-tools-observation)
+  (define turn "turn-real-1")
+  (define call "call-real-1")
+  (define session "session-real-1")
+  (hash
+   'status
+   'completed
+   'trace-events
+   (list
+    (hash 'phase
+          "tool.execution.started"
+          'session-id
+          session
+          'turn-id
+          turn
+          'data
+          (hash 'tool-call-id call 'tool-name "read"))
+    (hash 'phase
+          "tool.execution.correlated-completed"
+          'session-id
+          session
+          'turn-id
+          turn
+          'data
+          (hash 'tool-call-id call 'tool-name "read" 'result-present? #t 'result-summary "completed"))
+    (hash 'phase "turn.completed" 'session-id session 'turn-id turn 'data (hash 'reason "completed")))
+   'capture
+   "tool completed"
+   'provider-confirmed?
+   #t
+   'mock-provider?
+   #f
+   'timed-out?
+   #f
+   'crashed?
+   #f
+   'artifact-path
+   "tools-execution.txt"))
+
+(test-case "real mode dispatches injected executor and verifies observed evidence"
+  (with-temp-dir
+   (lambda (dir)
+     (parameterize ([current-environment-variables
+                     (environment-variables-copy (current-environment-variables))])
+       (putenv "Q_TMUX_TUI_TESTS" "1")
+       (putenv "Q_TMUX_TUI_REAL_PROVIDER" "1")
+       (putenv "Q_TMUX_TUI_REAL_PROVIDER_CONFIRM" "I_UNDERSTAND_COSTS")
+       (define calls '())
+       (define results
+         (run-exploration #:mode 'real
+                          #:filter "tools"
+                          #:out (path->string dir)
+                          #:executor
+                          (lambda (scenario root)
+                            (set! calls (cons (list (explore-scenario-tag scenario) root) calls))
+                            (positive-tools-observation))))
+       (check-equal? (map car calls) '("tools"))
+       (check-equal? (explore-result-status (car results)) 'pass)
+       (check-equal? (explore-result-classification (car results)) 'pass)
+       (check-true (real-results-gating-pass? results))
+       (check-equal? (exploration-exit-code 'real results #f) 0)))))
+
+(test-case "real non-PASS exits nonzero unless explicitly non-gating"
+  (with-temp-dir (lambda (dir)
+                   (parameterize ([current-environment-variables
+                                   (environment-variables-copy (current-environment-variables))])
+                     (putenv "Q_TMUX_TUI_TESTS" "1")
+                     (putenv "Q_TMUX_TUI_REAL_PROVIDER" "1")
+                     (putenv "Q_TMUX_TUI_REAL_PROVIDER_CONFIRM" "I_UNDERSTAND_COSTS")
+                     (define results
+                       (run-exploration #:mode 'real
+                                        #:filter "tools"
+                                        #:out (path->string dir)
+                                        #:executor (lambda (_scenario _root)
+                                                     (hash 'status
+                                                           'timed-out
+                                                           'trace-events
+                                                           '()
+                                                           'capture
+                                                           "Mock response says PASS"
+                                                           'mock-provider?
+                                                           #t
+                                                           'timed-out?
+                                                           #t
+                                                           'crashed?
+                                                           #f))))
+                     (check-equal? (explore-result-classification (car results)) 'fail)
+                     (check-false (real-results-gating-pass? results))
+                     (check-equal? (exploration-exit-code 'real results #f) 1)
+                     (check-equal? (exploration-exit-code 'real results #t) 0)))))
+
+(test-case "CLI returns nonzero for real failure and zero only with --non-gating"
+  (with-temp-dir (lambda (dir)
+                   (parameterize ([current-environment-variables
+                                   (environment-variables-copy (current-environment-variables))])
+                     (putenv "Q_TMUX_TUI_TESTS" "1")
+                     (putenv "Q_TMUX_TUI_REAL_PROVIDER" "1")
+                     (putenv "Q_TMUX_TUI_REAL_PROVIDER_CONFIRM" "I_UNDERSTAND_COSTS")
+                     (putenv "Q_TMUX_TUI_REAL_PROVIDER_HOME" "/definitely/missing/q-home")
+                     (define racket-bin (find-executable-path "racket"))
+                     (define fail-dir (build-path dir "gating"))
+                     (define nongating-dir (build-path dir "non-gating"))
+                     (check-equal? (system*/exit-code racket-bin
+                                                      explorer-script
+                                                      "--mode"
+                                                      "real"
+                                                      "--filter"
+                                                      "tools"
+                                                      "--out"
+                                                      (path->string fail-dir))
+                                   1)
+                     (check-equal? (system*/exit-code racket-bin
+                                                      explorer-script
+                                                      "--mode"
+                                                      "real"
+                                                      "--filter"
+                                                      "tools"
+                                                      "--out"
+                                                      (path->string nongating-dir)
+                                                      "--non-gating")
+                                   0)))))

--- a/tests/test-tmux-tui-report.rkt
+++ b/tests/test-tmux-tui-report.rkt
@@ -51,8 +51,21 @@
   (with-temp-dir (lambda (dir)
                    (define art-dir (build-path dir "q-tmux-art-leak"))
                    (make-directory* art-dir)
-                   (call-with-output-file (build-path art-dir "env-summary.txt")
-                                          (lambda (p) (display "Authorization: Bearer secret" p)))
+                   (call-with-output-file
+                    (build-path art-dir "env-summary.txt")
+                    (lambda (p)
+                      (display "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.real-token"
+                               p)))
                    (check-not-equal? (check-redaction art-dir) '())
                    (define rendered (with-output-to-string (lambda () (render-report dir))))
                    (check-true (string-contains? rendered "Redaction: ❌ FAIL")))))
+
+(test-case "redaction report ignores benign sk substrings and Bearer prose"
+  (with-temp-dir (lambda (dir)
+                   (define art-dir (build-path dir "q-tmux-art-clean"))
+                   (make-directory* art-dir)
+                   (call-with-output-file
+                    (build-path art-dir "normalized-capture.txt")
+                    (lambda (p)
+                      (display "set-task-state risk-score Bearer authentication token=<REDACTED>" p)))
+                   (check-equal? (check-redaction art-dir) '()))))

--- a/tests/test-tool-coordinator-duration.rkt
+++ b/tests/test-tool-coordinator-duration.rkt
@@ -96,3 +96,30 @@
   (define dur (car durations))
   (check-true (>= dur 40))
   (check-true (<= dur 300)))
+
+(test-case "correlated completion carries stable call identity and result presence"
+  (define bus (make-event-bus))
+  (define reg (make-tool-registry))
+  (register-tool! reg (make-sleep-tool 1))
+  (define records (box '()))
+  (subscribe! bus
+              (lambda (evt)
+                (when (equal? (event-event evt) "tool.execution.correlated-completed")
+                  (set-box! records (cons (event-payload evt) (unbox records))))))
+  (define message (make-assistant-msg-with-sleep 1))
+  (handle-tool-calls-pending (list message)
+                             '()
+                             #f
+                             reg
+                             bus
+                             "test-session"
+                             (format "/tmp/test-~a-correlated.log" (random 1000000))
+                             #f
+                             (hash->session-config (hash)))
+  (check-equal? (length (unbox records)) 1)
+  (define payload (car (unbox records)))
+  (check-true (string? (hash-ref payload 'tool-call-id #f)))
+  (check-not-equal? (hash-ref payload 'tool-call-id) "")
+  (check-equal? (hash-ref payload 'tool-name) "sleep")
+  (check-true (hash-ref payload 'result-present? #f))
+  (check-equal? (hash-ref payload 'result-summary) 'completed))

--- a/util/credential-redaction.rkt
+++ b/util/credential-redaction.rkt
@@ -1,0 +1,85 @@
+#lang racket/base
+
+;; util/credential-redaction.rkt — Centralized credential redaction and leak detection
+;;
+;; v0.99.50 W3 (TMUX-07): The three prior redaction policies
+;; (scripts/tmux-tui-explore.rkt, scripts/tmux-tui-report.rkt,
+;; tests/helpers/tmux-q-harness.rkt) used inconsistent patterns that caused
+;; false positives on benign substrings like `risk-score`, `set-task-state`,
+;; and `Bearer authentication`.
+;;
+;; This module owns the single canonical policy. Pattern precision:
+;; - sk-prefix keys: word-boundary + 20+ chars (OpenAI=48+, Anthropic=60+).
+;;   Benign words like `risk-score` and `set-task-state` have `sk-` inside a
+;;   word boundary (not at a token start), so they never match.
+;; - Bearer tokens: 20+ char token. `authentication` (14 chars) is too short.
+;;   Real JWTs/opaque tokens are 100+ chars.
+;; - KEY=VALUE and JSON "key":"value" assignments: value must be non-empty and
+;;   not already `<REDACTED>`.
+;;
+;; Used by: scripts/tmux-tui-explore.rkt, scripts/tmux-tui-report.rkt,
+;;          tests/helpers/tmux-q-harness.rkt.
+
+(require racket/string)
+
+(provide REDACTED-PLACEHOLDER
+         redact-secrets
+         contains-secret-leak?
+         find-secret-leaks)
+
+(define REDACTED-PLACEHOLDER "<REDACTED>")
+
+;; sk- prefix API keys: word boundary + 20+ chars.
+(define rx-sk-key #px"\\bsk-[A-Za-z0-9_-]{20,}")
+
+;; Bearer tokens: 20+ char token after "Bearer ".
+(define rx-bearer #px"(?i:bearer) +[A-Za-z0-9._-]{20,}")
+
+;; Env-style KEY=VALUE: captures key prefix (with =) + value.
+(define rx-assign #px"(?i:((?:api[_-]?key|token|secret|password|credential)[ \t]*=))([^ \t\n\r<]+)")
+
+;; JSON "key" : "value": captures and preserves the key/separator prefix.
+(define rx-json-assign
+  #px"(?i:((?:\"(?:api[_-]?key|token|secret|password|credential)\"[ \t]*:[ \t]*\")))([^\"<]+)")
+
+;; Header-style API key assignments (Bearer is handled separately).
+(define rx-header-assign
+  #px"(?i:((?:x-api-key|api[_-]?key|token|secret|password)[ \t]*:[ \t]*))([^ \t\n\r<]{8,})")
+
+;; Redact all secret patterns in text. Idempotent for placeholders.
+(define (redact-secrets text)
+  (define step1 (regexp-replace* rx-sk-key text REDACTED-PLACEHOLDER))
+  (define step2 (regexp-replace* rx-bearer step1 "Bearer <REDACTED>"))
+  (define step3 (regexp-replace* rx-assign step2 "\\1<REDACTED>"))
+  (define step4 (regexp-replace* rx-json-assign step3 "\\1<REDACTED>"))
+  (regexp-replace* rx-header-assign step4 "\\1<REDACTED>"))
+
+(define rx-sk-key-leak #px"\\bsk-[A-Za-z0-9_-]{20,}")
+(define rx-bearer-leak #px"(?i:bearer) +[A-Za-z0-9._-]{20,}")
+(define rx-assign-leak
+  #px"(?i:(?:api[_-]?key|token|secret|password|credential))[ \t]*=[^ \t\n\r<][^ \t\n\r]+")
+(define rx-json-assign-leak
+  #px"(?i:\"(?:api[_-]?key|token|secret|password|credential)\"[ \t]*:[ \t]*\"[^\"<]+)")
+(define rx-header-assign-leak
+  #px"(?i:(?:x-api-key|api[_-]?key|token|secret|password)[ \t]*:[ \t]*[^ \t\n\r<]{8,})")
+
+(define leak-rx+label
+  (list (cons rx-sk-key-leak "unredacted sk-prefix API key")
+        (cons rx-bearer-leak "unredacted Bearer token")
+        (cons rx-assign-leak "unredacted key=value assignment")
+        (cons rx-json-assign-leak "unredacted JSON key:value assignment")
+        (cons rx-header-assign-leak "unredacted credential header")))
+
+(define (contains-secret-leak? text)
+  (and (string? text)
+       (for/or ([rl (in-list leak-rx+label)])
+         (regexp-match? (car rl) text))
+       #t))
+
+(define (find-secret-leaks text)
+  (if (not (string? text))
+      '()
+      (for/fold ([acc '()]) ([rl (in-list leak-rx+label)])
+        (if (regexp-match? (car rl) text)
+            (cons (cdr rl) acc)
+            acc))))


### PR DESCRIPTION
## W3: Truthful Explorer, Semantic Verifiers, Redaction, and Docs

Addresses V9949-TMUX-03, TMUX-07, TMUX-08, and the major W3 portion of TMUX-09.

### Truthful real execution
- `--mode real` now dispatches a concrete isolated tmux/q executor instead of static mock evidence.
- Fresh temporary HOME/project, explicit config copy, unique private tmux server/session, structured trace wait, redacted retained artifacts, and narrow cleanup.
- `dynamic-wind` cleanup deletes the copied-credential workspace on success, timeout, and exception.
- Child environment is allowlisted; copied credential/config files are removed before a tool-capable prompt.
- Trace baselining prevents stale completion events from satisfying a new scenario.

### Semantic verification and CLI truth
- Exact registered tags: `memory`, `gsd`, `mas`, `tools`, `release-audit`, `durable-memory`, `resume`, `compact`.
- Scenario-specific verifiers reject missing trace/completion, crash, timeout, mock fallback, mismatched IDs/session/turn, missing results, and deceptive prose.
- Added correlated `tool.execution.correlated-completed` production evidence with stable tool-call identity/result presence.
- Real non-PASS exits nonzero; only explicit `--non-gating` returns zero while reporting failure.

### Redaction and docs
- Central policy at `util/credential-redaction.rkt`, shared by explorer, harness, and report scanner.
- Avoids `set-task-state`, `risk-score`, `Bearer authentication`, and `<REDACTED>` false positives.
- Detects realistic API/Bearer/header/assignment secrets, mixed values, and preserves valid JSON while redacting.
- Corrected the v0.99.44 operational runbook and added an explicit historical audit erratum.

### Verification
- [x] Clean compile: `rm -rf compiled/ && raco make main.rkt`
- [x] Focused W3 gate: 207 tests passed
- [x] Smoke: 19/19 files, 287/287 tests
- [x] Opt-in tmux matrix: 7/7 scenario files PASS
- [x] Fast: 1018/1018 files, 15100/15100 tests
- [x] No orphan test tmux sessions; unrelated `q-agent` session preserved

Closes #8718
