### PR TITLE
feat(v0.99.50 W4): durable compaction lifecycle and UX (#8719)

### DIFF
--- a/runtime/compaction/compactor.rkt
+++ b/runtime/compaction/compactor.rkt
@@ -337,9 +337,10 @@
           (if (pair? adjusted-recent)
               (message-id (car adjusted-recent))
               #f))
+        (define summary-parent-id (and (pair? adjusted-recent) (message-id (last adjusted-recent))))
         (define summary-msg
           (make-message (format "compaction-~a" (now-fn))
-                        #f ; no parent — compaction summaries are root-level context
+                        summary-parent-id ; append-only checkpoint after the kept window
                         'system
                         'compaction-summary
                         (list (make-text-part summary-text))

--- a/runtime/compaction/session-compaction.rkt
+++ b/runtime/compaction/session-compaction.rkt
@@ -56,9 +56,8 @@
      (cond
        [(and last-compact (< (- now-ms last-compact) 2000))
         context-with-system] ; too soon after last compaction
-       [(agent-session-compacting? sess) context-with-system] ; recursive compaction guard
+       [(not (try-claim-compaction! sess #t)) context-with-system] ; explicit prompt-owned claim
        [else
-        (guarded-set-compacting! sess #t)
         (emit-typed-event! bus
                            (make-compaction-event #:session-id sid
                                                   #:turn-id #f
@@ -75,7 +74,7 @@
                                                         bus
                                                         sid))
                       (lambda ()
-                        (guarded-set-compacting! sess #f)
+                        (release-compaction! sess)
                         (guarded-set-last-compaction-time! sess (now-epoch-ms))
                         (emit-typed-event! bus
                                            (make-compaction-event #:session-id sid

--- a/runtime/context-assembly/context-floor.rkt
+++ b/runtime/context-assembly/context-floor.rkt
@@ -104,45 +104,56 @@
     (trace-cb 'start (hasheq 'total (length messages))))
   (define-values (compaction-summaries regular-msgs)
     (partition (lambda (m) (eq? (message-kind m) 'compaction-summary)) messages))
-  (define-values (gsd-pinned regular) (partition gsd-progress-message? regular-msgs))
-  (define-values (sys-protected unpinned-raw)
-    (partition (lambda (m) (eq? (message-kind m) 'system-instruction)) regular))
-  ;; UNIVERSAL PINNING: Pin ALL user messages to Tier A, not just the first.
-  (define-values (pinned-user unpinned)
-    (partition (lambda (m) (eq? (message-role m) 'user)) unpinned-raw))
-  (define total (length unpinned))
-  (define effective-tier-b (or tier-b-count (compute-dynamic-tier-b-count total)))
-  (define effective-tier-c
-    (if (= tier-c-count DEFAULT-TIER-C-COUNT)
-        (compute-tier-c-count total)
-        tier-c-count))
-  (define tier-c-size (min effective-tier-c total))
-  (define tier-c
-    (if (> tier-c-size 0)
-        (take-right unpinned tier-c-size)
-        '()))
-  (define remaining-after-c
-    (if (> tier-c-size 0)
-        (drop-right unpinned tier-c-size)
-        unpinned))
-  (define remaining-count (length remaining-after-c))
-  (define tier-b-size (min effective-tier-b remaining-count))
-  (define tier-b
-    (if (> tier-b-size 0)
-        (take-right remaining-after-c tier-b-size)
-        '()))
-  (define tier-a (append sys-protected pinned-user gsd-pinned compaction-summaries ws-messages))
-  (when trace-cb
-    (trace-cb 'partition
-              (hasheq 'tier-a
-                      (length tier-a)
-                      'tier-b
-                      (length tier-b)
-                      'tier-c
-                      (length tier-c)
-                      'gsd-pinned
-                      (length gsd-pinned))))
-  (tiered-context tier-a tier-b tier-c))
+  (cond
+    [(pair? compaction-summaries)
+     ;; Compaction already bounded this context. Preserve its protocol order
+     ;; exactly: summary, verbatim kept window, then the new user prompt.
+     (define ordered (append messages ws-messages))
+     (when trace-cb
+       (trace-cb
+        'partition
+        (hasheq 'tier-a (length ordered) 'tier-b 0 'tier-c 0 'gsd-pinned 0 'compaction-ordered? #t)))
+     (tiered-context ordered '() '())]
+    [else
+     (define-values (gsd-pinned regular) (partition gsd-progress-message? regular-msgs))
+     (define-values (sys-protected unpinned-raw)
+       (partition (lambda (m) (eq? (message-kind m) 'system-instruction)) regular))
+     ;; UNIVERSAL PINNING: Pin ALL user messages to Tier A, not just the first.
+     (define-values (pinned-user unpinned)
+       (partition (lambda (m) (eq? (message-role m) 'user)) unpinned-raw))
+     (define total (length unpinned))
+     (define effective-tier-b (or tier-b-count (compute-dynamic-tier-b-count total)))
+     (define effective-tier-c
+       (if (= tier-c-count DEFAULT-TIER-C-COUNT)
+           (compute-tier-c-count total)
+           tier-c-count))
+     (define tier-c-size (min effective-tier-c total))
+     (define tier-c
+       (if (> tier-c-size 0)
+           (take-right unpinned tier-c-size)
+           '()))
+     (define remaining-after-c
+       (if (> tier-c-size 0)
+           (drop-right unpinned tier-c-size)
+           unpinned))
+     (define remaining-count (length remaining-after-c))
+     (define tier-b-size (min effective-tier-b remaining-count))
+     (define tier-b
+       (if (> tier-b-size 0)
+           (take-right remaining-after-c tier-b-size)
+           '()))
+     (define tier-a (append sys-protected pinned-user gsd-pinned ws-messages))
+     (when trace-cb
+       (trace-cb 'partition
+                 (hasheq 'tier-a
+                         (length tier-a)
+                         'tier-b
+                         (length tier-b)
+                         'tier-c
+                         (length tier-c)
+                         'gsd-pinned
+                         (length gsd-pinned))))
+     (tiered-context tier-a tier-b tier-c)]))
 
 ;; build-tiered-context-with-hooks : variant with hook dispatch
 (define (build-tiered-context-with-hooks messages

--- a/runtime/context-assembly/session-walk.rkt
+++ b/runtime/context-assembly/session-walk.rkt
@@ -54,7 +54,19 @@
 
 (define (assemble-context path)
   (define-values (pre post) (split-at-compaction path))
-  (define relevant (if post post path))
+  (define relevant
+    (cond
+      [(not post) path]
+      [else
+       (define summary (car post))
+       (define first-kept-id (hash-ref (message-meta summary) 'firstKeptEntryId #f))
+       (define kept
+         (if first-kept-id
+             (dropf pre (lambda (entry) (not (equal? (message-id entry) first-kept-id))))
+             '()))
+       ;; Durable logs are append-only, so kept entries precede the summary on
+       ;; disk. Provider context is summary, then kept entries, then new turns.
+       (append (list summary) kept (cdr post))]))
   (filter-map entry->context-message relevant))
 
 (define (split-at-compaction path)

--- a/runtime/session/session-events.rkt
+++ b/runtime/session/session-events.rkt
@@ -14,7 +14,7 @@
          "../session-index/mutations.rkt"
          "../session-index/query.rkt"
          (only-in "../../util/event/event.rkt" event-ev)
-         (only-in "../../util/message/message.rkt" message-id)
+         (only-in "../../util/message/message.rkt" message-id message-kind)
          (only-in "../../util/event/event.rkt" event-payload)
          (only-in "../runtime-helpers.rkt" emit-session-event!)
          "session-types.rkt"
@@ -23,7 +23,10 @@
                   current-conclusion-to-memory-bridge-enabled
                   persist-high-value-conclusions!)
          (only-in "../memory/service.rkt" current-memory-backend)
-         racket/set)
+         racket/set
+         (only-in "../../util/ids.rkt" generate-id)
+         (only-in "../context-assembly/session-walk.rkt" build-session-context)
+         (only-in "../trace-logger.rkt" make-trace-logger start-trace-logger! stop-trace-logger!))
 (require "session-mutation.rkt")
 (require (only-in "../context-assembly/state-inference.rkt"
                   infer-task-state-from-tools
@@ -34,7 +37,12 @@
 ;; context.ws-evolve-requested event for turn-orchestrator to handle.
 ;; (require (only-in "../context-assembly/ws-evolution.rkt" evolve-working-set-for-state))
 
-(provide (contract-out [wire-session-event-handlers! (-> agent-session? procedure? void?)])
+(provide (contract-out
+          [wire-session-event-handlers! (-> agent-session? procedure? void?)]
+          [compact-session-durably!
+           (->* (agent-session?)
+                (#:request-id string? #:load-history procedure? #:compact-and-persist procedure?)
+                symbol?)])
          current-mid-session-bridge-enabled
          current-mid-session-persisted-ids
          major-forward-transition?
@@ -82,6 +90,140 @@
                                                        ([c (in-list new-conclusions)])
                                                (set-add s (task-conclusion-id c)))))))))
 
+;; Durable manual compaction lifecycle. Shared claim/release primitives prevent
+;; manual and automatic compaction from owning the session guard concurrently.
+(define (emit-compact-lifecycle! sess phase payload)
+  (emit-session-event! (agent-session-event-bus sess) (agent-session-session-id sess) phase payload))
+
+(define (effective-compaction-history sess durable-history)
+  (if (and (agent-session-index sess)
+           (for/or ([message (in-list durable-history)])
+             (eq? (message-kind message) 'compaction-summary)))
+      (build-session-context (agent-session-index sess))
+      durable-history))
+
+(define (stop-compact-tracer! tracer)
+  (with-handlers ([exn:fail? (lambda (e)
+                               (log-warning "compaction trace cleanup failed: ~a" (exn-message e)))])
+    (stop-trace-logger! tracer)))
+
+(define (compact-session-durably! sess
+                                  #:request-id [request-id (generate-id)]
+                                  #:load-history [load-history load-session-log]
+                                  #:compact-and-persist [compact-proc compact-and-persist!])
+  (define claimed? (try-claim-compaction! sess))
+  (cond
+    [(not claimed?)
+     (define active-owner (if (agent-session-prompt-running? sess) 'prompt 'compaction))
+     (emit-compact-lifecycle! sess
+                              "session.compact.already-running"
+                              (hasheq 'request-id
+                                      request-id
+                                      'persisted?
+                                      #f
+                                      'outcome
+                                      'already-running
+                                      'active-owner
+                                      active-owner))
+     'already-running]
+    [else
+     (define persisted? (box #f))
+     (define tracer
+       (make-trace-logger (agent-session-event-bus sess)
+                          (agent-session-session-dir sess)
+                          #:enabled? #t))
+     (with-handlers ([exn:fail? (lambda (e)
+                                  (emit-compact-lifecycle! sess
+                                                           "session.compact.failed"
+                                                           (hasheq 'request-id
+                                                                   request-id
+                                                                   'persisted?
+                                                                   (unbox persisted?)
+                                                                   'outcome
+                                                                   'failed
+                                                                   'error
+                                                                   (exn-message e)))
+                                  (release-compaction! sess)
+                                  (stop-compact-tracer! tracer)
+                                  'failed)])
+       (start-trace-logger! tracer)
+       (emit-compact-lifecycle! sess
+                                "session.compact.started"
+                                (hasheq 'request-id request-id 'persisted? #f 'outcome 'started))
+       (define outcome
+         (dynamic-wind void
+                       (lambda ()
+                         (define log-path (session-log-path-for sess))
+                         (define durable-history (load-history log-path))
+                         (define history (effective-compaction-history sess durable-history))
+                         (cond
+                           [(null? history)
+                            (emit-compact-lifecycle! sess
+                                                     "session.compact.nothing-to-compact"
+                                                     (hasheq 'request-id
+                                                             request-id
+                                                             'persisted?
+                                                             #f
+                                                             'outcome
+                                                             'nothing-to-compact
+                                                             'before-count
+                                                             0
+                                                             'after-count
+                                                             0))
+                            'nothing-to-compact]
+                           [else
+                            (define compact-result (compact-proc history log-path))
+                            (define removed (compaction-result-removed-count compact-result))
+                            (define kept (length (compaction-result-kept-messages compact-result)))
+                            (cond
+                              [(zero? removed)
+                               (emit-compact-lifecycle! sess
+                                                        "session.compact.nothing-to-compact"
+                                                        (hasheq 'request-id
+                                                                request-id
+                                                                'persisted?
+                                                                #f
+                                                                'outcome
+                                                                'nothing-to-compact
+                                                                'before-count
+                                                                (length history)
+                                                                'after-count
+                                                                (length history)
+                                                                'removed-count
+                                                                0
+                                                                'kept-count
+                                                                kept))
+                               'nothing-to-compact]
+                              [else
+                               (set-box! persisted? #t)
+                               (define rebuilt-index
+                                 (build-index! log-path
+                                               (session-index-path (agent-session-session-dir sess))))
+                               (define summary (compaction-result-summary-message compact-result))
+                               (when summary
+                                 (mark-active-leaf! rebuilt-index (message-id summary)))
+                               (guarded-set-index! sess rebuilt-index)
+                               (emit-compact-lifecycle! sess
+                                                        "session.compact.completed"
+                                                        (hasheq 'request-id
+                                                                request-id
+                                                                'persisted?
+                                                                #t
+                                                                'outcome
+                                                                'completed
+                                                                'before-count
+                                                                (length history)
+                                                                'after-count
+                                                                (add1 kept)
+                                                                'removed-count
+                                                                removed
+                                                                'kept-count
+                                                                kept))
+                               'completed])]))
+                       (lambda () (release-compaction! sess))))
+       (stop-compact-tracer! tracer)
+       outcome)]))
+
 ;; Wire event-bus subscribers for fork.requested, compact.requested,
 ;; tool execution, conclusions, and state transitions.
 
@@ -112,31 +254,21 @@
                                                  (or entry-id "latest")))))
                 #:filter (lambda (evt) (equal? (event-ev evt) "fork.requested")))
 
-    ;; Subscribe to compact.requested — compact the session context
+    ;; Run durable I/O off the synchronous event-bus/render path;
+    ;; compact-session-durably! owns all correlated terminal events.
     (subscribe! bus
                 (lambda (evt)
-                  (with-handlers ([exn:fail? (lambda (e)
-                                               (emit-session-event! bus
-                                                                    (agent-session-session-id sess)
-                                                                    "session.compact.failed"
-                                                                    (hasheq 'error
-                                                                            (exn-message e))))])
-                    (define log-path (session-log-path-for sess))
-                    (when (file-exists? log-path)
-                      (define history (load-session-log log-path))
-                      (when (and (not (null? history)) (not (agent-session-compacting? sess)))
-                        (guarded-set-compacting! sess #t)
-                        (define compact-result (compact-history history))
-                        (guarded-set-compacting! sess #f)
-                        (emit-session-event! bus
-                                             (agent-session-session-id sess)
-                                             "session.compact.completed"
-                                             (hasheq 'removedCount
-                                                     (compaction-result-removed-count compact-result)
-                                                     'keptCount
-                                                     (length (compaction-result-kept-messages
-                                                              compact-result))))))))
-                #:filter (lambda (evt) (equal? (event-ev evt) "compact.requested")))
+                  (define payload (event-payload evt))
+                  (define request-id
+                    (if (hash? payload)
+                        (hash-ref payload 'request-id (generate-id))
+                        (generate-id)))
+                  (thread (lambda ()
+                            (parameterize ([current-prompt-operation-session #f])
+                              (compact-session-durably! sess #:request-id request-id)))))
+                #:filter (lambda (evt)
+                           (member (event-ev evt)
+                                   '("session.compact.requested" "compact.requested"))))
     ;; Subscribe to tool.execution.completed — infer task state
     (subscribe! bus
                 (lambda (evt)

--- a/runtime/session/session-lifecycle.rkt
+++ b/runtime/session/session-lifecycle.rkt
@@ -373,16 +373,17 @@
   (unless (agent-session-active? sess)
     (raise-session-error (format "run-prompt!: session ~a is closed" (agent-session-session-id sess))
                          (agent-session-session-id sess)))
-  ;; Guard against concurrent prompt execution
-  (when (agent-session-prompt-running? sess)
+  ;; Atomically exclude both another prompt and manual/automatic compaction.
+  (unless (try-claim-prompt! sess)
+    (define reason
+      (if (agent-session-compacting? sess)
+          "Session compaction is active — retry the prompt after it completes"
+          "Prompt already running — ignoring concurrent submission"))
     (emit-session-event! (agent-session-event-bus sess)
                          (agent-session-session-id sess)
                          "runtime.error"
-                         (hasheq 'error "Prompt already running — ignoring concurrent submission"))
-    (raise-session-error (format "run-prompt!: session ~a already has a prompt running"
-                                 (agent-session-session-id sess))
-                         (agent-session-session-id sess)))
-  (guarded-set-prompt-running! sess #t)
+                         (hasheq 'error reason))
+    (raise-session-error (format "run-prompt!: ~a" reason) (agent-session-session-id sess)))
   (define bus (agent-session-event-bus sess))
   (define sid (agent-session-session-id sess))
   ;; F2: Emit turn.started immediately so TUI shows activity
@@ -424,19 +425,20 @@
           (if (and input-hook-res (eq? (hook-result-action input-hook-res) 'amend))
               (hash-ref (hook-result-payload input-hook-res) 'message user-message)
               user-message))
-        (begin0 (run-prompt-internal sess
-                                     effective-input
-                                     max-iterations
-                                     token-budget-threshold
-                                     ep!
-                                     ba!)
-          (set-box! emit-cleanup-turn-completed? #f))]))
+        (parameterize ([current-prompt-operation-session sess])
+          (begin0 (run-prompt-internal sess
+                                       effective-input
+                                       max-iterations
+                                       token-budget-threshold
+                                       ep!
+                                       ba!)
+            (set-box! emit-cleanup-turn-completed? #f)))]))
    ;; Cleanup: always reset prompt-running? even on error
    ;; v0.45.14: Safety-net turn.completed ensures TUI busy? is always cleared,
    ;; even if a regression prevents normal event flow.
    ;; B3-A: Emergency persist — defense-in-depth if session not yet persisted
    (lambda ()
-     (guarded-set-prompt-running! sess #f)
+     (release-prompt! sess)
      ;; v0.45.14 W0a: Safety-net turn.completed for TUI busy-state recovery
      ;; only on abnormal/early-exit paths.
      (when (unbox emit-cleanup-turn-completed?)

--- a/runtime/session/session-mutation.rkt
+++ b/runtime/session/session-mutation.rkt
@@ -21,6 +21,47 @@
 
 (define-logger q-session-mutation)
 
+;; One atomic ownership boundary shared by prompts plus manual/automatic compaction.
+(define session-operation-lock (make-semaphore 1))
+(define current-prompt-operation-session (make-parameter #f))
+
+(define (try-claim-compaction! sess [prompt-owned? #f])
+  (call-with-semaphore session-operation-lock
+                       (lambda ()
+                         (cond
+                           [(agent-session-compacting? sess) #f]
+                           [(and (agent-session-prompt-running? sess)
+                                 (not (and prompt-owned?
+                                           (eq? (current-prompt-operation-session) sess))))
+                            #f]
+                           [else
+                            ;; Only the automatic path may request a prompt-owned nested claim,
+                            ;; and the dynamic owner must be this exact session.
+                            (set-agent-session-compacting?! sess #t)
+                            #t]))))
+
+(define (release-compaction! sess)
+  (call-with-semaphore session-operation-lock
+                       (lambda ()
+                         (when (agent-session-compacting? sess)
+                           (set-agent-session-compacting?! sess #f)))))
+
+(define (try-claim-prompt! sess)
+  (call-with-semaphore
+   session-operation-lock
+   (lambda ()
+     (cond
+       [(or (agent-session-prompt-running? sess) (agent-session-compacting? sess)) #f]
+       [else
+        (set-agent-session-prompt-running?! sess #t)
+        #t]))))
+
+(define (release-prompt! sess)
+  (call-with-semaphore session-operation-lock
+                       (lambda ()
+                         (when (agent-session-prompt-running? sess)
+                           (set-agent-session-prompt-running?! sess #f)))))
+
 ;; v0.79.2 GAP-4: Injectable callback for persisting archived WS entries.
 ;; Signature: (-> ws-entry? void?). Runtime wires real implementation.
 (define current-archive-entry-fn (make-parameter #f))
@@ -44,7 +85,12 @@
                        [guarded-set-working-set-evolved! (-> agent-session? evolution-result? void?)]
                        [valid-session-phase? (-> symbol? boolean?)]
                        [session-phase (-> agent-session? symbol?)])
-         current-archive-entry-fn)
+         current-archive-entry-fn
+         try-claim-compaction!
+         release-compaction!
+         try-claim-prompt!
+         release-prompt!
+         current-prompt-operation-session)
 
 ;; Valid session phases derived from boolean flags
 (define (valid-session-phase? phase)

--- a/scripts/tmux-explore/executor.rkt
+++ b/scripts/tmux-explore/executor.rkt
@@ -15,10 +15,15 @@
          racket/runtime-path
          racket/string
          racket/system
-         "../../util/credential-redaction.rkt")
+         "../../util/credential-redaction.rkt"
+         (only-in "../../runtime/session/session-store.rkt" append-entry! load-session-log)
+         (only-in "../../util/message/message.rkt" make-message message-id)
+         (only-in "../../util/content/content-parts.rkt" make-text-part))
 
 (provide call-with-executor-cleanup
-         run-real-scenario)
+         run-real-scenario
+         scenario-terminal-event?
+         seed-compact-history!)
 
 (define-runtime-path q-root "../..")
 
@@ -186,7 +191,41 @@
   (string-downcase (format "~a" raw)))
 
 (define (completion-event? event)
-  (member (event-phase event) completion-phases))
+  (and (member (event-phase event) completion-phases) #t))
+
+(define compact-terminal-phases
+  '("session.compact.completed" "session.compact.nothing-to-compact"
+                                "session.compact.already-running"
+                                "session.compact.failed"))
+
+(define (scenario-terminal-event? tag event)
+  (if (string=? tag "compact")
+      (and (member (event-phase event) compact-terminal-phases) #t)
+      (completion-event? event)))
+
+(define (find-session-log-path sessions-root)
+  (and (directory-exists? sessions-root)
+       (findf (lambda (path) (equal? (path->string (file-name-from-path path)) "session.jsonl"))
+              (find-files file-exists? sessions-root))))
+
+(define (seed-compact-history! session-log-path [count 240])
+  (define existing (load-session-log session-log-path))
+  (define initial-parent (and (pair? existing) (message-id (last existing))))
+  (for ([i (in-range count)])
+    (define id (format "explorer-compact-seed-~a" i))
+    (define parent-id
+      (if (zero? i)
+          initial-parent
+          (format "explorer-compact-seed-~a" (sub1 i))))
+    (append-entry! session-log-path
+                   (make-message id
+                                 parent-id
+                                 (if (even? i) 'user 'assistant)
+                                 'message
+                                 (list (make-text-part (make-string 2000 #\x)))
+                                 (+ (current-inexact-milliseconds) i)
+                                 (hasheq 'fixture "tmux-compact"))))
+  session-log-path)
 
 (define (trace-text events)
   (with-output-to-string (lambda ()
@@ -293,6 +332,19 @@
                      30000))
        (unless ready?
          (error 'tmux-tui-explore "q TUI did not become ready in the named tmux session"))
+       ;; /compact is a control command, not a provider turn. Seed only its
+       ;; isolated durable log so real verification can exercise positive
+       ;; compaction without paying for artificial model traffic.
+       (when (string=? tag "compact")
+         (define compact-log (box #f))
+         (unless (wait-until (lambda ()
+                               (define found (find-session-log-path sessions-root))
+                               (when found
+                                 (set-box! compact-log found))
+                               found)
+                             10000)
+           (error 'tmux-tui-explore "compact scenario session log was not created"))
+         (seed-compact-history! (unbox compact-log)))
        ;; Read-only tools are auto-approved. Remove every copied config or
        ;; credential file before a tool-capable prompt. If provider setup was
        ;; lazy and this makes the turn fail, the result truthfully remains FAIL.
@@ -305,7 +357,8 @@
          (wait-until (lambda ()
                        (define all-events (read-trace-events sessions-root))
                        (and (> (length all-events) baseline-count)
-                            (findf completion-event? (drop all-events baseline-count))))
+                            (findf (lambda (event) (scenario-terminal-event? tag event))
+                                   (drop all-events baseline-count))))
                      timeout-ms))
        (define all-events (read-trace-events sessions-root))
        (define events
@@ -329,7 +382,9 @@
              'capture
              capture
              'provider-confirmed?
-             (and completed? (not mock?))
+             (and completed? (not (string=? tag "compact")) (not mock?))
+             'control-command-confirmed?
+             (and completed? (string=? tag "compact"))
              'mock-provider?
              mock?
              'timed-out?

--- a/scripts/tmux-explore/verifiers.rkt
+++ b/scripts/tmux-explore/verifiers.rkt
@@ -199,21 +199,29 @@
                       (event-field resumed '(previous-session-id previousSessionId)))
          (ordered? events started resumed completion))))
 
-(define (verify-compact events completion)
-  (for/or ([event (in-list (events-with-phase events "session.compact.completed"))])
-    (define removed (event-field event '(removed-count removedCount) #f))
-    (define kept (event-field event '(kept-count keptCount) #f))
+(define (verify-compact events terminal)
+  (for*/or ([started (in-list (events-with-phase events "session.compact.started"))]
+            [completed (in-list (events-with-phase events "session.compact.completed"))])
+    (define removed (event-field completed '(removed-count removedCount) #f))
+    (define kept (event-field completed '(kept-count keptCount) #f))
     (define before
       (or
-       (event-field event '(before-count beforeCount original-count) #f)
+       (event-field completed '(before-count beforeCount original-count) #f)
        (and (exact-nonnegative-integer? removed) (exact-nonnegative-integer? kept) (+ removed kept))))
-    (define after (or (event-field event '(after-count afterCount compacted-count) #f) kept))
-    (and (correlated-to-completion? event completion)
+    (define after (or (event-field completed '(after-count afterCount compacted-count) #f) kept))
+    (and (eq? completed terminal)
+         (same-value? (event-session started) (event-session completed))
+         (same-value? (event-field started '(request-id requestId))
+                      (event-field completed '(request-id requestId)))
+         (exact-nonnegative-integer? removed)
+         (positive? removed)
+         (exact-nonnegative-integer? kept)
          (exact-nonnegative-integer? before)
          (exact-nonnegative-integer? after)
+         (= after (add1 kept))
          (<= after before)
-         (truthy? (event-field event '(persisted? durable?) #f))
-         (ordered? events event completion))))
+         (truthy? (event-field completed '(persisted? durable?) #f))
+         (ordered? events started completed))))
 
 (define (scenario-semantic-pass? tag events completion)
   (case (string->symbol tag)
@@ -236,6 +244,7 @@
     [else
      (define status (hash-ref-any observation '(status) 'failed))
      (define events (hash-ref-any observation '(trace-events traceEvents) '()))
+     (define compact? (string=? tag "compact"))
      (define blockers
        (filter values
                (list (and (not (eq? status 'completed)) (format "terminal status is ~a" status))
@@ -243,17 +252,26 @@
                      (and (truthy? (hash-ref-any observation '(crashed?) #f)) "session crashed")
                      (and (truthy? (hash-ref-any observation '(mock-provider?) #f))
                           "mock-provider fallback observed")
-                     (and (not (truthy? (hash-ref-any observation '(provider-confirmed?) #f)))
+                     (and (not compact?)
+                          (not (truthy? (hash-ref-any observation '(provider-confirmed?) #f)))
                           "non-mock provider execution is not positively confirmed")
+                     (and compact?
+                          (not (truthy? (hash-ref-any observation '(control-command-confirmed?) #f)))
+                          "real control-command execution is not positively confirmed")
                      (and (not (and (list? events) (pair? events))) "structured trace is missing"))))
-     (define completion (and (list? events) (findf completion-event? (reverse events))))
+     (define completion
+       (and (list? events)
+            (findf (if compact?
+                       (lambda (event) (phase=? event "session.compact.completed"))
+                       completion-event?)
+                   (reverse events))))
      (define turn-id (and completion (event-turn completion)))
      (define reasons
        (append blockers
                (if completion
                    '()
                    (list "terminal completion event is missing"))
-               (if (and completion turn-id)
+               (if (or compact? (and completion turn-id))
                    '()
                    (list "completion turn ID is missing"))
                (if (and completion (event-session completion))

--- a/tests/test-agent-session-context.rkt
+++ b/tests/test-agent-session-context.rkt
@@ -166,22 +166,12 @@
    ;; Now build tiered context
    (define tiered (build-tiered-context compacted-context #:tier-b-count 2 #:tier-c-count 1))
 
-   ;; Tier A should have the summary message + all pinned user messages.
-   (check-equal? (length (tiered-context-tier-a tiered))
-                 3
-                 "Tier A should have 1 summary + all user messages")
-   ;; The compaction-summary should be present in Tier A
-   (define tier-a-kinds (map message-kind (tiered-context-tier-a tiered)))
-   (check-not-false (member 'compaction-summary tier-a-kinds)
-                    "Tier A should contain a compaction-summary message")
-
-   ;; No non-user regular messages remain after compaction + all-user pinning.
-   (check-equal? (length (tiered-context-tier-b tiered)) 0 "Tier B should have no unpinned messages")
-
-   ;; Tier C keeps the remaining unpinned assistant message.
-   (check-equal? (length (tiered-context-tier-c tiered))
-                 1
-                 "Tier C should keep the unpinned assistant message"))
+   ;; A compaction result is already bounded. Tiering must preserve its exact
+   ;; protocol order instead of pinning/reordering user and assistant messages.
+   (check-equal? (map message-id (tiered-context-tier-a tiered)) (map message-id compacted-context))
+   (check-equal? (length (tiered-context-tier-b tiered)) 0)
+   (check-equal? (length (tiered-context-tier-c tiered)) 0)
+   (check-eq? (message-kind (first (tiered-context-tier-a tiered))) 'compaction-summary))
  (test-case "build-tiered-context with no compaction returns empty Tier A"
    (define msgs
      (list (make-message "id-1" #f 'user 'message (list (make-text-part "User 1")) 1000 (hasheq))
@@ -336,23 +326,32 @@
         (run-prompt! sess (format "message ~a" i)))
       ;; Collect events from compact
       (define compact-events (box '()))
+      (define terminal-names
+        '("session.compact.completed" "session.compact.nothing-to-compact"
+                                      "session.compact.already-running"
+                                      "session.compact.failed"))
       (subscribe! bus
                   (lambda (evt) (set-box! compact-events (cons evt (unbox compact-events))))
-                  #:filter (lambda (e)
-                             (member (event-ev e)
-                                     '("session.compact.completed" "session.compact.failed"))))
+                  #:filter (lambda (e) (member (event-ev e) terminal-names)))
       ;; Publish compact.requested
-      (publish! bus (make-event "compact.requested" 1001 (session-id sess) #f (hasheq)))
-      ;; Allow thread to process (publish! is synchronous but yield for safety)
-      (sync/timeout 0.5 never-evt)
-      ;; Verify compact completed event was emitted
-      (check-not-equal? (length (unbox compact-events))
-                        0
-                        "compact.requested should trigger session.compact.completed")
-      (define completed-evt (car (unbox compact-events)))
-      (define payload (event-payload completed-evt))
-      (check-true (hash-has-key? payload 'removedCount) "completed event should have removedCount")
-      (check-true (hash-has-key? payload 'keptCount) "completed event should have keptCount")
+      (publish! bus
+                (make-event "session.compact.requested"
+                            1001
+                            (session-id sess)
+                            #f
+                            (hasheq 'request-id "compact-request-test")))
+      ;; Durable compaction runs off the synchronous event-bus/render path.
+      (let wait ([remaining 50])
+        (when (and (null? (unbox compact-events)) (positive? remaining))
+          (sleep 0.01)
+          (wait (sub1 remaining))))
+      ;; Every accepted request emits exactly one truthful terminal outcome.
+      (check-equal? (length (unbox compact-events)) 1)
+      (define terminal-evt (car (unbox compact-events)))
+      (check-not-false (member (event-ev terminal-evt) terminal-names))
+      (define payload (event-payload terminal-evt))
+      (check-equal? (hash-ref payload 'request-id #f) "compact-request-test")
+      (check-true (hash-has-key? payload 'persisted?))
       (close-session! sess)
       (delete-directory/files tmpdir))))
 

--- a/tests/test-compaction-command.rkt
+++ b/tests/test-compaction-command.rkt
@@ -13,11 +13,23 @@
          "../util/message/protocol-types.rkt")
 
 (define (make-test-cctx [bus #f])
-  (cmd-ctx (box (initial-ui-state)) (box #t) bus #f (box #f) #f (box #f) #f (box "") #f #f (box #f) (box #f)))
+  (cmd-ctx (box (initial-ui-state))
+           (box #t)
+           bus
+           #f
+           (box #f)
+           #f
+           (box #f)
+           #f
+           (box "")
+           #f
+           #f
+           (box #f)
+           (box #f)))
 
 (define compact-tests
   (test-suite "/compact command"
-    (test-case "/compact emits compact.requested event"
+    (test-case "/compact accepts once, enters in-progress state, and requests durable compaction"
       (define bus (make-event-bus))
       (define events (box '()))
       (subscribe! bus (lambda (evt) (set-box! events (cons evt (unbox events)))))
@@ -26,9 +38,15 @@
       (check-equal? result 'continue)
       (define evts (reverse (unbox events)))
       (check-equal? (length evts) 1)
-      (check-equal? (event-ev (car evts)) "compact.requested"))
+      (check-equal? (event-ev (car evts)) "session.compact.requested")
+      (check-true (hash-ref (event-payload (car evts)) 'persist? #f))
+      (check-pred string? (hash-ref (event-payload (car evts)) 'request-id #f))
+      (define new-state (unbox (cmd-ctx-state-box cctx)))
+      (check-equal? (ui-state-status-message new-state) "Compacting...")
+      (check-false (for/or ([entry (in-list (ui-state-transcript new-state))])
+                     (string-contains? (transcript-entry-text entry) "compact requested"))))
 
-    (test-case "/compact --dry-run shows preview without emitting event"
+    (test-case "/compact --dry-run refuses a misleading transcript preview"
       (define bus (make-event-bus))
       (define events (box '()))
       (subscribe! bus (lambda (evt) (set-box! events (cons evt (unbox events)))))
@@ -48,9 +66,18 @@
       (define new-state (unbox (cmd-ctx-state-box cctx)))
       (define transcript (ui-state-transcript new-state))
       (check-true (for/or ([e (in-list transcript)])
-                    (string-contains? (transcript-entry-text e) "dry-run")))
-      (check-true (for/or ([e (in-list transcript)])
-                    (string-contains? (transcript-entry-text e) "3"))))
+                    (string-contains? (transcript-entry-text e) "dry-run unavailable")))
+      (check-false (for/or ([e (in-list transcript)])
+                     (string-contains? (transcript-entry-text e) "would be compacted"))))
+
+    (test-case "/compact without runtime bus fails visibly and never enters in-progress state"
+      (define cctx (make-test-cctx))
+      (define state (unbox (cmd-ctx-state-box cctx)))
+      (check-equal? (handle-compact-command cctx state '()) 'continue)
+      (define new-state (unbox (cmd-ctx-state-box cctx)))
+      (check-false (ui-state-status-message new-state))
+      (check-true (for/or ([entry (in-list (ui-state-transcript new-state))])
+                    (string-contains? (transcript-entry-text entry) "event bus unavailable"))))
 
     (test-case "/compact blocked when busy"
       (define bus (make-event-bus))
@@ -65,7 +92,7 @@
       (define new-state (unbox (cmd-ctx-state-box cctx)))
       (define transcript (ui-state-transcript new-state))
       (check-true (for/or ([e (in-list transcript)])
-                    (string-contains? (transcript-entry-text e) "Cannot compact"))))))
+                    (string-contains? (transcript-entry-text e) "active turn"))))))
 
 (module+ main
   (run-tests compact-tests))

--- a/tests/test-compaction-guard.rkt
+++ b/tests/test-compaction-guard.rkt
@@ -17,87 +17,122 @@
          "../util/event/event-bus.rkt"
          "../runtime/agent-session.rkt"
          "../runtime/session/session-types.rkt"
-         (only-in "../runtime/session/session-mutation.rkt" guarded-set-compacting!)
+         (only-in "../runtime/session/session-mutation.rkt"
+                  current-prompt-operation-session
+                  guarded-set-compacting!
+                  release-prompt!
+                  try-claim-compaction!
+                  try-claim-prompt!)
          "../runtime/session/session-store.rkt"
          "../runtime/compaction/compactor.rkt"
          (only-in "helpers/temp-fs.rkt" with-temp-dir))
 
-(with-temp-dir (dir)
-
-  (test-case "compacting? flag starts as #f"
-    (check-equal? (agent-session-compacting? (make-agent-session (hasheq 'session-dir
-                                                                         dir
-                                                                         'event-bus
-                                                                         (make-event-bus)
-                                                                         'provider
-                                                                         #f
-                                                                         'tool-registry
-                                                                         #f
-                                                                         'model-name
-                                                                         "test"
-                                                                         'system-instructions
-                                                                         '())))
-                  #f))
-
-  (test-case "compaction.start and compaction.end events emitted"
-    (define bus (make-event-bus))
-    (define events (box '()))
-    (subscribe! bus (lambda (evt) (set-box! events (cons (event-ev evt) (unbox events)))))
-    ;; Simulate compaction start/end
-    (publish! bus (make-event "compaction.start" 0 "s1" "t1" (hasheq)))
-    (publish! bus (make-event "compaction.end" 0 "s1" "t1" (hasheq)))
-    (define evts (reverse (unbox events)))
-    (check-not-false (member "compaction.start" evts))
-    (check-not-false (member "compaction.end" evts))
-    ;; Verify start comes before end
-    (define start-idx (index-of evts "compaction.start"))
-    (define end-idx (index-of evts "compaction.end"))
-    (check-true (< start-idx end-idx)))
-
-  (test-case "compacting? flag prevents recursive compaction"
-    ;; Simulate: if compacting? is #t, maybe-compact-context returns context unchanged
-    (define sess
-      (make-agent-session (hasheq 'session-dir
-                                  dir
-                                  'event-bus
-                                  (make-event-bus)
-                                  'provider
-                                  #f
-                                  'tool-registry
-                                  #f
-                                  'model-name
-                                  "test"
-                                  'system-instructions
-                                  '())))
-    (guarded-set-compacting! sess #t)
-    (check-true (agent-session-compacting? sess))
-    ;; If flag is set, compaction should be skipped
-    (define context
-      (list (make-message "m1"
-                          #f
-                          'user
-                          'message
-                          (list (make-text-part "hello"))
-                          (current-seconds)
-                          (hasheq))))
-    (define result (maybe-compact-context sess context 0))
-    ;; Context should be returned unchanged since flag is set
-    (check-equal? result context))
-
-  (test-case "compacting? flag cleared after compaction"
-    (define sess
-      (make-agent-session (hasheq 'session-dir
-                                  dir
-                                  'event-bus
-                                  (make-event-bus)
-                                  'provider
-                                  #f
-                                  'tool-registry
-                                  #f
-                                  'model-name
-                                  "test"
-                                  'system-instructions
-                                  '())))
-    (guarded-set-compacting! sess #t)
-    (guarded-set-compacting! sess #f)
-    (check-false (agent-session-compacting? sess))))
+(with-temp-dir
+ (dir)
+ (test-case "compacting? flag starts as #f"
+   (check-equal? (agent-session-compacting? (make-agent-session (hasheq 'session-dir
+                                                                        dir
+                                                                        'event-bus
+                                                                        (make-event-bus)
+                                                                        'provider
+                                                                        #f
+                                                                        'tool-registry
+                                                                        #f
+                                                                        'model-name
+                                                                        "test"
+                                                                        'system-instructions
+                                                                        '())))
+                 #f))
+ (test-case "compaction.start and compaction.end events emitted"
+   (define bus (make-event-bus))
+   (define events (box '()))
+   (subscribe! bus (lambda (evt) (set-box! events (cons (event-ev evt) (unbox events)))))
+   ;; Simulate compaction start/end
+   (publish! bus (make-event "compaction.start" 0 "s1" "t1" (hasheq)))
+   (publish! bus (make-event "compaction.end" 0 "s1" "t1" (hasheq)))
+   (define evts (reverse (unbox events)))
+   (check-not-false (member "compaction.start" evts))
+   (check-not-false (member "compaction.end" evts))
+   ;; Verify start comes before end
+   (define start-idx (index-of evts "compaction.start"))
+   (define end-idx (index-of evts "compaction.end"))
+   (check-true (< start-idx end-idx)))
+ (test-case "compacting? flag prevents recursive compaction"
+   ;; Simulate: if compacting? is #t, maybe-compact-context returns context unchanged
+   (define sess
+     (make-agent-session (hasheq 'session-dir
+                                 dir
+                                 'event-bus
+                                 (make-event-bus)
+                                 'provider
+                                 #f
+                                 'tool-registry
+                                 #f
+                                 'model-name
+                                 "test"
+                                 'system-instructions
+                                 '())))
+   (guarded-set-compacting! sess #t)
+   (check-true (agent-session-compacting? sess))
+   ;; If flag is set, compaction should be skipped
+   (define context
+     (list (make-message "m1"
+                         #f
+                         'user
+                         'message
+                         (list (make-text-part "hello"))
+                         (current-seconds)
+                         (hasheq))))
+   (define result (maybe-compact-context sess context 0))
+   ;; Context should be returned unchanged since flag is set
+   (check-equal? result context))
+ (test-case "prompt owner may run automatic compaction without opening manual race"
+   (define sess
+     (make-agent-session (hasheq 'session-dir
+                                 dir
+                                 'event-bus
+                                 (make-event-bus)
+                                 'provider
+                                 #f
+                                 'tool-registry
+                                 #f
+                                 'model-name
+                                 "test"
+                                 'system-instructions
+                                 '())))
+   (define context
+     (list (make-message "automatic"
+                         #f
+                         'user
+                         'message
+                         (list (make-text-part "context that exceeds a zero threshold"))
+                         (current-seconds)
+                         (hasheq))))
+   (check-true (try-claim-prompt! sess))
+   (parameterize ([current-prompt-operation-session sess])
+     (check-false (try-claim-compaction! sess)
+                  "manual/default claim stays blocked inside prompt extent"))
+   (define result
+     (parameterize ([current-prompt-operation-session sess])
+       (maybe-compact-context sess context 0)))
+   (check-true (list? result))
+   (check-true (agent-session-prompt-running? sess))
+   (check-false (agent-session-compacting? sess))
+   (release-prompt! sess))
+ (test-case "compacting? flag cleared after compaction"
+   (define sess
+     (make-agent-session (hasheq 'session-dir
+                                 dir
+                                 'event-bus
+                                 (make-event-bus)
+                                 'provider
+                                 #f
+                                 'tool-registry
+                                 #f
+                                 'model-name
+                                 "test"
+                                 'system-instructions
+                                 '())))
+   (guarded-set-compacting! sess #t)
+   (guarded-set-compacting! sess #f)
+   (check-false (agent-session-compacting? sess))))

--- a/tests/test-replay.rkt
+++ b/tests/test-replay.rkt
@@ -748,9 +748,13 @@
    ;; Build tree after
    (define tree-after (build-visible-tree (load-session-log path)))
 
-   ;; Original relationships should still exist
+   ;; Original relationships remain unchanged. The append-only compaction
+   ;; checkpoint may additionally be a child of the last kept original.
+   (define original-ids (map message-id messages))
    (for ([(id children) (in-hash tree-before)])
-     (check-equal? (hash-ref tree-after id '()) children))
+     (define original-children-after
+       (filter (lambda (child-id) (member child-id original-ids)) (hash-ref tree-after id '())))
+     (check-equal? original-children-after children))
    (delete-directory/files dir #:must-exist? #f))
  (test-case "PROPERTY: replay after compaction includes all original entries"
    (define rng (make-seeded-rng SEED-1))

--- a/tests/test-session-compaction-lifecycle.rkt
+++ b/tests/test-session-compaction-lifecycle.rkt
@@ -1,0 +1,287 @@
+#lang racket
+
+;; @speed fast  ;; @suite runtime
+;; v0.99.50 W4: durable /compact lifecycle truth.
+
+(require rackunit
+         rackunit/text-ui
+         racket/file
+         "../runtime/agent-session.rkt"
+         "../runtime/session/session-events.rkt"
+         "../runtime/session/session-types.rkt"
+         (only-in "../runtime/session/session-mutation.rkt"
+                  guarded-set-compacting!
+                  release-prompt!
+                  try-claim-prompt!)
+         (only-in "../runtime/compaction/compactor.rkt"
+                  compact-and-persist!
+                  compaction-result
+                  compaction-result-kept-messages
+                  compaction-result-summary-message)
+         (only-in "../runtime/compaction/token-compaction.rkt" token-compaction-config)
+         (only-in "../runtime/session/session-store.rkt" append-entry! load-session-log)
+         (only-in "../util/message/protocol-types.rkt"
+                  make-message
+                  make-text-part
+                  message-id
+                  message-kind)
+         "../util/event/event-bus.rkt"
+         (only-in "../util/event/event.rkt" event-ev event-payload)
+         (only-in "../runtime/session-index/query.rkt" active-leaf)
+         (only-in "../runtime/session/session-lifecycle.rkt" build-session-context-for-prompt)
+         (only-in "../util/content/content-parts.rkt" text-part-text)
+         (only-in "../util/message/message.rkt" message-content message-role)
+         (only-in "../llm/provider.rkt" make-mock-provider)
+         (only-in "../llm/model.rkt" make-model-response))
+
+(define (make-test-session dir bus [provider #f])
+  (make-agent-session (hasheq 'session-dir
+                              dir
+                              'event-bus
+                              bus
+                              'provider
+                              provider
+                              'tool-registry
+                              #f
+                              'model-name
+                              "test"
+                              'system-instructions
+                              '())))
+
+(define (record-session-compact-events bus)
+  (define events (box '()))
+  (subscribe! bus
+              (lambda (evt) (set-box! events (append (unbox events) (list evt))))
+              #:filter (lambda (evt) (string-prefix? (event-ev evt) "session.compact.")))
+  events)
+
+(define terminal-names
+  '("session.compact.completed" "session.compact.nothing-to-compact"
+                                "session.compact.already-running"
+                                "session.compact.failed"))
+
+(define (terminal-events events)
+  (filter (lambda (evt) (member (event-ev evt) terminal-names)) events))
+
+(define lifecycle-tests
+  (test-suite "durable session compaction lifecycle"
+
+    (test-case "success emits started then exactly one durable completed outcome with counts"
+      (define dir (make-temporary-file "q-compact-life-~a" 'directory))
+      (dynamic-wind
+       void
+       (lambda ()
+         (define bus (make-event-bus))
+         (define sess (make-test-session dir bus))
+         (define events (record-session-compact-events bus))
+         (define seen-path (box #f))
+         (define outcome
+           (compact-session-durably! sess
+                                     #:load-history (lambda (_) '(m1 m2 m3 m4 m5 m6 m7))
+                                     #:compact-and-persist (lambda (_history path)
+                                                             (set-box! seen-path path)
+                                                             (compaction-result #f 5 '(m6 m7)))))
+         (check-equal? outcome 'completed)
+         (check-equal? (map event-ev (unbox events))
+                       '("session.compact.started" "session.compact.completed"))
+         (check-equal? (remove-duplicates (map (lambda (evt)
+                                                 (hash-ref (event-payload evt) 'request-id))
+                                               (unbox events)))
+                       (list (hash-ref (event-payload (first (unbox events))) 'request-id)))
+         (check-equal? (length (terminal-events (unbox events))) 1)
+         (define payload (event-payload (last (unbox events))))
+         (check-equal? (hash-ref payload 'removed-count) 5)
+         (check-equal? (hash-ref payload 'kept-count) 2)
+         (check-true (hash-ref payload 'persisted?))
+         (check-equal? (unbox seen-path) (session-log-path-for sess))
+         (check-false (agent-session-compacting? sess)))
+       (lambda () (delete-directory/files dir))))
+
+    (test-case "empty history emits exactly one nothing-to-compact terminal outcome"
+      (define dir (make-temporary-file "q-compact-empty-~a" 'directory))
+      (dynamic-wind void
+                    (lambda ()
+                      (define bus (make-event-bus))
+                      (define sess (make-test-session dir bus))
+                      (define events (record-session-compact-events bus))
+                      (define outcome (compact-session-durably! sess #:load-history (lambda (_) '())))
+                      (check-equal? outcome 'nothing-to-compact)
+                      (check-equal? (map event-ev (unbox events))
+                                    '("session.compact.started" "session.compact.nothing-to-compact"))
+                      (check-equal? (length (terminal-events (unbox events))) 1)
+                      (check-false (agent-session-compacting? sess)))
+                    (lambda () (delete-directory/files dir))))
+
+    (test-case "already-running request is terminal and does not clear the active guard"
+      (define dir (make-temporary-file "q-compact-running-~a" 'directory))
+      (dynamic-wind void
+                    (lambda ()
+                      (define bus (make-event-bus))
+                      (define sess (make-test-session dir bus))
+                      (define events (record-session-compact-events bus))
+                      (guarded-set-compacting! sess #t)
+                      (define outcome (compact-session-durably! sess))
+                      (check-equal? outcome 'already-running)
+                      (check-equal? (map event-ev (unbox events))
+                                    '("session.compact.already-running"))
+                      (check-equal? (length (terminal-events (unbox events))) 1)
+                      (check-true (agent-session-compacting? sess))
+                      (guarded-set-compacting! sess #f))
+                    (lambda () (delete-directory/files dir))))
+
+    (test-case "canonical path persists one summary and keeps every original log entry reconstructible"
+      (define dir (make-temporary-file "q-compact-durable-~a" 'directory))
+      (dynamic-wind
+       void
+       (lambda ()
+         (define bus (make-event-bus))
+         ;; A real provider implementation selects the production tiered context path.
+         (define provider
+           (make-mock-provider (make-model-response
+                                (list (hash 'type "text" 'text "requested answer"))
+                                (hash)
+                                "mock"
+                                'stop)))
+         (define sess (make-test-session dir bus provider))
+         (define path (session-log-path-for sess))
+         (define initial-log (load-session-log path))
+         (define initial-parent (and (pair? initial-log) (message-id (last initial-log))))
+         (define originals
+           (for/list ([i (in-range 30)])
+             (make-message (format "original-~a" i)
+                           (if (zero? i)
+                               initial-parent
+                               (format "original-~a" (sub1 i)))
+                           (if (even? i) 'user 'assistant)
+                           'message
+                           (list (make-text-part (make-string 80 #\x)))
+                           (+ (current-inexact-milliseconds) i)
+                           (hash))))
+         (for ([message (in-list originals)])
+           (append-entry! path message))
+         (define compact-result-box (box #f))
+         (define outcome
+           (compact-session-durably! sess
+                                     #:compact-and-persist
+                                     (lambda (history log-path)
+                                       (define result
+                                         (compact-and-persist! history
+                                                               log-path
+                                                               #:token-config
+                                                               (token-compaction-config 20 0 20)))
+                                       (set-box! compact-result-box result)
+                                       result)))
+         (check-equal? outcome 'completed)
+         (define trace-text
+           (file->string (build-path (agent-session-session-dir sess) "trace.jsonl")))
+         (check-true (string-contains? trace-text "session.compact.started"))
+         (check-true (string-contains? trace-text "session.compact.completed"))
+         (check-not-false (agent-session-index sess))
+         (check-eq? (message-kind (active-leaf (agent-session-index sess))) 'compaction-summary)
+         (define next-context
+           (build-session-context-for-prompt sess
+                                             "answer only this request"
+                                             ensure-persisted!
+                                             buffer-or-append!))
+         (define context-payload
+           (filter (lambda (message) (not (eq? (message-kind message) 'system-instruction)))
+                   next-context))
+         (define durable-result (unbox compact-result-box))
+         (define expected-compacted-ids
+           (cons (message-id (compaction-result-summary-message durable-result))
+                 (map message-id (compaction-result-kept-messages durable-result))))
+         (check-equal? (map message-id (drop-right context-payload 1)) expected-compacted-ids)
+         (check-eq? (message-role (last context-payload)) 'user)
+         (check-equal? (text-part-text (first (message-content (last next-context))))
+                       "answer only this request")
+         (define persisted (load-session-log path))
+         (define persisted-ids (map message-id persisted))
+         (for ([message (in-list originals)])
+           (check-not-false (member (message-id message) persisted-ids)))
+         (check-equal? (count (lambda (message) (eq? (message-kind message) 'compaction-summary))
+                              persisted)
+                       1))
+       (lambda () (delete-directory/files dir))))
+
+    (test-case "active prompt atomically rejects manual compaction"
+      (define dir (make-temporary-file "q-compact-prompt-owner-~a" 'directory))
+      (dynamic-wind void
+                    (lambda ()
+                      (define bus (make-event-bus))
+                      (define sess (make-test-session dir bus))
+                      (define events (record-session-compact-events bus))
+                      (check-true (try-claim-prompt! sess))
+                      (check-equal? (compact-session-durably! sess #:request-id "blocked-by-prompt")
+                                    'already-running)
+                      (check-equal? (map event-ev (unbox events))
+                                    '("session.compact.already-running"))
+                      (release-prompt! sess))
+                    (lambda () (delete-directory/files dir))))
+
+    (test-case "concurrent requests have distinct correlated terminal outcomes"
+      (define dir (make-temporary-file "q-compact-concurrent-~a" 'directory))
+      (dynamic-wind
+       void
+       (lambda ()
+         (define bus (make-event-bus))
+         (define sess (make-test-session dir bus))
+         (define events (record-session-compact-events bus))
+         (define entered (make-semaphore 0))
+         (define release (make-semaphore 0))
+         (define first-thread
+           (thread (lambda ()
+                     (compact-session-durably!
+                      sess
+                      #:request-id "request-one"
+                      #:load-history (lambda (_) '(old-message))
+                      #:compact-and-persist
+                      (lambda (_history path)
+                        (semaphore-post entered)
+                        (semaphore-wait release)
+                        (define summary
+                          (make-message "concurrent-summary"
+                                        #f
+                                        'system
+                                        'compaction-summary
+                                        (list (make-text-part "internal summary"))
+                                        (current-inexact-milliseconds)
+                                        (hash)))
+                        (append-entry! path summary)
+                        (compaction-result summary 1 '()))))))
+         (semaphore-wait entered)
+         (check-exn #rx"compaction is active" (lambda () (run-prompt! sess "must wait")))
+         (check-equal? (compact-session-durably! sess #:request-id "request-two") 'already-running)
+         (semaphore-post release)
+         (thread-wait first-thread)
+         (define terminals (terminal-events (unbox events)))
+         (check-equal? (length terminals) 2)
+         (check-equal? (map (lambda (evt) (hash-ref (event-payload evt) 'request-id)) terminals)
+                       '("request-two" "request-one"))
+         (check-equal? (map event-ev terminals)
+                       '("session.compact.already-running" "session.compact.completed"))
+         (check-false (agent-session-compacting? sess)))
+       (lambda () (delete-directory/files dir))))
+
+    (test-case "exception emits one failed outcome and always resets compacting guard"
+      (define dir (make-temporary-file "q-compact-fail-~a" 'directory))
+      (dynamic-wind void
+                    (lambda ()
+                      (define bus (make-event-bus))
+                      (define sess (make-test-session dir bus))
+                      (define events (record-session-compact-events bus))
+                      (define outcome
+                        (compact-session-durably! sess
+                                                  #:load-history (lambda (_) '(m1))
+                                                  #:compact-and-persist (lambda (_history _path)
+                                                                          (error 'compact "boom"))))
+                      (check-equal? outcome 'failed)
+                      (check-equal? (map event-ev (unbox events))
+                                    '("session.compact.started" "session.compact.failed"))
+                      (check-equal? (length (terminal-events (unbox events))) 1)
+                      (check-true (string-contains? (hash-ref (event-payload (last (unbox events)))
+                                                              'error)
+                                                    "boom"))
+                      (check-false (agent-session-compacting? sess)))
+                    (lambda () (delete-directory/files dir))))))
+
+(run-tests lifecycle-tests)

--- a/tests/test-tmux-explore-executor.rkt
+++ b/tests/test-tmux-explore-executor.rkt
@@ -6,7 +6,12 @@
 (require rackunit
          rackunit/text-ui
          racket/file
-         "../scripts/tmux-explore/executor.rkt")
+         "../scripts/tmux-explore/executor.rkt"
+         (only-in "../runtime/session/session-store.rkt" load-session-log)
+         (only-in "../util/message/message.rkt" message-id)
+         (only-in "../runtime/compaction/compactor.rkt"
+                  compact-history
+                  compaction-result-removed-count))
 
 (define (make-workspace)
   (define dir (make-temporary-file "q-executor-cleanup-~a" 'directory))
@@ -66,6 +71,39 @@
                                                #:stop-session
                                                (lambda (_name) (error 'fixture "stop failed")))))
       (check-false (directory-exists? dir)))
+
+    (test-case "compact fixture seeds a deterministic durable history without provider turns"
+      (define dir (make-temporary-file "q-compact-seed-~a" 'directory))
+      (define path (build-path dir "session.jsonl"))
+      (dynamic-wind void
+                    (lambda ()
+                      (check-equal? (seed-compact-history! path 4) path)
+                      (define messages (load-session-log path))
+                      (check-equal? (length messages) 4)
+                      (check-equal? (map message-id messages)
+                                    '("explorer-compact-seed-0" "explorer-compact-seed-1"
+                                                                "explorer-compact-seed-2"
+                                                                "explorer-compact-seed-3")))
+                    (lambda () (delete-directory/files dir))))
+
+    (test-case "default compact fixture exceeds the production compaction threshold"
+      (define dir (make-temporary-file "q-compact-threshold-~a" 'directory))
+      (define path (build-path dir "session.jsonl"))
+      (dynamic-wind void
+                    (lambda ()
+                      (seed-compact-history! path)
+                      (check-true (positive? (compaction-result-removed-count
+                                              (compact-history (load-session-log path))))))
+                    (lambda () (delete-directory/files dir))))
+
+    (test-case "compact scenario terminates on its lifecycle outcome without a model turn"
+      (check-true (scenario-terminal-event? "compact" (hash 'phase "session.compact.completed")))
+      (check-true (scenario-terminal-event? "compact" (hash 'phase "session.compact.failed")))
+      (check-false (scenario-terminal-event? "compact" (hash 'phase "session.compact.started"))))
+
+    (test-case "ordinary scenarios still require a completed model turn"
+      (check-true (scenario-terminal-event? "memory" (hash 'phase "turn.completed")))
+      (check-false (scenario-terminal-event? "memory" (hash 'phase "session.compact.completed"))))
 
     (test-case "no session name means no tmux cleanup call"
       (define dir (make-workspace))

--- a/tests/test-tmux-explore-verifiers.rkt
+++ b/tests/test-tmux-explore-verifiers.rkt
@@ -76,9 +76,25 @@
          (evt "session.resumed" #:data (hash 'session-id session 'previous-session-id "session-0"))
          completion)
    "compact"
-   (list (evt "session.compact.completed"
-              #:data (hash 'session-id session 'before-count 42 'after-count 12 'persisted? #t))
-         completion)))
+   (list (evt "session.compact.started"
+              #:turn #f
+              #:data (hash 'session-id session 'request-id "compact-1" 'persisted? #f))
+         (evt "session.compact.completed"
+              #:turn #f
+              #:data (hash 'session-id
+                           session
+                           'request-id
+                           "compact-1"
+                           'before-count
+                           42
+                           'after-count
+                           13
+                           'removed-count
+                           30
+                           'kept-count
+                           12
+                           'persisted?
+                           #t)))))
 
 (define negative-fixtures
   (hash
@@ -137,6 +153,7 @@
                      #:capture [capture "plausible assistant prose says everything passed"]
                      #:status [status 'completed]
                      #:mock? [mock? #f]
+                     #:control? [control? #t]
                      #:timed-out? [timed-out? #f]
                      #:crashed? [crashed? #f])
   (hash 'status
@@ -147,6 +164,8 @@
         capture
         'provider-confirmed?
         (not mock?)
+        'control-command-confirmed?
+        control?
         'mock-provider?
         mock?
         'timed-out?
@@ -178,6 +197,30 @@
                                 (observation valid-tools #:crashed? #t)
                                 (observation valid-tools #:status 'failed)))])
         (check-false (verification-result-passed? (verify-scenario-evidence "tools" obs)))))
+
+    (test-case "compact lifecycle requires one matching request ID"
+      (define events
+        (list (evt "session.compact.started"
+                   #:turn #f
+                   #:data (hash 'session-id session 'request-id "request-a"))
+              (evt "session.compact.completed"
+                   #:turn #f
+                   #:data (hash 'session-id
+                                session
+                                'request-id
+                                "request-b"
+                                'before-count
+                                10
+                                'after-count
+                                4
+                                'removed-count
+                                7
+                                'kept-count
+                                3
+                                'persisted?
+                                #t))))
+      (check-false (verification-result-passed? (verify-scenario-evidence "compact"
+                                                                          (observation events)))))
 
     (test-case "unknown scenario tag fails closed"
       (define result (verify-scenario-evidence "not-registered" (observation (list completion))))

--- a/tests/tui/test-state.rkt
+++ b/tests/tui/test-state.rkt
@@ -183,11 +183,44 @@
              [s2 (apply-event-to-state s evt)])
         (check-equal? (ui-state-status-message s2) "Compacting...")))
 
-    (test-case "apply-event: compaction.completed"
+    (test-case "apply-event: session compaction completed is visible with counts"
       (let* ([s (set-status-message (initial-ui-state) "Compacting...")]
-             [evt (make-test-event "compaction.completed" (hash))]
+             [evt (make-test-event "session.compact.completed"
+                                   (hash 'removed-count 8 'kept-count 3 'persisted? #t))]
              [s2 (apply-event-to-state s evt)])
-        (check-false (ui-state-status-message s2))))
+        (check-false (ui-state-status-message s2))
+        (check-equal? (transcript-entry-text (last (ui-state-transcript s2)))
+                      "[compact completed: removed 8, kept 3]")))
+
+    (test-case "apply-event: session compaction no-op and failure are terminal and visible"
+      (define terminal-cases
+        (list (cons (make-test-event "session.compact.nothing-to-compact" (hash))
+                    "[compact: nothing to compact]")
+              (cons (make-test-event "session.compact.failed" (hash 'error "disk full"))
+                    "[compact failed: disk full]")))
+      (for ([case (in-list terminal-cases)])
+        (define s2
+          (apply-event-to-state (set-status-message (initial-ui-state) "Compacting...") (car case)))
+        (check-false (ui-state-status-message s2))
+        (check-equal? (length (ui-state-transcript s2)) 1)
+        (check-equal? (transcript-entry-text (car (ui-state-transcript s2))) (cdr case))))
+
+    (test-case "apply-event: already-running does not clear the active owner's status"
+      (define s2
+        (apply-event-to-state (set-status-message (initial-ui-state) "Compacting...")
+                              (make-test-event "session.compact.already-running" (hash))))
+      (check-equal? (ui-state-status-message s2) "Compacting...")
+      (check-equal? (transcript-entry-text (car (ui-state-transcript s2)))
+                    "[compact: already running]"))
+
+    (test-case "apply-event: prompt-owned guard terminates the compact request status"
+      (define s2
+        (apply-event-to-state (set-status-message (initial-ui-state) "Compacting...")
+                              (make-test-event "session.compact.already-running"
+                                               (hash 'active-owner 'prompt))))
+      (check-false (ui-state-status-message s2))
+      (check-equal? (transcript-entry-text (car (ui-state-transcript s2)))
+                    "[compact: active prompt is blocking compaction]"))
 
     (test-case "apply-event: unknown event returns unchanged state"
       (let* ([s (initial-ui-state)]

--- a/tui/commands/runtime-control.rkt
+++ b/tui/commands/runtime-control.rkt
@@ -14,14 +14,14 @@
          "../../runtime/auth/oauth.rkt"
          "../../runtime/auth/oauth-callback.rkt"
          "../../runtime/auth/auth-store.rkt"
-         "context.rkt")
+         "context.rkt"
+         (only-in "../../util/ids.rkt" generate-id))
 
-;; Handle /compact — request compaction with optional --dry-run
+;; Handle /compact — request durable compaction with optional --dry-run.
 (define (handle-compact-command cctx state [args '()])
-  ;; Block during active tool loop
   (cond
     [(ui-state-busy? state)
-     (define entry (make-error-entry "Cannot compact while a tool is running. Wait for completion."))
+     (define entry (make-error-entry "Cannot compact while an active turn is running."))
      (set-box! (cmd-ctx-state-box cctx) (add-transcript-entry state entry))
      (set-box! (cmd-ctx-needs-redraw-box cctx) #t)
      'continue]
@@ -29,22 +29,25 @@
      (define dry-run? (member "--dry-run" args))
      (cond
        [dry-run?
-        (define transcript (ui-state-transcript state))
-        (define entry-count (length transcript))
-        (define msg
-          (format "[compact dry-run: ~a transcript entries would be compacted]" entry-count))
-        (set-box! (cmd-ctx-state-box cctx) (add-transcript-entry state (make-system-entry msg)))
+        (define msg "[compact dry-run unavailable: /compact always persists]")
+        (set-box! (cmd-ctx-state-box cctx) (add-transcript-entry state (make-error-entry msg)))
+        'continue]
+       [(not (cmd-ctx-event-bus cctx))
+        (set-box! (cmd-ctx-state-box cctx)
+                  (add-transcript-entry
+                   state
+                   (make-error-entry "[compact failed: runtime event bus unavailable]")))
+        (set-box! (cmd-ctx-needs-redraw-box cctx) #t)
         'continue]
        [else
-        (define entry (make-system-entry "[compact requested]"))
-        (set-box! (cmd-ctx-state-box cctx) (add-transcript-entry state entry))
-        (when (cmd-ctx-event-bus cctx)
-          (publish! (cmd-ctx-event-bus cctx)
-                    (make-event "compact.requested"
-                                (inexact->exact (truncate (/ (current-inexact-milliseconds) 1000)))
-                                (or (ui-state-session-id state) "")
-                                #f
-                                (hash))))
+        (set-box! (cmd-ctx-state-box cctx) (set-status-message state "Compacting..."))
+        (set-box! (cmd-ctx-needs-redraw-box cctx) #t)
+        (publish! (cmd-ctx-event-bus cctx)
+                  (make-event "session.compact.requested"
+                              (inexact->exact (truncate (/ (current-inexact-milliseconds) 1000)))
+                              (or (ui-state-session-id state) "")
+                              #f
+                              (hasheq 'request-id (generate-id) 'persist? #t)))
         'continue])]))
 
 ;; Handle /interrupt — interrupt current operation

--- a/tui/state-events/core-handlers.rkt
+++ b/tui/state-events/core-handlers.rkt
@@ -390,8 +390,29 @@
 
 (define (handle-compaction-lifecycle state evt)
   (define ev (event-ev evt))
+  (define payload (event-payload evt))
+  (define ts (event-time evt))
+  (define (terminal message)
+    (append-entry (set-status-message state #f) (make-entry 'system message ts (hash))))
   (match ev
-    [(or "compaction.started" "compaction.start") (set-status-message state "Compacting...")]
+    [(or "session.compact.started" "compaction.started" "compaction.start")
+     (set-status-message state "Compacting...")]
+    ["session.compact.completed"
+     (define removed (hash-ref-multi payload 'removed-count 'removedCount "?"))
+     (define kept (hash-ref-multi payload 'kept-count 'keptCount "?"))
+     (terminal (format "[compact completed: removed ~a, kept ~a]" removed kept))]
+    ["session.compact.nothing-to-compact" (terminal "[compact: nothing to compact]")]
+    ["session.compact.already-running"
+     (if (eq? (hash-ref payload 'active-owner 'compaction) 'prompt)
+         (terminal "[compact: active prompt is blocking compaction]")
+         ;; Another compaction still owns the guard; retain its active status.
+         (append-entry state (make-entry 'system "[compact: already running]" ts (hash))))]
+    ["session.compact.failed"
+     (define prefix
+       (if (hash-ref payload 'persisted? #f)
+           "compact failed after summary persistence"
+           "compact failed"))
+     (terminal (format "[~a: ~a]" prefix (hash-ref payload 'error "unknown error")))]
     [(or "compaction.completed" "compaction.end") (set-status-message state #f)]
     [_ state]))
 
@@ -500,6 +521,12 @@
 (register-event-reducer! "exploration.progress" handle-exploration-progress)
 (register-event-reducer! "gsd.plan.archived" handle-gsd-plan-archived)
 (register-event-reducer! "context.mid-turn-over-budget" handle-context-mid-turn-over-budget)
+(register-event-reducer! "session.compact.started" handle-compaction-lifecycle)
+(register-event-reducer! "session.compact.completed" handle-compaction-lifecycle)
+(register-event-reducer! "session.compact.nothing-to-compact" handle-compaction-lifecycle)
+(register-event-reducer! "session.compact.already-running" handle-compaction-lifecycle)
+(register-event-reducer! "session.compact.failed" handle-compaction-lifecycle)
+;; Legacy SDK/automatic-compaction names remain read-compatible at the UI boundary.
 (register-event-reducer! "compaction.started" handle-compaction-lifecycle)
 (register-event-reducer! "compaction.start" handle-compaction-lifecycle)
 (register-event-reducer! "compaction.completed" handle-compaction-lifecycle)


### PR DESCRIPTION
## W4: Durable Compaction Lifecycle and UX

Closes V9949-TMUX-06 and the compaction portion of TMUX-09.

### Durable lifecycle
- `/compact` publishes one correlated `session.compact.requested` event and runs `compact-and-persist!` off the render path.
- Every request has a stable request ID and exactly one terminal outcome: completed, nothing-to-compact, already-running, or failed.
- Success reports before/after/removed/kept counts and `persisted? = #t`; partial failures report whether persistence already occurred.
- A scoped trace logger records control-command lifecycle evidence even though `/compact` is not a provider turn.

### Session safety and context truth
- Added one atomic session-operation boundary shared by prompt, manual compaction, and automatic compaction.
- Manual compaction cannot overlap a prompt; automatic compaction can nest only for the exact dynamic prompt owner.
- Compaction summaries checkpoint after the kept window while the original JSONL remains append-only and reconstructible.
- Live and resumed context reconstructs exact protocol order: summary, every kept message, then subsequent prompts.
- The live index is rebuilt and selects the new summary immediately; internal summaries never become the next answer.

### UX and real evidence
- TUI renders truthful completed/no-op/already-running/failed messages and owner-aware status handling.
- Busy, unavailable dry-run, and missing-runtime cases publish nothing and fail visibly.
- Real compact exploration seeds an isolated above-threshold durable log without provider traffic, captures structured lifecycle trace, and verifies matching request/session IDs, positive removals, counts, and persistence.

### Verification
- [x] Independent reviewer: APPROVED
- [x] Clean compile: `rm -rf compiled/ && raco make main.rkt`
- [x] Focused compaction/context/workflow: 200 tests PASS
- [x] tmux slash commands: 5/5 PASS
- [x] Real compact explorer: PASS
- [x] Smoke: 19/19 files, 287/287 tests
- [x] Fast: 1019/1019 files, 15117/15117 tests
- [x] No orphan test tmux sessions; unrelated `q-agent` preserved

Closes #8719
